### PR TITLE
Fix rule content option counting (2605)

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1051,6 +1051,8 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
                         (DETECT_CONTENT_OFFSET | DETECT_CONTENT_DEPTH)) {
                         rule_content_offset_depth++;
                     }
+                } else {
+                    rule_content += 1;
                 }
             }
             else if (sm->type == DETECT_FLOW) {


### PR DESCRIPTION
The engine analyzer was producing inconsistent results,
saying that a rule had zero content options when it did not.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [#2605](https://redmine.openinfosecfoundation.org/issues/2605)

Describe changes:
I added a catch all increment of the counter and it started producing consistent results on the test cases mentioned in the issue, however, I am unsure about the side effects of that change and would appreciate feedback, and an explanation of the analyzer's internals as, as-is the code is not very expressive of its intent.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

I don't have access to that script, guess trusted developers will have to run it for me.

Thanks