### PR TITLE
[rfc, no-merge] WIP Packet multi queue: new queue type

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -247,7 +247,7 @@ Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *pare
     SCEnter();
 
     /* get us a packet */
-    Packet *p = PacketGetFromQueueOrAlloc();
+    Packet *p = PseudoPacketGet();
     if (unlikely(p == NULL)) {
         SCReturnPtr(NULL, "Packet");
     }
@@ -312,7 +312,7 @@ Packet *PacketDefragPktSetup(Packet *parent, uint8_t *pkt, uint16_t len, uint8_t
     SCEnter();
 
     /* get us a packet */
-    Packet *p = PacketGetFromQueueOrAlloc();
+    Packet *p = PseudoPacketGet();
     if (unlikely(p == NULL)) {
         SCReturnPtr(NULL, "Packet");
     }

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -273,7 +273,7 @@ static inline Packet *FlowForceReassemblyPseudoPacketGet(int direction,
 {
     Packet *p;
 
-    p = PacketGetFromAlloc();
+    p = PseudoPacketGet();//PacketGetFromAlloc();
     if (p == NULL)
         return NULL;
 

--- a/src/packet-queue.c
+++ b/src/packet-queue.c
@@ -30,6 +30,8 @@
 #include "suricata.h"
 #include "util-var.h"
 #include "pkt-var.h"
+#include "host.h"
+#include "util-profiling.h"
 
 #ifdef DEBUG
 void PacketQueueValidateDebug(PacketQueue *q) {
@@ -192,3 +194,236 @@ Packet *PacketDequeue (PacketQueue *q) {
     return p;
 }
 
+typedef struct PacketMultiQueue_ {
+    SC_ATOMIC_DECLARE(uint32_t, idx);
+    SC_ATOMIC_DECLARE(uint32_t, usage);
+    uint32_t size;
+    PacketQueue *queues;
+} PacketMultiQueue;
+
+
+/** \brief 2pass lookup for Packets
+ *
+ *  To reduce lock contention we start at a different position each
+ *  time. We look up in 2 passed. The first pass uses trylock, and
+ *  moves to the next queue immediately if a queue is locked. The 2nd
+ *  pass does wait for a lock.
+ *
+ *  \retval p Packet or NULL if all queues were empty.
+ */
+Packet *PacketMultiQueueGet(PacketMultiQueue *pm_queue) {
+    BUG_ON(pm_queue == NULL);
+    uint32_t idx = SC_ATOMIC_GET(pm_queue->idx);
+    idx %= pm_queue->size;
+    BUG_ON(idx > pm_queue->size);
+    Packet *p = NULL;
+    uint32_t tried = 0;
+    int pass = 0;
+
+    /* no need to do any looping when we know we don't
+     * have packets */
+    if (SC_ATOMIC_GET(pm_queue->usage) == 0)
+        return NULL;
+
+    /* loop through our queues once */
+    while (1) {
+        /* we walk the queues in 2 passes. */
+        if (tried >= pm_queue->size) {
+            if (pass == 1)
+                return NULL;
+
+            tried = 0;
+            pass = 1;
+        }
+
+        PacketQueue *q = &pm_queue->queues[idx];
+        BUG_ON(q == NULL);
+
+        if (pass == 1) {
+            SCMutexLock(&q->mutex_q);
+        } else {
+            /* skip locked queues */
+            if (SCMutexTrylock(&q->mutex_q) != 0) {
+                tried++;
+                idx++;
+                if (idx >= pm_queue->size)
+                    idx = 0;
+                continue;
+            }
+        }
+
+        /* have lock now */
+
+        /* skip empty queues */
+        if (q->len == 0) {
+            SCMutexUnlock(&q->mutex_q);
+            tried++;
+            idx++;
+            if (idx >= pm_queue->size)
+                idx = 0;
+            continue;
+
+        }
+
+        SC_ATOMIC_SUB(pm_queue->usage,1);
+        p = PacketDequeue(q);
+        BUG_ON(p == NULL); // can't fail as we have lock and q->len != 0
+        SCMutexUnlock(&q->mutex_q);
+        break;
+    }
+    SC_ATOMIC_ADD(pm_queue->idx, 1);
+    return p;
+}
+
+void PacketQueueInit(PacketQueue *pq)
+{
+    SCMutexInit(&pq->mutex_q, NULL);
+}
+
+void PacketQueueDeinit(PacketQueue *pq)
+{
+    SCMutexDestroy(&pq->mutex_q);
+}
+
+/** \brief Put a packet in the queue
+ *
+ *  Consider 2 things: (1) pick a queue that isn't locked, but (2) make sure to keep things somewhat balanced.
+ */
+void PacketMultiQueuePut(PacketMultiQueue *pm_queue, Packet *p) {
+    BUG_ON(pm_queue == NULL||p == NULL);
+
+    uint32_t idx = SC_ATOMIC_GET(pm_queue->idx);
+    idx %= pm_queue->size;
+    BUG_ON(idx > pm_queue->size);
+
+    while (1) {
+        PacketQueue *q = &pm_queue->queues[idx];
+
+        /* skip locked queues */
+        if (SCMutexTrylock(&q->mutex_q) != 0) {
+            idx++;
+            if (idx >= pm_queue->size)
+                idx = 0;
+            continue;
+        }
+
+        /* queue is now locked */
+
+        /* empty queue, put it in here */
+        if (q->len == 0) {
+            PacketEnqueue(q,p);
+            SC_ATOMIC_ADD(pm_queue->usage,1);
+            SCMutexUnlock(&q->mutex_q);
+            break; /* done */
+
+        /* non-empty. We need to check the balance:
+           threshold is: total in our multi queue, devided by num queues, times 2 */
+        } else {
+            uint32_t usage = SC_ATOMIC_GET(pm_queue->usage);
+            if (q->len > (2 * (usage / pm_queue->size))) {
+                SCMutexUnlock(&q->mutex_q);
+                /* too many in queue already, try the next */
+                idx++;
+                if (idx >= pm_queue->size)
+                    idx = 0;
+                continue;
+            } else {
+                PacketEnqueue(q,p);
+                SC_ATOMIC_ADD(pm_queue->usage,1);
+                SCMutexUnlock(&q->mutex_q);
+                break;
+            }
+        }
+    }
+    SC_ATOMIC_ADD(pm_queue->idx, 1);
+}
+
+PacketMultiQueue *PacketMultiQueueInit(uint32_t nqueues, uint32_t npackets)
+{
+    PacketMultiQueue *pm = SCMalloc(sizeof(*pm));
+    BUG_ON(pm == NULL);
+    memset(pm, 0x00, sizeof(*pm));
+    SC_ATOMIC_INIT(pm->usage);
+    SC_ATOMIC_INIT(pm->idx);
+    pm->queues = SCMalloc(nqueues * sizeof(PacketQueue));
+    BUG_ON(pm->queues == NULL);
+    memset(pm->queues, 0x00, (nqueues * sizeof(PacketQueue)));
+    pm->size = nqueues;
+    uint32_t u;
+    for (u = 0; u < nqueues; u++) {
+        PacketQueue *pq = &pm->queues[u];
+        BUG_ON(pq == NULL);
+        PacketQueueInit(pq);
+    }
+
+    for (u = 0; u < npackets; u++) {
+        Packet *p = PacketGetFromAlloc();
+        if (unlikely(p == NULL)) {
+            SCLogError(SC_ERR_FATAL, "Fatal error encountered while allocating a packet. Exiting...");
+            exit(EXIT_FAILURE);
+        }
+        p->flags &= ~PKT_ALLOC;
+        PacketMultiQueuePut(pm, p);
+    }
+
+    return pm;
+}
+
+void PacketMultiQueueDestroy(PacketMultiQueue *pm) {
+    BUG_ON(pm == NULL);
+
+    uint32_t packets = SC_ATOMIC_GET(pm->usage);
+    while (packets--) {
+        Packet *p = PacketMultiQueueGet(pm);
+        BUG_ON(p == NULL);
+        PACKET_CLEANUP(p);
+        PacketFree(p);
+    }
+
+    uint32_t u;
+    for (u = 0; u < pm->size; u++) {
+        PacketQueue *pq = &pm->queues[u];
+        BUG_ON(pq == NULL);
+        PacketQueueDeinit(pq);
+    }
+
+    SCFree(pm->queues);
+    SC_ATOMIC_DESTROY(pm->usage);
+    SC_ATOMIC_DESTROY(pm->idx);
+    SCFree(pm);
+}
+
+static PacketMultiQueue *pseudo_packet_mq = NULL;
+
+void PseudoPacketQueueInit(uint32_t nqueues, uint32_t npackets)
+{
+    BUG_ON(pseudo_packet_mq != NULL);
+    pseudo_packet_mq = PacketMultiQueueInit(nqueues, npackets);
+    BUG_ON(pseudo_packet_mq == NULL);
+}
+
+void PseudoPacketQueueDestroy(void)
+{
+    BUG_ON(pseudo_packet_mq == NULL);
+    PacketMultiQueueDestroy(pseudo_packet_mq);
+    pseudo_packet_mq = NULL;
+    BUG_ON(pseudo_packet_mq != NULL);
+}
+
+void PseudoPacketPut(Packet *p)
+{
+    BUG_ON(pseudo_packet_mq == NULL);
+    PacketMultiQueuePut(pseudo_packet_mq, p);
+}
+
+Packet *PseudoPacketGet(void)
+{
+    BUG_ON(pseudo_packet_mq == NULL);
+    Packet *p = PacketMultiQueueGet(pseudo_packet_mq);
+    if (p != NULL) {
+        PACKET_RECYCLE(p);
+        p->ReleasePacket = PseudoPacketPut;
+        PACKET_PROFILING_START(p);
+    }
+    return p;
+}

--- a/src/packet-queue.h
+++ b/src/packet-queue.h
@@ -30,5 +30,10 @@
 void PacketEnqueue (PacketQueue *, Packet *);
 Packet *PacketDequeue (PacketQueue *);
 
+void PseudoPacketQueueInit(uint32_t nqueues, uint32_t npackets);
+void PseudoPacketQueueDestroy(void);
+Packet *PseudoPacketGet(void);
+void PseudoPacketPut(Packet *p);
+
 #endif /* __PACKET_QUEUE_H__ */
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5248,7 +5248,7 @@ Packet *StreamTcpPseudoSetup(Packet *parent, uint8_t *pkt, uint32_t len)
         SCReturnPtr(NULL, "Packet");
     }
 
-    Packet *p = PacketGetFromQueueOrAlloc();
+    Packet *p = PseudoPacketGet();
     if (p == NULL) {
         SCReturnPtr(NULL, "Packet");
     }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2013,6 +2013,8 @@ static int PostConfLoadedSetup(SCInstance *suri)
 
     TmModuleRunInit();
 
+    PseudoPacketQueueInit(24, 32768);
+
     SCReturnInt(TM_ECODE_OK);
 }
 

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -44,6 +44,16 @@
 
 #ifdef UNITTESTS
 
+void UTHSetupGlobals(void)
+{
+    PseudoPacketQueueInit(4,32);
+}
+
+void UTHCleanupGlobals(void)
+{
+    PseudoPacketQueueDestroy();
+}
+
 /**
  *  \brief return the uint32_t for a ipv4 address string
  *

--- a/src/util-unittest-helper.h
+++ b/src/util-unittest-helper.h
@@ -25,6 +25,10 @@
 #define __UTIL_UNITTEST_HELPER__
 
 #ifdef UNITTESTS
+
+void UTHSetupGlobals(void);
+void UTHCleanupGlobals(void);
+
 uint32_t UTHSetIPv4Address(char *);
 
 Packet *UTHBuildPacketReal(uint8_t *, uint16_t, uint8_t ipproto, char *, char *, uint16_t, uint16_t);

--- a/src/util-unittest.c
+++ b/src/util-unittest.c
@@ -199,7 +199,10 @@ uint32_t UtRunTests(char *regex_arg) {
                 TimeModeSetOffline();
                 TimeSetToCurrentTime();
 
+                UTHSetupGlobals();
                 ret = ut->TestFn();
+                UTHCleanupGlobals();
+
                 printf("%s\n", (ret == ut->evalue) ? "pass" : "FAILED");
                 if (ret != ut->evalue) {
                     if (failure_fatal == 1) {

--- a/src/util-unittest.h
+++ b/src/util-unittest.h
@@ -27,6 +27,10 @@
 #ifndef __UTIL_UNITTEST_H__
 #define __UTIL_UNITTEST_H__
 
+#include "suricata-common.h"
+#include "decode.h"
+#include "util-unittest-helper.h"
+
 #ifdef UNITTESTS
 
 typedef struct UtTest_ {


### PR DESCRIPTION
New queue type for less contention. A series of packet queues that are
self-balancing and work hard to keep contention low.

The Get function does 2 passes: one with trylock, which skips over
locked and empty queues quicky. Then a 2nd pass which does use the
regular lock. The approach is not exact and non-deterministic. It is
possible that during the Get passes, packets are added to the queues
that we miss. This is a trade off for performance.

Setup a pseudo packet 'pool' using this method, where the various
pseudo packet users will now rely on this method for getting and
discarding packets.
