### PR TITLE
Adds payload field to JSON output

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -119,6 +119,13 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
         /* alert */
         json_object_set_new(js, "alert", ajs);
 
+	/* payload */
+	char payload[p->payload_len + 1];
+	uint32_t offset = 0;
+	PrintStringsToBuffer((uint8_t *)payload, &offset, p->payload_len + 1,
+			 p->payload, p->payload_len);
+	json_object_set_new(js, "payload", json_string(payload));
+
         OutputJSONBuffer(js, aft->file_ctx, aft->buffer);
         json_object_del(js, "alert");
     }

--- a/src/util-print.c
+++ b/src/util-print.c
@@ -215,6 +215,19 @@ void PrintRawDataToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32
     return;
 }
 
+void PrintStringsToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32_t dst_buf_size,
+                          uint8_t *src_buf, uint32_t src_buf_len)
+{
+    uint32_t ch = 0;
+    for (ch = 0; ch < src_buf_len; ch++) {
+        PrintBufferData((char *)dst_buf, dst_buf_offset_ptr, dst_buf_size,
+                        "%c",
+                        isprint((uint8_t)src_buf[ch]) || src_buf[ch] == '\n' || src_buf[ch] == '\r' ? (uint8_t)src_buf[ch] : '.');
+    }
+
+    return;
+}
+
 #ifndef s6_addr16
 # define s6_addr16 __u6_addr.__u6_addr16
 #endif

--- a/src/util-print.h
+++ b/src/util-print.h
@@ -49,6 +49,8 @@ void PrintRawJsonFp(FILE *, uint8_t *, uint32_t);
 void PrintRawDataFp(FILE *, uint8_t *, uint32_t);
 void PrintRawDataToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32_t dst_buf_size,
                           uint8_t *src_buf, uint32_t src_buf_len);
+void PrintStringsToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32_t dst_buf_size,
+                          uint8_t *src_buf, uint32_t src_buf_len);
 void PrintRawLineHexBuf(char *, uint32_t, uint8_t *, uint32_t );
 const char *PrintInet(int , const void *, char *, socklen_t);
 


### PR DESCRIPTION
The first part of this patch adds a new utility function that prints characters to a buffer similar to PrintRawDataToBuffer, but without the offset hex.  Printable characters, linefeeds, and carriage returns go into the buffer unchanged.  All other characters go in as "."

The new function is then used to add a "payload" field to the JSON alert output.
