### PR TITLE
Replace the deprecated AM_CONFIG_HEADER with AC_CONFIG_HEADERS.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 
 AC_INIT(configure.ac)
 
-    AM_CONFIG_HEADER(config.h)
+    AC_CONFIG_HEADERS([config.h])
     AM_INIT_AUTOMAKE(suricata, 1.4dev)
 
     AC_LANG_C

--- a/libhtp/configure.ac
+++ b/libhtp/configure.ac
@@ -4,7 +4,7 @@ dnl Initialization macros
 dnl ----------------------
 
 AC_INIT(htp/htp.h)
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS([config.h])
 
 
 dnl -----------------------------------------------


### PR DESCRIPTION
Addresses bug #704 for building on a Mac.  More generically
it addresses the issue building using newers versions of automake.

Tested on OS X 10.8.2 with autotools installed from MacPorts:
automake 1.13.1
autoconf 2.69
glibtoolize 2.4.2

Tested on CentOS 6:
automake 1.11.1
autoconf 2.63
libtoolize 2.2.6b
