### PR TITLE
Bug379

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -291,7 +291,15 @@ AC_INIT(configure.ac)
     AC_ARG_ENABLE(profiling,
            AS_HELP_STRING([--enable-profiling], [Enable performance profiling]),,[enable_profiling=no])
     AS_IF([test "x$enable_profiling" = "xyes"], [
-        CFLAGS="${CFLAGS} -DPROFILING"
+
+    	case "$host" in
+           *-*-openbsd*)
+		AC_MSG_ERROR([profiling is not supported on OpenBSD])
+		;;
+	   *)
+        	CFLAGS="${CFLAGS} -DPROFILING"
+		;;
+        esac
     ])
 
   # profiling support, locking


### PR DESCRIPTION
Here's a fix for bug #379. It also fixes suricata.yaml generation for openBSD 5.1 (where magic file place has changed).
