### PR TITLE
Flow/stream-tcp: bug 2057 fix missing vlan and iface on psuedopacket v2

### DIFF
--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -89,6 +89,16 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(Packet *p,
     p->flags |= PKT_HAS_FLOW;
     p->flags |= PKT_PSEUDO_STREAM_END;
 
+    if (f->vlan_id[0]) {
+        p->vlan_id[0] = f->vlan_id[0];
+        p->vlan_idx=1;
+
+        if (f->vlan_id[1]) {
+            p->vlan_id[1] = f->vlan_id[1];
+            p->vlan_idx=2;
+        }
+    }
+
     if (f->flags & FLOW_NOPACKET_INSPECTION) {
         DecodeSetNoPacketInspectionFlag(p);
     }

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -88,6 +88,7 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(Packet *p,
     p->flags |= PKT_STREAM_EOF;
     p->flags |= PKT_HAS_FLOW;
     p->flags |= PKT_PSEUDO_STREAM_END;
+    p->livedev = f->livedev;
 
     if (f->vlan_id[0]) {
         p->vlan_id[0] = f->vlan_id[0];

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -153,6 +153,7 @@ void FlowInit(Flow *f, const Packet *p)
     f->recursion_level = p->recursion_level;
     f->vlan_id[0] = p->vlan_id[0];
     f->vlan_id[1] = p->vlan_id[1];
+    f->livedev = p->livedev;
 
     if (PKT_IS_IPV4(p)) {
         FLOW_SET_IPV4_SRC_ADDR_FROM_PACKET(p, &f->src);

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -40,6 +40,7 @@
         (f)->sp = 0; \
         (f)->dp = 0; \
         (f)->proto = 0; \
+        (f)->livedev = NULL; \
         SC_ATOMIC_INIT((f)->flow_state); \
         SC_ATOMIC_INIT((f)->use_cnt); \
         (f)->tenant_id = 0; \
@@ -83,6 +84,7 @@
         (f)->sp = 0; \
         (f)->dp = 0; \
         (f)->proto = 0; \
+        (f)->livedev = NULL; \
         SC_ATOMIC_RESET((f)->flow_state); \
         SC_ATOMIC_RESET((f)->use_cnt); \
         (f)->tenant_id = 0; \

--- a/src/flow.h
+++ b/src/flow.h
@@ -345,6 +345,9 @@ typedef struct Flow_
     uint8_t recursion_level;
     uint16_t vlan_id[2];
 
+    /** Incoming interface */
+    struct LiveDevice_ *livedev;
+
     /** flow hash - the flow hash before hash table size mod. */
     uint32_t flow_hash;
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6028,6 +6028,7 @@ static void StreamTcpPseudoPacketCreateDetectLogFlush(ThreadVars *tv,
     np->flags |= PKT_HAS_FLOW;
     np->flags |= PKT_IGNORE_CHECKSUM;
     np->flags |= PKT_PSEUDO_DETECTLOG_FLUSH;
+    np->livedev = f->livedev;
 
     if (f->vlan_id[0]) {
         np->vlan_id[0] = f->vlan_id[0];

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6029,6 +6029,16 @@ static void StreamTcpPseudoPacketCreateDetectLogFlush(ThreadVars *tv,
     np->flags |= PKT_IGNORE_CHECKSUM;
     np->flags |= PKT_PSEUDO_DETECTLOG_FLUSH;
 
+    if (f->vlan_id[0]) {
+        np->vlan_id[0] = f->vlan_id[0];
+        np->vlan_idx=1;
+
+        if (f->vlan_id[1]) {
+            np->vlan_id[1] = f->vlan_id[1];
+            np->vlan_idx=2;
+        }
+    }
+
     if (f->flags & FLOW_NOPACKET_INSPECTION) {
         DecodeSetNoPacketInspectionFlag(np);
     }


### PR DESCRIPTION
Ref old PR: https://github.com/OISF/suricata/pull/3467

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2057

Describe changes:
This should fix the bug related to missing vlan and in_iface on logged/alerted psuedopackets. Without vlan and iface on output / alert of pseudopackets we are unable to split the output to the correct SIEM.
I have not noticed any issues related to this patch on sensors in IDS mode with live traffic.


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

