### PR TITLE
New option for logging hash of truncated files

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -92,6 +92,9 @@ The most common way to use this is through 'EVE', which is a firehose approach w
             # force logging of checksums, available hash functions are md5,
             # sha1 and sha256
             #force-hash: [md5]
+            # force hash calculation for truncated files
+            #force-hash-truncated: yes
+
         #- drop:
         #    alerts: yes      # log alerts that caused drops
         #    flows: all       # start or all: 'start' logs only a single drop

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -78,6 +78,42 @@ typedef struct JsonFileLogThread_ {
     MemBuffer *buffer;
 } JsonFileLogThread;
 
+/* Write result hash as json object... */
+#ifdef HAVE_NSS
+static void FileWriteJsonHash( const File *ff, json_t *fjs )
+{
+    if (ff->flags & FILE_MD5) {
+        size_t x;
+        int i;
+        char str[256];
+        for (i = 0, x = 0; x < sizeof(ff->md5); x++) {
+            i += snprintf(&str[i], 255-i, "%02x", ff->md5[x]);
+        }
+        json_object_set_new(fjs, "md5", json_string(str));
+    }
+
+    if (ff->flags & FILE_SHA1) {
+        size_t x;
+        int i;
+        char str[256];
+        for (i = 0, x = 0; x < sizeof(ff->sha1); x++) {
+            i += snprintf(&str[i], 255-i, "%02x", ff->sha1[x]);
+        }
+        json_object_set_new(fjs, "sha1", json_string(str));
+    }
+
+    if (ff->flags & FILE_SHA256) {
+        size_t x;
+        int i;
+        char str[256];
+        for (i = 0, x = 0; x < sizeof(ff->sha256); x++) {
+            i += snprintf(&str[i], 255-i, "%02x", ff->sha256[x]);
+        }
+        json_object_set_new(fjs, "sha256", json_string(str));
+    }
+}
+#endif
+
 /**
  *  \internal
  *  \brief Write meta data on a single line json record
@@ -140,37 +176,16 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
         case FILE_STATE_CLOSED:
             json_object_set_new(fjs, "state", json_string("CLOSED"));
 #ifdef HAVE_NSS
-            if (ff->flags & FILE_MD5) {
-                size_t x;
-                int i;
-                char str[256];
-                for (i = 0, x = 0; x < sizeof(ff->md5); x++) {
-                    i += snprintf(&str[i], 255-i, "%02x", ff->md5[x]);
-                }
-                json_object_set_new(fjs, "md5", json_string(str));
-            }
-            if (ff->flags & FILE_SHA1) {
-                size_t x;
-                int i;
-                char str[256];
-                for (i = 0, x = 0; x < sizeof(ff->sha1); x++) {
-                    i += snprintf(&str[i], 255-i, "%02x", ff->sha1[x]);
-                }
-                json_object_set_new(fjs, "sha1", json_string(str));
-            }
-            if (ff->flags & FILE_SHA256) {
-                size_t x;
-                int i;
-                char str[256];
-                for (i = 0, x = 0; x < sizeof(ff->sha256); x++) {
-                    i += snprintf(&str[i], 255-i, "%02x", ff->sha256[x]);
-                }
-                json_object_set_new(fjs, "sha256", json_string(str));
-            }
+            FileWriteJsonHash( ff, fjs );
 #endif
             break;
         case FILE_STATE_TRUNCATED:
             json_object_set_new(fjs, "state", json_string("TRUNCATED"));
+            /* for hashing truncated files... */
+#ifdef HAVE_NSS
+            if ( FileForceHashTruncated() )
+                FileWriteJsonHash( ff, fjs );
+#endif
             break;
         case FILE_STATE_ERROR:
             json_object_set_new(fjs, "state", json_string("ERROR"));
@@ -304,6 +319,9 @@ static OutputCtx *OutputFileLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         }
 
         FileForceHashParseCfg(conf);
+
+        /* for hashing truncated files... */
+        FileForceHashTruncatedCfg(conf);
     }
 
     output_ctx->data = output_file_ctx;

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -67,6 +67,12 @@ static int g_file_force_sha256 = 0;
  */
 static int g_file_force_tracking = 0;
 
+/* for hashing truncated files... */
+/** \brief switch to force hash calculation on
+ *         truncated files.
+ */
+static int g_file_force_hash_truncated = 0;
+
 /** \brief switch to use g_file_store_reassembly_depth
  *         to reassembly files
  */
@@ -147,6 +153,40 @@ int FileForceSha256(void)
 void FileForceTrackingEnable(void)
 {
     g_file_force_tracking = 1;
+}
+
+/* for hashing truncated files... */
+int FileForceHashTruncated(void)
+{
+    return g_file_force_hash_truncated;
+}
+
+/* for hashing truncated files... */
+void FileForceHashTruncatedEnable(void)
+{
+    g_file_force_hash_truncated = 1;
+}
+
+/**
+ * for hashing truncated files...
+ * \brief Function to parse forced truncated file hashing configuration.
+ */
+void FileForceHashTruncatedCfg(ConfNode *conf)
+{
+    BUG_ON(conf == NULL);
+
+    const char *forcehash_truncated = ConfNodeLookupChildValue( conf, "force-hash-truncated" );
+
+    if ( forcehash_truncated != NULL ) {
+        if ( ConfValIsTrue( forcehash_truncated ) ) {
+#ifdef HAVE_NSS
+        FileForceHashTruncatedEnable();
+        SCLogConfig("forcing hash calculation for truncated files");
+#else
+        SCLogInfo("hash calculation for truncated files requires linking against libnss");
+#endif
+        }
+    }
 }
 
 /**
@@ -839,6 +879,27 @@ File *FileOpenFileWithId(FileContainer *ffc, const StreamingBufferConfig *sbcfg,
     return ff;
 }
 
+#ifdef HAVE_NSS
+void FileCloseHashEnd( File *ff )
+{
+    if (ff->md5_ctx) {
+        unsigned int len = 0;
+        HASH_End(ff->md5_ctx, ff->md5, &len, sizeof(ff->md5));
+        ff->flags |= FILE_MD5;
+    }
+    if (ff->sha1_ctx) {
+        unsigned int len = 0;
+        HASH_End(ff->sha1_ctx, ff->sha1, &len, sizeof(ff->sha1));
+        ff->flags |= FILE_SHA1;
+    }
+    if (ff->sha256_ctx) {
+        unsigned int len = 0;
+        HASH_End(ff->sha256_ctx, ff->sha256, &len, sizeof(ff->sha256));
+        ff->flags |= FILE_SHA256;
+    }
+}
+#endif
+
 static int FileCloseFilePtr(File *ff, const uint8_t *data,
         uint32_t data_len, uint16_t flags)
 {
@@ -875,6 +936,9 @@ static int FileCloseFilePtr(File *ff, const uint8_t *data,
     if ((flags & FILE_TRUNCATED) || (ff->flags & FILE_HAS_GAPS)) {
         ff->state = FILE_STATE_TRUNCATED;
         SCLogDebug("flowfile state transitioned to FILE_STATE_TRUNCATED");
+#ifdef HAVE_NSS
+        FileCloseHashEnd( ff );
+#endif
 
         if (flags & FILE_NOSTORE) {
             SCLogDebug("not storing this file");
@@ -885,21 +949,7 @@ static int FileCloseFilePtr(File *ff, const uint8_t *data,
         SCLogDebug("flowfile state transitioned to FILE_STATE_CLOSED");
 
 #ifdef HAVE_NSS
-        if (ff->md5_ctx) {
-            unsigned int len = 0;
-            HASH_End(ff->md5_ctx, ff->md5, &len, sizeof(ff->md5));
-            ff->flags |= FILE_MD5;
-        }
-        if (ff->sha1_ctx) {
-            unsigned int len = 0;
-            HASH_End(ff->sha1_ctx, ff->sha1, &len, sizeof(ff->sha1));
-            ff->flags |= FILE_SHA1;
-        }
-        if (ff->sha256_ctx) {
-            unsigned int len = 0;
-            HASH_End(ff->sha256_ctx, ff->sha256, &len, sizeof(ff->sha256));
-            ff->flags |= FILE_SHA256;
-        }
+        FileCloseHashEnd( ff );
 #endif
     }
 

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -235,4 +235,10 @@ uint64_t FileTrackedSize(const File *file);
 
 uint16_t FileFlowToFlags(const Flow *flow, uint8_t direction);
 
+/* for hashing truncated files... */
+void FileForceHashTruncatedCfg(ConfNode *);
+void FileForceHashTruncatedEnable(void);
+int FileForceHashTruncated(void);
+void FileCloseHashEnd( File *ff );
+
 #endif /* __UTIL_FILE_H__ */


### PR DESCRIPTION
The prior iteration of this PR was #2824

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

[Redmine ticket](https://redmine.openinfosecfoundation.org/issues/2147)


Changes since PR #2824 :
- Removed code from output-json
- Refactored some minimal code shared between CLOSED and TRUNCATED file states
 
 
 
Changes since PR #2823 :
- Fixed coding style according to documentation
- Squashed some commits for comments
- Reverting part of commit that moved code

_EDIT: Fix Redmine ticket URL_

