### PR TITLE
app-layer: add tx iterator API

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -1302,15 +1302,10 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
  *  \brief get a DetectTransaction object
  *  \retval struct filled with relevant info or all nulls/0s
  */
-static DetectTransaction GetTx(const uint8_t ipproto, const AppProto alproto,
-        void *alstate, const uint64_t tx_id, const int tx_end_state,
+static DetectTransaction GetDetectTx(const uint8_t ipproto, const AppProto alproto,
+        void *alstate, const uint64_t tx_id, void *tx_ptr, const int tx_end_state,
         const uint8_t flow_flags)
 {
-    void *tx_ptr = AppLayerParserGetTx(ipproto, alproto, alstate, tx_id);
-    if (tx_ptr == NULL) {
-        DetectTransaction no_tx = { NULL, 0, NULL, 0, 0, 0, 0, 0, };
-        return no_tx;
-    }
     const uint64_t detect_flags = AppLayerParserGetTxDetectFlags(ipproto, alproto, tx_ptr, flow_flags);
     if (detect_flags & APP_LAYER_TX_INSPECTED_FLAG) {
         SCLogDebug("%"PRIu64" tx already fully inspected for %s. Flags %016"PRIx64,
@@ -1351,14 +1346,20 @@ static void DetectRunTx(ThreadVars *tv,
     void * const alstate = f->alstate;
     const uint8_t ipproto = f->proto;
     const AppProto alproto = f->alproto;
+    void *tx_ptr;
 
     const uint64_t total_txs = AppLayerParserGetTxCnt(f, alstate);
     uint64_t tx_id = AppLayerParserGetTransactionInspectId(f->alparser, flow_flags);
     const int tx_end_state = AppLayerParserGetStateProgressCompletionStatus(alproto, flow_flags);
 
-    for ( ; tx_id < total_txs; tx_id++) {
-        DetectTransaction tx = GetTx(ipproto, alproto,
-                alstate, tx_id, tx_end_state, flow_flags);
+    AppLayerGetTxIteratorFunc IterFunc = AppLayerGetTxIterator(ipproto, alproto);
+    AppLayerGetTxIterState state;
+    memset(&state, 0, sizeof(state));
+
+    while ((tx_ptr = IterFunc(ipproto, alproto, alstate, tx_id, total_txs, &tx_id, &state)) != NULL)
+    {
+        DetectTransaction tx = GetDetectTx(ipproto, alproto,
+                alstate, tx_id, tx_ptr, tx_end_state, flow_flags);
         if (tx.tx_ptr == NULL) {
             SCLogDebug("%p/%"PRIu64" no transaction to inspect",
                     tx.tx_ptr, tx_id);


### PR DESCRIPTION
Until now, the transaction space is assumed to be terse. Transactions
are handled sequentially so the difference between the lowest and highest
active tx id's is small. For this reason the logic of walking every id
between the 'minimum' and max id made sense. The space might look like:

    [..........TTTT]

Here the looping starts at the first T and loops 4 times.

This assumption isn't a great fit though. A protocol like NFS has 2 types
of transactions. Long running file transfer transactions and short lived
request/reply pairs are causing the id space to be sparse. This leads to
a lot of unnecessary looping in various parts of the engine, but most
prominently: detection, tx house keeping and tx logging.

    [.T..T...TTTT.T]

Here the looping starts at the first T and loops for every spot, even
those where no tx exists anymore.

Cases have been observed where the lowest tx id was 2 and the highest
was 50k. This lead to a lot of unnecessary looping.

This patch add an alternative approach. It allows a protocol to register
an iterator function, that simply returns the next transaction until
all transactions are returned. To do this it uses a bit of state the
caller must keep.

The registration is optional. If no iterator is registered the old
behaviour will be used.


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/84
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/86
