### PR TITLE
In AC MPM union pointers to state table data

### DIFF
--- a/src/util-mpm-ac-tile.h
+++ b/src/util-mpm-ac-tile.h
@@ -66,10 +66,13 @@ typedef struct SCACTileCtx_ {
     /* Convert input character to matching alphabet */
     uint8_t translate_table[256];
 
-    /* the all important memory hungry state_table */
-    SC_AC_TILE_STATE_TYPE_U16 *state_table_u16;
-    /* the all important memory hungry state_table */
-    SC_AC_TILE_STATE_TYPE_U32 (*state_table_u32)[256];
+    /* Only one state tatble is used for each MPM */
+    union {
+        /* the all important memory hungry state_table */
+        SC_AC_TILE_STATE_TYPE_U16 *state_table_u16;
+        /* the all important memory hungry state_table */
+        SC_AC_TILE_STATE_TYPE_U32 (*state_table_u32)[256];
+    };
 
     /* Specialized search function based on size of data in delta
      * tables.  The alphabet size determines address shifting and the

--- a/src/util-mpm-ac.h
+++ b/src/util-mpm-ac.h
@@ -73,10 +73,14 @@ typedef struct SCACCtx_ {
 
     /* no of states used by ac */
     uint32_t state_count;
-    /* the all important memory hungry state_table */
-    SC_AC_STATE_TYPE_U16 (*state_table_u16)[256];
-    /* the all important memory hungry state_table */
-    SC_AC_STATE_TYPE_U32 (*state_table_u32)[256];
+
+    /* Only one state tatble is used for each MPM */
+    union {
+        /* the all important memory hungry state_table */
+        SC_AC_STATE_TYPE_U16 (*state_table_u16)[256];
+        /* the all important memory hungry state_table */
+        SC_AC_STATE_TYPE_U32 (*state_table_u32)[256];
+    };
 
     /* goto_table, failure table and output table.  Needed to create state_table.
      * Will be freed, once we have created the state_table */


### PR DESCRIPTION
The MPM for AC has separate pointers for the state table data for
16-bit states and 32-bit states. Only one is used, so union them
together to save space. Saves 8 bytes per MPM matcher

https://buildbot.suricata-ids.org/builders/ken-tilera/builds/43
