### PR TITLE
Add support for TLSv1.3

### DIFF
--- a/doc/userguide/lua/lua-functions.rst
+++ b/doc/userguide/lua/lua-functions.rst
@@ -393,6 +393,22 @@ Initialize with:
       return needs
   end
 
+TlsGetVersion
+~~~~~~~~~~~~~
+
+Get the negotiated version in a TLS session as a string through TlsGetVersion.
+
+Example:
+
+::
+
+  function log (args)
+      version = TlsGetVersion()
+      if version then
+          -- do something
+      end
+  end
+
 TlsGetCertInfo
 ~~~~~~~~~~~~~~
 

--- a/doc/userguide/rules/tls-keywords.rst
+++ b/doc/userguide/rules/tls-keywords.rst
@@ -121,7 +121,17 @@ tls.version
 
 Match on negotiated TLS/SSL version.
 
-Example values: "1.0", "1.1", "1.2"
+Supported values: "1.0", "1.1", "1.2", "1.3"
+
+It is also possible to match versions using a hex string.
+
+Examples::
+
+  tls.version:1.2;
+  tls.version:0x7f12;
+
+The first example matches TLSv1.2, whilst the last example matches TLSv1.3
+draft 16.
 
 tls.subject
 -----------

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -561,6 +561,28 @@ static inline int TLSDecodeHSHelloVersion(SSLState *ssl_state,
 
     ssl_state->curr_connp->version = *input << 8 | *(input + 1);
 
+    /* TLSv1.3 draft1 to draft21 use the version field as earlier TLS
+       versions, instead of using the supported versions extension. */
+    if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_SERVER_HELLO) &&
+            ((ssl_state->curr_connp->version == TLS_VERSION_13) ||
+            (((ssl_state->curr_connp->version >> 8) & 0xff) == 0x7f))) {
+        ssl_state->flags |= SSL_AL_FLAG_LOG_WITHOUT_CERT;
+    }
+
+    /* Catch some early TLSv1.3 draft implementations that does not conform
+       to the draft version. */
+    if ((ssl_state->curr_connp->version >= 0x7f01) &&
+            (ssl_state->curr_connp->version < 0x7f10)) {
+        ssl_state->curr_connp->version = TLS_VERSION_13_PRE_DRAFT16;
+    }
+
+    /* TLSv1.3 drafts from draft1 to draft15 use 0x0304 (TLSv1.3) as the
+       version number, which makes it hard to accurately pinpoint the
+       exact draft version. */
+    else if (ssl_state->curr_connp->version == TLS_VERSION_13) {
+        ssl_state->curr_connp->version = TLS_VERSION_13_PRE_DRAFT16;
+    }
+
     if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) &&
             ssl_config.enable_ja3) {
         ssl_state->ja3_str = Ja3BufferInit();
@@ -1166,12 +1188,18 @@ static int TLSDecodeHandshakeHello(SSLState *ssl_state,
 
     parsed += ret;
 
-    ret = TLSDecodeHSHelloSessionID(ssl_state, input + parsed,
-                                    input_len - parsed);
-    if (ret < 0)
-        goto end;
+    /* The session id field in the server hello record was removed in
+       TLSv1.3 draft1, but was readded in draft22. */
+    if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) ||
+            ((ssl_state->current_flags & SSL_AL_FLAG_STATE_SERVER_HELLO) &&
+            ((ssl_state->flags & SSL_AL_FLAG_LOG_WITHOUT_CERT) == 0))) {
+        ret = TLSDecodeHSHelloSessionID(ssl_state, input + parsed,
+                                        input_len - parsed);
+        if (ret < 0)
+            goto end;
 
-    parsed += ret;
+        parsed += ret;
+    }
 
     ret = TLSDecodeHSHelloCipherSuites(ssl_state, input + parsed,
                                        input_len - parsed);
@@ -1180,12 +1208,18 @@ static int TLSDecodeHandshakeHello(SSLState *ssl_state,
 
     parsed += ret;
 
-    ret = TLSDecodeHSHelloCompressionMethods(ssl_state, input + parsed,
-                                             input_len - parsed);
-    if (ret < 0)
-        goto end;
+   /* The compression methods field in the server hello record was
+      removed in TLSv1.3 draft1, but was readded in draft22. */
+   if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) ||
+              ((ssl_state->current_flags & SSL_AL_FLAG_STATE_SERVER_HELLO) &&
+              ((ssl_state->flags & SSL_AL_FLAG_LOG_WITHOUT_CERT) == 0))) {
+        ret = TLSDecodeHSHelloCompressionMethods(ssl_state, input + parsed,
+                                                 input_len - parsed);
+        if (ret < 0)
+            goto end;
 
-    parsed += ret;
+        parsed += ret;
+    }
 
     ret = TLSDecodeHSHelloExtensions(ssl_state, input + parsed,
                                      input_len - parsed);

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -608,12 +608,28 @@ static inline int TLSDecodeHSHelloSessionID(SSLState *ssl_state,
     uint8_t session_id_length = *input;
     input += 1;
 
-    if (session_id_length != 0) {
-        ssl_state->flags |= SSL_AL_FLAG_SSL_CLIENT_SESSION_ID;
-    }
-
     if (!(HAS_SPACE(session_id_length)))
         goto invalid_length;
+
+    if (session_id_length != 0 && ssl_state->curr_connp->session_id == NULL) {
+        ssl_state->curr_connp->session_id = SCMalloc(session_id_length);
+
+        if (unlikely(ssl_state->curr_connp->session_id == NULL)) {
+            return -1;
+        }
+
+        memcpy(ssl_state->curr_connp->session_id, input, session_id_length);
+        ssl_state->curr_connp->session_id_length = session_id_length;
+
+        if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_SERVER_HELLO) &&
+                ssl_state->client_connp.session_id != NULL) {
+            if ((ssl_state->client_connp.session_id_length == session_id_length) &&
+                    (memcmp(ssl_state->server_connp.session_id,
+                    ssl_state->client_connp.session_id, session_id_length) == 0)) {
+                ssl_state->flags |= SSL_AL_FLAG_SESSION_RESUMED;
+            }
+        }
+    }
 
     input += session_id_length;
 
@@ -1955,13 +1971,6 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
 
             if (direction) {
                 ssl_state->flags |= SSL_AL_FLAG_SERVER_CHANGE_CIPHER_SPEC;
-
-                int server_cert_seen = (ssl_state->server_connp.cert0_issuerdn != NULL &&
-                                        ssl_state->server_connp.cert0_subject != NULL);
-                if (!server_cert_seen && (ssl_state->flags & SSL_AL_FLAG_SSL_CLIENT_SESSION_ID) != 0) {
-                    ssl_state->flags |= SSL_AL_FLAG_SESSION_RESUMED;
-                }
-
             } else {
                 ssl_state->flags |= SSL_AL_FLAG_CLIENT_CHANGE_CIPHER_SPEC;
             }
@@ -2312,6 +2321,8 @@ static void SSLStateFree(void *p)
         SCFree(ssl_state->client_connp.cert0_fingerprint);
     if (ssl_state->client_connp.sni)
         SCFree(ssl_state->client_connp.sni);
+    if (ssl_state->client_connp.session_id)
+        SCFree(ssl_state->client_connp.session_id);
 
     if (ssl_state->server_connp.trec)
         SCFree(ssl_state->server_connp.trec);
@@ -2323,6 +2334,8 @@ static void SSLStateFree(void *p)
         SCFree(ssl_state->server_connp.cert0_fingerprint);
     if (ssl_state->server_connp.sni)
         SCFree(ssl_state->server_connp.sni);
+    if (ssl_state->server_connp.session_id)
+        SCFree(ssl_state->server_connp.session_id);
 
     if (ssl_state->ja3_str)
         Ja3BufferFree(&ssl_state->ja3_str);
@@ -5055,7 +5068,7 @@ static int SSLParserTest26(void)
     FAIL_IF_NULL(ssl_state);
 
     FAIL_IF((ssl_state->flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) == 0);
-    FAIL_IF((ssl_state->flags & SSL_AL_FLAG_SSL_CLIENT_SESSION_ID) == 0);
+    FAIL_IF_NULL(ssl_state->client_connp.session_id);
 
     FLOWLOCK_WRLOCK(&f);
     r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_TLS, STREAM_TOCLIENT,

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1016,6 +1016,20 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
                 break;
             }
 
+            case SSL_EXTENSION_SESSION_TICKET:
+            {
+                if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) &&
+                        ext_len != 0) {
+                    /* This has to be verified later on by checking if a
+                       certificate record has been sent by the server. */
+                    ssl_state->flags |= SSL_AL_FLAG_SESSION_RESUMED;
+                }
+
+                input += ext_len;
+
+                break;
+            }
+
             default:
             {
                 input += ext_len;

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -262,6 +262,80 @@ static void SSLSetTxDetectFlags(void *vtx, uint8_t dir, uint64_t flags)
     }
 }
 
+void SSLVersionToString(uint16_t version, char *buffer)
+{
+    buffer[0] = '\0';
+
+    switch (version) {
+        case TLS_VERSION_UNKNOWN:
+            strlcat(buffer, "UNDETERMINED", 13);
+            break;
+        case SSL_VERSION_2:
+            strlcat(buffer, "SSLv2", 6);
+            break;
+        case SSL_VERSION_3:
+            strlcat(buffer, "SSLv3", 6);
+            break;
+        case TLS_VERSION_10:
+            strlcat(buffer, "TLSv1", 6);
+            break;
+        case TLS_VERSION_11:
+            strlcat(buffer, "TLS 1.1", 8);
+            break;
+        case TLS_VERSION_12:
+            strlcat(buffer, "TLS 1.2", 8);
+            break;
+        case TLS_VERSION_13:
+            strlcat(buffer, "TLS 1.3", 8);
+            break;
+        case TLS_VERSION_13_DRAFT28:
+            strlcat(buffer, "TLS 1.3 (draft 28)", 19);
+            break;
+        case TLS_VERSION_13_DRAFT27:
+            strlcat(buffer, "TLS 1.3 (draft 27)", 19);
+            break;
+        case TLS_VERSION_13_DRAFT26:
+            strlcat(buffer, "TLS 1.3 (draft 26)", 19);
+            break;
+        case TLS_VERSION_13_DRAFT25:
+            strlcat(buffer, "TLS 1.3 (draft 25)", 19);
+            break;
+        case TLS_VERSION_13_DRAFT24:
+            strlcat(buffer, "TLS 1.3 (draft 24)", 19);
+            break;
+        case TLS_VERSION_13_DRAFT23:
+            strlcat(buffer, "TLS 1.3 (draft 23)", 19);
+            break;
+        case TLS_VERSION_13_DRAFT22:
+            strlcat(buffer, "TLS 1.3 (draft 22)", 19);
+            break;
+        case TLS_VERSION_13_DRAFT21:
+            strlcat(buffer, "TLS 1.3 (draft 21)", 19);
+            break;
+        case TLS_VERSION_13_DRAFT20:
+            strlcat(buffer, "TLS 1.3 (draft 20)", 19);
+            break;
+        case TLS_VERSION_13_DRAFT19:
+            strlcat(buffer, "TLS 1.3 (draft 19)", 19);
+            break;
+        case TLS_VERSION_13_DRAFT18:
+            strlcat(buffer, "TLS 1.3 (draft 18)", 19);
+            break;
+        case TLS_VERSION_13_DRAFT17:
+            strlcat(buffer, "TLS 1.3 (draft 17)", 19);
+            break;
+        case TLS_VERSION_13_DRAFT16:
+            strlcat(buffer, "TLS 1.3 (draft 16)", 19);
+            break;
+        case TLS_VERSION_13_PRE_DRAFT16:
+            strlcat(buffer, "TLS 1.3 (draft <16)", 20);
+            break;
+        default:
+            snprintf(buffer, 7, "0x%04x", version);
+            break;
+    }
+}
+
 static void TlsDecodeHSCertificateErrSetEvent(SSLState *ssl_state, uint32_t err)
 {
     switch (err) {

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -123,6 +123,9 @@ enum {
 /* SNI types */
 #define SSL_SNI_TYPE_HOST_NAME                  0
 
+/* Max string length of the TLS version string */
+#define SSL_VERSION_MAX_STRLEN 20
+
 /* SSL versions.  We'll use a unified format for all, with the top byte
  * holding the major version and the lower byte the minor version */
 enum {
@@ -242,5 +245,6 @@ typedef struct SSLState_ {
 void RegisterSSLParsers(void);
 void SSLParserRegisterTests(void);
 void SSLSetEvent(SSLState *ssl_state, uint8_t event);
+void SSLVersionToString(uint16_t, char *);
 
 #endif /* __APP_LAYER_SSL_H__ */

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -153,7 +153,6 @@ typedef struct SSLStateConnp_ {
     /* the no of bytes processed in the currently parsed handshake */
     uint16_t hs_bytes_processed;
 
-    /* sslv2 client hello session id length */
     uint16_t session_id_length;
 
     char *cert0_subject;
@@ -165,6 +164,8 @@ typedef struct SSLStateConnp_ {
 
     /* ssl server name indication extension */
     char *sni;
+
+    char *session_id;
 
     TAILQ_HEAD(, SSLCertsChain_) certs;
 

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -110,6 +110,7 @@ enum {
 #define SSL_EXTENSION_SNI                       0x0000
 #define SSL_EXTENSION_ELLIPTIC_CURVES           0x000a
 #define SSL_EXTENSION_EC_POINT_FORMATS          0x000b
+#define SSL_EXTENSION_SESSION_TICKET            0x0023
 
 /* SNI types */
 #define SSL_SNI_TYPE_HOST_NAME                  0

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -103,6 +103,13 @@ enum {
 /* Session resumed without a full handshake */
 #define SSL_AL_FLAG_SESSION_RESUMED             BIT_U32(20)
 
+/* Encountered a supported_versions extension in client hello */
+#define SSL_AL_FLAG_CH_VERSION_EXTENSION        BIT_U32(21)
+
+/* Log the session even without ever seeing a certificate. This is used
+   to log TLSv1.3 sessions. */
+#define SSL_AL_FLAG_LOG_WITHOUT_CERT            BIT_U32(22)
+
 /* config flags */
 #define SSL_TLS_LOG_PEM                         (1 << 0)
 
@@ -111,6 +118,7 @@ enum {
 #define SSL_EXTENSION_ELLIPTIC_CURVES           0x000a
 #define SSL_EXTENSION_EC_POINT_FORMATS          0x000b
 #define SSL_EXTENSION_SESSION_TICKET            0x0023
+#define SSL_EXTENSION_SUPPORTED_VERSIONS        0x002b
 
 /* SNI types */
 #define SSL_SNI_TYPE_HOST_NAME                  0
@@ -124,6 +132,21 @@ enum {
     TLS_VERSION_10 = 0x0301,
     TLS_VERSION_11 = 0x0302,
     TLS_VERSION_12 = 0x0303,
+    TLS_VERSION_13 = 0x0304,
+    TLS_VERSION_13_DRAFT28 = 0x7f1c,
+    TLS_VERSION_13_DRAFT27 = 0x7f1b,
+    TLS_VERSION_13_DRAFT26 = 0x7f1a,
+    TLS_VERSION_13_DRAFT25 = 0x7f19,
+    TLS_VERSION_13_DRAFT24 = 0x7f18,
+    TLS_VERSION_13_DRAFT23 = 0x7f17,
+    TLS_VERSION_13_DRAFT22 = 0x7f16,
+    TLS_VERSION_13_DRAFT21 = 0x7f15,
+    TLS_VERSION_13_DRAFT20 = 0x7f14,
+    TLS_VERSION_13_DRAFT19 = 0x7f13,
+    TLS_VERSION_13_DRAFT18 = 0x7f12,
+    TLS_VERSION_13_DRAFT17 = 0x7f11,
+    TLS_VERSION_13_DRAFT16 = 0x7f10,
+    TLS_VERSION_13_PRE_DRAFT16 = 0x7f01,
 };
 
 typedef struct SSLCertsChain_ {

--- a/src/detect-ssl-version.c
+++ b/src/detect-ssl-version.c
@@ -148,6 +148,28 @@ static int DetectSslVersionMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
                 ret = 1;
             sig_ver = TLS12;
             break;
+        case TLS_VERSION_13_DRAFT28:
+        case TLS_VERSION_13_DRAFT27:
+        case TLS_VERSION_13_DRAFT26:
+        case TLS_VERSION_13_DRAFT25:
+        case TLS_VERSION_13_DRAFT24:
+        case TLS_VERSION_13_DRAFT23:
+        case TLS_VERSION_13_DRAFT22:
+        case TLS_VERSION_13_DRAFT21:
+        case TLS_VERSION_13_DRAFT20:
+        case TLS_VERSION_13_DRAFT19:
+        case TLS_VERSION_13_DRAFT18:
+        case TLS_VERSION_13_DRAFT17:
+        case TLS_VERSION_13_DRAFT16:
+        case TLS_VERSION_13_PRE_DRAFT16:
+            if (((ver >> 8) & 0xff) == 0x7f)
+                ver = TLS_VERSION_13;
+            /* fall through */
+        case TLS_VERSION_13:
+            if (ver == ssl->data[TLS13].ver)
+                ret = 1;
+            sig_ver = TLS13;
+            break;
     }
 
     if (sig_ver == TLS_UNKNOWN)
@@ -219,26 +241,30 @@ static DetectSslVersionData *DetectSslVersionParse(const char *str)
                 tmp_str++;
             }
 
-            if (strncasecmp("sslv2", tmp_str, 5) == 0) {
+            if (strcasecmp("sslv2", tmp_str) == 0) {
                 ssl->data[SSLv2].ver = SSL_VERSION_2;
                 if (neg == 1)
                     ssl->data[SSLv2].flags |= DETECT_SSL_VERSION_NEGATED;
-            } else if (strncasecmp("sslv3", tmp_str, 5) == 0) {
+            } else if (strcasecmp("sslv3", tmp_str) == 0) {
                 ssl->data[SSLv3].ver = SSL_VERSION_3;
                 if (neg == 1)
                     ssl->data[SSLv3].flags |= DETECT_SSL_VERSION_NEGATED;
-            } else if (strncasecmp("tls1.0", tmp_str, 6) == 0) {
+            } else if (strcasecmp("tls1.0", tmp_str) == 0) {
                 ssl->data[TLS10].ver = TLS_VERSION_10;
                 if (neg == 1)
                     ssl->data[TLS10].flags |= DETECT_SSL_VERSION_NEGATED;
-            } else if (strncasecmp("tls1.1", tmp_str, 6) == 0) {
+            } else if (strcasecmp("tls1.1", tmp_str) == 0) {
                 ssl->data[TLS11].ver = TLS_VERSION_11;
                 if (neg == 1)
                     ssl->data[TLS11].flags |= DETECT_SSL_VERSION_NEGATED;
-            } else if (strncasecmp("tls1.2", tmp_str, 6) == 0) {
+            } else if (strcasecmp("tls1.2", tmp_str) == 0) {
                 ssl->data[TLS12].ver = TLS_VERSION_12;
                 if (neg == 1)
                     ssl->data[TLS12].flags |= DETECT_SSL_VERSION_NEGATED;
+            } else if (strcasecmp("tls1.3", tmp_str) == 0) {
+                ssl->data[TLS13].ver = TLS_VERSION_13;
+                if (neg == 1)
+                    ssl->data[TLS13].flags |= DETECT_SSL_VERSION_NEGATED;
             }  else if (strcmp(tmp_str, "") == 0) {
                 SCFree(orig);
                 if (found == 0)

--- a/src/detect-ssl-version.h
+++ b/src/detect-ssl-version.h
@@ -33,9 +33,10 @@ enum {
     TLS10 = 2,
     TLS11 = 3,
     TLS12 = 4,
+    TLS13 = 5,
 
-    TLS_SIZE = 5,
-    TLS_UNKNOWN = 6,
+    TLS_SIZE = 6,
+    TLS_UNKNOWN = 7,
 };
 
 typedef struct SSLVersionData_ {

--- a/src/detect-tls-version.h
+++ b/src/detect-tls-version.h
@@ -24,8 +24,11 @@
 #ifndef __DETECT_TLS_VERSION_H__
 #define __DETECT_TLS_VERSION_H__
 
+#define DETECT_TLS_VERSION_FLAG_RAW  BIT_U8(0)
+
 typedef struct DetectTlsVersionData_ {
     uint16_t ver; /** tls version to match */
+    uint8_t flags;
 } DetectTlsVersionData;
 
 /* prototypes */

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -490,7 +490,12 @@ static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
                                  ssl_state->server_connp.cert0_issuerdn);
         }
         if (ssl_state->flags & SSL_AL_FLAG_SESSION_RESUMED) {
-            MemBufferWriteString(aft->buffer, " Session='resumed'");
+            /* Only log a session as 'resumed' if a certificate has not
+               been seen. */
+            if ((ssl_state->server_connp.cert0_issuerdn == NULL) &&
+                    (ssl_state->server_connp.cert0_subject == NULL)) {
+                MemBufferWriteString(aft->buffer, " Session='resumed'");
+            }
         }
 
         if (hlog->flags & LOG_TLS_EXTENDED) {

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -94,29 +94,9 @@ typedef struct LogTlsLogThread_ {
 
 static void LogTlsLogVersion(MemBuffer *buffer, uint16_t version)
 {
-    switch (version) {
-        case TLS_VERSION_UNKNOWN:
-            MemBufferWriteString(buffer, "VERSION='UNDETERMINED'");
-            break;
-        case SSL_VERSION_2:
-            MemBufferWriteString(buffer, "VERSION='SSLv2'");
-            break;
-        case SSL_VERSION_3:
-            MemBufferWriteString(buffer, "VERSION='SSLv3'");
-            break;
-        case TLS_VERSION_10:
-            MemBufferWriteString(buffer, "VERSION='TLSv1'");
-            break;
-        case TLS_VERSION_11:
-            MemBufferWriteString(buffer, "VERSION='TLS 1.1'");
-            break;
-        case TLS_VERSION_12:
-            MemBufferWriteString(buffer, "VERSION='TLS 1.2'");
-            break;
-        default:
-            MemBufferWriteString(buffer, "VERSION='0x%04x'", version);
-            break;
-    }
+    char ssl_version[SSL_VERSION_MAX_STRLEN];
+    SSLVersionToString(version, ssl_version);
+    MemBufferWriteString(buffer, "VERSION='%s'", ssl_version);
 }
 
 static void LogTlsLogDate(MemBuffer *buffer, const char *title, time_t *date)
@@ -458,7 +438,8 @@ static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
     if (((hlog->flags & LOG_TLS_SESSION_RESUMPTION) == 0 ||
             (ssl_state->flags & SSL_AL_FLAG_SESSION_RESUMED) == 0) &&
             (ssl_state->server_connp.cert0_issuerdn == NULL ||
-            ssl_state->server_connp.cert0_subject == NULL)) {
+            ssl_state->server_connp.cert0_subject == NULL) &&
+            ((ssl_state->flags & SSL_AL_FLAG_LOG_WITHOUT_CERT) == 0)) {
         return 0;
     }
 
@@ -493,7 +474,8 @@ static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
             /* Only log a session as 'resumed' if a certificate has not
                been seen. */
             if ((ssl_state->server_connp.cert0_issuerdn == NULL) &&
-                    (ssl_state->server_connp.cert0_subject == NULL)) {
+                    (ssl_state->server_connp.cert0_subject == NULL) &&
+                    ((ssl_state->flags & SSL_AL_FLAG_LOG_WITHOUT_CERT) == 0)) {
                 MemBufferWriteString(aft->buffer, " Session='resumed'");
             }
         }

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -133,7 +133,12 @@ static void JsonTlsLogIssuer(json_t *js, SSLState *ssl_state)
 static void JsonTlsLogSessionResumed(json_t *js, SSLState *ssl_state)
 {
     if (ssl_state->flags & SSL_AL_FLAG_SESSION_RESUMED) {
-        json_object_set_new(js, "session_resumed", json_boolean(true));
+        /* Only log a session as 'resumed' if a certificate has not
+           been seen. */
+        if (ssl_state->server_connp.cert0_issuerdn == NULL &&
+               ssl_state->server_connp.cert0_subject == NULL) {
+            json_object_set_new(js, "session_resumed", json_boolean(true));
+        }
     }
 }
 

--- a/src/util-lua-tls.c
+++ b/src/util-lua-tls.c
@@ -159,31 +159,8 @@ static int GetCertInfo(lua_State *luastate, const Flow *f, int direction)
         return LuaCallbackError(luastate, "error: no cert");
 
     /* tls.version */
-    char ssl_version[32] = "";
-    switch (ssl_state->server_connp.version) {
-        case TLS_VERSION_UNKNOWN:
-            snprintf(ssl_version, sizeof(ssl_version), "UNDETERMINED");
-            break;
-        case SSL_VERSION_2:
-            snprintf(ssl_version, sizeof(ssl_version), "SSLv2");
-            break;
-        case SSL_VERSION_3:
-            snprintf(ssl_version, sizeof(ssl_version), "SSLv3");
-            break;
-        case TLS_VERSION_10:
-            snprintf(ssl_version, sizeof(ssl_version), "TLSv1");
-            break;
-        case TLS_VERSION_11:
-            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.1");
-            break;
-        case TLS_VERSION_12:
-            snprintf(ssl_version, sizeof(ssl_version), "TLS 1.2");
-            break;
-        default:
-            snprintf(ssl_version, sizeof(ssl_version), "0x%04x",
-                     ssl_state->server_connp.version);
-            break;
-    }
+    char ssl_version[SSL_VERSION_MAX_STRLEN];
+    SSLVersionToString(ssl_state->server_connp.version, ssl_version);
 
     int r = LuaPushStringBuffer(luastate, (uint8_t *)ssl_version, strlen(ssl_version));
     r += LuaPushStringBuffer(luastate, (uint8_t *)connp->cert0_subject, strlen(connp->cert0_subject));

--- a/src/util-lua-tls.c
+++ b/src/util-lua-tls.c
@@ -187,6 +187,37 @@ static int TlsGetCertInfo(lua_State *luastate)
     return r;
 }
 
+static int GetAgreedVersion(lua_State *luastate, const Flow *f)
+{
+    void *state = FlowGetAppState(f);
+    if (state == NULL)
+        return LuaCallbackError(luastate, "error: no app layer state");
+
+    SSLState *ssl_state = (SSLState *)state;
+
+    char ssl_version[SSL_VERSION_MAX_STRLEN];
+    SSLVersionToString(ssl_state->server_connp.version, ssl_version);
+
+    return LuaPushStringBuffer(luastate, (uint8_t *)ssl_version,
+                               strlen(ssl_version));
+}
+
+static int TlsGetVersion(lua_State *luastate)
+{
+    int r;
+
+    if (!(LuaStateNeedProto(luastate, ALPROTO_TLS)))
+        return LuaCallbackError(luastate, "error: protocol not tls");
+
+    Flow *f = LuaStateGetFlow(luastate);
+    if (f == NULL)
+        return LuaCallbackError(luastate, "internal error: no flow");
+
+    r = GetAgreedVersion(luastate, f);
+
+    return r;
+}
+
 static int GetSNI(lua_State *luastate, const Flow *f)
 {
     void *state = FlowGetAppState(f);
@@ -315,6 +346,9 @@ int LuaRegisterTlsFunctions(lua_State *luastate)
 
     lua_pushcfunction(luastate, TlsGetCertNotAfter);
     lua_setglobal(luastate, "TlsGetCertNotAfter");
+
+    lua_pushcfunction(luastate, TlsGetVersion);
+    lua_setglobal(luastate, "TlsGetVersion");
 
     lua_pushcfunction(luastate, TlsGetCertInfo);
     lua_setglobal(luastate, "TlsGetCertInfo");


### PR DESCRIPTION
This PR contains various stuff that was fixed on the path to get TLSv1.3 support:
- Add support for TLSv1.3 (including all the drafts)
- Add support for session resumption by both session ID and session ticket
- Add 'raw' matching mode to "tls.version" keyword (e.g: "tls.version:0x7f10")

Updates:
- Fixed changes requested in #3462 
- Added function to get string from version
- Added Lua function 'TlsGetVersion', since 'TlsGetCertInfo' does not (and probably should not) work without a certificate

https://redmine.openinfosecfoundation.org/issues/2279

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/165
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/165