### PR TITLE
Feat/tcp/midstream/smb/v8

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -32,8 +32,13 @@ pub const APP_LAYER_EVENT_TYPE_TRANSACTION : i32 = 1;
 pub const APP_LAYER_EVENT_TYPE_PACKET      : i32 = 2;
 
 // From stream.h.
+pub const STREAM_START:    u8 = 0x01;
+pub const STREAM_EOF:      u8 = 0x02;
 pub const STREAM_TOSERVER: u8 = 0x04;
 pub const STREAM_TOCLIENT: u8 = 0x08;
+pub const STREAM_GAP:      u8 = 0x10;
+pub const STREAM_DEPTH:    u8 = 0x20;
+pub const STREAM_MIDSTREAM:u8 = 0x40;
 
 // Application layer protocol identifiers (app-layer-protos.h)
 pub type AppProto = libc::c_int;

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -258,7 +258,8 @@ pub extern "C" fn rs_dhcp_parse(_flow: *const core::Flow,
                                 _pstate: *mut libc::c_void,
                                 input: *const libc::uint8_t,
                                 input_len: u32,
-                                _data: *const libc::c_void) -> i8 {
+                                _data: *const libc::c_void,
+                                _flags: u8) -> i8 {
     let state = cast_pointer!(state, DHCPState);
     let buf = build_slice!(input, input_len as usize);
     if state.parse(buf) {

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -443,7 +443,8 @@ pub extern "C" fn rs_ikev2_parse_request(_flow: *const core::Flow,
                                        _pstate: *mut libc::c_void,
                                        input: *const libc::uint8_t,
                                        input_len: u32,
-                                       _data: *const libc::c_void) -> i8 {
+                                       _data: *const libc::c_void,
+                                       _flags: u8) -> i8 {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,IKEV2State);
     state.parse(buf, STREAM_TOSERVER)
@@ -455,7 +456,8 @@ pub extern "C" fn rs_ikev2_parse_response(_flow: *const core::Flow,
                                        pstate: *mut libc::c_void,
                                        input: *const libc::uint8_t,
                                        input_len: u32,
-                                       _data: *const libc::c_void) -> i8 {
+                                       _data: *const libc::c_void,
+                                       _flags: u8) -> i8 {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,IKEV2State);
     let res = state.parse(buf, STREAM_TOCLIENT);

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -461,7 +461,8 @@ pub extern "C" fn rs_krb5_parse_request(_flow: *const core::Flow,
                                        _pstate: *mut libc::c_void,
                                        input: *const libc::uint8_t,
                                        input_len: u32,
-                                       _data: *const libc::c_void) -> i8 {
+                                       _data: *const libc::c_void,
+                                       _flags: u8) -> i8 {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,KRB5State);
     state.parse(buf, STREAM_TOSERVER)
@@ -473,7 +474,8 @@ pub extern "C" fn rs_krb5_parse_response(_flow: *const core::Flow,
                                        _pstate: *mut libc::c_void,
                                        input: *const libc::uint8_t,
                                        input_len: u32,
-                                       _data: *const libc::c_void) -> i8 {
+                                       _data: *const libc::c_void,
+                                       _flags: u8) -> i8 {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,KRB5State);
     state.parse(buf, STREAM_TOCLIENT)
@@ -485,7 +487,8 @@ pub extern "C" fn rs_krb5_parse_request_tcp(_flow: *const core::Flow,
                                        _pstate: *mut libc::c_void,
                                        input: *const libc::uint8_t,
                                        input_len: u32,
-                                       _data: *const libc::c_void) -> i8 {
+                                       _data: *const libc::c_void,
+                                       _flags: u8) -> i8 {
     if input_len < 4 { return -1; }
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,KRB5State);
@@ -497,7 +500,7 @@ pub extern "C" fn rs_krb5_parse_request_tcp(_flow: *const core::Flow,
         _ => {
             // sanity check to avoid memory exhaustion
             if state.defrag_buf_ts.len() + buf.len() > 100000 {
-                SCLogDebug!("rs_krb5_parse_response_tcp: TCP buffer exploded {} {}",
+                SCLogDebug!("rs_krb5_parse_resquest_tcp: TCP buffer exploded {} {}",
                             state.defrag_buf_ts.len(), buf.len());
                 return 1;
             }
@@ -515,7 +518,7 @@ pub extern "C" fn rs_krb5_parse_request_tcp(_flow: *const core::Flow,
                     cur_i = rem;
                 },
                 _ => {
-                    SCLogDebug!("rs_krb5_parse_response_tcp: reading record mark failed!");
+                    SCLogDebug!("rs_krb5_parse_request_tcp: reading record mark failed!");
                     return 1;
                 }
             }
@@ -542,7 +545,8 @@ pub extern "C" fn rs_krb5_parse_response_tcp(_flow: *const core::Flow,
                                        _pstate: *mut libc::c_void,
                                        input: *const libc::uint8_t,
                                        input_len: u32,
-                                       _data: *const libc::c_void) -> i8 {
+                                       _data: *const libc::c_void,
+                                       _flags: u8) -> i8 {
     if input_len < 4 { return -1; }
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,KRB5State);

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -195,7 +195,8 @@ pub extern "C" fn rs_ntp_parse_request(_flow: *const core::Flow,
                                        _pstate: *mut libc::c_void,
                                        input: *const libc::uint8_t,
                                        input_len: u32,
-                                       _data: *const libc::c_void) -> i8 {
+                                       _data: *const libc::c_void,
+                                       _flags: u8) -> i8 {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,NTPState);
     state.parse(buf, 0)
@@ -207,7 +208,8 @@ pub extern "C" fn rs_ntp_parse_response(_flow: *const core::Flow,
                                        _pstate: *mut libc::c_void,
                                        input: *const libc::uint8_t,
                                        input_len: u32,
-                                       _data: *const libc::c_void) -> i8 {
+                                       _data: *const libc::c_void,
+                                       _flags: u8) -> i8 {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,NTPState);
     state.parse(buf, 1)

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -123,7 +123,8 @@ pub type ParseFn      = extern "C" fn (flow: *const Flow,
                                        pstate: *mut c_void,
                                        input: *const u8,
                                        input_len: u32,
-                                       data: *const c_void) -> i8;
+                                       data: *const c_void,
+                                       flags: u8) -> i8;
 pub type ProbeFn      = extern "C" fn (flow: *const Flow,input:*const u8, input_len: u32, offset: *const u32) -> AppProto;
 pub type StateAllocFn = extern "C" fn () -> *mut c_void;
 pub type StateFreeFn  = extern "C" fn (*mut c_void);

--- a/src/app-layer-dcerpc-udp.c
+++ b/src/app-layer-dcerpc-udp.c
@@ -717,7 +717,7 @@ static int DCERPCUDPParseHeader(Flow *f, void *dcerpcudp_state,
 
 static int DCERPCUDPParse(Flow *f, void *dcerpc_state,
     AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
-    void *local_data)
+    void *local_data, const uint8_t flags)
 {
     uint32_t retval = 0;
     uint32_t parsed = 0;

--- a/src/app-layer-dcerpc.c
+++ b/src/app-layer-dcerpc.c
@@ -1922,7 +1922,7 @@ static int DCERPCParse(Flow *f, void *dcerpc_state,
 static int DCERPCParseRequest(Flow *f, void *dcerpc_state,
                               AppLayerParserState *pstate,
                               uint8_t *input, uint32_t input_len,
-                              void *local_data)
+                              void *local_data, const uint8_t flags)
 {
     return DCERPCParse(f, dcerpc_state, pstate, input, input_len,
                        local_data, 0);
@@ -1931,7 +1931,7 @@ static int DCERPCParseRequest(Flow *f, void *dcerpc_state,
 static int DCERPCParseResponse(Flow *f, void *dcerpc_state,
                                AppLayerParserState *pstate,
                                uint8_t *input, uint32_t input_len,
-                               void *local_data)
+                               void *local_data, const uint8_t flags)
 {
     return DCERPCParse(f, dcerpc_state, pstate, input, input_len,
                        local_data, 1);

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -1111,7 +1111,8 @@ error:
  * multiple frames, but not the complete final frame).
  */
 static int DNP3ParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data)
+    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t flags)
 {
     SCEnter();
     DNP3State *dnp3 = (DNP3State *)state;
@@ -1250,7 +1251,8 @@ error:
  * See DNP3ParseResponsePDUs for DNP3 frame handling.
  */
 static int DNP3ParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data)
+    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t flags)
 {
     SCEnter();
     DNP3State *dnp3 = (DNP3State *)state;

--- a/src/app-layer-dns-tcp-rust.c
+++ b/src/app-layer-dns-tcp-rust.c
@@ -36,7 +36,7 @@ static void RustDNSTCPParserRegisterTests(void);
 
 static int RustDNSTCPParseRequest(Flow *f, void *state,
         AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
-        void *local_data)
+        void *local_data, const uint8_t flags)
 {
     SCLogDebug("RustDNSTCPParseRequest");
     return rs_dns_parse_request_tcp(f, state, pstate, input, input_len,
@@ -45,7 +45,7 @@ static int RustDNSTCPParseRequest(Flow *f, void *state,
 
 static int RustDNSTCPParseResponse(Flow *f, void *state,
         AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
-        void *local_data)
+        void *local_data, const uint8_t flags)
 {
     SCLogDebug("RustDNSTCPParseResponse");
     return rs_dns_parse_response_tcp(f, state, pstate, input, input_len,
@@ -295,7 +295,7 @@ static int RustDNSTCPParserTestMultiRecord(void)
     f->alstate = state;
 
     FAIL_IF(RustDNSTCPParseRequest(f, f->alstate, NULL, req, reqlen,
-                    NULL) < 0);
+                    NULL, STREAM_START) < 0);
     FAIL_IF(rs_dns_state_get_tx_count(state) != 20);
 
     UTHFreeFlow(f);

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -290,7 +290,7 @@ insufficient_data:
 static int DNSTCPRequestParse(Flow *f, void *dstate,
                               AppLayerParserState *pstate,
                               uint8_t *input, uint32_t input_len,
-                              void *local_data)
+                              void *local_data, const uint8_t flags)
 {
     DNSState *dns_state = (DNSState *)dstate;
     SCLogDebug("starting %u", input_len);
@@ -531,7 +531,7 @@ insufficient_data:
 static int DNSTCPResponseParse(Flow *f, void *dstate,
                                AppLayerParserState *pstate,
                                uint8_t *input, uint32_t input_len,
-                               void *local_data)
+                               void *local_data, const uint8_t flags)
 {
     DNSState *dns_state = (DNSState *)dstate;
 
@@ -887,7 +887,7 @@ static int DNSTCPParserTestMultiRecord(void)
     f->alproto = ALPROTO_DNS;
     f->alstate = state;
 
-    FAIL_IF_NOT(DNSTCPRequestParse(f, f->alstate, NULL, req, reqlen, NULL));
+    FAIL_IF_NOT(DNSTCPRequestParse(f, f->alstate, NULL, req, reqlen, NULL, STREAM_START));
     FAIL_IF(state->transaction_max != 20);
 
     UTHFreeFlow(f);

--- a/src/app-layer-dns-udp-rust.c
+++ b/src/app-layer-dns-udp-rust.c
@@ -36,7 +36,7 @@ static void RustDNSUDPParserRegisterTests(void);
 
 static int RustDNSUDPParseRequest(Flow *f, void *state,
         AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
-        void *local_data)
+        void *local_data, const uint8_t flags)
 {
     return rs_dns_parse_request(f, state, pstate, input, input_len,
             local_data);
@@ -44,7 +44,7 @@ static int RustDNSUDPParseRequest(Flow *f, void *state,
 
 static int RustDNSUDPParseResponse(Flow *f, void *state,
         AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
-        void *local_data)
+        void *local_data, const uint8_t flags)
 {
     return rs_dns_parse_response(f, state, pstate, input, input_len,
             local_data);
@@ -229,7 +229,7 @@ static int RustDNSUDPParserTest01 (void)
     FAIL_IF_NULL(f->alstate);
 
     FAIL_IF_NOT(RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
-                    NULL));
+                    NULL, STREAM_START));
 
     UTHFreeFlow(f);
     PASS;
@@ -260,7 +260,7 @@ static int RustDNSUDPParserTest02 (void)
     FAIL_IF_NULL(f->alstate);
 
     FAIL_IF_NOT(RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
-                    NULL));
+                    NULL, STREAM_START));
 
     UTHFreeFlow(f);
     PASS;
@@ -291,7 +291,7 @@ static int RustDNSUDPParserTest03 (void)
     FAIL_IF_NULL(f->alstate);
 
     FAIL_IF_NOT(RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
-                    NULL));
+                    NULL, STREAM_START));
 
     UTHFreeFlow(f);
     PASS;
@@ -325,7 +325,7 @@ static int RustDNSUDPParserTest04 (void)
     FAIL_IF_NULL(f->alstate);
 
     FAIL_IF_NOT(RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
-                    NULL));
+                    NULL, STREAM_START));
 
     UTHFreeFlow(f);
     PASS;
@@ -359,7 +359,7 @@ static int RustDNSUDPParserTest05 (void)
     FAIL_IF_NULL(f->alstate);
 
     FAIL_IF(RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
-                    NULL) != -1);
+                    NULL, STREAM_START) != -1);
 
     UTHFreeFlow(f);
     PASS;

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -308,7 +308,8 @@ static void ENIPStateTransactionFree(void *state, uint64_t tx_id)
  * \retval 1 when the command is parsed, 0 otherwise
  */
 static int ENIPParse(Flow *f, void *state, AppLayerParserState *pstate,
-        uint8_t *input, uint32_t input_len, void *local_data)
+        uint8_t *input, uint32_t input_len, void *local_data,
+        const uint8_t flags)
 {
     SCEnter();
     ENIPState *enip = (ENIPState *) state;

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -384,7 +384,7 @@ static void FtpTransferCmdFree(void *data)
 static int FTPParseRequest(Flow *f, void *ftp_state,
                            AppLayerParserState *pstate,
                            uint8_t *input, uint32_t input_len,
-                           void *local_data)
+                           void *local_data, const uint8_t flags)
 {
     SCEnter();
     /* PrintRawDataFp(stdout, input,input_len); */
@@ -540,7 +540,7 @@ static int FTPParsePassiveResponseV6(Flow *f, FtpState *state, uint8_t *input, u
  */
 static int FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserState *pstate,
                             uint8_t *input, uint32_t input_len,
-                            void *local_data)
+                            void *local_data, const uint8_t flags)
 {
     FtpState *state = (FtpState *)ftp_state;
 
@@ -787,7 +787,7 @@ out:
 static int FTPDataParseRequest(Flow *f, void *ftp_state,
         AppLayerParserState *pstate,
         uint8_t *input, uint32_t input_len,
-        void *local_data)
+        void *local_data, const uint8_t flags)
 {
     return FTPDataParse(f, ftp_state, pstate, input, input_len,
                                local_data, STREAM_TOSERVER);
@@ -796,7 +796,7 @@ static int FTPDataParseRequest(Flow *f, void *ftp_state,
 static int FTPDataParseResponse(Flow *f, void *ftp_state,
         AppLayerParserState *pstate,
         uint8_t *input, uint32_t input_len,
-        void *local_data)
+        void *local_data, const uint8_t flags)
 {
     return FTPDataParse(f, ftp_state, pstate, input, input_len,
                                local_data, STREAM_TOCLIENT);

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -706,7 +706,7 @@ error:
 static int HTPHandleRequestData(Flow *f, void *htp_state,
                                 AppLayerParserState *pstate,
                                 uint8_t *input, uint32_t input_len,
-                                void *local_data)
+                                void *local_data, const uint8_t flags)
 {
     SCEnter();
     int ret = 1;
@@ -769,7 +769,7 @@ error:
 static int HTPHandleResponseData(Flow *f, void *htp_state,
                                  AppLayerParserState *pstate,
                                  uint8_t *input, uint32_t input_len,
-                                 void *local_data)
+                                 void *local_data, const uint8_t flags)
 {
     SCEnter();
     int ret = 1;

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1266,7 +1266,8 @@ static int ModbusParseRequest(Flow                  *f,
                               AppLayerParserState   *pstate,
                               uint8_t               *input,
                               uint32_t              input_len,
-                              void                  *local_data)
+                              void                  *local_data,
+                              const uint8_t         flags)
 {
     SCEnter();
     ModbusState         *modbus = (ModbusState *) state;
@@ -1330,7 +1331,8 @@ static int ModbusParseResponse(Flow                 *f,
                                AppLayerParserState  *pstate,
                                uint8_t              *input,
                                uint32_t             input_len,
-                               void                 *local_data)
+                               void                 *local_data,
+                               const uint8_t        flags)
 {
     SCEnter();
     ModbusHeader        header;

--- a/src/app-layer-nfs-tcp.c
+++ b/src/app-layer-nfs-tcp.c
@@ -150,7 +150,7 @@ static AppProto NFSTCPProbingParserTC(Flow *f, uint8_t *input, uint32_t input_le
 
 static int NFSTCPParseRequest(Flow *f, void *state,
     AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
-    void *local_data)
+    void *local_data, const uint8_t flags)
 {
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOSERVER);
     rs_nfs3_setfileflags(0, state, file_flags);
@@ -165,7 +165,8 @@ static int NFSTCPParseRequest(Flow *f, void *state,
 }
 
 static int NFSTCPParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data)
+    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t flags)
 {
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOCLIENT);
     rs_nfs3_setfileflags(1, state, file_flags);

--- a/src/app-layer-nfs-udp.c
+++ b/src/app-layer-nfs-udp.c
@@ -155,7 +155,7 @@ static AppProto NFSProbingParserTC(Flow *f, uint8_t *input, uint32_t input_len,
 
 static int NFSParseRequest(Flow *f, void *state,
     AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
-    void *local_data)
+    void *local_data, const uint8_t flags)
 {
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOSERVER);
     rs_nfs3_setfileflags(0, state, file_flags);
@@ -164,7 +164,8 @@ static int NFSParseRequest(Flow *f, void *state,
 }
 
 static int NFSParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data)
+    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t flags)
 {
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOCLIENT);
     rs_nfs3_setfileflags(1, state, file_flags);

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1144,7 +1144,8 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
         /* invoke the parser */
         if (p->Parser[(flags & STREAM_TOSERVER) ? 0 : 1](f, alstate, pstate,
                 input, input_len,
-                alp_tctx->alproto_local_storage[f->protomap][alproto]) < 0)
+                alp_tctx->alproto_local_storage[f->protomap][alproto],
+                flags) < 0)
         {
             goto error;
         }
@@ -1909,7 +1910,7 @@ typedef struct TestState_ {
  */
 static int TestProtocolParser(Flow *f, void *test_state, AppLayerParserState *pstate,
                               uint8_t *input, uint32_t input_len,
-                              void *local_data)
+                              void *local_data, const uint8_t flags)
 {
     SCEnter();
     SCReturnInt(-1);

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -90,7 +90,7 @@ int AppLayerParserConfParserEnabled(const char *ipproto,
 typedef int (*AppLayerParserFPtr)(Flow *f, void *protocol_state,
         AppLayerParserState *pstate,
         uint8_t *buf, uint32_t buf_len,
-        void *local_storage);
+        void *local_storage, const uint8_t flags);
 
 typedef struct AppLayerGetTxIterTuple {
     void *tx_ptr;

--- a/src/app-layer-smb-tcp-rust.c
+++ b/src/app-layer-smb-tcp-rust.c
@@ -34,7 +34,7 @@
 
 static int RustSMBTCPParseRequest(Flow *f, void *state,
         AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
-        void *local_data)
+        void *local_data, const uint8_t flags)
 {
     SCLogDebug("RustSMBTCPParseRequest");
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOSERVER);
@@ -56,7 +56,7 @@ static int RustSMBTCPParseRequest(Flow *f, void *state,
 
 static int RustSMBTCPParseResponse(Flow *f, void *state,
         AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
-        void *local_data)
+        void *local_data, const uint8_t flags)
 {
     SCLogDebug("RustSMBTCPParseResponse");
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOCLIENT);

--- a/src/app-layer-smb-tcp-rust.c
+++ b/src/app-layer-smb-tcp-rust.c
@@ -45,7 +45,7 @@ static int RustSMBTCPParseRequest(Flow *f, void *state,
         res = rs_smb_parse_request_tcp_gap(state, input_len);
     } else {
         res = rs_smb_parse_request_tcp(f, state, pstate, input, input_len,
-            local_data);
+            local_data, flags);
     }
     if (res != 1) {
         SCLogNotice("SMB request%s of %u bytes, retval %d",
@@ -68,7 +68,7 @@ static int RustSMBTCPParseResponse(Flow *f, void *state,
         res = rs_smb_parse_response_tcp_gap(state, input_len);
     } else {
         res = rs_smb_parse_response_tcp(f, state, pstate, input, input_len,
-            local_data);
+            local_data, flags);
     }
     if (res != 1) {
         SCLogNotice("SMB response%s of %u bytes, retval %d",

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -1392,14 +1392,14 @@ static int SMBParse(Flow *f, void *smb_state, AppLayerParserState *pstate,
 
 static int SMBParseRequest(Flow *f, void *smb_state, AppLayerParserState *pstate,
                            uint8_t *input, uint32_t input_len,
-                           void *local_data)
+                           void *local_data, const uint8_t flags)
 {
     return SMBParse(f, smb_state, pstate, input, input_len, local_data, 0);
 }
 
 static int SMBParseResponse(Flow *f, void *smb_state, AppLayerParserState *pstate,
                             uint8_t *input, uint32_t input_len,
-                            void *local_data)
+                            void *local_data, const uint8_t flags)
 {
     return SMBParse(f, smb_state, pstate, input, input_len, local_data, 1);
 }

--- a/src/app-layer-smb2.c
+++ b/src/app-layer-smb2.c
@@ -522,7 +522,7 @@ static uint32_t SMB2ParseHeader(void *smb2_state, AppLayerParserState *pstate,
 
 static int SMB2Parse(Flow *f, void *smb2_state, AppLayerParserState *pstate,
                      uint8_t *input, uint32_t input_len,
-                     void *local_data)
+                     void *local_data, const uint8_t flags)
 {
     SCEnter();
     SMB2State *sstate = (SMB2State *) smb2_state;

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1268,7 +1268,7 @@ static int SMTPParse(int direction, Flow *f, SMTPState *state,
 static int SMTPParseClientRecord(Flow *f, void *alstate,
                                  AppLayerParserState *pstate,
                                  uint8_t *input, uint32_t input_len,
-                                 void *local_data)
+                                 void *local_data, const uint8_t flags)
 {
     SCEnter();
 
@@ -1279,7 +1279,7 @@ static int SMTPParseClientRecord(Flow *f, void *alstate,
 static int SMTPParseServerRecord(Flow *f, void *alstate,
                                  AppLayerParserState *pstate,
                                  uint8_t *input, uint32_t input_len,
-                                 void *local_data)
+                                 void *local_data, const uint8_t flags)
 {
     SCEnter();
 

--- a/src/app-layer-ssh.c
+++ b/src/app-layer-ssh.c
@@ -417,7 +417,7 @@ static int SSHParseData(SshState *state, SshHeader *header,
 
 static int SSHParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
                            uint8_t *input, uint32_t input_len,
-                           void *local_data)
+                           void *local_data, const uint8_t flags)
 {
     SshState *ssh_state = (SshState *)state;
     SshHeader *ssh_header = &ssh_state->cli_hdr;
@@ -442,7 +442,7 @@ static int SSHParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
 
 static int SSHParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
                             uint8_t *input, uint32_t input_len,
-                            void *local_data)
+                            void *local_data, const uint8_t flags)
 {
     SshState *ssh_state = (SshState *)state;
     SshHeader *ssh_header = &ssh_state->srv_hdr;

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2242,14 +2242,14 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
 
 static int SSLParseClientRecord(Flow *f, void *alstate, AppLayerParserState *pstate,
                          uint8_t *input, uint32_t input_len,
-                         void *local_data)
+                         void *local_data, const uint8_t flags)
 {
     return SSLDecode(f, 0 /* toserver */, alstate, pstate, input, input_len);
 }
 
 static int SSLParseServerRecord(Flow *f, void *alstate, AppLayerParserState *pstate,
                          uint8_t *input, uint32_t input_len,
-                         void *local_data)
+                         void *local_data, const uint8_t flags)
 {
     return SSLDecode(f, 1 /* toclient */, alstate, pstate, input, input_len);
 }

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -210,7 +210,7 @@ static AppProto TemplateProbingParser(Flow *f, uint8_t *input, uint32_t input_le
 
 static int TemplateParseRequest(Flow *f, void *state,
     AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
-    void *local_data)
+    void *local_data, const uint8_t flags)
 {
     TemplateState *echo = state;
 
@@ -278,7 +278,8 @@ end:
 }
 
 static int TemplateParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data)
+    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t flags)
 {
     TemplateState *echo = state;
     TemplateTransaction *tx = NULL, *ttx;;

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -128,7 +128,7 @@ static AppProto TFTPProbingParser(Flow *f, uint8_t *input, uint32_t input_len,
 
 static int TFTPParseRequest(Flow *f, void *state,
     AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
-    void *local_data)
+    void *local_data, const uint8_t flags)
 {
     SCLogDebug("Parsing echo request: len=%"PRIu32, input_len);
 
@@ -151,7 +151,8 @@ static int TFTPParseRequest(Flow *f, void *state,
  * \brief Response parsing is not implemented
  */
 static int TFTPParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data)
+    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t flags)
 {
     return 0;
 }

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -682,6 +682,11 @@ static uint8_t StreamGetAppLayerFlags(TcpSession *ssn, TcpStream *stream,
     if (ssn->state == TCP_CLOSED) {
         flag |= STREAM_EOF;
     }
+
+    if (ssn->flags & STREAMTCP_FLAG_MIDSTREAM) {
+        flag |= STREAM_MIDSTREAM;
+    }
+
     if (p->flags & PKT_PSEUDO_STREAM_END) {
         flag |= STREAM_EOF;
     }

--- a/src/stream.h
+++ b/src/stream.h
@@ -32,6 +32,7 @@
 #define STREAM_TOCLIENT         0x08
 #define STREAM_GAP              0x10    /**< data gap encountered */
 #define STREAM_DEPTH            0x20    /**< depth reached */
+#define STREAM_MIDSTREAM        0x40
 
 typedef int (*StreamSegmentCallback)(const Packet *, void *, const uint8_t *, uint32_t);
 int StreamSegmentForEach(const Packet *p, uint8_t flag,


### PR DESCRIPTION
Describe changes:
- add basic support for midstream pickup in the app-layer
- implement for smb

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/141
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/143

