### PR TITLE
rohash: fix potential bad shift

### DIFF
--- a/src/util-rohash.c
+++ b/src/util-rohash.c
@@ -56,7 +56,7 @@ typedef struct ROHashTableOffsets_ {
 
 /** \brief initialize a new rohash
  *
- *  \param hash_bits hash size as 2^hash_bits, so power of 2
+ *  \param hash_bits hash size as 2^hash_bits, so power of 2, max 31
  *  \param item_size size of the data to store
  *
  *  \retval table ptr or NULL on error
@@ -66,8 +66,8 @@ ROHashTable *ROHashInit(uint8_t hash_bits, uint16_t item_size) {
         SCLogError(SC_ERR_HASH_TABLE_INIT, "data size must be multiple of 4");
         return NULL;
     }
-    if (hash_bits < 4 || hash_bits > 32) {
-        SCLogError(SC_ERR_HASH_TABLE_INIT, "invalid hash_bits setting, valid range is 4-32");
+    if (hash_bits < 4 || hash_bits > 31) {
+        SCLogError(SC_ERR_HASH_TABLE_INIT, "invalid hash_bits setting, valid range is 4-31");
         return NULL;
     }
 


### PR DESCRIPTION
Fix issue detected by Coverity:

<pre>
*** CID 1197756:  Bad bit shift operation  (BAD_SHIFT)
/src/util-rohash.c: 74 in ROHashInit()
68         }
69         if (hash_bits < 4 || hash_bits > 32) {
70             SCLogError(SC_ERR_HASH_TABLE_INIT, "invalid hash_bits setting, valid range is 4-32");
71             return NULL;
72         }
73
>>>     CID 1197756:  Bad bit shift operation  (BAD_SHIFT)
>>>     In expression "1U << hash_bits", left shifting by more than 31 bits has undefined behavior.  The shift amount, "hash_bits", is as much as 32.
74         uint32_t size = hashsize(hash_bits) * sizeof(ROHashTableOffsets);
75
76         ROHashTable *table = SCMalloc(sizeof(ROHashTable) + size);
77         if (unlikely(table == NULL)) {
78             SCLogError(SC_ERR_HASH_TABLE_INIT, "failed to alloc memory");
79             return NULL;
</pre>


This was only a potential issue as ROHashInit was only called with
hash_bits 16 in the code.

Bug #1170. https://redmine.openinfosecfoundation.org/issues/1170

Prscript:
- PR build: https://buildbot.suricata-ids.org/builders/inliniac/builds/281
- PR pcaps: https://buildbot.suricata-ids.org/builders/inliniac-pcap/builds/199
