### PR TITLE
util-time: Add function to convert timespec to epoch millis

### DIFF
--- a/src/util-time.c
+++ b/src/util-time.c
@@ -593,3 +593,8 @@ uint64_t SCGetSecondsUntil (const char *str, time_t epoch)
 
     return seconds;
 }
+
+uint64_t SCTimespecAsEpochMillis(const struct timespec* ts)
+{
+    return ts->tv_sec * 1000L + ts->tv_nsec / 1000000L;
+}

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -62,6 +62,6 @@ int SCTimeToStringPattern (time_t epoch, const char *pattern, char *str,
                            size_t size);
 uint64_t SCParseTimeSizeString (const char *str);
 uint64_t SCGetSecondsUntil (const char *str, time_t epoch);
-
+uint64_t SCTimespecAsEpochMillis(const struct timespec *ts);
 #endif /* __UTIL_TIME_H__ */
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
Utility for https://redmine.openinfosecfoundation.org/issues/2394
Describe changes:
- Add method to convert a timespec to epoch millis

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

