### PR TITLE
Store Boyer Moore no case strings as lowercase

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -190,9 +190,9 @@ static AppProto AppLayerProtoDetectPMMatchSignature(const AppLayerProtoDetectPMS
                s->cd->offset, s->cd->depth);
 
     if (s->cd->flags & DETECT_CONTENT_NOCASE)
-        found = BoyerMooreNocase(s->cd->content, s->cd->content_len, sbuf, sbuflen, s->cd->bm_ctx->bmGs, s->cd->bm_ctx->bmBc);
+        found = BoyerMooreNocase(s->cd->content, s->cd->content_len, sbuf, sbuflen, s->cd->bm_ctx);
     else
-        found = BoyerMoore(s->cd->content, s->cd->content_len, sbuf, sbuflen, s->cd->bm_ctx->bmGs, s->cd->bm_ctx->bmBc);
+        found = BoyerMoore(s->cd->content, s->cd->content_len, sbuf, sbuflen, s->cd->bm_ctx);
     if (found != NULL)
         proto = s->alproto;
 

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -274,9 +274,9 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
 
             /* do the actual search */
             if (cd->flags & DETECT_CONTENT_NOCASE)
-                found = BoyerMooreNocase(cd->content, cd->content_len, sbuffer, sbuffer_len, cd->bm_ctx->bmGs, cd->bm_ctx->bmBc);
+                found = BoyerMooreNocase(cd->content, cd->content_len, sbuffer, sbuffer_len, cd->bm_ctx);
             else
-                found = BoyerMoore(cd->content, cd->content_len, sbuffer, sbuffer_len, cd->bm_ctx->bmGs, cd->bm_ctx->bmBc);
+                found = BoyerMoore(cd->content, cd->content_len, sbuffer, sbuffer_len, cd->bm_ctx);
 
             /* next we evaluate the result in combination with the
              * negation flag. */

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -220,8 +220,7 @@ static int DetectFilemagicMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         /* we include the \0 in the inspection, so patterns can match on the
          * end of the string. */
         if (BoyerMooreNocase(filemagic->name, filemagic->len, (uint8_t *)file->magic,
-                    strlen(file->magic) + 1, filemagic->bm_ctx->bmGs,
-                    filemagic->bm_ctx->bmBc) != NULL)
+                    strlen(file->magic) + 1, filemagic->bm_ctx) != NULL)
         {
 #ifdef DEBUG
             if (SCLogDebugEnabled()) {

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -105,8 +105,7 @@ static int DetectFilenameMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         SCReturnInt(0);
 
     if (BoyerMooreNocase(filename->name, filename->len, file->name,
-                file->name_len, filename->bm_ctx->bmGs,
-                filename->bm_ctx->bmBc) != NULL)
+                file->name_len, filename->bm_ctx) != NULL)
     {
 #ifdef DEBUG
         if (SCLogDebugEnabled()) {

--- a/src/detect-nocase.c
+++ b/src/detect-nocase.c
@@ -41,7 +41,6 @@
 #include "detect-http-uri.h"
 
 #include "util-debug.h"
-#include "util-memcpy.h"
 
 static int DetectNocaseSetup (DetectEngineCtx *, Signature *, char *);
 
@@ -119,8 +118,6 @@ static int DetectNocaseSetup (DetectEngineCtx *de_ctx, Signature *s, char *nulls
         goto end;
     }
     cd->flags |= DETECT_CONTENT_NOCASE;
-    /* Store the content as lower case to make searching faster */
-    memcpy_tolower(cd->content, cd->content, cd->content_len);
 
     /* Recreate the context with nocase chars */
     BoyerMooreCtxToNocase(cd->bm_ctx, cd->content, cd->content_len);

--- a/src/util-spm-bm.c
+++ b/src/util-spm-bm.c
@@ -36,6 +36,14 @@
 #include "util-spm-bm.h"
 #include "util-debug.h"
 #include "util-error.h"
+#include "util-memcpy.h"
+
+static int PreBmGs(const uint8_t *x, uint16_t m, uint16_t *bmGs);
+static void PreBmBc(const uint8_t *x, uint16_t m, uint16_t *bmBc);
+static void PreBmBcNocase(const uint8_t *x, uint16_t m, uint16_t *bmBc);
+static void BoyerMooreSuffixesNocase(const uint8_t *x, uint16_t m, 
+                                     uint16_t *suff);
+static void PreBmGsNocase(const uint8_t *x, uint16_t m, uint16_t *bmGs);
 
 /**
  * \brief Given a BmCtx structure, recreate the pre/suffixes for
@@ -46,6 +54,8 @@
  * \param size length of the string
  */
 void BoyerMooreCtxToNocase(BmCtx *bm_ctx, uint8_t *needle, uint16_t needle_len) {
+    /* Store the content as lower case to make searching faster */
+    memcpy_tolower(needle, needle, needle_len);
 
     /* Prepare bad chars with nocase chars */
     PreBmBcNocase(needle, needle_len, bm_ctx->bmBc);
@@ -113,7 +123,8 @@ void BoyerMooreCtxDeInit(BmCtx *bmctx)
  * \param size length of the string
  * \param result pointer to an empty array that will hold the badchars
  */
-void PreBmBc(const uint8_t *x, uint16_t m, uint16_t *bmBc) {
+static void PreBmBc(const uint8_t *x, uint16_t m, uint16_t *bmBc)
+{
     int32_t i;
 
     for (i = 0; i < 256; ++i) {
@@ -131,7 +142,7 @@ void PreBmBc(const uint8_t *x, uint16_t m, uint16_t *bmBc) {
  * \param m length of the string
  * \param suff pointer to an empty array that will hold the prefixes (shifts)
  */
-void BoyerMooreSuffixes(const uint8_t *x, uint16_t m, uint16_t *suff) {
+static void BoyerMooreSuffixes(const uint8_t *x, uint16_t m, uint16_t *suff) {
     int32_t f = 0, g, i;
     suff[m - 1] = m;
     g = m - 1;
@@ -157,7 +168,8 @@ void BoyerMooreSuffixes(const uint8_t *x, uint16_t m, uint16_t *suff) {
  * \param bmGs pointer to an empty array that will hold the prefixes (shifts)
  * \retval 0 ok, -1 failed
  */
-int PreBmGs(const uint8_t *x, uint16_t m, uint16_t *bmGs) {
+static int PreBmGs(const uint8_t *x, uint16_t m, uint16_t *bmGs)
+{
     int32_t i, j;
     uint16_t suff[m + 1];
 
@@ -187,7 +199,8 @@ int PreBmGs(const uint8_t *x, uint16_t m, uint16_t *bmGs) {
  * \param size length of the string
  * \param result pointer to an empty array that will hold the badchars
  */
-void PreBmBcNocase(const uint8_t *x, uint16_t m, uint16_t *bmBc) {
+static void PreBmBcNocase(const uint8_t *x, uint16_t m, uint16_t *bmBc)
+{
     int32_t i;
 
     for (i = 0; i < 256; ++i) {
@@ -198,7 +211,9 @@ void PreBmBcNocase(const uint8_t *x, uint16_t m, uint16_t *bmBc) {
     }
 }
 
-void BoyerMooreSuffixesNocase(const uint8_t *x, uint16_t m, uint16_t *suff) {
+static void BoyerMooreSuffixesNocase(const uint8_t *x, uint16_t m, 
+                                     uint16_t *suff)
+{
     int32_t f = 0, g, i;
 
     suff[m - 1] = m;
@@ -227,7 +242,8 @@ void BoyerMooreSuffixesNocase(const uint8_t *x, uint16_t m, uint16_t *suff) {
  * \param m length of the string
  * \param bmGs pointer to an empty array that will hold the prefixes (shifts)
  */
-void PreBmGsNocase(const uint8_t *x, uint16_t m, uint16_t *bmGs) {
+static void PreBmGsNocase(const uint8_t *x, uint16_t m, uint16_t *bmGs)
+{
     int32_t i, j;
     uint16_t suff[m + 1];
 
@@ -266,7 +282,11 @@ void PreBmGsNocase(const uint8_t *x, uint16_t m, uint16_t *bmGs) {
  *
  * \retval ptr to start of the match; NULL if no match
  */
-uint8_t *BoyerMoore(uint8_t *x, uint16_t m, uint8_t *y, int32_t n, uint16_t *bmGs, uint16_t *bmBc) {
+uint8_t *BoyerMoore(uint8_t *x, uint16_t m, uint8_t *y, int32_t n, BmCtx *bm_ctx)
+{
+    uint16_t *bmGs = bm_ctx->bmGs;
+    uint16_t *bmBc = bm_ctx->bmBc;
+
    int i, j, m1, m2;
 #if 0
     printf("\nBad:\n");
@@ -311,7 +331,10 @@ uint8_t *BoyerMoore(uint8_t *x, uint16_t m, uint8_t *y, int32_t n, uint16_t *bmG
  *
  * \retval ptr to start of the match; NULL if no match
  */
-uint8_t *BoyerMooreNocase(uint8_t *x, uint16_t m, uint8_t *y, int32_t n, uint16_t *bmGs, uint16_t *bmBc) {
+uint8_t *BoyerMooreNocase(uint8_t *x, uint16_t m, uint8_t *y, int32_t n, BmCtx *bm_ctx)
+{
+    uint16_t *bmGs = bm_ctx->bmGs;
+    uint16_t *bmBc = bm_ctx->bmBc;
     int i, j, m1, m2;
 #if 0
     printf("\nBad:\n");

--- a/src/util-spm-bm.h
+++ b/src/util-spm-bm.h
@@ -40,14 +40,8 @@ typedef struct BmCtx_ {
 BmCtx *BoyerMooreCtxInit(uint8_t *needle, uint16_t needle_len);
 
 void BoyerMooreCtxToNocase(BmCtx *, uint8_t *, uint16_t);
-void PreBmBc(const uint8_t *x, uint16_t m, uint16_t *bmBc);
-void BoyerMooreSuffixes(const uint8_t *x, uint16_t m, uint16_t *suff);
-int PreBmGs(const uint8_t *, uint16_t, uint16_t *);
-uint8_t *BoyerMoore(uint8_t *x, uint16_t m, uint8_t *y, int32_t n, uint16_t *bmGs, uint16_t *bmBc);
-void PreBmBcNocase(const uint8_t *x, uint16_t m, uint16_t *bmBc);
-void BoyerMooreSuffixesNocase(const uint8_t *x, uint16_t m, uint16_t *suff);
-void PreBmGsNocase(const uint8_t *x, uint16_t m, uint16_t *bmGs);
-uint8_t *BoyerMooreNocase(uint8_t *x, uint16_t m, uint8_t *y, int32_t n, uint16_t *bmGs, uint16_t *bmBc);
+uint8_t *BoyerMoore(uint8_t *x, uint16_t m, uint8_t *y, int32_t n, BmCtx *bm_ctx);
+uint8_t *BoyerMooreNocase(uint8_t *x, uint16_t m, uint8_t *y, int32_t n, BmCtx *bm_ctx);
 void BoyerMooreCtxDeInit(BmCtx *);
 
 #endif /* __UTIL_SPM_BM__ */


### PR DESCRIPTION
Rather than convert Boyer Moore nocase search strings to lowercase on the fly, store them in lowercase.

Replaces PR 1028
