### PR TITLE
Remove BUG_ON(1) in app layer event second stage preparation function.

### DIFF
--- a/src/detect-app-layer-event.c
+++ b/src/detect-app-layer-event.c
@@ -149,7 +149,7 @@ static int DetectAppLayerEventParseAppP2(DetectAppLayerEventData *data,
     } else if (ipproto_bitarray[IPPROTO_UDP / 8] & 1 << (IPPROTO_UDP % 8)) {
         ipproto = IPPROTO_UDP;
     } else {
-        BUG_ON(1);
+        return -1;
     }
 
     r = AppLayerParserGetEventInfo(ipproto, data->alproto,

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1367,7 +1367,8 @@ static Signature *SigInitHelper(DetectEngineCtx *de_ctx, char *sigstr,
             AppLayerProtoDetectSupportedIpprotos(sig->alproto, sig->proto.proto);
     }
 
-    DetectAppLayerEventPrepare(sig);
+    if (DetectAppLayerEventPrepare(sig) < 0)
+        goto error;
 
     /* set mpm_content_len */
 


### PR DESCRIPTION
This lets us single out and print rules that result in a failure, than
just post a core dump.
