### PR TITLE
LogNotice available Hyperscan version and instruction sets.

### DIFF
--- a/src/util-mpm.c
+++ b/src/util-mpm.c
@@ -299,6 +299,17 @@ void MpmTableSetup(void)
             /* Fall back to best Aho-Corasick variant. */
             mpm_default_matcher = DEFAULT_MPM_AC;
         } else {
+            /* Hyperscan Information - AVX512 implies the use of AVX2 */
+            SCLogNotice("Hyperscan Version: %s", hs_version());
+            hs_platform_info_t plat;
+            hs_populate_platform(&plat);
+            if (HS_CPU_FEATURES_AVX512 & plat.cpu_features) {
+                SCLogNotice("AVX512 Instructions are available for MPM");
+            } else {
+                if (HS_CPU_FEATURES_AVX2 & plat.cpu_features) {
+                    SCLogNotice("AVX2 Instructions are available for MPM");
+                }
+            }
             MpmHSRegister();
         }
     #else

--- a/src/util-spm.c
+++ b/src/util-spm.c
@@ -101,6 +101,17 @@ default_matcher:
             /* Use Boyer-Moore as fallback. */
             return SPM_BM;
         } else {
+            /* Hyperscan Information - AVX512 implies the use of AVX2 */
+            SCLogNotice("Hyperscan Version: %s", hs_version());
+            hs_platform_info_t plat;
+            hs_populate_platform(&plat);
+            if (HS_CPU_FEATURES_AVX512 & plat.cpu_features) {
+                SCLogNotice("AVX512 Instructions are available for SPM");
+            } else {
+                if (HS_CPU_FEATURES_AVX2 & plat.cpu_features) {
+                    SCLogNotice("AVX2 Instructions are available for SPM");
+                }
+            }
             return SPM_HS;
         }
     #else


### PR DESCRIPTION
Feature #2746

- [ X ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ X ] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2746#change-10680

Describe changes:
- LogNotice available Hyperscan version and instruction sets.
- The wording is hedged because I do not know how to determine if HS was compiled to ignore available instructions or if it was targeted to another architecture.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

This is my first attempt at C of any kind and I will not be offended if this is rejected or ignored.