### PR TITLE
json: add custom output capability to http eve log

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -96,6 +96,9 @@ outputs:
         - alert
         - http:
             extended: yes     # enable this for extended logging information
+            # custom allows additional http fields to be included in eve-log
+            # the example below adds three additional fields when uncommented
+            #custom: [Accept-Encoding, Accept-Language, Authorization]
         - dns
         - tls:
             extended: yes     # enable this for extended logging information


### PR DESCRIPTION
This is the eve-log custom http log output capability changes.  This permits the addition of custom http fields in the json eve log output via configuration contained in the suricata.yaml file.
- PR build: https://buildbot.suricata-ids.org/builders/decanio/builds/16
- PR pcaps: https://buildbot.suricata-ids.org/builders/decanio-pcap/builds/3
