### PR TITLE
Optimizations to reduce branch misses

### DIFF
--- a/src/alert-unified2-alert.c
+++ b/src/alert-unified2-alert.c
@@ -406,7 +406,7 @@ TmEcode Unified2Alert (ThreadVars *t, Packet *p, void *data, PacketQueue *pq, Pa
     Unified2AlertThread *aun = (Unified2AlertThread *)data;
     aun->xff_flags = UNIFIED2_ALERT_XFF_DISABLED;
 
-    if (p->alerts.cnt == 0 && !(p->flags & PKT_HAS_TAG))
+    if (likely(p->alerts.cnt == 0 && !(p->flags & PKT_HAS_TAG)))
         return TM_ECODE_OK;
 
     /* overwrite mode can only work per u2 block, not per individual
@@ -878,16 +878,18 @@ int Unified2IPv6TypeAlert (ThreadVars *t, Packet *p, void *data, PacketQueue *pq
 {
     Unified2AlertThread *aun = (Unified2AlertThread *)data;
     Unified2AlertFileHeader hdr;
-    AlertIPv6Unified2 *phdr = (AlertIPv6Unified2 *)(aun->data +
-                                sizeof(Unified2AlertFileHeader));
+    AlertIPv6Unified2 *phdr;
     AlertIPv6Unified2 gphdr;
     PacketAlert *pa;
     int offset, length;
     int ret;
     unsigned int event_id;
 
-    if (p->alerts.cnt == 0 && !(p->flags & PKT_HAS_TAG))
+    if (likely(p->alerts.cnt == 0 && !(p->flags & PKT_HAS_TAG)))
         return 0;
+
+    phdr = (AlertIPv6Unified2 *)(aun->data +
+                                sizeof(Unified2AlertFileHeader));
 
     length = (sizeof(Unified2AlertFileHeader) + sizeof(AlertIPv6Unified2));
     offset = length;
@@ -1062,16 +1064,18 @@ int Unified2IPv4TypeAlert (ThreadVars *tv, Packet *p, void *data, PacketQueue *p
 {
     Unified2AlertThread *aun = (Unified2AlertThread *)data;
     Unified2AlertFileHeader hdr;
-    AlertIPv4Unified2 *phdr = (AlertIPv4Unified2 *)(aun->data +
-                                sizeof(Unified2AlertFileHeader));
+    AlertIPv4Unified2 *phdr;
     AlertIPv4Unified2 gphdr;
     PacketAlert *pa;
     int offset, length;
     int ret;
     unsigned int event_id;
 
-    if (p->alerts.cnt == 0 && !(p->flags & PKT_HAS_TAG))
+    if (likely(p->alerts.cnt == 0 && !(p->flags & PKT_HAS_TAG)))
         return 0;
+
+    phdr = (AlertIPv4Unified2 *)(aun->data +
+                                sizeof(Unified2AlertFileHeader));
 
     length = (sizeof(Unified2AlertFileHeader) + sizeof(AlertIPv4Unified2));
     offset = length;

--- a/src/decode-ethernet.c
+++ b/src/decode-ethernet.c
@@ -42,13 +42,13 @@ void DecodeEthernet(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *p
 {
     SCPerfCounterIncr(dtv->counter_eth, tv->sc_perf_pca);
 
-    if (len < ETHERNET_HEADER_LEN) {
+    if (unlikely(len < ETHERNET_HEADER_LEN)) {
         ENGINE_SET_EVENT(p,ETHERNET_PKT_TOO_SMALL);
         return;
     }
 
     p->ethh = (EthernetHdr *)pkt;
-    if (p->ethh == NULL)
+    if (unlikely(p->ethh == NULL))
         return;
 
     SCLogDebug("p %p pkt %p ether type %04x", p, pkt, ntohs(p->ethh->eth_type));

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -88,9 +88,9 @@ static void DecodeIP6inIP6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uin
         return;
     }
     if (IP_GET_RAW_VER(pkt) == 6) {
-        if (pq != NULL) {
+        if (unlikely(pq != NULL)) {
             Packet *tp = PacketPseudoPktSetup(p, pkt, plen, IPPROTO_IPV6);
-            if (tp != NULL) {
+            if (unlikely(tp != NULL)) {
                 PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV6);
                 DecodeTunnel(tv, dtv, tp, GET_PKT_DATA(tp),
                              GET_PKT_LEN(tp), pq, IPPROTO_IPV6);
@@ -504,11 +504,11 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
 
 static int DecodeIPV6Packet (ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len)
 {
-    if (len < IPV6_HEADER_LEN) {
+    if (unlikely(len < IPV6_HEADER_LEN)) {
         return -1;
     }
 
-    if (IP_GET_RAW_VER(pkt) != 6) {
+    if (unlikely(IP_GET_RAW_VER(pkt) != 6)) {
         SCLogDebug("wrong ip version %" PRIu8 "",IP_GET_RAW_VER(pkt));
         ENGINE_SET_EVENT(p,IPV6_WRONG_IP_VER);
         return -1;
@@ -516,7 +516,7 @@ static int DecodeIPV6Packet (ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, u
 
     p->ip6h = (IPV6Hdr *)pkt;
 
-    if (len < (IPV6_HEADER_LEN + IPV6_GET_PLEN(p)))
+    if (unlikely(len < (IPV6_HEADER_LEN + IPV6_GET_PLEN(p))))
     {
         ENGINE_SET_EVENT(p,IPV6_TRUNC_PKT);
         return -1;
@@ -536,7 +536,7 @@ void DecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, 
 
     /* do the actual decoding */
     ret = DecodeIPV6Packet (tv, dtv, p, pkt, len);
-    if (ret < 0) {
+    if (unlikely(ret < 0)) {
         p->ip6h = NULL;
         return;
     }

--- a/src/decode-raw.c
+++ b/src/decode-raw.c
@@ -48,7 +48,7 @@ void DecodeRaw(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, u
     SCPerfCounterIncr(dtv->counter_raw, tv->sc_perf_pca);
 
     /* If it is ipv4 or ipv6 it should at least be the size of ipv4 */
-    if (len < IPV4_HEADER_LEN) {
+    if (unlikely(len < IPV4_HEADER_LEN)) {
         ENGINE_SET_EVENT(p,IPV4_PKT_TOO_SMALL);
         return;
     }

--- a/src/decode-sll.c
+++ b/src/decode-sll.c
@@ -40,13 +40,13 @@ void DecodeSll(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, u
 {
     SCPerfCounterIncr(dtv->counter_sll, tv->sc_perf_pca);
 
-    if (len < SLL_HEADER_LEN) {
+    if (unlikely(len < SLL_HEADER_LEN)) {
         ENGINE_SET_EVENT(p,SLL_PKT_TOO_SMALL);
         return;
     }
 
     SllHdr *sllh = (SllHdr *)pkt;
-    if (sllh == NULL)
+    if (unlikely(sllh == NULL))
         return;
 
     SCLogDebug("p %p pkt %p sll_protocol %04x", p, pkt, ntohs(sllh->sll_protocol));

--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -63,7 +63,7 @@ static int DecodeTCPOptions(Packet *p, uint8_t *pkt, uint16_t len)
             /* we already know that the total options len is valid,
              * so here the len of the specific option must be bad.
              * Also check for invalid lengths 0 and 1. */
-            if (*(pkt+1) > plen || *(pkt+1) < 2) {
+            if (unlikely(*(pkt+1) > plen || *(pkt+1) < 2)) {
                 ENGINE_SET_EVENT(p,TCP_OPT_INVALID_LEN);
                 return -1;
             }

--- a/src/decode.c
+++ b/src/decode.c
@@ -168,7 +168,7 @@ Packet *PacketGetFromQueueOrAlloc(void)
  */
 inline int PacketCopyDataOffset(Packet *p, int offset, uint8_t *data, int datalen)
 {
-    if (offset + datalen > MAX_PAYLOAD_SIZE) {
+    if (unlikely(offset + datalen > MAX_PAYLOAD_SIZE)) {
         /* too big */
         return -1;
     }
@@ -181,7 +181,7 @@ inline int PacketCopyDataOffset(Packet *p, int offset, uint8_t *data, int datale
         } else {
             /* here we need a dynamic allocation */
             p->ext_pkt = SCMalloc(MAX_PAYLOAD_SIZE);
-            if (p->ext_pkt == NULL) {
+            if (unlikely(p->ext_pkt == NULL)) {
                 SET_PKT_LEN(p, 0);
                 return -1;
             }
@@ -225,7 +225,7 @@ Packet *PacketPseudoPktSetup(Packet *parent, uint8_t *pkt, uint16_t len, uint8_t
 
     /* get us a packet */
     Packet *p = PacketGetFromQueueOrAlloc();
-    if (p == NULL) {
+    if (unlikely(p == NULL)) {
         SCReturnPtr(NULL, "Packet");
     }
 
@@ -279,7 +279,7 @@ Packet *PacketDefragPktSetup(Packet *parent, uint8_t *pkt, uint16_t len, uint8_t
 
     /* get us a packet */
     Packet *p = PacketGetFromQueueOrAlloc();
-    if (p == NULL) {
+    if (unlikely(p == NULL)) {
         SCReturnPtr(NULL, "Packet");
     }
 
@@ -454,7 +454,7 @@ DecodeThreadVars *DecodeThreadVarsAlloc()
 inline int PacketSetData(Packet *p, uint8_t *pktdata, int pktlen)
 {
     SET_PKT_LEN(p, (size_t)pktlen);
-    if (!pktdata) {
+    if (unlikely(!pktdata)) {
         return -1;
     }
     p->ext_pkt = pktdata;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4763,23 +4763,23 @@ int StreamTcpGetFlowState(void *s)
     SCEnter();
 
     TcpSession *ssn = (TcpSession *)s;
-    if (ssn == NULL) {
+    if (unlikely(ssn == NULL)) {
         SCReturnInt(FLOW_STATE_CLOSED);
     }
 
+    /* sorted most likely to least likely */
     switch(ssn->state) {
-        case TCP_NONE:
-        case TCP_SYN_SENT:
-        case TCP_SYN_RECV:
-        case TCP_LISTEN:
-            SCReturnInt(FLOW_STATE_NEW);
-
         case TCP_ESTABLISHED:
         case TCP_FIN_WAIT1:
         case TCP_FIN_WAIT2:
         case TCP_CLOSING:
         case TCP_CLOSE_WAIT:
             SCReturnInt(FLOW_STATE_ESTABLISHED);
+        case TCP_NONE:
+        case TCP_SYN_SENT:
+        case TCP_SYN_RECV:
+        case TCP_LISTEN:
+            SCReturnInt(FLOW_STATE_NEW);
         case TCP_LAST_ACK:
         case TCP_TIME_WAIT:
         case TCP_CLOSED:


### PR DESCRIPTION
"perf top -e branch-misses" showed that the decoders had quite a few misses in the error checks. After adding unlikely to these, the funcs no longer show this many misses.

https://buildbot.suricata-ids.org/builders/inliniac/builds/32
