### PR TITLE
conf: stack-based buffer-overflow in ParseFilename

### DIFF
--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -106,6 +106,7 @@ typedef struct PcapLogProfileData_ {
 } PcapLogProfileData;
 
 #define MAX_TOKS 9
+#define MAX_FILENAMELEN 513
 
 /**
  * PcapLog thread vars
@@ -832,16 +833,24 @@ static TmEcode PcapLogDataDeinit(ThreadVars *t, void *thread_data)
     return TM_ECODE_OK;
 }
 
+
 static int ParseFilename(PcapLogData *pl, const char *filename)
 {
     char *toks[MAX_TOKS] = { NULL };
     int tok = 0;
-    char str[512] = "";
+    char str[MAX_FILENAMELEN] = "";
     int s = 0;
     int i, x;
     char *p = NULL;
+    size_t filename_len = 0;
 
     if (filename) {
+        filename_len = strlen(filename);
+        if (filename_len > (MAX_FILENAMELEN-1)) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "invalid filename option. Max filename-length: %d",MAX_FILENAMELEN-1);
+            goto error;
+        }
+
         for (i = 0; i < (int)strlen(filename); i++) {
             if (tok >= MAX_TOKS) {
                 SCLogError(SC_ERR_INVALID_ARGUMENT,


### PR DESCRIPTION
There is a stack-based buffer-overflow in ParseFilename. Since the length of "outputs.pcap-log.filename" is not checked and the destination buffer "str" has a fixed length of 512 bytes, a buffer overflow happens with long filenames. An attacker could exploit this for code execution if the configuration-file is not protected properly. This commit fixes ticket #2335

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2335

Describe changes:
- created a macro definition for the bound of "str"
- added a length-check for filename
- exit with SCLogError if length exceeds the macro-definition

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

