### PR TITLE
runmodes: fix single runmode bug with pcap

### DIFF
--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -422,8 +422,8 @@ int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc ConfigParser,
         aconf = ConfigParser(live_dev);
         live_dev_c = live_dev;
     } else {
-        aconf = ConfigParser(live_dev_c);
         live_dev_c = LiveGetDeviceName(0);
+        aconf = ConfigParser(live_dev_c);
     }
 
     return RunModeSetLiveCaptureWorkersForDevice(


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Ticket: https://redmine.openinfosecfoundation.org/issues/2403

Describe changes:
- switch configuration parsing and live device name fetching when suricata runs with --pcap option and single runmode.
-
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

