### PR TITLE
Opt/tx cleanups/v6

### DIFF
--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -221,7 +221,7 @@ impl TemplateState {
                 index += 1;
                 continue;
             }
-            *state = index as u64 + 1;
+            *state = index as u64;
             return Some((tx, tx.tx_id - 1, (len - index) > 1));
         }
 

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -210,7 +210,7 @@ impl DHCPState {
                 index += 1;
                 continue;
             }
-            *state = index as u64 + 1;
+            *state = index as u64;
             return Some((tx, tx.tx_id - 1, (len - index) > 1));
         }
         

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -428,7 +428,10 @@ impl NFSState {
                 index += 1;
                 continue;
             }
-            *state = index as u64 + 1;
+            // store current index in the state and not the next
+            // as transactions might be freed between now and the
+            // next time we are called.
+            *state = index as u64;
             SCLogDebug!("returning tx_id {} has_next? {} (len {} index {}), tx {:?}",
                     tx.id - 1, (len - index) > 1, len, index, tx);
             return Some((tx, tx.id - 1, (len - index) > 1));

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -874,7 +874,10 @@ impl SMBState {
                 index += 1;
                 continue;
             }
-            *state = index as u64 + 1;
+            // store current index in the state and not the next
+            // as transactions might be freed between now and the
+            // next time we are called.
+            *state = index as u64;
             //SCLogDebug!("returning tx_id {} has_next? {} (len {} index {}), tx {:?}",
             //        tx.id - 1, (len - index) > 1, len, index, tx);
             return Some((tx, tx.id - 1, (len - index) > 1));

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -164,6 +164,17 @@ struct AppLayerParserState_ {
     AppLayerDecoderEvents *decoder_events;
 };
 
+#ifdef UNITTESTS
+void UTHAppLayerParserStateGetIds(void *ptr, uint64_t *i1, uint64_t *i2, uint64_t *log, uint64_t *min)
+{
+    struct AppLayerParserState_ *s = ptr;
+    *i1 = s->inspect_id[0];
+    *i2 = s->inspect_id[1];
+    *log = s->log_id;
+    *min = s->min_id;
+}
+#endif
+
 /* Static global version of the parser context.
  * Post 2.0 let's look at changing this to move it out to app-layer.c. */
 static AppLayerParserCtx alp_ctx;

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -277,6 +277,7 @@ void AppLayerParserRegisterProtocolUnittests(uint8_t ipproto, AppProto alproto,
 void AppLayerParserRegisterUnittests(void);
 void AppLayerParserBackupParserTable(void);
 void AppLayerParserRestoreParserTable(void);
+void UTHAppLayerParserStateGetIds(void *ptr, uint64_t *i1, uint64_t *i2, uint64_t *log, uint64_t *min);
 #endif
 
 #endif /* __APP_LAYER_PARSER_H__ */

--- a/src/app-layer-smb-tcp-rust.c
+++ b/src/app-layer-smb-tcp-rust.c
@@ -208,6 +208,10 @@ static SuricataFileContext sfc = { &sbcfg };
 
 #define SMB_CONFIG_DEFAULT_STREAM_DEPTH 0
 
+#ifdef UNITTESTS
+static void SMBParserRegisterTests(void);
+#endif
+
 static uint32_t stream_depth = SMB_CONFIG_DEFAULT_STREAM_DEPTH;
 
 void RegisterRustSMBTCPParsers(void)
@@ -299,7 +303,177 @@ void RegisterRustSMBTCPParsers(void)
         SCLogInfo("Parsed disabled for %s protocol. Protocol detection"
                   "still on.", proto_name);
     }
+#ifdef UNITTESTS
+    AppLayerParserRegisterProtocolUnittests(IPPROTO_TCP, ALPROTO_SMB, SMBParserRegisterTests);
+#endif
 
     return;
 }
+
+#ifdef UNITTESTS
+#include "stream-tcp.h"
+#include "util-unittest-helper.h"
+
+/** \test multi transactions and cleanup */
+static int SMBParserTxCleanupTest(void)
+{
+    uint64_t ret[4];
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    FAIL_IF_NULL(alp_tctx);
+
+    StreamTcpInitConfig(TRUE);
+    TcpSession ssn;
+    memset(&ssn, 0, sizeof(ssn));
+
+    Flow *f = UTHBuildFlow(AF_INET, "1.2.3.4", "1.2.3.5", 1024, 445);
+    FAIL_IF_NULL(f);
+    f->protoctx = &ssn;
+    f->proto = IPPROTO_TCP;
+    f->alproto = ALPROTO_SMB;
+
+    char req_str[] ="\x00\x00\x00\x79\xfe\x53\x4d\x42\x40\x00\x01\x00\x00\x00\x00\x00" \
+                     "\x05\x00\xe0\x1e\x10\x00\x00\x00\x00\x00\x00\x00\x0b\x00\x00\x00" \
+                     "\x00\x00\x00\x00\x00\x00\x00\x00\x10\x72\xd2\x9f\x36\xc2\x08\x14" \
+                     "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" \
+                     "\x00\x00\x00\x00\x39\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00" \
+                     "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x00" \
+                     "\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00" \
+                     "\x78\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+    req_str[28] = 0x01;
+    int r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOSERVER | STREAM_START, (uint8_t *)req_str, sizeof(req_str));
+    FAIL_IF_NOT(r == 0);
+    req_str[28]++;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOSERVER, (uint8_t *)req_str, sizeof(req_str));
+    FAIL_IF_NOT(r == 0);
+    req_str[28]++;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOSERVER, (uint8_t *)req_str, sizeof(req_str));
+    FAIL_IF_NOT(r == 0);
+    req_str[28]++;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOSERVER, (uint8_t *)req_str, sizeof(req_str));
+    FAIL_IF_NOT(r == 0);
+    req_str[28]++;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOSERVER, (uint8_t *)req_str, sizeof(req_str));
+    FAIL_IF_NOT(r == 0);
+    req_str[28]++;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOSERVER, (uint8_t *)req_str, sizeof(req_str));
+    FAIL_IF_NOT(r == 0);
+    req_str[28]++;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOSERVER, (uint8_t *)req_str, sizeof(req_str));
+    FAIL_IF_NOT(r == 0);
+    req_str[28]++;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOSERVER, (uint8_t *)req_str, sizeof(req_str));
+    FAIL_IF_NOT(r == 0);
+    req_str[28]++;
+
+    AppLayerParserTransactionsCleanup(f);
+    UTHAppLayerParserStateGetIds(f->alparser, &ret[0], &ret[1], &ret[2], &ret[3]);
+    FAIL_IF_NOT(ret[0] == 0); // inspect_id[0]
+    FAIL_IF_NOT(ret[1] == 0); // inspect_id[1]
+    FAIL_IF_NOT(ret[2] == 0); // log_id
+    FAIL_IF_NOT(ret[3] == 0); // min_id
+
+    char resp_str[] = "\x00\x00\x00\x98\xfe\x53\x4d\x42\x40\x00\x01\x00\x00\x00\x00\x00" \
+                       "\x05\x00\x21\x00\x11\x00\x00\x00\x00\x00\x00\x00\x0b\x00\x00\x00" \
+                       "\x00\x00\x00\x00\x00\x00\x00\x00\x10\x72\xd2\x9f\x36\xc2\x08\x14" \
+                       "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" \
+                       "\x00\x00\x00\x00\x59\x00\x00\x00\x01\x00\x00\x00\x48\x38\x40\xb3" \
+                       "\x0f\xa8\xd3\x01\x84\x9a\x2b\x46\xf7\xa8\xd3\x01\x48\x38\x40\xb3" \
+                       "\x0f\xa8\xd3\x01\x48\x38\x40\xb3\x0f\xa8\xd3\x01\x00\x00\x00\x00" \
+                       "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00" \
+                       "\x00\x00\x00\x00\x9e\x8f\xb8\x91\x00\x00\x00\x00\x01\x5b\x11\xbb" \
+                       "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+
+    resp_str[28] = 0x01;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOCLIENT | STREAM_START, (uint8_t *)resp_str, sizeof(resp_str));
+    FAIL_IF_NOT(r == 0);
+    resp_str[28] = 0x04;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOCLIENT, (uint8_t *)resp_str, sizeof(resp_str));
+    FAIL_IF_NOT(r == 0);
+    resp_str[28] = 0x05;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOCLIENT, (uint8_t *)resp_str, sizeof(resp_str));
+    FAIL_IF_NOT(r == 0);
+    resp_str[28] = 0x06;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOCLIENT, (uint8_t *)resp_str, sizeof(resp_str));
+    FAIL_IF_NOT(r == 0);
+    resp_str[28] = 0x08;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOCLIENT, (uint8_t *)resp_str, sizeof(resp_str));
+    FAIL_IF_NOT(r == 0);
+    resp_str[28] = 0x02;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOCLIENT, (uint8_t *)resp_str, sizeof(resp_str));
+    FAIL_IF_NOT(r == 0);
+    resp_str[28] = 0x07;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOCLIENT, (uint8_t *)resp_str, sizeof(resp_str));
+    FAIL_IF_NOT(r == 0);
+    AppLayerParserTransactionsCleanup(f);
+
+    UTHAppLayerParserStateGetIds(f->alparser, &ret[0], &ret[1], &ret[2], &ret[3]);
+    FAIL_IF_NOT(ret[0] == 2); // inspect_id[0]
+    FAIL_IF_NOT(ret[1] == 2); // inspect_id[1]
+    FAIL_IF_NOT(ret[2] == 2); // log_id
+    FAIL_IF_NOT(ret[3] == 2); // min_id
+
+    resp_str[28] = 0x03;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOCLIENT, (uint8_t *)resp_str, sizeof(resp_str));
+    FAIL_IF_NOT(r == 0);
+    AppLayerParserTransactionsCleanup(f);
+
+    UTHAppLayerParserStateGetIds(f->alparser, &ret[0], &ret[1], &ret[2], &ret[3]);
+    FAIL_IF_NOT(ret[0] == 8); // inspect_id[0]
+    FAIL_IF_NOT(ret[1] == 8); // inspect_id[1]
+    FAIL_IF_NOT(ret[2] == 8); // log_id
+    FAIL_IF_NOT(ret[3] == 8); // min_id
+
+    req_str[28] = 0x09;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOSERVER | STREAM_EOF, (uint8_t *)req_str, sizeof(req_str));
+    FAIL_IF_NOT(r == 0);
+    AppLayerParserTransactionsCleanup(f);
+
+    UTHAppLayerParserStateGetIds(f->alparser, &ret[0], &ret[1], &ret[2], &ret[3]);
+    FAIL_IF_NOT(ret[0] == 8); // inspect_id[0] not updated by ..Cleanup() until full tx is done
+    FAIL_IF_NOT(ret[1] == 8); // inspect_id[1]
+    FAIL_IF_NOT(ret[2] == 8); // log_id
+    FAIL_IF_NOT(ret[3] == 8); // min_id
+
+    resp_str[28] = 0x09;
+    r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
+                                STREAM_TOCLIENT | STREAM_EOF, (uint8_t *)resp_str, sizeof(resp_str));
+    FAIL_IF_NOT(r == 0);
+    AppLayerParserTransactionsCleanup(f);
+
+    UTHAppLayerParserStateGetIds(f->alparser, &ret[0], &ret[1], &ret[2], &ret[3]);
+    FAIL_IF_NOT(ret[0] == 9); // inspect_id[0]
+    FAIL_IF_NOT(ret[1] == 9); // inspect_id[1]
+    FAIL_IF_NOT(ret[2] == 9); // log_id
+    FAIL_IF_NOT(ret[3] == 9); // min_id
+
+    AppLayerParserThreadCtxFree(alp_tctx);
+    StreamTcpFreeConfig(TRUE);
+    UTHFreeFlow(f);
+
+    PASS;
+}
+
+static void SMBParserRegisterTests(void)
+{
+    UtRegisterTest("SMBParserTxCleanupTest", SMBParserTxCleanupTest);
+}
+
+#endif /* UNITTESTS */
 #endif /* HAVE_RUST */

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -205,7 +205,7 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
                     "tc_log_progress %d", logger, logger->LogCondition,
                     logger->ts_log_progress, logger->tc_log_progress);
             if (logger->alproto == alproto &&
-                (tx_logged & (1<<logger->logger_id)) == 0)
+                (tx_logged_old & (1<<logger->logger_id)) == 0)
             {
                 SCLogDebug("alproto match, logging tx_id %"PRIu64, tx_id);
 

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -270,6 +270,7 @@ next_logger:
 next_tx:
         if (!ires.has_next)
             break;
+        tx_id++;
     }
 
     /* Update the the last ID that has been logged with all

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -575,6 +575,7 @@ static TmEcode UnixSocketPcapFilesCheck(void *data)
 
     /* Un-pause all the paused threads */
     TmThreadWaitOnThreadInit();
+    PacketPoolPostRunmodes();
     TmThreadContinueThreads();
 
     SCLogInfo("Starting run for '%s'", this->current_file->filename);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2734
https://redmine.openinfosecfoundation.org/issues/2731

Describe changes:
- fix deadlock in unix runmode with many threads
- fix multiple instances of tx loggers
- optimize tx cleanup

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
N/A
