### PR TITLE
  Fix memory leak with TOS handling

### DIFF
--- a/src/detect-tos.c
+++ b/src/detect-tos.c
@@ -134,14 +134,20 @@ static DetectTosData *DetectTosParse(const char *arg, bool negate)
     if (*str_ptr == 'x' || *str_ptr == 'X') {
         int r = ByteExtractStringSigned(&tos, 16, 0, str_ptr + 1);
         if (r < 0) {
+            pcre_free_substring(str_ptr);
             goto error;
         }
     } else {
         int r = ByteExtractStringSigned(&tos, 10, 0, str_ptr);
         if (r < 0) {
+            pcre_free_substring(str_ptr);
             goto error;
         }
     }
+
+    /* Temporary buffer no longer needed */
+    pcre_free_substring(str_ptr);
+
     if (!(tos >= DETECT_IPTOS_MIN && tos <= DETECT_IPTOS_MAX)) {
         SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid tos argument - "
                    "%s.  The tos option value must be in the range "


### PR DESCRIPTION
  Memory leak detected by LEAK_SANTIZER fixed by returning memory
  allocated from pcre_get_substring().

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/2833) ticket:

Describe changes:
- Ensure string allocated on successful `pcre_get_substring` is freed on error and normal return paths.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

