### PR TITLE
Enforce Signature Header structure matches Signature

### DIFF
--- a/src/detect.h
+++ b/src/detect.h
@@ -335,31 +335,36 @@ typedef struct IPOnlyCIDRItem_ {
 
 /** \brief Subset of the Signature for cache efficient prefiltering
  */
+/* Using a macro because it must be the same in the Signature and
+ * Signature header structures. */
+#define SIGNATURE_HEADER \
+    union { \
+        struct { \
+            /* coccinelle: SignatureHeader:flags:SIG_FLAG */ \
+            uint32_t flags; \
+            AppProto alproto; \
+            uint16_t dsize_low; \
+        }; \
+        uint64_t hdr_copy1; \
+    }; \
+    union { \
+        struct { \
+            uint16_t dsize_high; \
+            uint16_t mpm_pattern_id_div_8; \
+        }; \
+        uint32_t hdr_copy2; \
+    }; \
+    union { \
+        struct { \
+            uint8_t mpm_pattern_id_mod_8; \
+            SignatureMask mask; \
+            SigIntId num; /**< signature number, internal id */ \
+        }; \
+        uint32_t hdr_copy3; \
+    }
+
 typedef struct SignatureHeader_ {
-    union {
-        struct {
-            /* coccinelle: SignatureHeader:flags:SIG_FLAG */
-            uint32_t flags;
-            AppProto alproto;
-            uint16_t dsize_low;
-        };
-        uint64_t hdr_copy1;
-    };
-    union {
-        struct {
-            uint16_t dsize_high;
-            uint16_t mpm_pattern_id_div_8;
-        };
-        uint32_t hdr_copy2;
-    };
-    union {
-        struct {
-            uint8_t mpm_pattern_id_mod_8;
-            SignatureMask mask;
-            SigIntId num; /**< signature number, internal id */
-        };
-        uint32_t hdr_copy3;
-    };
+    SIGNATURE_HEADER;
     /** pointer to the full signature */
     struct Signature_ *full_sig;
 } SignatureHeader;
@@ -375,30 +380,7 @@ typedef struct SigMatch_ {
 
 /** \brief Signature container */
 typedef struct Signature_ {
-    union {
-        struct {
-            /* coccinelle: Signature:flags:SIG_FLAG */
-            uint32_t flags;
-            AppProto alproto;
-            uint16_t dsize_low;
-        };
-        uint64_t hdr_copy1;
-    };
-    union {
-        struct {
-            uint16_t dsize_high;
-            uint16_t mpm_pattern_id_div_8;
-        };
-        uint32_t hdr_copy2;
-    };
-    union {
-        struct {
-            uint8_t mpm_pattern_id_mod_8;
-            SignatureMask mask;
-            SigIntId num; /**< signature number, internal id */
-        };
-        uint32_t hdr_copy3;
-    };
+    SIGNATURE_HEADER;
 
     /** inline -- action */
     uint8_t action;


### PR DESCRIPTION
Use a macro when defining the Signature Header and Signature structures
since the fields are required to match for correctness. This helps avoid changing code in one place and not the other.
- PR build: https://buildbot.openinfosecfoundation.org/builders/ken-tilera/builds/30
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/ken-tilera-pcap/builds/36
