### PR TITLE
NTP: update logger to use new API

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -37,12 +37,4 @@ impl LoggerFlags {
         self.flags = bits;
     }
 
-    pub fn set_logged(&mut self, logger: u32) {
-        self.flags |= logger;
-    }
-
-    pub fn is_logged(&self, logger: u32) -> bool {
-        self.flags & logger != 0
-    }
-
 }

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -268,21 +268,17 @@ pub extern "C" fn rs_ntp_tx_get_alstate_progress(_tx: *mut libc::c_void,
 #[no_mangle]
 pub extern "C" fn rs_ntp_tx_set_logged(_state: &mut NTPState,
                                        tx: &mut NTPTransaction,
-                                       logger: libc::uint32_t)
+                                       logged: libc::uint32_t)
 {
-    tx.logged.set_logged(logger);
+    tx.logged.set(logged);
 }
 
 #[no_mangle]
 pub extern "C" fn rs_ntp_tx_get_logged(_state: &mut NTPState,
-                                       tx: &mut NTPTransaction,
-                                       logger: libc::uint32_t)
-                                       -> i8
+                                       tx: &mut NTPTransaction)
+                                       -> u32
 {
-    if tx.logged.is_logged(logger) {
-        return 1;
-    }
-    return 0;
+    return tx.logged.get();
 }
 
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
Not applicable

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Commit bca0cd71ae1f9fec3ddaecceb9078ea738ddce15 changed the logger API, but the NTP parser was not updated to use the new API
- Update the NTP parser
- Additionally, one question: should we mark the (rust) functions `get_logged / set_logged` as deprecated ? There is a `#[deprecated]` function attribute if required. Or, since there are not so much code based on it, the functions could be removed.

