### PR TITLE
eve-http: print <unknown> like in eve-files

### DIFF
--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -89,7 +89,7 @@ static void JsonHttpLogJSON(JsonHttpLogThread *aft, json_t *js, htp_tx_t *tx)
             SCFree(c);
         }
     } else {
-        json_object_set_new(hjs, "hostname", json_string("<hostname unknown>"));
+        json_object_set_new(hjs, "hostname", json_string("<unknown>"));
     }
 
     /* uri */
@@ -114,7 +114,7 @@ static void JsonHttpLogJSON(JsonHttpLogThread *aft, json_t *js, htp_tx_t *tx)
             SCFree(c);
         }
     } else {
-        json_object_set_new(hjs, "http_user_agent", json_string("<useragent unknown>"));
+        json_object_set_new(hjs, "http_user_agent", json_string("unknown>"));
     }
 
     /* x-forwarded-for */


### PR DESCRIPTION
When UA or Host are unknown, print <unknown> instead of <useragent
unknown> or <hostname unknown>.

Bug #1131. https://redmine.openinfosecfoundation.org/issues/1131

Prscript:
- PR build: https://buildbot.suricata-ids.org/builders/inliniac/builds/227
- PR pcaps: https://buildbot.suricata-ids.org/builders/inliniac-pcap/builds/147
