### PR TITLE
detect-engine: add missing mutex unlock

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -901,6 +901,7 @@ static int DetectEngineReloadThreads(DetectEngineCtx *new_de_ctx)
         TmSlot *slots = tv->tm_slots;
         while (slots != NULL) {
             if (suricata_ctl_flags != 0) {
+                SCMutexUnlock(&tv_root_lock);
                 return -1;
             }
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:

mutex unlock was missing, minor fix thus no redmine ticket

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/58
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/60