### PR TITLE
magic: freebsd magic return differently

### DIFF
--- a/src/util-magic.c
+++ b/src/util-magic.c
@@ -150,6 +150,12 @@ void MagicDeinit(void) {
 
 #ifdef UNITTESTS
 
+#ifndef FREEBSD
+#define MICROSOFT_OFFICE_DOC "Microsoft Office Document"
+#else
+#define MICROSOFT_OFFICE_DOC "OLE 2 Compound Document"
+#endif
+
 /** \test magic lib calls -- init */
 int MagicInitTest01(void) {
     magic_t magic_ctx;
@@ -242,7 +248,7 @@ int MagicDetectTest02(void) {
         return 0;
 
     result = (char *)magic_buffer(magic_ctx, (void *)buffer, buffer_len);
-    if (result == NULL || strcmp(result, "Microsoft Office Document") != 0) {
+    if (result == NULL || strcmp(result, MICROSOFT_OFFICE_DOC) != 0) {
         printf("result %p:%s, not \"Microsoft Office Document\": ", result,result?result:"(null)");
         goto end;
     }
@@ -403,7 +409,7 @@ int MagicDetectTest06(void) {
     MagicInit();
 
     result = MagicGlobalLookup(buffer, buffer_len);
-    if (result == NULL || strcmp(result, "Microsoft Office Document") != 0) {
+    if (result == NULL || strcmp(result, MICROSOFT_OFFICE_DOC) != 0) {
         printf("result %p:%s, not \"Microsoft Office Document\": ", result,result?result:"(null)");
         goto end;
     }


### PR DESCRIPTION
FreeBSD don't return "Microsoft Office Document" but
"OLE 2 Compound Document". This patch takes this into account.
