### PR TITLE
Add interface name to JSON alert

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -57,6 +57,7 @@
 #include "util-optimize.h"
 #include "util-buffer.h"
 #include "util-logopenfile.h"
+#include "util-device.h"
 
 
 #ifndef HAVE_LIBJANSSON
@@ -208,6 +209,10 @@ json_t *CreateJSONHeader(Packet *p, int direction_sensitive, char *event_type)
     /* sensor id */
     if (sensor_id >= 0)
         json_object_set_new(js, "sensor_id", json_integer(sensor_id));
+
+    /* interface */
+    if (p->livedev)
+        json_object_set_new(js, "in_iface", json_string(p->livedev->dev));
 
     /* pcap_cnt */
     if (p->pcap_cnt != 0) {


### PR DESCRIPTION
Fixed/rebased  #1015.
This pull request extends the JSON logging - adds ability to log interface name in JSON alert. For instance, Snort can log interface name and it can be useful sometimes.
