### PR TITLE
streaming: randomize chunk size

### DIFF
--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -452,6 +452,12 @@ void StreamTcpInitConfig(char quiet)
         SCLogInfo("stream.reassembly \"depth\": %"PRIu32"", stream_config.reassembly_depth);
     }
 
+    int randomize = 0;
+    if ((ConfGetBool("stream.reassembly.randomize-chunk-size", &randomize)) == 0) {
+        /* randomize by default if value not set */
+        randomize = 1;
+    }
+
     char *temp_stream_reassembly_toserver_chunk_size_str;
     if (ConfGet("stream.reassembly.toserver-chunk-size",
                 &temp_stream_reassembly_toserver_chunk_size_str) == 1) {
@@ -466,6 +472,12 @@ void StreamTcpInitConfig(char quiet)
     } else {
         stream_config.reassembly_toserver_chunk_size =
             STREAMTCP_DEFAULT_TOSERVER_CHUNK_SIZE;
+    }
+
+    if (randomize) {
+        stream_config.reassembly_toserver_chunk_size +=
+            (int) (stream_config.reassembly_toserver_chunk_size *
+                    (random() - RAND_MAX / 2) / (10.0 * RAND_MAX));
     }
     StreamMsgQueueSetMinChunkLen(FLOW_PKT_TOSERVER,
             stream_config.reassembly_toserver_chunk_size);
@@ -485,6 +497,13 @@ void StreamTcpInitConfig(char quiet)
         stream_config.reassembly_toclient_chunk_size =
             STREAMTCP_DEFAULT_TOCLIENT_CHUNK_SIZE;
     }
+
+    if (randomize) {
+        stream_config.reassembly_toclient_chunk_size +=
+            (int) (stream_config.reassembly_toclient_chunk_size *
+                    (random() - RAND_MAX / 2) / (10.0 * RAND_MAX));
+    }
+
     StreamMsgQueueSetMinChunkLen(FLOW_PKT_TOCLIENT,
             stream_config.reassembly_toclient_chunk_size);
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -595,6 +595,9 @@ flow-timeouts:
 #     toclient-chunk-size: 2560 # inspect raw stream in chunks of at least
 #                               # this size.  Can be specified in kb, mb,
 #                               # gb.  Just a number indicates it's in bytes.
+#     randomize-chunk-size: yes # Take a random value for chunk size around the specified value.
+#                               # This lower the risk of some evasion technics but could lead
+#                               # detection change between runs. It is set to 'yes' by default.
 
 stream:
   memcap: 32mb
@@ -605,6 +608,7 @@ stream:
     depth: 1mb                  # reassemble 1mb into a stream
     toserver-chunk-size: 2560
     toclient-chunk-size: 2560
+    randomize-chunk-size: yes
 
 # Host table:
 #


### PR DESCRIPTION
By randomizing chunk size around the choosen value, it is possible
to escape some evasion technics that are using the fact they know
chunk size to split the attack at the correct place.
