### PR TITLE
decode: decode IP6-in-IP6

### DIFF
--- a/rules/decoder-events.rules
+++ b/rules/decoder-events.rules
@@ -89,6 +89,9 @@ alert icmp any any -> any any (msg:"SURICATA ICMPv6 invalid checksum"; icmpv6-cs
 # IPv4 in IPv6 rules
 alert pkthdr any any -> any any (msg:"SURICATA IPv4-in-IPv6 packet too short"; decode-event:ipv6.ipv4_in_ipv6_too_small; sid:2200082; rev:1;)
 alert pkthdr any any -> any any (msg:"SURICATA IPv4-in-IPv6 invalid protocol"; decode-event:ipv6.ipv4_in_ipv6_wrong_version; sid:2200083; rev:1;)
+# IP6 in IP6 rules
+alert pkthdr any any -> any any (msg:"SURICATA IP6-in-IP6 packet too short"; decode-event:ipv6.ip6_in_ip6_too_small; sid:2200084; rev:1;)
+alert pkthdr any any -> any any (msg:"SURICATA IP6-in-IP6 invalid protocol"; decode-event:ipv6.ip6_in_ip6_wrong_version; sid:2200085; rev:1;)
 
-# next sid is 2200084
+# next sid is 2200086
 

--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -200,6 +200,9 @@ enum {
     /* IPv4 in IPv6 events */
     IPV4_IN_IPV6_PKT_TOO_SMALL,
     IPV4_IN_IPV6_WRONG_IP_VER,
+    /* IP6 in IP6 events */
+    IP6_IN_IP6_PKT_TOO_SMALL,
+    IP6_IN_IP6_WRONG_IP_VER,
 
     /* should always be last! */
     DECODE_EVENT_MAX,

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -71,6 +71,32 @@ static void DecodeIPv4inIPv6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, u
     return;
 }
 
+/**
+ * \brief Function to decode IPv4 in IPv6 packets
+ *
+ */
+static void DecodeIP6inIP6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t plen, PacketQueue *pq)
+{
+
+    if (unlikely(plen < IPV6_HEADER_LEN)) {
+        ENGINE_SET_EVENT(p, IP6_IN_IP6_PKT_TOO_SMALL);
+        return;
+    }
+    if (IP_GET_RAW_VER(pkt) == 6) {
+        if (pq != NULL) {
+            Packet *tp = PacketPseudoPktSetup(p, pkt, plen, IPPROTO_IPV6);
+            if (tp != NULL) {
+                DecodeTunnel(tv, dtv, tp, pkt, plen, pq, IPPROTO_IPV6);
+                PacketEnqueue(pq,tp);
+                return;
+            }
+        }
+    } else {
+        ENGINE_SET_EVENT(p, IP6_IN_IP6_WRONG_IP_VER);
+    }
+    return;
+}
+
 static void
 DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
 {
@@ -515,6 +541,8 @@ void DecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, 
         case IPPROTO_IPIP:
             IPV6_SET_L4PROTO(p, IPPROTO_IPIP);
             return DecodeIPv4inIPv6(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
+        case IPPROTO_IPV6:
+            return DecodeIP6inIP6(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
         case IPPROTO_FRAGMENT:
         case IPPROTO_HOPOPTS:
         case IPPROTO_ROUTING:

--- a/src/detect-engine-event.h
+++ b/src/detect-engine-event.h
@@ -118,6 +118,8 @@ struct DetectEngineEvents_ {
     { "ipv6.frag_overlap", IPV6_FRAG_OVERLAP, },
     { "ipv6.ipv4_in_ipv6_too_small", IPV4_IN_IPV6_PKT_TOO_SMALL, },
     { "ipv6.ipv4_in_ipv6_wrong_version", IPV4_IN_IPV6_WRONG_IP_VER, },
+    { "ipv6.ip6_in_ip6_too_small", IP6_IN_IP6_PKT_TOO_SMALL, },
+    { "ipv6.ip6_in_ip6_wrong_version", IP6_IN_IP6_WRONG_IP_VER, },
     { "stream.3whs_ack_in_wrong_dir", STREAM_3WHS_ACK_IN_WRONG_DIR, },
     { "stream.3whs_async_wrong_seq", STREAM_3WHS_ASYNC_WRONG_SEQ, },
     { "stream.3whs_right_seq_wrong_ack_evasion", STREAM_3WHS_RIGHT_SEQ_WRONG_ACK_EVASION, },


### PR DESCRIPTION
This patch adds decoding of IP6-in-IP6. It also adds some events
for invalid packets.

This patch should fix #514.
