### PR TITLE
github: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+*                   @OISF/core-team
+rust/*              @victorjulien @jasonish
+src/source-*        @regit
+doc/*               @norg
+src/detect-engine*  @victorjulien
+*ssl*               @thus @OISF/core-team
+*tls*               @thus @OISF/core-team
+*nfs*               @victorjulien
+*dns*               @jasonish
+
+*prelude*           @ToToL
+
+*napatech*          @psanders240
+
+
+


### PR DESCRIPTION
Add code owners so that reviewers are automatically set.

See https://help.github.com/articles/about-codeowners/