### PR TITLE
Feature #901 - VLAN defrag support.

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -2156,6 +2156,100 @@ end:
     return ret;
 }
 
+/**
+ * Test that fragments in different VLANs that would otherwise be
+ * re-assembled, are not re-assembled.  Just use simple in-order
+ * fragments.
+ */
+static int
+DefragVlanTest(void) {
+    Packet *p1 = NULL, *p2 = NULL, *r = NULL;
+    int ret = 0;
+
+    DefragInit();
+
+    p1 = BuildTestPacket(1, 0, 1, 'A', 8);
+    if (p1 == NULL)
+        goto end;
+    p2 = BuildTestPacket(1, 1, 0, 'B', 8);
+    if (p2 == NULL)
+        goto end;
+
+    /* With no VLAN IDs set, packets should re-assemble. */
+    if ((r = Defrag(NULL, NULL, p1)) != NULL)
+        goto end;
+    if ((r = Defrag(NULL, NULL, p2)) == NULL)
+        goto end;
+    SCFree(r);
+
+    /* With mismatched VLANs, packets should not re-assemble. */
+    p1->vlan_id[0] = 1;
+    p2->vlan_id[0] = 2;
+    if ((r = Defrag(NULL, NULL, p1)) != NULL)
+        goto end;
+    if ((r = Defrag(NULL, NULL, p2)) != NULL)
+        goto end;
+
+    /* Pass. */
+    ret = 1;
+
+end:
+    if (p1 != NULL)
+        SCFree(p1);
+    if (p2 != NULL)
+        SCFree(p2);
+    DefragDestroy();
+
+    return ret;
+}
+
+/**
+ * Like DefragVlanTest, but for QinQ, testing the second level VLAN ID.
+ */
+static int
+DefragVlanQinQTest(void) {
+    Packet *p1 = NULL, *p2 = NULL, *r = NULL;
+    int ret = 0;
+
+    DefragInit();
+
+    p1 = BuildTestPacket(1, 0, 1, 'A', 8);
+    if (p1 == NULL)
+        goto end;
+    p2 = BuildTestPacket(1, 1, 0, 'B', 8);
+    if (p2 == NULL)
+        goto end;
+
+    /* With no VLAN IDs set, packets should re-assemble. */
+    if ((r = Defrag(NULL, NULL, p1)) != NULL)
+        goto end;
+    if ((r = Defrag(NULL, NULL, p2)) == NULL)
+        goto end;
+    SCFree(r);
+
+    /* With mismatched VLANs, packets should not re-assemble. */
+    p1->vlan_id[0] = 1;
+    p2->vlan_id[0] = 1;
+    p1->vlan_id[1] = 1;
+    p2->vlan_id[1] = 2;
+    if ((r = Defrag(NULL, NULL, p1)) != NULL)
+        goto end;
+    if ((r = Defrag(NULL, NULL, p2)) != NULL)
+        goto end;
+
+    /* Pass. */
+    ret = 1;
+
+end:
+    if (p1 != NULL)
+        SCFree(p1);
+    if (p2 != NULL)
+        SCFree(p2);
+    DefragDestroy();
+
+    return ret;
+}
+
 #endif /* UNITTESTS */
 
 void
@@ -2198,6 +2292,9 @@ DefragRegisterTests(void)
         IPV6DefragSturgesNovakFirstTest, 1);
     UtRegisterTest("IPV6DefragSturgesNovakLastTest",
         IPV6DefragSturgesNovakLastTest, 1);
+
+    UtRegisterTest("DefragVlanTest", DefragVlanTest, 1);
+    UtRegisterTest("DefragVlanQinQTest", DefragVlanQinQTest, 1);
 
     UtRegisterTest("DefragTimeoutTest",
         DefragTimeoutTest, 1);

--- a/src/defrag.h
+++ b/src/defrag.h
@@ -93,6 +93,8 @@ typedef struct DefragTracker_ {
     SCMutex lock; /**< Mutex for locking list operations on
                            * this tracker. */
 
+    uint16_t vlan_id[2]; /**< VLAN ID tracker applies to. */
+
     uint32_t id; /**< IP ID for this tracker.  32 bits for IPv6, 16
                   * for IPv4. */
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -554,10 +554,10 @@ flow:
   prealloc: 10000
   emergency-recovery: 30
 
-# This option controls the use of vlan ids in the flow hashing. Normally this
-# should be enabled, but in some (broken) setups where both sides of a flow are
-# not tagged with the same vlan tag, we can ignore the vlan id's in the flow
-# hashing.
+# This option controls the use of vlan ids in the flow (and defrag)
+# hashing. Normally this should be enabled, but in some (broken)
+# setups where both sides of a flow are not tagged with the same vlan
+# tag, we can ignore the vlan id's in the flow hashing.
 vlan:
   use-for-tracking: true
 


### PR DESCRIPTION
Take VLAN IDs into account when re-assembling fragments.

Prevents fragments that would otherwise match, but on different
VLANs from being reassembled with each other.
