### PR TITLE
New eve log option for wait before writing to a blocked UNIX stream socket 

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -15,6 +15,9 @@ The most common way to use this is through 'EVE', which is a firehose approach w
       enabled: yes
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
+      # usecs to wait before retrying a write to a blocked unix stream socket
+      # default value is 0 (won't wait)
+      #unix-retry-wait: 12830
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -650,6 +650,25 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
                     exit(EXIT_FAILURE);
                 }
             }
+
+            /* Check for usecs wait using unix stream socket...*/
+            if ( json_ctx->json_out == LOGFILE_TYPE_UNIX_STREAM ) {
+                const char *unix_retry_wait_s = ConfNodeLookupChildValue( conf,
+                                                                         "unix-retry-wait" );
+                if ( unix_retry_wait_s != NULL ) {
+                    uint32_t unix_retry_wait = 0;
+                    if ( ByteExtractStringUint32( &unix_retry_wait, 10,
+                                     strlen( unix_retry_wait_s ), unix_retry_wait_s ) > 0 ) {
+                        json_ctx->file_ctx->unix_retry_wait = unix_retry_wait ;
+                        SCLogInfo( "Will wait %d usecs before retry writing to blocked unix"
+                                    " stream socket", unix_retry_wait );
+                    } else {
+                        SCLogWarning( SC_ERR_INVALID_ARGUMENT, "Invalid usecs for unix stream"
+                                      "wait before retry: \"%s\", won't use wait before retry",
+                                      unix_retry_wait_s );
+                    }
+                }
+            }
         } else if (json_ctx->json_out == LOGFILE_TYPE_SYSLOG) {
             const char *facility_s = ConfNodeLookupChildValue(conf, "facility");
             if (facility_s == NULL) {

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -149,6 +149,11 @@ tryagain:
             ret = 0;
         } else {
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                if ( ctx->unix_retry_wait && ( tries < 4 ) ) {
+                    usleep( ctx->unix_retry_wait );
+                    tries++;
+                    goto tryagain;
+                }
                 SCLogDebug("Socket would block, dropping event.");
             } else if (errno == EINTR) {
                 if (tries++ == 0) {

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -128,6 +128,10 @@ typedef struct LogFileCtx_ {
     /* Socket types may need to drop events to keep from blocking
      * Suricata. */
     uint64_t dropped;
+
+    /* usecs to wait before retrying a write to a blocked unix_socket_stream,
+     * will never wait if 0 */
+    useconds_t unix_retry_wait ;
 } LogFileCtx;
 
 /* Min time (msecs) before trying to reconnect a Unix domain socket */


### PR DESCRIPTION
- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [Redmine ticket](https://redmine.openinfosecfoundation.org/issues/2215)

Changes:
When Suricata is configured with pcap offline analysis and, at the same time, for writing its eve log events to a UNIX socket some events could be lost if Suricata writes to the socket queue quicker than the other socket peer.

That behaviour has been observed analyzing pcap files generated by malware that uses DGA (Domains Generated Algorithm), that implies a lot of DNS flows.

This PR adds a new eve-log option named 'unix-retry-wait' for specifying an amount of microseconds to wait before retrying a write to a UNIX stream socket when its write queue is full.

I know it's a workaround but I don't see any other method suitable.

Regards