### PR TITLE
runmode-unix-socket: interrupt as commanded (2413)

### DIFF
--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -562,6 +562,7 @@ TmEcode UnixSocketPcapFile(TmEcode tm, struct timespec *last_processed)
         case TM_ECODE_OK:
             if (unix_manager_pcap_task_interrupted == 1) {
                 SCLogInfo("Interrupting current run mode");
+                unix_manager_pcap_task_interrupted = 0;
                 return TM_ECODE_DONE;
             } else {
                 return TM_ECODE_OK;


### PR DESCRIPTION
Once interrupt occurs, reset the interrupt flag so that future runs are
not immediately interrupted.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2413

Describe changes:
- Reset flag after interrupt occurs so future runs are not immediately interrupted

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):