### PR TITLE
Correct size increase in SigGroupHeadStore()

### DIFF
--- a/src/detect-engine-siggroup.c
+++ b/src/detect-engine-siggroup.c
@@ -125,8 +125,9 @@ void SigGroupHeadStore(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
     if (de_ctx->sgh_array_cnt < de_ctx->sgh_array_size) {
         de_ctx->sgh_array[de_ctx->sgh_array_cnt] = sgh;
     } else {
+        int increase = 16;
         ptmp = SCRealloc(de_ctx->sgh_array,
-                         sizeof(SigGroupHead *) * (16 + de_ctx->sgh_array_size));
+                         sizeof(SigGroupHead *) * (increase + de_ctx->sgh_array_size));
         if (ptmp == NULL) {
             SCFree(de_ctx->sgh_array);
             de_ctx->sgh_array = NULL;
@@ -134,7 +135,7 @@ void SigGroupHeadStore(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
         }
         de_ctx->sgh_array = ptmp;
 
-        de_ctx->sgh_array_size += 10;
+        de_ctx->sgh_array_size += increase;
         de_ctx->sgh_array[de_ctx->sgh_array_cnt] = sgh;
     }
     de_ctx->sgh_array_cnt++;


### PR DESCRIPTION
The code was increasing the size of the allocated memory by 16, but
only increasing the stored size by 10. Now uses one variable for both
places.

Passes PR scripts:
- PR build: https://buildbot.openinfosecfoundation.org/builders/ken-tilera/builds/41
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/ken-tilera-pcap/builds/47
