### PR TITLE
tls: allow matching for @ symbol in tls.subject

### DIFF
--- a/src/detect-tls.c
+++ b/src/detect-tls.c
@@ -64,7 +64,7 @@
  * \brief Regex for parsing "id" option, matching number or "number"
  */
 
-#define PARSE_REGEX  "^\\s*(\\!*)\\s*([A-z0-9\\s\\-\\.=,\\*]+|\"[A-z0-9\\s\\-\\.=,\\*]+\")\\s*$"
+#define PARSE_REGEX  "^\\s*(\\!*)\\s*([A-z0-9\\s\\-\\.=,\\*@]+|\"[A-z0-9\\s\\-\\.=,\\*@]+\")\\s*$"
 #define PARSE_REGEX_FINGERPRINT  "^\\s*(\\!*)\\s*([A-z0-9\\:\\*]+|\"[A-z0-9\\:\\* ]+\")\\s*$"
 
 static pcre *subject_parse_regex;


### PR DESCRIPTION
Also in tls.issuerdn keyword.

Original patch by Chris Wakelin.

Fixes #1042.

https://redmine.openinfosecfoundation.org/issues/1042
https://buildbot.suricata-ids.org/builders/inliniac/builds/77
