### PR TITLE
pfring: fixes pfring.h include

### DIFF
--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -96,7 +96,7 @@ static void *OldParsePfringConfig(const char *iface)
     PfringIfaceConfig *pfconf = SCMalloc(sizeof(*pfconf));
     const char *tmpclusterid;
     const char *tmpctype = NULL;
-    cluster_type default_ctype = CLUSTER_ROUND_ROBIN;
+    int default_ctype = CLUSTER_ROUND_ROBIN;
 
     if (unlikely(pfconf == NULL)) {
         return NULL;
@@ -156,11 +156,11 @@ static void *OldParsePfringConfig(const char *iface)
     } else if (strcmp(tmpctype, "cluster_round_robin") == 0) {
         SCLogInfo("Using round-robin cluster mode for PF_RING (iface %s)",
                 pfconf->iface);
-        pfconf->ctype = (cluster_type)tmpctype;
+        pfconf->ctype = CLUSTER_ROUND_ROBIN;
     } else if (strcmp(tmpctype, "cluster_flow") == 0) {
         SCLogInfo("Using flow cluster mode for PF_RING (iface %s)",
                 pfconf->iface);
-        pfconf->ctype = (cluster_type)tmpctype;
+        pfconf->ctype = CLUSTER_FLOW;
     } else {
         SCLogError(SC_ERR_INVALID_CLUSTER_TYPE,"invalid cluster-type %s",tmpctype);
         SCFree(pfconf);
@@ -192,7 +192,7 @@ static void *ParsePfringConfig(const char *iface)
     PfringIfaceConfig *pfconf = SCMalloc(sizeof(*pfconf));
     const char *tmpclusterid;
     const char *tmpctype = NULL;
-    cluster_type default_ctype = CLUSTER_ROUND_ROBIN;
+    int default_ctype = CLUSTER_ROUND_ROBIN;
     int getctype = 0;
     const char *bpf_filter = NULL;
 
@@ -209,7 +209,7 @@ static void *ParsePfringConfig(const char *iface)
     strlcpy(pfconf->iface, iface, sizeof(pfconf->iface));
     pfconf->threads = 1;
     pfconf->cluster_id = 1;
-    pfconf->ctype = (cluster_type)default_ctype;
+    pfconf->ctype = default_ctype;
     pfconf->DerefFunc = PfringDerefConfig;
     SC_ATOMIC_INIT(pfconf->ref);
     (void) SC_ATOMIC_ADD(pfconf->ref, 1);

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -28,10 +28,6 @@
  * \todo Allow ring options such as snaplen etc, to be user configurable.
  */
 
-#ifdef HAVE_PFRING
-#include <pfring.h>
-#endif /* HAVE_PFRING */
-
 #include "suricata-common.h"
 #include "suricata.h"
 #include "conf.h"
@@ -61,6 +57,10 @@
 #include "util-cuda-vars.h"
 
 #endif /* __SC_CUDA_SUPPORT__ */
+
+#ifdef HAVE_PFRING
+#include <pfring.h>
+#endif /* HAVE_PFRING */
 
 TmEcode ReceivePfringLoop(ThreadVars *tv, void *data, void *slot);
 TmEcode PfringBreakLoop(ThreadVars *tv, void *data);

--- a/src/source-pfring.h
+++ b/src/source-pfring.h
@@ -27,9 +27,6 @@
 #define PFRING_IFACE_NAME_LENGTH 48
 
 #include <config.h>
-#ifdef HAVE_PFRING
-#include <pfring.h>
-#endif
 
 typedef enum {
     PFRING_CONF_FLAGS_CLUSTER = 0x1
@@ -41,9 +38,7 @@ typedef struct PfringIfaceConfig_
 
     /* cluster param */
     int cluster_id;
-#ifdef HAVE_PFRING
-    cluster_type ctype;
-#endif
+    int ctype;
     char iface[PFRING_IFACE_NAME_LENGTH];
     /* number of threads */
     int threads;


### PR DESCRIPTION
This patch removes the pfring.h include from source-pfring.h which is not really
needed and can cause side effects when included in the suricata core sources,
and moves the pfring.h include in source-pfring.c after the conf.h include otherwise
it has no effect because HAVE_PFRING is not yet defined.
Some fixes to the cluster type are also needed as a consequence of this change.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/