### PR TITLE
Promote nodes set with --set to sequence nodes as needed.

### DIFF
--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -340,8 +340,8 @@ ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq)
                         SCFree(seq_node);
                         return -1;
                     }
-                    seq_node->is_seq = 1;
                 }
+                seq_node->is_seq = 1;
                 TAILQ_INSERT_TAIL(&node->head, seq_node, next);
                 if (ConfYamlParse(parser, seq_node, 0) != 0)
                     goto fail;


### PR DESCRIPTION
A node isn't known to be a sequence node until the YAML is parsed.
If a node sequence node was set on the command line, promote
it to a sequence node when it is discovered by YAML to be
a sequence node.

Fixes comment #18 in issue 921 (https://redmine.openinfosecfoundation.org/issues/921#change-4062)

Buildbot output:
https://buildbot.suricata-ids.org/builders/jasonish/builds/54
(pcap builder failed to start)
