### PR TITLE
Adds options to mark when a file is final.

### DIFF
--- a/doc/userguide/file-extraction/file-extraction.rst
+++ b/doc/userguide/file-extraction/file-extraction.rst
@@ -44,8 +44,10 @@ drop dir must be configured.
       waldo: file.waldo # waldo file to store the file_id across runs
       max-open-files: 0 # how many files to keep open (O means none)
       write-meta: yes   # write a .meta file if set to yes
+      working-file-prefix: . # if nonempty, and write-meta is yes, use the given prefix to indicate that the file is not finalized.
+      include-pid: yes  # include the pid in filenames if set to yes.
 
-Each file that is stored with have a name "file.<id>". The id will be reset and files will be overwritten unless the waldo option is used. A "file.<id>.meta" file is generated containing file metadata if write-meta is set to yes (default).
+Each file that is stored with have a name "file.<id>". The id will be reset and files will be overwritten unless the waldo option is used. A "file.<id>.meta" file is generated containing file metadata if write-meta is set to yes (default). If the include-pid option is set, the files will instead have a name "file.<pid>.<id>", and metafiles will be "file.<pid>.<id>.meta". Files will additionally have the suffix ".tmp" while they are open, which is only removed when they are finalized.
 
 
 ::

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -342,6 +342,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_WARN_EVENT_DROPPED);
         CASE_CODE (SC_ERR_NO_REDIS_ASYNC);
         CASE_CODE (SC_ERR_REDIS_CONFIG);
+        CASE_CODE (SC_WARN_RENAMING_FILE);
     }
 
     return "UNKNOWN_ERROR";

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -331,7 +331,8 @@ typedef enum {
     SC_WARN_LOG_CF_TOO_MANY_NODES,
     SC_WARN_EVENT_DROPPED,
     SC_ERR_NO_REDIS_ASYNC,
-    SC_ERR_REDIS_CONFIG
+    SC_ERR_REDIS_CONFIG,
+    SC_WARN_RENAMING_FILE
 } SCError;
 
 const char *SCErrorToString(SCError);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -425,7 +425,11 @@ outputs:
   #
   # The files are stored to the log-dir in a format "file.<id>" where <id> is
   # an incrementing number starting at 1. For each file "file.<id>" a meta
-  # file "file.<id>.meta" is created.
+  # file "file.<id>.meta" is created. Before they are finalized, they will
+  # have a ".tmp" suffix to indicate that they are still being processed.
+  #
+  # If include-pid is yes, then the files are instead "file.<pid>.<id>", with
+  # meta files named as "file.<pid>.<id>.meta"
   #
   # File extraction depends on a lot of things to be fully done:
   # - file-store stream-depth. For optimal results, set this to 0 (unlimited)
@@ -449,6 +453,7 @@ outputs:
       # remain open for filestore by Suricata. Default value is 0 which
       # means files get closed after each write
       #max-open-files: 1000
+      include-pid: no # set to yes to include pid in file names
 
   # output module to log files tracked in a easily parsable json format
   - file-log:


### PR DESCRIPTION
This takes the form of an option to add the pid of the process to file
names. Additionally, it adds a suffix to the file name to indicate it is
not finalized.

Adding the pid to the file name reduces the likelihood that a file is
overwritten when suricata is unexpectedly killed. The number in the
waldo file is only written out during a clean shutdown. In the event
of an improper shutdown, extracted files will be written using the old
number and existing files with the same name will be overwritten.

Writes extracted files and their metadata to a temporary file suffixed
with '.tmp' and '.tmp.meta' respectivecly. Renames the files when they
are completely done being written. As-is there is no way to know that
a file on disk is still being written to by suricata.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Followup to PR #2984.
- Changes are using a suffix instead of a prefix (".tmp", and ".tmp.meta"), making it the standard behavior, and not requiring write-meta for this option.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):