### PR TITLE
conf: NULL-pointer dereference in ConfUnixSocketIsEnable

### DIFF
--- a/src/util-conf.c
+++ b/src/util-conf.c
@@ -101,6 +101,11 @@ int ConfUnixSocketIsEnable(void)
         return 0;
     }
 
+    if (value == NULL) {
+        SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY, "malformed value for unix-command.enabled: NULL");
+        return 0;
+    }
+
     if (!strcmp(value, "auto")) {
 #ifdef HAVE_LIBJANSSON
 #ifdef OS_WIN32


### PR DESCRIPTION
The value for the configuration-option "unix-command.enabled" is not properly checked in ConfUnixSocketIsEnable. This causes a NULL-pointer dereference in strcmp. This commit fixes bug #2346. 

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2346

Describe changes:
- Added a check for "value"
- SCLogError if value is NULL

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

