### PR TITLE
Tunnel status flag not set for request state in libhtp.

### DIFF
--- a/libhtp/htp/htp_response.c
+++ b/libhtp/htp/htp_response.c
@@ -268,6 +268,7 @@ int htp_connp_RES_BODY_DETERMINE(htp_connp_t *connp) {
         &&(connp->out_tx->response_status_number >= 200)
         &&(connp->out_tx->response_status_number <= 299))
     {
+        connp->in_status = STREAM_STATE_TUNNEL;
         connp->out_status = STREAM_STATE_TUNNEL;
         connp->out_state = htp_connp_RES_IDLE;
         connp->out_tx->progress[1] = TX_PROGRESS_DONE;


### PR DESCRIPTION
More of a temporary fix for bundled htp in master to stop the crashes
resulting from this.  libhtp 0.5.x should clean things up nice.
