### PR TITLE
Fix uninitialized variable warning.

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -1109,7 +1109,7 @@ ConfNodeLookupChildValueTest(void)
 
 static int ConfGetChildValueWithDefaultTest(void)
 {
-    char  *val;
+    char  *val = "";
     int ret = 1;
     ConfCreateContextBackup();
     ConfInit();
@@ -1139,7 +1139,7 @@ static int ConfGetChildValueWithDefaultTest(void)
 
 static int ConfGetChildValueIntWithDefaultTest(void)
 {
-    intmax_t val;
+    intmax_t val = 0;
     ConfCreateContextBackup();
     ConfInit();
     ConfSet("af-packet.0.interface", "eth0");


### PR DESCRIPTION
These two lines reported warnings with -Werror -O3 on Tile.

Passes all regression tests:
https://buildbot.suricata-ids.org/builders/ken-tilera/builds/74
https://buildbot.suricata-ids.org/builders/ken-tilera-pcap/builds/11
