### PR TITLE
app-layer: fix 'detection-only' keyword

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -280,7 +280,7 @@ int AppLayerParserConfParserEnabled(const char *ipproto,
     } else if (strcasecmp(node->val, "no") == 0) {
         goto disabled;
     } else if (strcasecmp(node->val, "detection-only") == 0) {
-        goto enabled;
+        goto disabled;
     } else {
         SCLogError(SC_ERR_FATAL, "Invalid value found for %s.", param);
         exit(EXIT_FAILURE);


### PR DESCRIPTION
If we follow the description in the yaml file, we should disable
parsing if 'detection-only' keyword is used.

I did not test the result but the logic was looking wrong to my eyes.

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/25
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/23
