### PR TITLE
app-layer-htp, stream-tcp: prevent modulo bias in RandomGetWrap()

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2213,9 +2213,13 @@ static void HTPConfigSetDefaultsPhase1(HTPCfgRec *cfg_prec)
  */
 static int RandomGetWrap(void)
 {
-    long int r = RandomGet();
-    int r_int = r % (long int)RAND_MAX;
-    return abs(r_int);
+    unsigned long r;
+
+    do {
+        r = RandomGet();
+    } while(r >= ULONG_MAX - (ULONG_MAX % RAND_MAX));
+
+    return r % RAND_MAX;
 }
 
 /*

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -317,9 +317,13 @@ int StreamTcpInlineDropInvalid(void)
  */
 static int RandomGetWrap(void)
 {
-    long int r = RandomGet();
-    int r_int = r % (long int)RAND_MAX;
-    return abs(r_int);
+    unsigned long r;
+
+    do {
+        r = RandomGet();
+    } while(r >= ULONG_MAX - (ULONG_MAX % RAND_MAX));
+
+    return r % RAND_MAX;
 }
 
 /** \brief          To initialize the stream global configuration data


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
RAND_MAX is not guaranteed to be a divisor of ULONG_MAX, so take the necessary precautions to get unbiased random numbers. Although the bias might be negligible, it's not advisable to rely on it.

