### PR TITLE
suricata: add run-as.user and run-as.group yaml var

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1697,6 +1697,19 @@ int main(int argc, char **argv)
 	/* SIGHUP is not implemnetd on WIN32 */
     //UtilSignalHandlerSetup(SIGHUP, SignalHandlerSighup);
 
+    /* Try to get user/group to run suricata as if
+       command line as not decide of that */
+    if (do_setuid == FALSE && do_setgid == FALSE) {
+        char *id;
+        if (ConfGet("run-as.user", &id) == 1) {
+            do_setuid = TRUE;
+            user_name = id;
+        }
+        if (ConfGet("run-as.group", &id) == 1) {
+            do_setgid = TRUE;
+            group_name = id;
+        }
+    }
     /* Get the suricata user ID to given user ID */
     if (do_setuid == TRUE) {
         if (SCGetUserID(user_name, group_name, &userid, &groupid) != 0) {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -32,6 +32,11 @@
 #
 #autofp-scheduler: active-packets
 
+# Run suricata as user and group.
+#run-as:
+#  user: suri
+#  group: suri
+
 # Default pid file.
 # Will use this file if no --pidfile in command options.
 #pid-file: /var/run/suricata.pid


### PR DESCRIPTION
This patch update the YAML to be able to specify the user or the
group to run Suricata as:
 run-as:
   user: suri
   group: suri
