### PR TITLE
fix for #760.

### DIFF
--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -514,7 +514,7 @@ int DetectUDPV4CsumMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
 {
     DetectCsumData *cd = (DetectCsumData *)m->ctx;
 
-    if (p->ip4h == NULL || p->udph == NULL || p->proto != IPPROTO_UDP || PKT_IS_PSEUDOPKT(p))
+    if (p->ip4h == NULL || p->udph == NULL || p->proto != IPPROTO_UDP || PKT_IS_PSEUDOPKT(p) || p->udph->uh_sum == 0)
         return 0;
 
     if (p->flags & PKT_IGNORE_CHECKSUM) {


### PR DESCRIPTION
If udpv4 csum isn't calculated, udpv4-csum detection shouldn't run on the
csum.
