### PR TITLE
signal: use centralized pthread_sigmask for signals

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -323,10 +323,6 @@ static void StatsReleaseCtx(void)
  */
 static void *StatsMgmtThread(void *arg)
 {
-#ifndef OS_WIN32
-    /* block usr2.  usr2 to be handled by the main thread only */
-    UtilSignalBlock(SIGUSR2);
-#endif
     ThreadVars *tv_local = (ThreadVars *)arg;
     uint8_t run = 1;
     struct timespec cond_time;
@@ -411,10 +407,6 @@ static void *StatsMgmtThread(void *arg)
  */
 static void *StatsWakeupThread(void *arg)
 {
-#ifndef OS_WIN32
-    /* block usr2.  usr2 to be handled by the main thread only */
-    UtilSignalBlock(SIGUSR2);
-#endif
     ThreadVars *tv_local = (ThreadVars *)arg;
     uint8_t run = 1;
     ThreadVars *tv = NULL;

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -564,10 +564,6 @@ static TmEcode DetectLoaderThreadDeinit(ThreadVars *t, void *data)
 
 static TmEcode DetectLoader(ThreadVars *th_v, void *thread_data)
 {
-#ifndef OS_WIN32
-    /* block usr2. usr2 to be handled by the main thread only */
-    UtilSignalBlock(SIGUSR2);
-#endif
     DetectLoaderThreadData *ftd = (DetectLoaderThreadData *)thread_data;
     BUG_ON(ftd == NULL);
 

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -658,10 +658,6 @@ static TmEcode FlowManagerThreadDeinit(ThreadVars *t, void *data)
  */
 static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
 {
-#ifndef OS_WIN32
-    /* block usr2.  usr1 to be handled by the main thread only */
-    UtilSignalBlock(SIGUSR2);
-#endif
     FlowManagerThreadData *ftd = thread_data;
     struct timeval ts;
     uint32_t established_cnt = 0, new_cnt = 0, closing_cnt = 0;
@@ -887,10 +883,6 @@ static TmEcode FlowRecyclerThreadDeinit(ThreadVars *t, void *data)
  */
 static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
 {
-#ifndef OS_WIN32
-    /* block usr2. usr2 to be handled by the main thread only */
-    UtilSignalBlock(SIGUSR2);
-#endif
     struct timeval ts;
     struct timespec cond_time;
     int flow_update_delay_sec = FLOW_NORMAL_MODE_UPDATE_DELAY_SEC;

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -270,10 +270,6 @@ static int TmThreadTimeoutLoop(ThreadVars *tv, TmSlot *s)
 
 static void *TmThreadsSlotPktAcqLoop(void *td)
 {
-#ifndef OS_WIN32
-    /* block usr2.  usr2 to be handled by the main thread only */
-    UtilSignalBlock(SIGUSR2);
-#endif
     ThreadVars *tv = (ThreadVars *)td;
     TmSlot *s = tv->tm_slots;
     char run = 1;
@@ -522,10 +518,6 @@ error:
  */
 static void *TmThreadsSlotVar(void *td)
 {
-#ifndef OS_WIN32
-    /* block usr2.  usr2 to be handled by the main thread only */
-    UtilSignalBlock(SIGUSR2);
-#endif
     ThreadVars *tv = (ThreadVars *)td;
     TmSlot *s = (TmSlot *)tv->tm_slots;
     Packet *p = NULL;
@@ -684,10 +676,6 @@ error:
 
 static void *TmThreadsManagement(void *td)
 {
-#ifndef OS_WIN32
-    /* block usr2.  usr2 to be handled by the main thread only */
-    UtilSignalBlock(SIGUSR2);
-#endif
     ThreadVars *tv = (ThreadVars *)td;
     TmSlot *s = (TmSlot *)tv->tm_slots;
     TmEcode r = TM_ECODE_OK;

--- a/src/util-signal.c
+++ b/src/util-signal.c
@@ -34,7 +34,24 @@ int UtilSignalBlock(int signum)
         return -1;
     if (sigaddset(&x, signum) < 0)
         return -1;
-    if (sigprocmask(SIG_BLOCK, &x, NULL) < 0)
+    /* don't use sigprocmask(), as it's undefined for
+     * multithreaded programs. Use phtread_sigmask().
+     */
+    if (pthread_sigmask(SIG_BLOCK, &x, NULL) != 0)
+        return -1;
+#endif
+    return 0;
+}
+
+int UtilSignalUnblock(int signum)
+{
+#ifndef OS_WIN32
+    sigset_t x;
+    if (sigemptyset(&x) < 0)
+        return -1;
+    if (sigaddset(&x, signum) < 0)
+        return -1;
+    if (pthread_sigmask(SIG_UNBLOCK, &x, NULL) != 0)
         return -1;
 #endif
     return 0;
@@ -42,7 +59,7 @@ int UtilSignalBlock(int signum)
 
 void UtilSignalHandlerSetup(int sig, void (*handler)(int))
 {
-#if defined (OS_WIN32)
+#ifdef OS_WIN32
 	signal(sig, handler);
 #else
     struct sigaction action;

--- a/src/util-signal.h
+++ b/src/util-signal.h
@@ -25,6 +25,7 @@
 #define __UTIL_SIGNAL_H__
 
 int UtilSignalBlock(int);
+int UtilSignalUnblock(int);
 void UtilSignalHandlerSetup(int, void (*handler)(int));
 #if 0
 int UtilSignalIsHandler(int sig, void (*handler)(int));


### PR DESCRIPTION
according to its man page, sigprocmask has undefined behavior in
multithreaded environments. Instead of explictly blocking the handling
of SIGUSR2 in every thread, direct block handling SIGUSR2 before
creating the threads and enable again the handling of this signal
afterwards. In this way, only the main thread will be able to manage
this signal properly.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2420

Describe changes:
- use pthread_sigmask instead of sigprocmask
- remove blocking signal handling in the thread spawn
- add signal handling block before spawning threads
- regain signal handling from main thread after spawning the various threads

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):


