### PR TITLE
Fix error in DetectFlowintParse(). Assigning to both values of a union

### DIFF
--- a/src/detect-flowint.c
+++ b/src/detect-flowint.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2014 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-flowint.h
+++ b/src/detect-flowint.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2014 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free


### PR DESCRIPTION
Fix a bug in flowint parsing that was always assigning to one part of a union (target.value) whlie sometimes assigning to the other part (tarvalue). This only showed up in the unit tests after cleaning up flowint matching to not write the tvar.idx part of the context, since the match functions should not write any of the context.

Since Targetvar.idx is then never used, remove it, which saves 8 bytes from DetectFlowintData. It also makes the code more clear.

Passes PR scripts:
- PR build: https://buildbot.openinfosecfoundation.org/builders/ken-tilera/builds/50
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/ken-tilera-pcap/builds/56
