### PR TITLE
source-pcap-file: Missing pcap file will stop pcap thread under unix socket (bug #2451) v2

### DIFF
--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -180,24 +180,31 @@ TmEcode ReceivePcapFileLoop(ThreadVars *tv, void *data, void *slot)
 
     SCLogDebug("Pcap file loop complete with status %u", status);
 
-    SCReturnInt(PcapFileExit(status));
+    status = PcapFileExit(status);
+
+    SCReturnInt(status);
 }
 
 TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
     SCEnter();
 
+    TmEcode status = TM_ECODE_OK;
     const char *tmpstring = NULL;
     const char *tmp_bpf_string = NULL;
 
     if (initdata == NULL) {
         SCLogError(SC_ERR_INVALID_ARGUMENT, "error: initdata == NULL");
-        SCReturnInt(PcapFileExit(TM_ECODE_FAILED));
+
+        status = PcapFileExit(TM_ECODE_FAILED);
+        SCReturnInt(status);
     }
 
     PcapFileThreadVars *ptv = SCMalloc(sizeof(PcapFileThreadVars));
-    if (unlikely(ptv == NULL))
-        SCReturnInt(PcapFileExit(TM_ECODE_FAILED));
+    if (unlikely(ptv == NULL)) {
+        status = PcapFileExit(TM_ECODE_FAILED);
+        SCReturnInt(status);
+    }
     memset(ptv, 0, sizeof(PcapFileThreadVars));
     memset(&ptv->shared.last_processed, 0, sizeof(struct timespec));
 
@@ -218,7 +225,9 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
         if (unlikely(ptv->shared.bpf_string == NULL)) {
             SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate bpf_string");
             CleanupPcapFileThreadVars(ptv);
-            SCReturnInt(PcapFileExit(TM_ECODE_FAILED));
+
+            status = PcapFileExit(TM_ECODE_FAILED);
+            SCReturnInt(status);
         }
     }
 
@@ -226,7 +235,8 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
     SCLogInfo("Checking file or directory %s", (char*)initdata);
     if(PcapDetermineDirectoryOrFile((char *)initdata, &directory) == TM_ECODE_FAILED) {
         CleanupPcapFileThreadVars(ptv);
-        SCReturnInt(PcapFileExit(TM_ECODE_FAILED));
+        status = PcapFileExit(TM_ECODE_FAILED);
+        SCReturnInt(status);
     }
 
     if(directory == NULL) {
@@ -235,7 +245,8 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
         if (unlikely(pv == NULL)) {
             SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate file vars");
             CleanupPcapFileThreadVars(ptv);
-            SCReturnInt(PcapFileExit(TM_ECODE_FAILED));
+            status = PcapFileExit(TM_ECODE_FAILED);
+            SCReturnInt(status);
         }
         memset(pv, 0, sizeof(PcapFileFileVars));
 
@@ -244,11 +255,12 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
             SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate filename");
             CleanupPcapFileFileVars(pv);
             CleanupPcapFileThreadVars(ptv);
-            SCReturnInt(PcapFileExit(TM_ECODE_FAILED));
+            status = PcapFileExit(TM_ECODE_FAILED);
+            SCReturnInt(status);
         }
 
-        TmEcode init_file_return = InitPcapFile(pv);
-        if(init_file_return == TM_ECODE_OK) {
+        status = InitPcapFile(pv);
+        if(status == TM_ECODE_OK) {
             pv->shared = &ptv->shared;
 
             ptv->is_directory = 0;
@@ -258,7 +270,9 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
                          "Failed to init pcap file %s, skipping", (char *)initdata);
             CleanupPcapFileFileVars(pv);
             CleanupPcapFileThreadVars(ptv);
-            SCReturnInt(PcapFileExit(init_file_return));
+
+            status = PcapFileExit(status);
+            SCReturnInt(status);
         }
     } else {
         SCLogInfo("Argument %s was a directory", (char *)initdata);
@@ -267,7 +281,8 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
             SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate directory vars");
             closedir(directory);
             CleanupPcapFileThreadVars(ptv);
-            SCReturnInt(PcapFileExit(TM_ECODE_FAILED));
+            status = PcapFileExit(TM_ECODE_FAILED);
+            SCReturnInt(status);
         }
         memset(pv, 0, sizeof(PcapFileDirectoryVars));
 
@@ -276,7 +291,8 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
             SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate filename");
             CleanupPcapFileDirectoryVars(pv);
             CleanupPcapFileThreadVars(ptv);
-            SCReturnInt(PcapFileExit(TM_ECODE_FAILED));
+            status = PcapFileExit(TM_ECODE_FAILED);
+            SCReturnInt(status);
         }
 
         int should_loop = 0;


### PR DESCRIPTION
Version 2 of:
 * https://github.com/OISF/suricata/pull/3257

https://redmine.openinfosecfoundation.org/issues/2451

When a missing (or empty named) file is passed to source-pcap-file while
using unix socket, the pcap processing thread will incorrectly be stopped,
and no longer available for subsequent files.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2451

Describe changes:
- When running under unix socket, don't return failed.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

