### PR TITLE
app-layer-ssl: fix AddressSanitizer heap-buffer-overflow

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -771,6 +771,11 @@ static inline int TLSDecodeHSHelloCipherSuites(SSLState *ssl_state,
         if (!(HAS_SPACE(cipher_suites_length)))
             goto invalid_length;
 
+        /* Cipher suites length should always be divisible by 2 */
+        if ((cipher_suites_length & 1) != 0) {
+            goto invalid_length;
+        }
+
         if (ssl_config.enable_ja3) {
             int rc;
 


### PR DESCRIPTION
When decoding CipherSuites there is no check to verify that the CipherSuites length is divisible by 2, causing overflows whenever the length is in fact an odd number (which should never happen with normal traffic).

https://redmine.openinfosecfoundation.org/issues/2762

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/179
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/179