### PR TITLE
fix for bug #557.

### DIFF
--- a/src/detect-engine-hhd.c
+++ b/src/detect-engine-hhd.c
@@ -100,18 +100,21 @@ static void DetectEngineBufferHttpHeaders(DetectEngineThreadCtx *det_ctx, Flow *
     /* assign space to hold buffers.  Each per transaction */
     det_ctx->hhd_buffers = SCMalloc(det_ctx->hhd_buffers_list_len * sizeof(uint8_t *));
     if (det_ctx->hhd_buffers == NULL) {
+        det_ctx->hhd_buffers_list_len = 0;
         goto end;
     }
     memset(det_ctx->hhd_buffers, 0, det_ctx->hhd_buffers_list_len * sizeof(uint8_t *));
 
     det_ctx->hhd_buffers_len = SCMalloc(det_ctx->hhd_buffers_list_len * sizeof(uint32_t));
     if (det_ctx->hhd_buffers_len == NULL) {
+        det_ctx->hhd_buffers_list_len = 0;
         goto end;
     }
     memset(det_ctx->hhd_buffers_len, 0, det_ctx->hhd_buffers_list_len * sizeof(uint32_t));
 
     idx = AppLayerTransactionGetInspectId(f);
     if (idx == -1) {
+        det_ctx->hhd_buffers_list_len = 0;
         goto end;
     }
 
@@ -279,16 +282,16 @@ void DetectEngineCleanHHDBuffers(DetectEngineThreadCtx *det_ctx)
             if (det_ctx->hhd_buffers[i] != NULL)
                 SCFree(det_ctx->hhd_buffers[i]);
         }
-        if (det_ctx->hhd_buffers != NULL) {
-            SCFree(det_ctx->hhd_buffers);
-            det_ctx->hhd_buffers = NULL;
-        }
-        if (det_ctx->hhd_buffers_len != NULL) {
-            SCFree(det_ctx->hhd_buffers_len);
-            det_ctx->hhd_buffers_len = NULL;
-        }
-        det_ctx->hhd_buffers_list_len = 0;
     }
+    if (det_ctx->hhd_buffers != NULL) {
+        SCFree(det_ctx->hhd_buffers);
+        det_ctx->hhd_buffers = NULL;
+    }
+    if (det_ctx->hhd_buffers_len != NULL) {
+        SCFree(det_ctx->hhd_buffers_len);
+        det_ctx->hhd_buffers_len = NULL;
+    }
+    det_ctx->hhd_buffers_list_len = 0;
 
     return;
 }


### PR DESCRIPTION
Reset hhd buffers list len if we exit before allocating the buffer.
