### PR TITLE
valgrind: suppressions for AFP/AutoFP NIC offloading calls

### DIFF
--- a/qa/valgrind.suppress
+++ b/qa/valgrind.suppress
@@ -65,5 +65,103 @@
    fun:DetectIPProtoParse
    fun:DetectIPProtoTestParse02
 }
-
+{
+   AFP - NIC GET offloading
+   Memcheck:Param
+   ioctl(SIOCETHTOOL)
+   fun:ioctl
+   fun:GetEthtoolValue
+   fun:DisableIfaceOffloadingLinux
+   fun:DisableIfaceOffloading
+   fun:ParseAFPConfig
+   fun:RunModeSetLiveCaptureWorkers
+   fun:RunModeIdsAFPWorkers
+   fun:RunModeDispatch
+   fun:main
+}
+{
+   AFP - NIC SET offloading
+   Memcheck:Param
+   ioctl(SIOCETHTOOL)
+   fun:ioctl
+   fun:SetEthtoolValue
+   fun:DisableIfaceOffloadingLinux
+   fun:DisableIfaceOffloading
+   fun:ParseAFPConfig
+   fun:RunModeSetLiveCaptureWorkers
+   fun:RunModeIdsAFPWorkers
+   fun:RunModeDispatch
+   fun:main
+}
+{
+   NIC Set restore offloading
+   Memcheck:Param
+   ioctl(SIOCETHTOOL)
+   fun:ioctl
+   fun:SetEthtoolValue
+   fun:RestoreIfaceOffloadingLinux
+   fun:RestoreIfaceOffloading
+   fun:LiveDeviceListClean
+   fun:GlobalsDestroy
+   fun:main
+}
+{
+   Autofp - NIC Get offloading
+   Memcheck:Param
+   ioctl(SIOCETHTOOL)
+   fun:ioctl
+   fun:GetEthtoolValue
+   fun:GetIfaceOffloadingLinux
+   fun:GetIfaceOffloading
+   fun:ReceivePcapThreadInit
+   fun:TmThreadsSlotPktAcqLoop
+   fun:start_thread
+   fun:clone
+}
+{
+   Autofp - NIC Get disable offloading
+   Memcheck:Param
+   ioctl(SIOCETHTOOL)
+   fun:ioctl
+   fun:GetEthtoolValue
+   fun:DisableIfaceOffloadingLinux
+   fun:DisableIfaceOffloading
+   fun:ReceivePcapThreadInit
+   fun:TmThreadsSlotPktAcqLoop
+   fun:start_thread
+   fun:clone
+}
+{
+   Autofp - NIC Set disable offloading
+   Memcheck:Param
+   ioctl(SIOCETHTOOL)
+   fun:ioctl
+   fun:SetEthtoolValue
+   fun:DisableIfaceOffloadingLinux
+   fun:DisableIfaceOffloading
+   fun:ReceivePcapThreadInit
+   fun:TmThreadsSlotPktAcqLoop
+   fun:start_thread
+   fun:clone
+}
+{
+   Autofp - NIC GetIfaceOffloading
+   Memcheck:Cond
+   fun:GetIfaceOffloadingLinux
+   fun:GetIfaceOffloading
+   fun:ReceivePcapThreadInit
+   fun:TmThreadsSlotPktAcqLoop
+   fun:start_thread
+   fun:clone
+}
+{
+   Autofp - NIC DisableIfaceOffloading
+   Memcheck:Cond
+   fun:DisableIfaceOffloadingLinux
+   fun:DisableIfaceOffloading
+   fun:ReceivePcapThreadInit
+   fun:TmThreadsSlotPktAcqLoop
+   fun:start_thread
+   fun:clone
+}
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:  
https://redmine.openinfosecfoundation.org/issues/2230  

Describe changes:
- suppressions for AFP/AutoFP NIC offloading calls

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

