### PR TITLE
Optimization 563.

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -113,7 +113,7 @@ SCEnumCharMap smtp_decoder_event_table[ ] = {
     { NULL,                      -1 },
 };
 
-#define SMTP_MPM MPM_AC
+#define SMTP_MPM MPM_B2G
 
 static MpmCtx *smtp_mpm_ctx = NULL;
 MpmThreadCtx *smtp_mpm_thread_ctx;

--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -1248,7 +1248,8 @@ uint32_t SCACSearch(MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx,
                             ;
                         } else {
                             pmq->pattern_id_bitarray[(pids[k] & 0x0000FFFF) / 8] |= (1 << ((pids[k] & 0x0000FFFF) % 8));
-                            pmq->pattern_id_array[pmq->pattern_id_array_cnt++] = pids[k] & 0x0000FFFF;
+                            pmq->pattern_id_array_cnt++;
+                            //pmq->pattern_id_array[pmq->pattern_id_array_cnt++] = pids[k] & 0x0000FFFF;
                         }
                         matches++;
                     } else {
@@ -1256,7 +1257,8 @@ uint32_t SCACSearch(MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx,
                             ;
                         } else {
                             pmq->pattern_id_bitarray[pids[k] / 8] |= (1 << (pids[k] % 8));
-                            pmq->pattern_id_array[pmq->pattern_id_array_cnt++] = pids[k];
+                            pmq->pattern_id_array_cnt++;
+                            //pmq->pattern_id_array[pmq->pattern_id_array_cnt++] = pids[k];
                         }
                         matches++;
                     }
@@ -1289,7 +1291,8 @@ uint32_t SCACSearch(MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx,
                             ;
                         } else {
                             pmq->pattern_id_bitarray[(pids[k] & 0x0000FFFF) / 8] |= (1 << ((pids[k] & 0x0000FFFF) % 8));
-                            pmq->pattern_id_array[pmq->pattern_id_array_cnt++] = pids[k] & 0x0000FFFF;
+                            pmq->pattern_id_array_cnt++;
+                            //pmq->pattern_id_array[pmq->pattern_id_array_cnt++] = pids[k] & 0x0000FFFF;
                         }
                         matches++;
                     } else {
@@ -1297,7 +1300,8 @@ uint32_t SCACSearch(MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx,
                             ;
                         } else {
                             pmq->pattern_id_bitarray[pids[k] / 8] |= (1 << (pids[k] % 8));
-                            pmq->pattern_id_array[pmq->pattern_id_array_cnt++] = pids[k];
+                            pmq->pattern_id_array_cnt++;
+                            //pmq->pattern_id_array[pmq->pattern_id_array_cnt++] = pids[k];
                         }
                         matches++;
                     }


### PR DESCRIPTION
SMTP parser now uses b2g instead ac.
ac doesn't use pattern_id_array anymore.
