### PR TITLE
Nfq queue range v5

### DIFF
--- a/src/source-nfq.h
+++ b/src/source-nfq.h
@@ -30,7 +30,8 @@
 #include <linux/netfilter.h>		/* for NF_ACCEPT */
 #include <libnetfilter_queue/libnetfilter_queue.h>
 
-#define NFQ_MAX_QUEUE 16
+// Netfilter's limit
+#define NFQ_MAX_QUEUE 65535
 
 /* idea: set the recv-thread id in the packet to
  * select an verdict-queue */

--- a/src/source-nfq.h
+++ b/src/source-nfq.h
@@ -89,7 +89,8 @@ typedef struct NFQGlobalVars_
 } NFQGlobalVars;
 
 void NFQInitConfig(char quiet);
-int NFQRegisterQueue(char *queue);
+int NFQRegisterQueue(const uint16_t number);
+int NFQParseAndRegisterQueues(const char *queues);
 int NFQGetQueueCount(void);
 void *NFQGetQueue(int number);
 int NFQGetQueueNum(int number);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -582,7 +582,7 @@ static void PrintUsage(const char *progname)
     printf("\t-F <bpf filter file>                 : bpf filter file\n");
     printf("\t-r <path>                            : run in pcap file/offline mode\n");
 #ifdef NFQ
-    printf("\t-q <qid>                             : run in inline nfqueue mode\n");
+    printf("\t-q <qid[:qid]>                       : run in inline nfqueue mode (use colon to specify a range of queues)\n");
 #endif /* NFQ */
 #ifdef IPFW
     printf("\t-d <divert port>                     : run in inline ipfw divert mode\n");
@@ -1974,10 +1974,10 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             if (suri->run_mode == RUNMODE_UNKNOWN) {
                 suri->run_mode = RUNMODE_NFQ;
                 EngineModeSetIPS();
-                if (NFQRegisterQueue(optarg) == -1)
+                if (NFQParseAndRegisterQueues(optarg) == -1)
                     return TM_ECODE_FAILED;
             } else if (suri->run_mode == RUNMODE_NFQ) {
-                if (NFQRegisterQueue(optarg) == -1)
+                if (NFQParseAndRegisterQueues(optarg) == -1)
                     return TM_ECODE_FAILED;
             } else {
                 SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:

- added ability to specify Netfilter queue range with '-q' option (similar to iptables '--queue-balance' option)
- increase maximum number of queues from 16 to 65535
- NFQ contexts are created dynamically instead of on-stack arrays

This replaces #3582.