### PR TITLE
Don't alert on valid ICMP6 solicit/advert messages.

### DIFF
--- a/src/decode-icmpv6.h
+++ b/src/decode-icmpv6.h
@@ -47,6 +47,12 @@
 #define MLD_LISTENER_REPORT         131
 #define MLD_LISTENER_REDUCTION      132
 
+#define ND_ROUTER_SOLICIT           133
+#define ND_ROUTER_ADVERT            134
+#define ND_NEIGHBOR_SOLICIT         135
+#define ND_NEIGHBOR_ADVERT          136
+#define ND_REDIRECT                 137
+
 /** Destination Unreachable Message (type=1) Code: */
 
 #define ICMP6_DST_UNREACH_NOROUTE       0 /* no route to destination */


### PR DESCRIPTION
Handles ND_ROUTER_SOLICIT, ND_ROUTER_ADVERT, ND_NEIGHBOUR_ADMIN,
ND_NEIGHBOUR_SOLICIT and ND_REDIRECT.  Don't set ICMPV6_UNKONWN_CODE
if code is the expected value of 0.

Buildbot output:
https://buildbot.suricata-ids.org/builders/jasonish/builds/53
https://buildbot.suricata-ids.org/builders/jasonish-pcap/builds/9
