### PR TITLE
vlan/QinQ: add vlan_qinq counter

### DIFF
--- a/src/decode-vlan.c
+++ b/src/decode-vlan.c
@@ -60,7 +60,10 @@ int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, u
 {
     uint32_t proto;
 
-    SCPerfCounterIncr(dtv->counter_vlan, tv->sc_perf_pca);
+    if (p->vlan_idx == 0)
+        SCPerfCounterIncr(dtv->counter_vlan, tv->sc_perf_pca);
+    else if (p->vlan_idx == 1)
+        SCPerfCounterIncr(dtv->counter_vlan_qinq, tv->sc_perf_pca);
 
     if(len < VLAN_HEADER_LEN)    {
         ENGINE_SET_INVALID_EVENT(p, VLAN_HEADER_TOO_SMALL);

--- a/src/decode.c
+++ b/src/decode.c
@@ -393,6 +393,8 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
                                                SC_PERF_TYPE_UINT64, "NULL");
     dtv->counter_vlan = SCPerfTVRegisterCounter("decoder.vlan", tv,
                                                SC_PERF_TYPE_UINT64, "NULL");
+    dtv->counter_vlan_qinq = SCPerfTVRegisterCounter("decoder.vlan_qinq", tv,
+                                               SC_PERF_TYPE_UINT64, "NULL");
     dtv->counter_teredo = SCPerfTVRegisterCounter("decoder.teredo", tv,
                                                SC_PERF_TYPE_UINT64, "NULL");
     dtv->counter_ipv4inipv6 = SCPerfTVRegisterCounter("decoder.ipv4_in_ipv6", tv,

--- a/src/decode.h
+++ b/src/decode.h
@@ -580,6 +580,7 @@ typedef struct DecodeThreadVars_
     uint16_t counter_ppp;
     uint16_t counter_gre;
     uint16_t counter_vlan;
+    uint16_t counter_vlan_qinq;
     uint16_t counter_pppoe;
     uint16_t counter_teredo;
     uint16_t counter_ipv4inipv6;


### PR DESCRIPTION
This patch introduces a new counter "decoder.vlan_qinq". It counts
packets that have more than two stacked vlan layers.

Packets with 2 vlan layers will both increment "decoder.vlan" and
"decoder.vlan_qinq".

https://redmine.openinfosecfoundation.org/issues/1102

Prscript:
- PR build: https://buildbot.suricata-ids.org/builders/inliniac/builds/189
- PR pcaps: https://buildbot.suricata-ids.org/builders/inliniac-pcap/builds/109
