### PR TITLE
Fix unaligned load in AC-TILE MPM.

### DIFF
--- a/src/util-mpm-ac-tile-small.c
+++ b/src/util-mpm-ac-tile-small.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013 Open Information Security Foundation
+/* Copyright (C) 2013-2014 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -29,10 +29,6 @@
  *
  */
 #ifdef FUNC_NAME
-// Hint to compiler to expect L2 hit latency for Load int16_t
-#undef SLOAD
-#define SLOAD(x) __insn_ld2s_L2((STYPE* restrict)(x))
-
 
 /* This function handles (ctx->state_count < 32767) */
 uint32_t FUNC_NAME(SCACTileSearchCtx *ctx, MpmThreadCtx *mpm_thread_ctx,


### PR DESCRIPTION
The SLOAD define using __insn_ld2s_L2 is used to provide a compiler
hint that the load will come from the L2 cache instead of the L1. It
also specifies that it is a 2 byte signed load. For the Tiny MPM, that
needs to be a 1-byte load, which is what is specified in util-ac-mpm-tile.c,
but the #undef was removing that definition

This fixes unalgned loads,but it could also fix a real bug.

Passed  prscript.
https://buildbot.suricata-ids.org/builders/ken-tilera-pcap/builds/69
https://buildbot.suricata-ids.org/builders/ken-tilera/builds/135
