### PR TITLE
1. Fix assignment of signums, which affected how we used read

### DIFF
--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -3565,7 +3565,7 @@ end:
 static int DetectPcreFlowvarCapture02(void) {
     int result = 0;
     uint8_t uabuf1[] =
-        "Apache";
+        "Mozilla/5.0 (X11; U; Linux i686; es-ES; rv:1.9.0.13) Gecko/2009080315 Ubuntu/8.10 (intrepid) Firefox/3.0.13";
     uint32_t ualen1 = sizeof(uabuf1) - 1; /* minus the \0 */
     uint8_t httpbuf1[] =
         "GET / HTTP/1.1\r\n"

--- a/src/detect.c
+++ b/src/detect.c
@@ -462,16 +462,6 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     SCSigOrderSignatures(de_ctx);
     SCSigSignatureOrderingModuleCleanup(de_ctx);
 
-    Signature *s = de_ctx->sig_list;
-
-    /* Assign the unique order id of signatures after sorting,
-     * so the IP Only engine process them in order too */
-    SigIntId sig_id = 0;
-    while (s != NULL) {
-        s->order_id = sig_id++;
-        s = s->next;
-    }
-
     /* Setup the signature group lookup structure and pattern matchers */
     if (SigGroupBuild(de_ctx) < 0)
         goto end;
@@ -4386,6 +4376,22 @@ int SigAddressPrepareStage5(DetectEngineCtx *de_ctx) {
  */
 int SigGroupBuild(DetectEngineCtx *de_ctx)
 {
+    Signature *s = de_ctx->sig_list;
+
+    /* Assign the unique order id of signatures after sorting,
+     * so the IP Only engine process them in order too.  Also
+     * reset the old signums and assign new signums.  We would
+     * have experienced Sig reordering by now, hence the new
+     * signums. */
+    SigIntId sig_id = 0;
+    de_ctx->signum = 0;
+    while (s != NULL) {
+        s->num = de_ctx->signum++;
+        s->order_id = sig_id++;
+
+        s = s->next;
+    }
+
     if (DetectSetFastPatternAndItsId(de_ctx) < 0)
         return -1;
 

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -34,6 +34,7 @@
 #include "detect.h"
 #include "detect-parse.h"
 #include "detect-engine.h"
+#include "detect-engine-sigorder.h"
 
 #include "util-debug.h"
 #include "util-time.h"
@@ -685,6 +686,9 @@ int UTHMatchPackets(DetectEngineCtx *de_ctx, Packet **p, int num_packets) {
 
     //de_ctx->flags |= DE_QUIET;
 
+    SCSigRegisterSignatureOrderingFuncs(de_ctx);
+    SCSigOrderSignatures(de_ctx);
+    SCSigSignatureOrderingModuleCleanup(de_ctx);
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 


### PR DESCRIPTION
sigs(priority wise) inside staging.

   Previously we would assign signums before sig ordering, and hence the
   order didn't actually reflect the order of the sig in the
   sig_list(assuming sig reordering changed the sig_list).  Staging would
   use the old sig_nums to decide the priority of sigs.
2. Fix sig ordering for flowvar, flowbits, flowint, pktvar sigs.   We have
   introduced a new priority to treat sigs which (set + read) these above
   vars as lower priority compared to set only sigs.
3. Fix faulty unittest DetectPcreFlowvarCapture02.

There was a bug in sig numbering and staging, which despite the sigordering, the newly ordered sigs would be still read in the same order as before ordering.  This was because SigInit() would assign a signum before sigordering, and sigordering would re-order the sigs, but the signums are unchanged and hence don't actually reflect the new position of the sig in the sig_list.  But staging now reads the sigs from the list, based on the signum.

The right change would be to delete the signum allocation inside SigInitHelper() and update it after SigOrdering, which I'm doing currently in SigGroupBuild(), except that I have retained the old signum assignment in SigInitHelper(to keep unittests running fine), and I just overwrite them in SigGroupBuild().

I have also fixed what I think is a faulty unittest.  Have tested this patch with your tx redesign FN rules + pcap, and it alerts now.
