### PR TITLE
packet handling: fix release function

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -82,6 +82,19 @@ int DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     return TM_ECODE_OK;
 }
 
+static inline void PacketFreeExtData(Packet *p)
+{
+    /* if p uses extended data, free them */
+    if (p->ext_pkt) {
+        if (!(p->flags & PKT_ZERO_COPY)) {
+            SCFree(p->ext_pkt);
+        }
+        p->ext_pkt = NULL;
+    }
+}
+
+
+
 /**
  * \brief Return a malloced packet.
  */
@@ -140,6 +153,7 @@ Packet *PacketGetFromAlloc(void)
  */
 void PacketFreeOrRelease(Packet *p)
 {
+    PacketFreeExtData(p);
     if (p->flags & PKT_ALLOC)
         PacketFree(p);
     else

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -273,14 +273,6 @@ void TmqhOutputPacketpool(ThreadVars *t, Packet *p)
         p->root = NULL;
     }
 
-    /* if p uses extended data, free them */
-    if (p->ext_pkt) {
-        if (!(p->flags & PKT_ZERO_COPY)) {
-            SCFree(p->ext_pkt);
-        }
-        p->ext_pkt = NULL;
-    }
-
     PACKET_PROFILING_END(p);
 
     p->ReleasePacket(p);


### PR DESCRIPTION
Extended data were freed before the release function was called.
The result was that, in AF_PACKET IPS mode, the release function
was only sending void data because it the content of the extended
data is the content of the packet.

This patch updates the code to have the freeing of extended data
done in the cleaning function for a packet which is called by the
release function. This improves consistency of the code and fixes
the bug.

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/1176

PR builds:
- PR build: https://buildbot.suricata-ids.org/builders/regit/builds/127
- PR pcaps: https://buildbot.suricata-ids.org/builders/regit-pcap/builds/66
