### PR TITLE
lua:  in streaming api, indicate open/close

### DIFF
--- a/src/util-lua-common.c
+++ b/src/util-lua-common.c
@@ -113,7 +113,9 @@ static int LuaCallbackStreamingBufferPushToStack(lua_State *luastate, const LuaS
 {
     //PrintRawDataFp(stdout, (uint8_t *)b->data, b->data_len);
     lua_pushlstring (luastate, (const char *)b->data, b->data_len);
-    return 1;
+    lua_pushboolean (luastate, (b->flags & OUTPUT_STREAMING_FLAG_OPEN));
+    lua_pushboolean (luastate, (b->flags & OUTPUT_STREAMING_FLAG_CLOSE));
+    return 3;
 }
 
 /** \internal


### PR DESCRIPTION
The SCStreamingBuffer call now also returns two booleans:
    data, data_open, data_close = SCStreamingBuffer()

The first indicates this is the first data of this type for this
TCP session or HTTP transaction.

The second indicates this is the last data.

Ticket #1317.
