### PR TITLE
Remove an unused define COUNTER_DETECT_ALERTS

### DIFF
--- a/src/detect.h
+++ b/src/detect.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2014 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -42,8 +42,6 @@
 #include "reputation.h"
 
 #include "detect-mark.h"
-
-#define COUNTER_DETECT_ALERTS 1
 
 #define DETECT_MAX_RULE_SIZE 8192
 


### PR DESCRIPTION
The only place this exists in the code is when it is defined.
- PR build: https://buildbot.openinfosecfoundation.org/builders/ken-tilera/builds/45
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/ken-tilera-pcap/builds/51
