### PR TITLE
Conf: Multipe NULL-pointer dereferences after ConfGetBool in StreamTc…

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -506,7 +506,7 @@ int ConfGetBool(const char *name, int *val)
     const char *strval = NULL;
 
     *val = 0;
-    if (ConfGet(name, &strval) != 1)
+    if (ConfGetValue(name, &strval) != 1)
         return 0;
 
     *val = ConfValIsTrue(strval);


### PR DESCRIPTION
There are multiple NULL-pointer dereferences after calling ConfGetBool in StreamTcpInitConfig. ConfGetBool calls ConfGet which doesn't check the vptr-argument. 

This commit replaces ConfGet by ConfGetValue in ConfGetBool. This does not only fix Bug #2368 but might also fix others too.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2368

Describe changes:
- Replaced ConfGet by ConfGetValue in ConfGetBool


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

