### PR TITLE
Optimization/tcp rbtree/v35

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,8 +3,8 @@ noinst_HEADERS = action-globals.h \
     debug.h \
 	flow-private.h queue.h source-nfq-prototypes.h \
 	source-windivert-prototypes.h \
-	suricata-common.h threadvars.h util-binsearch.h \
-    util-validate.h
+	suricata-common.h threadvars.h tree.h \
+    util-binsearch.h util-validate.h
 bin_PROGRAMS = suricata
 
 suricata_SOURCES = \

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -151,8 +151,8 @@ typedef struct HTPCfgRec_ {
 /** Struct used to hold chunks of a body on a request */
 struct HtpBodyChunk_ {
     struct HtpBodyChunk_ *next; /**< Pointer to the next chunk */
-    StreamingBufferSegment sbseg;
     int logged;
+    StreamingBufferSegment sbseg;
 } __attribute__((__packed__));
 typedef struct HtpBodyChunk_ HtpBodyChunk;
 

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -1204,9 +1204,7 @@ static int FlowMgrTest02 (void)
 
     TimeGet(&ts);
     TCP_SEG_LEN(&seg) = 3;
-    seg.next = NULL;
-    seg.prev = NULL;
-    client.seg_list = &seg;
+    TCPSEG_RB_INSERT(&client.seg_tree, &seg);
     ssn.client = client;
     ssn.server = client;
     ssn.state = TCP_ESTABLISHED;
@@ -1310,9 +1308,7 @@ static int FlowMgrTest04 (void)
 
     TimeGet(&ts);
     TCP_SEG_LEN(&seg) = 3;
-    seg.next = NULL;
-    seg.prev = NULL;
-    client.seg_list = &seg;
+    TCPSEG_RB_INSERT(&client.seg_tree, &seg);
     ssn.client = client;
     ssn.server = client;
     ssn.state = TCP_ESTABLISHED;

--- a/src/stream-tcp-inline.c
+++ b/src/stream-tcp-inline.c
@@ -44,7 +44,8 @@
  *  \retval 0 shared data is the same (or no data is shared)
  *  \retval 1 shared data is different
  */
-int StreamTcpInlineSegmentCompare(TcpStream *stream, Packet *p, TcpSegment *seg)
+int StreamTcpInlineSegmentCompare(const TcpStream *stream,
+        const Packet *p, const TcpSegment *seg)
 {
     SCEnter();
 
@@ -108,7 +109,8 @@ int StreamTcpInlineSegmentCompare(TcpStream *stream, Packet *p, TcpSegment *seg)
  *  \todo What about reassembled fragments?
  *  \todo What about unwrapped tunnel packets?
  */
-void StreamTcpInlineSegmentReplacePacket(TcpStream *stream, Packet *p, TcpSegment *seg)
+void StreamTcpInlineSegmentReplacePacket(const TcpStream *stream,
+        Packet *p, const TcpSegment *seg)
 {
     SCEnter();
 

--- a/src/stream-tcp-inline.h
+++ b/src/stream-tcp-inline.h
@@ -26,8 +26,10 @@
 
 #include "stream-tcp-private.h"
 
-int StreamTcpInlineSegmentCompare(TcpStream *, Packet *, TcpSegment *);
-void StreamTcpInlineSegmentReplacePacket(TcpStream *, Packet *, TcpSegment *);
+int StreamTcpInlineSegmentCompare(const TcpStream *,
+        const Packet *, const TcpSegment *);
+void StreamTcpInlineSegmentReplacePacket(const TcpStream *,
+        Packet *, const TcpSegment *);
 
 void StreamTcpInlineRegisterTests(void);
 

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -31,8 +31,6 @@
 #include "util-print.h"
 #include "util-validate.h"
 
-//static void PrintList2(TcpSegment *seg);
-
 static void StreamTcpRemoveSegmentFromStream(TcpStream *stream, TcpSegment *seg);
 
 static int check_overlap_different_data = 0;
@@ -46,6 +44,23 @@ void StreamTcpReassembleConfigEnableOverlapCheck(void)
  *  Inserts and overlap handling
  */
 
+RB_GENERATE(TCPSEG, TcpSegment, rb, TcpSegmentCompare);
+
+int TcpSegmentCompare(struct TcpSegment *a, struct TcpSegment *b)
+{
+    if (SEQ_GT(a->seq, b->seq))
+        return 1;
+    else if (SEQ_LT(a->seq, b->seq))
+        return -1;
+    else {
+        if (a->payload_len == b->payload_len)
+            return 0;
+        else if (a->payload_len > b->payload_len)
+            return 1;
+        else
+            return -1;
+    }
+}
 
 /** \internal
  *  \brief insert segment data into the streaming buffer
@@ -98,22 +113,55 @@ static inline int InsertSegmentDataCustom(TcpStream *stream, TcpSegment *seg, ui
 }
 
 /** \internal
- *  \brief insert the segment into the proper place in the list
+ *  \brief check if this segments overlaps with an in-tree seg.
+ *  \retval true
+ *  \retval false
+ */
+static inline bool CheckOverlap(struct TCPSEG *tree, TcpSegment *seg)
+{
+    const uint32_t re = SEG_SEQ_RIGHT_EDGE(seg);
+    SCLogDebug("start. SEQ %u payload_len %u. Right edge: %u. Seg %p",
+            seg->seq, seg->payload_len, re, seg);
+
+    /* check forward */
+    TcpSegment *next = TCPSEG_RB_NEXT(seg);
+    if (next) {
+        // next has same seq, so data must overlap
+        if (SEQ_EQ(next->seq, seg->seq))
+            return true;
+        // our right edge is beyond next seq, overlap
+        if (SEQ_GT(re, next->seq))
+            return true;
+    }
+    /* check backwards */
+    TcpSegment *prev = TCPSEG_RB_PREV(seg);
+    if (prev) {
+        // prev has same seq, so data must overlap
+        if (SEQ_EQ(prev->seq, seg->seq))
+            return true;
+        // prev's right edge is beyond our seq, overlap
+        const uint32_t prev_re = SEG_SEQ_RIGHT_EDGE(prev);
+        if (SEQ_GT(prev_re, prev->seq))
+            return true;
+    }
+
+    SCLogDebug("no overlap");
+    return false;
+}
+
+/** \internal
+ *  \brief insert the segment into the proper place in the tree
  *         don't worry about the data or overlaps
  *
- *         If seq is equal to list seq, keep sorted by insert time.
- *         1. seg 123 len 12
- *         2. seg 123 len 14
- *         3. seg 124 len 1
- *
+ *  \retval 2 not inserted, data overlap
  *  \retval 1 inserted with overlap detected
  *  \retval 0 inserted, no overlap
  *  \retval -1 error
  */
-static int DoInsertSegment (TcpStream *stream, TcpSegment *seg, Packet *p)
+static int DoInsertSegment (TcpStream *stream, TcpSegment *seg, TcpSegment **dup_seg, Packet *p)
 {
     /* before our base_seq we don't insert it in our list */
-    if (SEQ_LEQ((seg->seq + TCP_SEG_LEN(seg)), stream->base_seq))
+    if (SEQ_LEQ(SEG_SEQ_RIGHT_EDGE(seg), stream->base_seq))
     {
         SCLogDebug("not inserting: SEQ+payload %"PRIu32", last_ack %"PRIu32", "
                 "base_seq %"PRIu32, (seg->seq + TCP_SEG_LEN(seg)),
@@ -123,74 +171,39 @@ static int DoInsertSegment (TcpStream *stream, TcpSegment *seg, Packet *p)
     }
 
     /* fast track */
-    if (stream->seg_list == NULL) {
-        SCLogDebug("empty list, inserting seg %p seq %" PRIu32 ", "
+    if (RB_EMPTY(&stream->seg_tree)) {
+        SCLogDebug("empty tree, inserting seg %p seq %" PRIu32 ", "
                    "len %" PRIu32 "", seg, seg->seq, TCP_SEG_LEN(seg));
-        stream->seg_list = seg;
-        seg->prev = NULL;
-        stream->seg_list_tail = seg;
+        TCPSEG_RB_INSERT(&stream->seg_tree, seg);
         return 0;
     }
 
-    /* insert the segment in the stream list using this fast track, if seg->seq
-       is equal or higher than stream->seg_list_tail.*/
-    if (SEQ_GEQ(seg->seq, (stream->seg_list_tail->seq +
-                    TCP_SEG_LEN(stream->seg_list_tail))))
+    /* insert the segment in the stream tree using this fast track, if seg->seq
+       is equal or higher than last segments tail. */
+    TcpSegment *last = RB_MAX(TCPSEG, &stream->seg_tree);
+    if (last && SEQ_GEQ(seg->seq, (uint32_t)SEG_SEQ_RIGHT_EDGE(last)))
     {
-        SCLogDebug("seg beyond list tail, append");
-        stream->seg_list_tail->next = seg;
-        seg->prev = stream->seg_list_tail;
-        stream->seg_list_tail = seg;
+        SCLogDebug("seg beyond tree tail, append");
+        TCPSEG_RB_INSERT(&stream->seg_tree, seg);
         return 0;
     }
 
-    /* walk the list to see where we can insert the segment.
-     * Check if a segment overlaps with us, if so we return 1 to indicate
-     * to the caller that we need to handle overlaps. */
-    TcpSegment *list_seg;
-    for (list_seg = stream->seg_list; list_seg != NULL; list_seg = list_seg->next)
-    {
-        if (SEQ_LT(seg->seq, list_seg->seq)) {
-            if (list_seg->prev != NULL) {
-                list_seg->prev->next = seg;
-            } else {
-                stream->seg_list = seg;
-            }
-            seg->prev = list_seg->prev;
-            seg->next = list_seg;
-            list_seg->prev = seg;
-
-            SCLogDebug("inserted %u before %p seq %u", seg->seq, list_seg, list_seg->seq);
-
-            if (seg->prev != NULL) {
-                SCLogDebug("previous %u", seg->prev->seq);
-            }
-            if (seg->next != NULL) {
-                SCLogDebug("next %u", seg->next->seq);
-            }
-            if (seg->prev != NULL && SEQ_GT(SEG_SEQ_RIGHT_EDGE(seg->prev), seg->seq)) {
-                SCLogDebug("seg inserted with overlap (before)");
-                return 1;
-            }
-            else if (SEQ_GT(SEG_SEQ_RIGHT_EDGE(seg), seg->next->seq)) {
-                SCLogDebug("seg inserted with overlap (after)");
-                return 1;
-            }
-
-            return 0;
+    /* insert and then check if there was any overlap with other segments */
+    TcpSegment *res = TCPSEG_RB_INSERT(&stream->seg_tree, seg);
+    if (res) {
+        SCLogDebug("seg has a duplicate in the tree seq %u/%u",
+                res->seq, res->payload_len);
+        /* exact duplicate SEQ + payload_len */
+        *dup_seg = res;
+        return 2; // duplicate has overlap by definition.
+    } else {
+        /* insert succeeded, now check if we overlap with someone */
+        if (CheckOverlap(&stream->seg_tree, seg) == true) {
+            SCLogDebug("seg %u has overlap in the tree", seg->seq);
+            return 1;
         }
     }
-    /* if we got here we didn't insert. Append */
-    seg->prev = stream->seg_list_tail;
-    stream->seg_list_tail->next = seg;
-    stream->seg_list_tail = seg;
-
-    if (seg->prev != NULL && SEQ_GT(SEG_SEQ_RIGHT_EDGE(seg->prev), seg->seq)) {
-        SCLogDebug("seg inserted with overlap (before)");
-        return 1;
-    }
-
-    SCLogDebug("default: append");
+    SCLogDebug("seg %u: no overlap", seg->seq);
     return 0;
 }
 
@@ -212,10 +225,12 @@ static int DoInsertSegment (TcpStream *stream, TcpSegment *seg, Packet *p)
  *  \retval 1 if data was different
  *  \retval 0 data was the same or we didn't check for differences
  */
-static int DoHandleDataOverlap(TcpStream *stream, TcpSegment *list, TcpSegment *seg, uint8_t *buf, Packet *p)
+static int DoHandleDataOverlap(TcpStream *stream, const TcpSegment *list,
+        const TcpSegment *seg, uint8_t *buf, Packet *p)
 {
     SCLogDebug("handle overlap for segment %p seq %u len %u re %u, "
-            "list segment %p seq %u len %u re %u", seg, seg->seq, p->payload_len, SEG_SEQ_RIGHT_EDGE(seg),
+            "list segment %p seq %u len %u re %u", seg, seg->seq,
+            p->payload_len, SEG_SEQ_RIGHT_EDGE(seg),
             list, list->seq, TCP_SEG_LEN(list), SEG_SEQ_RIGHT_EDGE(list));
 
     int data_is_different = 0;
@@ -402,51 +417,55 @@ static int DoHandleDataOverlap(TcpStream *stream, TcpSegment *list, TcpSegment *
 #define MAX_IP_DATA (uint32_t)(65536 - 40) // min ip header and min tcp header
 
 /** \internal
- *  \brief walk segment list backwards to see if there are overlaps
+ *  \brief walk segment tree backwards to see if there are overlaps
  *
- *  Walk back from the current segment which is already in the list.
+ *  Walk back from the current segment which is already in the tree.
  *  We walk until we can't possibly overlap anymore.
  */
-static int DoHandleDataCheckBackwards(TcpStream *stream, TcpSegment *seg, uint8_t *buf, Packet *p)
+static int DoHandleDataCheckBackwards(TcpStream *stream,
+        TcpSegment *seg, uint8_t *buf, Packet *p)
 {
     int retval = 0;
 
-    SCLogDebug("check list backwards: insert data for segment %p seq %u len %u re %u",
+    SCLogDebug("check tree backwards: insert data for segment %p seq %u len %u re %u",
             seg, seg->seq, TCP_SEG_LEN(seg), SEG_SEQ_RIGHT_EDGE(seg));
 
-    TcpSegment *list = seg->prev;
-    do {
+    /* check backwards */
+    TcpSegment *tree_seg = NULL, *s = seg;
+    RB_FOREACH_REVERSE_FROM(tree_seg, TCPSEG, s) {
+        if (tree_seg == seg)
+            continue;
+
         int overlap = 0;
-        if (SEQ_LEQ(SEG_SEQ_RIGHT_EDGE(list), stream->base_seq)) {
+        if (SEQ_LEQ(SEG_SEQ_RIGHT_EDGE(tree_seg), stream->base_seq)) {
             // segment entirely before base_seq
             ;
-        } else if (SEQ_LEQ(list->seq + MAX_IP_DATA, seg->seq)) {
+        } else if (SEQ_LEQ(tree_seg->seq + MAX_IP_DATA, seg->seq)) {
             SCLogDebug("list segment too far to the left, no more overlap will be found");
             break;
-        } else if (SEQ_GT(SEG_SEQ_RIGHT_EDGE(list), seg->seq)) {
+        } else if (SEQ_GT(SEG_SEQ_RIGHT_EDGE(tree_seg), seg->seq)) {
             overlap = 1;
         }
 
-        SCLogDebug("(back) list seg %u len %u re %u overlap? %s", list->seq, TCP_SEG_LEN(list),
-                SEG_SEQ_RIGHT_EDGE(list), overlap ? "yes" : "no");
+        SCLogDebug("(back) tree seg %u len %u re %u overlap? %s",
+                tree_seg->seq, TCP_SEG_LEN(tree_seg),
+                SEG_SEQ_RIGHT_EDGE(tree_seg), overlap ? "yes" : "no");
 
         if (overlap) {
-            retval |= DoHandleDataOverlap(stream, list, seg, buf, p);
+            retval |= DoHandleDataOverlap(stream, tree_seg, seg, buf, p);
         }
-
-        list = list->prev;
-    } while (list != NULL);
-
+    }
     return retval;
 }
 
 /** \internal
- *  \brief walk segment list in forward direction to see if there are overlaps
+ *  \brief walk segment tree in forward direction to see if there are overlaps
  *
- *  Walk forward from the current segment which is already in the list.
+ *  Walk forward from the current segment which is already in the tree.
  *  We walk until the next segs start with a SEQ beyond our right edge.
  */
-static int DoHandleDataCheckForward(TcpStream *stream, TcpSegment *seg, uint8_t *buf, Packet *p)
+static int DoHandleDataCheckForward(TcpStream *stream,
+        TcpSegment *seg, uint8_t *buf, Packet *p)
 {
     int retval = 0;
 
@@ -455,34 +474,39 @@ static int DoHandleDataCheckForward(TcpStream *stream, TcpSegment *seg, uint8_t 
     SCLogDebug("check list forward: insert data for segment %p seq %u len %u re %u",
             seg, seg->seq, TCP_SEG_LEN(seg), seg_re);
 
-    TcpSegment *list = seg->next;
-    do {
+    TcpSegment *tree_seg = NULL, *s = seg;
+    RB_FOREACH_FROM(tree_seg, TCPSEG, s) {
+        if (tree_seg == seg)
+            continue;
+
         int overlap = 0;
-        if (SEQ_GT(seg_re, list->seq))
+        if (SEQ_GT(seg_re, tree_seg->seq))
             overlap = 1;
-        else if (SEQ_LEQ(seg_re, list->seq)) {
-            SCLogDebug("list segment %u too far ahead, "
-                    "no more overlaps can happen", list->seq);
+        else if (SEQ_LEQ(seg_re, tree_seg->seq)) {
+            SCLogDebug("tree segment %u too far ahead, "
+                    "no more overlaps can happen", tree_seg->seq);
             break;
         }
 
-        SCLogDebug("(fwd) list seg %u len %u re %u overlap? %s", list->seq,
-                TCP_SEG_LEN(list), SEG_SEQ_RIGHT_EDGE(list), overlap ? "yes" : "no");
+        SCLogDebug("(fwd) in-tree seg %u len %u re %u overlap? %s",
+                tree_seg->seq, TCP_SEG_LEN(tree_seg),
+                SEG_SEQ_RIGHT_EDGE(tree_seg), overlap ? "yes" : "no");
 
         if (overlap) {
-            retval |= DoHandleDataOverlap(stream, list, seg, buf, p);
+            retval |= DoHandleDataOverlap(stream, tree_seg, seg, buf, p);
         }
-
-        list = list->next;
-    } while (list != NULL);
-
+    }
     return retval;
 }
 
+/**
+ *  \param dup_seg in-tree duplicate of `seg`
+ */
 static int DoHandleData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
-        TcpStream *stream, TcpSegment *seg, Packet *p)
+        TcpStream *stream, TcpSegment *seg, TcpSegment *tree_seg, Packet *p)
 {
     int result = 0;
+    TcpSegment *handle = seg;
 
     SCLogDebug("insert data for segment %p seq %u len %u re %u",
             seg, seg->seq, TCP_SEG_LEN(seg), SEG_SEQ_RIGHT_EDGE(seg));
@@ -493,18 +517,24 @@ static int DoHandleData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
     uint8_t buf[p->payload_len];
     memcpy(buf, p->payload, p->payload_len);
 
+    /* if tree_seg is set, we have an exact duplicate that we need to check */
+    if (tree_seg) {
+        DoHandleDataOverlap(stream, tree_seg, seg, buf, p);
+        handle = tree_seg;
+    }
+
     /* new list head  */
-    if (seg->next != NULL && seg->prev == NULL) {
-        result = DoHandleDataCheckForward(stream, seg, buf, p);
+    if (handle == RB_MIN(TCPSEG, &stream->seg_tree) && TCPSEG_RB_NEXT(handle)) {
+        result = DoHandleDataCheckForward(stream, handle, buf, p);
 
     /* new list tail */
-    } else if (seg->next == NULL && seg->prev != NULL) {
-        result = DoHandleDataCheckBackwards(stream, seg, buf, p);
+    } else if (handle == RB_MAX(TCPSEG, &stream->seg_tree) && TCPSEG_RB_PREV(handle)) {
+        result = DoHandleDataCheckBackwards(stream, handle, buf, p);
 
     /* middle of the list */
-    } else if (seg->next != NULL && seg->prev != NULL) {
-        result = DoHandleDataCheckBackwards(stream, seg, buf, p);
-        result |= DoHandleDataCheckForward(stream, seg, buf, p);
+    } else if (TCPSEG_RB_NEXT(handle) && TCPSEG_RB_PREV(handle)) {
+        result = DoHandleDataCheckBackwards(stream, handle, buf, p);
+        result |= DoHandleDataCheckForward(stream, handle, buf, p);
     }
 
     /* we had an overlap with different data */
@@ -515,7 +545,7 @@ static int DoHandleData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
 
     /* insert the temp buffer now that we've (possibly) updated
      * it to account for the overlap policies */
-    if (InsertSegmentDataCustom(stream, seg, buf, p->payload_len) < 0) {
+    if (InsertSegmentDataCustom(stream, handle, buf, p->payload_len) < 0) {
         return -1;
     }
 
@@ -530,25 +560,21 @@ static int DoHandleData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
  *  In case of error, this function returns the segment to the pool
  */
 int StreamTcpReassembleInsertSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
-        TcpStream *stream, TcpSegment *seg, Packet *p, uint32_t pkt_seq, uint8_t *pkt_data, uint16_t pkt_datalen)
+        TcpStream *stream, TcpSegment *seg, Packet *p,
+        uint32_t pkt_seq, uint8_t *pkt_data, uint16_t pkt_datalen)
 {
-#ifdef DEBUG
-    SCLogDebug("pre insert");
-    PrintList(stream->seg_list);
-#endif
+    SCEnter();
+
+    TcpSegment *dup_seg = NULL;
 
     /* insert segment into list. Note: doesn't handle the data */
-    int r = DoInsertSegment (stream, seg, p);
+    int r = DoInsertSegment (stream, seg, &dup_seg, p);
+    SCLogDebug("DoInsertSegment returned %d", r);
     if (r < 0) {
         StatsIncr(tv, ra_ctx->counter_tcp_reass_list_fail);
         StreamTcpSegmentReturntoPool(seg);
         SCReturnInt(-1);
     }
-
-#ifdef DEBUG
-    SCLogDebug("post insert");
-    PrintList(stream->seg_list);
-#endif
 
     if (likely(r == 0)) {
         /* no overlap, straight data insert */
@@ -560,17 +586,46 @@ int StreamTcpReassembleInsertSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
             SCReturnInt(-1);
         }
 
-    } else if (r == 1) {
+    } else if (r == 1 || r == 2) {
+        SCLogDebug("overlap (%s%s)", r == 1 ? "normal" : "", r == 2 ? "duplicate" : "");
+
+        if (r == 2) {
+            SCLogDebug("dup_seg %p", dup_seg);
+        }
+
         /* XXX should we exclude 'retransmissions' here? */
         StatsIncr(tv, ra_ctx->counter_tcp_reass_overlap);
 
         /* now let's consider the data in the overlap case */
-        int res = DoHandleData(tv, ra_ctx, stream, seg, p);
+        int res = DoHandleData(tv, ra_ctx, stream, seg, dup_seg, p);
         if (res < 0) {
             StatsIncr(tv, ra_ctx->counter_tcp_reass_data_overlap_fail);
-            StreamTcpRemoveSegmentFromStream(stream, seg);
+
+            if (r == 1) // r == 2 mean seg wasn't added to stream
+                StreamTcpRemoveSegmentFromStream(stream, seg);
+
             StreamTcpSegmentReturntoPool(seg);
             SCReturnInt(-1);
+        }
+        if (r == 2) {
+            SCLogDebug("duplicate segment %u/%u, discard it",
+                    seg->seq, seg->payload_len);
+
+            StreamTcpSegmentReturntoPool(seg);
+#ifdef DEBUG
+            if (SCLogDebugEnabled()) {
+                TcpSegment *s = NULL, *safe = NULL;
+                RB_FOREACH_SAFE(s, TCPSEG, &stream->seg_tree, safe)
+                {
+                    SCLogDebug("tree: seg %p, SEQ %"PRIu32", LEN %"PRIu16", SUM %"PRIu32"%s%s%s",
+                            s, s->seq, TCP_SEG_LEN(s),
+                            (uint32_t)(s->seq + TCP_SEG_LEN(s)),
+                            s->seq == seg->seq ? " DUPLICATE" : "",
+                            TCPSEG_RB_PREV(s) == NULL ? " HEAD" : "",
+                            TCPSEG_RB_NEXT(s) == NULL ? " TAIL" : "");
+                }
+            }
+#endif
         }
     }
 
@@ -703,9 +758,8 @@ static inline uint64_t GetLeftEdge(TcpSession *ssn, TcpStream *stream)
         /* we know left edge based on the progress values now,
          * lets adjust it to make sure in-use segments still have
          * data */
-        const TcpSegment *seg;
-        for (seg = stream->seg_list; seg != NULL; seg = seg->next)
-        {
+        TcpSegment *seg = NULL;
+        RB_FOREACH(seg, TCPSEG, &stream->seg_tree) {
             if (TCP_SEG_OFFSET(seg) > left_edge) {
                 SCLogDebug("seg beyond left_edge, we're done");
                 break;
@@ -724,18 +778,7 @@ static inline uint64_t GetLeftEdge(TcpSession *ssn, TcpStream *stream)
 
 static void StreamTcpRemoveSegmentFromStream(TcpStream *stream, TcpSegment *seg)
 {
-    if (seg->prev == NULL) {
-        stream->seg_list = seg->next;
-        if (stream->seg_list != NULL)
-            stream->seg_list->prev = NULL;
-    } else {
-        seg->prev->next = seg->next;
-        if (seg->next != NULL)
-            seg->next->prev = seg->prev;
-    }
-
-    if (stream->seg_list_tail == seg)
-        stream->seg_list_tail = seg->prev;
+    RB_REMOVE(TCPSEG, &stream->seg_tree, seg);
 }
 
 /** \brief Remove idle TcpSegments from TcpSession
@@ -817,9 +860,9 @@ void StreamTcpPruneSession(Flow *f, uint8_t flags)
                 stream->base_seq, STREAM_BASE_OFFSET(stream));
     }
 
-    /* loop through the segments and fill one or more msgs */
-    TcpSegment *seg = stream->seg_list;
-    while (seg != NULL)
+    /* loop through the segments and remove all not in use */
+    TcpSegment *seg = NULL, *safe = NULL;
+    RB_FOREACH_SAFE(seg, TCPSEG, &stream->seg_tree, safe)
     {
         SCLogDebug("seg %p, SEQ %"PRIu32", LEN %"PRIu16", SUM %"PRIu32,
                 seg, seg->seq, TCP_SEG_LEN(seg),
@@ -830,147 +873,15 @@ void StreamTcpPruneSession(Flow *f, uint8_t flags)
             break;
         }
 
-        TcpSegment *next_seg = seg->next;
         StreamTcpRemoveSegmentFromStream(stream, seg);
         StreamTcpSegmentReturntoPool(seg);
-        seg = next_seg;
         SCLogDebug("removed segment");
         continue;
     }
-#ifdef DEBUG
-    PrintList(stream->seg_list);
-#endif
+
     SCReturn;
 }
 
-/*
- *  Utils
- */
-
-#if 0
-void PrintList2(TcpSegment *seg)
-{
-    TcpSegment *prev_seg = NULL;
-
-    if (seg == NULL)
-        return;
-
-    uint32_t next_seq = seg->seq;
-
-    while (seg != NULL) {
-        if (SEQ_LT(next_seq,seg->seq)) {
-            SCLogDebug("missing segment(s) for %" PRIu32 " bytes of data",
-                        (seg->seq - next_seq));
-        }
-
-        SCLogDebug("seg %10"PRIu32" len %" PRIu16 ", seg %p, prev %p, next %p",
-                    seg->seq, TCP_SEG_LEN(seg), seg, seg->prev, seg->next);
-
-        if (seg->prev != NULL && SEQ_LT(seg->seq,seg->prev->seq)) {
-            /* check for SEQ_LT cornercase where a - b is exactly 2147483648,
-             * which makes the marco return TRUE in both directions. This is
-             * a hack though, we're going to check next how we end up with
-             * a segment list with seq differences that big */
-            if (!(SEQ_LT(seg->prev->seq,seg->seq))) {
-                SCLogDebug("inconsistent list: SEQ_LT(seg->seq,seg->prev->seq)) =="
-                        " TRUE, seg->seq %" PRIu32 ", seg->prev->seq %" PRIu32 ""
-                        "", seg->seq, seg->prev->seq);
-            }
-        }
-
-        if (SEQ_LT(seg->seq,next_seq)) {
-            SCLogDebug("inconsistent list: SEQ_LT(seg->seq,next_seq)) == TRUE, "
-                       "seg->seq %" PRIu32 ", next_seq %" PRIu32 "", seg->seq,
-                       next_seq);
-        }
-
-        if (prev_seg != seg->prev) {
-            SCLogDebug("inconsistent list: prev_seg %p != seg->prev %p",
-                        prev_seg, seg->prev);
-        }
-
-        next_seq = seg->seq + TCP_SEG_LEN(seg);
-        SCLogDebug("next_seq is now %"PRIu32"", next_seq);
-        prev_seg = seg;
-        seg = seg->next;
-    }
-}
-#endif
-
-void PrintList(TcpSegment *seg)
-{
-    TcpSegment *prev_seg = NULL;
-//    TcpSegment *head_seg = seg;
-
-    if (seg == NULL)
-        return;
-
-    uint32_t next_seq = seg->seq;
-
-    while (seg != NULL) {
-        if (SEQ_LT(next_seq,seg->seq)) {
-            SCLogDebug("missing segment(s) for %" PRIu32 " bytes of data",
-                        (seg->seq - next_seq));
-        }
-
-        SCLogDebug("seg %10"PRIu32" len %" PRIu16 ", seg %p, prev %p, next %p",
-                    seg->seq, TCP_SEG_LEN(seg), seg, seg->prev, seg->next);
-
-        if (seg->prev != NULL && SEQ_LT(seg->seq,seg->prev->seq)) {
-            /* check for SEQ_LT cornercase where a - b is exactly 2147483648,
-             * which makes the marco return TRUE in both directions. This is
-             * a hack though, we're going to check next how we end up with
-             * a segment list with seq differences that big */
-            if (!(SEQ_LT(seg->prev->seq,seg->seq))) {
-                SCLogDebug("inconsistent list: SEQ_LT(seg->seq,seg->prev->seq)) == "
-                        "TRUE, seg->seq %" PRIu32 ", seg->prev->seq %" PRIu32 "",
-                        seg->seq, seg->prev->seq);
-//                PrintList2(head_seg);
-//                abort();
-            }
-        }
-
-        if (SEQ_LT(seg->seq,next_seq)) {
-            SCLogDebug("inconsistent list: SEQ_LT(seg->seq,next_seq)) == TRUE, "
-                       "seg->seq %" PRIu32 ", next_seq %" PRIu32 "", seg->seq,
-                       next_seq);
-//            PrintList2(head_seg);
-//            abort();
-        }
-
-        if (prev_seg != seg->prev) {
-            SCLogDebug("inconsistent list: prev_seg %p != seg->prev %p",
-                       prev_seg, seg->prev);
-//            PrintList2(head_seg);
-            abort();
-        }
-
-        next_seq = seg->seq + TCP_SEG_LEN(seg);
-        SCLogDebug("next_seq is now %"PRIu32"", next_seq);
-        prev_seg = seg;
-        seg = seg->next;
-    }
-}
-
-#if 0
-void ValidateList(const TcpStream *stream)
-{
-    TcpSegment *seg = stream->seg_list;
-    TcpSegment *prev_seg = NULL;
-
-    BUG_ON(seg && seg->next == NULL && stream->seg_list != stream->seg_list_tail);
-    BUG_ON(stream->seg_list != stream->seg_list_tail && stream->seg_list_tail->prev == NULL);
-
-    while (seg != NULL) {
-        prev_seg = seg;
-        seg = seg->next;
-        BUG_ON(seg && seg->prev != prev_seg);
-
-        // equal is possible
-        BUG_ON(seg && SEQ_LT(seg->seq, prev_seg->seq));
-    }
-}
-#endif
 
 /*
  *  unittests

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -178,16 +178,6 @@ static int DoInsertSegment (TcpStream *stream, TcpSegment *seg, TcpSegment **dup
         return 0;
     }
 
-    /* insert the segment in the stream tree using this fast track, if seg->seq
-       is equal or higher than last segments tail. */
-    TcpSegment *last = RB_MAX(TCPSEG, &stream->seg_tree);
-    if (last && SEQ_GEQ(seg->seq, (uint32_t)SEG_SEQ_RIGHT_EDGE(last)))
-    {
-        SCLogDebug("seg beyond tree tail, append");
-        TCPSEG_RB_INSERT(&stream->seg_tree, seg);
-        return 0;
-    }
-
     /* insert and then check if there was any overlap with other segments */
     TcpSegment *res = TCPSEG_RB_INSERT(&stream->seg_tree, seg);
     if (res) {

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -521,16 +521,19 @@ static int DoHandleData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         handle = tree_seg;
     }
 
+    const bool is_head = !(TCPSEG_RB_PREV(handle));
+    const bool is_tail = !(TCPSEG_RB_NEXT(handle));
+
     /* new list head  */
-    if (handle == RB_MIN(TCPSEG, &stream->seg_tree) && TCPSEG_RB_NEXT(handle)) {
+    if (is_head && !is_tail) {
         result = DoHandleDataCheckForward(stream, handle, buf, p);
 
     /* new list tail */
-    } else if (handle == RB_MAX(TCPSEG, &stream->seg_tree) && TCPSEG_RB_PREV(handle)) {
+    } else if (!is_head && is_tail) {
         result = DoHandleDataCheckBackwards(stream, handle, buf, p);
 
     /* middle of the list */
-    } else if (TCPSEG_RB_NEXT(handle) && TCPSEG_RB_PREV(handle)) {
+    } else if (!is_head && !is_tail) {
         result = DoHandleDataCheckBackwards(stream, handle, buf, p);
         result |= DoHandleDataCheckForward(stream, handle, buf, p);
     }

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -414,8 +414,6 @@ static int DoHandleDataOverlap(TcpStream *stream, const TcpSegment *list,
     return (check_overlap_different_data && data_is_different);
 }
 
-#define MAX_IP_DATA (uint32_t)(65536 - 40) // min ip header and min tcp header
-
 /** \internal
  *  \brief walk segment tree backwards to see if there are overlaps
  *
@@ -440,7 +438,7 @@ static int DoHandleDataCheckBackwards(TcpStream *stream,
         if (SEQ_LEQ(SEG_SEQ_RIGHT_EDGE(tree_seg), stream->base_seq)) {
             // segment entirely before base_seq
             ;
-        } else if (SEQ_LEQ(tree_seg->seq + MAX_IP_DATA, seg->seq)) {
+        } else if (SEQ_LEQ(tree_seg->seq + tree_seg->payload_len, seg->seq)) {
             SCLogDebug("list segment too far to the left, no more overlap will be found");
             break;
         } else if (SEQ_GT(SEG_SEQ_RIGHT_EDGE(tree_seg), seg->seq)) {

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -175,6 +175,7 @@ static int DoInsertSegment (TcpStream *stream, TcpSegment *seg, TcpSegment **dup
         SCLogDebug("empty tree, inserting seg %p seq %" PRIu32 ", "
                    "len %" PRIu32 "", seg, seg->seq, TCP_SEG_LEN(seg));
         TCPSEG_RB_INSERT(&stream->seg_tree, seg);
+        stream->segs_right_edge = SEG_SEQ_RIGHT_EDGE(seg);
         return 0;
     }
 
@@ -187,6 +188,9 @@ static int DoInsertSegment (TcpStream *stream, TcpSegment *seg, TcpSegment **dup
         *dup_seg = res;
         return 2; // duplicate has overlap by definition.
     } else {
+        if (SEQ_GT(SEG_SEQ_RIGHT_EDGE(seg), stream->segs_right_edge))
+            stream->segs_right_edge = SEG_SEQ_RIGHT_EDGE(seg);
+
         /* insert succeeded, now check if we overlap with someone */
         if (CheckOverlap(&stream->seg_tree, seg) == true) {
             SCLogDebug("seg %u has overlap in the tree", seg->seq);

--- a/src/stream-tcp-list.h
+++ b/src/stream-tcp-list.h
@@ -26,8 +26,6 @@
 
 #include "stream-tcp-private.h"
 
-void PrintList(TcpSegment *);
-
 #ifdef UNITTESTS
 void StreamTcpListRegisterTests(void);
 #endif

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -119,6 +119,8 @@ typedef struct TcpStream_ {
     struct TCPSEG seg_tree;         /**< red black tree of TCP segments. Data is stored in TcpStream::sb */
     uint32_t segs_right_edge;
 
+    uint32_t sack_size;             /**< combined size of the SACK ranges currently in our tree. Updated
+                                     *   at INSERT/REMOVE time. */
     struct TCPSACK sack_tree;       /**< red back tree of TCP SACK records. */
 } TcpStream;
 

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -62,9 +62,9 @@ typedef struct TcpSegment {
     PoolThreadReserved res;
     uint16_t payload_len;       /**< actual size of the payload */
     uint32_t seq;
+    RB_ENTRY(TcpSegment) __attribute__((__packed__)) rb;
     StreamingBufferSegment sbseg;
-    RB_ENTRY(TcpSegment) rb;
-} TcpSegment;
+} __attribute__((__packed__)) TcpSegment;
 
 /** \brief compare function for the Segment tree
  *

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -46,11 +46,17 @@ typedef struct TcpStateQueue_ {
     struct TcpStateQueue_ *next;
 } TcpStateQueue;
 
-typedef struct StreamTcpSackRecord_ {
+typedef struct StreamTcpSackRecord {
     uint32_t le;    /**< left edge, host order */
     uint32_t re;    /**< right edge, host order */
-    struct StreamTcpSackRecord_ *next;
+    RB_ENTRY(StreamTcpSackRecord) rb;
 } StreamTcpSackRecord;
+
+int TcpSackCompare(struct StreamTcpSackRecord *a, struct StreamTcpSackRecord *b);
+
+/* red-black tree prototype for SACK records */
+RB_HEAD(TCPSACK, StreamTcpSackRecord);
+RB_PROTOTYPE(TCPSACK, StreamTcpSackRecord, rb, TcpSackCompare);
 
 typedef struct TcpSegment {
     PoolThreadReserved res;
@@ -113,8 +119,7 @@ typedef struct TcpStream_ {
     struct TCPSEG seg_tree;         /**< red black tree of TCP segments. Data is stored in TcpStream::sb */
     uint32_t segs_right_edge;
 
-    StreamTcpSackRecord *sack_head; /**< head of list of SACK records */
-    StreamTcpSackRecord *sack_tail; /**< tail of list of SACK records */
+    struct TCPSACK sack_tree;       /**< red back tree of TCP SACK records. */
 } TcpStream;
 
 #define STREAM_BASE_OFFSET(stream)  ((stream)->sb.stream_offset)

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -78,6 +78,13 @@ RB_PROTOTYPE(TCPSEG, TcpSegment, rb, TcpSegmentCompare);
 
 #define SEG_SEQ_RIGHT_EDGE(seg) ((seg)->seq + TCP_SEG_LEN((seg)))
 
+/* get right edge of sequence space of seen segments.
+ * Only use if STREAM_HAS_SEEN_DATA is true. */
+#define STREAM_SEQ_RIGHT_EDGE(stream)   (stream)->segs_right_edge
+#define STREAM_RIGHT_EDGE(stream)       (STREAM_BASE_OFFSET((stream)) + (STREAM_SEQ_RIGHT_EDGE((stream)) - (stream)->base_seq))
+/* return true if we have seen data segments. */
+#define STREAM_HAS_SEEN_DATA(stream)    (!RB_EMPTY(&(stream)->sb.sbb_tree) || (stream)->sb.stream_offset)
+
 typedef struct TcpStream_ {
     uint16_t flags:12;              /**< Flag specific to the stream e.g. Timestamp */
     /* coccinelle: TcpStream:flags:STREAMTCP_STREAM_FLAG_ */
@@ -104,6 +111,7 @@ typedef struct TcpStream_ {
 
     StreamingBuffer sb;
     struct TCPSEG seg_tree;         /**< red black tree of TCP segments. Data is stored in TcpStream::sb */
+    uint32_t segs_right_edge;
 
     StreamTcpSackRecord *sack_head; /**< head of list of SACK records */
     StreamTcpSackRecord *sack_tail; /**< tail of list of SACK records */

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -898,7 +898,7 @@ static void GetAppBuffer(TcpStream *stream, const uint8_t **data, uint32_t *data
         *data = mydata;
         *data_len = mydata_len;
     } else {
-        StreamingBufferBlock *blk = RB_MIN(SBB, &stream->sb.sbb_tree);
+        const StreamingBufferBlock *blk = stream->sb.head;
 
         if (blk->offset > offset) {
             SCLogDebug("gap, want data at offset %"PRIu64", "
@@ -955,7 +955,7 @@ static inline bool CheckGap(TcpSession *ssn, TcpStream *stream, Packet *p)
                     return false;
                 } else {
                     const uint64_t next_seq_abs = STREAM_BASE_OFFSET(stream) + (stream->next_seq - stream->base_seq);
-                    StreamingBufferBlock *blk = RB_MIN(SBB, &stream->sb.sbb_tree);
+                    const StreamingBufferBlock *blk = stream->sb.head;
                     if (blk->offset > next_seq_abs && blk->offset < last_ack_abs) {
                         /* ack'd data after the gap */
                         SCLogDebug("packet %"PRIu64": GAP. "

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -322,6 +322,7 @@ void StreamTcpReturnStreamSegments (TcpStream *stream)
     }
 }
 
+#ifdef UNITTESTS
 /** \internal
  *  \brief check if segments falls before stream 'offset' */
 static inline int SEGMENT_BEFORE_OFFSET(TcpStream *stream, TcpSegment *seg, uint64_t offset)
@@ -330,6 +331,7 @@ static inline int SEGMENT_BEFORE_OFFSET(TcpStream *stream, TcpSegment *seg, uint
         return 1;
     return 0;
 }
+#endif
 
 /** \param f locked flow */
 void StreamTcpDisableAppLayer(Flow *f)
@@ -1105,9 +1107,7 @@ int StreamTcpReassembleAppLayer (ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
 #endif
     /* if no segments are in the list or all are already processed,
      * and state is beyond established, we send an empty msg */
-    TcpSegment *seg_tail = RB_MAX(TCPSEG, &stream->seg_tree);
-    if (seg_tail == NULL ||
-            SEGMENT_BEFORE_OFFSET(stream, seg_tail, STREAM_APP_PROGRESS(stream)))
+    if (STREAM_HAS_SEEN_DATA(stream) && STREAM_RIGHT_EDGE(stream) <= STREAM_APP_PROGRESS(stream))
     {
         /* send an empty EOF msg if we have no segments but TCP state
          * is beyond ESTABLISHED */

--- a/src/stream-tcp-sack.c
+++ b/src/stream-tcp-sack.c
@@ -29,17 +29,34 @@
 #include "stream-tcp-sack.h"
 #include "util-unittest.h"
 
+RB_GENERATE(TCPSACK, StreamTcpSackRecord, rb, TcpSackCompare);
+
+int TcpSackCompare(struct StreamTcpSackRecord *a, struct StreamTcpSackRecord *b)
+{
+    if (SEQ_GT(a->le, b->le))
+        return 1;
+    else if (SEQ_LT(a->le, b->le))
+        return -1;
+    else {
+        if (SEQ_EQ(a->re, b->re))
+            return 0;
+        else if (SEQ_GT(a->re, b->re))
+            return 1;
+        else
+            return -1;
+    }
+}
 #ifdef DEBUG
 static void StreamTcpSackPrintList(TcpStream *stream)
 {
-    StreamTcpSackRecord *rec = stream->sack_head;
-    for (; rec != NULL; rec = rec->next) {
+    StreamTcpSackRecord *rec = NULL;
+    RB_FOREACH(rec, TCPSACK, &stream->sack_tree) {
         SCLogDebug("record %8u - %8u", rec->le, rec->re);
     }
 }
 #endif /* DEBUG */
 
-static StreamTcpSackRecord *StreamTcpSackRecordAlloc(void)
+static inline StreamTcpSackRecord *StreamTcpSackRecordAlloc(void)
 {
     if (StreamTcpCheckMemcap((uint32_t)sizeof(StreamTcpSackRecord)) == 0)
         return NULL;
@@ -52,10 +69,122 @@ static StreamTcpSackRecord *StreamTcpSackRecordAlloc(void)
     return rec;
 }
 
-static void StreamTcpSackRecordFree(StreamTcpSackRecord *rec)
+static inline void StreamTcpSackRecordFree(StreamTcpSackRecord *rec)
 {
     SCFree(rec);
     StreamTcpDecrMemuse((uint64_t)sizeof(*rec));
+}
+
+static inline void ConsolidateFwd(struct TCPSACK *tree, struct StreamTcpSackRecord *sa)
+{
+    struct StreamTcpSackRecord *tr, *s = sa;
+    RB_FOREACH_FROM(tr, TCPSACK, s) {
+        if (sa == tr)
+            continue;
+        SCLogDebug("-> (fwd) tr %p %u/%u", tr, tr->le, tr->re);
+
+        if (SEQ_LT(sa->re, tr->le))
+            break; // entirely before
+
+        if (SEQ_GEQ(sa->le, tr->le) && SEQ_LEQ(sa->re, tr->re)) {
+            sa->re = tr->re;
+            sa->le = tr->le;
+            SCLogDebug("-> (fwd) tr %p %u/%u REMOVED ECLIPSED2", tr, tr->le, tr->re);
+            TCPSACK_RB_REMOVE(tree, tr);
+            StreamTcpSackRecordFree(tr);
+        /*
+            sa: [         ]
+            tr: [         ]
+            sa: [         ]
+            tr:    [      ]
+            sa: [         ]
+            tr:    [   ]
+        */
+        } else if (SEQ_LEQ(sa->le, tr->le) && SEQ_GEQ(sa->re, tr->re)) {
+            SCLogDebug("-> (fwd) tr %p %u/%u REMOVED ECLIPSED", tr, tr->le, tr->re);
+            TCPSACK_RB_REMOVE(tree, tr);
+            StreamTcpSackRecordFree(tr);
+        /*
+            sa: [         ]
+            tr:      [         ]
+            sa: [       ]
+            tr:         [       ]
+        */
+        } else if (SEQ_LT(sa->le, tr->le) && // starts before
+                   SEQ_GEQ(sa->re, tr->le) && SEQ_LT(sa->re, tr->re) // ends inside
+            ) {
+            // merge
+            sa->re = tr->re;
+            SCLogDebug("-> (fwd) tr %p %u/%u REMOVED MERGED", tr, tr->le, tr->re);
+            TCPSACK_RB_REMOVE(tree, tr);
+            StreamTcpSackRecordFree(tr);
+        }
+    }
+}
+
+static inline void ConsolidateBackward(struct TCPSACK *tree, struct StreamTcpSackRecord *sa)
+{
+    struct StreamTcpSackRecord *tr, *s = sa;
+    RB_FOREACH_REVERSE_FROM(tr, TCPSACK, s) {
+        if (sa == tr)
+            continue;
+        SCLogDebug("-> (bwd) tr %p %u/%u", tr, tr->le, tr->re);
+
+        if (SEQ_GT(sa->le, tr->re))
+            break; // entirely after
+        if (SEQ_GEQ(sa->le, tr->le) && SEQ_LEQ(sa->re, tr->re)) {
+            sa->re = tr->re;
+            sa->le = tr->le;
+            SCLogDebug("-> (bwd) tr %p %u/%u REMOVED ECLIPSED2", tr, tr->le, tr->re);
+            TCPSACK_RB_REMOVE(tree, tr);
+            StreamTcpSackRecordFree(tr);
+        /*
+            sa: [         ]
+            tr: [         ]
+            sa:    [      ]
+            tr: [         ]
+            sa:    [   ]
+            tr: [         ]
+        */
+        } else if (SEQ_LEQ(sa->le, tr->le) && SEQ_GEQ(sa->re, tr->re)) {
+            SCLogDebug("-> (bwd) tr %p %u/%u REMOVED ECLIPSED", tr, tr->le, tr->re);
+            TCPSACK_RB_REMOVE(tree, tr);
+            StreamTcpSackRecordFree(tr);
+        /*
+            sa:     [   ]
+            tr: [   ]
+            sa:    [    ]
+            tr: [   ]
+        */
+        } else if (SEQ_GT(sa->le, tr->le) && SEQ_GT(sa->re, tr->re) && SEQ_LEQ(sa->le,tr->re)) {
+            // merge
+            sa->le = tr->le;
+            SCLogDebug("-> (bwd) tr %p %u/%u REMOVED MERGED", tr, tr->le, tr->re);
+            TCPSACK_RB_REMOVE(tree, tr);
+            StreamTcpSackRecordFree(tr);
+        }
+    }
+}
+
+static int Insert(struct TCPSACK *tree, uint32_t le, uint32_t re)
+{
+    SCLogDebug("* inserting: %u/%u\n", le, re);
+
+    struct StreamTcpSackRecord *sa = StreamTcpSackRecordAlloc();
+    if (unlikely(sa == NULL))
+        return -1;
+    sa->le = le;
+    sa->re = re;
+    struct StreamTcpSackRecord *res = TCPSACK_RB_INSERT(tree, sa);
+    if (res) {
+        // exact overlap
+        SCLogDebug("* insert failed: exact match in tree with %p %u/%u", res, res->le, res->re);
+        StreamTcpSackRecordFree(sa);
+        return 0;
+    }
+    ConsolidateBackward(tree, sa);
+    ConsolidateFwd(tree, sa);
+    return 0;
 }
 
 /**
@@ -77,167 +206,17 @@ static int StreamTcpSackInsertRange(TcpStream *stream, uint32_t le, uint32_t re)
     /* if to the left of last_ack then ignore */
     if (SEQ_LT(re, stream->last_ack)) {
         SCLogDebug("too far left. discarding");
-        goto end;
+        SCReturnInt(0);
     }
     /* if to the right of the tcp window then ignore */
     if (SEQ_GT(le, (stream->last_ack + stream->window))) {
         SCLogDebug("too far right. discarding");
-        goto end;
-    }
-    if (stream->sack_head != NULL) {
-        StreamTcpSackRecord *rec;
-
-        for (rec = stream->sack_head; rec != NULL; rec = rec->next) {
-            SCLogDebug("rec %p, le %u, re %u", rec, rec->le, rec->re);
-
-            if (SEQ_LT(le, rec->le)) {
-                SCLogDebug("SEQ_LT(le, rec->le)");
-                if (SEQ_LT(re, rec->le)) {
-                    SCLogDebug("SEQ_LT(re, rec->le)");
-                    // entirely before, prepend
-                    StreamTcpSackRecord *stsr = StreamTcpSackRecordAlloc();
-                    if (unlikely(stsr == NULL)) {
-                        SCReturnInt(-1);
-                    }
-                    stsr->le = le;
-                    stsr->re = re;
-
-                    stsr->next = stream->sack_head;
-                    stream->sack_head = stsr;
-                    goto end;
-                } else if (SEQ_EQ(re, rec->le)) {
-                    SCLogDebug("SEQ_EQ(re, rec->le)");
-                    // starts before, ends on rec->le, expand
-                    rec->le = le;
-                } else if (SEQ_GT(re, rec->le)) {
-                    SCLogDebug("SEQ_GT(re, rec->le)");
-                    // starts before, ends beyond rec->le
-                    if (SEQ_LEQ(re, rec->re)) {
-                        SCLogDebug("SEQ_LEQ(re, rec->re)");
-                        // ends before rec->re, expand
-                        rec->le = le;
-                    } else { // implied if (re > rec->re)
-                        SCLogDebug("implied if (re > rec->re), le set to %u", rec->re);
-                        le = rec->re;
-                        continue;
-                    }
-                }
-            } else if (SEQ_EQ(le, rec->le)) {
-                SCLogDebug("SEQ_EQ(le, rec->le)");
-                if (SEQ_LEQ(re, rec->re)) {
-                    SCLogDebug("SEQ_LEQ(re, rec->re)");
-                    // new record fully overlapped
-                    SCReturnInt(0);
-                } else { // implied re > rec->re
-                    SCLogDebug("implied re > rec->re");
-                    if (rec->next != NULL) {
-                        if (SEQ_LEQ(re, rec->next->le)) {
-                            rec->re = re;
-                            goto end;
-                        } else {
-                            rec->re = rec->next->le;
-                            le = rec->next->le;
-                            SCLogDebug("le is now %u", le);
-                            continue;
-                        }
-                    } else {
-                        rec->re = re;
-                        goto end;
-                    }
-                }
-            } else { // implied (le > rec->le)
-                SCLogDebug("implied (le > rec->le)");
-                if (SEQ_LT(le, rec->re)) {
-                    SCLogDebug("SEQ_LT(le, rec->re))");
-                    // new record fully overlapped
-                    if (SEQ_GT(re, rec->re)) {
-                        SCLogDebug("SEQ_GT(re, rec->re)");
-
-                        if (rec->next != NULL) {
-                            if (SEQ_LEQ(re, rec->next->le)) {
-                                rec->re = re;
-                                goto end;
-                            } else {
-                                rec->re = rec->next->le;
-                                le = rec->next->le;
-                                continue;
-                            }
-                        } else {
-                            rec->re = re;
-                            goto end;
-                        }
-                    }
-
-                    SCLogDebug("new range fully overlapped");
-                    SCReturnInt(0);
-                } else if (SEQ_EQ(le, rec->re)) {
-                    SCLogDebug("here");
-                    // new record fully overlapped
-                    //int r = StreamTcpSackInsertRange(stream, rec->re+1, re);
-                    //SCReturnInt(r);
-                    le = rec->re;
-                    continue;
-                } else { /* implied le > rec->re */
-                    SCLogDebug("implied le > rec->re");
-                    if (rec->next == NULL) {
-                        SCLogDebug("rec->next == NULL");
-                        StreamTcpSackRecord *stsr = StreamTcpSackRecordAlloc();
-                        if (unlikely(stsr == NULL)) {
-                            SCReturnInt(-1);
-                        }
-                        stsr->le = le;
-                        stsr->re = re;
-                        stsr->next = NULL;
-
-                        stream->sack_tail->next = stsr;
-                        stream->sack_tail = stsr;
-                        goto end;
-                    } else {
-                        SCLogDebug("implied rec->next != NULL");
-                        if (SEQ_LT(le, rec->next->le) && SEQ_LT(re, rec->next->le)) {
-                            SCLogDebug("SEQ_LT(le, rec->next->le) && SEQ_LT(re, rec->next->le)");
-                            StreamTcpSackRecord *stsr = StreamTcpSackRecordAlloc();
-                            if (unlikely(stsr == NULL)) {
-                                SCReturnInt(-1);
-                            }
-                            stsr->le = le;
-                            stsr->re = re;
-                            stsr->next = rec->next;
-                            rec->next = stsr;
-
-                        } else if (SEQ_LT(le, rec->next->le) && SEQ_GEQ(re, rec->next->le)) {
-                            SCLogDebug("SEQ_LT(le, rec->next->le) && SEQ_GEQ(re, rec->next->le)");
-                            StreamTcpSackRecord *stsr = StreamTcpSackRecordAlloc();
-                            if (unlikely(stsr == NULL)) {
-                                SCReturnInt(-1);
-                            }
-                            stsr->le = le;
-                            stsr->re = rec->next->le;
-                            stsr->next = rec->next;
-                            rec->next = stsr;
-
-                            le = rec->next->le;
-                        }
-                    }
-                }
-            }
-        }
-    } else {
-        SCLogDebug("implied empty list");
-        StreamTcpSackRecord *stsr = StreamTcpSackRecordAlloc();
-        if (unlikely(stsr == NULL)) {
-            SCReturnInt(-1);
-        }
-        stsr->le = le;
-        stsr->re = re;
-        stsr->next = NULL;
-
-        stream->sack_head = stsr;
-        stream->sack_tail = stsr;
+        SCReturnInt(0);
     }
 
-    StreamTcpSackPruneList(stream);
-end:
+    if (Insert(&stream->sack_tree, le, re) < 0)
+        SCReturnInt(-1);
+
     SCReturnInt(0);
 }
 
@@ -252,8 +231,7 @@ end:
  */
 int StreamTcpSackUpdatePacket(TcpStream *stream, Packet *p)
 {
-    int records = TCP_GET_SACK_CNT(p);
-    int record = 0;
+    const int records = TCP_GET_SACK_CNT(p);
     const uint8_t *data = TCP_GET_SACK_PTR(p);
 
     if (records == 0 || data == NULL)
@@ -262,35 +240,37 @@ int StreamTcpSackUpdatePacket(TcpStream *stream, Packet *p)
     TCPOptSackRecord rec[records], *sack_rec = rec;
     memcpy(&rec, data, sizeof(TCPOptSackRecord) * records);
 
-    for (record = 0; record < records; record++) {
-        SCLogDebug("%p last_ack %u, left edge %u, right edge %u", sack_rec,
-            stream->last_ack, SCNtohl(sack_rec->le), SCNtohl(sack_rec->re));
+    for (int record = 0; record < records; record++) {
+        const uint32_t le = SCNtohl(sack_rec->le);
+        const uint32_t re = SCNtohl(sack_rec->re);
 
-        if (SEQ_LEQ(SCNtohl(sack_rec->re), stream->last_ack)) {
+        SCLogDebug("%p last_ack %u, left edge %u, right edge %u", sack_rec,
+            stream->last_ack, le, re);
+
+        if (SEQ_LEQ(re, stream->last_ack)) {
             SCLogDebug("record before last_ack");
             goto next;
         }
 
-        if (SEQ_GT(SCNtohl(sack_rec->re), stream->next_win)) {
+        if (SEQ_GT(re, stream->next_win)) {
             SCLogDebug("record %u:%u beyond next_win %u",
-                    SCNtohl(sack_rec->le), SCNtohl(sack_rec->re), stream->next_win);
+                    le, re, stream->next_win);
             goto next;
         }
 
-        if (SEQ_GEQ(SCNtohl(sack_rec->le), SCNtohl(sack_rec->re))) {
+        if (SEQ_GEQ(le, re)) {
             SCLogDebug("invalid record: le >= re");
             goto next;
         }
 
-        if (StreamTcpSackInsertRange(stream, SCNtohl(sack_rec->le),
-                    SCNtohl(sack_rec->re)) == -1)
-        {
+        if (StreamTcpSackInsertRange(stream, le, re) == -1) {
             SCReturnInt(-1);
         }
 
     next:
         sack_rec++;
     }
+    StreamTcpSackPruneList(stream);
 #ifdef DEBUG
     StreamTcpSackPrintList(stream);
 #endif
@@ -301,23 +281,13 @@ void StreamTcpSackPruneList(TcpStream *stream)
 {
     SCEnter();
 
-    StreamTcpSackRecord *rec = stream->sack_head;
-
-    while (rec != NULL) {
+    StreamTcpSackRecord *rec = NULL, *safe = NULL;
+    RB_FOREACH_SAFE(rec, TCPSACK, &stream->sack_tree, safe) {
         if (SEQ_LT(rec->re, stream->last_ack)) {
             SCLogDebug("removing le %u re %u", rec->le, rec->re);
+            TCPSACK_RB_REMOVE(&stream->sack_tree, rec);
+            StreamTcpSackRecordFree(rec);
 
-            if (rec->next != NULL) {
-                stream->sack_head = rec->next;
-                StreamTcpSackRecordFree(rec);
-                rec = stream->sack_head;
-                continue;
-            } else {
-                stream->sack_head = NULL;
-                stream->sack_tail = NULL;
-                StreamTcpSackRecordFree(rec);
-                break;
-            }
         } else if (SEQ_LT(rec->le, stream->last_ack)) {
             SCLogDebug("adjusting record to le %u re %u", rec->le, rec->re);
             /* last ack inside this record, update */
@@ -335,7 +305,7 @@ void StreamTcpSackPruneList(TcpStream *stream)
 }
 
 /**
- *  \brief Free SACK list from a stream
+ *  \brief Free SACK tree from a stream
  *
  *  \param stream Stream to cleanup
  */
@@ -343,17 +313,12 @@ void StreamTcpSackFreeList(TcpStream *stream)
 {
     SCEnter();
 
-    StreamTcpSackRecord *rec = stream->sack_head;
-    StreamTcpSackRecord *next = NULL;
-
-    while (rec != NULL) {
-        next = rec->next;
+    StreamTcpSackRecord *rec = NULL, *safe = NULL;
+    RB_FOREACH_SAFE(rec, TCPSACK, &stream->sack_tree, safe) {
+        TCPSACK_RB_REMOVE(&stream->sack_tree, rec);
         StreamTcpSackRecordFree(rec);
-        rec = next;
     }
 
-    stream->sack_head = NULL;
-    stream->sack_tail = NULL;
     SCReturn;
 }
 
@@ -369,8 +334,6 @@ void StreamTcpSackFreeList(TcpStream *stream)
 static int StreamTcpSackTest01 (void)
 {
     TcpStream stream;
-    int retval = 0;
-
     memset(&stream, 0, sizeof(stream));
     stream.window = 100;
 
@@ -382,21 +345,15 @@ static int StreamTcpSackTest01 (void)
     StreamTcpSackPrintList(&stream);
 #endif /* DEBUG */
 
-    if (stream.sack_head->le != 1 || stream.sack_head->re != 20) {
-        printf("list in weird state, head le %u, re %u: ",
-                stream.sack_head->le, stream.sack_head->re);
-        goto end;
-    }
+    StreamTcpSackRecord *rec = RB_MIN(TCPSACK, &stream.sack_tree);
+    FAIL_IF_NULL(rec);
 
-    if (StreamTcpSackedSize(&stream) != 19) {
-        printf("size should be 19, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
+    FAIL_IF(rec->le != 1);
+    FAIL_IF(rec->re != 20);
 
-    retval = 1;
-end:
+    FAIL_IF(StreamTcpSackedSize(&stream) != 19);
     StreamTcpSackFreeList(&stream);
-    SCReturnInt(retval);
+    PASS;
 }
 
 /**
@@ -408,8 +365,6 @@ end:
 static int StreamTcpSackTest02 (void)
 {
     TcpStream stream;
-    int retval = 0;
-
     memset(&stream, 0, sizeof(stream));
     stream.window = 100;
 
@@ -419,21 +374,15 @@ static int StreamTcpSackTest02 (void)
     StreamTcpSackPrintList(&stream);
 #endif /* DEBUG */
 
-    if (stream.sack_head->le != 1 || stream.sack_head->re != 20) {
-        printf("list in weird state, head le %u, re %u: ",
-                stream.sack_head->le, stream.sack_head->re);
-        goto end;
-    }
+    StreamTcpSackRecord *rec = RB_MIN(TCPSACK, &stream.sack_tree);
+    FAIL_IF_NULL(rec);
 
-    if (StreamTcpSackedSize(&stream) != 19) {
-        printf("size should be 19, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
+    FAIL_IF(rec->le != 1);
+    FAIL_IF(rec->re != 20);
 
-    retval = 1;
-end:
+    FAIL_IF(StreamTcpSackedSize(&stream) != 19);
     StreamTcpSackFreeList(&stream);
-    SCReturnInt(retval);
+    PASS;
 }
 
 /**
@@ -445,8 +394,6 @@ end:
 static int StreamTcpSackTest03 (void)
 {
     TcpStream stream;
-    int retval = 0;
-
     memset(&stream, 0, sizeof(stream));
     stream.window = 100;
 
@@ -460,19 +407,15 @@ static int StreamTcpSackTest03 (void)
     StreamTcpSackPrintList(&stream);
 #endif /* DEBUG */
 
-    if (stream.sack_head->le != 5) {
-        goto end;
-    }
+    StreamTcpSackRecord *rec = RB_MIN(TCPSACK, &stream.sack_tree);
+    FAIL_IF_NULL(rec);
 
-    if (StreamTcpSackedSize(&stream) != 20) {
-        printf("size should be 20, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
+    FAIL_IF(rec->le != 5);
+    FAIL_IF(rec->re != 25);
 
-    retval = 1;
-end:
+    FAIL_IF(StreamTcpSackedSize(&stream) != 20);
     StreamTcpSackFreeList(&stream);
-    SCReturnInt(retval);
+    PASS;
 }
 
 /**
@@ -484,8 +427,6 @@ end:
 static int StreamTcpSackTest04 (void)
 {
     TcpStream stream;
-    int retval = 0;
-
     memset(&stream, 0, sizeof(stream));
     stream.window = 100;
 
@@ -496,19 +437,15 @@ static int StreamTcpSackTest04 (void)
     StreamTcpSackPrintList(&stream);
 #endif /* DEBUG */
 
-    if (stream.sack_head->le != 0) {
-        goto end;
-    }
+    StreamTcpSackRecord *rec = RB_MIN(TCPSACK, &stream.sack_tree);
+    FAIL_IF_NULL(rec);
 
-    if (StreamTcpSackedSize(&stream) != 45) {
-        printf("size should be 45, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
+    FAIL_IF(rec->le != 0);
+    FAIL_IF(rec->re != 25);
 
-    retval = 1;
-end:
+    FAIL_IF(StreamTcpSackedSize(&stream) != 45);
     StreamTcpSackFreeList(&stream);
-    SCReturnInt(retval);
+    PASS;
 }
 
 /**
@@ -520,8 +457,6 @@ end:
 static int StreamTcpSackTest05 (void)
 {
     TcpStream stream;
-    int retval = 0;
-
     memset(&stream, 0, sizeof(stream));
     stream.window = 100;
 
@@ -532,19 +467,15 @@ static int StreamTcpSackTest05 (void)
     StreamTcpSackPrintList(&stream);
 #endif /* DEBUG */
 
-    if (stream.sack_head->le != 0) {
-        goto end;
-    }
+    StreamTcpSackRecord *rec = RB_MIN(TCPSACK, &stream.sack_tree);
+    FAIL_IF_NULL(rec);
 
-    if (StreamTcpSackedSize(&stream) != 50) {
-        printf("size should be 50, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
+    FAIL_IF(rec->le != 0);
+    FAIL_IF(rec->re != 50);
 
-    retval = 1;
-end:
+    FAIL_IF(StreamTcpSackedSize(&stream) != 50);
     StreamTcpSackFreeList(&stream);
-    SCReturnInt(retval);
+    PASS;
 }
 
 /**
@@ -556,8 +487,6 @@ end:
 static int StreamTcpSackTest06 (void)
 {
     TcpStream stream;
-    int retval = 0;
-
     memset(&stream, 0, sizeof(stream));
     stream.window = 100;
 
@@ -570,19 +499,15 @@ static int StreamTcpSackTest06 (void)
     StreamTcpSackPrintList(&stream);
 #endif /* DEBUG */
 
-    if (stream.sack_head->le != 0) {
-        goto end;
-    }
+    StreamTcpSackRecord *rec = RB_MIN(TCPSACK, &stream.sack_tree);
+    FAIL_IF_NULL(rec);
 
-    if (StreamTcpSackedSize(&stream) != 40) {
-        printf("size should be 40, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
+    FAIL_IF(rec->le != 0);
+    FAIL_IF(rec->re != 40);
 
-    retval = 1;
-end:
+    FAIL_IF(StreamTcpSackedSize(&stream) != 40);
     StreamTcpSackFreeList(&stream);
-    SCReturnInt(retval);
+    PASS;
 }
 
 /**
@@ -594,8 +519,6 @@ end:
 static int StreamTcpSackTest07 (void)
 {
     TcpStream stream;
-    int retval = 0;
-
     memset(&stream, 0, sizeof(stream));
     stream.window = 100;
 
@@ -608,28 +531,18 @@ static int StreamTcpSackTest07 (void)
     StreamTcpSackPrintList(&stream);
 #endif /* DEBUG */
 
-    if (stream.sack_head->le != 0) {
-        goto end;
-    }
-
-    if (StreamTcpSackedSize(&stream) != 40) {
-        printf("size should be 40, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
+    StreamTcpSackRecord *rec = RB_MIN(TCPSACK, &stream.sack_tree);
+    FAIL_IF_NULL(rec);
+    FAIL_IF(rec->le != 0);
+    FAIL_IF(rec->re != 40);
+    FAIL_IF(StreamTcpSackedSize(&stream) != 40);
 
     stream.last_ack = 10;
-
     StreamTcpSackPruneList(&stream);
+    FAIL_IF(StreamTcpSackedSize(&stream) != 30);
 
-    if (StreamTcpSackedSize(&stream) != 30) {
-        printf("size should be 30, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
-
-    retval = 1;
-end:
     StreamTcpSackFreeList(&stream);
-    SCReturnInt(retval);
+    PASS;
 }
 
 /**
@@ -641,8 +554,6 @@ end:
 static int StreamTcpSackTest08 (void)
 {
     TcpStream stream;
-    int retval = 0;
-
     memset(&stream, 0, sizeof(stream));
     stream.window = 100;
 
@@ -655,28 +566,18 @@ static int StreamTcpSackTest08 (void)
     StreamTcpSackPrintList(&stream);
 #endif /* DEBUG */
 
-    if (stream.sack_head->le != 0) {
-        goto end;
-    }
-
-    if (StreamTcpSackedSize(&stream) != 40) {
-        printf("size should be 40, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
+    StreamTcpSackRecord *rec = RB_MIN(TCPSACK, &stream.sack_tree);
+    FAIL_IF_NULL(rec);
+    FAIL_IF(rec->le != 0);
+    FAIL_IF(rec->re != 40);
+    FAIL_IF(StreamTcpSackedSize(&stream) != 40);
 
     stream.last_ack = 41;
-
     StreamTcpSackPruneList(&stream);
+    FAIL_IF(StreamTcpSackedSize(&stream) != 0);
 
-    if (StreamTcpSackedSize(&stream) != 0) {
-        printf("size should be 0, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
-
-    retval = 1;
-end:
     StreamTcpSackFreeList(&stream);
-    SCReturnInt(retval);
+    PASS;
 }
 
 /**
@@ -688,8 +589,6 @@ end:
 static int StreamTcpSackTest09 (void)
 {
     TcpStream stream;
-    int retval = 0;
-
     memset(&stream, 0, sizeof(stream));
     stream.window = 100;
 
@@ -703,28 +602,18 @@ static int StreamTcpSackTest09 (void)
     StreamTcpSackPrintList(&stream);
 #endif /* DEBUG */
 
-    if (stream.sack_head->le != 0) {
-        goto end;
-    }
-
-    if (StreamTcpSackedSize(&stream) != 40) {
-        printf("size should be 40, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
+    StreamTcpSackRecord *rec = RB_MIN(TCPSACK, &stream.sack_tree);
+    FAIL_IF_NULL(rec);
+    FAIL_IF(rec->le != 0);
+    FAIL_IF(rec->re != 40);
+    FAIL_IF(StreamTcpSackedSize(&stream) != 40);
 
     stream.last_ack = 39;
-
     StreamTcpSackPruneList(&stream);
+    FAIL_IF(StreamTcpSackedSize(&stream) != 1);
 
-    if (StreamTcpSackedSize(&stream) != 1) {
-        printf("size should be 1, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
-
-    retval = 1;
-end:
     StreamTcpSackFreeList(&stream);
-    SCReturnInt(retval);
+    PASS;
 }
 
 /**
@@ -736,8 +625,6 @@ end:
 static int StreamTcpSackTest10 (void)
 {
     TcpStream stream;
-    int retval = 0;
-
     memset(&stream, 0, sizeof(stream));
     stream.window = 1000;
 
@@ -750,28 +637,18 @@ static int StreamTcpSackTest10 (void)
     StreamTcpSackPrintList(&stream);
 #endif /* DEBUG */
 
-    if (stream.sack_head->le != 100) {
-        goto end;
-    }
-
-    if (StreamTcpSackedSize(&stream) != 40) {
-        printf("size should be 40, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
+    StreamTcpSackRecord *rec = RB_MIN(TCPSACK, &stream.sack_tree);
+    FAIL_IF_NULL(rec);
+    FAIL_IF(rec->le != 100);
+    FAIL_IF(rec->re != 140);
+    FAIL_IF(StreamTcpSackedSize(&stream) != 40);
 
     stream.last_ack = 99;
-
     StreamTcpSackPruneList(&stream);
+    FAIL_IF(StreamTcpSackedSize(&stream) != 40);
 
-    if (StreamTcpSackedSize(&stream) != 40) {
-        printf("size should be 40, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
-
-    retval = 1;
-end:
     StreamTcpSackFreeList(&stream);
-    SCReturnInt(retval);
+    PASS;
 }
 
 /**
@@ -783,8 +660,6 @@ end:
 static int StreamTcpSackTest11 (void)
 {
     TcpStream stream;
-    int retval = 0;
-
     memset(&stream, 0, sizeof(stream));
     stream.window = 1000;
 
@@ -797,28 +672,18 @@ static int StreamTcpSackTest11 (void)
     StreamTcpSackPrintList(&stream);
 #endif /* DEBUG */
 
-    if (stream.sack_head->le != 100) {
-        goto end;
-    }
-
-    if (StreamTcpSackedSize(&stream) != 40) {
-        printf("size should be 40, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
+    StreamTcpSackRecord *rec = RB_MIN(TCPSACK, &stream.sack_tree);
+    FAIL_IF_NULL(rec);
+    FAIL_IF(rec->le != 100);
+    FAIL_IF(rec->re != 140);
+    FAIL_IF(StreamTcpSackedSize(&stream) != 40);
 
     stream.last_ack = 99;
-
     StreamTcpSackPruneList(&stream);
+    FAIL_IF(StreamTcpSackedSize(&stream) != 40);
 
-    if (StreamTcpSackedSize(&stream) != 40) {
-        printf("size should be 40, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
-
-    retval = 1;
-end:
     StreamTcpSackFreeList(&stream);
-    SCReturnInt(retval);
+    PASS;
 }
 
 /**
@@ -830,8 +695,6 @@ end:
 static int StreamTcpSackTest12 (void)
 {
     TcpStream stream;
-    int retval = 0;
-
     memset(&stream, 0, sizeof(stream));
     stream.window = 2000;
 
@@ -844,35 +707,21 @@ static int StreamTcpSackTest12 (void)
     StreamTcpSackPrintList(&stream);
 #endif /* DEBUG */
 
-    if (stream.sack_head->le != 100) {
-        goto end;
-    }
-
-    if (StreamTcpSackedSize(&stream) != 900) {
-        printf("size should be 900, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
+    StreamTcpSackRecord *rec = RB_MIN(TCPSACK, &stream.sack_tree);
+    FAIL_IF_NULL(rec);
+    FAIL_IF(rec->le != 100);
+    FAIL_IF(rec->re != 1000);
+    FAIL_IF(StreamTcpSackedSize(&stream) != 900);
 
     StreamTcpSackInsertRange(&stream, 0, 1000);
-
-    if (StreamTcpSackedSize(&stream) != 1000) {
-        printf("size should be 1000, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
+    FAIL_IF(StreamTcpSackedSize(&stream) != 1000);
 
     stream.last_ack = 500;
-
     StreamTcpSackPruneList(&stream);
+    FAIL_IF(StreamTcpSackedSize(&stream) != 500);
 
-    if (StreamTcpSackedSize(&stream) != 500) {
-        printf("size should be 500, is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
-
-    retval = 1;
-end:
     StreamTcpSackFreeList(&stream);
-    SCReturnInt(retval);
+    PASS;
 }
 
 /**
@@ -883,29 +732,21 @@ end:
 
 static int StreamTcpSackTest13 (void) {
     TcpStream stream;
-    int retval = 0;
-    int i;
-
     memset(&stream, 0, sizeof(stream));
     stream.last_ack = 10000;
     stream.window = 2000;
 
-    for (i = 0; i < 10; i++) {
+    for (int i = 0; i < 10; i++) {
         StreamTcpSackInsertRange(&stream, 100+(20*i), 110+(20*i));
     }
 #ifdef DEBUG
     StreamTcpSackPrintList(&stream);
 #endif /* DEBUG */
 
-    if (StreamTcpSackedSize(&stream) != 0) {
-        printf("Sacked size is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
+    FAIL_IF(StreamTcpSackedSize(&stream) != 0);
 
-    retval = 1;
-end:
     StreamTcpSackFreeList(&stream);
-    SCReturnInt(retval);
+    PASS;
 }
 
 /**
@@ -916,29 +757,21 @@ end:
 
 static int StreamTcpSackTest14 (void) {
     TcpStream stream;
-    int retval = 0;
-    int i;
-
     memset(&stream, 0, sizeof(stream));
     stream.last_ack = 1000;
     stream.window = 2000;
 
-    for (i = 0; i < 10; i++) {
+    for (int i = 0; i < 10; i++) {
         StreamTcpSackInsertRange(&stream, 4000+(20*i), 4010+(20*i));
     }
 #ifdef DEBUG
     StreamTcpSackPrintList(&stream);
 #endif /* DEBUG */
 
-    if (StreamTcpSackedSize(&stream) != 0) {
-        printf("Sacked size is %u: ", StreamTcpSackedSize(&stream));
-        goto end;
-    }
+    FAIL_IF(StreamTcpSackedSize(&stream) != 0);
 
-    retval = 1;
-end:
     StreamTcpSackFreeList(&stream);
-    SCReturnInt(retval);
+    PASS;
 }
 
 #endif /* UNITTESTS */

--- a/src/stream-tcp-sack.h
+++ b/src/stream-tcp-sack.h
@@ -33,25 +33,10 @@
  *  \param stream Stream to get the size for.
  *
  *  \retval size the size
- *
- *  Optimized for case where SACK is not in use in the
- *  stream, as it *should* only be used in case of packet
- *  loss.
  */
 static inline uint32_t StreamTcpSackedSize(TcpStream *stream)
 {
-    if (likely(RB_EMPTY(&stream->sack_tree))) {
-        SCReturnUInt(0U);
-    } else {
-        uint32_t size = 0;
-
-        StreamTcpSackRecord *rec = NULL;
-        RB_FOREACH(rec, TCPSACK, &stream->sack_tree) {
-            size += (rec->re - rec->le);
-        }
-
-        SCReturnUInt(size);
-    }
+    SCReturnUInt(stream->sack_size);
 }
 
 int StreamTcpSackUpdatePacket(TcpStream *, Packet *);

--- a/src/stream-tcp-sack.h
+++ b/src/stream-tcp-sack.h
@@ -40,14 +40,13 @@
  */
 static inline uint32_t StreamTcpSackedSize(TcpStream *stream)
 {
-    if (likely(stream->sack_head == NULL)) {
+    if (likely(RB_EMPTY(&stream->sack_tree))) {
         SCReturnUInt(0U);
     } else {
         uint32_t size = 0;
 
         StreamTcpSackRecord *rec = NULL;
-
-        for (rec = stream->sack_head; rec != NULL; rec = rec->next) {
+        RB_FOREACH(rec, TCPSACK, &stream->sack_tree) {
             size += (rec->re - rec->le);
         }
 

--- a/src/stream-tcp-util.c
+++ b/src/stream-tcp-util.c
@@ -180,102 +180,64 @@ end:
 
 static int StreamTcpUtilStreamTest01(void)
 {
-    int ret = 0;
     TcpReassemblyThreadCtx *ra_ctx = NULL;
-    ThreadVars tv;
     TcpStream stream;
-
+    ThreadVars tv;
     memset(&tv, 0x00, sizeof(tv));
 
     StreamTcpUTInit(&ra_ctx);
     StreamTcpUTSetupStream(&stream, 1);
 
-    if (StreamTcpUTAddSegmentWithByte(&tv, ra_ctx, &stream,  2, 'A', 5) == -1) {
-        printf("failed to add segment 1: ");
-        goto end;
-    }
-    if (StreamTcpUTAddSegmentWithByte(&tv, ra_ctx, &stream,  7, 'B', 5) == -1) {
-        printf("failed to add segment 2: ");
-        goto end;
-    }
-    if (StreamTcpUTAddSegmentWithByte(&tv, ra_ctx, &stream, 12, 'C', 5) == -1) {
-        printf("failed to add segment 3: ");
-        goto end;
-    }
+    FAIL_IF(StreamTcpUTAddSegmentWithByte(&tv, ra_ctx, &stream,  2, 'A', 5) == -1);
+    FAIL_IF(StreamTcpUTAddSegmentWithByte(&tv, ra_ctx, &stream,  7, 'B', 5) == -1);
+    FAIL_IF(StreamTcpUTAddSegmentWithByte(&tv, ra_ctx, &stream, 12, 'C', 5) == -1);
 
-    TcpSegment *seg = stream.seg_list;
-    if (seg->seq != 2) {
-        printf("first seg in the list should have seq 2: ");
-        goto end;
-    }
+    TcpSegment *seg = RB_MIN(TCPSEG, &stream.seg_tree);
+    FAIL_IF_NULL(seg);
+    FAIL_IF(seg->seq != 2);
 
-    seg = seg->next;
-    if (seg->seq != 7) {
-        printf("first seg in the list should have seq 7: ");
-        goto end;
-    }
+    seg = TCPSEG_RB_NEXT(seg);
+    FAIL_IF_NULL(seg);
+    FAIL_IF(seg->seq != 7);
 
-    seg = seg->next;
-    if (seg->seq != 12) {
-        printf("first seg in the list should have seq 12: ");
-        goto end;
-    }
+    seg = TCPSEG_RB_NEXT(seg);
+    FAIL_IF_NULL(seg);
+    FAIL_IF(seg->seq != 12);
 
-    ret = 1;
-end:
     StreamTcpUTClearStream(&stream);
     StreamTcpUTDeinit(ra_ctx);
-    return ret;
+    PASS;
 }
 
 static int StreamTcpUtilStreamTest02(void)
 {
-    int ret = 0;
     TcpReassemblyThreadCtx *ra_ctx = NULL;
-    ThreadVars tv;
     TcpStream stream;
-
+    ThreadVars tv;
     memset(&tv, 0x00, sizeof(tv));
 
     StreamTcpUTInit(&ra_ctx);
     StreamTcpUTSetupStream(&stream, 1);
 
-    if (StreamTcpUTAddSegmentWithByte(&tv, ra_ctx, &stream,  7, 'B', 5) == -1) {
-        printf("failed to add segment 2: ");
-        goto end;
-    }
-    if (StreamTcpUTAddSegmentWithByte(&tv, ra_ctx, &stream, 12, 'C', 5) == -1) {
-        printf("failed to add segment 3: ");
-        goto end;
-    }
-    if (StreamTcpUTAddSegmentWithByte(&tv, ra_ctx, &stream,  2, 'A', 5) == -1) {
-        printf("failed to add segment 1: ");
-        goto end;
-    }
+    FAIL_IF(StreamTcpUTAddSegmentWithByte(&tv, ra_ctx, &stream,  7, 'B', 5) == -1);
+    FAIL_IF(StreamTcpUTAddSegmentWithByte(&tv, ra_ctx, &stream, 12, 'C', 5) == -1);
+    FAIL_IF(StreamTcpUTAddSegmentWithByte(&tv, ra_ctx, &stream,  2, 'A', 5) == -1);
 
-    TcpSegment *seg = stream.seg_list;
-    if (seg->seq != 2) {
-        printf("first seg in the list should have seq 2: ");
-        goto end;
-    }
+    TcpSegment *seg = RB_MIN(TCPSEG, &stream.seg_tree);
+    FAIL_IF_NULL(seg);
+    FAIL_IF(seg->seq != 2);
 
-    seg = seg->next;
-    if (seg->seq != 7) {
-        printf("first seg in the list should have seq 7: ");
-        goto end;
-    }
+    seg = TCPSEG_RB_NEXT(seg);
+    FAIL_IF_NULL(seg);
+    FAIL_IF(seg->seq != 7);
 
-    seg = seg->next;
-    if (seg->seq != 12) {
-        printf("first seg in the list should have seq 12: ");
-        goto end;
-    }
+    seg = TCPSEG_RB_NEXT(seg);
+    FAIL_IF_NULL(seg);
+    FAIL_IF(seg->seq != 12);
 
-    ret = 1;
-end:
     StreamTcpUTClearStream(&stream);
     StreamTcpUTDeinit(ra_ctx);
-    return ret;
+    PASS;
 }
 
 #endif

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -2399,9 +2399,8 @@ static inline uint32_t StreamTcpResetGetMaxAck(TcpStream *stream, uint32_t seq)
 {
     uint32_t ack = seq;
 
-    const TcpSegment *seg = RB_MAX(TCPSEG, &stream->seg_tree);
-    if (seg != NULL) {
-        const uint32_t tail_seq = seg->seq + TCP_SEG_LEN(seg);
+    if (STREAM_HAS_SEEN_DATA(stream)) {
+        const uint32_t tail_seq = STREAM_SEQ_RIGHT_EDGE(stream);
         if (SEQ_GT(tail_seq, ack)) {
             ack = tail_seq;
         }

--- a/src/tree.h
+++ b/src/tree.h
@@ -1,0 +1,801 @@
+/*	$NetBSD: tree.h,v 1.8 2004/03/28 19:38:30 provos Exp $	*/
+/*	$OpenBSD: tree.h,v 1.7 2002/10/17 21:51:54 art Exp $	*/
+/* $FreeBSD$ */
+
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright 2002 Niels Provos <provos@citi.umich.edu>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef	_SYS_TREE_H_
+#define	_SYS_TREE_H_
+
+/*
+ * This file defines data structures for different types of trees:
+ * splay trees and red-black trees.
+ *
+ * A splay tree is a self-organizing data structure.  Every operation
+ * on the tree causes a splay to happen.  The splay moves the requested
+ * node to the root of the tree and partly rebalances it.
+ *
+ * This has the benefit that request locality causes faster lookups as
+ * the requested nodes move to the top of the tree.  On the other hand,
+ * every lookup causes memory writes.
+ *
+ * The Balance Theorem bounds the total access time for m operations
+ * and n inserts on an initially empty tree as O((m + n)lg n).  The
+ * amortized cost for a sequence of m accesses to a splay tree is O(lg n);
+ *
+ * A red-black tree is a binary search tree with the node color as an
+ * extra attribute.  It fulfills a set of conditions:
+ *	- every search path from the root to a leaf consists of the
+ *	  same number of black nodes,
+ *	- each red node (except for the root) has a black parent,
+ *	- each leaf node is black.
+ *
+ * Every operation on a red-black tree is bounded as O(lg n).
+ * The maximum height of a red-black tree is 2lg (n+1).
+ */
+
+#define SPLAY_HEAD(name, type)						\
+struct name {								\
+	struct type *sph_root; /* root of the tree */			\
+}
+
+#define SPLAY_INITIALIZER(root)						\
+	{ NULL }
+
+#define SPLAY_INIT(root) do {						\
+	(root)->sph_root = NULL;					\
+} while (/*CONSTCOND*/ 0)
+
+#define SPLAY_ENTRY(type)						\
+struct {								\
+	struct type *spe_left; /* left element */			\
+	struct type *spe_right; /* right element */			\
+}
+
+#define SPLAY_LEFT(elm, field)		(elm)->field.spe_left
+#define SPLAY_RIGHT(elm, field)		(elm)->field.spe_right
+#define SPLAY_ROOT(head)		(head)->sph_root
+#define SPLAY_EMPTY(head)		(SPLAY_ROOT(head) == NULL)
+
+/* SPLAY_ROTATE_{LEFT,RIGHT} expect that tmp hold SPLAY_{RIGHT,LEFT} */
+#define SPLAY_ROTATE_RIGHT(head, tmp, field) do {			\
+	SPLAY_LEFT((head)->sph_root, field) = SPLAY_RIGHT(tmp, field);	\
+	SPLAY_RIGHT(tmp, field) = (head)->sph_root;			\
+	(head)->sph_root = tmp;						\
+} while (/*CONSTCOND*/ 0)
+
+#define SPLAY_ROTATE_LEFT(head, tmp, field) do {			\
+	SPLAY_RIGHT((head)->sph_root, field) = SPLAY_LEFT(tmp, field);	\
+	SPLAY_LEFT(tmp, field) = (head)->sph_root;			\
+	(head)->sph_root = tmp;						\
+} while (/*CONSTCOND*/ 0)
+
+#define SPLAY_LINKLEFT(head, tmp, field) do {				\
+	SPLAY_LEFT(tmp, field) = (head)->sph_root;			\
+	tmp = (head)->sph_root;						\
+	(head)->sph_root = SPLAY_LEFT((head)->sph_root, field);		\
+} while (/*CONSTCOND*/ 0)
+
+#define SPLAY_LINKRIGHT(head, tmp, field) do {				\
+	SPLAY_RIGHT(tmp, field) = (head)->sph_root;			\
+	tmp = (head)->sph_root;						\
+	(head)->sph_root = SPLAY_RIGHT((head)->sph_root, field);	\
+} while (/*CONSTCOND*/ 0)
+
+#define SPLAY_ASSEMBLE(head, node, left, right, field) do {		\
+	SPLAY_RIGHT(left, field) = SPLAY_LEFT((head)->sph_root, field);	\
+	SPLAY_LEFT(right, field) = SPLAY_RIGHT((head)->sph_root, field);\
+	SPLAY_LEFT((head)->sph_root, field) = SPLAY_RIGHT(node, field);	\
+	SPLAY_RIGHT((head)->sph_root, field) = SPLAY_LEFT(node, field);	\
+} while (/*CONSTCOND*/ 0)
+
+/* Generates prototypes and inline functions */
+
+#define SPLAY_PROTOTYPE(name, type, field, cmp)				\
+void name##_SPLAY(struct name *, struct type *);			\
+void name##_SPLAY_MINMAX(struct name *, int);				\
+struct type *name##_SPLAY_INSERT(struct name *, struct type *);		\
+struct type *name##_SPLAY_REMOVE(struct name *, struct type *);		\
+									\
+/* Finds the node with the same key as elm */				\
+static __inline struct type *						\
+name##_SPLAY_FIND(struct name *head, struct type *elm)			\
+{									\
+	if (SPLAY_EMPTY(head))						\
+		return(NULL);						\
+	name##_SPLAY(head, elm);					\
+	if ((cmp)(elm, (head)->sph_root) == 0)				\
+		return (head->sph_root);				\
+	return (NULL);							\
+}									\
+									\
+static __inline struct type *						\
+name##_SPLAY_NEXT(struct name *head, struct type *elm)			\
+{									\
+	name##_SPLAY(head, elm);					\
+	if (SPLAY_RIGHT(elm, field) != NULL) {				\
+		elm = SPLAY_RIGHT(elm, field);				\
+		while (SPLAY_LEFT(elm, field) != NULL) {		\
+			elm = SPLAY_LEFT(elm, field);			\
+		}							\
+	} else								\
+		elm = NULL;						\
+	return (elm);							\
+}									\
+									\
+static __inline struct type *						\
+name##_SPLAY_MIN_MAX(struct name *head, int val)			\
+{									\
+	name##_SPLAY_MINMAX(head, val);					\
+        return (SPLAY_ROOT(head));					\
+}
+
+/* Main splay operation.
+ * Moves node close to the key of elm to top
+ */
+#define SPLAY_GENERATE(name, type, field, cmp)				\
+struct type *								\
+name##_SPLAY_INSERT(struct name *head, struct type *elm)		\
+{									\
+    if (SPLAY_EMPTY(head)) {						\
+	    SPLAY_LEFT(elm, field) = SPLAY_RIGHT(elm, field) = NULL;	\
+    } else {								\
+	    int __comp;							\
+	    name##_SPLAY(head, elm);					\
+	    __comp = (cmp)(elm, (head)->sph_root);			\
+	    if(__comp < 0) {						\
+		    SPLAY_LEFT(elm, field) = SPLAY_LEFT((head)->sph_root, field);\
+		    SPLAY_RIGHT(elm, field) = (head)->sph_root;		\
+		    SPLAY_LEFT((head)->sph_root, field) = NULL;		\
+	    } else if (__comp > 0) {					\
+		    SPLAY_RIGHT(elm, field) = SPLAY_RIGHT((head)->sph_root, field);\
+		    SPLAY_LEFT(elm, field) = (head)->sph_root;		\
+		    SPLAY_RIGHT((head)->sph_root, field) = NULL;	\
+	    } else							\
+		    return ((head)->sph_root);				\
+    }									\
+    (head)->sph_root = (elm);						\
+    return (NULL);							\
+}									\
+									\
+struct type *								\
+name##_SPLAY_REMOVE(struct name *head, struct type *elm)		\
+{									\
+	struct type *__tmp;						\
+	if (SPLAY_EMPTY(head))						\
+		return (NULL);						\
+	name##_SPLAY(head, elm);					\
+	if ((cmp)(elm, (head)->sph_root) == 0) {			\
+		if (SPLAY_LEFT((head)->sph_root, field) == NULL) {	\
+			(head)->sph_root = SPLAY_RIGHT((head)->sph_root, field);\
+		} else {						\
+			__tmp = SPLAY_RIGHT((head)->sph_root, field);	\
+			(head)->sph_root = SPLAY_LEFT((head)->sph_root, field);\
+			name##_SPLAY(head, elm);			\
+			SPLAY_RIGHT((head)->sph_root, field) = __tmp;	\
+		}							\
+		return (elm);						\
+	}								\
+	return (NULL);							\
+}									\
+									\
+void									\
+name##_SPLAY(struct name *head, struct type *elm)			\
+{									\
+	struct type __node, *__left, *__right, *__tmp;			\
+	int __comp;							\
+\
+	SPLAY_LEFT(&__node, field) = SPLAY_RIGHT(&__node, field) = NULL;\
+	__left = __right = &__node;					\
+\
+	while ((__comp = (cmp)(elm, (head)->sph_root)) != 0) {		\
+		if (__comp < 0) {					\
+			__tmp = SPLAY_LEFT((head)->sph_root, field);	\
+			if (__tmp == NULL)				\
+				break;					\
+			if ((cmp)(elm, __tmp) < 0){			\
+				SPLAY_ROTATE_RIGHT(head, __tmp, field);	\
+				if (SPLAY_LEFT((head)->sph_root, field) == NULL)\
+					break;				\
+			}						\
+			SPLAY_LINKLEFT(head, __right, field);		\
+		} else if (__comp > 0) {				\
+			__tmp = SPLAY_RIGHT((head)->sph_root, field);	\
+			if (__tmp == NULL)				\
+				break;					\
+			if ((cmp)(elm, __tmp) > 0){			\
+				SPLAY_ROTATE_LEFT(head, __tmp, field);	\
+				if (SPLAY_RIGHT((head)->sph_root, field) == NULL)\
+					break;				\
+			}						\
+			SPLAY_LINKRIGHT(head, __left, field);		\
+		}							\
+	}								\
+	SPLAY_ASSEMBLE(head, &__node, __left, __right, field);		\
+}									\
+									\
+/* Splay with either the minimum or the maximum element			\
+ * Used to find minimum or maximum element in tree.			\
+ */									\
+void name##_SPLAY_MINMAX(struct name *head, int __comp) \
+{									\
+	struct type __node, *__left, *__right, *__tmp;			\
+\
+	SPLAY_LEFT(&__node, field) = SPLAY_RIGHT(&__node, field) = NULL;\
+	__left = __right = &__node;					\
+\
+	while (1) {							\
+		if (__comp < 0) {					\
+			__tmp = SPLAY_LEFT((head)->sph_root, field);	\
+			if (__tmp == NULL)				\
+				break;					\
+			if (__comp < 0){				\
+				SPLAY_ROTATE_RIGHT(head, __tmp, field);	\
+				if (SPLAY_LEFT((head)->sph_root, field) == NULL)\
+					break;				\
+			}						\
+			SPLAY_LINKLEFT(head, __right, field);		\
+		} else if (__comp > 0) {				\
+			__tmp = SPLAY_RIGHT((head)->sph_root, field);	\
+			if (__tmp == NULL)				\
+				break;					\
+			if (__comp > 0) {				\
+				SPLAY_ROTATE_LEFT(head, __tmp, field);	\
+				if (SPLAY_RIGHT((head)->sph_root, field) == NULL)\
+					break;				\
+			}						\
+			SPLAY_LINKRIGHT(head, __left, field);		\
+		}							\
+	}								\
+	SPLAY_ASSEMBLE(head, &__node, __left, __right, field);		\
+}
+
+#define SPLAY_NEGINF	-1
+#define SPLAY_INF	1
+
+#define SPLAY_INSERT(name, x, y)	name##_SPLAY_INSERT(x, y)
+#define SPLAY_REMOVE(name, x, y)	name##_SPLAY_REMOVE(x, y)
+#define SPLAY_FIND(name, x, y)		name##_SPLAY_FIND(x, y)
+#define SPLAY_NEXT(name, x, y)		name##_SPLAY_NEXT(x, y)
+#define SPLAY_MIN(name, x)		(SPLAY_EMPTY(x) ? NULL	\
+					: name##_SPLAY_MIN_MAX(x, SPLAY_NEGINF))
+#define SPLAY_MAX(name, x)		(SPLAY_EMPTY(x) ? NULL	\
+					: name##_SPLAY_MIN_MAX(x, SPLAY_INF))
+
+#define SPLAY_FOREACH(x, name, head)					\
+	for ((x) = SPLAY_MIN(name, head);				\
+	     (x) != NULL;						\
+	     (x) = SPLAY_NEXT(name, head, x))
+
+/* Macros that define a red-black tree */
+#define RB_HEAD(name, type)						\
+struct name {								\
+	struct type *rbh_root; /* root of the tree */			\
+}
+
+#define RB_INITIALIZER(root)						\
+	{ NULL }
+
+#define RB_INIT(root) do {						\
+	(root)->rbh_root = NULL;					\
+} while (/*CONSTCOND*/ 0)
+
+#define RB_BLACK	0
+#define RB_RED		1
+#define RB_ENTRY(type)							\
+struct {								\
+	struct type *rbe_left;		/* left element */		\
+	struct type *rbe_right;		/* right element */		\
+	struct type *rbe_parent;	/* parent element */		\
+	int rbe_color;			/* node color */		\
+}
+
+#define RB_LEFT(elm, field)		(elm)->field.rbe_left
+#define RB_RIGHT(elm, field)		(elm)->field.rbe_right
+#define RB_PARENT(elm, field)		(elm)->field.rbe_parent
+#define RB_COLOR(elm, field)		(elm)->field.rbe_color
+#define RB_ROOT(head)			(head)->rbh_root
+#define RB_EMPTY(head)			(RB_ROOT(head) == NULL)
+
+#define RB_SET(elm, parent, field) do {					\
+	RB_PARENT(elm, field) = parent;					\
+	RB_LEFT(elm, field) = RB_RIGHT(elm, field) = NULL;		\
+	RB_COLOR(elm, field) = RB_RED;					\
+} while (/*CONSTCOND*/ 0)
+
+#define RB_SET_BLACKRED(black, red, field) do {				\
+	RB_COLOR(black, field) = RB_BLACK;				\
+	RB_COLOR(red, field) = RB_RED;					\
+} while (/*CONSTCOND*/ 0)
+
+#ifndef RB_AUGMENT
+#define RB_AUGMENT(x)	do {} while (0)
+#endif
+
+#define RB_ROTATE_LEFT(head, elm, tmp, field) do {			\
+	(tmp) = RB_RIGHT(elm, field);					\
+	if ((RB_RIGHT(elm, field) = RB_LEFT(tmp, field)) != NULL) {	\
+		RB_PARENT(RB_LEFT(tmp, field), field) = (elm);		\
+	}								\
+	RB_AUGMENT(elm);						\
+	if ((RB_PARENT(tmp, field) = RB_PARENT(elm, field)) != NULL) {	\
+		if ((elm) == RB_LEFT(RB_PARENT(elm, field), field))	\
+			RB_LEFT(RB_PARENT(elm, field), field) = (tmp);	\
+		else							\
+			RB_RIGHT(RB_PARENT(elm, field), field) = (tmp);	\
+	} else								\
+		(head)->rbh_root = (tmp);				\
+	RB_LEFT(tmp, field) = (elm);					\
+	RB_PARENT(elm, field) = (tmp);					\
+	RB_AUGMENT(tmp);						\
+	if ((RB_PARENT(tmp, field)))					\
+		RB_AUGMENT(RB_PARENT(tmp, field));			\
+} while (/*CONSTCOND*/ 0)
+
+#define RB_ROTATE_RIGHT(head, elm, tmp, field) do {			\
+	(tmp) = RB_LEFT(elm, field);					\
+	if ((RB_LEFT(elm, field) = RB_RIGHT(tmp, field)) != NULL) {	\
+		RB_PARENT(RB_RIGHT(tmp, field), field) = (elm);		\
+	}								\
+	RB_AUGMENT(elm);						\
+	if ((RB_PARENT(tmp, field) = RB_PARENT(elm, field)) != NULL) {	\
+		if ((elm) == RB_LEFT(RB_PARENT(elm, field), field))	\
+			RB_LEFT(RB_PARENT(elm, field), field) = (tmp);	\
+		else							\
+			RB_RIGHT(RB_PARENT(elm, field), field) = (tmp);	\
+	} else								\
+		(head)->rbh_root = (tmp);				\
+	RB_RIGHT(tmp, field) = (elm);					\
+	RB_PARENT(elm, field) = (tmp);					\
+	RB_AUGMENT(tmp);						\
+	if ((RB_PARENT(tmp, field)))					\
+		RB_AUGMENT(RB_PARENT(tmp, field));			\
+} while (/*CONSTCOND*/ 0)
+
+/* Generates prototypes and inline functions */
+#define	RB_PROTOTYPE(name, type, field, cmp)				\
+	RB_PROTOTYPE_INTERNAL(name, type, field, cmp,)
+#define	RB_PROTOTYPE_STATIC(name, type, field, cmp)			\
+	RB_PROTOTYPE_INTERNAL(name, type, field, cmp, __unused static)
+#define RB_PROTOTYPE_INTERNAL(name, type, field, cmp, attr)		\
+	RB_PROTOTYPE_INSERT_COLOR(name, type, attr);			\
+	RB_PROTOTYPE_REMOVE_COLOR(name, type, attr);			\
+	RB_PROTOTYPE_INSERT(name, type, attr);				\
+	RB_PROTOTYPE_REMOVE(name, type, attr);				\
+	RB_PROTOTYPE_FIND(name, type, attr);				\
+	RB_PROTOTYPE_NFIND(name, type, attr);				\
+	RB_PROTOTYPE_NEXT(name, type, attr);				\
+	RB_PROTOTYPE_PREV(name, type, attr);				\
+	RB_PROTOTYPE_MINMAX(name, type, attr);
+#define RB_PROTOTYPE_INSERT_COLOR(name, type, attr)			\
+	attr void name##_RB_INSERT_COLOR(struct name *, struct type *)
+#define RB_PROTOTYPE_REMOVE_COLOR(name, type, attr)			\
+	attr void name##_RB_REMOVE_COLOR(struct name *, struct type *, struct type *)
+#define RB_PROTOTYPE_REMOVE(name, type, attr)				\
+	attr struct type *name##_RB_REMOVE(struct name *, struct type *)
+#define RB_PROTOTYPE_INSERT(name, type, attr)				\
+	attr struct type *name##_RB_INSERT(struct name *, struct type *)
+#define RB_PROTOTYPE_FIND(name, type, attr)				\
+	attr struct type *name##_RB_FIND(struct name *, struct type *)
+#define RB_PROTOTYPE_NFIND(name, type, attr)				\
+	attr struct type *name##_RB_NFIND(struct name *, struct type *)
+#define RB_PROTOTYPE_NEXT(name, type, attr)				\
+	attr struct type *name##_RB_NEXT(struct type *)
+#define RB_PROTOTYPE_PREV(name, type, attr)				\
+	attr struct type *name##_RB_PREV(struct type *)
+#define RB_PROTOTYPE_MINMAX(name, type, attr)				\
+	attr struct type *name##_RB_MINMAX(struct name *, int)
+
+/* Main rb operation.
+ * Moves node close to the key of elm to top
+ */
+#define	RB_GENERATE(name, type, field, cmp)				\
+	RB_GENERATE_INTERNAL(name, type, field, cmp,)
+#define	RB_GENERATE_STATIC(name, type, field, cmp)			\
+	RB_GENERATE_INTERNAL(name, type, field, cmp, __unused static)
+#define RB_GENERATE_INTERNAL(name, type, field, cmp, attr)		\
+	RB_GENERATE_INSERT_COLOR(name, type, field, attr)		\
+	RB_GENERATE_REMOVE_COLOR(name, type, field, attr)		\
+	RB_GENERATE_INSERT(name, type, field, cmp, attr)		\
+	RB_GENERATE_REMOVE(name, type, field, attr)			\
+	RB_GENERATE_FIND(name, type, field, cmp, attr)			\
+	RB_GENERATE_NFIND(name, type, field, cmp, attr)			\
+	RB_GENERATE_NEXT(name, type, field, attr)			\
+	RB_GENERATE_PREV(name, type, field, attr)			\
+	RB_GENERATE_MINMAX(name, type, field, attr)
+
+#define RB_GENERATE_INSERT_COLOR(name, type, field, attr)		\
+attr void								\
+name##_RB_INSERT_COLOR(struct name *head, struct type *elm)		\
+{									\
+	struct type *parent, *gparent, *tmp;				\
+	while ((parent = RB_PARENT(elm, field)) != NULL &&		\
+	    RB_COLOR(parent, field) == RB_RED) {			\
+		gparent = RB_PARENT(parent, field);			\
+		if (parent == RB_LEFT(gparent, field)) {		\
+			tmp = RB_RIGHT(gparent, field);			\
+			if (tmp && RB_COLOR(tmp, field) == RB_RED) {	\
+				RB_COLOR(tmp, field) = RB_BLACK;	\
+				RB_SET_BLACKRED(parent, gparent, field);\
+				elm = gparent;				\
+				continue;				\
+			}						\
+			if (RB_RIGHT(parent, field) == elm) {		\
+				RB_ROTATE_LEFT(head, parent, tmp, field);\
+				tmp = parent;				\
+				parent = elm;				\
+				elm = tmp;				\
+			}						\
+			RB_SET_BLACKRED(parent, gparent, field);	\
+			RB_ROTATE_RIGHT(head, gparent, tmp, field);	\
+		} else {						\
+			tmp = RB_LEFT(gparent, field);			\
+			if (tmp && RB_COLOR(tmp, field) == RB_RED) {	\
+				RB_COLOR(tmp, field) = RB_BLACK;	\
+				RB_SET_BLACKRED(parent, gparent, field);\
+				elm = gparent;				\
+				continue;				\
+			}						\
+			if (RB_LEFT(parent, field) == elm) {		\
+				RB_ROTATE_RIGHT(head, parent, tmp, field);\
+				tmp = parent;				\
+				parent = elm;				\
+				elm = tmp;				\
+			}						\
+			RB_SET_BLACKRED(parent, gparent, field);	\
+			RB_ROTATE_LEFT(head, gparent, tmp, field);	\
+		}							\
+	}								\
+	RB_COLOR(head->rbh_root, field) = RB_BLACK;			\
+}
+
+#define RB_GENERATE_REMOVE_COLOR(name, type, field, attr)		\
+attr void								\
+name##_RB_REMOVE_COLOR(struct name *head, struct type *parent, struct type *elm) \
+{									\
+	struct type *tmp;						\
+	while ((elm == NULL || RB_COLOR(elm, field) == RB_BLACK) &&	\
+	    elm != RB_ROOT(head)) {					\
+		if (RB_LEFT(parent, field) == elm) {			\
+			tmp = RB_RIGHT(parent, field);			\
+			if (RB_COLOR(tmp, field) == RB_RED) {		\
+				RB_SET_BLACKRED(tmp, parent, field);	\
+				RB_ROTATE_LEFT(head, parent, tmp, field);\
+				tmp = RB_RIGHT(parent, field);		\
+			}						\
+			if ((RB_LEFT(tmp, field) == NULL ||		\
+			    RB_COLOR(RB_LEFT(tmp, field), field) == RB_BLACK) &&\
+			    (RB_RIGHT(tmp, field) == NULL ||		\
+			    RB_COLOR(RB_RIGHT(tmp, field), field) == RB_BLACK)) {\
+				RB_COLOR(tmp, field) = RB_RED;		\
+				elm = parent;				\
+				parent = RB_PARENT(elm, field);		\
+			} else {					\
+				if (RB_RIGHT(tmp, field) == NULL ||	\
+				    RB_COLOR(RB_RIGHT(tmp, field), field) == RB_BLACK) {\
+					struct type *oleft;		\
+					if ((oleft = RB_LEFT(tmp, field)) \
+					    != NULL)			\
+						RB_COLOR(oleft, field) = RB_BLACK;\
+					RB_COLOR(tmp, field) = RB_RED;	\
+					RB_ROTATE_RIGHT(head, tmp, oleft, field);\
+					tmp = RB_RIGHT(parent, field);	\
+				}					\
+				RB_COLOR(tmp, field) = RB_COLOR(parent, field);\
+				RB_COLOR(parent, field) = RB_BLACK;	\
+				if (RB_RIGHT(tmp, field))		\
+					RB_COLOR(RB_RIGHT(tmp, field), field) = RB_BLACK;\
+				RB_ROTATE_LEFT(head, parent, tmp, field);\
+				elm = RB_ROOT(head);			\
+				break;					\
+			}						\
+		} else {						\
+			tmp = RB_LEFT(parent, field);			\
+			if (RB_COLOR(tmp, field) == RB_RED) {		\
+				RB_SET_BLACKRED(tmp, parent, field);	\
+				RB_ROTATE_RIGHT(head, parent, tmp, field);\
+				tmp = RB_LEFT(parent, field);		\
+			}						\
+			if ((RB_LEFT(tmp, field) == NULL ||		\
+			    RB_COLOR(RB_LEFT(tmp, field), field) == RB_BLACK) &&\
+			    (RB_RIGHT(tmp, field) == NULL ||		\
+			    RB_COLOR(RB_RIGHT(tmp, field), field) == RB_BLACK)) {\
+				RB_COLOR(tmp, field) = RB_RED;		\
+				elm = parent;				\
+				parent = RB_PARENT(elm, field);		\
+			} else {					\
+				if (RB_LEFT(tmp, field) == NULL ||	\
+				    RB_COLOR(RB_LEFT(tmp, field), field) == RB_BLACK) {\
+					struct type *oright;		\
+					if ((oright = RB_RIGHT(tmp, field)) \
+					    != NULL)			\
+						RB_COLOR(oright, field) = RB_BLACK;\
+					RB_COLOR(tmp, field) = RB_RED;	\
+					RB_ROTATE_LEFT(head, tmp, oright, field);\
+					tmp = RB_LEFT(parent, field);	\
+				}					\
+				RB_COLOR(tmp, field) = RB_COLOR(parent, field);\
+				RB_COLOR(parent, field) = RB_BLACK;	\
+				if (RB_LEFT(tmp, field))		\
+					RB_COLOR(RB_LEFT(tmp, field), field) = RB_BLACK;\
+				RB_ROTATE_RIGHT(head, parent, tmp, field);\
+				elm = RB_ROOT(head);			\
+				break;					\
+			}						\
+		}							\
+	}								\
+	if (elm)							\
+		RB_COLOR(elm, field) = RB_BLACK;			\
+}
+
+#define RB_GENERATE_REMOVE(name, type, field, attr)			\
+attr struct type *							\
+name##_RB_REMOVE(struct name *head, struct type *elm)			\
+{									\
+	struct type *child, *parent, *old = elm;			\
+	int color;							\
+	if (RB_LEFT(elm, field) == NULL)				\
+		child = RB_RIGHT(elm, field);				\
+	else if (RB_RIGHT(elm, field) == NULL)				\
+		child = RB_LEFT(elm, field);				\
+	else {								\
+		struct type *left;					\
+		elm = RB_RIGHT(elm, field);				\
+		while ((left = RB_LEFT(elm, field)) != NULL)		\
+			elm = left;					\
+		child = RB_RIGHT(elm, field);				\
+		parent = RB_PARENT(elm, field);				\
+		color = RB_COLOR(elm, field);				\
+		if (child)						\
+			RB_PARENT(child, field) = parent;		\
+		if (parent) {						\
+			if (RB_LEFT(parent, field) == elm)		\
+				RB_LEFT(parent, field) = child;		\
+			else						\
+				RB_RIGHT(parent, field) = child;	\
+			RB_AUGMENT(parent);				\
+		} else							\
+			RB_ROOT(head) = child;				\
+		if (RB_PARENT(elm, field) == old)			\
+			parent = elm;					\
+		(elm)->field = (old)->field;				\
+		if (RB_PARENT(old, field)) {				\
+			if (RB_LEFT(RB_PARENT(old, field), field) == old)\
+				RB_LEFT(RB_PARENT(old, field), field) = elm;\
+			else						\
+				RB_RIGHT(RB_PARENT(old, field), field) = elm;\
+			RB_AUGMENT(RB_PARENT(old, field));		\
+		} else							\
+			RB_ROOT(head) = elm;				\
+		RB_PARENT(RB_LEFT(old, field), field) = elm;		\
+		if (RB_RIGHT(old, field))				\
+			RB_PARENT(RB_RIGHT(old, field), field) = elm;	\
+		if (parent) {						\
+			left = parent;					\
+			do {						\
+				RB_AUGMENT(left);			\
+			} while ((left = RB_PARENT(left, field)) != NULL); \
+		}							\
+		goto color;						\
+	}								\
+	parent = RB_PARENT(elm, field);					\
+	color = RB_COLOR(elm, field);					\
+	if (child)							\
+		RB_PARENT(child, field) = parent;			\
+	if (parent) {							\
+		if (RB_LEFT(parent, field) == elm)			\
+			RB_LEFT(parent, field) = child;			\
+		else							\
+			RB_RIGHT(parent, field) = child;		\
+		RB_AUGMENT(parent);					\
+	} else								\
+		RB_ROOT(head) = child;					\
+color:									\
+	if (color == RB_BLACK)						\
+		name##_RB_REMOVE_COLOR(head, parent, child);		\
+	return (old);							\
+}									\
+
+#define RB_GENERATE_INSERT(name, type, field, cmp, attr)		\
+/* Inserts a node into the RB tree */					\
+attr struct type *							\
+name##_RB_INSERT(struct name *head, struct type *elm)			\
+{									\
+	struct type *tmp;						\
+	struct type *parent = NULL;					\
+	int comp = 0;							\
+	tmp = RB_ROOT(head);						\
+	while (tmp) {							\
+		parent = tmp;						\
+		comp = (cmp)(elm, parent);				\
+		if (comp < 0)						\
+			tmp = RB_LEFT(tmp, field);			\
+		else if (comp > 0)					\
+			tmp = RB_RIGHT(tmp, field);			\
+		else							\
+			return (tmp);					\
+	}								\
+	RB_SET(elm, parent, field);					\
+	if (parent != NULL) {						\
+		if (comp < 0)						\
+			RB_LEFT(parent, field) = elm;			\
+		else							\
+			RB_RIGHT(parent, field) = elm;			\
+		RB_AUGMENT(parent);					\
+	} else								\
+		RB_ROOT(head) = elm;					\
+	name##_RB_INSERT_COLOR(head, elm);				\
+	return (NULL);							\
+}
+
+#define RB_GENERATE_FIND(name, type, field, cmp, attr)			\
+/* Finds the node with the same key as elm */				\
+attr struct type *							\
+name##_RB_FIND(struct name *head, struct type *elm)			\
+{									\
+	struct type *tmp = RB_ROOT(head);				\
+	int comp;							\
+	while (tmp) {							\
+		comp = cmp(elm, tmp);					\
+		if (comp < 0)						\
+			tmp = RB_LEFT(tmp, field);			\
+		else if (comp > 0)					\
+			tmp = RB_RIGHT(tmp, field);			\
+		else							\
+			return (tmp);					\
+	}								\
+	return (NULL);							\
+}
+
+#define RB_GENERATE_NFIND(name, type, field, cmp, attr)			\
+/* Finds the first node greater than or equal to the search key */	\
+attr struct type *							\
+name##_RB_NFIND(struct name *head, struct type *elm)			\
+{									\
+	struct type *tmp = RB_ROOT(head);				\
+	struct type *res = NULL;					\
+	int comp;							\
+	while (tmp) {							\
+		comp = cmp(elm, tmp);					\
+		if (comp < 0) {						\
+			res = tmp;					\
+			tmp = RB_LEFT(tmp, field);			\
+		}							\
+		else if (comp > 0)					\
+			tmp = RB_RIGHT(tmp, field);			\
+		else							\
+			return (tmp);					\
+	}								\
+	return (res);							\
+}
+
+#define RB_GENERATE_NEXT(name, type, field, attr)			\
+/* ARGSUSED */								\
+attr struct type *							\
+name##_RB_NEXT(struct type *elm)					\
+{									\
+	if (RB_RIGHT(elm, field)) {					\
+		elm = RB_RIGHT(elm, field);				\
+		while (RB_LEFT(elm, field))				\
+			elm = RB_LEFT(elm, field);			\
+	} else {							\
+		if (RB_PARENT(elm, field) &&				\
+		    (elm == RB_LEFT(RB_PARENT(elm, field), field)))	\
+			elm = RB_PARENT(elm, field);			\
+		else {							\
+			while (RB_PARENT(elm, field) &&			\
+			    (elm == RB_RIGHT(RB_PARENT(elm, field), field)))\
+				elm = RB_PARENT(elm, field);		\
+			elm = RB_PARENT(elm, field);			\
+		}							\
+	}								\
+	return (elm);							\
+}
+
+#define RB_GENERATE_PREV(name, type, field, attr)			\
+/* ARGSUSED */								\
+attr struct type *							\
+name##_RB_PREV(struct type *elm)					\
+{									\
+	if (RB_LEFT(elm, field)) {					\
+		elm = RB_LEFT(elm, field);				\
+		while (RB_RIGHT(elm, field))				\
+			elm = RB_RIGHT(elm, field);			\
+	} else {							\
+		if (RB_PARENT(elm, field) &&				\
+		    (elm == RB_RIGHT(RB_PARENT(elm, field), field)))	\
+			elm = RB_PARENT(elm, field);			\
+		else {							\
+			while (RB_PARENT(elm, field) &&			\
+			    (elm == RB_LEFT(RB_PARENT(elm, field), field)))\
+				elm = RB_PARENT(elm, field);		\
+			elm = RB_PARENT(elm, field);			\
+		}							\
+	}								\
+	return (elm);							\
+}
+
+#define RB_GENERATE_MINMAX(name, type, field, attr)			\
+attr struct type *							\
+name##_RB_MINMAX(struct name *head, int val)				\
+{									\
+	struct type *tmp = RB_ROOT(head);				\
+	struct type *parent = NULL;					\
+	while (tmp) {							\
+		parent = tmp;						\
+		if (val < 0)						\
+			tmp = RB_LEFT(tmp, field);			\
+		else							\
+			tmp = RB_RIGHT(tmp, field);			\
+	}								\
+	return (parent);						\
+}
+
+#define RB_NEGINF	-1
+#define RB_INF	1
+
+#define RB_INSERT(name, x, y)	name##_RB_INSERT(x, y)
+#define RB_REMOVE(name, x, y)	name##_RB_REMOVE(x, y)
+#define RB_FIND(name, x, y)	name##_RB_FIND(x, y)
+#define RB_NFIND(name, x, y)	name##_RB_NFIND(x, y)
+#define RB_NEXT(name, x, y)	name##_RB_NEXT(y)
+#define RB_PREV(name, x, y)	name##_RB_PREV(y)
+#define RB_MIN(name, x)		name##_RB_MINMAX(x, RB_NEGINF)
+#define RB_MAX(name, x)		name##_RB_MINMAX(x, RB_INF)
+
+#define RB_FOREACH(x, name, head)					\
+	for ((x) = RB_MIN(name, head);					\
+	     (x) != NULL;						\
+	     (x) = name##_RB_NEXT(x))
+
+#define RB_FOREACH_FROM(x, name, y)					\
+	for ((x) = (y);							\
+	    ((x) != NULL) && ((y) = name##_RB_NEXT(x), (x) != NULL);	\
+	     (x) = (y))
+
+#define RB_FOREACH_SAFE(x, name, head, y)				\
+	for ((x) = RB_MIN(name, head);					\
+	    ((x) != NULL) && ((y) = name##_RB_NEXT(x), (x) != NULL);	\
+	     (x) = (y))
+
+#define RB_FOREACH_REVERSE(x, name, head)				\
+	for ((x) = RB_MAX(name, head);					\
+	     (x) != NULL;						\
+	     (x) = name##_RB_PREV(x))
+
+#define RB_FOREACH_REVERSE_FROM(x, name, y)				\
+	for ((x) = (y);							\
+	    ((x) != NULL) && ((y) = name##_RB_PREV(x), (x) != NULL);	\
+	     (x) = (y))
+
+#define RB_FOREACH_REVERSE_SAFE(x, name, head, y)			\
+	for ((x) = RB_MAX(name, head);					\
+	    ((x) != NULL) && ((y) = name##_RB_PREV(x), (x) != NULL);	\
+	     (x) = (y))
+
+#endif	/* _SYS_TREE_H_ */

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -19,6 +19,7 @@
 #include "util-streaming-buffer.h"
 #include "util-unittest.h"
 #include "util-print.h"
+#include "util-validate.h"
 
 /**
  * \file
@@ -40,6 +41,63 @@
     (cfg)->Free ? (cfg)->Free((ptr), (s)) : SCFree((ptr))
 
 static void SBBFree(StreamingBuffer *sb);
+
+RB_GENERATE(SBB, StreamingBufferBlock, rb, SBBCompare);
+
+int SBBCompare(struct StreamingBufferBlock *a, struct StreamingBufferBlock *b)
+{
+    SCLogDebug("a %"PRIu64" len %u, b %"PRIu64" len %u",
+            a->offset, a->len, b->offset, b->len);
+
+    if (a->offset > b->offset)
+        SCReturnInt(1);
+    else if (a->offset < b->offset)
+        SCReturnInt(-1);
+    else {
+        if (a->len == 0 || b->len == 0 || a->len ==  b->len)
+            SCReturnInt(0);
+        else if (a->len > b->len)
+            SCReturnInt(1);
+        else
+            SCReturnInt(-1);
+    }
+}
+
+/* inclusive compare function that also considers the right edge,
+ * not just the offset. */
+static inline int InclusiveCompare(StreamingBufferBlock *lookup, StreamingBufferBlock *intree) {
+    const uint64_t lre = lookup->offset + lookup->len;
+    const uint64_t tre = intree->offset + intree->len;
+    if (lre < intree->offset)   // entirely before
+        return -1;
+    else if (lre >= intree->offset && lre <= tre)    // (some) overlap
+        return 0;
+    else
+        return 1;   // entirely after
+}
+
+StreamingBufferBlock *SBB_RB_FIND_INCLUSIVE(struct SBB *head, StreamingBufferBlock *elm)
+{
+    SCLogDebug("looking up %"PRIu64, elm->offset);
+
+    struct StreamingBufferBlock *tmp = RB_ROOT(head);
+    struct StreamingBufferBlock *res = NULL;
+    while (tmp) {
+        SCLogDebug("compare with %"PRIu64"/%u", tmp->offset, tmp->len);
+        const int comp = InclusiveCompare(elm, tmp);
+        SCLogDebug("compare result: %d", comp);
+        if (comp < 0) {
+            res = tmp;
+            tmp = RB_LEFT(tmp, rb);
+        } else if (comp > 0) {
+            tmp = RB_RIGHT(tmp, rb);
+        } else {
+            return tmp;
+        }
+    }
+    return res;
+}
+
 
 static inline int InitBuffer(StreamingBuffer *sb)
 {
@@ -93,19 +151,18 @@ void StreamingBufferFree(StreamingBuffer *sb)
 }
 
 #ifdef DEBUG
-static void SBBPrintList(const StreamingBuffer *sb)
+static void SBBPrintList(StreamingBuffer *sb)
 {
-    const StreamingBufferBlock *sbb = sb->block_list;
-    while (sbb) {
+    StreamingBufferBlock *sbb = NULL;
+    RB_FOREACH(sbb, SBB, &sb->sbb_tree) {
         SCLogDebug("sbb: offset %"PRIu64", len %u", sbb->offset, sbb->len);
-        if (sbb->next) {
-            if ((sbb->offset + sbb->len) != sbb->next->offset) {
+        StreamingBufferBlock *next = SBB_RB_NEXT(sbb);
+        if (next) {
+            if ((sbb->offset + sbb->len) != next->offset) {
                 SCLogDebug("gap: offset %"PRIu64", len %"PRIu64, (sbb->offset + sbb->len),
-                        sbb->next->offset - (sbb->offset + sbb->len));
+                        next->offset - (sbb->offset + sbb->len));
             }
         }
-
-        sbb = sbb->next;
     }
 }
 #endif
@@ -117,8 +174,8 @@ static void SBBPrintList(const StreamingBuffer *sb)
 static void SBBInit(StreamingBuffer *sb,
                     uint32_t rel_offset, uint32_t data_len)
 {
-    BUG_ON(sb->block_list != NULL);
-    BUG_ON(sb->buf_offset > sb->stream_offset + rel_offset);
+    DEBUG_VALIDATE_BUG_ON(!RB_EMPTY(&sb->sbb_tree));
+    DEBUG_VALIDATE_BUG_ON(sb->buf_offset > sb->stream_offset + rel_offset);
 
     /* need to set up 2: existing data block and new data block */
     StreamingBufferBlock *sbb = CALLOC(sb->cfg, 1, sizeof(*sbb));
@@ -136,9 +193,8 @@ static void SBBInit(StreamingBuffer *sb,
     sbb2->offset = sb->stream_offset + rel_offset;
     sbb2->len = data_len;
 
-    sb->block_list = sbb;
-    sbb->next = sbb2;
-    sb->block_list_tail = sbb2;
+    SBB_RB_INSERT(&sb->sbb_tree, sbb);
+    SBB_RB_INSERT(&sb->sbb_tree, sbb2);
 
     SCLogDebug("sbb1 %"PRIu64", len %u, sbb2 %"PRIu64", len %u",
             sbb->offset, sbb->len, sbb2->offset, sbb2->len);
@@ -155,7 +211,7 @@ static void SBBInit(StreamingBuffer *sb,
 static void SBBInitLeadingGap(StreamingBuffer *sb,
                               uint64_t offset, uint32_t data_len)
 {
-    BUG_ON(sb->block_list != NULL);
+    DEBUG_VALIDATE_BUG_ON(!RB_EMPTY(&sb->sbb_tree));
 
     StreamingBufferBlock *sbb = CALLOC(sb->cfg, 1, sizeof(*sbb));
     if (sbb == NULL)
@@ -163,8 +219,7 @@ static void SBBInitLeadingGap(StreamingBuffer *sb,
     sbb->offset = offset;
     sbb->len = data_len;
 
-    sb->block_list = sbb;
-    sb->block_list_tail = sbb;
+    SBB_RB_INSERT(&sb->sbb_tree, sbb);
 
     SCLogDebug("sbb %"PRIu64", len %u",
             sbb->offset, sbb->len);
@@ -173,280 +228,164 @@ static void SBBInitLeadingGap(StreamingBuffer *sb,
 #endif
 }
 
-static int IsBefore(StreamingBufferBlock *me, StreamingBufferBlock *you)
+static inline void ConsolidateFwd(StreamingBuffer *sb,
+        struct SBB *tree, StreamingBufferBlock *sa)
 {
-    if ((me->offset + me->len) < you->offset) {
-        return 1;
-    }
-    return 0;
-}
+    uint64_t sa_re = sa->offset + sa->len;
+    StreamingBufferBlock *tr, *s = sa;
+    RB_FOREACH_FROM(tr, SBB, s) {
+        if (sa == tr)
+            continue;
 
-static int StartsBefore(StreamingBufferBlock *me, StreamingBufferBlock *you)
-{
-    if (me->offset < you->offset)
-        return 1;
-    return 0;
-}
+        const uint64_t tr_re = tr->offset + tr->len;
+        SCLogDebug("-> (fwd) tr %p %"PRIu64"/%u re %"PRIu64,
+                tr, tr->offset, tr->len, tr_re);
 
-static int IsAfter(StreamingBufferBlock *me, StreamingBufferBlock *you)
-{
-    if (you->offset + you->len < me->offset)
-        return 1;
-    return 0;
-}
+        if (sa_re < tr->offset)
+            break; // entirely before
 
-static int IsOverlappedBy(StreamingBufferBlock *me, StreamingBufferBlock *you)
-{
-    if (you->offset <= me->offset && (you->offset + you->len) >= (me->offset + me->len))
-        return 1;
-    return 0;
-}
-
-static int EndsAfter(StreamingBufferBlock *me, StreamingBufferBlock *you)
-{
-    if ((me->offset + me->len) > (you->offset + you->len))
-        return 1;
-    return 0;
-}
-
-static StreamingBufferBlock *GetNew(StreamingBuffer *sb,
-                                    uint64_t offset, uint32_t len,
-                                    StreamingBufferBlock *next)
-{
-    StreamingBufferBlock *new_sbb = CALLOC(sb->cfg, 1, sizeof(*new_sbb));
-    if (new_sbb == NULL)
-        return NULL;
-    new_sbb->offset = offset;
-    new_sbb->len = len;
-    new_sbb->next = next;
-    return new_sbb;
-}
-
-/* expand our sbb forward if possible */
-static int SBBUpdateLookForward(StreamingBuffer *sb,
-                                StreamingBufferBlock *sbb,
-                                StreamingBufferBlock *my_block)
-{
-    SCLogDebug("EndsAfter: consider next");
-
-    while (sbb->offset + sbb->len == sbb->next->offset)
-    {
-        SCLogDebug("EndsAfter: gobble up next: %"PRIu64"/%u", sbb->next->offset, sbb->next->len);
-        uint64_t right_edge = sbb->next->offset + sbb->next->len;
-        uint32_t expand_by = right_edge - (sbb->offset + sbb->len);
-        sbb->len += expand_by;
-        SCLogDebug("EndsAfter: expand_by %u (part 2)", expand_by);
-        SCLogDebug("EndsAfter: (loop) sbb now %"PRIu64"/%u", sbb->offset, sbb->len);
-
-        /* we can gobble up next */
-        StreamingBufferBlock *to_free = sbb->next;
-        sbb->next = sbb->next->next;
-        FREE(sb->cfg, to_free, sizeof(StreamingBufferBlock));
-        if (sbb->next == NULL)
-            sb->block_list_tail = sbb;
-
-        /* update my block */
-        if (expand_by >= my_block->len) {
-            return 1;
-        }
-
-        my_block->len -= expand_by;
-        my_block->offset += expand_by;
-
-        if (sbb->next == NULL) {
-            /* if we have nothing left in the list we're almost done,
-             * except we need to check if we have some of our block
-             * left */
-            sbb->len += my_block->len;
-            my_block->offset += my_block->len;
-            my_block->len = 0;
-            return 1;
-        } else {
-            /* if next is not directly connected and we have some
-             * block len left, expand sbb further */
-            uint32_t gap = sbb->next->offset - (sbb->offset + sbb->len);
-            SCLogDebug("EndsAfter: we now have a gap of %u and a block of %"PRIu64"/%u", gap, my_block->offset, my_block->len);
-
-            if (my_block->len < gap) {
-                sbb->len += my_block->len;
-                my_block->offset += my_block->len;
-                my_block->len = 0;
-                return 1;
-            } else {
-                sbb->len += gap;
-                my_block->offset += gap;
-                my_block->len -= gap;
-                SCLogDebug("EndsAfter: (loop) block at %"PRIu64"/%u, sbb %"PRIu64"/%u", my_block->offset, my_block->len, sbb->offset, sbb->len);
-                SCLogDebug("EndsAfter: (loop) sbb->next %"PRIu64"/%u", sbb->next->offset, sbb->next->len);
-            }
+        /*
+            sa:     [   ]
+            tr: [           ]
+            sa:     [   ]
+            tr:     [       ]
+            sa:     [   ]
+            tr: [       ]
+        */
+        if (sa->offset >= tr->offset && sa_re <= tr_re) {
+            sa->len = tr->len;
+            sa->offset = tr->offset;
+            sa_re = sa->offset + sa->len;
+            SCLogDebug("-> (fwd) tr %p %"PRIu64"/%u REMOVED ECLIPSED2", tr, tr->offset, tr->len);
+            SBB_RB_REMOVE(tree, tr);
+            FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
+        /*
+            sa: [         ]
+            tr: [         ]
+            sa: [         ]
+            tr:    [      ]
+            sa: [         ]
+            tr:    [   ]
+        */
+        } else if (sa->offset <= tr->offset && sa_re >= tr_re) {
+            SCLogDebug("-> (fwd) tr %p %"PRIu64"/%u REMOVED ECLIPSED", tr, tr->offset, tr->len);
+            SBB_RB_REMOVE(tree, tr);
+            FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
+        /*
+            sa: [         ]
+            tr:      [         ]
+            sa: [       ]
+            tr:         [       ]
+        */
+        } else if (sa->offset < tr->offset && // starts before
+                   sa_re >= tr->offset && sa_re < tr_re) // ends inside
+        {
+            // merge
+            sa->len = tr_re - sa->offset;
+            sa_re = sa->offset + sa->len;
+            SCLogDebug("-> (fwd) tr %p %"PRIu64"/%u REMOVED MERGED", tr, tr->offset, tr->len);
+            SBB_RB_REMOVE(tree, tr);
+            FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
         }
     }
+}
+
+static inline void ConsolidateBackward(StreamingBuffer *sb,
+        struct SBB *tree, StreamingBufferBlock *sa)
+{
+    uint64_t sa_re = sa->offset + sa->len;
+    StreamingBufferBlock *tr, *s = sa;
+    RB_FOREACH_REVERSE_FROM(tr, SBB, s) {
+        if (sa == tr)
+            continue;
+        const uint64_t tr_re = tr->offset + tr->len;
+        SCLogDebug("-> (bwd) tr %p %"PRIu64"/%u", tr, tr->offset, tr->len);
+
+        if (sa->offset > tr_re)
+            break; // entirely after
+
+        if (sa->offset >= tr->offset && sa_re <= tr_re) {
+            sa->len = tr->len;
+            sa->offset = tr->offset;
+            sa_re = sa->offset + sa->len;
+            SCLogDebug("-> (bwd) tr %p %"PRIu64"/%u REMOVED ECLIPSED2", tr, tr->offset, tr->len);
+            SBB_RB_REMOVE(tree, tr);
+            FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
+        /*
+            sa: [         ]
+            tr: [         ]
+            sa:    [      ]
+            tr: [         ]
+            sa:    [   ]
+            tr: [         ]
+        */
+        } else if (sa->offset <= tr->offset && sa_re >= tr_re) {
+            SCLogDebug("-> (bwd) tr %p %"PRIu64"/%u REMOVED ECLIPSED", tr, tr->offset, tr->len);
+            SBB_RB_REMOVE(tree, tr);
+            FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
+        /*
+            sa:     [   ]
+            tr: [   ]
+            sa:    [    ]
+            tr: [   ]
+        */
+        } else if (sa->offset > tr->offset && sa_re > tr_re && sa->offset <= tr_re) {
+            // merge
+            sa->len = sa_re - tr->offset;
+            sa->offset = tr->offset;
+            sa_re = sa->offset + sa->len;
+            SCLogDebug("-> (bwd) tr %p %"PRIu64"/%u REMOVED MERGED", tr, tr->offset, tr->len);
+            SBB_RB_REMOVE(tree, tr);
+            FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
+        }
+    }
+}
+
+static int Insert(StreamingBuffer *sb, struct SBB *tree,
+        uint32_t rel_offset, uint32_t len)
+{
+    SCLogDebug("* inserting: %u/%u\n", rel_offset, len);
+
+    StreamingBufferBlock *sbb = CALLOC(sb->cfg, 1, sizeof(*sbb));
+    if (sbb == NULL)
+        return -1;
+    sbb->offset = sb->stream_offset + rel_offset;
+    sbb->len = len;
+    StreamingBufferBlock *res = SBB_RB_INSERT(tree, sbb);
+    if (res) {
+        // exact overlap
+        SCLogDebug("* insert failed: exact match in tree with %p %"PRIu64"/%u", res, res->offset, res->len);
+        FREE(sb->cfg, sbb, sizeof(StreamingBufferBlock));
+        return 0;
+    }
+    ConsolidateBackward(sb, tree, sbb);
+    ConsolidateFwd(sb, tree, sbb);
+#ifdef DEBUG
+    SBBPrintList(sb);
+#endif
     return 0;
 }
 
 static void SBBUpdate(StreamingBuffer *sb,
                       uint32_t rel_offset, uint32_t data_len)
 {
-    StreamingBufferBlock my_block = { .offset = sb->stream_offset + rel_offset,
-                                      .len = data_len,
-                                      .next = NULL  };
-    const uint64_t my_block_right_edge = my_block.offset + my_block.len;
-
-    StreamingBufferBlock *tail = sb->block_list_tail;
-
-    /* fast path 1: expands tail */
-    if (tail && ((tail->offset + tail->len) == my_block.offset))
-    {
-        tail->len = my_block_right_edge - tail->offset;
-        goto done;
-    }
-    /* fast path 2: new isolated block after tail */
-    else if (tail && IsAfter(&my_block, tail)) {
-        StreamingBufferBlock *new_sbb = GetNew(sb, my_block.offset, my_block.len, NULL);
-        sb->block_list_tail = tail->next = new_sbb;
-        SCLogDebug("tail: new block at %"PRIu64"/%u", my_block.offset, my_block.len);
-        goto done;
-    }
-
-    BUG_ON(sb->block_list == NULL);
-#ifdef DEBUG
-    SBBPrintList(sb);
-#endif
-    SCLogDebug("PreInsert: block at %"PRIu64"/%u", my_block.offset, my_block.len);
-    StreamingBufferBlock *sbb = sb->block_list, *prev = NULL;
-    while (sbb) {
-        SCLogDebug("sbb %"PRIu64"/%u data %"PRIu64"/%u. Next %s", sbb->offset, sbb->len,
-                my_block.offset, my_block.len, sbb->next ? "true" : "false");
-
-        if (IsBefore(&my_block, sbb)) {
-            StreamingBufferBlock *new_sbb = GetNew(sb, my_block.offset, my_block.len, sbb);
-
-            /* place before, maybe replace list head */
-            if (prev == NULL) {
-                sb->block_list = new_sbb;
-            } else {
-                prev->next = new_sbb;
-            }
-            SCLogDebug("IsBefore: new block at %"PRIu64"/%u", my_block.offset, my_block.len);
-            break;
-
-        } else if (IsOverlappedBy(&my_block, sbb)) {
-            /* nothing to do */
-            SCLogDebug("IsOverlappedBy: overlapped block at %"PRIu64"/%u", my_block.offset, my_block.len);
-            break;
-
-        } else if (IsAfter(&my_block, sbb)) {
-
-            /* if no next, place after, otherwise, iterate */
-            if (sbb->next == NULL) {
-                StreamingBufferBlock *new_sbb = GetNew(sb, my_block.offset, my_block.len, NULL);
-                sbb->next = new_sbb;
-                sb->block_list_tail = new_sbb;
-                SCLogDebug("new block at %"PRIu64"/%u", my_block.offset, my_block.len);
-                break;
-            }
-            SCLogDebug("IsAfter: block at %"PRIu64"/%u, is after sbb", my_block.offset, my_block.len);
-
-        } else {
-
-            /* those were the simple cases */
-
-            if (StartsBefore(&my_block, sbb)) {
-                /* expand sbb */
-                uint32_t expand_by = sbb->offset - my_block.offset;
-                SCLogDebug("StartsBefore: expand_by %u", expand_by);
-                sbb->offset = my_block.offset;
-                sbb->len += expand_by;
-
-                /* if my_block ends before sbb right edge, we are done */
-                if (my_block_right_edge <= (sbb->offset + sbb->len))
-                    break;
-
-                my_block.offset = sbb->offset + sbb->len;
-                my_block.len = my_block_right_edge - my_block.offset;
-                SCLogDebug("StartsBefore: block now %"PRIu64"/%u", my_block.offset, my_block.len);
-
-                if (sbb->next == NULL) {
-                    sbb->len += my_block.len;
-                    break;
-                }
-                /* expand, but consider next */
-                uint64_t right_edge = my_block_right_edge;
-                if (right_edge > sbb->next->offset) {
-                    right_edge = sbb->next->offset;
-                }
-
-                expand_by = right_edge - (sbb->offset + sbb->len);
-                SCLogDebug("EndsAfter: expand_by %u", expand_by);
-                sbb->len += expand_by;
-                SCLogDebug("EndsAfter: sbb now %"PRIu64"/%u", sbb->offset, sbb->len);
-
-                my_block.offset = sbb->offset + sbb->len;
-                my_block.len = my_block_right_edge - my_block.offset;
-                SCLogDebug("StartsBefore: sbb now %"PRIu64"/%u", sbb->offset, sbb->len);
-
-            } else if (EndsAfter(&my_block, sbb)) {
-                /* expand sbb, but we need to mind "next" */
-
-                if (sbb->next == NULL) {
-                    /* last, so just expand sbb */
-                    sbb->len = my_block_right_edge - sbb->offset;
-                    break;
-                }
-
-                /* expand, but consider next */
-                uint64_t right_edge = my_block_right_edge;
-                if (right_edge > sbb->next->offset) {
-                    right_edge = sbb->next->offset;
-                }
-
-                uint32_t expand_by = right_edge - (sbb->offset + sbb->len);
-                SCLogDebug("EndsAfter: expand_by %u", expand_by);
-                sbb->len += expand_by;
-                SCLogDebug("EndsAfter: sbb now %"PRIu64"/%u", sbb->offset, sbb->len);
-
-                my_block.offset = sbb->offset + sbb->len;
-                my_block.len = my_block_right_edge - my_block.offset;
-            }
-
-            if (sbb->next != NULL) {
-                SCLogDebug("EndsAfter: consider next");
-
-                if (SBBUpdateLookForward(sb, sbb, &my_block) == 1)
-                    goto done;
-            }
-
-            SCLogDebug("EndsAfter: block at %"PRIu64"/%u, is after sbb", my_block.offset, my_block.len);
-
-            if (my_block.len == 0)
-                break;
-        }
-        prev = sbb;
-        sbb = sbb->next;
-    }
-done:
-    SCLogDebug("PostInsert: block at %"PRIu64"/%u", my_block.offset, my_block.len);
-    SCLogDebug("PostInsert");
-#ifdef DEBUG
-    SBBPrintList(sb);
-#endif
+    Insert(sb, &sb->sbb_tree, rel_offset, data_len);
 }
 
 static void SBBFree(StreamingBuffer *sb)
 {
-    StreamingBufferBlock *sbb = sb->block_list;
-    while (sbb) {
-        StreamingBufferBlock *next = sbb->next;
+    StreamingBufferBlock *sbb = NULL, *safe = NULL;
+    RB_FOREACH_SAFE(sbb, SBB, &sb->sbb_tree, safe) {
+        SBB_RB_REMOVE(&sb->sbb_tree, sbb);
         FREE(sb->cfg, sbb, sizeof(StreamingBufferBlock));
-        sbb = next;
     }
-    sb->block_list = NULL;
 }
 
 static void SBBPrune(StreamingBuffer *sb)
 {
-    StreamingBufferBlock *sbb = sb->block_list;
-    while (sbb) {
+    SCLogDebug("pruning %p to %"PRIu64, sb, sb->stream_offset);
+    StreamingBufferBlock *sbb = NULL, *safe = NULL;
+    RB_FOREACH_SAFE(sbb, SBB, &sb->sbb_tree, safe) {
         /* completely beyond window, we're done */
         if (sbb->offset > sb->stream_offset)
             break;
@@ -455,20 +394,18 @@ static void SBBPrune(StreamingBuffer *sb)
         if (sbb->offset < sb->stream_offset &&
             sbb->offset + sbb->len > sb->stream_offset) {
             uint32_t shrink_by = sb->stream_offset - sbb->offset;
-            BUG_ON(shrink_by > sbb->len);
-            sbb->len -=  shrink_by;
-            sbb->offset += shrink_by;
-            BUG_ON(sbb->offset != sb->stream_offset);
+            DEBUG_VALIDATE_BUG_ON(shrink_by > sbb->len);
+            if (sbb->len >= shrink_by) {
+                sbb->len -=  shrink_by;
+                sbb->offset += shrink_by;
+                DEBUG_VALIDATE_BUG_ON(sbb->offset != sb->stream_offset);
+            }
             break;
         }
 
-        StreamingBufferBlock *next = sbb->next;
+        SBB_RB_REMOVE(&sb->sbb_tree, sbb);
+        SCLogDebug("sb %p removed %p %"PRIu64", %u", sb, sbb, sbb->offset, sbb->len);
         FREE(sb->cfg, sbb, sizeof(StreamingBufferBlock));
-
-        sbb = next;
-        sb->block_list = next;
-        if (sbb && sbb->next == NULL)
-            sb->block_list_tail = NULL;
     }
 }
 
@@ -610,7 +547,7 @@ StreamingBufferSegment *StreamingBufferAppendRaw(StreamingBuffer *sb, const uint
         uint32_t rel_offset = sb->buf_offset;
         sb->buf_offset += data_len;
 
-        if (sb->block_list) {
+        if (!RB_EMPTY(&sb->sbb_tree)) {
             SBBUpdate(sb, rel_offset, data_len);
         }
         return seg;
@@ -652,7 +589,7 @@ int StreamingBufferAppend(StreamingBuffer *sb, StreamingBufferSegment *seg,
     uint32_t rel_offset = sb->buf_offset;
     sb->buf_offset += data_len;
 
-    if (sb->block_list) {
+    if (!RB_EMPTY(&sb->sbb_tree)) {
         SBBUpdate(sb, rel_offset, data_len);
     }
     return 0;
@@ -691,7 +628,7 @@ int StreamingBufferAppendNoTrack(StreamingBuffer *sb,
     uint32_t rel_offset = sb->buf_offset;
     sb->buf_offset += data_len;
 
-    if (sb->block_list) {
+    if (!RB_EMPTY(&sb->sbb_tree)) {
         SBBUpdate(sb, rel_offset, data_len);
     }
     return 0;
@@ -739,7 +676,7 @@ int StreamingBufferInsertAt(StreamingBuffer *sb, StreamingBufferSegment *seg,
     SCLogDebug("rel_offset %u sb->stream_offset %"PRIu64", buf_offset %u",
             rel_offset, sb->stream_offset, sb->buf_offset);
 
-    if (sb->block_list == NULL) {
+    if (RB_EMPTY(&sb->sbb_tree)) {
         SCLogDebug("empty sbb list");
 
         if (sb->stream_offset == offset) {
@@ -1145,7 +1082,7 @@ static int StreamingBufferTest04(void)
 
     StreamingBufferSegment seg1;
     FAIL_IF(StreamingBufferAppend(sb, &seg1, (const uint8_t *)"ABCDEFGH", 8) != 0);
-    FAIL_IF(sb->block_list != NULL);
+    FAIL_IF(!RB_EMPTY(&sb->sbb_tree));
     StreamingBufferSegment seg2;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg2, (const uint8_t *)"01234567", 8, 14) != 0);
     FAIL_IF(sb->stream_offset != 0);
@@ -1154,12 +1091,15 @@ static int StreamingBufferTest04(void)
     FAIL_IF(seg2.stream_offset != 14);
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg1));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg2));
-    FAIL_IF(sb->block_list == NULL);
-    FAIL_IF(sb->block_list->offset != 0);
-    FAIL_IF(sb->block_list->len != 8);
-    FAIL_IF(sb->block_list->next == NULL);
-    FAIL_IF(sb->block_list->next->offset != 14);
-    FAIL_IF(sb->block_list->next->len != 8);
+    FAIL_IF(RB_EMPTY(&sb->sbb_tree));
+    StreamingBufferBlock *sbb1 = RB_MIN(SBB, &sb->sbb_tree);
+    FAIL_IF_NULL(sbb1);
+    FAIL_IF(sbb1->offset != 0);
+    FAIL_IF(sbb1->len != 8);
+    StreamingBufferBlock *sbb2 = SBB_RB_NEXT(sbb1);
+    FAIL_IF_NULL(sbb2);
+    FAIL_IF(sbb2->offset != 14);
+    FAIL_IF(sbb2->len != 8);
     Dump(sb);
     DumpSegment(sb, &seg1);
     DumpSegment(sb, &seg2);
@@ -1172,10 +1112,11 @@ static int StreamingBufferTest04(void)
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg1));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg2));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg3));
-    FAIL_IF(sb->block_list == NULL);
-    FAIL_IF(sb->block_list->offset != 0);
-    FAIL_IF(sb->block_list->len != 22);
-    FAIL_IF(sb->block_list->next != NULL);
+    sbb1 = RB_MIN(SBB, &sb->sbb_tree);
+    FAIL_IF_NULL(sbb1);
+    FAIL_IF(sbb1->offset != 0);
+    FAIL_IF(sbb1->len != 22);
+    FAIL_IF(SBB_RB_NEXT(sbb1));
     Dump(sb);
     DumpSegment(sb, &seg1);
     DumpSegment(sb, &seg2);
@@ -1192,10 +1133,11 @@ static int StreamingBufferTest04(void)
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg2));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg3));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg4));
-    FAIL_IF(sb->block_list == NULL);
-    FAIL_IF(sb->block_list->offset != 0);
-    FAIL_IF(sb->block_list->len != 22);
-    FAIL_IF(sb->block_list->next == NULL);
+    sbb1 = RB_MIN(SBB, &sb->sbb_tree);
+    FAIL_IF_NULL(sbb1);
+    FAIL_IF(sbb1->offset != 0);
+    FAIL_IF(sbb1->len != 22);
+    FAIL_IF(!SBB_RB_NEXT(sbb1));
     Dump(sb);
     DumpSegment(sb, &seg1);
     DumpSegment(sb, &seg2);
@@ -1272,18 +1214,20 @@ static int StreamingBufferTest06(void)
     StreamingBufferSegment seg5;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg5, (const uint8_t *)"ABCDEFGHIJ", 10, 0) != 0);
     Dump(sb);
-    FAIL_IF(sb->block_list == NULL);
-    FAIL_IF(sb->block_list->offset != 0);
-    FAIL_IF(sb->block_list->len != 10);
-    FAIL_IF(sb->block_list->next != NULL);
+    StreamingBufferBlock *sbb1 = RB_MIN(SBB, &sb->sbb_tree);
+    FAIL_IF_NULL(sbb1);
+    FAIL_IF(sbb1->offset != 0);
+    FAIL_IF(sbb1->len != 10);
+    FAIL_IF(SBB_RB_NEXT(sbb1));
 
     StreamingBufferSegment seg6;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg6, (const uint8_t *)"abcdefghij", 10, 0) != 0);
     Dump(sb);
-    FAIL_IF(sb->block_list == NULL);
-    FAIL_IF(sb->block_list->offset != 0);
-    FAIL_IF(sb->block_list->len != 10);
-    FAIL_IF(sb->block_list->next != NULL);
+    sbb1 = RB_MIN(SBB, &sb->sbb_tree);
+    FAIL_IF_NULL(sbb1);
+    FAIL_IF(sbb1->offset != 0);
+    FAIL_IF(sbb1->len != 10);
+    FAIL_IF(SBB_RB_NEXT(sbb1));
 
     StreamingBufferFree(sb);
     PASS;
@@ -1313,18 +1257,20 @@ static int StreamingBufferTest07(void)
     StreamingBufferSegment seg5;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg5, (const uint8_t *)"ABCDEFGHIJ", 10, 0) != 0);
     Dump(sb);
-    FAIL_IF(sb->block_list == NULL);
-    FAIL_IF(sb->block_list->offset != 0);
-    FAIL_IF(sb->block_list->len != 10);
-    FAIL_IF(sb->block_list->next != NULL);
+    StreamingBufferBlock *sbb1 = RB_MIN(SBB, &sb->sbb_tree);
+    FAIL_IF_NULL(sbb1);
+    FAIL_IF(sbb1->offset != 0);
+    FAIL_IF(sbb1->len != 10);
+    FAIL_IF(SBB_RB_NEXT(sbb1));
 
     StreamingBufferSegment seg6;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg6, (const uint8_t *)"abcdefghij", 10, 0) != 0);
     Dump(sb);
-    FAIL_IF(sb->block_list == NULL);
-    FAIL_IF(sb->block_list->offset != 0);
-    FAIL_IF(sb->block_list->len != 10);
-    FAIL_IF(sb->block_list->next != NULL);
+    sbb1 = RB_MIN(SBB, &sb->sbb_tree);
+    FAIL_IF_NULL(sbb1);
+    FAIL_IF(sbb1->offset != 0);
+    FAIL_IF(sbb1->len != 10);
+    FAIL_IF(SBB_RB_NEXT(sbb1));
 
     StreamingBufferFree(sb);
     PASS;
@@ -1354,18 +1300,20 @@ static int StreamingBufferTest08(void)
     StreamingBufferSegment seg5;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg5, (const uint8_t *)"ABCDEFGHIJ", 10, 0) != 0);
     Dump(sb);
-    FAIL_IF(sb->block_list == NULL);
-    FAIL_IF(sb->block_list->offset != 0);
-    FAIL_IF(sb->block_list->len != 10);
-    FAIL_IF(sb->block_list->next != NULL);
+    StreamingBufferBlock *sbb1 = RB_MIN(SBB, &sb->sbb_tree);
+    FAIL_IF_NULL(sbb1);
+    FAIL_IF(sbb1->offset != 0);
+    FAIL_IF(sbb1->len != 10);
+    FAIL_IF(SBB_RB_NEXT(sbb1));
 
     StreamingBufferSegment seg6;
     FAIL_IF(StreamingBufferAppend(sb, &seg6, (const uint8_t *)"abcdefghij", 10) != 0);
     Dump(sb);
-    FAIL_IF(sb->block_list == NULL);
-    FAIL_IF(sb->block_list->offset != 0);
-    FAIL_IF(sb->block_list->len != 20);
-    FAIL_IF(sb->block_list->next != NULL);
+    sbb1 = RB_MIN(SBB, &sb->sbb_tree);
+    FAIL_IF_NULL(sbb1);
+    FAIL_IF(sbb1->offset != 0);
+    FAIL_IF(sbb1->len != 20);
+    FAIL_IF(SBB_RB_NEXT(sbb1));
 
     StreamingBufferFree(sb);
     PASS;
@@ -1395,18 +1343,20 @@ static int StreamingBufferTest09(void)
     StreamingBufferSegment seg5;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg5, (const uint8_t *)"ABCDEFGHIJ", 10, 0) != 0);
     Dump(sb);
-    FAIL_IF(sb->block_list == NULL);
-    FAIL_IF(sb->block_list->offset != 0);
-    FAIL_IF(sb->block_list->len != 10);
-    FAIL_IF(sb->block_list->next != NULL);
+    StreamingBufferBlock *sbb1 = RB_MIN(SBB, &sb->sbb_tree);
+    FAIL_IF_NULL(sbb1);
+    FAIL_IF(sbb1->offset != 0);
+    FAIL_IF(sbb1->len != 10);
+    FAIL_IF(SBB_RB_NEXT(sbb1));
 
     StreamingBufferSegment seg6;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg6, (const uint8_t *)"abcdefghij", 10, 0) != 0);
     Dump(sb);
-    FAIL_IF(sb->block_list == NULL);
-    FAIL_IF(sb->block_list->offset != 0);
-    FAIL_IF(sb->block_list->len != 10);
-    FAIL_IF(sb->block_list->next != NULL);
+    sbb1 = RB_MIN(SBB, &sb->sbb_tree);
+    FAIL_IF_NULL(sbb1);
+    FAIL_IF(sbb1->offset != 0);
+    FAIL_IF(sbb1->len != 10);
+    FAIL_IF(SBB_RB_NEXT(sbb1));
 
     StreamingBufferFree(sb);
     PASS;
@@ -1421,10 +1371,10 @@ static int StreamingBufferTest10(void)
 
     StreamingBufferSegment seg1;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg1, (const uint8_t *)"A", 1, 0) != 0);
+    Dump(sb);
     StreamingBufferSegment seg2;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg2, (const uint8_t *)"D", 1, 3) != 0);
     Dump(sb);
-
     StreamingBufferSegment seg3;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg3, (const uint8_t *)"H", 1, 7) != 0);
     Dump(sb);
@@ -1442,18 +1392,20 @@ static int StreamingBufferTest10(void)
     StreamingBufferSegment seg7;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg7, (const uint8_t *)"ABCDEFGHIJ", 10, 0) != 0);
     Dump(sb);
-    FAIL_IF(sb->block_list == NULL);
-    FAIL_IF(sb->block_list->offset != 0);
-    FAIL_IF(sb->block_list->len != 10);
-    FAIL_IF(sb->block_list->next != NULL);
+    StreamingBufferBlock *sbb1 = RB_MIN(SBB, &sb->sbb_tree);
+    FAIL_IF_NULL(sbb1);
+    FAIL_IF(sbb1->offset != 0);
+    FAIL_IF(sbb1->len != 10);
+    FAIL_IF(SBB_RB_NEXT(sbb1));
 
     StreamingBufferSegment seg8;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg8, (const uint8_t *)"abcdefghij", 10, 0) != 0);
     Dump(sb);
-    FAIL_IF(sb->block_list == NULL);
-    FAIL_IF(sb->block_list->offset != 0);
-    FAIL_IF(sb->block_list->len != 10);
-    FAIL_IF(sb->block_list->next != NULL);
+    sbb1 = RB_MIN(SBB, &sb->sbb_tree);
+    FAIL_IF_NULL(sbb1);
+    FAIL_IF(sbb1->offset != 0);
+    FAIL_IF(sbb1->len != 10);
+    FAIL_IF(SBB_RB_NEXT(sbb1));
 
     StreamingBufferFree(sb);
     PASS;

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -59,6 +59,8 @@
 #ifndef __UTIL_STREAMING_BUFFER_H__
 #define __UTIL_STREAMING_BUFFER_H__
 
+#include "tree.h"
+
 #define STREAMING_BUFFER_NOFLAGS     0
 #define STREAMING_BUFFER_AUTOSLIDE  (1<<0)
 
@@ -77,11 +79,18 @@ typedef struct StreamingBufferConfig_ {
 /**
  *  \brief block of continues data
  */
-typedef struct StreamingBufferBlock_ {
+typedef struct StreamingBufferBlock {
     uint64_t offset;
+    RB_ENTRY(StreamingBufferBlock) rb;
     uint32_t len;
-    struct StreamingBufferBlock_ *next;
-} StreamingBufferBlock;
+} __attribute__((__packed__)) StreamingBufferBlock;
+
+int SBBCompare(struct StreamingBufferBlock *a, struct StreamingBufferBlock *b);
+
+/* red-black tree prototype for SACK records */
+RB_HEAD(SBB, StreamingBufferBlock);
+RB_PROTOTYPE(SBB, StreamingBufferBlock, rb, SBBCompare);
+StreamingBufferBlock *SBB_RB_FIND_INCLUSIVE(struct SBB *head, StreamingBufferBlock *elm);
 
 typedef struct StreamingBuffer_ {
     const StreamingBufferConfig *cfg;
@@ -91,17 +100,16 @@ typedef struct StreamingBuffer_ {
     uint32_t buf_size;      /**< size of memory block */
     uint32_t buf_offset;    /**< how far we are in buf_size */
 
-    StreamingBufferBlock *block_list;
-    StreamingBufferBlock *block_list_tail;
+    struct SBB sbb_tree;    /**< red black tree of Stream Buffer Blocks */
 #ifdef DEBUG
     uint32_t buf_size_max;
 #endif
 } StreamingBuffer;
 
 #ifndef DEBUG
-#define STREAMING_BUFFER_INITIALIZER(cfg) { (cfg), 0, NULL, 0, 0, NULL, NULL};
+#define STREAMING_BUFFER_INITIALIZER(cfg) { (cfg), 0, NULL, 0, 0, { NULL }, };
 #else
-#define STREAMING_BUFFER_INITIALIZER(cfg) { (cfg), 0, NULL, 0, 0, NULL, NULL, 0 };
+#define STREAMING_BUFFER_INITIALIZER(cfg) { (cfg), 0, NULL, 0, 0, { NULL }, 0 };
 #endif
 
 typedef struct StreamingBufferSegment_ {

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -114,8 +114,8 @@ typedef struct StreamingBuffer_ {
 #endif
 
 typedef struct StreamingBufferSegment_ {
-    uint64_t stream_offset;
     uint32_t segment_len;
+    uint64_t stream_offset;
 } __attribute__((__packed__)) StreamingBufferSegment;
 
 StreamingBuffer *StreamingBufferInit(const StreamingBufferConfig *cfg);

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -101,15 +101,16 @@ typedef struct StreamingBuffer_ {
     uint32_t buf_offset;    /**< how far we are in buf_size */
 
     struct SBB sbb_tree;    /**< red black tree of Stream Buffer Blocks */
+    StreamingBufferBlock *head; /**< head, should always be the same as RB_MIN */
 #ifdef DEBUG
     uint32_t buf_size_max;
 #endif
 } StreamingBuffer;
 
 #ifndef DEBUG
-#define STREAMING_BUFFER_INITIALIZER(cfg) { (cfg), 0, NULL, 0, 0, { NULL }, };
+#define STREAMING_BUFFER_INITIALIZER(cfg) { (cfg), 0, NULL, 0, 0, { NULL }, NULL, };
 #else
-#define STREAMING_BUFFER_INITIALIZER(cfg) { (cfg), 0, NULL, 0, 0, { NULL }, 0 };
+#define STREAMING_BUFFER_INITIALIZER(cfg) { (cfg), 0, NULL, 0, 0, { NULL }, NULL, 0 };
 #endif
 
 typedef struct StreamingBufferSegment_ {


### PR DESCRIPTION
Improve performance of TCP engine in the face of many out of order segments and SACK ranges, like with SegmentSmack.

Describe changes:
- switch TCP segment, SACK lists to rbtrees
- switch streaming buffer blocks list to rbtree

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/165
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/167

