### PR TITLE
Mixed mode v15

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -489,6 +489,7 @@ util-reference-config.c util-reference-config.h \
 util-rohash.c util-rohash.h \
 util-rule-vars.c util-rule-vars.h \
 util-runmodes.c util-runmodes.h \
+util-runmodes-slots.c util-runmodes-slots.h \
 util-running-modes.c util-running-modes.h \
 util-signal.c util-signal.h \
 util-spm-bm.c util-spm-bm.h \

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -135,7 +135,7 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)
         }
 
         const char *action = "";
-        if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+        if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
             action = "[Drop] ";
         } else if (pa->action & ACTION_DROP) {
             action = "[wDrop] ";

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -223,7 +223,7 @@ static TmEcode AlertSyslogIPv4(ThreadVars *tv, const Packet *p, void *data)
         PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), dstip, sizeof(dstip));
 
-        if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+        if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
             action = "[Drop] ";
         } else if (pa->action & ACTION_DROP) {
             action = "[wDrop] ";
@@ -279,7 +279,7 @@ static TmEcode AlertSyslogIPv6(ThreadVars *tv, const Packet *p, void *data)
         PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), dstip, sizeof(dstip));
 
-        if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+        if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
             action = "[Drop] ";
         } else if (pa->action & ACTION_DROP) {
             action = "[wDrop] ";
@@ -340,7 +340,7 @@ static TmEcode AlertSyslogDecoderEvent(ThreadVars *tv, const Packet *p, void *da
             continue;
         }
 
-        if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+        if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
             action = "[Drop] ";
         } else if (pa->action & ACTION_DROP) {
             action = "[wDrop] ";

--- a/src/alert-unified2-alert.c
+++ b/src/alert-unified2-alert.c
@@ -1457,8 +1457,7 @@ static int Unified2AlertOpenFileCtx(LogFileCtx *file_ctx, const char *prefix,
     struct timeval ts;
     memset(&ts, 0x00, sizeof(struct timeval));
 
-    extern int run_mode;
-    if (run_mode == RUNMODE_UNITTEST)
+    if (RunmodeIsUnittests())
         TimeGet(&ts);
     else
         gettimeofday(&ts, NULL);

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -287,7 +287,7 @@ static int TCPProtoDetectTriggerOpposingSide(ThreadVars *tv,
         return -1;
     }
 
-    enum StreamUpdateDir dir = StreamTcpInlineMode() ?
+    enum StreamUpdateDir dir = StreamTcpInlineMode(p) ?
                                                 UPDATE_DIR_OPPOSING :
                                                 UPDATE_DIR_PACKET;
     int ret = StreamTcpReassembleAppLayer(tv, ra_ctx, ssn,

--- a/src/decode.c
+++ b/src/decode.c
@@ -259,6 +259,16 @@ inline int PacketCopyData(Packet *p, uint8_t *pktdata, uint32_t pktlen)
     return PacketCopyDataOffset(p, 0, pktdata, pktlen);
 }
 
+int PacketModeIsIPS(const Packet *p)
+{
+  return (p->pkt_mode == PKT_MODE_IPS);
+}
+
+int PacketModeIsIDS(const Packet *p)
+{
+  return (p->pkt_mode == PKT_MODE_IDS);
+}
+
 /**
  *  \brief Setup a pseudo packet (tunnel)
  *
@@ -290,6 +300,7 @@ Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *pare
     p->ts.tv_usec = parent->ts.tv_usec;
     p->datalink = DLT_RAW;
     p->tenant_id = parent->tenant_id;
+    p->pkt_mode = parent->pkt_mode;
 
     /* set the root ptr to the lowest layer */
     if (parent->root != NULL)
@@ -364,6 +375,8 @@ Packet *PacketDefragPktSetup(Packet *parent, uint8_t *pkt, uint32_t len, uint8_t
     p->ts.tv_usec = parent->ts.tv_usec;
     p->datalink = DLT_RAW;
     p->tenant_id = parent->tenant_id;
+    p->pkt_mode = parent->pkt_mode;
+
     /* tell new packet it's part of a tunnel */
     SET_TUNNEL_PKT(p);
     p->vlan_id[0] = parent->vlan_id[0];

--- a/src/decode.h
+++ b/src/decode.h
@@ -387,6 +387,8 @@ typedef struct PktProfiling_ {
 /* forward declartion since Packet struct definition requires this */
 struct PacketQueue_;
 
+enum PktMode {PKT_MODE_IDS, PKT_MODE_IPS, PKY_MODE_AUTO};
+
 /* sizes of the members:
  * src: 17 bytes
  * dst: 17 bytes
@@ -448,6 +450,8 @@ typedef struct Packet_
     uint32_t flow_hash;
 
     struct timeval ts;
+
+    enum PktMode pkt_mode;
 
     union {
         /* nfq stuff */
@@ -926,6 +930,8 @@ int PacketSetData(Packet *p, uint8_t *pktdata, uint32_t pktlen);
 int PacketCopyDataOffset(Packet *p, uint32_t offset, uint8_t *data, uint32_t datalen);
 const char *PktSrcToString(enum PktSrcEnum pkt_src);
 void PacketBypassCallback(Packet *p);
+int PacketModeIsIPS(const Packet *p);
+int PacketModeIsIDS(const Packet *p);
 
 DecodeThreadVars *DecodeThreadVarsAlloc(ThreadVars *);
 void DecodeThreadVarsFree(ThreadVars *, DecodeThreadVars *);

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -281,13 +281,14 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     char varname[128] = "rule-files";
     int good_sigs = 0;
     int bad_sigs = 0;
+    extern RunmodesSlots runmodesslots;
 
     if (strlen(de_ctx->config_prefix) > 0) {
         snprintf(varname, sizeof(varname), "%s.rule-files",
                 de_ctx->config_prefix);
     }
 
-    if (RunmodeGetCurrent() == RUNMODE_ENGINE_ANALYSIS) {
+    if (RunmodesSlotsGetFirstSlot(&runmodesslots) == RUNMODE_ENGINE_ANALYSIS) {
         fp_engine_analysis_set = SetupFPAnalyzer();
         rule_engine_analysis_set = SetupRuleAnalyzer();
     }
@@ -370,7 +371,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
 
  end:
     gettimeofday(&de_ctx->last_reload, NULL);
-    if (RunmodeGetCurrent() == RUNMODE_ENGINE_ANALYSIS) {
+    if (RunmodesSlotsGetFirstSlot(&runmodesslots) == RUNMODE_ENGINE_ANALYSIS) {
         if (rule_engine_analysis_set) {
             CleanupRuleAnalyzer();
         }

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2970,7 +2970,7 @@ static int DetectEngineMultiTenantSetupLoadLivedevMappings(const ConfNode *mappi
             }
 
             const char *dev = device_node->val;
-            LiveDevice *ld = LiveGetDevice(dev);
+            LiveDevice *ld = LiveGetDevice(dev, LiveGetDeviceRunmode(dev));
             if (ld == NULL) {
                 SCLogWarning(SC_ERR_MT_NO_MAPPING, "device %s not found", dev);
                 goto bad_mapping;

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1770,7 +1770,7 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
         }
     }
 
-    if (run_mode == RUNMODE_UNITTEST) {
+    if (RunmodeIsUnittests()) {
         de_ctx->sgh_mpm_context = ENGINE_SGH_MPM_FACTORY_CONTEXT_FULL;
     }
 

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -268,7 +268,7 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data, PacketQueue *pr
     if (p->flow != NULL && p->proto == IPPROTO_TCP) {
         FLOWWORKER_PROFILING_START(p, PROFILE_FLOWWORKER_TCPPRUNE);
         StreamTcpPruneSession(p->flow, p->flowflags & FLOW_PKT_TOSERVER ?
-                STREAM_TOSERVER : STREAM_TOCLIENT);
+                STREAM_TOSERVER : STREAM_TOCLIENT, p);
         FLOWWORKER_PROFILING_END(p, PROFILE_FLOWWORKER_TCPPRUNE);
     }
 

--- a/src/log-droplog.c
+++ b/src/log-droplog.c
@@ -284,7 +284,7 @@ static int LogDropLogNetFilter (ThreadVars *tv, const Packet *p, void *data)
  */
 static int LogDropCondition(ThreadVars *tv, const Packet *p)
 {
-    if (!EngineModeIsIPS()) {
+    if (!PacketModeIsIPS(p)) {
         SCLogDebug("engine is not running in inline mode, so returning");
         return FALSE;
     }
@@ -376,6 +376,7 @@ static int LogDropLogTest01(void)
 
     memset(&th_v, 0, sizeof(th_v));
     p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
+    p->pkt_mode = PKT_MODE_IPS;
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL) {

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -308,7 +308,7 @@ void AlertJsonHeader(void *ctx, const Packet *p, const PacketAlert *pa, json_t *
     } else {
         if (pa->action & (ACTION_REJECT|ACTION_REJECT_DST|ACTION_REJECT_BOTH)) {
             action = "blocked";
-        } else if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+        } else if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
             action = "blocked";
         }
     }
@@ -658,7 +658,7 @@ static int AlertJsonDecoderEvent(ThreadVars *tv, JsonAlertLogThread *aft, const 
         const char *action = "allowed";
         if (pa->action & (ACTION_REJECT|ACTION_REJECT_DST|ACTION_REJECT_BOTH)) {
             action = "blocked";
-        } else if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+        } else if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
             action = "blocked";
         }
 

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -160,7 +160,7 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
                 continue;
             }
             if ((pa->action & (ACTION_REJECT|ACTION_REJECT_DST|ACTION_REJECT_BOTH)) ||
-               ((pa->action & ACTION_DROP) && EngineModeIsIPS()))
+               ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)))
             {
                 AlertJsonHeader(NULL, p, pa, js, 0);
                 logged = 1;
@@ -406,8 +406,8 @@ static int JsonDropLogger(ThreadVars *tv, void *thread_data, const Packet *p)
  */
 static int JsonDropLogCondition(ThreadVars *tv, const Packet *p)
 {
-    if (!EngineModeIsIPS()) {
-        SCLogDebug("engine is not running in inline mode, so returning");
+    if (!PacketModeIsIPS(p)) {
+        SCLogDebug("packet is not running in inline mode, so returning");
         return FALSE;
     }
     if (PKT_IS_PSEUDOPKT(p)) {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -60,6 +60,7 @@
 #include "util-device.h"
 #include "util-validate.h"
 #include "util-crypt.h"
+#include "util-runmodes-slots.h"
 
 #include "flow-var.h"
 #include "flow-bit.h"
@@ -828,6 +829,7 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer)
 OutputInitResult OutputJsonInitCtx(ConfNode *conf)
 {
     OutputInitResult result = { NULL, false };
+    extern RunmodesSlots runmodesslots;
 
     OutputJsonCtx *json_ctx = SCCalloc(1, sizeof(OutputJsonCtx));
     if (unlikely(json_ctx == NULL)) {
@@ -1040,7 +1042,7 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
         const char *pcapfile_s = ConfNodeLookupChildValue(conf, "pcap-file");
         if (pcapfile_s != NULL && ConfValIsTrue(pcapfile_s)) {
             json_ctx->file_ctx->is_pcap_offline =
-                (RunmodeGetCurrent() == RUNMODE_PCAP_FILE);
+                (RunmodesSlotsGetFirstSlot(&runmodesslots) == RUNMODE_PCAP_FILE);
         }
 
         json_ctx->file_ctx->type = json_ctx->json_out;

--- a/src/output-streaming.c
+++ b/src/output-streaming.c
@@ -323,7 +323,7 @@ static TmEcode OutputStreamingLog(ThreadVars *tv, Packet *p, void *thread_data)
         SCReturnInt(TM_ECODE_OK);
     }
 
-    if (!(StreamTcpInlineMode())) {
+    if (!(StreamTcpInlineMode(p))) {
         if (PKT_IS_TOCLIENT(p)) {
             flags |= OUTPUT_STREAMING_FLAG_TOSERVER;
         } else {

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -617,7 +617,7 @@ finalize:
                             "Using AF_PACKET with offloading activated leads to capture problems");
                 }
             } else {
-                DisableIfaceOffloading(LiveGetDevice(iface), 0, 1);
+                DisableIfaceOffloading(LiveGetDevice(iface, RUNMODE_AFP_DEV), 0, 1);
             }
             break;
         case -1:
@@ -654,7 +654,7 @@ static int AFPConfigGeThreadsCount(void *conf)
 
 int AFPRunModeIsIPS()
 {
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceCount(RUNMODE_AFP_DEV);
     int ldev;
     ConfNode *if_root;
     ConfNode *if_default = NULL;
@@ -671,7 +671,7 @@ int AFPRunModeIsIPS()
     if_default = ConfNodeLookupKeyValue(af_packet_node, "interface", "default");
 
     for (ldev = 0; ldev < nlive; ldev++) {
-        const char *live_dev = LiveGetDeviceName(ldev);
+        const char *live_dev = LiveGetDeviceName(ldev, RUNMODE_AFP_DEV);
         if (live_dev == NULL) {
             SCLogError(SC_ERR_INVALID_VALUE, "Problem with config file");
             return 0;
@@ -701,7 +701,7 @@ int AFPRunModeIsIPS()
     if (has_ids && has_ips) {
         SCLogInfo("AF_PACKET mode using IPS and IDS mode");
         for (ldev = 0; ldev < nlive; ldev++) {
-            const char *live_dev = LiveGetDeviceName(ldev);
+            const char *live_dev = LiveGetDeviceName(ldev, RUNMODE_AFP_DEV);
             if (live_dev == NULL) {
                 SCLogError(SC_ERR_INVALID_VALUE, "Problem with config file");
                 return 0;

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -759,7 +759,7 @@ int RunModeIdsAFPAutoFp(void)
                               AFPConfigGeThreadsCount,
                               "ReceiveAFP",
                               "DecodeAFP", thread_name_autofp,
-                              live_dev);
+                              live_dev, RUNMODE_AFP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -801,7 +801,7 @@ int RunModeIdsAFPSingle(void)
                                     AFPConfigGeThreadsCount,
                                     "ReceiveAFP",
                                     "DecodeAFP", thread_name_single,
-                                    live_dev);
+                                    live_dev, RUNMODE_AFP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -846,7 +846,7 @@ int RunModeIdsAFPWorkers(void)
                                     AFPConfigGeThreadsCount,
                                     "ReceiveAFP",
                                     "DecodeAFP", thread_name_workers,
-                                    live_dev);
+                                    live_dev, RUNMODE_AFP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);

--- a/src/runmode-erf-dag.c
+++ b/src/runmode-erf-dag.c
@@ -86,7 +86,8 @@ int RunModeIdsErfDagSingle(void)
         "ReceiveErfDag",
         "DecodeErfDag",
         thread_name_single,
-        NULL);
+        NULL,
+        RUNMODE_DAG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "DAG single runmode failed to start");
         exit(EXIT_FAILURE);
@@ -112,7 +113,8 @@ int RunModeIdsErfDagAutoFp(void)
         "ReceiveErfDag",
         "DecodeErfDag",
         thread_name_autofp,
-        NULL);
+        NULL,
+        RUNMODE_DAG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "DAG autofp runmode failed to start");
         exit(EXIT_FAILURE);
@@ -138,7 +140,8 @@ int RunModeIdsErfDagWorkers(void)
         "ReceiveErfDag",
         "DecodeErfDag",
         thread_name_workers,
-        NULL);
+        NULL,
+        RUNMODE_DAG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "DAG workers runmode failed to start");
         exit(EXIT_FAILURE);

--- a/src/runmode-ipfw.c
+++ b/src/runmode-ipfw.c
@@ -78,7 +78,8 @@ int RunModeIpsIPFWAutoFp(void)
     ret = RunModeSetIPSAutoFp(IPFWGetThread,
             "ReceiveIPFW",
             "VerdictIPFW",
-            "DecodeIPFW");
+            "DecodeIPFW",
+            RUNMODE_IPFW);
 #endif /* IPFW */
     return ret;
 }
@@ -98,7 +99,8 @@ int RunModeIpsIPFWWorker(void)
     ret = RunModeSetIPSWorker(IPFWGetThread,
             "ReceiveIPFW",
             "VerdictIPFW",
-            "DecodeIPFW");
+            "DecodeIPFW",
+            RUNMODE_IPFW);
 #endif /* IPFW */
     return ret;
 }

--- a/src/runmode-napatech.c
+++ b/src/runmode-napatech.c
@@ -191,12 +191,12 @@ static int NapatechInit(int runmode)
         case NT_RUNMODE_AUTOFP:
             ret = RunModeSetLiveCaptureAutoFp(NapatechConfigParser, NapatechGetThreadsCount,
                     "NapatechStream", "NapatechDecode",
-                    thread_name_autofp, NULL);
+                    thread_name_autofp, NULL, RUNMODE_NAPATECH);
             break;
         case NT_RUNMODE_WORKERS:
             ret = RunModeSetLiveCaptureWorkers(NapatechConfigParser, NapatechGetThreadsCount,
                     "NapatechStream", "NapatechDecode",
-                    thread_name_workers, NULL);
+                    thread_name_workers, NULL, RUNMODE_NAPATECH);
             break;
         default:
             ret = -1;

--- a/src/runmode-napatech.c
+++ b/src/runmode-napatech.c
@@ -109,7 +109,7 @@ static int NapatechRegisterDeviceStreams(void)
         snprintf(plive_dev_buf, 9, "nt%d", stream_config[inst].stream_id);
         SCLogInfo("registering Napatech device: %s - active stream%sfound.",
                         plive_dev_buf, stream_config[inst].is_active ? " " : " NOT ");
-        LiveRegisterDevice(plive_dev_buf);
+        LiveRegisterDevice(plive_dev_buf, RUNMODE_NAPATECH);
     }
 
     /* Napatech stats come from a separate thread.  This will surpress

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -211,7 +211,7 @@ finalize:
     if (LiveGetOffload() == 0) {
         (void)GetIfaceOffloading(ns->iface, 1, 1);
     } else {
-        DisableIfaceOffloading(LiveGetDevice(ns->iface), 1, 1);
+        DisableIfaceOffloading(LiveGetDevice(ns->iface, RUNMODE_NETMAP), 1, 1);
     }
 
     return 0;
@@ -287,7 +287,7 @@ static int NetmapConfigGeThreadsCount(void *conf)
 
 int NetmapRunModeIsIPS()
 {
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceCount(RUNMODE_NETMAP);
     int ldev;
     ConfNode *if_root;
     ConfNode *if_default = NULL;
@@ -304,7 +304,7 @@ int NetmapRunModeIsIPS()
     if_default = ConfNodeLookupKeyValue(netmap_node, "interface", "default");
 
     for (ldev = 0; ldev < nlive; ldev++) {
-        const char *live_dev = LiveGetDeviceName(ldev);
+        const char *live_dev = LiveGetDeviceName(ldev, RUNMODE_NETMAP);
         if (live_dev == NULL) {
             SCLogError(SC_ERR_INVALID_VALUE, "Problem with config file");
             return 0;
@@ -334,7 +334,7 @@ int NetmapRunModeIsIPS()
     if (has_ids && has_ips) {
         SCLogInfo("Netmap mode using IPS and IDS mode");
         for (ldev = 0; ldev < nlive; ldev++) {
-            const char *live_dev = LiveGetDeviceName(ldev);
+            const char *live_dev = LiveGetDeviceName(ldev, RUNMODE_NETMAP);
             if (live_dev == NULL) {
                 SCLogError(SC_ERR_INVALID_VALUE, "Problem with config file");
                 return 0;

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -386,7 +386,7 @@ int RunModeIdsNetmapAutoFp(void)
                               NetmapConfigGeThreadsCount,
                               "ReceiveNetmap",
                               "DecodeNetmap", thread_name_autofp,
-                              live_dev);
+                              live_dev, RUNMODE_NETMAP);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -419,7 +419,7 @@ int RunModeIdsNetmapSingle(void)
                                     NetmapConfigGeThreadsCount,
                                     "ReceiveNetmap",
                                     "DecodeNetmap", thread_name_single,
-                                    live_dev);
+                                    live_dev, RUNMODE_NETMAP);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -455,7 +455,7 @@ int RunModeIdsNetmapWorkers(void)
                                     NetmapConfigGeThreadsCount,
                                     "ReceiveNetmap",
                                     "DecodeNetmap", thread_name_workers,
-                                    live_dev);
+                                    live_dev, RUNMODE_NETMAP);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);

--- a/src/runmode-nflog.c
+++ b/src/runmode-nflog.c
@@ -186,7 +186,7 @@ int RunModeIdsNflogAutoFp(void)
                                       "ReceiveNFLOG",
                                       "DecodeNFLOG",
                                       thread_name_autofp,
-                                      live_dev);
+                                      live_dev, RUNMODE_NFLOG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -214,7 +214,7 @@ int RunModeIdsNflogSingle(void)
                                       "ReceiveNFLOG",
                                       "DecodeNFLOG",
                                       thread_name_single,
-                                      live_dev);
+                                      live_dev, RUNMODE_NFLOG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -242,7 +242,7 @@ int RunModeIdsNflogWorkers(void)
                                        "ReceiveNFLOG",
                                        "DecodeNFLOG",
                                        thread_name_workers,
-                                       live_dev);
+                                       live_dev, RUNMODE_NFLOG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);

--- a/src/runmode-nfq.c
+++ b/src/runmode-nfq.c
@@ -74,7 +74,8 @@ int RunModeIpsNFQAutoFp(void)
     ret = RunModeSetIPSAutoFp(NFQGetThread,
             "ReceiveNFQ",
             "VerdictNFQ",
-            "DecodeNFQ");
+            "DecodeNFQ",
+            RUNMODE_NFQ);
 #endif /* NFQ */
     return ret;
 }
@@ -94,7 +95,8 @@ int RunModeIpsNFQWorker(void)
     ret = RunModeSetIPSWorker(NFQGetThread,
             "ReceiveNFQ",
             "VerdictNFQ",
-            "DecodeNFQ");
+            "DecodeNFQ",
+            RUNMODE_NFQ);
 #endif /* NFQ */
     return ret;
 }

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -248,7 +248,7 @@ int RunModeIdsPcapSingle(void)
                                     PcapConfigGeThreadsCount,
                                     "ReceivePcap",
                                     "DecodePcap", thread_name_single,
-                                    live_dev);
+                                    live_dev, RUNMODE_PCAP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
         exit(EXIT_FAILURE);
@@ -289,7 +289,7 @@ int RunModeIdsPcapAutoFp(void)
                               PcapConfigGeThreadsCount,
                               "ReceivePcap",
                               "DecodePcap", thread_name_autofp,
-                              live_dev);
+                              live_dev, RUNMODE_PCAP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
         exit(EXIT_FAILURE);
@@ -321,7 +321,7 @@ int RunModeIdsPcapWorkers(void)
                                     PcapConfigGeThreadsCount,
                                     "ReceivePcap",
                                     "DecodePcap", thread_name_workers,
-                                    live_dev);
+                                    live_dev, RUNMODE_PCAP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -458,7 +458,7 @@ int RunModeIdsPfringAutoFp(void)
                               PfringConfigGetThreadsCount,
                               "ReceivePfring",
                               "DecodePfring", thread_name_autofp,
-                              live_dev);
+                              live_dev, RUNMODE_PFRING);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
         exit(EXIT_FAILURE);
@@ -495,7 +495,7 @@ int RunModeIdsPfringSingle(void)
                               PfringConfigGetThreadsCount,
                               "ReceivePfring",
                               "DecodePfring", thread_name_single,
-                              live_dev);
+                              live_dev, RUNMODE_PFRING);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
         exit(EXIT_FAILURE);
@@ -532,7 +532,7 @@ int RunModeIdsPfringWorkers(void)
                               PfringConfigGetThreadsCount,
                               "ReceivePfring",
                               "DecodePfring", thread_name_workers,
-                              live_dev);
+                              live_dev, RUNMODE_PFRING);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
         exit(EXIT_FAILURE);

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -385,7 +385,7 @@ static void *ParsePfringConfig(const char *iface)
                     "Using PF_RING with offloading activated leads to capture problems");
         }
     } else {
-        DisableIfaceOffloading(LiveGetDevice(iface), 0, 1);
+        DisableIfaceOffloading(LiveGetDevice(iface, RUNMODE_PFRING), 0, 1);
     }
     return pfconf;
 }
@@ -421,7 +421,7 @@ static int GetDevAndParser(const char **live_dev, ConfigIfaceParserFunc *parser)
         if (*live_dev == NULL) {
             if (ConfGet("pfring.interface", live_dev) == 1) {
                 SCLogInfo("Using interface %s", *live_dev);
-                LiveRegisterDevice(*live_dev);
+                LiveRegisterDevice(*live_dev, RUNMODE_PFRING);
             } else {
                 SCLogInfo("No interface found, problem incoming");
                 *live_dev = NULL;

--- a/src/runmode-tile.c
+++ b/src/runmode-tile.c
@@ -172,7 +172,7 @@ int RunModeTileMpipeWorkers(void)
     ReceiveMpipeInit();
 
     char *mpipe_dev = NULL;
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceCount(RUNMODE_TILERA_MPIPE);
     if (nlive > 0) {
         SCLogInfo("Using %d live device(s).", nlive);
         /*mpipe_dev = LiveGetDevice(0);*/

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -102,6 +102,7 @@ static TAILQ_HEAD(, OutputFreeList_) output_free_list =
 
 extern RunmodesSlots runmodesslots;
 
+static bool already_started = FALSE;
 /**
  * \internal
  * \brief Translate a runmode mode to a printale string.
@@ -391,7 +392,7 @@ void RunModeDispatch(int runmode, const char *custom_mode)
     /* Check if the alloted queues have at least 1 reader and writer */
     TmValidateQueueState();
 
-    if (runmode != RUNMODE_UNIX_SOCKET) {
+    if (runmode != RUNMODE_UNIX_SOCKET && !already_started) {
         /* spawn management threads */
         FlowManagerThreadSpawn();
         FlowRecyclerThreadSpawn();
@@ -399,6 +400,7 @@ void RunModeDispatch(int runmode, const char *custom_mode)
             BypassedFlowManagerThreadSpawn();
         }
         StatsSpawnThreads();
+        already_started = TRUE;
     }
 }
 

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -100,6 +100,8 @@ typedef struct OutputFreeList_ {
 static TAILQ_HEAD(, OutputFreeList_) output_free_list =
     TAILQ_HEAD_INITIALIZER(output_free_list);
 
+extern RunmodesSlots runmodesslots;
+
 /**
  * \internal
  * \brief Translate a runmode mode to a printale string.
@@ -199,9 +201,9 @@ char *RunmodeGetActive(void)
  *
  * \return a string containing the current running mode
  */
-const char *RunModeGetMainMode(void)
+const char *RunModeGetMainMode(int index)
 {
-    int mainmode = RunmodeGetCurrent();
+    int mainmode = RunmodesSlotsGetRunmode(&runmodesslots, index);
 
     return RunModeTranslateModeToName(mainmode);
 }

--- a/src/runmodes.h
+++ b/src/runmodes.h
@@ -73,7 +73,7 @@ extern const char *thread_name_counter_stats;
 extern const char *thread_name_counter_wakeup;
 
 char *RunmodeGetActive(void);
-const char *RunModeGetMainMode(void);
+const char *RunModeGetMainMode(int index);
 
 void RunModeListRunmodes(void);
 void RunModeDispatch(int, const char *);

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2532,7 +2532,7 @@ TmEcode ReceiveAFPThreadInit(ThreadVars *tv, const void *initdata, void **data)
     strlcpy(ptv->iface, afpconfig->iface, AFP_IFACE_NAME_LENGTH);
     ptv->iface[AFP_IFACE_NAME_LENGTH - 1]= '\0';
 
-    ptv->livedev = LiveGetDevice(ptv->iface);
+    ptv->livedev = LiveGetDevice(ptv->iface, RUNMODE_AFP_DEV);
     if (ptv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
         SCFree(ptv);

--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -212,7 +212,7 @@ ReceiveErfDagThreadInit(ThreadVars *tv, void *initdata, void **data)
         exit(EXIT_FAILURE);
     }
 
-    ewtn->livedev = LiveGetDevice(initdata);
+    ewtn->livedev = LiveGetDevice(initdata, RUNMODE_ERF_DAG);
     if (ewtn->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to get %s live device",
             (char *)initdata);

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -743,7 +743,7 @@ int IPFWRegisterQueue(char *queue)
     nq->port_num = port_num;
     receive_port_num++;
     SCMutexUnlock(&ipfw_init_lock);
-    LiveRegisterDeviceName(queue);
+    LiveRegisterDeviceName(queue, RUNMODE_IPFW);
 
     SCLogDebug("Queue \"%s\" registered.", queue);
     return 0;

--- a/src/source-mpipe.c
+++ b/src/source-mpipe.c
@@ -813,7 +813,7 @@ static int MpipeReceiveOpenEgress(char *out_iface, int iface_idx,
                                   MpipeIfaceConfig *mpipe_conf[])
 {
     int channel;
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceCount(RUNMODE_TILERA_MPIPE);
     int result;
 
     /* Initialize an equeue */
@@ -908,10 +908,10 @@ TmEcode ReceiveMpipeThreadInit(ThreadVars *tv, void *initdata, void **data)
     /* Initialize and configure mPIPE, which is only done by one core. */
 
     if (strcmp(link_name, "multi") == 0) {
-        int nlive = LiveGetDeviceCount();
-        int instance = gxio_mpipe_link_instance(LiveGetDeviceName(0));
+        int nlive = LiveGetDeviceCount(RUNMODE_TILERA_MPIPE);
+        int instance = gxio_mpipe_link_instance(LiveGetDeviceName(0, RUNMODE_TILERA_MPIPE));
         for (int i = 1; i < nlive; i++) {
-            link_name = LiveGetDeviceName(i);
+            link_name = LiveGetDeviceName(i, RUNMODE_TILERA_MPIPE);
             if (gxio_mpipe_link_instance(link_name) != instance) {
                 SCLogError(SC_ERR_INVALID_ARGUMENT, 
                            "All interfaces not on same mpipe instance");
@@ -922,7 +922,7 @@ TmEcode ReceiveMpipeThreadInit(ThreadVars *tv, void *initdata, void **data)
         VERIFY(result, "gxio_mpipe_init()");
         /* open ingress interfaces */
         for (int i = 0; i < nlive; i++) {
-            link_name = LiveGetDeviceName(i);
+            link_name = LiveGetDeviceName(i, RUNMODE_TILERA_MPIPE);
             SCLogInfo("opening interface %s", link_name);
             result = gxio_mpipe_link_open(&mpipe_link[i], context,
                                           link_name, 0);

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -500,7 +500,7 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, const void *initdata, voi
     ntv->checksum_mode = aconf->in.checksum_mode;
     ntv->copy_mode = aconf->in.copy_mode;
 
-    ntv->livedev = LiveGetDevice(aconf->iface_name);
+    ntv->livedev = LiveGetDevice(aconf->iface_name, RUNMODE_NETMAP);
     if (ntv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
         goto error_ntv;

--- a/src/source-nflog.c
+++ b/src/source-nflog.c
@@ -289,7 +289,7 @@ TmEcode ReceiveNFLOGThreadInit(ThreadVars *tv, const void *initdata, void **data
         SCLogDebug("NFLOG netlink queue timeout can't be set to %d",
                     ntv->qtimeout);
 
-    ntv->livedev = LiveGetDevice(nflconfig->numgroup);
+    ntv->livedev = LiveGetDevice(nflconfig->numgroup, RUNMODE_NFLOG);
     if (ntv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
 	    SCFree(ntv);

--- a/src/source-nflog.c
+++ b/src/source-nflog.c
@@ -157,6 +157,7 @@ static int NFLOGCallback(struct nflog_g_handle *gh, struct nfgenmsg *msg,
 
     PKT_SET_SRC(p, PKT_SRC_WIRE);
 
+    p->pkt_mode = PKT_MODE_IDS;
     ph = nflog_get_msg_packet_hdr(nfa);
     if (ph != NULL) {
         p->nflog_v.hw_protocol = ph->hw_protocol;

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -547,6 +547,7 @@ static int NFQCallBack(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg,
     }
     PKT_SET_SRC(p, PKT_SRC_WIRE);
 
+    p->pkt_mode = PKT_MODE_IPS;
     p->nfq_v.nfq_index = ntv->nfq_index;
     /* if bypass mask is set then we may want to bypass so set pointer */
     if (nfq_config.bypass_mask) {

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -857,7 +857,7 @@ int NFQRegisterQueue(char *queue)
     nq->queue_num = queue_num;
     receive_queue_num++;
     SCMutexUnlock(&nfq_init_lock);
-    LiveRegisterDeviceName(queue);
+    LiveRegisterDeviceName(queue, RUNMODE_NFQ);
 
     SCLogDebug("Queue \"%s\" registered.", queue);
     return 0;

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -332,7 +332,7 @@ TmEcode ReceivePcapThreadInit(ThreadVars *tv, const void *initdata, void **data)
 
     ptv->tv = tv;
 
-    ptv->livedev = LiveGetDevice(pcapconfig->iface);
+    ptv->livedev = LiveGetDevice(pcapconfig->iface, RUNMODE_PCAP_DEV);
     if (ptv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
         SCFree(ptv);

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -515,7 +515,7 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, const void *initdata, void **dat
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    ptv->livedev = LiveGetDevice(pfconf->iface);
+    ptv->livedev = LiveGetDevice(pfconf->iface, RUNMODE_PFRING);
     if (ptv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
         SCFree(ptv);

--- a/src/source-windivert.c
+++ b/src/source-windivert.c
@@ -331,7 +331,7 @@ unlock:
         wd_num_str[sizeof(wd_num_str) - 1] = 0;
         snprintf(wd_num_str, sizeof(wd_num_str), "%" PRId16 "", g_wd_num);
 
-        LiveRegisterDevice(wd_num_str);
+        LiveRegisterDevice(wd_num_str, RUNMODE_WINDIVERT);
 
         SCLogDebug("Queue %" PRId16 " registered", wd_qv->queue_num);
     }

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -230,7 +230,7 @@ static int DoHandleDataOverlap(TcpStream *stream, const TcpSegment *list,
     int data_is_different = 0;
     int use_new_data = 0;
 
-    if (StreamTcpInlineMode()) {
+    if (StreamTcpInlineMode(p)) {
         SCLogDebug("inline mode");
         if (StreamTcpInlineSegmentCompare(stream, p, list) != 0) {
             SCLogDebug("already accepted data not the same as packet data, rewrite packet");
@@ -665,7 +665,7 @@ static inline bool StreamTcpReturnSegmentCheck(const TcpStream *stream, const Tc
     SCReturnInt(true);
 }
 
-static inline uint64_t GetLeftEdge(TcpSession *ssn, TcpStream *stream)
+static inline uint64_t GetLeftEdge(TcpSession *ssn, TcpStream *stream, Packet *p)
 {
     bool use_app = true;
     bool use_raw = true;
@@ -688,7 +688,7 @@ static inline uint64_t GetLeftEdge(TcpSession *ssn, TcpStream *stream)
     if (use_raw) {
         uint64_t raw_progress = STREAM_RAW_PROGRESS(stream);
 
-        if (StreamTcpInlineMode() == TRUE) {
+        if (StreamTcpInlineMode(p) == TRUE) {
             uint32_t chunk_size = (stream == &ssn->client) ?
                 stream_config.reassembly_toserver_chunk_size :
                 stream_config.reassembly_toclient_chunk_size;
@@ -738,7 +738,7 @@ static inline uint64_t GetLeftEdge(TcpSession *ssn, TcpStream *stream)
     }
 
     /* in inline mode keep at least unack'd segments so we can check for overlaps */
-    if (StreamTcpInlineMode() == TRUE) {
+    if (StreamTcpInlineMode(p) == TRUE) {
         uint64_t last_ack_abs = STREAM_BASE_OFFSET(stream);
         if (STREAM_LASTACK_GT_BASESEQ(stream)) {
             /* get window of data that is acked */
@@ -798,7 +798,7 @@ static void StreamTcpRemoveSegmentFromStream(TcpStream *stream, TcpSegment *seg)
  *  \param f flow
  *  \param flags direction flags
  */
-void StreamTcpPruneSession(Flow *f, uint8_t flags)
+void StreamTcpPruneSession(Flow *f, uint8_t flags, Packet *p)
 {
     SCEnter();
 
@@ -841,7 +841,7 @@ void StreamTcpPruneSession(Flow *f, uint8_t flags)
         return;
     }
 
-    const uint64_t left_edge = GetLeftEdge(ssn, stream);
+    const uint64_t left_edge = GetLeftEdge(ssn, stream, p);
     if (left_edge && left_edge > STREAM_BASE_OFFSET(stream)) {
         uint32_t slide = left_edge - STREAM_BASE_OFFSET(stream);
         SCLogDebug("buffer sliding %u to offset %"PRIu64, slide, left_edge);

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -378,7 +378,9 @@ static int StreamTcpReassemblyConfig(char quiet)
     if (overlap_diff_data) {
         StreamTcpReassembleConfigEnableOverlapCheck();
     }
-    if (StreamTcpInlineMode() == TRUE) {
+    int stream_inline = 0;
+    ConfGetBool("stream.inline", &stream_inline);
+    if (stream_inline) {
         StreamTcpReassembleConfigEnableOverlapCheck();
     }
 
@@ -1040,7 +1042,7 @@ static int ReassembleUpdateAppLayer (ThreadVars *tv,
             stream, &stream->sb, mydata_len, app_progress);
 
     /* get window of data that is acked */
-    if (StreamTcpInlineMode() == FALSE) {
+    if (StreamTcpInlineMode(p) == FALSE) {
         if (p->flags & PKT_PSEUDO_STREAM_END) {
             // fall through, we use all available data
         } else {
@@ -1228,7 +1230,7 @@ bool StreamReassembleRawHasDataReady(TcpSession *ssn, Packet *p)
                          STREAMTCP_STREAM_FLAG_DISABLE_RAW))
         return false;
 
-    if (StreamTcpInlineMode() == FALSE) {
+    if (StreamTcpInlineMode(p) == FALSE) {
         if ((STREAM_RAW_PROGRESS(stream) == STREAM_BASE_OFFSET(stream) + stream->sb.buf_offset)) {
             return false;
         }
@@ -1656,7 +1658,7 @@ int StreamReassembleRaw(TcpSession *ssn, const Packet *p,
                         uint64_t *progress_out, bool respect_inspect_depth)
 {
     /* handle inline seperately as the logic is very different */
-    if (StreamTcpInlineMode() == TRUE) {
+    if (StreamTcpInlineMode(p) == TRUE) {
         return StreamReassembleRawInline(ssn, p, Callback, cb_data, progress_out);
     }
 
@@ -1730,7 +1732,7 @@ int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
     /* default IDS: update opposing side (triggered by ACK) */
     enum StreamUpdateDir dir = UPDATE_DIR_OPPOSING;
     /* inline and stream end and flow timeout packets trigger same dir handling */
-    if (StreamTcpInlineMode()) {
+    if (StreamTcpInlineMode(p)) {
         dir = UPDATE_DIR_PACKET;
     } else if (p->flags & PKT_PSEUDO_STREAM_END) {
         dir = UPDATE_DIR_PACKET;
@@ -1790,7 +1792,7 @@ int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
      * functions to handle EOF */
     if (dir == UPDATE_DIR_PACKET || dir == UPDATE_DIR_BOTH) {
         SCLogDebug("inline (%s) or PKT_PSEUDO_STREAM_END (%s)",
-                StreamTcpInlineMode()?"true":"false",
+                StreamTcpInlineMode(p)?"true":"false",
                 (p->flags & PKT_PSEUDO_STREAM_END) ?"true":"false");
         if (StreamTcpReassembleAppLayer(tv, ra_ctx, ssn, stream, p, dir) < 0) {
             SCReturnInt(-1);
@@ -2685,8 +2687,8 @@ static int StreamTcpReassembleTest39 (void)
     FAIL_IF(f.alproto_ts != ALPROTO_HTTP);
     FAIL_IF(f.alproto_tc != ALPROTO_HTTP);
 
-    StreamTcpPruneSession(&f, STREAM_TOSERVER);
-    StreamTcpPruneSession(&f, STREAM_TOCLIENT);
+    StreamTcpPruneSession(&f, STREAM_TOSERVER, p);
+    StreamTcpPruneSession(&f, STREAM_TOCLIENT, p);
 
     /* request acking a response */
     p->tcph->th_ack = htonl(328);
@@ -3332,7 +3334,7 @@ static int StreamTcpReassembleInlineTest08(void)
     FAIL_IF(StreamTcpUTAddSegmentWithByte(&tv, ra_ctx, &ssn.client, 17, 'D', 5) == -1);
     ssn.client.next_seq = 22;
     p->tcph->th_seq = htonl(17);
-    StreamTcpPruneSession(&f, STREAM_TOSERVER);
+    StreamTcpPruneSession(&f, STREAM_TOSERVER, p);
 
     TcpSegment *seg = RB_MIN(TCPSEG, &ssn.client.seg_tree);
     FAIL_IF_NULL(seg);
@@ -3458,6 +3460,7 @@ static int StreamTcpReassembleInlineTest10(void)
     p->tcph->th_seq = htonl(7);
     p->flow = f;
     p->flowflags = FLOW_PKT_TOSERVER;
+    p->pkt_mode = PKT_MODE_IPS;
 
     FLOWLOCK_WRLOCK(f);
     if (StreamTcpUTAddSegmentWithPayload(&tv, ra_ctx, &ssn.client,  2, stream_payload1, 2) == -1) {

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -110,7 +110,7 @@ void StreamTcpSegmentReturntoPool(TcpSegment *);
 
 void StreamTcpReassembleTriggerRawReassembly(TcpSession *, int direction);
 
-void StreamTcpPruneSession(Flow *, uint8_t);
+void StreamTcpPruneSession(Flow *, uint8_t, Packet *p);
 int StreamTcpReassembleDepthReached(Packet *p);
 
 void StreamTcpReassembleIncrMemuse(uint64_t size);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -454,9 +454,7 @@ void StreamTcpInitConfig(char quiet)
         /* checking for "auto" and falling back to boolean to provide
          * backward compatibility */
         if (strcmp(temp_stream_inline_str, "auto") == 0) {
-            if (EngineModeIsIPS()) {
-                stream_config.flags |= STREAMTCP_INIT_FLAG_INLINE;
-            }
+            stream_config.flags |= STREAMTCP_INIT_FLAG_INLINE_AUTO;
         } else if (ConfGetBool("stream.inline", &inl) == 1) {
             if (inl) {
                 stream_config.flags |= STREAMTCP_INIT_FLAG_INLINE;
@@ -464,9 +462,7 @@ void StreamTcpInitConfig(char quiet)
         }
     } else {
         /* default to 'auto' */
-        if (EngineModeIsIPS()) {
-            stream_config.flags |= STREAMTCP_INIT_FLAG_INLINE;
-        }
+        stream_config.flags |= STREAMTCP_INIT_FLAG_INLINE_AUTO;
     }
 
     if (!quiet) {
@@ -1864,7 +1860,7 @@ static int StreamTcpPacketStateSynRecv(ThreadVars *tv, Packet *p,
                  * pattern for MOTS/MITM injection attacks, we need to be
                  * careful.
                  */
-                if (StreamTcpInlineMode()) {
+                if (StreamTcpInlineMode(p)) {
                     if (p->payload_len > 0 &&
                             SEQ_EQ(TCP_GET_ACK(p), ssn->client.last_ack) &&
                             SEQ_EQ(TCP_GET_SEQ(p), ssn->server.next_seq)) {
@@ -6200,7 +6196,7 @@ void StreamTcpDetectLogFlush(ThreadVars *tv, StreamTcpThread *stt, Flow *f, Pack
     ssn->client.flags |= STREAMTCP_STREAM_FLAG_TRIGGER_RAW;
     ssn->server.flags |= STREAMTCP_STREAM_FLAG_TRIGGER_RAW;
     bool ts = PKT_IS_TOSERVER(p) ? true : false;
-    ts ^= StreamTcpInlineMode();
+    ts ^= StreamTcpInlineMode(p);
     StreamTcpPseudoPacketCreateDetectLogFlush(tv, stt, p, ssn, pq, ts^0);
     StreamTcpPseudoPacketCreateDetectLogFlush(tv, stt, p, ssn, pq, ts^1);
 }
@@ -6271,10 +6267,18 @@ int StreamTcpBypassEnabled(void)
  *  \retval 0 no
  *  \retval 1 yes
  */
-int StreamTcpInlineMode(void)
+int StreamTcpInlineMode(const Packet *p)
 {
-    return (stream_config.flags & STREAMTCP_INIT_FLAG_INLINE) ? 1 : 0;
+    if (stream_config.flags & STREAMTCP_INIT_FLAG_INLINE) {
+        return PKT_MODE_IPS;
+    } else if (stream_config.flags & STREAMTCP_INIT_FLAG_INLINE_AUTO) {
+        /* implied PKT_MODE_AUTO */
+      return PacketModeIsIPS(p);
+    } else {
+      return PKT_MODE_IDS;
+    }
 }
+
 
 
 void TcpSessionSetReassemblyDepth(TcpSession *ssn, uint32_t size)

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -37,6 +37,7 @@
 #define STREAMTCP_INIT_FLAG_DROP_INVALID           BIT_U8(1)
 #define STREAMTCP_INIT_FLAG_BYPASS                 BIT_U8(2)
 #define STREAMTCP_INIT_FLAG_INLINE                 BIT_U8(3)
+#define STREAMTCP_INIT_FLAG_INLINE_AUTO            BIT_U8(8)
 
 /*global flow data*/
 typedef struct TcpStreamCnf_ {
@@ -158,7 +159,7 @@ static inline int StreamTcpCheckFlowDrops(Packet *p)
      * the IP only module, or from a reassembled msg and/or from an
      * applayer detection, then drop the rest of the packets of the
      * same stream and avoid inspecting it any further */
-    if (EngineModeIsIPS() && (p->flow->flags & FLOW_ACTION_DROP))
+    if (PacketModeIsIPS(p) && (p->flow->flags & FLOW_ACTION_DROP))
         return 1;
 
     return 0;
@@ -221,7 +222,7 @@ void StreamTcpStreamCleanup(TcpStream *stream);
 /* check if bypass is enabled */
 int StreamTcpBypassEnabled(void);
 int StreamTcpInlineDropInvalid(void);
-int StreamTcpInlineMode(void);
+int StreamTcpInlineMode(const Packet *p);
 
 int TcpSessionPacketSsnReuse(const Packet *p, const Flow *f, const void *tcp_ssn);
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -202,6 +202,7 @@ volatile uint8_t suricata_ctl_flags = 0;
 
 /** Run mode selected */
 int run_mode = RUNMODE_UNKNOWN;
+RunmodesSlots runmodesslots = { {RUNMODE_UNKNOWN, RUNMODE_UNKNOWN}, 0};
 
 /** Engine mode: inline (ENGINE_MODE_IPS) or just
   * detection mode (ENGINE_MODE_IDS by default) */
@@ -256,19 +257,6 @@ void EngineModeSetIPS(void)
 void EngineModeSetIDS(void)
 {
     g_engine_mode = ENGINE_MODE_IDS;
-}
-
-int RunmodeIsUnittests(void)
-{
-    if (run_mode == RUNMODE_UNITTEST)
-        return 1;
-
-    return 0;
-}
-
-int RunmodeGetCurrent(void)
-{
-    return run_mode;
 }
 
 /** signal handlers

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -953,7 +953,7 @@ static TmEcode ParseInterfacesList(const int runmode, char *pcap_dev)
     /* run the selected runmode */
     if (runmode == RUNMODE_PCAP_DEV) {
         if (strlen(pcap_dev) == 0) {
-            int ret = LiveBuildDeviceList("pcap");
+            int ret = LiveBuildDeviceList("pcap", RUNMODE_PCAP_DEV);
             if (ret == 0) {
                 SCLogError(SC_ERR_INITIALIZATION, "No interface found in config for pcap");
                 SCReturnInt(TM_ECODE_FAILED);
@@ -967,7 +967,7 @@ static TmEcode ParseInterfacesList(const int runmode, char *pcap_dev)
                 SCReturnInt(TM_ECODE_FAILED);
             }
         } else {
-            int ret = LiveBuildDeviceList("mpipe.inputs");
+            int ret = LiveBuildDeviceList("mpipe.inputs", RUNMODE_TILERA_MPIPE);
             if (ret == 0) {
                 fprintf(stderr, "ERROR: No interface found in config for mpipe\n");
                 SCReturnInt(TM_ECODE_FAILED);
@@ -984,7 +984,7 @@ static TmEcode ParseInterfacesList(const int runmode, char *pcap_dev)
             }
         } else {
             /* not an error condition if we have a 1.0 config */
-            LiveBuildDeviceList("pfring");
+            LiveBuildDeviceList("pfring", RUNMODE_PFRING);
         }
 #ifdef HAVE_AF_PACKET
     } else if (runmode == RUNMODE_AFP_DEV) {
@@ -995,7 +995,7 @@ static TmEcode ParseInterfacesList(const int runmode, char *pcap_dev)
                 SCReturnInt(TM_ECODE_FAILED);
             }
         } else {
-            int ret = LiveBuildDeviceList("af-packet");
+            int ret = LiveBuildDeviceList("af-packet", RUNMODE_AFP_DEV);
             if (ret == 0) {
                 SCLogError(SC_ERR_INITIALIZATION, "No interface found in config for af-packet");
                 SCReturnInt(TM_ECODE_FAILED);
@@ -1011,7 +1011,7 @@ static TmEcode ParseInterfacesList(const int runmode, char *pcap_dev)
                 SCReturnInt(TM_ECODE_FAILED);
             }
         } else {
-            int ret = LiveBuildDeviceList("netmap");
+            int ret = LiveBuildDeviceList("netmap", RUNMODE_NETMAP);
             if (ret == 0) {
                 SCLogError(SC_ERR_INITIALIZATION, "No interface found in config for netmap");
                 SCReturnInt(TM_ECODE_FAILED);
@@ -1020,7 +1020,7 @@ static TmEcode ParseInterfacesList(const int runmode, char *pcap_dev)
 #endif
 #ifdef HAVE_NFLOG
     } else if (runmode == RUNMODE_NFLOG) {
-        int ret = LiveBuildDeviceListCustom("nflog", "group");
+        int ret = LiveBuildDeviceListCustom("nflog", "group", RUNMODE_NFLOG);
         if (ret == 0) {
             SCLogError(SC_ERR_INITIALIZATION, "No group found in config for nflog");
             SCReturnInt(TM_ECODE_FAILED);
@@ -1115,13 +1115,13 @@ static int ParseCommandLineAfpacket(SCInstance *suri, const char *in_arg)
     if (suri->run_mode == RUNMODE_UNKNOWN) {
         suri->run_mode = RUNMODE_AFP_DEV;
         if (in_arg) {
-            LiveRegisterDeviceName(in_arg);
+            LiveRegisterDeviceName(in_arg, RUNMODE_AFP_DEV);
             memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
             strlcpy(suri->pcap_dev, in_arg, sizeof(suri->pcap_dev));
         }
     } else if (suri->run_mode == RUNMODE_AFP_DEV) {
         if (in_arg) {
-            LiveRegisterDeviceName(in_arg);
+            LiveRegisterDeviceName(in_arg, RUNMODE_AFP_DEV);
         } else {
             SCLogInfo("Multiple af-packet option without interface on each is useless");
         }
@@ -1165,7 +1165,7 @@ static int ParseCommandLinePcapLive(SCInstance *suri, const char *in_arg)
     if (suri->run_mode == RUNMODE_UNKNOWN) {
         suri->run_mode = RUNMODE_PCAP_DEV;
         if (in_arg) {
-            LiveRegisterDeviceName(suri->pcap_dev);
+            LiveRegisterDeviceName(suri->pcap_dev, RUNMODE_PCAP_DEV);
         }
     } else if (suri->run_mode == RUNMODE_PCAP_DEV) {
 #ifdef OS_WIN32
@@ -1173,7 +1173,7 @@ static int ParseCommandLinePcapLive(SCInstance *suri, const char *in_arg)
                 "support is not (yet) supported on Windows.");
         return TM_ECODE_FAILED;
 #else
-        LiveRegisterDeviceName(suri->pcap_dev);
+        LiveRegisterDeviceName(suri->pcap_dev, RUNMODE_PCAP_DEV);
 #endif
     } else {
         SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "
@@ -1571,7 +1571,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                     strlcpy(suri->pcap_dev, optarg,
                             ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
                              (strlen(optarg) + 1) : sizeof(suri->pcap_dev)));
-                    LiveRegisterDeviceName(optarg);
+                    LiveRegisterDeviceName(optarg, RUNMODE_PFRING);
                 }
 #else
                 SCLogError(SC_ERR_NO_PF_RING,"PF_RING not enabled. Make sure "
@@ -1613,7 +1613,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 if (suri->run_mode == RUNMODE_UNKNOWN) {
                     suri->run_mode = RUNMODE_NETMAP;
                     if (optarg) {
-                        LiveRegisterDeviceName(optarg);
+                        LiveRegisterDeviceName(optarg, RUNMODE_NETMAP);
                         memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
                         strlcpy(suri->pcap_dev, optarg,
                                 ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
@@ -1621,7 +1621,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                     }
                 } else if (suri->run_mode == RUNMODE_NETMAP) {
                     if (optarg) {
-                        LiveRegisterDeviceName(optarg);
+                        LiveRegisterDeviceName(optarg, RUNMODE_NETMAP);
                     } else {
                         SCLogInfo("Multiple netmap option without interface on each is useless");
                         break;
@@ -1640,7 +1640,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #ifdef HAVE_NFLOG
                 if (suri->run_mode == RUNMODE_UNKNOWN) {
                     suri->run_mode = RUNMODE_NFLOG;
-                    LiveBuildDeviceListCustom("nflog", "group");
+                    LiveBuildDeviceListCustom("nflog", "group", RUNMODE_NFLOG);
                 }
 #else
                 SCLogError(SC_ERR_NFLOG_NOSUPPORT, "NFLOG not enabled.");
@@ -1770,7 +1770,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                     PrintUsage(argv[0]);
                     return TM_ECODE_FAILED;
                 }
-                LiveRegisterDeviceName(optarg);
+                LiveRegisterDeviceName(optarg, RUNMODE_DAG);
 #else
                 SCLogError(SC_ERR_DAG_REQUIRED, "libdag and a DAG card are required"
 						" to receive packets using --dag.");
@@ -1810,7 +1810,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                         strlcpy(suri->pcap_dev, optarg,
                                 ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
                                  (strlen(optarg) + 1) : sizeof(suri->pcap_dev)));
-                        LiveRegisterDeviceName(optarg);
+                        LiveRegisterDeviceName(optarg, RUNMODE_TILERA_MPIPE);
                     }
                 } else {
                     SCLogError(SC_ERR_MULTIPLE_RUN_MODE,
@@ -2500,9 +2500,9 @@ static int ConfigGetCaptureValue(SCInstance *suri)
                 strip_trailing_plus = 1;
                 /* fall through */
             case RUNMODE_PFRING:
-                nlive = LiveGetDeviceCount();
+                nlive = LiveGetDeviceCount(RUNMODE_PFRING);
                 for (lthread = 0; lthread < nlive; lthread++) {
-                    const char *live_dev = LiveGetDeviceName(lthread);
+                    const char *live_dev = LiveGetDeviceName(lthread, RUNMODE_PFRING);
                     char dev[128]; /* need to be able to support GUID names on Windows */
                     (void)strlcpy(dev, live_dev, sizeof(dev));
 

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -66,6 +66,7 @@
 
 #include "suricata-common.h"
 #include "packet-queue.h"
+#include "util-runmodes-slots.h"
 
 /* the name of our binary */
 #define PROG_NAME "Suricata"
@@ -177,8 +178,6 @@ extern int g_disable_randomness;
 void EngineStop(void);
 void EngineDone(void);
 
-int RunmodeIsUnittests(void);
-int RunmodeGetCurrent(void);
 int IsRuleReloadSet(int quiet);
 
 int SuriHasSigFile(void);

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -132,8 +132,8 @@ enum {
 PacketQueue trans_q[256];
 
 typedef struct SCInstance_ {
-    enum RunModes run_mode;
-    enum RunModes aux_run_mode;
+    RunmodesSlots runmodes;
+    RunmodesSlots aux_runmodes;
 
     char pcap_dev[128];
     char *sig_file;

--- a/src/tests/detect.c
+++ b/src/tests/detect.c
@@ -4728,11 +4728,13 @@ static int SigTestDropFlow03(void)
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p1->pkt_mode = PKT_MODE_IPS;
 
     p2->flow = &f;
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->pkt_mode = PKT_MODE_IPS;
     f.alproto = ALPROTO_HTTP;
 
     StreamTcpInitConfig(TRUE);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -732,7 +732,7 @@ static TmEcode UnixManagerCaptureModeCommand(json_t *cmd,
                                       json_t *server_msg, void *data)
 {
     SCEnter();
-    json_object_set_new(server_msg, "message", json_string(RunModeGetMainMode()));
+    json_object_set_new(server_msg, "message", json_string(RunModeGetMainMode(0)));
     SCReturnInt(TM_ECODE_OK);
 }
 

--- a/src/util-conf.c
+++ b/src/util-conf.c
@@ -27,6 +27,7 @@
 #include "conf.h"
 #include "runmodes.h"
 #include "util-conf.h"
+#include "util-runmodes-slots.h"
 
 TmEcode ConfigSetLogDirectory(char *name)
 {
@@ -96,6 +97,7 @@ ConfNode *ConfFindDeviceConfig(ConfNode *node, const char *iface)
 int ConfUnixSocketIsEnable(void)
 {
     const char *value;
+    extern RunmodesSlots runmodesslots;
 
     if (ConfGet("unix-command.enabled", &value) != 1) {
         return 0;
@@ -111,7 +113,7 @@ int ConfUnixSocketIsEnable(void)
 #ifdef OS_WIN32
         return 0;
 #else
-        if (!IsRunModeOffline(RunmodeGetCurrent())) {
+        if (!IsRunModeOffline(RunmodesSlotsGetRunmode(&runmodesslots, 0))) {
             SCLogInfo("Running in live mode, activating unix socket");
             return 1;
         } else {

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -181,6 +181,26 @@ const char *LiveGetDeviceName(int number)
     return NULL;
 }
 
+/**
+ *  \brief Get the runmode id associated to the iface
+ *
+ *  \param  name  interface's name
+ *
+ *  \retval runmode runmode id
+ *  \retval RUNMODE_UNKNOWN if not found
+ */
+int LiveGetDeviceRunmode(const char *name)
+{
+    LiveDevice *pd;
+
+    TAILQ_FOREACH(pd, &live_devices, next) {
+        if (!strcmp(name, pd->dev)) {
+            return pd->runmode;
+        }
+    }
+
+  return RUNMODE_UNKNOWN;
+}
 /** \internal
  *  \brief Shorten a device name that is to long
  *

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -172,15 +172,12 @@ int LiveGetDeviceCount(enum RunModes runmode)
  */
 const char *LiveGetDeviceName(int number, enum RunModes runmode)
 {
-    int i = 0;
     LiveDevice *pd;
 
     TAILQ_FOREACH(pd, &live_devices, next) {
-        if (i == number && pd->runmode == runmode) {
+        if (pd->id == number && pd->runmode == runmode) {
             return pd->dev;
         }
-
-        i++;
     }
 
     return NULL;

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -66,6 +66,7 @@ int LiveGetDeviceCount(void);
 const char *LiveGetDeviceName(int number);
 LiveDevice *LiveGetDevice(const char *dev);
 const char *LiveGetShortName(const char *dev);
+int LiveGetDeviceRunmode(const char *name);
 int LiveBuildDeviceList(const char *base);
 void LiveDeviceHasNoStats(void);
 int LiveDeviceListClean(void);

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -20,6 +20,7 @@
 
 #include "queue.h"
 #include "unix-manager.h"
+#include "runmodes.h"
 
 #define OFFLOAD_FLAG_SG     (1<<0)
 #define OFFLOAD_FLAG_TSO    (1<<1)
@@ -41,7 +42,7 @@ typedef struct LiveDevice_ {
     char *dev;  /**< the device (e.g. "eth0") */
     char dev_short[MAX_DEVNAME + 1];
     bool tenant_id_set;
-
+    enum RunModes runmode; /**< the runmode (e.g. "RUNMODE_NFLOG") */
     int ignore_checksum;
     int id;
 
@@ -57,20 +58,21 @@ typedef struct LiveDevice_ {
 
 typedef struct LiveDeviceName_ {
     char *dev;  /**< the device (e.g. "eth0") */
+    enum RunModes runmode; /**< the runmode (e.g. "RUNMODE_NFLOG") */
     TAILQ_ENTRY(LiveDeviceName_) next;
 } LiveDeviceName;
 
-int LiveRegisterDeviceName(const char *dev);
-int LiveRegisterDevice(const char *dev);
-int LiveGetDeviceCount(void);
-const char *LiveGetDeviceName(int number);
-LiveDevice *LiveGetDevice(const char *dev);
-const char *LiveGetShortName(const char *dev);
+int LiveRegisterDeviceName(const char *dev, enum RunModes runmode);
+int LiveRegisterDevice(const char *dev, enum RunModes runmode);
+int LiveGetDeviceCount(enum RunModes runmode);
+const char *LiveGetDeviceName(int number, enum RunModes runmode);
+LiveDevice *LiveGetDevice(const char *dev, enum RunModes runmode);
+const char *LiveGetShortName(const char *dev, enum RunModes runmode);
 int LiveGetDeviceRunmode(const char *name);
-int LiveBuildDeviceList(const char *base);
+int LiveBuildDeviceList(const char *base, enum RunModes runmode);
 void LiveDeviceHasNoStats(void);
 int LiveDeviceListClean(void);
-int LiveBuildDeviceListCustom(const char *base, const char *itemname);
+int LiveBuildDeviceListCustom(const char *base, const char *itemname, enum RunModes runmode);
 
 LiveDevice *LiveDeviceForEach(LiveDevice **ldev, LiveDevice **ndev);
 

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -107,7 +107,7 @@ static void EBPFDeleteKey(int fd, void *key)
 
 static struct bpf_maps_info *EBPFGetBpfMap(const char *iface)
 {
-    LiveDevice *livedev = LiveGetDevice(iface);
+    LiveDevice *livedev = LiveGetDevice(iface, LiveGetDeviceRunmode(iface));
     if (livedev == NULL)
         return NULL;
     void *data = LiveDevGetStorageById(livedev, g_livedev_storage_id);
@@ -166,7 +166,7 @@ int EBPFLoadFile(const char *iface, const char *path, const char * section,
 
     if (iface == NULL)
         return -1;
-    LiveDevice *livedev = LiveGetDevice(iface);
+    LiveDevice *livedev = LiveGetDevice(iface, LiveGetDeviceRunmode(iface));
     if (livedev == NULL)
         return -1;
 

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -32,6 +32,7 @@
 #include "util-path.h"
 #include "util-logopenfile.h"
 #include "util-logopenfile-tile.h"
+#include "util-runmodes-slots.h"
 
 #if defined(HAVE_SYS_UN_H) && defined(HAVE_SYS_SOCKET_H) && defined(HAVE_SYS_TYPES_H)
 #define BUILD_WITH_UNIXSOCKET
@@ -331,6 +332,7 @@ SCConfLogOpenGeneric(ConfNode *conf,
     char log_path[PATH_MAX];
     const char *log_dir;
     const char *filename, *filetype;
+    extern RunmodesSlots runmodesslots;
 
     // Arg check
     if (conf == NULL || log_ctx == NULL || default_filename == NULL) {
@@ -492,7 +494,7 @@ SCConfLogOpenGeneric(ConfNode *conf,
 
 #ifdef BUILD_WITH_UNIXSOCKET
     /* If a socket and running live, do non-blocking writes. */
-    if (log_ctx->is_sock && !IsRunModeOffline(RunmodeGetCurrent())) {
+    if (log_ctx->is_sock && !IsRunModeOffline(RunmodesSlotsGetRunmode(&runmodesslots, 0))) {
         SCLogInfo("Setting logging socket of non-blocking in live mode.");
         log_ctx->send_flags |= MSG_DONTWAIT;
     }

--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -48,7 +48,7 @@
 extern int sc_set_caps;
 
 /** our current runmode */
-extern int run_mode;
+extern RunmodesSlots runmodesslots;
 
 /**
  * \brief   Drop the previliges of the main thread
@@ -60,7 +60,7 @@ void SCDropMainThreadCaps(uint32_t userid, uint32_t groupid)
 
     capng_clear(CAPNG_SELECT_BOTH);
 
-    switch (run_mode) {
+    switch (RunmodesSlotsGetFirstSlot(&runmodesslots)) {
         case RUNMODE_PCAP_DEV:
         case RUNMODE_AFP_DEV:
             capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED,

--- a/src/util-runmodes-slots.c
+++ b/src/util-runmodes-slots.c
@@ -1,0 +1,89 @@
+/* Copyright (C) 2007-2018 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+#include "util-runmodes-slots.h"
+
+extern RunmodesSlots runmodesslots;
+
+int RunmodeGetCurrent(void)
+{
+  return RunmodesSlotsGetFirstSlot(&runmodesslots);
+}
+
+int RunmodeIsUnittests(void)
+{
+    if (RunmodesSlotsGetFirstSlot(&runmodesslots) == RUNMODE_UNITTEST) {
+        return 1;
+    }
+    return 0;
+}
+
+int RunmodesSlotsSetRunmode(RunmodesSlots *runmodes, enum RunModes runmode)
+{
+    runmodes->run_mode[runmodes->pos] = runmode;
+    if (runmodes->pos < RUNMODES_MAX && (runmode == RUNMODE_NFLOG || runmode == RUNMODE_NFQ)) {
+        runmodes->pos++;
+    } else {
+        return 0;
+    }
+    return 1;
+}
+
+int RunmodesSlotsGetRunmode(const RunmodesSlots *runmodes, int index)
+{
+    return runmodes->run_mode[index];
+}
+
+int RunmodesSlotsGetSlotsCount(const RunmodesSlots *runmodes)
+{
+    return runmodes->pos;
+}
+
+int RunmodesSlotsRunmodeIsUnknown(const RunmodesSlots *runmodes)
+{
+    return (runmodes->run_mode[runmodes->pos] == RUNMODE_UNKNOWN);
+}
+
+int RunmodesSlotsRunmodeIsInSlot(const RunmodesSlots *runmodes, const enum RunModes runmode)
+{
+    int i;
+    for (i = 0; i < runmodes->pos; i++) {
+        if (runmodes->run_mode[i] == runmode) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int RunmodesSlotsGetFirstSlot(const RunmodesSlots *runmodes)
+{
+    return runmodes->run_mode[0];
+}
+
+int RunmodesSlotsGetSecondSlot(const RunmodesSlots *runmodes)
+{
+    return runmodes->run_mode[1];
+}
+
+bool RunmodesSlotsMaxSlotsReached(const RunmodesSlots *runmodes)
+{
+  if (runmodes->pos < RUNMODES_MAX) {
+      return FALSE;
+  }
+  return TRUE;
+}

--- a/src/util-runmodes-slots.c
+++ b/src/util-runmodes-slots.c
@@ -20,11 +20,6 @@
 
 extern RunmodesSlots runmodesslots;
 
-int RunmodeGetCurrent(void)
-{
-  return RunmodesSlotsGetFirstSlot(&runmodesslots);
-}
-
 int RunmodeIsUnittests(void)
 {
     if (RunmodesSlotsGetFirstSlot(&runmodesslots) == RUNMODE_UNITTEST) {

--- a/src/util-runmodes-slots.h
+++ b/src/util-runmodes-slots.h
@@ -42,6 +42,5 @@ int RunmodesSlotsRunmodeIsInSlot(const RunmodesSlots *runmodes, const enum RunMo
 bool RunmodesSlotsMaxSlotsReached(const RunmodesSlots *runmodes);
 int RunmodesSlotsRunmodeIsUnknown(const RunmodesSlots *runmodes);
 int RunmodeIsUnittests(void);
-int RunmodeGetCurrent(void);
 
 #endif /* __RUNMODES_SLOTS_H__ */

--- a/src/util-runmodes-slots.h
+++ b/src/util-runmodes-slots.h
@@ -1,0 +1,47 @@
+/* Copyright (C) 2007-2018 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+/**
+ * \file
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ */
+
+#ifndef __RUNMODES_SLOTS_H__
+#define __RUNMODES_SLOTS_H__
+
+#include "runmodes.h"
+#define RUNMODES_MAX     2
+
+typedef struct RunmodesSlots_ {
+    enum RunModes run_mode[RUNMODES_MAX];
+    int pos;
+} RunmodesSlots;
+
+extern RunmodesSlots runmodesslots;
+
+int RunmodesSlotsSetRunmode(RunmodesSlots *runmodes, enum RunModes runmode);
+int RunmodesSlotsGetRunmode(const RunmodesSlots *runmodes, int index);
+int RunmodesSlotsGetFirstSlot(const RunmodesSlots *runmodes);
+int RunmodesSlotsGetSecondSlot(const RunmodesSlots *runmodes);
+int RunmodesSlotsGetSlotsCount(const RunmodesSlots *runmodes);
+int RunmodesSlotsRunmodeIsInSlot(const RunmodesSlots *runmodes, const enum RunModes runmode);
+bool RunmodesSlotsMaxSlotsReached(const RunmodesSlots *runmodes);
+int RunmodesSlotsRunmodeIsUnknown(const RunmodesSlots *runmodes);
+int RunmodeIsUnittests(void);
+int RunmodeGetCurrent(void);
+
+#endif /* __RUNMODES_SLOTS_H__ */

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -91,7 +91,8 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
                               const char *recv_mod_name,
                               const char *decode_mod_name,
                               const char *thread_name,
-                              const char *live_dev)
+                              const char *live_dev,
+                              enum RunModes runmode)
 {
     char tname[TM_THREAD_NAME_MAX];
     char qname[TM_QUEUE_NAME_MAX];
@@ -286,7 +287,8 @@ static int RunModeSetLiveCaptureWorkersForDevice(ConfigIfaceThreadsCountFunc Mod
                               const char *recv_mod_name,
                               const char *decode_mod_name, const char *thread_name,
                               const char *live_dev, void *aconf,
-                              unsigned char single_mode)
+                              unsigned char single_mode,
+                              enum RunModes runmode)
 {
     int threads_count;
 
@@ -372,7 +374,7 @@ int RunModeSetLiveCaptureWorkers(ConfigIfaceParserFunc ConfigParser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               const char *recv_mod_name,
                               const char *decode_mod_name, const char *thread_name,
-                              const char *live_dev)
+                              const char *live_dev, enum RunModes runmode)
 {
     int nlive = LiveGetDeviceCount();
     void *aconf;
@@ -397,7 +399,8 @@ int RunModeSetLiveCaptureWorkers(ConfigIfaceParserFunc ConfigParser,
                 thread_name,
                 live_dev_c,
                 aconf,
-                0);
+                0,
+                runmode);
     }
 
     return 0;
@@ -407,7 +410,7 @@ int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc ConfigParser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               const char *recv_mod_name,
                               const char *decode_mod_name, const char *thread_name,
-                              const char *live_dev)
+                              const char *live_dev, enum RunModes runmode)
 {
     int nlive = LiveGetDeviceCount();
     const char *live_dev_c = NULL;
@@ -434,7 +437,8 @@ int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc ConfigParser,
                                  thread_name,
                                  live_dev_c,
                                  aconf,
-                                 1);
+                                 1,
+                                 runmode);
 }
 
 
@@ -443,7 +447,8 @@ int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc ConfigParser,
 int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
                         const char *recv_mod_name,
                         const char *verdict_mod_name,
-                        const char *decode_mod_name)
+                        const char *decode_mod_name,
+                        enum RunModes runmode)
 {
     SCEnter();
     char tname[TM_THREAD_NAME_MAX];
@@ -591,7 +596,8 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
 int RunModeSetIPSWorker(ConfigIPSParserFunc ConfigParser,
         const char *recv_mod_name,
         const char *verdict_mod_name,
-        const char *decode_mod_name)
+        const char *decode_mod_name,
+        enum RunModes runmode)
 {
     char tname[TM_THREAD_NAME_MAX];
     ThreadVars *tv = NULL;

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -100,7 +100,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
 
     /* Available cpus */
     uint16_t ncpus = UtilCpuGetNumProcessorsOnline();
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceCount(runmode);
     int thread_max = TmThreadGetNbThreads(WORKER_CPU_SET);
     /* always create at least one thread */
     if (thread_max == 0)
@@ -174,8 +174,8 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
         SCLogInfo("Using %d live device(s).", nlive);
 
         for (int lthread = 0; lthread < nlive; lthread++) {
-            const char *dev = LiveGetDeviceName(lthread);
-            const char *visual_devname = LiveGetShortName(dev);
+            const char *dev = LiveGetDeviceName(lthread, runmode);
+            const char *visual_devname = LiveGetShortName(dev, runmode);
             void *aconf;
             int threads_count;
 
@@ -304,7 +304,7 @@ static int RunModeSetLiveCaptureWorkersForDevice(ConfigIfaceThreadsCountFunc Mod
         char tname[TM_THREAD_NAME_MAX];
         ThreadVars *tv = NULL;
         TmModule *tm_module = NULL;
-        const char *visual_devname = LiveGetShortName(live_dev);
+        const char *visual_devname = LiveGetShortName(live_dev, runmode);
         char *printable_threadname = SCMalloc(sizeof(char) * (strlen(thread_name)+5+strlen(live_dev)));
         if (unlikely(printable_threadname == NULL)) {
             SCLogError(SC_ERR_MEM_ALLOC, "failed to alloc printable thread name: %s", strerror(errno));
@@ -376,7 +376,7 @@ int RunModeSetLiveCaptureWorkers(ConfigIfaceParserFunc ConfigParser,
                               const char *decode_mod_name, const char *thread_name,
                               const char *live_dev, enum RunModes runmode)
 {
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceCount(runmode);
     void *aconf;
     int ldev;
 
@@ -390,7 +390,7 @@ int RunModeSetLiveCaptureWorkers(ConfigIfaceParserFunc ConfigParser,
                 exit(EXIT_FAILURE);
             }
         } else {
-            live_dev_c = LiveGetDeviceName(ldev);
+            live_dev_c = LiveGetDeviceName(ldev, runmode);
             aconf = ConfigParser(live_dev_c);
         }
         RunModeSetLiveCaptureWorkersForDevice(ModThreadsCount,
@@ -412,7 +412,7 @@ int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc ConfigParser,
                               const char *decode_mod_name, const char *thread_name,
                               const char *live_dev, enum RunModes runmode)
 {
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceCount(runmode);
     const char *live_dev_c = NULL;
     void *aconf;
 
@@ -426,7 +426,7 @@ int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc ConfigParser,
         aconf = ConfigParser(live_dev);
         live_dev_c = live_dev;
     } else {
-        live_dev_c = LiveGetDeviceName(0);
+        live_dev_c = LiveGetDeviceName(0, runmode);
         aconf = ConfigParser(live_dev_c);
     }
 
@@ -459,7 +459,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
 
     /* Available cpus */
     uint16_t ncpus = UtilCpuGetNumProcessorsOnline();
-    int nqueue = LiveGetDeviceCount();
+    int nqueue = LiveGetDeviceCount(runmode);
 
     int thread_max = TmThreadGetNbThreads(WORKER_CPU_SET);
     /* always create at least one thread */
@@ -480,7 +480,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
 
     for (int i = 0; i < nqueue; i++) {
     /* create the threads */
-        cur_queue = LiveGetDeviceName(i);
+        cur_queue = LiveGetDeviceName(i, runmode);
         if (cur_queue == NULL) {
             SCLogError(SC_ERR_RUNMODE, "invalid queue number");
             exit(EXIT_FAILURE);
@@ -604,11 +604,11 @@ int RunModeSetIPSWorker(ConfigIPSParserFunc ConfigParser,
     TmModule *tm_module = NULL;
     const char *cur_queue = NULL;
 
-    int nqueue = LiveGetDeviceCount();
+    int nqueue = LiveGetDeviceCount(runmode);
 
     for (int i = 0; i < nqueue; i++) {
         /* create the threads */
-        cur_queue = LiveGetDeviceName(i);
+        cur_queue = LiveGetDeviceName(i, runmode);
         if (cur_queue == NULL) {
             SCLogError(SC_ERR_RUNMODE, "invalid queue number");
             exit(EXIT_FAILURE);

--- a/src/util-runmodes.h
+++ b/src/util-runmodes.h
@@ -34,35 +34,37 @@ int RunModeSetLiveCaptureAuto(ConfigIfaceParserFunc configparser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               const char *recv_mod_name,
                               const char *decode_mod_name, const char *thread_name,
-                              const char *live_dev);
+                              const char *live_dev, enum RunModes runmode);
 
 int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc configparser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               const char *recv_mod_name,
                               const char *decode_mod_name, const char *thread_name,
-                              const char *live_dev);
+                              const char *live_dev, enum RunModes runmode);
 
 int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc configparser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               const char *recv_mod_name,
                               const char *decode_mod_name, const char *thread_name,
-                              const char *live_dev);
+                              const char *live_dev, enum RunModes runmode);
 
 int RunModeSetLiveCaptureWorkers(ConfigIfaceParserFunc configparser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               const char *recv_mod_name,
                               const char *decode_mod_name, const char *thread_name,
-                              const char *live_dev);
+                              const char *live_dev, enum RunModes runmode);
 
 int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
                         const char *recv_mod_name,
                         const char *verdict_mod_name,
-                        const char *decode_mod_name);
+                        const char *decode_mod_name,
+                        enum RunModes runmode);
 
 int RunModeSetIPSWorker(ConfigIPSParserFunc ConfigParser,
                         const char *recv_mod_name,
                         const char *verdict_mod_name,
-                        const char *decode_mod_name);
+                        const char *decode_mod_name,
+                        enum RunModes runmode);
 
 char *RunmodeAutoFpCreatePickupQueuesString(int n);
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1604

Describe changes:
The logic of this patchset is made up of 5 parts:
- Moving 'mode' logic (ids, ips) from engine to packets 
- Setting up runmode id to device and runmode functions
- Add new API to handle more capture methods
- Adapting the code to support multiple runmodes
- Start suricata with mixed mode

Some details:
- Only two runmodes can be ran in mixed mode: nfqueue, nflog
- Mixed mode works only with `--runmode=workers` due to a bug in nflog with autofp.
- `EngineModeSetIPS` and `EngineModeSetIDS` functions are not removed yet, the first one is needed for `--simulated-ips and I'm unsure if they can be removed.
- It likely needs more testing but having a review will help.

Testing:
I have basically tested mixed mode starting suricata with nflog and nfqueue, you can reproduce following the steps below:
```
# iptables -A INPUT -p icmp -j NFQUEUE --queue-num 0
# iptables -A INPUT -p tcp -j NFLOG --nflog-group 2
# ./bin/suricata -c etc/suricata/suricata.yaml -S mixedmode.rules -q 0 --nflog -k none -vvv --runmode workers
# ssh user@IP
# ping -c 5 IP
```

The following is the rule loaded:
`drop icmp any any -> any any (msg:"ICMP dropped"; rev:1; sid:1;)`

Some logs and stats:
- console output
```
[13799] 18/11/2018 -- 09:47:54 - (source-nfq.c:990) <Notice> (ReceiveNFQThreadExitStats) -- (W-Q0) Treated: Pkts 5, Bytes 420, Errors 0
[13799] 18/11/2018 -- 09:47:54 - (source-nfq.c:992) <Notice> (ReceiveNFQThreadExitStats) -- (W-Q0) Verdict: Accepted 0, Dropped 5, Replaced 0
[13804] 18/11/2018 -- 09:47:54 - (source-nflog.c:483) <Notice> (ReceiveNFLOGThreadExitStats) -- (W#01-2) Pkts 5, Bytes 296
[13798] 18/11/2018 -- 09:47:54 - (counters.c:830) <Info> (StatsLogSummary) -- Alerts: 1
```

- alert log
```
11/18/2018-09:47:24.723931  [Drop] [**] [1:1:1] ICMP dropped [**] [Classification: (null)] [Priority: 3] {ICMP} 192.168.0.178:8 -> 192.168.0.101:0
```

- stats.log
```
------------------------------------------------------------------------------------
Counter                                    | TM Name                   | Value
------------------------------------------------------------------------------------
decoder.pkts                               | Total                     | 10
decoder.bytes                              | Total                     | 716
decoder.ipv4                               | Total                     | 10
decoder.tcp                                | Total                     | 5
decoder.icmpv4                             | Total                     | 5
decoder.avg_pkt_size                       | Total                     | 71
decoder.max_pkt_size                       | Total                     | 88
flow.tcp                                   | Total                     | 1
flow.icmpv4                                | Total                     | 1
detect.alert                               | Total                     | 1
ips.blocked                                | Total                     | 5
flow.spare                                 | Total                     | 10000
flow_mgr.rows_checked                      | Total                     | 65536
flow_mgr.rows_skipped                      | Total                     | 65536
tcp.memuse                                 | Total                     | 1146880
tcp.reassembly_memuse                      | Total                     | 196608
flow.memuse                                | Total                     | 7234912
```
[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/194
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/58
