### PR TITLE
Add missing include in flow-manager

### DIFF
--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -62,6 +62,7 @@
 #include "app-layer-parser.h"
 
 #include "host-timeout.h"
+#include "defrag-timeout.h"
 
 /* Run mode selected at suricata.c */
 extern int run_mode;


### PR DESCRIPTION
DefragTimeoutHash was not declared before being used.
