### PR TITLE
yaml-loader: fix memory leak on fail include - v1

### DIFF
--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -118,7 +118,8 @@ ConfYamlHandleInclude(ConfNode *parent, const char *filename)
 {
     yaml_parser_t parser;
     char include_filename[PATH_MAX];
-    FILE *file;
+    FILE *file = NULL;
+    int ret = -1;
 
     if (yaml_parser_initialize(&parser) != 1) {
         SCLogError(SC_ERR_CONF_YAML_ERROR, "Failed to initialize YAML parser");
@@ -138,7 +139,7 @@ ConfYamlHandleInclude(ConfNode *parent, const char *filename)
         SCLogError(SC_ERR_FOPEN,
             "Failed to open configuration include file %s: %s",
             include_filename, strerror(errno));
-        return -1;
+        goto done;
     }
 
     yaml_parser_set_input_file(&parser, file);
@@ -146,13 +147,18 @@ ConfYamlHandleInclude(ConfNode *parent, const char *filename)
     if (ConfYamlParse(&parser, parent, 0) != 0) {
         SCLogError(SC_ERR_CONF_YAML_ERROR,
             "Failed to include configuration file %s", filename);
-        return -1;
+        goto done;
     }
 
-    yaml_parser_delete(&parser);
-    fclose(file);
+    ret = 0;
 
-    return 0;
+done:
+    yaml_parser_delete(&parser);
+    if (file != NULL) {
+        fclose(file);
+    }
+
+    return ret;
 }
 
 /**


### PR DESCRIPTION
Redmine issue:
https://redmine.openinfosecfoundation.org/issues/1929

If an include failed to load, either by the file not existing or
a parse error, the file pointer and yaml parser instance were
leaked.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/305
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/658
