### PR TITLE
Clean up function syntax

### DIFF
--- a/src/detect-tag.c
+++ b/src/detect-tag.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2013 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -57,15 +57,16 @@ SC_ATOMIC_EXTERN(unsigned int, num_tags);
 static pcre *parse_regex;
 static pcre_extra *parse_regex_study;
 
-int DetectTagMatch (ThreadVars *, DetectEngineThreadCtx *, Packet *, Signature *, SigMatch *);
-static int DetectTagSetup (DetectEngineCtx *, Signature *, char *);
+int DetectTagMatch(ThreadVars *, DetectEngineThreadCtx *, Packet *, Signature *, SigMatch *);
+static int DetectTagSetup(DetectEngineCtx *, Signature *, char *);
 void DetectTagRegisterTests(void);
 void DetectTagDataFree(void *);
 
 /**
  * \brief Registration function for keyword tag
  */
-void DetectTagRegister (void) {
+void DetectTagRegister(void)
+{
     sigmatch_table[DETECT_TAG].name = "tag";
     sigmatch_table[DETECT_TAG].Match = DetectTagMatch;
     sigmatch_table[DETECT_TAG].Setup = DetectTagSetup;
@@ -108,7 +109,7 @@ error:
  * \retval 0 no match
  * \retval 1 match
  */
-int DetectTagMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx, Packet *p, Signature *s, SigMatch *m)
+int DetectTagMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx, Packet *p, Signature *s, SigMatch *m)
 {
     DetectTagData *td = (DetectTagData *) m->ctx;
     DetectTagDataEntry tde;
@@ -166,7 +167,7 @@ int DetectTagMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx, Packet *p, Si
  * \retval td pointer to DetectTagData on success
  * \retval NULL on failure
  */
-DetectTagData *DetectTagParse (char *tagstr)
+DetectTagData *DetectTagParse(char *tagstr)
 {
     DetectTagData td;
 #define MAX_SUBSTRINGS 30
@@ -296,7 +297,7 @@ error:
  * \retval 0 on Success
  * \retval -1 on Failure
  */
-int DetectTagSetup (DetectEngineCtx *de_ctx, Signature *s, char *tagstr)
+int DetectTagSetup(DetectEngineCtx *de_ctx, Signature *s, char *tagstr)
 {
     DetectTagData *td = NULL;
     SigMatch *sm = NULL;
@@ -329,7 +330,8 @@ error:
  *
  *  \param td pointer to DetectTagDataEntry
  */
-static void DetectTagDataEntryFree(void *ptr) {
+static void DetectTagDataEntryFree(void *ptr)
+{
     if (ptr != NULL) {
         DetectTagDataEntry *dte = (DetectTagDataEntry *)ptr;
         SCFree(dte);
@@ -343,7 +345,8 @@ static void DetectTagDataEntryFree(void *ptr) {
  *
  * \param td pointer to DetectTagDataEntryList
  */
-void DetectTagDataListFree(void *ptr) {
+void DetectTagDataListFree(void *ptr)
+{
     if (ptr != NULL) {
         DetectTagDataEntry *entry = ptr;
 
@@ -361,7 +364,8 @@ void DetectTagDataListFree(void *ptr) {
  *
  * \param td pointer to DetectTagData
  */
-void DetectTagDataFree(void *ptr) {
+void DetectTagDataFree(void *ptr)
+{
     DetectTagData *td = (DetectTagData *)ptr;
     SCFree(td);
 }
@@ -372,7 +376,8 @@ void DetectTagDataFree(void *ptr) {
  * \test DetectTagTestParse01 is a test to make sure that we return "something"
  *  when given valid tag opt
  */
-int DetectTagTestParse01 (void) {
+static int DetectTagTestParse01(void)
+{
     int result = 0;
     DetectTagData *td = NULL;
     td = DetectTagParse("session, 123, packets");
@@ -389,7 +394,8 @@ int DetectTagTestParse01 (void) {
 /**
  * \test DetectTagTestParse02 is a test to check that we parse tag correctly
  */
-int DetectTagTestParse02 (void) {
+static int DetectTagTestParse02(void)
+{
     int result = 0;
     DetectTagData *td = NULL;
     td = DetectTagParse("host, 200, bytes, src");
@@ -407,7 +413,8 @@ int DetectTagTestParse02 (void) {
 /**
  * \test DetectTagTestParse03 is a test for setting the stateless tag opt
  */
-int DetectTagTestParse03 (void) {
+static int DetectTagTestParse03(void)
+{
     int result = 0;
     DetectTagData *td = NULL;
     td = DetectTagParse("host, 200, bytes, dst");
@@ -425,7 +432,8 @@ int DetectTagTestParse03 (void) {
 /**
  * \test DetectTagTestParse04 is a test for default opts
  */
-int DetectTagTestParse04 (void) {
+static int DetectTagTestParse04(void)
+{
     int result = 0;
     DetectTagData *td = NULL;
     td = DetectTagParse("session");
@@ -442,7 +450,8 @@ int DetectTagTestParse04 (void) {
 /**
  * \test DetectTagTestParse05 is a test for default opts
  */
-int DetectTagTestParse05 (void) {
+static int DetectTagTestParse05(void)
+{
     int result = 0;
     DetectTagData *td = NULL;
     td = DetectTagParse("host");
@@ -461,7 +470,8 @@ int DetectTagTestParse05 (void) {
 /**
  * \test DetectTagTestPacket01 is a test to check tagged hosts
  */
-int DetectTagTestPacket01 (void) {
+static int DetectTagTestPacket01(void)
+{
     int result = 0;
     uint8_t *buf = (uint8_t *)"Hi all!";
     uint8_t *buf2 = (uint8_t *)"lalala!";
@@ -521,7 +531,8 @@ int DetectTagTestPacket01 (void) {
 /**
  * \test DetectTagTestPacket02 is a test to check tagged hosts
  */
-int DetectTagTestPacket02 (void) {
+static int DetectTagTestPacket02(void)
+{
     int result = 0;
     uint8_t *buf = (uint8_t *)"Hi all!";
     uint8_t *buf2 = (uint8_t *)"lalala!";
@@ -622,7 +633,8 @@ end:
 /**
  * \test DetectTagTestPacket03 is a test to check tagged hosts
  */
-int DetectTagTestPacket03 (void) {
+static int DetectTagTestPacket03(void)
+{
     int result = 0;
     uint8_t *buf = (uint8_t *)"Hi all!";
     uint8_t *buf2 = (uint8_t *)"lalala!";
@@ -724,7 +736,8 @@ end:
 /**
  * \test DetectTagTestPacket04 is a test to check tagged hosts
  */
-int DetectTagTestPacket04 (void) {
+static int DetectTagTestPacket04(void)
+{
     int result = 0;
     uint8_t *buf = (uint8_t *)"Hi all!";
     uint8_t *buf2 = (uint8_t *)"lalala!";
@@ -846,7 +859,8 @@ end:
 /**
  * \brief this function registers unit tests for DetectTag
  */
-void DetectTagRegisterTests(void) {
+void DetectTagRegisterTests(void)
+{
 #ifdef UNITTESTS
     UtRegisterTest("DetectTagTestParse01", DetectTagTestParse01, 1);
     UtRegisterTest("DetectTagTestParse02", DetectTagTestParse02, 1);
@@ -867,4 +881,3 @@ void DetectTagRegisterTests(void) {
 #endif
 #endif /* UNITTESTS */
 }
-

--- a/src/detect-tag.h
+++ b/src/detect-tag.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2013 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -97,7 +97,7 @@ typedef struct DetectTagDataEntry_ {
 #define TAG_ENTRY_FLAG_SKIPPED_FIRST    0x04
 
 /* prototypes */
-void DetectTagRegister (void);
+void DetectTagRegister(void);
 void DetectTagDataFree(void *ptr);
 void DetectTagDataListFree(void *ptr);
 

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2013 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -65,15 +65,16 @@
 static pcre *parse_regex;
 static pcre_extra *parse_regex_study;
 
-static int DetectThresholdMatch (ThreadVars *, DetectEngineThreadCtx *, Packet *, Signature *, SigMatch *);
-static int DetectThresholdSetup (DetectEngineCtx *, Signature *, char *);
+static int DetectThresholdMatch(ThreadVars *, DetectEngineThreadCtx *, Packet *, Signature *, SigMatch *);
+static int DetectThresholdSetup(DetectEngineCtx *, Signature *, char *);
 static void DetectThresholdFree(void *);
 
 /**
  * \brief Registration function for threshold: keyword
  */
 
-void DetectThresholdRegister (void) {
+void DetectThresholdRegister(void)
+{
     sigmatch_table[DETECT_THRESHOLD].name = "threshold";
     sigmatch_table[DETECT_THRESHOLD].desc = "control the rule's alert frequency";
     sigmatch_table[DETECT_THRESHOLD].url = "https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Rule-Thresholding#threshold";
@@ -107,7 +108,7 @@ error:
 
 }
 
-static int DetectThresholdMatch (ThreadVars *thv, DetectEngineThreadCtx *det_ctx, Packet *p, Signature *s, SigMatch *sm)
+static int DetectThresholdMatch(ThreadVars *thv, DetectEngineThreadCtx *det_ctx, Packet *p, Signature *s, SigMatch *sm)
 {
     return 1;
 }
@@ -121,7 +122,7 @@ static int DetectThresholdMatch (ThreadVars *thv, DetectEngineThreadCtx *det_ctx
  * \retval de pointer to DetectThresholdData on success
  * \retval NULL on failure
  */
-static DetectThresholdData *DetectThresholdParse (char *rawstr)
+static DetectThresholdData *DetectThresholdParse(char *rawstr)
 {
     DetectThresholdData *de = NULL;
 #define MAX_SUBSTRINGS 30
@@ -237,7 +238,7 @@ error:
  * \retval 0 on Success
  * \retval -1 on Failure
  */
-static int DetectThresholdSetup (DetectEngineCtx *de_ctx, Signature *s, char *rawstr)
+static int DetectThresholdSetup(DetectEngineCtx *de_ctx, Signature *s, char *rawstr)
 {
     DetectThresholdData *de = NULL;
     SigMatch *sm = NULL;
@@ -278,7 +279,8 @@ error:
  *
  * \param de pointer to DetectThresholdData
  */
-static void DetectThresholdFree(void *de_ptr) {
+static void DetectThresholdFree(void *de_ptr)
+{
     DetectThresholdData *de = (DetectThresholdData *)de_ptr;
     if (de) {
         DetectAddressFree(de->addr);
@@ -304,7 +306,8 @@ static void DetectThresholdFree(void *de_ptr) {
  *  \retval 1 on succces
  *  \retval 0 on failure
  */
-static int ThresholdTestParse01 (void) {
+static int ThresholdTestParse01(void)
+{
     DetectThresholdData *de = NULL;
     de = DetectThresholdParse("type limit,track by_dst,count 10,seconds 60");
     if (de && (de->type == TYPE_LIMIT) && (de->track == TRACK_DST) && (de->count == 10) && (de->seconds == 60)) {
@@ -321,7 +324,8 @@ static int ThresholdTestParse01 (void) {
  *  \retval 1 on succces
  *  \retval 0 on failure
  */
-static int ThresholdTestParse02 (void) {
+static int ThresholdTestParse02(void)
+{
     DetectThresholdData *de = NULL;
     de = DetectThresholdParse("type any,track by_dst,count 10,seconds 60");
     if (de && (de->type == TYPE_LIMIT) && (de->track == TRACK_DST) && (de->count == 10) && (de->seconds == 60)) {
@@ -338,7 +342,8 @@ static int ThresholdTestParse02 (void) {
  *  \retval 1 on succces
  *  \retval 0 on failure
  */
-static int ThresholdTestParse03 (void) {
+static int ThresholdTestParse03(void)
+{
     DetectThresholdData *de = NULL;
     de = DetectThresholdParse("track by_dst, type limit, seconds 60, count 10");
     if (de && (de->type == TYPE_LIMIT) && (de->track == TRACK_DST) && (de->count == 10) && (de->seconds == 60)) {
@@ -356,7 +361,8 @@ static int ThresholdTestParse03 (void) {
  *  \retval 1 on succces
  *  \retval 0 on failure
  */
-static int ThresholdTestParse04 (void) {
+static int ThresholdTestParse04(void)
+{
     DetectThresholdData *de = NULL;
     de = DetectThresholdParse("count 10, track by_dst, seconds 60, type both, count 10");
     if (de && (de->type == TYPE_BOTH) && (de->track == TRACK_DST) && (de->count == 10) && (de->seconds == 60)) {
@@ -373,7 +379,8 @@ static int ThresholdTestParse04 (void) {
  *  \retval 1 on succces
  *  \retval 0 on failure
  */
-static int ThresholdTestParse05 (void) {
+static int ThresholdTestParse05(void)
+{
     DetectThresholdData *de = NULL;
     de = DetectThresholdParse("count 10, track by_dst, seconds 60, type both");
     if (de && (de->type == TYPE_BOTH) && (de->track == TRACK_DST) && (de->count == 10) && (de->seconds == 60)) {
@@ -394,8 +401,8 @@ static int ThresholdTestParse05 (void) {
  *  \retval 0 on failure
  */
 
-static int DetectThresholdTestSig1(void) {
-
+static int DetectThresholdTestSig1(void)
+{
     Packet *p = NULL;
     Signature *s = NULL;
     ThreadVars th_v;
@@ -498,7 +505,8 @@ end:
  *  \retval 0 on failure
  */
 
-static int DetectThresholdTestSig2(void) {
+static int DetectThresholdTestSig2(void)
+{
     Packet *p = NULL;
     Signature *s = NULL;
     ThreadVars th_v;
@@ -575,7 +583,8 @@ end:
  *  \retval 0 on failure
  */
 
-static int DetectThresholdTestSig3(void) {
+static int DetectThresholdTestSig3(void)
+{
     Packet *p = NULL;
     Signature *s = NULL;
     ThreadVars th_v;
@@ -679,7 +688,8 @@ end:
  *  \retval 0 on failure
  */
 
-static int DetectThresholdTestSig4(void) {
+static int DetectThresholdTestSig4(void)
+{
     Packet *p = NULL;
     Signature *s = NULL;
     ThreadVars th_v;
@@ -756,7 +766,8 @@ end:
  *  \retval 0 on failure
  */
 
-static int DetectThresholdTestSig5(void) {
+static int DetectThresholdTestSig5(void)
+{
     Packet *p = NULL;
     Signature *s = NULL;
     ThreadVars th_v;
@@ -834,7 +845,8 @@ end:
     return result;
 }
 
-static int DetectThresholdTestSig6Ticks(void) {
+static int DetectThresholdTestSig6Ticks(void)
+{
     Packet *p = NULL;
     Signature *s = NULL;
     ThreadVars th_v;
@@ -919,7 +931,8 @@ end:
 /**
  * \test Test drop action being set even if thresholded
  */
-static int DetectThresholdTestSig7(void) {
+static int DetectThresholdTestSig7(void)
+{
     Packet *p = NULL;
     Signature *s = NULL;
     ThreadVars th_v;
@@ -1012,7 +1025,8 @@ end:
 /**
  * \test Test drop action being set even if thresholded
  */
-static int DetectThresholdTestSig8(void) {
+static int DetectThresholdTestSig8(void)
+{
     Packet *p = NULL;
     Signature *s = NULL;
     ThreadVars th_v;
@@ -1198,7 +1212,8 @@ end:
 /**
  * \test Test drop action being set even if thresholded
  */
-static int DetectThresholdTestSig10(void) {
+static int DetectThresholdTestSig10(void)
+{
     Packet *p = NULL;
     Signature *s = NULL;
     ThreadVars th_v;
@@ -1291,7 +1306,8 @@ end:
 /**
  * \test Test drop action being set even if thresholded
  */
-static int DetectThresholdTestSig11(void) {
+static int DetectThresholdTestSig11(void)
+{
     Packet *p = NULL;
     Signature *s = NULL;
     ThreadVars th_v;
@@ -1384,7 +1400,8 @@ end:
 /**
  * \test Test drop action being set even if thresholded
  */
-static int DetectThresholdTestSig12(void) {
+static int DetectThresholdTestSig12(void)
+{
     Packet *p = NULL;
     Signature *s = NULL;
     ThreadVars th_v;
@@ -1476,7 +1493,8 @@ end:
 
 #endif /* UNITTESTS */
 
-void ThresholdRegisterTests(void) {
+void ThresholdRegisterTests(void)
+{
 #ifdef UNITTESTS
     UtRegisterTest("ThresholdTestParse01", ThresholdTestParse01, 1);
     UtRegisterTest("ThresholdTestParse02", ThresholdTestParse02, 0);

--- a/src/detect-threshold.h
+++ b/src/detect-threshold.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2013 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -83,7 +83,7 @@ typedef struct DetectThresholdEntry_ {
  * Registration function for threshold: keyword
  */
 
-void DetectThresholdRegister (void);
+void DetectThresholdRegister(void);
 
 /**
  * This function registers unit tests for Threshold


### PR DESCRIPTION
Remove space before ( in function definition. Put { on new line.
Make test functions static.

prscript:  https://buildbot.suricata-ids.org/builders/ken-tilera/builds/21
