### PR TITLE
Fix alert-prelude output

### DIFF
--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -696,6 +696,7 @@ static int PreludePrintStreamSegmentCallback(const Packet *p, void *data, const 
  */
 static TmEcode AlertPreludeThreadInit(ThreadVars *t, const void *initdata, void **data)
 {
+    int ret;
     AlertPreludeThread *aun;
 
     SCEnter();
@@ -715,20 +716,11 @@ static TmEcode AlertPreludeThreadInit(ThreadVars *t, const void *initdata, void 
     aun->ctx = ((OutputCtx *)initdata)->data;
 
     /* Create a per-thread idmef analyzer */
-    if (unlikely(idmef_analyzer_new(&aun->analyzer) < 0)) {
+    ret = idmef_analyzer_clone(prelude_client_get_analyzer(aun->ctx->client), &aun->analyzer);
+    if (unlikely(ret < 0)) {
         SCLogError(SC_ERR_INITIALIZATION,
                    "Error creating idmef analyzer for Prelude.");
 
-        SCFree(aun);
-        SCReturnInt(TM_ECODE_FAILED);
-    }
-
-    /* Setup the per-thread idmef analyzer */
-    if (unlikely(SetupAnalyzer(aun->analyzer) < 0)) {
-        SCLogError(SC_ERR_INITIALIZATION,
-                   "Error configuring idmef analyzer for Prelude.");
-
-        idmef_analyzer_destroy(aun->analyzer);
         SCFree(aun);
         SCReturnInt(TM_ECODE_FAILED);
     }

--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -237,12 +237,12 @@ static int EventToImpact(const PacketAlert *pa, const Packet *p, idmef_alert_t *
         idmef_assessment_set_action(assessment, action, 0);
     }
 
-    if (pa->s->class_msg) {
+    if (pa->s->msg) {
         ret = idmef_impact_new_description(impact, &str);
         if (unlikely(ret < 0))
             SCReturnInt(ret);
 
-        prelude_string_set_ref(str, pa->s->class_msg);
+        prelude_string_set_ref(str, pa->s->msg);
     }
 
     SCReturnInt(0);
@@ -921,12 +921,12 @@ static int AlertPreludeLogger(ThreadVars *tv, void *thread_data, const Packet *p
     if (unlikely(ret < 0))
         goto err;
 
-    if (pa->s->msg) {
+    if (pa->s->class_msg) {
         ret = idmef_classification_new_text(class, &str);
         if (unlikely(ret < 0))
             goto err;
 
-        prelude_string_set_ref(str, pa->s->msg);
+        prelude_string_set_ref(str, pa->s->class_msg);
     }
 
     ret = EventToImpact(pa, p, alert);


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/1842

Describe changes:
- Fix the issue where Prelude alerts were created with the "suricata" analyzer duplicated
- In Prelude alerts, use class_msg for classification and msg for impact description, instead of the reverse

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

