### PR TITLE
Fix latest build-info modification

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1531,9 +1531,9 @@ Generic build parameters:
 
 echo
 echo "$SURICATA_BUILD_CONF"
-echo "printf(" >${ac_srcdir}/src/build-info.h
-echo "$SURICATA_BUILD_CONF" | sed -e 's/^/"/' | sed -e 's/$/\\n"/' >>${ac_srcdir}/src/build-info.h
-echo ");" >>${ac_srcdir}/src/build-info.h
+echo "printf(" >${ac_builddir}/src/build-info.h
+echo "$SURICATA_BUILD_CONF" | sed -e 's/^/"/' | sed -e 's/$/\\n"/' >>${ac_builddir}/src/build-info.h
+echo ");" >>${ac_builddir}/src/build-info.h
 
 echo "
 To build and install run 'make' and 'make install'.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -393,3 +393,6 @@ if BUILD_UNITTESTS
 check-am:
 	$(top_builddir)/src/suricata -u
 endif
+
+distclean-local:
+	-rm -rf $(top_builddir)/src/build-info.h


### PR DESCRIPTION
The creation of build-info.h should have been made in build
directory and not in source directory. This should fix changes
introduced in #738.
