### PR TITLE
Bug fix: Added livedev on flow and set vlan and iface in stream-tcp and flow-timeout

### DIFF
--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -90,6 +90,18 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(Packet *p,
     p->flags |= PKT_HAS_FLOW;
     p->flags |= PKT_PSEUDO_STREAM_END;
 
+    if (f->vlan_id[0] > 0) {
+        p->vlan_id[0] = f->vlan_id[0];
+        p->vlan_idx=1;
+
+        if (f->vlan_id[1] > 0) {
+            p->vlan_id[1] = f->vlan_id[1];
+            p->vlan_idx=2;
+        }
+    }
+
+    p->livedev = f->livedev;
+
     if (f->flags & FLOW_NOPACKET_INSPECTION) {
         DecodeSetNoPacketInspectionFlag(p);
     }

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -153,6 +153,7 @@ void FlowInit(Flow *f, const Packet *p)
     f->recursion_level = p->recursion_level;
     f->vlan_id[0] = p->vlan_id[0];
     f->vlan_id[1] = p->vlan_id[1];
+    f->livedev = p->livedev;
 
     if (PKT_IS_IPV4(p)) {
         FLOW_SET_IPV4_SRC_ADDR_FROM_PACKET(p, &f->src);

--- a/src/flow.h
+++ b/src/flow.h
@@ -345,6 +345,10 @@ typedef struct Flow_
     uint8_t recursion_level;
     uint16_t vlan_id[2];
 
+    /** Incoming interface */
+    struct LiveDevice_ *livedev;
+
+
     /** flow hash - the flow hash before hash table size mod. */
     uint32_t flow_hash;
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6020,6 +6020,18 @@ static void StreamTcpPseudoPacketCreateDetectLogFlush(ThreadVars *tv,
     np->flags |= PKT_IGNORE_CHECKSUM;
     np->flags |= PKT_PSEUDO_DETECTLOG_FLUSH;
 
+    if (f->vlan_id[0] > 0) {
+        np->vlan_id[0] = f->vlan_id[0];
+        np->vlan_idx=1;
+ 
+        if (f->vlan_id[1] > 0) {
+            np->vlan_id[1] = f->vlan_id[1];
+            np->vlan_idx=2;                                               
+        }
+    }
+
+    np->livedev = f->livedev;
+
     if (f->flags & FLOW_NOPACKET_INSPECTION) {
         DecodeSetNoPacketInspectionFlag(np);
     }


### PR DESCRIPTION
Proposed bug fix for bug [#2057](https://redmine.openinfosecfoundation.org/issues/2057): 
Adding livedev and flow on psuedopackets in stream-tcp and flow-timeout.


Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Added and setting livedev on flow
- Setting VLAN and interface from flow to psuedopackets in stream-tcp and flow-timeout

This should fix the problem dealing with missing vlan and in_iface fields in logs caused by psuedo packets missing vlan and iface.

I have tested on some live traffic and it seems to work out fine, but I'm not 100% sure it does not affect corner cases with wierd flows etc.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable): N/A

