### PR TITLE
travis - rust improvements - v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,17 @@ default-cflags: &default-cflags
   CFLAGS="-Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-function"
 
 matrix:
+  allow_failures:
+    # Allow the rust-stable build to fail. These entries must match
+    # the env entry in the build matrix exactly.
+    - env:
+        - NAME="linux,gcc,rust-stable"
+        - *default-cflags
+        - ENABLE_RUST="yes"
+        - RUST_VERSION="stable"
+        - ARGS="--enable-rust --enable-rust-strict"
+        - DO_CHECK_SETUP_SCRIPTS="yes"
+        - DO_DISTCHECK="yes"
   include:
     # Linux, gcc, coccinelle.
     - os: linux
@@ -58,14 +69,17 @@ matrix:
             - *packages
             - coccinelle
     # Linux, gcc, Rust (latest stable).
+    # This is allowed to fail, update allow_failures if the env changes.
     - os: linux
       compiler: gcc
       env:
-        - NAME="linux,gcc,rust"
+        - NAME="linux,gcc,rust-stable"
         - *default-cflags
         - ENABLE_RUST="yes"
+        - RUST_VERSION="stable"
         - ARGS="--enable-rust --enable-rust-strict"
         - DO_CHECK_SETUP_SCRIPTS="yes"
+        - DO_DISTCHECK="yes"
     # Linux, gcc, Rust.
     # - Rust 1.21.0, the latest known working version.
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,17 @@ matrix:
         - ENABLE_RUST="yes"
         - ARGS="--enable-rust --enable-rust-strict"
         - DO_CHECK_SETUP_SCRIPTS="yes"
+    # Linux, gcc, Rust.
+    # - Rust 1.21.0, the latest known working version.
+    - os: linux
+      compiler: gcc
+      env:
+        - NAME="linux,gcc,rust-1.21.0"
+        - *default-cflags
+        - ENABLE_RUST="yes"
+        - RUST_VERSION="1.21.0"
+        - ARGS="--enable-rust --enable-rust-strict"
+        - DO_DISTCHECK="yes"
     # Linux, gcc, Rust (1.15.0 - oldest supported).
     - os: linux
       compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ matrix:
         - ENABLE_RUST="yes"
         - RUST_VERSION="1.15.0"
         - ARGS="--enable-rust --enable-rust-strict"
+        - DO_DISTCHECK="yes"
     # Linux, gcc, -DNDEBUG.
     - os: linux
       compiler: gcc
@@ -153,6 +154,10 @@ script:
         make ${j} check 2> stderr.log
     else
         make ${j} check
+    fi
+  - |
+    if [[ "$DO_DISTCHECK" == "yes" ]]; then
+        make distcheck DISTCHECK_CONFIGURE_FLAGS="${ARGS}"
     fi
   - |
     if [[ "$DO_CHECK_SETUP_SCRIPTS" == "yes" ]]; then


### PR DESCRIPTION
This PR addresses 3 Redmine tickets with respect to Rust and Travis:

- Pin Rustup to version 1.21, in addition to the build pinned at 1.15 as the lowest supported version.
  https://redmine.openinfosecfoundation.org/issues/2247

- Non-pinned Rust build that is allowed to fail.
  https://redmine.openinfosecfoundation.org/issues/2248

- For all Rust builds, do a make distcheck. I did this for all builds as the Rust version may cause different results here.
  https://redmine.openinfosecfoundation.org/issues/2246

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/213
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/566
