### PR TITLE
Align some structures to cacheline

### DIFF
--- a/src/data-queue.h
+++ b/src/data-queue.h
@@ -56,7 +56,7 @@ typedef struct SCDQDataQueue_ {
     SCMutex mutex_q;
     SCCondT cond_q;
 
-} SCDQDataQueue;
+} __attribute__((aligned(CLS))) SCDQDataQueue;
 
 void SCDQDataEnqueue(SCDQDataQueue *, SCDQGenericQData *);
 SCDQGenericQData *SCDQDataDequeue(SCDQDataQueue *);

--- a/src/flow-hash.h
+++ b/src/flow-hash.h
@@ -48,7 +48,7 @@ typedef struct FlowBucket_ {
 #else
     #error Enable FBLOCK_SPIN or FBLOCK_MUTEX
 #endif
-} FlowBucket;
+} __attribute__((aligned(CLS))) FlowBucket;
 
 #ifdef FBLOCK_SPIN
     #define FBLOCK_INIT(fb) SCSpinInit(&(fb)->s, 0)

--- a/src/host.h
+++ b/src/host.h
@@ -84,7 +84,7 @@ typedef struct HostHashRow_ {
     HRLOCK_TYPE lock;
     Host *head;
     Host *tail;
-} HostHashRow;
+} __attribute__((aligned(CLS))) HostHashRow;
 
 /** host hash table */
 HostHashRow *host_hash;


### PR DESCRIPTION
Align strucutres with pthread mutex locks to start on cachelines to keep
the lock within one cacheline.

Passed prscript.
