### PR TITLE
    Add experimental pkt processing times with nfq v0.2d

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -967,6 +967,11 @@
         if test "x$libnetfilter_queue_nfq_get_payload_signed" = "xyes"; then
             AC_DEFINE([NFQ_GET_PAYLOAD_SIGNED], [1], [For signed version of nfq_get_payload])
         fi
+        AC_ARG_ENABLE(nfqmemseg,
+             AS_HELP_STRING([--enable-nfqmemseg], [Enable NFQUEUE memseg support for packet transit time]),[enable_nfqmemseg=yes],[enable_nfqmemseg=no])
+        if test "x$enable_nfqmemseg" = "xyes"; then
+            AC_DEFINE([NFQ_MEMSEG], [1], [For packet processing time collection in memseg in NFQ mode])
+        fi
         CFLAGS="${STORECFLAGS}"
 
         if test "$NFQ" = "no"; then

--- a/contrib/experimental-pkt-processing-times-with-nfq/README.NFQmemseg
+++ b/contrib/experimental-pkt-processing-times-with-nfq/README.NFQmemseg
@@ -1,0 +1,103 @@
+Demo-of-concept Suricata code mods and external programs to allow
+monitoring Suricata inline packet processing time while using
+netfilter queues. This example uses external programs to minimize
+processing in Suricata.
+
+Background:
+
+Suricata is designed and built for high speed IDS/IPS detection. The
+designers (quite correctly) resist adding any feature that could slow
+down packet processing.
+
+As a demo of using ancient features of the Unix operating system, and
+because I'm curious about performance and Linux behavior under load,
+I've put together this demo of using shared memory and external
+processing to monitor the time it takes Suricata to get a packet from,
+process the packet, and return it to the netfilter queue. Kernel
+processing time isn't part of this, just Suri processing time.
+
+How it works.
+
+1. Added into Suricata's NFQ module, at the time the packet is handed
+back to netfilter for forwarding, rerouting or drop, the receipt time
+(delivered in the packet skb) and the current time (gotten from
+gettimeofday()) are saved into shared memory, and the current packet
+id is stored in the same shared structure. The gettimeofday() is the
+only call made by the added code in Suricata per packet.
+
+2. An external program (processmem) runs in a loop, looking for a new
+packet to process. When it sees that there is one, it gets the
+received and sent times from the shared memory, calculates the time
+difference, and updates an array of packet delta times according to
+the time difference. The delta times array is an array of 500 buckets,
+each representing a range of 10 microseconds, and containing the count
+of packets that fit within that time range (since startup of the
+processmem program or zeroing of the times/counts array).
+
+Processmem is an interactive program, in that it can be controlled by
+key presses while operating. If processmem isn't running, Suricata
+doesn't store anything in the shared memory segment, or do the
+gettimeofday() call to get the time of sending the packet off to
+netfilter (and thus should be essentially the same performance as
+"stock" Suricata). The list of commands/info can be seen by pressing
+the 'h' key while processmem is running. 'q' to quit, 'x' to see
+current pkt id and boxcar average of the times of the last 100 pkts.
+
+Processmem has two run modes - running in a dead loop looking for new
+packets, and a less intrusive mode that still gives a representative
+(but incomplete) look at the Suri processing time spread, by invoking
+a sched yield each time around the loop after it looks for a new
+packet. In the "slow" mode, processmem uses about 7-8% of a processor
+on my I7 box, in the fast mode it's 100% of a core (but it doesn't
+miss much in "fast" mode ).
+
+I usually run processmem in a screen or tmux session, since I'm rarely
+logged into my firewall other than over a network connection.
+
+3. A third program, readspread, is used to read the counts of packets
+within the 500 buckets (corresponding to 0 to 9 usec per bucket). A
+single argument controls how many buckets are printed per line,
+defaulting to 8 if nothing is given. I typically invoke it like this:
+
+"watch -n 1 -d readspread"
+
+or
+
+"watch -n 1 -d readspread 3"
+
+if you're using an 80 column terminal. (Run as root).
+
+The shared memory segment can be identified by the key "0xdeadbeef",
+and isn't removed between suricata runs, so the counters just keep
+incrementing unless zeroed.  To start from scratch, stop suricata and
+processmem, then remove the shared mem using "ipcrm -m " (shmid). Find
+the shmid from "ipcs -m". Nattach must be 0 for it to be actually
+removed; you can remove with ipcrm, but it won't be removed until the
+number of processes attached goes to zero.
+
+To build Suricata:
+
+Autogen.sh as usual, then configure with --enable-nfqueue and
+--enable-nfqmemseg.
+
+To build processmem and readspread:
+
+Install ncurses development package, if you don't already have it.
+
+gcc -g -O processmem.c -o processmem -lncurses
+
+gcc -g -O readspread.c -o readspread
+
+Notes:
+
+This experimental code for Suricata is currently meant to be run in a
+single instance of Suricata; only a single shared memory segment is
+created/used, and multiple copies of Suricata would step all over each
+other's data. Further development would be needed to make it
+multi-Suricata process safe.
+
+Suggestion:
+
+If you're remotely logged into the Suri machine, and want to keep
+processmem running if you get logged out, fire it up in a screen or
+tmux session.

--- a/contrib/experimental-pkt-processing-times-with-nfq/processmem.c
+++ b/contrib/experimental-pkt-processing-times-with-nfq/processmem.c
@@ -1,0 +1,191 @@
+/* Copyright (C) 2007-2017 Open Information Security Foundation
+ *            
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *            
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *            
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Dave Remien <dave.remien@gmail.com>
+ *
+ *  Use shared memseg to receive packet timing info from Suricata, (mods in
+ *  source-nfq.[ch]), and process counts into 10 usec buckets (0 to 4999 usec).
+ *  Suricata only records this info if this program is attached to the shared
+ *  memseg, to minimize CPU utilization in Suricata.
+ *
+ */
+
+#include <unistd.h>
+#include <curses.h>
+#include <signal.h>
+#include <time.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+
+
+
+
+#define BOX 100.0
+#define SHMID 0xdeadbeef
+#define SHM_SIZE 65536  /* make it a 64K shared memory segment */
+
+
+
+
+
+struct {
+    int reader_attached;
+    struct {
+	    struct timeval pktrcvd;
+	    struct timeval pktsent;
+	    uint32_t id;
+	} pkttimes[1024];
+    uint32_t updated;
+    uint64_t buckets10us[500];
+    double boxcar;
+    int shmid;
+} *m;
+
+int main(argc, argv)
+	int	argc;
+ 	char	*argv[];
+{
+
+    int shmid;
+    long n, i, j;
+    int mode;
+    uint32_t pmod;
+    int ntimes;
+    uint64_t delta;
+    uint32_t lastpktid;
+
+
+
+    /*   create or map the segment:  */
+    if ((shmid = shmget(SHMID, SHM_SIZE, 0644)) == -1) {
+ 	    perror("shmget");
+ 	    exit(1);
+    }
+
+    /* attach to the segment to get a pointer to it: */
+    m = shmat(shmid, (void *)0, 0);
+    if ((long)m == (-1)) {
+ 	    perror("shmat");
+ 	    exit(1);
+    }
+
+    m->reader_attached = 1;
+    mode = 0;
+    char c;
+    extern	void die();
+    ntimes = 1;
+
+    signal(SIGHUP, die);
+    signal(SIGINT, die);
+    signal(SIGQUIT, die);
+    signal(SIGTERM, die);
+
+    initscr();
+    cbreak();
+    noecho();
+    nodelay(stdscr, TRUE);
+    /*halfdelay(1); */
+    clear();
+
+    while (TRUE) {
+ 	    if (m->updated){
+ 	        lastpktid = m->updated;
+			pmod = lastpktid % 1024;
+			delta =
+			        ((((m->pkttimes[pmod].pktsent.tv_sec -
+						m->pkttimes[pmod].pktrcvd.tv_sec) * 1000000) +
+					  (m->pkttimes[pmod].pktsent.tv_usec - 
+					    m->pkttimes[pmod].pktrcvd.tv_usec)));
+			m->boxcar = (m->boxcar - (m->boxcar / BOX) + (double)delta / BOX);
+			if(delta < 4990)m->buckets10us[(delta / 10)]++;
+			else m->buckets10us[499]++;
+			m->updated = 0;
+		}
+		if ( !(ntimes++ % 100000)) {
+		    c = getch();
+			if(c == 81 || c == 113){
+			    die();
+			}else if(c == 67 || c == 99 || c == 12){
+			    initscr();
+				cbreak();
+				noecho();
+				nodelay(stdscr, TRUE);
+				clear();
+			}else if(c == 120){
+			    move(0, 0);
+				printw("pktid %d boxcar avg of last %d pkts =  %10.1f usec mode = %d",
+					   lastpktid, (int)BOX, m->boxcar, mode % 2);
+				addch('\n');
+				clrtoeol();
+				clrtobot();
+				move(LINES-1, 0);
+				printw(" Press 'h' for help.");
+				refresh();
+			}else if(c == 109){
+			    mode++;
+			}else if(c == 122){
+			    for (i = 0; i < 500; i++)m->buckets10us[i] = 0;
+			}else if(c == 104 || c == 72){   // Help!
+			    move (5, 0);
+				printw(" Help: \n");
+				printw(" c or C - clears screen, refreshes\n");
+				printw(" m - Mode change (dead loop (0) or with sched yield (1) - toggle)\n");
+				printw(" z - zero the 500 buckets (10 us per bucket)\n");
+				printw(" x - update the pktid / avg / mode line\n");
+				printw(" w - warranty\n");
+				printw(" l - license info\n");
+				printw(" q or Q - quit, detaching from memseg and stopping delta time collection for pkts\n");
+				clrtobot();
+				refresh();
+			}else if(c == 108){
+			    move (5, 0);
+				printw(" License and redistribution:\n\n");
+				printw(" See LICENSE and COPYING files in the top level suricata directory.\n");
+				clrtoeol();
+				clrtobot();
+				refresh();
+			}else if(c == 119){
+			    move (5, 0);
+				printw(" Warranty: \n\n");
+				printw(" processmem version 1, Copyright (C) 2017 Dave Remien\n");
+				printw(" processmem comes with ABSOLUTELY NO WARRANTY; for details type 'l'.\n");
+				printw(" This is free software, and you are welcome to redistribute it\n");
+				printw(" under certain conditions; type 'l' for details.\n");
+				clrtoeol();
+				clrtobot();
+				refresh();
+			}
+		}
+	    if(mode % 2) usleep(0);
+	}
+}
+
+void die()
+{
+    m->reader_attached = 0;
+    move(LINES-1, 0);
+    clrtoeol();
+    refresh();
+    endwin();
+    fprintf(stderr, " Time to die...\n");
+    exit(0);
+}

--- a/contrib/experimental-pkt-processing-times-with-nfq/readspread.c
+++ b/contrib/experimental-pkt-processing-times-with-nfq/readspread.c
@@ -1,0 +1,93 @@
+/* Copyright (C) 2007-2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Dave Remien <dave.remien@gmail.com>
+ *
+ *  Use shared memseg to receive packet timing info from Suricata, (mods in
+ *  source-nfq.c), and process counts into 10 usec buckets (0 to 4999 usec).
+ *  Suricata only records this info if this program is attached to the shared
+ *  memseg, to minimize CPU utilization in Suricata.
+ *  This program displays the bucket counts for each time segment (0-9 usec,
+ *  10-19 usec, etc.).
+ *
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+
+
+
+
+#define SHM_SIZE 65536  /* make it a 64K shared memory segment */
+
+struct  memseg {
+    int reader_attached;
+    struct {
+	    struct timeval pktrcvd;
+	    struct timeval pktsent;
+	    uint32_t id;
+	} pkttimes[1024];
+    uint32_t updated;
+    uint64_t buckets10us[500];
+    double boxcar;
+    int shmid;
+} *m;
+
+
+int main(argc, argv)
+	int	argc;
+	char	*argv[];
+{
+
+    int shmid;
+	long n, i, j;
+	int mode;
+	int nperline;
+	int ntimes;
+
+	nperline = 8;
+	if (argc > 1)nperline = atoi(argv[1]);
+	/*  get the handle of the segment: */
+	if ((shmid = shmget(0xdeadbeef, SHM_SIZE, 0644)) == -1) {
+	    perror("shmget");
+		exit(1);
+	}
+
+	/* attach to the segment to get a pointer to it: */
+    m = shmat(shmid, (void *)0, 0);
+    if ((long)m == (-1)) {
+	    perror("shmat");
+	    exit(1);
+    }
+
+
+	for (i = 0; i < 500; i++){
+	    if(m->buckets10us[i])printf ("%5ld usec # = %7ld  ", i * 10, 
+                  m->buckets10us[i]);
+	    if (!(i % nperline))printf("\n");
+	}
+	printf("\n");
+}

--- a/src/source-nfq.h
+++ b/src/source-nfq.h
@@ -94,6 +94,26 @@ int NFQGetQueueCount(void);
 void *NFQGetQueue(int number);
 int NFQGetQueueNum(int number);
 void *NFQGetThread(int number);
+
+#ifdef NFQ_MEMSEG
+
+#define SHM_SIZE 65536  /* make it a 1K shared memory segment */
+#define NFQ_TIMEVALS 1024
+struct NFQmemseg {
+  int reader_attached;
+  struct {
+	struct timeval pktrcvd;
+	struct timeval pktsent;
+	uint32_t id;
+  } pkttimes[1024];
+  uint32_t updated;
+  uint64_t buckets10us[500];
+  double boxcar;
+  int shmid;
+} *memseg;
+
+#endif /* NFQ_MEMSEG */
+
 #endif /* NFQ */
 #endif /* __SOURCE_NFQ_H__ */
 


### PR DESCRIPTION

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
Well, added a README in contrib/experimental-pkt-processing-times-with-nfq
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
NA - No one (in their right mind) has requested this.
Describe changes:

   Add code to source-nfq.[ch] to capture times of pkt receipt from and re-submission to NFQing.
    Receipt time = from skb, resubmission time just before handing back to NFQ. Delta t is nominally
    time spent processing be Suricata, recorded in shared memseg, with delta time stored in 10 usec
    buckets in memseg. Two external programs take care of math, bookkeeping and display.
    Added configure option "--enable-nfqmemseg" to enable memseg code in source-nfq.[ch] (per 
    Victor's request).


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

