### PR TITLE
Rotate log files based on file size

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -243,7 +243,7 @@ modifiers.
 Rotate log file
 ~~~~~~~~~~~~~~~
 
-Eve-log can be configured to rotate based on time.
+Eve-log can be configured to rotate based on time, file size, or both combined.
 
 ::
 
@@ -251,9 +251,16 @@ Eve-log can be configured to rotate based on time.
     - eve-log:
         filename: eve-%Y-%m-%d-%H:%M.json
         rotate-interval: minute
+        rotate-size: 100mb
 
-The example above creates a new log file each minute, where the filename contains
-a timestamp. Other supported ``rotate-interval`` values are ``hour`` and ``day``.
+The example above creates a new log file either each minute or when the file
+reaches 100 mb in size. The filename contains a timestamp to avoid overwriting
+itself when rotating.
+
+If both time-based and size-based rotation is used at the same time, then the
+rotation time is reset upon rotation, even if the rotation was based on size.
+
+Other supported ``rotate-interval`` values are ``hour`` and ``day``.
 
 In addition to this, it is also possible to specify the ``rotate-interval`` as a
 relative value. One example is to rotate the log file each X seconds.

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -432,9 +432,10 @@ SCConfLogOpenGeneric(ConfNode *conf,
             if (log_ctx->rotate_interval == 0) {
                 SCLogError(SC_ERR_INVALID_NUMERIC_VALUE,
                            "invalid rotate-interval value");
-                exit(EXIT_FAILURE);
+                log_ctx->flags &= ~LOGFILE_ROTATE_INTERVAL;
+            } else {
+                log_ctx->rotate_time = now + log_ctx->rotate_interval;
             }
-            log_ctx->rotate_time = now + log_ctx->rotate_interval;
         }
     }
 

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -29,6 +29,7 @@
 #include "conf.h"            /* ConfNode, etc. */
 #include "output.h"          /* DEFAULT_LOG_* */
 #include "util-byte.h"
+#include "util-misc.h"
 #include "util-logopenfile.h"
 #include "util-logopenfile-tile.h"
 
@@ -202,7 +203,19 @@ static int SCLogFileWrite(const char *buffer, int buffer_len, LogFileCtx *log_ct
             SCConfLogReopen(log_ctx);
         }
 
-        if (log_ctx->flags & LOGFILE_ROTATE_INTERVAL) {
+        /* Rotate on size, if specified */
+        if ((log_ctx->flags & LOGFILE_ROTATE_SIZE) &&
+                (log_ctx->size_current + buffer_len > log_ctx->size_limit)) {
+            SCConfLogReopen(log_ctx);
+
+            /* Reset time-based rotation, if used */
+            if (log_ctx->flags & LOGFILE_ROTATE_INTERVAL) {
+                time_t now = time(NULL);
+                log_ctx->rotate_time = now + log_ctx->rotate_interval;
+            }
+        }
+        /* Rotate on time, if specified */
+        else if (log_ctx->flags & LOGFILE_ROTATE_INTERVAL) {
             time_t now = time(NULL);
             if (now >= log_ctx->rotate_time) {
                 SCConfLogReopen(log_ctx);
@@ -214,6 +227,7 @@ static int SCLogFileWrite(const char *buffer, int buffer_len, LogFileCtx *log_ct
             clearerr(log_ctx->fp);
             ret = fwrite(buffer, buffer_len, 1, log_ctx->fp);
             fflush(log_ctx->fp);
+            log_ctx->size_current += buffer_len;
         }
     }
 
@@ -424,6 +438,17 @@ SCConfLogOpenGeneric(ConfNode *conf,
         }
     }
 
+    /* Rotate log file based on size */
+    const char *rotate_size = ConfNodeLookupChildValue(conf, "rotate-size");
+    if (rotate_size != NULL) {
+        if (ParseSizeStringU64(rotate_size, &log_ctx->size_limit) < 0) {
+            SCLogError(SC_ERR_INVALID_NUMERIC_VALUE,
+                       "invalid rotate-size value");
+        } else {
+            log_ctx->flags |= LOGFILE_ROTATE_SIZE;
+        }
+    }
+
     filetype = ConfNodeLookupChildValue(conf, "filetype");
     if (filetype == NULL)
         filetype = DEFAULT_LOG_FILETYPE;
@@ -566,6 +591,8 @@ int SCConfLogReopen(LogFileCtx *log_ctx)
     if (log_ctx->fp == NULL) {
         return -1; // Already logged by Open..Fp routine.
     }
+
+    log_ctx->size_current = 0;
 
     return 0;
 }

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -134,10 +134,10 @@ typedef struct LogFileCtx_ {
 #define LOGFILE_RECONN_MIN_TIME     500
 
 /* flags for LogFileCtx */
-#define LOGFILE_HEADER_WRITTEN  0x01
-#define LOGFILE_ALERTS_PRINTED  0x02
-#define LOGFILE_ROTATE_INTERVAL 0x04
-#define LOGFILE_ROTATE_SIZE     0x08
+#define LOGFILE_HEADER_WRITTEN  BIT_U8(0)
+#define LOGFILE_ALERTS_PRINTED  BIT_U8(1)
+#define LOGFILE_ROTATE_INTERVAL BIT_U8(2)
+#define LOGFILE_ROTATE_SIZE     BIT_U8(3)
 
 LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -137,6 +137,7 @@ typedef struct LogFileCtx_ {
 #define LOGFILE_HEADER_WRITTEN  0x01
 #define LOGFILE_ALERTS_PRINTED  0x02
 #define LOGFILE_ROTATE_INTERVAL 0x04
+#define LOGFILE_ROTATE_SIZE     0x08
 
 LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);


### PR DESCRIPTION
Rotate log files based on size. Similar to the time-based rotation.

Enable by adding 'rotate-size' to the logger in suricata.yaml:
```yaml
- eve-log:
    enabled: yes
    filetype: regular
    filename: eve-%s.json
    rotate-size: 50mb
```    

Also works together with time-based rotation, which makes it possible to rotate either when reaching a specific file size, or after a specified time.

https://redmine.openinfosecfoundation.org/issues/2107

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/138
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/138