### PR TITLE
ipfw: fix build

### DIFF
--- a/src/runmode-ipfw.c
+++ b/src/runmode-ipfw.c
@@ -46,6 +46,7 @@
 #include "util-affinity.h"
 #include "util-runmodes.h"
 #include "source-ipfw.h"
+#include "util-device.h"
 
 static const char *default_mode;
 


### PR DESCRIPTION
Buildbot reported:
 runmode-ipfw.c: In function 'RunModeIpsIPFWAuto':
 runmode-ipfw.c:85: error: implicit declaration of function 'LiveDeviceHasNoStats'

Tested on a Freebsd VM like last time but I've double checked which sources were build.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1124

PR builds:
- PR build: https://buildbot.suricata-ids.org/builders/regit/builds/118
- PR pcaps: https://buildbot.suricata-ids.org/builders/regit-pcap/builds/57
