### PR TITLE
Rust: add 'debug' feature

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -12,6 +12,7 @@ debug = true
 lua = []
 experimental = ["ntp-parser"]
 strict = []
+debug = []
 
 [dependencies]
 nom = "~3.2.1"

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -29,6 +29,10 @@ if HAVE_RUST_EXTERNAL
 RUST_FEATURES +=	experimental
 endif
 
+if DEBUG
+RUST_FEATURES +=	debug
+endif
+
 all-local:
 if HAVE_PYTHON
 	cd $(top_srcdir)/rust && \

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -114,11 +114,22 @@ macro_rules!SCLogConfig {
     }
 }
 
+// Debug mode: call C SCLogDebug
+#[cfg(feature = "debug")]
 #[macro_export]
 macro_rules!SCLogDebug {
     ($($arg:tt)*) => {
         do_log!(Level::Debug, file!(), line!(), function!(), 0, $($arg)*);
     }
+}
+
+// Release mode: ignore arguments
+// Use a reference to avoid moving values.
+#[cfg(not(feature = "debug"))]
+#[macro_export]
+macro_rules!SCLogDebug {
+    ($last:expr) => { let _ = &$last; let _ = Level::Debug; };
+    ($one:expr, $($arg:tt)*) => { let _ = &$one; SCLogDebug!($($arg)*); };
 }
 
 #[no_mangle]


### PR DESCRIPTION
The 'debug' feature is enabled if suricata was configured with the
--enabled-debug' flag.
If enabled, the SCLogDebug format and calls the logging function as
usual. Otherwise, this macro is a no-op (similarly to the C code).

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
not applicable

Describe changes:
- In the C code, `SCLogDebug` is a no-op when '--enable-debug' is not given to 'configure'. Replicate this behavior by adding a 'debug' feature to the rust code, set by the 'configure' flag as well
- Unfortunately, just using a no-op results in many errors in the code, because of the compiler strictness: some variables becomes unused, some `use log::*;` becomes unused etc.
- Two possible solutions: change the code in many places and result in a huge patch (forcing variables to start with a `_`), or use a trick to make the compiler think variables are used, but generate no code
- This patch implements # 2, so has a minimal impact on the code
- The trick is to take the arguments of the `SCLogDebug!` macro in debug mode, and recursively generate no-op code. For ex:
```rust
SCLogDebug!("log message: {}", var);
```
will get expanded to:
```rust
let _ = &"log message: {}";
let _ = &var;
```
The variables being unused, no code is generated.

Note that using the `&` to take a reference is necessary: it avoids moving values and resulting in errors. For ex, the following code would fail:
```rust
let _ = var; // <- value moved here
// ...
f(var); // <- no cannot be used here
```

As a result, the code gets smaller in release mode, and faster (had no time to have exact numbers, but this spares a call to `get_log_level()`, the comparison, the formatting of arguments and the call to the C `SCLogMessage` function).
Tested by disassembling the generated code.