### PR TITLE
decode: fix failure in layered tunnel

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -803,6 +803,7 @@ typedef struct DecodeThreadVars_
 
 #define IS_TUNNEL_PKT(p)            (((p)->flags & PKT_TUNNEL))
 #define SET_TUNNEL_PKT(p)           ((p)->flags |= PKT_TUNNEL)
+#define UNSET_TUNNEL_PKT(p)         ((p)->flags &= ~PKT_TUNNEL)
 #define IS_TUNNEL_ROOT_PKT(p)       (IS_TUNNEL_PKT(p) && (p)->root == NULL)
 
 #define IS_TUNNEL_PKT_VERDICTED(p)  (((p)->flags & PKT_TUNNEL_VERDICTED))


### PR DESCRIPTION
If we have multiple layer of tunnel, the decoding of initial
Packet will recurse in DecodeTunnel function called in
PacketTunnelPktSetup. If we are not setting the pseudo
packet root before calling DecodeTunnel (as done in previous
code), then the tunnel root will no be correct for the lower
layer packets. This result in an counter problem and a suricata
failure after some time.

PR build: https://buildbot.suricata-ids.org/builders/regit/builds/62
