### PR TITLE
App Layer TX cleanup API v1.7

### DIFF
--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -32,6 +32,28 @@
 #define APP_LAYER_PARSER_NO_INSPECTION  0x02
 #define APP_LAYER_PARSER_NO_REASSEMBLY  0x04
 
+
+
+/***** transaction handling *****/
+
+/** \brief Function ptr type for getting active TxId from a flow
+ *  Used by AppLayerTransactionGetActive.
+ */
+typedef uint64_t (*GetActiveTxIdFunc)(Flow *f, uint8_t flags);
+
+/** \brief Register GetActiveTxId Function
+ *
+ */
+void RegisterAppLayerGetActiveTxIdFunc(GetActiveTxIdFunc FuncPtr);
+
+/** \brief active TX retrieval for normal ops: so with detection and logging
+ *
+ *  \retval tx_id lowest tx_id that still needs work
+ *
+ *  This is the default function.
+ */
+uint64_t AppLayerTransactionGetActiveDetectLog(Flow *f, uint8_t flags);
+
 int AppLayerParserSetup(void);
 
 int AppLayerParserDeSetup(void);


### PR DESCRIPTION
Patchset in preparation of option to disable detection module. Currently TX timeout depends on inspect_id handling, which is controlled by the detection engine.

This patchset adds a simple API for registering a function to handle the ID's. By default, the inspect and log id's are taken into account, where just like before, the log_id is only considered if a logger is enabled for that protocol.

Changes since https://github.com/inliniac/suricata/pull/756:
- rebase

Prscript:
- PR build: https://buildbot.suricata-ids.org/builders/inliniac/builds/124
- PR pcaps: https://buildbot.suricata-ids.org/builders/inliniac-pcap/builds/45
