### PR TITLE
Adds options to mark when a file is final.

### DIFF
--- a/src/log-filestore.c
+++ b/src/log-filestore.c
@@ -203,6 +203,31 @@ static uint32_t FileGetMaxOpenFiles(void)
     return g_file_store_max_open_files;
 }
 
+static char g_file_store_working_file_prefix[PATH_MAX] = "";
+
+static void FileSetWorkingFilePrefix(const char* working_file_prefix)
+{
+    strlcpy(g_file_store_working_file_prefix, working_file_prefix,
+            sizeof(g_file_store_working_file_prefix));
+}
+
+static const char* FileGetWorkingFilePrefix(void)
+{
+    return g_file_store_working_file_prefix;
+}
+
+static int g_file_store_include_pid = 0;
+
+static void FileIncludePidEnable(void)
+{
+    g_file_store_include_pid = 1;
+}
+
+static int FileIncludePid(void)
+{
+    return g_file_store_include_pid;
+}
+
 static void LogFilestoreLogCreateMetaFile(const Packet *p, const File *ff, char *filename, int ipver) {
     if (!FileWriteMeta())
         return;
@@ -282,12 +307,23 @@ static void LogFilestoreLogCloseMetaFile(const File *ff)
     if (!FileWriteMeta())
         return;
 
-    char filename[PATH_MAX] = "";
-    snprintf(filename, sizeof(filename), "%s/file.%u",
-            g_logfile_base_dir, ff->file_store_id);
-    char metafilename[PATH_MAX] = "";
-    snprintf(metafilename, sizeof(metafilename), "%s.meta", filename);
-    FILE *fp = fopen(metafilename, "a");
+    char working_filename[PATH_MAX] = "";
+    char pid_expression[PATH_MAX] = "";
+    if (FileIncludePid())
+        snprintf(pid_expression, sizeof(pid_expression), ".%d", getpid());
+    snprintf(working_filename, sizeof(working_filename), "%s/%sfile%s.%u",
+            g_logfile_base_dir, FileGetWorkingFilePrefix(), pid_expression,
+            ff->file_store_id);
+    char working_metafilename[PATH_MAX] = "";
+    snprintf(working_metafilename, sizeof(working_metafilename),
+            "%s.meta", working_filename);
+    char final_filename[PATH_MAX] = "";
+    snprintf(final_filename, sizeof(final_filename), "%s/file%s.%u",
+            g_logfile_base_dir, pid_expression, ff->file_store_id);
+    char final_metafilename[PATH_MAX] = "";
+    snprintf(final_metafilename, sizeof(final_metafilename),
+            "%s.meta", final_filename);
+    FILE *fp = fopen(working_metafilename, "a");
     if (fp != NULL) {
 #ifdef HAVE_MAGIC
         fprintf(fp, "MAGIC:             %s\n",
@@ -336,8 +372,21 @@ static void LogFilestoreLogCloseMetaFile(const File *ff)
         fprintf(fp, "SIZE:              %"PRIu64"\n", FileTrackedSize(ff));
 
         fclose(fp);
+        /* Move working files to their final location now that we are done
+         * writing them.*/
+        if (strcmp(FileGetWorkingFilePrefix(), "") != 0) {
+            if (rename(working_filename, final_filename) != 0) {
+                SCLogWarning(SC_WARN_RENAMING_FILE, "renaming file %s to %s failed",
+                        working_filename, final_filename);
+                return;
+            }
+            if (rename(working_metafilename, final_metafilename) != 0 ) {
+                SCLogWarning(SC_WARN_RENAMING_FILE, "renaming metafile %s to %s failed",
+                        working_metafilename, final_metafilename);
+            }
+        }
     } else {
-        SCLogInfo("opening %s failed: %s", metafilename, strerror(errno));
+        SCLogInfo("opening %s failed: %s", working_metafilename, strerror(errno));
     }
 }
 
@@ -365,8 +414,12 @@ static int LogFilestoreLogger(ThreadVars *tv, void *thread_data, const Packet *p
 
     SCLogDebug("ff %p, data %p, data_len %u", ff, data, data_len);
 
-    snprintf(filename, sizeof(filename), "%s/file.%u",
-            g_logfile_base_dir, ff->file_store_id);
+    char pid_expression[PATH_MAX] = "";
+    if (FileIncludePid())
+        snprintf(pid_expression, sizeof(pid_expression), ".%d", getpid());
+    snprintf(filename, sizeof(filename), "%s/%sfile%s.%u",
+            g_logfile_base_dir, FileGetWorkingFilePrefix(), pid_expression,
+            ff->file_store_id);
 
     if (flags & OUTPUT_FILEDATA_FLAG_OPEN) {
         aft->file_cnt++;
@@ -596,6 +649,18 @@ static OutputCtx *LogFilestoreLogInitCtx(ConfNode *conf)
                           " open files", file_count);
             }
         }
+    }
+
+    const char *working_file_prefix = ConfNodeLookupChildValue(conf, "working_file_prefix");
+    if (working_file_prefix != NULL && strcmp(working_file_prefix, "") != 0) {
+        FileSetWorkingFilePrefix(working_file_prefix);
+        SCLogInfo("using %s as a working file prefix of all files", working_file_prefix);
+    }
+
+    const char *include_pid = ConfNodeLookupChildValue(conf, "include-pid");
+    if (include_pid != NULL && ConfValIsTrue(include_pid)) {
+        FileIncludePidEnable();
+        SCLogInfo("enabling pid as a part of all file names");
     }
 
     SCReturnPtr(output_ctx, "OutputCtx");

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -342,6 +342,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_WARN_EVENT_DROPPED);
         CASE_CODE (SC_ERR_NO_REDIS_ASYNC);
         CASE_CODE (SC_ERR_REDIS_CONFIG);
+        CASE_CODE (SC_WARN_RENAMING_FILE);
     }
 
     return "UNKNOWN_ERROR";

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -331,7 +331,8 @@ typedef enum {
     SC_WARN_LOG_CF_TOO_MANY_NODES,
     SC_WARN_EVENT_DROPPED,
     SC_ERR_NO_REDIS_ASYNC,
-    SC_ERR_REDIS_CONFIG
+    SC_ERR_REDIS_CONFIG,
+    SC_WARN_RENAMING_FILE
 } SCError;
 
 const char *SCErrorToString(SCError);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -427,6 +427,12 @@ outputs:
   # an incrementing number starting at 1. For each file "file.<id>" a meta
   # file "file.<id>.meta" is created.
   #
+  # If working-file-prefix is defined, then files are first written with the given
+  # prefix, and renamed to remove the prefix when finalized.
+  #
+  # If include-pid is yes, then the files are instead "file.<pid>.<id>", with
+  # meta files named as "file.<pid>.<id>.meta"
+  #
   # File extraction depends on a lot of things to be fully done:
   # - file-store stream-depth. For optimal results, set this to 0 (unlimited)
   # - http request / response body sizes. Again set to 0 for optimal results.
@@ -449,6 +455,9 @@ outputs:
       # remain open for filestore by Suricata. Default value is 0 which
       # means files get closed after each write
       #max-open-files: 1000
+      # uncomment to write to tmp files with the given prefix
+      #working-file-prefix: .
+      include-pid: no # set to yes to include pid in file names
 
   # output module to log files tracked in a easily parsable json format
   - file-log:


### PR DESCRIPTION
This takes the form of an option to have a working file prefix, which is
removed when files are finalized, and an option to add the pid of the
process to file names.

Adding the pid to the file name reduces the likelihood that a file is
overwritten when suricata is unexpectedly killed. The number in the
waldo file is only written out during a clean shutdown. In the event
of an improper shutdown, extracted files will be written using the old
number and existing files with the same name will be overwritten.

Writes extracted files and their metadata to a temporary file prefixed
with a '.'. Renames the files when they are completely done being
written and the meta file is closed. As-is there is no way to know that
a file on disk is still being written to by suricata.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- This adds options to add a pid to all file names, and to add a prefix to temporary files.
  This allows knowing when a file is finalized versus when it is still being processed.
- This is a follow up to [this pull request](https://github.com/OISF/suricata/pull/2981). The changes
are combining the changes into 1 commit.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

