### PR TITLE
conf: fix NULL-pointer dereference in CoredumpLoadConfig

### DIFF
--- a/src/util-coredump-config.c
+++ b/src/util-coredump-config.c
@@ -49,6 +49,10 @@ int32_t CoredumpLoadConfig (void)
         SCLogDebug ("core dump size not specified");
         return 1;
     }
+    if (dump_size_config == NULL) {
+        SCLogError (SC_ERR_INVALID_YAML_CONF_ENTRY, "malformed value for coredump.max-dump: NULL");
+        return 0;
+    }
     if (strcasecmp (dump_size_config, "unlimited") == 0) {
         unlimited = 1;
     }


### PR DESCRIPTION
An empty value for coredump.max-dump in the config-file leads to a segfault because of a NULL-pointer dereference in CoredumpLoadConfig().

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2276

Describe changes:
- This change validates dump_size_config. if it is NULL CoredumpLoadConfig will return with an error and a proper error-message.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

