### PR TITLE
NTP: ensure parser name is not freed after registration

### DIFF
--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -381,12 +381,13 @@ pub extern "C" fn ntp_probing_parser(_flow: *const Flow, input:*const u8, input_
     }
 }
 
+const PARSER_NAME : &'static [u8] = b"ntp\0";
+
 #[no_mangle]
 pub unsafe extern "C" fn rs_register_ntp_parser() {
-    let name = CString::new("ntp").unwrap();
     let default_port = CString::new("123").unwrap();
     let parser = RustParser {
-        name              : name.as_ptr(),
+        name              : PARSER_NAME.as_ptr() as *const libc::c_char,
         default_port      : default_port.as_ptr(),
         ipproto           : libc::IPPROTO_UDP,
         probe_ts          : ntp_probing_parser,


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
not applicable

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
[2414](https://redmine.openinfosecfoundation.org/issues/2414)

Describe changes:
- The parser name allocated in `rs_register_ntp_parser` is passed to the C layer to register the parser, which stores the pointer.
However, if a CString is allocated for that, it is freed at function exit.
- Ensure parser name is not freed after registration
