### PR TITLE
Test/stream events/v2

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -1131,6 +1131,7 @@ void DecodeUnregisterCounters(void);
 
 #define PKT_PSEUDO_DETECTLOG_FLUSH      (1<<27)     /**< Detect/log flush for protocol upgrade */
 
+#define PKT_STREAM_BAD                  (1<<28)     /**< packet is part of stream in known bad condition */
 
 /** \brief return 1 if the packet is a pseudo packet */
 #define PKT_IS_PSEUDOPKT(p) \

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -346,6 +346,10 @@ static void JsonFlowLogJSON(JsonFlowLogThread *aft, json_t *js, Flow *f)
                     break;
             }
             json_object_set_new(tjs, "state", json_string(tcp_state));
+            if (ssn->client.flags & STREAMTCP_STREAM_FLAG_GAP)
+                json_object_set_new(hjs, "gap_ts", json_true());
+            if (ssn->server.flags & STREAMTCP_STREAM_FLAG_GAP)
+                json_object_set_new(hjs, "gap_tc", json_true());
         }
 
         json_object_set_new(js, "tcp", tjs);

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -243,9 +243,15 @@ enum
     } while(0); \
 }
 
-#define StreamTcpSetEvent(p, e) { \
-    SCLogDebug("setting event %"PRIu8" on pkt %p (%"PRIu64")", (e), p, (p)->pcap_cnt); \
-    ENGINE_SET_EVENT((p), (e)); \
+#define StreamTcpSetEvent(p, e) {                                           \
+    if ((p)->flags & PKT_STREAM_BAD) {                                      \
+        SCLogDebug("NOT setting event %"PRIu8" on pkt %p (%"PRIu64"), "     \
+                   "stream in known bad condition", (e), p, (p)->pcap_cnt); \
+    } else {                                                                \
+        SCLogDebug("setting event %"PRIu8" on pkt %p (%"PRIu64")",          \
+                    (e), p, (p)->pcap_cnt);                                 \
+        ENGINE_SET_EVENT((p), (e));                                         \
+    }                                                                       \
 }
 
 typedef struct TcpSession_ {

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4765,6 +4765,14 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
             goto skip;
         }
 
+        if (p->flow->flags & FLOW_WRONG_THREAD ||
+            ssn->client.flags & STREAMTCP_STREAM_FLAG_GAP ||
+            ssn->server.flags & STREAMTCP_STREAM_FLAG_GAP)
+        {
+            // stream and/or session in known bad condition. Block events
+            p->flags |= PKT_STREAM_BAD;
+        }
+
         /* check if the packet is in right direction, when we missed the
            SYN packet and picked up midstream session. */
         if (ssn->flags & STREAMTCP_FLAG_MIDSTREAM_SYNACK)


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2484

Describe changes:
- when stream gaps or flow 'wrong thread' is encountered, stop setting stream events to avoid causing a flood of alerts
- add gap status to flow records

RFC: this stops both matching and stats increases of stream events after gap/wrong-thread. It may lead to reduced detection as a result, but I think it's a fair balance as the events are unreliable anyway in this scenario.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/220
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/222

