### PR TITLE
doc: fix minor typo

### DIFF
--- a/doc/userguide/capture-hardware/ebpf-xdp.rst
+++ b/doc/userguide/capture-hardware/ebpf-xdp.rst
@@ -40,7 +40,7 @@ card that support XDP in the driver.
 Suricata XDP code has been tested with 4.13.10 but 4.15 or later is necessary to use all
 features like the CPU redirect map.
 
-If you are using an Intel netword card, you will need to stay with in tree kernel NIC drivers.
+If you are using an Intel network card, you will need to stay with in tree kernel NIC drivers.
 The out of tree drivers do not contain the XDP support.
 
 Having a network card with support for RSS symmetric hashing is a good point or you will have to

--- a/doc/userguide/configuration/global-thresholds.rst
+++ b/doc/userguide/configuration/global-thresholds.rst
@@ -190,7 +190,7 @@ Threshold/event_filter
 When applied to a specific signature, thresholds and event_filters
 (threshold from now on) will override the signature setting. This can
 be useful for when the default in a signature doesn't suit your
-evironment.
+environment.
 
 ::
 

--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -16,7 +16,7 @@ Installing from the source distribution files gives the most control over the Su
 
 Basic steps::
 
-    tar xzvf suricata-4.1.0.tar.gz
+    tar xzvf suricata-4.1.2.tar.gz
     cd suricata-4.1.0
     ./configure
     make

--- a/doc/userguide/rules/flow-keywords.rst
+++ b/doc/userguide/rules/flow-keywords.rst
@@ -81,7 +81,7 @@ only_stream
   Match on packets that have been reassembled by the stream engine.
 no_stream
   Match on packets that have not been reassembled by the stream
-  engine. Will not match packets that have been reeassembled.
+  engine. Will not match packets that have been reassembled.
 only_frag
   Match packets that have been reassembled from fragments.
 no_frag

--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -452,7 +452,7 @@ http_start
 ----------
 
 Inspect the start of a HTTP request or response. This will contain the
-request/reponse line plus the request/response headers. Use flow:to_server
+request/response line plus the request/response headers. Use flow:to_server
 or flow:to_client to force inspection of request or response.
 
 Example::

--- a/doc/userguide/rules/meta.rst
+++ b/doc/userguide/rules/meta.rst
@@ -79,7 +79,7 @@ possible to modify this. It is not usual that it will be changed, and
 changing it has no technical implications. You can only notice it in
 the alert.
 
-Example of gid in an alert of fast.log. In the part [1:2008124:2], 1 is the gid (2008124 is the the sid and 2 the rev).
+Example of gid in an alert of fast.log. In the part [1:2008124:2], 1 is the gid (2008124 is the sid and 2 the rev).
 
 .. container:: example-rule
 
@@ -169,7 +169,7 @@ format of priority is::
 metadata
 --------
 
-The meatadata keyword allows additional, non-functional information to
+The metadata keyword allows additional, non-functional information to
 be added to the signature. While the format is free-form, it is
 recommended to stick to key, value pairs as Suricata can include these
 in eve alerts. The format is::

--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -84,7 +84,7 @@ For example::
   distance:-10; sid:9000000; rev:1;)
 
 You see ``content:!”Firefox/3.6.13”;``. This means an alert will be
-generated if the the used version of Firefox is not 3.6.13.
+generated if the used version of Firefox is not 3.6.13.
 
 .. note:: The following characters must be escaped inside the content:
              ``;`` ``\`` ``"``

--- a/doc/userguide/rules/tls-keywords.rst
+++ b/doc/userguide/rules/tls-keywords.rst
@@ -164,7 +164,7 @@ example:
 
   tls.subject:"CN=*.googleusercontent.com"
 
-Case sensitve, can't use 'nocase'.
+Case sensitive, can't use 'nocase'.
 
 Legacy keyword. ``tls_cert_subject`` is the replacement.
 
@@ -180,7 +180,7 @@ example:
 
   tls.issuerdn:!"CN=Google-Internet-Authority"
 
-Case sensitve, can't use 'nocase'.
+Case sensitive, can't use 'nocase'.
 
 Legacy keyword. ``tls_cert_issuer`` is the replacement.
 


### PR DESCRIPTION
Various fix typo in suricata documentation.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- fix minor typo within the userguide

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

