### PR TITLE
flow-manager: Signal condition variable from unix socket (Bug #2220)

### DIFF
--- a/src/flow-manager.h
+++ b/src/flow-manager.h
@@ -34,6 +34,7 @@ SCCtrlMutex flow_manager_ctrl_mutex;
 #define FlowWakeupFlowManagerThread() SCCtrlCondSignal(&flow_manager_ctrl_cond)
 
 void FlowManagerThreadSpawn(void);
+void FlowManagerWakeupThreads(void);
 void FlowDisableFlowManagerThread(void);
 void FlowMgrRegisterTests (void);
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2287,8 +2287,10 @@ void PreRunPostPrivsDropInit(const int runmode)
  * Will be run once per pcap in unix-socket mode */
 void PostRunDeinit(const int runmode, struct timeval *start_time)
 {
-    if (runmode == RUNMODE_UNIX_SOCKET)
+    if (runmode == RUNMODE_UNIX_SOCKET) {
+        FlowManagerWakeupThreads();
         return;
+    }
 
     /* needed by FlowForceReassembly */
     PacketPoolInit();

--- a/src/threads.h
+++ b/src/threads.h
@@ -152,6 +152,7 @@ enum {
 #define SCCtrlCondT pthread_cond_t
 #define SCCtrlCondInit pthread_cond_init
 #define SCCtrlCondSignal pthread_cond_signal
+#define SCCtrlCondBroadcast pthread_cond_broadcast
 #define SCCtrlCondTimedwait pthread_cond_timedwait
 #define SCCtrlCondWait pthread_cond_wait
 #define SCCtrlCondDestroy pthread_cond_destroy


### PR DESCRIPTION
Fix issue where flow manager could not be woken up by unix socket mode.
Introduced condition signal broadcast that is used by a wakeup function
that is called by flow manager and postrundeinit when running as a unix
socket.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2220

Describe changes:
- Introduce condition variable broadcast
- Use condition variable broadcast in flow manager to wakeup blocked threads
- Call wakeup from postrundeinit for unix socket

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

