### PR TITLE
source-nfq: fix display of next queue

### DIFF
--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -289,7 +289,7 @@ void NFQInitConfig(char quiet)
                 break;
             case NFQ_ROUTE_MODE:
                 SCLogInfo("NFQ running in route mode with next queue %"PRIu32,
-                        nfq_config.next_queue);
+                        nfq_config.next_queue >> 16);
             break;
         }
     }


### PR DESCRIPTION
Suricata was displaying an invalid queue number as the value is
shift at the moment of its assignement.

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/11
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/9
