### PR TITLE
solaris: fix compilation failure

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -302,7 +302,8 @@ void AlpProtoDeFinalize2Thread(AlpProtoDetectThreadCtx *tctx) {
 /** \brief to be called by ReassemblyThreadInit
  *  \todo this is a hack, we need a proper place to store the global ctx */
 void AlpProtoFinalize2Thread(AlpProtoDetectThreadCtx *tctx) {
-    return AlpProtoFinalizeThread(&alp_proto_ctx, tctx);
+    AlpProtoFinalizeThread(&alp_proto_ctx, tctx);
+    return;
 }
 
 void AlpProtoFinalizeGlobal(AlpProtoDetectCtx *ctx) {

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -555,22 +555,28 @@ void DecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, 
     switch(IPV6_GET_NH(p)) {
         case IPPROTO_TCP:
             IPV6_SET_L4PROTO (p, IPPROTO_TCP);
-            return DecodeTCP(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
+            DecodeTCP(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
+            return;
         case IPPROTO_UDP:
             IPV6_SET_L4PROTO (p, IPPROTO_UDP);
-            return DecodeUDP(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
+            DecodeUDP(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
+            return;
             break;
         case IPPROTO_ICMPV6:
             IPV6_SET_L4PROTO (p, IPPROTO_ICMPV6);
-            return DecodeICMPV6(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
+            DecodeICMPV6(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
+            return;
         case IPPROTO_SCTP:
             IPV6_SET_L4PROTO (p, IPPROTO_SCTP);
-            return DecodeSCTP(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
+            DecodeSCTP(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
+            return;
         case IPPROTO_IPIP:
             IPV6_SET_L4PROTO(p, IPPROTO_IPIP);
-            return DecodeIPv4inIPv6(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
+            DecodeIPv4inIPv6(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
+            return;
         case IPPROTO_IPV6:
-            return DecodeIP6inIP6(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
+            DecodeIP6inIP6(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p), pq);
+            return;
         case IPPROTO_FRAGMENT:
         case IPPROTO_HOPOPTS:
         case IPPROTO_ROUTING:

--- a/src/decode.c
+++ b/src/decode.c
@@ -66,13 +66,17 @@ void DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 {
     switch (proto) {
         case PPP_OVER_GRE:
-            return DecodePPP(tv, dtv, p, pkt, len, pq);
+            DecodePPP(tv, dtv, p, pkt, len, pq);
+            return;
         case IPPROTO_IP:
-            return DecodeIPV4(tv, dtv, p, pkt, len, pq);
+            DecodeIPV4(tv, dtv, p, pkt, len, pq);
+            return;
         case IPPROTO_IPV6:
-            return DecodeIPV6(tv, dtv, p, pkt, len, pq);
+            DecodeIPV6(tv, dtv, p, pkt, len, pq);
+            return;
        case VLAN_OVER_GRE:
-            return DecodeVLAN(tv, dtv, p, pkt, len, pq);
+            DecodeVLAN(tv, dtv, p, pkt, len, pq);
+            return;
         default:
             SCLogInfo("FIXME: DecodeTunnel: protocol %" PRIu32 " not supported.", proto);
             break;

--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -1310,7 +1310,8 @@ static void SCRadixRemoveKey(uint8_t *key_stream, uint16_t key_bitlen,
 void SCRadixRemoveKeyGeneric(uint8_t *key_stream, uint16_t key_bitlen,
                              SCRadixTree *tree)
 {
-    return SCRadixRemoveKey(key_stream, key_bitlen, tree, 255);
+    SCRadixRemoveKey(key_stream, key_bitlen, tree, 255);
+    return;
 }
 
 /**
@@ -1324,7 +1325,8 @@ void SCRadixRemoveKeyGeneric(uint8_t *key_stream, uint16_t key_bitlen,
 void SCRadixRemoveKeyIPV4Netblock(uint8_t *key_stream, SCRadixTree *tree,
                                   uint8_t netmask)
 {
-    return SCRadixRemoveKey(key_stream, 32, tree, netmask);
+    SCRadixRemoveKey(key_stream, 32, tree, netmask);
+    return;
 }
 
 /**
@@ -1339,7 +1341,8 @@ void SCRadixRemoveKeyIPV4Netblock(uint8_t *key_stream, SCRadixTree *tree,
  */
 void SCRadixRemoveKeyIPV4(uint8_t *key_stream, SCRadixTree *tree)
 {
-    return SCRadixRemoveKey(key_stream, 32, tree, 32);
+    SCRadixRemoveKey(key_stream, 32, tree, 32);
+    return;
 }
 
 /**
@@ -1353,7 +1356,8 @@ void SCRadixRemoveKeyIPV4(uint8_t *key_stream, SCRadixTree *tree)
 void SCRadixRemoveKeyIPV6Netblock(uint8_t *key_stream, SCRadixTree *tree,
                                   uint8_t netmask)
 {
-    return SCRadixRemoveKey(key_stream, 128, tree, netmask);
+    SCRadixRemoveKey(key_stream, 128, tree, netmask);
+    return;
 }
 
 /**
@@ -1368,7 +1372,8 @@ void SCRadixRemoveKeyIPV6Netblock(uint8_t *key_stream, SCRadixTree *tree,
  */
 void SCRadixRemoveKeyIPV6(uint8_t *key_stream, SCRadixTree *tree)
 {
-    return SCRadixRemoveKey(key_stream, 128, tree, 128);
+    SCRadixRemoveKey(key_stream, 128, tree, 128);
+    return;
 }
 
 /**


### PR DESCRIPTION
This patch fixes a compilation failure on Solaris. Compiler does
not support when a function returning void is used in return of
an other function returning void.
