### PR TITLE
SMB: simplifications and use kerberos 01

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -18,6 +18,7 @@ debug = []
 nom = "~3.2.1"
 libc = "^0.2.36"
 crc = "~1.7.0"
-der-parser = "0.5.1"
+der-parser = "0.5.2"
+kerberos-parser = "0.1.0"
 
 ntp-parser = { version = "^0", optional = true }

--- a/rust/src/smb/log.rs
+++ b/rust/src/smb/log.rs
@@ -42,12 +42,10 @@ fn fuid_to_string(fuid: &Vec<u8>) -> String {
     if fuid_len == 16 {
         guid_to_string(fuid)
     } else if fuid_len == 2 {
-        let o = format!("{:02x}{:02x}", fuid[1], fuid[0]);
-        o.to_string()
+        format!("{:02x}{:02x}", fuid[1], fuid[0])
     } else if fuid_len == 6 {
         let pure_fid = &fuid[0..2];
-        let o = format!("{:02x}{:02x}", pure_fid[1], pure_fid[0]);
-        o.to_string()
+        format!("{:02x}{:02x}", pure_fid[1], pure_fid[0])
     } else {
         "".to_string()
     }
@@ -76,13 +74,8 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
         js.set_string("dialect", &dialect);
     } else {
         let dialect = match &state.dialect_vec {
-            &Some(ref d) => {
-                match str::from_utf8(&d) {
-                    Ok(v) => v,
-                    Err(_) => "invalid",
-                }
-            },
-            &None => { "unknown" },
+            &Some(ref d) => str::from_utf8(&d).unwrap_or("invalid"),
+            &None        => "unknown",
         };
         js.set_string("dialect", &dialect);
     }

--- a/rust/src/smb/log.rs
+++ b/rust/src/smb/log.rs
@@ -173,18 +173,10 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
 
             if let Some(ref ticket) = x.krb_ticket {
                 let jsd = Json::object();
-                let realm = match str::from_utf8(&ticket.realm) {
-                    Ok(v) => v,
-                    Err(_) => "UTF8_ERROR",
-                };
-                jsd.set_string("realm", &realm);
+                jsd.set_string("realm", &ticket.realm.0);
                 let jsa = Json::array();
-                for sname in &ticket.snames {
-                    let name = match str::from_utf8(&sname) {
-                        Ok(v) => v,
-                        Err(_) => "UTF8_ERROR",
-                    };
-                    jsa.array_append_string(&name);
+                for sname in ticket.sname.name_string.iter() {
+                    jsa.array_append_string(&sname);
                 }
                 jsd.set("snames", jsa);
                 js.set("kerberos", jsd);

--- a/rust/src/smb/log.rs
+++ b/rust/src/smb/log.rs
@@ -146,22 +146,13 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
         Some(SMBTransactionTypeData::SESSIONSETUP(ref x)) => {
             if let Some(ref ntlmssp) = x.ntlmssp {
                 let jsd = Json::object();
-                let domain = match str::from_utf8(&ntlmssp.domain) {
-                    Ok(v) => v,
-                    Err(_) => "UTF8_ERROR",
-                };
+                let domain = String::from_utf8_lossy(&ntlmssp.domain);
                 jsd.set_string("domain", &domain);
 
-                let user = match str::from_utf8(&ntlmssp.user) {
-                    Ok(v) => v,
-                    Err(_) => "UTF8_ERROR",
-                };
+                let user = String::from_utf8_lossy(&ntlmssp.user);
                 jsd.set_string("user", &user);
 
-                let host = match str::from_utf8(&ntlmssp.host) {
-                    Ok(v) => v,
-                    Err(_) => "UTF8_ERROR",
-                };
+                let host = String::from_utf8_lossy(&ntlmssp.host);
                 jsd.set_string("host", &host);
 
                 if let Some(ref v) = ntlmssp.version {
@@ -185,15 +176,9 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
             match x.request_host {
                 Some(ref r) => {
                     let jsd = Json::object();
-                    let os = match str::from_utf8(&r.native_os) {
-                        Ok(v) => v,
-                            Err(_) => "UTF8_ERROR",
-                    };
+                    let os = String::from_utf8_lossy(&r.native_os);
                     jsd.set_string("native_os", &os);
-                    let lm = match str::from_utf8(&r.native_lm) {
-                        Ok(v) => v,
-                            Err(_) => "UTF8_ERROR",
-                    };
+                    let lm = String::from_utf8_lossy(&r.native_lm);
                     jsd.set_string("native_lm", &lm);
                     js.set("request", jsd);
                 },
@@ -202,15 +187,9 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
             match x.response_host {
                 Some(ref r) => {
                     let jsd = Json::object();
-                    let os = match str::from_utf8(&r.native_os) {
-                        Ok(v) => v,
-                            Err(_) => "UTF8_ERROR",
-                    };
+                    let os = String::from_utf8_lossy(&r.native_os);
                     jsd.set_string("native_os", &os);
-                    let lm = match str::from_utf8(&r.native_lm) {
-                        Ok(v) => v,
-                            Err(_) => "UTF8_ERROR",
-                    };
+                    let lm = String::from_utf8_lossy(&r.native_lm);
                     jsd.set_string("native_lm", &lm);
                     js.set("response", jsd);
                 },

--- a/rust/src/smb/mod.rs
+++ b/rust/src/smb/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+extern crate kerberos_parser;
+
 pub mod smb_records;
 pub mod smb1_records;
 pub mod smb2_records;

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -31,13 +31,11 @@ fn smb_get_unicode_string_with_offset(i: &[u8], offset: usize) -> IResult<&[u8],
 
 /// take a string, unicode or ascii based on record
 pub fn smb1_get_string<'a>(i: &'a[u8], r: &SmbRecord, offset: usize) -> IResult<&'a[u8], Vec<u8>> {
-    do_parse!(i,
-          u: value!(r.has_unicode_support())
-       >> s: switch!(value!(u),
-                true => apply!(smb_get_unicode_string_with_offset, offset) |
-                false => call!(smb_get_ascii_string))
-       >> ( s )
-    )
+    if r.has_unicode_support() {
+        smb_get_unicode_string_with_offset(i, offset)
+    } else {
+        smb_get_ascii_string(i)
+    }
 }
 
 #[derive(Debug,PartialEq)]


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
not applicable

Describe changes:
- Use the `kerberos-parser` crate to factorize the parsing of Kerberos elements (AP-REQ, Tickets, Realm and PrincipalName).
- Simplify parsing of DER elements
- Some cosmetic changes

Overall, there is no change in behavior and/or results.