### PR TITLE
ipv6: check for MLD messages with HL not 1

### DIFF
--- a/rules/decoder-events.rules
+++ b/rules/decoder-events.rules
@@ -56,6 +56,7 @@ alert pkthdr any any -> any any (msg:"SURICATA ICMPv6 unknown type"; decode-even
 alert pkthdr any any -> any any (msg:"SURICATA ICMPv6 unknown code"; decode-event:icmpv6.unknown_code; sid:2200030; rev:1;)
 alert pkthdr any any -> any any (msg:"SURICATA ICMPv6 truncated packet"; decode-event:icmpv6.ipv6_trunc_pkt; sid:2200031; rev:1;)
 alert pkthdr any any -> any any (msg:"SURICATA ICMPv6 unknown version"; decode-event:icmpv6.ipv6_unknown_version; sid:2200032; rev:1;)
+alert pkthdr any any -> any any (msg:"SURICATA ICMPv6 MLD hop limit not 1"; decode-event:icmpv6.mld_message_with_invalid_hl; sid:2200102; rev:1;)
 alert pkthdr any any -> any any (msg:"SURICATA TCP packet too small"; decode-event:tcp.pkt_too_small; sid:2200033; rev:1;)
 alert pkthdr any any -> any any (msg:"SURICATA TCP header length too small"; decode-event:tcp.hlen_too_small; sid:2200034; rev:1;)
 alert pkthdr any any -> any any (msg:"SURICATA TCP invalid option length"; decode-event:tcp.invalid_optlen; sid:2200035; rev:1;)
@@ -122,5 +123,5 @@ alert pkthdr any any -> any any (msg:"SURICATA MPLS bad implicit null label"; de
 alert pkthdr any any -> any any (msg:"SURICATA MPLS reserved label"; decode-event:mpls.bad_label_reserved; sid: 2200100; rev:1;)
 alert pkthdr any any -> any any (msg:"SURICATA MPLS unknown payload type"; decode-event:mpls.unknown_payload_type; sid: 2200101; rev:1;)
 
-# next sid is 2200102
+# next sid is 2200103
 

--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -57,6 +57,7 @@ enum {
     ICMPV6_PKT_TOO_SMALL,           /**< icmpv6 smaller than minimum size */
     ICMPV6_IPV6_UNKNOWN_VER,        /**< unknown version in icmpv6 packet */
     ICMPV6_IPV6_TRUNC_PKT,          /**< truncated icmpv6 packet */
+    ICMPV6_MLD_MESSAGE_WITH_INVALID_HL, /**< invalid MLD that doesn't have HL 1 */
 
     /* IPV6 EVENTS */
     IPV6_PKT_TOO_SMALL,             /**< ipv6 packet smaller than minimum size */

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -298,17 +298,26 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             if (p->icmpv6h->code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
+            if (IPV6_GET_HLIM(p) != 1) {
+                ENGINE_SET_EVENT(p, ICMPV6_MLD_MESSAGE_WITH_INVALID_HL);
+            }
             break;
         case MLD_LISTENER_REPORT:
             SCLogDebug("MLD_LISTENER_REPORT");
             if (p->icmpv6h->code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
+            if (IPV6_GET_HLIM(p) != 1) {
+                ENGINE_SET_EVENT(p, ICMPV6_MLD_MESSAGE_WITH_INVALID_HL);
+            }
             break;
         case MLD_LISTENER_REDUCTION:
             SCLogDebug("MLD_LISTENER_REDUCTION");
             if (p->icmpv6h->code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
+            }
+            if (IPV6_GET_HLIM(p) != 1) {
+                ENGINE_SET_EVENT(p, ICMPV6_MLD_MESSAGE_WITH_INVALID_HL);
             }
             break;
         default:

--- a/src/detect-engine-event.h
+++ b/src/detect-engine-event.h
@@ -70,6 +70,7 @@ struct DetectEngineEvents_ {
     { "icmpv6.pkt_too_small", ICMPV6_PKT_TOO_SMALL,},
     { "icmpv6.ipv6_unknown_version", ICMPV6_IPV6_UNKNOWN_VER,},
     { "icmpv6.ipv6_trunc_pkt", ICMPV6_IPV6_TRUNC_PKT,},
+    { "icmpv6.mld_message_with_invalid_hl", ICMPV6_MLD_MESSAGE_WITH_INVALID_HL,},
 
     /* IPV6 EVENTS */
     { "ipv6.pkt_too_small", IPV6_PKT_TOO_SMALL, },


### PR DESCRIPTION
MLD messages should have a hop limit of 1 only. All others are invalid.

Written at MLD talk of Enno Rey, Antonios Atlasis & Jayson Salazar during
Deepsec 2014.
