### PR TITLE
decode: use pointer inside packet area as param

### DIFF
--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -60,7 +60,8 @@ static void DecodeIPv4inIPv6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, u
         if (pq != NULL) {
             Packet *tp = PacketPseudoPktSetup(p, pkt, plen, IPPROTO_IP);
             if (tp != NULL) {
-                DecodeTunnel(tv, dtv, tp, pkt, plen, pq, IPPROTO_IP);
+                DecodeTunnel(tv, dtv, tp, GET_PKT_DATA(tp),
+                             GET_PKT_LEN(tp), pq, IPPROTO_IP);
                 PacketEnqueue(pq,tp);
                 SCPerfCounterIncr(dtv->counter_ipv4inipv6, tv->sc_perf_pca);
                 return;
@@ -87,7 +88,8 @@ static void DecodeIP6inIP6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uin
         if (pq != NULL) {
             Packet *tp = PacketPseudoPktSetup(p, pkt, plen, IPPROTO_IPV6);
             if (tp != NULL) {
-                DecodeTunnel(tv, dtv, tp, pkt, plen, pq, IPPROTO_IPV6);
+                DecodeTunnel(tv, dtv, tp, GET_PKT_DATA(tp),
+                             GET_PKT_LEN(tp), pq, IPPROTO_IP);
                 PacketEnqueue(pq,tp);
                 SCPerfCounterIncr(dtv->counter_ipv6inipv6, tv->sc_perf_pca);
                 return;

--- a/src/decode-teredo.c
+++ b/src/decode-teredo.c
@@ -89,7 +89,7 @@ int DecodeTeredo(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt,
                                                   IPPROTO_IPV6);
                 if (tp != NULL) {
                     /* send that to the Tunnel decoder */
-                    DecodeTunnel(tv, dtv, tp, start, blen,
+                    DecodeTunnel(tv, dtv, tp, GET_PKT_DATA(tp), GET_PKT_LEN(tp),
                                  pq, IPPROTO_IPV6);
                     /* add the tp to the packet queue. */
                     PacketEnqueue(pq,tp);


### PR DESCRIPTION
DecodeTeredo, DecodeIPv6InIPv6 and DecodeIPv4inIPv6 were calling
DecodeTunnel with packet being a pseudo packet and data being
data from initial packet:

``` C
        DecodeTunnel(tv, dtv, tp, start, blen,
                     pq, IPPROTO_IPV6);
```

In decoding functions, arithmetic was done on pkt to set some values?
It was resulting in field of packet  pointing outside of the scope of
packet data.
This patch switch to what has been done in DecodeGre(), I mean:

``` C
        DecodeTunnel(tv, dtv, tp, GET_PKT_DATA(tp),
                     GET_PKT_LEN(tp), pq, IPPROTO_IP);
```

Data buffer is then relative to the packet and the arithmetic is
correct.
