### PR TITLE
Fix IPv6 cidr mask limit bug in SCRadixAddKeyIPV6String() function.

### DIFF
--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -1001,7 +1001,7 @@ SCRadixNode *SCRadixAddKeyIPV6String(const char *str, SCRadixTree *tree, void *u
 
         /* Get binary values for cidr mask */
         cidr = atoi(mask_str);
-        if ((cidr < 0) || (cidr > 32)) {
+        if ((cidr < 0) || (cidr > 128)) {
             return NULL;
         }
         netmask = (uint8_t)cidr;


### PR DESCRIPTION
There is a bug in the SCRadixAddKeyIPV6String() function in the file util-radix-tree.c.  The test for min and max values for a CIDR mask incorrectly tests the upper limit as 32 when it should be 128 for an IPv6 address.  I think this perhaps is an old copy-paste error if the IPv6 version of this function was initially copied from the corresponding IPv4 version directly above it in the code.

Without this patch, the function will return null when you attempt to add an IPv6 network whose CIDR mask is larger than 32 (for example, the popular /64 mask will cause the function to return the NULL error condition).
