### PR TITLE
autotools: enable silent mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@
 
 
     AC_INIT(suricata, 2.0dev)
+    m4_ifndef([AM_SILENT_RULES], [m4_define([AM_SILENT_RULES],[])])AM_SILENT_RULES([yes])
     AC_CONFIG_HEADERS([config.h])
     AC_CONFIG_SRCDIR([src/suricata.c])
     AC_CONFIG_MACRO_DIR(m4)


### PR DESCRIPTION
Add check to make sure that if the functionality isn't available, we
don't error out.

Replaces #1025
