### PR TITLE
configure: rust support requires Python

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2234,6 +2234,14 @@ fi
     if test "x$enable_rust" != "xyes" && test "x$enable_rust" != "xyes (default)"; then
       enable_rust="no"
     elif test "x$enable_python" != "xyes" && test ! -f rust/gen/c-headers/rust-core-gen.h; then
+      if test "x$enable_rust" = "xyes"; then
+        echo ""
+        echo "   ERROR! Rust support requires Python."
+        echo
+        echo "   Ubuntu: apt install python"
+        echo ""
+        exit 1
+      fi
       enable_rust="no"
     else
       # Rust require jansson (json support).


### PR DESCRIPTION
Add error message to warn the user. The fail was completely silent before.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Warn user that Python is needed for Rust

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/433
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/214

