### PR TITLE
rust/dns: add v1 dns logging

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -164,7 +164,6 @@ outputs:
             # rather than an event for each of it.
             # Without setting a version the version
             # will fallback to 1 for backwards compatibility.
-            # Note: version 1 is not available with rust enabled
             version: 2
 
             # Enable/disable this logger. Default: enabled.


### PR DESCRIPTION
Enabled v1 json dns logging for Rust enabled builds.

Previous PR:
https://github.com/OISF/suricata/pull/3566

Changes from last PR:
- Remove debug log line (logged as notice).

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/2704

Suricata-Verify has been updated to test v1 json dns logging with Rust enabled builds:
- https://github.com/OISF/suricata-verify/pull/3

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/334
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/688
