### PR TITLE
Bug 977: -T / --init-errors-fatal to process all rules

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1535,12 +1535,6 @@ error:
     if (sig != NULL) {
         SigFree(sig);
     }
-
-    if (de_ctx->failure_fatal == 1) {
-        SCLogError(SC_ERR_INVALID_SIGNATURE, "Signature parsing failed: "
-                   "\"%s\"", sigstr);
-        exit(EXIT_FAILURE);
-    }
     return NULL;
 }
 
@@ -1578,13 +1572,6 @@ error:
     if (sig != NULL) {
         SigFree(sig);
     }
-
-    if (de_ctx->failure_fatal == 1) {
-        SCLogError(SC_ERR_INVALID_SIGNATURE, "Signature parsing failed: "
-                   "\"%s\"", sigstr);
-        exit(EXIT_FAILURE);
-    }
-
     /* if something failed, restore the old signum count
      * since we didn't install it */
     de_ctx->signum = oldsignum;


### PR DESCRIPTION
Have -T / --init-errors-fatal process all rules so that it's easier
to debug problems in ruleset. Otherwise it can be a lengthy fix, test
error cycle if multiple rules have issues.

Convert empty rulefile error into a warning.

Bug #977

Replaces #1224 
