### PR TITLE
app-layer-ssl: add support for early data (0-RTT) in TLSv1.3

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2208,6 +2208,14 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
             break;
 
         case SSLV3_APPLICATION_PROTOCOL:
+            /* In TLSv1.3 early data (0-RTT) could be sent before the
+               handshake is complete (rfc8446, section 2.3). We should
+               therefore not mark the handshake as done before we have
+               seen the ServerHello record. */
+            if ((ssl_state->flags & SSL_AL_FLAG_EARLY_DATA) &&
+                    ((ssl_state->flags & SSL_AL_FLAG_STATE_SERVER_HELLO) == 0))
+                break;
+
             if ((ssl_state->flags & SSL_AL_FLAG_CLIENT_CHANGE_CIPHER_SPEC) &&
                 (ssl_state->flags & SSL_AL_FLAG_SERVER_CHANGE_CIPHER_SPEC)) {
 
@@ -2234,8 +2242,16 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
             break;
 
         case SSLV3_HANDSHAKE_PROTOCOL:
-            if (ssl_state->flags & SSL_AL_FLAG_CHANGE_CIPHER_SPEC)
-                break;
+            if (ssl_state->flags & SSL_AL_FLAG_CHANGE_CIPHER_SPEC) {
+                /* In TLSv1.3, ChangeCipherSpec is only used for middlebox
+                   compability (rfc8446, appendix D.4). */
+                if ((ssl_state->client_connp.version > TLS_VERSION_12) &&
+                       ((ssl_state->flags & SSL_AL_FLAG_STATE_SERVER_HELLO) == 0)) {
+                    /* do nothing */
+                } else {
+                    break;
+                }
+            }
 
             if (ssl_state->curr_connp->record_length < 4) {
                 SSLParserReset(ssl_state);

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1174,6 +1174,19 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
                 break;
             }
 
+            case SSL_EXTENSION_EARLY_DATA:
+            {
+                if (ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) {
+                    /* Used by 0-RTT to indicate that encrypted data will
+                       be sent right after the ClientHello record. */
+                    ssl_state->flags |= SSL_AL_FLAG_EARLY_DATA;
+                }
+
+                input += ext_len;
+
+                break;
+            }
+
             case SSL_EXTENSION_SUPPORTED_VERSIONS:
             {
                 ret = TLSDecodeHSHelloExtensionSupportedVersions(ssl_state, input,

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -946,7 +946,7 @@ static inline int TLSDecodeHSHelloExtensionSupportedVersions(SSLState *ssl_state
         uint16_t ver = *input << 8 | *(input + 1);
 
         if ((ssl_state->flags & SSL_AL_FLAG_CH_VERSION_EXTENSION) &&
-            ((ver == TLS_VERSION_13) || (((ver >> 8) & 0xff) == 0x7f))) {
+                (ver > TLS_VERSION_12)) {
             ssl_state->flags |= SSL_AL_FLAG_LOG_WITHOUT_CERT;
         }
 

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2216,27 +2216,26 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
                     ((ssl_state->flags & SSL_AL_FLAG_STATE_SERVER_HELLO) == 0))
                 break;
 
-            if ((ssl_state->flags & SSL_AL_FLAG_CLIENT_CHANGE_CIPHER_SPEC) &&
-                (ssl_state->flags & SSL_AL_FLAG_SERVER_CHANGE_CIPHER_SPEC)) {
-
-                if (ssl_config.encrypt_mode != SSL_CNF_ENC_HANDLE_FULL) {
-                    SCLogDebug("setting APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD");
-                    AppLayerParserStateSetFlag(pstate,
-                            APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD);
-                }
-            }
-
             /* if we see (encrypted) aplication data, then this means the
                handshake must be done */
             ssl_state->flags |= SSL_AL_FLAG_HANDSHAKE_DONE;
+
+            if (ssl_config.encrypt_mode != SSL_CNF_ENC_HANDLE_FULL) {
+                SCLogDebug("setting APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD");
+                AppLayerParserStateSetFlag(pstate,
+                        APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD);
+            }
 
             /* Encrypted data, reassembly not asked, bypass asked, let's sacrifice
              * heartbeat lke inspection to be able to be able to bypass the flow */
             if (ssl_config.encrypt_mode == SSL_CNF_ENC_HANDLE_BYPASS) {
                 SCLogDebug("setting APP_LAYER_PARSER_NO_REASSEMBLY");
-                AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_REASSEMBLY);
-                AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_INSPECTION);
-                AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_BYPASS_READY);
+                AppLayerParserStateSetFlag(pstate,
+                        APP_LAYER_PARSER_NO_REASSEMBLY);
+                AppLayerParserStateSetFlag(pstate,
+                        APP_LAYER_PARSER_NO_INSPECTION);
+                AppLayerParserStateSetFlag(pstate,
+                        APP_LAYER_PARSER_BYPASS_READY);
             }
 
             break;

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -110,6 +110,10 @@ enum {
    to log TLSv1.3 sessions. */
 #define SSL_AL_FLAG_LOG_WITHOUT_CERT            BIT_U32(22)
 
+/* Encountered a early data extension in client hello. This extension is
+   used by 0-RTT. */
+#define SSL_AL_FLAG_EARLY_DATA                  BIT_U32(23)
+
 /* config flags */
 #define SSL_TLS_LOG_PEM                         (1 << 0)
 
@@ -118,6 +122,7 @@ enum {
 #define SSL_EXTENSION_ELLIPTIC_CURVES           0x000a
 #define SSL_EXTENSION_EC_POINT_FORMATS          0x000b
 #define SSL_EXTENSION_SESSION_TICKET            0x0023
+#define SSL_EXTENSION_EARLY_DATA                0x002a
 #define SSL_EXTENSION_SUPPORTED_VERSIONS        0x002b
 
 /* SNI types */


### PR DESCRIPTION
This pull request does three things:
- It stops TLS decoding from breaking when encountering early data in TLSv1.3.
- It fixes flow and inspection bypass for TLSv1.3.
- It handles all version numbers above TLSv1.2 as TLSv1.3.

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/173
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/173
