### PR TITLE
util-device: use safe tailq foreach

### DIFF
--- a/src/util-device.c
+++ b/src/util-device.c
@@ -162,9 +162,9 @@ int LiveBuildDeviceList(char * runmode)
 int LiveDeviceListClean()
 {
     SCEnter();
-    LiveDevice *pd;
+    LiveDevice *pd, *tpd;
 
-    TAILQ_FOREACH(pd, &live_devices, next) {
+    TAILQ_FOREACH_SAFE(pd, &live_devices, next, tpd) {
         SCLogNotice("Stats for '%s':  pkts: %u, drop: %u (%.2f%%), invalid chksum: %u",
                     pd->dev,
                     SC_ATOMIC_GET(pd->pkts),


### PR DESCRIPTION
The loop is freeing elements so we need to use the safe version
of TAILQ_FOREACH.

This fixes a valgrind error:

```
 Thread 1 Suricata-Main:
 Invalid read of size 8
    at 0x8E129C: LiveDeviceListClean (util-device.c:167)
    by 0x89B742: main (suricata.c:2284)
  Address 0x8382988 is 24 bytes inside a block of size 40 free'd
    at 0x4C2A70C: free (vg_replace_malloc.c:468)
    by 0x8E1297: LiveDeviceListClean (util-device.c:179)
    by 0x89B742: main (suricata.c:2284)
```

PR builds:
- PR build: https://buildbot.suricata-ids.org/builders/regit/builds/91
- PR pcaps: https://buildbot.suricata-ids.org/builders/regit-pcap/builds/30
