### PR TITLE
util-ioctl: only get MTU when iface name is set

### DIFF
--- a/src/util-ioctl.c
+++ b/src/util-ioctl.c
@@ -117,7 +117,12 @@ int GetIfaceMTU(char *pcap_dev)
 int GetIfaceMaxPacketSize(char *pcap_dev)
 {
     int ll_header = GetIfaceMaxHWHeaderLength(pcap_dev);
-    int mtu = GetIfaceMTU(pcap_dev);
+    int mtu = 0;
+
+    if ((pcap_dev == NULL) || strlen(pcap_dev) == 0)
+        return 0;
+
+    mtu = GetIfaceMTU(pcap_dev);
     switch (mtu) {
         case 0:
         case -1:


### PR DESCRIPTION
This patch fixes a warning message when suricata is started without
giving an interface name on the command line. The code was trying
to get the MTU even if pcap_dev was not set.

PR builds:
- PR build: https://buildbot.suricata-ids.org/builders/regit/builds/125
- PR pcaps: https://buildbot.suricata-ids.org/builders/regit-pcap/builds/64
