### PR TITLE
Packet Pool fixes

### DIFF
--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -211,6 +211,8 @@ void *TmThreadsSlot1NoIn(void *td)
         }
     } /* while (run) */
 
+    PacketPoolDestroy();
+
     TmThreadsSetFlag(tv, THV_RUNNING_DONE);
     TmThreadWaitForFlag(tv, THV_DEINIT);
 
@@ -305,6 +307,8 @@ void *TmThreadsSlot1NoOut(void *td)
         }
     } /* while (run) */
 
+    PacketPoolDestroy();
+
     TmThreadsSetFlag(tv, THV_RUNNING_DONE);
     TmThreadWaitForFlag(tv, THV_DEINIT);
 
@@ -393,6 +397,8 @@ void *TmThreadsSlot1NoInOut(void *td)
             run = 0;
         }
     } /* while (run) */
+
+    PacketPoolDestroy();
 
     TmThreadsSetFlag(tv, THV_RUNNING_DONE);
     TmThreadWaitForFlag(tv, THV_DEINIT);
@@ -522,6 +528,8 @@ void *TmThreadsSlot1(void *td)
             run = 0;
         }
     } /* while (run) */
+
+    PacketPoolDestroy();
 
     TmThreadsSetFlag(tv, THV_RUNNING_DONE);
     TmThreadWaitForFlag(tv, THV_DEINIT);
@@ -721,6 +729,8 @@ void *TmThreadsSlotPktAcqLoop(void *td) {
         }
     }
     SCPerfSyncCounters(tv);
+
+    PacketPoolDestroy();
 
     TmThreadsSetFlag(tv, THV_RUNNING_DONE);
     TmThreadWaitForFlag(tv, THV_DEINIT);

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -284,14 +284,13 @@ void PacketPoolInit(void)
             max_pending_packets, (uintmax_t)(max_pending_packets*SIZE_OF_PACKET));
 }
 
-void PacketPoolDestroy(void) {
-#if 0
+void PacketPoolDestroy(void)
+{
     Packet *p = NULL;
     while ((p = PacketPoolGetPacket()) != NULL) {
         PACKET_CLEANUP(p);
         SCFree(p);
     }
-#endif
 }
 
 Packet *TmqhInputPacketpool(ThreadVars *tv)


### PR DESCRIPTION
Fixes the non-TLS crash in autofp mode, where only some Packet Pools are initialized, by checking for initialization on each access and initializing if needed.

Adds calls to PacketPoolDestroy() to cleanup allocated memory.

Passes travis-ci
