### PR TITLE
Filestore stream-depth v10

### DIFF
--- a/doc/userguide/file-extraction/file-extraction.rst
+++ b/doc/userguide/file-extraction/file-extraction.rst
@@ -66,6 +66,19 @@ of the filename. For example, if the SHA256 hex string of an extracted
 file starts with "f9bc6d..." the file we be placed in the directory
 `filestore/f9`.
 
+
+The size of a file that can be stored depends on ``file-store.stream-depth``,
+if this value is reached a file can be truncated and might not be stored completely.
+If not enabled, ``stream.reassembly.depth`` will be considered.
+
+Setting ``file-store.stream-depth`` to 0 permits to store any files.
+
+``file-store.stream-depth`` will always override ``stream.reassembly.depth``
+when filestore keyword is used.
+
+A protocol parser, like modbus, could permit to set a different
+store-depth value and use it rather than ``file-store.stream-depth``.
+
 Using the SHA256 for file names allows for automatic de-duplication of
 extracted files. However, the timestamp of a pre-existing file will be
 updated if the same files is extracted again, similar to the `touch`

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -171,11 +171,12 @@ typedef struct HtpBody_ {
     uint64_t body_inspected;
 } HtpBody;
 
-#define HTP_CONTENTTYPE_SET     0x01    /**< We have the content type */
-#define HTP_BOUNDARY_SET        0x02    /**< We have a boundary string */
-#define HTP_BOUNDARY_OPEN       0x04    /**< We have a boundary string */
-#define HTP_FILENAME_SET        0x08   /**< filename is registered in the flow */
-#define HTP_DONTSTORE           0x10    /**< not storing this file */
+#define HTP_CONTENTTYPE_SET     BIT_U8(0)    /**< We have the content type */
+#define HTP_BOUNDARY_SET        BIT_U8(1)    /**< We have a boundary string */
+#define HTP_BOUNDARY_OPEN       BIT_U8(2)    /**< We have a boundary string */
+#define HTP_FILENAME_SET        BIT_U8(3)    /**< filename is registered in the flow */
+#define HTP_DONTSTORE           BIT_U8(4)    /**< not storing this file */
+#define HTP_STREAM_DEPTH_SET    BIT_U8(5)    /**< stream-depth is set */
 
 /** Now the Body Chunks will be stored per transaction, at
   * the tx user data */

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -173,6 +173,8 @@ void AppLayerParserRegisterMpmIDsFuncs(uint8_t ipproto, AppProto alproto,
 void AppLayerParserRegisterDetectFlagsFuncs(uint8_t ipproto, AppProto alproto,
         uint64_t(*GetTxDetectFlags)(void *tx, uint8_t dir),
         void (*SetTxDetectFlags)(void *tx, uint8_t dir, uint64_t));
+void AppLayerParserRegisterSetStreamDepthFlag(uint8_t ipproto, AppProto alproto,
+        void (*SetStreamDepthFlag)(void *tx, uint8_t flags));
 
 /***** Get and transaction functions *****/
 
@@ -237,6 +239,7 @@ LoggerId AppLayerParserProtocolGetLoggerBits(uint8_t ipproto, AppProto alproto);
 void AppLayerParserTriggerRawStreamReassembly(Flow *f, int direction);
 void AppLayerParserSetStreamDepth(uint8_t ipproto, AppProto alproto, uint32_t stream_depth);
 uint32_t AppLayerParserGetStreamDepth(const Flow *f);
+void AppLayerParserSetStreamDepthFlag(uint8_t ipproto, AppProto alproto, void *state, uint64_t tx_id, uint8_t flags);
 
 /***** Cleanup *****/
 

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -211,18 +211,24 @@ int DetectFilestorePostMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx, Pack
     else
         flags |= STREAM_TOSERVER;
 
+    uint16_t u;
+
+    for (u = 0; u < det_ctx->filestore_cnt; u++) {
+        AppLayerParserSetStreamDepthFlag(p->flow->proto, p->flow->alproto,
+                                         FlowGetAppState(p->flow),
+                                         det_ctx->filestore[u].tx_id,
+                                         flags);
+    }
+
     FileContainer *ffc = AppLayerParserGetFiles(p->flow->proto, p->flow->alproto,
                                                 p->flow->alstate, flags);
 
     /* filestore for single files only */
     if (s->filestore_ctx == NULL) {
-        uint16_t u;
         for (u = 0; u < det_ctx->filestore_cnt; u++) {
             FileStoreFileById(ffc, det_ctx->filestore[u].file_id);
         }
     } else {
-        uint16_t u;
-
         for (u = 0; u < det_ctx->filestore_cnt; u++) {
             FilestorePostMatchWithOptions(p, p->flow, s->filestore_ctx, ffc,
                     det_ctx->filestore[u].file_id, det_ctx->filestore[u].tx_id);


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2264

Describe changes:
- `AppLayerHtpCheckStreamDepth`: return `bool` instead of `int`
- `AppLayerHtpComputeChunkLength`:
    - return the value instead of return by pointer
    - cast `uint32_t` vars to `uint64_t`
- `AppLayerHtpCheckStreamDepth`: make code more readable
- `HTPParserTest27`: fix code style

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/199
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/63

