### PR TITLE
af-packet: add sanity check in free function

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -884,6 +884,9 @@ static int AFPRefSocket(AFPPeer* peer)
  */
 static int AFPDerefSocket(AFPPeer* peer)
 {
+    if (peer == NULL)
+        return 1;
+
     if (SC_ATOMIC_SUB(peer->sock_usage, 1) == 0) {
         if (SC_ATOMIC_GET(peer->state) == AFP_STATE_DOWN) {
             SCLogInfo("Cleaning socket connected to '%s'", peer->iface);


### PR DESCRIPTION
This should fix a crash I've recently discovered in af-packet running mode. I don't understand why it was working before...
