### PR TITLE
counter: Counter reset and max_parallel_flows

### DIFF
--- a/src/counters.h
+++ b/src/counters.h
@@ -29,10 +29,22 @@
 struct ThreadVars_;
 
 /**
+ * \brief These are modifiers that, regardless of the counter type,
+ *        change the behavior of the counter or the way it is written in the
+ *        output.
+ */
+enum {
+    STATS_FLAGS_RESETTING = 0x001,      // reset at every output
+};
+
+/**
  * \brief Container to hold the counter variable
  */
 typedef struct StatsCounter_ {
     int type;
+
+    /* modifier flags for the counter type */
+    uint32_t flags;
 
     /* local id for this counter in this thread */
     uint16_t id;
@@ -43,6 +55,9 @@ typedef struct StatsCounter_ {
     /* counter value(s): copies from the 'private' counter */
     uint64_t value;     /**< sum of updates/increments, or 'set' value */
     uint64_t updates;   /**< number of updates (for avg) */
+
+    /* need backsync */
+    uint8_t backsync;
 
     /* when using type STATS_TYPE_Q_FUNC this function is called once
      * to get the counter value, regardless of how many threads there are. */
@@ -118,10 +133,13 @@ uint16_t StatsRegisterAvgCounter(const char *, struct ThreadVars_ *);
 uint16_t StatsRegisterMaxCounter(const char *, struct ThreadVars_ *);
 uint16_t StatsRegisterGlobalCounter(const char *cname, uint64_t (*Func)(void));
 
+void StatsSetFlags(struct ThreadVars_ *, uint16_t, uint32_t);
+
 /* functions used to update local counter values */
 void StatsAddUI64(struct ThreadVars_ *, uint16_t, uint64_t);
 void StatsSetUI64(struct ThreadVars_ *, uint16_t, uint64_t);
 void StatsIncr(struct ThreadVars_ *, uint16_t);
+void StatsReset(struct ThreadVars_ *, uint16_t);
 
 /* utility functions */
 int StatsUpdateCounterArray(StatsPrivateThreadContext *, StatsPublicThreadContext *);

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -413,6 +413,7 @@ static Flow *FlowGetNew(ThreadVars *tv, DecodeThreadVars *dtv, const Packet *p)
         /* flow is initialized (recylced) but *unlocked* */
     }
 
+    FlowMgrIncreaseParflowsCtr();
     FLOWLOCK_WRLOCK(f);
     FlowUpdateCounter(tv, dtv, p->proto);
     return f;

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -125,6 +125,51 @@ typedef struct FlowTimeoutCounters_ {
 } FlowTimeoutCounters;
 
 /**
+ * Counter for keeping track of the max number of parallel flows Suricata is
+ * tracking in every single moment.
+ * There is a simple counter for the number of tracks, and a PerfCounter
+ * registered as MaxCounter (update value with set). MaxCounter will be updated
+ * in the flow manager main thread, while the counter is increased & decreased
+ * in an exposed function.
+ */
+struct {
+    SC_ATOMIC_DECLARE(uint64_t, num_parallel_flows);
+    uint16_t perfctr_id;
+    struct timeval tv;
+} parflows_ctr;
+
+/**
+ * \brief This function will increase the number of parallel_flows. It's called
+ * only by FlowGetNew function in flow-hash.c file.
+ */
+void FlowMgrIncreaseParflowsCtr() {
+    SC_ATOMIC_ADD(parflows_ctr.num_parallel_flows, 1);
+}
+
+/**
+ * \brief This function will decrease the number of parallel_flows. It's called
+ * only by FlowManagerHashRowTimeout function in flow-manager.c file.
+ */
+void FlowMgrDecreaseParflowsCtr() {
+    //if num_parallel_flows would drop below zero throw an epic failure
+    BUG_ON(SC_ATOMIC_GET(parflows_ctr.num_parallel_flows) == 0);
+    SC_ATOMIC_SUB(parflows_ctr.num_parallel_flows, 1);
+}
+
+/**
+ * \brief Initialization for parallel flow counter. Through the resetting flag,
+ * the counter is set to reset itself at every stats dump.
+ *
+ * \param th_v  ThreadVars used to associate the counter to the thread
+ */
+static void InitializeParallelFlowCounter(ThreadVars * th_v) {
+    parflows_ctr.perfctr_id = StatsRegisterMaxCounter(
+            "flow.max_parallel_flows", th_v);
+    StatsSetFlags(th_v, parflows_ctr.perfctr_id, STATS_FLAGS_RESETTING);
+    SC_ATOMIC_INIT(parflows_ctr.num_parallel_flows);
+}
+
+/**
  * \brief Used to disable flow manager thread(s).
  *
  * \todo Kinda hackish since it uses the tv name to identify flow manager
@@ -379,6 +424,10 @@ static uint32_t FlowManagerHashRowTimeout(Flow *f, struct timeval *ts,
 
             cnt++;
 
+            /* if the flow is to be discarded, decrease counter of
+             * parallel flows. */
+            FlowMgrDecreaseParflowsCtr();
+
             switch (state) {
                 case FLOW_STATE_NEW:
                 default:
@@ -625,6 +674,7 @@ static TmEcode FlowManagerThreadInit(ThreadVars *t, const void *initdata, void *
     ftd->flow_emerg_mode_enter = StatsRegisterCounter("flow.emerg_mode_entered", t);
     ftd->flow_emerg_mode_over = StatsRegisterCounter("flow.emerg_mode_over", t);
     ftd->flow_tcp_reuse = StatsRegisterCounter("flow.tcp_reuse", t);
+    InitializeParallelFlowCounter(t);
 
     ftd->flow_mgr_flows_checked = StatsRegisterCounter("flow_mgr.flows_checked", t);
     ftd->flow_mgr_flows_notimeout = StatsRegisterCounter("flow_mgr.flows_notimeout", t);
@@ -730,6 +780,8 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         StatsAddUI64(th_v, ftd->flow_mgr_cnt_est, (uint64_t)counters.est);
         StatsAddUI64(th_v, ftd->flow_mgr_cnt_byp, (uint64_t)counters.byp);
         StatsAddUI64(th_v, ftd->flow_tcp_reuse, (uint64_t)counters.tcp_reuse);
+        StatsSetUI64(th_v, parflows_ctr.perfctr_id,
+                SC_ATOMIC_GET(parflows_ctr.num_parallel_flows));
 
         StatsSetUI64(th_v, ftd->flow_mgr_flows_checked, (uint64_t)counters.flows_checked);
         StatsSetUI64(th_v, ftd->flow_mgr_flows_notimeout, (uint64_t)counters.flows_notimeout);

--- a/src/flow-manager.h
+++ b/src/flow-manager.h
@@ -49,4 +49,9 @@ void FlowDisableFlowRecyclerThread(void);
 void TmModuleFlowManagerRegister (void);
 void TmModuleFlowRecyclerRegister (void);
 
+/** Increase and Decrease counter of parallel flows active. Needed
+ *  because we create and destroy flows in different places. */
+void FlowMgrIncreaseParflowsCtr(void);
+void FlowMgrDecreaseParflowsCtr(void);
+
 #endif /* __FLOW_MANAGER_H__ */

--- a/src/log-stats.c
+++ b/src/log-stats.c
@@ -92,9 +92,10 @@ static int LogStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *s
     MemBufferWriteString(aft->buffer, "----------------------------------------------"
             "--------------------------------------\n");
     MemBufferWriteString(aft->buffer, "Date: %" PRId32 "/%" PRId32 "/%04d -- "
-            "%02d:%02d:%02d (uptime: %"PRId32"d, %02dh %02dm %02ds)\n",
+            "%02d:%02d:%02d (uptime: %"PRId32"d, %02dh %02dm %02ds) "
+            "Timestamp %"PRIu64"\n",
             tms->tm_mon + 1, tms->tm_mday, tms->tm_year + 1900, tms->tm_hour,
-            tms->tm_min, tms->tm_sec, days, hours, min, sec);
+            tms->tm_min, tms->tm_sec, days, hours, min, sec, tval.tv_sec);
     MemBufferWriteString(aft->buffer, "----------------------------------------------"
             "--------------------------------------\n");
     MemBufferWriteString(aft->buffer, "%-42s | %-25s | %-s\n", "Counter", "TM Name",


### PR DESCRIPTION
This feature adds the ability to reset the value of a counter. This
feature is controlled by the flag STATS_FLAGS_RESETTING. This flag will
trigger a reset (via function StatsReset) of the value of the counter
at the end of function StatsOutput and StatsOutputCounterSocket.

An example counter is provided. This counter counts the maximum number
of parallel flows at any single time, increasing and decreasing an
atomic variable every time we create/destroy a flow.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2410

Describe changes:
- Created a new option for counters that allow resetting the counter every time it gets dumped.
- Created a new Max Counter that use the RESET flag for counting the number of parallel flows, updating its number every time a flow is created or destroyed.
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

