### PR TITLE
stream: improve error handling of ssn/segment pools

### DIFF
--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -444,8 +444,11 @@ TcpReassemblyThreadCtx *StreamTcpReassembleInitThreadCtx(ThreadVars *tv)
                 ra_ctx->segment_thread_pool_id);
     }
     SCMutexUnlock(&segment_thread_pool_mutex);
-    if (ra_ctx->segment_thread_pool_id < 0 || segment_thread_pool == NULL)
-        abort();
+    if (ra_ctx->segment_thread_pool_id < 0 || segment_thread_pool == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "failed to setup/expand stream segment pool. Expand stream.reassembly.memcap?");
+        StreamTcpReassembleFreeThreadCtx(ra_ctx);
+        SCReturnPtr(NULL, "TcpReassemblyThreadCtx");
+    }
 
     SCReturnPtr(ra_ctx, "TcpReassemblyThreadCtx");
 }

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4984,8 +4984,10 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCLogDebug("pool size %d, thread ssn_pool_id %d", PoolThreadSize(ssn_pool), stt->ssn_pool_id);
     }
     SCMutexUnlock(&ssn_pool_mutex);
-    if (stt->ssn_pool_id < 0 || ssn_pool == NULL)
+    if (stt->ssn_pool_id < 0 || ssn_pool == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "failed to setup/expand stream session pool. Expand stream.memcap?");
         SCReturnInt(TM_ECODE_FAILED);
+    }
 
     SCReturnInt(TM_ECODE_OK);
 }


### PR DESCRIPTION
With large number of threads the default memcaps lead to pool setup
failures. Make sure these are reported properly so that the user
knows what is going on.

Bug: #2226

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2226

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/7
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/7
