### PR TITLE
add note about eve-alert metadata

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -200,6 +200,7 @@ outputs:
             # packet: yes              # enable dumping of packet (without stream segments)
             # http-body: yes           # enable dumping of http body in Base64
             # http-body-printable: yes # enable dumping of http body in printable format
+            # metadata: no             # enable inclusion of app layer metadata with alert. Default yes
 
             # Enable the logging of tagged packets for rules using the
             # "tag" keyword.


### PR DESCRIPTION
Signed-off-by: jason taylor <jtfas90@gmail.com>

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ x ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ x ] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- This PR adds a commented configuration line for the eve alert metadata setting

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

