### PR TITLE
suricata-update integration - v2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,6 +30,12 @@ install-conf:
 	install -m 770 -d "$(DESTDIR)$(e_localstatedir)"
 
 install-rules:
+if HAVE_SURICATA_UPDATE
+	$(DESTDIR)$(bindir)/suricata-update \
+		--suricata $(DESTDIR)$(bindir)/suricata \
+		--suricata-conf $(DESTDIR)$(sysconfdir)/suricata/suricata.yaml \
+		--no-test --no-reload
+else
 	install -d "$(DESTDIR)$(e_sysconfrulesdir)"
 if HAVE_FETCH_COMMAND
 if HAVE_WGET_COMMAND
@@ -58,3 +64,4 @@ endif
 	@echo "While rules are installed now, it's highly recommended to use a rule manager for maintaining rules."
 	@echo "The three most common are Suricata-Update, Oinkmaster and Pulledpork. For a guide see:"
 	@echo "https://suricata.readthedocs.io/en/latest/rule-management/index.html"
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -2234,6 +2234,7 @@ if test "$WINDOWS_PATH" = "yes"; then
     e_logdir="$e_winbase\\\\log"
     e_logfilesdir="$e_logdir\\\\files"
     e_logcertsdir="$e_logdir\\\\certs"
+    e_datarulesdir="$e_winbase\\\\rules\\\\"
 else
     EXPAND_VARIABLE(localstatedir, e_logdir, "/log/suricata/")
     EXPAND_VARIABLE(localstatedir, e_rundir, "/run/")
@@ -2242,6 +2243,7 @@ else
     EXPAND_VARIABLE(sysconfdir, e_sysconfdir, "/suricata/")
     EXPAND_VARIABLE(sysconfdir, e_sysconfrulesdir, "/suricata/rules")
     EXPAND_VARIABLE(localstatedir, e_localstatedir, "/run/suricata")
+    EXPAND_VARIABLE(datadir, e_datarulesdir, "/suricata/rules")
 fi
 AC_SUBST(e_logdir)
 AC_SUBST(e_rundir)
@@ -2254,6 +2256,7 @@ AC_DEFINE_UNQUOTED([CONFIG_DIR],["$e_sysconfdir"],[Our CONFIG_DIR])
 AC_SUBST(e_magic_file)
 AC_SUBST(e_magic_file_comment)
 AC_SUBST(e_enable_evelog)
+AC_SUBST(e_datarulesdir)
 
 EXPAND_VARIABLE(prefix, CONFIGURE_PREFIX)
 EXPAND_VARIABLE(sysconfdir, CONFIGURE_SYSCONDIR)

--- a/configure.ac
+++ b/configure.ac
@@ -1377,11 +1377,17 @@
 
   # suricata-update
   have_suricata_update="no"
+  ruledirprefix="$sysconfdir"
+  suricata_update_rule_files="suricata-update-rule-files"
+  classic_rule_files="rule-files"
   AC_CHECK_FILE([$srcdir/suricata-update/setup.py], [
       SURICATA_UPDATE_DIR="suricata-update"
       AC_SUBST(SURICATA_UPDATE_DIR)
       AC_OUTPUT(suricata-update/Makefile)
       have_suricata_update="yes"
+      ruledirprefix="$localstatedir/lib"
+      suricata_update_rule_files="rule-files"
+      classic_rule_files="classic-rule-files"
   ])
   AM_CONDITIONAL([HAVE_SURICATA_UPDATE], [test "x$have_suricata_update" != "xno"])
 
@@ -2233,6 +2239,7 @@ if test "$WINDOWS_PATH" = "yes"; then
 
     e_sysconfdir="${e_winbase}\\\\"
     e_sysconfrulesdir="$e_winbase\\\\rules\\\\"
+    e_defaultruledir="$e_winbase\\\\rules\\\\"
     e_magic_file="$e_winbase\\\\magic.mgc"
     e_logdir="$e_winbase\\\\log"
     e_logfilesdir="$e_logdir\\\\files"
@@ -2247,6 +2254,7 @@ else
     EXPAND_VARIABLE(sysconfdir, e_sysconfrulesdir, "/suricata/rules")
     EXPAND_VARIABLE(localstatedir, e_localstatedir, "/run/suricata")
     EXPAND_VARIABLE(datadir, e_datarulesdir, "/suricata/rules")
+    EXPAND_VARIABLE(ruledirprefix, e_defaultruledir, "/suricata/rules")
 fi
 AC_SUBST(e_logdir)
 AC_SUBST(e_rundir)
@@ -2260,6 +2268,9 @@ AC_SUBST(e_magic_file)
 AC_SUBST(e_magic_file_comment)
 AC_SUBST(e_enable_evelog)
 AC_SUBST(e_datarulesdir)
+AC_SUBST(e_defaultruledir)
+AC_SUBST(suricata_update_rule_files)
+AC_SUBST(classic_rule_files)
 
 EXPAND_VARIABLE(prefix, CONFIGURE_PREFIX)
 EXPAND_VARIABLE(sysconfdir, CONFIGURE_SYSCONDIR)

--- a/configure.ac
+++ b/configure.ac
@@ -1376,11 +1376,14 @@
   ])
 
   # suricata-update
+  have_suricata_update="no"
   AC_CHECK_FILE([$srcdir/suricata-update/setup.py], [
       SURICATA_UPDATE_DIR="suricata-update"
       AC_SUBST(SURICATA_UPDATE_DIR)
       AC_OUTPUT(suricata-update/Makefile)
+      have_suricata_update="yes"
   ])
+  AM_CONDITIONAL([HAVE_SURICATA_UPDATE], [test "x$have_suricata_update" != "xno"])
 
   # libhtp
     AC_ARG_ENABLE(non-bundled-htp,

--- a/configure.ac
+++ b/configure.ac
@@ -2266,7 +2266,7 @@ AC_SUBST(CONFIGURE_SYSCONDIR)
 AC_SUBST(CONFIGURE_LOCALSTATEDIR)
 AC_SUBST(PACKAGE_VERSION)
 
-AC_OUTPUT(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile contrib/tile_pcie_logd/Makefile suricata.yaml etc/Makefile etc/suricata.logrotate etc/suricata.service python/Makefile python/bin/suricatasc ebpf/Makefile)
+AC_OUTPUT(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile contrib/tile_pcie_logd/Makefile suricata.yaml etc/Makefile etc/suricata.logrotate etc/suricata.service python/Makefile python/suricata/config/defaults.py python/bin/suricatasc ebpf/Makefile)
 
 SURICATA_BUILD_CONF="Suricata Configuration:
   AF_PACKET support:                       ${enable_af_packet}

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -5,3 +5,5 @@ lib/
 scripts-*/
 bin/suricatasc
 !bin/suricatasc.in
+suricata/config/defaults.py
+!suricata/config/defaults.py.in

--- a/python/setup.py
+++ b/python/setup.py
@@ -28,6 +28,7 @@ setup(
     url='https://www.suricata-ids.org/',
     packages=[
         "suricata",
+        "suricata.config",
         "suricata.ctl",
         "suricata.sc",
         "suricatasc",

--- a/python/suricata/config/defaults.py.in
+++ b/python/suricata/config/defaults.py.in
@@ -1,0 +1,2 @@
+sysconfdir = "@e_sysconfdir@"
+datarulesdir = "@e_datarulesdir@"

--- a/rules/Makefile.am
+++ b/rules/Makefile.am
@@ -1,4 +1,6 @@
-EXTRA_DIST = \
+ruledir = $(datadir)/suricata/rules
+
+dist_rule_DATA = \
 decoder-events.rules \
 stream-events.rules \
 smtp-events.rules \

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -49,8 +49,11 @@ vars:
 ## Step 2: select the rules to enable or disable
 ##
 
-default-rule-path: @e_sysconfdir@rules
-rule-files:
+#default-rule-path: @e_sysconfdir@rules
+default-rule-path: @e_defaultruledir@
+@suricata_update_rule_files@:
+ - suricata.rules
+@classic_rule_files@:
  - botcc.rules
  # - botcc.portgrouped.rules
  - ciarmy.rules


### PR DESCRIPTION
More suricata-update integration:

- Install the engine provided rules in $datadir/suricata/rules (eg. /usr/share/suricata/rules).
- Create a python module, defaults.py that has the compile time directories such as sysconfdir, e_datarulesdir so Python tools can pick the locations that Suricata was compiled with. This seemed like the best idea at the time, but executing Suricata to extract the information is also possible. Even if not the best option for suricata-update, its still useful for other Python tools, ie: to prevent suricatasc.py being a .in file (will do another PR for that)
- If suricata-update is bundled, use it during "install-rules".
- If suricata-update is bundled, set the default-rule-path to the expected directory and enable only one rule file, suricata.rules.

Requires update suricata-update with this PR:
- https://github.com/OISF/suricata-update/pull/36

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/286
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/639

