### PR TITLE
output-file: Ensure that we evaluate whether a file has been stored (2500) v3

### DIFF
--- a/src/output-file.c
+++ b/src/output-file.c
@@ -114,7 +114,8 @@ static void OutputFileLogFfc(ThreadVars *tv,
 
             SCLogDebug("ff %p state %u", ff, ff->state);
 
-            if (ff->state > FILE_STATE_OPENED) {
+            if (ff->state > FILE_STATE_OPENED &&
+               (ff->flags & (FILE_STORED|FILE_NOSTORE))) {
                 bool file_logged = false;
 #ifdef HAVE_MAGIC
                 if (FileForceMagic() && ff->magic == NULL) {

--- a/src/output-filedata.c
+++ b/src/output-filedata.c
@@ -145,6 +145,12 @@ static void OutputFiledataLogFfc(ThreadVars *tv, OutputLoggerThreadStore *store,
 
             if (!(ff->flags & FILE_STORE)) {
                 SCLogDebug("ff FILE_STORE not set");
+                /* if the stream has been closed and we still
+                 * haven't stored the file then mark it no-store */
+                if (ff->state >= FILE_STATE_CLOSED &&
+                    (p->flowflags & STREAM_EOF)) {
+                    ff->flags |= FILE_NOSTORE;
+                }
                 continue;
             }
 

--- a/src/output-filedata.c
+++ b/src/output-filedata.c
@@ -148,7 +148,7 @@ static void OutputFiledataLogFfc(ThreadVars *tv, OutputLoggerThreadStore *store,
                 /* if the stream has been closed and we still
                  * haven't stored the file then mark it no-store */
                 if (ff->state >= FILE_STATE_CLOSED &&
-                    (p->flowflags & STREAM_EOF)) {
+                    (p->flags & PKT_STREAM_EOF)) {
                     ff->flags |= FILE_NOSTORE;
                 }
                 continue;


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2500

Describe changes:
The previous logic did not take into account whether a file has been stored or not before executing the logger functions. This would result in stored almost always (except where force file store for all files is enabled) evaluating to false as the store/no store evaluation happens after the logger calls. This change ensures that either FILE_STORED or FILE_NOSTORE is set before executing the logger functions. It also ensures that files which haven't been marked FILE_STORE after the stream is closed are marked FILE_NOSTORE.

**Test Case**
With filestore configured to only log selected files: `force-filestore: no`

Rule:
`alert http any any -> any any (msg:"FILESTORE executable file"; flow:established,to_client; filesize:5KB<>5MB; filemagic:"executable"; filestore; noalert; sid:95500001; rev:1;)`

Lua test script:
[test.lua.zip](https://github.com/OISF/suricata/files/1977368/test.lua.zip)

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

