### PR TITLE
suricatasc: pcap-file-continuous (2412)

### DIFF
--- a/scripts/suricatasc/src/suricatasc.py
+++ b/scripts/suricatasc/src/suricatasc.py
@@ -177,13 +177,16 @@ class SuricataSC:
         if command.split(' ', 2)[0] in self.cmd_list:
             if "pcap-file " in command:
                 try:
-                    parts = command.split(' ');
+                    parts = command.split(' ')
                 except:
                     raise SuricataCommandException("Arguments to command '%s' is missing" % (command))
                 cmd, filename, output = parts[0], parts[1], parts[2]
                 tenant = None
                 if len(parts) > 3:
                     tenant = parts[3]
+                continuous = None
+                if len(parts) > 4:
+                    continuous = parts[4]
                 if cmd != "pcap-file":
                     raise SuricataCommandException("Invalid command '%s'" % (command))
                 else:
@@ -192,22 +195,23 @@ class SuricataSC:
                     arguments["output-dir"] = output
                     if tenant != None:
                         arguments["tenant"] = int(tenant)
+                    if continuous != None:
+                        arguments["continuous"] = continuous
             elif "pcap-file-continuous " in command:
                 try:
-                    parts = command.split(' ');
+                    parts = command.split(' ')
                 except:
                     raise SuricataCommandException("Arguments to command '%s' is missing" % (command))
                 cmd, filename, output = parts[0], parts[1], parts[2]
                 tenant = None
                 if len(parts) > 3:
                     tenant = parts[3]
-                if cmd != "pcap-file":
+                if cmd != "pcap-file-continuous":
                     raise SuricataCommandException("Invalid command '%s'" % (command))
                 else:
                     arguments = {}
                     arguments["filename"] = filename
                     arguments["output-dir"] = output
-                    arguments["continuous"] = True
                     if tenant != None:
                         arguments["tenant"] = int(tenant)
             elif "iface-stat" in command:

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -290,14 +290,15 @@ static TmEcode UnixListAddFile(
  * \param cmd the content of command Arguments as a json_t object
  * \param answer the json_t object that has to be used to answer
  * \param data pointer to data defining the context here a PcapCommand::
+ * \param continuous If this should run in continuous mode
  */
-static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
+static TmEcode UnixSocketAddPcapFileImpl(json_t *cmd, json_t* answer, void *data,
+                                         bool continuous)
 {
     PcapCommand *this = (PcapCommand *) data;
     const char *filename;
     const char *output_dir;
     int tenant_id = 0;
-    bool continuous = false;
     time_t delay = 30;
     time_t poll_interval = 5;
 #ifdef OS_WIN32
@@ -362,11 +363,6 @@ static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
         tenant_id = json_number_value(targ);
     }
 
-    json_t *cont_arg = json_object_get(cmd, "continuous");
-    if (cont_arg != NULL) {
-        continuous = json_is_true(cont_arg);
-    }
-
     json_t *delay_arg = json_object_get(cmd, "delay");
     if (delay_arg != NULL) {
         if (!json_is_integer(delay_arg)) {
@@ -404,6 +400,37 @@ static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
             return TM_ECODE_OK;
     }
     return TM_ECODE_OK;
+}
+
+/**
+ * \brief Command to add a file to treatment list
+ *
+ * \param cmd the content of command Arguments as a json_t object
+ * \param answer the json_t object that has to be used to answer
+ * \param data pointer to data defining the context here a PcapCommand::
+ */
+static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
+{
+    bool continuous = false;
+
+    json_t *cont_arg = json_object_get(cmd, "continuous");
+    if (cont_arg != NULL) {
+        continuous = json_is_true(cont_arg);
+    }
+
+    UnixSocketAddPcapFileImpl(cmd, answer, data, continuous);
+}
+
+/**
+ * \brief Command to add a file to treatment list
+ *
+ * \param cmd the content of command Arguments as a json_t object
+ * \param answer the json_t object that has to be used to answer
+ * \param data pointer to data defining the context here a PcapCommand::
+ */
+static TmEcode UnixSocketAddPcapFileContinuous(json_t *cmd, json_t* answer, void *data)
+{
+    UnixSocketAddPcapFileImpl(cmd, answer, data, true);
 }
 
 /**
@@ -1372,6 +1399,7 @@ static int RunModeUnixSocketMaster(void)
     pcapcmd->current_file = NULL;
 
     UnixManagerRegisterCommand("pcap-file", UnixSocketAddPcapFile, pcapcmd, UNIX_CMD_TAKE_ARGS);
+    UnixManagerRegisterCommand("pcap-file-continuous", UnixSocketAddPcapFileContinuous, pcapcmd, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("pcap-file-number", UnixSocketPcapFilesNumber, pcapcmd, 0);
     UnixManagerRegisterCommand("pcap-file-list", UnixSocketPcapFilesList, pcapcmd, 0);
     UnixManagerRegisterCommand("pcap-last-processed", UnixSocketPcapLastProcessed, pcapcmd, 0);

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -418,7 +418,7 @@ static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
         continuous = json_is_true(cont_arg);
     }
 
-    UnixSocketAddPcapFileImpl(cmd, answer, data, continuous);
+    return UnixSocketAddPcapFileImpl(cmd, answer, data, continuous);
 }
 
 /**
@@ -430,7 +430,7 @@ static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
  */
 static TmEcode UnixSocketAddPcapFileContinuous(json_t *cmd, json_t* answer, void *data)
 {
-    UnixSocketAddPcapFileImpl(cmd, answer, data, true);
+    return UnixSocketAddPcapFileImpl(cmd, answer, data, true);
 }
 
 /**


### PR DESCRIPTION
Suricatasc is not supporting pcap-file processing in continuous mode.
Register a new command pcap-file-continuous in the unix manager to work
with suricatasc. Add defaulted arguments for pcap-file to support
backwards compatibility.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Register pcap-file-continuous command in unix socket
- Adjust pcap-file-continuous command in suricatasc
- Add additional argument to pcap-file to pass continuous

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

https://redmine.openinfosecfoundation.org/issues/2412
