### PR TITLE
filestore v2: print sid in json output (Optimization #2530)

### DIFF
--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -264,6 +264,15 @@ static int DetectFilestoreMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx, 
      * matches. */
     if (file != NULL) {
         file_id = file->file_store_id;
+
+        if (s->id) {
+            if (file->sid_sze > file->sid_cap) {
+                file->sid = SCRealloc(file->sid, sizeof(file->sid) * 2);
+                file->sid_cap = file->sid_cap * 2;
+            }
+            file->sid[file->sid_sze] = s->id;
+            file->sid_sze++;
+        }
     }
 
     det_ctx->filestore[det_ctx->filestore_cnt].file_id = file_id;

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -149,6 +149,16 @@ json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
     json_object_set_new(fjs, "filename", SCJsonString(s));
     if (s != NULL)
         SCFree(s);
+
+    if (ff->sid) {
+        uint16_t i;
+        json_t* tmp = json_array();
+        for (i=0; i < ff->sid_sze; i++) {
+            json_array_append(tmp, json_integer(ff->sid[i]));
+        }
+        json_object_set_new(fjs, "sid", tmp);
+    }
+
 #ifdef HAVE_MAGIC
     if (ff->magic)
         json_object_set_new(fjs, "magic", json_string((char *)ff->magic));

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -454,6 +454,14 @@ static File *FileAlloc(const uint8_t *name, uint16_t name_len)
     new->name_len = name_len;
     memcpy(new->name, name, name_len);
 
+    new->sid = SCMalloc(sizeof(uint32_t));
+    if (new->sid == NULL) {
+        SCFree(new);
+        return NULL;
+    }
+    new->sid_sze = 0;
+    new->sid_cap = 1;
+
     return new;
 }
 
@@ -464,6 +472,8 @@ static void FileFree(File *ff)
 
     if (ff->name != NULL)
         SCFree(ff->name);
+    if (ff->sid != NULL)
+        SCFree(ff->sid);
 #ifdef HAVE_MAGIC
     /* magic returned by libmagic is strdup'd by MagicLookup. */
     if (ff->magic != NULL)

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -89,6 +89,10 @@ typedef struct File_ {
                                      *   flag is set */
     uint64_t content_stored;
     uint64_t size;
+
+    uint32_t *sid; /* signature id of a rule that triggered the filestore event */
+    uint32_t sid_sze;
+    uint32_t sid_cap;
 } File;
 
 typedef struct FileContainer_ {


### PR DESCRIPTION
Redmine ticket: https://redmine.openinfosecfoundation.org/issues/2530

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2530
Describe changes:
- print SID(s) of a triggering rule in json fileinfo file if there are any
- fix up for #3600

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

