### PR TITLE
Store Boyer Moore no case strings as lowercase

### DIFF
--- a/src/detect-nocase.c
+++ b/src/detect-nocase.c
@@ -41,6 +41,7 @@
 #include "detect-http-uri.h"
 
 #include "util-debug.h"
+#include "util-memcpy.h"
 
 static int DetectNocaseSetup (DetectEngineCtx *, Signature *, char *);
 
@@ -118,6 +119,9 @@ static int DetectNocaseSetup (DetectEngineCtx *de_ctx, Signature *s, char *nulls
         goto end;
     }
     cd->flags |= DETECT_CONTENT_NOCASE;
+    /* Store the content as lower case to make searching faster */
+    memcpy_tolower(cd->content, cd->content, cd->content_len);
+
     /* Recreate the context with nocase chars */
     BoyerMooreCtxToNocase(cd->bm_ctx, cd->content, cd->content_len);
 

--- a/src/util-spm-bm.c
+++ b/src/util-spm-bm.c
@@ -325,7 +325,8 @@ uint8_t *BoyerMooreNocase(uint8_t *x, uint16_t m, uint8_t *y, int32_t n, uint16_
 #endif
     j = 0;
     while (j <= n - m ) {
-        for (i = m - 1; i >= 0 && u8_tolower(x[i]) == u8_tolower(y[i + j]); --i);
+        /* x is stored in lowercase. */
+        for (i = m - 1; i >= 0 && x[i] == u8_tolower(y[i + j]); --i);
 
         if (i < 0) {
             return y + j;


### PR DESCRIPTION
Rather than convert Boyer Moore nocase search strings to lowercase on the fly, store them in lowercase.
