### PR TITLE
Move tcp.reassembly_memuse to flow manager thread

### DIFF
--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -490,6 +490,10 @@ typedef struct FlowManagerThreadData_ {
     uint16_t flow_mgr_spare;
     uint16_t flow_emerg_mode_enter;
     uint16_t flow_emerg_mode_over;
+
+    /** account memory usage for the reassembly portion of the stream engine */
+    uint16_t tcp_reass_memuse;
+
 } FlowManagerThreadData;
 
 static TmEcode FlowManagerThreadInit(ThreadVars *t, void *initdata, void **data)
@@ -534,6 +538,10 @@ static TmEcode FlowManagerThreadInit(ThreadVars *t, void *initdata, void **data)
             SC_PERF_TYPE_UINT64, "NULL");
     ftd->flow_emerg_mode_over = SCPerfTVRegisterCounter("flow.emerg_mode_over", t,
             SC_PERF_TYPE_UINT64, "NULL");
+
+    ftd->tcp_reass_memuse = SCPerfTVRegisterCounter("tcp.reassembly_memuse", t,
+                                                    SC_PERF_TYPE_UINT64,
+                                                    "NULL");
 
     PacketPoolInit();
     return TM_ECODE_OK;
@@ -688,6 +696,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
 
         SCLogDebug("woke up... %s", SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY ? "emergency":"");
 
+        StreamTcpReassembleMemuseCounter(th_v, ftd->tcp_reass_memuse);
         SCPerfSyncCountersIfSignalled(th_v);
     }
 

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -135,12 +135,13 @@ void StreamTcpReassembleDecrMemuse(uint64_t size)
     return;
 }
 
-void StreamTcpReassembleMemuseCounter(ThreadVars *tv, TcpReassemblyThreadCtx *rtv)
+void StreamTcpReassembleMemuseCounter(ThreadVars *tv, uint16_t perf_cntr)
 {
+    if (tv == NULL)
+        return;
+
     uint64_t smemuse = SC_ATOMIC_GET(ra_memuse);
-    if (tv != NULL && rtv != NULL)
-        SCPerfCounterSetUI64(rtv->counter_tcp_reass_memuse, tv->sc_perf_pca, smemuse);
-    return;
+    SCPerfCounterSetUI64(perf_cntr, tv->sc_perf_pca, smemuse);
 }
 
 /**
@@ -3568,7 +3569,6 @@ int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
         }
     }
 
-    StreamTcpReassembleMemuseCounter(tv, ra_ctx);
     SCReturnInt(0);
 }
 

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -57,8 +57,6 @@ typedef struct TcpReassemblyThreadCtx_ {
     uint16_t counter_tcp_segment_memcap;
     /** number of streams that stop reassembly because their depth is reached */
     uint16_t counter_tcp_stream_depth;
-    /** account memory usage for the reassembly portion of the stream engine */
-    uint16_t counter_tcp_reass_memuse;
     /** count number of streams with a unrecoverable stream gap (missing pkts) */
     uint16_t counter_tcp_reass_gap;
     /** account memory usage by suricata to handle HTTP protocol (not counting
@@ -108,5 +106,8 @@ int StreamTcpReassembleDepthReached(Packet *p);
 void StreamTcpReassembleIncrMemuse(uint64_t size);
 void StreamTcpReassembleDecrMemuse(uint64_t size);
 int StreamTcpReassembleCheckMemcap(uint32_t size);
+
+void StreamTcpReassembleMemuseCounter(ThreadVars *tv, uint16_t perf_cntr);
+
 #endif /* __STREAM_TCP_REASSEMBLE_H__ */
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4778,9 +4778,6 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->ra_ctx->counter_tcp_stream_depth = SCPerfTVRegisterCounter("tcp.stream_depth_reached", tv,
                                                         SC_PERF_TYPE_UINT64,
                                                         "NULL");
-    stt->ra_ctx->counter_tcp_reass_memuse = SCPerfTVRegisterCounter("tcp.reassembly_memuse", tv,
-                                                        SC_PERF_TYPE_UINT64,
-                                                        "NULL");
     stt->ra_ctx->counter_tcp_reass_gap = SCPerfTVRegisterCounter("tcp.reassembly_gap", tv,
                                                         SC_PERF_TYPE_UINT64,
                                                         "NULL");


### PR DESCRIPTION
This solves two problems. One is that every worker thread was reporting
the same value for TCP reassembly memuse, which implied that it was a
per-thread value, but it is global.

The other problem is that the true value, stored in the global ra_memuse, was
only copied to the tcp_reassembly_memuse stat in one function, when it was
increased, so it missed when the value went down.

Passes PR scripts:
- PR build: https://buildbot.openinfosecfoundation.org/builders/ken-tilera/builds/54
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/ken-tilera-pcap/builds/60
