### PR TITLE
Use pflow variable in place of p->flow to prevent reloading.

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -1122,8 +1122,10 @@ int SigMatchSignatures(ThreadVars *th_v, DetectEngineCtx *de_ctx, DetectEngineTh
         SCReturnInt(0);
     }
 
-    /* Load the Packet's flow early, even though it might not be needed */
-    Flow *pflow = p->flow;
+    /* Load the Packet's flow early, even though it might not be needed.
+     * Mark as a constant pointer, although the flow can change.
+     */
+    Flow * const pflow = p->flow;
 
     /* grab the protocol state we will detect on */
     if (p->flags & PKT_HAS_FLOW) {


### PR DESCRIPTION
 In SigMatchSignatures, the value p->flow doesn't change, but GCC can't
figure that out, so it reloads p->flow many times during the function.
When p->flow is loaded into the variable pflow once at the start of the
function, the compile then doesn't need to reload it.

Also addresses Victor's review comments to mark pflow as a constant pointer.

Passes both regression tests:
https://buildbot.suricata-ids.org/builders/ken-tilera/builds/68
https://buildbot.suricata-ids.org/builders/ken-tilera-pcap/builds/5
