### PR TITLE
suricata: add -v[v] option to increase verbosity

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -223,6 +223,9 @@ int run_mode = RUNMODE_UNKNOWN;
   * running the engine with --engine-analysis */
 int engine_analysis = 0;
 
+/** Suricata verbosity */
+int suri_verbose = 0;
+
 /** Engine mode: inline (ENGINE_MODE_IPS) or just
   * detection mode (ENGINE_MODE_IDS by default) */
 uint8_t engine_mode = ENGINE_MODE_IDS;
@@ -509,6 +512,7 @@ void usage(const char *progname)
 	printf("\t--service-change-params              : change service startup parameters\n");
 #endif /* OS_WIN32 */
     printf("\t-V                                   : display Suricata version\n");
+    printf("\t-v[v]                                : increase default Suricata verbosity\n");
 #ifdef UNITTESTS
     printf("\t-u                                   : run the unittests and exit\n");
     printf("\t-U, --unittest-filter=REGEX          : filter unittests with a regex\n");
@@ -828,7 +832,7 @@ int main(int argc, char **argv)
     /* getopt_long stores the option index here. */
     int option_index = 0;
 
-    char short_opts[] = "c:TDhi:l:q:d:r:us:S:U:VF:";
+    char short_opts[] = "c:TDhi:l:q:d:r:us:S:U:VF:v";
 
     while ((opt = getopt_long(argc, argv, short_opts, long_opts, &option_index)) != -1) {
         switch (opt) {
@@ -1271,6 +1275,9 @@ int main(int argc, char **argv)
         case 'F':
             SetBpfStringFromFile(optarg);
             break;
+        case 'v':
+            suri_verbose++;
+            break;
         default:
             usage(argv[0]);
             exit(EXIT_FAILURE);
@@ -1450,7 +1457,7 @@ int main(int argc, char **argv)
 
     /* Since our config is now loaded we can finish configurating the
      * logging module. */
-    SCLogLoadConfig(daemon);
+    SCLogLoadConfig(daemon, suri_verbose);
 
 #ifdef __SC_CUDA_SUPPORT__
     /* load the cuda configuration */

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -1098,7 +1098,7 @@ void SCLogInitLogModule(SCLogInitData *sc_lid)
     return;
 }
 
-void SCLogLoadConfig(int daemon)
+void SCLogLoadConfig(int daemon, int verbose)
 {
     ConfNode *outputs;
     SCLogInitData *sc_lid;
@@ -1132,6 +1132,13 @@ void SCLogLoadConfig(int daemon)
             "No default log level set, will use info.");
         sc_lid->global_log_level = SC_LOG_INFO;
     }
+
+    if (verbose) {
+        sc_lid->global_log_level += verbose;
+        if (sc_lid->global_log_level > SC_LOG_LEVEL_MAX)
+            sc_lid->global_log_level = SC_LOG_LEVEL_MAX;
+    }
+
     if (ConfGet("logging.default-log-format", &sc_lid->global_log_format) != 1)
         sc_lid->global_log_format = SC_LOG_DEF_LOG_FORMAT;
 

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -546,6 +546,6 @@ int SCLogDebugEnabled(void);
 
 void SCLogRegisterTests(void);
 
-void SCLogLoadConfig(int daemon);
+void SCLogLoadConfig(int daemon, int verbose);
 
 #endif /* __UTIL_DEBUG_H__ */


### PR DESCRIPTION
This patch adds a -v option to suricata. It increases the log level
defined in the YAML.

This is a manual backport of 2be194d03f3b3d226b58f5c7fc999c9b31ce105e.
