### PR TITLE
Bug 1230 - byte_extract, within combination not working - fix - v1.

### DIFF
--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -770,22 +770,30 @@ void DetectByteExtractFree(void *ptr)
     return;
 }
 
-SigMatch *DetectByteExtractRetrieveSMVar(const char *arg, Signature *s, int list)
+/**
+ * \brief Lookup the SigMatch for a named byte_extract variable.
+ *
+ * \param arg The name of the byte_extract variable to lookup.
+ * \param s Pointer the signature to look in.
+ *
+ * \retval A pointer to the SigMatch if found, otherwise NULL.
+ */
+SigMatch *DetectByteExtractRetrieveSMVar(const char *arg, Signature *s)
 {
-    if (list == -1)
-        return NULL;
-
     DetectByteExtractData *bed = NULL;
-    SigMatch *sm = s->sm_lists[list];
+    int list;
 
-    while (sm != NULL) {
-        if (sm->type == DETECT_BYTE_EXTRACT) {
-            bed = (DetectByteExtractData *)sm->ctx;
-            if (strcmp(bed->name, arg) == 0) {
-                return sm;
+    for (list = 0; list < DETECT_SM_LIST_MAX; list++) {
+        SigMatch *sm = s->sm_lists[list];
+        while (sm != NULL) {
+            if (sm->type == DETECT_BYTE_EXTRACT) {
+                bed = (DetectByteExtractData *)sm->ctx;
+                if (strcmp(bed->name, arg) == 0) {
+                    return sm;
+                }
             }
+            sm = sm->next;
         }
-        sm = sm->next;
     }
 
     return NULL;

--- a/src/detect-byte-extract.h
+++ b/src/detect-byte-extract.h
@@ -64,7 +64,7 @@ int DetectByteExtractSetup(DetectEngineCtx *, Signature *, char *);
 void DetectByteExtractFree(void *);
 int DetectByteExtractMatch(ThreadVars *, DetectEngineThreadCtx *,
                            Packet *, Signature *, SigMatch *);
-SigMatch *DetectByteExtractRetrieveSMVar(const char *, Signature *, int);
+SigMatch *DetectByteExtractRetrieveSMVar(const char *, Signature *);
 int DetectByteExtractDoMatch(DetectEngineThreadCtx *, SigMatch *, Signature *,
                              uint8_t *, uint16_t, uint64_t *, uint8_t);
 

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -698,7 +698,7 @@ int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, char *optstr)
     }
 
     if (offset != NULL) {
-        SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(offset, s, sm_list);
+        SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(offset, s);
         if (bed_sm == NULL) {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "Unknown byte_extract var "
                        "seen in byte_jump - %s\n", offset);

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -623,7 +623,7 @@ int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, char *optstr)
     }
 
     if (value != NULL) {
-        SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(value, s, sm_list);
+        SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(value, s);
         if (bed_sm == NULL) {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "Unknown byte_extract var "
                        "seen in byte_test - %s\n", value);
@@ -635,7 +635,7 @@ int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, char *optstr)
     }
 
     if (offset != NULL) {
-        SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(offset, s, sm_list);
+        SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(offset, s);
         if (bed_sm == NULL) {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "Unknown byte_extract var "
                        "seen in byte_test - %s\n", offset);

--- a/src/detect-depth.c
+++ b/src/detect-depth.c
@@ -127,7 +127,7 @@ static int DetectDepthSetup (DetectEngineCtx *de_ctx, Signature *s, char *depths
         goto end;
     }
     if (str[0] != '-' && isalpha((unsigned char)str[0])) {
-        SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(str, s, SigMatchListSMBelongsTo(s, pm));
+        SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(str, s);
         if (bed_sm == NULL) {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "unknown byte_extract var "
                        "seen in depth - %s\n", str);

--- a/src/detect-distance.c
+++ b/src/detect-distance.c
@@ -133,7 +133,7 @@ static int DetectDistanceSetup (DetectEngineCtx *de_ctx, Signature *s,
         goto end;
     }
     if (str[0] != '-' && isalpha((unsigned char)str[0])) {
-        SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(str, s, SigMatchListSMBelongsTo(s, pm));
+        SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(str, s);
         if (bed_sm == NULL) {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "unknown byte_extract var "
                        "seen in distance - %s\n", str);

--- a/src/detect-isdataat.c
+++ b/src/detect-isdataat.c
@@ -375,7 +375,7 @@ int DetectIsdataatSetup (DetectEngineCtx *de_ctx, Signature *s, char *isdataatst
     }
 
     if (offset != NULL) {
-        SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(offset, s, sm_list);
+        SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(offset, s);
         if (bed_sm == NULL) {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "Unknown byte_extract var "
                        "seen in isdataat - %s\n", offset);

--- a/src/detect-offset.c
+++ b/src/detect-offset.c
@@ -127,7 +127,7 @@ int DetectOffsetSetup (DetectEngineCtx *de_ctx, Signature *s, char *offsetstr)
     }
     if (str[0] != '-' && isalpha((unsigned char)str[0])) {
         SigMatch *bed_sm =
-            DetectByteExtractRetrieveSMVar(str, s, SigMatchListSMBelongsTo(s, pm));
+            DetectByteExtractRetrieveSMVar(str, s);
         if (bed_sm == NULL) {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "unknown byte_extract var "
                        "seen in offset - %s\n", str);

--- a/src/detect-within.c
+++ b/src/detect-within.c
@@ -138,7 +138,7 @@ static int DetectWithinSetup(DetectEngineCtx *de_ctx, Signature *s, char *within
         goto end;
     }
     if (str[0] != '-' && isalpha((unsigned char)str[0])) {
-        SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(str, s, SigMatchListSMBelongsTo(s, pm));
+        SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(str, s);
         if (bed_sm == NULL) {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "unknown byte_extract var "
                        "seen in within - %s\n", str);
@@ -251,7 +251,6 @@ static int DetectWithinTestVarSetup(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 0;
-#if 1 /* FAILs */
     char sig[] = "alert tcp any any -> any any ( "
         "msg:\"test rule\"; "
         "content:\"abc\"; "
@@ -261,17 +260,6 @@ static int DetectWithinTestVarSetup(void)
         "within:somevar; "
         "http_client_body; "
         "sid:4; rev:1;)";
-#else /* WORKs */
-    char sig[] = "alert tcp any any -> any any ( "
-        "msg:\"test rule\"; "
-        "content:\"abc\"; "
-        "http_client_body; "
-        "byte_extract:2,0,somevar,relative; "
-        "content:\"def\"; "
-        "http_client_body; "
-        "within:somevar; "
-        "sid:4; rev:1;)";
-#endif
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL) {


### PR DESCRIPTION
This patch will fix rules like:

alert tcp any any -> any any (\
      msg:"test rule"; \
      content:"abc"; \
      http_client_body; \
      byte_extract:2,0,somevar,relative; \
      content:"def"; \
      within:somevar; \
      http_client_body; \
      sid:4; rev:1;)

What currently happens is the first http_client_body causes the byte_extract to be put on the DETECT_SM_LIST_HCBDMATCH list.  As the within comes after content (which could be called a terminal option as it terminates the previous modifiers), but before the next http_client_body, it fails to find "somevar" as its looking in the wrong list.

One fix (perhaps a bit naive) is to look in all lists when looking up a byte_extract variable.  The following http_client_body option will move all the list items to the correct list keeping everything intact for packet evaulation.

Buildbot output:
- PR build: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/8
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/8
