### PR TITLE
suricata-verify for travis; prefer python3 - v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -219,6 +219,7 @@ script:
             exit 1
         fi
     fi
+    (cd qa/coccinelle && make check)
   - |
     if [[ "$DO_DISTCHECK" == "yes" ]]; then
         make distcheck DISTCHECK_CONFIGURE_FLAGS="${ARGS}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,12 @@ addons:
       - *packages-without-jansson
       - libjansson-dev
 
+cache:
+  directories:
+    - /home/travis/.rustup
+    - /home/travis/.cargo
+    - /home/travis/.multirust
+
 # Define the default CFLAGS used by all builds as a YAML anchor.
 default-cflags: &default-cflags
   CFLAGS="-Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-function"

--- a/.travis.yml
+++ b/.travis.yml
@@ -221,6 +221,9 @@ script:
     if [[ "$DO_CHECK_SETUP_SCRIPTS" == "yes" ]]; then
         (cd scripts && ./check-setup.sh)
     fi
+  - |
+    git clone https://github.com/OISF/suricata-verify.git verify
+    python ./verify/run.py
 
 before_install:
   - export PATH=$HOME/.cargo/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -172,10 +172,10 @@ matrix:
         apt:
           packages:
             - *packages-without-jansson
-    # OSX 10.12, XCode 8.1
+    # OSX 10.13, XCode 8.3
     - os: osx
       compiler: gcc
-      osx_image: xcode8.1
+      osx_image: xcode8.3
       sudo: true
       env:
         - NAME="osx,gcc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -259,6 +259,7 @@ before_install:
         packages="$packages lua"
         packages="$packages pcre"
         packages="$packages hiredis"
+        packages="$packages jq"
         for package in $packages; do
             if brew ls $package --versions > /dev/null; then
                 brew unlink $package
@@ -271,5 +272,9 @@ before_install:
         # Now relink, becuase if a newer version of a package wasn't
         # installed above, it will remain unlinked.
         brew link $packages
+
+        curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+        sudo python ./get-pip.py
+        sudo pip install PyYAML
     fi
   - ./qa/travis-libhtp.sh

--- a/configure.ac
+++ b/configure.ac
@@ -85,22 +85,26 @@
         exit 1
     fi
 
+    python_version="not set"
+    python_path="not set"
+
     AC_ARG_ENABLE(python,
-           AS_HELP_STRING([--enable-python], [Enable python]),[enable_python=$enableval],[enable_python=yes])
-    AC_PATH_PROGS(HAVE_PYTHON, python python2 python2.7, "no")
-    if test "x$enable_python" = "xno" ; then
-        echo
-        echo "   Warning! python disabled, you will not be      "
-        echo "   able to install suricatasc unix socket client   "
-        echo
+           AS_HELP_STRING([--enable-python], [Enable python]),
+	   [enable_python=$enableval],[enable_python=yes])
+    if test "x$enable_python" != "xyes"; then
         enable_python="no"
-    fi
-    if test "$HAVE_PYTHON" = "no"; then
-        echo
-        echo "   Warning! python not found, you will not be     "
-        echo "   able to install suricatasc unix socket client   "
-        echo
-        enable_python="no"
+    else
+        AC_PATH_PROGS(HAVE_PYTHON, python3 python2.7 python2 python, "no")
+        if test "$HAVE_PYTHON" = "no"; then
+            echo
+            echo "   Warning! python not found, you will not be     "
+            echo "   able to install suricatasc unix socket client   "
+            echo
+            enable_python="no"
+	else
+	    python_path="$HAVE_PYTHON"
+	    python_version="$($HAVE_PYTHON --version)"
+        fi
     fi
     AM_CONDITIONAL([HAVE_PYTHON], [test "x$enable_python" = "xyes"])
 
@@ -2539,6 +2543,9 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   Rust compiler:                           ${rust_compiler_version}
   Rust cargo:                              ${rust_cargo_version}
 
+  Python support:                          ${enable_python}
+  Python path:                             ${python_path}
+  Python version:                          ${python_version}
   Install suricatasc:                      ${enable_python}
   Install suricata-update:                 ${install_suricata_update}
 


### PR DESCRIPTION
Bundling to separate issues in this PR if it helps review/qa.

Prefer Python 3:
- autoconf will now specifically look for python3, then python2, then python. The idea here is to prefer Python 3.
- Redmine issue: https://redmine.openinfosecfoundation.org/issues/2808
- Specially set the Mac environment to xcode8.3 to get rid of the warning that 8.1 is deprecrated and the tests will be done on 8.3 anyways.

Add suricata-verify to Travis-CI tests:
- Requires jq and pyyaml to be installed on Mac.
- As rustup can sometimes take a very long time on Travis (but not always), attempt to cache it.

You can verify that the correct Rust version is still being used here:
- 1.24.1 -- https://travis-ci.org/jasonish/suricata/jobs/498790305#L635
- 1.31.0 -- https://travis-ci.org/jasonish/suricata/jobs/498790303#L667

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/345
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/699
