### PR TITLE
eve metadata - v1

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -785,7 +785,15 @@ static void XffSetup(AlertJsonOutputCtx *json_output_ctx, ConfNode *conf)
     if (conf != NULL) {
         SetFlag(conf, "metadata", LOG_JSON_METADATA_ALL, &json_output_ctx->flags);
         SetFlag(conf, "flow", LOG_JSON_FLOW, &json_output_ctx->flags);
-        SetFlag(conf, "vars", LOG_JSON_VARS, &json_output_ctx->flags);
+
+        /* Break out vars so we can issue a deprecation notice. */
+        const char *vars = ConfNodeLookupChildValue(conf, "vars");
+        if (vars != NULL && ConfValIsTrue(vars)) {
+            SCLogNotice("The \"vars\" eve type has been deprecated.");
+            json_output_ctx->flags |= LOG_JSON_VARS;
+        } else {
+            json_output_ctx->flags &= ~LOG_JSON_VARS;
+        }
 
         SetFlag(conf, "http", LOG_JSON_HTTP, &json_output_ctx->flags);
         SetFlag(conf, "tls",  LOG_JSON_TLS,  &json_output_ctx->flags);

--- a/src/output-json-email-common.h
+++ b/src/output-json-email-common.h
@@ -28,6 +28,7 @@ typedef struct OutputJsonEmailCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags; /** Store mode */
     uint64_t fields;/** Store fields */
+    bool     include_metadata;
 } OutputJsonEmailCtx;
 
 

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -54,6 +54,7 @@
 typedef struct LogJsonFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags; /** Store mode */
+    bool include_metadata;
 } LogJsonFileCtx;
 
 typedef struct JsonFlowLogThread_ {
@@ -215,9 +216,7 @@ void JsonAddFlow(Flow *f, json_t *js, json_t *hjs)
 /* JSON format logging */
 static void JsonFlowLogJSON(JsonFlowLogThread *aft, json_t *js, Flow *f)
 {
-#if 0
     LogJsonFileCtx *flow_ctx = aft->flowlog_ctx;
-#endif
     json_t *hjs = json_object();
     if (hjs == NULL) {
         return;
@@ -279,6 +278,9 @@ static void JsonFlowLogJSON(JsonFlowLogThread *aft, json_t *js, Flow *f)
 
     json_object_set_new(js, "flow", hjs);
 
+    if (flow_ctx->include_metadata) {
+        JsonAddMetadata(NULL, f, js);
+    }
 
     /* TCP */
     if (f->proto == IPPROTO_TCP) {
@@ -441,6 +443,7 @@ static OutputCtx *OutputFlowLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 
     flow_ctx->file_ctx = ojc->file_ctx;
     flow_ctx->flags = LOG_HTTP_DEFAULT;
+    flow_ctx->include_metadata = ojc->include_metadata;
 
     output_ctx->data = flow_ctx;
     output_ctx->DeInit = OutputFlowLogDeinitSub;

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -58,6 +58,7 @@ typedef struct LogHttpFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags; /** Store mode */
     uint64_t fields;/** Store fields */
+    bool include_metadata;
 } LogHttpFileCtx;
 
 typedef struct JsonHttpLogThread_ {
@@ -455,6 +456,10 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 
+    if (jhl->httplog_ctx->include_metadata) {
+        JsonAddMetadata(p, f, js);
+    }
+
     SCLogDebug("got a HTTP request and now logging !!");
 
     /* reset */
@@ -572,6 +577,7 @@ static OutputCtx *OutputHttpLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 
     http_ctx->file_ctx = ojc->file_ctx;
     http_ctx->flags = LOG_HTTP_DEFAULT;
+    http_ctx->include_metadata = ojc->include_metadata;
 
     if (conf) {
         const char *extended = ConfNodeLookupChildValue(conf, "extended");

--- a/src/output-json-nfs.c
+++ b/src/output-json-nfs.c
@@ -54,6 +54,7 @@
 typedef struct LogNFSFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t    flags;
+    bool        include_metadata;
 } LogNFSFileCtx;
 
 typedef struct LogNFSLogThread_ {
@@ -103,6 +104,10 @@ static int JsonNFSLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
+    if (thread->nfslog_ctx->include_metadata) {
+        JsonAddMetadata(p, f, js);
+    }
+
     json_t *rpcjs = rs_rpc_log_json_response(tx);
     if (unlikely(rpcjs == NULL)) {
         goto error;
@@ -136,13 +141,14 @@ static void OutputNFSLogDeInitCtxSub(OutputCtx *output_ctx)
 static OutputCtx *OutputNFSLogInitSub(ConfNode *conf,
     OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ajt = parent_ctx->data;
 
     LogNFSFileCtx *nfslog_ctx = SCCalloc(1, sizeof(*nfslog_ctx));
     if (unlikely(nfslog_ctx == NULL)) {
         return NULL;
     }
     nfslog_ctx->file_ctx = ajt->file_ctx;
+    nfslog_ctx->include_metadata = ajt->include_metadata;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -96,6 +96,10 @@ static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     /* reset */
     MemBufferReset(jhl->buffer);
 
+    if (jhl->emaillog_ctx->include_metadata) {
+        JsonAddMetadata(p, f, js);
+    }
+
     sjs = JsonSmtpDataLogger(f, state, tx, tx_id);
     if (sjs) {
         json_object_set_new(js, "smtp", sjs);
@@ -203,6 +207,7 @@ static OutputCtx *OutputSmtpLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
     }
 
     email_ctx->file_ctx = ojc->file_ctx;
+    email_ctx->include_metadata = ojc->include_metadata;
 
     OutputEmailInitConf(conf, email_ctx);
 

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -57,6 +57,7 @@
 typedef struct OutputSshCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags; /** Store mode */
+    bool include_metadata;
 } OutputSshCtx;
 
 
@@ -108,6 +109,10 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
     json_t *js = CreateJSONHeader((Packet *)p, 1, "ssh");//TODO
     if (unlikely(js == NULL))
         return 0;
+
+    if (ssh_ctx->include_metadata) {
+        JsonAddMetadata(p, f, js);
+    }
 
     json_t *tjs = json_object();
     if (tjs == NULL) {
@@ -239,6 +244,7 @@ static OutputCtx *OutputSshLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
     }
 
     ssh_ctx->file_ctx = ojc->file_ctx;
+    ssh_ctx->include_metadata = ojc->include_metadata;
 
     output_ctx->data = ssh_ctx;
     output_ctx->DeInit = OutputSshLogDeinitSub;

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -102,6 +102,7 @@ typedef struct OutputTlsCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags;  /** Store mode */
     uint64_t fields; /** Store fields */
+    bool include_metadata;
 } OutputTlsCtx;
 
 
@@ -361,6 +362,10 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         return 0;
     }
 
+    if (tls_ctx->include_metadata) {
+        JsonAddMetadata(p, f, js);
+    }
+
     json_t *tjs = json_object();
     if (tjs == NULL) {
         free(js);
@@ -561,6 +566,7 @@ static OutputCtx *OutputTlsLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
     }
 
     tls_ctx->file_ctx = ojc->file_ctx;
+    tls_ctx->include_metadata = ojc->include_metadata;
 
     if ((tls_ctx->fields & LOG_TLS_FIELD_CERTIFICATE) &&
             (tls_ctx->fields & LOG_TLS_FIELD_CHAIN)) {

--- a/src/output-json-vars.c
+++ b/src/output-json-vars.c
@@ -186,6 +186,7 @@ static void JsonVarsLogDeInitCtxSub(OutputCtx *output_ctx)
  */
 static OutputCtx *JsonVarsLogInitCtx(ConfNode *conf)
 {
+    SCLogNotice("The \"vars\" eve type has been deprecated.");
     VarsJsonOutputCtx *json_output_ctx = NULL;
     LogFileCtx *logfile_ctx = LogFileNewCtx();
     if (logfile_ctx == NULL) {
@@ -227,6 +228,7 @@ static OutputCtx *JsonVarsLogInitCtx(ConfNode *conf)
  */
 static OutputCtx *JsonVarsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
+    SCLogNotice("The \"vars\" eve type has been deprecated.");
     OutputJsonCtx *ajt = parent_ctx->data;
     VarsJsonOutputCtx *json_output_ctx = NULL;
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -637,19 +637,6 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
                 return NULL;
             }
             OutputRegisterFileRotationFlag(&json_ctx->file_ctx->rotation_flag);
-
-            const char *format_s = ConfNodeLookupChildValue(conf, "format");
-            if (format_s != NULL) {
-                if (strcmp(format_s, "indent") == 0) {
-                    json_ctx->format = INDENT;
-                } else if (strcmp(format_s, "compact") == 0) {
-                    json_ctx->format = COMPACT;
-                } else {
-                    SCLogError(SC_ERR_INVALID_ARGUMENT,
-                               "Invalid JSON format option: %s", format_s);
-                    exit(EXIT_FAILURE);
-                }
-            }
         } else if (json_ctx->json_out == LOGFILE_TYPE_SYSLOG) {
             const char *facility_s = ConfNodeLookupChildValue(conf, "facility");
             if (facility_s == NULL) {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -371,7 +371,7 @@ void JsonAddVars(const Packet *p, const Flow *f, json_t *js)
 /**
  * \brief Add top-level metadata to the eve json object.
  */
-static void JsonAddMetadata(const Packet *p, const Flow *f, json_t *js)
+void JsonAddMetadata(const Packet *p, const Flow *f, json_t *js)
 {
     if ((p && p->pktvar) || (f && f->flowvar)) {
         json_t *js_vars = json_object();
@@ -575,9 +575,6 @@ json_t *CreateJSONHeader(const Packet *p, int direction_sensitive,
 
     /* 5-tuple */
     JsonFiveTuple(p, direction_sensitive, js);
-
-    /* Metadata. */
-    JsonAddMetadata(p, f, js);
 
     /* icmp */
     switch (p->proto) {
@@ -827,6 +824,15 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
                            "invalid sensor-is: %s", sensor_id_s);
                 exit(EXIT_FAILURE);
             }
+        }
+
+        /* Check if top-level metadata should be logged. */
+        const ConfNode *metadata = ConfNodeLookupChild(conf, "metadata");
+        if (metadata && metadata->val && ConfValIsFalse(metadata->val)) {
+            SCLogNotice("Disabling eve metadata logging.");
+            json_ctx->include_metadata = false;
+        } else {
+            json_ctx->include_metadata = true;
         }
 
         json_ctx->file_ctx->type = json_ctx->json_out;

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -154,6 +154,111 @@ static void JsonAddPacketvars(const Packet *p, json_t *js_vars)
     }
 }
 
+/**
+ * \brief "New" Add flow variables to a json object.
+ *
+ * Adds "flowvars" (map), "flowints" (map) and "flowbits" (array) to
+ * the json object provided as js_root.
+ *
+ * This is the "new" method for doing this as flowbits is an array of
+ * strings instead of a map of boolean values.
+ */
+static void JsonAddFlowVars(const Flow *f, json_t *js_root)
+{
+    if (f == NULL || f->flowvar == NULL) {
+        return;
+    }
+    json_t *js_flowvars = NULL;
+    json_t *js_flowints = NULL;
+    json_t *js_flowbits = NULL;
+    GenericVar *gv = f->flowvar;
+    while (gv != NULL) {
+        if (gv->type == DETECT_FLOWVAR || gv->type == DETECT_FLOWINT) {
+            FlowVar *fv = (FlowVar *)gv;
+            if (fv->datatype == FLOWVAR_TYPE_STR && fv->key == NULL) {
+                const char *varname = VarNameStoreLookupById(fv->idx,
+                        VAR_TYPE_FLOW_VAR);
+                if (varname) {
+                    if (js_flowvars == NULL) {
+                        js_flowvars = json_object();
+                        if (js_flowvars == NULL)
+                            break;
+                    }
+
+                    uint32_t len = fv->data.fv_str.value_len;
+                    uint8_t printable_buf[len + 1];
+                    uint32_t offset = 0;
+                    PrintStringsToBuffer(printable_buf, &offset,
+                            sizeof(printable_buf),
+                            fv->data.fv_str.value, fv->data.fv_str.value_len);
+
+                    json_object_set_new(js_flowvars, varname,
+                            json_string((char *)printable_buf));
+                }
+            } else if (fv->datatype == FLOWVAR_TYPE_STR && fv->key != NULL) {
+                if (js_flowvars == NULL) {
+                    js_flowvars = json_object();
+                    if (js_flowvars == NULL)
+                        break;
+                }
+
+                uint8_t keybuf[fv->keylen + 1];
+                uint32_t offset = 0;
+                PrintStringsToBuffer(keybuf, &offset,
+                        sizeof(keybuf),
+                        fv->key, fv->keylen);
+
+                uint32_t len = fv->data.fv_str.value_len;
+                uint8_t printable_buf[len + 1];
+                offset = 0;
+                PrintStringsToBuffer(printable_buf, &offset,
+                        sizeof(printable_buf),
+                        fv->data.fv_str.value, fv->data.fv_str.value_len);
+
+                json_object_set_new(js_flowvars, (const char *)keybuf,
+                        json_string((char *)printable_buf));
+
+            } else if (fv->datatype == FLOWVAR_TYPE_INT) {
+                const char *varname = VarNameStoreLookupById(fv->idx,
+                        VAR_TYPE_FLOW_INT);
+                if (varname) {
+                    if (js_flowints == NULL) {
+                        js_flowints = json_object();
+                        if (js_flowints == NULL)
+                            break;
+                    }
+
+                    json_object_set_new(js_flowints, varname,
+                            json_integer(fv->data.fv_int.value));
+                }
+
+            }
+        } else if (gv->type == DETECT_FLOWBITS) {
+            FlowBit *fb = (FlowBit *)gv;
+            const char *varname = VarNameStoreLookupById(fb->idx,
+                    VAR_TYPE_FLOW_BIT);
+            if (varname) {
+                if (js_flowbits == NULL) {
+                    js_flowbits = json_array();
+                    if (js_flowbits == NULL)
+                        break;
+                }
+                json_array_append(js_flowbits, json_string(varname));
+            }
+        }
+        gv = gv->next;
+    }
+    if (js_flowbits) {
+        json_object_set_new(js_root, "flowbits", js_flowbits);
+    }
+    if (js_flowints) {
+        json_object_set_new(js_root, "flowints", js_flowints);
+    }
+    if (js_flowvars) {
+        json_object_set_new(js_root, "flowvars", js_flowvars);
+    }
+}
+
 static void JsonAddFlowvars(const Flow *f, json_t *js_vars)
 {
     if (f == NULL || f->flowvar == NULL) {
@@ -259,6 +364,26 @@ void JsonAddVars(const Packet *p, const Flow *f, json_t *js)
             }
 
             json_object_set_new(js, "vars", js_vars);
+        }
+    }
+}
+
+/**
+ * \brief Add top-level metadata to the eve json object.
+ */
+static void JsonAddMetadata(const Packet *p, const Flow *f, json_t *js)
+{
+    if ((p && p->pktvar) || (f && f->flowvar)) {
+        json_t *js_vars = json_object();
+        if (js_vars) {
+            if (f && f->flowvar) {
+                JsonAddFlowVars(f, js_vars);
+            }
+            if (p && p->pktvar) {
+                JsonAddPacketvars(p, js_vars);
+            }
+
+            json_object_set_new(js, "metadata", js_vars);
         }
     }
 }
@@ -393,6 +518,7 @@ json_t *CreateJSONHeader(const Packet *p, int direction_sensitive,
                          const char *event_type)
 {
     char timebuf[64];
+    const Flow *f = (const Flow *)p->flow;
 
     json_t *js = json_object();
     if (unlikely(js == NULL))
@@ -403,7 +529,7 @@ json_t *CreateJSONHeader(const Packet *p, int direction_sensitive,
     /* time & tx */
     json_object_set_new(js, "timestamp", json_string(timebuf));
 
-    CreateJSONFlowId(js, (const Flow *)p->flow);
+    CreateJSONFlowId(js, f);
 
     /* sensor id */
     if (sensor_id >= 0)
@@ -449,6 +575,9 @@ json_t *CreateJSONHeader(const Packet *p, int direction_sensitive,
 
     /* 5-tuple */
     JsonFiveTuple(p, direction_sensitive, js);
+
+    /* Metadata. */
+    JsonAddMetadata(p, f, js);
 
     /* icmp */
     switch (p->proto) {

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -40,6 +40,7 @@ typedef struct OutputJSONMemBufferWrapper_ {
 int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
 
 void JsonAddVars(const Packet *p, const Flow *f, json_t *js);
+void JsonAddMetadata(const Packet *p, const Flow *f, json_t *js);
 void CreateJSONFlowId(json_t *js, const Flow *f);
 void JsonTcpFlags(uint8_t flags, json_t *js);
 void JsonFiveTuple(const Packet *, int, json_t *);
@@ -54,6 +55,7 @@ OutputCtx *OutputJsonInitCtx(ConfNode *);
 typedef struct OutputJsonCtx_ {
     LogFileCtx *file_ctx;
     enum LogFileType json_out;
+    bool include_metadata;
 } OutputJsonCtx;
 
 typedef struct AlertJsonThread_ {

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -48,15 +48,12 @@ json_t *CreateJSONHeaderWithTxId(const Packet *p, int direction_sensitive, const
 int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer);
 OutputCtx *OutputJsonInitCtx(ConfNode *);
 
-enum JsonFormat { COMPACT, INDENT };
-
 /*
  * Global configuration context data
  */
 typedef struct OutputJsonCtx_ {
     LogFileCtx *file_ctx;
     enum LogFileType json_out;
-    enum JsonFormat format;
 } OutputJsonCtx;
 
 typedef struct AlertJsonThread_ {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -163,6 +163,10 @@ outputs:
       #  pipelining:
       #    enabled: yes ## set enable to yes to enable query pipelining
       #    batch-size: 10 ## number of entry to keep in buffer
+
+      # Include top level metadata. Default yes.
+      #metadata: no
+
       types:
         - alert:
             # payload: yes             # enable dumping payload in Base64


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2352

Describe changes:
- Add a "metadata: yes/no" field to the eve-log section in suricata.yaml. This controls adding top-level metadata to all types enabled.
- This metadata currently includes flowbits  as an array, and flowints, flowvars and pktvars as maps.
- It is basically a remapping of the previous "vars" field to "metadata", but flowbits is now an array.
- There is no "vars" specific event type.
- Adds this metadata to all event types if turned on.

The metadata in an eve event will look something like:
```
{
  "metadata": {
    "flowbits": [
      "/traffic/id/facebook",
      "ET.TorIP" 
    ],
    "flowvars": {
      "flow_var0_name": "flow_var0_value",
      "flow_var1_name": "flow_var1_value" 
    },
    "flowints": {
      "flow_int0_name": 0,
      "flow_int1_name": 1
    },
    "pktvars": {
      "pkt_var0_name": "pkt_var0_value",
      "pkt_var1_name": "pkt_var1_value" 
    }
  }
}
```

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/228
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/581
