### PR TITLE
Give Suricata priority to receive packets over Linux with mPIPE.

### DIFF
--- a/src/source-mpipe.c
+++ b/src/source-mpipe.c
@@ -694,6 +694,8 @@ static int ReceiveMpipeRegisterRules(int bucket, int num_buckets)
     gxio_mpipe_rules_t rules;
     gxio_mpipe_rules_init(&rules, context);
     gxio_mpipe_rules_begin(&rules, bucket, num_buckets, NULL);
+    /* Give Suricata priority over Linux to receive packets. */
+    gxio_mpipe_rules_set_priority(&rules, -100);
     return gxio_mpipe_rules_commit(&rules);
 }
 


### PR DESCRIPTION
When installing the rules to tell mPIPE to send packet to Suricata,
give Suricata a higher priority than the default priority used by Linux. This way if
Linux also tells mPIPE to send it packets, Suricata will get them
instead, as long as Suricata is running.

https://buildbot.suricata-ids.org/builders/ken-tilera/builds/42
