### PR TITLE
decode: decode IPv6-in-IPv6

### DIFF
--- a/rules/decoder-events.rules
+++ b/rules/decoder-events.rules
@@ -89,6 +89,9 @@ alert icmp any any -> any any (msg:"SURICATA ICMPv6 invalid checksum"; icmpv6-cs
 # IPv4 in IPv6 rules
 alert pkthdr any any -> any any (msg:"SURICATA IPv4-in-IPv6 packet too short"; decode-event:ipv6.ipv4_in_ipv6_too_small; sid:2200082; rev:1;)
 alert pkthdr any any -> any any (msg:"SURICATA IPv4-in-IPv6 invalid protocol"; decode-event:ipv6.ipv4_in_ipv6_wrong_version; sid:2200083; rev:1;)
+# IPv6 in IPv6 rules
+alert pkthdr any any -> any any (msg:"SURICATA IPv6-in-IPv6 packet too short"; decode-event:ipv6.ipv6_in_ipv6_too_small; sid:2200084; rev:1;)
+alert pkthdr any any -> any any (msg:"SURICATA IPv6-in-IPv6 invalid protocol"; decode-event:ipv6.ipv6_in_ipv6_wrong_version; sid:2200085; rev:1;)
 
-# next sid is 2200084
+# next sid is 2200086
 

--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -200,6 +200,9 @@ enum {
     /* IPv4 in IPv6 events */
     IPV4_IN_IPV6_PKT_TOO_SMALL,
     IPV4_IN_IPV6_WRONG_IP_VER,
+    /* IPv6 in IPv6 events */
+    IPV6_IN_IPV6_PKT_TOO_SMALL,
+    IPV6_IN_IPV6_WRONG_IP_VER,
 
     /* should always be last! */
     DECODE_EVENT_MAX,

--- a/src/detect-engine-event.h
+++ b/src/detect-engine-event.h
@@ -118,6 +118,8 @@ struct DetectEngineEvents_ {
     { "ipv6.frag_overlap", IPV6_FRAG_OVERLAP, },
     { "ipv6.ipv4_in_ipv6_too_small", IPV4_IN_IPV6_PKT_TOO_SMALL, },
     { "ipv6.ipv4_in_ipv6_wrong_version", IPV4_IN_IPV6_WRONG_IP_VER, },
+    { "ipv6.ipv6_in_ipv6_too_small", IPV6_IN_IPV6_PKT_TOO_SMALL, },
+    { "ipv6.ipv6_in_ipv6_wrong_version", IPV6_IN_IPV6_WRONG_IP_VER, },
     { "stream.3whs_ack_in_wrong_dir", STREAM_3WHS_ACK_IN_WRONG_DIR, },
     { "stream.3whs_async_wrong_seq", STREAM_3WHS_ASYNC_WRONG_SEQ, },
     { "stream.3whs_right_seq_wrong_ack_evasion", STREAM_3WHS_RIGHT_SEQ_WRONG_ACK_EVASION, },


### PR DESCRIPTION
This patch adds decoding of IPv6-in-IPv6. It also adds some events
for invalid packets.

This patch should fix #514.
