### PR TITLE
keywords tls_sni is a Sticky buffer

### DIFF
--- a/src/detect-tls-sni.c
+++ b/src/detect-tls-sni.c
@@ -68,7 +68,7 @@ static int g_tls_sni_buffer_id = 0;
 void DetectTlsSniRegister(void)
 {
     sigmatch_table[DETECT_AL_TLS_SNI].name = "tls_sni";
-    sigmatch_table[DETECT_AL_TLS_SNI].desc = "content modifier to match specifically and only on the TLS SNI buffer";
+    sigmatch_table[DETECT_AL_TLS_SNI].desc = "Sticky buffer to match specifically and only on the TLS SNI buffer";
     sigmatch_table[DETECT_AL_TLS_SNI].url = DOC_URL DOC_VERSION "/rules/tls-keywords.html#tls-sni";
     sigmatch_table[DETECT_AL_TLS_SNI].Match = NULL;
     sigmatch_table[DETECT_AL_TLS_SNI].Setup = DetectTlsSniSetup;


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Changed the description of the keyword tls-sni in the return of `suricata --list-keywords=tls_sni`

