### PR TITLE
Rotate log files based on file size

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -243,7 +243,7 @@ modifiers.
 Rotate log file
 ~~~~~~~~~~~~~~~
 
-Eve-log can be configured to rotate based on time.
+Eve-log can be configured to rotate based on time, file size, or both combined.
 
 ::
 
@@ -251,9 +251,16 @@ Eve-log can be configured to rotate based on time.
     - eve-log:
         filename: eve-%Y-%m-%d-%H:%M.json
         rotate-interval: minute
+        rotate-size: 100mb
 
-The example above creates a new log file each minute, where the filename contains
-a timestamp. Other supported ``rotate-interval`` values are ``hour`` and ``day``.
+The example above creates a new log file either each minute or when the file
+reaches 100 mb in size. The filename contains a timestamp to avoid overwriting
+itself when rotating.
+
+If both time-based and size-based rotation is used at the same time, then the
+rotation time is reset upon rotation, even if the rotation was based on size.
+
+Other supported ``rotate-interval`` values are ``hour`` and ``day``.
 
 In addition to this, it is also possible to specify the ``rotate-interval`` as a
 relative value. One example is to rotate the log file each X seconds.

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -137,6 +137,7 @@ typedef struct LogFileCtx_ {
 #define LOGFILE_HEADER_WRITTEN  0x01
 #define LOGFILE_ALERTS_PRINTED  0x02
 #define LOGFILE_ROTATE_INTERVAL 0x04
+#define LOGFILE_ROTATE_SIZE     0x08
 
 LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);


### PR DESCRIPTION
Rotate log files based on size. Similar to the time-based rotation.

Enable by adding 'rotate-size' to the logger in suricata.yaml:
```yaml
- eve-log:
    enabled: yes
    filetype: regular
    filename: eve-%s.json
    rotate-size: 50mb
```    

Also works together with time-based rotation, which makes it possible to rotate either when reaching a specific file size, or after a specified time.

https://redmine.openinfosecfoundation.org/issues/2107

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/134
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/134