### PR TITLE
filestore v2 - v2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST = ChangeLog COPYING LICENSE suricata.yaml.in \
              classification.config threshold.config \
              reference.config
-SUBDIRS = $(HTP_DIR) rust src qa rules doc contrib scripts etc
+SUBDIRS = $(HTP_DIR) rust src qa rules doc contrib scripts etc python
 
 CLEANFILES = stamp-h[0-9]*
 

--- a/configure.ac
+++ b/configure.ac
@@ -2125,7 +2125,7 @@ AC_SUBST(CONFIGURE_SYSCONDIR)
 AC_SUBST(CONFIGURE_LOCALSTATEDIR)
 AC_SUBST(PACKAGE_VERSION)
 
-AC_OUTPUT(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile contrib/tile_pcie_logd/Makefile suricata.yaml scripts/Makefile scripts/suricatasc/Makefile scripts/suricatasc/suricatasc etc/Makefile etc/suricata.logrotate etc/suricata.service)
+AC_OUTPUT(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile contrib/tile_pcie_logd/Makefile suricata.yaml scripts/Makefile scripts/suricatasc/Makefile scripts/suricatasc/suricatasc etc/Makefile etc/suricata.logrotate etc/suricata.service python/Makefile)
 
 SURICATA_BUILD_CONF="Suricata Configuration:
   AF_PACKET support:                       ${enable_af_packet}

--- a/configure.ac
+++ b/configure.ac
@@ -131,6 +131,7 @@
     AC_CHECK_HEADERS([dirent.h fnmatch.h])
     AC_CHECK_HEADERS([sys/resource.h sys/types.h sys/un.h])
     AC_CHECK_HEADERS([sys/random.h])
+    AC_CHECK_HEADERS([utime.h])
 
     AC_CHECK_HEADERS([sys/socket.h net/if.h sys/mman.h linux/if_arp.h], [], [],
     [[#ifdef HAVE_SYS_SOCKET_H
@@ -175,6 +176,8 @@
         [], [
             #include <sys/random.h> 
             ])
+
+    AC_CHECK_FUNCS([utime])
 
     OCFLAGS=$CFLAGS
     CFLAGS=""

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -265,6 +265,8 @@ appearance of a single fast.log-file line:
      append: yes/no         #If this option is set to yes, the last filled fast.log-file will not be
                             #overwritten while restarting Suricata.
 
+.. _suricata-yaml-outputs-eve:
+
 Eve (Extensible Event Format)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -678,6 +680,52 @@ a Netfilter log format.
        filename: drop.log        #The log-name of the file for dropped packets.
        append: yes               #If this option is set to yes, the last filled drop.log-file will not be
                                   #overwritten while restarting Suricata. If set to 'no' the last filled drop.log file will be overwritten.
+
+.. _suricata-yaml-file-store:
+
+File-store (File Extraction)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `file-store` output enables storing of extracted files to disk and
+configures where they are stored.
+
+The following shows the configuration options for version 2 of the
+`file-store` output.
+
+.. code-block:: yaml
+
+  - file-store:
+      # This configures version 2 of the file-store.
+      version: 2
+
+      enabled: no
+
+      # Set the directory for the filestore. If the path is not
+      # absolute will be be relative to the default-log-dir.
+      #dir: filestore
+
+      # Write out a fileinfo record for each occurrence of a
+      # file. Disabled by default as each occurrence is already logged
+      # as a fileinfo record to the main eve-log.
+      #write-fileinfo: yes
+
+      # Force storing of all files. Default: no.
+      #force-filestore: yes
+
+      # Override the global stream-depth for sessions in which we want
+      # to perform file extraction. Set to 0 for unlimited.
+      #stream-depth: 0
+
+      # Uncomment the following variable to define how many files can
+      # remain open for filestore by Suricata. Default value is 0 which
+      # means files get closed after each write
+      #max-open-files: 1000
+
+      # Force logging of checksums, available hash functions are md5,
+      # sha1 and sha256. Note that SHA256 is automatically forced by
+      # the use of this output module as it uses the SHA256 as the
+      # file naming scheme.
+      #force-hash: [sha1, md5]
 
 Detection engine
 ----------------

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+.cache
+build

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -1,0 +1,29 @@
+EXTRA_DIST =	setup.py \
+		bin \
+		suricata
+
+if HAVE_PYTHON
+all-local:
+	cd $(srcdir) && \
+		$(HAVE_PYTHON) setup.py build --build-base $(abs_builddir)
+
+install-exec-local:
+	cd $(srcdir) && \
+		$(HAVE_PYTHON) setup.py build --build-base $(abs_builddir) \
+		install --prefix $(DESTDIR)$(prefix)
+
+uninstall-local:
+	rm -f $(DESTDIR)$(bindir)/suricatactl
+	rm -rf $(DESTDIR)$(prefix)/lib*/python*/site-packages/suricata
+	rm -rf $(DESTDIR)$(prefix)/lib*/python*/site-packages/suricata-[0-9]*.egg-info
+
+clean-local:
+	cd $(srcdir) && \
+		$(HAVE_PYTHON) setup.py clean \
+		--build-base $(abs_builddir)
+	rm -rf scripts-* lib* build
+	find . -name \*.pyc -delete
+
+distclean-local:
+	rm -f version
+endif

--- a/python/bin/suricatactl
+++ b/python/bin/suricatactl
@@ -1,0 +1,40 @@
+#! /usr/bin/env python
+#
+# Copyright (C) 2017 Open Information Security Foundation
+#
+# You can copy, redistribute or modify this Program under the terms of
+# the GNU General Public License version 2 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# version 2 along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+import sys
+import os
+import site
+
+exec_dir = os.path.dirname(__file__)
+
+if os.path.exists(os.path.join(exec_dir, "..", "suricata", "ctl", "main.py")):
+    # Looks like we're running from the development directory.
+    sys.path.insert(0, ".")
+else:
+    # This is to find the suricata module in the case of being installed
+    # to a non-standard prefix.
+    version_info = sys.version_info
+    pyver = "%d.%d" % (version_info.major, version_info.minor)
+    path = os.path.join(
+        exec_dir, "..", "lib", "python%s" % (pyver), "site-packages",
+        "suricata")
+    if os.path.exists(path):
+        sys.path.insert(0, os.path.dirname(path))
+
+from suricata.ctl.main import main
+sys.exit(main())

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+
+import os
+import re
+import sys
+
+from distutils.core import setup
+
+version = None
+if os.path.exists("../configure.ac"):
+    with open("../configure.ac", "r") as conf:
+        for line in conf:
+            m = re.search("AC_INIT\(suricata,\s+(\d.+)\)", line)
+            if m:
+                version = m.group(1)
+                break
+if version is None:
+    print("error: failed to parse Suricata version, will use 0.0.0",
+          file=sys.stderr)
+    version = "0.0.0"
+    
+setup(
+    name="suricata",
+    version=version,
+    packages=[
+        "suricata",
+        "suricata.ctl",
+    ],
+    scripts=[
+        "bin/suricatactl",
+    ]
+)

--- a/python/suricata/ctl/filestore.py
+++ b/python/suricata/ctl/filestore.py
@@ -1,0 +1,118 @@
+# Copyright (C) 2018 Open Information Security Foundation
+#
+# You can copy, redistribute or modify this Program under the terms of
+# the GNU General Public License version 2 as published by the Free
+# Software Foundation.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# version 2 along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+from __future__ import print_function
+
+import sys
+import os
+import os.path
+import time
+import re
+import glob
+import logging
+
+logger = logging.getLogger("filestore")
+
+class InvalidAgeFormatError(Exception):
+    pass
+
+def register_args(parser):
+
+    parsers = parser.add_subparsers()
+
+    prune_parser = parsers.add_parser("prune")
+    prune_parser.add_argument("-d", "--directory", help="filestore directory")
+    prune_parser.add_argument("--age", help="prune files older than age")
+    prune_parser.add_argument(
+        "-n", "--dry-run", action="store_true", default=False,
+        help="only print what would happen");
+    prune_parser.add_argument(
+        "-v", "--verbose", action="store_true",
+        default=False, help="increase verbosity")
+    prune_parser.add_argument(
+        "-q", "--quiet", action="store_true", default=False,
+        help="be quiet, log warnings and errors only")
+    prune_parser.set_defaults(func=prune)
+
+def is_fileinfo(path):
+    return path.endswith(".json")
+
+def parse_age(age):
+    m = re.match("(\d+)\s*(\w+)", age)
+    if not m:
+        raise InvalidAgeFormatError(age)
+    val = int(m.group(1))
+    unit = m.group(2)
+
+    if unit == "s":
+        return val
+    elif unit == "m":
+        return val * 60
+    elif unit == "h":
+        return val * 60 * 60
+    elif unit == "d":
+        return val * 60 * 60 * 24
+    else:
+        raise InvalidAgeFormatError("bad unit: %s" % (unit))
+
+def get_filesize(path):
+    return os.stat(path).st_size
+
+def remove_file(path, dry_run):
+    size = 0
+    size += get_filesize(path)
+    if not dry_run:
+        os.unlink(path)
+    return size
+
+def prune(args):
+
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+    if args.quiet:
+        logger.setLevel(logging.WARNING)
+
+    if not args.directory:
+        print(
+            "error: the filestore directory must be provided with --directory",
+            file=sys.stderr)
+        return 1
+    
+    if not args.age:
+        print("error: no age provided, nothing to do", file=sys.stderr)
+        return 1
+
+    age = parse_age(args.age)
+    now = time.time()
+    size = 0
+    count = 0
+
+    for dirpath, dirnames, filenames in os.walk(args.directory, topdown=True):
+
+        # Do not go into the tmp directory.
+        if "tmp" in dirnames:
+            dirnames.remove("tmp")
+
+        for filename in filenames:
+            path = os.path.join(dirpath, filename)
+            mtime = os.path.getmtime(path)
+            this_age = now - mtime
+            if this_age > age:
+                logger.debug("Deleting %s; age=%ds" % (path, this_age))
+                size += remove_file(path, args.dry_run)
+                count += 1
+
+    logger.info("Removed %d files; %d bytes." % (count, size))

--- a/python/suricata/ctl/loghandler.py
+++ b/python/suricata/ctl/loghandler.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2017 Open Information Security Foundation
+# Copyright (c) 2016 Jason Ish
+#
+# You can copy, redistribute or modify this Program under the terms of
+# the GNU General Public License version 2 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# version 2 along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+import logging
+import time
+
+GREEN = "\x1b[32m"
+BLUE = "\x1b[34m"
+REDB = "\x1b[1;31m"
+YELLOW = "\x1b[33m"
+RED = "\x1b[31m"
+YELLOWB = "\x1b[1;33m"
+ORANGE = "\x1b[38;5;208m"
+RESET = "\x1b[0m"
+
+# A list of secrets that will be replaced in the log output.
+secrets = {}
+
+def add_secret(secret, replacement):
+    """Register a secret to be masked. The secret will be replaced with:
+           <replacement>
+    """
+    secrets[str(secret)] = str(replacement)
+
+class SuriColourLogHandler(logging.StreamHandler):
+    """An alternative stream log handler that logs with Suricata inspired
+    log colours."""
+
+    def formatTime(self, record):
+        lt = time.localtime(record.created)
+        t = "%d/%d/%d -- %02d:%02d:%02d" % (lt.tm_mday,
+                                            lt.tm_mon,
+                                            lt.tm_year,
+                                            lt.tm_hour,
+                                            lt.tm_min,
+                                            lt.tm_sec)
+        return "%s" % (t)
+
+    def emit(self, record):
+
+        if record.levelname == "ERROR":
+            level_prefix = REDB
+            message_prefix = REDB
+        elif record.levelname == "WARNING":
+            level_prefix = ORANGE
+            message_prefix = ORANGE
+        else:
+            level_prefix = YELLOW
+            message_prefix = ""
+
+        self.stream.write("%s%s%s - <%s%s%s> -- %s%s%s\n" % (
+            GREEN,
+            self.formatTime(record),
+            RESET,
+            level_prefix,
+            record.levelname.title(),
+            RESET,
+            message_prefix,
+            self.mask_secrets(record.getMessage()),
+            RESET))
+
+    def mask_secrets(self, msg):
+        for secret in secrets:
+            msg = msg.replace(secret, "<%s>" % secrets[secret])
+        return msg

--- a/python/suricata/ctl/main.py
+++ b/python/suricata/ctl/main.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2018 Open Information Security Foundation
+#
+# You can copy, redistribute or modify this Program under the terms of
+# the GNU General Public License version 2 as published by the Free
+# Software Foundation.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# version 2 along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+import sys
+import os
+import argparse
+import logging
+
+from suricata.ctl import filestore
+from suricata.ctl import loghandler
+
+def init_logger():
+    """ Initialize logging, use colour if on a tty. """
+    if os.isatty(sys.stderr.fileno()):
+        logger = logging.getLogger()
+        logger.setLevel(level=logging.INFO)
+        logger.addHandler(loghandler.SuriColourLogHandler())
+    else:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - <%(levelname)s> - %(message)s")
+
+def main():
+
+    init_logger()
+
+    parser = argparse.ArgumentParser(description="Suricata Control Tool")
+
+    subparsers = parser.add_subparsers(
+        title="subcommands",
+        description="Commands")
+
+    filestore.register_args(subparsers.add_parser("filestore"))
+
+    args = parser.parse_args()
+
+    args.func(args)

--- a/python/suricata/ctl/test_filestore.py
+++ b/python/suricata/ctl/test_filestore.py
@@ -1,0 +1,18 @@
+from __future__ import print_function
+
+import unittest
+
+import filestore
+
+class PruneTestCase(unittest.TestCase):
+
+    def test_parse_age(self):
+        self.assertEqual(filestore.parse_age("1s"), 1)
+        self.assertEqual(filestore.parse_age("1m"), 60)
+        self.assertEqual(filestore.parse_age("1h"), 3600)
+        self.assertEqual(filestore.parse_age("1d"), 86400)
+
+        with self.assertRaises(filestore.InvalidAgeFormatError) as err:
+            filestore.parse_age("1")
+        with self.assertRaises(filestore.InvalidAgeFormatError) as err:
+            filestore.parse_age("1y")

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -291,6 +291,7 @@ log-tlsstore.c log-tlsstore.h \
 output.c output.h \
 output-file.c output-file.h \
 output-filedata.c output-filedata.h \
+output-filestore.c output-filestore.h \
 output-flow.c output-flow.h \
 output-json-alert.c output-json-alert.h \
 output-json-dns.c output-json-dns.h \

--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -430,8 +430,9 @@ static void AlertDebugLogDeInitCtx(OutputCtx *output_ctx)
  *
  *  \return output_ctx if succesful, NULL otherwise
  */
-static OutputCtx *AlertDebugLogInitCtx(ConfNode *conf)
+static OutputInitResult AlertDebugLogInitCtx(ConfNode *conf)
 {
+    OutputInitResult result = { NULL, false };
     LogFileCtx *file_ctx = NULL;
 
     file_ctx = LogFileNewCtx();
@@ -453,14 +454,16 @@ static OutputCtx *AlertDebugLogInitCtx(ConfNode *conf)
     output_ctx->DeInit = AlertDebugLogDeInitCtx;
 
     SCLogDebug("Alert debug log output initialized");
-    return output_ctx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
 
 error:
     if (file_ctx != NULL) {
         LogFileFreeCtx(file_ctx);
     }
 
-    return NULL;
+    return result;
 }
 
 static int AlertDebugLogCondition(ThreadVars *tv, const Packet *p)

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -220,26 +220,29 @@ TmEcode AlertFastLogThreadDeinit(ThreadVars *t, void *data)
  * \param conf The configuration node for this output.
  * \return A LogFileCtx pointer on success, NULL on failure.
  */
-OutputCtx *AlertFastLogInitCtx(ConfNode *conf)
+OutputInitResult AlertFastLogInitCtx(ConfNode *conf)
 {
+    OutputInitResult result = { NULL, false };
     LogFileCtx *logfile_ctx = LogFileNewCtx();
     if (logfile_ctx == NULL) {
         SCLogDebug("AlertFastLogInitCtx2: Could not create new LogFileCtx");
-        return NULL;
+        return result;
     }
 
     if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(logfile_ctx);
-        return NULL;
+        return result;
     }
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL))
-        return NULL;
+        return result;
     output_ctx->data = logfile_ctx;
     output_ctx->DeInit = AlertFastLogDeInitCtx;
 
-    return output_ctx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
 }
 
 static void AlertFastLogDeInitCtx(OutputCtx *output_ctx)

--- a/src/alert-fastlog.h
+++ b/src/alert-fastlog.h
@@ -27,7 +27,7 @@
 void AlertFastLogRegister(void);
 void TmModuleAlertFastLogIPv4Register(void);
 void TmModuleAlertFastLogIPv6Register(void);
-OutputCtx *AlertFastLogInitCtx(ConfNode *);
+OutputInitResult AlertFastLogInitCtx(ConfNode *);
 
 #endif /* __ALERT_FASTLOG_H__ */
 

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -88,8 +88,9 @@ static void AlertSyslogDeInitCtx(OutputCtx *output_ctx)
  * \param conf The configuration node for this output.
  * \return A OutputCtx pointer on success, NULL on failure.
  */
-static OutputCtx *AlertSyslogInitCtx(ConfNode *conf)
+static OutputInitResult AlertSyslogInitCtx(ConfNode *conf)
 {
+    OutputInitResult result = { NULL, false };
     const char *facility_s = ConfNodeLookupChildValue(conf, "facility");
     if (facility_s == NULL) {
         facility_s = DEFAULT_ALERT_SYSLOG_FACILITY_STR;
@@ -98,7 +99,7 @@ static OutputCtx *AlertSyslogInitCtx(ConfNode *conf)
     LogFileCtx *logfile_ctx = LogFileNewCtx();
     if (logfile_ctx == NULL) {
         SCLogDebug("AlertSyslogInitCtx: Could not create new LogFileCtx");
-        return NULL;
+        return result;
     }
 
     int facility = SCMapEnumNameToValue(facility_s, SCSyslogGetFacilityMap());
@@ -126,7 +127,7 @@ static OutputCtx *AlertSyslogInitCtx(ConfNode *conf)
     OutputCtx *output_ctx = SCMalloc(sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {
         SCLogDebug("AlertSyslogInitCtx: Could not create new OutputCtx");
-        return NULL;
+        return result;
     }
     memset(output_ctx, 0x00, sizeof(OutputCtx));
 
@@ -135,7 +136,9 @@ static OutputCtx *AlertSyslogInitCtx(ConfNode *conf)
 
     SCLogInfo("Syslog output initialized");
 
-    return output_ctx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
 }
 
 /**

--- a/src/alert-unified2-alert.h
+++ b/src/alert-unified2-alert.h
@@ -44,7 +44,7 @@
 #define UNIFIED2_EXTRADATA_TYPE_EXTRA_DATA 4
 
 void Unified2AlertRegister(void);
-OutputCtx *Unified2AlertInitCtx(ConfNode *);
+OutputInitResult Unified2AlertInitCtx(ConfNode *);
 
 #endif /* __ALERT_UNIFIED2_ALERT_H__ */
 

--- a/src/log-droplog.c
+++ b/src/log-droplog.c
@@ -135,34 +135,37 @@ static void LogDropLogDeInitCtx(OutputCtx *output_ctx)
  * \param conf The configuration node for this output.
  * \return A LogFileCtx pointer on success, NULL on failure.
  */
-static OutputCtx *LogDropLogInitCtx(ConfNode *conf)
+static OutputInitResult LogDropLogInitCtx(ConfNode *conf)
 {
+    OutputInitResult result = { NULL, false };
     if (OutputDropLoggerEnable() != 0) {
         SCLogError(SC_ERR_CONF_YAML_ERROR, "only one 'drop' logger "
             "can be enabled");
-        return NULL;
+        return result;
     }
 
     LogFileCtx *logfile_ctx = LogFileNewCtx();
     if (logfile_ctx == NULL) {
         SCLogDebug("LogDropLogInitCtx: Could not create new LogFileCtx");
-        return NULL;
+        return result;
     }
 
     if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(logfile_ctx);
-        return NULL;
+        return result;
     }
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {
         LogFileFreeCtx(logfile_ctx);
-        return NULL;
+        return result;
     }
     output_ctx->data = logfile_ctx;
     output_ctx->DeInit = LogDropLogDeInitCtx;
 
-    return output_ctx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
 }
 
 /**

--- a/src/log-filestore.c
+++ b/src/log-filestore.c
@@ -584,6 +584,13 @@ static OutputInitResult LogFilestoreLogInitCtx(ConfNode *conf)
         }
     }
 
+    if (RunModeOutputFiledataEnabled()) {
+        SCLogWarning(SC_ERR_NOT_SUPPORTED,
+                "A file data logger is already enabled. Filestore (v1) "
+                "will not be enabled.");
+        return result;
+    }
+
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL))
         return result;

--- a/src/log-filestore.c
+++ b/src/log-filestore.c
@@ -572,11 +572,12 @@ static void LogFilestoreLogDeInitCtx(OutputCtx *output_ctx)
  *  \param conf Pointer to ConfNode containing this loggers configuration.
  *  \return NULL if failure, LogFilestoreCtx* to the file_ctx if succesful
  * */
-static OutputCtx *LogFilestoreLogInitCtx(ConfNode *conf)
+static OutputInitResult LogFilestoreLogInitCtx(ConfNode *conf)
 {
+    OutputInitResult result = { NULL, false };
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL))
-        return NULL;
+        return result;
 
     output_ctx->data = NULL;
     output_ctx->DeInit = LogFilestoreLogDeInitCtx;
@@ -660,7 +661,9 @@ static OutputCtx *LogFilestoreLogInitCtx(ConfNode *conf)
         SCLogInfo("enabling pid as a part of all file names");
     }
 
-    SCReturnPtr(output_ctx, "OutputCtx");
+    result.ctx = output_ctx;
+    result.ok = true;
+    SCReturnCT(result, "OutputInitResult");
 }
 
 

--- a/src/log-filestore.c
+++ b/src/log-filestore.c
@@ -670,17 +670,13 @@ static OutputInitResult LogFilestoreLogInitCtx(ConfNode *conf)
         SCLogInfo("enabling pid as a part of all file names");
     }
 
+    StatsRegisterGlobalCounter("file_store.open_files",
+            LogFilestoreOpenFilesCounter);
+
     result.ctx = output_ctx;
     result.ok = true;
     SCReturnCT(result, "OutputInitResult");
 }
-
-
-void LogFilestoreInitConfig(void)
-{
-    StatsRegisterGlobalCounter("file_store.open_files", LogFilestoreOpenFilesCounter);
-}
-
 
 void LogFilestoreRegister (void)
 {

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -549,23 +549,24 @@ TmEcode LogHttpLogThreadDeinit(ThreadVars *t, void *data)
  *  \param conf Pointer to ConfNode containing this loggers configuration.
  *  \return NULL if failure, LogFileCtx* to the file_ctx if succesful
  * */
-OutputCtx *LogHttpLogInitCtx(ConfNode *conf)
+OutputInitResult LogHttpLogInitCtx(ConfNode *conf)
 {
+    OutputInitResult result = { NULL, false };
     LogFileCtx* file_ctx = LogFileNewCtx();
     if(file_ctx == NULL) {
         SCLogError(SC_ERR_HTTP_LOG_GENERIC, "couldn't create new file_ctx");
-        return NULL;
+        return result;
     }
 
     if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
-        return NULL;
+        return result;
     }
 
     LogHttpFileCtx *httplog_ctx = SCMalloc(sizeof(LogHttpFileCtx));
     if (unlikely(httplog_ctx == NULL)) {
         LogFileFreeCtx(file_ctx);
-        return NULL;
+        return result;
     }
     memset(httplog_ctx, 0x00, sizeof(LogHttpFileCtx));
 
@@ -612,7 +613,9 @@ OutputCtx *LogHttpLogInitCtx(ConfNode *conf)
     /* enable the logger for the app layer */
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_HTTP);
 
-    return output_ctx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
 
 parsererror:
     SCLogError(SC_ERR_INVALID_ARGUMENT,"Syntax error in custom http log format string.");
@@ -620,7 +623,7 @@ errorfree:
     LogCustomFormatFree(httplog_ctx->cf);
     LogFileFreeCtx(file_ctx);
     SCFree(httplog_ctx);
-    return NULL;
+    return result;
 
 }
 

--- a/src/log-httplog.h
+++ b/src/log-httplog.h
@@ -27,7 +27,7 @@
 void LogHttpLogRegister(void);
 void TmModuleLogHttpLogIPv4Register (void);
 void TmModuleLogHttpLogIPv6Register (void);
-OutputCtx *LogHttpLogInitCtx(ConfNode *);
+OutputInitResult LogHttpLogInitCtx(ConfNode *);
 
 #endif /* __LOG_HTTPLOG_H__ */
 

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -170,7 +170,7 @@ static int PcapLog(ThreadVars *, void *, const Packet *);
 static TmEcode PcapLogDataInit(ThreadVars *, const void *, void **);
 static TmEcode PcapLogDataDeinit(ThreadVars *, void *);
 static void PcapLogFileDeInitCtx(OutputCtx *);
-static OutputCtx *PcapLogInitCtx(ConfNode *);
+static OutputInitResult PcapLogInitCtx(ConfNode *);
 static void PcapLogProfilingDump(PcapLogData *);
 static int PcapLogCondition(ThreadVars *, const Packet *);
 
@@ -931,8 +931,9 @@ error:
  *  \param conf The configuration node for this output.
  *  \retval output_ctx
  * */
-static OutputCtx *PcapLogInitCtx(ConfNode *conf)
+static OutputInitResult PcapLogInitCtx(ConfNode *conf)
 {
+    OutputInitResult result = { NULL, false };
     const char *pcre_errbuf;
     int pcre_erroffset;
 
@@ -1162,7 +1163,9 @@ static OutputCtx *PcapLogInitCtx(ConfNode *conf)
     output_ctx->DeInit = PcapLogFileDeInitCtx;
     g_pcap_data = pl;
 
-    return output_ctx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
 }
 
 static void PcapLogFileDeInitCtx(OutputCtx *output_ctx)

--- a/src/log-tcp-data.c
+++ b/src/log-tcp-data.c
@@ -225,8 +225,9 @@ TmEcode LogTcpDataLogThreadDeinit(ThreadVars *t, void *data)
  *  \param conf Pointer to ConfNode containing this loggers configuration.
  *  \return NULL if failure, LogFileCtx* to the file_ctx if succesful
  * */
-OutputCtx *LogTcpDataLogInitCtx(ConfNode *conf)
+OutputInitResult LogTcpDataLogInitCtx(ConfNode *conf)
 {
+    OutputInitResult result = { NULL, false };
     char filename[PATH_MAX] = "";
     char dirname[32] = "";
     strlcpy(filename, DEFAULT_LOG_FILENAME, sizeof(filename));
@@ -234,13 +235,13 @@ OutputCtx *LogTcpDataLogInitCtx(ConfNode *conf)
     LogFileCtx *file_ctx = LogFileNewCtx();
     if(file_ctx == NULL) {
         SCLogError(SC_ERR_TCPDATA_LOG_GENERIC, "couldn't create new file_ctx");
-        return NULL;
+        return result;
     }
 
     LogTcpDataFileCtx *tcpdatalog_ctx = SCMalloc(sizeof(LogTcpDataFileCtx));
     if (unlikely(tcpdatalog_ctx == NULL)) {
         LogFileFreeCtx(file_ctx);
-        return NULL;
+        return result;
     }
     memset(tcpdatalog_ctx, 0x00, sizeof(LogTcpDataFileCtx));
 
@@ -281,7 +282,7 @@ OutputCtx *LogTcpDataLogInitCtx(ConfNode *conf)
         if (SCConfLogOpenGeneric(conf, file_ctx, filename, 1) < 0) {
             LogFileFreeCtx(file_ctx);
             SCFree(tcpdatalog_ctx);
-            return NULL;
+            return result;
         }
     }
 
@@ -307,13 +308,15 @@ OutputCtx *LogTcpDataLogInitCtx(ConfNode *conf)
     output_ctx->DeInit = LogTcpDataLogDeInitCtx;
 
     SCLogDebug("Streaming log output initialized");
-    return output_ctx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
 
 parsererror:
     LogFileFreeCtx(file_ctx);
     SCFree(tcpdatalog_ctx);
     SCLogError(SC_ERR_INVALID_ARGUMENT,"Syntax error in custom http log format string.");
-    return NULL;
+    return result;
 
 }
 

--- a/src/log-tcp-data.h
+++ b/src/log-tcp-data.h
@@ -25,6 +25,6 @@
 #define __LOG_TCPDATALOG_H__
 
 void LogTcpDataLogRegister(void);
-OutputCtx *LogTcpDataLogInitCtx(ConfNode *);
+OutputInitResult LogTcpDataLogInitCtx(ConfNode *);
 
 #endif /* __LOG_TCPDATALOG_H__ */

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -264,14 +264,15 @@ static void LogTlsLogExitPrintStats(ThreadVars *tv, void *data)
  *  \param conf Pointer to ConfNode containing this loggers configuration.
  *  \return NULL if failure, LogFileCtx* to the file_ctx if succesful
  * */
-static OutputCtx *LogTlsLogInitCtx(ConfNode *conf)
+static OutputInitResult LogTlsLogInitCtx(ConfNode *conf)
 {
+    OutputInitResult result = { NULL, false };
     LogFileCtx* file_ctx = LogFileNewCtx();
 
     if (file_ctx == NULL) {
         SCLogError(SC_ERR_TLS_LOG_GENERIC, "LogTlsLogInitCtx: Couldn't "
         "create new file_ctx");
-        return NULL;
+        return result;
     }
 
     if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
@@ -325,7 +326,9 @@ static OutputCtx *LogTlsLogInitCtx(ConfNode *conf)
     /* enable the logger for the app layer */
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_TLS);
 
-    return output_ctx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
 parser_error:
     SCLogError(SC_ERR_INVALID_ARGUMENT,"Syntax error in custom tls log format string.");
 tlslog_error:
@@ -333,7 +336,7 @@ tlslog_error:
     SCFree(tlslog_ctx);
 filectx_error:
     LogFileFreeCtx(file_ctx);
-    return NULL;
+    return result;
 }
 
 /* Custom format logging */

--- a/src/log-tlsstore.c
+++ b/src/log-tlsstore.c
@@ -374,12 +374,12 @@ static void LogTlsStoreLogDeInitCtx(OutputCtx *output_ctx)
  *  \param conf Pointer to ConfNode containing this loggers configuration.
  *  \return NULL if failure, LogFilestoreCtx* to the file_ctx if succesful
  * */
-static OutputCtx *LogTlsStoreLogInitCtx(ConfNode *conf)
+static OutputInitResult LogTlsStoreLogInitCtx(ConfNode *conf)
 {
-
+    OutputInitResult result = { NULL, false };
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL))
-        return NULL;
+        return result;
 
     output_ctx->data = NULL;
     output_ctx->DeInit = LogTlsStoreLogDeInitCtx;
@@ -408,7 +408,9 @@ static OutputCtx *LogTlsStoreLogInitCtx(ConfNode *conf)
     /* enable the logger for the app layer */
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_TLS);
 
-    SCReturnPtr(output_ctx, "OutputCtx");
+    result.ctx = output_ctx;
+    result.ok = true;
+    SCReturnCT(result, "OutputInitResult");
 }
 
 void LogTlsStoreRegister (void)

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2018 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,72 +15,52 @@
  * 02110-1301, USA.
  */
 
-/**
- * \file
- *
- * \author Victor Julien <victor@inliniac.net>
- *
- */
-
 #include "suricata-common.h"
-#include "debug.h"
-#include "detect.h"
-#include "pkt-var.h"
-#include "conf.h"
-
-#include "threadvars.h"
-#include "tm-modules.h"
-
-#include "threads.h"
 
 #include "app-layer-parser.h"
-
-#include "detect-filemagic.h"
-
-#include "stream.h"
-
-#include "util-print.h"
-#include "util-unittest.h"
-#include "util-privs.h"
-#include "util-debug.h"
-#include "util-atomic.h"
-#include "util-file.h"
-#include "util-time.h"
-#include "util-misc.h"
-
-#include "output.h"
-
-#include "log-file.h"
-#include "log-filestore.h"
-#include "util-logopenfile.h"
-
 #include "app-layer-htp.h"
 #include "app-layer-smtp.h"
-#include "util-decode-mime.h"
-#include "util-memcmp.h"
-#include "stream-tcp-reassemble.h"
 
-#define MODULE_NAME "LogFilestoreLog"
+#include "output.h"
+#include "output-filestore.h"
 
-static char g_logfile_base_dir[PATH_MAX] = "/tmp";
-static char g_working_file_suffix[PATH_MAX] = ".tmp";
+#include "util-print.h"
+#include "util-misc.h"
 
-SC_ATOMIC_DECLARE(uint32_t, filestore_open_file_cnt);  /**< Atomic counter of simultaneously open files */
+#ifdef HAVE_NSS
 
-typedef struct LogFilestoreLogThread_ {
-    LogFileCtx *file_ctx;
-    /** LogFilestoreCtx has the pointer to the file and a mutex to allow multithreading */
+#define MODULE_NAME "OutputFilestore"
+
+#define SHA256_STRING_LEN (SHA256_LENGTH * 2)
+#define LEAF_DIR_MAX_LEN 4
+#define FILESTORE_PREFIX_MAX (PATH_MAX - SHA256_STRING_LEN - LEAF_DIR_MAX_LEN)
+
+static const char *default_log_dir = "filestore";
+
+SC_ATOMIC_DECLARE(uint32_t, filestore_open_file_cnt);  /**< Atomic
+                                                        * counter of
+                                                        * simultaneously
+                                                        * open
+                                                        * files */
+
+typedef struct OutputFilestoreCtx_ {
+    char prefix[FILESTORE_PREFIX_MAX];
+    char tmpdir[FILESTORE_PREFIX_MAX];
+} OutputFilestoreCtx;
+
+typedef struct OutputFilestoreLogThread_ {
+    OutputFilestoreCtx *ctx;
     uint32_t file_cnt;
     uint16_t counter_max_hits;
-} LogFilestoreLogThread;
+} OutputFilestoreLogThread;
 
-static uint64_t LogFilestoreOpenFilesCounter(void)
+static uint64_t OutputFilestoreOpenFilesCounter(void)
 {
     uint64_t fcopy = SC_ATOMIC_GET(filestore_open_file_cnt);
     return fcopy;
 }
 
-static void LogFilestoreMetaGetUri(FILE *fp, const Packet *p, const File *ff)
+static void OutputFilestoreMetaGetUri(FILE *fp, const Packet *p, const File *ff)
 {
     HtpState *htp_state = (HtpState *)p->flow->alstate;
     if (htp_state != NULL) {
@@ -98,7 +78,7 @@ static void LogFilestoreMetaGetUri(FILE *fp, const Packet *p, const File *ff)
     fprintf(fp, "<unknown>");
 }
 
-static void LogFilestoreMetaGetHost(FILE *fp, const Packet *p, const File *ff)
+static void OutputFilestoreMetaGetHost(FILE *fp, const Packet *p, const File *ff)
 {
     HtpState *htp_state = (HtpState *)p->flow->alstate;
     if (htp_state != NULL) {
@@ -113,7 +93,7 @@ static void LogFilestoreMetaGetHost(FILE *fp, const Packet *p, const File *ff)
     fprintf(fp, "<unknown>");
 }
 
-static void LogFilestoreMetaGetReferer(FILE *fp, const Packet *p, const File *ff)
+static void OutputFilestoreMetaGetReferer(FILE *fp, const Packet *p, const File *ff)
 {
     HtpState *htp_state = (HtpState *)p->flow->alstate;
     if (htp_state != NULL) {
@@ -133,7 +113,7 @@ static void LogFilestoreMetaGetReferer(FILE *fp, const Packet *p, const File *ff
     fprintf(fp, "<unknown>");
 }
 
-static void LogFilestoreMetaGetUserAgent(FILE *fp, const Packet *p, const File *ff)
+static void OutputFilestoreMetaGetUserAgent(FILE *fp, const Packet *p, const File *ff)
 {
     HtpState *htp_state = (HtpState *)p->flow->alstate;
     if (htp_state != NULL) {
@@ -153,7 +133,7 @@ static void LogFilestoreMetaGetUserAgent(FILE *fp, const Packet *p, const File *
     fprintf(fp, "<unknown>");
 }
 
-static void LogFilestoreMetaGetSmtp(FILE *fp, const Packet *p, const File *ff)
+static void OutputFilestoreMetaGetSmtp(FILE *fp, const Packet *p, const File *ff)
 {
     SMTPState *state = (SMTPState *) p->flow->alstate;
     if (state != NULL) {
@@ -178,20 +158,6 @@ static void LogFilestoreMetaGetSmtp(FILE *fp, const Packet *p, const File *ff)
     }
 }
 
-/** \brief switch to write meta file
- */
-static int g_file_write_meta = 1;
-
-static void FileWriteMetaDisable(void)
-{
-    g_file_write_meta = 0;
-}
-
-static int FileWriteMeta(void)
-{
-    return g_file_write_meta;
-}
-
 static uint32_t g_file_store_max_open_files = 0;
 
 static void FileSetMaxOpenFiles(uint32_t count)
@@ -204,25 +170,11 @@ static uint32_t FileGetMaxOpenFiles(void)
     return g_file_store_max_open_files;
 }
 
-static int g_file_store_include_pid = 0;
-
-static void FileIncludePidEnable(void)
-{
-    g_file_store_include_pid = 1;
-}
-
-static int FileIncludePid(void)
-{
-    return g_file_store_include_pid;
-}
-
-static void LogFilestoreLogCreateMetaFile(const Packet *p, const File *ff, char *base_filename, int ipver) {
-    if (!FileWriteMeta())
-        return;
-
+static void OutputFilestoreLogCreateMetaFile(const Packet *p, const File *ff,
+        char *base_filename, int ipver) {
     char metafilename[PATH_MAX] = "";
-    snprintf(metafilename, sizeof(metafilename), "%s.meta%s", base_filename,
-            g_working_file_suffix);
+    snprintf(metafilename, sizeof(metafilename), "%s.meta", base_filename);
+    SCLogNotice("Opening %s.", metafilename);
     FILE *fp = fopen(metafilename, "w+");
     if (fp != NULL) {
         char timebuf[64];
@@ -267,20 +219,20 @@ static void LogFilestoreLogCreateMetaFile(const Packet *p, const File *ff, char 
         /* Only applicable to HTTP traffic */
         if (p->flow->alproto == ALPROTO_HTTP) {
             fprintf(fp, "HTTP URI:          ");
-            LogFilestoreMetaGetUri(fp, p, ff);
+            OutputFilestoreMetaGetUri(fp, p, ff);
             fprintf(fp, "\n");
             fprintf(fp, "HTTP HOST:         ");
-            LogFilestoreMetaGetHost(fp, p, ff);
+            OutputFilestoreMetaGetHost(fp, p, ff);
             fprintf(fp, "\n");
             fprintf(fp, "HTTP REFERER:      ");
-            LogFilestoreMetaGetReferer(fp, p, ff);
+            OutputFilestoreMetaGetReferer(fp, p, ff);
             fprintf(fp, "\n");
             fprintf(fp, "HTTP USER AGENT:   ");
-            LogFilestoreMetaGetUserAgent(fp, p, ff);
+            OutputFilestoreMetaGetUserAgent(fp, p, ff);
             fprintf(fp, "\n");
         } else if (p->flow->alproto == ALPROTO_SMTP) {
             /* Only applicable to SMTP */
-            LogFilestoreMetaGetSmtp(fp, p, ff);
+            OutputFilestoreMetaGetSmtp(fp, p, ff);
         }
 
         fprintf(fp, "FILENAME:          ");
@@ -291,111 +243,113 @@ static void LogFilestoreLogCreateMetaFile(const Packet *p, const File *ff, char 
     }
 }
 
-static void LogFilestoreLogCloseMetaFile(const File *ff)
+static void OutputFilestoreLogCloseMetaFile(const OutputFilestoreCtx *ctx,
+        const File *ff, const char *filename)
 {
-    char pid_expression[PATH_MAX] = "";
-    if (FileIncludePid())
-        snprintf(pid_expression, sizeof(pid_expression), ".%d", getpid());
-    char final_filename[PATH_MAX] = "";
-    snprintf(final_filename, sizeof(final_filename), "%s/file%s.%u",
-            g_logfile_base_dir, pid_expression, ff->file_store_id);
-    char final_metafilename[PATH_MAX] = "";
-    snprintf(final_metafilename, sizeof(final_metafilename),
-            "%s.meta", final_filename);
-    char working_metafilename[PATH_MAX] = "";
-    snprintf(working_metafilename, sizeof(working_metafilename),
-            "%s%s", final_metafilename, g_working_file_suffix);
-    FILE *fp = fopen(working_metafilename, "a");
-    if (fp != NULL) {
+    FILE *fp = fopen(filename, "a");
+    if (fp == NULL) {
+        SCLogInfo("Failed to open %s: %s", filename, strerror(errno));
+        return;
+    }
 #ifdef HAVE_MAGIC
-        fprintf(fp, "MAGIC:             %s\n",
-                ff->magic ? ff->magic : "<unknown>");
+    fprintf(fp, "MAGIC:             %s\n",
+            ff->magic ? ff->magic : "<unknown>");
 #endif
-        switch (ff->state) {
-            case FILE_STATE_CLOSED:
-                fprintf(fp, "STATE:             CLOSED\n");
+    switch (ff->state) {
+        case FILE_STATE_CLOSED:
+            fprintf(fp, "STATE:             CLOSED\n");
 #ifdef HAVE_NSS
-                if (ff->flags & FILE_MD5) {
-                    fprintf(fp, "MD5:               ");
-                    size_t x;
-                    for (x = 0; x < sizeof(ff->md5); x++) {
-                        fprintf(fp, "%02x", ff->md5[x]);
-                    }
-                    fprintf(fp, "\n");
+            if (ff->flags & FILE_MD5) {
+                fprintf(fp, "MD5:               ");
+                size_t x;
+                for (x = 0; x < sizeof(ff->md5); x++) {
+                    fprintf(fp, "%02x", ff->md5[x]);
                 }
-                if (ff->flags & FILE_SHA1) {
-                    fprintf(fp, "SHA1:              ");
-                    size_t x;
-                    for (x = 0; x < sizeof(ff->sha1); x++) {
-                        fprintf(fp, "%02x", ff->sha1[x]);
-                    }
-                    fprintf(fp, "\n");
+                fprintf(fp, "\n");
+            }
+            if (ff->flags & FILE_SHA1) {
+                fprintf(fp, "SHA1:              ");
+                size_t x;
+                for (x = 0; x < sizeof(ff->sha1); x++) {
+                    fprintf(fp, "%02x", ff->sha1[x]);
                 }
-                if (ff->flags & FILE_SHA256) {
-                    fprintf(fp, "SHA256:            ");
-                    size_t x;
-                    for (x = 0; x < sizeof(ff->sha256); x++) {
-                        fprintf(fp, "%02x", ff->sha256[x]);
-                    }
-                    fprintf(fp, "\n");
+                fprintf(fp, "\n");
+            }
+            if (ff->flags & FILE_SHA256) {
+                fprintf(fp, "SHA256:            ");
+                size_t x;
+                for (x = 0; x < sizeof(ff->sha256); x++) {
+                    fprintf(fp, "%02x", ff->sha256[x]);
                 }
+                fprintf(fp, "\n");
+            }
 #endif
-                break;
-            case FILE_STATE_TRUNCATED:
-                fprintf(fp, "STATE:             TRUNCATED\n");
-                break;
-            case FILE_STATE_ERROR:
-                fprintf(fp, "STATE:             ERROR\n");
-                break;
-            default:
-                fprintf(fp, "STATE:             UNKNOWN\n");
-                break;
-        }
-        fprintf(fp, "SIZE:              %"PRIu64"\n", FileTrackedSize(ff));
+            break;
+        case FILE_STATE_TRUNCATED:
+            fprintf(fp, "STATE:             TRUNCATED\n");
+            break;
+        case FILE_STATE_ERROR:
+            fprintf(fp, "STATE:             ERROR\n");
+            break;
+        default:
+            fprintf(fp, "STATE:             UNKNOWN\n");
+            break;
+    }
+    fprintf(fp, "SIZE:              %"PRIu64"\n", FileTrackedSize(ff));
+    
+    fclose(fp);
+}
 
-        fclose(fp);
-    } else {
-        SCLogInfo("opening %s failed: %s", working_metafilename,
-                strerror(errno));
+static void PrintHexString(char *str, size_t size, uint8_t *buf, size_t buf_len)
+{
+    int i = 0;
+    size_t x = 0;
+    for (i = 0, x = 0; x < buf_len; x++) {
+        i += snprintf(&str[i], size - i, "%02x", buf[x]);
     }
 }
 
-static void LogFilestoreFinalizeFiles(const File *ff) {
-    char pid_expression[PATH_MAX] = "";
-    if (FileIncludePid())
-        snprintf(pid_expression, sizeof(pid_expression), ".%d", getpid());
+static void OutputFilestoreFinalizeFiles(const OutputFilestoreCtx *ctx,
+        File *ff) {
     char final_filename[PATH_MAX] = "";
-    snprintf(final_filename, sizeof(final_filename), "%s/file%s.%u",
-            g_logfile_base_dir, pid_expression, ff->file_store_id);
+    snprintf(final_filename, sizeof(final_filename), "%s/file.%u",
+            ctx->tmpdir, ff->file_store_id);
     char working_filename[PATH_MAX] = "";
-    snprintf(working_filename, sizeof(working_filename), "%s%s",
-            final_filename, g_working_file_suffix);
+    snprintf(working_filename, sizeof(working_filename), "%s",
+            final_filename);
+    char sha256string[(SHA256_LENGTH * 2) + 1];
+    PrintHexString(sha256string, sizeof(sha256string), ff->sha256,
+            sizeof(ff->sha256));
+    snprintf(final_filename, sizeof(final_filename), "%s/%c%c/%s",
+            ctx->prefix, sha256string[0], sha256string[1], sha256string);
     if (rename(working_filename, final_filename) != 0) {
         SCLogWarning(SC_WARN_RENAMING_FILE, "renaming file %s to %s failed",
                 working_filename, final_filename);
         return;
     }
-    if (FileWriteMeta()) {
-        LogFilestoreLogCloseMetaFile(ff);
-        char final_metafilename[PATH_MAX] = "";
-        snprintf(final_metafilename, sizeof(final_metafilename),
-                "%s.meta", final_filename);
-        char working_metafilename[PATH_MAX] = "";
-        snprintf(working_metafilename, sizeof(working_metafilename),
-                "%s%s", final_metafilename, g_working_file_suffix);
-        if (rename(working_metafilename, final_metafilename) != 0) {
-            SCLogWarning(SC_WARN_RENAMING_FILE,
-                    "renaming metafile %s to %s failed", working_metafilename,
-                    final_metafilename);
-        }
+
+    /* Write metadata. */
+    char final_metafilename[PATH_MAX] = "";
+    snprintf(final_metafilename, sizeof(final_metafilename),
+            "%s.meta", final_filename);
+    char working_metafilename[PATH_MAX] = "";
+    snprintf(working_metafilename, sizeof(working_metafilename),
+            "%s.meta", working_filename);
+    OutputFilestoreLogCloseMetaFile(ctx, ff, working_metafilename);
+    if (rename(working_metafilename, final_metafilename) != 0) {
+        SCLogWarning(SC_WARN_RENAMING_FILE,
+                "renaming metafile %s to %s failed", working_metafilename,
+                final_metafilename);
     }
 }
 
-static int LogFilestoreLogger(ThreadVars *tv, void *thread_data, const Packet *p,
-        File *ff, const uint8_t *data, uint32_t data_len, uint8_t flags)
+static int OutputFilestoreLogger(ThreadVars *tv, void *thread_data,
+        const Packet *p, File *ff, const uint8_t *data, uint32_t data_len,
+        uint8_t flags)
 {
     SCEnter();
-    LogFilestoreLogThread *aft = (LogFilestoreLogThread *)thread_data;
+    OutputFilestoreLogThread *aft = (OutputFilestoreLogThread *)thread_data;
+    OutputFilestoreCtx *ctx = aft->ctx;
     char filename[PATH_MAX] = "";
     int file_fd = -1;
     int ipver = -1;
@@ -415,33 +369,31 @@ static int LogFilestoreLogger(ThreadVars *tv, void *thread_data, const Packet *p
 
     SCLogDebug("ff %p, data %p, data_len %u", ff, data, data_len);
 
-    char pid_expression[PATH_MAX] = "";
-    if (FileIncludePid())
-        snprintf(pid_expression, sizeof(pid_expression), ".%d", getpid());
     char base_filename[PATH_MAX] = "";
-    snprintf(base_filename, sizeof(base_filename), "%s/file%s.%u",
-            g_logfile_base_dir, pid_expression, ff->file_store_id);
-    snprintf(filename, sizeof(filename), "%s%s", base_filename,
-            g_working_file_suffix);
+    snprintf(base_filename, sizeof(base_filename), "%s/file.%u",
+            ctx->tmpdir, ff->file_store_id);
+    snprintf(filename, sizeof(filename), "%s", base_filename);
 
     if (flags & OUTPUT_FILEDATA_FLAG_OPEN) {
         aft->file_cnt++;
 
         /* create a .meta file that contains time, src/dst/sp/dp/proto */
-        LogFilestoreLogCreateMetaFile(p, ff, base_filename, ipver);
+        OutputFilestoreLogCreateMetaFile(p, ff, base_filename, ipver);
 
         if (SC_ATOMIC_GET(filestore_open_file_cnt) < FileGetMaxOpenFiles()) {
             SC_ATOMIC_ADD(filestore_open_file_cnt, 1);
+            SCLogNotice("Opening %s.", filename);
             ff->fd = open(filename, O_CREAT | O_TRUNC | O_NOFOLLOW | O_WRONLY, 0644);
             if (ff->fd == -1) {
-                SCLogDebug("failed to create file");
+                SCLogNotice("failed to create file");
                 return -1;
             }
             file_fd = ff->fd;
         } else {
+            SCLogNotice("Opening %s.", filename);
             file_fd = open(filename, O_CREAT | O_TRUNC | O_NOFOLLOW | O_WRONLY, 0644);
             if (file_fd == -1) {
-                SCLogDebug("failed to create file");
+                SCLogNotice("failed to create file");
                 return -1;
             }
             if (FileGetMaxOpenFiles() > 0) {
@@ -451,9 +403,10 @@ static int LogFilestoreLogger(ThreadVars *tv, void *thread_data, const Packet *p
     /* we can get called with a NULL ffd when we need to close */
     } else if (data != NULL) {
         if (ff->fd == -1) {
+            SCLogNotice("Opening %s.", filename);
             file_fd = open(filename, O_APPEND | O_NOFOLLOW | O_WRONLY);
             if (file_fd == -1) {
-                SCLogDebug("failed to open file %s: %s", filename, strerror(errno));
+                SCLogNotice("failed to open file %s: %s", filename, strerror(errno));
                 return -1;
             }
         } else {
@@ -481,18 +434,19 @@ static int LogFilestoreLogger(ThreadVars *tv, void *thread_data, const Packet *p
             ff->fd = -1;
             SC_ATOMIC_SUB(filestore_open_file_cnt, 1);
         }
-        LogFilestoreFinalizeFiles(ff);
+        OutputFilestoreFinalizeFiles(ctx, ff);
     }
 
     return 0;
 }
 
-static TmEcode LogFilestoreLogThreadInit(ThreadVars *t, const void *initdata, void **data)
+static TmEcode OutputFilestoreLogThreadInit(ThreadVars *t, const void *initdata,
+        void **data)
 {
-    LogFilestoreLogThread *aft = SCMalloc(sizeof(LogFilestoreLogThread));
+    OutputFilestoreLogThread *aft = SCMalloc(sizeof(OutputFilestoreLogThread));
     if (unlikely(aft == NULL))
         return TM_ECODE_FAILED;
-    memset(aft, 0, sizeof(LogFilestoreLogThread));
+    memset(aft, 0, sizeof(OutputFilestoreLogThread));
 
     if (initdata == NULL)
     {
@@ -501,51 +455,33 @@ static TmEcode LogFilestoreLogThreadInit(ThreadVars *t, const void *initdata, vo
         return TM_ECODE_FAILED;
     }
 
-    /* Use the Ouptut Context (file pointer and mutex) */
-    aft->file_ctx = ((OutputCtx *)initdata)->data;
+    OutputFilestoreCtx *ctx = ((OutputCtx *)initdata)->data;
+    aft->ctx = ctx;
 
-    struct stat stat_buf;
-    if (stat(g_logfile_base_dir, &stat_buf) != 0) {
-        int ret;
-        ret = SCMkDir(g_logfile_base_dir, S_IRWXU|S_IXGRP|S_IRGRP);
-        if (ret != 0) {
-            int err = errno;
-            if (err != EEXIST) {
-                SCLogError(SC_ERR_LOGDIR_CONFIG,
-                        "Cannot create file drop directory %s: %s",
-                        g_logfile_base_dir, strerror(err));
-                exit(EXIT_FAILURE);
-            }
-        } else {
-            SCLogInfo("Created file drop directory %s",
-                    g_logfile_base_dir);
-        }
-
-    }
-
-    aft->counter_max_hits = StatsRegisterCounter("file_store.open_files_max_hit", t);
+    aft->counter_max_hits =
+        StatsRegisterCounter("file_store.open_files_max_hit", t);
 
     *data = (void *)aft;
     return TM_ECODE_OK;
 }
 
-static TmEcode LogFilestoreLogThreadDeinit(ThreadVars *t, void *data)
+static TmEcode OutputFilestoreLogThreadDeinit(ThreadVars *t, void *data)
 {
-    LogFilestoreLogThread *aft = (LogFilestoreLogThread *)data;
+    OutputFilestoreLogThread *aft = (OutputFilestoreLogThread *)data;
     if (aft == NULL) {
         return TM_ECODE_OK;
     }
 
     /* clear memory */
-    memset(aft, 0, sizeof(LogFilestoreLogThread));
+    memset(aft, 0, sizeof(OutputFilestoreLogThread));
 
     SCFree(aft);
     return TM_ECODE_OK;
 }
 
-static void LogFilestoreLogExitPrintStats(ThreadVars *tv, void *data)
+static void OutputFilestoreLogExitPrintStats(ThreadVars *tv, void *data)
 {
-    LogFilestoreLogThread *aft = (LogFilestoreLogThread *)data;
+    OutputFilestoreLogThread *aft = (OutputFilestoreLogThread *)data;
     if (aft == NULL) {
         return;
     }
@@ -553,63 +489,107 @@ static void LogFilestoreLogExitPrintStats(ThreadVars *tv, void *data)
     SCLogInfo("(%s) Files extracted %" PRIu32 "", tv->name, aft->file_cnt);
 }
 
-/**
- *  \internal
- *
- *  \brief deinit the log ctx and write out the waldo
- *
- *  \param output_ctx output context to deinit
- */
-static void LogFilestoreLogDeInitCtx(OutputCtx *output_ctx)
+static void OutputFilestoreLogDeInitCtx(OutputCtx *output_ctx)
 {
-    LogFileCtx *logfile_ctx = (LogFileCtx *)output_ctx->data;
-    LogFileFreeCtx(logfile_ctx);
+    OutputFilestoreCtx *ctx = (OutputFilestoreCtx *)output_ctx->data;
+    SCFree(ctx);
     SCFree(output_ctx);
-
 }
 
-/** \brief Create a new http log LogFilestoreCtx.
- *  \param conf Pointer to ConfNode containing this loggers configuration.
- *  \return NULL if failure, LogFilestoreCtx* to the file_ctx if succesful
- * */
-static OutputInitResult LogFilestoreLogInitCtx(ConfNode *conf)
+static void GetLogDirectory(const ConfNode *conf, char *out, size_t out_size)
 {
-    OutputInitResult result = { NULL, false };
+    const char *log_base_dir = ConfNodeLookupChildValue(conf, "dir");
+    if (log_base_dir == NULL) {
+        SCLogNotice("Using default log directory %s", default_log_dir);
+        log_base_dir = default_log_dir;
+    }
+    if (PathIsAbsolute(log_base_dir)) {
+        strlcpy(out, log_base_dir, out_size);
+    } else {
+        const char *default_log_prefix = ConfigGetLogDirectory();
+        snprintf(out, out_size, "%s/%s", default_log_prefix, log_base_dir);
+    }
+}
 
-    intmax_t version = 0;
-    if (ConfGetChildValueInt(conf, "version", &version)) {
-        if (version > 1) {
-            result.ok = true;
-            return result;
+static bool InitFilestoreDirectory(const char *dir)
+{
+    const uint8_t dir_count = 0xff;
+
+    if (!SCPathExists(dir)) {
+        SCLogNotice("Creating directory %s", dir);
+        if (SCCreateDirectoryTree(dir, true) != 0) {
+            SCLogError(SC_ERR_CREATE_DIRECTORY,
+                    "Failed to create directory %s: %s", dir, strerror(errno));
+            return false;
         }
     }
+
+    for (int i = 0; i <= dir_count; i++) {
+        char leaf[PATH_MAX];
+        snprintf(leaf, sizeof(leaf) - 1, "%s/%02x", dir, i);
+        if (!SCPathExists(leaf)) {
+            SCLogNotice("Creating directory %s", leaf);
+            if (SCDefaultMkDir(leaf) != 0) {
+                SCLogError(SC_ERR_CREATE_DIRECTORY,
+                        "Failed to create directory %s: %s", leaf,
+                        strerror(errno));
+                return false;
+            }
+        }
+    }
+
+    /* Make sure the tmp directory exists. */
+    char tmpdir[PATH_MAX];
+    snprintf(tmpdir, sizeof(tmpdir) - 1, "%s/tmp", dir);
+    if (!SCPathExists(tmpdir)) {
+        SCLogNotice("Creating directory %s", tmpdir);
+        if (SCDefaultMkDir(tmpdir) != 0) {
+            SCLogError(SC_ERR_CREATE_DIRECTORY,
+                    "Failed to create directory %s: %s", tmpdir,
+                    strerror(errno));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/** \brief Create a new http log OutputFilestoreCtx.
+ *  \param conf Pointer to ConfNode containing this loggers configuration.
+ *  \return NULL if failure, OutputFilestoreCtx* to the file_ctx if succesful
+ * */
+static OutputCtx *OutputFilestoreLogInitCtx(ConfNode *conf)
+{
+    intmax_t version = 0;
+    if (!ConfGetChildValueInt(conf, "version", &version)) {
+        return NULL;
+    }
+    if (version < 2) {
+        return NULL;
+    }
+
+    char log_directory[PATH_MAX] = "";
+    GetLogDirectory(conf, log_directory, sizeof(log_directory));
+    if (!InitFilestoreDirectory(log_directory)) {
+        return NULL;
+    }
+
+    OutputFilestoreCtx *ctx = SCCalloc(1, sizeof(*ctx));
+    if (unlikely(ctx == NULL)) {
+        return NULL;
+    }
+    strlcpy(ctx->prefix, log_directory, sizeof(ctx->prefix));
+    snprintf(ctx->tmpdir, sizeof(ctx->tmpdir) - 1, "%s/tmp", log_directory);
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL))
-        return result;
+        return NULL;
 
-    output_ctx->data = NULL;
-    output_ctx->DeInit = LogFilestoreLogDeInitCtx;
+    output_ctx->data = ctx;
+    output_ctx->DeInit = OutputFilestoreLogDeInitCtx;
 
-    const char *s_default_log_dir = NULL;
-    s_default_log_dir = ConfigGetLogDirectory();
-
-    const char *s_base_dir = NULL;
-    s_base_dir = ConfNodeLookupChildValue(conf, "log-dir");
-    if (s_base_dir == NULL || strlen(s_base_dir) == 0) {
-        strlcpy(g_logfile_base_dir,
-                s_default_log_dir, sizeof(g_logfile_base_dir));
-    } else {
-        if (PathIsAbsolute(s_base_dir)) {
-            strlcpy(g_logfile_base_dir,
-                    s_base_dir, sizeof(g_logfile_base_dir));
-        } else {
-            snprintf(g_logfile_base_dir, sizeof(g_logfile_base_dir),
-                    "%s/%s", s_default_log_dir, s_base_dir);
-        }
-    }
-
-    const char *force_filestore = ConfNodeLookupChildValue(conf, "force-filestore");
+    const char *force_filestore = ConfNodeLookupChildValue(conf,
+            "force-filestore");
     if (force_filestore != NULL && ConfValIsTrue(force_filestore)) {
         FileForceFilestoreEnable();
         SCLogInfo("forcing filestore of all files");
@@ -621,16 +601,15 @@ static OutputInitResult LogFilestoreLogInitCtx(ConfNode *conf)
         SCLogInfo("forcing magic lookup for stored files");
     }
 
-    const char *write_meta = ConfNodeLookupChildValue(conf, "write-meta");
-    if (write_meta != NULL && !ConfValIsTrue(write_meta)) {
-        FileWriteMetaDisable();
-        SCLogInfo("File-store output will not write meta files");
-    }
-
     FileForceHashParseCfg(conf);
-    SCLogInfo("storing files in %s", g_logfile_base_dir);
 
-    const char *stream_depth_str = ConfNodeLookupChildValue(conf, "stream-depth");
+    /* The new filestore requires SHA256. */
+    FileForceSha256Enable();
+
+    SCLogInfo("storing files in %s", ctx->prefix);
+
+    const char *stream_depth_str = ConfNodeLookupChildValue(conf,
+            "stream-depth");
     if (stream_depth_str != NULL && strcmp(stream_depth_str, "no")) {
         uint32_t stream_depth = 0;
         if (ParseSizeStringU32(stream_depth_str,
@@ -645,7 +624,8 @@ static OutputInitResult LogFilestoreLogInitCtx(ConfNode *conf)
         }
     }
 
-    const char *file_count_str = ConfNodeLookupChildValue(conf, "max-open-files");
+    const char *file_count_str = ConfNodeLookupChildValue(conf,
+            "max-open-files");
     if (file_count_str != NULL) {
         uint32_t file_count = 0;
         if (ParseSizeStringU32(file_count_str,
@@ -664,34 +644,29 @@ static OutputInitResult LogFilestoreLogInitCtx(ConfNode *conf)
         }
     }
 
-    const char *include_pid = ConfNodeLookupChildValue(conf, "include-pid");
-    if (include_pid != NULL && ConfValIsTrue(include_pid)) {
-        FileIncludePidEnable();
-        SCLogInfo("enabling pid as a part of all file names");
-    }
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    SCReturnCT(result, "OutputInitResult");
+    SCReturnPtr(output_ctx, "OutputCtx");
 }
 
+#endif /* HAVE_NSS */
 
-void LogFilestoreInitConfig(void)
+void OutputFilestoreInitConfig(void)
 {
-    StatsRegisterGlobalCounter("file_store.open_files", LogFilestoreOpenFilesCounter);
+#ifdef HAVE_NSS
+    StatsRegisterGlobalCounter("file_store.open_files",
+            OutputFilestoreOpenFilesCounter);
+#endif /* HAVE_NSS */
 }
 
-
-void LogFilestoreRegister (void)
+void OutputFilestoreRegister (void)
 {
-    OutputRegisterFiledataModule(LOGGER_FILE_STORE, MODULE_NAME, "file",
-        LogFilestoreLogInitCtx, LogFilestoreLogger, LogFilestoreLogThreadInit,
-        LogFilestoreLogThreadDeinit, LogFilestoreLogExitPrintStats);
+#ifdef HAVE_NSS
     OutputRegisterFiledataModule(LOGGER_FILE_STORE, MODULE_NAME, "file-store",
-        LogFilestoreLogInitCtx, LogFilestoreLogger, LogFilestoreLogThreadInit,
-        LogFilestoreLogThreadDeinit, LogFilestoreLogExitPrintStats);
+            OutputFilestoreLogInitCtx, OutputFilestoreLogger,
+            OutputFilestoreLogThreadInit, OutputFilestoreLogThreadDeinit,
+            OutputFilestoreLogExitPrintStats);
 
     SC_ATOMIC_INIT(filestore_open_file_cnt);
     SC_ATOMIC_SET(filestore_open_file_cnt, 0);
     SCLogDebug("registered");
+#endif
 }

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -57,7 +57,19 @@ typedef struct OutputFilestoreLogThread_ {
     OutputFilestoreCtx *ctx;
     uint32_t file_cnt;
     uint16_t counter_max_hits;
+    uint16_t fs_error_counter;
 } OutputFilestoreLogThread;
+
+/* For WARN_ONCE, a record of warnings that have already been
+ * issued. */
+static __thread bool once_errs[SC_ERR_MAX];
+
+#define WARN_ONCE(err_code, ...)  do {                   \
+        if (!once_errs[err_code]) {                      \
+            once_errs[err_code] = true;                  \
+            SCLogWarning(err_code, __VA_ARGS__);         \
+        }                                                \
+    } while (0)
 
 static uint64_t OutputFilestoreOpenFilesCounter(void)
 {
@@ -110,7 +122,8 @@ static void OutputFilestoreUpdateFileTime(const char *src_filename,
     }
 }
 
-static void OutputFilestoreFinalizeFiles(const OutputFilestoreCtx *ctx,
+static void OutputFilestoreFinalizeFiles(ThreadVars *tv,
+        const OutputFilestoreLogThread *oft, const OutputFilestoreCtx *ctx,
         const Packet *p, File *ff) {
     /* Stringify the SHA256 which will be used in the final
      * filename. */
@@ -129,17 +142,19 @@ static void OutputFilestoreFinalizeFiles(const OutputFilestoreCtx *ctx,
     if (SCPathExists(final_filename)) {
         OutputFilestoreUpdateFileTime(tmp_filename, final_filename);
         if (unlink(tmp_filename) != 0) {
-            SCLogWarning(SC_WARN_REMOVE_FILE,
+            StatsIncr(tv, oft->fs_error_counter);
+            WARN_ONCE(SC_WARN_REMOVE_FILE,
                     "Failed to remove temporary file %s: %s", tmp_filename,
                     strerror(errno));
         }
     } else if (rename(tmp_filename, final_filename) != 0) {
-        SCLogWarning(SC_WARN_RENAMING_FILE, "Failed to rename %s to %s: %s",
+        StatsIncr(tv, oft->fs_error_counter);
+        WARN_ONCE(SC_WARN_RENAMING_FILE, "Failed to rename %s to %s: %s",
                 tmp_filename, final_filename, strerror(errno));
         if (unlink(tmp_filename) != 0) {
-            SCLogWarning(SC_WARN_REMOVE_FILE,
-                    "Failed to remove temporary file %s: %s", tmp_filename,
-                    strerror(errno));
+            /* Just increment, don't log as has_fs_errors would
+             * already be set above. */
+            StatsIncr(tv, oft->fs_error_counter);
         }
         return;
     }
@@ -188,20 +203,20 @@ static int OutputFilestoreLogger(ThreadVars *tv, void *thread_data,
     if (flags & OUTPUT_FILEDATA_FLAG_OPEN) {
         aft->file_cnt++;
 
+        file_fd = open(filename, O_CREAT | O_TRUNC | O_NOFOLLOW | O_WRONLY,
+                0644);
+        if (file_fd == -1) {
+            StatsIncr(tv, aft->fs_error_counter);
+            SCLogWarning(SC_ERR_OPENING_FILE,
+                    "Filestore (v2) failed to create %s: %s", filename,
+                    strerror(errno));
+            return -1;
+        }
+
         if (SC_ATOMIC_GET(filestore_open_file_cnt) < FileGetMaxOpenFiles()) {
             SC_ATOMIC_ADD(filestore_open_file_cnt, 1);
-            ff->fd = open(filename, O_CREAT | O_TRUNC | O_NOFOLLOW | O_WRONLY, 0644);
-            if (ff->fd == -1) {
-                SCLogNotice("failed to create file");
-                return -1;
-            }
-            file_fd = ff->fd;
+            ff->fd = file_fd;
         } else {
-            file_fd = open(filename, O_CREAT | O_TRUNC | O_NOFOLLOW | O_WRONLY, 0644);
-            if (file_fd == -1) {
-                SCLogNotice("failed to create file");
-                return -1;
-            }
             if (FileGetMaxOpenFiles() > 0) {
                 StatsIncr(tv, aft->counter_max_hits);
             }
@@ -211,7 +226,10 @@ static int OutputFilestoreLogger(ThreadVars *tv, void *thread_data,
         if (ff->fd == -1) {
             file_fd = open(filename, O_APPEND | O_NOFOLLOW | O_WRONLY);
             if (file_fd == -1) {
-                SCLogNotice("failed to open file %s: %s", filename, strerror(errno));
+                StatsIncr(tv, aft->fs_error_counter);
+                WARN_ONCE(SC_ERR_OPENING_FILE,
+                        "Filestore (v2) failed to open file %s: %s",
+                        filename, strerror(errno));
                 return -1;
             }
         } else {
@@ -222,7 +240,10 @@ static int OutputFilestoreLogger(ThreadVars *tv, void *thread_data,
     if (file_fd != -1) {
         ssize_t r = write(file_fd, (const void *)data, (size_t)data_len);
         if (r == -1) {
-            SCLogDebug("write failed: %s", strerror(errno));
+            StatsIncr(tv, aft->fs_error_counter);
+            WARN_ONCE(SC_ERR_FWRITE,
+                    "Filestore (v2) failed to write to %s: %s",
+                    filename, strerror(errno));
             if (ff->fd != -1) {
                 SC_ATOMIC_SUB(filestore_open_file_cnt, 1);
             }
@@ -239,7 +260,7 @@ static int OutputFilestoreLogger(ThreadVars *tv, void *thread_data,
             ff->fd = -1;
             SC_ATOMIC_SUB(filestore_open_file_cnt, 1);
         }
-        OutputFilestoreFinalizeFiles(ctx, p, ff);
+        OutputFilestoreFinalizeFiles(tv, aft, ctx, p, ff);
     }
 
     return 0;
@@ -264,6 +285,11 @@ static TmEcode OutputFilestoreLogThreadInit(ThreadVars *t, const void *initdata,
 
     aft->counter_max_hits =
         StatsRegisterCounter("file_store.open_files_max_hit", t);
+
+    /* File system type errors (open, write, rename) will only be
+     * logged once. But this stat will be incremented for every
+     * occurence. */
+    aft->fs_error_counter = StatsRegisterCounter("file_store.fs_errors", t);
 
     *data = (void *)aft;
     return TM_ECODE_OK;
@@ -481,6 +507,5 @@ void OutputFilestoreRegister(void)
 
     SC_ATOMIC_INIT(filestore_open_file_cnt);
     SC_ATOMIC_SET(filestore_open_file_cnt, 0);
-    SCLogDebug("registered");
 #endif
 }

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -399,6 +399,13 @@ static OutputInitResult OutputFilestoreLogInitCtx(ConfNode *conf)
         return result;
     }
 
+    if (RunModeOutputFiledataEnabled()) {
+        SCLogWarning(SC_ERR_NOT_SUPPORTED,
+                "A file data logger is already enabled. Filestore (v2) "
+                "will not be enabled.");
+        return result;
+    }
+
     char log_directory[PATH_MAX] = "";
     GetLogDirectory(conf, log_directory, sizeof(log_directory));
     if (!InitFilestoreDirectory(log_directory)) {

--- a/src/output-filestore.h
+++ b/src/output-filestore.h
@@ -1,0 +1,24 @@
+/* Copyright (C) 2018 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef __OUTPUT_FILESTORE_H__
+#define __OUTPUT_FILESTORE_H__
+
+void OutputFilestoreRegister(void);
+void OutputFilestoreInitConfig(void);
+
+#endif /* __OUTPUT_FILESTORE_H__ */

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -362,20 +362,21 @@ static void OutputDNP3LogDeInitCtxSub(OutputCtx *output_ctx)
 
 #define DEFAULT_LOG_FILENAME "dnp3.json"
 
-static OutputCtx *OutputDNP3LogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
+static OutputInitResult OutputDNP3LogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
+    OutputInitResult result = { NULL, false };
     OutputJsonCtx *ajt = parent_ctx->data;
 
     LogDNP3FileCtx *dnp3log_ctx = SCCalloc(1, sizeof(*dnp3log_ctx));
     if (unlikely(dnp3log_ctx == NULL)) {
-        return NULL;
+        return result;
     }
     dnp3log_ctx->file_ctx = ajt->file_ctx;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {
         SCFree(dnp3log_ctx);
-        return NULL;
+        return result;
     }
     output_ctx->data = dnp3log_ctx;
     output_ctx->DeInit = OutputDNP3LogDeInitCtxSub;
@@ -384,7 +385,9 @@ static OutputCtx *OutputDNP3LogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_DNP3);
 
-    return output_ctx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
 }
 
 #define OUTPUT_BUFFER_SIZE 65535

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -851,13 +851,14 @@ static void JsonDnsLogInitFilters(LogDnsFileCtx *dnslog_ctx, ConfNode *conf)
     }
 }
 
-static OutputCtx *JsonDnsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
+static OutputInitResult JsonDnsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
+    OutputInitResult result = { NULL, false };
     OutputJsonCtx *ojc = parent_ctx->data;
 
     LogDnsFileCtx *dnslog_ctx = SCMalloc(sizeof(LogDnsFileCtx));
     if (unlikely(dnslog_ctx == NULL)) {
-        return NULL;
+        return result;
     }
     memset(dnslog_ctx, 0x00, sizeof(LogDnsFileCtx));
 
@@ -866,7 +867,7 @@ static OutputCtx *JsonDnsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {
         SCFree(dnslog_ctx);
-        return NULL;
+        return result;
     }
 
     output_ctx->data = dnslog_ctx;
@@ -879,7 +880,9 @@ static OutputCtx *JsonDnsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
     AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_DNS);
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_DNS);
 
-    return output_ctx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
 }
 
 #define DEFAULT_LOG_FILENAME "dns.json"
@@ -887,24 +890,25 @@ static OutputCtx *JsonDnsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
  *  \param conf Pointer to ConfNode containing this loggers configuration.
  *  \return NULL if failure, LogFileCtx* to the file_ctx if succesful
  * */
-static OutputCtx *JsonDnsLogInitCtx(ConfNode *conf)
+static OutputInitResult JsonDnsLogInitCtx(ConfNode *conf)
 {
+    OutputInitResult result = { NULL, false };
     LogFileCtx *file_ctx = LogFileNewCtx();
 
     if(file_ctx == NULL) {
         SCLogError(SC_ERR_DNS_LOG_GENERIC, "couldn't create new file_ctx");
-        return NULL;
+        return result;
     }
 
     if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
-        return NULL;
+        return result;
     }
 
     LogDnsFileCtx *dnslog_ctx = SCMalloc(sizeof(LogDnsFileCtx));
     if (unlikely(dnslog_ctx == NULL)) {
         LogFileFreeCtx(file_ctx);
-        return NULL;
+        return result;
     }
     memset(dnslog_ctx, 0x00, sizeof(LogDnsFileCtx));
 
@@ -914,7 +918,7 @@ static OutputCtx *JsonDnsLogInitCtx(ConfNode *conf)
     if (unlikely(output_ctx == NULL)) {
         LogFileFreeCtx(file_ctx);
         SCFree(dnslog_ctx);
-        return NULL;
+        return result;
     }
 
     output_ctx->data = dnslog_ctx;
@@ -927,7 +931,9 @@ static OutputCtx *JsonDnsLogInitCtx(ConfNode *conf)
     AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_DNS);
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_DNS);
 
-    return output_ctx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
 }
 
 

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -78,19 +78,12 @@ typedef struct JsonFileLogThread_ {
     MemBuffer *buffer;
 } JsonFileLogThread;
 
-/**
- *  \internal
- *  \brief Write meta data on a single line json record
- */
-static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const File *ff)
+json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff)
 {
     json_t *js = CreateJSONHeader((Packet *)p, 0, "fileinfo"); //TODO const
     json_t *hjs = NULL;
     if (unlikely(js == NULL))
-        return;
-
-    /* reset */
-    MemBufferReset(aft->buffer);
+        return NULL;
 
     switch (p->flow->alproto) {
         case ALPROTO_HTTP:
@@ -124,7 +117,7 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
     json_t *fjs = json_object();
     if (unlikely(fjs == NULL)) {
         json_decref(js);
-        return;
+        return NULL;
     }
 
     char *s = BytesToString(ff->name, ff->name_len);
@@ -158,15 +151,6 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
                 }
                 json_object_set_new(fjs, "sha1", json_string(str));
             }
-            if (ff->flags & FILE_SHA256) {
-                size_t x;
-                int i;
-                char str[256];
-                for (i = 0, x = 0; x < sizeof(ff->sha256); x++) {
-                    i += snprintf(&str[i], 255-i, "%02x", ff->sha256[x]);
-                }
-                json_object_set_new(fjs, "sha256", json_string(str));
-            }
 #endif
             break;
         case FILE_STATE_TRUNCATED:
@@ -179,6 +163,19 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
             json_object_set_new(fjs, "state", json_string("UNKNOWN"));
             break;
     }
+
+#ifdef HAVE_NSS
+    if (ff->flags & FILE_SHA256) {
+        size_t x;
+        int i;
+        char str[256];
+        for (i = 0, x = 0; x < sizeof(ff->sha256); x++) {
+            i += snprintf(&str[i], 255-i, "%02x", ff->sha256[x]);
+        }
+        json_object_set_new(fjs, "sha256", json_string(str));
+    }
+#endif
+
     json_object_set_new(fjs, "stored",
                         (ff->flags & FILE_STORED) ? json_true() : json_false());
     if (ff->flags & FILE_STORED) {
@@ -189,20 +186,23 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
 
     /* originally just 'file', but due to bug 1127 naming it fileinfo */
     json_object_set_new(js, "fileinfo", fjs);
-    OutputJSONBuffer(js, aft->filelog_ctx->file_ctx, &aft->buffer);
-    json_object_del(js, "fileinfo");
 
-    switch (p->flow->alproto) {
-        case ALPROTO_HTTP:
-            json_object_del(js, "http");
-            break;
-        case ALPROTO_SMTP:
-            json_object_del(js, "smtp");
-            json_object_del(js, "email");
-            break;
+    return js;
+}
+
+/**
+ *  \internal
+ *  \brief Write meta data on a single line json record
+ */
+static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const File *ff)
+{
+    json_t *js = JsonBuildFileInfoRecord(p, ff);
+    if (unlikely(js == NULL)) {
+        return;
     }
 
-    json_object_clear(js);
+    MemBufferReset(aft->buffer);
+    OutputJSONBuffer(js, aft->filelog_ctx->file_ctx, &aft->buffer);
     json_decref(js);
 }
 

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -274,18 +274,19 @@ static void OutputFileLogDeinitSub(OutputCtx *output_ctx)
  *  \param conf Pointer to ConfNode containing this loggers configuration.
  *  \return NULL if failure, LogFileCtx* to the file_ctx if succesful
  * */
-static OutputCtx *OutputFileLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
+static OutputInitResult OutputFileLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
+    OutputInitResult result = { NULL, false };
     OutputJsonCtx *ojc = parent_ctx->data;
 
     OutputFileCtx *output_file_ctx = SCMalloc(sizeof(OutputFileCtx));
     if (unlikely(output_file_ctx == NULL))
-        return NULL;
+        return result;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {
         SCFree(output_file_ctx);
-        return NULL;
+        return result;
     }
 
     output_file_ctx->file_ctx = ojc->file_ctx;
@@ -310,7 +311,9 @@ static OutputCtx *OutputFileLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
     output_ctx->DeInit = OutputFileLogDeinitSub;
 
     FileForceTrackingEnable();
-    return output_ctx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
 }
 
 void JsonFileLogRegister (void)

--- a/src/output-json-file.h
+++ b/src/output-json-file.h
@@ -26,4 +26,8 @@
 
 void JsonFileLogRegister(void);
 
+#ifdef HAVE_LIBJANSSON
+json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff);
+#endif
+
 #endif /* __OUTPUT_JSON_FILE_H__ */

--- a/src/output-json-nfs.c
+++ b/src/output-json-nfs.c
@@ -133,21 +133,22 @@ static void OutputNFSLogDeInitCtxSub(OutputCtx *output_ctx)
     SCFree(output_ctx);
 }
 
-static OutputCtx *OutputNFSLogInitSub(ConfNode *conf,
+static OutputInitResult OutputNFSLogInitSub(ConfNode *conf,
     OutputCtx *parent_ctx)
 {
+    OutputInitResult result = { NULL, false };
     OutputJsonCtx *ajt = parent_ctx->data;
 
     LogNFSFileCtx *nfslog_ctx = SCCalloc(1, sizeof(*nfslog_ctx));
     if (unlikely(nfslog_ctx == NULL)) {
-        return NULL;
+        return result;
     }
     nfslog_ctx->file_ctx = ajt->file_ctx;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {
         SCFree(nfslog_ctx);
-        return NULL;
+        return result;
     }
     output_ctx->data = nfslog_ctx;
     output_ctx->DeInit = OutputNFSLogDeInitCtxSub;
@@ -157,7 +158,9 @@ static OutputCtx *OutputNFSLogInitSub(ConfNode *conf,
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_NFS);
     AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_NFS);
 
-    return output_ctx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
 }
 
 #define OUTPUT_BUFFER_SIZE 65535

--- a/src/output-json-template.c
+++ b/src/output-json-template.c
@@ -122,21 +122,22 @@ static void OutputTemplateLogDeInitCtxSub(OutputCtx *output_ctx)
     SCFree(output_ctx);
 }
 
-static OutputCtx *OutputTemplateLogInitSub(ConfNode *conf,
+static OutputInitResult OutputTemplateLogInitSub(ConfNode *conf,
     OutputCtx *parent_ctx)
 {
+    OutputInitResult result = { NULL, false };
     OutputJsonCtx *ajt = parent_ctx->data;
 
     LogTemplateFileCtx *templatelog_ctx = SCCalloc(1, sizeof(*templatelog_ctx));
     if (unlikely(templatelog_ctx == NULL)) {
-        return NULL;
+        return result;
     }
     templatelog_ctx->file_ctx = ajt->file_ctx;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {
         SCFree(templatelog_ctx);
-        return NULL;
+        return result;
     }
     output_ctx->data = templatelog_ctx;
     output_ctx->DeInit = OutputTemplateLogDeInitCtxSub;
@@ -145,7 +146,9 @@ static OutputCtx *OutputTemplateLogInitSub(ConfNode *conf,
 
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_TEMPLATE);
 
-    return output_ctx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
 }
 
 #define OUTPUT_BUFFER_SIZE 65535

--- a/src/output-json-vars.c
+++ b/src/output-json-vars.c
@@ -184,31 +184,32 @@ static void JsonVarsLogDeInitCtxSub(OutputCtx *output_ctx)
  * \param conf The configuration node for this output.
  * \return A LogFileCtx pointer on success, NULL on failure.
  */
-static OutputCtx *JsonVarsLogInitCtx(ConfNode *conf)
+static OutputInitResult JsonVarsLogInitCtx(ConfNode *conf)
 {
+    OutputInitResult result = { NULL, false };
     VarsJsonOutputCtx *json_output_ctx = NULL;
     LogFileCtx *logfile_ctx = LogFileNewCtx();
     if (logfile_ctx == NULL) {
         SCLogDebug("VarsFastLogInitCtx2: Could not create new LogFileCtx");
-        return NULL;
+        return result;
     }
 
     if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(logfile_ctx);
-        return NULL;
+        return result;
     }
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {
         LogFileFreeCtx(logfile_ctx);
-        return NULL;
+        return result;
     }
 
     json_output_ctx = SCMalloc(sizeof(VarsJsonOutputCtx));
     if (unlikely(json_output_ctx == NULL)) {
         LogFileFreeCtx(logfile_ctx);
         SCFree(output_ctx);
-        return NULL;
+        return result;
     }
     memset(json_output_ctx, 0, sizeof(VarsJsonOutputCtx));
 
@@ -217,7 +218,9 @@ static OutputCtx *JsonVarsLogInitCtx(ConfNode *conf)
     output_ctx->data = json_output_ctx;
     output_ctx->DeInit = JsonVarsLogDeInitCtx;
 
-    return output_ctx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
 }
 
 /**
@@ -225,14 +228,15 @@ static OutputCtx *JsonVarsLogInitCtx(ConfNode *conf)
  * \param conf The configuration node for this output.
  * \return A LogFileCtx pointer on success, NULL on failure.
  */
-static OutputCtx *JsonVarsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
+static OutputInitResult JsonVarsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
+    OutputInitResult result = { NULL, false };
     OutputJsonCtx *ajt = parent_ctx->data;
     VarsJsonOutputCtx *json_output_ctx = NULL;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL))
-        return NULL;
+        return result;
 
     json_output_ctx = SCMalloc(sizeof(VarsJsonOutputCtx));
     if (unlikely(json_output_ctx == NULL)) {
@@ -245,7 +249,9 @@ static OutputCtx *JsonVarsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
     output_ctx->data = json_output_ctx;
     output_ctx->DeInit = JsonVarsLogDeInitCtxSub;
 
-    return output_ctx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
 
 error:
     if (json_output_ctx != NULL) {
@@ -255,7 +261,7 @@ error:
         SCFree(output_ctx);
     }
 
-    return NULL;
+    return result;
 }
 
 void JsonVarsLogRegister (void)

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -27,6 +27,7 @@
 #include "suricata-common.h"
 #include "util-buffer.h"
 #include "util-logopenfile.h"
+#include "output.h"
 
 void OutputJsonRegister(void);
 
@@ -46,7 +47,7 @@ void JsonFiveTuple(const Packet *, int, json_t *);
 json_t *CreateJSONHeader(const Packet *p, int direction_sensative, const char *event_type);
 json_t *CreateJSONHeaderWithTxId(const Packet *p, int direction_sensitive, const char *event_type, uint64_t tx_id);
 int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer);
-OutputCtx *OutputJsonInitCtx(ConfNode *);
+OutputInitResult OutputJsonInitCtx(ConfNode *);
 
 /*
  * Global configuration context data

--- a/src/output.c
+++ b/src/output.c
@@ -73,6 +73,7 @@
 #include "output-lua.h"
 #include "output-json-dnp3.h"
 #include "output-json-vars.h"
+#include "output-filestore.h"
 
 typedef struct RootLogger_ {
     ThreadInitFunc ThreadInit;
@@ -1066,6 +1067,7 @@ void OutputRegisterLoggers(void)
     LogFileLogRegister();
     JsonFileLogRegister();
     LogFilestoreRegister();
+    OutputFilestoreRegister();
     /* dns log */
     LogDnsLogRegister();
     JsonDnsLogRegister();

--- a/src/output.h
+++ b/src/output.h
@@ -38,8 +38,13 @@
 #include "output-streaming.h"
 #include "output-stats.h"
 
-typedef OutputCtx *(*OutputInitFunc)(ConfNode *);
-typedef OutputCtx *(*OutputInitSubFunc)(ConfNode *, OutputCtx *);
+typedef struct OutputInitResult_ {
+    OutputCtx *ctx;
+    bool ok;
+} OutputInitResult;
+
+typedef OutputInitResult (*OutputInitFunc)(ConfNode *);
+typedef OutputInitResult (*OutputInitSubFunc)(ConfNode *, OutputCtx *);
 typedef TmEcode (*OutputLogFunc)(ThreadVars *, Packet *, void *);
 
 typedef struct OutputModule_ {

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -37,8 +37,8 @@
 #include "conf.h"
 #include "runmodes.h"
 #include "runmode-af-packet.h"
-#include "log-httplog.h"
 #include "output.h"
+#include "log-httplog.h"
 #include "detect-engine-mpm.h"
 
 #include "alert-fastlog.h"

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -36,8 +36,8 @@
 #include "conf.h"
 #include "runmodes.h"
 #include "runmode-netmap.h"
-#include "log-httplog.h"
 #include "output.h"
+#include "log-httplog.h"
 #include "detect-engine-mpm.h"
 
 #include "alert-fastlog.h"

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -20,8 +20,8 @@
 #include "conf.h"
 #include "runmodes.h"
 #include "runmode-pcap.h"
-#include "log-httplog.h"
 #include "output.h"
+#include "log-httplog.h"
 
 #include "util-debug.h"
 #include "util-time.h"

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -367,12 +367,6 @@
 
 #define WARN_UNUSED __attribute__((warn_unused_result))
 
-#ifndef HAVE_NON_POSIX_MKDIR
-    #define SCMkDir(a, b) mkdir(a, b)
-#else
-    #define SCMkDir(a, b) mkdir(a)
-#endif
-
 #define SCNtohl(x) (uint32_t)ntohl((x))
 #define SCNtohs(x) (uint16_t)ntohs((x))
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -167,7 +167,6 @@
 #include "host-storage.h"
 
 #include "util-lua.h"
-#include "log-filestore.h"
 
 #ifdef HAVE_RUST
 #include "rust.h"
@@ -2206,7 +2205,6 @@ void PreRunInit(const int runmode)
     DefragInit();
     FlowInitConfig(FLOW_QUIET);
     IPPairInitConfig(FLOW_QUIET);
-    LogFilestoreInitConfig();
     StreamTcpInitConfig(STREAM_VERBOSE);
     AppLayerParserPostStreamSetup();
     AppLayerRegisterGlobalCounters();

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -345,6 +345,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_ERR_BYPASS_NOT_SUPPORTED);
         CASE_CODE (SC_WARN_RENAMING_FILE);
         CASE_CODE (SC_ERR_PF_RING_VLAN);
+        CASE_CODE (SC_ERR_CREATE_DIRECTORY);
     }
 
     return "UNKNOWN_ERROR";

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -346,6 +346,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_WARN_RENAMING_FILE);
         CASE_CODE (SC_ERR_PF_RING_VLAN);
         CASE_CODE (SC_ERR_CREATE_DIRECTORY);
+        CASE_CODE (SC_ERR_MAX);
     }
 
     return "UNKNOWN_ERROR";

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -336,6 +336,7 @@ typedef enum {
     SC_WARN_RENAMING_FILE,
     SC_ERR_PF_RING_VLAN,
     SC_ERR_CREATE_DIRECTORY,
+    SC_ERR_MAX,
 } SCError;
 
 const char *SCErrorToString(SCError);

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -335,6 +335,7 @@ typedef enum {
     SC_ERR_BYPASS_NOT_SUPPORTED,
     SC_WARN_RENAMING_FILE,
     SC_ERR_PF_RING_VLAN,
+    SC_ERR_CREATE_DIRECTORY,
 } SCError;
 
 const char *SCErrorToString(SCError);

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -267,7 +267,7 @@ SCLogOpenFileFp(const char *path, const char *append_setting, uint32_t mode)
         return NULL;
     }
 
-    int rc = SCCreateDirectoryTree(filename);
+    int rc = SCCreateDirectoryTree(filename, false);
     if (rc < 0) {
         SCFree(filename);
         return NULL;

--- a/src/util-path.c
+++ b/src/util-path.c
@@ -120,3 +120,20 @@ int SCCreateDirectoryTree(const char *path, const bool final)
 
     return 0;
 }
+
+/**
+ * \brief Check if a path exists.
+ *
+ * \param Path to check for existence
+ *
+ * \retval true if path exists
+ * \retval false if path does not exist
+ */
+bool SCPathExists(const char *path)
+{
+    struct stat sb;
+    if (stat(path, &sb) == 0) {
+        return true;
+    }
+    return false;
+}

--- a/src/util-path.c
+++ b/src/util-path.c
@@ -81,7 +81,7 @@ int SCCreateDirectoryTree(const char *path)
         return -1;
     }
 
-    strlcpy(pathbuf, path, len);
+    strlcpy(pathbuf, path, sizeof(pathbuf));
 
     for (p = pathbuf + 1; *p; p++) {
         if (*p == '/') {

--- a/src/util-path.c
+++ b/src/util-path.c
@@ -66,12 +66,24 @@ int PathIsRelative(const char *path)
     return PathIsAbsolute(path) ? 0 : 1;
 }
 
-/** \brief Recursively create missing log directories.
- *  \param path path to log file
- *  \retval 0 on success
- *  \retval -1 on error
+/**
+ * \brief Wrapper around SCMkDir with default mode arguments.
  */
-int SCCreateDirectoryTree(const char *path)
+int SCDefaultMkDir(const char *path)
+{
+    return SCMkDir(path, S_IRWXU | S_IRGRP | S_IXGRP);
+}
+
+/**
+ * \brief Recursively create a directory.
+ *
+ * \param path Path to create
+ * \param final true will create the final path component, false will not
+ *
+ * \retval 0 on success
+ * \retval -1 on error
+ */
+int SCCreateDirectoryTree(const char *path, const bool final)
 {
     char pathbuf[PATH_MAX];
     char *p;
@@ -88,13 +100,21 @@ int SCCreateDirectoryTree(const char *path)
             /* Truncate, while creating directory */
             *p = '\0';
 
-            if (SCMkDir(pathbuf, S_IRWXU | S_IRGRP | S_IXGRP) != 0) {
+            if (SCDefaultMkDir(pathbuf) != 0) {
                 if (errno != EEXIST) {
                     return -1;
                 }
             }
 
             *p = '/';
+        }
+    }
+
+    if (final) {
+        if (SCDefaultMkDir(pathbuf) != 0) {
+            if (errno != EEXIST) {
+                return -1;
+            }
         }
     }
 

--- a/src/util-path.h
+++ b/src/util-path.h
@@ -35,5 +35,6 @@ int PathIsAbsolute(const char *);
 int PathIsRelative(const char *);
 int SCDefaultMkDir(const char *path);
 int SCCreateDirectoryTree(const char *path, const bool final);
+bool SCPathExists(const char *path);
 
 #endif /* __UTIL_PATH_H__ */

--- a/src/util-path.h
+++ b/src/util-path.h
@@ -33,6 +33,7 @@
 
 int PathIsAbsolute(const char *);
 int PathIsRelative(const char *);
-int SCCreateDirectoryTree(const char *path);
+int SCDefaultMkDir(const char *path);
+int SCCreateDirectoryTree(const char *path, const bool final);
 
 #endif /* __UTIL_PATH_H__ */

--- a/src/util-path.h
+++ b/src/util-path.h
@@ -25,7 +25,14 @@
 #ifndef __UTIL_PATH_H__
 #define __UTIL_PATH_H__
 
+#ifndef HAVE_NON_POSIX_MKDIR
+    #define SCMkDir(a, b) mkdir(a, b)
+#else
+    #define SCMkDir(a, b) mkdir(a)
+#endif
+
 int PathIsAbsolute(const char *);
 int PathIsRelative(const char *);
+int SCCreateDirectoryTree(const char *path);
 
 #endif /* __UTIL_PATH_H__ */

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -30,8 +30,8 @@
 #include "conf.h"
 #include "runmodes.h"
 #include "runmode-af-packet.h"
-#include "log-httplog.h"
 #include "output.h"
+#include "log-httplog.h"
 
 #include "detect-engine.h"
 #include "detect-engine-mpm.h"

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -455,6 +455,13 @@ outputs:
       #max-open-files: 1000
       include-pid: no # set to yes to include pid in file names
 
+  - file-store:
+      version: 2
+      enabled: no
+
+      # Force storing of all files. Default: no.
+      #force-filestore: yes
+
   # output module to log files tracked in a easily parsable json format
   - file-log:
       enabled: no

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -421,7 +421,54 @@ outputs:
       append: yes
       #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
 
-  # output module to store extracted files to disk
+  # Output module for storing files on disk. Files are stored in a
+  # directory names consisting of the first 2 characaters of the
+  # SHA256 of the file. Each file is given its SHA256 as a filename.
+  #
+  # When a duplicate file is found, the existing file is touched to
+  # have its timestamps updated.
+  #
+  # Unlike the older filestore, metadata is not written out by default
+  # as each file should already have a "fileinfo" record in the
+  # eve.log. If write-fileinfo is set to yes, the each file will have
+  # one more associated .json files that consists of the fileinfo
+  # record. A fileinfo file will be written for each occurrence of the
+  # file seen using a filename suffix to ensure uniqueness.
+  #
+  # To prune the filestore directory see the "suricatactl filestore
+  # prune" command which can delete files over a certain age.
+  - file-store:
+      version: 2
+      enabled: no
+
+      # Set the directory for the filestore. If the path is not
+      # absolute will be be relative to the default-log-dir.
+      #dir: filestore
+
+      # Write out a fileinfo record for each occurrence of a
+      # file. Disabled by default as each occurrence is already logged
+      # as a fileinfo record to the main eve-log.
+      #write-fileinfo: yes
+
+      # Force storing of all files. Default: no.
+      #force-filestore: yes
+
+      # Override the global stream-depth for sessions in which we want
+      # to perform file extraction. Set to 0 for unlimited.
+      #stream-depth: 0
+
+      # Uncomment the following variable to define how many files can
+      # remain open for filestore by Suricata. Default value is 0 which
+      # means files get closed after each write
+      #max-open-files: 1000
+
+      # Force logging of checksums, available hash functions are md5,
+      # sha1 and sha256. Note that SHA256 is automatically forced by
+      # the use of this output module as it uses the SHA256 as the
+      # file naming scheme.
+      #force-hash: [sha1, md5]
+
+  # output module to store extracted files to disk (old style, deprecated)
   #
   # The files are stored to the log-dir in a format "file.<id>" where <id> is
   # an incrementing number starting at 1. For each file "file.<id>" a meta
@@ -454,13 +501,6 @@ outputs:
       # means files get closed after each write
       #max-open-files: 1000
       include-pid: no # set to yes to include pid in file names
-
-  - file-store:
-      version: 2
-      enabled: no
-
-      # Force storing of all files. Default: no.
-      #force-filestore: yes
 
   # output module to log files tracked in a easily parsable json format
   - file-log:


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Previous PR:
https://github.com/OISF/suricata/pull/3139

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2303

This PR introduces a new version of the filestore output to address the issues with the current one.

New directory layout:
```
.../filestore/00/
.../filestore/01/
...
.../filestore/ff/
.../filestore/tmp/
```

And files are named by their SHA256. Files in progress are stored in the tmp/ directory, then when completed are renamed into the directory that shares the first 2 characters of its SHA256 sum. If the file already exists its timestamps are updated. This layout provides depuplication of saved files and eliminates the need for "waldo" file.

As SHA256 is required, this module require libnss, and it will force SHA256 checksums. An additional change was made to even force the SHA256 if the file is not in a complete state, as we need this for the final filename.

Metadata is disabled by default as we already have the `fileinfo` records in the main eve-log. If `write-fileinfo` is enabled, then a `fileinfo` file will be written for each occurrence of the file. These files are named <SHA256>.<TV.TV_SEC>.<FILE_ID>.json. This is unique enough that each occurrence of the file will get its own fileinfo file, but subsequent runs over the same pcap should collide causing the file to be overwritten.

A new tool is also installed (provided Python is installed) name `suricatactl` provides a command for pruning the filestore. The idea is that more miscellaneous commands will be added over time.  Example usage:
```
suricatactl filestore prune --age 7d
```
which will remove all files from the filestore over 7 days old.

Known issues:
- The new filestore output is named output-filestore.c, which started as an exact copy of log-filestore.c then modified as required. Both filestores have the same configuration name and use the "version" field to determine if they should be enabled or not. Currently the output code handles a NULL returned from an output init function as an error, which is what the filestore init functions return if for a different version. I need a better way to handle this. They could simply have different names I suppose, like "file-store" and "file-store2" instead of adding a version field. Changing the configuration name would obviously change the filenames. 
- The idea without output-filestore.c was to start using a consistent naming scheme for loggers, as we currently use log-, output- and alert-. But then we also use output- for output support files that are not individual loggers.
- Nothing is done about files in tmp/ that may be left hanging due to an abnormal exit. I'm thinking of simply removing all existing files in tmp/ on startup.

Changes from last PR:
- Only allow one file-store to be registered at a time.
- Apply limits to logging of file system errors.
- Add a stat/counter for file system errors.
- Fix (most) issues from previous PR.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/252
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/605
