### PR TITLE
output-json: update timestamp format

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -141,7 +141,7 @@ static int AlertJsonDecoderEvent(ThreadVars *tv, JsonAlertLogThread *aft, const 
 
     MemBufferReset(buffer);
 
-    CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
+    CreateIsoTimeString(&p->ts, timebuf, sizeof(timebuf));
 
     for (i = 0; i < p->alerts.cnt; i++) {
         const PacketAlert *pa = &p->alerts.alerts[i];
@@ -169,7 +169,7 @@ static int AlertJsonDecoderEvent(ThreadVars *tv, JsonAlertLogThread *aft, const 
         }
 
         /* time & tx */
-        json_object_set_new(js, "time", json_string(timebuf));
+        json_object_set_new(js, "timestamp", json_string(timebuf));
 
         /* tuple */
         //json_object_set_new(js, "srcip", json_string(srcip));

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -158,7 +158,7 @@ json_t *CreateJSONHeader(Packet *p, int direction_sensitive, char *event_type)
     if (unlikely(js == NULL))
         return NULL;
 
-    CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
+    CreateIsoTimeString(&p->ts, timebuf, sizeof(timebuf));
 
     srcip[0] = '\0';
     dstip[0] = '\0';
@@ -204,7 +204,7 @@ json_t *CreateJSONHeader(Packet *p, int direction_sensitive, char *event_type)
     }
 
     /* time & tx */
-    json_object_set_new(js, "time", json_string(timebuf));
+    json_object_set_new(js, "timestamp", json_string(timebuf));
 
     /* sensor id */
     if (sensor_id >= 0)

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -35,6 +35,9 @@ static struct timeval current_time = { 0, 0 };
 static SCSpinlock current_time_spinlock;
 static char live = TRUE;
 
+
+struct tm *SCLocalTime(time_t timep, struct tm *result);
+
 void TimeInit(void)
 {
     SCSpinInit(&current_time_spinlock, 0);
@@ -118,6 +121,17 @@ void TimeSetIncrementTime(uint32_t tv_sec)
     tv.tv_sec += tv_sec;
 
     TimeSet(&tv);
+}
+
+void CreateIsoTimeString (const struct timeval *ts, char *str, size_t size)
+{
+    time_t time = ts->tv_sec;
+    struct tm local_tm;
+    struct tm *t = (struct tm*)SCLocalTime(time, &local_tm);
+
+    snprintf(str, size, "%04d-%02d-%02dT%02d:%02d:%02d.%06u",
+             t->tm_year + 1900, t->tm_mon + 1, t->tm_mday, t->tm_hour,
+             t->tm_min, t->tm_sec, (uint32_t) ts->tv_usec);
 }
 
 /*

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -48,6 +48,7 @@ void TimeModeSetOffline (void);
 
 struct tm *SCLocalTime(time_t timep, struct tm *result);
 void CreateTimeString (const struct timeval *ts, char *str, size_t size);
+void CreateIsoTimeString (const struct timeval *ts, char *str, size_t size);
 
 #endif /* __UTIL_TIME_H__ */
 


### PR DESCRIPTION
This patch updates the timestamp format used in eve loggin.
It uses a ISO 8601 comptatible string. This allow tools parsing
the output to easily detect adn/or use the timestamp.

In the EVE JSON output, the value of the timestamp key has been
changed to 'timestamp' (instead of 'time'). This allows tools
like Splunk to detect the timestamp and use it without configuration.

Logstash configuration is simple:

input {
   file {
      path => [ "/usr/local/var/log/suricata/eve.json" ]
      codec =>   json
      type => "suricata-log"
   }
}

filter {
   if [type] == "suricata-log" {
      date {
        match => [ "timestamp", "ISO8601" ]
      }
   }
}

In splunk, auto detection of the fle format is failling and it seems
you need to define a type to parse JSON in
$SPLUNK_DIR/etc/system/local/props.conf:

[suricata]
KV_MODE = json
NO_BINARY_CHECK = 1
TRUNCATE = 0

Then you can simply declare the log file in
$SPLUNK_DIR/etc/system/local/inputs.conf:

[monitor:///usr/local/var/log/suricata/eve.json]
sourcetype = suricata

In both cases the timestamp are correctly imported by
the tools.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1123

PR builds:
- PR build: https://buildbot.suricata-ids.org/builders/regit/builds/119
- PR pcaps: https://buildbot.suricata-ids.org/builders/regit-pcap/builds/58
