### PR TITLE
output-json: fix duplicate logging

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -348,8 +348,9 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer *buffer)
     if (json_out == ALERT_SYSLOG) {
         syslog(alert_syslog_level, "%s", js_s);
     } else if (json_out == ALERT_FILE || json_out == ALERT_UNIX_DGRAM || json_out == ALERT_UNIX_STREAM) {
+        int prev_offset = MEMBUFFER_OFFSET(buffer);
         MemBufferWriteString(buffer, "%s\n", js_s);
-        file_ctx->Write((const char *)MEMBUFFER_BUFFER(buffer),
+        file_ctx->Write((const char *)MEMBUFFER_BUFFER(buffer) + prev_offset,
             MEMBUFFER_OFFSET(buffer), file_ctx);
     }
     SCMutexUnlock(&file_ctx->fp_mutex);


### PR DESCRIPTION
This patches is fixing a issue in the OutputJSONBuffer function. It
was writing to file the content of the buffer starting from the start
to the final offset. But as the writing is done for each JSON string
we are duplicating the previous events if we are reusing the same
buffer.

Duplication was for example triggered when we have multiple alerts
attached to a packet. In the case of two alerts, the first one was
logged twice more as the second one.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1337

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/23
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/21
