### PR TITLE
af-packet: leave reading loop at each turn

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -838,6 +838,8 @@ int AFPReadFromRing(AFPThreadVars *ptv)
 next_frame:
         if (++ptv->frame_offset >= ptv->req.tp_frame_nr) {
             ptv->frame_offset = 0;
+            /* Get out of loop to be sure we will reach maintenance tasks */
+            SCReturnInt(AFP_READ_OK);
         }
     }
 


### PR DESCRIPTION
The idea of this patch is to be sure to leave the ring reading loop
enough to be able to sync counters. This should fix #706.
