### PR TITLE
fix regression (clobbered register; redmine #534)

### DIFF
--- a/src/util-cpu.c
+++ b/src/util-cpu.c
@@ -192,8 +192,10 @@ uint64_t UtilCpuGetTicks(void)
 #else
     __asm__ __volatile__ (
     "xorl %%eax,%%eax\n\t"
+    "pushl %%ebx\n\t"
     "cpuid\n\t"
-    ::: "%eax", "%ebx", "%ecx", "%edx");
+    "popl %%ebx\n\t"
+    ::: "%eax", "%ecx", "%edx");
 #endif
     uint32_t a, d;
     __asm__ __volatile__ ("rdtsc" : "=a" (a), "=d" (d));
@@ -206,8 +208,10 @@ uint64_t UtilCpuGetTicks(void)
 #else
     __asm__ __volatile__ (
     "xorl %%eax,%%eax\n\t"
+    "pushl %%ebx\n\t"
     "cpuid\n\t"
-    ::: "%eax", "%ebx", "%ecx", "%edx");
+    "popl %%ebx\n\t"
+    ::: "%eax", "%ecx", "%edx");
 #endif
 
 #else /* #if defined(__GNU__) */


### PR DESCRIPTION
This regression is the one caused by executing the cpuid asm instruction on i386/i686 architecture. This instruction clobbers the EBX register, which is used for PIC on 32-bit gcc GNU/Linux.
