### PR TITLE
Do not trim the FCS, pcaps converted to ERF will have have an FCS.

### DIFF
--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -483,7 +483,7 @@ static inline TmEcode ProcessErfDagRecord(ErfDagThreadVars *ewtn, char *prec)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    SET_PKT_LEN(p, wlen - 4);   /* Trim the FCS... */
+    SET_PKT_LEN(p, wlen);
     p->datalink = LINKTYPE_ETHERNET;
 
     /* Take into account for link type Ethernet ETH frame starts

--- a/src/source-erf-file.c
+++ b/src/source-erf-file.c
@@ -186,7 +186,7 @@ static inline TmEcode ReadErfRecord(ThreadVars *tv, Packet *p, void *data)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    GET_PKT_LEN(p) = wlen - 4; /* Trim the FCS... */
+    GET_PKT_LEN(p) = wlen;
     p->datalink = LINKTYPE_ETHERNET;
 
     /* Convert ERF time to timeval - from libpcap. */


### PR DESCRIPTION
Victor, we discussed this some time ago, that Suricata would not have any issues with some trailing data after the IP packet, but I never did provide the required patch.  Anyways, this is required to handle ERF files that were converted from pcaps.
