### PR TITLE
Replace ringbuffer in Packet Pool with a stack for better cache locality

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2014 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -73,7 +73,7 @@ int DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             return DecodeIPV4(tv, dtv, p, pkt, len, pq);
         case IPPROTO_IPV6:
             return DecodeIPV6(tv, dtv, p, pkt, len, pq);
-       case VLAN_OVER_GRE:
+        case VLAN_OVER_GRE:
             return DecodeVLAN(tv, dtv, p, pkt, len, pq);
         default:
             SCLogInfo("FIXME: DecodeTunnel: protocol %" PRIu32 " not supported.", proto);
@@ -155,12 +155,8 @@ void PacketFreeOrRelease(Packet *p)
  */
 Packet *PacketGetFromQueueOrAlloc(void)
 {
-    Packet *p = NULL;
-
     /* try the pool first */
-    if (PacketPoolSize() > 0) {
-        p = PacketPoolGetPacket();
-    }
+    Packet *p = PacketPoolGetPacket();
 
     if (p == NULL) {
         /* non fatal, we're just not processing a packet then */

--- a/src/decode.h
+++ b/src/decode.h
@@ -87,6 +87,8 @@ enum PktSrcEnum {
 struct DetectionEngineThreadCtx_;
 typedef struct AppLayerThreadCtx_ AppLayerThreadCtx;
 
+struct PktPool_;
+
 /* declare these here as they are called from the
  * PACKET_RECYCLE and PACKET_CLEANUP macro's. */
 typedef struct AppLayerDecoderEvents_ AppLayerDecoderEvents;
@@ -524,6 +526,10 @@ typedef struct Packet_
     /* tunnel packet ref count */
     uint16_t tunnel_tpr_cnt;
 
+    /* The Packet pool from which this packet was allocated. Used when returning
+     * the packet to its owner's stack. If NULL, then allocated with malloc.
+     */
+    struct PktPool_ *pool;
 
 #ifdef PROFILING
     PktProfiling *profile;

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2011-2013 Open Information Security Foundation
+/* Copyright (C) 2011-2014 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1113,7 +1113,6 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
 {
     SCEnter();
 
-    uint16_t packet_q_len = 0;
     AFPThreadVars *ptv = (AFPThreadVars *)data;
     struct pollfd fds;
     int r;
@@ -1162,12 +1161,7 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
 
         /* make sure we have at least one packet in the packet pool, to prevent
          * us from alloc'ing packets at line rate */
-        do {
-            packet_q_len = PacketPoolSize();
-            if (unlikely(packet_q_len == 0)) {
-                PacketPoolWait();
-            }
-        } while (packet_q_len == 0);
+        PacketPoolWait();
 
         r = poll(&fds, 1, POLL_TIMEOUT);
 
@@ -1764,6 +1758,8 @@ TmEcode ReceiveAFPThreadInit(ThreadVars *tv, void *initdata, void **data) {
     if (! SCKernelVersionIsAtLeast(3, 0)) {
         ptv->vlan_disabled = 1;
     }
+
+    PacketPoolInit();
 
     SCReturnInt(TM_ECODE_OK);
 }

--- a/src/source-erf-file.c
+++ b/src/source-erf-file.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2010 Open Information Security Foundation
+/* Copyright (C) 2010-2014 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -123,12 +123,7 @@ TmEcode ReceiveErfFileLoop(ThreadVars *tv, void *data, void *slot)
 
         /* Make sure we have at least one packet in the packet pool,
          * to prevent us from alloc'ing packets at line rate. */
-        do {
-            packet_q_len = PacketPoolSize();
-            if (unlikely(packet_q_len == 0)) {
-                PacketPoolWait();
-            }
-        } while (packet_q_len == 0);
+        PacketPoolWait();
 
         p = PacketGetFromQueueOrAlloc();
         if (unlikely(p == NULL)) {
@@ -239,6 +234,8 @@ ReceiveErfFileThreadInit(ThreadVars *tv, void *initdata, void **data)
     etv->erf = erf;
     etv->tv = tv;
     *data = (void *)etv;
+
+    PacketPoolInit();
 
     SCLogInfo("Processing ERF file %s", (char *)initdata);
 

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2011 Open Information Security Foundation
+/* Copyright (C) 2007-2014 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -271,12 +271,7 @@ TmEcode ReceiveIPFWLoop(ThreadVars *tv, void *data, void *slot)
 
         /* make sure we have at least one packet in the packet pool, to prevent
          * us from alloc'ing packets at line rate */
-        do {
-            packet_q_len = PacketPoolSize();
-            if (unlikely(packet_q_len == 0)) {
-                PacketPoolWait();
-            }
-        } while (packet_q_len == 0);
+        PacketPoolWait();
 
         p = PacketGetFromQueueOrAlloc();
         if (p == NULL) {
@@ -378,6 +373,8 @@ TmEcode ReceiveIPFWThreadInit(ThreadVars *tv, void *initdata, void **data)
     ntv->datalink = DLT_RAW;
 
     *data = (void *)ntv;
+
+    PacketPoolInit();
 
     SCReturnInt(TM_ECODE_OK);
 }

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2012 Open Information Security Foundation
+/* Copyright (C) 2012-2014 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -171,6 +171,8 @@ TmEcode NapatechStreamThreadInit(ThreadVars *tv, void *initdata, void **data)
 
     *data = (void *)ntv;
 
+    PacketPoolInit();
+
     SCReturnInt(TM_ECODE_OK);
 }
 
@@ -208,12 +210,7 @@ TmEcode NapatechStreamLoop(ThreadVars *tv, void *data, void *slot)
     while (!(suricata_ctl_flags & (SURICATA_STOP | SURICATA_KILL))) {
         /* make sure we have at least one packet in the packet pool, to prevent
          * us from alloc'ing packets at line rate */
-        do {
-            packet_q_len = PacketPoolSize();
-            if (unlikely(packet_q_len == 0)) {
-                PacketPoolWait();
-            }
-        } while (packet_q_len == 0);
+        PacketPoolWait();
 
         /*
          * Napatech returns packets 1 at a time

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2014 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -717,6 +717,9 @@ TmEcode ReceiveNFQThreadInit(ThreadVars *tv, void *initdata, void **data) {
 #undef T_DATA_SIZE
 
     *data = (void *)ntv;
+
+    PacketPoolInit();
+
     SCMutexUnlock(&nfq_init_lock);
     return TM_ECODE_OK;
 }

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2014 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -200,12 +200,7 @@ TmEcode ReceivePcapFileLoop(ThreadVars *tv, void *data, void *slot)
 
         /* make sure we have at least one packet in the packet pool, to prevent
          * us from alloc'ing packets at line rate */
-        do {
-            packet_q_len = PacketPoolSize();
-            if (unlikely(packet_q_len == 0)) {
-                PacketPoolWait();
-            }
-        } while (packet_q_len == 0);
+        PacketPoolWait();
 
         /* Right now we just support reading packets one at a time. */
         r = pcap_dispatch(pcap_g.pcap_handle, (int)packet_q_len,
@@ -345,6 +340,9 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, void *initdata, void **data) {
 
     ptv->tv = tv;
     *data = (void *)ptv;
+
+    PacketPoolInit();
+
     SCReturnInt(TM_ECODE_OK);
 }
 

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2014 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -309,12 +309,7 @@ TmEcode ReceivePcapLoop(ThreadVars *tv, void *data, void *slot)
 
         /* make sure we have at least one packet in the packet pool, to prevent
          * us from alloc'ing packets at line rate */
-        do {
-            packet_q_len = PacketPoolSize();
-            if (unlikely(packet_q_len == 0)) {
-                PacketPoolWait();
-            }
-        } while (packet_q_len == 0);
+        PacketPoolWait();
 
         /* Right now we just support reading packets one at a time. */
         r = pcap_dispatch(ptv->pcap_handle, (int)packet_q_len,
@@ -642,6 +637,8 @@ TmEcode ReceivePcapThreadInit(ThreadVars *tv, void *initdata, void **data) {
             "NULL");
 
     *data = (void *)ptv;
+
+    PacketPoolInit();
 
     /* Dereference config */
     pcapconfig->DerefFunc(pcapconfig);

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -317,12 +317,7 @@ TmEcode ReceivePfringLoop(ThreadVars *tv, void *data, void *slot)
 
         /* make sure we have at least one packet in the packet pool, to prevent
          * us from alloc'ing packets at line rate */
-        do {
-            packet_q_len = PacketPoolSize();
-            if (unlikely(packet_q_len == 0)) {
-                PacketPoolWait();
-            }
-        } while (packet_q_len == 0);
+        PacketPoolWait();
 
         p = PacketGetFromQueueOrAlloc();
         if (p == NULL) {
@@ -542,6 +537,9 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, void *initdata, void **data) {
 
     *data = (void *)ptv;
     pfconf->DerefFunc(pfconf);
+
+    PacketPoolInit();
+
     return TM_ECODE_OK;
 }
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2133,7 +2133,6 @@ int main(int argc, char **argv)
     NSS_NoDB_Init(NULL);
 #endif
 
-    PacketPoolInit(max_pending_packets);
     HostInitConfig(HOST_VERBOSE);
     if (suri.run_mode != RUNMODE_UNIX_SOCKET) {
         FlowInitConfig(FLOW_VERBOSE);

--- a/src/tmqh-packetpool.h
+++ b/src/tmqh-packetpool.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2014 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -24,17 +24,28 @@
 #ifndef __TMQH_PACKETPOOL_H__
 #define __TMQH_PACKETPOOL_H__
 
+#include "decode.h"
+
+typedef struct PktPool_ {
+    /* link listed of free packets local to this thread. */
+    Packet *head;
+  
+    /* Return stack, onto which other threads free packets. */
+    struct {
+        /* linked list of free packets. */
+        Packet *return_head;
+        SCMutex return_mutex;
+    } __attribute__((aligned(CLS)));
+} PktPool;
+
 Packet *TmqhInputPacketpool(ThreadVars *);
 void TmqhOutputPacketpool(ThreadVars *, Packet *);
 void TmqhReleasePacketsToPacketPool(PacketQueue *);
-void TmqhPacketpoolRegister (void);
-void TmqhPacketpoolDestroy (void);
+void TmqhPacketpoolRegister(void);
 Packet *PacketPoolGetPacket(void);
-uint16_t PacketPoolSize(void);
-void PacketPoolStorePacket(Packet *);
 void PacketPoolWait(void);
 void PacketPoolReturnPacket(Packet *p);
-void PacketPoolInit(intmax_t max_pending_packets);
+void PacketPoolInit(void);
 void PacketPoolDestroy(void);
 
 #endif /* __TMQH_PACKETPOOL_H__ */


### PR DESCRIPTION
Implements optimization 1039 (https://redmine.openinfosecfoundation.org/issues/1039#change-4093)
Using a stack for free Packet storage causes recently freed Packets to be
reused quickly, while there is more likelihood of the data still being in
cache.

The new structure has a per-thread private stack for allocating Packets
which does not need any locking. Since Packets can be freed by any thread,
there is a second stack (return stack) for freeing packets by other threads.
The return stack is protected by a mutex. Packets are moved from the return
stack to the private stack when the private stack is empty.

Returning packets back to their "home" stack keeps the stacks from getting out
of balance.

The PacketPoolInit() function is now called by each thread that will be
allocating packets. Each thread allocates max_pending_packets, which is a
change from before, where that was the total number of packets across all
threads.

This code depends on __thread to store one packet pool per thread. I need to find a solution for BSD, but wanted to get feed back on this approach first. One thought the case of not having __thread is to simply have one central buffer stack using a lock. I looked into storing the PktPool in ThreadVars, but that was not available every place a packet is allocated.

Passes regression script:
https://buildbot.suricata-ids.org/builders/ken-tilera/builds/133
https://buildbot.suricata-ids.org/builders/ken-tilera-pcap/builds/67

@poona you might want to see if this is going to break Cuda.
