### PR TITLE
python/rust - fix out of tree builds - 2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2296,7 +2296,7 @@ AC_SUBST(CONFIGURE_SYSCONDIR)
 AC_SUBST(CONFIGURE_LOCALSTATEDIR)
 AC_SUBST(PACKAGE_VERSION)
 
-AC_OUTPUT(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile contrib/tile_pcie_logd/Makefile suricata.yaml etc/Makefile etc/suricata.logrotate etc/suricata.service python/Makefile python/suricata/config/defaults.py python/bin/suricatasc ebpf/Makefile)
+AC_OUTPUT(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile contrib/tile_pcie_logd/Makefile suricata.yaml etc/Makefile etc/suricata.logrotate etc/suricata.service python/Makefile python/suricata/config/defaults.py ebpf/Makefile)
 
 SURICATA_BUILD_CONF="Suricata Configuration:
   AF_PACKET support:                       ${enable_af_packet}

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -3,7 +3,5 @@
 build
 lib/
 scripts-*/
-bin/suricatasc
-!bin/suricatasc.in
 suricata/config/defaults.py
 !suricata/config/defaults.py.in

--- a/python/bin/suricatasc
+++ b/python/bin/suricatasc
@@ -38,6 +38,12 @@ else:
 
 from suricata.sc import *
 
+try:
+    from suricata.config import defaults
+    has_defaults = True
+except:
+    has_defaults = False
+
 parser = argparse.ArgumentParser(prog='suricatasc', description='Client for Suricata unix socket')
 parser.add_argument('-v', '--verbose', action='store_const', const=True, help='verbose output (including JSON dump)')
 parser.add_argument('-c', '--command', default=None, help='execute on single command and return JSON')
@@ -46,8 +52,11 @@ args = parser.parse_args()
 
 if args.socket != None:
     SOCKET_PATH = args.socket
+elif has_defaults:
+    SOCKET_PATH = os.path.join(defaults.localstatedir, "suricata-command.socket")
 else:
-    SOCKET_PATH = "@e_localstatedir@/suricata-command.socket"
+    print("Unable to determine path to suricata-command.socket.", file=sys.stderr)
+    sys.exit(1)
 
 sc = SuricataSC(SOCKET_PATH, verbose=args.verbose)
 try:

--- a/python/suricata/config/defaults.py.in
+++ b/python/suricata/config/defaults.py.in
@@ -1,2 +1,3 @@
 sysconfdir = "@e_sysconfdir@"
 datarulesdir = "@e_datarulesdir@"
+localstatedir = "@e_localstatedir@"

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -4,6 +4,7 @@ version = "@PACKAGE_VERSION@"
 
 [lib]
 crate-type = ["staticlib"]
+path = "@abs_srcdir@/src/lib.rs"
 
 [profile.release]
 debug = true

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -31,31 +31,25 @@ endif
 
 all-local:
 if HAVE_PYTHON
-	cd $(top_srcdir)/rust && \
-		$(HAVE_PYTHON) ./gen-c-headers.py && \
-		CARGO_TARGET_DIR=$(abs_builddir)/target \
-		CARGO_HOME=$(CARGO_HOME) $(CARGO) build $(RELEASE) $(FROZEN) \
-			--features "$(RUST_FEATURES)"
+	cd $(top_srcdir)/rust && $(HAVE_PYTHON) ./gen-c-headers.py
+	CARGO_HOME=$(CARGO_HOME) $(CARGO) build $(RELEASE) $(FROZEN) \
+		--features "$(RUST_FEATURES)"
 else
-	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
-		CARGO_HOME=$(CARGO_HOME) $(CARGO) build $(RELEASE) $(FROZEN) \
-			--features "$(RUST_FEATURES)"
+	CARGO_HOME=$(CARGO_HOME) $(CARGO) build $(RELEASE) $(FROZEN) \
+		--features "$(RUST_FEATURES)"
 endif
 
 clean-local:
-	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
-		CARGO_HOME=$(CARGO_HOME) $(CARGO) clean
+	-rm -rf target
 
-distclean-local:
+distclean-local: clean-local
 	rm -rf vendor gen Cargo.lock
 
 check:
-	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
-		CARGO_HOME=$(CARGO_HOME) $(CARGO) test
+	CARGO_HOME=$(CARGO_HOME) $(CARGO) test
 
 Cargo.lock: Cargo.toml
-	cd $(top_srcdir)/rust && \
-		CARGO_HOME=$(CARGO_HOME) $(CARGO) generate-lockfile
+	CARGO_HOME=$(CARGO_HOME) $(CARGO) generate-lockfile
 
 if HAVE_CARGO_VENDOR
 vendor:


### PR DESCRIPTION
Python and Rust fixes for out of tree builds.

Changes from last PR:
- Fix parrallel make issue in clean.
- Simplfiy rust/Makefile.am.

Previous PR:
- https://github.com/OISF/suricata/pull/3381

PRscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/297
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/650
