### PR TITLE
Fixed typo as described in Bug #2000

### DIFF
--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -303,7 +303,7 @@ void JsonHttpLogJSONExtended(json_t *js, htp_tx_t *tx)
     if (h_referer != NULL) {
         c = bstr_util_strdup_to_c(h_referer->value);
         if (c != NULL) {
-            json_object_set_new(js, "http_refer", json_string(c));
+            json_object_set_new(js, "http_referer", json_string(c));
             SCFree(c);
         }
     }


### PR DESCRIPTION
A small typo in output-json-http.c that is described in Bug #2000, 
the typo resulted in JSON objects with a http_refer field and not http_referer field.