### PR TITLE
NSM: provide minimum and maximum time-to-live to a netflow log

### DIFF
--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -137,10 +137,12 @@ void FlowInit(Flow *f, const Packet *p)
     if (PKT_IS_IPV4(p)) {
         FLOW_SET_IPV4_SRC_ADDR_FROM_PACKET(p, &f->src);
         FLOW_SET_IPV4_DST_ADDR_FROM_PACKET(p, &f->dst);
+        FLOW_SET_IPV4_TTL_FROM_PACKET(p, f);
         f->flags |= FLOW_IPV4;
     } else if (PKT_IS_IPV6(p)) {
         FLOW_SET_IPV6_SRC_ADDR_FROM_PACKET(p, &f->src);
         FLOW_SET_IPV6_DST_ADDR_FROM_PACKET(p, &f->dst);
+        FLOW_SET_IPV6_HLIM_FROM_PACKET(p, f);
         f->flags |= FLOW_IPV6;
     }
 #ifdef DEBUG

--- a/src/flow.c
+++ b/src/flow.c
@@ -344,6 +344,24 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p)
         SCLogDebug("setting FLOW_NOPAYLOAD_INSPECTION flag on flow %p", f);
         DecodeSetNoPayloadInspectionFlag(p);
     }
+
+
+    /* update flow's ttl fields if needed */
+    if (PKT_IS_IPV4(p)) {
+        uint8_t ttl = IPV4_GET_IPTTL(p);
+        if (ttl < f->min_ttl) {
+            f->min_ttl = ttl;
+        } else if (ttl > f->max_ttl) {
+            f->max_ttl = ttl;
+        }
+    } else if (PKT_IS_IPV6(p)) {
+        uint8_t ttl = IPV6_GET_HLIM(p);
+        if (ttl < f->min_ttl) {
+            f->min_ttl = ttl;
+        } else if (ttl > f->max_ttl) {
+            f->max_ttl = ttl;
+        }
+    }
 }
 
 /** \brief Entry point for packet flow handling

--- a/src/flow.c
+++ b/src/flow.c
@@ -266,6 +266,29 @@ static inline int FlowUpdateSeenFlag(const Packet *p)
     return 1;
 }
 
+static inline void FlowUpdateTTL(Flow *f, Packet *p, uint8_t ttl)
+{
+    if (FlowGetPacketDirection(f, p) == TOSERVER) {
+        if (ttl < f->min_ttl_toserver) {
+            f->min_ttl_toserver = ttl;
+        } else if (f->min_ttl_toserver == 0) {
+            f->min_ttl_toserver = ttl;
+        }
+        if (ttl > f->max_ttl_toserver) {
+            f->max_ttl_toserver = ttl;
+        }
+    } else {
+        if (ttl < f->min_ttl_toclient) {
+            f->min_ttl_toclient = ttl;
+        } else if (f->min_ttl_toclient == 0) {
+            f->min_ttl_toclient = ttl;
+        }
+        if (ttl > f->max_ttl_toclient) {
+            f->max_ttl_toclient = ttl;
+        }
+    }
+}
+
 /** \brief Update Packet and Flow
  *
  *  Updates packet and flow based on the new packet.
@@ -349,18 +372,10 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p)
     /* update flow's ttl fields if needed */
     if (PKT_IS_IPV4(p)) {
         uint8_t ttl = IPV4_GET_IPTTL(p);
-        if (ttl < f->min_ttl) {
-            f->min_ttl = ttl;
-        } else if (ttl > f->max_ttl) {
-            f->max_ttl = ttl;
-        }
+        FlowUpdateTTL(f, p, ttl);
     } else if (PKT_IS_IPV6(p)) {
         uint8_t ttl = IPV6_GET_HLIM(p);
-        if (ttl < f->min_ttl) {
-            f->min_ttl = ttl;
-        } else if (ttl > f->max_ttl) {
-            f->max_ttl = ttl;
-        }
+        FlowUpdateTTL(f, p, ttl);
     }
 }
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -184,13 +184,13 @@ typedef struct AppLayerParserState_ AppLayerParserState;
     } while (0)
 
 #define FLOW_SET_IPV4_TTL_FROM_PACKET(p, f) do {    \
-        (f)->min_ttl = IPV4_GET_IPTTL((p));         \
-        (f)->max_ttl = IPV4_GET_IPTTL((p));         \
+        (f)->min_ttl_toserver = IPV4_GET_IPTTL((p));         \
+        (f)->max_ttl_toserver = IPV4_GET_IPTTL((p));         \
     } while (0)
 
 #define FLOW_SET_IPV6_HLIM_FROM_PACKET(p, f) do {   \
-        (f)->min_ttl = IPV6_GET_HLIM((p));          \
-        (f)->max_ttl = IPV6_GET_HLIM((p));          \
+        (f)->min_ttl_toserver = IPV6_GET_HLIM((p));          \
+        (f)->max_ttl_toserver = IPV6_GET_HLIM((p));          \
     } while (0)
 
 /* pkt flow flags */
@@ -340,8 +340,10 @@ typedef struct Flow_
     };
     uint8_t proto;
     uint8_t recursion_level;
-    uint8_t min_ttl;
-    uint8_t max_ttl;
+    uint8_t min_ttl_toserver;
+    uint8_t max_ttl_toserver;
+    uint8_t min_ttl_toclient;
+    uint8_t max_ttl_toclient;
     uint16_t vlan_id[2];
 
     /** flow hash - the flow hash before hash table size mod. */

--- a/src/flow.h
+++ b/src/flow.h
@@ -183,6 +183,16 @@ typedef struct AppLayerParserState_ AppLayerParserState;
         (a)->addr_data32[3] = (p)->ip6h->s_ip6_dst[3];  \
     } while (0)
 
+#define FLOW_SET_IPV4_TTL_FROM_PACKET(p, f) do {    \
+        (f)->min_ttl = IPV4_GET_IPTTL((p));         \
+        (f)->max_ttl = IPV4_GET_IPTTL((p));         \
+    } while (0)
+
+#define FLOW_SET_IPV6_HLIM_FROM_PACKET(p, f) do {   \
+        (f)->min_ttl = IPV6_GET_HLIM((p));          \
+        (f)->max_ttl = IPV6_GET_HLIM((p));          \
+    } while (0)
+
 /* pkt flow flags */
 #define FLOW_PKT_TOSERVER               0x01
 #define FLOW_PKT_TOCLIENT               0x02
@@ -330,6 +340,8 @@ typedef struct Flow_
     };
     uint8_t proto;
     uint8_t recursion_level;
+    uint8_t min_ttl;
+    uint8_t max_ttl;
     uint16_t vlan_id[2];
 
     /** flow hash - the flow hash before hash table size mod. */

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -214,8 +214,8 @@ static void JsonNetFlowLogJSONToServer(JsonNetFlowLogThread *aft, json_t *js, Fl
     json_object_set_new(hjs, "age",
             json_integer(age));
 
-    json_object_set_new(hjs, "min_ttl", json_integer(f->min_ttl));
-    json_object_set_new(hjs, "max_ttl", json_integer(f->max_ttl));
+    json_object_set_new(hjs, "min_ttl", json_integer(f->min_ttl_toserver));
+    json_object_set_new(hjs, "max_ttl", json_integer(f->max_ttl_toserver));
 
     json_object_set_new(js, "netflow", hjs);
 
@@ -265,6 +265,12 @@ static void JsonNetFlowLogJSONToClient(JsonNetFlowLogThread *aft, json_t *js, Fl
     int32_t age = f->lastts.tv_sec - f->startts.tv_sec;
     json_object_set_new(hjs, "age",
             json_integer(age));
+
+    /* To client is zero if we did not see any packet */
+    if (f->max_ttl_toclient) {
+        json_object_set_new(hjs, "min_ttl", json_integer(f->min_ttl_toclient));
+        json_object_set_new(hjs, "max_ttl", json_integer(f->max_ttl_toclient));
+    }
 
     json_object_set_new(js, "netflow", hjs);
 

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -214,6 +214,9 @@ static void JsonNetFlowLogJSONToServer(JsonNetFlowLogThread *aft, json_t *js, Fl
     json_object_set_new(hjs, "age",
             json_integer(age));
 
+    json_object_set_new(hjs, "min_ttl", json_integer(f->min_ttl));
+    json_object_set_new(hjs, "max_ttl", json_integer(f->max_ttl));
+
     json_object_set_new(js, "netflow", hjs);
 
     /* TCP */


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x ] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-The goal is to add extra information for network security monitoring:
- in case of netflow logging, add TTL fields (min_ttl and  max_ttl).


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

