### PR TITLE
eve/json/xff - remove check for flow being NULL - v1

### DIFF
--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -209,7 +209,7 @@ json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
     json_object_set_new(fjs, "tx_id", json_integer(ff->txid));
 
     /* xff header */
-    if ((xff_cfg != NULL) && !(xff_cfg->flags & XFF_DISABLED) && p->flow != NULL) {
+    if ((xff_cfg != NULL) && !(xff_cfg->flags & XFF_DISABLED)) {
         int have_xff_ip = 0;
         char buffer[XFF_MAXLEN];
 


### PR DESCRIPTION
Fix Coverity issue:
** CID 1435535:  Null pointer dereferences  (REVERSE_INULL)
/src/output-json-file.c: 212 in JsonBuildFileInfoRecord()

Where we check a variable for being NULL, when all paths to the
code show that it can't be NULL.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/293
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/646
