### PR TITLE
doc: spelling mistakes in various sections of the user guide V2

### DIFF
--- a/doc/userguide/configuration/global-thresholds.rst
+++ b/doc/userguide/configuration/global-thresholds.rst
@@ -3,7 +3,7 @@ Global-Thresholds
 
 Thresholds can be configured in the rules themselves, see
 :doc:`../rules/thresholding`. They are often set by rule writers based on
-their intel for creating a rule combined with a judgement on how often
+their intelligence for creating a rule combined with a judgement on how often
 a rule will alert.
 
 Threshold Config

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -149,7 +149,7 @@ Splitting configuration in multiple files
 -----------------------------------------
 
 Some users might have a need or a wish to split their suricata.yaml
-file in to seperate files, this is available vis the 'include' and
+file in to separate files, this is available vis the 'include' and
 '!include' keyword. The first example is of taking the contents of the
 outputs section and storing them in outputs.yaml
 
@@ -316,7 +316,7 @@ This output supports IPv6 and IPv4 events.
 
       # By default unified2 log files have the file creation time (in
       # unix epoch format) appended to the filename. Set this to yes to
-      # disable this behaviour.
+      # disable this behavior.
       #nostamp: no
 
       # Sensor ID field of unified2 alerts.
@@ -393,7 +393,7 @@ server, ttl, resource record data. This logging can also be performed
 through the use of the :ref:`Eve-log capability <eve-json-format>` which
 offers easier parsing.
 
-Example of the apperance of a DNS log of a query with a preceding reply:
+Example of the appearance of a DNS log of a query with a preceding reply:
 
 ::
 
@@ -625,7 +625,7 @@ Detection engine
 Inspection configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The detection-engine builds internal groups of signatures. Suricata loads signatures, with which the network traffic will be compared. The fact is, that many rules certainly will not be necessary. (For instance: if there appears a packet with the UDP-protocol, all signatures for the TCP-protocol won't be needed.)  For that reason, all signatures will be divided in groups. However, a distribution containing many groups will make use of a lot of memory. Not every type of signature gets its own group. There is a possibility that different signatures with several properties in common, will be placed together in a group.  The quantity of groups will determine the balance between memory and performance. A small amount of groups will lower the performance yet uses little memory. The opposite counts for a higher amount of groups. The engine allows you to manage the balance between memory and performance. To manage this, (by determining the amount of groups) there are several general options:high for good performance and more use of memory, low for low performance and little use of memory. The option medium is the balance between performance and memory usage. This is the default setting.The option custom is for advanced users. This option has values which can be managed by the user.
+The detection-engine builds internal groups of signatures. Suricata loads signatures, with which the network traffic will be compared. The fact is, that many rules certainly will not be necessary. (For instance: if there appears a packet with the UDP-protocol, all signatures for the TCP-protocol won't be needed.)  For that reason, all signatures will be divided in groups. However, a distribution containing many groups will make use of a lot of memory. Not every type of signature gets its own group. There is a possibility that different signatures with several properties in common, will be placed together in a group.  The quantity of groups will determine the balance between memory and performance. A small amount of groups will lower the performance yet uses little memory. The opposite counts for a higher amount of groups. The engine allows you to manage the balance between memory and performance. To manage this, (by determining the amount of groups) there are several general options:high for good performance and more use of memory, low for low performance and little use of memory. The option medium is the balance between performance and memory usage. This is the default setting. The option custom is for advanced users. This option has values which can be managed by the user.
 
 ::
 
@@ -741,7 +741,7 @@ These are the proceedings:
 
 1)A packet comes in.
 
-2)The packed will be analysed by the Multi-pattern-matcher in search
+2)The packed will be analyzed by the Multi-pattern-matcher in search
   of patterns that match.
 
 3)All patterns that match, will be further processed by Suricata (signatures).
@@ -989,7 +989,7 @@ Flow Settings
 
 Within Suricata, Flows are very important. They play a big part in the
 way Suricata organizes data internally. A flow is a bit similar to a
-connection, except a flow is more general.All packets having the same
+connection, except a flow is more general. All packets having the same
 Tuple (protocol, source IP, destination IP, source-port,
 destination-port), belong to the same flow. Packets belonging to a
 flow are connected to it internally.
@@ -1120,7 +1120,7 @@ exists of two parts: The stream tracking- and the reassembly-engine.
 
 The stream-tracking engine monitors the state of a connection. The
 reassembly-engine reconstructs the flow as it used to be, so it will
-be recognised by Suricata.
+be recognized by Suricata.
 
 The stream-engine has two memcaps that can be set. One for the
 stream-tracking-engine and one for the reassembly-engine.
@@ -1403,7 +1403,7 @@ use of libhtp.
        # Apache does not do this, but IIS does. If enabled, a path such as
        # "/one%2ftwo" will be normalized to "/one/two". If the
        # backslash_separators option is also enabled, encoded backslash
-       # characters will be converted too (and subseqently normalized to
+       # characters will be converted too (and subsequently normalized to
        # forward slashes).  Accepted values - yes, no.
        #path-decode-separators: yes
 
@@ -1434,7 +1434,7 @@ use of libhtp.
        # path.  Accepted values - none, terminate, status_400, status_404.
        path-nul-raw-handling: none
 
-       # Sets the replacement characater that will be used to in the lossy
+       # Sets the replacement character that will be used to in the lossy
        # best-fit mapping from Unicode characters into single-byte streams.
        # The question mark is the default replacement character.
        #set-path-replacement-char: ?
@@ -1884,7 +1884,7 @@ Engine-analysis
 ~~~~~~~~~~~~~~~
 
 The option engine-analysis provides information for signature writers
-about how Suricata organises signatures internally.
+about how Suricata organizes signatures internally.
 
 Like mentioned before, signatures have zero or more patterns on which
 they can match. Only one of these patterns will be used by the multi
@@ -2118,7 +2118,7 @@ Encrypted traffic
 
 There is no decryption of encrypted traffic, so once the handshake is complete
 continued tracking of the session is of limited use. The ``no-reassemble``
-option controls the behaviour after the handshake.
+option controls the behavior after the handshake.
 
 If ``no-reassemble`` is set to ``true``, all processing of this session is
 stopped. No further parsing and inspection happens. If ``bypass`` is enabled

--- a/doc/userguide/make-sense-alerts.rst
+++ b/doc/userguide/make-sense-alerts.rst
@@ -49,7 +49,7 @@ information:
   www.emergingthreats.net/cgi-bin/cvsweb.cgi/sigs/CURRENT_EVENTS/CURRENT_Adobe
 
 Some rules contain a reference like: "reference:cve,2009-3958;" should
-allow you to find info about the specific CVE using your favourite
+allow you to find info about the specific CVE using your favorite
 search engine.
 
 It's not always straight forward and sometimes not all of that

--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -124,12 +124,12 @@ Fields
 In addition to these fields, if the extended logging is enabled in the suricata.yaml file the following fields are (can) also included:
 
 * "length": The content size of the HTTP body
-* "status": HTTP statuscode
+* "status": HTTP status code
 * "protocol": Protocol / Version of HTTP (ex: HTTP/1.1)
 * "http_method": The HTTP method (ex: GET, POST, HEAD)
 * "http_refer": The referer for this action
 
-In addition to the extended logging fields one can also choose to enable/add from 50 additional custom logging HTTP fields enabled in the suricata.yaml file. The additional fields can be enabled as following:
+In addition to the extended logging fields one can also choose to enable/add from more than 50 additional custom logging HTTP fields enabled in the suricata.yaml file. The additional fields can be enabled as following:
 
 
 ::
@@ -474,7 +474,7 @@ SMB Fields
 * "filename" (string): filename for CREATE and other commands.
 * "disposition" (string): requested disposition. E.g. FILE_OPEN, FILE_CREATE and FILE_OVERWRITE. See https://msdn.microsoft.com/en-us/library/ee442175.aspx#Appendix_A_Target_119
 * "access" (string): indication of how the file was opened. "normal" or "delete on close" (field is subject to change)
-* "created", "accessed", "modified", "changed" (interger): timestamps in seconds since unix epoch
+* "created", "accessed", "modified", "changed" (integer): timestamps in seconds since unix epoch
 * "size" (integer): size of the requested file
 * "fuid" (string): SMB2+ file GUID. SMB1 FID as hex.
 * "share" (string): share name.

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -47,7 +47,7 @@ Output types::
 Alerts
 ~~~~~~
 
-Alerts are event records for rule matches. They can be ammended with
+Alerts are event records for rule matches. They can be amended with
 metadata, such as the application layer record (HTTP, DNS, etc) an
 alert was generated for, and elements of the rule.
 

--- a/doc/userguide/output/syslog-alerting-comp.rst
+++ b/doc/userguide/output/syslog-alerting-comp.rst
@@ -9,7 +9,7 @@ Popular syslog daemons
 ----------------------
 
 * **syslogd** - logs system messages
-* **syslog-ng** - logs system messages but also suports TCP, TLS, and other enhanced enterprise features
+* **syslog-ng** - logs system messages but also supports TCP, TLS, and other enhanced enterprise features
 * **rsyslogd** - logs system messages but also support TCP, TLS, multi-threading, and other enhanced features
 * **klogd** - logs kernel messages
 * **sysklogd** - basically a bundle of syslogd and klogd
@@ -46,7 +46,7 @@ Locate those files and look at them to give you clues as to what syslog daemon y
 Example
 -------
 
-Here is an example where the Suricata sensor is sending syslog messages in rsyslogd format but the SIEM is expecting and parsing them in a sysklogd format.  In the syslog configuration file (ususally in /etc with a filename like rsyslog.conf or syslog.conf), first add the template:
+Here is an example where the Suricata sensor is sending syslog messages in rsyslogd format but the SIEM is expecting and parsing them in a sysklogd format.  In the syslog configuration file (usually in /etc with a filename like rsyslog.conf or syslog.conf), first add the template:
 
 ::
 

--- a/doc/userguide/partials/options-unittests.rst
+++ b/doc/userguide/partials/options-unittests.rst
@@ -18,7 +18,7 @@
 .. option:: --fatal-unittests
 
    Enables fatal failure on a unit test error. Suricata will exit
-   instead of continuuing more tests.
+   instead of continuing more tests.
 
 .. option:: --unittests-coverage
 

--- a/doc/userguide/rules/enip-keyword.rst
+++ b/doc/userguide/rules/enip-keyword.rst
@@ -13,7 +13,7 @@ There are three ways of using this keyword:
 
 For the ENIP command, we are matching against the command field found in the ENIP encapsulation.
 
-For the CIP Service, we use a maximum of 3 comma seperated values representing the Service, Class and Attribute.
+For the CIP Service, we use a maximum of 3 comma separated values representing the Service, Class and Attribute.
 These values are described in the CIP specification.  CIP Classes are associated with their Service, and CIP Attributes
 are associated with their Service.  If you only need to match up until the Service, then only provide the Service value.
 If you want to match to the CIP Attribute, then you must provide all 3 values.

--- a/doc/userguide/rules/fast-pattern-explained.rst
+++ b/doc/userguide/rules/fast-pattern-explained.rst
@@ -131,7 +131,7 @@ score is returned.
     *  Longer patterns score better than short patters.
     *
     *  \param pat pattern
-    *  \param patlen length of the patternn
+    *  \param patlen length of the pattern
     *
     *  \retval s pattern score
     */

--- a/doc/userguide/rules/header-keywords.rst
+++ b/doc/userguide/rules/header-keywords.rst
@@ -261,7 +261,7 @@ The ack is the acknowledgement of the receipt of all previous
 (data)-bytes send by the other side of the TCP-connection. In most
 occasions every packet of a TCP connection has an ACK flag after the
 first SYN and a ack-number which increases with the receipt of every
-new data-byte.  The ack-keyword can be used in a signature to check
+new data-byte.  The ack keyword can be used in a signature to check
 for a specific TCP acknowledgement number.
 
 Format of ack::

--- a/doc/userguide/rules/modbus-keyword.rst
+++ b/doc/userguide/rules/modbus-keyword.rst
@@ -71,7 +71,7 @@ Examples::
   modbus: access read input                              # Read access to Discretes Input table
   modbus: access write coils                             # Write access to Coils table
   modbus: access read discretes, address <100            # Read access at address smaller than 100 of Discretes Input table
-  modbus: access write holding, address 500, value >200  # Write value greather than 200 at address 500 of Holding Registers table
+  modbus: access write holding, address 500, value >200  # Write value greater than 200 at address 500 of Holding Registers table
 
 With the setting **unit**, you can match on:
 
@@ -108,7 +108,7 @@ Examples::
   modbus: unit 10, access read                                          # Unit identifier 10 and Read access
   modbus: unit 10, access write coils                                   # Unit identifier 10 and Write access to Coils table
   modbus: unit >10, access read discretes, address <100                 # Greater than unit identifier 10 and Read access at address smaller than 100 of Discretes Input table
-  modbus: unit 10<>20, access write holding, address 500, value >200    # Greater than unit identifier 10 and smaller than unit identifier 20 and Write value greather than 200 at address 500 of Holding Registers table
+  modbus: unit 10<>20, access write holding, address 500, value >200    # Greater than unit identifier 10 and smaller than unit identifier 20 and Write value greater than 200 at address 500 of Holding Registers table
 
 (cf. http://www.modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf)
 

--- a/doc/userguide/rules/xbits.rst
+++ b/doc/userguide/rules/xbits.rst
@@ -42,7 +42,7 @@ Threading
 ---------
 
 Due to subtle timing issues between threads the order of sets and checks
-can be slightly unpredictible.
+can be slightly unpredictable.
 
 Unix Socket
 -----------


### PR DESCRIPTION
Various spelling issues within a few sections of the suricata user guide.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- spelling issues in documentation
- ensure used words are English USA

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

