### PR TITLE
use Packet test macro

### DIFF
--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -238,7 +238,7 @@ static int EventToImpact(PacketAlert *pa, Packet *p, idmef_alert_t *alert)
 
     idmef_impact_set_severity(impact, severity);
 
-    if (p->action & ACTION_DROP) {
+    if (PACKET_TEST_ACTION(p, ACTION_DROP)) {
         idmef_action_t *action;
 
         ret = idmef_action_new(&action);

--- a/src/alert-unified2-alert.c
+++ b/src/alert-unified2-alert.c
@@ -648,7 +648,7 @@ int Unified2IPv6TypeAlert (ThreadVars *t, Packet *p, void *data, PacketQueue *pq
     gphdr.dst_ip = *(struct in6_addr*)GET_IPV6_DST_ADDR(p);
     gphdr.protocol = p->proto;
 
-    if(p->action & ACTION_DROP)
+    if(PACKET_TEST_ACTION(p, ACTION_DROP))
         gphdr.packet_action = UNIFIED2_BLOCKED_FLAG;
     else
         gphdr.packet_action = 0;
@@ -794,7 +794,7 @@ int Unified2IPv4TypeAlert (ThreadVars *tv, Packet *p, void *data, PacketQueue *p
     gphdr.dst_ip = p->ip4h->s_ip_dst.s_addr;
     gphdr.protocol = IPV4_GET_RAW_IPPROTO(p->ip4h);
 
-    if(p->action & ACTION_DROP)
+    if(PACKET_TEST_ACTION(p, ACTION_DROP))
         gphdr.packet_action = UNIFIED2_BLOCKED_FLAG;
     else
         gphdr.packet_action = 0;

--- a/src/decode.h
+++ b/src/decode.h
@@ -787,6 +787,11 @@ typedef struct DecodeThreadVars_
      ((p)->action |= a)); \
 } while (0)
 
+#define PACKET_TEST_ACTION(p, a) \
+    ((p)->root ? \
+     ((p)->root->action & a) : \
+     ((p)->action & a))
+
 #define TUNNEL_INCR_PKT_RTV(p) do {                                                 \
         SCMutexLock((p)->root ? &(p)->root->tunnel_mutex : &(p)->tunnel_mutex);     \
         ((p)->root ? (p)->root->tunnel_rtv_cnt++ : (p)->tunnel_rtv_cnt++);          \

--- a/src/detect-detection-filter.c
+++ b/src/detect-detection-filter.c
@@ -579,17 +579,17 @@ static int DetectDetectionFilterTestSig3(void) {
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts = PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     TimeSetIncrementTime(200);
@@ -597,22 +597,22 @@ static int DetectDetectionFilterTestSig3(void) {
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     if (alerts == 3 && drops == 3)

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -249,14 +249,14 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
             /* set verdict on packet */
             UPDATE_PACKET_ACTION(p, p->alerts.alerts[i].action);
 
-            if (p->action & ACTION_PASS) {
+            if (PACKET_TEST_ACTION(p, ACTION_PASS)) {
                 /* Ok, reset the alert cnt to end in the previous of pass
                  * so we ignore the rest with less prio */
                 p->alerts.cnt = i;
                 break;
             /* if the signature wants to drop, check if the
              * PACKET_ALERT_FLAG_DROP_FLOW flag is set. */
-            } else if ((p->action & ACTION_DROP) &&
+            } else if ((PACKET_TEST_ACTION(p, ACTION_DROP)) &&
                     ((p->alerts.alerts[i].flags & PACKET_ALERT_FLAG_DROP_FLOW) ||
                          (s->flags & SIG_FLAG_APPLAYER))
                        && p->flow != NULL)

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -959,17 +959,17 @@ static int DetectThresholdTestSig7(void) {
     TimeGet(&p->ts);
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts = PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     TimeSetIncrementTime(200);
@@ -977,17 +977,17 @@ static int DetectThresholdTestSig7(void) {
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     if (alerts == 1 && drops == 6)
@@ -1052,17 +1052,17 @@ static int DetectThresholdTestSig8(void) {
     TimeGet(&p->ts);
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts = PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     TimeSetIncrementTime(200);
@@ -1070,17 +1070,17 @@ static int DetectThresholdTestSig8(void) {
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     if (alerts == 2 && drops == 6)
@@ -1145,17 +1145,17 @@ static int DetectThresholdTestSig9(void) {
     TimeGet(&p->ts);
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts = PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     TimeSetIncrementTime(200);
@@ -1163,17 +1163,17 @@ static int DetectThresholdTestSig9(void) {
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     if (alerts == 2 && drops == 2)
@@ -1238,17 +1238,17 @@ static int DetectThresholdTestSig10(void) {
     TimeGet(&p->ts);
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts = PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     TimeSetIncrementTime(200);
@@ -1256,17 +1256,17 @@ static int DetectThresholdTestSig10(void) {
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     if (alerts == 1 && drops == 1)
@@ -1331,17 +1331,17 @@ static int DetectThresholdTestSig11(void) {
     TimeGet(&p->ts);
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts = PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     TimeSetIncrementTime(200);
@@ -1349,17 +1349,17 @@ static int DetectThresholdTestSig11(void) {
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     if (alerts == 1 && drops == 4)
@@ -1424,17 +1424,17 @@ static int DetectThresholdTestSig12(void) {
     TimeGet(&p->ts);
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts = PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     TimeSetIncrementTime(200);
@@ -1442,17 +1442,17 @@ static int DetectThresholdTestSig12(void) {
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
-    drops += ((p->action & ACTION_DROP)?1:0);
+    drops += ((PACKET_TEST_ACTION(p, ACTION_DROP))?1:0);
     p->action = 0;
 
     if (alerts == 1 && drops == 2)

--- a/src/detect.c
+++ b/src/detect.c
@@ -1760,7 +1760,7 @@ TmEcode Detect(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, PacketQue
     DEBUG_VALIDATE_PACKET(p);
 
     /* No need to perform any detection on this packet, if the the given flag is set.*/
-    if ((p->flags & PKT_NOPACKET_INSPECTION) || (p->action & ACTION_DROP))
+    if ((p->flags & PKT_NOPACKET_INSPECTION) || (PACKET_TEST_ACTION(p, ACTION_DROP)))
         return 0;
 
     DetectEngineThreadCtx *det_ctx = (DetectEngineThreadCtx *)data;
@@ -10910,7 +10910,7 @@ static int SigTestDropFlow03(void)
         goto end;
     }
 
-    if ( !(p2->action & ACTION_DROP)) {
+    if ( !(PACKET_TEST_ACTION(p2, ACTION_DROP))) {
         printf("A \"drop\" action should be set from the flow to the packet: ");
         goto end;
     }
@@ -11041,7 +11041,7 @@ static int SigTestDropFlow04(void)
         goto end;
     }
 
-    if (!(p1->action & ACTION_DROP)) {
+    if (!(PACKET_TEST_ACTION(p1, ACTION_DROP))) {
         printf("A \"drop\" action was set from the flow to the packet "
                "which is right, but setting the flag shouldn't disable "
                "inspection on the packet in IDS mode");
@@ -11082,7 +11082,7 @@ static int SigTestDropFlow04(void)
         goto end;
     }
 
-    if (!(p2->action & ACTION_DROP)) {
+    if (!(PACKET_TEST_ACTION(p2, ACTION_DROP))) {
         printf("A \"drop\" action was set from the flow to the packet "
                "which is right, but setting the flag shouldn't disable "
                "inspection on the packet in IDS mode");

--- a/src/log-droplog.c
+++ b/src/log-droplog.c
@@ -214,7 +214,7 @@ TmEcode LogDropLogNetFilter (ThreadVars *tv, Packet *p, void *data, PacketQueue 
     uint16_t proto = 0;
     char timebuf[64];
 
-    if (!(p->action & ACTION_DROP) || PKT_IS_PSEUDOPKT(p)) {
+    if (!(PACKET_TEST_ACTION(p, ACTION_DROP)) || PKT_IS_PSEUDOPKT(p)) {
         return TM_ECODE_OK;
     }
 
@@ -394,7 +394,7 @@ int LogDropLogTest01()
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    if (p->alerts.cnt == 1 && (p->action & ACTION_DROP))
+    if (p->alerts.cnt == 1 && (PACKET_TEST_ACTION(p, ACTION_DROP)))
         result = (strcmp(p->alerts.alerts[0].s->class_msg, "Unknown are we") == 0);
     else
         result = 0;

--- a/src/respond-reject.c
+++ b/src/respond-reject.c
@@ -60,9 +60,9 @@ TmEcode RespondRejectFunc(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq
     int ret = 0;
 
     /* ACTION_REJECT defaults to rejecting the SRC */
-    if (!(p->action & ACTION_REJECT) &&
-        !(p->action & ACTION_REJECT_DST) &&
-        !(p->action & ACTION_REJECT_BOTH)) {
+    if (!(PACKET_TEST_ACTION(p, ACTION_REJECT)) &&
+        !(PACKET_TEST_ACTION(p, ACTION_REJECT_DST)) &&
+        !(PACKET_TEST_ACTION(p, ACTION_REJECT_BOTH))) {
         return TM_ECODE_OK;
     }
 
@@ -94,11 +94,11 @@ TmEcode RespondRejectFunc(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq
 }
 
 int RejectSendIPv4TCP(ThreadVars *tv, Packet *p, void *data) {
-    if (p->action & ACTION_REJECT) {
+    if (PACKET_TEST_ACTION(p, ACTION_REJECT)) {
         return RejectSendLibnet11L3IPv4TCP(tv, p, data, REJECT_DIR_SRC);
-    } else if (p->action & ACTION_REJECT_DST) {
+    } else if (PACKET_TEST_ACTION(p, ACTION_REJECT_DST)) {
         return RejectSendLibnet11L3IPv4TCP(tv, p, data, REJECT_DIR_DST);
-    } else if(p->action & ACTION_REJECT_BOTH) {
+    } else if(PACKET_TEST_ACTION(p, ACTION_REJECT_BOTH)) {
         if (RejectSendLibnet11L3IPv4TCP(tv, p, data, REJECT_DIR_SRC) == 0 &&
             RejectSendLibnet11L3IPv4TCP(tv, p, data, REJECT_DIR_DST) == 0) {
             return 0;
@@ -110,11 +110,11 @@ int RejectSendIPv4TCP(ThreadVars *tv, Packet *p, void *data) {
 }
 
 int RejectSendIPv4ICMP(ThreadVars *tv, Packet *p, void *data) {
-    if (p->action & ACTION_REJECT) {
+    if (PACKET_TEST_ACTION(p, ACTION_REJECT)) {
         return RejectSendLibnet11L3IPv4ICMP(tv, p, data, REJECT_DIR_SRC);
-    } else if (p->action & ACTION_REJECT_DST) {
+    } else if (PACKET_TEST_ACTION(p, ACTION_REJECT_DST)) {
         return RejectSendLibnet11L3IPv4ICMP(tv, p, data, REJECT_DIR_DST);
-    } else if(p->action & ACTION_REJECT_BOTH) {
+    } else if(PACKET_TEST_ACTION(p, ACTION_REJECT_BOTH)) {
         if (RejectSendLibnet11L3IPv4ICMP(tv, p, data, REJECT_DIR_SRC) == 0 &&
             RejectSendLibnet11L3IPv4ICMP(tv, p, data, REJECT_DIR_DST) == 0) {
             return 0;

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -614,7 +614,7 @@ TmEcode AFPWritePacket(Packet *p)
     int socket;
 
     if (p->afp_v.copy_mode == AFP_COPY_MODE_IPS) {
-        if (p->action & ACTION_DROP) {
+        if (PACKET_TEST_ACTION(p, ACTION_DROP)) {
             return TM_ECODE_OK;
         }
     }

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -518,7 +518,7 @@ TmEcode IPFWSetVerdict(ThreadVars *tv, IPFWThreadVars *ptv, Packet *p)
     IPFWpoll.fd = nq->fd;
     IPFWpoll.events = POLLWRNORM;
 
-    if (p->action & ACTION_DROP) {
+    if (PACKET_TEST_ACTION(p, ACTION_DROP)) {
         verdict = IPFW_DROP;
     } else {
         verdict = IPFW_ACCEPT;

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -895,7 +895,7 @@ TmEcode NFQSetVerdict(Packet *p) {
         return TM_ECODE_OK;
     }
 
-    if (p->action & ACTION_DROP) {
+    if (PACKET_TEST_ACTION(p, ACTION_DROP)) {
         verdict = NF_DROP;
 #ifdef COUNTERS
         t->dropped++;

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -1642,7 +1642,7 @@ int SCThresholdConfTest09(void)
     p->alerts.cnt = 0;
     p->action = 0;
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    if (p->alerts.cnt != 1 || p->action & ACTION_DROP) {
+    if (p->alerts.cnt != 1 || PACKET_TEST_ACTION(p, ACTION_DROP)) {
         result = 0;
         goto end;
     }
@@ -1650,7 +1650,7 @@ int SCThresholdConfTest09(void)
     p->alerts.cnt = 0;
     p->action = 0;
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    if (p->alerts.cnt != 1 || p->action & ACTION_DROP) {
+    if (p->alerts.cnt != 1 || PACKET_TEST_ACTION(p, ACTION_DROP)) {
         result = 0;
         goto end;
     }
@@ -1658,7 +1658,7 @@ int SCThresholdConfTest09(void)
     p->alerts.cnt = 0;
     p->action = 0;
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    if (p->alerts.cnt != 1 || p->action & ACTION_DROP) {
+    if (p->alerts.cnt != 1 || PACKET_TEST_ACTION(p, ACTION_DROP)) {
         result = 0;
         goto end;
     }
@@ -1669,7 +1669,7 @@ int SCThresholdConfTest09(void)
     p->alerts.cnt = 0;
     p->action = 0;
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    if (p->alerts.cnt != 1 || !(p->action & ACTION_DROP)) {
+    if (p->alerts.cnt != 1 || !(PACKET_TEST_ACTION(p, ACTION_DROP))) {
         result = 0;
         goto end;
     }
@@ -1680,7 +1680,7 @@ int SCThresholdConfTest09(void)
     p->alerts.cnt = 0;
     p->action = 0;
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    if (p->alerts.cnt != 1 || !(p->action & ACTION_DROP)) {
+    if (p->alerts.cnt != 1 || !(PACKET_TEST_ACTION(p, ACTION_DROP))) {
         result = 0;
         goto end;
     }
@@ -1691,7 +1691,7 @@ int SCThresholdConfTest09(void)
     p->alerts.cnt = 0;
     p->action = 0;
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    if (p->alerts.cnt != 1 || p->action & ACTION_DROP) {
+    if (p->alerts.cnt != 1 || PACKET_TEST_ACTION(p, ACTION_DROP)) {
         result = 0;
         goto end;
     }
@@ -1699,7 +1699,7 @@ int SCThresholdConfTest09(void)
     p->alerts.cnt = 0;
     p->action = 0;
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    if (p->alerts.cnt != 1 || p->action & ACTION_DROP) {
+    if (p->alerts.cnt != 1 || PACKET_TEST_ACTION(p, ACTION_DROP)) {
         result = 0;
         goto end;
     }
@@ -2221,7 +2221,7 @@ static int SCThresholdConfTest15(void)
         goto end;
     }
     /* however, it should have set the drop flag */
-    if (!(p->action & ACTION_DROP)) {
+    if (!(PACKET_TEST_ACTION(p, ACTION_DROP))) {
         printf("sid 10000 should have set DROP flag even if suppressed: ");
         goto end;
     }
@@ -2290,7 +2290,7 @@ static int SCThresholdConfTest16(void)
         goto end;
     }
     /* however, it should have set the drop flag */
-    if (!(p->action & ACTION_DROP)) {
+    if (!(PACKET_TEST_ACTION(p, ACTION_DROP))) {
         printf("sid 1000 should have set DROP flag even if suppressed: ");
         goto end;
     }
@@ -2359,7 +2359,7 @@ static int SCThresholdConfTest17(void)
         goto end;
     }
     /* however, it should have set the drop flag */
-    if (!(p->action & ACTION_DROP)) {
+    if (!(PACKET_TEST_ACTION(p, ACTION_DROP))) {
         printf("sid 10000 should have set DROP flag even if suppressed: ");
         goto end;
     }


### PR DESCRIPTION
This patch updates the code to use Packet test macro instead of
direct test on action flag instead Packet structure. This fixes
the issues related to p->root->action being set and not detected
in tests.
This should fix bug 864.
