### PR TITLE
Add documentation for SSH keywords

### DIFF
--- a/doc/userguide/rules/index.rst
+++ b/doc/userguide/rules/index.rst
@@ -13,6 +13,7 @@ Suricata Rules
    file-keywords
    dns-keywords
    tls-keywords
+   ssh-keywords
    ja3-keywords
    modbus-keyword
    dnp3-keywords

--- a/doc/userguide/rules/ssh-keywords.rst
+++ b/doc/userguide/rules/ssh-keywords.rst
@@ -1,0 +1,60 @@
+SSH Keywords
+============
+
+Suricata comes with several rule keywords to match on SSH connections.
+
+ssh_proto
+---------
+
+Match on the version of the SSH protocol used.
+
+Example::
+
+  alert ssh any any -> any any (msg:"match SSH protocol version"; \
+      ssh_proto; content:"2.0"; sid:1000010;)
+
+The example above matches on SSH connections with SSH version 2.
+
+``ssh_proto`` is a 'Sticky buffer'.
+
+``ssh_proto`` can be used as ``fast_pattern``.
+
+ssh_version
+-----------
+
+Match on the software string from the SSH banner.
+
+Example::
+
+  alert ssh any any -> any any (msg:"match SSH software string"; \
+      ssh_software: content:"openssh"; nocase; sid:1000020;)
+
+The example above matches on SSH connections where the software string contains "openssh".
+
+``ssh_software`` is a 'Sticky buffer'.
+
+``ssh_software`` can be used as ``fast_pattern``.
+
+ssh.protoversion
+----------------
+
+This is a legacy keyword. Use ``ssh_proto`` instead!
+
+Match on the version of the SSH protocol used.
+
+Example::
+
+  alert ssh any any -> any any (msg:"match SSH protocol version"; \
+      ssh.protoversion:"2.0"; sid:1000030;)
+
+ssh.softwareversion
+-------------------
+
+This is a legacy keyword. Use ``ssh_software`` instead!
+
+Match on the software string from the SSH banner.
+
+Example::
+
+  alert ssh any any -> any any (msg:"match SSH software string"; \
+      ssh.softwareversion:"OpenSSH"; sid:10000040;)

--- a/src/detect-ssh-proto-version.c
+++ b/src/detect-ssh-proto-version.c
@@ -76,6 +76,8 @@ static int g_ssh_banner_list_id = 0;
 void DetectSshVersionRegister(void)
 {
     sigmatch_table[DETECT_AL_SSH_PROTOVERSION].name = "ssh.protoversion";
+    sigmatch_table[DETECT_AL_SSH_PROTOVERSION].desc = "match SSH protocol version";
+    sigmatch_table[DETECT_AL_SSH_PROTOVERSION].url = DOC_URL DOC_VERSION "/rules/ssh-keywords.html#ssh-protoversion";
     sigmatch_table[DETECT_AL_SSH_PROTOVERSION].AppLayerTxMatch = DetectSshVersionMatch;
     sigmatch_table[DETECT_AL_SSH_PROTOVERSION].Setup = DetectSshVersionSetup;
     sigmatch_table[DETECT_AL_SSH_PROTOVERSION].Free  = DetectSshVersionFree;

--- a/src/detect-ssh-proto.c
+++ b/src/detect-ssh-proto.c
@@ -48,7 +48,7 @@
 #include "detect-ssh-proto.h"
 
 #define KEYWORD_NAME "ssh_proto"
-#define KEYWORD_DOC "ssh-keywords#ssh-protocol"
+#define KEYWORD_DOC "ssh-keywords.html#ssh-proto"
 #define BUFFER_NAME "ssh_protocol"
 #define BUFFER_DESC "ssh protocol field"
 static int g_buffer_id = 0;

--- a/src/detect-ssh-software-version.c
+++ b/src/detect-ssh-software-version.c
@@ -90,6 +90,8 @@ static int InspectSshBanner(ThreadVars *tv,
 void DetectSshSoftwareVersionRegister(void)
 {
     sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].name = "ssh.softwareversion";
+    sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].desc = "match SSH software string";
+    sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].url = DOC_URL DOC_VERSION "/rules/ssh-keywords.html#ssh-softwareversion";
     sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].AppLayerTxMatch = DetectSshSoftwareVersionMatch;
     sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].Setup = DetectSshSoftwareVersionSetup;
     sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].Free  = DetectSshSoftwareVersionFree;

--- a/src/detect-ssh-software.c
+++ b/src/detect-ssh-software.c
@@ -48,7 +48,7 @@
 #include "detect-ssh-software.h"
 
 #define KEYWORD_NAME "ssh_software"
-#define KEYWORD_DOC "ssh-keywords#ssh-software"
+#define KEYWORD_DOC "ssh-keywords.html#ssh-software"
 #define BUFFER_NAME "ssh_software"
 #define BUFFER_DESC "ssh software"
 static int g_buffer_id = 0;


### PR DESCRIPTION
Add documentation for the SSH keywords:
- ssh_proto
- ssh_software
- ssh.protoversion
- ssh.softwareversion

Also fix wrong or missing url and description for the keywords.

Redmine:
https://redmine.openinfosecfoundation.org/issues/2591

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/169
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/169