### PR TITLE
Fix live reload

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -499,9 +499,9 @@ static void *DetectEngineLiveRuleSwap(void *arg)
     DetectEngineThreadCtx *old_det_ctx[no_of_detect_tvs];
     DetectEngineThreadCtx *new_det_ctx[no_of_detect_tvs];
     ThreadVars *detect_tvs[no_of_detect_tvs];
-    memset(old_det_ctx, 0x00, (no_of_detect_tvs * sizeof(DetectEngineThreadCtx)));
-    memset(new_det_ctx, 0x00, (no_of_detect_tvs * sizeof(DetectEngineThreadCtx)));
-    memset(detect_tvs, 0x00, (no_of_detect_tvs * sizeof(ThreadVars)));
+    memset(old_det_ctx, 0x00, (no_of_detect_tvs * sizeof(DetectEngineThreadCtx *)));
+    memset(new_det_ctx, 0x00, (no_of_detect_tvs * sizeof(DetectEngineThreadCtx *)));
+    memset(detect_tvs, 0x00, (no_of_detect_tvs * sizeof(ThreadVars *)));
 
     SCMutexUnlock(&tv_root_lock);
 


### PR DESCRIPTION
Fix memsets clearing out of bounds memory on live reload, causing
crashes and corrupted backtraces.

Bug #1128. https://redmine.openinfosecfoundation.org/issues/1128

Rebase of https://github.com/inliniac/suricata/pull/882

Prscript:
- PR build: https://buildbot.suricata-ids.org/builders/inliniac/builds/226
- PR pcaps: https://buildbot.suricata-ids.org/builders/inliniac-pcap/builds/146
