### PR TITLE
eve-http: register with app-layer api

### DIFF
--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -274,6 +274,9 @@ OutputCtx *OutputHttpLogInit(ConfNode *conf)
     output_ctx->data = http_ctx;
     output_ctx->DeInit = NULL;
 
+    /* enable the logger for the app layer */
+    AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_HTTP);
+
     return output_ctx;
 }
 
@@ -305,6 +308,9 @@ OutputCtx *OutputHttpLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
     }
     output_ctx->data = http_ctx;
     output_ctx->DeInit = NULL;
+
+    /* enable the logger for the app layer */
+    AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_HTTP);
 
     return output_ctx;
 }


### PR DESCRIPTION
The HTTP module of Eve didn't register itself with the app-layer
for HTTP. This meant that if no other HTTP logger was active, the
HTTP logging in Eve wouldn't work.

This patch makes the HTTP Eve module register itself correctly.

Bug #1133. https://redmine.openinfosecfoundation.org/issues/1133

Prscript:
- PR build: https://buildbot.suricata-ids.org/builders/inliniac/builds/230
- PR pcaps: https://buildbot.suricata-ids.org/builders/inliniac-pcap/builds/150
