### PR TITLE
filestore v2: print sid in json output

### DIFF
--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -264,7 +264,26 @@ static int DetectFilestoreMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx, 
      * matches. */
     if (file != NULL) {
         file_id = file->file_store_id;
+        if (file->sid != NULL && s->id > 0) {
+            if (file->sid_cnt >= file->sid_max) {
+                void *p = SCRealloc(file->sid, sizeof(uint32_t) * (file->sid_max + 8));
+                if (p == NULL) {
+                    SCFree(file->sid);
+                    file->sid = NULL;
+                    file->sid_cnt = 0;
+                    file->sid_max = 0;
+                    goto continue_after_realloc_fail;
+                } else {
+                    file->sid = p;
+                    file->sid_max += 8;
+                }
+            }
+            file->sid[file->sid_cnt] = s->id;
+            file->sid_cnt++;
+        }
     }
+
+continue_after_realloc_fail:
 
     det_ctx->filestore[det_ctx->filestore_cnt].file_id = file_id;
     det_ctx->filestore[det_ctx->filestore_cnt].tx_id = det_ctx->tx_id;

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -149,6 +149,18 @@ json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
     json_object_set_new(fjs, "filename", SCJsonString(s));
     if (s != NULL)
         SCFree(s);
+
+    json_t *sig_ids = json_array();
+    if (unlikely(fjs == NULL)) {
+        json_decref(js);
+        return NULL;
+    }
+
+    for (uint32_t i = 0; ff->sid != NULL && i < ff->sid_cnt; i++) {
+        json_array_append(sig_ids, json_integer(ff->sid[i]));
+    }
+    json_object_set_new(fjs, "sid", sig_ids);
+
 #ifdef HAVE_MAGIC
     if (ff->magic)
         json_object_set_new(fjs, "magic", json_string((char *)ff->magic));

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -454,6 +454,13 @@ static File *FileAlloc(const uint8_t *name, uint16_t name_len)
     new->name_len = name_len;
     memcpy(new->name, name, name_len);
 
+    new->sid_cnt = 0;
+    new->sid_max = 8;
+    /* SCMalloc() is allowed to fail here because sid well be checked later on */
+    new->sid = SCMalloc(sizeof(uint32_t) * new->sid_max);
+    if (new->sid == NULL)
+        sid->max = 0;
+
     return new;
 }
 
@@ -464,6 +471,8 @@ static void FileFree(File *ff)
 
     if (ff->name != NULL)
         SCFree(ff->name);
+    if (ff->sid != NULL)
+        SCFree(ff->sid);
 #ifdef HAVE_MAGIC
     /* magic returned by libmagic is strdup'd by MagicLookup. */
     if (ff->magic != NULL)

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -89,6 +89,10 @@ typedef struct File_ {
                                      *   flag is set */
     uint64_t content_stored;
     uint64_t size;
+
+    uint32_t *sid; /* signature id of a rule that triggered the filestore event */
+    uint32_t sid_cnt;
+    uint32_t sid_max;
 } File;
 
 typedef struct FileContainer_ {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2530

Describe changes:
- print SID(s) of a triggering rule in json fileinfo file if there are any
- fixup for [#3655](https://github.com/OISF/suricata/pull/3608)

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

