### PR TITLE
source-nfq: support queue range and increase maximum number of queues to 128

### DIFF
--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -48,6 +48,7 @@
 #include "util-debug.h"
 #include "util-error.h"
 #include "util-byte.h"
+#include "util-cpu.h"
 #include "util-privs.h"
 #include "util-device.h"
 
@@ -827,6 +828,8 @@ int NFQRegisterQueue(const char *queue)
 {
     NFQThreadVars *ntv = NULL;
     NFQQueueVars *nq = NULL;
+    static bool many_queues_warned = false;
+    uint16_t num_cpus = UtilCpuGetNumProcessorsOnline();
     /* Extract the queue number from the specified command line argument */
     uint16_t queue_num = 0;
     if ((ByteExtractStringUint16(&queue_num, 10, strlen(queue), queue)) < 0)
@@ -837,10 +840,17 @@ int NFQRegisterQueue(const char *queue)
     }
 
     SCMutexLock(&nfq_init_lock);
+    if (!many_queues_warned && (receive_queue_num >= num_cpus)) {
+        SCLogWarning(SC_WARN_UNCOMMON,
+                     "using more Netfilter queues than %hu available CPU core(s) "
+                     "may degrade performance",
+                     num_cpus);
+        many_queues_warned = true;
+    }
     if (receive_queue_num >= NFQ_MAX_QUEUE) {
         SCLogError(SC_ERR_INVALID_ARGUMENT,
-                   "too much Netfilter queue registered (%d)",
-                   receive_queue_num);
+                   "can not register more than %d Netfilter queues",
+                   NFQ_MAX_QUEUE);
         SCMutexUnlock(&nfq_init_lock);
         return -1;
     }
@@ -878,18 +888,17 @@ int NFQParseAndRegisterQueues(const char *queues)
 
     if ((queue2 = strchr(queues, ':')) != NULL)  {
         // "Start:end" format (e.g. "0:5")
-        queue2[0] = '\0';
         queue2++;
 
-        if ((ByteExtractStringUint16(&queue_start, 10, strlen(queues), queues)) < 0) {
-            SCLogError(SC_ERR_INVALID_ARGUMENT, "specified start queue '%s' is not "
+        if ((ByteExtractStringUint16(&queue_start, 10, queue2 - queues, queues)) < 0) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "specified starting queue '%s' is not "
                                         "valid", queues);
             return -1;
         }
 
         if (strcmp(queue2, "") != 0) {
             if ((ByteExtractStringUint16(&queue_end, 10, strlen(queue2), queue2)) < 0) {
-                SCLogError(SC_ERR_INVALID_ARGUMENT, "specified end queue '%s' is not "
+                SCLogError(SC_ERR_INVALID_ARGUMENT, "specified ending queue '%s' is not "
                                             "valid", queue2);
                 return -1;
             }
@@ -899,7 +908,7 @@ int NFQParseAndRegisterQueues(const char *queues)
 
         // Sanity check
         if (queue_start > queue_end) {
-            SCLogError(SC_ERR_INVALID_ARGUMENT, "start queue's number %d is greater than "
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "starting queue's number %d is greater than "
                                             "ending number %d", queue_start, queue_end);
             return -1;
         }

--- a/src/source-nfq.h
+++ b/src/source-nfq.h
@@ -30,7 +30,8 @@
 #include <linux/netfilter.h>		/* for NF_ACCEPT */
 #include <libnetfilter_queue/libnetfilter_queue.h>
 
-#define NFQ_MAX_QUEUE 16
+// Not a Netfilter's limit, it's just for sanity
+#define NFQ_MAX_QUEUE 128
 
 /* idea: set the recv-thread id in the packet to
  * select an verdict-queue */

--- a/src/source-nfq.h
+++ b/src/source-nfq.h
@@ -89,7 +89,8 @@ typedef struct NFQGlobalVars_
 } NFQGlobalVars;
 
 void NFQInitConfig(char quiet);
-int NFQRegisterQueue(char *queue);
+int NFQRegisterQueue(const char *queue);
+int NFQParseAndRegisterQueues(const char *queues);
 int NFQGetQueueCount(void);
 void *NFQGetQueue(int number);
 int NFQGetQueueNum(int number);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -582,7 +582,7 @@ static void PrintUsage(const char *progname)
     printf("\t-F <bpf filter file>                 : bpf filter file\n");
     printf("\t-r <path>                            : run in pcap file/offline mode\n");
 #ifdef NFQ
-    printf("\t-q <qid>                             : run in inline nfqueue mode\n");
+    printf("\t-q <qid[:qid]>                       : run in inline nfqueue mode (use semicolon to specify a range of queues)\n");
 #endif /* NFQ */
 #ifdef IPFW
     printf("\t-d <divert port>                     : run in inline ipfw divert mode\n");
@@ -1974,10 +1974,10 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             if (suri->run_mode == RUNMODE_UNKNOWN) {
                 suri->run_mode = RUNMODE_NFQ;
                 EngineModeSetIPS();
-                if (NFQRegisterQueue(optarg) == -1)
+                if (NFQParseAndRegisterQueues(optarg) == -1)
                     return TM_ECODE_FAILED;
             } else if (suri->run_mode == RUNMODE_NFQ) {
-                if (NFQRegisterQueue(optarg) == -1)
+                if (NFQParseAndRegisterQueues(optarg) == -1)
                     return TM_ECODE_FAILED;
             } else {
                 SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x ] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- added ability to specify Netfilter queue range with '-q' option (similar to iptables '--queue-balance' option)
- increase maximum number of queues from 16 to 128
