### PR TITLE
Dns compact logging v4

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -337,6 +337,38 @@ integration with 3rd party tools like logstash.
             # the example below adds three additional fields when uncommented
             #custom: [Accept-Encoding, Accept-Language, Authorization]
         - dns:
+            # Use version 2 logging with the new format:
+            # dns answers will be logged in one single event
+            # rather than an event for each of the answers.
+            # Without setting a version the version
+            # will fallback to 1 for backwards compatibility.
+            version: 2
+
+            # Enable/disable this logger. Default: enabled.
+            #enabled: no
+
+            # Control logging of requests and responses:
+            # - requests: enable logging of DNS queries
+            # - responses: enable logging of DNS answers
+            # By default both requests and responses are logged.
+            #requests: no
+            #responses: no
+
+            # Format of answer logging:
+            # - detailed: array item per answer
+            # - grouped: answers aggregated by type
+            # Default: all
+            #answer-format: [detailed, grouped]
+
+            # Answer types to log.
+            # Default: all
+            #answer-types: [a, aaaa, cname, mx, ns, ptr, txt]
+        - dns:
+            # Version 1 (deprecated) DNS logger.
+            version: 1
+
+            enabled: no
+
             # control logging of queries and answers
             # default yes, no to disable
             query: yes     # enable logging of DNS queries

--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -177,6 +177,21 @@ Event with extended logging:
 Event type: DNS
 ---------------
 
+A new version of dns logging has been introduced to improve how dns answers
+are logged.
+
+With that new version, dns answers are logged in one event
+rather than an event for each answer.
+
+It's possible to customize how a dns answer will be logged with the following
+formats:
+
+* "detailed": "rrname", "rrtype", "rdata" and "ttl" fields are logged for each answer
+* "grouped": answers logged are aggregated by their type (A, AAAA, NS, ...)
+
+It will be still possible to use the old DNS logging format, you can control it
+with "version" option in dns configuration section.
+
 Fields
 ~~~~~~
 
@@ -184,6 +199,7 @@ Outline of fields seen in the different kinds of DNS events:
 
 * "type": Indicating DNS message type, can be "answer" or "query".
 * "id": Identifier field
+* "version": Indicating DNS logging version in use
 * "flags": Indicating DNS answer flag, in hexadecimal (ex: 8180 , please note 0x is not output)
 * "qr": Indicating in case of DNS answer flag, Query/Response flag (ex: true if set)
 * "aa": Indicating in case of DNS answer flag, Authoritative Answer flag (ex: true if set)
@@ -212,7 +228,68 @@ Example of a DNS query for the IPv4 address of "twitter.com" (resource record ty
       "rrtype":"A"
   }
 
-Example of a DNS answer with an IPv4 (resource record type 'A') return:
+Example of a DNS answer with "detailed" format:
+
+::
+
+
+  "dns": {
+      "version": 2,
+      "type": "answer",
+      "id": 45444,
+      "flags": "8180",
+      "qr": true,
+      "rd": true,
+      "ra": true,
+      "rcode": "NOERROR",
+      "answers": [
+        {
+          "rrname": "www.suricata-ids.org",
+          "rrtype": "CNAME",
+          "ttl": 3324,
+          "rdata": "suricata-ids.org"
+        },
+        {
+          "rrname": "suricata-ids.org",
+          "rrtype": "A",
+          "ttl": 10,
+          "rdata": "192.0.78.24"
+        },
+        {
+          "rrname": "suricata-ids.org",
+          "rrtype": "A",
+          "ttl": 10,
+          "rdata": "192.0.78.25"
+        }
+      ]
+  }
+
+Example of a DNS answer with "grouped" format:
+
+::
+
+  "dns": {
+      "version": 2,
+      "type": "answer",
+      "id": 18523,
+      "flags": "8180",
+      "qr": true,
+      "rd": true,
+      "ra": true,
+      "rcode": "NOERROR",
+      "grouped": {
+        "A": [
+          "192.0.78.24",
+          "192.0.78.25"
+        ],
+        "CNAME": [
+          "suricata-ids.org"
+        ]
+      }
+  }
+
+
+Example of a old DNS answer with an IPv4 (resource record type 'A') return:
 
 ::
 

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -45,6 +45,7 @@
 #include "detect-reference.h"
 #include "app-layer-parser.h"
 #include "app-layer-dnp3.h"
+#include "app-layer-dns-common.h"
 #include "app-layer-htp.h"
 #include "app-layer-htp-xff.h"
 #include "app-layer-ftp.h"
@@ -56,6 +57,7 @@
 #include "output-json.h"
 #include "output-json-alert.h"
 #include "output-json-dnp3.h"
+#include "output-json-dns.h"
 #include "output-json-http.h"
 #include "output-json-tls.h"
 #include "output-json-ssh.h"
@@ -91,8 +93,9 @@
 #define LOG_JSON_FLOW              BIT_U16(11)
 #define LOG_JSON_HTTP_BODY         BIT_U16(12)
 #define LOG_JSON_HTTP_BODY_BASE64  BIT_U16(13)
+#define LOG_JSON_DNS               BIT_U16(14)
 
-#define LOG_JSON_METADATA_ALL  (LOG_JSON_APP_LAYER|LOG_JSON_HTTP|LOG_JSON_TLS|LOG_JSON_SSH|LOG_JSON_SMTP|LOG_JSON_DNP3|LOG_JSON_VARS|LOG_JSON_FLOW)
+#define LOG_JSON_METADATA_ALL  (LOG_JSON_APP_LAYER|LOG_JSON_HTTP|LOG_JSON_TLS|LOG_JSON_SSH|LOG_JSON_SMTP|LOG_JSON_DNP3|LOG_JSON_VARS|LOG_JSON_FLOW|LOG_JSON_DNS)
 
 #define JSON_STREAM_BUFFER_SIZE 4096
 
@@ -181,6 +184,35 @@ static void AlertJsonDnp3(const Flow *f, json_t *js)
         }
     }
 
+    return;
+}
+
+static void AlertJsonDns(const Flow *f, json_t *js)
+{
+#ifndef HAVE_RUST
+    DNSState *dns_state = (DNSState *)FlowGetAppState(f);
+    if (dns_state) {
+        uint64_t tx_id = AppLayerParserGetTransactionLogId(f->alparser);
+        DNSTransaction *tx = AppLayerParserGetTx(f->proto, ALPROTO_DNS,
+                                                 dns_state, tx_id);
+        if (tx) {
+            json_t *dnsjs = json_object();
+            if (unlikely(dnsjs == NULL)) {
+                return;
+            }
+
+            json_t *qjs = JsonDNSLogQuery(tx, tx_id);
+            if (qjs != NULL) {
+                json_object_set_new(dnsjs, "query", qjs);
+            }
+            json_t *ajs = JsonDNSLogAnswer(tx, tx_id);
+            if (ajs != NULL) {
+                json_object_set_new(dnsjs, "answer", ajs);
+            }
+            json_object_set_new(js, "dns", dnsjs);
+        }
+    }
+#endif
     return;
 }
 
@@ -471,8 +503,14 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                 json_object_set_new(js, "app_proto",
                         json_string(AppProtoToString(p->flow->alproto)));
             }
-        }
 
+            if (json_output_ctx->flags & LOG_JSON_DNS) {
+                AppProto proto = FlowGetAppProtocol(p->flow);
+                if (proto == ALPROTO_DNS) {
+                    AlertJsonDns(p->flow, js);
+                }
+            }
+        }
 
         /* payload */
         if (json_output_ctx->flags & (LOG_JSON_PAYLOAD | LOG_JSON_PAYLOAD_BASE64)) {
@@ -800,6 +838,7 @@ static void XffSetup(AlertJsonOutputCtx *json_output_ctx, ConfNode *conf)
         SetFlag(conf, "payload-printable", LOG_JSON_PAYLOAD, &json_output_ctx->flags);
         SetFlag(conf, "http-body-printable", LOG_JSON_HTTP_BODY, &json_output_ctx->flags);
         SetFlag(conf, "http-body", LOG_JSON_HTTP_BODY_BASE64, &json_output_ctx->flags);
+        SetFlag(conf, "dns", LOG_JSON_DNS, &json_output_ctx->flags);
 
         const char *payload_buffer_value = ConfNodeLookupChildValue(conf, "payload-buffer-size");
 

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -123,7 +123,11 @@
 #define LOG_ANY        BIT_U64(58)
 #define LOG_URI        BIT_U64(59)
 
-#define LOG_ALL_RRTYPES (~(uint64_t)(LOG_QUERIES|LOG_ANSWERS))
+#define LOG_FORMAT_GROUPED     BIT_U64(60)
+#define LOG_FORMAT_DETAILED    BIT_U64(61)
+
+#define LOG_FORMAT_ALL (LOG_FORMAT_GROUPED|LOG_FORMAT_DETAILED)
+#define LOG_ALL_RRTYPES (~(uint64_t)(LOG_QUERIES|LOG_ANSWERS|LOG_FORMAT_DETAILED|LOG_FORMAT_GROUPED))
 
 typedef enum {
     DNS_RRTYPE_A = 0,
@@ -401,25 +405,12 @@ static int DNSRRTypeEnabled(uint16_t type, uint64_t flags)
 #endif
 
 #ifndef HAVE_RUST
-static void LogQuery(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx,
-        uint64_t tx_id, DNSQueryEntry *entry) __attribute__((nonnull));
-
-static void LogQuery(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx,
-        uint64_t tx_id, DNSQueryEntry *entry)
+static json_t *OutputQuery(DNSTransaction *tx, uint64_t tx_id, DNSQueryEntry *entry)
 {
-    SCLogDebug("got a DNS request and now logging !!");
-
-    if (!DNSRRTypeEnabled(entry->type, aft->dnslog_ctx->flags)) {
-        return;
-    }
-
     json_t *djs = json_object();
     if (djs == NULL) {
-        return;
+        return NULL;
     }
-
-    /* reset */
-    MemBufferReset(aft->buffer);
 
     /* type */
     json_object_set_new(djs, "type", json_string("query"));
@@ -443,6 +434,26 @@ static void LogQuery(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx,
     /* tx id (tx counter) */
     json_object_set_new(djs, "tx_id", json_integer(tx_id));
 
+    return djs;
+}
+
+static void LogQuery(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx,
+        uint64_t tx_id, DNSQueryEntry *entry)
+{
+    SCLogDebug("got a DNS request and now logging !!");
+
+    if (!DNSRRTypeEnabled(entry->type, aft->dnslog_ctx->flags)) {
+        return;
+    }
+
+    json_t *djs = OutputQuery(tx, tx_id, entry);
+    if (djs == NULL) {
+        return;
+    }
+
+    /* reset */
+    MemBufferReset(aft->buffer);
+
     /* dns */
     json_object_set_new(js, "dns", djs);
     OutputJSONBuffer(js, aft->dnslog_ctx->file_ctx, &aft->buffer);
@@ -451,10 +462,242 @@ static void LogQuery(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx,
 #endif
 
 #ifndef HAVE_RUST
-static void OutputAnswer(LogDnsLogThread *aft, json_t *djs,
-        DNSTransaction *tx, DNSAnswerEntry *entry) __attribute__((nonnull));
 
-static void OutputAnswer(LogDnsLogThread *aft, json_t *djs,
+static json_t *DnsParseSshFpType(DNSAnswerEntry *entry, uint8_t *ptr)
+{
+    /* get algo and type */
+    uint8_t algo = *ptr;
+    uint8_t fptype = *(ptr+1);
+
+    /* turn fp raw buffer into a nice :-separate hex string */
+    uint16_t fp_len = (entry->data_len - 2);
+    uint8_t *dptr = ptr+2;
+
+    /* c-string for ':' separated hex and trailing \0. */
+    uint32_t output_len = fp_len * 3 + 1;
+    char hexstring[output_len];
+    memset(hexstring, 0x00, output_len);
+
+    uint16_t x;
+    for (x = 0; x < fp_len; x++) {
+        char one[4];
+        snprintf(one, sizeof(one), x == fp_len - 1 ? "%02x" : "%02x:", dptr[x]);
+        strlcat(hexstring, one, output_len);
+    }
+
+    /* wrap the whole thing in it's own structure */
+    json_t *hjs = json_object();
+    if (hjs == NULL) {
+        return NULL;
+    }
+
+    json_object_set_new(hjs, "fingerprint", json_string(hexstring));
+    json_object_set_new(hjs, "algo", json_integer(algo));
+    json_object_set_new(hjs, "type", json_integer(fptype));
+
+    return hjs;
+}
+
+static void OutputAnswerDetailed(DNSAnswerEntry *entry, json_t *js)
+{
+    do {
+        json_t *jdata = json_object();
+        if (jdata == NULL) {
+            return;
+        }
+
+        /* query */
+        if (entry->fqdn_len > 0) {
+            char *c;
+            c = BytesToString((uint8_t *)((uint8_t *)entry + sizeof(DNSAnswerEntry)),
+                    entry->fqdn_len);
+            if (c != NULL) {
+                json_object_set_new(jdata, "rrname", json_string(c));
+                SCFree(c);
+            }
+        }
+
+        /* name */
+        char record[16] = "";
+        DNSCreateTypeString(entry->type, record, sizeof(record));
+        json_object_set_new(jdata, "rrtype", json_string(record));
+
+        /* ttl */
+        json_object_set_new(jdata, "ttl", json_integer(entry->ttl));
+
+        uint8_t *ptr = (uint8_t *)((uint8_t *)entry + sizeof(DNSAnswerEntry)+ entry->fqdn_len);
+        if (entry->type == DNS_RECORD_TYPE_A && entry->data_len == 4) {
+            char a[16] = "";
+            PrintInet(AF_INET, (const void *)ptr, a, sizeof(a));
+            json_object_set_new(jdata, "rdata", json_string(a));
+        } else if (entry->type == DNS_RECORD_TYPE_AAAA && entry->data_len == 16) {
+            char a[46] = "";
+            PrintInet(AF_INET6, (const void *)ptr, a, sizeof(a));
+            json_object_set_new(jdata, "rdata", json_string(a));
+        } else if (entry->data_len == 0) {
+            json_object_set_new(jdata, "rdata", json_string(""));
+        } else if (entry->type == DNS_RECORD_TYPE_TXT || entry->type == DNS_RECORD_TYPE_CNAME ||
+                entry->type == DNS_RECORD_TYPE_MX || entry->type == DNS_RECORD_TYPE_PTR ||
+                entry->type == DNS_RECORD_TYPE_NS) {
+            if (entry->data_len != 0) {
+                char buffer[256] = "";
+                uint16_t copy_len = entry->data_len < (sizeof(buffer) - 1) ?
+                    entry->data_len : sizeof(buffer) - 1;
+                memcpy(buffer, ptr, copy_len);
+                buffer[copy_len] = '\0';
+                json_object_set_new(jdata, "rdata", json_string(buffer));
+            } else {
+                json_object_set_new(jdata, "rdata", json_string(""));
+            }
+        } else if (entry->type == DNS_RECORD_TYPE_SSHFP) {
+            if (entry->data_len > 2) {
+                json_t *hjs = DnsParseSshFpType(entry, ptr);
+                if (hjs != NULL) {
+                   json_object_set_new(jdata, "sshfp", hjs);
+                }
+            }
+        }
+        json_array_append_new(js, jdata);
+    } while ((entry = TAILQ_NEXT(entry, next)));
+}
+
+static void OutputAnswerGrouped(DNSAnswerEntry *entry, json_t *js)
+{
+    struct {
+        #define ENTRY_TYPE_A        0
+        #define ENTRY_TYPE_AAAA     1
+        #define ENTRY_TYPE_TXT      2
+        #define ENTRY_TYPE_CNAME    3
+        #define ENTRY_TYPE_MX       4
+        #define ENTRY_TYPE_PTR      5
+        #define ENTRY_TYPE_NS       6
+        #define ENTRY_TYPE_SSHFP    7
+        #define ENTRY_TYPE_MAX      8
+        const char *name;
+        json_t *value;
+    } dns_rtypes[] = {
+        { "A",      NULL },
+        { "AAAA",   NULL },
+        { "TXT",    NULL },
+        { "CNAME",  NULL },
+        { "MX",     NULL },
+        { "PTR",    NULL },
+        { "NS",     NULL },
+        { "SSHFP",  NULL }
+    };
+
+    int i;
+    json_t *jrdata = json_object();
+    if (jrdata == NULL) {
+        return;
+    }
+
+    do {
+        uint8_t *ptr = (uint8_t *)((uint8_t *)entry + sizeof(DNSAnswerEntry)+ entry->fqdn_len);
+        if (entry->type == DNS_RECORD_TYPE_A && entry->data_len == 4) {
+            char a[16] = "";
+            if (dns_rtypes[ENTRY_TYPE_A].value == NULL) {
+                dns_rtypes[ENTRY_TYPE_A].value = json_array();
+                if (dns_rtypes[ENTRY_TYPE_A].value == NULL) {
+                    goto out;
+                }
+            }
+            PrintInet(AF_INET, (const void *)ptr, a, sizeof(a));
+            json_array_append_new(dns_rtypes[ENTRY_TYPE_A].value, json_string(a));
+        } else if (entry->type == DNS_RECORD_TYPE_AAAA && entry->data_len == 16) {
+            char a[46] = "";
+            if (dns_rtypes[ENTRY_TYPE_AAAA].value == NULL) {
+                dns_rtypes[ENTRY_TYPE_AAAA].value = json_array();
+                if (dns_rtypes[ENTRY_TYPE_AAAA].value == NULL) {
+                    goto out;
+                }
+            }
+            PrintInet(AF_INET6, (const void *)ptr, a, sizeof(a));
+            json_array_append_new(dns_rtypes[ENTRY_TYPE_AAAA].value, json_string(a));
+        } else if (entry->data_len == 0) {
+            json_object_set_new(js, "rdata", json_string(""));
+        } else if (entry->type == DNS_RECORD_TYPE_TXT || entry->type == DNS_RECORD_TYPE_CNAME ||
+                entry->type == DNS_RECORD_TYPE_MX || entry->type == DNS_RECORD_TYPE_PTR ||
+                entry->type == DNS_RECORD_TYPE_NS) {
+            if (entry->data_len != 0) {
+                char buffer[256] = "";
+                uint16_t copy_len = entry->data_len < (sizeof(buffer) - 1) ?
+                    entry->data_len : sizeof(buffer) - 1;
+                memcpy(buffer, ptr, copy_len);
+                buffer[copy_len] = '\0';
+
+                if (entry->type == DNS_RECORD_TYPE_TXT) {
+                    if (dns_rtypes[ENTRY_TYPE_TXT].value == NULL) {
+                        dns_rtypes[ENTRY_TYPE_TXT].value = json_array();
+                        if (dns_rtypes[ENTRY_TYPE_TXT].value == NULL) {
+                            goto out;
+                        }
+                    }
+                    json_array_append_new(dns_rtypes[ENTRY_TYPE_TXT].value, json_string(buffer));
+                } else if (entry->type == DNS_RECORD_TYPE_CNAME) {
+                    if (dns_rtypes[ENTRY_TYPE_CNAME].value == NULL) {
+                        dns_rtypes[ENTRY_TYPE_CNAME].value = json_array();
+                        if (dns_rtypes[ENTRY_TYPE_CNAME].value == NULL) {
+                            goto out;
+                        }
+                    }
+                    json_array_append_new(dns_rtypes[ENTRY_TYPE_CNAME].value, json_string(buffer));
+                } else if (entry->type == DNS_RECORD_TYPE_MX) {
+                    if (dns_rtypes[ENTRY_TYPE_MX].value == NULL) {
+                        dns_rtypes[ENTRY_TYPE_MX].value = json_array();
+                        if (dns_rtypes[ENTRY_TYPE_MX].value == NULL) {
+                            goto out;
+                        }
+                    }
+                    json_array_append_new(dns_rtypes[ENTRY_TYPE_MX].value, json_string(buffer));
+                } else if (entry->type == DNS_RECORD_TYPE_PTR) {
+                    if (dns_rtypes[ENTRY_TYPE_PTR].value == NULL) {
+                        dns_rtypes[ENTRY_TYPE_PTR].value = json_array();
+                        if (dns_rtypes[ENTRY_TYPE_PTR].value == NULL) {
+                            goto out;
+                        }
+                    }
+                    json_array_append_new(dns_rtypes[ENTRY_TYPE_PTR].value, json_string(buffer));
+                } else if (entry->type == DNS_RECORD_TYPE_NS) {
+                    if (dns_rtypes[ENTRY_TYPE_NS].value == NULL) {
+                        dns_rtypes[ENTRY_TYPE_NS].value = json_array();
+                        if (dns_rtypes[ENTRY_TYPE_NS].value == NULL) {
+                            goto out;
+                        }
+                    }
+                    json_array_append_new(dns_rtypes[ENTRY_TYPE_NS].value, json_string(buffer));
+                }
+            } else {
+                json_object_set_new(js, "rdata", json_string(""));
+            }
+        } else if (entry->type == DNS_RECORD_TYPE_SSHFP) {
+            if (entry->data_len > 2) {
+                json_t *hjs = DnsParseSshFpType(entry, ptr);
+                if (hjs != NULL) {
+                    if (dns_rtypes[ENTRY_TYPE_SSHFP].value == NULL) {
+                        dns_rtypes[ENTRY_TYPE_SSHFP].value = json_array();
+                        if (dns_rtypes[ENTRY_TYPE_SSHFP].value == NULL) {
+                            goto out;
+                        }
+                    }
+                    json_array_append_new(dns_rtypes[ENTRY_TYPE_SSHFP].value, hjs);
+                }
+            }
+        }
+    } while ((entry = TAILQ_NEXT(entry, next)));
+
+out:
+    for (i = 0; i < ENTRY_TYPE_MAX; i++) {
+        if (dns_rtypes[i].value != NULL) {
+            json_object_set_new(jrdata, dns_rtypes[i].name, dns_rtypes[i].value);
+            dns_rtypes[i].value = NULL;
+        }
+    }
+
+    json_object_set_new(js, "grouped", jrdata);
+}
+
+static void OutputAnswerV1(LogDnsLogThread *aft, json_t *djs,
         DNSTransaction *tx, DNSAnswerEntry *entry)
 {
     if (!DNSRRTypeEnabled(entry->type, aft->dnslog_ctx->flags)) {
@@ -537,36 +780,55 @@ static void OutputAnswer(LogDnsLogThread *aft, json_t *djs,
         }
     } else if (entry->type == DNS_RECORD_TYPE_SSHFP) {
         if (entry->data_len > 2) {
-            /* get algo and type */
-            uint8_t algo = *ptr;
-            uint8_t fptype = *(ptr+1);
-
-            /* turn fp raw buffer into a nice :-separate hex string */
-            uint16_t fp_len = (entry->data_len - 2);
-            uint8_t *dptr = ptr+2;
-
-            /* c-string for ':' separated hex and trailing \0. */
-            uint32_t output_len = fp_len * 3 + 1;
-            char hexstring[output_len];
-            memset(hexstring, 0x00, output_len);
-
-            uint16_t x;
-            for (x = 0; x < fp_len; x++) {
-                char one[4];
-                snprintf(one, sizeof(one), x == fp_len - 1 ? "%02x" : "%02x:", dptr[x]);
-                strlcat(hexstring, one, output_len);
-            }
-
-            /* wrap the whole thing in it's own structure */
-            json_t *hjs = json_object();
+            json_t *hjs = DnsParseSshFpType(entry, ptr);
             if (hjs != NULL) {
-                json_object_set_new(hjs, "fingerprint", json_string(hexstring));
-                json_object_set_new(hjs, "algo", json_integer(algo));
-                json_object_set_new(hjs, "type", json_integer(fptype));
-
                 json_object_set_new(js, "sshfp", hjs);
             }
         }
+    }
+
+    /* reset */
+    MemBufferReset(aft->buffer);
+    json_object_set_new(djs, "dns", js);
+    OutputJSONBuffer(djs, aft->dnslog_ctx->file_ctx, &aft->buffer);
+    json_object_del(djs, "dns");
+
+    return;
+}
+
+static void OutputAnswerV2(LogDnsLogThread *aft, json_t *djs,
+        DNSTransaction *tx, DNSAnswerEntry *entry)
+{
+    if (!DNSRRTypeEnabled(entry->type, aft->dnslog_ctx->flags)) {
+        return;
+    }
+
+    json_t *js = json_object();
+    if (js == NULL)
+        return;
+
+    /* type */
+    json_object_set_new(js, "type", json_string("answer"));
+
+    /* id */
+    json_object_set_new(js, "id", json_integer(tx->tx_id));
+
+    /* rcode */
+    char rcode[16] = "";
+    DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));
+    json_object_set_new(js, "rcode", json_string(rcode));
+
+    if (aft->dnslog_ctx->flags & LOG_FORMAT_DETAILED) {
+        json_t *jarray = json_array();
+        if (jarray == NULL)
+            return;
+
+        OutputAnswerDetailed(entry, jarray);
+        json_object_set_new(js, "answers", jarray);
+    }
+
+    if (aft->dnslog_ctx->flags & LOG_FORMAT_GROUPED) {
+        OutputAnswerGrouped(entry, js);
     }
 
     /* reset */
@@ -641,13 +903,20 @@ static void LogAnswers(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx, uin
     }
 
     DNSAnswerEntry *entry = NULL;
-    TAILQ_FOREACH(entry, &tx->answer_list, next) {
-        OutputAnswer(aft, js, tx, entry);
+    if (aft->dnslog_ctx->version == DNS_VERSION_2) {
+        entry = TAILQ_FIRST(&tx->answer_list);
+        if (entry) {
+            OutputAnswerV2(aft, js, tx, entry);
+        }
+    } else {
+        TAILQ_FOREACH(entry, &tx->answer_list, next) {
+            OutputAnswerV1(aft, js, tx, entry);
+        }
     }
 
     entry = NULL;
     TAILQ_FOREACH(entry, &tx->authority_list, next) {
-        OutputAnswer(aft, js, tx, entry);
+        OutputAnswerV1(aft, js, tx, entry);
     }
 
 }
@@ -901,6 +1170,23 @@ static void JsonDnsLogInitFilters(LogDnsFileCtx *dnslog_ctx, ConfNode *conf)
             JsonDnsLogParseConfig(dnslog_ctx, conf, "query", "answer", "custom");
         } else {
             JsonDnsLogParseConfig(dnslog_ctx, conf, "requests", "responses", "types");
+
+            if (dnslog_ctx->flags & LOG_ANSWERS) {
+                ConfNode *format;
+                if ((format = ConfNodeLookupChild(conf, "formats")) != NULL) {
+                    dnslog_ctx->flags &= ~LOG_FORMAT_ALL;
+                    ConfNode *field;
+                    TAILQ_FOREACH(field, &format->head, next) {
+                        if (strcasecmp(field->val, "detailed") == 0) {
+                            dnslog_ctx->flags |= LOG_FORMAT_DETAILED;
+                        } else if (strcasecmp(field->val, "grouped") == 0) {
+                            dnslog_ctx->flags |= LOG_FORMAT_GROUPED;
+                        }
+                    }
+                } else {
+                    dnslog_ctx->flags |= LOG_FORMAT_ALL;
+                }
+            }
         }
     }
 }

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -187,6 +187,11 @@ typedef enum {
     DNS_RRTYPE_MAX,
 } DnsRRTypes;
 
+typedef enum {
+    DNS_VERSION_1 = 1,
+    DNS_VERSION_2
+} DnsVersion;
+
 static struct {
     const char *config_rrtype;
     uint64_t flags;
@@ -254,6 +259,7 @@ static struct {
 typedef struct LogDnsFileCtx_ {
     LogFileCtx *file_ctx;
     uint64_t flags; /** Store mode */
+    DnsVersion version;
 } LogDnsFileCtx;
 
 typedef struct LogDnsLogThread_ {
@@ -806,53 +812,106 @@ static void LogDnsLogDeInitCtxSub(OutputCtx *output_ctx)
     SCFree(output_ctx);
 }
 
+static void JsonDnsLogParseConfig(LogDnsFileCtx *dnslog_ctx, ConfNode *conf,
+                                  const char *query_key, const char *answer_key,
+                                  const char *answer_types_key)
+{
+    const char *query = ConfNodeLookupChildValue(conf, query_key);
+    if (query != NULL) {
+        if (ConfValIsTrue(query)) {
+            dnslog_ctx->flags |= LOG_QUERIES;
+        } else {
+            dnslog_ctx->flags &= ~LOG_QUERIES;
+        }
+    } else {
+        if (dnslog_ctx->version == DNS_VERSION_2) {
+            dnslog_ctx->flags |= LOG_QUERIES;
+        }
+    }
+
+    const char *response = ConfNodeLookupChildValue(conf, answer_key);
+    if (response != NULL) {
+        if (ConfValIsTrue(response)) {
+            dnslog_ctx->flags |= LOG_ANSWERS;
+        } else {
+            dnslog_ctx->flags &= ~LOG_ANSWERS;
+        }
+    } else {
+        if (dnslog_ctx->version == DNS_VERSION_2) {
+            dnslog_ctx->flags |= LOG_ANSWERS;
+        }
+    }
+
+    ConfNode *custom;
+    if ((custom = ConfNodeLookupChild(conf, answer_types_key)) != NULL) {
+        dnslog_ctx->flags &= ~LOG_ALL_RRTYPES;
+        ConfNode *field;
+        TAILQ_FOREACH(field, &custom->head, next)
+        {
+            if (field != NULL)
+            {
+                DnsRRTypes f;
+                for (f = DNS_RRTYPE_A; f < DNS_RRTYPE_MAX; f++)
+                {
+                    if (strcasecmp(dns_rrtype_fields[f].config_rrtype,
+                                   field->val) == 0)
+                    {
+                        dnslog_ctx->flags |= dns_rrtype_fields[f].flags;
+                        break;
+                    }
+                }
+            }
+        }
+    } else {
+        if (dnslog_ctx->version == DNS_VERSION_2) {
+            dnslog_ctx->flags |= LOG_ALL_RRTYPES;
+        }
+    }
+}
+
 static void JsonDnsLogInitFilters(LogDnsFileCtx *dnslog_ctx, ConfNode *conf)
 {
     dnslog_ctx->flags = ~0UL;
 
     if (conf) {
-        const char *query = ConfNodeLookupChildValue(conf, "query");
-        if (query != NULL) {
-            if (ConfValIsTrue(query)) {
-                dnslog_ctx->flags |= LOG_QUERIES;
-            } else {
-                dnslog_ctx->flags &= ~LOG_QUERIES;
+        intmax_t version;
+        int ret = ConfGetChildValueInt(conf, "version", &version);
+        if (ret) {
+            switch(version) {
+                case 1:
+                    dnslog_ctx->version = DNS_VERSION_1;
+                    break;
+                case 2:
+                    dnslog_ctx->version = DNS_VERSION_2;
+                    break;
+                default:
+                    SCLogWarning(SC_ERR_INVALID_ARGUMENT,
+                                 "Invalid version option: %ji, "
+                                 "forcing it to version 1", version);
+                    dnslog_ctx->version = DNS_VERSION_1;
+                    break;
             }
+        } else {
+            SCLogWarning(SC_ERR_INVALID_ARGUMENT,
+                         "Version not found, forcing it to version 1");
+            dnslog_ctx->version = DNS_VERSION_1;
         }
-        const char *response = ConfNodeLookupChildValue(conf, "answer");
-        if (response != NULL) {
-            if (ConfValIsTrue(response)) {
-                dnslog_ctx->flags |= LOG_ANSWERS;
-            } else {
-                dnslog_ctx->flags &= ~LOG_ANSWERS;
-            }
-        }
-        ConfNode *custom;
-        if ((custom = ConfNodeLookupChild(conf, "custom")) != NULL) {
-            dnslog_ctx->flags &= ~LOG_ALL_RRTYPES;
-            ConfNode *field;
-            TAILQ_FOREACH(field, &custom->head, next)
-            {
-                if (field != NULL)
-                {
-                    DnsRRTypes f;
-                    for (f = DNS_RRTYPE_A; f < DNS_RRTYPE_MAX; f++)
-                    {
-                        if (strcasecmp(dns_rrtype_fields[f].config_rrtype,
-                                       field->val) == 0)
-                        {
-                            dnslog_ctx->flags |= dns_rrtype_fields[f].flags;
-                            break;
-                        }
-                    }
-                }
-            }
+
+        if (dnslog_ctx->version == DNS_VERSION_1) {
+            JsonDnsLogParseConfig(dnslog_ctx, conf, "query", "answer", "custom");
+        } else {
+            JsonDnsLogParseConfig(dnslog_ctx, conf, "requests", "responses", "types");
         }
     }
 }
 
 static OutputCtx *JsonDnsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
+    const char *enabled = ConfNodeLookupChildValue(conf, "enabled");
+    if (enabled != NULL && !ConfValIsTrue(enabled)) {
+        return NULL;
+    }
+
     OutputJsonCtx *ojc = parent_ctx->data;
 
     LogDnsFileCtx *dnslog_ctx = SCMalloc(sizeof(LogDnsFileCtx));
@@ -889,6 +948,11 @@ static OutputCtx *JsonDnsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
  * */
 static OutputCtx *JsonDnsLogInitCtx(ConfNode *conf)
 {
+    const char *enabled = ConfNodeLookupChildValue(conf, "enabled");
+    if (enabled != NULL && !ConfValIsTrue(enabled)) {
+        return NULL;
+    }
+
     LogFileCtx *file_ctx = LogFileNewCtx();
 
     if(file_ctx == NULL) {

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -437,6 +437,23 @@ static json_t *OutputQuery(DNSTransaction *tx, uint64_t tx_id, DNSQueryEntry *en
     return djs;
 }
 
+json_t *JsonDNSLogQuery(DNSTransaction *tx, uint64_t tx_id)
+{
+    DNSQueryEntry *entry = NULL;
+    json_t *queryjs = json_array();
+    if (queryjs == NULL)
+        return NULL;
+
+    TAILQ_FOREACH(entry, &tx->query_list, next) {
+        json_t *qjs = OutputQuery(tx, tx_id, entry);
+        if (qjs != NULL) {
+            json_array_append_new(queryjs, qjs);
+        }
+    }
+
+    return queryjs;
+}
+
 static void LogQuery(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx,
         uint64_t tx_id, DNSQueryEntry *entry)
 {
@@ -796,16 +813,20 @@ static void OutputAnswerV1(LogDnsLogThread *aft, json_t *djs,
     return;
 }
 
-static void OutputAnswerV2(LogDnsLogThread *aft, json_t *djs,
-        DNSTransaction *tx, DNSAnswerEntry *entry)
+static json_t *BuildAnswer(DNSTransaction *tx, DNSAnswerEntry *entry,
+                           uint64_t tx_id, uint64_t flags,
+                           DnsVersion version)
 {
-    if (!DNSRRTypeEnabled(entry->type, aft->dnslog_ctx->flags)) {
-        return;
-    }
-
     json_t *js = json_object();
     if (js == NULL)
-        return;
+        return NULL;
+
+    /* version */
+    if (version == DNS_VERSION_2) {
+        json_object_set_new(js, "version", json_integer(DNS_VERSION_2));
+    } else {
+        json_object_set_new(js, "version", json_integer(DNS_VERSION_1));
+    }
 
     /* type */
     json_object_set_new(js, "type", json_string("answer"));
@@ -813,32 +834,73 @@ static void OutputAnswerV2(LogDnsLogThread *aft, json_t *djs,
     /* id */
     json_object_set_new(js, "id", json_integer(tx->tx_id));
 
+    /* flags */
+    char dns_flags[7] = "";
+    snprintf(dns_flags, sizeof(dns_flags), "%4x", tx->flags);
+    json_object_set_new(js, "flags", json_string(dns_flags));
+    if (tx->flags & 0x8000)
+        json_object_set_new(js, "qr", json_true());
+    if (tx->flags & 0x0400)
+        json_object_set_new(js, "aa", json_true());
+    if (tx->flags & 0x0200)
+        json_object_set_new(js, "tc", json_true());
+    if (tx->flags & 0x0100)
+        json_object_set_new(js, "rd", json_true());
+    if (tx->flags & 0x0080)
+        json_object_set_new(js, "ra", json_true());
+
     /* rcode */
     char rcode[16] = "";
     DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));
     json_object_set_new(js, "rcode", json_string(rcode));
 
-    if (aft->dnslog_ctx->flags & LOG_FORMAT_DETAILED) {
+    if (flags & LOG_FORMAT_DETAILED) {
         json_t *jarray = json_array();
-        if (jarray == NULL)
-            return;
+        if (jarray == NULL) {
+            json_decref(js);
+            return NULL;
+        }
 
         OutputAnswerDetailed(entry, jarray);
         json_object_set_new(js, "answers", jarray);
     }
 
-    if (aft->dnslog_ctx->flags & LOG_FORMAT_GROUPED) {
+    if (flags & LOG_FORMAT_GROUPED) {
         OutputAnswerGrouped(entry, js);
     }
 
-    /* reset */
-    MemBufferReset(aft->buffer);
-    json_object_set_new(djs, "dns", js);
-    OutputJSONBuffer(djs, aft->dnslog_ctx->file_ctx, &aft->buffer);
-    json_object_del(djs, "dns");
-
-    return;
+    return js;
 }
+
+static void OutputAnswerV2(LogDnsLogThread *aft, json_t *djs,
+        DNSTransaction *tx, DNSAnswerEntry *entry)
+{
+    if (!DNSRRTypeEnabled(entry->type, aft->dnslog_ctx->flags)) {
+        return;
+    }
+
+    json_t *dnsjs = BuildAnswer(tx, entry, tx->tx_id, aft->dnslog_ctx->flags,
+                                aft->dnslog_ctx->version);
+    if (dnsjs != NULL) {
+        /* reset */
+        MemBufferReset(aft->buffer);
+        json_object_set_new(djs, "dns", dnsjs);
+        OutputJSONBuffer(djs, aft->dnslog_ctx->file_ctx, &aft->buffer);
+    }
+}
+
+json_t *JsonDNSLogAnswer(DNSTransaction *tx, uint64_t tx_id)
+{
+    DNSAnswerEntry *entry = TAILQ_FIRST(&tx->answer_list);
+    json_t *js = NULL;
+
+    if (entry) {
+        js = BuildAnswer(tx, entry, tx_id, LOG_FORMAT_DETAILED, DNS_VERSION_2);
+    }
+
+    return js;
+}
+
 #endif
 
 #ifndef HAVE_RUST

--- a/src/output-json-dns.h
+++ b/src/output-json-dns.h
@@ -26,4 +26,11 @@
 
 void JsonDnsLogRegister(void);
 
+#ifdef HAVE_LIBJANSSON
+#include "app-layer-dns-common.h"
+
+json_t *JsonDNSLogQuery(DNSTransaction *tx, uint64_t tx_id) __attribute__((nonnull));
+json_t *JsonDNSLogAnswer(DNSTransaction *tx, uint64_t tx_id) __attribute__((nonnull));
+#endif
+
 #endif /* __OUTPUT_JSON_DNS_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -200,13 +200,35 @@ outputs:
             # the example below adds three additional fields when uncommented
             #custom: [Accept-Encoding, Accept-Language, Authorization]
         - dns:
-            # control logging of queries and answers
-            # default yes, no to disable
-            query: yes     # enable logging of DNS queries
-            answer: yes    # enable logging of DNS answers
-            # control which RR types are logged
-            # all enabled if custom not specified
-            #custom: [a, aaaa, cname, mx, ns, ptr, txt]
+            # This configuration uses the new DNS logging format,
+            # the old configuration is still available:
+            # http://suricata.readthedocs.io/en/latest/configuration/suricata-yaml.html#eve-extensible-event-format
+            # Use version 2 logging with the new format:
+            # dns answers will be logged in one single event
+            # rather than an event for each of it.
+            # Without setting a version the version
+            # will fallback to 1 for backwards compatibility.
+            version: 2
+
+            # Enable/disable this logger. Default: enabled.
+            #enabled: no
+
+            # Control logging of requests and responses:
+            # - requests: enable logging of DNS queries
+            # - responses: enable logging of DNS answers
+            # By default both requests and responses are logged.
+            #requests: no
+            #responses: no
+
+            # Format of answer logging:
+            # - detailed: array item per answer
+            # - grouped: answers aggregated by type
+            # Default: all
+            #formats: [detailed, grouped]
+
+            # Answer types to log.
+            # Default: all
+            #types: [a, aaaa, cname, mx, ns, ptr, txt]
         - tls:
             extended: yes     # enable this for extended logging information
             # output TLS transaction where the session is resumed using a


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2199
https://redmine.openinfosecfoundation.org/issues/1198
https://redmine.openinfosecfoundation.org/issues/2086

Previous PR: #3075 

Describe changes:
- Rebased on master: a dns event now contains the flags fields 
- Update doc
- Add `version` field in a dns event
- Rename fields in dns configuration:
  - `answer-types` with `types`
  - `answer-format` with `format`

Example of a dns event with `version` field:
```
  "dns": {
    "version": 2,
    "type": "answer",
    "id": 53410,
    "flags": "8180",
    "qr": true,
    "rd": true,
    "ra": true,
    "rcode": "NOERROR",
    "grouped": {
      "A": [
        "64.170.98.42",
        "4.31.198.62",
        "4.31.198.61"
      ]
    }
  }
```

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/163
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/27


