### PR TITLE
201902 miscfixes

### DIFF
--- a/doc/userguide/rules/xbits.rst
+++ b/doc/userguide/rules/xbits.rst
@@ -5,7 +5,7 @@ Set, unset, toggle and check for bits stored per host or ip_pair.
 
 Syntax::
 
-    xbits:<set|unset|isset|toggle>,<name>,track <ip_src|ip_dst|ip_pair>;
+    xbits:<set|unset|isset|isnotset|toggle>,<name>,track <ip_src|ip_dst|ip_pair>;
     xbits:<set|unset|isset|toggle>,<name>,track <ip_src|ip_dst|ip_pair> \
         [,expire <seconds>];
     xbits:<set|unset|isset|toggle>,<name>,track <ip_src|ip_dst|ip_pair> \
@@ -22,6 +22,8 @@ Notes
    you check it (``isset``) with ``track ip_src``.
 
 -  To not alert, use ``noalert;``
+
+- the ``toggle`` option will flip the value of the xbits.
 
 -  See also:
 

--- a/doc/userguide/rules/xbits.rst
+++ b/doc/userguide/rules/xbits.rst
@@ -5,7 +5,6 @@ Set, unset, toggle and check for bits stored per host or ip_pair.
 
 Syntax::
 
-    xbits:noalert;
     xbits:<set|unset|isset|toggle>,<name>,track <ip_src|ip_dst|ip_pair>;
     xbits:<set|unset|isset|toggle>,<name>,track <ip_src|ip_dst|ip_pair> \
         [,expire <seconds>];

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -45,7 +45,7 @@
 #include "util-unittest.h"
 #include "util-debug.h"
 
-#define PARSE_REGEX         "([a-z]+)(?:,\\s*(.*))?"
+#define PARSE_REGEX         "^([a-z]+)(?:,\\s*(.*))?"
 static pcre *parse_regex;
 static pcre_extra *parse_regex_study;
 
@@ -767,6 +767,9 @@ static int FlowBitsTestSig02(void)
     FAIL_IF_NOT_NULL(s);
 
     s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"toggle rule need an option\"; flowbits:toggle; content:\"GET \"; sid:5;)");
+    FAIL_IF_NOT_NULL(s);
+
+    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"!set is not an option\"; flowbits:!set,myerr; content:\"GET \"; sid:6;)");
     FAIL_IF_NOT_NULL(s);
 
     SigGroupBuild(de_ctx);

--- a/src/detect-hostbits.c
+++ b/src/detect-hostbits.c
@@ -61,7 +61,7 @@ TODO:
     hostbits:set,bitname,both,120;
  */
 
-#define PARSE_REGEX "([a-z]+)"          /* Action */                    \
+#define PARSE_REGEX "^([a-z]+)"          /* Action */                    \
     "(?:\\s*,\\s*([^\\s,]+))?(?:\\s*)?" /* Name. */                     \
     "(?:\\s*,\\s*([^,\\s]+))?(?:\\s*)?" /* Direction. */                \
     "(.+)?"                             /* Any remainding data. */
@@ -618,6 +618,10 @@ static int HostBitsTestSig02(void)
     s = DetectEngineAppendSig(de_ctx,
             "alert ip any any -> any any (hostbits:isnotset,abc,dst; content:\"GET \"; sid:2;)");
     FAIL_IF_NULL(s);
+
+    s = DetectEngineAppendSig(de_ctx,
+            "alert ip any any -> any any (hostbits:!isset,abc,dst; content:\"GET \"; sid:3;)");
+    FAIL_IF_NOT_NULL(s);
 
 /* TODO reenable after both is supported
     s = DetectEngineAppendSig(de_ctx,

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -53,7 +53,7 @@
     xbits:set,bitname,track ip_pair,expire 60
  */
 
-#define PARSE_REGEX     "([a-z]+)" "(?:,\\s*([^,]+))?" "(?:,\\s*(?:track\\s+([^,]+)))" "(?:,\\s*(?:expire\\s+([^,]+)))?"
+#define PARSE_REGEX     "^([a-z]+)" "(?:,\\s*([^,]+))?" "(?:,\\s*(?:track\\s+([^,]+)))" "(?:,\\s*(?:expire\\s+([^,]+)))?"
 static pcre *parse_regex;
 static pcre_extra *parse_regex_study;
 
@@ -527,6 +527,10 @@ static int XBitsTestSig02(void)
     s = DetectEngineAppendSig(de_ctx,
             "alert ip any any -> any any (xbits:toggle,abc,track ip_dst; content:\"GET \"; sid:5;)");
     FAIL_IF_NULL(s);
+
+    s = DetectEngineAppendSig(de_ctx,
+            "alert ip any any -> any any (xbits:!set,abc,track ip_dst; content:\"GET \"; sid:6;)");
+    FAIL_IF_NOT_NULL(s);
 
     DetectEngineCtxFree(de_ctx);
     PASS;

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -86,7 +86,7 @@
 #define DOC_URL "https://suricata.readthedocs.io/en/"
 
 #if defined RELEASE
-#define DOC_VERSION PROG_VER
+#define DOC_VERSION "suricata-" PROG_VER
 #else
 #define DOC_VERSION "latest"
 #endif


### PR DESCRIPTION
A series of small fixes related to doc and some invalid option detection.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Improve xbits doc
- Better parsing of hostbuts, xbits and flowbits
- Fix list-keywords command line option in release mode

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/434
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/215

