### PR TITLE
Doc suricatasc/v1

### DIFF
--- a/doc/userguide/unix-socket.rst
+++ b/doc/userguide/unix-socket.rst
@@ -78,6 +78,15 @@ The set of existing commands is the following:
 * memcap-set: update memcap value of an item specified
 * memcap-show: show memcap value of an item specified
 * memcap-list: list all memcap values available
+* reload-rules: alias of ruleset-reload-rules
+* register-tenant-handler: register a tenant handler with the specified mapping
+* unregister-tenant-handler: unregister a tenant handler with the specified mapping
+* register-tenant: register tenant with a particular ID and filename
+* unregister-tenant: unregister tenant with a particular ID
+* reload-tenant: reload a tenant with specified ID and filename
+* add-hostbit: add hostbit on a host IP with a particular bit name and time of expiry
+* remove-hostbit: remove hostbit on a host IP with specified bit name
+* list-hostbit: list hostbit for a particular host IP
 
 You can access to these commands with the provided example script which
 is named ``suricatasc``. A typical session with ``suricatasc`` will looks like:

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -789,7 +789,7 @@ TmEcode UnixSocketUnregisterTenantHandler(json_t *cmd, json_t* answer, void *dat
         return TM_ECODE_FAILED;
     }
 
-    json_object_set_new(answer, "message", json_string("handler added"));
+    json_object_set_new(answer, "message", json_string("handler removed"));
     return TM_ECODE_OK;
 }
 


### PR DESCRIPTION
- Add missing commands and their corresponding details in unix-socket
userguide.
- Fix the message for unregister-tenant-handler

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2800
