### PR TITLE
Backports/32x/v8

### DIFF
--- a/src/app-layer-dcerpc.c
+++ b/src/app-layer-dcerpc.c
@@ -1191,10 +1191,15 @@ static uint32_t StubDataParser(DCERPC *dcerpc, uint8_t *input, uint32_t input_le
         stub_data_buffer_len = &dcerpc->dcerpcresponse.stub_data_buffer_len;
         stub_data_fresh = &dcerpc->dcerpcresponse.stub_data_fresh;
     }
+    if (*stub_data_buffer_len > (1024 * 1024)) {
+        SCFree(*stub_data_buffer);
+        *stub_data_buffer = NULL;
+        SCReturnUInt(0);
+    }
 
     stub_len = (dcerpc->padleft < input_len) ? dcerpc->padleft : input_len;
     if (stub_len == 0) {
-        SCLogError(SC_ERR_DCERPC, "stub_len is NULL.  We shouldn't be seeing "
+        SCLogDebug("stub_len is NULL.  We shouldn't be seeing "
                    "this.  In case you are, there is something gravely wrong "
                    "with the dcerpc parser");
         SCReturnInt(0);

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -3031,7 +3031,7 @@ int DetectByteExtractTest48(void)
     if (strncmp((char *)cd->content, "four", cd->content_len) != 0 ||
         cd->flags != (DETECT_CONTENT_DISTANCE_BE |
                       DETECT_CONTENT_DISTANCE |
-                      DETECT_CONTENT_RELATIVE_NEXT) ||
+                      DETECT_CONTENT_DISTANCE_NEXT) ||
         cd->distance != bed1->local_id ||
         cd->depth != 0 ||
         cd->offset != 0) {
@@ -3260,7 +3260,7 @@ int DetectByteExtractTest50(void)
     if (strncmp((char *)cd->content, "four", cd->content_len) != 0 ||
         cd->flags != (DETECT_CONTENT_WITHIN_BE |
                       DETECT_CONTENT_WITHIN|
-                      DETECT_CONTENT_RELATIVE_NEXT) ||
+                      DETECT_CONTENT_WITHIN_NEXT) ||
         cd->within != bed1->local_id ||
         cd->depth != 0 ||
         cd->offset != 0 ||

--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -39,8 +39,7 @@
 /** content is negated */
 #define DETECT_CONTENT_NEGATED           (1 << 9)
 
-/** a relative match to this content is next, used in matching phase */
-#define DETECT_CONTENT_RELATIVE_NEXT     (1 << 10)
+// bit 10 unused
 
 /* BE - byte extract */
 #define DETECT_CONTENT_OFFSET_BE         (1 << 11)
@@ -53,7 +52,12 @@
 /* this flag is set during the staging phase.  It indicates that a content
  * has been added to the mpm phase and requires no further inspection inside
  * the inspection phase */
-#define DETECT_CONTENT_NO_DOUBLE_INSPECTION_REQUIRED (1 << 16)
+#define DETECT_CONTENT_NO_DOUBLE_INSPECTION_REQUIRED BIT_U32(16)
+
+#define DETECT_CONTENT_WITHIN_NEXT      BIT_U32(17)
+#define DETECT_CONTENT_DISTANCE_NEXT    BIT_U32(18)
+/** a relative match to this content is next, used in matching phase */
+#define DETECT_CONTENT_RELATIVE_NEXT    (DETECT_CONTENT_WITHIN_NEXT|DETECT_CONTENT_DISTANCE_NEXT)
 
 #define DETECT_CONTENT_IS_SINGLE(c) (!( ((c)->flags & DETECT_CONTENT_DISTANCE) || \
                                         ((c)->flags & DETECT_CONTENT_WITHIN) || \

--- a/src/detect-distance.c
+++ b/src/detect-distance.c
@@ -163,7 +163,11 @@ static int DetectDistanceSetup (DetectEngineCtx *de_ctx, Signature *s,
                        "only content");
             goto end;
         }
-        prev_cd->flags |= DETECT_CONTENT_RELATIVE_NEXT;
+        if ((cd->flags & DETECT_CONTENT_NEGATED) == 0) {
+            prev_cd->flags |= DETECT_CONTENT_DISTANCE_NEXT;
+        } else {
+            prev_cd->flags |= DETECT_CONTENT_RELATIVE_NEXT;
+        }
     } else if (prev_pm->type == DETECT_PCRE) {
         DetectPcreData *pd = (DetectPcreData *)prev_pm->ctx;
         pd->flags |= DETECT_PCRE_RELATIVE_NEXT;

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -339,7 +339,7 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
                 }
 
                 /* no match and no reason to look for another instance */
-                if ((cd->flags & DETECT_CONTENT_RELATIVE_NEXT) == 0) {
+                if ((cd->flags & DETECT_CONTENT_WITHIN_NEXT) == 0) {
                     SCLogDebug("'next sm' does not depend on me, so we can give up");
                     det_ctx->discontinue_matching = 1;
                     goto no_match;

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -499,7 +499,7 @@ int DeStateDetectStartDetection(ThreadVars *tv, DetectEngineCtx *de_ctx,
 
         /* if continue detection already inspected this rule for this tx,
          * continue with the first not-inspected tx */
-        uint8_t offset = det_ctx->de_state_sig_array[s->num] & 0xef;
+        uint8_t offset = det_ctx->de_state_sig_array[s->num] & 0x7f;
         tx_id = AppLayerParserGetTransactionInspectId(f->alparser, flags);
         if (offset > 0) {
             SCLogDebug("using stored_tx_id %u instead of %u", (uint)tx_id+offset, (uint)tx_id);

--- a/src/detect-within.c
+++ b/src/detect-within.c
@@ -178,7 +178,7 @@ static int DetectWithinSetup(DetectEngineCtx *de_ctx, Signature *s, char *within
                        "only content");
             goto end;
         }
-        prev_cd->flags |= DETECT_CONTENT_RELATIVE_NEXT;
+        prev_cd->flags |= DETECT_CONTENT_WITHIN_NEXT;
     } else if (prev_pm->type == DETECT_PCRE) {
         DetectPcreData *pd = (DetectPcreData *)prev_pm->ctx;
         pd->flags |= DETECT_PCRE_RELATIVE_NEXT;

--- a/src/output.c
+++ b/src/output.c
@@ -966,6 +966,9 @@ TmEcode OutputLoggerThreadInit(ThreadVars *tv, void *initdata, void **data)
 
 TmEcode OutputLoggerThreadDeinit(ThreadVars *tv, void *thread_data)
 {
+    if (thread_data == NULL)
+        return TM_ECODE_FAILED;
+
     LoggerThreadStore *thread_store = (LoggerThreadStore *)thread_data;
     RootLogger *logger = TAILQ_FIRST(&RootLoggers);
     LoggerThreadStoreNode *thread_store_node = TAILQ_FIRST(thread_store);

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -188,7 +188,7 @@ void *ParseAFPConfig(const char *iface)
             if (strcmp(threadsstr, "auto") == 0) {
                 aconf->threads = 0;
             } else {
-                aconf->threads = (uint8_t)atoi(threadsstr);
+                aconf->threads = atoi(threadsstr);
             }
         }
     }

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -138,7 +138,7 @@ static int ParseNetmapSettings(NetmapIfaceSettings *ns, const char *iface,
         if (strcmp(threadsstr, "auto") == 0) {
             ns->threads = 0;
         } else {
-            ns->threads = (uint8_t)atoi(threadsstr);
+            ns->threads = atoi(threadsstr);
         }
     }
 

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -142,7 +142,7 @@ void *ParsePcapConfig(const char *iface)
         aconf->threads = 1;
     } else {
         if (threadsstr != NULL) {
-            aconf->threads = (uint8_t)atoi(threadsstr);
+            aconf->threads = atoi(threadsstr);
         }
     }
     if (aconf->threads == 0) {

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -125,7 +125,7 @@ void *OldParsePfringConfig(const char *iface)
         pfconf->threads = 1;
     } else {
         if (threadsstr != NULL) {
-            pfconf->threads = (uint8_t)atoi(threadsstr);
+            pfconf->threads = atoi(threadsstr);
         }
     }
     if (pfconf->threads == 0) {
@@ -252,7 +252,7 @@ void *ParsePfringConfig(const char *iface)
         pfconf->threads = 1;
     } else {
         if (threadsstr != NULL) {
-            pfconf->threads = (uint8_t)atoi(threadsstr);
+            pfconf->threads = atoi(threadsstr);
         }
     }
     if (pfconf->threads == 0) {

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4973,8 +4973,10 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCLogDebug("pool size %d, thread ssn_pool_id %d", PoolThreadSize(ssn_pool), stt->ssn_pool_id);
     }
     SCMutexUnlock(&ssn_pool_mutex);
-    if (stt->ssn_pool_id < 0 || ssn_pool == NULL)
+    if (stt->ssn_pool_id < 0 || ssn_pool == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "failed to setup/expand stream session pool. Expand stream.memcap?");
         SCReturnInt(TM_ECODE_FAILED);
+    }
 
     SCReturnInt(TM_ECODE_OK);
 }


### PR DESCRIPTION
Describe changes:
- fix performance problem with certain rules and traffic
- fix bad dcerpc traffic leading to memory exhaustion and crash
- fix stateful detection bug
- smaller fixes

Tickets:
https://redmine.openinfosecfoundation.org/issues/2231
https://redmine.openinfosecfoundation.org/issues/2241
https://redmine.openinfosecfoundation.org/issues/2214
https://redmine.openinfosecfoundation.org/issues/2242
https://redmine.openinfosecfoundation.org/issues/2243

PRscript passed.
