### PR TITLE
Correct flow memory usage bookkeeping error

### DIFF
--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -79,7 +79,8 @@ void FlowFree(Flow *f)
     FLOW_DESTROY(f);
     SCFree(f);
 
-    (void) SC_ATOMIC_SUB(flow_memuse, sizeof(Flow));
+    size_t size = sizeof(Flow) + FlowStorageSize();
+    (void) SC_ATOMIC_SUB(flow_memuse, size);
 }
 
 /**


### PR DESCRIPTION
Fix bug 1321 where flow_memuse was incremented more on allocation than
free.

Passes PR Scripts:
- PR build: https://buildbot.openinfosecfoundation.org/builders/ken-tilera/builds/53
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/ken-tilera-pcap/builds/59

Fixes bug 1321 - https://redmine.openinfosecfoundation.org/issues/1321
