### PR TITLE
eve-log: swap ip/port pairs in dns answers

### DIFF
--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -217,15 +217,22 @@ static int JsonDnsLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flo
 
     LogDnsLogThread *td = (LogDnsLogThread *)thread_data;
     DNSTransaction *tx = txptr;
-
-    json_t *js = CreateJSONHeader((Packet *)p, 1, "dns");//TODO const
-    if (unlikely(js == NULL))
-        return TM_ECODE_OK;
+    json_t *js;
 
     DNSQueryEntry *query = NULL;
     TAILQ_FOREACH(query, &tx->query_list, next) {
+        js = CreateJSONHeader((Packet *)p, 1, "dns");
+        if (unlikely(js == NULL))
+            return TM_ECODE_OK;
+
         LogQuery(td, js, tx, query);
+
+        json_decref(js);
     }
+
+    js = CreateJSONHeader((Packet *)p, 0, "dns");
+    if (unlikely(js == NULL))
+        return TM_ECODE_OK;
 
     LogAnswers(td, js, tx);
 


### PR DESCRIPTION
Swap ip/port pairs in dns answer eve jon logs.

The PR script didn't produce proper output due to a password change, but here's the URLs for the buildbot output.

https://buildbot.suricata-ids.org/builders/decanio/builds/17
https://buildbot.suricata-ids.org/builders/decanio-pcap/builds/4
