### PR TITLE
Update comment in yaml to indicate size limit for the following vars -

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -589,9 +589,11 @@ flow-timeouts:
 #     toserver-chunk-size: 2560 # inspect raw stream in chunks of at least
 #                               # this size.  Can be specified in kb, mb,
 #                               # gb.  Just a number indicates it's in bytes.
+#                               # The max acceptable size is 4024 bytes.
 #     toclient-chunk-size: 2560 # inspect raw stream in chunks of at least
 #                               # this size.  Can be specified in kb, mb,
 #                               # gb.  Just a number indicates it's in bytes.
+#                               # The max acceptable size is 4024 bytes.
 
 stream:
   memcap: 32mb


### PR DESCRIPTION
stream.reassembly.toserver-chunk-size and stream.reassembly.toclient-chunk-size
