### PR TITLE
rust/dns: add v1 dns logging - v3

### DIFF
--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -69,14 +69,9 @@ pub extern "C" fn rs_dns_lua_get_query_table(clua: &mut CLuaState,
 
     let mut i: i64 = 0;
 
-    for request in &tx.request {
+    lua.newtable();
 
-        if request.queries.len() == 0 {
-            break;
-        }
-
-        lua.newtable();
-
+    if let Some(request) = &tx.request {
         for query in &request.queries {
             lua.pushinteger(i);
             i += 1;
@@ -93,11 +88,26 @@ pub extern "C" fn rs_dns_lua_get_query_table(clua: &mut CLuaState,
 
             lua.settable(-3);
         }
+    } else if let Some(response) = &tx.response {
+        for query in &response.queries {
+            lua.pushinteger(i);
+            i += 1;
 
-        return 1;
+            lua.newtable();
+
+            lua.pushstring("type");
+            lua.pushstring(&dns_rrtype_string(query.rrtype));
+            lua.settable(-3);
+
+            lua.pushstring("rrname");
+            lua.pushstring(&String::from_utf8_lossy(&query.name));
+            lua.settable(-3);
+
+            lua.settable(-3);
+        }
     }
 
-    return 0;
+    return 1;
 }
 
 #[no_mangle]
@@ -111,14 +121,9 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
 
     let mut i: i64 = 0;
 
-    for response in &tx.response {
+    lua.newtable();
 
-        if response.answers.len() == 0 {
-            break;
-        }
-
-        lua.newtable();
-
+    if let Some(response) = &tx.response {
         for answer in &response.answers {
             lua.pushinteger(i);
             i += 1;
@@ -150,11 +155,9 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
             }
             lua.settable(-3);
         }
-
-        return 1;
     }
 
-    return 0;
+    return 1;
 }
 
 #[no_mangle]
@@ -168,14 +171,9 @@ pub extern "C" fn rs_dns_lua_get_authority_table(clua: &mut CLuaState,
 
     let mut i: i64 = 0;
 
-    for response in &tx.response {
+    lua.newtable();
 
-        if response.authorities.len() == 0 {
-            break;
-        }
-
-        lua.newtable();
-
+    if let Some(response) = &tx.response {
         for answer in &response.authorities {
             lua.pushinteger(i);
             i += 1;
@@ -195,9 +193,7 @@ pub extern "C" fn rs_dns_lua_get_authority_table(clua: &mut CLuaState,
 
             lua.settable(-3);
         }
-
-        return 1;
     }
 
-    return 0;
+    return 1;
 }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -164,7 +164,6 @@ outputs:
             # rather than an event for each of it.
             # Without setting a version the version
             # will fallback to 1 for backwards compatibility.
-            # Note: version 1 is not available with rust enabled
             version: 2
 
             # Enable/disable this logger. Default: enabled.


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/3569

Changes from last PR:
- Fix Lua support functions to match that of C, allowing the dns-lua suricata-verify test to pass.

Redmine issues:
- https://redmine.openinfosecfoundation.org/issues/2730
- https://redmine.openinfosecfoundation.org/issues/2704

Suricata-Verify has been updated as well:
- https://github.com/OISF/suricata-verify/pull/4

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/335
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/689
