### PR TITLE
Refresh netmap_if address after each NIOCREGIF

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,7 +86,7 @@
     fi
 
     AC_ARG_ENABLE(python,
-           AS_HELP_STRING([--enable-python], [Enable python]),,[enable_python=yes])
+           AS_HELP_STRING([--enable-python], [Enable python]),[enable_python=$enableval],[enable_python=yes])
     AC_PATH_PROGS(HAVE_PYTHON, python python2 python2.7, "no")
     if test "x$enable_python" = "xno" ; then
         echo
@@ -312,7 +312,7 @@
     #These flags seem to be supported on CentOS 5+, Ubuntu 8.04+, and FedoreCore 11+
     #Options are taken from https://wiki.ubuntu.com/CompilerFlags
     AC_ARG_ENABLE(gccprotect,
-           AS_HELP_STRING([--enable-gccprotect], [Detect and use gcc hardening options]),,[enable_gccprotect=no])
+           AS_HELP_STRING([--enable-gccprotect], [Detect and use gcc hardening options]),[enable_gccprotect=$enableval],[enable_gccprotect=no])
 
     AS_IF([test "x$enable_gccprotect" = "xyes"], [
         #buffer overflow protection
@@ -366,14 +366,14 @@
 
     #enable profile generation
     AC_ARG_ENABLE(gccprofile,
-           AS_HELP_STRING([--enable-gccprofile], [Enable gcc profile info i.e -pg flag is set]),,[enable_gccprofile=no])
+           AS_HELP_STRING([--enable-gccprofile], [Enable gcc profile info i.e -pg flag is set]),[enable_gccprofile=$enableval],[enable_gccprofile=no])
     AS_IF([test "x$enable_gccprofile" = "xyes"], [
         CFLAGS="${CFLAGS} -pg"
     ])
 
     #enable gcc march=native gcc 4.2 or later
     AC_ARG_ENABLE(gccmarch_native,
-           AS_HELP_STRING([--enable-gccmarch-native], [Enable gcc march=native gcc 4.2 and later only]),,[enable_gccmarch_native=yes])
+           AS_HELP_STRING([--enable-gccmarch-native], [Enable gcc march=native gcc 4.2 and later only]),[enable_gccmarch_native=$enableval],[enable_gccmarch_native=yes])
     AS_IF([test "x$enable_gccmarch_native" = "xyes"], [
         case "$host" in
             *powerpc*)
@@ -402,7 +402,7 @@
 
   # enable the running of unit tests
     AC_ARG_ENABLE(unittests,
-           AS_HELP_STRING([--enable-unittests], [Enable compilation of the unit tests]),,[enable_unittests=no])
+           AS_HELP_STRING([--enable-unittests], [Enable compilation of the unit tests]),[enable_unittests=$enableval],[enable_unittests=no])
     AS_IF([test "x$enable_unittests" = "xyes"], [
         AC_DEFINE([UNITTESTS],[1],[Enable built-in unittests])
     ])
@@ -410,7 +410,7 @@
 
   # enable the building of ebpf files 
     AC_ARG_ENABLE(ebpf-build,
-           AS_HELP_STRING([--enable-ebpf-build], [Enable compilation of ebpf files]),,[enable_ebpf_build=no])
+           AS_HELP_STRING([--enable-ebpf-build], [Enable compilation of ebpf files]),[enable_ebpf_build=$enableval],[enable_ebpf_build=no])
     AM_CONDITIONAL([BUILD_EBPF], [test "x$enable_ebpf_build" = "xyes"])
 
     if test "x$enable_ebpf_build" = "xyes"; then
@@ -459,14 +459,14 @@
 
   # enable workaround for old barnyard2 for unified alert output
     AC_ARG_ENABLE(old-barnyard2,
-           AS_HELP_STRING([--enable-old-barnyard2], [Use workaround for old barnyard2 in unified2 output]),,[enable_old_barnyard2=no])
+           AS_HELP_STRING([--enable-old-barnyard2], [Use workaround for old barnyard2 in unified2 output]),[enable_old_barnyard2=$enableval],[enable_old_barnyard2=no])
     AS_IF([test "x$enable_old_barnyard2" = "xyes"], [
         AC_DEFINE([HAVE_OLD_BARNYARD2],[1],[Use workaround for old barnyard2 in unified2 output])
     ])
 
   # enable debug output
     AC_ARG_ENABLE(debug,
-           AS_HELP_STRING([--enable-debug], [Enable debug output]),,[enable_debug=no])
+           AS_HELP_STRING([--enable-debug], [Enable debug output]),[enable_debug=$enableval],[enable_debug=no])
     AS_IF([test "x$enable_debug" = "xyes"], [
         AC_DEFINE([DEBUG],[1],[Enable debug output])
     ])
@@ -474,7 +474,7 @@
 
   # enable debug validation functions & macro's output
     AC_ARG_ENABLE(debug-validation,
-           AS_HELP_STRING([--enable-debug-validation], [Enable (debug) validation code output]),,[enable_debug_validation=no])
+           AS_HELP_STRING([--enable-debug-validation], [Enable (debug) validation code output]),[enable_debug_validation=$enableval],[enable_debug_validation=no])
     AS_IF([test "x$enable_debug_validation" = "xyes"], [
         if test "$enable_unittests" = "yes"; then
             AC_MSG_ERROR([debug_validation can't be enabled with enabled unittests!])
@@ -485,7 +485,7 @@
 
   # profiling support
     AC_ARG_ENABLE(profiling,
-           AS_HELP_STRING([--enable-profiling], [Enable performance profiling]),,[enable_profiling=no])
+           AS_HELP_STRING([--enable-profiling], [Enable performance profiling]),[enable_profiling=$enableval],[enable_profiling=no])
     AS_IF([test "x$enable_profiling" = "xyes"], [
     case "$host" in
         *-*-openbsd*)
@@ -499,7 +499,7 @@
 
   # profiling support, locking
     AC_ARG_ENABLE(profiling-locks,
-           AS_HELP_STRING([--enable-profiling-locks], [Enable performance profiling for locks]),,[enable_profiling_locks=no])
+           AS_HELP_STRING([--enable-profiling-locks], [Enable performance profiling for locks]),[enable_profiling_locks=$enableval],[enable_profiling_locks=no])
     AS_IF([test "x$enable_profiling_locks" = "xyes"], [
         AC_DEFINE([PROFILING],[1],[Enable performance profiling])
         AC_DEFINE([PROFILE_LOCKING],[1],[Enable performance profiling for locks])
@@ -507,7 +507,7 @@
 
   # enable support for IPFW
     AC_ARG_ENABLE(ipfw,
-            AS_HELP_STRING([--enable-ipfw], [Enable FreeBSD IPFW support for inline IDP]),,[enable_ipfw=no])
+            AS_HELP_STRING([--enable-ipfw], [Enable FreeBSD IPFW support for inline IDP]),[enable_ipfw=$enableval],[enable_ipfw=no])
     AS_IF([test "x$enable_ipfw" = "xyes"], [
         AC_DEFINE([IPFW],[1],[Enable FreeBSD IPFW support for inline IDP])
     ])
@@ -933,10 +933,10 @@
 
     AC_ARG_ENABLE(nflog,
             AS_HELP_STRING([--enable-nflog],[Enable libnetfilter_log support]),
-                           [ enable_nflog="yes"],
+                           [ enable_nflog="$enableval"],
                            [ enable_nflog="no"])
     AC_ARG_ENABLE(nfqueue,
-           AS_HELP_STRING([--enable-nfqueue], [Enable NFQUEUE support for inline IDP]),[enable_nfqueue=yes],[enable_nfqueue=no])
+           AS_HELP_STRING([--enable-nfqueue], [Enable NFQUEUE support for inline IDP]),[enable_nfqueue=$enableval],[enable_nfqueue=no])
     if test "$enable_nfqueue" != "no"; then
         PKG_CHECK_MODULES([libnetfilter_queue], [libnetfilter_queue], [enable_nfqueue=yes], [enable_nfqueue=no])
         CPPFLAGS="${CPPFLAGS} ${libnetfilter_queue_CFLAGS}"
@@ -1082,7 +1082,7 @@
 
   # WinDivert support
     AC_ARG_ENABLE(windivert,
-        AS_HELP_STRING([--enable-windivert],[Enable WinDivert support [default=no]]),,
+        AS_HELP_STRING([--enable-windivert],[Enable WinDivert support [default=no]]),[enable_windivert=$enableval],
         [enable_windivert="no"])
     
   # WinDivert can only be enabled on Windows builds
@@ -1126,7 +1126,7 @@
 
   # prelude
     AC_ARG_ENABLE(prelude,
-            AS_HELP_STRING([--enable-prelude], [Enable Prelude support for alerts]),,[enable_prelude=no])
+            AS_HELP_STRING([--enable-prelude], [Enable Prelude support for alerts]),[enable_prelude=$enableval],[enable_prelude=no])
     # Prelude doesn't work with -Werror
     STORECFLAGS="${CFLAGS}"
     CFLAGS="${CFLAGS} -Wno-error=unused-result"
@@ -1334,7 +1334,7 @@
     # libpfring (currently only supported for libpcap enabled pfring)
     # Error on the side of caution. If libpfring enabled pcap is being used and we don't link against -lpfring compilation will fail.
     AC_ARG_ENABLE(pfring,
-           AS_HELP_STRING([--enable-pfring], [Enable Native PF_RING support]),,[enable_pfring=no])
+           AS_HELP_STRING([--enable-pfring], [Enable Native PF_RING support]),[enable_pfring=$enableval],[enable_pfring=no])
     AS_IF([test "x$enable_pfring" = "xyes"], [
         AC_DEFINE([HAVE_PFRING],[1],(PF_RING support enabled))
 
@@ -1411,7 +1411,7 @@
   # AF_PACKET support
     AC_ARG_ENABLE(af-packet,
            AS_HELP_STRING([--enable-af-packet], [Enable AF_PACKET support [default=yes]]),
-                        ,[enable_af_packet=yes])
+                        [enable_af_packet=$enableval],[enable_af_packet=yes])
     AS_IF([test "x$enable_af_packet" = "xyes"], [
         AC_CHECK_DECL([TPACKET_V2],
             AC_DEFINE([HAVE_AF_PACKET],[1],[AF_PACKET support is available]),
@@ -1435,7 +1435,7 @@
 
   # Netmap support
     AC_ARG_ENABLE(netmap,
-            AS_HELP_STRING([--enable-netmap], [Enable Netmap support]),,[enable_netmap=no])
+            AS_HELP_STRING([--enable-netmap], [Enable Netmap support]),[enable_netmap=$enableval],[enable_netmap=no])
     AC_ARG_WITH(netmap_includes,
             [  --with-netmap-includes=DIR netmap include directory],
             [with_netmap_includes="$withval"],[with_netmap_includes=no])
@@ -1493,7 +1493,7 @@
 
   # libhtp
     AC_ARG_ENABLE(non-bundled-htp,
-           AS_HELP_STRING([--enable-non-bundled-htp], [Enable the use of an already installed version of htp]),,[enable_non_bundled_htp=no])
+           AS_HELP_STRING([--enable-non-bundled-htp], [Enable the use of an already installed version of htp]),[enable_non_bundled_htp=$enableval],[enable_non_bundled_htp=no])
     AS_IF([test "x$enable_non_bundled_htp" = "xyes"], [
         PKG_CHECK_MODULES([libhtp], htp,, [with_pkgconfig_htp=no])
         if test "$with_pkgconfig_htp" != "no"; then
@@ -1625,7 +1625,7 @@
 
     AC_ARG_ENABLE(ebpf,
 	        AS_HELP_STRING([--enable-ebpf],[Enable eBPF support]),
-	        [ enable_ebpf="yes"],
+	        [ enable_ebpf="$enableval"],
 	        [ enable_ebpf="no"])
 
     have_xdp="no"
@@ -1661,7 +1661,7 @@
   # Check for DAG support.
     AC_ARG_ENABLE(dag,
 	        AS_HELP_STRING([--enable-dag],[Enable DAG capture]),
-	        [ enable_dag=yes ],
+	        [ enable_dag=$enableval ],
 	        [ enable_dag=no])
     AC_ARG_WITH(dag_includes,
             [  --with-dag-includes=DIR  dagapi include directory],
@@ -1795,7 +1795,7 @@
     enable_magic="no"
     AC_ARG_ENABLE(libmagic,
            AS_HELP_STRING([--enable-libmagic], [Enable libmagic support [default=yes]]),
-                        ,[enable_magic=yes])
+                        [enable_magic=$enableval],[enable_magic=yes])
     if test "$enable_magic" = "yes"; then
         AC_ARG_WITH(libmagic_includes,
                 [  --with-libmagic-includes=DIR  libmagic include directory],
@@ -1835,7 +1835,7 @@
   # Napatech - Using the 3GD API
     AC_ARG_ENABLE(napatech,
                 AS_HELP_STRING([--enable-napatech],[Enabled Napatech Devices]),
-                [ enable_napatech=yes ],
+                [ enable_napatech=$enableval ],
                 [ enable_napatech=no])
     AC_ARG_WITH(napatech_includes,
                 [  --with-napatech-includes=DIR   napatech include directory],
@@ -1866,11 +1866,11 @@
   # liblua
     AC_ARG_ENABLE(lua,
 	        AS_HELP_STRING([--enable-lua],[Enable Lua support]),
-	        [ enable_lua="yes"],
+	        [ enable_lua="$enableval"],
 	        [ enable_lua="no"])
     AC_ARG_ENABLE(luajit,
 	        AS_HELP_STRING([--enable-luajit],[Enable Luajit support]),
-	        [ enable_luajit="yes"],
+	        [ enable_luajit="$enableval"],
 	        [ enable_luajit="no"])
     if test "$enable_lua" = "yes"; then
         if test "$enable_luajit" = "yes"; then
@@ -2034,7 +2034,7 @@
   # libgeoip
     AC_ARG_ENABLE(geoip,
 	        AS_HELP_STRING([--enable-geoip],[Enable GeoIP support]),
-	        [ enable_geoip="yes"],
+	        [ enable_geoip="$enableval"],
 	        [ enable_geoip="no"])
     AC_ARG_WITH(libgeoip_includes,
             [  --with-libgeoip-includes=DIR  libgeoip include directory],
@@ -2074,7 +2074,7 @@
   # Position Independent Executable
     AC_ARG_ENABLE(pie,
                 AS_HELP_STRING([--enable-pie],[Enable compiling as a position independent executable]),
-                [ enable_pie="yes"],
+                [ enable_pie="$enableval"],
                 [ enable_pie="no"])
     if test "$enable_pie" = "yes"; then
         CPPFLAGS="${CPPFLAGS} -fPIC"
@@ -2092,7 +2092,7 @@
 # libhiredis
     AC_ARG_ENABLE(hiredis,
 	        AS_HELP_STRING([--enable-hiredis],[Enable Redis support]),
-	        [ enable_hiredis="yes"],
+	        [ enable_hiredis="$enableval"],
 	        [ enable_hiredis="no"])
     AC_ARG_WITH(libhiredis_includes,
             [  --with-libhiredis-includes=DIR  libhiredis include directory],
@@ -2338,14 +2338,14 @@ fi
     AM_CONDITIONAL([HAVE_CARGO_VENDOR], [test "x$HAVE_CARGO_VENDOR" != "xno"])
 
     AC_ARG_ENABLE(rust_strict,
-           AS_HELP_STRING([--enable-rust-strict], [Rust warnings as errors]),,[enable_rust_strict=no])
+           AS_HELP_STRING([--enable-rust-strict], [Rust warnings as errors]),[enable_rust_strict=$enableval],[enable_rust_strict=no])
     AS_IF([test "x$enable_rust_strict" = "xyes"], [
         RUST_FEATURES="strict"
     ])
     AC_SUBST(RUST_FEATURES)
 
     AC_ARG_ENABLE(rust_debug,
-           AS_HELP_STRING([--enable-rust-debug], [Rust not in --release mode]),,[enable_rust_debug=no])
+           AS_HELP_STRING([--enable-rust-debug], [Rust not in --release mode]),[enable_rust_debug=$enableval],[enable_rust_debug=no])
     AM_CONDITIONAL([RUST_DEBUG], [test "x$enable_rust_debug" = "xyes"])
     AC_SUBST(RUST_DEBUG)
 

--- a/rust/gen-c-headers.py
+++ b/rust/gen-c-headers.py
@@ -169,7 +169,7 @@ def gen_headers(filename):
     if not should_regen(filename, output_filename):
         return
 
-    buf = open(filename).read()
+    buf = open(filename, "rb").read().decode("utf-8")
     writer = StringIO()
 
     for fn in re.findall(

--- a/src/app-layer-dcerpc-udp.c
+++ b/src/app-layer-dcerpc-udp.c
@@ -242,8 +242,8 @@ static int DCERPCUDPParseHeader(Flow *f, void *dcerpcudp_state,
                         sstate->dcerpc.dcerpchdrudp.seqnum |= (uint32_t) *(p + 65) << 16;
                         sstate->dcerpc.dcerpchdrudp.seqnum |= (uint32_t) *(p + 66) << 8;
                         sstate->dcerpc.dcerpchdrudp.seqnum |= (uint32_t) *(p + 67);
-                        sstate->dcerpc.dcerpchdrudp.opnum = *(p + 68) << 24;
-                        sstate->dcerpc.dcerpchdrudp.opnum |= *(p + 69) << 16;
+                        sstate->dcerpc.dcerpchdrudp.opnum = *(p + 68) << 8;
+                        sstate->dcerpc.dcerpchdrudp.opnum |= *(p + 69);
                         sstate->dcerpc.dcerpchdrudp.ihint = *(p + 70) << 8;
                         sstate->dcerpc.dcerpchdrudp.ihint |= *(p + 71);
                         sstate->dcerpc.dcerpchdrudp.ahint = *(p + 72) << 8;

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -771,6 +771,11 @@ static inline int TLSDecodeHSHelloCipherSuites(SSLState *ssl_state,
         if (!(HAS_SPACE(cipher_suites_length)))
             goto invalid_length;
 
+        /* Cipher suites length should always be divisible by 2 */
+        if ((cipher_suites_length % 2) != 0) {
+            goto invalid_length;
+        }
+
         if (ssl_config.enable_ja3) {
             int rc;
 

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -157,7 +157,7 @@ int DetectBytetestDoMatch(DetectEngineThreadCtx *det_ctx,
                 SCLogDebug("No Numeric value");
                 SCReturnInt(0);
             } else {
-                SCLogError(SC_ERR_INVALID_NUM_BYTES, "Error extracting %d "
+                SCLogDebug("error extracting %d "
                         "bytes of string data: %d", data->nbytes, extbytes);
                 SCReturnInt(-1);
             }
@@ -171,8 +171,8 @@ int DetectBytetestDoMatch(DetectEngineThreadCtx *det_ctx,
                           BYTE_LITTLE_ENDIAN : BYTE_BIG_ENDIAN;
         extbytes = ByteExtractUint64(&val, endianness, data->nbytes, ptr);
         if (extbytes != data->nbytes) {
-            SCLogError(SC_ERR_INVALID_NUM_BYTES, "Error extracting %d bytes "
-                   "of numeric data: %d\n", data->nbytes, extbytes);
+            SCLogDebug("error extracting %d bytes "
+                   "of numeric data: %d", data->nbytes, extbytes);
             SCReturnInt(-1);
         }
 

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -324,8 +324,9 @@ static int DetectPcreHasUpperCase(const char *re)
     return 0;
 }
 
-static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx, const char *regexstr, int *sm_list,
-        char *capture_names, size_t capture_names_size, bool negate)
+static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx,
+        const char *regexstr, int *sm_list, char *capture_names,
+        size_t capture_names_size, bool negate, AppProto *alproto)
 {
     int ec;
     const char *eb;
@@ -466,6 +467,7 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx, const char *reg
                     }
                     int list = DetectBufferTypeGetByName("http_uri");
                     *sm_list = DetectPcreSetList(*sm_list, list);
+                    *alproto = ALPROTO_HTTP;
                     break;
                 }
                 case 'V': {
@@ -475,6 +477,7 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx, const char *reg
                     }
                     int list = DetectBufferTypeGetByName("http_user_agent");
                     *sm_list = DetectPcreSetList(*sm_list, list);
+                    *alproto = ALPROTO_HTTP;
                     break;
                 }
                 case 'W': {
@@ -484,6 +487,7 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx, const char *reg
                     }
                     int list = DetectBufferTypeGetByName("http_host");
                     *sm_list = DetectPcreSetList(*sm_list, list);
+                    *alproto = ALPROTO_HTTP;
                     check_host_header = 1;
                     break;
                 }
@@ -494,6 +498,7 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx, const char *reg
                     }
                     int list = DetectBufferTypeGetByName("http_raw_host");
                     *sm_list = DetectPcreSetList(*sm_list, list);
+                    *alproto = ALPROTO_HTTP;
                     break;
                 }
                 case 'H': { /* snort's option */
@@ -503,6 +508,7 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx, const char *reg
                     }
                     int list = DetectBufferTypeGetByName("http_header");
                     *sm_list = DetectPcreSetList(*sm_list, list);
+                    *alproto = ALPROTO_HTTP;
                     break;
                 } case 'I': { /* snort's option */
                     if (pd->flags & DETECT_PCRE_RAWBYTES) {
@@ -511,11 +517,13 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx, const char *reg
                     }
                     int list = DetectBufferTypeGetByName("http_raw_uri");
                     *sm_list = DetectPcreSetList(*sm_list, list);
+                    *alproto = ALPROTO_HTTP;
                     break;
                 }
                 case 'D': { /* snort's option */
                     int list = DetectBufferTypeGetByName("http_raw_header");
                     *sm_list = DetectPcreSetList(*sm_list, list);
+                    *alproto = ALPROTO_HTTP;
                     break;
                 }
                 case 'M': { /* snort's option */
@@ -525,6 +533,7 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx, const char *reg
                     }
                     int list = DetectBufferTypeGetByName("http_method");
                     *sm_list = DetectPcreSetList(*sm_list, list);
+                    *alproto = ALPROTO_HTTP;
                     break;
                 }
                 case 'C': { /* snort's option */
@@ -534,30 +543,35 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx, const char *reg
                     }
                     int list = DetectBufferTypeGetByName("http_cookie");
                     *sm_list = DetectPcreSetList(*sm_list, list);
+                    *alproto = ALPROTO_HTTP;
                     break;
                 }
                 case 'P': {
                     /* snort's option (http request body inspection) */
                     int list = DetectBufferTypeGetByName("http_client_body");
                     *sm_list = DetectPcreSetList(*sm_list, list);
+                    *alproto = ALPROTO_HTTP;
                     break;
                 }
                 case 'Q': {
                     int list = DetectBufferTypeGetByName("file_data");
                     /* suricata extension (http response body inspection) */
                     *sm_list = DetectPcreSetList(*sm_list, list);
+                    *alproto = ALPROTO_HTTP;
                     break;
                 }
                 case 'Y': {
                     /* snort's option */
                     int list = DetectBufferTypeGetByName("http_stat_msg");
                     *sm_list = DetectPcreSetList(*sm_list, list);
+                    *alproto = ALPROTO_HTTP;
                     break;
                 }
                 case 'S': {
                     /* snort's option */
                     int list = DetectBufferTypeGetByName("http_stat_code");
                     *sm_list = DetectPcreSetList(*sm_list, list);
+                    *alproto = ALPROTO_HTTP;
                     break;
                 }
                 default:
@@ -661,7 +675,6 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx, const char *reg
     } else {
         goto error;
     }
-
     return pd;
 
 error:
@@ -817,9 +830,11 @@ static int DetectPcreSetup (DetectEngineCtx *de_ctx, Signature *s, const char *r
     int ret = -1;
     int parsed_sm_list = DETECT_SM_LIST_NOTSET;
     char capture_names[1024] = "";
+    AppProto alproto = ALPROTO_UNKNOWN;
 
     pd = DetectPcreParse(de_ctx, regexstr, &parsed_sm_list,
-            capture_names, sizeof(capture_names), s->init_data->negated);
+            capture_names, sizeof(capture_names), s->init_data->negated,
+            &alproto);
     if (pd == NULL)
         goto error;
     if (DetectPcreParseCapture(regexstr, de_ctx, pd, capture_names) < 0)
@@ -837,9 +852,19 @@ static int DetectPcreSetup (DetectEngineCtx *de_ctx, Signature *s, const char *r
             case DETECT_SM_LIST_NOTSET:
                 sm_list = DETECT_SM_LIST_PMATCH;
                 break;
-            default:
+            default: {
+                if (alproto != ALPROTO_UNKNOWN) {
+                    /* see if the proto doesn't conflict
+                     * with what we already have. */
+                    if (s->alproto != ALPROTO_UNKNOWN &&
+                            alproto != s->alproto) {
+                        goto error;
+                    }
+                    s->alproto = alproto;
+                }
                 sm_list = parsed_sm_list;
                 break;
+            }
         }
     }
     if (sm_list == -1)
@@ -921,8 +946,9 @@ static int DetectPcreParseTest01 (void)
     int list = DETECT_SM_LIST_NOTSET;
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
+    AppProto alproto = ALPROTO_UNKNOWN;
 
-    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false);
+    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false, &alproto);
     FAIL_IF_NOT_NULL(pd);
 
     DetectEngineCtxFree(de_ctx);
@@ -940,9 +966,11 @@ static int DetectPcreParseTest02 (void)
     int list = DETECT_SM_LIST_NOTSET;
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
+    AppProto alproto = ALPROTO_UNKNOWN;
 
-    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false);
+    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false, &alproto);
     FAIL_IF_NOT_NULL(pd);
+    FAIL_IF_NOT(alproto == ALPROTO_HTTP);
 
     DetectEngineCtxFree(de_ctx);
     return result;
@@ -959,8 +987,9 @@ static int DetectPcreParseTest03 (void)
     int list = DETECT_SM_LIST_NOTSET;
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
+    AppProto alproto = ALPROTO_UNKNOWN;
 
-    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false);
+    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false, &alproto);
     FAIL_IF_NOT_NULL(pd);
 
     DetectEngineCtxFree(de_ctx);
@@ -978,9 +1007,11 @@ static int DetectPcreParseTest04 (void)
     int list = DETECT_SM_LIST_NOTSET;
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
+    AppProto alproto = ALPROTO_UNKNOWN;
 
-    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false);
+    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false, &alproto);
     FAIL_IF_NULL(pd);
+    FAIL_IF_NOT(alproto == ALPROTO_UNKNOWN);
 
     DetectPcreFree(pd);
     DetectEngineCtxFree(de_ctx);
@@ -998,9 +1029,11 @@ static int DetectPcreParseTest05 (void)
     int list = DETECT_SM_LIST_NOTSET;
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
+    AppProto alproto = ALPROTO_UNKNOWN;
 
-    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false);
+    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false, &alproto);
     FAIL_IF_NULL(pd);
+    FAIL_IF_NOT(alproto == ALPROTO_UNKNOWN);
 
     DetectPcreFree(pd);
     DetectEngineCtxFree(de_ctx);
@@ -1018,9 +1051,11 @@ static int DetectPcreParseTest06 (void)
     int list = DETECT_SM_LIST_NOTSET;
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
+    AppProto alproto = ALPROTO_UNKNOWN;
 
-    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false);
+    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false, &alproto);
     FAIL_IF_NULL(pd);
+    FAIL_IF_NOT(alproto == ALPROTO_UNKNOWN);
 
     DetectPcreFree(pd);
     DetectEngineCtxFree(de_ctx);
@@ -1038,9 +1073,11 @@ static int DetectPcreParseTest07 (void)
     int list = DETECT_SM_LIST_NOTSET;
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
+    AppProto alproto = ALPROTO_UNKNOWN;
 
-    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false);
+    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false, &alproto);
     FAIL_IF_NULL(pd);
+    FAIL_IF_NOT(alproto == ALPROTO_HTTP);
 
     DetectPcreFree(pd);
     DetectEngineCtxFree(de_ctx);
@@ -1058,9 +1095,11 @@ static int DetectPcreParseTest08 (void)
     int list = DETECT_SM_LIST_NOTSET;
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
+    AppProto alproto = ALPROTO_UNKNOWN;
 
-    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false);
+    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false, &alproto);
     FAIL_IF_NULL(pd);
+    FAIL_IF_NOT(alproto == ALPROTO_UNKNOWN);
 
     DetectPcreFree(pd);
     DetectEngineCtxFree(de_ctx);
@@ -1078,8 +1117,9 @@ static int DetectPcreParseTest09 (void)
     int list = DETECT_SM_LIST_NOTSET;
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
+    AppProto alproto = ALPROTO_UNKNOWN;
 
-    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false);
+    pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false, &alproto);
     FAIL_IF_NULL(pd);
 
     DetectPcreFree(pd);
@@ -3422,30 +3462,30 @@ static int DetectPcreFlowvarCapture03(void)
  */
 static int DetectPcreParseHttpHost(void)
 {
-    DetectPcreData *pd = NULL;
+    AppProto alproto = ALPROTO_UNKNOWN;
     int list = DETECT_SM_LIST_NOTSET;
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
 
     FAIL_IF(de_ctx == NULL);
 
-    pd = DetectPcreParse(de_ctx, "/domain\\.com/W", &list, NULL, 0, false);
+    DetectPcreData *pd = DetectPcreParse(de_ctx, "/domain\\.com/W", &list, NULL, 0, false, &alproto);
     FAIL_IF(pd == NULL);
     DetectPcreFree(pd);
 
     list = DETECT_SM_LIST_NOTSET;
-    pd = DetectPcreParse(de_ctx, "/dOmain\\.com/W", &list, NULL, 0, false);
+    pd = DetectPcreParse(de_ctx, "/dOmain\\.com/W", &list, NULL, 0, false, &alproto);
     FAIL_IF(pd != NULL);
 
     /* Uppercase meta characters are valid. */
     list = DETECT_SM_LIST_NOTSET;
-    pd = DetectPcreParse(de_ctx, "/domain\\D+\\.com/W", &list, NULL, 0, false);
+    pd = DetectPcreParse(de_ctx, "/domain\\D+\\.com/W", &list, NULL, 0, false, &alproto);
     FAIL_IF(pd == NULL);
     DetectPcreFree(pd);
 
     /* This should not parse as the first \ escapes the second \, then
      * we have a D. */
     list = DETECT_SM_LIST_NOTSET;
-    pd = DetectPcreParse(de_ctx, "/\\\\Ddomain\\.com/W", &list, NULL, 0, false);
+    pd = DetectPcreParse(de_ctx, "/\\\\Ddomain\\.com/W", &list, NULL, 0, false, &alproto);
     FAIL_IF(pd != NULL);
 
     DetectEngineCtxFree(de_ctx);

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -189,29 +189,26 @@ static void AlertJsonDnp3(const Flow *f, const uint64_t tx_id, json_t *js)
 
 static void AlertJsonDns(const Flow *f, const uint64_t tx_id, json_t *js)
 {
-#ifndef HAVE_RUST
     DNSState *dns_state = (DNSState *)FlowGetAppState(f);
     if (dns_state) {
-        DNSTransaction *tx = AppLayerParserGetTx(f->proto, ALPROTO_DNS,
-                                                 dns_state, tx_id);
-        if (tx) {
+        void *txptr = AppLayerParserGetTx(f->proto, ALPROTO_DNS,
+                                          dns_state, tx_id);
+        if (txptr) {
             json_t *dnsjs = json_object();
             if (unlikely(dnsjs == NULL)) {
                 return;
             }
-
-            json_t *qjs = JsonDNSLogQuery(tx, tx_id);
+            json_t *qjs = JsonDNSLogQuery(txptr, tx_id);
             if (qjs != NULL) {
                 json_object_set_new(dnsjs, "query", qjs);
             }
-            json_t *ajs = JsonDNSLogAnswer(tx, tx_id);
+            json_t *ajs = JsonDNSLogAnswer(txptr, tx_id);
             if (ajs != NULL) {
                 json_object_set_new(dnsjs, "answer", ajs);
             }
             json_object_set_new(js, "dns", dnsjs);
         }
     }
-#endif
     return;
 }
 

--- a/src/output-json-dns.h
+++ b/src/output-json-dns.h
@@ -29,8 +29,8 @@ void JsonDnsLogRegister(void);
 #ifdef HAVE_LIBJANSSON
 #include "app-layer-dns-common.h"
 
-json_t *JsonDNSLogQuery(DNSTransaction *tx, uint64_t tx_id) __attribute__((nonnull));
-json_t *JsonDNSLogAnswer(DNSTransaction *tx, uint64_t tx_id) __attribute__((nonnull));
+json_t *JsonDNSLogQuery(void *txptr, uint64_t tx_id) __attribute__((nonnull));
+json_t *JsonDNSLogAnswer(void *txptr, uint64_t tx_id) __attribute__((nonnull));
 #endif
 
 #endif /* __OUTPUT_JSON_DNS_H__ */

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -165,7 +165,6 @@ typedef struct NetmapDevice_
     char ifname[IFNAMSIZ];
     void *mem;
     size_t memsize;
-    struct netmap_if *nif;
     int rings_cnt;
     int rx_rings_cnt;
     int tx_rings_cnt;
@@ -268,6 +267,7 @@ static int NetmapOpen(char *ifname, int promisc, NetmapDevice **pdevice, int ver
 {
     NetmapDevice *pdev = NULL;
     struct nmreq nm_req;
+    struct netmap_if *nifp = NULL;
 
     *pdevice = NULL;
 
@@ -385,14 +385,14 @@ static int NetmapOpen(char *ifname, int promisc, NetmapDevice **pdevice, int ver
                            strerror(errno));
                 break;
             }
-            pdev->nif = NETMAP_IF(pdev->mem, nm_req.nr_offset);
         }
+        nifp = NETMAP_IF(pdev->mem, nm_req.nr_offset);
 
         if ((i < pdev->rx_rings_cnt) || (i == pdev->rings_cnt)) {
-            pring->rx = NETMAP_RXRING(pdev->nif, i);
+            pring->rx = NETMAP_RXRING(nifp, i);
         }
         if ((i < pdev->tx_rings_cnt) || (i == pdev->rings_cnt)) {
-            pring->tx = NETMAP_TXRING(pdev->nif, i);
+            pring->tx = NETMAP_TXRING(nifp, i);
         }
         SCSpinInit(&pring->tx_lock, 0);
         success_cnt++;

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -775,11 +775,13 @@ static int NetmapRingRead(NetmapThreadVars *ntv, int ring_id)
         } else if (ntv->checksum_mode == CHECKSUM_VALIDATION_AUTO) {
             if (ntv->livedev->ignore_checksum) {
                 p->flags |= PKT_IGNORE_CHECKSUM;
-            } else if (ChecksumAutoModeCheck(ntv->pkts,
-                        SC_ATOMIC_GET(ntv->livedev->pkts),
-                        SC_ATOMIC_GET(ntv->livedev->invalid_checksums))) {
-                ntv->livedev->ignore_checksum = 1;
-                p->flags |= PKT_IGNORE_CHECKSUM;
+            } else {
+                uint64_t pkts = SC_ATOMIC_GET(ntv->livedev->pkts);
+                if (ChecksumAutoModeCheck(pkts, pkts,
+                            SC_ATOMIC_GET(ntv->livedev->invalid_checksums))) {
+                    ntv->livedev->ignore_checksum = 1;
+                    p->flags |= PKT_IGNORE_CHECKSUM;
+                }
             }
         }
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2827,13 +2827,13 @@ static int PostConfLoadedSetup(SCInstance *suri)
 
     DecodeGlobalConfig();
 
-    PreRunInit(suri->run_mode);
-
     LiveDeviceFinalize();
 
     if (PostDeviceFinalizedSetup(&suricata) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }
+
+    PreRunInit(suri->run_mode);
 
     SCReturnInt(TM_ECODE_OK);
 }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1168,13 +1168,7 @@ static int ParseCommandLinePcapLive(SCInstance *suri, const char *in_arg)
             LiveRegisterDeviceName(suri->pcap_dev);
         }
     } else if (suri->run_mode == RUNMODE_PCAP_DEV) {
-#ifdef OS_WIN32
-        SCLogError(SC_ERR_PCAP_MULTI_DEV_NO_SUPPORT, "pcap multi dev "
-                "support is not (yet) supported on Windows.");
-        return TM_ECODE_FAILED;
-#else
         LiveRegisterDeviceName(suri->pcap_dev);
-#endif
     } else {
         SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "
                 "has been specified");

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2633,14 +2633,45 @@ static int PostDeviceFinalizedSetup(SCInstance *suri)
     SCReturnInt(TM_ECODE_OK);
 }
 
+static void PostConfLoadedSetupHostMode(void)
+{
+    const char *hostmode = NULL;
+
+    if (ConfGetValue("host-mode", &hostmode) == 1) {
+        if (!strcmp(hostmode, "router")) {
+            host_mode = SURI_HOST_IS_ROUTER;
+        } else if (!strcmp(hostmode, "sniffer-only")) {
+            host_mode = SURI_HOST_IS_SNIFFER_ONLY;
+        } else {
+            if (strcmp(hostmode, "auto") != 0) {
+                WarnInvalidConfEntry("host-mode", "%s", "auto");
+            }
+            if (EngineModeIsIPS()) {
+                host_mode = SURI_HOST_IS_ROUTER;
+            } else {
+                host_mode = SURI_HOST_IS_SNIFFER_ONLY;
+            }
+        }
+    } else {
+        if (EngineModeIsIPS()) {
+            host_mode = SURI_HOST_IS_ROUTER;
+            SCLogInfo("No 'host-mode': suricata is in IPS mode, using "
+                      "default setting 'router'");
+        } else {
+            host_mode = SURI_HOST_IS_SNIFFER_ONLY;
+            SCLogInfo("No 'host-mode': suricata is in IDS mode, using "
+                      "default setting 'sniffer-only'");
+        }
+    }
+
+}
+
 /**
  * This function is meant to contain code that needs
  * to be run once the configuration has been loaded.
  */
 static int PostConfLoadedSetup(SCInstance *suri)
 {
-    const char *hostmode = NULL;
-
     /* do this as early as possible #1577 #1955 */
 #ifdef HAVE_LUAJIT
     if (LuajitSetupStatesPool() != 0) {
@@ -2714,33 +2745,6 @@ static int PostConfLoadedSetup(SCInstance *suri)
 
     if (ConfigGetCaptureValue(suri) != TM_ECODE_OK) {
         SCReturnInt(TM_ECODE_FAILED);
-    }
-
-    if (ConfGetValue("host-mode", &hostmode) == 1) {
-        if (!strcmp(hostmode, "router")) {
-            host_mode = SURI_HOST_IS_ROUTER;
-        } else if (!strcmp(hostmode, "sniffer-only")) {
-            host_mode = SURI_HOST_IS_SNIFFER_ONLY;
-        } else {
-            if (strcmp(hostmode, "auto") != 0) {
-                WarnInvalidConfEntry("host-mode", "%s", "auto");
-            }
-            if (EngineModeIsIPS()) {
-                host_mode = SURI_HOST_IS_ROUTER;
-            } else {
-                host_mode = SURI_HOST_IS_SNIFFER_ONLY;
-            }
-        }
-    } else {
-        if (EngineModeIsIPS()) {
-            host_mode = SURI_HOST_IS_ROUTER;
-            SCLogInfo("No 'host-mode': suricata is in IPS mode, using "
-                      "default setting 'router'");
-        } else {
-            host_mode = SURI_HOST_IS_SNIFFER_ONLY;
-            SCLogInfo("No 'host-mode': suricata is in IDS mode, using "
-                      "default setting 'sniffer-only'");
-        }
     }
 
 #ifdef NFQ
@@ -2829,9 +2833,13 @@ static int PostConfLoadedSetup(SCInstance *suri)
 
     LiveDeviceFinalize();
 
+    /* set engine mode if L2 IPS */
     if (PostDeviceFinalizedSetup(&suricata) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }
+
+    /* hostmode depends on engine mode being set */
+    PostConfLoadedSetupHostMode();
 
     PreRunInit(suri->run_mode);
 

--- a/src/util-byte.c
+++ b/src/util-byte.c
@@ -149,7 +149,7 @@ int ByteExtractString(uint64_t *res, int base, uint16_t len, const char *str)
     char strbuf[24];
 
     if (len > 23) {
-        SCLogError(SC_ERR_ARG_LEN_LONG, "len too large (23 max)");
+        SCLogDebug("len too large (23 max)");
         return -1;
     }
 
@@ -164,15 +164,15 @@ int ByteExtractString(uint64_t *res, int base, uint16_t len, const char *str)
     *res = strtoull(ptr, &endptr, base);
 
     if (errno == ERANGE) {
-        SCLogError(SC_ERR_NUMERIC_VALUE_ERANGE, "Numeric value out of range");
+        SCLogDebug("numeric value out of range");
         return -1;
         /* If there is no numeric value in the given string then strtoull(), makes
         endptr equals to ptr and return 0 as result */
     } else if (endptr == ptr && *res == 0) {
-        SCLogDebug("No numeric value");
+        SCLogDebug("no numeric value");
         return -1;
     } else if (endptr == ptr) {
-        SCLogError(SC_ERR_INVALID_NUMERIC_VALUE, "Invalid numeric value");
+        SCLogDebug("invalid numeric value");
         return -1;
     }
     /* This will interfere with some rules that do not know the length

--- a/src/util-file-swf-decompression.c
+++ b/src/util-file-swf-decompression.c
@@ -50,15 +50,20 @@ uint32_t FileGetSwfDecompressedLen(const uint8_t *buffer,
         return 0;
     }
 
-    int a = buffer[4];
-    int b = buffer[5];
-    int c = buffer[6];
-    int d = buffer[7];
+    uint32_t a = buffer[4];
+    uint32_t b = buffer[5];
+    uint32_t c = buffer[6];
+    uint32_t d = buffer[7];
 
-    uint32_t value = (((a & 0xff) << 24) | ((b & 0xff) << 16) | ((c & 0xff) << 8) | (d & 0xff));
+    uint32_t value = (((a & 0xff) << 24UL) |
+                      ((b & 0xff) << 16UL) |
+                      ((c & 0xff) << 8UL) |
+                       (d & 0xff));
 
-    uint32_t len = (((value >> 24) & 0x000000FF) | ((value >> 8) & 0x0000FF00) |
-                   ((value << 8) & 0x00FF0000) | ((value << 24) & 0xFF000000));
+    uint32_t len = (((value >> 24) & 0x000000FFUL) |
+                    ((value >> 8)  & 0x0000FF00UL) |
+                    ((value << 8)  & 0x00FF0000UL) |
+                    ((value << 24) & 0xFF000000UL));
 
     return MIN(MAX_SWF_DECOMPRESSED_LEN, len);
 }

--- a/src/util-ja3.c
+++ b/src/util-ja3.c
@@ -77,10 +77,6 @@ static int Ja3BufferResizeIfFull(JA3Buffer *buffer, uint32_t len)
 {
     DEBUG_VALIDATE_BUG_ON(buffer == NULL);
 
-    if (len == 0) {
-        return 0;
-    }
-
     while (buffer->used + len + 2 > buffer->size)
     {
         buffer->size *= 2;

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -747,8 +747,8 @@ void StreamingBufferSBBGetData(const StreamingBuffer *sb,
     if (sbb->offset >= sb->stream_offset) {
         uint64_t offset = sbb->offset - sb->stream_offset;
         *data = sb->buf + offset;
-        if (offset + sbb->len > sb->buf_size)
-            *data_len = sb->buf_size - offset;
+        if (offset + sbb->len > sb->buf_offset)
+            *data_len = sb->buf_offset - offset;
         else
             *data_len = sbb->len;
         return;

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -68,7 +68,7 @@ int SBBCompare(struct StreamingBufferBlock *a, struct StreamingBufferBlock *b)
 static inline int InclusiveCompare(StreamingBufferBlock *lookup, StreamingBufferBlock *intree) {
     const uint64_t lre = lookup->offset + lookup->len;
     const uint64_t tre = intree->offset + intree->len;
-    if (lre < intree->offset)   // entirely before
+    if (lre <= intree->offset)   // entirely before
         return -1;
     else if (lre >= intree->offset && lre <= tre)    // (some) overlap
         return 0;


### PR DESCRIPTION
With the introduction of netmap "partial opening" feature
netmap requires that we get a new NETMAP_IF pointer after
every `NIOCREGIF` registration. Because this allocates an
independent instance of `struct netmap_if`. If one
separately opens hw rings and sw rings he/she'll get two
`struct netmap_if`, one with the valid hw rings, and the other
with valid sw rings.

Because of that we get a new netmap_if pointer after each
NIOCREGIF.

Also removing netmap_if struct from NetmapDevice since
it's no more required.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/2855) ticket:

Describe changes:
-
-
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

