### PR TITLE
detect: allow alias registration for rule keywords

### DIFF
--- a/src/detect-luajit.c
+++ b/src/detect-luajit.c
@@ -71,6 +71,7 @@ static int DetectLuajitSetupNoSupport (DetectEngineCtx *a, Signature *b, char *c
  */
 void DetectLuajitRegister(void) {
     sigmatch_table[DETECT_LUAJIT].name = "luajit";
+    sigmatch_table[DETECT_LUAJIT].alias = "lua";
     sigmatch_table[DETECT_LUAJIT].Setup = DetectLuajitSetupNoSupport;
     sigmatch_table[DETECT_LUAJIT].Free  = NULL;
     sigmatch_table[DETECT_LUAJIT].RegisterTests = NULL;
@@ -95,6 +96,7 @@ static void DetectLuajitFree(void *);
  */
 void DetectLuajitRegister(void) {
     sigmatch_table[DETECT_LUAJIT].name = "luajit";
+    sigmatch_table[DETECT_LUAJIT].alias = "lua";
     sigmatch_table[DETECT_LUAJIT].desc = "match via a luajit script";
     sigmatch_table[DETECT_LUAJIT].url = "https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Lua_scripting";
     sigmatch_table[DETECT_LUAJIT].Match = DetectLuajitMatch;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -273,6 +273,8 @@ SigTableElmt *SigTableGet(char *name) {
         if (st->name != NULL) {
             if (strcasecmp(name,st->name) == 0)
                 return st;
+            if (st->alias != NULL && strcasecmp(name,st->alias) == 0)
+                return st;
         }
     }
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -897,7 +897,8 @@ typedef struct SigTableElmt_ {
     void (*RegisterTests)(void);
 
     uint8_t flags;
-    char *name;
+    char *name;     /**< keyword name alias */
+    char *alias;    /**< name alias */
     char *desc;
     char *url;
 


### PR DESCRIPTION
This allows for registering a keyword under another name while keeping
the old name active and supported.

Do this for 'luajit', which can now also be used as just 'lua'.

Prscript:
- PR build: https://buildbot.suricata-ids.org/builders/inliniac/builds/233
- PR pcaps: https://buildbot.suricata-ids.org/builders/inliniac-pcap/builds/153
