### PR TITLE
autotools: add warning on Jansson dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -610,12 +610,12 @@ AC_INIT(configure.ac)
             esac
         fi
     else
+        echo
+        echo "   Jansson >= 2.2 is required for features like unix socket"
+        echo "   Go get it from your distribution of from:"
+        echo "     http://www.digip.org/jansson/"
+        echo
         if test "x$enable_unixsocket" = "xyes"; then
-            echo
-            echo "   Jansson >= 2.2 is required for features like unix socket"
-            echo "   Go get it from your distribution of from:"
-            echo "     http://www.digip.org/jansson/"
-            echo
             exit 1
         fi
         enable_unixsocket="no"


### PR DESCRIPTION
Modify configure to have it display the warning about missing JANSSON
library in any case.
