### PR TITLE
Try to use pkg-config to resolve libnss and related dependencies.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1221,6 +1221,14 @@ AC_INIT(configure.ac)
 
   # libnss
     enable_nss="no"
+
+    # Try pkg-config first:
+    PKG_CHECK_MODULES([libnss], nss,, [with_pkgconfig_nss=no])
+    if test "$with_pkgconfig_nss" != "no"; then
+        CPPFLAGS="${CPPFLAGS} ${libnss_CFLAGS}"
+        LIBS="${LIBS} ${libnss_LIBS}"
+    fi
+
     AC_ARG_WITH(libnss_includes,
             [  --with-libnss-includes=DIR  libnss include directory],
             [with_libnss_includes="$withval"],[with_libnss_includes=no])


### PR DESCRIPTION
Hi Victor,

Here's the tiny tweak for using pkg-config to locate libnss et al. at configure time, as we briefly discussed over email. If anything's amiss, shout!

Cheers,
-C.
