### PR TITLE
output: Add direction for eve JSON logs

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -706,6 +706,20 @@ json_t *CreateJSONHeader(const Packet *p, enum OutputJsonLogDirection dir,
         json_object_set_new(js, "in_iface", json_string(p->livedev->dev));
     }
 
+    /* 
+     * Stream direction based on TO_CLIENT|TO_SERVER, will in most cases describe 
+     * what direction the first packet was seen.
+     * NB: This might have some weird results in IPS mode
+     * so we disable this if we are in IPS mode
+    */
+
+    if (!EngineModeIsIPS()) {
+        if (p->flowflags & FLOW_PKT_TOCLIENT) {
+            json_object_set_new(js, "flow_direction", json_string("to_client"));
+        } else if (p->flowflags & FLOW_PKT_TOSERVER) {
+            json_object_set_new(js, "flow_direction", json_string("to_server"));
+        }
+    }
     /* pcap_cnt */
     if (p->pcap_cnt != 0) {
         json_object_set_new(js, "pcap_cnt", json_integer(p->pcap_cnt));


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues/) ticket: [#2644](https://redmine.openinfosecfoundation.org/issues/2644)

Describe changes:
- Created a new field in EVE output declaring the direction of the flow ( TO_SERVER/TO_CLIENT )
This makes it easier to understand what direction the event actually happend in, so you don't have to wonder if a request is to or from a service depending on ports.

Example: 
"flow_direction": "to_client",
  "pcap_cnt": 23,
  "event_type": "dns",
  "src_ip": "10.0.0.10",
  "src_port": 53,
  "dest_ip": "10.0.0.201",
  "dest_port": 52697,


I saw from https://github.com/OISF/suricata/pull/3438/ that you tried to do this for Alerts, but i think it should be part of every event.
I also disabled this for IPS mode as it might behave weird in IPS mode.
