### PR TITLE
ipv6: fix dst/hop header option parsing

### DIFF
--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -212,7 +212,7 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                 IPV6OptHAO *hao = NULL;
                 IPV6OptRA *ra = NULL;
                 IPV6OptJumbo *jumbo = NULL;
-                uint8_t optslen = 0;
+                uint16_t optslen = 0;
 
                 IPV6_SET_L4PROTO(p,nh);
                 hdrextlen =  (*(pkt+1) + 1) << 3;


### PR DESCRIPTION
The extension header option parsing used a uint8_t internally. However
much bigger option sizes are valid.

Prscript:
- PR build: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/8
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/8
