### PR TITLE
source-pcap-file: delete when done (2417)

### DIFF
--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -35,6 +35,12 @@
    interrupted. This is useful with directories to add new files and not reset
    flow state between files.
 
+.. option:: --pcap-file-delete
+
+   Used with the -r option to indicate that the mode should delete pcap files
+   after they have been processed. This is useful with pcap-file-continuous to
+   continuously feed files to a directory and have them cleaned up when done.
+
 .. option::  -i <interface>
 
    After the -i option you can enter the interface card you would like

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -58,6 +58,7 @@ typedef struct PcapFiles_ {
     time_t delay;
     time_t poll_interval;
     bool continuous;
+    bool should_delete;
     TAILQ_ENTRY(PcapFiles_) next;
 } PcapFiles;
 
@@ -233,6 +234,7 @@ static void PcapFilesFree(PcapFiles *cfile)
  * \param output_dir absolute name of directory where log will be put
  * \param tenant_id Id of tenant associated with this file
  * \param continuous If file should be run in continuous mode
+ * \param delete If file should be deleted when done
  * \param delay Delay required for file modified time before being processed
  * \param poll_interval How frequently directory mode polls for new files
  *
@@ -244,6 +246,7 @@ static TmEcode UnixListAddFile(
     const char *output_dir,
     int tenant_id,
     bool continuous,
+    bool should_delete,
     time_t delay,
     time_t poll_interval
 )
@@ -277,6 +280,7 @@ static TmEcode UnixListAddFile(
 
     cfile->tenant_id = tenant_id;
     cfile->continuous = continuous;
+    cfile->should_delete = should_delete;
     cfile->delay = delay;
     cfile->poll_interval = poll_interval;
 
@@ -298,6 +302,7 @@ static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
     const char *output_dir;
     int tenant_id = 0;
     bool continuous = false;
+    bool should_delete = false;
     time_t delay = 30;
     time_t poll_interval = 5;
 #ifdef OS_WIN32
@@ -367,6 +372,11 @@ static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
         continuous = json_is_true(cont_arg);
     }
 
+    json_t *delete_arg = json_object_get(cmd, "delete-when-done");
+    if (delete_arg != NULL) {
+        should_delete = json_is_true(delete_arg);
+    }
+
     json_t *delay_arg = json_object_get(cmd, "delay");
     if (delay_arg != NULL) {
         if (!json_is_integer(delay_arg)) {
@@ -391,7 +401,7 @@ static TmEcode UnixSocketAddPcapFile(json_t *cmd, json_t* answer, void *data)
     }
 
     switch (UnixListAddFile(this, filename, output_dir, tenant_id, continuous,
-                           delay, poll_interval)) {
+                           should_delete, delay, poll_interval)) {
         case TM_ECODE_FAILED:
         case TM_ECODE_DONE:
             json_object_set_new(answer, "message",
@@ -466,6 +476,16 @@ static TmEcode UnixSocketPcapFilesCheck(void *data)
     }
     if (set_res != 1) {
         SCLogError(SC_ERR_INVALID_ARGUMENT, "Can not set continuous mode for pcap processing");
+        PcapFilesFree(cfile);
+        return TM_ECODE_FAILED;
+    }
+    if (cfile->should_delete) {
+        set_res = ConfSetFinal("pcap-file.delete-when-done", "true");
+    } else {
+        set_res = ConfSetFinal("pcap-file.delete-when-done", "false");
+    }
+    if (set_res != 1) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT, "Can not set delete mode for pcap processing");
         PcapFilesFree(cfile);
         return TM_ECODE_FAILED;
     }

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -40,6 +40,13 @@ void CleanupPcapFileFileVars(PcapFileFileVars *pfv)
             pfv->pcap_handle = NULL;
         }
         if (pfv->filename != NULL) {
+            if(pfv->shared->should_delete) {
+                SCLogDebug("Deleting pcap file %s", pfv->filename);
+                if(remove(pfv->filename) != 0) {
+                    SCLogWarning(SC_ERR_PCAP_FILE_DELETE_FAILED,
+                                 "Failed to delete %s", pfv->filename);
+                }
+            }
             SCFree(pfv->filename);
             pfv->filename = NULL;
         }

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -45,6 +45,8 @@ typedef struct PcapFileSharedVars_
 
     struct timespec last_processed;
 
+    bool should_delete;
+
     ThreadVars *tv;
     TmSlot *slot;
 

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -215,6 +215,12 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
         }
     }
 
+    int should_delete = 0;
+    ptv->shared.should_delete = false;
+    if (ConfGetBool("pcap-file.delete-when-done", &should_delete) == 1) {
+        ptv->shared.should_delete = should_delete == 1;
+    }
+
     DIR *directory = NULL;
     SCLogInfo("Checking file or directory %s", (char*)initdata);
     if(PcapDetermineDirectoryOrFile((char *)initdata, &directory) == TM_ECODE_FAILED) {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1454,6 +1454,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         {"netmap", optional_argument, 0, 0},
         {"pcap", optional_argument, 0, 0},
         {"pcap-file-continuous", 0, 0, 0},
+        {"pcap-file-delete", 0, 0, 0},
         {"simulate-ips", 0, 0 , 0},
         {"no-random", 0, &g_disable_randomness, 1},
 
@@ -1826,6 +1827,12 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             else if (strcmp((long_opts[option_index]).name, "pcap-file-continuous") == 0) {
                 if(ConfSetFinal("pcap-file.continuous", "true") != 1) {
                     SCLogError(SC_ERR_CMD_LINE, "Failed to set pcap-file.continuous");
+                    return TM_ECODE_FAILED;
+                }
+            }
+            else if (strcmp((long_opts[option_index]).name, "pcap-file-delete") == 0) {
+                if(ConfSetFinal("pcap-file.delete", "true") != 1) {
+                    SCLogError(SC_ERR_CMD_LINE, "Failed to set pcap-file.delete-when-done");
                     return TM_ECODE_FAILED;
                 }
             }


### PR DESCRIPTION
Add option to have pcap files deleted after they have been processed.
This option combines well with pcap file continuous and streaming
files to a directory being processed.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2417

Describe changes:
- Add option "pcap-file-delete" and corresponding json argument "delete-when-done" to indicate the source-pcap-file should delete the pcap files it processes.
- Cleanup in source-pcap-file-helper will use flag to determine whether file should be deleted.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

