### PR TITLE
pfring: hw bypass support

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -69,6 +69,7 @@ enum PktSrcEnum {
 #include "source-af-packet.h"
 #include "source-mpipe.h"
 #include "source-netmap.h"
+#include "source-pfring.h"
 
 #include "action-globals.h"
 
@@ -459,6 +460,9 @@ typedef struct Packet_
 #endif
 #ifdef HAVE_NETMAP
         NetmapPacketVars netmap_v;
+#endif
+#ifdef HAVE_PFRING
+        PfringPacketVars pfring_v;
 #endif
 
         /** libpcap vars: shared by Pcap Live mode and Pcap File mode */

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -195,6 +195,7 @@ static void *ParsePfringConfig(const char *iface)
     cluster_type default_ctype = CLUSTER_ROUND_ROBIN;
     int getctype = 0;
     const char *bpf_filter = NULL;
+    int bool_val;
 
     if (unlikely(pfconf == NULL)) {
         return NULL;
@@ -351,6 +352,13 @@ static void *ParsePfringConfig(const char *iface)
             pfconf->checksum_mode = CHECKSUM_VALIDATION_RXONLY;
         } else {
             SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid value for checksum-checks for %s", pfconf->iface);
+        }
+    }
+
+    if (ConfGetChildValueBoolWithDefault(if_root, if_default, "bypass", &bool_val) == 1) {
+        if (bool_val) {
+            SCLogConfig("Using bypass support in PF_RING for iface %s (if supported by underlying hw)", pfconf->iface);
+            pfconf->flags |= PFRING_CONF_FLAGS_BYPASS; 
         }
     }
 

--- a/src/source-pfring.h
+++ b/src/source-pfring.h
@@ -31,9 +31,11 @@
 #include <pfring.h>
 #endif
 
-typedef enum {
-    PFRING_CONF_FLAGS_CLUSTER = 0x1
-} PfringIfaceConfigFlags;
+typedef struct PfringThreadVars_ PfringThreadVars;
+
+/* PfringIfaceConfig flags */
+#define PFRING_CONF_FLAGS_CLUSTER (1 << 0)
+#define PFRING_CONF_FLAGS_BYPASS  (1 << 1)
 
 typedef struct PfringIfaceConfig_
 {
@@ -55,6 +57,16 @@ typedef struct PfringIfaceConfig_
     void (*DerefFunc)(void *);
 } PfringIfaceConfig;
 
+/**
+ * \brief per packet Pfring vars
+ *
+ * This structure is used to pass packet metadata in callbacks.
+ */
+typedef struct PfringPacketVars_
+{
+    PfringThreadVars *ptv;
+    u_int32_t flow_id;
+} PfringPacketVars;
 
 
 void TmModuleReceivePfringRegister (void);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1620,6 +1620,12 @@ pfring:
     cluster-type: cluster_flow
     # bpf filter for this interface
     #bpf-filter: tcp
+
+    # If bypass is set then the PF_RING hw bypass is activated, when supported
+    # by the interface in use. Suricata will instruct the interface to bypass  
+    # all future packets for a flow that need to be bypassed.
+    #bypass: yes
+
     # Choose checksum verification mode for the interface. At the moment
     # of the capture, some packets may be with an invalid checksum due to
     # offloading to the network card of the checksum computation.


### PR DESCRIPTION
This patch adds support for hw bypass by enabling flow offload in the network
card (when supported) and implementing the BypassPacketsFlow callback.
Hw bypass support is disabled by default, and can be enabled by setting
"bypass: yes" in the pfring interface configuration section in suricata.yaml.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/

