### PR TITLE
http: add info message about memcap

### DIFF
--- a/src/app-layer-htp-mem.c
+++ b/src/app-layer-htp-mem.c
@@ -56,6 +56,7 @@ void HTPParseMemcap()
                        conf_val);
             exit(EXIT_FAILURE);
         }
+        SCLogInfo("HTTP memcap: %"PRIu64, htp_config_memcap);
     } else {
         /* default to unlimited */
         htp_config_memcap = 0;


### PR DESCRIPTION
Display a message about http memcap when it is set in config file.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1118

PR builds:
- PR build: https://buildbot.suricata-ids.org/builders/regit/builds/114
- PR pcaps: https://buildbot.suricata-ids.org/builders/regit-pcap/builds/53
