### PR TITLE
af-packet: update packet reading loop logic

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -723,7 +723,7 @@ int AFPReadFromRing(AFPThreadVars *ptv)
             SCReturnInt(AFP_FAILURE);
         }
 
-        if (h.h2->tp_status == TP_STATUS_KERNEL) {
+        if (h.h2->tp_status & (TP_STATUS_KERNEL|TP_STATUS_USER_BUSY)) {
             if (read_pkts == 0) {
                 if (loop_start == -1) {
                     loop_start = ptv->frame_offset;


### PR DESCRIPTION
This patch updates the logic of the packet acquisition loop. When
the reader loop function is called and when the data to read
at offset is a without data (kernel) or still used by suricata. We
try to iter for a loop on the ring to try to find kernel put by
data.
As we are entering the function because the poll said there was some
data. This allow us to jump to the data added to the ring by the
kernel.
When using suricata in autofp mode, with multiple detect threads and
packet acquisition threads attached to a dedicated CPU, the reader
loop function was looping really fast because poll call was returning
immediatly because we did read the data available.

PR builds:
- PR build: https://buildbot.suricata-ids.org/builders/regit/builds/79
- PR pcaps: https://buildbot.suricata-ids.org/builders/regit-pcap/builds/17
