### PR TITLE
unix-socket: dynamic adjustment of polling timeout

### DIFF
--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -402,6 +402,8 @@ static TmEcode UnixSocketAddPcapFileImpl(json_t *cmd, json_t* answer, void *data
             SCLogInfo("Added file '%s' to list", filename);
             json_object_set_new(answer, "message",
                                 json_string("Successfully added file to list"));
+            /* Increase polling speed */
+            UnixManagerSetTimeout(TIMEOUT_INCREASE_SEC, TIMEOUT_INCREASE_USEC);
             return TM_ECODE_OK;
     }
     return TM_ECODE_OK;
@@ -475,6 +477,8 @@ static TmEcode UnixSocketPcapFilesCheck(void *data)
 
     if (TAILQ_EMPTY(&this->files)) {
         // nothing to do
+        /* When idle, reset timeout */
+        UnixManagerSetTimeout(TIMEOUT_DEFAULT_SEC, TIMEOUT_DEFAULT_USEC);
         return TM_ECODE_OK;
     }
 

--- a/src/unix-manager.h
+++ b/src/unix-manager.h
@@ -30,6 +30,12 @@
 
 #define UNIX_CMD_TAKE_ARGS 1
 
+/* Timeout for polling */
+#define TIMEOUT_DEFAULT_SEC   0
+#define TIMEOUT_DEFAULT_USEC (200*1000)
+#define TIMEOUT_INCREASE_SEC 0
+#define TIMEOUT_INCREASE_USEC 100
+
 SCCtrlCondT unix_manager_ctrl_cond;
 SCCtrlMutex unix_manager_ctrl_mutex;
 
@@ -44,6 +50,9 @@ TmEcode UnixManagerRegisterCommand(const char * keyword,
 TmEcode UnixManagerRegisterBackgroundTask(
         TmEcode (*Func)(void *),
         void *data);
+TmEcode UnixManagerSetTimeout(
+        int seconds,
+        int microseconds);
 #endif
 
 void TmModuleUnixManagerRegister(void);


### PR DESCRIPTION
Whenever a pcap is received, reduce the polling timeout. If no pcap is
available, reset the polling timeout to its standard value.
It allows suricata to be able to process multiple pcaps faster, while
reducing its CPU time whenever suricata does not have any work to do.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2460

Describe changes:
- reduce polling timeout whenever a pcap is received on the unix-socket
- increase polling timeout if the queue is empty

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

