### PR TITLE
app-layer: use FILE_HAS_GAPS flag in http & smtp

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2714,7 +2714,7 @@ static void HTPStateTruncate(void *state, uint8_t direction)
 {
     FileContainer *fc = HTPStateGetFiles(state, direction);
     if (fc != NULL) {
-        FileTruncateAllOpenFiles(fc);
+        FileTruncateAllOpenFiles(fc, direction);
     }
 }
 

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1606,7 +1606,7 @@ static void SMTPStateTruncate(void *state, uint8_t direction)
     if (fc != NULL) {
         SCLogDebug("truncating stream, closing files in %s direction (container %p)",
                 direction & STREAM_TOCLIENT ? "STREAM_TOCLIENT" : "STREAM_TOSERVER", fc);
-        FileTruncateAllOpenFiles(fc);
+        FileTruncateAllOpenFiles(fc, direction);
     }
 }
 

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -873,9 +873,6 @@ static int FileCloseFilePtr(File *ff, const uint8_t *data,
     }
 
     if ((flags & FILE_TRUNCATED) || (ff->flags & FILE_HAS_GAPS)) {
-        ff->state = FILE_STATE_TRUNCATED;
-        SCLogDebug("flowfile state transitioned to FILE_STATE_TRUNCATED");
-
         if (flags & FILE_NOSTORE) {
             SCLogDebug("not storing this file");
             ff->flags |= FILE_NOSTORE;
@@ -1271,7 +1268,7 @@ void FileStoreAllFiles(FileContainer *fc)
     }
 }
 
-void FileTruncateAllOpenFiles(FileContainer *fc)
+void FileTruncateAllOpenFiles(FileContainer *fc, uint8_t flags)
 {
     File *ptr = NULL;
 
@@ -1281,6 +1278,9 @@ void FileTruncateAllOpenFiles(FileContainer *fc)
         for (ptr = fc->head; ptr != NULL; ptr = ptr->next) {
             if (ptr->state == FILE_STATE_OPENED) {
                 FileCloseFilePtr(ptr, NULL, 0, FILE_TRUNCATED);
+            }
+            if (flags & STREAM_GAP) {
+                ptr->flags |= FILE_HAS_GAPS;
             }
         }
     }

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -228,7 +228,7 @@ void FileStoreAllFiles(FileContainer *);
 void FileStoreAllFilesForTx(FileContainer *, uint64_t);
 void FileStoreFileById(FileContainer *fc, uint32_t);
 
-void FileTruncateAllOpenFiles(FileContainer *);
+void FileTruncateAllOpenFiles(FileContainer *, uint8_t);
 
 uint64_t FileDataSize(const File *file);
 uint64_t FileTrackedSize(const File *file);


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- add parameter flags to FileTruncateAllOpenFiles
- check flags parameter in FileTruncateAllOpenFiles, setting FILE_HAS_GAPS if STREAM_GAP is in flags
- Remove file state set to FILE_STATE_TRUNCATED from FileCloseFilePtr

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

