### PR TITLE
packet pool: fix ext_pkt cleaning

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -85,7 +85,7 @@ int DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     return TM_ECODE_OK;
 }
 
-static inline void PacketFreeExtData(Packet *p)
+void PacketFreeExtData(Packet *p)
 {
     /* if p uses extended data, free them */
     if (p->ext_pkt) {
@@ -95,8 +95,6 @@ static inline void PacketFreeExtData(Packet *p)
         p->ext_pkt = NULL;
     }
 }
-
-
 
 /**
  * \brief Return a malloced packet.
@@ -156,7 +154,6 @@ Packet *PacketGetFromAlloc(void)
  */
 void PacketFreeOrRelease(Packet *p)
 {
-    PacketFreeExtData(p);
     if (p->flags & PKT_ALLOC)
         PacketFree(p);
     else

--- a/src/decode.h
+++ b/src/decode.h
@@ -623,6 +623,8 @@ typedef struct DecodeThreadVars_
         (p)->level4_comp_csum = -1;   \
     } while (0)
 
+void PacketFreeExtData(Packet *p);
+
 /**
  *  \brief Initialize a packet structure for use.
  */
@@ -657,6 +659,7 @@ typedef struct DecodeThreadVars_
         (p)->dp = 0;                            \
         (p)->proto = 0;                         \
         (p)->recursion_level = 0;               \
+        PacketFreeExtData(p);                   \
         (p)->flags = (p)->flags & PKT_ALLOC;    \
         (p)->flowflags = 0;                     \
         (p)->pkt_src = 0;                       \
@@ -730,6 +733,7 @@ typedef struct DecodeThreadVars_
         if ((p)->pktvar != NULL) {              \
             PktVarFree((p)->pktvar);            \
         }                                       \
+        PacketFreeExtData(p);                   \
         SCMutexDestroy(&(p)->tunnel_mutex);     \
         AppLayerDecoderEventsFreeEvents(&(p)->app_layer_events); \
         PACKET_PROFILING_RESET((p));            \

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -395,23 +395,9 @@ void TmqhOutputPacketpool(ThreadVars *t, Packet *p)
         SCLogDebug("getting rid of root pkt... alloc'd %s", p->root->flags & PKT_ALLOC ? "true" : "false");
 
         FlowDeReference(&p->root->flow);
-        /* if p->root uses extended data, free them */
-        if (p->root->ext_pkt) {
-            if (!(p->root->flags & PKT_ZERO_COPY)) {
-                SCFree(p->root->ext_pkt);
-            }
-            p->root->ext_pkt = NULL;
-        }
+
         p->root->ReleasePacket(p->root);
         p->root = NULL;
-    }
-
-    /* if p uses extended data, free them */
-    if (p->ext_pkt) {
-        if (!(p->flags & PKT_ZERO_COPY)) {
-            SCFree(p->ext_pkt);
-        }
-        p->ext_pkt = NULL;
     }
 
     PACKET_PROFILING_END(p);


### PR DESCRIPTION
The field ext_pkt was cleaned before calling the release function.
The result was that IPS mode such as the one of AF_PACKET were not
working anymore because they were not able to send the data which
were initially pointed by ext_pkt.

This patch moves the ext_pkt cleaning to the cleaning macro. This
ensures that the cleaning is done for allocated and pool packets.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1259

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/9
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/7
