### PR TITLE
suricata: list-keywords does not depend on unittest

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -484,9 +484,9 @@ void usage(const char *progname)
     printf("\t-U, --unittest-filter=REGEX  : filter unittests with a regex\n");
     printf("\t--list-app-layer-protos      : list supported app layer protocols\n");
     printf("\t--list-unittests             : list unit tests\n");
-    printf("\t--list-keywords              : list all keywords implemented by the engine\n");
     printf("\t--fatal-unittests            : enable fatal failure on unittest error\n");
 #endif /* UNITTESTS */
+    printf("\t--list-keywords              : list all keywords implemented by the engine\n");
 #ifdef __SC_CUDA_SUPPORT__
     printf("\t--list-cuda-cards            : list cuda supported cards\n");
 #endif


### PR DESCRIPTION
The help message did not display the list-keywords commands when unittest were not build.
