### PR TITLE
stream.inline: add 'auto' mode

### DIFF
--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -396,8 +396,20 @@ void StreamTcpInitConfig(char quiet)
 
     int inl = 0;
 
-    if (ConfGetBool("stream.inline", &inl) == 1) {
+
+    char *temp_stream_inline_str;
+    if (ConfGet("stream.inline", &temp_stream_inline_str) == 1) {
+        /* checking for "auto" and falling back to boolean to provide
+         * backward compatibility */
+        if (!strncmp(temp_stream_inline_str, "auto", strlen("auto"))) {
+            if (IS_ENGINE_MODE_IPS(engine_mode)) {
+                stream_inline = 1;
+            } else {
+                stream_inline = 0;
+            }
+        } else if (ConfGetBool("stream.inline", &inl) == 1) {
             stream_inline = inl;
+        }
     }
 
     if (!quiet) {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -570,7 +570,7 @@ flow-timeouts:
 stream:
   memcap: 32mb
   checksum-validation: yes      # reject wrong csums
-  inline: no                    # no inline mode
+  inline: auto                  # auto will use inline mode in IPS mode, yes or no set it statically
   reassembly:
     memcap: 64mb
     depth: 1mb                  # reassemble 1mb into a stream


### PR DESCRIPTION
stream.inline YAML configuration variable now support the 'auto' value.
In this case, inline mode is activated for IPS running mode (NFQ and
IPFW) and is deactivated for IDS mode. This patch should fix bug #592.
