### PR TITLE
Rename checksums to level3_comp_csum and level4_comp_csum.

### DIFF
--- a/src/decode-icmpv4.h
+++ b/src/decode-icmpv4.h
@@ -200,7 +200,7 @@ typedef struct ICMPV4Vars_
 } ICMPV4Vars;
 
 #define CLEAR_ICMPV4_PACKET(p) do { \
-    (p)->comp_csum = -1; \
+    (p)->level4_comp_csum = -1; \
     (p)->icmpv4vars.id = 0; \
     (p)->icmpv4vars.seq = 0; \
     (p)->icmpv4vars.mtu = 0; \

--- a/src/decode-icmpv6.h
+++ b/src/decode-icmpv6.h
@@ -152,7 +152,7 @@ typedef struct ICMPV6Vars_ {
 
 
 #define CLEAR_ICMPV6_PACKET(p) do { \
-    (p)->comp_csum = -1; \
+    (p)->level4_comp_csum = -1; \
     (p)->icmpv6vars.id = 0; \
     (p)->icmpv6vars.seq = 0; \
     (p)->icmpv6vars.mtu = 0; \

--- a/src/decode-ipv4.h
+++ b/src/decode-ipv4.h
@@ -150,7 +150,7 @@ typedef struct IPV4Hdr_
 
 #define CLEAR_IPV4_PACKET(p) do { \
     (p)->ip4h = NULL; \
-    (p)->ip4vars.comp_csum = 0; \
+    (p)->level3_comp_csum = -1; \
     (p)->ip4vars.ip_src_u32 = 0; \
     (p)->ip4vars.ip_dst_u32 = 0; \
     (p)->ip4vars.ip_opt_cnt = 0; \

--- a/src/decode-tcp.h
+++ b/src/decode-tcp.h
@@ -153,7 +153,7 @@ typedef struct TCPVars_
 
 #define CLEAR_TCP_PACKET(p) { \
     (p)->tcph = NULL; \
-    (p)->comp_csum = -1; \
+    (p)->level4_comp_csum = -1; \
     (p)->tcpvars.tcp_opt_cnt = 0; \
     (p)->tcpvars.ts = NULL; \
     (p)->tcpvars.sack = NULL; \

--- a/src/decode-udp.h
+++ b/src/decode-udp.h
@@ -50,7 +50,7 @@ typedef struct UDPVars_
 
 #define CLEAR_UDP_PACKET(p) do { \
     (p)->udph = NULL; \
-    (p)->comp_csum = -1; \
+    (p)->level4_comp_csum = -1; \
 } while (0)
 
 void DecodeUDPV4RegisterTests(void);

--- a/src/decode.h
+++ b/src/decode.h
@@ -427,8 +427,10 @@ typedef struct Packet_
     /* header pointers */
     EthernetHdr *ethh;
 
+    /* Checksum for IP packets. */
+    int32_t level3_comp_csum;
     /* Check sum for TCP, UDP or ICMP packets */
-    int32_t comp_csum;
+    int32_t level4_comp_csum;
 
     IPV4Hdr *ip4h;
     IPV4Vars ip4vars;
@@ -612,8 +614,8 @@ typedef struct DecodeThreadVars_
  *  \brief reset these to -1(indicates that the packet is fresh from the queue)
  */
 #define PACKET_RESET_CHECKSUMS(p) do { \
-        (p)->ip4vars.comp_csum = -1;   \
-        (p)->comp_csum = -1;   \
+        (p)->level3_comp_csum = -1;   \
+        (p)->level4_comp_csum = -1;   \
     } while (0)
 
 /**

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -241,13 +241,13 @@ int DetectIPV4CsumMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->ip4vars.comp_csum == -1)
-        p->ip4vars.comp_csum = IPV4CalculateChecksum((uint16_t *)p->ip4h,
-                                                     IPV4_GET_HLEN(p));
+    if (p->level3_comp_csum == -1)
+        p->level3_comp_csum = IPV4CalculateChecksum((uint16_t *)p->ip4h,
+                                                    IPV4_GET_HLEN(p));
 
-    if (p->ip4vars.comp_csum == p->ip4h->ip_csum && cd->valid == 1)
+    if (p->level3_comp_csum == p->ip4h->ip_csum && cd->valid == 1)
         return 1;
-    else if (p->ip4vars.comp_csum != p->ip4h->ip_csum && cd->valid == 0)
+    else if (p->level3_comp_csum != p->ip4h->ip_csum && cd->valid == 0)
         return 1;
     else
         return 0;
@@ -335,14 +335,14 @@ int DetectTCPV4CsumMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->comp_csum == -1)
-        p->comp_csum = TCPCalculateChecksum(p->ip4h->s_ip_addrs,
-                                            (uint16_t *)p->tcph,
-                                            (p->payload_len + TCP_GET_HLEN(p)));
+    if (p->level4_comp_csum == -1)
+        p->level4_comp_csum = TCPCalculateChecksum(p->ip4h->s_ip_addrs,
+                                                   (uint16_t *)p->tcph,
+                                                   (p->payload_len + TCP_GET_HLEN(p)));
 
-    if (p->comp_csum == p->tcph->th_sum && cd->valid == 1)
+    if (p->level4_comp_csum == p->tcph->th_sum && cd->valid == 1)
         return 1;
-    else if (p->comp_csum != p->tcph->th_sum && cd->valid == 0)
+    else if (p->level4_comp_csum != p->tcph->th_sum && cd->valid == 0)
         return 1;
     else
         return 0;
@@ -430,14 +430,14 @@ int DetectTCPV6CsumMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->comp_csum == -1)
-        p->comp_csum = TCPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
-                                              (uint16_t *)p->tcph,
-                                              (p->payload_len + TCP_GET_HLEN(p)));
+    if (p->level4_comp_csum == -1)
+        p->level4_comp_csum = TCPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
+                                                     (uint16_t *)p->tcph,
+                                                     (p->payload_len + TCP_GET_HLEN(p)));
 
-    if (p->comp_csum == p->tcph->th_sum && cd->valid == 1)
+    if (p->level4_comp_csum == p->tcph->th_sum && cd->valid == 1)
         return 1;
-    else if (p->comp_csum != p->tcph->th_sum && cd->valid == 0)
+    else if (p->level4_comp_csum != p->tcph->th_sum && cd->valid == 0)
         return 1;
     else
         return 0;
@@ -525,15 +525,15 @@ int DetectUDPV4CsumMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->comp_csum == -1)
-        p->comp_csum = UDPV4CalculateChecksum(p->ip4h->s_ip_addrs,
-                                              (uint16_t *)p->udph,
-                                              (p->payload_len +
-                                               UDP_HEADER_LEN) );
+    if (p->level4_comp_csum == -1)
+        p->level4_comp_csum = UDPV4CalculateChecksum(p->ip4h->s_ip_addrs,
+                                                     (uint16_t *)p->udph,
+                                                     (p->payload_len +
+                                                      UDP_HEADER_LEN) );
 
-    if (p->comp_csum == p->udph->uh_sum && cd->valid == 1)
+    if (p->level4_comp_csum == p->udph->uh_sum && cd->valid == 1)
         return 1;
-    else if (p->comp_csum != p->udph->uh_sum && cd->valid == 0)
+    else if (p->level4_comp_csum != p->udph->uh_sum && cd->valid == 0)
         return 1;
     else
         return 0;
@@ -621,15 +621,15 @@ int DetectUDPV6CsumMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->comp_csum == -1)
-        p->comp_csum = UDPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
-                                              (uint16_t *)p->udph,
-                                              (p->payload_len +
-                                               UDP_HEADER_LEN) );
+    if (p->level4_comp_csum == -1)
+        p->level4_comp_csum = UDPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
+                                                     (uint16_t *)p->udph,
+                                                     (p->payload_len +
+                                                      UDP_HEADER_LEN) );
 
-    if (p->comp_csum == p->udph->uh_sum && cd->valid == 1)
+    if (p->level4_comp_csum == p->udph->uh_sum && cd->valid == 1)
         return 1;
-    else if (p->comp_csum != p->udph->uh_sum && cd->valid == 0)
+    else if (p->level4_comp_csum != p->udph->uh_sum && cd->valid == 0)
         return 1;
     else
         return 0;
@@ -717,14 +717,14 @@ int DetectICMPV4CsumMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->comp_csum == -1)
-        p->comp_csum = ICMPV4CalculateChecksum((uint16_t *)p->icmpv4h,
-                                               ntohs(IPV4_GET_RAW_IPLEN(p->ip4h)) -
-                                               IPV4_GET_RAW_HLEN(p->ip4h) * 4);
+    if (p->level4_comp_csum == -1)
+        p->level4_comp_csum = ICMPV4CalculateChecksum((uint16_t *)p->icmpv4h,
+                                                      ntohs(IPV4_GET_RAW_IPLEN(p->ip4h)) -
+                                                      IPV4_GET_RAW_HLEN(p->ip4h) * 4);
 
-    if (p->comp_csum == p->icmpv4h->checksum && cd->valid == 1)
+    if (p->level4_comp_csum == p->icmpv4h->checksum && cd->valid == 1)
         return 1;
-    else if (p->comp_csum != p->icmpv4h->checksum && cd->valid == 0)
+    else if (p->level4_comp_csum != p->icmpv4h->checksum && cd->valid == 0)
         return 1;
     else
         return 0;
@@ -814,14 +814,14 @@ int DetectICMPV6CsumMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->comp_csum == -1)
-        p->comp_csum = ICMPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
-                                                          (uint16_t *)p->icmpv6h,
-                                                          GET_PKT_LEN(p) - ((uint8_t *)p->icmpv6h - GET_PKT_DATA(p)));
+    if (p->level4_comp_csum == -1)
+        p->level4_comp_csum = ICMPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
+                                                      (uint16_t *)p->icmpv6h,
+                                                      GET_PKT_LEN(p) - ((uint8_t *)p->icmpv6h - GET_PKT_DATA(p)));
 
-    if (p->comp_csum == p->icmpv6h->csum && cd->valid == 1)
+    if (p->level4_comp_csum == p->icmpv6h->csum && cd->valid == 1)
         return 1;
-    else if (p->comp_csum != p->icmpv6h->csum && cd->valid == 0)
+    else if (p->level4_comp_csum != p->icmpv6h->csum && cd->valid == 0)
         return 1;
     else
         return 0;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4410,21 +4410,21 @@ static inline int StreamTcpValidateChecksum(Packet *p)
     if (p->flags & PKT_IGNORE_CHECKSUM)
         return ret;
 
-    if (p->comp_csum == -1) {
+    if (p->level4_comp_csum == -1) {
         if (PKT_IS_IPV4(p)) {
-            p->comp_csum = TCPCalculateChecksum(p->ip4h->s_ip_addrs,
-                                                (uint16_t *)p->tcph,
-                                                (p->payload_len +
-                                                 TCP_GET_HLEN(p)));
+            p->level4_comp_csum = TCPCalculateChecksum(p->ip4h->s_ip_addrs,
+                                                       (uint16_t *)p->tcph,
+                                                       (p->payload_len +
+                                                        TCP_GET_HLEN(p)));
         } else if (PKT_IS_IPV6(p)) {
-            p->comp_csum = TCPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
-                                                  (uint16_t *)p->tcph,
-                                                  (p->payload_len +
-                                                   TCP_GET_HLEN(p)));
+            p->level4_comp_csum = TCPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
+                                                         (uint16_t *)p->tcph,
+                                                         (p->payload_len +
+                                                          TCP_GET_HLEN(p)));
         }
     }
 
-    if (p->comp_csum != p->tcph->th_sum) {
+    if (p->level4_comp_csum != p->tcph->th_sum) {
         ret = 0;
         SCLogDebug("Checksum of received packet %p is invalid",p);
         if (p->livedev) {
@@ -8375,7 +8375,7 @@ static int StreamTcpTest29(void)
     p.payload = packet;
     p.ip4h = &ipv4h;
     p.tcpc = tcpc;
-    p.tcpc.comp_csum = -1;
+    p.tcpc.level4_comp_csum = -1;
     tcpvars.hlen = 20;
     p.tcpvars = tcpvars;
     ssn.state = TCP_ESTABLISHED;
@@ -8398,9 +8398,6 @@ static int StreamTcpTest29(void)
     ssn.server.last_ack = 119197101;
     ssn.server.ra_base_seq = 119197101;
 
-
-
-
     tcph.th_flags = TH_PUSH | TH_ACK;
     p.flowflags = FLOW_PKT_TOSERVER;
     p.tcph->th_seq = htonl(11);
@@ -8408,9 +8405,9 @@ static int StreamTcpTest29(void)
     p.payload_len = 4;
     p.ip4h->ip_src = addr1;
     p.tcph->th_sum = TCPCalculateChecksum((uint16_t *)&(p.ip4h->ip_src),
-                                                 (uint16_t *)p.tcph,
-                                                 (p.payload_len +
-                                                  p.tcpvars.hlen) );
+                                          (uint16_t *)p.tcph,
+                                          (p.payload_len +
+                                           p.tcpvars.hlen) );
 
     if (StreamTcp(&tv, &p, (void *)&stt, NULL, NULL) != TM_ECODE_OK) {
         printf("failed in segment reassmebling\n");
@@ -8519,7 +8516,7 @@ static int StreamTcpTest30(void)
     p.payload = payload;
     p.ip4h = &ipv4h;
     p.tcpc = tcpc;
-    p.tcpc.comp_csum = -1;
+    p.tcpc.level4_comp_csum = -1;
     p.tcpvars = tcpvars;
     ssn.state = TCP_ESTABLISHED;
     addr.s_addr = inet_addr("10.1.3.53");
@@ -8657,7 +8654,7 @@ static int StreamTcpTest31(void)
     p.tcph = &tcph;
     p.ip4h = &ipv4h;
     p.tcpc = tcpc;
-    p.tcpc.comp_csum = -1;
+    p.tcpc.level4_comp_csum = -1;
     p.tcpvars = tcpvars;
     p.tcpvars.ts = &tcpopt;
     addr.s_addr = inet_addr("10.1.3.53");
@@ -8699,11 +8696,11 @@ static int StreamTcpTest31(void)
     p.payload_len = 0;
     p.ip4h->ip_src = addr1;
     p.tcpc.ts1 = 10;
-    p.tcpc.comp_csum = -1;
+    p.tcpc.level4_comp_csum = -1;
     p.tcph->th_sum = TCPCalculateChecksum((uint16_t *)&(p.ip4h->ip_src),
-                                                 (uint16_t *)p.tcph,
-                                                 (p.payload_len +
-                                                  p.tcpvars.hlen) );
+                                          (uint16_t *)p.tcph,
+                                          (p.payload_len +
+                                           p.tcpvars.hlen) );
 
     if (StreamTcp(&tv, &p, (void *)&stt, NULL, NULL) != TM_ECODE_OK) {
         printf("failed in segment reassmebling\n");
@@ -8719,11 +8716,11 @@ static int StreamTcpTest31(void)
     p.payload_len = 0;
     p.tcpc.ts1 = 10;
     p.ip4h->ip_src = addr;
-    p.tcpc.comp_csum = -1;
+    p.tcpc.level4_comp_csum = -1;
     p.tcph->th_sum = TCPCalculateChecksum((uint16_t *)&(p.ip4h->ip_src),
-                                                 (uint16_t *)p.tcph,
-                                                 (p.payload_len +
-                                                  p.tcpvars.hlen) );
+                                          (uint16_t *)p.tcph,
+                                          (p.payload_len +
+                                           p.tcpvars.hlen) );
 
     if (StreamTcp(&tv, &p, (void *)&stt, NULL, NULL) != TM_ECODE_OK) {
         printf("failed in segment reassmebling\n");
@@ -8738,12 +8735,12 @@ static int StreamTcpTest31(void)
     p.payload_len = 0;
     p.tcpc.ts1 = 10;
     p.ip4h->ip_src = addr1;
-    p.tcpc.comp_csum = -1;
+    p.tcpc.level4_comp_csum = -1;
     p.tcph->th_sum = TCPCalculateChecksum((uint16_t *)&(p.ip4h->ip_src),
-                                                 (uint16_t *)p.tcph,
-                                                 (p.payload_len +
-                                                  p.tcpvars.hlen) );
-
+                                          (uint16_t *)p.tcph,
+                                          (p.payload_len +
+                                           p.tcpvars.hlen) );
+    
     if (StreamTcp(&tv, &p, (void *)&stt, NULL, NULL) != TM_ECODE_OK) {
         printf("failed in segment reassmebling\n");
         result &= 0;


### PR DESCRIPTION
This will allow sharing even more memory in the Packet_ structure.

https://buildbot.suricata-ids.org/builders/ken-tilera/builds/59
