### PR TITLE
Filestore stream-depth fixes

### DIFF
--- a/doc/userguide/file-extraction/file-extraction.rst
+++ b/doc/userguide/file-extraction/file-extraction.rst
@@ -63,6 +63,15 @@ of the filename. For example, if the SHA256 hex string of an extracted
 file starts with "f9bc6d..." the file we be placed in the directory
 `filestore/f9`.
 
+The size of a file that can be stored depends on ``file-store.stream-depth``,
+if this value is reached a file can be truncated and not stored completely.
+If not enabled, ``strem.reassembly.depth`` will be considered.
+
+Setting ``file-store.stream-depth`` to 0 permits to store any files.
+
+A protocol parser, like modbus, could permit to set a different
+store-depth value and use it rather than ``file-store.stream-depth``.
+
 Using the SHA256 for file names allows for automatic de-duplication of
 extracted files. However, the timestamp of a pre-existing file will be
 updated if the same files is extracted again, similar to the `touch`

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -473,6 +473,14 @@ void AppLayerHtpNeedFileInspection(void)
     SCReturn;
 }
 
+void AppLayerHtpUseStreamDepth(htp_tx_t *tx)
+{
+    HtpTxUserData *tx_ud = (HtpTxUserData *) htp_tx_get_user_data(tx);
+    if (tx_ud) {
+        tx_ud->use_stream_depth = TRUE;
+    }
+}
+
 /* below error messages updated up to libhtp 0.5.7 (git 379632278b38b9a792183694a4febb9e0dbd1e7a) */
 struct {
     const char *msg;
@@ -1755,7 +1763,9 @@ static int HTPCallbackRequestBodyData(htp_tx_data_t *d)
     SCLogDebug("hstate->cfg->request.body_limit %u", hstate->cfg->request.body_limit);
 
     /* within limits, add the body chunk to the state. */
-    if (hstate->cfg->request.body_limit == 0 || tx_ud->request_body.content_len_so_far < hstate->cfg->request.body_limit)
+    if ((hstate->cfg->request.body_limit == 0 || tx_ud->request_body.content_len_so_far < hstate->cfg->request.body_limit) ||
+        (tx_ud->use_stream_depth && tx_ud->request_body.content_len_so_far < FileReassemblyDepth()) ||
+        (tx_ud->use_stream_depth && FileReassemblyDepth() == 0))
     {
         uint32_t len = (uint32_t)d->len;
 
@@ -1851,7 +1861,10 @@ static int HTPCallbackResponseBodyData(htp_tx_data_t *d)
     SCLogDebug("hstate->cfg->response.body_limit %u", hstate->cfg->response.body_limit);
 
     /* within limits, add the body chunk to the state. */
-    if (hstate->cfg->response.body_limit == 0 || tx_ud->response_body.content_len_so_far < hstate->cfg->response.body_limit)
+    if ((hstate->cfg->response.body_limit == 0 || tx_ud->response_body.content_len_so_far < hstate->cfg->response.body_limit) ||
+        (tx_ud->use_stream_depth && tx_ud->response_body.content_len_so_far < FileReassemblyDepth()) ||
+        (tx_ud->use_stream_depth && FileReassemblyDepth() == 0))
+
     {
         uint32_t len = (uint32_t)d->len;
 

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -229,6 +229,8 @@ typedef struct HtpTxUserData_ {
     uint8_t response_body_type;
 
     DetectEngineState *de_state;
+
+    bool use_stream_depth;
 } HtpTxUserData;
 
 typedef struct HtpState_ {
@@ -273,6 +275,7 @@ void AppLayerHtpEnableRequestBodyCallback(void);
 void AppLayerHtpEnableResponseBodyCallback(void);
 void AppLayerHtpNeedFileInspection(void);
 void AppLayerHtpPrintStats(void);
+void AppLayerHtpUseStreamDepth(htp_tx_t *tx);
 
 void HTPConfigure(void);
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -206,8 +206,11 @@ void AppLayerParserPostStreamSetup(void)
     /* lets set a default value for stream_depth */
     for (flow_proto = 0; flow_proto < FLOW_PROTO_DEFAULT; flow_proto++) {
         for (alproto = 0; alproto < ALPROTO_MAX; alproto++) {
-            alp_ctx.ctxs[flow_proto][alproto].stream_depth =
-                stream_config.reassembly_depth;
+            if (!(alp_ctx.ctxs[flow_proto][alproto].flags &
+                APP_LAYER_PARSER_OPT_STREAM_DEPTH_SET)) {
+                alp_ctx.ctxs[flow_proto][alproto].stream_depth =
+                    stream_config.reassembly_depth;
+            }
         }
     }
 }
@@ -1250,6 +1253,8 @@ void AppLayerParserSetStreamDepth(uint8_t ipproto, AppProto alproto, uint32_t st
     SCEnter();
 
     alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].stream_depth = stream_depth;
+    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].flags |=
+        APP_LAYER_PARSER_OPT_STREAM_DEPTH_SET;
 
     SCReturn;
 }

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -39,6 +39,7 @@
 
 /* Flags for AppLayerParserProtoCtx. */
 #define APP_LAYER_PARSER_OPT_ACCEPT_GAPS        BIT_U64(0)
+#define APP_LAYER_PARSER_OPT_STREAM_DEPTH_SET   BIT_U64(1)
 
 /* applies to DetectFlags uint64_t field */
 

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -205,6 +205,18 @@ int DetectFilestorePostMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx, Pack
     TcpSession *ssn = (TcpSession *)p->flow->protoctx;
     TcpSessionSetReassemblyDepth(ssn, FileReassemblyDepth());
 
+    if (p->flow->alproto == ALPROTO_HTTP) {
+        HtpState *htp_state = (HtpState *)FlowGetAppState(p->flow);
+        if (htp_state != NULL) {
+            uint64_t tx_id = AppLayerParserGetTransactionLogId(p->flow->alparser);
+            htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP,
+                                               htp_state, tx_id);
+            if (tx != NULL) {
+                AppLayerHtpUseStreamDepth(tx);
+            }
+        }
+    }
+
     if (p->flowflags & FLOW_PKT_TOCLIENT)
         flags |= STREAM_TOCLIENT;
     else

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -561,19 +561,19 @@ static uint32_t StreamTcpReassembleCheckDepth(TcpSession *ssn, TcpStream *stream
             stream->base_seq, seg_depth,
             stream_config.reassembly_depth);
 
-    if (seg_depth > (uint64_t)stream_config.reassembly_depth) {
+    if (seg_depth > (uint64_t)ssn->reassembly_depth) {
         SCLogDebug("STREAMTCP_STREAM_FLAG_DEPTH_REACHED");
         stream->flags |= STREAMTCP_STREAM_FLAG_DEPTH_REACHED;
         SCReturnUInt(0);
     }
     SCLogDebug("NOT STREAMTCP_STREAM_FLAG_DEPTH_REACHED");
-    SCLogDebug("%"PRIu64" <= %u", seg_depth, stream_config.reassembly_depth);
+    SCLogDebug("%"PRIu64" <= %u", seg_depth, ssn->reassembly_depth);
 #if 0
     SCLogDebug("full depth not yet reached: %"PRIu64" <= %"PRIu32,
             (stream->base_seq_offset + stream->base_seq + size),
             (stream->isn + stream_config.reassembly_depth));
 #endif
-    if (SEQ_GEQ(seq, stream->isn) && SEQ_LT(seq, (stream->isn + stream_config.reassembly_depth))) {
+    if (SEQ_GEQ(seq, stream->isn) && SEQ_LT(seq, (stream->isn + ssn->reassembly_depth))) {
         /* packet (partly?) fits the depth window */
 
         if (SEQ_LEQ((seq + size),(stream->isn + 1 + ssn->reassembly_depth))) {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2264

Describe changes:
Currently if file-store.stream-depth is set, it doesn't behave correctly.
If its value is zero, it works as expected, but if the value is fixed it won't be used.
Even if stream-depth is enabled in an application layer, it doesn't work because the value is overwritten.
This patchset fixes the usage of stream-depth when:
- global file-store.stream-depth is enabled
- stream-depth is enabled for an application layer
- file-store keyword is used with http protocol

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/169
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/33
