### PR TITLE
[rfc] eve: add tx_id to output for alerts and events

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -114,6 +114,9 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                             json_string((pa->s->class_msg) ? pa->s->class_msg : ""));
         json_object_set_new(ajs, "severity", json_integer(pa->s->prio));
 
+        if (pa->flags & PACKET_ALERT_FLAG_TX)
+            json_object_set_new(ajs, "tx_id", json_integer(pa->tx_id));
+
         /* alert */
         json_object_set_new(js, "alert", ajs);
 

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -232,6 +232,7 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
     json_object_set_new(fjs, "stored",
                         (ff->flags & FILE_STORED) ? json_true() : json_false());
     json_object_set_new(fjs, "size", json_integer(ff->size));
+    json_object_set_new(fjs, "tx_id", json_integer(ff->txid));
 
     /* originally just 'file', but due to bug 1127 naming it fileinfo */
     json_object_set_new(js, "fileinfo", fjs);

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -180,7 +180,7 @@ struct {
 
 
 /* JSON format logging */
-static void JsonHttpLogJSON(JsonHttpLogThread *aft, json_t *js, htp_tx_t *tx)
+static void JsonHttpLogJSON(JsonHttpLogThread *aft, json_t *js, htp_tx_t *tx, uint64_t tx_id)
 {
     LogHttpFileCtx *http_ctx = aft->httplog_ctx;
     json_t *hjs = json_object();
@@ -348,6 +348,9 @@ static void JsonHttpLogJSON(JsonHttpLogThread *aft, json_t *js, htp_tx_t *tx)
         json_object_set_new(hjs, "length", json_integer(tx->response_message_len));
     }
 
+    /* tx id for correlation with alerts */
+    json_object_set_new(hjs, "tx_id", json_integer(tx_id));
+
     json_object_set_new(js, "http", hjs);
 }
 
@@ -368,7 +371,7 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     /* reset */
     MemBufferReset(buffer);
 
-    JsonHttpLogJSON(jhl, js, tx);
+    JsonHttpLogJSON(jhl, js, tx, tx_id);
 
     OutputJSONBuffer(js, jhl->httplog_ctx->file_ctx, buffer);
     json_object_del(js, "http");


### PR DESCRIPTION
Add tx_id field for correlating alerts and events per tx.

TODO:
still need to check the CIM to see if it says anything about this info
