### PR TITLE
Better lua output setup error handling (#1503) v1

### DIFF
--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -863,6 +863,18 @@ static OutputInitResult OutputLuaLogInit(ConfNode *conf)
 error:
     if (output_ctx->DeInit)
         output_ctx->DeInit(output_ctx);
+
+    int failure_fatal = 0;
+    if (ConfGetBool("engine.init-failure-fatal", &failure_fatal) != 1) {
+        SCLogDebug("ConfGetBool could not load the value.");
+    }
+    if (failure_fatal) {
+        SCLogError(SC_ERR_LUA_ERROR,
+                   "Error during setup of lua output. Details should be "
+                   "described in previous error messages. Shutting down...");
+        exit(EXIT_FAILURE);
+    }
+
     return result;
 }
 

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -24,7 +24,6 @@
 
 #include "suricata-common.h"
 #include "debug.h"
-#include "detect.h"
 #include "pkt-var.h"
 #include "conf.h"
 


### PR DESCRIPTION
## Checkboxes

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

## Redmine Ticket
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: 
https://redmine.openinfosecfoundation.org/issues/1503

## Description of Changes:

If suricata was started with --init-errors-fatal and an error occured
during setup of lua output (like if lua scripts configured in the conf file
don't exist or are not readable) suricata continued, which did not reflect
"init errors fatal" very well.

This fix makes the suricata initialization exit and print an error message
in such cases.

It also removes an unnecesarry header inclusion.

For details see:
https://redmine.openinfosecfoundation.org/issues/1503

## PRScript
[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR richi235-pcap: https://buildbot.openinfosecfoundation.org/builders/richi235-pcap/builds/5
- PR richi235: https://buildbot.openinfosecfoundation.org/builders/richi235/builds/5