### PR TITLE
Fix DetectReplaceAddToList

### DIFF
--- a/src/detect-replace.c
+++ b/src/detect-replace.c
@@ -160,16 +160,13 @@ DetectReplaceList * DetectReplaceAddToList(DetectReplaceList *replist, uint8_t *
 
     newlist = SCMalloc(sizeof(DetectReplaceList));
     if (unlikely(newlist == NULL))
-        return NULL;
+        return replist;
     newlist->found = found;
     newlist->cd = cd;
-    newlist->next = NULL;
+    /* Push new value onto the front of the list. */
+    newlist->next = replist;
 
-    if (replist) {
-        replist->next = newlist;
-        return replist;
-    } else
-        return newlist;
+    return newlist;
 }
 
 
@@ -197,7 +194,7 @@ void DetectReplaceFree(DetectReplaceList *replist)
 {
     DetectReplaceList *tlist = NULL;
     while(replist) {
-        SCLogDebug("replace: Freing match");
+        SCLogDebug("replace: Freeing match");
         tlist = replist;
         replist = replist->next;
         SCFree(tlist);


### PR DESCRIPTION
I see two problems:
1) If allocating a newlist fails, the function returns NULL, which then
   leaks any existing list elements.
2) The code to add the new value to the list works for the first two, but
   for not the third. For example, replist=A, A->next=B, B->next=NULL, then
   adding C results in replist=A, A->next=C, C->next=NULL, B is lost.

The fix pushes new values onto the head of the list, which might not be
what is needed, but there are no comments on what the function does, so I
made an assumption.

@regit - Your name is on this file, so you should probably review this proposed fix.

Passes all regressions:
https://buildbot.suricata-ids.org/builders/ken-tilera/builds/83
https://buildbot.suricata-ids.org/builders/ken-tilera-pcap/builds/20
