### PR TITLE
hardening: unix suricata-command.socket permission update

### DIFF
--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -163,19 +163,6 @@ static int UnixNew(UnixCommand * this)
     }
     this->select_max = this->socket + 1;
 
-#if !(defined OS_FREEBSD || defined __OpenBSD__)
-    /* Set file mode: will not fully work on most system, the group
-     * permission is not changed on some Linux. *BSD won't do the
-     * chmod: it returns EINVAL when calling fchmod on sockets. */
-    ret = fchmod(this->socket, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
-    if (ret == -1) {
-        int err = errno;
-        SCLogWarning(SC_ERR_INITIALIZATION,
-                     "Unable to change permission on socket: %s (%d)",
-                     strerror(err),
-                     err);
-    }
-#endif
     /* set reuse option */
     ret = setsockopt(this->socket, SOL_SOCKET, SO_REUSEADDR,
                      (char *) &on, sizeof(on));
@@ -192,6 +179,20 @@ static int UnixNew(UnixCommand * this)
                      sockettarget, strerror(errno));
         return 0;
     }
+
+#if !(defined OS_FREEBSD || defined __OpenBSD__)
+    /* Set file mode: will not fully work on most system, the group
+     * permission is not changed on some Linux. *BSD won't do the
+     * chmod: it returns EINVAL when calling chmod on sockets. */
+    ret = chmod(sockettarget, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
+    if (ret == -1) {
+        int err = errno;
+        SCLogWarning(SC_ERR_INITIALIZATION,
+                     "Unable to change permission on socket: %s (%d)",
+                     strerror(err),
+                     err);
+    }
+#endif
 
     /* listen */
     if (listen(this->socket, 1) == -1) {


### PR DESCRIPTION
- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
So far, the suricata socket suricata-command.socket has the rights rw-r----- suricata:user. 
When suricata is used with restricted access, an other application (suricatasc like) that needs to access to the command socket also with restricted access can not write to the socket since it is not the owner (e.g suricata within container, with an hardened value for umask and hardened rights for users). 
The socket should be set as rw-rw----. Use chmod instead of fchmod and set it after the socket creation.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

