### PR TITLE
fix of #784.

### DIFF
--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -354,7 +354,8 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
             r = DetectPcrePayloadMatch(det_ctx, s, sm, p, f,
                                        buffer, buffer_len);
             if (r == 0) {
-                det_ctx->discontinue_matching = 1;
+                if (!(pe->flags & DETECT_PCRE_RELATIVE) || !(pe->flags & DETECT_PCRE_MATCH_FROM_START_OF_LINE))
+                    det_ctx->discontinue_matching = 1;
                 SCReturnInt(0);
             }
 

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -470,6 +470,9 @@ DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx, char *regexstr)
         }
     }
 
+    if (re[0] == '^')
+        pd->flags |= DETECT_PCRE_MATCH_FROM_START_OF_LINE;
+
     //printf("DetectPcreParse: \"%s\"\n", re);
 
     /* Try to compile as if all (...) groups had been meant as (?:...),

--- a/src/detect-pcre.h
+++ b/src/detect-pcre.h
@@ -52,6 +52,8 @@
 #define DETECT_PCRE_NEGATE              0x80000
 #define DETECT_PCRE_CASELESS           0x100000
 
+#define DETECT_PCRE_MATCH_FROM_START_OF_LINE 0x200000
+
 typedef struct DetectPcreData_ {
     /* pcre options */
     pcre *re;


### PR DESCRIPTION
Handle the case of pcre combined with a relative content, where pcre has the
^ set to match from start of line and we discontinue matching on not finding a
match.
