### PR TITLE
Remove GCC -no-strict-aliasing compiler flag.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@
                 CFLAGS="$CFLAGS -W"
         fi
     fi
-    CFLAGS="$CFLAGS -Wall -fno-strict-aliasing"
+    CFLAGS="$CFLAGS -Wall"
     CFLAGS="$CFLAGS -Wno-unused-parameter"
     CFLAGS="$CFLAGS -std=gnu99"
 


### PR DESCRIPTION
GCC typically generates better code without the -no-strict-aliasing flag.
It is only required if code makes assumptions that break strict aliasing.
The unit tests pass on x86 and Tile without the flag.

Is this flags needed for a reason?

Removing the -no-strict-aliasing flag sped up my performance test by 3%.

https://buildbot.suricata-ids.org/builders/ken-tilera/builds/90
https://buildbot.suricata-ids.org/builders/ken-tilera-pcap/builds/26
