### PR TITLE
Make AppLayerProfiling functions inline

### DIFF
--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -656,20 +656,14 @@ void AppLayerDestroyCtxThread(AppLayerThreadCtx *app_tctx)
     SCReturn;
 }
 
-/* profiling */
-
-void AppLayerProfilingReset(AppLayerThreadCtx *app_tctx)
+void AppLayerProfilingResetInternal(AppLayerThreadCtx *app_tctx)
 {
-#ifdef PROFILING
     PACKET_PROFILING_APP_RESET(app_tctx);
-#endif
 }
 
-void AppLayerProfilingStore(AppLayerThreadCtx *app_tctx, Packet *p)
+void AppLayerProfilingStoreInternal(AppLayerThreadCtx *app_tctx, Packet *p)
 {
-#ifdef PROFILING
     PACKET_PROFILING_APP_STORE(app_tctx, p);
-#endif
 }
 
 /***** Unittests *****/

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -31,6 +31,8 @@
 #include "stream-tcp-reassemble.h"
 #include "stream.h"
 
+#include "util-profiling.h"
+
 #define APP_LAYER_DATA_ALREADY_SENT_TO_APP_LAYER \
     (~STREAM_TOSERVER & ~STREAM_TOCLIENT)
 
@@ -108,8 +110,26 @@ AppLayerThreadCtx *AppLayerGetCtxThread(ThreadVars *tv);
 void AppLayerDestroyCtxThread(AppLayerThreadCtx *tctx);
 
 
-void AppLayerProfilingReset(AppLayerThreadCtx *tctx);
-void AppLayerProfilingStore(AppLayerThreadCtx *tctx, Packet *p);
+/***** Profiling *****/
+
+void AppLayerProfilingResetInternal(AppLayerThreadCtx *app_tctx);
+
+static inline void AppLayerProfilingReset(AppLayerThreadCtx *app_tctx)
+{
+#ifdef PROFILING
+    AppLayerProfilingResetInternal(app_tctx);
+#endif
+}
+
+void AppLayerProfilingStoreInternal(AppLayerThreadCtx *app_tctx, Packet *p);
+
+static inline void AppLayerProfilingStore(AppLayerThreadCtx *app_tctx, Packet *p)
+{
+#ifdef PROFILING
+    AppLayerProfilingStoreInternal(app_tctx, p);
+#endif
+}
+
 
 /***** Unittests *****/
 


### PR DESCRIPTION
The entire body of these functions are protected by ifdef PROFILING.
If the functions are inlined, then this check removes the need for the
function call entirely.

Previously, the empty function was still called, even when not built
for profiling. The functions showed as being 0.25% of total CPU time
without being built for profiling.
- PR build: https://buildbot.openinfosecfoundation.org/builders/ken-tilera/builds/31
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/ken-tilera-pcap/builds/37
