### PR TITLE
app-layer: remove has events callback - not used - v1

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -749,14 +749,6 @@ pub extern "C" fn rs_dns_state_get_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_state_has_events(state: &mut DNSState) -> u8 {
-    if state.events > 0 {
-        return 1;
-    }
-    return 0;
-}
-
-#[no_mangle]
 pub extern "C" fn rs_dns_state_get_events(state: &mut DNSState,
                                           tx_id: libc::uint64_t)
                                           -> *mut core::AppLayerDecoderEvents

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -1976,14 +1976,6 @@ pub extern "C" fn rs_nfs_tx_get_detect_flags(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_has_events(state: &mut NFSState) -> u8 {
-    if state.events > 0 {
-        return 1;
-    }
-    return 0;
-}
-
-#[no_mangle]
 pub extern "C" fn rs_nfs_state_get_events(state: &mut NFSState,
                                           tx_id: libc::uint64_t)
                                           -> *mut AppLayerDecoderEvents

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -302,15 +302,6 @@ pub extern "C" fn rs_ntp_state_get_tx_detect_state(
 
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_state_has_events(state: *mut libc::c_void) -> libc::c_int {
-    let state = cast_pointer!(state,NTPState);
-    if state.events > 0 {
-        return 1;
-    }
-    return 0;
-}
-
-#[no_mangle]
 pub extern "C" fn rs_ntp_state_get_events(state: *mut libc::c_void,
                                           tx_id: libc::uint64_t)
                                           -> *mut core::AppLayerDecoderEvents
@@ -396,7 +387,6 @@ pub unsafe extern "C" fn rs_register_ntp_parser() {
         set_tx_logged     : None,
         get_de_state      : rs_ntp_state_get_tx_detect_state,
         set_de_state      : rs_ntp_state_set_tx_detect_state,
-        has_events        : Some(rs_ntp_state_has_events),
         get_events        : Some(rs_ntp_state_get_events),
         get_eventinfo     : Some(rs_ntp_state_get_event_info),
         localstorage_new  : None,

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -77,8 +77,6 @@ pub struct RustParser {
     /// Function called to set a detection state
     pub set_de_state:      SetDetectStateFn,
 
-    /// Function to check if there are events
-    pub has_events:        Option<HasEventsFn>,
     /// Function to get events
     pub get_events:        Option<GetEventsFn>,
     /// Function to get an event description
@@ -135,7 +133,6 @@ pub type GetDetectStateFn   = extern "C" fn (*mut c_void) -> *mut DetectEngineSt
 pub type SetDetectStateFn   = extern "C" fn (*mut c_void, &mut DetectEngineState) -> c_int;
 pub type GetEventInfoFn     = extern "C" fn (*const c_char, *mut c_int, *mut AppLayerEventType) -> c_int;
 pub type GetEventsFn        = extern "C" fn (*mut c_void, u64) -> *mut AppLayerDecoderEvents;
-pub type HasEventsFn        = extern "C" fn (*mut c_void) -> c_int;
 pub type GetTxLoggedFn      = extern "C" fn (*mut c_void, *mut c_void) -> u32;
 pub type SetTxLoggedFn      = extern "C" fn (*mut c_void, *mut c_void, u32);
 pub type LocalStorageNewFn  = extern "C" fn () -> *mut c_void;

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -1325,13 +1325,6 @@ static AppLayerDecoderEvents *DNP3GetEvents(void *state, uint64_t tx_id)
     return NULL;
 }
 
-static int DNP3HasEvents(void *state)
-{
-    SCEnter();
-    uint16_t events = (((DNP3State *)state)->events);
-    SCReturnInt((events > 0));
-}
-
 static void *DNP3GetTx(void *alstate, uint64_t tx_id)
 {
     SCEnter();
@@ -1620,8 +1613,6 @@ void RegisterDNP3Parsers(void)
 
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_DNP3,
             DNP3GetEvents);
-        AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_DNP3,
-            DNP3HasEvents);
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_DNP3,
             DNP3GetTxDetectState, DNP3SetTxDetectState);
 
@@ -2130,7 +2121,6 @@ static int DNP3ParserTestRequestResponse(void)
 
     state = flow.alstate;
     FAIL_IF(state == NULL);
-    FAIL_IF(DNP3HasEvents(state));
 
     DNP3Transaction *tx = DNP3GetTx(state, 0);
     FAIL_IF(tx == NULL);
@@ -2198,7 +2188,6 @@ static int DNP3ParserTestUnsolicitedResponseConfirm(void)
 
     state = flow.alstate;
     FAIL_IF(state == NULL);
-    FAIL_IF(DNP3HasEvents(state));
 
     DNP3Transaction *tx = DNP3GetTx(state, 0);
     FAIL_IF(tx == NULL);
@@ -2265,7 +2254,6 @@ static int DNP3ParserTestFlooded(void)
 
     state = flow.alstate;
     FAIL_IF(state == NULL);
-    FAIL_IF(DNP3HasEvents(state));
 
     DNP3Transaction *tx = DNP3GetTx(state, 0);
     FAIL_IF(tx == NULL);
@@ -2554,7 +2542,6 @@ static int DNP3ParserDecodeG70V3Test(void)
     FAIL_IF_NULL(dnp3state);
     int bytes = DNP3HandleRequestLinkLayer(dnp3state, pkt, sizeof(pkt));
     FAIL_IF(bytes != sizeof(pkt));
-    FAIL_IF(DNP3HasEvents(dnp3state));
     DNP3Transaction *tx = DNP3GetTx(dnp3state, 0);
     FAIL_IF_NULL(tx);
     FAIL_IF_NOT(tx->has_request);
@@ -2616,9 +2603,6 @@ static int DNP3ParserUnknownEventAlertTest(void)
     FAIL_IF_NULL(dnp3state);
     int bytes = DNP3HandleRequestLinkLayer(dnp3state, pkt, sizeof(pkt));
     FAIL_IF(bytes != sizeof(pkt));
-
-    /* Should have an event now. */
-    FAIL_IF_NOT(DNP3HasEvents(dnp3state));
 
     DNP3StateFree(dnp3state);
     PASS;

--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -172,12 +172,6 @@ AppLayerDecoderEvents *DNSGetEvents(void *state, uint64_t id)
     return NULL;
 }
 
-int DNSHasEvents(void *state)
-{
-    DNSState *dns_state = (DNSState *)state;
-    return (dns_state->events > 0);
-}
-
 void *DNSGetTx(void *alstate, uint64_t tx_id)
 {
     DNSState *dns_state = (DNSState *)alstate;

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -286,7 +286,6 @@ void DNSSetEvent(DNSState *s, uint8_t e);
 void *DNSStateAlloc(void);
 void DNSStateFree(void *s);
 AppLayerDecoderEvents *DNSGetEvents(void *state, uint64_t id);
-int DNSHasEvents(void *state);
 
 int DNSValidateRequestHeader(DNSState *, const DNSHeader *dns_header);
 int DNSValidateResponseHeader(DNSState *, const DNSHeader *dns_header);

--- a/src/app-layer-dns-tcp-rust.c
+++ b/src/app-layer-dns-tcp-rust.c
@@ -110,11 +110,6 @@ static int RustDNSSetTxDetectState(void *tx,
     return 0;
 }
 
-static int RustDNSHasEvents(void *state)
-{
-    return rs_dns_state_has_events(state);
-}
-
 static AppLayerDecoderEvents *RustDNSGetEvents(void *state, uint64_t id)
 {
     return rs_dns_state_get_events(state, id);
@@ -163,8 +158,6 @@ void RegisterRustDNSTCPParsers(void)
                 RustDNSStateTransactionFree);
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_DNS,
                 RustDNSGetEvents);
-        AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_DNS,
-                RustDNSHasEvents);
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_DNS,
                 RustDNSGetTxDetectState, RustDNSSetTxDetectState);
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_DNS, RustDNSGetTx);

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -748,7 +748,6 @@ void RegisterDNSTCPParsers(void)
                                          DNSStateTransactionFree);
 
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_DNS, DNSGetEvents);
-        AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_DNS, DNSHasEvents);
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_DNS,
                                                DNSGetTxDetectState, DNSSetTxDetectState);
         AppLayerParserRegisterDetectFlagsFuncs(IPPROTO_TCP, ALPROTO_DNS,

--- a/src/app-layer-dns-udp-rust.c
+++ b/src/app-layer-dns-udp-rust.c
@@ -116,12 +116,6 @@ static uint64_t RustDNSGetDetectFlags(void *tx, uint8_t dir)
     return rs_dns_tx_get_detect_flags(tx, dir);
 }
 
-
-static int RustDNSHasEvents(void *state)
-{
-    return rs_dns_state_has_events(state);
-}
-
 static AppLayerDecoderEvents *RustDNSGetEvents(void *state, uint64_t id)
 {
     return rs_dns_state_get_events(state, id);
@@ -172,8 +166,6 @@ void RegisterRustDNSUDPParsers(void)
                 RustDNSStateTransactionFree);
         AppLayerParserRegisterGetEventsFunc(IPPROTO_UDP, ALPROTO_DNS,
                 RustDNSGetEvents);
-        AppLayerParserRegisterHasEventsFunc(IPPROTO_UDP, ALPROTO_DNS,
-                RustDNSHasEvents);
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_DNS,
                 RustDNSGetTxDetectState, RustDNSSetTxDetectState);
         AppLayerParserRegisterDetectFlagsFuncs(IPPROTO_UDP, ALPROTO_DNS,

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -441,7 +441,6 @@ void RegisterDNSUDPParsers(void)
                                          DNSStateTransactionFree);
 
         AppLayerParserRegisterGetEventsFunc(IPPROTO_UDP, ALPROTO_DNS, DNSGetEvents);
-        AppLayerParserRegisterHasEventsFunc(IPPROTO_UDP, ALPROTO_DNS, DNSHasEvents);
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_DNS,
                                                DNSGetTxDetectState, DNSSetTxDetectState);
         AppLayerParserRegisterDetectFlagsFuncs(IPPROTO_UDP, ALPROTO_DNS,

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -128,11 +128,6 @@ static AppLayerDecoderEvents *ENIPGetEvents(void *state, uint64_t id)
     return NULL;
 }
 
-static int ENIPHasEvents(void *state)
-{
-    return (((ENIPState *) state)->events > 0);
-}
-
 static int ENIPStateGetEventInfo(const char *event_name, int *event_id, AppLayerEventType *event_type)
 {
     *event_id = SCMapEnumNameToValue(event_name, enip_decoder_event_table);
@@ -433,7 +428,6 @@ void RegisterENIPUDPParsers(void)
                 ENIPStateAlloc, ENIPStateFree);
 
         AppLayerParserRegisterGetEventsFunc(IPPROTO_UDP, ALPROTO_ENIP, ENIPGetEvents);
-        AppLayerParserRegisterHasEventsFunc(IPPROTO_UDP, ALPROTO_ENIP, ENIPHasEvents);
 
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_ENIP,
                 ENIPGetTxDetectState, ENIPSetTxDetectState);
@@ -513,7 +507,6 @@ void RegisterENIPTCPParsers(void)
                 ENIPStateAlloc, ENIPStateFree);
 
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_ENIP, ENIPGetEvents);
-        AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_ENIP, ENIPHasEvents);
 
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_ENIP,
                 ENIPGetTxDetectState, ENIPSetTxDetectState);

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -257,12 +257,6 @@ static void HTPSetEvent(HtpState *s, HtpTxUserData *htud, uint8_t e)
     SCLogDebug("couldn't set event %u", e);
 }
 
-static int HTPHasEvents(void *state)
-{
-    HtpState *htp_state = (HtpState *)state;
-    return (htp_state->events > 0);
-}
-
 static AppLayerDecoderEvents *HTPGetEvents(void *state, uint64_t tx_id)
 {
     SCLogDebug("get HTTP events for TX %"PRIu64, tx_id);
@@ -2857,7 +2851,6 @@ void RegisterHTPParsers(void)
                                           HTPStateSetTxLogged);
         AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_HTTP,
                                                                HTPStateGetAlstateProgressCompletionStatus);
-        AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_HTTP, HTPHasEvents);
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_HTTP, HTPGetEvents);
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_HTTP, HTPStateGetEventInfo);
 

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -214,11 +214,6 @@ static AppLayerDecoderEvents *ModbusGetEvents(void *state, uint64_t id)
     return NULL;
 }
 
-static int ModbusHasEvents(void *state)
-{
-    return (((ModbusState *) state)->events > 0);
-}
-
 static int ModbusGetAlstateProgress(void *modbus_tx, uint8_t direction)
 {
     ModbusTransaction   *tx     = (ModbusTransaction *) modbus_tx;
@@ -1526,7 +1521,6 @@ void RegisterModbusParsers(void)
         AppLayerParserRegisterStateFuncs(IPPROTO_TCP, ALPROTO_MODBUS, ModbusStateAlloc, ModbusStateFree);
 
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_MODBUS, ModbusGetEvents);
-        AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_MODBUS, ModbusHasEvents);
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_MODBUS,
                                                ModbusGetTxDetectState, ModbusSetTxDetectState);
 

--- a/src/app-layer-nfs-tcp.c
+++ b/src/app-layer-nfs-tcp.c
@@ -101,11 +101,6 @@ static int NFSTCPStateGetEventInfo(const char *event_name, int *event_id,
     return rs_nfs_state_get_event_info(event_name, event_id, event_type);
 }
 
-static int NFSTCPHasEvents(void *state)
-{
-    return rs_nfs_state_has_events(state);
-}
-
 static AppLayerDecoderEvents *NFSTCPGetEvents(void *state, uint64_t id)
 {
     return rs_nfs_state_get_events(state, id);
@@ -359,10 +354,6 @@ void RegisterNFSTCPParsers(void)
                 RustNFSTCPGetTxIterator);
 
         AppLayerParserRegisterGetFilesFunc(IPPROTO_TCP, ALPROTO_NFS, NFSTCPGetFiles);
-
-        /* Application layer event handling. */
-        AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_NFS,
-                NFSTCPHasEvents);
 
         /* What is this being registered for? */
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_NFS,

--- a/src/app-layer-nfs-udp.c
+++ b/src/app-layer-nfs-udp.c
@@ -98,11 +98,6 @@ static int NFSStateGetEventInfo(const char *event_name, int *event_id,
     return rs_nfs_state_get_event_info(event_name, event_id, event_type);
 }
 
-static int NFSHasEvents(void *state)
-{
-    return rs_nfs_state_has_events(state);
-}
-
 static AppLayerDecoderEvents *NFSGetEvents(void *state, uint64_t id)
 {
     return rs_nfs_state_get_events(state, id);
@@ -352,10 +347,6 @@ void RegisterNFSUDPParsers(void)
                 RustNFSGetTxIterator);
 
         AppLayerParserRegisterGetFilesFunc(IPPROTO_UDP, ALPROTO_NFS, NFSGetFiles);
-
-        /* Application layer event handling. */
-        AppLayerParserRegisterHasEventsFunc(IPPROTO_UDP, ALPROTO_NFS,
-            NFSHasEvents);
 
         /* What is this being registered for? */
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_NFS,

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -100,7 +100,6 @@ typedef struct AppLayerParserProtoCtx_
     void (*Truncate)(void *, uint8_t);
     FileContainer *(*StateGetFiles)(void *, uint8_t);
     AppLayerDecoderEvents *(*StateGetEvents)(void *, uint64_t);
-    int (*StateHasEvents)(void *);
 
     int (*StateGetProgress)(void *alstate, uint8_t direction);
     uint64_t (*StateGetTxCnt)(void *alstate);
@@ -416,17 +415,6 @@ void AppLayerParserRegisterGetEventsFunc(uint8_t ipproto, AppProto alproto,
 
     alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].StateGetEvents =
         StateGetEvents;
-
-    SCReturn;
-}
-
-void AppLayerParserRegisterHasEventsFunc(uint8_t ipproto, AppProto alproto,
-                              int (*StateHasEvents)(void *))
-{
-    SCEnter();
-
-    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].StateHasEvents =
-        StateHasEvents;
 
     SCReturn;
 }
@@ -1370,7 +1358,7 @@ static void ValidateParserProtoDump(AppProto alproto, uint8_t ipproto)
     printf("Optional:\n");
     printf("- LocalStorageAlloc %p LocalStorageFree %p\n", ctx->LocalStorageAlloc, ctx->LocalStorageFree);
     printf("- StateGetTxLogged %p StateSetTxLogged %p\n", ctx->StateGetTxLogged, ctx->StateSetTxLogged);
-    printf("- StateGetEvents %p StateHasEvents %p StateGetEventInfo %p\n", ctx->StateGetEvents, ctx->StateHasEvents, ctx->StateGetEventInfo);
+    printf("- StateGetEvents %p StateGetEventInfo %p\n", ctx->StateGetEvents, ctx->StateGetEventInfo);
 }
 
 #define BOTH_SET(a, b) ((a) != NULL && (b) != NULL)

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -137,8 +137,6 @@ void AppLayerParserRegisterGetFilesFunc(uint8_t ipproto, AppProto alproto,
                              FileContainer *(*StateGetFiles)(void *, uint8_t));
 void AppLayerParserRegisterGetEventsFunc(uint8_t ipproto, AppProto proto,
     AppLayerDecoderEvents *(*StateGetEvents)(void *, uint64_t));
-void AppLayerParserRegisterHasEventsFunc(uint8_t ipproto, AppProto alproto,
-                              int (*StateHasEvents)(void *));
 void AppLayerParserRegisterLoggerFuncs(uint8_t ipproto, AppProto alproto,
                          LoggerId (*StateGetTxLogged)(void *, void *),
                          void (*StateSetTxLogged)(void *, void *, LoggerId));

--- a/src/app-layer-register.c
+++ b/src/app-layer-register.c
@@ -137,12 +137,6 @@ int AppLayerRegisterParser(const struct AppLayerParser *p, AppProto alproto)
                 p->StateGetTxLogged, p->StateSetTxLogged);
     }
 
-    /* Application layer event handling. */
-    if (p->StateHasEvents) {
-        AppLayerParserRegisterHasEventsFunc(p->ip_proto, alproto,
-                p->StateHasEvents);
-    }
-
     /* What is this being registered for? */
     AppLayerParserRegisterDetectStateFuncs(p->ip_proto, alproto,
         p->GetTxDetectState, p->SetTxDetectState);

--- a/src/app-layer-register.h
+++ b/src/app-layer-register.h
@@ -54,7 +54,6 @@ typedef struct AppLayerParser {
     DetectEngineState *(*GetTxDetectState)(void *tx);
     int (*SetTxDetectState)(void *tx, DetectEngineState *);
 
-    int (*StateHasEvents)(void *);
     AppLayerDecoderEvents *(*StateGetEvents)(void *, uint64_t);
     int (*StateGetEventInfo)(const char *event_name,
                              int *event_id, AppLayerEventType *event_type);

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -158,12 +158,6 @@ static AppLayerDecoderEvents *SSLGetEvents(void *state, uint64_t id)
     return ssl_state->decoder_events;
 }
 
-static int SSLHasEvents(void *state)
-{
-    SSLState *ssl_state = (SSLState *)state;
-    return (ssl_state->events > 0);
-}
-
 static int SSLSetTxDetectState(void *vtx, DetectEngineState *de_state)
 {
     SSLState *ssl_state = (SSLState *)vtx;
@@ -1850,8 +1844,6 @@ void RegisterSSLParsers(void)
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_TLS, SSLStateTransactionFree);
 
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_TLS, SSLGetEvents);
-
-        AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_TLS, SSLHasEvents);
 
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_TLS,
                                                SSLGetTxDetectState, SSLSetTxDetectState);

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -189,12 +189,6 @@ static AppLayerDecoderEvents *TemplateGetEvents(void *state, uint64_t tx_id)
     return NULL;
 }
 
-static int TemplateHasEvents(void *state)
-{
-    TemplateState *echo = state;
-    return echo->events;
-}
-
 /**
  * \brief Probe the input to see if it looks like echo.
  *
@@ -534,10 +528,6 @@ void RegisterTemplateParsers(void)
             ALPROTO_TEMPLATE, TemplateGetStateProgress);
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_TEMPLATE,
             TemplateGetTx);
-
-        /* Application layer event handling. */
-        AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_TEMPLATE,
-            TemplateHasEvents);
 
         /* What is this being registered for? */
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_TEMPLATE,

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -106,11 +106,6 @@ static AppLayerDecoderEvents *TFTPGetEvents(void *state, uint64_t tx_id)
     return NULL;
 }
 
-static int TFTPHasEvents(void *state)
-{
-    return rs_tftp_has_event(state);
-}
-
 /**
  * \brief Probe the input to see if it looks like echo.
  *
@@ -294,10 +289,6 @@ void RegisterTFTPParsers(void)
                                                    TFTPGetStateProgress);
         AppLayerParserRegisterGetTx(IPPROTO_UDP, ALPROTO_TFTP,
                                     TFTPGetTx);
-
-        /* Application layer event handling. */
-        AppLayerParserRegisterHasEventsFunc(IPPROTO_UDP, ALPROTO_TFTP,
-                                            TFTPHasEvents);
 
         /* What is this being registered for? */
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_TFTP,


### PR DESCRIPTION
Remove the HasEvents callback in the app-layer as it is no longer being called.

This also fixes issue https://redmine.openinfosecfoundation.org/issues/2437 by removing the event count tracking code that triggered the panic.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/274
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/627

