### PR TITLE
2215 Lost Unix Socket Events v3

### DIFF
--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -484,6 +484,20 @@ int RunModeOutputFiledataEnabled(void)
     return filedata_logger_count > 0;
 }
 
+bool IsRunModeOffline(int run_mode)
+{
+    switch(run_mode) {
+        case RUNMODE_PCAP_FILE:
+        case RUNMODE_ERF_FILE:
+        case RUNMODE_ENGINE_ANALYSIS:
+        case RUNMODE_UNIX_SOCKET:
+            return TRUE;
+            break;
+        case RUNMODE_UNKNOWN:
+            return FALSE;
+    }
+}
+
 /**
  * Cleanup the run mode.
  */

--- a/src/runmodes.h
+++ b/src/runmodes.h
@@ -88,6 +88,8 @@ void RunModeShutDown(void);
 int RunModeOutputFileEnabled(void);
 /* bool indicating if filedata logger is enabled */
 int RunModeOutputFiledataEnabled(void);
+/** bool indicating if run mode is offline */
+bool IsRunModeOffline(int run_mode);
 
 #include "runmode-pcap.h"
 #include "runmode-pcap-file.h"

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -203,9 +203,6 @@ volatile uint8_t suricata_ctl_flags = 0;
 /** Run mode selected */
 int run_mode = RUNMODE_UNKNOWN;
 
-/** Is this an offline run mode. */
-int run_mode_offline = 0;
-
 /** Engine mode: inline (ENGINE_MODE_IPS) or just
   * detection mode (ENGINE_MODE_IDS by default) */
 static enum EngineMode g_engine_mode = ENGINE_MODE_IDS;
@@ -2108,6 +2105,8 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
     if (engine_analysis)
         suri->run_mode = RUNMODE_ENGINE_ANALYSIS;
 
+    suri->offline = IsRunModeOffline(suri->run_mode);
+
     ret = SetBpfString(optind, argv);
     if (ret != TM_ECODE_OK)
         return ret;
@@ -2373,11 +2372,6 @@ static int StartInternalRunMode(SCInstance *suri, int argc, char **argv)
 static int FinalizeRunMode(SCInstance *suri, char **argv)
 {
     switch (suri->run_mode) {
-        case RUNMODE_PCAP_FILE:
-        case RUNMODE_ERF_FILE:
-        case RUNMODE_ENGINE_ANALYSIS:
-            suri->offline = 1;
-            break;
         case RUNMODE_UNKNOWN:
             PrintUsage(argv[0]);
             return TM_ECODE_FAILED;
@@ -2386,7 +2380,6 @@ static int FinalizeRunMode(SCInstance *suri, char **argv)
     }
     /* Set the global run mode and offline flag. */
     run_mode = suri->run_mode;
-    run_mode_offline = suri->offline;
 
     if (!CheckValidDaemonModes(suri->daemon, suri->run_mode)) {
         return TM_ECODE_FAILED;

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -194,7 +194,6 @@ int RunmodeGetCurrent(void);
 int IsRuleReloadSet(int quiet);
 
 extern int run_mode;
-extern int run_mode_offline;
 
 void PreRunInit(const int runmode);
 void PreRunPostPrivsDropInit(const int runmode);

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -526,7 +526,7 @@ SCConfLogOpenGeneric(ConfNode *conf,
 
 #ifdef BUILD_WITH_UNIXSOCKET
     /* If a socket and running live, do non-blocking writes. */
-    if (log_ctx->is_sock && run_mode_offline == 0) {
+    if (log_ctx->is_sock && IsRunModeOffline(RunmodeGetCurrent()) == FALSE) {
         SCLogInfo("Setting logging socket of non-blocking in live mode.");
         log_ctx->send_flags |= MSG_DONTWAIT;
     }


### PR DESCRIPTION
Version 3 of:
 - https://github.com/OISF/suricata/pull/2972

Add a method for determining offline from run mode. Make sure SCInstance offline is set correctly. Use current run mode to set socket flags.

V3 makes this bug fixed focused only.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2215

Describe changes:
- Add method IsRunModeOffline to determine if a run mode is offline
- Make sure offline flag is set correctly for SCInstance
- Use IsRunModeOffline to determine socket flags for unix socket output

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

