### PR TITLE
suricata-update: bundle suricata update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ src/suricata
 stamp-h1
 src/build-info.h
 qa/log/
+
+/suricata-update/*
+!/suricata-update/Makefile.am

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,8 +4,9 @@ AUTOMAKE_OPTIONS = foreign 1.4
 ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST = ChangeLog COPYING LICENSE suricata.yaml.in \
              classification.config threshold.config \
-             reference.config
-SUBDIRS = $(HTP_DIR) rust src qa rules doc contrib scripts etc python
+             reference.config $(SURICATA_UPDATE_DIR)
+SUBDIRS = $(HTP_DIR) rust src qa rules doc contrib scripts etc python \
+          $(SURICATA_UPDATE_DIR)
 
 CLEANFILES = stamp-h[0-9]*
 

--- a/configure.ac
+++ b/configure.ac
@@ -1267,6 +1267,13 @@
         AC_CHECK_HEADER(net/netmap_user.h,,[AC_ERROR(net/netmap_user.h not found ...)],)
   ])
 
+  # suricata-update
+  AC_CHECK_FILE([$srcdir/suricata-update/setup.py], [
+      SURICATA_UPDATE_DIR="suricata-update"
+      AC_SUBST(SURICATA_UPDATE_DIR)
+      AC_OUTPUT(suricata-update/Makefile)
+  ])
+
   # libhtp
     AC_ARG_ENABLE(non-bundled-htp,
            AS_HELP_STRING([--enable-non-bundled-htp], [Enable the use of an already installed version of htp]),,[enable_non_bundled_htp=no])

--- a/suricata-update/Makefile.am
+++ b/suricata-update/Makefile.am
@@ -1,0 +1,22 @@
+if HAVE_PYTHON
+
+install-exec-local:
+	cd $(srcdir) && \
+		$(HAVE_PYTHON) setup.py build --build-base $(abs_builddir) \
+		install --prefix $(DESTDIR)$(prefix)
+
+uninstall-local:
+	rm -f $(DESTDIR)$(bindir)/suricata-update
+	rm -rf $(DESTDIR)$(prefix)/lib*/python*/site-packages/suricata-update
+	rm -rf $(DESTDIR)$(prefix)/lib*/python*/site-packages/suricata_update-[0-9]*.egg-info
+
+clean-local:
+	cd $(srcdir) && \
+		$(HAVE_PYTHON) setup.py clean \
+		--build-base $(abs_builddir)
+	rm -rf scripts-* lib* build
+	find . -name \*.pyc -print0 | xargs -0 rm -f
+
+distclean-local:
+
+endif


### PR DESCRIPTION
Add autoconf/automake support for installing suricata-update
if found in the top level suricata-update.

Requires this PR to suricata-update:
https://github.com/OISF/suricata-update/pull/28

There are still some things we can do better, but are outside the simple scope of bundling. Especially when a --prefix is used, it would be nice for suricata-update to default to the same locations as Suricata. I think this could be done by looking at the --build-info of Suricata itself. First check if a suricata programs exists in the same directory as suricata-update (the case when bundling), then fall back to suricata on the path. Of course --suricata would always take precedence. These changes would be done in suricata-update.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/266
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/619
