### PR TITLE
SMTP logging and detection improvement v2

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -366,10 +366,10 @@ integration with 3rd party tools like logstash.
             #  x-originating-ip, in-reply-to, references, importance, priority,
             #  sensitivity, organization, content-md5, date
             #custom: [received, x-mailer, x-originating-ip, relays, reply-to, bcc]
-            # output md5 of fields: body, subject
+            # output md5 of fields: body, subject, attachments
             # for the body you need to set app-layer.protocols.smtp.mime.body-md5
             # to yes
-            #md5: [body, subject]
+            #md5: [body, subject, attachments]
 
         - ssh
         - stats:

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -232,10 +232,10 @@ outputs:
             #  x-originating-ip, in-reply-to, references, importance, priority,
             #  sensitivity, organization, content-md5, date
             #custom: [received, x-mailer, x-originating-ip, relays, reply-to, bcc]
-            # output md5 of fields: body, subject
+            # output md5 of fields: body, subject, attachments
             # for the body you need to set app-layer.protocols.smtp.mime.body-md5
             # to yes
-            #md5: [body, subject]
+            #md5: [body, subject, attachments]
 
         #- dnp3
         @rust_config_comment@- nfs


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2388
https://redmine.openinfosecfoundation.org/issues/2387

Describe changes:
This patchset permits to log the md5 hash of attachments in smtp events and also extends probing parser to detect smtp protocol.

Example:
```
{
  "timestamp": "2009-10-05T08:06:12.200179+0200",
  "flow_id": 1461377869746838,
  "pcap_cnt": 48,
  "event_type": "smtp",
  "src_ip": "10.10.1.4",
  "src_port": 1470,
  "dest_ip": "74.53.140.153",
  "dest_port": 25,
  "proto": "TCP",
  "tx_id": 0,
  "smtp": {
    "helo": "GP",
    "mail_from": "<gurpartap@patriots.in>",
    "rcpt_to": [
      "<raj_deol2002in@yahoo.co.in>"
    ]
  },
  "email": {
    "status": "PARSE_DONE",
    "from": "\"Gurpartap Singh\" <gurpartap@patriots.in>",
    "to": [
      "<raj_deol2002in@yahoo.co.in>"
    ],
    "attachment": [
      "NEWS.txt"
    ],
    "body_md5": "8059e338b7dd1960e5f5ea18225615b9",
    "attachments_md5": [
      {
        "filename": "NEWS.txt",
        "md5": "5d968be75ab3ada2ae17c1f9db5d232b"
      }
    ]
  }
}
```

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/165
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/29
