### PR TITLE
RFC/Preview: Filestore stream-depth fixes v2

### DIFF
--- a/doc/userguide/file-extraction/file-extraction.rst
+++ b/doc/userguide/file-extraction/file-extraction.rst
@@ -63,6 +63,15 @@ of the filename. For example, if the SHA256 hex string of an extracted
 file starts with "f9bc6d..." the file we be placed in the directory
 `filestore/f9`.
 
+The size of a file that can be stored depends on ``file-store.stream-depth``,
+if this value is reached a file can be truncated and not stored completely.
+If not enabled, ``stream.reassembly.depth`` will be considered.
+
+Setting ``file-store.stream-depth`` to 0 permits to store any files.
+
+A protocol parser, like modbus, could permit to set a different
+store-depth value and use it rather than ``file-store.stream-depth``.
+
 Using the SHA256 for file names allows for automatic de-duplication of
 extracted files. However, the timestamp of a pre-existing file will be
 updated if the same files is extracted again, similar to the `touch`

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -459,6 +459,36 @@ void AppLayerHtpNeedFileInspection(void)
     SCReturn;
 }
 
+void AppLayerHtpFollowFileStreamDepth(htp_tx_t *tx, uint8_t flags)
+{
+    HtpTxUserData *tx_ud = (HtpTxUserData *) htp_tx_get_user_data(tx);
+    if (tx_ud) {
+        if (flags & STREAM_TOCLIENT) {
+            tx_ud->tcflags |= HTP_STREAM_DEPTH_SET;
+        } else {
+            tx_ud->tsflags |= HTP_STREAM_DEPTH_SET;
+        }
+    }
+}
+
+static int AppLayerHtpCheckStreamDepth(HtpTxUserData *tx_ud)
+{
+    if (tx_ud->tcflags & HTP_STREAM_DEPTH_SET) {
+        if (tx_ud->response_body.content_len_so_far < FileReassemblyDepth() ||
+            FileReassemblyDepth() == 0)
+        {
+            return 1;
+        }
+    } else if (tx_ud->tsflags & HTP_STREAM_DEPTH_SET) {
+        if (tx_ud->request_body.content_len_so_far < FileReassemblyDepth() ||
+            FileReassemblyDepth() == 0)
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 /* below error messages updated up to libhtp 0.5.7 (git 379632278b38b9a792183694a4febb9e0dbd1e7a) */
 struct {
     const char *msg;
@@ -1709,15 +1739,22 @@ static int HTPCallbackRequestBodyData(htp_tx_data_t *d)
     SCLogDebug("hstate->cfg->request.body_limit %u", hstate->cfg->request.body_limit);
 
     /* within limits, add the body chunk to the state. */
-    if (hstate->cfg->request.body_limit == 0 || tx_ud->request_body.content_len_so_far < hstate->cfg->request.body_limit)
+    if (hstate->cfg->request.body_limit == 0 || tx_ud->request_body.content_len_so_far < hstate->cfg->request.body_limit ||
+        AppLayerHtpCheckStreamDepth(tx_ud))
     {
         uint32_t len = (uint32_t)d->len;
+        uint64_t stream_depth = FileReassemblyDepth();
 
-        if (hstate->cfg->request.body_limit > 0 &&
+        if (!(tx_ud->tsflags & HTP_STREAM_DEPTH_SET) && hstate->cfg->request.body_limit > 0 &&
                 (tx_ud->request_body.content_len_so_far + len) > hstate->cfg->request.body_limit)
         {
             len = hstate->cfg->request.body_limit - tx_ud->request_body.content_len_so_far;
             BUG_ON(len > (uint32_t)d->len);
+        } else if ((tx_ud->tsflags & HTP_STREAM_DEPTH_SET) && stream_depth > 0 &&
+                   (tx_ud->request_body.content_len_so_far + len) > stream_depth)
+        {
+            len = stream_depth - tx_ud->request_body.content_len_so_far;
+            BUG_ON(len > d->len);
         }
         SCLogDebug("len %u", len);
 
@@ -1801,14 +1838,22 @@ static int HTPCallbackResponseBodyData(htp_tx_data_t *d)
     SCLogDebug("hstate->cfg->response.body_limit %u", hstate->cfg->response.body_limit);
 
     /* within limits, add the body chunk to the state. */
-    if (hstate->cfg->response.body_limit == 0 || tx_ud->response_body.content_len_so_far < hstate->cfg->response.body_limit)
+    if (hstate->cfg->response.body_limit == 0 || tx_ud->response_body.content_len_so_far < hstate->cfg->response.body_limit ||
+        AppLayerHtpCheckStreamDepth(tx_ud))
+
     {
         uint32_t len = (uint32_t)d->len;
+        uint64_t stream_depth = FileReassemblyDepth();
 
-        if (hstate->cfg->response.body_limit > 0 &&
+        if (!(tx_ud->tsflags & HTP_STREAM_DEPTH_SET) && hstate->cfg->response.body_limit > 0 &&
                 (tx_ud->response_body.content_len_so_far + len) > hstate->cfg->response.body_limit)
         {
             len = hstate->cfg->response.body_limit - tx_ud->response_body.content_len_so_far;
+            BUG_ON(len > (uint32_t)d->len);
+        } else if ((tx_ud->tsflags & HTP_STREAM_DEPTH_SET) && stream_depth > 0 &&
+                   (tx_ud->request_body.content_len_so_far + len) > stream_depth)
+        {
+            len = stream_depth - tx_ud->request_body.content_len_so_far;
             BUG_ON(len > (uint32_t)d->len);
         }
         SCLogDebug("len %u", len);

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -174,6 +174,7 @@ typedef struct HtpBody_ {
 #define HTP_BOUNDARY_OPEN       0x04    /**< We have a boundary string */
 #define HTP_FILENAME_SET        0x08   /**< filename is registered in the flow */
 #define HTP_DONTSTORE           0x10    /**< not storing this file */
+#define HTP_STREAM_DEPTH_SET    0x20    /**< stream-depth is set */
 
 /** Now the Body Chunks will be stored per transaction, at
   * the tx user data */
@@ -259,6 +260,7 @@ void AppLayerHtpEnableRequestBodyCallback(void);
 void AppLayerHtpEnableResponseBodyCallback(void);
 void AppLayerHtpNeedFileInspection(void);
 void AppLayerHtpPrintStats(void);
+void AppLayerHtpFollowFileStreamDepth(htp_tx_t *tx, uint8_t flags);
 
 void HTPConfigure(void);
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -206,8 +206,11 @@ void AppLayerParserPostStreamSetup(void)
     /* lets set a default value for stream_depth */
     for (flow_proto = 0; flow_proto < FLOW_PROTO_DEFAULT; flow_proto++) {
         for (alproto = 0; alproto < ALPROTO_MAX; alproto++) {
-            alp_ctx.ctxs[flow_proto][alproto].stream_depth =
-                stream_config.reassembly_depth;
+            if (!(alp_ctx.ctxs[flow_proto][alproto].flags &
+                APP_LAYER_PARSER_OPT_STREAM_DEPTH_SET)) {
+                alp_ctx.ctxs[flow_proto][alproto].stream_depth =
+                    stream_config.reassembly_depth;
+            }
         }
     }
 }
@@ -1311,6 +1314,8 @@ void AppLayerParserSetStreamDepth(uint8_t ipproto, AppProto alproto, uint32_t st
     SCEnter();
 
     alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].stream_depth = stream_depth;
+    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].flags |=
+        APP_LAYER_PARSER_OPT_STREAM_DEPTH_SET;
 
     SCReturn;
 }

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -39,6 +39,7 @@
 
 /* Flags for AppLayerParserProtoCtx. */
 #define APP_LAYER_PARSER_OPT_ACCEPT_GAPS        BIT_U64(0)
+#define APP_LAYER_PARSER_OPT_STREAM_DEPTH_SET   BIT_U64(1)
 
 /* applies to DetectFlags uint64_t field */
 

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -201,14 +201,26 @@ int DetectFilestorePostMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx, Pack
 #endif
     }
 
-    /* set filestore depth for stream reassembling */
-    TcpSession *ssn = (TcpSession *)p->flow->protoctx;
-    TcpSessionSetReassemblyDepth(ssn, FileReassemblyDepth());
-
     if (p->flowflags & FLOW_PKT_TOCLIENT)
         flags |= STREAM_TOCLIENT;
     else
         flags |= STREAM_TOSERVER;
+
+    /* set filestore depth for stream reassembling */
+    TcpSession *ssn = (TcpSession *)p->flow->protoctx;
+    TcpSessionSetReassemblyDepth(ssn, FileReassemblyDepth());
+
+    if (p->flow->alproto == ALPROTO_HTTP) {
+        HtpState *htp_state = (HtpState *)FlowGetAppState(p->flow);
+        if (htp_state != NULL) {
+            uint64_t tx_id = AppLayerParserGetTransactionLogId(p->flow->alparser);
+            htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP,
+                                               htp_state, tx_id);
+            if (tx != NULL) {
+                AppLayerHtpFollowFileStreamDepth(tx, flags);
+            }
+        }
+    }
 
     FileContainer *ffc = AppLayerParserGetFiles(p->flow->proto, p->flow->alproto,
                                                 p->flow->alstate, flags);

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -561,19 +561,19 @@ static uint32_t StreamTcpReassembleCheckDepth(TcpSession *ssn, TcpStream *stream
             stream->base_seq, seg_depth,
             stream_config.reassembly_depth);
 
-    if (seg_depth > (uint64_t)stream_config.reassembly_depth) {
+    if (seg_depth > (uint64_t)ssn->reassembly_depth) {
         SCLogDebug("STREAMTCP_STREAM_FLAG_DEPTH_REACHED");
         stream->flags |= STREAMTCP_STREAM_FLAG_DEPTH_REACHED;
         SCReturnUInt(0);
     }
     SCLogDebug("NOT STREAMTCP_STREAM_FLAG_DEPTH_REACHED");
-    SCLogDebug("%"PRIu64" <= %u", seg_depth, stream_config.reassembly_depth);
+    SCLogDebug("%"PRIu64" <= %u", seg_depth, ssn->reassembly_depth);
 #if 0
     SCLogDebug("full depth not yet reached: %"PRIu64" <= %"PRIu32,
             (stream->base_seq_offset + stream->base_seq + size),
             (stream->isn + stream_config.reassembly_depth));
 #endif
-    if (SEQ_GEQ(seq, stream->isn) && SEQ_LT(seq, (stream->isn + stream_config.reassembly_depth))) {
+    if (SEQ_GEQ(seq, stream->isn) && SEQ_LT(seq, (stream->isn + ssn->reassembly_depth))) {
         /* packet (partly?) fits the depth window */
 
         if (SEQ_LEQ((seq + size),(stream->isn + 1 + ssn->reassembly_depth))) {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2264

Describe changes:

In the previous patchset, when a TX was flagged by file-store, at some point
the request or response body reassembled reaches its respective body limit,
so the chunk's len calculated by the line below is zero, which is cleary wrong:
```
len = hstate->cfg->request.body_limit - tx_ud->request_body.content_len_so_far;
```
This happens because a TX is flagged but then the stream depth value is not used
to determine the length of a chunk.
To calculate the correct length, when a TX is not flagged the body limit is used,
in the other case, when a TX is flagged, the stream depth value set is used.

While testing it, I have noticed that in case of file storing a file in TOSERVER direction, 
if a file will be truncated its state will be closed, as you can see in the example below:
```
outputs.14.file-store.stream-depth = 50kb
app-layer.protocols.http.libhtp.default-config.request-body-limit = 20kb
# cat var/log/suricata/files/file.1.meta 
TIME:              03/05/2005-15:33:05.147818
PCAP PKT NUM:      11
SRC IP:            131.212.31.167
DST IP:            128.119.245.12
PROTO:             6
SRC PORT:          2096
DST PORT:          80
APP PROTO:         http
HTTP URI:          /ethereal-labs/lab3-1-reply.htm
HTTP HOST:         gaia.cs.umass.edu
HTTP REFERER:      http://gaia.cs.umass.edu/ethereal-labs/TCP-ethereal-file1.html
HTTP USER AGENT:   Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)
FILENAME:          C:\\bchoi\\class\\CS4411-5651-Spr05\\Labs\\ethereal\\alice.txt
MAGIC:             <unknown>
STATE:             CLOSED
MD5:               cc170abc361e0107e73b01194ccf47c8
SHA1:              5064decf143bfb3f0c020921c43c11505b43495c
SHA256:            7f368df4207fbd9015038a32acab63040468898bfa0224c5c91eb136d419b9c1
SIZE:              50972
```
The file size is around ~150kb, and here even the size is less the state is set to CLOSED.

Attached files contains all the cases tested: [stream_depth_tests.txt](https://github.com/OISF/suricata/files/1780161/stream_depth_tests.txt)

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/180
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/44
