### PR TITLE
Teredo tunnel supports

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,6 +34,7 @@ decode-ethernet.c decode-ethernet.h \
 decode-vlan.c decode-vlan.h \
 decode-sll.c decode-sll.h \
 decode-gre.c decode-gre.h \
+decode-teredo.c decode-teredo.h \
 decode-ppp.c decode-ppp.h \
 decode-pppoe.c decode-pppoe.h \
 decode-ipv4.c decode-ipv4.h \

--- a/src/decode-teredo.c
+++ b/src/decode-teredo.c
@@ -1,0 +1,101 @@
+/* Copyright (C) 2012 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \ingroup decode
+ *
+ * @{
+ */
+
+
+/**
+ * \file
+ *
+ * \author Eric Leblond <eric@regit.org>
+ *
+ * Decode Teredo Tunneling protocol
+ */
+
+#include "suricata-common.h"
+#include "decode.h"
+#include "decode-ipv6.h"
+#include "util-debug.h"
+
+/**
+ * \brief Function to decode Teredo packets
+ *
+ * \retval 0 if packet is not a Teredo packet, 1 if it is
+ */
+int DecodeTeredo(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
+{
+
+    uint8_t *start = pkt;
+
+    /* Is this packet to short to contain an IPv6 packet ? */
+    if (len < IPV6_HEADER_LEN)
+        return 0;
+
+    /* Teredo encapsulate IPv6 in UDP and can add some custom message
+     * part before the IPv6 packet. Here we iter on the messages to get
+     * on the IPv6 packet. */
+    while (start[0] == 0x0) {
+        switch (start[1]) {
+            /* origin indication: compatible with tunnel */
+            case 0x0:
+                if (len >= 8 + (pkt - start) + IPV6_HEADER_LEN)
+                    start += 8;
+                else
+                    return 0;
+                break;
+            /* authentication: negotiation not real tunnel */
+            case 0x1:
+                return 0;
+            /* this case is not possible in Teredo: not that protocol */
+            default:
+                return 0;
+        }
+    }
+
+    if (IP_GET_RAW_VER(start) == 6) {
+        IPV6Hdr *thdr = (IPV6Hdr *)start;
+        /* This does looks like Teredo protocol, let's pray together */
+        if (len ==  IPV6_HEADER_LEN +
+                IPV6_GET_RAW_PLEN(thdr) + (start - pkt)) {
+            if (pq != NULL) {
+                int blen = len - (start - pkt);
+                /* spawn off tunnel packet */
+                Packet *tp = PacketPseudoPktSetup(p, start, blen,
+                                                  IPPROTO_IPV6);
+                if (tp != NULL) {
+                    /* send that to the Tunnel decoder */
+                    DecodeTunnel(tv, dtv, tp, start, blen,
+                                 pq, IPPROTO_IPV6);
+                    /* add the tp to the packet queue. */
+                    PacketEnqueue(pq,tp);
+                    return 1;
+                }
+            }
+        }
+        return 0;
+    }
+
+    return 0;
+}
+
+/**
+ * @}
+ */

--- a/src/decode-teredo.h
+++ b/src/decode-teredo.h
@@ -1,0 +1,19 @@
+/* Copyright (C) 2012 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+int DecodeTeredo(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+                 uint8_t *pkt, uint16_t len, PacketQueue *pq);

--- a/src/decode-udp.c
+++ b/src/decode-udp.c
@@ -33,6 +33,7 @@
 #include "suricata-common.h"
 #include "decode.h"
 #include "decode-udp.h"
+#include "decode-teredo.h"
 #include "decode-events.h"
 #include "util-unittest.h"
 #include "util-debug.h"
@@ -80,6 +81,11 @@ void DecodeUDP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, u
 
     SCLogDebug("UDP sp: %" PRIu32 " -> dp: %" PRIu32 " - HLEN: %" PRIu32 " LEN: %" PRIu32 "",
         UDP_GET_SRC_PORT(p), UDP_GET_DST_PORT(p), UDP_HEADER_LEN, p->payload_len);
+
+    if (DecodeTeredo(tv, dtv, p, p->payload, p->payload_len, pq) == 1) {
+        FlowHandlePacket(tv, p);
+        return;
+    }
 
     /* Flow is an integral part of us */
     FlowHandlePacket(tv, p);


### PR DESCRIPTION
This patch should fix #480 by adding the support of Teredo tunnel.
The IPv6 content of the tunnel will be parsed in a similar way as
what is done the GRE tunnel. Signatures will then be matched on the
IPv6 content.
