### PR TITLE
Support Modbus Unit Identifier

### DIFF
--- a/doc/userguide/rules/modbus-keyword.rst
+++ b/doc/userguide/rules/modbus-keyword.rst
@@ -4,10 +4,11 @@ Modbus Keyword
 The modbus keyword can be used for matching on various properties of
 Modbus requests.
 
-There are two ways of using this keyword:
+There are three ways of using this keyword:
 
 * matching on functions properties with the setting "function";
-* matching on directly on data access with the setting "access".
+* matching on directly on data access with the setting "access";
+* matching on unit identifier with the setting "unit" only or with the previous setting "function" or "access".
 
 With the setting **function**, you can match on:
 
@@ -72,6 +73,43 @@ Examples::
   modbus: access read discretes, address <100            # Read access at address smaller than 100 of Discretes Input table
   modbus: access write holding, address 500, value >200  # Write value greather than 200 at address 500 of Holding Registers table
 
+With the setting **unit**, you can match on:
+
+* a MODBUS slave address of a remote device connected on the sub-network behind a bridge or a gateway. The destination IP address identifies the bridge itself and the bridge uses the MODBUS unit identifier to forward the request to the right slave device. 
+
+Syntax::
+
+  modbus: unit <value>
+  modbus: unit <value>, function <value>
+  modbus: unit <value>, function <value>, subfunction <value>
+  modbus: unit <value>, function [!] <assigned | unassigned | public | user | reserved | all>
+  modbus: unit <value>, access <read | write>
+  modbus: unit <value>, access read <discretes | coils | input | holding>
+  modbus: unit <value>, access read <discretes | coils | input | holding>, address <value>
+  modbus: unit <value>, access write < coils | holding>
+  modbus: unit <value>, access write < coils | holding>, address <value>
+  modbus: unit <value>, access write < coils | holding>, address <value>, value <value>
+
+With _<value>_ setting matches on the address or value as it is being
+accessed or written as follows::
+
+  unit 10     # exactly unit identifier 10
+  unit 10<>20 # greater than unit identifier 10 and smaller than unit identifier 20
+  unit >10    # greater than unit identifier 10
+  unit <10    # smaller than unit identifier 10
+
+Examples::
+
+  modbus: unit 10                                                       # Unit identifier 10
+  modbus: unit 10, function 21                                          # Unit identifier 10 and write File record function
+  modbus: unit 10, function 4, subfunction 4                            # Unit identifier 10 and force Listen Only Mode (Diagnostics) function
+  modbus: unit 10, function assigned                                    # Unit identifier 10 and assigned function
+  modbus: unit 10, function !reserved                                   # Unit identifier 10 and every function but reserved function
+  modbus: unit 10, access read                                          # Unit identifier 10 and Read access
+  modbus: unit 10, access write coils                                   # Unit identifier 10 and Write access to Coils table
+  modbus: unit >10, access read discretes, address <100                 # Greater than unit identifier 10 and Read access at address smaller than 100 of Discretes Input table
+  modbus: unit 10<>20, access write holding, address 500, value >200    # Greater than unit identifier 10 and smaller than unit identifier 20 and Write value greather than 200 at address 500 of Holding Registers table
+
 (cf. http://www.modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf)
 
 **Note:** Address of read and write are starting at 1. So if your system
@@ -82,6 +120,10 @@ V1.0b, it is recommended to keep the TCP connection opened with a
 remote device and not to open and close it for each MODBUS/TCP
 transaction. In that case, it is important to set the depth of the
 stream reassembling as unlimited (stream.reassembly.depth: 0)
+
+**Note:** According to MODBUS Messaging on TCP/IP Implementation Guide
+V1.0b, the MODBUS slave device addresses on serial line are assigned from 1 to
+247 (decimal). Address 0 is used as broadcast address.
 
 (cf. http://www.modbus.org/docs/Modbus_Messaging_Implementation_Guide_V1_0b.pdf)
 

--- a/src/app-layer-modbus.h
+++ b/src/app-layer-modbus.h
@@ -78,6 +78,9 @@ enum {
 #define MODBUS_TYP_WRITE_MULTIPLE       (MODBUS_TYP_WRITE | MODBUS_TYP_MULTIPLE)
 #define MODBUS_TYP_READ_WRITE_MULTIPLE  (MODBUS_TYP_READ | MODBUS_TYP_WRITE | MODBUS_TYP_MULTIPLE)
 
+/* Modbus Function Code. */
+#define MODBUS_FUNC_NONE                0x00
+
 /* Modbus Transaction Structure, request/response. */
 typedef struct ModbusTransaction_ {
     struct ModbusState_ *modbus;
@@ -86,6 +89,7 @@ typedef struct ModbusTransaction_ {
     uint32_t    logged;         /**< flags indicating which loggers have logged */
     uint16_t    transactionId;
     uint16_t    length;
+    uint8_t     unit_id;
     uint8_t     function;
     uint8_t     category;
     uint8_t     type;

--- a/src/detect-engine-modbus.c
+++ b/src/detect-engine-modbus.c
@@ -218,16 +218,28 @@ int DetectEngineInspectModbus(ThreadVars            *tv,
         SCReturnInt(0);
     }
 
+    if (modbus->unit_id != NULL) {
+        if (DetectEngineInspectModbusValueMatch(modbus->unit_id, tx->unit_id, 0) == 0) {
+            SCReturnInt(0);
+        } else {
+            ret = 1;
+        }
+    }
+
     if (modbus->type == MODBUS_TYP_NONE) {
         if (modbus->category == MODBUS_CAT_NONE) {
-            if (modbus->function == tx->function) {
-                if (modbus->subfunction != NULL) {
-                    SCLogDebug("looking for Modbus server function %d and subfunction %d",
-                                modbus->function, *(modbus->subfunction));
-                    ret = (*(modbus->subfunction) == (tx->subFunction))? 1 : 0;
+            if (modbus->function != MODBUS_FUNC_NONE) {
+                if (modbus->function == tx->function) {
+                    if (modbus->subfunction != NULL) {
+                        SCLogDebug("looking for Modbus server function %d and subfunction %d",
+                                   modbus->function, *(modbus->subfunction));
+                        ret = (*(modbus->subfunction) == (tx->subFunction))? 1 : 0;
+                    } else {
+                        SCLogDebug("looking for Modbus server function %d", modbus->function);
+                        ret = 1;
+                    }
                 } else {
-                    SCLogDebug("looking for Modbus server function %d", modbus->function);
-                    ret = 1;
+                    ret = 0;
                 }
             }
         } else {
@@ -238,16 +250,20 @@ int DetectEngineInspectModbus(ThreadVars            *tv,
         uint8_t access      = modbus->type & MODBUS_TYP_ACCESS_MASK;
         uint8_t function    = modbus->type & MODBUS_TYP_ACCESS_FUNCTION_MASK;
 
-        if ((access & tx->type) && ((function == MODBUS_TYP_NONE) || (function & tx->type))) {
-            if (modbus->address != NULL) {
-                ret = DetectEngineInspectModbusAddress(tx, modbus->address, access);
+        if (access != MODBUS_TYP_NONE) {
+            if ((access & tx->type) && ((function == MODBUS_TYP_NONE) || (function & tx->type))) {
+                if (modbus->address != NULL) {
+                    ret = DetectEngineInspectModbusAddress(tx, modbus->address, access);
 
-                if (ret && (modbus->data != NULL)) {
-                    ret = DetectEngineInspectModbusData(tx, modbus->address->min, modbus->data);
+                    if (ret && (modbus->data != NULL)) {
+                        ret = DetectEngineInspectModbusData(tx, modbus->address->min, modbus->data);
+                    }
+                } else {
+                    SCLogDebug("looking for Modbus access type %d and function type %d", access, function);
+                    ret = 1;
                 }
             } else {
-                SCLogDebug("looking for Modbus access type %d and function type %d", access, function);
-                ret = 1;
+                ret = 0;
             }
         }
     }
@@ -274,7 +290,7 @@ int DetectEngineInspectModbus(ThreadVars            *tv,
 static uint8_t readCoilsReq[] = {/* Transaction ID */    0x00, 0x00,
                                  /* Protocol ID */       0x00, 0x00,
                                  /* Length */            0x00, 0x06,
-                                 /* Unit ID */           0x00,
+                                 /* Unit ID */           0x0a,
                                  /* Function code */     0x01,
                                  /* Starting Address */  0x78, 0x90,
                                  /* Quantity of coils */ 0x00, 0x13 };
@@ -295,7 +311,7 @@ static uint8_t readInputsRegistersReq[] = {/* Transaction ID */          0x00, 0
 static uint8_t readWriteMultipleRegistersReq[] = {/* Transaction ID */          0x12, 0x34,
                                                   /* Protocol ID */             0x00, 0x00,
                                                   /* Length */                  0x00, 0x11,
-                                                  /* Unit ID */                 0x00,
+                                                  /* Unit ID */                 0x0a,
                                                   /* Function code */           0x17,
                                                   /* Read Starting Address */   0x00, 0x03,
                                                   /* Quantity to Read */        0x00, 0x06,
@@ -1341,6 +1357,471 @@ end:
     UTHFreePacket(p);
     return result;
 }
+
+/** \test Test code unit_id. */
+static int DetectEngineInspectModbusTest10(void)
+{
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    DetectEngineThreadCtx *det_ctx = NULL;
+    DetectEngineCtx *de_ctx = NULL;
+    Flow f;
+    Packet *p = NULL;
+    Signature *s = NULL;
+    TcpSession ssn;
+    ThreadVars tv;
+
+    int result = 0;
+
+    memset(&tv, 0, sizeof(ThreadVars));
+    memset(&f, 0, sizeof(Flow));
+    memset(&ssn, 0, sizeof(TcpSession));
+
+    p = UTHBuildPacket(readWriteMultipleRegistersReq,
+                       sizeof(readWriteMultipleRegistersReq),
+                       IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.alproto   = ALPROTO_MODBUS;
+    f.protoctx  = (void *)&ssn;
+    f.proto     = IPPROTO_TCP;
+    f.flags     |= FLOW_IPV4;
+
+    p->flow         = &f;
+    p->flags        |= PKT_HAS_FLOW | PKT_STREAM_EST;
+    p->flowflags    |= FLOW_PKT_TOSERVER | FLOW_PKT_ESTABLISHED;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    /* readWriteMultipleRegistersReq, Write Starting Address = 0x0E, Quantity to Write = 0x03 */
+    /* Unit ID                          = 0x0a (10)         */
+    /* Function code                    = 0x17 (23)         */
+    /* Write access register address 15 = 0x1234 (4660)     */
+    /* Write access register address 16 = 0x5678 (22136)    */
+    /* Write access register address 17 = 0x9ABC (39612)    */
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 10; sid:1;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 12; sid:2;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 5<>15; sid:3;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 5<>9; sid:4;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 11<>15; sid:5;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit >9; sid:6;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit >11; sid:7;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit <11; sid:8;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit <9; sid:9;)");
+
+    if (s == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&tv, (void *)de_ctx, (void *)&det_ctx);
+
+    FLOWLOCK_WRLOCK(&f);
+    int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_MODBUS,
+                                STREAM_TOSERVER,
+                                readWriteMultipleRegistersReq,
+                                sizeof(readWriteMultipleRegistersReq));
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        FLOWLOCK_UNLOCK(&f);
+        goto end;
+    }
+    FLOWLOCK_UNLOCK(&f);
+
+    ModbusState    *modbus_state = f.alstate;
+    if (modbus_state == NULL) {
+        printf("no modbus state: ");
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&tv, de_ctx, det_ctx, p);
+
+    if (!(PacketAlertCheck(p, 1))) {
+        printf("sid 1 didn't match but should have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 2)) {
+        printf("sid 2 did match but should not have: ");
+        goto end;
+    }
+
+    if (!(PacketAlertCheck(p, 3))) {
+        printf("sid 3 didn't match but should have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 4)) {
+        printf("sid 4 did match but should not have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 5)) {
+        printf("sid 5 did match but should not have: ");
+        goto end;
+    }
+
+    if (!(PacketAlertCheck(p, 6))) {
+        printf("sid 6 didn't match but should have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 7)) {
+        printf("sid 7 did match but should not have: ");
+        goto end;
+    }
+
+    if (!(PacketAlertCheck(p, 8))) {
+        printf("sid 8 didn't match but should have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 9)) {
+        printf("sid 9 did match but should not have: ");
+        goto end;
+    }
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (det_ctx != NULL)
+        DetectEngineThreadCtxDeinit(&tv, det_ctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePacket(p);
+    return result;
+}
+
+/** \test Test code unit_id and code function. */
+static int DetectEngineInspectModbusTest11(void)
+{
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    DetectEngineThreadCtx *det_ctx = NULL;
+    DetectEngineCtx *de_ctx = NULL;
+    Flow f;
+    Packet *p = NULL;
+    Signature *s = NULL;
+    TcpSession ssn;
+    ThreadVars tv;
+
+    int result = 0;
+
+    memset(&tv, 0, sizeof(ThreadVars));
+    memset(&f, 0, sizeof(Flow));
+    memset(&ssn, 0, sizeof(TcpSession));
+
+    p = UTHBuildPacket(readWriteMultipleRegistersReq,
+                       sizeof(readWriteMultipleRegistersReq),
+                       IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.alproto   = ALPROTO_MODBUS;
+    f.protoctx  = (void *)&ssn;
+    f.proto     = IPPROTO_TCP;
+    f.flags     |= FLOW_IPV4;
+
+    p->flow         = &f;
+    p->flags        |= PKT_HAS_FLOW | PKT_STREAM_EST;
+    p->flowflags    |= FLOW_PKT_TOSERVER | FLOW_PKT_ESTABLISHED;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    /* readWriteMultipleRegistersReq, Write Starting Address = 0x0E, Quantity to Write = 0x03 */
+    /* Unit ID                          = 0x0a (10)         */
+    /* Function code                    = 0x17 (23)         */
+    /* Write access register address 15 = 0x1234 (4660)     */
+    /* Write access register address 16 = 0x5678 (22136)    */
+    /* Write access register address 17 = 0x9ABC (39612)    */
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 10, function 20; sid:1;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 10, function 23; sid:2;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 11, function 20; sid:3;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 11, function 23; sid:4;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 10, function public; sid:5;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 11, function public; sid:6;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 10, function user; sid:7;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 10, function !user; sid:8;)");
+
+    if (s == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&tv, (void *)de_ctx, (void *)&det_ctx);
+
+    FLOWLOCK_WRLOCK(&f);
+    int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_MODBUS,
+                                STREAM_TOSERVER,
+                                readWriteMultipleRegistersReq,
+                                sizeof(readWriteMultipleRegistersReq));
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        FLOWLOCK_UNLOCK(&f);
+        goto end;
+    }
+    FLOWLOCK_UNLOCK(&f);
+
+    ModbusState    *modbus_state = f.alstate;
+    if (modbus_state == NULL) {
+        printf("no modbus state: ");
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&tv, de_ctx, det_ctx, p);
+
+    if (PacketAlertCheck(p, 1)) {
+        printf("sid 1 did match but should not have: ");
+        goto end;
+    }
+
+    if (!(PacketAlertCheck(p, 2))) {
+        printf("sid 2 didn't match but should have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 3)) {
+        printf("sid 3 did match but should not have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 4)) {
+        printf("sid 4 did match but should not have: ");
+        goto end;
+    }
+
+    if (!(PacketAlertCheck(p, 5))) {
+        printf("sid 5 didn't match but should have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 6)) {
+        printf("sid 6 did match but should not have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 7)) {
+        printf("sid 7 did match but should not have: ");
+        goto end;
+    }
+
+    if (!(PacketAlertCheck(p, 8))) {
+        printf("sid 8 didn't match but should have: ");
+        goto end;
+    }
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (det_ctx != NULL)
+        DetectEngineThreadCtxDeinit(&tv, det_ctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePacket(p);
+    return result;
+}
+
+/** \test unit_id and read access at an address. */
+static int DetectEngineInspectModbusTest12(void)
+{
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    DetectEngineThreadCtx *det_ctx = NULL;
+    DetectEngineCtx *de_ctx = NULL;
+    Flow f;
+    Packet *p = NULL;
+    Signature *s = NULL;
+    TcpSession ssn;
+    ThreadVars tv;
+
+    int result = 0;
+
+    memset(&tv, 0, sizeof(ThreadVars));
+    memset(&f, 0, sizeof(Flow));
+    memset(&ssn, 0, sizeof(TcpSession));
+
+    p = UTHBuildPacket(readCoilsReq, sizeof(readCoilsReq), IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.alproto   = ALPROTO_MODBUS;
+    f.protoctx  = (void *)&ssn;
+    f.proto     = IPPROTO_TCP;
+    f.flags     |= FLOW_IPV4;
+
+    p->flow         = &f;
+    p->flags        |= PKT_HAS_FLOW | PKT_STREAM_EST;
+    p->flowflags    |= FLOW_PKT_TOSERVER | FLOW_PKT_ESTABLISHED;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    /* readCoilsReq, Read coils Starting Address = 0x7890 (30864), Quantity of coils = 0x13 (19) */
+    /* Unit ID              = 0x0a (10) */
+    /* Function code        = 0x01 (01) */
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus address access\"; "
+                              "modbus: unit 10, access read, address 30870;  sid:1;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus address access\"; "
+                              "modbus: unit 10, access read, address 30863;  sid:2;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus address access\"; "
+                              "modbus: unit 11, access read, address 30870;  sid:3;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus address access\"; "
+                              "modbus: unit 11, access read, address 30863;  sid:4;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus address access\"; "
+                              "modbus: unit 10, access write;  sid:5;)");
+
+    if (s == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&tv, (void *)de_ctx, (void *)&det_ctx);
+
+    FLOWLOCK_WRLOCK(&f);
+    int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_MODBUS,
+                                STREAM_TOSERVER, readCoilsReq,
+                                sizeof(readCoilsReq));
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        FLOWLOCK_UNLOCK(&f);
+        goto end;
+    }
+    FLOWLOCK_UNLOCK(&f);
+
+    ModbusState    *modbus_state = f.alstate;
+    if (modbus_state == NULL) {
+        printf("no modbus state: ");
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&tv, de_ctx, det_ctx, p);
+
+    if (!(PacketAlertCheck(p, 1))) {
+        printf("sid 1 didn't match but should have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 2)) {
+        printf("sid 2 did match but should not have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 3)) {
+        printf("sid 3 did match but should not have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 4)) {
+        printf("sid 4 did match but should not have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 5)) {
+        printf("sid 5 did match but should not have: ");
+        goto end;
+    }
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (det_ctx != NULL)
+        DetectEngineThreadCtxDeinit(&tv, det_ctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePacket(p);
+    return result;
+}
 #endif /* UNITTESTS */
 
 void DetectEngineInspectModbusRegisterTests(void)
@@ -1364,6 +1845,12 @@ void DetectEngineInspectModbusRegisterTests(void)
                    DetectEngineInspectModbusTest08);
     UtRegisterTest("DetectEngineInspectModbusTest09 - Write access at an address a range of value",
                    DetectEngineInspectModbusTest09);
+    UtRegisterTest("DetectEngineInspectModbusTest10 - Code unit_id",
+                   DetectEngineInspectModbusTest10);
+    UtRegisterTest("DetectEngineInspectModbusTest11 - Code unit_id and code function",
+                   DetectEngineInspectModbusTest11);
+    UtRegisterTest("DetectEngineInspectModbusTest12 - Code unit_id and acces function",
+                   DetectEngineInspectModbusTest12);
 #endif /* UNITTESTS */
     return;
 }

--- a/src/detect-modbus.h
+++ b/src/detect-modbus.h
@@ -54,6 +54,7 @@ typedef struct DetectModbus_ {
     uint8_t             function;       /** < Modbus function code to match */
     uint16_t            *subfunction;   /** < Modbus subfunction to match */
     uint8_t             type;           /** < Modbus access type to match */
+    DetectModbusValue   *unit_id;       /** < Modbus unit id to match */
     DetectModbusValue   *address;       /** < Modbus address to match */
     DetectModbusValue   *data;          /** < Modbus data to match */
 } DetectModbus;


### PR DESCRIPTION
**When destination IP address does not suffice to uniquely identify the Modbus/TCP device.**

Some Modbus/TCP devices act as gateways to other Modbus/TCP devices that are behind this gateways.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [issue #1579] (https://redmine.openinfosecfoundation.org/issues/1579)

Describe changes:
- Add new Modbus keyword : **unit**
- New Modbus keyword can be used alone or with the one of the others Modbus keywords "function" and "access"

cc @jasonish 
