### PR TITLE
stream-tcp: bypass flow without streaming

### DIFF
--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -911,8 +911,13 @@ static int StreamTcpPacketStateNone(ThreadVars *tv, Packet *p,
     /* SYN/ACK */
     } else if ((p->tcph->th_flags & (TH_SYN|TH_ACK)) == (TH_SYN|TH_ACK)) {
         if (stream_config.midstream == FALSE &&
-                stream_config.async_oneside == FALSE)
+                stream_config.async_oneside == FALSE) {
+            /* There will be no TCP streaming so let's bypass */
+            if (StreamTcpBypassEnabled()) {
+                PacketBypassCallback(p);
+            }
             return 0;
+        }
 
         if (ssn == NULL) {
             ssn = StreamTcpNewSession(p, stt->ssn_pool_id);


### PR DESCRIPTION
If midstream or async flow are not enabled, Suricata won't stream
the packets for the flow so we can bypass them.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Bypass if suricata is not gonna stream

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/388
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/171

