### PR TITLE
filestore: fix parsing bug

### DIFF
--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -77,7 +77,7 @@ void DetectFilestoreRegister(void)
     sigmatch_table[DETECT_FILESTORE].Setup = DetectFilestoreSetup;
     sigmatch_table[DETECT_FILESTORE].Free  = DetectFilestoreFree;
     sigmatch_table[DETECT_FILESTORE].RegisterTests = NULL;
-    sigmatch_table[DETECT_FILESTORE].flags = SIGMATCH_NOOPT;
+    sigmatch_table[DETECT_FILESTORE].flags = SIGMATCH_OPTIONAL_OPT;
 
     const char *eb;
     int eo;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -552,7 +552,7 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
         }
     }
 
-    if (!(st->flags & SIGMATCH_NOOPT)) {
+    if (!(st->flags & (SIGMATCH_NOOPT|SIGMATCH_OPTIONAL_OPT))) {
         if (strlen(optvalue) == 0) {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid formatting or malformed option to %s keyword: \'%s\'",
                     optname, optstr);

--- a/src/detect.h
+++ b/src/detect.h
@@ -1023,6 +1023,9 @@ typedef struct SigGroupHead_ {
 #define SIGMATCH_PAYLOAD        (1 << 3)
 /**< Flag to indicate that the signature is not built-in */
 #define SIGMATCH_NOT_BUILT      (1 << 4)
+/** sigmatch may have options, so the parser should be ready to
+ *  deal with both cases */
+#define SIGMATCH_OPTIONAL_OPT   (1 << 5)
 
 /** Remember to add the options in SignatureIsIPOnly() at detect.c otherwise it wont be part of a signature group */
 


### PR DESCRIPTION
Filestore keyword can have options or no options, and the parser
was enforcing the NOOPT flag too strictly.

Bug #1288 https://redmine.openinfosecfoundation.org/issues/1288

Prscript:
- PR build: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/25
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/25
