### PR TITLE
eve: log pcap filename if possible

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -47,6 +47,29 @@ The common part has a field "event_type" to indicate the log type.
 
   "event_type":"TYPE"
 
+PCAP fields
+~~~~~~~~~~~
+
+If Suricata is processing a pcap file, additional fields are added:
+
+::
+
+    "pcap_cnt": 123
+
+``pcap_cnt`` contains the packet number in the pcap. This can be used to look
+up a packet in Wireshark for example.
+
+::
+
+    "pcap_filename":"/path/to/file.pcap"
+
+``pcap_filename`` contains the file name and location of the pcap that
+generated the event.
+
+.. note:: the pcap fields are only available on "real" packets, and are
+          omitted from internal "pseudo" packets such as flow timeout
+          packets.
+
 Event type: Alert
 -----------------
 

--- a/src/decode.c
+++ b/src/decode.c
@@ -282,6 +282,7 @@ Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *pare
     p->ts.tv_usec = parent->ts.tv_usec;
     p->datalink = DLT_RAW;
     p->tenant_id = parent->tenant_id;
+    p->pcap_filename = parent->pcap_filename;
 
     /* set the root ptr to the lowest layer */
     if (parent->root != NULL)
@@ -361,6 +362,7 @@ Packet *PacketDefragPktSetup(Packet *parent, uint8_t *pkt, uint16_t len, uint8_t
     p->vlan_id[0] = parent->vlan_id[0];
     p->vlan_id[1] = parent->vlan_id[1];
     p->vlan_idx = parent->vlan_idx;
+    p->pcap_filename = parent->pcap_filename;
 
     SCReturnPtr(p, "Packet");
 }

--- a/src/decode.h
+++ b/src/decode.h
@@ -554,6 +554,7 @@ typedef struct Packet_
 
     /** packet number in the pcap file, matches wireshark */
     uint64_t pcap_cnt;
+    const char *pcap_filename;
 
 
     /* engine events */
@@ -820,6 +821,7 @@ void CaptureStatsSetup(ThreadVars *tv, CaptureStats *s);
         (p)->alerts.cnt = 0;                    \
         (p)->alerts.drop.action = 0;            \
         (p)->pcap_cnt = 0;                      \
+        (p)->pcap_filename = NULL;              \
         (p)->tunnel_rtv_cnt = 0;                \
         (p)->tunnel_tpr_cnt = 0;                \
         (p)->events.cnt = 0;                    \

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -418,6 +418,9 @@ json_t *CreateJSONHeader(const Packet *p, int direction_sensitive,
     if (p->pcap_cnt != 0) {
         json_object_set_new(js, "pcap_cnt", json_integer(p->pcap_cnt));
     }
+    if (p->pcap_filename != NULL) {
+        json_object_set_new(js, "pcap_filename", json_string(p->pcap_filename));
+    }
 
     if (event_type) {
         json_object_set_new(js, "event_type", json_string(event_type));

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -78,6 +78,7 @@ void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
     SCLogDebug("p->ts.tv_sec %"PRIuMAX"", (uintmax_t)p->ts.tv_sec);
     p->datalink = ptv->datalink;
     p->pcap_cnt = ++pcap_g.cnt;
+    p->pcap_filename = ptv->filename;
 
     p->pcap_v.tenant_id = ptv->shared->tenant_id;
     ptv->shared->pkts++;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5668,6 +5668,7 @@ Packet *StreamTcpPseudoSetup(Packet *parent, uint8_t *pkt, uint32_t len)
     /* copy packet and set lenght, proto */
     p->proto = parent->proto;
     p->datalink = parent->datalink;
+    p->pcap_filename = parent->pcap_filename;
 
     PacketCopyData(p, pkt, len);
     p->recursion_level = parent->recursion_level + 1;


### PR DESCRIPTION
Log the pcap filename generating a record. This is useful for unix socket
and reading pcaps from a directoy.

The filename is referenced from the packet. To keep things simple the flow
remains unaware, so flow timeout packets will not have a filename
associated with them.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/54
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/55
