### PR TITLE
Optimization/tx iterator/v8

### DIFF
--- a/rust/gen-c-headers.py
+++ b/rust/gen-c-headers.py
@@ -88,6 +88,8 @@ type_map = {
     "core::AppLayerDecoderEvents": "AppLayerDecoderEvents",
     "AppLayerDecoderEvents": "AppLayerDecoderEvents",
     "core::AppLayerEventType": "AppLayerEventType",
+    "applayer::AppLayerGetTxIterTuple": "AppLayerGetTxIterTuple",
+    "AppLayerGetTxIterTuple": "AppLayerGetTxIterTuple",
     "AppLayerEventType": "AppLayerEventType",
     "CLuaState": "lua_State",
     "Store": "Store",

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -15,6 +15,29 @@
  * 02110-1301, USA.
  */
 
+extern crate libc;
+use std;
+
+#[repr(C)]
+pub struct AppLayerGetTxIterTuple {
+    tx_ptr: *mut libc::c_void,
+    tx_id: u64,
+    has_next: bool,
+}
+
+impl AppLayerGetTxIterTuple {
+    pub fn with_values(tx_ptr: *mut libc::c_void, tx_id: u64, has_next: bool) -> AppLayerGetTxIterTuple {
+        AppLayerGetTxIterTuple {
+            tx_ptr: tx_ptr, tx_id: tx_id, has_next: has_next,
+        }
+    }
+    pub fn not_found() -> AppLayerGetTxIterTuple {
+        AppLayerGetTxIterTuple {
+            tx_ptr: std::ptr::null_mut(), tx_id: 0, has_next: false,
+        }
+    }
+}
+
 /// LoggerFlags tracks which loggers have already been executed.
 #[derive(Debug)]
 pub struct LoggerFlags {

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -244,8 +244,6 @@ pub struct DNSState {
     // Transactions.
     pub transactions: Vec<DNSTransaction>,
 
-    pub de_state_count: u64,
-
     pub events: u16,
 
     pub request_buffer: Vec<u8>,
@@ -260,7 +258,6 @@ impl DNSState {
         return DNSState{
             tx_id: 0,
             transactions: Vec::new(),
-            de_state_count: 0,
             events: 0,
             request_buffer: Vec::new(),
             response_buffer: Vec::new(),
@@ -274,7 +271,6 @@ impl DNSState {
         return DNSState{
             tx_id: 0,
             transactions: Vec::new(),
-            de_state_count: 0,
             events: 0,
             request_buffer: Vec::with_capacity(0xffff),
             response_buffer: Vec::with_capacity(0xffff),
@@ -321,7 +317,6 @@ impl DNSState {
         match tx.de_state {
             Some(state) => {
                 core::sc_detect_engine_state_free(state);
-                self.de_state_count -= 1;
             }
             _ => {}
         }
@@ -752,21 +747,10 @@ pub extern "C" fn rs_dns_state_get_tx(state: &mut DNSState,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_state_has_detect_state(state: &mut DNSState) -> u8
-{
-    if state.de_state_count > 0 {
-        return 1;
-    }
-    return 0;
-}
-
-#[no_mangle]
 pub extern "C" fn rs_dns_state_set_tx_detect_state(
-    state: &mut DNSState,
     tx: &mut DNSTransaction,
     de_state: &mut core::DetectEngineState)
 {
-    state.de_state_count += 1;
     tx.de_state = Some(de_state);
 }
 

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -325,11 +325,6 @@ pub struct NFSState {
     tx_id: u64,
 
     pub de_state_count: u64,
-
-    // HACK flag state if tx has been marked complete in a direction
-    // this way we can skip a lot of looping in output-tx.c
-    //pub ts_txs_updated: bool,
-    //pub tc_txs_updated: bool,
 }
 
 impl NFSState {
@@ -355,8 +350,6 @@ impl NFSState {
             events:0,
             tx_id:0,
             de_state_count:0,
-            //ts_txs_updated:false,
-            //tc_txs_updated:false,
         }
     }
     pub fn free(&mut self) {
@@ -477,8 +470,6 @@ impl NFSState {
                 //SCLogNotice!("process_reply_record: not TX found for XID {}", r.hdr.xid);
             },
         }
-
-        //self.tc_txs_updated = true;
     }
 
     fn process_request_record_lookup<'b>(&mut self, r: &RpcPacket<'b>, xidmap: &mut NFSRequestXidMap) {
@@ -656,7 +647,6 @@ impl NFSState {
                         },
                         None => { },
                     }
-                    //self.ts_txs_updated = true;
                 },
                 IResult::Incomplete(_) => {
                     self.set_event(NFSEvent::MalformedData);
@@ -676,7 +666,6 @@ impl NFSState {
             tx.file_name = xidmap.file_name.to_vec();
             tx.nfs_version = r.progver as u16;
             tx.file_handle = xidmap.file_handle.to_vec();
-            //self.ts_txs_updated = true;
 
             if r.procedure == NFSPROC3_RENAME {
                 tx.type_data = Some(NFSTransactionTypeData::RENAME(aux_file_name));
@@ -768,7 +757,6 @@ impl NFSState {
             tx.file_name = xidmap.file_name.to_vec();
             tx.file_handle = xidmap.file_handle.to_vec();
             tx.nfs_version = r.progver as u16;
-            //self.ts_txs_updated = true;
 
             if r.procedure == NFSPROC3_RENAME {
                 tx.type_data = Some(NFSTransactionTypeData::RENAME(aux_file_name));
@@ -1327,9 +1315,6 @@ impl NFSState {
             }
         }
 
-        //if is_last {
-        //    self.tc_txs_updated = true;
-        //}
         if !self.is_udp {
             self.tc_chunk_xid = r.hdr.xid;
             self.tc_chunk_left = (reply.count as u32 + fill_bytes) - reply.data.len() as u32;
@@ -1924,30 +1909,6 @@ pub extern "C" fn rs_nfs3_tx_get_alstate_progress(tx: &mut NFSTransaction,
         return 0;
     }
 }
-
-/*
-#[no_mangle]
-pub extern "C" fn rs_nfs3_get_txs_updated(state: &mut NFSState,
-                                          direction: u8) -> bool
-{
-    if direction == STREAM_TOSERVER {
-        return state.ts_txs_updated;
-    } else {
-        return state.tc_txs_updated;
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn rs_nfs3_reset_txs_updated(state: &mut NFSState,
-                                            direction: u8)
-{
-    if direction == STREAM_TOSERVER {
-        state.ts_txs_updated = false;
-    } else {
-        state.tc_txs_updated = false;
-    }
-}
-*/
 
 #[no_mangle]
 pub extern "C" fn rs_nfs3_tx_set_logged(_state: &mut NFSState,

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -214,17 +214,17 @@ impl NFSTransaction {
         if self.events != std::ptr::null_mut() {
             sc_app_layer_decoder_events_free_events(&mut self.events);
         }
-    }
-}
-
-impl Drop for NFSTransaction {
-    fn drop(&mut self) {
         match self.de_state {
             Some(state) => {
                 sc_detect_engine_state_free(state);
             }
             _ => {}
         }
+    }
+}
+
+impl Drop for NFSTransaction {
+    fn drop(&mut self) {
         self.free();
     }
 }

--- a/src/app-layer-dcerpc-udp.c
+++ b/src/app-layer-dcerpc-udp.c
@@ -823,17 +823,9 @@ static void DCERPCUDPStateFree(void *s)
     SCFree(s);
 }
 
-static int DCERPCUDPStateHasTxDetectState(void *state)
+static int DCERPCUDPSetTxDetectState(void *vtx, DetectEngineState *de_state)
 {
-    DCERPCUDPState *dce_state = (DCERPCUDPState *)state;
-    if (dce_state->de_state)
-        return 1;
-    return 0;
-}
-
-static int DCERPCUDPSetTxDetectState(void *state, void *vtx, DetectEngineState *de_state)
-{
-    DCERPCUDPState *dce_state = (DCERPCUDPState *)state;
+    DCERPCUDPState *dce_state = (DCERPCUDPState *)vtx;
     dce_state->de_state = de_state;
     return 0;
 }
@@ -907,7 +899,7 @@ void RegisterDCERPCUDPParsers(void)
 
         AppLayerParserRegisterTxFreeFunc(IPPROTO_UDP, ALPROTO_DCERPC, DCERPCUDPStateTransactionFree);
 
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_DCERPC, DCERPCUDPStateHasTxDetectState,
+        AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_DCERPC,
                                                DCERPCUDPGetTxDetectState, DCERPCUDPSetTxDetectState);
 
         AppLayerParserRegisterGetTx(IPPROTO_UDP, ALPROTO_DCERPC, DCERPCUDPGetTx);

--- a/src/app-layer-dcerpc.c
+++ b/src/app-layer-dcerpc.c
@@ -1999,17 +1999,9 @@ static void DCERPCStateFree(void *s)
     SCFree(s);
 }
 
-static int DCERPCStateHasTxDetectState(void *state)
+static int DCERPCSetTxDetectState(void *vtx, DetectEngineState *de_state)
 {
-    DCERPCState *dce_state = (DCERPCState *)state;
-    if (dce_state->de_state)
-        return 1;
-    return 0;
-}
-
-static int DCERPCSetTxDetectState(void *state, void *vtx, DetectEngineState *de_state)
-{
-    DCERPCState *dce_state = (DCERPCState *)state;
+    DCERPCState *dce_state = (DCERPCState *)vtx;
     dce_state->de_state = de_state;
     return 0;
 }
@@ -2089,7 +2081,7 @@ void RegisterDCERPCParsers(void)
 
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_DCERPC, DCERPCStateTransactionFree);
 
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_DCERPC, DCERPCStateHasTxDetectState,
+        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_DCERPC,
                                                DCERPCGetTxDetectState, DCERPCSetTxDetectState);
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_DCERPC, DCERPCGetTx);

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -1535,7 +1535,7 @@ static DetectEngineState *DNP3GetTxDetectState(void *vtx)
 /**
  * \brief App-layer support.
  */
-static int DNP3SetTxDetectState(void *state, void *vtx, DetectEngineState *s)
+static int DNP3SetTxDetectState(void *vtx, DetectEngineState *s)
 {
     DNP3Transaction *tx = vtx;
     tx->de_state = s;
@@ -1622,7 +1622,7 @@ void RegisterDNP3Parsers(void)
             DNP3GetEvents);
         AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_DNP3,
             DNP3HasEvents);
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_DNP3, NULL,
+        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_DNP3,
             DNP3GetTxDetectState, DNP3SetTxDetectState);
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_DNP3, DNP3GetTx);

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -225,8 +225,6 @@ typedef struct DNSState_ {
     uint32_t unreplied_cnt;                 /**< number of unreplied requests in a row */
     uint32_t memuse;                        /**< state memuse, for comparing with
                                                  state-memcap settings */
-    uint64_t tx_with_detect_state_cnt;
-
     struct timeval last_req;      /**< Timestamp of last request. */
     struct timeval last_resp;     /**< Timestamp of last response. */
 
@@ -279,9 +277,8 @@ int DNSGetAlstateProgressCompletionStatus(uint8_t direction);
 void DNSStateTransactionFree(void *state, uint64_t tx_id);
 DNSTransaction *DNSTransactionFindByTxId(const DNSState *dns_state, const uint16_t tx_id);
 
-int DNSStateHasTxDetectState(void *alstate);
 DetectEngineState *DNSGetTxDetectState(void *vtx);
-int DNSSetTxDetectState(void *alstate, void *vtx, DetectEngineState *s);
+int DNSSetTxDetectState(void *vtx, DetectEngineState *s);
 uint64_t DNSGetTxDetectFlags(void *vtx, uint8_t dir);
 void DNSSetTxDetectFlags(void *vtx, uint8_t dir, uint64_t detect_flags);
 

--- a/src/app-layer-dns-tcp-rust.c
+++ b/src/app-layer-dns-tcp-rust.c
@@ -98,20 +98,15 @@ static void RustDNSStateTransactionFree(void *state, uint64_t tx_id)
     rs_dns_state_tx_free(state, tx_id);
 }
 
-static int RustDNSStateHasTxDetectState(void *state)
-{
-    return rs_dns_state_has_detect_state(state);
-}
-
 static DetectEngineState *RustDNSGetTxDetectState(void *tx)
 {
     return rs_dns_state_get_tx_detect_state(tx);
 }
 
-static int RustDNSSetTxDetectState(void *state, void *tx,
+static int RustDNSSetTxDetectState(void *tx,
         DetectEngineState *s)
 {
-    rs_dns_state_set_tx_detect_state(state, tx, s);
+    rs_dns_state_set_tx_detect_state(tx, s);
     return 0;
 }
 
@@ -171,8 +166,7 @@ void RegisterRustDNSTCPParsers(void)
         AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_DNS,
                 RustDNSHasEvents);
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_DNS,
-                RustDNSStateHasTxDetectState, RustDNSGetTxDetectState,
-                RustDNSSetTxDetectState);
+                RustDNSGetTxDetectState, RustDNSSetTxDetectState);
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_DNS, RustDNSGetTx);
         AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_DNS,
                 RustDNSGetTxCnt);

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -750,7 +750,6 @@ void RegisterDNSTCPParsers(void)
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_DNS, DNSGetEvents);
         AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_DNS, DNSHasEvents);
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_DNS,
-                                               DNSStateHasTxDetectState,
                                                DNSGetTxDetectState, DNSSetTxDetectState);
         AppLayerParserRegisterDetectFlagsFuncs(IPPROTO_TCP, ALPROTO_DNS,
                                                DNSGetTxDetectFlags, DNSSetTxDetectFlags);

--- a/src/app-layer-dns-udp-rust.c
+++ b/src/app-layer-dns-udp-rust.c
@@ -95,20 +95,14 @@ static void RustDNSStateTransactionFree(void *state, uint64_t tx_id)
     rs_dns_state_tx_free(state, tx_id);
 }
 
-static int RustDNSStateHasTxDetectState(void *state)
-{
-    return rs_dns_state_has_detect_state(state);
-}
-
 static DetectEngineState *RustDNSGetTxDetectState(void *tx)
 {
     return rs_dns_state_get_tx_detect_state(tx);
 }
 
-static int RustDNSSetTxDetectState(void *state, void *tx,
-        DetectEngineState *s)
+static int RustDNSSetTxDetectState(void *tx, DetectEngineState *s)
 {
-    rs_dns_state_set_tx_detect_state(state, tx, s);
+    rs_dns_state_set_tx_detect_state(tx, s);
     return 0;
 }
 
@@ -181,8 +175,7 @@ void RegisterRustDNSUDPParsers(void)
         AppLayerParserRegisterHasEventsFunc(IPPROTO_UDP, ALPROTO_DNS,
                 RustDNSHasEvents);
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_DNS,
-                RustDNSStateHasTxDetectState, RustDNSGetTxDetectState,
-                RustDNSSetTxDetectState);
+                RustDNSGetTxDetectState, RustDNSSetTxDetectState);
         AppLayerParserRegisterDetectFlagsFuncs(IPPROTO_UDP, ALPROTO_DNS,
                 RustDNSGetDetectFlags, RustDNSSetDetectFlags);
 

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -443,7 +443,6 @@ void RegisterDNSUDPParsers(void)
         AppLayerParserRegisterGetEventsFunc(IPPROTO_UDP, ALPROTO_DNS, DNSGetEvents);
         AppLayerParserRegisterHasEventsFunc(IPPROTO_UDP, ALPROTO_DNS, DNSHasEvents);
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_DNS,
-                                               DNSStateHasTxDetectState,
                                                DNSGetTxDetectState, DNSSetTxDetectState);
         AppLayerParserRegisterDetectFlagsFuncs(IPPROTO_UDP, ALPROTO_DNS,
                                                DNSGetTxDetectFlags, DNSSetTxDetectFlags);

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -81,7 +81,7 @@ static DetectEngineState *ENIPGetTxDetectState(void *vtx)
     return tx->de_state;
 }
 
-static int ENIPSetTxDetectState(void *state, void *vtx, DetectEngineState *s)
+static int ENIPSetTxDetectState(void *vtx, DetectEngineState *s)
 {
     ENIPTransaction *tx = (ENIPTransaction *)vtx;
     tx->de_state = s;
@@ -435,8 +435,8 @@ void RegisterENIPUDPParsers(void)
         AppLayerParserRegisterGetEventsFunc(IPPROTO_UDP, ALPROTO_ENIP, ENIPGetEvents);
         AppLayerParserRegisterHasEventsFunc(IPPROTO_UDP, ALPROTO_ENIP, ENIPHasEvents);
 
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_ENIP, NULL,
-                                                       ENIPGetTxDetectState, ENIPSetTxDetectState);
+        AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_ENIP,
+                ENIPGetTxDetectState, ENIPSetTxDetectState);
 
         AppLayerParserRegisterGetTx(IPPROTO_UDP, ALPROTO_ENIP, ENIPGetTx);
         AppLayerParserRegisterGetTxCnt(IPPROTO_UDP, ALPROTO_ENIP, ENIPGetTxCnt);
@@ -515,8 +515,8 @@ void RegisterENIPTCPParsers(void)
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_ENIP, ENIPGetEvents);
         AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_ENIP, ENIPHasEvents);
 
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_ENIP, NULL,
-                                                       ENIPGetTxDetectState, ENIPSetTxDetectState);
+        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_ENIP,
+                ENIPGetTxDetectState, ENIPSetTxDetectState);
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_ENIP, ENIPGetTx);
         AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_ENIP, ENIPGetTxCnt);

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -613,17 +613,9 @@ static void FTPStateFree(void *s)
 #endif
 }
 
-static int FTPStateHasTxDetectState(void *state)
+static int FTPSetTxDetectState(void *vtx, DetectEngineState *de_state)
 {
-    FtpState *ftp_state = (FtpState *)state;
-    if (ftp_state->de_state)
-        return 1;
-    return 0;
-}
-
-static int FTPSetTxDetectState(void *state, void *vtx, DetectEngineState *de_state)
-{
-    FtpState *ftp_state = (FtpState *)state;
+    FtpState *ftp_state = (FtpState *)vtx;
     ftp_state->de_state = de_state;
     return 0;
 }
@@ -846,17 +838,9 @@ static void FTPDataStateFree(void *s)
 #endif
 }
 
-static int FTPDataStateHasTxDetectState(void *state)
+static int FTPDataSetTxDetectState(void *vtx, DetectEngineState *de_state)
 {
-    FtpDataState *ftp_state = (FtpDataState *)state;
-    if (ftp_state->de_state)
-        return 1;
-    return 0;
-}
-
-static int FTPDataSetTxDetectState(void *state, void *vtx, DetectEngineState *de_state)
-{
-    FtpDataState *ftp_state = (FtpDataState *)state;
+    FtpDataState *ftp_state = (FtpDataState *)vtx;
     ftp_state->de_state = de_state;
     return 0;
 }
@@ -925,8 +909,8 @@ void RegisterFTPParsers(void)
 
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_FTP, FTPStateTransactionFree);
 
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_FTP, FTPStateHasTxDetectState,
-                                               FTPGetTxDetectState, FTPSetTxDetectState);
+        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_FTP,
+                FTPGetTxDetectState, FTPSetTxDetectState);
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_FTP, FTPGetTx);
 
@@ -946,7 +930,7 @@ void RegisterFTPParsers(void)
         AppLayerParserRegisterStateFuncs(IPPROTO_TCP, ALPROTO_FTPDATA, FTPDataStateAlloc, FTPDataStateFree);
         AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_TCP, ALPROTO_FTPDATA, STREAM_TOSERVER | STREAM_TOCLIENT);
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_FTPDATA, FTPDataStateTransactionFree);
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_FTPDATA, FTPDataStateHasTxDetectState,
+        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_FTPDATA,
                 FTPDataGetTxDetectState, FTPDataSetTxDetectState);
 
         AppLayerParserRegisterGetFilesFunc(IPPROTO_TCP, ALPROTO_FTPDATA, FTPDataStateGetFiles);

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -232,7 +232,6 @@ typedef struct HtpState_ {
     uint16_t flags;
     uint16_t events;
     uint16_t htp_messages_offset; /**< offset into conn->messages list */
-    uint64_t tx_with_detect_state_cnt;
 } HtpState;
 
 /** part of the engine needs the request body (e.g. http_client_body keyword) */

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1453,7 +1453,7 @@ static DetectEngineState *ModbusGetTxDetectState(void *vtx)
     return tx->de_state;
 }
 
-static int ModbusSetTxDetectState(void *state, void *vtx, DetectEngineState *s)
+static int ModbusSetTxDetectState(void *vtx, DetectEngineState *s)
 {
     ModbusTransaction *tx = (ModbusTransaction *)vtx;
     tx->de_state = s;
@@ -1527,7 +1527,7 @@ void RegisterModbusParsers(void)
 
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_MODBUS, ModbusGetEvents);
         AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_MODBUS, ModbusHasEvents);
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_MODBUS, NULL,
+        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_MODBUS,
                                                ModbusGetTxDetectState, ModbusSetTxDetectState);
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_MODBUS, ModbusGetTx);

--- a/src/app-layer-nfs-tcp.c
+++ b/src/app-layer-nfs-tcp.c
@@ -250,10 +250,9 @@ static DetectEngineState *NFSTCPGetTxDetectState(void *vtx)
 /**
  * \brief set store tx detect state
  */
-static int NFSTCPSetTxDetectState(void *state, void *vtx,
-    DetectEngineState *s)
+static int NFSTCPSetTxDetectState(void *vtx, DetectEngineState *s)
 {
-    rs_nfs3_state_set_tx_detect_state(state, vtx, s);
+    rs_nfs3_state_set_tx_detect_state(vtx, s);
     return 0;
 }
 
@@ -367,7 +366,7 @@ void RegisterNFSTCPParsers(void)
 
         /* What is this being registered for? */
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_NFS,
-            NULL, NFSTCPGetTxDetectState, NFSTCPSetTxDetectState);
+            NFSTCPGetTxDetectState, NFSTCPSetTxDetectState);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_NFS,
                 NFSTCPStateGetEventInfo);

--- a/src/app-layer-nfs-tcp.c
+++ b/src/app-layer-nfs-tcp.c
@@ -194,6 +194,14 @@ static void *NFSTCPGetTx(void *state, uint64_t tx_id)
     return rs_nfs3_state_get_tx(state, tx_id);
 }
 
+static AppLayerGetTxIterTuple RustNFSTCPGetTxIterator(
+        const uint8_t ipproto, const AppProto alproto,
+        void *alstate, uint64_t min_tx_id, uint64_t max_tx_id,
+        AppLayerGetTxIterState *istate)
+{
+    return rs_nfs_state_get_tx_iterator(alstate, min_tx_id, (uint64_t *)istate);
+}
+
 static void NFSTCPSetTxLogged(void *state, void *vtx, LoggerId logged)
 {
     rs_nfs3_tx_set_logged(state, vtx, logged);
@@ -348,6 +356,8 @@ void RegisterNFSTCPParsers(void)
             ALPROTO_NFS, NFSTCPGetStateProgress);
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_NFS,
             NFSTCPGetTx);
+        AppLayerParserRegisterGetTxIterator(IPPROTO_TCP, ALPROTO_NFS,
+                RustNFSTCPGetTxIterator);
 
         AppLayerParserRegisterGetFilesFunc(IPPROTO_TCP, ALPROTO_NFS, NFSTCPGetFiles);
 

--- a/src/app-layer-nfs-udp.c
+++ b/src/app-layer-nfs-udp.c
@@ -187,6 +187,14 @@ static void *NFSGetTx(void *state, uint64_t tx_id)
     return rs_nfs3_state_get_tx(state, tx_id);
 }
 
+static AppLayerGetTxIterTuple RustNFSGetTxIterator(
+        const uint8_t ipproto, const AppProto alproto,
+        void *alstate, uint64_t min_tx_id, uint64_t max_tx_id,
+        AppLayerGetTxIterState *istate)
+{
+    return rs_nfs_state_get_tx_iterator(alstate, min_tx_id, (uint64_t *)istate);
+}
+
 static void NFSSetTxLogged(void *state, void *vtx, LoggerId logged)
 {
     rs_nfs3_tx_set_logged(state, vtx, logged);
@@ -341,6 +349,8 @@ void RegisterNFSUDPParsers(void)
             ALPROTO_NFS, NFSGetStateProgress);
         AppLayerParserRegisterGetTx(IPPROTO_UDP, ALPROTO_NFS,
             NFSGetTx);
+        AppLayerParserRegisterGetTxIterator(IPPROTO_UDP, ALPROTO_NFS,
+                RustNFSGetTxIterator);
 
         AppLayerParserRegisterGetFilesFunc(IPPROTO_UDP, ALPROTO_NFS, NFSGetFiles);
 

--- a/src/app-layer-nfs-udp.c
+++ b/src/app-layer-nfs-udp.c
@@ -243,10 +243,9 @@ static DetectEngineState *NFSGetTxDetectState(void *vtx)
 /**
  * \brief set store tx detect state
  */
-static int NFSSetTxDetectState(void *state, void *vtx,
-    DetectEngineState *s)
+static int NFSSetTxDetectState(void *vtx, DetectEngineState *s)
 {
-    rs_nfs3_state_set_tx_detect_state(state, vtx, s);
+    rs_nfs3_state_set_tx_detect_state(vtx, s);
     return 0;
 }
 
@@ -360,7 +359,7 @@ void RegisterNFSUDPParsers(void)
 
         /* What is this being registered for? */
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_NFS,
-            NULL, NFSGetTxDetectState, NFSSetTxDetectState);
+            NFSGetTxDetectState, NFSSetTxDetectState);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_UDP, ALPROTO_NFS,
             NFSStateGetEventInfo);

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -105,6 +105,7 @@ typedef struct AppLayerParserProtoCtx_
     int (*StateGetProgress)(void *alstate, uint8_t direction);
     uint64_t (*StateGetTxCnt)(void *alstate);
     void *(*StateGetTx)(void *alstate, uint64_t tx_id);
+    AppLayerGetTxIteratorFunc StateGetTxIterator;
     int (*StateGetProgressCompletionStatus)(uint8_t direction);
     int (*StateGetEventInfo)(const char *event_name,
                              int *event_id, AppLayerEventType *event_type);
@@ -518,6 +519,14 @@ void AppLayerParserRegisterGetTx(uint8_t ipproto, AppProto alproto,
     SCReturn;
 }
 
+void AppLayerParserRegisterGetTxIterator(uint8_t ipproto, AppProto alproto,
+                      AppLayerGetTxIteratorFunc Func)
+{
+    SCEnter();
+    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].StateGetTxIterator = Func;
+    SCReturn;
+}
+
 void AppLayerParserRegisterGetStateProgressCompletionStatus(AppProto alproto,
     int (*StateGetProgressCompletionStatus)(uint8_t direction))
 {
@@ -609,6 +618,49 @@ void AppLayerParserDestroyProtocolParserLocalStorage(uint8_t ipproto, AppProto a
     SCReturn;
 }
 
+/** \brief default tx iterator
+ *
+ *  Used if the app layer parser doesn't register its own iterator.
+ *  Simply walks the tx_id space until it finds a tx. Uses 'state' to
+ *  keep track of where it left off.
+ *
+ *  \retval txptr or NULL if no more txs in list
+ */
+static AppLayerGetTxIterTuple AppLayerDefaultGetTxIterator(
+        const uint8_t ipproto, const AppProto alproto,
+        void *alstate, uint64_t min_tx_id, uint64_t max_tx_id,
+        AppLayerGetTxIterState *state)
+{
+    uint64_t ustate = *(uint64_t *)state;
+    uint64_t tx_id = MAX(min_tx_id, ustate);
+    for ( ; tx_id < max_tx_id; tx_id++) {
+        void *tx_ptr = AppLayerParserGetTx(ipproto, alproto, alstate, tx_id);
+        if (tx_ptr != NULL) {
+            ustate = tx_id + 1;
+            *state = *(AppLayerGetTxIterState *)&ustate;
+            AppLayerGetTxIterTuple tuple = {
+                .tx_ptr = tx_ptr,
+                .tx_id = tx_id,
+                .has_next = (tx_id + 1 < max_tx_id),
+            };
+            SCLogDebug("tulpe: %p/%"PRIu64"/%s", tuple.tx_ptr, tuple.tx_id,
+                    tuple.has_next ? "true" : "false");
+            return tuple;
+        }
+    }
+
+    AppLayerGetTxIterTuple no_tuple = { NULL, 0, false };
+    return no_tuple;
+}
+
+AppLayerGetTxIteratorFunc AppLayerGetTxIterator(const uint8_t ipproto,
+        const AppProto alproto)
+{
+    AppLayerGetTxIteratorFunc Func =
+        alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].StateGetTxIterator;
+    return Func ? Func : AppLayerDefaultGetTxIterator;
+}
+
 void AppLayerParserSetTxLogged(uint8_t ipproto, AppProto alproto,
                                void *alstate, void *tx, LoggerId logger)
 {
@@ -677,28 +729,37 @@ void AppLayerParserSetTransactionInspectId(const Flow *f, AppLayerParserState *p
     const uint8_t ipproto = f->proto;
     const AppProto alproto = f->alproto;
 
+    AppLayerGetTxIteratorFunc IterFunc = AppLayerGetTxIterator(ipproto, alproto);
+    AppLayerGetTxIterState state;
+    memset(&state, 0, sizeof(state));
+
     SCLogDebug("called: %s, tag_txs_as_inspected %s",direction==0?"toserver":"toclient",
             tag_txs_as_inspected?"true":"false");
 
     /* mark all txs as inspected if the applayer progress is
      * at the 'end state'. */
-    for (; idx < total_txs; idx++) {
-        void *tx = AppLayerParserGetTx(ipproto, alproto, alstate, idx);
-        if (tx == NULL)
-            continue;
+    while (1) {
+        AppLayerGetTxIterTuple ires = IterFunc(ipproto, alproto, alstate, idx, total_txs, &state);
+        if (ires.tx_ptr == NULL)
+            break;
+
+        void *tx = ires.tx_ptr;
+        idx = ires.tx_id;
+
         int state_progress = AppLayerParserGetStateProgress(ipproto, alproto, tx, flags);
-        if (state_progress >= state_done_progress) {
-            if (tag_txs_as_inspected) {
-                uint64_t detect_flags = AppLayerParserGetTxDetectFlags(ipproto, alproto, tx, flags);
-                if ((detect_flags & APP_LAYER_TX_INSPECTED_FLAG) == 0) {
-                    detect_flags |= APP_LAYER_TX_INSPECTED_FLAG;
-                    AppLayerParserSetTxDetectFlags(ipproto, alproto, tx, flags, detect_flags);
-                    SCLogDebug("%p/%"PRIu64" in-order tx is done for direction %s. Flag %016"PRIx64,
-                            tx, idx, flags & STREAM_TOSERVER ? "toserver" : "toclient", detect_flags);
-                }
+        if (state_progress < state_done_progress)
+            break;
+
+        if (tag_txs_as_inspected) {
+            uint64_t detect_flags = AppLayerParserGetTxDetectFlags(ipproto, alproto, tx, flags);
+            if ((detect_flags & APP_LAYER_TX_INSPECTED_FLAG) == 0) {
+                detect_flags |= APP_LAYER_TX_INSPECTED_FLAG;
+                AppLayerParserSetTxDetectFlags(ipproto, alproto, tx, flags, detect_flags);
+                SCLogDebug("%p/%"PRIu64" in-order tx is done for direction %s. Flag %016"PRIx64,
+                        tx, idx, flags & STREAM_TOSERVER ? "toserver" : "toclient", detect_flags);
             }
-            continue;
-        } else
+        }
+        if (!ires.has_next)
             break;
     }
     pstate->inspect_id[direction] = idx;
@@ -707,29 +768,39 @@ void AppLayerParserSetTransactionInspectId(const Flow *f, AppLayerParserState *p
     /* if necessary we flag all txs that are complete as 'inspected'
      * also move inspect_id forward. */
     if (tag_txs_as_inspected) {
-        for (; idx < total_txs; idx++) {
-            bool check_inspect_id = false;
-            void *tx = AppLayerParserGetTx(ipproto, alproto, alstate, idx);
-            if (tx == NULL) {
-                check_inspect_id = true;
-            } else {
-                int state_progress = AppLayerParserGetStateProgress(ipproto, alproto, tx, flags);
-                if (state_progress >= state_done_progress) {
-                    uint64_t detect_flags = AppLayerParserGetTxDetectFlags(ipproto, alproto, tx, flags);
-                    if ((detect_flags & APP_LAYER_TX_INSPECTED_FLAG) == 0) {
-                        detect_flags |= APP_LAYER_TX_INSPECTED_FLAG;
-                        AppLayerParserSetTxDetectFlags(ipproto, alproto, tx, flags, detect_flags);
-                        SCLogDebug("%p/%"PRIu64" out of order tx is done for direction %s. Flag %016"PRIx64,
-                                tx, idx, flags & STREAM_TOSERVER ? "toserver" : "toclient", detect_flags);
-                        check_inspect_id = true;
-                    }
-                }
+        /* continue at idx */
+        while (1) {
+            AppLayerGetTxIterTuple ires = IterFunc(ipproto, alproto, alstate, idx, total_txs, &state);
+            if (ires.tx_ptr == NULL)
+                break;
+
+            void *tx = ires.tx_ptr;
+            /* if we got a higher id than the minimum we requested, we
+             * skipped a bunch of 'null-txs'. Lets see if we can up the
+             * inspect tracker */
+            if (ires.tx_id > idx && pstate->inspect_id[direction] == idx) {
+                pstate->inspect_id[direction] = ires.tx_id;
             }
-            if (check_inspect_id) {
-                SCLogDebug("%p/%"PRIu64" out of order tx. Update inspect_id? %"PRIu64, tx, idx, pstate->inspect_id[direction]);
+            idx = ires.tx_id;
+
+            const int state_progress = AppLayerParserGetStateProgress(ipproto, alproto, tx, flags);
+            if (state_progress < state_done_progress)
+                break;
+
+            uint64_t detect_flags = AppLayerParserGetTxDetectFlags(ipproto, alproto, tx, flags);
+            if ((detect_flags & APP_LAYER_TX_INSPECTED_FLAG) == 0) {
+                detect_flags |= APP_LAYER_TX_INSPECTED_FLAG;
+                AppLayerParserSetTxDetectFlags(ipproto, alproto, tx, flags, detect_flags);
+                SCLogDebug("%p/%"PRIu64" out of order tx is done for direction %s. Flag %016"PRIx64,
+                        tx, idx, flags & STREAM_TOSERVER ? "toserver" : "toclient", detect_flags);
+
+                SCLogDebug("%p/%"PRIu64" out of order tx. Update inspect_id? %"PRIu64,
+                        tx, idx, pstate->inspect_id[direction]);
                 if (pstate->inspect_id[direction]+1 == idx)
                     pstate->inspect_id[direction] = idx;
             }
+            if (!ires.has_next)
+                break;
         }
     }
 
@@ -808,31 +879,38 @@ void AppLayerParserTransactionsCleanup(Flow *f)
     const int tx_end_state_ts = AppLayerParserGetStateProgressCompletionStatus(alproto, STREAM_TOSERVER);
     const int tx_end_state_tc = AppLayerParserGetStateProgressCompletionStatus(alproto, STREAM_TOCLIENT);
 
-    SCLogDebug("checking %"PRIu64" txs from offset %"PRIu64, total_txs, min);
-    for (uint64_t i = min ; i < total_txs; i++) {
-        void * const tx = AppLayerParserGetTx(ipproto, alproto, alstate, i);
-        if (tx == NULL) {
-            SCLogDebug("%p/%"PRIu64" skipping: no tx", tx, i);
-            goto wrap_up;
-        }
+    AppLayerGetTxIteratorFunc IterFunc = AppLayerGetTxIterator(ipproto, alproto);
+    AppLayerGetTxIterState state;
+    memset(&state, 0, sizeof(state));
+    uint64_t i = min;
+    uint64_t new_min = min;
+
+    while (1) {
+        AppLayerGetTxIterTuple ires = IterFunc(ipproto, alproto, alstate, i, total_txs, &state);
+        if (ires.tx_ptr == NULL)
+            break;
+
+        void *tx = ires.tx_ptr;
+        i = ires.tx_id;
+
         SCLogDebug("%p/%"PRIu64" checking", tx, i);
 
         const int tx_progress_tc = AppLayerParserGetStateProgress(ipproto, alproto, tx, STREAM_TOCLIENT);
         if (tx_progress_tc < tx_end_state_tc) {
             SCLogDebug("%p/%"PRIu64" skipping: tc parser not done", tx, i);
-            continue;
+            goto next;
         }
         const int tx_progress_ts = AppLayerParserGetStateProgress(ipproto, alproto, tx, STREAM_TOSERVER);
         if (tx_progress_ts < tx_end_state_ts) {
             SCLogDebug("%p/%"PRIu64" skipping: ts parser not done", tx, i);
-            continue;
+            goto next;
         }
         if (f->sgh_toserver != NULL) {
             uint64_t detect_flags_ts = AppLayerParserGetTxDetectFlags(ipproto, alproto, tx, STREAM_TOSERVER);
             if (!(detect_flags_ts & APP_LAYER_TX_INSPECTED_FLAG)) {
                 SCLogDebug("%p/%"PRIu64" skipping: TS inspect not done: ts:%"PRIx64,
                         tx, i, detect_flags_ts);
-                continue;
+                goto next;
             }
         }
         if (f->sgh_toclient != NULL) {
@@ -840,7 +918,7 @@ void AppLayerParserTransactionsCleanup(Flow *f)
             if (!(detect_flags_tc & APP_LAYER_TX_INSPECTED_FLAG)) {
                 SCLogDebug("%p/%"PRIu64" skipping: TC inspect not done: tc:%"PRIx64,
                         tx, i, detect_flags_tc);
-                continue;
+                goto next;
             }
         }
         if (logger_expectation != 0) {
@@ -848,25 +926,32 @@ void AppLayerParserTransactionsCleanup(Flow *f)
             if (tx_logged != logger_expectation) {
                 SCLogDebug("%p/%"PRIu64" skipping: logging not done: want:%"PRIx32", have:%"PRIx32,
                         tx, i, logger_expectation, tx_logged);
-                continue;
+                goto next;
             }
         }
 
         /* if we are here, the tx can be freed. */
         p->StateTransactionFree(alstate, i);
         SCLogDebug("%p/%"PRIu64" freed", tx, i);
-    wrap_up:
-        /* see if this tx is actually in order. If so, we need to bring all
-         * trackers up to date. */
-        SCLogDebug("%p/%"PRIu64" update f->alparser->min_id? %"PRIu64, tx, i, alparser->min_id);
-        if (i == alparser->min_id) {
-            uint64_t next_id = i + 1;
-            alparser->min_id = next_id;
-            alparser->inspect_id[0] = MAX(alparser->inspect_id[0], next_id);
-            alparser->inspect_id[1] = MAX(alparser->inspect_id[1], next_id);
-            alparser->log_id = MAX(alparser->log_id, next_id);
-            SCLogDebug("%p/%"PRIu64" updated f->alparser->min_id %"PRIu64, tx, i, alparser->min_id);
-        }
+
+        /* if this tx was the minimum, up the minimum */
+        if (i == new_min)
+            new_min = i + 1;
+
+next:
+        if (!ires.has_next)
+            break;
+    }
+
+    /* see if we need to bring all trackers up to date. */
+    SCLogDebug("update f->alparser->min_id? %"PRIu64, alparser->min_id);
+    if (new_min > alparser->min_id) {
+        const uint64_t next_id = new_min;
+        alparser->min_id = next_id;
+        alparser->inspect_id[0] = MAX(alparser->inspect_id[0], next_id);
+        alparser->inspect_id[1] = MAX(alparser->inspect_id[1], next_id);
+        alparser->log_id = MAX(alparser->log_id, next_id);
+        SCLogDebug("updated f->alparser->min_id %"PRIu64, alparser->min_id);
     }
 }
 

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -162,9 +162,8 @@ void AppLayerParserRegisterGetEventInfo(uint8_t ipproto, AppProto alproto,
     int (*StateGetEventInfo)(const char *event_name, int *event_id,
                              AppLayerEventType *event_type));
 void AppLayerParserRegisterDetectStateFuncs(uint8_t ipproto, AppProto alproto,
-        int (*StateHasTxDetectState)(void *alstate),
         DetectEngineState *(*GetTxDetectState)(void *tx),
-        int (*SetTxDetectState)(void *alstate, void *tx, DetectEngineState *));
+        int (*SetTxDetectState)(void *tx, DetectEngineState *));
 void AppLayerParserRegisterGetStreamDepth(uint8_t ipproto,
                                           AppProto alproto,
                                           uint32_t (*GetStreamDepth)(void));
@@ -218,7 +217,7 @@ int AppLayerParserSupportsFiles(uint8_t ipproto, AppProto alproto);
 int AppLayerParserSupportsTxDetectState(uint8_t ipproto, AppProto alproto);
 int AppLayerParserHasTxDetectState(uint8_t ipproto, AppProto alproto, void *alstate);
 DetectEngineState *AppLayerParserGetTxDetectState(uint8_t ipproto, AppProto alproto, void *tx);
-int AppLayerParserSetTxDetectState(const Flow *f, void *alstate, void *tx, DetectEngineState *s);
+int AppLayerParserSetTxDetectState(const Flow *f, void *tx, DetectEngineState *s);
 
 uint64_t AppLayerParserGetTxDetectFlags(uint8_t ipproto, AppProto alproto, void *tx, uint8_t dir);
 void AppLayerParserSetTxDetectFlags(uint8_t ipproto, AppProto alproto, void *tx, uint8_t dir, uint64_t);

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -92,6 +92,25 @@ typedef int (*AppLayerParserFPtr)(Flow *f, void *protocol_state,
         uint8_t *buf, uint32_t buf_len,
         void *local_storage);
 
+typedef struct AppLayerGetTxIterTuple {
+    void *tx_ptr;
+    uint64_t tx_id;
+    bool has_next;
+} AppLayerGetTxIterTuple;
+
+typedef struct AppLayerGetTxIterState {
+    union {
+        void *ptr;
+        uint64_t u64;
+    } un;
+} AppLayerGetTxIterState;
+
+/** \brief tx iterator prototype */
+typedef AppLayerGetTxIterTuple (*AppLayerGetTxIteratorFunc)
+       (const uint8_t ipproto, const AppProto alproto,
+        void *alstate, uint64_t min_tx_id, uint64_t max_tx_id,
+        AppLayerGetTxIterState *state);
+
 /***** Parser related registration *****/
 
 /**
@@ -135,6 +154,8 @@ void AppLayerParserRegisterGetTxCnt(uint8_t ipproto, AppProto alproto,
                          uint64_t (*StateGetTxCnt)(void *alstate));
 void AppLayerParserRegisterGetTx(uint8_t ipproto, AppProto alproto,
                       void *(StateGetTx)(void *alstate, uint64_t tx_id));
+void AppLayerParserRegisterGetTxIterator(uint8_t ipproto, AppProto alproto,
+                      AppLayerGetTxIteratorFunc Func);
 void AppLayerParserRegisterGetStateProgressCompletionStatus(AppProto alproto,
     int (*StateGetStateProgressCompletionStatus)(uint8_t direction));
 void AppLayerParserRegisterGetEventInfo(uint8_t ipproto, AppProto alproto,
@@ -155,6 +176,9 @@ void AppLayerParserRegisterDetectFlagsFuncs(uint8_t ipproto, AppProto alproto,
         void (*SetTxDetectFlags)(void *tx, uint8_t dir, uint64_t));
 
 /***** Get and transaction functions *****/
+
+AppLayerGetTxIteratorFunc AppLayerGetTxIterator(const uint8_t ipproto,
+         const AppProto alproto);
 
 void *AppLayerParserGetProtocolParserLocalStorage(uint8_t ipproto, AppProto alproto);
 void AppLayerParserDestroyProtocolParserLocalStorage(uint8_t ipproto, AppProto alproto,

--- a/src/app-layer-register.c
+++ b/src/app-layer-register.c
@@ -145,7 +145,7 @@ int AppLayerRegisterParser(const struct AppLayerParser *p, AppProto alproto)
 
     /* What is this being registered for? */
     AppLayerParserRegisterDetectStateFuncs(p->ip_proto, alproto,
-        p->StateHasTxDetectState, p->GetTxDetectState, p->SetTxDetectState);
+        p->GetTxDetectState, p->SetTxDetectState);
 
     if (p->StateGetEventInfo) {
         AppLayerParserRegisterGetEventInfo(p->ip_proto, alproto,

--- a/src/app-layer-register.h
+++ b/src/app-layer-register.h
@@ -52,8 +52,7 @@ typedef struct AppLayerParser {
     void (*StateSetTxLogged)(void *alstate, void *tx, uint32_t logger);
 
     DetectEngineState *(*GetTxDetectState)(void *tx);
-    int (*SetTxDetectState)(void *alstate, void *tx, DetectEngineState *);
-    int (*StateHasTxDetectState)(void *alstate);
+    int (*SetTxDetectState)(void *tx, DetectEngineState *);
 
     int (*StateHasEvents)(void *);
     AppLayerDecoderEvents *(*StateGetEvents)(void *, uint64_t);

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -1458,17 +1458,9 @@ static void SMBStateFree(void *s)
     SCReturn;
 }
 
-static int SMBStateHasTxDetectState(void *state)
+static int SMBSetTxDetectState(void *vtx, DetectEngineState *de_state)
 {
-    SMBState *smb_state = (SMBState *)state;
-    if (smb_state->ds.de_state)
-        return 1;
-    return 0;
-}
-
-static int SMBSetTxDetectState(void *state, void *vtx, DetectEngineState *de_state)
-{
-    SMBState *smb_state = (SMBState *)state;
+    SMBState *smb_state = (SMBState *)vtx;
     smb_state->ds.de_state = de_state;
     return 0;
 }
@@ -1603,7 +1595,7 @@ void RegisterSMBParsers(void)
 
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_SMB, SMBStateTransactionFree);
 
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_SMB, SMBStateHasTxDetectState,
+        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_SMB,
                                                SMBGetTxDetectState, SMBSetTxDetectState);
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_SMB, SMBGetTx);

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1624,7 +1624,7 @@ static DetectEngineState *SMTPGetTxDetectState(void *vtx)
     return tx->de_state;
 }
 
-static int SMTPSetTxDetectState(void *state, void *vtx, DetectEngineState *s)
+static int SMTPSetTxDetectState(void *vtx, DetectEngineState *s)
 {
     SMTPTransaction *tx = (SMTPTransaction *)vtx;
     tx->de_state = s;
@@ -1678,7 +1678,7 @@ void RegisterSMTPParsers(void)
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetEventInfo);
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_SMTP, SMTPGetEvents);
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_SMTP, NULL,
+        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_SMTP,
                                                SMTPGetTxDetectState, SMTPSetTxDetectState);
         AppLayerParserRegisterDetectFlagsFuncs(IPPROTO_TCP, ALPROTO_SMTP,
                                                SMTPGetTxDetectFlags, SMTPSetTxDetectFlags);

--- a/src/app-layer-ssh.c
+++ b/src/app-layer-ssh.c
@@ -505,17 +505,9 @@ static void SSHStateFree(void *state)
     SCFree(s);
 }
 
-static int SSHStateHasTxDetectState(void *state)
+static int SSHSetTxDetectState(void *vtx, DetectEngineState *de_state)
 {
-    SshState *ssh_state = (SshState *)state;
-    if (ssh_state->de_state)
-        return 1;
-    return 0;
-}
-
-static int SSHSetTxDetectState(void *state, void *vtx, DetectEngineState *de_state)
-{
-    SshState *ssh_state = (SshState *)state;
+    SshState *ssh_state = (SshState *)vtx;
     ssh_state->de_state = de_state;
     return 0;
 }
@@ -644,7 +636,7 @@ void RegisterSSHParsers(void)
 
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_SSH, SSHStateTransactionFree);
 
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_SSH, SSHStateHasTxDetectState,
+        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_SSH,
                                                SSHGetTxDetectState, SSHSetTxDetectState);
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_SSH, SSHGetTx);

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -164,18 +164,9 @@ static int SSLHasEvents(void *state)
     return (ssl_state->events > 0);
 }
 
-static int SSLStateHasTxDetectState(void *state)
+static int SSLSetTxDetectState(void *vtx, DetectEngineState *de_state)
 {
-    SSLState *ssl_state = (SSLState *)state;
-    if (ssl_state->de_state)
-        return 1;
-
-    return 0;
-}
-
-static int SSLSetTxDetectState(void *state, void *vtx, DetectEngineState *de_state)
-{
-    SSLState *ssl_state = (SSLState *)state;
+    SSLState *ssl_state = (SSLState *)vtx;
     ssl_state->de_state = de_state;
     return 0;
 }
@@ -1862,7 +1853,7 @@ void RegisterSSLParsers(void)
 
         AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_TLS, SSLHasEvents);
 
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_TLS, SSLStateHasTxDetectState,
+        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_TLS,
                                                SSLGetTxDetectState, SSLSetTxDetectState);
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_TLS, SSLGetTx);

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -442,7 +442,7 @@ static DetectEngineState *TemplateGetTxDetectState(void *vtx)
 /**
  * \brief ???
  */
-static int TemplateSetTxDetectState(void *state, void *vtx,
+static int TemplateSetTxDetectState(void *vtx,
     DetectEngineState *s)
 {
     TemplateTransaction *tx = vtx;
@@ -541,7 +541,7 @@ void RegisterTemplateParsers(void)
 
         /* What is this being registered for? */
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_TEMPLATE,
-            NULL, TemplateGetTxDetectState, TemplateSetTxDetectState);
+            TemplateGetTxDetectState, TemplateSetTxDetectState);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_TEMPLATE,
             TemplateStateGetEventInfo);

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -213,7 +213,7 @@ static DetectEngineState *TFTPGetTxDetectState(void *vtx)
     return NULL;
 }
 
-static int TFTPSetTxDetectState(void *state, void *vtx,
+static int TFTPSetTxDetectState(void *vtx,
     DetectEngineState *s)
 {
     return 0;
@@ -301,7 +301,7 @@ void RegisterTFTPParsers(void)
 
         /* What is this being registered for? */
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_TFTP,
-                                               NULL, TFTPGetTxDetectState,
+                                               TFTPGetTxDetectState,
                                                TFTPSetTxDetectState);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_UDP, ALPROTO_TFTP,

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -231,7 +231,7 @@ void DetectRunStoreStateTx(
         destate = DetectEngineStateAlloc();
         if (destate == NULL)
             return;
-        if (AppLayerParserSetTxDetectState(f, f->alstate, tx, destate) < 0) {
+        if (AppLayerParserSetTxDetectState(f, tx, destate) < 0) {
             DetectEngineStateFree(destate);
             return;
         }

--- a/src/detect-nfs-procedure.c
+++ b/src/detect-nfs-procedure.c
@@ -34,6 +34,8 @@
 #include "detect-pcre.h"
 #include "detect-nfs-procedure.h"
 
+#include "app-layer-parser.h"
+
 #include "flow.h"
 #include "flow-util.h"
 #include "flow-var.h"

--- a/src/detect-nfs-version.c
+++ b/src/detect-nfs-version.c
@@ -34,6 +34,8 @@
 #include "detect-pcre.h"
 #include "detect-nfs-version.h"
 
+#include "app-layer-parser.h"
+
 #include "flow.h"
 #include "flow-util.h"
 #include "flow-var.h"


### PR DESCRIPTION
Until now, the transaction space is assumed to be terse. Transactions
are handled sequentially so the difference between the lowest and highest
active tx id's is small. For this reason the logic of walking every id
between the 'minimum' and max id made sense. The space might look like:

    [..........TTTT]

Here the looping starts at the first T and loops 4 times.

This assumption isn't a great fit though. A protocol like NFS has 2 types
of transactions. Long running file transfer transactions and short lived
request/reply pairs are causing the id space to be sparse. This leads to
a lot of unnecessary looping in various parts of the engine, but most
prominently: detection, tx house keeping and tx logging.

    [.T..T...TTTT.T]

Here the looping starts at the first T and loops for every spot, even
those where no tx exists anymore.

Cases have been observed where the lowest tx id was 2 and the highest
was 50k. This lead to a lot of unnecessary looping.

This patch add an alternative approach. It allows a protocol to register
an iterator function, that simply returns the next transaction until
all transactions are returned. To do this it uses a bit of state the
caller must keep.

The registration is optional. If no iterator is registered the old
behaviour will be used.

Changes since #3214:
- make iterator return a struct { ptr, id, has_next } (tuple)
- remove unused HasTxDetectState call
- simplify GetTxDetectState

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/86
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/88
