### PR TITLE
defrag: fix reconstruction

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -697,7 +697,7 @@ insert:
 
     Frag *frag;
     TAILQ_FOREACH(frag, &tracker->frags, next) {
-        if (frag_offset < frag->offset)
+        if (new->offset < frag->offset)
             break;
     }
     if (frag == NULL) {


### PR DESCRIPTION
This patch is fixing an issue in defragmentation code. The
insertion of a fragment in the list of fragments is done with
respect to the offset of the fragment. But the code was using
the original offset of the fragment and not the one of the
new reconstructed fragment (which can be different in the
case of overlapping segment where the left part is trimmed).

This case could lead to some evasion techniques by causing
Suricata to analyse a different payload.

PR builds:
- PR build: https://buildbot.suricata-ids.org/builders/regit/builds/132
- PR pcaps: https://buildbot.suricata-ids.org/builders/regit-pcap/builds/71
