### PR TITLE
Change configure to allow statically linking libpcre.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -418,7 +418,7 @@
         LDFLAGS="${LDFLAGS}  -L${with_libpcre_libraries}"
     fi
     PCRE=""
-    AC_CHECK_LIB(pcre, pcre_get_substring,, PCRE="no")
+    AC_CHECK_LIB(pcre, pcre_get_substring,, PCRE="no",-lpthread)
     if test "$PCRE" = "no"; then
         echo
         echo "   ERROR!  pcre library not found, go get it"


### PR DESCRIPTION
Statically linking libpcre requires using -lpthread, which is added
when building Suricata, but not while checking for libpcre in configure.

Replaces PR 887 to address Victor's review comments.

Change from static-1 now use -lpthread instead of -pthread.

Passes PR Script:
https://buildbot.suricata-ids.org/builders/ken-tilera-pcap/builds/62
https://buildbot.suricata-ids.org/builders/ken-tilera/builds/128
