### PR TITLE
ParseSizeString in util-misc.c: Null-pointer dereference:

### DIFF
--- a/src/util-misc.c
+++ b/src/util-misc.c
@@ -75,6 +75,18 @@ static int ParseSizeString(const char *size, double *res)
 
     *res = 0;
 
+    if (size == NULL) {
+        SCLogError(SC_ERR_INVALID_ARGUMENTS,"invalid size argument - NULL. Valid size "
+                   "argument should be in the format - \n"
+                   "xxx <- indicates it is just bytes\n"
+                   "xxxkb or xxxKb or xxxKB or xxxkB <- indicates kilobytes\n"
+                   "xxxmb or xxxMb or xxxMB or xxxmB <- indicates megabytes\n"
+                   "xxxgb or xxxGb or xxxGB or xxxgB <- indicates gigabytes.\n"
+			    );
+        retval = -2;
+        goto end;
+    }
+
     pcre_exec_ret = pcre_exec(parse_regex, parse_regex_study, size, strlen(size), 0, 0,
                     ov, MAX_SUBSTRINGS);
     if (!(pcre_exec_ret == 2 || pcre_exec_ret == 3)) {


### PR DESCRIPTION
If someone accidently writes invalid characters in some parts of the suricata.yaml-configfile, the size-parameter of the ParseSizeString-function becomes NULL and gets dereferenced. Suricata crashes with SEGV. This commit fixes Ticket #2274 (https://redmine.openinfosecfoundation.org/issues/2274)

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2274

Describe changes:

 - In ParseSizeString my changes validate the size-parameter. If it is NULL, the function throws an error and returns with -2.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

