### PR TITLE
build: error on implicit function declaration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ AC_INIT(configure.ac)
 
     if test "$gccvernum" -ge "400"; then
             dnl gcc 4.0 or later
-            CFLAGS="$CFLAGS -Wextra"
+            CFLAGS="$CFLAGS -Wextra -Werror=implicit-function-declaration"
     else
             CFLAGS="$CFLAGS -W"
     fi


### PR DESCRIPTION
This patch modifies gcc options to error in case of implicit
declaration. Bug #612 has shown this kind of bugs can be very
costly.
