### PR TITLE
ConfGetInt in conf.c: NULL-pointer dereference

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -386,6 +386,12 @@ int ConfGetInt(const char *name, intmax_t *val)
     if (ConfGet(name, &strval) == 0)
         return 0;
 
+    if (strval == NULL) {
+        SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY, "malformed integer value "
+                "for %s: NULL", name);
+        return 0;
+    }
+
     errno = 0;
     tmpint = strtoimax(strval, &endptr, 0);
     if (strval[0] == '\0' || *endptr != '\0') {


### PR DESCRIPTION

 - [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
 - [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
 - [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to redmine ticket: https://redmine.openinfosecfoundation.org/issues/2275

Describe changes:

 - This changes will validate strval in ConfGetInt right before strtoimax is called. If strval is NULL, the function will exit with an proper error.

PRScript output (if applicable):