### PR TITLE
rust/dns - remove extra parantheses - v1

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -914,7 +914,7 @@ mod tests {
         // than the available data.
         let mut request = Vec::new();
         request.push(((dns_payload.len() as u16) >> 8) as u8);
-        request.push((((dns_payload.len() as u16) & 0xff) as u8 + 1));
+        request.push(((dns_payload.len() as u16) & 0xff) as u8 + 1);
         request.extend(dns_payload);
 
         let mut state = DNSState::new();


### PR DESCRIPTION
Removes rust compiler warning.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/2521

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/306
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/659
