### PR TITLE
configure: fix error hw timestamp check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1355,7 +1355,7 @@
         AC_CHECK_DECL([SOF_TIMESTAMPING_RAW_HARDWARE],
             AC_DEFINE([HAVE_HW_TIMESTAMPING],[1],[Hardware timestamping support is available]),
             [],
-            [[#include <linux/net_tstamp.h>]]),
+            [[#include <linux/net_tstamp.h>]])
     ])
 
   # Netmap support


### PR DESCRIPTION
This fixes #2469

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- fix an error message in configure.ac

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/394
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/177

