### PR TITLE
source-pcap-file: Missing pcap file will stop pcap thread under unix socket (bug #2451)

### DIFF
--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -67,6 +67,7 @@ static void CleanupPcapDirectoryFromThreadVars(PcapFileThreadVars *tv,
                                                PcapFileDirectoryVars *ptv);
 static void CleanupPcapFileFromThreadVars(PcapFileThreadVars *tv, PcapFileFileVars *pfv);
 static void CleanupPcapFileThreadVars(PcapFileThreadVars *tv);
+static TmEcode PcapFileExit(TmEcode status);
 
 void CleanupPcapFileFromThreadVars(PcapFileThreadVars *tv, PcapFileFileVars *pfv)
 {
@@ -141,6 +142,16 @@ void PcapFileGlobalInit()
     SC_ATOMIC_INIT(pcap_g.invalid_checksums);
 }
 
+TmEcode PcapFileExit(TmEcode status)
+{
+    if(RunModeUnixSocketIsActive()) {
+        SCReturnInt(TM_ECODE_DONE);
+    } else {
+        EngineStop();
+        SCReturnInt(status);
+    }
+}
+
 TmEcode ReceivePcapFileLoop(ThreadVars *tv, void *data, void *slot)
 {
     SCEnter();
@@ -169,12 +180,7 @@ TmEcode ReceivePcapFileLoop(ThreadVars *tv, void *data, void *slot)
 
     SCLogDebug("Pcap file loop complete with status %u", status);
 
-    if(RunModeUnixSocketIsActive()) {
-        SCReturnInt(TM_ECODE_DONE);
-    } else {
-        EngineStop();
-        SCReturnInt(TM_ECODE_OK);
-    }
+    SCReturnInt(PcapFileExit(status));
 }
 
 TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **data)
@@ -186,12 +192,12 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
 
     if (initdata == NULL) {
         SCLogError(SC_ERR_INVALID_ARGUMENT, "error: initdata == NULL");
-        SCReturnInt(TM_ECODE_FAILED);
+        SCReturnInt(PcapFileExit(TM_ECODE_FAILED));
     }
 
     PcapFileThreadVars *ptv = SCMalloc(sizeof(PcapFileThreadVars));
     if (unlikely(ptv == NULL))
-        SCReturnInt(TM_ECODE_FAILED);
+        SCReturnInt(PcapFileExit(TM_ECODE_FAILED));
     memset(ptv, 0, sizeof(PcapFileThreadVars));
 
     intmax_t tenant = 0;
@@ -211,7 +217,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
         if (unlikely(ptv->shared.bpf_string == NULL)) {
             SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate bpf_string");
             CleanupPcapFileThreadVars(ptv);
-            SCReturnInt(TM_ECODE_FAILED);
+            SCReturnInt(PcapFileExit(TM_ECODE_FAILED));
         }
     }
 
@@ -219,7 +225,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
     SCLogInfo("Checking file or directory %s", (char*)initdata);
     if(PcapDetermineDirectoryOrFile((char *)initdata, &directory) == TM_ECODE_FAILED) {
         CleanupPcapFileThreadVars(ptv);
-        SCReturnInt(TM_ECODE_FAILED);
+        SCReturnInt(PcapFileExit(TM_ECODE_FAILED));
     }
 
     if(directory == NULL) {
@@ -228,7 +234,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
         if (unlikely(pv == NULL)) {
             SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate file vars");
             CleanupPcapFileThreadVars(ptv);
-            SCReturnInt(TM_ECODE_FAILED);
+            SCReturnInt(PcapFileExit(TM_ECODE_FAILED));
         }
         memset(pv, 0, sizeof(PcapFileFileVars));
 
@@ -237,7 +243,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
             SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate filename");
             CleanupPcapFileFileVars(pv);
             CleanupPcapFileThreadVars(ptv);
-            SCReturnInt(TM_ECODE_FAILED);
+            SCReturnInt(PcapFileExit(TM_ECODE_FAILED));
         }
 
         TmEcode init_file_return = InitPcapFile(pv);
@@ -251,7 +257,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
                          "Failed to init pcap file %s, skipping", (char *)initdata);
             CleanupPcapFileFileVars(pv);
             CleanupPcapFileThreadVars(ptv);
-            SCReturnInt(init_file_return);
+            SCReturnInt(PcapFileExit(init_file_return));
         }
     } else {
         SCLogInfo("Argument %s was a directory", (char *)initdata);
@@ -260,7 +266,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
             SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate directory vars");
             closedir(directory);
             CleanupPcapFileThreadVars(ptv);
-            SCReturnInt(TM_ECODE_FAILED);
+            SCReturnInt(PcapFileExit(TM_ECODE_FAILED));
         }
         memset(pv, 0, sizeof(PcapFileDirectoryVars));
 
@@ -269,7 +275,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
             SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate filename");
             CleanupPcapFileDirectoryVars(pv);
             CleanupPcapFileThreadVars(ptv);
-            SCReturnInt(TM_ECODE_FAILED);
+            SCReturnInt(PcapFileExit(TM_ECODE_FAILED));
         }
 
         int should_loop = 0;


### PR DESCRIPTION
https://redmine.openinfosecfoundation.org/issues/2451

When a missing (or empty named) file is passed to source-pcap-file while
using unix socket, the pcap processing thread will incorrectly be stopped,
and no longer available for subsequent files.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2451

Describe changes:
- When running under unix socket, don't return failed.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

