### PR TITLE
eve/http: add tx->request_port_number as http_port

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -180,6 +180,21 @@ Event with non-extended logging:
       "http_content_type": "application\/x-gzip"
   }
 
+In case the hostname shows a port number (such as in case the header "Hostname: www.test.org:1337") is present:
+
+::
+
+
+  "http": {
+      "http_port": 1337,
+      "hostname": "www.test.org",
+      "url" :"\/this\/is\/test.tar.gz",
+      "http_user_agent": "<User-Agent>",
+      "http_content_type": "application\/x-gzip"
+  }
+
+
+
 Event with extended logging:
 
 ::

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -202,6 +202,18 @@ static void JsonHttpLogJSONBasic(json_t *js, htp_tx_t *tx)
         }
     }
 
+    /* port */
+    /* NOTE: that this field will be set ONLY if the port is present in the
+     * hostname. It may be present in the header "Hostname" or in the URL.
+     * There is no connection (from the suricata point of view) between this
+     * port and the TCP destination port of the flow.
+     */
+    if (tx->request_port_number >= 0)
+    {
+        json_object_set_new(js, "http_port",
+                json_integer(tx->request_port_number));
+    }
+
     /* uri */
     if (tx->request_uri != NULL)
     {


### PR DESCRIPTION
Add the port specified in the hostname (if any) to the http object in
eve. The port may be different from the dest_port used by the TCP flow.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2562

Describe changes:
- add http_port to the http object with the port specified in the hostname (if any)
-
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

