### PR TITLE
Network tree in events v1

### DIFF
--- a/doc/userguide/configuration/multi-tenant.rst
+++ b/doc/userguide/configuration/multi-tenant.rst
@@ -5,7 +5,8 @@ Introduction
 ------------
 
 Multi tenancy support allows for different rule sets with different
-rule vars.
+rule vars and network information, specifying a different network
+information file for each tenant.
 
 YAML
 ----
@@ -91,6 +92,10 @@ configuration:
       SHELLCODE_PORTS: "!80"
 
       ...
+
+  # Information about your networks can be defined in the file
+  # below using a JSON syntax and added when an event is generated.
+  #network-info: /etc/suricata/network.json
 
 Unix Socket
 -----------

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1814,6 +1814,30 @@ address, you should enter 'any'.
     ORACLE_PORTS: 1521
     SSH_PORTS: 22
 
+Network information
+~~~~~~~~~~~~~~~~~~~
+
+Networks can be structured with names which means that a label
+can be added either for a single or a group of hosts or
+even for the entire network.
+The structure is defined using JSON syntax in the file below:
+
+::
+
+ network-info: /etc/suricata/network.json
+
+The following is an example of a network structure:
+
+::
+
+ [{"name": "Data Center", "children": [{"name":"Italy", "addresses":["192.168.1.0/24", "192.168.2.0/24"],
+   "children":[{"name":"Suricata", "addresses":["192.168.1.3"]}]}]}]
+
+The JSON structure is made up of three labels:
+* name: it represents the label
+* addresses: the IP addresses which belogs to that label, multiple address can be specified and this field is not mandatory
+* children: sub-networks can be specified in this field. It is not mandatory.
+
 .. _host-os-policy:
 
 Host-os-policy

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -443,6 +443,7 @@ util-mpm-ac-tile-small.c \
 util-mpm-hs.c util-mpm-hs.h \
 util-mpm.c util-mpm.h \
 util-napatech.c util-napatech.h \
+util-network-tree.c util-network-tree.h \
 util-optimize.h \
 util-pages.c util-pages.h \
 util-path.c util-path.h \

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -38,6 +38,7 @@
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 
+#include "decode.h"
 #include "detect-parse.h"
 #include "detect-engine.h"
 #include "detect-engine-mpm.h"
@@ -59,6 +60,7 @@
 #include "util-log-redis.h"
 #include "util-device.h"
 #include "util-validate.h"
+#include "util-network-tree.h"
 
 #include "flow-var.h"
 #include "flow-bit.h"
@@ -383,6 +385,8 @@ void JsonFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, json_t *js)
     char srcip[46], dstip[46];
     Port sp, dp;
     char proto[16];
+    json_t *src_net_info = NULL;
+    json_t *dst_net_info = NULL;
 
     srcip[0] = '\0';
     dstip[0] = '\0';
@@ -395,11 +399,15 @@ void JsonFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, json_t *js)
                             srcip, sizeof(srcip));
                     PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
                             dstip, sizeof(dstip));
+                    src_net_info = NetworkTreeGetIPv4InfoAsJSON((uint8_t *)GET_IPV4_SRC_ADDR_PTR(p), p->tenant_id);
+                    dst_net_info = NetworkTreeGetIPv4InfoAsJSON((uint8_t *)GET_IPV4_DST_ADDR_PTR(p), p->tenant_id);
                 } else if (PKT_IS_IPV6(p)) {
                     PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
                             srcip, sizeof(srcip));
                     PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
                             dstip, sizeof(dstip));
+                    src_net_info = NetworkTreeGetIPv6InfoAsJSON((uint8_t *)GET_IPV6_SRC_ADDR(p), p->tenant_id);
+                    dst_net_info = NetworkTreeGetIPv6InfoAsJSON((uint8_t *)GET_IPV6_DST_ADDR(p), p->tenant_id);
                 }
                 sp = p->sp;
                 dp = p->dp;
@@ -409,11 +417,15 @@ void JsonFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, json_t *js)
                             srcip, sizeof(srcip));
                     PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
                             dstip, sizeof(dstip));
+                    src_net_info = NetworkTreeGetIPv4InfoAsJSON((uint8_t *)GET_IPV4_DST_ADDR_PTR(p), p->tenant_id);
+                    dst_net_info = NetworkTreeGetIPv4InfoAsJSON((uint8_t *)GET_IPV4_SRC_ADDR_PTR(p), p->tenant_id);
                 } else if (PKT_IS_IPV6(p)) {
                     PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
                             srcip, sizeof(srcip));
                     PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
                             dstip, sizeof(dstip));
+                    src_net_info = NetworkTreeGetIPv6InfoAsJSON((uint8_t *)GET_IPV6_DST_ADDR(p), p->tenant_id);
+                    dst_net_info = NetworkTreeGetIPv6InfoAsJSON((uint8_t *)GET_IPV6_SRC_ADDR(p), p->tenant_id);
                 }
                 sp = p->dp;
                 dp = p->sp;
@@ -425,11 +437,15 @@ void JsonFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, json_t *js)
                         srcip, sizeof(srcip));
                 PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
                         dstip, sizeof(dstip));
+                src_net_info = NetworkTreeGetIPv4InfoAsJSON((uint8_t *)GET_IPV4_SRC_ADDR_PTR(p), p->tenant_id);
+                dst_net_info = NetworkTreeGetIPv4InfoAsJSON((uint8_t *)GET_IPV4_DST_ADDR_PTR(p), p->tenant_id);
             } else if (PKT_IS_IPV6(p)) {
                 PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
                         srcip, sizeof(srcip));
                 PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
                         dstip, sizeof(dstip));
+                src_net_info = NetworkTreeGetIPv6InfoAsJSON((uint8_t *)GET_IPV6_SRC_ADDR(p), p->tenant_id);
+                dst_net_info = NetworkTreeGetIPv6InfoAsJSON((uint8_t *)GET_IPV6_DST_ADDR(p), p->tenant_id);
             }
             sp = p->sp;
             dp = p->dp;
@@ -470,6 +486,19 @@ void JsonFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, json_t *js)
     }
 
     json_object_set_new(js, "proto", json_string(proto));
+
+    if (src_net_info != NULL || dst_net_info != NULL) {
+        json_t *netinfojs = json_object();
+        if (netinfojs != NULL) {
+            if (src_net_info != NULL) {
+                json_object_set_new(netinfojs, "src", src_net_info);
+            }
+            if (dst_net_info != NULL) {
+                json_object_set_new(netinfojs, "dest", dst_net_info);
+            }
+            json_object_set_new(js, "net_info", netinfojs);
+        }
+    }
 }
 
 void CreateJSONFlowId(json_t *js, const Flow *f)

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -121,6 +121,7 @@
 
 #include "util-streaming-buffer.h"
 #include "util-lua.h"
+#include "util-network-tree.h"
 
 #ifdef HAVE_NSS
 #include <prinit.h>
@@ -218,6 +219,7 @@ static void RegisterUnittests(void)
     AppLayerUnittestsRegister();
     MimeDecRegisterTests();
     StreamingBufferRegisterTests();
+    NetworkTreeRegisterTests();
 }
 #endif
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -175,6 +175,8 @@
 #include "rust-core-gen.h"
 #endif
 
+#include "util-network-tree.h"
+
 /*
  * we put this here, because we only use it here in main.
  */
@@ -2512,6 +2514,10 @@ static void PostConfLoadedDetectSetup(SCInstance *suri)
             if (suri->run_mode == RUNMODE_ENGINE_ANALYSIS) {
                 exit(EXIT_SUCCESS);
             }
+        }
+
+        if (!mt_enabled) {
+            NetworkTreeInit();
         }
 
         gettimeofday(&de_ctx->last_reload, NULL);

--- a/src/tests/util-network-tree.c
+++ b/src/tests/util-network-tree.c
@@ -1,0 +1,256 @@
+/* Copyright (C) 2018 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Giuseppe Longo <glongo@stamus-networks.com>
+ *
+ * Tests for network tree code.
+ */
+
+#include "../suricata-common.h"
+#include "../util-network-tree.h"
+
+static int NetworkTreeTest01(void)
+{
+    const char *js = "[{\"name\":\"User networks\", \"children\":[{\"name\":\"Italy\", \"children\":[{\"name\": \"Lecce\", \"addresses\":[\"192.168.1.176\"]}]}]}]";
+    json_t *networkjs = json_loads(js, 0, NULL);
+    FAIL_IF(networkjs == NULL);
+
+    Packet *p = UTHBuildPacketSrcDst(NULL, 0, IPPROTO_TCP, "192.168.1.176", "192.168.1.1");
+    FAIL_IF_NULL(p);
+
+    NetworkTreeInitForTests(networkjs);
+
+    json_t *resultjs = NetworkTreeGetIPv4InfoAsJSON((uint8_t *)GET_IPV4_SRC_ADDR_PTR(p), p->tenant_id);
+    FAIL_IF(resultjs == NULL);
+
+    const char *results[] = { "Lecce", "Italy", "User networks" };
+    size_t size;
+    json_t *elem;
+    int i = 0;
+
+    json_array_foreach(resultjs, size, elem) {
+        FAIL_IF(strcmp(results[i], json_string_value(elem)) != 0);
+        i++;
+    }
+
+    json_decref(resultjs);
+    json_decref(networkjs);
+    UTHFreePacket(p);
+    NetworkTreeDeInit();
+
+    PASS;
+}
+
+static int NetworkTreeTest02(void)
+{
+    const char *js = "[{\"name\":\"User networks\", \"addresses\":[\"192.168.1.0/24\"], \"children\":[{\"name\":\"Italy\", \"children\":[{\"name\": \"Lecce\", \"addresses\":[\"192.168.1.176\"]}]}]}]";
+    json_t *networkjs = json_loads(js, 0, NULL);
+    FAIL_IF(networkjs == NULL);
+
+    Packet *p = UTHBuildPacketSrcDst(NULL, 0, IPPROTO_TCP, "192.168.1.2", "192.168.1.1");
+    FAIL_IF_NULL(p);
+
+    NetworkTreeInitForTests(networkjs);
+
+    json_t *resultjs = NetworkTreeGetIPv4InfoAsJSON((uint8_t *)GET_IPV4_SRC_ADDR_PTR(p), p->tenant_id);
+    FAIL_IF(resultjs == NULL);
+
+    const char *result = "User networks";
+    size_t size;
+    json_t *elem;
+
+    json_array_foreach(resultjs, size, elem) {
+        FAIL_IF(strcmp(result, json_string_value(elem)) != 0);
+    }
+
+    json_decref(resultjs);
+    json_decref(networkjs);
+    UTHFreePacket(p);
+    NetworkTreeDeInit();
+
+    PASS;
+}
+
+static int NetworkTreeTest03(void)
+{
+    const char *js = "[{\"name\":\"User networks\", \"addresses\":[\"192.168.1.0/24\"], \"children\":[{\"name\":\"Italy\", \"addresses\":[\"192.168.1.175\"], \"children\":[{\"name\": \"Lecce\", \"addresses\":[\"192.168.1.176\"]}]}]}]";
+    json_t *networkjs = json_loads(js, 0, NULL);
+    FAIL_IF(networkjs == NULL);
+
+    Packet *p = UTHBuildPacketSrcDst(NULL, 0, IPPROTO_TCP, "192.168.1.175", "192.168.1.1");
+    FAIL_IF_NULL(p);
+
+    NetworkTreeInitForTests(networkjs);
+
+    json_t *resultjs = NetworkTreeGetIPv4InfoAsJSON((uint8_t *)GET_IPV4_SRC_ADDR_PTR(p), p->tenant_id);
+    FAIL_IF(resultjs == NULL);
+
+    const char *results[] = { "Italy", "User networks" };
+    size_t size;
+    json_t *elem;
+    int i = 0;
+
+    json_array_foreach(resultjs, size, elem) {
+        FAIL_IF(strcmp(results[i], json_string_value(elem)) != 0);
+        i++;
+    }
+
+    json_decref(resultjs);
+    json_decref(networkjs);
+    UTHFreePacket(p);
+    NetworkTreeDeInit();
+
+    PASS;
+}
+
+static int NetworkTreeTest04(void)
+{
+    const char *js = "[{\"name\": \"Private class A\", \"addresses\": [\"10.0.0.0/8\"]}, {\"name\": \"Private class B\", \"addresses\": [\"172.16.0.0/12\"]}, {\"name\": \"Private class C\", \"addresses\": [\"192.168.0.0/16\"]}]";
+    json_t *networkjs = json_loads(js, 0, NULL);
+    FAIL_IF(networkjs == NULL);
+
+    Packet *p = UTHBuildPacketSrcDst(NULL, 0, IPPROTO_TCP, "10.0.0.2", "10.0.0.1");
+    FAIL_IF_NULL(p);
+
+    NetworkTreeInitForTests(networkjs);
+
+    json_t *resultjs = NetworkTreeGetIPv4InfoAsJSON((uint8_t *)GET_IPV4_SRC_ADDR_PTR(p), p->tenant_id);
+    FAIL_IF(resultjs == NULL);
+
+    const char *result = "Private class A";
+    size_t size;
+    json_t *elem;
+
+    json_array_foreach(resultjs, size, elem) {
+        FAIL_IF(strcmp(result, json_string_value(elem)) != 0);
+    }
+
+    json_decref(resultjs);
+    json_decref(networkjs);
+    UTHFreePacket(p);
+    NetworkTreeDeInit();
+
+    PASS;
+}
+
+static int NetworkTreeTest05(void)
+{
+    const char *js = "[{\"name\": \"Private class A\", \"addresses\": [\"10.0.0.0/8\"]}, {\"name\": \"Private class B\", \"addresses\": [\"172.16.0.0/12\"]}, {\"name\": \"Private class C\", \"addresses\": [\"192.168.0.0/16\"]}]";
+    json_t *networkjs = json_loads(js, 0, NULL);
+    FAIL_IF(networkjs == NULL);
+
+    Packet *p = UTHBuildPacketSrcDst(NULL, 0, IPPROTO_TCP, "172.16.0.2", "172.16.0.1");
+    FAIL_IF_NULL(p);
+
+    NetworkTreeInitForTests(networkjs);
+
+    json_t *resultjs = NetworkTreeGetIPv4InfoAsJSON((uint8_t *)GET_IPV4_SRC_ADDR_PTR(p), p->tenant_id);
+    FAIL_IF(resultjs == NULL);
+
+    const char *result = "Private class B";
+    size_t size;
+    json_t *elem;
+
+    json_array_foreach(resultjs, size, elem) {
+        FAIL_IF(strcmp(result, json_string_value(elem)) != 0);
+    }
+
+    json_decref(resultjs);
+    json_decref(networkjs);
+    UTHFreePacket(p);
+    NetworkTreeDeInit();
+
+    PASS;
+}
+
+static int NetworkTreeTest06(void)
+{
+    const char *js = "[{\"name\": \"Private class A\", \"addresses\": [\"10.0.0.0/8\"]}, {\"name\": \"Private class B\", \"addresses\": [\"172.16.0.0/12\"]}, {\"name\": \"Private class C\", \"addresses\": [\"192.168.0.0/16\"]}]";
+    json_t *networkjs = json_loads(js, 0, NULL);
+    FAIL_IF(networkjs == NULL);
+
+    Packet *p = UTHBuildPacketSrcDst(NULL, 0, IPPROTO_TCP, "192.168.0.2", "192.168.0.1");
+    FAIL_IF_NULL(p);
+
+    NetworkTreeInitForTests(networkjs);
+
+    json_t *resultjs = NetworkTreeGetIPv4InfoAsJSON((uint8_t *)GET_IPV4_SRC_ADDR_PTR(p), p->tenant_id);
+    FAIL_IF(resultjs == NULL);
+
+    const char *result = "Private class C";
+    size_t size;
+    json_t *elem;
+
+    json_array_foreach(resultjs, size, elem) {
+        FAIL_IF(strcmp(result, json_string_value(elem)) != 0);
+    }
+
+    json_decref(resultjs);
+    json_decref(networkjs);
+    UTHFreePacket(p);
+    NetworkTreeDeInit();
+
+    PASS;
+}
+
+static int NetworkTreeTest07(void)
+{
+    const char *js = "[{\"name\": \"XS\", \"children\": [{\"name\": \"Red team\", \"addresses\":[\"192.168.17.0/24\"]}, {\"name\": \"Crimsonia\", \"addresses\":[\"198.18.2.0/24\",\"198.18.3.0/24\",\"10.242.4.0/24\",\"10.242.5.0/24\",\"10.242.6.0/24\",\"198.18.0.0/24\",\"2a07:1181:130:3602::/64\",\"2a07:1181:130:3603::/64\",\"2a07:1181:130:3604::/64\",\"2a07:1181:130:3605::/64\",\"2a07:1181:130:3606::/64\",\"2a07:1181:130:3607::/64\"]}, {\"name\": \"Internet\", \"addresses\":[\"0.0.0.0/0\",\"0::/0\"]}]}]";
+    json_t *networkjs = json_loads(js, 0, NULL);
+    FAIL_IF(networkjs == NULL);
+
+    Packet *p = UTHBuildPacketSrcDst(NULL, 0, IPPROTO_TCP, "100.116.103.160", "198.18.2.5");
+    FAIL_IF_NULL(p);
+
+    NetworkTreeInitForTests(networkjs);
+
+    p->tenant_id = 0;
+    json_t *resultjs = NetworkTreeGetIPv4InfoAsJSON((uint8_t *)GET_IPV4_SRC_ADDR_PTR(p), p->tenant_id);
+    FAIL_IF(resultjs == NULL);
+
+    const char *results[] = { "Internet", "XS" };
+    size_t size;
+    json_t *elem;
+    int i = 0;
+
+    json_array_foreach(resultjs, size, elem) {
+        FAIL_IF(strcmp(results[i], json_string_value(elem)) != 0);
+        i++;
+    }
+
+    json_decref(resultjs);
+    json_decref(networkjs);
+    UTHFreePacket(p);
+    NetworkTreeDeInit();
+
+    PASS;
+}
+
+void NetworkTreeDoRegisterTests(void)
+{
+    UtRegisterTest("NetworkTreeTest01", NetworkTreeTest01);
+    UtRegisterTest("NetworkTreeTest02", NetworkTreeTest02);
+    UtRegisterTest("NetworkTreeTest03", NetworkTreeTest03);
+    UtRegisterTest("NetworkTreeTest04", NetworkTreeTest04);
+    UtRegisterTest("NetworkTreeTest05", NetworkTreeTest05);
+    UtRegisterTest("NetworkTreeTest06", NetworkTreeTest06);
+    UtRegisterTest("NetworkTreeTest07", NetworkTreeTest07);
+}
+

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -347,6 +347,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_ERR_PF_RING_VLAN);
         CASE_CODE (SC_ERR_CREATE_DIRECTORY);
         CASE_CODE (SC_WARN_FLOWBIT);
+        CASE_CODE (SC_ERR_JSON_FILE_NOT_LOADED);
 
         CASE_CODE (SC_ERR_MAX);
     }

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -337,6 +337,7 @@ typedef enum {
     SC_ERR_PF_RING_VLAN,
     SC_ERR_CREATE_DIRECTORY,
     SC_WARN_FLOWBIT,
+    SC_ERR_JSON_FILE_NOT_LOADED,
 
     SC_ERR_MAX,
 } SCError;

--- a/src/util-network-tree.c
+++ b/src/util-network-tree.c
@@ -1,0 +1,659 @@
+/* Copyright (C) 2018 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Eric Leblond <eric@regit.org>
+ * \author Giuseppe Longo <glongo@stamus-networks.com>
+ *
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+#include "conf.h"
+#include "detect-engine.h"
+#include "util-network-tree.h"
+#include "util-unittest.h"
+#include "util-unittest-helper.h"
+
+/* workaround for old libjansson on Centos */
+#ifndef json_array_foreach
+#define json_array_foreach(array, index, value) \
+    for(index = 0; \
+        index < json_array_size(array) && (value = json_array_get(array, index)); \
+        index++)
+#endif
+
+typedef struct NetworkTreeElt_ {
+    const char *name;
+    struct NetworkTreeElt_ *next;
+} NetworkTreeElt;
+
+typedef struct NetworkTree_ {
+    int tenant_id;
+    int ref_cnt;
+    SCRadixTree *tree_v4;
+    SCRadixTree *tree_v6;
+} NetworkTree;
+
+typedef struct NetworkTreeMaster_ {
+    SCMutex lock;
+    NetworkTree *tree;
+    HashTable *mt_trees_hash;
+} NetworkTreeMaster;
+
+static NetworkTreeMaster g_master_net_tree = { SCMUTEX_INITIALIZER, NULL, NULL };
+
+static uint32_t NetworkTreeTenantIdHash(HashTable *h, void *data, uint16_t data_len);
+static char NetworkTreeTenantIdCompare(void *d1, uint16_t d1_len, void *d2, uint16_t d2_len);
+static void NetworkTreeTenantIdFree(void *d);
+static void NetworkTreeFreeInstance(NetworkTree *ntree);
+
+static uint32_t NetworkTreeTenantIdHash(HashTable *h, void *data, uint16_t data_len)
+{
+    NetworkTree *ntree = (NetworkTree *)data;
+    return ntree->tenant_id % h->array_size;
+}
+
+static char NetworkTreeTenantIdCompare(void *d1, uint16_t d1_len, void *d2, uint16_t d2_len)
+{
+    NetworkTree *ntree1 = (NetworkTree *)d1;
+    NetworkTree *ntree2 = (NetworkTree *)d2;
+    return (ntree1->tenant_id == ntree2->tenant_id);
+}
+
+static void NetworkTreeTenantIdFree(void *d)
+{
+    NetworkTreeFreeInstance(d);
+}
+
+static void NetworkTreeEltFree(NetworkTreeElt *elt)
+{
+    NetworkTreeElt *pelt;
+
+    while (elt) {
+        if (elt->name)
+            SCFree((void *)elt->name);
+        pelt = elt;
+        elt = elt->next;
+        SCFree(pelt);
+    }
+}
+static NetworkTreeElt *NetworkTreeEltCopy(NetworkTreeElt *elt)
+{
+    NetworkTreeElt *new_elt = NULL;
+    NetworkTreeElt *l_elt, *last_elt = NULL;
+
+    while (elt) {
+        l_elt = SCCalloc(1, sizeof(*l_elt));
+        if (l_elt == NULL)
+            goto error;
+        if (new_elt == NULL) {
+            new_elt = l_elt;
+            last_elt = new_elt;
+        } else {
+            last_elt->next = l_elt;
+            last_elt = l_elt;
+        }
+        l_elt->name = SCStrdup(elt->name);
+        if (l_elt->name == NULL)
+            goto error;
+        l_elt->next = NULL;
+        elt = elt->next;
+        last_elt = l_elt;
+    }
+    return new_elt;
+
+error:
+    SCLogError(SC_ERR_MEM_ALLOC,
+               "Memory allocation failure "
+               "when copying network tree element");
+    NetworkTreeEltFree(new_elt);
+    return NULL;
+}
+
+static NetworkTreeElt *NetworkTreeEltAdd(NetworkTreeElt *elt, const char *name)
+{
+    NetworkTreeElt *new_elt = SCCalloc(1, sizeof(*new_elt));
+    if (new_elt == NULL)
+        return NULL;
+    new_elt->name = SCStrdup(name);
+    if (new_elt->name == NULL) {
+        SCFree(new_elt);
+        return NULL;
+    }
+    new_elt->next = elt;
+    return new_elt;
+}
+
+static void NetworkTreeFreeUserData(void *data)
+{
+    NetworkTreeElt *ldata = (NetworkTreeElt *) data;
+    return NetworkTreeEltFree(ldata);
+}
+
+static json_t *NetworkTreeEltAsJSON(NetworkTreeElt *elt)
+{
+    json_t *ejson = NULL;
+    if (elt == NULL)
+        return NULL;
+    ejson = json_array();
+    if (ejson == NULL)
+        return NULL;
+    while (elt) {
+        json_array_append_new(ejson, json_string(elt->name));
+        elt = elt->next;
+    }
+    return ejson;
+}
+
+static NetworkTree *NetworkTreeCreateInstance(int tenant_id)
+{
+    NetworkTree *ntree = SCMalloc(sizeof(NetworkTree));
+    if (ntree == NULL)
+        return NULL;
+
+    ntree->tree_v4 = SCRadixCreateRadixTree(NetworkTreeFreeUserData, NULL);
+    if (ntree->tree_v4 == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC,
+                   "Can't alloc memory for the network tree.");
+        SCFree(ntree);
+        return NULL;
+    }
+
+    ntree->tree_v6 = SCRadixCreateRadixTree(NetworkTreeFreeUserData, NULL);
+    if (ntree->tree_v6 == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC,
+                   "Can't alloc memory for the network tree.");
+        SCFree(ntree->tree_v4);
+        SCFree(ntree);
+        return NULL;
+    }
+
+    ntree->tenant_id = tenant_id;
+    ntree->ref_cnt = 0;
+
+    return ntree;
+}
+
+static void NetworkTreeFreeInstance(NetworkTree *ntree)
+{
+    if (ntree->ref_cnt == 0) {
+        SCRadixReleaseRadixTree(ntree->tree_v4);
+        SCRadixReleaseRadixTree(ntree->tree_v6);
+        SCFree(ntree);
+        ntree = NULL;
+    }
+}
+
+static int ParseIPV4String(const char *str, uint32_t *ip, uint8_t *netmask)
+{
+    char ip_str[32]; /* Max length for full ipv4/mask string with NUL */
+    char *mask_str = NULL;
+    struct in_addr addr;
+
+    /* Make a copy of the string so it can be modified */
+    strlcpy(ip_str, str, sizeof(ip_str) - 2);
+    *(ip_str + (sizeof(ip_str) - 1)) = '\0';
+
+    *netmask = 32;
+
+    /* Does it have a mask? */
+    if (NULL != (mask_str = strchr(ip_str, '/'))) {
+        int cidr;
+        *(mask_str++) = '\0';
+
+        /* Dotted type netmask not supported (yet) */
+        if (strchr(mask_str, '.') != NULL) {
+            return -1;
+        }
+
+        /* Get binary values for cidr mask */
+        cidr = atoi(mask_str);
+        if ((cidr < 0) || (cidr > 32)) {
+            return -1;
+        }
+        *netmask = (uint8_t)cidr;
+    }
+
+    /* Validate the IP */
+    if (inet_pton(AF_INET, ip_str, &addr) <= 0) {
+        return -1;
+    }
+    *ip = addr.s_addr;
+    return 0;
+}
+
+static int ParseIPV6String(const char *str, struct in6_addr *addr, uint8_t *netmask)
+{
+    char ip_str[80]; /* Max length for full ipv6/mask string with NUL */
+    char *mask_str = NULL;
+
+    /* Make a copy of the string so it can be modified */
+    strlcpy(ip_str, str, sizeof(ip_str) - 2);
+    *(ip_str + sizeof(ip_str) - 1) = '\0';
+
+    *netmask = 128;
+
+    /* Does it have a mask? */
+    if (NULL != (mask_str = strchr(ip_str, '/'))) {
+        int cidr;
+        *(mask_str++) = '\0';
+
+        /* Dotted type netmask not supported (yet) */
+        if (strchr(mask_str, '.') != NULL) {
+            return -1;
+        }
+
+        /* Get binary values for cidr mask */
+        cidr = atoi(mask_str);
+        if ((cidr < 0) || (cidr > 128)) {
+            return -1;
+        }
+        *netmask = (uint8_t)cidr;
+    }
+
+    /* Validate the IP */
+    if (inet_pton(AF_INET6, ip_str, addr) <= 0) {
+        return -1;
+    }
+    return 0;
+}
+
+/**
+ * \ brief Function that put all the network information
+ *         specified in the configuration file into a tree.
+ *         It's called recursively
+ *
+ * \param js json array with information about networks
+ * \param jnames json array of strings which store a network name
+ *
+ * \retval 0 if success
+ * \retval -1 if an error occurred
+ */
+static int NetworkTreeParseJson(json_t *js, NetworkTreeElt *jnames, NetworkTree *ntree)
+{
+    size_t size;
+    json_t *elem;
+
+    /**
+     * For each network, take the name and addresses
+     * and add it into the tree, then fetch the children
+     * and call the function recursively.
+     */
+    json_array_foreach(js, size, elem) {
+        json_t *jname = json_object_get(elem, "name");
+        NetworkTreeElt *local_jnames = NULL;
+        if (jname == NULL) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Name not specified, "
+                                             "network information not loaded.");
+            return -1;
+        }
+
+        if (!json_is_string(jname)) {
+            SCLogError(SC_ERR_INVALID_VALUE, "An invalid name is specified");
+            return -1;
+        }
+        /* if NULL we are at the top of the tree and we allocate
+         * our array in the other case we copy the function param to
+         * be able to have a correct and simple freeing code.
+         */
+        if (jnames != NULL) {
+            local_jnames = NetworkTreeEltCopy(jnames);
+        }
+        local_jnames = NetworkTreeEltAdd(local_jnames, json_string_value(jname));
+
+        json_t *jaddres = json_object_get(elem, "addresses");
+
+        if (jaddres != NULL) {
+            size_t addr_size;
+            json_t *jaddr;
+            json_array_foreach(jaddres, addr_size, jaddr) {
+                NetworkTreeElt *jnames_node = NetworkTreeEltCopy(local_jnames);
+                /* without a deep copy each node of the tree share the same array
+                   reference, so as result you have all the same array for all nodes. */
+                if (jnames_node == NULL) {
+                    SCLogError(SC_ERR_MEM_ALLOC, "Can't alloc memory");
+                    return -1;
+                }
+                if (!json_is_string(jaddr)) {
+                    SCLogError(SC_ERR_INVALID_VALUE, "Expected an IP address as"
+                            "string, but it's not.");
+                    continue;
+                }
+                const char *ip_addr = json_string_value(jaddr);
+
+                if (strchr(ip_addr, ':') != NULL) {
+                    void *user_data = NULL;
+                    struct in6_addr addr;
+                    uint8_t netmask;
+
+                    /* if an ip address is duplicated, it's not added */
+                    if (ParseIPV6String(ip_addr, &addr, &netmask) != 0) {
+                        SCLogError(SC_ERR_INVALID_VALUE, "Invalid IP address: %s", ip_addr);
+                        NetworkTreeEltFree(jnames_node);
+                        return -1;
+                    }
+
+                    if (SCRadixFindKeyIPV6Netblock((uint8_t *)addr.s6_addr, ntree->tree_v6,
+                                                   netmask, &user_data) != NULL)
+                    {
+                        SCLogWarning(SC_ERR_INVALID_VALUE,
+                                "ipv6 address %s already added", ip_addr);
+                        NetworkTreeEltFree(jnames_node);
+                        continue;
+                    }
+                    if (SCRadixAddKeyIPV6String(ip_addr, ntree->tree_v6,
+                                                (void *)jnames_node) == NULL) {
+                        SCLogWarning(SC_ERR_INVALID_VALUE,
+                                "failed to add ipv6 host %s", ip_addr);
+                    }
+                } else {
+                    void *user_data = NULL;
+                    uint32_t ip;
+                    uint8_t netmask;
+
+                    /* if an ip address is duplicated, it's not added */
+                    if (ParseIPV4String(ip_addr, &ip, &netmask) != 0) {
+                        SCLogError(SC_ERR_INVALID_VALUE, "Invalid IP address: %s", ip_addr);
+                        NetworkTreeEltFree(jnames_node);
+                        break;
+                    }
+                    if (SCRadixFindKeyIPV4Netblock((uint8_t *)&ip, ntree->tree_v4,
+                                                    netmask, &user_data) != NULL) {
+                        SCLogWarning(SC_ERR_INVALID_VALUE,
+                                "ipv4 address %s already added", ip_addr);
+                        NetworkTreeEltFree(jnames_node);
+                        continue;
+                    }
+                    if (SCRadixAddKeyIPV4String(ip_addr, ntree->tree_v4,
+                                                (void *)jnames_node) == NULL) {
+                        SCLogWarning(SC_ERR_INVALID_VALUE,
+                                "failed to add ipv4 host %s", ip_addr);
+                    }
+                }
+            }
+        }
+
+        json_t *jchildren = json_object_get(elem, "children");
+        if (jchildren == NULL) {
+            /* no children to add, so let's continue */
+            NetworkTreeEltFree(local_jnames);
+            continue;
+        } else {
+            if (!json_is_array(jchildren)) {
+                SCLogError(SC_ERR_INVALID_VALUE, "children format for '%s' is wrong,"
+                        "json array is expected",
+                        json_string_value(jname));
+                NetworkTreeEltFree(jnames);
+                NetworkTreeEltFree(local_jnames);
+                return -1;
+            }
+
+            NetworkTreeElt *recursive_elt = NetworkTreeEltCopy(local_jnames);
+            if (recursive_elt) {
+                NetworkTreeParseJson(jchildren, recursive_elt, ntree);
+            } else {
+                SCLogError(SC_ERR_MEM_ALLOC, "Unable to duplicate recursive elt");
+                NetworkTreeEltFree(jnames);
+                NetworkTreeEltFree(local_jnames);
+                return -1;
+            }
+        }
+        NetworkTreeEltFree(local_jnames);
+    }
+    NetworkTreeEltFree(jnames);
+    return 0;
+}
+
+static NetworkTreeElt *NetworkTreeGetIPv4Info(uint8_t *ipv4_addr, int tenant_id)
+{
+    NetworkTreeMaster *master = &g_master_net_tree;
+    NetworkTree *ntree = NULL;
+
+    if (DetectEngineMultiTenantEnabled()) {
+        SCMutexLock(&master->lock);
+        ntree = HashTableLookup(master->mt_trees_hash, &tenant_id, 0);
+        if (ntree != NULL) {
+            ntree->ref_cnt++;
+        }
+        SCMutexUnlock(&master->lock);
+    } else {
+        ntree = master->tree;
+    }
+
+    if (ntree == NULL) {
+        return NULL;
+    }
+
+    void *user_data = NULL;
+    (void)SCRadixFindKeyIPV4BestMatch(ipv4_addr, ntree->tree_v4, &user_data);
+
+    if (DetectEngineMultiTenantEnabled()) {
+        SCMutexLock(&master->lock);
+        ntree->ref_cnt--;
+        SCMutexUnlock(&master->lock);
+    }
+
+    return ((user_data != NULL) ? (NetworkTreeElt *)user_data : NULL);
+}
+
+static NetworkTreeElt *NetworkTreeGetIPv6Info(uint8_t *ipv6_addr, int tenant_id)
+{
+    NetworkTreeMaster *master = &g_master_net_tree;
+    NetworkTree *ntree = NULL;
+
+    if (DetectEngineMultiTenantEnabled()) {
+        SCMutexLock(&master->lock);
+        ntree = HashTableLookup(master->mt_trees_hash, &tenant_id, 0);
+        if (ntree != NULL) {
+            ntree->ref_cnt++;
+        }
+        SCMutexUnlock(&master->lock);
+    } else {
+        ntree = master->tree;
+    }
+
+    if (ntree == NULL) {
+        return NULL;
+    }
+
+    void *user_data = NULL;
+    (void)SCRadixFindKeyIPV6BestMatch(ipv6_addr, ntree->tree_v6, &user_data);
+
+    if (DetectEngineMultiTenantEnabled()) {
+        SCMutexLock(&master->lock);
+        ntree->ref_cnt--;
+        SCMutexUnlock(&master->lock);
+    }
+
+    return ((user_data != NULL) ? (NetworkTreeElt *)user_data : NULL);
+}
+
+/**
+ * \brief Returns an array of labels associated to an ip address
+ *
+ * \param ipv4_addr IPv4 address to retreive network configuration
+ * \param tenant_id Load configuration for this specific id
+ *
+ * \retval elt A json array containing all the labels associated to the ip address.
+ */
+json_t *NetworkTreeGetIPv4InfoAsJSON(uint8_t *ipv4_addr, int tenant_id)
+{
+    NetworkTreeElt *elt = NetworkTreeGetIPv4Info(ipv4_addr, tenant_id);
+    if (elt == NULL)
+        return NULL;
+    return NetworkTreeEltAsJSON(elt);
+}
+
+/**
+ * \brief Returns an array of labels associated to an ip address
+ *
+ * \param ipv4_addr IPv6 address to retreive network configuration
+ * \param tenant_id Load configuration for this specific id
+ *
+ * \retval elt A json array containing all the labels associated to the ip address.
+ */
+json_t *NetworkTreeGetIPv6InfoAsJSON(uint8_t *ipv6_addr, int tenant_id)
+{
+    NetworkTreeElt *elt = NetworkTreeGetIPv6Info(ipv6_addr, tenant_id);
+    if (elt == NULL)
+        return NULL;
+    return NetworkTreeEltAsJSON(elt);
+}
+
+static int NetworkTreeParseConfig(const char *node, NetworkTree *ntree)
+{
+    const char *filepath = NULL;
+    json_t *jfile = NULL;
+    int r = 0;
+
+    if (ConfGet(node, &filepath) < 1) {
+        return -1;
+    }
+
+    jfile = json_load_file(filepath, 0, NULL);
+    if (jfile == NULL) {
+        SCLogError(SC_ERR_JSON_FILE_NOT_LOADED, "Cannot load the file specified");
+        return -1;
+    }
+
+    if (!json_is_array(jfile)) {
+        SCLogError(SC_ERR_INVALID_VALUE, "Format wrong, json array is expected.");
+        json_decref(jfile);
+        return -1;
+    }
+
+    r = NetworkTreeParseJson(jfile, NULL, ntree);
+
+    json_decref(jfile);
+
+    return r;
+}
+
+/**
+ * \brief Load network configuration for a tenant
+ *
+ * \param de_ctx it's used to retrieve the tenant id
+ *
+ */
+void NetworkTreeLoadConfigMultiTenant(DetectEngineCtx *de_ctx)
+{
+    NetworkTreeMaster *master = &g_master_net_tree;
+    char varname[128] = "network-tree-path";
+
+    if (strlen(de_ctx->config_prefix) > 0) {
+        snprintf(varname, sizeof(varname), "%s.network-tree-path",
+                 de_ctx->config_prefix);
+    }
+    if (master->mt_trees_hash == NULL) {
+        return;
+    }
+    NetworkTree *ntree = NetworkTreeCreateInstance(de_ctx->tenant_id);
+    if (ntree == NULL) {
+        return;
+    }
+    if (NetworkTreeParseConfig(varname, ntree) != 0) {
+        NetworkTreeFreeInstance(ntree);
+        return;
+    }
+    if (HashTableAdd(master->mt_trees_hash, ntree, 0) != 0) {
+        NetworkTreeFreeInstance(ntree);
+        return;
+    }
+}
+
+/**
+ * \brief Initialize the context to store network configuration
+ *
+ */
+void NetworkTreeInit(void)
+{
+    NetworkTreeMaster *master = &g_master_net_tree;
+
+    if (DetectEngineMultiTenantEnabled()) {
+        HashTable *mt_trees_hash = NULL;
+        /* number of tenants is needed to allocate hash table */
+        ConfNode *tenants_root_node = ConfGetNode("multi-detect.tenants");
+        ConfNode *tenant_node = NULL;
+        int tenants_cnt = 0;
+
+        if (tenants_root_node != NULL) {
+            TAILQ_FOREACH(tenant_node, &tenants_root_node->head, next) {
+                tenants_cnt++;
+            }
+            mt_trees_hash = HashTableInit(tenants_cnt * 2, NetworkTreeTenantIdHash,
+                                          NetworkTreeTenantIdCompare, NetworkTreeTenantIdFree);
+            if (mt_trees_hash == NULL) {
+                SCLogError(SC_ERR_MEM_ALLOC, "Can't alloc memory for hash table.");
+                return;
+            }
+            master->mt_trees_hash = mt_trees_hash;
+        }
+    } else {
+        master->tree = NetworkTreeCreateInstance(0);
+        if (master->tree == NULL) {
+            return;
+        }
+        if (NetworkTreeParseConfig("network-tree-path", master->tree) != 0) {
+            NetworkTreeFreeInstance(master->tree);
+        }
+    }
+    return;
+}
+
+/**
+ * \brief Deinitialize the context and frees the resources
+ *
+ */
+void NetworkTreeDeInit(void)
+{
+    NetworkTreeMaster *master = &g_master_net_tree;
+
+    if (master->tree != NULL) {
+        NetworkTreeFreeInstance(master->tree);
+    }
+    if (master->mt_trees_hash != NULL) {
+        HashTableFree(master->mt_trees_hash);
+    }
+}
+
+#ifdef UNITTESTS
+#include "tests/util-network-tree.c"
+
+void NetworkTreeInitForTests(json_t *networkjs)
+{
+    NetworkTreeMaster *master = &g_master_net_tree;
+
+    master->tree = NetworkTreeCreateInstance(0);
+    if (master->tree == NULL) {
+        return;
+    }
+
+    if (NetworkTreeParseJson(networkjs, NULL, master->tree) != 0) {
+        NetworkTreeFreeInstance(master->tree);
+    }
+}
+#endif /* UNITTESTS */
+
+void NetworkTreeRegisterTests(void)
+{
+#ifdef UNITTESTS
+    NetworkTreeDoRegisterTests();
+#endif
+}

--- a/src/util-network-tree.h
+++ b/src/util-network-tree.h
@@ -1,0 +1,45 @@
+/* Copyright (C) 2018 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Eric Leblond <eric@regit.org>
+ * \author Giuseppe Longo <glongo@stamus-networks.com>
+ *
+ */
+
+#ifndef UTIL_NETWORK_TREE_H_
+#define UTIL_NETWORK_TREE_H_
+
+void NetworkTreeInit(void);
+void NetworkTreeDeInit(void);
+void NetworkTreeLoadConfig(void);
+void NetworkTreeLoadConfigMultiTenant(DetectEngineCtx *de_ctx);
+json_t *NetworkTreeGetIPv4InfoAsJSON(uint8_t *ipv4_addr, int tenant_id);
+json_t *NetworkTreeGetIPv6InfoAsJSON(uint8_t *ipv6_addr, int tenant_id);
+int NetworkTreeMoveToFreeList(DetectEngineCtx *de_ctx);
+void NetworkTreePruneFreeList(void);
+void NetworkTreeRegisterTests(void);
+
+#ifdef UNITTESTS
+void NetworkTreeInitForTests(json_t *networkjs);
+void NetworkTreeDoRegisterTests(void);
+#endif /* UNITTESTS */
+
+#endif /* UTIL_NETWORK_TREE_H_ */
+

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -45,6 +45,10 @@ vars:
     FTP_PORTS: 21
 
 
+# Information about your networks can be defined in the file
+# below using a JSON syntax and added when an event is generated.
+#network-info: @e_sysconfdir@network.json
+
 ##
 ## Step 2: select the rules to enable or disable
 ##


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2277

Describe changes:
This feature will allow user to defined a network tree structure with name. During event generation, a lookup will be made to add information about the hierarchy of networks the source and destination address belong too.
The structure is defined using the following JSON format:
```
[{"name": "<label>", "addresses":["<IPs>"], "children":[{"name": "...", "addresses":["..."]}]}]
```
`children` field is not mandatory so a simple structure looks like:
```
[{"name": "Home network", "addresses":["192.168.43.0/24"]}]
```
The structure below is an example that can be used for testing:
```
[{"name": "Home Network", "addresses":["192.168.0.0/24"], "children": [{"name":"Router", "addresses":["192.168.1.1"]}, {"name":"Sensor", "addresses":["192.168.1.2"]}]}]
```
The structure defined will be added in events into `net_info` field, then respectively in `src` or `dest` field.
An example below:
```
{
  "timestamp": "2018-01-04T15:44:16.018667+0100",
  "flow_id": 414428872802379,
  "in_iface": "wlp2s0",
  "event_type": "http",
  "src_ip": "192.168.1.3",
  "src_port": 45200,
  "dest_ip": "213.186.33.24",
  "dest_port": 80,
  "proto": "TCP",
  "net_info": {
    "src": [
      "Red team",
      "XS" 
    ],
    "dest": [
      "Internet",
      "XS" 
    ]
  },
  "tx_id": 0,
  "http": {
    "hostname": "www.glongo.it",
    "url": "/",
    "http_user_agent": "curl/7.52.1",
    "http_content_type": "text/html",
    "http_method": "GET",
    "protocol": "HTTP/1.1",
    "status": 200,
    "length": 17207
  }
}
```

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/181
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/45
