### PR TITLE
Use unlikely in malloc failure test.

### DIFF
--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -129,7 +129,7 @@ void DNSSetEvent(DNSState *s, uint8_t e) {
  *  \retval tx or NULL */
 DNSTransaction *DNSTransactionAlloc(const uint16_t tx_id) {
     DNSTransaction *tx = SCMalloc(sizeof(DNSTransaction));
-    if (tx == NULL)
+    if (unlikely(tx == NULL))
         return NULL;
     memset(tx, 0x00, sizeof(DNSTransaction));
 
@@ -329,7 +329,7 @@ void DNSStoreQueryInState(DNSState *dns_state, const uint8_t *fqdn, const uint16
     }
 
     DNSQueryEntry *q = SCMalloc(sizeof(DNSQueryEntry) + fqdn_len);
-    if (q == NULL)
+    if (unlikely(q == NULL))
         return;
     q->type = type;
     q->class = class;
@@ -357,7 +357,7 @@ void DNSStoreAnswerInState(DNSState *dns_state, const int rtype, const uint8_t *
     }
 
     DNSAnswerEntry *q = SCMalloc(sizeof(DNSAnswerEntry) + fqdn_len + data_len);
-    if (q == NULL)
+    if (unlikely(q == NULL))
         return;
     q->type = type;
     q->class = class;

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2002,7 +2002,7 @@ static int HTPCallbackRequestLine(htp_tx_t *tx)
         return HTP_OK;
 
     tx_ud = SCMalloc(sizeof(*tx_ud));
-    if (tx_ud == NULL) {
+    if (unlikely(tx_ud == NULL)) {
         bstr_free(request_uri_normalized);
         return HTP_OK;
     }
@@ -2047,7 +2047,7 @@ static int HTPCallbackRequestHeaderData(htp_tx_data_t *tx_data)
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx_data->tx);
     if (tx_ud == NULL) {
         tx_ud = SCMalloc(sizeof(*tx_ud));
-        if (tx_ud == NULL)
+        if (unlikely(tx_ud == NULL))
             return HTP_OK;
         memset(tx_ud, 0, sizeof(*tx_ud));
         htp_tx_set_user_data(tx_data->tx, tx_ud);
@@ -2079,7 +2079,7 @@ static int HTPCallbackResponseHeaderData(htp_tx_data_t *tx_data)
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx_data->tx);
     if (tx_ud == NULL) {
         tx_ud = SCMalloc(sizeof(*tx_ud));
-        if (tx_ud == NULL)
+        if (unlikely(tx_ud == NULL))
             return HTP_OK;
         memset(tx_ud, 0, sizeof(*tx_ud));
         htp_tx_set_user_data(tx_data->tx, tx_ud);
@@ -4966,7 +4966,7 @@ libhtp:\n\
     HTPConfigure();
 
     httpbuf = SCMalloc(len);
-    if (httpbuf == NULL)
+    if (unlikely(httpbuf == NULL))
         goto end;
     memset(httpbuf, 0x00, len);
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1777,7 +1777,7 @@ static uint32_t AppLayerProbingParserGetMask(uint16_t al_proto)
 static inline AppLayerProbingParserElement *AllocAppLayerProbingParserElement(void)
 {
     AppLayerProbingParserElement *p = SCMalloc(sizeof(AppLayerProbingParserElement));
-    if (p == NULL) {
+    if (unlikely(p == NULL)) {
         exit(EXIT_FAILURE);
     }
     memset(p, 0, sizeof(AppLayerProbingParserElement));
@@ -1796,7 +1796,7 @@ static inline void DeAllocAppLayerProbingParserElement(AppLayerProbingParserElem
 static inline AppLayerProbingParserPort *AllocAppLayerProbingParserPort(void)
 {
     AppLayerProbingParserPort *p = SCMalloc(sizeof(AppLayerProbingParserPort));
-    if (p == NULL) {
+    if (unlikely(p == NULL)) {
         exit(EXIT_FAILURE);
     }
     memset(p, 0, sizeof(AppLayerProbingParserPort));
@@ -1830,7 +1830,7 @@ static inline void DeAllocAppLayerProbingParserPort(AppLayerProbingParserPort *p
 static inline AppLayerProbingParser *AllocAppLayerProbingParser(void)
 {
     AppLayerProbingParser *p = SCMalloc(sizeof(AppLayerProbingParser));
-    if (p == NULL) {
+    if (unlikely(p == NULL)) {
         exit(EXIT_FAILURE);
     }
     memset(p, 0, sizeof(AppLayerProbingParser));

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -2079,7 +2079,7 @@ int DetectContentParseTest41(void)
     DetectContentData *cd = NULL;
     int patlen = 257;
     char *teststring = SCMalloc(sizeof(char) * (patlen + 1));
-    if (teststring == NULL)
+    if (unlikely(teststring == NULL))
         return 0;
     int idx = 0;
     teststring[idx++] = '\"';
@@ -2106,7 +2106,7 @@ int DetectContentParseTest42(void)
     DetectContentData *cd = NULL;
     int patlen = 258;
     char *teststring = SCMalloc(sizeof(char) * (patlen + 1));
-    if (teststring == NULL)
+    if (unlikely(teststring == NULL))
         return 0;
     int idx = 0;
     teststring[idx++] = '\"';
@@ -2133,7 +2133,7 @@ int DetectContentParseTest43(void)
     DetectContentData *cd = NULL;
     int patlen = 260;
     char *teststring = SCMalloc(sizeof(char) * (patlen + 1));
-    if (teststring == NULL)
+    if (unlikely(teststring == NULL))
         return 0;
     int idx = 0;
     teststring[idx++] = '\"';
@@ -2164,7 +2164,7 @@ int DetectContentParseTest44(void)
     DetectContentData *cd = NULL;
     int patlen = 261;
     char *teststring = SCMalloc(sizeof(char) * (patlen + 1));
-    if (teststring == NULL)
+    if (unlikely(teststring == NULL))
         return 0;
     int idx = 0;
     teststring[idx++] = '\"';

--- a/src/detect-engine-hcbd.c
+++ b/src/detect-engine-hcbd.c
@@ -3502,7 +3502,7 @@ static int DetectEngineHttpClientBodyTest29(void)
 
 #define TOTAL_REQUESTS 45
     uint8_t *http_buf = SCMalloc(TOTAL_REQUESTS * strlen(request_buffer));
-    if (http_buf == NULL)
+    if (unlikely(http_buf == NULL))
         goto end;
     for (int i = 0; i < TOTAL_REQUESTS; i++) {
         memcpy(http_buf + i * strlen(request_buffer), request_buffer,

--- a/src/detect-engine-hhd.c
+++ b/src/detect-engine-hhd.c
@@ -157,7 +157,7 @@ static uint8_t *DetectEngineHHDGetBufferForTX(htp_tx_t *tx, uint64_t tx_id,
 
         /* the extra 4 bytes if for ": " and "\r\n" */
         headers_buffer = SCRealloc(headers_buffer, headers_buffer_len + size1 + size2 + 4);
-        if (headers_buffer == NULL) {
+        if (unlikely(headers_buffer == NULL)) {
             det_ctx->hhd_buffers[index] = NULL;
             det_ctx->hhd_buffers_len[index] = 0;
             goto end;

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -2838,7 +2838,7 @@ int DetectSetFastPatternAndItsId(DetectEngineCtx *de_ctx)
 
     /* array hash buffer - i've run out of ideas to name it */
     uint8_t *ahb = SCMalloc(sizeof(uint8_t) * (struct_total_size + content_total_size));
-    if (ahb == NULL)
+    if (unlikely(ahb == NULL))
         return -1;
 
     uint8_t *content = NULL;

--- a/src/detect-luajit-extensions.c
+++ b/src/detect-luajit-extensions.c
@@ -250,7 +250,7 @@ int LuajitSetFlowvar(lua_State *luastate) {
     }
 
     buffer = SCMalloc(len+1);
-    if (buffer == NULL) {
+    if (unlikely(buffer == NULL)) {
         lua_pushnil(luastate);
         lua_pushstring(luastate, "out of memory");
         return 2;

--- a/src/flow-storage.c
+++ b/src/flow-storage.c
@@ -174,7 +174,7 @@ static int FlowStorageTest02(void) {
     }
 
     void *ptr1a = SCMalloc(128);
-    if (ptr1a == NULL) {
+    if (unlikely(ptr1a == NULL)) {
         goto error;
     }
     FlowSetStorageById(f, id1, ptr1a);
@@ -230,13 +230,13 @@ static int FlowStorageTest03(void) {
     }
 
     void *ptr1a = SCMalloc(128);
-    if (ptr1a == NULL) {
+    if (unlikely(ptr1a == NULL)) {
         goto error;
     }
     FlowSetStorageById(f, id1, ptr1a);
 
     void *ptr2a = SCMalloc(256);
-    if (ptr2a == NULL) {
+    if (unlikely(ptr2a == NULL)) {
         goto error;
     }
     FlowSetStorageById(f, id2, ptr2a);

--- a/src/host-storage.c
+++ b/src/host-storage.c
@@ -173,7 +173,7 @@ static int HostStorageTest02(void) {
     }
 
     void *ptr1a = SCMalloc(128);
-    if (ptr1a == NULL) {
+    if (unlikely(ptr1a == NULL)) {
         goto error;
     }
     HostSetStorageById(h, id1, ptr1a);
@@ -228,13 +228,13 @@ static int HostStorageTest03(void) {
     }
 
     void *ptr1a = SCMalloc(128);
-    if (ptr1a == NULL) {
+    if (unlikely(ptr1a == NULL)) {
         goto error;
     }
     HostSetStorageById(h, id1, ptr1a);
 
     void *ptr2a = SCMalloc(256);
-    if (ptr2a == NULL) {
+    if (unlikely(ptr2a == NULL)) {
         goto error;
     }
     HostSetStorageById(h, id2, ptr2a);

--- a/src/runmode-tile.c
+++ b/src/runmode-tile.c
@@ -81,7 +81,7 @@ void *ParseMpipeConfig(const char *iface)
     char *copymodestr;
     char *out_iface = NULL;
 
-    if (aconf == NULL) {
+    if (unlikely(aconf == NULL)) {
         return NULL;
     }
 
@@ -202,14 +202,14 @@ int RunModeTileMpipeWorkers(DetectEngineCtx *de_ctx)
         } else {
             mpipe_devc = SCStrdup(mpipe_dev);
         }
-        if (mpipe_devc == NULL) {
+        if (unlikely(mpipe_devc == NULL)) {
             printf("ERROR: SCStrdup failed for ReceiveMpipe\n");
             exit(EXIT_FAILURE);
         }
 
         snprintf(tname, sizeof(tname), "Worker%d", pipe+1);
         thread_name = SCStrdup(tname);
-        if (thread_name == NULL) {
+        if (unlikely(thread_name == NULL)) {
             printf("ERROR: SCStrdup failed for ReceiveMpipe\n");
             exit(EXIT_FAILURE);
         }

--- a/src/source-mpipe.c
+++ b/src/source-mpipe.c
@@ -787,7 +787,7 @@ TmEcode ReceiveMpipeThreadInit(ThreadVars *tv, void *initdata, void **data)
     }
 
     MpipeThreadVars *ptv = SCMalloc(sizeof(MpipeThreadVars));
-    if (ptv == NULL)
+    if (unlikely(ptv == NULL))
         SCReturnInt(TM_ECODE_FAILED);
 
     memset(ptv, 0, sizeof(MpipeThreadVars));
@@ -863,7 +863,7 @@ TmEcode ReceiveMpipeThreadInit(ThreadVars *tv, void *initdata, void **data)
 
     /* Allocate some ingress queues. */
     iqueues = SCCalloc(num_workers, sizeof(*iqueues));
-    if (iqueues == NULL)
+    if (unlikely(iqueues == NULL))
         SCReturnInt(TM_ECODE_FAILED);
 
     /* Allocate some NotifRings. */
@@ -984,7 +984,7 @@ TmEcode DecodeMpipe(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq,
 int MpipeLiveRegisterDevice(char *dev)
 {
     MpipeDevice *nd = SCMalloc(sizeof(MpipeDevice));
-    if (nd == NULL) {
+    if (unlikely(nd == NULL)) {
         return -1;
     }
 

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -156,9 +156,8 @@ TmEcode NapatechStreamThreadInit(ThreadVars *tv, void *initdata, void **data)
     SCLogInfo("Napatech  Thread Stream ID:%lu", stream_id);
 
     NapatechThreadVars *ntv = SCMalloc(sizeof(NapatechThreadVars));
-    if (ntv == NULL) {
-        SCLogError(SC_ERR_MEM_ALLOC,
-                "Failed to allocate memory for NAPATECH  thread vars.");
+    if (unlikely(ntv == NULL)) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate memory for NAPATECH  thread vars.");
         exit(EXIT_FAILURE);
     }
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1054,7 +1054,7 @@ int StreamTcp3whsQueueSynAck(TcpSession *ssn, Packet *p) {
     }
 
     TcpStateQueue *q = SCMalloc(sizeof(*q));
-    if (q == NULL) {
+    if (unlikely(q == NULL)) {
         SCLogDebug("ssn %p: =~ SYN/ACK queue failed: alloc failed", ssn);
         return -1;
     }

--- a/src/util-cuda-buffer.c
+++ b/src/util-cuda-buffer.c
@@ -382,7 +382,7 @@ CudaBufferData *CudaBufferRegisterNew(uint8_t *d_buffer, uint32_t d_buffer_len,
     }
 
     CudaBufferData *new = SCMalloc(sizeof(CudaBufferData));
-    if (new == NULL) {
+    if (unlikely(new == NULL)) {
         return NULL;
     }
     memset(new, 0, sizeof(CudaBufferData));
@@ -406,7 +406,7 @@ CudaBufferData *CudaBufferRegisterNew(uint8_t *d_buffer, uint32_t d_buffer_len,
 static void *CudaBufferSlicePoolAlloc(void *null)
 {
     void *ptr = SCMalloc(sizeof(CudaBufferSlice));
-    if (ptr == NULL)
+    if (unlikely(ptr == NULL))
         return NULL;
     memset(ptr, 0, sizeof(CudaBufferSlice));
 

--- a/src/util-cuda-handlers.c
+++ b/src/util-cuda-handlers.c
@@ -83,7 +83,7 @@ void CudaHandlerAddCudaProfileFromConf(const char *name,
     }
 
     CudaHandlerConfProfile *new_cp = SCMalloc(sizeof(CudaHandlerConfProfile));
-    if (new_cp == NULL)
+    if (unlikely(new_cp == NULL))
         exit(EXIT_FAILURE);
     memset(new_cp, 0, sizeof(CudaHandlerConfProfile));
     new_cp->name = SCStrdup(name);
@@ -188,7 +188,7 @@ CUcontext CudaHandlerModuleGetContext(const char *name, int device_id)
     }
 
     CudaHandlerModule *new_module = SCMalloc(sizeof(CudaHandlerModule));
-    if (new_module == NULL)
+    if (unlikely(new_module == NULL))
         exit(EXIT_FAILURE);
     memset(new_module, 0, sizeof(CudaHandlerModule));
     new_module->device_id = device_id;
@@ -204,7 +204,7 @@ CUcontext CudaHandlerModuleGetContext(const char *name, int device_id)
 
     if (no_of_cuda_contexts <= device_id) {
         cuda_contexts = SCRealloc(cuda_contexts, sizeof(CUcontext) * (device_id + 1));
-        if (cuda_contexts == NULL)
+        if (unlikely(cuda_contexts == NULL))
             exit(EXIT_FAILURE);
         memset(cuda_contexts + no_of_cuda_contexts, 0,
                sizeof(CUcontext) * ((device_id + 1) - no_of_cuda_contexts));
@@ -253,7 +253,7 @@ void CudaHandlerModuleStoreData(const char *module_name,
     }
 
     CudaHandlerModuleData *new_data = SCMalloc(sizeof(CudaHandlerModuleData));
-    if (new_data == NULL)
+    if (unlikely(new_data == NULL))
         exit(EXIT_FAILURE);
     memset(new_data, 0, sizeof(CudaHandlerModuleData));
     new_data->name = SCStrdup(data_name);

--- a/src/util-cuda.c
+++ b/src/util-cuda.c
@@ -796,7 +796,7 @@ int SCCudaDeviceTotalMem(size_t *bytes, CUdevice dev)
 static SCCudaDevice *SCCudaAllocSCCudaDevice(void)
 {
     SCCudaDevice *device = SCMalloc(sizeof(SCCudaDevice));
-    if (device == NULL)
+    if (unlikely(device == NULL))
         return NULL;
     memset(device, 0 , sizeof(SCCudaDevice));
 
@@ -825,7 +825,7 @@ static void SCCudaDeAllocSCCudaDevice(SCCudaDevice *device)
 static SCCudaDevices *SCCudaAllocSCCudaDevices(void)
 {
     SCCudaDevices *devices = SCMalloc(sizeof(SCCudaDevices));
-    if (devices == NULL)
+    if (unlikely(devices == NULL))
         return NULL;
     memset(devices, 0 , sizeof(SCCudaDevices));
 

--- a/src/util-magic.c
+++ b/src/util-magic.c
@@ -105,7 +105,7 @@ char *MagicGlobalLookup(uint8_t *buf, uint32_t buflen)
         result = magic_buffer(g_magic_ctx, (void *)buf, (size_t)buflen);
         if (result != NULL) {
             magic = SCStrdup(result);
-            if (magic == NULL) {
+            if (unlikely(magic == NULL)) {
                 SCLogError(SC_ERR_MEM_ALLOC, "Unable to dup magic");
             }
         }
@@ -132,7 +132,7 @@ char *MagicThreadLookup(magic_t *ctx, uint8_t *buf, uint32_t buflen)
         result = magic_buffer(*ctx, (void *)buf, (size_t)buflen);
         if (result != NULL) {
             magic = SCStrdup(result);
-            if (magic == NULL) {
+            if (unlikely(magic == NULL)) {
                 SCLogError(SC_ERR_MEM_ALLOC, "Unable to dup magic");
             }
         }

--- a/src/util-mpm-ac-tile.c
+++ b/src/util-mpm-ac-tile.c
@@ -826,7 +826,7 @@ static inline void SCACTileCreateDeltaTable(MpmCtx *mpm_ctx)
         }
         int size = ctx->state_count * sizeof(SC_AC_TILE_STATE_TYPE_U16) * alpha_size;
         SC_AC_TILE_STATE_TYPE_U16 *state_table = SCMalloc(size);
-        if (state_table == NULL) {
+        if (unlikely(state_table == NULL)) {
             SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
             exit(EXIT_FAILURE);
         }

--- a/src/util-mpm.c
+++ b/src/util-mpm.c
@@ -144,7 +144,7 @@ int32_t MpmFactoryRegisterMpmCtxProfile(DetectEngineCtx *de_ctx, const char *nam
         /* let's make the new entry */
         items = SCRealloc(items,
                           (de_ctx->mpm_ctx_factory_container->no_of_items + 1) * sizeof(MpmCtxFactoryItem));
-        if (items == NULL) {
+        if (unlikely(items == NULL)) {
             SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
             exit(EXIT_FAILURE);
         }
@@ -283,7 +283,7 @@ static void *MpmCudaConfParse(ConfNode *node)
     const char *value;
 
     MpmCudaConf *conf = SCMalloc(sizeof(MpmCudaConf));
-    if (conf == NULL)
+    if (unlikely(conf == NULL))
         exit(EXIT_FAILURE);
     memset(conf, 0, sizeof(*conf));
 

--- a/src/util-pool-thread.c
+++ b/src/util-pool-thread.c
@@ -46,7 +46,7 @@ PoolThread *PoolThreadInit(int threads, uint32_t size, uint32_t prealloc_size, u
     }
 
     pt = SCMalloc(sizeof(*pt));
-    if (pt == NULL) {
+    if (unlikely(pt == NULL)) {
         SCLogDebug("memory alloc error");
         goto error;
     }

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -299,7 +299,7 @@ char *RunmodeAutoFpCreatePickupQueuesString(int n) {
     char qname[TM_QUEUE_NAME_MAX];
 
     queues = SCMalloc(queues_size);
-    if (queues == NULL) {
+    if (unlikely(queues == NULL)) {
         SCLogError(SC_ERR_MEM_ALLOC, "failed to alloc queues buffer: %s", strerror(errno));
         return NULL;
     }

--- a/src/util-storage.c
+++ b/src/util-storage.c
@@ -114,7 +114,7 @@ int StorageRegister(const StorageEnum type, const char *name, const unsigned int
     }
 
     StorageList *entry = SCMalloc(sizeof(StorageList));
-    if (entry == NULL)
+    if (unlikely(entry == NULL))
         return -1;
 
     memset(entry, 0x00, sizeof(StorageList));
@@ -147,7 +147,7 @@ int StorageFinalize(void)
         return 0;
 
     storage_map = SCMalloc(sizeof(StorageMapping *) * STORAGE_MAX);
-    if (storage_map == NULL) {
+    if (unlikely(storage_map == NULL)) {
         return -1;
     }
     memset(storage_map, 0x00, sizeof(StorageMapping *) * STORAGE_MAX);
@@ -258,8 +258,8 @@ void *StorageAllocById(Storage **storage, StorageEnum type, int id)
     Storage *store = *storage;
     if (store == NULL) {
         store = SCMalloc(sizeof(void *) * storage_max_id[type]);
-        if (store == NULL)
-            return NULL;
+        if (unlikely(store == NULL))
+        return NULL;
         memset(store, 0x00, sizeof(void *) * storage_max_id[type]);
     }
     SCLogDebug("store %p", store);

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -1154,7 +1154,7 @@ void SCThresholdConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
             else
                 line = SCRealloc(line, strlen(line) + len + 1);
 
-            if (line == NULL) {
+            if (unlikely(line == NULL)) {
                 SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
                 break;
             }


### PR DESCRIPTION
This patch is a result of applying the following coccinelle
transformation to suricata sources:

  @istested@
  identifier x;
  statement S1;
  identifier func =~ "(SCMalloc|SCStrdup|SCCalloc|SCMallocAligned|SCRealloc)";
  @@

  x = func(...)
  ... when != x
- if (x == NULL) S1
- if (unlikely(x == NULL)) S1

PR build: https://buildbot.suricata-ids.org/builders/regit/builds/47
