### PR TITLE
bug #695 - Modify handling of negated content.

### DIFF
--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -286,7 +286,8 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
                 SCLogDebug("content %"PRIu32" matched at offset %"PRIu32", but negated so no match", cd->id, match_offset);
                 /* don't bother carrying recursive matches now, for preceding
                  * relative keywords */
-                det_ctx->discontinue_matching = 1;
+                if (DETECT_CONTENT_IS_SINGLE(cd))
+                    det_ctx->discontinue_matching = 1;
                 SCReturnInt(0);
             } else {
                 match_offset = (uint32_t)((found - buffer) + cd->content_len);

--- a/src/detect-engine-dcepayload.c
+++ b/src/detect-engine-dcepayload.c
@@ -9424,6 +9424,9 @@ int DcePayloadParseTest41(void)
 
 /**
  * \test Test the working of consecutive relative matches with a negated content.
+ *
+ * By AWS.  This test was modified by a commit
+ * a8d401a5011374570b6f090a21dc65d704c64e38.
  */
 int DcePayloadTest42(void)
 {
@@ -9495,7 +9498,7 @@ int DcePayloadTest42(void)
     }
     /* detection phase */
     SigMatchSignatures(&tv, de_ctx, det_ctx, p);
-    if ((PacketAlertCheck(p, 1))) {
+    if (!(PacketAlertCheck(p, 1))) {
         printf("sid 1 matched but shouldn't have for packet: ");
         goto end;
     }

--- a/src/detect-engine-payload.c
+++ b/src/detect-engine-payload.c
@@ -296,6 +296,9 @@ end:
 /**
  * \test Test multiple relative matches with negative matches
  *       and show the need for det_ctx->discontinue_matching.
+ *
+ * By AWS.  This test was modified by a commit
+ * a8d401a5011374570b6f090a21dc65d704c64e38.
  */
 static int PayloadTestSig08(void)
 {
@@ -307,7 +310,7 @@ static int PayloadTestSig08(void)
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"fix\"; content:\"this\"; within:6; content:!\"and\"; distance:0; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, MPM_B2G) == 1) {
+    if (UTHPacketMatchSigMpm(p, sig, MPM_B2G) != 1) {
         goto end;
     }
 

--- a/src/detect-engine-uri.c
+++ b/src/detect-engine-uri.c
@@ -2269,6 +2269,9 @@ end:
 
 /**
  * \test Test multiple relative contents with a negated content.
+ *
+ * By AWS.  This test was modified by a commit
+ * a8d401a5011374570b6f090a21dc65d704c64e38.
  */
 static int UriTestSig21(void)
 {
@@ -2334,7 +2337,7 @@ static int UriTestSig21(void)
     /* do detect */
     SigMatchSignatures(&tv, de_ctx, det_ctx, p);
 
-    if (PacketAlertCheck(p, 1)) {
+    if (!PacketAlertCheck(p, 1)) {
         printf("sig 1 alerted, but it should not: ");
         goto end;
     }


### PR DESCRIPTION
The old behaviour of returning a failure if we found a pattern while
matching on negated content is now changed to continuing searching
for other combinations where we don't find the pattern for the
negated content.

Thanks to Will Metcalf for reporting this.
