### PR TITLE
Fixed DeStateDetectStartDetection may use wrong Hexadecimal : Bug #2214  V1

### DIFF
--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -375,7 +375,7 @@ int DeStateDetectStartDetection(ThreadVars *tv, DetectEngineCtx *de_ctx,
 
     /* if continue detection already inspected this rule for this tx,
      * continue with the first not-inspected tx */
-    uint8_t offset = det_ctx->de_state_sig_array[s->num] & 0xef;
+    uint8_t offset = det_ctx->de_state_sig_array[s->num] & 0x7f;
     uint64_t tx_id = AppLayerParserGetTransactionInspectId(f->alparser, flags);
     if (offset > 0) {
         SCLogDebug("using stored_tx_id %"PRIu64" instead of %"PRIu64, tx_id+offset, tx_id);


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
 [https://redmine.openinfosecfoundation.org/issues/2214](https://redmine.openinfosecfoundation.org/issues/2214)

Describe changes:
- changed 0xef to 0x7f 

The de_state_sig_array value consists of 2 parts :
  the first bit bypass the rule,the other bits to specify an offset 。
so it 0x7f 。


