### PR TITLE
[WIP] Rust 2018 Transition

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -26,14 +26,22 @@ pub struct AppLayerGetTxIterTuple {
 }
 
 impl AppLayerGetTxIterTuple {
-    pub fn with_values(tx_ptr: *mut libc::c_void, tx_id: u64, has_next: bool) -> AppLayerGetTxIterTuple {
+    pub fn with_values(
+        tx_ptr: *mut libc::c_void,
+        tx_id: u64,
+        has_next: bool,
+    ) -> AppLayerGetTxIterTuple {
         AppLayerGetTxIterTuple {
-            tx_ptr: tx_ptr, tx_id: tx_id, has_next: has_next,
+            tx_ptr: tx_ptr,
+            tx_id: tx_id,
+            has_next: has_next,
         }
     }
     pub fn not_found() -> AppLayerGetTxIterTuple {
         AppLayerGetTxIterTuple {
-            tx_ptr: std::ptr::null_mut(), tx_id: 0, has_next: false,
+            tx_ptr: std::ptr::null_mut(),
+            tx_id: 0,
+            has_next: false,
         }
     }
 }
@@ -45,11 +53,8 @@ pub struct LoggerFlags {
 }
 
 impl LoggerFlags {
-
     pub fn new() -> LoggerFlags {
-        return LoggerFlags{
-            flags: 0,
-        }
+        return LoggerFlags { flags: 0 };
     }
 
     pub fn get(&self) -> u32 {
@@ -59,41 +64,41 @@ impl LoggerFlags {
     pub fn set(&mut self, bits: u32) {
         self.flags = bits;
     }
-
 }
 
 /// Export a function to get the DetectEngineState on a struct.
 #[macro_export]
-macro_rules!export_tx_get_detect_state {
-    ($name:ident, $type:ty) => (
+macro_rules! export_tx_get_detect_state {
+    ($name:ident, $type:ty) => {
         #[no_mangle]
-        pub extern "C" fn $name(tx: *mut libc::c_void)
-            -> *mut core::DetectEngineState
-        {
+        pub extern "C" fn $name(
+            tx: *mut libc::c_void,
+        ) -> *mut core::DetectEngineState {
             let tx = cast_pointer!(tx, $type);
             match tx.de_state {
                 Some(ds) => {
                     return ds;
-                },
+                }
                 None => {
                     return std::ptr::null_mut();
                 }
             }
         }
-    )
+    };
 }
 
 /// Export a function to set the DetectEngineState on a struct.
 #[macro_export]
-macro_rules!export_tx_set_detect_state {
-    ($name:ident, $type:ty) => (
+macro_rules! export_tx_set_detect_state {
+    ($name:ident, $type:ty) => {
         #[no_mangle]
-        pub extern "C" fn $name(tx: *mut libc::c_void,
-                de_state: &mut core::DetectEngineState) -> libc::c_int
-        {
+        pub extern "C" fn $name(
+            tx: *mut libc::c_void,
+            de_state: &mut core::DetectEngineState,
+        ) -> libc::c_int {
             let tx = cast_pointer!(tx, $type);
             tx.de_state = Some(de_state);
             0
         }
-    )
+    };
 }

--- a/rust/src/applayertemplate/logger.rs
+++ b/rust/src/applayertemplate/logger.rs
@@ -15,10 +15,10 @@
  * 02110-1301, USA.
  */
 
+use super::template::TemplateTransaction;
+use crate::json::*;
 use libc;
 use std;
-use crate::json::*;
-use super::template::TemplateTransaction;
 
 fn log_template(tx: &TemplateTransaction) -> Option<Json> {
     let js = Json::object();

--- a/rust/src/applayertemplate/logger.rs
+++ b/rust/src/applayertemplate/logger.rs
@@ -17,7 +17,7 @@
 
 use libc;
 use std;
-use json::*;
+use crate::json::*;
 use super::template::TemplateTransaction;
 
 fn log_template(tx: &TemplateTransaction) -> Option<Json> {

--- a/rust/src/applayertemplate/mod.rs
+++ b/rust/src/applayertemplate/mod.rs
@@ -15,8 +15,8 @@
  * 02110-1301, USA.
  */
 
-pub mod template;
 mod parser;
+pub mod template;
 /* TEMPLATE_START_REMOVE */
 pub mod logger;
 /* TEMPLATE_END_REMOVE */

--- a/rust/src/applayertemplate/parser.rs
+++ b/rust/src/applayertemplate/parser.rs
@@ -35,8 +35,8 @@ named!(pub parse_message<String>,
 #[cfg(test)]
 mod tests {
 
-    use nom::*;
     use super::*;
+    use nom::*;
 
     /// Simple test of some valid data.
     #[test]

--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -15,16 +15,16 @@
  * 02110-1301, USA.
  */
 
-use std;
-use crate::core::{self, ALPROTO_UNKNOWN, AppProto, Flow};
-use libc;
-use crate::log::*;
-use std::mem::transmute;
-use crate::applayer::{self, LoggerFlags};
-use crate::parser::*;
-use std::ffi::CString;
-use nom;
 use super::parser;
+use crate::applayer::{self, LoggerFlags};
+use crate::core::{self, AppProto, Flow, ALPROTO_UNKNOWN};
+use crate::log::*;
+use crate::parser::*;
+use libc;
+use nom;
+use std;
+use std::ffi::CString;
+use std::mem::transmute;
 
 static mut ALPROTO_TEMPLATE: AppProto = ALPROTO_UNKNOWN;
 
@@ -447,9 +447,7 @@ pub extern "C" fn rs_template_state_get_tx_iterator(
         Some((tx, out_tx_id, has_next)) => {
             let c_tx = unsafe { transmute(tx) };
             let ires = applayer::AppLayerGetTxIterTuple::with_values(
-                c_tx,
-                out_tx_id,
-                has_next,
+                c_tx, out_tx_id, has_next,
             );
             return ires;
         }
@@ -468,8 +466,7 @@ pub extern "C" fn rs_template_get_request_buffer(
     tx: *mut libc::c_void,
     buf: *mut *const libc::uint8_t,
     len: *mut libc::uint32_t,
-) -> libc::uint8_t
-{
+) -> libc::uint8_t {
     let tx = cast_pointer!(tx, TemplateTransaction);
     if let Some(ref request) = tx.request {
         if request.len() > 0 {
@@ -489,8 +486,7 @@ pub extern "C" fn rs_template_get_response_buffer(
     tx: *mut libc::c_void,
     buf: *mut *const libc::uint8_t,
     len: *mut libc::uint32_t,
-) -> libc::uint8_t
-{
+) -> libc::uint8_t {
     let tx = cast_pointer!(tx, TemplateTransaction);
     if let Some(ref response) = tx.response {
         if response.len() > 0 {
@@ -550,10 +546,8 @@ pub unsafe extern "C" fn rs_template_register_parser() {
     {
         let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
         ALPROTO_TEMPLATE = alproto;
-        if AppLayerParserConfParserEnabled(
-            ip_proto_str.as_ptr(),
-            parser.name,
-        ) != 0
+        if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name)
+            != 0
         {
             let _ = AppLayerRegisterParser(&parser, alproto);
         }

--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -16,12 +16,12 @@
  */
 
 use std;
-use core::{self, ALPROTO_UNKNOWN, AppProto, Flow};
+use crate::core::{self, ALPROTO_UNKNOWN, AppProto, Flow};
 use libc;
-use log::*;
+use crate::log::*;
 use std::mem::transmute;
-use applayer::{self, LoggerFlags};
-use parser::*;
+use crate::applayer::{self, LoggerFlags};
+use crate::parser::*;
 use std::ffi::CString;
 use nom;
 use super::parser;

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -22,7 +22,7 @@ use std::ffi::{CString, CStr};
 use std::ptr;
 use std::str;
 
-use log::*;
+use crate::log::*;
 
 extern {
     fn ConfGet(key: *const c_char, res: *mut *const c_char) -> i8;

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -19,7 +19,7 @@
 
 extern crate libc;
 
-use filecontainer::*;
+use crate::filecontainer::*;
 
 /// Opaque C types.
 pub enum Flow {}

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -28,30 +28,32 @@ pub enum AppLayerDecoderEvents {}
 
 // From app-layer-events.h
 pub type AppLayerEventType = libc::c_int;
-pub const APP_LAYER_EVENT_TYPE_TRANSACTION : i32 = 1;
-pub const APP_LAYER_EVENT_TYPE_PACKET      : i32 = 2;
+pub const APP_LAYER_EVENT_TYPE_TRANSACTION: i32 = 1;
+pub const APP_LAYER_EVENT_TYPE_PACKET: i32 = 2;
 
 // From stream.h.
-pub const STREAM_START:    u8 = 0x01;
-pub const STREAM_EOF:      u8 = 0x02;
+pub const STREAM_START: u8 = 0x01;
+pub const STREAM_EOF: u8 = 0x02;
 pub const STREAM_TOSERVER: u8 = 0x04;
 pub const STREAM_TOCLIENT: u8 = 0x08;
-pub const STREAM_GAP:      u8 = 0x10;
-pub const STREAM_DEPTH:    u8 = 0x20;
-pub const STREAM_MIDSTREAM:u8 = 0x40;
+pub const STREAM_GAP: u8 = 0x10;
+pub const STREAM_DEPTH: u8 = 0x20;
+pub const STREAM_MIDSTREAM: u8 = 0x40;
 
 // Application layer protocol identifiers (app-layer-protos.h)
 pub type AppProto = libc::c_int;
 
-pub const ALPROTO_UNKNOWN : AppProto = 0;
-pub static mut ALPROTO_FAILED : AppProto = 0; // updated during init
+pub const ALPROTO_UNKNOWN: AppProto = 0;
+pub static mut ALPROTO_FAILED: AppProto = 0; // updated during init
 
-macro_rules!BIT_U64 {
-    ($x:expr) => (1 << $x);
+macro_rules! BIT_U64 {
+    ($x:expr) => {
+        1 << $x
+    };
 }
 
 // Defined in app-layer-protos.h
-extern {
+extern "C" {
     pub fn StringToAppProto(proto_name: *const u8) -> AppProto;
 }
 
@@ -60,54 +62,61 @@ extern {
 //
 
 #[allow(non_snake_case)]
-pub type SCLogMessageFunc =
-    extern "C" fn(level: libc::c_int,
-                  filename: *const libc::c_char,
-                  line: libc::c_uint,
-                  function: *const libc::c_char,
-                  code: libc::c_int,
-                  message: *const libc::c_char) -> libc::c_int;
+pub type SCLogMessageFunc = extern "C" fn(
+    level: libc::c_int,
+    filename: *const libc::c_char,
+    line: libc::c_uint,
+    function: *const libc::c_char,
+    code: libc::c_int,
+    message: *const libc::c_char,
+) -> libc::c_int;
 
 pub type DetectEngineStateFreeFunc =
     extern "C" fn(state: *mut DetectEngineState);
 
-pub type AppLayerDecoderEventsSetEventRawFunc =
-    extern "C" fn (events: *mut *mut AppLayerDecoderEvents,
-                   event: libc::uint8_t);
+pub type AppLayerDecoderEventsSetEventRawFunc = extern "C" fn(
+    events: *mut *mut AppLayerDecoderEvents,
+    event: libc::uint8_t,
+);
 
 pub type AppLayerDecoderEventsFreeEventsFunc =
-    extern "C" fn (events: *mut *mut AppLayerDecoderEvents);
+    extern "C" fn(events: *mut *mut AppLayerDecoderEvents);
 
 pub struct SuricataStreamingBufferConfig;
 
-pub type SCFileOpenFileWithId = extern "C" fn (
-        file_container: &FileContainer,
-        sbcfg: &SuricataStreamingBufferConfig,
-        track_id: u32,
-        name: *const u8, name_len: u16,
-        data: *const u8, data_len: u32,
-        flags: u16) -> i32;
-pub type SCFileCloseFileById = extern "C" fn (
-        file_container: &FileContainer,
-        track_id: u32,
-        data: *const u8, data_len: u32,
-        flags: u16) -> i32;
-pub type SCFileAppendDataById = extern "C" fn (
-        file_container: &FileContainer,
-        track_id: u32,
-        data: *const u8, data_len: u32) -> i32;
-pub type SCFileAppendGAPById = extern "C" fn (
-        file_container: &FileContainer,
-        track_id: u32,
-        data: *const u8, data_len: u32) -> i32;
-pub type SCFilePrune = extern "C" fn (
-        file_container: &FileContainer);
-pub type SCFileContainerRecycle = extern "C" fn (
-        file_container: &FileContainer);
+pub type SCFileOpenFileWithId = extern "C" fn(
+    file_container: &FileContainer,
+    sbcfg: &SuricataStreamingBufferConfig,
+    track_id: u32,
+    name: *const u8,
+    name_len: u16,
+    data: *const u8,
+    data_len: u32,
+    flags: u16,
+) -> i32;
+pub type SCFileCloseFileById = extern "C" fn(
+    file_container: &FileContainer,
+    track_id: u32,
+    data: *const u8,
+    data_len: u32,
+    flags: u16,
+) -> i32;
+pub type SCFileAppendDataById = extern "C" fn(
+    file_container: &FileContainer,
+    track_id: u32,
+    data: *const u8,
+    data_len: u32,
+) -> i32;
+pub type SCFileAppendGAPById = extern "C" fn(
+    file_container: &FileContainer,
+    track_id: u32,
+    data: *const u8,
+    data_len: u32,
+) -> i32;
+pub type SCFilePrune = extern "C" fn(file_container: &FileContainer);
+pub type SCFileContainerRecycle = extern "C" fn(file_container: &FileContainer);
 
-pub type SCFileSetTx = extern "C" fn (
-        file: &FileContainer,
-        tx_id: u64);
+pub type SCFileSetTx = extern "C" fn(file: &FileContainer, tx_id: u64);
 
 // A Suricata context that is passed in from C. This is alternative to
 // using functions from Suricata directly, so they can be wrapped so
@@ -142,8 +151,7 @@ pub struct SuricataFileContext {
 pub static mut SC: Option<&'static SuricataContext> = None;
 
 #[no_mangle]
-pub extern "C" fn rs_init(context: &'static mut SuricataContext)
-{
+pub extern "C" fn rs_init(context: &'static mut SuricataContext) {
     unsafe {
         SC = Some(context);
         ALPROTO_FAILED = StringToAppProto("failed\0".as_ptr());
@@ -151,8 +159,7 @@ pub extern "C" fn rs_init(context: &'static mut SuricataContext)
 }
 
 /// DetectEngineStateFree wrapper.
-pub fn sc_detect_engine_state_free(state: *mut DetectEngineState)
-{
+pub fn sc_detect_engine_state_free(state: *mut DetectEngineState) {
     unsafe {
         if let Some(c) = SC {
             (c.DetectEngineStateFree)(state);
@@ -162,8 +169,9 @@ pub fn sc_detect_engine_state_free(state: *mut DetectEngineState)
 
 /// AppLayerDecoderEventsSetEventRaw wrapper.
 pub fn sc_app_layer_decoder_events_set_event_raw(
-    events: *mut *mut AppLayerDecoderEvents, event: libc::uint8_t)
-{
+    events: *mut *mut AppLayerDecoderEvents,
+    event: libc::uint8_t,
+) {
     unsafe {
         if let Some(c) = SC {
             (c.AppLayerDecoderEventsSetEventRaw)(events, event);
@@ -173,8 +181,8 @@ pub fn sc_app_layer_decoder_events_set_event_raw(
 
 /// AppLayerDecoderEventsFreeEvents wrapper.
 pub fn sc_app_layer_decoder_events_free_events(
-    events: *mut *mut AppLayerDecoderEvents)
-{
+    events: *mut *mut AppLayerDecoderEvents,
+) {
     unsafe {
         if let Some(c) = SC {
             (c.AppLayerDecoderEventsFreeEvents)(events);

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -15,15 +15,15 @@
  * 02110-1301, USA.
  */
 
-use applayer;
-use core;
-use core::{ALPROTO_UNKNOWN, AppProto, Flow};
-use core::{sc_detect_engine_state_free, sc_app_layer_decoder_events_free_events};
-use dhcp::parser::*;
+use crate::applayer;
+use crate::core;
+use crate::core::{ALPROTO_UNKNOWN, AppProto, Flow};
+use crate::core::{sc_detect_engine_state_free, sc_app_layer_decoder_events_free_events};
+use crate::dhcp::parser::*;
 use libc;
-use log::*;
+use crate::log::*;
 use nom;
-use parser::*;
+use crate::parser::*;
 use std;
 use std::ffi::{CStr,CString};
 use std::mem::transmute;

--- a/rust/src/dhcp/logger.rs
+++ b/rust/src/dhcp/logger.rs
@@ -20,11 +20,11 @@ extern crate libc;
 use std;
 use std::os::raw::c_void;
 
-use dhcp::dhcp::*;
-use dhcp::parser::{DHCPOptionWrapper,DHCPOptGeneric};
-use dns::log::dns_print_addr;
-use json::*;
-use conf::ConfNode;
+use crate::dhcp::dhcp::*;
+use crate::dhcp::parser::{DHCPOptionWrapper,DHCPOptGeneric};
+use crate::dns::log::dns_print_addr;
+use crate::json::*;
+use crate::conf::ConfNode;
 
 pub struct DHCPLogger {
     extended: bool,

--- a/rust/src/dhcp/logger.rs
+++ b/rust/src/dhcp/logger.rs
@@ -20,20 +20,19 @@ extern crate libc;
 use std;
 use std::os::raw::c_void;
 
+use crate::conf::ConfNode;
 use crate::dhcp::dhcp::*;
-use crate::dhcp::parser::{DHCPOptionWrapper,DHCPOptGeneric};
+use crate::dhcp::parser::{DHCPOptGeneric, DHCPOptionWrapper};
 use crate::dns::log::dns_print_addr;
 use crate::json::*;
-use crate::conf::ConfNode;
 
 pub struct DHCPLogger {
     extended: bool,
 }
 
 impl DHCPLogger {
-    
     pub fn new(conf: ConfNode) -> DHCPLogger {
-        return DHCPLogger{
+        return DHCPLogger {
             extended: conf.get_child_bool("extended"),
         };
     }
@@ -43,16 +42,14 @@ impl DHCPLogger {
         for option in options {
             let code = option.code;
             match &option.option {
-                &DHCPOptionWrapper::Generic(ref option) => {
-                    match code {
-                        DHCP_OPT_TYPE => {
-                            if option.data.len() > 0 {
-                                return Some(option.data[0]);
-                            }
+                &DHCPOptionWrapper::Generic(ref option) => match code {
+                    DHCP_OPT_TYPE => {
+                        if option.data.len() > 0 {
+                            return Some(option.data[0]);
                         }
-                        _ => {}
                     }
-                }
+                    _ => {}
+                },
                 _ => {}
             }
         }
@@ -62,14 +59,12 @@ impl DHCPLogger {
     fn do_log(&self, tx: &DHCPTransaction) -> bool {
         if !self.extended {
             match self.get_type(tx) {
-                Some(t) => {
-                    match t {
-                        DHCP_TYPE_ACK => {
-                            return true;
-                        }
-                        _ => {}
+                Some(t) => match t {
+                    DHCP_TYPE_ACK => {
+                        return true;
                     }
-                }
+                    _ => {}
+                },
                 _ => {}
             }
             return false;
@@ -81,7 +76,7 @@ impl DHCPLogger {
         if !self.do_log(tx) {
             return None;
         }
-        
+
         let header = &tx.message.header;
         let options = &tx.message.options;
         let js = Json::object();
@@ -97,95 +92,105 @@ impl DHCPLogger {
                 js.set_string("type", "<unknown>");
             }
         }
-        
+
         js.set_integer("id", header.txid as u64);
-        js.set_string("client_mac",
-                      &format_addr_hex(&header.clienthw.to_vec()));
+        js.set_string(
+            "client_mac",
+            &format_addr_hex(&header.clienthw.to_vec()),
+        );
         js.set_string("assigned_ip", &dns_print_addr(&header.yourip));
 
         if self.extended {
             js.set_string("client_ip", &dns_print_addr(&header.clientip));
             if header.opcode == BOOTP_REPLY {
-                js.set_string("relay_ip",
-                              &dns_print_addr(&header.giaddr));
-                js.set_string("next_server_ip",
-                              &dns_print_addr(&header.serverip));
+                js.set_string("relay_ip", &dns_print_addr(&header.giaddr));
+                js.set_string(
+                    "next_server_ip",
+                    &dns_print_addr(&header.serverip),
+                );
             }
         }
-        
+
         for option in options {
             let code = option.code;
             match &option.option {
                 &DHCPOptionWrapper::ClientId(ref clientid) => {
-                    js.set_string("client_id",
-                                  &format_addr_hex(&clientid.data));
+                    js.set_string(
+                        "client_id",
+                        &format_addr_hex(&clientid.data),
+                    );
                 }
-                &DHCPOptionWrapper::TimeValue(ref time_value) => {
-                    match code {
-                        DHCP_OPT_ADDRESS_TIME => {
-                            if self.extended {
-                                js.set_integer("lease_time",
-                                               time_value.seconds as u64);
-                            }
+                &DHCPOptionWrapper::TimeValue(ref time_value) => match code {
+                    DHCP_OPT_ADDRESS_TIME => {
+                        if self.extended {
+                            js.set_integer(
+                                "lease_time",
+                                time_value.seconds as u64,
+                            );
                         }
-                        DHCP_OPT_REBINDING_TIME => {
-                            if self.extended {
-                                js.set_integer("rebinding_time",
-                                               time_value.seconds as u64);
-                            }
-                        }
-                        DHCP_OPT_RENEWAL_TIME => {
-                            js.set_integer("renewal_time",
-                                           time_value.seconds as u64);
-                        }
-                        _ => {}
                     }
-                }
-                &DHCPOptionWrapper::Generic(ref option) => {
-                    match code {
-                        DHCP_OPT_SUBNET_MASK => {
-                            if self.extended {
-                                js.set_string("subnet_mask",
-                                              &dns_print_addr(&option.data));
-                            }
+                    DHCP_OPT_REBINDING_TIME => {
+                        if self.extended {
+                            js.set_integer(
+                                "rebinding_time",
+                                time_value.seconds as u64,
+                            );
                         }
-                        DHCP_OPT_HOSTNAME => {
-                            if option.data.len() > 0 {
-                                js.set_string_from_bytes("hostname",
-                                                         &option.data);
-                            }
-                        }
-                        DHCP_OPT_TYPE => {
-                            self.log_opt_type(&js, option);
-                        }
-                        DHCP_OPT_REQUESTED_IP => {
-                            if self.extended {
-                                js.set_string("requested_ip",
-                                              &dns_print_addr(&option.data));
-                            }
-                        }
-                        DHCP_OPT_PARAMETER_LIST => {
-                            if self.extended {
-                                self.log_opt_parameters(&js, option);
-                            }
-                        }
-                        DHCP_OPT_DNS_SERVER => {
-                            if self.extended {
-                                self.log_opt_dns_server(&js, option);
-                            }
-                        }
-                        DHCP_OPT_ROUTERS => {
-                            if self.extended {
-                                self.log_opt_routers(&js, option);
-                            }
-                        }
-                        _ => {}
                     }
-                }
+                    DHCP_OPT_RENEWAL_TIME => {
+                        js.set_integer(
+                            "renewal_time",
+                            time_value.seconds as u64,
+                        );
+                    }
+                    _ => {}
+                },
+                &DHCPOptionWrapper::Generic(ref option) => match code {
+                    DHCP_OPT_SUBNET_MASK => {
+                        if self.extended {
+                            js.set_string(
+                                "subnet_mask",
+                                &dns_print_addr(&option.data),
+                            );
+                        }
+                    }
+                    DHCP_OPT_HOSTNAME => {
+                        if option.data.len() > 0 {
+                            js.set_string_from_bytes("hostname", &option.data);
+                        }
+                    }
+                    DHCP_OPT_TYPE => {
+                        self.log_opt_type(&js, option);
+                    }
+                    DHCP_OPT_REQUESTED_IP => {
+                        if self.extended {
+                            js.set_string(
+                                "requested_ip",
+                                &dns_print_addr(&option.data),
+                            );
+                        }
+                    }
+                    DHCP_OPT_PARAMETER_LIST => {
+                        if self.extended {
+                            self.log_opt_parameters(&js, option);
+                        }
+                    }
+                    DHCP_OPT_DNS_SERVER => {
+                        if self.extended {
+                            self.log_opt_dns_server(&js, option);
+                        }
+                    }
+                    DHCP_OPT_ROUTERS => {
+                        if self.extended {
+                            self.log_opt_routers(&js, option);
+                        }
+                    }
+                    _ => {}
+                },
                 _ => {}
             }
         }
-        
+
         return Some(js);
     }
 
@@ -200,7 +205,7 @@ impl DHCPLogger {
                 DHCP_TYPE_NAK => "nak",
                 DHCP_TYPE_RELEASE => "release",
                 DHCP_TYPE_INFORM => "inform",
-                _ => "unknown"
+                _ => "unknown",
             };
             js.set_string("dhcp_type", dhcp_type);
         }
@@ -218,7 +223,7 @@ impl DHCPLogger {
                 DHCP_PARAM_NTP_SERVER => "ntp_server",
                 DHCP_PARAM_TFTP_SERVER_NAME => "tftp_server_name",
                 DHCP_PARAM_TFTP_SERVER_IP => "tftp_server_ip",
-                _ => ""
+                _ => "",
             };
             if param.len() > 0 {
                 params.array_append_string(param);
@@ -226,31 +231,31 @@ impl DHCPLogger {
         }
         js.set("params", params);
     }
-    
+
     fn log_opt_dns_server(&self, js: &Json, option: &DHCPOptGeneric) {
         let servers = Json::array();
         for i in 0..(option.data.len() / 4) {
             servers.array_append_string(&dns_print_addr(
-                &option.data[(i * 4)..(i * 4) + 4].to_vec()))
+                &option.data[(i * 4)..(i * 4) + 4].to_vec(),
+            ))
         }
         js.set("dns_servers", servers);
     }
-    
+
     fn log_opt_routers(&self, js: &Json, option: &DHCPOptGeneric) {
         let routers = Json::array();
         for i in 0..(option.data.len() / 4) {
             routers.array_append_string(&dns_print_addr(
-                &option.data[(i * 4)..(i * 4) + 4].to_vec()))
+                &option.data[(i * 4)..(i * 4) + 4].to_vec(),
+            ))
         }
         js.set("routers", routers);
     }
-
 }
 
 fn format_addr_hex(input: &Vec<u8>) -> String {
-    let parts: Vec<String> = input.iter()
-        .map(|b| format!("{:02x}", b))
-        .collect();
+    let parts: Vec<String> =
+        input.iter().map(|b| format!("{:02x}", b)).collect();
     return parts.join(":");
 }
 
@@ -258,17 +263,19 @@ fn format_addr_hex(input: &Vec<u8>) -> String {
 pub extern "C" fn rs_dhcp_logger_new(conf: *const c_void) -> *mut libc::c_void {
     let conf = ConfNode::wrap(conf);
     let boxed = Box::new(DHCPLogger::new(conf));
-    return unsafe{std::mem::transmute(boxed)};
+    return unsafe { std::mem::transmute(boxed) };
 }
 
 #[no_mangle]
 pub extern "C" fn rs_dhcp_logger_free(logger: *mut libc::c_void) {
-    let _: Box<DHCPLogger> = unsafe{std::mem::transmute(logger)};
+    let _: Box<DHCPLogger> = unsafe { std::mem::transmute(logger) };
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dhcp_logger_log(logger: *mut libc::c_void,
-                                     tx: *mut libc::c_void) -> *mut JsonT {
+pub extern "C" fn rs_dhcp_logger_log(
+    logger: *mut libc::c_void,
+    tx: *mut libc::c_void,
+) -> *mut JsonT {
     let logger = cast_pointer!(logger, DHCPLogger);
     let tx = cast_pointer!(tx, DHCPTransaction);
     match logger.log(tx) {

--- a/rust/src/dhcp/mod.rs
+++ b/rust/src/dhcp/mod.rs
@@ -16,5 +16,5 @@
  */
 
 pub mod dhcp;
-pub mod parser;
 pub mod logger;
+pub mod parser;

--- a/rust/src/dhcp/parser.rs
+++ b/rust/src/dhcp/parser.rs
@@ -123,7 +123,7 @@ named!(pub parse_clientid_option<DHCPOption>,
            code: be_u8 >>
            len: be_u8 >>
            htype: be_u8 >>
-           data: take!(len - 1) >>    
+           data: take!(len - 1) >>
                (
                    DHCPOption{
                        code: code,
@@ -262,8 +262,10 @@ mod tests {
                 assert_eq!(header.yourip, &[0, 0, 0, 0]);
                 assert_eq!(header.serverip, &[0, 0, 0, 0]);
                 assert_eq!(header.giaddr, &[0, 0, 0, 0]);
-                assert_eq!(&header.clienthw[..(header.hlen as usize)],
-                           &[0x00, 0x0b, 0x82, 0x01, 0xfc, 0x42]);
+                assert_eq!(
+                    &header.clienthw[..(header.hlen as usize)],
+                    &[0x00, 0x0b, 0x82, 0x01, 0xfc, 0x42]
+                );
                 assert!(header.servername.iter().all(|&x| x == 0));
                 assert!(header.bootfilename.iter().all(|&x| x == 0));
                 assert_eq!(header.magic, &[0x63, 0x82, 0x53, 0x63]);

--- a/rust/src/dhcp/parser.rs
+++ b/rust/src/dhcp/parser.rs
@@ -17,7 +17,7 @@
 
 use std::cmp::min;
 
-use dhcp::dhcp::*;
+use crate::dhcp::dhcp::*;
 use nom::*;
 
 pub struct DHCPMessage {
@@ -240,8 +240,8 @@ pub fn dhcp_parse(input: &[u8]) -> IResult<&[u8], DHCPMessage> {
 
 #[cfg(test)]
 mod tests {
-    use dhcp::dhcp::*;
-    use dhcp::parser::*;
+    use crate::dhcp::dhcp::*;
+    use crate::dhcp::parser::*;
 
     #[test]
     fn test_parse_discover() {

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -21,94 +21,93 @@ extern crate nom;
 use std;
 use std::mem::transmute;
 
-use crate::log::*;
 use crate::applayer::LoggerFlags;
 use crate::core;
 use crate::dns::parser;
+use crate::log::*;
 
 /// DNS record types.
-pub const DNS_RECORD_TYPE_A           : u16 = 1;
-pub const DNS_RECORD_TYPE_NS          : u16 = 2;
-pub const DNS_RECORD_TYPE_MD          : u16 = 3;   // Obsolete
-pub const DNS_RECORD_TYPE_MF          : u16 = 4;   // Obsolete
-pub const DNS_RECORD_TYPE_CNAME       : u16 = 5;
-pub const DNS_RECORD_TYPE_SOA         : u16 = 6;
-pub const DNS_RECORD_TYPE_MB          : u16 = 7;   // Experimental
-pub const DNS_RECORD_TYPE_MG          : u16 = 8;   // Experimental
-pub const DNS_RECORD_TYPE_MR          : u16 = 9;   // Experimental
-pub const DNS_RECORD_TYPE_NULL        : u16 = 10;  // Experimental
-pub const DNS_RECORD_TYPE_WKS         : u16 = 11;
-pub const DNS_RECORD_TYPE_PTR         : u16 = 12;
-pub const DNS_RECORD_TYPE_HINFO       : u16 = 13;
-pub const DNS_RECORD_TYPE_MINFO       : u16 = 14;
-pub const DNS_RECORD_TYPE_MX          : u16 = 15;
-pub const DNS_RECORD_TYPE_TXT         : u16 = 16;
-pub const DNS_RECORD_TYPE_RP          : u16 = 17;
-pub const DNS_RECORD_TYPE_AFSDB       : u16 = 18;
-pub const DNS_RECORD_TYPE_X25         : u16 = 19;
-pub const DNS_RECORD_TYPE_ISDN        : u16 = 20;
-pub const DNS_RECORD_TYPE_RT          : u16 = 21;
-pub const DNS_RECORD_TYPE_NSAP        : u16 = 22;
-pub const DNS_RECORD_TYPE_NSAPPTR     : u16 = 23;
-pub const DNS_RECORD_TYPE_SIG         : u16 = 24;
-pub const DNS_RECORD_TYPE_KEY         : u16 = 25;
-pub const DNS_RECORD_TYPE_PX          : u16 = 26;
-pub const DNS_RECORD_TYPE_GPOS        : u16 = 27;
-pub const DNS_RECORD_TYPE_AAAA        : u16 = 28;
-pub const DNS_RECORD_TYPE_LOC         : u16 = 29;
-pub const DNS_RECORD_TYPE_NXT         : u16 = 30;  // Obsolete
-pub const DNS_RECORD_TYPE_SRV         : u16 = 33;
-pub const DNS_RECORD_TYPE_ATMA        : u16 = 34;
-pub const DNS_RECORD_TYPE_NAPTR       : u16 = 35;
-pub const DNS_RECORD_TYPE_KX          : u16 = 36;
-pub const DNS_RECORD_TYPE_CERT        : u16 = 37;
-pub const DNS_RECORD_TYPE_A6          : u16 = 38;  // Obsolete
-pub const DNS_RECORD_TYPE_DNAME       : u16 = 39;
-pub const DNS_RECORD_TYPE_OPT         : u16 = 41;
-pub const DNS_RECORD_TYPE_APL         : u16 = 42;
-pub const DNS_RECORD_TYPE_DS          : u16 = 43;
-pub const DNS_RECORD_TYPE_SSHFP       : u16 = 44;
-pub const DNS_RECORD_TYPE_IPSECKEY    : u16 = 45;
-pub const DNS_RECORD_TYPE_RRSIG       : u16 = 46;
-pub const DNS_RECORD_TYPE_NSEC        : u16 = 47;
-pub const DNS_RECORD_TYPE_DNSKEY      : u16 = 48;
-pub const DNS_RECORD_TYPE_DHCID       : u16 = 49;
-pub const DNS_RECORD_TYPE_NSEC3       : u16 = 50;
-pub const DNS_RECORD_TYPE_NSEC3PARAM  : u16 = 51;
-pub const DNS_RECORD_TYPE_TLSA        : u16 = 52;
-pub const DNS_RECORD_TYPE_HIP         : u16 = 55;
-pub const DNS_RECORD_TYPE_CDS         : u16 = 59;
-pub const DNS_RECORD_TYPE_CDNSKEY     : u16 = 60;
-pub const DNS_RECORD_TYPE_SPF         : u16 = 99;  // Obsolete
-pub const DNS_RECORD_TYPE_TKEY        : u16 = 249;
-pub const DNS_RECORD_TYPE_TSIG        : u16 = 250;
-pub const DNS_RECORD_TYPE_MAILA       : u16 = 254; // Obsolete
-pub const DNS_RECORD_TYPE_ANY         : u16 = 255;
-pub const DNS_RECORD_TYPE_URI         : u16 = 256;
+pub const DNS_RECORD_TYPE_A: u16 = 1;
+pub const DNS_RECORD_TYPE_NS: u16 = 2;
+pub const DNS_RECORD_TYPE_MD: u16 = 3; // Obsolete
+pub const DNS_RECORD_TYPE_MF: u16 = 4; // Obsolete
+pub const DNS_RECORD_TYPE_CNAME: u16 = 5;
+pub const DNS_RECORD_TYPE_SOA: u16 = 6;
+pub const DNS_RECORD_TYPE_MB: u16 = 7; // Experimental
+pub const DNS_RECORD_TYPE_MG: u16 = 8; // Experimental
+pub const DNS_RECORD_TYPE_MR: u16 = 9; // Experimental
+pub const DNS_RECORD_TYPE_NULL: u16 = 10; // Experimental
+pub const DNS_RECORD_TYPE_WKS: u16 = 11;
+pub const DNS_RECORD_TYPE_PTR: u16 = 12;
+pub const DNS_RECORD_TYPE_HINFO: u16 = 13;
+pub const DNS_RECORD_TYPE_MINFO: u16 = 14;
+pub const DNS_RECORD_TYPE_MX: u16 = 15;
+pub const DNS_RECORD_TYPE_TXT: u16 = 16;
+pub const DNS_RECORD_TYPE_RP: u16 = 17;
+pub const DNS_RECORD_TYPE_AFSDB: u16 = 18;
+pub const DNS_RECORD_TYPE_X25: u16 = 19;
+pub const DNS_RECORD_TYPE_ISDN: u16 = 20;
+pub const DNS_RECORD_TYPE_RT: u16 = 21;
+pub const DNS_RECORD_TYPE_NSAP: u16 = 22;
+pub const DNS_RECORD_TYPE_NSAPPTR: u16 = 23;
+pub const DNS_RECORD_TYPE_SIG: u16 = 24;
+pub const DNS_RECORD_TYPE_KEY: u16 = 25;
+pub const DNS_RECORD_TYPE_PX: u16 = 26;
+pub const DNS_RECORD_TYPE_GPOS: u16 = 27;
+pub const DNS_RECORD_TYPE_AAAA: u16 = 28;
+pub const DNS_RECORD_TYPE_LOC: u16 = 29;
+pub const DNS_RECORD_TYPE_NXT: u16 = 30; // Obsolete
+pub const DNS_RECORD_TYPE_SRV: u16 = 33;
+pub const DNS_RECORD_TYPE_ATMA: u16 = 34;
+pub const DNS_RECORD_TYPE_NAPTR: u16 = 35;
+pub const DNS_RECORD_TYPE_KX: u16 = 36;
+pub const DNS_RECORD_TYPE_CERT: u16 = 37;
+pub const DNS_RECORD_TYPE_A6: u16 = 38; // Obsolete
+pub const DNS_RECORD_TYPE_DNAME: u16 = 39;
+pub const DNS_RECORD_TYPE_OPT: u16 = 41;
+pub const DNS_RECORD_TYPE_APL: u16 = 42;
+pub const DNS_RECORD_TYPE_DS: u16 = 43;
+pub const DNS_RECORD_TYPE_SSHFP: u16 = 44;
+pub const DNS_RECORD_TYPE_IPSECKEY: u16 = 45;
+pub const DNS_RECORD_TYPE_RRSIG: u16 = 46;
+pub const DNS_RECORD_TYPE_NSEC: u16 = 47;
+pub const DNS_RECORD_TYPE_DNSKEY: u16 = 48;
+pub const DNS_RECORD_TYPE_DHCID: u16 = 49;
+pub const DNS_RECORD_TYPE_NSEC3: u16 = 50;
+pub const DNS_RECORD_TYPE_NSEC3PARAM: u16 = 51;
+pub const DNS_RECORD_TYPE_TLSA: u16 = 52;
+pub const DNS_RECORD_TYPE_HIP: u16 = 55;
+pub const DNS_RECORD_TYPE_CDS: u16 = 59;
+pub const DNS_RECORD_TYPE_CDNSKEY: u16 = 60;
+pub const DNS_RECORD_TYPE_SPF: u16 = 99; // Obsolete
+pub const DNS_RECORD_TYPE_TKEY: u16 = 249;
+pub const DNS_RECORD_TYPE_TSIG: u16 = 250;
+pub const DNS_RECORD_TYPE_MAILA: u16 = 254; // Obsolete
+pub const DNS_RECORD_TYPE_ANY: u16 = 255;
+pub const DNS_RECORD_TYPE_URI: u16 = 256;
 
 /// DNS error codes.
-pub const DNS_RCODE_NOERROR:  u16 = 0;
-pub const DNS_RCODE_FORMERR:  u16 = 1;
+pub const DNS_RCODE_NOERROR: u16 = 0;
+pub const DNS_RCODE_FORMERR: u16 = 1;
 pub const DNS_RCODE_SERVFAIL: u16 = 2;
 pub const DNS_RCODE_NXDOMAIN: u16 = 3;
-pub const DNS_RCODE_NOTIMP:   u16 = 4;
-pub const DNS_RCODE_REFUSED:  u16 = 5;
+pub const DNS_RCODE_NOTIMP: u16 = 4;
+pub const DNS_RCODE_REFUSED: u16 = 5;
 pub const DNS_RCODE_YXDOMAIN: u16 = 6;
-pub const DNS_RCODE_YXRRSET:  u16 = 7;
-pub const DNS_RCODE_NXRRSET:  u16 = 8;
-pub const DNS_RCODE_NOTAUTH:  u16 = 9;
-pub const DNS_RCODE_NOTZONE:  u16 = 10;
+pub const DNS_RCODE_YXRRSET: u16 = 7;
+pub const DNS_RCODE_NXRRSET: u16 = 8;
+pub const DNS_RCODE_NOTAUTH: u16 = 9;
+pub const DNS_RCODE_NOTZONE: u16 = 10;
 // Support for OPT RR from RFC6891 will be needed to
 // parse RCODE values over 15
-pub const DNS_RCODE_BADVERS:  u16 = 16;
-pub const DNS_RCODE_BADSIG:   u16 = 16;
-pub const DNS_RCODE_BADKEY:   u16 = 17;
-pub const DNS_RCODE_BADTIME:  u16 = 18;
-pub const DNS_RCODE_BADMODE:  u16 = 19;
-pub const DNS_RCODE_BADNAME:  u16 = 20;
-pub const DNS_RCODE_BADALG:   u16 = 21;
+pub const DNS_RCODE_BADVERS: u16 = 16;
+pub const DNS_RCODE_BADSIG: u16 = 16;
+pub const DNS_RCODE_BADKEY: u16 = 17;
+pub const DNS_RCODE_BADTIME: u16 = 18;
+pub const DNS_RCODE_BADMODE: u16 = 19;
+pub const DNS_RCODE_BADNAME: u16 = 20;
+pub const DNS_RCODE_BADALG: u16 = 21;
 pub const DNS_RCODE_BADTRUNC: u16 = 22;
-
 
 /// The maximum number of transactions to keep in the queue pending
 /// processing before they are aggressively purged. Due to the
@@ -134,7 +133,7 @@ pub enum DNSEvent {
     StateMemCapReached,
 }
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct DNSHeader {
     pub tx_id: u16,
     pub flags: u16,
@@ -151,7 +150,7 @@ pub struct DNSQueryEntry {
     pub rrclass: u16,
 }
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct DNSAnswerEntry {
     pub name: Vec<u8>,
     pub rrtype: u16,
@@ -187,9 +186,8 @@ pub struct DNSTransaction {
 }
 
 impl DNSTransaction {
-
     pub fn new() -> DNSTransaction {
-        return DNSTransaction{
+        return DNSTransaction {
             id: 0,
             request: None,
             response: None,
@@ -198,7 +196,7 @@ impl DNSTransaction {
             logged: LoggerFlags::new(),
             de_state: None,
             events: std::ptr::null_mut(),
-        }
+        };
     }
 
     pub fn free(&mut self) {
@@ -209,7 +207,7 @@ impl DNSTransaction {
             Some(state) => {
                 core::sc_detect_engine_state_free(state);
             }
-            None => { },
+            None => {}
         }
     }
 
@@ -234,7 +232,6 @@ impl DNSTransaction {
         }
         return 0;
     }
-
 }
 
 impl Drop for DNSTransaction {
@@ -259,9 +256,8 @@ pub struct DNSState {
 }
 
 impl DNSState {
-
     pub fn new() -> DNSState {
-        return DNSState{
+        return DNSState {
             tx_id: 0,
             transactions: Vec::new(),
             events: 0,
@@ -274,7 +270,7 @@ impl DNSState {
     /// Allocate a new state with capacites in the buffers for
     /// potentially buffering as might be needed in TCP.
     pub fn new_tcp() -> DNSState {
-        return DNSState{
+        return DNSState {
             tx_id: 0,
             transactions: Vec::new(),
             events: 0,
@@ -346,8 +342,10 @@ impl DNSState {
         }
 
         let tx = &mut self.transactions[len - 1];
-        core::sc_app_layer_decoder_events_set_event_raw(&mut tx.events,
-                                                        event as u8);
+        core::sc_app_layer_decoder_events_set_event_raw(
+            &mut tx.events,
+            event as u8,
+        );
         self.events += 1;
     }
 
@@ -389,7 +387,6 @@ impl DNSState {
     pub fn parse_response(&mut self, input: &[u8]) -> bool {
         match parser::dns_parse_response(input) {
             nom::IResult::Done(_, response) => {
-
                 SCLogDebug!("Response header flags: {}", response.header.flags);
 
                 if response.header.flags & 0x8000 == 0 {
@@ -435,7 +432,7 @@ impl DNSState {
             if probe_tcp(input) {
                 self.gap = false;
             } else {
-                return 0
+                return 0;
             }
         }
 
@@ -445,13 +442,16 @@ impl DNSState {
         while self.request_buffer.len() > 0 {
             let size = match nom::be_u16(&self.request_buffer) {
                 nom::IResult::Done(_, len) => len,
-                _ => 0
+                _ => 0,
             } as usize;
-            SCLogDebug!("Have {} bytes, need {} to parse",
-                        self.request_buffer.len(), size);
+            SCLogDebug!(
+                "Have {} bytes, need {} to parse",
+                self.request_buffer.len(),
+                size
+            );
             if size > 0 && self.request_buffer.len() >= size + 2 {
-                let msg: Vec<u8> = self.request_buffer.drain(0..(size + 2))
-                    .collect();
+                let msg: Vec<u8> =
+                    self.request_buffer.drain(0..(size + 2)).collect();
                 if self.parse_request(&msg[2..]) {
                     count += 1
                 }
@@ -475,7 +475,7 @@ impl DNSState {
             if probe_tcp(input) {
                 self.gap = false;
             } else {
-                return 0
+                return 0;
             }
         }
 
@@ -485,11 +485,11 @@ impl DNSState {
         while self.response_buffer.len() > 0 {
             let size = match nom::be_u16(&self.response_buffer) {
                 nom::IResult::Done(_, len) => len,
-                _ => 0
+                _ => 0,
             } as usize;
             if size > 0 && self.response_buffer.len() >= size + 2 {
-                let msg: Vec<u8> = self.response_buffer.drain(0..(size + 2))
-                    .collect();
+                let msg: Vec<u8> =
+                    self.response_buffer.drain(0..(size + 2)).collect();
                 if self.parse_response(&msg[2..]) {
                     count += 1;
                 }
@@ -523,7 +523,7 @@ impl DNSState {
 fn probe(input: &[u8]) -> bool {
     match parser::dns_parse_request(input) {
         nom::IResult::Done(_, _) => true,
-        _ => false
+        _ => false,
     }
 }
 
@@ -532,7 +532,7 @@ pub fn probe_tcp(input: &[u8]) -> bool {
     match nom::be_u16(input) {
         nom::IResult::Done(rem, _) => {
             return probe(rem);
-        },
+        }
         _ => {}
     }
     return false;
@@ -543,7 +543,7 @@ pub fn probe_tcp(input: &[u8]) -> bool {
 pub extern "C" fn rs_dns_state_new() -> *mut libc::c_void {
     let state = DNSState::new();
     let boxed = Box::new(state);
-    return unsafe{transmute(boxed)};
+    return unsafe { transmute(boxed) };
 }
 
 /// Returns *mut DNSState
@@ -551,7 +551,7 @@ pub extern "C" fn rs_dns_state_new() -> *mut libc::c_void {
 pub extern "C" fn rs_dns_state_tcp_new() -> *mut libc::c_void {
     let state = DNSState::new_tcp();
     let boxed = Box::new(state);
-    return unsafe{transmute(boxed)};
+    return unsafe { transmute(boxed) };
 }
 
 /// Params:
@@ -559,26 +559,28 @@ pub extern "C" fn rs_dns_state_tcp_new() -> *mut libc::c_void {
 #[no_mangle]
 pub extern "C" fn rs_dns_state_free(state: *mut libc::c_void) {
     // Just unbox...
-    let _drop: Box<DNSState> = unsafe{transmute(state)};
+    let _drop: Box<DNSState> = unsafe { transmute(state) };
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_state_tx_free(state: &mut DNSState,
-                                       tx_id: libc::uint64_t)
-{
+pub extern "C" fn rs_dns_state_tx_free(
+    state: &mut DNSState,
+    tx_id: libc::uint64_t,
+) {
     state.free_tx(tx_id);
 }
 
 /// C binding parse a DNS request. Returns 1 on success, -1 on failure.
 #[no_mangle]
-pub extern "C" fn rs_dns_parse_request(_flow: *mut core::Flow,
-                                       state: &mut DNSState,
-                                       _pstate: *mut libc::c_void,
-                                       input: *mut libc::uint8_t,
-                                       input_len: libc::uint32_t,
-                                       _data: *mut libc::c_void)
-                                       -> libc::int8_t {
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+pub extern "C" fn rs_dns_parse_request(
+    _flow: *mut core::Flow,
+    state: &mut DNSState,
+    _pstate: *mut libc::c_void,
+    input: *mut libc::uint8_t,
+    input_len: libc::uint32_t,
+    _data: *mut libc::c_void,
+) -> libc::int8_t {
+    let buf = unsafe { std::slice::from_raw_parts(input, input_len as usize) };
     if state.parse_request(buf) {
         1
     } else {
@@ -587,14 +589,15 @@ pub extern "C" fn rs_dns_parse_request(_flow: *mut core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_parse_response(_flow: *mut core::Flow,
-                                        state: &mut DNSState,
-                                        _pstate: *mut libc::c_void,
-                                        input: *mut libc::uint8_t,
-                                        input_len: libc::uint32_t,
-                                        _data: *mut libc::c_void)
-                                        -> libc::int8_t {
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+pub extern "C" fn rs_dns_parse_response(
+    _flow: *mut core::Flow,
+    state: &mut DNSState,
+    _pstate: *mut libc::c_void,
+    input: *mut libc::uint8_t,
+    input_len: libc::uint32_t,
+    _data: *mut libc::c_void,
+) -> libc::int8_t {
+    let buf = unsafe { std::slice::from_raw_parts(input, input_len as usize) };
     if state.parse_response(buf) {
         1
     } else {
@@ -604,17 +607,19 @@ pub extern "C" fn rs_dns_parse_response(_flow: *mut core::Flow,
 
 /// C binding parse a DNS request. Returns 1 on success, -1 on failure.
 #[no_mangle]
-pub extern "C" fn rs_dns_parse_request_tcp(_flow: *mut core::Flow,
-                                           state: &mut DNSState,
-                                           _pstate: *mut libc::c_void,
-                                           input: *mut libc::uint8_t,
-                                           input_len: libc::uint32_t,
-                                           _data: *mut libc::c_void)
-                                           -> libc::int8_t {
+pub extern "C" fn rs_dns_parse_request_tcp(
+    _flow: *mut core::Flow,
+    state: &mut DNSState,
+    _pstate: *mut libc::c_void,
+    input: *mut libc::uint8_t,
+    input_len: libc::uint32_t,
+    _data: *mut libc::c_void,
+) -> libc::int8_t {
     if input_len > 0 {
         if input != std::ptr::null_mut() {
-            let buf = unsafe{
-                std::slice::from_raw_parts(input, input_len as usize)};
+            let buf = unsafe {
+                std::slice::from_raw_parts(input, input_len as usize)
+            };
             return state.parse_request_tcp(buf);
         }
         state.request_gap(input_len);
@@ -623,17 +628,19 @@ pub extern "C" fn rs_dns_parse_request_tcp(_flow: *mut core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_parse_response_tcp(_flow: *mut core::Flow,
-                                            state: &mut DNSState,
-                                            _pstate: *mut libc::c_void,
-                                            input: *mut libc::uint8_t,
-                                            input_len: libc::uint32_t,
-                                            _data: *mut libc::c_void)
-                                            -> libc::int8_t {
+pub extern "C" fn rs_dns_parse_response_tcp(
+    _flow: *mut core::Flow,
+    state: &mut DNSState,
+    _pstate: *mut libc::c_void,
+    input: *mut libc::uint8_t,
+    input_len: libc::uint32_t,
+    _data: *mut libc::c_void,
+) -> libc::int8_t {
     if input_len > 0 {
         if input != std::ptr::null_mut() {
-            let buf = unsafe{
-                std::slice::from_raw_parts(input, input_len as usize)};
+            let buf = unsafe {
+                std::slice::from_raw_parts(input, input_len as usize)
+            };
             return state.parse_response_tcp(buf);
         }
         state.response_gap(input_len);
@@ -643,18 +650,17 @@ pub extern "C" fn rs_dns_parse_response_tcp(_flow: *mut core::Flow,
 
 #[no_mangle]
 pub extern "C" fn rs_dns_state_progress_completion_status(
-    _direction: libc::uint8_t)
-    -> libc::c_int
-{
+    _direction: libc::uint8_t,
+) -> libc::c_int {
     SCLogDebug!("rs_dns_state_progress_completion_status");
     return 1;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_tx_get_alstate_progress(_tx: &mut DNSTransaction,
-                                                 _direction: libc::uint8_t)
-                                                 -> libc::uint8_t
-{
+pub extern "C" fn rs_dns_tx_get_alstate_progress(
+    _tx: &mut DNSTransaction,
+    _direction: libc::uint8_t,
+) -> libc::uint8_t {
     // This is a stateless parser, just the existence of a transaction
     // means its complete.
     SCLogDebug!("rs_dns_tx_get_alstate_progress");
@@ -662,10 +668,11 @@ pub extern "C" fn rs_dns_tx_get_alstate_progress(_tx: &mut DNSTransaction,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_tx_set_detect_flags(tx: &mut DNSTransaction,
-                                             dir: libc::uint8_t,
-                                             flags: libc::uint64_t)
-{
+pub extern "C" fn rs_dns_tx_set_detect_flags(
+    tx: &mut DNSTransaction,
+    dir: libc::uint8_t,
+    flags: libc::uint64_t,
+) {
     if dir & core::STREAM_TOSERVER != 0 {
         tx.detect_flags_ts = flags as u64;
     } else {
@@ -674,10 +681,10 @@ pub extern "C" fn rs_dns_tx_set_detect_flags(tx: &mut DNSTransaction,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_tx_get_detect_flags(tx: &mut DNSTransaction,
-                                             dir: libc::uint8_t)
-                                       -> libc::uint64_t
-{
+pub extern "C" fn rs_dns_tx_get_detect_flags(
+    tx: &mut DNSTransaction,
+    dir: libc::uint8_t,
+) -> libc::uint64_t {
     if dir & core::STREAM_TOSERVER != 0 {
         return tx.detect_flags_ts as libc::uint64_t;
     } else {
@@ -686,37 +693,38 @@ pub extern "C" fn rs_dns_tx_get_detect_flags(tx: &mut DNSTransaction,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_tx_set_logged(_state: &mut DNSState,
-                                       tx: &mut DNSTransaction,
-                                       logged: libc::uint32_t)
-{
+pub extern "C" fn rs_dns_tx_set_logged(
+    _state: &mut DNSState,
+    tx: &mut DNSTransaction,
+    logged: libc::uint32_t,
+) {
     tx.logged.set(logged);
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_tx_get_logged(_state: &mut DNSState,
-                                       tx: &mut DNSTransaction)
-                                       -> u32
-{
+pub extern "C" fn rs_dns_tx_get_logged(
+    _state: &mut DNSState,
+    tx: &mut DNSTransaction,
+) -> u32 {
     return tx.logged.get();
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_state_get_tx_count(state: &mut DNSState)
-                                            -> libc::uint64_t
-{
+pub extern "C" fn rs_dns_state_get_tx_count(
+    state: &mut DNSState,
+) -> libc::uint64_t {
     SCLogDebug!("rs_dns_state_get_tx_count: returning {}", state.tx_id);
     return state.tx_id;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_state_get_tx(state: &mut DNSState,
-                                      tx_id: libc::uint64_t)
-                                      -> *mut DNSTransaction
-{
+pub extern "C" fn rs_dns_state_get_tx(
+    state: &mut DNSState,
+    tx_id: libc::uint64_t,
+) -> *mut DNSTransaction {
     match state.get_tx(tx_id) {
         Some(tx) => {
-            return unsafe{transmute(tx)};
+            return unsafe { transmute(tx) };
         }
         None => {
             return std::ptr::null_mut();
@@ -727,20 +735,19 @@ pub extern "C" fn rs_dns_state_get_tx(state: &mut DNSState,
 #[no_mangle]
 pub extern "C" fn rs_dns_state_set_tx_detect_state(
     tx: &mut DNSTransaction,
-    de_state: &mut core::DetectEngineState)
-{
+    de_state: &mut core::DetectEngineState,
+) {
     tx.de_state = Some(de_state);
 }
 
 #[no_mangle]
 pub extern "C" fn rs_dns_state_get_tx_detect_state(
-    tx: &mut DNSTransaction)
-    -> *mut core::DetectEngineState
-{
+    tx: &mut DNSTransaction,
+) -> *mut core::DetectEngineState {
     match tx.de_state {
         Some(ds) => {
             return ds;
-        },
+        }
         None => {
             return std::ptr::null_mut();
         }
@@ -748,10 +755,10 @@ pub extern "C" fn rs_dns_state_get_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_state_get_events(state: &mut DNSState,
-                                          tx_id: libc::uint64_t)
-                                          -> *mut core::AppLayerDecoderEvents
-{
+pub extern "C" fn rs_dns_state_get_events(
+    state: &mut DNSState,
+    tx_id: libc::uint64_t,
+) -> *mut core::AppLayerDecoderEvents {
     match state.get_tx(tx_id) {
         Some(tx) => {
             return tx.events;
@@ -763,12 +770,12 @@ pub extern "C" fn rs_dns_state_get_events(state: &mut DNSState,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_tx_get_query_name(tx: &mut DNSTransaction,
-                                       i: libc::uint16_t,
-                                       buf: *mut *const libc::uint8_t,
-                                       len: *mut libc::uint32_t)
-                                       -> libc::uint8_t
-{
+pub extern "C" fn rs_dns_tx_get_query_name(
+    tx: &mut DNSTransaction,
+    i: libc::uint16_t,
+    buf: *mut *const libc::uint8_t,
+    len: *mut libc::uint32_t,
+) -> libc::uint8_t {
     if let &Some(ref request) = &tx.request {
         if (i as usize) < request.queries.len() {
             let query = &request.queries[i as usize];
@@ -788,27 +795,28 @@ pub extern "C" fn rs_dns_tx_get_query_name(tx: &mut DNSTransaction,
 //
 /// extern uint16_t rs_dns_tx_get_tx_id(RSDNSTransaction *);
 #[no_mangle]
-pub extern "C" fn rs_dns_tx_get_tx_id(tx: &mut DNSTransaction) -> libc::uint16_t
-{
-    return tx.tx_id()
+pub extern "C" fn rs_dns_tx_get_tx_id(
+    tx: &mut DNSTransaction,
+) -> libc::uint16_t {
+    return tx.tx_id();
 }
 
 /// Get the DNS response flags for a transaction.
 ///
 /// extern uint16_t rs_dns_tx_get_response_flags(RSDNSTransaction *);
 #[no_mangle]
-pub extern "C" fn rs_dns_tx_get_response_flags(tx: &mut DNSTransaction)
-                                           -> libc::uint16_t
-{
+pub extern "C" fn rs_dns_tx_get_response_flags(
+    tx: &mut DNSTransaction,
+) -> libc::uint16_t {
     return tx.rcode();
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_tx_get_query_rrtype(tx: &mut DNSTransaction,
-                                         i: libc::uint16_t,
-                                         rrtype: *mut libc::uint16_t)
-                                         -> libc::uint8_t
-{
+pub extern "C" fn rs_dns_tx_get_query_rrtype(
+    tx: &mut DNSTransaction,
+    i: libc::uint16_t,
+    rrtype: *mut libc::uint16_t,
+) -> libc::uint8_t {
     if let &Some(ref request) = &tx.request {
         if (i as usize) < request.queries.len() {
             let query = &request.queries[i as usize];
@@ -824,12 +832,12 @@ pub extern "C" fn rs_dns_tx_get_query_rrtype(tx: &mut DNSTransaction,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_probe(input: *const libc::uint8_t, len: libc::uint32_t)
-                               -> libc::uint8_t
-{
-    let slice: &[u8] = unsafe {
-        std::slice::from_raw_parts(input as *mut u8, len as usize)
-    };
+pub extern "C" fn rs_dns_probe(
+    input: *const libc::uint8_t,
+    len: libc::uint32_t,
+) -> libc::uint8_t {
+    let slice: &[u8] =
+        unsafe { std::slice::from_raw_parts(input as *mut u8, len as usize) };
     if probe(slice) {
         return 1;
     }
@@ -837,13 +845,12 @@ pub extern "C" fn rs_dns_probe(input: *const libc::uint8_t, len: libc::uint32_t)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_probe_tcp(input: *const libc::uint8_t,
-                                   len: libc::uint32_t)
-                                   -> libc::uint8_t
-{
-    let slice: &[u8] = unsafe {
-        std::slice::from_raw_parts(input as *mut u8, len as usize)
-    };
+pub extern "C" fn rs_dns_probe_tcp(
+    input: *const libc::uint8_t,
+    len: libc::uint32_t,
+) -> libc::uint8_t {
+    let slice: &[u8] =
+        unsafe { std::slice::from_raw_parts(input as *mut u8, len as usize) };
     if probe_tcp(slice) {
         return 1;
     }
@@ -871,7 +878,7 @@ mod tests {
             0x61, 0x74, 0x61, 0x2d, 0x69, 0x64, 0x73, 0x03, /* ata-ids. */
             0x6f, 0x72, 0x67, 0x00, 0x00, 0x01, 0x00, 0x01, /* org..... */
             0x00, 0x00, 0x29, 0x10, 0x00, 0x00, 0x00, 0x00, /* ..)..... */
-            0x00, 0x00, 0x00                                /* ... */
+            0x00, 0x00, 0x00, /* ... */
         ];
 
         // The DNS payload starts at offset 42.
@@ -903,7 +910,7 @@ mod tests {
             0x61, 0x74, 0x61, 0x2d, 0x69, 0x64, 0x73, 0x03, /* ata-ids. */
             0x6f, 0x72, 0x67, 0x00, 0x00, 0x01, 0x00, 0x01, /* org..... */
             0x00, 0x00, 0x29, 0x10, 0x00, 0x00, 0x00, 0x00, /* ..)..... */
-            0x00, 0x00, 0x00                                /* ... */
+            0x00, 0x00, 0x00, /* ... */
         ];
 
         // The DNS payload starts at offset 42.
@@ -942,7 +949,7 @@ mod tests {
             0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0xf4, /* ........ */
             0x00, 0x04, 0xc0, 0x00, 0x4e, 0x18, 0xc0, 0x32, /* ....N..2 */
             0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0xf4, /* ........ */
-            0x00, 0x04, 0xc0, 0x00, 0x4e, 0x19              /* ....N. */
+            0x00, 0x04, 0xc0, 0x00, 0x4e, 0x19, /* ....N. */
         ];
 
         // The DNS payload starts at offset 42.
@@ -982,7 +989,7 @@ mod tests {
             0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0xf4, /* ........ */
             0x00, 0x04, 0xc0, 0x00, 0x4e, 0x18, 0xc0, 0x32, /* ....N..2 */
             0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0xf4, /* ........ */
-            0x00, 0x04, 0xc0, 0x00, 0x4e, 0x19              /* ....N. */
+            0x00, 0x04, 0xc0, 0x00, 0x4e, 0x19, /* ....N. */
         ];
 
         // The DNS payload starts at offset 42.

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -21,10 +21,10 @@ extern crate nom;
 use std;
 use std::mem::transmute;
 
-use log::*;
-use applayer::LoggerFlags;
-use core;
-use dns::parser;
+use crate::log::*;
+use crate::applayer::LoggerFlags;
+use crate::core;
+use crate::dns::parser;
 
 /// DNS record types.
 pub const DNS_RECORD_TYPE_A           : u16 = 1;
@@ -853,7 +853,7 @@ pub extern "C" fn rs_dns_probe_tcp(input: *const libc::uint8_t,
 #[cfg(test)]
 mod tests {
 
-    use dns::dns::DNSState;
+    use crate::dns::dns::DNSState;
 
     #[test]
     fn test_dns_parse_request_tcp_valid() {

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -21,8 +21,8 @@ use std;
 use std::string::String;
 use std::collections::HashMap;
 
-use json::*;
-use dns::dns::*;
+use crate::json::*;
+use crate::dns::dns::*;
 
 pub const LOG_QUERIES    : u64 = BIT_U64!(0);
 pub const LOG_ANSWER     : u64 = BIT_U64!(1);

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -18,79 +18,78 @@
 extern crate libc;
 
 use std;
-use std::string::String;
 use std::collections::HashMap;
+use std::string::String;
 
-use crate::json::*;
 use crate::dns::dns::*;
+use crate::json::*;
 
-pub const LOG_QUERIES    : u64 = BIT_U64!(0);
-pub const LOG_ANSWER     : u64 = BIT_U64!(1);
+pub const LOG_QUERIES: u64 = BIT_U64!(0);
+pub const LOG_ANSWER: u64 = BIT_U64!(1);
 
-pub const LOG_A          : u64 = BIT_U64!(2);
-pub const LOG_NS         : u64 = BIT_U64!(3);
-pub const LOG_MD         : u64 = BIT_U64!(4);
-pub const LOG_MF         : u64 = BIT_U64!(5);
-pub const LOG_CNAME      : u64 = BIT_U64!(6);
-pub const LOG_SOA        : u64 = BIT_U64!(7);
-pub const LOG_MB         : u64 = BIT_U64!(8);
-pub const LOG_MG         : u64 = BIT_U64!(9);
-pub const LOG_MR         : u64 = BIT_U64!(10);
-pub const LOG_NULL       : u64 = BIT_U64!(11);
-pub const LOG_WKS        : u64 = BIT_U64!(12);
-pub const LOG_PTR        : u64 = BIT_U64!(13);
-pub const LOG_HINFO      : u64 = BIT_U64!(14);
-pub const LOG_MINFO      : u64 = BIT_U64!(15);
-pub const LOG_MX         : u64 = BIT_U64!(16);
-pub const LOG_TXT        : u64 = BIT_U64!(17);
-pub const LOG_RP         : u64 = BIT_U64!(18);
-pub const LOG_AFSDB      : u64 = BIT_U64!(19);
-pub const LOG_X25        : u64 = BIT_U64!(20);
-pub const LOG_ISDN       : u64 = BIT_U64!(21);
-pub const LOG_RT         : u64 = BIT_U64!(22);
-pub const LOG_NSAP       : u64 = BIT_U64!(23);
-pub const LOG_NSAPPTR    : u64 = BIT_U64!(24);
-pub const LOG_SIG        : u64 = BIT_U64!(25);
-pub const LOG_KEY        : u64 = BIT_U64!(26);
-pub const LOG_PX         : u64 = BIT_U64!(27);
-pub const LOG_GPOS       : u64 = BIT_U64!(28);
-pub const LOG_AAAA       : u64 = BIT_U64!(29);
-pub const LOG_LOC        : u64 = BIT_U64!(30);
-pub const LOG_NXT        : u64 = BIT_U64!(31);
-pub const LOG_SRV        : u64 = BIT_U64!(32);
-pub const LOG_ATMA       : u64 = BIT_U64!(33);
-pub const LOG_NAPTR      : u64 = BIT_U64!(34);
-pub const LOG_KX         : u64 = BIT_U64!(35);
-pub const LOG_CERT       : u64 = BIT_U64!(36);
-pub const LOG_A6         : u64 = BIT_U64!(37);
-pub const LOG_DNAME      : u64 = BIT_U64!(38);
-pub const LOG_OPT        : u64 = BIT_U64!(39);
-pub const LOG_APL        : u64 = BIT_U64!(40);
-pub const LOG_DS         : u64 = BIT_U64!(41);
-pub const LOG_SSHFP      : u64 = BIT_U64!(42);
-pub const LOG_IPSECKEY   : u64 = BIT_U64!(43);
-pub const LOG_RRSIG      : u64 = BIT_U64!(44);
-pub const LOG_NSEC       : u64 = BIT_U64!(45);
-pub const LOG_DNSKEY     : u64 = BIT_U64!(46);
-pub const LOG_DHCID      : u64 = BIT_U64!(47);
-pub const LOG_NSEC3      : u64 = BIT_U64!(48);
-pub const LOG_NSEC3PARAM : u64 = BIT_U64!(49);
-pub const LOG_TLSA       : u64 = BIT_U64!(50);
-pub const LOG_HIP        : u64 = BIT_U64!(51);
-pub const LOG_CDS        : u64 = BIT_U64!(52);
-pub const LOG_CDNSKEY    : u64 = BIT_U64!(53);
-pub const LOG_SPF        : u64 = BIT_U64!(54);
-pub const LOG_TKEY       : u64 = BIT_U64!(55);
-pub const LOG_TSIG       : u64 = BIT_U64!(56);
-pub const LOG_MAILA      : u64 = BIT_U64!(57);
-pub const LOG_ANY        : u64 = BIT_U64!(58);
-pub const LOG_URI        : u64 = BIT_U64!(59);
+pub const LOG_A: u64 = BIT_U64!(2);
+pub const LOG_NS: u64 = BIT_U64!(3);
+pub const LOG_MD: u64 = BIT_U64!(4);
+pub const LOG_MF: u64 = BIT_U64!(5);
+pub const LOG_CNAME: u64 = BIT_U64!(6);
+pub const LOG_SOA: u64 = BIT_U64!(7);
+pub const LOG_MB: u64 = BIT_U64!(8);
+pub const LOG_MG: u64 = BIT_U64!(9);
+pub const LOG_MR: u64 = BIT_U64!(10);
+pub const LOG_NULL: u64 = BIT_U64!(11);
+pub const LOG_WKS: u64 = BIT_U64!(12);
+pub const LOG_PTR: u64 = BIT_U64!(13);
+pub const LOG_HINFO: u64 = BIT_U64!(14);
+pub const LOG_MINFO: u64 = BIT_U64!(15);
+pub const LOG_MX: u64 = BIT_U64!(16);
+pub const LOG_TXT: u64 = BIT_U64!(17);
+pub const LOG_RP: u64 = BIT_U64!(18);
+pub const LOG_AFSDB: u64 = BIT_U64!(19);
+pub const LOG_X25: u64 = BIT_U64!(20);
+pub const LOG_ISDN: u64 = BIT_U64!(21);
+pub const LOG_RT: u64 = BIT_U64!(22);
+pub const LOG_NSAP: u64 = BIT_U64!(23);
+pub const LOG_NSAPPTR: u64 = BIT_U64!(24);
+pub const LOG_SIG: u64 = BIT_U64!(25);
+pub const LOG_KEY: u64 = BIT_U64!(26);
+pub const LOG_PX: u64 = BIT_U64!(27);
+pub const LOG_GPOS: u64 = BIT_U64!(28);
+pub const LOG_AAAA: u64 = BIT_U64!(29);
+pub const LOG_LOC: u64 = BIT_U64!(30);
+pub const LOG_NXT: u64 = BIT_U64!(31);
+pub const LOG_SRV: u64 = BIT_U64!(32);
+pub const LOG_ATMA: u64 = BIT_U64!(33);
+pub const LOG_NAPTR: u64 = BIT_U64!(34);
+pub const LOG_KX: u64 = BIT_U64!(35);
+pub const LOG_CERT: u64 = BIT_U64!(36);
+pub const LOG_A6: u64 = BIT_U64!(37);
+pub const LOG_DNAME: u64 = BIT_U64!(38);
+pub const LOG_OPT: u64 = BIT_U64!(39);
+pub const LOG_APL: u64 = BIT_U64!(40);
+pub const LOG_DS: u64 = BIT_U64!(41);
+pub const LOG_SSHFP: u64 = BIT_U64!(42);
+pub const LOG_IPSECKEY: u64 = BIT_U64!(43);
+pub const LOG_RRSIG: u64 = BIT_U64!(44);
+pub const LOG_NSEC: u64 = BIT_U64!(45);
+pub const LOG_DNSKEY: u64 = BIT_U64!(46);
+pub const LOG_DHCID: u64 = BIT_U64!(47);
+pub const LOG_NSEC3: u64 = BIT_U64!(48);
+pub const LOG_NSEC3PARAM: u64 = BIT_U64!(49);
+pub const LOG_TLSA: u64 = BIT_U64!(50);
+pub const LOG_HIP: u64 = BIT_U64!(51);
+pub const LOG_CDS: u64 = BIT_U64!(52);
+pub const LOG_CDNSKEY: u64 = BIT_U64!(53);
+pub const LOG_SPF: u64 = BIT_U64!(54);
+pub const LOG_TKEY: u64 = BIT_U64!(55);
+pub const LOG_TSIG: u64 = BIT_U64!(56);
+pub const LOG_MAILA: u64 = BIT_U64!(57);
+pub const LOG_ANY: u64 = BIT_U64!(58);
+pub const LOG_URI: u64 = BIT_U64!(59);
 
-pub const LOG_FORMAT_GROUPED  : u64 = BIT_U64!(60);
-pub const LOG_FORMAT_DETAILED : u64 = BIT_U64!(61);
+pub const LOG_FORMAT_GROUPED: u64 = BIT_U64!(60);
+pub const LOG_FORMAT_DETAILED: u64 = BIT_U64!(61);
 
-fn dns_log_rrtype_enabled(rtype: u16, flags: u64) -> bool
-{
+fn dns_log_rrtype_enabled(rtype: u16, flags: u64) -> bool {
     if flags == !0 {
         return true;
     }
@@ -234,9 +233,7 @@ fn dns_log_rrtype_enabled(rtype: u16, flags: u64) -> bool
         DNS_RECORD_TYPE_DHCID => {
             return flags & LOG_DHCID != 0;
         }
-        DNS_RECORD_TYPE_NSEC3 => {
-            return flags & LOG_NSEC3 != 0
-        }
+        DNS_RECORD_TYPE_NSEC3 => return flags & LOG_NSEC3 != 0,
         DNS_RECORD_TYPE_NSEC3PARAM => {
             return flags & LOG_NSEC3PARAM != 0;
         }
@@ -339,7 +336,8 @@ pub fn dns_rrtype_string(rrtype: u16) -> String {
         _ => {
             return rrtype.to_string();
         }
-    }.to_string()
+    }
+    .to_string()
 }
 
 fn dns_rcode_string(flags: u16) -> String {
@@ -365,15 +363,15 @@ fn dns_rcode_string(flags: u16) -> String {
         _ => {
             return (flags & 0x000f).to_string();
         }
-    }.to_string()
+    }
+    .to_string()
 }
 
 /// Format bytes as an IP address string.
 pub fn dns_print_addr(addr: &Vec<u8>) -> std::string::String {
     if addr.len() == 4 {
         return format!("{}.{}.{}.{}", addr[0], addr[1], addr[2], addr[3]);
-    }
-    else if addr.len() == 16 {
+    } else if addr.len() == 16 {
         return format!("{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}",
                        addr[0],
                        addr[1],
@@ -391,18 +389,16 @@ pub fn dns_print_addr(addr: &Vec<u8>) -> std::string::String {
                        addr[13],
                        addr[14],
                        addr[15]);
-    }
-    else {
+    } else {
         return "".to_string();
     }
 }
 
 ///  Log the SSHPF in an DNSAnswerEntry.
-fn dns_log_sshfp(answer: &DNSAnswerEntry) -> Option<Json>
-{
+fn dns_log_sshfp(answer: &DNSAnswerEntry) -> Option<Json> {
     // Need at least 3 bytes - TODO: log something if we don't?
     if answer.data.len() < 3 {
-        return None
+        return None;
     }
 
     let sshfp = Json::object();
@@ -418,8 +414,7 @@ fn dns_log_sshfp(answer: &DNSAnswerEntry) -> Option<Json>
     return Some(sshfp);
 }
 
-fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Json
-{
+fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Json {
     let jsa = Json::object();
 
     jsa.set_string_from_bytes("rrname", &answer.name);
@@ -430,25 +425,24 @@ fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Json
         DNS_RECORD_TYPE_A | DNS_RECORD_TYPE_AAAA => {
             jsa.set_string("rdata", &dns_print_addr(&answer.data));
         }
-        DNS_RECORD_TYPE_CNAME |
-        DNS_RECORD_TYPE_MX |
-        DNS_RECORD_TYPE_TXT |
-        DNS_RECORD_TYPE_PTR => {
+        DNS_RECORD_TYPE_CNAME
+        | DNS_RECORD_TYPE_MX
+        | DNS_RECORD_TYPE_TXT
+        | DNS_RECORD_TYPE_PTR => {
             jsa.set_string_from_bytes("rdata", &answer.data);
-        },
+        }
         DNS_RECORD_TYPE_SSHFP => {
             for sshfp in dns_log_sshfp(&answer) {
                 jsa.set("sshfp", sshfp);
             }
-        },
+        }
         _ => {}
     }
 
     return jsa;
 }
 
-fn dns_log_json_answer(response: &DNSResponse, flags: u64) -> Json
-{
+fn dns_log_json_answer(response: &DNSResponse, flags: u64) -> Json {
     let header = &response.header;
     let js = Json::object();
 
@@ -486,44 +480,45 @@ fn dns_log_json_answer(response: &DNSResponse, flags: u64) -> Json
         let mut answer_types = HashMap::new();
 
         for answer in &response.answers {
-
             if flags & LOG_FORMAT_GROUPED != 0 {
                 let type_string = dns_rrtype_string(answer.rrtype);
                 match answer.rrtype {
                     DNS_RECORD_TYPE_A | DNS_RECORD_TYPE_AAAA => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(),
-                                                Json::array());
+                            answer_types
+                                .insert(type_string.to_string(), Json::array());
                         }
                         for a in &answer_types.get(&type_string) {
-                            a.array_append(
-                                Json::string(&dns_print_addr(&answer.data)));
+                            a.array_append(Json::string(&dns_print_addr(
+                                &answer.data,
+                            )));
                         }
                     }
-                    DNS_RECORD_TYPE_CNAME |
-                    DNS_RECORD_TYPE_MX |
-                    DNS_RECORD_TYPE_TXT |
-                    DNS_RECORD_TYPE_PTR => {
+                    DNS_RECORD_TYPE_CNAME
+                    | DNS_RECORD_TYPE_MX
+                    | DNS_RECORD_TYPE_TXT
+                    | DNS_RECORD_TYPE_PTR => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(),
-                                                Json::array());
+                            answer_types
+                                .insert(type_string.to_string(), Json::array());
                         }
                         for a in &answer_types.get(&type_string) {
-                            a.array_append(
-                                Json::string_from_bytes(&answer.data));
+                            a.array_append(Json::string_from_bytes(
+                                &answer.data,
+                            ));
                         }
-                    },
+                    }
                     DNS_RECORD_TYPE_SSHFP => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(),
-                                                Json::array());
+                            answer_types
+                                .insert(type_string.to_string(), Json::array());
                         }
                         for a in &answer_types.get(&type_string) {
                             for sshfp in dns_log_sshfp(&answer) {
                                 a.array_append(sshfp);
                             }
                         }
-                    },
+                    }
                     _ => {}
                 }
             }
@@ -544,7 +539,6 @@ fn dns_log_json_answer(response: &DNSResponse, flags: u64) -> Json
             }
             js.set("grouped", grouped);
         }
-
     }
 
     if response.authorities.len() > 0 {
@@ -559,11 +553,11 @@ fn dns_log_json_answer(response: &DNSResponse, flags: u64) -> Json
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_log_json_query(tx: &mut DNSTransaction,
-                                        i: libc::uint16_t,
-                                        flags: libc::uint64_t)
-                                        -> *mut JsonT
-{
+pub extern "C" fn rs_dns_log_json_query(
+    tx: &mut DNSTransaction,
+    i: libc::uint16_t,
+    flags: libc::uint64_t,
+) -> *mut JsonT {
     let index = i as usize;
     if let &Some(ref request) = &tx.request {
         if index < request.queries.len() {
@@ -584,10 +578,10 @@ pub extern "C" fn rs_dns_log_json_query(tx: &mut DNSTransaction,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_log_json_answer(tx: &mut DNSTransaction,
-                                         flags: libc::uint64_t)
-                                         -> *mut JsonT
-{
+pub extern "C" fn rs_dns_log_json_answer(
+    tx: &mut DNSTransaction,
+    flags: libc::uint64_t,
+) -> *mut JsonT {
     if let &Some(ref response) = &tx.response {
         for query in &response.queries {
             if dns_log_rrtype_enabled(query.rrtype, flags) {
@@ -602,9 +596,7 @@ pub extern "C" fn rs_dns_log_json_answer(tx: &mut DNSTransaction,
 
 // Version 1 logging support.
 
-fn dns_log_json_answer_v1(header: &DNSHeader, answer: &DNSAnswerEntry)
-                       -> Json
-{
+fn dns_log_json_answer_v1(header: &DNSHeader, answer: &DNSAnswerEntry) -> Json {
     let js = Json::object();
 
     js.set_string("type", "answer");
@@ -634,25 +626,28 @@ fn dns_log_json_answer_v1(header: &DNSHeader, answer: &DNSAnswerEntry)
         DNS_RECORD_TYPE_A | DNS_RECORD_TYPE_AAAA => {
             js.set_string("rdata", &dns_print_addr(&answer.data));
         }
-        DNS_RECORD_TYPE_CNAME |
-        DNS_RECORD_TYPE_MX |
-        DNS_RECORD_TYPE_TXT |
-        DNS_RECORD_TYPE_PTR => {
+        DNS_RECORD_TYPE_CNAME
+        | DNS_RECORD_TYPE_MX
+        | DNS_RECORD_TYPE_TXT
+        | DNS_RECORD_TYPE_PTR => {
             js.set_string_from_bytes("rdata", &answer.data);
-        },
+        }
         DNS_RECORD_TYPE_SSHFP => {
             if let Some(sshfp) = dns_log_sshfp(&answer) {
                 js.set("sshfp", sshfp);
             }
-        },
+        }
         _ => {}
     }
 
     return js;
 }
 
-fn dns_log_json_failure_v1(r: &DNSResponse, index: usize, flags: u64)
-                        -> * mut JsonT {
+fn dns_log_json_failure_v1(
+    r: &DNSResponse,
+    index: usize,
+    flags: u64,
+) -> *mut JsonT {
     if index >= r.queries.len() {
         return std::ptr::null_mut();
     }
@@ -674,11 +669,11 @@ fn dns_log_json_failure_v1(r: &DNSResponse, index: usize, flags: u64)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_log_json_answer_v1(tx: &mut DNSTransaction,
-                                         i: libc::uint16_t,
-                                         flags: libc::uint64_t)
-                                         -> *mut JsonT
-{
+pub extern "C" fn rs_dns_log_json_answer_v1(
+    tx: &mut DNSTransaction,
+    i: libc::uint16_t,
+    flags: libc::uint64_t,
+) -> *mut JsonT {
     let index = i as usize;
     // Note for loop over Option for easier break out to default
     // return value.
@@ -702,11 +697,11 @@ pub extern "C" fn rs_dns_log_json_answer_v1(tx: &mut DNSTransaction,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_log_json_authority_v1(tx: &mut DNSTransaction,
-                                            i: libc::uint16_t,
-                                            flags: libc::uint64_t)
-                                            -> *mut JsonT
-{
+pub extern "C" fn rs_dns_log_json_authority_v1(
+    tx: &mut DNSTransaction,
+    i: libc::uint16_t,
+    flags: libc::uint64_t,
+) -> *mut JsonT {
     let index = i as usize;
     if let &Some(ref response) = &tx.response {
         if index < response.authorities.len() {

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -17,29 +17,26 @@
 
 use std::os::raw::c_int;
 
-use lua::*;
 use dns::dns::*;
 use dns::log::*;
+use lua::*;
 
 #[no_mangle]
-pub extern "C" fn rs_dns_lua_get_tx_id(clua: &mut CLuaState,
-                                       tx: &mut DNSTransaction)
-{
-    let lua = LuaState{
-        lua: clua,
-    };
+pub extern "C" fn rs_dns_lua_get_tx_id(
+    clua: &mut CLuaState,
+    tx: &mut DNSTransaction,
+) {
+    let lua = LuaState { lua: clua };
 
     lua.pushinteger(tx.tx_id() as i64);
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_lua_get_rrname(clua: &mut CLuaState,
-                                        tx: &mut DNSTransaction)
-                                        -> c_int
-{
-    let lua = LuaState{
-        lua: clua,
-    };
+pub extern "C" fn rs_dns_lua_get_rrname(
+    clua: &mut CLuaState,
+    tx: &mut DNSTransaction,
+) -> c_int {
+    let lua = LuaState { lua: clua };
 
     if let &Some(ref request) = &tx.request {
         for query in &request.queries {
@@ -57,13 +54,11 @@ pub extern "C" fn rs_dns_lua_get_rrname(clua: &mut CLuaState,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_lua_get_query_table(clua: &mut CLuaState,
-                                             tx: &mut DNSTransaction)
-                                             -> c_int
-{
-    let lua = LuaState{
-        lua: clua,
-    };
+pub extern "C" fn rs_dns_lua_get_query_table(
+    clua: &mut CLuaState,
+    tx: &mut DNSTransaction,
+) -> c_int {
+    let lua = LuaState { lua: clua };
 
     let mut i: i64 = 0;
 
@@ -115,13 +110,11 @@ pub extern "C" fn rs_dns_lua_get_query_table(clua: &mut CLuaState,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
-                                              tx: &mut DNSTransaction)
-                                              -> c_int
-{
-    let lua = LuaState{
-        lua: clua,
-    };
+pub extern "C" fn rs_dns_lua_get_answer_table(
+    clua: &mut CLuaState,
+    tx: &mut DNSTransaction,
+) -> c_int {
+    let lua = LuaState { lua: clua };
 
     let mut i: i64 = 0;
 
@@ -169,13 +162,11 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_lua_get_authority_table(clua: &mut CLuaState,
-                                                 tx: &mut DNSTransaction)
-                                                 -> c_int
-{
-    let lua = LuaState{
-        lua: clua,
-    };
+pub extern "C" fn rs_dns_lua_get_authority_table(
+    clua: &mut CLuaState,
+    tx: &mut DNSTransaction,
+) -> c_int {
+    let lua = LuaState { lua: clua };
 
     let mut i: i64 = 0;
 

--- a/rust/src/dns/mod.rs
+++ b/rust/src/dns/mod.rs
@@ -15,9 +15,9 @@
  * 02110-1301, USA.
  */
 
-pub mod parser;
 pub mod dns;
 pub mod log;
+pub mod parser;
 
 #[cfg(feature = "lua")]
 pub mod lua;

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -19,7 +19,7 @@
 
 use nom::{be_u8, be_u16, be_u32};
 use nom;
-use dns::dns::*;
+use crate::dns::dns::*;
 
 /// Parse a DNS header.
 named!(pub dns_parse_header<DNSHeader>,
@@ -314,8 +314,8 @@ pub fn dns_parse_request<'a>(input: &'a [u8]) -> nom::IResult<&[u8], DNSRequest>
 #[cfg(test)]
 mod tests {
 
-    use dns::dns::{DNSHeader,DNSAnswerEntry};
-    use dns::parser::*;
+    use crate::dns::dns::{DNSHeader,DNSAnswerEntry};
+    use crate::dns::parser::*;
     use nom::IResult;
 
     /// Parse a simple name with no pointers.

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -17,9 +17,9 @@
 
 //! Nom parsers for DNS.
 
-use nom::{be_u8, be_u16, be_u32};
-use nom;
 use crate::dns::dns::*;
+use nom;
+use nom::{be_u16, be_u32, be_u8};
 
 /// Parse a DNS header.
 named!(pub dns_parse_header<DNSHeader>,
@@ -48,9 +48,10 @@ named!(pub dns_parse_header<DNSHeader>,
 /// Parameters:
 ///   start: the start of the name
 ///   message: the complete message that start is a part of
-pub fn dns_parse_name<'a, 'b>(start: &'b [u8],
-                              message: &'b [u8])
-                              -> nom::IResult<&'b [u8], Vec<u8>> {
+pub fn dns_parse_name<'a, 'b>(
+    start: &'b [u8],
+    message: &'b [u8],
+) -> nom::IResult<&'b [u8], Vec<u8>> {
     let mut pos = start;
     let mut pivot = start;
     let mut name: Vec<u8> = Vec::with_capacity(32);
@@ -76,8 +77,10 @@ pub fn dns_parse_name<'a, 'b>(start: &'b [u8],
                     pos = rem;
                 }
                 _ => {
-                    return nom::IResult::Error(
-                        error_position!(nom::ErrorKind::OctDigit, pos));
+                    return nom::IResult::Error(error_position!(
+                        nom::ErrorKind::OctDigit,
+                        pos
+                    ));
                 }
             }
         } else if len & 0b1100_0000 == 0b1100_0000 {
@@ -85,8 +88,10 @@ pub fn dns_parse_name<'a, 'b>(start: &'b [u8],
                 nom::IResult::Done(rem, leader) => {
                     let offset = leader & 0x3fff;
                     if offset as usize > message.len() {
-                        return nom::IResult::Error(
-                            error_position!(nom::ErrorKind::OctDigit, pos));
+                        return nom::IResult::Error(error_position!(
+                            nom::ErrorKind::OctDigit,
+                            pos
+                        ));
                     }
                     pos = &message[offset as usize..];
                     if pivot == start {
@@ -94,22 +99,27 @@ pub fn dns_parse_name<'a, 'b>(start: &'b [u8],
                     }
                 }
                 _ => {
-                    return nom::IResult::Error(
-                        error_position!(nom::ErrorKind::OctDigit, pos));
+                    return nom::IResult::Error(error_position!(
+                        nom::ErrorKind::OctDigit,
+                        pos
+                    ));
                 }
             }
         } else {
-            return nom::IResult::Error(
-                error_position!(nom::ErrorKind::OctDigit, pos));
+            return nom::IResult::Error(error_position!(
+                nom::ErrorKind::OctDigit,
+                pos
+            ));
         }
 
         // Return error if we've looped a certain number of times.
         count += 1;
         if count > 255 {
-            return nom::IResult::Error(
-                error_position!(nom::ErrorKind::OctDigit, pos));
+            return nom::IResult::Error(error_position!(
+                nom::ErrorKind::OctDigit,
+                pos
+            ));
         }
-
     }
 
     // If we followed a pointer we return the position after the first
@@ -120,7 +130,6 @@ pub fn dns_parse_name<'a, 'b>(start: &'b [u8],
         return nom::IResult::Done(pivot, name);
     }
     return nom::IResult::Done(pos, name);
-
 }
 
 /// Parse answer entries.
@@ -133,28 +142,28 @@ pub fn dns_parse_name<'a, 'b>(start: &'b [u8],
 /// This function could be a made a whole lot simpler if we logged a
 /// multi-string TXT entry as a single quote string, similar to the
 /// output of dig. Something to consider for a future version.
-fn dns_parse_answer<'a>(slice: &'a [u8], message: &'a [u8], count: usize)
-                        -> nom::IResult<&'a [u8], Vec<DNSAnswerEntry>> {
-
+fn dns_parse_answer<'a>(
+    slice: &'a [u8],
+    message: &'a [u8],
+    count: usize,
+) -> nom::IResult<&'a [u8], Vec<DNSAnswerEntry>> {
     let mut answers = Vec::new();
     let mut input = slice;
 
     for _ in 0..count {
-        match closure!(&'a [u8], do_parse!(
-            name: apply!(dns_parse_name, message) >>
-                rrtype: be_u16 >>
-                rrclass: be_u16 >>
-                ttl: be_u32 >>
-                data_len: be_u16 >>
-                data: take!(data_len) >>
-                (
-                    name,
-                    rrtype,
-                    rrclass,
-                    ttl,
-                    data
-                )
-        ))(input) {
+        match closure!(
+            &'a [u8],
+            do_parse!(
+                name: apply!(dns_parse_name, message)
+                    >> rrtype: be_u16
+                    >> rrclass: be_u16
+                    >> ttl: be_u32
+                    >> data_len: be_u16
+                    >> data: take!(data_len)
+                    >> (name, rrtype, rrclass, ttl, data)
+            )
+        )(input)
+        {
             nom::IResult::Done(rem, val) => {
                 let name = val.0;
                 let rrtype = val.1;
@@ -177,15 +186,22 @@ fn dns_parse_answer<'a>(slice: &'a [u8], message: &'a [u8], count: usize)
                     }
                 };
                 let result: nom::IResult<&'a [u8], Vec<Vec<u8>>> =
-                    closure!(&'a [u8], do_parse!(
-                        rdata: many_m_n!(1, n,
-                                         apply!(dns_parse_rdata, message, rrtype))
-                            >> (rdata)
-                    ))(data);
+                    closure!(
+                        &'a [u8],
+                        do_parse!(
+                            rdata:
+                                many_m_n!(
+                                    1,
+                                    n,
+                                    apply!(dns_parse_rdata, message, rrtype)
+                                )
+                                >> (rdata)
+                        )
+                    )(data);
                 match result {
                     nom::IResult::Done(_, rdatas) => {
                         for rdata in rdatas {
-                            answers.push(DNSAnswerEntry{
+                            answers.push(DNSAnswerEntry {
                                 name: name.clone(),
                                 rrtype: rrtype,
                                 rrclass: rrclass,
@@ -215,27 +231,35 @@ fn dns_parse_answer<'a>(slice: &'a [u8], message: &'a [u8], count: usize)
     return nom::IResult::Done(input, answers);
 }
 
-
 /// Parse a DNS response.
-pub fn dns_parse_response<'a>(slice: &'a [u8])
-                              -> nom::IResult<&[u8], DNSResponse> {
-    let response = closure!(&'a [u8], do_parse!(
-        header: dns_parse_header
-            >> queries: count!(
-                apply!(dns_parse_query, slice), header.questions as usize)
-            >> answers: apply!(
-                dns_parse_answer, slice, header.answer_rr as usize)
-            >> authorities: apply!(
-                dns_parse_answer, slice, header.authority_rr as usize)
-            >> (
-                DNSResponse{
+pub fn dns_parse_response<'a>(
+    slice: &'a [u8],
+) -> nom::IResult<&[u8], DNSResponse> {
+    let response = closure!(
+        &'a [u8],
+        do_parse!(
+            header: dns_parse_header
+                >> queries:
+                    count!(
+                        apply!(dns_parse_query, slice),
+                        header.questions as usize
+                    )
+                >> answers:
+                    apply!(dns_parse_answer, slice, header.answer_rr as usize)
+                >> authorities:
+                    apply!(
+                        dns_parse_answer,
+                        slice,
+                        header.authority_rr as usize
+                    )
+                >> (DNSResponse {
                     header: header,
                     queries: queries,
                     answers: answers,
                     authorities: authorities,
-                }
-            )
-    ))(slice);
+                })
+        )
+    )(slice);
 
     return response;
 }
@@ -245,76 +269,80 @@ pub fn dns_parse_response<'a>(slice: &'a [u8])
 /// Arguments are suitable for using with apply!:
 ///
 ///    apply!(complete_dns_message_buffer)
-pub fn dns_parse_query<'a>(input: &'a [u8],
-                           message: &'a [u8])
-                           -> nom::IResult<&'a [u8], DNSQueryEntry> {
-    return closure!(&'a [u8], do_parse!(
-        name: apply!(dns_parse_name, message) >>
-        rrtype: be_u16 >>
-        rrclass: be_u16 >>
-            (
-                DNSQueryEntry{
+pub fn dns_parse_query<'a>(
+    input: &'a [u8],
+    message: &'a [u8],
+) -> nom::IResult<&'a [u8], DNSQueryEntry> {
+    return closure!(
+        &'a [u8],
+        do_parse!(
+            name: apply!(dns_parse_name, message)
+                >> rrtype: be_u16
+                >> rrclass: be_u16
+                >> (DNSQueryEntry {
                     name: name,
                     rrtype: rrtype,
                     rrclass: rrclass,
-                }
-            )
-    ))(input);
+                })
+        )
+    )(input);
 }
 
-pub fn dns_parse_rdata<'a>(input: &'a [u8], message: &'a [u8], rrtype: u16)
-    -> nom::IResult<&'a [u8], Vec<u8>>
-{
+pub fn dns_parse_rdata<'a>(
+    input: &'a [u8],
+    message: &'a [u8],
+    rrtype: u16,
+) -> nom::IResult<&'a [u8], Vec<u8>> {
     match rrtype {
-        DNS_RECORD_TYPE_CNAME |
-        DNS_RECORD_TYPE_PTR |
-        DNS_RECORD_TYPE_SOA => {
+        DNS_RECORD_TYPE_CNAME | DNS_RECORD_TYPE_PTR | DNS_RECORD_TYPE_SOA => {
             dns_parse_name(input, message)
-        },
+        }
         DNS_RECORD_TYPE_MX => {
             // For MX we we skip over the preference field before
             // parsing out the name.
-            closure!(&'a [u8], do_parse!(
-                be_u16 >>
-                name: apply!(dns_parse_name, message) >>
-                    (name)
-            ))(input)
-        },
-        DNS_RECORD_TYPE_TXT => {
-            closure!(&'a [u8], do_parse!(
-                len: be_u8 >>
-                txt: take!(len) >>
-                    (txt.to_vec())
-            ))(input)
-        },
-        _ => {
-            closure!(&'a [u8], do_parse!(
-                data: take!(input.len()) >>
-                    (data.to_vec())
-            ))(input)
+            closure!(
+                &'a [u8],
+                do_parse!(
+                    be_u16 >> name: apply!(dns_parse_name, message) >> (name)
+                )
+            )(input)
         }
+        DNS_RECORD_TYPE_TXT => closure!(
+            &'a [u8],
+            do_parse!(len: be_u8 >> txt: take!(len) >> (txt.to_vec()))
+        )(input),
+        _ => closure!(
+            &'a [u8],
+            do_parse!(data: take!(input.len()) >> (data.to_vec()))
+        )(input),
     }
 }
 
 /// Parse a DNS request.
-pub fn dns_parse_request<'a>(input: &'a [u8]) -> nom::IResult<&[u8], DNSRequest> {
-    return closure!(&'a [u8], do_parse!(
-        header: dns_parse_header >>
-        queries: count!(apply!(dns_parse_query, input),
-                        header.questions as usize) >>
-            (
-                DNSRequest{
+pub fn dns_parse_request<'a>(
+    input: &'a [u8],
+) -> nom::IResult<&[u8], DNSRequest> {
+    return closure!(
+        &'a [u8],
+        do_parse!(
+            header: dns_parse_header
+                >> queries:
+                    count!(
+                        apply!(dns_parse_query, input),
+                        header.questions as usize
+                    )
+                >> (DNSRequest {
                     header: header,
                     queries: queries,
-                }
-            )
-    ))(input);
+                })
+        )
+    )(input);
 }
 
 #[cfg(test)]
 mod tests {
 
-    use crate::dns::dns::{DNSHeader,DNSAnswerEntry};
+    use crate::dns::dns::{DNSAnswerEntry, DNSHeader};
     use crate::dns::parser::*;
     use nom::IResult;
 
@@ -322,7 +350,7 @@ mod tests {
     #[test]
     fn test_dns_parse_name() {
         let buf: &[u8] = &[
-                                                0x09, 0x63, /* .......c */
+            0x09, 0x63, /* .......c */
             0x6c, 0x69, 0x65, 0x6e, 0x74, 0x2d, 0x63, 0x66, /* lient-cf */
             0x07, 0x64, 0x72, 0x6f, 0x70, 0x62, 0x6f, 0x78, /* .dropbox */
             0x03, 0x63, 0x6f, 0x6d, 0x00, 0x00, 0x01, 0x00, /* .com.... */
@@ -344,24 +372,41 @@ mod tests {
     #[test]
     fn test_dns_parse_name_with_pointer() {
         let buf: &[u8] = &[
-            0xd8, 0xcb, 0x8a, 0xed, 0xa1, 0x46, 0x00, 0x15 /* 0   - .....F.. */,
-            0x17, 0x0d, 0x06, 0xf7, 0x08, 0x00, 0x45, 0x00 /* 8   - ......E. */,
-            0x00, 0x7b, 0x71, 0x6e, 0x00, 0x00, 0x39, 0x11 /* 16  - .{qn..9. */,
-            0xf4, 0xd9, 0x08, 0x08, 0x08, 0x08, 0x0a, 0x10 /* 24  - ........ */,
-            0x01, 0x0b, 0x00, 0x35, 0xe1, 0x8e, 0x00, 0x67 /* 32  - ...5...g */,
-            0x60, 0x00, 0xef, 0x08, 0x81, 0x80, 0x00, 0x01 /* 40  - `....... */,
-            0x00, 0x03, 0x00, 0x00, 0x00, 0x01, 0x03, 0x77 /* 48  - .......w */,
-            0x77, 0x77, 0x0c, 0x73, 0x75, 0x72, 0x69, 0x63 /* 56  - ww.suric */,
-            0x61, 0x74, 0x61, 0x2d, 0x69, 0x64, 0x73, 0x03 /* 64  - ata-ids. */,
-            0x6f, 0x72, 0x67, 0x00, 0x00, 0x01, 0x00, 0x01 /* 72  - org..... */,
-            0xc0, 0x0c, 0x00, 0x05, 0x00, 0x01, 0x00, 0x00 /* 80  - ........ */,
-            0x0e, 0x0f, 0x00, 0x02, 0xc0, 0x10, 0xc0, 0x10 /* 88  - ........ */,
-            0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x01, 0x2b /* 96  - .......+ */,
-            0x00, 0x04, 0xc0, 0x00, 0x4e, 0x19, 0xc0, 0x10 /* 104 - ....N... */,
-            0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x01, 0x2b /* 112 - .......+ */,
-            0x00, 0x04, 0xc0, 0x00, 0x4e, 0x18, 0x00, 0x00 /* 120 - ....N... */,
-            0x29, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 /* 128 - )....... */,
-            0x00,                                          /* 136 - . */
+            0xd8, 0xcb, 0x8a, 0xed, 0xa1, 0x46, 0x00,
+            0x15, /* 0   - .....F.. */
+            0x17, 0x0d, 0x06, 0xf7, 0x08, 0x00, 0x45,
+            0x00, /* 8   - ......E. */
+            0x00, 0x7b, 0x71, 0x6e, 0x00, 0x00, 0x39,
+            0x11, /* 16  - .{qn..9. */
+            0xf4, 0xd9, 0x08, 0x08, 0x08, 0x08, 0x0a,
+            0x10, /* 24  - ........ */
+            0x01, 0x0b, 0x00, 0x35, 0xe1, 0x8e, 0x00,
+            0x67, /* 32  - ...5...g */
+            0x60, 0x00, 0xef, 0x08, 0x81, 0x80, 0x00,
+            0x01, /* 40  - `....... */
+            0x00, 0x03, 0x00, 0x00, 0x00, 0x01, 0x03,
+            0x77, /* 48  - .......w */
+            0x77, 0x77, 0x0c, 0x73, 0x75, 0x72, 0x69,
+            0x63, /* 56  - ww.suric */
+            0x61, 0x74, 0x61, 0x2d, 0x69, 0x64, 0x73,
+            0x03, /* 64  - ata-ids. */
+            0x6f, 0x72, 0x67, 0x00, 0x00, 0x01, 0x00,
+            0x01, /* 72  - org..... */
+            0xc0, 0x0c, 0x00, 0x05, 0x00, 0x01, 0x00,
+            0x00, /* 80  - ........ */
+            0x0e, 0x0f, 0x00, 0x02, 0xc0, 0x10, 0xc0,
+            0x10, /* 88  - ........ */
+            0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x01,
+            0x2b, /* 96  - .......+ */
+            0x00, 0x04, 0xc0, 0x00, 0x4e, 0x19, 0xc0,
+            0x10, /* 104 - ....N... */
+            0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x01,
+            0x2b, /* 112 - .......+ */
+            0x00, 0x04, 0xc0, 0x00, 0x4e, 0x18, 0x00,
+            0x00, /* 120 - ....N... */
+            0x29, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, /* 128 - )....... */
+            0x00, /* 136 - . */
         ];
 
         // The DNS payload starts at offset 42.
@@ -370,53 +415,77 @@ mod tests {
         // The name at offset 54 is the complete name.
         let start1 = &buf[54..];
         let res1 = dns_parse_name(start1, message);
-        assert_eq!(res1,
-                   IResult::Done(&start1[22..],
-                                 "www.suricata-ids.org".as_bytes().to_vec()));
+        assert_eq!(
+            res1,
+            IResult::Done(
+                &start1[22..],
+                "www.suricata-ids.org".as_bytes().to_vec()
+            )
+        );
 
         // The second name starts at offset 80, but is just a pointer
         // to the first.
         let start2 = &buf[80..];
         let res2 = dns_parse_name(start2, message);
-        assert_eq!(res2,
-                   IResult::Done(&start2[2..],
-                                 "www.suricata-ids.org".as_bytes().to_vec()));
+        assert_eq!(
+            res2,
+            IResult::Done(
+                &start2[2..],
+                "www.suricata-ids.org".as_bytes().to_vec()
+            )
+        );
 
         // The third name starts at offset 94, but is a pointer to a
         // portion of the first.
         let start3 = &buf[94..];
         let res3 = dns_parse_name(start3, message);
-        assert_eq!(res3,
-                   IResult::Done(&start3[2..],
-                                 "suricata-ids.org".as_bytes().to_vec()));
+        assert_eq!(
+            res3,
+            IResult::Done(&start3[2..], "suricata-ids.org".as_bytes().to_vec())
+        );
 
         // The fourth name starts at offset 110, but is a pointer to a
         // portion of the first.
         let start4 = &buf[110..];
         let res4 = dns_parse_name(start4, message);
-        assert_eq!(res4,
-                   IResult::Done(&start4[2..],
-                                 "suricata-ids.org".as_bytes().to_vec()));
+        assert_eq!(
+            res4,
+            IResult::Done(&start4[2..], "suricata-ids.org".as_bytes().to_vec())
+        );
     }
 
     #[test]
     fn test_dns_parse_name_double_pointer() {
         let buf: &[u8] = &[
-            0xd8, 0xcb, 0x8a, 0xed, 0xa1, 0x46, 0x00, 0x15 /* 0:   .....F.. */,
-            0x17, 0x0d, 0x06, 0xf7, 0x08, 0x00, 0x45, 0x00 /* 8:   ......E. */,
-            0x00, 0x66, 0x5e, 0x20, 0x40, 0x00, 0x40, 0x11 /* 16:  .f^ @.@. */,
-            0xc6, 0x3b, 0x0a, 0x10, 0x01, 0x01, 0x0a, 0x10 /* 24:  .;...... */,
-            0x01, 0x0b, 0x00, 0x35, 0xc2, 0x21, 0x00, 0x52 /* 32:  ...5.!.R */,
-            0x35, 0xc5, 0x0d, 0x4f, 0x81, 0x80, 0x00, 0x01 /* 40:  5..O.... */,
-            0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x05, 0x62 /* 48:  .......b */,
-            0x6c, 0x6f, 0x63, 0x6b, 0x07, 0x64, 0x72, 0x6f /* 56:  lock.dro */,
-            0x70, 0x62, 0x6f, 0x78, 0x03, 0x63, 0x6f, 0x6d /* 64:  pbox.com */,
-            0x00, 0x00, 0x01, 0x00, 0x01, 0xc0, 0x0c, 0x00 /* 72:  ........ */,
-            0x05, 0x00, 0x01, 0x00, 0x00, 0x00, 0x09, 0x00 /* 80:  ........ */,
-            0x0b, 0x05, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x02 /* 88:  ..block. */,
-            0x67, 0x31, 0xc0, 0x12, 0xc0, 0x2f, 0x00, 0x01 /* 96:  g1.../.. */,
-            0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x04 /* 104: ........ */,
-            0x2d, 0x3a, 0x46, 0x21                         /* 112: -:F!     */
+            0xd8, 0xcb, 0x8a, 0xed, 0xa1, 0x46, 0x00,
+            0x15, /* 0:   .....F.. */
+            0x17, 0x0d, 0x06, 0xf7, 0x08, 0x00, 0x45,
+            0x00, /* 8:   ......E. */
+            0x00, 0x66, 0x5e, 0x20, 0x40, 0x00, 0x40,
+            0x11, /* 16:  .f^ @.@. */
+            0xc6, 0x3b, 0x0a, 0x10, 0x01, 0x01, 0x0a,
+            0x10, /* 24:  .;...... */
+            0x01, 0x0b, 0x00, 0x35, 0xc2, 0x21, 0x00,
+            0x52, /* 32:  ...5.!.R */
+            0x35, 0xc5, 0x0d, 0x4f, 0x81, 0x80, 0x00,
+            0x01, /* 40:  5..O.... */
+            0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x05,
+            0x62, /* 48:  .......b */
+            0x6c, 0x6f, 0x63, 0x6b, 0x07, 0x64, 0x72,
+            0x6f, /* 56:  lock.dro */
+            0x70, 0x62, 0x6f, 0x78, 0x03, 0x63, 0x6f,
+            0x6d, /* 64:  pbox.com */
+            0x00, 0x00, 0x01, 0x00, 0x01, 0xc0, 0x0c,
+            0x00, /* 72:  ........ */
+            0x05, 0x00, 0x01, 0x00, 0x00, 0x00, 0x09,
+            0x00, /* 80:  ........ */
+            0x0b, 0x05, 0x62, 0x6c, 0x6f, 0x63, 0x6b,
+            0x02, /* 88:  ..block. */
+            0x67, 0x31, 0xc0, 0x12, 0xc0, 0x2f, 0x00,
+            0x01, /* 96:  g1.../.. */
+            0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00,
+            0x04, /* 104: ........ */
+            0x2d, 0x3a, 0x46, 0x21, /* 112: -:F!     */
         ];
 
         // The start of the DNS message in the above packet.
@@ -428,46 +497,54 @@ mod tests {
         let start: &[u8] = &buf[100..];
 
         let res = dns_parse_name(start, message);
-        assert_eq!(res,
-                   IResult::Done(&start[2..],
-                                 "block.g1.dropbox.com".as_bytes().to_vec()));
+        assert_eq!(
+            res,
+            IResult::Done(
+                &start[2..],
+                "block.g1.dropbox.com".as_bytes().to_vec()
+            )
+        );
     }
 
     #[test]
     fn test_dns_parse_request() {
         // DNS request from dig-a-www.suricata-ids.org.pcap.
         let pkt: &[u8] = &[
-                        0x8d, 0x32, 0x01, 0x20, 0x00, 0x01, /* ...2. .. */
+            0x8d, 0x32, 0x01, 0x20, 0x00, 0x01, /* ...2. .. */
             0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x03, 0x77, /* .......w */
             0x77, 0x77, 0x0c, 0x73, 0x75, 0x72, 0x69, 0x63, /* ww.suric */
             0x61, 0x74, 0x61, 0x2d, 0x69, 0x64, 0x73, 0x03, /* ata-ids. */
             0x6f, 0x72, 0x67, 0x00, 0x00, 0x01, 0x00, 0x01, /* org..... */
             0x00, 0x00, 0x29, 0x10, 0x00, 0x00, 0x00, 0x00, /* ..)..... */
-            0x00, 0x00, 0x00                                /* ... */
+            0x00, 0x00, 0x00, /* ... */
         ];
 
         let res = dns_parse_request(pkt);
         match res {
             IResult::Done(rem, request) => {
-
                 // For now we have some remainder data as there is an
                 // additional record type we don't parse yet.
                 assert!(rem.len() > 0);
 
-                assert_eq!(request.header, DNSHeader {
-                    tx_id: 0x8d32,
-                    flags: 0x0120,
-                    questions: 1,
-                    answer_rr: 0,
-                    authority_rr: 0,
-                    additional_rr: 1,
-                });
+                assert_eq!(
+                    request.header,
+                    DNSHeader {
+                        tx_id: 0x8d32,
+                        flags: 0x0120,
+                        questions: 1,
+                        answer_rr: 0,
+                        authority_rr: 0,
+                        additional_rr: 1,
+                    }
+                );
 
                 assert_eq!(request.queries.len(), 1);
 
                 let query = &request.queries[0];
-                assert_eq!(query.name,
-                           "www.suricata-ids.org".as_bytes().to_vec());
+                assert_eq!(
+                    query.name,
+                    "www.suricata-ids.org".as_bytes().to_vec()
+                );
                 assert_eq!(query.rrtype, 1);
                 assert_eq!(query.rrclass, 1);
             }
@@ -481,7 +558,7 @@ mod tests {
     fn test_dns_parse_response() {
         // DNS response from dig-a-www.suricata-ids.org.pcap.
         let pkt: &[u8] = &[
-                        0x8d, 0x32, 0x81, 0xa0, 0x00, 0x01, /* ...2.... */
+            0x8d, 0x32, 0x81, 0xa0, 0x00, 0x01, /* ...2.... */
             0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x03, 0x77, /* .......w */
             0x77, 0x77, 0x0c, 0x73, 0x75, 0x72, 0x69, 0x63, /* ww.suric */
             0x61, 0x74, 0x61, 0x2d, 0x69, 0x64, 0x73, 0x03, /* ata-ids. */
@@ -493,55 +570,66 @@ mod tests {
             0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0xf4, /* ........ */
             0x00, 0x04, 0xc0, 0x00, 0x4e, 0x18, 0xc0, 0x32, /* ....N..2 */
             0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0xf4, /* ........ */
-            0x00, 0x04, 0xc0, 0x00, 0x4e, 0x19              /* ....N. */
+            0x00, 0x04, 0xc0, 0x00, 0x4e, 0x19, /* ....N. */
         ];
 
         let res = dns_parse_response(pkt);
         match res {
             IResult::Done(rem, response) => {
-
                 // The response should be full parsed.
                 assert_eq!(rem.len(), 0);
 
-                assert_eq!(response.header, DNSHeader{
-                    tx_id: 0x8d32,
-                    flags: 0x81a0,
-                    questions: 1,
-                    answer_rr: 3,
-                    authority_rr: 0,
-                    additional_rr: 0,
-                });
+                assert_eq!(
+                    response.header,
+                    DNSHeader {
+                        tx_id: 0x8d32,
+                        flags: 0x81a0,
+                        questions: 1,
+                        answer_rr: 3,
+                        authority_rr: 0,
+                        additional_rr: 0,
+                    }
+                );
 
                 assert_eq!(response.answers.len(), 3);
 
                 let answer1 = &response.answers[0];
-                assert_eq!(answer1.name,
-                           "www.suricata-ids.org".as_bytes().to_vec());
+                assert_eq!(
+                    answer1.name,
+                    "www.suricata-ids.org".as_bytes().to_vec()
+                );
                 assert_eq!(answer1.rrtype, 5);
                 assert_eq!(answer1.rrclass, 1);
                 assert_eq!(answer1.ttl, 3544);
-                assert_eq!(answer1.data,
-                           "suricata-ids.org".as_bytes().to_vec());
+                assert_eq!(
+                    answer1.data,
+                    "suricata-ids.org".as_bytes().to_vec()
+                );
 
                 let answer2 = &response.answers[1];
-                assert_eq!(answer2, &DNSAnswerEntry{
-                    name: "suricata-ids.org".as_bytes().to_vec(),
-                    rrtype: 1,
-                    rrclass: 1,
-                    ttl: 244,
-                    data: [192, 0, 78, 24].to_vec(),
-                });
+                assert_eq!(
+                    answer2,
+                    &DNSAnswerEntry {
+                        name: "suricata-ids.org".as_bytes().to_vec(),
+                        rrtype: 1,
+                        rrclass: 1,
+                        ttl: 244,
+                        data: [192, 0, 78, 24].to_vec(),
+                    }
+                );
 
                 let answer3 = &response.answers[2];
-                assert_eq!(answer3, &DNSAnswerEntry{
-                    name: "suricata-ids.org".as_bytes().to_vec(),
-                    rrtype: 1,
-                    rrclass: 1,
-                    ttl: 244,
-                    data: [192, 0, 78, 25].to_vec(),
-                })
-
-            },
+                assert_eq!(
+                    answer3,
+                    &DNSAnswerEntry {
+                        name: "suricata-ids.org".as_bytes().to_vec(),
+                        rrtype: 1,
+                        rrclass: 1,
+                        ttl: 244,
+                        data: [192, 0, 78, 25].to_vec(),
+                    }
+                )
+            }
             _ => {
                 assert!(false);
             }

--- a/rust/src/filecontainer.rs
+++ b/rust/src/filecontainer.rs
@@ -16,69 +16,98 @@
  */
 
 extern crate libc;
+use libc::c_void;
 use std::ptr;
-use libc::{c_void};
 
-use crate::log::*;
 use crate::core::*;
+use crate::log::*;
 
 pub struct File;
 #[repr(C)]
 #[derive(Debug)]
 pub struct FileContainer {
-    head: * mut c_void,
-    tail: * mut c_void,
+    head: *mut c_void,
+    tail: *mut c_void,
 }
 
 impl FileContainer {
     pub fn default() -> FileContainer {
-        FileContainer { head:ptr::null_mut(), tail:ptr::null_mut() }
+        FileContainer {
+            head: ptr::null_mut(),
+            tail: ptr::null_mut(),
+        }
     }
     pub fn free(&mut self) {
         SCLogDebug!("freeing self");
-        match unsafe {SC} {
+        match unsafe { SC } {
             None => panic!("BUG no suricata_config"),
             Some(c) => {
                 (c.FileContainerRecycle)(&self);
-            },
+            }
         }
     }
 
-    pub fn file_open(&mut self, cfg: &'static SuricataFileContext, track_id: &u32, name: &[u8], flags: u16) -> i32 {
-        match unsafe {SC} {
+    pub fn file_open(
+        &mut self,
+        cfg: &'static SuricataFileContext,
+        track_id: &u32,
+        name: &[u8],
+        flags: u16,
+    ) -> i32 {
+        match unsafe { SC } {
             None => panic!("BUG no suricata_config"),
             Some(c) => {
                 SCLogDebug!("FILE {:p} OPEN flags {:04X}", &self, flags);
 
-                let res = (c.FileOpenFile)(&self, cfg.files_sbcfg, *track_id,
-                        name.as_ptr(), name.len() as u16,
-                        ptr::null(), 0u32, flags);
+                let res = (c.FileOpenFile)(
+                    &self,
+                    cfg.files_sbcfg,
+                    *track_id,
+                    name.as_ptr(),
+                    name.len() as u16,
+                    ptr::null(),
+                    0u32,
+                    flags,
+                );
                 res
             }
         }
     }
 
-    pub fn file_append(&mut self, track_id: &u32, data: &[u8], is_gap: bool) -> i32 {
+    pub fn file_append(
+        &mut self,
+        track_id: &u32,
+        data: &[u8],
+        is_gap: bool,
+    ) -> i32 {
         SCLogDebug!("FILECONTAINER: append {}", data.len());
         if data.len() == 0 {
-            return 0
+            return 0;
         }
-        match unsafe {SC} {
+        match unsafe { SC } {
             None => panic!("BUG no suricata_config"),
             Some(c) => {
                 let res = match is_gap {
                     false => {
                         SCLogDebug!("appending file data");
-                        let r = (c.FileAppendData)(&self, *track_id,
-                                data.as_ptr(), data.len() as u32);
+                        let r = (c.FileAppendData)(
+                            &self,
+                            *track_id,
+                            data.as_ptr(),
+                            data.len() as u32,
+                        );
                         r
-                    },
+                    }
                     true => {
                         SCLogDebug!("appending GAP");
-                        let r = (c.FileAppendGAP)(&self, *track_id,
-                                data.as_ptr(), data.len() as u32);
+                        let r = (c.FileAppendGAP)(
+                            &self,
+                            *track_id,
+                            data.as_ptr(),
+                            data.len() as u32,
+                        );
                         r
-                    },
+                    }
                 };
                 res
             }
@@ -88,19 +117,24 @@ impl FileContainer {
     pub fn file_close(&mut self, track_id: &u32, flags: u16) -> i32 {
         SCLogDebug!("FILECONTAINER: CLOSEing");
 
-        match unsafe {SC} {
+        match unsafe { SC } {
             None => panic!("BUG no suricata_config"),
             Some(c) => {
-                let res = (c.FileCloseFile)(&self, *track_id, ptr::null(), 0u32, flags);
+                let res = (c.FileCloseFile)(
+                    &self,
+                    *track_id,
+                    ptr::null(),
+                    0u32,
+                    flags,
+                );
                 res
             }
         }
-
     }
 
     pub fn files_prune(&mut self) {
         SCLogDebug!("FILECONTAINER: pruning");
-        match unsafe {SC} {
+        match unsafe { SC } {
             None => panic!("BUG no suricata_config"),
             Some(c) => {
                 (c.FilePrune)(&self);
@@ -109,7 +143,7 @@ impl FileContainer {
     }
 
     pub fn file_set_txid_on_last_file(&mut self, tx_id: u64) {
-        match unsafe {SC} {
+        match unsafe { SC } {
             None => panic!("BUG no suricata_config"),
             Some(c) => {
                 (c.FileSetTx)(&self, tx_id);

--- a/rust/src/filecontainer.rs
+++ b/rust/src/filecontainer.rs
@@ -19,8 +19,8 @@ extern crate libc;
 use std::ptr;
 use libc::{c_void};
 
-use log::*;
-use core::*;
+use crate::log::*;
+use crate::core::*;
 
 pub struct File;
 #[repr(C)]

--- a/rust/src/filetracker.rs
+++ b/rust/src/filetracker.rs
@@ -29,11 +29,11 @@
  */
 
 extern crate libc;
-use log::*;
-use core::*;
+use crate::log::*;
+use crate::core::*;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
-use filecontainer::*;
+use crate::filecontainer::*;
 
 #[derive(Debug)]
 pub struct FileChunk {

--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -23,7 +23,7 @@ use std::str;
 use std;
 use std::str::FromStr;
 
-use log::*;
+use crate::log::*;
 
 // We transform an integer string into a i64, ignoring surrounding whitespaces
 // We look for a digit suite, and try to convert it.

--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -18,9 +18,9 @@
 extern crate libc;
 extern crate nom;
 
-use nom::{digit};
-use std::str;
+use nom::digit;
 use std;
+use std::str;
 use std::str::FromStr;
 
 use crate::log::*;
@@ -29,14 +29,9 @@ use crate::log::*;
 // We look for a digit suite, and try to convert it.
 // If either str::from_utf8 or FromStr::from_str fail,
 // we fallback to the parens parser defined above
-named!(getu16<u16>,
-    map_res!(
-      map_res!(
-        ws!(digit),
-        str::from_utf8
-      ),
-      FromStr::from_str
-    )
+named!(
+    getu16<u16>,
+    map_res!(map_res!(ws!(digit), str::from_utf8), FromStr::from_str)
 );
 
 // 227 Entering Passive Mode (212,27,32,66,221,243).
@@ -56,22 +51,29 @@ named!(pub ftp_pasv_response<u16>,
         )
 );
 
-
 #[no_mangle]
-pub extern "C" fn rs_ftp_pasv_response(input: *const libc::uint8_t, len: libc::uint32_t) -> u16 {
-    let buf = unsafe{std::slice::from_raw_parts(input, len as usize)};
+pub extern "C" fn rs_ftp_pasv_response(
+    input: *const libc::uint8_t,
+    len: libc::uint32_t,
+) -> u16 {
+    let buf = unsafe { std::slice::from_raw_parts(input, len as usize) };
     match ftp_pasv_response(buf) {
         nom::IResult::Done(_, dport) => {
             return dport;
         }
         nom::IResult::Incomplete(_) => {
-            let buf = unsafe{std::slice::from_raw_parts(input, len as usize)};
-            SCLogDebug!("pasv incomplete: '{:?}'", String::from_utf8_lossy(buf));
-        },
+            let buf =
+                unsafe { std::slice::from_raw_parts(input, len as usize) };
+            SCLogDebug!(
+                "pasv incomplete: '{:?}'",
+                String::from_utf8_lossy(buf)
+            );
+        }
         nom::IResult::Error(_) => {
-            let buf = unsafe{std::slice::from_raw_parts(input, len as usize)};
+            let buf =
+                unsafe { std::slice::from_raw_parts(input, len as usize) };
             SCLogDebug!("pasv error on '{:?}'", String::from_utf8_lossy(buf));
-        },
+        }
     }
     return 0;
 }
@@ -90,21 +92,31 @@ named!(pub ftp_epsv_response<u16>,
 );
 
 #[no_mangle]
-pub extern "C" fn rs_ftp_epsv_response(input: *const libc::uint8_t, len: libc::uint32_t) -> u16 {
-    let buf = unsafe{std::slice::from_raw_parts(input, len as usize)};
+pub extern "C" fn rs_ftp_epsv_response(
+    input: *const libc::uint8_t,
+    len: libc::uint32_t,
+) -> u16 {
+    let buf = unsafe { std::slice::from_raw_parts(input, len as usize) };
     match ftp_epsv_response(buf) {
         nom::IResult::Done(_, dport) => {
             return dport;
-        },
+        }
         nom::IResult::Incomplete(_) => {
-            let buf = unsafe{std::slice::from_raw_parts(input, len as usize)};
-            SCLogDebug!("epsv incomplete: '{:?}'", String::from_utf8_lossy(buf));
-        },
+            let buf =
+                unsafe { std::slice::from_raw_parts(input, len as usize) };
+            SCLogDebug!(
+                "epsv incomplete: '{:?}'",
+                String::from_utf8_lossy(buf)
+            );
+        }
         nom::IResult::Error(_) => {
-            let buf = unsafe{std::slice::from_raw_parts(input, len as usize)};
-            SCLogDebug!("epsv incomplete: '{:?}'", String::from_utf8_lossy(buf));
-        },
-
+            let buf =
+                unsafe { std::slice::from_raw_parts(input, len as usize) };
+            SCLogDebug!(
+                "epsv incomplete: '{:?}'",
+                String::from_utf8_lossy(buf)
+            );
+        }
     }
     return 0;
 }

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -17,17 +17,17 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
-use ikev2::ipsec_parser::*;
-use ikev2::state::IKEV2ConnectionState;
-use core;
-use core::{AppProto,Flow,ALPROTO_UNKNOWN,ALPROTO_FAILED,STREAM_TOSERVER,STREAM_TOCLIENT};
-use applayer;
-use parser::*;
+use crate::ikev2::ipsec_parser::*;
+use crate::ikev2::state::IKEV2ConnectionState;
+use crate::core;
+use crate::core::{AppProto,Flow,ALPROTO_UNKNOWN,ALPROTO_FAILED,STREAM_TOSERVER,STREAM_TOCLIENT};
+use crate::applayer;
+use crate::parser::*;
 use libc;
 use std;
 use std::ffi::{CStr,CString};
 
-use log::*;
+use crate::log::*;
 
 use nom::IResult;
 

--- a/rust/src/ikev2/log.rs
+++ b/rust/src/ikev2/log.rs
@@ -17,10 +17,10 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
-use json::*;
-use ikev2::ikev2::{IKEV2State,IKEV2Transaction};
+use crate::json::*;
+use crate::ikev2::ikev2::{IKEV2State,IKEV2Transaction};
 
-use ikev2::ipsec_parser::IKEV2_FLAG_INITIATOR;
+use crate::ikev2::ipsec_parser::IKEV2_FLAG_INITIATOR;
 
 #[no_mangle]
 pub extern "C" fn rs_ikev2_log_json_response(state: &mut IKEV2State, tx: &mut IKEV2Transaction) -> *mut JsonT

--- a/rust/src/ikev2/log.rs
+++ b/rust/src/ikev2/log.rs
@@ -17,14 +17,16 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
+use crate::ikev2::ikev2::{IKEV2State, IKEV2Transaction};
 use crate::json::*;
-use crate::ikev2::ikev2::{IKEV2State,IKEV2Transaction};
 
 use crate::ikev2::ipsec_parser::IKEV2_FLAG_INITIATOR;
 
 #[no_mangle]
-pub extern "C" fn rs_ikev2_log_json_response(state: &mut IKEV2State, tx: &mut IKEV2Transaction) -> *mut JsonT
-{
+pub extern "C" fn rs_ikev2_log_json_response(
+    state: &mut IKEV2State,
+    tx: &mut IKEV2Transaction,
+) -> *mut JsonT {
     let js = Json::object();
     js.set_integer("version_major", tx.hdr.maj_ver as u64);
     js.set_integer("version_minor", tx.hdr.min_ver as u64);

--- a/rust/src/ikev2/mod.rs
+++ b/rust/src/ikev2/mod.rs
@@ -20,5 +20,5 @@
 extern crate ipsec_parser;
 
 pub mod ikev2;
-pub mod state;
 pub mod log;
+pub mod state;

--- a/rust/src/ikev2/state.rs
+++ b/rust/src/ikev2/state.rs
@@ -41,17 +41,19 @@ impl IKEV2ConnectionState {
     pub fn advance(&self, payload: &IkeV2Payload) -> IKEV2ConnectionState {
         use self::IKEV2ConnectionState::*;
         match (self, &payload.content) {
-            (&Init, &IkeV2PayloadContent::SA(_))                          => InitSASent,
-            (&InitSASent, &IkeV2PayloadContent::KE(_))                    => InitKESent,
-            (&InitKESent, &IkeV2PayloadContent::Nonce(_))                 => InitNonceSent,
-            (&InitNonceSent, &IkeV2PayloadContent::SA(_))                 => RespSASent,
-            (&RespSASent, &IkeV2PayloadContent::KE(_))                    => RespKESent,
-            (&RespKESent, &IkeV2PayloadContent::Nonce(_))                 => ParsingDone, // RespNonceSent,
-            (&RespNonceSent, &IkeV2PayloadContent::CertificateRequest(_)) => ParsingDone, // RespCertReqSent,
-            (&ParsingDone,_)                                              => self.clone(),
-            (_, &IkeV2PayloadContent::Notify(_))                          => self.clone(),
-            (_, &IkeV2PayloadContent::Dummy)                              => self.clone(),
-            (_,_) => Invalid,
+            (&Init, &IkeV2PayloadContent::SA(_)) => InitSASent,
+            (&InitSASent, &IkeV2PayloadContent::KE(_)) => InitKESent,
+            (&InitKESent, &IkeV2PayloadContent::Nonce(_)) => InitNonceSent,
+            (&InitNonceSent, &IkeV2PayloadContent::SA(_)) => RespSASent,
+            (&RespSASent, &IkeV2PayloadContent::KE(_)) => RespKESent,
+            (&RespKESent, &IkeV2PayloadContent::Nonce(_)) => ParsingDone, // RespNonceSent,
+            (&RespNonceSent, &IkeV2PayloadContent::CertificateRequest(_)) => {
+                ParsingDone
+            } // RespCertReqSent,
+            (&ParsingDone, _) => self.clone(),
+            (_, &IkeV2PayloadContent::Notify(_)) => self.clone(),
+            (_, &IkeV2PayloadContent::Dummy) => self.clone(),
+            (_, _) => Invalid,
         }
     }
 }

--- a/rust/src/json.rs
+++ b/rust/src/json.rs
@@ -156,7 +156,7 @@ fn to_cstring(val: &[u8]) -> CString {
 #[cfg(test)]
 mod tests {
 
-    use json::to_cstring;
+    use crate::json::to_cstring;
 
     #[test]
     fn test_to_string() {

--- a/rust/src/json.rs
+++ b/rust/src/json.rs
@@ -25,10 +25,13 @@ use std::os::raw::c_char;
 pub enum JsonT {}
 
 /// Expose the jansson functions we need.
-extern {
+extern "C" {
     fn json_object() -> *mut JsonT;
-    fn json_object_set_new(js: *mut JsonT, key: *const c_char,
-                           val: *mut JsonT) -> u32;
+    fn json_object_set_new(
+        js: *mut JsonT,
+        key: *const c_char,
+        val: *mut JsonT,
+    ) -> u32;
 
     fn json_array() -> *mut JsonT;
     fn json_array_append_new(array: *mut JsonT, value: *mut JsonT);
@@ -44,32 +47,31 @@ pub struct Json {
 }
 
 impl Json {
-
     pub fn decref(val: Json) {
-        unsafe{SCJsonDecref(val.js)};
+        unsafe { SCJsonDecref(val.js) };
     }
 
     pub fn object() -> Json {
-        return Json{
-            js: unsafe{json_object()},
-        }
+        return Json {
+            js: unsafe { json_object() },
+        };
     }
 
     pub fn array() -> Json {
-        return Json{
-            js: unsafe{json_array()},
-        }
+        return Json {
+            js: unsafe { json_array() },
+        };
     }
 
     pub fn string(val: &str) -> Json {
-        return Json{
-            js: unsafe{json_string(to_cstring(val.as_bytes()).as_ptr())}
+        return Json {
+            js: unsafe { json_string(to_cstring(val.as_bytes()).as_ptr()) },
         };
     }
 
     pub fn string_from_bytes(val: &[u8]) -> Json {
-        return Json{
-            js: unsafe{json_string(to_cstring(val).as_ptr())}
+        return Json {
+            js: unsafe { json_string(to_cstring(val).as_ptr()) },
         };
     }
 
@@ -79,41 +81,51 @@ impl Json {
 
     pub fn set(&self, key: &str, val: Json) {
         unsafe {
-            json_object_set_new(self.js,
-                                CString::new(key).unwrap().as_ptr(),
-                                val.js);
+            json_object_set_new(
+                self.js,
+                CString::new(key).unwrap().as_ptr(),
+                val.js,
+            );
         }
     }
 
     pub fn set_string_from_bytes(&self, key: &str, val: &[u8]) {
         unsafe {
-            json_object_set_new(self.js,
-                                CString::new(key).unwrap().as_ptr(),
-                                json_string(to_cstring(val).as_ptr()));
+            json_object_set_new(
+                self.js,
+                CString::new(key).unwrap().as_ptr(),
+                json_string(to_cstring(val).as_ptr()),
+            );
         }
     }
 
     pub fn set_string(&self, key: &str, val: &str) {
         unsafe {
-            json_object_set_new(self.js,
-                                CString::new(key).unwrap().as_ptr(),
-                                json_string(to_cstring(val.as_bytes()).as_ptr()));
+            json_object_set_new(
+                self.js,
+                CString::new(key).unwrap().as_ptr(),
+                json_string(to_cstring(val.as_bytes()).as_ptr()),
+            );
         }
     }
 
     pub fn set_integer(&self, key: &str, val: u64) {
         unsafe {
-            json_object_set_new(self.js,
-                                CString::new(key).unwrap().as_ptr(),
-                                json_integer(val));
+            json_object_set_new(
+                self.js,
+                CString::new(key).unwrap().as_ptr(),
+                json_integer(val),
+            );
         }
     }
 
     pub fn set_boolean(&self, key: &str, val: bool) {
         unsafe {
-            json_object_set_new(self.js,
-                                CString::new(key).unwrap().as_ptr(),
-                                SCJsonBool(val));
+            json_object_set_new(
+                self.js,
+                CString::new(key).unwrap().as_ptr(),
+                SCJsonBool(val),
+            );
         }
     }
 
@@ -124,7 +136,10 @@ impl Json {
     }
     pub fn array_append_string(&self, val: &str) {
         unsafe {
-            json_array_append_new(self.js, json_string(to_cstring(val.as_bytes()).as_ptr()));
+            json_array_append_new(
+                self.js,
+                json_string(to_cstring(val.as_bytes()).as_ptr()),
+            );
         }
     }
 }
@@ -147,9 +162,7 @@ fn to_cstring(val: &[u8]) -> CString {
     }
     match CString::new(safe) {
         Ok(cstr) => cstr,
-        _ => {
-            CString::new("<failed to encode string>").unwrap()
-        }
+        _ => CString::new("<failed to encode string>").unwrap(),
     }
 }
 
@@ -160,11 +173,15 @@ mod tests {
 
     #[test]
     fn test_to_string() {
-        assert_eq!("A\\x00A",
-                   to_cstring(&[0x41, 0x00, 0x41]).into_string().unwrap());
+        assert_eq!(
+            "A\\x00A",
+            to_cstring(&[0x41, 0x00, 0x41]).into_string().unwrap()
+        );
         assert_eq!("", to_cstring(&[]).into_string().unwrap());
-        assert_eq!("\\x80\\xf1\\xf2\\xf3",
-                   to_cstring(&[0x80, 0xf1, 0xf2, 0xf3]).into_string().unwrap());
+        assert_eq!(
+            "\\x80\\xf1\\xf2\\xf3",
+            to_cstring(&[0x80, 0xf1, 0xf2, 0xf3]).into_string().unwrap()
+        );
     }
 
 }

--- a/rust/src/kerberos.rs
+++ b/rust/src/kerberos.rs
@@ -15,50 +15,57 @@
  * 02110-1301, USA.
  */
 
-use kerberos_parser::krb5_parser::parse_ap_req;
-use kerberos_parser::krb5::{ApReq,Realm,PrincipalName};
-use nom::{IResult, ErrorKind, le_u16};
 use der_parser;
 use der_parser::parse_der_oid;
+use kerberos_parser::krb5::{ApReq, PrincipalName, Realm};
+use kerberos_parser::krb5_parser::parse_ap_req;
+use nom::{le_u16, ErrorKind, IResult};
 
 use crate::log::*;
 
-pub const SECBLOB_NOT_SPNEGO :  u32 = 128;
-pub const SECBLOB_KRB_FMT_ERR : u32 = 129;
+pub const SECBLOB_NOT_SPNEGO: u32 = 128;
+pub const SECBLOB_KRB_FMT_ERR: u32 = 129;
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Kerberos5Ticket {
     pub realm: Realm,
     pub sname: PrincipalName,
 }
 
-fn parse_kerberos5_request_do(blob: &[u8]) -> IResult<&[u8], ApReq>
-{
+fn parse_kerberos5_request_do(blob: &[u8]) -> IResult<&[u8], ApReq> {
     let blob = match der_parser::parse_der(blob) {
-        IResult::Done(_, b) => {
-            match b.content.as_slice() {
-                Ok(b) => { b },
-                _ => { return IResult::Error(error_code!(ErrorKind::Custom(SECBLOB_KRB_FMT_ERR))); },
+        IResult::Done(_, b) => match b.content.as_slice() {
+            Ok(b) => b,
+            _ => {
+                return IResult::Error(error_code!(ErrorKind::Custom(
+                    SECBLOB_KRB_FMT_ERR
+                )));
             }
         },
-        IResult::Incomplete(needed) => { return IResult::Incomplete(needed); },
-        IResult::Error(err) => { return IResult::Error(err); },
+        IResult::Incomplete(needed) => {
+            return IResult::Incomplete(needed);
+        }
+        IResult::Error(err) => {
+            return IResult::Error(err);
+        }
     };
     do_parse!(
         blob,
-        base_o: parse_der_oid >>
-        tok_id: le_u16 >>
-        ap_req: parse_ap_req >>
-        ({
-            SCLogDebug!("parse_kerberos5_request: base_o {:?}", base_o.as_oid());
-            SCLogDebug!("parse_kerberos5_request: tok_id {}", tok_id);
-            ap_req
-        })
+        base_o: parse_der_oid
+            >> tok_id: le_u16
+            >> ap_req: parse_ap_req
+            >> ({
+                SCLogDebug!(
+                    "parse_kerberos5_request: base_o {:?}",
+                    base_o.as_oid()
+                );
+                SCLogDebug!("parse_kerberos5_request: tok_id {}", tok_id);
+                ap_req
+            })
     )
 }
 
-pub fn parse_kerberos5_request(blob: &[u8]) -> IResult<&[u8], Kerberos5Ticket>
-{
+pub fn parse_kerberos5_request(blob: &[u8]) -> IResult<&[u8], Kerberos5Ticket> {
     match parse_kerberos5_request_do(blob) {
         IResult::Done(rem, req) => {
             let t = Kerberos5Ticket {
@@ -67,7 +74,11 @@ pub fn parse_kerberos5_request(blob: &[u8]) -> IResult<&[u8], Kerberos5Ticket>
             };
             return IResult::Done(rem, t);
         }
-        IResult::Incomplete(needed) => { return IResult::Incomplete(needed); },
-        IResult::Error(err) => { return IResult::Error(err); },
+        IResult::Incomplete(needed) => {
+            return IResult::Incomplete(needed);
+        }
+        IResult::Error(err) => {
+            return IResult::Error(err);
+        }
     }
 }

--- a/rust/src/kerberos.rs
+++ b/rust/src/kerberos.rs
@@ -21,7 +21,7 @@ use nom::{IResult, ErrorKind, le_u16};
 use der_parser;
 use der_parser::parse_der_oid;
 
-use log::*;
+use crate::log::*;
 
 pub const SECBLOB_NOT_SPNEGO :  u32 = 128;
 pub const SECBLOB_KRB_FMT_ERR : u32 = 129;

--- a/rust/src/krb/detect.rs
+++ b/rust/src/krb/detect.rs
@@ -22,34 +22,36 @@ use libc;
 use crate::krb::krb5::KRB5Transaction;
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_tx_get_msgtype(tx:  &mut KRB5Transaction,
-                                                ptr: *mut libc::uint32_t)
-{
+pub unsafe extern "C" fn rs_krb5_tx_get_msgtype(
+    tx: &mut KRB5Transaction,
+    ptr: *mut libc::uint32_t,
+) {
     *ptr = tx.msg_type.0;
 }
 
 /// Get error code, if present in transaction
 /// Return 0 if error code was filled, else 1
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_tx_get_errcode(tx:  &mut KRB5Transaction,
-                                                ptr: *mut libc::int32_t) -> u32
-{
+pub unsafe extern "C" fn rs_krb5_tx_get_errcode(
+    tx: &mut KRB5Transaction,
+    ptr: *mut libc::int32_t,
+) -> u32 {
     match tx.error_code {
         Some(ref e) => {
             *ptr = e.0;
             0
-        },
-        None        => 1
+        }
+        None => 1,
     }
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_tx_get_cname(tx:  &mut KRB5Transaction,
-                                              i: libc::uint16_t,
-                                              buffer: *mut *const libc::uint8_t,
-                                              buffer_len: *mut libc::uint32_t)
-                                              -> libc::uint8_t
-{
+pub unsafe extern "C" fn rs_krb5_tx_get_cname(
+    tx: &mut KRB5Transaction,
+    i: libc::uint16_t,
+    buffer: *mut *const libc::uint8_t,
+    buffer_len: *mut libc::uint32_t,
+) -> libc::uint8_t {
     if let Some(ref s) = tx.cname {
         if (i as usize) < s.name_string.len() {
             let value = &s.name_string[i as usize];
@@ -62,12 +64,12 @@ pub unsafe extern "C" fn rs_krb5_tx_get_cname(tx:  &mut KRB5Transaction,
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_tx_get_sname(tx:  &mut KRB5Transaction,
-                                              i: libc::uint16_t,
-                                              buffer: *mut *const libc::uint8_t,
-                                              buffer_len: *mut libc::uint32_t)
-                                              -> libc::uint8_t
-{
+pub unsafe extern "C" fn rs_krb5_tx_get_sname(
+    tx: &mut KRB5Transaction,
+    i: libc::uint16_t,
+    buffer: *mut *const libc::uint8_t,
+    buffer_len: *mut libc::uint32_t,
+) -> libc::uint8_t {
     if let Some(ref s) = tx.sname {
         if (i as usize) < s.name_string.len() {
             let value = &s.name_string[i as usize];

--- a/rust/src/krb/detect.rs
+++ b/rust/src/krb/detect.rs
@@ -19,7 +19,7 @@
 
 use libc;
 
-use krb::krb5::KRB5Transaction;
+use crate::krb::krb5::KRB5Transaction;
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_krb5_tx_get_msgtype(tx:  &mut KRB5Transaction,

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -24,12 +24,12 @@ use nom::{IResult,be_u32};
 use der_parser::der_read_element_header;
 use kerberos_parser::krb5_parser;
 use kerberos_parser::krb5::{EncryptionType,ErrorCode,MessageType,PrincipalName,Realm};
-use applayer;
-use core;
-use core::{AppProto,Flow,ALPROTO_FAILED,ALPROTO_UNKNOWN,STREAM_TOCLIENT,STREAM_TOSERVER,sc_detect_engine_state_free};
-use parser::*;
+use crate::applayer;
+use crate::core;
+use crate::core::{AppProto,Flow,ALPROTO_FAILED,ALPROTO_UNKNOWN,STREAM_TOCLIENT,STREAM_TOSERVER,sc_detect_engine_state_free};
+use crate::parser::*;
 
-use log::*;
+use crate::log::*;
 
 #[repr(u32)]
 pub enum KRB5Event {

--- a/rust/src/krb/log.rs
+++ b/rust/src/krb/log.rs
@@ -17,8 +17,8 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
-use json::*;
-use krb::krb5::{KRB5State,KRB5Transaction,test_weak_encryption};
+use crate::json::*;
+use crate::krb::krb5::{KRB5State,KRB5Transaction,test_weak_encryption};
 
 #[no_mangle]
 pub extern "C" fn rs_krb5_log_json_response(_state: &mut KRB5State, tx: &mut KRB5Transaction) -> *mut JsonT

--- a/rust/src/krb/log.rs
+++ b/rust/src/krb/log.rs
@@ -18,41 +18,47 @@
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
 use crate::json::*;
-use crate::krb::krb5::{KRB5State,KRB5Transaction,test_weak_encryption};
+use crate::krb::krb5::{test_weak_encryption, KRB5State, KRB5Transaction};
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_log_json_response(_state: &mut KRB5State, tx: &mut KRB5Transaction) -> *mut JsonT
-{
+pub extern "C" fn rs_krb5_log_json_response(
+    _state: &mut KRB5State,
+    tx: &mut KRB5Transaction,
+) -> *mut JsonT {
     let js = Json::object();
     match tx.error_code {
         Some(c) => {
             js.set_string("msg_type", "KRB_ERROR");
             js.set_string("failed_request", &format!("{:?}", tx.msg_type));
             js.set_string("error_code", &format!("{:?}", c));
-        },
-        None    => { js.set_string("msg_type", &format!("{:?}", tx.msg_type)); },
+        }
+        None => {
+            js.set_string("msg_type", &format!("{:?}", tx.msg_type));
+        }
     }
     let cname = match tx.cname {
         Some(ref x) => format!("{}", x),
-        None        => "<empty>".to_owned(),
+        None => "<empty>".to_owned(),
     };
     let realm = match tx.realm {
         Some(ref x) => format!("{}", x.0),
-        None        => "<empty>".to_owned(),
+        None => "<empty>".to_owned(),
     };
     let sname = match tx.sname {
         Some(ref x) => format!("{}", x),
-        None        => "<empty>".to_owned(),
+        None => "<empty>".to_owned(),
     };
     let encryption = match tx.etype {
         Some(ref x) => format!("{:?}", x),
-        None        => "<none>".to_owned(),
+        None => "<none>".to_owned(),
     };
     js.set_string("cname", &cname);
     js.set_string("realm", &realm);
     js.set_string("sname", &sname);
     js.set_string("encryption", &encryption);
-    js.set_boolean("weak_encryption", tx.etype.map_or(false,test_weak_encryption));
+    js.set_boolean(
+        "weak_encryption",
+        tx.etype.map_or(false, test_weak_encryption),
+    );
     return js.unwrap();
 }
-

--- a/rust/src/krb/mod.rs
+++ b/rust/src/krb/mod.rs
@@ -17,6 +17,6 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
-pub mod krb5;
 pub mod detect;
+pub mod krb5;
 pub mod log;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -47,14 +47,14 @@ pub mod kerberos;
 pub mod lua;
 
 pub mod dns;
-pub mod nfs;
 pub mod ftp;
-pub mod smb;
 pub mod krb;
+pub mod nfs;
+pub mod smb;
 
 pub mod ikev2;
 
+pub mod applayertemplate;
+pub mod dhcp;
 pub mod ntp;
 pub mod tftp;
-pub mod dhcp;
-pub mod applayertemplate;

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -41,9 +41,7 @@ pub enum Level {
 pub static mut LEVEL: i32 = Level::NotSet as i32;
 
 pub fn get_log_level() -> i32 {
-    unsafe {
-        LEVEL
-    }
+    unsafe { LEVEL }
 }
 
 fn basename(filename: &str) -> &str {
@@ -56,23 +54,25 @@ fn basename(filename: &str) -> &str {
     return filename;
 }
 
-pub fn sclog(level: Level, file: &str, line: u32, function: &str,
-         code: i32, message: &str)
-{
+pub fn sclog(
+    level: Level,
+    file: &str,
+    line: u32,
+    function: &str,
+    code: i32,
+    message: &str,
+) {
     let filename = basename(file);
-    sc_log_message(level,
-                   filename,
-                   line,
-                   function,
-                   code,
-                   message);
+    sc_log_message(level, filename, line, function, code, message);
 }
 
 /// Return the function name, but for now just return <rust> as Rust
 /// has no macro to return the function name, but may in the future,
 /// see: https://github.com/rust-lang/rfcs/pull/1719
-macro_rules!function {
-    () => {{ "<rust>" }}
+macro_rules! function {
+    () => {{
+        "<rust>"
+    }};
 }
 
 #[macro_export]
@@ -146,13 +146,14 @@ pub fn log_set_level(level: Level) {
 /// SCLogMessage wrapper. If the Suricata C context is not registered
 /// a more basic log format will be used (for example, when running
 /// Rust unit tests).
-pub fn sc_log_message(level: Level,
-                      filename: &str,
-                      line: libc::c_uint,
-                      function: &str,
-                      code: libc::c_int,
-                      message: &str) -> libc::c_int
-{
+pub fn sc_log_message(
+    level: Level,
+    filename: &str,
+    line: libc::c_uint,
+    function: &str,
+    code: libc::c_int,
+    message: &str,
+) -> libc::c_int {
     unsafe {
         if let Some(c) = SC {
             return (c.SCLogMessage)(
@@ -161,7 +162,8 @@ pub fn sc_log_message(level: Level,
                 line,
                 to_safe_cstring(function).as_ptr(),
                 code,
-                to_safe_cstring(message).as_ptr());
+                to_safe_cstring(message).as_ptr(),
+            );
         }
     }
 
@@ -186,8 +188,6 @@ fn to_safe_cstring(val: &str) -> CString {
     }
     match CString::new(safe) {
         Ok(cstr) => cstr,
-        _ => {
-            CString::new("<failed to encode string>").unwrap()
-        }
+        _ => CString::new("<failed to encode string>").unwrap(),
     }
 }

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -20,7 +20,7 @@ extern crate libc;
 use std::ffi::CString;
 use std::path::Path;
 
-use core::*;
+use crate::core::*;
 
 #[derive(Debug)]
 pub enum Level {

--- a/rust/src/lua.rs
+++ b/rust/src/lua.rs
@@ -22,7 +22,7 @@ use std::os::raw::c_long;
 /// The Rust place holder for lua_State.
 pub enum CLuaState {}
 
-extern {
+extern "C" {
     fn lua_createtable(lua: *mut CLuaState, narr: c_int, nrec: c_int);
     fn lua_settable(lua: *mut CLuaState, idx: c_long);
     fn lua_pushlstring(lua: *mut CLuaState, s: *const c_char, len: usize);
@@ -34,7 +34,6 @@ pub struct LuaState {
 }
 
 impl LuaState {
-
     pub fn newtable(&self) {
         unsafe {
             lua_createtable(self.lua, 0, 0);

--- a/rust/src/nfs/log.rs
+++ b/rust/src/nfs/log.rs
@@ -17,17 +17,17 @@
 
 extern crate libc;
 
-use std::string::String;
 use crate::json::*;
-use crate::nfs::types::*;
 use crate::nfs::nfs::*;
+use crate::nfs::types::*;
 use crc::crc32;
+use std::string::String;
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_tx_logging_is_filtered(state: &mut NFSState,
-                                                tx: &mut NFSTransaction)
-                                                -> libc::uint8_t
-{
+pub extern "C" fn rs_nfs_tx_logging_is_filtered(
+    state: &mut NFSState,
+    tx: &mut NFSTransaction,
+) -> libc::uint8_t {
     // TODO probably best to make this configurable
 
     if state.nfs_version <= 3 && tx.procedure == NFSPROC3_GETATTR {
@@ -37,15 +37,14 @@ pub extern "C" fn rs_nfs_tx_logging_is_filtered(state: &mut NFSState,
     return 0;
 }
 
-fn nfs_rename_object(tx: &NFSTransaction) -> Json
-{
+fn nfs_rename_object(tx: &NFSTransaction) -> Json {
     let js = Json::object();
     let from_str = String::from_utf8_lossy(&tx.file_name);
     js.set_string("from", &from_str);
 
     let to_vec = match tx.type_data {
-        Some(NFSTransactionTypeData::RENAME(ref x)) => { x.to_vec() },
-        _ => { Vec::new() }
+        Some(NFSTransactionTypeData::RENAME(ref x)) => x.to_vec(),
+        _ => Vec::new(),
     };
 
     let to_str = String::from_utf8_lossy(&to_vec);
@@ -53,8 +52,7 @@ fn nfs_rename_object(tx: &NFSTransaction) -> Json
     return js;
 }
 
-fn nfs_creds_object(tx: &NFSTransaction) -> Json
-{
+fn nfs_creds_object(tx: &NFSTransaction) -> Json {
     let js = Json::object();
     let mach_name = String::from_utf8_lossy(&tx.request_machine_name);
     js.set_string("machine_name", &mach_name);
@@ -63,8 +61,7 @@ fn nfs_creds_object(tx: &NFSTransaction) -> Json
     return js;
 }
 
-fn nfs_file_object(tx: &NFSTransaction) -> Json
-{
+fn nfs_file_object(tx: &NFSTransaction) -> Json {
     let js = Json::object();
     js.set_boolean("first", tx.is_first);
     js.set_boolean("last", tx.is_last);
@@ -88,8 +85,7 @@ fn nfs_handle2crc(bytes: &Vec<u8>) -> u32 {
     c
 }
 
-fn nfs_common_header(state: &NFSState, tx: &NFSTransaction) -> Json
-{
+fn nfs_common_header(state: &NFSState, tx: &NFSTransaction) -> Json {
     let js = Json::object();
     js.set_integer("version", state.nfs_version as u64);
     let proc_string = if state.nfs_version < 4 {
@@ -113,16 +109,20 @@ fn nfs_common_header(state: &NFSState, tx: &NFSTransaction) -> Json
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_log_json_request(state: &mut NFSState, tx: &mut NFSTransaction) -> *mut JsonT
-{
+pub extern "C" fn rs_nfs_log_json_request(
+    state: &mut NFSState,
+    tx: &mut NFSTransaction,
+) -> *mut JsonT {
     let js = nfs_common_header(state, tx);
     js.set_string("type", "request");
     return js.unwrap();
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_log_json_response(state: &mut NFSState, tx: &mut NFSTransaction) -> *mut JsonT
-{
+pub extern "C" fn rs_nfs_log_json_response(
+    state: &mut NFSState,
+    tx: &mut NFSTransaction,
+) -> *mut JsonT {
     let js = nfs_common_header(state, tx);
     js.set_string("type", "response");
 
@@ -144,10 +144,10 @@ pub extern "C" fn rs_nfs_log_json_response(state: &mut NFSState, tx: &mut NFSTra
     return js.unwrap();
 }
 
-
 #[no_mangle]
-pub extern "C" fn rs_rpc_log_json_response(tx: &mut NFSTransaction) -> *mut JsonT
-{
+pub extern "C" fn rs_rpc_log_json_response(
+    tx: &mut NFSTransaction,
+) -> *mut JsonT {
     let js = Json::object();
     js.set_integer("xid", tx.xid as u64);
     js.set_string("status", &rpc_status_string(tx.rpc_response_status));

--- a/rust/src/nfs/log.rs
+++ b/rust/src/nfs/log.rs
@@ -18,9 +18,9 @@
 extern crate libc;
 
 use std::string::String;
-use json::*;
-use nfs::types::*;
-use nfs::nfs::*;
+use crate::json::*;
+use crate::nfs::types::*;
+use crate::nfs::nfs::*;
 use crc::crc32;
 
 #[no_mangle]

--- a/rust/src/nfs/mod.rs
+++ b/rust/src/nfs/mod.rs
@@ -15,17 +15,17 @@
  * 02110-1301, USA.
  */
 
-pub mod types;
-pub mod rpc_records;
-pub mod nfs_records;
-pub mod nfs2_records;
-pub mod nfs3_records;
-pub mod nfs4_records;
+pub mod log;
 pub mod nfs;
 pub mod nfs2;
+pub mod nfs2_records;
 pub mod nfs3;
+pub mod nfs3_records;
 pub mod nfs4;
-pub mod log;
+pub mod nfs4_records;
+pub mod nfs_records;
+pub mod rpc_records;
+pub mod types;
 
 //#[cfg(feature = "lua")]
 //pub mod lua;

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -20,26 +20,27 @@
 
 extern crate libc;
 use std;
-use std::mem::transmute;
-use std::collections::{HashMap};
+use std::collections::HashMap;
 use std::ffi::CStr;
+use std::mem::transmute;
 
 use nom::IResult;
 
-use crate::log::*;
 use crate::applayer;
 use crate::applayer::LoggerFlags;
 use crate::core::*;
-use crate::filetracker::*;
 use crate::filecontainer::*;
+use crate::filetracker::*;
+use crate::log::*;
 
-use crate::nfs::types::*;
-use crate::nfs::rpc_records::*;
-use crate::nfs::nfs_records::*;
 use crate::nfs::nfs2_records::*;
 use crate::nfs::nfs3_records::*;
+use crate::nfs::nfs_records::*;
+use crate::nfs::rpc_records::*;
+use crate::nfs::types::*;
 
-pub static mut SURICATA_NFS_FILE_CONFIG: Option<&'static SuricataFileContext> = None;
+pub static mut SURICATA_NFS_FILE_CONFIG: Option<&'static SuricataFileContext> =
+    None;
 
 /*
  * Record parsing.
@@ -117,17 +118,19 @@ impl NFSTransactionFile {
     pub fn new() -> NFSTransactionFile {
         return NFSTransactionFile {
             file_additional_procs: Vec::new(),
-            chunk_count:0,
+            chunk_count: 0,
             file_last_xid: 0,
             file_tracker: FileTransferTracker::new(),
-        }
+        };
     }
 }
 
 #[derive(Debug)]
 pub struct NFSTransaction {
-    pub id: u64,    /// internal id
-    pub xid: u32,   /// nfs req/reply pair id
+    pub id: u64,
+    /// internal id
+    pub xid: u32,
+    /// nfs req/reply pair id
     pub procedure: u32,
     /// file name of the object we're dealing with. In case of RENAME
     /// this is the 'from' or original name.
@@ -173,32 +176,32 @@ pub struct NFSTransaction {
 
 impl NFSTransaction {
     pub fn new() -> NFSTransaction {
-        return NFSTransaction{
+        return NFSTransaction {
             id: 0,
             xid: 0,
             procedure: 0,
-            file_name:Vec::new(),
-            request_machine_name:Vec::new(),
-            request_uid:0,
-            request_gid:0,
-            rpc_response_status:0,
-            nfs_response_status:0,
+            file_name: Vec::new(),
+            request_machine_name: Vec::new(),
+            request_uid: 0,
+            request_gid: 0,
+            rpc_response_status: 0,
+            nfs_response_status: 0,
             auth_type: 0,
             is_first: false,
             is_last: false,
             request_done: false,
             response_done: false,
-            nfs_version:0,
+            nfs_version: 0,
             is_file_tx: false,
             file_tx_direction: 0,
-            file_handle:Vec::new(),
+            file_handle: Vec::new(),
             type_data: None,
             detect_flags_ts: 0,
             detect_flags_tc: 0,
             logged: LoggerFlags::new(),
             de_state: None,
             events: std::ptr::null_mut(),
-        }
+        };
     }
 
     pub fn free(&mut self) {
@@ -225,23 +228,27 @@ pub struct NFSRequestXidMap {
     pub progver: u32,
     pub procedure: u32,
     pub chunk_offset: u64,
-    pub file_name:Vec<u8>,
+    pub file_name: Vec<u8>,
 
     /// READ replies can use this to get to the handle the request used
-    pub file_handle:Vec<u8>,
+    pub file_handle: Vec<u8>,
 
     pub gssapi_proc: u32,
     pub gssapi_service: u32,
 }
 
 impl NFSRequestXidMap {
-    pub fn new(progver: u32, procedure: u32, chunk_offset: u64) -> NFSRequestXidMap {
+    pub fn new(
+        progver: u32,
+        procedure: u32,
+        chunk_offset: u64,
+    ) -> NFSRequestXidMap {
         NFSRequestXidMap {
-            progver:progver,
-            procedure:procedure,
-            chunk_offset:chunk_offset,
-            file_name:Vec::new(),
-            file_handle:Vec::new(),
+            progver: progver,
+            procedure: procedure,
+            chunk_offset: chunk_offset,
+            file_name: Vec::new(),
+            file_handle: Vec::new(),
             gssapi_proc: 0,
             gssapi_service: 0,
         }
@@ -259,10 +266,10 @@ pub struct NFSFiles {
 impl NFSFiles {
     pub fn new() -> NFSFiles {
         NFSFiles {
-            files_ts:FileContainer::default(),
-            files_tc:FileContainer::default(),
-            flags_ts:0,
-            flags_tc:0,
+            files_ts: FileContainer::default(),
+            files_tc: FileContainer::default(),
+            flags_ts: 0,
+            flags_tc: 0,
         }
     }
     pub fn free(&mut self) {
@@ -270,8 +277,7 @@ impl NFSFiles {
         self.files_tc.free();
     }
 
-    pub fn get(&mut self, direction: u8) -> (&mut FileContainer, u16)
-    {
+    pub fn get(&mut self, direction: u8) -> (&mut FileContainer, u16) {
         if direction == STREAM_TOSERVER {
             (&mut self.files_ts, self.flags_ts)
         } else {
@@ -281,14 +287,33 @@ impl NFSFiles {
 }
 
 /// little wrapper around the FileTransferTracker::new_chunk method
-pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContainer,
-        flags: u16, name: &Vec<u8>, data: &[u8],
-        chunk_offset: u64, chunk_size: u32, fill_bytes: u8, is_last: bool, xid: &u32)
-{
-    match unsafe {SURICATA_NFS_FILE_CONFIG} {
+pub fn filetracker_newchunk(
+    ft: &mut FileTransferTracker,
+    files: &mut FileContainer,
+    flags: u16,
+    name: &Vec<u8>,
+    data: &[u8],
+    chunk_offset: u64,
+    chunk_size: u32,
+    fill_bytes: u8,
+    is_last: bool,
+    xid: &u32,
+) {
+    match unsafe { SURICATA_NFS_FILE_CONFIG } {
         Some(sfcm) => {
-            ft.new_chunk(sfcm, files, flags, &name, data, chunk_offset,
-                    chunk_size, fill_bytes, is_last, xid); }
+            ft.new_chunk(
+                sfcm,
+                files,
+                flags,
+                &name,
+                data,
+                chunk_offset,
+                chunk_size,
+                fill_bytes,
+                is_last,
+                xid,
+            );
+        }
         None => panic!("BUG"),
     }
 }
@@ -339,25 +364,25 @@ impl NFSState {
     /// Allocation function for a new TLS parser instance
     pub fn new() -> NFSState {
         NFSState {
-            requestmap:HashMap::new(),
-            namemap:HashMap::new(),
+            requestmap: HashMap::new(),
+            namemap: HashMap::new(),
             transactions: Vec::new(),
-            tcp_buffer_ts:Vec::with_capacity(8192),
-            tcp_buffer_tc:Vec::with_capacity(8192),
-            files:NFSFiles::new(),
-            ts_chunk_xid:0,
-            tc_chunk_xid:0,
-            ts_chunk_left:0,
-            tc_chunk_left:0,
-            ts_chunk_fh:Vec::new(),
-            ts_ssn_gap:false,
-            tc_ssn_gap:false,
-            ts_gap:false,
-            tc_gap:false,
-            is_udp:false,
-            nfs_version:0,
-            events:0,
-            tx_id:0,
+            tcp_buffer_ts: Vec::with_capacity(8192),
+            tcp_buffer_tc: Vec::with_capacity(8192),
+            files: NFSFiles::new(),
+            ts_chunk_xid: 0,
+            tc_chunk_xid: 0,
+            ts_chunk_left: 0,
+            tc_chunk_left: 0,
+            ts_chunk_fh: Vec::new(),
+            ts_ssn_gap: false,
+            tc_ssn_gap: false,
+            ts_gap: false,
+            tc_gap: false,
+            is_udp: false,
+            nfs_version: 0,
+            events: 0,
+            tx_id: 0,
         }
     }
     pub fn free(&mut self) {
@@ -402,11 +427,18 @@ impl NFSState {
         return None;
     }
 
-    pub fn get_tx_by_xid(&mut self, tx_xid: u32) -> Option<&mut NFSTransaction> {
+    pub fn get_tx_by_xid(
+        &mut self,
+        tx_xid: u32,
+    ) -> Option<&mut NFSTransaction> {
         SCLogDebug!("get_tx_by_xid: tx_xid={}", tx_xid);
         for tx in &mut self.transactions {
             if !tx.is_file_tx && tx.xid == tx_xid {
-                SCLogDebug!("Found NFS TX with ID {} XID {:04X}", tx.id, tx.xid);
+                SCLogDebug!(
+                    "Found NFS TX with ID {} XID {:04X}",
+                    tx.id,
+                    tx.xid
+                );
                 return Some(tx);
             }
         }
@@ -415,9 +447,11 @@ impl NFSState {
     }
 
     // for use with the C API call StateGetTxIterator
-    pub fn get_tx_iterator(&mut self, min_tx_id: u64, state: &mut u64) ->
-        Option<(&NFSTransaction, u64, bool)>
-    {
+    pub fn get_tx_iterator(
+        &mut self,
+        min_tx_id: u64,
+        state: &mut u64,
+    ) -> Option<(&NFSTransaction, u64, bool)> {
         let mut index = *state as usize;
         let len = self.transactions.len();
 
@@ -432,8 +466,14 @@ impl NFSState {
             // as transactions might be freed between now and the
             // next time we are called.
             *state = index as u64;
-            SCLogDebug!("returning tx_id {} has_next? {} (len {} index {}), tx {:?}",
-                    tx.id - 1, (len - index) > 1, len, index, tx);
+            SCLogDebug!(
+                "returning tx_id {} has_next? {} (len {} index {}), tx {:?}",
+                tx.id - 1,
+                (len - index) > 1,
+                len,
+                index,
+                tx
+            );
             return Some((tx, tx.id - 1, (len - index) > 1));
         }
         return None;
@@ -452,8 +492,13 @@ impl NFSState {
     }
 
     // TODO maybe not enough users to justify a func
-    pub fn mark_response_tx_done(&mut self, xid: u32, rpc_status: u32, nfs_status: u32, resp_handle: &Vec<u8>)
-    {
+    pub fn mark_response_tx_done(
+        &mut self,
+        xid: u32,
+        rpc_status: u32,
+        nfs_status: u32,
+        resp_handle: &Vec<u8>,
+    ) {
         match self.get_tx_by_xid(xid) {
             Some(mytx) => {
                 mytx.response_done = true;
@@ -465,22 +510,26 @@ impl NFSState {
 
                 SCLogDebug!("process_reply_record: tx ID {} XID {:04X} REQUEST {} RESPONSE {}",
                         mytx.id, mytx.xid, mytx.request_done, mytx.response_done);
-            },
+            }
             None => {
                 //SCLogNotice!("process_reply_record: not TX found for XID {}", r.hdr.xid);
-            },
+            }
         }
     }
 
-    pub fn process_request_record_lookup<'b>(&mut self, r: &RpcPacket<'b>, xidmap: &mut NFSRequestXidMap) {
+    pub fn process_request_record_lookup<'b>(
+        &mut self,
+        r: &RpcPacket<'b>,
+        xidmap: &mut NFSRequestXidMap,
+    ) {
         match parse_nfs3_request_lookup(r.prog_data) {
             IResult::Done(_, lookup) => {
                 SCLogDebug!("LOOKUP {:?}", lookup);
                 xidmap.file_name = lookup.name_vec;
-            },
+            }
             _ => {
                 self.set_event(NFSEvent::MalformedData);
-            },
+            }
         };
     }
 
@@ -489,64 +538,78 @@ impl NFSState {
             Some(n) => {
                 SCLogDebug!("xidmap_handle2name: name {:?}", n);
                 xidmap.file_name = n.to_vec();
-            },
+            }
             _ => {
-                SCLogDebug!("xidmap_handle2name: object {:?} not found",
-                        xidmap.file_handle);
-            },
+                SCLogDebug!(
+                    "xidmap_handle2name: object {:?} not found",
+                    xidmap.file_handle
+                );
+            }
         }
     }
 
     /// complete request record
     fn process_request_record<'b>(&mut self, r: &RpcPacket<'b>) -> u32 {
-        SCLogDebug!("REQUEST {} procedure {} ({}) blob size {}",
-                r.hdr.xid, r.procedure, self.requestmap.len(), r.prog_data.len());
+        SCLogDebug!(
+            "REQUEST {} procedure {} ({}) blob size {}",
+            r.hdr.xid,
+            r.procedure,
+            self.requestmap.len(),
+            r.prog_data.len()
+        );
 
         match r.progver {
-            4 => {
-                self.process_request_record_v4(r)
-            },
-            3 => {
-                self.process_request_record_v3(r)
-            },
-            2 => {
-                self.process_request_record_v2(r)
-            },
-            _ => { 1 },
+            4 => self.process_request_record_v4(r),
+            3 => self.process_request_record_v3(r),
+            2 => self.process_request_record_v2(r),
+            _ => 1,
         }
     }
 
-    pub fn new_file_tx(&mut self, file_handle: &Vec<u8>, file_name: &Vec<u8>, direction: u8)
-        -> (&mut NFSTransaction, &mut FileContainer, u16)
-    {
+    pub fn new_file_tx(
+        &mut self,
+        file_handle: &Vec<u8>,
+        file_name: &Vec<u8>,
+        direction: u8,
+    ) -> (&mut NFSTransaction, &mut FileContainer, u16) {
         let mut tx = self.new_tx();
         tx.file_name = file_name.to_vec();
         tx.file_handle = file_handle.to_vec();
         tx.is_file_tx = true;
         tx.file_tx_direction = direction;
 
-        tx.type_data = Some(NFSTransactionTypeData::FILE(NFSTransactionFile::new()));
+        tx.type_data =
+            Some(NFSTransactionTypeData::FILE(NFSTransactionFile::new()));
         if let Some(NFSTransactionTypeData::FILE(ref mut d)) = tx.type_data {
             d.file_tracker.tx_id = tx.id - 1;
         }
-        SCLogDebug!("new_file_tx: TX FILE created: ID {} NAME {}",
-                tx.id, String::from_utf8_lossy(file_name));
+        SCLogDebug!(
+            "new_file_tx: TX FILE created: ID {} NAME {}",
+            tx.id,
+            String::from_utf8_lossy(file_name)
+        );
         self.transactions.push(tx);
         let tx_ref = self.transactions.last_mut();
         let (files, flags) = self.files.get(direction);
-        return (tx_ref.unwrap(), files, flags)
+        return (tx_ref.unwrap(), files, flags);
     }
 
-    pub fn get_file_tx_by_handle(&mut self, file_handle: &Vec<u8>, direction: u8)
-        -> Option<(&mut NFSTransaction, &mut FileContainer, u16)>
-    {
+    pub fn get_file_tx_by_handle(
+        &mut self,
+        file_handle: &Vec<u8>,
+        direction: u8,
+    ) -> Option<(&mut NFSTransaction, &mut FileContainer, u16)> {
         let fh = file_handle.to_vec();
         for tx in &mut self.transactions {
-            if tx.is_file_tx &&
-                direction == tx.file_tx_direction &&
-                tx.file_handle == fh
+            if tx.is_file_tx
+                && direction == tx.file_tx_direction
+                && tx.file_handle == fh
             {
-                SCLogDebug!("Found NFS file TX with ID {} XID {:04X}", tx.id, tx.xid);
+                SCLogDebug!(
+                    "Found NFS file TX with ID {} XID {:04X}",
+                    tx.id,
+                    tx.xid
+                );
                 let (files, flags) = self.files.get(direction);
                 return Some((tx, files, flags));
             }
@@ -555,7 +618,11 @@ impl NFSState {
         return None;
     }
 
-    pub fn process_write_record<'b>(&mut self, r: &RpcPacket<'b>, w: &Nfs3RequestWrite<'b>) -> u32 {
+    pub fn process_write_record<'b>(
+        &mut self,
+        r: &RpcPacket<'b>,
+        w: &Nfs3RequestWrite<'b>,
+    ) -> u32 {
         // for now assume that stable FILE_SYNC flags means a single chunk
         let is_last = if w.stable == 2 { true } else { false };
 
@@ -570,38 +637,62 @@ impl NFSState {
             Some(n) => {
                 SCLogDebug!("WRITE name {:?}", n);
                 n.to_vec()
-            },
+            }
             None => {
                 SCLogDebug!("WRITE object {:?} not found", w.handle.value);
                 Vec::new()
-            },
+            }
         };
 
-        let found = match self.get_file_tx_by_handle(&file_handle, STREAM_TOSERVER) {
-            Some((tx, files, flags)) => {
-                if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                    filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                            &file_name, w.file_data, w.offset,
-                            w.file_len, fill_bytes as u8, is_last, &r.hdr.xid);
-                    tdf.chunk_count += 1;
-                    if is_last {
-                        tdf.file_last_xid = r.hdr.xid;
-                        tx.is_last = true;
-                        tx.response_done = true;
+        let found =
+            match self.get_file_tx_by_handle(&file_handle, STREAM_TOSERVER) {
+                Some((tx, files, flags)) => {
+                    if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) =
+                        tx.type_data
+                    {
+                        filetracker_newchunk(
+                            &mut tdf.file_tracker,
+                            files,
+                            flags,
+                            &file_name,
+                            w.file_data,
+                            w.offset,
+                            w.file_len,
+                            fill_bytes as u8,
+                            is_last,
+                            &r.hdr.xid,
+                        );
+                        tdf.chunk_count += 1;
+                        if is_last {
+                            tdf.file_last_xid = r.hdr.xid;
+                            tx.is_last = true;
+                            tx.response_done = true;
+                        }
+                        true
+                    } else {
+                        false
                     }
-                    true
-                } else {
-                    false
                 }
-            },
-            None => { false },
-        };
+                None => false,
+            };
         if !found {
-            let (tx, files, flags) = self.new_file_tx(&file_handle, &file_name, STREAM_TOSERVER);
-            if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                        &file_name, w.file_data, w.offset,
-                        w.file_len, fill_bytes as u8, is_last, &r.hdr.xid);
+            let (tx, files, flags) =
+                self.new_file_tx(&file_handle, &file_name, STREAM_TOSERVER);
+            if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) =
+                tx.type_data
+            {
+                filetracker_newchunk(
+                    &mut tdf.file_tracker,
+                    files,
+                    flags,
+                    &file_name,
+                    w.file_data,
+                    w.offset,
+                    w.file_len,
+                    fill_bytes as u8,
+                    is_last,
+                    &r.hdr.xid,
+                );
                 tx.procedure = NFSPROC3_WRITE;
                 tx.xid = r.hdr.xid;
                 tx.is_first = true;
@@ -618,13 +709,26 @@ impl NFSState {
             let file_data_len = w.file_data.len() as u32 - fill_bytes as u32;
             self.ts_chunk_left = w.file_len as u32 - file_data_len as u32;
             self.ts_chunk_fh = file_handle;
-            SCLogDebug!("REQUEST chunk_xid {:04X} chunk_left {}", self.ts_chunk_xid, self.ts_chunk_left);
+            SCLogDebug!(
+                "REQUEST chunk_xid {:04X} chunk_left {}",
+                self.ts_chunk_xid,
+                self.ts_chunk_left
+            );
         }
         0
     }
 
-    fn process_partial_write_request_record<'b>(&mut self, r: &RpcPacket<'b>, w: &Nfs3RequestWrite<'b>) -> u32 {
-        SCLogDebug!("REQUEST {} procedure {} blob size {}", r.hdr.xid, r.procedure, r.prog_data.len());
+    fn process_partial_write_request_record<'b>(
+        &mut self,
+        r: &RpcPacket<'b>,
+        w: &Nfs3RequestWrite<'b>,
+    ) -> u32 {
+        SCLogDebug!(
+            "REQUEST {} procedure {} blob size {}",
+            r.hdr.xid,
+            r.procedure,
+            r.prog_data.len()
+        );
 
         let mut xidmap = NFSRequestXidMap::new(r.progver, r.procedure, 0);
         xidmap.file_handle = w.handle.value.to_vec();
@@ -636,18 +740,26 @@ impl NFSState {
     fn process_reply_record<'b>(&mut self, r: &RpcReplyPacket<'b>) -> u32 {
         let mut xidmap;
         match self.requestmap.remove(&r.hdr.xid) {
-            Some(p) => { xidmap = p; },
+            Some(p) => {
+                xidmap = p;
+            }
             _ => {
-                SCLogDebug!("REPLY: xid {:04X} NOT FOUND. GAPS? TS:{} TC:{}",
-                        r.hdr.xid, self.ts_ssn_gap, self.tc_ssn_gap);
+                SCLogDebug!(
+                    "REPLY: xid {:04X} NOT FOUND. GAPS? TS:{} TC:{}",
+                    r.hdr.xid,
+                    self.ts_ssn_gap,
+                    self.tc_ssn_gap
+                );
 
                 // TODO we might be able to try to infer from the size + data
                 // that this is a READ reply and pass the data to the file API anyway?
                 return 0;
-            },
+            }
         }
-        SCLogDebug!("process_reply_record: removed xid {:04X} from requestmap",
-            r.hdr.xid);
+        SCLogDebug!(
+            "process_reply_record: removed xid {:04X} from requestmap",
+            r.hdr.xid
+        );
 
         if self.nfs_version == 0 {
             self.nfs_version = xidmap.progver as u16;
@@ -657,40 +769,50 @@ impl NFSState {
             2 => {
                 SCLogDebug!("NFSv2 reply record");
                 return self.process_reply_record_v2(r, &xidmap);
-            },
+            }
             3 => {
                 SCLogDebug!("NFSv3 reply record");
                 return self.process_reply_record_v3(r, &mut xidmap);
-            },
+            }
             4 => {
                 SCLogDebug!("NFSv4 reply record");
                 return self.process_reply_record_v4(r, &mut xidmap);
-            },
+            }
             _ => {
                 SCLogDebug!("Invalid NFS version");
                 self.set_event(NFSEvent::NonExistingVersion);
                 return 0;
-            },
+            }
         }
     }
 
     // update in progress chunks for file transfers
     // return how much data we consumed
-    fn filetracker_update(&mut self, direction: u8, data: &[u8], gap_size: u32) -> u32 {
+    fn filetracker_update(
+        &mut self,
+        direction: u8,
+        data: &[u8],
+        gap_size: u32,
+    ) -> u32 {
         let mut chunk_left = if direction == STREAM_TOSERVER {
             self.ts_chunk_left
         } else {
             self.tc_chunk_left
         };
         if chunk_left == 0 {
-            return 0
+            return 0;
         }
         let xid = if direction == STREAM_TOSERVER {
             self.ts_chunk_xid
         } else {
             self.tc_chunk_xid
         };
-        SCLogDebug!("filetracker_update: chunk left {}, input {} chunk_xid {:04X}", chunk_left, data.len(), xid);
+        SCLogDebug!(
+            "filetracker_update: chunk left {}, input {} chunk_xid {:04X}",
+            chunk_left,
+            data.len(),
+            xid
+        );
 
         let file_handle;
         // we have the data that we expect
@@ -708,11 +830,11 @@ impl NFSState {
                 match self.requestmap.remove(&xid) {
                     None => {
                         SCLogDebug!("no file handle found for XID {:04X}", xid);
-                        return 0
-                    },
+                        return 0;
+                    }
                     Some(xidmap) => {
                         file_handle = xidmap.file_handle.to_vec();
-                    },
+                    }
                 }
             }
         } else {
@@ -725,11 +847,11 @@ impl NFSState {
                 match self.requestmap.get(&xid) {
                     None => {
                         SCLogDebug!("no file handle found for XID {:04X}", xid);
-                        return 0
-                    },
+                        return 0;
+                    }
                     Some(xidmap) => {
                         file_handle = xidmap.file_handle.to_vec();
-                    },
+                    }
                 }
             }
         }
@@ -742,19 +864,24 @@ impl NFSState {
 
         let ssn_gap = self.ts_ssn_gap | self.tc_ssn_gap;
         // get the tx and update it
-        let consumed = match self.get_file_tx_by_handle(&file_handle, direction) {
+        let consumed = match self.get_file_tx_by_handle(&file_handle, direction)
+        {
             Some((tx, files, flags)) => {
-                if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
+                if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) =
+                    tx.type_data
+                {
                     if ssn_gap {
                         let queued_data = tdf.file_tracker.get_queued_size();
-                        if queued_data > 2000000 { // TODO should probably be configurable
+                        if queued_data > 2000000 {
+                            // TODO should probably be configurable
                             SCLogDebug!("QUEUED size {} while we've seen GAPs. Truncating file.", queued_data);
                             tdf.file_tracker.trunc(files, flags);
                         }
                     }
 
                     tdf.chunk_count += 1;
-                    let cs = tdf.file_tracker.update(files, flags, data, gap_size);
+                    let cs =
+                        tdf.file_tracker.update(files, flags, data, gap_size);
                     /* see if we need to close the tx */
                     if tdf.file_tracker.is_done() {
                         if direction == STREAM_TOCLIENT {
@@ -769,17 +896,20 @@ impl NFSState {
                 } else {
                     0
                 }
-            },
-            None => { 0 },
+            }
+            None => 0,
         };
         return consumed;
     }
 
     /// xidmapr is an Option as it's already removed from the map if we
     /// have a complete record. Otherwise we do a lookup ourselves.
-    pub fn process_read_record<'b>(&mut self, r: &RpcReplyPacket<'b>,
-            reply: &NfsReplyRead<'b>, xidmapr: Option<&NFSRequestXidMap>) -> u32
-    {
+    pub fn process_read_record<'b>(
+        &mut self,
+        r: &RpcReplyPacket<'b>,
+        reply: &NfsReplyRead<'b>,
+        xidmapr: Option<&NFSRequestXidMap>,
+    ) -> u32 {
         let file_name;
         let file_handle;
         let chunk_offset;
@@ -791,7 +921,7 @@ impl NFSState {
                 file_handle = xidmap.file_handle.to_vec();
                 chunk_offset = xidmap.chunk_offset;
                 nfs_version = xidmap.progver;
-            },
+            }
             None => {
                 if let Some(xidmap) = self.requestmap.get(&r.hdr.xid) {
                     file_name = xidmap.file_name.to_vec();
@@ -801,7 +931,7 @@ impl NFSState {
                 } else {
                     return 0;
                 }
-            },
+            }
         }
         SCLogDebug!("chunk_offset {}", chunk_offset);
 
@@ -816,10 +946,8 @@ impl NFSState {
 
         if nfs_version == 2 {
             let size = match parse_nfs2_attribs(reply.attr_blob) {
-                IResult::Done(_, ref attr) => {
-                    attr.asize
-                },
-                _ => { 0 },
+                IResult::Done(_, ref attr) => attr.asize,
+                _ => 0,
             };
             SCLogDebug!("NFSv2 READ reply record: File size {}. Offset {} data len {}: total {}",
                     size, chunk_offset, reply.data_len, chunk_offset + reply.data_len as u64);
@@ -827,48 +955,75 @@ impl NFSState {
             if size as u64 == chunk_offset + reply.data_len as u64 {
                 is_last = true;
             }
-
         }
 
         let is_partial = reply.data.len() < reply.count as usize;
         SCLogDebug!("partial data? {}", is_partial);
 
-        let found = match self.get_file_tx_by_handle(&file_handle, STREAM_TOCLIENT) {
-            Some((tx, files, flags)) => {
-                SCLogDebug!("updated TX {:?}", tx);
-                if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                    filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                            &file_name, reply.data, chunk_offset,
-                            reply.count, fill_bytes as u8, is_last, &r.hdr.xid);
-                    tdf.chunk_count += 1;
-                    if is_last {
-                        tdf.file_last_xid = r.hdr.xid;
-                        tx.rpc_response_status = r.reply_state;
-                        tx.nfs_response_status = reply.status;
-                        tx.is_last = true;
-                        tx.request_done = true;
+        let found =
+            match self.get_file_tx_by_handle(&file_handle, STREAM_TOCLIENT) {
+                Some((tx, files, flags)) => {
+                    SCLogDebug!("updated TX {:?}", tx);
+                    if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) =
+                        tx.type_data
+                    {
+                        filetracker_newchunk(
+                            &mut tdf.file_tracker,
+                            files,
+                            flags,
+                            &file_name,
+                            reply.data,
+                            chunk_offset,
+                            reply.count,
+                            fill_bytes as u8,
+                            is_last,
+                            &r.hdr.xid,
+                        );
+                        tdf.chunk_count += 1;
+                        if is_last {
+                            tdf.file_last_xid = r.hdr.xid;
+                            tx.rpc_response_status = r.reply_state;
+                            tx.nfs_response_status = reply.status;
+                            tx.is_last = true;
+                            tx.request_done = true;
 
-                        /* if this is a partial record we will close the tx
-                         * when we've received the final data */
-                        if !is_partial {
-                            tx.response_done = true;
-                            SCLogDebug!("TX {} is DONE", tx.id);
+                            /* if this is a partial record we will close the tx
+                             * when we've received the final data */
+                            if !is_partial {
+                                tx.response_done = true;
+                                SCLogDebug!("TX {} is DONE", tx.id);
+                            }
                         }
+                        true
+                    } else {
+                        false
                     }
-                    true
-                } else {
-                    false
                 }
-            },
-            None => { false },
-        };
+                None => false,
+            };
         if !found {
-            let (tx, files, flags) = self.new_file_tx(&file_handle, &file_name, STREAM_TOCLIENT);
-            if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                        &file_name, reply.data, chunk_offset,
-                        reply.count, fill_bytes as u8, is_last, &r.hdr.xid);
-                tx.procedure = if nfs_version < 4 { NFSPROC3_READ } else { NFSPROC4_READ };
+            let (tx, files, flags) =
+                self.new_file_tx(&file_handle, &file_name, STREAM_TOCLIENT);
+            if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) =
+                tx.type_data
+            {
+                filetracker_newchunk(
+                    &mut tdf.file_tracker,
+                    files,
+                    flags,
+                    &file_name,
+                    reply.data,
+                    chunk_offset,
+                    reply.count,
+                    fill_bytes as u8,
+                    is_last,
+                    &r.hdr.xid,
+                );
+                tx.procedure = if nfs_version < 4 {
+                    NFSPROC3_READ
+                } else {
+                    NFSPROC4_READ
+                };
                 tx.xid = r.hdr.xid;
                 tx.is_first = true;
                 if is_last {
@@ -890,7 +1045,8 @@ impl NFSState {
 
         if !self.is_udp {
             self.tc_chunk_xid = r.hdr.xid;
-            self.tc_chunk_left = (reply.count as u32 + fill_bytes) - reply.data.len() as u32;
+            self.tc_chunk_left =
+                (reply.count as u32 + fill_bytes) - reply.data.len() as u32;
         }
 
         SCLogDebug!("REPLY {} to procedure {} blob size {} / {}: chunk_left {} chunk_xid {:04X}",
@@ -899,9 +1055,17 @@ impl NFSState {
         0
     }
 
-    fn process_partial_read_reply_record<'b>(&mut self, r: &RpcReplyPacket<'b>, reply: &NfsReplyRead<'b>) -> u32 {
-        SCLogDebug!("REPLY {} to procedure READ blob size {} / {}",
-                r.hdr.xid, r.prog_data.len(), reply.count);
+    fn process_partial_read_reply_record<'b>(
+        &mut self,
+        r: &RpcReplyPacket<'b>,
+        reply: &NfsReplyRead<'b>,
+    ) -> u32 {
+        SCLogDebug!(
+            "REPLY {} to procedure READ blob size {} / {}",
+            r.hdr.xid,
+            r.prog_data.len(),
+            reply.count
+        );
 
         return self.process_read_record(r, reply, None);
     }
@@ -909,8 +1073,13 @@ impl NFSState {
     fn peek_reply_record(&mut self, r: &RpcPacketHeader) -> u32 {
         let xidmap;
         match self.requestmap.get(&r.xid) {
-            Some(p) => { xidmap = p; },
-            _ => { SCLogDebug!("REPLY: xid {} NOT FOUND", r.xid); return 0; },
+            Some(p) => {
+                xidmap = p;
+            }
+            _ => {
+                SCLogDebug!("REPLY: xid {} NOT FOUND", r.xid);
+                return 0;
+            }
         }
 
         xidmap.procedure
@@ -924,13 +1093,17 @@ impl NFSState {
         let gap = vec![0; gap_size as usize];
         let consumed = self.filetracker_update(STREAM_TOSERVER, &gap, gap_size);
         if consumed > gap_size {
-            SCLogDebug!("consumed more than GAP size: {} > {}", consumed, gap_size);
+            SCLogDebug!(
+                "consumed more than GAP size: {} > {}",
+                consumed,
+                gap_size
+            );
             return 1;
         }
         self.ts_ssn_gap = true;
         self.ts_gap = true;
         SCLogDebug!("parse_tcp_data_ts_gap ({}) done", gap_size);
-        return 0
+        return 0;
     }
 
     pub fn parse_tcp_data_tc_gap<'b>(&mut self, gap_size: u32) -> u32 {
@@ -941,20 +1114,24 @@ impl NFSState {
         let gap = vec![0; gap_size as usize];
         let consumed = self.filetracker_update(STREAM_TOCLIENT, &gap, gap_size);
         if consumed > gap_size {
-            SCLogDebug!("consumed more than GAP size: {} > {}", consumed, gap_size);
+            SCLogDebug!(
+                "consumed more than GAP size: {} > {}",
+                consumed,
+                gap_size
+            );
             return 1;
         }
         self.tc_ssn_gap = true;
         self.tc_gap = true;
         SCLogDebug!("parse_tcp_data_tc_gap ({}) done", gap_size);
-        return 0
+        return 0;
     }
 
     /// Parsing function, handling TCP chunks fragmentation
-    pub fn parse_tcp_data_ts<'b>(&mut self, i: &'b[u8]) -> u32 {
-        let mut v : Vec<u8>;
+    pub fn parse_tcp_data_ts<'b>(&mut self, i: &'b [u8]) -> u32 {
+        let mut v: Vec<u8>;
         let mut status = 0;
-        SCLogDebug!("parse_tcp_data_ts ({})",i.len());
+        SCLogDebug!("parse_tcp_data_ts ({})", i.len());
         //SCLogDebug!("{:?}",i);
         // Check if TCP data is being defragmented
         let tcp_buffer = match self.tcp_buffer_ts.len() {
@@ -963,13 +1140,16 @@ impl NFSState {
                 v = self.tcp_buffer_ts.split_off(0);
                 // sanity check vector length to avoid memory exhaustion
                 if self.tcp_buffer_ts.len() + i.len() > 1000000 {
-                    SCLogDebug!("parse_tcp_data_ts: TS buffer exploded {} {}",
-                            self.tcp_buffer_ts.len(), i.len());
+                    SCLogDebug!(
+                        "parse_tcp_data_ts: TS buffer exploded {} {}",
+                        self.tcp_buffer_ts.len(),
+                        i.len()
+                    );
                     return 1;
                 };
                 v.extend_from_slice(i);
                 v.as_slice()
-            },
+            }
         };
         //SCLogDebug!("tcp_buffer ({})",tcp_buffer.len());
         let mut cur_i = tcp_buffer;
@@ -980,11 +1160,16 @@ impl NFSState {
         // and skip buffer beyond it
         let consumed = self.filetracker_update(STREAM_TOSERVER, cur_i, 0);
         if consumed > 0 {
-            if consumed > cur_i.len() as u32 { return 1; }
+            if consumed > cur_i.len() as u32 {
+                return 1;
+            }
             cur_i = &cur_i[consumed as usize..];
         }
         if self.ts_gap {
-            SCLogDebug!("TS trying to catch up after GAP (input {})", cur_i.len());
+            SCLogDebug!(
+                "TS trying to catch up after GAP (input {})",
+                cur_i.len()
+            );
 
             let mut cnt = 0;
             while cur_i.len() > 0 {
@@ -994,25 +1179,28 @@ impl NFSState {
                         SCLogDebug!("expected data found");
                         self.ts_gap = false;
                         break;
-                    },
+                    }
                     0 => {
                         SCLogDebug!("incomplete, queue and retry with the next block (input {}). Looped {} times.", cur_i.len(), cnt);
                         self.tcp_buffer_tc.extend_from_slice(cur_i);
                         return 0;
-                    },
+                    }
                     -1 => {
                         cur_i = &cur_i[1..];
                         if cur_i.len() == 0 {
                             SCLogDebug!("all post-GAP data in this chunk was bad. Looped {} times.", cnt);
                         }
-                    },
-                    _ => { return 1; },
+                    }
+                    _ => {
+                        return 1;
+                    }
                 }
             }
             SCLogDebug!("TS GAP handling done (input {})", cur_i.len());
         }
 
-        while cur_i.len() > 0 { // min record size
+        while cur_i.len() > 0 {
+            // min record size
             match parse_rpc_request_partial(cur_i) {
                 IResult::Done(_, ref rpc_phdr) => {
                     let rec_size = (rpc_phdr.hdr.frag_len + 4) as usize;
@@ -1024,7 +1212,10 @@ impl NFSState {
                         // as these can be large.
                         if rec_size >= 512 && cur_i.len() >= 44 {
                             // large record, likely file xfer
-                            SCLogDebug!("large record {}, likely file xfer", rec_size);
+                            SCLogDebug!(
+                                "large record {}, likely file xfer",
+                                rec_size
+                            );
 
                             // quick peek, are in WRITE mode?
                             if rpc_phdr.procedure == NFSPROC3_WRITE {
@@ -1032,30 +1223,40 @@ impl NFSState {
 
                                 // lets try to parse the RPC record. Might fail with Incomplete.
                                 match parse_rpc(cur_i) {
-                                    IResult::Done(remaining, ref rpc_record) => {
-                                        match parse_nfs3_request_write(rpc_record.prog_data) {
-                                            IResult::Done(_, ref nfs_request_write) => {
+                                    IResult::Done(
+                                        remaining,
+                                        ref rpc_record,
+                                    ) => {
+                                        match parse_nfs3_request_write(
+                                            rpc_record.prog_data,
+                                        ) {
+                                            IResult::Done(
+                                                _,
+                                                ref nfs_request_write,
+                                            ) => {
                                                 // deal with the partial nfs write data
                                                 status |= self.process_partial_write_request_record(rpc_record, nfs_request_write);
                                                 cur_i = remaining; // progress input past parsed record
-                                            },
+                                            }
                                             _ => {
-                                                self.set_event(NFSEvent::MalformedData);
-                                            },
+                                                self.set_event(
+                                                    NFSEvent::MalformedData,
+                                                );
+                                            }
                                         }
-                                    },
+                                    }
                                     IResult::Incomplete(_) => {
                                         // we just size checked for the minimal record size above,
                                         // so if options are used (creds/verifier), we can still
                                         // have Incomplete data. Fall through to the buffer code
                                         // and try again on our next iteration.
                                         SCLogDebug!("TS data incomplete");
-                                    },
+                                    }
                                     IResult::Error(_e) => {
                                         self.set_event(NFSEvent::MalformedData);
                                         SCLogDebug!("Parsing failed: {:?}", _e);
                                         return 1;
-                                    },
+                                    }
                                 }
                             }
                         }
@@ -1069,7 +1270,7 @@ impl NFSState {
                         IResult::Done(_, ref rpc_record) => {
                             cur_i = &cur_i[rec_size..];
                             status |= self.process_request_record(rpc_record);
-                        },
+                        }
                         IResult::Incomplete(_) => {
                             cur_i = &cur_i[rec_size..]; // progress input past parsed record
 
@@ -1079,34 +1280,34 @@ impl NFSState {
                             self.set_event(NFSEvent::MalformedData);
 
                             status = 1;
-                        },
+                        }
                         IResult::Error(_e) => {
                             self.set_event(NFSEvent::MalformedData);
                             SCLogDebug!("Parsing failed: {:?}", _e);
                             return 1;
-                        },
+                        }
                     }
-                },
+                }
                 IResult::Incomplete(_) => {
                     SCLogDebug!("Fragmentation required (TCP level) 2");
                     self.tcp_buffer_ts.extend_from_slice(cur_i);
                     break;
-                },
+                }
                 IResult::Error(_e) => {
                     self.set_event(NFSEvent::MalformedData);
                     SCLogDebug!("Parsing failed: {:?}", _e);
                     return 1;
-                },
+                }
             }
-        };
+        }
         status
     }
 
     /// Parsing function, handling TCP chunks fragmentation
-    pub fn parse_tcp_data_tc<'b>(&mut self, i: &'b[u8]) -> u32 {
-        let mut v : Vec<u8>;
+    pub fn parse_tcp_data_tc<'b>(&mut self, i: &'b [u8]) -> u32 {
+        let mut v: Vec<u8>;
         let mut status = 0;
-        SCLogDebug!("parse_tcp_data_tc ({})",i.len());
+        SCLogDebug!("parse_tcp_data_tc ({})", i.len());
         //SCLogDebug!("{:?}",i);
         // Check if TCP data is being defragmented
         let tcp_buffer = match self.tcp_buffer_tc.len() {
@@ -1121,24 +1322,36 @@ impl NFSState {
 
                 v.extend_from_slice(i);
                 v.as_slice()
-            },
+            }
         };
-        SCLogDebug!("TC tcp_buffer ({}), input ({})",tcp_buffer.len(), i.len());
+        SCLogDebug!(
+            "TC tcp_buffer ({}), input ({})",
+            tcp_buffer.len(),
+            i.len()
+        );
 
         let mut cur_i = tcp_buffer;
         if cur_i.len() > 100000 {
-            SCLogDebug!("parse_tcp_data_tc: BUG buffer exploded {}", cur_i.len());
+            SCLogDebug!(
+                "parse_tcp_data_tc: BUG buffer exploded {}",
+                cur_i.len()
+            );
         }
 
         // take care of in progress file chunk transfers
         // and skip buffer beyond it
         let consumed = self.filetracker_update(STREAM_TOCLIENT, cur_i, 0);
         if consumed > 0 {
-            if consumed > cur_i.len() as u32 { return 1; }
+            if consumed > cur_i.len() as u32 {
+                return 1;
+            }
             cur_i = &cur_i[consumed as usize..];
         }
         if self.tc_gap {
-            SCLogDebug!("TC trying to catch up after GAP (input {})", cur_i.len());
+            SCLogDebug!(
+                "TC trying to catch up after GAP (input {})",
+                cur_i.len()
+            );
 
             let mut cnt = 0;
             while cur_i.len() > 0 {
@@ -1148,19 +1361,21 @@ impl NFSState {
                         SCLogDebug!("expected data found");
                         self.tc_gap = false;
                         break;
-                    },
+                    }
                     0 => {
                         SCLogDebug!("incomplete, queue and retry with the next block (input {}). Looped {} times.", cur_i.len(), cnt);
                         self.tcp_buffer_tc.extend_from_slice(cur_i);
                         return 0;
-                    },
+                    }
                     -1 => {
                         cur_i = &cur_i[1..];
                         if cur_i.len() == 0 {
                             SCLogDebug!("all post-GAP data in this chunk was bad. Looped {} times.", cnt);
                         }
-                    },
-                    _ => { return 1; },
+                    }
+                    _ => {
+                        return 1;
+                    }
                 }
             }
             SCLogDebug!("TC GAP handling done (input {})", cur_i.len());
@@ -1174,38 +1389,58 @@ impl NFSState {
                     if rec_size > cur_i.len() {
                         // special case: avoid buffering file read blobs
                         // as these can be large.
-                        if rec_size >= 512 && cur_i.len() >= 128 {//36 {
+                        if rec_size >= 512 && cur_i.len() >= 128 {
+                            //36 {
                             // large record, likely file xfer
-                            SCLogDebug!("large record {}, likely file xfer", rec_size);
+                            SCLogDebug!(
+                                "large record {}, likely file xfer",
+                                rec_size
+                            );
 
                             // quick peek, are in READ mode?
-                            if self.peek_reply_record(&rpc_hdr) == NFSPROC3_READ {
+                            if self.peek_reply_record(&rpc_hdr) == NFSPROC3_READ
+                            {
                                 SCLogDebug!("CONFIRMED large READ record {}, likely file chunk xfer", rec_size);
 
                                 // we should have enough data to parse the RPC record
                                 match parse_rpc_reply(cur_i) {
-                                    IResult::Done(remaining, ref rpc_record) => {
-                                        match parse_nfs3_reply_read(rpc_record.prog_data) {
-                                            IResult::Done(_, ref nfs_reply_read) => {
+                                    IResult::Done(
+                                        remaining,
+                                        ref rpc_record,
+                                    ) => {
+                                        match parse_nfs3_reply_read(
+                                            rpc_record.prog_data,
+                                        ) {
+                                            IResult::Done(
+                                                _,
+                                                ref nfs_reply_read,
+                                            ) => {
                                                 // deal with the partial nfs read data
                                                 status |= self.process_partial_read_reply_record(rpc_record, nfs_reply_read);
                                                 cur_i = remaining; // progress input past parsed record
-                                            },
+                                            }
                                             IResult::Incomplete(_) => {
-                                                self.set_event(NFSEvent::MalformedData);
-                                            },
+                                                self.set_event(
+                                                    NFSEvent::MalformedData,
+                                                );
+                                            }
                                             IResult::Error(_e) => {
-                                                self.set_event(NFSEvent::MalformedData);
-                                                SCLogDebug!("Parsing failed: {:?}", _e);
+                                                self.set_event(
+                                                    NFSEvent::MalformedData,
+                                                );
+                                                SCLogDebug!(
+                                                    "Parsing failed: {:?}",
+                                                    _e
+                                                );
                                                 return 1;
                                             }
                                         }
-                                    },
+                                    }
                                     IResult::Incomplete(_) => {
                                         // size check was done for MINIMAL record size,
                                         // so Incomplete is normal.
                                         SCLogDebug!("TC data incomplete");
-                                    },
+                                    }
                                     IResult::Error(_e) => {
                                         self.set_event(NFSEvent::MalformedData);
                                         SCLogDebug!("Parsing failed: {:?}", _e);
@@ -1223,7 +1458,7 @@ impl NFSState {
                         IResult::Done(_, ref rpc_record) => {
                             cur_i = &cur_i[rec_size..]; // progress input past parsed record
                             status |= self.process_reply_record(rpc_record);
-                        },
+                        }
                         IResult::Incomplete(_) => {
                             cur_i = &cur_i[rec_size..]; // progress input past parsed record
 
@@ -1233,30 +1468,30 @@ impl NFSState {
                             self.set_event(NFSEvent::MalformedData);
 
                             status = 1;
-                        },
+                        }
                         IResult::Error(_e) => {
                             self.set_event(NFSEvent::MalformedData);
                             SCLogDebug!("Parsing failed: {:?}", _e);
                             return 1;
                         }
                     }
-                },
+                }
                 IResult::Incomplete(_) => {
                     SCLogDebug!("REPLY: insufficient data for HDR");
                     self.tcp_buffer_tc.extend_from_slice(cur_i);
                     break;
-                },
+                }
                 IResult::Error(_e) => {
                     self.set_event(NFSEvent::MalformedData);
                     SCLogDebug!("Parsing failed: {:?}", _e);
                     return 1;
-                },
+                }
             }
-        };
+        }
         status
     }
     /// Parsing function
-    pub fn parse_udp_ts<'b>(&mut self, input: &'b[u8]) -> u32 {
+    pub fn parse_udp_ts<'b>(&mut self, input: &'b [u8]) -> u32 {
         let mut status = 0;
         SCLogDebug!("parse_udp_ts ({})", input.len());
         if input.len() > 0 {
@@ -1266,24 +1501,27 @@ impl NFSState {
                     match rpc_record.progver {
                         3 => {
                             status |= self.process_request_record(rpc_record);
-                        },
+                        }
                         2 => {
-                            status |= self.process_request_record_v2(rpc_record);
-                        },
-                        _ => { status = 1; },
+                            status |=
+                                self.process_request_record_v2(rpc_record);
+                        }
+                        _ => {
+                            status = 1;
+                        }
                     }
-                },
-                IResult::Incomplete(_) => {
-                },
-                IResult::Error(_e) => { SCLogDebug!("Parsing failed: {:?}", _e);
-                },
+                }
+                IResult::Incomplete(_) => {}
+                IResult::Error(_e) => {
+                    SCLogDebug!("Parsing failed: {:?}", _e);
+                }
             }
         }
         status
     }
 
     /// Parsing function
-    pub fn parse_udp_tc<'b>(&mut self, input: &'b[u8]) -> u32 {
+    pub fn parse_udp_tc<'b>(&mut self, input: &'b [u8]) -> u32 {
         let mut status = 0;
         SCLogDebug!("parse_udp_tc ({})", input.len());
         if input.len() > 0 {
@@ -1291,17 +1529,16 @@ impl NFSState {
                 IResult::Done(_, ref rpc_record) => {
                     self.is_udp = true;
                     status |= self.process_reply_record(rpc_record);
-                },
-                IResult::Incomplete(_) => {
-                },
+                }
+                IResult::Incomplete(_) => {}
                 IResult::Error(_e) => {
                     SCLogDebug!("Parsing failed: {:?}", _e);
-                },
+                }
             }
         };
         status
     }
-    fn getfiles(&mut self, direction: u8) -> * mut FileContainer {
+    fn getfiles(&mut self, direction: u8) -> *mut FileContainer {
         //SCLogDebug!("direction: {}", direction);
         if direction == STREAM_TOCLIENT {
             &mut self.files.files_tc as *mut FileContainer
@@ -1325,7 +1562,7 @@ pub extern "C" fn rs_nfs_state_new() -> *mut libc::c_void {
     let state = NFSState::new();
     let boxed = Box::new(state);
     SCLogDebug!("allocating state");
-    return unsafe{transmute(boxed)};
+    return unsafe { transmute(boxed) };
 }
 
 /// Params:
@@ -1334,21 +1571,21 @@ pub extern "C" fn rs_nfs_state_new() -> *mut libc::c_void {
 pub extern "C" fn rs_nfs_state_free(state: *mut libc::c_void) {
     // Just unbox...
     SCLogDebug!("freeing state");
-    let mut nfs_state: Box<NFSState> = unsafe{transmute(state)};
+    let mut nfs_state: Box<NFSState> = unsafe { transmute(state) };
     nfs_state.free();
 }
 
 /// C binding parse a NFS TCP request. Returns 1 on success, -1 on failure.
 #[no_mangle]
-pub extern "C" fn rs_nfs_parse_request(_flow: *mut Flow,
-                                       state: &mut NFSState,
-                                       _pstate: *mut libc::c_void,
-                                       input: *mut libc::uint8_t,
-                                       input_len: libc::uint32_t,
-                                       _data: *mut libc::c_void)
-                                       -> libc::int8_t
-{
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+pub extern "C" fn rs_nfs_parse_request(
+    _flow: *mut Flow,
+    state: &mut NFSState,
+    _pstate: *mut libc::c_void,
+    input: *mut libc::uint8_t,
+    input_len: libc::uint32_t,
+    _data: *mut libc::c_void,
+) -> libc::int8_t {
+    let buf = unsafe { std::slice::from_raw_parts(input, input_len as usize) };
     SCLogDebug!("parsing {} bytes of request data", input_len);
 
     if state.parse_tcp_data_ts(buf) == 0 {
@@ -1360,10 +1597,9 @@ pub extern "C" fn rs_nfs_parse_request(_flow: *mut Flow,
 
 #[no_mangle]
 pub extern "C" fn rs_nfs_parse_request_tcp_gap(
-                                        state: &mut NFSState,
-                                        input_len: libc::uint32_t)
-                                        -> libc::int8_t
-{
+    state: &mut NFSState,
+    input_len: libc::uint32_t,
+) -> libc::int8_t {
     if state.parse_tcp_data_ts_gap(input_len as u32) == 0 {
         return 1;
     }
@@ -1371,16 +1607,16 @@ pub extern "C" fn rs_nfs_parse_request_tcp_gap(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_parse_response(_flow: *mut Flow,
-                                        state: &mut NFSState,
-                                        _pstate: *mut libc::c_void,
-                                        input: *mut libc::uint8_t,
-                                        input_len: libc::uint32_t,
-                                        _data: *mut libc::c_void)
-                                        -> libc::int8_t
-{
+pub extern "C" fn rs_nfs_parse_response(
+    _flow: *mut Flow,
+    state: &mut NFSState,
+    _pstate: *mut libc::c_void,
+    input: *mut libc::uint8_t,
+    input_len: libc::uint32_t,
+    _data: *mut libc::c_void,
+) -> libc::int8_t {
     SCLogDebug!("parsing {} bytes of response data", input_len);
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+    let buf = unsafe { std::slice::from_raw_parts(input, input_len as usize) };
 
     if state.parse_tcp_data_tc(buf) == 0 {
         1
@@ -1391,10 +1627,9 @@ pub extern "C" fn rs_nfs_parse_response(_flow: *mut Flow,
 
 #[no_mangle]
 pub extern "C" fn rs_nfs_parse_response_tcp_gap(
-                                        state: &mut NFSState,
-                                        input_len: libc::uint32_t)
-                                        -> libc::int8_t
-{
+    state: &mut NFSState,
+    input_len: libc::uint32_t,
+) -> libc::int8_t {
     if state.parse_tcp_data_tc_gap(input_len as u32) == 0 {
         return 1;
     }
@@ -1403,15 +1638,15 @@ pub extern "C" fn rs_nfs_parse_response_tcp_gap(
 
 /// C binding parse a DNS request. Returns 1 on success, -1 on failure.
 #[no_mangle]
-pub extern "C" fn rs_nfs_parse_request_udp(_flow: *mut Flow,
-                                       state: &mut NFSState,
-                                       _pstate: *mut libc::c_void,
-                                       input: *mut libc::uint8_t,
-                                       input_len: libc::uint32_t,
-                                       _data: *mut libc::c_void)
-                                       -> libc::int8_t
-{
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+pub extern "C" fn rs_nfs_parse_request_udp(
+    _flow: *mut Flow,
+    state: &mut NFSState,
+    _pstate: *mut libc::c_void,
+    input: *mut libc::uint8_t,
+    input_len: libc::uint32_t,
+    _data: *mut libc::c_void,
+) -> libc::int8_t {
+    let buf = unsafe { std::slice::from_raw_parts(input, input_len as usize) };
     SCLogDebug!("parsing {} bytes of request data", input_len);
 
     if state.parse_udp_ts(buf) == 0 {
@@ -1422,16 +1657,16 @@ pub extern "C" fn rs_nfs_parse_request_udp(_flow: *mut Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_parse_response_udp(_flow: *mut Flow,
-                                        state: &mut NFSState,
-                                        _pstate: *mut libc::c_void,
-                                        input: *mut libc::uint8_t,
-                                        input_len: libc::uint32_t,
-                                        _data: *mut libc::c_void)
-                                        -> libc::int8_t
-{
+pub extern "C" fn rs_nfs_parse_response_udp(
+    _flow: *mut Flow,
+    state: &mut NFSState,
+    _pstate: *mut libc::c_void,
+    input: *mut libc::uint8_t,
+    input_len: libc::uint32_t,
+    _data: *mut libc::c_void,
+) -> libc::int8_t {
     SCLogDebug!("parsing {} bytes of response data", input_len);
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+    let buf = unsafe { std::slice::from_raw_parts(input, input_len as usize) };
 
     if state.parse_udp_tc(buf) == 0 {
         1
@@ -1441,21 +1676,21 @@ pub extern "C" fn rs_nfs_parse_response_udp(_flow: *mut Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_get_tx_count(state: &mut NFSState)
-                                            -> libc::uint64_t
-{
+pub extern "C" fn rs_nfs_state_get_tx_count(
+    state: &mut NFSState,
+) -> libc::uint64_t {
     SCLogDebug!("rs_nfs_state_get_tx_count: returning {}", state.tx_id);
     return state.tx_id;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_get_tx(state: &mut NFSState,
-                                      tx_id: libc::uint64_t)
-                                      -> *mut NFSTransaction
-{
+pub extern "C" fn rs_nfs_state_get_tx(
+    state: &mut NFSState,
+    tx_id: libc::uint64_t,
+) -> *mut NFSTransaction {
     match state.get_tx_by_id(tx_id) {
         Some(tx) => {
-            return unsafe{transmute(tx)};
+            return unsafe { transmute(tx) };
         }
         None => {
             return std::ptr::null_mut();
@@ -1466,15 +1701,16 @@ pub extern "C" fn rs_nfs_state_get_tx(state: &mut NFSState,
 // for use with the C API call StateGetTxIterator
 #[no_mangle]
 pub extern "C" fn rs_nfs_state_get_tx_iterator(
-                                      state: &mut NFSState,
-                                      min_tx_id: libc::uint64_t,
-                                      istate: &mut libc::uint64_t)
-                                      -> applayer::AppLayerGetTxIterTuple
-{
+    state: &mut NFSState,
+    min_tx_id: libc::uint64_t,
+    istate: &mut libc::uint64_t,
+) -> applayer::AppLayerGetTxIterTuple {
     match state.get_tx_iterator(min_tx_id, istate) {
         Some((tx, out_tx_id, has_next)) => {
             let c_tx = unsafe { transmute(tx) };
-            let ires = applayer::AppLayerGetTxIterTuple::with_values(c_tx, out_tx_id, has_next);
+            let ires = applayer::AppLayerGetTxIterTuple::with_values(
+                c_tx, out_tx_id, has_next,
+            );
             return ires;
         }
         None => {
@@ -1484,25 +1720,25 @@ pub extern "C" fn rs_nfs_state_get_tx_iterator(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_tx_free(state: &mut NFSState,
-                                       tx_id: libc::uint64_t)
-{
+pub extern "C" fn rs_nfs_state_tx_free(
+    state: &mut NFSState,
+    tx_id: libc::uint64_t,
+) {
     state.free_tx(tx_id);
 }
 
 #[no_mangle]
 pub extern "C" fn rs_nfs_state_progress_completion_status(
-    _direction: libc::uint8_t)
-    -> libc::c_int
-{
+    _direction: libc::uint8_t,
+) -> libc::c_int {
     return 1;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_tx_get_alstate_progress(tx: &mut NFSTransaction,
-                                                  direction: libc::uint8_t)
-                                                  -> libc::uint8_t
-{
+pub extern "C" fn rs_nfs_tx_get_alstate_progress(
+    tx: &mut NFSTransaction,
+    direction: libc::uint8_t,
+) -> libc::uint8_t {
     if direction == STREAM_TOSERVER && tx.request_done {
         //SCLogNotice!("TOSERVER progress 1");
         return 1;
@@ -1516,39 +1752,39 @@ pub extern "C" fn rs_nfs_tx_get_alstate_progress(tx: &mut NFSTransaction,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_tx_set_logged(_state: &mut NFSState,
-                                       tx: &mut NFSTransaction,
-                                       logged: libc::uint32_t)
-{
+pub extern "C" fn rs_nfs_tx_set_logged(
+    _state: &mut NFSState,
+    tx: &mut NFSTransaction,
+    logged: libc::uint32_t,
+) {
     tx.logged.set(logged);
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_tx_get_logged(_state: &mut NFSState,
-                                       tx: &mut NFSTransaction)
-                                       -> u32
-{
+pub extern "C" fn rs_nfs_tx_get_logged(
+    _state: &mut NFSState,
+    tx: &mut NFSTransaction,
+) -> u32 {
     return tx.logged.get();
 }
 
 #[no_mangle]
 pub extern "C" fn rs_nfs_state_set_tx_detect_state(
     tx: &mut NFSTransaction,
-    de_state: &mut DetectEngineState)
-{
+    de_state: &mut DetectEngineState,
+) {
     tx.de_state = Some(de_state);
 }
 
 #[no_mangle]
 pub extern "C" fn rs_nfs_state_get_tx_detect_state(
-    tx: &mut NFSTransaction)
-    -> *mut DetectEngineState
-{
+    tx: &mut NFSTransaction,
+) -> *mut DetectEngineState {
     match tx.de_state {
         Some(ds) => {
             SCLogDebug!("{}: getting de_state", tx.id);
             return ds;
-        },
+        }
         None => {
             SCLogDebug!("{}: getting de_state: have none", tx.id);
             return std::ptr::null_mut();
@@ -1558,10 +1794,10 @@ pub extern "C" fn rs_nfs_state_get_tx_detect_state(
 
 #[no_mangle]
 pub extern "C" fn rs_nfs_tx_set_detect_flags(
-                                       tx: &mut NFSTransaction,
-                                       direction: libc::uint8_t,
-                                       flags: libc::uint64_t)
-{
+    tx: &mut NFSTransaction,
+    direction: libc::uint8_t,
+    flags: libc::uint64_t,
+) {
     if (direction & STREAM_TOSERVER) != 0 {
         tx.detect_flags_ts = flags as u64;
     } else {
@@ -1571,10 +1807,9 @@ pub extern "C" fn rs_nfs_tx_set_detect_flags(
 
 #[no_mangle]
 pub extern "C" fn rs_nfs_tx_get_detect_flags(
-                                       tx: &mut NFSTransaction,
-                                       direction: libc::uint8_t)
-                                       -> libc::uint64_t
-{
+    tx: &mut NFSTransaction,
+    direction: libc::uint8_t,
+) -> libc::uint64_t {
     if (direction & STREAM_TOSERVER) != 0 {
         return tx.detect_flags_ts as libc::uint64_t;
     } else {
@@ -1583,10 +1818,10 @@ pub extern "C" fn rs_nfs_tx_get_detect_flags(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_get_events(state: &mut NFSState,
-                                          tx_id: libc::uint64_t)
-                                          -> *mut AppLayerDecoderEvents
-{
+pub extern "C" fn rs_nfs_state_get_events(
+    state: &mut NFSState,
+    tx_id: libc::uint64_t,
+) -> *mut AppLayerDecoderEvents {
     match state.get_tx_by_id(tx_id) {
         Some(tx) => {
             return tx.events;
@@ -1598,11 +1833,11 @@ pub extern "C" fn rs_nfs_state_get_events(state: &mut NFSState,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_get_event_info(event_name: *const libc::c_char,
-                                              event_id: *mut libc::c_int,
-                                              event_type: *mut AppLayerEventType)
-                                              -> i8
-{
+pub extern "C" fn rs_nfs_state_get_event_info(
+    event_name: *const libc::c_char,
+    event_id: *mut libc::c_int,
+    event_type: *mut AppLayerEventType,
+) -> i8 {
     if event_name == std::ptr::null() {
         return -1;
     }
@@ -1613,10 +1848,10 @@ pub extern "C" fn rs_nfs_state_get_event_info(event_name: *const libc::c_char,
                 "malformed_data" => NFSEvent::MalformedData as i32,
                 _ => -1, // unknown event
             }
-        },
+        }
         Err(_) => -1, // UTF-8 conversion failed
     };
-    unsafe{
+    unsafe {
         *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
         *event_id = event as libc::c_int;
     };
@@ -1627,11 +1862,11 @@ pub extern "C" fn rs_nfs_state_get_event_info(event_name: *const libc::c_char,
 /// otherwise get procs from the 'file_additional_procs'.
 /// Keep calling until 0 is returned.
 #[no_mangle]
-pub extern "C" fn rs_nfs_tx_get_procedures(tx: &mut NFSTransaction,
-                                           i: libc::uint16_t,
-                                           procedure: *mut libc::uint32_t)
-                                           -> libc::uint8_t
-{
+pub extern "C" fn rs_nfs_tx_get_procedures(
+    tx: &mut NFSTransaction,
+    i: libc::uint16_t,
+    procedure: *mut libc::uint32_t,
+) -> libc::uint8_t {
     if i == 0 {
         unsafe {
             *procedure = tx.procedure as libc::uint32_t;
@@ -1659,17 +1894,17 @@ pub extern "C" fn rs_nfs_tx_get_procedures(tx: &mut NFSTransaction,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_tx_get_version(tx: &mut NFSTransaction,
-                                        version: *mut libc::uint32_t)
-{
+pub extern "C" fn rs_nfs_tx_get_version(
+    tx: &mut NFSTransaction,
+    version: *mut libc::uint32_t,
+) {
     unsafe {
         *version = tx.nfs_version as libc::uint32_t;
     }
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_init(context: &'static mut SuricataFileContext)
-{
+pub extern "C" fn rs_nfs_init(context: &'static mut SuricataFileContext) {
     unsafe {
         SURICATA_NFS_FILE_CONFIG = Some(context);
     }
@@ -1679,55 +1914,75 @@ pub fn nfs_probe(i: &[u8], direction: u8) -> i8 {
     if direction == STREAM_TOCLIENT {
         match parse_rpc_reply(i) {
             IResult::Done(_, ref rpc) => {
-                if rpc.hdr.frag_len >= 24 && rpc.hdr.frag_len <= 35000 && rpc.hdr.msgtype == 1 && rpc.reply_state == 0 && rpc.accept_state == 0 {
-                    SCLogDebug!("TC PROBE LEN {} XID {} TYPE {}", rpc.hdr.frag_len, rpc.hdr.xid, rpc.hdr.msgtype);
+                if rpc.hdr.frag_len >= 24
+                    && rpc.hdr.frag_len <= 35000
+                    && rpc.hdr.msgtype == 1
+                    && rpc.reply_state == 0
+                    && rpc.accept_state == 0
+                {
+                    SCLogDebug!(
+                        "TC PROBE LEN {} XID {} TYPE {}",
+                        rpc.hdr.frag_len,
+                        rpc.hdr.xid,
+                        rpc.hdr.msgtype
+                    );
                     return 1;
                 } else {
                     return -1;
                 }
-            },
+            }
             IResult::Incomplete(_) => {
-                match parse_rpc_packet_header (i) {
+                match parse_rpc_packet_header(i) {
                     IResult::Done(_, ref rpc_hdr) => {
-                        if rpc_hdr.frag_len >= 24 && rpc_hdr.frag_len <= 35000 && rpc_hdr.xid != 0 && rpc_hdr.msgtype == 1 {
-                            SCLogDebug!("TC PROBE LEN {} XID {} TYPE {}", rpc_hdr.frag_len, rpc_hdr.xid, rpc_hdr.msgtype);
+                        if rpc_hdr.frag_len >= 24
+                            && rpc_hdr.frag_len <= 35000
+                            && rpc_hdr.xid != 0
+                            && rpc_hdr.msgtype == 1
+                        {
+                            SCLogDebug!(
+                                "TC PROBE LEN {} XID {} TYPE {}",
+                                rpc_hdr.frag_len,
+                                rpc_hdr.xid,
+                                rpc_hdr.msgtype
+                            );
                             return 1;
                         } else {
                             return -1;
                         }
-                    },
-                    IResult::Incomplete(_) => { },
+                    }
+                    IResult::Incomplete(_) => {}
                     IResult::Error(_) => {
                         return -1;
-                    },
+                    }
                 }
 
-
                 return 0;
-            },
+            }
             IResult::Error(_) => {
                 return -1;
-            },
+            }
         }
     } else {
         match parse_rpc(i) {
             IResult::Done(_, ref rpc) => {
-                if rpc.hdr.frag_len >= 40 && rpc.hdr.msgtype == 0 &&
-                   rpc.rpcver == 2 && (rpc.progver == 3 || rpc.progver == 4) &&
-                   rpc.program == 100003 &&
-                   rpc.procedure <= NFSPROC3_COMMIT
+                if rpc.hdr.frag_len >= 40
+                    && rpc.hdr.msgtype == 0
+                    && rpc.rpcver == 2
+                    && (rpc.progver == 3 || rpc.progver == 4)
+                    && rpc.program == 100003
+                    && rpc.procedure <= NFSPROC3_COMMIT
                 {
                     return 1;
                 } else {
                     return -1;
                 }
-            },
+            }
             IResult::Incomplete(_) => {
                 return 0;
-            },
+            }
             IResult::Error(_) => {
                 return -1;
-            },
+            }
         }
     }
 }
@@ -1736,95 +1991,123 @@ pub fn nfs_probe_udp(i: &[u8], direction: u8) -> i8 {
     if direction == STREAM_TOCLIENT {
         match parse_rpc_udp_reply(i) {
             IResult::Done(_, ref rpc) => {
-                if i.len() >= 32 && rpc.hdr.msgtype == 1 && rpc.reply_state == 0 && rpc.accept_state == 0 {
-                    SCLogDebug!("TC PROBE LEN {} XID {} TYPE {}", rpc.hdr.frag_len, rpc.hdr.xid, rpc.hdr.msgtype);
+                if i.len() >= 32
+                    && rpc.hdr.msgtype == 1
+                    && rpc.reply_state == 0
+                    && rpc.accept_state == 0
+                {
+                    SCLogDebug!(
+                        "TC PROBE LEN {} XID {} TYPE {}",
+                        rpc.hdr.frag_len,
+                        rpc.hdr.xid,
+                        rpc.hdr.msgtype
+                    );
                     return 1;
                 } else {
                     return -1;
                 }
-            },
+            }
             IResult::Incomplete(_) => {
                 return -1;
-            },
+            }
             IResult::Error(_) => {
                 return -1;
-            },
+            }
         }
     } else {
         match parse_rpc_udp_request(i) {
             IResult::Done(_, ref rpc) => {
-                if i.len() >= 48 && rpc.hdr.msgtype == 0 && rpc.progver == 3 && rpc.program == 100003 {
+                if i.len() >= 48
+                    && rpc.hdr.msgtype == 0
+                    && rpc.progver == 3
+                    && rpc.program == 100003
+                {
                     return 1;
-                } else if i.len() >= 48 && rpc.hdr.msgtype == 0 && rpc.progver == 2 && rpc.program == 100003 {
+                } else if i.len() >= 48
+                    && rpc.hdr.msgtype == 0
+                    && rpc.progver == 2
+                    && rpc.program == 100003
+                {
                     SCLogDebug!("NFSv2!");
                     return 1;
                 } else {
                     return -1;
                 }
-            },
+            }
             IResult::Incomplete(_) => {
                 return -1;
-            },
+            }
             IResult::Error(_) => {
                 return -1;
-            },
+            }
         }
     }
 }
 
 /// TOSERVER probe function
 #[no_mangle]
-pub extern "C" fn rs_nfs_probe_ts(input: *const libc::uint8_t, len: libc::uint32_t)
-                               -> libc::int8_t
-{
-    let slice: &[u8] = unsafe {
-        std::slice::from_raw_parts(input as *mut u8, len as usize)
-    };
+pub extern "C" fn rs_nfs_probe_ts(
+    input: *const libc::uint8_t,
+    len: libc::uint32_t,
+) -> libc::int8_t {
+    let slice: &[u8] =
+        unsafe { std::slice::from_raw_parts(input as *mut u8, len as usize) };
     return nfs_probe(slice, STREAM_TOSERVER);
 }
 
 /// TOCLIENT probe function
 #[no_mangle]
-pub extern "C" fn rs_nfs_probe_tc(input: *const libc::uint8_t, len: libc::uint32_t)
-                               -> libc::int8_t
-{
-    let slice: &[u8] = unsafe {
-        std::slice::from_raw_parts(input as *mut u8, len as usize)
-    };
+pub extern "C" fn rs_nfs_probe_tc(
+    input: *const libc::uint8_t,
+    len: libc::uint32_t,
+) -> libc::int8_t {
+    let slice: &[u8] =
+        unsafe { std::slice::from_raw_parts(input as *mut u8, len as usize) };
     return nfs_probe(slice, STREAM_TOCLIENT);
 }
 
 /// TOSERVER probe function
 #[no_mangle]
-pub extern "C" fn rs_nfs_probe_udp_ts(input: *const libc::uint8_t, len: libc::uint32_t)
-                               -> libc::int8_t
-{
-    let slice: &[u8] = unsafe {
-        std::slice::from_raw_parts(input as *mut u8, len as usize)
-    };
+pub extern "C" fn rs_nfs_probe_udp_ts(
+    input: *const libc::uint8_t,
+    len: libc::uint32_t,
+) -> libc::int8_t {
+    let slice: &[u8] =
+        unsafe { std::slice::from_raw_parts(input as *mut u8, len as usize) };
     return nfs_probe_udp(slice, STREAM_TOSERVER);
 }
 
 /// TOCLIENT probe function
 #[no_mangle]
-pub extern "C" fn rs_nfs_probe_udp_tc(input: *const libc::uint8_t, len: libc::uint32_t)
-                               -> libc::int8_t
-{
-    let slice: &[u8] = unsafe {
-        std::slice::from_raw_parts(input as *mut u8, len as usize)
-    };
+pub extern "C" fn rs_nfs_probe_udp_tc(
+    input: *const libc::uint8_t,
+    len: libc::uint32_t,
+) -> libc::int8_t {
+    let slice: &[u8] =
+        unsafe { std::slice::from_raw_parts(input as *mut u8, len as usize) };
     return nfs_probe_udp(slice, STREAM_TOCLIENT);
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_getfiles(direction: u8, ptr: *mut NFSState) -> * mut FileContainer {
-    if ptr.is_null() { panic!("NULL ptr"); };
+pub extern "C" fn rs_nfs_getfiles(
+    direction: u8,
+    ptr: *mut NFSState,
+) -> *mut FileContainer {
+    if ptr.is_null() {
+        panic!("NULL ptr");
+    };
     let parser = unsafe { &mut *ptr };
     parser.getfiles(direction)
 }
 #[no_mangle]
-pub extern "C" fn rs_nfs_setfileflags(direction: u8, ptr: *mut NFSState, flags: u16) {
-    if ptr.is_null() { panic!("NULL ptr"); };
+pub extern "C" fn rs_nfs_setfileflags(
+    direction: u8,
+    ptr: *mut NFSState,
+    flags: u16,
+) {
+    if ptr.is_null() {
+        panic!("NULL ptr");
+    };
     let parser = unsafe { &mut *ptr };
     SCLogDebug!("direction {} flags {}", direction, flags);
     parser.setfileflags(direction, flags)

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -26,18 +26,18 @@ use std::ffi::CStr;
 
 use nom::IResult;
 
-use log::*;
-use applayer;
-use applayer::LoggerFlags;
-use core::*;
-use filetracker::*;
-use filecontainer::*;
+use crate::log::*;
+use crate::applayer;
+use crate::applayer::LoggerFlags;
+use crate::core::*;
+use crate::filetracker::*;
+use crate::filecontainer::*;
 
-use nfs::types::*;
-use nfs::rpc_records::*;
-use nfs::nfs_records::*;
-use nfs::nfs2_records::*;
-use nfs::nfs3_records::*;
+use crate::nfs::types::*;
+use crate::nfs::rpc_records::*;
+use crate::nfs::nfs_records::*;
+use crate::nfs::nfs2_records::*;
+use crate::nfs::nfs3_records::*;
 
 pub static mut SURICATA_NFS_FILE_CONFIG: Option<&'static SuricataFileContext> = None;
 

--- a/rust/src/nfs/nfs2.rs
+++ b/rust/src/nfs/nfs2.rs
@@ -19,12 +19,12 @@
 
 use nom;
 use nom::IResult;
-use log::*;
+use crate::log::*;
 
-use nfs::nfs::*;
-use nfs::types::*;
-use nfs::rpc_records::*;
-use nfs::nfs2_records::*;
+use crate::nfs::nfs::*;
+use crate::nfs::types::*;
+use crate::nfs::rpc_records::*;
+use crate::nfs::nfs2_records::*;
 
 impl NFSState {
     /// complete request record

--- a/rust/src/nfs/nfs2.rs
+++ b/rust/src/nfs/nfs2.rs
@@ -17,20 +17,25 @@
 
 // written by Victor Julien
 
+use crate::log::*;
 use nom;
 use nom::IResult;
-use crate::log::*;
 
 use crate::nfs::nfs::*;
-use crate::nfs::types::*;
-use crate::nfs::rpc_records::*;
 use crate::nfs::nfs2_records::*;
+use crate::nfs::rpc_records::*;
+use crate::nfs::types::*;
 
 impl NFSState {
     /// complete request record
     pub fn process_request_record_v2<'b>(&mut self, r: &RpcPacket<'b>) -> u32 {
-        SCLogDebug!("NFSv2: REQUEST {} procedure {} ({}) blob size {}",
-                r.hdr.xid, r.procedure, self.requestmap.len(), r.prog_data.len());
+        SCLogDebug!(
+            "NFSv2: REQUEST {} procedure {} ({}) blob size {}",
+            r.hdr.xid,
+            r.procedure,
+            self.requestmap.len(),
+            r.prog_data.len()
+        );
 
         let mut xidmap = NFSRequestXidMap::new(r.progver, r.procedure, 0);
         let aux_file_name = Vec::new();
@@ -40,10 +45,10 @@ impl NFSState {
                 IResult::Done(_, ar) => {
                     xidmap.file_handle = ar.handle.value.to_vec();
                     self.xidmap_handle2name(&mut xidmap);
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             };
         } else if r.procedure == NFSPROC3_READ {
             match parse_nfs2_request_read(r.prog_data) {
@@ -51,16 +56,17 @@ impl NFSState {
                     xidmap.chunk_offset = read_record.offset as u64;
                     xidmap.file_handle = read_record.handle.value.to_vec();
                     self.xidmap_handle2name(&mut xidmap);
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             };
         }
 
         if !(r.procedure == NFSPROC3_COMMIT || // commit handled separately
              r.procedure == NFSPROC3_WRITE  || // write handled in file tx
-             r.procedure == NFSPROC3_READ)     // read handled in file tx at reply
+             r.procedure == NFSPROC3_READ)
+        // read handled in file tx at reply
         {
             let mut tx = self.new_tx();
             tx.xid = r.hdr.xid;
@@ -71,7 +77,8 @@ impl NFSState {
             tx.nfs_version = r.progver as u16;
 
             if r.procedure == NFSPROC3_RENAME {
-                tx.type_data = Some(NFSTransactionTypeData::RENAME(aux_file_name));
+                tx.type_data =
+                    Some(NFSTransactionTypeData::RENAME(aux_file_name));
             }
 
             tx.auth_type = r.creds_flavor;
@@ -80,11 +87,15 @@ impl NFSState {
                     tx.request_machine_name = u.machine_name_buf.to_vec();
                     tx.request_uid = u.uid;
                     tx.request_gid = u.gid;
-                },
-                _ => { },
+                }
+                _ => {}
             }
-            SCLogDebug!("NFSv2: TX created: ID {} XID {} PROCEDURE {}",
-                    tx.id, tx.xid, tx.procedure);
+            SCLogDebug!(
+                "NFSv2: TX created: ID {} XID {} PROCEDURE {}",
+                tx.id,
+                tx.xid,
+                tx.procedure
+            );
             self.transactions.push(tx);
         }
 
@@ -93,7 +104,11 @@ impl NFSState {
         0
     }
 
-    pub fn process_reply_record_v2<'b>(&mut self, r: &RpcReplyPacket<'b>, xidmap: &NFSRequestXidMap) -> u32 {
+    pub fn process_reply_record_v2<'b>(
+        &mut self,
+        r: &RpcReplyPacket<'b>,
+        xidmap: &NFSRequestXidMap,
+    ) -> u32 {
         let mut nfs_status = 0;
         let resp_handle = Vec::new();
 
@@ -103,26 +118,32 @@ impl NFSState {
                     SCLogDebug!("NFSv2: READ reply record");
                     self.process_read_record(r, reply, Some(&xidmap));
                     nfs_status = reply.status;
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             }
         } else {
             let stat = match nom::be_u32(&r.prog_data) {
-                nom::IResult::Done(_, stat) => {
-                    stat as u32
-                }
-                _ => 0 as u32
+                nom::IResult::Done(_, stat) => stat as u32,
+                _ => 0 as u32,
             };
             nfs_status = stat;
         }
-        SCLogDebug!("NFSv2: REPLY {} to procedure {} blob size {}",
-                r.hdr.xid, xidmap.procedure, r.prog_data.len());
+        SCLogDebug!(
+            "NFSv2: REPLY {} to procedure {} blob size {}",
+            r.hdr.xid,
+            xidmap.procedure,
+            r.prog_data.len()
+        );
 
-        self.mark_response_tx_done(r.hdr.xid, r.reply_state, nfs_status, &resp_handle);
+        self.mark_response_tx_done(
+            r.hdr.xid,
+            r.reply_state,
+            nfs_status,
+            &resp_handle,
+        );
 
         0
     }
-
 }

--- a/rust/src/nfs/nfs2_records.rs
+++ b/rust/src/nfs/nfs2_records.rs
@@ -16,12 +16,12 @@
  */
 
 //! Nom parsers for NFSv2 records
-use nom::{be_u32, rest};
 use crate::nfs::nfs_records::*;
+use nom::{be_u32, rest};
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs2Handle<'a> {
-    pub value: &'a[u8],
+    pub value: &'a [u8],
 }
 
 named!(pub parse_nfs2_handle<Nfs2Handle>,
@@ -34,7 +34,7 @@ named!(pub parse_nfs2_handle<Nfs2Handle>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs2RequestLookup<'a> {
     pub handle: Nfs2Handle<'a>,
     pub name_vec: Vec<u8>,
@@ -54,7 +54,7 @@ named!(pub parse_nfs2_request_lookup<Nfs2RequestLookup>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs2RequestRead<'a> {
     pub handle: Nfs2Handle<'a>,
     pub offset: u32,
@@ -92,8 +92,8 @@ named!(pub parse_nfs2_reply_read<NfsReplyRead>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
-pub struct Nfs2Attributes<> {
+#[derive(Debug, PartialEq)]
+pub struct Nfs2Attributes {
     pub atype: u32,
     pub asize: u32,
 }

--- a/rust/src/nfs/nfs2_records.rs
+++ b/rust/src/nfs/nfs2_records.rs
@@ -17,7 +17,7 @@
 
 //! Nom parsers for NFSv2 records
 use nom::{be_u32, rest};
-use nfs::nfs_records::*;
+use crate::nfs::nfs_records::*;
 
 #[derive(Debug,PartialEq)]
 pub struct Nfs2Handle<'a> {

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -17,29 +17,38 @@
 
 // written by Victor Julien
 
+use crate::core::*;
+use crate::log::*;
 use nom;
 use nom::IResult;
-use crate::log::*;
-use crate::core::*;
 
 use crate::nfs::nfs::*;
-use crate::nfs::types::*;
-use crate::nfs::rpc_records::*;
 use crate::nfs::nfs3_records::*;
+use crate::nfs::rpc_records::*;
+use crate::nfs::types::*;
 
 /// nom bug leads to this wrappers being necessary
 /// TODO for some reason putting these in parser.rs and making them public
 /// leads to a compile error wrt an unknown lifetime identifier 'a
 //named!(many0_nfs3_request_objects<Vec<Nfs3RequestObject<'a>>>, many0!(parse_nfs3_request_object));
 //named!(many0_nfs3_reply_objects<Vec<Nfs3ReplyObject<'a>>>, many0!(parse_nfs3_reply_object));
-named!(many0_nfs3_response_readdirplus_entries<Vec<Nfs3ResponseReaddirplusEntry<'a>>>,
-        many0!(parse_nfs3_response_readdirplus_entry_cond));
+named!(
+    many0_nfs3_response_readdirplus_entries<
+        Vec<Nfs3ResponseReaddirplusEntry<'a>>,
+    >,
+    many0!(parse_nfs3_response_readdirplus_entry_cond)
+);
 
 impl NFSState {
     /// complete NFS3 request record
     pub fn process_request_record_v3<'b>(&mut self, r: &RpcPacket<'b>) -> u32 {
-        SCLogDebug!("REQUEST {} procedure {} ({}) blob size {}",
-                r.hdr.xid, r.procedure, self.requestmap.len(), r.prog_data.len());
+        SCLogDebug!(
+            "REQUEST {} procedure {} ({}) blob size {}",
+            r.hdr.xid,
+            r.procedure,
+            self.requestmap.len(),
+            r.prog_data.len()
+        );
 
         let mut xidmap = NFSRequestXidMap::new(r.progver, r.procedure, 0);
         let mut aux_file_name = Vec::new();
@@ -50,36 +59,35 @@ impl NFSState {
 
         if r.procedure == NFSPROC3_LOOKUP {
             self.process_request_record_lookup(r, &mut xidmap);
-
         } else if r.procedure == NFSPROC3_ACCESS {
             match parse_nfs3_request_access(r.prog_data) {
                 IResult::Done(_, ar) => {
                     xidmap.file_handle = ar.handle.value.to_vec();
                     self.xidmap_handle2name(&mut xidmap);
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             };
         } else if r.procedure == NFSPROC3_GETATTR {
             match parse_nfs3_request_getattr(r.prog_data) {
                 IResult::Done(_, gar) => {
                     xidmap.file_handle = gar.handle.value.to_vec();
                     self.xidmap_handle2name(&mut xidmap);
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             };
         } else if r.procedure == NFSPROC3_READDIRPLUS {
             match parse_nfs3_request_readdirplus(r.prog_data) {
                 IResult::Done(_, rdp) => {
                     xidmap.file_handle = rdp.handle.value.to_vec();
                     self.xidmap_handle2name(&mut xidmap);
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             };
         } else if r.procedure == NFSPROC3_READ {
             match parse_nfs3_request_read(r.prog_data) {
@@ -87,72 +95,71 @@ impl NFSState {
                     xidmap.chunk_offset = nfs3_read_record.offset;
                     xidmap.file_handle = nfs3_read_record.handle.value.to_vec();
                     self.xidmap_handle2name(&mut xidmap);
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             };
         } else if r.procedure == NFSPROC3_WRITE {
             match parse_nfs3_request_write(r.prog_data) {
                 IResult::Done(_, w) => {
                     self.process_write_record(r, &w);
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             }
         } else if r.procedure == NFSPROC3_CREATE {
             match parse_nfs3_request_create(r.prog_data) {
                 IResult::Done(_, nfs3_create_record) => {
-                    xidmap.file_handle = nfs3_create_record.handle.value.to_vec();
+                    xidmap.file_handle =
+                        nfs3_create_record.handle.value.to_vec();
                     xidmap.file_name = nfs3_create_record.name_vec;
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             };
-
         } else if r.procedure == NFSPROC3_REMOVE {
             match parse_nfs3_request_remove(r.prog_data) {
                 IResult::Done(_, rr) => {
                     xidmap.file_handle = rr.handle.value.to_vec();
                     xidmap.file_name = rr.name_vec;
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             };
-
         } else if r.procedure == NFSPROC3_RENAME {
             match parse_nfs3_request_rename(r.prog_data) {
                 IResult::Done(_, rr) => {
                     xidmap.file_handle = rr.from_handle.value.to_vec();
                     xidmap.file_name = rr.from_name_vec;
                     aux_file_name = rr.to_name_vec;
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             };
         } else if r.procedure == NFSPROC3_MKDIR {
             match parse_nfs3_request_mkdir(r.prog_data) {
                 IResult::Done(_, mr) => {
                     xidmap.file_handle = mr.handle.value.to_vec();
                     xidmap.file_name = mr.name_vec;
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             };
         } else if r.procedure == NFSPROC3_RMDIR {
             match parse_nfs3_request_rmdir(r.prog_data) {
                 IResult::Done(_, rr) => {
                     xidmap.file_handle = rr.handle.value.to_vec();
                     xidmap.file_name = rr.name_vec;
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             };
         } else if r.procedure == NFSPROC3_COMMIT {
             SCLogDebug!("COMMIT, closing shop");
@@ -160,9 +167,14 @@ impl NFSState {
             match parse_nfs3_request_commit(r.prog_data) {
                 IResult::Done(_, cr) => {
                     let file_handle = cr.handle.value.to_vec();
-                    match self.get_file_tx_by_handle(&file_handle, STREAM_TOSERVER) {
+                    match self
+                        .get_file_tx_by_handle(&file_handle, STREAM_TOSERVER)
+                    {
                         Some((tx, files, flags)) => {
-                            if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
+                            if let Some(NFSTransactionTypeData::FILE(
+                                ref mut tdf,
+                            )) = tx.type_data
+                            {
                                 tdf.chunk_count += 1;
                                 tdf.file_additional_procs.push(NFSPROC3_COMMIT);
                                 tdf.file_tracker.close(files, flags);
@@ -170,19 +182,20 @@ impl NFSState {
                                 tx.is_last = true;
                                 tx.request_done = true;
                             }
-                        },
-                        None => { },
+                        }
+                        None => {}
                     }
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             };
         }
 
         if !(r.procedure == NFSPROC3_COMMIT || // commit handled separately
              r.procedure == NFSPROC3_WRITE  || // write handled in file tx
-             r.procedure == NFSPROC3_READ)     // read handled in file tx at reply
+             r.procedure == NFSPROC3_READ)
+        // read handled in file tx at reply
         {
             let mut tx = self.new_tx();
             tx.xid = r.hdr.xid;
@@ -193,7 +206,8 @@ impl NFSState {
             tx.file_handle = xidmap.file_handle.to_vec();
 
             if r.procedure == NFSPROC3_RENAME {
-                tx.type_data = Some(NFSTransactionTypeData::RENAME(aux_file_name));
+                tx.type_data =
+                    Some(NFSTransactionTypeData::RENAME(aux_file_name));
             }
 
             tx.auth_type = r.creds_flavor;
@@ -202,21 +216,29 @@ impl NFSState {
                     tx.request_machine_name = u.machine_name_buf.to_vec();
                     tx.request_uid = u.uid;
                     tx.request_gid = u.gid;
-                },
-                _ => { },
+                }
+                _ => {}
             }
-            SCLogDebug!("TX created: ID {} XID {} PROCEDURE {}",
-                    tx.id, tx.xid, tx.procedure);
+            SCLogDebug!(
+                "TX created: ID {} XID {} PROCEDURE {}",
+                tx.id,
+                tx.xid,
+                tx.procedure
+            );
             self.transactions.push(tx);
-
         } else if r.procedure == NFSPROC3_READ {
-
-            let found = match self.get_file_tx_by_handle(&xidmap.file_handle, STREAM_TOCLIENT) {
+            let found = match self
+                .get_file_tx_by_handle(&xidmap.file_handle, STREAM_TOCLIENT)
+            {
                 Some((_, _, _)) => true,
                 None => false,
             };
             if !found {
-                let (tx, _, _) = self.new_file_tx(&xidmap.file_handle, &xidmap.file_name, STREAM_TOCLIENT);
+                let (tx, _, _) = self.new_file_tx(
+                    &xidmap.file_handle,
+                    &xidmap.file_name,
+                    STREAM_TOCLIENT,
+                );
                 tx.procedure = NFSPROC3_READ;
                 tx.xid = r.hdr.xid;
                 tx.is_first = true;
@@ -228,8 +250,8 @@ impl NFSState {
                         tx.request_machine_name = u.machine_name_buf.to_vec();
                         tx.request_uid = u.uid;
                         tx.request_gid = u.gid;
-                    },
-                    _ => { },
+                    }
+                    _ => {}
                 }
             }
         }
@@ -238,7 +260,11 @@ impl NFSState {
         0
     }
 
-    pub fn process_reply_record_v3<'b>(&mut self, r: &RpcReplyPacket<'b>, xidmap: &mut NFSRequestXidMap) -> u32 {
+    pub fn process_reply_record_v3<'b>(
+        &mut self,
+        r: &RpcReplyPacket<'b>,
+        xidmap: &mut NFSRequestXidMap,
+    ) -> u32 {
         let mut nfs_status = 0;
         let mut resp_handle = Vec::new();
 
@@ -246,46 +272,57 @@ impl NFSState {
             match parse_nfs3_response_lookup(r.prog_data) {
                 IResult::Done(_, lookup) => {
                     SCLogDebug!("LOOKUP: {:?}", lookup);
-                    SCLogDebug!("RESPONSE LOOKUP file_name {:?}", xidmap.file_name);
+                    SCLogDebug!(
+                        "RESPONSE LOOKUP file_name {:?}",
+                        xidmap.file_name
+                    );
 
                     nfs_status = lookup.status;
 
                     SCLogDebug!("LOOKUP handle {:?}", lookup.handle);
-                    self.namemap.insert(lookup.handle.value.to_vec(), xidmap.file_name.to_vec());
+                    self.namemap.insert(
+                        lookup.handle.value.to_vec(),
+                        xidmap.file_name.to_vec(),
+                    );
                     resp_handle = lookup.handle.value.to_vec();
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             };
         } else if xidmap.procedure == NFSPROC3_CREATE {
             match parse_nfs3_response_create(r.prog_data) {
                 IResult::Done(_, nfs3_create_record) => {
                     SCLogDebug!("nfs3_create_record: {:?}", nfs3_create_record);
 
-                    SCLogDebug!("RESPONSE CREATE file_name {:?}", xidmap.file_name);
+                    SCLogDebug!(
+                        "RESPONSE CREATE file_name {:?}",
+                        xidmap.file_name
+                    );
                     nfs_status = nfs3_create_record.status;
 
                     if let Some(h) = nfs3_create_record.handle {
                         SCLogDebug!("handle {:?}", h);
-                        self.namemap.insert(h.value.to_vec(), xidmap.file_name.to_vec());
+                        self.namemap.insert(
+                            h.value.to_vec(),
+                            xidmap.file_name.to_vec(),
+                        );
                         resp_handle = h.value.to_vec();
                     }
-
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             };
         } else if xidmap.procedure == NFSPROC3_READ {
             match parse_nfs3_reply_read(r.prog_data) {
                 IResult::Done(_, ref reply) => {
                     self.process_read_record(r, reply, Some(&xidmap));
                     nfs_status = reply.status;
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             }
         } else if xidmap.procedure == NFSPROC3_READDIRPLUS {
             match parse_nfs3_response_readdirplus(r.prog_data) {
@@ -295,7 +332,7 @@ impl NFSState {
                     nfs_status = reply.status;
 
                     // cut off final eof field
-                    let d = &reply.data[..reply.data.len()-4 as usize];
+                    let d = &reply.data[..reply.data.len() - 4 as usize];
 
                     // store all handle/filename mappings
                     match many0_nfs3_response_readdirplus_entries(d) {
@@ -308,46 +345,57 @@ impl NFSState {
                                         match e.handle {
                                             Some(ref h) => {
                                                 SCLogDebug!("h {:?}", h);
-                                                self.namemap.insert(h.value.to_vec(), e.name_vec.to_vec());
-                                            },
-                                            _ => { },
+                                                self.namemap.insert(
+                                                    h.value.to_vec(),
+                                                    e.name_vec.to_vec(),
+                                                );
+                                            }
+                                            _ => {}
                                         }
-                                    },
-                                    _ => { },
+                                    }
+                                    _ => {}
                                 }
                             }
 
-                            SCLogDebug!("READDIRPLUS ENTRIES reply {:?}", entries);
-                        },
+                            SCLogDebug!(
+                                "READDIRPLUS ENTRIES reply {:?}",
+                                entries
+                            );
+                        }
                         _ => {
                             self.set_event(NFSEvent::MalformedData);
-                        },
+                        }
                     }
-                },
+                }
                 _ => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             }
         }
         // for all other record types only parse the status
         else {
             let stat = match nom::be_u32(&r.prog_data) {
-                nom::IResult::Done(_, stat) => {
-                    stat as u32
-                }
-                _ => 0 as u32
+                nom::IResult::Done(_, stat) => stat as u32,
+                _ => 0 as u32,
             };
             nfs_status = stat;
         }
-        SCLogDebug!("REPLY {} to procedure {} blob size {}",
-                r.hdr.xid, xidmap.procedure, r.prog_data.len());
+        SCLogDebug!(
+            "REPLY {} to procedure {} blob size {}",
+            r.hdr.xid,
+            xidmap.procedure,
+            r.prog_data.len()
+        );
 
         if xidmap.procedure != NFSPROC3_READ {
-            self.mark_response_tx_done(r.hdr.xid, r.reply_state, nfs_status, &resp_handle);
+            self.mark_response_tx_done(
+                r.hdr.xid,
+                r.reply_state,
+                nfs_status,
+                &resp_handle,
+            );
         }
 
         0
     }
-
 }
-

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -19,13 +19,13 @@
 
 use nom;
 use nom::IResult;
-use log::*;
-use core::*;
+use crate::log::*;
+use crate::core::*;
 
-use nfs::nfs::*;
-use nfs::types::*;
-use nfs::rpc_records::*;
-use nfs::nfs3_records::*;
+use crate::nfs::nfs::*;
+use crate::nfs::types::*;
+use crate::nfs::rpc_records::*;
+use crate::nfs::nfs3_records::*;
 
 /// nom bug leads to this wrappers being necessary
 /// TODO for some reason putting these in parser.rs and making them public

--- a/rust/src/nfs/nfs3_records.rs
+++ b/rust/src/nfs/nfs3_records.rs
@@ -17,13 +17,13 @@
 
 //! Nom parsers for RPC & NFSv3
 
-use nom::{be_u32, be_u64, rest};
 use crate::nfs::nfs_records::*;
+use nom::{be_u32, be_u64, rest};
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3Handle<'a> {
     pub len: u32,
-    pub value: &'a[u8],
+    pub value: &'a [u8],
 }
 
 named!(pub parse_nfs3_handle<Nfs3Handle>,
@@ -38,7 +38,7 @@ named!(pub parse_nfs3_handle<Nfs3Handle>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3ReplyCreate<'a> {
     pub status: u32,
     pub handle: Option<Nfs3Handle<'a>>,
@@ -57,7 +57,7 @@ named!(pub parse_nfs3_response_create<Nfs3ReplyCreate>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3ReplyLookup<'a> {
     pub status: u32,
     pub handle: Nfs3Handle<'a>,
@@ -75,12 +75,12 @@ named!(pub parse_nfs3_response_lookup<Nfs3ReplyLookup>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3RequestCreate<'a> {
     pub handle: Nfs3Handle<'a>,
     pub name_len: u32,
     pub create_mode: u32,
-    pub verifier: &'a[u8],
+    pub verifier: &'a [u8],
     pub name_vec: Vec<u8>,
 }
 
@@ -102,7 +102,7 @@ named!(pub parse_nfs3_request_create<Nfs3RequestCreate>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3RequestRemove<'a> {
     pub handle: Nfs3Handle<'a>,
     pub name_len: u32,
@@ -124,7 +124,7 @@ named!(pub parse_nfs3_request_remove<Nfs3RequestRemove>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3RequestRmdir<'a> {
     pub handle: Nfs3Handle<'a>,
     pub name_vec: Vec<u8>,
@@ -144,7 +144,7 @@ named!(pub parse_nfs3_request_rmdir<Nfs3RequestRmdir>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3RequestMkdir<'a> {
     pub handle: Nfs3Handle<'a>,
     pub name_vec: Vec<u8>,
@@ -165,7 +165,7 @@ named!(pub parse_nfs3_request_mkdir<Nfs3RequestMkdir>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3RequestRename<'a> {
     pub from_handle: Nfs3Handle<'a>,
     pub from_name_vec: Vec<u8>,
@@ -193,7 +193,7 @@ named!(pub parse_nfs3_request_rename<Nfs3RequestRename>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3RequestGetAttr<'a> {
     pub handle: Nfs3Handle<'a>,
 }
@@ -208,7 +208,7 @@ named!(pub parse_nfs3_request_getattr<Nfs3RequestGetAttr>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3RequestAccess<'a> {
     pub handle: Nfs3Handle<'a>,
     pub check_access: u32,
@@ -226,7 +226,7 @@ named!(pub parse_nfs3_request_access<Nfs3RequestAccess>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3RequestCommit<'a> {
     pub handle: Nfs3Handle<'a>,
 }
@@ -243,7 +243,7 @@ named!(pub parse_nfs3_request_commit<Nfs3RequestCommit>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3RequestRead<'a> {
     pub handle: Nfs3Handle<'a>,
     pub offset: u64,
@@ -262,7 +262,7 @@ named!(pub parse_nfs3_request_read<Nfs3RequestRead>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3RequestLookup<'a> {
     pub handle: Nfs3Handle<'a>,
 
@@ -283,8 +283,7 @@ named!(pub parse_nfs3_request_lookup<Nfs3RequestLookup>,
         ))
 );
 
-
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3ResponseReaddirplusEntryC<'a> {
     pub name_vec: Vec<u8>,
     pub handle: Option<Nfs3Handle<'a>>,
@@ -310,7 +309,7 @@ named!(pub parse_nfs3_response_readdirplus_entry<Nfs3ResponseReaddirplusEntryC>,
         )
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3ResponseReaddirplusEntry<'a> {
     pub entry: Option<Nfs3ResponseReaddirplusEntryC<'a>>,
 }
@@ -326,10 +325,10 @@ named!(pub parse_nfs3_response_readdirplus_entry_cond<Nfs3ResponseReaddirplusEnt
            ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3ResponseReaddirplus<'a> {
     pub status: u32,
-    pub data: &'a[u8],
+    pub data: &'a [u8],
 }
 
 named!(pub parse_nfs3_response_readdirplus<Nfs3ResponseReaddirplus>,
@@ -346,12 +345,12 @@ named!(pub parse_nfs3_response_readdirplus<Nfs3ResponseReaddirplus>,
         } ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3RequestReaddirplus<'a> {
     pub handle: Nfs3Handle<'a>,
 
     pub cookie: u32,
-    pub verifier: &'a[u8],
+    pub verifier: &'a [u8],
     pub dircount: u32,
     pub maxcount: u32,
 }
@@ -374,7 +373,7 @@ named!(pub parse_nfs3_request_readdirplus<Nfs3RequestReaddirplus>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs3RequestWrite<'a> {
     pub handle: Nfs3Handle<'a>,
 
@@ -382,7 +381,7 @@ pub struct Nfs3RequestWrite<'a> {
     pub count: u32,
     pub stable: u32,
     pub file_len: u32,
-    pub file_data: &'a[u8],
+    pub file_data: &'a [u8],
 }
 
 named!(pub parse_nfs3_request_write<Nfs3RequestWrite>,

--- a/rust/src/nfs/nfs3_records.rs
+++ b/rust/src/nfs/nfs3_records.rs
@@ -18,7 +18,7 @@
 //! Nom parsers for RPC & NFSv3
 
 use nom::{be_u32, be_u64, rest};
-use nfs::nfs_records::*;
+use crate::nfs::nfs_records::*;
 
 #[derive(Debug,PartialEq)]
 pub struct Nfs3Handle<'a> {

--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -19,31 +19,40 @@
 
 extern crate libc;
 
-use nom::{IResult, be_u32};
+use nom::{be_u32, IResult};
 
 use crate::core::*;
 use crate::log::*;
 
 use crate::nfs::nfs::*;
-use crate::nfs::types::*;
-use crate::nfs::rpc_records::*;
-use crate::nfs::nfs_records::*;
 use crate::nfs::nfs4_records::*;
+use crate::nfs::nfs_records::*;
+use crate::nfs::rpc_records::*;
+use crate::nfs::types::*;
 
 use crate::kerberos;
 
-named!(parse_req_gssapi<kerberos::Kerberos5Ticket>,
-   do_parse!(
+named!(
+    parse_req_gssapi<kerberos::Kerberos5Ticket>,
+    do_parse!(
         len: be_u32
-    >>  ap: flat_map!(take!(len), call!(kerberos::parse_kerberos5_request))
-    >> ( ap )
-));
+            >> ap: flat_map!(
+                take!(len),
+                call!(kerberos::parse_kerberos5_request)
+            )
+            >> (ap)
+    )
+);
 
 impl NFSState {
     /* normal write: PUTFH (file handle), WRITE (write opts/data). File handle
      * is not part of the write record itself so we pass it in here. */
-    fn write_v4<'b>(&mut self, r: &RpcPacket<'b>, w: &Nfs4RequestWrite<'b>, fh: &'b[u8])
-    {
+    fn write_v4<'b>(
+        &mut self,
+        r: &RpcPacket<'b>,
+        w: &Nfs4RequestWrite<'b>,
+        fh: &'b [u8],
+    ) {
         // for now assume that stable FILE_SYNC flags means a single chunk
         let is_last = if w.stable == 2 { true } else { false };
         SCLogDebug!("is_last {}", is_last);
@@ -59,36 +68,60 @@ impl NFSState {
             Some(n) => {
                 SCLogDebug!("WRITE name {:?}", n);
                 n.to_vec()
-            },
+            }
             None => {
                 SCLogDebug!("WRITE object {:?} not found", w.stateid.data);
                 Vec::new()
-            },
+            }
         };
 
-        let found = match self.get_file_tx_by_handle(&file_handle, STREAM_TOSERVER) {
-            Some((tx, files, flags)) => {
-                if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                    filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                            &file_name, w.data, w.offset,
-                            w.write_len, fill_bytes as u8, is_last, &r.hdr.xid);
-                    tdf.chunk_count += 1;
-                    if is_last {
-                        tdf.file_last_xid = r.hdr.xid;
-                        tx.is_last = true;
-                        tx.response_done = true;
+        let found =
+            match self.get_file_tx_by_handle(&file_handle, STREAM_TOSERVER) {
+                Some((tx, files, flags)) => {
+                    if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) =
+                        tx.type_data
+                    {
+                        filetracker_newchunk(
+                            &mut tdf.file_tracker,
+                            files,
+                            flags,
+                            &file_name,
+                            w.data,
+                            w.offset,
+                            w.write_len,
+                            fill_bytes as u8,
+                            is_last,
+                            &r.hdr.xid,
+                        );
+                        tdf.chunk_count += 1;
+                        if is_last {
+                            tdf.file_last_xid = r.hdr.xid;
+                            tx.is_last = true;
+                            tx.response_done = true;
+                        }
                     }
+                    true
                 }
-                true
-            },
-            None => { false },
-        };
+                None => false,
+            };
         if !found {
-            let (tx, files, flags) = self.new_file_tx(&file_handle, &file_name, STREAM_TOSERVER);
-            if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                        &file_name, w.data, w.offset,
-                        w.write_len, fill_bytes as u8, is_last, &r.hdr.xid);
+            let (tx, files, flags) =
+                self.new_file_tx(&file_handle, &file_name, STREAM_TOSERVER);
+            if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) =
+                tx.type_data
+            {
+                filetracker_newchunk(
+                    &mut tdf.file_tracker,
+                    files,
+                    flags,
+                    &file_name,
+                    w.data,
+                    w.offset,
+                    w.write_len,
+                    fill_bytes as u8,
+                    is_last,
+                    &r.hdr.xid,
+                );
                 tx.procedure = NFSPROC4_WRITE;
                 tx.xid = r.hdr.xid;
                 tx.is_first = true;
@@ -105,28 +138,32 @@ impl NFSState {
         self.ts_chunk_left = w.write_len as u32 - file_data_len as u32;
     }
 
-    fn commit_v4<'b>(&mut self, r: &RpcPacket<'b>, fh: &'b[u8])
-    {
+    fn commit_v4<'b>(&mut self, r: &RpcPacket<'b>, fh: &'b [u8]) {
         SCLogDebug!("COMMIT, closing shop");
 
         let file_handle = fh.to_vec();
         match self.get_file_tx_by_handle(&file_handle, STREAM_TOSERVER) {
             Some((tx, files, flags)) => {
-                if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
+                if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) =
+                    tx.type_data
+                {
                     tdf.file_tracker.close(files, flags);
                     tdf.file_last_xid = r.hdr.xid;
                     tx.is_last = true;
                     tx.request_done = true;
                 }
             }
-            None => {},
+            None => {}
         }
     }
 
-    fn new_tx_v4<'b>(&mut self, r: &RpcPacket<'b>,
-            xidmap: &NFSRequestXidMap, procedure: u32,
-            _aux_opcodes: &Vec<u32>)
-    {
+    fn new_tx_v4<'b>(
+        &mut self,
+        r: &RpcPacket<'b>,
+        xidmap: &NFSRequestXidMap,
+        procedure: u32,
+        _aux_opcodes: &Vec<u32>,
+    ) {
         let mut tx = self.new_tx();
         tx.xid = r.hdr.xid;
         tx.procedure = procedure;
@@ -141,24 +178,30 @@ impl NFSState {
                 tx.request_machine_name = u.machine_name_buf.to_vec();
                 tx.request_uid = u.uid;
                 tx.request_gid = u.gid;
-            },
-            _ => { },
+            }
+            _ => {}
         }
-        SCLogDebug!("NFSv4: TX created: ID {} XID {} PROCEDURE {}",
-                tx.id, tx.xid, tx.procedure);
+        SCLogDebug!(
+            "NFSv4: TX created: ID {} XID {} PROCEDURE {}",
+            tx.id,
+            tx.xid,
+            tx.procedure
+        );
         self.transactions.push(tx);
     }
 
     /* A normal READ request looks like: PUTFH (file handle) READ (read opts).
      * We need the file handle for the READ.
      */
-    fn compound_request<'b>(&mut self, r: &RpcPacket<'b>,
-            cr: &Nfs4RequestCompoundRecord<'b>,
-            xidmap: &mut NFSRequestXidMap)
-    {
-        let mut last_putfh : Option<&'b[u8]> = None;
-        let mut main_opcode : u32 = 0;
-        let mut aux_opcodes : Vec<u32> = Vec::new();
+    fn compound_request<'b>(
+        &mut self,
+        r: &RpcPacket<'b>,
+        cr: &Nfs4RequestCompoundRecord<'b>,
+        xidmap: &mut NFSRequestXidMap,
+    ) {
+        let mut last_putfh: Option<&'b [u8]> = None;
+        let mut main_opcode: u32 = 0;
+        let mut aux_opcodes: Vec<u32> = Vec::new();
 
         for c in &cr.commands {
             SCLogDebug!("c {:?}", c);
@@ -176,11 +219,17 @@ impl NFSState {
                     }
                 }
                 &Nfs4RequestContent::Open(ref rd) => {
-                    SCLogDebug!("OPENv4: {}", String::from_utf8_lossy(&rd.filename));
+                    SCLogDebug!(
+                        "OPENv4: {}",
+                        String::from_utf8_lossy(&rd.filename)
+                    );
                     xidmap.file_name = rd.filename.to_vec();
                 }
                 &Nfs4RequestContent::Lookup(ref rd) => {
-                    SCLogDebug!("LOOKUPv4: {}", String::from_utf8_lossy(&rd.filename));
+                    SCLogDebug!(
+                        "LOOKUPv4: {}",
+                        String::from_utf8_lossy(&rd.filename)
+                    );
                     xidmap.file_name = rd.filename.to_vec();
                 }
                 &Nfs4RequestContent::Write(ref rd) => {
@@ -212,12 +261,14 @@ impl NFSState {
                     main_opcode = NFSPROC4_REMOVE;
                 }
                 &Nfs4RequestContent::SetClientId(ref rd) => {
-                    SCLogDebug!("SETCLIENTIDv4: client id {} r_netid {} r_addr {}",
-                            String::from_utf8_lossy(&rd.client_id),
-                            String::from_utf8_lossy(&rd.r_netid),
-                            String::from_utf8_lossy(&rd.r_addr));
+                    SCLogDebug!(
+                        "SETCLIENTIDv4: client id {} r_netid {} r_addr {}",
+                        String::from_utf8_lossy(&rd.client_id),
+                        String::from_utf8_lossy(&rd.r_netid),
+                        String::from_utf8_lossy(&rd.r_addr)
+                    );
                 }
-                &_ => { },
+                &_ => {}
             }
         }
 
@@ -228,8 +279,13 @@ impl NFSState {
 
     /// complete request record
     pub fn process_request_record_v4<'b>(&mut self, r: &RpcPacket<'b>) -> u32 {
-        SCLogDebug!("NFSv4 REQUEST {} procedure {} ({}) blob size {}",
-                r.hdr.xid, r.procedure, self.requestmap.len(), r.prog_data.len());
+        SCLogDebug!(
+            "NFSv4 REQUEST {} procedure {} ({}) blob size {}",
+            r.hdr.xid,
+            r.procedure,
+            self.requestmap.len(),
+            r.prog_data.len()
+        );
 
         let mut xidmap = NFSRequestXidMap::new(r.progver, r.procedure, 0);
 
@@ -244,7 +300,7 @@ impl NFSState {
             let mut data = r.prog_data;
 
             if let RpcRequestCreds::GssApi(ref creds) = r.creds {
-                if creds.procedure == 0  && creds.service == 2 {
+                if creds.procedure == 0 && creds.service == 2 {
                     SCLogDebug!("GSS INTEGRITIY: {:?}", creds);
                     match parse_rpc_gssapi_integrity(r.prog_data) {
                         IResult::Done(_rem, rec) => {
@@ -253,17 +309,17 @@ impl NFSState {
                             // store proc and serv for the reply
                             xidmap.gssapi_proc = creds.procedure;
                             xidmap.gssapi_service = creds.service;
-                        },
+                        }
                         IResult::Incomplete(_n) => {
                             SCLogDebug!("NFSPROC4_COMPOUND/GSS INTEGRITIY: INCOMPLETE {:?}", _n);
                             self.set_event(NFSEvent::MalformedData);
                             return 0;
-                        },
+                        }
                         IResult::Error(_e) => {
                             SCLogDebug!("NFSPROC4_COMPOUND/GSS INTEGRITIY: Parsing failed: {:?}", _e);
                             self.set_event(NFSEvent::MalformedData);
                             return 0;
-                        },
+                        }
                     }
                 }
             }
@@ -272,15 +328,15 @@ impl NFSState {
                 IResult::Done(_, rd) => {
                     SCLogDebug!("NFSPROC4_COMPOUND: {:?}", rd);
                     self.compound_request(&r, &rd, &mut xidmap);
-                },
+                }
                 IResult::Incomplete(_n) => {
                     SCLogDebug!("NFSPROC4_COMPOUND: INCOMPLETE {:?}", _n);
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
                 IResult::Error(_e) => {
                     SCLogDebug!("NFSPROC4_COMPOUND: Parsing failed: {:?}", _e);
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             };
         }
 
@@ -288,13 +344,15 @@ impl NFSState {
         0
     }
 
-    fn compound_response<'b>(&mut self, r: &RpcReplyPacket<'b>,
-            cr: &Nfs4ResponseCompoundRecord<'b>,
-            xidmap: &mut NFSRequestXidMap)
-    {
+    fn compound_response<'b>(
+        &mut self,
+        r: &RpcReplyPacket<'b>,
+        cr: &Nfs4ResponseCompoundRecord<'b>,
+        xidmap: &mut NFSRequestXidMap,
+    ) {
         let mut insert_filename_with_getfh = false;
-        let mut main_opcode_status : u32 = 0;
-        let mut main_opcode_status_set : bool = false;
+        let mut main_opcode_status: u32 = 0;
+        let mut main_opcode_status_set: bool = false;
 
         for c in &cr.commands {
             SCLogDebug!("c {:?}", c);
@@ -305,25 +363,32 @@ impl NFSState {
 
                         for d in &rd.listing {
                             if let &Some(ref d) = d {
-                                SCLogDebug!("READDIRv4: dir {}", String::from_utf8_lossy(&d.name));
+                                SCLogDebug!(
+                                    "READDIRv4: dir {}",
+                                    String::from_utf8_lossy(&d.name)
+                                );
                             }
                         }
-
                     }
                 }
                 &Nfs4ResponseContent::Remove(s) => {
                     SCLogDebug!("REMOVE4: status {}", s);
                     main_opcode_status = s;
                     main_opcode_status_set = true;
-                },
+                }
                 &Nfs4ResponseContent::Create(s) => {
                     SCLogDebug!("CREATE4: status {}", s);
                     main_opcode_status = s;
                     main_opcode_status_set = true;
-                },
+                }
                 &Nfs4ResponseContent::Read(s, ref rd) => {
                     if let &Some(ref rd) = rd {
-                        SCLogDebug!("READ4: xidmap {:?} status {} data {}", xidmap, s, rd.data.len());
+                        SCLogDebug!(
+                            "READ4: xidmap {:?} status {} data {}",
+                            xidmap,
+                            s,
+                            rd.data.len()
+                        );
                         // convert record to generic read reply
                         let reply = NfsReplyRead {
                             status: s,
@@ -336,74 +401,86 @@ impl NFSState {
                         };
                         self.process_read_record(r, &reply, Some(&xidmap));
                     }
-                },
+                }
                 &Nfs4ResponseContent::Open(s, ref rd) => {
                     if let &Some(ref rd) = rd {
                         SCLogDebug!("OPENv4: status {} opendata {:?}", s, rd);
                         insert_filename_with_getfh = true;
                     }
-                },
+                }
                 &Nfs4ResponseContent::GetFH(_s, ref rd) => {
                     if let &Some(ref rd) = rd {
                         if insert_filename_with_getfh {
-                            self.namemap.insert(rd.value.to_vec(),
-                                    xidmap.file_name.to_vec());
+                            self.namemap.insert(
+                                rd.value.to_vec(),
+                                xidmap.file_name.to_vec(),
+                            );
                         }
                     }
-                },
+                }
                 &Nfs4ResponseContent::PutRootFH(s) => {
                     if s == NFS4_OK && xidmap.file_name.len() == 0 {
                         xidmap.file_name = b"<mount_root>".to_vec();
                         SCLogDebug!("filename {:?}", xidmap.file_name);
                     }
-                },
-                &_ => { },
+                }
+                &_ => {}
             }
         }
 
         if main_opcode_status_set {
             let resp_handle = Vec::new();
-            self.mark_response_tx_done(r.hdr.xid, r.reply_state, main_opcode_status, &resp_handle);
+            self.mark_response_tx_done(
+                r.hdr.xid,
+                r.reply_state,
+                main_opcode_status,
+                &resp_handle,
+            );
         }
     }
 
-    pub fn process_reply_record_v4<'b>(&mut self, r: &RpcReplyPacket<'b>,
-            xidmap: &mut NFSRequestXidMap) -> u32 {
+    pub fn process_reply_record_v4<'b>(
+        &mut self,
+        r: &RpcReplyPacket<'b>,
+        xidmap: &mut NFSRequestXidMap,
+    ) -> u32 {
         if xidmap.procedure == NFSPROC4_COMPOUND {
             let mut data = r.prog_data;
 
             if xidmap.gssapi_proc == 0 && xidmap.gssapi_service == 2 {
-
                 SCLogDebug!("GSS INTEGRITIY as set by call: {:?}", xidmap);
                 match parse_rpc_gssapi_integrity(r.prog_data) {
                     IResult::Done(_rem, rec) => {
                         SCLogDebug!("GSS INTEGRITIY wrapper: {:?}", rec);
                         data = rec.data;
-                    },
+                    }
                     IResult::Incomplete(_n) => {
-                        SCLogDebug!("NFSPROC4_COMPOUND/GSS INTEGRITIY: INCOMPLETE {:?}", _n);
+                        SCLogDebug!(
+                            "NFSPROC4_COMPOUND/GSS INTEGRITIY: INCOMPLETE {:?}",
+                            _n
+                        );
                         self.set_event(NFSEvent::MalformedData);
                         return 0;
-                    },
+                    }
                     IResult::Error(_e) => {
                         SCLogDebug!("NFSPROC4_COMPOUND/GSS INTEGRITIY: Parsing failed: {:?}", _e);
                         self.set_event(NFSEvent::MalformedData);
                         return 0;
-                    },
+                    }
                 }
             }
             match parse_nfs4_response_compound(data) {
                 IResult::Done(_, rd) => {
                     SCLogDebug!("COMPOUNDv4: {:?}", rd);
                     self.compound_response(&r, &rd, xidmap);
-                },
+                }
                 IResult::Incomplete(_) => {
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
                 IResult::Error(_e) => {
                     SCLogDebug!("Parsing failed: {:?}", _e);
                     self.set_event(NFSEvent::MalformedData);
-                },
+                }
             };
         }
         0

--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -21,16 +21,16 @@ extern crate libc;
 
 use nom::{IResult, be_u32};
 
-use core::*;
-use log::*;
+use crate::core::*;
+use crate::log::*;
 
-use nfs::nfs::*;
-use nfs::types::*;
-use nfs::rpc_records::*;
-use nfs::nfs_records::*;
-use nfs::nfs4_records::*;
+use crate::nfs::nfs::*;
+use crate::nfs::types::*;
+use crate::nfs::rpc_records::*;
+use crate::nfs::nfs_records::*;
+use crate::nfs::nfs4_records::*;
 
-use kerberos;
+use crate::kerberos;
 
 named!(parse_req_gssapi<kerberos::Kerberos5Ticket>,
    do_parse!(

--- a/rust/src/nfs/nfs4_records.rs
+++ b/rust/src/nfs/nfs4_records.rs
@@ -20,7 +20,7 @@ use nom::{be_u32, be_u64};
 
 use crate::nfs::types::*;
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum Nfs4RequestContent<'a> {
     PutFH(Nfs4Handle<'a>),
     GetFH,
@@ -40,7 +40,7 @@ pub enum Nfs4RequestContent<'a> {
     GetAttr(Nfs4Attr),
     SetAttr(Nfs4RequestSetAttr<'a>),
     Renew(u64),
-    Remove(&'a[u8]),
+    Remove(&'a [u8]),
     DelegReturn(Nfs4StateId<'a>),
     SetClientId(Nfs4RequestSetClientId<'a>),
     SetClientIdConfirm,
@@ -48,455 +48,484 @@ pub enum Nfs4RequestContent<'a> {
     Sequence(Nfs4RequestSequence<'a>),
 }
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4Attr {
     attr_mask: u64,
 }
 
-named!(nfs4_parse_attr_fields<u32>,
-    do_parse!(
-        len: be_u32
-    >>  take!(len)
-    >> (len)
-));
+named!(
+    nfs4_parse_attr_fields<u32>,
+    do_parse!(len: be_u32 >> take!(len) >> (len))
+);
 
-named!(nfs4_parse_attrs<Nfs4Attr>,
-    do_parse!(
-        attr_cnt: be_u32
-    >>  attr_mask1: be_u32
-    >>  attr_mask2: cond!(attr_cnt >= 2, be_u32)
-    >>  cond!(attr_cnt == 3, be_u32)
-    >>  nfs4_parse_attr_fields
-    >> ( Nfs4Attr {
-            attr_mask: ((attr_mask1 as u64) << 32) | attr_mask2.unwrap_or(0) as u64,
-        } )
-));
-
-named!(nfs4_parse_attrbits<Nfs4Attr>,
+named!(
+    nfs4_parse_attrs<Nfs4Attr>,
     do_parse!(
         attr_cnt: be_u32
-    >>  attr_mask1: be_u32
-    >>  attr_mask2: cond!(attr_cnt >= 2, be_u32)
-    >>  cond!(attr_cnt == 3, be_u32)
-    >> ( Nfs4Attr {
-            attr_mask: ((attr_mask1 as u64) << 32) | attr_mask2.unwrap_or(0) as u64,
-        } )
-));
+            >> attr_mask1: be_u32
+            >> attr_mask2: cond!(attr_cnt >= 2, be_u32)
+            >> cond!(attr_cnt == 3, be_u32)
+            >> nfs4_parse_attr_fields
+            >> (Nfs4Attr {
+                attr_mask: ((attr_mask1 as u64) << 32)
+                    | attr_mask2.unwrap_or(0) as u64,
+            })
+    )
+);
 
-#[derive(Debug,PartialEq)]
+named!(
+    nfs4_parse_attrbits<Nfs4Attr>,
+    do_parse!(
+        attr_cnt: be_u32
+            >> attr_mask1: be_u32
+            >> attr_mask2: cond!(attr_cnt >= 2, be_u32)
+            >> cond!(attr_cnt == 3, be_u32)
+            >> (Nfs4Attr {
+                attr_mask: ((attr_mask1 as u64) << 32)
+                    | attr_mask2.unwrap_or(0) as u64,
+            })
+    )
+);
+
+#[derive(Debug, PartialEq)]
 pub struct Nfs4StateId<'a> {
     pub seqid: u32,
-    pub data: &'a[u8],
+    pub data: &'a [u8],
 }
 
-named!(nfs4_parse_stateid<Nfs4StateId>,
+named!(
+    nfs4_parse_stateid<Nfs4StateId>,
     do_parse!(
-            seqid: be_u32
-        >>  data: take!(12)
-        >> ( Nfs4StateId {
+        seqid: be_u32
+            >> data: take!(12)
+            >> (Nfs4StateId {
                 seqid: seqid,
                 data: data,
             })
-        )
+    )
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4Handle<'a> {
     pub len: u32,
-    pub value: &'a[u8],
+    pub value: &'a [u8],
 }
 
-named!(nfs4_parse_handle<Nfs4Handle>,
+named!(
+    nfs4_parse_handle<Nfs4Handle>,
     do_parse!(
-            obj_len: be_u32
-        >>  obj: take!(obj_len)
-        >> ( Nfs4Handle {
+        obj_len: be_u32
+            >> obj: take!(obj_len)
+            >> (Nfs4Handle {
                 len: obj_len,
                 value: obj,
             })
-));
+    )
+);
 
-named!(nfs4_parse_nfsstring<&[u8]>,
+named!(
+    nfs4_parse_nfsstring<&[u8]>,
     do_parse!(
-            len: be_u32
-        >>  data: take!(len)
-        >>  _fill_bytes: cond!(len % 4 != 0, take!(4 - len % 4))
-        >> ( data )
-));
+        len: be_u32
+            >> data: take!(len)
+            >> _fill_bytes: cond!(len % 4 != 0, take!(4 - len % 4))
+            >> (data)
+    )
+);
 
-named!(nfs4_req_putfh<Nfs4RequestContent>,
-    do_parse!(
-            h: nfs4_parse_handle
-        >> ( Nfs4RequestContent::PutFH(h) )
-));
+named!(
+    nfs4_req_putfh<Nfs4RequestContent>,
+    do_parse!(h: nfs4_parse_handle >> (Nfs4RequestContent::PutFH(h)))
+);
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4RequestSetClientId<'a> {
-    pub client_id: &'a[u8],
-    pub r_netid: &'a[u8],
-    pub r_addr: &'a[u8],
+    pub client_id: &'a [u8],
+    pub r_netid: &'a [u8],
+    pub r_addr: &'a [u8],
 }
 
-named!(nfs4_req_setclientid<Nfs4RequestContent>,
+named!(
+    nfs4_req_setclientid<Nfs4RequestContent>,
     do_parse!(
-            client_verifier: take!(8)
-        >>  client_id: nfs4_parse_nfsstring
-        >>  cb_program: be_u32
-        >>  r_netid: nfs4_parse_nfsstring
-        >>  r_addr: nfs4_parse_nfsstring
-        >>  cb_id: be_u32
-        >> (Nfs4RequestContent::SetClientId(Nfs4RequestSetClientId {
+        client_verifier: take!(8)
+            >> client_id: nfs4_parse_nfsstring
+            >> cb_program: be_u32
+            >> r_netid: nfs4_parse_nfsstring
+            >> r_addr: nfs4_parse_nfsstring
+            >> cb_id: be_u32
+            >> (Nfs4RequestContent::SetClientId(Nfs4RequestSetClientId {
                 client_id: client_id,
                 r_netid: r_netid,
                 r_addr: r_addr,
             }))
-));
+    )
+);
 
-named!(nfs4_req_setclientid_confirm<Nfs4RequestContent>,
+named!(
+    nfs4_req_setclientid_confirm<Nfs4RequestContent>,
     do_parse!(
-            client_id: take!(8)
-        >>  verifier: take!(8)
-        >> (Nfs4RequestContent::SetClientIdConfirm)
-));
+        client_id: take!(8)
+            >> verifier: take!(8)
+            >> (Nfs4RequestContent::SetClientIdConfirm)
+    )
+);
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4RequestCreate<'a> {
     pub ftype4: u32,
-    pub filename: &'a[u8],
-    pub link_content: &'a[u8],
+    pub filename: &'a [u8],
+    pub link_content: &'a [u8],
 }
 
-named!(nfs4_req_create<Nfs4RequestContent>,
+named!(
+    nfs4_req_create<Nfs4RequestContent>,
     do_parse!(
-            ftype4: be_u32
-        >>  link_content: cond!(ftype4 == 5, nfs4_parse_nfsstring)
-        >>  filename: nfs4_parse_nfsstring
-        >>  attrs: nfs4_parse_attrs
-        >> ( Nfs4RequestContent::Create(Nfs4RequestCreate {
+        ftype4: be_u32
+            >> link_content: cond!(ftype4 == 5, nfs4_parse_nfsstring)
+            >> filename: nfs4_parse_nfsstring
+            >> attrs: nfs4_parse_attrs
+            >> (Nfs4RequestContent::Create(Nfs4RequestCreate {
                 ftype4: ftype4,
                 filename: filename,
                 link_content: link_content.unwrap_or(&[]),
-            })
-        ))
+            }))
+    )
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum Nfs4OpenRequestContent<'a> {
-    Exclusive4(&'a[u8]),
+    Exclusive4(&'a [u8]),
     Unchecked4(Nfs4Attr),
     Guarded4(Nfs4Attr),
 }
 
-named!(nfs4_req_open_unchecked4<Nfs4OpenRequestContent>,
+named!(
+    nfs4_req_open_unchecked4<Nfs4OpenRequestContent>,
     do_parse!(
-            attrs: nfs4_parse_attrs
-        >> ( Nfs4OpenRequestContent::Unchecked4(attrs) )
-));
-
-named!(nfs4_req_open_guarded4<Nfs4OpenRequestContent>,
-    do_parse!(
-            attrs: nfs4_parse_attrs
-        >> ( Nfs4OpenRequestContent::Guarded4(attrs) )
-));
-
-named!(nfs4_req_open_exclusive4<Nfs4OpenRequestContent>,
-    do_parse!(
-            ver: take!(8)
-        >> ( Nfs4OpenRequestContent::Exclusive4(ver) )
-));
-
-
-named!(nfs4_req_open_type<Nfs4OpenRequestContent>,
-    do_parse!(
-            mode: be_u32
-        >>  data: switch!(value!(mode),
-                0 => call!(nfs4_req_open_unchecked4)  |
-                1 => call!(nfs4_req_open_guarded4)    |
-                2 => call!(nfs4_req_open_exclusive4))
-        >> ( data )
-));
-
-#[derive(Debug,PartialEq)]
-pub struct Nfs4RequestOpen<'a> {
-    pub open_type: u32,
-    pub filename: &'a[u8],
-    pub open_data: Option<Nfs4OpenRequestContent<'a>>,
-}
-
-named!(nfs4_req_open<Nfs4RequestContent>,
-    do_parse!(
-            seqid: be_u32
-        >>  share_access: be_u32
-        >>  share_deny: be_u32
-        >>  client_id: be_u64
-        >>  owner_len: be_u32
-        >>  cond!(owner_len > 0, take!(owner_len))
-        >>  open_type: be_u32
-        >>  open_data: cond!(open_type == 1, nfs4_req_open_type)
-        >>  claim_type: be_u32
-        >>  filename: nfs4_parse_nfsstring
-        >> ( Nfs4RequestContent::Open(Nfs4RequestOpen {
-                open_type: open_type,
-                filename: filename,
-                open_data: open_data,
-            })
-        ))
-);
-
-named!(nfs4_req_readdir<Nfs4RequestContent>,
-    do_parse!(
-            cookie: be_u64
-        >>  cookie_verf: be_u64
-        >>  dir_cnt: be_u32
-        >>  max_cnt: be_u32
-        >>  attr: nfs4_parse_attrbits
-        >> ( Nfs4RequestContent::ReadDir )
+        attrs: nfs4_parse_attrs >> (Nfs4OpenRequestContent::Unchecked4(attrs))
     )
 );
 
-#[derive(Debug,PartialEq)]
-pub struct Nfs4RequestRename<'a> {
-    pub oldname: &'a[u8],
-    pub newname: &'a[u8],
+named!(
+    nfs4_req_open_guarded4<Nfs4OpenRequestContent>,
+    do_parse!(
+        attrs: nfs4_parse_attrs >> (Nfs4OpenRequestContent::Guarded4(attrs))
+    )
+);
+
+named!(
+    nfs4_req_open_exclusive4<Nfs4OpenRequestContent>,
+    do_parse!(ver: take!(8) >> (Nfs4OpenRequestContent::Exclusive4(ver)))
+);
+
+named!(
+    nfs4_req_open_type<Nfs4OpenRequestContent>,
+    do_parse!(
+        mode: be_u32
+            >> data: switch!(value!(mode),
+                0 => call!(nfs4_req_open_unchecked4)  |
+                1 => call!(nfs4_req_open_guarded4)    |
+                2 => call!(nfs4_req_open_exclusive4))
+            >> (data)
+    )
+);
+
+#[derive(Debug, PartialEq)]
+pub struct Nfs4RequestOpen<'a> {
+    pub open_type: u32,
+    pub filename: &'a [u8],
+    pub open_data: Option<Nfs4OpenRequestContent<'a>>,
 }
 
-named!(nfs4_req_rename<Nfs4RequestContent>,
+named!(
+    nfs4_req_open<Nfs4RequestContent>,
     do_parse!(
-            oldname: nfs4_parse_nfsstring
-        >>  newname: nfs4_parse_nfsstring
-        >> ( Nfs4RequestContent::Rename(Nfs4RequestRename {
+        seqid: be_u32
+            >> share_access: be_u32
+            >> share_deny: be_u32
+            >> client_id: be_u64
+            >> owner_len: be_u32
+            >> cond!(owner_len > 0, take!(owner_len))
+            >> open_type: be_u32
+            >> open_data: cond!(open_type == 1, nfs4_req_open_type)
+            >> claim_type: be_u32
+            >> filename: nfs4_parse_nfsstring
+            >> (Nfs4RequestContent::Open(Nfs4RequestOpen {
+                open_type: open_type,
+                filename: filename,
+                open_data: open_data,
+            }))
+    )
+);
+
+named!(
+    nfs4_req_readdir<Nfs4RequestContent>,
+    do_parse!(
+        cookie: be_u64
+            >> cookie_verf: be_u64
+            >> dir_cnt: be_u32
+            >> max_cnt: be_u32
+            >> attr: nfs4_parse_attrbits
+            >> (Nfs4RequestContent::ReadDir)
+    )
+);
+
+#[derive(Debug, PartialEq)]
+pub struct Nfs4RequestRename<'a> {
+    pub oldname: &'a [u8],
+    pub newname: &'a [u8],
+}
+
+named!(
+    nfs4_req_rename<Nfs4RequestContent>,
+    do_parse!(
+        oldname: nfs4_parse_nfsstring
+            >> newname: nfs4_parse_nfsstring
+            >> (Nfs4RequestContent::Rename(Nfs4RequestRename {
                 oldname: oldname,
                 newname: newname,
-            })
-        ))
+            }))
+    )
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4RequestLookup<'a> {
-    pub filename: &'a[u8],
+    pub filename: &'a [u8],
 }
 
-named!(nfs4_req_lookup<Nfs4RequestContent>,
+named!(
+    nfs4_req_lookup<Nfs4RequestContent>,
     do_parse!(
-            filename: nfs4_parse_nfsstring
-        >> ( Nfs4RequestContent::Lookup(Nfs4RequestLookup {
+        filename: nfs4_parse_nfsstring
+            >> (Nfs4RequestContent::Lookup(Nfs4RequestLookup {
                 filename: filename,
-            })
-        ))
+            }))
+    )
 );
 
-named!(nfs4_req_remove<Nfs4RequestContent>,
+named!(
+    nfs4_req_remove<Nfs4RequestContent>,
     do_parse!(
-            filename: nfs4_parse_nfsstring
-        >> ( Nfs4RequestContent::Remove(filename) )
-));
+        filename: nfs4_parse_nfsstring
+            >> (Nfs4RequestContent::Remove(filename))
+    )
+);
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4RequestSetAttr<'a> {
     pub stateid: Nfs4StateId<'a>,
 }
 
-named!(nfs4_req_setattr<Nfs4RequestContent>,
+named!(
+    nfs4_req_setattr<Nfs4RequestContent>,
     do_parse!(
-            stateid: nfs4_parse_stateid
-        >>  attrs: nfs4_parse_attrs
-        >> (Nfs4RequestContent::SetAttr(Nfs4RequestSetAttr {
+        stateid: nfs4_parse_stateid
+            >> attrs: nfs4_parse_attrs
+            >> (Nfs4RequestContent::SetAttr(Nfs4RequestSetAttr {
                 stateid: stateid,
             }))
-));
-
-named!(nfs4_req_getattr<Nfs4RequestContent>,
-    do_parse!(
-            attrs: nfs4_parse_attrbits
-        >> ( Nfs4RequestContent::GetAttr(attrs) )
     )
 );
 
-#[derive(Debug,PartialEq)]
+named!(
+    nfs4_req_getattr<Nfs4RequestContent>,
+    do_parse!(
+        attrs: nfs4_parse_attrbits >> (Nfs4RequestContent::GetAttr(attrs))
+    )
+);
+
+#[derive(Debug, PartialEq)]
 pub struct Nfs4RequestWrite<'a> {
     pub stateid: Nfs4StateId<'a>,
     pub offset: u64,
     pub stable: u32,
     pub write_len: u32,
-    pub data: &'a[u8],
+    pub data: &'a [u8],
 }
 
-named!(nfs4_req_write<Nfs4RequestContent>,
+named!(
+    nfs4_req_write<Nfs4RequestContent>,
     do_parse!(
-            stateid: nfs4_parse_stateid
-        >>  offset: be_u64
-        >>  stable: be_u32
-        >>  write_len: be_u32
-        >>  data: take!(write_len)
-        >>  _padding: cond!(write_len % 4 != 0, take!(4 - write_len % 4))
-        >> (Nfs4RequestContent::Write(Nfs4RequestWrite {
+        stateid: nfs4_parse_stateid
+            >> offset: be_u64
+            >> stable: be_u32
+            >> write_len: be_u32
+            >> data: take!(write_len)
+            >> _padding: cond!(write_len % 4 != 0, take!(4 - write_len % 4))
+            >> (Nfs4RequestContent::Write(Nfs4RequestWrite {
                 stateid: stateid,
                 offset: offset,
                 stable: stable,
                 write_len: write_len,
                 data: data,
             }))
-));
+    )
+);
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4RequestRead<'a> {
     pub stateid: Nfs4StateId<'a>,
     pub offset: u64,
     pub count: u32,
 }
 
-named!(nfs4_req_read<Nfs4RequestContent>,
+named!(
+    nfs4_req_read<Nfs4RequestContent>,
     do_parse!(
-            stateid: nfs4_parse_stateid
-        >>  offset: be_u64
-        >>  count: be_u32
-        >> ( Nfs4RequestContent::Read(Nfs4RequestRead {
+        stateid: nfs4_parse_stateid
+            >> offset: be_u64
+            >> count: be_u32
+            >> (Nfs4RequestContent::Read(Nfs4RequestRead {
                 stateid: stateid,
                 offset: offset,
                 count: count,
-            })
-        ))
+            }))
+    )
 );
 
-named!(nfs4_req_close<Nfs4RequestContent>,
+named!(
+    nfs4_req_close<Nfs4RequestContent>,
     do_parse!(
-            seqid: be_u32
-        >>  stateid: nfs4_parse_stateid
-        >> ( Nfs4RequestContent::Close(stateid) )
-));
+        seqid: be_u32
+            >> stateid: nfs4_parse_stateid
+            >> (Nfs4RequestContent::Close(stateid))
+    )
+);
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4RequestOpenConfirm<'a> {
     pub stateid: Nfs4StateId<'a>,
 }
 
-named!(nfs4_req_open_confirm<Nfs4RequestContent>,
+named!(
+    nfs4_req_open_confirm<Nfs4RequestContent>,
     do_parse!(
-            stateid: nfs4_parse_stateid
-        >>  seqid: be_u32
-        >> ( Nfs4RequestContent::OpenConfirm(Nfs4RequestOpenConfirm {
+        stateid: nfs4_parse_stateid
+            >> seqid: be_u32
+            >> (Nfs4RequestContent::OpenConfirm(Nfs4RequestOpenConfirm {
                 stateid: stateid,
-            })
-        ))
-);
-
-named!(nfs4_req_delegreturn<Nfs4RequestContent>,
-    do_parse!(
-            a: nfs4_parse_stateid
-        >> ( Nfs4RequestContent::DelegReturn(a) )
+            }))
     )
 );
 
-named!(nfs4_req_renew<Nfs4RequestContent>,
-    do_parse!(
-            a: be_u64
-        >> ( Nfs4RequestContent::Renew(a) )
-    )
+named!(
+    nfs4_req_delegreturn<Nfs4RequestContent>,
+    do_parse!(a: nfs4_parse_stateid >> (Nfs4RequestContent::DelegReturn(a)))
 );
 
-named!(nfs4_req_getfh<Nfs4RequestContent>,
-    do_parse!( ( Nfs4RequestContent::GetFH ) ));
-
-named!(nfs4_req_savefh<Nfs4RequestContent>,
-    do_parse!( ( Nfs4RequestContent::SaveFH ) ));
-
-named!(nfs4_req_putrootfh<Nfs4RequestContent>,
-    do_parse!( ( Nfs4RequestContent::PutRootFH ) ));
-
-named!(nfs4_req_access<Nfs4RequestContent>,
-    do_parse!(
-            a: be_u32
-        >> ( Nfs4RequestContent::Access(a) )
-    )
+named!(
+    nfs4_req_renew<Nfs4RequestContent>,
+    do_parse!(a: be_u64 >> (Nfs4RequestContent::Renew(a)))
 );
 
-named!(nfs4_req_commit<Nfs4RequestContent>,
-    do_parse!(
-            offset: be_u64
-        >>  count: be_u32
-        >> ( Nfs4RequestContent::Commit )
-    )
+named!(
+    nfs4_req_getfh<Nfs4RequestContent>,
+    do_parse!((Nfs4RequestContent::GetFH))
 );
 
-#[derive(Debug,PartialEq)]
+named!(
+    nfs4_req_savefh<Nfs4RequestContent>,
+    do_parse!((Nfs4RequestContent::SaveFH))
+);
+
+named!(
+    nfs4_req_putrootfh<Nfs4RequestContent>,
+    do_parse!((Nfs4RequestContent::PutRootFH))
+);
+
+named!(
+    nfs4_req_access<Nfs4RequestContent>,
+    do_parse!(a: be_u32 >> (Nfs4RequestContent::Access(a)))
+);
+
+named!(
+    nfs4_req_commit<Nfs4RequestContent>,
+    do_parse!(offset: be_u64 >> count: be_u32 >> (Nfs4RequestContent::Commit))
+);
+
+#[derive(Debug, PartialEq)]
 pub struct Nfs4RequestExchangeId<'a> {
-    pub client_string: &'a[u8],
-    pub nii_domain: &'a[u8],
-    pub nii_name: &'a[u8],
+    pub client_string: &'a [u8],
+    pub nii_domain: &'a [u8],
+    pub nii_name: &'a [u8],
 }
 
-named!(nfs4_req_exchangeid<Nfs4RequestContent>,
+named!(
+    nfs4_req_exchangeid<Nfs4RequestContent>,
     do_parse!(
         verifier: take!(8)
-    >>  eia_clientstring: nfs4_parse_nfsstring
-    >>  eia_clientflags: be_u32
-    >>  eia_state_protect: be_u32
-    >>  eia_client_impl_id: be_u32
-    >>  nii_domain: nfs4_parse_nfsstring
-    >>  nii_name: nfs4_parse_nfsstring
-    >>  nii_data_sec: be_u64
-    >>  nii_data_nsec: be_u32
-    >> (Nfs4RequestContent::ExchangeId(
-            Nfs4RequestExchangeId {
+            >> eia_clientstring: nfs4_parse_nfsstring
+            >> eia_clientflags: be_u32
+            >> eia_state_protect: be_u32
+            >> eia_client_impl_id: be_u32
+            >> nii_domain: nfs4_parse_nfsstring
+            >> nii_name: nfs4_parse_nfsstring
+            >> nii_data_sec: be_u64
+            >> nii_data_nsec: be_u32
+            >> (Nfs4RequestContent::ExchangeId(Nfs4RequestExchangeId {
                 client_string: eia_clientstring,
                 nii_domain: nii_domain,
                 nii_name: nii_name,
-            }
-        ))
-));
+            }))
+    )
+);
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4RequestSequence<'a> {
-    pub ssn_id: &'a[u8],
+    pub ssn_id: &'a [u8],
 }
 
-named!(nfs4_req_sequence<Nfs4RequestContent>,
+named!(
+    nfs4_req_sequence<Nfs4RequestContent>,
     do_parse!(
         ssn_id: take!(16)
-    >>  seq_id: be_u32
-    >>  slot_id: be_u32
-    >>  high_slot_id: be_u32
-    >>  cache_this: be_u32
-    >> (Nfs4RequestContent::Sequence(
-            Nfs4RequestSequence {
+            >> seq_id: be_u32
+            >> slot_id: be_u32
+            >> high_slot_id: be_u32
+            >> cache_this: be_u32
+            >> (Nfs4RequestContent::Sequence(Nfs4RequestSequence {
                 ssn_id: ssn_id,
-            }
-        ))
-));
+            }))
+    )
+);
 
-named!(parse_request_compound_command<Nfs4RequestContent>,
+named!(
+    parse_request_compound_command<Nfs4RequestContent>,
     do_parse!(
         cmd: be_u32
-    >>  cmd_data: switch!(value!(cmd),
-            NFSPROC4_PUTFH                  => call!(nfs4_req_putfh)                |
-            NFSPROC4_READ                   => call!(nfs4_req_read)                 |
-            NFSPROC4_WRITE                  => call!(nfs4_req_write)                |
-            NFSPROC4_GETFH                  => call!(nfs4_req_getfh)                |
-            NFSPROC4_SAVEFH                 => call!(nfs4_req_savefh)               |
-            NFSPROC4_OPEN                   => call!(nfs4_req_open)                 |
-            NFSPROC4_CLOSE                  => call!(nfs4_req_close)                |
-            NFSPROC4_LOOKUP                 => call!(nfs4_req_lookup)               |
-            NFSPROC4_ACCESS                 => call!(nfs4_req_access)               |
-            NFSPROC4_COMMIT                 => call!(nfs4_req_commit)               |
-            NFSPROC4_GETATTR                => call!(nfs4_req_getattr)              |
-            NFSPROC4_READDIR                => call!(nfs4_req_readdir)              |
-            NFSPROC4_RENEW                  => call!(nfs4_req_renew)                |
-            NFSPROC4_OPEN_CONFIRM           => call!(nfs4_req_open_confirm)         |
-            NFSPROC4_REMOVE                 => call!(nfs4_req_remove)               |
-            NFSPROC4_RENAME                 => call!(nfs4_req_rename)               |
-            NFSPROC4_CREATE                 => call!(nfs4_req_create)               |
-            NFSPROC4_DELEGRETURN            => call!(nfs4_req_delegreturn)          |
-            NFSPROC4_SETATTR                => call!(nfs4_req_setattr)              |
-            NFSPROC4_PUTROOTFH              => call!(nfs4_req_putrootfh)            |
-            NFSPROC4_SETCLIENTID            => call!(nfs4_req_setclientid)          |
-            NFSPROC4_SETCLIENTID_CONFIRM    => call!(nfs4_req_setclientid_confirm)  |
-            NFSPROC4_SEQUENCE               => call!(nfs4_req_sequence)             |
-            NFSPROC4_EXCHANGE_ID            => call!(nfs4_req_exchangeid)
-            )
-        >> ( cmd_data )
-));
+            >> cmd_data:
+                switch!(value!(cmd),
+                NFSPROC4_PUTFH                  => call!(nfs4_req_putfh)                |
+                NFSPROC4_READ                   => call!(nfs4_req_read)                 |
+                NFSPROC4_WRITE                  => call!(nfs4_req_write)                |
+                NFSPROC4_GETFH                  => call!(nfs4_req_getfh)                |
+                NFSPROC4_SAVEFH                 => call!(nfs4_req_savefh)               |
+                NFSPROC4_OPEN                   => call!(nfs4_req_open)                 |
+                NFSPROC4_CLOSE                  => call!(nfs4_req_close)                |
+                NFSPROC4_LOOKUP                 => call!(nfs4_req_lookup)               |
+                NFSPROC4_ACCESS                 => call!(nfs4_req_access)               |
+                NFSPROC4_COMMIT                 => call!(nfs4_req_commit)               |
+                NFSPROC4_GETATTR                => call!(nfs4_req_getattr)              |
+                NFSPROC4_READDIR                => call!(nfs4_req_readdir)              |
+                NFSPROC4_RENEW                  => call!(nfs4_req_renew)                |
+                NFSPROC4_OPEN_CONFIRM           => call!(nfs4_req_open_confirm)         |
+                NFSPROC4_REMOVE                 => call!(nfs4_req_remove)               |
+                NFSPROC4_RENAME                 => call!(nfs4_req_rename)               |
+                NFSPROC4_CREATE                 => call!(nfs4_req_create)               |
+                NFSPROC4_DELEGRETURN            => call!(nfs4_req_delegreturn)          |
+                NFSPROC4_SETATTR                => call!(nfs4_req_setattr)              |
+                NFSPROC4_PUTROOTFH              => call!(nfs4_req_putrootfh)            |
+                NFSPROC4_SETCLIENTID            => call!(nfs4_req_setclientid)          |
+                NFSPROC4_SETCLIENTID_CONFIRM    => call!(nfs4_req_setclientid_confirm)  |
+                NFSPROC4_SEQUENCE               => call!(nfs4_req_sequence)             |
+                NFSPROC4_EXCHANGE_ID            => call!(nfs4_req_exchangeid)
+                )
+            >> (cmd_data)
+    )
+);
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4RequestCompoundRecord<'a> {
     pub commands: Vec<Nfs4RequestContent<'a>>,
 }
@@ -513,7 +542,7 @@ named!(pub parse_nfs4_request_compound<Nfs4RequestCompoundRecord>,
             })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum Nfs4ResponseContent<'a> {
     PutFH(u32),
     PutRootFH(u32),
@@ -540,57 +569,65 @@ pub enum Nfs4ResponseContent<'a> {
     Sequence(u32, Option<Nfs4ResponseSequence<'a>>),
 }
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4ResponseWrite {
     pub count: u32,
     pub committed: u32,
 }
 
-named!(nfs4_res_write_ok<Nfs4ResponseWrite>,
+named!(
+    nfs4_res_write_ok<Nfs4ResponseWrite>,
     do_parse!(
-            count: be_u32
-        >>  committed: be_u32
-        >>  verifier: be_u64
-        >> (Nfs4ResponseWrite {
+        count: be_u32
+            >> committed: be_u32
+            >> verifier: be_u64
+            >> (Nfs4ResponseWrite {
                 count: count,
                 committed: committed,
-           })
-));
+            })
+    )
+);
 
-named!(nfs4_res_write<Nfs4ResponseContent>,
+named!(
+    nfs4_res_write<Nfs4ResponseContent>,
     do_parse!(
-            status: be_u32
-        >>  wd: cond!(status == 0, nfs4_res_write_ok)
-        >> (Nfs4ResponseContent::Write(status, wd) )
-));
+        status: be_u32
+            >> wd: cond!(status == 0, nfs4_res_write_ok)
+            >> (Nfs4ResponseContent::Write(status, wd))
+    )
+);
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4ResponseRead<'a> {
     pub eof: bool,
     pub count: u32,
-    pub data: &'a[u8],
+    pub data: &'a [u8],
 }
 
-named!(nfs4_res_read_ok<Nfs4ResponseRead>,
+named!(
+    nfs4_res_read_ok<Nfs4ResponseRead>,
     do_parse!(
-            eof: be_u32
-        >>  read_len: be_u32
-        >>  read_data: take!(read_len)
-        >> (Nfs4ResponseRead {
-                eof: eof==1,
+        eof: be_u32
+            >> read_len: be_u32
+            >> read_data: take!(read_len)
+            >> (Nfs4ResponseRead {
+                eof: eof == 1,
                 count: read_len,
                 data: read_data,
             })
-));
+    )
+);
 
-named!(nfs4_res_read<Nfs4ResponseContent>,
+named!(
+    nfs4_res_read<Nfs4ResponseContent>,
     do_parse!(
-            status: be_u32
-        >>  rd: cond!(status == 0, nfs4_res_read_ok)
-        >> (Nfs4ResponseContent::Read(status, rd) )
-));
+        status: be_u32
+            >> rd: cond!(status == 0, nfs4_res_read_ok)
+            >> (Nfs4ResponseContent::Read(status, rd))
+    )
+);
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4ResponseOpen<'a> {
     pub stateid: Nfs4StateId<'a>,
     pub result_flags: u32,
@@ -598,275 +635,301 @@ pub struct Nfs4ResponseOpen<'a> {
     pub delegate_read: Option<Nfs4ResponseOpenDelegateRead<'a>>,
 }
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4ResponseOpenDelegateRead<'a> {
     pub stateid: Nfs4StateId<'a>,
 }
 
-named!(nfs4_res_open_ok_delegate_read<Nfs4ResponseOpenDelegateRead>,
+named!(
+    nfs4_res_open_ok_delegate_read<Nfs4ResponseOpenDelegateRead>,
     do_parse!(
-            stateid: nfs4_parse_stateid
-        >>  recall: be_u32
-        >>  ace_type: be_u32
-        >>  ace_flags: be_u32
-        >>  ace_mask: be_u32
-        >>  who_len: be_u32
-        >>  who: take!(who_len)
-        >> (Nfs4ResponseOpenDelegateRead {
+        stateid: nfs4_parse_stateid
+            >> recall: be_u32
+            >> ace_type: be_u32
+            >> ace_flags: be_u32
+            >> ace_mask: be_u32
+            >> who_len: be_u32
+            >> who: take!(who_len)
+            >> (Nfs4ResponseOpenDelegateRead { stateid: stateid })
+    )
+);
+
+named!(
+    nfs4_res_open_ok<Nfs4ResponseOpen>,
+    do_parse!(
+        stateid: nfs4_parse_stateid
+            >> change_info: take!(20)
+            >> result_flags: be_u32
+            >> attrs: nfs4_parse_attrbits
+            >> delegation_type: be_u32
+            >> delegate_read:
+                cond!(delegation_type == 1, nfs4_res_open_ok_delegate_read)
+            >> (Nfs4ResponseOpen {
                 stateid: stateid,
+                result_flags: result_flags,
+                delegation_type: delegation_type,
+                delegate_read: delegate_read,
             })
-));
+    )
+);
 
-named!(nfs4_res_open_ok<Nfs4ResponseOpen>,
+named!(
+    nfs4_res_open<Nfs4ResponseContent>,
     do_parse!(
-            stateid: nfs4_parse_stateid
-        >>  change_info: take!(20)
-        >>  result_flags: be_u32
-        >>  attrs: nfs4_parse_attrbits
-        >>  delegation_type: be_u32
-        >>  delegate_read: cond!(delegation_type == 1, nfs4_res_open_ok_delegate_read)
-        >> ( Nfs4ResponseOpen {
-                 stateid: stateid, result_flags: result_flags,
-                 delegation_type: delegation_type,
-                 delegate_read: delegate_read,
-             } )
-));
+        status: be_u32
+            >> open_data: cond!(status == 0, nfs4_res_open_ok)
+            >> (Nfs4ResponseContent::Open(status, open_data))
+    )
+);
 
-named!(nfs4_res_open<Nfs4ResponseContent>,
-    do_parse!(
-            status: be_u32
-        >>  open_data: cond!(status == 0, nfs4_res_open_ok)
-        >> ( Nfs4ResponseContent::Open(status, open_data) )
-));
-
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4ResponseReaddirEntry<'a> {
-    pub name: &'a[u8],
+    pub name: &'a [u8],
 }
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4ResponseReaddir<'a> {
     pub eof: bool,
     pub listing: Vec<Option<Nfs4ResponseReaddirEntry<'a>>>,
 }
 
-named!(nfs4_res_readdir_entry_do<Nfs4ResponseReaddirEntry>,
+named!(
+    nfs4_res_readdir_entry_do<Nfs4ResponseReaddirEntry>,
     do_parse!(
-            cookie: be_u64
-        >>  name: nfs4_parse_nfsstring
-        >>  attrs: nfs4_parse_attrs
-        >> ( Nfs4ResponseReaddirEntry {
-                name: name,
-            })
-));
+        cookie: be_u64
+            >> name: nfs4_parse_nfsstring
+            >> attrs: nfs4_parse_attrs
+            >> (Nfs4ResponseReaddirEntry { name: name })
+    )
+);
 
-named!(nfs4_res_readdir_entry<Option<Nfs4ResponseReaddirEntry>>,
+named!(
+    nfs4_res_readdir_entry<Option<Nfs4ResponseReaddirEntry>>,
     do_parse!(
-            value_follows: be_u32
-        >>  entry: cond!(value_follows == 1, nfs4_res_readdir_entry_do)
-        >> (entry)
-));
+        value_follows: be_u32
+            >> entry: cond!(value_follows == 1, nfs4_res_readdir_entry_do)
+            >> (entry)
+    )
+);
 
-named!(nfs4_res_readdir_ok<Nfs4ResponseReaddir>,
+named!(
+    nfs4_res_readdir_ok<Nfs4ResponseReaddir>,
     do_parse!(
-            verifier: be_u64
+        verifier: be_u64
         // run parser until we find a 'value follows == 0'
         >>  listing: many_till!(call!(nfs4_res_readdir_entry), peek!(tag!(b"\x00\x00\x00\x00")))
         // value follows == 0 checked by line above
         >>  _value_follows: be_u32
         >>  eof: be_u32
         >> ( Nfs4ResponseReaddir { eof: eof==1, listing: listing.0 })
-));
+    )
+);
 
-named!(nfs4_res_readdir<Nfs4ResponseContent>,
+named!(
+    nfs4_res_readdir<Nfs4ResponseContent>,
     do_parse!(
-            status: be_u32
-        >>  rd: cond!(status == 0, nfs4_res_readdir_ok)
-        >> ( Nfs4ResponseContent::ReadDir(status, rd) )
-));
+        status: be_u32
+            >> rd: cond!(status == 0, nfs4_res_readdir_ok)
+            >> (Nfs4ResponseContent::ReadDir(status, rd))
+    )
+);
 
-named!(nfs4_res_create_ok<Nfs4Attr>,
-    do_parse!(
-            change_info: take!(20)
-        >>  attrs: nfs4_parse_attrbits
-        >> ( attrs )
-));
+named!(
+    nfs4_res_create_ok<Nfs4Attr>,
+    do_parse!(change_info: take!(20) >> attrs: nfs4_parse_attrbits >> (attrs))
+);
 
-named!(nfs4_res_create<Nfs4ResponseContent>,
+named!(
+    nfs4_res_create<Nfs4ResponseContent>,
     do_parse!(
-            status: be_u32
-        >>  attrs: cond!(status == 0, nfs4_res_create_ok)
-        >> ( Nfs4ResponseContent::Create(status) )
-));
+        status: be_u32
+            >> attrs: cond!(status == 0, nfs4_res_create_ok)
+            >> (Nfs4ResponseContent::Create(status))
+    )
+);
 
-named!(nfs4_res_setattr_ok<Nfs4Attr>,
-    do_parse!(
-            attrs: nfs4_parse_attrbits
-        >> ( attrs )
-));
+named!(
+    nfs4_res_setattr_ok<Nfs4Attr>,
+    do_parse!(attrs: nfs4_parse_attrbits >> (attrs))
+);
 
-named!(nfs4_res_setattr<Nfs4ResponseContent>,
+named!(
+    nfs4_res_setattr<Nfs4ResponseContent>,
     do_parse!(
-            status: be_u32
-        >>  attrs: cond!(status == 0, nfs4_res_setattr_ok)
-        >> ( Nfs4ResponseContent::SetAttr(status) )
-));
+        status: be_u32
+            >> attrs: cond!(status == 0, nfs4_res_setattr_ok)
+            >> (Nfs4ResponseContent::SetAttr(status))
+    )
+);
 
-named!(nfs4_res_getattr_ok<Nfs4Attr>,
-    do_parse!(
-            attrs: nfs4_parse_attrs
-        >> ( attrs )
-));
+named!(
+    nfs4_res_getattr_ok<Nfs4Attr>,
+    do_parse!(attrs: nfs4_parse_attrs >> (attrs))
+);
 
-named!(nfs4_res_getattr<Nfs4ResponseContent>,
+named!(
+    nfs4_res_getattr<Nfs4ResponseContent>,
     do_parse!(
-            status: be_u32
-        >>  attrs: cond!(status == 0, nfs4_res_getattr_ok)
-        >> ( Nfs4ResponseContent::GetAttr(status, attrs) )
-));
+        status: be_u32
+            >> attrs: cond!(status == 0, nfs4_res_getattr_ok)
+            >> (Nfs4ResponseContent::GetAttr(status, attrs))
+    )
+);
 
-named!(nfs4_res_openconfirm<Nfs4ResponseContent>,
+named!(
+    nfs4_res_openconfirm<Nfs4ResponseContent>,
     do_parse!(
-            status: be_u32
-        >>  stateid: cond!(status == 0, nfs4_parse_stateid)
-        >> ( Nfs4ResponseContent::OpenConfirm(status, stateid) )
-));
+        status: be_u32
+            >> stateid: cond!(status == 0, nfs4_parse_stateid)
+            >> (Nfs4ResponseContent::OpenConfirm(status, stateid))
+    )
+);
 
-named!(nfs4_res_close<Nfs4ResponseContent>,
+named!(
+    nfs4_res_close<Nfs4ResponseContent>,
     do_parse!(
-            status: be_u32
-        >>  stateid: cond!(status == 0, nfs4_parse_stateid)
-        >> ( Nfs4ResponseContent::Close(status, stateid) )
-));
+        status: be_u32
+            >> stateid: cond!(status == 0, nfs4_parse_stateid)
+            >> (Nfs4ResponseContent::Close(status, stateid))
+    )
+);
 
-named!(nfs4_res_remove<Nfs4ResponseContent>,
+named!(
+    nfs4_res_remove<Nfs4ResponseContent>,
     do_parse!(
-            status: be_u32
+        status: be_u32
         >>  cond!(status == 0, take!(20))   // change_info
         >> ( Nfs4ResponseContent::Remove(status) )
-));
+    )
+);
 
-named!(nfs4_res_rename<Nfs4ResponseContent>,
+named!(
+    nfs4_res_rename<Nfs4ResponseContent>,
+    do_parse!(status: be_u32 >> (Nfs4ResponseContent::Rename(status)))
+);
+
+named!(
+    nfs4_res_savefh<Nfs4ResponseContent>,
+    do_parse!(status: be_u32 >> (Nfs4ResponseContent::SaveFH(status)))
+);
+
+named!(
+    nfs4_res_lookup<Nfs4ResponseContent>,
+    do_parse!(status: be_u32 >> (Nfs4ResponseContent::Lookup(status)))
+);
+
+named!(
+    nfs4_res_renew<Nfs4ResponseContent>,
+    do_parse!(status: be_u32 >> (Nfs4ResponseContent::Renew(status)))
+);
+
+named!(
+    nfs4_res_getfh<Nfs4ResponseContent>,
     do_parse!(
-            status: be_u32
-        >> ( Nfs4ResponseContent::Rename(status) )
-));
+        status: be_u32
+            >> fh: cond!(status == 0, nfs4_parse_handle)
+            >> (Nfs4ResponseContent::GetFH(status, fh))
+    )
+);
 
-named!(nfs4_res_savefh<Nfs4ResponseContent>,
+named!(
+    nfs4_res_putfh<Nfs4ResponseContent>,
+    do_parse!(status: be_u32 >> (Nfs4ResponseContent::PutFH(status)))
+);
+
+named!(
+    nfs4_res_putrootfh<Nfs4ResponseContent>,
+    do_parse!(status: be_u32 >> (Nfs4ResponseContent::PutRootFH(status)))
+);
+
+named!(
+    nfs4_res_delegreturn<Nfs4ResponseContent>,
+    do_parse!(status: be_u32 >> (Nfs4ResponseContent::DelegReturn(status)))
+);
+
+named!(
+    nfs4_res_setclientid<Nfs4ResponseContent>,
     do_parse!(
-            status: be_u32
-        >> ( Nfs4ResponseContent::SaveFH(status) )
-));
+        status: be_u32
+            >> client_id: be_u64
+            >> verifier: be_u32
+            >> (Nfs4ResponseContent::SetClientId(status))
+    )
+);
 
-named!(nfs4_res_lookup<Nfs4ResponseContent>,
+named!(
+    nfs4_res_setclientid_confirm<Nfs4ResponseContent>,
     do_parse!(
-            status: be_u32
-        >> ( Nfs4ResponseContent::Lookup(status) )
-));
+        status: be_u32 >> (Nfs4ResponseContent::SetClientIdConfirm(status))
+    )
+);
 
-named!(nfs4_res_renew<Nfs4ResponseContent>,
+named!(
+    nfs4_res_commit<Nfs4ResponseContent>,
     do_parse!(
-            status: be_u32
-        >> ( Nfs4ResponseContent::Renew(status) )
-));
+        status: be_u32
+            >> verifier: cond!(status == 0, take!(8))
+            >> (Nfs4ResponseContent::Commit(status))
+    )
+);
 
-named!(nfs4_res_getfh<Nfs4ResponseContent>,
-    do_parse!(
-            status: be_u32
-        >>  fh: cond!(status == 0, nfs4_parse_handle)
-        >> ( Nfs4ResponseContent::GetFH(status, fh) )
-));
-
-named!(nfs4_res_putfh<Nfs4ResponseContent>,
-    do_parse!(
-            status: be_u32
-        >> ( Nfs4ResponseContent::PutFH(status) )
-));
-
-named!(nfs4_res_putrootfh<Nfs4ResponseContent>,
-    do_parse!(
-            status: be_u32
-        >> ( Nfs4ResponseContent::PutRootFH(status) )
-));
-
-named!(nfs4_res_delegreturn<Nfs4ResponseContent>,
-    do_parse!(
-            status: be_u32
-        >> ( Nfs4ResponseContent::DelegReturn(status) )
-));
-
-named!(nfs4_res_setclientid<Nfs4ResponseContent>,
-    do_parse!(
-            status: be_u32
-        >>  client_id: be_u64
-        >>  verifier: be_u32
-        >> ( Nfs4ResponseContent::SetClientId(status) )
-));
-
-named!(nfs4_res_setclientid_confirm<Nfs4ResponseContent>,
-    do_parse!(
-            status: be_u32
-        >> ( Nfs4ResponseContent::SetClientIdConfirm(status) )
-));
-
-named!(nfs4_res_commit<Nfs4ResponseContent>,
-    do_parse!(
-            status: be_u32
-        >>  verifier: cond!(status == 0, take!(8))
-        >> ( Nfs4ResponseContent::Commit(status))
-));
-
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4ResponseAccess {
     pub supported_types: u32,
     pub access_rights: u32,
 }
 
-named!(nfs4_res_access_ok<Nfs4ResponseAccess>,
+named!(
+    nfs4_res_access_ok<Nfs4ResponseAccess>,
     do_parse!(
-            s: be_u32
-        >>  a: be_u32
-        >> (Nfs4ResponseAccess {
+        s: be_u32
+            >> a: be_u32
+            >> (Nfs4ResponseAccess {
                 supported_types: s,
                 access_rights: a,
             })
-));
+    )
+);
 
-named!(nfs4_res_access<Nfs4ResponseContent>,
+named!(
+    nfs4_res_access<Nfs4ResponseContent>,
     do_parse!(
-            status: be_u32
-        >>  ad: cond!(status == 0, nfs4_res_access_ok)
-        >> ( Nfs4ResponseContent::Access(
-                status, ad, ))
-));
+        status: be_u32
+            >> ad: cond!(status == 0, nfs4_res_access_ok)
+            >> (Nfs4ResponseContent::Access(status, ad,))
+    )
+);
 
-
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4ResponseSequence<'a> {
-    pub ssn_id: &'a[u8],
+    pub ssn_id: &'a [u8],
 }
 
-named!(nfs4_res_sequence_ok<Nfs4ResponseSequence>,
+named!(
+    nfs4_res_sequence_ok<Nfs4ResponseSequence>,
     do_parse!(
-            ssn_id: take!(16)
-        >>  _slots: take!(12)
-        >>  _flags: be_u32
-        >> ( Nfs4ResponseSequence {
-                ssn_id: ssn_id,
-            })
-));
+        ssn_id: take!(16)
+            >> _slots: take!(12)
+            >> _flags: be_u32
+            >> (Nfs4ResponseSequence { ssn_id: ssn_id })
+    )
+);
 
-named!(nfs4_res_sequence<Nfs4ResponseContent>,
+named!(
+    nfs4_res_sequence<Nfs4ResponseContent>,
     do_parse!(
-            status: be_u32
-        >>  seq: cond!(status == 0, nfs4_res_sequence_ok)
-        >> ( Nfs4ResponseContent::Sequence(status, seq) )
-));
+        status: be_u32
+            >> seq: cond!(status == 0, nfs4_res_sequence_ok)
+            >> (Nfs4ResponseContent::Sequence(status, seq))
+    )
+);
 
-named!(nfs4_res_compound_command<Nfs4ResponseContent>,
+named!(
+    nfs4_res_compound_command<Nfs4ResponseContent>,
     do_parse!(
         cmd: be_u32
-    >>  cmd_data: switch!(value!(cmd),
+            >> cmd_data:
+                switch!(value!(cmd),
             NFSPROC4_READ                   => call!(nfs4_res_read)                |
             NFSPROC4_WRITE                  => call!(nfs4_res_write)               |
             NFSPROC4_ACCESS                 => call!(nfs4_res_access)              |
@@ -890,10 +953,11 @@ named!(nfs4_res_compound_command<Nfs4ResponseContent>,
             NFSPROC4_PUTROOTFH              => call!(nfs4_res_putrootfh)           |
             NFSPROC4_SEQUENCE               => call!(nfs4_res_sequence)            |
             NFSPROC4_RENEW                  => call!(nfs4_res_renew))
-    >> (cmd_data)
-));
+            >> (cmd_data)
+    )
+);
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Nfs4ResponseCompoundRecord<'a> {
     pub status: u32,
     pub commands: Vec<Nfs4ResponseContent<'a>>,

--- a/rust/src/nfs/nfs4_records.rs
+++ b/rust/src/nfs/nfs4_records.rs
@@ -18,7 +18,7 @@
 //! Nom parsers for NFSv4 records
 use nom::{be_u32, be_u64};
 
-use nfs::types::*;
+use crate::nfs::types::*;
 
 #[derive(Debug,PartialEq)]
 pub enum Nfs4RequestContent<'a> {

--- a/rust/src/nfs/nfs_records.rs
+++ b/rust/src/nfs/nfs_records.rs
@@ -17,13 +17,13 @@
 
 //! Nom parsers for NFS
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct NfsReplyRead<'a> {
     pub status: u32,
     pub attr_follows: u32,
-    pub attr_blob: &'a[u8],
+    pub attr_blob: &'a [u8],
     pub count: u32,
     pub eof: bool,
     pub data_len: u32,
-    pub data: &'a[u8], // likely partial
+    pub data: &'a [u8], // likely partial
 }

--- a/rust/src/nfs/rpc_records.rs
+++ b/rust/src/nfs/rpc_records.rs
@@ -19,18 +19,18 @@
 
 use nom::{be_u32, rest};
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum RpcRequestCreds<'a> {
     Unix(RpcRequestCredsUnix<'a>),
     GssApi(RpcRequestCredsGssApi<'a>),
-    Unknown(&'a[u8]),
+    Unknown(&'a [u8]),
 }
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct RpcRequestCredsUnix<'a> {
     pub stamp: u32,
     pub machine_name_len: u32,
-    pub machine_name_buf: &'a[u8],
+    pub machine_name_buf: &'a [u8],
     pub uid: u32,
     pub gid: u32,
     pub aux_gids: Option<Vec<u32>>,
@@ -41,7 +41,8 @@ pub struct RpcRequestCredsUnix<'a> {
 //    many0!(be_u32)
 //);
 
-named!(parse_rpc_request_creds_unix<RpcRequestCreds>,
+named!(
+    parse_rpc_request_creds_unix<RpcRequestCreds>,
     do_parse!(
         stamp: be_u32
     >>  machine_name_len: be_u32
@@ -57,45 +58,47 @@ named!(parse_rpc_request_creds_unix<RpcRequestCreds>,
             gid:gid,
             aux_gids:None,
         }))
-));
+    )
+);
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct RpcRequestCredsGssApi<'a> {
     pub version: u32,
     pub procedure: u32,
     pub seq_num: u32,
     pub service: u32,
 
-    pub ctx: &'a[u8],
+    pub ctx: &'a [u8],
 }
 
-named!(parse_rpc_request_creds_gssapi<RpcRequestCreds>,
+named!(
+    parse_rpc_request_creds_gssapi<RpcRequestCreds>,
     do_parse!(
         version: be_u32
-    >>  procedure: be_u32
-    >>  seq_num: be_u32
-    >>  service: be_u32
-    >>  ctx_len: be_u32
-    >>  ctx: take!(ctx_len)
-    >> (RpcRequestCreds::GssApi(RpcRequestCredsGssApi {
-            version: version,
-            procedure: procedure,
-            seq_num: seq_num,
-            service: service,
-            ctx: ctx,
-        }))
-));
+            >> procedure: be_u32
+            >> seq_num: be_u32
+            >> service: be_u32
+            >> ctx_len: be_u32
+            >> ctx: take!(ctx_len)
+            >> (RpcRequestCreds::GssApi(RpcRequestCredsGssApi {
+                version: version,
+                procedure: procedure,
+                seq_num: seq_num,
+                service: service,
+                ctx: ctx,
+            }))
+    )
+);
 
-named!(parse_rpc_request_creds_unknown<RpcRequestCreds>,
-    do_parse!(
-        blob: rest
-    >> (RpcRequestCreds::Unknown(blob) )
-));
+named!(
+    parse_rpc_request_creds_unknown<RpcRequestCreds>,
+    do_parse!(blob: rest >> (RpcRequestCreds::Unknown(blob)))
+);
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct RpcGssApiIntegrity<'a> {
     pub seq_num: u32,
-    pub data: &'a[u8],
+    pub data: &'a [u8],
 }
 
 // Parse the GSSAPI Integrity envelope to get to the
@@ -111,8 +114,8 @@ named!(pub parse_rpc_gssapi_integrity<RpcGssApiIntegrity>,
         })
 ));
 
-#[derive(Debug,PartialEq)]
-pub struct RpcPacketHeader<> {
+#[derive(Debug, PartialEq)]
+pub struct RpcPacketHeader {
     pub frag_is_last: bool,
     pub frag_len: u32,
     pub xid: u32,
@@ -137,18 +140,18 @@ named!(pub parse_rpc_packet_header<RpcPacketHeader>,
         ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct RpcReplyPacket<'a> {
-    pub hdr: RpcPacketHeader<>,
+    pub hdr: RpcPacketHeader,
 
     pub verifier_flavor: u32,
     pub verifier_len: u32,
-    pub verifier: Option<&'a[u8]>,
+    pub verifier: Option<&'a [u8]>,
 
     pub reply_state: u32,
     pub accept_state: u32,
 
-    pub prog_data: &'a[u8],
+    pub prog_data: &'a [u8],
 }
 
 // top of request packet, just to get to procedure
@@ -180,9 +183,9 @@ named!(pub parse_rpc_request_partial<RpcRequestPacketPartial>,
           ))
 );
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct RpcPacket<'a> {
-    pub hdr: RpcPacketHeader<>,
+    pub hdr: RpcPacketHeader,
 
     pub rpcver: u32,
     pub program: u32,
@@ -194,9 +197,9 @@ pub struct RpcPacket<'a> {
 
     pub verifier_flavor: u32,
     pub verifier_len: u32,
-    pub verifier: &'a[u8],
+    pub verifier: &'a [u8],
 
-    pub prog_data: &'a[u8],
+    pub prog_data: &'a [u8],
 }
 
 named!(pub parse_rpc<RpcPacket>,

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -16,311 +16,314 @@
  */
 
 /* RFC 1813, section '3. Server Procedures' */
-pub const NFSPROC3_NULL:        u32 = 0;
-pub const NFSPROC3_GETATTR:     u32 = 1;
-pub const NFSPROC3_SETATTR:     u32 = 2;
-pub const NFSPROC3_LOOKUP:      u32 = 3;
-pub const NFSPROC3_ACCESS:      u32 = 4;
-pub const NFSPROC3_READLINK:    u32 = 5;
-pub const NFSPROC3_READ:        u32 = 6;
-pub const NFSPROC3_WRITE:       u32 = 7;
-pub const NFSPROC3_CREATE:      u32 = 8;
-pub const NFSPROC3_MKDIR:       u32 = 9;
-pub const NFSPROC3_SYMLINK:     u32 = 10;
-pub const NFSPROC3_MKNOD:       u32 = 11;
-pub const NFSPROC3_REMOVE:      u32 = 12;
-pub const NFSPROC3_RMDIR:       u32 = 13;
-pub const NFSPROC3_RENAME:      u32 = 14;
-pub const NFSPROC3_LINK:        u32 = 15;
-pub const NFSPROC3_READDIR:     u32 = 16;
+pub const NFSPROC3_NULL: u32 = 0;
+pub const NFSPROC3_GETATTR: u32 = 1;
+pub const NFSPROC3_SETATTR: u32 = 2;
+pub const NFSPROC3_LOOKUP: u32 = 3;
+pub const NFSPROC3_ACCESS: u32 = 4;
+pub const NFSPROC3_READLINK: u32 = 5;
+pub const NFSPROC3_READ: u32 = 6;
+pub const NFSPROC3_WRITE: u32 = 7;
+pub const NFSPROC3_CREATE: u32 = 8;
+pub const NFSPROC3_MKDIR: u32 = 9;
+pub const NFSPROC3_SYMLINK: u32 = 10;
+pub const NFSPROC3_MKNOD: u32 = 11;
+pub const NFSPROC3_REMOVE: u32 = 12;
+pub const NFSPROC3_RMDIR: u32 = 13;
+pub const NFSPROC3_RENAME: u32 = 14;
+pub const NFSPROC3_LINK: u32 = 15;
+pub const NFSPROC3_READDIR: u32 = 16;
 pub const NFSPROC3_READDIRPLUS: u32 = 17;
-pub const NFSPROC3_FSSTAT:      u32 = 18;
-pub const NFSPROC3_FSINFO:      u32 = 19;
-pub const NFSPROC3_PATHCONF:    u32 = 20;
-pub const NFSPROC3_COMMIT:      u32 = 21;
+pub const NFSPROC3_FSSTAT: u32 = 18;
+pub const NFSPROC3_FSINFO: u32 = 19;
+pub const NFSPROC3_PATHCONF: u32 = 20;
+pub const NFSPROC3_COMMIT: u32 = 21;
 
 pub fn nfs3_procedure_string(procedure: u32) -> String {
     match procedure {
-        NFSPROC3_NULL           => "NULL",
-        NFSPROC3_GETATTR        => "GETATTR",
-        NFSPROC3_SETATTR        => "SETATTR",
-        NFSPROC3_LOOKUP         => "LOOKUP",
-        NFSPROC3_ACCESS         => "ACCESS",
-        NFSPROC3_READLINK       => "READLINK",
-        NFSPROC3_READ           => "READ",
-        NFSPROC3_WRITE          => "WRITE",
-        NFSPROC3_CREATE         => "CREATE",
-        NFSPROC3_MKDIR          => "MKDIR",
-        NFSPROC3_SYMLINK        => "SYMLINK",
-        NFSPROC3_MKNOD          => "MKNOD",
-        NFSPROC3_REMOVE         => "REMOVE",
-        NFSPROC3_RMDIR          => "RMDIR",
-        NFSPROC3_RENAME         => "RENAME",
-        NFSPROC3_LINK           => "LINK",
-        NFSPROC3_READDIR        => "READDIR",
-        NFSPROC3_READDIRPLUS    => "READDIRPLUS",
-        NFSPROC3_FSSTAT         => "FSSTAT",
-        NFSPROC3_FSINFO         => "FSINFO",
-        NFSPROC3_PATHCONF       => "PATHCONF",
-        NFSPROC3_COMMIT         => "COMMIT",
+        NFSPROC3_NULL => "NULL",
+        NFSPROC3_GETATTR => "GETATTR",
+        NFSPROC3_SETATTR => "SETATTR",
+        NFSPROC3_LOOKUP => "LOOKUP",
+        NFSPROC3_ACCESS => "ACCESS",
+        NFSPROC3_READLINK => "READLINK",
+        NFSPROC3_READ => "READ",
+        NFSPROC3_WRITE => "WRITE",
+        NFSPROC3_CREATE => "CREATE",
+        NFSPROC3_MKDIR => "MKDIR",
+        NFSPROC3_SYMLINK => "SYMLINK",
+        NFSPROC3_MKNOD => "MKNOD",
+        NFSPROC3_REMOVE => "REMOVE",
+        NFSPROC3_RMDIR => "RMDIR",
+        NFSPROC3_RENAME => "RENAME",
+        NFSPROC3_LINK => "LINK",
+        NFSPROC3_READDIR => "READDIR",
+        NFSPROC3_READDIRPLUS => "READDIRPLUS",
+        NFSPROC3_FSSTAT => "FSSTAT",
+        NFSPROC3_FSINFO => "FSINFO",
+        NFSPROC3_PATHCONF => "PATHCONF",
+        NFSPROC3_COMMIT => "COMMIT",
         _ => {
             return (procedure).to_string();
         }
-    }.to_string()
+    }
+    .to_string()
 }
 
 /* RFC 1813, section '2.6 Defined Error Numbers' */
-pub const NFS3_OK:              u32 = 0;
-pub const NFS3ERR_PERM:         u32 = 1;
-pub const NFS3ERR_NOENT:        u32 = 2;
-pub const NFS3ERR_IO:           u32 = 5;
-pub const NFS3ERR_NXIO:         u32 = 6;
-pub const NFS3ERR_ACCES:        u32 = 13;
-pub const NFS3ERR_EXIST:        u32 = 17;
-pub const NFS3ERR_XDEV:         u32 = 18;
-pub const NFS3ERR_NODEV:        u32 = 19;
-pub const NFS3ERR_NOTDIR:       u32 = 20;
-pub const NFS3ERR_ISDIR:        u32 = 21;
-pub const NFS3ERR_INVAL:        u32 = 22;
-pub const NFS3ERR_FBIG:         u32 = 27;
-pub const NFS3ERR_NOSPC:        u32 = 28;
-pub const NFS3ERR_ROFS:         u32 = 30;
-pub const NFS3ERR_MLINK:        u32 = 31;
-pub const NFS3ERR_NAMETOOLONG:  u32 = 63;
-pub const NFS3ERR_NOTEMPTY:     u32 = 66;
-pub const NFS3ERR_DQUOT:        u32 = 69;
-pub const NFS3ERR_STALE:        u32 = 70;
-pub const NFS3ERR_REMOTE:       u32 = 71;
-pub const NFS3ERR_BADHANDLE:    u32 = 10001;
-pub const NFS3ERR_NOT_SYNC:     u32 = 10002;
-pub const NFS3ERR_BAD_COOKIE:   u32 = 10003;
-pub const NFS3ERR_NOTSUPP:      u32 = 10004;
-pub const NFS3ERR_TOOSMALL:     u32 = 10005;
-pub const NFS3ERR_SERVERFAULT:  u32 = 10006;
-pub const NFS3ERR_BADTYPE:      u32 = 10007;
-pub const NFS3ERR_JUKEBOX:      u32 = 10008;
+pub const NFS3_OK: u32 = 0;
+pub const NFS3ERR_PERM: u32 = 1;
+pub const NFS3ERR_NOENT: u32 = 2;
+pub const NFS3ERR_IO: u32 = 5;
+pub const NFS3ERR_NXIO: u32 = 6;
+pub const NFS3ERR_ACCES: u32 = 13;
+pub const NFS3ERR_EXIST: u32 = 17;
+pub const NFS3ERR_XDEV: u32 = 18;
+pub const NFS3ERR_NODEV: u32 = 19;
+pub const NFS3ERR_NOTDIR: u32 = 20;
+pub const NFS3ERR_ISDIR: u32 = 21;
+pub const NFS3ERR_INVAL: u32 = 22;
+pub const NFS3ERR_FBIG: u32 = 27;
+pub const NFS3ERR_NOSPC: u32 = 28;
+pub const NFS3ERR_ROFS: u32 = 30;
+pub const NFS3ERR_MLINK: u32 = 31;
+pub const NFS3ERR_NAMETOOLONG: u32 = 63;
+pub const NFS3ERR_NOTEMPTY: u32 = 66;
+pub const NFS3ERR_DQUOT: u32 = 69;
+pub const NFS3ERR_STALE: u32 = 70;
+pub const NFS3ERR_REMOTE: u32 = 71;
+pub const NFS3ERR_BADHANDLE: u32 = 10001;
+pub const NFS3ERR_NOT_SYNC: u32 = 10002;
+pub const NFS3ERR_BAD_COOKIE: u32 = 10003;
+pub const NFS3ERR_NOTSUPP: u32 = 10004;
+pub const NFS3ERR_TOOSMALL: u32 = 10005;
+pub const NFS3ERR_SERVERFAULT: u32 = 10006;
+pub const NFS3ERR_BADTYPE: u32 = 10007;
+pub const NFS3ERR_JUKEBOX: u32 = 10008;
 
 pub fn nfs3_status_string(status: u32) -> String {
     match status {
-        NFS3_OK             => "OK",
-        NFS3ERR_PERM        => "ERR_PERM",
-        NFS3ERR_NOENT       => "ERR_NOENT",
-        NFS3ERR_IO          => "ERR_IO",
-        NFS3ERR_NXIO        => "ERR_NXIO",
-        NFS3ERR_ACCES       => "ERR_ACCES",
-        NFS3ERR_EXIST       => "ERR_EXIST",
-        NFS3ERR_XDEV        => "ERR_XDEV",
-        NFS3ERR_NODEV       => "ERR_NODEV",
-        NFS3ERR_NOTDIR      => "ERR_NOTDIR",
-        NFS3ERR_ISDIR       => "ERR_ISDIR",
-        NFS3ERR_INVAL       => "ERR_INVAL",
-        NFS3ERR_FBIG        => "ERR_FBIG",
-        NFS3ERR_NOSPC       => "ERR_NOSPC",
-        NFS3ERR_ROFS        => "ERR_ROFS",
-        NFS3ERR_MLINK       => "ERR_MLINK",
+        NFS3_OK => "OK",
+        NFS3ERR_PERM => "ERR_PERM",
+        NFS3ERR_NOENT => "ERR_NOENT",
+        NFS3ERR_IO => "ERR_IO",
+        NFS3ERR_NXIO => "ERR_NXIO",
+        NFS3ERR_ACCES => "ERR_ACCES",
+        NFS3ERR_EXIST => "ERR_EXIST",
+        NFS3ERR_XDEV => "ERR_XDEV",
+        NFS3ERR_NODEV => "ERR_NODEV",
+        NFS3ERR_NOTDIR => "ERR_NOTDIR",
+        NFS3ERR_ISDIR => "ERR_ISDIR",
+        NFS3ERR_INVAL => "ERR_INVAL",
+        NFS3ERR_FBIG => "ERR_FBIG",
+        NFS3ERR_NOSPC => "ERR_NOSPC",
+        NFS3ERR_ROFS => "ERR_ROFS",
+        NFS3ERR_MLINK => "ERR_MLINK",
         NFS3ERR_NAMETOOLONG => "ERR_NAMETOOLONG",
-        NFS3ERR_NOTEMPTY    => "ERR_NOTEMPTY",
-        NFS3ERR_DQUOT       => "ERR_DQUOT",
-        NFS3ERR_STALE       => "ERR_STALE",
-        NFS3ERR_REMOTE      => "ERR_REMOTE",
-        NFS3ERR_BADHANDLE   => "ERR_BADHANDLE",
-        NFS3ERR_NOT_SYNC    => "ERR_NOT_SYNC",
-        NFS3ERR_BAD_COOKIE  => "ERR_BAD_COOKIE",
-        NFS3ERR_NOTSUPP     => "ERR_NOTSUPP",
-        NFS3ERR_TOOSMALL    => "ERR_TOOSMALL",
+        NFS3ERR_NOTEMPTY => "ERR_NOTEMPTY",
+        NFS3ERR_DQUOT => "ERR_DQUOT",
+        NFS3ERR_STALE => "ERR_STALE",
+        NFS3ERR_REMOTE => "ERR_REMOTE",
+        NFS3ERR_BADHANDLE => "ERR_BADHANDLE",
+        NFS3ERR_NOT_SYNC => "ERR_NOT_SYNC",
+        NFS3ERR_BAD_COOKIE => "ERR_BAD_COOKIE",
+        NFS3ERR_NOTSUPP => "ERR_NOTSUPP",
+        NFS3ERR_TOOSMALL => "ERR_TOOSMALL",
         NFS3ERR_SERVERFAULT => "ERR_SERVERFAULT",
-        NFS3ERR_BADTYPE     => "ERR_BADTYPE",
-        NFS3ERR_JUKEBOX     => "ERR_JUKEBOX",
+        NFS3ERR_BADTYPE => "ERR_BADTYPE",
+        NFS3ERR_JUKEBOX => "ERR_JUKEBOX",
         _ => {
             return (status).to_string();
-        },
-    }.to_string()
+        }
+    }
+    .to_string()
 }
 
-pub const RPCMSG_ACCEPTED:  u32 = 0;
-pub const RPCMSG_DENIED:    u32 = 1;
+pub const RPCMSG_ACCEPTED: u32 = 0;
+pub const RPCMSG_DENIED: u32 = 1;
 
 pub fn rpc_status_string(status: u32) -> String {
     match status {
         RPCMSG_ACCEPTED => "ACCEPTED",
-        RPCMSG_DENIED   => "DENIED",
+        RPCMSG_DENIED => "DENIED",
         _ => {
             return (status).to_string();
-        },
-    }.to_string()
+        }
+    }
+    .to_string()
 }
 
 /* http://www.iana.org/assignments/rpc-authentication-numbers/rpc-authentication-numbers.xhtml */
 /* RFC 1057 Section 7.2 */
 /* RFC 2203 Section 3 */
 
-pub const RPCAUTH_NULL:         u32 = 0;
-pub const RPCAUTH_UNIX:         u32 = 1;
-pub const RPCAUTH_SHORT:        u32 = 2;
-pub const RPCAUTH_DH:           u32 = 3;
-pub const RPCAUTH_KERB:         u32 = 4;
-pub const RPCAUTH_RSA:          u32 = 5;
-pub const RPCAUTH_GSS:          u32 = 6;
+pub const RPCAUTH_NULL: u32 = 0;
+pub const RPCAUTH_UNIX: u32 = 1;
+pub const RPCAUTH_SHORT: u32 = 2;
+pub const RPCAUTH_DH: u32 = 3;
+pub const RPCAUTH_KERB: u32 = 4;
+pub const RPCAUTH_RSA: u32 = 5;
+pub const RPCAUTH_GSS: u32 = 6;
 
 pub fn rpc_auth_type_string(auth_type: u32) -> String {
     match auth_type {
-        RPCAUTH_NULL    => "NULL",
-        RPCAUTH_UNIX    => "UNIX",
-        RPCAUTH_SHORT   => "SHORT",
-        RPCAUTH_DH      => "DH",
-        RPCAUTH_KERB    => "KERB",
-        RPCAUTH_RSA     => "RSA",
-        RPCAUTH_GSS     => "GSS",
+        RPCAUTH_NULL => "NULL",
+        RPCAUTH_UNIX => "UNIX",
+        RPCAUTH_SHORT => "SHORT",
+        RPCAUTH_DH => "DH",
+        RPCAUTH_KERB => "KERB",
+        RPCAUTH_RSA => "RSA",
+        RPCAUTH_GSS => "GSS",
         _ => {
             return (auth_type).to_string();
-        },
-    }.to_string()
+        }
+    }
+    .to_string()
 }
 
 /* http://www.iana.org/assignments/rpc-authentication-numbers/rpc-authentication-numbers.xhtml */
-pub const RPCAUTH_OK:                   u32 = 0;  // success/failed at remote end    [RFC5531]
-pub const RPCAUTH_BADCRED:              u32 = 1;  // bad credential (seal broken)    [RFC5531]
-pub const RPCAUTH_REJECTEDCRED:         u32 = 2;  // client must begin new session   [RFC5531]
-pub const RPCAUTH_BADVERF:              u32 = 3;  // bad verifier (seal broken)  [RFC5531]
-pub const RPCAUTH_REJECTEDVERF:         u32 = 4;  // verifier expired or replayed    [RFC5531]
-pub const RPCAUTH_TOOWEAK:              u32 = 5;  // rejected for security reasons/failed locally    [RFC5531]
-pub const RPCAUTH_INVALIDRESP:          u32 = 6;  // bogus response verifier     [RFC5531]
-pub const RPCAUTH_FAILED:               u32 = 7;  // reason unknown/AUTH_KERB errors; deprecated. See [RFC2695]  [RFC5531]
-pub const RPCAUTH_KERB_GENERIC:         u32 = 8;  // kerberos generic error  [RFC5531]
-pub const RPCAUTH_TIMEEXPIRE:           u32 = 9;  // time of credential expired  [RFC5531]
-pub const RPCAUTH_TKT_FILE:             u32 = 10; // problem with ticket file    [RFC5531]
-pub const RPCAUTH_DECODE:               u32 = 11; // can't decode authenticator  [RFC5531]
-pub const RPCAUTH_NET_ADDR:             u32 = 12; // wrong net address in ticket/RPCSEC_GSS GSS related errors   [RFC5531]
-pub const RPCSEC_GSS_CREDPROBLEM:       u32 = 13; // no credentials for user     [RFC5531]
-pub const RPCSEC_GSS_CTXPROBLEM:        u32 = 14; // problem with context    [RFC5531]
+pub const RPCAUTH_OK: u32 = 0; // success/failed at remote end    [RFC5531]
+pub const RPCAUTH_BADCRED: u32 = 1; // bad credential (seal broken)    [RFC5531]
+pub const RPCAUTH_REJECTEDCRED: u32 = 2; // client must begin new session   [RFC5531]
+pub const RPCAUTH_BADVERF: u32 = 3; // bad verifier (seal broken)  [RFC5531]
+pub const RPCAUTH_REJECTEDVERF: u32 = 4; // verifier expired or replayed    [RFC5531]
+pub const RPCAUTH_TOOWEAK: u32 = 5; // rejected for security reasons/failed locally    [RFC5531]
+pub const RPCAUTH_INVALIDRESP: u32 = 6; // bogus response verifier     [RFC5531]
+pub const RPCAUTH_FAILED: u32 = 7; // reason unknown/AUTH_KERB errors; deprecated. See [RFC2695]  [RFC5531]
+pub const RPCAUTH_KERB_GENERIC: u32 = 8; // kerberos generic error  [RFC5531]
+pub const RPCAUTH_TIMEEXPIRE: u32 = 9; // time of credential expired  [RFC5531]
+pub const RPCAUTH_TKT_FILE: u32 = 10; // problem with ticket file    [RFC5531]
+pub const RPCAUTH_DECODE: u32 = 11; // can't decode authenticator  [RFC5531]
+pub const RPCAUTH_NET_ADDR: u32 = 12; // wrong net address in ticket/RPCSEC_GSS GSS related errors   [RFC5531]
+pub const RPCSEC_GSS_CREDPROBLEM: u32 = 13; // no credentials for user     [RFC5531]
+pub const RPCSEC_GSS_CTXPROBLEM: u32 = 14; // problem with context    [RFC5531]
 pub const RPCSEC_GSS_INNER_CREDPROBLEM: u32 = 15; // No credentials for multi-principal assertion inner context user     [RFC7861]
-pub const RPCSEC_GSS_LABEL_PROBLEM:     u32 = 16; // Problem with label assertion    [RFC7861]
+pub const RPCSEC_GSS_LABEL_PROBLEM: u32 = 16; // Problem with label assertion    [RFC7861]
 pub const RPCSEC_GSS_PRIVILEGE_PROBLEM: u32 = 17; // Problem with structured privilege assertion     [RFC7861]
-pub const RPCSEC_GSS_UNKNOWN_MESSAGE:   u32 = 18; // Unknown structured privilege assertion  [RFC7861]
+pub const RPCSEC_GSS_UNKNOWN_MESSAGE: u32 = 18; // Unknown structured privilege assertion  [RFC7861]
 
 pub fn rpc_auth_status_string(auth_status: u32) -> String {
     match auth_status {
-        RPCAUTH_OK                      => "OK",
-        RPCAUTH_BADCRED                 => "BADCRED",
-        RPCAUTH_REJECTEDCRED            => "REJECTEDCRED",
-        RPCAUTH_BADVERF                 => "BADVERF",
-        RPCAUTH_REJECTEDVERF            => "REJECTEDVERF",
-        RPCAUTH_TOOWEAK                 => "TOOWEAK",
-        RPCAUTH_INVALIDRESP             => "NVALIDRESP",
-        RPCAUTH_FAILED                  => "FAILED",
-        RPCAUTH_KERB_GENERIC            => "KERB_GENERIC",
-        RPCAUTH_TIMEEXPIRE              => "TIMEEXPIRE",
-        RPCAUTH_TKT_FILE                => "TKT_FILE",
-        RPCAUTH_DECODE                  => "DECODE",
-        RPCAUTH_NET_ADDR                => "NET_ADDR",
-        RPCSEC_GSS_CREDPROBLEM          => "GSS_CREDPROBLEM",
-        RPCSEC_GSS_CTXPROBLEM           => "GSS_CTXPROBLEM",
-        RPCSEC_GSS_INNER_CREDPROBLEM    => "GSS_INNER_CREDPROBLEM",
-        RPCSEC_GSS_LABEL_PROBLEM        => "GSS_LABEL_PROBLEM",
-        RPCSEC_GSS_PRIVILEGE_PROBLEM    => "GSS_PRIVILEGE_PROBLEM",
-        RPCSEC_GSS_UNKNOWN_MESSAGE      => "GSS_UNKNOWN_MESSAGE",
+        RPCAUTH_OK => "OK",
+        RPCAUTH_BADCRED => "BADCRED",
+        RPCAUTH_REJECTEDCRED => "REJECTEDCRED",
+        RPCAUTH_BADVERF => "BADVERF",
+        RPCAUTH_REJECTEDVERF => "REJECTEDVERF",
+        RPCAUTH_TOOWEAK => "TOOWEAK",
+        RPCAUTH_INVALIDRESP => "NVALIDRESP",
+        RPCAUTH_FAILED => "FAILED",
+        RPCAUTH_KERB_GENERIC => "KERB_GENERIC",
+        RPCAUTH_TIMEEXPIRE => "TIMEEXPIRE",
+        RPCAUTH_TKT_FILE => "TKT_FILE",
+        RPCAUTH_DECODE => "DECODE",
+        RPCAUTH_NET_ADDR => "NET_ADDR",
+        RPCSEC_GSS_CREDPROBLEM => "GSS_CREDPROBLEM",
+        RPCSEC_GSS_CTXPROBLEM => "GSS_CTXPROBLEM",
+        RPCSEC_GSS_INNER_CREDPROBLEM => "GSS_INNER_CREDPROBLEM",
+        RPCSEC_GSS_LABEL_PROBLEM => "GSS_LABEL_PROBLEM",
+        RPCSEC_GSS_PRIVILEGE_PROBLEM => "GSS_PRIVILEGE_PROBLEM",
+        RPCSEC_GSS_UNKNOWN_MESSAGE => "GSS_UNKNOWN_MESSAGE",
         _ => {
             return (auth_status).to_string();
-        },
-    }.to_string()
+        }
+    }
+    .to_string()
 }
 
-pub const NFSPROC4_NULL:                u32 = 0;
-pub const NFSPROC4_COMPOUND:            u32 = 1;
+pub const NFSPROC4_NULL: u32 = 0;
+pub const NFSPROC4_COMPOUND: u32 = 1;
 /* ops */
-pub const NFSPROC4_ACCESS:              u32 = 3;
-pub const NFSPROC4_CLOSE:               u32 = 4;
-pub const NFSPROC4_COMMIT:              u32 = 5;
-pub const NFSPROC4_CREATE:              u32 = 6;
-pub const NFSPROC4_DELEGPURGE:          u32 = 7;
-pub const NFSPROC4_DELEGRETURN:         u32 = 8;
-pub const NFSPROC4_GETATTR:             u32 = 9;
-pub const NFSPROC4_GETFH:               u32 = 10;
-pub const NFSPROC4_LINK:                u32 = 11;
-pub const NFSPROC4_LOCK:                u32 = 12;
-pub const NFSPROC4_LOCKT:               u32 = 13;
-pub const NFSPROC4_LOCKU:               u32 = 14;
-pub const NFSPROC4_LOOKUP:              u32 = 15;
-pub const NFSPROC4_LOOKUPP:             u32 = 16;
-pub const NFSPROC4_NVERIFY:             u32 = 17;
-pub const NFSPROC4_OPEN:                u32 = 18;
-pub const NFSPROC4_OPENATTR:            u32 = 19;
-pub const NFSPROC4_OPEN_CONFIRM:        u32 = 20;
-pub const NFSPROC4_OPEN_DOWNGRADE:      u32 = 21;
-pub const NFSPROC4_PUTFH:               u32 = 22;
-pub const NFSPROC4_PUTPUBFH:            u32 = 23;
-pub const NFSPROC4_PUTROOTFH:           u32 = 24;
-pub const NFSPROC4_READ:                u32 = 25;
-pub const NFSPROC4_READDIR:             u32 = 26;
-pub const NFSPROC4_READLINK:            u32 = 27;
-pub const NFSPROC4_REMOVE:              u32 = 28;
-pub const NFSPROC4_RENAME:              u32 = 29;
-pub const NFSPROC4_RENEW:               u32 = 30;
-pub const NFSPROC4_RESTOREFH:           u32 = 31;
-pub const NFSPROC4_SAVEFH:              u32 = 32;
-pub const NFSPROC4_SECINFO:             u32 = 33;
-pub const NFSPROC4_SETATTR:             u32 = 34;
-pub const NFSPROC4_SETCLIENTID:         u32 = 35;
+pub const NFSPROC4_ACCESS: u32 = 3;
+pub const NFSPROC4_CLOSE: u32 = 4;
+pub const NFSPROC4_COMMIT: u32 = 5;
+pub const NFSPROC4_CREATE: u32 = 6;
+pub const NFSPROC4_DELEGPURGE: u32 = 7;
+pub const NFSPROC4_DELEGRETURN: u32 = 8;
+pub const NFSPROC4_GETATTR: u32 = 9;
+pub const NFSPROC4_GETFH: u32 = 10;
+pub const NFSPROC4_LINK: u32 = 11;
+pub const NFSPROC4_LOCK: u32 = 12;
+pub const NFSPROC4_LOCKT: u32 = 13;
+pub const NFSPROC4_LOCKU: u32 = 14;
+pub const NFSPROC4_LOOKUP: u32 = 15;
+pub const NFSPROC4_LOOKUPP: u32 = 16;
+pub const NFSPROC4_NVERIFY: u32 = 17;
+pub const NFSPROC4_OPEN: u32 = 18;
+pub const NFSPROC4_OPENATTR: u32 = 19;
+pub const NFSPROC4_OPEN_CONFIRM: u32 = 20;
+pub const NFSPROC4_OPEN_DOWNGRADE: u32 = 21;
+pub const NFSPROC4_PUTFH: u32 = 22;
+pub const NFSPROC4_PUTPUBFH: u32 = 23;
+pub const NFSPROC4_PUTROOTFH: u32 = 24;
+pub const NFSPROC4_READ: u32 = 25;
+pub const NFSPROC4_READDIR: u32 = 26;
+pub const NFSPROC4_READLINK: u32 = 27;
+pub const NFSPROC4_REMOVE: u32 = 28;
+pub const NFSPROC4_RENAME: u32 = 29;
+pub const NFSPROC4_RENEW: u32 = 30;
+pub const NFSPROC4_RESTOREFH: u32 = 31;
+pub const NFSPROC4_SAVEFH: u32 = 32;
+pub const NFSPROC4_SECINFO: u32 = 33;
+pub const NFSPROC4_SETATTR: u32 = 34;
+pub const NFSPROC4_SETCLIENTID: u32 = 35;
 pub const NFSPROC4_SETCLIENTID_CONFIRM: u32 = 36;
-pub const NFSPROC4_VERIFY:              u32 = 37;
-pub const NFSPROC4_WRITE:               u32 = 38;
-pub const NFSPROC4_RELEASE_LOCKOWNER:   u32 = 39;
-pub const NFSPROC4_SEQUENCE:            u32 = 53;
+pub const NFSPROC4_VERIFY: u32 = 37;
+pub const NFSPROC4_WRITE: u32 = 38;
+pub const NFSPROC4_RELEASE_LOCKOWNER: u32 = 39;
+pub const NFSPROC4_SEQUENCE: u32 = 53;
 
+pub const NFSPROC4_EXCHANGE_ID: u32 = 42;
 
-pub const NFSPROC4_EXCHANGE_ID:         u32 = 42;
-
-pub const NFSPROC4_ILLEGAL:             u32 = 10044;
-
+pub const NFSPROC4_ILLEGAL: u32 = 10044;
 
 pub fn nfs4_procedure_string(procedure: u32) -> String {
     match procedure {
-        NFSPROC4_COMPOUND               => "COMPOUND",
-        NFSPROC4_NULL                   => "NULL",
+        NFSPROC4_COMPOUND => "COMPOUND",
+        NFSPROC4_NULL => "NULL",
         // ops
-        NFSPROC4_ACCESS                 => "ACCESS",
-        NFSPROC4_CLOSE                  => "CLOSE",
-        NFSPROC4_COMMIT                 => "COMMIT",
-        NFSPROC4_CREATE                 => "CREATE",
-        NFSPROC4_DELEGPURGE             => "DELEGPURGE",
-        NFSPROC4_DELEGRETURN            => "DELEGRETURN",
-        NFSPROC4_GETATTR                => "GETATTR",
-        NFSPROC4_GETFH                  => "GETFH",
-        NFSPROC4_LINK                   => "LINK",
-        NFSPROC4_LOCK                   => "LOCK",
-        NFSPROC4_LOCKT                  => "LOCKT",
-        NFSPROC4_LOCKU                  => "LOCKU",
-        NFSPROC4_LOOKUP                 => "LOOKUP",
-        NFSPROC4_LOOKUPP                => "LOOKUPP",
-        NFSPROC4_NVERIFY                => "NVERIFY",
-        NFSPROC4_OPEN                   => "OPEN",
-        NFSPROC4_OPENATTR               => "OPENATTR",
-        NFSPROC4_OPEN_CONFIRM           => "OPEN_CONFIRM",
-        NFSPROC4_OPEN_DOWNGRADE         => "OPEN_DOWNGRADE",
-        NFSPROC4_PUTFH                  => "PUTFH",
-        NFSPROC4_PUTPUBFH               => "PUTPUBFH",
-        NFSPROC4_PUTROOTFH              => "PUTROOTFH",
-        NFSPROC4_READ                   => "READ",
-        NFSPROC4_READDIR                => "READDIR",
-        NFSPROC4_READLINK               => "READLINK",
-        NFSPROC4_REMOVE                 => "REMOVE",
-        NFSPROC4_RENAME                 => "RENAME",
-        NFSPROC4_RENEW                  => "RENEW",
-        NFSPROC4_RESTOREFH              => "RESTOREFH",
-        NFSPROC4_SAVEFH                 => "SAVEFH",
-        NFSPROC4_SECINFO                => "SECINFO",
-        NFSPROC4_SETATTR                => "SETATTR",
-        NFSPROC4_SETCLIENTID            => "SETCLIENTID",
-        NFSPROC4_SETCLIENTID_CONFIRM    => "SETCLIENTID_CONFIRM",
-        NFSPROC4_VERIFY                 => "VERIFY",
-        NFSPROC4_WRITE                  => "WRITE",
-        NFSPROC4_RELEASE_LOCKOWNER      => "RELEASE_LOCKOWNER",
-        NFSPROC4_ILLEGAL                => "ILLEGAL",
+        NFSPROC4_ACCESS => "ACCESS",
+        NFSPROC4_CLOSE => "CLOSE",
+        NFSPROC4_COMMIT => "COMMIT",
+        NFSPROC4_CREATE => "CREATE",
+        NFSPROC4_DELEGPURGE => "DELEGPURGE",
+        NFSPROC4_DELEGRETURN => "DELEGRETURN",
+        NFSPROC4_GETATTR => "GETATTR",
+        NFSPROC4_GETFH => "GETFH",
+        NFSPROC4_LINK => "LINK",
+        NFSPROC4_LOCK => "LOCK",
+        NFSPROC4_LOCKT => "LOCKT",
+        NFSPROC4_LOCKU => "LOCKU",
+        NFSPROC4_LOOKUP => "LOOKUP",
+        NFSPROC4_LOOKUPP => "LOOKUPP",
+        NFSPROC4_NVERIFY => "NVERIFY",
+        NFSPROC4_OPEN => "OPEN",
+        NFSPROC4_OPENATTR => "OPENATTR",
+        NFSPROC4_OPEN_CONFIRM => "OPEN_CONFIRM",
+        NFSPROC4_OPEN_DOWNGRADE => "OPEN_DOWNGRADE",
+        NFSPROC4_PUTFH => "PUTFH",
+        NFSPROC4_PUTPUBFH => "PUTPUBFH",
+        NFSPROC4_PUTROOTFH => "PUTROOTFH",
+        NFSPROC4_READ => "READ",
+        NFSPROC4_READDIR => "READDIR",
+        NFSPROC4_READLINK => "READLINK",
+        NFSPROC4_REMOVE => "REMOVE",
+        NFSPROC4_RENAME => "RENAME",
+        NFSPROC4_RENEW => "RENEW",
+        NFSPROC4_RESTOREFH => "RESTOREFH",
+        NFSPROC4_SAVEFH => "SAVEFH",
+        NFSPROC4_SECINFO => "SECINFO",
+        NFSPROC4_SETATTR => "SETATTR",
+        NFSPROC4_SETCLIENTID => "SETCLIENTID",
+        NFSPROC4_SETCLIENTID_CONFIRM => "SETCLIENTID_CONFIRM",
+        NFSPROC4_VERIFY => "VERIFY",
+        NFSPROC4_WRITE => "WRITE",
+        NFSPROC4_RELEASE_LOCKOWNER => "RELEASE_LOCKOWNER",
+        NFSPROC4_ILLEGAL => "ILLEGAL",
         _ => {
             return (procedure).to_string();
         }
-    }.to_string()
+    }
+    .to_string()
 }
 
-pub const NFS4_OK:              u32 = 0;
-
+pub const NFS4_OK: u32 = 0;

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -19,15 +19,15 @@
 
 extern crate ntp_parser;
 use self::ntp_parser::*;
-use core;
-use core::{AppProto,Flow,ALPROTO_UNKNOWN,ALPROTO_FAILED};
-use applayer;
-use parser::*;
+use crate::core;
+use crate::core::{AppProto,Flow,ALPROTO_UNKNOWN,ALPROTO_FAILED};
+use crate::applayer;
+use crate::parser::*;
 use libc;
 use std;
 use std::ffi::{CStr,CString};
 
-use log::*;
+use crate::log::*;
 
 use nom::IResult;
 

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -19,11 +19,11 @@
 
 //! Parser registration functions and common interface
 
-use core::{DetectEngineState,Flow,AppLayerEventType,AppLayerDecoderEvents,AppProto};
-use filecontainer::FileContainer;
+use crate::core::{DetectEngineState,Flow,AppLayerEventType,AppLayerDecoderEvents,AppProto};
+use crate::filecontainer::FileContainer;
 
 use libc::{c_void,c_char,c_int};
-use applayer::{AppLayerGetTxIterTuple};
+use crate::applayer::{AppLayerGetTxIterTuple};
 
 /// Rust parser declaration
 #[repr(C)]

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -19,95 +19,96 @@
 
 //! Parser registration functions and common interface
 
-use crate::core::{DetectEngineState,Flow,AppLayerEventType,AppLayerDecoderEvents,AppProto};
+use crate::core::{
+    AppLayerDecoderEvents, AppLayerEventType, AppProto, DetectEngineState, Flow,
+};
 use crate::filecontainer::FileContainer;
 
-use libc::{c_void,c_char,c_int};
-use crate::applayer::{AppLayerGetTxIterTuple};
+use crate::applayer::AppLayerGetTxIterTuple;
+use libc::{c_char, c_int, c_void};
 
 /// Rust parser declaration
 #[repr(C)]
 pub struct RustParser {
     /// Parser name.
-    pub name:              *const c_char,
+    pub name: *const c_char,
     /// Default port
-    pub default_port:      *const c_char,
+    pub default_port: *const c_char,
 
     /// IP Protocol (libc::IPPROTO_UDP, libc::IPPROTO_TCP, etc.)
-    pub ipproto:           c_int,
+    pub ipproto: c_int,
 
     /// Probing function, for packets going to server
-    pub probe_ts:          ProbeFn,
+    pub probe_ts: ProbeFn,
     /// Probing function, for packets going to client
-    pub probe_tc:          ProbeFn,
+    pub probe_tc: ProbeFn,
 
     /// Minimum frame depth for probing
-    pub min_depth:         u16,
+    pub min_depth: u16,
     /// Maximum frame depth for probing
-    pub max_depth:         u16,
+    pub max_depth: u16,
 
     /// Allocation function for a new state
-    pub state_new:         StateAllocFn,
+    pub state_new: StateAllocFn,
     /// Function called to free a state
-    pub state_free:        StateFreeFn,
+    pub state_free: StateFreeFn,
 
     /// Parsing function, for packets going to server
-    pub parse_ts:          ParseFn,
+    pub parse_ts: ParseFn,
     /// Parsing function, for packets going to client
-    pub parse_tc:          ParseFn,
+    pub parse_tc: ParseFn,
 
     /// Get the current transaction count
-    pub get_tx_count:      StateGetTxCntFn,
+    pub get_tx_count: StateGetTxCntFn,
     /// Get a transaction
-    pub get_tx:            StateGetTxFn,
+    pub get_tx: StateGetTxFn,
     /// Function called to free a transaction
-    pub tx_free:           StateTxFreeFn,
+    pub tx_free: StateTxFreeFn,
     /// Function returning the current transaction completion status
-    pub tx_get_comp_st:    StateGetTxCompletionStatusFn,
+    pub tx_get_comp_st: StateGetTxCompletionStatusFn,
     /// Function returning the current transaction progress
-    pub tx_get_progress:   StateGetProgressFn,
+    pub tx_get_progress: StateGetProgressFn,
 
     /// Logged transaction getter function
-    pub get_tx_logged:     Option<GetTxLoggedFn>,
+    pub get_tx_logged: Option<GetTxLoggedFn>,
     /// Logged transaction setter function
-    pub set_tx_logged:     Option<SetTxLoggedFn>,
+    pub set_tx_logged: Option<SetTxLoggedFn>,
 
     /// Function called to get a detection state
-    pub get_de_state:      GetDetectStateFn,
+    pub get_de_state: GetDetectStateFn,
     /// Function called to set a detection state
-    pub set_de_state:      SetDetectStateFn,
+    pub set_de_state: SetDetectStateFn,
 
     /// Function to get events
-    pub get_events:        Option<GetEventsFn>,
+    pub get_events: Option<GetEventsFn>,
     /// Function to get an event description
-    pub get_eventinfo:     Option<GetEventInfoFn>,
+    pub get_eventinfo: Option<GetEventInfoFn>,
 
     /// Function to allocate local storage
-    pub localstorage_new:  Option<LocalStorageNewFn>,
+    pub localstorage_new: Option<LocalStorageNewFn>,
     /// Function to free local storage
     pub localstorage_free: Option<LocalStorageFreeFn>,
 
     /// Function to get transaction MPM ID
-    pub get_tx_mpm_id:     Option<GetTxMpmIDFn>,
+    pub get_tx_mpm_id: Option<GetTxMpmIDFn>,
     /// Function to set transaction MPM ID
-    pub set_tx_mpm_id:     Option<SetTxMpmIDFn>,
+    pub set_tx_mpm_id: Option<SetTxMpmIDFn>,
 
     /// Function to get files
-    pub get_files:         Option<GetFilesFn>,
+    pub get_files: Option<GetFilesFn>,
 
     /// Function to get the TX iterator
-    pub get_tx_iterator:   Option<GetTxIteratorFn>,
+    pub get_tx_iterator: Option<GetTxIteratorFn>,
 }
-
-
-
 
 /// Create a slice, given a buffer and a length
 ///
 /// UNSAFE !
 #[macro_export]
 macro_rules! build_slice {
-    ($buf:ident, $len:expr) => ( unsafe{ std::slice::from_raw_parts($buf, $len) } );
+    ($buf:ident, $len:expr) => {
+        unsafe { std::slice::from_raw_parts($buf, $len) }
+    };
 }
 
 /// Cast pointer to a variable, as a mutable reference to an object
@@ -115,62 +116,88 @@ macro_rules! build_slice {
 /// UNSAFE !
 #[macro_export]
 macro_rules! cast_pointer {
-    ($ptr:ident, $ty:ty) => ( unsafe{ &mut *($ptr as *mut $ty) } );
+    ($ptr:ident, $ty:ty) => {
+        unsafe { &mut *($ptr as *mut $ty) }
+    };
 }
 
-pub type ParseFn      = extern "C" fn (flow: *const Flow,
-                                       state: *mut c_void,
-                                       pstate: *mut c_void,
-                                       input: *const u8,
-                                       input_len: u32,
-                                       data: *const c_void,
-                                       flags: u8) -> i32;
-pub type ProbeFn      = extern "C" fn (flow: *const Flow,input:*const u8, input_len: u32) -> AppProto;
-pub type StateAllocFn = extern "C" fn () -> *mut c_void;
-pub type StateFreeFn  = extern "C" fn (*mut c_void);
-pub type StateTxFreeFn  = extern "C" fn (*mut c_void, u64);
-pub type StateGetTxFn            = extern "C" fn (*mut c_void, u64) -> *mut c_void;
-pub type StateGetTxCntFn         = extern "C" fn (*mut c_void) -> u64;
-pub type StateGetTxCompletionStatusFn = extern "C" fn (u8) -> c_int;
-pub type StateGetProgressFn = extern "C" fn (*mut c_void, u8) -> c_int;
-pub type GetDetectStateFn   = extern "C" fn (*mut c_void) -> *mut DetectEngineState;
-pub type SetDetectStateFn   = extern "C" fn (*mut c_void, &mut DetectEngineState) -> c_int;
-pub type GetEventInfoFn     = extern "C" fn (*const c_char, *mut c_int, *mut AppLayerEventType) -> c_int;
-pub type GetEventsFn        = extern "C" fn (*mut c_void, u64) -> *mut AppLayerDecoderEvents;
-pub type GetTxLoggedFn      = extern "C" fn (*mut c_void, *mut c_void) -> u32;
-pub type SetTxLoggedFn      = extern "C" fn (*mut c_void, *mut c_void, u32);
-pub type LocalStorageNewFn  = extern "C" fn () -> *mut c_void;
-pub type LocalStorageFreeFn = extern "C" fn (*mut c_void);
-pub type GetTxMpmIDFn       = extern "C" fn (*mut c_void) -> u64;
-pub type SetTxMpmIDFn       = extern "C" fn (*mut c_void, u64) -> c_int;
-pub type GetFilesFn         = extern "C" fn (*mut c_void, u8) -> *mut FileContainer;
-pub type GetTxIteratorFn    = extern "C" fn (ipproto: u8, alproto: AppProto,
-                                             state: *mut c_void,
-                                             min_tx_id: u64,
-                                             max_tx_id: u64,
-                                             istate: &mut u64)
-                                             -> AppLayerGetTxIterTuple;
+pub type ParseFn = extern "C" fn(
+    flow: *const Flow,
+    state: *mut c_void,
+    pstate: *mut c_void,
+    input: *const u8,
+    input_len: u32,
+    data: *const c_void,
+    flags: u8,
+) -> i32;
+pub type ProbeFn = extern "C" fn(
+    flow: *const Flow,
+    input: *const u8,
+    input_len: u32,
+) -> AppProto;
+pub type StateAllocFn = extern "C" fn() -> *mut c_void;
+pub type StateFreeFn = extern "C" fn(*mut c_void);
+pub type StateTxFreeFn = extern "C" fn(*mut c_void, u64);
+pub type StateGetTxFn = extern "C" fn(*mut c_void, u64) -> *mut c_void;
+pub type StateGetTxCntFn = extern "C" fn(*mut c_void) -> u64;
+pub type StateGetTxCompletionStatusFn = extern "C" fn(u8) -> c_int;
+pub type StateGetProgressFn = extern "C" fn(*mut c_void, u8) -> c_int;
+pub type GetDetectStateFn =
+    extern "C" fn(*mut c_void) -> *mut DetectEngineState;
+pub type SetDetectStateFn =
+    extern "C" fn(*mut c_void, &mut DetectEngineState) -> c_int;
+pub type GetEventInfoFn =
+    extern "C" fn(*const c_char, *mut c_int, *mut AppLayerEventType) -> c_int;
+pub type GetEventsFn =
+    extern "C" fn(*mut c_void, u64) -> *mut AppLayerDecoderEvents;
+pub type GetTxLoggedFn = extern "C" fn(*mut c_void, *mut c_void) -> u32;
+pub type SetTxLoggedFn = extern "C" fn(*mut c_void, *mut c_void, u32);
+pub type LocalStorageNewFn = extern "C" fn() -> *mut c_void;
+pub type LocalStorageFreeFn = extern "C" fn(*mut c_void);
+pub type GetTxMpmIDFn = extern "C" fn(*mut c_void) -> u64;
+pub type SetTxMpmIDFn = extern "C" fn(*mut c_void, u64) -> c_int;
+pub type GetFilesFn = extern "C" fn(*mut c_void, u8) -> *mut FileContainer;
+pub type GetTxIteratorFn = extern "C" fn(
+    ipproto: u8,
+    alproto: AppProto,
+    state: *mut c_void,
+    min_tx_id: u64,
+    max_tx_id: u64,
+    istate: &mut u64,
+) -> AppLayerGetTxIterTuple;
 
 // Defined in app-layer-register.h
-extern {
-    pub fn AppLayerRegisterProtocolDetection(parser: *const RustParser, enable_default: c_int) -> AppProto;
-    pub fn AppLayerRegisterParser(parser: *const RustParser, alproto: AppProto) -> c_int;
+extern "C" {
+    pub fn AppLayerRegisterProtocolDetection(
+        parser: *const RustParser,
+        enable_default: c_int,
+    ) -> AppProto;
+    pub fn AppLayerRegisterParser(
+        parser: *const RustParser,
+        alproto: AppProto,
+    ) -> c_int;
 }
 
 // Defined in app-layer-detect-proto.h
-extern {
-    pub fn AppLayerProtoDetectConfProtoDetectionEnabled(ipproto: *const c_char, proto: *const c_char) -> c_int;
+extern "C" {
+    pub fn AppLayerProtoDetectConfProtoDetectionEnabled(
+        ipproto: *const c_char,
+        proto: *const c_char,
+    ) -> c_int;
 }
 
 // Defined in app-layer-parser.h
-pub const APP_LAYER_PARSER_EOF : u8 = 0b0;
-pub const APP_LAYER_PARSER_NO_INSPECTION : u8 = 0b1;
-pub const APP_LAYER_PARSER_NO_REASSEMBLY : u8 = 0b10;
-pub const APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD : u8 = 0b100;
-pub const APP_LAYER_PARSER_BYPASS_READY : u8 = 0b1000;
+pub const APP_LAYER_PARSER_EOF: u8 = 0b0;
+pub const APP_LAYER_PARSER_NO_INSPECTION: u8 = 0b1;
+pub const APP_LAYER_PARSER_NO_REASSEMBLY: u8 = 0b10;
+pub const APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD: u8 = 0b100;
+pub const APP_LAYER_PARSER_BYPASS_READY: u8 = 0b1000;
 
-extern {
+extern "C" {
     pub fn AppLayerParserStateSetFlag(state: *mut c_void, flag: u8);
     pub fn AppLayerParserStateIssetFlag(state: *mut c_void, flag: u8) -> c_int;
-    pub fn AppLayerParserConfParserEnabled(ipproto: *const c_char, proto: *const c_char) -> c_int;
+    pub fn AppLayerParserConfParserEnabled(
+        ipproto: *const c_char,
+        proto: *const c_char,
+    ) -> c_int;
 }

--- a/rust/src/smb/auth.rs
+++ b/rust/src/smb/auth.rs
@@ -15,11 +15,11 @@
  * 02110-1301, USA.
  */
 
-use kerberos::*;
+use crate::kerberos::*;
 
-use log::*;
-use smb::ntlmssp_records::*;
-use smb::smb::*;
+use crate::log::*;
+use crate::smb::ntlmssp_records::*;
+use crate::smb::smb::*;
 
 use nom::{IResult, ErrorKind};
 use der_parser;

--- a/rust/src/smb/auth.rs
+++ b/rust/src/smb/auth.rs
@@ -21,43 +21,58 @@ use crate::log::*;
 use crate::smb::ntlmssp_records::*;
 use crate::smb::smb::*;
 
-use nom::{IResult, ErrorKind};
 use der_parser;
+use nom::{ErrorKind, IResult};
 
-fn parse_secblob_get_spnego(blob: &[u8]) -> IResult<&[u8], &[u8]>
-{
+fn parse_secblob_get_spnego(blob: &[u8]) -> IResult<&[u8], &[u8]> {
     let (rem, base_o) = match der_parser::parse_der(blob) {
         IResult::Done(rem, o) => (rem, o),
-        IResult::Incomplete(needed) => { return IResult::Incomplete(needed); },
-        IResult::Error(err) => { return IResult::Error(err); },
+        IResult::Incomplete(needed) => {
+            return IResult::Incomplete(needed);
+        }
+        IResult::Error(err) => {
+            return IResult::Error(err);
+        }
     };
     SCLogDebug!("parse_secblob_get_spnego: base_o {:?}", base_o);
     let d = match base_o.content.as_slice() {
-        Err(_) => { return IResult::Error(error_code!(ErrorKind::Custom(SECBLOB_NOT_SPNEGO))); },
+        Err(_) => {
+            return IResult::Error(error_code!(ErrorKind::Custom(
+                SECBLOB_NOT_SPNEGO
+            )));
+        }
         Ok(d) => d,
     };
     let (next, o) = match der_parser::parse_der_oid(d) {
-        IResult::Done(rem,y) => { (rem,y) },
-        IResult::Incomplete(needed) => { return IResult::Incomplete(needed); },
-        IResult::Error(err) => { return IResult::Error(err); },
+        IResult::Done(rem, y) => (rem, y),
+        IResult::Incomplete(needed) => {
+            return IResult::Incomplete(needed);
+        }
+        IResult::Error(err) => {
+            return IResult::Error(err);
+        }
     };
     SCLogDebug!("parse_secblob_get_spnego: sub_o {:?}", o);
 
     let oid = match o.content.as_oid() {
         Ok(oid) => oid,
         Err(_) => {
-            return IResult::Error(error_code!(ErrorKind::Custom(SECBLOB_NOT_SPNEGO)));
-        },
+            return IResult::Error(error_code!(ErrorKind::Custom(
+                SECBLOB_NOT_SPNEGO
+            )));
+        }
     };
     SCLogDebug!("oid {}", oid.to_string());
 
     match oid.to_string().as_str() {
         "1.3.6.1.5.5.2" => {
             SCLogDebug!("SPNEGO {}", oid);
-        },
+        }
         _ => {
-            return IResult::Error(error_code!(ErrorKind::Custom(SECBLOB_NOT_SPNEGO)));
-        },
+            return IResult::Error(error_code!(ErrorKind::Custom(
+                SECBLOB_NOT_SPNEGO
+            )));
+        }
     }
 
     SCLogDebug!("parse_secblob_get_spnego: next {:?}", next);
@@ -65,24 +80,29 @@ fn parse_secblob_get_spnego(blob: &[u8]) -> IResult<&[u8], &[u8]>
     IResult::Done(rem, next)
 }
 
-fn parse_secblob_spnego_start(blob: &[u8]) -> IResult<&[u8], &[u8]>
-{
+fn parse_secblob_spnego_start(blob: &[u8]) -> IResult<&[u8], &[u8]> {
     let (rem, o) = match der_parser::parse_der(blob) {
-        IResult::Done(rem,o) => {
+        IResult::Done(rem, o) => {
             SCLogDebug!("o {:?}", o);
             (rem, o)
-        },
-        IResult::Incomplete(needed) => { return IResult::Incomplete(needed); },
-        IResult::Error(err) => { return IResult::Error(err); },
+        }
+        IResult::Incomplete(needed) => {
+            return IResult::Incomplete(needed);
+        }
+        IResult::Error(err) => {
+            return IResult::Error(err);
+        }
     };
     let d = match o.content.as_slice() {
         Ok(d) => {
-            SCLogDebug!("d: next data len {}",d.len());
+            SCLogDebug!("d: next data len {}", d.len());
             d
-        },
+        }
         _ => {
-            return IResult::Error(error_code!(ErrorKind::Custom(SECBLOB_NOT_SPNEGO)));
-        },
+            return IResult::Error(error_code!(ErrorKind::Custom(
+                SECBLOB_NOT_SPNEGO
+            )));
+        }
     };
     IResult::Done(rem, d)
 }
@@ -92,27 +112,32 @@ pub struct SpnegoRequest {
     pub ntlmssp: Option<NtlmsspData>,
 }
 
-fn parse_secblob_spnego(blob: &[u8]) -> Option<SpnegoRequest>
-{
+fn parse_secblob_spnego(blob: &[u8]) -> Option<SpnegoRequest> {
     let mut have_ntlmssp = false;
     let mut have_kerberos = false;
-    let mut kticket : Option<Kerberos5Ticket> = None;
-    let mut ntlmssp : Option<NtlmsspData> = None;
+    let mut kticket: Option<Kerberos5Ticket> = None;
+    let mut ntlmssp: Option<NtlmsspData> = None;
 
     let o = match der_parser::parse_der_sequence(blob) {
         IResult::Done(_, o) => o,
-        _ => { return None; },
+        _ => {
+            return None;
+        }
     };
     for s in o {
         SCLogDebug!("s {:?}", s);
 
         let n = match s.content.as_slice() {
             Ok(s) => s,
-            _ => { continue; },
+            _ => {
+                continue;
+            }
         };
         let o = match der_parser::parse_der(n) {
-            IResult::Done(_,x) => x,
-            _ => { continue; },
+            IResult::Done(_, x) => x,
+            _ => {
+                continue;
+            }
         };
         SCLogDebug!("o {:?}", o);
         match o.content {
@@ -123,27 +148,45 @@ fn parse_secblob_spnego(blob: &[u8]) -> Option<SpnegoRequest>
                         der_parser::DerObjectContent::OID(ref oid) => {
                             SCLogDebug!("OID {:?}", oid);
                             match oid.to_string().as_str() {
-                                "1.2.840.48018.1.2.2" => { SCLogDebug!("Microsoft Kerberos 5"); },
-                                "1.2.840.113554.1.2.2" => { SCLogDebug!("Kerberos 5"); have_kerberos = true; },
-                                "1.2.840.113554.1.2.2.1" => { SCLogDebug!("krb5-name"); },
-                                "1.2.840.113554.1.2.2.2" => { SCLogDebug!("krb5-principal"); },
-                                "1.2.840.113554.1.2.2.3" => { SCLogDebug!("krb5-user-to-user-mech"); },
-                                "1.3.6.1.4.1.311.2.2.10" => { SCLogDebug!("NTLMSSP"); have_ntlmssp = true; },
-                                "1.3.6.1.4.1.311.2.2.30" => { SCLogDebug!("NegoEx"); },
-                                _ => { SCLogDebug!("unexpected OID {:?}", oid); },
+                                "1.2.840.48018.1.2.2" => {
+                                    SCLogDebug!("Microsoft Kerberos 5");
+                                }
+                                "1.2.840.113554.1.2.2" => {
+                                    SCLogDebug!("Kerberos 5");
+                                    have_kerberos = true;
+                                }
+                                "1.2.840.113554.1.2.2.1" => {
+                                    SCLogDebug!("krb5-name");
+                                }
+                                "1.2.840.113554.1.2.2.2" => {
+                                    SCLogDebug!("krb5-principal");
+                                }
+                                "1.2.840.113554.1.2.2.3" => {
+                                    SCLogDebug!("krb5-user-to-user-mech");
+                                }
+                                "1.3.6.1.4.1.311.2.2.10" => {
+                                    SCLogDebug!("NTLMSSP");
+                                    have_ntlmssp = true;
+                                }
+                                "1.3.6.1.4.1.311.2.2.30" => {
+                                    SCLogDebug!("NegoEx");
+                                }
+                                _ => {
+                                    SCLogDebug!("unexpected OID {:?}", oid);
+                                }
                             }
-                        },
-                        _ => { SCLogDebug!("expected OID, got {:?}", se); },
+                        }
+                        _ => {
+                            SCLogDebug!("expected OID, got {:?}", se);
+                        }
                     }
                 }
-            },
+            }
             der_parser::DerObjectContent::OctetString(ref os) => {
                 if have_kerberos {
                     match parse_kerberos5_request(os) {
-                        IResult::Done(_, t) => {
-                            kticket = Some(t)
-                        },
-                        _ => { },
+                        IResult::Done(_, t) => kticket = Some(t),
+                        _ => {}
                     }
                 }
 
@@ -151,8 +194,8 @@ fn parse_secblob_spnego(blob: &[u8]) -> Option<SpnegoRequest>
                     SCLogDebug!("parsing expected NTLMSSP");
                     ntlmssp = parse_ntlmssp_blob(os);
                 }
-            },
-            _ => {},
+            }
+            _ => {}
         }
     }
 
@@ -163,7 +206,7 @@ fn parse_secblob_spnego(blob: &[u8]) -> Option<SpnegoRequest>
     Some(s)
 }
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct NtlmsspData {
     pub host: Vec<u8>,
     pub user: Vec<u8>,
@@ -172,82 +215,75 @@ pub struct NtlmsspData {
 }
 
 /// take in blob, search for the header and parse it
-fn parse_ntlmssp_blob(blob: &[u8]) -> Option<NtlmsspData>
-{
-    let mut ntlmssp_data : Option<NtlmsspData> = None;
+fn parse_ntlmssp_blob(blob: &[u8]) -> Option<NtlmsspData> {
+    let mut ntlmssp_data: Option<NtlmsspData> = None;
 
     SCLogDebug!("NTLMSSP {:?}", blob);
     match parse_ntlmssp(blob) {
         IResult::Done(_, nd) => {
-            SCLogDebug!("NTLMSSP TYPE {}/{} nd {:?}",
-                    nd.msg_type, &ntlmssp_type_string(nd.msg_type), nd);
+            SCLogDebug!(
+                "NTLMSSP TYPE {}/{} nd {:?}",
+                nd.msg_type,
+                &ntlmssp_type_string(nd.msg_type),
+                nd
+            );
             match nd.msg_type {
-                NTLMSSP_NEGOTIATE => {
-                },
-                NTLMSSP_AUTH => {
-                    match parse_ntlm_auth_record(nd.data) {
-                        IResult::Done(_, ad) => {
-                            SCLogDebug!("auth data {:?}", ad);
-                            let mut host = ad.host.to_vec();
-                            host.retain(|&i|i != 0x00);
-                            let mut user = ad.user.to_vec();
-                            user.retain(|&i|i != 0x00);
-                            let mut domain = ad.domain.to_vec();
-                            domain.retain(|&i|i != 0x00);
+                NTLMSSP_NEGOTIATE => {}
+                NTLMSSP_AUTH => match parse_ntlm_auth_record(nd.data) {
+                    IResult::Done(_, ad) => {
+                        SCLogDebug!("auth data {:?}", ad);
+                        let mut host = ad.host.to_vec();
+                        host.retain(|&i| i != 0x00);
+                        let mut user = ad.user.to_vec();
+                        user.retain(|&i| i != 0x00);
+                        let mut domain = ad.domain.to_vec();
+                        domain.retain(|&i| i != 0x00);
 
-                            let d = NtlmsspData {
-                                host: host,
-                                user: user,
-                                domain: domain,
-                                version: ad.version,
-                            };
-                            ntlmssp_data = Some(d);
-                        },
-                        _ => {},
+                        let d = NtlmsspData {
+                            host: host,
+                            user: user,
+                            domain: domain,
+                            version: ad.version,
+                        };
+                        ntlmssp_data = Some(d);
                     }
+                    _ => {}
                 },
-                _ => {},
+                _ => {}
             }
-        },
-        _ => {},
+        }
+        _ => {}
     }
     return ntlmssp_data;
 }
 
 // if spnego parsing fails try to fall back to ntlmssp
-pub fn parse_secblob(blob: &[u8]) -> Option<SpnegoRequest>
-{
+pub fn parse_secblob(blob: &[u8]) -> Option<SpnegoRequest> {
     match parse_secblob_get_spnego(blob) {
-        IResult::Done(_, spnego) => {
-            match parse_secblob_spnego_start(spnego) {
-                IResult::Done(_, spnego_start) => {
-                    parse_secblob_spnego(spnego_start)
-                },
-                _ => {
-                    match parse_ntlmssp_blob(blob) {
-                        Some(n) => {
-                            let s = SpnegoRequest {
-                                krb: None,
-                                ntlmssp: Some(n),
-                            };
-                            Some(s)
-                        },
-                        None => { None },
-                    }
-                },
+        IResult::Done(_, spnego) => match parse_secblob_spnego_start(spnego) {
+            IResult::Done(_, spnego_start) => {
+                parse_secblob_spnego(spnego_start)
             }
-        },
-        _ => {
-            match parse_ntlmssp_blob(blob) {
+            _ => match parse_ntlmssp_blob(blob) {
                 Some(n) => {
                     let s = SpnegoRequest {
                         krb: None,
-                         ntlmssp: Some(n),
+                        ntlmssp: Some(n),
                     };
                     Some(s)
-                },
-                None => { None },
+                }
+                None => None,
+            },
+        },
+        _ => match parse_ntlmssp_blob(blob) {
+            Some(n) => {
+                let s = SpnegoRequest {
+                    krb: None,
+                    ntlmssp: Some(n),
+                };
+                Some(s)
             }
+            None => None,
         },
     }
 }

--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -19,12 +19,12 @@
 extern crate libc;
 
 use nom::IResult;
-use log::*;
+use crate::log::*;
 
-use smb::smb::*;
-use smb::smb2::*;
-use smb::dcerpc_records::*;
-use smb::events::*;
+use crate::smb::smb::*;
+use crate::smb::smb2::*;
+use crate::smb::dcerpc_records::*;
+use crate::smb::events::*;
 
 pub const DCERPC_TYPE_REQUEST:              u8 = 0;
 pub const DCERPC_TYPE_PING:                 u8 = 1;

--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -18,61 +18,64 @@
 // written by Victor Julien
 extern crate libc;
 
-use nom::IResult;
 use crate::log::*;
+use nom::IResult;
 
-use crate::smb::smb::*;
-use crate::smb::smb2::*;
 use crate::smb::dcerpc_records::*;
 use crate::smb::events::*;
+use crate::smb::smb::*;
+use crate::smb::smb2::*;
 
-pub const DCERPC_TYPE_REQUEST:              u8 = 0;
-pub const DCERPC_TYPE_PING:                 u8 = 1;
-pub const DCERPC_TYPE_RESPONSE:             u8 = 2;
-pub const DCERPC_TYPE_FAULT:                u8 = 3;
-pub const DCERPC_TYPE_WORKING:              u8 = 4;
-pub const DCERPC_TYPE_NOCALL:               u8 = 5;
-pub const DCERPC_TYPE_REJECT:               u8 = 6;
-pub const DCERPC_TYPE_ACK:                  u8 = 7;
-pub const DCERPC_TYPE_CL_CANCEL:            u8 = 8;
-pub const DCERPC_TYPE_FACK:                 u8 = 9;
-pub const DCERPC_TYPE_CANCEL_ACK:           u8 = 10;
-pub const DCERPC_TYPE_BIND:                 u8 = 11;
-pub const DCERPC_TYPE_BINDACK:              u8 = 12;
-pub const DCERPC_TYPE_BINDNAK:              u8 = 13;
-pub const DCERPC_TYPE_ALTER_CONTEXT:        u8 = 14;
-pub const DCERPC_TYPE_ALTER_CONTEXT_RESP:   u8 = 15;
-pub const DCERPC_TYPE_AUTH3:                u8 = 16;
-pub const DCERPC_TYPE_SHUTDOWN:             u8 = 17;
-pub const DCERPC_TYPE_CO_CANCEL:            u8 = 18;
-pub const DCERPC_TYPE_ORPHANED:             u8 = 19;
-pub const DCERPC_TYPE_RTS:                  u8 = 20;
+pub const DCERPC_TYPE_REQUEST: u8 = 0;
+pub const DCERPC_TYPE_PING: u8 = 1;
+pub const DCERPC_TYPE_RESPONSE: u8 = 2;
+pub const DCERPC_TYPE_FAULT: u8 = 3;
+pub const DCERPC_TYPE_WORKING: u8 = 4;
+pub const DCERPC_TYPE_NOCALL: u8 = 5;
+pub const DCERPC_TYPE_REJECT: u8 = 6;
+pub const DCERPC_TYPE_ACK: u8 = 7;
+pub const DCERPC_TYPE_CL_CANCEL: u8 = 8;
+pub const DCERPC_TYPE_FACK: u8 = 9;
+pub const DCERPC_TYPE_CANCEL_ACK: u8 = 10;
+pub const DCERPC_TYPE_BIND: u8 = 11;
+pub const DCERPC_TYPE_BINDACK: u8 = 12;
+pub const DCERPC_TYPE_BINDNAK: u8 = 13;
+pub const DCERPC_TYPE_ALTER_CONTEXT: u8 = 14;
+pub const DCERPC_TYPE_ALTER_CONTEXT_RESP: u8 = 15;
+pub const DCERPC_TYPE_AUTH3: u8 = 16;
+pub const DCERPC_TYPE_SHUTDOWN: u8 = 17;
+pub const DCERPC_TYPE_CO_CANCEL: u8 = 18;
+pub const DCERPC_TYPE_ORPHANED: u8 = 19;
+pub const DCERPC_TYPE_RTS: u8 = 20;
 
 pub fn dcerpc_type_string(t: u8) -> String {
     match t {
-        DCERPC_TYPE_REQUEST             => "REQUEST",
-        DCERPC_TYPE_PING                => "PING",
-        DCERPC_TYPE_RESPONSE            => "RESPONSE",
-        DCERPC_TYPE_FAULT               => "FAULT",
-        DCERPC_TYPE_WORKING             => "WORKING",
-        DCERPC_TYPE_NOCALL              => "NOCALL",
-        DCERPC_TYPE_REJECT              => "REJECT",
-        DCERPC_TYPE_ACK                 => "ACK",
-        DCERPC_TYPE_CL_CANCEL           => "CL_CANCEL",
-        DCERPC_TYPE_FACK                => "FACK",
-        DCERPC_TYPE_CANCEL_ACK          => "CANCEL_ACK",
-        DCERPC_TYPE_BIND                => "BIND",
-        DCERPC_TYPE_BINDACK             => "BINDACK",
-        DCERPC_TYPE_BINDNAK             => "BINDNAK",
-        DCERPC_TYPE_ALTER_CONTEXT       => "ALTER_CONTEXT",
-        DCERPC_TYPE_ALTER_CONTEXT_RESP  => "ALTER_CONTEXT_RESP",
-        DCERPC_TYPE_AUTH3               => "AUTH3",
-        DCERPC_TYPE_SHUTDOWN            => "SHUTDOWN",
-        DCERPC_TYPE_CO_CANCEL           => "CO_CANCEL",
-        DCERPC_TYPE_ORPHANED            => "ORPHANED",
-        DCERPC_TYPE_RTS                 => "RTS",
-        _ => { return (t).to_string(); },
-    }.to_string()
+        DCERPC_TYPE_REQUEST => "REQUEST",
+        DCERPC_TYPE_PING => "PING",
+        DCERPC_TYPE_RESPONSE => "RESPONSE",
+        DCERPC_TYPE_FAULT => "FAULT",
+        DCERPC_TYPE_WORKING => "WORKING",
+        DCERPC_TYPE_NOCALL => "NOCALL",
+        DCERPC_TYPE_REJECT => "REJECT",
+        DCERPC_TYPE_ACK => "ACK",
+        DCERPC_TYPE_CL_CANCEL => "CL_CANCEL",
+        DCERPC_TYPE_FACK => "FACK",
+        DCERPC_TYPE_CANCEL_ACK => "CANCEL_ACK",
+        DCERPC_TYPE_BIND => "BIND",
+        DCERPC_TYPE_BINDACK => "BINDACK",
+        DCERPC_TYPE_BINDNAK => "BINDNAK",
+        DCERPC_TYPE_ALTER_CONTEXT => "ALTER_CONTEXT",
+        DCERPC_TYPE_ALTER_CONTEXT_RESP => "ALTER_CONTEXT_RESP",
+        DCERPC_TYPE_AUTH3 => "AUTH3",
+        DCERPC_TYPE_SHUTDOWN => "SHUTDOWN",
+        DCERPC_TYPE_CO_CANCEL => "CO_CANCEL",
+        DCERPC_TYPE_ORPHANED => "ORPHANED",
+        DCERPC_TYPE_RTS => "RTS",
+        _ => {
+            return (t).to_string();
+        }
+    }
+    .to_string()
 }
 
 impl SMBCommonHdr {
@@ -87,21 +90,21 @@ impl SMBCommonHdr {
             2 => {
                 let (_, cmd2) = vercmd.get_smb2_cmd();
                 let x = match cmd2 as u16 {
-                    SMB2_COMMAND_READ => { 0 },
-                    SMB2_COMMAND_WRITE => { 0 },
-                    SMB2_COMMAND_IOCTL => { self.msg_id },
-                    _ => { self.msg_id },
+                    SMB2_COMMAND_READ => 0,
+                    SMB2_COMMAND_WRITE => 0,
+                    SMB2_COMMAND_IOCTL => self.msg_id,
+                    _ => self.msg_id,
                 };
                 use_msg_id = x;
-            },
+            }
             1 => {
                 SCLogDebug!("FIXME TODO");
                 //let (_, cmd1) = vercmd.get_smb1_cmd();
                 //if cmd1 != SMB1_COMMAND_IOCTL {
                 use_msg_id = 0;
                 //}
-            },
-            _ => { },
+            }
+            _ => {}
         }
         SMBCommonHdr {
             ssn_id: self.ssn_id,
@@ -126,11 +129,11 @@ impl DCERPCIface {
     pub fn new(uuid: Vec<u8>, ver: u16, ver_min: u16) -> DCERPCIface {
         DCERPCIface {
             uuid: uuid,
-            ver:ver,
-            ver_min:ver_min,
-            ack_result:0,
-            ack_reason:0,
-            acked:false,
+            ver: ver,
+            ver_min: ver_min,
+            ack_result: 0,
+            ack_reason: 0,
+            acked: false,
         }
     }
 }
@@ -143,7 +146,6 @@ pub fn dcerpc_uuid_to_string(i: &DCERPCIface) -> String {
             i.uuid[12], i.uuid[13], i.uuid[14], i.uuid[15]);
     return output;
 }
-
 
 #[derive(Debug)]
 pub struct SMBTransactionDCERPC {
@@ -170,9 +172,9 @@ impl SMBTransactionDCERPC {
             call_id: call_id,
             frag_cnt_ts: 0,
             frag_cnt_tc: 0,
-            stub_data_ts:Vec::new(),
-            stub_data_tc:Vec::new(),
-        }
+            stub_data_ts: Vec::new(),
+            stub_data_tc: Vec::new(),
+        };
     }
     fn new_response(call_id: u32) -> SMBTransactionDCERPC {
         return SMBTransactionDCERPC {
@@ -184,9 +186,9 @@ impl SMBTransactionDCERPC {
             call_id: call_id,
             frag_cnt_ts: 0,
             frag_cnt_tc: 0,
-            stub_data_ts:Vec::new(),
-            stub_data_tc:Vec::new(),
-        }
+            stub_data_ts: Vec::new(),
+            stub_data_tc: Vec::new(),
+        };
     }
     pub fn set_result(&mut self, res: u8) {
         self.res_set = true;
@@ -195,14 +197,19 @@ impl SMBTransactionDCERPC {
 }
 
 impl SMBState {
-    fn new_dcerpc_tx(&mut self, hdr: SMBCommonHdr, vercmd: SMBVerCmdStat, cmd: u8, call_id: u32)
-        -> (&mut SMBTransaction)
-    {
+    fn new_dcerpc_tx(
+        &mut self,
+        hdr: SMBCommonHdr,
+        vercmd: SMBVerCmdStat,
+        cmd: u8,
+        call_id: u32,
+    ) -> (&mut SMBTransaction) {
         let mut tx = self.new_tx();
         tx.hdr = hdr;
         tx.vercmd = vercmd;
         tx.type_data = Some(SMBTransactionTypeData::DCERPC(
-                    SMBTransactionDCERPC::new_request(cmd, call_id)));
+            SMBTransactionDCERPC::new_request(cmd, call_id),
+        ));
 
         SCLogDebug!("SMB: TX DCERPC created: ID {} hdr {:?}", tx.id, tx.hdr);
         self.transactions.push(tx);
@@ -210,14 +217,18 @@ impl SMBState {
         return tx_ref.unwrap();
     }
 
-    fn new_dcerpc_tx_for_response(&mut self, hdr: SMBCommonHdr, vercmd: SMBVerCmdStat, call_id: u32)
-        -> (&mut SMBTransaction)
-    {
+    fn new_dcerpc_tx_for_response(
+        &mut self,
+        hdr: SMBCommonHdr,
+        vercmd: SMBVerCmdStat,
+        call_id: u32,
+    ) -> (&mut SMBTransaction) {
         let mut tx = self.new_tx();
         tx.hdr = hdr;
         tx.vercmd = vercmd;
         tx.type_data = Some(SMBTransactionTypeData::DCERPC(
-                    SMBTransactionDCERPC::new_response(call_id)));
+            SMBTransactionDCERPC::new_response(call_id),
+        ));
 
         SCLogDebug!("SMB: TX DCERPC created: ID {} hdr {:?}", tx.id, tx.hdr);
         self.transactions.push(tx);
@@ -225,20 +236,23 @@ impl SMBState {
         return tx_ref.unwrap();
     }
 
-    fn get_dcerpc_tx(&mut self, hdr: &SMBCommonHdr, vercmd: &SMBVerCmdStat, call_id: u32)
-        -> Option<&mut SMBTransaction>
-    {
+    fn get_dcerpc_tx(
+        &mut self,
+        hdr: &SMBCommonHdr,
+        vercmd: &SMBVerCmdStat,
+        call_id: u32,
+    ) -> Option<&mut SMBTransaction> {
         let dce_hdr = hdr.to_dcerpc(vercmd);
 
         SCLogDebug!("looking for {:?}", dce_hdr);
         for tx in &mut self.transactions {
-            let found = dce_hdr.compare(&tx.hdr.to_dcerpc(vercmd)) &&
-                match tx.type_data {
-                Some(SMBTransactionTypeData::DCERPC(ref x)) => {
-                    x.call_id == call_id
-                },
-                _ => { false },
-            };
+            let found = dce_hdr.compare(&tx.hdr.to_dcerpc(vercmd))
+                && match tx.type_data {
+                    Some(SMBTransactionTypeData::DCERPC(ref x)) => {
+                        x.call_id == call_id
+                    }
+                    _ => false,
+                };
             if found {
                 return Some(tx);
             }
@@ -250,34 +264,64 @@ impl SMBState {
 /// Handle DCERPC request data from a WRITE, IOCTL or TRANS record.
 /// return bool indicating whether an tx has been created/updated.
 ///
-pub fn smb_write_dcerpc_record<'b>(state: &mut SMBState,
-        vercmd: SMBVerCmdStat,
-        hdr: SMBCommonHdr,
-        data: &'b [u8]) -> bool
-{
-    let mut bind_ifaces : Option<Vec<DCERPCIface>> = None;
+pub fn smb_write_dcerpc_record<'b>(
+    state: &mut SMBState,
+    vercmd: SMBVerCmdStat,
+    hdr: SMBCommonHdr,
+    data: &'b [u8],
+) -> bool {
+    let mut bind_ifaces: Option<Vec<DCERPCIface>> = None;
 
     SCLogDebug!("called for {} bytes of data", data.len());
     match parse_dcerpc_record(data) {
         IResult::Done(_, dcer) => {
-            SCLogDebug!("DCERPC: version {}.{} write data {} => {:?}",
-                    dcer.version_major, dcer.version_minor, dcer.data.len(), dcer);
+            SCLogDebug!(
+                "DCERPC: version {}.{} write data {} => {:?}",
+                dcer.version_major,
+                dcer.version_minor,
+                dcer.data.len(),
+                dcer
+            );
 
             /* if this isn't the first frag, simply update the existing
              * tx with the additional stub data */
-            if dcer.packet_type == DCERPC_TYPE_REQUEST && dcer.first_frag == false {
+            if dcer.packet_type == DCERPC_TYPE_REQUEST
+                && dcer.first_frag == false
+            {
                 SCLogDebug!("NOT the first frag. Need to find an existing TX");
-                match parse_dcerpc_request_record(dcer.data, dcer.frag_len, dcer.little_endian) {
+                match parse_dcerpc_request_record(
+                    dcer.data,
+                    dcer.frag_len,
+                    dcer.little_endian,
+                ) {
                     IResult::Done(_, recr) => {
-                        let found = match state.get_dcerpc_tx(&hdr, &vercmd, dcer.call_id) {
+                        let found = match state.get_dcerpc_tx(
+                            &hdr,
+                            &vercmd,
+                            dcer.call_id,
+                        ) {
                             Some(tx) => {
-                                SCLogDebug!("previous CMD {} found at tx {} => {:?}",
-                                        dcer.packet_type, tx.id, tx);
-                                if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) = tx.type_data {
-                                    SCLogDebug!("additional frag of size {}", recr.data.len());
-                                    tdn.stub_data_ts.extend_from_slice(&recr.data);
+                                SCLogDebug!(
+                                    "previous CMD {} found at tx {} => {:?}",
+                                    dcer.packet_type,
+                                    tx.id,
+                                    tx
+                                );
+                                if let Some(SMBTransactionTypeData::DCERPC(
+                                    ref mut tdn,
+                                )) = tx.type_data
+                                {
+                                    SCLogDebug!(
+                                        "additional frag of size {}",
+                                        recr.data.len()
+                                    );
+                                    tdn.stub_data_ts
+                                        .extend_from_slice(&recr.data);
                                     tdn.frag_cnt_ts += 1;
-                                    SCLogDebug!("stub_data now {}", tdn.stub_data_ts.len());
+                                    SCLogDebug!(
+                                        "stub_data now {}",
+                                        tdn.stub_data_ts.len()
+                                    );
                                 }
                                 if dcer.last_frag {
                                     SCLogDebug!("last frag set, so request side of DCERPC closed");
@@ -286,46 +330,67 @@ pub fn smb_write_dcerpc_record<'b>(state: &mut SMBState,
                                     SCLogDebug!("NOT last frag, so request side of DCERPC remains open");
                                 }
                                 true
-                            },
+                            }
                             None => {
-                                SCLogDebug!("NO previous CMD {} found", dcer.packet_type);
+                                SCLogDebug!(
+                                    "NO previous CMD {} found",
+                                    dcer.packet_type
+                                );
                                 false
-                            },
+                            }
                         };
                         return found;
-                    },
+                    }
                     _ => {
                         state.set_event(SMBEvent::MalformedData);
                         return false;
-                    },
+                    }
                 }
             }
 
-            let tx = state.new_dcerpc_tx(hdr, vercmd, dcer.packet_type, dcer.call_id);
+            let tx = state.new_dcerpc_tx(
+                hdr,
+                vercmd,
+                dcer.packet_type,
+                dcer.call_id,
+            );
             match dcer.packet_type {
                 DCERPC_TYPE_REQUEST => {
-                    match parse_dcerpc_request_record(dcer.data, dcer.frag_len, dcer.little_endian) {
+                    match parse_dcerpc_request_record(
+                        dcer.data,
+                        dcer.frag_len,
+                        dcer.little_endian,
+                    ) {
                         IResult::Done(_, recr) => {
                             SCLogDebug!("DCERPC: REQUEST {:?}", recr);
-                            if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) = tx.type_data {
-                                SCLogDebug!("first frag size {}", recr.data.len());
+                            if let Some(SMBTransactionTypeData::DCERPC(
+                                ref mut tdn,
+                            )) = tx.type_data
+                            {
+                                SCLogDebug!(
+                                    "first frag size {}",
+                                    recr.data.len()
+                                );
                                 tdn.stub_data_ts.extend_from_slice(&recr.data);
                                 tdn.opnum = recr.opnum;
                                 tdn.frag_cnt_ts += 1;
-                                SCLogDebug!("DCERPC: REQUEST opnum {} stub data len {}",
-                                        tdn.opnum, tdn.stub_data_ts.len());
+                                SCLogDebug!(
+                                    "DCERPC: REQUEST opnum {} stub data len {}",
+                                    tdn.opnum,
+                                    tdn.stub_data_ts.len()
+                                );
                             }
                             if dcer.last_frag {
                                 tx.request_done = true;
                             } else {
                                 SCLogDebug!("NOT last frag, so request side of DCERPC remains open");
                             }
-                        },
+                        }
                         _ => {
                             tx.set_event(SMBEvent::MalformedData);
-                        },
+                        }
                     }
-                },
+                }
                 DCERPC_TYPE_BIND => {
                     let brec = if dcer.little_endian == true {
                         parse_dcerpc_bind_record(dcer.data)
@@ -334,43 +399,66 @@ pub fn smb_write_dcerpc_record<'b>(state: &mut SMBState,
                     };
                     match brec {
                         IResult::Done(_, bindr) => {
-                            SCLogDebug!("SMB DCERPC {:?} BIND {:?}", dcer, bindr);
+                            SCLogDebug!(
+                                "SMB DCERPC {:?} BIND {:?}",
+                                dcer,
+                                bindr
+                            );
 
                             if bindr.ifaces.len() > 0 {
                                 let mut ifaces: Vec<DCERPCIface> = Vec::new();
                                 for i in bindr.ifaces {
                                     let x = if dcer.little_endian == true {
-                                        vec![i.iface[3],  i.iface[2],  i.iface[1],  i.iface[0],
-                                             i.iface[5],  i.iface[4],  i.iface[7],  i.iface[6],
-                                             i.iface[8],  i.iface[9],  i.iface[10], i.iface[11],
-                                             i.iface[12], i.iface[13], i.iface[14], i.iface[15]]
+                                        vec![
+                                            i.iface[3],
+                                            i.iface[2],
+                                            i.iface[1],
+                                            i.iface[0],
+                                            i.iface[5],
+                                            i.iface[4],
+                                            i.iface[7],
+                                            i.iface[6],
+                                            i.iface[8],
+                                            i.iface[9],
+                                            i.iface[10],
+                                            i.iface[11],
+                                            i.iface[12],
+                                            i.iface[13],
+                                            i.iface[14],
+                                            i.iface[15],
+                                        ]
                                     } else {
                                         i.iface.to_vec()
                                     };
-                                    let d = DCERPCIface::new(x,i.ver,i.ver_min);
-                                    SCLogDebug!("UUID {} version {}/{} bytes {:?}",
-                                            dcerpc_uuid_to_string(&d),
-                                            i.ver, i.ver_min,i.iface);
+                                    let d =
+                                        DCERPCIface::new(x, i.ver, i.ver_min);
+                                    SCLogDebug!(
+                                        "UUID {} version {}/{} bytes {:?}",
+                                        dcerpc_uuid_to_string(&d),
+                                        i.ver,
+                                        i.ver_min,
+                                        i.iface
+                                    );
                                     ifaces.push(d);
                                 }
                                 bind_ifaces = Some(ifaces);
                             }
                             tx.request_done = true;
-                        },
+                        }
                         _ => {
                             tx.set_event(SMBEvent::MalformedData);
-                        },
+                        }
                     }
                 }
                 21...255 => {
                     tx.set_event(SMBEvent::MalformedData);
-                },
-                _ => { }, // valid type w/o special processing
+                }
+                _ => {} // valid type w/o special processing
             }
-        },
+        }
         _ => {
             state.set_event(SMBEvent::MalformedData);
-        },
+        }
     }
 
     state.dcerpc_ifaces = bind_ifaces; // TODO store per ssn
@@ -380,25 +468,27 @@ pub fn smb_write_dcerpc_record<'b>(state: &mut SMBState,
 /// Update TX for bind ack. Needs to update both tx and state.
 ///
 fn smb_dcerpc_response_bindack(
-        state: &mut SMBState,
-        vercmd: SMBVerCmdStat,
-        hdr: SMBCommonHdr,
-        dcer: &DceRpcRecord,
-        ntstatus: u32)
-{
+    state: &mut SMBState,
+    vercmd: SMBVerCmdStat,
+    hdr: SMBCommonHdr,
+    dcer: &DceRpcRecord,
+    ntstatus: u32,
+) {
     match parse_dcerpc_bindack_record(dcer.data) {
         IResult::Done(_, bindackr) => {
             SCLogDebug!("SMB READ BINDACK {:?}", bindackr);
 
             let found = match state.get_dcerpc_tx(&hdr, &vercmd, dcer.call_id) {
                 Some(tx) => {
-                    if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) = tx.type_data {
+                    if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) =
+                        tx.type_data
+                    {
                         tdn.set_result(DCERPC_TYPE_BINDACK);
                     }
                     tx.vercmd.set_ntstatus(ntstatus);
                     tx.response_done = true;
                     true
-                },
+                }
                 None => false,
             };
             if found {
@@ -414,21 +504,23 @@ fn smb_dcerpc_response_bindack(
                             ifaces[i].acked = true;
                             i = i + 1;
                         }
-                    },
-                    _ => {},
+                    }
+                    _ => {}
                 }
             }
-        },
+        }
         _ => {
             state.set_event(SMBEvent::MalformedData);
-        },
+        }
     }
 }
 
-fn smb_read_dcerpc_record_error(state: &mut SMBState,
-        hdr: SMBCommonHdr, vercmd: SMBVerCmdStat, ntstatus: u32)
-    -> bool
-{
+fn smb_read_dcerpc_record_error(
+    state: &mut SMBState,
+    hdr: SMBCommonHdr,
+    vercmd: SMBVerCmdStat,
+    ntstatus: u32,
+) -> bool {
     let ver = vercmd.get_version();
     let cmd = if ver == 2 {
         let (_, c) = vercmd.get_smb2_cmd();
@@ -444,26 +536,29 @@ fn smb_read_dcerpc_record_error(state: &mut SMBState,
             tx.set_status(ntstatus, false);
             tx.response_done = true;
             true
-        },
+        }
         None => {
             SCLogDebug!("NOT found");
             false
-        },
+        }
     };
     return found;
 }
 
-fn dcerpc_response_handle<'b>(tx: &mut SMBTransaction,
-        vercmd: SMBVerCmdStat,
-        dcer: &DceRpcRecord)
-{
+fn dcerpc_response_handle<'b>(
+    tx: &mut SMBTransaction,
+    vercmd: SMBVerCmdStat,
+    dcer: &DceRpcRecord,
+) {
     let (_, ntstatus) = vercmd.get_ntstatus();
     match dcer.packet_type {
         DCERPC_TYPE_RESPONSE => {
             match parse_dcerpc_response_record(dcer.data, dcer.frag_len) {
                 IResult::Done(_, respr) => {
                     SCLogDebug!("SMBv1 READ RESPONSE {:?}", respr);
-                    if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) = tx.type_data {
+                    if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) =
+                        tx.type_data
+                    {
                         SCLogDebug!("CMD 11 found at tx {}", tx.id);
                         tdn.set_result(DCERPC_TYPE_RESPONSE);
                         tdn.stub_data_tc.extend_from_slice(&respr.data);
@@ -471,51 +566,66 @@ fn dcerpc_response_handle<'b>(tx: &mut SMBTransaction,
                     }
                     tx.vercmd.set_ntstatus(ntstatus);
                     tx.response_done = dcer.last_frag;
-                },
+                }
                 _ => {
                     tx.set_event(SMBEvent::MalformedData);
-                },
+                }
             }
-        },
+        }
         DCERPC_TYPE_BINDACK => {
             // handled elsewhere
-        },
+        }
         21...255 => {
-            if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) = tx.type_data {
+            if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) =
+                tx.type_data
+            {
                 tdn.set_result(dcer.packet_type);
             }
             tx.vercmd.set_ntstatus(ntstatus);
             tx.response_done = true;
             tx.set_event(SMBEvent::MalformedData);
         }
-        _ => { // valid type w/o special processing
-            if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) = tx.type_data {
+        _ => {
+            // valid type w/o special processing
+            if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) =
+                tx.type_data
+            {
                 tdn.set_result(dcer.packet_type);
             }
             tx.vercmd.set_ntstatus(ntstatus);
             tx.response_done = true;
-        },
+        }
     }
 }
 
 /// Handle DCERPC reply record. Called for READ, TRANS, IOCTL
 ///
-pub fn smb_read_dcerpc_record<'b>(state: &mut SMBState,
-        vercmd: SMBVerCmdStat,
-        hdr: SMBCommonHdr,
-        guid: &[u8],
-        indata: &'b [u8]) -> bool
-{
+pub fn smb_read_dcerpc_record<'b>(
+    state: &mut SMBState,
+    vercmd: SMBVerCmdStat,
+    hdr: SMBCommonHdr,
+    guid: &[u8],
+    indata: &'b [u8],
+) -> bool {
     let (_, ntstatus) = vercmd.get_ntstatus();
 
-    if ntstatus != SMB_NTSTATUS_SUCCESS && ntstatus != SMB_NTSTATUS_BUFFER_OVERFLOW {
+    if ntstatus != SMB_NTSTATUS_SUCCESS
+        && ntstatus != SMB_NTSTATUS_BUFFER_OVERFLOW
+    {
         return smb_read_dcerpc_record_error(state, hdr, vercmd, ntstatus);
     }
 
     SCLogDebug!("lets first see if we have prior data");
     // msg_id 0 as this data crosses cmd/reply pairs
-    let ehdr = SMBHashKeyHdrGuid::new(SMBCommonHdr::new(SMBHDR_TYPE_TRANS_FRAG,
-            hdr.ssn_id as u64, hdr.tree_id as u32, 0 as u64), guid.to_vec());
+    let ehdr = SMBHashKeyHdrGuid::new(
+        SMBCommonHdr::new(
+            SMBHDR_TYPE_TRANS_FRAG,
+            hdr.ssn_id as u64,
+            hdr.tree_id as u32,
+            0 as u64,
+        ),
+        guid.to_vec(),
+    );
     let mut prevdata = match state.ssnguid2vec_map.remove(&ehdr) {
         Some(s) => s,
         None => Vec::new(),
@@ -528,46 +638,62 @@ pub fn smb_read_dcerpc_record<'b>(state: &mut SMBState,
 
     if data.len() == 0 {
         SCLogDebug!("weird: no DCERPC data"); // TODO
-        // TODO set event?
+                                              // TODO set event?
         return false;
-
     } else {
         match parse_dcerpc_record(&data) {
             IResult::Done(_, dcer) => {
-                SCLogDebug!("DCERPC: version {}.{} read data {} => {:?}",
-                        dcer.version_major, dcer.version_minor, dcer.data.len(), dcer);
+                SCLogDebug!(
+                    "DCERPC: version {}.{} read data {} => {:?}",
+                    dcer.version_major,
+                    dcer.version_minor,
+                    dcer.data.len(),
+                    dcer
+                );
 
-                if ntstatus == SMB_NTSTATUS_BUFFER_OVERFLOW && data.len() < dcer.frag_len as usize {
-                    SCLogDebug!("short record {} < {}: storing partial data in state",
-                            data.len(), dcer.frag_len);
+                if ntstatus == SMB_NTSTATUS_BUFFER_OVERFLOW
+                    && data.len() < dcer.frag_len as usize
+                {
+                    SCLogDebug!(
+                        "short record {} < {}: storing partial data in state",
+                        data.len(),
+                        dcer.frag_len
+                    );
                     state.ssnguid2vec_map.insert(ehdr, data.to_vec());
                     return true; // TODO review
                 }
 
                 if dcer.packet_type == DCERPC_TYPE_BINDACK {
-                    smb_dcerpc_response_bindack(state, vercmd, hdr, &dcer, ntstatus);
+                    smb_dcerpc_response_bindack(
+                        state, vercmd, hdr, &dcer, ntstatus,
+                    );
                     return true;
                 }
 
-                let found = match state.get_dcerpc_tx(&hdr, &vercmd, dcer.call_id) {
-                    Some(tx) => {
-                        dcerpc_response_handle(tx, vercmd.clone(), &dcer);
-                        true
-                    },
-                    None => {
-                        SCLogDebug!("no tx");
-                        false
-                    },
-                };
+                let found =
+                    match state.get_dcerpc_tx(&hdr, &vercmd, dcer.call_id) {
+                        Some(tx) => {
+                            dcerpc_response_handle(tx, vercmd.clone(), &dcer);
+                            true
+                        }
+                        None => {
+                            SCLogDebug!("no tx");
+                            false
+                        }
+                    };
                 if !found {
                     // pick up DCERPC tx even if we missed the request
-                    let tx = state.new_dcerpc_tx_for_response(hdr, vercmd.clone(), dcer.call_id);
+                    let tx = state.new_dcerpc_tx_for_response(
+                        hdr,
+                        vercmd.clone(),
+                        dcer.call_id,
+                    );
                     dcerpc_response_handle(tx, vercmd, &dcer);
                 }
-            },
+            }
             _ => {
                 malformed = true;
-            },
+            }
         }
     }
 
@@ -579,19 +705,20 @@ pub fn smb_read_dcerpc_record<'b>(state: &mut SMBState,
 }
 
 /// Try to find out if the input data looks like DCERPC
-pub fn smb_dcerpc_probe<'b>(data: &[u8]) -> bool
-{
+pub fn smb_dcerpc_probe<'b>(data: &[u8]) -> bool {
     match parse_dcerpc_record(data) {
         IResult::Done(_, recr) => {
             SCLogDebug!("SMB: could be DCERPC {:?}", recr);
-            if recr.version_major == 5 && recr.version_minor < 3 &&
-               recr.frag_len > 0 && recr.packet_type <= 20
+            if recr.version_major == 5
+                && recr.version_minor < 3
+                && recr.frag_len > 0
+                && recr.packet_type <= 20
             {
                 SCLogDebug!("SMB: looks like we have dcerpc");
                 return true;
             }
-        },
-        _ => { },
+        }
+        _ => {}
     }
     return false;
 }

--- a/rust/src/smb/dcerpc_records.rs
+++ b/rust/src/smb/dcerpc_records.rs
@@ -15,59 +15,68 @@
  * 02110-1301, USA.
  */
 
-use nom::{rest, le_u8, be_u16, le_u16, le_u32, IResult, ErrorKind, Endianness};
+use nom::{
+    be_u16, le_u16, le_u32, le_u8, rest, Endianness, ErrorKind, IResult,
+};
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct DceRpcResponseRecord<'a> {
-    pub data: &'a[u8],
+    pub data: &'a [u8],
 }
 
 /// parse a packet type 'response' DCERPC record. Implemented
 /// as function to be able to pass the fraglen in.
-pub fn parse_dcerpc_response_record(i:&[u8], frag_len: u16 )
-    -> IResult<&[u8], DceRpcResponseRecord>
-{
+pub fn parse_dcerpc_response_record(
+    i: &[u8],
+    frag_len: u16,
+) -> IResult<&[u8], DceRpcResponseRecord> {
     if frag_len < 24 {
         return IResult::Error(error_code!(ErrorKind::Custom(128)));
     }
-    do_parse!(i,
-                take!(8)
-            >>  data:take!(frag_len - 24)
-            >> (DceRpcResponseRecord {
-                    data:data,
-               })
+    do_parse!(
+        i,
+        take!(8)
+            >> data: take!(frag_len - 24)
+            >> (DceRpcResponseRecord { data: data })
     )
 }
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct DceRpcRequestRecord<'a> {
     pub opnum: u16,
-    pub data: &'a[u8],
+    pub data: &'a [u8],
 }
 
 /// parse a packet type 'request' DCERPC record. Implemented
 /// as function to be able to pass the fraglen in.
-pub fn parse_dcerpc_request_record(i:&[u8], frag_len: u16, little: bool)
-    -> IResult<&[u8], DceRpcRequestRecord>
-{
+pub fn parse_dcerpc_request_record(
+    i: &[u8],
+    frag_len: u16,
+    little: bool,
+) -> IResult<&[u8], DceRpcRequestRecord> {
     if frag_len < 24 {
         return IResult::Error(error_code!(ErrorKind::Custom(128)));
     }
-    do_parse!(i,
-                take!(6)
-            >>  endian: value!(if little { Endianness::Little } else { Endianness::Big })
-            >>  opnum: u16!(endian)
-            >>  data:take!(frag_len - 24)
+    do_parse!(
+        i,
+        take!(6)
+            >> endian: value!(if little {
+                Endianness::Little
+            } else {
+                Endianness::Big
+            })
+            >> opnum: u16!(endian)
+            >> data: take!(frag_len - 24)
             >> (DceRpcRequestRecord {
-                    opnum:opnum,
-                    data:data,
-               })
+                opnum: opnum,
+                data: data,
+            })
     )
 }
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct DceRpcBindIface<'a> {
-    pub iface: &'a[u8],
+    pub iface: &'a [u8],
     pub ver: u16,
     pub ver_min: u16,
 }
@@ -104,7 +113,7 @@ named!(pub parse_dcerpc_bind_iface_big<DceRpcBindIface>,
             })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct DceRpcBindRecord<'a> {
     pub num_ctx_items: u8,
     pub ifaces: Vec<DceRpcBindIface<'a>>,
@@ -138,11 +147,11 @@ named!(pub parse_dcerpc_bind_record_big<DceRpcBindRecord>,
            })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct DceRpcBindAckResult<'a> {
     pub ack_result: u16,
     pub ack_reason: u16,
-    pub transfer_syntax: &'a[u8],
+    pub transfer_syntax: &'a [u8],
     pub syntax_version: u32,
 }
 
@@ -160,7 +169,7 @@ named!(pub parse_dcerpc_bindack_result<DceRpcBindAckResult>,
             })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct DceRpcBindAckRecord<'a> {
     pub num_results: u8,
     pub results: Vec<DceRpcBindAckResult<'a>>,
@@ -183,7 +192,7 @@ named!(pub parse_dcerpc_bindack_record<DceRpcBindAckRecord>,
            })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct DceRpcRecord<'a> {
     pub version_major: u8,
     pub version_minor: u8,
@@ -198,7 +207,7 @@ pub struct DceRpcRecord<'a> {
     pub packet_type: u8,
 
     pub call_id: u32,
-    pub data: &'a[u8],
+    pub data: &'a [u8],
 }
 
 named!(pub parse_dcerpc_record<DceRpcRecord>,

--- a/rust/src/smb/debug.rs
+++ b/rust/src/smb/debug.rs
@@ -22,7 +22,7 @@ use log::*;
 
 impl SMBState {
     #[cfg(not(feature = "debug"))]
-    pub fn _debug_tx_stats(&self) { }
+    pub fn _debug_tx_stats(&self) {}
 
     #[cfg(feature = "debug")]
     pub fn _debug_tx_stats(&self) {
@@ -30,7 +30,12 @@ impl SMBState {
             let txf = self.transactions.first().unwrap();
             let txl = self.transactions.last().unwrap();
 
-            SCLogDebug!("TXs {} MIN {} MAX {}", self.transactions.len(), txf.id, txl.id);
+            SCLogDebug!(
+                "TXs {} MIN {} MAX {}",
+                self.transactions.len(),
+                txf.id,
+                txl.id
+            );
             SCLogDebug!("- OLD tx.id {}: {:?}", txf.id, txf);
             SCLogDebug!("- NEW tx.id {}: {:?}", txl.id, txl);
             self._dump_txs();
@@ -38,7 +43,7 @@ impl SMBState {
     }
 
     #[cfg(not(feature = "debug"))]
-    pub fn _dump_txs(&self) { }
+    pub fn _dump_txs(&self) {}
     #[cfg(feature = "debug")]
     pub fn _dump_txs(&self) {
         let len = self.transactions.len();
@@ -59,17 +64,17 @@ impl SMBState {
                     SCLogDebug!("idx {} tx id {} progress {}/{} filename {} type_data {:?}",
                             i, tx.id, tx.request_done, tx.response_done,
                             String::from_utf8_lossy(&d.file_name), tx.type_data);
-                },
+                }
                 _ => {
                     SCLogDebug!("idx {} tx id {} ver:{} cmd:{} progress {}/{} type_data {:?} tx {:?}",
                             i, tx.id, ver, _smbcmd, tx.request_done, tx.response_done, tx.type_data, tx);
-                },
+                }
             }
         }
     }
 
     #[cfg(not(feature = "debug"))]
-    pub fn _debug_state_stats(&self) { }
+    pub fn _debug_state_stats(&self) {}
 
     #[cfg(feature = "debug")]
     pub fn _debug_state_stats(&self) {

--- a/rust/src/smb/debug.rs
+++ b/rust/src/smb/debug.rs
@@ -15,7 +15,7 @@
  * 02110-1301, USA.
  */
 
-use smb::smb::*;
+use crate::smb::smb::*;
 
 #[cfg(feature = "debug")]
 use log::*;

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -17,18 +17,18 @@
 
 extern crate libc;
 
-use std;
-use std::ptr;
 use crate::core::*;
 use crate::log::*;
 use crate::smb::smb::*;
+use std;
+use std::ptr;
 
 #[no_mangle]
-pub extern "C" fn rs_smb_tx_get_share(tx: &mut SMBTransaction,
-                                            buffer: *mut *const libc::uint8_t,
-                                            buffer_len: *mut libc::uint32_t)
-                                            -> libc::uint8_t
-{
+pub extern "C" fn rs_smb_tx_get_share(
+    tx: &mut SMBTransaction,
+    buffer: *mut *const libc::uint8_t,
+    buffer_len: *mut libc::uint32_t,
+) -> libc::uint8_t {
     match tx.type_data {
         Some(SMBTransactionTypeData::TREECONNECT(ref x)) => {
             SCLogDebug!("is_pipe {}", x.is_pipe);
@@ -40,8 +40,7 @@ pub extern "C" fn rs_smb_tx_get_share(tx: &mut SMBTransaction,
                 }
             }
         }
-        _ => {
-        }
+        _ => {}
     }
 
     unsafe {
@@ -52,11 +51,11 @@ pub extern "C" fn rs_smb_tx_get_share(tx: &mut SMBTransaction,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_tx_get_named_pipe(tx: &mut SMBTransaction,
-                                            buffer: *mut *const libc::uint8_t,
-                                            buffer_len: *mut libc::uint32_t)
-                                            -> libc::uint8_t
-{
+pub extern "C" fn rs_smb_tx_get_named_pipe(
+    tx: &mut SMBTransaction,
+    buffer: *mut *const libc::uint8_t,
+    buffer_len: *mut libc::uint32_t,
+) -> libc::uint8_t {
     match tx.type_data {
         Some(SMBTransactionTypeData::TREECONNECT(ref x)) => {
             SCLogDebug!("is_pipe {}", x.is_pipe);
@@ -68,8 +67,7 @@ pub extern "C" fn rs_smb_tx_get_named_pipe(tx: &mut SMBTransaction,
                 }
             }
         }
-        _ => {
-        }
+        _ => {}
     }
 
     unsafe {
@@ -80,12 +78,12 @@ pub extern "C" fn rs_smb_tx_get_named_pipe(tx: &mut SMBTransaction,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_tx_get_stub_data(tx: &mut SMBTransaction,
-                                            direction: u8,
-                                            buffer: *mut *const libc::uint8_t,
-                                            buffer_len: *mut libc::uint32_t)
-                                            -> libc::uint8_t
-{
+pub extern "C" fn rs_smb_tx_get_stub_data(
+    tx: &mut SMBTransaction,
+    direction: u8,
+    buffer: *mut *const libc::uint8_t,
+    buffer_len: *mut libc::uint32_t,
+) -> libc::uint8_t {
     match tx.type_data {
         Some(SMBTransactionTypeData::DCERPC(ref x)) => {
             let vref = if direction == STREAM_TOSERVER {
@@ -101,8 +99,7 @@ pub extern "C" fn rs_smb_tx_get_stub_data(tx: &mut SMBTransaction,
                 }
             }
         }
-        _ => {
-        }
+        _ => {}
     }
 
     unsafe {
@@ -113,22 +110,22 @@ pub extern "C" fn rs_smb_tx_get_stub_data(tx: &mut SMBTransaction,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_tx_get_dce_opnum(tx: &mut SMBTransaction,
-                                            opnum: *mut libc::uint16_t)
-                                            -> libc::uint8_t
-{
+pub extern "C" fn rs_smb_tx_get_dce_opnum(
+    tx: &mut SMBTransaction,
+    opnum: *mut libc::uint16_t,
+) -> libc::uint8_t {
     SCLogDebug!("rs_smb_tx_get_dce_opnum: start");
     match tx.type_data {
         Some(SMBTransactionTypeData::DCERPC(ref x)) => {
-            if x.req_cmd == 1 { // REQUEST
+            if x.req_cmd == 1 {
+                // REQUEST
                 unsafe {
                     *opnum = x.opnum as libc::uint16_t;
                     return 1;
                 }
             }
         }
-        _ => {
-        }
+        _ => {}
     }
 
     unsafe {
@@ -149,24 +146,29 @@ pub extern "C" fn rs_smb_tx_get_dce_opnum(tx: &mut SMBTransaction,
 #[inline]
 fn match_version(op: u8, them: u16, us: u16) -> bool {
     let result = match op {
-        0 => { // NONE
+        0 => {
+            // NONE
             true
-        },
-        1 => { // LT
+        }
+        1 => {
+            // LT
             (them < us)
-        },
-        2 => { // GT
+        }
+        2 => {
+            // GT
             (them > us)
-        },
-        3 => { // EQ
+        }
+        3 => {
+            // EQ
             (them == us)
-        },
-        4 => { // NE
+        }
+        4 => {
+            // NE
             (them != us)
-        },
+        }
         _ => {
             panic!("called with invalid op {}", op);
-        },
+        }
     };
     result
 }
@@ -176,17 +178,17 @@ fn match_version(op: u8, them: u16, us: u16) -> bool {
  *                     dce_opnum and dce_stub_data)
  * - only match on approved ifaces (so ack_result == 0) */
 #[no_mangle]
-pub extern "C" fn rs_smb_tx_get_dce_iface(state: &mut SMBState,
-                                            tx: &mut SMBTransaction,
-                                            uuid_ptr: *mut libc::uint8_t,
-                                            uuid_len: libc::uint16_t,
-                                            ver_op: libc::uint8_t,
-                                            ver_check: libc::uint16_t)
-                                            -> libc::uint8_t
-{
+pub extern "C" fn rs_smb_tx_get_dce_iface(
+    state: &mut SMBState,
+    tx: &mut SMBTransaction,
+    uuid_ptr: *mut libc::uint8_t,
+    uuid_len: libc::uint16_t,
+    ver_op: libc::uint8_t,
+    ver_check: libc::uint16_t,
+) -> libc::uint8_t {
     let is_dcerpc_request = match tx.type_data {
-        Some(SMBTransactionTypeData::DCERPC(ref x)) => { x.req_cmd == 1 },
-        _ => { false },
+        Some(SMBTransactionTypeData::DCERPC(ref x)) => x.req_cmd == 1,
+        _ => false,
     };
     if !is_dcerpc_request {
         return 0;
@@ -195,14 +197,20 @@ pub extern "C" fn rs_smb_tx_get_dce_iface(state: &mut SMBState,
         Some(ref x) => x,
         _ => {
             return 0;
-        },
+        }
     };
 
-    let uuid = unsafe{std::slice::from_raw_parts(uuid_ptr, uuid_len as usize)};
+    let uuid =
+        unsafe { std::slice::from_raw_parts(uuid_ptr, uuid_len as usize) };
     SCLogDebug!("looking for UUID {:?}", uuid);
 
     for i in ifaces {
-        SCLogDebug!("stored UUID {:?} acked {} ack_result {}", i, i.acked, i.ack_result);
+        SCLogDebug!(
+            "stored UUID {:?} acked {} ack_result {}",
+            i,
+            i.acked,
+            i.ack_result
+        );
 
         if i.acked && i.ack_result == 0 && i.uuid == uuid {
             if match_version(ver_op as u8, ver_check as u16, i.ver) {

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -19,9 +19,9 @@ extern crate libc;
 
 use std;
 use std::ptr;
-use core::*;
-use log::*;
-use smb::smb::*;
+use crate::core::*;
+use crate::log::*;
+use crate::smb::smb::*;
 
 #[no_mangle]
 pub extern "C" fn rs_smb_tx_get_share(tx: &mut SMBTransaction,

--- a/rust/src/smb/events.rs
+++ b/rust/src/smb/events.rs
@@ -15,9 +15,9 @@
  * 02110-1301, USA.
  */
 
-use core::*;
-use log::*;
-use smb::smb::*;
+use crate::core::*;
+use crate::log::*;
+use crate::smb::smb::*;
 
 #[repr(u32)]
 pub enum SMBEvent {

--- a/rust/src/smb/events.rs
+++ b/rust/src/smb/events.rs
@@ -33,13 +33,17 @@ pub enum SMBEvent {
 pub fn smb_str_to_event(instr: &str) -> i32 {
     SCLogDebug!("checking {}", instr);
     match instr {
-        "internal_error"                => SMBEvent::InternalError as i32,
-        "malformed_data"                => SMBEvent::MalformedData as i32,
-        "record_overflow"               => SMBEvent::RecordOverflow as i32,
-        "malformed_ntlmssp_request"     => SMBEvent::MalformedNtlmsspRequest as i32,
-        "malformed_ntlmssp_response"    => SMBEvent::MalformedNtlmsspResponse as i32,
-        "duplicate_negotiate"           => SMBEvent::DuplicateNegotiate as i32,
-        "negotiate_malformed_dialects"  => SMBEvent::NegotiateMalformedDialects as i32,
+        "internal_error" => SMBEvent::InternalError as i32,
+        "malformed_data" => SMBEvent::MalformedData as i32,
+        "record_overflow" => SMBEvent::RecordOverflow as i32,
+        "malformed_ntlmssp_request" => SMBEvent::MalformedNtlmsspRequest as i32,
+        "malformed_ntlmssp_response" => {
+            SMBEvent::MalformedNtlmsspResponse as i32
+        }
+        "duplicate_negotiate" => SMBEvent::DuplicateNegotiate as i32,
+        "negotiate_malformed_dialects" => {
+            SMBEvent::NegotiateMalformedDialects as i32
+        }
         _ => -1,
     }
 }
@@ -53,7 +57,10 @@ impl SMBTransaction {
     /// Set events from vector of events.
     pub fn set_events(&mut self, events: Vec<SMBEvent>) {
         for e in events {
-            sc_app_layer_decoder_events_set_event_raw(&mut self.events, e as u8);
+            sc_app_layer_decoder_events_set_event_raw(
+                &mut self.events,
+                e as u8,
+            );
         }
     }
 }

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -16,9 +16,9 @@
  */
 
 use crate::core::*;
-use crate::log::*;
-use crate::filetracker::*;
 use crate::filecontainer::*;
+use crate::filetracker::*;
+use crate::log::*;
 
 use crate::smb::smb::*;
 
@@ -40,7 +40,7 @@ impl SMBTransactionFile {
             file_name: Vec::new(),
             share_name: Vec::new(),
             file_tracker: FileTransferTracker::new(),
-        }
+        };
     }
 }
 
@@ -56,10 +56,10 @@ pub struct SMBFiles {
 impl SMBFiles {
     pub fn new() -> SMBFiles {
         SMBFiles {
-            files_ts:FileContainer::default(),
-            files_tc:FileContainer::default(),
-            flags_ts:0,
-            flags_tc:0,
+            files_ts: FileContainer::default(),
+            files_tc: FileContainer::default(),
+            flags_ts: 0,
+            flags_tc: 0,
         }
     }
     pub fn free(&mut self) {
@@ -67,8 +67,7 @@ impl SMBFiles {
         self.files_tc.free();
     }
 
-    pub fn get(&mut self, direction: u8) -> (&mut FileContainer, u16)
-    {
+    pub fn get(&mut self, direction: u8) -> (&mut FileContainer, u16) {
         if direction == STREAM_TOSERVER {
             (&mut self.files_ts, self.flags_ts)
         } else {
@@ -78,51 +77,79 @@ impl SMBFiles {
 }
 
 /// little wrapper around the FileTransferTracker::new_chunk method
-pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContainer,
-        flags: u16, name: &Vec<u8>, data: &[u8],
-        chunk_offset: u64, chunk_size: u32, fill_bytes: u8, is_last: bool, xid: &u32)
-{
-    match unsafe {SURICATA_SMB_FILE_CONFIG} {
+pub fn filetracker_newchunk(
+    ft: &mut FileTransferTracker,
+    files: &mut FileContainer,
+    flags: u16,
+    name: &Vec<u8>,
+    data: &[u8],
+    chunk_offset: u64,
+    chunk_size: u32,
+    fill_bytes: u8,
+    is_last: bool,
+    xid: &u32,
+) {
+    match unsafe { SURICATA_SMB_FILE_CONFIG } {
         Some(sfcm) => {
-            ft.new_chunk(sfcm, files, flags, &name, data, chunk_offset,
-                    chunk_size, fill_bytes, is_last, xid); }
+            ft.new_chunk(
+                sfcm,
+                files,
+                flags,
+                &name,
+                data,
+                chunk_offset,
+                chunk_size,
+                fill_bytes,
+                is_last,
+                xid,
+            );
+        }
         None => panic!("BUG"),
     }
 }
 
 impl SMBState {
-    pub fn new_file_tx(&mut self, fuid: &Vec<u8>, file_name: &Vec<u8>, direction: u8)
-        -> (&mut SMBTransaction, &mut FileContainer, u16)
-    {
+    pub fn new_file_tx(
+        &mut self,
+        fuid: &Vec<u8>,
+        file_name: &Vec<u8>,
+        direction: u8,
+    ) -> (&mut SMBTransaction, &mut FileContainer, u16) {
         let mut tx = self.new_tx();
-        tx.type_data = Some(SMBTransactionTypeData::FILE(SMBTransactionFile::new()));
+        tx.type_data =
+            Some(SMBTransactionTypeData::FILE(SMBTransactionFile::new()));
         match tx.type_data {
             Some(SMBTransactionTypeData::FILE(ref mut d)) => {
                 d.direction = direction;
                 d.fuid = fuid.to_vec();
                 d.file_name = file_name.to_vec();
                 d.file_tracker.tx_id = tx.id - 1;
-            },
-            _ => { },
+            }
+            _ => {}
         }
-        SCLogDebug!("SMB: new_file_tx: TX FILE created: ID {} NAME {}",
-                tx.id, String::from_utf8_lossy(file_name));
+        SCLogDebug!(
+            "SMB: new_file_tx: TX FILE created: ID {} NAME {}",
+            tx.id,
+            String::from_utf8_lossy(file_name)
+        );
         self.transactions.push(tx);
         let tx_ref = self.transactions.last_mut();
         let (files, flags) = self.files.get(direction);
-        return (tx_ref.unwrap(), files, flags)
+        return (tx_ref.unwrap(), files, flags);
     }
 
-    pub fn get_file_tx_by_fuid(&mut self, fuid: &Vec<u8>, direction: u8)
-        -> Option<(&mut SMBTransaction, &mut FileContainer, u16)>
-    {
+    pub fn get_file_tx_by_fuid(
+        &mut self,
+        fuid: &Vec<u8>,
+        direction: u8,
+    ) -> Option<(&mut SMBTransaction, &mut FileContainer, u16)> {
         let f = fuid.to_vec();
         for tx in &mut self.transactions {
             let found = match tx.type_data {
                 Some(SMBTransactionTypeData::FILE(ref mut d)) => {
                     direction == d.direction && f == d.fuid
-                },
-                _ => { false },
+                }
+                _ => false,
             };
 
             if found {
@@ -135,7 +162,7 @@ impl SMBState {
         return None;
     }
 
-    fn getfiles(&mut self, direction: u8) -> * mut FileContainer {
+    fn getfiles(&mut self, direction: u8) -> *mut FileContainer {
         //SCLogDebug!("direction: {}", direction);
         if direction == STREAM_TOCLIENT {
             &mut self.files.files_tc as *mut FileContainer
@@ -154,14 +181,19 @@ impl SMBState {
 
     // update in progress chunks for file transfers
     // return how much data we consumed
-    pub fn filetracker_update(&mut self, direction: u8, data: &[u8], gap_size: u32) -> u32 {
+    pub fn filetracker_update(
+        &mut self,
+        direction: u8,
+        data: &[u8],
+        gap_size: u32,
+    ) -> u32 {
         let mut chunk_left = if direction == STREAM_TOSERVER {
             self.file_ts_left
         } else {
             self.file_tc_left
         };
         if chunk_left == 0 {
-            return 0
+            return 0;
         }
         SCLogDebug!("chunk_left {} data {}", chunk_left, data.len());
         let file_handle = if direction == STREAM_TOSERVER {
@@ -192,25 +224,31 @@ impl SMBState {
         // get the tx and update it
         let consumed = match self.get_file_tx_by_fuid(&file_handle, direction) {
             Some((tx, files, flags)) => {
-                if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
+                if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) =
+                    tx.type_data
+                {
                     if ssn_gap {
                         let queued_data = tdf.file_tracker.get_queued_size();
-                        if queued_data > 2000000 { // TODO should probably be configurable
+                        if queued_data > 2000000 {
+                            // TODO should probably be configurable
                             SCLogDebug!("QUEUED size {} while we've seen GAPs. Truncating file.", queued_data);
                             tdf.file_tracker.trunc(files, flags);
                         }
                     }
 
                     let file_data = &data[0..data_to_handle_len];
-                    let cs = tdf.file_tracker.update(files, flags, file_data, gap_size);
+                    let cs = tdf
+                        .file_tracker
+                        .update(files, flags, file_data, gap_size);
                     cs
                 } else {
                     0
                 }
-            },
+            }
             None => {
                 SCLogDebug!("not found for handle {:?}", file_handle);
-                0 },
+                0
+            }
         };
 
         return consumed;
@@ -218,15 +256,26 @@ impl SMBState {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_getfiles(direction: u8, ptr: *mut SMBState) -> * mut FileContainer {
-    if ptr.is_null() { panic!("NULL ptr"); };
+pub extern "C" fn rs_smb_getfiles(
+    direction: u8,
+    ptr: *mut SMBState,
+) -> *mut FileContainer {
+    if ptr.is_null() {
+        panic!("NULL ptr");
+    };
     let parser = unsafe { &mut *ptr };
     parser.getfiles(direction)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_setfileflags(direction: u8, ptr: *mut SMBState, flags: u16) {
-    if ptr.is_null() { panic!("NULL ptr"); };
+pub extern "C" fn rs_smb_setfileflags(
+    direction: u8,
+    ptr: *mut SMBState,
+    flags: u16,
+) {
+    if ptr.is_null() {
+        panic!("NULL ptr");
+    };
     let parser = unsafe { &mut *ptr };
     SCLogDebug!("direction {} flags {}", direction, flags);
     parser.setfileflags(direction, flags)

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -15,12 +15,12 @@
  * 02110-1301, USA.
  */
 
-use core::*;
-use log::*;
-use filetracker::*;
-use filecontainer::*;
+use crate::core::*;
+use crate::log::*;
+use crate::filetracker::*;
+use crate::filecontainer::*;
 
-use smb::smb::*;
+use crate::smb::smb::*;
 
 /// File tracking transaction. Single direction only.
 #[derive(Debug)]

--- a/rust/src/smb/funcs.rs
+++ b/rust/src/smb/funcs.rs
@@ -23,7 +23,7 @@ pub fn fsctl_func_to_string(f: u32) -> String {
         0x00060194 => "FSCTL_DFS_GET_REFERRALS",
         0x000601B0 => "FSCTL_DFS_GET_REFERRALS_EX",
         0x00090000 => "FSCTL_REQUEST_OPLOCK_LEVEL_1",
-        0x00090004 => "FSCTL_REQUEST_OPLOCK_LEVEL_2", 
+        0x00090004 => "FSCTL_REQUEST_OPLOCK_LEVEL_2",
         0x00090008 => "FSCTL_REQUEST_BATCH_OPLOCK",
         0x0009000C => "FSCTL_OPLOCK_BREAK_ACKNOWLEDGE",
         0x00090010 => "FSCTL_OPBATCH_ACK_CLOSE_PENDING",
@@ -38,7 +38,7 @@ pub fn fsctl_func_to_string(f: u32) -> String {
         0x0009003C => "FSCTL_GET_COMPRESSION",
         0x0009004F => "FSCTL_MARK_AS_SYSTEM_HIVE",
         0x00090050 => "FSCTL_OPLOCK_BREAK_ACK_NO_2",
-        0x00090054 => "FSCTL_INVALIDATE_VOLUMES", 
+        0x00090054 => "FSCTL_INVALIDATE_VOLUMES",
         0x00090058 => "FSCTL_QUERY_FAT_BPB",
         0x0009005C => "FSCTL_REQUEST_FILTER_OPLOCK",
         0x00090060 => "FSCTL_FILESYSTEM_GET_STATISTICS",
@@ -48,7 +48,7 @@ pub fn fsctl_func_to_string(f: u32) -> String {
         0x00090073 => "FSCTL_GET_RETRIEVAL_POINTERS",
         0x00090074 => "FSCTL_MOVE_FILE",
         0x00090078 => "FSCTL_IS_VOLUME_DIRTY",
-        0x0009007C => "FSCTL_GET_HFS_INFORMATION", 
+        0x0009007C => "FSCTL_GET_HFS_INFORMATION",
         0x00090083 => "FSCTL_ALLOW_EXTENDED_DASD_IO",
         0x00090087 => "FSCTL_READ_PROPERTY_DATA",
         0x0009008B => "FSCTL_WRITE_PROPERTY_DATA",
@@ -109,6 +109,9 @@ pub fn fsctl_func_to_string(f: u32) -> String {
         0x001440F2 => "FSCTL_SRV_COPYCHUNK",
         0x001441bb => "FSCTL_SRV_READ_HASH",
         0x001480F2 => "FSCTL_SRV_COPYCHUNK_WRITE",
-        _ => { return (f).to_string(); },
-    }.to_string()
+        _ => {
+            return (f).to_string();
+        }
+    }
+    .to_string()
 }

--- a/rust/src/smb/log.rs
+++ b/rust/src/smb/log.rs
@@ -17,17 +17,17 @@
 
 extern crate libc;
 
-use std::str;
-use std::string::String;
 use crate::json::*;
+use crate::smb::dcerpc::*;
+use crate::smb::funcs::*;
 use crate::smb::smb::*;
 use crate::smb::smb1::*;
 use crate::smb::smb2::*;
-use crate::smb::dcerpc::*;
-use crate::smb::funcs::*;
+use std::str;
+use std::string::String;
 
 #[cfg(not(feature = "debug"))]
-fn debug_add_progress(_js: &Json, _tx: &SMBTransaction) { }
+fn debug_add_progress(_js: &Json, _tx: &SMBTransaction) {}
 
 #[cfg(feature = "debug")]
 fn debug_add_progress(js: &Json, tx: &SMBTransaction) {
@@ -64,8 +64,7 @@ fn guid_to_string(guid: &Vec<u8>) -> String {
     }
 }
 
-fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
-{
+fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json {
     let js = Json::object();
     js.set_integer("id", tx.id as u64);
 
@@ -75,7 +74,7 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
     } else {
         let dialect = match &state.dialect_vec {
             &Some(ref d) => str::from_utf8(&d).unwrap_or("invalid"),
-            &None        => "unknown",
+            &None => "unknown",
         };
         js.set_string("dialect", &dialect);
     }
@@ -86,14 +85,14 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
             if ok {
                 js.set_string("command", &smb1_command_string(cmd));
             }
-        },
+        }
         2 => {
             let (ok, cmd) = tx.vercmd.get_smb2_cmd();
             if ok {
                 js.set_string("command", &smb2_command_string(cmd));
             }
-        },
-        _ => { },
+        }
+        _ => {}
     }
 
     match tx.vercmd.get_ntstatus() {
@@ -102,33 +101,36 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
             js.set_string("status", &status);
             let status_hex = format!("0x{:x}", ntstatus);
             js.set_string("status_code", &status_hex);
-        },
+        }
         (false, _) => {
             match tx.vercmd.get_dos_error() {
                 (true, errclass, errcode) => {
                     match errclass {
-                        1 => { // DOSERR
+                        1 => {
+                            // DOSERR
                             let status = smb_dos_error_string(errcode);
                             js.set_string("status", &status);
-                        },
-                        2 => { // SRVERR
+                        }
+                        2 => {
+                            // SRVERR
                             let status = smb_srv_error_string(errcode);
                             js.set_string("status", &status);
                         }
                         _ => {
-                            let s = format!("UNKNOWN_{:02x}_{:04x}", errclass, errcode);
+                            let s = format!(
+                                "UNKNOWN_{:02x}_{:04x}",
+                                errclass, errcode
+                            );
                             js.set_string("status", &s);
-                        },
+                        }
                     }
                     let status_hex = format!("0x{:04x}", errcode);
                     js.set_string("status_code", &status_hex);
-                },
-                (_, _, _) => {
-                },
+                }
+                (_, _, _) => {}
             }
-        },
+        }
     }
-
 
     js.set_integer("session_id", tx.hdr.ssn_id);
     js.set_integer("tree_id", tx.hdr.tree_id as u64);
@@ -174,8 +176,8 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
                     let lm = String::from_utf8_lossy(&r.native_lm);
                     jsd.set_string("native_lm", &lm);
                     js.set("request", jsd);
-                },
-                None => { },
+                }
+                None => {}
             }
             match x.response_host {
                 Some(ref r) => {
@@ -185,13 +187,13 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
                     let lm = String::from_utf8_lossy(&r.native_lm);
                     jsd.set_string("native_lm", &lm);
                     js.set("response", jsd);
-                },
-                None => { },
+                }
+                None => {}
             }
-        },
+        }
         Some(SMBTransactionTypeData::CREATE(ref x)) => {
             let mut name_raw = x.filename.to_vec();
-            name_raw.retain(|&i|i != 0x00);
+            name_raw.retain(|&i| i != 0x00);
             if name_raw.len() > 0 {
                 let name = String::from_utf8_lossy(&name_raw);
                 if x.directory {
@@ -204,13 +206,27 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
                 js.set_string("filename", "<share_root>");
             }
             match x.disposition {
-                0 => { js.set_string("disposition", "FILE_SUPERSEDE"); },
-                1 => { js.set_string("disposition", "FILE_OPEN"); },
-                2 => { js.set_string("disposition", "FILE_CREATE"); },
-                3 => { js.set_string("disposition", "FILE_OPEN_IF"); },
-                4 => { js.set_string("disposition", "FILE_OVERWRITE"); },
-                5 => { js.set_string("disposition", "FILE_OVERWRITE_IF"); },
-                _ => { js.set_string("disposition", "UNKNOWN"); },
+                0 => {
+                    js.set_string("disposition", "FILE_SUPERSEDE");
+                }
+                1 => {
+                    js.set_string("disposition", "FILE_OPEN");
+                }
+                2 => {
+                    js.set_string("disposition", "FILE_CREATE");
+                }
+                3 => {
+                    js.set_string("disposition", "FILE_OPEN_IF");
+                }
+                4 => {
+                    js.set_string("disposition", "FILE_OVERWRITE");
+                }
+                5 => {
+                    js.set_string("disposition", "FILE_OVERWRITE_IF");
+                }
+                _ => {
+                    js.set_string("disposition", "UNKNOWN");
+                }
             }
             if x.delete_on_close {
                 js.set_string("access", "delete on close");
@@ -227,7 +243,7 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
 
             let gs = fuid_to_string(&x.guid);
             js.set_string("fuid", &gs);
-        },
+        }
         Some(SMBTransactionTypeData::NEGOTIATE(ref x)) => {
             if x.smb_ver == 1 {
                 let jsa = Json::array();
@@ -250,7 +266,7 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
             }
 
             js.set_string("server_guid", &guid_to_string(&x.server_guid));
-        },
+        }
         Some(SMBTransactionTypeData::TREECONNECT(ref x)) => {
             js.set_integer("tree_id", x.tree_id as u64);
 
@@ -278,13 +294,21 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
             // share type only for SMB2
             } else {
                 match x.share_type {
-                    1 => { js.set_string("share_type", "FILE"); },
-                    2 => { js.set_string("share_type", "PIPE"); },
-                    3 => { js.set_string("share_type", "PRINT"); },
-                    _ => { js.set_string("share_type", "UNKNOWN"); },
+                    1 => {
+                        js.set_string("share_type", "FILE");
+                    }
+                    2 => {
+                        js.set_string("share_type", "PIPE");
+                    }
+                    3 => {
+                        js.set_string("share_type", "PRINT");
+                    }
+                    _ => {
+                        js.set_string("share_type", "UNKNOWN");
+                    }
                 }
             }
-        },
+        }
         Some(SMBTransactionTypeData::FILE(ref x)) => {
             let file_name = String::from_utf8_lossy(&x.file_name);
             js.set_string("filename", &file_name);
@@ -292,7 +316,7 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
             js.set_string("share", &share_name);
             let gs = fuid_to_string(&x.fuid);
             js.set_string("fuid", &gs);
-        },
+        }
         Some(SMBTransactionTypeData::RENAME(ref x)) => {
             if tx.vercmd.get_version() == 2 {
                 let jsd = Json::object();
@@ -309,7 +333,7 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
             js.set("rename", jsd);
             let gs = fuid_to_string(&x.fuid);
             js.set_string("fuid", &gs);
-        },
+        }
         Some(SMBTransactionTypeData::DCERPC(ref x)) => {
             let jsd = Json::object();
             if x.req_set {
@@ -328,34 +352,41 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
                         jsd.set_integer("opnum", x.opnum as u64);
                         let req = Json::object();
                         req.set_integer("frag_cnt", x.frag_cnt_ts as u64);
-                        req.set_integer("stub_data_size", x.stub_data_ts.len() as u64);
+                        req.set_integer(
+                            "stub_data_size",
+                            x.stub_data_ts.len() as u64,
+                        );
                         jsd.set("req", req);
-                    },
-                    DCERPC_TYPE_BIND => {
-                        match state.dcerpc_ifaces {
-                            Some(ref ifaces) => {
-                                let jsa = Json::array();
-                                for i in ifaces {
-                                    let jso = Json::object();
-                                    let ifstr = dcerpc_uuid_to_string(&i);
-                                    jso.set_string("uuid", &ifstr);
-                                    let vstr = format!("{}.{}", i.ver, i.ver_min);
-                                    jso.set_string("version", &vstr);
+                    }
+                    DCERPC_TYPE_BIND => match state.dcerpc_ifaces {
+                        Some(ref ifaces) => {
+                            let jsa = Json::array();
+                            for i in ifaces {
+                                let jso = Json::object();
+                                let ifstr = dcerpc_uuid_to_string(&i);
+                                jso.set_string("uuid", &ifstr);
+                                let vstr = format!("{}.{}", i.ver, i.ver_min);
+                                jso.set_string("version", &vstr);
 
-                                    if i.acked {
-                                        jso.set_integer("ack_result", i.ack_result as u64);
-                                        jso.set_integer("ack_reason", i.ack_reason as u64);
-                                    }
-
-                                    jsa.array_append(jso);
+                                if i.acked {
+                                    jso.set_integer(
+                                        "ack_result",
+                                        i.ack_result as u64,
+                                    );
+                                    jso.set_integer(
+                                        "ack_reason",
+                                        i.ack_reason as u64,
+                                    );
                                 }
 
-                                jsd.set("interfaces", jsa);
-                            },
-                            _ => {},
+                                jsa.array_append(jso);
+                            }
+
+                            jsd.set("interfaces", jsa);
                         }
+                        _ => {}
                     },
-                    _ => {},
+                    _ => {}
                 }
             }
             if x.res_set {
@@ -363,11 +394,14 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
                     DCERPC_TYPE_RESPONSE => {
                         let res = Json::object();
                         res.set_integer("frag_cnt", x.frag_cnt_tc as u64);
-                        res.set_integer("stub_data_size", x.stub_data_tc.len() as u64);
+                        res.set_integer(
+                            "stub_data_size",
+                            x.stub_data_tc.len() as u64,
+                        );
                         jsd.set("res", res);
-                    },
+                    }
                     // we don't handle BINDACK w/o BIND
-                    _ => {},
+                    _ => {}
                 }
             }
             jsd.set_integer("call_id", x.call_id as u64);
@@ -375,10 +409,10 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
         }
         Some(SMBTransactionTypeData::IOCTL(ref x)) => {
             js.set_string("function", &fsctl_func_to_string(x.func));
-        },
+        }
         Some(SMBTransactionTypeData::SETFILEPATHINFO(ref x)) => {
             let mut name_raw = x.filename.to_vec();
-            name_raw.retain(|&i|i != 0x00);
+            name_raw.retain(|&i| i != 0x00);
             if name_raw.len() > 0 {
                 let name = String::from_utf8_lossy(&name_raw);
                 js.set_string("filename", &name);
@@ -395,39 +429,46 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
             match x.subcmd {
                 8 => {
                     js.set_string("subcmd", "SET_FILE_INFO");
-                },
+                }
                 6 => {
                     js.set_string("subcmd", "SET_PATH_INFO");
-                },
-                _ => { },
+                }
+                _ => {}
             }
 
             match x.loi {
-                1013 => { // Set Disposition Information
-                    js.set_string("level_of_interest", "Set Disposition Information");
-                },
-                _ => { },
+                1013 => {
+                    // Set Disposition Information
+                    js.set_string(
+                        "level_of_interest",
+                        "Set Disposition Information",
+                    );
+                }
+                _ => {}
             }
 
             let gs = fuid_to_string(&x.fid);
             js.set_string("fuid", &gs);
-        },
-        _ => {  },
+        }
+        _ => {}
     }
     return js;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_log_json_request(state: &mut SMBState, tx: &mut SMBTransaction) -> *mut JsonT
-{
+pub extern "C" fn rs_smb_log_json_request(
+    state: &mut SMBState,
+    tx: &mut SMBTransaction,
+) -> *mut JsonT {
     let js = smb_common_header(state, tx);
     return js.unwrap();
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_log_json_response(state: &mut SMBState, tx: &mut SMBTransaction) -> *mut JsonT
-{
+pub extern "C" fn rs_smb_log_json_response(
+    state: &mut SMBState,
+    tx: &mut SMBTransaction,
+) -> *mut JsonT {
     let js = smb_common_header(state, tx);
     return js.unwrap();
 }
-

--- a/rust/src/smb/log.rs
+++ b/rust/src/smb/log.rs
@@ -19,12 +19,12 @@ extern crate libc;
 
 use std::str;
 use std::string::String;
-use json::*;
-use smb::smb::*;
-use smb::smb1::*;
-use smb::smb2::*;
-use smb::dcerpc::*;
-use smb::funcs::*;
+use crate::json::*;
+use crate::smb::smb::*;
+use crate::smb::smb1::*;
+use crate::smb::smb2::*;
+use crate::smb::dcerpc::*;
+use crate::smb::funcs::*;
 
 #[cfg(not(feature = "debug"))]
 fn debug_add_progress(_js: &Json, _tx: &SMBTransaction) { }

--- a/rust/src/smb/mod.rs
+++ b/rust/src/smb/mod.rs
@@ -15,29 +15,29 @@
  * 02110-1301, USA.
  */
 
-pub mod smb_records;
+pub mod dcerpc_records;
+pub mod nbss_records;
+pub mod ntlmssp_records;
 pub mod smb1_records;
 pub mod smb2_records;
-pub mod nbss_records;
-pub mod dcerpc_records;
-pub mod ntlmssp_records;
+pub mod smb_records;
 
+pub mod auth;
+pub mod dcerpc;
+pub mod debug;
+pub mod detect;
+pub mod events;
+pub mod files;
+pub mod funcs;
+pub mod log;
+pub mod session;
 pub mod smb;
 pub mod smb1;
 pub mod smb1_session;
 pub mod smb2;
-pub mod smb2_session;
 pub mod smb2_ioctl;
+pub mod smb2_session;
 pub mod smb3;
-pub mod dcerpc;
-pub mod session;
-pub mod log;
-pub mod detect;
-pub mod debug;
-pub mod events;
-pub mod auth;
-pub mod files;
-pub mod funcs;
 
 //#[cfg(feature = "lua")]
 //pub mod lua;

--- a/rust/src/smb/nbss_records.rs
+++ b/rust/src/smb/nbss_records.rs
@@ -15,40 +15,44 @@
  * 02110-1301, USA.
  */
 
-use nom::{rest};
+use nom::rest;
 
-pub const NBSS_MSGTYPE_SESSION_MESSAGE:         u8 = 0x00;
-pub const NBSS_MSGTYPE_SESSION_REQUEST:         u8 = 0x81;
-pub const NBSS_MSGTYPE_POSITIVE_SSN_RESPONSE:   u8 = 0x82;
-pub const NBSS_MSGTYPE_NEGATIVE_SSN_RESPONSE:   u8 = 0x83;
-pub const NBSS_MSGTYPE_RETARG_RESPONSE:         u8 = 0x84;
-pub const NBSS_MSGTYPE_KEEP_ALIVE:              u8 = 0x85;
+pub const NBSS_MSGTYPE_SESSION_MESSAGE: u8 = 0x00;
+pub const NBSS_MSGTYPE_SESSION_REQUEST: u8 = 0x81;
+pub const NBSS_MSGTYPE_POSITIVE_SSN_RESPONSE: u8 = 0x82;
+pub const NBSS_MSGTYPE_NEGATIVE_SSN_RESPONSE: u8 = 0x83;
+pub const NBSS_MSGTYPE_RETARG_RESPONSE: u8 = 0x84;
+pub const NBSS_MSGTYPE_KEEP_ALIVE: u8 = 0x85;
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct NbssRecord<'a> {
     pub message_type: u8,
     pub length: u32,
-    pub data: &'a[u8],
+    pub data: &'a [u8],
 }
 
 impl<'a> NbssRecord<'a> {
     pub fn is_valid(&self) -> bool {
         let valid = match self.message_type {
-            NBSS_MSGTYPE_SESSION_MESSAGE |
-            NBSS_MSGTYPE_SESSION_REQUEST |
-            NBSS_MSGTYPE_POSITIVE_SSN_RESPONSE |
-            NBSS_MSGTYPE_NEGATIVE_SSN_RESPONSE |
-            NBSS_MSGTYPE_RETARG_RESPONSE |
-            NBSS_MSGTYPE_KEEP_ALIVE => true,
+            NBSS_MSGTYPE_SESSION_MESSAGE
+            | NBSS_MSGTYPE_SESSION_REQUEST
+            | NBSS_MSGTYPE_POSITIVE_SSN_RESPONSE
+            | NBSS_MSGTYPE_NEGATIVE_SSN_RESPONSE
+            | NBSS_MSGTYPE_RETARG_RESPONSE
+            | NBSS_MSGTYPE_KEEP_ALIVE => true,
             _ => false,
         };
         valid
     }
     pub fn is_smb(&self) -> bool {
         let valid = self.is_valid();
-        let smb = if self.data.len() >= 4 &&
-            self.data[1] == 'S' as u8 && self.data[2] == 'M' as u8 && self.data[3] == 'B' as u8 &&
-            (self.data[0] == b'\xFE' || self.data[0] == b'\xFF' || self.data[0] == b'\xFD')
+        let smb = if self.data.len() >= 4
+            && self.data[1] == 'S' as u8
+            && self.data[2] == 'M' as u8
+            && self.data[3] == 'B' as u8
+            && (self.data[0] == b'\xFE'
+                || self.data[0] == b'\xFF'
+                || self.data[0] == b'\xFD')
         {
             true
         } else {

--- a/rust/src/smb/ntlmssp_records.rs
+++ b/rust/src/smb/ntlmssp_records.rs
@@ -15,9 +15,9 @@
  * 02110-1301, USA.
  */
 
-use nom::{rest, le_u8, le_u16, le_u32};
+use nom::{le_u16, le_u32, le_u8, rest};
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct NTLMSSPVersion {
     pub ver_major: u8,
     pub ver_minor: u8,
@@ -27,32 +27,35 @@ pub struct NTLMSSPVersion {
 
 impl NTLMSSPVersion {
     pub fn to_string(&self) -> String {
-        format!("{}.{} build {} rev {}",
-                self.ver_major, self.ver_minor,
-                self.ver_build, self.ver_ntlm_rev)
+        format!(
+            "{}.{} build {} rev {}",
+            self.ver_major, self.ver_minor, self.ver_build, self.ver_ntlm_rev
+        )
     }
 }
 
-named!(parse_ntlm_auth_version<NTLMSSPVersion>,
+named!(
+    parse_ntlm_auth_version<NTLMSSPVersion>,
     do_parse!(
-            ver_major: le_u8
-         >> ver_minor: le_u8
-         >> ver_build: le_u16
-         >> take!(3)
-         >> ver_ntlm_rev: le_u8
-         >> ( NTLMSSPVersion {
+        ver_major: le_u8
+            >> ver_minor: le_u8
+            >> ver_build: le_u16
+            >> take!(3)
+            >> ver_ntlm_rev: le_u8
+            >> (NTLMSSPVersion {
                 ver_major: ver_major,
                 ver_minor: ver_minor,
                 ver_build: ver_build,
                 ver_ntlm_rev: ver_ntlm_rev,
-             })
-));
+            })
+    )
+);
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct NTLMSSPAuthRecord<'a> {
-    pub domain: &'a[u8],
-    pub user: &'a[u8],
-    pub host: &'a[u8],
+    pub domain: &'a [u8],
+    pub user: &'a [u8],
+    pub host: &'a [u8],
     pub version: Option<NTLMSSPVersion>,
 }
 
@@ -104,10 +107,10 @@ named!(pub parse_ntlm_auth_record<NTLMSSPAuthRecord>,
             })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct NTLMSSPRecord<'a> {
     pub msg_type: u32,
-    pub data: &'a[u8],
+    pub data: &'a [u8],
 }
 
 named!(pub parse_ntlmssp<NTLMSSPRecord>,

--- a/rust/src/smb/session.rs
+++ b/rust/src/smb/session.rs
@@ -15,11 +15,11 @@
  * 02110-1301, USA.
  */
 
-use log::*;
-use kerberos::*;
-use smb::smb::*;
-use smb::smb1_session::*;
-use smb::auth::*;
+use crate::log::*;
+use crate::kerberos::*;
+use crate::smb::smb::*;
+use crate::smb::smb1_session::*;
+use crate::smb::auth::*;
 
 #[derive(Debug)]
 pub struct SMBTransactionSessionSetup {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -33,23 +33,23 @@ use std::ffi::CStr;
 use nom::IResult;
 use std::collections::HashMap;
 
-use core::*;
-use log::*;
-use applayer;
-use applayer::LoggerFlags;
+use crate::core::*;
+use crate::log::*;
+use crate::applayer;
+use crate::applayer::LoggerFlags;
 
-use smb::nbss_records::*;
-use smb::smb1_records::*;
-use smb::smb2_records::*;
+use crate::smb::nbss_records::*;
+use crate::smb::smb1_records::*;
+use crate::smb::smb2_records::*;
 
-use smb::smb1::*;
-use smb::smb2::*;
-use smb::smb3::*;
-use smb::dcerpc::*;
-use smb::session::*;
-use smb::events::*;
-use smb::files::*;
-use smb::smb2_ioctl::*;
+use crate::smb::smb1::*;
+use crate::smb::smb2::*;
+use crate::smb::smb3::*;
+use crate::smb::dcerpc::*;
+use crate::smb::session::*;
+use crate::smb::events::*;
+use crate::smb::files::*;
+use crate::smb::smb2_ioctl::*;
 
 pub static mut SURICATA_SMB_FILE_CONFIG: Option<&'static SuricataFileContext> = None;
 

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -26,169 +26,189 @@
 // written by Victor Julien
 extern crate libc;
 use std;
+use std::ffi::CStr;
 use std::mem::transmute;
 use std::str;
-use std::ffi::CStr;
 
 use nom::IResult;
 use std::collections::HashMap;
 
-use crate::core::*;
-use crate::log::*;
 use crate::applayer;
 use crate::applayer::LoggerFlags;
+use crate::core::*;
+use crate::log::*;
 
 use crate::smb::nbss_records::*;
 use crate::smb::smb1_records::*;
 use crate::smb::smb2_records::*;
 
-use crate::smb::smb1::*;
-use crate::smb::smb2::*;
-use crate::smb::smb3::*;
 use crate::smb::dcerpc::*;
-use crate::smb::session::*;
 use crate::smb::events::*;
 use crate::smb::files::*;
+use crate::smb::session::*;
+use crate::smb::smb1::*;
+use crate::smb::smb2::*;
 use crate::smb::smb2_ioctl::*;
+use crate::smb::smb3::*;
 
-pub static mut SURICATA_SMB_FILE_CONFIG: Option<&'static SuricataFileContext> = None;
+pub static mut SURICATA_SMB_FILE_CONFIG: Option<&'static SuricataFileContext> =
+    None;
 
 #[no_mangle]
-pub extern "C" fn rs_smb_init(context: &'static mut SuricataFileContext)
-{
+pub extern "C" fn rs_smb_init(context: &'static mut SuricataFileContext) {
     unsafe {
         SURICATA_SMB_FILE_CONFIG = Some(context);
     }
 }
 
-pub const SMB_NTSTATUS_SUCCESS:                    u32 = 0;
-pub const SMB_NTSTATUS_PENDING:                    u32 = 0x00000103;
-pub const SMB_NTSTATUS_BUFFER_OVERFLOW:            u32 = 0x80000005;
-pub const SMB_NTSTATUS_NO_MORE_FILES:              u32 = 0x80000006;
-pub const SMB_NTSTATUS_NO_MORE_ENTRIES:            u32 = 0x8000001a;
-pub const SMB_NTSTATUS_INVALID_HANDLE:             u32 = 0xc0000008;
-pub const SMB_NTSTATUS_INVALID_PARAMETER:          u32 = 0xc000000d;
-pub const SMB_NTSTATUS_NO_SUCH_DEVICE:             u32 = 0xc000000e;
-pub const SMB_NTSTATUS_NO_SUCH_FILE:               u32 = 0xc000000f;
-pub const SMB_NTSTATUS_INVALID_DEVICE_REQUEST:     u32 = 0xc0000010;
-pub const SMB_NTSTATUS_END_OF_FILE:                u32 = 0xc0000011;
-pub const SMB_NTSTATUS_MORE_PROCESSING_REQUIRED:   u32 = 0xc0000016;
-pub const SMB_NTSTATUS_ACCESS_DENIED:              u32 = 0xc0000022;
-pub const SMB_NTSTATUS_OBJECT_NAME_INVALID:        u32 = 0xc0000033;
-pub const SMB_NTSTATUS_OBJECT_NAME_NOT_FOUND:      u32 = 0xc0000034;
-pub const SMB_NTSTATUS_OBJECT_NAME_COLLISION:      u32 = 0xc0000035;
-pub const SMB_NTSTATUS_OBJECT_PATH_NOT_FOUND:      u32 = 0xc000003a;
-pub const SMB_NTSTATUS_SHARING_VIOLATION:          u32 = 0xc0000043;
-pub const SMB_NTSTATUS_LOCK_CONFLICT:              u32 = 0xc0000054;
-pub const SMB_NTSTATUS_LOCK_NOT_GRANTED:           u32 = 0xc0000055;
-pub const SMB_NTSTATUS_PRIVILEGE_NOT_HELD:         u32 = 0xc0000061;
-pub const SMB_NTSTATUS_LOGON_FAILURE:              u32 = 0xc000006d;
-pub const SMB_NTSTATUS_PIPE_DISCONNECTED:          u32 = 0xc00000b0;
-pub const SMB_NTSTATUS_FILE_IS_A_DIRECTORY:        u32 = 0xc00000ba;
-pub const SMB_NTSTATUS_NOT_SUPPORTED:              u32 = 0xc00000bb;
-pub const SMB_NTSTATUS_BAD_NETWORK_NAME:           u32 = 0xc00000cc;
-pub const SMB_NTSTATUS_REQUEST_NOT_ACCEPTED:       u32 = 0xc00000d0;
-pub const SMB_NTSTATUS_OPLOCK_NOT_GRANTED:         u32 = 0xc00000e2;
-pub const SMB_NTSTATUS_CANCELLED:                  u32 = 0xc0000120;
-pub const SMB_NTSTATUS_FILE_CLOSED:                u32 = 0xc0000128;
-pub const SMB_NTSTATUS_FS_DRIVER_REQUIRED:         u32 = 0xc000019c;
-pub const SMB_NTSTATUS_INSUFF_SERVER_RESOURCES:    u32 = 0xc0000205;
-pub const SMB_NTSTATUS_NOT_FOUND:                  u32 = 0xc0000225;
-pub const SMB_NTSTATUS_PIPE_BROKEN:                u32 = 0xc000014b;
-pub const SMB_NTSTATUS_TRUSTED_RELATIONSHIP_FAILURE:    u32 = 0xc000018d;
-pub const SMB_NTSTATUS_NOT_A_REPARSE_POINT:        u32 = 0xc0000275;
-pub const SMB_NTSTATUS_NETWORK_SESSION_EXPIRED:    u32 = 0xc000035c;
+pub const SMB_NTSTATUS_SUCCESS: u32 = 0;
+pub const SMB_NTSTATUS_PENDING: u32 = 0x00000103;
+pub const SMB_NTSTATUS_BUFFER_OVERFLOW: u32 = 0x80000005;
+pub const SMB_NTSTATUS_NO_MORE_FILES: u32 = 0x80000006;
+pub const SMB_NTSTATUS_NO_MORE_ENTRIES: u32 = 0x8000001a;
+pub const SMB_NTSTATUS_INVALID_HANDLE: u32 = 0xc0000008;
+pub const SMB_NTSTATUS_INVALID_PARAMETER: u32 = 0xc000000d;
+pub const SMB_NTSTATUS_NO_SUCH_DEVICE: u32 = 0xc000000e;
+pub const SMB_NTSTATUS_NO_SUCH_FILE: u32 = 0xc000000f;
+pub const SMB_NTSTATUS_INVALID_DEVICE_REQUEST: u32 = 0xc0000010;
+pub const SMB_NTSTATUS_END_OF_FILE: u32 = 0xc0000011;
+pub const SMB_NTSTATUS_MORE_PROCESSING_REQUIRED: u32 = 0xc0000016;
+pub const SMB_NTSTATUS_ACCESS_DENIED: u32 = 0xc0000022;
+pub const SMB_NTSTATUS_OBJECT_NAME_INVALID: u32 = 0xc0000033;
+pub const SMB_NTSTATUS_OBJECT_NAME_NOT_FOUND: u32 = 0xc0000034;
+pub const SMB_NTSTATUS_OBJECT_NAME_COLLISION: u32 = 0xc0000035;
+pub const SMB_NTSTATUS_OBJECT_PATH_NOT_FOUND: u32 = 0xc000003a;
+pub const SMB_NTSTATUS_SHARING_VIOLATION: u32 = 0xc0000043;
+pub const SMB_NTSTATUS_LOCK_CONFLICT: u32 = 0xc0000054;
+pub const SMB_NTSTATUS_LOCK_NOT_GRANTED: u32 = 0xc0000055;
+pub const SMB_NTSTATUS_PRIVILEGE_NOT_HELD: u32 = 0xc0000061;
+pub const SMB_NTSTATUS_LOGON_FAILURE: u32 = 0xc000006d;
+pub const SMB_NTSTATUS_PIPE_DISCONNECTED: u32 = 0xc00000b0;
+pub const SMB_NTSTATUS_FILE_IS_A_DIRECTORY: u32 = 0xc00000ba;
+pub const SMB_NTSTATUS_NOT_SUPPORTED: u32 = 0xc00000bb;
+pub const SMB_NTSTATUS_BAD_NETWORK_NAME: u32 = 0xc00000cc;
+pub const SMB_NTSTATUS_REQUEST_NOT_ACCEPTED: u32 = 0xc00000d0;
+pub const SMB_NTSTATUS_OPLOCK_NOT_GRANTED: u32 = 0xc00000e2;
+pub const SMB_NTSTATUS_CANCELLED: u32 = 0xc0000120;
+pub const SMB_NTSTATUS_FILE_CLOSED: u32 = 0xc0000128;
+pub const SMB_NTSTATUS_FS_DRIVER_REQUIRED: u32 = 0xc000019c;
+pub const SMB_NTSTATUS_INSUFF_SERVER_RESOURCES: u32 = 0xc0000205;
+pub const SMB_NTSTATUS_NOT_FOUND: u32 = 0xc0000225;
+pub const SMB_NTSTATUS_PIPE_BROKEN: u32 = 0xc000014b;
+pub const SMB_NTSTATUS_TRUSTED_RELATIONSHIP_FAILURE: u32 = 0xc000018d;
+pub const SMB_NTSTATUS_NOT_A_REPARSE_POINT: u32 = 0xc0000275;
+pub const SMB_NTSTATUS_NETWORK_SESSION_EXPIRED: u32 = 0xc000035c;
 
 pub fn smb_ntstatus_string(c: u32) -> String {
     match c {
-        SMB_NTSTATUS_SUCCESS                   => "STATUS_SUCCESS",
-        SMB_NTSTATUS_BUFFER_OVERFLOW           => "STATUS_BUFFER_OVERFLOW",
-        SMB_NTSTATUS_PENDING                   => "STATUS_PENDING",
-        SMB_NTSTATUS_NO_MORE_FILES             => "STATUS_NO_MORE_FILES",
-        SMB_NTSTATUS_NO_MORE_ENTRIES           => "STATUS_NO_MORE_ENTRIES",
-        SMB_NTSTATUS_INVALID_HANDLE            => "STATUS_INVALID_HANDLE",
-        SMB_NTSTATUS_INVALID_PARAMETER         => "STATUS_INVALID_PARAMETER",
-        SMB_NTSTATUS_NO_SUCH_DEVICE            => "STATUS_NO_SUCH_DEVICE",
-        SMB_NTSTATUS_NO_SUCH_FILE              => "STATUS_NO_SUCH_FILE",
-        SMB_NTSTATUS_INVALID_DEVICE_REQUEST    => "STATUS_INVALID_DEVICE_REQUEST",
-        SMB_NTSTATUS_END_OF_FILE               => "STATUS_END_OF_FILE",
-        SMB_NTSTATUS_MORE_PROCESSING_REQUIRED  => "STATUS_MORE_PROCESSING_REQUIRED",
-        SMB_NTSTATUS_ACCESS_DENIED             => "STATUS_ACCESS_DENIED",
-        SMB_NTSTATUS_OBJECT_NAME_INVALID       => "STATUS_OBJECT_NAME_INVALID",
-        SMB_NTSTATUS_OBJECT_NAME_NOT_FOUND     => "STATUS_OBJECT_NAME_NOT_FOUND",
-        SMB_NTSTATUS_OBJECT_NAME_COLLISION     => "STATUS_OBJECT_NAME_COLLISION",
-        SMB_NTSTATUS_OBJECT_PATH_NOT_FOUND     => "STATUS_OBJECT_PATH_NOT_FOUND",
-        SMB_NTSTATUS_SHARING_VIOLATION         => "STATUS_SHARING_VIOLATION",
-        SMB_NTSTATUS_LOCK_CONFLICT             => "STATUS_LOCK_CONFLICT",
-        SMB_NTSTATUS_LOCK_NOT_GRANTED          => "STATUS_LOCK_NOT_GRANTED",
-        SMB_NTSTATUS_PRIVILEGE_NOT_HELD        => "STATUS_PRIVILEGE_NOT_HELD",
-        SMB_NTSTATUS_LOGON_FAILURE             => "STATUS_LOGON_FAILURE",
-        SMB_NTSTATUS_PIPE_DISCONNECTED         => "STATUS_PIPE_DISCONNECTED",
-        SMB_NTSTATUS_FILE_IS_A_DIRECTORY       => "STATUS_FILE_IS_A_DIRECTORY",
-        SMB_NTSTATUS_NOT_SUPPORTED             => "STATUS_NOT_SUPPORTED",
-        SMB_NTSTATUS_BAD_NETWORK_NAME          => "STATUS_BAD_NETWORK_NAME",
-        SMB_NTSTATUS_REQUEST_NOT_ACCEPTED      => "STATUS_REQUEST_NOT_ACCEPTED",
-        SMB_NTSTATUS_OPLOCK_NOT_GRANTED        => "STATUS_OPLOCK_NOT_GRANTED",
-        SMB_NTSTATUS_CANCELLED                 => "STATUS_CANCELLED",
-        SMB_NTSTATUS_FILE_CLOSED               => "STATUS_FILE_CLOSED",
-        SMB_NTSTATUS_FS_DRIVER_REQUIRED        => "STATUS_FS_DRIVER_REQUIRED",
-        SMB_NTSTATUS_INSUFF_SERVER_RESOURCES   => "STATUS_INSUFF_SERVER_RESOURCES",
-        SMB_NTSTATUS_NOT_FOUND                 => "STATUS_NOT_FOUND",
-        SMB_NTSTATUS_PIPE_BROKEN               => "STATUS_PIPE_BROKEN",
-        SMB_NTSTATUS_TRUSTED_RELATIONSHIP_FAILURE   => "STATUS_TRUSTED_RELATIONSHIP_FAILURE",
-        SMB_NTSTATUS_NOT_A_REPARSE_POINT       => "STATUS_NOT_A_REPARSE_POINT",
-        SMB_NTSTATUS_NETWORK_SESSION_EXPIRED   => "STATUS_NETWORK_SESSION_EXPIRED",
-        _ => { return (c).to_string(); },
-    }.to_string()
+        SMB_NTSTATUS_SUCCESS => "STATUS_SUCCESS",
+        SMB_NTSTATUS_BUFFER_OVERFLOW => "STATUS_BUFFER_OVERFLOW",
+        SMB_NTSTATUS_PENDING => "STATUS_PENDING",
+        SMB_NTSTATUS_NO_MORE_FILES => "STATUS_NO_MORE_FILES",
+        SMB_NTSTATUS_NO_MORE_ENTRIES => "STATUS_NO_MORE_ENTRIES",
+        SMB_NTSTATUS_INVALID_HANDLE => "STATUS_INVALID_HANDLE",
+        SMB_NTSTATUS_INVALID_PARAMETER => "STATUS_INVALID_PARAMETER",
+        SMB_NTSTATUS_NO_SUCH_DEVICE => "STATUS_NO_SUCH_DEVICE",
+        SMB_NTSTATUS_NO_SUCH_FILE => "STATUS_NO_SUCH_FILE",
+        SMB_NTSTATUS_INVALID_DEVICE_REQUEST => "STATUS_INVALID_DEVICE_REQUEST",
+        SMB_NTSTATUS_END_OF_FILE => "STATUS_END_OF_FILE",
+        SMB_NTSTATUS_MORE_PROCESSING_REQUIRED => {
+            "STATUS_MORE_PROCESSING_REQUIRED"
+        }
+        SMB_NTSTATUS_ACCESS_DENIED => "STATUS_ACCESS_DENIED",
+        SMB_NTSTATUS_OBJECT_NAME_INVALID => "STATUS_OBJECT_NAME_INVALID",
+        SMB_NTSTATUS_OBJECT_NAME_NOT_FOUND => "STATUS_OBJECT_NAME_NOT_FOUND",
+        SMB_NTSTATUS_OBJECT_NAME_COLLISION => "STATUS_OBJECT_NAME_COLLISION",
+        SMB_NTSTATUS_OBJECT_PATH_NOT_FOUND => "STATUS_OBJECT_PATH_NOT_FOUND",
+        SMB_NTSTATUS_SHARING_VIOLATION => "STATUS_SHARING_VIOLATION",
+        SMB_NTSTATUS_LOCK_CONFLICT => "STATUS_LOCK_CONFLICT",
+        SMB_NTSTATUS_LOCK_NOT_GRANTED => "STATUS_LOCK_NOT_GRANTED",
+        SMB_NTSTATUS_PRIVILEGE_NOT_HELD => "STATUS_PRIVILEGE_NOT_HELD",
+        SMB_NTSTATUS_LOGON_FAILURE => "STATUS_LOGON_FAILURE",
+        SMB_NTSTATUS_PIPE_DISCONNECTED => "STATUS_PIPE_DISCONNECTED",
+        SMB_NTSTATUS_FILE_IS_A_DIRECTORY => "STATUS_FILE_IS_A_DIRECTORY",
+        SMB_NTSTATUS_NOT_SUPPORTED => "STATUS_NOT_SUPPORTED",
+        SMB_NTSTATUS_BAD_NETWORK_NAME => "STATUS_BAD_NETWORK_NAME",
+        SMB_NTSTATUS_REQUEST_NOT_ACCEPTED => "STATUS_REQUEST_NOT_ACCEPTED",
+        SMB_NTSTATUS_OPLOCK_NOT_GRANTED => "STATUS_OPLOCK_NOT_GRANTED",
+        SMB_NTSTATUS_CANCELLED => "STATUS_CANCELLED",
+        SMB_NTSTATUS_FILE_CLOSED => "STATUS_FILE_CLOSED",
+        SMB_NTSTATUS_FS_DRIVER_REQUIRED => "STATUS_FS_DRIVER_REQUIRED",
+        SMB_NTSTATUS_INSUFF_SERVER_RESOURCES => {
+            "STATUS_INSUFF_SERVER_RESOURCES"
+        }
+        SMB_NTSTATUS_NOT_FOUND => "STATUS_NOT_FOUND",
+        SMB_NTSTATUS_PIPE_BROKEN => "STATUS_PIPE_BROKEN",
+        SMB_NTSTATUS_TRUSTED_RELATIONSHIP_FAILURE => {
+            "STATUS_TRUSTED_RELATIONSHIP_FAILURE"
+        }
+        SMB_NTSTATUS_NOT_A_REPARSE_POINT => "STATUS_NOT_A_REPARSE_POINT",
+        SMB_NTSTATUS_NETWORK_SESSION_EXPIRED => {
+            "STATUS_NETWORK_SESSION_EXPIRED"
+        }
+        _ => {
+            return (c).to_string();
+        }
+    }
+    .to_string()
 }
 
-pub const SMB_SRV_ERROR:                u16 = 1;
-pub const SMB_SRV_BADPW:                u16 = 2;
-pub const SMB_SRV_BADTYPE:              u16 = 3;
-pub const SMB_SRV_ACCESS:               u16 = 4;
-pub const SMB_SRV_BADUID:               u16 = 91;
+pub const SMB_SRV_ERROR: u16 = 1;
+pub const SMB_SRV_BADPW: u16 = 2;
+pub const SMB_SRV_BADTYPE: u16 = 3;
+pub const SMB_SRV_ACCESS: u16 = 4;
+pub const SMB_SRV_BADUID: u16 = 91;
 
 pub fn smb_srv_error_string(c: u16) -> String {
     match c {
-        SMB_SRV_ERROR           => "SRV_ERROR",
-        SMB_SRV_BADPW           => "SRV_BADPW",
-        SMB_SRV_BADTYPE         => "SRV_BADTYPE",
-        SMB_SRV_ACCESS          => "SRV_ACCESS",
-        SMB_SRV_BADUID          => "SRV_BADUID",
-        _ => { return (c).to_string(); },
-    }.to_string()
+        SMB_SRV_ERROR => "SRV_ERROR",
+        SMB_SRV_BADPW => "SRV_BADPW",
+        SMB_SRV_BADTYPE => "SRV_BADTYPE",
+        SMB_SRV_ACCESS => "SRV_ACCESS",
+        SMB_SRV_BADUID => "SRV_BADUID",
+        _ => {
+            return (c).to_string();
+        }
+    }
+    .to_string()
 }
 
-pub const SMB_DOS_SUCCESS:                u16 = 0;
-pub const SMB_DOS_BAD_FUNC:               u16 = 1;
-pub const SMB_DOS_BAD_FILE:               u16 = 2;
-pub const SMB_DOS_BAD_PATH:               u16 = 3;
-pub const SMB_DOS_TOO_MANY_OPEN_FILES:    u16 = 4;
-pub const SMB_DOS_ACCESS_DENIED:          u16 = 5;
+pub const SMB_DOS_SUCCESS: u16 = 0;
+pub const SMB_DOS_BAD_FUNC: u16 = 1;
+pub const SMB_DOS_BAD_FILE: u16 = 2;
+pub const SMB_DOS_BAD_PATH: u16 = 3;
+pub const SMB_DOS_TOO_MANY_OPEN_FILES: u16 = 4;
+pub const SMB_DOS_ACCESS_DENIED: u16 = 5;
 
 pub fn smb_dos_error_string(c: u16) -> String {
     match c {
-        SMB_DOS_SUCCESS           => "DOS_SUCCESS",
-        SMB_DOS_BAD_FUNC          => "DOS_BAD_FUNC",
-        SMB_DOS_BAD_FILE          => "DOS_BAD_FILE",
-        SMB_DOS_BAD_PATH          => "DOS_BAD_PATH",
+        SMB_DOS_SUCCESS => "DOS_SUCCESS",
+        SMB_DOS_BAD_FUNC => "DOS_BAD_FUNC",
+        SMB_DOS_BAD_FILE => "DOS_BAD_FILE",
+        SMB_DOS_BAD_PATH => "DOS_BAD_PATH",
         SMB_DOS_TOO_MANY_OPEN_FILES => "DOS_TOO_MANY_OPEN_FILES",
-        SMB_DOS_ACCESS_DENIED     => "DOS_ACCESS_DENIED",
-        _ => { return (c).to_string(); },
-    }.to_string()
+        SMB_DOS_ACCESS_DENIED => "DOS_ACCESS_DENIED",
+        _ => {
+            return (c).to_string();
+        }
+    }
+    .to_string()
 }
 
-pub const NTLMSSP_NEGOTIATE:               u32 = 1;
-pub const NTLMSSP_CHALLENGE:               u32 = 2;
-pub const NTLMSSP_AUTH:                    u32 = 3;
+pub const NTLMSSP_NEGOTIATE: u32 = 1;
+pub const NTLMSSP_CHALLENGE: u32 = 2;
+pub const NTLMSSP_AUTH: u32 = 3;
 
 pub fn ntlmssp_type_string(c: u32) -> String {
     match c {
-        NTLMSSP_NEGOTIATE   => "NTLMSSP_NEGOTIATE",
-        NTLMSSP_CHALLENGE   => "NTLMSSP_CHALLENGE",
-        NTLMSSP_AUTH        => "NTLMSSP_AUTH",
-        _ => { return (c).to_string(); },
-    }.to_string()
+        NTLMSSP_NEGOTIATE => "NTLMSSP_NEGOTIATE",
+        NTLMSSP_CHALLENGE => "NTLMSSP_CHALLENGE",
+        NTLMSSP_AUTH => "NTLMSSP_AUTH",
+        _ => {
+            return (c).to_string();
+        }
+    }
+    .to_string()
 }
 
 #[derive(Eq, PartialEq, Debug, Clone)]
@@ -213,7 +233,7 @@ impl SMBVerCmdStat {
             status_is_dos_error: false,
             status_error_class: 0,
             status: 0,
-        }
+        };
     }
     pub fn new1(cmd: u8) -> SMBVerCmdStat {
         return SMBVerCmdStat {
@@ -224,7 +244,7 @@ impl SMBVerCmdStat {
             status_is_dos_error: false,
             status_error_class: 0,
             status: 0,
-        }
+        };
     }
     pub fn new1_with_ntstatus(cmd: u8, status: u32) -> SMBVerCmdStat {
         return SMBVerCmdStat {
@@ -235,7 +255,7 @@ impl SMBVerCmdStat {
             status_is_dos_error: false,
             status_error_class: 0,
             status: status,
-        }
+        };
     }
     pub fn new2(cmd: u16) -> SMBVerCmdStat {
         return SMBVerCmdStat {
@@ -246,7 +266,7 @@ impl SMBVerCmdStat {
             status_is_dos_error: false,
             status_error_class: 0,
             status: 0,
-        }
+        };
     }
 
     pub fn new2_with_ntstatus(cmd: u16, status: u32) -> SMBVerCmdStat {
@@ -258,7 +278,7 @@ impl SMBVerCmdStat {
             status_is_dos_error: false,
             status_error_class: 0,
             status: status,
-        }
+        };
     }
 
     pub fn set_smb1_cmd(&mut self, cmd: u8) -> bool {
@@ -302,11 +322,14 @@ impl SMBVerCmdStat {
     }
 
     pub fn get_dos_error(&self) -> (bool, u8, u16) {
-        (self.status_set && self.status_is_dos_error, self.status_error_class, self.status as u16)
+        (
+            self.status_set && self.status_is_dos_error,
+            self.status_error_class,
+            self.status as u16,
+        )
     }
 
-    fn set_status(&mut self, status: u32, is_dos_error: bool)
-    {
+    fn set_status(&mut self, status: u32, is_dos_error: bool) {
         if is_dos_error {
             self.status_is_dos_error = true;
             self.status_error_class = (status & 0x0000_00ff) as u8;
@@ -317,13 +340,11 @@ impl SMBVerCmdStat {
         self.status_set = true;
     }
 
-    pub fn set_ntstatus(&mut self, status: u32)
-    {
+    pub fn set_ntstatus(&mut self, status: u32) {
         self.set_status(status, false)
     }
 
-    pub fn set_status_dos_error(&mut self, status: u32)
-    {
+    pub fn set_status_dos_error(&mut self, status: u32) {
         self.set_status(status, true)
     }
 }
@@ -333,14 +354,12 @@ impl SMBVerCmdStat {
 /// Coordinated Universal Time (UTC)."
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub struct SMBFiletime {
-    ts: u64, 
+    ts: u64,
 }
 
 impl SMBFiletime {
     pub fn new(raw: u64) -> SMBFiletime {
-        SMBFiletime {
-            ts: raw,
-        }
+        SMBFiletime { ts: raw }
     }
 
     /// inspired by Bro, convert FILETIME to secs since unix epoch
@@ -378,28 +397,43 @@ pub struct SMBTransactionSetFilePathInfo {
 }
 
 impl SMBTransactionSetFilePathInfo {
-    pub fn new(filename: Vec<u8>, fid: Vec<u8>, subcmd: u16, loi: u16, delete_on_close: bool)
-        -> SMBTransactionSetFilePathInfo
-    {
+    pub fn new(
+        filename: Vec<u8>,
+        fid: Vec<u8>,
+        subcmd: u16,
+        loi: u16,
+        delete_on_close: bool,
+    ) -> SMBTransactionSetFilePathInfo {
         return SMBTransactionSetFilePathInfo {
-            filename: filename, fid: fid,
+            filename: filename,
+            fid: fid,
             subcmd: subcmd,
             loi: loi,
             delete_on_close: delete_on_close,
-        }
+        };
     }
 }
 
 impl SMBState {
-    pub fn new_setfileinfo_tx(&mut self, filename: Vec<u8>, fid: Vec<u8>,
-            subcmd: u16, loi: u16, delete_on_close: bool)
-        -> (&mut SMBTransaction)
-    {
+    pub fn new_setfileinfo_tx(
+        &mut self,
+        filename: Vec<u8>,
+        fid: Vec<u8>,
+        subcmd: u16,
+        loi: u16,
+        delete_on_close: bool,
+    ) -> (&mut SMBTransaction) {
         let mut tx = self.new_tx();
 
         tx.type_data = Some(SMBTransactionTypeData::SETFILEPATHINFO(
-                    SMBTransactionSetFilePathInfo::new(
-                        filename, fid, subcmd, loi, delete_on_close)));
+            SMBTransactionSetFilePathInfo::new(
+                filename,
+                fid,
+                subcmd,
+                loi,
+                delete_on_close,
+            ),
+        ));
         tx.request_done = true;
         tx.response_done = self.tc_trunc; // no response expected if tc is truncated
 
@@ -409,16 +443,25 @@ impl SMBState {
         return tx_ref.unwrap();
     }
 
-    pub fn new_setpathinfo_tx(&mut self, filename: Vec<u8>,
-            subcmd: u16, loi: u16, delete_on_close: bool)
-        -> (&mut SMBTransaction)
-    {
+    pub fn new_setpathinfo_tx(
+        &mut self,
+        filename: Vec<u8>,
+        subcmd: u16,
+        loi: u16,
+        delete_on_close: bool,
+    ) -> (&mut SMBTransaction) {
         let mut tx = self.new_tx();
 
-        let fid : Vec<u8> = Vec::new();
+        let fid: Vec<u8> = Vec::new();
         tx.type_data = Some(SMBTransactionTypeData::SETFILEPATHINFO(
-                    SMBTransactionSetFilePathInfo::new(filename, fid,
-                        subcmd, loi, delete_on_close)));
+            SMBTransactionSetFilePathInfo::new(
+                filename,
+                fid,
+                subcmd,
+                loi,
+                delete_on_close,
+            ),
+        ));
         tx.request_done = true;
         tx.response_done = self.tc_trunc; // no response expected if tc is truncated
 
@@ -437,21 +480,31 @@ pub struct SMBTransactionRename {
 }
 
 impl SMBTransactionRename {
-    pub fn new(fuid: Vec<u8>, oldname: Vec<u8>, newname: Vec<u8>) -> SMBTransactionRename {
+    pub fn new(
+        fuid: Vec<u8>,
+        oldname: Vec<u8>,
+        newname: Vec<u8>,
+    ) -> SMBTransactionRename {
         return SMBTransactionRename {
-            fuid: fuid, oldname: oldname, newname: newname,
-        }
+            fuid: fuid,
+            oldname: oldname,
+            newname: newname,
+        };
     }
 }
 
 impl SMBState {
-    pub fn new_rename_tx(&mut self, fuid: Vec<u8>, oldname: Vec<u8>, newname: Vec<u8>)
-        -> (&mut SMBTransaction)
-    {
+    pub fn new_rename_tx(
+        &mut self,
+        fuid: Vec<u8>,
+        oldname: Vec<u8>,
+        newname: Vec<u8>,
+    ) -> (&mut SMBTransaction) {
         let mut tx = self.new_tx();
 
         tx.type_data = Some(SMBTransactionTypeData::RENAME(
-                    SMBTransactionRename::new(fuid, oldname, newname)));
+            SMBTransactionRename::new(fuid, oldname, newname),
+        ));
         tx.request_done = true;
         tx.response_done = self.tc_trunc; // no response expected if tc is truncated
 
@@ -479,7 +532,12 @@ pub struct SMBTransactionCreate {
 }
 
 impl SMBTransactionCreate {
-    pub fn new(filename: Vec<u8>, disp: u32, del: bool, dir: bool) -> SMBTransactionCreate {
+    pub fn new(
+        filename: Vec<u8>,
+        disp: u32,
+        del: bool,
+        dir: bool,
+    ) -> SMBTransactionCreate {
         return SMBTransactionCreate {
             disposition: disp,
             delete_on_close: del,
@@ -491,7 +549,7 @@ impl SMBTransactionCreate {
             last_write_ts: 0,
             last_change_ts: 0,
             size: 0,
-        }
+        };
     }
 }
 
@@ -514,7 +572,7 @@ impl SMBTransactionNegotiate {
             dialects2: Vec::new(),
             client_guid: None,
             server_guid: Vec::with_capacity(16),
-        }
+        };
     }
 }
 
@@ -533,19 +591,20 @@ pub struct SMBTransactionTreeConnect {
 impl SMBTransactionTreeConnect {
     pub fn new(share_name: Vec<u8>) -> SMBTransactionTreeConnect {
         return SMBTransactionTreeConnect {
-            is_pipe:false,
+            is_pipe: false,
             share_type: 0,
-            tree_id:0,
-            share_name:share_name,
+            tree_id: 0,
+            share_name: share_name,
             req_service: None,
             res_service: None,
-        }
+        };
     }
 }
 
 #[derive(Debug)]
 pub struct SMBTransaction {
-    pub id: u64,    /// internal id
+    pub id: u64,
+    /// internal id
 
     /// version, command and status
     pub vercmd: SMBVerCmdStat,
@@ -570,7 +629,7 @@ pub struct SMBTransaction {
 
 impl SMBTransaction {
     pub fn new() -> SMBTransaction {
-        return SMBTransaction{
+        return SMBTransaction {
             id: 0,
             vercmd: SMBVerCmdStat::new(),
             hdr: SMBCommonHdr::init(),
@@ -582,11 +641,10 @@ impl SMBTransaction {
             logged: LoggerFlags::new(),
             de_state: None,
             events: std::ptr::null_mut(),
-        }
+        };
     }
 
-    pub fn set_status(&mut self, status: u32, is_dos_error: bool)
-    {
+    pub fn set_status(&mut self, status: u32, is_dos_error: bool) {
         if is_dos_error {
             self.vercmd.set_status_dos_error(status);
         } else {
@@ -622,24 +680,24 @@ pub struct SMBFileGUIDOffset {
 impl SMBFileGUIDOffset {
     pub fn new(guid: Vec<u8>, offset: u64) -> SMBFileGUIDOffset {
         SMBFileGUIDOffset {
-            guid:guid,
-            offset:offset,
+            guid: guid,
+            offset: offset,
         }
     }
 }
 
 /// type values to make sure we're not mixing things
 /// up in hashmap lookups
-pub const SMBHDR_TYPE_GUID:        u32 = 1;
-pub const SMBHDR_TYPE_SHARE:       u32 = 2;
-pub const SMBHDR_TYPE_FILENAME:    u32 = 3;
-pub const SMBHDR_TYPE_OFFSET:      u32 = 4;
-pub const SMBHDR_TYPE_GENERICTX:   u32 = 5;
-pub const SMBHDR_TYPE_HEADER:      u32 = 6;
-pub const SMBHDR_TYPE_MAX_SIZE:    u32 = 7; // max resp size for SMB1_COMMAND_TRANS
-pub const SMBHDR_TYPE_TRANS_FRAG:  u32 = 8;
-pub const SMBHDR_TYPE_TREE:        u32 = 9;
-pub const SMBHDR_TYPE_DCERPCTX:    u32 = 10;
+pub const SMBHDR_TYPE_GUID: u32 = 1;
+pub const SMBHDR_TYPE_SHARE: u32 = 2;
+pub const SMBHDR_TYPE_FILENAME: u32 = 3;
+pub const SMBHDR_TYPE_OFFSET: u32 = 4;
+pub const SMBHDR_TYPE_GENERICTX: u32 = 5;
+pub const SMBHDR_TYPE_HEADER: u32 = 6;
+pub const SMBHDR_TYPE_MAX_SIZE: u32 = 7; // max resp size for SMB1_COMMAND_TRANS
+pub const SMBHDR_TYPE_TRANS_FRAG: u32 = 8;
+pub const SMBHDR_TYPE_TREE: u32 = 9;
+pub const SMBHDR_TYPE_DCERPCTX: u32 = 10;
 
 #[derive(Hash, Eq, PartialEq, Debug)]
 pub struct SMBCommonHdr {
@@ -652,60 +710,65 @@ pub struct SMBCommonHdr {
 impl SMBCommonHdr {
     pub fn init() -> SMBCommonHdr {
         SMBCommonHdr {
-            rec_type : 0,
-            ssn_id : 0,
-            tree_id : 0,
-            msg_id : 0,
+            rec_type: 0,
+            ssn_id: 0,
+            tree_id: 0,
+            msg_id: 0,
         }
     }
-    pub fn new(rec_type: u32, ssn_id: u64, tree_id: u32, msg_id: u64) -> SMBCommonHdr {
+    pub fn new(
+        rec_type: u32,
+        ssn_id: u64,
+        tree_id: u32,
+        msg_id: u64,
+    ) -> SMBCommonHdr {
         SMBCommonHdr {
-            rec_type : rec_type,
-            ssn_id : ssn_id,
-            tree_id : tree_id,
-            msg_id : msg_id,
+            rec_type: rec_type,
+            ssn_id: ssn_id,
+            tree_id: tree_id,
+            msg_id: msg_id,
         }
     }
     pub fn from2(r: &Smb2Record, rec_type: u32) -> SMBCommonHdr {
         let tree_id = match rec_type {
-            SMBHDR_TYPE_TREE => { 0 },
+            SMBHDR_TYPE_TREE => 0,
             _ => r.tree_id,
         };
         let msg_id = match rec_type {
-            SMBHDR_TYPE_TRANS_FRAG | SMBHDR_TYPE_SHARE => { 0 },
-            _ => { r.message_id as u64 },
+            SMBHDR_TYPE_TRANS_FRAG | SMBHDR_TYPE_SHARE => 0,
+            _ => r.message_id as u64,
         };
 
         SMBCommonHdr {
-            rec_type : rec_type,
-            ssn_id : r.session_id,
-            tree_id : tree_id,
-            msg_id : msg_id,
+            rec_type: rec_type,
+            ssn_id: r.session_id,
+            tree_id: tree_id,
+            msg_id: msg_id,
         }
-
     }
     pub fn from1(r: &SmbRecord, rec_type: u32) -> SMBCommonHdr {
         let tree_id = match rec_type {
-            SMBHDR_TYPE_TREE => { 0 },
+            SMBHDR_TYPE_TREE => 0,
             _ => r.tree_id as u32,
         };
         let msg_id = match rec_type {
-            SMBHDR_TYPE_TRANS_FRAG | SMBHDR_TYPE_SHARE => { 0 },
-            _ => { r.multiplex_id as u64 },
+            SMBHDR_TYPE_TRANS_FRAG | SMBHDR_TYPE_SHARE => 0,
+            _ => r.multiplex_id as u64,
         };
 
         SMBCommonHdr {
-            rec_type : rec_type,
-            ssn_id : r.ssn_id as u64,
-            tree_id : tree_id,
-            msg_id : msg_id,
+            rec_type: rec_type,
+            ssn_id: r.ssn_id as u64,
+            tree_id: tree_id,
+            msg_id: msg_id,
         }
     }
 
     // don't include tree id
     pub fn compare(&self, hdr: &SMBCommonHdr) -> bool {
-        (self.rec_type == hdr.rec_type && self.ssn_id == hdr.ssn_id &&
-         self.msg_id == hdr.msg_id)
+        (self.rec_type == hdr.rec_type
+            && self.ssn_id == hdr.ssn_id
+            && self.msg_id == hdr.msg_id)
     }
 }
 
@@ -718,7 +781,8 @@ pub struct SMBHashKeyHdrGuid {
 impl SMBHashKeyHdrGuid {
     pub fn new(hdr: SMBCommonHdr, guid: Vec<u8>) -> SMBHashKeyHdrGuid {
         SMBHashKeyHdrGuid {
-            hdr: hdr, guid: guid,
+            hdr: hdr,
+            guid: guid,
         }
     }
 }
@@ -732,21 +796,21 @@ pub struct SMBTree {
 impl SMBTree {
     pub fn new(name: Vec<u8>, is_pipe: bool) -> SMBTree {
         SMBTree {
-            name:name,
-            is_pipe:is_pipe,
+            name: name,
+            is_pipe: is_pipe,
         }
     }
 }
 
-pub fn u32_as_bytes(i: u32) -> [u8;4] {
+pub fn u32_as_bytes(i: u32) -> [u8; 4] {
     let o1: u8 = ((i >> 24) & 0xff) as u8;
     let o2: u8 = ((i >> 16) & 0xff) as u8;
-    let o3: u8 = ((i >> 8)  & 0xff) as u8;
-    let o4: u8 =  (i        & 0xff) as u8;
-    return [o1, o2, o3, o4]
+    let o3: u8 = ((i >> 8) & 0xff) as u8;
+    let o4: u8 = (i & 0xff) as u8;
+    return [o1, o2, o3, o4];
 }
 
-pub struct SMBState<> {
+pub struct SMBState {
     /// map ssn/tree/msgid to vec (guid/name/share)
     pub ssn2vec_map: HashMap<SMBCommonHdr, Vec<u8>>,
     /// map guid to filename
@@ -769,10 +833,10 @@ pub struct SMBState<> {
     skip_ts: u32,
     skip_tc: u32,
 
-    pub file_ts_left : u32,
-    pub file_tc_left : u32,
-    pub file_ts_guid : Vec<u8>,
-    pub file_tc_guid : Vec<u8>,
+    pub file_ts_left: u32,
+    pub file_tc_left: u32,
+    pub file_ts_guid: Vec<u8>,
+    pub file_tc_guid: Vec<u8>,
 
     pub ts_ssn_gap: bool,
     pub tc_ssn_gap: bool,
@@ -803,20 +867,20 @@ impl SMBState {
     /// Allocation function for a new TLS parser instance
     pub fn new() -> SMBState {
         SMBState {
-            ssn2vec_map:HashMap::new(),
-            guid2name_map:HashMap::new(),
-            ssn2vecoffset_map:HashMap::new(),
-            ssn2tree_map:HashMap::new(),
-            ssnguid2vec_map:HashMap::new(),
-            tcp_buffer_ts:Vec::new(),
-            tcp_buffer_tc:Vec::new(),
+            ssn2vec_map: HashMap::new(),
+            guid2name_map: HashMap::new(),
+            ssn2vecoffset_map: HashMap::new(),
+            ssn2tree_map: HashMap::new(),
+            ssnguid2vec_map: HashMap::new(),
+            tcp_buffer_ts: Vec::new(),
+            tcp_buffer_tc: Vec::new(),
             files: SMBFiles::new(),
-            skip_ts:0,
-            skip_tc:0,
-            file_ts_left:0,
-            file_tc_left:0,
-            file_ts_guid:Vec::new(),
-            file_tc_guid:Vec::new(),
+            skip_ts: 0,
+            skip_tc: 0,
+            file_ts_left: 0,
+            file_tc_left: 0,
+            file_ts_guid: Vec::new(),
+            file_tc_guid: Vec::new(),
             ts_ssn_gap: false,
             tc_ssn_gap: false,
             ts_gap: false,
@@ -824,8 +888,8 @@ impl SMBState {
             ts_trunc: false,
             tc_trunc: false,
             transactions: Vec::new(),
-            tx_id:0,
-            dialect:0,
+            tx_id: 0,
+            dialect: 0,
             dialect_vec: None,
             dcerpc_ifaces: None,
         }
@@ -846,7 +910,7 @@ impl SMBState {
     }
 
     pub fn free_tx(&mut self, tx_id: u64) {
-        SCLogDebug!("Freeing TX with ID {} TX.ID {}", tx_id, tx_id+1);
+        SCLogDebug!("Freeing TX with ID {} TX.ID {}", tx_id, tx_id + 1);
         let len = self.transactions.len();
         let mut found = false;
         let mut index = 0;
@@ -855,7 +919,12 @@ impl SMBState {
             if tx.id == tx_id + 1 {
                 found = true;
                 index = i;
-                SCLogDebug!("tx {} progress {}/{}", tx.id, tx.request_done, tx.response_done);
+                SCLogDebug!(
+                    "tx {} progress {}/{}",
+                    tx.id,
+                    tx.request_done,
+                    tx.response_done
+                );
                 break;
             }
         }
@@ -867,9 +936,11 @@ impl SMBState {
     }
 
     // for use with the C API call StateGetTxIterator
-    pub fn get_tx_iterator(&mut self, min_tx_id: u64, state: &mut u64) ->
-        Option<(&SMBTransaction, u64, bool)>
-    {
+    pub fn get_tx_iterator(
+        &mut self,
+        min_tx_id: u64,
+        state: &mut u64,
+    ) -> Option<(&SMBTransaction, u64, bool)> {
         let mut index = *state as usize;
         let len = self.transactions.len();
 
@@ -892,13 +963,13 @@ impl SMBState {
     }
 
     pub fn get_tx_by_id(&mut self, tx_id: u64) -> Option<&SMBTransaction> {
-/*
-        if self.transactions.len() > 100 {
-            SCLogNotice!("get_tx_by_id: tx_id={} in list={}", tx_id, self.transactions.len());
-            self._dump_txs();
-            panic!("txs exploded");
-        }
-*/
+        /*
+                if self.transactions.len() > 100 {
+                    SCLogNotice!("get_tx_by_id: tx_id={} in list={}", tx_id, self.transactions.len());
+                    self._dump_txs();
+                    panic!("txs exploded");
+                }
+        */
         for tx in &mut self.transactions {
             if tx.id == tx_id + 1 {
                 let ver = tx.vercmd.get_version();
@@ -922,9 +993,12 @@ impl SMBState {
     /* generic TX has no type_data and is only used to
      * track a single cmd request/reply pair. */
 
-    pub fn new_generic_tx(&mut self, smb_ver: u8, smb_cmd: u16, key: SMBCommonHdr)
-        -> (&mut SMBTransaction)
-    {
+    pub fn new_generic_tx(
+        &mut self,
+        smb_ver: u8,
+        smb_cmd: u16,
+        key: SMBCommonHdr,
+    ) -> (&mut SMBTransaction) {
         let mut tx = self.new_tx();
         if smb_ver == 1 && smb_cmd <= 255 {
             tx.vercmd.set_smb1_cmd(smb_cmd as u8);
@@ -937,16 +1011,22 @@ impl SMBState {
         tx.response_done = self.tc_trunc; // no response expected if tc is truncated
         tx.hdr = key;
 
-        SCLogDebug!("SMB: TX GENERIC created: ID {} tx list {} {:?}",
-                tx.id, self.transactions.len(), &tx);
+        SCLogDebug!(
+            "SMB: TX GENERIC created: ID {} tx list {} {:?}",
+            tx.id,
+            self.transactions.len(),
+            &tx
+        );
         self.transactions.push(tx);
         let tx_ref = self.transactions.last_mut();
         return tx_ref.unwrap();
     }
 
-    pub fn get_last_tx(&mut self, smb_ver: u8, smb_cmd: u16)
-        -> Option<&mut SMBTransaction>
-    {
+    pub fn get_last_tx(
+        &mut self,
+        smb_ver: u8,
+        smb_cmd: u16,
+    ) -> Option<&mut SMBTransaction> {
         let tx_ref = self.transactions.last_mut();
         match tx_ref {
             Some(tx) => {
@@ -966,15 +1046,18 @@ impl SMBState {
                 if found {
                     return Some(tx);
                 }
-            },
-            None => { },
+            }
+            None => {}
         }
         return None;
     }
 
-    pub fn get_generic_tx(&mut self, smb_ver: u8, smb_cmd: u16, key: &SMBCommonHdr)
-        -> Option<&mut SMBTransaction>
-    {
+    pub fn get_generic_tx(
+        &mut self,
+        smb_ver: u8,
+        smb_cmd: u16,
+        key: &SMBCommonHdr,
+    ) -> Option<&mut SMBTransaction> {
         for tx in &mut self.transactions {
             let found = if tx.vercmd.get_version() == smb_ver {
                 if smb_ver == 1 {
@@ -996,9 +1079,7 @@ impl SMBState {
         return None;
     }
 
-    pub fn new_negotiate_tx(&mut self, smb_ver: u8)
-        -> (&mut SMBTransaction)
-    {
+    pub fn new_negotiate_tx(&mut self, smb_ver: u8) -> (&mut SMBTransaction) {
         let mut tx = self.new_tx();
         if smb_ver == 1 {
             tx.vercmd.set_smb1_cmd(SMB1_COMMAND_NEGOTIATE_PROTOCOL);
@@ -1007,19 +1088,25 @@ impl SMBState {
         }
 
         tx.type_data = Some(SMBTransactionTypeData::NEGOTIATE(
-                    SMBTransactionNegotiate::new(smb_ver)));
+            SMBTransactionNegotiate::new(smb_ver),
+        ));
         tx.request_done = true;
         tx.response_done = self.tc_trunc; // no response expected if tc is truncated
 
-        SCLogDebug!("SMB: TX NEGOTIATE created: ID {} SMB ver {}", tx.id, smb_ver);
+        SCLogDebug!(
+            "SMB: TX NEGOTIATE created: ID {} SMB ver {}",
+            tx.id,
+            smb_ver
+        );
         self.transactions.push(tx);
         let tx_ref = self.transactions.last_mut();
         return tx_ref.unwrap();
     }
 
-    pub fn get_negotiate_tx(&mut self, smb_ver: u8)
-        -> Option<&mut SMBTransaction>
-    {
+    pub fn get_negotiate_tx(
+        &mut self,
+        smb_ver: u8,
+    ) -> Option<&mut SMBTransaction> {
         for tx in &mut self.transactions {
             let found = match tx.type_data {
                 Some(SMBTransactionTypeData::NEGOTIATE(ref x)) => {
@@ -1028,8 +1115,8 @@ impl SMBState {
                     } else {
                         false
                     }
-                },
-                _ => { false },
+                }
+                _ => false,
             };
             if found {
                 return Some(tx);
@@ -1038,32 +1125,40 @@ impl SMBState {
         return None;
     }
 
-    pub fn new_treeconnect_tx(&mut self, hdr: SMBCommonHdr, name: Vec<u8>)
-        -> (&mut SMBTransaction)
-    {
+    pub fn new_treeconnect_tx(
+        &mut self,
+        hdr: SMBCommonHdr,
+        name: Vec<u8>,
+    ) -> (&mut SMBTransaction) {
         let mut tx = self.new_tx();
 
         tx.hdr = hdr;
         tx.type_data = Some(SMBTransactionTypeData::TREECONNECT(
-                    SMBTransactionTreeConnect::new(name.to_vec())));
+            SMBTransactionTreeConnect::new(name.to_vec()),
+        ));
         tx.request_done = true;
         tx.response_done = self.tc_trunc; // no response expected if tc is truncated
 
-        SCLogDebug!("SMB: TX TREECONNECT created: ID {} NAME {}",
-                tx.id, String::from_utf8_lossy(&name));
+        SCLogDebug!(
+            "SMB: TX TREECONNECT created: ID {} NAME {}",
+            tx.id,
+            String::from_utf8_lossy(&name)
+        );
         self.transactions.push(tx);
         let tx_ref = self.transactions.last_mut();
         return tx_ref.unwrap();
     }
 
-    pub fn get_treeconnect_tx(&mut self, hdr: SMBCommonHdr)
-        -> Option<&mut SMBTransaction>
-    {
+    pub fn get_treeconnect_tx(
+        &mut self,
+        hdr: SMBCommonHdr,
+    ) -> Option<&mut SMBTransaction> {
         for tx in &mut self.transactions {
-            let hit = tx.hdr.compare(&hdr) && match tx.type_data {
-                Some(SMBTransactionTypeData::TREECONNECT(_)) => { true },
-                _ => { false },
-            };
+            let hit = tx.hdr.compare(&hdr)
+                && match tx.type_data {
+                    Some(SMBTransactionTypeData::TREECONNECT(_)) => true,
+                    _ => false,
+                };
             if hit {
                 return Some(tx);
             }
@@ -1071,17 +1166,23 @@ impl SMBState {
         return None;
     }
 
-    pub fn new_create_tx(&mut self, file_name: &Vec<u8>,
-            disposition: u32, del: bool, dir: bool,
-            hdr: SMBCommonHdr)
-        -> &mut SMBTransaction
-    {
+    pub fn new_create_tx(
+        &mut self,
+        file_name: &Vec<u8>,
+        disposition: u32,
+        del: bool,
+        dir: bool,
+        hdr: SMBCommonHdr,
+    ) -> &mut SMBTransaction {
         let mut tx = self.new_tx();
         tx.hdr = hdr;
-        tx.type_data = Some(SMBTransactionTypeData::CREATE(
-                            SMBTransactionCreate::new(
-                                file_name.to_vec(), disposition,
-                                del, dir)));
+        tx.type_data =
+            Some(SMBTransactionTypeData::CREATE(SMBTransactionCreate::new(
+                file_name.to_vec(),
+                disposition,
+                del,
+                dir,
+            )));
         tx.request_done = true;
         tx.response_done = self.tc_trunc; // no response expected if tc is truncated
 
@@ -1090,15 +1191,16 @@ impl SMBState {
         return tx_ref.unwrap();
     }
 
-    pub fn get_create_tx_by_hdr(&mut self, hdr: &SMBCommonHdr)
-        -> Option<&mut SMBTransaction>
-    {
+    pub fn get_create_tx_by_hdr(
+        &mut self,
+        hdr: &SMBCommonHdr,
+    ) -> Option<&mut SMBTransaction> {
         for tx in &mut self.transactions {
             let found = match tx.type_data {
                 Some(SMBTransactionTypeData::CREATE(ref _d)) => {
                     tx.hdr.compare(&hdr)
-                },
-                _ => { false },
+                }
+                _ => false,
             };
 
             if found {
@@ -1110,8 +1212,7 @@ impl SMBState {
         return None;
     }
 
-    pub fn get_service_for_guid(&self, guid: &[u8]) -> (&'static str, bool)
-    {
+    pub fn get_service_for_guid(&self, guid: &[u8]) -> (&'static str, bool) {
         let (name, is_dcerpc) = match self.guid2name_map.get(&guid.to_vec()) {
             Some(n) => {
                 let mut s = n.as_slice();
@@ -1130,12 +1231,15 @@ impl SMBState {
                     Ok("suricata::dcerpc") => ("unknown", true),
                     Err(_) => ("MALFORMED", false),
                     Ok(&_) => {
-                        SCLogDebug!("don't know {}", String::from_utf8_lossy(&n));
+                        SCLogDebug!(
+                            "don't know {}",
+                            String::from_utf8_lossy(&n)
+                        );
                         ("UNKNOWN", false)
-                    },
+                    }
                 }
-            },
-            _ => { ("UNKNOWN", false) },
+            }
+            _ => ("UNKNOWN", false),
         };
         SCLogDebug!("service {} is_dcerpc {}", name, is_dcerpc);
         (&name, is_dcerpc)
@@ -1145,17 +1249,18 @@ impl SMBState {
      * we've caught up. The check is to see if we have the last
      * tx in our list is done. This means we've seen both sides
      * and we're back in sync. Mark older txs as 'done' */
-    fn check_gap_resync(&mut self, prior_max_id: u64)
-    {
-        SCLogDebug!("check_gap_resync2: post-GAP resync check ({}/{})", self.ts_ssn_gap, self.tc_ssn_gap);
+    fn check_gap_resync(&mut self, prior_max_id: u64) {
+        SCLogDebug!(
+            "check_gap_resync2: post-GAP resync check ({}/{})",
+            self.ts_ssn_gap,
+            self.tc_ssn_gap
+        );
         if !self.ts_ssn_gap && !self.tc_ssn_gap {
             return;
         }
 
         let (last_done, id) = match self.transactions.last() {
-            Some(tx) => {
-                (tx.request_done && tx.response_done, tx.id)
-            },
+            Some(tx) => (tx.request_done && tx.response_done, tx.id),
             None => (false, 0),
         };
         if last_done && id > 0 {
@@ -1184,8 +1289,13 @@ impl SMBState {
         }
     }
 
-    pub fn set_file_left(&mut self, direction: u8, rec_size: u32, data_size: u32, fuid: Vec<u8>)
-    {
+    pub fn set_file_left(
+        &mut self,
+        direction: u8,
+        rec_size: u32,
+        data_size: u32,
+        fuid: Vec<u8>,
+    ) {
         let left = rec_size.saturating_sub(data_size);
         if direction == STREAM_TOSERVER {
             self.file_ts_left = left;
@@ -1196,8 +1306,7 @@ impl SMBState {
         }
     }
 
-    pub fn set_skip(&mut self, direction: u8, rec_size: u32, data_size: u32)
-    {
+    pub fn set_skip(&mut self, direction: u8, rec_size: u32, data_size: u32) {
         let skip = rec_size.saturating_sub(data_size);
         if direction == STREAM_TOSERVER {
             self.skip_ts = skip;
@@ -1214,7 +1323,7 @@ impl SMBState {
             self.skip_tc
         };
         if skip_left == 0 {
-            return 0
+            return 0;
         }
         SCLogDebug!("skip_left {} input_size {}", skip_left, input_size);
 
@@ -1239,8 +1348,7 @@ impl SMBState {
     }
 
     /// return bytes consumed
-    pub fn parse_tcp_data_ts_partial<'b>(&mut self, input: &'b[u8]) -> usize
-    {
+    pub fn parse_tcp_data_ts_partial<'b>(&mut self, input: &'b [u8]) -> usize {
         SCLogDebug!("incomplete of size {}", input.len());
         if input.len() < 512 {
             // check for malformed data. Wireshark reports as
@@ -1254,8 +1362,8 @@ impl SMBState {
                             self.trunc_ts();
                             return 0;
                         }
-                    },
-                    _ => {},
+                    }
+                    _ => {}
                 }
             }
             return 0;
@@ -1263,21 +1371,33 @@ impl SMBState {
 
         match parse_nbss_record_partial(input) {
             IResult::Done(output, ref nbss_part_hdr) => {
-                SCLogDebug!("parse_nbss_record_partial ok, output len {}", output.len());
+                SCLogDebug!(
+                    "parse_nbss_record_partial ok, output len {}",
+                    output.len()
+                );
                 if nbss_part_hdr.message_type == NBSS_MSGTYPE_SESSION_MESSAGE {
                     match parse_smb_version(&nbss_part_hdr.data) {
                         IResult::Done(_, ref smb) => {
                             SCLogDebug!("SMB {:?}", smb);
-                            if smb.version == 0xff_u8 { // SMB1
+                            if smb.version == 0xff_u8 {
+                                // SMB1
                                 SCLogDebug!("SMBv1 record");
                                 match parse_smb_record(&nbss_part_hdr.data) {
                                     IResult::Done(_, ref r) => {
-                                        if r.command == SMB1_COMMAND_WRITE_ANDX {
+                                        if r.command == SMB1_COMMAND_WRITE_ANDX
+                                        {
                                             // see if it's a write to a pipe. We only handle those
                                             // if complete.
-                                            let tree_key = SMBCommonHdr::new(SMBHDR_TYPE_SHARE,
-                                                    r.ssn_id as u64, r.tree_id as u32, 0);
-                                            let is_pipe = match self.ssn2tree_map.get(&tree_key) {
+                                            let tree_key = SMBCommonHdr::new(
+                                                SMBHDR_TYPE_SHARE,
+                                                r.ssn_id as u64,
+                                                r.tree_id as u32,
+                                                0,
+                                            );
+                                            let is_pipe = match self
+                                                .ssn2tree_map
+                                                .get(&tree_key)
+                                            {
                                                 Some(n) => n.is_pipe,
                                                 None => false,
                                             };
@@ -1285,46 +1405,57 @@ impl SMBState {
                                                 return 0;
                                             }
                                             smb1_write_request_record(self, r);
-                                            let consumed = input.len() - output.len();
+                                            let consumed =
+                                                input.len() - output.len();
                                             return consumed;
                                         }
-                                    },
-                                    _ => { },
-
+                                    }
+                                    _ => {}
                                 }
-                            } else if smb.version == 0xfe_u8 { // SMB2
+                            } else if smb.version == 0xfe_u8 {
+                                // SMB2
                                 SCLogDebug!("SMBv2 record");
-                                match parse_smb2_request_record(&nbss_part_hdr.data) {
+                                match parse_smb2_request_record(
+                                    &nbss_part_hdr.data,
+                                ) {
                                     IResult::Done(_, ref smb_record) => {
-                                        SCLogDebug!("SMB2: partial record {}",
-                                                &smb2_command_string(smb_record.command));
-                                        if smb_record.command == SMB2_COMMAND_WRITE {
-                                            smb2_write_request_record(self, smb_record);
-                                            let consumed = input.len() - output.len();
+                                        SCLogDebug!(
+                                            "SMB2: partial record {}",
+                                            &smb2_command_string(
+                                                smb_record.command
+                                            )
+                                        );
+                                        if smb_record.command
+                                            == SMB2_COMMAND_WRITE
+                                        {
+                                            smb2_write_request_record(
+                                                self, smb_record,
+                                            );
+                                            let consumed =
+                                                input.len() - output.len();
                                             return consumed;
                                         }
-                                    },
-                                    _ => { },
+                                    }
+                                    _ => {}
                                 }
                             }
                             // no SMB3 here yet, will buffer full records
-                        },
-                        _ => { },
+                        }
+                        _ => {}
                     }
                 }
-            },
-            _ => { },
+            }
+            _ => {}
         }
 
         return 0;
     }
 
     /// Parsing function, handling TCP chunks fragmentation
-    pub fn parse_tcp_data_ts<'b>(&mut self, i: &'b[u8]) -> u32
-    {
+    pub fn parse_tcp_data_ts<'b>(&mut self, i: &'b [u8]) -> u32 {
         let max_tx_id = self.tx_id;
 
-        let mut v : Vec<u8>;
+        let mut v: Vec<u8>;
         //println!("parse_tcp_data_ts ({})",i.len());
         //println!("{:?}",i);
         // Check if TCP data is being defragmented
@@ -1338,7 +1469,7 @@ impl SMBState {
                 };
                 v.extend_from_slice(i);
                 v.as_slice()
-            },
+            }
         };
         //println!("tcp_buffer ({})",tcp_buffer.len());
         let mut cur_i = tcp_buffer;
@@ -1366,7 +1497,10 @@ impl SMBState {
         }
         // gap
         if self.ts_gap {
-            SCLogDebug!("TS trying to catch up after GAP (input {})", cur_i.len());
+            SCLogDebug!(
+                "TS trying to catch up after GAP (input {})",
+                cur_i.len()
+            );
             match search_smb_record(cur_i) {
                 IResult::Done(_, pg) => {
                     SCLogDebug!("smb record found");
@@ -1378,15 +1512,16 @@ impl SMBState {
                     cur_i = &cur_i[nbss_offset..];
 
                     self.ts_gap = false;
-                },
+                }
                 _ => {
                     SCLogDebug!("smb record NOT found");
                     self.tcp_buffer_ts.extend_from_slice(cur_i);
                     return 0;
-                },
+                }
             }
         }
-        while cur_i.len() > 0 { // min record size
+        while cur_i.len() > 0 {
+            // min record size
             match parse_nbss_record(cur_i) {
                 IResult::Done(rem, ref nbss_hdr) => {
                     if nbss_hdr.message_type == NBSS_MSGTYPE_SESSION_MESSAGE {
@@ -1395,81 +1530,106 @@ impl SMBState {
                         match parse_smb_version(&nbss_hdr.data) {
                             IResult::Done(_, ref smb) => {
                                 SCLogDebug!("SMB {:?}", smb);
-                                if smb.version == 0xff_u8 { // SMB1
+                                if smb.version == 0xff_u8 {
+                                    // SMB1
                                     SCLogDebug!("SMBv1 record");
                                     match parse_smb_record(&nbss_hdr.data) {
                                         IResult::Done(_, ref smb_record) => {
-                                            smb1_request_record(self, smb_record);
-                                        },
+                                            smb1_request_record(
+                                                self, smb_record,
+                                            );
+                                        }
                                         _ => {
-                                            self.set_event(SMBEvent::MalformedData);
+                                            self.set_event(
+                                                SMBEvent::MalformedData,
+                                            );
                                             return 1;
-                                        },
+                                        }
                                     }
-                                } else if smb.version == 0xfe_u8 { // SMB2
+                                } else if smb.version == 0xfe_u8 {
+                                    // SMB2
                                     let mut nbss_data = nbss_hdr.data;
                                     while nbss_data.len() > 0 {
                                         SCLogDebug!("SMBv2 record");
-                                        match parse_smb2_request_record(&nbss_data) {
-                                            IResult::Done(nbss_data_rem, ref smb_record) => {
-                                                SCLogDebug!("nbss_data_rem {}", nbss_data_rem.len());
+                                        match parse_smb2_request_record(
+                                            &nbss_data,
+                                        ) {
+                                            IResult::Done(
+                                                nbss_data_rem,
+                                                ref smb_record,
+                                            ) => {
+                                                SCLogDebug!(
+                                                    "nbss_data_rem {}",
+                                                    nbss_data_rem.len()
+                                                );
 
-                                                smb2_request_record(self, smb_record);
+                                                smb2_request_record(
+                                                    self, smb_record,
+                                                );
                                                 nbss_data = nbss_data_rem;
-                                            },
+                                            }
                                             _ => {
-                                                self.set_event(SMBEvent::MalformedData);
+                                                self.set_event(
+                                                    SMBEvent::MalformedData,
+                                                );
                                                 return 1;
-                                            },
+                                            }
                                         }
                                     }
-                                } else if smb.version == 0xfd_u8 { // SMB3 transform
+                                } else if smb.version == 0xfd_u8 {
+                                    // SMB3 transform
                                     let mut nbss_data = nbss_hdr.data;
                                     while nbss_data.len() > 0 {
                                         SCLogDebug!("SMBv3 transform record");
-                                        match parse_smb3_transform_record(&nbss_data) {
-                                            IResult::Done(nbss_data_rem, ref _smb3_record) => {
+                                        match parse_smb3_transform_record(
+                                            &nbss_data,
+                                        ) {
+                                            IResult::Done(
+                                                nbss_data_rem,
+                                                ref _smb3_record,
+                                            ) => {
                                                 nbss_data = nbss_data_rem;
-                                            },
+                                            }
                                             _ => {
-                                                self.set_event(SMBEvent::MalformedData);
+                                                self.set_event(
+                                                    SMBEvent::MalformedData,
+                                                );
                                                 return 1;
-                                            },
+                                            }
                                         }
                                     }
                                 }
-                            },
+                            }
                             _ => {
                                 self.set_event(SMBEvent::MalformedData);
                                 return 1;
-                            },
+                            }
                         }
                     } else {
                         SCLogDebug!("NBSS message {:X}", nbss_hdr.message_type);
                     }
                     cur_i = rem;
-                },
+                }
                 IResult::Incomplete(_) => {
                     let consumed = self.parse_tcp_data_ts_partial(cur_i);
-                    cur_i = &cur_i[consumed ..];
+                    cur_i = &cur_i[consumed..];
 
                     self.tcp_buffer_ts.extend_from_slice(cur_i);
                     break;
-                },
+                }
                 IResult::Error(_) => {
                     self.set_event(SMBEvent::MalformedData);
                     return 1;
-                },
+                }
             }
-        };
+        }
 
         self.check_gap_resync(max_tx_id);
         0
     }
 
     /// return bytes consumed
-    pub fn parse_tcp_data_tc_partial<'b>(&mut self, input: &'b[u8]) -> usize
-    {
+    pub fn parse_tcp_data_tc_partial<'b>(&mut self, input: &'b [u8]) -> usize {
         SCLogDebug!("incomplete of size {}", input.len());
         if input.len() < 512 {
             // check for malformed data. Wireshark reports as
@@ -1483,8 +1643,8 @@ impl SMBState {
                             self.trunc_tc();
                             return 0;
                         }
-                    },
-                    _ => {},
+                    }
+                    _ => {}
                 }
             }
             return 0;
@@ -1492,21 +1652,34 @@ impl SMBState {
 
         match parse_nbss_record_partial(input) {
             IResult::Done(output, ref nbss_part_hdr) => {
-                SCLogDebug!("parse_nbss_record_partial ok, output len {}", output.len());
+                SCLogDebug!(
+                    "parse_nbss_record_partial ok, output len {}",
+                    output.len()
+                );
                 if nbss_part_hdr.message_type == NBSS_MSGTYPE_SESSION_MESSAGE {
                     match parse_smb_version(&nbss_part_hdr.data) {
                         IResult::Done(_, ref smb) => {
                             SCLogDebug!("SMB {:?}", smb);
-                            if smb.version == 255u8 { // SMB1
+                            if smb.version == 255u8 {
+                                // SMB1
                                 SCLogDebug!("SMBv1 record");
                                 match parse_smb_record(&nbss_part_hdr.data) {
                                     IResult::Done(_, ref r) => {
-                                        SCLogDebug!("SMB1: partial record {}",
-                                                r.command);
+                                        SCLogDebug!(
+                                            "SMB1: partial record {}",
+                                            r.command
+                                        );
                                         if r.command == SMB1_COMMAND_READ_ANDX {
-                                            let tree_key = SMBCommonHdr::new(SMBHDR_TYPE_SHARE,
-                                                    r.ssn_id as u64, r.tree_id as u32, 0);
-                                            let is_pipe = match self.ssn2tree_map.get(&tree_key) {
+                                            let tree_key = SMBCommonHdr::new(
+                                                SMBHDR_TYPE_SHARE,
+                                                r.ssn_id as u64,
+                                                r.tree_id as u32,
+                                                0,
+                                            );
+                                            let is_pipe = match self
+                                                .ssn2tree_map
+                                                .get(&tree_key)
+                                            {
                                                 Some(n) => n.is_pipe,
                                                 None => false,
                                             };
@@ -1514,45 +1687,57 @@ impl SMBState {
                                                 return 0;
                                             }
                                             smb1_read_response_record(self, r);
-                                            let consumed = input.len() - output.len();
+                                            let consumed =
+                                                input.len() - output.len();
                                             return consumed;
                                         }
-                                    },
-                                    _ => { },
+                                    }
+                                    _ => {}
                                 }
-                            } else if smb.version == 254u8 { // SMB2
+                            } else if smb.version == 254u8 {
+                                // SMB2
                                 SCLogDebug!("SMBv2 record");
-                                match parse_smb2_response_record(&nbss_part_hdr.data) {
+                                match parse_smb2_response_record(
+                                    &nbss_part_hdr.data,
+                                ) {
                                     IResult::Done(_, ref smb_record) => {
-                                        SCLogDebug!("SMB2: partial record {}",
-                                                &smb2_command_string(smb_record.command));
-                                        if smb_record.command == SMB2_COMMAND_READ {
-                                            smb2_read_response_record(self, smb_record);
-                                            let consumed = input.len() - output.len();
+                                        SCLogDebug!(
+                                            "SMB2: partial record {}",
+                                            &smb2_command_string(
+                                                smb_record.command
+                                            )
+                                        );
+                                        if smb_record.command
+                                            == SMB2_COMMAND_READ
+                                        {
+                                            smb2_read_response_record(
+                                                self, smb_record,
+                                            );
+                                            let consumed =
+                                                input.len() - output.len();
                                             return consumed;
                                         }
-                                    },
-                                    _ => { },
+                                    }
+                                    _ => {}
                                 }
                             }
                             // no SMB3 here yet, will buffer full records
-                        },
-                        _ => { },
+                        }
+                        _ => {}
                     }
                 }
-            },
-            _ => { },
+            }
+            _ => {}
         }
 
         return 0;
     }
 
     /// Parsing function, handling TCP chunks fragmentation
-    pub fn parse_tcp_data_tc<'b>(&mut self, i: &'b[u8]) -> u32
-    {
+    pub fn parse_tcp_data_tc<'b>(&mut self, i: &'b [u8]) -> u32 {
         let max_tx_id = self.tx_id;
 
-        let mut v : Vec<u8>;
+        let mut v: Vec<u8>;
         // Check if TCP data is being defragmented
         let tcp_buffer = match self.tcp_buffer_tc.len() {
             0 => i,
@@ -1564,7 +1749,7 @@ impl SMBState {
                 };
                 v.extend_from_slice(i);
                 v.as_slice()
-            },
+            }
         };
         let mut cur_i = tcp_buffer;
         SCLogDebug!("cur_i.len {}", cur_i.len());
@@ -1592,7 +1777,10 @@ impl SMBState {
         }
         // gap
         if self.tc_gap {
-            SCLogDebug!("TC trying to catch up after GAP (input {})", cur_i.len());
+            SCLogDebug!(
+                "TC trying to catch up after GAP (input {})",
+                cur_i.len()
+            );
             match search_smb_record(cur_i) {
                 IResult::Done(_, pg) => {
                     SCLogDebug!("smb record found");
@@ -1604,15 +1792,16 @@ impl SMBState {
                     cur_i = &cur_i[nbss_offset..];
 
                     self.tc_gap = false;
-                },
+                }
                 _ => {
                     SCLogDebug!("smb record NOT found");
                     self.tcp_buffer_tc.extend_from_slice(cur_i);
                     return 0;
-                },
+                }
             }
         }
-        while cur_i.len() > 0 { // min record size
+        while cur_i.len() > 0 {
+            // min record size
             match parse_nbss_record(cur_i) {
                 IResult::Done(rem, ref nbss_hdr) => {
                     if nbss_hdr.message_type == NBSS_MSGTYPE_SESSION_MESSAGE {
@@ -1621,77 +1810,104 @@ impl SMBState {
                         match parse_smb_version(&nbss_hdr.data) {
                             IResult::Done(_, ref smb) => {
                                 SCLogDebug!("SMB {:?}", smb);
-                                if smb.version == 0xff_u8 { // SMB1
+                                if smb.version == 0xff_u8 {
+                                    // SMB1
                                     SCLogDebug!("SMBv1 record");
                                     match parse_smb_record(&nbss_hdr.data) {
                                         IResult::Done(_, ref smb_record) => {
-                                            smb1_response_record(self, smb_record);
-                                        },
+                                            smb1_response_record(
+                                                self, smb_record,
+                                            );
+                                        }
                                         _ => {
-                                            self.set_event(SMBEvent::MalformedData);
+                                            self.set_event(
+                                                SMBEvent::MalformedData,
+                                            );
                                             return 1;
-                                        },
+                                        }
                                     }
-                                } else if smb.version == 0xfe_u8 { // SMB2
+                                } else if smb.version == 0xfe_u8 {
+                                    // SMB2
                                     let mut nbss_data = nbss_hdr.data;
                                     while nbss_data.len() > 0 {
                                         SCLogDebug!("SMBv2 record");
-                                        match parse_smb2_response_record(&nbss_data) {
-                                            IResult::Done(nbss_data_rem, ref smb_record) => {
-                                                smb2_response_record(self, smb_record);
+                                        match parse_smb2_response_record(
+                                            &nbss_data,
+                                        ) {
+                                            IResult::Done(
+                                                nbss_data_rem,
+                                                ref smb_record,
+                                            ) => {
+                                                smb2_response_record(
+                                                    self, smb_record,
+                                                );
                                                 nbss_data = nbss_data_rem;
-                                            },
+                                            }
                                             _ => {
-                                                self.set_event(SMBEvent::MalformedData);
+                                                self.set_event(
+                                                    SMBEvent::MalformedData,
+                                                );
                                                 return 1;
-                                            },
+                                            }
                                         }
                                     }
-                                } else if smb.version == 0xfd_u8 { // SMB3 transform
+                                } else if smb.version == 0xfd_u8 {
+                                    // SMB3 transform
                                     let mut nbss_data = nbss_hdr.data;
                                     while nbss_data.len() > 0 {
                                         SCLogDebug!("SMBv3 transform record");
-                                        match parse_smb3_transform_record(&nbss_data) {
-                                            IResult::Done(nbss_data_rem, ref _smb3_record) => {
+                                        match parse_smb3_transform_record(
+                                            &nbss_data,
+                                        ) {
+                                            IResult::Done(
+                                                nbss_data_rem,
+                                                ref _smb3_record,
+                                            ) => {
                                                 nbss_data = nbss_data_rem;
-                                            },
+                                            }
                                             _ => {
-                                                self.set_event(SMBEvent::MalformedData);
+                                                self.set_event(
+                                                    SMBEvent::MalformedData,
+                                                );
                                                 return 1;
-                                            },
+                                            }
                                         }
                                     }
                                 }
-                            },
+                            }
                             IResult::Incomplete(_) => {
                                 // not enough data to contain basic SMB hdr
                                 // TODO event: empty NBSS_MSGTYPE_SESSION_MESSAGE
-                            },
+                            }
                             IResult::Error(_) => {
                                 self.set_event(SMBEvent::MalformedData);
                                 return 1;
-                            },
+                            }
                         }
                     } else {
                         SCLogDebug!("NBSS message {:X}", nbss_hdr.message_type);
                     }
                     cur_i = rem;
-                },
+                }
                 IResult::Incomplete(needed) => {
-                    SCLogDebug!("INCOMPLETE have {} needed {:?}", cur_i.len(), needed);
+                    SCLogDebug!(
+                        "INCOMPLETE have {} needed {:?}",
+                        cur_i.len(),
+                        needed
+                    );
                     let consumed = self.parse_tcp_data_tc_partial(cur_i);
-                    cur_i = &cur_i[consumed ..];
+                    cur_i = &cur_i[consumed..];
 
                     SCLogDebug!("INCOMPLETE have {}", cur_i.len());
                     self.tcp_buffer_tc.extend_from_slice(cur_i);
                     break;
-                },
+                }
                 IResult::Error(_) => {
                     self.set_event(SMBEvent::MalformedData);
                     return 1;
-                },
+                }
             }
-        };
+        }
         self.check_gap_resync(max_tx_id);
         self._debug_tx_stats();
         0
@@ -1708,9 +1924,14 @@ impl SMBState {
             let new_gap_size = gap_size - consumed;
             let gap = vec![0; new_gap_size as usize];
 
-            let consumed2 = self.filetracker_update(STREAM_TOSERVER, &gap, new_gap_size);
+            let consumed2 =
+                self.filetracker_update(STREAM_TOSERVER, &gap, new_gap_size);
             if consumed2 > new_gap_size {
-                SCLogDebug!("consumed more than GAP size: {} > {}", consumed2, new_gap_size);
+                SCLogDebug!(
+                    "consumed more than GAP size: {} > {}",
+                    consumed2,
+                    new_gap_size
+                );
                 self.set_event(SMBEvent::InternalError);
                 return 1;
             }
@@ -1718,7 +1939,7 @@ impl SMBState {
         SCLogDebug!("GAP of size {} in toserver direction", gap_size);
         self.ts_ssn_gap = true;
         self.ts_gap = true;
-        return 0
+        return 0;
     }
 
     /// handle a gap in the TOCLIENT direction
@@ -1732,9 +1953,14 @@ impl SMBState {
             let new_gap_size = gap_size - consumed;
             let gap = vec![0; new_gap_size as usize];
 
-            let consumed2 = self.filetracker_update(STREAM_TOCLIENT, &gap, new_gap_size);
+            let consumed2 =
+                self.filetracker_update(STREAM_TOCLIENT, &gap, new_gap_size);
             if consumed2 > new_gap_size {
-                SCLogDebug!("consumed more than GAP size: {} > {}", consumed2, new_gap_size);
+                SCLogDebug!(
+                    "consumed more than GAP size: {} > {}",
+                    consumed2,
+                    new_gap_size
+                );
                 self.set_event(SMBEvent::InternalError);
                 return 1;
             }
@@ -1742,7 +1968,7 @@ impl SMBState {
         SCLogDebug!("GAP of size {} in toclient direction", gap_size);
         self.tc_ssn_gap = true;
         self.tc_gap = true;
-        return 0
+        return 0;
     }
 
     pub fn trunc_ts(&mut self) {
@@ -1755,7 +1981,7 @@ impl SMBState {
                 SCLogDebug!("TRUNCING TX {} in TOSERVER direction", tx.id);
                 tx.request_done = true;
             }
-       }
+        }
     }
     pub fn trunc_tc(&mut self) {
         SCLogDebug!("TRUNC TC");
@@ -1777,7 +2003,7 @@ pub extern "C" fn rs_smb_state_new() -> *mut libc::c_void {
     let state = SMBState::new();
     let boxed = Box::new(state);
     SCLogDebug!("allocating state");
-    return unsafe{transmute(boxed)};
+    return unsafe { transmute(boxed) };
 }
 
 /// Params:
@@ -1786,26 +2012,28 @@ pub extern "C" fn rs_smb_state_new() -> *mut libc::c_void {
 pub extern "C" fn rs_smb_state_free(state: *mut libc::c_void) {
     // Just unbox...
     SCLogDebug!("freeing state");
-    let mut smb_state: Box<SMBState> = unsafe{transmute(state)};
+    let mut smb_state: Box<SMBState> = unsafe { transmute(state) };
     smb_state.free();
 }
 
 /// C binding parse a SMB request. Returns 1 on success, -1 on failure.
 #[no_mangle]
-pub extern "C" fn rs_smb_parse_request_tcp(_flow: *mut Flow,
-                                       state: &mut SMBState,
-                                       _pstate: *mut libc::c_void,
-                                       input: *mut libc::uint8_t,
-                                       input_len: libc::uint32_t,
-                                       _data: *mut libc::c_void,
-                                       flags: u8)
-                                       -> libc::int8_t
-{
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+pub extern "C" fn rs_smb_parse_request_tcp(
+    _flow: *mut Flow,
+    state: &mut SMBState,
+    _pstate: *mut libc::c_void,
+    input: *mut libc::uint8_t,
+    input_len: libc::uint32_t,
+    _data: *mut libc::c_void,
+    flags: u8,
+) -> libc::int8_t {
+    let buf = unsafe { std::slice::from_raw_parts(input, input_len as usize) };
     SCLogDebug!("parsing {} bytes of request data", input_len);
 
     /* START with MISTREAM set: record might be starting the middle. */
-    if flags & (STREAM_START|STREAM_MIDSTREAM) == (STREAM_START|STREAM_MIDSTREAM) {
+    if flags & (STREAM_START | STREAM_MIDSTREAM)
+        == (STREAM_START | STREAM_MIDSTREAM)
+    {
         state.ts_gap = true;
     }
 
@@ -1818,32 +2046,32 @@ pub extern "C" fn rs_smb_parse_request_tcp(_flow: *mut Flow,
 
 #[no_mangle]
 pub extern "C" fn rs_smb_parse_request_tcp_gap(
-                                        state: &mut SMBState,
-                                        input_len: libc::uint32_t)
-                                        -> libc::int8_t
-{
+    state: &mut SMBState,
+    input_len: libc::uint32_t,
+) -> libc::int8_t {
     if state.parse_tcp_data_ts_gap(input_len as u32) == 0 {
         return 1;
     }
     return -1;
 }
 
-
 #[no_mangle]
-pub extern "C" fn rs_smb_parse_response_tcp(_flow: *mut Flow,
-                                        state: &mut SMBState,
-                                        _pstate: *mut libc::c_void,
-                                        input: *mut libc::uint8_t,
-                                        input_len: libc::uint32_t,
-                                        _data: *mut libc::c_void,
-                                        flags: u8)
-                                        -> libc::int8_t
-{
+pub extern "C" fn rs_smb_parse_response_tcp(
+    _flow: *mut Flow,
+    state: &mut SMBState,
+    _pstate: *mut libc::c_void,
+    input: *mut libc::uint8_t,
+    input_len: libc::uint32_t,
+    _data: *mut libc::c_void,
+    flags: u8,
+) -> libc::int8_t {
     SCLogDebug!("parsing {} bytes of response data", input_len);
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+    let buf = unsafe { std::slice::from_raw_parts(input, input_len as usize) };
 
     /* START with MISTREAM set: record might be starting the middle. */
-    if flags & (STREAM_START|STREAM_MIDSTREAM) == (STREAM_START|STREAM_MIDSTREAM) {
+    if flags & (STREAM_START | STREAM_MIDSTREAM)
+        == (STREAM_START | STREAM_MIDSTREAM)
+    {
         state.tc_gap = true;
     }
 
@@ -1856,10 +2084,9 @@ pub extern "C" fn rs_smb_parse_response_tcp(_flow: *mut Flow,
 
 #[no_mangle]
 pub extern "C" fn rs_smb_parse_response_tcp_gap(
-                                        state: &mut SMBState,
-                                        input_len: libc::uint32_t)
-                                        -> libc::int8_t
-{
+    state: &mut SMBState,
+    input_len: libc::uint32_t,
+) -> libc::int8_t {
     if state.parse_tcp_data_tc_gap(input_len as u32) == 0 {
         return 1;
     }
@@ -1869,18 +2096,19 @@ pub extern "C" fn rs_smb_parse_response_tcp_gap(
 // probing parser
 // return 1 if found, 0 is not found
 #[no_mangle]
-pub extern "C" fn rs_smb_probe_tcp(input: *const libc::uint8_t, len: libc::uint32_t)
-                               -> libc::int8_t
-{
+pub extern "C" fn rs_smb_probe_tcp(
+    input: *const libc::uint8_t,
+    len: libc::uint32_t,
+) -> libc::int8_t {
     let slice = build_slice!(input, len as usize);
     match search_smb_record(slice) {
         IResult::Done(_, _) => {
             SCLogDebug!("smb found");
             return 1;
-        },
+        }
         _ => {
             SCLogDebug!("smb not found in {:?}", slice);
-        },
+        }
     }
     match parse_nbss_record_partial(slice) {
         IResult::Done(_, ref hdr) => {
@@ -1891,29 +2119,29 @@ pub extern "C" fn rs_smb_probe_tcp(input: *const libc::uint8_t, len: libc::uint3
                 SCLogDebug!("nbss found, assume smb");
                 return 1;
             }
-        },
-        _ => { },
+        }
+        _ => {}
     }
     SCLogDebug!("no smb");
-    return -1
+    return -1;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_state_get_tx_count(state: &mut SMBState)
-                                            -> libc::uint64_t
-{
+pub extern "C" fn rs_smb_state_get_tx_count(
+    state: &mut SMBState,
+) -> libc::uint64_t {
     SCLogDebug!("rs_smb_state_get_tx_count: returning {}", state.tx_id);
     return state.tx_id;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_state_get_tx(state: &mut SMBState,
-                                      tx_id: libc::uint64_t)
-                                      -> *mut SMBTransaction
-{
+pub extern "C" fn rs_smb_state_get_tx(
+    state: &mut SMBState,
+    tx_id: libc::uint64_t,
+) -> *mut SMBTransaction {
     match state.get_tx_by_id(tx_id) {
         Some(tx) => {
-            return unsafe{transmute(tx)};
+            return unsafe { transmute(tx) };
         }
         None => {
             return std::ptr::null_mut();
@@ -1924,15 +2152,16 @@ pub extern "C" fn rs_smb_state_get_tx(state: &mut SMBState,
 // for use with the C API call StateGetTxIterator
 #[no_mangle]
 pub extern "C" fn rs_smb_state_get_tx_iterator(
-                                      state: &mut SMBState,
-                                      min_tx_id: libc::uint64_t,
-                                      istate: &mut libc::uint64_t)
-                                      -> applayer::AppLayerGetTxIterTuple
-{
+    state: &mut SMBState,
+    min_tx_id: libc::uint64_t,
+    istate: &mut libc::uint64_t,
+) -> applayer::AppLayerGetTxIterTuple {
     match state.get_tx_iterator(min_tx_id, istate) {
         Some((tx, out_tx_id, has_next)) => {
             let c_tx = unsafe { transmute(tx) };
-            let ires = applayer::AppLayerGetTxIterTuple::with_values(c_tx, out_tx_id, has_next);
+            let ires = applayer::AppLayerGetTxIterTuple::with_values(
+                c_tx, out_tx_id, has_next,
+            );
             return ires;
         }
         None => {
@@ -1942,26 +2171,26 @@ pub extern "C" fn rs_smb_state_get_tx_iterator(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_state_tx_free(state: &mut SMBState,
-                                       tx_id: libc::uint64_t)
-{
+pub extern "C" fn rs_smb_state_tx_free(
+    state: &mut SMBState,
+    tx_id: libc::uint64_t,
+) {
     SCLogDebug!("freeing tx {}", tx_id as u64);
     state.free_tx(tx_id);
 }
 
 #[no_mangle]
 pub extern "C" fn rs_smb_state_progress_completion_status(
-    _direction: libc::uint8_t)
-    -> libc::c_int
-{
+    _direction: libc::uint8_t,
+) -> libc::c_int {
     return 1;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_tx_get_alstate_progress(tx: &mut SMBTransaction,
-                                                  direction: libc::uint8_t)
-                                                  -> libc::uint8_t
-{
+pub extern "C" fn rs_smb_tx_get_alstate_progress(
+    tx: &mut SMBTransaction,
+    direction: libc::uint8_t,
+) -> libc::uint8_t {
     if direction == STREAM_TOSERVER && tx.request_done {
         SCLogDebug!("tx {} TOSERVER progress 1 => {:?}", tx.id, tx);
         return 1;
@@ -1975,27 +2204,28 @@ pub extern "C" fn rs_smb_tx_get_alstate_progress(tx: &mut SMBTransaction,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_tx_set_logged(_state: &mut SMBState,
-                                       tx: &mut SMBTransaction,
-                                       bits: libc::uint32_t)
-{
+pub extern "C" fn rs_smb_tx_set_logged(
+    _state: &mut SMBState,
+    tx: &mut SMBTransaction,
+    bits: libc::uint32_t,
+) {
     tx.logged.set(bits);
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_tx_get_logged(_state: &mut SMBState,
-                                       tx: &mut SMBTransaction)
-                                       -> u32
-{
+pub extern "C" fn rs_smb_tx_get_logged(
+    _state: &mut SMBState,
+    tx: &mut SMBTransaction,
+) -> u32 {
     return tx.logged.get();
 }
 
 #[no_mangle]
 pub extern "C" fn rs_smb_tx_set_detect_flags(
-                                       tx: &mut SMBTransaction,
-                                       direction: libc::uint8_t,
-                                       flags: libc::uint64_t)
-{
+    tx: &mut SMBTransaction,
+    direction: libc::uint8_t,
+    flags: libc::uint64_t,
+) {
     if (direction & STREAM_TOSERVER) != 0 {
         tx.detect_flags_ts = flags as u64;
     } else {
@@ -2005,10 +2235,9 @@ pub extern "C" fn rs_smb_tx_set_detect_flags(
 
 #[no_mangle]
 pub extern "C" fn rs_smb_tx_get_detect_flags(
-                                       tx: &mut SMBTransaction,
-                                       direction: libc::uint8_t)
-                                       -> libc::uint64_t
-{
+    tx: &mut SMBTransaction,
+    direction: libc::uint8_t,
+) -> libc::uint64_t {
     if (direction & STREAM_TOSERVER) != 0 {
         return tx.detect_flags_ts as libc::uint64_t;
     } else {
@@ -2019,20 +2248,19 @@ pub extern "C" fn rs_smb_tx_get_detect_flags(
 #[no_mangle]
 pub extern "C" fn rs_smb_state_set_tx_detect_state(
     tx: &mut SMBTransaction,
-    de_state: &mut DetectEngineState)
-{
+    de_state: &mut DetectEngineState,
+) {
     tx.de_state = Some(de_state);
 }
 
 #[no_mangle]
 pub extern "C" fn rs_smb_state_get_tx_detect_state(
-    tx: &mut SMBTransaction)
-    -> *mut DetectEngineState
-{
+    tx: &mut SMBTransaction,
+) -> *mut DetectEngineState {
     match tx.de_state {
         Some(ds) => {
             return ds;
-        },
+        }
         None => {
             return std::ptr::null_mut();
         }
@@ -2041,9 +2269,9 @@ pub extern "C" fn rs_smb_state_get_tx_detect_state(
 
 #[no_mangle]
 pub extern "C" fn rs_smb_state_truncate(
-        state: &mut SMBState,
-        direction: libc::uint8_t)
-{
+    state: &mut SMBState,
+    direction: libc::uint8_t,
+) {
     if (direction & STREAM_TOSERVER) != 0 {
         state.trunc_ts();
     } else {
@@ -2052,10 +2280,10 @@ pub extern "C" fn rs_smb_state_truncate(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_state_get_events(state: &mut SMBState,
-                                          tx_id: libc::uint64_t)
-                                          -> *mut AppLayerDecoderEvents
-{
+pub extern "C" fn rs_smb_state_get_events(
+    state: &mut SMBState,
+    tx_id: libc::uint64_t,
+) -> *mut AppLayerDecoderEvents {
     match state.get_tx_by_id(tx_id) {
         Some(tx) => {
             return tx.events;
@@ -2067,19 +2295,17 @@ pub extern "C" fn rs_smb_state_get_events(state: &mut SMBState,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_state_get_event_info(event_name: *const libc::c_char,
-                                              event_id: *mut libc::c_int,
-                                              event_type: *mut AppLayerEventType)
-                                              -> i8
-{
+pub extern "C" fn rs_smb_state_get_event_info(
+    event_name: *const libc::c_char,
+    event_id: *mut libc::c_int,
+    event_type: *mut AppLayerEventType,
+) -> i8 {
     if event_name == std::ptr::null() {
         return -1;
     }
     let c_event_name: &CStr = unsafe { CStr::from_ptr(event_name) };
     let event = match c_event_name.to_str() {
-        Ok(s) => {
-            smb_str_to_event(s)
-        },
+        Ok(s) => smb_str_to_event(s),
         Err(_) => -1, // UTF-8 conversion failed
     };
     unsafe {

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -21,116 +21,119 @@
 
 extern crate libc;
 
-use nom::{IResult};
+use nom::IResult;
 
 use crate::core::*;
 use crate::log::*;
 
-use crate::smb::smb::*;
 use crate::smb::dcerpc::*;
 use crate::smb::events::*;
 use crate::smb::files::*;
+use crate::smb::smb::*;
 
 use crate::smb::smb1_records::*;
 use crate::smb::smb1_session::*;
 
 // https://msdn.microsoft.com/en-us/library/ee441741.aspx
-pub const SMB1_COMMAND_CREATE_DIRECTORY:        u8 = 0x00;
-pub const SMB1_COMMAND_DELETE_DIRECTORY:        u8 = 0x01;
-pub const SMB1_COMMAND_OPEN:                    u8 = 0x02;
-pub const SMB1_COMMAND_CREATE:                  u8 = 0x03;
-pub const SMB1_COMMAND_CLOSE:                   u8 = 0x04;
-pub const SMB1_COMMAND_FLUSH:                   u8 = 0x05;
-pub const SMB1_COMMAND_DELETE:                  u8 = 0x06;
-pub const SMB1_COMMAND_RENAME:                  u8 = 0x07;
-pub const SMB1_COMMAND_QUERY_INFORMATION:       u8 = 0x08;
-pub const SMB1_COMMAND_SET_INFORMATION:         u8 = 0x09;
-pub const SMB1_COMMAND_READ:                    u8 = 0x0a;
-pub const SMB1_COMMAND_WRITE:                   u8 = 0x0b;
-pub const SMB1_COMMAND_LOCK_BYTE_RANGE:         u8 = 0x0c;
-pub const SMB1_COMMAND_UNLOCK_BYTE_RANGE:       u8 = 0x0d;
-pub const SMB1_COMMAND_CREATE_TEMPORARY:        u8 = 0x0e;
-pub const SMB1_COMMAND_CREATE_NEW:              u8 = 0x0f;
-pub const SMB1_COMMAND_CHECK_DIRECTORY:         u8 = 0x10;
-pub const SMB1_COMMAND_PROCESS_EXIT:            u8 = 0x11;
-pub const SMB1_COMMAND_SEEK:                    u8 = 0x12;
-pub const SMB1_COMMAND_LOCK_AND_READ:           u8 = 0x13;
-pub const SMB1_COMMAND_WRITE_AND_UNLOCK:        u8 = 0x14;
-pub const SMB1_COMMAND_LOCKING_ANDX:            u8 = 0x24;
-pub const SMB1_COMMAND_TRANS:                   u8 = 0x25;
-pub const SMB1_COMMAND_ECHO:                    u8 = 0x2b;
-pub const SMB1_COMMAND_WRITE_AND_CLOSE:         u8 = 0x2c;
-pub const SMB1_COMMAND_OPEN_ANDX:               u8 = 0x2d;
-pub const SMB1_COMMAND_READ_ANDX:               u8 = 0x2e;
-pub const SMB1_COMMAND_WRITE_ANDX:              u8 = 0x2f;
-pub const SMB1_COMMAND_TRANS2:                  u8 = 0x32;
-pub const SMB1_COMMAND_TRANS2_SECONDARY:        u8 = 0x33;
-pub const SMB1_COMMAND_FIND_CLOSE2:             u8 = 0x34;
-pub const SMB1_COMMAND_TREE_DISCONNECT:         u8 = 0x71;
-pub const SMB1_COMMAND_NEGOTIATE_PROTOCOL:      u8 = 0x72;
-pub const SMB1_COMMAND_SESSION_SETUP_ANDX:      u8 = 0x73;
-pub const SMB1_COMMAND_LOGOFF_ANDX:             u8 = 0x74;
-pub const SMB1_COMMAND_TREE_CONNECT_ANDX:       u8 = 0x75;
-pub const SMB1_COMMAND_QUERY_INFO_DISK:         u8 = 0x80;
-pub const SMB1_COMMAND_NT_TRANS:                u8 = 0xa0;
-pub const SMB1_COMMAND_NT_CREATE_ANDX:          u8 = 0xa2;
-pub const SMB1_COMMAND_NT_CANCEL:               u8 = 0xa4;
+pub const SMB1_COMMAND_CREATE_DIRECTORY: u8 = 0x00;
+pub const SMB1_COMMAND_DELETE_DIRECTORY: u8 = 0x01;
+pub const SMB1_COMMAND_OPEN: u8 = 0x02;
+pub const SMB1_COMMAND_CREATE: u8 = 0x03;
+pub const SMB1_COMMAND_CLOSE: u8 = 0x04;
+pub const SMB1_COMMAND_FLUSH: u8 = 0x05;
+pub const SMB1_COMMAND_DELETE: u8 = 0x06;
+pub const SMB1_COMMAND_RENAME: u8 = 0x07;
+pub const SMB1_COMMAND_QUERY_INFORMATION: u8 = 0x08;
+pub const SMB1_COMMAND_SET_INFORMATION: u8 = 0x09;
+pub const SMB1_COMMAND_READ: u8 = 0x0a;
+pub const SMB1_COMMAND_WRITE: u8 = 0x0b;
+pub const SMB1_COMMAND_LOCK_BYTE_RANGE: u8 = 0x0c;
+pub const SMB1_COMMAND_UNLOCK_BYTE_RANGE: u8 = 0x0d;
+pub const SMB1_COMMAND_CREATE_TEMPORARY: u8 = 0x0e;
+pub const SMB1_COMMAND_CREATE_NEW: u8 = 0x0f;
+pub const SMB1_COMMAND_CHECK_DIRECTORY: u8 = 0x10;
+pub const SMB1_COMMAND_PROCESS_EXIT: u8 = 0x11;
+pub const SMB1_COMMAND_SEEK: u8 = 0x12;
+pub const SMB1_COMMAND_LOCK_AND_READ: u8 = 0x13;
+pub const SMB1_COMMAND_WRITE_AND_UNLOCK: u8 = 0x14;
+pub const SMB1_COMMAND_LOCKING_ANDX: u8 = 0x24;
+pub const SMB1_COMMAND_TRANS: u8 = 0x25;
+pub const SMB1_COMMAND_ECHO: u8 = 0x2b;
+pub const SMB1_COMMAND_WRITE_AND_CLOSE: u8 = 0x2c;
+pub const SMB1_COMMAND_OPEN_ANDX: u8 = 0x2d;
+pub const SMB1_COMMAND_READ_ANDX: u8 = 0x2e;
+pub const SMB1_COMMAND_WRITE_ANDX: u8 = 0x2f;
+pub const SMB1_COMMAND_TRANS2: u8 = 0x32;
+pub const SMB1_COMMAND_TRANS2_SECONDARY: u8 = 0x33;
+pub const SMB1_COMMAND_FIND_CLOSE2: u8 = 0x34;
+pub const SMB1_COMMAND_TREE_DISCONNECT: u8 = 0x71;
+pub const SMB1_COMMAND_NEGOTIATE_PROTOCOL: u8 = 0x72;
+pub const SMB1_COMMAND_SESSION_SETUP_ANDX: u8 = 0x73;
+pub const SMB1_COMMAND_LOGOFF_ANDX: u8 = 0x74;
+pub const SMB1_COMMAND_TREE_CONNECT_ANDX: u8 = 0x75;
+pub const SMB1_COMMAND_QUERY_INFO_DISK: u8 = 0x80;
+pub const SMB1_COMMAND_NT_TRANS: u8 = 0xa0;
+pub const SMB1_COMMAND_NT_CREATE_ANDX: u8 = 0xa2;
+pub const SMB1_COMMAND_NT_CANCEL: u8 = 0xa4;
 
 pub fn smb1_command_string(c: u8) -> String {
     match c {
-        SMB1_COMMAND_CREATE_DIRECTORY   => "SMB1_COMMAND_CREATE_DIRECTORY",
-        SMB1_COMMAND_DELETE_DIRECTORY   => "SMB1_COMMAND_DELETE_DIRECTORY",
-        SMB1_COMMAND_OPEN               => "SMB1_COMMAND_OPEN",
-        SMB1_COMMAND_CREATE             => "SMB1_COMMAND_CREATE",
-        SMB1_COMMAND_CLOSE              => "SMB1_COMMAND_CLOSE",
-        SMB1_COMMAND_FLUSH              => "SMB1_COMMAND_FLUSH",
-        SMB1_COMMAND_DELETE             => "SMB1_COMMAND_DELETE",
-        SMB1_COMMAND_RENAME             => "SMB1_COMMAND_RENAME",
-        SMB1_COMMAND_QUERY_INFORMATION  => "SMB1_COMMAND_QUERY_INFORMATION",
-        SMB1_COMMAND_SET_INFORMATION    => "SMB1_COMMAND_SET_INFORMATION",
-        SMB1_COMMAND_READ               => "SMB1_COMMAND_READ",
-        SMB1_COMMAND_WRITE              => "SMB1_COMMAND_WRITE",
-        SMB1_COMMAND_LOCK_BYTE_RANGE    => "SMB1_COMMAND_LOCK_BYTE_RANGE",
-        SMB1_COMMAND_UNLOCK_BYTE_RANGE  => "SMB1_COMMAND_UNLOCK_BYTE_RANGE",
-        SMB1_COMMAND_CREATE_TEMPORARY   => "SMB1_COMMAND_CREATE_TEMPORARY",
-        SMB1_COMMAND_CREATE_NEW         => "SMB1_COMMAND_CREATE_NEW",
-        SMB1_COMMAND_CHECK_DIRECTORY    => "SMB1_COMMAND_CHECK_DIRECTORY",
-        SMB1_COMMAND_PROCESS_EXIT       => "SMB1_COMMAND_PROCESS_EXIT",
-        SMB1_COMMAND_SEEK               => "SMB1_COMMAND_SEEK",
-        SMB1_COMMAND_LOCK_AND_READ      => "SMB1_COMMAND_LOCK_AND_READ",
-        SMB1_COMMAND_WRITE_AND_UNLOCK   => "SMB1_COMMAND_WRITE_AND_UNLOCK",
-        SMB1_COMMAND_LOCKING_ANDX       => "SMB1_COMMAND_LOCKING_ANDX",
-        SMB1_COMMAND_ECHO               => "SMB1_COMMAND_ECHO",
-        SMB1_COMMAND_WRITE_AND_CLOSE    => "SMB1_COMMAND_WRITE_AND_CLOSE",
-        SMB1_COMMAND_OPEN_ANDX          => "SMB1_COMMAND_OPEN_ANDX",
-        SMB1_COMMAND_READ_ANDX          => "SMB1_COMMAND_READ_ANDX",
-        SMB1_COMMAND_WRITE_ANDX         => "SMB1_COMMAND_WRITE_ANDX",
-        SMB1_COMMAND_TRANS              => "SMB1_COMMAND_TRANS",
-        SMB1_COMMAND_TRANS2             => "SMB1_COMMAND_TRANS2",
-        SMB1_COMMAND_TRANS2_SECONDARY   => "SMB1_COMMAND_TRANS2_SECONDARY",
-        SMB1_COMMAND_FIND_CLOSE2        => "SMB1_COMMAND_FIND_CLOSE2",
-        SMB1_COMMAND_TREE_DISCONNECT    => "SMB1_COMMAND_TREE_DISCONNECT",
+        SMB1_COMMAND_CREATE_DIRECTORY => "SMB1_COMMAND_CREATE_DIRECTORY",
+        SMB1_COMMAND_DELETE_DIRECTORY => "SMB1_COMMAND_DELETE_DIRECTORY",
+        SMB1_COMMAND_OPEN => "SMB1_COMMAND_OPEN",
+        SMB1_COMMAND_CREATE => "SMB1_COMMAND_CREATE",
+        SMB1_COMMAND_CLOSE => "SMB1_COMMAND_CLOSE",
+        SMB1_COMMAND_FLUSH => "SMB1_COMMAND_FLUSH",
+        SMB1_COMMAND_DELETE => "SMB1_COMMAND_DELETE",
+        SMB1_COMMAND_RENAME => "SMB1_COMMAND_RENAME",
+        SMB1_COMMAND_QUERY_INFORMATION => "SMB1_COMMAND_QUERY_INFORMATION",
+        SMB1_COMMAND_SET_INFORMATION => "SMB1_COMMAND_SET_INFORMATION",
+        SMB1_COMMAND_READ => "SMB1_COMMAND_READ",
+        SMB1_COMMAND_WRITE => "SMB1_COMMAND_WRITE",
+        SMB1_COMMAND_LOCK_BYTE_RANGE => "SMB1_COMMAND_LOCK_BYTE_RANGE",
+        SMB1_COMMAND_UNLOCK_BYTE_RANGE => "SMB1_COMMAND_UNLOCK_BYTE_RANGE",
+        SMB1_COMMAND_CREATE_TEMPORARY => "SMB1_COMMAND_CREATE_TEMPORARY",
+        SMB1_COMMAND_CREATE_NEW => "SMB1_COMMAND_CREATE_NEW",
+        SMB1_COMMAND_CHECK_DIRECTORY => "SMB1_COMMAND_CHECK_DIRECTORY",
+        SMB1_COMMAND_PROCESS_EXIT => "SMB1_COMMAND_PROCESS_EXIT",
+        SMB1_COMMAND_SEEK => "SMB1_COMMAND_SEEK",
+        SMB1_COMMAND_LOCK_AND_READ => "SMB1_COMMAND_LOCK_AND_READ",
+        SMB1_COMMAND_WRITE_AND_UNLOCK => "SMB1_COMMAND_WRITE_AND_UNLOCK",
+        SMB1_COMMAND_LOCKING_ANDX => "SMB1_COMMAND_LOCKING_ANDX",
+        SMB1_COMMAND_ECHO => "SMB1_COMMAND_ECHO",
+        SMB1_COMMAND_WRITE_AND_CLOSE => "SMB1_COMMAND_WRITE_AND_CLOSE",
+        SMB1_COMMAND_OPEN_ANDX => "SMB1_COMMAND_OPEN_ANDX",
+        SMB1_COMMAND_READ_ANDX => "SMB1_COMMAND_READ_ANDX",
+        SMB1_COMMAND_WRITE_ANDX => "SMB1_COMMAND_WRITE_ANDX",
+        SMB1_COMMAND_TRANS => "SMB1_COMMAND_TRANS",
+        SMB1_COMMAND_TRANS2 => "SMB1_COMMAND_TRANS2",
+        SMB1_COMMAND_TRANS2_SECONDARY => "SMB1_COMMAND_TRANS2_SECONDARY",
+        SMB1_COMMAND_FIND_CLOSE2 => "SMB1_COMMAND_FIND_CLOSE2",
+        SMB1_COMMAND_TREE_DISCONNECT => "SMB1_COMMAND_TREE_DISCONNECT",
         SMB1_COMMAND_NEGOTIATE_PROTOCOL => "SMB1_COMMAND_NEGOTIATE_PROTOCOL",
         SMB1_COMMAND_SESSION_SETUP_ANDX => "SMB1_COMMAND_SESSION_SETUP_ANDX",
-        SMB1_COMMAND_LOGOFF_ANDX        => "SMB1_COMMAND_LOGOFF_ANDX",
-        SMB1_COMMAND_TREE_CONNECT_ANDX  => "SMB1_COMMAND_TREE_CONNECT_ANDX",
-        SMB1_COMMAND_QUERY_INFO_DISK    => "SMB1_COMMAND_QUERY_INFO_DISK",
-        SMB1_COMMAND_NT_TRANS           => "SMB1_COMMAND_NT_TRANS",
-        SMB1_COMMAND_NT_CREATE_ANDX     => "SMB1_COMMAND_NT_CREATE_ANDX",
-        SMB1_COMMAND_NT_CANCEL          => "SMB1_COMMAND_NT_CANCEL",
-        _ => { return (c).to_string(); },
-    }.to_string()
+        SMB1_COMMAND_LOGOFF_ANDX => "SMB1_COMMAND_LOGOFF_ANDX",
+        SMB1_COMMAND_TREE_CONNECT_ANDX => "SMB1_COMMAND_TREE_CONNECT_ANDX",
+        SMB1_COMMAND_QUERY_INFO_DISK => "SMB1_COMMAND_QUERY_INFO_DISK",
+        SMB1_COMMAND_NT_TRANS => "SMB1_COMMAND_NT_TRANS",
+        SMB1_COMMAND_NT_CREATE_ANDX => "SMB1_COMMAND_NT_CREATE_ANDX",
+        SMB1_COMMAND_NT_CANCEL => "SMB1_COMMAND_NT_CANCEL",
+        _ => {
+            return (c).to_string();
+        }
+    }
+    .to_string()
 }
 
 // later we'll use this to determine if we need to
 // track a ssn per type
 pub fn smb1_create_new_tx(cmd: u8) -> bool {
     match cmd {
-        SMB1_COMMAND_READ_ANDX |
-        SMB1_COMMAND_WRITE_ANDX |
-        SMB1_COMMAND_TRANS |
-        SMB1_COMMAND_TRANS2 => { false },
-        _ => { true },
+        SMB1_COMMAND_READ_ANDX
+        | SMB1_COMMAND_WRITE_ANDX
+        | SMB1_COMMAND_TRANS
+        | SMB1_COMMAND_TRANS2 => false,
+        _ => true,
     }
 }
 
@@ -139,21 +142,22 @@ pub fn smb1_create_new_tx(cmd: u8) -> bool {
 // excludes the 'maybe' commands like TRANS2
 pub fn smb1_check_tx(cmd: u8) -> bool {
     match cmd {
-        SMB1_COMMAND_READ_ANDX |
-        SMB1_COMMAND_WRITE_ANDX |
-        SMB1_COMMAND_TRANS => { false },
-        _ => { true },
+        SMB1_COMMAND_READ_ANDX
+        | SMB1_COMMAND_WRITE_ANDX
+        | SMB1_COMMAND_TRANS => false,
+        _ => true,
     }
 }
 
-fn smb1_close_file(state: &mut SMBState, fid: &Vec<u8>)
-{
+fn smb1_close_file(state: &mut SMBState, fid: &Vec<u8>) {
     // we can have created 2 txs for a FID: one for reads
     // and one for writes. So close both.
     match state.get_file_tx_by_fuid(&fid, STREAM_TOSERVER) {
         Some((tx, files, flags)) => {
             SCLogDebug!("found tx {}", tx.id);
-            if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
+            if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) =
+                tx.type_data
+            {
                 if !tx.request_done {
                     SCLogDebug!("closing file tx {} FID {:?}", tx.id, fid);
                     tdf.file_tracker.close(files, flags);
@@ -162,13 +166,15 @@ fn smb1_close_file(state: &mut SMBState, fid: &Vec<u8>)
                     SCLogDebug!("tx {} is done", tx.id);
                 }
             }
-        },
-        None => { },
+        }
+        None => {}
     }
     match state.get_file_tx_by_fuid(&fid, STREAM_TOCLIENT) {
         Some((tx, files, flags)) => {
             SCLogDebug!("found tx {}", tx.id);
-            if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
+            if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) =
+                tx.type_data
+            {
                 if !tx.request_done {
                     SCLogDebug!("closing file tx {} FID {:?}", tx.id, fid);
                     tdf.file_tracker.close(files, flags);
@@ -177,39 +183,37 @@ fn smb1_close_file(state: &mut SMBState, fid: &Vec<u8>)
                     SCLogDebug!("tx {} is done", tx.id);
                 }
             }
-        },
-        None => { },
+        }
+        None => {}
     }
 }
 
 pub fn smb1_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 {
     SCLogDebug!("record: command {}: record {:?}", r.command, r);
 
-    let mut events : Vec<SMBEvent> = Vec::new();
+    let mut events: Vec<SMBEvent> = Vec::new();
     let mut no_response_expected = false;
 
     let have_tx = match r.command {
-        SMB1_COMMAND_RENAME => {
-            match parse_smb_rename_request_record(r.data) {
-                IResult::Done(_, rd) => {
-                    SCLogDebug!("RENAME {:?}", rd);
+        SMB1_COMMAND_RENAME => match parse_smb_rename_request_record(r.data) {
+            IResult::Done(_, rd) => {
+                SCLogDebug!("RENAME {:?}", rd);
 
-                    let tx_hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
-                    let mut newname = rd.newname;
-                    newname.retain(|&i|i != 0x00);
-                    let mut oldname = rd.oldname;
-                    oldname.retain(|&i|i != 0x00);
+                let tx_hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
+                let mut newname = rd.newname;
+                newname.retain(|&i| i != 0x00);
+                let mut oldname = rd.oldname;
+                oldname.retain(|&i| i != 0x00);
 
-                    let tx = state.new_rename_tx(Vec::new(), oldname, newname);
-                    tx.hdr = tx_hdr;
-                    tx.request_done = true;
-                    tx.vercmd.set_smb1_cmd(SMB1_COMMAND_RENAME);
-                    true
-                },
-                _ => {
-                    events.push(SMBEvent::MalformedData);
-                    false
-                },
+                let tx = state.new_rename_tx(Vec::new(), oldname, newname);
+                tx.hdr = tx_hdr;
+                tx.request_done = true;
+                tx.vercmd.set_smb1_cmd(SMB1_COMMAND_RENAME);
+                true
+            }
+            _ => {
+                events.push(SMBEvent::MalformedData);
+                false
             }
         },
         SMB1_COMMAND_TRANS2 => {
@@ -219,11 +223,17 @@ pub fn smb1_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 {
 
                     if rd.subcmd == 6 {
                         SCLogDebug!("SET_PATH_INFO");
-                        match parse_trans2_request_params_set_path_info(rd.setup_blob) {
+                        match parse_trans2_request_params_set_path_info(
+                            rd.setup_blob,
+                        ) {
                             IResult::Done(_, pd) => {
-                                SCLogDebug!("TRANS2 SET_PATH_INFO PARAMS DONE {:?}", pd);
+                                SCLogDebug!(
+                                    "TRANS2 SET_PATH_INFO PARAMS DONE {:?}",
+                                    pd
+                                );
 
-                                if pd.loi == 1013 { // set disposition info
+                                if pd.loi == 1013 {
+                                    // set disposition info
                                     match parse_trans2_request_data_set_file_info_disposition(rd.data_blob) {
                                         IResult::Done(_, disp) => {
                                             SCLogDebug!("TRANS2 SET_FILE_INFO DATA DISPOSITION DONE {:?}", disp);
@@ -278,25 +288,34 @@ pub fn smb1_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 {
                                 } else {
                                     false
                                 }
-                            },
+                            }
                             IResult::Incomplete(n) => {
                                 SCLogDebug!("TRANS2 SET_PATH_INFO PARAMS INCOMPLETE {:?}", n);
                                 events.push(SMBEvent::MalformedData);
                                 false
-                            },
+                            }
                             IResult::Error(e) => {
-                                SCLogDebug!("TRANS2 SET_PATH_INFO PARAMS ERROR {:?}", e);
+                                SCLogDebug!(
+                                    "TRANS2 SET_PATH_INFO PARAMS ERROR {:?}",
+                                    e
+                                );
                                 events.push(SMBEvent::MalformedData);
                                 false
-                            },
+                            }
                         }
                     } else if rd.subcmd == 8 {
                         SCLogDebug!("SET_FILE_INFO");
-                        match parse_trans2_request_params_set_file_info(rd.setup_blob) {
+                        match parse_trans2_request_params_set_file_info(
+                            rd.setup_blob,
+                        ) {
                             IResult::Done(_, pd) => {
-                                SCLogDebug!("TRANS2 SET_FILE_INFO PARAMS DONE {:?}", pd);
+                                SCLogDebug!(
+                                    "TRANS2 SET_FILE_INFO PARAMS DONE {:?}",
+                                    pd
+                                );
 
-                                if pd.loi == 1013 { // set disposition info
+                                if pd.loi == 1013 {
+                                    // set disposition info
                                     match parse_trans2_request_data_set_file_info_disposition(rd.data_blob) {
                                         IResult::Done(_, disp) => {
                                             SCLogDebug!("TRANS2 SET_FILE_INFO DATA DISPOSITION DONE {:?}", disp);
@@ -363,34 +382,37 @@ pub fn smb1_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 {
                                 } else {
                                     false
                                 }
-                            },
+                            }
                             IResult::Incomplete(n) => {
                                 SCLogDebug!("TRANS2 SET_FILE_INFO PARAMS INCOMPLETE {:?}", n);
                                 events.push(SMBEvent::MalformedData);
                                 false
-                            },
+                            }
                             IResult::Error(e) => {
-                                SCLogDebug!("TRANS2 SET_FILE_INFO PARAMS ERROR {:?}", e);
+                                SCLogDebug!(
+                                    "TRANS2 SET_FILE_INFO PARAMS ERROR {:?}",
+                                    e
+                                );
                                 events.push(SMBEvent::MalformedData);
                                 false
-                            },
+                            }
                         }
                     } else {
                         false
                     }
-                },
+                }
                 IResult::Incomplete(n) => {
                     SCLogDebug!("TRANS2 INCOMPLETE {:?}", n);
                     events.push(SMBEvent::MalformedData);
                     false
-                },
+                }
                 IResult::Error(e) => {
                     SCLogDebug!("TRANS2 ERROR {:?}", e);
                     events.push(SMBEvent::MalformedData);
                     false
-                },
+                }
             }
-        },
+        }
         SMB1_COMMAND_READ_ANDX => {
             match parse_smb_read_andx_request_record(r.data) {
                 IResult::Done(_, rr) => {
@@ -402,30 +424,30 @@ pub fn smb1_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 {
                     fid.extend_from_slice(&u32_as_bytes(r.ssn_id));
                     let fidoff = SMBFileGUIDOffset::new(fid, rr.offset);
                     state.ssn2vecoffset_map.insert(fid_key, fidoff);
-                },
+                }
                 _ => {
                     events.push(SMBEvent::MalformedData);
-                },
+                }
             }
             false
-        },
-        SMB1_COMMAND_WRITE_ANDX |
-        SMB1_COMMAND_WRITE |
-        SMB1_COMMAND_WRITE_AND_CLOSE => {
+        }
+        SMB1_COMMAND_WRITE_ANDX
+        | SMB1_COMMAND_WRITE
+        | SMB1_COMMAND_WRITE_AND_CLOSE => {
             smb1_write_request_record(state, r);
             true // tx handling in func
-        },
+        }
         SMB1_COMMAND_TRANS => {
             smb1_trans_request_record(state, r);
             true
-        },
+        }
         SMB1_COMMAND_NEGOTIATE_PROTOCOL => {
             match parse_smb1_negotiate_protocol_record(r.data) {
                 IResult::Done(_, pr) => {
                     SCLogDebug!("SMB_COMMAND_NEGOTIATE_PROTOCOL {:?}", pr);
 
                     let mut bad_dialects = false;
-                    let mut dialects : Vec<Vec<u8>> = Vec::new();
+                    let mut dialects: Vec<Vec<u8>> = Vec::new();
                     for d in &pr.dialects {
                         if d.len() == 0 {
                             bad_dialects = true;
@@ -443,12 +465,15 @@ pub fn smb1_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 {
                             SCLogDebug!("WEIRD, should not have NEGOTIATE tx!");
                             tx.set_event(SMBEvent::DuplicateNegotiate);
                             true
-                        },
-                        None => { false },
+                        }
+                        None => false,
                     };
                     if !found {
                         let tx = state.new_negotiate_tx(1);
-                        if let Some(SMBTransactionTypeData::NEGOTIATE(ref mut tdn)) = tx.type_data {
+                        if let Some(SMBTransactionTypeData::NEGOTIATE(
+                            ref mut tdn,
+                        )) = tx.type_data
+                        {
                             tdn.dialects = dialects;
                         }
                         tx.request_done = true;
@@ -457,43 +482,56 @@ pub fn smb1_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 {
                         }
                     }
                     true
-                },
+                }
                 _ => {
                     events.push(SMBEvent::MalformedData);
                     false
-                },
+                }
             }
-        },
+        }
         SMB1_COMMAND_NT_CREATE_ANDX => {
             match parse_smb_create_andx_request_record(r.data) {
                 IResult::Done(_, cr) => {
                     SCLogDebug!("Create AndX {:?}", cr);
                     let del = cr.create_options & 0x0000_1000 != 0;
                     let dir = cr.create_options & 0x0000_0001 != 0;
-                    SCLogDebug!("del {} dir {} options {:08x}", del, dir, cr.create_options);
+                    SCLogDebug!(
+                        "del {} dir {} options {:08x}",
+                        del,
+                        dir,
+                        cr.create_options
+                    );
 
                     let name_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_FILENAME);
                     let name_val = cr.file_name.to_vec();
                     state.ssn2vec_map.insert(name_key, name_val);
 
                     let tx_hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
-                    let tx = state.new_create_tx(&cr.file_name.to_vec(),
-                            cr.disposition, del, dir, tx_hdr);
+                    let tx = state.new_create_tx(
+                        &cr.file_name.to_vec(),
+                        cr.disposition,
+                        del,
+                        dir,
+                        tx_hdr,
+                    );
                     tx.vercmd.set_smb1_cmd(r.command);
                     SCLogDebug!("TS CREATE TX {} created", tx.id);
                     true
-                },
+                }
                 _ => {
                     events.push(SMBEvent::MalformedData);
                     false
-                },
+                }
             }
-        },
+        }
         SMB1_COMMAND_SESSION_SETUP_ANDX => {
-            SCLogDebug!("SMB1_COMMAND_SESSION_SETUP_ANDX user_id {}", r.user_id);
+            SCLogDebug!(
+                "SMB1_COMMAND_SESSION_SETUP_ANDX user_id {}",
+                r.user_id
+            );
             smb1_session_setup_request(state, r);
             true
-        },
+        }
         SMB1_COMMAND_TREE_CONNECT_ANDX => {
             SCLogDebug!("SMB1_COMMAND_TREE_CONNECT_ANDX");
             match parse_smb_connect_tree_andx_record(r.data, r) {
@@ -507,24 +545,27 @@ pub fn smb1_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 {
                     // store hdr as SMBHDR_TYPE_TREE, so with tree id 0
                     // when the response finds this we update it
                     let tx = state.new_treeconnect_tx(name_key, name_val);
-                    if let Some(SMBTransactionTypeData::TREECONNECT(ref mut tdn)) = tx.type_data {
+                    if let Some(SMBTransactionTypeData::TREECONNECT(
+                        ref mut tdn,
+                    )) = tx.type_data
+                    {
                         tdn.req_service = Some(tr.service.to_vec());
                     }
                     tx.request_done = true;
                     tx.vercmd.set_smb1_cmd(SMB1_COMMAND_TREE_CONNECT_ANDX);
                     true
-                },
+                }
                 _ => {
                     events.push(SMBEvent::MalformedData);
                     false
-                },
+                }
             }
-        },
+        }
         SMB1_COMMAND_TREE_DISCONNECT => {
             let tree_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_SHARE);
             state.ssn2tree_map.remove(&tree_key);
             false
-        },
+        }
         SMB1_COMMAND_CLOSE => {
             match parse_smb1_close_request_record(r.data) {
                 IResult::Done(_, cd) => {
@@ -532,40 +573,49 @@ pub fn smb1_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 {
                     fid.extend_from_slice(&u32_as_bytes(r.ssn_id));
                     SCLogDebug!("closing FID {:?}/{:?}", cd.fid, fid);
                     smb1_close_file(state, &fid);
-                },
+                }
                 _ => {
                     events.push(SMBEvent::MalformedData);
-                },
+                }
             }
             false
-        },
-        SMB1_COMMAND_NT_CANCEL |
-        SMB1_COMMAND_TRANS2_SECONDARY |
-        SMB1_COMMAND_LOCKING_ANDX => {
+        }
+        SMB1_COMMAND_NT_CANCEL
+        | SMB1_COMMAND_TRANS2_SECONDARY
+        | SMB1_COMMAND_LOCKING_ANDX => {
             no_response_expected = true;
             false
-        },
+        }
         _ => {
-            if r.command == SMB1_COMMAND_LOGOFF_ANDX ||
-               r.command == SMB1_COMMAND_TREE_DISCONNECT ||
-               r.command == SMB1_COMMAND_NT_TRANS ||
-               r.command == SMB1_COMMAND_NT_CANCEL ||
-               r.command == SMB1_COMMAND_RENAME ||
-               r.command == SMB1_COMMAND_CHECK_DIRECTORY ||
-               r.command == SMB1_COMMAND_ECHO ||
-               r.command == SMB1_COMMAND_TRANS
-            { } else {
-                 SCLogDebug!("unsupported command {}/{}",
-                         r.command, &smb1_command_string(r.command));
+            if r.command == SMB1_COMMAND_LOGOFF_ANDX
+                || r.command == SMB1_COMMAND_TREE_DISCONNECT
+                || r.command == SMB1_COMMAND_NT_TRANS
+                || r.command == SMB1_COMMAND_NT_CANCEL
+                || r.command == SMB1_COMMAND_RENAME
+                || r.command == SMB1_COMMAND_CHECK_DIRECTORY
+                || r.command == SMB1_COMMAND_ECHO
+                || r.command == SMB1_COMMAND_TRANS
+            {
+            } else {
+                SCLogDebug!(
+                    "unsupported command {}/{}",
+                    r.command,
+                    &smb1_command_string(r.command)
+                );
             }
             false
-        },
+        }
     };
     if !have_tx {
         if smb1_create_new_tx(r.command) {
             let tx_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
             let tx = state.new_generic_tx(1, r.command as u16, tx_key);
-            SCLogDebug!("tx {} created for {}/{}", tx.id, r.command, &smb1_command_string(r.command));
+            SCLogDebug!(
+                "tx {} created for {}/{}",
+                tx.id,
+                r.command,
+                &smb1_command_string(r.command)
+            );
             tx.set_events(events);
             if no_response_expected {
                 tx.response_done = true;
@@ -575,20 +625,28 @@ pub fn smb1_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 {
     0
 }
 
-pub fn smb1_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 {
-    SCLogDebug!("record: command {} status {} -> {:?}", r.command, r.nt_status, r);
+pub fn smb1_response_record<'b>(
+    state: &mut SMBState,
+    r: &SmbRecord<'b>,
+) -> u32 {
+    SCLogDebug!(
+        "record: command {} status {} -> {:?}",
+        r.command,
+        r.nt_status,
+        r
+    );
 
     let key_ssn_id = r.ssn_id;
     let key_tree_id = r.tree_id;
     let key_multiplex_id = r.multiplex_id;
     let mut tx_sync = false;
-    let mut events : Vec<SMBEvent> = Vec::new();
+    let mut events: Vec<SMBEvent> = Vec::new();
 
     let have_tx = match r.command {
         SMB1_COMMAND_READ_ANDX => {
             smb1_read_response_record(state, &r);
             true // tx handling in func
-        },
+        }
         SMB1_COMMAND_NEGOTIATE_PROTOCOL => {
             SCLogDebug!("SMB1_COMMAND_NEGOTIATE_PROTOCOL response");
             match parse_smb1_negotiate_protocol_response_record(r.data) {
@@ -599,51 +657,59 @@ pub fn smb1_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 
                             tx.response_done = true;
                             SCLogDebug!("tx {} is done", tx.id);
                             let d = match tx.type_data {
-                                Some(SMBTransactionTypeData::NEGOTIATE(ref mut x)) => {
+                                Some(SMBTransactionTypeData::NEGOTIATE(
+                                    ref mut x,
+                                )) => {
                                     x.server_guid = pr.server_guid.to_vec();
 
                                     let dialect_idx = pr.dialect_idx as usize;
                                     if x.dialects.len() <= dialect_idx {
                                         None
                                     } else {
-                                        let d = x.dialects[dialect_idx].to_vec();
+                                        let d =
+                                            x.dialects[dialect_idx].to_vec();
                                         Some(d)
                                     }
-                                },
-                                _ => { None },
+                                }
+                                _ => None,
                             };
                             if d == None {
-                                tx.set_event(SMBEvent::NegotiateMalformedDialects);
+                                tx.set_event(
+                                    SMBEvent::NegotiateMalformedDialects,
+                                );
                             }
                             (true, d)
-                        },
-                        None => { (false, None) },
+                        }
+                        None => (false, None),
                     };
                     if let Some(d) = dialect {
                         SCLogDebug!("dialect {:?}", d);
                         state.dialect_vec = Some(d);
                     }
                     have_ntx
-                },
+                }
                 _ => {
                     events.push(SMBEvent::MalformedData);
                     false
-                },
+                }
             }
-        },
+        }
         SMB1_COMMAND_TREE_CONNECT_ANDX => {
             if r.nt_status != SMB_NTSTATUS_SUCCESS {
                 let name_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_TREE);
                 match state.get_treeconnect_tx(name_key) {
                     Some(tx) => {
-                        if let Some(SMBTransactionTypeData::TREECONNECT(ref mut tdn)) = tx.type_data {
+                        if let Some(SMBTransactionTypeData::TREECONNECT(
+                            ref mut tdn,
+                        )) = tx.type_data
+                        {
                             tdn.tree_id = r.tree_id as u32;
                         }
                         tx.set_status(r.nt_status, r.is_dos_error);
                         tx.response_done = true;
                         SCLogDebug!("tx {} is done", tx.id);
-                    },
-                    None => { },
+                    }
+                    None => {}
                 }
                 return 0;
             }
@@ -655,7 +721,10 @@ pub fn smb1_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 
                     let mut share_name = Vec::new();
                     let found = match state.get_treeconnect_tx(name_key) {
                         Some(tx) => {
-                            if let Some(SMBTransactionTypeData::TREECONNECT(ref mut tdn)) = tx.type_data {
+                            if let Some(SMBTransactionTypeData::TREECONNECT(
+                                ref mut tdn,
+                            )) = tx.type_data
+                            {
                                 tdn.is_pipe = is_pipe;
                                 tdn.tree_id = r.tree_id as u32;
                                 share_name = tdn.share_name.to_vec();
@@ -666,111 +735,138 @@ pub fn smb1_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 
                             tx.response_done = true;
                             SCLogDebug!("tx {} is done", tx.id);
                             true
-                        },
-                        None => { false },
+                        }
+                        None => false,
                     };
                     if found {
                         let tree = SMBTree::new(share_name.to_vec(), is_pipe);
-                        let tree_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_SHARE);
+                        let tree_key =
+                            SMBCommonHdr::from1(r, SMBHDR_TYPE_SHARE);
                         state.ssn2tree_map.insert(tree_key, tree);
                     }
                     found
-                },
+                }
                 _ => {
                     events.push(SMBEvent::MalformedData);
                     false
-                },
+                }
             }
-        },
+        }
         SMB1_COMMAND_TREE_DISCONNECT => {
             // normally removed when processing request,
             // but in case we missed that try again here
             let tree_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_SHARE);
             state.ssn2tree_map.remove(&tree_key);
             false
-        },
+        }
         SMB1_COMMAND_NT_CREATE_ANDX => {
-            SCLogDebug!("SMB1_COMMAND_NT_CREATE_ANDX response {:08x}", r.nt_status);
+            SCLogDebug!(
+                "SMB1_COMMAND_NT_CREATE_ANDX response {:08x}",
+                r.nt_status
+            );
             if r.nt_status == SMB_NTSTATUS_SUCCESS {
                 match parse_smb_create_andx_response_record(r.data) {
                     IResult::Done(_, cr) => {
                         SCLogDebug!("Create AndX {:?}", cr);
 
-                        let guid_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_FILENAME);
+                        let guid_key =
+                            SMBCommonHdr::from1(r, SMBHDR_TYPE_FILENAME);
                         match state.ssn2vec_map.remove(&guid_key) {
                             Some(mut p) => {
-                                p.retain(|&i|i != 0x00);
+                                p.retain(|&i| i != 0x00);
 
                                 let mut fid = cr.fid.to_vec();
                                 fid.extend_from_slice(&u32_as_bytes(r.ssn_id));
-                                SCLogDebug!("SMB1_COMMAND_NT_CREATE_ANDX fid {:?}", fid);
+                                SCLogDebug!(
+                                    "SMB1_COMMAND_NT_CREATE_ANDX fid {:?}",
+                                    fid
+                                );
                                 SCLogDebug!("fid {:?} name {:?}", fid, p);
                                 state.guid2name_map.insert(fid, p);
-                            },
+                            }
                             _ => {
                                 SCLogDebug!("SMBv1 response: GUID NOT FOUND");
-                            },
+                            }
                         }
 
-                        let tx_hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
-                        if let Some(tx) = state.get_generic_tx(1, r.command as u16, &tx_hdr) {
-                            SCLogDebug!("tx {} with {}/{} marked as done",
-                                    tx.id, r.command, &smb1_command_string(r.command));
+                        let tx_hdr =
+                            SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
+                        if let Some(tx) =
+                            state.get_generic_tx(1, r.command as u16, &tx_hdr)
+                        {
+                            SCLogDebug!(
+                                "tx {} with {}/{} marked as done",
+                                tx.id,
+                                r.command,
+                                &smb1_command_string(r.command)
+                            );
                             tx.set_status(r.nt_status, false);
                             tx.response_done = true;
 
-                            if let Some(SMBTransactionTypeData::CREATE(ref mut tdn)) = tx.type_data {
+                            if let Some(SMBTransactionTypeData::CREATE(
+                                ref mut tdn,
+                            )) = tx.type_data
+                            {
                                 tdn.create_ts = cr.create_ts.as_unix();
-                                tdn.last_access_ts = cr.last_access_ts.as_unix();
+                                tdn.last_access_ts =
+                                    cr.last_access_ts.as_unix();
                                 tdn.last_write_ts = cr.last_write_ts.as_unix();
-                                tdn.last_change_ts = cr.last_change_ts.as_unix();
+                                tdn.last_change_ts =
+                                    cr.last_change_ts.as_unix();
                                 tdn.size = cr.file_size;
                                 tdn.guid = cr.fid.to_vec();
                             }
                         }
                         true
-                    },
+                    }
                     _ => {
                         events.push(SMBEvent::MalformedData);
                         false
-                    },
+                    }
                 }
             } else {
                 false
             }
-        },
+        }
         SMB1_COMMAND_TRANS => {
             smb1_trans_response_record(state, r);
             true
-        },
+        }
         SMB1_COMMAND_SESSION_SETUP_ANDX => {
             smb1_session_setup_response(state, r);
             true
-        },
+        }
         SMB1_COMMAND_LOGOFF_ANDX => {
             tx_sync = true;
             false
-        },
-        _ => {
-            false
-        },
+        }
+        _ => false,
     };
 
     if !have_tx && tx_sync {
         match state.get_last_tx(1, r.command as u16) {
             Some(tx) => {
-                SCLogDebug!("last TX {} is CMD {}", tx.id, &smb1_command_string(r.command));
+                SCLogDebug!(
+                    "last TX {} is CMD {}",
+                    tx.id,
+                    &smb1_command_string(r.command)
+                );
                 tx.response_done = true;
                 SCLogDebug!("tx {} cmd {} is done", tx.id, r.command);
                 tx.set_status(r.nt_status, r.is_dos_error);
                 tx.set_events(events);
-            },
-            _ => {},
+            }
+            _ => {}
         }
     } else if !have_tx && smb1_check_tx(r.command) {
-        let tx_key = SMBCommonHdr::new(SMBHDR_TYPE_GENERICTX,
-                key_ssn_id as u64, key_tree_id as u32, key_multiplex_id as u64);
-        let _have_tx2 = match state.get_generic_tx(1, r.command as u16, &tx_key) {
+        let tx_key = SMBCommonHdr::new(
+            SMBHDR_TYPE_GENERICTX,
+            key_ssn_id as u64,
+            key_tree_id as u32,
+            key_multiplex_id as u64,
+        );
+        let _have_tx2 = match state.get_generic_tx(1, r.command as u16, &tx_key)
+        {
             Some(tx) => {
                 tx.request_done = true;
                 tx.response_done = true;
@@ -778,11 +874,11 @@ pub fn smb1_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 
                 tx.set_status(r.nt_status, r.is_dos_error);
                 tx.set_events(events);
                 true
-            },
+            }
             _ => {
                 SCLogDebug!("no TX found for key {:?}", tx_key);
                 false
-            },
+            }
         };
     } else {
         SCLogDebug!("have tx for cmd {}", r.command);
@@ -790,9 +886,8 @@ pub fn smb1_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 
     0
 }
 
-pub fn smb1_trans_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
-{
-    let mut events : Vec<SMBEvent> = Vec::new();
+pub fn smb1_trans_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) {
+    let mut events: Vec<SMBEvent> = Vec::new();
 
     match parse_smb_trans_request_record(r.data, r) {
         IResult::Done(_, rd) => {
@@ -802,17 +897,23 @@ pub fn smb1_trans_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
             let mut pipe_dcerpc = false;
             if rd.pipe != None {
                 let pipe = rd.pipe.unwrap();
-                state.ssn2vec_map.insert(SMBCommonHdr::from1(r, SMBHDR_TYPE_GUID),
-                        pipe.fid.to_vec());
+                state.ssn2vec_map.insert(
+                    SMBCommonHdr::from1(r, SMBHDR_TYPE_GUID),
+                    pipe.fid.to_vec(),
+                );
 
                 let mut frankenfid = pipe.fid.to_vec();
                 frankenfid.extend_from_slice(&u32_as_bytes(r.ssn_id));
 
-                let (filename, is_dcerpc) = match state.get_service_for_guid(&frankenfid) {
-                    (n, x) => (n, x),
-                };
-                SCLogDebug!("smb1_trans_request_record: name {} is_dcerpc {}",
-                        filename, is_dcerpc);
+                let (filename, is_dcerpc) =
+                    match state.get_service_for_guid(&frankenfid) {
+                        (n, x) => (n, x),
+                    };
+                SCLogDebug!(
+                    "smb1_trans_request_record: name {} is_dcerpc {}",
+                    filename,
+                    is_dcerpc
+                );
                 pipe_dcerpc = is_dcerpc;
             }
 
@@ -822,25 +923,26 @@ pub fn smb1_trans_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
                 let vercmd = SMBVerCmdStat::new1(r.command);
                 smb_write_dcerpc_record(state, vercmd, hdr, &rd.data.data);
             }
-        },
+        }
         _ => {
             events.push(SMBEvent::MalformedData);
-        },
+        }
     }
     smb1_request_record_generic(state, r, events);
 }
 
-pub fn smb1_trans_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
-{
-    let mut events : Vec<SMBEvent> = Vec::new();
+pub fn smb1_trans_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) {
+    let mut events: Vec<SMBEvent> = Vec::new();
 
     match parse_smb_trans_response_record(r.data) {
         IResult::Done(_, rd) => {
             SCLogDebug!("TRANS response {:?}", rd);
 
             // see if we have a stored fid
-            let fid = match state.ssn2vec_map.remove(
-                    &SMBCommonHdr::from1(r, SMBHDR_TYPE_GUID)) {
+            let fid = match state
+                .ssn2vec_map
+                .remove(&SMBCommonHdr::from1(r, SMBHDR_TYPE_GUID))
+            {
                 Some(f) => f,
                 None => Vec::new(),
             };
@@ -849,28 +951,40 @@ pub fn smb1_trans_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
             let mut frankenfid = fid.to_vec();
             frankenfid.extend_from_slice(&u32_as_bytes(r.ssn_id));
 
-            let (filename, is_dcerpc) = match state.get_service_for_guid(&frankenfid) {
-                (n, x) => (n, x),
-            };
-            SCLogDebug!("smb1_trans_response_record: name {} is_dcerpc {}",
-                    filename, is_dcerpc);
+            let (filename, is_dcerpc) =
+                match state.get_service_for_guid(&frankenfid) {
+                    (n, x) => (n, x),
+                };
+            SCLogDebug!(
+                "smb1_trans_response_record: name {} is_dcerpc {}",
+                filename,
+                is_dcerpc
+            );
 
             // if we get status 'BUFFER_OVERFLOW' this is only a part of
             // the data. Store it in the ssn/tree for later use.
             if r.nt_status == SMB_NTSTATUS_BUFFER_OVERFLOW {
-                let key = SMBHashKeyHdrGuid::new(SMBCommonHdr::from1(r, SMBHDR_TYPE_TRANS_FRAG), fid);
-                SCLogDebug!("SMBv1/TRANS: queueing data for len {} key {:?}", rd.data.len(), key);
+                let key = SMBHashKeyHdrGuid::new(
+                    SMBCommonHdr::from1(r, SMBHDR_TYPE_TRANS_FRAG),
+                    fid,
+                );
+                SCLogDebug!(
+                    "SMBv1/TRANS: queueing data for len {} key {:?}",
+                    rd.data.len(),
+                    key
+                );
                 state.ssnguid2vec_map.insert(key, rd.data.to_vec());
             } else if is_dcerpc {
                 SCLogDebug!("SMBv1 TRANS TO PIPE");
                 let hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_HEADER);
-                let vercmd = SMBVerCmdStat::new1_with_ntstatus(r.command, r.nt_status);
+                let vercmd =
+                    SMBVerCmdStat::new1_with_ntstatus(r.command, r.nt_status);
                 smb_read_dcerpc_record(state, vercmd, hdr, &fid, &rd.data);
             }
-        },
+        }
         _ => {
             events.push(SMBEvent::MalformedData);
-        },
+        }
     }
 
     // generic tx as well. Set events if needed.
@@ -878,9 +992,8 @@ pub fn smb1_trans_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
 }
 
 /// Handle WRITE, WRITE_ANDX, WRITE_AND_CLOSE request records
-pub fn smb1_write_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
-{
-    let mut events : Vec<SMBEvent> = Vec::new();
+pub fn smb1_write_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) {
+    let mut events: Vec<SMBEvent> = Vec::new();
 
     let result = if r.command == SMB1_COMMAND_WRITE_ANDX {
         parse_smb1_write_andx_request_record(r.data)
@@ -895,68 +1008,103 @@ pub fn smb1_write_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
 
             let mut file_fid = rd.fid.to_vec();
             file_fid.extend_from_slice(&u32_as_bytes(r.ssn_id));
-            SCLogDebug!("SMBv1 WRITE: FID {:?} offset {}",
-                    file_fid, rd.offset);
+            SCLogDebug!("SMBv1 WRITE: FID {:?} offset {}", file_fid, rd.offset);
 
             let file_name = match state.guid2name_map.get(&file_fid) {
                 Some(n) => n.to_vec(),
                 None => b"<unknown>".to_vec(),
             };
-            let found = match state.get_file_tx_by_fuid(&file_fid, STREAM_TOSERVER) {
+            let found = match state
+                .get_file_tx_by_fuid(&file_fid, STREAM_TOSERVER)
+            {
                 Some((tx, files, flags)) => {
-                    let file_id : u32 = tx.id as u32;
-                    if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                        filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                                &file_name, rd.data, rd.offset,
-                                rd.len, 0, false, &file_id);
+                    let file_id: u32 = tx.id as u32;
+                    if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) =
+                        tx.type_data
+                    {
+                        filetracker_newchunk(
+                            &mut tdf.file_tracker,
+                            files,
+                            flags,
+                            &file_name,
+                            rd.data,
+                            rd.offset,
+                            rd.len,
+                            0,
+                            false,
+                            &file_id,
+                        );
                         SCLogDebug!("FID {:?} found at tx {}", file_fid, tx.id);
                     }
                     true
-                },
-                None => { false },
+                }
+                None => false,
             };
             if !found {
                 let tree_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_SHARE);
-                let (share_name, is_pipe) = match state.ssn2tree_map.get(&tree_key) {
-                    Some(n) => (n.name.to_vec(), n.is_pipe),
-                    None => (Vec::new(), false),
-                };
+                let (share_name, is_pipe) =
+                    match state.ssn2tree_map.get(&tree_key) {
+                        Some(n) => (n.name.to_vec(), n.is_pipe),
+                        None => (Vec::new(), false),
+                    };
                 if is_pipe {
                     SCLogDebug!("SMBv1 WRITE TO PIPE");
                     let hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_HEADER);
-                    let vercmd = SMBVerCmdStat::new1_with_ntstatus(r.command, r.nt_status);
+                    let vercmd = SMBVerCmdStat::new1_with_ntstatus(
+                        r.command,
+                        r.nt_status,
+                    );
                     smb_write_dcerpc_record(state, vercmd, hdr, &rd.data);
                 } else {
-                    let (tx, files, flags) = state.new_file_tx(&file_fid, &file_name, STREAM_TOSERVER);
-                    if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                        let file_id : u32 = tx.id as u32;
+                    let (tx, files, flags) = state.new_file_tx(
+                        &file_fid,
+                        &file_name,
+                        STREAM_TOSERVER,
+                    );
+                    if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) =
+                        tx.type_data
+                    {
+                        let file_id: u32 = tx.id as u32;
                         SCLogDebug!("FID {:?} found at tx {}", file_fid, tx.id);
-                        filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                                &file_name, rd.data, rd.offset,
-                                rd.len, 0, false, &file_id);
+                        filetracker_newchunk(
+                            &mut tdf.file_tracker,
+                            files,
+                            flags,
+                            &file_name,
+                            rd.data,
+                            rd.offset,
+                            rd.len,
+                            0,
+                            false,
+                            &file_id,
+                        );
                         tdf.share_name = share_name;
                     }
                     tx.vercmd.set_smb1_cmd(SMB1_COMMAND_WRITE_ANDX);
                 }
             }
 
-            state.set_file_left(STREAM_TOSERVER, rd.len, rd.data.len() as u32, file_fid.to_vec());
+            state.set_file_left(
+                STREAM_TOSERVER,
+                rd.len,
+                rd.data.len() as u32,
+                file_fid.to_vec(),
+            );
 
             if r.command == SMB1_COMMAND_WRITE_AND_CLOSE {
                 SCLogDebug!("closing FID {:?}", file_fid);
                 smb1_close_file(state, &file_fid);
             }
-        },
+        }
         _ => {
             events.push(SMBEvent::MalformedData);
-        },
+        }
     }
     smb1_request_record_generic(state, r, events);
 }
 
-pub fn smb1_read_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
-{
-    let mut events : Vec<SMBEvent> = Vec::new();
+pub fn smb1_read_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) {
+    let mut events: Vec<SMBEvent> = Vec::new();
 
     if r.nt_status == SMB_NTSTATUS_SUCCESS {
         match parse_smb_read_andx_response_record(r.data) {
@@ -964,48 +1112,93 @@ pub fn smb1_read_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
                 SCLogDebug!("SMBv1: read response => {:?}", rd);
 
                 let fid_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_OFFSET);
-                let (offset, file_fid) = match state.ssn2vecoffset_map.remove(&fid_key) {
+                let (offset, file_fid) = match state
+                    .ssn2vecoffset_map
+                    .remove(&fid_key)
+                {
                     Some(o) => (o.offset, o.guid),
                     None => {
                         SCLogDebug!("SMBv1 READ response: reply to unknown request: left {} {:?}",
                                 rd.len - rd.data.len() as u32, rd);
-                        state.set_skip(STREAM_TOCLIENT, rd.len, rd.data.len() as u32);
+                        state.set_skip(
+                            STREAM_TOCLIENT,
+                            rd.len,
+                            rd.data.len() as u32,
+                        );
                         return;
-                    },
+                    }
                 };
                 SCLogDebug!("SMBv1 READ: FID {:?} offset {}", file_fid, offset);
 
                 let tree_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_SHARE);
-                let (is_pipe, share_name) = match state.ssn2tree_map.get(&tree_key) {
-                    Some(n) => (n.is_pipe, n.name.to_vec()),
-                    _ => { (false, Vec::new()) },
-                };
+                let (is_pipe, share_name) =
+                    match state.ssn2tree_map.get(&tree_key) {
+                        Some(n) => (n.is_pipe, n.name.to_vec()),
+                        _ => (false, Vec::new()),
+                    };
                 if !is_pipe {
                     let file_name = match state.guid2name_map.get(&file_fid) {
                         Some(n) => n.to_vec(),
                         None => Vec::new(),
                     };
-                    let found = match state.get_file_tx_by_fuid(&file_fid, STREAM_TOCLIENT) {
+                    let found = match state
+                        .get_file_tx_by_fuid(&file_fid, STREAM_TOCLIENT)
+                    {
                         Some((tx, files, flags)) => {
-                            if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                                let file_id : u32 = tx.id as u32;
-                                SCLogDebug!("FID {:?} found at tx {}", file_fid, tx.id);
-                                filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                                        &file_name, rd.data, offset,
-                                        rd.len, 0, false, &file_id);
+                            if let Some(SMBTransactionTypeData::FILE(
+                                ref mut tdf,
+                            )) = tx.type_data
+                            {
+                                let file_id: u32 = tx.id as u32;
+                                SCLogDebug!(
+                                    "FID {:?} found at tx {}",
+                                    file_fid,
+                                    tx.id
+                                );
+                                filetracker_newchunk(
+                                    &mut tdf.file_tracker,
+                                    files,
+                                    flags,
+                                    &file_name,
+                                    rd.data,
+                                    offset,
+                                    rd.len,
+                                    0,
+                                    false,
+                                    &file_id,
+                                );
                             }
                             true
-                        },
-                        None => { false },
+                        }
+                        None => false,
                     };
                     if !found {
-                        let (tx, files, flags) = state.new_file_tx(&file_fid, &file_name, STREAM_TOCLIENT);
-                        if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                            let file_id : u32 = tx.id as u32;
-                            SCLogDebug!("FID {:?} found at tx {}", file_fid, tx.id);
-                            filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                                    &file_name, rd.data, offset,
-                                    rd.len, 0, false, &file_id);
+                        let (tx, files, flags) = state.new_file_tx(
+                            &file_fid,
+                            &file_name,
+                            STREAM_TOCLIENT,
+                        );
+                        if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) =
+                            tx.type_data
+                        {
+                            let file_id: u32 = tx.id as u32;
+                            SCLogDebug!(
+                                "FID {:?} found at tx {}",
+                                file_fid,
+                                tx.id
+                            );
+                            filetracker_newchunk(
+                                &mut tdf.file_tracker,
+                                files,
+                                flags,
+                                &file_name,
+                                rd.data,
+                                offset,
+                                rd.len,
+                                0,
+                                false,
+                                &file_id,
+                            );
                             tdf.share_name = share_name;
                         }
                         tx.vercmd.set_smb1_cmd(SMB1_COMMAND_READ_ANDX);
@@ -1017,15 +1210,26 @@ pub fn smb1_read_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
 
                     // hack: we store fid with ssn id mixed in, but here we want the
                     // real thing instead.
-                    let pure_fid = if file_fid.len() > 2 { &file_fid[0..2] } else { &[] };
-                    smb_read_dcerpc_record(state, vercmd, hdr, &pure_fid, &rd.data);
+                    let pure_fid = if file_fid.len() > 2 {
+                        &file_fid[0..2]
+                    } else {
+                        &[]
+                    };
+                    smb_read_dcerpc_record(
+                        state, vercmd, hdr, &pure_fid, &rd.data,
+                    );
                 }
 
-                state.set_file_left(STREAM_TOCLIENT, rd.len, rd.data.len() as u32, file_fid.to_vec());
+                state.set_file_left(
+                    STREAM_TOCLIENT,
+                    rd.len,
+                    rd.data.len() as u32,
+                    file_fid.to_vec(),
+                );
             }
             _ => {
                 events.push(SMBEvent::MalformedData);
-            },
+            }
         }
     }
 
@@ -1036,7 +1240,11 @@ pub fn smb1_read_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
 /// create a tx for a command / response pair if we're
 /// configured to do so, or if this is a tx especially
 /// for setting an event.
-fn smb1_request_record_generic<'b>(state: &mut SMBState, r: &SmbRecord<'b>, events: Vec<SMBEvent>) {
+fn smb1_request_record_generic<'b>(
+    state: &mut SMBState,
+    r: &SmbRecord<'b>,
+    events: Vec<SMBEvent>,
+) {
     if smb1_create_new_tx(r.command) || events.len() > 0 {
         let tx_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
         let tx = state.new_generic_tx(1, r.command as u16, tx_key);
@@ -1047,7 +1255,11 @@ fn smb1_request_record_generic<'b>(state: &mut SMBState, r: &SmbRecord<'b>, even
 /// update or create a tx for a command / reponse pair based
 /// on the response. We only create a tx for the response side
 /// if we didn't already update a tx, and we have to set events
-fn smb1_response_record_generic<'b>(state: &mut SMBState, r: &SmbRecord<'b>, events: Vec<SMBEvent>) {
+fn smb1_response_record_generic<'b>(
+    state: &mut SMBState,
+    r: &SmbRecord<'b>,
+    events: Vec<SMBEvent>,
+) {
     // see if we want a tx per command
     if smb1_create_new_tx(r.command) {
         let tx_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -23,16 +23,16 @@ extern crate libc;
 
 use nom::{IResult};
 
-use core::*;
-use log::*;
+use crate::core::*;
+use crate::log::*;
 
-use smb::smb::*;
-use smb::dcerpc::*;
-use smb::events::*;
-use smb::files::*;
+use crate::smb::smb::*;
+use crate::smb::dcerpc::*;
+use crate::smb::events::*;
+use crate::smb::files::*;
 
-use smb::smb1_records::*;
-use smb::smb1_session::*;
+use crate::smb::smb1_records::*;
+use crate::smb::smb1_session::*;
 
 // https://msdn.microsoft.com/en-us/library/ee441741.aspx
 pub const SMB1_COMMAND_CREATE_DIRECTORY:        u8 = 0x00;

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -15,10 +15,10 @@
  * 02110-1301, USA.
  */
 
-use log::*;
+use crate::log::*;
 use nom::{rest, le_u8, le_u16, le_u32, le_u64, IResult};
-use smb::smb::*;
-use smb::smb_records::*;
+use crate::smb::smb::*;
+use crate::smb::smb_records::*;
 
 fn smb_get_unicode_string_with_offset(i: &[u8], offset: usize) -> IResult<&[u8], Vec<u8>>
 {

--- a/rust/src/smb/smb1_session.rs
+++ b/rust/src/smb/smb1_session.rs
@@ -17,13 +17,13 @@
 
 use nom::{IResult};
 
-use log::*;
+use crate::log::*;
 
-use smb::smb_records::*;
-use smb::smb1_records::*;
-use smb::smb::*;
-use smb::events::*;
-use smb::auth::*;
+use crate::smb::smb_records::*;
+use crate::smb::smb1_records::*;
+use crate::smb::smb::*;
+use crate::smb::events::*;
+use crate::smb::auth::*;
 
 #[derive(Debug)]
 pub struct SessionSetupRequest {

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -19,58 +19,60 @@ use crate::core::*;
 use crate::log::*;
 use nom::IResult;
 
-use crate::smb::smb::*;
-use crate::smb::smb2_records::*;
-use crate::smb::smb2_session::*;
-use crate::smb::smb2_ioctl::*;
 use crate::smb::dcerpc::*;
 use crate::smb::events::*;
 use crate::smb::files::*;
+use crate::smb::smb::*;
+use crate::smb::smb2_ioctl::*;
+use crate::smb::smb2_records::*;
+use crate::smb::smb2_session::*;
 
-pub const SMB2_COMMAND_NEGOTIATE_PROTOCOL:      u16 = 0;
-pub const SMB2_COMMAND_SESSION_SETUP:           u16 = 1;
-pub const SMB2_COMMAND_SESSION_LOGOFF:          u16 = 2;
-pub const SMB2_COMMAND_TREE_CONNECT:            u16 = 3;
-pub const SMB2_COMMAND_TREE_DISCONNECT:         u16 = 4;
-pub const SMB2_COMMAND_CREATE:                  u16 = 5;
-pub const SMB2_COMMAND_CLOSE:                   u16 = 6;
-pub const SMB2_COMMAND_FLUSH:                   u16 = 7;
-pub const SMB2_COMMAND_READ:                    u16 = 8;
-pub const SMB2_COMMAND_WRITE:                   u16 = 9;
-pub const SMB2_COMMAND_LOCK:                    u16 = 10;
-pub const SMB2_COMMAND_IOCTL:                   u16 = 11;
-pub const SMB2_COMMAND_CANCEL:                  u16 = 12;
-pub const SMB2_COMMAND_KEEPALIVE:               u16 = 13;
-pub const SMB2_COMMAND_FIND:                    u16 = 14;
-pub const SMB2_COMMAND_CHANGE_NOTIFY:           u16 = 15;
-pub const SMB2_COMMAND_GET_INFO:                u16 = 16;
-pub const SMB2_COMMAND_SET_INFO:                u16 = 17;
-pub const SMB2_COMMAND_OPLOCK_BREAK:            u16 = 18;
+pub const SMB2_COMMAND_NEGOTIATE_PROTOCOL: u16 = 0;
+pub const SMB2_COMMAND_SESSION_SETUP: u16 = 1;
+pub const SMB2_COMMAND_SESSION_LOGOFF: u16 = 2;
+pub const SMB2_COMMAND_TREE_CONNECT: u16 = 3;
+pub const SMB2_COMMAND_TREE_DISCONNECT: u16 = 4;
+pub const SMB2_COMMAND_CREATE: u16 = 5;
+pub const SMB2_COMMAND_CLOSE: u16 = 6;
+pub const SMB2_COMMAND_FLUSH: u16 = 7;
+pub const SMB2_COMMAND_READ: u16 = 8;
+pub const SMB2_COMMAND_WRITE: u16 = 9;
+pub const SMB2_COMMAND_LOCK: u16 = 10;
+pub const SMB2_COMMAND_IOCTL: u16 = 11;
+pub const SMB2_COMMAND_CANCEL: u16 = 12;
+pub const SMB2_COMMAND_KEEPALIVE: u16 = 13;
+pub const SMB2_COMMAND_FIND: u16 = 14;
+pub const SMB2_COMMAND_CHANGE_NOTIFY: u16 = 15;
+pub const SMB2_COMMAND_GET_INFO: u16 = 16;
+pub const SMB2_COMMAND_SET_INFO: u16 = 17;
+pub const SMB2_COMMAND_OPLOCK_BREAK: u16 = 18;
 
 pub fn smb2_command_string(c: u16) -> String {
     match c {
-        SMB2_COMMAND_NEGOTIATE_PROTOCOL     => "SMB2_COMMAND_NEGOTIATE_PROTOCOL",
-        SMB2_COMMAND_SESSION_SETUP          => "SMB2_COMMAND_SESSION_SETUP",
-        SMB2_COMMAND_SESSION_LOGOFF         => "SMB2_COMMAND_SESSION_LOGOFF",
-        SMB2_COMMAND_TREE_CONNECT           => "SMB2_COMMAND_TREE_CONNECT",
-        SMB2_COMMAND_TREE_DISCONNECT        => "SMB2_COMMAND_TREE_DISCONNECT",
-        SMB2_COMMAND_CREATE                 => "SMB2_COMMAND_CREATE",
-        SMB2_COMMAND_CLOSE                  => "SMB2_COMMAND_CLOSE",
-        SMB2_COMMAND_READ                   => "SMB2_COMMAND_READ",
-        SMB2_COMMAND_FLUSH                  => "SMB2_COMMAND_FLUSH",
-        SMB2_COMMAND_WRITE                  => "SMB2_COMMAND_WRITE",
-        SMB2_COMMAND_LOCK                   => "SMB2_COMMAND_LOCK",
-        SMB2_COMMAND_IOCTL                  => "SMB2_COMMAND_IOCTL",
-        SMB2_COMMAND_CANCEL                 => "SMB2_COMMAND_CANCEL",
-        SMB2_COMMAND_KEEPALIVE              => "SMB2_COMMAND_KEEPALIVE",
-        SMB2_COMMAND_FIND                   => "SMB2_COMMAND_FIND",
-        SMB2_COMMAND_CHANGE_NOTIFY          => "SMB2_COMMAND_CHANGE_NOTIFY",
-        SMB2_COMMAND_GET_INFO               => "SMB2_COMMAND_GET_INFO",
-        SMB2_COMMAND_SET_INFO               => "SMB2_COMMAND_SET_INFO",
-        SMB2_COMMAND_OPLOCK_BREAK           => "SMB2_COMMAND_OPLOCK_BREAK",
-        _ => { return (c).to_string(); },
-    }.to_string()
-
+        SMB2_COMMAND_NEGOTIATE_PROTOCOL => "SMB2_COMMAND_NEGOTIATE_PROTOCOL",
+        SMB2_COMMAND_SESSION_SETUP => "SMB2_COMMAND_SESSION_SETUP",
+        SMB2_COMMAND_SESSION_LOGOFF => "SMB2_COMMAND_SESSION_LOGOFF",
+        SMB2_COMMAND_TREE_CONNECT => "SMB2_COMMAND_TREE_CONNECT",
+        SMB2_COMMAND_TREE_DISCONNECT => "SMB2_COMMAND_TREE_DISCONNECT",
+        SMB2_COMMAND_CREATE => "SMB2_COMMAND_CREATE",
+        SMB2_COMMAND_CLOSE => "SMB2_COMMAND_CLOSE",
+        SMB2_COMMAND_READ => "SMB2_COMMAND_READ",
+        SMB2_COMMAND_FLUSH => "SMB2_COMMAND_FLUSH",
+        SMB2_COMMAND_WRITE => "SMB2_COMMAND_WRITE",
+        SMB2_COMMAND_LOCK => "SMB2_COMMAND_LOCK",
+        SMB2_COMMAND_IOCTL => "SMB2_COMMAND_IOCTL",
+        SMB2_COMMAND_CANCEL => "SMB2_COMMAND_CANCEL",
+        SMB2_COMMAND_KEEPALIVE => "SMB2_COMMAND_KEEPALIVE",
+        SMB2_COMMAND_FIND => "SMB2_COMMAND_FIND",
+        SMB2_COMMAND_CHANGE_NOTIFY => "SMB2_COMMAND_CHANGE_NOTIFY",
+        SMB2_COMMAND_GET_INFO => "SMB2_COMMAND_GET_INFO",
+        SMB2_COMMAND_SET_INFO => "SMB2_COMMAND_SET_INFO",
+        SMB2_COMMAND_OPLOCK_BREAK => "SMB2_COMMAND_OPLOCK_BREAK",
+        _ => {
+            return (c).to_string();
+        }
+    }
+    .to_string()
 }
 
 pub fn smb2_dialect_string(d: u16) -> String {
@@ -84,24 +86,29 @@ pub fn smb2_dialect_string(d: u16) -> String {
         0x0302 => "3.02",
         0x0310 => "3.10",
         0x0311 => "3.11",
-        _ => { return (d).to_string(); },
-    }.to_string()
+        _ => {
+            return (d).to_string();
+        }
+    }
+    .to_string()
 }
 
 // later we'll use this to determine if we need to
 // track a ssn per type
 fn smb2_create_new_tx(cmd: u16) -> bool {
     match cmd {
-        SMB2_COMMAND_READ |
-        SMB2_COMMAND_WRITE |
-        SMB2_COMMAND_GET_INFO |
-        SMB2_COMMAND_SET_INFO => { false },
-        _ => { true },
+        SMB2_COMMAND_READ
+        | SMB2_COMMAND_WRITE
+        | SMB2_COMMAND_GET_INFO
+        | SMB2_COMMAND_SET_INFO => false,
+        _ => true,
     }
 }
 
-fn smb2_read_response_record_generic<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
-{
+fn smb2_read_response_record_generic<'b>(
+    state: &mut SMBState,
+    r: &Smb2Record<'b>,
+) {
     if smb2_create_new_tx(r.command) {
         let tx_hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_GENERICTX);
         let tx = state.get_generic_tx(2, r.command as u16, &tx_hdr);
@@ -112,18 +119,20 @@ fn smb2_read_response_record_generic<'b>(state: &mut SMBState, r: &Smb2Record<'b
     }
 }
 
-pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
-{
+pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>) {
     smb2_read_response_record_generic(state, r);
 
     match parse_smb2_response_read(r.data) {
         IResult::Done(_, rd) => {
             if r.nt_status == SMB_NTSTATUS_BUFFER_OVERFLOW {
-                SCLogDebug!("SMBv2/READ: incomplete record, expecting a follow up");
-                // fall through
-
+                SCLogDebug!(
+                    "SMBv2/READ: incomplete record, expecting a follow up"
+                );
+            // fall through
             } else if r.nt_status != SMB_NTSTATUS_SUCCESS {
-                SCLogDebug!("SMBv2: read response error code received: skip record");
+                SCLogDebug!(
+                    "SMBv2: read response error code received: skip record"
+                );
                 state.set_skip(STREAM_TOCLIENT, rd.len, rd.data.len() as u32);
                 return;
             }
@@ -133,45 +142,71 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
             // get the request info. If we don't have it, there is nothing
             // we can do except skip this record.
             let guid_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_OFFSET);
-            let (offset, file_guid) = match state.ssn2vecoffset_map.remove(&guid_key) {
-                Some(o) => (o.offset, o.guid),
-                None => {
-                    SCLogDebug!("SMBv2 READ response: reply to unknown request {:?}",rd);
-                    state.set_skip(STREAM_TOCLIENT, rd.len, rd.data.len() as u32);
-                    return;
-                },
-            };
+            let (offset, file_guid) =
+                match state.ssn2vecoffset_map.remove(&guid_key) {
+                    Some(o) => (o.offset, o.guid),
+                    None => {
+                        SCLogDebug!(
+                        "SMBv2 READ response: reply to unknown request {:?}",
+                        rd
+                    );
+                        state.set_skip(
+                            STREAM_TOCLIENT,
+                            rd.len,
+                            rd.data.len() as u32,
+                        );
+                        return;
+                    }
+                };
             SCLogDebug!("SMBv2 READ: GUID {:?} offset {}", file_guid, offset);
 
             // look up existing tracker and if we have it update it
-            let found = match state.get_file_tx_by_fuid(&file_guid, STREAM_TOCLIENT) {
-                Some((tx, files, flags)) => {
-                    if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                        let file_id : u32 = tx.id as u32;
-                        filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                                &tdf.file_name, rd.data, offset,
-                                rd.len, 0, false, &file_id);
+            let found =
+                match state.get_file_tx_by_fuid(&file_guid, STREAM_TOCLIENT) {
+                    Some((tx, files, flags)) => {
+                        if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) =
+                            tx.type_data
+                        {
+                            let file_id: u32 = tx.id as u32;
+                            filetracker_newchunk(
+                                &mut tdf.file_tracker,
+                                files,
+                                flags,
+                                &tdf.file_name,
+                                rd.data,
+                                offset,
+                                rd.len,
+                                0,
+                                false,
+                                &file_id,
+                            );
+                        }
+                        true
                     }
-                    true
-                },
-                None => { false },
-            };
+                    None => false,
+                };
             SCLogDebug!("existing file tx? {}", found);
             if !found {
                 let tree_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_SHARE);
-                let (share_name, mut is_pipe) = match state.ssn2tree_map.get(&tree_key) {
-                    Some(n) => (n.name.to_vec(), n.is_pipe),
-                    _ => { (Vec::new(), false) },
-                };
-                let mut is_dcerpc = if is_pipe || (share_name.len() == 0 && !is_pipe) {
-                    match state.get_service_for_guid(&file_guid) {
-                        (_, x) => x,
-                    }
-                } else {
-                    false
-                };
-                SCLogDebug!("SMBv2/READ: share_name {:?} is_pipe {} is_dcerpc {}",
-                        share_name, is_pipe, is_dcerpc);
+                let (share_name, mut is_pipe) =
+                    match state.ssn2tree_map.get(&tree_key) {
+                        Some(n) => (n.name.to_vec(), n.is_pipe),
+                        _ => (Vec::new(), false),
+                    };
+                let mut is_dcerpc =
+                    if is_pipe || (share_name.len() == 0 && !is_pipe) {
+                        match state.get_service_for_guid(&file_guid) {
+                            (_, x) => x,
+                        }
+                    } else {
+                        false
+                    };
+                SCLogDebug!(
+                    "SMBv2/READ: share_name {:?} is_pipe {} is_dcerpc {}",
+                    share_name,
+                    is_pipe,
+                    is_dcerpc
+                );
 
                 if share_name.len() == 0 && !is_pipe {
                     SCLogDebug!("SMBv2/READ: no tree connect seen, we don't know if we are a pipe");
@@ -179,10 +214,14 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     if smb_dcerpc_probe(rd.data) == true {
                         SCLogDebug!("SMBv2/READ: looks like dcerpc");
                         // insert fake tree to assist in follow up lookups
-                        let tree = SMBTree::new(b"suricata::dcerpc".to_vec(), true);
+                        let tree =
+                            SMBTree::new(b"suricata::dcerpc".to_vec(), true);
                         state.ssn2tree_map.insert(tree_key, tree);
                         if !is_dcerpc {
-                            state.guid2name_map.insert(file_guid.to_vec(), b"suricata::dcerpc".to_vec());
+                            state.guid2name_map.insert(
+                                file_guid.to_vec(),
+                                b"suricata::dcerpc".to_vec(),
+                            );
                         }
                         is_pipe = true;
                         is_dcerpc = true;
@@ -194,31 +233,64 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                 if is_pipe && is_dcerpc {
                     SCLogDebug!("SMBv2 DCERPC read");
                     let hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
-                    let vercmd = SMBVerCmdStat::new2_with_ntstatus(SMB2_COMMAND_READ, r.nt_status);
-                    smb_read_dcerpc_record(state, vercmd, hdr, &file_guid, rd.data);
+                    let vercmd = SMBVerCmdStat::new2_with_ntstatus(
+                        SMB2_COMMAND_READ,
+                        r.nt_status,
+                    );
+                    smb_read_dcerpc_record(
+                        state, vercmd, hdr, &file_guid, rd.data,
+                    );
                 } else if is_pipe {
                     SCLogDebug!("non-DCERPC pipe");
-                    state.set_skip(STREAM_TOCLIENT, rd.len, rd.data.len() as u32);
+                    state.set_skip(
+                        STREAM_TOCLIENT,
+                        rd.len,
+                        rd.data.len() as u32,
+                    );
                 } else {
                     let file_name = match state.guid2name_map.get(&file_guid) {
-                        Some(n) => { n.to_vec() },
-                        None => { b"<unknown>".to_vec() },
+                        Some(n) => n.to_vec(),
+                        None => b"<unknown>".to_vec(),
                     };
-                    let (tx, files, flags) = state.new_file_tx(&file_guid, &file_name, STREAM_TOCLIENT);
-                    if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                        let file_id : u32 = tx.id as u32;
-                        filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                                &file_name, rd.data, offset,
-                                rd.len, 0, false, &file_id);
+                    let (tx, files, flags) = state.new_file_tx(
+                        &file_guid,
+                        &file_name,
+                        STREAM_TOCLIENT,
+                    );
+                    if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) =
+                        tx.type_data
+                    {
+                        let file_id: u32 = tx.id as u32;
+                        filetracker_newchunk(
+                            &mut tdf.file_tracker,
+                            files,
+                            flags,
+                            &file_name,
+                            rd.data,
+                            offset,
+                            rd.len,
+                            0,
+                            false,
+                            &file_id,
+                        );
                         tdf.share_name = share_name;
                     }
                     tx.vercmd.set_smb2_cmd(SMB2_COMMAND_READ);
-                    tx.hdr = SMBCommonHdr::new(SMBHDR_TYPE_HEADER,
-                            r.session_id, r.tree_id, 0); // TODO move into new_file_tx
+                    tx.hdr = SMBCommonHdr::new(
+                        SMBHDR_TYPE_HEADER,
+                        r.session_id,
+                        r.tree_id,
+                        0,
+                    ); // TODO move into new_file_tx
                 }
             }
 
-            state.set_file_left(STREAM_TOCLIENT, rd.len, rd.data.len() as u32, file_guid.to_vec());
+            state.set_file_left(
+                STREAM_TOCLIENT,
+                rd.len,
+                rd.data.len() as u32,
+                file_guid.to_vec(),
+            );
         }
         _ => {
             SCLogDebug!("SMBv2: failed to parse read response");
@@ -227,8 +299,7 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
     }
 }
 
-pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
-{
+pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>) {
     SCLogDebug!("SMBv2/WRITE: request record");
     if smb2_create_new_tx(r.command) {
         let tx_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_GENERICTX);
@@ -247,33 +318,51 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                 None => Vec::new(),
             };
 
-            let found = match state.get_file_tx_by_fuid(&file_guid, STREAM_TOSERVER) {
-                Some((tx, files, flags)) => {
-                    if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                        let file_id : u32 = tx.id as u32;
-                        filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                                &file_name, wr.data, wr.wr_offset,
-                                wr.wr_len, 0, false, &file_id);
+            let found =
+                match state.get_file_tx_by_fuid(&file_guid, STREAM_TOSERVER) {
+                    Some((tx, files, flags)) => {
+                        if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) =
+                            tx.type_data
+                        {
+                            let file_id: u32 = tx.id as u32;
+                            filetracker_newchunk(
+                                &mut tdf.file_tracker,
+                                files,
+                                flags,
+                                &file_name,
+                                wr.data,
+                                wr.wr_offset,
+                                wr.wr_len,
+                                0,
+                                false,
+                                &file_id,
+                            );
+                        }
+                        true
                     }
-                    true
-                },
-                None => { false },
-            };
+                    None => false,
+                };
             if !found {
                 let tree_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_SHARE);
-                let (share_name, mut is_pipe) = match state.ssn2tree_map.get(&tree_key) {
-                    Some(n) => { (n.name.to_vec(), n.is_pipe) },
-                    _ => { (Vec::new(), false) },
-                };
-                let mut is_dcerpc = if is_pipe || (share_name.len() == 0 && !is_pipe) {
-                    match state.get_service_for_guid(&wr.guid) {
-                        (_, x) => x,
-                    }
-                } else {
-                    false
-                };
-                SCLogDebug!("SMBv2/WRITE: share_name {:?} is_pipe {} is_dcerpc {}",
-                        share_name, is_pipe, is_dcerpc);
+                let (share_name, mut is_pipe) =
+                    match state.ssn2tree_map.get(&tree_key) {
+                        Some(n) => (n.name.to_vec(), n.is_pipe),
+                        _ => (Vec::new(), false),
+                    };
+                let mut is_dcerpc =
+                    if is_pipe || (share_name.len() == 0 && !is_pipe) {
+                        match state.get_service_for_guid(&wr.guid) {
+                            (_, x) => x,
+                        }
+                    } else {
+                        false
+                    };
+                SCLogDebug!(
+                    "SMBv2/WRITE: share_name {:?} is_pipe {} is_dcerpc {}",
+                    share_name,
+                    is_pipe,
+                    is_dcerpc
+                );
 
                 // if we missed the TREE connect we can't be sure if 'is_dcerpc' is correct
                 if share_name.len() == 0 && !is_pipe {
@@ -282,11 +371,14 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     if smb_dcerpc_probe(wr.data) == true {
                         SCLogDebug!("SMBv2/WRITE: looks like we have dcerpc");
 
-                        let tree = SMBTree::new(b"suricata::dcerpc".to_vec(), true);
+                        let tree =
+                            SMBTree::new(b"suricata::dcerpc".to_vec(), true);
                         state.ssn2tree_map.insert(tree_key, tree);
                         if !is_dcerpc {
-                            state.guid2name_map.insert(file_guid.to_vec(),
-                                    b"suricata::dcerpc".to_vec());
+                            state.guid2name_map.insert(
+                                file_guid.to_vec(),
+                                b"suricata::dcerpc".to_vec(),
+                            );
                         }
                         is_pipe = true;
                         is_dcerpc = true;
@@ -301,34 +393,65 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     smb_write_dcerpc_record(state, vercmd, hdr, wr.data);
                 } else if is_pipe {
                     SCLogDebug!("non-DCERPC pipe: skip rest of the record");
-                    state.set_skip(STREAM_TOSERVER, wr.wr_len, wr.data.len() as u32);
+                    state.set_skip(
+                        STREAM_TOSERVER,
+                        wr.wr_len,
+                        wr.data.len() as u32,
+                    );
                 } else {
-                    let (tx, files, flags) = state.new_file_tx(&file_guid, &file_name, STREAM_TOSERVER);
-                    if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                        let file_id : u32 = tx.id as u32;
-                        filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                                &file_name, wr.data, wr.wr_offset,
-                                wr.wr_len, 0, false, &file_id);
+                    let (tx, files, flags) = state.new_file_tx(
+                        &file_guid,
+                        &file_name,
+                        STREAM_TOSERVER,
+                    );
+                    if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) =
+                        tx.type_data
+                    {
+                        let file_id: u32 = tx.id as u32;
+                        filetracker_newchunk(
+                            &mut tdf.file_tracker,
+                            files,
+                            flags,
+                            &file_name,
+                            wr.data,
+                            wr.wr_offset,
+                            wr.wr_len,
+                            0,
+                            false,
+                            &file_id,
+                        );
                     }
                     tx.vercmd.set_smb2_cmd(SMB2_COMMAND_WRITE);
-                    tx.hdr = SMBCommonHdr::new(SMBHDR_TYPE_HEADER,
-                            r.session_id, r.tree_id, 0); // TODO move into new_file_tx
+                    tx.hdr = SMBCommonHdr::new(
+                        SMBHDR_TYPE_HEADER,
+                        r.session_id,
+                        r.tree_id,
+                        0,
+                    ); // TODO move into new_file_tx
                 }
             }
-            state.set_file_left(STREAM_TOSERVER, wr.wr_len, wr.data.len() as u32, file_guid.to_vec());
-        },
+            state.set_file_left(
+                STREAM_TOSERVER,
+                wr.wr_len,
+                wr.data.len() as u32,
+                file_guid.to_vec(),
+            );
+        }
         _ => {
             state.set_event(SMBEvent::MalformedData);
-        },
+        }
     }
 }
 
-pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
-{
-    SCLogDebug!("SMBv2 request record, command {} tree {} session {}",
-            &smb2_command_string(r.command), r.tree_id, r.session_id);
+pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>) {
+    SCLogDebug!(
+        "SMBv2 request record, command {} tree {} session {}",
+        &smb2_command_string(r.command),
+        r.tree_id,
+        r.session_id
+    );
 
-    let mut events : Vec<SMBEvent> = Vec::new();
+    let mut events: Vec<SMBEvent> = Vec::new();
 
     let have_tx = match r.command {
         SMB2_COMMAND_SET_INFO => {
@@ -338,14 +461,19 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     SCLogDebug!("SMB2_COMMAND_SET_INFO: {:?}", rd);
 
                     if let Some(ref ren) = rd.rename {
-                        let tx_hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_GENERICTX);
+                        let tx_hdr =
+                            SMBCommonHdr::from2(r, SMBHDR_TYPE_GENERICTX);
                         let mut newname = ren.name.to_vec();
-                        newname.retain(|&i|i != 0x00);
+                        newname.retain(|&i| i != 0x00);
                         let oldname = match state.guid2name_map.get(rd.guid) {
-                            Some(n) => { n.to_vec() },
-                            None => { b"<unknown>".to_vec() },
+                            Some(n) => n.to_vec(),
+                            None => b"<unknown>".to_vec(),
                         };
-                        let tx = state.new_rename_tx(rd.guid.to_vec(), oldname, newname);
+                        let tx = state.new_rename_tx(
+                            rd.guid.to_vec(),
+                            oldname,
+                            newname,
+                        );
                         tx.hdr = tx_hdr;
                         tx.request_done = true;
                         tx.vercmd.set_smb2_cmd(SMB2_COMMAND_SET_INFO);
@@ -353,24 +481,24 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     } else {
                         false
                     }
-                },
+                }
                 IResult::Incomplete(_n) => {
                     SCLogDebug!("SMB2_COMMAND_SET_INFO: {:?}", _n);
                     events.push(SMBEvent::MalformedData);
                     false
-                },
+                }
                 IResult::Error(_e) => {
                     SCLogDebug!("SMB2_COMMAND_SET_INFO: {:?}", _e);
                     events.push(SMBEvent::MalformedData);
                     false
-                },
+                }
             };
             have_si_tx
-        },
+        }
         SMB2_COMMAND_IOCTL => {
             smb2_ioctl_request_record(state, r);
             true
-        },
+        }
         SMB2_COMMAND_TREE_DISCONNECT => {
             let tree_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_SHARE);
             state.ssn2tree_map.remove(&tree_key);
@@ -379,9 +507,13 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
         SMB2_COMMAND_NEGOTIATE_PROTOCOL => {
             match parse_smb2_request_negotiate_protocol(r.data) {
                 IResult::Done(_, rd) => {
-                    let mut dialects : Vec<Vec<u8>> = Vec::new();
+                    let mut dialects: Vec<Vec<u8>> = Vec::new();
                     for d in rd.dialects_vec {
-                        SCLogDebug!("dialect {:x} => {}", d, &smb2_dialect_string(d));
+                        SCLogDebug!(
+                            "dialect {:x} => {}",
+                            d,
+                            &smb2_dialect_string(d)
+                        );
                         let dvec = smb2_dialect_string(d).as_bytes().to_vec();
                         dialects.push(dvec);
                     }
@@ -390,35 +522,38 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         Some(_) => {
                             SCLogDebug!("WEIRD, should not have NEGOTIATE tx!");
                             true
-                        },
-                        None => { false },
+                        }
+                        None => false,
                     };
                     if !found {
                         let tx = state.new_negotiate_tx(2);
-                        if let Some(SMBTransactionTypeData::NEGOTIATE(ref mut tdn)) = tx.type_data {
+                        if let Some(SMBTransactionTypeData::NEGOTIATE(
+                            ref mut tdn,
+                        )) = tx.type_data
+                        {
                             tdn.dialects2 = dialects;
                             tdn.client_guid = Some(rd.client_guid.to_vec());
                         }
                         tx.request_done = true;
                     }
                     true
-                },
+                }
                 _ => {
                     events.push(SMBEvent::MalformedData);
                     false
-                },
+                }
             }
-        },
+        }
         SMB2_COMMAND_SESSION_SETUP => {
             smb2_session_setup_request(state, r);
             true
-        },
+        }
         SMB2_COMMAND_TREE_CONNECT => {
             match parse_smb2_request_tree_connect(r.data) {
                 IResult::Done(_, tr) => {
                     let name_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_TREE);
                     let mut name_val = tr.share_name.to_vec();
-                    name_val.retain(|&i|i != 0x00);
+                    name_val.retain(|&i| i != 0x00);
                     if name_val.len() > 1 {
                         name_val = name_val[1..].to_vec();
                     }
@@ -431,9 +566,9 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                 _ => {
                     events.push(SMBEvent::MalformedData);
                     false
-                },
+                }
             }
-        },
+        }
         SMB2_COMMAND_READ => {
             match parse_smb2_request_read(r.data) {
                 IResult::Done(_, rd) => {
@@ -442,50 +577,59 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
 
                     // store read guid,offset in map
                     let guid_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_OFFSET);
-                    let guidoff = SMBFileGUIDOffset::new(rd.guid.to_vec(), rd.rd_offset);
+                    let guidoff =
+                        SMBFileGUIDOffset::new(rd.guid.to_vec(), rd.rd_offset);
                     state.ssn2vecoffset_map.insert(guid_key, guidoff);
-                },
+                }
                 _ => {
                     events.push(SMBEvent::MalformedData);
-                },
+                }
             }
             false
-        },
-        SMB2_COMMAND_CREATE => {
-            match parse_smb2_request_create(r.data) {
-                IResult::Done(_, cr) => {
-                    let del = cr.create_options & 0x0000_1000 != 0;
-                    let dir = cr.create_options & 0x0000_0001 != 0;
+        }
+        SMB2_COMMAND_CREATE => match parse_smb2_request_create(r.data) {
+            IResult::Done(_, cr) => {
+                let del = cr.create_options & 0x0000_1000 != 0;
+                let dir = cr.create_options & 0x0000_0001 != 0;
 
-                    SCLogDebug!("create_options {:08x}", cr.create_options);
+                SCLogDebug!("create_options {:08x}", cr.create_options);
 
-                    let name_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_FILENAME);
-                    state.ssn2vec_map.insert(name_key, cr.data.to_vec());
+                let name_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_FILENAME);
+                state.ssn2vec_map.insert(name_key, cr.data.to_vec());
 
-                    let tx_hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_GENERICTX);
-                    let tx = state.new_create_tx(&cr.data.to_vec(),
-                            cr.disposition, del, dir, tx_hdr);
-                    tx.vercmd.set_smb2_cmd(r.command);
-                    SCLogDebug!("TS CREATE TX {} created", tx.id);
-                    true
-                },
-                _ => {
-                    events.push(SMBEvent::MalformedData);
-                    false
-                },
+                let tx_hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_GENERICTX);
+                let tx = state.new_create_tx(
+                    &cr.data.to_vec(),
+                    cr.disposition,
+                    del,
+                    dir,
+                    tx_hdr,
+                );
+                tx.vercmd.set_smb2_cmd(r.command);
+                SCLogDebug!("TS CREATE TX {} created", tx.id);
+                true
+            }
+            _ => {
+                events.push(SMBEvent::MalformedData);
+                false
             }
         },
         SMB2_COMMAND_WRITE => {
             smb2_write_request_record(state, &r);
             true // write handling creates both file tx and generic tx
-        },
+        }
         SMB2_COMMAND_CLOSE => {
             match parse_smb2_request_close(r.data) {
                 IResult::Done(_, cd) => {
-                    let found_ts = match state.get_file_tx_by_fuid(&cd.guid.to_vec(), STREAM_TOSERVER) {
+                    let found_ts = match state
+                        .get_file_tx_by_fuid(&cd.guid.to_vec(), STREAM_TOSERVER)
+                    {
                         Some((tx, files, flags)) => {
                             if !tx.request_done {
-                                if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
+                                if let Some(SMBTransactionTypeData::FILE(
+                                    ref mut tdf,
+                                )) = tx.type_data
+                                {
                                     tdf.file_tracker.close(files, flags);
                                 }
                             }
@@ -493,13 +637,18 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                             tx.response_done = true;
                             tx.set_status(SMB_NTSTATUS_SUCCESS, false);
                             true
-                        },
-                        None => { false },
+                        }
+                        None => false,
                     };
-                    let found_tc = match state.get_file_tx_by_fuid(&cd.guid.to_vec(), STREAM_TOCLIENT) {
+                    let found_tc = match state
+                        .get_file_tx_by_fuid(&cd.guid.to_vec(), STREAM_TOCLIENT)
+                    {
                         Some((tx, files, flags)) => {
                             if !tx.request_done {
-                                if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
+                                if let Some(SMBTransactionTypeData::FILE(
+                                    ref mut tdf,
+                                )) = tx.type_data
+                                {
                                     tdf.file_tracker.close(files, flags);
                                 }
                             }
@@ -507,22 +656,23 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                             tx.response_done = true;
                             tx.set_status(SMB_NTSTATUS_SUCCESS, false);
                             true
-                        },
-                        None => { false },
+                        }
+                        None => false,
                     };
                     if !found_ts && !found_tc {
-                        SCLogDebug!("SMBv2: CLOSE(TS): no TX at GUID {:?}", cd.guid);
+                        SCLogDebug!(
+                            "SMBv2: CLOSE(TS): no TX at GUID {:?}",
+                            cd.guid
+                        );
                     }
-                },
+                }
                 _ => {
                     events.push(SMBEvent::MalformedData);
-                },
+                }
             }
             false
-        },
-        _ => {
-            false
-        },
+        }
+        _ => false,
     };
     /* if we don't have a tx, create it here (maybe) */
     if !have_tx {
@@ -536,114 +686,145 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
     }
 }
 
-pub fn smb2_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
-{
+pub fn smb2_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>) {
     SCLogDebug!("SMBv2 response record, command {} status {} tree {} session {} message {}",
             &smb2_command_string(r.command), &smb_ntstatus_string(r.nt_status),
             r.tree_id, r.session_id, r.message_id);
 
-    let mut events : Vec<SMBEvent> = Vec::new();
+    let mut events: Vec<SMBEvent> = Vec::new();
 
     let have_tx = match r.command {
         SMB2_COMMAND_IOCTL => {
             smb2_ioctl_response_record(state, r);
             true
-        },
+        }
         SMB2_COMMAND_SESSION_SETUP => {
             smb2_session_setup_response(state, r);
             true
-        },
+        }
         SMB2_COMMAND_WRITE => {
             if r.nt_status == SMB_NTSTATUS_SUCCESS {
-                match parse_smb2_response_write(r.data)
-                {
+                match parse_smb2_response_write(r.data) {
                     IResult::Done(_, wr) => {
                         SCLogDebug!("SMBv2: Write response => {:?}", wr);
 
                         /* search key-guid map */
-                        let guid_key = SMBCommonHdr::new(SMBHDR_TYPE_GUID,
-                                r.session_id, r.tree_id, r.message_id);
-                        let guid_vec = match state.ssn2vec_map.remove(&guid_key) {
+                        let guid_key = SMBCommonHdr::new(
+                            SMBHDR_TYPE_GUID,
+                            r.session_id,
+                            r.tree_id,
+                            r.message_id,
+                        );
+                        let guid_vec = match state.ssn2vec_map.remove(&guid_key)
+                        {
                             Some(p) => p,
                             None => {
                                 SCLogDebug!("SMBv2 response: GUID NOT FOUND");
                                 Vec::new()
-                            },
+                            }
                         };
-                        SCLogDebug!("SMBv2 write response for GUID {:?}", guid_vec);
+                        SCLogDebug!(
+                            "SMBv2 write response for GUID {:?}",
+                            guid_vec
+                        );
                     }
                     _ => {
                         events.push(SMBEvent::MalformedData);
-                    },
+                    }
                 }
             }
             false // the request may have created a generic tx, so handle that here
-        },
+        }
         SMB2_COMMAND_READ => {
-            if r.nt_status == SMB_NTSTATUS_SUCCESS ||
-               r.nt_status == SMB_NTSTATUS_BUFFER_OVERFLOW {
+            if r.nt_status == SMB_NTSTATUS_SUCCESS
+                || r.nt_status == SMB_NTSTATUS_BUFFER_OVERFLOW
+            {
                 smb2_read_response_record(state, &r);
                 false
-
             } else if r.nt_status == SMB_NTSTATUS_END_OF_FILE {
                 SCLogDebug!("SMBv2: read response => EOF");
 
                 let guid_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_OFFSET);
-                let file_guid = match state.ssn2vecoffset_map.remove(&guid_key) {
+                let file_guid = match state.ssn2vecoffset_map.remove(&guid_key)
+                {
                     Some(o) => o.guid,
                     _ => {
-                        SCLogDebug!("SMBv2 READ response: reply to unknown request");
+                        SCLogDebug!(
+                            "SMBv2 READ response: reply to unknown request"
+                        );
                         Vec::new()
-                    },
+                    }
                 };
-                let found = match state.get_file_tx_by_fuid(&file_guid, STREAM_TOCLIENT) {
+                let found = match state
+                    .get_file_tx_by_fuid(&file_guid, STREAM_TOCLIENT)
+                {
                     Some((tx, files, flags)) => {
                         if !tx.request_done {
-                            if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
+                            if let Some(SMBTransactionTypeData::FILE(
+                                ref mut tdf,
+                            )) = tx.type_data
+                            {
                                 tdf.file_tracker.close(files, flags);
                             }
                         }
                         tx.set_status(r.nt_status, false);
                         tx.request_done = true;
                         false
-                    },
-                    None => { false },
+                    }
+                    None => false,
                 };
                 if !found {
                     SCLogDebug!("SMBv2 READ: no TX at GUID {:?}", file_guid);
                 }
                 false
             } else {
-                SCLogDebug!("SMBv2 READ: status {}", &smb_ntstatus_string(r.nt_status));
+                SCLogDebug!(
+                    "SMBv2 READ: status {}",
+                    &smb_ntstatus_string(r.nt_status)
+                );
                 false
             }
-        },
+        }
         SMB2_COMMAND_CREATE => {
             if r.nt_status == SMB_NTSTATUS_SUCCESS {
                 match parse_smb2_response_create(r.data) {
                     IResult::Done(_, cr) => {
                         SCLogDebug!("SMBv2: Create response => {:?}", cr);
 
-                        let guid_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_FILENAME);
-                        if let Some(mut p) = state.ssn2vec_map.remove(&guid_key) {
-                            p.retain(|&i|i != 0x00);
+                        let guid_key =
+                            SMBCommonHdr::from2(r, SMBHDR_TYPE_FILENAME);
+                        if let Some(mut p) = state.ssn2vec_map.remove(&guid_key)
+                        {
+                            p.retain(|&i| i != 0x00);
                             state.guid2name_map.insert(cr.guid.to_vec(), p);
                         } else {
                             SCLogDebug!("SMBv2 response: GUID NOT FOUND");
                         }
 
-                        let tx_hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_GENERICTX);
-                        if let Some(tx) = state.get_generic_tx(2, r.command, &tx_hdr) {
-                            SCLogDebug!("tx {} with {}/{} marked as done",
-                                    tx.id, r.command, &smb2_command_string(r.command));
+                        let tx_hdr =
+                            SMBCommonHdr::from2(r, SMBHDR_TYPE_GENERICTX);
+                        if let Some(tx) =
+                            state.get_generic_tx(2, r.command, &tx_hdr)
+                        {
+                            SCLogDebug!(
+                                "tx {} with {}/{} marked as done",
+                                tx.id,
+                                r.command,
+                                &smb2_command_string(r.command)
+                            );
                             tx.set_status(r.nt_status, false);
                             tx.response_done = true;
 
-                            if let Some(SMBTransactionTypeData::CREATE(ref mut tdn)) = tx.type_data {
+                            if let Some(SMBTransactionTypeData::CREATE(
+                                ref mut tdn,
+                            )) = tx.type_data
+                            {
                                 tdn.create_ts = cr.create_ts.as_unix();
-                                tdn.last_access_ts = cr.last_access_ts.as_unix();
+                                tdn.last_access_ts =
+                                    cr.last_access_ts.as_unix();
                                 tdn.last_write_ts = cr.last_write_ts.as_unix();
-                                tdn.last_change_ts = cr.last_change_ts.as_unix();
+                                tdn.last_change_ts =
+                                    cr.last_change_ts.as_unix();
                                 tdn.size = cr.size;
                                 tdn.guid = cr.guid.to_vec();
                             }
@@ -651,13 +832,13 @@ pub fn smb2_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     }
                     _ => {
                         events.push(SMBEvent::MalformedData);
-                    },
+                    }
                 }
                 true
             } else {
                 false
             }
-        },
+        }
         SMB2_COMMAND_TREE_DISCONNECT => {
             // normally removed when processing request,
             // but in case we missed that try again here
@@ -674,23 +855,31 @@ pub fn smb2_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         let is_pipe = tr.share_type == 2;
                         let found = match state.get_treeconnect_tx(name_key) {
                             Some(tx) => {
-                                if let Some(SMBTransactionTypeData::TREECONNECT(ref mut tdn)) = tx.type_data {
+                                if let Some(
+                                    SMBTransactionTypeData::TREECONNECT(
+                                        ref mut tdn,
+                                    ),
+                                ) = tx.type_data
+                                {
                                     tdn.share_type = tr.share_type;
                                     tdn.is_pipe = is_pipe;
                                     tdn.tree_id = r.tree_id as u32;
                                     share_name = tdn.share_name.to_vec();
                                 }
                                 // update hdr now that we have a tree_id
-                                tx.hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
+                                tx.hdr =
+                                    SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
                                 tx.response_done = true;
                                 tx.set_status(r.nt_status, false);
                                 true
-                            },
-                            None => { false },
+                            }
+                            None => false,
                         };
                         if found {
-                            let tree = SMBTree::new(share_name.to_vec(), is_pipe);
-                            let tree_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_SHARE);
+                            let tree =
+                                SMBTree::new(share_name.to_vec(), is_pipe);
+                            let tree_key =
+                                SMBCommonHdr::from2(r, SMBHDR_TYPE_SHARE);
                             state.ssn2tree_map.insert(tree_key, tree);
                         }
                         true
@@ -698,7 +887,7 @@ pub fn smb2_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     _ => {
                         events.push(SMBEvent::MalformedData);
                         false
-                    },
+                    }
                 }
             } else {
                 let name_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_TREE);
@@ -707,12 +896,12 @@ pub fn smb2_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         tx.response_done = true;
                         tx.set_status(r.nt_status, false);
                         true
-                    },
-                    None => { false },
+                    }
+                    None => false,
                 };
                 found
             }
-        },
+        }
         SMB2_COMMAND_NEGOTIATE_PROTOCOL => {
             let res = if r.nt_status == SMB_NTSTATUS_SUCCESS {
                 parse_smb2_response_negotiate_protocol(r.data)
@@ -721,65 +910,85 @@ pub fn smb2_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
             };
             match res {
                 IResult::Done(_, rd) => {
-                    SCLogDebug!("SERVER dialect => {}", &smb2_dialect_string(rd.dialect));
+                    SCLogDebug!(
+                        "SERVER dialect => {}",
+                        &smb2_dialect_string(rd.dialect)
+                    );
 
                     state.dialect = rd.dialect;
                     let found2 = match state.get_negotiate_tx(2) {
                         Some(tx) => {
-                            if let Some(SMBTransactionTypeData::NEGOTIATE(ref mut tdn)) = tx.type_data {
+                            if let Some(SMBTransactionTypeData::NEGOTIATE(
+                                ref mut tdn,
+                            )) = tx.type_data
+                            {
                                 tdn.server_guid = rd.server_guid.to_vec();
                             }
                             tx.set_status(r.nt_status, false);
                             tx.response_done = true;
                             true
-                        },
-                        None => { false },
+                        }
+                        None => false,
                     };
                     // SMB2 response to SMB1 request?
-                    let found1 = !found2 && match state.get_negotiate_tx(1) {
-                        Some(tx) => {
-                            if let Some(SMBTransactionTypeData::NEGOTIATE(ref mut tdn)) = tx.type_data {
-                                tdn.server_guid = rd.server_guid.to_vec();
+                    let found1 = !found2
+                        && match state.get_negotiate_tx(1) {
+                            Some(tx) => {
+                                if let Some(
+                                    SMBTransactionTypeData::NEGOTIATE(
+                                        ref mut tdn,
+                                    ),
+                                ) = tx.type_data
+                                {
+                                    tdn.server_guid = rd.server_guid.to_vec();
+                                }
+                                tx.set_status(r.nt_status, false);
+                                tx.response_done = true;
+                                true
                             }
-                            tx.set_status(r.nt_status, false);
-                            tx.response_done = true;
-                            true
-                        },
-                        None => { false },
-                    };
+                            None => false,
+                        };
                     found1 || found2
-                },
+                }
                 _ => {
                     events.push(SMBEvent::MalformedData);
                     false
                 }
             }
-        },
+        }
         _ => {
             SCLogDebug!("default case: no TX");
             false
-        },
+        }
     };
     if !have_tx {
         let tx_hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_GENERICTX);
-        SCLogDebug!("looking for TX {} with session_id {} tree_id {} message_id {}",
-                &smb2_command_string(r.command),
-                r.session_id, r.tree_id, r.message_id);
+        SCLogDebug!(
+            "looking for TX {} with session_id {} tree_id {} message_id {}",
+            &smb2_command_string(r.command),
+            r.session_id,
+            r.tree_id,
+            r.message_id
+        );
         let _found = match state.get_generic_tx(2, r.command, &tx_hdr) {
             Some(tx) => {
-                SCLogDebug!("tx {} with {}/{} marked as done",
-                        tx.id, r.command, &smb2_command_string(r.command));
+                SCLogDebug!(
+                    "tx {} with {}/{} marked as done",
+                    tx.id,
+                    r.command,
+                    &smb2_command_string(r.command)
+                );
                 if r.nt_status != SMB_NTSTATUS_PENDING {
                     tx.response_done = true;
                 }
                 tx.set_status(r.nt_status, false);
                 tx.set_events(events);
                 true
-            },
+            }
             _ => {
                 SCLogDebug!("no tx found for {:?}", r);
                 false
-            },
+            }
         };
     }
 }

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -15,17 +15,17 @@
  * 02110-1301, USA.
  */
 
-use core::*;
-use log::*;
+use crate::core::*;
+use crate::log::*;
 use nom::IResult;
 
-use smb::smb::*;
-use smb::smb2_records::*;
-use smb::smb2_session::*;
-use smb::smb2_ioctl::*;
-use smb::dcerpc::*;
-use smb::events::*;
-use smb::files::*;
+use crate::smb::smb::*;
+use crate::smb::smb2_records::*;
+use crate::smb::smb2_session::*;
+use crate::smb::smb2_ioctl::*;
+use crate::smb::dcerpc::*;
+use crate::smb::events::*;
+use crate::smb::files::*;
 
 pub const SMB2_COMMAND_NEGOTIATE_PROTOCOL:      u16 = 0;
 pub const SMB2_COMMAND_SESSION_SETUP:           u16 = 1;

--- a/rust/src/smb/smb2_ioctl.rs
+++ b/rust/src/smb/smb2_ioctl.rs
@@ -16,13 +16,13 @@
  */
 
 use nom::IResult;
-use log::*;
-use smb::smb::*;
-use smb::smb2::*;
-use smb::smb2_records::*;
-use smb::dcerpc::*;
-use smb::events::*;
-use smb::funcs::*;
+use crate::log::*;
+use crate::smb::smb::*;
+use crate::smb::smb2::*;
+use crate::smb::smb2_records::*;
+use crate::smb::dcerpc::*;
+use crate::smb::events::*;
+use crate::smb::funcs::*;
 
 #[derive(Debug)]
 pub struct SMBTransactionIoctl {

--- a/rust/src/smb/smb2_ioctl.rs
+++ b/rust/src/smb/smb2_ioctl.rs
@@ -15,14 +15,14 @@
  * 02110-1301, USA.
  */
 
-use nom::IResult;
 use crate::log::*;
-use crate::smb::smb::*;
-use crate::smb::smb2::*;
-use crate::smb::smb2_records::*;
 use crate::smb::dcerpc::*;
 use crate::smb::events::*;
 use crate::smb::funcs::*;
+use crate::smb::smb::*;
+use crate::smb::smb2::*;
+use crate::smb::smb2_records::*;
+use nom::IResult;
 
 #[derive(Debug)]
 pub struct SMBTransactionIoctl {
@@ -31,25 +31,30 @@ pub struct SMBTransactionIoctl {
 
 impl SMBTransactionIoctl {
     pub fn new(func: u32) -> SMBTransactionIoctl {
-        return SMBTransactionIoctl {
-            func: func,
-        }
+        return SMBTransactionIoctl { func: func };
     }
 }
 
 impl SMBState {
-    pub fn new_ioctl_tx(&mut self, hdr: SMBCommonHdr, func: u32)
-        -> (&mut SMBTransaction)
-    {
+    pub fn new_ioctl_tx(
+        &mut self,
+        hdr: SMBCommonHdr,
+        func: u32,
+    ) -> (&mut SMBTransaction) {
         let mut tx = self.new_tx();
         tx.hdr = hdr;
         tx.type_data = Some(SMBTransactionTypeData::IOCTL(
-                    SMBTransactionIoctl::new(func)));
+            SMBTransactionIoctl::new(func),
+        ));
         tx.request_done = true;
         tx.response_done = self.tc_trunc; // no response expected if tc is truncated
 
-        SCLogDebug!("SMB: TX IOCTL created: ID {} FUNC {:08x}: {}",
-                tx.id, func, &fsctl_func_to_string(func));
+        SCLogDebug!(
+            "SMB: TX IOCTL created: ID {} FUNC {:08x}: {}",
+            tx.id,
+            func,
+            &fsctl_func_to_string(func)
+        );
         self.transactions.push(tx);
         let tx_ref = self.transactions.last_mut();
         return tx_ref.unwrap();
@@ -57,63 +62,79 @@ impl SMBState {
 }
 
 // IOCTL responses ASYNC don't set the tree id
-pub fn smb2_ioctl_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
-{
+pub fn smb2_ioctl_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>) {
     let hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
     match parse_smb2_request_ioctl(r.data) {
         IResult::Done(_, rd) => {
             SCLogDebug!("IOCTL request data: {:?}", rd);
-            let is_dcerpc = rd.is_pipe && match state.get_service_for_guid(&rd.guid) {
-                (_, x) => x,
-            };
+            let is_dcerpc = rd.is_pipe
+                && match state.get_service_for_guid(&rd.guid) {
+                    (_, x) => x,
+                };
             if is_dcerpc {
                 SCLogDebug!("IOCTL request data is_pipe. Calling smb_write_dcerpc_record");
                 let vercmd = SMBVerCmdStat::new2(SMB2_COMMAND_IOCTL);
                 smb_write_dcerpc_record(state, vercmd, hdr, rd.data);
             } else {
-                SCLogDebug!("IOCTL {:08x} {}", rd.function, &fsctl_func_to_string(rd.function));
+                SCLogDebug!(
+                    "IOCTL {:08x} {}",
+                    rd.function,
+                    &fsctl_func_to_string(rd.function)
+                );
                 let tx = state.new_ioctl_tx(hdr, rd.function);
                 tx.vercmd.set_smb2_cmd(SMB2_COMMAND_IOCTL);
             }
-        },
+        }
         _ => {
             let tx = state.new_generic_tx(2, r.command, hdr);
             tx.set_event(SMBEvent::MalformedData);
-        },
+        }
     };
 }
 
 // IOCTL responses ASYNC don't set the tree id
-pub fn smb2_ioctl_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
-{
+pub fn smb2_ioctl_response_record<'b>(
+    state: &mut SMBState,
+    r: &Smb2Record<'b>,
+) {
     let hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
     match parse_smb2_response_ioctl(r.data) {
         IResult::Done(_, rd) => {
             SCLogDebug!("IOCTL response data: {:?}", rd);
 
-            let is_dcerpc = rd.is_pipe && match state.get_service_for_guid(&rd.guid) {
-                (_, x) => x,
-            };
+            let is_dcerpc = rd.is_pipe
+                && match state.get_service_for_guid(&rd.guid) {
+                    (_, x) => x,
+                };
             if is_dcerpc {
                 SCLogDebug!("IOCTL response data is_pipe. Calling smb_read_dcerpc_record");
-                let vercmd = SMBVerCmdStat::new2_with_ntstatus(SMB2_COMMAND_IOCTL, r.nt_status);
+                let vercmd = SMBVerCmdStat::new2_with_ntstatus(
+                    SMB2_COMMAND_IOCTL,
+                    r.nt_status,
+                );
                 SCLogDebug!("TODO passing empty GUID");
-                smb_read_dcerpc_record(state, vercmd, hdr, &[],rd.data);
+                smb_read_dcerpc_record(state, vercmd, hdr, &[], rd.data);
             } else {
-                SCLogDebug!("SMB2_COMMAND_IOCTL/SMB_NTSTATUS_PENDING looking for {:?}", hdr);
+                SCLogDebug!(
+                    "SMB2_COMMAND_IOCTL/SMB_NTSTATUS_PENDING looking for {:?}",
+                    hdr
+                );
                 match state.get_generic_tx(2, SMB2_COMMAND_IOCTL, &hdr) {
                     Some(tx) => {
                         tx.set_status(r.nt_status, false);
                         if r.nt_status != SMB_NTSTATUS_PENDING {
                             tx.response_done = true;
                         }
-                    },
-                    None => { },
+                    }
+                    None => {}
                 }
             }
-        },
+        }
         _ => {
-            SCLogDebug!("SMB2_COMMAND_IOCTL/SMB_NTSTATUS_PENDING looking for {:?}", hdr);
+            SCLogDebug!(
+                "SMB2_COMMAND_IOCTL/SMB_NTSTATUS_PENDING looking for {:?}",
+                hdr
+            );
             match state.get_generic_tx(2, SMB2_COMMAND_IOCTL, &hdr) {
                 Some(tx) => {
                     SCLogDebug!("updated status of tx {}", tx.id);
@@ -127,9 +148,9 @@ pub fn smb2_ioctl_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         SCLogDebug!("parse fail {:?}", r);
                         tx.set_event(SMBEvent::MalformedData);
                     }
-                },
-                _ => { },
+                }
+                _ => {}
             }
-        },
+        }
     };
 }

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -15,12 +15,12 @@
  * 02110-1301, USA.
  */
 
-use nom::{rest, le_u8, le_u16, le_u32, le_u64, AsBytes, IResult};
 use crate::smb::smb::*;
+use nom::{le_u16, le_u32, le_u64, le_u8, rest, AsBytes, IResult};
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Smb2SecBlobRecord<'a> {
-    pub data: &'a[u8],
+    pub data: &'a [u8],
 }
 
 named!(pub parse_smb2_sec_blob<Smb2SecBlobRecord>,
@@ -31,16 +31,16 @@ named!(pub parse_smb2_sec_blob<Smb2SecBlobRecord>,
             })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Smb2Record<'a> {
-    pub direction: u8,    // 0 req, 1 res
+    pub direction: u8, // 0 req, 1 res
     pub nt_status: u32,
     pub command: u16,
     pub message_id: u64,
     pub tree_id: u32,
     pub async_id: u64,
     pub session_id: u64,
-    pub data: &'a[u8],
+    pub data: &'a [u8],
 }
 
 impl<'a> Smb2Record<'a> {
@@ -89,10 +89,10 @@ named!(pub parse_smb2_request_record<Smb2Record>,
            })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Smb2NegotiateProtocolRequestRecord<'a> {
     pub dialects_vec: Vec<u16>,
-    pub client_guid: &'a[u8],
+    pub client_guid: &'a [u8],
 }
 
 named!(pub parse_smb2_request_negotiate_protocol<Smb2NegotiateProtocolRequestRecord>,
@@ -113,10 +113,10 @@ named!(pub parse_smb2_request_negotiate_protocol<Smb2NegotiateProtocolRequestRec
             })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Smb2NegotiateProtocolResponseRecord<'a> {
     pub dialect: u16,
-    pub server_guid: &'a[u8],
+    pub server_guid: &'a [u8],
 }
 
 named!(pub parse_smb2_response_negotiate_protocol<Smb2NegotiateProtocolResponseRecord>,
@@ -142,10 +142,9 @@ named!(pub parse_smb2_response_negotiate_protocol_error<Smb2NegotiateProtocolRes
             })
 ));
 
-
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Smb2SessionSetupRequestRecord<'a> {
-    pub data: &'a[u8],
+    pub data: &'a [u8],
 }
 
 named!(pub parse_smb2_request_session_setup<Smb2SessionSetupRequestRecord>,
@@ -164,10 +163,9 @@ named!(pub parse_smb2_request_session_setup<Smb2SessionSetupRequestRecord>,
             })
 ));
 
-
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Smb2TreeConnectRequestRecord<'a> {
-    pub share_name: &'a[u8],
+    pub share_name: &'a [u8],
 }
 
 named!(pub parse_smb2_request_tree_connect<Smb2TreeConnectRequestRecord>,
@@ -180,8 +178,8 @@ named!(pub parse_smb2_request_tree_connect<Smb2TreeConnectRequestRecord>,
             })
 ));
 
-#[derive(Debug,PartialEq)]
-pub struct Smb2TreeConnectResponseRecord<> {
+#[derive(Debug, PartialEq)]
+pub struct Smb2TreeConnectResponseRecord {
     pub share_type: u8,
 }
 
@@ -197,12 +195,11 @@ named!(pub parse_smb2_response_tree_connect<Smb2TreeConnectResponseRecord>,
             })
 ));
 
-
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Smb2CreateRequestRecord<'a> {
     pub disposition: u32,
     pub create_options: u32,
-    pub data: &'a[u8],
+    pub data: &'a [u8],
 }
 
 named!(pub parse_smb2_request_create<Smb2CreateRequestRecord>,
@@ -222,12 +219,12 @@ named!(pub parse_smb2_request_create<Smb2CreateRequestRecord>,
             })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Smb2IOCtlRequestRecord<'a> {
     pub is_pipe: bool,
     pub function: u32,
-    pub guid: &'a[u8],
-    pub data: &'a[u8],
+    pub guid: &'a [u8],
+    pub data: &'a [u8],
 }
 
 named!(pub parse_smb2_request_ioctl<Smb2IOCtlRequestRecord>,
@@ -251,11 +248,11 @@ named!(pub parse_smb2_request_ioctl<Smb2IOCtlRequestRecord>,
             })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Smb2IOCtlResponseRecord<'a> {
     pub is_pipe: bool,
-    pub guid: &'a[u8],
-    pub data: &'a[u8],
+    pub guid: &'a [u8],
+    pub data: &'a [u8],
     pub indata_len: u32,
     pub outdata_len: u32,
     pub indata_offset: u32,
@@ -286,9 +283,9 @@ named!(pub parse_smb2_response_ioctl<Smb2IOCtlResponseRecord>,
             })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Smb2CloseRequestRecord<'a> {
-    pub guid: &'a[u8],
+    pub guid: &'a [u8],
 }
 
 named!(pub parse_smb2_request_close<Smb2CloseRequestRecord>,
@@ -302,7 +299,7 @@ named!(pub parse_smb2_request_close<Smb2CloseRequestRecord>,
 
 #[derive(Debug)]
 pub struct Smb2SetInfoRequestRenameRecord<'a> {
-    pub name: &'a[u8],
+    pub name: &'a [u8],
 }
 
 named!(pub parse_smb2_request_setinfo_rename<Smb2SetInfoRequestRenameRecord>,
@@ -319,7 +316,7 @@ named!(pub parse_smb2_request_setinfo_rename<Smb2SetInfoRequestRenameRecord>,
 
 #[derive(Debug)]
 pub struct Smb2SetInfoRequestRecord<'a> {
-    pub guid: &'a[u8],
+    pub guid: &'a [u8],
     pub class: u8,
     pub infolvl: u8,
     pub rename: Option<Smb2SetInfoRequestRenameRecord<'a>>,
@@ -344,12 +341,12 @@ named!(pub parse_smb2_request_setinfo<Smb2SetInfoRequestRecord>,
             })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Smb2WriteRequestRecord<'a> {
     pub wr_len: u32,
     pub wr_offset: u64,
-    pub guid: &'a[u8],
-    pub data: &'a[u8],
+    pub guid: &'a [u8],
+    pub data: &'a [u8],
 }
 
 // can be called on incomplete records
@@ -372,11 +369,11 @@ named!(pub parse_smb2_request_write<Smb2WriteRequestRecord>,
             })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Smb2ReadRequestRecord<'a> {
     pub rd_len: u32,
     pub rd_offset: u64,
-    pub guid: &'a[u8],
+    pub guid: &'a [u8],
 }
 
 named!(pub parse_smb2_request_read<Smb2ReadRequestRecord>,
@@ -396,18 +393,16 @@ named!(pub parse_smb2_request_read<Smb2ReadRequestRecord>,
             })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Smb2ReadResponseRecord<'a> {
     pub len: u32,
-    pub data: &'a[u8],
+    pub data: &'a [u8],
 }
 
 // parse read/write data. If all is available, 'take' it.
 // otherwise just return what we have. So this may return
 // partial data.
-fn parse_smb2_data<'a>(i: &'a[u8], len: u32)
-    -> IResult<&'a[u8], &'a[u8]>
-{
+fn parse_smb2_data<'a>(i: &'a [u8], len: u32) -> IResult<&'a [u8], &'a [u8]> {
     if len as usize > i.len() {
         rest(i)
     } else {
@@ -430,9 +425,9 @@ named!(pub parse_smb2_response_read<Smb2ReadResponseRecord>,
             })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Smb2CreateResponseRecord<'a> {
-    pub guid: &'a[u8],
+    pub guid: &'a [u8],
     pub create_ts: SMBFiletime,
     pub last_access_ts: SMBFiletime,
     pub last_write_ts: SMBFiletime,
@@ -466,8 +461,8 @@ named!(pub parse_smb2_response_create<Smb2CreateResponseRecord>,
             })
 ));
 
-#[derive(Debug,PartialEq)]
-pub struct Smb2WriteResponseRecord<> {
+#[derive(Debug, PartialEq)]
+pub struct Smb2WriteResponseRecord {
     pub wr_cnt: u32,
 }
 
@@ -521,9 +516,9 @@ named!(pub parse_smb2_response_record<Smb2Record>,
            })
 ));
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct SmbRecordPostGap<'a> {
-    pub data: &'a[u8],
+    pub data: &'a [u8],
 }
 
 named!(pub search_smb_record<SmbRecordPostGap>,

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -16,7 +16,7 @@
  */
 
 use nom::{rest, le_u8, le_u16, le_u32, le_u64, AsBytes, IResult};
-use smb::smb::*;
+use crate::smb::smb::*;
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2SecBlobRecord<'a> {

--- a/rust/src/smb/smb2_session.rs
+++ b/rust/src/smb/smb2_session.rs
@@ -15,17 +15,16 @@
  * 02110-1301, USA.
  */
 
-use nom::{IResult};
+use nom::IResult;
 
 use crate::log::*;
 
-use crate::smb::smb2_records::*;
 use crate::smb::smb::*;
+use crate::smb::smb2_records::*;
 //use smb::events::*;
 use crate::smb::auth::*;
 
-pub fn smb2_session_setup_request(state: &mut SMBState, r: &Smb2Record)
-{
+pub fn smb2_session_setup_request(state: &mut SMBState, r: &Smb2Record) {
     SCLogDebug!("SMB2_COMMAND_SESSION_SETUP: r.data.len() {}", r.data.len());
     match parse_smb2_request_session_setup(r.data) {
         IResult::Done(_, setup) => {
@@ -33,51 +32,58 @@ pub fn smb2_session_setup_request(state: &mut SMBState, r: &Smb2Record)
             let tx = state.new_sessionsetup_tx(hdr);
             tx.vercmd.set_smb2_cmd(r.command);
 
-            if let Some(SMBTransactionTypeData::SESSIONSETUP(ref mut td)) = tx.type_data {
+            if let Some(SMBTransactionTypeData::SESSIONSETUP(ref mut td)) =
+                tx.type_data
+            {
                 if let Some(s) = parse_secblob(setup.data) {
                     td.ntlmssp = s.ntlmssp;
                     td.krb_ticket = s.krb;
                 }
             }
-        },
-            _ => {
-//                events.push(SMBEvent::MalformedData);
-        },
+        }
+        _ => {
+            //                events.push(SMBEvent::MalformedData);
+        }
     }
 }
 
-fn smb2_session_setup_update_tx(tx: &mut SMBTransaction, r: &Smb2Record)
-{
+fn smb2_session_setup_update_tx(tx: &mut SMBTransaction, r: &Smb2Record) {
     tx.hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER); // to overwrite ssn_id 0
     tx.set_status(r.nt_status, false);
     tx.response_done = true;
 }
 
-pub fn smb2_session_setup_response(state: &mut SMBState, r: &Smb2Record)
-{
+pub fn smb2_session_setup_response(state: &mut SMBState, r: &Smb2Record) {
     // try exact match with session id already set (e.g. NTLMSSP AUTH phase)
-    let found = r.session_id != 0 && match state.get_sessionsetup_tx(
-                SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER))
-    {
-        Some(tx) => {
-            smb2_session_setup_update_tx(tx, r);
-            SCLogDebug!("smb2_session_setup_response: tx {:?}", tx);
-            true
-        },
-        None => { false },
-    };
-    // otherwise try match with ssn id 0 (e.g. NTLMSSP_NEGOTIATE)
-    if !found {
-        match state.get_sessionsetup_tx(
-                SMBCommonHdr::new(SMBHDR_TYPE_HEADER, 0, 0, r.message_id))
+    let found = r.session_id != 0
+        && match state
+            .get_sessionsetup_tx(SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER))
         {
             Some(tx) => {
                 smb2_session_setup_update_tx(tx, r);
                 SCLogDebug!("smb2_session_setup_response: tx {:?}", tx);
-            },
+                true
+            }
+            None => false,
+        };
+    // otherwise try match with ssn id 0 (e.g. NTLMSSP_NEGOTIATE)
+    if !found {
+        match state.get_sessionsetup_tx(SMBCommonHdr::new(
+            SMBHDR_TYPE_HEADER,
+            0,
+            0,
+            r.message_id,
+        )) {
+            Some(tx) => {
+                smb2_session_setup_update_tx(tx, r);
+                SCLogDebug!("smb2_session_setup_response: tx {:?}", tx);
+            }
             None => {
-                SCLogDebug!("smb2_session_setup_response: tx not found for {:?}", r);
-            },
+                SCLogDebug!(
+                    "smb2_session_setup_response: tx not found for {:?}",
+                    r
+                );
+            }
         }
     }
 }

--- a/rust/src/smb/smb2_session.rs
+++ b/rust/src/smb/smb2_session.rs
@@ -17,12 +17,12 @@
 
 use nom::{IResult};
 
-use log::*;
+use crate::log::*;
 
-use smb::smb2_records::*;
-use smb::smb::*;
+use crate::smb::smb2_records::*;
+use crate::smb::smb::*;
 //use smb::events::*;
-use smb::auth::*;
+use crate::smb::auth::*;
 
 pub fn smb2_session_setup_request(state: &mut SMBState, r: &Smb2Record)
 {

--- a/rust/src/smb/smb3.rs
+++ b/rust/src/smb/smb3.rs
@@ -17,11 +17,11 @@
 
 use nom::{le_u16, le_u32, le_u64};
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Smb3TransformRecord<'a> {
     pub session_id: u64,
     pub enc_algo: u16,
-    pub enc_data: &'a[u8],
+    pub enc_data: &'a [u8],
 }
 
 named!(pub parse_smb3_transform_record<Smb3TransformRecord>,

--- a/rust/src/smb/smb_records.rs
+++ b/rust/src/smb/smb_records.rs
@@ -15,28 +15,27 @@
  * 02110-1301, USA.
  */
 
-use nom::{IResult, ErrorKind};
 use crate::log::*;
+use nom::{ErrorKind, IResult};
 
 /// parse a UTF16 string that is null terminated. Normally by 2 null
 /// bytes, but at the end of the data it can also be a single null.
 /// Skip every second byte.
-pub fn smb_get_unicode_string(blob: &[u8]) -> IResult<&[u8], Vec<u8>>
-{
+pub fn smb_get_unicode_string(blob: &[u8]) -> IResult<&[u8], Vec<u8>> {
     SCLogDebug!("get_unicode_string: blob {} {:?}", blob.len(), blob);
-    let mut name : Vec<u8> = Vec::new();
+    let mut name: Vec<u8> = Vec::new();
     let mut c = blob;
     while c.len() >= 1 {
         if c.len() == 1 && c[0] == 0 {
             let rem = &c[1..];
             SCLogDebug!("get_unicode_string: name {:?}", name);
-            return IResult::Done(rem, name)
+            return IResult::Done(rem, name);
         } else if c.len() == 1 {
             break;
         } else if c[0] == 0 && c[1] == 0 {
             let rem = &c[2..];
             SCLogDebug!("get_unicode_string: name {:?}", name);
-            return IResult::Done(rem, name)
+            return IResult::Done(rem, name);
         }
         name.push(c[0]);
         c = &c[2..];
@@ -50,4 +49,3 @@ named!(pub smb_get_ascii_string<Vec<u8>>,
             s: take_until_and_consume!("\x00")
         >> ( s.to_vec() )
 ));
-

--- a/rust/src/smb/smb_records.rs
+++ b/rust/src/smb/smb_records.rs
@@ -16,7 +16,7 @@
  */
 
 use nom::{IResult, ErrorKind};
-use log::*;
+use crate::log::*;
 
 /// parse a UTF16 string that is null terminated. Normally by 2 null
 /// bytes, but at the end of the data it can also be a single null.

--- a/rust/src/tftp/log.rs
+++ b/rust/src/tftp/log.rs
@@ -23,13 +23,14 @@ use crate::json::*;
 use crate::tftp::tftp::*;
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_log_json_request(tx: &mut TFTPTransaction) -> *mut JsonT
-{
+pub extern "C" fn rs_tftp_log_json_request(
+    tx: &mut TFTPTransaction,
+) -> *mut JsonT {
     let js = Json::object();
     match tx.opcode {
         1 => js.set_string("packet", "read"),
         2 => js.set_string("packet", "write"),
-        _ => js.set_string("packet", "error")
+        _ => js.set_string("packet", "error"),
     };
     js.set_string("file", tx.filename.as_str());
     js.set_string("mode", tx.mode.as_str());

--- a/rust/src/tftp/log.rs
+++ b/rust/src/tftp/log.rs
@@ -19,8 +19,8 @@
 
 extern crate libc;
 
-use json::*;
-use tftp::tftp::*;
+use crate::json::*;
+use crate::tftp::tftp::*;
 
 #[no_mangle]
 pub extern "C" fn rs_tftp_log_json_request(tx: &mut TFTPTransaction) -> *mut JsonT

--- a/rust/src/tftp/mod.rs
+++ b/rust/src/tftp/mod.rs
@@ -17,5 +17,5 @@
 
 // written by Clément Galland <clement.galland@epita.fr>
 
-pub mod tftp;
 pub mod log;
+pub mod tftp;

--- a/rust/src/tftp/tftp.rs
+++ b/rust/src/tftp/tftp.rs
@@ -24,7 +24,7 @@ use std::str;
 use std;
 use std::mem::transmute;
 
-use applayer::LoggerFlags;
+use crate::applayer::LoggerFlags;
 
 #[derive(Debug)]
 pub struct TFTPTransaction {


### PR DESCRIPTION
Update rust code to be compatible with Rust 2015 or 2018. This requires rust 1.30.0+.

More information on which OS's support which rust versions can be found [here](https://redmine.openinfosecfoundation.org/issues/2507)

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2629

Describe changes:
- Run `cargo fix --edition` to make compatible with 1.30.0+ rust
- Run `cargo fmt` to format

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

