### PR TITLE
Bug 977: -T / --init-errors-fatal to process all rules v3

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1535,12 +1535,6 @@ error:
     if (sig != NULL) {
         SigFree(sig);
     }
-
-    if (de_ctx->failure_fatal == 1) {
-        SCLogError(SC_ERR_INVALID_SIGNATURE, "Signature parsing failed: "
-                   "\"%s\"", sigstr);
-        exit(EXIT_FAILURE);
-    }
     return NULL;
 }
 
@@ -1578,13 +1572,6 @@ error:
     if (sig != NULL) {
         SigFree(sig);
     }
-
-    if (de_ctx->failure_fatal == 1) {
-        SCLogError(SC_ERR_INVALID_SIGNATURE, "Signature parsing failed: "
-                   "\"%s\"", sigstr);
-        exit(EXIT_FAILURE);
-    }
-
     /* if something failed, restore the old signum count
      * since we didn't install it */
     de_ctx->signum = oldsignum;

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1913,11 +1913,7 @@ static void SetupDelayedDetect(DetectEngineCtx *de_ctx, SCInstance *suri)
 static int LoadSignatures(DetectEngineCtx *de_ctx, SCInstance *suri)
 {
     if (SigLoadSignatures(de_ctx, suri->sig_file, suri->sig_file_exclusive) < 0) {
-        if (suri->sig_file == NULL) {
-            SCLogError(SC_ERR_OPENING_FILE, "Signature file has not been provided");
-        } else {
-            SCLogError(SC_ERR_NO_RULES_LOADED, "Loading signatures failed.");
-        }
+        SCLogError(SC_ERR_NO_RULES_LOADED, "Loading signatures failed.");
         if (de_ctx->failure_fatal)
             return TM_ECODE_FAILED;
     }


### PR DESCRIPTION
Have -T / --init-errors-fatal process all rules so that it's easier
to debug problems in ruleset. Otherwise it can be a lengthy fix, test
error cycle if multiple rules have issues.

Convert empty rulefile error into a warning.

Bug #977

Replaces #1225

Prscript:
- PR build: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/62
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/62
