### PR TITLE
SSE 4.2 memcmp: don't read beyond var boundary

### DIFF
--- a/src/util-memcmp.h
+++ b/src/util-memcmp.h
@@ -87,9 +87,9 @@ static inline int SCMemcmp(void *s1, void *s2, size_t n)
     return ((m == n) ? 0 : 1);
 }
 
-/* Range of values of uppercase characters */
-static char scmemcmp_uppercase[2] __attribute__((aligned(16))) = {
-    'A', 'Z' };
+/* Range of values of uppercase characters. We only use the first 2 bytes. */
+static char scmemcmp_uppercase[16] __attribute__((aligned(16))) = {
+    'A', 'Z', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, };
 
 /** \brief compare two buffers in a case insensitive way
  *  \param s1 buffer already in lowercase


### PR DESCRIPTION
In the SSE 4.2 SCMemcmpLowercase implementation, there would be a
_mm_load_si128 of a 2 byte array. However, _mm_load_si128 loads
16 bytes, causing it to read beyond the var. I don't think this lead
to crashes, as it was a static var, but clangs ASAN complained about
it.

https://buildbot.suricata-ids.org/builders/inliniac/builds/52
