### PR TITLE
detect: add more defensive checks for flow handling

### DIFF
--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -212,15 +212,24 @@ void DetectEngineStateFree(DetectEngineState *state)
     return;
 }
 
+/**
+ *  \retval 0 no inspectable state
+ *  \retval 1 inspectable state
+ *  \retval 2 inspectable state, but no update
+ */
 int DeStateFlowHasInspectableState(Flow *f, AppProto alproto, uint16_t alversion, uint8_t flags)
 {
     int r = 0;
+
+    if (f->alparser == NULL || f->alstate == NULL)
+        return 0;
 
     SCMutexLock(&f->de_state_m);
     if (f->de_state == NULL || f->de_state->dir_state[flags & STREAM_TOSERVER ? 0 : 1].cnt == 0) {
         if (AppLayerParserProtocolSupportsTxs(f->proto, alproto)) {
             FLOWLOCK_RDLOCK(f);
-            if (AppLayerParserGetTransactionInspectId(f->alparser, flags) >= AppLayerParserGetTxCnt(f->proto, alproto, f->alstate))
+            if (AppLayerParserGetTransactionInspectId(f->alparser, flags) >=
+                    AppLayerParserGetTxCnt(f->proto, alproto, f->alstate))
                 r = 2;
             else
                 r = 0;


### PR DESCRIPTION
Don't unconditionally deref f->alparser in detection through
DeStateFlowHasInspectableState(). In very rare cases it can
be NULL.

Prscript:
- PR build: https://buildbot.suricata-ids.org/builders/inliniac/builds/290
- PR pcaps: https://buildbot.suricata-ids.org/builders/inliniac-pcap/builds/208
