### PR TITLE
Support for Tile Gx atomic instructions

### DIFF
--- a/src/defrag.h
+++ b/src/defrag.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2013 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -111,7 +111,7 @@ typedef struct DefragTracker_ {
     uint32_t timeout; /**< When this tracker will timeout. */
 
     /** use cnt, reference counter */
-    SC_ATOMIC_DECLARE(unsigned short, use_cnt);
+    SC_ATOMIC_DECLARE(unsigned int, use_cnt);
 
     TAILQ_HEAD(frag_tailq, Frag_) frags; /**< Head of list of fragments. */
 

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2013 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -45,7 +45,7 @@
 #define FLOW_DEFAULT_FLOW_PRUNE 5
 
 SC_ATOMIC_EXTERN(unsigned int, flow_prune_idx);
-SC_ATOMIC_EXTERN(unsigned char, flow_flags);
+SC_ATOMIC_EXTERN(unsigned int, flow_flags);
 
 static Flow *FlowGetUsedFlow(void);
 

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2013 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -67,7 +67,7 @@
 /* Run mode selected at suricata.c */
 extern int run_mode;
 
-SC_ATOMIC_EXTERN(unsigned char, flow_flags);
+SC_ATOMIC_EXTERN(unsigned int, flow_flags);
 
 /* 1 seconds */
 #define FLOW_NORMAL_MODE_UPDATE_DELAY_SEC 1

--- a/src/flow.c
+++ b/src/flow.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2013 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -80,7 +80,7 @@
 SC_ATOMIC_DECLARE(unsigned int, flow_prune_idx);
 
 /** atomic flags */
-SC_ATOMIC_DECLARE(unsigned char, flow_flags);
+SC_ATOMIC_DECLARE(unsigned int, flow_flags);
 
 void FlowRegisterTests(void);
 void FlowInitFlowProto();

--- a/src/flow.h
+++ b/src/flow.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2013 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -247,6 +247,13 @@ typedef struct FlowAddress_ {
 #define addr_data16 address.address_un_data16
 #define addr_data8  address.address_un_data8
 
+#ifdef __tile__
+/* Atomic Ints performance better on Tile. */
+typedef unsigned int FlowRefCount;
+#else
+typedef unsigned short FlowRefCount;
+#endif
+
 /**
  *  \brief Flow data structure.
  *
@@ -290,7 +297,7 @@ typedef struct Flow_
      *  On receiving a packet the counter is incremented while the flow
      *  bucked is locked, which is also the case on timeout pruning.
      */
-    SC_ATOMIC_DECLARE(unsigned short, use_cnt);
+    SC_ATOMIC_DECLARE(FlowRefCount, use_cnt);
 
     /** flow queue id, used with autofp */
     SC_ATOMIC_DECLARE(int, autofp_tmqh_flow_qid);

--- a/src/host.h
+++ b/src/host.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2013 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -63,7 +63,7 @@ typedef struct Host_ {
     Address a;
 
     /** use cnt, reference counter */
-    SC_ATOMIC_DECLARE(unsigned short, use_cnt);
+    SC_ATOMIC_DECLARE(unsigned int, use_cnt);
 
     /** pointers to iprep storage */
     void *iprep;

--- a/src/threadvars.h
+++ b/src/threadvars.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2013 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -60,7 +60,7 @@ typedef struct ThreadVars_ {
     char *name;
     char *thread_group_name;
 
-    SC_ATOMIC_DECLARE(unsigned short, flags);
+    SC_ATOMIC_DECLARE(unsigned int, flags);
 
     /** aof(action on failure) determines what should be done with the thread
         when it encounters certain conditions like failures */

--- a/src/util-atomic.h
+++ b/src/util-atomic.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2013 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -42,8 +42,11 @@
 #define __UTIL_ATOMIC_H__
 
 /* test if we have atomic operations support */
-#if !defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8) || !defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4) || \
-    !defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_2) || !defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_1)
+#if (!defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8) || !defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4) || \
+     !defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_2) || !defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_1)) && \
+  !defined(__tile__)
+
+/* Do not have atomic operations support, so implement them with locks. */
 
 /**
  *  \brief wrapper to declare an atomic variable including a (spin) lock


### PR DESCRIPTION
Tilera's GCC supports the GCC __sync_ intrinsics.

Increase the size of some atomic variables for better performance on
Tile.  The Tile-Gx architecture has native support for 32-bit and
64-bit atomic operations, but not 8-bit and 16-bit, which are emulated
using 32-bit atomics, so changing some 16-bit and 8-bit atomic into
ints improves performance.

Increasing the size of the atomic variables modified in this change
does not increase the total size of the structures in which they
reside because of existing padding requirements. The one case that
would increase the size of the structure (Flow_) was conditionalized
to only change the size on Tile.

Passed prscript.
