### PR TITLE
source-pcap-file: Directory mode may miss files (bug #2394)

### DIFF
--- a/scripts/suricatasc/src/suricatasc.py
+++ b/scripts/suricatasc/src/suricatasc.py
@@ -201,13 +201,12 @@ class SuricataSC:
                 tenant = None
                 if len(parts) > 3:
                     tenant = parts[3]
-                if cmd != "pcap-file":
+                if cmd != "pcap-file-continuous":
                     raise SuricataCommandException("Invalid command '%s'" % (command))
                 else:
                     arguments = {}
                     arguments["filename"] = filename
                     arguments["output-dir"] = output
-                    arguments["continuous"] = True
                     if tenant != None:
                         arguments["tenant"] = int(tenant)
             elif "iface-stat" in command:

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -569,6 +569,7 @@ TmEcode UnixSocketPcapFile(TmEcode tm, struct timespec *last_processed)
         case TM_ECODE_OK:
             if (unix_manager_pcap_task_interrupted == 1) {
                 SCLogInfo("Interrupting current run mode");
+                unix_manager_pcap_task_interrupted = 0;
                 return TM_ECODE_DONE;
             } else {
                 return TM_ECODE_OK;
@@ -1383,6 +1384,7 @@ static int RunModeUnixSocketMaster(void)
     SCCtrlMutexInit(&unix_manager_pcap_last_processed_mutex, NULL);
 
     UnixManagerRegisterCommand("pcap-file", UnixSocketAddPcapFile, pcapcmd, UNIX_CMD_TAKE_ARGS);
+    UnixManagerRegisterCommand("pcap-file-continuous", UnixSocketAddPcapFileContinuous, pcapcmd, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("pcap-file-number", UnixSocketPcapFilesNumber, pcapcmd, 0);
     UnixManagerRegisterCommand("pcap-file-list", UnixSocketPcapFilesList, pcapcmd, 0);
     UnixManagerRegisterCommand("pcap-last-processed", UnixSocketPcapLastProcessed, pcapcmd, 0);

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -34,6 +34,7 @@
 #include "flow-timeout.h"
 #include "stream-tcp.h"
 #include "stream-tcp-reassemble.h"
+#include "source-pcap-file-directory-helper.h"
 #include "host.h"
 #include "defrag.h"
 #include "defrag-hash.h"
@@ -200,8 +201,7 @@ static TmEcode UnixSocketPcapLastProcessed(json_t *cmd, json_t *answer, void *da
 {
     json_int_t epoch_millis;
     SCCtrlMutexLock(&unix_manager_pcap_last_processed_mutex);
-    epoch_millis = unix_manager_pcap_last_processed.tv_sec * 1000L +
-                        unix_manager_pcap_last_processed.tv_nsec / 100000L;
+    epoch_millis = AsEpochMillis(&unix_manager_pcap_last_processed);
     SCCtrlMutexUnlock(&unix_manager_pcap_last_processed_mutex);
 
     json_object_set_new(answer, "message",

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -188,7 +188,7 @@ static TmEcode UnixSocketPcapCurrent(json_t *cmd, json_t* answer, void *data)
 {
     PcapCommand *this = (PcapCommand *) data;
 
-    if (this->current_file && this->current_file->filename) {
+    if (this->current_file != NULL && this->current_file->filename != NULL) {
         json_object_set_new(answer, "message",
                             json_string(this->current_file->filename));
     } else {
@@ -470,6 +470,7 @@ static TmEcode UnixSocketPcapFilesCheck(void *data)
         }
         this->current_file = NULL;
     }
+
     if (TAILQ_EMPTY(&this->files)) {
         // nothing to do
         return TM_ECODE_OK;

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -296,15 +296,14 @@ static TmEcode UnixListAddFile(
  * \param answer the json_t object that has to be used to answer
  * \param data pointer to data defining the context here a PcapCommand::
  */
-static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
+static TmEcode UnixSocketAddPcapFileImpl(json_t *cmd, json_t* answer, void *data, bool continuous)
 {
     PcapCommand *this = (PcapCommand *) data;
     const char *filename;
     const char *output_dir;
     int tenant_id = 0;
-    bool continuous = false;
-    time_t delay = 30;
-    time_t poll_interval = 5;
+    time_t delay = 2;
+    time_t poll_interval = 1;
 #ifdef OS_WIN32
     struct _stat st;
 #else
@@ -367,11 +366,6 @@ static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
         tenant_id = json_number_value(targ);
     }
 
-    json_t *cont_arg = json_object_get(cmd, "continuous");
-    if (cont_arg != NULL) {
-        continuous = json_is_true(cont_arg);
-    }
-
     json_t *delay_arg = json_object_get(cmd, "delay");
     if (delay_arg != NULL) {
         if (!json_is_integer(delay_arg)) {
@@ -409,6 +403,37 @@ static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
             return TM_ECODE_OK;
     }
     return TM_ECODE_OK;
+}
+
+/**
+ * \brief Command to add a file to treatment list
+ *
+ * \param cmd the content of command Arguments as a json_t object
+ * \param answer the json_t object that has to be used to answer
+ * \param data pointer to data defining the context here a PcapCommand::
+ */
+static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
+{
+    bool continuous = false;
+
+    json_t *cont_arg = json_object_get(cmd, "continuous");
+    if (cont_arg != NULL) {
+        continuous = json_is_true(cont_arg);
+    }
+
+    return UnixSocketAddPcapFileImpl(cmd, answer, data, continuous);
+}
+
+/**
+ * \brief Command to add a file to treatment list, forcing continuous mode
+ *
+ * \param cmd the content of command Arguments as a json_t object
+ * \param answer the json_t object that has to be used to answer
+ * \param data pointer to data defining the context here a PcapCommand::
+ */
+static TmEcode UnixSocketAddPcapFileContinuous(json_t *cmd, json_t* answer, void *data)
+{
+    return UnixSocketAddPcapFileImpl(cmd, answer, data, true);
 }
 
 /**

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -132,6 +132,7 @@ static int unix_manager_pcap_task_running = 0;
 static int unix_manager_pcap_task_failed = 0;
 static int unix_manager_pcap_task_interrupted = 0;
 static struct timespec unix_manager_pcap_last_processed;
+static SCCtrlMutex unix_manager_pcap_last_processed_mutex;
 
 /**
  * \brief return list of files in the queue
@@ -197,8 +198,12 @@ static TmEcode UnixSocketPcapCurrent(json_t *cmd, json_t* answer, void *data)
 
 static TmEcode UnixSocketPcapLastProcessed(json_t *cmd, json_t *answer, void *data)
 {
-    uint64_t epoch_millis = unix_manager_pcap_last_processed.tv_sec * 1000l +
-                        unix_manager_pcap_last_processed.tv_nsec / 100000l;
+    json_int_t epoch_millis;
+    SCCtrlMutexLock(&unix_manager_pcap_last_processed_mutex);
+    epoch_millis = unix_manager_pcap_last_processed.tv_sec * 1000L +
+                        unix_manager_pcap_last_processed.tv_nsec / 100000L;
+    SCCtrlMutexUnlock(&unix_manager_pcap_last_processed_mutex);
+
     json_object_set_new(answer, "message",
                         json_integer(epoch_millis));
 
@@ -546,8 +551,10 @@ void RunModeUnixSocketRegister(void)
 TmEcode UnixSocketPcapFile(TmEcode tm, struct timespec *last_processed)
 {
 #ifdef BUILD_UNIX_SOCKET
+    SCCtrlMutexLock(&unix_manager_pcap_last_processed_mutex);
     unix_manager_pcap_last_processed.tv_sec = last_processed->tv_sec;
     unix_manager_pcap_last_processed.tv_nsec = last_processed->tv_nsec;
+    SCCtrlMutexUnlock(&unix_manager_pcap_last_processed_mutex);
     switch (tm) {
         case TM_ECODE_DONE:
             SCLogInfo("Marking current task as done");
@@ -1370,6 +1377,10 @@ static int RunModeUnixSocketMaster(void)
     TAILQ_INIT(&pcapcmd->files);
     pcapcmd->running = 0;
     pcapcmd->current_file = NULL;
+
+    memset(&unix_manager_pcap_last_processed, 0, sizeof(struct timespec));
+
+    SCCtrlMutexInit(&unix_manager_pcap_last_processed_mutex, NULL);
 
     UnixManagerRegisterCommand("pcap-file", UnixSocketAddPcapFile, pcapcmd, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("pcap-file-number", UnixSocketPcapFilesNumber, pcapcmd, 0);

--- a/src/source-pcap-file-directory-helper.c
+++ b/src/source-pcap-file-directory-helper.c
@@ -26,7 +26,6 @@
 #include "source-pcap-file-directory-helper.h"
 #include "runmode-unix-socket.h"
 #include "util-mem.h"
-#include "flow-manager.h"
 
 static void GetTime(struct timespec *tm);
 static void CopyTime(struct timespec *from, struct timespec *to);

--- a/src/source-pcap-file-directory-helper.c
+++ b/src/source-pcap-file-directory-helper.c
@@ -26,6 +26,7 @@
 #include "source-pcap-file-directory-helper.h"
 #include "runmode-unix-socket.h"
 #include "util-mem.h"
+#include "flow-manager.h"
 
 static void GetTime(struct timespec *tm);
 static void CopyTime(struct timespec *from, struct timespec *to);

--- a/src/source-pcap-file-directory-helper.h
+++ b/src/source-pcap-file-directory-helper.h
@@ -31,6 +31,7 @@
 typedef struct PendingFile_
 {
     char *filename;
+    struct timespec modified_time;
     TAILQ_ENTRY(PendingFile_) next;
 } PendingFile;
 /**

--- a/src/source-pcap-file-directory-helper.h
+++ b/src/source-pcap-file-directory-helper.h
@@ -52,6 +52,13 @@ typedef struct PcapFileDirectoryVars_
 } PcapFileDirectoryVars;
 
 /**
+ * Convert a timespec into milliseconds since epoch
+ * @param timespec
+ * @return time
+ */
+long AsEpochMillis(struct timespec *tm);
+
+/**
  * Cleanup resources associated with a PendingFile object
  * @param pending Object to be cleaned up
  */

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -205,6 +205,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
     if (unlikely(ptv == NULL))
         SCReturnInt(TM_ECODE_FAILED);
     memset(ptv, 0, sizeof(PcapFileThreadVars));
+    memset(&ptv->shared.last_processed, 0, sizeof(struct timespec));
 
     intmax_t tenant = 0;
     if (ConfGetInt("pcap-file.tenant-id", &tenant) == 1) {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2297,8 +2297,10 @@ void PostRunDeinit(const int runmode, struct timeval *start_time)
     FlowDisableFlowRecyclerThread();
 
     /* kill the stats threads */
-    TmThreadKillThreadsFamily(TVT_MGMT);
-    TmThreadClearThreadsFamily(TVT_MGMT);
+    if (!RunModeUnixSocketIsActive()) {
+        TmThreadKillThreadsFamily(TVT_MGMT);
+        TmThreadClearThreadsFamily(TVT_MGMT);
+    }
 
     /* kill packet threads -- already in 'disabled' state */
     TmThreadKillThreadsFamily(TVT_PPT);
@@ -2315,6 +2317,7 @@ void PostRunDeinit(const int runmode, struct timeval *start_time)
     HostCleanup();
     StreamTcpFreeConfig(STREAM_VERBOSE);
     DefragDestroy();
+
     TmqResetQueues();
 #ifdef PROFILING
     if (profiling_rules_enabled)

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -62,6 +62,7 @@ int SCTimeToStringPattern (time_t epoch, const char *pattern, char *str,
                            size_t size);
 uint64_t SCParseTimeSizeString (const char *str);
 uint64_t SCGetSecondsUntil (const char *str, time_t epoch);
+uint64_t SCTimespecAsEpochMillis(const struct timespec *ts);
 
 #endif /* __UTIL_TIME_H__ */
 


### PR DESCRIPTION
https://redmine.openinfosecfoundation.org/issues/2394

Certain parameters of delay and poll interval could cause newly added
files in a directory to be missed. Cleaned up how time is handled for
files in a directory and fix which time is used for future directory
traversals. Add a mutex to make sure processing time is not optimized
away.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Make sure correct time is used when setting processing time
- Only update processing time of unix socket when all files are processed
- Make sure processing time updates are not optimized away via mutex

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

