### PR TITLE
 Startup: Check if logrotation will still work after priv drop (Issue #2386) v2

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2039,6 +2039,46 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         }
     }
 
+#ifndef OS_WIN32
+    /* Get the suricata user ID to given user ID */
+    if (suri->do_setuid == TRUE) {
+        if (SCGetUserID(suri->user_name, suri->group_name,
+                        &suri->userid, &suri->groupid) != 0) {
+            SCLogError(SC_ERR_UID_FAILED, "failed in getting user ID");
+            return TM_ECODE_FAILED;
+        }
+    /* Get the suricata group ID to given group ID */
+    } else if (suri->do_setgid == TRUE) {
+        if (SCGetGroupID(suri->group_name, &suri->groupid) != 0) {
+            SCLogError(SC_ERR_GID_FAILED, "failed in getting group ID");
+            return TM_ECODE_FAILED;
+        }
+    }
+
+    if (set_log_directory
+        && ConfigCheckFileWritablePrivDrop(ConfigGetLogDirectory()) != TM_ECODE_DONE ) {
+
+        if (suri->do_setuid || suri->do_setgid) { /* We will drop privileges */
+            FatalError(SC_ERR_LOGDIR_CMDLINE,
+                      "After dropping privileges to another user the logfile directory \"%s\" "
+                      "defined on the commandline (-l parameter) will no longer be writeable. "
+                      "This means after logrotation it will not be possible to create a new "
+                      "logfile and all following logmessages will get lost. "
+                      "To avoid this, please make the default logdir writeable "
+                      "for the privilege drop user or configure another logdir. Exiting ..." ,
+                       ConfigGetLogDirectory());
+        } else { /* We will not drop privileges */
+            FatalError(SC_ERR_LOGDIR_CMDLINE,
+                      "The logfile directory \"%s\" defined on the commandline (-l parameter) is not writeable. "
+                      "This means after logrotation it will not be possible to create a new "
+                      "logfile and all following log messages will get lost. "
+                      "To avoid this, please make the default logdir writeable "
+                      "or configure another logdir. Exiting ...",
+                       ConfigGetLogDirectory());
+        }
+    }
+#endif /* OS_WIN32 */
+
     if (suri->disabled_detect && suri->sig_file != NULL) {
         SCLogError(SC_ERR_INITIALIZATION, "can't use -s/-S when detection is disabled");
         return TM_ECODE_FAILED;
@@ -2669,6 +2709,31 @@ static int PostConfLoadedSetup(SCInstance *suri)
     if (InitSignalHandler(suri) != TM_ECODE_OK)
         SCReturnInt(TM_ECODE_FAILED);
 
+#ifndef OS_WIN32
+    if (ConfigCheckFileWritablePrivDrop(suri->log_dir) != TM_ECODE_DONE) {
+
+        if (sc_set_caps) { /* We will drop privileges */
+            FatalError(SC_ERR_LOGDIR_CONFIG,
+                      "After dropping privileges to another user the logfile directory \"%s\" "
+                      "defined in %s will no longer be writeable. "
+                      "This means after logrotation it will not be possible to create a new "
+                      "logfile and all following log messages will get lost. "
+                      "To avoid this, please make the default logdir writeable "
+                      "for the privilege drop user or configure another logdir. Exiting ...",
+                       suri->log_dir,
+                       suri->conf_filename);
+        } else { /* We will not drop privileges */
+            FatalError(SC_ERR_LOGDIR_CONFIG,
+                      "The logfile directory \"%s\" defined in %s is not writeable. "
+                      "This means after logrotation it will not be possible to create a new "
+                      "logfile and all following log messages will get lost. "
+                      "To avoid this, please make the default logdir writeable "
+                      "or configure another logdir. Exiting ...",
+                       suri->log_dir,
+                       suri->conf_filename);
+        }
+    }
+#endif /* OS_WIN32 */
 
 #ifdef HAVE_NSS
     if (suri->run_mode != RUNMODE_CONF_TEST) {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1901,7 +1901,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 SCLogError(SC_ERR_FATAL, "Failed to set log directory.\n");
                 return TM_ECODE_FAILED;
             }
-            if (ConfigCheckLogDirectory(optarg) != TM_ECODE_OK) {
+            if (ConfigCheckFileExists(optarg) != TM_ECODE_OK) {
                 SCLogError(SC_ERR_LOGDIR_CMDLINE, "The logging directory \"%s\""
                         " supplied at the commandline (-l %s) doesn't "
                         "exist. Shutting down the engine.", optarg, optarg);
@@ -2612,7 +2612,7 @@ static int PostConfLoadedSetup(SCInstance *suri)
      * from suricata.yaml.  If not found, shut the engine down */
     suri->log_dir = ConfigGetLogDirectory();
 
-    if (ConfigCheckLogDirectory(suri->log_dir) != TM_ECODE_OK) {
+    if (ConfigCheckFileExists(suri->log_dir) != TM_ECODE_OK) {
         SCLogError(SC_ERR_LOGDIR_CONFIG, "The logging directory \"%s\" "
                 "supplied by %s (default-log-dir) doesn't exist. "
                 "Shutting down the engine", suri->log_dir, suri->conf_filename);

--- a/src/util-conf.c
+++ b/src/util-conf.c
@@ -59,7 +59,7 @@ const char *ConfigGetLogDirectory()
     return log_dir;
 }
 
-TmEcode ConfigCheckLogDirectory(const char *log_dir)
+TmEcode ConfigCheckFileExists(const char *filename)
 {
     SCEnter();
 #ifdef OS_WIN32
@@ -67,7 +67,7 @@ TmEcode ConfigCheckLogDirectory(const char *log_dir)
     if (_stat(log_dir, &buf) != 0) {
 #else
     struct stat buf;
-    if (stat(log_dir, &buf) != 0) {
+    if (stat(filename, &buf) != 0) {
 #endif /* OS_WIN32 */
             SCReturnInt(TM_ECODE_FAILED);
     }

--- a/src/util-conf.h
+++ b/src/util-conf.h
@@ -31,6 +31,8 @@ TmEcode ConfigSetLogDirectory(char *name);
 const char *ConfigGetLogDirectory(void);
 TmEcode ConfigCheckLogDirectory(const char *log_dir);
 
+TmEcode ConfigCheckFileWritablePrivDrop(const char * const filename);
+
 ConfNode *ConfFindDeviceConfig(ConfNode *node, const char *iface);
 
 int ConfUnixSocketIsEnable(void);

--- a/src/util-conf.h
+++ b/src/util-conf.h
@@ -29,7 +29,7 @@
 
 TmEcode ConfigSetLogDirectory(char *name);
 const char *ConfigGetLogDirectory(void);
-TmEcode ConfigCheckLogDirectory(const char *log_dir);
+TmEcode ConfigCheckFileExists(const char *filename);
 
 TmEcode ConfigCheckFileWritablePrivDrop(const char * const filename);
 

--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -235,4 +235,92 @@ int SCGetGroupID(const char *group_name, uint32_t *gid)
 
     return 0;
 }
+
+/**
+ * \brief   Check if requested file access is allowed for arbitrary user, file and access mode
+ *          (pure, no side effects)
+ *
+ * \param   asked_uid      The uid to check for
+ * \param   asked_gids     Array of the gids to check for
+ * \param   gid_count      The number gids at the supplied gid array address
+ * \param   file_stat_struct   Pointer to the stat() return struct of the file to check for
+ * \param   requested_access   The requested access mode
+ *                             Use access type macro symbols from unistd.h, like in man 2 access
+ *
+ * \retval  Boolean. True if requested access is allowed. False otherwise
+ */
+bool SCCheckArbitraryFileAccess(const uid_t asked_uid,
+                                const gid_t * const asked_gids,
+                                const int gid_count,
+                                struct stat const * const file_stat_struct,
+                                const int requested_permissions)
+{
+    /* Step 0: root can do anything, so for root don't bother and just return true */
+    if (asked_uid == 0) {
+        return true;
+        /* the root group is not special in any way, so we don't need to check for it */
+    }
+
+    /* Step 1: Prepare Bitmasks for permission checks */
+    /* This is necesarry because the requested_permission bitfield is
+     * in another format (no notion of group/user/other) than the stat() return mode bit field */
+    int requested_user_permissions_bitmask   = 0;
+    int requested_group_permissions_bitmask  = 0;
+    int requested_others_permissions_bitmask = 0;
+
+    if (requested_permissions & R_OK) {
+        requested_user_permissions_bitmask   |= S_IRUSR;
+        requested_group_permissions_bitmask  |= S_IRGRP;
+        requested_others_permissions_bitmask |= S_IROTH;
+    }
+    if (requested_permissions & W_OK) {
+        requested_user_permissions_bitmask   |= S_IWUSR;
+        requested_group_permissions_bitmask  |= S_IWGRP;
+        requested_others_permissions_bitmask |= S_IWOTH;
+    }
+    if (requested_permissions & X_OK) {
+        requested_user_permissions_bitmask   |= S_IXUSR;
+        requested_group_permissions_bitmask  |= S_IXGRP;
+        requested_others_permissions_bitmask |= S_IXOTH;
+    }
+
+    /* Step 2: Check the permission flags */
+
+    /* if we are file owner... */
+    if (asked_uid == file_stat_struct->st_uid) { /* check owner permissions */
+
+        /* Here we check multiple flags at once by first querying all the
+         * relevant bits with AND and than checking if all the relevant bits
+         * are there. (They only are if the result is equal to the mask
+         * i.e same bits set). Same happens for group and others */
+        const int relevant_bits = file_stat_struct->st_mode
+                                  & requested_user_permissions_bitmask;
+
+        if (relevant_bits == requested_user_permissions_bitmask)
+            return true;
+    }
+
+    /* for groups the process is in */
+    for (int i = 0; i < gid_count; i++) {
+        const gid_t gid_to_check = asked_gids[i];
+
+        /* if it matches file group */
+        if (gid_to_check == file_stat_struct->st_gid) {
+            const int relevant_bits = file_stat_struct->st_mode
+                                      & requested_group_permissions_bitmask;
+            if (relevant_bits == requested_group_permissions_bitmask)
+                return true;
+         }
+    }
+
+    /* check "others" permissions */
+    const int relevant_bits = file_stat_struct->st_mode
+                              & requested_others_permissions_bitmask;
+    if (relevant_bits == requested_others_permissions_bitmask) {
+        return true;
+    }
+
+    return false;  /* none matched */
+}
+
 #endif /* OS_WIN32 */

--- a/src/util-privs.h
+++ b/src/util-privs.h
@@ -94,5 +94,11 @@ void SCDropMainThreadCaps(uint32_t , uint32_t );
 int SCGetUserID(const char *, const char *, uint32_t *, uint32_t *);
 int SCGetGroupID(const char *, uint32_t *);
 
+bool SCCheckArbitraryFileAccess(const uid_t asked_uid,
+                                const gid_t * const asked_gids,
+                                const int gid_count,
+                                struct stat const * const file_stat_struct,
+                                const int requested_permissions);
+
 #endif	/* _UTIL_PRIVS_H */
 


### PR DESCRIPTION
## Checkboxes

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

## Redmine Ticket
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2386

## Description of Patch:
Write permission on the logdir is necesarry to create new files in there, which is necesary after logrotation to continue logging. (use cases: exe.json and others)

If suricata could open the log files but not create new ones it silently failed, not writing any logs after the first logrotation. This patch adds a check before priv drop and warns+exit()s if we will not be able to create new files after priv drop.

If we won't drop privs we check if the current (and general) user will be able to create logfiles after log rotation.

For details and discussion see:
https://redmine.openinfosecfoundation.org/issues/2386

## Previous PR (v1)
 #3197

## Changes from v1

  * remove all superfluous `#include`s of standard unix headers
  * don't use malloc and heap for supplementary `gids` array but a variable length array on stack available since C99
  * write `const` before the type of the var it constifies because it's suricata convention that way
  * make suricata struct instance a global variable in `util-conf.c`, to avoid passing it as param, to avoid circular header inclusion problems
  * directly pass `strerror()` output string to `FatalError()`
  * directly call `FatalError()` in suricata.c
  * rephrase error messages
  * implement semantics of root user (root can always write to files, even if he doesn't own them)
  

## PRScript
[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR richi235-pcap: https://buildbot.openinfosecfoundation.org/builders/richi235-pcap/builds/3
- PR richi235: https://buildbot.openinfosecfoundation.org/builders/richi235/builds/3