### PR TITLE
Update the way we handle http_host keywords.

### DIFF
--- a/src/detect-engine-hhhd.c
+++ b/src/detect-engine-hhhd.c
@@ -192,7 +192,7 @@ static int DetectEngineHttpHHTest01(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http host header test\"; "
-                               "content:\"CONNECT\"; http_host; nocase; "
+                               "content:\"connect\"; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -283,7 +283,7 @@ static int DetectEngineHttpHHTest02(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http host header test\"; "
-                               "content:\"CO\"; depth:4; http_host; nocase; "
+                               "content:\"co\"; depth:4; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -374,7 +374,7 @@ static int DetectEngineHttpHHTest03(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:!\"ECT\"; depth:4; http_host; nocase; "
+                               "content:!\"ect\"; depth:4; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -465,7 +465,7 @@ static int DetectEngineHttpHHTest04(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http host header test\"; "
-                               "content:\"ECT\"; depth:4; http_host; nocase; "
+                               "content:\"ect\"; depth:4; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -556,7 +556,7 @@ static int DetectEngineHttpHHTest05(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http host header test\"; "
-                               "content:!\"CON\"; depth:4; http_host; nocase; "
+                               "content:!\"con\"; depth:4; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -647,7 +647,7 @@ static int DetectEngineHttpHHTest06(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http host header test\"; "
-                               "content:\"ECT\"; offset:3; http_host; nocase; "
+                               "content:\"ect\"; offset:3; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -738,7 +738,7 @@ static int DetectEngineHttpHHTest07(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http host header test\"; "
-                               "content:!\"CO\"; offset:3; http_host; nocase; "
+                               "content:!\"co\"; offset:3; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -829,7 +829,7 @@ static int DetectEngineHttpHHTest08(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http host header test\"; "
-                               "content:!\"ECT\"; offset:3; http_host; nocase; "
+                               "content:!\"ect\"; offset:3; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -920,7 +920,7 @@ static int DetectEngineHttpHHTest09(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http host header test\"; "
-                               "content:\"CON\"; offset:3; http_host; nocase; "
+                               "content:\"con\"; offset:3; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -1011,8 +1011,8 @@ static int DetectEngineHttpHHTest10(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:\"CO\"; http_host; nocase; "
-                               "content:\"EC\"; within:4; http_host; nocase; "
+                               "content:\"co\"; http_host;  "
+                               "content:\"ec\"; within:4; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -1103,8 +1103,8 @@ static int DetectEngineHttpHHTest11(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:\"CO\"; http_host; nocase; "
-                               "content:!\"EC\"; within:3; http_host; nocase; "
+                               "content:\"co\"; http_host;  "
+                               "content:!\"ec\"; within:3; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -1195,8 +1195,8 @@ static int DetectEngineHttpHHTest12(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:\"CO\"; http_host; nocase; "
-                               "content:\"EC\"; within:3; http_host; nocase; "
+                               "content:\"co\"; http_host;  "
+                               "content:\"ec\"; within:3; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -1287,8 +1287,8 @@ static int DetectEngineHttpHHTest13(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:\"CO\"; http_host; nocase; "
-                               "content:!\"EC\"; within:4; http_host; nocase; "
+                               "content:\"co\"; http_host;  "
+                               "content:!\"ec\"; within:4; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -1379,8 +1379,8 @@ static int DetectEngineHttpHHTest14(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:\"CO\"; http_host; nocase; "
-                               "content:\"EC\"; distance:2; http_host; nocase; "
+                               "content:\"co\"; http_host;  "
+                               "content:\"ec\"; distance:2; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -1471,8 +1471,8 @@ static int DetectEngineHttpHHTest15(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:\"CO\"; http_host; nocase; "
-                               "content:!\"EC\"; distance:3; http_host; nocase; "
+                               "content:\"co\"; http_host;  "
+                               "content:!\"ec\"; distance:3; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -1563,8 +1563,8 @@ static int DetectEngineHttpHHTest16(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:\"CO\"; http_host; nocase; "
-                               "content:\"EC\"; distance:3; http_host; nocase; "
+                               "content:\"co\"; http_host;  "
+                               "content:\"ec\"; distance:3; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -1655,8 +1655,8 @@ static int DetectEngineHttpHHTest17(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:\"CO\"; http_host; nocase; "
-                               "content:!\"EC\"; distance:2; http_host; nocase; "
+                               "content:\"co\"; http_host;  "
+                               "content:!\"ec\"; distance:2; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -1743,7 +1743,7 @@ static int DetectEngineHttpHHTest18(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:\"kaboom\"; http_host; nocase; "
+                               "content:\"kaboom\"; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -1830,7 +1830,7 @@ static int DetectEngineHttpHHTest19(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:\"kaboom\"; http_host; nocase; "
+                               "content:\"kaboom\"; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -1917,7 +1917,7 @@ static int DetectEngineHttpHHTest20(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:\"8080\"; http_host; nocase; "
+                               "content:\"8080\"; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -2003,7 +2003,7 @@ static int DetectEngineHttpHHTest21(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:\"kaboom\"; http_host; nocase; "
+                               "content:\"kaboom\"; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -2089,7 +2089,7 @@ static int DetectEngineHttpHHTest22(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:\"kaboom\"; http_host; nocase; "
+                               "content:\"kaboom\"; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -2175,7 +2175,7 @@ static int DetectEngineHttpHHTest23(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:\"8080\"; http_host; nocase; "
+                               "content:\"8080\"; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -2262,7 +2262,7 @@ static int DetectEngineHttpHHTest24(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:\"kaboom\"; http_host; nocase; "
+                               "content:\"kaboom\"; http_host;  "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -2349,7 +2349,7 @@ static int DetectEngineHttpHHTest25(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http_host header test\"; "
-                               "content:\"rabbit\"; http_host; nocase; "
+                               "content:\"rabbit\"; http_host; "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -16937,15 +16937,14 @@ int DetectFastPatternTest589(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; nocase; "
-                               "content:\"three\"; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; "
+                               "content:\"three\"; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
         ud->flags & DETECT_CONTENT_NEGATED &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY) &&
         ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP &&
         ud->fp_chop_offset == 3 &&
@@ -16975,7 +16974,7 @@ int DetectFastPatternTest590(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_host; nocase; "
+                               "(content:\"one\"; fast_pattern:only; http_host;  "
                                "msg:\"Testing fast_pattern\"; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -16984,9 +16983,7 @@ int DetectFastPatternTest590(void)
     sm = de_ctx->sig_list->sm_lists[DETECT_SM_LIST_HHHDMATCH];
     if (sm != NULL) {
         if ( (((DetectContentData *)sm->ctx)->flags &
-             DETECT_CONTENT_FAST_PATTERN) &&
-             (((DetectContentData *)sm->ctx)->flags &
-              DETECT_CONTENT_NOCASE)) {
+              DETECT_CONTENT_FAST_PATTERN)) {
             result = 1;
         } else {
             result = 0;
@@ -17014,7 +17011,7 @@ int DetectFastPatternTest591(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_host; nocase; "
+                               "(content:\"oneoneone\"; fast_pattern:3,4; http_host; "
                                "msg:\"Testing fast_pattern\"; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -17023,9 +17020,7 @@ int DetectFastPatternTest591(void)
     sm = de_ctx->sig_list->sm_lists[DETECT_SM_LIST_HHHDMATCH];
     if (sm != NULL) {
         if ( (((DetectContentData *)sm->ctx)->flags &
-              DETECT_CONTENT_FAST_PATTERN) &&
-             (((DetectContentData *)sm->ctx)->flags &
-              DETECT_CONTENT_NOCASE)) {
+              DETECT_CONTENT_FAST_PATTERN)) {
             result = 1;
         } else {
             result = 0;
@@ -17049,7 +17044,7 @@ int DetectFastPatternTest592(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; fast_pattern:only; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -17059,7 +17054,6 @@ int DetectFastPatternTest592(void)
     }
     DetectContentData *ud = sm->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
             ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY &&
             !(ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP) &&
             ud->fp_chop_offset == 0 &&
@@ -17086,7 +17080,7 @@ int DetectFastPatternTest593(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_host; nocase; sid:1;)");
+                               "(content:\"oneoneone\"; fast_pattern:3,4; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -17097,7 +17091,6 @@ int DetectFastPatternTest593(void)
 
     DetectContentData *ud = sm->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY) &&
             ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP &&
             ud->fp_chop_offset == 3 &&
@@ -17123,8 +17116,8 @@ int DetectFastPatternTest594(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; fast_pattern:only; http_host; distance:10; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; fast_pattern:only; http_host; distance:10; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17146,8 +17139,8 @@ int DetectFastPatternTest595(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; distance:10; fast_pattern:only; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; distance:10; fast_pattern:only; http_host; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17169,8 +17162,8 @@ int DetectFastPatternTest596(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; fast_pattern:only; http_host; within:10; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; fast_pattern:only; http_host; within:10; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17192,8 +17185,8 @@ int DetectFastPatternTest597(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; within:10; fast_pattern:only; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; within:10; fast_pattern:only; http_host; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17215,8 +17208,8 @@ int DetectFastPatternTest598(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; fast_pattern:only; http_host; offset:10; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; fast_pattern:only; http_host; offset:10; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17238,8 +17231,8 @@ int DetectFastPatternTest599(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; offset:10; fast_pattern:only; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; offset:10; fast_pattern:only; http_host; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17261,8 +17254,8 @@ int DetectFastPatternTest600(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; fast_pattern:only; http_host; depth:10; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; fast_pattern:only; http_host; depth:10; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17284,8 +17277,8 @@ int DetectFastPatternTest601(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; depth:10; fast_pattern:only; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; depth:10; fast_pattern:only; http_host; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17307,8 +17300,8 @@ int DetectFastPatternTest602(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:!\"two\"; fast_pattern:only; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:!\"two\"; fast_pattern:only; http_host; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17330,15 +17323,14 @@ int DetectFastPatternTest603(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\" one\"; http_host; nocase; "
-                               "content:\"two\"; http_host; distance:30; nocase; "
-                               "content:\"two\"; fast_pattern:only; http_host; nocase; sid:1;)");
+                               "(content:\" one\"; http_host; "
+                               "content:\"two\"; http_host; distance:30; "
+                               "content:\"two\"; fast_pattern:only; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
 
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP) &&
         ud->fp_chop_offset == 0 &&
@@ -17364,14 +17356,13 @@ int DetectFastPatternTest604(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; http_host; within:30; nocase; "
-                               "content:\"two\"; fast_pattern:only; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; http_host; within:30; "
+                               "content:\"two\"; fast_pattern:only; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP) &&
         ud->fp_chop_offset == 0 &&
@@ -17397,14 +17388,13 @@ int DetectFastPatternTest605(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; http_host; offset:30; nocase; "
-                               "content:\"two\"; fast_pattern:only; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; http_host; offset:30; "
+                               "content:\"two\"; fast_pattern:only; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP) &&
         ud->fp_chop_offset == 0 &&
@@ -17430,14 +17420,13 @@ int DetectFastPatternTest606(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; http_host; depth:30; nocase; "
-                               "content:\"two\"; fast_pattern:only; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; http_host; depth:30; "
+                               "content:\"two\"; fast_pattern:only; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP) &&
         ud->fp_chop_offset == 0 &&
@@ -17463,13 +17452,12 @@ int DetectFastPatternTest607(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:!\"one\"; fast_pattern; http_host; nocase; "
-                               "content:\"two\"; http_host; nocase; sid:1;)");
+                               "(content:!\"one\"; fast_pattern; http_host; "
+                               "content:\"two\"; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         ud->flags & DETECT_CONTENT_NEGATED &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY) &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP) &&
@@ -17496,8 +17484,8 @@ int DetectFastPatternTest608(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_host; nocase; "
-                               "content:!\"one\"; fast_pattern; http_host; distance:20; nocase; sid:1;)");
+                               "(content:\"two\"; http_host; "
+                               "content:!\"one\"; fast_pattern; http_host; distance:20; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17519,8 +17507,8 @@ int DetectFastPatternTest609(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_host; nocase; "
-                               "content:!\"one\"; fast_pattern; http_host; within:20; nocase; sid:1;)");
+                               "(content:\"two\"; http_host; "
+                               "content:!\"one\"; fast_pattern; http_host; within:20; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17542,8 +17530,8 @@ int DetectFastPatternTest610(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_host; nocase; "
-                               "content:!\"one\"; fast_pattern; http_host; offset:20; nocase; sid:1;)");
+                               "(content:\"two\"; http_host; "
+                               "content:!\"one\"; fast_pattern; http_host; offset:20; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17565,8 +17553,8 @@ int DetectFastPatternTest611(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_host; nocase; "
-                               "content:!\"one\"; fast_pattern; http_host; depth:20; nocase; sid:1;)");
+                               "(content:\"two\"; http_host; "
+                               "content:!\"one\"; fast_pattern; http_host; depth:20; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17588,14 +17576,13 @@ int DetectFastPatternTest612(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_host; nocase; "
-                               "content:\"three\"; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"oneonetwo\"; fast_pattern:3,4; http_host; "
+                               "content:\"three\"; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY) &&
         ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP &&
         ud->fp_chop_offset == 3 &&
@@ -17621,14 +17608,13 @@ int DetectFastPatternTest613(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_host; nocase; "
-                               "content:\"three\"; http_host; distance:30; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"oneonetwo\"; fast_pattern:3,4; http_host; "
+                               "content:\"three\"; http_host; distance:30; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY) &&
         ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP &&
         ud->fp_chop_offset == 3 &&
@@ -17654,14 +17640,13 @@ int DetectFastPatternTest614(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_host; nocase; "
-                               "content:\"three\"; http_host; within:30; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"oneonetwo\"; fast_pattern:3,4; http_host; "
+                               "content:\"three\"; http_host; within:30; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY) &&
         ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP &&
         ud->fp_chop_offset == 3 &&
@@ -17687,14 +17672,13 @@ int DetectFastPatternTest615(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_host; nocase; "
-                               "content:\"three\"; http_host; offset:30; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"oneonetwo\"; fast_pattern:3,4; http_host; "
+                               "content:\"three\"; http_host; offset:30; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY) &&
         ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP &&
         ud->fp_chop_offset == 3 &&
@@ -17720,14 +17704,13 @@ int DetectFastPatternTest616(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_host; nocase; "
-                               "content:\"three\"; http_host; depth:30; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"oneonetwo\"; fast_pattern:3,4; http_host; "
+                               "content:\"three\"; http_host; depth:30; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY) &&
         ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP &&
         ud->fp_chop_offset == 3 &&
@@ -17753,14 +17736,13 @@ int DetectFastPatternTest617(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; http_host; distance:10; nocase; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; http_host; distance:10; "
+                               "content:\"oneonethree\"; fast_pattern:3,4; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY) &&
         ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP &&
         ud->fp_chop_offset == 3 &&
@@ -17786,14 +17768,13 @@ int DetectFastPatternTest618(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; http_host; within:10; nocase; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; http_host; within:10; "
+                               "content:\"oneonethree\"; fast_pattern:3,4; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY) &&
         ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP &&
         ud->fp_chop_offset == 3 &&
@@ -17819,14 +17800,13 @@ int DetectFastPatternTest619(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; http_host; offset:10; nocase; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; http_host; offset:10; "
+                               "content:\"oneonethree\"; fast_pattern:3,4; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY) &&
         ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP &&
         ud->fp_chop_offset == 3 &&
@@ -17852,14 +17832,13 @@ int DetectFastPatternTest620(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; http_host; depth:10; nocase; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; http_host; depth:10; "
+                               "content:\"oneonethree\"; fast_pattern:3,4; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY) &&
         ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP &&
         ud->fp_chop_offset == 3 &&
@@ -17888,9 +17867,9 @@ int DetectFastPatternTest621(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; fast_pattern:65977,4; http_host; nocase; "
-                               "content:\"three\"; http_host; distance:10; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; fast_pattern:65977,4; http_host; "
+                               "content:\"three\"; http_host; distance:10; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17912,9 +17891,9 @@ int DetectFastPatternTest622(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\";  http_host; nocase; "
-                               "content:\"oneonetwo\"; fast_pattern:3,65977; http_host; nocase; "
-                               "content:\"three\"; distance:10; http_host; nocase; sid:1;)");
+                               "(content:\"one\";  http_host; "
+                               "content:\"oneonetwo\"; fast_pattern:3,65977; http_host; "
+                               "content:\"three\"; distance:10; http_host; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17936,9 +17915,9 @@ int DetectFastPatternTest623(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; fast_pattern:65534,4; http_host; nocase; "
-                               "content:\"three\"; http_host; distance:10; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; fast_pattern:65534,4; http_host; "
+                               "content:\"three\"; http_host; distance:10; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17960,14 +17939,13 @@ int DetectFastPatternTest624(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; nocase; "
-                               "content:\"three\"; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; "
+                               "content:\"three\"; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         ud->flags & DETECT_CONTENT_NEGATED &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY) &&
         ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP &&
@@ -17994,9 +17972,9 @@ int DetectFastPatternTest625(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; distance:10; nocase; "
-                               "content:\"three\"; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; distance:10; "
+                               "content:\"three\"; http_host; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18018,9 +17996,9 @@ int DetectFastPatternTest626(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; within:10; nocase; "
-                               "content:\"three\"; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; within:10; "
+                               "content:\"three\"; http_host; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18042,9 +18020,9 @@ int DetectFastPatternTest627(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; offset:10; nocase; "
-                               "content:\"three\"; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; offset:10; "
+                               "content:\"three\"; http_host; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18066,9 +18044,9 @@ int DetectFastPatternTest628(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; depth:10; nocase; "
-                               "content:\"three\"; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; depth:10; "
+                               "content:\"three\"; http_host; sid:1;)");
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18090,14 +18068,13 @@ int DetectFastPatternTest629(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; nocase; "
-                               "content:\"three\"; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; "
+                               "content:\"three\"; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
     if (ud->flags & DETECT_CONTENT_FAST_PATTERN &&
-        ud->flags & DETECT_CONTENT_NOCASE &&
         ud->flags & DETECT_CONTENT_NEGATED &&
         !(ud->flags & DETECT_CONTENT_FAST_PATTERN_ONLY) &&
         ud->flags & DETECT_CONTENT_FAST_PATTERN_CHOP &&

--- a/src/detect-http-hh.c
+++ b/src/detect-http-hh.c
@@ -144,7 +144,7 @@ static int DetectHttpHHTest01(void)
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
                                "(msg:\"Testing http_host\"; "
-                               "content:\"one\"; http_host; nocase; sid:1;)");
+                               "content:\"one\"; http_host; sid:1;)");
     if (de_ctx->sig_list != NULL) {
         result = 1;
     } else {
@@ -175,7 +175,7 @@ static int DetectHttpHHTest02(void)
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
                                "(msg:\"Testing http_host\"; "
-                               "content:\"one\"; http_host; nocase; sid:1;)");
+                               "content:\"one\"; http_host; sid:1;)");
     if (de_ctx->sig_list != NULL)
         result = 1;
 
@@ -258,7 +258,7 @@ static int DetectHttpHHTest05(void)
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
                                "(msg:\"Testing http_host\"; "
-                               "content:\"one\"; http_host; nocase; sid:1;)");
+                               "content:\"one\"; http_host; sid:1;)");
     if (de_ctx->sig_list != NULL)
         result = 1;
 
@@ -318,7 +318,7 @@ static int DetectHttpHHTest06(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http host test\"; "
-                               "content:\"message\"; http_host; nocase; "
+                               "content:\"message\"; http_host; "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -418,7 +418,7 @@ static int DetectHttpHHTest07(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http host test\"; "
-                               "content:\"message\"; http_host; nocase; "
+                               "content:\"message\"; http_host; "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -532,7 +532,7 @@ static int DetectHttpHHTest08(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http host test\"; "
-                               "content:\"message\"; http_host; nocase; "
+                               "content:\"message\"; http_host; "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -653,7 +653,7 @@ static int DetectHttpHHTest09(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http host test\"; "
-                               "content:\"body1This\"; http_host; nocase; "
+                               "content:\"body1this\"; http_host; "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -773,7 +773,7 @@ static int DetectHttpHHTest10(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http host test\"; "
-                               "content:\"body1this\"; http_host; nocase;"
+                               "content:\"body1this\"; http_host; "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -882,7 +882,7 @@ static int DetectHttpHHTest11(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http host test\"; "
-                               "content:!\"message\"; http_host; nocase; "
+                               "content:!\"message\"; http_host; "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -974,7 +974,7 @@ static int DetectHttpHHTest12(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http host test\"; "
-                               "content:!\"message\"; http_host; nocase; "
+                               "content:!\"message\"; http_host; "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -1068,7 +1068,7 @@ static int DetectHttpHHTest13(void)
 
     de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
                                "(msg:\"http host test\"; "
-                               "content:\"abcdefghijklmnopqrstuvwxyz0123456789\"; http_host; nocase; "
+                               "content:\"abcdefghijklmnopqrstuvwxyz0123456789\"; http_host; "
                                "sid:1;)");
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -1164,12 +1164,12 @@ static int DetectHttpHHTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"dummy1\"; http_cookie; content:\"Body one\"; http_host; nocase; sid:1; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"dummy1\"; http_cookie; content:\"body one\"; http_host; sid:1; rev:1;)");
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"dummy2\"; http_cookie; content:\"Body two\"; http_host; nocase; sid:2; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"dummy2\"; http_cookie; content:\"body two\"; http_host; sid:2; rev:1;)");
     if (s == NULL) {
         printf("sig2 parse failed: ");
         goto end;
@@ -1312,8 +1312,8 @@ int DetectHttpHHTest22(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; http_host; nocase; "
-                               "content:\"three\"; distance:10; http_host; nocase; content:\"four\"; sid:1;)");
+                               "(content:\"one\"; content:\"two\"; http_host; "
+                               "content:\"three\"; distance:10; http_host; content:\"four\"; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1335,9 +1335,9 @@ int DetectHttpHHTest22(void)
     DetectContentData *hhhd2 = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
     if (cd1->flags != 0 || memcmp(cd1->content, "one", cd1->content_len) != 0 ||
         cd2->flags != 0 || memcmp(cd2->content, "four", cd2->content_len) != 0 ||
-        hhhd1->flags != (DETECT_CONTENT_RELATIVE_NEXT | DETECT_CONTENT_NOCASE) ||
+        hhhd1->flags != (DETECT_CONTENT_RELATIVE_NEXT) ||
         memcmp(hhhd1->content, "two", hhhd1->content_len) != 0 ||
-        hhhd2->flags != (DETECT_CONTENT_DISTANCE | DETECT_CONTENT_NOCASE) ||
+        hhhd2->flags != (DETECT_CONTENT_DISTANCE) ||
         memcmp(hhhd2->content, "three", hhhd1->content_len) != 0) {
         goto end;
     }
@@ -1367,8 +1367,8 @@ int DetectHttpHHTest23(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_host; nocase; content:\"four\"; sid:1;)");
+                               "(content:\"one\"; http_host; pcre:/two/; "
+                               "content:\"three\"; distance:10; http_host; content:\"four\"; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1390,9 +1390,9 @@ int DetectHttpHHTest23(void)
     DetectContentData *hhhd2 = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
     if (pd1->flags != 0 ||
         cd2->flags != 0 || memcmp(cd2->content, "four", cd2->content_len) != 0 ||
-        hhhd1->flags != (DETECT_CONTENT_RELATIVE_NEXT | DETECT_CONTENT_NOCASE) ||
+        hhhd1->flags != (DETECT_CONTENT_RELATIVE_NEXT) ||
         memcmp(hhhd1->content, "one", hhhd1->content_len) != 0 ||
-        hhhd2->flags != (DETECT_CONTENT_DISTANCE | DETECT_CONTENT_NOCASE) ||
+        hhhd2->flags != (DETECT_CONTENT_DISTANCE) ||
         memcmp(hhhd2->content, "three", hhhd1->content_len) != 0) {
         goto end;
     }
@@ -1421,8 +1421,8 @@ int DetectHttpHHTest24(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; pcre:/two/; "
-                               "content:\"three\"; distance:10; within:15; http_host; nocase; content:\"four\"; sid:1;)");
+                               "(content:\"one\"; http_host; pcre:/two/; "
+                               "content:\"three\"; distance:10; within:15; http_host; content:\"four\"; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1444,9 +1444,9 @@ int DetectHttpHHTest24(void)
     DetectContentData *hhhd2 = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
     if (pd1->flags != 0 ||
         cd2->flags != 0 || memcmp(cd2->content, "four", cd2->content_len) != 0 ||
-        hhhd1->flags != (DETECT_CONTENT_RELATIVE_NEXT | DETECT_CONTENT_NOCASE) ||
+        hhhd1->flags != (DETECT_CONTENT_RELATIVE_NEXT) ||
         memcmp(hhhd1->content, "one", hhhd1->content_len) != 0 ||
-        hhhd2->flags != (DETECT_CONTENT_DISTANCE | DETECT_CONTENT_WITHIN | DETECT_CONTENT_NOCASE) ||
+        hhhd2->flags != (DETECT_CONTENT_DISTANCE | DETECT_CONTENT_WITHIN) ||
         memcmp(hhhd2->content, "three", hhhd1->content_len) != 0) {
         goto end;
     }
@@ -1475,8 +1475,8 @@ int DetectHttpHHTest25(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_host; nocase; "
+                               "(content:\"one\"; http_host; pcre:/two/; "
+                               "content:\"three\"; distance:10; http_host; "
                                "content:\"four\"; distance:10; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
@@ -1500,9 +1500,9 @@ int DetectHttpHHTest25(void)
     if (pd1->flags != DETECT_PCRE_RELATIVE_NEXT ||
         cd2->flags != DETECT_CONTENT_DISTANCE ||
         memcmp(cd2->content, "four", cd2->content_len) != 0 ||
-        hhhd1->flags != (DETECT_CONTENT_RELATIVE_NEXT | DETECT_CONTENT_NOCASE) ||
+        hhhd1->flags != (DETECT_CONTENT_RELATIVE_NEXT) ||
         memcmp(hhhd1->content, "one", hhhd1->content_len) != 0 ||
-        hhhd2->flags != (DETECT_CONTENT_DISTANCE | DETECT_CONTENT_NOCASE) ||
+        hhhd2->flags != (DETECT_CONTENT_DISTANCE) ||
         memcmp(hhhd2->content, "three", hhhd1->content_len) != 0) {
         goto end;
     }
@@ -1531,8 +1531,8 @@ int DetectHttpHHTest26(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; offset:10; http_host; nocase; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_host; nocase; within:10; "
+                               "(content:\"one\"; offset:10; http_host; pcre:/two/; "
+                               "content:\"three\"; distance:10; http_host; within:10; "
                                "content:\"four\"; distance:10; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
@@ -1556,9 +1556,9 @@ int DetectHttpHHTest26(void)
     if (pd1->flags != (DETECT_PCRE_RELATIVE_NEXT) ||
         cd2->flags != DETECT_CONTENT_DISTANCE ||
         memcmp(cd2->content, "four", cd2->content_len) != 0 ||
-        hhhd1->flags != (DETECT_CONTENT_RELATIVE_NEXT | DETECT_CONTENT_OFFSET | DETECT_CONTENT_NOCASE) ||
+        hhhd1->flags != (DETECT_CONTENT_RELATIVE_NEXT | DETECT_CONTENT_OFFSET) ||
         memcmp(hhhd1->content, "one", hhhd1->content_len) != 0 ||
-        hhhd2->flags != (DETECT_CONTENT_DISTANCE | DETECT_CONTENT_WITHIN | DETECT_CONTENT_NOCASE) ||
+        hhhd2->flags != (DETECT_CONTENT_DISTANCE | DETECT_CONTENT_WITHIN) ||
         memcmp(hhhd2->content, "three", hhhd1->content_len) != 0) {
         printf ("failed: http_host incorrect flags");
         goto end;
@@ -1588,8 +1588,8 @@ int DetectHttpHHTest27(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; offset:10; http_host; nocase; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_host; nocase; within:10; "
+                               "(content:\"one\"; offset:10; http_host; pcre:/two/; "
+                               "content:\"three\"; distance:10; http_host; within:10; "
                                "content:\"four\"; distance:10; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
@@ -1614,8 +1614,8 @@ int DetectHttpHHTest28(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; pcre:/two/; "
-                               "content:\"three\"; http_host; nocase; depth:10; "
+                               "(content:\"one\"; http_host; pcre:/two/; "
+                               "content:\"three\"; http_host; depth:10; "
                                "content:\"four\"; distance:10; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
@@ -1639,9 +1639,9 @@ int DetectHttpHHTest28(void)
     if (pd1->flags != (DETECT_PCRE_RELATIVE_NEXT) ||
         cd2->flags != DETECT_CONTENT_DISTANCE ||
         memcmp(cd2->content, "four", cd2->content_len) != 0 ||
-        hhhd1->flags != (DETECT_CONTENT_NOCASE) ||
+        hhhd1->flags != (0) ||
         memcmp(hhhd1->content, "one", hhhd1->content_len) != 0 ||
-        hhhd2->flags != (DETECT_CONTENT_DEPTH | DETECT_CONTENT_NOCASE) ||
+        hhhd2->flags != (DETECT_CONTENT_DEPTH) ||
         memcmp(hhhd2->content, "three", hhhd1->content_len) != 0) {
         goto end;
     }
@@ -1670,8 +1670,8 @@ int DetectHttpHHTest29(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; distance:0; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; distance:0; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1689,9 +1689,9 @@ int DetectHttpHHTest29(void)
 
     DetectContentData *hhhd1 = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
     DetectContentData *hhhd2 = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
-    if (hhhd1->flags != (DETECT_CONTENT_RELATIVE_NEXT | DETECT_CONTENT_NOCASE) ||
+    if (hhhd1->flags != (DETECT_CONTENT_RELATIVE_NEXT) ||
         memcmp(hhhd1->content, "one", hhhd1->content_len) != 0 ||
-        hhhd2->flags != (DETECT_CONTENT_DISTANCE | DETECT_CONTENT_NOCASE) ||
+        hhhd2->flags != (DETECT_CONTENT_DISTANCE) ||
         memcmp(hhhd2->content, "two", hhhd1->content_len) != 0) {
         goto end;
     }
@@ -1714,8 +1714,8 @@ int DetectHttpHHTest30(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; "
-                               "content:\"two\"; within:5; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; http_host; "
+                               "content:\"two\"; within:5; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1733,9 +1733,9 @@ int DetectHttpHHTest30(void)
 
     DetectContentData *hhhd1 = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
     DetectContentData *hhhd2 = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
-    if (hhhd1->flags != (DETECT_CONTENT_RELATIVE_NEXT | DETECT_CONTENT_NOCASE) ||
+    if (hhhd1->flags != (DETECT_CONTENT_RELATIVE_NEXT) ||
         memcmp(hhhd1->content, "one", hhhd1->content_len) != 0 ||
-        hhhd2->flags != (DETECT_CONTENT_WITHIN | DETECT_CONTENT_NOCASE) ||
+        hhhd2->flags != (DETECT_CONTENT_WITHIN) ||
         memcmp(hhhd2->content, "two", hhhd1->content_len) != 0) {
         goto end;
     }
@@ -1758,7 +1758,7 @@ int DetectHttpHHTest31(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; within:5; http_host; nocase; sid:1;)");
+                               "(content:\"one\"; within:5; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1782,7 +1782,7 @@ int DetectHttpHHTest32(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_host; nocase; within:5; sid:1;)");
+                               "(content:\"one\"; http_host; within:5; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list != NULL\n");
         goto end;
@@ -1830,8 +1830,8 @@ int DetectHttpHHTest34(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(pcre:/one/Wi; "
-                               "content:\"two\"; within:5; http_host; nocase; sid:1;)");
+                               "(pcre:/one/W; "
+                               "content:\"two\"; within:5; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1857,8 +1857,8 @@ int DetectHttpHHTest34(void)
 
     DetectPcreData *pd1 = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
     DetectContentData *hhhd2 = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
-    if (pd1->flags != (DETECT_PCRE_RELATIVE_NEXT | DETECT_PCRE_HTTP_HOST | DETECT_PCRE_CASELESS) ||
-        hhhd2->flags != (DETECT_CONTENT_WITHIN | DETECT_CONTENT_NOCASE) ||
+    if (pd1->flags != (DETECT_PCRE_RELATIVE_NEXT | DETECT_PCRE_HTTP_HOST) ||
+        hhhd2->flags != (DETECT_CONTENT_WITHIN) ||
         memcmp(hhhd2->content, "two", hhhd2->content_len) != 0) {
         goto end;
     }
@@ -1881,8 +1881,8 @@ int DetectHttpHHTest35(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"two\"; http_host; nocase; "
-                               "pcre:/one/WRi; sid:1;)");
+                               "(content:\"two\"; http_host; "
+                               "pcre:/one/WR; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1908,8 +1908,8 @@ int DetectHttpHHTest35(void)
 
     DetectContentData *hhhd1 = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
     DetectPcreData *pd2 = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
-    if (pd2->flags != (DETECT_PCRE_RELATIVE | DETECT_PCRE_HTTP_HOST | DETECT_PCRE_CASELESS) ||
-        hhhd1->flags != (DETECT_CONTENT_RELATIVE_NEXT | DETECT_CONTENT_NOCASE) ||
+    if (pd2->flags != (DETECT_PCRE_RELATIVE | DETECT_PCRE_HTTP_HOST) ||
+        hhhd1->flags != (DETECT_CONTENT_RELATIVE_NEXT) ||
         memcmp(hhhd1->content, "two", hhhd1->content_len) != 0) {
         goto end;
     }
@@ -1932,8 +1932,8 @@ int DetectHttpHHTest36(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(pcre:/one/Wi; "
-                               "content:\"two\"; distance:5; http_host; nocase; sid:1;)");
+                               "(pcre:/one/W; "
+                               "content:\"two\"; distance:5; http_host; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1959,8 +1959,8 @@ int DetectHttpHHTest36(void)
 
     DetectPcreData *pd1 = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
     DetectContentData *hhhd2 = de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
-    if (pd1->flags != (DETECT_PCRE_RELATIVE_NEXT | DETECT_PCRE_HTTP_HOST | DETECT_PCRE_CASELESS) ||
-        hhhd2->flags != (DETECT_CONTENT_DISTANCE | DETECT_CONTENT_NOCASE) ||
+    if (pd1->flags != (DETECT_PCRE_RELATIVE_NEXT | DETECT_PCRE_HTTP_HOST) ||
+        hhhd2->flags != (DETECT_CONTENT_DISTANCE) ||
         memcmp(hhhd2->content, "two", hhhd2->content_len) != 0) {
         goto end;
     }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -52,6 +52,7 @@
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 #include "util-debug.h"
+#include "util-memcmp.h"
 #include "string.h"
 #include "detect-parse.h"
 #include "detect-engine-iponly.h"
@@ -1165,17 +1166,36 @@ int SigValidate(DetectEngineCtx *de_ctx, Signature *s) {
              sm != NULL; sm = sm->next) {
             if (sm->type == DETECT_CONTENT) {
                 DetectContentData *cd = (DetectContentData *)sm->ctx;
-                if (!(cd->flags & DETECT_CONTENT_NOCASE)) {
+                if (cd->flags & DETECT_CONTENT_NOCASE) {
                     SCLogError(SC_ERR_INVALID_SIGNATURE, "http_host keyword "
-                               "requires the \"nocase\" modifier to be set.");
+                               "specified along with \"nocase\". "
+                               "Since the hostname buffer we match against "
+                               "is actually lowercase.  So having a "
+                               "nocase is redundant.");
                     SCReturnInt(0);
-                }
+                } else {
+                    uint8_t u = 0;
+                    for (u = 0; u < cd->content_len; u++) {
+                        if (isupper(cd->content[u]))
+                            break;
+                    }
+                    if (u != cd->content_len) {
+                        SCLogError(SC_ERR_INVALID_SIGNATURE, "A pattern with "
+                                   "uppercase chars detected for http_host.  "
+                                   "Since the hostname buffer we match against "
+                                   "is lowercase only, please specify a "
+                                   "lowercase pattern.");
+                        SCReturnInt(0);
+                    }
+                } /* else */
             } else if (sm->type == DETECT_PCRE) {
                 DetectPcreData *pd = (DetectPcreData *)sm->ctx;
-                if (!(pd->flags & DETECT_PCRE_CASELESS)) {
+                if (pd->flags & DETECT_PCRE_CASELESS) {
                     SCLogError(SC_ERR_INVALID_SIGNATURE, "pcre http_host "
-                               "modifier requires the nocase modifier "
-                               "\"i\"to be set");
+                               "specified along with \"nocase\". "
+                               "Since the hostname buffer we match against "
+                               "is actually lowercase.  So having a "
+                               "nocase is redundant.");
                     SCReturnInt(0);
                 }
             }


### PR DESCRIPTION
Previously we would have forced all users to use nocase with http_host
keywords(since the hostname buffer is lowercase).

We now error out on sigs that has nocase set with http_host set.  Also if
the http_host pattern or http_host pcre has an uppercase character set, we
invalidate such sigs.  Unittests also updated to reflect the above change.
