### PR TITLE
modbus: duplicate alerts unaware of direction

### DIFF
--- a/doc/userguide/rules/modbus-keyword.rst
+++ b/doc/userguide/rules/modbus-keyword.rst
@@ -49,9 +49,11 @@ With the **access** setting, you can match on:
 Syntax::
 
   modbus: access <read | write>
-  modbus: access <read | write> <discretes | coils | input | holding>
-  modbus: access <read | write> <discretes | coils | input | holding>, address <value>
-  modbus: access <read | write> <discretes | coils | input | holding>, address <value>, value <value>
+  modbus: access read <discretes | coils | input | holding>
+  modbus: access read <discretes | coils | input | holding>, address <value>
+  modbus: access write < coils | holding>
+  modbus: access write < coils | holding>, address <value>
+  modbus: access write < coils | holding>, address <value>, value <value>
 
 With _<value>_ setting matches on the address or value as it is being
 accessed or written as follows::

--- a/src/detect-modbus.c
+++ b/src/detect-modbus.c
@@ -221,6 +221,10 @@ static DetectModbus *DetectModbusAccessParse(const char *str)
                     }
 
                     /* We have a correct address option */
+                    if (modbus->type == MODBUS_TYP_READ)
+                        /* Value access is only possible in write access. */
+                        goto error;
+
                     modbus->data = (DetectModbusValue *) SCCalloc(1, sizeof(DetectModbusValue));
                     if (unlikely(modbus->data == NULL))
                         goto error;
@@ -415,9 +419,6 @@ void DetectModbusRegister(void)
 
     DetectAppLayerInspectEngineRegister("modbus",
             ALPROTO_MODBUS, SIG_FLAG_TOSERVER, 0,
-            DetectEngineInspectModbus);
-    DetectAppLayerInspectEngineRegister("modbus",
-            ALPROTO_MODBUS, SIG_FLAG_TOCLIENT, 0,
             DetectEngineInspectModbus);
 
     g_modbus_buffer_id = DetectBufferTypeGetByName("modbus");


### PR DESCRIPTION
Remove DetectAppLayerInspectEngineRegister for TOCLIENT direction
because Modbus inspection engine is only performing in request (TOSERVER).

Detect Value keyword in read access rule. In read access, match on value
is not possible.

Update Modbus keyword documentation.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [issue #1904] (https://redmine.openinfosecfoundation.org/issues/1904)

Describe changes:
- Remove DetectAppLayerInspectEngineRegister for TOCLIENT direction
- Detect Value keyword in read access rule

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

