### PR TITLE
Fix compiler warning about uninitialized variable in mpipe.

### DIFF
--- a/src/source-mpipe.c
+++ b/src/source-mpipe.c
@@ -540,7 +540,7 @@ static TmEcode ReceiveMpipeAllocatePacketBuffers(void)
     unsigned long available_pagesizes = tmc_alloc_get_pagesizes();
 
     void *packet_page = NULL;
-    size_t tile_vhuge_size;
+    size_t tile_vhuge_size = 64 * 1024;
 
     /* Try the largest available page size first to see if any
      * pages of that size can be allocated. */


### PR DESCRIPTION
Fix compiler warning only seen at O2.
- PR build: https://buildbot.openinfosecfoundation.org/builders/ken-tilera/builds/2
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/ken-tilera-pcap/builds/2
