### PR TITLE
Added RunModeNapatechUnregister in order to call NT_Done().

### DIFF
--- a/src/runmode-napatech.c
+++ b/src/runmode-napatech.c
@@ -59,6 +59,13 @@ const char *RunModeNapatechGetDefaultMode(void)
     return default_mode;
 }
 
+void RunModeNapatechUnregister(void)
+{
+#ifdef HAVE_NAPATECH
+	NT_Done();
+#endif
+}
+
 void RunModeNapatechRegister(void)
 {
 #ifdef HAVE_NAPATECH

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -446,6 +446,8 @@ void RunModeShutDown(void)
     OutputTxShutdown();
     OutputFileShutdown();
     OutputFiledataShutdown();
+    
+    RunModeNapatechUnregister();
 
     /* Close any log files. */
     RunModeOutput *output;


### PR DESCRIPTION
In order for Napatech connection to be properly shut down, one should call NT_Done().
