### PR TITLE
rust/dns: add dns to dns alerts - v1

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -189,29 +189,26 @@ static void AlertJsonDnp3(const Flow *f, const uint64_t tx_id, json_t *js)
 
 static void AlertJsonDns(const Flow *f, const uint64_t tx_id, json_t *js)
 {
-#ifndef HAVE_RUST
     DNSState *dns_state = (DNSState *)FlowGetAppState(f);
     if (dns_state) {
-        DNSTransaction *tx = AppLayerParserGetTx(f->proto, ALPROTO_DNS,
-                                                 dns_state, tx_id);
-        if (tx) {
+        void *txptr = AppLayerParserGetTx(f->proto, ALPROTO_DNS,
+                                          dns_state, tx_id);
+        if (txptr) {
             json_t *dnsjs = json_object();
             if (unlikely(dnsjs == NULL)) {
                 return;
             }
-
-            json_t *qjs = JsonDNSLogQuery(tx, tx_id);
+            json_t *qjs = JsonDNSLogQuery(txptr, tx_id);
             if (qjs != NULL) {
                 json_object_set_new(dnsjs, "query", qjs);
             }
-            json_t *ajs = JsonDNSLogAnswer(tx, tx_id);
+            json_t *ajs = JsonDNSLogAnswer(txptr, tx_id);
             if (ajs != NULL) {
                 json_object_set_new(dnsjs, "answer", ajs);
             }
             json_object_set_new(js, "dns", dnsjs);
         }
     }
-#endif
     return;
 }
 

--- a/src/output-json-dns.h
+++ b/src/output-json-dns.h
@@ -29,8 +29,8 @@ void JsonDnsLogRegister(void);
 #ifdef HAVE_LIBJANSSON
 #include "app-layer-dns-common.h"
 
-json_t *JsonDNSLogQuery(DNSTransaction *tx, uint64_t tx_id) __attribute__((nonnull));
-json_t *JsonDNSLogAnswer(DNSTransaction *tx, uint64_t tx_id) __attribute__((nonnull));
+json_t *JsonDNSLogQuery(void *txptr, uint64_t tx_id) __attribute__((nonnull));
+json_t *JsonDNSLogAnswer(void *txptr, uint64_t tx_id) __attribute__((nonnull));
 #endif
 
 #endif /* __OUTPUT_JSON_DNS_H__ */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2775

Rust builds were missing the DNS object on EVE alerts when DNS metadata was available. This PR adds the DNS object to be equivalent to C builds.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/340
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/694
