### PR TITLE
lua: fix http.request_line

### DIFF
--- a/src/detect-luajit.c
+++ b/src/detect-luajit.c
@@ -891,7 +891,7 @@ static int DetectLuajitSetup (DetectEngineCtx *de_ctx, Signature *s, char *str)
         else if (luajit->flags & DATATYPE_HTTP_RESPONSE_COOKIE)
             SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_HCDMATCH);
         else
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_AMATCH);
+            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
     } else {
         SCLogError(SC_ERR_LUAJIT_ERROR, "luajit can't be used with protocol %s",
                    AppLayerGetProtoName(luajit->alproto));


### PR DESCRIPTION
The request line scripts were added to the AMATCH list. However, there
is not AppLayerMatch function defined for lua scripts. So scripts
would not run.

This patch adds the request line scripts to the normal 'MATCH' list.

Bug #1273.
