### PR TITLE
Add const for Packet * in flow functions.

### DIFF
--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -154,7 +154,7 @@ void FlowHashDebugDeinit(void)
  *           detect-engine-address-ipv6.c's AddressIPv6GtU32 is likely
  *           what you are looking for.
  */
-static inline int FlowHashRawAddressIPv6GtU32(uint32_t *a, uint32_t *b)
+static inline int FlowHashRawAddressIPv6GtU32(const uint32_t *a, const uint32_t *b)
 {
     int i;
 
@@ -207,7 +207,7 @@ typedef struct FlowHashKey6_ {
  *
  *  For ICMP we only consider UNREACHABLE errors atm.
  */
-static inline uint32_t FlowGetKey(Packet *p)
+static inline uint32_t FlowGetKey(const Packet *p)
 {
     uint32_t key;
 
@@ -346,7 +346,7 @@ static inline uint32_t FlowGetKey(Packet *p)
  *  \retval 1 match
  *  \retval 0 no match
  */
-static inline int FlowCompareICMPv4(Flow *f, Packet *p)
+static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
 {
     if (ICMPV4_DEST_UNREACH_IS_VALID(p)) {
         /* first check the direction of the flow, in other words, the client ->
@@ -386,7 +386,7 @@ static inline int FlowCompareICMPv4(Flow *f, Packet *p)
     return 0;
 }
 
-static inline int FlowCompare(Flow *f, Packet *p)
+static inline int FlowCompare(Flow *f, const Packet *p)
 {
     if (p->proto == IPPROTO_ICMP) {
         return FlowCompareICMPv4(f, p);
@@ -405,7 +405,7 @@ static inline int FlowCompare(Flow *f, Packet *p)
  *  \retval 1 true
  *  \retval 0 false
  */
-static inline int FlowCreateCheck(Packet *p)
+static inline int FlowCreateCheck(const Packet *p)
 {
     if (PKT_IS_ICMPV4(p)) {
         if (ICMPV4_IS_ERROR_MSG(p)) {
@@ -424,7 +424,7 @@ static inline int FlowCreateCheck(Packet *p)
  *
  *  \retval f *LOCKED* flow on succes, NULL on error.
  */
-static Flow *FlowGetNew(Packet *p)
+static Flow *FlowGetNew(const Packet *p)
 {
     Flow *f = NULL;
 
@@ -487,7 +487,7 @@ static Flow *FlowGetNew(Packet *p)
  *
  * returns a *LOCKED* flow or NULL
  */
-Flow *FlowGetFlowFromHash(Packet *p)
+Flow *FlowGetFlowFromHash(const Packet *p)
 {
     Flow *f = NULL;
     FlowHashCountInit;
@@ -514,9 +514,6 @@ Flow *FlowGetFlowFromHash(Packet *p)
         /* flow is locked */
         fb->head = f;
         fb->tail = f;
-
-        /* Point the Packet at the Flow */
-        FlowReference(&p->flow, f);
 
         /* got one, now lock, initialize and return */
         FlowInit(f, p);
@@ -553,9 +550,6 @@ Flow *FlowGetFlowFromHash(Packet *p)
 
                 f->hprev = pf;
 
-                /* Point the Packet at the Flow */
-                FlowReference(&p->flow, f);
-
                 /* initialize and return */
                 FlowInit(f, p);
                 f->fb = fb;
@@ -582,10 +576,7 @@ Flow *FlowGetFlowFromHash(Packet *p)
                 f->hprev = NULL;
                 fb->head->hprev = f;
                 fb->head = f;
-
-                /* Point the Packet at the Flow */
-                FlowReference(&p->flow, f);
-
+ 
                 /* found our flow, lock & return */
                 FLOWLOCK_WRLOCK(f);
                 FBLOCK_UNLOCK(fb);
@@ -595,8 +586,6 @@ Flow *FlowGetFlowFromHash(Packet *p)
         }
     }
 
-    /* Point the Packet at the Flow */
-    FlowReference(&p->flow, f);
     /* lock & return */
     FLOWLOCK_WRLOCK(f);
     FBLOCK_UNLOCK(fb);

--- a/src/flow-hash.h
+++ b/src/flow-hash.h
@@ -68,7 +68,7 @@ typedef struct FlowBucket_ {
 
 /* prototypes */
 
-Flow *FlowGetFlowFromHash(Packet *);
+Flow *FlowGetFlowFromHash(const Packet *);
 
 /** enable to print stats on hash lookups in flow-debug.log */
 //#define FLOW_DEBUG_STATS

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -106,7 +106,7 @@ uint8_t FlowGetProtoMapping(uint8_t proto)
 
 /* initialize the flow from the first packet
  * we see from it. */
-void FlowInit(Flow *f, Packet *p)
+void FlowInit(Flow *f, const Packet *p)
 {
     SCEnter();
     SCLogDebug("flow %p", f);

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -134,7 +134,7 @@ Flow *FlowAlloc(void);
 Flow *FlowAllocDirect(void);
 void FlowFree(Flow *);
 uint8_t FlowGetProtoMapping(uint8_t);
-void FlowInit(Flow *, Packet *);
+void FlowInit(Flow *, const Packet *);
 
 #endif /* __FLOW_UTIL_H__ */
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -412,7 +412,7 @@ static inline void FlowLockSetNoPayloadInspectionFlag(Flow *);
 static inline void FlowSetNoPayloadInspectionFlag(Flow *);
 static inline void FlowSetSessionNoApplayerInspectionFlag(Flow *);
 
-int FlowGetPacketDirection(Flow *, Packet *);
+int FlowGetPacketDirection(Flow *, const Packet *);
 
 void FlowCleanupAppLayer(Flow *);
 


### PR DESCRIPTION
By moving FlowReference() out of FlowGetFlowFromHash() and into the one
function that calls it, all the flow functions take const Packet \* instead
of Packet *.

Passed all regression tests:
https://buildbot.suricata-ids.org/builders/ken-tilera/builds/69
https://buildbot.suricata-ids.org/builders/ken-tilera-pcap/builds/6

This replaces PR 631 (branch flow-const) and is simply rebasing to master to pass regression tests.
