### PR TITLE
tls: add setup and validation callbacks for keywords

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -764,7 +764,7 @@ bool DetectBufferTypeSupportsMpmGetById(const DetectEngineCtx *de_ctx, const int
 }
 
 void DetectBufferTypeRegisterSetupCallback(const char *name,
-        void (*SetupCallback)(Signature *))
+        void (*SetupCallback)(const DetectEngineCtx *, Signature *))
 {
     BUG_ON(g_buffer_type_reg_closed);
     DetectBufferTypeRegister(name);
@@ -778,7 +778,7 @@ void DetectBufferRunSetupCallback(const DetectEngineCtx *de_ctx,
 {
     const DetectBufferType *map = DetectBufferTypeGetById(de_ctx, id);
     if (map && map->SetupCallback) {
-        map->SetupCallback(s);
+        map->SetupCallback(de_ctx, s);
     }
 }
 

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -46,7 +46,7 @@ void DetectBufferTypeCloseRegistration(void);
 void DetectBufferTypeSetDescriptionByName(const char *name, const char *desc);
 const char *DetectBufferTypeGetDescriptionByName(const char *name);
 void DetectBufferTypeRegisterSetupCallback(const char *name,
-        void (*Callback)(Signature *));
+        void (*Callback)(const DetectEngineCtx *, Signature *));
 void DetectBufferTypeRegisterValidateCallback(const char *name,
         _Bool (*ValidateCallback)(const Signature *, const char **sigerror));
 

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -51,7 +51,8 @@
 
 static int DetectFiledataSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectFiledataRegisterTests(void);
-static void DetectFiledataSetupCallback(Signature *s);
+static void DetectFiledataSetupCallback(const DetectEngineCtx *de_ctx,
+                                        Signature *s);
 static int g_file_data_buffer_id = 0;
 
 /**
@@ -174,7 +175,8 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     return 0;
 }
 
-static void DetectFiledataSetupCallback(Signature *s)
+static void DetectFiledataSetupCallback(const DetectEngineCtx *de_ctx,
+                                        Signature *s)
 {
     if (s->alproto == ALPROTO_HTTP || s->alproto == ALPROTO_UNKNOWN) {
         AppLayerHtpEnableRequestBodyCallback();

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -61,7 +61,8 @@
 static int DetectHttpClientBodySetup(DetectEngineCtx *, Signature *, const char *);
 static void DetectHttpClientBodyRegisterTests(void);
 static void DetectHttpClientBodyFree(void *);
-static void DetectHttpClientBodySetupCallback(Signature *s);
+static void DetectHttpClientBodySetupCallback(const DetectEngineCtx *de_ctx,
+                                              Signature *s);
 static int g_http_client_body_buffer_id = 0;
 
 /**
@@ -95,7 +96,8 @@ void DetectHttpClientBodyRegister(void)
     g_http_client_body_buffer_id = DetectBufferTypeGetByName("http_client_body");
 }
 
-static void DetectHttpClientBodySetupCallback(Signature *s)
+static void DetectHttpClientBodySetupCallback(const DetectEngineCtx *de_ctx,
+                                              Signature *s)
 {
     SCLogDebug("callback invoked by %u", s->id);
     AppLayerHtpEnableRequestBodyCallback();

--- a/src/detect-http-raw-uri.c
+++ b/src/detect-http-raw-uri.c
@@ -58,7 +58,8 @@
 
 static int DetectHttpRawUriSetup(DetectEngineCtx *, Signature *, const char *);
 static void DetectHttpRawUriRegisterTests(void);
-static void DetectHttpRawUriSetupCallback(Signature *s);
+static void DetectHttpRawUriSetupCallback(const DetectEngineCtx *de_ctx,
+                                          Signature *s);
 static bool DetectHttpRawUriValidateCallback(const Signature *s, const char **);
 static int g_http_raw_uri_buffer_id = 0;
 
@@ -118,7 +119,8 @@ static bool DetectHttpRawUriValidateCallback(const Signature *s, const char **si
     return DetectUrilenValidateContent(s, g_http_raw_uri_buffer_id, sigerror);
 }
 
-static void DetectHttpRawUriSetupCallback(Signature *s)
+static void DetectHttpRawUriSetupCallback(const DetectEngineCtx *de_ctx,
+                                          Signature *s)
 {
     SCLogDebug("callback invoked by %u", s->id);
     DetectUrilenApplyToContent(s, g_http_raw_uri_buffer_id);

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -58,7 +58,8 @@
 #include "stream-tcp.h"
 
 static void DetectHttpUriRegisterTests(void);
-static void DetectHttpUriSetupCallback(Signature *s);
+static void DetectHttpUriSetupCallback(const DetectEngineCtx *de_ctx,
+                                       Signature *s);
 static bool DetectHttpUriValidateCallback(const Signature *s, const char **sigerror);
 
 static int g_http_uri_buffer_id = 0;
@@ -122,7 +123,8 @@ static bool DetectHttpUriValidateCallback(const Signature *s, const char **siger
     return DetectUrilenValidateContent(s, g_http_uri_buffer_id, sigerror);
 }
 
-static void DetectHttpUriSetupCallback(Signature *s)
+static void DetectHttpUriSetupCallback(const DetectEngineCtx *de_ctx,
+                                       Signature *s)
 {
     SCLogDebug("callback invoked by %u", s->id);
     DetectUrilenApplyToContent(s, g_http_uri_buffer_id);

--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -516,7 +516,7 @@ static int DetectTlsFingerprintTest02(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx, "alert tls any any -> any any "
-                              "(msg:\"Test tls_cert_serial\"; "
+                              "(msg:\"Test tls_cert_fingerprint\"; "
                               "tls_cert_fingerprint; "
                               "content:\"4a:a3:66:76:82:cb:6b:23:bb:c3:58:47:23:a4:63:a7:78:a4:a1:18\"; "
                               "sid:1;)");

--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -154,7 +154,7 @@ static _Bool DetectTlsFingerprintValidateCallback(const Signature *s,
         if (sm->type != DETECT_CONTENT)
             continue;
 
-        DetectContentData *cd = (DetectContentData *)sm->ctx;
+        const DetectContentData *cd = (DetectContentData *)sm->ctx;
 
         if (cd->content_len != 59) {
             *sigerror = "Invalid length of the specified fingerprint. "
@@ -181,6 +181,12 @@ static _Bool DetectTlsFingerprintValidateCallback(const Signature *s,
             return FALSE;
         }
 
+        if (cd->flags & DETECT_CONTENT_NOCASE) {
+            *sigerror = "tls_cert_fingerprint should not be used together "
+                        "with nocase, since the rule is automatically "
+                        "lowercased anyway which makes nocase redundant.";
+            SCLogWarning(SC_WARN_POOR_RULE, "rule %u: %s", s->id, *sigerror);
+        }
     }
 
     return TRUE;

--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -239,7 +239,9 @@ static int DetectTlsFingerprintTest01(void)
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tls any any -> any any "
                                "(msg:\"Testing tls_cert_fingerprint\"; "
-                               "tls_cert_fingerprint; content:\"XX:XX:XX\"; sid:1;)");
+                               "tls_cert_fingerprint; "
+                               "content:\"11:22:33:44:55:66:77:88:99:00:11:22:33:44:55:66:77:88:99:00\"; "
+                               "sid:1;)");
     FAIL_IF_NULL(de_ctx->sig_list);
 
     /* sm should not be in the MATCH list */

--- a/src/detect-tls-cert-serial.c
+++ b/src/detect-tls-cert-serial.c
@@ -153,7 +153,14 @@ static _Bool DetectTlsSerialValidateCallback(const Signature *s,
         if (sm->type != DETECT_CONTENT)
             continue;
 
-        DetectContentData *cd = (DetectContentData *)sm->ctx;
+        const DetectContentData *cd = (DetectContentData *)sm->ctx;
+
+        if (cd->flags & DETECT_CONTENT_NOCASE) {
+            *sigerror = "tls_cert_serial should not be used together "
+                        "with nocase, since the rule is automatically "
+                        "uppercased anyway which makes nocase redundant.";
+            SCLogWarning(SC_WARN_POOR_RULE, "rule %u: %s", s->id, *sigerror);
+        }
 
         /* no need to worry about this if the content is short enough */
         if (cd->content_len <= 2)

--- a/src/detect-tls-cert-serial.c
+++ b/src/detect-tls-cert-serial.c
@@ -60,6 +60,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms,
         Flow *_f, const uint8_t _flow_flags,
         void *txv, const int list_id);
+static void DetectTlsSerialSetupCallback(const DetectEngineCtx *de_ctx,
+        Signature *s);
 static _Bool DetectTlsSerialValidateCallback(const Signature *s,
         const char **sigerror);
 static int g_tls_cert_serial_buffer_id = 0;
@@ -89,6 +91,9 @@ void DetectTlsSerialRegister(void)
 
     DetectBufferTypeSetDescriptionByName("tls_cert_serial",
             "TLS certificate serial number");
+
+    DetectBufferTypeRegisterSetupCallback("tls_cert_serial",
+            DetectTlsSerialSetupCallback);
 
     DetectBufferTypeRegisterValidateCallback("tls_cert_serial",
             DetectTlsSerialValidateCallback);
@@ -168,6 +173,36 @@ static _Bool DetectTlsSerialValidateCallback(const Signature *s,
     }
 
     return TRUE;
+}
+
+static void DetectTlsSerialSetupCallback(const DetectEngineCtx *de_ctx,
+                                         Signature *s)
+{
+    SigMatch *sm = s->init_data->smlists[g_tls_cert_serial_buffer_id];
+    for ( ; sm != NULL; sm = sm->next)
+    {
+        if (sm->type != DETECT_CONTENT)
+            continue;
+
+        DetectContentData *cd = (DetectContentData *)sm->ctx;
+
+        _Bool changed = FALSE;
+        uint32_t u;
+        for (u = 0; u < cd->content_len; u++)
+        {
+            if (islower(cd->content[u])) {
+                cd->content[u] = toupper(cd->content[u]);
+                changed = TRUE;
+            }
+        }
+
+        /* recreate the context if changes were made */
+        if (changed) {
+            SpmDestroyCtx(cd->spm_ctx);
+            cd->spm_ctx = SpmInitCtx(cd->content, cd->content_len, 1,
+                                     de_ctx->spm_global_thread_ctx);
+        }
+    }
 }
 
 #ifdef UNITTESTS

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -154,7 +154,14 @@ static _Bool DetectTlsJa3HashValidateCallback(const Signature *s,
         if (sm->type != DETECT_CONTENT)
             continue;
 
-        DetectContentData *cd = (DetectContentData *)sm->ctx;
+        const DetectContentData *cd = (DetectContentData *)sm->ctx;
+
+        if (cd->flags & DETECT_CONTENT_NOCASE) {
+            *sigerror = "ja3_hash should not be used together with "
+                        "nocase, since the rule is automatically "
+                        "lowercased anyway which makes nocase redundant.";
+            SCLogWarning(SC_WARN_POOR_RULE, "rule %u: %s", s->id, *sigerror);
+        }
 
         if (cd->content_len == 32)
             return TRUE;

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -64,6 +64,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
        const DetectEngineTransforms *transforms,
        Flow *_f, const uint8_t _flow_flags,
        void *txv, const int list_id);
+static void DetectTlsJa3HashSetupCallback(const DetectEngineCtx *de_ctx,
+       Signature *s);
 static _Bool DetectTlsJa3HashValidateCallback(const Signature *s,
        const char **sigerror);
 static int g_tls_ja3_hash_buffer_id = 0;
@@ -90,6 +92,9 @@ void DetectTlsJa3HashRegister(void)
             PrefilterGenericMpmRegister, GetData, ALPROTO_TLS, 0);
 
     DetectBufferTypeSetDescriptionByName("ja3_hash", "TLS JA3 hash");
+
+    DetectBufferTypeRegisterSetupCallback("ja3_hash",
+            DetectTlsJa3HashSetupCallback);
 
     DetectBufferTypeRegisterValidateCallback("ja3_hash",
             DetectTlsJa3HashValidateCallback);
@@ -174,6 +179,36 @@ static _Bool DetectTlsJa3HashValidateCallback(const Signature *s,
     }
 
     return TRUE;
+}
+
+static void DetectTlsJa3HashSetupCallback(const DetectEngineCtx *de_ctx,
+                                          Signature *s)
+{
+    SigMatch *sm = s->init_data->smlists[g_tls_ja3_hash_buffer_id];
+    for ( ; sm != NULL; sm = sm->next)
+    {
+        if (sm->type != DETECT_CONTENT)
+            continue;
+
+        DetectContentData *cd = (DetectContentData *)sm->ctx;
+
+        _Bool changed = FALSE;
+        uint32_t u;
+        for (u = 0; u < cd->content_len; u++)
+        {
+            if (isupper(cd->content[u])) {
+                cd->content[u] = tolower(cd->content[u]);
+                changed = TRUE;
+            }
+        }
+
+        /* recreate the context if changes were made */
+        if (changed) {
+            SpmDestroyCtx(cd->spm_ctx);
+            cd->spm_ctx = SpmInitCtx(cd->content, cd->content_len, 1,
+                                     de_ctx->spm_global_thread_ctx);
+        }
+    }
 }
 
 #ifndef HAVE_NSS

--- a/src/detect.h
+++ b/src/detect.h
@@ -421,7 +421,7 @@ typedef struct DetectBufferType_ {
     _Bool mpm;
     _Bool packet; /**< compat to packet matches */
     bool supports_transforms;
-    void (*SetupCallback)(struct Signature_ *);
+    void (*SetupCallback)(const struct DetectEngineCtx_ *, struct Signature_ *);
     bool (*ValidateCallback)(const struct Signature_ *, const char **sigerror);
     DetectEngineTransforms transforms;
 } DetectBufferType;


### PR DESCRIPTION
Add setup and validation callbacks for the following keywords:
- tls_cert_serial (check for delimiters and nocase) - uppercase the content
- tls_cert_fingerprint (check length, delimiters and nocase) - lowercase the content
- ja3_hash (check length and nocase)

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/160
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/160