### PR TITLE
af-packet: fix error handling

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1067,7 +1067,7 @@ static int AFPSynchronizeStart(AFPThreadVars *ptv)
         } else if (r == 0 && AFPPeersListStarted()) {
             SCLogInfo("Starting to read on %s", ptv->tv->name);
             return 1;
-        } else {
+        } else if (r < 0) { /* only exit on error */
             SCLogWarning(SC_ERR_AFP_READ, "poll failed with retval %d", r);
             return 0;
         }


### PR DESCRIPTION
Only exit from synchronization loop on poll error and not in case
of a timeout.
This fixes the suppress the useless error message:

```
[9496] 11/4/2014 -- 12:02:51 - (source-af-packet.c:1071) <Warning> (AFPSynchronizeStart) -- [ERRCODE: SC_ERR_AFP_READ(191)] - poll failed with retval 0
```

PR builds:
- PR build: https://buildbot.suricata-ids.org/builders/regit/builds/128
- PR pcaps: https://buildbot.suricata-ids.org/builders/regit-pcap/builds/67
