### PR TITLE
Startup: Check if logrotation will still work after priv drop (Issue #2386)

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1901,7 +1901,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 SCLogError(SC_ERR_FATAL, "Failed to set log directory.\n");
                 return TM_ECODE_FAILED;
             }
-            if (ConfigCheckLogDirectory(optarg) != TM_ECODE_OK) {
+            if (ConfigCheckFileExists(optarg) != TM_ECODE_OK) {
                 SCLogError(SC_ERR_LOGDIR_CMDLINE, "The logging directory \"%s\""
                         " supplied at the commandline (-l %s) doesn't "
                         "exist. Shutting down the engine.", optarg, optarg);
@@ -2618,7 +2618,7 @@ static int PostConfLoadedSetup(SCInstance *suri)
      * from suricata.yaml.  If not found, shut the engine down */
     suri->log_dir = ConfigGetLogDirectory();
 
-    if (ConfigCheckLogDirectory(suri->log_dir) != TM_ECODE_OK) {
+    if (ConfigCheckFileExists(suri->log_dir) != TM_ECODE_OK) {
         SCLogError(SC_ERR_LOGDIR_CONFIG, "The logging directory \"%s\" "
                 "supplied by %s (default-log-dir) doesn't exist. "
                 "Shutting down the engine", suri->log_dir, suri->conf_filename);

--- a/src/util-conf.c
+++ b/src/util-conf.c
@@ -28,6 +28,16 @@
 #include "runmodes.h"
 #include "util-conf.h"
 
+#ifndef OS_WIN32
+
+#include "util-privs.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
+
+#endif /* OS_WIN32 */
+
 TmEcode ConfigSetLogDirectory(char *name)
 {
     return ConfSetFinal("default-log-dir", name) ? TM_ECODE_OK : TM_ECODE_FAILED;
@@ -65,6 +75,80 @@ TmEcode ConfigCheckLogDirectory(const char *log_dir)
     }
     SCReturnInt(TM_ECODE_OK);
 }
+
+#ifndef OS_WIN32
+/**
+ * \brief   Check if requested file is writable after privilege drop.
+ *          (Or now if we won't drop privs)
+ *
+ * \param   filename    Name of file to check
+ * \param   suri    	Pointer to suricata instance, necesarry for priv drop details
+ *
+ * \retval  TmEcode. TM_ECODE_DONE if writable. TM_ECODE_FAILED otherwise. Never TM_ECODE_OK
+ */
+TmEcode ConfigCheckFileWritablePrivDrop(const char * const filename, SCInstance const * const suri)
+{
+    struct stat file_stat_struct;
+
+    if (stat(filename, &file_stat_struct) != 0) {
+        char const * const stat_error_message = strerror(errno);
+        FatalError(SC_ERR_FATAL, "Checking writeability of logfile dir failed with following error message: %s",
+                   stat_error_message);
+    }
+
+    if (suri->do_setgid || suri->do_setuid) { /* We will drop privs */
+
+        if (SCCheckArbitraryFileAccess((uid_t)    suri->userid,      /* future uid */
+                                       (gid_t *) &(suri->groupid),  /* future gid */
+                                       1, /* only one future gid because alle supplementary
+                                           * gids will be purged while dropping privs  */
+                                       &file_stat_struct,
+                                       W_OK /* check for write access */ )) {
+            return TM_ECODE_DONE; /* log dir will stay writable */
+        }
+        return TM_ECODE_FAILED; /* Dir not writeable */
+
+    } else { /* We will stay the user and group(s) we are */
+        /* Step 1: getting and preparing data */
+        gid_t *gids = NULL;
+        int supplementary_gid_count;
+
+        /* With 0 as first arg getgroups returns the number of existing supplementary gids */
+        if ( -1 == (supplementary_gid_count = getgroups(0 , gids)) ) {
+            char const * const getgroups_error_message = strerror(errno);
+            FatalError(SC_ERR_FATAL, "Getting group IDs of suricata process failed with following error message: %s",
+                       getgroups_error_message);
+        }
+
+        /* engine_stage is SURICATA_INIT, so the error handling in the SCMalloc
+         * macro is used. It's sufficient. */
+        /* +1 is for the primary group id we will add later */
+        gids = (gid_t *) SCMalloc( (supplementary_gid_count+1) * sizeof(gid_t));
+
+        /* get supplementary gids */
+        if (supplementary_gid_count != getgroups(supplementary_gid_count, gids)) {
+            char const * const getgroups_error_message = strerror(errno);
+            FatalError(SC_ERR_FATAL, "Getting group IDs of suricata process failed with following error message: %s",
+                       getgroups_error_message);
+        }
+
+        /* It's undefinded whether getgroups() also returns our primary gid
+         * or only the supplementary gids. So to be safe here we manually
+         * add our primary group id to the last slot of the array.
+         * If it's already in there this does not break correctness,
+         * because the following SCCheckArbitrartyFileAcees()
+         * then simply does the check for this gid twice. */
+        gids[supplementary_gid_count] = getegid();
+
+        /* Step 2: Calling the low level permission bit check function */
+        if (SCCheckArbitraryFileAccess(getuid(), gids, supplementary_gid_count+1,
+                                       &file_stat_struct, W_OK)) {
+            return TM_ECODE_DONE;
+        }
+        return TM_ECODE_FAILED;
+    }
+}
+#endif /* OS_WIN32 */
 
 /**
  * \brief Find the configuration node for a specific device.

--- a/src/util-conf.c
+++ b/src/util-conf.c
@@ -61,7 +61,7 @@ const char *ConfigGetLogDirectory()
     return log_dir;
 }
 
-TmEcode ConfigCheckLogDirectory(const char *log_dir)
+TmEcode ConfigCheckFileExists(const char *filename)
 {
     SCEnter();
 #ifdef OS_WIN32
@@ -69,7 +69,7 @@ TmEcode ConfigCheckLogDirectory(const char *log_dir)
     if (_stat(log_dir, &buf) != 0) {
 #else
     struct stat buf;
-    if (stat(log_dir, &buf) != 0) {
+    if (stat(filename, &buf) != 0) {
 #endif /* OS_WIN32 */
             SCReturnInt(TM_ECODE_FAILED);
     }

--- a/src/util-conf.h
+++ b/src/util-conf.h
@@ -30,6 +30,12 @@
 TmEcode ConfigSetLogDirectory(char *name);
 const char *ConfigGetLogDirectory(void);
 TmEcode ConfigCheckLogDirectory(const char *log_dir);
+/* This forward declaration for SCInstance is necesarry because
+ * we can not include it's definition suricata.h since this would mean a
+ * circular inclusion, since suricata.h includes this file. */
+typedef struct SCInstance_ SCInstance;
+TmEcode ConfigCheckFileWritablePrivDrop(const char * const filename,
+                                        SCInstance const * const suri);
 
 ConfNode *ConfFindDeviceConfig(ConfNode *node, const char *iface);
 

--- a/src/util-conf.h
+++ b/src/util-conf.h
@@ -29,7 +29,8 @@
 
 TmEcode ConfigSetLogDirectory(char *name);
 const char *ConfigGetLogDirectory(void);
-TmEcode ConfigCheckLogDirectory(const char *log_dir);
+TmEcode ConfigCheckFileExists(const char *filename);
+
 /* This forward declaration for SCInstance is necesarry because
  * we can not include it's definition suricata.h since this would mean a
  * circular inclusion, since suricata.h includes this file. */

--- a/src/util-privs.h
+++ b/src/util-privs.h
@@ -33,6 +33,10 @@
 #define SC_CAP_NET_BIND_SERVICE 0x40
 #define SC_CAP_NET_BROADCAST    0x80
 
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
 #ifndef HAVE_LIBCAP_NG
 #define SCDropCaps(...)
 #define SCDropMainThreadCaps(...)
@@ -93,6 +97,12 @@ void SCDropMainThreadCaps(uint32_t , uint32_t );
 
 int SCGetUserID(const char *, const char *, uint32_t *, uint32_t *);
 int SCGetGroupID(const char *, uint32_t *);
+
+bool SCCheckArbitraryFileAccess(const uid_t asked_uid,
+                                const gid_t * const asked_gids,
+                                const int gid_count,
+                                struct stat const * const file_stat_struct,
+                                const int requested_permissions);
 
 #endif	/* _UTIL_PRIVS_H */
 


### PR DESCRIPTION
## Checkboxes

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

## Redmine Ticket
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2386

## Description of Changes:
Write permission on the logdir is necesarry to create new files in there, which is necesary after logrotation to continue logging. (use cases: exe.json and others)

If suricata could open the log files but not create new ones it silently failed, not writing any logs after the first logrotation. This patch adds a check before priv drop and warns+exit()s if we will not be able to create new files after priv drop.

If we won't drop privs we check if the current (and general) user will be able to create logfiles after log rotation.

For details and discussion see:
https://redmine.openinfosecfoundation.org/issues/2386

## PRScript
[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR richi235-pcap: https://buildbot.openinfosecfoundation.org/builders/richi235-pcap/builds/1
- PR richi235: https://buildbot.openinfosecfoundation.org/builders/richi235/builds/1