### PR TITLE
problem: 2nd key in bpf_map_get_next_key usage is the current one.

### DIFF
--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -391,7 +391,7 @@ static int EBPFForEachFlowV4Table(LiveDevice *dev, const char *name,
                                   struct timespec *ctime)
 {
     int mapfd = EBPFGetMapFDByName(dev->dev, name);
-    struct flowv4_keys key = {}, next_key;
+    struct flowv4_keys prev_key = {}, key;
     int found = 0;
     unsigned int i;
     unsigned int nr_cpus = UtilCpuGetNumProcessorsConfigured();
@@ -401,7 +401,7 @@ static int EBPFForEachFlowV4Table(LiveDevice *dev, const char *name,
     }
 
     uint64_t hash_cnt = 0;
-    while (bpf_map_get_next_key(mapfd, &key, &next_key) == 0) {
+    while (bpf_map_get_next_key(mapfd, &prev_key, &key) == 0) {
         bool purge = true;
         uint64_t pkts_cnt = 0;
         uint64_t bytes_cnt = 0;
@@ -412,7 +412,7 @@ static int EBPFForEachFlowV4Table(LiveDevice *dev, const char *name,
         int res = bpf_map_lookup_elem(mapfd, &key, values_array);
         if (res < 0) {
             SCLogDebug("no entry in v4 table for %d -> %d", key.port16[0], key.port16[1]);
-            key = next_key;
+            prev_key = key;
             continue;
         }
         for (i = 0; i < nr_cpus; i++) {
@@ -441,7 +441,7 @@ static int EBPFForEachFlowV4Table(LiveDevice *dev, const char *name,
             found = 1;
             EBPFDeleteKey(mapfd, &key);
         }
-        key = next_key;
+        prev_key = key;
     }
 
     struct bpf_maps_info *bpfdata = LiveDevGetStorageById(dev, g_livedev_storage_id);
@@ -463,7 +463,7 @@ static int EBPFForEachFlowV6Table(LiveDevice *dev, const char *name,
                                   struct timespec *ctime)
 {
     int mapfd = EBPFGetMapFDByName(dev->dev, name);
-    struct flowv6_keys key = {}, next_key;
+    struct flowv6_keys prev_key = {}, key;
     int found = 0;
     unsigned int i;
     unsigned int nr_cpus = UtilCpuGetNumProcessorsConfigured();
@@ -473,7 +473,7 @@ static int EBPFForEachFlowV6Table(LiveDevice *dev, const char *name,
     }
 
     uint64_t hash_cnt = 0;
-    while (bpf_map_get_next_key(mapfd, &key, &next_key) == 0) {
+    while (bpf_map_get_next_key(mapfd, &prev_key, &key) == 0) {
         bool purge = true;
         uint64_t pkts_cnt = 0;
         uint64_t bytes_cnt = 0;
@@ -483,7 +483,7 @@ static int EBPFForEachFlowV6Table(LiveDevice *dev, const char *name,
         int res = bpf_map_lookup_elem(mapfd, &key, values_array);
         if (res < 0) {
             SCLogDebug("no entry in v6 table for %d -> %d", key.port16[0], key.port16[1]);
-            key = next_key;
+            prev_key = key;
             continue;
         }
         for (i = 0; i < nr_cpus; i++) {
@@ -504,7 +504,7 @@ static int EBPFForEachFlowV6Table(LiveDevice *dev, const char *name,
             found = 1;
             EBPFDeleteKey(mapfd, &key);
         }
-        key = next_key;
+        prev_key = key;
     }
 
     struct bpf_maps_info *bpfdata = LiveDevGetStorageById(dev, g_livedev_storage_id);


### PR DESCRIPTION
The 2nd key passed to bpf_map_get_next_key is the one that contains
the current key in the iteration.

If the map only contains a single key, after one call to
bpf_map_get_next_key key is undefined and next_key is the first item.
doing key = next_key and calling bpf_map_get_next_key ends the loop
because there are no more keys and bpf_map_lookup_elem is never called
with the first key.  I believe in maps containing more than one key this
will just result in the first key being skipped.

linux/samples/bpf/sampleip_user.c is one of the only uses of
bpf_map_get_next_key I can find, and they do:

    key = 0, i = 0;
    while (bpf_map_get_next_key(fd, &key, &next_key) == 0) {
            bpf_map_lookup_elem(fd, &next_key, &value);
            counts[i].ip = next_key;
            counts[i++].count = value;
            key = next_key;
    }

Note how bpf_map_lookup_elem is called with next_key, not key.

To avoid having to change a ton of references to key, I just renamed key
to prev_key and nextkey to key.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ ] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

