### PR TITLE
rust: add --enable-rust-debug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2098,6 +2098,11 @@
     ])
     AC_SUBST(RUST_FEATURES)
 
+    AC_ARG_ENABLE(rust_debug,
+           AS_HELP_STRING([--enable-rust-debug], [Rust not in --release mode]),,[enable_rust_debug=no])
+    AM_CONDITIONAL([RUST_DEBUG], [test "x$enable_rust_debug" = "xyes"])
+    AC_SUBST(RUST_DEBUG)
+
 # get revision
     if test -f ./revision; then
         REVISION=`cat ./revision`
@@ -2212,6 +2217,7 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   Rust support (experimental):             ${enable_rust}
   Experimental Rust parsers:               ${enable_rust_experimental}
   Rust strict mode:                        ${enable_rust_strict}
+  Rust strict debug:                       ${enable_rust_debug}
 
   Suricatasc install:                      ${enable_python}
 

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -15,7 +15,7 @@ if HAVE_RUST_VENDOR
 FROZEN = --frozen
 endif
 
-if !DEBUG
+if !RUST_DEBUG
 RELEASE = --release
 endif
 


### PR DESCRIPTION
Add option to put Rust code in non-'--release' mode, preserving
debug symbols.

Until now Suricata would have to be compiled with --enable-debug for
this.


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/62
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/63

