### PR TITLE
doc: spelling mistakes in various sections of the user guide V3

### DIFF
--- a/doc/userguide/configuration/global-thresholds.rst
+++ b/doc/userguide/configuration/global-thresholds.rst
@@ -3,7 +3,7 @@ Global-Thresholds
 
 Thresholds can be configured in the rules themselves, see
 :doc:`../rules/thresholding`. They are often set by rule writers based on
-their intel for creating a rule combined with a judgement on how often
+their intelligence for creating a rule combined with a judgement on how often
 a rule will alert.
 
 Threshold Config

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -14,13 +14,13 @@ Max-pending-packets
 -------------------
 
 With the max-pending-packets setting you can set the number of packets
-you allow Suricata to process simultaneously.  This can range from one
-packet to tens of thousands/hundreds of thousands of packets.  It is a
+you allow Suricata to process simultaneously. This can range from one
+packet to tens of thousands/hundreds of thousands of packets. It is a
 trade of higher performance and the use of more memory (RAM), or lower
 performance and less use of memory. A high number of packets being
 processed results in a higher performance and the use of more
 memory. A low number of packets, results in lower performance and less
-use of memory.  Choosing a low number of packets being processed while
+use of memory. Choosing a low number of packets being processed while
 having many CPU's/CPU cores, can result in not making use of the whole
 computer-capacity. (For instance: using one core while having three
 waiting for processing packets.)
@@ -91,7 +91,7 @@ Action-order
 
 All signatures have different properties. One of those is the Action
 property. This one determines what will happen when a signature
-matches.  There are four types of Action. A summary of what will
+matches. There are four types of Action. A summary of what will
 happen when a signature matches and contains one of those Actions:
 
 1) Pass
@@ -102,9 +102,9 @@ packet).
 
 2) Drop
 
-This only concerns the IPS/inline mode.  If the program finds a
+This only concerns the IPS/inline mode. If the program finds a
 signature that matches, containing drop, it stops immediately. The
-packet will not be sent any further.  Drawback: The receiver does not
+packet will not be sent any further. Drawback: The receiver does not
 receive a message of what is going on, resulting in a time-out
 (certainly with TCP). Suricata generates an alert for this packet.
 
@@ -149,7 +149,7 @@ Splitting configuration in multiple files
 -----------------------------------------
 
 Some users might have a need or a wish to split their suricata.yaml
-file in to seperate files, this is available vis the 'include' and
+file in to separate files, this is available vis the 'include' and
 '!include' keyword. The first example is of taking the contents of the
 outputs section and storing them in outputs.yaml
 
@@ -248,7 +248,7 @@ the use of more disc space, so enable only the outputs you need.
 Line based alerts log (fast.log)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This log contains alerts consisting of a single line.  Example of the
+This log contains alerts consisting of a single line. Example of the
 appearance of a single fast.log-file line:
 
 ::
@@ -316,7 +316,7 @@ This output supports IPv6 and IPv4 events.
 
       # By default unified2 log files have the file creation time (in
       # unix epoch format) appended to the filename. Set this to yes to
-      # disable this behaviour.
+      # disable this behavior.
       #nostamp: no
 
       # Sensor ID field of unified2 alerts.
@@ -393,7 +393,7 @@ server, ttl, resource record data. This logging can also be performed
 through the use of the :ref:`Eve-log capability <eve-json-format>` which
 offers easier parsing.
 
-Example of the apperance of a DNS log of a query with a preceding reply:
+Example of the appearance of a DNS log of a query with a preceding reply:
 
 ::
 
@@ -441,9 +441,9 @@ The pcap-log option can be enabled and disabled.
 
 There is a size limit for the pcap-log file that can be set. The
 default limit is 32 MB. If the log-file reaches this limit, the file
-will be rotated and a new one will be created.  The pcap-log option
+will be rotated and a new one will be created. The pcap-log option
 has an extra functionality for "Sguil":http://sguil.sourceforge.net/
-that can be enabled in the 'mode' option.  In the sguil mode the
+that can be enabled in the 'mode' option. In the sguil mode the
 "sguil_base_dir" indicates the base directory. In this base dir the
 pcaps are created in a Sguil-specific directory structure that is
 based on the day:
@@ -544,7 +544,7 @@ want the output-data to be written to the log file.
 
   - stats:
        enabled: yes               #By default, the stats-option is enabled
-       filename: stats.log        #The log-name. Combined with the  default logging directory
+       filename: stats.log        #The log-name. Combined with the default logging directory
                                   #(default-log-dir) it will result in /var/log/suricata/stats.log.
                                   #This directory can be overruled with a absolute path. (A
                                   #directory starting with / ).
@@ -633,7 +633,7 @@ Detection engine
 Inspection configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The detection-engine builds internal groups of signatures. Suricata loads signatures, with which the network traffic will be compared. The fact is, that many rules certainly will not be necessary. (For instance: if there appears a packet with the UDP-protocol, all signatures for the TCP-protocol won't be needed.)  For that reason, all signatures will be divided in groups. However, a distribution containing many groups will make use of a lot of memory. Not every type of signature gets its own group. There is a possibility that different signatures with several properties in common, will be placed together in a group.  The quantity of groups will determine the balance between memory and performance. A small amount of groups will lower the performance yet uses little memory. The opposite counts for a higher amount of groups. The engine allows you to manage the balance between memory and performance. To manage this, (by determining the amount of groups) there are several general options:high for good performance and more use of memory, low for low performance and little use of memory. The option medium is the balance between performance and memory usage. This is the default setting.The option custom is for advanced users. This option has values which can be managed by the user.
+The detection-engine builds internal groups of signatures. Suricata loads signatures, with which the network traffic will be compared. The fact is, that many rules certainly will not be necessary. (For instance: if there appears a packet with the UDP-protocol, all signatures for the TCP-protocol won't be needed.) For that reason, all signatures will be divided in groups. However, a distribution containing many groups will make use of a lot of memory. Not every type of signature gets its own group. There is a possibility that different signatures with several properties in common, will be placed together in a group. The quantity of groups will determine the balance between memory and performance. A small amount of groups will lower the performance yet uses little memory. The opposite counts for a higher amount of groups. The engine allows you to manage the balance between memory and performance. To manage this, (by determining the amount of groups) there are several general options: high for good performance and more use of memory, low for low performance and little use of memory. The option medium is the balance between performance and memory usage. This is the default setting. The option custom is for advanced users. This option has values which can be managed by the user.
 
 ::
 
@@ -645,13 +645,13 @@ The detection-engine builds internal groups of signatures. Suricata loads signat
     sgh-mpm-context: auto
     inspection-recursion-limit: 3000
 
-At all of these options, you can add (or change) a value.  Most
+At all of these options, you can add (or change) a value. Most
 signatures have the adjustment to focus on one direction, meaning
 focusing exclusively on the server, or exclusively on the client.
 
 If you take a look at example 4, *the Detection-engine grouping tree*,
 you see it has many branches. At the end of each branch, there is
-actually a 'sig group head'.  Within that sig group head there is a
+actually a 'sig group head'. Within that sig group head there is a
 container which contains a list with signatures that are significant
 for that specific group/that specific end of the branch. Also within
 the sig group head the settings for Multi-Pattern-Matcher (MPM) can be
@@ -668,7 +668,7 @@ For setting the option sgh-mpm-context, you can choose from auto, full
 or single. The default setting is 'auto', meaning Suricata selects
 full or single based on the algorithm you use. 'Full' means that every
 group has its own MPM-context, and 'single' that all groups share one
-MPM-context.  The two algorithms ac and ac-gfbs are new in 1.03. These
+MPM-context. The two algorithms ac and ac-gfbs are new in 1.03. These
 algorithms use a single MPM-context if the Sgh-MPM-context setting is
 'auto'. The rest of the algorithms use full in that case.
 
@@ -749,7 +749,7 @@ These are the proceedings:
 
 1)A packet comes in.
 
-2)The packed will be analysed by the Multi-pattern-matcher in search
+2)The packed will be analyzed by the Multi-pattern-matcher in search
   of patterns that match.
 
 3)All patterns that match, will be further processed by Suricata (signatures).
@@ -790,7 +790,7 @@ used with the final step of the pattern matcher, namely the validation
 of the pattern. For this option the same counts as for the hash-size
 option: setting it to low will cause lower memory usage, but lowers
 the performance. The opposite counts for a high setting of the
-bf_size: higher memory usage, but (generally) higher performance.  The
+bf_size: higher memory usage, but (generally) higher performance. The
 bloom-filter sizes can vary from low (512) - medium (1024) - high
 (2048).
 
@@ -889,13 +889,13 @@ become active.
 In the option 'cpu affinity' you can set which CPU's/cores work on which
 thread. In this option there are several sets of threads. The management-,
 receive-, worker- and verdict-set. These are fixed names and can not be
-changed. For each set there are several options: cpu, mode, and prio.  In the
+changed. For each set there are several options: cpu, mode, and prio. In the
 option 'cpu' you can set the numbers of the CPU's/cores which will run the
 threads from that set. You can set this option to 'all', use a range (0-3) or a
 comma separated list (0,1).  The option 'mode' can be set to 'balanced' or
 'exclusive'. When set to 'balanced', the individual threads can be processed by
 all cores set in the option 'cpu'. If the option 'mode' is set to 'exclusive',
-there will be fixed cores for each thread.  As mentioned before, threads can
+there will be fixed cores for each thread. As mentioned before, threads can
 have different priority's. In the option 'prio' you can set a priority for each
 thread. This priority can be low, medium, high or you can set the priority to
 'default'. If you do not set a priority for a CPU, than the settings in
@@ -972,7 +972,7 @@ packet is reconstructed by the defragment-engine, the engine sends on
 the reassembled packet to rest of Suricata.
 
 There are three options within defrag: max-frags, prealloc and
-timeout.  At the moment Suricata receives a fragment of a packet, it
+timeout. At the moment Suricata receives a fragment of a packet, it
 keeps in memory that other fragments of that packet will appear soon
 to complete the packet. However, there is a possibility that one of
 the fragments does not appear. To prevent Suricata for keeping waiting
@@ -997,7 +997,7 @@ Flow Settings
 
 Within Suricata, Flows are very important. They play a big part in the
 way Suricata organizes data internally. A flow is a bit similar to a
-connection, except a flow is more general.All packets having the same
+connection, except a flow is more general. All packets having the same
 Tuple (protocol, source IP, destination IP, source-port,
 destination-port), belong to the same flow. Packets belonging to a
 flow are connected to it internally.
@@ -1128,7 +1128,7 @@ exists of two parts: The stream tracking- and the reassembly-engine.
 
 The stream-tracking engine monitors the state of a connection. The
 reassembly-engine reconstructs the flow as it used to be, so it will
-be recognised by Suricata.
+be recognized by Suricata.
 
 The stream-engine has two memcaps that can be set. One for the
 stream-tracking-engine and one for the reassembly-engine.
@@ -1160,7 +1160,7 @@ started. This way, Suricata misses the original setup of those
 sessions. This setup always includes a lot of information. If you want
 Suricata to check the stream from that time on, you can do so by
 setting the option 'midstream' to 'true'. The default setting is
-'false'.  Normally Suricata is able to see all packets of a
+'false'. Normally Suricata is able to see all packets of a
 connection. Some networks make it more complicated though. Some of the
 network-traffic follows a different route than the other part, in
 other words: the traffic goes asynchronous. To make sure Suricata will
@@ -1411,7 +1411,7 @@ use of libhtp.
        # Apache does not do this, but IIS does. If enabled, a path such as
        # "/one%2ftwo" will be normalized to "/one/two". If the
        # backslash_separators option is also enabled, encoded backslash
-       # characters will be converted too (and subseqently normalized to
+       # characters will be converted too (and subsequently normalized to
        # forward slashes).  Accepted values - yes, no.
        #path-decode-separators: yes
 
@@ -1442,7 +1442,7 @@ use of libhtp.
        # path.  Accepted values - none, terminate, status_400, status_404.
        path-nul-raw-handling: none
 
-       # Sets the replacement characater that will be used to in the lossy
+       # Sets the replacement character that will be used to in the lossy
        # best-fit mapping from Unicode characters into single-byte streams.
        # The question mark is the default replacement character.
        #set-path-replacement-char: ?
@@ -1528,7 +1528,7 @@ is the actual message.)
 
 It is possible to determine which information will be displayed in
 this line and (the manner how it will be displayed) in which format it
-will be displayed.  This option is the so called format string::
+will be displayed. This option is the so called format string::
 
   default-log-format: "[%i] %t - (%f:%l) <%d> (%n) -- "
 
@@ -1595,7 +1595,7 @@ Pf-ring
 ~~~~~~~
 
 The Pf_ring is a library that aims to improve packet capture
-performance over libcap. It performs packet acquisition.  There are
+performance over libcap. It performs packet acquisition. There are
 three options within Pf_ring: interface, cluster-id and cluster-type.
 
 ::
@@ -1718,7 +1718,7 @@ Rule-files
 For different categories of risk there are different rule-files
 available containing one or more rules. There is a possibility to
 instruct Suricata where to find these rules and which rules you want
-to be load for use.  You can set the directory where the files can be
+to be load for use. You can set the directory where the files can be
 found.
 
 ::
@@ -1892,7 +1892,7 @@ Engine-analysis
 ~~~~~~~~~~~~~~~
 
 The option engine-analysis provides information for signature writers
-about how Suricata organises signatures internally.
+about how Suricata organizes signatures internally.
 
 Like mentioned before, signatures have zero or more patterns on which
 they can match. Only one of these patterns will be used by the multi
@@ -2090,9 +2090,9 @@ in yaml.
 
 It is best to use runmode 'single' if you would like to profile the
 speed of the code.  When using a single thread, there is no situation
-in which two threads have to wait for each other . When using two
+in which two threads have to wait for each other. When using two
 threads, the time threads might have to wait for each other will be
-taken in account when/during profiling packets.  For more information
+taken in account when/during profiling packets. For more information
 see :doc:`../performance/packet-profiling`.
 
 Application layers
@@ -2126,7 +2126,7 @@ Encrypted traffic
 
 There is no decryption of encrypted traffic, so once the handshake is complete
 continued tracking of the session is of limited use. The ``no-reassemble``
-option controls the behaviour after the handshake.
+option controls the behavior after the handshake.
 
 If ``no-reassemble`` is set to ``true``, all processing of this session is
 stopped. No further parsing and inspection happens. If ``bypass`` is enabled

--- a/doc/userguide/make-sense-alerts.rst
+++ b/doc/userguide/make-sense-alerts.rst
@@ -49,7 +49,7 @@ information:
   www.emergingthreats.net/cgi-bin/cvsweb.cgi/sigs/CURRENT_EVENTS/CURRENT_Adobe
 
 Some rules contain a reference like: "reference:cve,2009-3958;" should
-allow you to find info about the specific CVE using your favourite
+allow you to find info about the specific CVE using your favorite
 search engine.
 
 It's not always straight forward and sometimes not all of that

--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -124,12 +124,12 @@ Fields
 In addition to these fields, if the extended logging is enabled in the suricata.yaml file the following fields are (can) also included:
 
 * "length": The content size of the HTTP body
-* "status": HTTP statuscode
+* "status": HTTP status code
 * "protocol": Protocol / Version of HTTP (ex: HTTP/1.1)
 * "http_method": The HTTP method (ex: GET, POST, HEAD)
 * "http_refer": The referer for this action
 
-In addition to the extended logging fields one can also choose to enable/add from 50 additional custom logging HTTP fields enabled in the suricata.yaml file. The additional fields can be enabled as following:
+In addition to the extended logging fields one can also choose to enable/add from more than 50 additional custom logging HTTP fields enabled in the suricata.yaml file. The additional fields can be enabled as following:
 
 
 ::
@@ -474,7 +474,7 @@ SMB Fields
 * "filename" (string): filename for CREATE and other commands.
 * "disposition" (string): requested disposition. E.g. FILE_OPEN, FILE_CREATE and FILE_OVERWRITE. See https://msdn.microsoft.com/en-us/library/ee442175.aspx#Appendix_A_Target_119
 * "access" (string): indication of how the file was opened. "normal" or "delete on close" (field is subject to change)
-* "created", "accessed", "modified", "changed" (interger): timestamps in seconds since unix epoch
+* "created", "accessed", "modified", "changed" (integer): timestamps in seconds since unix epoch
 * "size" (integer): size of the requested file
 * "fuid" (string): SMB2+ file GUID. SMB1 FID as hex.
 * "share" (string): share name.

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -47,7 +47,7 @@ Output types::
 Alerts
 ~~~~~~
 
-Alerts are event records for rule matches. They can be ammended with
+Alerts are event records for rule matches. They can be amended with
 metadata, such as the application layer record (HTTP, DNS, etc) an
 alert was generated for, and elements of the rule.
 

--- a/doc/userguide/output/syslog-alerting-comp.rst
+++ b/doc/userguide/output/syslog-alerting-comp.rst
@@ -1,20 +1,20 @@
 Syslog Alerting Compatibility
 =============================
 
-Suricata can alert via sylog which is a very handy feature for central log collection, compliance, and reporting to a SIEM.  Instructions on setting this up can be found in the .yaml file in the section where you can configure what type of alert (and other) logging you would like.
+Suricata can alert via sylog which is a very handy feature for central log collection, compliance, and reporting to a SIEM. Instructions on setting this up can be found in the .yaml file in the section where you can configure what type of alert (and other) logging you would like.
 
-However, there are different syslog daemons and there can be parsing issues with the syslog format a SIEM expects and what syslog format Suricata sends.  The syslog format from Suricata is dependent on the syslog daemon running on the Suricata sensor but often the format it sends is not the format the SIEM expects and cannot parse it properly.
+However, there are different syslog daemons and there can be parsing issues with the syslog format a SIEM expects and what syslog format Suricata sends. The syslog format from Suricata is dependent on the syslog daemon running on the Suricata sensor but often the format it sends is not the format the SIEM expects and cannot parse it properly.
 
 Popular syslog daemons
 ----------------------
 
 * **syslogd** - logs system messages
-* **syslog-ng** - logs system messages but also suports TCP, TLS, and other enhanced enterprise features
+* **syslog-ng** - logs system messages but also supports TCP, TLS, and other enhanced enterprise features
 * **rsyslogd** - logs system messages but also support TCP, TLS, multi-threading, and other enhanced features
 * **klogd** - logs kernel messages
 * **sysklogd** - basically a bundle of syslogd and klogd
 
-If the syslog format the Suricata sensor is sending is not compatible with what your SIEM or syslog collector expects, you will need to fix this.  You can do this on your SIEM if it is capable of being able to be configured to interpret the message, or by configuring the syslog daemon on the Suricata sensor itself to send in a format you SIEM can parse.  The latter can be done by applying a template to your syslog config file.
+If the syslog format the Suricata sensor is sending is not compatible with what your SIEM or syslog collector expects, you will need to fix this. You can do this on your SIEM if it is capable of being able to be configured to interpret the message, or by configuring the syslog daemon on the Suricata sensor itself to send in a format you SIEM can parse. The latter can be done by applying a template to your syslog config file.
 
 Finding what syslog daemon you are using
 ----------------------------------------
@@ -27,7 +27,7 @@ There are many ways to find out what syslog daemon you are using but here is one
   cd /etc/init.d
   ls | grep syslog
 
-You should see a file with the word syslog in it, e.g. "syslog", "rsyslogd", etc. Obviously if the name is "rsyslogd" you can be fairly confident you are running rsyslogd.  If unsure or the filename is just "syslog", take a look at that file. For example, if it was "rsyslogd", run:
+You should see a file with the word syslog in it, e.g. "syslog", "rsyslogd", etc. Obviously if the name is "rsyslogd" you can be fairly confident you are running rsyslogd. If unsure or the filename is just "syslog", take a look at that file. For example, if it was "rsyslogd", run:
 
 ::
 
@@ -41,12 +41,12 @@ At the top you should see a comment line that looks something like this:
 
   # rsyslog        Starts rsyslogd/rklogd.
 
-Locate those files and look at them to give you clues as to what syslog daemon you are running.  Also look in the *start()* section of the file you ran "less" on and see what binaries get started because that can give you clues as well.
+Locate those files and look at them to give you clues as to what syslog daemon you are running. Also look in the *start()* section of the file you ran "less" on and see what binaries get started because that can give you clues as well.
 
 Example
 -------
 
-Here is an example where the Suricata sensor is sending syslog messages in rsyslogd format but the SIEM is expecting and parsing them in a sysklogd format.  In the syslog configuration file (ususally in /etc with a filename like rsyslog.conf or syslog.conf), first add the template:
+Here is an example where the Suricata sensor is sending syslog messages in rsyslogd format but the SIEM is expecting and parsing them in a sysklogd format. In the syslog configuration file (usually in /etc with a filename like rsyslog.conf or syslog.conf), first add the template:
 
 ::
 

--- a/doc/userguide/partials/options-unittests.rst
+++ b/doc/userguide/partials/options-unittests.rst
@@ -8,7 +8,7 @@
 .. option:: -U, --unittest-filter=REGEX
 
    With the -U option you can select which of the unit tests you want
-   to run. This option uses REGEX.  Example of use: suricata -u -U
+   to run. This option uses REGEX. Example of use: suricata -u -U
    http
 
 .. option:: --list-unittests
@@ -18,7 +18,7 @@
 .. option:: --fatal-unittests
 
    Enables fatal failure on a unit test error. Suricata will exit
-   instead of continuuing more tests.
+   instead of continuing more tests.
 
 .. option:: --unittests-coverage
 

--- a/doc/userguide/rules/enip-keyword.rst
+++ b/doc/userguide/rules/enip-keyword.rst
@@ -13,9 +13,9 @@ There are three ways of using this keyword:
 
 For the ENIP command, we are matching against the command field found in the ENIP encapsulation.
 
-For the CIP Service, we use a maximum of 3 comma seperated values representing the Service, Class and Attribute.
-These values are described in the CIP specification.  CIP Classes are associated with their Service, and CIP Attributes
-are associated with their Service.  If you only need to match up until the Service, then only provide the Service value.
+For the CIP Service, we use a maximum of 3 comma separated values representing the Service, Class and Attribute.
+These values are described in the CIP specification. CIP Classes are associated with their Service, and CIP Attributes
+are associated with their Service. If you only need to match up until the Service, then only provide the Service value.
 If you want to match to the CIP Attribute, then you must provide all 3 values.
 
 

--- a/doc/userguide/rules/fast-pattern-explained.rst
+++ b/doc/userguide/rules/fast-pattern-explained.rst
@@ -2,8 +2,8 @@ Suricata Fast Pattern Determination Explained
 =============================================
 
 If the 'fast_pattern' keyword is explicitly set in a rule, Suricata
-will use that as the fast pattern match.  The 'fast_pattern' keyword
-can only be set once per rule.  If 'fast_pattern' is not set, Suricata
+will use that as the fast pattern match. The 'fast_pattern' keyword
+can only be set once per rule. If 'fast_pattern' is not set, Suricata
 automatically determines the content to use as the fast pattern match.
 
 The following explains the logic Suricata uses to automatically
@@ -11,7 +11,7 @@ determine the fast pattern match to use.
 
 Be aware that if there are positive (i.e. non-negated) content
 matches, then negated content matches are ignored for fast pattern
-determination.  Otherwise, negated content matches are considered.
+determination. Otherwise, negated content matches are considered.
 
 The fast_pattern selection criteria are as follows:
 
@@ -111,13 +111,13 @@ fast pattern match for Suricata 2.0.7 but registration order does.
 Appendix C - Pattern Strength Algorithm
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-From detect-engine-mpm.c.  Basically the Pattern Strength "score"
+From detect-engine-mpm.c. Basically the Pattern Strength "score"
 starts at zero and looks at each character/byte in the passed in byte
-array from left to right.  If the character/byte has not been seen
+array from left to right. If the character/byte has not been seen
 before in the array, it adds 3 to the score if it is an alpha
 character; else it adds 4 to the score if it is a printable character,
-0x00, 0x01, or 0xFF; else it adds 6 to the score.  If the
-character/byte has been seen before it adds 1 to the score.  The final
+0x00, 0x01, or 0xFF; else it adds 6 to the score. If the
+character/byte has been seen before it adds 1 to the score. The final
 score is returned.
 
 .. code-block:: c
@@ -131,7 +131,7 @@ score is returned.
     *  Longer patterns score better than short patters.
     *
     *  \param pat pattern
-    *  \param patlen length of the patternn
+    *  \param patlen length of the pattern
     *
     *  \retval s pattern score
     */

--- a/doc/userguide/rules/header-keywords.rst
+++ b/doc/userguide/rules/header-keywords.rst
@@ -8,7 +8,7 @@ ttl
 ^^^
 
 The ttl keyword is used to check for a specific IP time-to-live value
-in the header of a packet.  The format is::
+in the header of a packet. The format is::
 
   ttl:<number>
 
@@ -19,9 +19,9 @@ For example::
 At the end of the ttl keyword you can enter the value on which you
 want to match.  The Time-to-live value determines the maximal amount
 of time a packet can be in the Internet-system. If this field is set
-to 0, then the packet has to be destroyed.  The time-to-live is based
+to 0, then the packet has to be destroyed. The time-to-live is based
 on hop count. Each hop/router the packet passes subtracts one of the
-packet TTL counter.  The purpose of this mechanism is to limit the
+packet TTL counter. The purpose of this mechanism is to limit the
 existence of packets so that packets can not end up in infinite
 routing loops.
 
@@ -73,7 +73,7 @@ sameip
 Every packet has a source IP-address and a destination IP-address. It
 can be that the source IP is the same as the destination IP.  With the
 sameip keyword you can check if the IP address of the source is the
-same as the IP address of the destination.  The format of the sameip
+same as the IP address of the destination. The format of the sameip
 keyword is::
 
   sameip;
@@ -116,7 +116,7 @@ id
 
 With the id keyword, you can match on a specific IP ID value.  The ID
 identifies each packet sent by a host and increments usually with one
-with each packet that is being send.  The IP ID is used as a fragment
+with each packet that is being send. The IP ID is used as a fragment
 identification number. Each packet has an IP ID, and when the packet
 becomes fragmented, all fragments of this packet have the same ID. In
 this way, the receiver of the packet knows which fragments belong to
@@ -164,8 +164,8 @@ fragbits (IP fragmentation)
 
 With the fragbits keyword, you can check if the fragmentation and
 reserved bits are set in the IP header. The fragbits keyword should be
-placed at the beginning of a rule.  Fragbits is used to modify the
-fragmentation mechanism.  During routing of messages from one Internet
+placed at the beginning of a rule. Fragbits is used to modify the
+fragmentation mechanism. During routing of messages from one Internet
 module to the other, it can occur that a packet is bigger than the
 maximal packet size a network can process. In that case, a packet can
 be send in fragments. This maximum of the packet size is called
@@ -198,9 +198,9 @@ fragoffset
 ^^^^^^^^^^
 
 With the fragoffset keyword you can match on specific decimal values
-of the IP fragment offset field.  If you would like to check the first
+of the IP fragment offset field. If you would like to check the first
 fragments of a session, you have to combine fragoffset 0 with the More
-Fragment option.  The fragmentation offset field is convenient for
+Fragment option. The fragmentation offset field is convenient for
 reassembly. The id is used to determine which fragments belong to
 which packet and the fragmentation offset field clarifies the order of
 the fragments.
@@ -227,12 +227,12 @@ TCP keywords
 seq
 ^^^
 The seq keyword can be used in a signature to check for a specific TCP
-sequence number.  A sequence number is a number that is generated
+sequence number. A sequence number is a number that is generated
 practically at random by both endpoints of a TCP-connection. The
 client and the server both create a sequence number, which increases
 with one with every byte that they send. So this sequence number is
 different for both sides. This sequence number has to be acknowledged
-by both sides of the connection.  Through sequence numbers, TCP
+by both sides of the connection. Through sequence numbers, TCP
 handles acknowledgement, order and retransmission. Its number
 increases with every data-byte the sender has send. The seq helps
 keeping track of to what place in a data-stream a byte belongs. If the
@@ -261,7 +261,7 @@ The ack is the acknowledgement of the receipt of all previous
 (data)-bytes send by the other side of the TCP-connection. In most
 occasions every packet of a TCP connection has an ACK flag after the
 first SYN and a ack-number which increases with the receipt of every
-new data-byte.  The ack-keyword can be used in a signature to check
+new data-byte. The ack keyword can be used in a signature to check
 for a specific TCP acknowledgement number.
 
 Format of ack::
@@ -289,7 +289,7 @@ received. This amount of data has to be acknowledged by the receiver
 first, before the sender can send the same amount of new data. This
 mechanism is used to prevent the receiver from being overflowed by
 data. The value of the window size is limited and can be 2 to 65.535
-bytes.  To make more use of your bandwidth you can use a bigger
+bytes. To make more use of your bandwidth you can use a bigger
 TCP-window.
 
 The format of the window keyword::
@@ -310,7 +310,7 @@ is not reliable when it comes to delivering data (datagram). ICMP
 gives feedback in case problems occur. It does not prevent problems
 from happening, but helps in understanding what went wrong and
 where. If reliability is necessary, protocols that use IP have to take
-care of reliability themselves.  In different situations ICMP messages
+care of reliability themselves. In different situations ICMP messages
 will be send. For instance when the destination is unreachable, if
 there is not enough buffer-capacity to forward the data, or when a
 datagram is send fragmented when it should not be, etcetera. More can
@@ -326,7 +326,7 @@ itype
 The itype keyword is for matching on a specific ICMP type (number).
 ICMP has several kinds of messages and uses codes to clarify those
 messages. The different messages are distinct by different names, but
-more important by numeric values.  For more information see the table
+more important by numeric values. For more information see the table
 with message-types and codes.
 
 The format of the itype keyword::

--- a/doc/userguide/rules/modbus-keyword.rst
+++ b/doc/userguide/rules/modbus-keyword.rst
@@ -71,7 +71,7 @@ Examples::
   modbus: access read input                              # Read access to Discretes Input table
   modbus: access write coils                             # Write access to Coils table
   modbus: access read discretes, address <100            # Read access at address smaller than 100 of Discretes Input table
-  modbus: access write holding, address 500, value >200  # Write value greather than 200 at address 500 of Holding Registers table
+  modbus: access write holding, address 500, value >200  # Write value greater than 200 at address 500 of Holding Registers table
 
 With the setting **unit**, you can match on:
 
@@ -108,7 +108,7 @@ Examples::
   modbus: unit 10, access read                                          # Unit identifier 10 and Read access
   modbus: unit 10, access write coils                                   # Unit identifier 10 and Write access to Coils table
   modbus: unit >10, access read discretes, address <100                 # Greater than unit identifier 10 and Read access at address smaller than 100 of Discretes Input table
-  modbus: unit 10<>20, access write holding, address 500, value >200    # Greater than unit identifier 10 and smaller than unit identifier 20 and Write value greather than 200 at address 500 of Holding Registers table
+  modbus: unit 10<>20, access write holding, address 500, value >200    # Greater than unit identifier 10 and smaller than unit identifier 20 and Write value greater than 200 at address 500 of Holding Registers table
 
 (cf. http://www.modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf)
 

--- a/doc/userguide/rules/xbits.rst
+++ b/doc/userguide/rules/xbits.rst
@@ -42,7 +42,7 @@ Threading
 ---------
 
 Due to subtle timing issues between threads the order of sets and checks
-can be slightly unpredictible.
+can be slightly unpredictable.
 
 Unix Socket
 -----------


### PR DESCRIPTION
Update of PR https://github.com/OISF/suricata/pull/3361

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-spelling issues in documentation
-ensure used words are English USA
-remove a few "double space" in a few sections

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

