### PR TITLE
Fix live reload segv when startup isn't complete

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -496,6 +496,13 @@ static void *DetectEngineLiveRuleSwap(void *arg)
         tv = tv->next;
     }
 
+    if (no_of_detect_tvs == 0) {
+        TmThreadsSetFlag(tv_local, THV_CLOSED);
+        UtilSignalHandlerSetup(SIGUSR2, SignalHandlerSigusr2);
+        SCLogInfo("===== Live rule swap FAILURE =====");
+        pthread_exit(NULL);
+    }
+
     DetectEngineThreadCtx *old_det_ctx[no_of_detect_tvs];
     DetectEngineThreadCtx *new_det_ctx[no_of_detect_tvs];
     ThreadVars *detect_tvs[no_of_detect_tvs];


### PR DESCRIPTION
If a live reload signal was given before the engine was fully started
up (e.g. pcap file thread waiting for a disk to spin up), a segv could
occur.

This patch only enables live reloads after the threads have been
started up completely.

Prscript:
- PR build: https://buildbot.suricata-ids.org/builders/inliniac/builds/320
- PR pcaps: https://buildbot.suricata-ids.org/builders/inliniac-pcap/builds/235
