### PR TITLE
Suricata ctl cleanup/v2

### DIFF
--- a/doc/userguide/unix-socket.rst
+++ b/doc/userguide/unix-socket.rst
@@ -78,6 +78,15 @@ The set of existing commands is the following:
 * memcap-set: update memcap value of an item specified
 * memcap-show: show memcap value of an item specified
 * memcap-list: list all memcap values available
+* reload-rules: alias of ruleset-reload-rules
+* register-tenant-handler: register a tenant handler with the specified mapping
+* unregister-tenant-handler: unregister a tenant handler with the specified mapping
+* register-tenant: register tenant with a particular ID and filename
+* unregister-tenant: unregister tenant with a particular ID
+* reload-tenant: reload a tenant with specified ID and filename
+* add-hostbit: add hostbit on a host IP with a particular bit name and time of expiry
+* remove-hostbit: remove hostbit on a host IP with specified bit name
+* list-hostbit: list hostbit for a particular host IP
 
 You can access to these commands with the provided example script which
 is named ``suricatasc``. A typical session with ``suricatasc`` will looks like:

--- a/python/suricata/ctl/filestore.py
+++ b/python/suricata/ctl/filestore.py
@@ -30,7 +30,6 @@ class InvalidAgeFormatError(Exception):
     pass
 
 def register_args(parser):
-
     parsers = parser.add_subparsers()
 
     prune_parser = parsers.add_parser("prune")

--- a/python/suricata/ctl/loghandler.py
+++ b/python/suricata/ctl/loghandler.py
@@ -40,15 +40,16 @@ class SuriColourLogHandler(logging.StreamHandler):
     """An alternative stream log handler that logs with Suricata inspired
     log colours."""
 
-    def formatTime(self, record):
-        lt = time.localtime(record.created)
-        t = "%d/%d/%d -- %02d:%02d:%02d" % (lt.tm_mday,
-                                            lt.tm_mon,
-                                            lt.tm_year,
-                                            lt.tm_hour,
-                                            lt.tm_min,
-                                            lt.tm_sec)
-        return "%s" % (t)
+    @staticmethod
+    def format_time(record):
+        local_time = time.localtime(record.created)
+        formatted_time = "%d/%d/%d -- %02d:%02d:%02d" % (local_time.tm_mday,
+                                                         local_time.tm_mon,
+                                                         local_time.tm_year,
+                                                         local_time.tm_hour,
+                                                         local_time.tm_min,
+                                                         local_time.tm_sec)
+        return "%s" % (formatted_time)
 
     def emit(self, record):
 
@@ -64,7 +65,7 @@ class SuriColourLogHandler(logging.StreamHandler):
 
         self.stream.write("%s%s%s - <%s%s%s> -- %s%s%s\n" % (
             GREEN,
-            self.formatTime(record),
+            self.format_time(record),
             RESET,
             level_prefix,
             record.levelname.title(),
@@ -73,7 +74,8 @@ class SuriColourLogHandler(logging.StreamHandler):
             self.mask_secrets(record.getMessage()),
             RESET))
 
-    def mask_secrets(self, msg):
+    @staticmethod
+    def mask_secrets(msg):
         for secret in secrets:
             msg = msg.replace(secret, "<%s>" % secrets[secret])
         return msg

--- a/python/suricata/ctl/main.py
+++ b/python/suricata/ctl/main.py
@@ -34,11 +34,10 @@ def init_logger():
 
 def main():
     init_logger()
-    parser = argparse.ArgumentParser(description="Suricata Control Tool")
-    subparsers = parser.add_subparsers(
-        title="subcommands",
-        description="Commands")
-    filestore.register_args(subparsers.add_parser("filestore"))
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(help='sub-command help')
+    fs_parser = subparsers.add_parser("filestore", help="Filestore related commands")
+    filestore.register_args(parser=fs_parser)
     args = parser.parse_args()
     try:
         func = args.func

--- a/python/suricata/ctl/main.py
+++ b/python/suricata/ctl/main.py
@@ -46,5 +46,8 @@ def main():
     filestore.register_args(subparsers.add_parser("filestore"))
 
     args = parser.parse_args()
-
-    args.func(args)
+    try:
+        func = args.func
+    except AttributeError:
+        parser.error("too few arguments")
+    func(args)

--- a/python/suricata/ctl/main.py
+++ b/python/suricata/ctl/main.py
@@ -19,8 +19,7 @@ import os
 import argparse
 import logging
 
-from suricata.ctl import filestore
-from suricata.ctl import loghandler
+from suricata.ctl import filestore, loghandler
 
 def init_logger():
     """ Initialize logging, use colour if on a tty. """
@@ -34,17 +33,12 @@ def init_logger():
             format="%(asctime)s - <%(levelname)s> - %(message)s")
 
 def main():
-
     init_logger()
-
     parser = argparse.ArgumentParser(description="Suricata Control Tool")
-
     subparsers = parser.add_subparsers(
         title="subcommands",
         description="Commands")
-
     filestore.register_args(subparsers.add_parser("filestore"))
-
     args = parser.parse_args()
     try:
         func = args.func

--- a/python/suricata/ctl/test_filestore.py
+++ b/python/suricata/ctl/test_filestore.py
@@ -12,7 +12,7 @@ class PruneTestCase(unittest.TestCase):
         self.assertEqual(filestore.parse_age("1h"), 3600)
         self.assertEqual(filestore.parse_age("1d"), 86400)
 
-        with self.assertRaises(filestore.InvalidAgeFormatError) as err:
+        with self.assertRaises(filestore.InvalidAgeFormatError):
             filestore.parse_age("1")
-        with self.assertRaises(filestore.InvalidAgeFormatError) as err:
+        with self.assertRaises(filestore.InvalidAgeFormatError):
             filestore.parse_age("1y")

--- a/python/suricata/ctl/test_filestore.py
+++ b/python/suricata/ctl/test_filestore.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import unittest
 
-import filestore
+from suricata.ctl import filestore
 
 class PruneTestCase(unittest.TestCase):
 

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -789,7 +789,7 @@ TmEcode UnixSocketUnregisterTenantHandler(json_t *cmd, json_t* answer, void *dat
         return TM_ECODE_FAILED;
     }
 
-    json_object_set_new(answer, "message", json_string("handler added"));
+    json_object_set_new(answer, "message", json_string("handler removed"));
     return TM_ECODE_OK;
 }
 


### PR DESCRIPTION
- Fix the message for unregister-tenant-handler
- Add missing commands and detail to unix-socket doc
- Clean up parser, improve help for suricatactl
- Fix PyLint issues with suricatactl
- Make code compatible with Python 3 for suricatactl

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) tickets:
- https://redmine.openinfosecfoundation.org/issues/2793
- https://redmine.openinfosecfoundation.org/issues/2800

This PR is a rework of #3671 and #3670 