### PR TITLE
pf-ring: add counter for kernel drop and packets

### DIFF
--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -123,6 +123,9 @@ typedef struct PfringThreadVars_
     uint64_t bytes;
     uint32_t pkts;
 
+    uint16_t capture_kernel_packets;
+    uint16_t capture_kernel_drops;
+
     ThreadVars *tv;
     TmSlot *slot;
 
@@ -169,6 +172,17 @@ void TmModuleDecodePfringRegister (void) {
     tmm_modules[TMM_DECODEPFRING].ThreadDeinit = NULL;
     tmm_modules[TMM_DECODEPFRING].RegisterTests = NULL;
     tmm_modules[TMM_DECODEPFRING].flags = TM_FLAG_DECODE_TM;
+}
+
+static inline void PfringDumpCounters(PfringThreadVars *ptv, int forced)
+{
+    if (((ptv->pkts & 0xfff) == 0) || forced) {
+        pfring_stat pfring_s;
+        if (pfring_stats(ptv->pd, &pfring_s) >= 0) {
+            SCPerfCounterSetUI64(ptv->capture_kernel_packets, ptv->tv->sc_perf_pca, pfring_s.recv);
+            SCPerfCounterSetUI64(ptv->capture_kernel_drops, ptv->tv->sc_perf_pca, pfring_s.drop);
+        }
+    }
 }
 
 /**
@@ -298,6 +312,8 @@ TmEcode ReceivePfringLoop(ThreadVars *tv, void *data, void *slot)
                 TmqhOutputPacketpool(ptv->tv, p);
                 SCReturnInt(TM_ECODE_FAILED);
             }
+
+            PfringDumpCounters(ptv, 0);
         } else {
             SCLogError(SC_ERR_PF_RING_RECV,"pfring_recv error  %" PRId32 "", r);
             TmqhOutputPacketpool(ptv->tv, p);
@@ -411,6 +427,15 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, void *initdata, void **data) {
     }
 #endif /* HAVE_PFRING_SET_BPF_FILTER */
 
+    ptv->capture_kernel_packets = SCPerfTVRegisterCounter("capture.kernel_packets",
+            ptv->tv,
+            SC_PERF_TYPE_UINT64,
+            "NULL");
+    ptv->capture_kernel_drops = SCPerfTVRegisterCounter("capture.kernel_drops",
+            ptv->tv,
+            SC_PERF_TYPE_UINT64,
+            "NULL");
+
 /* It seems that as of 4.7.1 this is required */
 #ifdef HAVE_PFRING_ENABLE
     rc = pfring_enable_ring(ptv->pd);
@@ -435,18 +460,13 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, void *initdata, void **data) {
  */
 void ReceivePfringThreadExitStats(ThreadVars *tv, void *data) {
     PfringThreadVars *ptv = (PfringThreadVars *)data;
-    pfring_stat pfring_s;
 
-    if(pfring_stats(ptv->pd, &pfring_s) < 0) {
-        SCLogError(SC_ERR_STAT,"(%s) Failed to get pfring stats", tv->name);
-        SCLogInfo("(%s) Packets %" PRIu32 ", bytes %" PRIu64 "", tv->name, ptv->pkts, ptv->bytes);
-    } else {
-        SCLogInfo("(%s) Packets %" PRIu32 ", bytes %" PRIu64 "", tv->name, ptv->pkts, ptv->bytes);
-
-        SCLogInfo("(%s) Pfring Total:%" PRIu64 " Recv:%" PRIu64 " Drop:%" PRIu64 " (%02.1f%%).", tv->name,
-        (uint64_t)pfring_s.recv + (uint64_t)pfring_s.drop, (uint64_t)pfring_s.recv,
-        (uint64_t)pfring_s.drop, ((float)pfring_s.drop/(float)(pfring_s.drop + pfring_s.recv))*100);
-    }
+    PfringDumpCounters(ptv, 1);
+    SCLogInfo("(%s) Kernel: Packets %" PRIu64 ", dropped %" PRIu64 "",
+            tv->name,
+            (uint64_t) SCPerfGetLocalCounterValue(ptv->capture_kernel_packets, tv->sc_perf_pca),
+            (uint64_t) SCPerfGetLocalCounterValue(ptv->capture_kernel_drops, tv->sc_perf_pca));
+    SCLogInfo("(%s) Packets %" PRIu32 ", bytes %" PRIu64 "", tv->name, ptv->pkts, ptv->bytes);
 }
 
 /**


### PR DESCRIPTION
This patch adds a counter for kernel drop and packets by using the
same strategy as the one used in af-packet.
