### PR TITLE
Af packet exit 6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -403,26 +403,40 @@
     if test "x$enable_ebpf_build" = "xyes"; then
         if echo $CC | grep clang; then
             if test "x$CC" = "xclang"; then
-                AC_MSG_CHECKING([llc binary])
-                AC_PATH_PROG(HAVE_LLC, llc, "yes", "no")
-                if test "$HAVE_LLC" = "yes"; then
+                AC_PATH_PROG(HAVE_LLC, llc, "no")
+                if test "$HAVE_LLC" != "no"; then
                     LLC="llc"
                     AC_SUBST(LLC)
                 else
-                    AC_MSG_CHECKING([llc binary for clang version])
                     llc_version_line=$($CC --version|$GREP version)
                     llc_version=$(echo $llc_version_line| cut -d '(' -f 1 | $GREP -E -o '@<:@0-9@:>@\.@<:@0-9@:>@')
-                    AC_MSG_RESULT($llc_version)
-                    LLC="llc-$llc_version"
-                    AC_SUBST(LLC)
+                    AC_PATH_PROG(HAVE_LLC, "llc-$llc_version", "no")
+                    if test "$HAVE_LLC" != "no"; then
+                        LLC="llc-$llc_version"
+                        AC_SUBST(LLC)
+		    else
+                        echo "unable to find llc needed to build ebpf files"
+                        exit 1
+                    fi
                 fi
             else
-                AC_MSG_CHECKING([llc binary for clang version])
-                llc_version_line=$($CC --version|$GREP version)
-                llc_version=$(echo $llc_version_line| cut -d '(' -f 1 | $GREP -E -o '@<:@0-9@:>@\.@<:@0-9@:>@')
-                AC_MSG_RESULT($llc_version)
-                LLC="llc-$llc_version"
-                AC_SUBST(LLC)
+                llc_version=$(echo $CC | cut -d '-' -f 2)
+                AC_PATH_PROG(HAVE_LLC, "llc-$llc_version", "no")
+                if test "$HAVE_LLC" != "no"; then
+                    LLC="llc-$llc_version"
+                    AC_SUBST(LLC)
+                else
+                    llc_version_line=$($CC --version|$GREP version)
+                    llc_version=$(echo $llc_version_line| cut -d '(' -f 1 | $GREP -E -o '@<:@0-9@:>@\.@<:@0-9@:>@')
+                    AC_PATH_PROG(HAVE_LLC, "llc-$llc_version", "no")
+                    if test "$HAVE_LLC" != "no"; then
+                        LLC="llc-$llc_version"
+                        AC_SUBST(LLC)
+                    else
+                        echo "unable to find llc needed to build ebpf files"
+                        exit 1
+                    fi
+                fi
             fi
         else
             echo "clang needed to build ebpf files"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -405,6 +405,7 @@ util-atomic.c util-atomic.h \
 util-base64.c util-base64.h \
 util-bloomfilter-counting.c util-bloomfilter-counting.h \
 util-bloomfilter.c util-bloomfilter.h \
+util-bpf.c util-bpf.h \
 util-buffer.c util-buffer.h \
 util-byte.c util-byte.h \
 util-checksum.c util-checksum.h \

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -28,8 +28,6 @@
  *
  * AF_PACKET socket acquisition support
  *
- * \todo watch other interface event to detect suppression of the monitored
- *       interface
  */
 
 #define PCAP_DONT_INCLUDE_PCAP_BPF_H 1
@@ -133,7 +131,6 @@ void TmModuleReceiveAFPRegister (void)
 
 /**
  * \brief Registration Function for DecodeAFP.
- * \todo Unit tests are needed for this module.
  */
 void TmModuleDecodeAFPRegister (void)
 {

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1058,8 +1058,7 @@ static inline int AFPParsePacketV3(AFPThreadVars *ptv, struct tpacket_block_desc
         p->afp_v.v4_map_fd = ptv->v4_map_fd;
         p->afp_v.v6_map_fd = ptv->v6_map_fd;
 #endif
-    }
-    if (ptv->flags & AFP_XDPBYPASS) {
+    } else if (ptv->flags & AFP_XDPBYPASS) {
         p->BypassPacketsFlow = AFPXDPBypassCallback;
 #ifdef HAVE_PACKET_EBPF
         p->afp_v.v4_map_fd = ptv->v4_map_fd;

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -292,8 +292,6 @@ typedef struct AFPThreadVars_
 
     uint8_t xdp_mode;
 
-    int map_fd[MAX_MAPS];
-
 } AFPThreadVars;
 
 TmEcode ReceiveAFP(ThreadVars *, Packet *, void *, PacketQueue *, PacketQueue *);

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -30,6 +30,7 @@
 *
 */
 
+
 #include "suricata-common.h"
 #include "config.h"
 #include "suricata.h"
@@ -42,6 +43,7 @@
 #include "tm-threads.h"
 #include "tm-threads-common.h"
 #include "conf.h"
+#include "util-bpf.h"
 #include "util-debug.h"
 #include "util-device.h"
 #include "util-error.h"
@@ -616,15 +618,19 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, const void *initdata, voi
     if (aconf->in.bpf_filter) {
         SCLogConfig("Using BPF '%s' on iface '%s'",
                   aconf->in.bpf_filter, ntv->ifsrc->ifname);
-        if (pcap_compile_nopcap(default_packet_size,  /* snaplen_arg */
+        char errbuf[PCAP_ERRBUF_SIZE];
+        if (SCBPFCompile(default_packet_size,  /* snaplen_arg */
                     LINKTYPE_ETHERNET,    /* linktype_arg */
                     &ntv->bpf_prog,       /* program */
                     aconf->in.bpf_filter, /* const char *buf */
                     1,                    /* optimize */
-                    PCAP_NETMASK_UNKNOWN  /* mask */
-                    ) == -1)
+                    PCAP_NETMASK_UNKNOWN,  /* mask */
+                    errbuf,
+                    sizeof(errbuf)) == -1)
         {
-            SCLogError(SC_ERR_NETMAP_CREATE, "Filter compilation failed.");
+            SCLogError(SC_ERR_NETMAP_CREATE, "Failed to compile BPF \"%s\": %s",
+                   aconf->in.bpf_filter,
+                   errbuf);
             goto error_dst;
         }
     }
@@ -952,7 +958,7 @@ static TmEcode ReceiveNetmapThreadDeinit(ThreadVars *tv, void *data)
         ntv->ifdst = NULL;
     }
     if (ntv->bpf_prog.bf_insns) {
-        pcap_freecode(&ntv->bpf_prog);
+        SCBPFFree(&ntv->bpf_prog);
     }
 
     SCReturnInt(TM_ECODE_OK);

--- a/src/util-bpf.c
+++ b/src/util-bpf.c
@@ -1,0 +1,73 @@
+/* Copyright (C) 2018 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Eric Leblond <eric@regit.org>
+ */
+
+
+#include "suricata-common.h"
+#include "config.h"
+#include "suricata.h"
+#include "util-bpf.h"
+
+
+/** protect bpf filter build, as it is not thread safe */
+static SCMutex bpf_set_filter_lock = SCMUTEX_INITIALIZER;
+
+void SCBPFFree(struct bpf_program *program)
+{
+    if (program)
+        pcap_freecode(program);
+}
+
+int SCBPFCompile(int snaplen_arg, int linktype_arg, struct bpf_program *program,
+                 const char *buf, int optimize, uint32_t mask,
+                 char *errbuf, size_t errbuf_len)
+{
+    pcap_t *p;
+    int ret;
+
+    p = pcap_open_dead(linktype_arg, snaplen_arg);
+    if (p == NULL)
+        return (-1);
+
+    SCMutexLock(&bpf_set_filter_lock);
+    ret = pcap_compile(p, program, buf, optimize, mask);
+    if (ret == -1) {
+        if (errbuf) {
+            snprintf(errbuf, errbuf_len, "%s", pcap_geterr(p));
+        }
+        pcap_close(p);
+        SCMutexUnlock(&bpf_set_filter_lock);
+        return (-1);
+    }
+    pcap_close(p);
+    SCMutexUnlock(&bpf_set_filter_lock);
+
+    if (program->bf_insns == NULL) {
+        if (errbuf) {
+            snprintf(errbuf, errbuf_len, "Filter badly setup");
+        }
+        SCBPFFree(program);
+        return (-1);
+    }
+
+    return (ret);
+}

--- a/src/util-bpf.h
+++ b/src/util-bpf.h
@@ -1,0 +1,33 @@
+/* Copyright (C) 2018 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Eric Leblond <eric@regit.org>
+ */
+
+#ifndef __UTIL_BPF_H__
+#define __UTIL_BPF_H__
+
+int SCBPFCompile(int snaplen_arg, int linktype_arg, struct bpf_program *program,
+                 const char *buf, int optimize, uint32_t mask,
+                 char *errbuf, size_t errbuf_len);
+
+void SCBPFFree(struct bpf_program *program);
+
+#endif /* __UTIL_BPF_H__ */


### PR DESCRIPTION
Update of #3519 with rebase and build fix for netmap.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Rebase on latest master
- Build fix for netmap
- Remove useless variable in af-packet thread structure

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/424
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/206
