### PR TITLE
Add sanity check for '-' on commandline for bpf

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -460,13 +460,18 @@ static int SetBpfString(int argc, char *argv[])
     tmpindex = optind;
     while(argv[tmpindex] != NULL) {
         strlcat(bpf_filter, argv[tmpindex],bpf_len);
-        if(argv[tmpindex + 1] != NULL) {
+	if (*bpf_filter == '-') {
+	    SCLogError(SC_ERR_FATAL, "Bad bpf filter specified.");
+	    SCFree(bpf_filter);
+	    return TM_ECODE_FAILED;
+	}
+        if (argv[tmpindex + 1] != NULL) {
             strlcat(bpf_filter," ", bpf_len);
         }
         tmpindex++;
     }
 
-    if(strlen(bpf_filter) > 0) {
+    if (strlen(bpf_filter) > 0) {
         if (ConfSetFinal("bpf-filter", bpf_filter) != 1) {
             SCLogError(SC_ERR_FATAL, "Failed to set bpf filter.");
             SCFree(bpf_filter);


### PR DESCRIPTION
As described in #1013 a '-' on the command line will get compiled
into the bpf. This commit adds a check for '-', fails the
bpf compile, enters a log entry, and exits suricata.

This was tested against offline (-r) and online (af-packet) run options.

Signed-off-by: jason taylor <jtfas90@gmail.com>

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1013

Describe changes:
- Add check for dangling '-' on command line to prevent runtime bpf filter issues
- Minor formatting fix for if()
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

