### PR TITLE
stream: don't send EOF to AppLayer too soon

### DIFF
--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1911,7 +1911,10 @@ int StreamTcpReassembleHandleSegmentHandleData(ThreadVars *tv, TcpReassemblyThre
     if (!(stream->flags & STREAMTCP_STREAM_FLAG_APPPROTO_DETECTION_COMPLETED)) {\
         flag |= STREAM_START; \
     } \
-    if (stream->flags & STREAMTCP_STREAM_FLAG_CLOSE_INITIATED) {    \
+    if (ssn->state == TCP_CLOSED) { \
+        flag |= STREAM_EOF; \
+    } \
+    if (p->flags & PKT_PSEUDO_STREAM_END) { \
         flag |= STREAM_EOF; \
     } \
     if ((p)->flowflags & FLOW_PKT_TOSERVER) { \
@@ -1929,7 +1932,10 @@ int StreamTcpReassembleHandleSegmentHandleData(ThreadVars *tv, TcpReassemblyThre
     if (!(stream->flags & STREAMTCP_STREAM_FLAG_APPPROTO_DETECTION_COMPLETED)) {\
         flag |= STREAM_START; \
     } \
-    if (stream->flags & STREAMTCP_STREAM_FLAG_CLOSE_INITIATED) {    \
+    if (ssn->state == TCP_CLOSED) { \
+        flag |= STREAM_EOF; \
+    } \
+    if (p->flags & PKT_PSEUDO_STREAM_END) { \
         flag |= STREAM_EOF; \
     } \
     if ((p)->flowflags & FLOW_PKT_TOSERVER) { \


### PR DESCRIPTION
Sending EOF too soon results in the AppLayer cleaning up prematurely.

Prscript:
- PR build: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/83
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/83
