### PR TITLE
print: Escape backslash in PrintRawUriFp

### DIFF
--- a/src/util-print.c
+++ b/src/util-print.c
@@ -99,8 +99,13 @@ void PrintRawUriFp(FILE *fp, uint8_t *buf, uint32_t buflen)
 
     for (u = 0; u < buflen; u++) {
         if (isprint(buf[u]) && buf[u] != '\"') {
-            PrintBufferData(nbuf, &offset, BUFFER_LENGTH,
-                             "%c", buf[u]);
+            if (buf[u] == '\\') {
+                PrintBufferData(nbuf, &offset, BUFFER_LENGTH,
+                                "\\\\");
+            } else {
+                PrintBufferData(nbuf, &offset, BUFFER_LENGTH,
+                                "%c", buf[u]);
+            }
         } else {
             PrintBufferData(nbuf, &offset, BUFFER_LENGTH,
                             "\\x%02X", buf[u]);


### PR DESCRIPTION
PrintRawUriFp does not properly escape backslash. This causes confusion
between a \ character and an hex-encoded character. PrintRawUriBuffer,
instead, correctly does backslash-encoding.
Adding proper escaping of backslash to PrintRawUriFp.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2408

Describe changes:
- Add backslash escaping to PrintRawUriFp
-
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

