### PR TITLE
time: option to set timezone to UTC

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1581,6 +1581,16 @@ The last three, f, l and n are mainly convenient for developers.
 The log-format can be overridden in the command line by the
 environment variable: SC_LOG_FORMAT
 
+
+Utc-timestamps
+~~~~~~~~~~~~~~
+
+By default, suricata will use the default timezone. It's possible to enforce
+the use of UTC timestamp by setting the appropriate boolean utc-timestamps.
+This parameter, when enabled, will reset the environment variable TZ to UTC and
+trigger the reinitialization of the Time configuration.
+
+
 Output-filter
 ~~~~~~~~~~~~~
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2819,6 +2819,7 @@ int main(int argc, char **argv)
         exit(EXIT_SUCCESS);
     }
 
+    TimeConfig();
     /* Since our config is now loaded we can finish configurating the
      * logging module. */
     SCLogLoadConfig(suricata.daemon, suricata.verbose);

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -74,6 +74,16 @@ void TimeInit(void)
     tzset();
 }
 
+void TimeConfig(void) {
+    int use_utc_ts = 0;
+    if (ConfGetBool("logging.utc-timestamps", &use_utc_ts) == 1 &&
+            use_utc_ts == 1) {
+        setenv("TZ", "UTC", 1);
+        /* ReInit Time Zone settings. */
+        tzset();
+    }
+}
+
 void TimeDeinit(void)
 {
     SCSpinDestroy(&current_time_spinlock);

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -35,6 +35,7 @@ typedef struct SCTimeval32_ {
 } SCTimeval32;
 
 void TimeInit(void);
+void TimeConfig(void);
 void TimeDeinit(void);
 
 void TimeSetByThread(const int thread_id, const struct timeval *tv);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -509,6 +509,9 @@ logging:
   # This value is overriden by the SC_LOG_LEVEL env var.
   default-log-level: notice
 
+  # enforce the timezone to UTC
+  utc-timestamps: yes
+
   # The default output format.  Optional parameter, should default to
   # something reasonable if not provided.  Can be overriden in an
   # output section.  You can leave this out to get the default.


### PR DESCRIPTION
Add a new option, logging.utc-timestamps, to force the use of UTC
timezone. This option is provided via a boolean configuration value and
it will set the timezone to UTC (via setenv of TZ variable), followed
by a reinitialization of the Time module.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2415

Describe changes:
- add logging.utc-timestamps to suricata.yaml.in
- add logging.utc-timestamps description to doc/userguide
- when utc-timestamps is enabled, set the TZ environment variable and call tzset

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

