### PR TITLE
eve-file: set event_type to fileinfo

### DIFF
--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -165,7 +165,7 @@ static json_t *LogFileMetaGetUserAgent(const Packet *p, const File *ff) {
  */
 static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const File *ff) {
     MemBuffer *buffer = (MemBuffer *)aft->buffer;
-    json_t *js = CreateJSONHeader((Packet *)p, 0, "file"); //TODO const
+    json_t *js = CreateJSONHeader((Packet *)p, 0, "fileinfo"); //TODO const
     if (unlikely(js == NULL))
         return;
 


### PR DESCRIPTION
To remain constistent with the other logs, set the event type to
the same name as the structure containing the defails. In this
case fileinfo.

Part of bug #1127. https://redmine.openinfosecfoundation.org/issues/1127
- PR build: https://buildbot.suricata-ids.org/builders/inliniac/builds/229
- PR pcaps: https://buildbot.suricata-ids.org/builders/inliniac-pcap/builds/149
