### PR TITLE
stream: add counter for packets on the wrong thread

### DIFF
--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4679,10 +4679,9 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
     /* assign the thread id to the flow */
     if (unlikely(p->flow->thread_id == 0)) {
         p->flow->thread_id = (FlowThreadId)tv->id;
-#ifdef DEBUG
     } else if (unlikely((FlowThreadId)tv->id != p->flow->thread_id)) {
         SCLogDebug("wrong thread: flow has %u, we are %d", p->flow->thread_id, tv->id);
-#endif
+        StatsIncr(tv, stt->counter_tcp_wrong_thread);
     }
 
     TcpSession *ssn = (TcpSession *)p->flow->protoctx;
@@ -5144,6 +5143,7 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->counter_tcp_synack = StatsRegisterCounter("tcp.synack", tv);
     stt->counter_tcp_rst = StatsRegisterCounter("tcp.rst", tv);
     stt->counter_tcp_midstream_pickups = StatsRegisterCounter("tcp.midstream_pickups", tv);
+    stt->counter_tcp_wrong_thread = StatsRegisterCounter("tcp.wrong_thread", tv);
 
     /* init reassembly ctx */
     stt->ra_ctx = StreamTcpReassembleInitThreadCtx(tv);

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -96,6 +96,8 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_rst;
     /** midstream pickups */
     uint16_t counter_tcp_midstream_pickups;
+    /** wrong thread */
+    uint16_t counter_tcp_wrong_thread;
 
     /** tcp reassembly thread data */
     TcpReassemblyThreadCtx *ra_ctx;


### PR DESCRIPTION
Describe changes:
- add 'tcp.wrong_thread' counter that is incremented if a packet comes in on an unexpected thread. Could be useful checking if flow balancing on the capture side works correctly.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/175
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/177


