### PR TITLE
Lua from default 2627 v1

### DIFF
--- a/doc/userguide/output/lua-output.rst
+++ b/doc/userguide/output/lua-output.rst
@@ -92,8 +92,7 @@ scripts like so:
           - flow.lua
 
 The scripts-dir option is optional. It makes Suricata load the scripts
-from this directory. Otherwise scripts will be loaded from the current
-workdir.
+from this directory. Otherwise scripts will be loaded from the rules folder.
 
 Developing lua output script
 -----------------------------

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -450,7 +450,6 @@ typedef struct LogLuaScriptOptions_ {
 static int LuaScriptInit(const char *filename, LogLuaScriptOptions *options) {
     int status;
 
-    printf("Lua filename %s \n", filename);
     lua_State *luastate = LuaGetState();
     if (luastate == NULL)
         goto error;
@@ -667,7 +666,6 @@ static OutputInitResult OutputLuaLogInitSub(ConfNode *conf, OutputCtx *parent_ct
 {
     OutputInitResult result = { NULL, false };
     if (conf == NULL) {
-        printf("Is conf NULL?");
         return result;
     }
     LogLuaCtx *lua_ctx = SCMalloc(sizeof(LogLuaCtx));
@@ -689,7 +687,6 @@ static OutputInitResult OutputLuaLogInitSub(ConfNode *conf, OutputCtx *parent_ct
         dir = mc->path;
     }
 
-    printf("Lua dir: %s \n", dir);
     char path[PATH_MAX] = "";
     int ret = snprintf(path, sizeof(path),"%s%s%s", dir, strlen(dir) ? "/" : "", conf->val);
     if (ret < 0 || ret == sizeof(path)) {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2627
Describe changes:
- Changed the default fallback for lua scripts from the working directory to the same as the default rule folder

I would like some feedback on this PR:
- Is this was you intended with the issue VictorJ?
- Is this enough, or should there be a second fallback if the rule directory is not set? Or will it fail somewhere else?
