### PR TITLE
Ruleset stats v23

### DIFF
--- a/doc/userguide/unix-socket.rst
+++ b/doc/userguide/unix-socket.rst
@@ -63,6 +63,11 @@ The set of existing commands is the following:
 * capture-mode: display capture system used
 * conf-get: get configuration item (see example below)
 * dump-counters: dump Suricata's performance counters
+* ruleset-reload-rules: reload ruleset and wait for completion
+* ruleset-reload-nonblocking: ask a ruleset reload and return
+* ruleset-last-reload: return time of last reload
+* ruleset-stats: display the number of rules loaded and failed
+* ruleset-failed-rules: display the list of failed rules
 
 You can access to these commands with the provided example script which
 is named ``suricatasc``. A typical session with ``suricatasc`` will looks like:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -387,6 +387,7 @@ util-decode-asn1.c util-decode-asn1.h \
 util-decode-der.c util-decode-der.h \
 util-decode-der-get.c util-decode-der-get.h \
 util-decode-mime.c util-decode-mime.h \
+util-detect.c util-detect.h \
 util-device.c util-device.h \
 util-enum.c util-enum.h \
 util-error.c util-error.h \

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -626,7 +626,6 @@ void DetectBufferTypeFinalizeRegistration(void)
 enum DetectEngineSyncState {
     IDLE,   /**< ready to start a reload */
     RELOAD, /**< command main thread to do the reload */
-    DONE,   /**< main thread telling us reload is done */
 };
 
 
@@ -664,21 +663,20 @@ int DetectEngineReloadIsStart(void)
 }
 
 /* main thread sets done when it's done */
-void DetectEngineReloadSetDone(void)
+void DetectEngineReloadSetIdle(void)
 {
     SCMutexLock(&detect_sync.m);
-    detect_sync.state = DONE;
+    detect_sync.state = IDLE;
     SCMutexUnlock(&detect_sync.m);
 }
 
 /* caller loops this until it returns 1 */
-int DetectEngineReloadIsDone(void)
+int DetectEngineReloadIsIdle(void)
 {
     int r = 0;
     SCMutexLock(&detect_sync.m);
-    if (detect_sync.state == DONE) {
+    if (detect_sync.state == IDLE) {
         r = 1;
-        detect_sync.state = IDLE;
     }
     SCMutexUnlock(&detect_sync.m);
     return r;

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1001,6 +1001,7 @@ static DetectEngineCtx *DetectEngineCtxInitReal(int minimal, const char *prefix)
         goto error;
 
     memset(de_ctx,0,sizeof(DetectEngineCtx));
+    memset(&de_ctx->sig_stat, 0, sizeof(SigFileLoaderStat));
 
     if (minimal) {
         de_ctx->minimal = 1;

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -83,8 +83,8 @@ int DetectEngineMultiTenantSetup(void);
 
 int DetectEngineReloadStart(void);
 int DetectEngineReloadIsStart(void);
-void DetectEngineReloadSetDone(void);
-int DetectEngineReloadIsDone(void);
+void DetectEngineReloadSetIdle(void);
+int DetectEngineReloadIsIdle(void);
 
 int DetectEngineLoadTenantBlocking(uint32_t tenant_id, const char *yaml);
 int DetectEngineReloadTenantBlocking(uint32_t tenant_id, const char *yaml, int reload_cnt);

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -44,8 +44,8 @@ void DetectBufferTypeRegisterSetupCallback(const char *name,
         void (*Callback)(Signature *));
 void DetectBufferRunSetupCallback(const int id, Signature *s);
 void DetectBufferTypeRegisterValidateCallback(const char *name,
-        _Bool (*ValidateCallback)(const Signature *));
-_Bool DetectBufferRunValidateCallback(const int id, const Signature *s);
+        _Bool (*ValidateCallback)(const Signature *, const char **sigerror));
+_Bool DetectBufferRunValidateCallback(const int id, const Signature *s, const char **sigerror);
 
 /* prototypes */
 DetectEngineCtx *DetectEngineCtxInitWithPrefix(const char *prefix);

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -65,7 +65,7 @@ static int DetectHttpMethodSetup(DetectEngineCtx *, Signature *, const char *);
 void DetectHttpMethodRegisterTests(void);
 void DetectHttpMethodFree(void *);
 static void DetectHttpMethodSetupCallback(Signature *s);
-static _Bool DetectHttpMethodValidateCallback(const Signature *s);
+static _Bool DetectHttpMethodValidateCallback(const Signature *s, const char **sigerror);
 
 /**
  * \brief Registration function for keyword: http_method
@@ -144,7 +144,7 @@ static void DetectHttpMethodSetupCallback(Signature *s)
  *  \retval 1 valid
  *  \retval 0 invalid
  */
-static _Bool DetectHttpMethodValidateCallback(const Signature *s)
+static _Bool DetectHttpMethodValidateCallback(const Signature *s, const char **sigerror)
 {
     const SigMatch *sm = s->init_data->smlists[g_http_method_buffer_id];
     for ( ; sm != NULL; sm = sm->next) {
@@ -153,16 +153,32 @@ static _Bool DetectHttpMethodValidateCallback(const Signature *s)
         const DetectContentData *cd = (const DetectContentData *)sm->ctx;
         if (cd->content && cd->content_len) {
             if (cd->content[cd->content_len-1] == 0x20) {
-                SCLogError(SC_ERR_INVALID_SIGNATURE, "http_method pattern with trailing space");
+                *sigerror = "http_method pattern with trailing space";
+                SCLogError(SC_ERR_INVALID_SIGNATURE, "%s", *sigerror);
                 return FALSE;
             } else if (cd->content[0] == 0x20) {
-                SCLogError(SC_ERR_INVALID_SIGNATURE, "http_method pattern with leading space");
+                *sigerror = SCStrdup("http_method pattern with leading space");
+                if (*sigerror == NULL) {
+                    SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+                    return FALSE;
+                }
+                SCLogError(SC_ERR_INVALID_SIGNATURE, "%s", *sigerror);
                 return FALSE;
             } else if (cd->content[cd->content_len-1] == 0x09) {
-                SCLogError(SC_ERR_INVALID_SIGNATURE, "http_method pattern with trailing tab");
+                *sigerror = SCStrdup("http_method pattern with trailing tab");
+                if (*sigerror == NULL) {
+                    SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+                    return FALSE;
+                }
+                SCLogError(SC_ERR_INVALID_SIGNATURE, "%s", *sigerror);
                 return FALSE;
             } else if (cd->content[0] == 0x09) {
-                SCLogError(SC_ERR_INVALID_SIGNATURE, "http_method pattern with leading tab");
+                *sigerror = SCStrdup("http_method pattern with leading tab");
+                if (*sigerror == NULL) {
+                    SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+                    return FALSE;
+                }
+                SCLogError(SC_ERR_INVALID_SIGNATURE, "%s", *sigerror);
                 return FALSE;
             }
         }

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -63,7 +63,7 @@
 static int DetectHttpRawHeaderSetup(DetectEngineCtx *, Signature *, const char *);
 static void DetectHttpRawHeaderRegisterTests(void);
 static void DetectHttpRawHeaderFree(void *);
-static _Bool DetectHttpRawHeaderValidateCallback(const Signature *s);
+static _Bool DetectHttpRawHeaderValidateCallback(const Signature *s, const char **sigerror);
 static void DetectHttpRawHeaderSetupCallback(Signature *s);
 static int g_http_raw_header_buffer_id = 0;
 
@@ -143,13 +143,15 @@ int DetectHttpRawHeaderSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
                                                   ALPROTO_HTTP);
 }
 
-static _Bool DetectHttpRawHeaderValidateCallback(const Signature *s)
+static _Bool DetectHttpRawHeaderValidateCallback(const Signature *s, const char **sigerror)
 {
     if ((s->flags & (SIG_FLAG_TOCLIENT|SIG_FLAG_TOSERVER)) == (SIG_FLAG_TOCLIENT|SIG_FLAG_TOSERVER)) {
-        SCLogError(SC_ERR_INVALID_SIGNATURE,"http_raw_header signature "
+        *sigerror = "http_raw_header signature "
                 "without a flow direction. Use flow:to_server for "
                 "inspecting request headers or flow:to_client for "
-                "inspecting response headers.");
+                "inspecting response headers.";
+
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "%s", *sigerror);
         SCReturnInt(FALSE);
     }
     return TRUE;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1448,7 +1448,7 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
     int x;
     for (x = 0; x < nlists; x++) {
         if (s->init_data->smlists[x]) {
-            if (DetectBufferRunValidateCallback(x, s) == FALSE) {
+            if (DetectBufferRunValidateCallback(x, s, &de_ctx->sigerror) == FALSE) {
                 SCReturnInt(0);
             }
         }

--- a/src/detect.c
+++ b/src/detect.c
@@ -446,14 +446,12 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
 
     ConfNode *rule_files;
     ConfNode *file = NULL;
-    SigFileLoaderStat sig_stat;
+    SigFileLoaderStat *sig_stat = &de_ctx->sig_stat;
     int ret = 0;
     char *sfile = NULL;
     char varname[128] = "rule-files";
     int good_sigs = 0;
     int bad_sigs = 0;
-
-    memset(&sig_stat, 0, sizeof(SigFileLoaderStat));
 
     if (strlen(de_ctx->config_prefix) > 0) {
         snprintf(varname, sizeof(varname), "%s.rule-files",
@@ -478,7 +476,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
                 TAILQ_FOREACH(file, &rule_files->head, next) {
                     sfile = DetectLoadCompleteSigPath(de_ctx, file->val);
                     good_sigs = bad_sigs = 0;
-                    ret = ProcessSigFiles(de_ctx, sfile, &sig_stat, &good_sigs, &bad_sigs);
+                    ret = ProcessSigFiles(de_ctx, sfile, sig_stat, &good_sigs, &bad_sigs);
                     SCFree(sfile);
 
                     if (de_ctx->failure_fatal && ret != 0) {
@@ -497,7 +495,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
 
     /* If a Signature file is specified from commandline, parse it too */
     if (sig_file != NULL) {
-        ret = ProcessSigFiles(de_ctx, sig_file, &sig_stat, &good_sigs, &bad_sigs);
+        ret = ProcessSigFiles(de_ctx, sig_file, sig_stat, &good_sigs, &bad_sigs);
 
         if (ret != 0) {
             if (de_ctx->failure_fatal == 1) {
@@ -511,9 +509,9 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     }
 
     /* now we should have signatures to work with */
-    if (sig_stat.good_sigs_total <= 0) {
-        if (sig_stat.total_files > 0) {
-           SCLogWarning(SC_ERR_NO_RULES_LOADED, "%d rule files specified, but no rule was loaded at all!", sig_stat.total_files);
+    if (sig_stat->good_sigs_total <= 0) {
+        if (sig_stat->total_files > 0) {
+           SCLogWarning(SC_ERR_NO_RULES_LOADED, "%d rule files specified, but no rule was loaded at all!", sig_stat->total_files);
         } else {
             SCLogInfo("No signatures supplied.");
             goto end;
@@ -521,10 +519,10 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     } else {
         /* we report the total of files and rules successfully loaded and failed */
         SCLogInfo("%" PRId32 " rule files processed. %" PRId32 " rules successfully loaded, %" PRId32 " rules failed",
-            sig_stat.total_files, sig_stat.good_sigs_total, sig_stat.bad_sigs_total);
+            sig_stat->total_files, sig_stat->good_sigs_total, sig_stat->bad_sigs_total);
     }
 
-    if ((sig_stat.bad_sigs_total || sig_stat.bad_files) && de_ctx->failure_fatal) {
+    if ((sig_stat->bad_sigs_total || sig_stat->bad_files) && de_ctx->failure_fatal) {
         ret = -1;
         goto end;
     }
@@ -542,6 +540,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     ret = 0;
 
  end:
+    gettimeofday(&de_ctx->last_reload, NULL);
     if (RunmodeGetCurrent() == RUNMODE_ENGINE_ANALYSIS) {
         if (rule_engine_analysis_set) {
             CleanupRuleAnalyzer();

--- a/src/detect.c
+++ b/src/detect.c
@@ -227,6 +227,7 @@
 #include "util-optimize.h"
 #include "util-path.h"
 #include "util-mpm-ac.h"
+#include "util-detect.h"
 #include "runmodes.h"
 
 #include <glob.h>
@@ -374,6 +375,13 @@ static int DetectLoadSigFile(DetectEngineCtx *de_ctx, char *sig_file,
                 EngineAnalysisRulesFailure(line, sig_file, lineno - multiline);
             }
             bad++;
+            if (!SigStringAppend(&de_ctx->sig_stat, sig_file, line, de_ctx->sigerror, (lineno - multiline))) {
+                SCLogError(SC_ERR_MEM_ALLOC, "Error adding sig \"%s\" from "
+                     "file %s at line %"PRId32"", line, sig_file, lineno - multiline);
+            }
+            if (de_ctx->sigerror) {
+                de_ctx->sigerror = NULL;
+            }
         }
         multiline = 0;
     }

--- a/src/detect.h
+++ b/src/detect.h
@@ -574,6 +574,14 @@ typedef struct ThresholdCtx_    {
     uint32_t th_size;
 } ThresholdCtx;
 
+/** \brief Signature loader statistics */
+typedef struct SigFileLoaderStat_ {
+    int bad_files;
+    int total_files;
+    int good_sigs_total;
+    int bad_sigs_total;
+} SigFileLoaderStat;
+
 typedef struct DetectEngineThreadKeywordCtxItem_ {
     void *(*InitFunc)(void *);
     void (*FreeFunc)(void *);
@@ -735,6 +743,13 @@ typedef struct DetectEngineCtx_ {
      *  \todo we only need this at init, so perhaps this
      *        can move to a DetectEngineCtx 'init' struct */
     DetectMpmAppLayerKeyword *app_mpms;
+
+    /** time of last ruleset reload */
+    struct timeval last_reload;
+
+    /** signatures stats */
+    SigFileLoaderStat sig_stat;
+
 } DetectEngineCtx;
 
 /* Engine groups profiles (low, medium, high, custom) */
@@ -1176,14 +1191,6 @@ typedef struct DetectEngineMasterCtx_ {
     DetectEngineThreadKeywordCtxItem *keyword_list;
     int keyword_id;
 } DetectEngineMasterCtx;
-
-/** \brief Signature loader statistics */
-typedef struct SigFileLoaderStat_ {
-    int bad_files;
-    int total_files;
-    int good_sigs_total;
-    int bad_sigs_total;
-} SigFileLoaderStat;
 
 /** Remember to add the options in SignatureIsIPOnly() at detect.c otherwise it wont be part of a signature group */
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -574,8 +574,17 @@ typedef struct ThresholdCtx_    {
     uint32_t th_size;
 } ThresholdCtx;
 
+typedef struct SigString_ {
+    char *filename;
+    char *sig_str;
+    char *sig_error;
+    int line;
+    TAILQ_ENTRY(SigString_) next;
+} SigString;
+
 /** \brief Signature loader statistics */
 typedef struct SigFileLoaderStat_ {
+    TAILQ_HEAD(, SigString_) failed_sigs;
     int bad_files;
     int total_files;
     int good_sigs_total;
@@ -701,6 +710,7 @@ typedef struct DetectEngineCtx_ {
     /** Store rule file and line so that parsers can use them in errors. */
     char *rule_file;
     int rule_line;
+    const char *sigerror;
 
     /** list of keywords that need thread local ctxs */
     DetectEngineThreadKeywordCtxItem *keyword_list;

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -28,6 +28,7 @@
 #include "detect.h"
 #include "pkt-var.h"
 #include "conf.h"
+#include "detect-engine.h"
 
 #include "threads.h"
 #include "threadvars.h"
@@ -51,6 +52,16 @@
 
 #ifdef HAVE_LIBJANSSON
 
+/**
+ * specify which engine info will be printed in stats log.
+ * ALL means both last reload and ruleset stats.
+ */
+typedef enum OutputEngineInfo_ {
+    OUTPUT_ENGINE_LAST_RELOAD = 0,
+    OUTPUT_ENGINE_RULESET,
+    OUTPUT_ENGINE_ALL,
+} OutputEngineInfo;
+
 typedef struct OutputStatsCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags; /** Store mode */
@@ -60,6 +71,101 @@ typedef struct JsonStatsLogThread_ {
     OutputStatsCtx *statslog_ctx;
     MemBuffer *buffer;
 } JsonStatsLogThread;
+
+static json_t *OutputDetectEngineStats2Json(const DetectEngineCtx *de_ctx,
+                                            const OutputEngineInfo output)
+{
+    struct timeval last_reload;
+    char timebuf[64];
+    const SigFileLoaderStat *sig_stat = NULL;
+
+    json_t *jdata = json_object();
+    if (jdata == NULL) {
+        return NULL;
+    }
+
+    if (output == OUTPUT_ENGINE_LAST_RELOAD || output == OUTPUT_ENGINE_ALL) {
+        last_reload = de_ctx->last_reload;
+        CreateIsoTimeString(&last_reload, timebuf, sizeof(timebuf));
+        json_object_set_new(jdata, "last_reload", json_string(timebuf));
+    }
+
+    sig_stat = &de_ctx->sig_stat;
+    if ((output == OUTPUT_ENGINE_RULESET || output == OUTPUT_ENGINE_ALL) &&
+        sig_stat != NULL)
+    {
+        json_object_set_new(jdata, "rules_loaded",
+                            json_integer(sig_stat->good_sigs_total));
+        json_object_set_new(jdata, "rules_failed",
+                            json_integer(sig_stat->bad_sigs_total));
+    }
+
+    return jdata;
+}
+
+static TmEcode OutputTenancyStats2Json(json_t **jdata, const OutputEngineInfo output)
+{
+    DetectEngineCtx *de_ctx = DetectEngineGetCurrent();
+    if (de_ctx == NULL) {
+        goto err1;
+    }
+    /* Since we need to deference de_ctx pointer, we don't want to lost it. */
+    DetectEngineCtx *list = de_ctx;
+
+    if (list->minimal) {
+        json_object_set_new(*jdata, "message", json_string("Detect engine is not yet ready"));
+        DetectEngineDeReference(&de_ctx);
+        return TM_ECODE_FAILED;
+    }
+
+    json_t *js_tenant_list = json_array();
+    json_t *js_tenant = NULL;
+
+    if (js_tenant_list == NULL) {
+        goto err1;
+    }
+
+    while(list) {
+        js_tenant = json_object();
+        if (js_tenant == NULL) {
+            goto err2;
+        }
+        json_object_set_new(js_tenant, "id", json_integer(list->tenant_id));
+
+        json_t *js_stats = OutputDetectEngineStats2Json(list, output);
+        if (js_stats == NULL) {
+            goto err3;
+        }
+        json_object_update(js_tenant, js_stats);
+        json_array_append_new(js_tenant_list, js_tenant);
+        list = list->next;
+    }
+
+    DetectEngineDeReference(&de_ctx);
+    *jdata = js_tenant_list;
+    return TM_ECODE_OK;
+
+err3:
+    json_object_clear(js_tenant);
+    json_decref(js_tenant);
+
+err2:
+    json_object_clear(js_tenant_list);
+    json_decref(js_tenant_list);
+
+err1:
+    json_object_set_new(*jdata, "message", json_string("Unable to get info"));
+    DetectEngineDeReference(&de_ctx);
+    return TM_ECODE_FAILED;
+}
+
+TmEcode OutputTenancyStatsLastReload(json_t **jdata) {
+    return OutputTenancyStats2Json(jdata, OUTPUT_ENGINE_LAST_RELOAD);
+}
+
+TmEcode OutputTenancyStatsRuleset(json_t **jdata) {
+    return OutputTenancyStats2Json(jdata, OUTPUT_ENGINE_RULESET);
+}
 
 static json_t *OutputStats2Json(json_t *js, const char *key)
 {
@@ -79,6 +185,20 @@ static json_t *OutputStats2Json(json_t *js, const char *key)
     json_t *value = json_object_iter_value(iter);
     if (value == NULL) {
         value = json_object();
+        /* If multi-tenancy is disabled, it means we have only one engine.
+           In this case, we add engine stats in detect obj.
+           The output will be:
+           "detect":{"engine":{"last_reload":"...","rules_loaded":...,"rules_failed":...}, ...}
+        */
+        if (!DetectEngineMultiTenantEnabled() && !strncmp(s, "detect", 6)) {
+            DetectEngineCtx *de_ctx = DetectEngineGetCurrent();
+            json_t *js_engine =
+                OutputDetectEngineStats2Json(de_ctx, OUTPUT_ENGINE_ALL);
+            if (js_engine != NULL) {
+                json_object_set_new(value, "engine", js_engine);
+            }
+            DetectEngineDeReference(&de_ctx);
+        }
         json_object_set_new(js, s, value);
     }
     if (s2 != NULL) {
@@ -105,6 +225,24 @@ json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
     double up_time_d = difftime(tval.tv_sec, st->start_time);
     json_object_set_new(js_stats, "uptime",
         json_integer((int)up_time_d));
+
+    /* tenancy stats */
+    if (DetectEngineMultiTenantEnabled()) {
+        /* In this case, we add a new "tenancy" object,
+           which contains stats for each tenant.
+           The output will be:
+           "tenancy":[{"id":1,"last_reload":"...","rules_loaded":...,"rules_failed":...},
+                      {"id":2,"last_reload":"...","rules_loaded":...,"rules_failed":...}]
+        */
+        json_t *js_tenancy = json_object();
+        if (unlikely(js_tenancy == NULL)) {
+            json_decref(js_stats);
+            return 0;
+        }
+        TmEcode ret = OutputTenancyStats2Json(&js_tenancy, OUTPUT_ENGINE_ALL);
+        if (ret == TM_ECODE_OK)
+            json_object_set_new(js_stats, "tenants", js_tenancy);
+    }
 
     uint32_t u = 0;
     if (flags & JSON_STATS_TOTALS) {

--- a/src/output-json-stats.h
+++ b/src/output-json-stats.h
@@ -32,6 +32,8 @@
 
 #ifdef HAVE_LIBJANSSON
 json_t *StatsToJSON(const StatsTable *st, uint8_t flags);
+TmEcode OutputTenancyStatsLastReload(json_t **jdata);
+TmEcode OutputTenancyStatsRuleset(json_t **jdata);
 #endif
 void JsonStatsLogRegister(void);
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2786,7 +2786,7 @@ static void SuricataMainLoop(SCInstance *suri)
                 if (!(DetectEngineReloadIsStart())) {
                     DetectEngineReloadStart();
                     DetectEngineReload(suri);
-                    DetectEngineReloadSetDone();
+                    DetectEngineReloadSetIdle();
                     sigusr2_count--;
                 }
             }
@@ -2795,10 +2795,10 @@ static void SuricataMainLoop(SCInstance *suri)
             if (suri->sig_file != NULL) {
                 SCLogWarning(SC_ERR_LIVE_RULE_SWAP, "Live rule reload not "
                         "possible if -s or -S option used at runtime.");
-                DetectEngineReloadSetDone();
+                DetectEngineReloadSetIdle();
             } else {
                 DetectEngineReload(suri);
-                DetectEngineReloadSetDone();
+                DetectEngineReloadSetIdle();
             }
         }
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -233,6 +233,14 @@ int g_disable_randomness = 0;
 int g_disable_randomness = 1;
 #endif
 
+/** Suricata instance */
+SCInstance suri;
+
+int SuriHasSigFile(void)
+{
+    return (suri.sig_file != NULL);
+}
+
 int EngineModeIsIPS(void)
 {
     return (g_engine_mode == ENGINE_MODE_IPS);
@@ -2808,7 +2816,6 @@ static void SuricataMainLoop(SCInstance *suri)
 
 int main(int argc, char **argv)
 {
-    SCInstance suri;
     SCInstanceInit(&suri, argv[0]);
 
 #ifdef HAVE_RUST

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -193,6 +193,8 @@ int RunmodeIsUnittests(void);
 int RunmodeGetCurrent(void);
 int IsRuleReloadSet(int quiet);
 
+int SuriHasSigFile(void);
+
 extern int run_mode;
 extern int run_mode_offline;
 

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -659,6 +659,14 @@ static TmEcode UnixManagerCaptureModeCommand(json_t *cmd,
 static TmEcode UnixManagerReloadRulesWrapper(json_t *cmd, json_t *server_msg, void *data, int do_wait)
 {
     SCEnter();
+
+    if (SuriHasSigFile()) {
+        json_object_set_new(server_msg, "message",
+                            json_string("Live rule reload not possible if -s "
+                                        "or -S option used at runtime."));
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+
     int r = DetectEngineReloadStart();
 
     if (r == 0 && do_wait) {

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -654,16 +654,33 @@ static TmEcode UnixManagerCaptureModeCommand(json_t *cmd,
     SCReturnInt(TM_ECODE_OK);
 }
 
-static TmEcode UnixManagerReloadRules(json_t *cmd, json_t *server_msg, void *data)
+static TmEcode UnixManagerReloadRulesWrapper(json_t *cmd, json_t *server_msg, void *data, int do_wait)
 {
     SCEnter();
-    DetectEngineReloadStart();
+    int r = DetectEngineReloadStart();
 
-    while (DetectEngineReloadIsDone() == 0)
-        usleep(100);
+    if (r == 0 && do_wait) {
+        while (DetectEngineReloadIsIdle() == 0)
+            usleep(100);
+    } else {
+        if (r == -1) {
+            json_object_set_new(server_msg, "message", json_string("Reload already in progress"));
+            SCReturnInt(TM_ECODE_FAILED);
+        }
+    }
 
     json_object_set_new(server_msg, "message", json_string("done"));
     SCReturnInt(TM_ECODE_OK);
+}
+
+static TmEcode UnixManagerReloadRules(json_t *cmd, json_t *server_msg, void *data)
+{
+    return UnixManagerReloadRulesWrapper(cmd, server_msg, data, 1);
+}
+
+static TmEcode UnixManagerNonBlockingReloadRules(json_t *cmd, json_t *server_msg, void *data)
+{
+    return UnixManagerReloadRulesWrapper(cmd, server_msg, data, 0);
 }
 
 static TmEcode UnixManagerLastReloadCommand(json_t *cmd,
@@ -909,6 +926,7 @@ int UnixManagerInit(void)
     UnixManagerRegisterCommand("conf-get", UnixManagerConfGetCommand, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("dump-counters", StatsOutputCounterSocket, NULL, 0);
     UnixManagerRegisterCommand("reload-rules", UnixManagerReloadRules, NULL, 0);
+    UnixManagerRegisterCommand("ruleset-reload-nonblocking", UnixManagerNonBlockingReloadRules, NULL, 0);
     UnixManagerRegisterCommand("ruleset-last-reload", UnixManagerLastReloadCommand, NULL, 0);
     UnixManagerRegisterCommand("ruleset-stats", UnixManagerRulesetStatsCommand, NULL, 0);
     UnixManagerRegisterCommand("register-tenant-handler", UnixSocketRegisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -981,6 +981,7 @@ int UnixManagerInit(void)
     UnixManagerRegisterCommand("conf-get", UnixManagerConfGetCommand, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("dump-counters", StatsOutputCounterSocket, NULL, 0);
     UnixManagerRegisterCommand("reload-rules", UnixManagerReloadRules, NULL, 0);
+    UnixManagerRegisterCommand("ruleset-reload-rules", UnixManagerReloadRules, NULL, 0);
     UnixManagerRegisterCommand("ruleset-reload-nonblocking", UnixManagerNonBlockingReloadRules, NULL, 0);
     UnixManagerRegisterCommand("ruleset-last-reload", UnixManagerLastReloadCommand, NULL, 0);
     UnixManagerRegisterCommand("ruleset-stats", UnixManagerRulesetStatsCommand, NULL, 0);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -57,6 +57,8 @@
 #define SOCKET_FILENAME "suricata-command.socket"
 #define SOCKET_TARGET SOCKET_PATH SOCKET_FILENAME
 
+#define MAX_FAILED_RULES   20
+
 typedef struct Command_ {
     char *name;
     TmEcode (*Func)(json_t *, json_t *, void *);
@@ -715,6 +717,59 @@ static TmEcode UnixManagerRulesetStatsCommand(json_t *cmd,
     SCReturnInt(retval);
 }
 
+static TmEcode UnixManagerShowFailedRules(json_t *cmd,
+                                          json_t *server_msg, void *data)
+{
+    SCEnter();
+    int rules_cnt = 0;
+    DetectEngineCtx *de_ctx = DetectEngineGetCurrent();
+    /* Since we need to deference de_ctx, we don't want to lost it. */
+    DetectEngineCtx *list = de_ctx;
+    json_t *js_sigs_array = json_array();
+
+    if (js_sigs_array == NULL) {
+        json_object_set_new(server_msg, "message", json_string("Unable to get info"));
+        goto error;
+    }
+    while (list) {
+        SigString *sigs_str = NULL;
+        TAILQ_FOREACH(sigs_str, &list->sig_stat.failed_sigs, next) {
+            json_t *jdata = json_object();
+            if (jdata == NULL) {
+                json_object_set_new(server_msg, "message", json_string("Unable to get the sig"));
+                json_object_clear(js_sigs_array);
+                goto error;
+            }
+
+            json_object_set_new(jdata, "tenant_id", json_integer(list->tenant_id));
+            json_object_set_new(jdata, "rule", json_string(sigs_str->sig_str));
+            json_object_set_new(jdata, "filename", json_string(sigs_str->filename));
+            json_object_set_new(jdata, "line", json_integer(sigs_str->line));
+            if (sigs_str->sig_error) {
+                json_object_set_new(jdata, "error", json_string(sigs_str->sig_error));
+            }
+            json_array_append_new(js_sigs_array, jdata);
+            if (++rules_cnt > MAX_FAILED_RULES) {
+                break;
+            }
+        }
+        if (rules_cnt > MAX_FAILED_RULES) {
+            break;
+        }
+        list = list->next;
+    }
+
+    json_object_set_new(server_msg, "message", js_sigs_array);
+    DetectEngineDeReference(&de_ctx);
+    SCReturnInt(TM_ECODE_OK);
+
+error:
+    DetectEngineDeReference(&de_ctx);
+    json_object_clear(js_sigs_array);
+    json_decref(js_sigs_array);
+    SCReturnInt(TM_ECODE_FAILED);
+}
+
 static TmEcode UnixManagerConfGetCommand(json_t *cmd,
                                          json_t *server_msg, void *data)
 {
@@ -929,6 +984,7 @@ int UnixManagerInit(void)
     UnixManagerRegisterCommand("ruleset-reload-nonblocking", UnixManagerNonBlockingReloadRules, NULL, 0);
     UnixManagerRegisterCommand("ruleset-last-reload", UnixManagerLastReloadCommand, NULL, 0);
     UnixManagerRegisterCommand("ruleset-stats", UnixManagerRulesetStatsCommand, NULL, 0);
+    UnixManagerRegisterCommand("ruleset-failed-rules", UnixManagerShowFailedRules, NULL, 0);
     UnixManagerRegisterCommand("register-tenant-handler", UnixSocketRegisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("unregister-tenant-handler", UnixSocketUnregisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("register-tenant", UnixSocketRegisterTenant, &command, UNIX_CMD_TAKE_ARGS);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -29,6 +29,8 @@
 #include "runmodes.h"
 #include "conf.h"
 
+#include "output-json-stats.h"
+
 #include "util-privs.h"
 #include "util-debug.h"
 #include "util-device.h"
@@ -664,8 +666,40 @@ static TmEcode UnixManagerReloadRules(json_t *cmd, json_t *server_msg, void *dat
     SCReturnInt(TM_ECODE_OK);
 }
 
+static TmEcode UnixManagerLastReloadCommand(json_t *cmd,
+                                            json_t *server_msg, void *data)
+{
+    SCEnter();
+    TmEcode retval;
+    json_t *jdata = json_object();
+    if (jdata == NULL) {
+        json_object_set_new(server_msg, "message", json_string("Unable to get info"));
+        return TM_ECODE_FAILED;
+    }
+
+    retval = OutputTenancyStatsLastReload(&jdata);
+    json_object_set_new(server_msg, "message", jdata);
+    SCReturnInt(retval);
+}
+
+static TmEcode UnixManagerRulesetStatsCommand(json_t *cmd,
+                                              json_t *server_msg, void *data)
+{
+    SCEnter();
+    TmEcode retval;
+    json_t *jdata = json_object();
+    if (jdata == NULL) {
+        json_object_set_new(server_msg, "message", json_string("Unable to get info"));
+        return TM_ECODE_FAILED;
+    }
+
+    retval = OutputTenancyStatsRuleset(&jdata);
+    json_object_set_new(server_msg, "message", jdata);
+    SCReturnInt(retval);
+}
+
 static TmEcode UnixManagerConfGetCommand(json_t *cmd,
-                                  json_t *server_msg, void *data)
+                                         json_t *server_msg, void *data)
 {
     SCEnter();
 
@@ -875,6 +909,8 @@ int UnixManagerInit(void)
     UnixManagerRegisterCommand("conf-get", UnixManagerConfGetCommand, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("dump-counters", StatsOutputCounterSocket, NULL, 0);
     UnixManagerRegisterCommand("reload-rules", UnixManagerReloadRules, NULL, 0);
+    UnixManagerRegisterCommand("ruleset-last-reload", UnixManagerLastReloadCommand, NULL, 0);
+    UnixManagerRegisterCommand("ruleset-stats", UnixManagerRulesetStatsCommand, NULL, 0);
     UnixManagerRegisterCommand("register-tenant-handler", UnixSocketRegisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("unregister-tenant-handler", UnixSocketUnregisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("register-tenant", UnixSocketRegisterTenant, &command, UNIX_CMD_TAKE_ARGS);

--- a/src/util-detect.c
+++ b/src/util-detect.c
@@ -1,0 +1,120 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Giuseppe Longo <glongo@stamus-networks.com>
+ *
+ * Detection engine helper functions
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+#include "detect.h"
+#include "util-detect.h"
+
+/**
+ * \brief Allocate SigString list member
+ *
+ * \retval Pointer to SigString
+ */
+SigString *SigStringAlloc(void)
+{
+    SigString *sigstr = SCCalloc(1, sizeof(SigString));
+    if (unlikely(sigstr == NULL))
+        return NULL;
+
+    sigstr->line = 0;
+
+    return sigstr;
+}
+
+/**
+ * \brief Assigns the filename, signature, lineno to SigString list member
+ *
+ * \param sig pointer to SigString
+ * \param sig_file filename that contains the signature
+ * \param sig_str signature in string format
+ * \param sig_error signature parsing error
+ * \param line line line number
+ *
+ * \retval 1 on success 0 on failure
+ */
+static int SigStringAddSig(SigString *sig, const char *sig_file,
+                           const char *sig_str, const char *sig_error,
+                           int line)
+{
+    if (sig_file == NULL || sig_str == NULL) {
+        return 0;
+    }
+
+    sig->filename = SCStrdup(sig_file);
+    if (sig->filename == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+        return 0;
+    }
+
+    sig->sig_str = SCStrdup(sig_str);
+    if (sig->sig_str == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+        SCFree(sig->filename);
+        return 0;
+    }
+
+    if (sig_error) {
+        sig->sig_error = SCStrdup(sig_error);
+        if (sig->sig_error == NULL) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+            SCFree(sig->filename);
+            SCFree(sig->sig_str);
+            return 0;
+        }
+    }
+
+    sig->line = line;
+
+    return 1;
+}
+
+/**
+ * \brief Append a new list member to SigString list
+ *
+ * \param list pointer to the start of the SigString list
+ * \param sig_file filename that contains the signature
+ * \param sig_str signature in string format
+ * \param line line line number
+ *
+ * \retval 1 on success 0 on failure
+ */
+int SigStringAppend(SigFileLoaderStat *sig_stats, const char *sig_file,
+                    const char *sig_str, const char *sig_error, int line)
+{
+    SigString *item = SigStringAlloc();
+    if (item == NULL) {
+        return 0;
+    }
+
+    if (!SigStringAddSig(item, sig_file, sig_str, sig_error, line)) {
+        SCFree(item);
+        return 0;
+    }
+
+    TAILQ_INSERT_TAIL(&sig_stats->failed_sigs, item, next);
+
+    return 1;
+}

--- a/src/util-detect.h
+++ b/src/util-detect.h
@@ -1,0 +1,28 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Giuseppe Longo <glongo@stamus-networks.com>
+ *
+ * Detection engine helper functions
+ */
+
+SigString *SigStringAlloc(void);
+int SigStringAppend(SigFileLoaderStat *sigs_stats, const char *sig_file, const char *sig_str,
+                    const char *sig_error, int line);


### PR DESCRIPTION
A patchset updated that aims at improving information regarding ruleset returned to the user by suricata.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/1585

Previous PR: https://github.com/OISF/suricata/pull/2847

Describe changes:
- Remove SCStrdup for static strings 
- Rename "tenancy" with "tenants" 
- Don't remove `reload-rules` command for backward compatibility

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/146
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/10
