### PR TITLE
configure: allow to disable libnss and libnspr

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1586,15 +1586,8 @@
     fi
 
   # libnspr
-    enable_nspr="no"
-
-    # Try pkg-config first:
-    PKG_CHECK_MODULES([libnspr], nspr,, [with_pkgconfig_nspr=no])
-    if test "$with_pkgconfig_nspr" != "no"; then
-        CPPFLAGS="${CPPFLAGS} ${libnspr_CFLAGS}"
-        LIBS="${LIBS} ${libnspr_LIBS}"
-    fi
-
+    AC_ARG_ENABLE(nspr,
+            AS_HELP_STRING([--disable-nspr],[Disable libnspr support]))
     AC_ARG_WITH(libnspr_includes,
             [  --with-libnspr-includes=DIR  libnspr include directory],
             [with_libnspr_includes="$withval"],[with_libnspr_includes=no])
@@ -1602,41 +1595,43 @@
             [  --with-libnspr-libraries=DIR    libnspr library directory],
             [with_libnspr_libraries="$withval"],[with_libnspr_libraries="no"])
 
-    if test "$with_libnspr_includes" != "no"; then
-        CPPFLAGS="${CPPFLAGS} -I${with_libnspr_includes}"
-    fi
+    if test "$enable_nspr" != "no"; then
+      # Try pkg-config first:
+      PKG_CHECK_MODULES([libnspr], nspr,, [with_pkgconfig_nspr=no])
+      if test "$with_pkgconfig_nspr" != "no"; then
+          CPPFLAGS="${CPPFLAGS} ${libnspr_CFLAGS}"
+          LIBS="${LIBS} ${libnspr_LIBS}"
+      fi
 
-    AC_CHECK_HEADER(nspr.h,NSPR="yes",NSPR="no")
-    if test "$NSPR" = "yes"; then
-        if test "$with_libnspr_libraries" != "no"; then
-            LDFLAGS="${LDFLAGS}  -L${with_libnspr_libraries}"
-        fi
+      if test "$with_libnspr_includes" != "no"; then
+          CPPFLAGS="${CPPFLAGS} -I${with_libnspr_includes}"
+      fi
 
-        AC_CHECK_LIB(nspr4, PR_GetCurrentThread,, NSPR="no")
+      AC_CHECK_HEADER(nspr.h,NSPR="yes",NSPR="no")
+      if test "$NSPR" = "yes"; then
+          if test "$with_libnspr_libraries" != "no"; then
+              LDFLAGS="${LDFLAGS}  -L${with_libnspr_libraries}"
+          fi
 
-        if test "$NSPR" = "no"; then
-            echo
-            echo "   ERROR!  libnspr library not found, go get it"
-            echo "   from Mozilla or your distribution:"
-            echo
-            echo "   Ubuntu: apt-get install libnspr4-dev"
-            echo "   Fedora: yum install nspr-devel"
-            echo
-            exit 1
-        fi
-        enable_nspr="yes"
+          AC_CHECK_LIB(nspr4, PR_GetCurrentThread,, NSPR="no")
+
+          if test "$NSPR" = "no"; then
+              echo
+              echo "   ERROR!  libnspr library not found, go get it"
+              echo "   from Mozilla or your distribution:"
+              echo
+              echo "   Ubuntu: apt-get install libnspr4-dev"
+              echo "   Fedora: yum install nspr-devel"
+              echo
+              exit 1
+          fi
+          enable_nspr="yes"
+      fi
     fi
 
   # libnss
-    enable_nss="no"
-
-    # Try pkg-config first:
-    PKG_CHECK_MODULES([libnss], nss,, [with_pkgconfig_nss=no])
-    if test "$with_pkgconfig_nss" != "no"; then
-        CPPFLAGS="${CPPFLAGS} ${libnss_CFLAGS}"
-        LIBS="${LIBS} ${libnss_LIBS}"
-    fi
-
+    AC_ARG_ENABLE(nss,
+            AS_HELP_STRING([--disable-nss],[Disable libnss support]))
     AC_ARG_WITH(libnss_includes,
             [  --with-libnss-includes=DIR  libnss include directory],
             [with_libnss_includes="$withval"],[with_libnss_includes=no])
@@ -1644,31 +1639,40 @@
             [  --with-libnss-libraries=DIR    libnss library directory],
             [with_libnss_libraries="$withval"],[with_libnss_libraries="no"])
 
-    if test "$with_libnss_includes" != "no"; then
-        CPPFLAGS="${CPPFLAGS} -I${with_libnss_includes}"
-    fi
+    if test "$enable_nss" != "no"; then
+      # Try pkg-config first:
+      PKG_CHECK_MODULES([libnss], nss,, [with_pkgconfig_nss=no])
+      if test "$with_pkgconfig_nss" != "no"; then
+          CPPFLAGS="${CPPFLAGS} ${libnss_CFLAGS}"
+          LIBS="${LIBS} ${libnss_LIBS}"
+      fi
 
-    AC_CHECK_HEADER(sechash.h,NSS="yes",NSS="no")
-    if test "$NSS" = "yes"; then
-        if test "$with_libnss_libraries" != "no"; then
-            LDFLAGS="${LDFLAGS}  -L${with_libnss_libraries}"
-        fi
+      if test "$with_libnss_includes" != "no"; then
+          CPPFLAGS="${CPPFLAGS} -I${with_libnss_includes}"
+      fi
 
-        AC_CHECK_LIB(nss3, HASH_Begin,, NSS="no")
+      AC_CHECK_HEADER(sechash.h,NSS="yes",NSS="no")
+      if test "$NSS" = "yes"; then
+          if test "$with_libnss_libraries" != "no"; then
+              LDFLAGS="${LDFLAGS}  -L${with_libnss_libraries}"
+          fi
 
-        if test "$NSS" = "no"; then
-            echo
-            echo "   ERROR!  libnss library not found, go get it"
-            echo "   from Mozilla or your distribution:"
-            echo
-            echo "   Ubuntu: apt-get install libnss3-dev"
-            echo "   Fedora: yum install nss-devel"
-            echo
-            exit 1
-        fi
+          AC_CHECK_LIB(nss3, HASH_Begin,, NSS="no")
 
-        AC_DEFINE([HAVE_NSS],[1],[libnss available for md5])
-        enable_nss="yes"
+          if test "$NSS" = "no"; then
+              echo
+              echo "   ERROR!  libnss library not found, go get it"
+              echo "   from Mozilla or your distribution:"
+              echo
+              echo "   Ubuntu: apt-get install libnss3-dev"
+              echo "   Fedora: yum install nss-devel"
+              echo
+              exit 1
+          fi
+
+          AC_DEFINE([HAVE_NSS],[1],[libnss available for md5])
+          enable_nss="yes"
+      fi
     fi
 
   # libmagic


### PR DESCRIPTION
Let user chose to disable libnss and libnspr support even if these
libraries are installed in the system. Default remains to enable when
libraries are found and disable parameter were not used

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

https://redmine.openinfosecfoundation.org/issues/2461

Describe changes:
Since libnss and libnspr are not mandatory, there is an option on FreeBSD ports tree to let user to chose to disable it during build phase. It works as expected when building binary packages on a clean environment. When user build the port locally and has one of these libraries installed in the system, if it choses to disable them, configure script doesn't provide a explicit option to have it disabled and then binary package ends up broken because it has binaries linked against these libraries but doesn't have the correct dependency registered to make sure nss/nspr are installed on the system.

This change adds 2 new configure parameters: `--disable-nss` and `--disable-nspr`. When they are used it will not link against respective libraries. The default behavior is not changed.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

