### PR TITLE
Bug1111

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -191,9 +191,9 @@ typedef struct AFPThreadVars_
     int cooked;
 
     /* counters */
-    uint32_t pkts;
+    uint64_t pkts;
     uint64_t bytes;
-    uint32_t errs;
+    uint64_t errs;
 
     ThreadVars *tv;
     TmSlot *slot;
@@ -499,8 +499,8 @@ static inline void AFPDumpCounters(AFPThreadVars *ptv)
                 kstats.tp_packets, kstats.tp_drops);
         SCPerfCounterAddUI64(ptv->capture_kernel_packets, ptv->tv->sc_perf_pca, kstats.tp_packets);
         SCPerfCounterAddUI64(ptv->capture_kernel_drops, ptv->tv->sc_perf_pca, kstats.tp_drops);
-        (void) SC_ATOMIC_ADD(ptv->livedev->drop, kstats.tp_drops);
-        (void) SC_ATOMIC_ADD(ptv->livedev->pkts, kstats.tp_packets);
+        (void) SC_ATOMIC_ADD(ptv->livedev->drop, (uint64_t) kstats.tp_drops);
+        (void) SC_ATOMIC_ADD(ptv->livedev->pkts, (uint64_t) kstats.tp_packets);
     }
 #endif
 }
@@ -1648,7 +1648,7 @@ void ReceiveAFPThreadExitStats(ThreadVars *tv, void *data) {
             (uint64_t) SCPerfGetLocalCounterValue(ptv->capture_kernel_drops, tv->sc_perf_pca));
 #endif
 
-    SCLogInfo("(%s) Packets %" PRIu32 ", bytes %" PRIu64 "", tv->name, ptv->pkts, ptv->bytes);
+    SCLogInfo("(%s) Packets %" PRIu64 ", bytes %" PRIu64 "", tv->name, ptv->pkts, ptv->bytes);
 }
 
 /**

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -132,7 +132,7 @@ typedef struct PfringThreadVars_
 
     /* counters */
     uint64_t bytes;
-    uint32_t pkts;
+    uint64_t pkts;
 
     uint16_t capture_kernel_packets;
     uint16_t capture_kernel_drops;
@@ -525,7 +525,7 @@ void ReceivePfringThreadExitStats(ThreadVars *tv, void *data) {
             tv->name,
             (uint64_t) SCPerfGetLocalCounterValue(ptv->capture_kernel_packets, tv->sc_perf_pca),
             (uint64_t) SCPerfGetLocalCounterValue(ptv->capture_kernel_drops, tv->sc_perf_pca));
-    SCLogInfo("(%s) Packets %" PRIu32 ", bytes %" PRIu64 "", tv->name, ptv->pkts, ptv->bytes);
+    SCLogInfo("(%s) Packets %" PRIu64 ", bytes %" PRIu64 "", tv->name, ptv->pkts, ptv->bytes);
 }
 
 /**

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -165,7 +165,7 @@ int LiveDeviceListClean()
     LiveDevice *pd, *tpd;
 
     TAILQ_FOREACH_SAFE(pd, &live_devices, next, tpd) {
-        SCLogNotice("Stats for '%s':  pkts: %u, drop: %u (%.2f%%), invalid chksum: %u",
+        SCLogNotice("Stats for '%s':  pkts: %" PRIu64", drop: %" PRIu64 " (%.2f%%), invalid chksum: %" PRIu64,
                     pd->dev,
                     SC_ATOMIC_GET(pd->pkts),
                     SC_ATOMIC_GET(pd->drop),

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -25,9 +25,9 @@
 typedef struct LiveDevice_ {
     char *dev;  /**< the device (e.g. "eth0") */
     int ignore_checksum;
-    SC_ATOMIC_DECLARE(unsigned int, pkts);
-    SC_ATOMIC_DECLARE(unsigned int, drop);
-    SC_ATOMIC_DECLARE(unsigned int, invalid_checksums);
+    SC_ATOMIC_DECLARE(uint64_t, pkts);
+    SC_ATOMIC_DECLARE(uint64_t, drop);
+    SC_ATOMIC_DECLARE(uint64_t, invalid_checksums);
     TAILQ_ENTRY(LiveDevice_) next;
 } LiveDevice;
 


### PR DESCRIPTION
The first patch is a fix for bug 1111. The second converts the packets counter to 64bits integer to avoid a potential overflow on busy boxes.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1111

PR builds:
- PR build: https://buildbot.suricata-ids.org/builders/regit/builds/110
- PR pcaps: https://buildbot.suricata-ids.org/builders/regit-pcap/builds/49
