### PR TITLE
Fix 2 compiler warnings

### DIFF
--- a/src/detect-engine-payload.c
+++ b/src/detect-engine-payload.c
@@ -505,7 +505,7 @@ static int PayloadTestSig13(void)
     tv_diff.tv_sec = tv_end.tv_sec - tv_start.tv_sec;
     tv_diff.tv_usec = tv_end.tv_usec - tv_start.tv_usec;
 
-    printf("%ld.%06ld\n", tv_diff.tv_sec, (long int)tv_diff.tv_usec);
+    printf("%ld.%06ld\n", (long int)tv_diff.tv_sec, (long int)tv_diff.tv_usec);
 
     result = 1;
 

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -169,7 +169,7 @@ static int CreateFileName(LogTlsFileCtx *log, const Packet *p, SSLState *state, 
      * On a live device, we will not be able to overwrite */
     snprintf(filename, filenamelen, "%s/%ld.%ld-%d.pem",
              tls_logfile_base_dir,
-             p->ts.tv_sec,
+             (long int)p->ts.tv_sec,
              (long int)p->ts.tv_usec,
              file_id);
     return 1;


### PR DESCRIPTION
FreeBSD 10 32-bit with clang 3.3:

<pre>
log-tlslog.c:172:14: error: format specifies type 'long' but the argument has type 'time_t' (aka 'int') [-Werror,-Wformat]
             p->ts.tv_sec,
             ^~~~~~~~~~~~
1 error generated.

detect-engine-payload.c:508:27: warning: format specifies type 'long' but the argument has type 'time_t' (aka 'int') [-Wformat]
    printf("%ld.%06ld\n", tv_diff.tv_sec, (long int)tv_diff.tv_usec);
            ~~~           ^~~~~~~~~~~~~~
            %d
1 warning generated.
</pre>

Prscript:
- PR build: https://buildbot.suricata-ids.org/builders/inliniac/builds/258
- PR pcaps: https://buildbot.suricata-ids.org/builders/inliniac-pcap/builds/177
