### PR TITLE
ebpf: remove vlan_hdr alignement

### DIFF
--- a/ebpf/xdp_filter.c
+++ b/ebpf/xdp_filter.c
@@ -47,7 +47,7 @@
 struct vlan_hdr {
     __u16	h_vlan_TCI;
     __u16	h_vlan_encapsulated_proto;
-} __attribute__((__aligned__(8))) ;
+};
 
 struct flowv4_keys {
     __u32 src;


### PR DESCRIPTION
This fixes a mistake done in the XDP filter causing a failure of the parsing of IPv4 and IPv6 packets and by consequences the flows could be timeouted too early and the counters were wrong. Thanks @pevma for the bug report.

If we align the vlan_hdr then we increase its size and the parsing
of packets with VLAN tag is broken.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- fix XDP bypass filter for VLAN

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/387
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/170
