### PR TITLE
nfqueue stats fixes

### DIFF
--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -844,7 +844,7 @@ int NFQRegisterQueue(const uint16_t number)
 {
     NFQThreadVars *ntv = NULL;
     NFQQueueVars *nq = NULL;
-    char queue[8] = { 0 };
+    char queue[10] = { 0 };
     static bool many_queues_warned = false;
     uint16_t num_cpus = UtilCpuGetNumProcessorsOnline();
 
@@ -876,7 +876,7 @@ int NFQRegisterQueue(const uint16_t number)
     nq->queue_num = number;
     receive_queue_num++;
     SCMutexUnlock(&nfq_init_lock);
-    snprintf(queue, sizeof(queue) - 1, "%hu", number);
+    snprintf(queue, sizeof(queue) - 1, "NFQ#%hu", number);
     LiveRegisterDevice(queue);
 
     ntv->livedev = LiveGetDevice(queue);

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -129,6 +129,8 @@ typedef struct NFQThreadVars_
     ThreadVars *tv;
     TmSlot *slot;
 
+    LiveDevice *livedev;
+
     char *data; /** Per function and thread data */
     int datalen; /** Length of per function and thread data */
 
@@ -561,6 +563,8 @@ static int NFQCallBack(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg,
         q->pkts++;
         q->bytes += GET_PKT_LEN(p);
 #endif /* COUNTERS */
+        (void) SC_ATOMIC_ADD(ntv->livedev->pkts, 1);
+
         /* NFQSetupPkt is issuing a verdict
            so we only recycle Packet and leave */
         TmqhOutputPacketpool(tv, p);
@@ -574,6 +578,7 @@ static int NFQCallBack(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg,
     q->pkts++;
     q->bytes += GET_PKT_LEN(p);
 #endif /* COUNTERS */
+    (void) SC_ATOMIC_ADD(ntv->livedev->pkts, 1);
 
     if (ntv->slot) {
         if (TmThreadsSlotProcessPkt(tv, ntv->slot, p) != TM_ECODE_OK) {
@@ -839,7 +844,7 @@ int NFQRegisterQueue(const uint16_t number)
 {
     NFQThreadVars *ntv = NULL;
     NFQQueueVars *nq = NULL;
-    char queue[6] = { 0 };
+    char queue[8] = { 0 };
     static bool many_queues_warned = false;
     uint16_t num_cpus = UtilCpuGetNumProcessorsOnline();
 
@@ -872,7 +877,14 @@ int NFQRegisterQueue(const uint16_t number)
     receive_queue_num++;
     SCMutexUnlock(&nfq_init_lock);
     snprintf(queue, sizeof(queue) - 1, "%hu", number);
-    LiveRegisterDeviceName(queue);
+    LiveRegisterDevice(queue);
+
+    ntv->livedev = LiveGetDevice(queue);
+
+    if (ntv->livedev == NULL) {
+        SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
+        return -1;
+    }
 
     SCLogDebug("Queue %d registered.", number);
     return 0;

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -481,7 +481,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
             exit(EXIT_FAILURE);
         }
         memset(tname, 0, sizeof(tname));
-        snprintf(tname, sizeof(tname), "%s-Q%s", thread_name_autofp, cur_queue);
+        snprintf(tname, sizeof(tname), "%s-%s", thread_name_autofp, cur_queue);
 
         ThreadVars *tv_receive =
             TmThreadCreatePacketHandler(tname,
@@ -608,7 +608,7 @@ int RunModeSetIPSWorker(ConfigIPSParserFunc ConfigParser,
             exit(EXIT_FAILURE);
         }
         memset(tname, 0, sizeof(tname));
-        snprintf(tname, sizeof(tname), "%s-Q%s", thread_name_workers, cur_queue);
+        snprintf(tname, sizeof(tname), "%s-%s", thread_name_workers, cur_queue);
 
         tv = TmThreadCreatePacketHandler(tname,
                 "packetpool", "packetpool",


### PR DESCRIPTION
Previously nfqueue did not update received packets counter in a livedev so 'iface-stat' UNIX-socket command always showed zeros.

Also nfqueue livedev names are more descriptive now ('iface-stat' will show, for instance, 'NFQ#1' instead of '1' as iface name).

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- added a pointer to livedev to NFQThreadVars so it is possible to update received packets counter in NFQCallBack().
- changed queue's name format from 'number' to 'NFQ#number'.
