### PR TITLE
Rework Tile CPU affinity setting to handle non-contiguous sets of CPUs.

### DIFF
--- a/src/runmode-tile.c
+++ b/src/runmode-tile.c
@@ -194,6 +194,16 @@ int RunModeTileMpipeWorkers(DetectEngineCtx *de_ctx)
         }
     }
 
+    /* Get affinity for worker */
+    cpu_set_t cpus;
+    //int result = tmc_cpus_get_my_affinity(&cpus);
+    int result = tmc_cpus_get_dataplane_cpus(&cpus);
+    if (result < 0) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT, 
+                   "tmc_cpus_get_my_affinity() returned=%d", result);
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+
     for (pipe = 0; pipe < tile_num_pipelines; pipe++) {
         char *mpipe_devc;
 
@@ -231,8 +241,10 @@ int RunModeTileMpipeWorkers(DetectEngineCtx *de_ctx)
         }
         TmSlotSetFuncAppend(tv_worker, tm_module, (void *)mpipe_devc);
 
-        /* set affinity for worker */
-        int pipe_cpu = pipe + 1;
+	/* Bind to a single cpu. */
+	int pipe_cpu = tmc_cpus_find_nth_cpu(&cpus, pipe);
+	tv_worker->rank = pipe;
+
         TmThreadSetCPUAffinity(tv_worker, pipe_cpu);
 
         tm_module = TmModuleGetByName("DecodeMpipe");

--- a/src/source-mpipe.c
+++ b/src/source-mpipe.c
@@ -331,7 +331,7 @@ TmEcode ReceiveMpipeLoop(ThreadVars *tv, void *data, void *slot)
     ptv->slot = s->slot_next;
     Packet *p = NULL;
     int cpu = tmc_cpus_get_my_cpu();
-    int rank = cpu - 1;
+    int rank = tv->rank;
     int max_queued = 0;
     char *ctype;
 
@@ -875,8 +875,7 @@ static int MpipeReceiveOpenEgress(char *out_iface, int iface_idx,
 TmEcode ReceiveMpipeThreadInit(ThreadVars *tv, void *initdata, void **data)
 {
     SCEnter();
-    int cpu = tmc_cpus_get_my_cpu();
-    int rank = (cpu-1); // FIXME: Assumes worker CPUs start at 1.
+    int rank = tv->rank;
     int num_buckets = 4096; 
     int num_workers = tile_num_pipelines;
 
@@ -896,13 +895,6 @@ TmEcode ReceiveMpipeThreadInit(ThreadVars *tv, void *initdata, void **data)
     int result;
     char *link_name = (char *)initdata;
   
-    /* Bind to a single cpu. */
-    cpu_set_t cpus;
-    result = tmc_cpus_get_my_affinity(&cpus);
-    VERIFY(result, "tmc_cpus_get_my_affinity()");
-    result = tmc_cpus_set_my_cpu(tmc_cpus_find_first_cpu(&cpus));
-    VERIFY(result, "tmc_cpus_set_my_cpu()");
-
     MpipeRegisterPerfCounters(ptv, tv);
 
     *data = (void *)ptv;

--- a/src/threadvars.h
+++ b/src/threadvars.h
@@ -93,6 +93,7 @@ typedef struct ThreadVars_ {
     uint8_t type;
 
     uint16_t cpu_affinity; /** cpu or core number to set affinity to */
+    uint16_t rank;
     int thread_priority; /** priority (real time) for this thread. Look at threads.h */
 
     /* the perf counter context and the perf counter array */


### PR DESCRIPTION
It is possible to have a non-contiguous CPU set, which was not being
handled correctly on the TILE architecture.

Added a "rank" field in the ThreadVar to store the worker's rank separately
from the cpu for this case.

passes PR script:
- PR pcaps: https://buildbot.suricata-ids.org/builders/ken-tilera-pcap/builds/71
- PR build: https://buildbot.suricata-ids.org/builders/ken-tilera/builds/137
