### PR TITLE
tm-thread: detect thread death

### DIFF
--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -1771,7 +1771,7 @@ TmEcode TmThreadSpawn(ThreadVars *tv)
         return TM_ECODE_FAILED;
     }
 
-    TmThreadWaitForFlag(tv, THV_INIT_DONE);
+    TmThreadWaitForFlag(tv, THV_INIT_DONE | THV_RUNNING_DONE);
 
     TmThreadAppend(tv, tv->type);
 


### PR DESCRIPTION
When a thread is dead at init the THV_INIT_DONE flag is not set
and the spawn function can freeze (see bug #553 for an example).
In this case THV_RUNNING_DONE is set and we can also check on this
state for leaving the function. This should fix #bug553
