### PR TITLE
detect: fix fileext and filename negated match

### DIFF
--- a/src/detect-fileext.c
+++ b/src/detect-fileext.c
@@ -116,9 +116,7 @@ static int DetectFileextMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx,
             ret = 1;
             SCLogDebug("File ext found");
         }
-    }
-
-    if (ret == 0 && (fileext->flags & DETECT_CONTENT_NEGATED)) {
+    } else if (fileext->flags & DETECT_CONTENT_NEGATED) {
         SCLogDebug("negated match");
         ret = 1;
     }

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -156,7 +156,7 @@ static int DetectFilenameMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         }
     }
 
-    if (ret == 0 && (filename->flags & DETECT_CONTENT_NEGATED)) {
+    else if (filename->flags & DETECT_CONTENT_NEGATED) {
         SCLogDebug("negated match");
         ret = 1;
     }


### PR DESCRIPTION
fix bug in fileext and filename preventing negated match to work
correctly. Previously, negated fileext (such as !"php") would cause a
match anyway on files that have extension php, as the last if would not
be accessed.

Using the same workflow as detect-filemagic we remove the final
isolated if and set it as a branch of the previous if.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2558
Describe changes:
- fix in detect-fileext.c adding the last if as an alternative branch to the previous if
- fix in detect-filemagic.c adding the last if as an alternative branch to the previous if
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

