### PR TITLE
unix-manager: fix cppcheck errors

### DIFF
--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -297,6 +297,7 @@ int UnixCommandAccept(UnixCommand *this)
         SCLogInfo("Command server: client message is too long, "
                   "disconnect him.");
         close(client);
+        return 0;
     }
     buffer[ret] = 0;
 


### PR DESCRIPTION
This patch fixes the following errors:
 [src/unix-manager.c:306]: (error) Memory pointed to by 'client' is freed twice.
 [src/unix-manager.c:313]: (error) Memory pointed to by 'client' is freed twice.
 [src/unix-manager.c:323]: (error) Memory pointed to by 'client' is freed twice.
 [src/unix-manager.c:334]: (error) Memory pointed to by 'client' is freed twice.

Unix manager was treating the packet after closing the socket if message was
too long.

This fixes: https://redmine.openinfosecfoundation.org/issues/1182
PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/21
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/19
