### PR TITLE
decode: update API to return error

### DIFF
--- a/src/decode-ethernet.c
+++ b/src/decode-ethernet.c
@@ -38,18 +38,18 @@
 #include "util-unittest.h"
 #include "util-debug.h"
 
-void DecodeEthernet(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
+int DecodeEthernet(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
 {
     SCPerfCounterIncr(dtv->counter_eth, tv->sc_perf_pca);
 
     if (unlikely(len < ETHERNET_HEADER_LEN)) {
         ENGINE_SET_EVENT(p,ETHERNET_PKT_TOO_SMALL);
-        return;
+        return TM_ECODE_FAILED;
     }
 
     p->ethh = (EthernetHdr *)pkt;
     if (unlikely(p->ethh == NULL))
-        return;
+        return TM_ECODE_FAILED;
 
     SCLogDebug("p %p pkt %p ether type %04x", p, pkt, ntohs(p->ethh->eth_type));
 
@@ -83,7 +83,7 @@ void DecodeEthernet(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *p
                        pkt, ntohs(p->ethh->eth_type));
     }
 
-    return;
+    return TM_ECODE_OK;
 }
 
 #ifdef UNITTESTS

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -46,6 +46,8 @@
 #include "util-print.h"
 #include "util-profiling.h"
 
+#include "tmqh-packetpool.h"
+
 /* Generic validation
  *
  * [--type--][--len---]
@@ -513,8 +515,10 @@ static int DecodeIPV4Packet(Packet *p, uint8_t *pkt, uint16_t len)
     return 0;
 }
 
-void DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
+int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
 {
+    int ret;
+
     SCPerfCounterIncr(dtv->counter_ipv4, tv->sc_perf_pca);
 
     SCLogDebug("pkt %p len %"PRIu16"", pkt, len);
@@ -523,7 +527,7 @@ void DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, 
     if (unlikely(DecodeIPV4Packet (p, pkt, len) < 0)) {
         SCLogDebug("decoding IPv4 packet failed");
         p->ip4h = NULL;
-        return;
+        return TM_ECODE_FAILED;
     }
     p->proto = IPV4_GET_IPPROTO(p);
 
@@ -532,11 +536,15 @@ void DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, 
         Packet *rp = Defrag(tv, dtv, p);
         if (rp != NULL) {
             /* Got re-assembled packet, re-run through decoder. */
-            DecodeIPV4(tv, dtv, rp, (void *)rp->ip4h, IPV4_GET_IPLEN(rp), pq);
-            PacketEnqueue(pq, rp);
+            ret = DecodeIPV4(tv, dtv, rp, (void *)rp->ip4h, IPV4_GET_IPLEN(rp), pq);
+            if (unlikely(ret != TM_ECODE_OK)) {
+                TmqhOutputPacketpool(tv, rp);
+            } else {
+                PacketEnqueue(pq, rp);
+            }
         }
         p->flags |= PKT_IS_FRAGMENT;
-        return;
+        return TM_ECODE_OK;
     }
 
     /* do hdr test, process hdr rules */
@@ -585,11 +593,15 @@ void DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, 
                     if (tp != NULL) {
                         PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV4);
                         /* send that to the Tunnel decoder */
-                        DecodeTunnel(tv, dtv, tp, GET_PKT_DATA(tp),
+                        ret = DecodeTunnel(tv, dtv, tp, GET_PKT_DATA(tp),
                                 GET_PKT_LEN(tp), pq, IPV4_GET_IPPROTO(p));
 
-                        /* add the tp to the packet queue. */
-                        PacketEnqueue(pq,tp);
+                        if (unlikely(ret != TM_ECODE_OK)) {
+                            TmqhOutputPacketpool(tv, tp);
+                        } else {
+                            /* add the tp to the packet queue. */
+                            PacketEnqueue(pq,tp);
+                        }
                     }
                 }
                 break;
@@ -603,7 +615,7 @@ void DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, 
             break;
     }
 
-    return;
+    return TM_ECODE_OK;
 }
 
 /* UNITTESTS */

--- a/src/decode-ppp.c
+++ b/src/decode-ppp.c
@@ -40,18 +40,18 @@
 #include "util-unittest.h"
 #include "util-debug.h"
 
-void DecodePPP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
+int DecodePPP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
 {
     SCPerfCounterIncr(dtv->counter_ppp, tv->sc_perf_pca);
 
     if (unlikely(len < PPP_HEADER_LEN)) {
         ENGINE_SET_EVENT(p,PPP_PKT_TOO_SMALL);
-        return;
+        return TM_ECODE_FAILED;
     }
 
     p->ppph = (PPPHdr *)pkt;
     if (unlikely(p->ppph == NULL))
-        return;
+        return TM_ECODE_FAILED;
 
     SCLogDebug("p %p pkt %p PPP protocol %04x Len: %" PRId32 "",
         p, pkt, ntohs(p->ppph->protocol), len);
@@ -61,32 +61,34 @@ void DecodePPP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, u
         case PPP_VJ_UCOMP:
             if (unlikely(len < (PPP_HEADER_LEN + IPV4_HEADER_LEN))) {
                 ENGINE_SET_EVENT(p,PPPVJU_PKT_TOO_SMALL);
-                return;
+                p->ppph = NULL;
+                return TM_ECODE_FAILED;
             }
 
             if (likely(IPV4_GET_RAW_VER((IPV4Hdr *)(pkt + PPP_HEADER_LEN)) == 4)) {
-                DecodeIPV4(tv, dtv, p, pkt + PPP_HEADER_LEN, len - PPP_HEADER_LEN, pq);
-            }
+                return DecodeIPV4(tv, dtv, p, pkt + PPP_HEADER_LEN, len - PPP_HEADER_LEN, pq);
+            } else
+                return TM_ECODE_FAILED;
             break;
 
         case PPP_IP:
             if (unlikely(len < (PPP_HEADER_LEN + IPV4_HEADER_LEN))) {
                 ENGINE_SET_EVENT(p,PPPIPV4_PKT_TOO_SMALL);
-                return;
+                p->ppph = NULL;
+                return TM_ECODE_FAILED;
             }
 
-            DecodeIPV4(tv, dtv, p, pkt + PPP_HEADER_LEN, len - PPP_HEADER_LEN, pq);
-            break;
+            return DecodeIPV4(tv, dtv, p, pkt + PPP_HEADER_LEN, len - PPP_HEADER_LEN, pq);
 
             /* PPP IPv6 was not tested */
         case PPP_IPV6:
             if (unlikely(len < (PPP_HEADER_LEN + IPV6_HEADER_LEN))) {
                 ENGINE_SET_EVENT(p,PPPIPV6_PKT_TOO_SMALL);
-                return;
+                p->ppph = NULL;
+                return TM_ECODE_FAILED;
             }
 
-            DecodeIPV6(tv, dtv, p, pkt + PPP_HEADER_LEN, len - PPP_HEADER_LEN, pq);
-            break;
+            return DecodeIPV6(tv, dtv, p, pkt + PPP_HEADER_LEN, len - PPP_HEADER_LEN, pq);
 
         case PPP_VJ_COMP:
         case PPP_IPX:
@@ -117,15 +119,15 @@ void DecodePPP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, u
         case PPP_LQM:
         case PPP_CHAP:
             ENGINE_SET_EVENT(p,PPP_UNSUP_PROTO);
-            break;
+            return TM_ECODE_OK;
 
         default:
             SCLogDebug("unknown PPP protocol: %" PRIx32 "",ntohs(p->ppph->protocol));
             ENGINE_SET_EVENT(p,PPP_WRONG_TYPE);
-            return;
+            return TM_ECODE_OK;
     }
 
-    return;
+    return TM_ECODE_FAILED;
 }
 
 /* TESTS BELOW */

--- a/src/decode-raw.c
+++ b/src/decode-raw.c
@@ -43,14 +43,14 @@
 #include "host.h"
 
 
-void DecodeRaw(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
+int DecodeRaw(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
 {
     SCPerfCounterIncr(dtv->counter_raw, tv->sc_perf_pca);
 
     /* If it is ipv4 or ipv6 it should at least be the size of ipv4 */
     if (unlikely(len < IPV4_HEADER_LEN)) {
         ENGINE_SET_EVENT(p,IPV4_PKT_TOO_SMALL);
-        return;
+        return TM_ECODE_FAILED;
     }
 
     if (IP_GET_RAW_VER(pkt) == 4) {
@@ -63,7 +63,7 @@ void DecodeRaw(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, u
         SCLogDebug("Unknown ip version %" PRIu8 "", IP_GET_RAW_VER(pkt));
         ENGINE_SET_EVENT(p,IPRAW_INVALID_IPV);
     }
-    return;
+    return TM_ECODE_OK;
 }
 
 #ifdef UNITTESTS

--- a/src/decode-sll.c
+++ b/src/decode-sll.c
@@ -36,18 +36,18 @@
 #include "decode-events.h"
 #include "util-debug.h"
 
-void DecodeSll(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
+int DecodeSll(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
 {
     SCPerfCounterIncr(dtv->counter_sll, tv->sc_perf_pca);
 
     if (unlikely(len < SLL_HEADER_LEN)) {
         ENGINE_SET_EVENT(p,SLL_PKT_TOO_SMALL);
-        return;
+        return TM_ECODE_FAILED;
     }
 
     SllHdr *sllh = (SllHdr *)pkt;
     if (unlikely(sllh == NULL))
-        return;
+        return TM_ECODE_FAILED;
 
     SCLogDebug("p %p pkt %p sll_protocol %04x", p, pkt, ntohs(sllh->sll_protocol));
 
@@ -68,6 +68,8 @@ void DecodeSll(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, u
             SCLogDebug("p %p pkt %p sll type %04x not supported", p,
                        pkt, ntohs(sllh->sll_protocol));
     }
+
+    return TM_ECODE_OK;
 }
 /**
  * @}

--- a/src/decode.c
+++ b/src/decode.c
@@ -61,26 +61,23 @@
 #include "util-profiling.h"
 #include "pkt-var.h"
 
-void DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+int DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         uint8_t *pkt, uint16_t len, PacketQueue *pq, uint8_t proto)
 {
     switch (proto) {
         case PPP_OVER_GRE:
-            DecodePPP(tv, dtv, p, pkt, len, pq);
-            return;
+            return DecodePPP(tv, dtv, p, pkt, len, pq);
         case IPPROTO_IP:
-            DecodeIPV4(tv, dtv, p, pkt, len, pq);
-            return;
+            return DecodeIPV4(tv, dtv, p, pkt, len, pq);
         case IPPROTO_IPV6:
-            DecodeIPV6(tv, dtv, p, pkt, len, pq);
-            return;
+            return DecodeIPV6(tv, dtv, p, pkt, len, pq);
        case VLAN_OVER_GRE:
-            DecodeVLAN(tv, dtv, p, pkt, len, pq);
-            return;
+            return DecodeVLAN(tv, dtv, p, pkt, len, pq);
         default:
             SCLogInfo("FIXME: DecodeTunnel: protocol %" PRIu32 " not supported.", proto);
             break;
     }
+    return TM_ECODE_OK;
 }
 
 /**

--- a/src/decode.h
+++ b/src/decode.h
@@ -826,22 +826,22 @@ const char *PktSrcToString(enum PktSrcEnum pkt_src);
 DecodeThreadVars *DecodeThreadVarsAlloc();
 
 /* decoder functions */
-void DecodeEthernet(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
-void DecodeSll(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
-void DecodePPP(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
+int DecodeEthernet(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
+int DecodeSll(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
+int DecodePPP(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
 void DecodePPPOESession(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
 void DecodePPPOEDiscovery(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
-void DecodeTunnel(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *, uint8_t);
-void DecodeRaw(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
-void DecodeIPV4(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
-void DecodeIPV6(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
+int DecodeTunnel(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *, uint8_t);
+int DecodeRaw(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
+int DecodeIPV4(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
+int DecodeIPV6(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
 void DecodeICMPV4(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
 void DecodeICMPV6(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
 void DecodeTCP(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
 void DecodeUDP(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
 void DecodeSCTP(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
 void DecodeGRE(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
-void DecodeVLAN(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
+int DecodeVLAN(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
 
 void AddressDebugPrint(Address *);
 

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -62,7 +62,7 @@ extern int max_pending_packets;
 
 typedef struct PcapFileGlobalVars_ {
     pcap_t *pcap_handle;
-    void (*Decoder)(ThreadVars *, DecodeThreadVars *, Packet *, u_int8_t *, u_int16_t, PacketQueue *);
+    int (*Decoder)(ThreadVars *, DecodeThreadVars *, Packet *, u_int8_t *, u_int16_t, PacketQueue *);
     int datalink;
     struct bpf_program filter;
     uint64_t cnt; /** packet counter */


### PR DESCRIPTION
Here's an RFC on implementation of decoding API update.

In some cases, the decoding is not possible and some really invalid
packet can be created. This is in particular the case of tunnel. In
that case, it is more interesting to forget about the tunneled
packet and only consider the original packet.

PR build: https://buildbot.suricata-ids.org/builders/regit/builds/56

Implement: https://redmine.openinfosecfoundation.org/issues/746
