### PR TITLE
Netmap 11 to 12 fix

### DIFF
--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -268,6 +268,7 @@ static int NetmapOpen(char *ifname, int promisc, NetmapDevice **pdevice, int ver
 {
     NetmapDevice *pdev = NULL;
     struct nmreq nm_req;
+    struct netmap_if *nifp = NULL;
 
     *pdevice = NULL;
 
@@ -367,7 +368,7 @@ static int NetmapOpen(char *ifname, int promisc, NetmapDevice **pdevice, int ver
             nm_req.nr_ringid = i | NETMAP_NO_TX_POLL;
         } else {
             nm_req.nr_flags = NR_REG_SW;
-            nm_req.nr_ringid = NETMAP_NO_TX_POLL;
+            nm_req.nr_ringid = i | NETMAP_NO_TX_POLL;
         }
         if (ioctl(pring->fd, NIOCREGIF, &nm_req) != 0) {
             SCLogError(SC_ERR_NETMAP_CREATE,
@@ -385,14 +386,15 @@ static int NetmapOpen(char *ifname, int promisc, NetmapDevice **pdevice, int ver
                            strerror(errno));
                 break;
             }
-            pdev->nif = NETMAP_IF(pdev->mem, nm_req.nr_offset);
-        }
+            pdev->nif = nifp = NETMAP_IF(pdev->mem, nm_req.nr_offset);
+        } else
+		nifp = NETMAP_IF(pdev->mem, nm_req.nr_offset);
 
         if ((i < pdev->rx_rings_cnt) || (i == pdev->rings_cnt)) {
-            pring->rx = NETMAP_RXRING(pdev->nif, i);
+            pring->rx = NETMAP_RXRING(nifp, i);
         }
         if ((i < pdev->tx_rings_cnt) || (i == pdev->rings_cnt)) {
-            pring->tx = NETMAP_TXRING(pdev->nif, i);
+            pring->tx = NETMAP_TXRING(nifp, i);
         }
         SCSpinInit(&pring->tx_lock, 0);
         success_cnt++;


### PR DESCRIPTION
Although, there are no visible API changes, moving from API version
11 to 12, for every rx/tx ring that is being opened, one needs to
explicitly call NETMAP_IF to get the fresh address of the netmap_if
struct.

When the netmap-rework branch is done, it will also handle the
situation, but anyhow, this is a quick fix for 4.1.3 so that Suricata
can still happily run on FreeBSD 12 & 11 newcoming releases, since
they all come with the new netmap code.

Contributed by: Sunny Valley Networks

Attn: @inliniac

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

