### PR TITLE
filestore: fix dropping of unwanted files (Issue #2853)

### DIFF
--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -263,7 +263,7 @@ static int DetectFilestoreMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx, 
     /* file can be NULL when a rule with filestore scope > file
      * matches. */
     if (file != NULL) {
-        file_id = file->file_store_id;
+        file_id = file->file_track_id;
         if (file->sid != NULL && s->id > 0) {
             if (file->sid_cnt >= file->sid_max) {
                 void *p = SCRealloc(file->sid, sizeof(uint32_t) * (file->sid_max + 8));

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -1256,7 +1256,7 @@ void FileStoreFileById(FileContainer *fc, uint32_t file_id)
 
     if (fc != NULL) {
         for (ptr = fc->head; ptr != NULL; ptr = ptr->next) {
-            if (ptr->file_store_id == file_id) {
+            if (ptr->file_track_id == file_id) {
                 FileStore(ptr);
             }
         }


### PR DESCRIPTION
- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [Issue #2853](https://redmine.openinfosecfoundation.org/issues/2853)

Describe changes:
- use `file_track_id` instead of `file_store_id` to uniquely identify files to drop

`file_store_id` is is/was used by filestore v1. file_store_id only gets updated if the file gets actually dropped to disk. in this case the file is still in memory and just selected / search for dropping. esp in filestore v2 this value is always 0. this leads to dropping of all files in a `FileContainer` when at least one file was marked for dropping.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

