### PR TITLE
NFQ queue range v3

### DIFF
--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -816,14 +816,14 @@ TmEcode VerdictNFQThreadDeinit(ThreadVars *tv, void *data)
 }
 
 /**
- *  \brief Add a Netfilter queue
+ *  \brief Add a single Netfilter queue
  *
- *  \param string with the queue name
+ *  \param string with the queue number
  *
  *  \retval 0 on success.
  *  \retval -1 on failure.
  */
-int NFQRegisterQueue(char *queue)
+int NFQRegisterQueue(const char *queue)
 {
     NFQThreadVars *ntv = NULL;
     NFQQueueVars *nq = NULL;
@@ -858,11 +858,67 @@ int NFQRegisterQueue(char *queue)
     SCMutexUnlock(&nfq_init_lock);
     LiveRegisterDeviceName(queue);
 
-    SCLogDebug("Queue \"%s\" registered.", queue);
+    SCLogDebug("Queue %d registered.", queue_num);
     return 0;
 }
 
+/**
+ *  \brief Parses and adds Netfilter queue(s).
+ *
+ *  \param string with the queue number or range
+ *
+ *  \retval 0 on success.
+ *  \retval -1 on failure.
+ */
+int NFQParseAndRegisterQueues(const char *queues)
+{
+    char *queue2 = NULL;
+    uint16_t queue_start = 0;
+    uint16_t queue_end = 0;
 
+    if ((queue2 = strchr(queues, ':')) != NULL)  {
+        // "Start:end" format (e.g. "0:5")
+        queue2++;
+
+        if ((ByteExtractStringUint16(&queue_start, 10, queue2 - queues, queues)) < 0) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "specified start queue '%s' is not "
+                                        "valid", queues);
+            return -1;
+        }
+
+        if (strcmp(queue2, "") != 0) {
+            if ((ByteExtractStringUint16(&queue_end, 10, strlen(queue2), queue2)) < 0) {
+                SCLogError(SC_ERR_INVALID_ARGUMENT, "specified end queue '%s' is not "
+                                            "valid", queue2);
+                return -1;
+            }
+        } else {
+            queue_end = 65535;
+        }
+
+        // Sanity check
+        if (queue_start > queue_end) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "start queue's number %d is greater than "
+                                            "ending number %d", queue_start, queue_end);
+            return -1;
+        }
+
+        for (uint16_t i = queue_start; i <= queue_end; ++i) {
+            char q[6];
+            snprintf(q, sizeof(q), "%hu", i);
+
+            if (NFQRegisterQueue(q) != 0) {
+                return -1;
+            }
+        }
+    } else if (NFQRegisterQueue(queues) != 0) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT, "queue(s) argument '%s' is not "
+                                        "valid", queues);
+        return -1;
+    }
+
+    return 0;
+}
 
 /**
  *  \brief Get a pointer to the NFQ queue at index

--- a/src/source-nfq.h
+++ b/src/source-nfq.h
@@ -89,7 +89,8 @@ typedef struct NFQGlobalVars_
 } NFQGlobalVars;
 
 void NFQInitConfig(char quiet);
-int NFQRegisterQueue(char *queue);
+int NFQRegisterQueue(const char *queue);
+int NFQParseAndRegisterQueues(const char *queues);
 int NFQGetQueueCount(void);
 void *NFQGetQueue(int number);
 int NFQGetQueueNum(int number);

--- a/src/source-nfq.h
+++ b/src/source-nfq.h
@@ -30,7 +30,8 @@
 #include <linux/netfilter.h>		/* for NF_ACCEPT */
 #include <libnetfilter_queue/libnetfilter_queue.h>
 
-#define NFQ_MAX_QUEUE 16
+// Netfilter's limit
+#define NFQ_MAX_QUEUE 65535
 
 /* idea: set the recv-thread id in the packet to
  * select an verdict-queue */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -582,7 +582,7 @@ static void PrintUsage(const char *progname)
     printf("\t-F <bpf filter file>                 : bpf filter file\n");
     printf("\t-r <path>                            : run in pcap file/offline mode\n");
 #ifdef NFQ
-    printf("\t-q <qid>                             : run in inline nfqueue mode\n");
+    printf("\t-q <qid[:qid]>                       : run in inline nfqueue mode (use semicolon to specify a range of queues)\n");
 #endif /* NFQ */
 #ifdef IPFW
     printf("\t-d <divert port>                     : run in inline ipfw divert mode\n");
@@ -1974,10 +1974,10 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             if (suri->run_mode == RUNMODE_UNKNOWN) {
                 suri->run_mode = RUNMODE_NFQ;
                 EngineModeSetIPS();
-                if (NFQRegisterQueue(optarg) == -1)
+                if (NFQParseAndRegisterQueues(optarg) == -1)
                     return TM_ECODE_FAILED;
             } else if (suri->run_mode == RUNMODE_NFQ) {
-                if (NFQRegisterQueue(optarg) == -1)
+                if (NFQParseAndRegisterQueues(optarg) == -1)
                     return TM_ECODE_FAILED;
             } else {
                 SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:

- added ability to specify Netfilter queue range with '-q' option (similar to iptables '--queue-balance' option)
- increase maximum number of queues from 16 to 65535
- NFQ context are created dynamically instead of on-stack arrays

This replaces #3550.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

