### PR TITLE
Next/20181003/v2

### DIFF
--- a/doc/userguide/performance/hyperscan.rst
+++ b/doc/userguide/performance/hyperscan.rst
@@ -4,7 +4,7 @@ Hyperscan
 Introduction
 ~~~~~~~~~~~~
 
-"Hyperscan is a high-performance multiple regex matching library." https://01.org/hyperscan
+"Hyperscan is a high-performance multiple regex matching library." https://www.hyperscan.io
 
 In Suricata it can be used to perform multi pattern matching (mpm). Support was implemented by Justin Viiret and Jim Xu from Intel: https://github.com/inliniac/suricata/pull/1965, https://redmine.openinfosecfoundation.org/issues/1704
 
@@ -67,10 +67,10 @@ Trusty has 1.57, so it's too old. We can grab a newer libboost version, but we *
 
 
   sudo apt-get python-dev libbz2-dev
-  wget http://downloads.sourceforge.net/project/boost/boost/1.60.0/boost_1_60_0.tar.gz
-  tar xvzf boost_1_60_0.tar.gz
-  cd boost_1_60_0
-  ./bootstrap.sh --prefix=~/tmp/boost-1.60
+  wget https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz
+  tar xvzf boost_1_66_0.tar.gz
+  cd boost_1_66_0
+  ./bootstrap.sh --prefix=~/tmp/boost-1.66
   ./b2 install
 
 Hyperscan
@@ -82,7 +82,7 @@ We'll install version 4.2.0.
 ::
 
 
-  git clone https://github.com/01org/hyperscan
+  git clone https://github.com/intel/hyperscan
   cd hyperscan
   mkdir build
   cd build
@@ -93,7 +93,7 @@ If you have your own libboost headers, use this cmake line instead:
 ::
 
 
-  cmake -DBUILD_STATIC_AND_SHARED=1 -DBOOST_ROOT=~/tmp/boost-1.60 ../
+  cmake -DBUILD_STATIC_AND_SHARED=1 -DBOOST_ROOT=~/tmp/boost-1.66 ../
 
 Finally, make and make install:
 

--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -301,7 +301,7 @@ pub extern "C" fn rs_template_parse_request(
     input_len: u32,
     _data: *const libc::c_void,
     _flags: u8,
-) -> i8 {
+) -> i32 {
     let eof = unsafe {
         if AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF) > 0 {
             true
@@ -331,7 +331,7 @@ pub extern "C" fn rs_template_parse_response(
     input_len: u32,
     _data: *const libc::c_void,
     _flags: u8,
-) -> i8 {
+) -> i32 {
     let _eof = unsafe {
         if AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF) > 0 {
             true

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -278,7 +278,7 @@ pub extern "C" fn rs_dhcp_parse(_flow: *const core::Flow,
                                 input: *const libc::uint8_t,
                                 input_len: u32,
                                 _data: *const libc::c_void,
-                                _flags: u8) -> i8 {
+                                _flags: u8) -> i32 {
     let state = cast_pointer!(state, DHCPState);
     let buf = build_slice!(input, input_len as usize);
     if state.parse(buf) {

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -126,7 +126,7 @@ impl IKEV2State {
     /// Parse an IKEV2 request message
     ///
     /// Returns The number of messages parsed, or -1 on error
-    fn parse(&mut self, i: &[u8], direction: u8) -> i8 {
+    fn parse(&mut self, i: &[u8], direction: u8) -> i32 {
         match parse_ikev2_header(i) {
             IResult::Done(rem,ref hdr) => {
                 if rem.len() == 0 && hdr.length == 28 {
@@ -444,7 +444,7 @@ pub extern "C" fn rs_ikev2_parse_request(_flow: *const core::Flow,
                                        input: *const libc::uint8_t,
                                        input_len: u32,
                                        _data: *const libc::c_void,
-                                       _flags: u8) -> i8 {
+                                       _flags: u8) -> i32 {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,IKEV2State);
     state.parse(buf, STREAM_TOSERVER)
@@ -457,7 +457,7 @@ pub extern "C" fn rs_ikev2_parse_response(_flow: *const core::Flow,
                                        input: *const libc::uint8_t,
                                        input_len: u32,
                                        _data: *const libc::c_void,
-                                       _flags: u8) -> i8 {
+                                       _flags: u8) -> i32 {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,IKEV2State);
     let res = state.parse(buf, STREAM_TOCLIENT);

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -105,7 +105,7 @@ impl KRB5State {
     /// Parse a Kerberos request message
     ///
     /// Returns The number of messages parsed, or -1 on error
-    fn parse(&mut self, i: &[u8], _direction: u8) -> i8 {
+    fn parse(&mut self, i: &[u8], _direction: u8) -> i32 {
         match der_read_element_header(i) {
             IResult::Done(_rem,hdr) => {
                 // Kerberos messages start with an APPLICATION header
@@ -462,7 +462,7 @@ pub extern "C" fn rs_krb5_parse_request(_flow: *const core::Flow,
                                        input: *const libc::uint8_t,
                                        input_len: u32,
                                        _data: *const libc::c_void,
-                                       _flags: u8) -> i8 {
+                                       _flags: u8) -> i32 {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,KRB5State);
     state.parse(buf, STREAM_TOSERVER)
@@ -475,7 +475,7 @@ pub extern "C" fn rs_krb5_parse_response(_flow: *const core::Flow,
                                        input: *const libc::uint8_t,
                                        input_len: u32,
                                        _data: *const libc::c_void,
-                                       _flags: u8) -> i8 {
+                                       _flags: u8) -> i32 {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,KRB5State);
     state.parse(buf, STREAM_TOCLIENT)
@@ -488,7 +488,7 @@ pub extern "C" fn rs_krb5_parse_request_tcp(_flow: *const core::Flow,
                                        input: *const libc::uint8_t,
                                        input_len: u32,
                                        _data: *const libc::c_void,
-                                       _flags: u8) -> i8 {
+                                       _flags: u8) -> i32 {
     if input_len < 4 { return -1; }
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,KRB5State);
@@ -546,7 +546,7 @@ pub extern "C" fn rs_krb5_parse_response_tcp(_flow: *const core::Flow,
                                        input: *const libc::uint8_t,
                                        input_len: u32,
                                        _data: *const libc::c_void,
-                                       _flags: u8) -> i8 {
+                                       _flags: u8) -> i32 {
     if input_len < 4 { return -1; }
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,KRB5State);

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -85,7 +85,7 @@ impl NTPState {
     /// Parse an NTP request message
     ///
     /// Returns The number of messages parsed, or -1 on error
-    fn parse(&mut self, i: &[u8], _direction: u8) -> i8 {
+    fn parse(&mut self, i: &[u8], _direction: u8) -> i32 {
         match parse_ntp(i) {
             IResult::Done(_,ref msg) => {
                 // SCLogDebug!("parse_ntp: {:?}",msg);
@@ -196,7 +196,7 @@ pub extern "C" fn rs_ntp_parse_request(_flow: *const core::Flow,
                                        input: *const libc::uint8_t,
                                        input_len: u32,
                                        _data: *const libc::c_void,
-                                       _flags: u8) -> i8 {
+                                       _flags: u8) -> i32 {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,NTPState);
     state.parse(buf, 0)
@@ -209,7 +209,7 @@ pub extern "C" fn rs_ntp_parse_response(_flow: *const core::Flow,
                                        input: *const libc::uint8_t,
                                        input_len: u32,
                                        _data: *const libc::c_void,
-                                       _flags: u8) -> i8 {
+                                       _flags: u8) -> i32 {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,NTPState);
     state.parse(buf, 1)

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -124,7 +124,7 @@ pub type ParseFn      = extern "C" fn (flow: *const Flow,
                                        input: *const u8,
                                        input_len: u32,
                                        data: *const c_void,
-                                       flags: u8) -> i8;
+                                       flags: u8) -> i32;
 pub type ProbeFn      = extern "C" fn (flow: *const Flow,input:*const u8, input_len: u32) -> AppProto;
 pub type StateAllocFn = extern "C" fn () -> *mut c_void;
 pub type StateFreeFn  = extern "C" fn (*mut c_void);

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1546,7 +1546,7 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
                 if (recv(ptv->socket, &c, sizeof c, MSG_PEEK) != -1)
                     continue; /* what, no error? */
                 SCLogError(SC_ERR_AFP_READ,
-                           "Error reading data from iface '%s': (%d" PRIu32 ") %s",
+                           "Error reading data from iface '%s': (%d) %s",
                            ptv->iface, errno, strerror(errno));
                 AFPSwitchState(ptv, AFP_STATE_DOWN);
                 continue;
@@ -1569,7 +1569,7 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
                 case AFP_READ_FAILURE:
                     /* AFPRead in error: best to reset the socket */
                     SCLogError(SC_ERR_AFP_READ,
-                           "AFPRead error reading data from iface '%s': (%d" PRIu32 ") %s",
+                           "AFPRead error reading data from iface '%s': (%d) %s",
                            ptv->iface, errno, strerror(errno));
                     AFPSwitchState(ptv, AFP_STATE_DOWN);
                     continue;
@@ -1592,7 +1592,7 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
             TmThreadsCaptureInjectPacket(tv, ptv->slot, NULL);
 
         } else if ((r < 0) && (errno != EINTR)) {
-            SCLogError(SC_ERR_AFP_READ, "Error reading data from iface '%s': (%d" PRIu32 ") %s",
+            SCLogError(SC_ERR_AFP_READ, "Error reading data from iface '%s': (%d) %s",
                        ptv->iface,
                        errno, strerror(errno));
             AFPSwitchState(ptv, AFP_STATE_DOWN);


### PR DESCRIPTION
Describe changes:
- fix Rust parsers return codes randomly being wrong
- #3495
- minor afpacket error message fixups

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/174
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/176

