### PR TITLE
Change one more atomic size in detect.h

### DIFF
--- a/src/detect.h
+++ b/src/detect.h
@@ -800,7 +800,7 @@ typedef struct DetectionEngineThreadCtx_ {
     /** ID of the transaction currently being inspected. */
     uint64_t tx_id;
 
-    SC_ATOMIC_DECLARE(uint16_t, so_far_used_by_detect);
+    SC_ATOMIC_DECLARE(int, so_far_used_by_detect);
 
     /* holds the current recursion depth on content inspection */
     int inspection_recursion_counter;


### PR DESCRIPTION
Change uint16_t to int for better tile atomic performance. Checked with
pahole that it doesn't increase the size of the structure.

Passed prscript.
