### PR TITLE
coccinelle: fix problem with coccinelle 1.0rc21

### DIFF
--- a/qa/coccinelle/banned-functions.cocci
+++ b/qa/coccinelle/banned-functions.cocci
@@ -1,17 +1,15 @@
 @banned@
-identifier func =~ "^(sprintf|strcat|strcpy|strncpy|strncat|strndup|strchrdup)$";
+identifier i;
 position p1;
 @@
 
-<+...
-func(...)@p1
-...+>
+\(sprintf@i\|strcat@i\|strcpy@i\|strncpy@i\|strncat@i\|strndup@i\|strchrdup@i\)(...)@p1
 
-@ script:python @
+@script:python@
 p1 << banned.p1;
-func << banned.func;
+i << banned.i;
 @@
 
-print "Banned function %s() used at %s:%s" % (func, p1[0].file, p1[0].line)
+print("Banned function '%s' used at %s:%s" % (i, p1[0].file, p1[0].line))
 import sys
 sys.exit(1)


### PR DESCRIPTION
coccinelle 1.0rc21 has a problem with regular expression handling.
This result in a Fatal Error when test system detects an coding
error.

This patch fixes the problem by using a simple blob inside
semantic patch instead of using a regular expression to define
the function.

It also fixes add an optimization on matching suppressing a
useless <.. ..> construction.

Fixes have been suggested by Julia Lawall.
