### PR TITLE
files: properly close files on flow timeout

### DIFF
--- a/src/output-filedata.c
+++ b/src/output-filedata.c
@@ -152,6 +152,9 @@ static void OutputFiledataLogFfc(ThreadVars *tv, OutputLoggerThreadStore *store,
              * close the logger(s) */
             if (FileDataSize(ff) == ff->content_stored &&
                 (file_trunc || file_close)) {
+                if (ff->state < FILE_STATE_CLOSED) {
+                    FileCloseFilePtr(ff, NULL, 0, FILE_TRUNCATED);
+                }
                 CallLoggers(tv, store, p, ff, NULL, 0, OUTPUT_FILEDATA_FLAG_CLOSE);
                 ff->flags |= FILE_STORED;
                 continue;
@@ -171,7 +174,7 @@ static void OutputFiledataLogFfc(ThreadVars *tv, OutputLoggerThreadStore *store,
             /* if file needs to be closed or truncated, inform
              * loggers */
             if ((file_close || file_trunc) && ff->state < FILE_STATE_CLOSED) {
-                ff->state = FILE_STATE_TRUNCATED;
+                FileCloseFilePtr(ff, NULL, 0, FILE_TRUNCATED);
             }
 
             /* tell the logger we're closing up */

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -847,7 +847,7 @@ int FileOpenFileWithId(FileContainer *ffc, const StreamingBufferConfig *sbcfg,
     return 0;
 }
 
-static int FileCloseFilePtr(File *ff, const uint8_t *data,
+int FileCloseFilePtr(File *ff, const uint8_t *data,
         uint32_t data_len, uint16_t flags)
 {
     SCEnter();

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -145,6 +145,8 @@ int FileCloseFile(FileContainer *, const uint8_t *data, uint32_t data_len,
         uint16_t flags);
 int FileCloseFileById(FileContainer *, uint32_t track_id,
         const uint8_t *data, uint32_t data_len, uint16_t flags);
+int FileCloseFilePtr(File *ff, const uint8_t *data,
+        uint32_t data_len, uint16_t flags);
 
 /**
  *  \brief Store a chunk of file data in the flow. The open "flowfile"


### PR DESCRIPTION
If a file transfer stops on flow timeout, it won't be closed or
truncated. This patch makes sure that in such cases the files
are indeed truncated. This fixes the filestore-v2 output module,
as that requires a sha256 for storing the partial file correctly.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/127
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/129

