### PR TITLE
Update reference.config

### DIFF
--- a/reference.config
+++ b/reference.config
@@ -1,8 +1,9 @@
 # config reference: system URL
 
-config reference: bugtraq   http://www.securityfocus.com/bid/
-config reference: bid	    http://www.securityfocus.com/bid/
+config reference: bugtraq   http://www.securityfocus.com/bid/ 
+config reference: bid	    http://www.securityfocus.com/bid/ 
 config reference: cve       http://cve.mitre.org/cgi-bin/cvename.cgi?name=
+#config reference: cve       http://cvedetails.com/cve/
 config reference: secunia   http://www.secunia.com/advisories/
 
 #whitehats is unfortunately gone
@@ -12,8 +13,14 @@ config reference: McAfee    http://vil.nai.com/vil/content/v_
 config reference: nessus    http://cgi.nessus.org/plugins/dump.php3?id=
 config reference: url       http://
 config reference: et        http://doc.emergingthreats.net/
-config reference: etpro     http://doc.emergingthreatpro.com/
+config reference: etpro     http://doc.emergingthreatspro.com/
 config reference: telus     http://
-
-config reference: md5       http://www.threatexpert.com/report.aspx?md5=
-
+config reference: osvdb     http://osvdb.org/show/osvdb/
+config reference: threatexpert http://www.threatexpert.com/report.aspx?md5=
+config reference: md5	    http://www.threatexpert.com/report.aspx?md5=
+config reference: exploitdb http://www.exploit-db.com/exploits/
+config reference: openpacket https://www.openpacket.org/capture/grab/
+config reference: securitytracker http://securitytracker.com/id?
+config reference: secunia   http://secunia.com/advisories/
+config reference: xforce    http://xforce.iss.net/xforce/xfdb/
+config reference: msft      http://technet.microsoft.com/security/bulletin/


### PR DESCRIPTION
Updated reference.config to match ET Open reference.config found here: 
https://rules.emergingthreats.net/open/suricata/reference.config

Due to startup error shown here:
root@xxxxxxx01:/etc/suricata/rules# /usr/bin/suricata -c /etc/suricata/suricata.yaml --pidfile /var/run/suricata.pid --af-packet
23/12/2014 -- 22:07:56 - <Error> - [ERRCODE: SC_ERR_REFERENCE_UNKNOWN(150)] - unknown reference key "osvdb". Supported keys are defined in reference.config file.  Please have a look at the conf param "reference-config-file"
<...>
Killed
