### PR TITLE
nfqueue: added received packets counter for 'iface-stat' command

### DIFF
--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -481,7 +481,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
             exit(EXIT_FAILURE);
         }
         memset(tname, 0, sizeof(tname));
-        snprintf(tname, sizeof(tname), "%s-Q%s", thread_name_autofp, cur_queue);
+        snprintf(tname, sizeof(tname), "%s-%s", thread_name_autofp, cur_queue);
 
         ThreadVars *tv_receive =
             TmThreadCreatePacketHandler(tname,


### PR DESCRIPTION
Previously nfqueue did not update received packets counter in a livedev so 'iface-stat' UNIX-socket command always showed zeros.

Also nfqueue livedev names are more descriptive now ('iface-stat' will show, for instance, 'Q#1' instead of '1' as iface name).

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes: added a pointer to livedev to NFQThreadVars so it is possible to update received packets counter in NFQCallBack().