### PR TITLE
Moved EngineAnalysisRules2 w/EngineAnalysisRules

### DIFF
--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1820,9 +1820,6 @@ static int SigMatchPrepare(DetectEngineCtx *de_ctx)
             SigMatch *sm = s->init_data->smlists[type];
             s->sm_arrays[type] = SigMatchList2DataArray(sm);
         }
-#ifdef HAVE_LIBJANSSON
-        EngineAnalysisRules2(de_ctx, s);
-#endif
         /* free lists. Ctx' are xferred to sm_arrays so won't get freed */
         uint32_t i;
         for (i = 0; i < s->init_data->smlists_array_size; i++) {

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -175,6 +175,9 @@ static int DetectLoadSigFile(DetectEngineCtx *de_ctx, char *sig_file,
                 }
                 if (rule_engine_analysis_set) {
                     EngineAnalysisRules(de_ctx, sig, line);
+#ifdef HAVE_LIBJANSSON
+                    EngineAnalysisRules2(de_ctx, sig);
+#endif
                 }
             }
             SCLogDebug("signature %"PRIu32" loaded", sig->id);


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [**N/A**] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2493

Describe changes:
-EngineAnalysisRules2 was in a strange location where it did not respect
the --engine-analysis flag. It has been moved to the same call location
as EngineAnalysisRules.
