### PR TITLE
Fix/smb2/multi record dce/v4

### DIFF
--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -577,3 +577,21 @@ pub fn smb_read_dcerpc_record<'b>(state: &mut SMBState,
 
     return true;
 }
+
+/// Try to find out if the input data looks like DCERPC
+pub fn smb_dcerpc_probe<'b>(data: &[u8]) -> bool
+{
+    match parse_dcerpc_record(data) {
+        IResult::Done(_, recr) => {
+            SCLogDebug!("SMB: could be DCERPC {:?}", recr);
+            if recr.version_major == 5 && recr.version_minor < 3 &&
+               recr.frag_len > 0 && recr.packet_type <= 20
+            {
+                SCLogDebug!("SMB: looks like we have dcerpc");
+                return true;
+            }
+        },
+        _ => { },
+    }
+    return false;
+}

--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -149,6 +149,7 @@ pub fn dcerpc_uuid_to_string(i: &DCERPCIface) -> String {
 pub struct SMBTransactionDCERPC {
     pub opnum: u16,
     pub req_cmd: u8,
+    pub req_set: bool,
     pub res_cmd: u8,
     pub res_set: bool,
     pub call_id: u32,
@@ -159,10 +160,25 @@ pub struct SMBTransactionDCERPC {
 }
 
 impl SMBTransactionDCERPC {
-    pub fn new(req: u8, call_id: u32) -> SMBTransactionDCERPC {
+    fn new_request(req: u8, call_id: u32) -> SMBTransactionDCERPC {
         return SMBTransactionDCERPC {
             opnum: 0,
             req_cmd: req,
+            req_set: true,
+            res_cmd: 0,
+            res_set: false,
+            call_id: call_id,
+            frag_cnt_ts: 0,
+            frag_cnt_tc: 0,
+            stub_data_ts:Vec::new(),
+            stub_data_tc:Vec::new(),
+        }
+    }
+    fn new_response(call_id: u32) -> SMBTransactionDCERPC {
+        return SMBTransactionDCERPC {
+            opnum: 0,
+            req_cmd: 0,
+            req_set: false,
             res_cmd: 0,
             res_set: false,
             call_id: call_id,
@@ -179,14 +195,14 @@ impl SMBTransactionDCERPC {
 }
 
 impl SMBState {
-    pub fn new_dcerpc_tx(&mut self, hdr: SMBCommonHdr, vercmd: SMBVerCmdStat, cmd: u8, call_id: u32)
+    fn new_dcerpc_tx(&mut self, hdr: SMBCommonHdr, vercmd: SMBVerCmdStat, cmd: u8, call_id: u32)
         -> (&mut SMBTransaction)
     {
         let mut tx = self.new_tx();
         tx.hdr = hdr;
         tx.vercmd = vercmd;
         tx.type_data = Some(SMBTransactionTypeData::DCERPC(
-                    SMBTransactionDCERPC::new(cmd, call_id)));
+                    SMBTransactionDCERPC::new_request(cmd, call_id)));
 
         SCLogDebug!("SMB: TX DCERPC created: ID {} hdr {:?}", tx.id, tx.hdr);
         self.transactions.push(tx);
@@ -194,7 +210,22 @@ impl SMBState {
         return tx_ref.unwrap();
     }
 
-    pub fn get_dcerpc_tx(&mut self, hdr: &SMBCommonHdr, vercmd: &SMBVerCmdStat, call_id: u32)
+    fn new_dcerpc_tx_for_response(&mut self, hdr: SMBCommonHdr, vercmd: SMBVerCmdStat, call_id: u32)
+        -> (&mut SMBTransaction)
+    {
+        let mut tx = self.new_tx();
+        tx.hdr = hdr;
+        tx.vercmd = vercmd;
+        tx.type_data = Some(SMBTransactionTypeData::DCERPC(
+                    SMBTransactionDCERPC::new_response(call_id)));
+
+        SCLogDebug!("SMB: TX DCERPC created: ID {} hdr {:?}", tx.id, tx.hdr);
+        self.transactions.push(tx);
+        let tx_ref = self.transactions.last_mut();
+        return tx_ref.unwrap();
+    }
+
+    fn get_dcerpc_tx(&mut self, hdr: &SMBCommonHdr, vercmd: &SMBVerCmdStat, call_id: u32)
         -> Option<&mut SMBTransaction>
     {
         let dce_hdr = hdr.to_dcerpc(vercmd);
@@ -422,6 +453,51 @@ fn smb_read_dcerpc_record_error(state: &mut SMBState,
     return found;
 }
 
+fn dcerpc_response_handle<'b>(tx: &mut SMBTransaction,
+        vercmd: SMBVerCmdStat,
+        dcer: &DceRpcRecord)
+{
+    let (_, ntstatus) = vercmd.get_ntstatus();
+    match dcer.packet_type {
+        DCERPC_TYPE_RESPONSE => {
+            match parse_dcerpc_response_record(dcer.data, dcer.frag_len) {
+                IResult::Done(_, respr) => {
+                    SCLogDebug!("SMBv1 READ RESPONSE {:?}", respr);
+                    if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) = tx.type_data {
+                        SCLogDebug!("CMD 11 found at tx {}", tx.id);
+                        tdn.set_result(DCERPC_TYPE_RESPONSE);
+                        tdn.stub_data_tc.extend_from_slice(&respr.data);
+                        tdn.frag_cnt_tc += 1;
+                    }
+                    tx.vercmd.set_ntstatus(ntstatus);
+                    tx.response_done = dcer.last_frag;
+                },
+                _ => {
+                    tx.set_event(SMBEvent::MalformedData);
+                },
+            }
+        },
+        DCERPC_TYPE_BINDACK => {
+            // handled elsewhere
+        },
+        21...255 => {
+            if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) = tx.type_data {
+                tdn.set_result(dcer.packet_type);
+            }
+            tx.vercmd.set_ntstatus(ntstatus);
+            tx.response_done = true;
+            tx.set_event(SMBEvent::MalformedData);
+        }
+        _ => { // valid type w/o special processing
+            if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) = tx.type_data {
+                tdn.set_result(dcer.packet_type);
+            }
+            tx.vercmd.set_ntstatus(ntstatus);
+            tx.response_done = true;
+        },
+    }
+}
+
 /// Handle DCERPC reply record. Called for READ, TRANS, IOCTL
 ///
 pub fn smb_read_dcerpc_record<'b>(state: &mut SMBState,
@@ -432,19 +508,17 @@ pub fn smb_read_dcerpc_record<'b>(state: &mut SMBState,
 {
     let (_, ntstatus) = vercmd.get_ntstatus();
 
-    if ntstatus != SMB_NTSTATUS_SUCCESS {
+    if ntstatus != SMB_NTSTATUS_SUCCESS && ntstatus != SMB_NTSTATUS_BUFFER_OVERFLOW {
         return smb_read_dcerpc_record_error(state, hdr, vercmd, ntstatus);
     }
 
     SCLogDebug!("lets first see if we have prior data");
     // msg_id 0 as this data crosses cmd/reply pairs
-    let ehdr = SMBCommonHdr::new(SMBHDR_TYPE_TRANS_FRAG,
-            hdr.ssn_id as u64, hdr.tree_id as u32, 0 as u64);
-    let ekey = SMBHashKeyHdrGuid::new(ehdr, guid.to_vec());
-    SCLogDebug!("ekey {:?}", ekey);
-    let mut prevdata = match state.ssnguid2vec_map.remove(&ekey) {
+    let ehdr = SMBHashKeyHdrGuid::new(SMBCommonHdr::new(SMBHDR_TYPE_TRANS_FRAG,
+            hdr.ssn_id as u64, hdr.tree_id as u32, 0 as u64), guid.to_vec());
+    let mut prevdata = match state.ssnguid2vec_map.remove(&ehdr) {
         Some(s) => s,
-            None => Vec::new(),
+        None => Vec::new(),
     };
     SCLogDebug!("indata {} prevdata {}", indata.len(), prevdata.len());
     prevdata.extend_from_slice(&indata);
@@ -464,31 +538,10 @@ pub fn smb_read_dcerpc_record<'b>(state: &mut SMBState,
                         dcer.version_major, dcer.version_minor, dcer.data.len(), dcer);
 
                 if ntstatus == SMB_NTSTATUS_BUFFER_OVERFLOW && data.len() < dcer.frag_len as usize {
-                    SCLogDebug!("short record {} < {}: lets see if we expected this", data.len(), dcer.frag_len);
-                    let ehdr = SMBCommonHdr::new(SMBHDR_TYPE_MAX_SIZE,
-                            hdr.ssn_id as u64, hdr.tree_id as u32, hdr.msg_id as u64);
-                    let max_size = match state.ssn2maxsize_map.remove(&ehdr) {
-                        Some(s) => s,
-                        None => 0,
-                    };
-                    if max_size as usize == data.len() {
-                        SCLogDebug!("YES this is expected. We should now see a follow up READ for {} bytes",
-                                dcer.frag_len as usize - data.len());
-                        let store = match state.get_dcerpc_tx(&hdr, &vercmd, dcer.call_id) {
-                            Some(_) => true,
-                            None => {
-                                SCLogDebug!("no TX found");
-                                false
-                            },
-                        };
-                        if store {
-                            SCLogDebug!("storing partial data in state");
-                            let ehdr = SMBCommonHdr::new(SMBHDR_TYPE_MAX_SIZE,
-                                    hdr.ssn_id as u64, hdr.tree_id as u32, 0 as u64);
-                            state.ssn2vec_map.insert(ehdr, data.to_vec());
-                        }
-                        return true; // TODO review
-                    }
+                    SCLogDebug!("short record {} < {}: storing partial data in state",
+                            data.len(), dcer.frag_len);
+                    state.ssnguid2vec_map.insert(ehdr, data.to_vec());
+                    return true; // TODO review
                 }
 
                 if dcer.packet_type == DCERPC_TYPE_BINDACK {
@@ -496,50 +549,20 @@ pub fn smb_read_dcerpc_record<'b>(state: &mut SMBState,
                     return true;
                 }
 
-                let tx = match state.get_dcerpc_tx(&hdr, &vercmd, dcer.call_id) {
-                    Some(tx) => tx,
+                let found = match state.get_dcerpc_tx(&hdr, &vercmd, dcer.call_id) {
+                    Some(tx) => {
+                        dcerpc_response_handle(tx, vercmd.clone(), &dcer);
+                        true
+                    },
                     None => {
                         SCLogDebug!("no tx");
-                        return false; },
+                        false
+                    },
                 };
-
-                match dcer.packet_type {
-                    DCERPC_TYPE_RESPONSE => {
-                        match parse_dcerpc_response_record(dcer.data, dcer.frag_len) {
-                            IResult::Done(_, respr) => {
-                                SCLogDebug!("SMBv1 READ RESPONSE {:?}", respr);
-                                if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) = tx.type_data {
-                                    SCLogDebug!("CMD 11 found at tx {}", tx.id);
-                                    tdn.set_result(DCERPC_TYPE_RESPONSE);
-                                    tdn.stub_data_tc.extend_from_slice(&respr.data);
-                                    tdn.frag_cnt_tc += 1;
-                                }
-                                tx.vercmd.set_ntstatus(ntstatus);
-                                tx.response_done = dcer.last_frag;
-                            },
-                            _ => {
-                                tx.set_event(SMBEvent::MalformedData);
-                            },
-                        }
-                    },
-                    DCERPC_TYPE_BINDACK => {
-                        // handled above
-                    },
-                    21...255 => {
-                        if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) = tx.type_data {
-                            tdn.set_result(dcer.packet_type);
-                        }
-                        tx.vercmd.set_ntstatus(ntstatus);
-                        tx.response_done = true;
-                        tx.set_event(SMBEvent::MalformedData);
-                    }
-                    _ => { // valid type w/o special processing
-                        if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) = tx.type_data {
-                            tdn.set_result(dcer.packet_type);
-                        }
-                        tx.vercmd.set_ntstatus(ntstatus);
-                        tx.response_done = true;
-                    },
+                if !found {
+                    // pick up DCERPC tx even if we missed the request
+                    let tx = state.new_dcerpc_tx_for_response(hdr, vercmd.clone(), dcer.call_id);
+                    dcerpc_response_handle(tx, vercmd, &dcer);
                 }
             },
             _ => {

--- a/rust/src/smb/debug.rs
+++ b/rust/src/smb/debug.rs
@@ -73,6 +73,6 @@ impl SMBState {
 
     #[cfg(feature = "debug")]
     pub fn _debug_state_stats(&self) {
-        SCLogNotice!("ssn2vec_map {} guid2name_map {} ssn2vecoffset_map {} ssn2tree_map {} ssn2maxsize_map {} ssnguid2vec_map {} tcp_buffer_ts {} tcp_buffer_tc {} file_ts_guid {} file_tc_guid {} transactions {}", self.ssn2vec_map.len(), self.guid2name_map.len(), self.ssn2vecoffset_map.len(), self.ssn2tree_map.len(), self.ssn2maxsize_map.len(), self.ssnguid2vec_map.len(), self.tcp_buffer_ts.len(), self.tcp_buffer_tc.len(), self.file_ts_guid.len(), self.file_tc_guid.len(), self.transactions.len());
+        SCLogNotice!("ssn2vec_map {} guid2name_map {} ssn2vecoffset_map {} ssn2tree_map {} ssnguid2vec_map {} tcp_buffer_ts {} tcp_buffer_tc {} file_ts_guid {} file_tc_guid {} transactions {}", self.ssn2vec_map.len(), self.guid2name_map.len(), self.ssn2vecoffset_map.len(), self.ssn2tree_map.len(), self.ssnguid2vec_map.len(), self.tcp_buffer_ts.len(), self.tcp_buffer_tc.len(), self.file_ts_guid.len(), self.file_tc_guid.len(), self.transactions.len());
     }
 }

--- a/rust/src/smb/log.rs
+++ b/rust/src/smb/log.rs
@@ -312,49 +312,63 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
         },
         Some(SMBTransactionTypeData::DCERPC(ref x)) => {
             let jsd = Json::object();
-            jsd.set_string("request", &dcerpc_type_string(x.req_cmd));
+            if x.req_set {
+                jsd.set_string("request", &dcerpc_type_string(x.req_cmd));
+            } else {
+                jsd.set_string("request", "REQUEST_LOST");
+            }
             if x.res_set {
                 jsd.set_string("response", &dcerpc_type_string(x.res_cmd));
             } else {
                 jsd.set_string("response", "UNREPLIED");
             }
-            match x.req_cmd {
-                DCERPC_TYPE_REQUEST => {
-                    jsd.set_integer("opnum", x.opnum as u64);
-                    let req = Json::object();
-                    req.set_integer("frag_cnt", x.frag_cnt_ts as u64);
-                    req.set_integer("stub_data_size", x.stub_data_ts.len() as u64);
-                    jsd.set("req", req);
-                    let res = Json::object();
-                    res.set_integer("frag_cnt", x.frag_cnt_tc as u64);
-                    res.set_integer("stub_data_size", x.stub_data_tc.len() as u64);
-                    jsd.set("res", res);
-                },
-                DCERPC_TYPE_BIND => {
-                    match state.dcerpc_ifaces {
-                        Some(ref ifaces) => {
-                            let jsa = Json::array();
-                            for i in ifaces {
-                                let jso = Json::object();
-                                let ifstr = dcerpc_uuid_to_string(&i);
-                                jso.set_string("uuid", &ifstr);
-                                let vstr = format!("{}.{}", i.ver, i.ver_min);
-                                jso.set_string("version", &vstr);
+            if x.req_set {
+                match x.req_cmd {
+                    DCERPC_TYPE_REQUEST => {
+                        jsd.set_integer("opnum", x.opnum as u64);
+                        let req = Json::object();
+                        req.set_integer("frag_cnt", x.frag_cnt_ts as u64);
+                        req.set_integer("stub_data_size", x.stub_data_ts.len() as u64);
+                        jsd.set("req", req);
+                    },
+                    DCERPC_TYPE_BIND => {
+                        match state.dcerpc_ifaces {
+                            Some(ref ifaces) => {
+                                let jsa = Json::array();
+                                for i in ifaces {
+                                    let jso = Json::object();
+                                    let ifstr = dcerpc_uuid_to_string(&i);
+                                    jso.set_string("uuid", &ifstr);
+                                    let vstr = format!("{}.{}", i.ver, i.ver_min);
+                                    jso.set_string("version", &vstr);
 
-                                if i.acked {
-                                    jso.set_integer("ack_result", i.ack_result as u64);
-                                    jso.set_integer("ack_reason", i.ack_reason as u64);
+                                    if i.acked {
+                                        jso.set_integer("ack_result", i.ack_result as u64);
+                                        jso.set_integer("ack_reason", i.ack_reason as u64);
+                                    }
+
+                                    jsa.array_append(jso);
                                 }
 
-                                jsa.array_append(jso);
-                            }
-
-                            jsd.set("interfaces", jsa);
-                        },
-                        _ => {},
-                    }
-                },
-                _ => {},
+                                jsd.set("interfaces", jsa);
+                            },
+                            _ => {},
+                        }
+                    },
+                    _ => {},
+                }
+            }
+            if x.res_set {
+                match x.res_cmd {
+                    DCERPC_TYPE_RESPONSE => {
+                        let res = Json::object();
+                        res.set_integer("frag_cnt", x.frag_cnt_tc as u64);
+                        res.set_integer("stub_data_size", x.stub_data_tc.len() as u64);
+                        jsd.set("res", res);
+                    },
+                    // we don't handle BINDACK w/o BIND
+                    _ => {},
+                }
             }
             jsd.set_integer("call_id", x.call_id as u64);
             js.set("dcerpc", jsd);

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1119,6 +1119,7 @@ impl SMBState {
                     Ok("lsarpc") => ("lsarpc", true),
                     Ok("samr") => ("samr", true),
                     Ok("spoolss") => ("spoolss", true),
+                    Ok("suricata::dcerpc") => ("unknown", true),
                     Err(_) => ("MALFORMED", false),
                     Ok(&_) => {
                         SCLogDebug!("don't know {}", String::from_utf8_lossy(&n));

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -750,8 +750,8 @@ pub struct SMBState<> {
 
     pub ssn2tree_map: HashMap<SMBCommonHdr, SMBTree>,
 
-    // track the max size we expect for TRANS responses
-    pub ssn2maxsize_map: HashMap<SMBCommonHdr, u16>,
+    // store partial data records that are transfered in multiple
+    // requests for DCERPC.
     pub ssnguid2vec_map: HashMap<SMBHashKeyHdrGuid, Vec<u8>>,
 
     /// TCP segments defragmentation buffer
@@ -801,7 +801,6 @@ impl SMBState {
             guid2name_map:HashMap::new(),
             ssn2vecoffset_map:HashMap::new(),
             ssn2tree_map:HashMap::new(),
-            ssn2maxsize_map:HashMap::new(),
             ssnguid2vec_map:HashMap::new(),
             tcp_buffer_ts:Vec::new(),
             tcp_buffer_tc:Vec::new(),

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -817,17 +817,6 @@ pub fn smb1_trans_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
             }
 
             if pipe_dcerpc {
-                // trans request will tell us the max size of the response
-                // if there is more response data, it will first give a
-                // TRANS with 'max data cnt' worth of data, and the rest
-                // will be pulled by a 'READ'. So we setup an expectation
-                // here.
-                if rd.params.max_data_cnt > 0 {
-                    // expect max max_data_cnt for this fid in the other dir
-                    let ehdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_MAX_SIZE);
-                    state.ssn2maxsize_map.insert(ehdr, rd.params.max_data_cnt);
-                }
-
                 SCLogDebug!("SMBv1 TRANS TO PIPE");
                 let hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_HEADER);
                 let vercmd = SMBVerCmdStat::new1(r.command);

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -869,9 +869,9 @@ pub fn smb1_trans_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
             // if we get status 'BUFFER_OVERFLOW' this is only a part of
             // the data. Store it in the ssn/tree for later use.
             if r.nt_status == SMB_NTSTATUS_BUFFER_OVERFLOW {
-                state.ssnguid2vec_map.insert(SMBHashKeyHdrGuid::new(
-                            SMBCommonHdr::from1(r, SMBHDR_TYPE_TRANS_FRAG), fid),
-                        rd.data.to_vec());
+                let key = SMBHashKeyHdrGuid::new(SMBCommonHdr::from1(r, SMBHDR_TYPE_TRANS_FRAG), fid);
+                SCLogDebug!("SMBv1/TRANS: queueing data for len {} key {:?}", rd.data.len(), key);
+                state.ssnguid2vec_map.insert(key, rd.data.to_vec());
             } else if is_dcerpc {
                 SCLogDebug!("SMBv1 TRANS TO PIPE");
                 let hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_HEADER);


### PR DESCRIPTION
Describe changes:
- fix handling of DCERPC records passed in multiple SMB records w/o being fragged
- pick up DCERPC by probing it when we've missed the tree connect
- allow logging of partial DCERPC transactions

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/176
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/178

