### PR TITLE
af-packet: declare TP_STATUS_VLAN_VALID if needed

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -157,6 +157,10 @@ TmEcode NoAFPSupportExit(ThreadVars *tv, void *initdata, void **data)
 #define TP_STATUS_USER_BUSY (1 << 31)
 #endif
 
+#ifndef TP_STATUS_VLAN_VALID
+#define TP_STATUS_VLAN_VALID (1 << 4)
+#endif
+
 /** protect pfring_set_bpf_filter, as it is not thread safe */
 static SCMutex afpacket_bpf_set_filter_lock = SCMUTEX_INITIALIZER;
 


### PR DESCRIPTION
Some old distribution don't ship recent enough linux header. This
result in TP_STATUS_VLAN_VALID being undefined. This patch defines
the constant and use it as it is used in backward compatible method
in the code: the flag is not set by kernel and a test on vci value
will be made.

This should fix https://redmine.openinfosecfoundation.org/issues/1106

PR builds:
- PR build: https://buildbot.suricata-ids.org/builders/regit/builds/108
- PR pcaps: https://buildbot.suricata-ids.org/builders/regit-pcap/builds/47
