### PR TITLE
pcap-log: add option to honor pass rules

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -210,6 +210,7 @@ outputs:
       #sguil-base-dir: /nsm_data/
       #ts-format: usec # sec or usec second format (default) is filename.sec usec is filename.sec.usec
       use-stream-depth: no #If set to "yes" packets seen after reaching stream inspection depth are ignored. "no" logs all packets
+      honor-pass-rules: no # If set to "yes", flows in which a pass rule matched will stopped being logged.
 
   # a full alerts log containing much information for signature writers
   # or for investigating suspected false positives.


### PR DESCRIPTION
Add option (disabled by default) to honor pass rules. This means that
when a pass rule matches in a flow, it's packets are no longer stored
by the pcap-log module.

Prscript:
- PR build: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/2
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/2
