### PR TITLE
Make the error message for lack of bundled libhtp more useful.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1088,8 +1088,12 @@
             AC_DEFINE_UNQUOTED([HAVE_HTP_DECODE_QUERY_INPLACE],[1],[Assuming htp_decode_query_inplace function in bundled libhtp])
         else
             echo
-            echo "  ERROR: Libhtp is not bundled. Get libhtp from https://github.com/ironbee/libhtp"
-            echo "  and pass --enable-non-bundled-htp to Suricata's configure script."
+            echo "  ERROR: Libhtp is not bundled. Get libhtp by doing:"
+            echo "     git clone https://github.com/ironbee/libhtp"
+            echo "     cd libhtp; ./autogen.sh; ./configure; make; cd .."
+            echo "  Then re-run Suricata's configure script."
+            echo "  Or, if libhtp is installed in a different location,"
+            echo "  pass --enable-non-bundled-htp to Suricata's configure script."
             echo "  Add --with-libhtp-includes=<dir> and --with-libhtp-libraries=<dir> if"
             echo "  libhtp is not installed in the include and library paths."
             echo


### PR DESCRIPTION
Added explicit instructions for downloading and building the latest libhtp
into the Suricata build tree. These instructions can simply be cut and pasted
to run them.
