### PR TITLE
coccinelle: fix distcheck

### DIFF
--- a/qa/coccinelle/run_check.sh
+++ b/qa/coccinelle/run_check.sh
@@ -7,19 +7,19 @@ if [ $1 ]; then
 		;;
         *..*) 
         	LIST=$(git diff --pretty="format:" --name-only $1 | grep -E '[ch]$')
-		PREFIX="../../"
+		PREFIX=$(git rev-parse --show-toplevel)/
 		;;
 	*)
 		LIST=$(git show --pretty="format:" --name-only $1 | grep -E '[ch]$')
-		PREFIX="../../"
+		PREFIX=$(git rev-parse --show-toplevel)/
 		;;
 	esac
 else
 	LIST=$(git ls-tree -r --name-only --full-tree  HEAD src/ | grep -E '*.c$')
-	PREFIX="../../"
+	PREFIX=$(git rev-parse --show-toplevel)/
 fi
 
-for SMPL in *.cocci; do
+for SMPL in $(git rev-parse --show-toplevel)/qa/coccinelle/*.cocci; do
 	echo "Testing cocci file: $SMPL"
 	for FILE in $LIST ; do
 		spatch --very-quiet -sp_file $SMPL --undefined UNITTESTS  $PREFIX$FILE || exit 1;


### PR DESCRIPTION
distcheck is running run_check.sh from another directory and
run_check.sh was not ready for this.
