### PR TITLE
http: strip 'proxy' part of http_uri

### DIFF
--- a/src/app-layer-htp-libhtp.h
+++ b/src/app-layer-htp-libhtp.h
@@ -45,7 +45,7 @@
 #include "suricata.h"
 #include "suricata-common.h"
 
-bstr *SCHTPGenerateNormalizedUri(htp_tx_t *tx, htp_uri_t *uri);
+bstr *SCHTPGenerateNormalizedUri(htp_tx_t *tx, htp_uri_t *uri, int uri_include_all);
 int64_t SC_htp_parse_content_length(bstr *b);
 
 #endif /* __APP_LAYER_HTP_LIBHTP__H__ */

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -134,6 +134,8 @@ typedef struct HTPCfgRec_ {
     htp_cfg_t           *cfg;
     struct HTPCfgRec_   *next;
 
+    int                 uri_include_all; /**< use all info in uri (bool) */
+
     /** max size of the client body we inspect */
     uint32_t            request_body_limit;
     uint32_t            response_body_limit;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1057,6 +1057,16 @@ app-layer:
       #   double-decode-path:     Double decode path section of the URI
       #   double-decode-query:    Double decode query section of the URI
       #
+      #   uri-include-all:        Include all parts of the URI. By default the
+      #                           'scheme', username/password, hostname and port
+      #                           are excluded. Setting this option to true adds
+      #                           all of them to the normalized uri as inspected
+      #                           by http_uri, urilen, pcre with /U and the other
+      #                           keywords that inspect the normalized uri.
+      #                           Note that this does not affect http_raw_uri.
+      #                           Also, note that including all was the default in
+      #                           1.4 and 2.0beta1.
+      #
       # Currently Available Personalities:
       #   Minimal
       #   Generic


### PR DESCRIPTION
Strip the 'proxy' parts from the normalized uri as inspected by http_uri,
urilen, pcre /U and others.

  In a request line like:

<pre>
    GET http://suricata-ids.org/blah/ HTTP/1.1
</pre>

  the normalized URI will now be:

<pre>
    /blah/
</pre>


This doesn't affect http_raw_uri. So matching the hostname, etc is still
possible through this keyword.

Additionally, a new per HTTP 'personality' option was added to change
this behavior: "uri-include-all":

<pre>
  uri-include-all: <true|false>
    Include all parts of the URI. By default the
    'scheme', username/password, hostname and port
    are excluded. Setting this option to true adds
    all of them to the normalized uri as inspected
    by http_uri, urilen, pcre with /U and the other
    keywords that inspect the normalized uri.
    Note that this does not affect http_raw_uri.
</pre>

So adding uri-include-all:true to all personalities in the yaml will
restore the old default behavior.

Ticket 1008.

https://redmine.openinfosecfoundation.org/issues/1008
https://buildbot.suricata-ids.org/builders/inliniac/builds/51
