### PR TITLE
doc: minor updates (tls custom, ftp/smb file rules...)

### DIFF
--- a/doc/userguide/configuration/global-thresholds.rst
+++ b/doc/userguide/configuration/global-thresholds.rst
@@ -202,9 +202,9 @@ Each of these will replace the threshold setting for 2002087 by the
 new threshold setting.
 
 **Note:** overriding all gids or sids (by using gen_id 0 or sig_id 0)
-is not supported. Bug #425.
+is not supported. Bug https://redmine.openinfosecfoundation.org/issues/425.
 
 Rate_filter
 ~~~~~~~~~~~
 
-TODO
+see https://redmine.openinfosecfoundation.org/issues/425.

--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -381,8 +381,8 @@ If extended logging is enabled the following fields are also included:
 * "fingerprint": The (SHA1) fingerprint of the TLS certificate
 * "sni": The Server Name Indication (SNI) extension sent by the client
 * "version": The SSL/TLS version used
-* "notbefore": The NotBefore field from the TLS certificate
-* "notafter": The NotAfter field from the TLS certificate
+* "not_before": The NotBefore field from the TLS certificate
+* "not_after": The NotAfter field from the TLS certificate
 * "ja3": The JA3 fingerprint consisting of both a JA3 hash and a JA3 string
 
 JA3 must be enabled in the Suricata config file (set 'app-layer.protocols.tls.ja3-fingerprints' to 'yes').

--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -157,7 +157,7 @@ The keywords offset and depth can be combined and are often used together.
 
 For example::
 
-  content; “def”; offset:3; depth:3;
+  content:“def”; offset:3; depth:3;
 
 If this was used in a signature, it would check the payload from the
 third byte till the sixth byte.

--- a/rules/files.rules
+++ b/rules/files.rules
@@ -50,3 +50,12 @@
 #alert http any any -> any any (msg:"Black list checksum match and extract MD5"; filemd5:fileextraction-chksum.list; filestore; sid:28; rev:1;)
 #alert http any any -> any any (msg:"Black list checksum match and extract SHA1"; filesha1:fileextraction-chksum.list; filestore; sid:29; rev:1;)
 #alert http any any -> any any (msg:"Black list checksum match and extract SHA256"; filesha256:fileextraction-chksum.list; filestore; sid:30; rev:1;)
+
+# Alert and store files over FTP
+#alert ftp-data any any -> any any (msg:"File Found within FTP and stored"; filestore; filename:"password"; ftpdata_command:stor; sid:31; rev:1;)
+
+# Alert and store files over SMB (with RUST activated)
+#alert smb any any -> any any (msg:"File Found over SMB and stored"; filestore; sid:32; rev:1;)
+
+# Alert and store files over NFS (with RUST activated)
+#alert nfs any any -> any any (msg:"File found within NFS and stored"; filestore; sid:33; rev:1;)


### PR DESCRIPTION
A few doc minor updates, correction of PR https://github.com/OISF/suricata/pull/3319.
IP reputation doc update will come later.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- doc update: TODO removal
- doc update: correction of notbefore/notafter for extented TLS
- doc update: rule example mistake
- file.rules : add smb and ftp examples

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

