### PR TITLE
prscript: update url to use OISF repo

### DIFF
--- a/qa/prscript.py
+++ b/qa/prscript.py
@@ -61,7 +61,7 @@ except ImportError:
 
 BASE_URI="https://buildbot.openinfosecfoundation.org/"
 GITHUB_BASE_URI = "https://api.github.com/repos/"
-GITHUB_MASTER_URI = "https://api.github.com/repos/inliniac/suricata/commits?sha=master"
+GITHUB_MASTER_URI = "https://api.github.com/repos/OISF/suricata/commits?sha=master"
 
 if GOT_DOCKER:
     parser = argparse.ArgumentParser(prog='prscript', description='Script checking validity of branch before PR')


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Change path to new repo

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/331
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/115

