### PR TITLE
conf/yaml: don't allow empty key values - v1

### DIFF
--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -206,6 +206,14 @@ ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq)
             char *tag = (char *)event.data.scalar.tag;
             SCLogDebug("event.type=YAML_SCALAR_EVENT; state=%d; value=%s; "
                 "tag=%s; inseq=%d", state, value, tag, inseq);
+
+            /* Skip over empty scalar values while in KEY state. This
+             * tends to only happen on an empty file, where a scalar
+             * event probably shouldn't fire anyways. */
+            if (state == CONF_KEY && strlen(value) == 0) {
+                goto next;
+            }
+
             if (inseq) {
                 char sequence_node_name[DEFAULT_NAME_LEN];
                 snprintf(sequence_node_name, DEFAULT_NAME_LEN, "%d", seq_idx++);


### PR DESCRIPTION
Another approach to https://github.com/OISF/suricata/pull/3163.

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/2418

Prevent the include of an empty file from creating an empty configuration key. This happens because libyaml givers on a scalar event on an empty file, and the first scalar event is received while in the state of looking for a key, so we set an empty key. Instead, don't transition the state if the value is an empty string.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/271
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/624
