### PR TITLE
2215: Configurable Log Event Drop

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -241,6 +241,13 @@ There are several types of output. The general structure is:
       enabled: yes
       filename: fast.log
       append: yes/no
+      when-blocked:
+        drop-events: yes/no     #Whether events to output should drop if they would
+                                #block in offline mode
+        poll-interval: 100      #How long to poll for when blocked and not dropping
+      retries:
+        reconnecting: 1      #number of retries when reconnecting
+        interrupted: 1       #number of retries if write is interrupted
 
 Enabling all of the logs, will result in a much lower performance and
 the use of more disc space, so enable only the outputs you need.
@@ -259,11 +266,18 @@ appearance of a single fast.log-file line:
 
 ::
 
-  -fast:                    #The log-name.
-     enabled:yes            #This log is enabled. Set to 'no' to disable.
-     filename: fast.log     #The name of the file in the default logging directory.
-     append: yes/no         #If this option is set to yes, the last filled fast.log-file will not be
-                            #overwritten while restarting Suricata.
+  -fast:                       #The log-name.
+     enabled:yes               #This log is enabled. Set to 'no' to disable.
+     filename: fast.log        #The name of the file in the default logging directory.
+     append: yes/no            #If this option is set to yes, the last filled fast.log-file will not be
+                               #overwritten while restarting Suricata.
+     when-blocked:
+       drop-events: yes/no     #Whether events to output should drop if they would
+                               #block in offline mode
+       poll-interval: 100      #How long to poll for when blocked and not dropping
+     retries:
+       reconnecting: 1         #number of retries when reconnecting
+       interrupted: 1          #number of retries if write is interrupted
 
 Eve (Extensible Event Format)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -278,6 +292,13 @@ integration with 3rd party tools like logstash.
       enabled: yes
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
+      when-blocked:
+        drop-events: yes/no     #Whether events to output should drop if they would
+                                #block in offline mode
+        poll-interval: 100      #How long to poll for when blocked and not dropping
+      retries:
+        reconnecting: 1         #number of retries when reconnecting
+        interrupted: 1          #number of retries if write is interrupted
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -15,6 +15,13 @@ The most common way to use this is through 'EVE', which is a firehose approach w
       enabled: yes
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
+      when-blocked:
+        drop-events: yes/no     #Whether events to output should drop if they would
+                                #block in offline mode
+        poll-interval: 100      #How long to poll for when blocked and not dropping
+      retries:
+        reconnecting: 1         #number of retries when reconnecting
+        interrupted: 1          #number of retries if write is interrupted
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -128,6 +128,18 @@ typedef struct LogFileCtx_ {
     /* Socket types may need to drop events to keep from blocking
      * Suricata. */
     uint64_t dropped;
+
+    /* Number of retries when reconnected */
+    int retries_when_reconnecting;
+
+    /* If events should be dropped if write would block */
+    bool when_blocked_drop_events;
+
+    /* Poll interval in ms if blocked and not dropping */
+    int when_blocked_poll_interval_ms;
+
+    /* Number of retries allowed when log write is interrupted */
+    int retries_when_interrupted;
 } LogFileCtx;
 
 /* Min time (msecs) before trying to reconnect a Unix domain socket */


### PR DESCRIPTION
Version 2 of:
 - https://github.com/OISF/suricata/pull/2972

Make retries configurable for logs, so that block does not automatically result in a dropped event.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2215

Describe changes:
- Provide new config option when-blocked.drop-events, defaulted to yes to determine if events are dropped when write would block, settable to no online in offline mode
- Provide new config option when-blocked.poll-interval, default to 100 to determine poll interval when not dropping events in offline mode
- Provide new config option retries.interrupted, defaulted to 1 to determine number of retries if log write is interrupted
- Provide  new config option retries.reconnecting, defaulted to 1 to determine number of retries when reconnecting to log

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

