### PR TITLE
Don't printf on util-enum errors (Bug #2268)

### DIFF
--- a/src/util-enum.c
+++ b/src/util-enum.c
@@ -25,6 +25,7 @@
 #include <string.h>
 
 #include "util-enum.h"
+#include "util-debug.h"
 
 /**
  * \brief Maps a string name to an enum value from the supplied table.  Please
@@ -42,7 +43,7 @@ int SCMapEnumNameToValue(const char *enum_name, SCEnumCharMap *table)
     int result = -1;
 
     if (enum_name == NULL || table == NULL) {
-        printf("Invalid argument(s) passed into SCMapEnumNameToValue\n");
+        SCLogDebug("Invalid argument(s) passed into SCMapEnumNameToValue\n");
         return -1;
     }
 
@@ -68,7 +69,7 @@ int SCMapEnumNameToValue(const char *enum_name, SCEnumCharMap *table)
 const char * SCMapEnumValueToName(int enum_value, SCEnumCharMap *table)
 {
     if (table == NULL) {
-        printf("Invalid argument(s) passed into SCMapEnumValueToName\n");
+        SCLogDebug("Invalid argument(s) passed into SCMapEnumValueToName\n");
         return NULL;
     }
 
@@ -78,7 +79,7 @@ const char * SCMapEnumValueToName(int enum_value, SCEnumCharMap *table)
         }
     }
 
-    printf("A enum by the value %d doesn't exist in this table\n", enum_value);
+    SCLogDebug("A enum by the value %d doesn't exist in this table\n", enum_value);
 
     return NULL;
 }


### PR DESCRIPTION
When util-enum encounters an error around enum value it should log the error rather than losing it to console with printf.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2268

Describe changes:
- Convert printf's on error in util-enum.c to SCLogDebug

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

