### PR TITLE
Add counters for IPv4 in IPv6 and IPv6 in IPv6

### DIFF
--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -62,6 +62,7 @@ static void DecodeIPv4inIPv6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, u
             if (tp != NULL) {
                 DecodeTunnel(tv, dtv, tp, pkt, plen, pq, IPPROTO_IP);
                 PacketEnqueue(pq,tp);
+                SCPerfCounterIncr(dtv->counter_ipv4inipv6, tv->sc_perf_pca);
                 return;
             }
         }
@@ -88,6 +89,7 @@ static void DecodeIP6inIP6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uin
             if (tp != NULL) {
                 DecodeTunnel(tv, dtv, tp, pkt, plen, pq, IPPROTO_IPV6);
                 PacketEnqueue(pq,tp);
+                SCPerfCounterIncr(dtv->counter_ipv6inipv6, tv->sc_perf_pca);
                 return;
             }
         }

--- a/src/decode.c
+++ b/src/decode.c
@@ -336,6 +336,10 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
                                                SC_PERF_TYPE_UINT64, "NULL");
     dtv->counter_teredo = SCPerfTVRegisterCounter("decoder.teredo", tv,
                                                SC_PERF_TYPE_UINT64, "NULL");
+    dtv->counter_ipv4inipv6 = SCPerfTVRegisterCounter("decoder.ipv4_in_ipv6", tv,
+                                               SC_PERF_TYPE_UINT64, "NULL");
+    dtv->counter_ipv6inipv6 = SCPerfTVRegisterCounter("decoder.ipv6_in_ipv6", tv,
+                                               SC_PERF_TYPE_UINT64, "NULL");
     dtv->counter_avg_pkt_size = SCPerfTVRegisterAvgCounter("decoder.avg_pkt_size", tv,
                                                            SC_PERF_TYPE_DOUBLE, "NULL");
     dtv->counter_max_pkt_size = SCPerfTVRegisterMaxCounter("decoder.max_pkt_size", tv,

--- a/src/decode.h
+++ b/src/decode.h
@@ -555,6 +555,8 @@ typedef struct DecodeThreadVars_
     uint16_t counter_vlan;
     uint16_t counter_pppoe;
     uint16_t counter_teredo;
+    uint16_t counter_ipv4inipv6;
+    uint16_t counter_ipv6inipv6;
     uint16_t counter_avg_pkt_size;
     uint16_t counter_max_pkt_size;
 


### PR DESCRIPTION
Hello,

Here's a patch adding two counters for IPv6 related tunnels.
