### PR TITLE
util-mem - WIN32 case identical to !WIN32 case

### DIFF
--- a/src/util-mem.h
+++ b/src/util-mem.h
@@ -237,8 +237,6 @@ SC_ATOMIC_EXTERN(unsigned int, engine_stage);
     free(a); \
 })
 
-#if defined(__WIN32) || defined(_WIN32)
-
 /** \brief wrapper for allocing aligned mem
  *  \param a size
  *  \param b alignement
@@ -246,7 +244,7 @@ SC_ATOMIC_EXTERN(unsigned int, engine_stage);
 #define SCMallocAligned(a, b) ({ \
     void *ptrmem = NULL; \
     \
-	ptrmem = _mm_malloc((a), (b)); \
+    ptrmem = _mm_malloc((a), (b)); \
     if (ptrmem == NULL) { \
         if (SC_ATOMIC_GET(engine_stage) == SURICATA_INIT) {\
             SCLogError(SC_ERR_MEM_ALLOC, "SCMallocAligned(posix_memalign) failed: %s, while trying " \
@@ -267,39 +265,6 @@ SC_ATOMIC_EXTERN(unsigned int, engine_stage);
 #define SCFreeAligned(a) ({ \
     _mm_free(a); \
 })
-
-#else /* !win */
-
-/** \brief wrapper for allocing aligned mem
- *  \param a size
- *  \param b alignement
- */
-#define SCMallocAligned(a, b) ({ \
-    void *ptrmem = NULL; \
-    \
-    ptrmem = _mm_malloc((a), (b)); \
-    if (ptrmem == NULL) { \
-        if (SC_ATOMIC_GET(engine_stage) == SURICATA_INIT) {\
-            SCLogError(SC_ERR_MEM_ALLOC, "SCMallocAligned(posix_memalign) failed: %s, while trying " \
-                "to allocate %"PRIuMAX" bytes, alignment %"PRIuMAX, strerror(errno), (uintmax_t)a, (uintmax_t)b); \
-            SCLogError(SC_ERR_FATAL, "Out of memory. The engine cannot be initialized. Exiting..."); \
-            exit(EXIT_FAILURE); \
-        } \
-    } \
-    (void*)ptrmem; \
-})
-
-/** \brief Free aligned memory
- *
- * Not needed for mem alloc'd by posix_memalign,
- * but for possible future use of _mm_malloc needing
- * _mm_free.
- */
-#define SCFreeAligned(a) ({ \
-    _mm_free((a)); \
-})
-
-#endif /* __WIN32 */
 
 #endif /* DBG_MEM_ALLOC */
 


### PR DESCRIPTION
Remove the #ifdef for WIN32, since both cases have the same function, differing
only in using "a" or "(a)" in the syntax.

This is just code clean up.

Passes all regression tests:
https://buildbot.suricata-ids.org/builders/ken-tilera/builds/78
https://buildbot.suricata-ids.org/builders/ken-tilera-pcap/builds/15
