### PR TITLE
Make suricata_ctl_flags be volatile

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -96,7 +96,6 @@
 
 #endif /* HAVE_AF_PACKET */
 
-extern uint8_t suricata_ctl_flags;
 extern int max_pending_packets;
 
 #ifndef HAVE_AF_PACKET

--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -91,7 +91,6 @@ NoErfDagSupportExit(ThreadVars *tv, void *initdata, void **data)
 #define BYTES_PER_LOOP (4 * 1024 * 1024) /* 4 MB */
 
 extern int max_pending_packets;
-extern uint8_t suricata_ctl_flags;
 
 typedef struct ErfDagThreadVars_ {
     ThreadVars *tv;

--- a/src/source-mpipe.c
+++ b/src/source-mpipe.c
@@ -76,8 +76,6 @@
 
 #define min(a,b) (((a) < (b)) ? (a) : (b))
 
-extern uint8_t suricata_ctl_flags;
-
 /** storage for mpipe device names */
 typedef struct MpipeDevice_ {
     char *dev;  /**< the device (e.g. "xgbe1") */

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -79,7 +79,6 @@ TmEcode NoNapatechSupportExit(ThreadVars *tv, void *initdata, void **data)
 #include <nt.h>
 
 extern int max_pending_packets;
-extern uint8_t suricata_ctl_flags;
 
 typedef struct NapatechThreadVars_ {
     ThreadVars *tv;

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -57,7 +57,6 @@
 
 #endif /* __SC_CUDA_SUPPORT__ */
 
-extern uint8_t suricata_ctl_flags;
 extern int max_pending_packets;
 
 //static int pcap_max_read_packets = 0;

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -54,8 +54,6 @@
 
 #endif /* __SC_CUDA_SUPPORT__ */
 
-extern uint8_t suricata_ctl_flags;
-
 #define PCAP_STATE_DOWN 0
 #define PCAP_STATE_UP 1
 

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -71,7 +71,6 @@ TmEcode DecodePfring(ThreadVars *, Packet *, void *, PacketQueue *, PacketQueue 
 TmEcode DecodePfringThreadDeinit(ThreadVars *tv, void *data);
 
 extern int max_pending_packets;
-extern uint8_t suricata_ctl_flags;
 
 #ifndef HAVE_PFRING
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -202,7 +202,7 @@ SC_ATOMIC_DECLARE(unsigned int, engine_stage);
 #define DEFAULT_MAX_PENDING_PACKETS 1024
 
 /** suricata engine control flags */
-uint8_t suricata_ctl_flags = 0;
+volatile uint8_t suricata_ctl_flags = 0;
 
 /** Run mode selected */
 int run_mode = RUNMODE_UNKNOWN;

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2014 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -162,7 +162,7 @@ typedef struct SCInstance_ {
 /* memset to zeros, and mutex init! */
 void GlobalInits();
 
-extern uint8_t suricata_ctl_flags;
+extern volatile uint8_t suricata_ctl_flags;
 
 /* uppercase to lowercase conversion lookup table */
 uint8_t g_u8_lowercasetable[256];


### PR DESCRIPTION
The global variable suricata_ctl_flags needs to volatile, otherwise the
compiler might not force the variable to be loaded every time it is used. This is required because the
variable can be written by other threads.

This was causing Suricata to not exit under some conditions.
- PR build: https://buildbot.openinfosecfoundation.org/builders/ken-tilera/builds/32
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/ken-tilera-pcap/builds/38
