### PR TITLE
fix for #694.

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -1250,6 +1250,13 @@ int DetectAddressTestConfVars(void)
             goto error;
         }
 
+        if (seq_node->val == NULL) {
+            SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
+                       "Address var \"%s\" probably has a sequence value set "
+                       "without any quotes.", seq_node->name);
+            exit(EXIT_FAILURE);
+        }
+
         int r = DetectAddressParse2(gh, ghn, seq_node->val, /* start with negate no */0);
         if (r < 0) {
             SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,

--- a/src/detect-engine-port.c
+++ b/src/detect-engine-port.c
@@ -1308,6 +1308,13 @@ int DetectPortTestConfVars(void)
         }
         DetectPort *ghn = NULL;
 
+        if (seq_node->val == NULL) {
+            SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
+                       "Port var \"%s\" probably has a sequence value set "
+                       "without any quotes.", seq_node->name);
+            exit(EXIT_FAILURE);
+        }
+
         int r = DetectPortParseDo(&gh, &ghn, seq_node->val, /* start with negate no */0);
         if (r < 0) {
             goto error;


### PR DESCRIPTION
Invalidate any address/port vars in the conf that uses a sequence
without quotes.
