### PR TITLE
dns: log flags field

### DIFF
--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -194,6 +194,7 @@ typedef struct DNSAnswerEntry_ {
 typedef struct DNSTransaction_ {
     uint16_t tx_num;                                /**< internal: id */
     uint16_t tx_id;                                 /**< transaction id */
+    uint16_t flags;                                 /**< dns flags */
     uint32_t logged;                                /**< flags for loggers done logging */
     uint8_t replied;                                /**< bool indicating request is
                                                          replied to. */

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -316,6 +316,7 @@ static int DNSUDPResponseParse(Flow *f, void *dstate,
             tx->recursion_desired = 1;
         }
 
+        tx->flags = ntohs(dns_header->flags);
         tx->replied = 1;
     }
     if (f != NULL) {

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -465,6 +465,11 @@ static void OutputAnswer(LogDnsLogThread *aft, json_t *djs,
     /* id */
     json_object_set_new(js, "id", json_integer(tx->tx_id));
 
+    /* dns */
+    char flags[7] = "";
+    snprintf(flags, sizeof(flags), "0x%4x", tx->flags);
+    json_object_set_new(js, "flags", json_string(flags));
+
     /* rcode */
     char rcode[16] = "";
     DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));


### PR DESCRIPTION
This adds dns header's flags in eve
log.

Signed-off-by: Eric Leblond <eric@regit.org>

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-ADD DNS header's flags in eve log
-
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

