### PR TITLE
Remove declaration of unused function.

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -239,7 +239,6 @@ typedef struct AFPThreadVars_
 
 } AFPThreadVars;
 
-TmEcode ReceiveAFP(ThreadVars *, Packet *, void *, PacketQueue *, PacketQueue *);
 TmEcode ReceiveAFPThreadInit(ThreadVars *, void *, void **);
 void ReceiveAFPThreadExitStats(ThreadVars *, void *);
 TmEcode ReceiveAFPThreadDeinit(ThreadVars *, void *);


### PR DESCRIPTION
The function ReceiveAFP() is declared, but never defined, so removed it.

Simple clean noticed while reading the file.

tests passed with PR script.
https://buildbot.suricata-ids.org/builders/ken-tilera/builds/119
https://buildbot.suricata-ids.org/builders/ken-tilera-pcap/builds/53

@regit - This is your code, so you might want to double check.
