### PR TITLE
source-pcap-file: delete when done (2417) v2

### DIFF
--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -25,15 +25,21 @@
 
 .. option:: -r <path>
 
-   Run in pcap offline mode reading files from pcap file. If <path> specifies
-   a directory, all files in that directory will be processed in order of
-   modified time maintaining flow state between files.
+   Run in pcap offline mode (replay mode) reading files from pcap file. If
+   <path> specifies a directory, all files in that directory will be processed
+   in order of modified time maintaining flow state between files.
 
 .. option:: --pcap-file-continuous
 
    Used with the -r option to indicate that the mode should stay alive until
    interrupted. This is useful with directories to add new files and not reset
    flow state between files.
+
+.. option:: --pcap-file-delete
+
+   Used with the -r option to indicate that the mode should delete pcap files
+   after they have been processed. This is useful with pcap-file-continuous to
+   continuously feed files to a directory and have them cleaned up when done.
 
 .. option::  -i <interface>
 

--- a/doc/userguide/unix-socket.rst
+++ b/doc/userguide/unix-socket.rst
@@ -256,9 +256,35 @@ In pcap-file mode, this gives:
   SND: {"command": "pcap-file-list"}
   RCV: {"message": {"count": 1, "files": ["/home/eric/git/oisf/benches/sandnet.pcap"]}, "return": "OK"}
   Success: {'count': 1, 'files': ['/home/eric/git/oisf/benches/sandnet.pcap']}
+  >>> pcap-file-continuous /home/eric/git/oisf/benches /tmp/bench 0 true
+  SND: {"command": "pcap-file", "arguments": {"output-dir": "/tmp/bench", "filename": "/home/eric/git/oisf/benches/sandnet.pcap", "tenant": 0, "delete-when-done": true}}
+  RCV: {"message": "Successfully added file to list", "return": "OK"}
+  Success: Successfully added file to list
 
 There is one thing to be careful about: a Suricata message is sent in
 multiple send operations. This result in possible incomplete read on
 client side. The worse workaround is to sleep a bit before trying a
 recv call. An other solution is to use non blocking socket and retry a
 recv if the previous one has failed.
+
+Pcap-file json format is:
+
+::
+
+  {
+    "command": "pcap-file",
+    "arguments": {
+      "output-dir": "path to output dir",
+      "filename": "path to file or directory to run",
+      "tenant": 0,
+      "continuous": false,
+      "delete-when-done": false
+    }
+  }
+
+`output-dir` and `filename` are required. `tenant` is optional and should be a
+number, indicating which tenant the file or directory should run under. `continuous`
+is optional and should be true/false, indicating that file or directory should be
+run until `pcap-interrupt` is sent or ctrl-c is invoked. `delete-when-done` is
+optional and should be true/false, indicating that the file or files under the
+directory specified by `filename` should be deleted when processing is complete.

--- a/python/suricata/sc/suricatasc.py
+++ b/python/suricata/sc/suricatasc.py
@@ -184,6 +184,9 @@ class SuricataSC:
                 continuous = None
                 if len(parts) > 4:
                     continuous = parts[4]
+                delete_when_done = None
+                if len(parts) > 5:
+                    delete_when_done = parts[5]
                 if cmd != "pcap-file":
                     raise SuricataCommandException("Invalid command '%s'" % (command))
                 else:
@@ -194,6 +197,8 @@ class SuricataSC:
                         arguments["tenant"] = int(tenant)
                     if continuous != None:
                         arguments["continuous"] = continuous
+                    if delete_when_done != None:
+                        arguments["delete-when-done"] = delete_when_done
             elif "pcap-file-continuous " in command:
                 try:
                     parts = command.split(' ')
@@ -203,6 +208,9 @@ class SuricataSC:
                 tenant = None
                 if len(parts) > 3:
                     tenant = parts[3]
+                delete_when_done = None
+                if len(parts) > 4:
+                    delete_when_done = parts[4]
                 if cmd != "pcap-file":
                     raise SuricataCommandException("Invalid command '%s'" % (command))
                 else:
@@ -212,6 +220,8 @@ class SuricataSC:
                     arguments["continuous"] = True
                     if tenant != None:
                         arguments["tenant"] = int(tenant)
+                    if delete_when_done != None:
+                        arguments["delete-when-done"] = delete_when_done
             elif "iface-stat" in command:
                 try:
                     [cmd, iface] = command.split(' ', 1)

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -41,6 +41,13 @@ void CleanupPcapFileFileVars(PcapFileFileVars *pfv)
             pfv->pcap_handle = NULL;
         }
         if (pfv->filename != NULL) {
+            if (pfv->shared->should_delete) {
+                SCLogDebug("Deleting pcap file %s", pfv->filename);
+                if (unlink(pfv->filename) != 0) {
+                    SCLogWarning(SC_ERR_PCAP_FILE_DELETE_FAILED,
+                                 "Failed to delete %s", pfv->filename);
+                }
+            }
             SCFree(pfv->filename);
             pfv->filename = NULL;
         }

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -45,6 +45,8 @@ typedef struct PcapFileSharedVars_
 
     struct timespec last_processed;
 
+    bool should_delete;
+
     ThreadVars *tv;
     TmSlot *slot;
 

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -231,6 +231,12 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
         }
     }
 
+    int should_delete = 0;
+    ptv->shared.should_delete = false;
+    if (ConfGetBool("pcap-file.delete-when-done", &should_delete) == 1) {
+        ptv->shared.should_delete = should_delete == 1;
+    }
+
     DIR *directory = NULL;
     SCLogInfo("Checking file or directory %s", (char*)initdata);
     if(PcapDetermineDirectoryOrFile((char *)initdata, &directory) == TM_ECODE_FAILED) {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -619,6 +619,7 @@ static void PrintUsage(const char *progname)
     printf("\t--build-info                         : display build information\n");
     printf("\t--pcap[=<dev>]                       : run in pcap mode, no value select interfaces from suricata.yaml\n");
     printf("\t--pcap-file-continuous               : when running in pcap mode with a directory, continue checking directory for pcaps until interrupted\n");
+    printf("\t--pcap-file-delete                   : when running in replay mode (-r with directory or file), will delete pcap files that have been processed when done\n");
 #ifdef HAVE_PCAP_SET_BUFF
     printf("\t--pcap-buffer-size                   : size of the pcap buffer value from 0 - %i\n",INT_MAX);
 #endif /* HAVE_SET_PCAP_BUFF */
@@ -1459,6 +1460,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         {"netmap", optional_argument, 0, 0},
         {"pcap", optional_argument, 0, 0},
         {"pcap-file-continuous", 0, 0, 0},
+        {"pcap-file-delete", 0, 0, 0},
         {"simulate-ips", 0, 0 , 0},
         {"no-random", 0, &g_disable_randomness, 1},
 
@@ -1829,8 +1831,14 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 }
             }
             else if (strcmp((long_opts[option_index]).name, "pcap-file-continuous") == 0) {
-                if(ConfSetFinal("pcap-file.continuous", "true") != 1) {
+                if (ConfSetFinal("pcap-file.continuous", "true") != 1) {
                     SCLogError(SC_ERR_CMD_LINE, "Failed to set pcap-file.continuous");
+                    return TM_ECODE_FAILED;
+                }
+            }
+            else if (strcmp((long_opts[option_index]).name, "pcap-file-delete") == 0) {
+                if (ConfSetFinal("pcap-file.delete-when-done", "true") != 1) {
+                    SCLogError(SC_ERR_CMD_LINE, "Failed to set pcap-file.delete-when-done");
                     return TM_ECODE_FAILED;
                 }
             }


### PR DESCRIPTION
Version 2 of:
 * https://github.com/OISF/suricata/pull/3164

Add option to have pcap files deleted after they have been processed.
This option combines well with pcap file continuous and streaming
files to a directory being processed.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2417

Describe changes:
- Add option "pcap-file-delete" and corresponding json argument "delete-when-done" to indicate the source-pcap-file should delete the pcap files it processes.
- Cleanup in source-pcap-file-helper will use flag to determine whether file should be deleted.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):