### PR TITLE
rust/dns: add v1 dns logging - v5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,46 +85,46 @@ matrix:
         - DO_CHECK_SETUP_SCRIPTS="yes"
         - DO_DISTCHECK="yes"
     # Linux, gcc, Rust (auto detect).
-    # - Rust 1.29.1, the latest known working version.
+    # - Rust 1.31.0, the latest known working version.
     - os: linux
       compiler: gcc
       env:
-        - NAME="linux,gcc,rust-1.29.1-disabled"
+        - NAME="linux,gcc,rust-1.31.0-disabled"
         - *default-cflags
         - ENABLE_RUST="yes"
-        - RUST_VERSION="1.29.1"
+        - RUST_VERSION="1.31.0"
         - ARGS="--disable-rust"
         - DO_DISTCHECK="yes"
     # Linux, gcc, Rust (auto detect).
-    # - Rust 1.29.1, the latest known working version.
+    # - Rust 1.31.0, the latest known working version.
     - os: linux
       compiler: gcc
       env:
-        - NAME="linux,gcc,rust-1.29.1-auto"
+        - NAME="linux,gcc,rust-1.31.0-auto"
         - *default-cflags
         - ENABLE_RUST="yes"
-        - RUST_VERSION="1.29.1"
+        - RUST_VERSION="1.31.0"
         - ARGS=""
         - DO_DISTCHECK="yes"
     # Linux, gcc, Rust.
-    # - Rust 1.29.1, the latest known working version.
+    # - Rust 1.31.0, the latest known working version.
     - os: linux
       compiler: gcc
       env:
-        - NAME="linux,gcc,rust-1.29.1"
+        - NAME="linux,gcc,rust-1.31.0"
         - *default-cflags
         - ENABLE_RUST="yes"
-        - RUST_VERSION="1.29.1"
+        - RUST_VERSION="1.31.0"
         - ARGS="--enable-rust --enable-rust-strict"
         - DO_DISTCHECK="yes"
-    # Linux, gcc, Rust (1.21.0 - oldest supported).
+    # Linux, gcc, Rust (1.24.1 - oldest supported).
     - os: linux
       compiler: gcc
       env:
-        - NAME="linux,gcc,rust-1.21.0"
+        - NAME="linux,gcc,rust-1.24.1"
         - *default-cflags
         - ENABLE_RUST="yes"
-        - RUST_VERSION="1.21.0"
+        - RUST_VERSION="1.24.1"
         - ARGS="--enable-rust --enable-rust-strict"
         - DO_DISTCHECK="yes"
     # Linux, gcc, -DNDEBUG.

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -215,10 +215,10 @@ impl DNSTransaction {
 
     /// Get the DNS transactions ID (not the internal tracking ID).
     pub fn tx_id(&self) -> u16 {
-        for request in &self.request {
+        if let &Some(ref request) = &self.request {
             return request.header.tx_id;
         }
-        for response in &self.response {
+        if let &Some(ref response) = &self.response {
             return response.header.tx_id;
         }
 
@@ -229,7 +229,7 @@ impl DNSTransaction {
     /// Get the reply code of the transaction. Note that this will
     /// also return 0 if there is no reply.
     pub fn rcode(&self) -> u16 {
-        for response in &self.response {
+        if let &Some(ref response) = &self.response {
             return response.header.flags & 0x000f;
         }
         return 0;
@@ -292,7 +292,6 @@ impl DNSState {
     }
 
     pub fn free_tx(&mut self, tx_id: u64) {
-        SCLogDebug!("************** Freeing TX with ID {}", tx_id);
         let len = self.transactions.len();
         let mut found = false;
         let mut index = 0;
@@ -770,7 +769,7 @@ pub extern "C" fn rs_dns_tx_get_query_name(tx: &mut DNSTransaction,
                                        len: *mut libc::uint32_t)
                                        -> libc::uint8_t
 {
-    for request in &tx.request {
+    if let &Some(ref request) = &tx.request {
         if (i as usize) < request.queries.len() {
             let query = &request.queries[i as usize];
             if query.name.len() > 0 {
@@ -810,7 +809,7 @@ pub extern "C" fn rs_dns_tx_get_query_rrtype(tx: &mut DNSTransaction,
                                          rrtype: *mut libc::uint16_t)
                                          -> libc::uint8_t
 {
-    for request in &tx.request {
+    if let &Some(ref request) = &tx.request {
         if (i as usize) < request.queries.len() {
             let query = &request.queries[i as usize];
             if query.name.len() > 0 {

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -474,6 +474,7 @@ fn dns_log_json_answer(response: &DNSResponse, flags: u64) -> Json
 
     for query in &response.queries {
         js.set_string_from_bytes("rrname", &query.name);
+        js.set_string("rrtype", &dns_rrtype_string(query.rrtype));
         break;
     }
     js.set_string("rcode", &dns_rcode_string(header.flags));

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -69,14 +69,13 @@ pub extern "C" fn rs_dns_lua_get_query_table(clua: &mut CLuaState,
 
     let mut i: i64 = 0;
 
-    for request in &tx.request {
+    // Create table now to be consistent with C that always returns
+    // table even in the absence of any authorities.
+    lua.newtable();
 
-        if request.queries.len() == 0 {
-            break;
-        }
-
-        lua.newtable();
-
+    // We first look in the request for queries. However, if there is
+    // no request, check the response for queries.
+    if let Some(request) = &tx.request {
         for query in &request.queries {
             lua.pushinteger(i);
             i += 1;
@@ -93,11 +92,28 @@ pub extern "C" fn rs_dns_lua_get_query_table(clua: &mut CLuaState,
 
             lua.settable(-3);
         }
+    } else if let Some(response) = &tx.response {
+        for query in &response.queries {
+            lua.pushinteger(i);
+            i += 1;
 
-        return 1;
+            lua.newtable();
+
+            lua.pushstring("type");
+            lua.pushstring(&dns_rrtype_string(query.rrtype));
+            lua.settable(-3);
+
+            lua.pushstring("rrname");
+            lua.pushstring(&String::from_utf8_lossy(&query.name));
+            lua.settable(-3);
+
+            lua.settable(-3);
+        }
     }
 
-    return 0;
+    // Again, always return 1 to be consistent with C, even if the
+    // table is empty.
+    return 1;
 }
 
 #[no_mangle]
@@ -111,14 +127,11 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
 
     let mut i: i64 = 0;
 
-    for response in &tx.response {
+    // Create table now to be consistent with C that always returns
+    // table even in the absence of any authorities.
+    lua.newtable();
 
-        if response.answers.len() == 0 {
-            break;
-        }
-
-        lua.newtable();
-
+    if let Some(response) = &tx.response {
         for answer in &response.answers {
             lua.pushinteger(i);
             i += 1;
@@ -150,11 +163,11 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
             }
             lua.settable(-3);
         }
-
-        return 1;
     }
 
-    return 0;
+    // Again, always return 1 to be consistent with C, even if the
+    // table is empty.
+    return 1;
 }
 
 #[no_mangle]
@@ -168,14 +181,11 @@ pub extern "C" fn rs_dns_lua_get_authority_table(clua: &mut CLuaState,
 
     let mut i: i64 = 0;
 
-    for response in &tx.response {
+    // Create table now to be consistent with C that always returns
+    // table even in the absence of any authorities.
+    lua.newtable();
 
-        if response.authorities.len() == 0 {
-            break;
-        }
-
-        lua.newtable();
-
+    if let Some(response) = &tx.response {
         for answer in &response.authorities {
             lua.pushinteger(i);
             i += 1;
@@ -195,9 +205,9 @@ pub extern "C" fn rs_dns_lua_get_authority_table(clua: &mut CLuaState,
 
             lua.settable(-3);
         }
-
-        return 1;
     }
 
-    return 0;
+    // Again, always return 1 to be consistent with C, even if the
+    // table is empty.
+    return 1;
 }

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -41,14 +41,12 @@ pub extern "C" fn rs_dns_lua_get_rrname(clua: &mut CLuaState,
         lua: clua,
     };
 
-    for request in &tx.request {
+    if let Some(request) = &tx.request {
         for query in &request.queries {
             lua.pushstring(&String::from_utf8_lossy(&query.name));
             return 1;
         }
-    }
-
-    for response in &tx.response {
+    } else if let Some(response) = &tx.response {
         for query in &response.queries {
             lua.pushstring(&String::from_utf8_lossy(&query.name));
             return 1;

--- a/scripts/check-setup.sh
+++ b/scripts/check-setup.sh
@@ -22,11 +22,11 @@ cd ${tmpdir}
 ./autogen.sh
 ./configure
 
-./scripts/setup-app-layer.sh Echo
+./scripts/setup-app-layer.py --parser Echo
 
-./scripts/setup-app-layer-detect.sh Echo request
+./scripts/setup-app-layer.py --detect Echo request
 
-./scripts/setup-app-layer-logger.sh Echo
+./scripts/setup-app-layer.py --logger Echo
 
 ./scripts/setup-decoder.sh Udplite
 

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -861,8 +861,8 @@ static json_t *BuildAnswer(DNSTransaction *tx, uint64_t tx_id, uint64_t flags,
     DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));
     json_object_set_new(js, "rcode", json_string(rcode));
 
-    /* Log the query rrname. Mostly useful on error, but still
-     * useful. */
+    /* Log the query rrname and rrtype. Mostly useful on error, but
+     * still useful. */
     DNSQueryEntry *query = TAILQ_FIRST(&tx->query_list);
     if (query != NULL) {
         char *c;
@@ -872,6 +872,9 @@ static json_t *BuildAnswer(DNSTransaction *tx, uint64_t tx_id, uint64_t flags,
             json_object_set_new(js, "rrname", json_string(c));
             SCFree(c);
         }
+        char rrtype[16] = "";
+        DNSCreateTypeString(query->type, rrtype, sizeof(rrtype));
+        json_object_set_new(js, "rrtype", json_string(rrtype));
     }
 
     if (flags & LOG_FORMAT_DETAILED) {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -164,7 +164,6 @@ outputs:
             # rather than an event for each of it.
             # Without setting a version the version
             # will fallback to 1 for backwards compatibility.
-            # Note: version 1 is not available with rust enabled
             version: 2
 
             # Enable/disable this logger. Default: enabled.


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/3572

Changes since last PR:
- Add comment as to why we return 1 and an empty lua table if there is no data to be returned (to be compatible with the C implementation).
- Migrate from for Option<type> to if let Some(), except for one case where the iterator is more clear.
- Add the rrtype to the logged json response object outside of the actual answers. Redmine issue 2723.
- Travis: Update the minimum Rust version to 1.24.1. This appears to be the older version we need to support across the major Linux distributions.
- Travis: Update the the latest version of Rust to the recently released 1.31. This should be a popular release as it introduces 2018 edition to stable rust.
- Fix check-setup script to test setup scripts.

Relevant Redmine tickets:
- https://redmine.openinfosecfoundation.org/issues/2730
- https://redmine.openinfosecfoundation.org/issues/2704
- https://redmine.openinfosecfoundation.org/issues/2723

Suricata-Update branch: OISF/suricata-verify#4

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- Buildbot not available.