### PR TITLE
Restore core dump privileges after uid/gid change (1271)

### DIFF
--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -93,7 +93,7 @@ void SCDropMainThreadCaps(uint32_t userid, uint32_t groupid)
     #ifdef HAVE_SYS_PRCTL_H
     if(prctl(PR_SET_DUMPABLE, 1) < 0) {
         SCLogError(SC_ERR_CHANGING_CAPS_FAILED, "restoring core dump privileges"
-                " failed");
+                " failed, error (%s)", strerror(errno));
     }
     #endif
     

--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -90,6 +90,13 @@ void SCDropMainThreadCaps(uint32_t userid, uint32_t groupid)
         exit(EXIT_FAILURE);
     }
 
+    #ifdef HAVE_SYS_PRCTL_H
+    if(prctl(PR_SET_DUMPABLE, 1) < 0) {
+        SCLogError(SC_ERR_CHANGING_CAPS_FAILED, "restoring core dump privileges"
+                " failed");
+    }
+    #endif
+    
     SCLogInfo("dropped the caps for main thread");
 }
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1271

Describe changes:
Per man(2) prctl, this flag is set to the value of '/proc/sys/fs/suid_dumpable' - which defaults to zero - when the effective user and/or group for the process is changed, effectively preventing suricata from creating core dumps after the main thread drops capabilities and changes the process uid/gid. This PR resets the flag (in order to allow suricata to create core dumps) after the process's effective UID/GID have been changed.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

