### PR TITLE
Unix reopen command

### DIFF
--- a/doc/userguide/unix-socket.rst
+++ b/doc/userguide/unix-socket.rst
@@ -67,6 +67,7 @@ The set of existing commands is the following:
 * capture-mode: display capture system used
 * conf-get: get configuration item (see example below)
 * dump-counters: dump Suricata's performance counters
+* reopen-log-files: reopen log files (to be run after external log rotation)
 * ruleset-reload-rules: reload ruleset and wait for completion
 * ruleset-reload-nonblocking: reload rulesat and proceed without waiting
 * ruleset-reload-time: return time of last reload

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -44,6 +44,7 @@
 
 #include <jansson.h>
 
+#include "output.h"
 #include "output-json.h"
 
 // MSG_NOSIGNAL does not exists on OS X
@@ -839,6 +840,13 @@ static TmEcode UnixManagerListCommand(json_t *cmd,
 }
 
 
+static TmEcode UnixManagerReopenLogFiles(json_t *cmd, json_t *server_msg, void *data)
+{
+    OutputNotifyFileRotation();
+    json_object_set_new(server_msg, "message", json_string("done"));
+    SCReturnInt(TM_ECODE_OK);
+}
+
 #if 0
 TmEcode UnixManagerReloadRules(json_t *cmd,
                                json_t *server_msg, void *data)
@@ -998,6 +1006,7 @@ int UnixManagerInit(void)
     UnixManagerRegisterCommand("add-hostbit", UnixSocketHostbitAdd, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("remove-hostbit", UnixSocketHostbitRemove, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("list-hostbit", UnixSocketHostbitList, &command, UNIX_CMD_TAKE_ARGS);
+    UnixManagerRegisterCommand("reopen-log-files", UnixManagerReopenLogFiles, NULL, 0);
 
     return 0;
 }


### PR DESCRIPTION
Add a unix socket command to trigger log files reopening.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Add the command
- Documentation

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/358
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/142


