### PR TITLE
detect: ... skip if packet want a flow and has a flow - established issue for incomplete TCP

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -865,8 +865,10 @@ static inline void DetectRulePacketRules(
                     SCLogDebug("no match in stream, fall back to packet payload");
 
                     /* skip if we don't have to inspect the packet and segment was
-                     * added to stream */
-                    if (!(sflags & SIG_FLAG_REQUIRE_PACKET) && (p->flags & PKT_STREAM_ADD)) {
+                     * added to stream or packets wants flow and comes from zero copy. */
+                    if ((!(sflags & SIG_FLAG_REQUIRE_PACKET) && ((p->flags & PKT_STREAM_ADD)
+                         || ((p->flags & PKT_HAS_FLOW) && (p->flags & PKT_WANTS_FLOW) && (p->flags & PKT_ZERO_COPY)))
+                         )) {
                         goto next;
                     }
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/

----

Describe changes:
- Adds a check if the signature requires a stream while doing packet payload inspection.

### So why and how did we get here?

We detected some alerts being issued for rules with the **established** flow keyword, for connections without the TCP 3whs .

`alert tcp 127.0.0.1 any -> 127.0.0.1 1212 ( msg:"RULE:to_server,established #1"; content:"MATCH?"; flow:to_server,established; priority:3; sid:2; )`

To reproduce this, we can run a hping command and a batch of PSH packets without start a valid connection.

`for i in {1..2}; do sudo hping3 127.0.0.1 -c 1 -d 6 -E match -p 1212 -P -A; done`

where the _match_ file contains the MATCH? content


A tcpdump for this will show the following lines: 

https://www.irccloud.com/pastebin/raw/K9FEqQMr/two%20pushes%20

```
16:09:13.585780 IP localhost.1075 > localhost.1212: Flags [P.], seq 2098018628:2098018634, ack 972709509, win 512, length 6
16:09:13.585884 IP localhost.1212 > localhost.1075: Flags [R], seq 972709509, win 0, length 0
16:09:13.795828 IP localhost.1075 > localhost.1212: Flags [P.], seq 0:6, ack 1, win 512, length 6
16:09:13.795888 IP localhost.1212 > localhost.1075: Flags [R], seq 972709509, win 0, length 0
```

And will produce two alerts ...

https://www.irccloud.com/pastebin/qUjkdokC/2%20alerts%20for%20established


I'm am missing anything here?

