### PR TITLE
output-json: update timestamp format

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -169,7 +169,7 @@ static int AlertJsonDecoderEvent(ThreadVars *tv, JsonAlertLogThread *aft, const 
         }
 
         /* time & tx */
-        json_object_set_new(js, "time", json_string(timebuf));
+        json_object_set_new(js, "timestamp", json_string(timebuf));
 
         /* tuple */
         //json_object_set_new(js, "srcip", json_string(srcip));

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -204,7 +204,7 @@ json_t *CreateJSONHeader(Packet *p, int direction_sensitive, char *event_type)
     }
 
     /* time & tx */
-    json_object_set_new(js, "time", json_string(timebuf));
+    json_object_set_new(js, "timestamp", json_string(timebuf));
 
     /* sensor id */
     if (sensor_id >= 0)

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1889,6 +1889,7 @@ static int ConfigGetCaptureValue(SCInstance *suri)
 static int PostConfLoadedSetup(SCInstance *suri)
 {
     char *hostmode = NULL;
+    char *timestamp = NULL;
 
     /* load the pattern matchers */
     MpmTableSetup();
@@ -1918,6 +1919,16 @@ static int PostConfLoadedSetup(SCInstance *suri)
                 "supplied by %s (default-log-dir) doesn't exist. "
                 "Shutting down the engine", suri->log_dir, conf_filename);
         SCReturnInt(TM_ECODE_FAILED);
+    }
+
+    if (ConfGet("timestamp-format", &timestamp) == 1) {
+        if (!strcmp(timestamp, "iso")) {
+            TimeUseIsoFormat();
+        } else if (strcmp(timestamp, "legacy")) {
+            SCLogError(SC_ERR_INVALID_VALUE,
+                       "Timestamp format '%s' is not supported. Using 'legacy'",
+                       timestamp);
+        }
     }
 
     if (ConfigGetCaptureValue(suri) != TM_ECODE_OK) {

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -48,6 +48,7 @@ void TimeModeSetOffline (void);
 
 struct tm *SCLocalTime(time_t timep, struct tm *result);
 void CreateTimeString (const struct timeval *ts, char *str, size_t size);
+void TimeUseIsoFormat();
 
 #endif /* __UTIL_TIME_H__ */
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -72,6 +72,12 @@ unix-command:
   enabled: no
   #filename: custom.socket
 
+# Select which timestamp format to use.
+# Possible values: 'iso' or 'legacy' (default)
+# 'iso' is a ISO 8601 format which is compatible with a lot of tools.
+# It is recommanded to use it in the case the EVE output is used.
+#timestamp-format: iso
+
 # Configure the type of alert (and other) logging you would like.
 outputs:
 
@@ -83,6 +89,7 @@ outputs:
       #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
 
   # "United" event log in JSON format
+  # It is recommanded to set timestamp-format to 'iso' if this output is used.
   - eve-log:
       enabled: no
       type: file #file|syslog|unix_dgram|unix_stream


### PR DESCRIPTION
This patch allows user to set the format to use. The new
YAML variable 'timestamp-format' can be set to 'iso' or
'legacy' (default value). If set to 'legacy' nothing change
but if set to 'iso' then it updates the timestamp format
to use a ISO 8601 comptabile string. This allow tools parsing
the output to easily detect adn/or use the timestamp.

In the EVE JSON output, the value of the timestamp key has been
changed to 'timestamp' (instead of 'time'). This allows tools
like Splunk to detect the timestamp and use it without configuration.

Logstash configuration is simple:

input {
   file {
      path => [ "/usr/local/var/log/suricata/eve.json" ]
      codec =>   json
      type => "suricata-log"
   }
}

filter {
   if [type] == "suricata-log" {
      date {
        match => [ "timestamp", "ISO8601" ]
      }
   }
}

In splunk, auto detection of the fle format is failling and it seems
you need to define a type to parse JSON in
$SPLUNK_DIR/etc/system/local/props.conf:

[suricata]
KV_MODE = json
NO_BINARY_CHECK = 1
TRUNCATE = 0

Then you can simply declare the log file in
$SPLUNK_DIR/etc/system/local/inputs.conf:

[monitor:///usr/local/var/log/suricata/eve.json]
sourcetype = suricata

In both cases the timestamp are correctly imported by
the tools.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1123

PR builds:
- PR build: https://buildbot.suricata-ids.org/builders/regit/builds/117
- PR pcaps: https://buildbot.suricata-ids.org/builders/regit-pcap/builds/56
