### PR TITLE
af-packet: fix problem introduced in recent commit

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -723,7 +723,7 @@ int AFPReadFromRing(AFPThreadVars *ptv)
             SCReturnInt(AFP_FAILURE);
         }
 
-        if (h.h2->tp_status & (TP_STATUS_KERNEL|TP_STATUS_USER_BUSY)) {
+        if ((! h.h2->tp_status) || (h.h2->tp_status & TP_STATUS_USER_BUSY)) {
             if (read_pkts == 0) {
                 if (loop_start == -1) {
                     loop_start = ptv->frame_offset;


### PR DESCRIPTION
Logic of patch 98e4a14f6d59fe8928fd6e2af3d9c3e8b42d00bf was correct
but implementation is wrong because TP_STATUS_KERNEL is equal to
zero and thus can not be evaluated in a binary operation. This patch
updates the logic by doing two tests.

Reported-by: Alessandro Guido

Ticket: https://redmine.openinfosecfoundation.org/issues/1081

PR builds:
- PR build: https://buildbot.suricata-ids.org/builders/regit/builds/90
- PR pcaps: https://buildbot.suricata-ids.org/builders/regit-pcap/builds/29
