### PR TITLE
Bug 1329: error out on invalid rule protocol

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1729,19 +1729,17 @@ AppProto AppLayerProtoDetectGetProtoByName(char *alproto_name)
 {
     SCEnter();
 
-    AppProto a = ALPROTO_UNKNOWN;
-
+    AppProto a;
     for (a = 0; a < ALPROTO_MAX; a++) {
         if (alpd_ctx.alproto_names[a] != NULL &&
             strlen(alpd_ctx.alproto_names[a]) == strlen(alproto_name) &&
             (SCMemcmp(alpd_ctx.alproto_names[a], alproto_name, strlen(alproto_name)) == 0))
         {
-            goto end;
+            SCReturnCT(a, "AppProto");
         }
     }
 
- end:
-    SCReturnCT(a, "AppProto");
+    SCReturnCT(ALPROTO_UNKNOWN, "AppProto");
 }
 
 char *AppLayerProtoDetectGetProtoName(AppProto alproto)


### PR DESCRIPTION
Due to a logic error in AppLayerProtoDetectGetProtoByName invalid
protocols would not be detected as such. Instead of ALPROTO_UNKNOWN
ALPROTO_MAX was returned.

Bug #1329 https://redmine.openinfosecfoundation.org/issues/1329

Prscript:
- PR build: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/72
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/72

CC: @duanehoward
