### PR TITLE
Add user-configurable umask setting

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -154,6 +154,7 @@
 #include "util-debug.h"
 #include "util-error.h"
 #include "util-daemon.h"
+#include "util-byte.h"
 #include "reputation.h"
 
 #include "output.h"
@@ -2624,6 +2625,17 @@ static int PostConfLoadedSetup(SCInstance *suri)
     }
 
     AppLayerSetup();
+
+    /* Suricata will use this umask if provided. By default it will use the
+       umask passed on from the shell. */
+    const char *custom_umask;
+    if (ConfGet("umask", &custom_umask) == 1) {
+        uint16_t mask;
+        if (ByteExtractStringUint16(&mask, 8, strlen(custom_umask),
+                                    custom_umask) > 0) {
+            umask((mode_t)mask);
+        }
+    }
 
     /* Check for the existance of the default logging directory which we pick
      * from suricata.yaml.  If not found, shut the engine down */

--- a/src/util-daemon.c
+++ b/src/util-daemon.c
@@ -121,8 +121,6 @@ void Daemonize (void)
         /* Child continues here */
         const char *daemondir;
 
-        umask(027);
-
         sid = setsid();
         if (sid < 0) {
             SCLogError(SC_ERR_DAEMON, "Error creating new session");

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -938,6 +938,11 @@ asn1-max-frames: 256
 # Default: "/"
 #daemon-directory: "/"
 
+# Umask.
+# Suricata will use this umask if it is provided. By default it will use the
+# umask passed on by the shell.
+#umask: 022
+
 # Suricata core dump configuration. Limits the size of the core dump file to
 # approximately max-dump. The actual core dump size will be a multiple of the
 # page size. Core dumps that would be larger than max-dump are truncated. On


### PR DESCRIPTION
Make umask user-configurable by setting 'umask' in suricata.yaml.

This works both when daemonizing and when running in the foreground.

https://redmine.openinfosecfoundation.org/issues/1678

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/130
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/130
