### PR TITLE
SMTP logging and detection improvement

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -232,10 +232,10 @@ outputs:
             #  x-originating-ip, in-reply-to, references, importance, priority,
             #  sensitivity, organization, content-md5, date
             #custom: [received, x-mailer, x-originating-ip, relays, reply-to, bcc]
-            # output md5 of fields: body, subject
+            # output md5 of fields: body, subject, attachments
             # for the body you need to set app-layer.protocols.smtp.mime.body-md5
             # to yes
-            #md5: [body, subject]
+            #md5: [body, subject, attachments]
 
         #- dnp3
         @rust_config_comment@- nfs


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2388
https://redmine.openinfosecfoundation.org/issues/2387

Describe changes:
This patchset permits to log the md5 hash of attachments in smtp events and also extends probing parser to detect smtp protocol.
I would discuss if there is another way to do that.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/162
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/26

