### PR TITLE
fix of bug 675.

### DIFF
--- a/src/detect-engine-hcbd.c
+++ b/src/detect-engine-hcbd.c
@@ -214,6 +214,7 @@ static void DetectEngineBufferHttpClientBodies(DetectEngineCtx *de_ctx,
                 det_ctx->hcbd[i].buffer_size += cur->len * 2;
 
                 if ((det_ctx->hcbd[i].buffer = SCRealloc(det_ctx->hcbd[i].buffer, det_ctx->hcbd[i].buffer_size)) == NULL) {
+                    det_ctx->hcbd[i].buffer_len = 0;
                     goto end;
                 }
             }

--- a/src/detect-engine-hsbd.c
+++ b/src/detect-engine-hsbd.c
@@ -210,6 +210,7 @@ static void DetectEngineBufferHttpServerBodies(DetectEngineCtx *de_ctx,
                 det_ctx->hsbd[i].buffer_size += cur->len * 2;
 
                 if ((det_ctx->hsbd[i].buffer = SCRealloc(det_ctx->hsbd[i].buffer, det_ctx->hsbd[i].buffer_size)) == NULL) {
+                    det_ctx->hsbd[i].buffer_len = 0;
                     goto end;
                 }
             }


### PR DESCRIPTION
Reset len in hsbd and hcbd buffering back to 0, if realloc fails.
