### PR TITLE
SCLogMapLogLevelToSyslogLevel(): treat SC_LOG_PERF messages as LOG_DEBUG.

### DIFF
--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -141,6 +141,7 @@ static inline int SCLogMapLogLevelToSyslogLevel(int log_level)
             syslog_log_level = LOG_INFO;
             break;
         case SC_LOG_DEBUG:
+        case SC_LOG_PERF:
             syslog_log_level = LOG_DEBUG;
             break;
         default:


### PR DESCRIPTION
Previously, when logging to syslog, perf events had a default EMERG priority, which could be a bit confusing.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x ] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes: SCLogMapLogLevelToSyslogLevel() returned LOG_EMERG as a default loglevel. However, a handling of perf events was omitted and they were logged with 'Emergency' priority.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

