### PR TITLE
IP reputation updatex through unix-socket v1

### DIFF
--- a/doc/userguide/unix-socket.rst
+++ b/doc/userguide/unix-socket.rst
@@ -78,6 +78,7 @@ The set of existing commands is the following:
 * memcap-set: update memcap value of an item specified
 * memcap-show: show memcap value of an item specified
 * memcap-list: list all memcap values available
+* iprep-add: add an IP address to the IP reputation module
 
 You can access to these commands with the provided example script which
 is named ``suricatasc``. A typical session with ``suricatasc`` will looks like:

--- a/python/suricata/sc/suricatasc.py
+++ b/python/suricata/sc/suricatasc.py
@@ -80,7 +80,7 @@ class SuricataCompleter:
 
 class SuricataSC:
     def __init__(self, sck_path, verbose=False):
-        self.cmd_list=['shutdown','quit','pcap-file','pcap-file-continuous','pcap-file-number','pcap-file-list','pcap-last-processed','pcap-interrupt','iface-list','iface-stat','register-tenant','unregister-tenant','register-tenant-handler','unregister-tenant-handler', 'add-hostbit', 'remove-hostbit', 'list-hostbit', 'memcap-set', 'memcap-show']
+        self.cmd_list=['shutdown','quit','pcap-file','pcap-file-continuous','pcap-file-number','pcap-file-list','pcap-last-processed','pcap-interrupt','iface-list','iface-stat','register-tenant','unregister-tenant','register-tenant-handler','unregister-tenant-handler', 'add-hostbit', 'remove-hostbit', 'list-hostbit', 'memcap-set', 'memcap-show', 'iprep-add']
         self.sck_path = sck_path
         self.verbose = verbose
 
@@ -352,6 +352,18 @@ class SuricataSC:
                 else:
                     arguments = {}
                     arguments["config"] = config
+            elif "iprep-add" in command:
+                try:
+                    [cmd, ipaddress, category, value] = command.split(' ', 3)
+                except:
+                    raise SuricataCommandException("Arguments to command '%s' is missing" % (command))
+                if cmd != "iprep-add":
+                    raise SuricataCommandException("Invalid command '%s'" % (command))
+                else:
+                    arguments = {}
+                    arguments["ipaddress"] = ipaddress;
+                    arguments["category"] = int(category);
+                    arguments["value"] = int(value);
             else:
                 cmd = command
         else:

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -325,7 +325,7 @@ static int SRepSplitLine(SRepCIDRTree *cidr_ctx, char *line, Address *ip, uint8_
     }
 
     int v = atoi(ptrs[2]);
-    if (v < 0 || v > 127) {
+    if (v < 0 || v > SREP_MAX_VAL) {
         return -1;
     }
 
@@ -446,6 +446,54 @@ static int SRepLoadFile(SRepCIDRTree *cidr_ctx, char *filename)
 
 }
 
+static void SRepLoadLine(Address *a, int cat, int value)
+{
+    Host *h = HostGetHostFromHash(a);
+    if (h == NULL) {
+        SCLogError(SC_ERR_NO_REPUTATION, "failed to get a host, increase host.memcap");
+        return;
+    } else {
+        //SCLogInfo("host %p", h);
+
+        if (h->iprep == NULL) {
+            h->iprep = SCMalloc(sizeof(SReputation));
+            if (h->iprep != NULL) {
+                memset(h->iprep, 0x00, sizeof(SReputation));
+
+                HostIncrUsecnt(h);
+            }
+        }
+        if (h->iprep != NULL) {
+            SReputation *rep = h->iprep;
+
+            /* if version is outdated, it's an older entry that we'll
+             * now replace. */
+            if (rep->version != SRepGetVersion()) {
+                memset(rep, 0x00, sizeof(SReputation));
+            }
+
+            rep->version = SRepGetVersion();
+            rep->rep[cat] = value;
+
+            SCLogDebug("host %p iprep %p setting cat %u to value %u",
+                h, h->iprep, cat, value);
+#ifdef DEBUG
+            if (SCLogDebugEnabled()) {
+                int i;
+                for (i = 0; i < SREP_MAX_CATS; i++) {
+                    if (rep->rep[i] == 0)
+                        continue;
+
+                        SCLogDebug("--> host %p iprep %p cat %d to value %u",
+                                h, h->iprep, i, rep->rep[i]);
+                }
+            }
+#endif
+        }
+        HostRelease(h);
+    }
+}
+
 int SRepLoadFileFromFD(SRepCIDRTree *cidr_ctx, FILE *fp)
 {
     char line[8192] = "";
@@ -487,53 +535,31 @@ int SRepLoadFileFromFD(SRepCIDRTree *cidr_ctx, FILE *fp)
                 PrintInet(AF_INET6, (const void *)&a.address, ipstr, sizeof(ipstr));
                 SCLogDebug("%s %u %u", ipstr, cat, value);
             }
-
-            Host *h = HostGetHostFromHash(&a);
-            if (h == NULL) {
-                SCLogError(SC_ERR_NO_REPUTATION, "failed to get a host, increase host.memcap");
-                break;
-            } else {
-                //SCLogInfo("host %p", h);
-
-                if (h->iprep == NULL) {
-                    h->iprep = SCMalloc(sizeof(SReputation));
-                    if (h->iprep != NULL) {
-                        memset(h->iprep, 0x00, sizeof(SReputation));
-
-                        HostIncrUsecnt(h);
-                    }
-                }
-                if (h->iprep != NULL) {
-                    SReputation *rep = h->iprep;
-
-                    /* if version is outdated, it's an older entry that we'll
-                     * now replace. */
-                    if (rep->version != SRepGetVersion()) {
-                        memset(rep, 0x00, sizeof(SReputation));
-                    }
-
-                    rep->version = SRepGetVersion();
-                    rep->rep[cat] = value;
-
-                    SCLogDebug("host %p iprep %p setting cat %u to value %u",
-                        h, h->iprep, cat, value);
-#ifdef DEBUG
-                    if (SCLogDebugEnabled()) {
-                        int i;
-                        for (i = 0; i < SREP_MAX_CATS; i++) {
-                            if (rep->rep[i] == 0)
-                                continue;
-
-                            SCLogDebug("--> host %p iprep %p cat %d to value %u",
-                                    h, h->iprep, i, rep->rep[i]);
-                        }
-                    }
-#endif
-                }
-
-                HostRelease(h);
-            }
+            SRepLoadLine(&a, cat, value);
         }
+    }
+
+    return 0;
+}
+
+int SRepLoadLineFromUnix(SRepCIDRTree *cidr_ctx,
+                         char *ipaddress,
+                         int cat, int val)
+{
+    if (strchr(ipaddress, '/') != NULL) {
+        int r = SRepCIDRAddNetblock(cidr_ctx, ipaddress, cat, val);
+        return r;
+    } else {
+        Address ip;
+        memset(&ip, 0, sizeof(ip));
+        if (inet_pton(AF_INET, ipaddress, &ip.address) == 1) {
+            ip.family = AF_INET;
+        } else if (inet_pton(AF_INET6, ipaddress, &ip.address) == 1) {
+            ip.family = AF_INET6;
+        } else {
+            return -1;
+        }
+        SRepLoadLine(&ip, cat, val);
     }
 
     return 0;

--- a/src/reputation.h
+++ b/src/reputation.h
@@ -29,6 +29,7 @@
 #include "host.h"
 
 #define SREP_MAX_CATS 60
+#define SREP_MAX_VAL  127
 
 typedef struct SRepCIDRTree_ {
     SCRadixTree *srepIPV4_tree[SREP_MAX_CATS];
@@ -87,6 +88,7 @@ uint8_t SRepCIDRGetIPRepDst(SRepCIDRTree *cidr_ctx, Packet *p, uint8_t cat, uint
 void SRepResetVersion(void);
 int SRepLoadCatFileFromFD(FILE *fp);
 int SRepLoadFileFromFD(SRepCIDRTree *cidr_ctx, FILE *fp);
+int SRepLoadLineFromUnix(SRepCIDRTree *cidr_ctx, char *ipaddress, int cat, int val);
 
 #if 0
 /** Reputation Data */

--- a/src/runmode-unix-socket.h
+++ b/src/runmode-unix-socket.h
@@ -42,6 +42,7 @@ TmEcode UnixSocketHostbitList(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketSetMemcap(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketShowMemcap(json_t *cmd, json_t *answer, void *data);
 TmEcode UnixSocketShowAllMemcap(json_t *cmd, json_t *answer, void *data);
+TmEcode UnixSocketIpReputationAdd(json_t *cmd, json_t* answer, void *data);
 #endif
 
 #endif /* __RUNMODE_UNIX_SOCKET_H__ */

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -1088,7 +1088,7 @@ int UnixManagerInit(void)
     UnixManagerRegisterCommand("memcap-set", UnixSocketSetMemcap, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("memcap-show", UnixSocketShowMemcap, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("memcap-list", UnixSocketShowAllMemcap, NULL, 0);
-
+    UnixManagerRegisterCommand("iprep-add", UnixSocketIpReputationAdd, &command, UNIX_CMD_TAKE_ARGS);
     return 0;
 }
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/659

Describe changes:
This patchset adds a new unix command that permits to update IP reputation through unix-socket.
The command syntax is: `iprep-add <IP> <cat> <value>`
IP reputation must be enabled in suricata configuration file, otherwise it won't be possible to run the command.
Some example below:
```
>>> iprep-add 192.168.1.1 1 30
Success:
"IP reputation updated."

>>> iprep-add 192.168.1.0/24 1 30
Success:
"IP reputation updated."

>>> iprep-add 1.1.1.1 100 10
Error:
"invalid category number"

>>> iprep-add 1.1.1.1 10 130
Error:
"invalid value"
```
[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/186
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/50
