### PR TITLE
Fix build with old pcap library.

### DIFF
--- a/src/source-pcap.h
+++ b/src/source-pcap.h
@@ -32,6 +32,7 @@ int PcapLiveRegisterDevice(char *);
 int PcapLiveGetDeviceCount(void);
 char *PcapLiveGetDevice(int);
 
+#define LIBPCAP_SNAPLEN     1518
 #define LIBPCAP_COPYWAIT    500
 #define LIBPCAP_PROMISC     1
 


### PR DESCRIPTION
Pcap snaplen related modification broke compilation of Suricata for
system having old pcap library. This patch fixes the issue and allow
old pcap library to honour the snaplen value.
