### PR TITLE
Bug 980: fix HTTP memory cleanup at shutdown

### DIFF
--- a/qa/drmemory.suppress
+++ b/qa/drmemory.suppress
@@ -23,40 +23,6 @@ libpthread.so.0!start_thread
 libc.so.6!__clone 
 
 LEAK
-name=bug 980 (1)
-*
-suricata!DetectEngineHSBDGetBufferForTX
-suricata!DetectEngineRunHttpServerBodyMpm
-suricata!DetectMpmPrefilter
-suricata!SigMatchSignatures
-suricata!Detect
-suricata!TmThreadsSlotVarRun
-*
-
-LEAK
-name=bug 980 (2)
-*
-suricata!HHDCreateSpace
-suricata!DetectEngineHHDGetBufferForTX
-suricata!DetectEngineRunHttpHeaderMpm
-suricata!DetectMpmPrefilter
-suricata!SigMatchSignatures
-suricata!Detect
-suricata!TmThreadsSlotVarRun
-*
-
-LEAK
-name=bug 980 (3)
-*
-suricata!DetectEngineHCBDGetBufferForTX
-suricata!DetectEngineRunHttpClientBodyMpm
-suricata!DetectMpmPrefilter
-suricata!SigMatchSignatures
-suricata!Detect
-suricata!TmThreadsSlotVarRun
-*
-
-LEAK
 name=useless warning, likely DrMemory bug
 *
 libpcre.so.3!pcre_get_substring

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1408,18 +1408,32 @@ TmEcode DetectEngineThreadCtxDeinit(ThreadVars *tv, void *data) {
     if (det_ctx->bj_values != NULL)
         SCFree(det_ctx->bj_values);
 
+    /* HHD temp storage */
+    for (i = 0; i < det_ctx->hhd_buffers_size; i++) {
+        if (det_ctx->hhd_buffers[i] != NULL)
+            SCFree(det_ctx->hhd_buffers[i]);
+    }
+    if (det_ctx->hhd_buffers)
+        SCFree(det_ctx->hhd_buffers);
+    det_ctx->hhd_buffers = NULL;
+    if (det_ctx->hhd_buffers_len)
+        SCFree(det_ctx->hhd_buffers_len);
+    det_ctx->hhd_buffers_len = NULL;
+
+    /* HSBD */
     if (det_ctx->hsbd != NULL) {
-        SCLogDebug("det_ctx hsbd %u", det_ctx->hsbd_buffers_list_len);
-        for (i = 0; i < det_ctx->hsbd_buffers_list_len; i++) {
+        SCLogDebug("det_ctx hsbd %u", det_ctx->hsbd_buffers_size);
+        for (i = 0; i < det_ctx->hsbd_buffers_size; i++) {
             if (det_ctx->hsbd[i].buffer != NULL)
                 SCFree(det_ctx->hsbd[i].buffer);
         }
         SCFree(det_ctx->hsbd);
     }
 
+    /* HSCB */
     if (det_ctx->hcbd != NULL) {
-        SCLogDebug("det_ctx hcbd %u", det_ctx->hcbd_buffers_list_len);
-        for (i = 0; i < det_ctx->hcbd_buffers_list_len; i++) {
+        SCLogDebug("det_ctx hcbd %u", det_ctx->hcbd_buffers_size);
+        for (i = 0; i < det_ctx->hcbd_buffers_size; i++) {
             if (det_ctx->hcbd[i].buffer != NULL)
                 SCFree(det_ctx->hcbd[i].buffer);
             SCLogDebug("det_ctx->hcbd[i].buffer_size %u", det_ctx->hcbd[i].buffer_size);


### PR DESCRIPTION
Buffers in per thread HTTP header, client body and server body storage
would be freed based on the usage indicator instead of the size
indicator.

As the usage indicator (e.g. hsbd_buffers_list_len) could be reset
while leaving the memory untouched for later reuse, the free function
would not iterate over all memory blocks.

Removed DrMemory suppressions as well.

Bug #980. https://redmine.openinfosecfoundation.org/issues/980

PRscript:
- PR build: https://buildbot.suricata-ids.org/builders/inliniac/builds/149
- PR pcaps: https://buildbot.suricata-ids.org/builders/inliniac-pcap/builds/69
