### PR TITLE
Fix for bug688

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1021,11 +1021,10 @@ AC_INIT(configure.ac)
             exit 1
         fi
 
-
-
         AC_CHECK_LIB([htp], [htp_config_register_request_uri_normalize],AC_DEFINE_UNQUOTED([HAVE_HTP_URI_NORMALIZE_HOOK],[1],[Found htp_config_register_request_uri_normalize function in libhtp]) ,,[-lhtp])
         # check for htp_tx_get_response_headers_raw
         AC_CHECK_LIB([htp], [htp_tx_get_response_headers_raw],AC_DEFINE_UNQUOTED([HAVE_HTP_TX_GET_RESPONSE_HEADERS_RAW],[1],[Found htp_tx_get_response_headers_raw in libhtp]) ,,[-lhtp])
+        AC_EGREP_HEADER(htp_config_set_path_decode_u_encoding, htp/htp.h, AC_DEFINE_UNQUOTED([HAVE_HTP_SET_PATH_DECODE_U_ENCODING],[1],[Found usable htp_config_set_path_decode_u_encoding function in libhtp]) )
 
     ])
 

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -72,6 +72,10 @@
 
 #include "util-memcmp.h"
 
+#ifndef HAVE_HTP_SET_PATH_DECODE_U_ENCODING
+void htp_config_set_path_decode_u_encoding(htp_cfg_t *cfg, int decode_u_encoding);
+#endif
+
 //#define PRINT
 
 /** Fast lookup tree (radix) for the various HTP configurations */


### PR DESCRIPTION
Hello,

Here's a little patchset aiming at fixing #688. First patch add a check on libhtp 0.3.0 which is not supported and second patch adds a workaround on the include missing function. 
