### PR TITLE
fileinfo: fix IP parameters order in events

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -740,6 +740,17 @@ static int FTPDataParse(Flow *f, FtpDataState *ftpdata_state,
                          input, input_len, flags) == NULL) {
             SCLogDebug("Can't open file");
             ret = -1;
+        } else {
+            switch (data->cmd) {
+                case FTP_COMMAND_STOR:
+                    FileSetSide(ftpdata_state->files->tail, FILE_TO_SERVER);
+                    break;
+                case FTP_COMMAND_RETR:
+                    FileSetSide(ftpdata_state->files->tail, FILE_TO_CLIENT);
+                    break;
+                default:
+                    break;
+            }
         }
         FlowFreeStorageById(f, AppLayerExpectationGetDataId());
     } else {

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -145,6 +145,12 @@ int HTPFileOpen(HtpState *s, const uint8_t *filename, uint16_t filename_len,
 
     FileSetTx(files->tail, txid);
 
+    if (direction & STREAM_TOCLIENT) {
+        FileSetSide(files->tail, FILE_TO_CLIENT);
+    } else {
+        FileSetSide(files->tail, FILE_TO_SERVER);
+    }
+
     FilePrune(files);
 end:
     SCReturnInt(retval);

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -449,6 +449,8 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
                     (uint8_t *) chunk, len, flags) == NULL) {
                 ret = MIME_DEC_ERR_DATA;
                 SCLogDebug("FileOpenFile() failed");
+            } else {
+                FileSetSide(files->tail, FILE_TO_SERVER);
             }
             FlagDetectStateNewFile(smtp_state->curr_tx);
 

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -82,8 +82,23 @@ typedef struct JsonFileLogThread_ {
 json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
         const bool stored)
 {
-    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "fileinfo");
+    json_t *js = NULL;
     json_t *hjs = NULL;
+    enum OutputJsonLogDirection dir = LOG_DIR_FLOW;
+
+    switch (ff->side) {
+        case FILE_NO_SIDE:
+            dir = LOG_DIR_FLOW;
+            break;
+        case FILE_TO_SERVER:
+            dir = LOG_DIR_FLOW_TO_SERVER;
+            break;
+        case FILE_TO_CLIENT:
+            dir = LOG_DIR_FLOW_TO_CLIENT;
+            break;
+    }
+
+    js = CreateJSONHeader(p, dir, "fileinfo");
     if (unlikely(js == NULL))
         return NULL;
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -445,6 +445,68 @@ void JsonFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, json_t *js)
             sp = p->sp;
             dp = p->dp;
             break;
+        case LOG_DIR_FLOW_TO_CLIENT:
+            if ((PKT_IS_TOCLIENT(p))) {
+                if (PKT_IS_IPV4(p)) {
+                    PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                            dstip, sizeof(dstip));
+                } else if (PKT_IS_IPV6(p)) {
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                            dstip, sizeof(dstip));
+                }
+                sp = p->sp;
+                dp = p->dp;
+            } else {
+                if (PKT_IS_IPV4(p)) {
+                    PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                            dstip, sizeof(dstip));
+                } else if (PKT_IS_IPV6(p)) {
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                            dstip, sizeof(dstip));
+                }
+                sp = p->dp;
+                dp = p->sp;
+            }
+            break;
+        case LOG_DIR_FLOW_TO_SERVER:
+            if ((PKT_IS_TOSERVER(p))) {
+                if (PKT_IS_IPV4(p)) {
+                    PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                            dstip, sizeof(dstip));
+                } else if (PKT_IS_IPV6(p)) {
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                            dstip, sizeof(dstip));
+                }
+                sp = p->sp;
+                dp = p->dp;
+            } else {
+                if (PKT_IS_IPV4(p)) {
+                    PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                            dstip, sizeof(dstip));
+                } else if (PKT_IS_IPV6(p)) {
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                            dstip, sizeof(dstip));
+                }
+                sp = p->dp;
+                dp = p->sp;
+            }
+            break;
         default:
             DEBUG_VALIDATE_BUG_ON(1);
             return;

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -36,6 +36,8 @@ void OutputJsonRegister(void);
 enum OutputJsonLogDirection {
     LOG_DIR_PACKET = 0,
     LOG_DIR_FLOW,
+    LOG_DIR_FLOW_TO_CLIENT,
+    LOG_DIR_FLOW_TO_SERVER,
 };
 
 /* helper struct for OutputJSONMemBufferCallback */

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -519,6 +519,13 @@ int FileSetTx(File *ff, uint64_t txid)
     SCReturnInt(0);
 }
 
+int FileSetSide(File *ff, FileSide side)
+{
+    if (ff != NULL)
+        ff->side = side;
+    SCReturnInt(0);
+}
+
 void FileContainerSetTx(FileContainer *ffc, uint64_t tx_id)
 {
     if (ffc && ffc->tail) {

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -61,6 +61,12 @@ typedef enum FileState_ {
     FILE_STATE_MAX
 } FileState;
 
+typedef enum FileSide_ {
+    FILE_NO_SIDE = 0,
+    FILE_TO_CLIENT,
+    FILE_TO_SERVER,
+} FileSide;
+
 typedef struct File_ {
     uint16_t flags;
     uint16_t name_len;
@@ -89,6 +95,7 @@ typedef struct File_ {
                                      *   flag is set */
     uint64_t content_stored;
     uint64_t size;
+    FileSide side;                   /**< side of stream the File is attached to */
 } File;
 
 typedef struct FileContainer_ {
@@ -171,6 +178,8 @@ int FileAppendGAPById(FileContainer *ffc, uint32_t track_id,
  *  \param ff The file to store
  */
 int FileStore(File *);
+
+int FileSetSide(File *ff, FileSide side);
 
 /**
  *  \brief Set the TX id for a file


### PR DESCRIPTION
All fileinfo events should have a source IP that is the one sending
the data and a destination IP that is the receiving part. This was
not the case as the side information was not contained in the File
structure.

This patch adds a side information to the File allowing the
application layer to define which side should be considered at
logging time.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2492

Describe changes:
- Add FileSetSide function to set if file is to_client or to_server
- Make SMTP, HTTP and FTP use that API
- Protocols with Rust parser are NOT covered

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/396
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/179


