### PR TITLE
Use the stack for temporary memory buffers.

### DIFF
--- a/src/util-error.c
+++ b/src/util-error.c
@@ -281,6 +281,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_ERR_THRESHOLD_SETUP);
         CASE_CODE (SC_ERR_DNS_CONFIG);
         CASE_CODE (SC_ERR_CONF_YAML_ERROR);
+        CASE_CODE (SC_ERR_CONF_NAME_TOO_LONG);
     }
 
     return "UNKNOWN_ERROR";

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -270,6 +270,7 @@ typedef enum {
     SC_ERR_THRESHOLD_SETUP,
     SC_ERR_DNS_CONFIG,
     SC_ERR_CONF_YAML_ERROR,
+    SC_ERR_CONF_NAME_TOO_LONG,
 } SCError;
 
 const char *SCErrorToString(SCError);


### PR DESCRIPTION
Reduces strdups.
