### PR TITLE
Fix two JA3 bugs

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -628,7 +628,8 @@ static inline int TLSDecodeHSHelloVersion(SSLState *ssl_state,
         return -1;
     }
 
-    ssl_state->curr_connp->version = *input << 8 | *(input + 1);
+    uint16_t version = *input << 8 | *(input + 1);
+    ssl_state->curr_connp->version = version;
 
     /* TLSv1.3 draft1 to draft21 use the version field as earlier TLS
        versions, instead of using the supported versions extension. */
@@ -659,8 +660,7 @@ static inline int TLSDecodeHSHelloVersion(SSLState *ssl_state,
         if (ssl_state->ja3_str == NULL)
             return -1;
 
-        int rc = Ja3BufferAddValue(&ssl_state->ja3_str,
-                                   ssl_state->curr_connp->version);
+        int rc = Ja3BufferAddValue(&ssl_state->ja3_str, version);
         if (rc != 0)
             return -1;
     }

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1197,6 +1197,7 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
             }
         }
 
+next:
         if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) &&
                 ssl_config.enable_ja3) {
             if (TLSDecodeValueIsGREASE(ext_type) != 1) {
@@ -1206,7 +1207,6 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
             }
         }
 
-next:
         processed_len += ext_len + 4;
     }
 

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -317,12 +317,112 @@ static int DetectTlsJa3HashTest01(void)
     PASS;
 }
 
+/**
+ * \test Test matching on a simple client hello packet
+ */
+static int DetectTlsJa3HashTest02(void)
+{
+    /* Client hello */
+    uint8_t buf[] = { 0x16, 0x03, 0x01, 0x00, 0xc0, 0x01, 0x00, 0x00, 0xbc,
+                      0x03, 0x03, 0x03, 0xb7, 0x16, 0x16, 0x5a, 0xe7, 0xc1,
+                      0xbd, 0x46, 0x2f, 0xff, 0xf3, 0x68, 0xb8, 0x6f, 0x6e,
+                      0x93, 0xdf, 0x06, 0x6a, 0xa7, 0x2d, 0xa0, 0xea, 0x9f,
+                      0x48, 0xb5, 0xe7, 0x91, 0x20, 0xd7, 0x25, 0x00, 0x00,
+                      0x1c, 0x0a, 0x0a, 0xc0, 0x2b, 0xc0, 0x2f, 0xc0, 0x2c,
+                      0xc0, 0x30, 0xcc, 0xa9, 0xcc, 0xa8, 0xc0, 0x13, 0xc0,
+                      0x14, 0x00, 0x9c, 0x00, 0x9d, 0x00, 0x2f, 0x00, 0x35,
+                      0x00, 0x0a, 0x01, 0x00, 0x00, 0x77, 0x1a, 0x1a, 0x00,
+                      0x00, 0xff, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+                      0x12, 0x00, 0x10, 0x00, 0x00, 0x0d, 0x77, 0x77, 0x77,
+                      0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x6e,
+                      0x6f, 0x00, 0x17, 0x00, 0x00, 0x00, 0x23, 0x00, 0x00,
+                      0x00, 0x0d, 0x00, 0x14, 0x00, 0x12, 0x04, 0x03, 0x08,
+                      0x04, 0x04, 0x01, 0x05, 0x03, 0x08, 0x05, 0x05, 0x01,
+                      0x08, 0x06, 0x06, 0x01, 0x02, 0x01, 0x00, 0x05, 0x00,
+                      0x05, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x00,
+                      0x00, 0x00, 0x10, 0x00, 0x0e, 0x00, 0x0c, 0x02, 0x68,
+                      0x32, 0x08, 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e,
+                      0x31, 0x00, 0x0b, 0x00, 0x02, 0x01, 0x00, 0x00, 0x0a,
+                      0x00, 0x0a, 0x00, 0x08, 0xba, 0xba, 0x00, 0x1d, 0x00,
+                      0x17, 0x00, 0x18, 0x0a, 0x0a, 0x00, 0x01, 0x00 };
+
+    Flow f;
+    SSLState *ssl_state = NULL;
+    Packet *p = NULL;
+    Signature *s = NULL;
+    ThreadVars tv;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    TcpSession ssn;
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    memset(&tv, 0, sizeof(ThreadVars));
+    memset(&f, 0, sizeof(Flow));
+    memset(&ssn, 0, sizeof(TcpSession));
+
+    p = UTHBuildPacketReal(buf, sizeof(buf), IPPROTO_TCP,
+                           "192.168.1.5", "192.168.1.1",
+                           41424, 443);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.flags |= FLOW_IPV4;
+    f.proto = IPPROTO_TCP;
+    f.protomap = FlowGetProtoMapping(f.proto);
+
+    p->flow = &f;
+    p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p->flowflags |= FLOW_PKT_TOSERVER|FLOW_PKT_ESTABLISHED;
+    f.alproto = ALPROTO_TLS;
+
+    StreamTcpInitConfig(TRUE);
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    de_ctx->mpm_matcher = mpm_default_matcher;
+    de_ctx->flags |= DE_QUIET;
+
+    s = DetectEngineAppendSig(de_ctx, "alert tls any any -> any any "
+                              "(msg:\"Test ja3_hash\"; ja3_hash; "
+                              "content:\"bc6c386f480ee97b9d9e52d472b772d8\"; "
+                              "sid:1;)");
+    FAIL_IF_NULL(s);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&tv, (void *)de_ctx, (void *)&det_ctx);
+
+    FLOWLOCK_WRLOCK(&f);
+    int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_TLS,
+                                STREAM_TOSERVER, buf, sizeof(buf));
+    FLOWLOCK_UNLOCK(&f);
+    FAIL_IF(r != 0);
+
+    ssl_state = f.alstate;
+    FAIL_IF_NULL(ssl_state);
+
+    FAIL_IF_NULL(ssl_state->ja3_hash);
+
+    SigMatchSignatures(&tv, de_ctx, det_ctx, p);
+
+    FAIL_IF_NOT(PacketAlertCheck(p, 1));
+
+    AppLayerParserThreadCtxFree(alp_tctx);
+    DetectEngineThreadCtxDeinit(&tv, det_ctx);
+    DetectEngineCtxFree(de_ctx);
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePacket(p);
+
+    PASS;
+}
 #endif /* UNITTESTS */
 
 static void DetectTlsJa3HashRegisterTests(void)
 {
 #ifdef UNITTESTS
     UtRegisterTest("DetectTlsJa3HashTest01", DetectTlsJa3HashTest01);
+    UtRegisterTest("DetectTlsJa3HashTest02", DetectTlsJa3HashTest02);
 #endif /* UNITTESTS */
 }
 


### PR DESCRIPTION
Fix JA3 bug that occurs when decoding empty extensions in ClientHello packet. Also fix JA3 bug that occurs when encountering earlier drafts of TLSv1.3.

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/171
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/171