### PR TITLE
coccinelle: update pkt not set test

### DIFF
--- a/qa/coccinelle/pktnotset-packet.cocci
+++ b/qa/coccinelle/pktnotset-packet.cocci
@@ -14,7 +14,11 @@ position zeroed.p1;
 
 memset(p@p1, 0, ...);
 ... when != p
+(
 p->pkt
+|
+PACKET_INITIALIZE(p)
+)
 
 @script:python depends on !isset@
 p1 << zeroed.p1;


### PR DESCRIPTION
This patch updates the test to add the support of initialization
of a Packet via the INITIALIZE macro.
