### PR TITLE
Krb5: make TCP probing function less strict, messages can be fragmented

### DIFF
--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -443,7 +443,8 @@ pub extern "C" fn rs_krb5_probing_parser_tcp(_flow: *const Flow, input:*const li
     if slice.len() <= 14 { return unsafe{ALPROTO_FAILED}; }
     match be_u32(slice) {
         IResult::Done(rem, record_mark) => {
-            if record_mark != rem.len() as u32 { return unsafe{ALPROTO_FAILED}; }
+            // protocol implementations forbid very large requests
+            if record_mark > 16384 { return unsafe{ALPROTO_FAILED}; }
             return rs_krb5_probing_parser(_flow, rem.as_ptr(), rem.len() as u32);
         },
         IResult::Incomplete(_) => {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
not applicable

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2528

Describe changes:
- The TCP probing code for Kerberos was too strict and expected and complete message
- Remove this check, but add a basic test (messages > 16k will not be tested, they are not accepted by implementations)
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

