### PR TITLE
fix for #932.

### DIFF
--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -93,7 +93,7 @@ static void DecodeIP6inIP6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uin
             if (tp != NULL) {
                 PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV6);
                 DecodeTunnel(tv, dtv, tp, GET_PKT_DATA(tp),
-                             GET_PKT_LEN(tp), pq, IPPROTO_IP);
+                             GET_PKT_LEN(tp), pq, IPPROTO_IPV6);
                 PacketEnqueue(pq,tp);
                 SCPerfCounterIncr(dtv->counter_ipv6inipv6, tv->sc_perf_pca);
                 return;


### PR DESCRIPTION
ipv6 tunnel decoder wrongly treats the tunneled ipv6 packets as an ipv4
packet.
