### PR TITLE
doc: remove deprecated force-md5 flag from userguide

### DIFF
--- a/doc/userguide/file-extraction/file-extraction.rst
+++ b/doc/userguide/file-extraction/file-extraction.rst
@@ -104,7 +104,7 @@ recommended.
       enabled: yes      # set to yes to enable
       log-dir: files    # directory to store the files
       force-magic: no   # force logging magic on all stored files
-      force-md5: no     # force logging of md5 checksums
+      force-hash: [md5] # force logging of md5 checksums
       stream-depth: 1mb # reassemble 1mb into a stream, set to no to disable
       waldo: file.waldo # waldo file to store the file_id across runs
       max-open-files: 0 # how many files to keep open (O means none)
@@ -129,7 +129,7 @@ output.
         append: yes
         #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
         force-magic: no   # force logging magic on all logged files
-        force-md5: no     # force logging of md5 checksums
+        force-hash: [md5] # force logging of md5 checksums
 
 
 Rules

--- a/doc/userguide/file-extraction/md5.rst
+++ b/doc/userguide/file-extraction/md5.rst
@@ -16,7 +16,7 @@ In the suricata yaml:
          enabled: yes       # set to yes to enable
          log-dir: files     # directory to store the files
          force-magic: yes   # force logging magic on all stored files
-         force-md5: yes     # force logging of md5 checksums
+         force-hash: [md5]  # force logging of md5 checksums
          #waldo: file.waldo # waldo file to store the file_id across runs
 
 Optionally, for JSON output:
@@ -128,7 +128,7 @@ If you would like to log MD5s for everything and anything that passes through th
       enabled: no       # set to yes to enable
       log-dir: files    # directory to store the files
       force-magic: yes   # force logging magic on all stored files
-      force-md5: yes     # force logging of md5 checksums
+      force-hash: [md5]  # force logging of md5 checksums
       #waldo: file.waldo # waldo file to store the file_id across runs
 
   - file-log:
@@ -137,5 +137,4 @@ If you would like to log MD5s for everything and anything that passes through th
       append: no
       #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
       force-magic: yes   # force logging magic on all logged files
-      force-md5: yes     # force logging of md5 checksums
-
+      force-hash: [md5]  # force logging of md5 checksums


### PR DESCRIPTION
Cleanup suricata userguide for deprecated force-md5 flag.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- remove from suricata userguide deprecated force-md5 flag

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

