### PR TITLE
Fix configuring Prelude with -Werror

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -761,6 +761,10 @@
   # prelude
     AC_ARG_ENABLE(prelude,
             AS_HELP_STRING([--enable-prelude], [Enable Prelude support for alerts]),,[enable_prelude=no])
+    # Prelude doesn't work with -Werror
+    STORECFLAGS="${CFLAGS}"
+    CFLAGS="${CFLAGS} -Wno-error=unused-result"
+
     AS_IF([test "x$enable_prelude" = "xyes"], [
         CFLAGS="$CFLAGS -DPRELUDE"
         AM_PATH_LIBPRELUDE(0.9.9, , AC_MSG_ERROR(Cannot find libprelude: Is libprelude-config in the path?), no)
@@ -776,6 +780,8 @@
             LDFLAGS="${LDFLAGS} ${LIBPRELUDE_LIBS}"
         fi
     ])
+    CFLAGS="${STORECFLAGS}"
+
 
   # libnet
     AC_ARG_WITH(libnet_includes,


### PR DESCRIPTION
Running with:

CFLAGS="-Werror" ./configure

would fail when configuring libprelude because of an unused-result
warning. Ignore that one warning.

Passes both new regression tests:
https://buildbot.suricata-ids.org/builders/ken-tilera-pcap/builds/3
https://buildbot.suricata-ids.org/builders/ken-tilera/builds/66
