### PR TITLE
Issue #2751 , implement PktAcqBreakLoop handler in libpcap mode

### DIFF
--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -94,6 +94,7 @@ TmEcode ReceivePcapThreadInit(ThreadVars *, const void *, void **);
 void ReceivePcapThreadExitStats(ThreadVars *, void *);
 TmEcode ReceivePcapThreadDeinit(ThreadVars *, void *);
 TmEcode ReceivePcapLoop(ThreadVars *tv, void *data, void *slot);
+TmEcode ReceivePcapBreakLoop(ThreadVars *tv, void *data);
 
 TmEcode DecodePcapThreadInit(ThreadVars *, const void *, void **);
 TmEcode DecodePcapThreadDeinit(ThreadVars *tv, void *data);
@@ -113,7 +114,7 @@ void TmModuleReceivePcapRegister (void)
     tmm_modules[TMM_RECEIVEPCAP].ThreadInit = ReceivePcapThreadInit;
     tmm_modules[TMM_RECEIVEPCAP].Func = NULL;
     tmm_modules[TMM_RECEIVEPCAP].PktAcqLoop = ReceivePcapLoop;
-    tmm_modules[TMM_RECEIVEPCAP].PktAcqBreakLoop = NULL;
+    tmm_modules[TMM_RECEIVEPCAP].PktAcqBreakLoop = ReceivePcapBreakLoop;
     tmm_modules[TMM_RECEIVEPCAP].ThreadExitPrintStats = ReceivePcapThreadExitStats;
     tmm_modules[TMM_RECEIVEPCAP].ThreadDeinit = NULL;
     tmm_modules[TMM_RECEIVEPCAP].RegisterTests = NULL;
@@ -234,6 +235,21 @@ static void PcapCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
     }
 
     SCReturn;
+}
+
+/**
+ *  \brief PCAP Break Loop function
+ */
+TmEcode ReceivePcapBreakLoop(ThreadVars *tv, void *data)
+{
+	SCEnter();
+	PcapThreadVars *ptv = (PcapThreadVars *)data;
+	if (ptv->pcap_handle == NULL)
+	{
+		return TM_ECODE_FAILED;
+	}
+	pcap_breakloop(ptv->pcap_handle);
+	SCReturnInt(TM_ECODE_OK);
 }
 
 /**


### PR DESCRIPTION
Issue #2751, Engine unable to disable detect thread, Killing engine. (in libpcap mode)

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:https://redmine.openinfosecfoundation.org/issues/2751

Bug:
When I terminate suricata (libpcap mode, --pcap=iface ), if the packet capturing thread is busy (100% cpu), the main thread have to kill the capturing thread after timeout.
The main reason is that the PktAcqBreakLoop handler is set to NULL in the src/source-pcap.c:117.

Describe changes:
- In order to avoid terminating capturing thread forcefully, implement PktAcqBreakLoop handler to call pcap_breakloop internally

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
