### PR TITLE
time: force init cached_minute_start array

### DIFF
--- a/src/util-time.c
+++ b/src/util-time.c
@@ -301,19 +301,24 @@ struct tm *SCLocalTime(time_t timep, struct tm *result)
     int mru_seconds = timep - cached_minute_start[mru];
     int lru_seconds = timep - cached_minute_start[lru];
     int new_seconds;
-    if (mru_seconds >= 0 && mru_seconds <= 59) {
+    if (cached_minute_start[mru]==0 && cached_minute_start[lru]==0) {
+        localtime_r(&timep, &cached_local_tm[lru]);
+        /* Subtract seconds to get back to the start of the minute. */
+        new_seconds = cached_local_tm[lru].tm_sec;
+        cached_minute_start[lru] = timep - new_seconds;
+        mru = lru;
+        mru_tm_slot = mru;
+    } else if (lru_seconds > 0 && (mru_seconds >= 0 && mru_seconds <= 59)) {
         /* Use most-recently cached time, adjusting the seconds. */
         new_seconds = mru_seconds;
-    } else if (lru_seconds >= 0 && lru_seconds <= 59) {
+    } else if (mru_seconds > 0 && (lru_seconds >= 0 && lru_seconds <= 59)) {
         /* Use least-recently cached time, update to most recently used. */
         new_seconds = lru_seconds;
         mru = lru;
         mru_tm_slot = mru;
     } else {
         /* Update least-recent cached time. */
-        if (localtime_r(&timep, &cached_local_tm[lru]) == NULL)
-            return NULL;
-
+        localtime_r(&timep, &cached_local_tm[lru]);
         /* Subtract seconds to get back to the start of the minute. */
         new_seconds = cached_local_tm[lru].tm_sec;
         cached_minute_start[lru] = timep - new_seconds;
@@ -360,7 +365,11 @@ void CreateTimeString (const struct timeval *ts, char *str, size_t size)
     int lru = 1 - mru;
     int mru_seconds = time - last_local_time[mru];
     int lru_seconds = time - last_local_time[lru];
-    if (mru_seconds >= 0 && mru_seconds <= 59) {
+    if (last_local_time[mru]==0 && last_local_time[lru]==0) {
+        /* First time here, update both caches */
+        seconds = UpdateCachedTime(mru, time);
+        seconds = UpdateCachedTime(lru, time);
+    } else if (mru_seconds >= 0 && mru_seconds <= 59) {
         /* Use most-recently cached time. */
         seconds = mru_seconds;
     } else if (lru_seconds >= 0 && lru_seconds <= 59) {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- force initialization of cached_minute_array
- remove check localtime_r == NULL
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

