### PR TITLE
Add support for PCAP LINKTYPE_IPV4

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -1090,6 +1090,7 @@ void DecodeGlobalConfig(void);
 /* http://www.tcpdump.org/linktypes.html defines DLT_RAW as 101, yet others don't.
  * Libpcap on at least OpenBSD returns 101 as datalink type for RAW pcaps though. */
 #define LINKTYPE_RAW2       101
+#define LINKTYPE_IPV4       228
 #define PPP_OVER_GRE        11
 #define VLAN_OVER_GRE       13
 

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -326,6 +326,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
         case LINKTYPE_PPP:
             pcap_g.Decoder = DecodePPP;
             break;
+        case LINKTYPE_IPV4:
         case LINKTYPE_RAW:
         case LINKTYPE_RAW2:
             pcap_g.Decoder = DecodeRaw;


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Trivial PR to add support for PCAP linktype 228 (raw IPV4), see http://www.tcpdump.org/linktypes.html
- This format is the default for PCAP files generated by scapy. It is similar to LINKTYPE_RAW
- I have not seen doc files mentioning the link type, except this wiki page: https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Packet_Pipeline

