### PR TITLE
Make bad copy-mode be an error in runmode-tile.

### DIFF
--- a/src/runmode-tile.c
+++ b/src/runmode-tile.c
@@ -130,7 +130,8 @@ void *ParseMpipeConfig(const char *iface)
                       aconf->out_iface);
             aconf->copy_mode = MPIPE_COPY_MODE_TAP;
         } else {
-            SCLogInfo("Invalid mode (no in tap, ips)");
+            SCLogError(SC_ERR_RUNMODE, "Invalid mode (expected tap or ips)");
+            exit(EXIT_FAILURE);
         }
     }
     return aconf;


### PR DESCRIPTION
Making this case harder for a user to ignore so that it is not missed, which can result in no traffic being forwarded.

Passes PR script:
- PR build: https://buildbot.openinfosecfoundation.org/builders/ken-tilera/builds/40
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/ken-tilera-pcap/builds/46
