### PR TITLE
travis: use gcc-7 on cocci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,17 +57,21 @@ matrix:
   include:
     # Linux, gcc, coccinelle.
     - os: linux
-      compiler: gcc
+      compiler: gcc-7
       env:
-        - NAME="linux,gcc,cocci"
+        - NAME="linux,gcc-7,cocci"
         - *default-cflags
+        - NO_UNITTESTS=yes
       addons:
         apt:
           sources:
             - sourceline: ppa:npalix/coccinelle
+            # For gcc-7.
+            - sourceline: ppa:ubuntu-toolchain-r/test
           packages:
             - *packages
             - coccinelle
+            - gcc-7
     # Linux, gcc, Rust (latest stable).
     # This is allowed to fail, update allow_failures if the env changes.
     - os: linux
@@ -152,21 +156,22 @@ matrix:
 script:
   - sh ./autogen.sh
   - |
+    if [[ "${NO_UNITTESTS}" != "yes" ]]; then
+        ARGS="${ARGS} --enable-unittests"
+    fi
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         export CFLAGS="${CFLAGS} ${EXTRA_CFLAGS}"
-        ./configure --enable-nfqueue --enable-unittests --enable-hiredis ${ARGS}
-    fi
-  - |
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        ./configure --enable-nfqueue --enable-hiredis ${ARGS}
+    elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         export CFLAGS="${CFLAGS} ${EXTRA_CFLAGS}"
-        ./configure --enable-unittests --enable-hiredis --enable-ipfw \
+        ./configure --enable-hiredis --enable-ipfw \
             --enable-lua --with-libpcre-includes=/usr/local/include \
             --with-libpcre-includes=/usr/local/include \
             --with-libpcre-libraries=/usr/local/lib \
             --with-libnss-includes=/usr/local/opt/nss/include/nss \
             --with-libnss-libraries=/usr/local/opt/nss/lib \
             --with-libnspr-includes=/usr/local/opt/nspr/include/nspr \
-            --with-libnspr-libraries=/usr/local/opt/nspr/lib
+            --with-libnspr-libraries=/usr/local/opt/nspr/lib ${ARGS}
     fi
   - |
     # Linux container builds have 2 cores, make use of them.
@@ -177,12 +182,14 @@ script:
   - |
     # Like "make check", but fail on first error. We redirect the output
     # so Travis doesn't fail the build with a too much output error.
-    mkdir -p ./qa/log
-    ./src/suricata -u -l ./qa/log --fatal-unittests > unittests.log 2>&1
-    if [[ $? -ne 0 ]]; then
-        echo "Unit tests failed, last 500 lines of output are:"
-        tail -n 500 unittests.log
-        exit 1
+    if [[ "${NO_UNITTESTS}" != "yes" ]]; then
+        mkdir -p ./qa/log
+        ./src/suricata -u -l ./qa/log --fatal-unittests > unittests.log 2>&1
+        if [[ $? -ne 0 ]]; then
+            echo "Unit tests failed, last 500 lines of output are:"
+            tail -n 500 unittests.log
+            exit 1
+        fi
     fi
   - |
     if [[ "$DO_DISTCHECK" == "yes" ]]; then


### PR DESCRIPTION
Catches more errors, like switch statements fall throughs that are caught in private QA.

Also allows a build to opt-out of enabling unit tests. We still fail with unit tests enabled and truncation warnings enabled.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/304
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/657
