### PR TITLE
tls: fix negated match

### DIFF
--- a/src/detect-tls.c
+++ b/src/detect-tls.c
@@ -212,12 +212,6 @@ static int DetectTlsSubjectMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx,
     int ret = 0;
     FLOWLOCK_RDLOCK(f);
 
-    if (tls_data->flags & DETECT_CONTENT_NEGATED) {
-        ret = 1;
-    } else {
-        ret = 0;
-    }
-
     SSLStateConnp *connp = NULL;
     if (flags & STREAM_TOSERVER) {
         connp = &ssl_state->client_connp;
@@ -235,7 +229,15 @@ static int DetectTlsSubjectMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx,
             } else {
                 ret = 1;
             }
+        } else {
+            if (tls_data->flags & DETECT_CONTENT_NEGATED) {
+                ret = 1;
+            } else {
+                ret = 0;
+            }
         }
+    } else {
+        ret = 0;
     }
 
     FLOWLOCK_UNLOCK(f);
@@ -418,12 +420,6 @@ static int DetectTlsIssuerDNMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx
     int ret = 0;
     FLOWLOCK_RDLOCK(f);
 
-    if (tls_data->flags & DETECT_CONTENT_NEGATED) {
-        ret = 1;
-    } else {
-        ret = 0;
-    }
-
     SSLStateConnp *connp = NULL;
     if (flags & STREAM_TOSERVER) {
         connp = &ssl_state->client_connp;
@@ -441,7 +437,15 @@ static int DetectTlsIssuerDNMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx
             } else {
                 ret = 1;
             }
+        } else {
+            if (tls_data->flags & DETECT_CONTENT_NEGATED) {
+                ret = 1;
+            } else {
+                ret = 0;
+            }
         }
+    } else {
+        ret = 0;
     }
 
     FLOWLOCK_UNLOCK(f);
@@ -694,11 +698,6 @@ static int DetectTlsFingerprintMatch (ThreadVars *t, DetectEngineThreadCtx *det_
     int ret = 0;
     FLOWLOCK_RDLOCK(f);
 
-    if (tls_data->flags & DETECT_CONTENT_NEGATED) {
-        ret = 1;
-    } else {
-        ret = 0;
-    }
     if (ssl_state->server_connp.cert0_fingerprint != NULL) {
         SCLogDebug("TLS: Fingerprint is [%s], looking for [%s]\n",
                    ssl_state->server_connp.cert0_fingerprint,
@@ -713,7 +712,15 @@ static int DetectTlsFingerprintMatch (ThreadVars *t, DetectEngineThreadCtx *det_
                 ret = 1;
 
             }
+        } else {
+            if (tls_data->flags & DETECT_CONTENT_NEGATED) {
+                ret = 1;
+            } else {
+                ret = 0;
+            }
         }
+    } else {
+        ret = 0;
     }
 
     FLOWLOCK_UNLOCK(f);


### PR DESCRIPTION
A negated match is matching if the tested field is NULL. But as it
is not set, nor negated nor normal test must match.

Without this patch, both following signatures match when connecting to a SSL server using a US certificate:

```
alert tls any any -> any any (msg:"negated match"; tls.subject:!"C=US"; sid:1; rev:1;)
alert tls any any -> any any (msg:"non negated match"; tls.subject:"C=US"; sid:2; rev:1;)
```

PR builds:
- PR build: https://buildbot.suricata-ids.org/builders/regit/builds/92
- PR pcaps: https://buildbot.suricata-ids.org/builders/regit-pcap/builds/31
