### PR TITLE
Refresh netmap_if address after each NIOCREGIF

### DIFF
--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -165,7 +165,6 @@ typedef struct NetmapDevice_
     char ifname[IFNAMSIZ];
     void *mem;
     size_t memsize;
-    struct netmap_if *nif;
     int rings_cnt;
     int rx_rings_cnt;
     int tx_rings_cnt;
@@ -268,6 +267,7 @@ static int NetmapOpen(char *ifname, int promisc, NetmapDevice **pdevice, int ver
 {
     NetmapDevice *pdev = NULL;
     struct nmreq nm_req;
+    struct netmap_if *nifp = NULL;
 
     *pdevice = NULL;
 
@@ -385,14 +385,14 @@ static int NetmapOpen(char *ifname, int promisc, NetmapDevice **pdevice, int ver
                            strerror(errno));
                 break;
             }
-            pdev->nif = NETMAP_IF(pdev->mem, nm_req.nr_offset);
         }
+        nifp = NETMAP_IF(pdev->mem, nm_req.nr_offset);
 
         if ((i < pdev->rx_rings_cnt) || (i == pdev->rings_cnt)) {
-            pring->rx = NETMAP_RXRING(pdev->nif, i);
+            pring->rx = NETMAP_RXRING(nifp, i);
         }
         if ((i < pdev->tx_rings_cnt) || (i == pdev->rings_cnt)) {
-            pring->tx = NETMAP_TXRING(pdev->nif, i);
+            pring->tx = NETMAP_TXRING(nifp, i);
         }
         SCSpinInit(&pring->tx_lock, 0);
         success_cnt++;


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/2855) ticket:

Describe changes:
- Refreshing the address of struct netmap_if for every NIOCREGIF
- Removed netmap_if from NetmapDevice since it's no longer required

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

