### PR TITLE
lua-file: Fix segfault when the protocol is anything other than HTTP (2498)

### DIFF
--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -322,7 +322,7 @@ static int LuaFileLogger(ThreadVars *tv, void *thread_data, const Packet *p, con
     LuaStateSetThreadVars(td->lua_ctx->luastate, tv);
     LuaStateSetPacket(td->lua_ctx->luastate, (Packet *)p);
     if (p->flow && p->flow->alstate) {
-        txptr = AppLayerParserGetTx(p->proto, p->flow->alproto, p->flow->alstate, ff->txid);
+        void *txptr = AppLayerParserGetTx(p->proto, p->flow->alproto, p->flow->alstate, ff->txid);
         if (txptr) {
             LuaStateSetTX(td->lua_ctx->luastate, txptr);
         }


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2498

Describe changes:
When a file is transferred over anything other than HTTP, the previously hard-coded HTTP protocol would trigger a non-existent index into htp_list_array_get(), causing a segfault. This patch mimics the logic in detect-lua-extensions.c  by referencing the alproto value in p->flow.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

