### PR TITLE
suricatasc: fix make distcheck.

### DIFF
--- a/scripts/suricatasc/Makefile.am
+++ b/scripts/suricatasc/Makefile.am
@@ -2,6 +2,7 @@ EXTRA_DIST = setup.py suricatasc.in src/__init__.py src/suricatasc.py
 
 if HAVE_PYTHON
 all-local:
+	mkdir -p $(top_builddir)/scripts/suricatasc/src
 	$(PYTHON) $(srcdir)/setup.py build;
 
 install-exec-local:
@@ -14,5 +15,8 @@ clean-local:
 uninstall-local:
 	[ ! -f "$(DESTDIR)$(prefix)/bin/suricatasc" ] || rm -f "$(DESTDIR)$(prefix)/bin/suricatasc"
 	find "$(DESTDIR)$(prefix)/lib" -name "suricatasc-*.egg-info" -delete ||true
+
+distclean-local:
+	-rm -rf $(top_builddir)/scripts/suricatasc/src
 
 endif


### PR DESCRIPTION
Fix make distcheck by creating and destroying the src directory.
