### PR TITLE
Pcap Directory Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.DS_Store
 *.o
 *.lo
 *.in

--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -25,7 +25,9 @@
 
 .. option:: -r <path>
 
-   Run in pcap offline mode reading files from pcap file.
+   Run in pcap offline mode reading files from pcap file. If <path> specifies
+   a directory, all files in that directory will be processed in order of modified time
+   maintaining flow state between files.
 
 .. option::  -i <interface>
 

--- a/doc/userguide/unix-socket.rst
+++ b/doc/userguide/unix-socket.rst
@@ -48,7 +48,11 @@ example to write custom scripts:
 
 Commands in standard running mode
 ---------------------------------
+You may need to install suricatasc if you have not done so, running the following command from scripts/suricatasc
 
+::
+
+  sudo python setup.py install
 
 The set of existing commands is the following:
 
@@ -152,9 +156,11 @@ You can add multiple files without waiting the result: they will be
 sequentially processed and the generated log/alert files will be put
 into the directory specified as second arguments of the pcap-file
 command. You need to provide absolute path to the files and directory
-as suricata don’t know from where the script has been run.
+as suricata doesn’t know from where the script has been run. If you pass
+a directory instead of a file, all files in the directory will be processed
+until you use ``pcap-interrupt`` or delete/move the directory.
 
-To know how much files are waiting to get processed, you can do:
+To know how many files are waiting to get processed, you can do:
   
 ::
   
@@ -175,6 +181,22 @@ To get current processed file:
   >>> pcap-current
   Success:
   "/tmp/test.pcap"
+
+When passing in a directory, you can see last processed time (modified time of last file):
+
+::
+
+  >>> pcap-last-processed
+  Success:
+  1509138964000
+
+To interrupt directory processing which terminates the current state:
+
+::
+
+  >>> pcap-interrupt
+  Success:
+  "Interrupted"
 
 Build your own client
 ---------------------

--- a/scripts/suricatasc/src/suricatasc.py
+++ b/scripts/suricatasc/src/suricatasc.py
@@ -80,7 +80,7 @@ class SuricataCompleter:
 
 class SuricataSC:
     def __init__(self, sck_path, verbose=False):
-        self.cmd_list=['shutdown','quit','pcap-file','pcap-file-number','pcap-file-list','iface-list','iface-stat','register-tenant','unregister-tenant','register-tenant-handler','unregister-tenant-handler', 'add-hostbit', 'remove-hostbit', 'list-hostbit']
+        self.cmd_list=['shutdown','quit','pcap-file','pcap-file-number','pcap-file-list','pcap-last-processed','pcap-interrupt','iface-list','iface-stat','register-tenant','unregister-tenant','register-tenant-handler','unregister-tenant-handler', 'add-hostbit', 'remove-hostbit', 'list-hostbit']
         self.sck_path = sck_path
         self.verbose = verbose
 

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -51,13 +51,15 @@ typedef struct PcapFiles_ {
     char *filename;
     char *output_dir;
     int tenant_id;
+    time_t delay;
+    time_t poll_interval;
     TAILQ_ENTRY(PcapFiles_) next;
 } PcapFiles;
 
 typedef struct PcapCommand_ {
     TAILQ_HEAD(, PcapFiles_) files;
     int running;
-    char *currentfile;
+    PcapFiles *current_file;
 } PcapCommand;
 
 const char *RunModeUnixSocketGetDefaultMode(void)
@@ -68,8 +70,10 @@ const char *RunModeUnixSocketGetDefaultMode(void)
 #ifdef BUILD_UNIX_SOCKET
 
 static int RunModeUnixSocketMaster(void);
-static int unix_manager_file_task_running = 0;
-static int unix_manager_file_task_failed = 0;
+static int unix_manager_pcap_task_running = 0;
+static int unix_manager_pcap_task_failed = 0;
+static int unix_manager_pcap_task_interrupted = 0;
+static time_t unix_manager_pcap_last_processed = 0;
 
 /**
  * \brief return list of files in the queue
@@ -124,15 +128,29 @@ static TmEcode UnixSocketPcapCurrent(json_t *cmd, json_t* answer, void *data)
 {
     PcapCommand *this = (PcapCommand *) data;
 
-    if (this->currentfile) {
-        json_object_set_new(answer, "message", json_string(this->currentfile));
+    if (this->current_file && this->current_file->filename) {
+        json_object_set_new(answer, "message", json_string(this->current_file->filename));
     } else {
         json_object_set_new(answer, "message", json_string("None"));
     }
     return TM_ECODE_OK;
 }
 
+static TmEcode UnixSocketPcapLastProcessed(json_t *cmd, json_t *answer, void *data)
+{
+    json_object_set_new(answer, "message", json_integer(unix_manager_pcap_last_processed * 1000));
 
+    return TM_ECODE_OK;
+}
+
+static TmEcode UnixSocketPcapInterrupt(json_t *cmd, json_t *answer, void *data)
+{
+    unix_manager_pcap_task_interrupted = 1;
+
+    json_object_set_new(answer, "message", json_string("Interrupted"));
+
+    return TM_ECODE_OK;
+}
 
 static void PcapFilesFree(PcapFiles *cfile)
 {
@@ -154,8 +172,7 @@ static void PcapFilesFree(PcapFiles *cfile)
  *
  * \retval 0 in case of error, 1 in case of success
  */
-static TmEcode UnixListAddFile(PcapCommand *this,
-        const char *filename, const char *output_dir, int tenant_id)
+static TmEcode UnixListAddFile(PcapCommand *this, const char *filename, const char *output_dir, int tenant_id, time_t delay, time_t poll_interval)
 {
     PcapFiles *cfile = NULL;
     if (filename == NULL || this == NULL)
@@ -185,6 +202,8 @@ static TmEcode UnixListAddFile(PcapCommand *this,
     }
 
     cfile->tenant_id = tenant_id;
+    cfile->delay = delay;
+    cfile->poll_interval = poll_interval;
 
     TAILQ_INSERT_TAIL(&this->files, cfile, next);
     return TM_ECODE_OK;
@@ -200,10 +219,11 @@ static TmEcode UnixListAddFile(PcapCommand *this,
 static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
 {
     PcapCommand *this = (PcapCommand *) data;
-    int ret;
     const char *filename;
     const char *output_dir;
     int tenant_id = 0;
+    time_t delay = 30;
+    time_t poll_interval = 5;
 #ifdef OS_WIN32
     struct _stat st;
 #else
@@ -212,8 +232,8 @@ static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
 
     json_t *jarg = json_object_get(cmd, "filename");
     if(!json_is_string(jarg)) {
-        SCLogInfo("error: command is not a string");
-        json_object_set_new(answer, "message", json_string("command is not a string"));
+        SCLogError(SC_ERR_INVALID_ARGUMENT, "error: filename is not a string");
+        json_object_set_new(answer, "message", json_string("filename is not a string"));
         return TM_ECODE_FAILED;
     }
     filename = json_string_value(jarg);
@@ -222,21 +242,21 @@ static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
 #else
     if(stat(filename, &st) != 0) {
 #endif /* OS_WIN32 */
-        json_object_set_new(answer, "message", json_string("File does not exist"));
+        json_object_set_new(answer, "message", json_string("filename does not exist"));
         return TM_ECODE_FAILED;
     }
 
     json_t *oarg = json_object_get(cmd, "output-dir");
     if (oarg != NULL) {
         if(!json_is_string(oarg)) {
-            SCLogInfo("error: output dir is not a string");
-            json_object_set_new(answer, "message", json_string("output dir is not a string"));
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "error: output-dir is not a string");
+            json_object_set_new(answer, "message", json_string("output-dir is not a string"));
             return TM_ECODE_FAILED;
         }
         output_dir = json_string_value(oarg);
     } else {
-        SCLogInfo("error: can't get output-dir");
-        json_object_set_new(answer, "message", json_string("output dir param is mandatory"));
+        SCLogError(SC_ERR_INVALID_ARGUMENT, "error: can't get output-dir");
+        json_object_set_new(answer, "message", json_string("output-dir param is mandatory"));
         return TM_ECODE_FAILED;
     }
 
@@ -245,22 +265,42 @@ static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
 #else
     if(stat(output_dir, &st) != 0) {
 #endif /* OS_WIN32 */
-        json_object_set_new(answer, "message", json_string("Output directory does not exist"));
+        json_object_set_new(answer, "message", json_string("output-dir does not exist"));
         return TM_ECODE_FAILED;
     }
 
     json_t *targ = json_object_get(cmd, "tenant");
     if (targ != NULL) {
-        if(!json_is_number(targ)) {
+        if(!json_is_boolean(targ)) {
             json_object_set_new(answer, "message", json_string("tenant is not a number"));
             return TM_ECODE_FAILED;
         }
         tenant_id = json_number_value(targ);
     }
 
-    ret = UnixListAddFile(this, filename, output_dir, tenant_id);
-    switch(ret) {
+    json_t *delay_arg = json_object_get(cmd, "delay");
+    if(delay_arg != NULL) {
+        if(!json_is_integer(delay_arg)) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "error: delay is not a integer");
+            json_object_set_new(answer, "message", json_string("delay is not a integer"));
+            return TM_ECODE_FAILED;
+        }
+        delay = json_integer_value(delay_arg);
+    }
+
+    json_t *interval_arg = json_object_get(cmd, "poll-interval");
+    if(interval_arg != NULL) {
+        if(!json_is_integer(interval_arg)) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "error: poll-interval is not a integer");
+            json_object_set_new(answer, "message", json_string("poll-interval is not a integer"));
+            return TM_ECODE_FAILED;
+        }
+        poll_interval = json_integer_value(interval_arg);
+    }
+
+    switch(UnixListAddFile(this, filename, output_dir, tenant_id, delay, poll_interval)) {
         case TM_ECODE_FAILED:
+        case TM_ECODE_DONE:
             json_object_set_new(answer, "message", json_string("Unable to add file to list"));
             return TM_ECODE_FAILED;
         case TM_ECODE_OK:
@@ -287,21 +327,23 @@ static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
 static TmEcode UnixSocketPcapFilesCheck(void *data)
 {
     PcapCommand *this = (PcapCommand *) data;
-    if (unix_manager_file_task_running == 1) {
+    if (unix_manager_pcap_task_running == 1) {
         return TM_ECODE_OK;
     }
-    if ((unix_manager_file_task_failed == 1) || (this->running == 1)) {
-        if (unix_manager_file_task_failed) {
+    if ((unix_manager_pcap_task_failed == 1) || (this->running == 1)) {
+        if (unix_manager_pcap_task_failed) {
             SCLogInfo("Preceeding task failed, cleaning the running mode");
         }
-        unix_manager_file_task_failed = 0;
+        unix_manager_pcap_task_failed = 0;
         this->running = 0;
-        if (this->currentfile) {
-            SCFree(this->currentfile);
-        }
-        this->currentfile = NULL;
 
+        SCLogInfo("Resetting engine state");
         PostRunDeinit(RUNMODE_PCAP_FILE, NULL /* no ts */);
+
+        if (this->current_file) {
+            PcapFilesFree(this->current_file);
+        }
+        this->current_file = NULL;
     }
     if (TAILQ_EMPTY(&this->files)) {
         // nothing to do
@@ -310,41 +352,62 @@ static TmEcode UnixSocketPcapFilesCheck(void *data)
 
     PcapFiles *cfile = TAILQ_FIRST(&this->files);
     TAILQ_REMOVE(&this->files, cfile, next);
-    SCLogInfo("Starting run for '%s'", cfile->filename);
-    unix_manager_file_task_running = 1;
+
+    unix_manager_pcap_task_running = 1;
     this->running = 1;
-    if (ConfSet("pcap-file.file", cfile->filename) != 1) {
-        SCLogError(SC_ERR_INVALID_ARGUMENTS,
-                "Can not set working file to '%s'", cfile->filename);
+
+    if (ConfSetFinal("pcap-file.file", cfile->filename) != 1) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT,
+            "Can not set working file to '%s'", cfile->filename);
         PcapFilesFree(cfile);
         return TM_ECODE_FAILED;
     }
-    if (cfile->output_dir) {
-        if (ConfSet("default-log-dir", cfile->output_dir) != 1) {
-            SCLogError(SC_ERR_INVALID_ARGUMENTS,
-                    "Can not set output dir to '%s'", cfile->output_dir);
+
+    if(cfile->delay > 0) {
+        char tstr[32];
+        snprintf(tstr, sizeof(tstr), "%ld", cfile->delay);
+        if (ConfSetFinal("pcap-file.delay", tstr) != 1) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT,
+                "Can not set delay to '%s'", tstr);
             PcapFilesFree(cfile);
             return TM_ECODE_FAILED;
         }
     }
+
+    if(cfile->poll_interval > 0) {
+        char tstr[32];
+        snprintf(tstr, sizeof(tstr), "%ld", cfile->poll_interval);
+        if (ConfSetFinal("pcap-file.poll-interval", tstr) != 1) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT,
+                "Can not set poll-interval to '%s'", tstr);
+            PcapFilesFree(cfile);
+            return TM_ECODE_FAILED;
+        }
+    }
+
     if (cfile->tenant_id > 0) {
         char tstr[16];
         snprintf(tstr, sizeof(tstr), "%d", cfile->tenant_id);
-        if (ConfSet("pcap-file.tenant-id", tstr) != 1) {
-            SCLogError(SC_ERR_INVALID_ARGUMENTS,
-                    "Can not set working tenant-id to '%s'", tstr);
+        if (ConfSetFinal("pcap-file.tenant-id", tstr) != 1) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT,
+                "Can not set working tenant-id to '%s'", tstr);
             PcapFilesFree(cfile);
             return TM_ECODE_FAILED;
         }
     } else {
         SCLogInfo("pcap-file.tenant-id not set");
     }
-    this->currentfile = SCStrdup(cfile->filename);
-    if (unlikely(this->currentfile == NULL)) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Failed file name allocation");
-        return TM_ECODE_FAILED;
+
+    if (cfile->output_dir) {
+        if (ConfSetFinal("default-log-dir", cfile->output_dir) != 1) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT,
+                    "Can not set output dir to '%s'", cfile->output_dir);
+            PcapFilesFree(cfile);
+            return TM_ECODE_FAILED;
+        }
     }
-    PcapFilesFree(cfile);
+
+    this->current_file = cfile;
 
     PreRunInit(RUNMODE_PCAP_FILE);
     PreRunPostPrivsDropInit(RUNMODE_PCAP_FILE);
@@ -353,6 +416,9 @@ static TmEcode UnixSocketPcapFilesCheck(void *data)
     /* Un-pause all the paused threads */
     TmThreadWaitOnThreadInit();
     TmThreadContinueThreads();
+
+    SCLogInfo("Starting run for '%s'", this->current_file->filename);
+
     return TM_ECODE_OK;
 }
 #endif
@@ -369,24 +435,32 @@ void RunModeUnixSocketRegister(void)
                               RunModeUnixSocketMaster);
     default_mode = "autofp";
 #endif
-    return;
 }
 
-void UnixSocketPcapFile(TmEcode tm)
+TmEcode UnixSocketPcapFile(TmEcode tm, time_t last_processed)
 {
 #ifdef BUILD_UNIX_SOCKET
+    unix_manager_pcap_last_processed = last_processed;
     switch (tm) {
         case TM_ECODE_DONE:
-            unix_manager_file_task_running = 0;
-            break;
+            SCLogInfo("Marking current task as done");
+            unix_manager_pcap_task_running = 0;
+            return TM_ECODE_DONE;
         case TM_ECODE_FAILED:
-            unix_manager_file_task_running = 0;
-            unix_manager_file_task_failed = 1;
-            break;
+            SCLogInfo("Marking current task as failed");
+            unix_manager_pcap_task_running = 0;
+            unix_manager_pcap_task_failed = 1;
+            return TM_ECODE_DONE; //if we return failed, we can't stop the thread and suricata will fail to close
         case TM_ECODE_OK:
-            break;
+            if(unix_manager_pcap_task_interrupted == 1) {
+                SCLogInfo("Interrupting current run mode");
+                return TM_ECODE_DONE;
+            } else {
+                return TM_ECODE_OK;
+            }
     }
 #endif
+    return TM_ECODE_FAILED;
 }
 
 #ifdef BUILD_UNIX_SOCKET
@@ -1029,11 +1103,13 @@ static int RunModeUnixSocketMaster(void)
     }
     TAILQ_INIT(&pcapcmd->files);
     pcapcmd->running = 0;
-    pcapcmd->currentfile = NULL;
+    pcapcmd->current_file = NULL;
 
     UnixManagerRegisterCommand("pcap-file", UnixSocketAddPcapFile, pcapcmd, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("pcap-file-number", UnixSocketPcapFilesNumber, pcapcmd, 0);
     UnixManagerRegisterCommand("pcap-file-list", UnixSocketPcapFilesList, pcapcmd, 0);
+    UnixManagerRegisterCommand("pcap-last-processed", UnixSocketPcapLastProcessed, pcapcmd, 0);
+    UnixManagerRegisterCommand("pcap-interrupt", UnixSocketPcapInterrupt, pcapcmd, 0);
     UnixManagerRegisterCommand("pcap-current", UnixSocketPcapCurrent, pcapcmd, 0);
 
     UnixManagerRegisterBackgroundTask(UnixSocketPcapFilesCheck, pcapcmd);

--- a/src/runmode-unix-socket.h
+++ b/src/runmode-unix-socket.h
@@ -28,7 +28,7 @@ const char *RunModeUnixSocketGetDefaultMode(void);
 
 int RunModeUnixSocketIsActive(void);
 
-void UnixSocketPcapFile(TmEcode tm);
+TmEcode UnixSocketPcapFile(TmEcode tm, time_t last_processed);
 
 #ifdef BUILD_UNIX_SOCKET
 TmEcode UnixSocketRegisterTenantHandler(json_t *cmd, json_t* answer, void *data);

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -45,6 +45,14 @@
 #include "util-checksum.h"
 #include "util-atomic.h"
 
+//directory support
+#include <dirent.h> // dirent
+#include <limits.h> // PATH_MAX
+#include <sys/types.h>  // stat
+#include <sys/stat.h>   // stat
+#include <unistd.h>     // stat
+#include "util-buffer.h"
+
 #ifdef __SC_CUDA_SUPPORT__
 
 #include "util-cuda.h"
@@ -60,38 +68,76 @@
 extern int max_pending_packets;
 
 typedef struct PcapFileGlobalVars_ {
-    pcap_t *pcap_handle;
-    int (*Decoder)(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
-    int datalink;
-    struct bpf_program filter;
     uint64_t cnt; /** packet counter */
     ChecksumValidationMode conf_checksum_mode;
     ChecksumValidationMode checksum_mode;
     SC_ATOMIC_DECLARE(unsigned int, invalid_checksums);
-
 } PcapFileGlobalVars;
 
-typedef struct PcapFileThreadVars_
+typedef struct PcapFileSharedVars_
 {
+    char *bpf_string;
+
     uint32_t tenant_id;
 
-    /* counters */
-    uint32_t pkts;
-    uint64_t bytes;
+    time_t last_processed;
 
     ThreadVars *tv;
     TmSlot *slot;
 
-    /** callback result -- set if one of the thread module failed. */
-    int cb_result;
+    /* counters */
+    uint64_t pkts;
+    uint64_t bytes;
+    uint64_t files;
 
     uint8_t done;
     uint32_t errs;
+
+    /** callback result -- set if one of the thread module failed. */
+    int cb_result;
+} PcapFileSharedVars;
+
+typedef struct PcapFileFileVars_
+{
+    char *filename;
+    pcap_t *pcap_handle;
+
+    int datalink;
+    struct bpf_program filter;
+
+    PcapFileSharedVars *shared;
+} PcapFileFileVars;
+
+typedef struct PcapFileDirectoryVars_
+{
+    char *filename;
+    DIR *directory;
+    PcapFileFileVars *current_file;
+    time_t delay;
+    time_t poll_interval;
+
+    PcapFileSharedVars *shared;
+} PcapFileDirectoryVars;
+
+typedef union PcapFileBehaviorVar_
+{
+    PcapFileDirectoryVars *directory;
+    PcapFileFileVars *file;
+} PcapFileBehaviorVar;
+
+typedef struct PcapFileThreadVars_
+{
+    PcapFileBehaviorVar behavior;
+    int is_directory;
+
+    PcapFileSharedVars shared;
 } PcapFileThreadVars;
 
 static PcapFileGlobalVars pcap_g;
 
 TmEcode ReceivePcapFileLoop(ThreadVars *, void *, void *);
+TmEcode ReceivePcapFileFileLoop(PcapFileThreadVars *tv, PcapFileFileVars *ptv);
+TmEcode ReceivePcapFileDirectoryLoop(PcapFileThreadVars *tv, PcapFileDirectoryVars *ptv);
 
 TmEcode ReceivePcapFileThreadInit(ThreadVars *, const void *, void **);
 void ReceivePcapFileThreadExitStats(ThreadVars *, void *);
@@ -101,6 +147,351 @@ TmEcode DecodePcapFile(ThreadVars *, Packet *, void *, PacketQueue *, PacketQueu
 TmEcode DecodePcapFileThreadInit(ThreadVars *, const void *, void **);
 TmEcode DecodePcapFileThreadDeinit(ThreadVars *tv, void *data);
 
+TmEcode InitPcapFile(PcapFileFileVars *pfv, const char *filename);
+TmEcode PcapRunStatus(PcapFileDirectoryVars *);
+void CleanupPcapFileDirectoryVars(PcapFileThreadVars *tv, PcapFileDirectoryVars *ptv);
+void CleanupPcapFileFileVars(PcapFileThreadVars *tv, PcapFileFileVars *ptv);
+void CleanupPcapFileThreadVars(PcapFileThreadVars *tv);
+TmEcode PcapDirectoryFailure(PcapFileThreadVars *tv, PcapFileDirectoryVars *ptv);
+TmEcode PcapDirectoryDone(PcapFileThreadVars *tv, PcapFileDirectoryVars *ptv);
+TmEcode PcapCheckFile(char *filename, DIR **directory);
+int PcapDirectoryGetModifiedTime(char const * file, struct timespec * out);
+int PcapDirectorySortByStatTime(const void * vleft, const void * vright);
+void FreeDirectoryMemBuffer(MemBuffer * buffer);
+TmEcode PcapDirectoryPopulateBuffer(PcapFileDirectoryVars *ptv, time_t newer_than, time_t older_than, time_t *first_new_file_time, MemBuffer **directory_content);
+TmEcode PcapDirectoryDispatch(PcapFileThreadVars *tv, PcapFileDirectoryVars *ptv, time_t *newer_than, time_t *older_than, time_t * first_new_file_time);
+
+/**
+ * Pcap Folder Utilities
+ */
+TmEcode PcapRunStatus(PcapFileDirectoryVars *ptv)
+{
+    if(RunModeUnixSocketIsActive()) {
+        if( (suricata_ctl_flags & SURICATA_STOP) || UnixSocketPcapFile(TM_ECODE_OK, ptv->shared->last_processed) != TM_ECODE_OK ) {
+            SCReturnInt(TM_ECODE_DONE);
+        }
+    } else {
+        if(suricata_ctl_flags & SURICATA_STOP) {
+            SCReturnInt(TM_ECODE_DONE);
+        }
+    }
+    SCReturnInt(TM_ECODE_OK);
+}
+
+void CleanupPcapFileFileVars(PcapFileThreadVars *tv, PcapFileFileVars *pfv)
+{
+    if(pfv->pcap_handle != NULL) {
+        pcap_close(pfv->pcap_handle);
+        pfv->pcap_handle = NULL;
+    }
+    if(pfv->filename != NULL) {
+        SCFree(pfv->filename);
+        pfv->filename = NULL;
+    }
+    if(tv->is_directory == 0) {
+        tv->behavior.file = NULL;
+    }
+    pfv->shared = NULL;
+    SCFree(pfv);
+}
+
+void CleanupPcapFileDirectoryVars(PcapFileThreadVars *tv, PcapFileDirectoryVars *ptv)
+{
+    if(ptv->current_file != NULL) {
+        CleanupPcapFileFileVars(tv, ptv->current_file);
+        ptv->current_file = NULL;
+    }
+    closedir(ptv->directory);
+    if(tv->is_directory == 1) {
+        tv->behavior.directory = NULL;
+    }
+    if(ptv->filename != NULL) {
+        SCFree(ptv->filename);
+    }
+    ptv->shared = NULL;
+    SCFree(ptv);
+}
+
+void CleanupPcapFileThreadVars(PcapFileThreadVars *tv)
+{
+    if(tv->is_directory == 0) {
+        if (tv->behavior.file != NULL) {
+            CleanupPcapFileFileVars(tv, tv->behavior.file);
+        }
+        tv->behavior.file = NULL;
+    } else {
+        if(tv->behavior.directory != NULL) {
+            CleanupPcapFileDirectoryVars(tv, tv->behavior.directory);
+        }
+        tv->behavior.directory = NULL;
+    }
+    if(tv->shared.bpf_string != NULL) {
+        SCFree(tv->shared.bpf_string);
+        tv->shared.bpf_string = NULL;
+    }
+    SCFree(tv);
+}
+
+TmEcode PcapDirectoryFailure(PcapFileThreadVars *tv, PcapFileDirectoryVars *ptv)
+{
+    TmEcode status = TM_ECODE_FAILED;
+
+    if (RunModeUnixSocketIsActive()) {
+        status = UnixSocketPcapFile(status, ptv->shared->last_processed);
+    }
+
+    CleanupPcapFileDirectoryVars(tv, ptv);
+
+    SCReturnInt(status);
+}
+
+TmEcode PcapDirectoryDone(PcapFileThreadVars *tv, PcapFileDirectoryVars *ptv)
+{
+    TmEcode status = TM_ECODE_DONE;
+
+    if (RunModeUnixSocketIsActive()) {
+        status = UnixSocketPcapFile(status, ptv->shared->last_processed);
+    }
+
+    CleanupPcapFileDirectoryVars(tv, ptv);
+
+    SCReturnInt(status);
+}
+
+TmEcode PcapCheckFile(char *filename, DIR **directory)
+{
+    DIR *temp_dir = NULL;
+    TmEcode return_code = TM_ECODE_FAILED;
+
+    temp_dir = opendir(filename);
+
+    if (temp_dir == NULL)
+    {
+        switch (errno)
+        {
+            case EACCES:
+                SCLogError(SC_ERR_FOPEN, "%s: Permission denied", filename);
+                break;
+
+            case EBADF:
+                SCLogError(SC_ERR_FOPEN, "%s: Not a valid file descriptor opened for reading", filename);
+                break;
+
+            case EMFILE:
+                SCLogError(SC_ERR_FOPEN, "%s: The per-process limit on the number of open file descriptors has been reached", filename);
+                break;
+
+            case ENFILE:
+                SCLogError(SC_ERR_FOPEN, "%s: The system-wide limit on the number of open file descriptors has been reached", filename);
+                break;
+
+            case ENOENT:
+                SCLogError(SC_ERR_FOPEN, "%s: Does not exist, or name is an empty string", filename);
+                break;
+            case ENOMEM:
+                SCLogError(SC_ERR_FOPEN, "%s: Insufficient memory to complete the operation", filename);
+                break;
+
+            case ENOTDIR:
+                SCLogInfo("%s: File is not a directory", filename);
+                return_code = TM_ECODE_OK;
+                break;
+
+            default:
+                SCLogError(SC_ERR_FOPEN, "%s: %" PRId32, filename, errno);
+        }
+    } else {
+        *directory = temp_dir;
+        return_code = TM_ECODE_OK;
+    }
+
+    return return_code;
+}
+
+int PcapDirectoryGetModifiedTime(char const * file, struct timespec * out)
+{
+    struct stat buf;
+    int ret;
+
+    if (file == NULL)
+        return -1;
+
+    if ((ret = stat(file, &buf)) != 0)
+        return ret;
+
+#ifdef OS_DARWIN
+    *out = buf.st_mtimespec;
+#else
+    *out = buf.st_mtim;
+#endif
+
+    return ret;
+}
+
+int PcapDirectorySortByStatTime(const void * vleft, const void * vright)
+{
+    if (vleft == vright)
+        return 0;
+
+    struct timespec leftTime, rightTime;
+
+    int leftRet, rightRet;
+
+    leftRet = PcapDirectoryGetModifiedTime(*(const char **)vleft, &leftTime);
+    rightRet = PcapDirectoryGetModifiedTime(*(const char **)vright, &rightTime);
+
+    if (leftRet == 0 && rightRet == 0)
+    {
+        if(leftTime.tv_sec < rightTime.tv_sec) {
+            return -1;
+        } else if(leftTime.tv_sec > rightTime.tv_sec) {
+            return 1;
+        } else { //seconds equal
+            if(leftTime.tv_nsec < rightTime.tv_nsec) {
+                return -1;
+            } else if(leftTime.tv_nsec > rightTime.tv_nsec) {
+                return 1;
+            } else {
+                return 0;
+            }
+        }
+    }
+    else
+    {
+        return (leftRet == rightRet) ? 0 : ((leftRet < rightRet) ? -1 : 1);
+    }
+}
+
+void FreeDirectoryMemBuffer(MemBuffer * buffer)
+{
+    if (buffer == NULL)
+        return;
+
+    size_t offset = 0;
+    char *buffer_value;
+
+    while (offset < MEMBUFFER_OFFSET(buffer))
+    {
+        buffer_value = *((char**)(MEMBUFFER_BUFFER(buffer) + offset));
+        if(buffer_value != NULL) {
+            SCFree(buffer_value);
+        }
+        offset += sizeof(char*);
+    }
+    MemBufferFree(buffer);
+}
+
+TmEcode PcapDirectoryPopulateBuffer(
+        PcapFileDirectoryVars *ptv,
+        time_t newer_than,
+        time_t older_than,
+        time_t *first_new_file_time,
+        MemBuffer **directory_content
+) {
+    struct dirent * dir = NULL;
+
+    MemBuffer *temp_directory_content = NULL;
+
+    time_t fnt = *first_new_file_time;
+
+    while ((dir = readdir(ptv->directory)) != NULL)
+    {
+        if (dir->d_type != DT_REG)
+        {
+            continue;
+        }
+
+        char pathbuff[PATH_MAX] = {0};
+
+        int written = 0;
+
+        written = snprintf(pathbuff, PATH_MAX, "%s/%s", ptv->filename, dir->d_name);
+
+        if (written > 0 && written < PATH_MAX)
+        {
+            struct timespec temp_time;
+
+            if (PcapDirectoryGetModifiedTime(pathbuff, &temp_time) == 0)
+            {
+                SCLogDebug("File %s time (%lu > %lu < %lu)", pathbuff, newer_than, temp_time.tv_sec, older_than);
+
+                // Skip files outside of our time range
+                if (temp_time.tv_sec < newer_than) {
+                    SCLogDebug("Skipping old file %s", pathbuff);
+                    continue;
+                }
+                else if (temp_time.tv_sec > older_than) {
+                    SCLogDebug("Skipping new file %s", pathbuff);
+                    if (temp_time.tv_sec < fnt || fnt == 0)
+                    {
+                        *first_new_file_time = temp_time.tv_sec;
+                    }
+                    continue;
+                }
+            }
+
+            if (temp_directory_content == NULL)
+            {
+                temp_directory_content = MemBufferCreateNew(sizeof(char*) * 32);
+                if (!temp_directory_content)
+                {
+                    SCLogError(SC_ERR_MEM_ALLOC, "Failed to create buffer");
+
+                    SCReturnInt(TM_ECODE_FAILED);
+                }
+            }
+            else if (MEMBUFFER_SIZE(temp_directory_content) - MEMBUFFER_OFFSET(temp_directory_content) < sizeof(char*))
+            {
+                // Double size
+                if (MemBufferExpand(&temp_directory_content, MEMBUFFER_SIZE(temp_directory_content)) != 0)
+                {
+                    FreeDirectoryMemBuffer(temp_directory_content);
+
+                    SCLogError(SC_ERR_MEM_ALLOC, "Failed to expand buffer");
+
+                    SCReturnInt(TM_ECODE_FAILED);
+                }
+            }
+
+            char * mem = SCMalloc(sizeof(char *) * (written + 1));
+            if (!mem)
+            {
+                FreeDirectoryMemBuffer(temp_directory_content);
+
+                SCLogError(SC_ERR_MEM_ALLOC, "Failed to copy file name");
+
+                SCReturnInt(TM_ECODE_FAILED);
+            }
+            memcpy(mem, pathbuff, written + 1);
+
+            SCLogDebug("Found \"%s\"", mem);
+
+            *((char**)(MEMBUFFER_BUFFER(temp_directory_content) + MEMBUFFER_OFFSET(temp_directory_content))) = mem;
+
+            MEMBUFFER_OFFSET(temp_directory_content) += sizeof(char *);
+        }
+        else
+        {
+            FreeDirectoryMemBuffer(temp_directory_content);
+
+            SCReturnInt(TM_ECODE_FAILED);
+        }
+    }
+
+    if (temp_directory_content != NULL)
+    {
+        // Sort buffer
+        qsort(MEMBUFFER_BUFFER(temp_directory_content), MEMBUFFER_OFFSET(temp_directory_content) / sizeof(char*), sizeof(char*), &PcapDirectorySortByStatTime);
+    }
+
+    *directory_content = temp_directory_content;
+
+    SCReturnInt(TM_ECODE_OK);
+}
+
+/**
+ * Pcap File Functionality
+ */
 void TmModuleReceivePcapFileRegister (void)
 {
     tmm_modules[TMM_RECEIVEPCAPFILE].name = "ReceivePcapFile";
@@ -137,7 +528,7 @@ static void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
 {
     SCEnter();
 
-    PcapFileThreadVars *ptv = (PcapFileThreadVars *)user;
+    PcapFileFileVars *ptv = (PcapFileFileVars *)user;
     Packet *p = PacketGetFromQueueOrAlloc();
 
     if (unlikely(p == NULL)) {
@@ -149,15 +540,15 @@ static void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
     p->ts.tv_sec = h->ts.tv_sec;
     p->ts.tv_usec = h->ts.tv_usec;
     SCLogDebug("p->ts.tv_sec %"PRIuMAX"", (uintmax_t)p->ts.tv_sec);
-    p->datalink = pcap_g.datalink;
+    p->datalink = ptv->datalink;
     p->pcap_cnt = ++pcap_g.cnt;
 
-    p->pcap_v.tenant_id = ptv->tenant_id;
-    ptv->pkts++;
-    ptv->bytes += h->caplen;
+    p->pcap_v.tenant_id = ptv->shared->tenant_id;
+    ptv->shared->pkts++;
+    ptv->shared->bytes += h->caplen;
 
     if (unlikely(PacketCopyData(p, pkt, h->caplen))) {
-        TmqhOutputPacketpool(ptv->tv, p);
+        TmqhOutputPacketpool(ptv->shared->tv, p);
         PACKET_PROFILING_TMM_END(p, TMM_RECEIVEPCAPFILE);
         SCReturn;
     }
@@ -166,7 +557,7 @@ static void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
     if (pcap_g.checksum_mode == CHECKSUM_VALIDATION_DISABLE) {
         p->flags |= PKT_IGNORE_CHECKSUM;
     } else if (pcap_g.checksum_mode == CHECKSUM_VALIDATION_AUTO) {
-        if (ChecksumAutoModeCheck(ptv->pkts, p->pcap_cnt,
+        if (ChecksumAutoModeCheck(ptv->shared->pkts, p->pcap_cnt,
                                   SC_ATOMIC_GET(pcap_g.invalid_checksums))) {
             pcap_g.checksum_mode = CHECKSUM_VALIDATION_DISABLE;
             p->flags |= PKT_IGNORE_CHECKSUM;
@@ -175,9 +566,9 @@ static void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
 
     PACKET_PROFILING_TMM_END(p, TMM_RECEIVEPCAPFILE);
 
-    if (TmThreadsSlotProcessPkt(ptv->tv, ptv->slot, p) != TM_ECODE_OK) {
-        pcap_breakloop(pcap_g.pcap_handle);
-        ptv->cb_result = TM_ECODE_FAILED;
+    if (TmThreadsSlotProcessPkt(ptv->shared->tv, ptv->shared->slot, p) != TM_ECODE_OK) {
+        pcap_breakloop(ptv->pcap_handle);
+        ptv->shared->cb_result = TM_ECODE_FAILED;
     }
 
     SCReturn;
@@ -186,19 +577,15 @@ static void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
 /**
  *  \brief Main PCAP file reading Loop function
  */
-TmEcode ReceivePcapFileLoop(ThreadVars *tv, void *data, void *slot)
+TmEcode ReceivePcapFileFileLoop(PcapFileThreadVars *tv, PcapFileFileVars *ptv)
 {
     SCEnter();
 
     int packet_q_len = 64;
-    PcapFileThreadVars *ptv = (PcapFileThreadVars *)data;
     int r;
-    TmSlot *s = (TmSlot *)slot;
+    TmEcode loop_result = TM_ECODE_OK;
 
-    ptv->slot = s->slot_next;
-    ptv->cb_result = TM_ECODE_OK;
-
-    while (1) {
+    while (loop_result == TM_ECODE_OK) {
         if (suricata_ctl_flags & SURICATA_STOP) {
             SCReturnInt(TM_ECODE_OK);
         }
@@ -208,63 +595,256 @@ TmEcode ReceivePcapFileLoop(ThreadVars *tv, void *data, void *slot)
         PacketPoolWait();
 
         /* Right now we just support reading packets one at a time. */
-        r = pcap_dispatch(pcap_g.pcap_handle, packet_q_len,
+        r = pcap_dispatch(ptv->pcap_handle, packet_q_len,
                           (pcap_handler)PcapFileCallbackLoop, (u_char *)ptv);
         if (unlikely(r == -1)) {
             SCLogError(SC_ERR_PCAP_DISPATCH, "error code %" PRId32 " %s",
-                       r, pcap_geterr(pcap_g.pcap_handle));
-            if (ptv->cb_result == TM_ECODE_FAILED) {
+                       r, pcap_geterr(ptv->pcap_handle));
+            if (ptv->shared->cb_result == TM_ECODE_FAILED) {
                 SCReturnInt(TM_ECODE_FAILED);
             }
-            if (! RunModeUnixSocketIsActive()) {
-                EngineStop();
-            } else {
-                pcap_close(pcap_g.pcap_handle);
-                pcap_g.pcap_handle = NULL;
-                UnixSocketPcapFile(TM_ECODE_DONE);
-                SCReturnInt(TM_ECODE_DONE);
-            }
+            loop_result = TM_ECODE_DONE;
         } else if (unlikely(r == 0)) {
             SCLogInfo("pcap file end of file reached (pcap err code %" PRId32 ")", r);
-            if (! RunModeUnixSocketIsActive()) {
-                EngineStop();
-            } else {
-                pcap_close(pcap_g.pcap_handle);
-                pcap_g.pcap_handle = NULL;
-                UnixSocketPcapFile(TM_ECODE_DONE);
-                SCReturnInt(TM_ECODE_DONE);
-            }
-            break;
-        } else if (ptv->cb_result == TM_ECODE_FAILED) {
+            tv->shared.files++;
+            loop_result = TM_ECODE_DONE;
+        } else if (ptv->shared->cb_result == TM_ECODE_FAILED) {
             SCLogError(SC_ERR_PCAP_DISPATCH, "Pcap callback PcapFileCallbackLoop failed");
+            loop_result = TM_ECODE_FAILED;
+        }
+        StatsSyncCountersIfSignalled(ptv->shared->tv);
+    }
+
+    SCReturnInt(loop_result);
+}
+
+TmEcode InitPcapFile(PcapFileFileVars *pfv, const char *filename)
+{
+    char errbuf[PCAP_ERRBUF_SIZE] = "";
+
+    pfv->filename = SCStrdup(filename);
+    if (unlikely(pfv->filename == NULL)) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate filename");
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+    pfv->pcap_handle = pcap_open_offline(pfv->filename, errbuf);
+    if (pfv->pcap_handle == NULL) {
+        SCLogError(SC_ERR_FOPEN, "%s", errbuf);
+        if (!RunModeUnixSocketIsActive()) {
+            SCReturnInt(TM_ECODE_FAILED);
+        } else {
+            UnixSocketPcapFile(TM_ECODE_FAILED, 0);
+            SCReturnInt(TM_ECODE_DONE);
+        }
+    }
+
+    if(pfv->shared != NULL && pfv->shared->bpf_string != NULL) {
+        SCLogInfo("using bpf-filter \"%s\"", pfv->shared->bpf_string);
+
+        if (pcap_compile(pfv->pcap_handle, &pfv->filter, pfv->shared->bpf_string, 1, 0) < 0) {
+            SCLogError(SC_ERR_BPF,"bpf compilation error %s",
+                       pcap_geterr(pfv->pcap_handle));
+            SCReturnInt(TM_ECODE_FAILED);
+        }
+
+        if (pcap_setfilter(pfv->pcap_handle, &pfv->filter) < 0) {
+            SCLogError(SC_ERR_BPF,"could not set bpf filter %s", pcap_geterr(pfv->pcap_handle));
+            SCReturnInt(TM_ECODE_FAILED);
+        }
+    }
+
+    pfv->datalink = pcap_datalink(pfv->pcap_handle);
+    SCLogDebug("datalink %" PRId32 "", pfv->datalink);
+
+    switch (pfv->datalink) {
+        case LINKTYPE_LINUX_SLL:
+        case LINKTYPE_ETHERNET:
+        case LINKTYPE_PPP:
+        case LINKTYPE_RAW:
+        case LINKTYPE_RAW2:
+        case LINKTYPE_NULL:
+            break;
+
+        default:
+            SCLogError(SC_ERR_UNIMPLEMENTED, "datalink type %" PRId32 " not "
+                    "(yet) supported in module PcapFile.", pfv->datalink);
             if (! RunModeUnixSocketIsActive()) {
                 SCReturnInt(TM_ECODE_FAILED);
             } else {
-                pcap_close(pcap_g.pcap_handle);
-                pcap_g.pcap_handle = NULL;
-                UnixSocketPcapFile(TM_ECODE_DONE);
+                UnixSocketPcapFile(TM_ECODE_DONE, 0);
                 SCReturnInt(TM_ECODE_DONE);
             }
-        }
-        StatsSyncCountersIfSignalled(tv);
     }
 
     SCReturnInt(TM_ECODE_OK);
+}
+
+TmEcode PcapDirectoryDispatch(
+        PcapFileThreadVars *tv,
+        PcapFileDirectoryVars *pv,
+        time_t *newer_than,
+        time_t *older_than,
+        time_t * first_new_file_time
+)
+{
+    MemBuffer *directory_content = NULL;
+
+    if(PcapDirectoryPopulateBuffer(pv, *newer_than, *older_than, first_new_file_time, &directory_content) == TM_ECODE_FAILED) {
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+
+    TmEcode status = TM_ECODE_OK;
+
+    if(directory_content == NULL) {
+        *older_than = time(NULL) - pv->delay;
+        SCLogInfo("Directory %s has no files to process", pv->filename);
+        rewinddir(pv->directory);
+        status = TM_ECODE_OK;
+    } else {
+        size_t offset = 0;
+
+        while (status == TM_ECODE_OK && offset < MEMBUFFER_OFFSET(directory_content)) {
+            char *pathbuff = (*((char **) (MEMBUFFER_BUFFER(directory_content) + offset)));
+
+            if(pathbuff != NULL) {
+
+                SCLogDebug("Processing file %s", pathbuff);
+
+                PcapFileFileVars *pftv = SCMalloc(sizeof(PcapFileFileVars));
+                if (unlikely(pftv == NULL)) {
+                    SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate PcapFileFileVars");
+                    SCReturnInt(TM_ECODE_FAILED);
+                }
+                memset(pftv, 0, sizeof(PcapFileFileVars));
+
+                pftv->shared = pv->shared;
+
+                if (InitPcapFile(pftv, pathbuff) == TM_ECODE_FAILED) {
+                    FreeDirectoryMemBuffer(directory_content);
+                    CleanupPcapFileFileVars(tv, pftv);
+                    SCReturnInt(TM_ECODE_FAILED);
+                }
+
+                pv->current_file = pftv;
+
+                if (ReceivePcapFileFileLoop(tv, pftv) == TM_ECODE_FAILED) {
+                    FreeDirectoryMemBuffer(directory_content);
+                    CleanupPcapFileFileVars(tv, pftv);
+                    SCReturnInt(TM_ECODE_FAILED);
+                }
+
+                CleanupPcapFileFileVars(tv, pftv);
+                pv->current_file = NULL;
+
+                struct timespec temp_time;
+
+                if (PcapDirectoryGetModifiedTime(pathbuff, &temp_time) != 0) {
+                    temp_time.tv_sec = *newer_than;
+                }
+                SCLogDebug("Processed file %s, processed up to %ld", pathbuff, temp_time.tv_sec);
+                pv->shared->last_processed = temp_time.tv_sec;
+
+                status = PcapRunStatus(pv);
+            }
+            offset += sizeof(char *);
+        }
+
+        *newer_than = *older_than;
+    }
+    FreeDirectoryMemBuffer(directory_content);
+    *older_than = time(NULL) - pv->delay;
+
+    SCReturnInt(status);
+}
+
+TmEcode ReceivePcapFileDirectoryLoop(PcapFileThreadVars *tv, PcapFileDirectoryVars *ptv)
+{
+    SCEnter();
+
+    time_t newer_than = 0;
+    time_t older_than = time(NULL) - ptv->delay;
+    uint32_t poll_seconds = (uint32_t)localtime(&ptv->poll_interval)->tm_sec;
+
+    TmEcode status = TM_ECODE_OK;
+
+    while (status == TM_ECODE_OK) {
+        if (ptv->directory != NULL) {
+            SCLogInfo("Pcap File Ok, Looping");
+            //loop while directory is ok
+            while (status == TM_ECODE_OK) {
+                SCLogInfo("Processing pcaps directory %s, files must be newer than %ld and older than %ld",
+                          ptv->filename, newer_than, older_than);
+                time_t first_new_file_time;
+                status = PcapDirectoryDispatch(tv, ptv, &newer_than, &older_than, &first_new_file_time);
+                if (status == TM_ECODE_OK) {
+                    sleep(poll_seconds);
+                    //update our status based on suricata control flags or unix command socket
+                    status = PcapRunStatus(ptv);
+                }
+            }
+
+            //check directory
+            if(PcapCheckFile(ptv->filename, &(ptv->directory)) == TM_ECODE_FAILED) {
+                SCLogInfo("Directory %s no longer exists, stopping", ptv->filename);
+                status = TM_ECODE_DONE;
+            }
+        } else {
+            status = TM_ECODE_DONE;
+        }
+    }
+
+    StatsSyncCountersIfSignalled(ptv->shared->tv);
+
+    if(status == TM_ECODE_FAILED) {
+        SCLogError(SC_ERR_PCAP_DISPATCH, "Directory run mode failed");
+        status = PcapDirectoryFailure(tv, ptv);
+    } else {
+        SCLogInfo("Directory run mode complete");
+        status = PcapDirectoryDone(tv, ptv);
+    }
+
+    SCReturnInt(status);
+}
+
+TmEcode ReceivePcapFileLoop(ThreadVars *tv, void *data, void *slot)
+{
+    SCEnter();
+
+    TmEcode status = TM_ECODE_OK;
+    PcapFileThreadVars *ptv = (PcapFileThreadVars *) data;
+    TmSlot *s = (TmSlot *)slot;
+
+    ptv->shared.slot = s->slot_next;
+    ptv->shared.cb_result = TM_ECODE_OK;
+
+    if(ptv->is_directory == 0) {
+        SCLogInfo("Starting file run for %s", ptv->behavior.file->filename);
+        status = ReceivePcapFileFileLoop(ptv, ptv->behavior.file);
+        if (! RunModeUnixSocketIsActive()) {
+            EngineStop();
+        } else {
+            status = UnixSocketPcapFile(status, ptv->shared.last_processed);
+        }
+        CleanupPcapFileFileVars(ptv, ptv->behavior.file);
+    } else {
+        SCLogInfo("Starting directory run for %s", ptv->behavior.directory->filename);
+        status = ReceivePcapFileDirectoryLoop(ptv, ptv->behavior.directory);
+    }
+
+    SCReturnInt(status);
 }
 
 TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
     SCEnter();
 
-    const char *tmpbpfstring = NULL;
     const char *tmpstring = NULL;
+    const char *tmp_bpf_string = NULL;
 
     if (initdata == NULL) {
         SCLogError(SC_ERR_INVALID_ARGUMENT, "error: initdata == NULL");
         SCReturnInt(TM_ECODE_FAILED);
     }
-
-    SCLogInfo("reading pcap file %s", (char *)initdata);
 
     PcapFileThreadVars *ptv = SCMalloc(sizeof(PcapFileThreadVars));
     if (unlikely(ptv == NULL))
@@ -274,78 +854,86 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
     intmax_t tenant = 0;
     if (ConfGetInt("pcap-file.tenant-id", &tenant) == 1) {
         if (tenant > 0 && tenant < UINT_MAX) {
-            ptv->tenant_id = (uint32_t)tenant;
-            SCLogInfo("tenant %u", ptv->tenant_id);
+            ptv->shared.tenant_id = (uint32_t)tenant;
+            SCLogInfo("tenant %u", ptv->shared.tenant_id);
         } else {
             SCLogError(SC_ERR_INVALID_ARGUMENT, "tenant out of range");
         }
     }
 
-    char errbuf[PCAP_ERRBUF_SIZE] = "";
-    pcap_g.pcap_handle = pcap_open_offline((char *)initdata, errbuf);
-    if (pcap_g.pcap_handle == NULL) {
-        SCLogError(SC_ERR_FOPEN, "%s\n", errbuf);
-        SCFree(ptv);
-        if (! RunModeUnixSocketIsActive()) {
-            return TM_ECODE_FAILED;
-        } else {
-            UnixSocketPcapFile(TM_ECODE_FAILED);
-            SCReturnInt(TM_ECODE_DONE);
-        }
-    }
-
-    if (ConfGet("bpf-filter", &tmpbpfstring) != 1) {
+    if (ConfGet("bpf-filter", &(tmp_bpf_string)) != 1) {
         SCLogDebug("could not get bpf or none specified");
     } else {
-        SCLogInfo("using bpf-filter \"%s\"", tmpbpfstring);
-
-        if (pcap_compile(pcap_g.pcap_handle, &pcap_g.filter, (char *)tmpbpfstring, 1, 0) < 0) {
-            SCLogError(SC_ERR_BPF,"bpf compilation error %s",
-                    pcap_geterr(pcap_g.pcap_handle));
-            SCFree(ptv);
-            return TM_ECODE_FAILED;
-        }
-
-        if (pcap_setfilter(pcap_g.pcap_handle, &pcap_g.filter) < 0) {
-            SCLogError(SC_ERR_BPF,"could not set bpf filter %s", pcap_geterr(pcap_g.pcap_handle));
-            SCFree(ptv);
-            return TM_ECODE_FAILED;
+        ptv->shared.bpf_string = SCStrdup(tmp_bpf_string);
+        if (unlikely(ptv->shared.bpf_string == NULL)) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate bpf_string");
+            SCReturnInt(TM_ECODE_FAILED);
         }
     }
 
-    pcap_g.datalink = pcap_datalink(pcap_g.pcap_handle);
-    SCLogDebug("datalink %" PRId32 "", pcap_g.datalink);
+    DIR *directory = NULL;
+    SCLogInfo("Checking file or directory %s", (char*)initdata);
+    if(PcapCheckFile((char *)initdata, &directory) == TM_ECODE_FAILED) {
+        CleanupPcapFileThreadVars(ptv);
+        SCReturnInt(TM_ECODE_FAILED);
+    }
 
-    switch (pcap_g.datalink) {
-        case LINKTYPE_LINUX_SLL:
-            pcap_g.Decoder = DecodeSll;
-            break;
-        case LINKTYPE_ETHERNET:
-            pcap_g.Decoder = DecodeEthernet;
-            break;
-        case LINKTYPE_PPP:
-            pcap_g.Decoder = DecodePPP;
-            break;
-        case LINKTYPE_RAW:
-        case LINKTYPE_RAW2:
-            pcap_g.Decoder = DecodeRaw;
-            break;
-        case LINKTYPE_NULL:
-            pcap_g.Decoder = DecodeNull;
-            break;
+    if(directory == NULL) {
+        SCLogInfo("Argument %s was a file", (char *)initdata);
+        PcapFileFileVars *pv = SCMalloc(sizeof(PcapFileFileVars));
+        if (unlikely(pv == NULL))
+            SCReturnInt(TM_ECODE_FAILED);
+        memset(pv, 0, sizeof(PcapFileFileVars));
 
-        default:
-            SCLogError(SC_ERR_UNIMPLEMENTED, "datalink type %" PRId32 " not "
-                      "(yet) supported in module PcapFile.\n", pcap_g.datalink);
-            SCFree(ptv);
-            if (! RunModeUnixSocketIsActive()) {
-                SCReturnInt(TM_ECODE_FAILED);
+        TmEcode init_file_return = InitPcapFile(pv, (char *)initdata);
+        if(init_file_return == TM_ECODE_OK) {
+            pv->shared = &ptv->shared;
+
+            ptv->is_directory = 0;
+            ptv->behavior.file = pv;
+        } else {
+            CleanupPcapFileFileVars(ptv, pv);
+            SCReturnInt(init_file_return);
+        }
+    } else {
+        SCLogInfo("Argument %s was a directory", (char *)initdata);
+        PcapFileDirectoryVars *pv = SCMalloc(sizeof(PcapFileDirectoryVars));
+        if (unlikely(pv == NULL))
+            SCReturnInt(TM_ECODE_FAILED);
+        memset(pv, 0, sizeof(PcapFileDirectoryVars));
+
+        pv->delay = 30;
+        intmax_t delay = 0;
+        if (ConfGetInt("pcap-file.delay", &delay) == 1) {
+            if (delay > 0 && delay < UINT_MAX) {
+                pv->delay = (time_t)delay;
+                SCLogDebug("delay %lu", pv->delay);
             } else {
-                pcap_close(pcap_g.pcap_handle);
-                pcap_g.pcap_handle = NULL;
-                UnixSocketPcapFile(TM_ECODE_DONE);
-                SCReturnInt(TM_ECODE_DONE);
+                SCLogError(SC_ERR_INVALID_ARGUMENT, "delay out of range");
             }
+        }
+
+        pv->poll_interval = 5;
+        intmax_t poll_interval = 0;
+        if (ConfGetInt("pcap-file.poll-interval", &poll_interval) == 1) {
+            if (poll_interval > 0 && poll_interval < UINT_MAX) {
+                pv->poll_interval = (time_t)poll_interval;
+                SCLogDebug("poll-interval %lu", pv->delay);
+            } else {
+                SCLogError(SC_ERR_INVALID_ARGUMENT, "poll-interval out of range");
+            }
+        }
+
+        pv->shared = &ptv->shared;
+        pv->filename = SCStrdup((char*)initdata);
+        if (unlikely(pv->filename == NULL)) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate filename");
+            SCReturnInt(TM_ECODE_FAILED);
+        }
+        pv->directory = directory;
+
+        ptv->is_directory = 1;
+        ptv->behavior.directory = pv;
     }
 
     if (ConfGet("pcap-file.checksum-checks", &tmpstring) != 1) {
@@ -361,7 +949,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
     }
     pcap_g.checksum_mode = pcap_g.conf_checksum_mode;
 
-    ptv->tv = tv;
+    ptv->shared.tv = tv;
     *data = (void *)ptv;
 
     SCReturnInt(TM_ECODE_OK);
@@ -373,29 +961,33 @@ void ReceivePcapFileThreadExitStats(ThreadVars *tv, void *data)
     PcapFileThreadVars *ptv = (PcapFileThreadVars *)data;
 
     if (pcap_g.conf_checksum_mode == CHECKSUM_VALIDATION_AUTO &&
-            pcap_g.cnt < CHECKSUM_SAMPLE_COUNT &&
-            SC_ATOMIC_GET(pcap_g.invalid_checksums)) {
+        pcap_g.cnt < CHECKSUM_SAMPLE_COUNT &&
+        SC_ATOMIC_GET(pcap_g.invalid_checksums)) {
         uint64_t chrate = pcap_g.cnt / SC_ATOMIC_GET(pcap_g.invalid_checksums);
         if (chrate < CHECKSUM_INVALID_RATIO)
             SCLogWarning(SC_ERR_INVALID_CHECKSUM,
                          "1/%" PRIu64 "th of packets have an invalid checksum,"
-                         " consider setting pcap-file.checksum-checks variable to no"
-                         " or use '-k none' option on command line.",
+                                 " consider setting pcap-file.checksum-checks variable to no"
+                                 " or use '-k none' option on command line.",
                          chrate);
         else
             SCLogInfo("1/%" PRIu64 "th of packets have an invalid checksum",
                       chrate);
     }
-    SCLogNotice("Pcap-file module read %" PRIu32 " packets, %" PRIu64 " bytes", ptv->pkts, ptv->bytes);
-    return;
+    SCLogNotice(
+            "Pcap-file module read %" PRIu64 " files, %" PRIu64 " packets, %" PRIu64 " bytes",
+            ptv->shared.files,
+            ptv->shared.pkts,
+            ptv->shared.bytes
+    );
 }
 
 TmEcode ReceivePcapFileThreadDeinit(ThreadVars *tv, void *data)
 {
     SCEnter();
     PcapFileThreadVars *ptv = (PcapFileThreadVars *)data;
-    if (ptv) {
-        SCFree(ptv);
+    if (ptv != NULL) {
+        CleanupPcapFileThreadVars(ptv);
     }
     SCReturnInt(TM_ECODE_OK);
 }
@@ -404,6 +996,8 @@ static double prev_signaled_ts = 0;
 
 TmEcode DecodePcapFile(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, PacketQueue *postpq)
 {
+    int (*decoder)(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
+
     SCEnter();
     DecodeThreadVars *dtv = (DecodeThreadVars *)data;
 
@@ -421,8 +1015,32 @@ TmEcode DecodePcapFile(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, P
         FlowWakeupFlowManagerThread();
     }
 
+    switch (p->datalink) {
+        case LINKTYPE_LINUX_SLL:
+            decoder = DecodeSll;
+            break;
+        case LINKTYPE_ETHERNET:
+            decoder = DecodeEthernet;
+            break;
+        case LINKTYPE_PPP:
+            decoder = DecodePPP;
+            break;
+        case LINKTYPE_RAW:
+        case LINKTYPE_RAW2:
+            decoder = DecodeRaw;
+            break;
+        case LINKTYPE_NULL:
+            decoder = DecodeNull;
+            break;
+
+        default:
+            SCLogError(SC_ERR_UNIMPLEMENTED, "datalink type %" PRId32 " not "
+                    "(yet) supported in module PcapFile.", p->datalink);
+            SCReturnInt(TM_ECODE_FAILED);
+    }
+
     /* call the decoder */
-    pcap_g.Decoder(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
+    decoder(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
 
 #ifdef DEBUG
     BUG_ON(p->pkt_src != PKT_SRC_WIRE && p->pkt_src != PKT_SRC_FFR);
@@ -467,4 +1085,3 @@ void PcapIncreaseInvalidChecksum()
 }
 
 /* eof */
-

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2270,9 +2270,6 @@ void PreRunPostPrivsDropInit(const int runmode)
  * Will be run once per pcap in unix-socket mode */
 void PostRunDeinit(const int runmode, struct timeval *start_time)
 {
-    if (runmode == RUNMODE_UNIX_SOCKET)
-        return;
-
     /* needed by FlowForceReassembly */
     PacketPoolInit();
 

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -65,12 +65,16 @@ SCLogOpenUnixSocketFp(const char *path, int sock_type, int log_err)
     saun.sun_family = AF_UNIX;
     strlcpy(saun.sun_path, path, sizeof(saun.sun_path));
 
+    SCLogInfo("Log connecting to unix socket %s", path);
+
     if (connect(s, (const struct sockaddr *)&saun, sizeof(saun)) < 0)
         goto err;
 
     ret = fdopen(s, "w");
     if (ret == NULL)
         goto err;
+
+    SCLogInfo("Log connected to unix socket %s", path);
 
     return ret;
 
@@ -133,6 +137,7 @@ static int SCLogFileWriteSocket(const char *buffer, int buffer_len,
     int tries = 0;
     int ret = 0;
     bool reopen = false;
+
 #ifdef BUILD_WITH_UNIXSOCKET
     if (ctx->fp == NULL && ctx->is_sock) {
         SCLogUnixSocketReconnect(ctx);
@@ -149,13 +154,13 @@ tryagain:
             ret = 0;
         } else {
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
-                SCLogDebug("Socket would block, dropping event.");
+                SCLogWarning(SC_ERR_SOCKET, "Socket would block, dropping event.");
             } else if (errno == EINTR) {
                 if (tries++ == 0) {
                     SCLogDebug("Interrupted system call, trying again.");
                     goto tryagain;
                 }
-                SCLogDebug("Too many interrupted system calls, "
+                SCLogWarning(SC_ERR_SOCKET, "Too many interrupted system calls, "
                         "dropping event.");
             } else {
                 /* Some other error. Assume badness and reopen. */


### PR DESCRIPTION
Version 5 of 
 - https://github.com/OISF/suricata/pull/2961
 - https://github.com/OISF/suricata/pull/2960
 - https://github.com/OISF/suricata/pull/2958
 - https://github.com/OISF/suricata/pull/2957

Pcap file mode that when passed a directory will process all files in that directory until the directory is moved/deleted or suricata is interrupted.

Engine state will not reset between files.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2222

Describe changes:
- If source-pcap-file is passed a directory instead of a file, all files in that directory will be processed in order of modified time, without state resetting between files.
- source-pcap-file will continue to process files until suricata is interrupted or the directory is moved/deleted
- runmode-unix-socket is updated to provide a current time to determine what state of processing of the directory is

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):