### PR TITLE
nfq: be sure to always verdict packets

### DIFF
--- a/src/source-nfq.h
+++ b/src/source-nfq.h
@@ -43,6 +43,7 @@ typedef struct NFQPacketVars_
 {
     int id; /* this nfq packets id */
     uint16_t nfq_index; /* index in NFQ array */
+    uint8_t verdicted;
 
     uint32_t mark;
     uint32_t ifi;


### PR DESCRIPTION
Update version of previous PR with buildfix and optimisation.

To be sure to always verdict packets (bug #769), this patch adds
a ReleaseData function to NFQ packets. The release function simply
drop the packet if it has not been verdicted before.
