### PR TITLE
runmodes: allow more than 256 threads

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -188,7 +188,7 @@ static void *ParseAFPConfig(const char *iface)
             if (strcmp(threadsstr, "auto") == 0) {
                 aconf->threads = 0;
             } else {
-                aconf->threads = (uint8_t)atoi(threadsstr);
+                aconf->threads = atoi(threadsstr);
             }
         }
     }

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -138,7 +138,7 @@ static int ParseNetmapSettings(NetmapIfaceSettings *ns, const char *iface,
         if (strcmp(threadsstr, "auto") == 0) {
             ns->threads = 0;
         } else {
-            ns->threads = (uint8_t)atoi(threadsstr);
+            ns->threads = atoi(threadsstr);
         }
     }
 

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -141,7 +141,7 @@ static void *ParsePcapConfig(const char *iface)
         aconf->threads = 1;
     } else {
         if (threadsstr != NULL) {
-            aconf->threads = (uint8_t)atoi(threadsstr);
+            aconf->threads = atoi(threadsstr);
         }
     }
     if (aconf->threads == 0) {

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -122,7 +122,7 @@ static void *OldParsePfringConfig(const char *iface)
         pfconf->threads = 1;
     } else {
         if (threadsstr != NULL) {
-            pfconf->threads = (uint8_t)atoi(threadsstr);
+            pfconf->threads = atoi(threadsstr);
         }
     }
     if (pfconf->threads == 0) {
@@ -243,7 +243,7 @@ static void *ParsePfringConfig(const char *iface)
         pfconf->threads = 1;
     } else {
         if (threadsstr != NULL) {
-            pfconf->threads = (uint8_t)atoi(threadsstr);
+            pfconf->threads = atoi(threadsstr);
         }
     }
     if (pfconf->threads == 0) {

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -95,7 +95,6 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
     char tname[TM_THREAD_NAME_MAX];
     char qname[TM_QUEUE_NAME_MAX];
     char *queues = NULL;
-    uint16_t thread = 0;
 
     /* Available cpus */
     uint16_t ncpus = UtilCpuGetNumProcessorsOnline();
@@ -106,8 +105,10 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
         thread_max = ncpus * threading_detect_ratio;
     if (thread_max < 1)
         thread_max = 1;
-    if (thread_max > 1024)
+    if (thread_max > 1024) {
+        SCLogWarning(SC_ERR_RUNMODE, "limited number of 'worker' threads to 1024. Wanted %d", thread_max);
         thread_max = 1024;
+    }
 
     queues = RunmodeAutoFpCreatePickupQueuesString(thread_max);
     if (queues == NULL) {
@@ -123,8 +124,8 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
 
         aconf = ConfigParser(live_dev);
         if (aconf == NULL) {
-            SCLogError(SC_ERR_RUNMODE, "Failed to allocate config for %s (%d)",
-                   live_dev, thread);
+            SCLogError(SC_ERR_RUNMODE, "Failed to allocate config for %s",
+                   live_dev);
             exit(EXIT_FAILURE);
         }
 
@@ -133,7 +134,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
                   threads_count, recv_mod_name);
 
         /* create the threads */
-        for (thread = 0; thread < threads_count; thread++) {
+        for (int thread = 0; thread < MIN(thread_max, threads_count); thread++) {
             snprintf(tname, sizeof(tname), "%s#%02d", thread_name, thread+1);
             ThreadVars *tv_receive =
                 TmThreadCreatePacketHandler(tname,
@@ -169,9 +170,8 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
         }
     } else { /* Multiple input device */
         SCLogInfo("Using %d live device(s).", nlive);
-        int lthread;
 
-        for (lthread = 0; lthread < nlive; lthread++) {
+        for (int lthread = 0; lthread < nlive; lthread++) {
             const char *dev = LiveGetDeviceName(lthread);
             const char *visual_devname = LiveGetShortName(dev);
             void *aconf;
@@ -191,7 +191,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
             }
 
             threads_count = ModThreadsCount(aconf);
-            for (thread = 0; thread < threads_count; thread++) {
+            for (int thread = 0; thread < threads_count; thread++) {
                 snprintf(tname, sizeof(tname), "%s#%02d-%s", thread_name,
                          thread+1, visual_devname);
 
@@ -227,7 +227,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
         }
     }
 
-    for (thread = 0; thread < (uint16_t)thread_max; thread++) {
+    for (int thread = 0; thread < thread_max; thread++) {
         snprintf(tname, sizeof(tname), "%s#%02u", thread_name_workers, thread+1);
         snprintf(qname, sizeof(qname), "pickup%u", thread+1);
 
@@ -278,7 +278,6 @@ static int RunModeSetLiveCaptureWorkersForDevice(ConfigIfaceThreadsCountFunc Mod
                               const char *live_dev, void *aconf,
                               unsigned char single_mode)
 {
-    int thread;
     int threads_count;
 
     if (single_mode) {
@@ -289,7 +288,7 @@ static int RunModeSetLiveCaptureWorkersForDevice(ConfigIfaceThreadsCountFunc Mod
     }
 
     /* create the threads */
-    for (thread = 0; thread < threads_count; thread++) {
+    for (int thread = 0; thread < threads_count; thread++) {
         char tname[TM_THREAD_NAME_MAX];
         ThreadVars *tv = NULL;
         TmModule *tm_module = NULL;
@@ -432,7 +431,6 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
     TmModule *tm_module ;
     const char *cur_queue = NULL;
     char *queues = NULL;
-    uint16_t thread;
 
     /* Available cpus */
     uint16_t ncpus = UtilCpuGetNumProcessorsOnline();
@@ -444,8 +442,10 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
         thread_max = ncpus * threading_detect_ratio;
     if (thread_max < 1)
         thread_max = 1;
-    if (thread_max > 1024)
+    if (thread_max > 1024) {
+        SCLogWarning(SC_ERR_RUNMODE, "limited number of 'worker' threads to 1024. Wanted %d", thread_max);
         thread_max = 1024;
+    }
 
     queues = RunmodeAutoFpCreatePickupQueuesString(thread_max);
     if (queues == NULL) {
@@ -493,7 +493,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
         }
 
     }
-    for (thread = 0; thread < (uint16_t)thread_max; thread++) {
+    for (int thread = 0; thread < thread_max; thread++) {
         snprintf(tname, sizeof(tname), "%s#%02u", thread_name_workers, thread+1);
         snprintf(qname, sizeof(qname), "pickup%u", thread+1);
 


### PR DESCRIPTION
Don't cast int to uint8_t for no reason. Add warning that upper
limit is 1024.

Small code cleanups.

Bug: #2228

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2228

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/6
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/6