### PR TITLE
unittest to display issue #920.  We now parse addresses that have

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -2302,6 +2302,74 @@ int AddressTestParse37(void)
     return 0;
 }
 
+int AddressTestParse38(void)
+{
+    int result = 0;
+
+    char *addr1 = "[192.168.0.0/16, 10.0.0.0/8,172.16.0.0/12]";
+    char *addr2 = "[10.10.10.0/24, !10.10.10.247]";
+    char *addr3 = "[10.10.10.0/24, !10.10.10.247/32]";
+
+    DetectAddressHead *gh;
+    int r;
+
+    gh = DetectAddressHeadInit();
+    if (gh == NULL)
+        goto end;
+    r = DetectAddressParse(gh, addr1);
+    if (r < 0)
+        goto end;
+    if (gh->ipv4_head == NULL ||
+        gh->ipv4_head->ip.addr_data32[0] != 0x0000000a || gh->ipv4_head->ip2.addr_data32[0] != 0xffffff0a ||
+        gh->ipv4_head->next == NULL ||
+        gh->ipv4_head->next->ip.addr_data32[0] != 0x000010ac ||
+        gh->ipv4_head->next->ip2.addr_data32[0] != 0xffff1Fac ||
+        gh->ipv4_head->next->next == NULL ||
+        gh->ipv4_head->next->next->ip.addr_data32[0] != 0x0000a8c0 ||
+        gh->ipv4_head->next->next->ip2.addr_data32[0] != 0xffffa8c0)
+    {
+        goto end;
+    }
+    DetectAddressHeadFree(gh);
+
+    gh = DetectAddressHeadInit();
+    if (gh == NULL)
+        goto end;
+    r = DetectAddressParse(gh, addr2);
+    if (r < 0)
+        goto end;
+    if (gh->ipv4_head == NULL ||
+        gh->ipv4_head->ip.addr_data32[0] != 0x000a0a0a || gh->ipv4_head->ip2.addr_data32[0] != 0xf60a0a0a ||
+        gh->ipv4_head->next == NULL ||
+        gh->ipv4_head->next->ip.addr_data32[0] != 0xf80a0a0a ||
+        gh->ipv4_head->next->ip2.addr_data32[0] != 0xff0a0a0a)
+    {
+        goto end;
+    }
+    DetectAddressHeadFree(gh);
+
+    gh = DetectAddressHeadInit();
+    if (gh == NULL)
+        goto end;
+    r = DetectAddressParse(gh, addr3);
+    if (r < 0)
+        goto end;
+    if (gh->ipv4_head == NULL ||
+        gh->ipv4_head->ip.addr_data32[0] != 0x000a0a0a || gh->ipv4_head->ip2.addr_data32[0] != 0xf60a0a0a ||
+        gh->ipv4_head->next == NULL ||
+        gh->ipv4_head->next->ip.addr_data32[0] != 0xf80a0a0a ||
+        gh->ipv4_head->next->ip2.addr_data32[0] != 0xff0a0a0a)
+    {
+        goto end;
+    }
+    DetectAddressHeadFree(gh);
+
+    result = 1;
+
+ end:
+    return result;
+}
+
 int AddressTestMatch01(void)
 {
     DetectAddress *dd = NULL;
@@ -4765,6 +4833,7 @@ void DetectAddressTests(void)
     UtRegisterTest("AddressTestParse35", AddressTestParse35, 1);
     UtRegisterTest("AddressTestParse36", AddressTestParse36, 1);
     UtRegisterTest("AddressTestParse37", AddressTestParse37, 1);
+    UtRegisterTest("AddressTestParse38", AddressTestParse38, 1);
 
     UtRegisterTest("AddressTestMatch01", AddressTestMatch01, 1);
     UtRegisterTest("AddressTestMatch02", AddressTestMatch02, 1);


### PR DESCRIPTION
a space after the ,

The unittest also validates the internal state.
