### PR TITLE
Json shortening fix v2

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -905,7 +905,7 @@ void StatsSpawnThreads(void)
 uint16_t StatsRegisterCounter(const char *name, struct ThreadVars_ *tv)
 {
     uint16_t id = StatsRegisterQualifiedCounter(name,
-                                                 (tv->thread_group_name != NULL) ? tv->thread_group_name : tv->name,
+                                                 (tv->thread_group_name != NULL) ? tv->thread_group_name : tv->printable_name,
                                                  &tv->perf_public_ctx,
                                                  STATS_TYPE_NORMAL, NULL);
 
@@ -926,7 +926,7 @@ uint16_t StatsRegisterCounter(const char *name, struct ThreadVars_ *tv)
 uint16_t StatsRegisterAvgCounter(const char *name, struct ThreadVars_ *tv)
 {
     uint16_t id = StatsRegisterQualifiedCounter(name,
-                                                 (tv->thread_group_name != NULL) ? tv->thread_group_name : tv->name,
+                                                 (tv->thread_group_name != NULL) ? tv->thread_group_name : tv->printable_name,
                                                  &tv->perf_public_ctx,
                                                  STATS_TYPE_AVERAGE, NULL);
 
@@ -947,7 +947,7 @@ uint16_t StatsRegisterAvgCounter(const char *name, struct ThreadVars_ *tv)
 uint16_t StatsRegisterMaxCounter(const char *name, struct ThreadVars_ *tv)
 {
     uint16_t id = StatsRegisterQualifiedCounter(name,
-                                                 (tv->thread_group_name != NULL) ? tv->thread_group_name : tv->name,
+                                                 (tv->thread_group_name != NULL) ? tv->thread_group_name : tv->printable_name,
                                                  &tv->perf_public_ctx,
                                                  STATS_TYPE_MAXIMUM, NULL);
 
@@ -1168,7 +1168,8 @@ int StatsSetupPrivate(ThreadVars *tv)
 {
     StatsGetAllCountersArray(&(tv)->perf_public_ctx, &(tv)->perf_private_ctx);
 
-    StatsThreadRegister(tv->name, &(tv)->perf_public_ctx);
+    StatsThreadRegister(tv->printable_name ? tv->printable_name : tv->name,
+        &(tv)->perf_public_ctx);
     return 0;
 }
 

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -68,6 +68,8 @@ static json_t *OutputStats2Json(json_t *js, const char *key)
     const char *dot = index(key, '.');
     if (dot == NULL)
         return NULL;
+    if (*(dot + 1) == '.' && *(dot + 2) != '\0')
+        dot = index(dot + 2, '.');
 
     size_t predot_len = (dot - key) + 1;
     char s[predot_len];

--- a/src/threadvars.h
+++ b/src/threadvars.h
@@ -57,6 +57,7 @@ struct TmSlot_;
 typedef struct ThreadVars_ {
     pthread_t t;
     char name[16];
+    char *printable_name;
     char *thread_group_name;
 
     SC_ATOMIC_DECLARE(unsigned int, flags);
@@ -117,4 +118,3 @@ typedef struct ThreadVars_ {
 #define THREAD_SET_AFFTYPE      0x04 /** Priority and affinity */
 
 #endif /* __THREADVARS_H__ */
-

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -1833,6 +1833,10 @@ static void TmThreadFree(ThreadVars *tv)
         SCFree(tv->thread_group_name);
     }
 
+    if (tv->printable_name) {
+        SCFree(tv->printable_name);
+    }
+
     s = (TmSlot *)tv->tm_slots;
     while (s) {
         ps = s;

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -192,8 +192,16 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
 
             threads_count = ModThreadsCount(aconf);
             for (thread = 0; thread < threads_count; thread++) {
+                char *printable_threadname = SCMalloc(sizeof(char) * (16+strlen(live_dev)));
+                if (unlikely(printable_threadname == NULL)) {
+                    SCLogError(SC_ERR_MEM_ALLOC, "failed to alloc printable thread name: %s", strerror(errno));
+                    exit(EXIT_FAILURE);
+                }
                 snprintf(tname, sizeof(tname), "%s#%02d-%s", thread_name,
                          thread+1, visual_devname);
+                snprintf(printable_threadname, 16+strlen(live_dev),
+                         "%s#%02d-%s", thread_name, thread+1,
+                         dev);
 
                 ThreadVars *tv_receive =
                     TmThreadCreatePacketHandler(tname,
@@ -203,6 +211,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
                     SCLogError(SC_ERR_RUNMODE, "TmThreadsCreate failed");
                     exit(EXIT_FAILURE);
                 }
+                tv_receive->printable_name = printable_threadname;
                 TmModule *tm_module = TmModuleGetByName(recv_mod_name);
                 if (tm_module == NULL) {
                     SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName failed for %s", recv_mod_name);
@@ -294,12 +303,22 @@ static int RunModeSetLiveCaptureWorkersForDevice(ConfigIfaceThreadsCountFunc Mod
         ThreadVars *tv = NULL;
         TmModule *tm_module = NULL;
         const char *visual_devname = LiveGetShortName(live_dev);
+        char *printable_threadname = SCMalloc(sizeof(char) * (16+strlen(live_dev)));
+        if (unlikely(printable_threadname == NULL)) {
+            SCLogError(SC_ERR_MEM_ALLOC, "failed to alloc printable thread name: %s", strerror(errno));
+            exit(EXIT_FAILURE);
+        }
 
         if (single_mode) {
-            snprintf(tname, sizeof(tname), "%s#01-%s", thread_name, visual_devname);
+            snprintf(tname, sizeof(tname), "%s#01-%s", thread_name,
+                     visual_devname);
+            snprintf(printable_threadname, 16+strlen(live_dev), "%s#01-%s",
+                     thread_name, live_dev);
         } else {
             snprintf(tname, sizeof(tname), "%s#%02d-%s", thread_name,
                      thread+1, visual_devname);
+            snprintf(printable_threadname, 16+strlen(live_dev), "%s#%02d-%s",
+                     thread_name, thread+1, live_dev);
         }
         tv = TmThreadCreatePacketHandler(tname,
                 "packetpool", "packetpool",
@@ -309,6 +328,7 @@ static int RunModeSetLiveCaptureWorkersForDevice(ConfigIfaceThreadsCountFunc Mod
             SCLogError(SC_ERR_THREAD_CREATE, "TmThreadsCreate failed");
             exit(EXIT_FAILURE);
         }
+        tv->printable_name = printable_threadname;
 
         tm_module = TmModuleGetByName(recv_mod_name);
         if (tm_module == NULL) {


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [#2208](https://redmine.openinfosecfoundation.org/issues/2208)

First version of this PR was https://github.com/OISF/suricata/pull/2886.

Describe changes:
- Interface name shortening introduces double periods (`..`) as spacers, which cause issues during JSON stats serialization as there `.` characters are also used as separators to define nesting of the JSON output. This commit makes sure that `..` are skipped during tokenizing.
- To approach this problem more generically, we also make sure that in addition to the internal thread names (which are restricted to a limited number of characters, which prompted the shortening in the first place) we also keep a 'printable' version of the thread names, to be used in stats output.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- http://dropbox.tetrinetsucht.de/wf/gcc/
- http://dropbox.tetrinetsucht.de/wf/pcaps/

(from local dockerized run)