### PR TITLE
NSM: add DNS header flag for dns event record V2

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -184,6 +184,13 @@ Outline of fields seen in the different kinds of DNS events:
 
 * "type": Indicating DNS message type, can be "answer" or "query".
 * "id": <needs explanation>
+* "flags": Indicating DNS answer flag, in hexadecimal (ex: 8180 , please note 0x is not output)
+* "qr": Indicating in case of DNS answer flag, Query/Response flag (ex: true if set)
+* "aa": Indicating in case of DNS answer flag, Authoritative Answer flag (ex: true if set)
+* "tc": Indicating in case of DNS answer flag, Truncation flag (ex: true if set)
+* "rd": Indicating in case of DNS answer flag, Recursion Desired flag (ex: true if set)
+* "ra": Indicating in case of DNS answer flag, Recursion Available flag (ex: true if set)
+* "rcode": (ex: NOERROR)
 * "rrname": Resource Record Name (ex: a domain name)
 * "rrtype": Resource Record Type (ex: A, AAAA, NS, PTR)
 * "rdata": Resource Data (ex. IP that domain name resolves to)
@@ -213,6 +220,11 @@ Example of a DNS answer with an IPv4 (resource record type 'A') return:
   "dns": {
       "type": "answer",
       "id":16000,
+      "flags":"8180", 
+      "qr":true,
+      "rd":true,
+      "ra":true,
+      "rcode":"NOERROR"
       "rrname": "twitter.com",
       "rrtype":"A",
       "ttl":8,

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -379,6 +379,22 @@ fn dns_log_json_answer(header: &DNSHeader, answer: &DNSAnswerEntry)
 
     js.set_string("type", "answer");
     js.set_integer("id", header.tx_id as u64);
+    js.set_string("flags", format!("{:x}", header.flags).as_str());
+    if header.flags & 0x8000 != 0 {
+        js.set_boolean("qr", true);
+    }
+    if header.flags & 0x0400 != 0 {
+        js.set_boolean("aa", true);
+    }
+    if header.flags & 0x0200 != 0 {
+        js.set_boolean("tc", true);
+    }
+    if header.flags & 0x0100 != 0 {
+        js.set_boolean("rd", true);
+    }
+    if header.flags & 0x0080 != 0 {
+        js.set_boolean("ra", true);
+    }
     js.set_string("rcode", &dns_rcode_string(header.flags));
     js.set_string_from_bytes("rrname", &answer.name);
     js.set_string("rrtype", &dns_rrtype_string(answer.rrtype));

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -194,6 +194,7 @@ typedef struct DNSAnswerEntry_ {
 typedef struct DNSTransaction_ {
     uint16_t tx_num;                                /**< internal: id */
     uint16_t tx_id;                                 /**< transaction id */
+    uint16_t flags;                                 /**< dns flags */
     uint32_t logged;                                /**< flags for loggers done logging */
     uint8_t replied;                                /**< bool indicating request is
                                                          replied to. */

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -508,6 +508,8 @@ static int DNSReponseParseData(Flow *f, DNSState *dns_state, const uint8_t *inpu
             tx->recursion_desired = 1;
     }
 
+    tx->flags = ntohs(dns_header->flags);
+
     if (tx != NULL) {
         tx->replied = 1;
     }

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -316,6 +316,7 @@ static int DNSUDPResponseParse(Flow *f, void *dstate,
             tx->recursion_desired = 1;
         }
 
+        tx->flags = ntohs(dns_header->flags);
         tx->replied = 1;
     }
     if (f != NULL) {

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -467,8 +467,19 @@ static void OutputAnswer(LogDnsLogThread *aft, json_t *djs,
 
     /* dns */
     char flags[7] = "";
-    snprintf(flags, sizeof(flags), "0x%4x", tx->flags);
+    snprintf(flags, sizeof(flags), "%4x", tx->flags);
     json_object_set_new(js, "flags", json_string(flags));
+    if (tx->flags & 0x8000)
+        json_object_set_new(js, "qr", json_true());
+    if (tx->flags & 0x0400)
+        json_object_set_new(js, "aa", json_true());
+    if (tx->flags & 0x0200)
+        json_object_set_new(js, "tc", json_true());
+    if (tx->flags & 0x0100)
+        json_object_set_new(js, "rd", json_true());
+    if (tx->flags & 0x0080)
+        json_object_set_new(js, "ra", json_true());
+
 
     /* rcode */
     char rcode[16] = "";

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -465,6 +465,11 @@ static void OutputAnswer(LogDnsLogThread *aft, json_t *djs,
     /* id */
     json_object_set_new(js, "id", json_integer(tx->tx_id));
 
+    /* dns */
+    char flags[7] = "";
+    snprintf(flags, sizeof(flags), "0x%4x", tx->flags);
+    json_object_set_new(js, "flags", json_string(flags));
+
     /* rcode */
     char rcode[16] = "";
     DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));


### PR DESCRIPTION
Update of PR  #2946
- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-  add dns flag code in eve log (updated from code review of PR 2920)
-  add dns flag in hexa code and various data (like tcp flags) (suggested from PR 2920)
    eg: "flags":"8180","qr":true,"rd":true,"ra":true
-  done with C code and rust code  (requested from PR 2920)
-  do it for DNS over UDP (PR 2920) and DNS over TCP (requested from PR 2946)
-  update documentation as requested in previous code review (requested from PR 2946)

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

