### PR TITLE
Pool block alloc

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -98,12 +98,18 @@ FileContainer *AppLayerGetFilesFromFlow(Flow *f, uint8_t direction) {
 }
 
 /** \brief Alloc a AppLayerParserResultElmt func for the pool */
-static void *AlpResultElmtPoolAlloc(void *null)
+static void *AlpResultElmtPoolAlloc(void *null, void *data)
 {
-    AppLayerParserResultElmt *e = (AppLayerParserResultElmt *)SCMalloc
-                                    (sizeof(AppLayerParserResultElmt));
-    if (e == NULL)
-        return NULL;
+    AppLayerParserResultElmt *e = NULL;
+
+    if (data == NULL) {
+        e = (AppLayerParserResultElmt *)SCMalloc
+            (sizeof(AppLayerParserResultElmt));
+        if (e == NULL)
+            return NULL;
+    } else {
+        e = data;
+    }
 
     memset(e, 0, sizeof(AppLayerParserResultElmt));
 
@@ -1314,7 +1320,9 @@ void RegisterAppLayerParsers(void)
 
     /** setup result pool
      * \todo Per thread pool */
-    al_result_pool = PoolInit(1000,250,AlpResultElmtPoolAlloc,NULL,AlpResultElmtPoolFree);
+    al_result_pool = PoolInit(1000,250,
+            sizeof(AppLayerParserResultElmt),
+            AlpResultElmtPoolAlloc,NULL,AlpResultElmtPoolFree);
 
     RegisterHTPParsers();
     RegisterSSLParsers();

--- a/src/stream.c
+++ b/src/stream.c
@@ -44,10 +44,16 @@ static uint16_t toclient_min_chunk_len = 2560;
 static Pool *stream_msg_pool = NULL;
 static SCMutex stream_msg_pool_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-void *StreamMsgAlloc(void *null) {
-    StreamMsg *s = SCMalloc(sizeof(StreamMsg));
-    if (s == NULL)
-        return NULL;
+void *StreamMsgAlloc(void *null, void *data) {
+    StreamMsg *s;
+
+    if (data == NULL) {
+        s = SCMalloc(sizeof(StreamMsg));
+        if (s == NULL)
+            return NULL;
+    } else {
+        s = data;
+    }
 
     memset(s, 0, sizeof(StreamMsg));
 
@@ -159,7 +165,7 @@ void StreamMsgQueuesInit(void) {
     SCMutexInit(&stream_pool_memuse_mutex, NULL);
 #endif
     SCMutexLock(&stream_msg_pool_mutex);
-    stream_msg_pool = PoolInit(0,250,StreamMsgAlloc,NULL,StreamMsgFree);
+    stream_msg_pool = PoolInit(0,250,sizeof(StreamMsg),StreamMsgAlloc,NULL,StreamMsgFree);
     if (stream_msg_pool == NULL)
         exit(EXIT_FAILURE); /* XXX */
     SCMutexUnlock(&stream_msg_pool_mutex);

--- a/src/util-pool.h
+++ b/src/util-pool.h
@@ -25,6 +25,7 @@
 #define __UTIL_POOL_H__
 
 #define POOL_BUCKET_PREALLOCATED    1 << 0
+#define POOL_BUCKET_PREALLOCATED_DATA  1 << 1
 
 /* pool bucket structure */
 typedef struct PoolBucket_ {
@@ -36,6 +37,7 @@ typedef struct PoolBucket_ {
 /* pool structure */
 typedef struct Pool_ {
     uint32_t max_buckets;
+    uint32_t preallocated;
     uint32_t allocated;
 
     PoolBucket *alloc_list;
@@ -47,16 +49,17 @@ typedef struct Pool_ {
     PoolBucket *pb_buffer;
     void *data_buffer;
 
-    void *(*Alloc)(void *);
+    void *(*Alloc)(void *, void *);
     void *AllocData;
     void (*Free)(void *);
 
+    uint32_t elt_size;
     uint32_t outstanding;
     uint32_t max_outstanding;
 } Pool;
 
 /* prototypes */
-Pool* PoolInit(uint32_t, uint32_t, void *(*Alloc)(void *), void *, void (*Free)(void *));
+Pool* PoolInit(uint32_t, uint32_t, uint32_t, void *(*Alloc)(void *, void *), void *, void (*Free)(void *));
 void PoolFree(Pool *);
 void PoolPrint(Pool *);
 void PoolPrintSaturation(Pool *p);


### PR DESCRIPTION
This patchset modify the pool allocation system to use a block allocation instead of using a series of allocation.
