### PR TITLE
alproto mpm prefilter fix

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -1234,46 +1234,46 @@ static inline void DetectMpmPrefilter(DetectEngineCtx *de_ctx,
 
         /* all http based mpms */
         if (alproto == ALPROTO_HTTP && alstate != NULL) {
-                if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_URI) {
-                    PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_URI);
-                    DetectUricontentInspectMpm(det_ctx, p->flow, alstate, flags);
-                    PACKET_PROFILING_DETECT_END(p, PROF_DETECT_MPM_URI);
-                }
-                if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_HRUD) {
-                    PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_HRUD);
-                    DetectEngineRunHttpRawUriMpm(det_ctx, p->flow, alstate, flags);
-                    PACKET_PROFILING_DETECT_END(p, PROF_DETECT_MPM_HRUD);
-                }
-                if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_HCBD) {
-                    PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_HCBD);
-                    DetectEngineRunHttpClientBodyMpm(de_ctx, det_ctx, p->flow, alstate, flags);
-                    PACKET_PROFILING_DETECT_END(p, PROF_DETECT_MPM_HCBD);
-                }
-                if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_HMD) {
-                    PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_HMD);
-                    DetectEngineRunHttpMethodMpm(det_ctx, p->flow, alstate, flags);
-                    PACKET_PROFILING_DETECT_END(p, PROF_DETECT_MPM_HMD);
-                }
-                if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_HUAD) {
-                    PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_HUAD);
-                    DetectEngineRunHttpUAMpm(det_ctx, p->flow, alstate, flags);
-                    PACKET_PROFILING_DETECT_END(p, PROF_DETECT_MPM_HUAD);
-                }
-                if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_HSBD) {
-                    PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_HSBD);
-                    DetectEngineRunHttpServerBodyMpm(de_ctx, det_ctx, p->flow, alstate, flags);
-                    PACKET_PROFILING_DETECT_END(p, PROF_DETECT_MPM_HSBD);
-                }
-                if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_HSMD) {
-                    PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_HSMD);
-                    DetectEngineRunHttpStatMsgMpm(det_ctx, p->flow, alstate, flags);
-                    PACKET_PROFILING_DETECT_END(p, PROF_DETECT_MPM_HSMD);
-                }
-                if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_HSCD) {
-                    PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_HSCD);
-                    DetectEngineRunHttpStatCodeMpm(det_ctx, p->flow, alstate, flags);
-                    PACKET_PROFILING_DETECT_END(p, PROF_DETECT_MPM_HSCD);
-                }
+            if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_URI) {
+                PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_URI);
+                DetectUricontentInspectMpm(det_ctx, p->flow, alstate, flags);
+                PACKET_PROFILING_DETECT_END(p, PROF_DETECT_MPM_URI);
+            }
+            if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_HRUD) {
+                PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_HRUD);
+                DetectEngineRunHttpRawUriMpm(det_ctx, p->flow, alstate, flags);
+                PACKET_PROFILING_DETECT_END(p, PROF_DETECT_MPM_HRUD);
+            }
+            if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_HCBD) {
+                PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_HCBD);
+                DetectEngineRunHttpClientBodyMpm(de_ctx, det_ctx, p->flow, alstate, flags);
+                PACKET_PROFILING_DETECT_END(p, PROF_DETECT_MPM_HCBD);
+            }
+            if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_HMD) {
+                PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_HMD);
+                DetectEngineRunHttpMethodMpm(det_ctx, p->flow, alstate, flags);
+                PACKET_PROFILING_DETECT_END(p, PROF_DETECT_MPM_HMD);
+            }
+            if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_HUAD) {
+                PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_HUAD);
+                DetectEngineRunHttpUAMpm(det_ctx, p->flow, alstate, flags);
+                PACKET_PROFILING_DETECT_END(p, PROF_DETECT_MPM_HUAD);
+            }
+            if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_HSBD) {
+                PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_HSBD);
+                DetectEngineRunHttpServerBodyMpm(de_ctx, det_ctx, p->flow, alstate, flags);
+                PACKET_PROFILING_DETECT_END(p, PROF_DETECT_MPM_HSBD);
+            }
+            if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_HSMD) {
+                PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_HSMD);
+                DetectEngineRunHttpStatMsgMpm(det_ctx, p->flow, alstate, flags);
+                PACKET_PROFILING_DETECT_END(p, PROF_DETECT_MPM_HSMD);
+            }
+            if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_HSCD) {
+                PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_HSCD);
+                DetectEngineRunHttpStatCodeMpm(det_ctx, p->flow, alstate, flags);
+                PACKET_PROFILING_DETECT_END(p, PROF_DETECT_MPM_HSCD);
+            }
             if (det_ctx->sgh->flags & SIG_GROUP_HEAD_MPM_HHD) {
                 PACKET_PROFILING_DETECT_START(p, PROF_DETECT_MPM_HHD);
                 DetectEngineRunHttpHeaderMpm(det_ctx, p->flow, alstate, flags);


### PR DESCRIPTION
In our mpm engine, if the alproto is ALPROTO_HTTP, we should run both the
toserver mpms like uri, hcbd, and the toclient mpms like hsbd for any packet
direction we receive.  This is because if we have a sig which has a uri fp
set, but the sig also has a hsbd keyword set, we won't end up inspecting the
hsbd data, since we never run the uri mpm while we receive a toclient packet.

Another solution is, if we have a alproto mpm set, and if the same sig has
the same alproto content in the other direction, we should set a mpm for
the other direction as well.
