### PR TITLE
doc: fix typo for various sections

### DIFF
--- a/doc/userguide/configuration/global-thresholds.rst
+++ b/doc/userguide/configuration/global-thresholds.rst
@@ -197,9 +197,9 @@ Each of these will replace the threshold setting for 2002087 by the
 new threshold setting.
 
 **Note:** overriding all gids or sids (by using gen_id 0 or sig_id 0)
-is not supported. Bug #425.
+is not supported. Bug https://redmine.openinfosecfoundation.org/issues/425.
 
 Rate_filter
 ~~~~~~~~~~~
 
-TODO
+see https://redmine.openinfosecfoundation.org/issues/425.

--- a/doc/userguide/file-extraction/file-extraction.rst
+++ b/doc/userguide/file-extraction/file-extraction.rst
@@ -14,8 +14,9 @@ Supported protocols are:
 
 - HTTP
 - SMTP
-- NFS
 - FTP
+- NFS (with RUST activated)
+- SMB (with RUST activated)
 
 Settings
 ~~~~~~~~
@@ -142,7 +143,7 @@ Without rules in place no extraction will happen. The simplest rule would be:
 
 This will simply store all files to disk.
 
-Want to store all files with a pdf extension?
+Want to store all files with a pdf extension ?
 
 
 ::

--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -129,7 +129,7 @@ In addition to these fields, if the extended logging is enabled in the suricata.
 * "http_method": The HTTP method (ex: GET, POST, HEAD)
 * "http_refer": The referer for this action
 
-In addition to the extended logging fields one can also choose to enable/add from 50 additional custom logging HTTP fields enabled in the suricata.yaml file. The additional fields can be enabled as following:
+In addition to the extended logging fields one can also choose to enable/add more than 50 additional custom logging HTTP fields enabled in the suricata.yaml file. The additional fields can be enabled as following:
 
 
 ::
@@ -381,8 +381,8 @@ If extended logging is enabled the following fields are also included:
 * "fingerprint": The (SHA1) fingerprint of the TLS certificate
 * "sni": The Server Name Indication (SNI) extension sent by the client
 * "version": The SSL/TLS version used
-* "notbefore": The NotBefore field from the TLS certificate
-* "notafter": The NotAfter field from the TLS certificate
+* "not_before": The NotBefore field from the TLS certificate
+* "not_after": The NotAfter field from the TLS certificate
 * "ja3": The JA3 fingerprint consisting of both a JA3 hash and a JA3 string
 
 JA3 must be enabled in the Suricata config file (set 'app-layer.protocols.tls.ja3-fingerprints' to 'yes').

--- a/doc/userguide/reputation/ipreputation/ip-reputation.rst
+++ b/doc/userguide/reputation/ipreputation/ip-reputation.rst
@@ -6,9 +6,38 @@ IP Reputation
    ip-reputation-config
    ip-reputation-format
 
-The purpose of the IP reputation component is the ranking of IP Addresses within the Suricata Engine.  It will collect, store, update and distribute reputation intelligence on IP Addresses.  The hub and spoke architecture will allows the central database (The Hub) to collect, store and compile updated IP reputation details that are then distributed to user-side sensor databases (Spokes) for inclusion in user security systems.  The reputation data update frequency and security action taken, is defined in the user security configuration.
 
-The intent of IP Reputation is to allow sharing of intelligence regarding a vast number of IP addresses. This can be positive or negative intelligence classified into a number of categories. The technical implementation requires three major efforts; engine integration, the hub that redistributes reputation, and the communication protocol between hubs and sensors.  The hub will have a number of responsibilities. This will be a separate module running on a separate system as any sensor. Most often it would run on a central database that all sensors already have communication with. It will be able to subscribe to one or more external feeds.   The local admin should be able to define the feeds to be subscribed to, provide authentication credentials if required, and give a weight to that feed. The weight can be an overall number or a by category weight. This will allow the admin to minimize the influence a feed has on their overall reputation if they distrust a particular category or feed, or trust another implicitly. Feeds can be configured to accept feedback or not and will report so on connect. The admin can override and choose not to give any feedback, but the sensor should report these to the Hub upstream on connect.  The hub will take all of these feeds and aggregate them into an average single score for each IP or IP Block, and then redistribute this data to all local sensors as configured. It should receive connections from sensors. The sensor will have to provide authentication and will provide feedback. The hub should redistribute that feedback from sensors to all other sensors as well as up to any feeds that accept feedback.  The hub should also have an API to allow outside statistical analysis to be done to the database and fed back in to the stream. For instance a local site may choose to change the reputation on all Russian IP blocks, etc.
+The purpose of the IP reputation component is the ranking of IP Addresses within the Suricata Engine.
+
+It will collect, store, update and distribute reputation intelligence on IP Addresses.
+
+The hub and spoke architecture will allows the central database (the Hub) to collect, store and compile updated IP reputation details that are then distributed to user-side sensor databases (Spokes) for inclusion in user security systems.
+
+The reputation data update frequency and security action taken, is defined in the user security configuration.
+
+The intent of IP Reputation is to allow sharing of intelligence regarding a vast number of IP addresses.
+
+This can be positive or negative intelligence classified into a number of categories.
+
+The technical implementation requires three major efforts: engine integration, the hub that redistributes reputation, and the communication protocol between hubs and sensors.
+
+The hub will have a number of responsibilities. This will be a separate module running on a separate system as any sensor.
+Most often it would run on a central database that all sensors already have communication with.
+It will be able to subscribe to one or more external feeds.
+
+The local admin should be able to define the feeds to be subscribed to, provide authentication credentials if required, and give a weight to that feed.
+The weight can be an overall number or a by category weight.
+This will allow the admin to minimize the influence a feed has on their overall reputation if they distrust a particular category or feed, or trust another implicitly.
+
+Feeds can be configured to accept feedback or not and will report so on connect.
+The admin can override and choose not to give any feedback, but the sensor should report these to the Hub upstream on connect.
+The hub will take all of these feeds and aggregate them into an average single score for each IP or IP Block, and then redistribute this data to all local sensors as configured.
+It should receive connections from sensors. The sensor will have to provide authentication and will provide feedback.
+
+The hub should redistribute that feedback from sensors to all other sensors as well as up to any feeds that accept feedback.
+The hub should also have an API to allow outside statistical analysis to be done to the database and fed back in to the stream.
+
+For instance a local site may choose to change the reputation on all Russian IP blocks, etc.
 
 
 For more information about IP Reputation see :doc:`ip-reputation-config`, :doc:`/rules/ip-reputation-rules` and :doc:`ip-reputation-format`.

--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -157,7 +157,7 @@ The keywords offset and depth can be combined and are often used together.
 
 For example::
 
-  content; “def”; offset:3; depth:3;
+  content:“def”; offset:3; depth:3;
 
 If this was used in a signature, it would check the payload from the
 third byte till the sixth byte.

--- a/rules/files.rules
+++ b/rules/files.rules
@@ -50,3 +50,12 @@
 #alert http any any -> any any (msg:"Black list checksum match and extract MD5"; filemd5:fileextraction-chksum.list; filestore; sid:28; rev:1;)
 #alert http any any -> any any (msg:"Black list checksum match and extract SHA1"; filesha1:fileextraction-chksum.list; filestore; sid:29; rev:1;)
 #alert http any any -> any any (msg:"Black list checksum match and extract SHA256"; filesha256:fileextraction-chksum.list; filestore; sid:30; rev:1;)
+
+# Alert and store files over FTP
+#alert ftp-data any any -> any any (msg:"File Found within FTP and stored"; filestore; filename:"password"; ftpdata_command:stor; sid:31; rev:1;)
+
+# Alert and store files over SMB (with RUST activated)
+#alert smb any any -> any any (msg:"File Found over SMB and stored"; filestore; sid:32; rev:1;)
+
+# Alert and store files over NFS (with RUST activated)
+#alert nfs any any -> any any (msg:"File found within NFS and stored"; filestore; sid:33; rev:1;)


### PR DESCRIPTION
Fix minor typo in various section of documentation (filestore, iprep...)

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- various typo
- update files.rules with a few basic examples of filestore for ftp/smb/nfs.


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

