### PR TITLE
Add support for TLSv1.3

### DIFF
--- a/doc/userguide/rules/tls-keywords.rst
+++ b/doc/userguide/rules/tls-keywords.rst
@@ -121,7 +121,17 @@ tls.version
 
 Match on negotiated TLS/SSL version.
 
-Example values: "1.0", "1.1", "1.2"
+Supported values: "1.0", "1.1", "1.2", "1.3"
+
+It is also possible to match versions using a hex string.
+
+Examples::
+
+  tls.version:1.2;
+  tls.version:0x7f12;
+
+The first example matches TLSv1.2, whilst the last example matches TLSv1.3
+draft 16.
 
 tls.subject
 -----------

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -561,6 +561,28 @@ static inline int TLSDecodeHSHelloVersion(SSLState *ssl_state,
 
     ssl_state->curr_connp->version = *input << 8 | *(input + 1);
 
+    /* TLSv1.3 draft1 to draft21 use the version field as earlier TLS
+       versions, instead of using the supported versions extension. */
+    if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_SERVER_HELLO) &&
+            ((ssl_state->curr_connp->version == TLS_VERSION_13) ||
+            (((ssl_state->curr_connp->version >> 8) & 0xff) == 0x7f))) {
+        ssl_state->flags |= SSL_AL_FLAG_LOG_WITHOUT_CERT;
+    }
+
+    /* Catch some early TLSv1.3 draft implementations that does not conform
+       to the draft version. */
+    if ((ssl_state->curr_connp->version >= 0x7f01) &&
+            (ssl_state->curr_connp->version < 0x7f10)) {
+        ssl_state->curr_connp->version = TLS_VERSION_13_PRE_DRAFT16;
+    }
+
+    /* TLSv1.3 drafts from draft1 to draft15 use 0x0304 (TLSv1.3) as the
+       version number, which makes it hard to accurately pinpoint the
+       exact draft version. */
+    else if (ssl_state->curr_connp->version == TLS_VERSION_13) {
+        ssl_state->curr_connp->version = TLS_VERSION_13_PRE_DRAFT16;
+    }
+
     if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) &&
             ssl_config.enable_ja3) {
         ssl_state->ja3_str = Ja3BufferInit();
@@ -1165,12 +1187,18 @@ static int TLSDecodeHandshakeHello(SSLState *ssl_state,
 
     parsed += ret;
 
-    ret = TLSDecodeHSHelloSessionID(ssl_state, input + parsed,
-                                    input_len - parsed);
-    if (ret < 0)
-        goto end;
+    /* The session id field in the server hello record was removed in
+       TLSv1.3 draft1, but was readded in draft22. */
+    if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) ||
+            ((ssl_state->current_flags & SSL_AL_FLAG_STATE_SERVER_HELLO) &&
+            ((ssl_state->flags & SSL_AL_FLAG_LOG_WITHOUT_CERT) == 0))) {
+        ret = TLSDecodeHSHelloSessionID(ssl_state, input + parsed,
+                                        input_len - parsed);
+        if (ret < 0)
+            goto end;
 
-    parsed += ret;
+        parsed += ret;
+    }
 
     ret = TLSDecodeHSHelloCipherSuites(ssl_state, input + parsed,
                                        input_len - parsed);
@@ -1179,12 +1207,18 @@ static int TLSDecodeHandshakeHello(SSLState *ssl_state,
 
     parsed += ret;
 
-    ret = TLSDecodeHSHelloCompressionMethods(ssl_state, input + parsed,
-                                             input_len - parsed);
-    if (ret < 0)
-        goto end;
+   /* The compression methods field in the server hello record was
+      removed in TLSv1.3 draft1, but was readded in draft22. */
+   if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) ||
+              ((ssl_state->current_flags & SSL_AL_FLAG_STATE_SERVER_HELLO) &&
+              ((ssl_state->flags & SSL_AL_FLAG_LOG_WITHOUT_CERT) == 0))) {
+        ret = TLSDecodeHSHelloCompressionMethods(ssl_state, input + parsed,
+                                                 input_len - parsed);
+        if (ret < 0)
+            goto end;
 
-    parsed += ret;
+        parsed += ret;
+    }
 
     ret = TLSDecodeHSHelloExtensions(ssl_state, input + parsed,
                                      input_len - parsed);

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1015,6 +1015,20 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
                 break;
             }
 
+            case SSL_EXTENSION_SESSION_TICKET:
+            {
+                if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) &&
+                        ext_len != 0) {
+                    /* This has to be verified later on by checking if a
+                       certificate record has been sent by the server. */
+                    ssl_state->flags |= SSL_AL_FLAG_SESSION_RESUMED;
+                }
+
+                input += ext_len;
+
+                break;
+            }
+
             default:
             {
                 input += ext_len;

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -559,15 +559,16 @@ static inline int TLSDecodeHSHelloVersion(SSLState *ssl_state,
         return -1;
     }
 
+    ssl_state->curr_connp->version = *input << 8 | *(input + 1);
+
     if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) &&
             ssl_config.enable_ja3) {
-        uint16_t version = *input << 8 | *(input + 1);
-
         ssl_state->ja3_str = Ja3BufferInit();
         if (ssl_state->ja3_str == NULL)
             return -1;
 
-        int rc = Ja3BufferAddValue(&ssl_state->ja3_str, version);
+        int rc = Ja3BufferAddValue(&ssl_state->ja3_str,
+                                   ssl_state->curr_connp->version);
         if (rc != 0)
             return -1;
     }
@@ -818,6 +819,56 @@ invalid_length:
     return -1;
 }
 
+static inline int TLSDecodeHSHelloExtensionSupportedVersions(SSLState *ssl_state,
+                                             const uint8_t * const initial_input,
+                                             const uint32_t input_len)
+{
+    uint8_t *input = (uint8_t *)initial_input;
+
+    if (ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) {
+        if (!(HAS_SPACE(1)))
+            goto invalid_length;
+
+        uint8_t supported_ver_len = *input;
+        input += 1;
+
+        if (!(HAS_SPACE(supported_ver_len)))
+            goto invalid_length;
+
+        /* Use the first (and prefered) version as client version */
+        ssl_state->curr_connp->version = *input << 8 | *(input + 1);
+
+        /* Set a flag to indicate that we have seen this extension */
+        ssl_state->flags |= SSL_AL_FLAG_CH_VERSION_EXTENSION;
+
+        input += supported_ver_len;
+    }
+
+    else if (ssl_state->current_flags & SSL_AL_FLAG_STATE_SERVER_HELLO) {
+        if (!(HAS_SPACE(2)))
+            goto invalid_length;
+
+        uint16_t ver = *input << 8 | *(input + 1);
+
+        if ((ssl_state->flags & SSL_AL_FLAG_CH_VERSION_EXTENSION) &&
+            ((ver == TLS_VERSION_13) || (((ver >> 8) & 0xff) == 0x7f))) {
+            ssl_state->flags |= SSL_AL_FLAG_LOG_WITHOUT_CERT;
+        }
+
+        ssl_state->curr_connp->version = ver;
+        input += 2;
+    }
+
+    return (input - initial_input);
+
+invalid_length:
+    SCLogDebug("TLS handshake invalid length");
+    SSLSetEvent(ssl_state,
+                TLS_DECODER_EVENT_HANDSHAKE_INVALID_LENGTH);
+
+    return -1;
+}
+
 static inline int TLSDecodeHSHelloExtensionEllipticCurves(SSLState *ssl_state,
                                           const uint8_t * const initial_input,
                                           const uint32_t input_len,
@@ -1007,6 +1058,18 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
                 ret = TLSDecodeHSHelloExtensionEllipticCurvePF(ssl_state, input,
                                                                input_len - parsed,
                                                                ja3_elliptic_curves_pf);
+                if (ret < 0)
+                    goto end;
+
+                input += ret;
+
+                break;
+            }
+
+            case SSL_EXTENSION_SUPPORTED_VERSIONS:
+            {
+                ret = TLSDecodeHSHelloExtensionSupportedVersions(ssl_state, input,
+                                                                 input_len - parsed);
                 if (ret < 0)
                     goto end;
 
@@ -1532,12 +1595,30 @@ static int SSLv3ParseRecord(uint8_t direction, SSLState *ssl_state,
         return 0;
     }
 
+    uint8_t skip_version = 0;
+
+    /* Only set SSL/TLS version here if it has not already been set in
+       client/server hello. */
+    if (direction == 0) {
+        if ((ssl_state->flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) &&
+                (ssl_state->client_connp.version != TLS_VERSION_UNKNOWN)) {
+            skip_version = 1;
+        }
+    } else {
+        if ((ssl_state->flags & SSL_AL_FLAG_STATE_SERVER_HELLO) &&
+                (ssl_state->server_connp.version != TLS_VERSION_UNKNOWN)) {
+            skip_version = 1;
+        }
+    }
+
     switch (ssl_state->curr_connp->bytes_processed) {
         case 0:
             if (input_len >= 5) {
                 ssl_state->curr_connp->content_type = input[0];
-                ssl_state->curr_connp->version = input[1] << 8;
-                ssl_state->curr_connp->version |= input[2];
+                if (!skip_version) {
+                    ssl_state->curr_connp->version = input[1] << 8;
+                    ssl_state->curr_connp->version |= input[2];
+                }
                 ssl_state->curr_connp->record_length = input[3] << 8;
                 ssl_state->curr_connp->record_length |= input[4];
                 ssl_state->curr_connp->bytes_processed += SSLV3_RECORD_HDR_LEN;
@@ -1550,13 +1631,23 @@ static int SSLv3ParseRecord(uint8_t direction, SSLState *ssl_state,
 
             /* fall through */
         case 1:
-            ssl_state->curr_connp->version = *(input++) << 8;
+            if (!skip_version) {
+                ssl_state->curr_connp->version = *(input++) << 8;
+                printf("%d\n", ssl_state->curr_connp->version);
+            } else {
+                input++;
+            }
             if (--input_len == 0)
                 break;
 
             /* fall through */
         case 2:
-            ssl_state->curr_connp->version |= *(input++);
+            if (!skip_version) {
+                ssl_state->curr_connp->version |= *(input++);
+                printf("%d\n", ssl_state->curr_connp->version);
+            } else {
+                input++;
+            }
             if (--input_len == 0)
                 break;
 
@@ -1961,14 +2052,6 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
         return parsed;
     }
 
-    /* check record version */
-    if (ssl_state->curr_connp->version < SSL_VERSION_3 ||
-            ssl_state->curr_connp->version > TLS_VERSION_12) {
-
-        SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_RECORD_VERSION);
-        return -1;
-    }
-
     /* record_length should never be zero */
     if (ssl_state->curr_connp->record_length == 0) {
         SCLogDebug("SSLv3 Record length is 0");
@@ -2196,9 +2279,6 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
                     }
                 } else {
                     SCLogDebug("SSLv3.x detected");
-                    /* we will keep it this way till our record parser tells
-                       us what exact version this is */
-                    ssl_state->curr_connp->version = TLS_VERSION_UNKNOWN;
                     retval = SSLv3Decode(direction, ssl_state, pstate, input,
                                          input_len);
                     if (retval < 0) {
@@ -4455,8 +4535,6 @@ static int SSLParserTest23(void)
      * record */
     FAIL_IF(app_state->client_connp.content_type != SSLV3_HANDSHAKE_PROTOCOL);
 
-    FAIL_IF(app_state->client_connp.version != SSL_VERSION_3);
-
     FAIL_IF((app_state->flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) == 0);
     FAIL_IF((app_state->flags & SSL_AL_FLAG_SSL_CLIENT_HS) == 0);
     FAIL_IF((app_state->flags & SSL_AL_FLAG_SSL_NO_SESSION_ID) == 0);
@@ -4494,8 +4572,6 @@ static int SSLParserTest23(void)
     FAIL_IF(r != 0);
 
     FAIL_IF(app_state->client_connp.content_type != SSLV3_APPLICATION_PROTOCOL);
-
-    FAIL_IF(app_state->client_connp.version != SSL_VERSION_3);
 
     FAIL_IF((app_state->flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) == 0);
     FAIL_IF((app_state->flags & SSL_AL_FLAG_SSL_CLIENT_HS) == 0);

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -110,6 +110,7 @@ enum {
 #define SSL_EXTENSION_SNI                       0x0000
 #define SSL_EXTENSION_ELLIPTIC_CURVES           0x000a
 #define SSL_EXTENSION_EC_POINT_FORMATS          0x000b
+#define SSL_EXTENSION_SESSION_TICKET            0x0023
 
 /* SNI types */
 #define SSL_SNI_TYPE_HOST_NAME                  0

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -166,6 +166,9 @@ typedef struct SSLStateConnp_ {
     /* ssl server name indication extension */
     char *sni;
 
+    char *session_id;
+    uint8_t ssl3_session_id_length;
+
     TAILQ_HEAD(, SSLCertsChain_) certs;
 
     uint32_t cert_log_flag;

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -103,6 +103,13 @@ enum {
 /* Session resumed without a full handshake */
 #define SSL_AL_FLAG_SESSION_RESUMED             BIT_U32(20)
 
+/* Encountered a supported_versions extension in client hello */
+#define SSL_AL_FLAG_CH_VERSION_EXTENSION        BIT_U32(21)
+
+/* Log the session even without ever seeing a certificate. This is used
+   to log TLSv1.3 sessions. */
+#define SSL_AL_FLAG_LOG_WITHOUT_CERT            BIT_U32(22)
+
 /* config flags */
 #define SSL_TLS_LOG_PEM                         (1 << 0)
 
@@ -111,6 +118,7 @@ enum {
 #define SSL_EXTENSION_ELLIPTIC_CURVES           0x000a
 #define SSL_EXTENSION_EC_POINT_FORMATS          0x000b
 #define SSL_EXTENSION_SESSION_TICKET            0x0023
+#define SSL_EXTENSION_SUPPORTED_VERSIONS        0x002b
 
 /* SNI types */
 #define SSL_SNI_TYPE_HOST_NAME                  0
@@ -124,6 +132,21 @@ enum {
     TLS_VERSION_10 = 0x0301,
     TLS_VERSION_11 = 0x0302,
     TLS_VERSION_12 = 0x0303,
+    TLS_VERSION_13 = 0x0304,
+    TLS_VERSION_13_DRAFT28 = 0x7f1c,
+    TLS_VERSION_13_DRAFT27 = 0x7f1b,
+    TLS_VERSION_13_DRAFT26 = 0x7f1a,
+    TLS_VERSION_13_DRAFT25 = 0x7f19,
+    TLS_VERSION_13_DRAFT24 = 0x7f18,
+    TLS_VERSION_13_DRAFT23 = 0x7f17,
+    TLS_VERSION_13_DRAFT22 = 0x7f16,
+    TLS_VERSION_13_DRAFT21 = 0x7f15,
+    TLS_VERSION_13_DRAFT20 = 0x7f14,
+    TLS_VERSION_13_DRAFT19 = 0x7f13,
+    TLS_VERSION_13_DRAFT18 = 0x7f12,
+    TLS_VERSION_13_DRAFT17 = 0x7f11,
+    TLS_VERSION_13_DRAFT16 = 0x7f10,
+    TLS_VERSION_13_PRE_DRAFT16 = 0x7f01,
 };
 
 typedef struct SSLCertsChain_ {

--- a/src/detect-ssl-version.c
+++ b/src/detect-ssl-version.c
@@ -148,6 +148,28 @@ static int DetectSslVersionMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
                 ret = 1;
             sig_ver = TLS12;
             break;
+        case TLS_VERSION_13_DRAFT28:
+        case TLS_VERSION_13_DRAFT27:
+        case TLS_VERSION_13_DRAFT26:
+        case TLS_VERSION_13_DRAFT25:
+        case TLS_VERSION_13_DRAFT24:
+        case TLS_VERSION_13_DRAFT23:
+        case TLS_VERSION_13_DRAFT22:
+        case TLS_VERSION_13_DRAFT21:
+        case TLS_VERSION_13_DRAFT20:
+        case TLS_VERSION_13_DRAFT19:
+        case TLS_VERSION_13_DRAFT18:
+        case TLS_VERSION_13_DRAFT17:
+        case TLS_VERSION_13_DRAFT16:
+        case TLS_VERSION_13_PRE_DRAFT16:
+            if (((ver >> 8) & 0xff) == 0x7f)
+                ver = TLS_VERSION_13;
+            /* fall through */
+        case TLS_VERSION_13:
+            if (ver == ssl->data[TLS13].ver)
+                ret = 1;
+            sig_ver = TLS13;
+            break;
     }
 
     if (sig_ver == TLS_UNKNOWN)
@@ -239,6 +261,10 @@ static DetectSslVersionData *DetectSslVersionParse(const char *str)
                 ssl->data[TLS12].ver = TLS_VERSION_12;
                 if (neg == 1)
                     ssl->data[TLS12].flags |= DETECT_SSL_VERSION_NEGATED;
+            } else if (strncasecmp("tls1.3", tmp_str, 6) == 0) {
+                ssl->data[TLS13].ver = TLS_VERSION_13;
+                if (neg == 1)
+                    ssl->data[TLS13].flags |= DETECT_SSL_VERSION_NEGATED;
             }  else if (strcmp(tmp_str, "") == 0) {
                 SCFree(orig);
                 if (found == 0)

--- a/src/detect-ssl-version.h
+++ b/src/detect-ssl-version.h
@@ -33,9 +33,10 @@ enum {
     TLS10 = 2,
     TLS11 = 3,
     TLS12 = 4,
+    TLS13 = 5,
 
-    TLS_SIZE = 5,
-    TLS_UNKNOWN = 6,
+    TLS_SIZE = 6,
+    TLS_UNKNOWN = 7,
 };
 
 typedef struct SSLVersionData_ {

--- a/src/detect-tls-version.h
+++ b/src/detect-tls-version.h
@@ -24,8 +24,11 @@
 #ifndef __DETECT_TLS_VERSION_H__
 #define __DETECT_TLS_VERSION_H__
 
+#define DETECT_TLS_VERSION_FLAG_RAW  BIT_U8(0)
+
 typedef struct DetectTlsVersionData_ {
     uint16_t ver; /** tls version to match */
+    uint8_t flags;
 } DetectTlsVersionData;
 
 /* prototypes */

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -113,6 +113,51 @@ static void LogTlsLogVersion(MemBuffer *buffer, uint16_t version)
         case TLS_VERSION_12:
             MemBufferWriteString(buffer, "VERSION='TLS 1.2'");
             break;
+        case TLS_VERSION_13:
+            MemBufferWriteString(buffer, "VERSION='TLS 1.3'");
+            break;
+        case TLS_VERSION_13_DRAFT28:
+            MemBufferWriteString(buffer, "VERSION='TLS 1.3 (draft 28)'");
+            break;
+        case TLS_VERSION_13_DRAFT27:
+              MemBufferWriteString(buffer, "VERSION='TLS 1.3 (draft 27)'");
+              break;
+        case TLS_VERSION_13_DRAFT26:
+              MemBufferWriteString(buffer, "VERSION='TLS 1.3 (draft 26)'");
+              break;
+        case TLS_VERSION_13_DRAFT25:
+              MemBufferWriteString(buffer, "VERSION='TLS 1.3 (draft 25)'");
+              break;
+        case TLS_VERSION_13_DRAFT24:
+              MemBufferWriteString(buffer, "VERSION='TLS 1.3 (draft 24)'");
+              break;
+        case TLS_VERSION_13_DRAFT23:
+              MemBufferWriteString(buffer, "VERSION='TLS 1.3 (draft 23)'");
+              break;
+        case TLS_VERSION_13_DRAFT22:
+              MemBufferWriteString(buffer, "VERSION='TLS 1.3 (draft 22)'");
+              break;
+        case TLS_VERSION_13_DRAFT21:
+              MemBufferWriteString(buffer, "VERSION='TLS 1.3 (draft 21)'");
+              break;
+        case TLS_VERSION_13_DRAFT20:
+              MemBufferWriteString(buffer, "VERSION='TLS 1.3 (draft 20)'");
+              break;
+        case TLS_VERSION_13_DRAFT19:
+              MemBufferWriteString(buffer, "VERSION='TLS 1.3 (draft 19)'");
+              break;
+        case TLS_VERSION_13_DRAFT18:
+              MemBufferWriteString(buffer, "VERSION='TLS 1.3 (draft 18)'");
+              break;
+        case TLS_VERSION_13_DRAFT17:
+              MemBufferWriteString(buffer, "VERSION='TLS 1.3 (draft 17)'");
+              break;
+        case TLS_VERSION_13_DRAFT16:
+              MemBufferWriteString(buffer, "VERSION='TLS 1.3 (draft 16)'");
+              break;
+        case TLS_VERSION_13_PRE_DRAFT16:
+              MemBufferWriteString(buffer, "VERSION='TLS 1.3 (draft <16)'");
+              break;
         default:
             MemBufferWriteString(buffer, "VERSION='0x%04x'", version);
             break;
@@ -458,7 +503,8 @@ static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
     if (((hlog->flags & LOG_TLS_SESSION_RESUMPTION) == 0 ||
             (ssl_state->flags & SSL_AL_FLAG_SESSION_RESUMED) == 0) &&
             (ssl_state->server_connp.cert0_issuerdn == NULL ||
-            ssl_state->server_connp.cert0_subject == NULL)) {
+            ssl_state->server_connp.cert0_subject == NULL) &&
+            ((ssl_state->flags & SSL_AL_FLAG_LOG_WITHOUT_CERT) == 0)) {
         return 0;
     }
 
@@ -493,7 +539,8 @@ static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
             /* Only log a session as 'resumed' if a certificate has not
                been seen. */
             if ((ssl_state->server_connp.cert0_issuerdn == NULL) &&
-                    (ssl_state->server_connp.cert0_subject == NULL)) {
+                    (ssl_state->server_connp.cert0_subject == NULL) &&
+                    ((ssl_state->flags & SSL_AL_FLAG_LOG_WITHOUT_CERT) == 0)) {
                 MemBufferWriteString(aft->buffer, " Session='resumed'");
             }
         }

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -490,7 +490,12 @@ static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
                                  ssl_state->server_connp.cert0_issuerdn);
         }
         if (ssl_state->flags & SSL_AL_FLAG_SESSION_RESUMED) {
-            MemBufferWriteString(aft->buffer, " Session='resumed'");
+            /* Only log a session as 'resumed' if a certificate has not
+               been seen. */
+            if ((ssl_state->server_connp.cert0_issuerdn == NULL) &&
+                    (ssl_state->server_connp.cert0_subject == NULL)) {
+                MemBufferWriteString(aft->buffer, " Session='resumed'");
+            }
         }
 
         if (hlog->flags & LOG_TLS_EXTENDED) {

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -133,7 +133,12 @@ static void JsonTlsLogIssuer(json_t *js, SSLState *ssl_state)
 static void JsonTlsLogSessionResumed(json_t *js, SSLState *ssl_state)
 {
     if (ssl_state->flags & SSL_AL_FLAG_SESSION_RESUMED) {
-        json_object_set_new(js, "session_resumed", json_boolean(true));
+        /* Only log a session as 'resumed' if a certificate has not
+           been seen. */
+        if (ssl_state->server_connp.cert0_issuerdn == NULL &&
+               ssl_state->server_connp.cert0_subject == NULL) {
+            json_object_set_new(js, "session_resumed", json_boolean(true));
+        }
     }
 }
 

--- a/src/util-lua-tls.c
+++ b/src/util-lua-tls.c
@@ -160,6 +160,7 @@ static int GetCertInfo(lua_State *luastate, const Flow *f, int direction)
 
     /* tls.version */
     char ssl_version[32] = "";
+
     switch (ssl_state->server_connp.version) {
         case TLS_VERSION_UNKNOWN:
             snprintf(ssl_version, sizeof(ssl_version), "UNDETERMINED");
@@ -178,6 +179,51 @@ static int GetCertInfo(lua_State *luastate, const Flow *f, int direction)
             break;
         case TLS_VERSION_12:
             snprintf(ssl_version, sizeof(ssl_version), "TLS 1.2");
+            break;
+        case TLS_VERSION_13:
+            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.3");
+            break;
+        case TLS_VERSION_13_DRAFT28:
+            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.3 (draft 28)");
+            break;
+       case TLS_VERSION_13_DRAFT27:
+            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.3 (draft 27)");
+            break;
+       case TLS_VERSION_13_DRAFT26:
+            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.3 (draft 26)");
+            break;
+       case TLS_VERSION_13_DRAFT25:
+            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.3 (draft 25)");
+            break;
+       case TLS_VERSION_13_DRAFT24:
+            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.3 (draft 24)");
+            break;
+       case TLS_VERSION_13_DRAFT23:
+            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.3 (draft 23)");
+            break;
+       case TLS_VERSION_13_DRAFT22:
+            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.3 (draft 22)");
+            break;
+       case TLS_VERSION_13_DRAFT21:
+            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.3 (draft 21)");
+            break;
+       case TLS_VERSION_13_DRAFT20:
+            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.3 (draft 20)");
+            break;
+       case TLS_VERSION_13_DRAFT19:
+            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.3 (draft 19)");
+            break;
+       case TLS_VERSION_13_DRAFT18:
+            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.3 (draft 18)");
+            break;
+       case TLS_VERSION_13_DRAFT17:
+            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.3 (draft 17)");
+            break;
+       case TLS_VERSION_13_DRAFT16:
+            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.3 (draft 16)");
+            break;
+       case TLS_VERSION_13_PRE_DRAFT16:
+            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.3 (draft <16)");
             break;
         default:
             snprintf(ssl_version, sizeof(ssl_version), "0x%04x",


### PR DESCRIPTION
This PR contains various stuff that was fixed on the path to get TLSv1.3 support:
- Add support for TLSv1.3 (including all the drafts)
- Add support for session resumption by both session ID and session ticket
- Add 'raw' matching mode to "tls.version" keyword (e.g: "tls.version:0x7f10")

https://redmine.openinfosecfoundation.org/issues/2279

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/163
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/163
