### PR TITLE
output-file: Ensure that we evaluate whether a file has been stored (2500) v2

### DIFF
--- a/src/output-file.c
+++ b/src/output-file.c
@@ -114,7 +114,7 @@ static void OutputFileLogFfc(ThreadVars *tv,
 
             SCLogDebug("ff %p state %u", ff, ff->state);
 
-            if (ff->state > FILE_STATE_OPENED (ff->flags & FILE_STORE || ff->flags & FILE_NOSTORE)) {
+            if (ff->state > FILE_STATE_OPENED && (ff->flags & FILE_STORE || ff->flags & FILE_NOSTORE)) {
                 bool file_logged = false;
 #ifdef HAVE_MAGIC
                 if (FileForceMagic() && ff->magic == NULL) {

--- a/src/output-file.c
+++ b/src/output-file.c
@@ -114,7 +114,7 @@ static void OutputFileLogFfc(ThreadVars *tv,
 
             SCLogDebug("ff %p state %u", ff, ff->state);
 
-            if (ff->state > FILE_STATE_OPENED) {
+            if (ff->state > FILE_STATE_OPENED (ff->flags & FILE_STORE || ff->flags & FILE_NOSTORE)) {
                 bool file_logged = false;
 #ifdef HAVE_MAGIC
                 if (FileForceMagic() && ff->magic == NULL) {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2500

Describe changes:
The previous logic did not take into account whether a file has been stored or not before executing the logger functions. This would result in stored almost always (except where force file store for all files is enabled) evaluating to false as the store/no store evaluation happens after the logger calls. This change ensures that either FILE_STORE or FILE_NOSTORE is set before executing the logger functions.

**Test Case**
With filestore configured to only log selected files: `force-filestore: no`

Rule:
`
alert http any any -> any any (msg:"FILESTORE executable file"; flow:established,to_client; filesize:5KB<>5MB; filemagic:"executable"; filestore; noalert; sid:95500001; rev:1;)
`

Lua test script:
[test.lua.zip](https://github.com/OISF/suricata/files/1971074/test.lua.zip)


Expected result:
Without the change, stored will always evaluate to false even if the file is ultimately stored due to the filestore keyword in the rule.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

