### PR TITLE
Fix make distcheck for Tile

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -305,6 +305,7 @@ util-mpm-ac-bs.c util-mpm-ac-bs.h \
 util-mpm-ac.c util-mpm-ac.h \
 util-mpm-ac-gfbs.c util-mpm-ac-gfbs.h \
 util-mpm-ac-tile.c util-mpm-ac-tile.h \
+util-mpm-ac-tile-small.c \
 util-mpm-b2gc.c util-mpm-b2gc.h \
 util-mpm-b2g.c util-mpm-b2g.h \
 util-mpm-b2gm.c util-mpm-b2gm.h \

--- a/src/util-mpm-ac-tile-small.c
+++ b/src/util-mpm-ac-tile-small.c
@@ -25,6 +25,10 @@
  *
  */
 
+/* Only included into util-mpm-ac-tile.c, which defines FUNC_NAME
+ *
+ */
+#ifdef FUNC_NAME
 // Hint to compiler to expect L2 hit latency for Load int16_t
 #undef SLOAD
 #define SLOAD(x) __insn_ld2s_L2((STYPE* restrict)(x))
@@ -93,3 +97,5 @@ uint32_t FUNC_NAME(SCACTileSearchCtx *ctx, MpmThreadCtx *mpm_thread_ctx,
 
     return matches;
 }
+
+#endif /* FUNC_NAME */


### PR DESCRIPTION
src/Makefile.am was missing util-mpm-ac-tile-small.c which caused
release tarballs for fail to build on Tile-Gx.

passes: make distcheck
Buildbot: https://buildbot.suricata-ids.org/builders/ken-tilera/builds/92
Buildbot-pcal: https://buildbot.suricata-ids.org/builders/ken-tilera-pcap/builds/27
