### PR TITLE
pool: add option to disable packet pool

### DIFF
--- a/src/suricata.h
+++ b/src/suricata.h
@@ -155,6 +155,7 @@ typedef struct SCInstance_ {
     int daemon;
     int offline;
     int verbose;
+    int no_packet_pool;
 
     struct timeval start_time;
 

--- a/src/tm-queuehandlers.c
+++ b/src/tm-queuehandlers.c
@@ -41,7 +41,6 @@ void TmqhSetup (void) {
 
     TmqhSimpleRegister();
     TmqhNfqRegister();
-    TmqhPacketpoolRegister();
     TmqhFlowRegister();
     TmqhRingBufferRegister();
 }

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -58,10 +58,13 @@ static RingBuffer16 *ringbuffer = NULL;
  * \brief TmqhPacketpoolRegister
  * \initonly
  */
-void TmqhPacketpoolRegister (void) {
+void TmqhPacketpoolRegister (int use_ring) {
     tmqh_table[TMQH_PACKETPOOL].name = "packetpool";
     tmqh_table[TMQH_PACKETPOOL].InHandler = TmqhInputPacketpool;
     tmqh_table[TMQH_PACKETPOOL].OutHandler = TmqhOutputPacketpool;
+
+    if (! use_ring)
+        return;
 
     ringbuffer = RingBufferInit();
     if (ringbuffer == NULL) {
@@ -76,15 +79,22 @@ void TmqhPacketpoolDestroy (void) {
 }
 
 int PacketPoolIsEmpty(void) {
-    return RingBufferIsEmpty(ringbuffer);
+    if (ringbuffer)
+        return RingBufferIsEmpty(ringbuffer);
+    else
+        return 0;
 }
 
 uint16_t PacketPoolSize(void) {
-    return RingBufferSize(ringbuffer);
+    if (ringbuffer)
+        return RingBufferSize(ringbuffer);
+    else
+        return 1;
 }
 
 void PacketPoolWait(void) {
-    RingBufferWait(ringbuffer);
+    if (ringbuffer)
+        RingBufferWait(ringbuffer);
 }
 
 /** \brief a initialized packet
@@ -109,6 +119,8 @@ void PacketPoolStorePacket(Packet *p) {
  *         pool is empty, don't wait, just return NULL
  */
 Packet *PacketPoolGetPacket(void) {
+    if (!ringbuffer)
+        return NULL;
     if (RingBufferIsEmpty(ringbuffer))
         return NULL;
 

--- a/src/tmqh-packetpool.h
+++ b/src/tmqh-packetpool.h
@@ -27,7 +27,7 @@
 Packet *TmqhInputPacketpool(ThreadVars *);
 void TmqhOutputPacketpool(ThreadVars *, Packet *);
 void TmqhReleasePacketsToPacketPool(PacketQueue *);
-void TmqhPacketpoolRegister (void);
+void TmqhPacketpoolRegister (int use_ring);
 void TmqhPacketpoolDestroy (void);
 Packet *PacketPoolGetPacket(void);
 uint16_t PacketPoolSize(void);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -15,6 +15,11 @@
 # pattern matcher buffers and scans as many packets as possible in parallel.
 #max-pending-packets: 1024
 
+# Don't use packet pool but allocate packets instead (default: no). This seems to
+# improve performance on some systems where reinjecting packet to the pool consume
+# too much ressources.
+#no-packet-pool: yes
+
 # Runmode the engine should use. Please check --list-runmodes to get the available
 # runmodes for each packet acquisition method. Defaults to "autofp" (auto flow pinned
 # load balancing).


### PR DESCRIPTION
This patch is adding an option named 'no-packet-pool'. If set to
yes, the packet pool will not be allocated and instead direct
allocation will be used. The default value of the option is 'no'
to keep backward compatibility.

This option has proven to have a huge impact on some system where
the packet pool handling was taking a huge amount of CPU in the
spinlock.
