### PR TITLE
NFQ queue range v4

### DIFF
--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -48,6 +48,7 @@
 #include "util-debug.h"
 #include "util-error.h"
 #include "util-byte.h"
+#include "util-cpu.h"
 #include "util-privs.h"
 #include "util-device.h"
 
@@ -136,8 +137,8 @@ typedef struct NFQThreadVars_
 /* shared vars for all for nfq queues and threads */
 static NFQGlobalVars nfq_g;
 
-static NFQThreadVars g_nfq_t[NFQ_MAX_QUEUE];
-static NFQQueueVars g_nfq_q[NFQ_MAX_QUEUE];
+static NFQThreadVars *g_nfq_t;
+static NFQQueueVars *g_nfq_q;
 static uint16_t receive_queue_num = 0;
 static SCMutex nfq_init_lock;
 
@@ -828,18 +829,28 @@ int NFQRegisterQueue(const uint16_t number)
     NFQThreadVars *ntv = NULL;
     NFQQueueVars *nq = NULL;
     char queue[6] = { 0 };
+    static bool many_queues_warned = false;
+    uint16_t num_cpus = UtilCpuGetNumProcessorsOnline();
 
-    SCMutexLock(&nfq_init_lock);
-    if (receive_queue_num >= NFQ_MAX_QUEUE) {
-        SCLogError(SC_ERR_INVALID_ARGUMENT,
-                   "too much Netfilter queue registered (%d)",
-                   receive_queue_num);
-        SCMutexUnlock(&nfq_init_lock);
+    if (g_nfq_t == NULL || g_nfq_q == NULL) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT, "NFQ context is not initialized");
         return -1;
     }
-    if (receive_queue_num == 0) {
-        memset(&g_nfq_t, 0, sizeof(g_nfq_t));
-        memset(&g_nfq_q, 0, sizeof(g_nfq_q));
+
+    SCMutexLock(&nfq_init_lock);
+    if (!many_queues_warned && (receive_queue_num >= num_cpus)) {
+        SCLogWarning(SC_WARN_UNCOMMON,
+                     "using more Netfilter queues than %hu available CPU core(s) "
+                     "may degrade performance",
+                     num_cpus);
+        many_queues_warned = true;
+    }
+    if (receive_queue_num >= NFQ_MAX_QUEUE) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT,
+                   "can not register more than %d Netfilter queues",
+                   NFQ_MAX_QUEUE);
+        SCMutexUnlock(&nfq_init_lock);
+        return -1;
     }
 
     ntv = &g_nfq_t[receive_queue_num];
@@ -868,6 +879,7 @@ int NFQParseAndRegisterQueues(const char *queues)
 {
     uint16_t queue_start = 0;
     uint16_t queue_end = 0;
+    uint16_t num_queues = 1;    // if argument is correct, at least one queue will be created
 
     // Either "id" or "start:end" format (e.g., "12" or "0:5")
     if (sscanf(queues, "%hu:%hu", &queue_start, &queue_end) < 1) {
@@ -885,16 +897,29 @@ int NFQParseAndRegisterQueues(const char *queues)
             return -1;
         }
 
-        for (uint16_t i = queue_start; i <= queue_end; i++) {
-            if (NFQRegisterQueue(i) != 0) {
-                return -1;
-            }
-        }
-    } else if (NFQRegisterQueue(queue_start) != 0) {
-        SCLogError(SC_ERR_INVALID_ARGUMENT, "queue(s) argument '%s' is not "
-                                        "valid", queues);
-        return -1;
+        num_queues = queue_end - queue_start + 1; // +1 due to inclusive range
     }
+
+    g_nfq_t = (NFQThreadVars *)SCCalloc(num_queues, sizeof(NFQThreadVars));
+
+    if (g_nfq_t == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate NFQThreadVars");
+        exit(EXIT_FAILURE);
+    }
+
+    g_nfq_q = (NFQQueueVars *)SCCalloc(num_queues, sizeof(NFQQueueVars));
+
+    if (g_nfq_q == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate NFQQueueVars");
+        SCFree(g_nfq_t);
+        exit(EXIT_FAILURE);
+    }
+
+    do {
+        if (NFQRegisterQueue(queue_start) != 0) {
+            return -1;
+        }
+    } while (++queue_start <= queue_end);
 
     return 0;
 }
@@ -1264,4 +1289,3 @@ TmEcode DecodeNFQThreadDeinit(ThreadVars *tv, void *data)
 }
 
 #endif /* NFQ */
-

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -816,25 +816,18 @@ TmEcode VerdictNFQThreadDeinit(ThreadVars *tv, void *data)
 }
 
 /**
- *  \brief Add a Netfilter queue
+ *  \brief Add a single Netfilter queue
  *
- *  \param string with the queue name
+ *  \param string with the queue number
  *
  *  \retval 0 on success.
  *  \retval -1 on failure.
  */
-int NFQRegisterQueue(char *queue)
+int NFQRegisterQueue(const uint16_t number)
 {
     NFQThreadVars *ntv = NULL;
     NFQQueueVars *nq = NULL;
-    /* Extract the queue number from the specified command line argument */
-    uint16_t queue_num = 0;
-    if ((ByteExtractStringUint16(&queue_num, 10, strlen(queue), queue)) < 0)
-    {
-        SCLogError(SC_ERR_INVALID_ARGUMENT, "specified queue number %s is not "
-                                        "valid", queue);
-        return -1;
-    }
+    char queue[6] = { 0 };
 
     SCMutexLock(&nfq_init_lock);
     if (receive_queue_num >= NFQ_MAX_QUEUE) {
@@ -853,16 +846,58 @@ int NFQRegisterQueue(char *queue)
     ntv->nfq_index = receive_queue_num;
 
     nq = &g_nfq_q[receive_queue_num];
-    nq->queue_num = queue_num;
+    nq->queue_num = number;
     receive_queue_num++;
     SCMutexUnlock(&nfq_init_lock);
+    snprintf(queue, sizeof(queue) - 1, "%hu", number);
     LiveRegisterDeviceName(queue);
 
-    SCLogDebug("Queue \"%s\" registered.", queue);
+    SCLogDebug("Queue %d registered.", number);
     return 0;
 }
 
+/**
+ *  \brief Parses and adds Netfilter queue(s).
+ *
+ *  \param string with the queue number or range
+ *
+ *  \retval 0 on success.
+ *  \retval -1 on failure.
+ */
+int NFQParseAndRegisterQueues(const char *queues)
+{
+    uint16_t queue_start = 0;
+    uint16_t queue_end = 0;
 
+    // Either "id" or "start:end" format (e.g., "12" or "0:5")
+    if (sscanf(queues, "%hu:%hu", &queue_start, &queue_end) < 1) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT, "specified queue(s) argument '%s' is not "
+                                            "valid (allowed queue numbers are 0-65535)", queues);
+        return -1;
+    }
+
+    // Do we have a range?
+    if (queue_end != 0) {
+        // Sanity check
+        if (queue_start > queue_end) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "start queue's number %d is greater than "
+                                            "ending number %d", queue_start, queue_end);
+            return -1;
+        }
+
+        for (uint16_t i = queue_start; i <= queue_end; i++) {
+            if (NFQRegisterQueue(i) != 0) {
+                return -1;
+            }
+        }
+    } else if (NFQRegisterQueue(queue_start) != 0) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT, "queue(s) argument '%s' is not "
+                                        "valid", queues);
+        return -1;
+    }
+
+    return 0;
+}
 
 /**
  *  \brief Get a pointer to the NFQ queue at index

--- a/src/source-nfq.h
+++ b/src/source-nfq.h
@@ -30,7 +30,8 @@
 #include <linux/netfilter.h>		/* for NF_ACCEPT */
 #include <libnetfilter_queue/libnetfilter_queue.h>
 
-#define NFQ_MAX_QUEUE 16
+// Netfilter's limit
+#define NFQ_MAX_QUEUE 65535
 
 /* idea: set the recv-thread id in the packet to
  * select an verdict-queue */

--- a/src/source-nfq.h
+++ b/src/source-nfq.h
@@ -89,7 +89,8 @@ typedef struct NFQGlobalVars_
 } NFQGlobalVars;
 
 void NFQInitConfig(char quiet);
-int NFQRegisterQueue(char *queue);
+int NFQRegisterQueue(const uint16_t number);
+int NFQParseAndRegisterQueues(const char *queues);
 int NFQGetQueueCount(void);
 void *NFQGetQueue(int number);
 int NFQGetQueueNum(int number);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -582,7 +582,7 @@ static void PrintUsage(const char *progname)
     printf("\t-F <bpf filter file>                 : bpf filter file\n");
     printf("\t-r <path>                            : run in pcap file/offline mode\n");
 #ifdef NFQ
-    printf("\t-q <qid>                             : run in inline nfqueue mode\n");
+    printf("\t-q <qid[:qid]>                       : run in inline nfqueue mode (use colon to specify a range of queues)\n");
 #endif /* NFQ */
 #ifdef IPFW
     printf("\t-d <divert port>                     : run in inline ipfw divert mode\n");
@@ -1974,10 +1974,10 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             if (suri->run_mode == RUNMODE_UNKNOWN) {
                 suri->run_mode = RUNMODE_NFQ;
                 EngineModeSetIPS();
-                if (NFQRegisterQueue(optarg) == -1)
+                if (NFQParseAndRegisterQueues(optarg) == -1)
                     return TM_ECODE_FAILED;
             } else if (suri->run_mode == RUNMODE_NFQ) {
-                if (NFQRegisterQueue(optarg) == -1)
+                if (NFQParseAndRegisterQueues(optarg) == -1)
                     return TM_ECODE_FAILED;
             } else {
                 SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- added ability to specify Netfilter queue range with '-q' option (similar to iptables '--queue-balance' option)
- increase maximum number of queues from 16 to 65535
- NFQ context are created dynamically instead of on-stack arrays

This replaces #3552.
