### PR TITLE
Configurable Log Event Drop

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -241,6 +241,10 @@ There are several types of output. The general structure is:
       enabled: yes
       filename: fast.log
       append: yes/no
+      retries:
+          reconnecting: 1    #number of retries when reconnecting
+          interrupted: 1     #number of retries if write is interrupted
+          blocked: 0         #number of retries if write is blocked
 
 Enabling all of the logs, will result in a much lower performance and
 the use of more disc space, so enable only the outputs you need.
@@ -264,6 +268,10 @@ appearance of a single fast.log-file line:
      filename: fast.log     #The name of the file in the default logging directory.
      append: yes/no         #If this option is set to yes, the last filled fast.log-file will not be
                             #overwritten while restarting Suricata.
+     retries:
+         reconnecting: 1    #number of retries when reconnecting
+         interrupted: 1     #number of retries if write is interrupted
+         blocked: 0         #number of retries if write is blocked
 
 Eve (Extensible Event Format)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -278,6 +286,10 @@ integration with 3rd party tools like logstash.
       enabled: yes
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
+      retries:
+          reconnecting: 1  #number of retries when reconnecting
+          interrupted: 1   #number of retries if write is interrupted
+          blocked: 0       #number of retries if write is blocked
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -128,6 +128,15 @@ typedef struct LogFileCtx_ {
     /* Socket types may need to drop events to keep from blocking
      * Suricata. */
     uint64_t dropped;
+
+    /* Number of retries when reconnected */
+    intmax_t retries_when_reconnecting;
+
+    /* Number of retries allowed when log write would be blocked */
+    intmax_t retries_when_blocked;
+
+    /* Number of retries allowed when log write is interrupted */
+    intmax_t retries_when_interrupted;
 } LogFileCtx;
 
 /* Min time (msecs) before trying to reconnect a Unix domain socket */


### PR DESCRIPTION
Make retries configurable for logs, so that block does not automatically result in a dropped event.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2215

Describe changes:
- Provide new config option retries.blocked, defaulted to 0 to determine number of retries if log write is blocked
- Provide new config option retries.interrupted, defaulted to 1 to determine number of retries if log write is interrupted
- Provide  new config option retries.reconnecting, defaulted to 1 to determine number of retries when reconnecting to log

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

