### PR TITLE
issue 2795: python 3 fix in Rust C header gen - v1

### DIFF
--- a/rust/gen-c-headers.py
+++ b/rust/gen-c-headers.py
@@ -169,7 +169,7 @@ def gen_headers(filename):
     if not should_regen(filename, output_filename):
         return
 
-    buf = open(filename).read()
+    buf = open(filename, "rb").read().decode("utf-8")
     writer = StringIO()
 
     for fn in re.findall(


### PR DESCRIPTION
The C header generation script was failing with a unicode error
in Python 3 on FreeBSD.  Fix the reading of files to properly
handle unicode in all Python 3 environments.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/2794

To test you will need to do a built from git on FreeBSD and make sure /usr/local/bin/python is python3, not python2.  I've also prepped a 4.0.x branch.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/341
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/695
