### PR TITLE
Share Packet checksum values for TCP, UDP, IPv6. ICMPv4 and ICMPv6

### DIFF
--- a/src/decode-icmpv4.h
+++ b/src/decode-icmpv4.h
@@ -177,9 +177,6 @@ typedef struct ICMPV4ExtHdr_
 /* ICMPv4 vars */
 typedef struct ICMPV4Vars_
 {
-    /* checksum computed over the icmpv4 packet */
-    int32_t comp_csum;
-
     uint16_t  id;
     uint16_t  seq;
     uint32_t  mtu;
@@ -203,7 +200,7 @@ typedef struct ICMPV4Vars_
 } ICMPV4Vars;
 
 #define CLEAR_ICMPV4_PACKET(p) do { \
-    (p)->icmpv4vars.comp_csum = -1; \
+    (p)->comp_csum = -1; \
     (p)->icmpv4vars.id = 0; \
     (p)->icmpv4vars.seq = 0; \
     (p)->icmpv4vars.mtu = 0; \

--- a/src/decode-icmpv6.h
+++ b/src/decode-icmpv6.h
@@ -127,9 +127,6 @@ typedef struct ICMPV6Hdr_
 
 /** Data available from the decoded packet */
 typedef struct ICMPV6Vars_ {
-    /* checksum computed over the icmpv6 packet */
-    int32_t comp_csum;
-
     /* checksum of the icmpv6 packet */
     uint16_t  id;
     uint16_t  seq;
@@ -155,7 +152,7 @@ typedef struct ICMPV6Vars_ {
 
 
 #define CLEAR_ICMPV6_PACKET(p) do { \
-    (p)->icmpv6vars.comp_csum = -1; \
+    (p)->comp_csum = -1; \
     (p)->icmpv6vars.id = 0; \
     (p)->icmpv6vars.seq = 0; \
     (p)->icmpv6vars.mtu = 0; \

--- a/src/decode-tcp.h
+++ b/src/decode-tcp.h
@@ -140,9 +140,6 @@ typedef struct TCPHdr_
 
 typedef struct TCPVars_
 {
-    /* checksum computed over the tcp(for both ipv4 and ipv6) packet */
-    int32_t comp_csum;
-
     uint8_t tcp_opt_cnt;
     TCPOpt tcp_opts[TCP_OPTMAX];
 
@@ -156,7 +153,7 @@ typedef struct TCPVars_
 
 #define CLEAR_TCP_PACKET(p) { \
     (p)->tcph = NULL; \
-    (p)->tcpvars.comp_csum = -1; \
+    (p)->comp_csum = -1; \
     (p)->tcpvars.tcp_opt_cnt = 0; \
     (p)->tcpvars.ts = NULL; \
     (p)->tcpvars.sack = NULL; \

--- a/src/decode-udp.h
+++ b/src/decode-udp.h
@@ -46,13 +46,11 @@ typedef struct UDPHdr_
 
 typedef struct UDPVars_
 {
-    /* checksum computed over the udp(for both ipv4 and ipv6) packet */
-    int32_t comp_csum;
 } UDPVars;
 
 #define CLEAR_UDP_PACKET(p) do { \
     (p)->udph = NULL; \
-    (p)->udpvars.comp_csum = -1; \
+    (p)->comp_csum = -1; \
 } while (0)
 
 void DecodeUDPV4RegisterTests(void);

--- a/src/decode.h
+++ b/src/decode.h
@@ -427,6 +427,9 @@ typedef struct Packet_
     /* header pointers */
     EthernetHdr *ethh;
 
+    /* Check sum for TCP, UDP or ICMP packets */
+    int32_t comp_csum;
+
     IPV4Hdr *ip4h;
     IPV4Vars ip4vars;
 
@@ -610,10 +613,7 @@ typedef struct DecodeThreadVars_
  */
 #define PACKET_RESET_CHECKSUMS(p) do { \
         (p)->ip4vars.comp_csum = -1;   \
-        (p)->tcpvars.comp_csum = -1;      \
-        (p)->udpvars.comp_csum = -1;      \
-        (p)->icmpv4vars.comp_csum = -1;   \
-        (p)->icmpv6vars.comp_csum = -1;   \
+        (p)->comp_csum = -1;   \
     } while (0)
 
 /**

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -335,14 +335,14 @@ int DetectTCPV4CsumMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->tcpvars.comp_csum == -1)
-        p->tcpvars.comp_csum = TCPCalculateChecksum(p->ip4h->s_ip_addrs,
-                                                 (uint16_t *)p->tcph,
-                                                 (p->payload_len + TCP_GET_HLEN(p)));
+    if (p->comp_csum == -1)
+        p->comp_csum = TCPCalculateChecksum(p->ip4h->s_ip_addrs,
+                                            (uint16_t *)p->tcph,
+                                            (p->payload_len + TCP_GET_HLEN(p)));
 
-    if (p->tcpvars.comp_csum == p->tcph->th_sum && cd->valid == 1)
+    if (p->comp_csum == p->tcph->th_sum && cd->valid == 1)
         return 1;
-    else if (p->tcpvars.comp_csum != p->tcph->th_sum && cd->valid == 0)
+    else if (p->comp_csum != p->tcph->th_sum && cd->valid == 0)
         return 1;
     else
         return 0;
@@ -430,14 +430,14 @@ int DetectTCPV6CsumMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->tcpvars.comp_csum == -1)
-        p->tcpvars.comp_csum = TCPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
-                                                   (uint16_t *)p->tcph,
-                                                   (p->payload_len + TCP_GET_HLEN(p)));
+    if (p->comp_csum == -1)
+        p->comp_csum = TCPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
+                                              (uint16_t *)p->tcph,
+                                              (p->payload_len + TCP_GET_HLEN(p)));
 
-    if (p->tcpvars.comp_csum == p->tcph->th_sum && cd->valid == 1)
+    if (p->comp_csum == p->tcph->th_sum && cd->valid == 1)
         return 1;
-    else if (p->tcpvars.comp_csum != p->tcph->th_sum && cd->valid == 0)
+    else if (p->comp_csum != p->tcph->th_sum && cd->valid == 0)
         return 1;
     else
         return 0;
@@ -525,15 +525,15 @@ int DetectUDPV4CsumMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->udpvars.comp_csum == -1)
-        p->udpvars.comp_csum = UDPV4CalculateChecksum(p->ip4h->s_ip_addrs,
-                                                   (uint16_t *)p->udph,
-                                                   (p->payload_len +
-                                                    UDP_HEADER_LEN) );
+    if (p->comp_csum == -1)
+        p->comp_csum = UDPV4CalculateChecksum(p->ip4h->s_ip_addrs,
+                                              (uint16_t *)p->udph,
+                                              (p->payload_len +
+                                               UDP_HEADER_LEN) );
 
-    if (p->udpvars.comp_csum == p->udph->uh_sum && cd->valid == 1)
+    if (p->comp_csum == p->udph->uh_sum && cd->valid == 1)
         return 1;
-    else if (p->udpvars.comp_csum != p->udph->uh_sum && cd->valid == 0)
+    else if (p->comp_csum != p->udph->uh_sum && cd->valid == 0)
         return 1;
     else
         return 0;
@@ -621,15 +621,15 @@ int DetectUDPV6CsumMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->udpvars.comp_csum == -1)
-        p->udpvars.comp_csum = UDPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
-                                                   (uint16_t *)p->udph,
-                                                   (p->payload_len +
-                                                    UDP_HEADER_LEN) );
+    if (p->comp_csum == -1)
+        p->comp_csum = UDPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
+                                              (uint16_t *)p->udph,
+                                              (p->payload_len +
+                                               UDP_HEADER_LEN) );
 
-    if (p->udpvars.comp_csum == p->udph->uh_sum && cd->valid == 1)
+    if (p->comp_csum == p->udph->uh_sum && cd->valid == 1)
         return 1;
-    else if (p->udpvars.comp_csum != p->udph->uh_sum && cd->valid == 0)
+    else if (p->comp_csum != p->udph->uh_sum && cd->valid == 0)
         return 1;
     else
         return 0;
@@ -717,14 +717,14 @@ int DetectICMPV4CsumMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->icmpv4vars.comp_csum == -1)
-        p->icmpv4vars.comp_csum = ICMPV4CalculateChecksum((uint16_t *)p->icmpv4h,
-                                                       ntohs(IPV4_GET_RAW_IPLEN(p->ip4h)) -
-                                                       IPV4_GET_RAW_HLEN(p->ip4h) * 4);
+    if (p->comp_csum == -1)
+        p->comp_csum = ICMPV4CalculateChecksum((uint16_t *)p->icmpv4h,
+                                               ntohs(IPV4_GET_RAW_IPLEN(p->ip4h)) -
+                                               IPV4_GET_RAW_HLEN(p->ip4h) * 4);
 
-    if (p->icmpv4vars.comp_csum == p->icmpv4h->checksum && cd->valid == 1)
+    if (p->comp_csum == p->icmpv4h->checksum && cd->valid == 1)
         return 1;
-    else if (p->icmpv4vars.comp_csum != p->icmpv4h->checksum && cd->valid == 0)
+    else if (p->comp_csum != p->icmpv4h->checksum && cd->valid == 0)
         return 1;
     else
         return 0;
@@ -814,14 +814,14 @@ int DetectICMPV6CsumMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->icmpv6vars.comp_csum == -1)
-        p->icmpv6vars.comp_csum = ICMPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
+    if (p->comp_csum == -1)
+        p->comp_csum = ICMPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
                                                           (uint16_t *)p->icmpv6h,
                                                           GET_PKT_LEN(p) - ((uint8_t *)p->icmpv6h - GET_PKT_DATA(p)));
 
-    if (p->icmpv6vars.comp_csum == p->icmpv6h->csum && cd->valid == 1)
+    if (p->comp_csum == p->icmpv6h->csum && cd->valid == 1)
         return 1;
-    else if (p->icmpv6vars.comp_csum != p->icmpv6h->csum && cd->valid == 0)
+    else if (p->comp_csum != p->icmpv6h->csum && cd->valid == 0)
         return 1;
     else
         return 0;

--- a/src/detect.c
+++ b/src/detect.c
@@ -6560,8 +6560,8 @@ int SigTest24IPV4Keyword(void)
     p1->pkt = (uint8_t *)(p1 + 1);
     memset(p2, 0, SIZE_OF_PACKET);
     p2->pkt = (uint8_t *)(p2 + 1);
-    p1->ip4vars.comp_csum = -1;
-    p2->ip4vars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p1);
+    PACKET_RESET_CHECKSUMS(p2);
 
     p1->ip4h = (IPV4Hdr *)valid_raw_ipv4;
 
@@ -6666,8 +6666,8 @@ int SigTest25NegativeIPV4Keyword(void)
     p1->pkt = (uint8_t *)(p1 + 1);
     memset(p2, 0, SIZE_OF_PACKET);
     p2->pkt = (uint8_t *)(p2 + 1);
-    p1->ip4vars.comp_csum = -1;
-    p2->ip4vars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p1);
+    PACKET_RESET_CHECKSUMS(p2);
 
     p1->ip4h = (IPV4Hdr *)valid_raw_ipv4;
 
@@ -6783,7 +6783,7 @@ int SigTest26TCPV4Keyword(void)
     PacketCopyData(p2, raw_ipv4, sizeof(raw_ipv4));
     PacketCopyDataOffset(p2, GET_PKT_LEN(p2), invalid_raw_tcp, sizeof(invalid_raw_tcp));
 
-    p1->tcpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p1);
     p1->ip4h = (IPV4Hdr *)GET_PKT_DATA(p1);
     p1->tcph = (TCPHdr *)(GET_PKT_DATA(p1) + sizeof(raw_ipv4));
     p1->src.family = AF_INET;
@@ -6792,7 +6792,7 @@ int SigTest26TCPV4Keyword(void)
     p1->payload_len = 20;
     p1->proto = IPPROTO_TCP;
 
-    p2->tcpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p2);
     p2->ip4h = (IPV4Hdr *)GET_PKT_DATA(p2);
     p2->tcph = (TCPHdr *)(GET_PKT_DATA(p2) + sizeof(raw_ipv4));
     p2->src.family = AF_INET;
@@ -6900,7 +6900,6 @@ static int SigTest26TCPV4AndNegativeIPV4Keyword(void)
     PacketCopyDataOffset(p2, GET_PKT_LEN(p2), invalid_raw_tcp, sizeof(invalid_raw_tcp));
 
     PACKET_RESET_CHECKSUMS(p1);
-    p1->tcpvars.comp_csum = -1;
     p1->ip4h = (IPV4Hdr *)GET_PKT_DATA(p1);
     p1->tcph = (TCPHdr *)(GET_PKT_DATA(p1) + sizeof(raw_ipv4));
     p1->src.family = AF_INET;
@@ -7144,7 +7143,7 @@ static int SigTest27NegativeTCPV4Keyword(void)
     PacketCopyData(p2, raw_ipv4, sizeof(raw_ipv4));
     PacketCopyDataOffset(p2, GET_PKT_LEN(p2), invalid_raw_tcp, sizeof(invalid_raw_tcp));
 
-    p1->tcpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p1);
     p1->ip4h = (IPV4Hdr *)GET_PKT_DATA(p1);
     p1->tcph = (TCPHdr *)(GET_PKT_DATA(p1) + sizeof(raw_ipv4));
     p1->src.family = AF_INET;
@@ -7153,7 +7152,7 @@ static int SigTest27NegativeTCPV4Keyword(void)
     p1->payload_len = 20;
     p1->proto = IPPROTO_TCP;
 
-    p2->tcpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p2);
     p2->ip4h = (IPV4Hdr *)GET_PKT_DATA(p2);
     p2->tcph = (TCPHdr *)(GET_PKT_DATA(p2) + sizeof(raw_ipv4));
     p2->src.family = AF_INET;
@@ -7266,7 +7265,7 @@ int SigTest28TCPV6Keyword(void)
     memset(p2, 0, SIZE_OF_PACKET);
     p2->pkt = (uint8_t *)(p2 + 1);
 
-    p1->tcpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p1);
     p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
     p1->tcph = (TCPHdr *) (valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
@@ -7279,7 +7278,7 @@ int SigTest28TCPV6Keyword(void)
         BUG_ON(1);
     }
 
-    p2->tcpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p2);
     p2->ip6h = (IPV6Hdr *)(invalid_raw_ipv6 + 14);
     p2->tcph = (TCPHdr *) (invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
@@ -7396,7 +7395,7 @@ int SigTest29NegativeTCPV6Keyword(void)
     memset(p2, 0, SIZE_OF_PACKET);
     p2->pkt = (uint8_t *)(p2 + 1);
 
-    p1->tcpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p1);
     p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
     p1->tcph = (TCPHdr *) (valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
@@ -7409,7 +7408,7 @@ int SigTest29NegativeTCPV6Keyword(void)
         BUG_ON(1);
     }
 
-    p2->tcpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p2);
     p2->ip6h = (IPV6Hdr *)(invalid_raw_ipv6 + 14);
     p2->tcph = (TCPHdr *) (invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
@@ -7524,7 +7523,7 @@ int SigTest30UDPV4Keyword(void)
     memset(p2, 0, SIZE_OF_PACKET);
     p2->pkt = (uint8_t *)(p2 + 1);
 
-    p1->udpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p1);
     p1->ip4h = (IPV4Hdr *)raw_ipv4;
     p1->udph = (UDPHdr *)valid_raw_udp;
     p1->src.family = AF_INET;
@@ -7533,7 +7532,7 @@ int SigTest30UDPV4Keyword(void)
     p1->payload_len = sizeof(valid_raw_udp) - UDP_HEADER_LEN;
     p1->proto = IPPROTO_UDP;
 
-    p2->udpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p2);
     p2->ip4h = (IPV4Hdr *)raw_ipv4;
     p2->udph = (UDPHdr *)invalid_raw_udp;
     p2->src.family = AF_INET;
@@ -7649,7 +7648,7 @@ int SigTest31NegativeUDPV4Keyword(void)
     memset(p2, 0, SIZE_OF_PACKET);
     p2->pkt = (uint8_t *)(p2 + 1);
 
-    p1->udpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p1);
     p1->ip4h = (IPV4Hdr *)raw_ipv4;
     p1->udph = (UDPHdr *)valid_raw_udp;
     p1->src.family = AF_INET;
@@ -7658,7 +7657,7 @@ int SigTest31NegativeUDPV4Keyword(void)
     p1->payload_len = sizeof(valid_raw_udp) - UDP_HEADER_LEN;
     p1->proto = IPPROTO_UDP;
 
-    p2->udpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p2);
     p2->ip4h = (IPV4Hdr *)raw_ipv4;
     p2->udph = (UDPHdr *)invalid_raw_udp;
     p2->src.family = AF_INET;
@@ -7768,7 +7767,7 @@ int SigTest32UDPV6Keyword(void)
     memset(p2, 0, SIZE_OF_PACKET);
     p2->pkt = (uint8_t *)(p2 + 1);
 
-    p1->udpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p1);
     p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
     p1->udph = (UDPHdr *) (valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
@@ -7777,7 +7776,7 @@ int SigTest32UDPV6Keyword(void)
     p1->payload_len = IPV6_GET_PLEN((p1)) - UDP_HEADER_LEN;
     p1->proto = IPPROTO_UDP;
 
-    p2->udpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p2);
     p2->ip6h = (IPV6Hdr *)(invalid_raw_ipv6 + 14);
     p2->udph = (UDPHdr *) (invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
@@ -7885,7 +7884,7 @@ int SigTest33NegativeUDPV6Keyword(void)
     memset(p2, 0, SIZE_OF_PACKET);
     p2->pkt = (uint8_t *)(p2 + 1);
 
-    p1->udpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p1);
     p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
     p1->udph = (UDPHdr *) (valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
@@ -7894,7 +7893,7 @@ int SigTest33NegativeUDPV6Keyword(void)
     p1->payload_len = IPV6_GET_PLEN((p1)) - UDP_HEADER_LEN;
     p1->proto = IPPROTO_UDP;
 
-    p2->udpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p2);
     p2->ip6h = (IPV6Hdr *)(invalid_raw_ipv6 + 14);
     p2->udph = (UDPHdr *) (invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
@@ -8005,7 +8004,7 @@ int SigTest34ICMPV4Keyword(void)
     memset(p2, 0, SIZE_OF_PACKET);
     p2->pkt = (uint8_t *)(p2 + 1);
 
-    p1->icmpv4vars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p1);
     p1->ip4h = (IPV4Hdr *)(valid_raw_ipv4);
     p1->ip4h->ip_verhl = 69;
     p1->icmpv4h = (ICMPV4Hdr *) (valid_raw_ipv4 + IPV4_GET_RAW_HLEN(p1->ip4h) * 4);
@@ -8015,7 +8014,7 @@ int SigTest34ICMPV4Keyword(void)
     p1->payload_len = buflen;
     p1->proto = IPPROTO_ICMP;
 
-    p2->icmpv4vars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p2);
     p2->ip4h = (IPV4Hdr *)(invalid_raw_ipv4);
     p2->ip4h->ip_verhl = 69;
     p2->icmpv4h = (ICMPV4Hdr *) (invalid_raw_ipv4 + IPV4_GET_RAW_HLEN(p2->ip4h) * 4);
@@ -8127,7 +8126,7 @@ int SigTest35NegativeICMPV4Keyword(void)
     memset(p2, 0, SIZE_OF_PACKET);
     p2->pkt = (uint8_t *)(p2 + 1);
 
-    p1->icmpv4vars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p1);
     p1->ip4h = (IPV4Hdr *)(valid_raw_ipv4);
     p1->ip4h->ip_verhl = 69;
     p1->icmpv4h = (ICMPV4Hdr *) (valid_raw_ipv4 + IPV4_GET_RAW_HLEN(p1->ip4h) * 4);
@@ -8137,7 +8136,7 @@ int SigTest35NegativeICMPV4Keyword(void)
     p1->payload_len = buflen;
     p1->proto = IPPROTO_ICMP;
 
-    p2->icmpv4vars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p2);
     p2->ip4h = (IPV4Hdr *)(invalid_raw_ipv4);
     p2->ip4h->ip_verhl = 69;
     p2->icmpv4h = (ICMPV4Hdr *) (invalid_raw_ipv4 + IPV4_GET_RAW_HLEN(p2->ip4h) * 4);
@@ -8260,7 +8259,7 @@ int SigTest36ICMPV6Keyword(void)
     memset(p2, 0, SIZE_OF_PACKET);
     p2->pkt = (uint8_t *)(p2 + 1);
 
-    p1->icmpv6vars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p1);
     p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
     p1->icmpv6h = (ICMPV6Hdr *) (valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
@@ -8269,7 +8268,7 @@ int SigTest36ICMPV6Keyword(void)
     p1->payload_len = buflen;
     p1->proto = IPPROTO_ICMPV6;
 
-    p2->icmpv6vars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p2);
     p2->ip6h = (IPV6Hdr *)(invalid_raw_ipv6 + 14);
     p2->icmpv6h = (ICMPV6Hdr *) (invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
@@ -8390,7 +8389,7 @@ int SigTest37NegativeICMPV6Keyword(void)
     memset(p2, 0, SIZE_OF_PACKET);
     p2->pkt = (uint8_t *)(p2 + 1);
 
-    p1->icmpv6vars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p1);
     p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
     p1->icmpv6h = (ICMPV6Hdr *) (valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
@@ -8399,7 +8398,7 @@ int SigTest37NegativeICMPV6Keyword(void)
     p1->payload_len = buflen;
     p1->proto = IPPROTO_ICMPV6;
 
-    p2->icmpv6vars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p2);
     p2->ip6h = (IPV6Hdr *)(invalid_raw_ipv6 + 14);
     p2->icmpv6h = (ICMPV6Hdr *) (invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
@@ -8525,7 +8524,7 @@ int SigTest38Real(int mpm_type)
     }
     SET_PKT_LEN(p1, ethlen + ipv4len + tcplen + buflen);
 
-    p1->tcpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p1);
     p1->ethh = (EthernetHdr *)raw_eth;
     p1->ip4h = (IPV4Hdr *)raw_ipv4;
     p1->tcph = (TCPHdr *)raw_tcp;
@@ -8668,7 +8667,7 @@ int SigTest39Real(int mpm_type)
     }
     SET_PKT_LEN(p1, ethlen + ipv4len + tcplen + buflen);
 
-    p1->tcpvars.comp_csum = -1;
+    PACKET_RESET_CHECKSUMS(p1);
     p1->ethh = (EthernetHdr *)raw_eth;
     p1->ip4h = (IPV4Hdr *)raw_ipv4;
     p1->tcph = (TCPHdr *)raw_tcp;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4410,21 +4410,21 @@ static inline int StreamTcpValidateChecksum(Packet *p)
     if (p->flags & PKT_IGNORE_CHECKSUM)
         return ret;
 
-    if (p->tcpvars.comp_csum == -1) {
+    if (p->comp_csum == -1) {
         if (PKT_IS_IPV4(p)) {
-            p->tcpvars.comp_csum = TCPCalculateChecksum(p->ip4h->s_ip_addrs,
-                                                 (uint16_t *)p->tcph,
-                                                 (p->payload_len +
-                                                  TCP_GET_HLEN(p)));
+            p->comp_csum = TCPCalculateChecksum(p->ip4h->s_ip_addrs,
+                                                (uint16_t *)p->tcph,
+                                                (p->payload_len +
+                                                 TCP_GET_HLEN(p)));
         } else if (PKT_IS_IPV6(p)) {
-            p->tcpvars.comp_csum = TCPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
-                                                   (uint16_t *)p->tcph,
-                                                   (p->payload_len +
-                                                    TCP_GET_HLEN(p)));
+            p->comp_csum = TCPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
+                                                  (uint16_t *)p->tcph,
+                                                  (p->payload_len +
+                                                   TCP_GET_HLEN(p)));
         }
     }
 
-    if (p->tcpvars.comp_csum != p->tcph->th_sum) {
+    if (p->comp_csum != p->tcph->th_sum) {
         ret = 0;
         SCLogDebug("Checksum of received packet %p is invalid",p);
         if (p->livedev) {


### PR DESCRIPTION
Keep a separate checksum for IPV4, since a packet can have both an IPV4
checksum and a TCPV4 checksum, or IPV4 and UDPV4 checksum.

This will allow future sharing of more values.

Use PACKET_RESET_CHECKSUMS() in Unit Tests in place of setting the
individual checksum values.

https://buildbot.suricata-ids.org/builders/ken-tilera/builds/48
