### PR TITLE
add vlan and in_iface fields to eve/flow and pseudopackets - v2

### DIFF
--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -88,6 +88,17 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(Packet *p,
     p->flags |= PKT_STREAM_EOF;
     p->flags |= PKT_HAS_FLOW;
     p->flags |= PKT_PSEUDO_STREAM_END;
+    p->livedev = f->livedev;
+    
+    if (f->vlan_idx > 0) {
+        p->vlan_id[0] = f->vlan_id[0];
+        p->vlan_idx=1;
+
+        if (f->vlan_idx > 1) {
+            p->vlan_id[1] = f->vlan_id[1];
+            p->vlan_idx=2;
+        }
+    }
 
     if (f->flags & FLOW_NOPACKET_INSPECTION) {
         DecodeSetNoPacketInspectionFlag(p);

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -203,4 +203,3 @@ void FlowInit(Flow *f, const Packet *p)
 
     SCReturn;
 }
-

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -153,6 +153,8 @@ void FlowInit(Flow *f, const Packet *p)
     f->recursion_level = p->recursion_level;
     f->vlan_id[0] = p->vlan_id[0];
     f->vlan_id[1] = p->vlan_id[1];
+    f->vlan_idx = p->vlan_idx;
+    f->livedev = p->livedev;
 
     if (PKT_IS_IPV4(p)) {
         FLOW_SET_IPV4_SRC_ADDR_FROM_PACKET(p, &f->src);

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -40,6 +40,8 @@
         (f)->sp = 0; \
         (f)->dp = 0; \
         (f)->proto = 0; \
+        (f)->livedev = NULL; \
+        (f)->vlan_idx = 0; \
         SC_ATOMIC_INIT((f)->flow_state); \
         SC_ATOMIC_INIT((f)->use_cnt); \
         (f)->tenant_id = 0; \
@@ -83,6 +85,8 @@
         (f)->sp = 0; \
         (f)->dp = 0; \
         (f)->proto = 0; \
+        (f)->livedev = NULL; \
+        (f)->vlan_idx = 0; \
         SC_ATOMIC_RESET((f)->flow_state); \
         SC_ATOMIC_RESET((f)->use_cnt); \
         (f)->tenant_id = 0; \

--- a/src/flow.h
+++ b/src/flow.h
@@ -27,6 +27,7 @@
 #include "decode.h"
 #include "util-var.h"
 #include "util-atomic.h"
+#include "util-device.h"
 #include "detect-tag.h"
 #include "util-optimize.h"
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -629,4 +629,3 @@ uint8_t FlowGetDisruptionFlags(const Flow *f, uint8_t flags);
 void FlowHandlePacketUpdate(Flow *f, Packet *p);
 
 #endif /* __FLOW_H__ */
-

--- a/src/flow.h
+++ b/src/flow.h
@@ -346,6 +346,10 @@ typedef struct Flow_
     uint8_t proto;
     uint8_t recursion_level;
     uint16_t vlan_id[2];
+    uint8_t vlan_idx;
+
+    /** Incoming interface */
+    struct LiveDevice_ *livedev;
 
     /** flow hash - the flow hash before hash table size mod. */
     uint32_t flow_hash;

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -112,9 +112,9 @@ static json_t *CreateJSONHeaderFromFlow(const Flow *f, const char *event_type)
     if (event_type) {
         json_object_set_new(js, "event_type", json_string(event_type));
     }
-#if 0
+
     /* vlan */
-    if (f->vlan_id[0] > 0) {
+    if (f->vlan_idx > 0) {
         json_t *js_vlan;
         switch (f->vlan_idx) {
             case 1:
@@ -125,9 +125,9 @@ static json_t *CreateJSONHeaderFromFlow(const Flow *f, const char *event_type)
                 js_vlan = json_array();
                 if (unlikely(js != NULL)) {
                     json_array_append_new(js_vlan,
-                                    json_integer(VLAN_GET_ID1(p)));
+                                    json_integer(f->vlan_id[0]));
                     json_array_append_new(js_vlan,
-                                    json_integer(VLAN_GET_ID2(p)));
+                                    json_integer(f->vlan_id[1]));
                     json_object_set_new(js, "vlan", js_vlan);
                 }
                 break;
@@ -136,7 +136,7 @@ static json_t *CreateJSONHeaderFromFlow(const Flow *f, const char *event_type)
                 break;
         }
     }
-#endif
+
     /* tuple */
     json_object_set_new(js, "src_ip", json_string(srcip));
     switch(f->proto) {

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -109,6 +109,12 @@ static json_t *CreateJSONHeaderFromFlow(const Flow *f, const char *event_type)
     if (sensor_id >= 0)
         json_object_set_new(js, "sensor_id", json_integer(sensor_id));
 #endif
+
+    /* input interface */
+    if (f->livedev) {
+        json_object_set_new(js, "in_iface", json_string(f->livedev->dev));
+    }
+
     if (event_type) {
         json_object_set_new(js, "event_type", json_string(event_type));
     }

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -125,6 +125,12 @@ static json_t *CreateJSONHeaderFromFlow(const Flow *f, const char *event_type, i
     if (sensor_id >= 0)
         json_object_set_new(js, "sensor_id", json_integer(sensor_id));
 #endif
+
+    /* input interface */
+    if (f->livedev) {
+        json_object_set_new(js, "in_iface", json_string(f->livedev->dev));
+    }
+
     if (event_type) {
         json_object_set_new(js, "event_type", json_string(event_type));
     }

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -128,9 +128,9 @@ static json_t *CreateJSONHeaderFromFlow(const Flow *f, const char *event_type, i
     if (event_type) {
         json_object_set_new(js, "event_type", json_string(event_type));
     }
-#if 0
+
     /* vlan */
-    if (f->vlan_id[0] > 0) {
+    if (f->vlan_idx > 0) {
         json_t *js_vlan;
         switch (f->vlan_idx) {
             case 1:
@@ -141,9 +141,9 @@ static json_t *CreateJSONHeaderFromFlow(const Flow *f, const char *event_type, i
                 js_vlan = json_array();
                 if (unlikely(js != NULL)) {
                     json_array_append_new(js_vlan,
-                                    json_integer(VLAN_GET_ID1(p)));
+                                    json_integer(f->vlan_id[0]));
                     json_array_append_new(js_vlan,
-                                    json_integer(VLAN_GET_ID2(p)));
+                                    json_integer(f->vlan_id[1]));
                     json_object_set_new(js, "vlan", js_vlan);
                 }
                 break;
@@ -152,7 +152,7 @@ static json_t *CreateJSONHeaderFromFlow(const Flow *f, const char *event_type, i
                 break;
         }
     }
-#endif
+
     /* tuple */
     json_object_set_new(js, "src_ip", json_string(srcip));
     switch(f->proto) {

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6034,6 +6034,17 @@ static void StreamTcpPseudoPacketCreateDetectLogFlush(ThreadVars *tv,
     np->flags |= PKT_HAS_FLOW;
     np->flags |= PKT_IGNORE_CHECKSUM;
     np->flags |= PKT_PSEUDO_DETECTLOG_FLUSH;
+    np->livedev = f->livedev;
+
+    if (f->vlan_idx > 0) {
+        np->vlan_id[0] = f->vlan_id[0];
+        np->vlan_idx=1;
+
+        if (f->vlan_idx > 1) {
+            np->vlan_id[1] = f->vlan_id[1];
+            np->vlan_idx=2;
+        }
+    }
 
     if (f->flags & FLOW_NOPACKET_INSPECTION) {
         DecodeSetNoPacketInspectionFlag(np);


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable) => not applicable

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2057

Describe changes:
- add vlan and in_iface to logged/alerted psuedopackets
- eve/flow: add vlan field 
- eve/flow: add in_iface field

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
not applicable

Supersedes #3494 and #3624.