### PR TITLE
unix-socket: cleanup host table instead of destroying it

### DIFF
--- a/src/host.h
+++ b/src/host.h
@@ -133,6 +133,7 @@ SC_ATOMIC_DECLARE(unsigned int,host_prune_idx);
 
 void HostInitConfig(char quiet);
 void HostShutdown(void);
+void HostCleanup(void);
 
 Host *HostLookupHostFromHash (Address *);
 Host *HostGetHostFromHash (Address *);

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -273,7 +273,7 @@ TmEcode UnixSocketPcapFilesCheck(void *data)
         SCPerfReleaseResources();
         /* thread killed, we can run non thread-safe shutdown functions */
         FlowShutdown();
-        HostShutdown();
+        HostCleanup();
         StreamTcpFreeConfig(STREAM_VERBOSE);
         DefragDestroy();
         TmqResetQueues();
@@ -299,7 +299,6 @@ TmEcode UnixSocketPcapFilesCheck(void *data)
         PcapFilesFree(cfile);
         SCPerfInitCounterApi();
         DefragInit();
-        HostInitConfig(HOST_QUIET);
         FlowInitConfig(FLOW_QUIET);
         StreamTcpInitConfig(STREAM_VERBOSE);
         RunModeInitializeOutputs();

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1805,8 +1805,8 @@ int main(int argc, char **argv)
 #endif /* OS_WIN32 */
 
     PacketPoolInit(max_pending_packets);
+    HostInitConfig(HOST_VERBOSE);
     if (run_mode != RUNMODE_UNIX_SOCKET) {
-        HostInitConfig(HOST_VERBOSE);
         FlowInitConfig(FLOW_VERBOSE);
     }
 
@@ -2076,9 +2076,9 @@ int main(int argc, char **argv)
     if (run_mode != RUNMODE_UNIX_SOCKET) {
         SCPerfReleaseResources();
         FlowShutdown();
-        HostShutdown();
         StreamTcpFreeConfig(STREAM_VERBOSE);
     }
+    HostShutdown();
 
     HTPFreeConfig();
     HTPAtExitPrintStats();


### PR DESCRIPTION
This patch should fix the bug #637. Between pcap files, it uses a
new function HostCleanup() to clear tag and threshold on host with
an IP regputation. An other consequence of this modification is
that Host init and shutdown are now init and shutdown unconditionaly.
