### PR TITLE
configure: handle --disable-lua/--disable-luajit correctly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1749,11 +1749,11 @@
   # liblua
     AC_ARG_ENABLE(lua,
 	        AS_HELP_STRING([--enable-lua],[Enable Lua support]),
-	        [ enable_lua="yes"],
+	        [],
 	        [ enable_lua="no"])
     AC_ARG_ENABLE(luajit,
 	        AS_HELP_STRING([--enable-luajit],[Enable Luajit support]),
-	        [ enable_luajit="yes"],
+	        [],
 	        [ enable_luajit="no"])
     if test "$enable_lua" = "yes"; then
         if test "$enable_luajit" = "yes"; then


### PR DESCRIPTION
For both lua and luajit, current version of configure.ac enables these
features in the if-present action of respective AC_ARG_ENABLE
declarations. This result in them being enabled even if the relevant
command-line arguments were in fact *--disable-foo*; the only way of
disabling them is to omit the arguments from the command line
altogether.

Make the if-present action for both arguments null so that configure
respects both positive and negative command-line options if provided.
Both if-absent actions remain as they were so that lua/luajit support is
disabled by default.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ ] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- configure: passing --disable-lua no longer actually enables liblua support
- same goes for --disable-luajit

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

