### PR TITLE
nfqueue: fake packet on timeout (fixes nfqueue and delayed-detect)

### DIFF
--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -916,6 +916,9 @@ static void NFQRecvPkt(NFQQueueVars *t, NFQThreadVars *tv)
             /* no error on timeout */
             if (flag)
                 NFQVerdictCacheFlush(t);
+
+            /* inject a fake packet on timeout */
+            TmThreadsCaptureInjectPacket(tv->tv, tv->slot, NULL);
         } else {
 #ifdef COUNTERS
             NFQMutexLock(t);


### PR DESCRIPTION
On systems with small amount of traffic (or with no traffic at all) nfqueue with 'delayed-detect' enabled hanged in 'workers' mode.

Bug #2362.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- inject a fake packet if recv() times out