### PR TITLE
[discussion] flowbit logging: add to flows; log as array - 1

### DIFF
--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -277,6 +277,14 @@ static void JsonFlowLogJSON(JsonFlowLogThread *aft, json_t *js, Flow *f)
 
     json_object_set_new(hjs, "alerted", json_boolean(FlowHasAlerts(f)));
 
+    if (f->flowvar) {
+        json_t *js_vars = json_object();
+        if (likely(js_vars != NULL)) {
+            JsonAddFlowvars(f, js_vars);
+            json_object_set_new(js, "vars", js_vars);
+        }
+    }
+
     json_object_set_new(js, "flow", hjs);
 
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -226,11 +226,11 @@ void JsonAddFlowvars(const Flow *f, json_t *js_vars)
             const char *varname = VarNameStoreLookupById(fb->idx, VAR_TYPE_FLOW_BIT);
             if (varname) {
                 if (js_flowbits == NULL) {
-                    js_flowbits = json_object();
+                    js_flowbits = json_array();
                     if (js_flowbits == NULL)
                         break;
                 }
-                json_object_set_new(js_flowbits, varname, json_boolean(1));
+                json_array_append(js_flowbits, json_string(varname));
             }
         }
         gv = gv->next;

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -154,7 +154,7 @@ static void JsonAddPacketvars(const Packet *p, json_t *js_vars)
     }
 }
 
-static void JsonAddFlowvars(const Flow *f, json_t *js_vars)
+void JsonAddFlowvars(const Flow *f, json_t *js_vars)
 {
     if (f == NULL || f->flowvar == NULL) {
         return;

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -39,6 +39,7 @@ typedef struct OutputJSONMemBufferWrapper_ {
 
 int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
 
+void JsonAddFlowvars(const Flow *f, json_t *js_vars);
 void JsonAddVars(const Packet *p, const Flow *f, json_t *js);
 void CreateJSONFlowId(json_t *js, const Flow *f);
 void JsonTcpFlags(uint8_t flags, json_t *js);


### PR DESCRIPTION
Putting this out here for discussion:
- First, add the vars/flowbit logging to flow records.
- Second, log the flowbits as an array instead of a map where the flowbit is a key with a true value. This is the point of discussion, and I think it will also make searching/correlation with Elastic Search easier.
Example
```
  "vars": {
    "flowbits": [
      "traffic/id/facebook",
      "traffic/label/social-network",
      "traffic/id/facebook-messenger",
      "traffic/label/im"
    ]
  },
```

As this changes Eve this also involves the discussion of versioning. As "vars" is also an event type, this complicates things. Do we update the version of "eve", as vars is also added to non-"var" events. Or do we just update the version of "vars".

Thought: Introduce a new object, "attributes", "parameters" or even "metadata' which then contains the list of flowbits, etc. More or less what the "vars" is I guess.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/215
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/568
