### PR TITLE
rust/mingw: fix linker issues on mingw

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -197,6 +197,9 @@
     fi
     echo -n "installation for $host OS... "
 
+    RUST_LDADD="-ldl -lrt -lm"
+    RUST_SURICATA_LIBNAME="libsuricata.a"
+
     e_magic_file=""
     e_magic_file_comment="#"
     PCAP_LIB_NAME="pcap"
@@ -223,7 +226,6 @@
             ;;
         *-*-linux*)
             #for now do nothing
-            RUST_LDADD="-ldl -lrt -lm"
             ;;
         *-*-mingw32*)
             CFLAGS="${CFLAGS} -DOS_WIN32"
@@ -231,6 +233,8 @@
             WINDOWS_PATH="yes"
             PCAP_LIB_NAME="wpcap"
             AC_DEFINE([HAVE_NON_POSIX_MKDIR], [1], [mkdir is not POSIX compliant: single arg])
+            RUST_SURICATA_LIBNAME="suricata.lib"
+            RUST_LDADD="-luserenv -lshell32 -ladvapi32 -lgcc_eh"
             ;;
         *-*-cygwin)
             LUA_PC_NAME="lua"
@@ -2040,9 +2044,9 @@
           enable_rust="yes"
           AC_DEFINE([HAVE_RUST],[1],[Enable Rust language])
           if test "x$enable_debug" = "xyes"; then
-            RUST_SURICATA_LIB="../rust/target/debug/libsuricata.a"
+            RUST_SURICATA_LIB="../rust/target/debug/${RUST_SURICATA_LIBNAME}"
           else
-            RUST_SURICATA_LIB="../rust/target/release/libsuricata.a"
+            RUST_SURICATA_LIB="../rust/target/release/${RUST_SURICATA_LIBNAME}"
           fi
           RUST_LDADD="${RUST_SURICATA_LIB} ${RUST_LDADD}"
           CFLAGS="${CFLAGS} -I\${srcdir}/../rust/gen/c-headers"


### PR DESCRIPTION
Fixes for building Rust on MinGW.

Installed 'mingw-w64-x86_64-rust' and also needed 'mingw-64-x86_64-libssh2' for cargo to work.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/65
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/67
