### PR TITLE
output: clean file desc at exit.

### DIFF
--- a/src/output-file.c
+++ b/src/output-file.c
@@ -277,3 +277,13 @@ void TmModuleFileLoggerRegister (void) {
     tmm_modules[TMM_FILELOGGER].ThreadDeinit = OutputFileLogThreadDeinit;
     tmm_modules[TMM_FILELOGGER].cap_flags = 0;
 }
+
+void OutputFileShutdown(void)
+{
+    OutputFileLogger *logger = list;
+    while (logger) {
+        if (logger->output_ctx != NULL && logger->output_ctx->DeInit != NULL)
+            logger->output_ctx->DeInit(logger->output_ctx);
+        logger = logger->next;
+    }
+}

--- a/src/output-file.h
+++ b/src/output-file.h
@@ -41,4 +41,6 @@ int OutputRegisterFileLogger(const char *name, FileLogger LogFunc, OutputCtx *);
 
 void TmModuleFileLoggerRegister (void);
 
+void OutputFileShutdown(void);
+
 #endif /* __OUTPUT_FILE_H__ */

--- a/src/output-packet.c
+++ b/src/output-packet.c
@@ -217,3 +217,16 @@ void TmModulePacketLoggerRegister (void) {
     tmm_modules[TMM_PACKETLOGGER].ThreadDeinit = OutputPacketLogThreadDeinit;
     tmm_modules[TMM_PACKETLOGGER].cap_flags = 0;
 }
+
+void OutputPacketShutdown(void)
+{
+    OutputPacketLogger *logger = list;
+    while (logger) {
+        if (logger->output_ctx != NULL && logger->output_ctx->DeInit != NULL)
+            logger->output_ctx->DeInit(logger->output_ctx);
+        logger = logger->next;
+    }
+
+    /* FIXME */
+    list = NULL;
+}

--- a/src/output-packet.h
+++ b/src/output-packet.h
@@ -41,4 +41,6 @@ int OutputRegisterPacketLogger(const char *name, PacketLogger LogFunc,
 
 void TmModulePacketLoggerRegister (void);
 
+void OutputPacketShutdown(void);
+
 #endif /* __OUTPUT_PACKET_H__ */

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -284,3 +284,13 @@ void TmModuleTxLoggerRegister (void) {
     tmm_modules[TMM_TXLOGGER].ThreadDeinit = OutputTxLogThreadDeinit;
     tmm_modules[TMM_TXLOGGER].cap_flags = 0;
 }
+
+void OutputTxShutdown(void)
+{
+    OutputTxLogger *logger = list;
+    while (logger) {
+        if (logger->output_ctx != NULL && logger->output_ctx->DeInit != NULL)
+            logger->output_ctx->DeInit(logger->output_ctx);
+        logger = logger->next;
+    }
+}

--- a/src/output-tx.h
+++ b/src/output-tx.h
@@ -40,4 +40,6 @@ int OutputRegisterTxLogger(const char *name, AppProto alproto, TxLogger LogFunc,
 
 void TmModuleTxLoggerRegister (void);
 
+void OutputTxShutdown(void);
+
 #endif /* __OUTPUT_PACKET_H__ */

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -408,6 +408,10 @@ void RunModeShutDown(void)
             output->output_ctx->DeInit(output->output_ctx);
         SCFree(output);
     }
+
+    OutputPacketShutdown();
+    OutputTxShutdown();
+    OutputFileShutdown();
 }
 
 static TmModule *pkt_logger_module = NULL;


### PR DESCRIPTION
This is a beginning of implementation for bug #1660:
 https://redmine.openinfosecfoundation.org/issues/1160

This patch adds a cleaning function for each logger of new type
(packet, tx and file). These functions are called in RunModeShutDown().

The state of this patch is that it is crashing suricata when sending
pcap to analyse:
- At first pcap if tx and file cleaning function are called
- At second pcap if only packet cleaning function is called

The cause in first case is unknown. In second case this is due to
the necessity of cleaning the list of logger registered to a logging
type.
