### PR TITLE
Add support for IPv4-in-IPv6

### DIFF
--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -45,6 +45,33 @@
 #define IPV6_EXTHDRS     ip6eh.ip6_exthdrs
 #define IPV6_EH_CNT      ip6eh.ip6_exthdrs_cnt
 
+/**
+ * \brief Function to decode IPv4 in IPv6 packets
+ *
+ */
+static void DecodeIPv4inIPv6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t plen, PacketQueue *pq)
+{
+
+    if (unlikely(plen < IPV4_HEADER_LEN)) {
+        ENGINE_SET_EVENT(p, IPV4_PKT_TOO_SMALL);
+        return;
+    }
+    if (IP_GET_RAW_VER(pkt) == 4) {
+        if (pq != NULL) {
+            Packet *tp = PacketPseudoPktSetup(p, pkt, plen, IPPROTO_IP);
+            if (tp != NULL) {
+                DecodeTunnel(tv, dtv, tp, GET_PKT_DATA(tp),
+                        GET_PKT_LEN(tp), pq, IPPROTO_IP);
+                PacketEnqueue(pq,tp);
+                return;
+            }
+        }
+    } else {
+        ENGINE_SET_EVENT(p, IPV4_WRONG_IP_VER);
+    }
+    return;
+}
+
 static void
 DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
 {
@@ -403,6 +430,10 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                 plen -= hdrextlen;
                 break;
             }
+            case IPPROTO_IPIP:
+                IPV6_SET_L4PROTO(p,nh);
+                DecodeIPv4inIPv6(tv, dtv, p, pkt, plen, pq);
+                SCReturn;
             case IPPROTO_NONE:
                 IPV6_SET_L4PROTO(p,nh);
                 SCReturn;
@@ -482,6 +513,9 @@ void DecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, 
         case IPPROTO_SCTP:
             IPV6_SET_L4PROTO (p, IPPROTO_SCTP);
             return DecodeSCTP(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
+        case IPPROTO_IPIP:
+            IPV6_SET_L4PROTO(p, IPPROTO_IPIP);
+            return DecodeIPv4inIPv6(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
         case IPPROTO_FRAGMENT:
         case IPPROTO_HOPOPTS:
         case IPPROTO_ROUTING:
@@ -491,6 +525,7 @@ void DecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, 
         case IPPROTO_ESP:
             DecodeIPV6ExtHdrs(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
             break;
+
         default:
             p->proto = IPV6_GET_NH(p);
             break;


### PR DESCRIPTION
This version adds the missing check and use protocol store in IPv6 header to start the appropriate decoding.
