### PR TITLE
Fix for #819

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -781,6 +781,12 @@ typedef struct DecodeThreadVars_
      ((p)->action = ACTION_PASS)); \
 } while (0)
 
+#define UPDATE_PACKET_ACTION(p, a) do { \
+    ((p)->root ? \
+     ((p)->root->action |= a) : \
+     ((p)->action |= a)); \
+} while (0)
+
 #define TUNNEL_INCR_PKT_RTV(p) do {                                                 \
         SCMutexLock((p)->root ? &(p)->root->tunnel_mutex : &(p)->tunnel_mutex);     \
         ((p)->root ? (p)->root->tunnel_rtv_cnt++ : (p)->tunnel_rtv_cnt++);          \

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -247,7 +247,7 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
             }
 
             /* set verdict on packet */
-            p->action |= p->alerts.alerts[i].action;
+            UPDATE_PACKET_ACTION(p, p->alerts.alerts[i].action);
 
             if (p->action & ACTION_PASS) {
                 /* Ok, reset the alert cnt to end in the previous of pass

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -1076,7 +1076,7 @@ void IPOnlyMatchPacket(ThreadVars *tv,
                             PacketAlertAppend(det_ctx, s, p, 0);
                     } else {
                         /* apply actions for noalert/rule suppressed as well */
-                        p->action |= s->action;
+                        UPDATE_PACKET_ACTION(p, s->action);
                     }
                 }
             }

--- a/src/detect.c
+++ b/src/detect.c
@@ -1299,7 +1299,7 @@ int SigMatchSignatures(ThreadVars *th_v, DetectEngineCtx *de_ctx, DetectEngineTh
             /* Get the result of the first IPOnlyMatch() */
             if (p->flow->flags & FLOW_ACTION_PASS) {
                 /* if it matched a "pass" rule, we have to let it go */
-                p->action |= ACTION_PASS;
+                UPDATE_PACKET_ACTION(p, ACTION_PASS);
             }
             /* If we have a drop from IP only module,
              * we will drop the rest of the flow packets
@@ -1307,7 +1307,7 @@ int SigMatchSignatures(ThreadVars *th_v, DetectEngineCtx *de_ctx, DetectEngineTh
             if (p->flow->flags & FLOW_ACTION_DROP)
             {
                 alert_flags = PACKET_ALERT_FLAG_DROP_FLOW;
-                p->action |= ACTION_DROP;
+                UPDATE_PACKET_ACTION(p, ACTION_DROP);
             }
         }
 
@@ -1602,7 +1602,7 @@ int SigMatchSignatures(ThreadVars *th_v, DetectEngineCtx *de_ctx, DetectEngineTh
             PacketAlertAppend(det_ctx, s, p, alert_flags);
         } else {
             /* apply actions even if not alerting */
-            p->action |= s->action;
+            UPDATE_PACKET_ACTION(p, s->action);
         }
 next:
         DetectFlowvarCleanupList(det_ctx);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -3800,7 +3800,7 @@ static int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
         FlowSetNoPacketInspectionFlag(p->flow);
         DecodeSetNoPacketInspectionFlag(p);
         FlowSetSessionNoApplayerInspectionFlag(p->flow);
-        p->action |= ACTION_DROP;
+        UPDATE_PACKET_ACTION(p, ACTION_DROP);
         /* return the segments to the pool */
         StreamTcpSessionPktFree(p);
         SCReturnInt(0);
@@ -4001,7 +4001,7 @@ error:
     }
 
     if (StreamTcpInlineMode()) {
-        p->action |= ACTION_DROP;
+        UPDATE_PACKET_ACTION(p, ACTION_DROP);
     }
     SCReturnInt(-1);
 }


### PR DESCRIPTION
This patch is fixing #819. This includes the impossibility to drop
fragmented and tunnelled packets.
