### PR TITLE
Match on the MATCH list keywords first.

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -1490,6 +1490,18 @@ int SigMatchSignatures(ThreadVars *th_v, DetectEngineCtx *de_ctx, DetectEngineTh
             }
         }
 
+        /* run the packet match functions */
+        if (s->sm_lists[DETECT_SM_LIST_MATCH] != NULL) {
+            sm = s->sm_lists[DETECT_SM_LIST_MATCH];
+
+            SCLogDebug("running match functions, sm %p", sm);
+            for ( ; sm != NULL; sm = sm->next) {
+                if (sigmatch_table[sm->type].Match(th_v, det_ctx, p, s, sm) <= 0) {
+                    goto next;
+                }
+            }
+        }
+
         /* Check the payload keywords. If we are a MPM sig and we've made
          * to here, we've had at least one of the patterns match */
         if (s->sm_lists[DETECT_SM_LIST_PMATCH] != NULL) {
@@ -1563,18 +1575,6 @@ int SigMatchSignatures(ThreadVars *th_v, DetectEngineCtx *de_ctx, DetectEngineTh
                 } else {
                     if (DetectEngineInspectPacketPayload(de_ctx, det_ctx, s, p->flow, flags, alstate, p) != 1)
                         goto next;
-                }
-            }
-        }
-
-        /* run the packet match functions */
-        if (s->sm_lists[DETECT_SM_LIST_MATCH] != NULL) {
-            sm = s->sm_lists[DETECT_SM_LIST_MATCH];
-
-            SCLogDebug("running match functions, sm %p", sm);
-            for ( ; sm != NULL; sm = sm->next) {
-                if (sigmatch_table[sm->type].Match(th_v, det_ctx, p, s, sm) <= 0) {
-                    goto next;
                 }
             }
         }


### PR DESCRIPTION
Theoretically MATCH list keywords are less processor intensive than the
rest and should offer better performance.

Was wondring if this patch makes sense.  I have seen the no of rules with match list keywords and some of those keywords are flowbits/flowints checking if flags/vars are set.  So moving it before the cpu intensive ones might offer some perf, although the pcap runs shows nothing.

Let's not push this yet.   Would like to hear your ideas on this first.
