### PR TITLE
Update ntp-parser to 0.2.0

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -20,5 +20,5 @@ crc = "~1.7.0"
 der-parser = "0.5.2"
 kerberos-parser = "0.1.0"
 
-ntp-parser = "^0"
+ntp-parser = "0.2.0"
 ipsec-parser = "~0.3.0"

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -89,7 +89,7 @@ impl NTPState {
         match parse_ntp(i) {
             IResult::Done(_,ref msg) => {
                 // SCLogDebug!("parse_ntp: {:?}",msg);
-                if msg.mode == 1 || msg.mode == 3 {
+                if msg.mode == NtpMode::SymmetricActive || msg.mode == NtpMode::Client {
                     let mut tx = self.new_tx();
                     // use the reference id as identifier
                     tx.xid = msg.ref_id;


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2504

Describe changes:
- Update ntp-parser to 0.2.0, and fix build failure
- Change dependency in Cargo.toml to use 0.2.0: bug fixes (0.2.x) will be allowed, but not updates (fro ex. 0.3.0). This should prevent new problems.
