### PR TITLE
app-layer-ssl: fix coverty error (RESOURCE_LEAK)

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1115,7 +1115,7 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
         ja3_elliptic_curves_pf = Ja3BufferInit();
         if (ja3_extensions == NULL || ja3_elliptic_curves == NULL ||
                 ja3_elliptic_curves_pf == NULL)
-            return -1;
+            goto error;
     }
 
     /* Extensions are optional (RFC5246 section 7.4.1.2) */


### PR DESCRIPTION
Fix possible memory leak in JA3 detected by coverty.

https://redmine.openinfosecfoundation.org/issues/2677

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/176
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/176