### PR TITLE
Flash decompression v7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -454,6 +454,78 @@
 
 # libraries
 
+  # zlib
+    AC_ARG_WITH(zlib_includes,
+            [  --with-zlib-includes=DIR  zlib include directory],
+            [with_zlib_includes="$withval"],[with_zlib_includes=no])
+    AC_ARG_WITH(zlib_libraries,
+            [  --with-zlib-libraries=DIR    zlib library directory],
+            [with_zlib_libraries="$withval"],[with_zlib_libraries="no"])
+
+    if test "$with_zlib_includes" != "no"; then
+        CPPFLAGS="${CPPFLAGS} -I${with_zlib_includes}"
+    fi
+
+    AC_CHECK_HEADER(zlib.h, ZLIB="yes",ZLIB="no")
+    if test "$ZLIB" = "yes"; then
+        if test "$with_zlib_libraries" != "no"; then
+            LDFLAGS="${LDFLAGS}  -L${with_zlib_libraries}"
+        fi
+
+        # To prevent duping the lib link we reset LIBS after this check. Setting action-if-found to NULL doesn't seem to work
+        # see: http://blog.flameeyes.eu/2008/04/29/i-consider-ac_check_lib-harmful
+        ZLIB=""
+        TMPLIBS="${LIBS}"
+        AC_CHECK_LIB(z,inflate,,ZLIB="no")
+
+        if test "$ZLIB" = "no"; then
+            echo
+            echo "   ERROR!  zlib library not found, go get it"
+            echo
+            exit 1
+        fi
+        LIBS="${TMPLIBS} -lz"
+    fi
+
+  # liblzma
+    enable_liblzma=no
+
+    AC_ARG_WITH(liblzma_includes,
+            [  --with-liblzma-includes=DIR  liblzma include directory],
+            [with_liblzma_includes="$withval"],[with_liblzma_includes=no])
+    AC_ARG_WITH(liblzma_libraries,
+            [  --with-liblzma-libraries=DIR    liblzma library directory],
+            [with_liblzma_libraries="$withval"],[with_liblzma_libraries="no"])
+
+    if test "$with_liblzma_includes" != "no"; then
+        CPPFLAGS="${CPPFLAGS} -I${with_liblzma_includes}"
+    fi
+
+    AC_CHECK_HEADER(lzma.h,LIBLZMA="yes",LIBLZMA="no")
+    if test "$LIBLZMA" = "yes"; then
+        if test "$with_liblzma_libraries" != "no"; then
+            LDFLAGS="${LDFLAGS}  -L${with_liblzma_libraries}"
+        fi
+
+        # To prevent duping the lib link we reset LIBS after this check. Setting action-if-found to NULL doesn't seem to work
+        # see: http://blog.flameeyes.eu/2008/04/29/i-consider-ac_check_lib-harmful
+        LIBLZMA=""
+        TMPLIBS="${LIBS}"
+        AC_CHECK_LIB(lzma,lzma_code,,LIBLZMA="no")
+
+        if test "$LIBLZMA" = "no"; then
+            echo
+            echo "   Warning! liblzma library not found, you will not be"
+            echo "   able to decompress flash file compressed with lzma."
+            echo
+            enable_liblzma=no
+        else
+            enable_liblzma=yes
+            AC_DEFINE([HAVE_LIBLZMA],[1],[liblzma available])
+            LIBS="${TMPLIBS} -llzma"
+        fi
+    fi
+
     AC_MSG_CHECKING([for Mpipe])
     AC_COMPILE_IFELSE(
         [AC_LANG_PROGRAM([[#include <gxio/mpipe.h>]])],
@@ -2171,6 +2243,7 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   libnss support:                          ${enable_nss}
   libnspr support:                         ${enable_nspr}
   libjansson support:                      ${enable_jansson}
+  liblzma support:                         ${enable_liblzma}
   hiredis support:                         ${enable_hiredis}
   hiredis async with libevent:             ${enable_hiredis_async}
   Prelude support:                         ${enable_prelude}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -391,6 +391,8 @@ util-device.c util-device.h \
 util-enum.c util-enum.h \
 util-error.c util-error.h \
 util-file.c util-file.h \
+util-file-decompression.c util-file-decompression.h \
+util-file-swf-decompression.c util-file-swf-decompression.h \
 util-fix_checksum.c util-fix_checksum.h \
 util-fmemopen.c util-fmemopen.h \
 util-hash.c util-hash.h \

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -133,6 +133,13 @@ enum {
     HTTP_DECODER_EVENT_MULTIPART_INVALID_HEADER,
 };
 
+typedef enum HtpSwfCompressType_ {
+    HTTP_SWF_COMPRESSION_NONE = 0,
+    HTTP_SWF_COMPRESSION_ZLIB,
+    HTTP_SWF_COMPRESSION_LZMA,
+    HTTP_SWF_COMPRESSION_BOTH,
+} HtpSwfCompressType;
+
 typedef struct HTPCfgDir_ {
     uint32_t body_limit;
     uint32_t inspect_min_size;
@@ -151,6 +158,11 @@ typedef struct HTPCfgRec_ {
     int                 randomize;
     int                 randomize_range;
     int                 http_body_inline;
+
+    int                 swf_decompression_enabled;
+    HtpSwfCompressType  swf_compression_type;
+    uint32_t            swf_decompress_depth;
+    uint32_t            swf_compress_depth;
 
     HTPCfgDir request;
     HTPCfgDir response;

--- a/src/detect-app-layer-event.h
+++ b/src/detect-app-layer-event.h
@@ -28,6 +28,9 @@ typedef struct DetectAppLayerEventData_ {
     AppProto alproto;
     int event_id;
 
+    /* it's used to check if there are event set into the detect engine */
+    bool needs_detctx;
+
     char *arg;
 } DetectAppLayerEventData;
 

--- a/src/detect-engine-hsbd.c
+++ b/src/detect-engine-hsbd.c
@@ -56,6 +56,7 @@
 
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
+#include "util-file-decompression.h"
 #include "app-layer.h"
 #include "app-layer-htp.h"
 #include "app-layer-htp-mem.h"
@@ -93,6 +94,7 @@ static inline int HSBDCreateSpace(DetectEngineThreadCtx *det_ctx, uint64_t size)
     for (i = det_ctx->hsbd_buffers_list_len; i < ((uint16_t)size); i++) {
         det_ctx->hsbd[i].buffer_len = 0;
         det_ctx->hsbd[i].offset = 0;
+        det_ctx->hsbd[i].decompressed_buffer_len = 0;
     }
 
     return 0;
@@ -103,6 +105,7 @@ static const uint8_t *DetectEngineHSBDGetBufferForTX(htp_tx_t *tx, uint64_t tx_i
                                                DetectEngineThreadCtx *det_ctx,
                                                Flow *f, HtpState *htp_state,
                                                uint8_t flags,
+                                               int *hsbd_index,
                                                uint32_t *buffer_len,
                                                uint32_t *stream_start_offset)
 {
@@ -122,11 +125,13 @@ static const uint8_t *DetectEngineHSBDGetBufferForTX(htp_tx_t *tx, uint64_t tx_i
         index = (tx_id - base_inspect_id);
         det_ctx->hsbd_start_tx_id = base_inspect_id;
         det_ctx->hsbd_buffers_list_len = txs;
+        *hsbd_index = index;
     } else {
         if ((tx_id - det_ctx->hsbd_start_tx_id) < det_ctx->hsbd_buffers_list_len) {
             if (det_ctx->hsbd[(tx_id - det_ctx->hsbd_start_tx_id)].buffer_len != 0) {
                 *buffer_len = det_ctx->hsbd[(tx_id - det_ctx->hsbd_start_tx_id)].buffer_len;
                 *stream_start_offset = det_ctx->hsbd[(tx_id - det_ctx->hsbd_start_tx_id)].offset;
+                *hsbd_index = (tx_id - det_ctx->hsbd_start_tx_id);
                 return det_ctx->hsbd[(tx_id - det_ctx->hsbd_start_tx_id)].buffer;
             }
         } else {
@@ -137,6 +142,7 @@ static const uint8_t *DetectEngineHSBDGetBufferForTX(htp_tx_t *tx, uint64_t tx_i
             det_ctx->hsbd_buffers_list_len = txs;
         }
         index = (tx_id - det_ctx->hsbd_start_tx_id);
+        *hsbd_index = index;
     }
 
     HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx);
@@ -237,14 +243,36 @@ static void PrefilterTxHttpResponseBody(DetectEngineThreadCtx *det_ctx,
     const MpmCtx *mpm_ctx = (MpmCtx *)pectx;
     htp_tx_t *tx = (htp_tx_t *)txv;
     HtpState *htp_state = f->alstate;
+    int ret = 0;
+    int hsbd_index = 0;
     uint32_t buffer_len = 0;
     uint32_t stream_start_offset = 0;
     const uint8_t *buffer = DetectEngineHSBDGetBufferForTX(tx, idx,
                                                      NULL, det_ctx,
                                                      f, htp_state,
                                                      flags,
+                                                     &hsbd_index,
                                                      &buffer_len,
                                                      &stream_start_offset);
+
+    if (htp_state->cfg->swf_decompression_enabled) {
+        int swf_file_type = FileIsSwfFile(buffer, buffer_len);
+        if (swf_file_type == FILE_SWF_ZLIB_COMPRESSION ||
+            swf_file_type == FILE_SWF_LZMA_COMPRESSION)
+        {
+            ret = FileSwfDecompression(buffer, buffer_len,
+                                       det_ctx,
+                                       hsbd_index,
+                                       htp_state->cfg->swf_compression_type,
+                                       htp_state->cfg->swf_decompress_depth,
+                                       htp_state->cfg->swf_compress_depth);
+
+            if (ret == 1 && det_ctx->hsbd[hsbd_index].decompressed_buffer_len != 0) {
+                buffer = det_ctx->hsbd[hsbd_index].decompressed_buffer;
+                buffer_len = det_ctx->hsbd[hsbd_index].decompressed_buffer_len;
+            }
+        }
+    }
 
     if (buffer_len >= mpm_ctx->minlen) {
         (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
@@ -268,14 +296,24 @@ int DetectEngineInspectHttpServerBody(ThreadVars *tv,
         Flow *f, uint8_t flags, void *alstate, void *tx, uint64_t tx_id)
 {
     HtpState *htp_state = (HtpState *)alstate;
+    int hsbd_index = 0;
     uint32_t buffer_len = 0;
     uint32_t stream_start_offset = 0;
     const uint8_t *buffer = DetectEngineHSBDGetBufferForTX(tx, tx_id,
                                                      de_ctx, det_ctx,
                                                      f, htp_state,
                                                      flags,
+                                                     &hsbd_index,
                                                      &buffer_len,
                                                      &stream_start_offset);
+
+    if (htp_state->cfg->swf_decompression_enabled) {
+        if (det_ctx->hsbd[hsbd_index].decompressed_buffer_len != 0) {
+            buffer = det_ctx->hsbd[hsbd_index].decompressed_buffer;
+            buffer_len = det_ctx->hsbd[hsbd_index].decompressed_buffer_len;
+        } 
+    }
+
     if (buffer_len == 0)
         goto end;
 
@@ -4392,6 +4430,8 @@ libhtp:\n\
     const char *sig = "alert http any any -> any any (file_data; content:\"bccd\"; depth:4; sid:1;)";
     return RunTest(steps, sig, yaml);
 }
+
+#include "tests/detect-engine-hsbd.c"
 #endif /* UNITTESTS */
 
 void DetectEngineHttpServerBodyRegisterTests(void)
@@ -4480,6 +4520,7 @@ void DetectEngineHttpServerBodyRegisterTests(void)
     UtRegisterTest("DetectEngineHttpServerBodyFileDataTest18",
                    DetectEngineHttpServerBodyFileDataTest18);
 
+    DetectEngineHttpServerBodyFileRegisterTests();
 #endif /* UNITTESTS */
 
     return;

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1957,6 +1957,9 @@ static void DetectEngineThreadCtxFree(DetectEngineThreadCtx *det_ctx)
 
     /* HSBD */
     if (det_ctx->hsbd != NULL) {
+        if (det_ctx->hsbd->decompressed_buffer != NULL) {
+            SCFree(det_ctx->hsbd->decompressed_buffer);
+        }
         SCLogDebug("det_ctx hsbd %u", det_ctx->hsbd_buffers_size);
         SCFree(det_ctx->hsbd);
     }

--- a/src/detect.c
+++ b/src/detect.c
@@ -237,6 +237,27 @@ extern int engine_analysis;
 static int fp_engine_analysis_set = 0;
 static int rule_engine_analysis_set = 0;
 
+SCEnumCharMap det_ctx_event_table[ ] = {
+#ifdef UNITTESTS
+    { "TEST",                       DET_CTX_EVENT_TEST },
+#endif
+    { "NO_MEMORY",                  FILE_DECODER_EVENT_NO_MEM },
+    { "INVALID_SWF_LENGTH",         FILE_DECODER_EVENT_INVALID_SWF_LENGTH },
+    { "INVALID_SWF_VERSION",        FILE_DECODER_EVENT_INVALID_SWF_VERSION },
+    { "Z_DATA_ERROR",               FILE_DECODER_EVENT_Z_DATA_ERROR },
+    { "Z_STREAM_ERROR",             FILE_DECODER_EVENT_Z_STREAM_ERROR },
+    { "Z_BUF_ERROR",                FILE_DECODER_EVENT_Z_BUF_ERROR },
+    { "Z_UNKNOWN_ERROR",            FILE_DECODER_EVENT_Z_UNKNOWN_ERROR },
+    { "LZMA_DECODER_ERROR",         FILE_DECODER_EVENT_LZMA_DECODER_ERROR },
+    { "LZMA_MEMLIMIT_ERROR",        FILE_DECODER_EVENT_LZMA_MEMLIMIT_ERROR },
+    { "LZMA_OPTIONS_ERROR",         FILE_DECODER_EVENT_LZMA_OPTIONS_ERROR },
+    { "LZMA_FORMAT_ERROR",          FILE_DECODER_EVENT_LZMA_FORMAT_ERROR },
+    { "LZMA_DATA_ERROR",            FILE_DECODER_EVENT_LZMA_DATA_ERROR },
+    { "LZMA_BUF_ERROR",             FILE_DECODER_EVENT_LZMA_BUF_ERROR },
+    { "LZMA_UNKNOWN_ERROR",         FILE_DECODER_EVENT_LZMA_UNKNOWN_ERROR },
+    { NULL,                         -1 },
+};
+
 SigMatch *SigMatchAlloc(void);
 void DetectExitPrintStats(ThreadVars *tv, void *data);
 
@@ -1476,6 +1497,33 @@ static DetectEngineThreadCtx *GetTenantById(HashTable *h, uint32_t id)
      * tentant_id member. But as that member is the first in the struct, we
      * can use the id directly. */
     return HashTableLookup(h, &id, 0);
+}
+
+/* events api */
+void DetectEngineSetEvent(DetectEngineThreadCtx *det_ctx, uint8_t e)
+{
+    AppLayerDecoderEventsSetEventRaw(&det_ctx->decoder_events, e);
+    det_ctx->events++;
+}
+
+AppLayerDecoderEvents *DetectEngineGetEvents(DetectEngineThreadCtx *det_ctx)
+{
+    return det_ctx->decoder_events;
+}
+
+int DetectEngineGetEventInfo(const char *event_name, int *event_id,
+                             AppLayerEventType *event_type)
+{
+    *event_id = SCMapEnumNameToValue(event_name, det_ctx_event_table);
+    if (*event_id == -1) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%s\" not present in "
+                   "det_ctx's enum map table.",  event_name);
+        /* this should be treated as fatal */
+        return -1;
+    }
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
 }
 
 static void DetectFlow(ThreadVars *tv,

--- a/src/detect.h
+++ b/src/detect.h
@@ -49,6 +49,8 @@
 
 #include "util-var-name.h"
 
+#include "app-layer-events.h"
+
 #define DETECT_MAX_RULE_SIZE 8192
 
 /* forward declarations for the structures from detect-engine-sigorder.h */
@@ -916,6 +918,9 @@ typedef struct DetectEngineThreadCtx_ {
     int base64_decoded_len;
     int base64_decoded_len_max;
 
+    AppLayerDecoderEvents *decoder_events;
+    uint16_t events;
+
 #ifdef DEBUG
     uint64_t pkt_stream_add_cnt;
     uint64_t payload_mpm_cnt;
@@ -971,6 +976,27 @@ typedef struct SigTableElmt_ {
     const char *url;
 
 } SigTableElmt;
+
+/* event code */
+enum {
+#ifdef UNITTESTS
+    DET_CTX_EVENT_TEST,
+#endif
+    FILE_DECODER_EVENT_NO_MEM,
+    FILE_DECODER_EVENT_INVALID_SWF_LENGTH,
+    FILE_DECODER_EVENT_INVALID_SWF_VERSION,
+    FILE_DECODER_EVENT_Z_DATA_ERROR,
+    FILE_DECODER_EVENT_Z_STREAM_ERROR,
+    FILE_DECODER_EVENT_Z_BUF_ERROR,
+    FILE_DECODER_EVENT_Z_UNKNOWN_ERROR,
+    FILE_DECODER_EVENT_LZMA_DECODER_ERROR,
+    FILE_DECODER_EVENT_LZMA_MEMLIMIT_ERROR,
+    FILE_DECODER_EVENT_LZMA_OPTIONS_ERROR,
+    FILE_DECODER_EVENT_LZMA_FORMAT_ERROR,
+    FILE_DECODER_EVENT_LZMA_DATA_ERROR,
+    FILE_DECODER_EVENT_LZMA_BUF_ERROR,
+    FILE_DECODER_EVENT_LZMA_UNKNOWN_ERROR,
+};
 
 #define SIG_GROUP_HEAD_HAVERAWSTREAM    (1 << 0)
 #ifdef HAVE_MAGIC
@@ -1416,6 +1442,12 @@ int SigMatchSignaturesRunPostMatch(ThreadVars *tv,
                                    DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx, Packet *p,
                                    const Signature *s);
 void DetectSignatureApplyActions(Packet *p, const Signature *s, const uint8_t);
+
+/* events */
+void DetectEngineSetEvent(DetectEngineThreadCtx *det_ctx, uint8_t e);
+AppLayerDecoderEvents *DetectEngineGetEvents(DetectEngineThreadCtx *det_ctx);
+int DetectEngineGetEventInfo(const char *event_name, int *event_id,
+                             AppLayerEventType *event_type);
 
 #endif /* __DETECT_H__ */
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -758,8 +758,10 @@ enum {
 
 typedef struct HttpReassembledBody_ {
     const uint8_t *buffer;
+    uint8_t *decompressed_buffer;
     uint32_t buffer_size;   /**< size of the buffer itself */
     uint32_t buffer_len;    /**< data len in the buffer */
+    uint32_t decompressed_buffer_len;
     uint64_t offset;        /**< data offset */
 } HttpReassembledBody;
 

--- a/src/tests/detect-engine-hsbd.c
+++ b/src/tests/detect-engine-hsbd.c
@@ -1,0 +1,1428 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ *
+ * Tests for the hsbd with swf files
+ */
+
+#include "../suricata-common.h"
+#include "../decode.h"
+#include "../flow.h"
+#include "../detect.h"
+
+static int DetectEngineHttpServerBodyFileDataTest19(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    swf-decompression:\n\
+      enabled: yes\n\
+      type: both\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '8', '0', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','x','-','s','h','o','c','k','w','a','v','e','-','f','l','a','s','h', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x43, 0x57, 0x53, 0x0a, 0xcb, 0x6c, 0x00, 0x00, 0x78, 0xda, 0xad, 0xbd, 0x07, 0x98, 0x55, 0x55,
+        0x9e, 0xee, 0xbd, 0x4f, 0xd8, 0xb5, 0x4e, 0x15, 0xc1, 0xc2, 0x80, 0x28, 0x86, 0xd2, 0x2e, 0x5a,
+        0xdb, 0x46, 0xd9, 0x39, 0x38, 0xdd, 0x4e, 0x1b, 0xa8, 0x56, 0x5b, 0xc5, 0x6b, 0xe8, 0x76, 0xfa,
+        0x0e, 0xc2, 0x8e, 0x50, 0x76, 0x51, 0xc5, 0x54, 0x15, 0x88, 0x73, 0xc3, 0xd0, 0x88, 0x39, 0x81,
+        0x98, 0x63, 0x91, 0x93, 0x8a, 0x82, 0x89, 0x60, 0x00, 0xcc, 0xb1, 0x00, 0x01, 0x73, 0xce, 0x39,
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    FAIL_IF_NULL(alp_tctx);
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"FWS\"; "
+                               "sid:1;)");
+    FAIL_IF_NULL(de_ctx->sig_list);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    FAIL_IF(r != 0);
+
+    http_state = f.alstate;
+    FAIL_IF_NULL(http_state);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    FAIL_IF((PacketAlertCheck(p1, 1)));
+
+    r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    FAIL_IF(r != 0);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    FAIL_IF(!(PacketAlertCheck(p2, 1)));
+
+    AppLayerParserThreadCtxFree(alp_tctx);
+    DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    PASS;
+}
+
+static int DetectEngineHttpServerBodyFileDataTest20(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    swf-decompression:\n\
+      enabled: no\n\
+      type: both\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '8', '0', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','x','-','s','h','o','c','k','w','a','v','e','-','f','l','a','s','h', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x43, 0x57, 0x53, 0x0a, 0xcb, 0x6c, 0x00, 0x00, 0x78, 0xda, 0xad, 0xbd, 0x07, 0x98, 0x55, 0x55,
+        0x9e, 0xee, 0xbd, 0x4f, 0xd8, 0xb5, 0x4e, 0x15, 0xc1, 0xc2, 0x80, 0x28, 0x86, 0xd2, 0x2e, 0x5a,
+        0xdb, 0x46, 0xd9, 0x39, 0x38, 0xdd, 0x4e, 0x1b, 0xa8, 0x56, 0x5b, 0xc5, 0x6b, 0xe8, 0x76, 0xfa,
+        0x0e, 0xc2, 0x8e, 0x50, 0x76, 0x51, 0xc5, 0x54, 0x15, 0x88, 0x73, 0xc3, 0xd0, 0x88, 0x39, 0x81,
+        0x98, 0x63, 0x91, 0x93, 0x8a, 0x82, 0x89, 0x60, 0x00, 0xcc, 0xb1, 0x00, 0x01, 0x73, 0xce, 0x39,
+    };
+    uint32_t http_len2 = sizeof(http_buf2); 
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    FAIL_IF_NULL(alp_tctx);
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"CWS\"; "
+                               "sid:1;)");
+    FAIL_IF_NULL(de_ctx->sig_list);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    FAIL_IF(r != 0);
+
+    http_state = f.alstate;
+    FAIL_IF_NULL(http_state);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    FAIL_IF((PacketAlertCheck(p1, 1)));
+
+    r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    FAIL_IF(r != 0);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    FAIL_IF(!(PacketAlertCheck(p2, 1)));
+ 
+    AppLayerParserThreadCtxFree(alp_tctx);
+    DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    PASS;
+}
+
+static int DetectEngineHttpServerBodyFileDataTest21(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    swf-decompression:\n\
+      enabled: yes\n\
+      type: deflate\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '8', '0', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','x','-','s','h','o','c','k','w','a','v','e','-','f','l','a','s','h', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x43, 0x57, 0x53, 0x0a, 0xcb, 0x6c, 0x00, 0x00, 0x78, 0xda, 0xad, 0xbd, 0x07, 0x98, 0x55, 0x55,
+        0x9e, 0xee, 0xbd, 0x4f, 0xd8, 0xb5, 0x4e, 0x15, 0xc1, 0xc2, 0x80, 0x28, 0x86, 0xd2, 0x2e, 0x5a,
+        0xdb, 0x46, 0xd9, 0x39, 0x38, 0xdd, 0x4e, 0x1b, 0xa8, 0x56, 0x5b, 0xc5, 0x6b, 0xe8, 0x76, 0xfa,
+        0x0e, 0xc2, 0x8e, 0x50, 0x76, 0x51, 0xc5, 0x54, 0x15, 0x88, 0x73, 0xc3, 0xd0, 0x88, 0x39, 0x81,
+        0x98, 0x63, 0x91, 0x93, 0x8a, 0x82, 0x89, 0x60, 0x00, 0xcc, 0xb1, 0x00, 0x01, 0x73, 0xce, 0x39,
+    };
+    uint32_t http_len2 = sizeof(http_buf2); 
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    FAIL_IF_NULL(alp_tctx);
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"FWS\"; "
+                               "sid:1;)");
+    FAIL_IF_NULL(de_ctx->sig_list);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    FAIL_IF(r != 0);
+
+    http_state = f.alstate;
+    FAIL_IF_NULL(http_state);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    FAIL_IF((PacketAlertCheck(p1, 1)));
+
+    r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    FAIL_IF(r != 0);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    FAIL_IF(!(PacketAlertCheck(p2, 1)));
+ 
+    AppLayerParserThreadCtxFree(alp_tctx);
+    DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    PASS;
+}
+
+static int DetectEngineHttpServerBodyFileDataTest22(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    swf-decompression:\n\
+      enabled: yes\n\
+      type: lzma\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '8', '0', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','x','-','s','h','o','c','k','w','a','v','e','-','f','l','a','s','h', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x43, 0x57, 0x53, 0x0a, 0xcb, 0x6c, 0x00, 0x00, 0x78, 0xda, 0xad, 0xbd, 0x07, 0x98, 0x55, 0x55,
+        0x9e, 0xee, 0xbd, 0x4f, 0xd8, 0xb5, 0x4e, 0x15, 0xc1, 0xc2, 0x80, 0x28, 0x86, 0xd2, 0x2e, 0x5a,
+        0xdb, 0x46, 0xd9, 0x39, 0x38, 0xdd, 0x4e, 0x1b, 0xa8, 0x56, 0x5b, 0xc5, 0x6b, 0xe8, 0x76, 0xfa,
+        0x0e, 0xc2, 0x8e, 0x50, 0x76, 0x51, 0xc5, 0x54, 0x15, 0x88, 0x73, 0xc3, 0xd0, 0x88, 0x39, 0x81,
+        0x98, 0x63, 0x91, 0x93, 0x8a, 0x82, 0x89, 0x60, 0x00, 0xcc, 0xb1, 0x00, 0x01, 0x73, 0xce, 0x39,
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    FAIL_IF_NULL(alp_tctx);
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"CWS\"; "
+                               "sid:1;)");
+    FAIL_IF_NULL(de_ctx->sig_list);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    FAIL_IF(r != 0);
+
+    http_state = f.alstate;
+    FAIL_IF_NULL(http_state);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    FAIL_IF((PacketAlertCheck(p1, 1)));
+
+    r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    FAIL_IF(r != 0);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    FAIL_IF(!(PacketAlertCheck(p2, 1)));
+
+    AppLayerParserThreadCtxFree(alp_tctx);
+    DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    PASS;
+}
+
+static int DetectEngineHttpServerBodyFileDataTest23(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    swf-decompression:\n\
+      enabled: yes\n\
+      type: both\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '8', '0', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','x','-','s','h','o','c','k','w','a','v','e','-','f','l','a','s','h', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x43, 0x57, 0x53, 0x01, 0xcb, 0x6c, 0x00, 0x00, 0x78, 0xda, 0xad, 0xbd, 0x07, 0x98, 0x55, 0x55,
+        0x9e, 0xee, 0xbd, 0x4f, 0xd8, 0xb5, 0x4e, 0x15, 0xc1, 0xc2, 0x80, 0x28, 0x86, 0xd2, 0x2e, 0x5a,
+        0xdb, 0x46, 0xd9, 0x39, 0x38, 0xdd, 0x4e, 0x1b, 0xa8, 0x56, 0x5b, 0xc5, 0x6b, 0xe8, 0x76, 0xfa,
+        0x0e, 0xc2, 0x8e, 0x50, 0x76, 0x51, 0xc5, 0x54, 0x15, 0x88, 0x73, 0xc3, 0xd0, 0x88, 0x39, 0x81,
+        0x98, 0x63, 0x91, 0x93, 0x8a, 0x82, 0x89, 0x60, 0x00, 0xcc, 0xb1, 0x00, 0x01, 0x73, 0xce, 0x39,
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    FAIL_IF_NULL(alp_tctx);
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"CWS\"; "
+                               "sid:1;)");
+    FAIL_IF_NULL(de_ctx->sig_list);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    FAIL_IF(r != 0);
+
+    http_state = f.alstate;
+    FAIL_IF_NULL(http_state);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    FAIL_IF((PacketAlertCheck(p1, 1)));
+
+    r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    FAIL_IF(r != 0);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    FAIL_IF(!(PacketAlertCheck(p2, 1)));
+
+    AppLayerParserThreadCtxFree(alp_tctx);
+    DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    PASS;
+}
+
+static int DetectEngineHttpServerBodyFileDataTest24(void)
+{
+#ifdef HAVE_LIBLZMA
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    swf-decompression:\n\
+      enabled: yes\n\
+      type: both\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '1', '0', '3', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','o','c','t','e','t','-','s','t','r','e','a','m', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x5a, 0x57, 0x53, 0x17, 0x5c, 0x24, 0x00, 0x00, 0xb7, 0x21, 0x00, 0x00, 0x5d, 0x00, 0x00, 0x20,
+        0x00, 0x00, 0x3b, 0xff, 0xfc, 0x8e, 0x19, 0xfa, 0xdf, 0xe7, 0x66, 0x08, 0xa0, 0x3d, 0x3e, 0x85,
+        0xf5, 0x75, 0x6f, 0xd0, 0x7e, 0x61, 0x35, 0x1b, 0x1a, 0x8b, 0x16, 0x4d, 0xdf, 0x05, 0x32, 0xfe,
+        0xa4, 0x4c, 0x46, 0x49, 0xb7, 0x7b, 0x6b, 0x75, 0xf9, 0x2b, 0x5c, 0x37, 0x29, 0x0b, 0x91, 0x37,
+        0x01, 0x37, 0x0e, 0xe9, 0xf2, 0xe1, 0xfc, 0x9e, 0x64, 0xda, 0x6c, 0x11, 0x21, 0x33, 0xed, 0xa0,
+        0x0e, 0x76, 0x70, 0xa0, 0xcd, 0x98, 0x2e, 0x76, 0x80, 0xf0, 0xe0, 0x59, 0x56, 0x06, 0x08, 0xe9,
+        0xca, 0xeb, 0xa2, 0xc6, 0xdb, 0x5a, 0x86
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    FAIL_IF_NULL(alp_tctx);
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"FWS\"; "
+                               "sid:1;)");
+    FAIL_IF_NULL(de_ctx->sig_list);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    FAIL_IF(r != 0);
+
+    http_state = f.alstate;
+    FAIL_IF_NULL(http_state);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    FAIL_IF((PacketAlertCheck(p1, 1)));
+
+    r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    FAIL_IF(r != 0);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    FAIL_IF(!(PacketAlertCheck(p2, 1)));
+
+    AppLayerParserThreadCtxFree(alp_tctx);
+    DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    PASS;
+#else
+    PASS;
+#endif /* HAVE_LIBLZMA */
+}
+
+static int DetectEngineHttpServerBodyFileDataTest25(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    swf-decompression:\n\
+      enabled: no\n\
+      type: both\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '1', '0', '3', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','o','c','t','e','t','-','s','t','r','e','a','m', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x5a, 0x57, 0x53, 0x17, 0x5c, 0x24, 0x00, 0x00, 0xb7, 0x21, 0x00, 0x00, 0x5d, 0x00, 0x00, 0x20, 0x00, 0x00, 0x3b, 0xff, 0xfc, 0x8e, 0x19,
+        0xfa, 0xdf, 0xe7, 0x66, 0x08, 0xa0, 0x3d, 0x3e, 0x85, 0xf5, 0x75, 0x6f, 0xd0, 0x7e, 0x61, 0x35, 0x1b, 0x1a, 0x8b, 0x16, 0x4d, 0xdf, 0x05,
+        0x32, 0xfe, 0xa4, 0x4c, 0x46, 0x49, 0xb7, 0x7b, 0x6b, 0x75, 0xf9, 0x2b, 0x5c, 0x37, 0x29, 0x0b, 0x91, 0x37, 0x01, 0x37, 0x0e, 0xe9, 0xf2,
+        0xe1, 0xfc, 0x9e, 0x64, 0xda, 0x6c, 0x11, 0x21, 0x33, 0xed, 0xa0, 0x0e, 0x76, 0x70, 0xa0, 0xcd, 0x98, 0x2e, 0x76, 0x80, 0xf0, 0xe0, 0x59,
+        0x56, 0x06, 0x08, 0xe9, 0xca, 0xeb, 0xa2, 0xc6, 0xdb, 0x5a, 0x86
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    FAIL_IF_NULL(alp_tctx);
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"ZWS\"; "
+                               "sid:1;)");
+    FAIL_IF_NULL(de_ctx->sig_list);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    FAIL_IF(r != 0);
+
+    http_state = f.alstate;
+    FAIL_IF_NULL(http_state);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    FAIL_IF((PacketAlertCheck(p1, 1)));
+
+    r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    FAIL_IF(r != 0);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    FAIL_IF(!(PacketAlertCheck(p2, 1)));
+
+    AppLayerParserThreadCtxFree(alp_tctx);
+    DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    PASS;
+}
+
+static int DetectEngineHttpServerBodyFileDataTest26(void)
+{
+#ifdef HAVE_LIBLZMA
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    swf-decompression:\n\
+      enabled: yes\n\
+      type: lzma\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '1', '0', '3', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','o','c','t','e','t','-','s','t','r','e','a','m', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x5a, 0x57, 0x53, 0x17, 0x5c, 0x24, 0x00, 0x00, 0xb7, 0x21, 0x00, 0x00, 0x5d, 0x00, 0x00, 0x20,
+        0x00, 0x00, 0x3b, 0xff, 0xfc, 0x8e, 0x19, 0xfa, 0xdf, 0xe7, 0x66, 0x08, 0xa0, 0x3d, 0x3e, 0x85,
+        0xf5, 0x75, 0x6f, 0xd0, 0x7e, 0x61, 0x35, 0x1b, 0x1a, 0x8b, 0x16, 0x4d, 0xdf, 0x05, 0x32, 0xfe,
+        0xa4, 0x4c, 0x46, 0x49, 0xb7, 0x7b, 0x6b, 0x75, 0xf9, 0x2b, 0x5c, 0x37, 0x29, 0x0b, 0x91, 0x37,
+        0x01, 0x37, 0x0e, 0xe9, 0xf2, 0xe1, 0xfc, 0x9e, 0x64, 0xda, 0x6c, 0x11, 0x21, 0x33, 0xed, 0xa0,
+        0x0e, 0x76, 0x70, 0xa0, 0xcd, 0x98, 0x2e, 0x76, 0x80, 0xf0, 0xe0, 0x59, 0x56, 0x06, 0x08, 0xe9,
+        0xca, 0xeb, 0xa2, 0xc6, 0xdb, 0x5a, 0x86
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    FAIL_IF_NULL(alp_tctx);
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"FWS\"; "
+                               "sid:1;)");
+    FAIL_IF_NULL(de_ctx->sig_list);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    FAIL_IF(r != 0);
+
+    http_state = f.alstate;
+    FAIL_IF_NULL(http_state);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    FAIL_IF((PacketAlertCheck(p1, 1)));
+
+    r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    FAIL_IF(r != 0);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    FAIL_IF(!(PacketAlertCheck(p2, 1)));
+
+    AppLayerParserThreadCtxFree(alp_tctx);
+    DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    PASS;
+#else
+    PASS;
+#endif /* HAVE_LIBLZMA */
+}
+
+static int DetectEngineHttpServerBodyFileDataTest27(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    swf-decompression:\n\
+      enabled: yes\n\
+      type: deflate\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '8', '0', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','o','c','t','e','t','-','s','t','r','e','a','m', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x5a, 0x57, 0x53, 0x17, 0x5c, 0x24, 0x00, 0x00, 0xb7, 0x21, 0x00, 0x00, 0x5d, 0x00, 0x00, 0x20,
+        0x00, 0x00, 0x3b, 0xff, 0xfc, 0x8e, 0x19, 0xfa, 0xdf, 0xe7, 0x66, 0x08, 0xa0, 0x3d, 0x3e, 0x85,
+        0x19, 0xfa, 0xdf, 0xe7, 0x66, 0x08, 0xa0, 0x3d, 0x3e, 0x85, 0xf5, 0x75, 0x6f, 0xd0, 0x7e, 0x61,
+        0x35, 0x1b, 0x1a, 0x8b, 0x16, 0x4d, 0xdf, 0x05, 0x32, 0xfe, 0xa4, 0x4c, 0x46, 0x49, 0xb7, 0x7b,
+        0x6b, 0x75, 0xf9, 0x2b, 0x5c, 0x37, 0x29, 0x0b, 0x91, 0x37, 0x01, 0x37, 0x0e, 0xe9, 0xf2, 0xe1,
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    FAIL_IF_NULL(alp_tctx);
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"ZWS\"; "
+                               "sid:1;)");
+    FAIL_IF_NULL(de_ctx->sig_list);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    FAIL_IF(r != 0);
+
+    http_state = f.alstate;
+    FAIL_IF_NULL(http_state);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    FAIL_IF((PacketAlertCheck(p1, 1)));
+
+    r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    FAIL_IF(r != 0);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    FAIL_IF(!(PacketAlertCheck(p2, 1)));
+
+    AppLayerParserThreadCtxFree(alp_tctx);
+    DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    PASS;
+}
+
+static int DetectEngineHttpServerBodyFileDataTest28(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    swf-decompression:\n\
+      enabled: yes\n\
+      type: both\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '8', '0', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','o','c','t','e','t','-','s','t','r','e','a','m', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x5a, 0x57, 0x53, 0x01, 0x5c, 0x24, 0x00, 0x00, 0xb7, 0x21, 0x00, 0x00, 0x5d, 0x00, 0x00, 0x20,
+        0x00, 0x00, 0x3b, 0xff, 0xfc, 0x8e, 0x19, 0xfa, 0xdf, 0xe7, 0x66, 0x08, 0xa0, 0x3d, 0x3e, 0x85,
+        0x19, 0xfa, 0xdf, 0xe7, 0x66, 0x08, 0xa0, 0x3d, 0x3e, 0x85, 0xf5, 0x75, 0x6f, 0xd0, 0x7e, 0x61,
+        0x35, 0x1b, 0x1a, 0x8b, 0x16, 0x4d, 0xdf, 0x05, 0x32, 0xfe, 0xa4, 0x4c, 0x46, 0x49, 0xb7, 0x7b,
+        0x6b, 0x75, 0xf9, 0x2b, 0x5c, 0x37, 0x29, 0x0b, 0x91, 0x37, 0x01, 0x37, 0x0e, 0xe9, 0xf2, 0xe1,
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    FAIL_IF_NULL(alp_tctx);
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"ZWS\"; "
+                               "sid:1;)");
+    FAIL_IF_NULL(de_ctx->sig_list);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    FAIL_IF(r != 0);
+
+    http_state = f.alstate;
+    FAIL_IF_NULL(http_state);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    FAIL_IF((PacketAlertCheck(p1, 1)));
+
+    r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    FAIL_IF(r != 0);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    FAIL_IF(!(PacketAlertCheck(p2, 1)));
+
+    AppLayerParserThreadCtxFree(alp_tctx);
+    DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    PASS;
+}
+
+static int DetectEngineHttpServerBodyFileDataTest29(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    swf-decompression:\n\
+      enabled: yes\n\
+      type: both\n\
+      compress-depth: 1000\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '8', '0', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','x','-','s','h','o','c','k','w','a','v','e','-','f','l','a','s','h', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x43, 0x57, 0x53, 0x0a, 0xcb, 0x6c, 0x00, 0x00, 0x78, 0xda, 0xad, 0xbd, 0x07, 0x98, 0x55, 0x55,
+        0x9e, 0xee, 0xbd, 0x4f, 0xd8, 0xb5, 0x4e, 0x15, 0xc1, 0xc2, 0x80, 0x28, 0x86, 0xd2, 0x2e, 0x5a,
+        0xdb, 0x46, 0xd9, 0x39, 0x38, 0xdd, 0x4e, 0x1b, 0xa8, 0x56, 0x5b, 0xc5, 0x6b, 0xe8, 0x76, 0xfa,
+        0x0e, 0xc2, 0x8e, 0x50, 0x76, 0x51, 0xc5, 0x54, 0x15, 0x88, 0x73, 0xc3, 0xd0, 0x88, 0x39, 0x81,
+        0x98, 0x63, 0x91, 0x93, 0x8a, 0x82, 0x89, 0x60, 0x00, 0xcc, 0xb1, 0x00, 0x01, 0x73, 0xce, 0x39,
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    FAIL_IF_NULL(alp_tctx);
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"FWS\"; "
+                               "sid:1;)");
+    FAIL_IF_NULL(de_ctx->sig_list);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    FAIL_IF(r != 0);
+
+    http_state = f.alstate;
+    FAIL_IF_NULL(http_state);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    FAIL_IF((PacketAlertCheck(p1, 1)));
+
+    r = AppLayerParserParse(&th_v, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    FAIL_IF(r != 0);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    FAIL_IF(!(PacketAlertCheck(p2, 1)));
+
+    AppLayerParserThreadCtxFree(alp_tctx);
+    DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    PASS;
+}
+
+static void DetectEngineHttpServerBodyFileRegisterTests(void)
+{
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest19",
+                  DetectEngineHttpServerBodyFileDataTest19);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest20",
+                  DetectEngineHttpServerBodyFileDataTest20);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest21",
+                  DetectEngineHttpServerBodyFileDataTest21);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest22",
+                  DetectEngineHttpServerBodyFileDataTest22);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest23",
+                  DetectEngineHttpServerBodyFileDataTest23);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest24",
+                  DetectEngineHttpServerBodyFileDataTest24);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest25",
+                  DetectEngineHttpServerBodyFileDataTest25);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest26",
+                  DetectEngineHttpServerBodyFileDataTest26);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest27",
+                  DetectEngineHttpServerBodyFileDataTest27);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest28",
+                  DetectEngineHttpServerBodyFileDataTest28);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest29",
+                  DetectEngineHttpServerBodyFileDataTest29);
+}

--- a/src/util-file-decompression.c
+++ b/src/util-file-decompression.c
@@ -1,0 +1,214 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/** \file
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ *
+ * \brief Decompress files transfered via HTTP corresponding to file_data
+ * keyword.
+ *
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+
+#include "app-layer-htp.h"
+
+#include "util-file-decompression.h"
+#include "util-file-swf-decompression.h"
+#include "util-misc.h"
+#include "util-print.h"
+
+#define SWF_ZLIB_MIN_VERSION    0x06
+#define SWF_LZMA_MIN_VERSION    0x0D
+
+int FileIsSwfFile(const uint8_t *buffer, uint32_t buffer_len)
+{
+    if (buffer_len >= 3 && buffer[1] == 'W' && buffer[2] == 'S') {
+        if (buffer[0] == 'F')
+            return FILE_SWF_NO_COMPRESSION;
+        else if (buffer[0] == 'C')
+            return FILE_SWF_ZLIB_COMPRESSION;
+        else if (buffer[0] == 'Z')
+            return FILE_SWF_LZMA_COMPRESSION;
+        else
+            return FILE_IS_NOT_SWF;
+    }
+
+    return FILE_IS_NOT_SWF;
+}
+
+/**
+ * \brief This function decompresses a buffer with zlib/lzma algorithm
+ *
+ * \param buffer compressed buffer
+ * \param buffer_len compressed buffer length
+ * \param decompressed_buffer buffer that store decompressed data
+ * \param decompressed_buffer_len decompressesd data length
+ * \param swf_type decompression algorithm to use
+ * \param decompress_depth how much decompressed data we want to store
+ * \param compress_depth how much compressed data we want to decompress
+ *
+ * \retval 1 if decompression works
+ * \retval 0 an error occured, and event set
+ */
+int FileSwfDecompression(const uint8_t *buffer, uint32_t buffer_len,
+                         DetectEngineThreadCtx *det_ctx,
+                         int index,
+                         int swf_type,
+                         uint32_t decompress_depth,
+                         uint32_t compress_depth)
+{
+    int r = 0;
+
+    int compression_type = FileIsSwfFile(buffer, buffer_len);
+    if (compression_type == FILE_SWF_NO_COMPRESSION) {
+        return 0;
+    }
+
+    uint32_t offset = 0;
+    if (compression_type == FILE_SWF_ZLIB_COMPRESSION) {
+        /* compressed data start from the 4th bytes */
+        offset = 8;
+    } else if (compression_type == FILE_SWF_LZMA_COMPRESSION) {
+        /* compressed data start from the 17th bytes */
+        offset = 17;
+    }
+
+    if (buffer_len <= offset) {
+        DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_INVALID_SWF_LENGTH);
+        return 0;
+    }
+
+    uint32_t compressed_data_len = 0;
+    if (buffer_len > offset && compress_depth == 0) {
+        compressed_data_len = buffer_len - offset;
+    } else if (compress_depth > 0 && compress_depth <= buffer_len) {
+        compressed_data_len = compress_depth;
+    } else if (compress_depth > 0 && compress_depth > buffer_len) {
+        compressed_data_len = buffer_len;
+    }
+
+    /* get swf version */
+    uint8_t swf_version = FileGetSwfVersion(buffer, buffer_len);
+    if (compression_type == FILE_SWF_ZLIB_COMPRESSION &&
+        swf_version < SWF_ZLIB_MIN_VERSION)
+    {
+        DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_INVALID_SWF_VERSION);
+        return 0;
+    }
+    if (compression_type == FILE_SWF_LZMA_COMPRESSION &&
+        swf_version < SWF_LZMA_MIN_VERSION)
+    {
+        DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_INVALID_SWF_VERSION);
+        return 0;
+    }
+
+    /* get flash decompressed file length */
+    uint32_t decompressed_swf_len = FileGetSwfDecompressedLen(buffer, buffer_len);
+    if (decompressed_swf_len == 0) {
+        decompressed_swf_len = MIN_SWF_LEN;
+    }
+
+    /* if decompress_depth is 0, keep the flash file length */
+    uint32_t decompressed_data_len = (decompress_depth == 0) ? decompressed_swf_len : decompress_depth;
+    decompressed_data_len += 8;
+
+    if (det_ctx->hsbd[index].decompressed_buffer_len == 0 ||
+        det_ctx->hsbd[index].decompressed_buffer_len < decompressed_data_len) {
+        void *ptmp = NULL;
+        ptmp = SCRealloc(det_ctx->hsbd[index].decompressed_buffer,
+                         decompressed_data_len);
+        if (ptmp == NULL) {
+            DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_NO_MEM);
+            return 0;
+        }
+        det_ctx->hsbd[index].decompressed_buffer = ptmp;
+    }
+
+    det_ctx->hsbd[index].decompressed_buffer_len = decompressed_data_len;
+    memset(det_ctx->hsbd[index].decompressed_buffer, 0x00,
+           det_ctx->hsbd[index].decompressed_buffer_len);
+
+    /*
+     * FWS format
+     * | 4 bytes         | 4 bytes    | n bytes |
+     * | 'FWS' + version | script len | data    |
+     */
+    det_ctx->hsbd[index].decompressed_buffer[0] = 'F';
+    det_ctx->hsbd[index].decompressed_buffer[1] = 'W';
+    det_ctx->hsbd[index].decompressed_buffer[2] = 'S';
+    det_ctx->hsbd[index].decompressed_buffer[3] = swf_version;
+    memcpy(det_ctx->hsbd[index].decompressed_buffer  + 4, &decompressed_swf_len, 4);
+
+    if ((swf_type == HTTP_SWF_COMPRESSION_ZLIB || swf_type == HTTP_SWF_COMPRESSION_BOTH) &&
+        compression_type == FILE_SWF_ZLIB_COMPRESSION)
+    {
+        /* the first 8 bytes represents the fws header, see 'FWS format' above.
+         * data will start from 8th bytes
+         */
+        r = FileSwfZlibDecompression(det_ctx,
+                                     (uint8_t *)buffer + offset, compressed_data_len,
+                                     det_ctx->hsbd[index].decompressed_buffer + 8,
+                                     det_ctx->hsbd[index].decompressed_buffer_len - 8);
+        if (r == 0)
+            goto error;
+
+    } else if ((swf_type == HTTP_SWF_COMPRESSION_LZMA || swf_type == HTTP_SWF_COMPRESSION_BOTH) &&
+               compression_type == FILE_SWF_LZMA_COMPRESSION)
+    {
+        /* we need to setup the lzma header */
+        /*
+         * | 5 bytes         | 8 bytes             | n bytes         |
+         * | LZMA properties | Uncompressed length | Compressed data |
+         */
+        compressed_data_len += 13;
+        uint8_t *compressed_data = SCMalloc(compressed_data_len);
+        if (compressed_data == NULL) {
+            DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_NO_MEM);
+            goto error;
+        }
+        /* put lzma properties */
+        memcpy(compressed_data, buffer + 12, 5);
+        /* put lzma end marker */
+        memset(compressed_data + 5, 0xFF, 8);
+        /* put compressed data */
+        memcpy(compressed_data + 13, buffer + offset, compressed_data_len - 13);
+
+        /* the first 8 bytes represents the fws header, see 'FWS format' above.
+         * data will start from 8th bytes
+         */
+        r = FileSwfLzmaDecompression(det_ctx,
+                                     compressed_data, compressed_data_len,
+                                     det_ctx->hsbd[index].decompressed_buffer + 8,
+                                     det_ctx->hsbd[index].decompressed_buffer_len - 8);
+        SCFree(compressed_data);
+        if (r == 0)
+            goto error;
+    } else {
+        goto error;
+    }
+
+    return 1;
+
+error:
+    det_ctx->hsbd[index].decompressed_buffer_len = 0;
+    memset(det_ctx->hsbd[index].decompressed_buffer, 0x00,
+           det_ctx->hsbd[index].decompressed_buffer_len);
+    return 0;
+}

--- a/src/util-file-decompression.h
+++ b/src/util-file-decompression.h
@@ -1,0 +1,44 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/** \file
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ *
+ *
+ */
+
+#ifndef __UTIL_FILE_DECOMPRESSION_H__
+#define __UTIL_FILE_DECOMPRESSION_H__
+
+#include "detect.h"
+
+enum {
+    FILE_IS_NOT_SWF = 0,
+    FILE_SWF_NO_COMPRESSION,
+    FILE_SWF_ZLIB_COMPRESSION,
+    FILE_SWF_LZMA_COMPRESSION,
+};
+
+int FileIsSwfFile(const uint8_t *buffer, uint32_t buffer_len);
+int FileSwfDecompression(const uint8_t *buffer, uint32_t buffer_len,
+                         DetectEngineThreadCtx *det_ctx,
+                         int hsbd_index,
+                         int swf_type,
+                         uint32_t decompress_depth, uint32_t compress_depth);
+
+#endif /* __UTIL_FILE_DECOMPRESSION_H__ */

--- a/src/util-file-swf-decompression.c
+++ b/src/util-file-swf-decompression.c
@@ -1,0 +1,185 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/** \file
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ *
+ */
+
+
+#include "suricata.h"
+#include "suricata-common.h"
+
+#include "app-layer-htp.h"
+
+#include "util-file-decompression.h"
+#include "util-file-swf-decompression.h"
+#include "util-misc.h"
+#include "util-print.h"
+
+#include <zlib.h>
+
+#ifdef HAVE_LIBLZMA
+#include <lzma.h>
+#endif
+
+#define MAX_SWF_DECOMPRESSED_LEN 50000000
+/*
+ * Return uncompressed file length
+ * in little-endian order
+ */
+uint32_t FileGetSwfDecompressedLen(const uint8_t *buffer,
+                                   const uint32_t buffer_len)
+{
+    if (buffer_len < 8) {
+        return 0;
+    }
+
+    int a = buffer[4];
+    int b = buffer[5];
+    int c = buffer[6];
+    int d = buffer[7];
+
+    uint32_t value = (((a & 0xff) << 24) | ((b & 0xff) << 16) | ((c & 0xff) << 8) | (d & 0xff));
+
+    uint32_t len = (((value >> 24) & 0x000000FF) | ((value >> 8) & 0x0000FF00) |
+                   ((value << 8) & 0x00FF0000) | ((value << 24) & 0xFF000000));
+
+    return MIN(MAX_SWF_DECOMPRESSED_LEN, len);
+}
+
+uint8_t FileGetSwfVersion(const uint8_t *buffer, const uint32_t buffer_len)
+{
+    if (buffer_len > 3)
+        return buffer[3];
+
+    return 0;
+}
+
+/* CWS format */
+/*
+ * | 4 bytes         | 4 bytes    | n bytes         |
+ * | 'CWS' + version | script len | compressed data |
+ */
+int FileSwfZlibDecompression(DetectEngineThreadCtx *det_ctx,
+                             uint8_t *compressed_data, uint32_t compressed_data_len,
+                             uint8_t *decompressed_data, uint32_t decompressed_data_len)
+{
+    int ret = 1;
+    z_stream infstream;
+    infstream.zalloc = Z_NULL;
+    infstream.zfree = Z_NULL;
+    infstream.opaque = Z_NULL;
+
+    infstream.avail_in = (uInt)compressed_data_len;
+    infstream.next_in = (Bytef *)compressed_data;
+    infstream.avail_out = (uInt)decompressed_data_len;
+    infstream.next_out = (Bytef *)decompressed_data;
+
+    inflateInit(&infstream);
+    int result = inflate(&infstream, Z_NO_FLUSH);
+    switch(result) {
+        case Z_STREAM_END:
+            break;
+        case Z_OK:
+            break;
+        case Z_DATA_ERROR:
+            DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_Z_DATA_ERROR);
+            ret = 0;
+            break;
+        case Z_STREAM_ERROR:
+            DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_Z_STREAM_ERROR);
+            ret = 0;
+            break;
+        case Z_BUF_ERROR:
+            DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_Z_BUF_ERROR);
+            ret = 0;
+            break;
+        default:
+            DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_Z_UNKNOWN_ERROR);
+            ret = 0;
+            break;
+    }
+    inflateEnd(&infstream);
+
+    return ret;
+}
+
+/* ZWS format */
+/*
+ * | 4 bytes         | 4 bytes    | 4 bytes        | 5 bytes    | n bytes   | 6 bytes         |
+ * | 'ZWS' + version | script len | compressed len | LZMA props | LZMA data | LZMA end marker |
+ */
+int FileSwfLzmaDecompression(DetectEngineThreadCtx *det_ctx,
+                             uint8_t *compressed_data, uint32_t compressed_data_len,
+                             uint8_t *decompressed_data, uint32_t decompressed_data_len)
+{
+#ifdef HAVE_LIBLZMA
+    int ret = 1;
+    lzma_stream strm = LZMA_STREAM_INIT;
+    lzma_ret result = lzma_alone_decoder(&strm, UINT64_MAX /* memlimit */);
+    if (result != LZMA_OK) {
+        DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_DECODER_ERROR);
+        return 0;
+    }
+
+    strm.avail_in = compressed_data_len;
+    strm.next_in = compressed_data;
+    strm.avail_out = decompressed_data_len;
+    strm.next_out = decompressed_data;
+
+    result = lzma_code(&strm, LZMA_RUN);
+    switch(result) {
+        case LZMA_STREAM_END:
+            break;
+        case LZMA_OK:
+            break;
+        case LZMA_MEMLIMIT_ERROR:
+            DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_MEMLIMIT_ERROR);
+            ret = 0;
+            break;
+        case LZMA_OPTIONS_ERROR:
+            DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_OPTIONS_ERROR);
+            ret = 0;
+            break;
+        case LZMA_FORMAT_ERROR:
+            DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_FORMAT_ERROR);
+            ret = 0;
+            break;
+        case LZMA_DATA_ERROR:
+            DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_DATA_ERROR);
+            ret = 0;
+            break;
+        case LZMA_BUF_ERROR:
+            DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_BUF_ERROR);
+            ret = 0;
+            break;
+        default:
+            DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_UNKNOWN_ERROR);
+            ret = 0;
+            break;
+    }
+
+    lzma_end(&strm);
+    return ret;
+#else
+    return 0;
+#endif /* HAVE_LIBLZMA */
+}
+
+

--- a/src/util-file-swf-decompression.h
+++ b/src/util-file-swf-decompression.h
@@ -1,0 +1,42 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/** \file
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ *
+ *
+ */
+
+#ifndef __UTIL_FILE_SWF_DECOMPRESSION_H__
+#define __UTIL_FILE_SWF_DECOMPRESSION_H__
+
+/* If we don't have the decompressed data len,
+ * we use a default value.
+ */
+#define MIN_SWF_LEN    2920
+
+uint8_t FileGetSwfVersion(const uint8_t *buffer, const uint32_t buffer_len);
+uint32_t FileGetSwfDecompressedLen(const uint8_t *buffer, uint32_t buffr_len);
+int FileSwfZlibDecompression(DetectEngineThreadCtx *det_ctx,
+                             uint8_t *compressed_data, uint32_t compressed_data_len,
+                             uint8_t *decompressed_data, uint32_t decompressed_data_len);
+int FileSwfLzmaDecompression(DetectEngineThreadCtx *det_ctx,
+                             uint8_t *compressed_data, uint32_t compressed_data_len,
+                             uint8_t *decompressed_data, uint32_t decompressed_data_len);
+
+#endif /* __UTIL_FILE_SWF_DECOMPRESSION_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -827,6 +827,20 @@ app-layer:
            # auto will use http-body-inline mode in IPS mode, yes or no set it statically
            http-body-inline: auto
 
+           # Decompress SWF files.
+           # 2 types: 'deflate', 'lzma', 'both' will decompress deflate and lzma
+           # compress-depth:
+           # Specifies the maximum amount of data to decompress,
+           # set 0 for unlimited.
+           # decompress-depth:
+           # Specifies the maximum amount of decompressed data to obtain,
+           # set 0 for unlimited.
+           swf-decompression:
+             enabled: yes
+             type: both
+             compress-depth: 0
+             decompress-depth: 0
+
            # Take a random value for inspection sizes around the specified value.
            # This lower the risk of some evasion technics but could lead
            # detection change between runs. It is set to 'yes' by default.


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/1600

Describe changes:

This addresses comments in the previous PR (https://github.com/OISF/suricata/pull/2867), in particular: 
- `needs_detctx` is declared as `bool` rather than `int`
- Unit tests for detect-engine-hsbd moved in `src/tests` dir, conditions and function like `SigGroupCleanup`, `SigCleanSignatures` are removed
- `MIN` macro added in `FileGetSwfDecompressedLen`

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/148
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/12

