### PR TITLE
filestore v2: print sid in json output (Optimization #2530)

### DIFF
--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -264,6 +264,7 @@ static int DetectFilestoreMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx, 
      * matches. */
     if (file != NULL) {
         file_id = file->file_store_id;
+        file->sid = s->id;
     }
 
     det_ctx->filestore[det_ctx->filestore_cnt].file_id = file_id;

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -149,6 +149,9 @@ json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
     json_object_set_new(fjs, "filename", SCJsonString(s));
     if (s != NULL)
         SCFree(s);
+
+    json_object_set_new(fjs, "sid", json_integer(ff->sid));
+
 #ifdef HAVE_MAGIC
     if (ff->magic)
         json_object_set_new(fjs, "magic", json_string((char *)ff->magic));

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -453,6 +453,7 @@ static File *FileAlloc(const uint8_t *name, uint16_t name_len)
 
     new->name_len = name_len;
     memcpy(new->name, name, name_len);
+    new->sid = 0;
 
     return new;
 }

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -89,6 +89,7 @@ typedef struct File_ {
                                      *   flag is set */
     uint64_t content_stored;
     uint64_t size;
+    uint32_t sid; /* signature id of a rule that triggered the filestore event */
 } File;
 
 typedef struct FileContainer_ {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2530
Describe changes:
- print SID (signature id) of a triggering rule in json fileinfo file
- default sid = 0
- if more than one sid triggers for the same file only the first sid will be printed

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

