### PR TITLE
detect: only inspect smsg for valid tcp packets

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -706,7 +706,7 @@ static StreamMsg *SigMatchSignaturesGetSmsg(Flow *f, Packet *p, uint8_t flags) {
 
     StreamMsg *smsg = NULL;
 
-    if (p->proto == IPPROTO_TCP && f->protoctx != NULL) {
+    if (p->proto == IPPROTO_TCP && f->protoctx != NULL && (p->flags & PKT_STREAM_EST)) {
         TcpSession *ssn = (TcpSession *)f->protoctx;
 
         /* at stream eof, or in inline mode, inspect all smsg's */


### PR DESCRIPTION
Packets that are rejected by the stream engine are not considered
part of an established tcp session. By allowing them to inspect
an smsg, some smsgs would not be properly inspected.

https://buildbot.suricata-ids.org/builders/inliniac/builds/46
