### PR TITLE
eve metadata - v2

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -301,16 +301,20 @@ integration with 3rd party tools like logstash.
       #  pipelining:
       #    enabled: yes ## set enable to yes to enable query pipelining
       #    batch-size: 10 ## number of entry to keep in buffer
+
+      # Include top level metadata. Default yes.
+      #metadata: no
+
       types:
         - alert:
             # payload: yes             # enable dumping payload in Base64
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # packet: yes              # enable dumping of packet (without stream segments)
-            http: yes                # enable dumping of http fields
-            tls: yes                 # enable dumping of tls fields
-            ssh: yes                 # enable dumping of ssh fields
-            smtp: yes                # enable dumping of smtp fields
+
+            # http-body: yes           # enable dumping of http body in Base64
+            # http-body-printable: yes # enable dumping of http body in printable format
+            metadata: yes              # add L7/applayer fields, flowbit and other vars to the alert
 
             # Enable the logging of tagged packets for rules using the
             # "tag" keyword.
@@ -382,6 +386,9 @@ integration with 3rd party tools like logstash.
         - flow
         # uni-directional flows
         #- netflow
+        # An event for logging metadata, specifically pktvars when
+        # they are set, but will also include the full metadata object.
+	#- metadata
 
 For more advanced configuration options, see :ref:`Eve JSON Output <eve-json-output>`.
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -309,7 +309,7 @@ output-json-stats.c output-json-stats.h \
 output-json-tls.c output-json-tls.h \
 output-json-nfs.c output-json-nfs.h \
 output-json-template.c output-json-template.h \
-output-json-vars.c output-json-vars.h \
+output-json-metadata.c output-json-metadata.h \
 output-lua.c output-lua.h \
 output-packet.c output-packet.h \
 output-stats.c output-stats.h \

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -50,6 +50,7 @@ typedef struct LogDNP3FileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t    flags;
     uint8_t     include_object_data;
+    bool        include_metadata;
 } LogDNP3FileCtx;
 
 typedef struct LogDNP3LogThread_ {
@@ -315,6 +316,9 @@ static int JsonDNP3LoggerToServer(ThreadVars *tv, void *thread_data,
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
         }
+        if (thread->dnp3log_ctx->include_metadata) {
+            JsonAddMetadata(p, f, js);
+        }
         json_t *dnp3js = JsonDNP3LogRequest(tx);
         if (dnp3js != NULL) {
             json_object_set_new(js, "dnp3", dnp3js);
@@ -341,6 +345,9 @@ static int JsonDNP3LoggerToClient(ThreadVars *tv, void *thread_data,
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
         }
+        if (thread->dnp3log_ctx->include_metadata) {
+            JsonAddMetadata(p, f, js);
+        }
         json_t *dnp3js = JsonDNP3LogResponse(tx);
         if (dnp3js != NULL) {
             json_object_set_new(js, "dnp3", dnp3js);
@@ -365,13 +372,14 @@ static void OutputDNP3LogDeInitCtxSub(OutputCtx *output_ctx)
 static OutputInitResult OutputDNP3LogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
     OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ajt = parent_ctx->data;
+    OutputJsonCtx *json_ctx = parent_ctx->data;
 
     LogDNP3FileCtx *dnp3log_ctx = SCCalloc(1, sizeof(*dnp3log_ctx));
     if (unlikely(dnp3log_ctx == NULL)) {
         return result;
     }
-    dnp3log_ctx->file_ctx = ajt->file_ctx;
+    dnp3log_ctx->file_ctx = json_ctx->file_ctx;
+    dnp3log_ctx->include_metadata = json_ctx->include_metadata;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -254,6 +254,7 @@ static struct {
 typedef struct LogDnsFileCtx_ {
     LogFileCtx *file_ctx;
     uint64_t flags; /** Store mode */
+    bool include_metadata;
 } LogDnsFileCtx;
 
 typedef struct LogDnsLogThread_ {
@@ -666,6 +667,9 @@ static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
         }
+        if (dnslog_ctx->include_metadata) {
+            JsonAddMetadata(p, f, js);
+        }
         json_t *dns = rs_dns_log_json_query(txptr, i, td->dnslog_ctx->flags);
         if (unlikely(dns == NULL)) {
             json_decref(js);
@@ -683,6 +687,9 @@ static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
         js = CreateJSONHeader((Packet *)p, 1, "dns");
         if (unlikely(js == NULL))
             return TM_ECODE_OK;
+        if (dnslog_ctx->include_metadata) {
+            JsonAddMetadata(p, f, js);
+        }
 
         LogQuery(td, js, tx, tx_id, query);
 
@@ -707,6 +714,10 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
     }
 
     js = CreateJSONHeader((Packet *)p, 0, "dns");
+
+    if (dnslog_ctx->include_metadata) {
+        JsonAddMetadata(p, f, js);
+    }
 
 #if HAVE_RUST
     /* Log answers. */
@@ -863,6 +874,7 @@ static OutputInitResult JsonDnsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_c
     memset(dnslog_ctx, 0x00, sizeof(LogDnsFileCtx));
 
     dnslog_ctx->file_ctx = ojc->file_ctx;
+    dnslog_ctx->include_metadata = ojc->include_metadata;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -65,6 +65,7 @@
 typedef struct JsonDropOutputCtx_ {
     LogFileCtx *file_ctx;
     uint8_t flags;
+    bool include_metadata;
 } JsonDropOutputCtx;
 
 typedef struct JsonDropLogThread_ {
@@ -86,10 +87,15 @@ static int g_droplog_flows_start = 1;
  */
 static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
 {
+    JsonDropOutputCtx *drop_ctx = aft->drop_ctx;
     uint16_t proto = 0;
     json_t *js = CreateJSONHeader((Packet *)p, 0, "drop");//TODO const
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
+
+    if (drop_ctx->include_metadata) {
+        JsonAddMetadata(p, p->flow, js);
+    }
 
     json_t *djs = json_object();
     if (unlikely(djs == NULL)) {
@@ -350,6 +356,7 @@ static OutputInitResult JsonDropLogInitCtxSub(ConfNode *conf, OutputCtx *parent_
     }
 
     drop_ctx->file_ctx = ajt->file_ctx;
+    drop_ctx->include_metadata = ajt->include_metadata;
 
     output_ctx->data = drop_ctx;
     output_ctx->DeInit = JsonDropLogDeInitCtxSub;

--- a/src/output-json-email-common.h
+++ b/src/output-json-email-common.h
@@ -28,6 +28,7 @@ typedef struct OutputJsonEmailCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags; /** Store mode */
     uint64_t fields;/** Store fields */
+    bool     include_metadata;
 } OutputJsonEmailCtx;
 
 

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -54,6 +54,7 @@
 typedef struct LogJsonFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags; /** Store mode */
+    bool include_metadata;
 } LogJsonFileCtx;
 
 typedef struct JsonFlowLogThread_ {
@@ -208,9 +209,7 @@ void JsonAddFlow(Flow *f, json_t *js, json_t *hjs)
 /* JSON format logging */
 static void JsonFlowLogJSON(JsonFlowLogThread *aft, json_t *js, Flow *f)
 {
-#if 0
     LogJsonFileCtx *flow_ctx = aft->flowlog_ctx;
-#endif
     json_t *hjs = json_object();
     if (hjs == NULL) {
         return;
@@ -272,6 +271,9 @@ static void JsonFlowLogJSON(JsonFlowLogThread *aft, json_t *js, Flow *f)
 
     json_object_set_new(js, "flow", hjs);
 
+    if (flow_ctx->include_metadata) {
+        JsonAddMetadata(NULL, f, js);
+    }
 
     /* TCP */
     if (f->proto == IPPROTO_TCP) {
@@ -436,6 +438,7 @@ static OutputInitResult OutputFlowLogInitSub(ConfNode *conf, OutputCtx *parent_c
     }
 
     flow_ctx->file_ctx = ojc->file_ctx;
+    flow_ctx->include_metadata = ojc->include_metadata;
 
     output_ctx->data = flow_ctx;
     output_ctx->DeInit = OutputFlowLogDeinitSub;

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -58,6 +58,7 @@ typedef struct LogHttpFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags; /** Store mode */
     uint64_t fields;/** Store fields */
+    bool include_metadata;
 } LogHttpFileCtx;
 
 typedef struct JsonHttpLogThread_ {
@@ -455,6 +456,10 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 
+    if (jhl->httplog_ctx->include_metadata) {
+        JsonAddMetadata(p, f, js);
+    }
+
     SCLogDebug("got a HTTP request and now logging !!");
 
     /* reset */
@@ -576,6 +581,7 @@ static OutputInitResult OutputHttpLogInitSub(ConfNode *conf, OutputCtx *parent_c
 
     http_ctx->file_ctx = ojc->file_ctx;
     http_ctx->flags = LOG_HTTP_DEFAULT;
+    http_ctx->include_metadata = ojc->include_metadata;
 
     if (conf) {
         const char *extended = ConfNodeLookupChildValue(conf, "extended");

--- a/src/output-json-metadata.h
+++ b/src/output-json-metadata.h
@@ -20,13 +20,13 @@
  *
  * \author Victor Julien <victor@inliniac.net>
  *
- * Logs alerts in JSON format.
+ * Logs metadata in JSON/eve format.
  *
  */
 
-#ifndef __OUTPUT_JSON_VARS_H__
-#define __OUTPUT_JSON_VARS_H__
+#ifndef __OUTPUT_JSON_METADATA_H__
+#define __OUTPUT_JSON_METADATA_H__
 
-void JsonVarsLogRegister(void);
+void JsonMetadataLogRegister(void);
 
-#endif /* __OUTPUT_JSON_VARS_H__ */
+#endif /* __OUTPUT_JSON_METADATA_H__ */

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -53,6 +53,7 @@
 
 typedef struct LogJsonFileCtx_ {
     LogFileCtx *file_ctx;
+    bool include_metadata;
 } LogJsonFileCtx;
 
 typedef struct JsonNetFlowLogThread_ {
@@ -298,6 +299,7 @@ static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
 {
     SCEnter();
     JsonNetFlowLogThread *jhl = (JsonNetFlowLogThread *)thread_data;
+    LogJsonFileCtx *netflow_ctx = jhl->flowlog_ctx;
 
     /* reset */
     MemBufferReset(jhl->buffer);
@@ -305,6 +307,9 @@ static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
     JsonNetFlowLogJSONToServer(jhl, js, f);
+    if (netflow_ctx->include_metadata) {
+        JsonAddMetadata(NULL, f, js);
+    }
     OutputJSONBuffer(js, jhl->flowlog_ctx->file_ctx, &jhl->buffer);
     json_object_del(js, "netflow");
     json_object_clear(js);
@@ -316,6 +321,9 @@ static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
     JsonNetFlowLogJSONToClient(jhl, js, f);
+    if (netflow_ctx->include_metadata) {
+        JsonAddMetadata(NULL, f, js);
+    }
     OutputJSONBuffer(js, jhl->flowlog_ctx->file_ctx, &jhl->buffer);
     json_object_del(js, "netflow");
     json_object_clear(js);
@@ -393,6 +401,7 @@ static OutputInitResult OutputNetFlowLogInitSub(ConfNode *conf, OutputCtx *paren
     }
 
     flow_ctx->file_ctx = ojc->file_ctx;
+    flow_ctx->include_metadata = ojc->include_metadata;
 
     output_ctx->data = flow_ctx;
     output_ctx->DeInit = OutputNetFlowLogDeinitSub;

--- a/src/output-json-nfs.c
+++ b/src/output-json-nfs.c
@@ -54,6 +54,7 @@
 typedef struct LogNFSFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t    flags;
+    bool        include_metadata;
 } LogNFSFileCtx;
 
 typedef struct LogNFSLogThread_ {
@@ -103,6 +104,10 @@ static int JsonNFSLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
+    if (thread->nfslog_ctx->include_metadata) {
+        JsonAddMetadata(p, f, js);
+    }
+
     json_t *rpcjs = rs_rpc_log_json_response(tx);
     if (unlikely(rpcjs == NULL)) {
         goto error;
@@ -144,6 +149,7 @@ static OutputInitResult OutputNFSLogInitSub(ConfNode *conf,
         return result;
     }
     nfslog_ctx->file_ctx = ajt->file_ctx;
+    nfslog_ctx->include_metadata = ajt->include_metadata;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -96,6 +96,10 @@ static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     /* reset */
     MemBufferReset(jhl->buffer);
 
+    if (jhl->emaillog_ctx->include_metadata) {
+        JsonAddMetadata(p, f, js);
+    }
+
     sjs = JsonSmtpDataLogger(f, state, tx, tx_id);
     if (sjs) {
         json_object_set_new(js, "smtp", sjs);
@@ -207,6 +211,7 @@ static OutputInitResult OutputSmtpLogInitSub(ConfNode *conf, OutputCtx *parent_c
     }
 
     email_ctx->file_ctx = ojc->file_ctx;
+    email_ctx->include_metadata = ojc->include_metadata;
 
     OutputEmailInitConf(conf, email_ctx);
 

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -57,6 +57,7 @@
 typedef struct OutputSshCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags; /** Store mode */
+    bool include_metadata;
 } OutputSshCtx;
 
 
@@ -108,6 +109,10 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
     json_t *js = CreateJSONHeader((Packet *)p, 1, "ssh");//TODO
     if (unlikely(js == NULL))
         return 0;
+
+    if (ssh_ctx->include_metadata) {
+        JsonAddMetadata(p, f, js);
+    }
 
     json_t *tjs = json_object();
     if (tjs == NULL) {
@@ -244,6 +249,7 @@ static OutputInitResult OutputSshLogInitSub(ConfNode *conf, OutputCtx *parent_ct
     }
 
     ssh_ctx->file_ctx = ojc->file_ctx;
+    ssh_ctx->include_metadata = ojc->include_metadata;
 
     output_ctx->data = ssh_ctx;
     output_ctx->DeInit = OutputSshLogDeinitSub;

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -102,6 +102,7 @@ typedef struct OutputTlsCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags;  /** Store mode */
     uint64_t fields; /** Store fields */
+    bool include_metadata;
 } OutputTlsCtx;
 
 
@@ -361,6 +362,10 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         return 0;
     }
 
+    if (tls_ctx->include_metadata) {
+        JsonAddMetadata(p, f, js);
+    }
+
     json_t *tjs = json_object();
     if (tjs == NULL) {
         free(js);
@@ -565,6 +570,7 @@ static OutputInitResult OutputTlsLogInitSub(ConfNode *conf, OutputCtx *parent_ct
     }
 
     tls_ctx->file_ctx = ojc->file_ctx;
+    tls_ctx->include_metadata = ojc->include_metadata;
 
     if ((tls_ctx->fields & LOG_TLS_FIELD_CERTIFICATE) &&
             (tls_ctx->fields & LOG_TLS_FIELD_CHAIN)) {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -154,6 +154,111 @@ static void JsonAddPacketvars(const Packet *p, json_t *js_vars)
     }
 }
 
+/**
+ * \brief "New" Add flow variables to a json object.
+ *
+ * Adds "flowvars" (map), "flowints" (map) and "flowbits" (array) to
+ * the json object provided as js_root.
+ *
+ * This is the "new" method for doing this as flowbits is an array of
+ * strings instead of a map of boolean values.
+ */
+static void JsonAddFlowVars(const Flow *f, json_t *js_root)
+{
+    if (f == NULL || f->flowvar == NULL) {
+        return;
+    }
+    json_t *js_flowvars = NULL;
+    json_t *js_flowints = NULL;
+    json_t *js_flowbits = NULL;
+    GenericVar *gv = f->flowvar;
+    while (gv != NULL) {
+        if (gv->type == DETECT_FLOWVAR || gv->type == DETECT_FLOWINT) {
+            FlowVar *fv = (FlowVar *)gv;
+            if (fv->datatype == FLOWVAR_TYPE_STR && fv->key == NULL) {
+                const char *varname = VarNameStoreLookupById(fv->idx,
+                        VAR_TYPE_FLOW_VAR);
+                if (varname) {
+                    if (js_flowvars == NULL) {
+                        js_flowvars = json_object();
+                        if (js_flowvars == NULL)
+                            break;
+                    }
+
+                    uint32_t len = fv->data.fv_str.value_len;
+                    uint8_t printable_buf[len + 1];
+                    uint32_t offset = 0;
+                    PrintStringsToBuffer(printable_buf, &offset,
+                            sizeof(printable_buf),
+                            fv->data.fv_str.value, fv->data.fv_str.value_len);
+
+                    json_object_set_new(js_flowvars, varname,
+                            json_string((char *)printable_buf));
+                }
+            } else if (fv->datatype == FLOWVAR_TYPE_STR && fv->key != NULL) {
+                if (js_flowvars == NULL) {
+                    js_flowvars = json_object();
+                    if (js_flowvars == NULL)
+                        break;
+                }
+
+                uint8_t keybuf[fv->keylen + 1];
+                uint32_t offset = 0;
+                PrintStringsToBuffer(keybuf, &offset,
+                        sizeof(keybuf),
+                        fv->key, fv->keylen);
+
+                uint32_t len = fv->data.fv_str.value_len;
+                uint8_t printable_buf[len + 1];
+                offset = 0;
+                PrintStringsToBuffer(printable_buf, &offset,
+                        sizeof(printable_buf),
+                        fv->data.fv_str.value, fv->data.fv_str.value_len);
+
+                json_object_set_new(js_flowvars, (const char *)keybuf,
+                        json_string((char *)printable_buf));
+
+            } else if (fv->datatype == FLOWVAR_TYPE_INT) {
+                const char *varname = VarNameStoreLookupById(fv->idx,
+                        VAR_TYPE_FLOW_INT);
+                if (varname) {
+                    if (js_flowints == NULL) {
+                        js_flowints = json_object();
+                        if (js_flowints == NULL)
+                            break;
+                    }
+
+                    json_object_set_new(js_flowints, varname,
+                            json_integer(fv->data.fv_int.value));
+                }
+
+            }
+        } else if (gv->type == DETECT_FLOWBITS) {
+            FlowBit *fb = (FlowBit *)gv;
+            const char *varname = VarNameStoreLookupById(fb->idx,
+                    VAR_TYPE_FLOW_BIT);
+            if (varname) {
+                if (js_flowbits == NULL) {
+                    js_flowbits = json_array();
+                    if (js_flowbits == NULL)
+                        break;
+                }
+                json_array_append(js_flowbits, json_string(varname));
+            }
+        }
+        gv = gv->next;
+    }
+    if (js_flowbits) {
+        json_object_set_new(js_root, "flowbits", js_flowbits);
+    }
+    if (js_flowints) {
+        json_object_set_new(js_root, "flowints", js_flowints);
+    }
+    if (js_flowvars) {
+        json_object_set_new(js_root, "flowvars", js_flowvars);
+    }
+}
+
 static void JsonAddFlowvars(const Flow *f, json_t *js_vars)
 {
     if (f == NULL || f->flowvar == NULL) {
@@ -259,6 +364,26 @@ void JsonAddVars(const Packet *p, const Flow *f, json_t *js)
             }
 
             json_object_set_new(js, "vars", js_vars);
+        }
+    }
+}
+
+/**
+ * \brief Add top-level metadata to the eve json object.
+ */
+static void JsonAddMetadata(const Packet *p, const Flow *f, json_t *js)
+{
+    if ((p && p->pktvar) || (f && f->flowvar)) {
+        json_t *js_vars = json_object();
+        if (js_vars) {
+            if (f && f->flowvar) {
+                JsonAddFlowVars(f, js_vars);
+            }
+            if (p && p->pktvar) {
+                JsonAddPacketvars(p, js_vars);
+            }
+
+            json_object_set_new(js, "metadata", js_vars);
         }
     }
 }
@@ -396,6 +521,7 @@ json_t *CreateJSONHeader(const Packet *p, int direction_sensitive,
                          const char *event_type)
 {
     char timebuf[64];
+    const Flow *f = (const Flow *)p->flow;
 
     json_t *js = json_object();
     if (unlikely(js == NULL))
@@ -406,7 +532,7 @@ json_t *CreateJSONHeader(const Packet *p, int direction_sensitive,
     /* time & tx */
     json_object_set_new(js, "timestamp", json_string(timebuf));
 
-    CreateJSONFlowId(js, (const Flow *)p->flow);
+    CreateJSONFlowId(js, f);
 
     /* sensor id */
     if (sensor_id >= 0)
@@ -452,6 +578,9 @@ json_t *CreateJSONHeader(const Packet *p, int direction_sensitive,
 
     /* 5-tuple */
     JsonFiveTuple(p, direction_sensitive, js);
+
+    /* Metadata. */
+    JsonAddMetadata(p, f, js);
 
     /* icmp */
     switch (p->proto) {

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -41,6 +41,7 @@ typedef struct OutputJSONMemBufferWrapper_ {
 int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
 
 void JsonAddVars(const Packet *p, const Flow *f, json_t *js);
+void JsonAddMetadata(const Packet *p, const Flow *f, json_t *js);
 void CreateJSONFlowId(json_t *js, const Flow *f);
 void JsonTcpFlags(uint8_t flags, json_t *js);
 void JsonFiveTuple(const Packet *, int, json_t *);
@@ -55,6 +56,7 @@ OutputInitResult OutputJsonInitCtx(ConfNode *);
 typedef struct OutputJsonCtx_ {
     LogFileCtx *file_ctx;
     enum LogFileType json_out;
+    bool include_metadata;
 } OutputJsonCtx;
 
 json_t *SCJsonBool(int val);

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -40,7 +40,6 @@ typedef struct OutputJSONMemBufferWrapper_ {
 
 int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
 
-void JsonAddVars(const Packet *p, const Flow *f, json_t *js);
 void JsonAddMetadata(const Packet *p, const Flow *f, json_t *js);
 void CreateJSONFlowId(json_t *js, const Flow *f);
 void JsonTcpFlags(uint8_t flags, json_t *js);

--- a/src/output.c
+++ b/src/output.c
@@ -72,7 +72,7 @@
 #include "output-json-template.h"
 #include "output-lua.h"
 #include "output-json-dnp3.h"
-#include "output-json-vars.h"
+#include "output-json-metadata.h"
 #include "output-filestore.h"
 
 typedef struct RootLogger_ {
@@ -1085,7 +1085,7 @@ void OutputRegisterLoggers(void)
 
     /* DNP3. */
     JsonDNP3LogRegister();
-    JsonVarsLogRegister();
+    JsonMetadataLogRegister();
 
     /* NFS JSON logger. */
     JsonNFSLogRegister();

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -430,7 +430,7 @@ typedef enum {
     LOGGER_JSON_STATS,
     LOGGER_PRELUDE,
     LOGGER_PCAP,
-    LOGGER_JSON_VARS,
+    LOGGER_JSON_METADATA,
     LOGGER_SIZE,
 } LoggerId;
 

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -1265,7 +1265,7 @@ const char * PacketProfileLoggertIdToString(LoggerId id)
         CASE_CODE (LOGGER_JSON_STATS);
         CASE_CODE (LOGGER_PRELUDE);
         CASE_CODE (LOGGER_PCAP);
-        CASE_CODE (LOGGER_JSON_VARS);
+        CASE_CODE (LOGGER_JSON_METADATA);
         default:
             return "UNKNOWN";
     }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -163,6 +163,10 @@ outputs:
       #  pipelining:
       #    enabled: yes ## set enable to yes to enable query pipelining
       #    batch-size: 10 ## number of entry to keep in buffer
+
+      # Include top level metadata. Default yes.
+      #metadata: no
+
       types:
         - alert:
             # payload: yes             # enable dumping payload in Base64

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -252,8 +252,11 @@ outputs:
         - flow
         # uni-directional flows
         #- netflow
-        # Vars log flowbits and other packet and flow vars
-        #- vars
+
+        # Metadata event type. Triggered whenever a pktvar is saved
+        # and will include the pktvars, flowvars, flowbits and
+        # flowints.
+        #- metadata
 
   # alert output for use with Barnyard2
   - unified2-alert:


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2352

Describe changes:
- Add a "metadata: yes/no" field to the eve-log section in suricata.yaml. This controls adding top-level metadata to all types enabled.
- This metadata currently includes flowbits  as an array, and flowints, flowvars and pktvars as maps.
- It is basically a remapping of the previous "vars" field to "metadata", but flowbits is now an array.
- There is no "vars" specific event type.
- Adds this metadata to all event types if turned on.

The metadata in an eve event will look something like:
```
{
  "metadata": {
    "flowbits": [
      "/traffic/id/facebook",
      "ET.TorIP" 
    ],
    "flowvars": {
      "flow_var0_name": "flow_var0_value",
      "flow_var1_name": "flow_var1_value" 
    },
    "flowints": {
      "flow_int0_name": 0,
      "flow_int1_name": 1
    },
    "pktvars": {
      "pkt_var0_name": "pkt_var0_value",
      "pkt_var1_name": "pkt_var1_value" 
    }
  }
}
```

Changes from last PR:
- Rename the "vars" event type to "metadata" event type. It can still be registered as "vars" though.

Issue: Flowvars and pktvars are logged differently, but should probable be the same.
```
"flowvars":{"gid":"0"},"pktvars":[{"uid":"0"}]
```
In the case of pktvars, if a name is set more than once, the list will be appended to so you get all occurrences of that name being used. However, when matching, it only matches against the first one.

But re-using a flowvar name will overwrite the one thats there. It would probably make sense to have them both formatted the same.

This is really an issue outside of this PR, but something to think about as we make this metadata object more visible to end-users, as it will be harder to change in the future.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/255
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/608
