### PR TITLE
App Layer TX cleanup v1.4

### DIFF
--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -312,6 +312,24 @@ int AlpParseFieldByDelimiter(AppLayerParserResult *, AppLayerParserState *,
 
 /***** transaction handling *****/
 
+/** \brief Function ptr type for getting active TxId from a flow
+ *  Used by AppLayerTransactionGetActive.
+ */
+typedef uint64_t (*GetActiveTxIdFunc)(Flow *f, uint8_t flags);
+
+/** \brief Register GetActiveTxId Function
+ *
+ */
+void RegisterAppLayerGetActiveTxIdFunc(GetActiveTxIdFunc FuncPtr);
+
+/** \brief active TX retrieval for normal ops: so with detection and logging
+ *
+ *  \retval tx_id lowest tx_id that still needs work
+ *
+ *  This is the default function.
+ */
+uint64_t AppLayerTransactionGetActiveDetectLog(Flow *f, uint8_t flags);
+
 /**
  * \brief Update the current log id.  Does one step increments currently.
  *


### PR DESCRIPTION
Patchset in preparation of option to disable detection module. Currently TX timeout depends on inspect_id handling, which is controlled by the detection engine.

This patchset adds a simple API for registering a function to handle the ID's. By default, the inspect and log id's are taken into account, where just like before, the log_id is only considered if a logger is enabled for that protocol.
- PR build: https://buildbot.suricata-ids.org/builders/inliniac/builds/98
- PR pcaps: https://buildbot.suricata-ids.org/builders/inliniac-pcap/builds/19
