### PR TITLE
af-packet: force suricata in IPS mode when needed

### DIFF
--- a/src/runmode-af-packet.h
+++ b/src/runmode-af-packet.h
@@ -29,5 +29,6 @@ int RunModeIdsAFPAutoFp(DetectEngineCtx *);
 int RunModeIdsAFPWorkers(DetectEngineCtx *);
 void RunModeIdsAFPRegister(void);
 const char *RunModeAFPGetDefaultMode(void);
+int AFPRunModeIsIPS();
 
 #endif /* __RUNMODE_AF_PACKET_H__ */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -969,6 +969,10 @@ static TmEcode ParseInterfacesList(int run_mode, char *pcap_dev)
                 SCLogError(SC_ERR_INITIALIZATION, "No interface found in config for af-packet");
                 SCReturnInt(TM_ECODE_FAILED);
             }
+            if (AFPRunModeIsIPS()) {
+                SCLogInfo("AF_PACKET: Setting IPS mode");
+                EngineModeSetIPS();
+            }
         }
 #ifdef HAVE_NFLOG
     } else if (run_mode == RUNMODE_NFLOG) {


### PR DESCRIPTION
AF_PACKET is not setting the engine mode to IPS when some
interfaces are peered and use IPS mode. This is due to the
fact, it is possible to peer 2 interfaces and run an IPS on
them and have a third one that is running in normal IDS mode.

In fact this choice is the bad one as unwanted side effect is
that there is no drop log and that stream inline is not used.

To fix that, this patch puts suricata in IPS mode as soon as
there is two interfaces in IPS mode. And it displays a error
message to warn user that the accuracy of detection on IDS only
interfaces will be low.

Cherry-pick of commit of https://github.com/inliniac/suricata/pull/1130
