### PR TITLE
Make util-hash.c faster

### DIFF
--- a/src/util-hash.c
+++ b/src/util-hash.c
@@ -38,7 +38,7 @@ HashTable* HashTableInit(uint32_t size, uint32_t (*Hash)(struct HashTable_ *, vo
     if (size == 0) {
         goto error;
     }
-    if (size & (size - 1) == 0) {
+    if ((size & (size - 1)) != 0) {
         //printf("ERROR: Size must be a power of 2\n"); 
         goto error;
     }

--- a/src/util-hash.c
+++ b/src/util-hash.c
@@ -38,6 +38,10 @@ HashTable* HashTableInit(uint32_t size, uint32_t (*Hash)(struct HashTable_ *, vo
     if (size == 0) {
         goto error;
     }
+    if (size & (size - 1) == 0) {
+        //printf("ERROR: Size must be a power of 2\n"); 
+        goto error;
+    }
 
     if (Hash == NULL) {
         //printf("ERROR: HashTableInit no Hash function\n");
@@ -219,7 +223,7 @@ uint32_t HashTableGenericHash(HashTable *ht, void *data, uint16_t datalen)
      }
 
      hash *= datalen;
-     hash %= ht->array_size;
+     hash &= ht->array_size - 1;
      return hash;
 }
 

--- a/src/util-mpm-hs.c
+++ b/src/util-mpm-hs.c
@@ -65,7 +65,7 @@ void SCHSRegisterTests(void);
 #define INIT_HASH_SIZE 65536
 
 /* Initial size of the global database hash (used for de-duplication). */
-#define INIT_DB_HASH_SIZE 1000
+#define INIT_DB_HASH_SIZE 1024
 
 /* Global prototype scratch, built incrementally as Hyperscan databases are
  * built and then cloned for each thread context. Access is serialised via


### PR DESCRIPTION
Restriction: Hash table must be an even power of 2. This appears to be the case everywhere it's used, however.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Optimize hashing, as per http://mziccard.me/2015/05/08/modulo-and-division-vs-bitwise-operations/
- Requires hash table to be a power of 2, as per https://blog.mozilla.org/nnethercote/2014/11/04/please-grow-your-buffers-exponentially/

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

