### PR TITLE
Conf: Multipe NULL-pointer dereferences in HostInitConfig

### DIFF
--- a/src/host.c
+++ b/src/host.c
@@ -152,7 +152,7 @@ void HostInitConfig(char quiet)
     uint32_t configval = 0;
 
     /** set config values for memcap, prealloc and hash_size */
-    if ((ConfGet("host.memcap", &conf_val)) == 1)
+    if ((ConfGetValue("host.memcap", &conf_val)) == 1)
     {
         if (ParseSizeStringU64(conf_val, &host_config.memcap) < 0) {
             SCLogError(SC_ERR_SIZE_PARSE, "Error parsing host.memcap "
@@ -161,7 +161,7 @@ void HostInitConfig(char quiet)
             exit(EXIT_FAILURE);
         }
     }
-    if ((ConfGet("host.hash-size", &conf_val)) == 1)
+    if ((ConfGetValue("host.hash-size", &conf_val)) == 1)
     {
         if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
@@ -169,7 +169,7 @@ void HostInitConfig(char quiet)
         }
     }
 
-    if ((ConfGet("host.prealloc", &conf_val)) == 1)
+    if ((ConfGetValue("host.prealloc", &conf_val)) == 1)
     {
         if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {


### PR DESCRIPTION
Multiple NULL-pointer dereferences after ConfGet in HostInitConfig can cause suricata to terminate with segfaults. 

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2367

Describe changes:
- replaced ConfGet by ConfGetValue


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

