### PR TITLE
Use the Async versions of SCCudaMemcpy* to improve gpu performance.

### DIFF
--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -1831,12 +1831,12 @@ static void *SCACCudaDispatcher(void *arg)
                   cb_data->op_buffer_read,
                   cb_data->op_buffer_write);
 #endif
-        r = SCCudaMemcpyHtoD(cuda_packets_buffer_d, (cb_data->d_buffer + cb_culled_info.d_buffer_start_offset), cb_culled_info.d_buffer_len);
+        r = SCCudaMemcpyHtoDAsync(cuda_packets_buffer_d, (cb_data->d_buffer + cb_culled_info.d_buffer_start_offset), cb_culled_info.d_buffer_len, 0);
         if (r < 0) {
             SCLogError(SC_ERR_AC_CUDA_ERROR, "SCCudaMemcpyHtoD failure.");
             exit(EXIT_FAILURE);
         }
-        r = SCCudaMemcpyHtoD(cuda_offset_buffer_d, (cb_data->o_buffer + cb_culled_info.op_buffer_start_offset), sizeof(uint32_t) * cb_culled_info.no_of_items);
+        r = SCCudaMemcpyHtoDAsync(cuda_offset_buffer_d, (cb_data->o_buffer + cb_culled_info.op_buffer_start_offset), sizeof(uint32_t) * cb_culled_info.no_of_items, 0);
         if (r < 0) {
             SCLogError(SC_ERR_AC_CUDA_ERROR, "SCCudaMemcpyHtoD failure.");
             exit(EXIT_FAILURE);
@@ -1856,7 +1856,7 @@ static void *SCACCudaDispatcher(void *arg)
             SCLogError(SC_ERR_AC_CUDA_ERROR, "SCCudaLaunchKernel failure.");
             exit(EXIT_FAILURE);
         }
-        r = SCCudaMemcpyDtoH(cuda_results_buffer_h, cuda_results_buffer_d, sizeof(uint32_t) * (cb_culled_info.d_buffer_len * 2));
+        r = SCCudaMemcpyDtoHAsync(cuda_results_buffer_h, cuda_results_buffer_d, sizeof(uint32_t) * (cb_culled_info.d_buffer_len * 2), 0);
         if (r < 0) {
             SCLogError(SC_ERR_AC_CUDA_ERROR, "SCCudaMemcpyDtoH failure.");
             exit(EXIT_FAILURE);


### PR DESCRIPTION
Improves gpu performance by removing unnecessary synchronizing with the host.

Here are a couple of traces from the nvidia profiler that show the gaps in between dmas and processing in the synchronous and aysncronous cases:

![cuda_synchronous](https://f.cloud.github.com/assets/5377197/1084620/79919da0-15b2-11e3-932e-7067c688a491.jpg)

![cuda_async](https://f.cloud.github.com/assets/5377197/1084637/af2f9688-15b2-11e3-8165-c247db5c5e27.jpg)
