### PR TITLE
Feature/smb/v19.9

### DIFF
--- a/rust/src/smb/log.rs
+++ b/rust/src/smb/log.rs
@@ -330,14 +330,19 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
             js.set_string("fuid", &gs);
         },
         Some(SMBTransactionTypeData::RENAME(ref x)) => {
+            if tx.vercmd.get_version() == 2 {
+                let jsd = Json::object();
+                jsd.set_string("class", "FILE_INFO");
+                jsd.set_string("info_level", "SMB2_FILE_RENAME_INFO");
+                js.set("set_info", jsd);
+            }
+
             let jsd = Json::object();
-            jsd.set_string("class", "FILE_INFO");
-            jsd.set_string("info_level", "SMB2_FILE_RENAME_INFO");
             let file_name = String::from_utf8_lossy(&x.oldname);
             jsd.set_string("from", &file_name);
             let file_name = String::from_utf8_lossy(&x.newname);
             jsd.set_string("to", &file_name);
-            js.set("set_info", jsd);
+            js.set("rename", jsd);
             let gs = fuid_to_string(&x.fuid);
             js.set_string("fuid", &gs);
         },

--- a/rust/src/smb/log.rs
+++ b/rust/src/smb/log.rs
@@ -329,6 +329,18 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
             let gs = fuid_to_string(&x.fuid);
             js.set_string("fuid", &gs);
         },
+        Some(SMBTransactionTypeData::RENAME(ref x)) => {
+            let jsd = Json::object();
+            jsd.set_string("class", "FILE_INFO");
+            jsd.set_string("info_level", "SMB2_FILE_RENAME_INFO");
+            let file_name = String::from_utf8_lossy(&x.oldname);
+            jsd.set_string("from", &file_name);
+            let file_name = String::from_utf8_lossy(&x.newname);
+            jsd.set_string("to", &file_name);
+            js.set("set_info", jsd);
+            let gs = fuid_to_string(&x.fuid);
+            js.set_string("fuid", &gs);
+        },
         Some(SMBTransactionTypeData::DCERPC(ref x)) => {
             let jsd = Json::object();
             jsd.set_string("request", &dcerpc_type_string(x.req_cmd));

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -710,7 +710,7 @@ pub fn smb1_write_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
 
             let file_name = match state.guid2name_map.get(&file_fid) {
                 Some(n) => n.to_vec(),
-                None => Vec::new(),
+                None => b"<unknown>".to_vec(),
             };
             let found = match state.get_file_tx_by_fuid(&file_fid, STREAM_TOSERVER) {
                 Some((tx, files, flags)) => {

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -565,6 +565,79 @@ named!(pub parse_smb_create_andx_request_record<SmbRequestCreateAndXRecord>,
 );
 
 #[derive(Debug,PartialEq)]
+pub struct Trans2RecordParamSetFileInfo<'a> {
+    pub fid: &'a[u8],
+    pub loi: u16,
+}
+
+named!(pub parse_trans2_request_params_set_file_info<Trans2RecordParamSetFileInfo>,
+    do_parse!(
+            fid: take!(2)
+        >>  loi: le_u16
+        >> (Trans2RecordParamSetFileInfo {
+                fid:fid,
+                loi:loi,
+            })
+));
+
+#[derive(Debug,PartialEq)]
+pub struct Trans2RecordParamSetFileInfoRename<'a> {
+    pub replace: bool,
+    pub newname: &'a[u8],
+}
+
+named!(pub parse_trans2_request_data_set_file_info_rename<Trans2RecordParamSetFileInfoRename>,
+    do_parse!(
+            replace: le_u8
+        >>  _reserved: take!(3)
+        >>  root_dir: take!(4)
+        >>  newname_len: le_u32
+        >>  newname: take!(newname_len)
+        >> (Trans2RecordParamSetFileInfoRename {
+                replace: replace==1,
+                newname: newname,
+            })
+));
+
+#[derive(Debug,PartialEq)]
+pub struct SmbRequestTrans2Record<'a> {
+    pub subcmd: u16,
+    pub setup_blob: &'a[u8],
+    pub data_blob: &'a[u8],
+}
+
+named!(pub parse_smb_trans2_request_record<SmbRequestTrans2Record>,
+    do_parse!(
+            wct: le_u8
+        >>  total_param_cnt: le_u16
+        >>  total_data_cnt: le_u16
+        >>  max_param_cnt: le_u16
+        >>  max_data_cnt: le_u16
+        >>  max_setup_cnt: le_u8
+        >>  _reserved1: take!(1)
+        >>  flags: le_u16
+        >>  timeout: le_u32
+        >>  _reserved2: take!(2)
+        >>  param_cnt: le_u16
+        >>  param_offset: le_u16
+        >>  data_cnt: le_u16
+        >>  data_offset: le_u16
+        >>  setup_cnt: le_u8
+        >>  _reserved3: take!(1)
+        >>  subcmd: le_u16
+        >>  bcc: le_u16
+        >>  _padding: take!(3)
+        >>  setup_blob: take!(param_cnt)
+        >>  data_blob: take!(data_cnt)
+
+        >> (SmbRequestTrans2Record {
+                subcmd: subcmd,
+                setup_blob: setup_blob,
+                data_blob: data_blob,
+           }))
+);
+
+#[derive(Debug,PartialEq)]
 pub struct SmbResponseCreateAndXRecord<'a> {
     pub fid: &'a[u8],
     pub create_ts: SMBFiletime,

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -520,6 +520,27 @@ named!(pub parse_smb_read_andx_response_record<SmbResponseReadAndXRecord>,
 );
 
 #[derive(Debug,PartialEq)]
+pub struct SmbRequestRenameRecord {
+    pub oldname: Vec<u8>,
+    pub newname: Vec<u8>,
+}
+
+named!(pub parse_smb_rename_request_record<SmbRequestRenameRecord>,
+    do_parse!(
+            wct: le_u8
+        >>  search_attr: le_u16
+        >>  bcc: le_u16
+        >>  oldtype: le_u8
+        >>  oldname: smb_get_unicode_string
+        >>  newtype: le_u8
+        >>  newname: apply!(smb_get_unicode_string_with_offset, 1) // HACK if we assume oldname is a series of utf16 chars offset would be 1
+        >> (SmbRequestRenameRecord {
+                oldname: oldname,
+                newname: newname,
+           }))
+);
+
+#[derive(Debug,PartialEq)]
 pub struct SmbRequestCreateAndXRecord<'a> {
     pub disposition: u32,
     pub create_options: u32,

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -170,7 +170,7 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                 } else {
                     let file_name = match state.guid2name_map.get(&file_guid) {
                         Some(n) => { n.to_vec() },
-                        None => { Vec::new() },
+                        None => { b"<unknown>".to_vec() },
                     };
                     let (tx, files, flags) = state.new_file_tx(&file_guid, &file_name, STREAM_TOCLIENT);
                     if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {


### PR DESCRIPTION
Describe changes:
- add support for renames: SMB1 RENAME command, TRANS2 set file info rename and SMB2 SET_INFO rename

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/111
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/113
