### PR TITLE
refactor IDS/IPS engine mode logic

### DIFF
--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -116,7 +116,6 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)
     int i;
     char timebuf[64];
     int decoder_event = 0;
-    extern uint8_t engine_mode;
 
     CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
 
@@ -146,7 +145,7 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)
         }
 
         char *action = "";
-        if ((pa->action & ACTION_DROP) && IS_ENGINE_MODE_IPS(engine_mode)) {
+        if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
             action = "[Drop] ";
         } else if (pa->action & ACTION_DROP) {
             action = "[wDrop] ";

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -57,7 +57,6 @@
 #define DEFAULT_ALERT_SYSLOG_LEVEL              LOG_ERR
 #define MODULE_NAME                             "AlertSyslog"
 
-extern uint8_t engine_mode;
 static int alert_syslog_level = DEFAULT_ALERT_SYSLOG_LEVEL;
 
 typedef struct AlertSyslogThread_ {
@@ -221,7 +220,7 @@ static TmEcode AlertSyslogIPv4(ThreadVars *tv, const Packet *p, void *data)
         PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), dstip, sizeof(dstip));
 
-        if ((pa->action & ACTION_DROP) && IS_ENGINE_MODE_IPS(engine_mode)) {
+        if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
             action = "[Drop] ";
         } else if (pa->action & ACTION_DROP) {
             action = "[wDrop] ";
@@ -279,7 +278,7 @@ static TmEcode AlertSyslogIPv6(ThreadVars *tv, const Packet *p, void *data)
         PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), dstip, sizeof(dstip));
 
-        if ((pa->action & ACTION_DROP) && IS_ENGINE_MODE_IPS(engine_mode)) {
+        if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
             action = "[Drop] ";
         } else if (pa->action & ACTION_DROP) {
             action = "[wDrop] ";
@@ -341,7 +340,7 @@ static TmEcode AlertSyslogDecoderEvent(ThreadVars *tv, const Packet *p, void *da
             continue;
         }
 
-        if ((pa->action & ACTION_DROP) && IS_ENGINE_MODE_IPS(engine_mode)) {
+        if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
             action = "[Drop] ";
         } else if (pa->action & ACTION_DROP) {
             action = "[wDrop] ";

--- a/src/detect.c
+++ b/src/detect.c
@@ -194,7 +194,6 @@
 
 #include "runmodes.h"
 
-extern uint8_t engine_mode;
 extern int rule_reload;
 
 extern int engine_analysis;
@@ -10960,7 +10959,7 @@ static int SigTestDropFlow03(void)
     uint32_t http_buf2_len = sizeof(http_buf1) - 1;
 
     /* Set the engine mode to IPS */
-    SET_ENGINE_MODE_IPS(engine_mode);
+    EngineModeSetIPS();
 
     TcpSession ssn;
     Packet *p1 = NULL;
@@ -11113,7 +11112,7 @@ end:
     UTHFreePackets(&p2, 1);
 
     /* Restore mode to IDS */
-    SET_ENGINE_MODE_IDS(engine_mode);
+    EngineModeSetIDS();
     return result;
 }
 

--- a/src/log-droplog.c
+++ b/src/log-droplog.c
@@ -268,8 +268,7 @@ static int LogDropLogNetFilter (ThreadVars *tv, const Packet *p, void *data)
  * \retval bool TRUE or FALSE
  */
 static int LogDropCondition(ThreadVars *tv, const Packet *p) {
-    extern uint8_t engine_mode;
-    if (!IS_ENGINE_MODE_IPS(engine_mode)) {
+    if (!EngineModeIsIPS()) {
         SCLogDebug("engine is not running in inline mode, so returning");
         return FALSE;
     }
@@ -341,8 +340,7 @@ static void LogDropLogExitPrintStats(ThreadVars *tv, void *data) {
 int LogDropLogTest01()
 {
     int result = 0;
-    extern uint8_t engine_mode;
-    SET_ENGINE_MODE_IPS(engine_mode);
+    EngineModeSetIPS();
 
     uint8_t *buf = (uint8_t *) "GET /one/ HTTP/1.1\r\n"
         "Host: one.example.org\r\n";
@@ -404,6 +402,7 @@ int LogDropLogTest01()
     DetectEngineCtxFree(de_ctx);
 
     UTHFreePackets(&p, 1);
+    EngineModeSetIDS();
     return result;
 }
 
@@ -411,8 +410,7 @@ int LogDropLogTest01()
 int LogDropLogTest02()
 {
     int result = 0;
-    extern uint8_t engine_mode;
-    SET_ENGINE_MODE_IPS(engine_mode);
+    EngineModeSetIPS();
 
     uint8_t *buf = (uint8_t *) "GET";
 
@@ -473,6 +471,8 @@ int LogDropLogTest02()
     DetectEngineCtxFree(de_ctx);
 
     UTHFreePackets(&p, 1);
+
+    EngineModeSetIDS();
     return result;
 }
 

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -62,8 +62,6 @@
 
 #ifdef HAVE_LIBJANSSON
 
-extern int engine_mode;
-
 typedef struct JsonAlertLogThread_ {
     /** LogFileCtx has the pointer to the file and a mutex to allow multithreading */
     LogFileCtx* file_ctx;
@@ -96,7 +94,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
         char *action = "allowed";
         if (pa->action & (ACTION_REJECT|ACTION_REJECT_DST|ACTION_REJECT_BOTH)) {
             action = "blocked";
-        } else if ((pa->action & ACTION_DROP) && IS_ENGINE_MODE_IPS(engine_mode)) {
+        } else if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
             action = "blocked";
         }
 
@@ -151,7 +149,7 @@ static int AlertJsonDecoderEvent(ThreadVars *tv, JsonAlertLogThread *aft, const 
         char *action = "allowed";
         if (pa->action & (ACTION_REJECT|ACTION_REJECT_DST|ACTION_REJECT_BOTH)) {
             action = "blocked";
-        } else if ((pa->action & ACTION_DROP) && IS_ENGINE_MODE_IPS(engine_mode)) {
+        } else if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
             action = "blocked";
         }
 

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -289,8 +289,7 @@ static int JsonDropLogger(ThreadVars *tv, void *thread_data, const Packet *p)
  * \retval bool TRUE or FALSE
  */
 static int JsonDropLogCondition(ThreadVars *tv, const Packet *p) {
-    extern uint8_t engine_mode;
-    if (!IS_ENGINE_MODE_IPS(engine_mode)) {
+    if (!EngineModeIsIPS()) {
         SCLogDebug("engine is not running in inline mode, so returning");
         return FALSE;
     }

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -117,7 +117,6 @@ void OutputJsonRegisterTests (void)
 
 #define OUTPUT_BUFFER_SIZE 65535
 
-extern uint8_t engine_mode;
 #ifndef OS_WIN32
 static int alert_syslog_level = DEFAULT_ALERT_SYSLOG_LEVEL;
 #endif /* OS_WIN32 */

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -114,8 +114,6 @@ static SCMutex ssn_pool_mutex = SCMUTEX_INITIALIZER; /**< init only, protect ini
 static uint64_t ssn_pool_cnt = 0; /** counts ssns, protected by ssn_pool_mutex */
 #endif
 
-extern uint8_t engine_mode;
-
 SC_ATOMIC_DECLARE(uint64_t, st_memuse);
 
 /* stream engine running in "inline" mode. */
@@ -426,7 +424,7 @@ void StreamTcpInitConfig(char quiet)
         /* checking for "auto" and falling back to boolean to provide
          * backward compatibility */
         if (strcmp(temp_stream_inline_str, "auto") == 0) {
-            if (IS_ENGINE_MODE_IPS(engine_mode)) {
+            if (EngineModeIsIPS()) {
                 stream_inline = 1;
             } else {
                 stream_inline = 0;

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -135,12 +135,11 @@ void StreamTcpReassembleConfigEnableOverlapCheck(void);
   * \retval 0 if the stream still legal
   */
 static inline int StreamTcpCheckFlowDrops(Packet *p) {
-    extern uint8_t engine_mode;
     /* If we are on IPS mode, and got a drop action triggered from
      * the IP only module, or from a reassembled msg and/or from an
      * applayer detection, then drop the rest of the packets of the
      * same stream and avoid inspecting it any further */
-    if (IS_ENGINE_MODE_IPS(engine_mode) && (p->flow->flags & FLOW_ACTION_DROP))
+    if (EngineModeIsIPS() && (p->flow->flags & FLOW_ACTION_DROP))
         return 1;
 
     return 0;

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -100,20 +100,15 @@ enum {
 };
 
 /* Engine is acting as */
-enum {
+enum EngineMode {
     ENGINE_MODE_IDS,
     ENGINE_MODE_IPS,
 };
 
-/** You can use this macros to set/check if we have real drop capabilities */
-#define SET_ENGINE_MODE_IPS(engine_mode) do { \
-	    (engine_mode) = ENGINE_MODE_IPS; \
-    } while (0)
-#define SET_ENGINE_MODE_IDS(engine_mode) do { \
-	    (engine_mode) = ENGINE_MODE_IDS; \
-    } while (0)
-#define IS_ENGINE_MODE_IPS(engine_mode)  ((engine_mode) == ENGINE_MODE_IPS)
-#define IS_ENGINE_MODE_IDS(engine_mode)  ((engine_mode) == ENGINE_MODE_IDS)
+void EngineModeSetIPS(void);
+void EngineModeSetIDS(void);
+int EngineModeIsIPS(void);
+int EngineModeIsIDS(void);
 
 /* Box is acting as router */
 enum {


### PR DESCRIPTION
Instead of error prone externs with macro's, use functions with a local
static enum var instead.
- EngineModeIsIPS(): in IPS mode
- EngineModeIsIDS(): in IDS mode

To set the modes:
- EngineModeSetIDS(): IDS mode (default)
- EngineModeSetIPS(): IPS mode

Bug #1177. https://redmine.openinfosecfoundation.org/issues/1177

Prscript:
- PR build: https://buildbot.suricata-ids.org/builders/inliniac/builds/263
- PR pcaps: https://buildbot.suricata-ids.org/builders/inliniac-pcap/builds/182
