### PR TITLE
Fix address parsing issues

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -3158,6 +3158,31 @@ end:
 }
 
 /**
+ * \test check valid negation bug 1079
+ */
+static int SigParseTestNegation08 (void) {
+    int result = 0;
+    DetectEngineCtx *de_ctx;
+    Signature *s=NULL;
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+    de_ctx->flags |= DE_QUIET;
+
+    s = SigInit(de_ctx,"alert tcp any any -> [192.168.0.0/16,!192.168.0.0/24] any (sid:410006; rev:1;)");
+    if (s == NULL) {
+        goto end;
+    }
+
+    result = 1;
+end:
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+    return result;
+}
+
+/**
  * \test mpm
  */
 int SigParseTestMpm01 (void) {
@@ -3377,6 +3402,7 @@ void SigParseRegisterTests(void) {
     UtRegisterTest("SigParseTestNegation05", SigParseTestNegation05, 1);
     UtRegisterTest("SigParseTestNegation06", SigParseTestNegation06, 1);
     UtRegisterTest("SigParseTestNegation07", SigParseTestNegation07, 1);
+    UtRegisterTest("SigParseTestNegation08", SigParseTestNegation08, 1);
     UtRegisterTest("SigParseTestMpm01", SigParseTestMpm01, 1);
     UtRegisterTest("SigParseTestMpm02", SigParseTestMpm02, 1);
     UtRegisterTest("SigParseTestAppLayerTLS01", SigParseTestAppLayerTLS01, 1);

--- a/src/util-rule-vars.c
+++ b/src/util-rule-vars.c
@@ -358,7 +358,7 @@ int SCRuleVarsPositiveTest03(void)
         goto end;
     SigFree(s);
 */
-    s = SigInit(de_ctx, "alert tcp [![192.168.1.3,$EXTERNAL_NET],[$HTTP_SERVERS,!$HOME_NET],192.168.2.5] $HTTP_PORTS -> !$HTTP_SERVERS [80,[!$HTTP_PORTS,$ORACLE_PORTS]] (msg:\"Rule Vars Test\"; sid:1;)");
+    s = SigInit(de_ctx, "alert tcp [$HTTP_SERVERS,$HOME_NET,192.168.2.5] $HTTP_PORTS -> $EXTERNAL_NET [80,[!$HTTP_PORTS,$ORACLE_PORTS]] (msg:\"Rule Vars Test\"; sid:1;)");
     if (s == NULL)
         goto end;
     SigFree(s);


### PR DESCRIPTION
Fix issue where negating a range containing a negation would fail.

E.g. HOME_NET: [192.168.0.0/16,!192.168.10.0], can be used in a rule
     as !$HOME_NET.

Also, fix another parsing issue:

If the negation range would be bigger than the 'positive' range, parsing
wouldn't be correct. Now this case is rejected.

E.g. [192.168.1.3,!192.168.0.0/16] is now explicitly rejected

Ticket 1079: https://redmine.openinfosecfoundation.org/issues/1079

Prscript:
- PR build: https://buildbot.suricata-ids.org/builders/inliniac/builds/178
- PR pcaps: https://buildbot.suricata-ids.org/builders/inliniac-pcap/builds/98
