### PR TITLE
redis: support for rpush in list mode for 3.2.x

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -267,7 +267,9 @@ integration with 3rd party tools like logstash.
       #redis:
       #  server: 127.0.0.1
       #  port: 6379
-      #  mode: list ## possible values: list (default), channel
+      #  mode: list ## possible values: list|lpush (default), rpush, channel|publish
+      #             ## lpush and rpush are using a Redis list. "list" is an alias for lpush
+      #             ## publish is using a Redis channel. "channel" is an alias for publish
       #  key: suricata ## key or channel to use (default to suricata)
       # Redis pipelining set up. This will enable to only do a query every
       # 'batch-size' events. This should lower the latency induced by network

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -24,7 +24,9 @@ The most common way to use this is through 'EVE', which is a firehose approach w
       #redis:
       #  server: 127.0.0.1
       #  port: 6379
-      #  mode: list ## possible values: list (default), channel
+      #  mode: list ## possible values: list|lpush (default), rpush, channel|publish
+      #             ## lpush and rpush are using a Redis list. "list" is an alias for lpush
+      #             ## publish is using a Redis channel. "channel" is an alias for publish
       #  key: suricata ## key or channel to use (default to suricata)
       # Redis pipelining set up. This will enable to only do a query every
       # 'batch-size' events. This should lower the latency induced by network
@@ -134,7 +136,9 @@ Output types::
       #redis:
       #  server: 127.0.0.1
       #  port: 6379
-      #  mode: list ## possible values: list (default), channel
+      #  mode: list ## possible values: list|lpush (default), rpush, channel|publish
+      #             ## lpush and rpush are using a Redis list. "list" is an alias for lpush
+      #             ## publish is using a Redis channel. "channel" is an alias for publish
       #  key: suricata ## key or channel to use (default to suricata)
       # Redis pipelining set up. This will enable to only do a query every
       # 'batch-size' events. This should lower the latency induced by network

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -335,6 +335,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE(SC_WARN_REMOVE_FILE);
         CASE_CODE (SC_ERR_NO_MAGIC_SUPPORT);
         CASE_CODE (SC_ERR_REDIS);
+        CASE_CODE (SC_ERR_REDIS_CONFIG);
     }
 
     return "UNKNOWN_ERROR";

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -325,6 +325,7 @@ typedef enum {
     SC_WARN_REMOVE_FILE,
     SC_ERR_NO_MAGIC_SUPPORT,
     SC_ERR_REDIS,
+    SC_ERR_REDIS_CONFIG,
 } SCError;
 
 const char *SCErrorToString(SCError);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -148,7 +148,9 @@ outputs:
       #redis:
       #  server: 127.0.0.1
       #  port: 6379
-      #  mode: list ## possible values: list (default), channel
+      #  mode: list ## possible values: list|lpush (default), rpush, channel|publish
+      #             ## lpush and rpush are using a Redis list. "list" is an alias for lpush
+      #             ## publish is using a Redis channel. "channel" is an alias for publish
       #  key: suricata ## key or channel to use (default to suricata)
       # Redis pipelining set up. This will enable to only do a query every
       # 'batch-size' events. This should lower the latency induced by network


### PR DESCRIPTION
This is the a backport of PR #2865 for 3.2.x
Resubmitted as requested in #2822

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2114

Describe changes:

This adds a new redis mode rpush. Also more consistent config keywords orientated at the redis command: lpush and publish.
Keeping list and channel config keywords for backwards compatibility. Removed unnecessary checks.

