### PR TITLE
stream-tcp: fix stream depth computation

### DIFF
--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -559,21 +559,21 @@ static uint32_t StreamTcpReassembleCheckDepth(TcpSession *ssn, TcpStream *stream
      * wraps as well */
     SCLogDebug("seq + size %u, base %u, seg_depth %"PRIu64" limit %u", (seq + size),
             stream->base_seq, seg_depth,
-            stream_config.reassembly_depth);
+            ssn->reassembly_depth);
 
-    if (seg_depth > (uint64_t)stream_config.reassembly_depth) {
+    if (seg_depth > (uint64_t)ssn->reassembly_depth) {
         SCLogDebug("STREAMTCP_STREAM_FLAG_DEPTH_REACHED");
         stream->flags |= STREAMTCP_STREAM_FLAG_DEPTH_REACHED;
         SCReturnUInt(0);
     }
     SCLogDebug("NOT STREAMTCP_STREAM_FLAG_DEPTH_REACHED");
-    SCLogDebug("%"PRIu64" <= %u", seg_depth, stream_config.reassembly_depth);
+    SCLogDebug("%"PRIu64" <= %u", seg_depth, ssn->reassembly_depth);
 #if 0
     SCLogDebug("full depth not yet reached: %"PRIu64" <= %"PRIu32,
             (stream->base_seq_offset + stream->base_seq + size),
-            (stream->isn + stream_config.reassembly_depth));
+            (stream->isn + ssn->reassembly_depth));
 #endif
-    if (SEQ_GEQ(seq, stream->isn) && SEQ_LT(seq, (stream->isn + stream_config.reassembly_depth))) {
+    if (SEQ_GEQ(seq, stream->isn) && SEQ_LT(seq, (stream->isn + ssn->reassembly_depth))) {
         /* packet (partly?) fits the depth window */
 
         if (SEQ_LEQ((seq + size),(stream->isn + 1 + ssn->reassembly_depth))) {


### PR DESCRIPTION
The stream depth computation was partly done with the stream_config
depth instead of using the value in the TCP session. As a result,
some configuration were resulting in abnormal behavior.

In particular, when stream depth was 0 and the file store depth was
not 0, Suricata was stopping the streaming on the flow as soon as
the filestore was started.

Reported by @macpas 

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2495

Describe changes:
- Use TCP session stream reassembly depth in all cases

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/402
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/184
