### PR TITLE
pedro's hsbd bug.

### DIFF
--- a/src/detect-engine-hcbd.c
+++ b/src/detect-engine-hcbd.c
@@ -161,11 +161,11 @@ static void DetectEngineBufferHttpClientBodies(DetectEngineCtx *de_ctx,
          * and running content validation on this buffer type of architecture
          * to a stateful inspection, where we can inspect body chunks as and
          * when they come */
-            if ((htud->request_body.content_len_so_far > 0) &&
-                    tx->progress != TX_PROGRESS_REQ_BODY) {
-                /* final length of the body */
-                htud->tsflags |= HTP_REQ_BODY_COMPLETE;
-            }
+        if ((htud->request_body.content_len_so_far > 0) &&
+            tx->progress != TX_PROGRESS_REQ_BODY) {
+            /* final length of the body */
+            htud->tsflags |= HTP_REQ_BODY_COMPLETE;
+        }
 
         if (flags & STREAM_EOF) {
             htud->tsflags |= HTP_REQ_BODY_COMPLETE;

--- a/src/detect-engine-hsbd.c
+++ b/src/detect-engine-hsbd.c
@@ -155,11 +155,11 @@ static void DetectEngineBufferHttpServerBodies(DetectEngineCtx *de_ctx,
          * and running content validation on this buffer type of architecture
          * to a stateful inspection, where we can inspect body chunks as and
          * when they come */
-            if ((htud->response_body.content_len_so_far > 0) &&
-                    tx->progress != TX_PROGRESS_REQ_BODY) {
-                /* final length of the body */
-                htud->tcflags |= HTP_RES_BODY_COMPLETE;
-            }
+        if ((htud->response_body.content_len_so_far > 0) &&
+            tx->progress != TX_PROGRESS_REQ_BODY) {
+            /* final length of the body */
+            htud->tcflags |= HTP_RES_BODY_COMPLETE;
+        }
 
         if (flags & STREAM_EOF) {
             htud->tcflags |= HTP_RES_BODY_COMPLETE;


### PR DESCRIPTION
This is pedro's hsbd bug.  I have fixed it for both hsbd and hcbd.

Basically we use the tx state to update whether we have seen the entire body or not.   I would have rather had the check inside the response_body_callback function but the tx state is updated after the callbacks, and hence we will have to do the check inside the detection engine function.
