### PR TITLE
Rust/fix/warnings/v0

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -352,7 +352,7 @@ impl DNSState {
             return;
         }
 
-        let mut tx = &mut self.transactions[len - 1];
+        let tx = &mut self.transactions[len - 1];
         core::sc_app_layer_decoder_events_set_event_raw(&mut tx.events,
                                                         event as u8);
         self.events += 1;

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -426,7 +426,7 @@ impl NFSState {
             return;
         }
 
-        let mut tx = &mut self.transactions[len - 1];
+        let tx = &mut self.transactions[len - 1];
         sc_app_layer_decoder_events_set_event_raw(&mut tx.events, event as u8);
         self.events += 1;
     }
@@ -435,7 +435,7 @@ impl NFSState {
     fn mark_response_tx_done(&mut self, xid: u32, rpc_status: u32, nfs_status: u32, resp_handle: &Vec<u8>)
     {
         match self.get_tx_by_xid(xid) {
-            Some(mut mytx) => {
+            Some(mytx) => {
                 mytx.response_done = true;
                 mytx.rpc_response_status = rpc_status;
                 mytx.nfs_response_status = nfs_status;


### PR DESCRIPTION
Describe changes:
- fix new rust warnings with rustc 1.21

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/9
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/9