### PR TITLE
util-random: fix detection of getrandom failure

### DIFF
--- a/src/util-random.c
+++ b/src/util-random.c
@@ -89,7 +89,7 @@ long int RandomGet(void)
     /* ret should be sizeof(value), but if it is > 0 and < sizeof(value)
      * it's still better than nothing so we return what we have */
     if (ret <= 0) {
-        if (ret == -ENOSYS) {
+        if (ret == -1 && errno == ENOSYS) {
 #if defined(HAVE_CLOCK_GETTIME)
             return RandomGetClock();
 #else


### PR DESCRIPTION
This fixes the error handling of workaround introduced in 851efd9c60eaa30d8843f935c1445d91ddd86d68. Our QA did success after a long series of failure but it seems it was due to tests executed on a different runner.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2505

Describe changes:
- fix error handling

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/405
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/187

