### PR TITLE
Fix PmqSetup() argument removal in ac-tile MPM unit tests.

### DIFF
--- a/src/util-mpm-ac-tile.c
+++ b/src/util-mpm-ac-tile.c
@@ -1793,7 +1793,7 @@ static int SCACTileTest01(void)
 
     /* 1 match */
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"abcd", 4, 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -1827,7 +1827,7 @@ static int SCACTileTest02(void)
 
     /* 1 match */
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"abce", 4, 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -1864,7 +1864,7 @@ static int SCACTileTest03(void)
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"bcde", 4, 0, 0, 1, 0, 0);
     /* 1 match */
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"fghj", 4, 0, 0, 2, 0, 0);
-    PmqSetup(&pmq, 0, 3);
+    PmqSetup(&pmq, 3);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -1898,7 +1898,7 @@ static int SCACTileTest04(void)
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"abcd", 4, 0, 0, 0, 0, 0);
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"bcdegh", 6, 0, 0, 1, 0, 0);
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"fghjxyz", 7, 0, 0, 2, 0, 0);
-    PmqSetup(&pmq, 0, 3);
+    PmqSetup(&pmq, 3);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -1932,7 +1932,7 @@ static int SCACTileTest05(void)
     MpmAddPatternCI(&mpm_ctx, (uint8_t *)"ABCD", 4, 0, 0, 0, 0, 0);
     MpmAddPatternCI(&mpm_ctx, (uint8_t *)"bCdEfG", 6, 0, 0, 1, 0, 0);
     MpmAddPatternCI(&mpm_ctx, (uint8_t *)"fghJikl", 7, 0, 0, 2, 0, 0);
-    PmqSetup(&pmq, 0, 3);
+    PmqSetup(&pmq, 3);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -1964,7 +1964,7 @@ static int SCACTileTest06(void)
     SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx, 0);
 
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"abcd", 4, 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2008,7 +2008,7 @@ static int SCACTileTest07(void)
     /* 1 */
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                      30, 0, 0, 5, 0, 0);
-    PmqSetup(&pmq, 0, 6);
+    PmqSetup(&pmq, 6);
     /* total matches: 135 */
 
     SCACTilePreparePatterns(&mpm_ctx);
@@ -2042,7 +2042,7 @@ static int SCACTileTest08(void)
 
     /* 1 match */
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"abcd", 4, 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2074,7 +2074,7 @@ static int SCACTileTest09(void)
 
     /* 1 match */
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"ab", 2, 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2106,7 +2106,7 @@ static int SCACTileTest10(void)
 
     /* 1 match */
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"abcdefgh", 8, 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2149,7 +2149,7 @@ static int SCACTileTest11(void)
         goto end;
     if (MpmAddPatternCS(&mpm_ctx, (uint8_t *)"hers", 4, 0, 0, 4, 0, 0) == -1)
         goto end;
-    PmqSetup(&pmq, 0, 5);
+    PmqSetup(&pmq, 5);
 
     if (SCACTilePreparePatterns(&mpm_ctx) == -1)
         goto end;
@@ -2192,7 +2192,7 @@ static int SCACTileTest12(void)
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"wxyz", 4, 0, 0, 0, 0, 0);
     /* 1 match */
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"vwxyz", 5, 0, 0, 1, 0, 0);
-    PmqSetup(&pmq, 0, 2);
+    PmqSetup(&pmq, 2);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2226,7 +2226,7 @@ static int SCACTileTest13(void)
     /* 1 match */
     char *pat = "abcdefghijklmnopqrstuvwxyzABCD";
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2260,7 +2260,7 @@ static int SCACTileTest14(void)
     /* 1 match */
     char *pat = "abcdefghijklmnopqrstuvwxyzABCDE";
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2294,7 +2294,7 @@ static int SCACTileTest15(void)
     /* 1 match */
     char *pat = "abcdefghijklmnopqrstuvwxyzABCDEF";
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2328,7 +2328,7 @@ static int SCACTileTest16(void)
     /* 1 match */
     char *pat = "abcdefghijklmnopqrstuvwxyzABC";
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2362,7 +2362,7 @@ static int SCACTileTest17(void)
     /* 1 match */
     char *pat = "abcdefghijklmnopqrstuvwxyzAB";
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2396,7 +2396,7 @@ static int SCACTileTest18(void)
     /* 1 match */
     char *pat = "abcde""fghij""klmno""pqrst""uvwxy""z";
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2430,7 +2430,7 @@ static int SCACTileTest19(void)
     /* 1 */
     char *pat = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2464,7 +2464,7 @@ static int SCACTileTest20(void)
     /* 1 */
     char *pat = "AAAAA""AAAAA""AAAAA""AAAAA""AAAAA""AAAAA""AA";
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2497,7 +2497,7 @@ static int SCACTileTest21(void)
 
     /* 1 */
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"AA", 2, 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2531,7 +2531,7 @@ static int SCACTileTest22(void)
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"abcd", 4, 0, 0, 0, 0, 0);
     /* 1 match */
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"abcde", 5, 0, 0, 1, 0, 0);
-    PmqSetup(&pmq, 0, 2);
+    PmqSetup(&pmq, 2);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2564,7 +2564,7 @@ static int SCACTileTest23(void)
 
     /* 1 */
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"AA", 2, 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2596,7 +2596,7 @@ static int SCACTileTest24(void)
 
     /* 1 */
     MpmAddPatternCI(&mpm_ctx, (uint8_t *)"AA", 2, 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2629,7 +2629,7 @@ static int SCACTileTest25(void)
     MpmAddPatternCI(&mpm_ctx, (uint8_t *)"ABCD", 4, 0, 0, 0, 0, 0);
     MpmAddPatternCI(&mpm_ctx, (uint8_t *)"bCdEfG", 6, 0, 0, 1, 0, 0);
     MpmAddPatternCI(&mpm_ctx, (uint8_t *)"fghiJkl", 7, 0, 0, 2, 0, 0);
-    PmqSetup(&pmq, 0, 3);
+    PmqSetup(&pmq, 3);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2662,7 +2662,7 @@ static int SCACTileTest26(void)
 
     MpmAddPatternCI(&mpm_ctx, (uint8_t *)"Works", 5, 0, 0, 0, 0, 0);
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"Works", 5, 0, 0, 1, 0, 0);
-    PmqSetup(&pmq, 0, 2);
+    PmqSetup(&pmq, 2);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2695,7 +2695,7 @@ static int SCACTileTest27(void)
 
     /* 0 match */
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"ONE", 3, 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 
@@ -2728,7 +2728,7 @@ static int SCACTileTest28(void)
 
     /* 0 match */
     MpmAddPatternCS(&mpm_ctx, (uint8_t *)"one", 3, 0, 0, 0, 0, 0);
-    PmqSetup(&pmq, 0, 1);
+    PmqSetup(&pmq, 1);
 
     SCACTilePreparePatterns(&mpm_ctx);
 


### PR DESCRIPTION
Needed to remove the second argument from all the calls, which was always 0
and was removed in other tests in a previous commit today.

Unit tests were failing on Tile-Gx before this fix.

Regression tests pass:
https://buildbot.suricata-ids.org/builders/ken-tilera-pcap/builds/25
https://buildbot.suricata-ids.org/builders/ken-tilera/builds/89
