### PR TITLE
tls: don't set event on small input data

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1418,7 +1418,7 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
     }
 
     /* if we have more than one record */
-    uint32_t max_records = input_len / SSL_RECORD_MINIMUM_LENGTH;
+    uint32_t max_records = MAX((input_len / SSL_RECORD_MINIMUM_LENGTH),1);
     while (input_len > 0) {
         if (counter > max_records) {
             SCLogDebug("Looks like we have looped quite a bit. Reset state "


### PR DESCRIPTION
On very small data the max loop count could be 0. Make sure
it's always at least 1.



TEST