### PR TITLE
output-json: fix duplicate logging

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -131,8 +131,6 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
     if (p->alerts.cnt == 0)
         return TM_ECODE_OK;
 
-    MemBufferReset(aft->json_buffer);
-
     json_t *js = CreateJSONHeader((Packet *)p, 0, "alert");
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
@@ -155,6 +153,8 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
             json_decref(js);
             return TM_ECODE_OK;
         }
+
+        MemBufferReset(aft->json_buffer);
 
         json_object_set_new(ajs, "action", json_string(action));
         json_object_set_new(ajs, "gid", json_integer(pa->s->gid));
@@ -269,11 +269,11 @@ static int AlertJsonDecoderEvent(ThreadVars *tv, JsonAlertLogThread *aft, const 
     if (p->alerts.cnt == 0)
         return TM_ECODE_OK;
 
-    MemBufferReset(buffer);
-
     CreateIsoTimeString(&p->ts, timebuf, sizeof(timebuf));
 
     for (i = 0; i < p->alerts.cnt; i++) {
+        MemBufferReset(buffer);
+
         const PacketAlert *pa = &p->alerts.alerts[i];
         if (unlikely(pa->s == NULL)) {
             continue;


### PR DESCRIPTION
This patches is fixing a issue in the OutputJSONBuffer function. It
was writing to file the content of the buffer starting from the start
to the final offset. But as the writing is done for each JSON string
we are duplicating the previous events if we are reusing the same
buffer.

Duplication was for example triggered when we have multiple alerts
attached to a packet. In the case of two alerts, the first one was
logged twice more as the second one.

Redmine tickets: https://redmine.openinfosecfoundation.org/issues/1337

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/24
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/22
