### PR TITLE
Added ability to generate filestore metadata in json and regular (curren...

### DIFF
--- a/src/log-filestore.c
+++ b/src/log-filestore.c
@@ -58,10 +58,18 @@
 
 #define MODULE_NAME "LogFilestoreLog"
 
+#define META_FORMAT_REGULAR 0
+#define META_FORMAT_JSON 1
+
 static char g_logfile_base_dir[PATH_MAX] = "/tmp";
 
-typedef struct LogFilestoreLogThread_ {
+typedef struct LogFilestoreFileCtx_ {
     LogFileCtx *file_ctx;
+    uint32_t flags; /* output format mode */
+} LogFilestoreFileCtx;
+
+typedef struct LogFilestoreLogThread_ {
+    LogFilestoreFileCtx *file_ctx;
     /** LogFilestoreCtx has the pointer to the file and a mutex to allow multithreading */
     uint32_t file_cnt;
 } LogFilestoreLogThread;
@@ -80,7 +88,7 @@ static void LogFilestoreMetaGetUri(FILE *fp, const Packet *p, const File *ff) {
         }
     }
 
-    fprintf(fp, "<unknown>");
+    fprintf(fp, "unknown");
 }
 
 static void LogFilestoreMetaGetHost(FILE *fp, const Packet *p, const File *ff) {
@@ -94,7 +102,7 @@ static void LogFilestoreMetaGetHost(FILE *fp, const Packet *p, const File *ff) {
         }
     }
 
-    fprintf(fp, "<unknown>");
+    fprintf(fp, "unknown");
 }
 
 static void LogFilestoreMetaGetReferer(FILE *fp, const Packet *p, const File *ff) {
@@ -113,7 +121,7 @@ static void LogFilestoreMetaGetReferer(FILE *fp, const Packet *p, const File *ff
         }
     }
 
-    fprintf(fp, "<unknown>");
+    fprintf(fp, "unknown");
 }
 
 static void LogFilestoreMetaGetUserAgent(FILE *fp, const Packet *p, const File *ff) {
@@ -132,10 +140,11 @@ static void LogFilestoreMetaGetUserAgent(FILE *fp, const Packet *p, const File *
         }
     }
 
-    fprintf(fp, "<unknown>");
+    fprintf(fp, "unknown");
 }
 
-static void LogFilestoreLogCreateMetaFile(const Packet *p, const File *ff, const char *filename, int ipver) {
+static void LogFilestoreLogCreateMetaFileRegular(const Packet *p, const File *ff, const char *filename, int ipver)
+{
     char metafilename[PATH_MAX] = "";
     snprintf(metafilename, sizeof(metafilename), "%s.meta", filename);
     FILE *fp = fopen(metafilename, "w+");
@@ -195,7 +204,8 @@ static void LogFilestoreLogCreateMetaFile(const Packet *p, const File *ff, const
     }
 }
 
-static void LogFilestoreLogCloseMetaFile(const File *ff) {
+static void LogFilestoreLogCloseMetaFileRegular(const File *ff)
+{
     char filename[PATH_MAX] = "";
     snprintf(filename, sizeof(filename), "%s/file.%u",
             g_logfile_base_dir, ff->file_id);
@@ -238,10 +248,115 @@ static void LogFilestoreLogCloseMetaFile(const File *ff) {
     }
 }
 
+static void LogFilestoreLogCreateMetaFileJSON(const Packet *p, const File *ff, const char *filename, int ipver) {
+    char metafilename[PATH_MAX] = "";
+    snprintf(metafilename, sizeof(metafilename), "%s.meta", filename);
+    FILE *fp = fopen(metafilename, "w+");
+    if (fp != NULL) {
+        char timebuf[64];
+
+        CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
+        fprintf(fp, "{\"timestamp\": \"%s\", ", timebuf);
+
+        if (p->pcap_cnt > 0) {
+            fprintf(fp, "\"pcap_packet_number\": %"PRIu64", ", p->pcap_cnt);
+        }
+
+        char srcip[46], dstip[46];
+        Port sp, dp;
+        switch (ipver) {
+            case AF_INET:
+                PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), srcip, sizeof(srcip));
+                PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), dstip, sizeof(dstip));
+                break;
+            case AF_INET6:
+                PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), srcip, sizeof(srcip));
+                PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), dstip, sizeof(dstip));
+                break;
+            default:
+                strlcpy(srcip, "unknown", sizeof(srcip));
+                strlcpy(dstip, "unknown", sizeof(dstip));
+                break;
+        }
+        sp = p->sp;
+        dp = p->dp;
+
+        fprintf(fp, "\"src_ip\": \"%s\", ", srcip);
+        fprintf(fp, "\"dst_ip\": \"%s\", ", dstip);
+        fprintf(fp, "\"proto\": %" PRIu32 ", ", p->proto);
+        if (PKT_IS_TCP(p) || PKT_IS_UDP(p)) {
+            fprintf(fp, "\"src_port\": %"PRIu16", ", sp);
+            fprintf(fp, "\"dst_port\": %"PRIu16", ", dp);
+        }
+        fprintf(fp, "\"http_uri\": \"");
+        LogFilestoreMetaGetUri(fp, p, ff);
+        fprintf(fp, "\", ");
+        fprintf(fp, "\"http_host\": \"");
+        LogFilestoreMetaGetHost(fp, p, ff);
+        fprintf(fp, "\", ");
+        fprintf(fp, "\"http_refer\": \"");
+        LogFilestoreMetaGetReferer(fp, p, ff);
+        fprintf(fp, "\", ");
+        fprintf(fp, "\"user_agent\": \"");
+        LogFilestoreMetaGetUserAgent(fp, p, ff);
+        fprintf(fp, "\", ");
+        fprintf(fp, "\"filename\": \"");
+        PrintRawUriFp(fp, ff->name, ff->name_len);
+        fprintf(fp, "\"}\n");
+        fclose(fp);
+    }
+}
+
+static void LogFilestoreLogCloseMetaFileJSON(const File *ff) {
+    char filename[PATH_MAX] = "";
+    snprintf(filename, sizeof(filename), "%s/file.%u",
+            g_logfile_base_dir, ff->file_id);
+    char metafilename[PATH_MAX] = "";
+    snprintf(metafilename, sizeof(metafilename), "%s.meta", filename);
+    FILE *fp = fopen(metafilename, "r+");
+    if (fp != NULL) {
+        fseek(fp, -2, SEEK_END);
+        fprintf(fp, ", ");
+        fprintf(fp, "\"magic\": \"%s\", ",
+                ff->magic ? ff->magic : "unknown");
+
+        switch (ff->state) {
+            case FILE_STATE_CLOSED:
+                fprintf(fp, "\"state\": \"closed\", ");
+#ifdef HAVE_NSS
+                if (ff->flags & FILE_MD5) {
+                    fprintf(fp, "\"md5\": \"");
+                    size_t x;
+                    for (x = 0; x < sizeof(ff->md5); x++) {
+                        fprintf(fp, "%02x", ff->md5[x]);
+                    }
+                    fprintf(fp, "\", ");
+                }
+#endif
+                break;
+            case FILE_STATE_TRUNCATED:
+                fprintf(fp, "\"state\": \"truncated\", ");
+                break;
+            case FILE_STATE_ERROR:
+                fprintf(fp, "\"state\": \"error\", ");
+                break;
+            default:
+                fprintf(fp, "\"state\": \"unknown\", ");
+                break;
+        }
+        fprintf(fp, "\"size\": %"PRIu64"}\n", ff->size);
+
+        fclose(fp);
+    } else {
+        SCLogInfo("opening %s failed: %s", metafilename, strerror(errno));
+    }
+}
+
 static int LogFilestoreLogger(ThreadVars *tv, void *thread_data, const Packet *p, const File *ff, const FileData *ffd, uint8_t flags)
 {
     SCEnter();
     LogFilestoreLogThread *aft = (LogFilestoreLogThread *)thread_data;
+    LogFilestoreFileCtx *flog = aft->file_ctx;
     char filename[PATH_MAX] = "";
     int file_fd = -1;
     int ipver = -1;
@@ -268,7 +383,11 @@ static int LogFilestoreLogger(ThreadVars *tv, void *thread_data, const Packet *p
         aft->file_cnt++;
 
         /* create a .meta file that contains time, src/dst/sp/dp/proto */
-        LogFilestoreLogCreateMetaFile(p, ff, filename, ipver);
+        if (flog->flags & META_FORMAT_JSON) {
+            LogFilestoreLogCreateMetaFileJSON(p, ff, filename, ipver);
+        } else {
+            LogFilestoreLogCreateMetaFileRegular(p, ff, filename, ipver);
+        }
 
         file_fd = open(filename, O_CREAT | O_TRUNC | O_NOFOLLOW | O_WRONLY, 0644);
         if (file_fd == -1) {
@@ -293,7 +412,11 @@ static int LogFilestoreLogger(ThreadVars *tv, void *thread_data, const Packet *p
     }
 
     if (flags & OUTPUT_FILEDATA_FLAG_CLOSE) {
-        LogFilestoreLogCloseMetaFile(ff);
+        if (flog->flags & META_FORMAT_JSON) {
+            LogFilestoreLogCloseMetaFileJSON(ff);
+        } else{
+            LogFilestoreLogCloseMetaFileRegular(ff);
+        }
     }
 
     return 0;
@@ -371,8 +494,8 @@ static void LogFilestoreLogExitPrintStats(ThreadVars *tv, void *data) {
  */
 static void LogFilestoreLogDeInitCtx(OutputCtx *output_ctx)
 {
-    LogFileCtx *logfile_ctx = (LogFileCtx *)output_ctx->data;
-    LogFileFreeCtx(logfile_ctx);
+    LogFilestoreFileCtx *filestorelog_ctx = (LogFilestoreFileCtx *) output_ctx->data;
+    LogFileFreeCtx(filestorelog_ctx->file_ctx);
     free(output_ctx);
 
 }
@@ -383,18 +506,12 @@ static void LogFilestoreLogDeInitCtx(OutputCtx *output_ctx)
  * */
 static OutputCtx *LogFilestoreLogInitCtx(ConfNode *conf)
 {
-    LogFileCtx *logfile_ctx = LogFileNewCtx();
-    if (logfile_ctx == NULL) {
+    LogFileCtx *file_ctx = LogFileNewCtx();
+
+    if (file_ctx == NULL) {
         SCLogDebug("Could not create new LogFilestoreCtx");
         return NULL;
     }
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
-    if (unlikely(output_ctx == NULL))
-        return NULL;
-
-    output_ctx->data = NULL;
-    output_ctx->DeInit = LogFilestoreLogDeInitCtx;
 
     char *s_default_log_dir = NULL;
     s_default_log_dir = ConfigGetLogDirectory();
@@ -414,6 +531,31 @@ static OutputCtx *LogFilestoreLogInitCtx(ConfNode *conf)
         }
     }
 
+    LogFilestoreFileCtx *filestorelog_ctx = SCCalloc(1, sizeof(LogFilestoreFileCtx));
+    if (unlikely(filestorelog_ctx == NULL))
+        goto filectx_error;
+    filestorelog_ctx->file_ctx = file_ctx;
+
+
+    filestorelog_ctx->flags = 0;
+    const char *metaformat = ConfNodeLookupChildValue(conf, "format");
+    if (metaformat != NULL) {
+        if (strcmp(metaformat, "regular") == 0) {
+            filestorelog_ctx->flags = META_FORMAT_REGULAR;
+            SCLogInfo("Setting filestore metadata format to regular");
+        } else if (strcmp(metaformat, "json") == 0) {
+            filestorelog_ctx->flags = META_FORMAT_JSON;
+            SCLogInfo("Setting filestore metadata format to JSON");
+        } else {
+            SCLogError(SC_ERR_INVALID_ARGUMENT,
+                       "Invalid filestore meta format %s", metaformat);
+            exit(EXIT_FAILURE);
+        }
+    } else {
+        filestorelog_ctx->flags = META_FORMAT_REGULAR;
+        SCLogInfo("Could not find filestore metadata format - setting regular");
+    }
+
     const char *force_magic = ConfNodeLookupChildValue(conf, "force-magic");
     if (force_magic != NULL && ConfValIsTrue(force_magic)) {
         FileForceMagicEnable();
@@ -431,7 +573,20 @@ static OutputCtx *LogFilestoreLogInitCtx(ConfNode *conf)
     }
     SCLogInfo("storing files in %s", g_logfile_base_dir);
 
-    SCReturnPtr(output_ctx, "OutputCtx");
+
+    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
+    if (unlikely(output_ctx == NULL))
+        goto filestorelog_error;
+    output_ctx->data = filestorelog_ctx;
+    output_ctx->DeInit = LogFilestoreLogDeInitCtx;
+
+    return output_ctx;
+
+filestorelog_error:
+    SCFree(filestorelog_ctx);
+filectx_error:
+    LogFileFreeCtx(file_ctx);
+    return NULL;
 }
 
 void TmModuleLogFilestoreRegister (void) {


### PR DESCRIPTION
Added ability to get the filestore metadata files in JSON format. While keeping support for the current "regular text" format. The choice is done in the suricata yaml file with file-store.format=(regular|json)
