### PR TITLE
detect-ftpdata: register keyword

### DIFF
--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -176,6 +176,7 @@
 #include "detect-target.h"
 #include "detect-template-buffer.h"
 #include "detect-bypass.h"
+#include "detect-ftpdata.h"
 #include "detect-engine-content-inspection.h"
 
 #include "util-rule-vars.h"
@@ -421,6 +422,7 @@ void SigTableSetup(void)
     DetectWindowRegister();
     DetectRpcRegister();
     DetectFtpbounceRegister();
+    DetectFtpdataRegister();
     DetectIsdataatRegister();
     DetectIdRegister();
     DetectDsizeRegister();


### PR DESCRIPTION
Keyword registration was missing so the keyword was not existing.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Register the keyword

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/362
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/145
