### PR TITLE
defrag: don't use message for repetitive error

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -363,6 +363,9 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_defrag_ipv6_timeouts =
         SCPerfTVRegisterCounter("defrag.ipv6.timeouts", tv,
             SC_PERF_TYPE_UINT64, "NULL");
+    dtv->counter_defrag_max_hit =
+        SCPerfTVRegisterCounter("defrag.max_frag_hits", tv,
+            SC_PERF_TYPE_UINT64, "NULL");
 
     tv->sc_perf_pca = SCPerfGetAllCountersArray(&tv->sc_perf_pctx);
     SCPerfAddToClubbedTMTable(tv->name, &tv->sc_perf_pctx);

--- a/src/decode.h
+++ b/src/decode.h
@@ -574,6 +574,7 @@ typedef struct DecodeThreadVars_
     uint16_t counter_defrag_ipv6_fragments;
     uint16_t counter_defrag_ipv6_reassembled;
     uint16_t counter_defrag_ipv6_timeouts;
+    uint16_t counter_defrag_max_hit;
 } DecodeThreadVars;
 
 /**

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1151,8 +1151,8 @@ DefragGetTracker(ThreadVars *tv, DecodeThreadVars *dtv, DefragContext *dc,
         }
         SCMutexUnlock(&dc->tracker_pool_lock);
         if (tracker == NULL) {
-            /* Report memory error - actually a pool allocation error. */
-            SCLogError(SC_ERR_MEM_ALLOC, "Defrag: Failed to allocate tracker.");
+            SCPerfCounterIncr(dtv->counter_defrag_max_hit,
+                tv->sc_perf_pca);
             goto done;
         }
         DefragTrackerReset(tracker);


### PR DESCRIPTION
When nothing can be fetch from the pool, this can repeat frequently.
Thus displaying a message in the log will not help. This patch
uses a counter instead of a log message. As this is a sort of memcap
this is conformed to what is done for other issues of the same type.
