### PR TITLE
Fix the segmentation fault while logging the host on the custom HTTP logger

### DIFF
--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -258,8 +258,8 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const struct t
                 if (tx->request_hostname != NULL)
                 {
                     datalen = httplog_ctx->cf_nodes[i]->maxlen;
-                    if (datalen == 0 || datalen > bstr_len(tx->parsed_uri->hostname)) {
-                        datalen = bstr_len(tx->parsed_uri->hostname);
+                    if (datalen == 0 || datalen > bstr_len(tx->request_hostname)) {
+                        datalen = bstr_len(tx->request_hostname);
                     }
                     PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset,
                                 aft->buffer->size, (uint8_t *)bstr_ptr(tx->request_hostname),


### PR DESCRIPTION
- Seems to be a regression introduced in the commit
  796bfab2317699779bb0d7dca257bb97083399d8 (fix was already done in commit
  ee0b21652b00f9398869b097c3ddceb9f86600a9)
- Doesn't happen with htplib v0.5.6, but it does in the latest, v0.5.9
