### PR TITLE
nfq: implement 'fail-accept' option

### DIFF
--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -154,7 +154,8 @@ typedef enum NFQMode_ {
     NFQ_ROUTE_MODE,
 } NFQMode;
 
-#define NFQ_FLAG_FAIL_OPEN  (1 << 0)
+#define NFQ_FLAG_FAIL_OPEN      (1 << 0)
+#define NFQ_FLAG_FAIL_ACCEPT    (1 << 1)
 
 typedef struct NFQCnf_ {
     NFQMode mode;
@@ -239,6 +240,12 @@ void NFQInitConfig(char quiet)
         SCLogError(SC_ERR_NFQ_NOSUPPORT,
                    "nfq.fail-open set but NFQ library has no support for it.");
 #endif
+    }
+
+    (void)ConfGetBool("nfq.fail-accept", (int *)&boolval);
+    if (boolval) {
+        SCLogInfo("Enabling fail-accept on queue");
+        nfq_config.flags |= NFQ_FLAG_FAIL_ACCEPT;
     }
 
     if ((ConfGetInt("nfq.repeat-mark", &value)) == 1) {
@@ -402,6 +409,13 @@ static int NFQCallBack(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg,
     if (ntv->slot) {
         if (TmThreadsSlotProcessPkt(tv, ntv->slot, p) != TM_ECODE_OK) {
             TmqhOutputPacketpool(ntv->tv, p);
+            /* Force verdict of packet */
+            if (nfq_config.flags & NFQ_FLAG_FAIL_ACCEPT) {
+                p->action &= ~ACTION_DROP;
+            } else {
+                p->action |= ACTION_DROP;
+            }
+            NFQSetVerdict(p);
             return -1;
         }
     } else {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -221,13 +221,16 @@ magic-file: @e_magic_file@
 # If you want packet to be sent to another queue after an ACCEPT decision
 # set mode to 'route' and set next-queue value.
 # On linux >= 3.6, you can set the fail-open option to yes to have the kernel
-# accept the packet if suricata is not able to keep pace.
+# accept the packet if suricata is not able to keep pace.
+# If fail-accept is set to yes, packet will be accepted in case of an internal
+# error in suricata
 nfq:
 #  mode: accept
 #  repeat-mark: 1
 #  repeat-mask: 1
 #  route-queue: 2
 #  fail-open: yes
+#  fail-accept: yes
 
 # af-packet support
 # Set threads to > 1 to use PACKET_FANOUT support


### PR DESCRIPTION
If there is an error inside Suricata, then the packet is accepted
inconditionnaly.

This patch does not treat the case for the 'auto' running mode. I don't think this is used somewhere now.
