### PR TITLE
Compact DNS logging - v5

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -177,6 +177,21 @@ Event with extended logging:
 Event type: DNS
 ---------------
 
+A new version of dns logging has been introduced to improve how dns answers
+are logged.
+
+With that new version, dns answers are logged in one event
+rather than an event for each answer.
+
+It's possible to customize how a dns answer will be logged with the following
+formats:
+
+* "detailed": "rrname", "rrtype", "rdata" and "ttl" fields are logged for each answer
+* "grouped": answers logged are aggregated by their type (A, AAAA, NS, ...)
+
+It will be still possible to use the old DNS logging format, you can control it
+with "version" option in dns configuration section.
+
 Fields
 ~~~~~~
 
@@ -184,6 +199,7 @@ Outline of fields seen in the different kinds of DNS events:
 
 * "type": Indicating DNS message type, can be "answer" or "query".
 * "id": Identifier field
+* "version": Indicating DNS logging version in use
 * "flags": Indicating DNS answer flag, in hexadecimal (ex: 8180 , please note 0x is not output)
 * "qr": Indicating in case of DNS answer flag, Query/Response flag (ex: true if set)
 * "aa": Indicating in case of DNS answer flag, Authoritative Answer flag (ex: true if set)
@@ -212,7 +228,68 @@ Example of a DNS query for the IPv4 address of "twitter.com" (resource record ty
       "rrtype":"A"
   }
 
-Example of a DNS answer with an IPv4 (resource record type 'A') return:
+Example of a DNS answer with "detailed" format:
+
+::
+
+
+  "dns": {
+      "version": 2,
+      "type": "answer",
+      "id": 45444,
+      "flags": "8180",
+      "qr": true,
+      "rd": true,
+      "ra": true,
+      "rcode": "NOERROR",
+      "answers": [
+        {
+          "rrname": "www.suricata-ids.org",
+          "rrtype": "CNAME",
+          "ttl": 3324,
+          "rdata": "suricata-ids.org"
+        },
+        {
+          "rrname": "suricata-ids.org",
+          "rrtype": "A",
+          "ttl": 10,
+          "rdata": "192.0.78.24"
+        },
+        {
+          "rrname": "suricata-ids.org",
+          "rrtype": "A",
+          "ttl": 10,
+          "rdata": "192.0.78.25"
+        }
+      ]
+  }
+
+Example of a DNS answer with "grouped" format:
+
+::
+
+  "dns": {
+      "version": 2,
+      "type": "answer",
+      "id": 18523,
+      "flags": "8180",
+      "qr": true,
+      "rd": true,
+      "ra": true,
+      "rcode": "NOERROR",
+      "grouped": {
+        "A": [
+          "192.0.78.24",
+          "192.0.78.25"
+        ],
+        "CNAME": [
+          "suricata-ids.org"
+        ]
+      }
+  }
+
+
+Example of a old DNS answer with an IPv4 (resource record type 'A') return:
 
 ::
 

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -86,6 +86,37 @@ outputs:
             # the example below adds three additional fields when uncommented
             #custom: [Accept-Encoding, Accept-Language, Authorization]
         - dns:
+            # Use version 2 logging with the new format:
+            # dns answers will be logged in one single event
+            # rather than an event for each of the answers.
+            # Without setting a version the version
+            # will fallback to 1 for backwards compatibility.
+            version: 2
+
+            # Enable/disable this logger. Default: enabled.
+            #enabled: no
+
+            # Control logging of requests and responses:
+            # - requests: enable logging of DNS queries
+            # - responses: enable logging of DNS answers
+            # By default both requests and responses are logged.
+            #requests: no
+            #responses: no
+
+            # Format of answer logging:
+            # - detailed: array item per answer
+            # - grouped: answers aggregated by type
+            # Default: all
+            #answer-format: [detailed, grouped]
+
+            # Answer types to log.
+            # Default: all
+            #answer-types: [a, aaaa, cname, mx, ns, ptr, txt]
+        - dns:
+            # Version 1 (deprecated) DNS logger.
+            version: 1
+
+            enabled: no
             # control logging of queries and answers
             # default yes, no to disable
             query: yes     # enable logging of DNS queries

--- a/rust/src/json.rs
+++ b/rust/src/json.rs
@@ -35,6 +35,7 @@ extern {
 
     fn json_string(value: *const c_char) -> *mut JsonT;
     fn json_integer(val: u64) -> *mut JsonT;
+    fn SCJsonDecref(value: *mut JsonT);
     fn SCJsonBool(val: bool) -> *mut JsonT;
 }
 
@@ -43,6 +44,10 @@ pub struct Json {
 }
 
 impl Json {
+
+    pub fn decref(val: Json) {
+        unsafe{SCJsonDecref(val.js)};
+    }
 
     pub fn object() -> Json {
         return Json{
@@ -54,6 +59,18 @@ impl Json {
         return Json{
             js: unsafe{json_array()},
         }
+    }
+
+    pub fn string(val: &str) -> Json {
+        return Json{
+            js: unsafe{json_string(to_cstring(val.as_bytes()).as_ptr())}
+        };
+    }
+
+    pub fn string_from_bytes(val: &[u8]) -> Json {
+        return Json{
+            js: unsafe{json_string(to_cstring(val).as_ptr())}
+        };
     }
 
     pub fn unwrap(&self) -> *mut JsonT {

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -46,6 +46,7 @@
 #include "detect-metadata.h"
 #include "app-layer-parser.h"
 #include "app-layer-dnp3.h"
+#include "app-layer-dns-common.h"
 #include "app-layer-htp.h"
 #include "app-layer-htp-xff.h"
 #include "app-layer-ftp.h"
@@ -57,6 +58,7 @@
 #include "output-json.h"
 #include "output-json-alert.h"
 #include "output-json-dnp3.h"
+#include "output-json-dns.h"
 #include "output-json-http.h"
 #include "output-json-tls.h"
 #include "output-json-ssh.h"
@@ -181,6 +183,35 @@ static void AlertJsonDnp3(const Flow *f, json_t *js)
         }
     }
 
+    return;
+}
+
+static void AlertJsonDns(const Flow *f, json_t *js)
+{
+#ifndef HAVE_RUST
+    DNSState *dns_state = (DNSState *)FlowGetAppState(f);
+    if (dns_state) {
+        uint64_t tx_id = AppLayerParserGetTransactionLogId(f->alparser);
+        DNSTransaction *tx = AppLayerParserGetTx(f->proto, ALPROTO_DNS,
+                                                 dns_state, tx_id);
+        if (tx) {
+            json_t *dnsjs = json_object();
+            if (unlikely(dnsjs == NULL)) {
+                return;
+            }
+
+            json_t *qjs = JsonDNSLogQuery(tx, tx_id);
+            if (qjs != NULL) {
+                json_object_set_new(dnsjs, "query", qjs);
+            }
+            json_t *ajs = JsonDNSLogAnswer(tx, tx_id);
+            if (ajs != NULL) {
+                json_object_set_new(dnsjs, "answer", ajs);
+            }
+            json_object_set_new(js, "dns", dnsjs);
+        }
+    }
+#endif
     return;
 }
 
@@ -473,6 +504,9 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                 AlertJsonDnp3(p->flow, js);
             }
 
+            if (proto == ALPROTO_DNS) {
+                AlertJsonDns(p->flow, js);
+            }
         }
 
         if (p->flow) {
@@ -487,7 +521,6 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                         json_string(AppProtoToString(p->flow->alproto)));
             }
         }
-
 
         /* payload */
         if (json_output_ctx->flags & (LOG_JSON_PAYLOAD | LOG_JSON_PAYLOAD_BASE64)) {

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -187,6 +187,11 @@ typedef enum {
     DNS_RRTYPE_MAX,
 } DnsRRTypes;
 
+typedef enum {
+    DNS_VERSION_1 = 1,
+    DNS_VERSION_2
+} DnsVersion;
+
 static struct {
     const char *config_rrtype;
     uint64_t flags;
@@ -255,6 +260,7 @@ typedef struct LogDnsFileCtx_ {
     LogFileCtx *file_ctx;
     uint64_t flags; /** Store mode */
     bool include_metadata;
+    DnsVersion version;
 } LogDnsFileCtx;
 
 typedef struct LogDnsLogThread_ {
@@ -817,47 +823,95 @@ static void LogDnsLogDeInitCtxSub(OutputCtx *output_ctx)
     SCFree(output_ctx);
 }
 
+static void JsonDnsLogParseConfig(LogDnsFileCtx *dnslog_ctx, ConfNode *conf,
+                                  const char *query_key, const char *answer_key,
+                                  const char *answer_types_key)
+{
+    const char *query = ConfNodeLookupChildValue(conf, query_key);
+    if (query != NULL) {
+        if (ConfValIsTrue(query)) {
+            dnslog_ctx->flags |= LOG_QUERIES;
+        } else {
+            dnslog_ctx->flags &= ~LOG_QUERIES;
+        }
+    } else {
+        if (dnslog_ctx->version == DNS_VERSION_2) {
+            dnslog_ctx->flags |= LOG_QUERIES;
+        }
+    }
+
+    const char *response = ConfNodeLookupChildValue(conf, answer_key);
+    if (response != NULL) {
+        if (ConfValIsTrue(response)) {
+            dnslog_ctx->flags |= LOG_ANSWERS;
+        } else {
+            dnslog_ctx->flags &= ~LOG_ANSWERS;
+        }
+    } else {
+        if (dnslog_ctx->version == DNS_VERSION_2) {
+            dnslog_ctx->flags |= LOG_ANSWERS;
+        }
+    }
+
+    ConfNode *custom;
+    if ((custom = ConfNodeLookupChild(conf, answer_types_key)) != NULL) {
+        dnslog_ctx->flags &= ~LOG_ALL_RRTYPES;
+        ConfNode *field;
+        TAILQ_FOREACH(field, &custom->head, next)
+        {
+            if (field != NULL)
+            {
+                DnsRRTypes f;
+                for (f = DNS_RRTYPE_A; f < DNS_RRTYPE_MAX; f++)
+                {
+                    if (strcasecmp(dns_rrtype_fields[f].config_rrtype,
+                                   field->val) == 0)
+                    {
+                        dnslog_ctx->flags |= dns_rrtype_fields[f].flags;
+                        break;
+                    }
+                }
+            }
+        }
+    } else {
+        if (dnslog_ctx->version == DNS_VERSION_2) {
+            dnslog_ctx->flags |= LOG_ALL_RRTYPES;
+        }
+    }
+}
+
 static void JsonDnsLogInitFilters(LogDnsFileCtx *dnslog_ctx, ConfNode *conf)
 {
     dnslog_ctx->flags = ~0UL;
 
     if (conf) {
-        const char *query = ConfNodeLookupChildValue(conf, "query");
-        if (query != NULL) {
-            if (ConfValIsTrue(query)) {
-                dnslog_ctx->flags |= LOG_QUERIES;
-            } else {
-                dnslog_ctx->flags &= ~LOG_QUERIES;
+        intmax_t version;
+        int ret = ConfGetChildValueInt(conf, "version", &version);
+        if (ret) {
+            switch(version) {
+                case 1:
+                    dnslog_ctx->version = DNS_VERSION_1;
+                    break;
+                case 2:
+                    dnslog_ctx->version = DNS_VERSION_2;
+                    break;
+                default:
+                    SCLogWarning(SC_ERR_INVALID_ARGUMENT,
+                                 "Invalid version option: %ji, "
+                                 "forcing it to version 1", version);
+                    dnslog_ctx->version = DNS_VERSION_1;
+                    break;
             }
+        } else {
+            SCLogWarning(SC_ERR_INVALID_ARGUMENT,
+                         "Version not found, forcing it to version 1");
+            dnslog_ctx->version = DNS_VERSION_1;
         }
-        const char *response = ConfNodeLookupChildValue(conf, "answer");
-        if (response != NULL) {
-            if (ConfValIsTrue(response)) {
-                dnslog_ctx->flags |= LOG_ANSWERS;
-            } else {
-                dnslog_ctx->flags &= ~LOG_ANSWERS;
-            }
-        }
-        ConfNode *custom;
-        if ((custom = ConfNodeLookupChild(conf, "custom")) != NULL) {
-            dnslog_ctx->flags &= ~LOG_ALL_RRTYPES;
-            ConfNode *field;
-            TAILQ_FOREACH(field, &custom->head, next)
-            {
-                if (field != NULL)
-                {
-                    DnsRRTypes f;
-                    for (f = DNS_RRTYPE_A; f < DNS_RRTYPE_MAX; f++)
-                    {
-                        if (strcasecmp(dns_rrtype_fields[f].config_rrtype,
-                                       field->val) == 0)
-                        {
-                            dnslog_ctx->flags |= dns_rrtype_fields[f].flags;
-                            break;
-                        }
-                    }
-                }
-            }
+
+        if (dnslog_ctx->version == DNS_VERSION_1) {
+            JsonDnsLogParseConfig(dnslog_ctx, conf, "query", "answer", "custom");
+        } else {
+            JsonDnsLogParseConfig(dnslog_ctx, conf, "requests", "responses", "types");
         }
     }
 }
@@ -865,6 +919,11 @@ static void JsonDnsLogInitFilters(LogDnsFileCtx *dnslog_ctx, ConfNode *conf)
 static OutputInitResult JsonDnsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
     OutputInitResult result = { NULL, false };
+    const char *enabled = ConfNodeLookupChildValue(conf, "enabled");
+    if (enabled != NULL && !ConfValIsTrue(enabled)) {
+        return result;
+    }
+
     OutputJsonCtx *ojc = parent_ctx->data;
 
     LogDnsFileCtx *dnslog_ctx = SCMalloc(sizeof(LogDnsFileCtx));
@@ -905,6 +964,11 @@ static OutputInitResult JsonDnsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_c
 static OutputInitResult JsonDnsLogInitCtx(ConfNode *conf)
 {
     OutputInitResult result = { NULL, false };
+    const char *enabled = ConfNodeLookupChildValue(conf, "enabled");
+    if (enabled != NULL && !ConfValIsTrue(enabled)) {
+        return result;
+    }
+
     LogFileCtx *file_ctx = LogFileNewCtx();
 
     if(file_ctx == NULL) {

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -520,10 +520,6 @@ static void OutputAnswerDetailed(DNSAnswerEntry *entry, json_t *js,
         uint64_t flags)
 {
     do {
-        if (!DNSRRTypeEnabled(entry->type, flags)) {
-            continue;
-        }
-
         json_t *jdata = json_object();
         if (jdata == NULL) {
             return;
@@ -978,6 +974,10 @@ static void LogAnswers(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx, uin
     SCLogDebug("got a DNS response and now logging !!");
 
     if (aft->dnslog_ctx->version == DNS_VERSION_2) {
+        DNSQueryEntry *query = TAILQ_FIRST(&tx->query_list);
+        if (query && !DNSRRTypeEnabled(query->type, aft->dnslog_ctx->flags)) {
+            return;
+        }
         OutputAnswerV2(aft, js, tx);
     } else {
         DNSAnswerEntry *entry = NULL;

--- a/src/output-json-dns.h
+++ b/src/output-json-dns.h
@@ -26,4 +26,11 @@
 
 void JsonDnsLogRegister(void);
 
+#ifdef HAVE_LIBJANSSON
+#include "app-layer-dns-common.h"
+
+json_t *JsonDNSLogQuery(DNSTransaction *tx, uint64_t tx_id) __attribute__((nonnull));
+json_t *JsonDNSLogAnswer(DNSTransaction *tx, uint64_t tx_id) __attribute__((nonnull));
+#endif
+
 #endif /* __OUTPUT_JSON_DNS_H__ */

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -105,6 +105,15 @@ json_t *SCJsonBool(int val)
     return (val ? json_true() : json_false());
 }
 
+/**
+ * Wrap json_decref. This is mainly to expose this function to Rust as its
+ * defined in the Jansson header file as an inline function.
+ */
+void SCJsonDecref(json_t *json)
+{
+    json_decref(json);
+}
+
 /* Default Sensor ID value */
 static int64_t sensor_id = -1; /* -1 = not defined */
 

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -59,6 +59,7 @@ typedef struct OutputJsonCtx_ {
 } OutputJsonCtx;
 
 json_t *SCJsonBool(int val);
+void SCJsonDecref(json_t *js);
 
 #endif /* HAVE_LIBJANSSON */
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -203,13 +203,35 @@ outputs:
             # the example below adds three additional fields when uncommented
             #custom: [Accept-Encoding, Accept-Language, Authorization]
         - dns:
-            # control logging of queries and answers
-            # default yes, no to disable
-            query: yes     # enable logging of DNS queries
-            answer: yes    # enable logging of DNS answers
-            # control which RR types are logged
-            # all enabled if custom not specified
-            #custom: [a, aaaa, cname, mx, ns, ptr, txt]
+            # This configuration uses the new DNS logging format,
+            # the old configuration is still available:
+            # http://suricata.readthedocs.io/en/latest/configuration/suricata-yaml.html#eve-extensible-event-format
+            # Use version 2 logging with the new format:
+            # dns answers will be logged in one single event
+            # rather than an event for each of it.
+            # Without setting a version the version
+            # will fallback to 1 for backwards compatibility.
+            version: 2
+
+            # Enable/disable this logger. Default: enabled.
+            #enabled: no
+
+            # Control logging of requests and responses:
+            # - requests: enable logging of DNS queries
+            # - responses: enable logging of DNS answers
+            # By default both requests and responses are logged.
+            #requests: no
+            #responses: no
+
+            # Format of answer logging:
+            # - detailed: array item per answer
+            # - grouped: answers aggregated by type
+            # Default: all
+            #formats: [detailed, grouped]
+
+            # Answer types to log.
+            # Default: all
+            #types: [a, aaaa, cname, mx, ns, ptr, txt]
         - tls:
             extended: yes     # enable this for extended logging information
             # output TLS transaction where the session is resumed using a


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
- https://redmine.openinfosecfoundation.org/issues/2199
- https://redmine.openinfosecfoundation.org/issues/1198
- https://redmine.openinfosecfoundation.org/issues/2086

Previous PR:
- https://github.com/OISF/suricata/pull/3125

Changes from last PR:
- Add authorities to the response record under the authorities key to prevent standalone records just for authorities.
- Include the query rrname in the response. Makes the response more useful on its own, and adds more contaxt to NXDOMAIN return types that don't have any answers.
- When logging responses, the response will only be logged if the query type is enabled for logging.
- Update Rust DNS to support v2 records (and remove the old format from Rust).

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/269
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/622

cc: @glongo 