### PR TITLE
host: suppress double memory clear

### DIFF
--- a/src/host.c
+++ b/src/host.c
@@ -260,7 +260,6 @@ void HostShutdown(void)
             Host *h = host_hash[u].head;
             while (h) {
                 Host *n = h->hnext;
-                HostClearMemory(h);
                 HostFree(h);
                 h = n;
             }


### PR DESCRIPTION
HostFree() is calling HostClearMemory() so calling HostClearMemory()
before HostFree() is useless.
