### PR TITLE
tls: fix issue with session tickets

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1184,8 +1184,7 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
 
             case SSL_EXTENSION_SESSION_TICKET:
             {
-                if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) &&
-                        ext_len != 0) {
+                if (ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) {
                     /* This has to be verified later on by checking if a
                        certificate record has been sent by the server. */
                     ssl_state->flags |= SSL_AL_FLAG_SESSION_RESUMED;

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -475,6 +475,7 @@ static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
                been seen. */
             if ((ssl_state->server_connp.cert0_issuerdn == NULL) &&
                     (ssl_state->server_connp.cert0_subject == NULL) &&
+                    (ssl_state->flags & SSL_AL_FLAG_STATE_SERVER_HELLO) &&
                     ((ssl_state->flags & SSL_AL_FLAG_LOG_WITHOUT_CERT) == 0)) {
                 MemBufferWriteString(aft->buffer, " Session='resumed'");
             }

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -135,6 +135,7 @@ static void JsonTlsLogSessionResumed(json_t *js, SSLState *ssl_state)
            been seen, and the session is not TLSv1.3 or later. */
         if ((ssl_state->server_connp.cert0_issuerdn == NULL &&
                ssl_state->server_connp.cert0_subject == NULL) &&
+               (ssl_state->flags & SSL_AL_FLAG_STATE_SERVER_HELLO) &&
                ((ssl_state->flags & SSL_AL_FLAG_LOG_WITHOUT_CERT) == 0)) {
             json_object_set_new(js, "session_resumed", json_boolean(true));
         }


### PR DESCRIPTION
TLS sessions where the ClientHello record contains a session ticket are logged as "resumed", as long as we don't see a certificate in the session. The problem with this, is that this also happens when the session is incomplete. This PR makes this a lot less likely to happen.

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/168
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/168