### PR TITLE
Memcap updates over unix socket v2

### DIFF
--- a/doc/userguide/unix-socket.rst
+++ b/doc/userguide/unix-socket.rst
@@ -72,6 +72,9 @@ The set of existing commands is the following:
 * ruleset-reload-time: return time of last reload
 * ruleset-stats: display the number of rules loaded and failed
 * ruleset-failed-rules: display the list of failed rules
+* memcap-set: update memcap value of an item specified
+* memcap-show: show memcap value of an item specified
+* memcap-list: list all memcap values available
 
 You can access to these commands with the provided example script which
 is named ``suricatasc``. A typical session with ``suricatasc`` will looks like:

--- a/scripts/suricatasc/src/suricatasc.py
+++ b/scripts/suricatasc/src/suricatasc.py
@@ -80,7 +80,7 @@ class SuricataCompleter:
 
 class SuricataSC:
     def __init__(self, sck_path, verbose=False):
-        self.cmd_list=['shutdown','quit','pcap-file','pcap-file-continuous','pcap-file-number','pcap-file-list','pcap-last-processed','pcap-interrupt','iface-list','iface-stat','register-tenant','unregister-tenant','register-tenant-handler','unregister-tenant-handler', 'add-hostbit', 'remove-hostbit', 'list-hostbit']
+        self.cmd_list=['shutdown','quit','pcap-file','pcap-file-continuous','pcap-file-number','pcap-file-list','pcap-last-processed','pcap-interrupt','iface-list','iface-stat','register-tenant','unregister-tenant','register-tenant-handler','unregister-tenant-handler', 'add-hostbit', 'remove-hostbit', 'list-hostbit', 'memcap-set', 'memcap-show']
         self.sck_path = sck_path
         self.verbose = verbose
 
@@ -329,6 +329,27 @@ class SuricataSC:
                 else:
                     arguments = {}
                     arguments["ipaddress"] = ipaddress
+            elif "memcap-set" in command:
+                try:
+                    [cmd, config, memcap] = command.split(' ', 2)
+                except:
+                    raise SuricataCommandException("Arguments to command '%s' is missing" % (command))
+                if cmd != "memcap-set":
+                    raise SuricataCommandException("Invalid command '%s'" % (command))
+                else:
+                    arguments = {}
+                    arguments["config"] = config
+                    arguments["memcap"] = memcap
+            elif "memcap-show" in command:
+                try:
+                    [cmd, config] = command.split(' ')
+                except:
+                    raise SuricataCommandException("Arguments to command '%s' is missing" % (command))
+                if cmd != "memcap-show":
+                    raise SuricataCommandException("Invalid command '%s'" % (command))
+                else:
+                    arguments = {}
+                    arguments["config"] = config
             else:
                 cmd = command
         else:

--- a/src/app-layer-htp-mem.c
+++ b/src/app-layer-htp-mem.c
@@ -38,8 +38,7 @@
 
 #include "app-layer-htp-mem.h"
 
-uint64_t htp_config_memcap = 0;
-
+SC_ATOMIC_DECLARE(uint64_t, htp_config_memcap);
 SC_ATOMIC_DECLARE(uint64_t, htp_memuse);
 SC_ATOMIC_DECLARE(uint64_t, htp_memcap);
 
@@ -47,19 +46,24 @@ void HTPParseMemcap()
 {
     const char *conf_val;
 
+    SC_ATOMIC_INIT(htp_config_memcap);
+
     /** set config values for memcap, prealloc and hash_size */
+    uint64_t memcap;
     if ((ConfGet("app-layer.protocols.http.memcap", &conf_val)) == 1)
     {
-        if (ParseSizeStringU64(conf_val, &htp_config_memcap) < 0) {
+        if (ParseSizeStringU64(conf_val, &memcap) < 0) {
             SCLogError(SC_ERR_SIZE_PARSE, "Error parsing http.memcap "
                        "from conf file - %s.  Killing engine",
                        conf_val);
             exit(EXIT_FAILURE);
+        } else {
+            SC_ATOMIC_SET(htp_config_memcap, memcap);
         }
-        SCLogInfo("HTTP memcap: %"PRIu64, htp_config_memcap);
+        SCLogInfo("HTTP memcap: %"PRIu64, SC_ATOMIC_GET(htp_config_memcap));
     } else {
         /* default to unlimited */
-        htp_config_memcap = 0;
+        SC_ATOMIC_SET(htp_config_memcap, 0);
     }
 
     SC_ATOMIC_INIT(htp_memuse);
@@ -98,10 +102,36 @@ uint64_t HTPMemcapGlobalCounter(void)
  */
 static int HTPCheckMemcap(uint64_t size)
 {
-    if (htp_config_memcap == 0 || size + SC_ATOMIC_GET(htp_memuse) <= htp_config_memcap)
+    uint64_t memcapcopy = SC_ATOMIC_GET(htp_config_memcap);
+    if (memcapcopy == 0 || size + SC_ATOMIC_GET(htp_memuse) <= memcapcopy)
         return 1;
     (void) SC_ATOMIC_ADD(htp_memcap, 1);
     return 0;
+}
+
+/**
+ *  \brief Update memcap value
+ *
+ *  \param size new memcap value
+ */
+int HTPSetMemcap(uint64_t size)
+{
+    if (size == 0 || (uint64_t)SC_ATOMIC_GET(htp_memuse) < size) {
+        SC_ATOMIC_SET(htp_config_memcap, size);
+        return 1;
+    }
+    return 0;
+}
+
+/**
+ *  \brief Update memcap value
+ *
+ *  \retval memcap value
+ */
+uint64_t HTPGetMemcap(void)
+{
+    uint64_t memcapcopy = SC_ATOMIC_GET(htp_config_memcap);
+    return memcapcopy;
 }
 
 void *HTPMalloc(size_t size)

--- a/src/app-layer-htp-mem.c
+++ b/src/app-layer-htp-mem.c
@@ -195,6 +195,12 @@ void HTPFree(void *ptr, size_t size)
     HTPDecrMemuse((uint64_t)size);
 }
 
+void HTPDestroyMemcap(void)
+{
+    SC_ATOMIC_DESTROY(htp_config_memcap);
+    SC_ATOMIC_DESTROY(htp_memcap);
+    SC_ATOMIC_DESTROY(htp_memuse);
+}
 
 /**
  * @}

--- a/src/app-layer-htp-mem.h
+++ b/src/app-layer-htp-mem.h
@@ -23,5 +23,8 @@ void *HTPCalloc(size_t n, size_t size);
 void *HTPRealloc(void *ptr, size_t orig_size, size_t size);
 void HTPFree(void *ptr, size_t size);
 
+int HTPSetMemcap(uint64_t size);
+uint64_t HTPGetMemcap(void);
+
 uint64_t HTPMemuseGlobalCounter(void);
 uint64_t HTPMemcapGlobalCounter(void);

--- a/src/app-layer-htp-mem.h
+++ b/src/app-layer-htp-mem.h
@@ -22,6 +22,7 @@ void *HTPMalloc(size_t size);
 void *HTPCalloc(size_t n, size_t size);
 void *HTPRealloc(void *ptr, size_t orig_size, size_t size);
 void HTPFree(void *ptr, size_t size);
+void HTPDestroyMemcap(void);
 
 int HTPSetMemcap(uint64_t size);
 uint64_t HTPGetMemcap(void);

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1916,6 +1916,7 @@ void HTPFreeConfig(void)
         htp_config_destroy(htprec->cfg);
         SCFree(htprec);
     }
+    HTPDestroyMemcap();
     SCReturn;
 }
 

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -30,6 +30,43 @@ static DefragTracker *DefragTrackerGetUsedDefragTracker(void);
 /** queue with spare tracker */
 static DefragTrackerQueue defragtracker_spare_q;
 
+/**
+ *  \brief Update memcap value
+ *
+ *  \param size new memcap value
+ */
+int DefragTrackerSetMemcap(uint64_t size)
+{
+    if ((uint64_t)SC_ATOMIC_GET(defrag_memuse) < size) {
+        SC_ATOMIC_SET(defrag_config.memcap, size);
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
+ *  \brief Return memcap value
+ *
+ *  \retval memcap value
+ */
+uint64_t DefragTrackerGetMemcap(void)
+{
+    uint64_t memcapcopy = SC_ATOMIC_GET(defrag_config.memcap);
+    return memcapcopy;
+}
+
+/**
+ *  \brief Return memuse value
+ *
+ *  \retval memuse value
+ */
+uint64_t DefragTrackerGetMemuse(void)
+{
+    uint64_t memusecopy = (uint64_t)SC_ATOMIC_GET(defrag_memuse);
+    return memusecopy;
+}
+
 uint32_t DefragTrackerSpareQueueGetSize(void)
 {
     return DefragTrackerQueueLen(&defragtracker_spare_q);
@@ -131,26 +168,30 @@ void DefragInitConfig(char quiet)
     SC_ATOMIC_INIT(defragtracker_counter);
     SC_ATOMIC_INIT(defrag_memuse);
     SC_ATOMIC_INIT(defragtracker_prune_idx);
+    SC_ATOMIC_INIT(defrag_config.memcap);
     DefragTrackerQueueInit(&defragtracker_spare_q);
 
     /* set defaults */
     defrag_config.hash_rand   = (uint32_t)RandomGet();
     defrag_config.hash_size   = DEFRAG_DEFAULT_HASHSIZE;
-    defrag_config.memcap      = DEFRAG_DEFAULT_MEMCAP;
     defrag_config.prealloc    = DEFRAG_DEFAULT_PREALLOC;
+    SC_ATOMIC_SET(defrag_config.memcap, DEFRAG_DEFAULT_MEMCAP);
 
     /* Check if we have memcap and hash_size defined at config */
     const char *conf_val;
     uint32_t configval = 0;
 
+    uint64_t defrag_memcap;
     /** set config values for memcap, prealloc and hash_size */
     if ((ConfGet("defrag.memcap", &conf_val)) == 1)
     {
-        if (ParseSizeStringU64(conf_val, &defrag_config.memcap) < 0) {
+        if (ParseSizeStringU64(conf_val, &defrag_memcap) < 0) {
             SCLogError(SC_ERR_SIZE_PARSE, "Error parsing defrag.memcap "
                        "from conf file - %s.  Killing engine",
                        conf_val);
             exit(EXIT_FAILURE);
+        } else {
+            SC_ATOMIC_SET(defrag_config.memcap, defrag_memcap);
         }
     }
     if ((ConfGet("defrag.hash-size", &conf_val)) == 1)
@@ -174,7 +215,7 @@ void DefragInitConfig(char quiet)
         }
     }
     SCLogDebug("DefragTracker config from suricata.yaml: memcap: %"PRIu64", hash-size: "
-               "%"PRIu32", prealloc: %"PRIu32, defrag_config.memcap,
+               "%"PRIu32", prealloc: %"PRIu32, SC_ATOMIC_GET(defrag_config.memcap),
                defrag_config.hash_size, defrag_config.prealloc);
 
     /* alloc hash memory */
@@ -184,7 +225,7 @@ void DefragInitConfig(char quiet)
                 "max defrag memcap is smaller than projected hash size. "
                 "Memcap: %"PRIu64", Hash table size %"PRIu64". Calculate "
                 "total hash size by multiplying \"defrag.hash-size\" with %"PRIuMAX", "
-                "which is the hash bucket size.", defrag_config.memcap, hash_size,
+                "which is the hash bucket size.", SC_ATOMIC_GET(defrag_config.memcap), hash_size,
                 (uintmax_t)sizeof(DefragTrackerHashRow));
         exit(EXIT_FAILURE);
     }
@@ -216,7 +257,7 @@ void DefragInitConfig(char quiet)
                 if (!(DEFRAG_CHECK_MEMCAP(sizeof(DefragTracker)))) {
                     SCLogError(SC_ERR_DEFRAG_INIT, "preallocating defrag trackers failed: "
                             "max defrag memcap reached. Memcap %"PRIu64", "
-                            "Memuse %"PRIu64".", defrag_config.memcap,
+                            "Memuse %"PRIu64".", SC_ATOMIC_GET(defrag_config.memcap),
                             ((uint64_t)SC_ATOMIC_GET(defrag_memuse) + (uint64_t)sizeof(DefragTracker)));
                     exit(EXIT_FAILURE);
                 }
@@ -237,7 +278,7 @@ void DefragInitConfig(char quiet)
 
     if (quiet == FALSE) {
         SCLogConfig("defrag memory usage: %"PRIu64" bytes, maximum: %"PRIu64,
-                SC_ATOMIC_GET(defrag_memuse), defrag_config.memcap);
+                SC_ATOMIC_GET(defrag_memuse), SC_ATOMIC_GET(defrag_config.memcap));
     }
 
     return;
@@ -286,6 +327,7 @@ void DefragHashShutdown(void)
     SC_ATOMIC_DESTROY(defragtracker_prune_idx);
     SC_ATOMIC_DESTROY(defrag_memuse);
     SC_ATOMIC_DESTROY(defragtracker_counter);
+    SC_ATOMIC_DESTROY(defrag_config.memcap);
     //SC_ATOMIC_DESTROY(flow_flags);
     return;
 }

--- a/src/defrag-hash.h
+++ b/src/defrag-hash.h
@@ -68,7 +68,7 @@ DefragTrackerHashRow *defragtracker_hash;
 #define DEFRAG_QUIET      1
 
 typedef struct DefragConfig_ {
-    uint64_t memcap;
+    SC_ATOMIC_DECLARE(uint64_t, memcap);
     uint32_t hash_rand;
     uint32_t hash_size;
     uint32_t prealloc;
@@ -82,7 +82,7 @@ typedef struct DefragConfig_ {
  *  \retval 0 no fit
  */
 #define DEFRAG_CHECK_MEMCAP(size) \
-    ((((uint64_t)SC_ATOMIC_GET(defrag_memuse) + (uint64_t)(size)) <= defrag_config.memcap))
+    ((((uint64_t)SC_ATOMIC_GET(defrag_memuse) + (uint64_t)(size)) <= SC_ATOMIC_GET(defrag_config.memcap)))
 
 DefragConfig defrag_config;
 SC_ATOMIC_DECLARE(uint64_t,defrag_memuse);
@@ -98,6 +98,10 @@ void DefragTrackerRelease(DefragTracker *);
 void DefragTrackerClearMemory(DefragTracker *);
 void DefragTrackerMoveToSpare(DefragTracker *);
 uint32_t DefragTrackerSpareQueueGetSize(void);
+
+int DefragTrackerSetMemcap(uint64_t);
+uint64_t DefragTrackerGetMemcap(void);
+uint64_t DefragTrackerGetMemuse(void);
 
 #endif /* __DEFRAG_HASH_H__ */
 

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -803,12 +803,6 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
     return TM_ECODE_OK;
 }
 
-static uint64_t FlowGetMemuse(void)
-{
-    uint64_t flow_memuse = SC_ATOMIC_GET(flow_memuse);
-    return flow_memuse;
-}
-
 /** \brief spawn the flow manager thread */
 void FlowManagerThreadSpawn()
 {
@@ -1366,7 +1360,7 @@ static int FlowMgrTest05 (void)
 
     uint32_t ini = 0;
     uint32_t end = flow_spare_q.len;
-    flow_config.memcap = 10000;
+    SC_ATOMIC_SET(flow_config.memcap, 10000);
     flow_config.prealloc = 100;
 
     /* Let's get the flow_spare_q empty */

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -127,7 +127,7 @@
  *  \retval 0 no fit
  */
 #define FLOW_CHECK_MEMCAP(size) \
-    ((((uint64_t)SC_ATOMIC_GET(flow_memuse) + (uint64_t)(size)) <= flow_config.memcap))
+    ((((uint64_t)SC_ATOMIC_GET(flow_memuse) + (uint64_t)(size)) <= SC_ATOMIC_GET(flow_config.memcap)))
 
 Flow *FlowAlloc(void);
 Flow *FlowAllocDirect(void);

--- a/src/flow.h
+++ b/src/flow.h
@@ -245,7 +245,6 @@ typedef struct FlowCnf_
 {
     uint32_t hash_rand;
     uint32_t hash_size;
-    uint64_t memcap;
     uint32_t max_flows;
     uint32_t prealloc;
 
@@ -256,6 +255,7 @@ typedef struct FlowCnf_
     uint32_t emerg_timeout_est;
     uint32_t emergency_recovery;
 
+    SC_ATOMIC_DECLARE(uint64_t, memcap);
 } FlowConfig;
 
 /* Hash key for the flow hash */
@@ -496,6 +496,10 @@ int FlowGetPacketDirection(const Flow *, const Packet *);
 void FlowCleanupAppLayer(Flow *);
 
 void FlowUpdateState(Flow *f, enum FlowState s);
+
+int FlowSetMemcap(uint64_t size);
+uint64_t FlowGetMemcap(void);
+uint64_t FlowGetMemuse(void);
 
 /** ----- Inline functions ----- */
 

--- a/src/host.c
+++ b/src/host.c
@@ -52,6 +52,43 @@ static HostQueue host_spare_q;
  *  the storage APIs additions. */
 static uint16_t g_host_size = sizeof(Host);
 
+/**
+ *  \brief Update memcap value
+ *
+ *  \param size new memcap value
+ */
+int HostSetMemcap(uint64_t size)
+{
+    if ((uint64_t)SC_ATOMIC_GET(host_memuse) < size) {
+        SC_ATOMIC_SET(host_config.memcap, size);
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
+ *  \brief Return memcap value
+ *
+ *  \retval memcap value
+ */
+uint64_t HostGetMemcap(void)
+{
+    uint64_t memcapcopy = SC_ATOMIC_GET(host_config.memcap);
+    return memcapcopy;
+}
+
+/**
+ *  \brief Return memuse value
+ *
+ *  \retval memuse value
+ */
+uint64_t HostGetMemuse(void)
+{
+    uint64_t memuse = SC_ATOMIC_GET(host_memuse);
+    return memuse;
+}
+
 uint32_t HostSpareQueueGetSize(void)
 {
     return HostQueueLen(&host_spare_q);
@@ -139,26 +176,30 @@ void HostInitConfig(char quiet)
     SC_ATOMIC_INIT(host_counter);
     SC_ATOMIC_INIT(host_memuse);
     SC_ATOMIC_INIT(host_prune_idx);
+    SC_ATOMIC_INIT(host_config.memcap);
     HostQueueInit(&host_spare_q);
 
     /* set defaults */
     host_config.hash_rand   = (uint32_t)RandomGet();
     host_config.hash_size   = HOST_DEFAULT_HASHSIZE;
-    host_config.memcap      = HOST_DEFAULT_MEMCAP;
     host_config.prealloc    = HOST_DEFAULT_PREALLOC;
+    SC_ATOMIC_SET(host_config.memcap, HOST_DEFAULT_MEMCAP);
 
     /* Check if we have memcap and hash_size defined at config */
     const char *conf_val;
     uint32_t configval = 0;
 
     /** set config values for memcap, prealloc and hash_size */
+    uint64_t host_memcap;
     if ((ConfGet("host.memcap", &conf_val)) == 1)
     {
-        if (ParseSizeStringU64(conf_val, &host_config.memcap) < 0) {
+        if (ParseSizeStringU64(conf_val, &host_memcap) < 0) {
             SCLogError(SC_ERR_SIZE_PARSE, "Error parsing host.memcap "
                        "from conf file - %s.  Killing engine",
                        conf_val);
             exit(EXIT_FAILURE);
+        } else {
+            SC_ATOMIC_SET(host_config.memcap, host_memcap);
         }
     }
     if ((ConfGet("host.hash-size", &conf_val)) == 1)
@@ -179,7 +220,7 @@ void HostInitConfig(char quiet)
         }
     }
     SCLogDebug("Host config from suricata.yaml: memcap: %"PRIu64", hash-size: "
-               "%"PRIu32", prealloc: %"PRIu32, host_config.memcap,
+               "%"PRIu32", prealloc: %"PRIu32, SC_ATOMIC_GET(host_config.memcap),
                host_config.hash_size, host_config.prealloc);
 
     /* alloc hash memory */
@@ -189,7 +230,7 @@ void HostInitConfig(char quiet)
                 "max host memcap is smaller than projected hash size. "
                 "Memcap: %"PRIu64", Hash table size %"PRIu64". Calculate "
                 "total hash size by multiplying \"host.hash-size\" with %"PRIuMAX", "
-                "which is the hash bucket size.", host_config.memcap, hash_size,
+                "which is the hash bucket size.", SC_ATOMIC_GET(host_config.memcap), hash_size,
                 (uintmax_t)sizeof(HostHashRow));
         exit(EXIT_FAILURE);
     }
@@ -218,7 +259,7 @@ void HostInitConfig(char quiet)
         if (!(HOST_CHECK_MEMCAP(g_host_size))) {
             SCLogError(SC_ERR_HOST_INIT, "preallocating hosts failed: "
                     "max host memcap reached. Memcap %"PRIu64", "
-                    "Memuse %"PRIu64".", host_config.memcap,
+                    "Memuse %"PRIu64".", SC_ATOMIC_GET(host_config.memcap),
                     ((uint64_t)SC_ATOMIC_GET(host_memuse) + g_host_size));
             exit(EXIT_FAILURE);
         }
@@ -235,7 +276,7 @@ void HostInitConfig(char quiet)
         SCLogConfig("preallocated %" PRIu32 " hosts of size %" PRIu16 "",
                 host_spare_q.len, g_host_size);
         SCLogConfig("host memory usage: %"PRIu64" bytes, maximum: %"PRIu64,
-                SC_ATOMIC_GET(host_memuse), host_config.memcap);
+                SC_ATOMIC_GET(host_memuse), SC_ATOMIC_GET(host_config.memcap));
     }
 
     return;
@@ -250,7 +291,7 @@ void HostPrintStats (void)
         hostbits_added, hostbits_removed, hostbits_memuse_max);
 #endif /* HOSTBITS_STATS */
     SCLogPerf("host memory usage: %"PRIu64" bytes, maximum: %"PRIu64,
-            SC_ATOMIC_GET(host_memuse), host_config.memcap);
+            SC_ATOMIC_GET(host_memuse), SC_ATOMIC_GET(host_config.memcap));
     return;
 }
 
@@ -290,6 +331,7 @@ void HostShutdown(void)
     SC_ATOMIC_DESTROY(host_prune_idx);
     SC_ATOMIC_DESTROY(host_memuse);
     SC_ATOMIC_DESTROY(host_counter);
+    SC_ATOMIC_DESTROY(host_config.memcap);
     //SC_ATOMIC_DESTROY(flow_flags);
     return;
 }

--- a/src/host.h
+++ b/src/host.h
@@ -93,7 +93,7 @@ HostHashRow *host_hash;
 #define HOST_QUIET      1
 
 typedef struct HostConfig_ {
-    uint64_t memcap;
+    SC_ATOMIC_DECLARE(uint64_t, memcap);
     uint32_t hash_rand;
     uint32_t hash_size;
     uint32_t prealloc;
@@ -107,7 +107,7 @@ typedef struct HostConfig_ {
  *  \retval 0 no fit
  */
 #define HOST_CHECK_MEMCAP(size) \
-    ((((uint64_t)SC_ATOMIC_GET(host_memuse) + (uint64_t)(size)) <= host_config.memcap))
+    ((((uint64_t)SC_ATOMIC_GET(host_memuse) + (uint64_t)(size)) <= SC_ATOMIC_GET(host_config.memcap)))
 
 #define HostIncrUsecnt(h) \
     (void)SC_ATOMIC_ADD((h)->use_cnt, 1)
@@ -152,6 +152,10 @@ Host *HostAlloc(void);
 void HostFree(Host *);
 
 void HostUnlock(Host *h);
+
+int HostSetMemcap(uint64_t);
+uint64_t HostGetMemcap(void);
+uint64_t HostGetMemuse(void);
 
 #endif /* __HOST_H__ */
 

--- a/src/ippair.c
+++ b/src/ippair.c
@@ -51,6 +51,43 @@ static IPPairQueue ippair_spare_q;
  *  the storage APIs additions. */
 static uint16_t g_ippair_size = sizeof(IPPair);
 
+/**
+ *  \brief Update memcap value
+ *
+ *  \param size new memcap value
+ */
+int IPPairSetMemcap(uint64_t size)
+{
+    if ((uint64_t)SC_ATOMIC_GET(ippair_memuse) < size) {
+        SC_ATOMIC_SET(ippair_config.memcap, size);
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
+ *  \brief Return memcap value
+ *
+ *  \retval memcap value
+ */
+uint64_t IPPairGetMemcap(void)
+{
+    uint64_t memcapcopy = SC_ATOMIC_GET(ippair_config.memcap);
+    return memcapcopy;
+}
+
+/**
+ *  \brief Return memuse value
+ *
+ *  \retval memuse value
+ */
+uint64_t IPPairGetMemuse(void)
+{
+    uint64_t memusecopy = SC_ATOMIC_GET(ippair_memuse);
+    return memusecopy;
+}
+
 uint32_t IPPairSpareQueueGetSize(void)
 {
     return IPPairQueueLen(&ippair_spare_q);
@@ -135,26 +172,30 @@ void IPPairInitConfig(char quiet)
     SC_ATOMIC_INIT(ippair_counter);
     SC_ATOMIC_INIT(ippair_memuse);
     SC_ATOMIC_INIT(ippair_prune_idx);
+    SC_ATOMIC_INIT(ippair_config.memcap);
     IPPairQueueInit(&ippair_spare_q);
 
     /* set defaults */
     ippair_config.hash_rand   = (uint32_t)RandomGet();
     ippair_config.hash_size   = IPPAIR_DEFAULT_HASHSIZE;
-    ippair_config.memcap      = IPPAIR_DEFAULT_MEMCAP;
     ippair_config.prealloc    = IPPAIR_DEFAULT_PREALLOC;
+    SC_ATOMIC_SET(ippair_config.memcap, IPPAIR_DEFAULT_MEMCAP);
 
     /* Check if we have memcap and hash_size defined at config */
     const char *conf_val;
     uint32_t configval = 0;
 
     /** set config values for memcap, prealloc and hash_size */
+    uint64_t ippair_memcap;
     if ((ConfGet("ippair.memcap", &conf_val)) == 1)
     {
-        if (ParseSizeStringU64(conf_val, &ippair_config.memcap) < 0) {
+        if (ParseSizeStringU64(conf_val, &ippair_memcap) < 0) {
             SCLogError(SC_ERR_SIZE_PARSE, "Error parsing ippair.memcap "
                        "from conf file - %s.  Killing engine",
                        conf_val);
             exit(EXIT_FAILURE);
+        } else {
+            SC_ATOMIC_SET(ippair_config.memcap, ippair_memcap);
         }
     }
     if ((ConfGet("ippair.hash-size", &conf_val)) == 1)
@@ -175,7 +216,7 @@ void IPPairInitConfig(char quiet)
         }
     }
     SCLogDebug("IPPair config from suricata.yaml: memcap: %"PRIu64", hash-size: "
-               "%"PRIu32", prealloc: %"PRIu32, ippair_config.memcap,
+               "%"PRIu32", prealloc: %"PRIu32, SC_ATOMIC_GET(ippair_config.memcap),
                ippair_config.hash_size, ippair_config.prealloc);
 
     /* alloc hash memory */
@@ -185,7 +226,7 @@ void IPPairInitConfig(char quiet)
                 "max ippair memcap is smaller than projected hash size. "
                 "Memcap: %"PRIu64", Hash table size %"PRIu64". Calculate "
                 "total hash size by multiplying \"ippair.hash-size\" with %"PRIuMAX", "
-                "which is the hash bucket size.", ippair_config.memcap, hash_size,
+                "which is the hash bucket size.", SC_ATOMIC_GET(ippair_config.memcap), hash_size,
                 (uintmax_t)sizeof(IPPairHashRow));
         exit(EXIT_FAILURE);
     }
@@ -214,7 +255,7 @@ void IPPairInitConfig(char quiet)
         if (!(IPPAIR_CHECK_MEMCAP(g_ippair_size))) {
             SCLogError(SC_ERR_IPPAIR_INIT, "preallocating ippairs failed: "
                     "max ippair memcap reached. Memcap %"PRIu64", "
-                    "Memuse %"PRIu64".", ippair_config.memcap,
+                    "Memuse %"PRIu64".", SC_ATOMIC_GET(ippair_config.memcap),
                     ((uint64_t)SC_ATOMIC_GET(ippair_memuse) + g_ippair_size));
             exit(EXIT_FAILURE);
         }
@@ -231,7 +272,7 @@ void IPPairInitConfig(char quiet)
         SCLogConfig("preallocated %" PRIu32 " ippairs of size %" PRIu16 "",
                 ippair_spare_q.len, g_ippair_size);
         SCLogConfig("ippair memory usage: %"PRIu64" bytes, maximum: %"PRIu64,
-                SC_ATOMIC_GET(ippair_memuse), ippair_config.memcap);
+                SC_ATOMIC_GET(ippair_memuse), SC_ATOMIC_GET(ippair_config.memcap));
     }
 
     return;
@@ -246,7 +287,7 @@ void IPPairPrintStats (void)
         ippairbits_added, ippairbits_removed, ippairbits_memuse_max);
 #endif /* IPPAIRBITS_STATS */
     SCLogPerf("ippair memory usage: %"PRIu64" bytes, maximum: %"PRIu64,
-            SC_ATOMIC_GET(ippair_memuse), ippair_config.memcap);
+            SC_ATOMIC_GET(ippair_memuse), SC_ATOMIC_GET(ippair_config.memcap));
     return;
 }
 
@@ -286,6 +327,7 @@ void IPPairShutdown(void)
     SC_ATOMIC_DESTROY(ippair_prune_idx);
     SC_ATOMIC_DESTROY(ippair_memuse);
     SC_ATOMIC_DESTROY(ippair_counter);
+    SC_ATOMIC_DESTROY(ippair_config.memcap);
     //SC_ATOMIC_DESTROY(flow_flags);
     return;
 }

--- a/src/ippair.h
+++ b/src/ippair.h
@@ -90,7 +90,7 @@ IPPairHashRow *ippair_hash;
 #define IPPAIR_QUIET      1
 
 typedef struct IPPairConfig_ {
-    uint64_t memcap;
+    SC_ATOMIC_DECLARE(uint64_t, memcap);
     uint32_t hash_rand;
     uint32_t hash_size;
     uint32_t prealloc;
@@ -104,7 +104,7 @@ typedef struct IPPairConfig_ {
  *  \retval 0 no fit
  */
 #define IPPAIR_CHECK_MEMCAP(size) \
-    ((((uint64_t)SC_ATOMIC_GET(ippair_memuse) + (uint64_t)(size)) <= ippair_config.memcap))
+    ((((uint64_t)SC_ATOMIC_GET(ippair_memuse) + (uint64_t)(size)) <= SC_ATOMIC_GET(ippair_config.memcap)))
 
 #define IPPairIncrUsecnt(h) \
     (void)SC_ATOMIC_ADD((h)->use_cnt, 1)
@@ -150,5 +150,9 @@ void IPPairFree(IPPair *);
 
 void IPPairLock(IPPair *);
 void IPPairUnlock(IPPair *);
+
+int IPPairSetMemcap(uint64_t size);
+uint64_t IPPairGetMemcap(void);
+uint64_t IPPairGetMemuse(void);
 
 #endif /* __IPPAIR_H__ */

--- a/src/runmode-unix-socket.h
+++ b/src/runmode-unix-socket.h
@@ -39,6 +39,9 @@ TmEcode UnixSocketUnregisterTenant(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketHostbitAdd(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketHostbitRemove(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketHostbitList(json_t *cmd, json_t* answer, void *data);
+TmEcode UnixSocketSetMemcap(json_t *cmd, json_t* answer, void *data);
+TmEcode UnixSocketShowMemcap(json_t *cmd, json_t *answer, void *data);
+TmEcode UnixSocketShowAllMemcap(json_t *cmd, json_t *answer, void *data);
 #endif
 
 #endif /* __RUNMODE_UNIX_SOCKET_H__ */

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -143,7 +143,7 @@ uint64_t StreamTcpReassembleMemuseGlobalCounter(void)
  * \retval 1 if in bounds
  * \retval 0 if not in bounds
  */
-int StreamTcpReassembleCheckMemcap(uint32_t size)
+int StreamTcpReassembleCheckMemcap(uint64_t size)
 {
     if (stream_config.reassembly_memcap == 0 ||
             (uint64_t)((uint64_t)size + SC_ATOMIC_GET(ra_memuse)) <= stream_config.reassembly_memcap)

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -145,10 +145,37 @@ uint64_t StreamTcpReassembleMemuseGlobalCounter(void)
  */
 int StreamTcpReassembleCheckMemcap(uint64_t size)
 {
-    if (stream_config.reassembly_memcap == 0 ||
-            (uint64_t)((uint64_t)size + SC_ATOMIC_GET(ra_memuse)) <= stream_config.reassembly_memcap)
+    uint64_t memcapcopy = SC_ATOMIC_GET(stream_config.reassembly_memcap);
+    if (memcapcopy == 0 ||
+        (uint64_t)((uint64_t)size + SC_ATOMIC_GET(ra_memuse)) <= memcapcopy)
         return 1;
     return 0;
+}
+
+/**
+ *  \brief Update memcap value
+ *
+ *  \param size new memcap value
+ */
+int StreamTcpReassembleSetMemcap(uint64_t size)
+{
+    if (size == 0 || (uint64_t)SC_ATOMIC_GET(ra_memuse) < size) {
+        SC_ATOMIC_SET(stream_config.reassembly_memcap, size);
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
+ *  \brief Return memcap value
+ *
+ *  \return memcap memcap value
+ */
+uint64_t StreamTcpReassembleGetMemcap()
+{
+    uint64_t memcapcopy = SC_ATOMIC_GET(stream_config.reassembly_memcap);
+    return memcapcopy;
 }
 
 /* memory functions for the streaming buffer API */
@@ -2885,7 +2912,7 @@ static int StreamTcpReassembleTest44(void)
     StreamTcpReassembleDecrMemuse(500);
     FAIL_IF(SC_ATOMIC_GET(ra_memuse) != memuse);
     FAIL_IF(StreamTcpReassembleCheckMemcap(500) != 1);
-    FAIL_IF(StreamTcpReassembleCheckMemcap((1 + memuse + stream_config.reassembly_memcap)) != 0);
+    FAIL_IF(StreamTcpReassembleCheckMemcap((1 + memuse + SC_ATOMIC_GET(stream_config.reassembly_memcap))) != 0);
     StreamTcpFreeConfig(TRUE);
     FAIL_IF(SC_ATOMIC_GET(ra_memuse) != 0);
     PASS;

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -114,6 +114,8 @@ int StreamTcpReassembleDepthReached(Packet *p);
 
 void StreamTcpReassembleIncrMemuse(uint64_t size);
 void StreamTcpReassembleDecrMemuse(uint64_t size);
+int StreamTcpReassembleSetMemcap(uint64_t size);
+uint64_t StreamTcpReassembleGetMemcap(void);
 int StreamTcpReassembleCheckMemcap(uint64_t size);
 uint64_t StreamTcpReassembleMemuseGlobalCounter(void);
 

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -114,7 +114,7 @@ int StreamTcpReassembleDepthReached(Packet *p);
 
 void StreamTcpReassembleIncrMemuse(uint64_t size);
 void StreamTcpReassembleDecrMemuse(uint64_t size);
-int StreamTcpReassembleCheckMemcap(uint32_t size);
+int StreamTcpReassembleCheckMemcap(uint64_t size);
 uint64_t StreamTcpReassembleMemuseGlobalCounter(void);
 
 void StreamTcpDisableAppLayer(Flow *f);

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -44,8 +44,8 @@ typedef struct TcpStreamCnf_ {
      *
      * max stream mem usage
      */
-    uint64_t memcap;
-    uint64_t reassembly_memcap; /**< max memory usage for stream reassembly */
+    SC_ATOMIC_DECLARE(uint64_t, memcap);
+    SC_ATOMIC_DECLARE(uint64_t, reassembly_memcap); /**< max memory usage for stream reassembly */
 
     uint16_t stream_init_flags; /**< new stream flags will be initialized to this */
 
@@ -109,6 +109,8 @@ void StreamTcpSessionPktFree (Packet *);
 void StreamTcpInitMemuse(void);
 void StreamTcpIncrMemuse(uint64_t);
 void StreamTcpDecrMemuse(uint64_t);
+int StreamTcpSetMemcap(uint64_t);
+uint64_t StreamTcpGetMemcap(void);
 int StreamTcpCheckMemcap(uint64_t);
 uint64_t StreamTcpMemuseCounter(void);
 uint64_t StreamTcpReassembleMemuseGlobalCounter(void);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -838,7 +838,6 @@ static TmEcode UnixManagerListCommand(json_t *cmd,
     SCReturnInt(TM_ECODE_OK);
 }
 
-
 #if 0
 TmEcode UnixManagerReloadRules(json_t *cmd,
                                json_t *server_msg, void *data)
@@ -998,6 +997,9 @@ int UnixManagerInit(void)
     UnixManagerRegisterCommand("add-hostbit", UnixSocketHostbitAdd, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("remove-hostbit", UnixSocketHostbitRemove, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("list-hostbit", UnixSocketHostbitList, &command, UNIX_CMD_TAKE_ARGS);
+    UnixManagerRegisterCommand("memcap-set", UnixSocketSetMemcap, &command, UNIX_CMD_TAKE_ARGS);
+    UnixManagerRegisterCommand("memcap-show", UnixSocketShowMemcap, &command, UNIX_CMD_TAKE_ARGS);
+    UnixManagerRegisterCommand("memcap-list", UnixSocketShowAllMemcap, NULL, 0);
 
     return 0;
 }


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2285

Describe changes:
- Handle memcap valus with SC_ATOMIC_* functions
- Memcap is updated only if it is lower than memuse:
```
>>> memcap-set flow 1mb
Error:
"memcap value specified for 'flow' is less than the memory in use: 4mb"
```
- In a case like above `memuse` value is shown only to help an user to set a correct memcap value
- `memcap-list` and `memcap-show` functions shows memcap value in kb, mb, or gb (previously was only mb)
- `memcap-show` function returns a json object rather than a string, example below:
```
>>> memcap-show flow
Success:
{
    "value": "64mb"
}
```
- In some cases, memcap can be set to 0 which means `unlimited`, in that case makes more sense to show `unlimited` rather than 0:
```
>>> memcap-show applayer-proto-http
Success:
{
    "value": "unlimited"
}
```
```
>>> memcap-set applayer-proto-http 0
Success:
"memcap value for 'applayer-proto-http' updated: 0 (unlimited)"
```

- HTP atomic vars are destroyed when Suricata is shutdown.
- `size` argument in `StreamTcpReassembleCheckMemcap` is declared as `uint64_t` as all other memcap checking function
- Previous PR: #3034 

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/158
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/22
