### PR TITLE
app-layer-ssl: add support for early data in TLSv1.3

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -946,7 +946,7 @@ static inline int TLSDecodeHSHelloExtensionSupportedVersions(SSLState *ssl_state
         uint16_t ver = *input << 8 | *(input + 1);
 
         if ((ssl_state->flags & SSL_AL_FLAG_CH_VERSION_EXTENSION) &&
-            ((ver == TLS_VERSION_13) || (((ver >> 8) & 0xff) == 0x7f))) {
+            (ver > TLS_VERSION_12)) {
             ssl_state->flags |= SSL_AL_FLAG_LOG_WITHOUT_CERT;
         }
 

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2187,31 +2187,28 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
             break;
 
         case SSLV3_APPLICATION_PROTOCOL:
-            if ((ssl_state->flags & SSL_AL_FLAG_CLIENT_CHANGE_CIPHER_SPEC) &&
-                (ssl_state->flags & SSL_AL_FLAG_SERVER_CHANGE_CIPHER_SPEC)) {
-
-                if (ssl_config.encrypt_mode != SSL_CNF_ENC_HANDLE_FULL) {
-                    SCLogDebug("setting APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD");
-                    AppLayerParserStateSetFlag(pstate,
-                            APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD);
-                }
-            }
-
             /* In TLSv1.3 early data (0-RTT) could be sent before the
                ServerHello record (rfc8446, section 2.3). We should
                therefore check that the ServerHello record is present
                before marking the handshake as done. */
             if (ssl_state->flags & SSL_AL_FLAG_STATE_SERVER_HELLO) {
                 ssl_state->flags |= SSL_AL_FLAG_HANDSHAKE_DONE;
-            }
 
-            /* Encrypted data, reassembly not asked, bypass asked, let's sacrifice
-             * heartbeat lke inspection to be able to be able to bypass the flow */
-            if (ssl_config.encrypt_mode == SSL_CNF_ENC_HANDLE_BYPASS) {
-                SCLogDebug("setting APP_LAYER_PARSER_NO_REASSEMBLY");
-                AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_REASSEMBLY);
-                AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_INSPECTION);
-                AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_BYPASS_READY);
+                if (ssl_config.encrypt_mode != SSL_CNF_ENC_HANDLE_FULL) {
+                    SCLogDebug("setting APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD");
+                    AppLayerParserStateSetFlag(pstate,
+                            APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD);
+                }
+
+                if (ssl_config.encrypt_mode == SSL_CNF_ENC_HANDLE_BYPASS) {
+                    SCLogDebug("setting APP_LAYER_PARSER_NO_REASSEMBLY");
+                    AppLayerParserStateSetFlag(pstate,
+                            APP_LAYER_PARSER_NO_REASSEMBLY);
+                    AppLayerParserStateSetFlag(pstate,
+                            APP_LAYER_PARSER_NO_INSPECTION);
+                    AppLayerParserStateSetFlag(pstate,
+                            APP_LAYER_PARSER_BYPASS_READY);
+                }
             }
 
             break;


### PR DESCRIPTION
This pull request does the following three things:
- It stops decoding from breaking when encountering TLSv1.3 0-RTT.
- Fixes flow and inspection bypass for TLSv1.3.
- Handles all version numbers above TLSv1.2 as TLSv1.3.

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/172
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/172