### PR TITLE
Rust: remove unused HasTxDetectState function, and state argument from SetTxDetectState

### DIFF
--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -45,9 +45,6 @@ pub struct NTPState {
     /// List of transactions for this session
     transactions: Vec<NTPTransaction>,
 
-    /// Detection engine states counter
-    de_state_count: u64,
-
     /// Events counter
     events: u16,
 
@@ -78,7 +75,6 @@ impl NTPState {
     pub fn new() -> NTPState {
         NTPState{
             transactions: Vec::new(),
-            de_state_count: 0,
             events: 0,
             tx_id: 0,
         }
@@ -284,13 +280,10 @@ pub extern "C" fn rs_ntp_tx_get_logged(_state: &mut NTPState,
 
 #[no_mangle]
 pub extern "C" fn rs_ntp_state_set_tx_detect_state(
-    state: *mut libc::c_void,
     tx: *mut libc::c_void,
     de_state: &mut core::DetectEngineState) -> libc::c_int
 {
-    let state = cast_pointer!(state,NTPState);
     let tx = cast_pointer!(tx,NTPTransaction);
-    state.de_state_count += 1;
     tx.de_state = Some(de_state);
     0
 }
@@ -403,7 +396,6 @@ pub unsafe extern "C" fn rs_register_ntp_parser() {
         set_tx_logged     : None,
         get_de_state      : rs_ntp_state_get_tx_detect_state,
         set_de_state      : rs_ntp_state_set_tx_detect_state,
-        has_de_state      : None,
         has_events        : Some(rs_ntp_state_has_events),
         get_events        : Some(rs_ntp_state_get_events),
         get_eventinfo     : Some(rs_ntp_state_get_event_info),

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -76,8 +76,6 @@ pub struct RustParser {
     pub get_de_state:      GetDetectStateFn,
     /// Function called to set a detection state
     pub set_de_state:      SetDetectStateFn,
-    /// Function to check if a detection state is present
-    pub has_de_state:      Option<HasDetectStateFn>,
 
     /// Function to check if there are events
     pub has_events:        Option<HasEventsFn>,
@@ -133,9 +131,8 @@ pub type StateGetTxFn            = extern "C" fn (*mut c_void, u64) -> *mut c_vo
 pub type StateGetTxCntFn         = extern "C" fn (*mut c_void) -> u64;
 pub type StateGetTxCompletionStatusFn = extern "C" fn (u8) -> c_int;
 pub type StateGetProgressFn = extern "C" fn (*mut c_void, u8) -> c_int;
-pub type HasDetectStateFn   = extern "C" fn (*mut c_void) -> c_int;
 pub type GetDetectStateFn   = extern "C" fn (*mut c_void) -> *mut DetectEngineState;
-pub type SetDetectStateFn   = extern "C" fn (*mut c_void, *mut c_void, &mut DetectEngineState) -> c_int;
+pub type SetDetectStateFn   = extern "C" fn (*mut c_void, &mut DetectEngineState) -> c_int;
 pub type GetEventInfoFn     = extern "C" fn (*const c_char, *mut c_int, *mut AppLayerEventType) -> c_int;
 pub type GetEventsFn        = extern "C" fn (*mut c_void, u64) -> *mut AppLayerDecoderEvents;
 pub type HasEventsFn        = extern "C" fn (*mut c_void) -> c_int;


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
not applicable

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
no ticket

Describe changes:
- update the Rust generic registration code and NTP parser to match changes from 7548944b49b0dfc218d73e3d12c993629258fb2a
- remove unused HasTxDetectState function, and state argument from SetTxDetectState
