### PR TITLE
correct output-tx loop so that it interates over all outstanding tx on list.

### DIFF
--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -125,7 +125,8 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data, PacketQ
         AppLayerParserGetStateProgressCompletionStatus(p->proto, alproto, 1);
     int proto_logged = 0;
 
-    for (; tx_id < total_txs; tx_id++)
+    int i;
+    for (i = 0; i < total_txs; i++, tx_id++)
     {
         void *tx = AppLayerParserGetTx(p->proto, alproto, alstate, tx_id);
         if (tx == NULL) {


### PR DESCRIPTION
While developing a tx logger for an expanded app-layer protocol I encountered lost log messages on long lived sessions that contained many transactions.  This change eliminates the loss of logs.

Log loss occurs when tx_id advanced beyond total_txs because some already logged txs had been freed.
