### PR TITLE
fix for #926.

### DIFF
--- a/src/host.c
+++ b/src/host.c
@@ -166,6 +166,11 @@ void HostInitConfig(char quiet)
         if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             host_config.prealloc = configval;
+        } else {
+            SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY, "Invalid value "
+                       "supplied for host.prealloc conf entry - \"%s\".  "
+                       "Using defaut value of %"PRIu32".", conf_val,
+                       host_config.prealloc);
         }
     }
     SCLogDebug("Host config from suricata.yaml: memcap: %"PRIu64", hash-size: "


### PR DESCRIPTION
Supply meaningful error message when user supplies invalid value for
host.prealloc.
