### PR TITLE
Add a definition for the number of actions

### DIFF
--- a/src/action-globals.h
+++ b/src/action-globals.h
@@ -24,13 +24,15 @@
 #ifndef __ACTION_GLOBALS_H__
 #define __ACTION_GLOBALS_H__
 
+#define NUMBER_OF_ACTIONS 4
+
 /* Changing them as flags, so later we can have alerts
  * and drop simultaneously */
-#define ACTION_ALERT        0x01
-#define ACTION_DROP         0x02
-#define ACTION_REJECT       0x04
-#define ACTION_REJECT_DST   0x08
-#define ACTION_REJECT_BOTH  0x10
-#define ACTION_PASS         0x20
+#define ACTION_ALERT        BIT_U8(0)
+#define ACTION_DROP         BIT_U8(1)
+#define ACTION_REJECT       BIT_U8(2)
+#define ACTION_REJECT_DST   BIT_U8(3)
+#define ACTION_REJECT_BOTH  BIT_U8(4)
+#define ACTION_PASS         BIT_U8(5)
 
 #endif /* __ACTION_GLOBALS_H__ */

--- a/src/detect-engine-sigorder.c
+++ b/src/detect-engine-sigorder.c
@@ -1599,7 +1599,7 @@ static int SCSigOrderingTest08(void)
 #ifdef HAVE_LIBNET11
     int result = 0;
     Signature *prevsig = NULL, *sig = NULL;
-    extern uint8_t action_order_sigs[4];
+    extern uint8_t action_order_sigs[NUMBER_OF_ACTIONS];
 
     /* Let's change the order. Default is pass, drop, reject, alert (pass has highest prio) */
     action_order_sigs[0] = ACTION_REJECT;
@@ -1726,7 +1726,7 @@ static int SCSigOrderingTest09(void)
 {
     int result = 0;
     Signature *prevsig = NULL, *sig = NULL;
-    extern uint8_t action_order_sigs[4];
+    extern uint8_t action_order_sigs[NUMBER_OF_ACTIONS];
 
     /* Let's change the order. Default is pass, drop, reject, alert (pass has highest prio) */
     action_order_sigs[0] = ACTION_DROP;

--- a/src/util-action.c
+++ b/src/util-action.c
@@ -37,7 +37,7 @@
 #include "util-debug.h"
 
 /* Default order: */
-uint8_t action_order_sigs[4] = {ACTION_PASS, ACTION_DROP, ACTION_REJECT, ACTION_ALERT};
+uint8_t action_order_sigs[NUMBER_OF_ACTIONS] = {ACTION_PASS, ACTION_DROP, ACTION_REJECT, ACTION_ALERT};
 /* This order can be changed from config */
 
 /**
@@ -59,7 +59,7 @@ uint8_t ActionOrderVal(uint8_t action)
         action = ACTION_REJECT;
     }
     uint8_t i = 0;
-    for (; i < 4; i++) {
+    for (; i < NUMBER_OF_ACTIONS; i++) {
         if (action_order_sigs[i] == action)
             return i;
     }
@@ -99,7 +99,7 @@ int ActionInitConfig()
 {
     uint8_t actions_used = 0;
     uint8_t action_flag = 0;
-    uint8_t actions_config[4] = {0, 0, 0, 0};
+    uint8_t actions_config[NUMBER_OF_ACTIONS] = {0, 0, 0, 0};
     int order = 0;
 
     ConfNode *action_order;
@@ -131,7 +131,7 @@ int ActionInitConfig()
                 goto error;
             }
 
-            if (order >= 4) {
+            if (order >= NUMBER_OF_ACTIONS) {
                 SCLogError(SC_ERR_ACTION_ORDER, "action-order, you have already specified all the "
                        "possible actions plus \"%s\". Please, use \"pass\","
                        "\"drop\",\"alert\",\"reject\". You have to specify"
@@ -143,7 +143,7 @@ int ActionInitConfig()
             actions_config[order++] = action_flag;
         }
     }
-    if (order < 4) {
+    if (order < NUMBER_OF_ACTIONS) {
         SCLogError(SC_ERR_ACTION_ORDER, "action-order, the config didn't specify all of the "
                "actions. Please, use \"pass\",\"drop\",\"alert\","
                "\"reject\". You have to specify all of them, without"
@@ -152,7 +152,7 @@ int ActionInitConfig()
     }
 
     /* Now, it's a valid config. Override the default preset */
-    for (order = 0; order < 4; order++) {
+    for (order = 0; order < NUMBER_OF_ACTIONS; order++) {
         action_order_sigs[order] = actions_config[order];
     }
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
Creates a definition to specify the number of actions. This is needed for my Xmas changes.

Until now, the number of actions (4) was hard-coded in multiple places of the code. This change fixes it.

It is now recommended to use the NUMBER_OF_ACTIONS definition anytime one need to use the number of actions.


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

