### PR TITLE
Check for compiler for -march=native support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -305,7 +305,6 @@
     AC_ARG_ENABLE(gccmarch_native,
            AS_HELP_STRING([--enable-gccmarch-native], [Enable gcc march=native gcc 4.2 and later only]),,[enable_gccmarch_native=yes])
     AS_IF([test "x$enable_gccmarch_native" = "xyes"], [
-        if test `basename $CC` = "clang"; then
             OFLAGS="$CFLAGS"
             CFLAGS="$CFLAGS -march=native"
             AC_MSG_CHECKING([checking if $CC supports -march=native])
@@ -320,25 +319,6 @@
                           enable_gccmarch_native=no
                         ]
                      )
-        fi
-        if test `basename $CC` = "gcc"; then
-            case $host in
-            *darwin*|*Darwin*)
-            if test "$gccvernum" -ge "403"; then
-                        dnl gcc 4.3 or later
-                        CFLAGS="$CFLAGS -march=native"
-            else
-                enable_gccmarch_native=no
-            fi
-            ;;
-            *)
-            if test "$gccvernum" -ge "402"; then
-                        dnl gcc 4.2 or later
-                        CFLAGS="$CFLAGS -march=native"
-            fi
-            ;;
-            esac
-        fi
     ])
 
 # options


### PR DESCRIPTION
Check all compilers to see if they support the -march=native flag, rather
than assuming gcc 4.2 or later does. Tile GCC doesn't currently support it,
so not checking break Tile compiles.

https://buildbot.suricata-ids.org/builders/ken-tilera/builds/62
