### PR TITLE
Fix issue #1214

### DIFF
--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -461,7 +461,7 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
                         "an event var set.  The signature event var is "
                         "given precedence over the threshold.conf one.  "
                         "We'll change this in the future though.", s->id);
-                goto end;
+                continue;
             }
 
             sm = SigMatchGetLastSMFromLists(s, 2,
@@ -471,7 +471,7 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
                         "an event var set.  The signature event var is "
                         "given precedence over the threshold.conf one.  "
                         "We'll change this in the future though.", s->id);
-                goto end;
+                continue;
             }
 
             de = SCMalloc(sizeof(DetectThresholdData));
@@ -525,7 +525,7 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
                             "an event var set.  The signature event var is "
                             "given precedence over the threshold.conf one.  "
                             "We'll change this in the future though.", id);
-                    goto end;
+                    continue;
                 }
 
                 sm = SigMatchGetLastSMFromLists(s, 2,
@@ -535,7 +535,7 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
                             "an event var set.  The signature event var is "
                             "given precedence over the threshold.conf one.  "
                             "We'll change this in the future though.", id);
-                    goto end;
+                    continue;
                 }
 
                 de = SCMalloc(sizeof(DetectThresholdData));


### PR DESCRIPTION
When applying wildcard thresholds (with sid = 0 and/or gid = 0) it's wrong
to exit on the first signature already having an event filter. Indeed,
doing so results in the theshold not being applied to all subsequent
signatures. Change the code in order to skip signatures with event
filters instead of breaking out of the loop.
