### PR TITLE
conf: multiple NULL-pointer dereferences in FlowInitConfig

### DIFF
--- a/src/flow.c
+++ b/src/flow.c
@@ -436,6 +436,11 @@ void FlowInitConfig(char quiet)
     /** set config values for memcap, prealloc and hash_size */
     if ((ConfGet("flow.memcap", &conf_val)) == 1)
     {
+        if (conf_val == NULL) {
+            SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,"Invalid value for flow.memcap: NULL");
+	    exit(EXIT_FAILURE);
+        }
+
         if (ParseSizeStringU64(conf_val, &flow_config.memcap) < 0) {
             SCLogError(SC_ERR_SIZE_PARSE, "Error parsing flow.memcap "
                        "from conf file - %s.  Killing engine",
@@ -445,6 +450,11 @@ void FlowInitConfig(char quiet)
     }
     if ((ConfGet("flow.hash-size", &conf_val)) == 1)
     {
+        if (conf_val == NULL) {
+            SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,"Invalid value for flow.hash-size: NULL");
+	    exit(EXIT_FAILURE);
+        }
+
         if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             flow_config.hash_size = configval;
@@ -452,6 +462,11 @@ void FlowInitConfig(char quiet)
     }
     if ((ConfGet("flow.prealloc", &conf_val)) == 1)
     {
+        if (conf_val == NULL) {
+            SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,"Invalid value for flow.prealloc: NULL");
+	    exit(EXIT_FAILURE);
+        }
+
         if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             flow_config.prealloc = configval;


### PR DESCRIPTION
This commit fixes multiple NULL-pointer dereferences in FlowInitConfig after reading in config-values(flow.hash-size, flow.prealloc and flow.memcap) for flow. 

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2349

Describe changes:
- NULL-check for value of flow.hash-size
- NULL-check for value of flow.prealloc
- NULL-check for value of flow.memcap

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

