### PR TITLE
fix for #920.

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -600,6 +600,10 @@ int DetectAddressParseString(DetectAddress *dd, char *str)
     char *ip2 = NULL;
     char *mask = NULL;
     int r = 0;
+
+    while (*str != '\0' && *str == ' ')
+        str++;
+
     char *ipdup = SCStrdup(str);
 
     if (unlikely(ipdup == NULL))

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -106,6 +106,10 @@ static int IPOnlyCIDRItemParseSingle(IPOnlyCIDRItem *dd, char *str)
     char *ip2 = NULL;
     char *mask = NULL;
     int r = 0;
+
+    while (*str != '\0' && *str == ' ')
+        str++;
+
     char *ipdup = SCStrdup(str);
 
     if (unlikely(ipdup == NULL))


### PR DESCRIPTION
Cull the space before the address specified in address var variables.
