### PR TITLE
Fileinfo order 4

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -733,6 +733,16 @@ static int FTPDataParse(Flow *f, FtpDataState *ftpdata_state,
         data->file_len = 0;
         f->parent_id = data->flow_id;
         ftpdata_state->command = data->cmd;
+        switch (data->cmd) {
+            case FTP_COMMAND_STOR:
+                ftpdata_state->direction = STREAM_TOSERVER;
+                break;
+            case FTP_COMMAND_RETR:
+                ftpdata_state->direction = STREAM_TOCLIENT;
+                break;
+            default:
+                break;
+        }
 
         if (FileOpenFile(ftpdata_state->files, &sbcfg,
                          (uint8_t *) ftpdata_state->file_name,
@@ -882,6 +892,9 @@ static int FTPDataGetAlstateProgress(void *tx, uint8_t direction)
 static FileContainer *FTPDataStateGetFiles(void *state, uint8_t direction)
 {
     FtpDataState *ftpdata_state = (FtpDataState *)state;
+
+    if (direction != ftpdata_state->direction)
+        SCReturnPtr(NULL, "FileContainer");
 
     SCReturnPtr(ftpdata_state->files, "FileContainer");
 }

--- a/src/log-file.c
+++ b/src/log-file.c
@@ -325,7 +325,8 @@ static void LogFileWriteJsonRecord(LogFileLogThread *aft, const Packet *p, const
     SCMutexUnlock(&aft->file_ctx->fp_mutex);
 }
 
-static int LogFileLogger(ThreadVars *tv, void *thread_data, const Packet *p, const File *ff)
+static int LogFileLogger(ThreadVars *tv, void *thread_data, const Packet *p,
+                         const File *ff, uint8_t dir)
 {
     SCEnter();
     LogFileLogThread *aft = (LogFileLogThread *)thread_data;

--- a/src/log-filestore.c
+++ b/src/log-filestore.c
@@ -392,7 +392,7 @@ static void LogFilestoreFinalizeFiles(const File *ff) {
 }
 
 static int LogFilestoreLogger(ThreadVars *tv, void *thread_data, const Packet *p,
-        File *ff, const uint8_t *data, uint32_t data_len, uint8_t flags)
+        File *ff, const uint8_t *data, uint32_t data_len, uint8_t flags, uint8_t dir)
 {
     SCEnter();
     LogFilestoreLogThread *aft = (LogFilestoreLogThread *)thread_data;

--- a/src/output-file.c
+++ b/src/output-file.c
@@ -94,7 +94,8 @@ int OutputRegisterFileLogger(LoggerId id, const char *name, FileLogger LogFunc,
 static void OutputFileLogFfc(ThreadVars *tv,
         OutputLoggerThreadData *op_thread_data,
         Packet *p,
-        FileContainer *ffc, const bool file_close, const bool file_trunc)
+        FileContainer *ffc, const bool file_close, const bool file_trunc,
+        uint8_t dir)
 {
     SCLogDebug("ffc %p", ffc);
     if (ffc != NULL) {
@@ -127,7 +128,7 @@ static void OutputFileLogFfc(ThreadVars *tv,
 
                     SCLogDebug("logger %p", logger);
                     PACKET_PROFILING_LOGGER_START(p, logger->logger_id);
-                    logger->LogFunc(tv, store->thread_data, (const Packet *)p, (const File *)ff);
+                    logger->LogFunc(tv, store->thread_data, (const Packet *)p, (const File *)ff, dir);
                     PACKET_PROFILING_LOGGER_END(p, logger->logger_id);
                     file_logged = true;
 
@@ -176,8 +177,8 @@ static TmEcode OutputFileLog(ThreadVars *tv, Packet *p, void *thread_data)
     FileContainer *ffc_tc = AppLayerParserGetFiles(p->proto, f->alproto,
                                                    f->alstate, STREAM_TOCLIENT);
 
-    OutputFileLogFfc(tv, op_thread_data, p, ffc_ts, file_close_ts, file_trunc);
-    OutputFileLogFfc(tv, op_thread_data, p, ffc_tc, file_close_tc, file_trunc);
+    OutputFileLogFfc(tv, op_thread_data, p, ffc_ts, file_close_ts, file_trunc, STREAM_TOSERVER);
+    OutputFileLogFfc(tv, op_thread_data, p, ffc_tc, file_close_tc, file_trunc, STREAM_TOCLIENT);
 
     return TM_ECODE_OK;
 }

--- a/src/output-file.h
+++ b/src/output-file.h
@@ -30,7 +30,8 @@
 #include "util-file.h"
 
 /** packet logger function pointer type */
-typedef int (*FileLogger)(ThreadVars *, void *thread_data, const Packet *, const File *);
+typedef int (*FileLogger)(ThreadVars *, void *thread_data, const Packet *,
+                          const File *, uint8_t direction);
 
 /** packet logger condition function pointer type,
  *  must return true for packets that should be logged

--- a/src/output-filedata.h
+++ b/src/output-filedata.h
@@ -34,7 +34,7 @@
 
 /** filedata logger function pointer type */
 typedef int (*FiledataLogger)(ThreadVars *, void *thread_data, const Packet *,
-        File *, const uint8_t *, uint32_t, uint8_t);
+        File *, const uint8_t *, uint32_t, uint8_t, uint8_t dir);
 
 /** packet logger condition function pointer type,
  *  must return true for packets that should be logged

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -121,7 +121,7 @@ static void OutputFilestoreUpdateFileTime(const char *src_filename,
 
 static void OutputFilestoreFinalizeFiles(ThreadVars *tv,
         const OutputFilestoreLogThread *oft, const OutputFilestoreCtx *ctx,
-        const Packet *p, File *ff) {
+        const Packet *p, File *ff, uint8_t dir) {
     /* Stringify the SHA256 which will be used in the final
      * filename. */
     char sha256string[(SHA256_LENGTH * 2) + 1];
@@ -162,7 +162,7 @@ static void OutputFilestoreFinalizeFiles(ThreadVars *tv,
         snprintf(js_metadata_filename, sizeof(js_metadata_filename),
                 "%s.%"PRIuMAX".%u.json", final_filename,
                 (uintmax_t)p->ts.tv_sec, ff->file_store_id);
-        json_t *js_fileinfo = JsonBuildFileInfoRecord(p, ff, true);
+        json_t *js_fileinfo = JsonBuildFileInfoRecord(p, ff, true, dir);
         if (likely(js_fileinfo != NULL)) {
             json_dump_file(js_fileinfo, js_metadata_filename, 0);
             json_decref(js_fileinfo);
@@ -173,7 +173,7 @@ static void OutputFilestoreFinalizeFiles(ThreadVars *tv,
 
 static int OutputFilestoreLogger(ThreadVars *tv, void *thread_data,
         const Packet *p, File *ff, const uint8_t *data, uint32_t data_len,
-        uint8_t flags)
+        uint8_t flags, uint8_t dir)
 {
     SCEnter();
     OutputFilestoreLogThread *aft = (OutputFilestoreLogThread *)thread_data;
@@ -255,7 +255,7 @@ static int OutputFilestoreLogger(ThreadVars *tv, void *thread_data,
             ff->fd = -1;
             SC_ATOMIC_SUB(filestore_open_file_cnt, 1);
         }
-        OutputFilestoreFinalizeFiles(tv, aft, ctx, p, ff);
+        OutputFilestoreFinalizeFiles(tv, aft, ctx, p, ff, dir);
     }
 
     return 0;

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -80,10 +80,24 @@ typedef struct JsonFileLogThread_ {
 } JsonFileLogThread;
 
 json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
-        const bool stored)
+        const bool stored, uint8_t dir)
 {
-    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "fileinfo");
+    json_t *js = NULL;
     json_t *hjs = NULL;
+    enum OutputJsonLogDirection fdir;
+
+    switch(dir) {
+        case STREAM_TOCLIENT:
+            fdir = LOG_DIR_FLOW_TOCLIENT;
+            break;
+        case STREAM_TOSERVER:
+            fdir = LOG_DIR_FLOW_TOSERVER;
+            break;
+        default:
+            fdir = LOG_DIR_FLOW;
+    }
+
+    js = CreateJSONHeader(p, fdir, "fileinfo");
     if (unlikely(js == NULL))
         return NULL;
 
@@ -200,10 +214,11 @@ json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
  *  \internal
  *  \brief Write meta data on a single line json record
  */
-static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const File *ff)
+static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p,
+                                const File *ff, uint32_t dir)
 {
     json_t *js = JsonBuildFileInfoRecord(p, ff,
-            ff->flags & FILE_STORED ? true : false);
+            ff->flags & FILE_STORED ? true : false, dir);
     if (unlikely(js == NULL)) {
         return;
     }
@@ -213,7 +228,8 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
     json_decref(js);
 }
 
-static int JsonFileLogger(ThreadVars *tv, void *thread_data, const Packet *p, const File *ff)
+static int JsonFileLogger(ThreadVars *tv, void *thread_data, const Packet *p,
+                          const File *ff, uint8_t dir)
 {
     SCEnter();
     JsonFileLogThread *aft = (JsonFileLogThread *)thread_data;
@@ -222,7 +238,7 @@ static int JsonFileLogger(ThreadVars *tv, void *thread_data, const Packet *p, co
 
     SCLogDebug("ff %p", ff);
 
-    FileWriteJsonRecord(aft, p, ff);
+    FileWriteJsonRecord(aft, p, ff, dir);
     return 0;
 }
 

--- a/src/output-json-file.h
+++ b/src/output-json-file.h
@@ -28,7 +28,7 @@ void JsonFileLogRegister(void);
 
 #ifdef HAVE_LIBJANSSON
 json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
-        const bool stored);
+        const bool stored, uint8_t dir);
 #endif
 
 #endif /* __OUTPUT_JSON_FILE_H__ */

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -445,6 +445,68 @@ void JsonFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, json_t *js)
             sp = p->sp;
             dp = p->dp;
             break;
+        case LOG_DIR_FLOW_TOSERVER:
+            if ((PKT_IS_TOSERVER(p))) {
+                if (PKT_IS_IPV4(p)) {
+                    PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                            dstip, sizeof(dstip));
+                } else if (PKT_IS_IPV6(p)) {
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                            dstip, sizeof(dstip));
+                }
+                sp = p->sp;
+                dp = p->dp;
+            } else {
+                if (PKT_IS_IPV4(p)) {
+                    PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                            dstip, sizeof(dstip));
+                } else if (PKT_IS_IPV6(p)) {
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                            dstip, sizeof(dstip));
+                }
+                sp = p->dp;
+                dp = p->sp;
+            }
+            break;
+        case LOG_DIR_FLOW_TOCLIENT:
+            if ((PKT_IS_TOCLIENT(p))) {
+                if (PKT_IS_IPV4(p)) {
+                    PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                            dstip, sizeof(dstip));
+                } else if (PKT_IS_IPV6(p)) {
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                            dstip, sizeof(dstip));
+                }
+                sp = p->sp;
+                dp = p->dp;
+            } else {
+                if (PKT_IS_IPV4(p)) {
+                    PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                            dstip, sizeof(dstip));
+                } else if (PKT_IS_IPV6(p)) {
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                            dstip, sizeof(dstip));
+                }
+                sp = p->dp;
+                dp = p->sp;
+            }
+            break;
         default:
             DEBUG_VALIDATE_BUG_ON(1);
             return;

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -36,6 +36,8 @@ void OutputJsonRegister(void);
 enum OutputJsonLogDirection {
     LOG_DIR_PACKET = 0,
     LOG_DIR_FLOW,
+    LOG_DIR_FLOW_TOCLIENT,
+    LOG_DIR_FLOW_TOSERVER,
 };
 
 /* helper struct for OutputJSONMemBufferCallback */

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -307,7 +307,7 @@ static int LuaPacketCondition(ThreadVars *tv, const Packet *p)
  *
  * NOTE p->flow is locked at this point
  */
-static int LuaFileLogger(ThreadVars *tv, void *thread_data, const Packet *p, const File *ff)
+static int LuaFileLogger(ThreadVars *tv, void *thread_data, const Packet *p, const File *ff, uint8_t dir)
 {
     SCEnter();
     LogLuaThreadCtx *td = (LogLuaThreadCtx *)thread_data;


### PR DESCRIPTION
Update of #3344 implementing the change discussed in the previous PR.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Update the logger APIs
- Fix ftp-data file extraction that was not respecting the client/server info

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/398
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/181


