### PR TITLE
detect/http_start: check if 'line' is valid

### DIFF
--- a/src/detect-http-start.c
+++ b/src/detect-http-start.c
@@ -109,7 +109,7 @@ static uint8_t *GetBufferForTX(htp_tx_t *tx, uint64_t tx_id,
         headers = tx->response_headers;
         line = tx->response_line;
     }
-    if (headers == NULL)
+    if (line == NULL || headers == NULL)
         return NULL;
 
     size_t line_size = bstr_len(line) + 2;


### PR DESCRIPTION
In certain conditions like low memory the line can be NULL.

Bug #2307.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2307

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/36
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/37
