### PR TITLE
Confgetint bug 2275 v1

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -386,9 +386,15 @@ int ConfGetInt(const char *name, intmax_t *val)
     if (ConfGet(name, &strval) == 0)
         return 0;
 
+    if (strval == NULL) {
+        SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY, "malformed integer value "
+                "for %s: NULL", name);
+        return 0;
+    }
+
     errno = 0;
     tmpint = strtoimax(strval, &endptr, 0);
-    if (strval[0] == '\0' || *endptr != '\0') {
+    if (*endptr != '\0') {
         SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY, "malformed integer value "
                 "for %s: '%s'", name, strval);
         return 0;

--- a/src/util-misc.c
+++ b/src/util-misc.c
@@ -75,6 +75,18 @@ static int ParseSizeString(const char *size, double *res)
 
     *res = 0;
 
+    if (size == NULL) {
+        SCLogError(SC_ERR_INVALID_ARGUMENTS,"invalid size argument - NULL. Valid size "
+                   "argument should be in the format - \n"
+                   "xxx <- indicates it is just bytes\n"
+                   "xxxkb or xxxKb or xxxKB or xxxkB <- indicates kilobytes\n"
+                   "xxxmb or xxxMb or xxxMB or xxxmB <- indicates megabytes\n"
+                   "xxxgb or xxxGb or xxxGB or xxxgB <- indicates gigabytes.\n"
+			    );
+        retval = -2;
+        goto end;
+    }
+
     pcre_exec_ret = pcre_exec(parse_regex, parse_regex_study, size, strlen(size), 0, 0,
                     ov, MAX_SUBSTRINGS);
     if (!(pcre_exec_ret == 2 || pcre_exec_ret == 3)) {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [* ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [*] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [*] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2275

Describe changes:

This changes will validate strval in ConfGetInt right before strtoimax is called. If strval is NULL, the function will exit with an proper error.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

