### PR TITLE
rust/dns: add v1 dns json logging - v1

### DIFF
--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -1087,6 +1087,32 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
             MemBufferReset(td->buffer);
             OutputJSONBuffer(js, td->dnslog_ctx->file_ctx, &td->buffer);
         }
+    } else {
+        SCLogNotice("DNSv1 logging format not available with Rust.");
+        /* Log answers. */
+        for (uint16_t i = 0; i < UINT16_MAX; i++) {
+            json_t *answer = rs_dns_log_json_answer_v1(txptr, i,
+                    td->dnslog_ctx->flags);
+            if (answer == NULL) {
+                break;
+            }
+            json_object_set_new(js, "dns", answer);
+            MemBufferReset(td->buffer);
+            OutputJSONBuffer(js, td->dnslog_ctx->file_ctx, &td->buffer);
+            json_object_del(js, "dns");
+        }
+        /* Log authorities. */
+        for (uint16_t i = 0; i < UINT16_MAX; i++) {
+            json_t *answer = rs_dns_log_json_authority_v1(txptr, i,
+                    td->dnslog_ctx->flags);
+            if (answer == NULL) {
+                break;
+            }
+            json_object_set_new(js, "dns", answer);
+            MemBufferReset(td->buffer);
+            OutputJSONBuffer(js, td->dnslog_ctx->file_ctx, &td->buffer);
+            json_object_del(js, "dns");
+        }
     }
 #else
     DNSTransaction *tx = txptr;
@@ -1245,12 +1271,6 @@ static DnsVersion JsonDnsParseVersion(ConfNode *conf)
                 DNS_VERSION_DEFAULT);
         version = DNS_VERSION_DEFAULT;
     }
-#ifdef HAVE_RUST
-    if (version != DNS_VERSION_2) {
-        FatalError(SC_ERR_NOT_SUPPORTED, "EVE/DNS version %d not support with "
-                "by Rust builds.", version);
-    }
-#endif
     return version;
 }
 
@@ -1342,13 +1362,6 @@ static OutputInitResult JsonDnsLogInitCtx(ConfNode *conf)
     }
 
     DnsVersion version = JsonDnsParseVersion(conf);
-#ifdef HAVE_RUST
-    if (version != 2) {
-        SCLogError(SC_ERR_NOT_SUPPORTED, "EVE/DNS version %d not support with "
-                "by Rust builds.", version);
-        exit(1);
-    }
-#endif
 
     LogFileCtx *file_ctx = LogFileNewCtx();
 


### PR DESCRIPTION
Here is a first cut and adding JSON DNS v1 logging to the Rust DNS support.

@victorjulien This is primarily a request to have you run it through your QA. Thanks!

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/2704

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/332
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/686
