### PR TITLE
unittest: make check use a qa/log dir for logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ src/TAGS
 src/suricata
 stamp-h1
 src/build-info.h
+qa/log/

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -410,7 +410,9 @@ AM_CFLAGS = -DLOCAL_STATE_DIR=\"$(localstatedir)\"
 
 if BUILD_UNITTESTS
 check-am:
-	$(top_builddir)/src/suricata -u
+	-mkdir $(top_srcdir)/qa/log/
+	$(top_builddir)/src/suricata -u -l $(top_srcdir)/qa/log/
+	-rm -rf $(top_srcdir)/qa/log
 endif
 
 distclean-local:


### PR DESCRIPTION
This patch is using the qa/log directory to store the output
of the check. In case of success, the directory is deleted.
In case of failure, the directory remains in place.

I've tried output in a temporary directory outside of the tree. But I did not find how to clean it correctly.

This should fixes #910.
