### PR TITLE
doxygen: add source browser

### DIFF
--- a/doxygen.cfg
+++ b/doxygen.cfg
@@ -790,7 +790,7 @@ USE_MDFILE_AS_MAINPAGE =
 # Note: To get rid of all source code in the generated output, make sure also
 # VERBATIM_HEADERS is set to NO.
 
-SOURCE_BROWSER         = NO
+SOURCE_BROWSER         = YES
 
 # Setting the INLINE_SOURCES tag to YES will include the body
 # of functions and classes directly in the documentation.


### PR DESCRIPTION
As discussed on IRC, here's a patch to have link to source code in doxygen doc.
