### PR TITLE
Exit if BPF filter file is specified in IPS mode

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -423,6 +423,13 @@ static void SetBpfStringFromFile(char *filename) {
     FILE *fp = NULL;
     size_t nm = 0;
 
+    if (IS_ENGINE_MODE_IPS(engine_mode)) {
+        SCLogError(SC_ERR_NOT_SUPPORTED,
+                   "BPF filter not available in IPS mode."
+                   " Use firewall filtering if possible.");
+        exit(EXIT_FAILURE);
+    }
+
 #ifdef OS_WIN32
     if(_stat(filename, &st) != 0) {
 #else


### PR DESCRIPTION
This patch adds a check that was missing when specifying BPF filter
from a file. Suricata behavior should have been the same as when
BPF filter is specified on command line and IPS mode is used (ie quit).

PR builds:
- PR build: https://buildbot.suricata-ids.org/builders/regit/builds/109
- PR pcaps: https://buildbot.suricata-ids.org/builders/regit-pcap/builds/48
