### PR TITLE
Support Modbus Unit Identifier v4

### DIFF
--- a/doc/userguide/rules/modbus-keyword.rst
+++ b/doc/userguide/rules/modbus-keyword.rst
@@ -4,10 +4,11 @@ Modbus Keyword
 The modbus keyword can be used for matching on various properties of
 Modbus requests.
 
-There are two ways of using this keyword:
+There are three ways of using this keyword:
 
 * matching on functions properties with the setting "function";
-* matching on directly on data access with the setting "access".
+* matching on directly on data access with the setting "access";
+* matching on unit identifier with the setting "unit" only or with the previous setting "function" or "access".
 
 With the setting **function**, you can match on:
 
@@ -72,6 +73,43 @@ Examples::
   modbus: access read discretes, address <100            # Read access at address smaller than 100 of Discretes Input table
   modbus: access write holding, address 500, value >200  # Write value greather than 200 at address 500 of Holding Registers table
 
+With the setting **unit**, you can match on:
+
+* a MODBUS slave address of a remote device connected on the sub-network behind a bridge or a gateway. The destination IP address identifies the bridge itself and the bridge uses the MODBUS unit identifier to forward the request to the right slave device. 
+
+Syntax::
+
+  modbus: unit <value>
+  modbus: unit <value>, function <value>
+  modbus: unit <value>, function <value>, subfunction <value>
+  modbus: unit <value>, function [!] <assigned | unassigned | public | user | reserved | all>
+  modbus: unit <value>, access <read | write>
+  modbus: unit <value>, access read <discretes | coils | input | holding>
+  modbus: unit <value>, access read <discretes | coils | input | holding>, address <value>
+  modbus: unit <value>, access write < coils | holding>
+  modbus: unit <value>, access write < coils | holding>, address <value>
+  modbus: unit <value>, access write < coils | holding>, address <value>, value <value>
+
+With _<value>_ setting matches on the address or value as it is being
+accessed or written as follows::
+
+  unit 10     # exactly unit identifier 10
+  unit 10<>20 # greater than unit identifier 10 and smaller than unit identifier 20
+  unit >10    # greater than unit identifier 10
+  unit <10    # smaller than unit identifier 10
+
+Examples::
+
+  modbus: unit 10                                                       # Unit identifier 10
+  modbus: unit 10, function 21                                          # Unit identifier 10 and write File record function
+  modbus: unit 10, function 4, subfunction 4                            # Unit identifier 10 and force Listen Only Mode (Diagnostics) function
+  modbus: unit 10, function assigned                                    # Unit identifier 10 and assigned function
+  modbus: unit 10, function !reserved                                   # Unit identifier 10 and every function but reserved function
+  modbus: unit 10, access read                                          # Unit identifier 10 and Read access
+  modbus: unit 10, access write coils                                   # Unit identifier 10 and Write access to Coils table
+  modbus: unit >10, access read discretes, address <100                 # Greater than unit identifier 10 and Read access at address smaller than 100 of Discretes Input table
+  modbus: unit 10<>20, access write holding, address 500, value >200    # Greater than unit identifier 10 and smaller than unit identifier 20 and Write value greather than 200 at address 500 of Holding Registers table
+
 (cf. http://www.modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf)
 
 **Note:** Address of read and write are starting at 1. So if your system
@@ -82,6 +120,10 @@ V1.0b, it is recommended to keep the TCP connection opened with a
 remote device and not to open and close it for each MODBUS/TCP
 transaction. In that case, it is important to set the depth of the
 stream reassembling as unlimited (stream.reassembly.depth: 0)
+
+**Note:** According to MODBUS Messaging on TCP/IP Implementation Guide
+V1.0b, the MODBUS slave device addresses on serial line are assigned from 1 to
+247 (decimal). Address 0 is used as broadcast address.
 
 (cf. http://www.modbus.org/docs/Modbus_Messaging_Implementation_Guide_V1_0b.pdf)
 

--- a/src/app-layer-modbus.h
+++ b/src/app-layer-modbus.h
@@ -78,6 +78,9 @@ enum {
 #define MODBUS_TYP_WRITE_MULTIPLE       (MODBUS_TYP_WRITE | MODBUS_TYP_MULTIPLE)
 #define MODBUS_TYP_READ_WRITE_MULTIPLE  (MODBUS_TYP_READ | MODBUS_TYP_WRITE | MODBUS_TYP_MULTIPLE)
 
+/* Modbus Function Code. */
+#define MODBUS_FUNC_NONE                0x00
+
 /* Modbus Transaction Structure, request/response. */
 typedef struct ModbusTransaction_ {
     struct ModbusState_ *modbus;
@@ -86,6 +89,7 @@ typedef struct ModbusTransaction_ {
     uint32_t    logged;         /**< flags indicating which loggers have logged */
     uint16_t    transactionId;
     uint16_t    length;
+    uint8_t     unit_id;
     uint8_t     function;
     uint8_t     category;
     uint8_t     type;

--- a/src/detect-engine-modbus.c
+++ b/src/detect-engine-modbus.c
@@ -218,16 +218,28 @@ int DetectEngineInspectModbus(ThreadVars            *tv,
         SCReturnInt(0);
     }
 
+    if (modbus->unit_id != NULL) {
+        if (DetectEngineInspectModbusValueMatch(modbus->unit_id, tx->unit_id, 0) == 0) {
+            SCReturnInt(0);
+        } else {
+            ret = 1;
+        }
+    }
+
     if (modbus->type == MODBUS_TYP_NONE) {
         if (modbus->category == MODBUS_CAT_NONE) {
-            if (modbus->function == tx->function) {
-                if (modbus->subfunction != NULL) {
-                    SCLogDebug("looking for Modbus server function %d and subfunction %d",
-                                modbus->function, *(modbus->subfunction));
-                    ret = (*(modbus->subfunction) == (tx->subFunction))? 1 : 0;
+            if (modbus->function != MODBUS_FUNC_NONE) {
+                if (modbus->function == tx->function) {
+                    if (modbus->subfunction != NULL) {
+                        SCLogDebug("looking for Modbus server function %d and subfunction %d",
+                                   modbus->function, *(modbus->subfunction));
+                        ret = (*(modbus->subfunction) == (tx->subFunction))? 1 : 0;
+                    } else {
+                        SCLogDebug("looking for Modbus server function %d", modbus->function);
+                        ret = 1;
+                    }
                 } else {
-                    SCLogDebug("looking for Modbus server function %d", modbus->function);
-                    ret = 1;
+                    ret = 0;
                 }
             }
         } else {
@@ -238,16 +250,20 @@ int DetectEngineInspectModbus(ThreadVars            *tv,
         uint8_t access      = modbus->type & MODBUS_TYP_ACCESS_MASK;
         uint8_t function    = modbus->type & MODBUS_TYP_ACCESS_FUNCTION_MASK;
 
-        if ((access & tx->type) && ((function == MODBUS_TYP_NONE) || (function & tx->type))) {
-            if (modbus->address != NULL) {
-                ret = DetectEngineInspectModbusAddress(tx, modbus->address, access);
+        if (access != MODBUS_TYP_NONE) {
+            if ((access & tx->type) && ((function == MODBUS_TYP_NONE) || (function & tx->type))) {
+                if (modbus->address != NULL) {
+                    ret = DetectEngineInspectModbusAddress(tx, modbus->address, access);
 
-                if (ret && (modbus->data != NULL)) {
-                    ret = DetectEngineInspectModbusData(tx, modbus->address->min, modbus->data);
+                    if (ret && (modbus->data != NULL)) {
+                        ret = DetectEngineInspectModbusData(tx, modbus->address->min, modbus->data);
+                    }
+                } else {
+                    SCLogDebug("looking for Modbus access type %d and function type %d", access, function);
+                    ret = 1;
                 }
             } else {
-                SCLogDebug("looking for Modbus access type %d and function type %d", access, function);
-                ret = 1;
+                ret = 0;
             }
         }
     }
@@ -274,7 +290,7 @@ int DetectEngineInspectModbus(ThreadVars            *tv,
 static uint8_t readCoilsReq[] = {/* Transaction ID */    0x00, 0x00,
                                  /* Protocol ID */       0x00, 0x00,
                                  /* Length */            0x00, 0x06,
-                                 /* Unit ID */           0x00,
+                                 /* Unit ID */           0x0a,
                                  /* Function code */     0x01,
                                  /* Starting Address */  0x78, 0x90,
                                  /* Quantity of coils */ 0x00, 0x13 };
@@ -295,7 +311,7 @@ static uint8_t readInputsRegistersReq[] = {/* Transaction ID */          0x00, 0
 static uint8_t readWriteMultipleRegistersReq[] = {/* Transaction ID */          0x12, 0x34,
                                                   /* Protocol ID */             0x00, 0x00,
                                                   /* Length */                  0x00, 0x11,
-                                                  /* Unit ID */                 0x00,
+                                                  /* Unit ID */                 0x0a,
                                                   /* Function code */           0x17,
                                                   /* Read Starting Address */   0x00, 0x03,
                                                   /* Quantity to Read */        0x00, 0x06,
@@ -1341,6 +1357,471 @@ end:
     UTHFreePacket(p);
     return result;
 }
+
+/** \test Test code unit_id. */
+static int DetectEngineInspectModbusTest10(void)
+{
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    DetectEngineThreadCtx *det_ctx = NULL;
+    DetectEngineCtx *de_ctx = NULL;
+    Flow f;
+    Packet *p = NULL;
+    Signature *s = NULL;
+    TcpSession ssn;
+    ThreadVars tv;
+
+    int result = 0;
+
+    memset(&tv, 0, sizeof(ThreadVars));
+    memset(&f, 0, sizeof(Flow));
+    memset(&ssn, 0, sizeof(TcpSession));
+
+    p = UTHBuildPacket(readWriteMultipleRegistersReq,
+                       sizeof(readWriteMultipleRegistersReq),
+                       IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.alproto   = ALPROTO_MODBUS;
+    f.protoctx  = (void *)&ssn;
+    f.proto     = IPPROTO_TCP;
+    f.flags     |= FLOW_IPV4;
+
+    p->flow         = &f;
+    p->flags        |= PKT_HAS_FLOW | PKT_STREAM_EST;
+    p->flowflags    |= FLOW_PKT_TOSERVER | FLOW_PKT_ESTABLISHED;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    /* readWriteMultipleRegistersReq, Write Starting Address = 0x0E, Quantity to Write = 0x03 */
+    /* Unit ID                          = 0x0a (10)         */
+    /* Function code                    = 0x17 (23)         */
+    /* Write access register address 15 = 0x1234 (4660)     */
+    /* Write access register address 16 = 0x5678 (22136)    */
+    /* Write access register address 17 = 0x9ABC (39612)    */
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 10; sid:1;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 12; sid:2;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 5<>15; sid:3;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 5<>9; sid:4;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 11<>15; sid:5;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit >9; sid:6;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit >11; sid:7;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit <11; sid:8;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit <9; sid:9;)");
+
+    if (s == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&tv, (void *)de_ctx, (void *)&det_ctx);
+
+    FLOWLOCK_WRLOCK(&f);
+    int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_MODBUS,
+                                STREAM_TOSERVER,
+                                readWriteMultipleRegistersReq,
+                                sizeof(readWriteMultipleRegistersReq));
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        FLOWLOCK_UNLOCK(&f);
+        goto end;
+    }
+    FLOWLOCK_UNLOCK(&f);
+
+    ModbusState    *modbus_state = f.alstate;
+    if (modbus_state == NULL) {
+        printf("no modbus state: ");
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&tv, de_ctx, det_ctx, p);
+
+    if (!(PacketAlertCheck(p, 1))) {
+        printf("sid 1 didn't match but should have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 2)) {
+        printf("sid 2 did match but should not have: ");
+        goto end;
+    }
+
+    if (!(PacketAlertCheck(p, 3))) {
+        printf("sid 3 didn't match but should have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 4)) {
+        printf("sid 4 did match but should not have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 5)) {
+        printf("sid 5 did match but should not have: ");
+        goto end;
+    }
+
+    if (!(PacketAlertCheck(p, 6))) {
+        printf("sid 6 didn't match but should have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 7)) {
+        printf("sid 7 did match but should not have: ");
+        goto end;
+    }
+
+    if (!(PacketAlertCheck(p, 8))) {
+        printf("sid 8 didn't match but should have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 9)) {
+        printf("sid 9 did match but should not have: ");
+        goto end;
+    }
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (det_ctx != NULL)
+        DetectEngineThreadCtxDeinit(&tv, det_ctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePacket(p);
+    return result;
+}
+
+/** \test Test code unit_id and code function. */
+static int DetectEngineInspectModbusTest11(void)
+{
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    DetectEngineThreadCtx *det_ctx = NULL;
+    DetectEngineCtx *de_ctx = NULL;
+    Flow f;
+    Packet *p = NULL;
+    Signature *s = NULL;
+    TcpSession ssn;
+    ThreadVars tv;
+
+    int result = 0;
+
+    memset(&tv, 0, sizeof(ThreadVars));
+    memset(&f, 0, sizeof(Flow));
+    memset(&ssn, 0, sizeof(TcpSession));
+
+    p = UTHBuildPacket(readWriteMultipleRegistersReq,
+                       sizeof(readWriteMultipleRegistersReq),
+                       IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.alproto   = ALPROTO_MODBUS;
+    f.protoctx  = (void *)&ssn;
+    f.proto     = IPPROTO_TCP;
+    f.flags     |= FLOW_IPV4;
+
+    p->flow         = &f;
+    p->flags        |= PKT_HAS_FLOW | PKT_STREAM_EST;
+    p->flowflags    |= FLOW_PKT_TOSERVER | FLOW_PKT_ESTABLISHED;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    /* readWriteMultipleRegistersReq, Write Starting Address = 0x0E, Quantity to Write = 0x03 */
+    /* Unit ID                          = 0x0a (10)         */
+    /* Function code                    = 0x17 (23)         */
+    /* Write access register address 15 = 0x1234 (4660)     */
+    /* Write access register address 16 = 0x5678 (22136)    */
+    /* Write access register address 17 = 0x9ABC (39612)    */
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 10, function 20; sid:1;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 10, function 23; sid:2;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 11, function 20; sid:3;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 11, function 23; sid:4;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 10, function public; sid:5;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 11, function public; sid:6;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 10, function user; sid:7;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus code unit_id\"; "
+                              "modbus: unit 10, function !user; sid:8;)");
+
+    if (s == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&tv, (void *)de_ctx, (void *)&det_ctx);
+
+    FLOWLOCK_WRLOCK(&f);
+    int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_MODBUS,
+                                STREAM_TOSERVER,
+                                readWriteMultipleRegistersReq,
+                                sizeof(readWriteMultipleRegistersReq));
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        FLOWLOCK_UNLOCK(&f);
+        goto end;
+    }
+    FLOWLOCK_UNLOCK(&f);
+
+    ModbusState    *modbus_state = f.alstate;
+    if (modbus_state == NULL) {
+        printf("no modbus state: ");
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&tv, de_ctx, det_ctx, p);
+
+    if (PacketAlertCheck(p, 1)) {
+        printf("sid 1 did match but should not have: ");
+        goto end;
+    }
+
+    if (!(PacketAlertCheck(p, 2))) {
+        printf("sid 2 didn't match but should have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 3)) {
+        printf("sid 3 did match but should not have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 4)) {
+        printf("sid 4 did match but should not have: ");
+        goto end;
+    }
+
+    if (!(PacketAlertCheck(p, 5))) {
+        printf("sid 5 didn't match but should have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 6)) {
+        printf("sid 6 did match but should not have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 7)) {
+        printf("sid 7 did match but should not have: ");
+        goto end;
+    }
+
+    if (!(PacketAlertCheck(p, 8))) {
+        printf("sid 8 didn't match but should have: ");
+        goto end;
+    }
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (det_ctx != NULL)
+        DetectEngineThreadCtxDeinit(&tv, det_ctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePacket(p);
+    return result;
+}
+
+/** \test unit_id and read access at an address. */
+static int DetectEngineInspectModbusTest12(void)
+{
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    DetectEngineThreadCtx *det_ctx = NULL;
+    DetectEngineCtx *de_ctx = NULL;
+    Flow f;
+    Packet *p = NULL;
+    Signature *s = NULL;
+    TcpSession ssn;
+    ThreadVars tv;
+
+    int result = 0;
+
+    memset(&tv, 0, sizeof(ThreadVars));
+    memset(&f, 0, sizeof(Flow));
+    memset(&ssn, 0, sizeof(TcpSession));
+
+    p = UTHBuildPacket(readCoilsReq, sizeof(readCoilsReq), IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.alproto   = ALPROTO_MODBUS;
+    f.protoctx  = (void *)&ssn;
+    f.proto     = IPPROTO_TCP;
+    f.flags     |= FLOW_IPV4;
+
+    p->flow         = &f;
+    p->flags        |= PKT_HAS_FLOW | PKT_STREAM_EST;
+    p->flowflags    |= FLOW_PKT_TOSERVER | FLOW_PKT_ESTABLISHED;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    /* readCoilsReq, Read coils Starting Address = 0x7890 (30864), Quantity of coils = 0x13 (19) */
+    /* Unit ID              = 0x0a (10) */
+    /* Function code        = 0x01 (01) */
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus address access\"; "
+                              "modbus: unit 10, access read, address 30870;  sid:1;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus address access\"; "
+                              "modbus: unit 10, access read, address 30863;  sid:2;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus address access\"; "
+                              "modbus: unit 11, access read, address 30870;  sid:3;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus address access\"; "
+                              "modbus: unit 11, access read, address 30863;  sid:4;)");
+
+    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
+                              "(msg:\"Testing modbus address access\"; "
+                              "modbus: unit 10, access write;  sid:5;)");
+
+    if (s == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&tv, (void *)de_ctx, (void *)&det_ctx);
+
+    FLOWLOCK_WRLOCK(&f);
+    int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_MODBUS,
+                                STREAM_TOSERVER, readCoilsReq,
+                                sizeof(readCoilsReq));
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        FLOWLOCK_UNLOCK(&f);
+        goto end;
+    }
+    FLOWLOCK_UNLOCK(&f);
+
+    ModbusState    *modbus_state = f.alstate;
+    if (modbus_state == NULL) {
+        printf("no modbus state: ");
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&tv, de_ctx, det_ctx, p);
+
+    if (!(PacketAlertCheck(p, 1))) {
+        printf("sid 1 didn't match but should have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 2)) {
+        printf("sid 2 did match but should not have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 3)) {
+        printf("sid 3 did match but should not have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 4)) {
+        printf("sid 4 did match but should not have: ");
+        goto end;
+    }
+
+    if (PacketAlertCheck(p, 5)) {
+        printf("sid 5 did match but should not have: ");
+        goto end;
+    }
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (det_ctx != NULL)
+        DetectEngineThreadCtxDeinit(&tv, det_ctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePacket(p);
+    return result;
+}
 #endif /* UNITTESTS */
 
 void DetectEngineInspectModbusRegisterTests(void)
@@ -1364,6 +1845,12 @@ void DetectEngineInspectModbusRegisterTests(void)
                    DetectEngineInspectModbusTest08);
     UtRegisterTest("DetectEngineInspectModbusTest09 - Write access at an address a range of value",
                    DetectEngineInspectModbusTest09);
+    UtRegisterTest("DetectEngineInspectModbusTest10 - Code unit_id",
+                   DetectEngineInspectModbusTest10);
+    UtRegisterTest("DetectEngineInspectModbusTest11 - Code unit_id and code function",
+                   DetectEngineInspectModbusTest11);
+    UtRegisterTest("DetectEngineInspectModbusTest12 - Code unit_id and acces function",
+                   DetectEngineInspectModbusTest12);
 #endif /* UNITTESTS */
     return;
 }

--- a/src/detect-modbus.c
+++ b/src/detect-modbus.c
@@ -57,6 +57,13 @@
 #include "stream-tcp.h"
 
 /**
+ * \brief Regex for parsing the Modbus unit id string
+ */
+#define PARSE_REGEX_UNIT_ID "^\\s*\"?\\s*unit\\s+([<>]?\\d+)(<>\\d+)?(,\\s*(.*))?\\s*\"?\\s*$"
+static pcre         *unit_id_parse_regex;
+static pcre_extra   *unit_id_parse_regex_study;
+
+/**
  * \brief Regex for parsing the Modbus function string
  */
 #define PARSE_REGEX_FUNCTION "^\\s*\"?\\s*function\\s*(!?[A-z0-9]+)(,\\s*subfunction\\s+(\\d+))?\\s*\"?\\s*$"
@@ -89,6 +96,9 @@ static void DetectModbusFree(void *ptr) {
     if(modbus) {
         if (modbus->subfunction)
             SCFree(modbus->subfunction);
+
+        if (modbus->unit_id)
+            SCFree(modbus->unit_id);
 
         if (modbus->address)
             SCFree(modbus->address);
@@ -302,6 +312,14 @@ static DetectModbus *DetectModbusFunctionParse(const char *str)
 
     if (isdigit((unsigned char)ptr[0])) {
         modbus->function = atoi((const char*) ptr);
+        /* Function code 0 is managed by decoder_event INVALID_FUNCTION_CODE */
+        if (modbus->function == MODBUS_FUNC_NONE) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE,
+                    "Invalid argument \"%d\" supplied to modbus function keyword.",
+                    modbus->function);
+            goto error;
+        }
+
         SCLogDebug("will look for modbus function %d", modbus->function);
 
         if (ret > 2) {
@@ -356,6 +374,96 @@ error:
 
 /** \internal
  *
+ * \brief This function is used to parse Modbus parameters in unit id mode
+ *
+ * \param str Pointer to the user provided id option
+ *
+ * \retval Pointer to DetectModbusUnit on success or NULL on failure
+ */
+static DetectModbus *DetectModbusUnitIdParse(const char *str)
+{
+    SCEnter();
+    DetectModbus *modbus = NULL;
+
+    char    arg[MAX_SUBSTRINGS];
+    int     ov[MAX_SUBSTRINGS], ret, res;
+
+    ret = pcre_exec(unit_id_parse_regex, unit_id_parse_regex_study, str, strlen(str), 0, 0, ov, MAX_SUBSTRINGS);
+
+    if (ret < 1)
+        goto error;
+
+    res = pcre_copy_substring(str, ov, MAX_SUBSTRINGS, 1, arg, MAX_SUBSTRINGS);
+    if (res < 0) {
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        goto error;
+    }
+
+    if (ret > 3) {
+        /* We have more Modbus option */
+        const char *str_ptr;
+
+        res = pcre_get_substring((char *)str, ov, MAX_SUBSTRINGS, 4, &str_ptr);
+        if (res < 0) {
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+            goto error;
+        }
+
+        if ((modbus = DetectModbusFunctionParse(str_ptr)) == NULL) {
+            if ((modbus = DetectModbusAccessParse(str_ptr)) == NULL) {
+                SCLogError(SC_ERR_PCRE_MATCH, "invalid modbus option");
+                goto error;
+            }
+        }
+    } else {
+        /* We have only unit id Modbus option */
+        modbus = (DetectModbus *) SCCalloc(1, sizeof(DetectModbus));
+        if (unlikely(modbus == NULL))
+            goto error;
+    }
+
+    /* We have a correct unit id option */
+    modbus->unit_id = (DetectModbusValue *) SCCalloc(1, sizeof(DetectModbusValue));
+    if (unlikely(modbus->unit_id == NULL))
+        goto error;
+
+    if (arg[0] == '>') {
+        modbus->unit_id->min   = atoi((const char*) (arg+1));
+        modbus->unit_id->mode  = DETECT_MODBUS_GT;
+    } else if (arg[0] == '<') {
+        modbus->unit_id->min   = atoi((const char*) (arg+1));
+        modbus->unit_id->mode  = DETECT_MODBUS_LT;
+    } else {
+        modbus->unit_id->min   = atoi((const char*) arg);
+    }
+    SCLogDebug("and min/equal unit id %d", modbus->unit_id->min);
+
+    if (ret > 2) {
+        res = pcre_copy_substring(str, ov, MAX_SUBSTRINGS, 2, arg, MAX_SUBSTRINGS);
+        if (res < 0) {
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+            goto error;
+        }
+
+        if (*arg != '\0') {
+            modbus->unit_id->max   = atoi((const char*) (arg+2));
+            modbus->unit_id->mode  = DETECT_MODBUS_RA;
+            SCLogDebug("and max unit id %d", modbus->unit_id->max);
+        }
+    }
+
+    SCReturnPtr(modbus, "DetectModbusUnitId");
+
+error:
+    if (modbus != NULL)
+        DetectModbusFree(modbus);
+
+    SCReturnPtr(NULL, "DetectModbus");
+}
+
+
+/** \internal
+ *
  * \brief this function is used to add the parsed "id" option into the current signature
  *
  * \param de_ctx    Pointer to the Detection Engine Context
@@ -373,10 +481,12 @@ static int DetectModbusSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
     if (DetectSignatureSetAppProto(s, ALPROTO_MODBUS) != 0)
         return -1;
 
-    if ((modbus = DetectModbusFunctionParse(str)) == NULL) {
-        if ((modbus = DetectModbusAccessParse(str)) == NULL) {
-            SCLogError(SC_ERR_PCRE_MATCH, "invalid modbus option");
-            goto error;
+    if ((modbus = DetectModbusUnitIdParse(str)) == NULL) {
+        if ((modbus = DetectModbusFunctionParse(str)) == NULL) {
+            if ((modbus = DetectModbusAccessParse(str)) == NULL) {
+                SCLogError(SC_ERR_PCRE_MATCH, "invalid modbus option");
+                goto error;
+            }
         }
     }
 
@@ -412,6 +522,8 @@ void DetectModbusRegister(void)
     sigmatch_table[DETECT_AL_MODBUS].Free          = DetectModbusFree;
     sigmatch_table[DETECT_AL_MODBUS].RegisterTests = DetectModbusRegisterTests;
 
+    DetectSetupParseRegexes(PARSE_REGEX_UNIT_ID,
+            &unit_id_parse_regex, &unit_id_parse_regex_study);
     DetectSetupParseRegexes(PARSE_REGEX_FUNCTION,
             &function_parse_regex, &function_parse_regex_study);
     DetectSetupParseRegexes(PARSE_REGEX_ACCESS,
@@ -852,6 +964,207 @@ static int DetectModbusTest09(void)
 
     return result;
 }
+
+/** \test Signature containing a unit_id. */
+static int DetectModbusTest10(void)
+{
+    DetectEngineCtx 	*de_ctx = NULL;
+    DetectModbus    	*modbus = NULL;
+    DetectModbusMode    mode = DETECT_MODBUS_EQ;
+
+    int result = 0;
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
+                                       "(msg:\"Testing modbus unit_id\"; "
+                                       "modbus: unit 10;  sid:1;)");
+
+    if (de_ctx->sig_list == NULL)
+        goto end;
+
+    if ((de_ctx->sig_list->sm_lists_tail[g_modbus_buffer_id] == NULL) ||
+        (de_ctx->sig_list->sm_lists_tail[g_modbus_buffer_id]->ctx == NULL)) {
+        printf("de_ctx->pmatch_tail == NULL && de_ctx->pmatch_tail->ctx == NULL: ");
+        goto end;
+    }
+
+    modbus = (DetectModbus *) de_ctx->sig_list->sm_lists_tail[g_modbus_buffer_id]->ctx;
+
+    if (((*modbus->unit_id).min != 10) 		||
+		((*modbus->unit_id).mode != mode)	){
+        printf("expected mode %u, got %u: ", mode, (*modbus->unit_id).mode);
+        printf("expected unit_id %d, got %" PRIu16 ": ", 10, (*modbus->unit_id).min);
+        goto end;
+    }
+
+    result = 1;
+
+ end:
+    SigGroupCleanup(de_ctx);
+    SigCleanSignatures(de_ctx);
+    DetectEngineCtxFree(de_ctx);
+
+    return result;
+}
+
+/** \test Signature containing a unit_id, a function and a subfunction. */
+static int DetectModbusTest11(void)
+{
+    DetectEngineCtx 	*de_ctx = NULL;
+    DetectModbus    	*modbus = NULL;
+    DetectModbusMode    mode = DETECT_MODBUS_EQ;
+
+    int result = 0;
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
+                                       "(msg:\"Testing modbus function and subfunction\"; "
+                                       "modbus: unit 10, function 8, subfunction 4;  sid:1;)");
+
+    if (de_ctx->sig_list == NULL)
+        goto end;
+
+    if ((de_ctx->sig_list->sm_lists_tail[g_modbus_buffer_id] == NULL) ||
+        (de_ctx->sig_list->sm_lists_tail[g_modbus_buffer_id]->ctx == NULL)) {
+        printf("de_ctx->pmatch_tail == NULL && de_ctx->pmatch_tail->ctx == NULL: ");
+        goto end;
+    }
+
+    modbus = (DetectModbus *) de_ctx->sig_list->sm_lists_tail[g_modbus_buffer_id]->ctx;
+
+    if (((*modbus->unit_id).min != 10) 		||
+        ((*modbus->unit_id).mode != mode)	||
+		(modbus->function != 8) 			||
+		(*modbus->subfunction != 4)			) {
+        printf("expected mode %u, got %u: ", mode, (*modbus->unit_id).mode);
+        printf("expected unit_id %d, got %" PRIu16 ": ", 10, (*modbus->unit_id).min);
+        printf("expected function %d, got %" PRIu8 ": ", 1, modbus->function);
+        printf("expected subfunction %d, got %" PRIu16 ": ", 4, *modbus->subfunction);
+        goto end;
+    }
+
+    result = 1;
+
+ end:
+    SigGroupCleanup(de_ctx);
+    SigCleanSignatures(de_ctx);
+    DetectEngineCtxFree(de_ctx);
+
+    return result;
+}
+
+/** \test Signature containing an unit_id and a read access at an address. */
+static int DetectModbusTest12(void)
+{
+    DetectEngineCtx     *de_ctx = NULL;
+    DetectModbus        *modbus = NULL;
+    DetectModbusMode    mode = DETECT_MODBUS_EQ;
+
+    uint8_t type = MODBUS_TYP_READ;
+    int result = 0;
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
+                                       "(msg:\"Testing modbus.access\"; "
+                                       "modbus: unit 10, access read, address 1000;  sid:1;)");
+
+    if (de_ctx->sig_list == NULL)
+        goto end;
+
+    if ((de_ctx->sig_list->sm_lists_tail[g_modbus_buffer_id] == NULL) ||
+        (de_ctx->sig_list->sm_lists_tail[g_modbus_buffer_id]->ctx == NULL)) {
+        printf("de_ctx->pmatch_tail == NULL && de_ctx->pmatch_tail->ctx == NULL: ");
+        goto end;
+    }
+
+    modbus = (DetectModbus *) de_ctx->sig_list->sm_lists_tail[g_modbus_buffer_id]->ctx;
+
+    if (((*modbus->unit_id).min != 10) 		||
+        ((*modbus->unit_id).mode != mode)	||
+        (modbus->type != type) 				||
+        ((*modbus->address).mode != mode) 	||
+        ((*modbus->address).min != 1000)	) {
+        printf("expected mode %u, got %u: ", mode, (*modbus->unit_id).mode);
+        printf("expected unit_id %d, got %" PRIu16 ": ", 10, (*modbus->unit_id).min);
+        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", type, modbus->type);
+        printf("expected mode %u, got %u: ", mode, (*modbus->address).mode);
+        printf("expected address %d, got %" PRIu16 ": ", 1000, (*modbus->address).min);
+        goto end;
+    }
+
+    result = 1;
+
+ end:
+    SigGroupCleanup(de_ctx);
+    SigCleanSignatures(de_ctx);
+    DetectEngineCtxFree(de_ctx);
+
+    return result;
+}
+
+/** \test Signature containing a range of unit_id. */
+static int DetectModbusTest13(void)
+{
+    DetectEngineCtx     *de_ctx = NULL;
+    DetectModbus        *modbus = NULL;
+    DetectModbusMode    mode = DETECT_MODBUS_RA;
+
+    int result = 0;
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
+                                       "(msg:\"Testing modbus.access\"; "
+                                       "modbus: unit 10<>500;  sid:1;)");
+
+    if (de_ctx->sig_list == NULL)
+        goto end;
+
+    if ((de_ctx->sig_list->sm_lists_tail[g_modbus_buffer_id] == NULL) ||
+        (de_ctx->sig_list->sm_lists_tail[g_modbus_buffer_id]->ctx == NULL)) {
+        printf("de_ctx->pmatch_tail == NULL && de_ctx->pmatch_tail->ctx == NULL: ");
+        goto end;
+    }
+
+    modbus = (DetectModbus *) de_ctx->sig_list->sm_lists_tail[g_modbus_buffer_id]->ctx;
+
+    if (((*modbus->unit_id).min != 10) 		||
+        ((*modbus->unit_id).max != 500)		||
+        ((*modbus->unit_id).mode != mode)) {
+        printf("expected mode %u, got %u: ", mode, (*modbus->unit_id).mode);
+        printf("expected min unit_id %d, got %" PRIu16 ": ", 10, (*modbus->unit_id).min);
+        printf("expected max unit_id %d, got %" PRIu16 ": ", 500, (*modbus->unit_id).max);
+        goto end;
+    }
+
+    result = 1;
+
+ end:
+    SigGroupCleanup(de_ctx);
+    SigCleanSignatures(de_ctx);
+    DetectEngineCtxFree(de_ctx);
+
+    return result;
+}
 #endif /* UNITTESTS */
 
 /**
@@ -878,5 +1191,13 @@ void DetectModbusRegisterTests(void)
                    DetectModbusTest08);
     UtRegisterTest("DetectModbusTest09 - Testing write a range of value",
                    DetectModbusTest09);
+    UtRegisterTest("DetectModbusTest10 - Testing unit_id",
+                   DetectModbusTest10);
+    UtRegisterTest("DetectModbusTest11 - Testing unit_id, function and subfunction",
+                   DetectModbusTest11);
+    UtRegisterTest("DetectModbusTest12 - Testing unit_id and access at address",
+                   DetectModbusTest12);
+    UtRegisterTest("DetectModbusTest13 - Testing a range of unit_id",
+                   DetectModbusTest13);
 #endif /* UNITTESTS */
 }

--- a/src/detect-modbus.h
+++ b/src/detect-modbus.h
@@ -54,6 +54,7 @@ typedef struct DetectModbus_ {
     uint8_t             function;       /** < Modbus function code to match */
     uint16_t            *subfunction;   /** < Modbus subfunction to match */
     uint8_t             type;           /** < Modbus access type to match */
+    DetectModbusValue   *unit_id;       /** < Modbus unit id to match */
     DetectModbusValue   *address;       /** < Modbus address to match */
     DetectModbusValue   *data;          /** < Modbus data to match */
 } DetectModbus;


### PR DESCRIPTION
**When destination IP address does not suffice to uniquely identify the Modbus/TCP device.**

Some Modbus/TCP devices act as gateways to other Modbus/TCP devices that are behind this gateways.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [Feature #1579](https://redmine.openinfosecfoundation.org/issues/1579)

Describe changes:
- Add new Modbus keyword : **unit**
- New Modbus keyword can be used alone or with the one of the others Modbus keywords "function" and "access"

cc @jasonish 

**Previous PR (v3)**
[#3268](https://github.com/OISF/suricata/pull/3268)

**Changes from v3**
- fix Travis CI build failed (request for member ‘max’ in something not a structure or union)