### PR TITLE
Reject vlan

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -145,6 +145,24 @@ is: pass, drop, reject, alert.
 This means a pass rule is considered before a drop rule, a drop rule
 before a reject rule and so on.
 
+Host mode and reject keyword
+----------------------------
+
+When using the reject keyword, Suricata needs to know where reject
+packets have to be sent. The `host-mode` and `reject-iface` options
+allow a selection of the sending iface. If `reject-iface` is set, all
+packets are sent to the specified interface. 
+
+If not set, interface will be choozen using the network interface that
+did capture the packet and using information from the `host-mode` variable.
+If `host-mode` is `sniffer-only` then the reject packets are sent to
+the interface that did capture the packet. If `host-mode` is set to `router`
+then the reject packets are sent to transmission interface (and to the
+originating interface if ever reject is sent both way).
+
+If `host-mode` is set to `auto` then the running mode determine the value.
+If will be `sniffer-only` in IDS modes and `router` in IPS mode.
+
 Splitting configuration in multiple files
 -----------------------------------------
 

--- a/src/respond-reject-libnet11.c
+++ b/src/respond-reject-libnet11.c
@@ -128,14 +128,14 @@ static libnet_t *LibnetInit(Packet *p, const char *devname, char *ebuf) {
     return c;
 }
 
-int RejectSendLibnet11L3IPv4TCP(ThreadVars *tv, Packet *p, void *data, int dir)
+int RejectSendLibnet11L3IPv4TCP(ThreadVars *tv, Packet *p, void *data, int dir,
+                                const char *devname)
 {
 
     Libnet11Packet lpacket;
     libnet_t *c; /* libnet context */
     char ebuf[LIBNET_ERRBUF_SIZE];
     int result;
-    const char *devname = NULL;
 
     /* fill in struct defaults */
     lpacket.ttl = 0;
@@ -143,7 +143,7 @@ int RejectSendLibnet11L3IPv4TCP(ThreadVars *tv, Packet *p, void *data, int dir)
     lpacket.flow = 0;
     lpacket.class = 0;
 
-    if (IS_SURI_HOST_MODE_SNIFFER_ONLY(host_mode) && (p->livedev)) {
+    if (!devname && IS_SURI_HOST_MODE_SNIFFER_ONLY(host_mode) && (p->livedev)) {
         devname = p->livedev->dev;
         SCLogDebug("Will emit reject packet on dev %s", devname);
     }
@@ -253,13 +253,13 @@ cleanup:
     return 0;
 }
 
-int RejectSendLibnet11L3IPv4ICMP(ThreadVars *tv, Packet *p, void *data, int dir)
+int RejectSendLibnet11L3IPv4ICMP(ThreadVars *tv, Packet *p, void *data, int dir,
+                                 const char *devname)
 {
     Libnet11Packet lpacket;
     libnet_t *c; /* libnet context */
     char ebuf[LIBNET_ERRBUF_SIZE];
     int result;
-    const char *devname = NULL;
 
     /* fill in struct defaults */
     lpacket.ttl = 0;
@@ -269,7 +269,7 @@ int RejectSendLibnet11L3IPv4ICMP(ThreadVars *tv, Packet *p, void *data, int dir)
 
     lpacket.len = (IPV4_GET_HLEN(p) + p->payload_len);
 
-    if (IS_SURI_HOST_MODE_SNIFFER_ONLY(host_mode) && (p->livedev)) {
+    if (!devname && IS_SURI_HOST_MODE_SNIFFER_ONLY(host_mode) && (p->livedev)) {
         devname = p->livedev->dev;
     }
     if ((c = LibnetInit(p, devname, ebuf)) == NULL) {
@@ -340,14 +340,14 @@ cleanup:
     return 0;
 }
 
-int RejectSendLibnet11L3IPv6TCP(ThreadVars *tv, Packet *p, void *data, int dir)
+int RejectSendLibnet11L3IPv6TCP(ThreadVars *tv, Packet *p, void *data, int dir,
+                                const char* devname)
 {
 
     Libnet11Packet lpacket;
     libnet_t *c; /* libnet context */
     char ebuf[LIBNET_ERRBUF_SIZE];
     int result;
-    const char *devname = NULL;
 
     /* fill in struct defaults */
     lpacket.ttl = 0;
@@ -355,7 +355,7 @@ int RejectSendLibnet11L3IPv6TCP(ThreadVars *tv, Packet *p, void *data, int dir)
     lpacket.flow = 0;
     lpacket.class = 0;
 
-    if (IS_SURI_HOST_MODE_SNIFFER_ONLY(host_mode) && (p->livedev)) {
+    if (!devname && IS_SURI_HOST_MODE_SNIFFER_ONLY(host_mode) && (p->livedev)) {
         devname = p->livedev->dev;
     }
     if ((c = LibnetInit(p, devname, ebuf)) == NULL) {
@@ -464,13 +464,13 @@ cleanup:
 }
 
 #ifdef HAVE_LIBNET_ICMPV6_UNREACH
-int RejectSendLibnet11L3IPv6ICMP(ThreadVars *tv, Packet *p, void *data, int dir)
+int RejectSendLibnet11L3IPv6ICMP(ThreadVars *tv, Packet *p, void *data, int dir,
+                                 const char*devname)
 {
     Libnet11Packet lpacket;
     libnet_t *c; /* libnet context */
     char ebuf[LIBNET_ERRBUF_SIZE];
     int result;
-    const char *devname = NULL;
 
     /* fill in struct defaults */
     lpacket.ttl = 0;
@@ -481,7 +481,7 @@ int RejectSendLibnet11L3IPv6ICMP(ThreadVars *tv, Packet *p, void *data, int dir)
 
     lpacket.len = IPV6_GET_PLEN(p) + IPV6_HEADER_LEN;
 
-    if (IS_SURI_HOST_MODE_SNIFFER_ONLY(host_mode) && (p->livedev)) {
+    if (!devname && IS_SURI_HOST_MODE_SNIFFER_ONLY(host_mode) && (p->livedev)) {
         devname = p->livedev->dev;
     }
     if ((c = LibnetInit(p, devname, ebuf)) == NULL) {
@@ -550,7 +550,8 @@ cleanup:
 }
 #else /* HAVE_LIBNET_ICMPV6_UNREACH */
 
-int RejectSendLibnet11L3IPv6ICMP(ThreadVars *tv, Packet *p, void *data, int dir)
+int RejectSendLibnet11L3IPv6ICMP(ThreadVars *tv, Packet *p, void *data, int dir,
+                                 const char *dev)
 {
     SCLogError(SC_ERR_LIBNET_NOT_ENABLED, "Libnet ICMPv6 based rejects are disabled."
                 "Usually this means that you don't have a patched libnet installed,"
@@ -562,7 +563,7 @@ int RejectSendLibnet11L3IPv6ICMP(ThreadVars *tv, Packet *p, void *data, int dir)
 
 #else
 
-int RejectSendLibnet11L3IPv4TCP(ThreadVars *tv, Packet *p, void *data, int dir)
+int RejectSendLibnet11L3IPv4TCP(ThreadVars *tv, Packet *p, void *data, int dir, const char *dev)
 {
     SCLogError(SC_ERR_LIBNET_NOT_ENABLED, "Libnet based rejects are disabled."
                 "Usually this means that you don't have libnet installed,"
@@ -570,7 +571,7 @@ int RejectSendLibnet11L3IPv4TCP(ThreadVars *tv, Packet *p, void *data, int dir)
     return 0;
 }
 
-int RejectSendLibnet11L3IPv4ICMP(ThreadVars *tv, Packet *p, void *data, int dir)
+int RejectSendLibnet11L3IPv4ICMP(ThreadVars *tv, Packet *p, void *data, int dir, const char *dev)
 {
     SCLogError(SC_ERR_LIBNET_NOT_ENABLED, "Libnet based rejects are disabled."
                 "Usually this means that you don't have libnet installed,"
@@ -578,7 +579,7 @@ int RejectSendLibnet11L3IPv4ICMP(ThreadVars *tv, Packet *p, void *data, int dir)
     return 0;
 }
 
-int RejectSendLibnet11L3IPv6TCP(ThreadVars *tv, Packet *p, void *data, int dir)
+int RejectSendLibnet11L3IPv6TCP(ThreadVars *tv, Packet *p, void *data, int dir, const char *dev)
 {
     SCLogError(SC_ERR_LIBNET_NOT_ENABLED, "Libnet based rejects are disabled."
                 "Usually this means that you don't have libnet installed,"
@@ -586,7 +587,7 @@ int RejectSendLibnet11L3IPv6TCP(ThreadVars *tv, Packet *p, void *data, int dir)
     return 0;
 }
 
-int RejectSendLibnet11L3IPv6ICMP(ThreadVars *tv, Packet *p, void *data, int dir)
+int RejectSendLibnet11L3IPv6ICMP(ThreadVars *tv, Packet *p, void *data, int dir, const char *dev)
 {
     SCLogError(SC_ERR_LIBNET_NOT_ENABLED, "Libnet based rejects are disabled."
                 "Usually this means that you don't have libnet installed,"

--- a/src/respond-reject-libnet11.c
+++ b/src/respond-reject-libnet11.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2018 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -78,6 +78,56 @@ typedef struct Libnet11Packet_ {
     size_t len;
 } Libnet11Packet;
 
+static int LibnetWrite(Packet *p, int ip_version, libnet_t *c)
+{
+    /* Only support one layer of VLAN */
+    if (p->vlan_idx == 1) {
+        int ret = libnet_build_802_1q(
+                p->ethh->eth_src,
+                p->ethh->eth_dst,
+                ETHERTYPE_VLAN,
+                0, // vlan_prio
+                0, // cfi
+                p->vlan_id[0],
+                ip_version,
+                NULL, // payload
+                0, // payload length
+                c,
+                0);
+        if (ret == -1) {
+            SCLogError(SC_ERR_LIBNET_BUILD_FAILED,"libnet_build_802_1q %s",
+                       libnet_geterror(c));
+            return ret;
+        }
+    }
+
+    return libnet_write(c);
+}
+
+static libnet_t *LibnetInit(Packet *p, const char *devname, char *ebuf) {
+    libnet_t *c = NULL; /* libnet context */
+    if (p->vlan_idx == 1) {
+        if ((c = libnet_init(LIBNET_LINK, LIBNET_INIT_CAST devname, ebuf)) == NULL) {
+            SCLogError(SC_ERR_LIBNET_INIT,"libnet_init failed: %s", ebuf);
+            return NULL;
+        }
+    } else {
+        if (PKT_IS_IPV4(p)) {
+            if ((c = libnet_init(LIBNET_RAW4, LIBNET_INIT_CAST devname, ebuf)) == NULL) {
+                SCLogError(SC_ERR_LIBNET_INIT,"libnet_init failed: %s", ebuf);
+                return NULL;
+            }
+        }
+        if (PKT_IS_IPV6(p)) {
+            if ((c = libnet_init(LIBNET_RAW6, LIBNET_INIT_CAST devname, ebuf)) == NULL) {
+                SCLogError(SC_ERR_LIBNET_INIT,"libnet_init failed: %s", ebuf);
+                return NULL;
+            }
+        }
+    }
+    return c;
+}
+
 int RejectSendLibnet11L3IPv4TCP(ThreadVars *tv, Packet *p, void *data, int dir)
 {
 
@@ -97,7 +147,7 @@ int RejectSendLibnet11L3IPv4TCP(ThreadVars *tv, Packet *p, void *data, int dir)
         devname = p->livedev->dev;
         SCLogDebug("Will emit reject packet on dev %s", devname);
     }
-    if ((c = libnet_init(LIBNET_RAW4, LIBNET_INIT_CAST devname, ebuf)) == NULL) {
+    if ((c = LibnetInit(p, devname, ebuf)) == NULL) {
         SCLogError(SC_ERR_LIBNET_INIT,"libnet_init failed: %s", ebuf);
         return 1;
     }
@@ -192,7 +242,7 @@ int RejectSendLibnet11L3IPv4TCP(ThreadVars *tv, Packet *p, void *data, int dir)
         goto cleanup;
     }
 
-    result = libnet_write(c);
+    result = LibnetWrite(p, ETHERTYPE_IP, c);
     if (result == -1) {
         SCLogError(SC_ERR_LIBNET_WRITE_FAILED,"libnet_write failed: %s", libnet_geterror(c));
         goto cleanup;
@@ -222,8 +272,8 @@ int RejectSendLibnet11L3IPv4ICMP(ThreadVars *tv, Packet *p, void *data, int dir)
     if (IS_SURI_HOST_MODE_SNIFFER_ONLY(host_mode) && (p->livedev)) {
         devname = p->livedev->dev;
     }
-    if ((c = libnet_init(LIBNET_RAW4, LIBNET_INIT_CAST devname, ebuf)) == NULL) {
-        SCLogError(SC_ERR_LIBNET_INIT,"libnet_inint failed: %s", ebuf);
+    if ((c = LibnetInit(p, devname, ebuf)) == NULL) {
+        SCLogError(SC_ERR_LIBNET_INIT,"libnet_init failed: %s", ebuf);
         return 1;
     }
 
@@ -279,7 +329,7 @@ int RejectSendLibnet11L3IPv4ICMP(ThreadVars *tv, Packet *p, void *data, int dir)
         goto cleanup;
     }
 
-    result = libnet_write(c);
+    result = LibnetWrite(p, ETHERTYPE_IP, c);
     if (result == -1) {
         SCLogError(SC_ERR_LIBNET_WRITE_FAILED,"libnet_write_raw_ipv4 failed: %s", libnet_geterror(c));
         goto cleanup;
@@ -308,7 +358,7 @@ int RejectSendLibnet11L3IPv6TCP(ThreadVars *tv, Packet *p, void *data, int dir)
     if (IS_SURI_HOST_MODE_SNIFFER_ONLY(host_mode) && (p->livedev)) {
         devname = p->livedev->dev;
     }
-    if ((c = libnet_init(LIBNET_RAW6, LIBNET_INIT_CAST devname, ebuf)) == NULL) {
+    if ((c = LibnetInit(p, devname, ebuf)) == NULL) {
         SCLogError(SC_ERR_LIBNET_INIT,"libnet_init failed: %s", ebuf);
         return 1;
     }
@@ -402,7 +452,7 @@ int RejectSendLibnet11L3IPv6TCP(ThreadVars *tv, Packet *p, void *data, int dir)
         goto cleanup;
     }
 
-    result = libnet_write(c);
+    result = LibnetWrite(p, ETHERTYPE_IPV6, c);
     if (result == -1) {
         SCLogError(SC_ERR_LIBNET_WRITE_FAILED,"libnet_write failed: %s", libnet_geterror(c));
         goto cleanup;
@@ -434,8 +484,8 @@ int RejectSendLibnet11L3IPv6ICMP(ThreadVars *tv, Packet *p, void *data, int dir)
     if (IS_SURI_HOST_MODE_SNIFFER_ONLY(host_mode) && (p->livedev)) {
         devname = p->livedev->dev;
     }
-    if ((c = libnet_init(LIBNET_RAW6, LIBNET_INIT_CAST devname, ebuf)) == NULL) {
-        SCLogError(SC_ERR_LIBNET_INIT,"libnet_inint failed: %s", ebuf);
+    if ((c = LibnetInit(p, devname, ebuf)) == NULL) {
+        SCLogError(SC_ERR_LIBNET_INIT,"libnet_init failed: %s", ebuf);
         return 1;
     }
 
@@ -488,7 +538,7 @@ int RejectSendLibnet11L3IPv6ICMP(ThreadVars *tv, Packet *p, void *data, int dir)
         goto cleanup;
     }
 
-    result = libnet_write(c);
+    result = LibnetWrite(p, ETHERTYPE_IPV6, c);
     if (result == -1) {
         SCLogError(SC_ERR_LIBNET_WRITE_FAILED,"libnet_write_raw_ipv6 failed: %s", libnet_geterror(c));
         goto cleanup;

--- a/src/respond-reject-libnet11.h
+++ b/src/respond-reject-libnet11.h
@@ -25,9 +25,9 @@
 #ifndef __RESPOND_REJECT_LIBNET11_H__
 #define __RESPOND_REJECT_LIBNET11_H__
 
-int RejectSendLibnet11L3IPv4TCP(ThreadVars *, Packet *, void *,int);
-int RejectSendLibnet11L3IPv4ICMP(ThreadVars *, Packet *, void *,int);
+int RejectSendLibnet11L3IPv4TCP(ThreadVars *, Packet *, void *,int, const char *devname);
+int RejectSendLibnet11L3IPv4ICMP(ThreadVars *, Packet *, void *,int, const char *devname);
 
-int RejectSendLibnet11L3IPv6TCP(ThreadVars *, Packet *, void *,int);
-int RejectSendLibnet11L3IPv6ICMP(ThreadVars *, Packet *, void *,int);
+int RejectSendLibnet11L3IPv6TCP(ThreadVars *, Packet *, void *,int, const char *devname);
+int RejectSendLibnet11L3IPv6ICMP(ThreadVars *, Packet *, void *,int, const char *devname);
 #endif /* __RESPOND_REJECT_LIBNET11_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1130,6 +1130,11 @@ coredump:
 # This feature is currently only used by the reject* keywords.
 host-mode: auto
 
+# Uncomment and set the following variable to define the interface where
+# response packet will be sent. If not set, interface will be choozen using
+# the capture iface and following host-mode logic.
+#reject-iface: eth0
+
 # Number of packets preallocated per thread. The default is 1024. A higher number 
 # will make sure each CPU will be more easily kept busy, but may negatively 
 # impact caching.


### PR DESCRIPTION
A small patchset around the reject keyword. It addresses the case where the reject packets can't be sent to the sniffing interface but where a dedicated interface has to be used. It also fixes the case where we have one VLAN layer. In this case the reject packets were sent without the VLAN tag which was not expected by the network equipment in most cases.

The case of 2 layers of VLAN is not supported. It would require to get out of libnet for the sending of packets.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) tickets:
- https://redmine.openinfosecfoundation.org/issues/2524
- https://redmine.openinfosecfoundation.org/issues/2525

Describe changes:
- add VLAN support to reject keyword
- add reject-iface option to force interface where reject messages are sent

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/410
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/192
