### PR TITLE
unix-socket: reset logging api's properly

### DIFF
--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -424,6 +424,11 @@ void RunOutputFreeList(void)
     }
 }
 
+static TmModule *pkt_logger_module = NULL;
+static TmModule *tx_logger_module = NULL;
+static TmModule *file_logger_module = NULL;
+static TmModule *filedata_logger_module = NULL;
+
 /**
  * Cleanup the run mode.
  */
@@ -444,12 +449,12 @@ void RunModeShutDown(void)
         SCFree(output);
     }
 
+    /* reset logger pointers */
+    pkt_logger_module = NULL;
+    tx_logger_module = NULL;
+    file_logger_module = NULL;
+    filedata_logger_module = NULL;
 }
-
-static TmModule *pkt_logger_module = NULL;
-static TmModule *tx_logger_module = NULL;
-static TmModule *file_logger_module = NULL;
-static TmModule *filedata_logger_module = NULL;
 
 /** \internal
  *  \brief add Sub RunModeOutput to list for Submodule so we can free


### PR DESCRIPTION
Lack of proper reset lead to logs not being written after the first
pcap had been processed.

Prscript:
- PR build: https://buildbot.suricata-ids.org/builders/inliniac/builds/296
- PR pcaps: https://buildbot.suricata-ids.org/builders/inliniac-pcap/builds/213
