### PR TITLE
detect-parse: fix missing space in error message (2541)

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -678,7 +678,7 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
         }
         /* if quoting is mandatory, enforce it */
         if (st->flags & SIGMATCH_QUOTES_MANDATORY && ovlen && *ptr != '"') {
-            SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid formattingto %s keyword: "
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid formatting to %s keyword: "
                     "value must be double quoted \'%s\'", optname, optstr);
             goto error;
         }


### PR DESCRIPTION
Fix missing space in error message.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Fix a missing space in error message

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

