### PR TITLE
tls log: add JSON output

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -100,6 +100,7 @@ outputs:
   # a line based log of TLS handshake parameters (no alerts)
   - tls-log:
       enabled: no  # Log TLS connections.
+      #json: yes # Log in JSON format if set to yes
       filename: tls.log # File to store TLS logs.
       #extended: yes # Log extended information like fingerprint
       certs-log-dir: certs # directory to store the certificates files


### PR DESCRIPTION
This patch adds a new json option to tls logging. If set to yes, it
output TLS logging information in JSON format.
