### PR TITLE
tls: fix AddressSanitizer heap-buffer-overflow

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -771,6 +771,11 @@ static inline int TLSDecodeHSHelloCipherSuites(SSLState *ssl_state,
         if (!(HAS_SPACE(cipher_suites_length)))
             goto invalid_length;
 
+        /* Cipher suites length should always be divisible by 2 */
+        if ((cipher_suites_length % 2) != 0) {
+            goto invalid_length;
+        }
+
         if (ssl_config.enable_ja3) {
             int rc;
 

--- a/src/util-ja3.c
+++ b/src/util-ja3.c
@@ -77,10 +77,6 @@ static int Ja3BufferResizeIfFull(JA3Buffer *buffer, uint32_t len)
 {
     DEBUG_VALIDATE_BUG_ON(buffer == NULL);
 
-    if (len == 0) {
-        return 0;
-    }
-
     while (buffer->used + len + 2 > buffer->size)
     {
         buffer->size *= 2;


### PR DESCRIPTION
The following changes were made:
* Make sure that the cipher suites length is never a odd number
* Don't skip resizing JA3 data when the buffer has a length of zero

https://redmine.openinfosecfoundation.org/issues/2762

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/180
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/180