### PR TITLE
counter: Implement reset ability for counters

### DIFF
--- a/src/counters.h
+++ b/src/counters.h
@@ -29,10 +29,22 @@
 struct ThreadVars_;
 
 /**
+ * \brief These are modifiers that, regardless of the counter type,
+ *        change the behavior of the counter or the way it is written in the
+ *        output.
+ */
+enum {
+    STATS_FLAGS_RESETTING = 0x001,      // reset at every output
+};
+
+/**
  * \brief Container to hold the counter variable
  */
 typedef struct StatsCounter_ {
     int type;
+
+    /* LL: modifier flags for the counter type */
+    uint32_t flags;
 
     /* local id for this counter in this thread */
     uint16_t id;
@@ -43,6 +55,9 @@ typedef struct StatsCounter_ {
     /* counter value(s): copies from the 'private' counter */
     uint64_t value;     /**< sum of updates/increments, or 'set' value */
     uint64_t updates;   /**< number of updates (for avg) */
+
+    /* need backsync */
+    uint8_t backsync;
 
     /* when using type STATS_TYPE_Q_FUNC this function is called once
      * to get the counter value, regardless of how many threads there are. */
@@ -118,10 +133,13 @@ uint16_t StatsRegisterAvgCounter(const char *, struct ThreadVars_ *);
 uint16_t StatsRegisterMaxCounter(const char *, struct ThreadVars_ *);
 uint16_t StatsRegisterGlobalCounter(const char *cname, uint64_t (*Func)(void));
 
+void StatsSetFlags(struct ThreadVars_ *, uint16_t, uint32_t);
+
 /* functions used to update local counter values */
 void StatsAddUI64(struct ThreadVars_ *, uint16_t, uint64_t);
 void StatsSetUI64(struct ThreadVars_ *, uint16_t, uint64_t);
 void StatsIncr(struct ThreadVars_ *, uint16_t);
+void StatsReset(struct ThreadVars_ *, uint16_t);
 
 /* utility functions */
 int StatsUpdateCounterArray(StatsPrivateThreadContext *, StatsPublicThreadContext *);

--- a/src/log-stats.c
+++ b/src/log-stats.c
@@ -92,9 +92,10 @@ static int LogStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *s
     MemBufferWriteString(aft->buffer, "----------------------------------------------"
             "--------------------------------------\n");
     MemBufferWriteString(aft->buffer, "Date: %" PRId32 "/%" PRId32 "/%04d -- "
-            "%02d:%02d:%02d (uptime: %"PRId32"d, %02dh %02dm %02ds)\n",
+            "%02d:%02d:%02d (uptime: %"PRId32"d, %02dh %02dm %02ds) "
+            "Timestamp %"PRIu64"\n",
             tms->tm_mon + 1, tms->tm_mday, tms->tm_year + 1900, tms->tm_hour,
-            tms->tm_min, tms->tm_sec, days, hours, min, sec);
+            tms->tm_min, tms->tm_sec, days, hours, min, sec, tval.tv_sec);
     MemBufferWriteString(aft->buffer, "----------------------------------------------"
             "--------------------------------------\n");
     MemBufferWriteString(aft->buffer, "%-42s | %-25s | %-s\n", "Counter", "TM Name",


### PR DESCRIPTION
This feature adds the ability to reset the value of a counter. This
feature is controlled by the flag STATS_FLAGS_RESETTING. This flag will
trigger a reset (via function StatsReset) of the value of the counter
at the end of function StatsOutput and StatsOutputCounterSocket.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2410

Describe changes:
- Add StatsReset function that gets triggered if counter has flag STATS_FLAGS_RESETTING
- Add StatsSetFlags to add flags to a counter (for now, only STATS_FLAGS_RESETTING flag is present)
- Add timestamp to stats.log

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

