### PR TITLE
ipv6: set flag on type 0 routing header

### DIFF
--- a/rules/decoder-events.rules
+++ b/rules/decoder-events.rules
@@ -35,6 +35,8 @@ alert pkthdr any any -> any any (msg:"SURICATA IPv6 HOPOPTS only padding"; decod
 alert pkthdr any any -> any any (msg:"SURICATA IPv6 DSTOPTS unknown option"; decode-event:ipv6.dstopts_unknown_opt; sid:2200088; rev:1;)
 # DST header with only padding, covert channel?
 alert pkthdr any any -> any any (msg:"SURICATA IPv6 DSTOPTS only padding"; decode-event:ipv6.dstopts_only_padding; sid:2200089; rev:1;)
+# Type 0 Routing header deprecated per RFC 5095
+alert ipv6 any any -> any any (msg:"SURICATA RH Type 0"; decode-event:ipv6.rh_type_0; sid:2200093; rev:1;)
 alert ipv6 any any -> any any (msg:"SURICATA IPv6 with ICMPv4 header"; decode-event:ipv6.icmpv4; sid:2200090; rev:1;)
 alert pkthdr any any -> any any (msg:"SURICATA ICMPv4 packet too small"; decode-event:icmpv4.pkt_too_small; sid:2200023; rev:1;)
 alert pkthdr any any -> any any (msg:"SURICATA ICMPv4 unknown type"; decode-event:icmpv4.unknown_type; sid:2200024; rev:1;)
@@ -106,5 +108,5 @@ alert pkthdr any any -> any any (msg:"SURICATA IPv4-in-IPv6 invalid protocol"; d
 alert pkthdr any any -> any any (msg:"SURICATA IPv6-in-IPv6 packet too short"; decode-event:ipv6.ipv6_in_ipv6_too_small; sid:2200084; rev:1;)
 alert pkthdr any any -> any any (msg:"SURICATA IPv6-in-IPv6 invalid protocol"; decode-event:ipv6.ipv6_in_ipv6_wrong_version; sid:2200085; rev:1;)
 
-# next sid is 2200093
+# next sid is 2200094
 

--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -79,6 +79,8 @@ enum {
     IPV6_DSTOPTS_UNKNOWN_OPT,       /**< unknown DST opt */
     IPV6_DSTOPTS_ONLY_PADDING,      /**< all options in DST opts are padding */
 
+    IPV6_EXTHDR_RH_TYPE_0,          /**< RH 0 is deprecated as per rfc5095 */
+
     IPV6_WITH_ICMPV4,               /**< IPv6 packet with ICMPv4 header */
 
     /* TCP EVENTS */

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -191,6 +191,8 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                         memcpy(&IPV6_EXTHDR_RH(p)->ip6rh0_addr[i], pkt+(i*16)+8, sizeof(IPV6_EXTHDR_RH(p)->ip6rh0_addr[i]));
                     }
                     IPV6_EXTHDR_RH(p)->ip6rh0_num_addrs = i;
+
+                    ENGINE_SET_EVENT(p, IPV6_EXTHDR_RH_TYPE_0);
                 }
 
                 nh = *pkt;

--- a/src/detect-engine-event.h
+++ b/src/detect-engine-event.h
@@ -89,6 +89,7 @@ struct DetectEngineEvents_ {
     { "ipv6.hopopts_only_padding", IPV6_HOPOPTS_ONLY_PADDING, },
     { "ipv6.dstopts_unknown_opt", IPV6_DSTOPTS_UNKNOWN_OPT, },
     { "ipv6.dstopts_only_padding", IPV6_DSTOPTS_ONLY_PADDING, },
+    { "ipv6.rh_type_0", IPV6_EXTHDR_RH_TYPE_0, },
     { "ipv6.icmpv4", IPV6_WITH_ICMPV4, },
 
     /* TCP EVENTS */


### PR DESCRIPTION
Type 0 Routing headers are deprecated per RFC 5095.

This patch sets an decode event flag that can be matched on through:
    decode-event:ipv6.rh_type_0;
