### PR TITLE
Certain unittests were registered twice, especially the app layer ones.

### DIFF
--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -187,12 +187,12 @@ int RunUnittests(int list_unittests, char *regex_arg)
     SCPerfRegisterTests();
     DecodePPPRegisterTests();
     DecodeVLANRegisterTests();
-    HTPParserRegisterTests();
-    SSHParserRegisterTests();
-    SMBParserRegisterTests();
-    DCERPCParserRegisterTests();
-    DCERPCUDPParserRegisterTests();
-    FTPParserRegisterTests();
+    //HTPParserRegisterTests();
+    //SSHParserRegisterTests();
+    //SMBParserRegisterTests();
+    //DCERPCParserRegisterTests();
+    //DCERPCUDPParserRegisterTests();
+    //FTPParserRegisterTests();
     DecodeRawRegisterTests();
     DecodePPPOERegisterTests();
     DecodeICMPV4RegisterTests();
@@ -247,7 +247,7 @@ int RunUnittests(int list_unittests, char *regex_arg)
     DetectEngineHttpHRHRegisterTests();
     DetectEngineRegisterTests();
     SCLogRegisterTests();
-    SMTPParserRegisterTests();
+    //SMTPParserRegisterTests();
     MagicRegisterTests();
     UtilMiscRegisterTests();
     DetectAddressTests();

--- a/src/util-action.c
+++ b/src/util-action.c
@@ -1559,7 +1559,6 @@ void UtilActionRegisterTests(void) {
     /* Generic tests */
     UtRegisterTest("UtilActionTest01", UtilActionTest01, 1);
     UtRegisterTest("UtilActionTest02", UtilActionTest02, 1);
-    UtRegisterTest("UtilActionTest02", UtilActionTest02, 1);
     UtRegisterTest("UtilActionTest03", UtilActionTest03, 1);
     UtRegisterTest("UtilActionTest04", UtilActionTest04, 1);
     UtRegisterTest("UtilActionTest05", UtilActionTest05, 1);


### PR DESCRIPTION
Duplicate unittests removed.

https://buildbot.suricata-ids.org/builders/poona/builds/20
