### PR TITLE
2497.dev

### DIFF
--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -486,4 +486,6 @@ void AlertDebugLogRegister(void)
     OutputRegisterPacketModule(LOGGER_ALERT_DEBUG, MODULE_NAME, "alert-debug",
         AlertDebugLogInitCtx, AlertDebugLogLogger, AlertDebugLogCondition,
         AlertDebugLogThreadInit, AlertDebugLogThreadDeinit, NULL);
+
+    SCSetModule("alert-debuglog");
 }

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -81,6 +81,7 @@ void AlertFastLogRegister(void)
         AlertFastLogInitCtx, AlertFastLogger, AlertFastLogCondition,
         AlertFastLogThreadInit, AlertFastLogThreadDeinit, NULL);
     AlertFastLogRegisterTests();
+    SCSetModule("alert-fastlog");
 }
 
 typedef struct AlertFastLogThread_ {

--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -1036,7 +1036,6 @@ static TmEcode AlertPreludeThreadInit(ThreadVars *t, const void *initdata, void 
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    printf(">>>>>>>>>> [%s] %s <<<<<<<<<<<\n", __func__, t->name);
     SCSetSubsystem("alert-prelude");
     *data = (void *)aun;
     SCReturnInt(TM_ECODE_OK);

--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -1036,6 +1036,8 @@ static TmEcode AlertPreludeThreadInit(ThreadVars *t, const void *initdata, void 
         SCReturnInt(TM_ECODE_FAILED);
     }
 
+    printf(">>>>>>>>>> [%s] %s <<<<<<<<<<<\n", __func__, t->name);
+    SCSetSubsystem("alert-prelude");
     *data = (void *)aun;
     SCReturnInt(TM_ECODE_OK);
 }

--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -1300,5 +1300,7 @@ void AlertPreludeRegister (void)
     OutputRegisterPacketModule(LOGGER_PRELUDE, "AlertPrelude", "alert-prelude",
         AlertPreludeInitCtx, AlertPreludeLogger, AlertPreludeCondition,
         AlertPreludeThreadInit, AlertPreludeThreadDeinit, NULL);
+
+    SCSetModule("alert-prelude");
 }
 #endif /* PRELUDE */

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -398,5 +398,7 @@ void AlertSyslogRegister (void)
     OutputRegisterPacketModule(LOGGER_ALERT_SYSLOG, MODULE_NAME, "syslog",
         AlertSyslogInitCtx, AlertSyslogLogger, AlertSyslogCondition,
         AlertSyslogThreadInit, AlertSyslogThreadDeinit, NULL);
+
+    SCSetModule("alert-syslog");
 #endif /* !OS_WIN32 */
 }

--- a/src/alert-unified2-alert.c
+++ b/src/alert-unified2-alert.c
@@ -239,6 +239,9 @@ void Unified2AlertRegister(void)
     OutputRegisterPacketModule(LOGGER_UNIFIED2, MODULE_NAME, "unified2-alert",
         Unified2AlertInitCtx, Unified2Logger, Unified2Condition,
         Unified2AlertThreadInit, Unified2AlertThreadDeinit, NULL);
+
+    SCSetModule("alert-unifed2");
+
     Unified2RegisterTests();
 }
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -124,6 +124,8 @@ void ConfInit(void)
         exit(EXIT_FAILURE);
     }
     SCLogDebug("configuration module initialized");
+
+    SCSetModule("configuration");
 }
 
 /**

--- a/src/counters.c
+++ b/src/counters.c
@@ -363,6 +363,8 @@ static void *StatsMgmtThread(void *arg)
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
 
+    SCSetSubsystem(tv_local->name);
+
     if (tv_local->thread_setup_flags != 0)
         TmThreadSetupOptions(tv_local);
 
@@ -451,6 +453,8 @@ static void *StatsWakeupThread(void *arg)
     if (SCSetThreadName(tv_local->name) < 0) {
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
+
+    SCSetSubsystem(tv_local->name);
 
     if (tv_local->thread_setup_flags != 0)
         TmThreadSetupOptions(tv_local);

--- a/src/counters.c
+++ b/src/counters.c
@@ -863,6 +863,7 @@ void StatsInit(void)
     memset(stats_ctx, 0, sizeof(StatsGlobalContext));
 
     StatsPublicThreadContextInit(&stats_ctx->global_counter_ctx);
+    SCSetModule("counters");
 }
 
 void StatsSetupPostConfigPreOutput(void)
@@ -1121,6 +1122,8 @@ static int StatsThreadRegister(const char *thread_name, StatsPublicThreadContext
     temp->next = stats_ctx->sts;
     stats_ctx->sts = temp;
     stats_ctx->sts_cnt++;
+
+    SCSetSubsystem(thread_name);
     SCLogDebug("stats_ctx->sts %p", stats_ctx->sts);
 
     SCMutexUnlock(&stats_ctx->sts_lock);

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -104,6 +104,8 @@ void DetectByteExtractRegister(void)
     sigmatch_table[DETECT_BYTE_EXTRACT].Free = DetectByteExtractFree;
     sigmatch_table[DETECT_BYTE_EXTRACT].RegisterTests = DetectByteExtractRegisterTests;
 
+	SCSetModule("detect-byte_extract");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -75,6 +75,8 @@ void DetectBytejumpRegister (void)
     sigmatch_table[DETECT_BYTEJUMP].Free  = DetectBytejumpFree;
     sigmatch_table[DETECT_BYTEJUMP].RegisterTests = DetectBytejumpRegisterTests;
 
+	SCSetModule("detect-byte_jump");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -76,6 +76,8 @@ void DetectBytetestRegister (void)
     sigmatch_table[DETECT_BYTETEST].Free  = DetectBytetestFree;
     sigmatch_table[DETECT_BYTETEST].RegisterTests = DetectBytetestRegisterTests;
 
+	SCSetModule("detect-byte_test");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-classtype.c
+++ b/src/detect-classtype.c
@@ -58,6 +58,8 @@ void DetectClasstypeRegister(void)
     sigmatch_table[DETECT_CLASSTYPE].Free  = NULL;
     sigmatch_table[DETECT_CLASSTYPE].RegisterTests = DetectClasstypeRegisterTests;
 
+    SCSetModule("detect-classtype");
+
     DetectSetupParseRegexes(PARSE_REGEX, &regex, &regex_study);
 }
 

--- a/src/detect-dce-iface.c
+++ b/src/detect-dce-iface.c
@@ -95,6 +95,8 @@ void DetectDceIfaceRegister(void)
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 
+    SCSetModule("detect-dce_iface");
+
     g_dce_generic_list_id = DetectBufferTypeRegister("dce_generic");
 
     DetectAppLayerInspectEngineRegister("dce_generic",

--- a/src/detect-dce-opnum.c
+++ b/src/detect-dce-opnum.c
@@ -90,6 +90,8 @@ void DetectDceOpnumRegister(void)
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 
+    SCSetModule("detect-dce_opnum");
+
     g_dce_generic_list_id = DetectBufferTypeRegister("dce_generic");
 }
 

--- a/src/detect-depth.c
+++ b/src/detect-depth.c
@@ -59,6 +59,8 @@ void DetectDepthRegister (void)
     sigmatch_table[DETECT_STARTS_WITH].url = DOC_URL DOC_VERSION "/rules/payload-keywords.html#startswith";
     sigmatch_table[DETECT_STARTS_WITH].Setup = DetectStartsWithSetup;
     sigmatch_table[DETECT_STARTS_WITH].flags |= SIGMATCH_NOOPT;
+
+    SCSetModule("detect-depth");
 }
 
 static int DetectDepthSetup (DetectEngineCtx *de_ctx, Signature *s, const char *depthstr)

--- a/src/detect-detection-filter.c
+++ b/src/detect-detection-filter.c
@@ -73,6 +73,8 @@ void DetectDetectionFilterRegister (void)
     sigmatch_table[DETECT_DETECTION_FILTER].flags |= SIGMATCH_IPONLY_COMPAT;
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
+
+    SCSetModule("detect-detection_filter");
 }
 
 static int DetectDetectionFilterMatch (ThreadVars *thv, DetectEngineThreadCtx *det_ctx,

--- a/src/detect-distance.c
+++ b/src/detect-distance.c
@@ -59,6 +59,8 @@ void DetectDistanceRegister(void)
     sigmatch_table[DETECT_DISTANCE].Setup = DetectDistanceSetup;
     sigmatch_table[DETECT_DISTANCE].Free  = NULL;
     sigmatch_table[DETECT_DISTANCE].RegisterTests = DetectDistanceRegisterTests;
+
+    SCSetModule("detect-distance");
 }
 
 static int DetectDistanceSetup (DetectEngineCtx *de_ctx, Signature *s,

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -76,6 +76,8 @@ void DetectDsizeRegister (void)
     sigmatch_table[DETECT_DSIZE].SetupPrefilter = PrefilterSetupDsize;
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
+
+    SCSetModule("detect-dsize");
 }
 
 static inline int

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1906,6 +1906,7 @@ int SigGroupBuild(DetectEngineCtx *de_ctx)
         s = s->next;
     }
 
+    SCSetModule("detect-engine");
     if (DetectSetFastPatternAndItsId(de_ctx) < 0)
         return -1;
 

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -78,6 +78,8 @@ void DetectEngineEventRegister (void)
     sigmatch_table[DETECT_STREAM_EVENT].Setup = DetectStreamEventSetup;
     sigmatch_table[DETECT_STREAM_EVENT].Free  = DetectEngineEventFree;
 
+    SCSetModule("detect-engine-event");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -474,6 +474,7 @@ void DetectLoadersInit(void)
     }
     num_loaders = (int32_t)setting;
 
+    SCSetModule("detect-loader");
     SCLogInfo("using %d detect loader threads", num_loaders);
 
     BUG_ON(loaders != NULL);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -175,6 +175,8 @@ void DetectAppLayerInspectEngineRegister(const char *name,
 
         t->next = new_engine;
     }
+
+    SCSetModule("detect-engine");
 }
 
 /** \brief register inspect engine at start up time

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1567,6 +1567,8 @@ static DetectEngineCtx *DetectEngineCtxInitReal(enum DetectEngineType type, cons
     de_ctx->sigerror = NULL;
     de_ctx->type = type;
 
+    SCSetModule("detect-engine");
+
     if (type == DETECT_ENGINE_TYPE_DD_STUB || type == DETECT_ENGINE_TYPE_MT_STUB) {
         de_ctx->version = DetectEngineGetVersion();
         SCLogDebug("stub %u with version %u", type, de_ctx->version);

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -170,6 +170,8 @@ void DetectFastPatternRegister(void)
 
     sigmatch_table[DETECT_FAST_PATTERN].flags |= SIGMATCH_NOOPT;
 
+    SCSetModule("detect-fast_pattern");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -89,6 +89,8 @@ void DetectFiledataRegister(void)
 #endif
     sigmatch_table[DETECT_FILE_DATA].flags = SIGMATCH_NOOPT;
 
+    SCSetModule("detect-file_data");
+
     DetectAppLayerMpmRegister2("file_data", SIG_FLAG_TOSERVER, 2,
             PrefilterMpmFiledataRegister, NULL,
             ALPROTO_SMTP, 0);

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -72,6 +72,8 @@ void DetectFilemagicRegister(void)
     sigmatch_table[DETECT_FILEMAGIC].url = "https://suricata.readthedocs.io/en/latest/rules/file-keywords.html#filemagic";
     sigmatch_table[DETECT_FILEMAGIC].Setup = DetectFilemagicSetupNoSupport;
     sigmatch_table[DETECT_FILEMAGIC].flags = SIGMATCH_QUOTES_MANDATORY|SIGMATCH_HANDLE_NEGATION;
+
+    SCSetModule("detect-filemagic");
 }
 
 #else /* HAVE_MAGIC */
@@ -98,6 +100,8 @@ void DetectFilemagicRegister(void)
     sigmatch_table[DETECT_FILEMAGIC].flags = SIGMATCH_QUOTES_MANDATORY|SIGMATCH_HANDLE_NEGATION;
 
     g_file_match_list_id = DetectBufferTypeRegister("files");
+
+    SCSetModule("detect-filemagic");
 
 	SCLogDebug("registering filemagic rule option");
     return;

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -92,6 +92,8 @@ void DetectFilenameRegister(void)
     sigmatch_table[DETECT_FILE_NAME].Setup = DetectFilenameSetupSticky;
     sigmatch_table[DETECT_FILE_NAME].flags = SIGMATCH_NOOPT|SIGMATCH_INFO_STICKY_BUFFER;
 
+    SCSetModule("detect-filename");
+
     DetectAppLayerInspectEngineRegister("files",
             ALPROTO_HTTP, SIG_FLAG_TOSERVER, HTP_REQUEST_BODY,
             DetectFileInspectGeneric);

--- a/src/detect-filesize.c
+++ b/src/detect-filesize.c
@@ -71,6 +71,8 @@ void DetectFilesizeRegister(void)
     sigmatch_table[DETECT_FILESIZE].Free = DetectFilesizeFree;
     sigmatch_table[DETECT_FILESIZE].RegisterTests = DetectFilesizeRegisterTests;
 
+    SCSetModule("detect-filesize");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 
     g_file_match_list_id = DetectBufferTypeRegister("files");

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -81,6 +81,8 @@ void DetectFilestoreRegister(void)
     sigmatch_table[DETECT_FILESTORE].RegisterTests = DetectFilestoreRegisterTests;
     sigmatch_table[DETECT_FILESTORE].flags = SIGMATCH_OPTIONAL_OPT;
 
+    SCSetModule("detect-filestore");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 
     g_file_match_list_id = DetectBufferTypeRegister("files");

--- a/src/detect-flags.c
+++ b/src/detect-flags.c
@@ -81,6 +81,8 @@ void DetectFlagsRegister (void)
     sigmatch_table[DETECT_FLAGS].SupportsPrefilter = PrefilterTcpFlagsIsPrefilterable;
     sigmatch_table[DETECT_FLAGS].SetupPrefilter = PrefilterSetupTcpFlags;
 
+    SCSetModule("detect-flags");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -74,6 +74,8 @@ void DetectFlowRegister (void)
     sigmatch_table[DETECT_FLOW].SupportsPrefilter = PrefilterFlowIsPrefilterable;
     sigmatch_table[DETECT_FLOW].SetupPrefilter = PrefilterSetupFlow;
 
+    SCSetModule("detect-flow");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -68,6 +68,8 @@ void DetectFlowbitsRegister (void)
     sigmatch_table[DETECT_FLOWBITS].flags |= SIGMATCH_IPONLY_COMPAT;
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
+
+    SCSetModule("detect-flowbits");
 }
 
 

--- a/src/detect-flowint.c
+++ b/src/detect-flowint.c
@@ -69,6 +69,8 @@ void DetectFlowintRegister(void)
     sigmatch_table[DETECT_FLOWINT].Free = DetectFlowintFree;
     sigmatch_table[DETECT_FLOWINT].RegisterTests = DetectFlowintRegisterTests;
 
+    SCSetModule("detect-flowint");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-flowvar.c
+++ b/src/detect-flowvar.c
@@ -67,6 +67,8 @@ void DetectFlowvarRegister (void)
     sigmatch_table[DETECT_FLOWVAR_POSTMATCH].Free  = DetectFlowvarDataFree;
     sigmatch_table[DETECT_FLOWVAR_POSTMATCH].RegisterTests  = NULL;
 
+    SCSetModule("detect-flowvar");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-fragbits.c
+++ b/src/detect-fragbits.c
@@ -93,6 +93,8 @@ void DetectFragBitsRegister (void)
     sigmatch_table[DETECT_FRAGBITS].SetupPrefilter = PrefilterSetupFragBits;
     sigmatch_table[DETECT_FRAGBITS].SupportsPrefilter = PrefilterFragBitsIsPrefilterable;
 
+    SCSetModule("detect-fragbits");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-fragoffset.c
+++ b/src/detect-fragoffset.c
@@ -69,6 +69,8 @@ void DetectFragOffsetRegister (void)
     sigmatch_table[DETECT_FRAGOFFSET].SupportsPrefilter = PrefilterFragOffsetIsPrefilterable;
     sigmatch_table[DETECT_FRAGOFFSET].SetupPrefilter = PrefilterSetupFragOffset;
 
+    SCSetModule("detect-fragoffset");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-ftpbounce.c
+++ b/src/detect-ftpbounce.c
@@ -74,6 +74,8 @@ void DetectFtpbounceRegister(void)
     sigmatch_table[DETECT_FTPBOUNCE].url = DOC_URL DOC_VERSION "/rules/ftp-keywords.html#ftpbounce";
     sigmatch_table[DETECT_FTPBOUNCE].flags = SIGMATCH_NOOPT;
 
+    SCSetModule("detect-ftpbounce");
+
     g_ftp_request_list_id = DetectBufferTypeRegister("ftp_request");
 
     DetectAppLayerInspectEngineRegister("ftp_request",

--- a/src/detect-gid.c
+++ b/src/detect-gid.c
@@ -51,6 +51,8 @@ void DetectGidRegister (void)
     sigmatch_table[DETECT_GID].Setup = DetectGidSetup;
     sigmatch_table[DETECT_GID].Free  = NULL;
     sigmatch_table[DETECT_GID].RegisterTests = GidRegisterTests;
+
+    SCSetModule("detect-gid");
 }
 
 /**

--- a/src/detect-hostbits.c
+++ b/src/detect-hostbits.c
@@ -86,6 +86,8 @@ void DetectHostbitsRegister (void)
     /* this is compatible to ip-only signatures */
     sigmatch_table[DETECT_HOSTBITS].flags |= SIGMATCH_IPONLY_COMPAT;
 
+    SCSetModule("detect-hostbits");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -98,6 +98,8 @@ void DetectHttpClientBodyRegister(void)
     sigmatch_table[DETECT_HTTP_REQUEST_BODY].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_HTTP_REQUEST_BODY].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
+    SCSetModule("detect-http_client_body");
+
     DetectAppLayerInspectEngineRegister2("http_client_body", ALPROTO_HTTP,
             SIG_FLAG_TOSERVER, HTP_REQUEST_BODY,
             DetectEngineInspectBufferGeneric,

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -102,6 +102,8 @@ void DetectHttpCookieRegister(void)
     sigmatch_table[DETECT_HTTP_COOKIE].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_HTTP_COOKIE].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
+    SCSetModule("detect-http.cookie");
+
     DetectAppLayerInspectEngineRegister2("http_cookie", ALPROTO_HTTP,
             SIG_FLAG_TOSERVER, HTP_REQUEST_HEADERS,
             DetectEngineInspectBufferGeneric, GetRequestData);

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -379,6 +379,8 @@ void DetectHttpHeaderNamesRegister(void)
 
     sigmatch_table[DETECT_AL_HTTP_HEADER_NAMES].flags |= SIGMATCH_NOOPT ;
 
+    SCSetModule("detect-" KEYWORD_NAME);
+
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2,
             PrefilterTxHttpRequestHeaderNamesRegister);
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2,

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -427,6 +427,8 @@ void DetectHttpHeaderRegister(void)
     sigmatch_table[DETECT_HTTP_HEADER].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_HTTP_HEADER].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
+    SCSetModule("detect-http.header");
+
     DetectAppLayerInspectEngineRegister2("http_header", ALPROTO_HTTP,
             SIG_FLAG_TOSERVER, HTP_REQUEST_HEADERS,
             DetectEngineInspectBufferHttpHeader, NULL);

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -331,6 +331,8 @@ static void DetectHttpHeadersRegisterStub(void)
     sigmatch_table[KEYWORD_ID].url = DOC_URL DOC_VERSION "/rules/" KEYWORD_DOC;
     sigmatch_table[KEYWORD_ID].Setup = DetectHttpHeadersSetup;
     sigmatch_table[KEYWORD_ID].flags |= SIGMATCH_NOOPT;
+
+	SCSetModule("detect" KEYWORD_NAME);
 #ifdef KEYWORD_TOSERVER
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2,
             PrefilterTxHttpRequestHeaderRegister);

--- a/src/detect-http-hh.c
+++ b/src/detect-http-hh.c
@@ -97,6 +97,8 @@ void DetectHttpHHRegister(void)
     sigmatch_table[DETECT_HTTP_HOST].Setup = DetectHttpHostSetup;
     sigmatch_table[DETECT_HTTP_HOST].flags |= SIGMATCH_NOOPT;
 
+    SCSetModule("detect-http_host");
+
     DetectAppLayerInspectEngineRegister2("http_host", ALPROTO_HTTP,
             SIG_FLAG_TOSERVER, HTP_REQUEST_HEADERS,
             DetectEngineInspectBufferGeneric, GetData);

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -94,6 +94,8 @@ void DetectHttpMethodRegister(void)
     sigmatch_table[DETECT_HTTP_METHOD].Setup = DetectHttpMethodSetupSticky;
     sigmatch_table[DETECT_HTTP_METHOD].flags |= SIGMATCH_NOOPT;
 
+    SCSetModule("detect-http_method");
+
     DetectAppLayerInspectEngineRegister2("http_method", ALPROTO_HTTP,
             SIG_FLAG_TOSERVER, HTP_REQUEST_LINE,
             DetectEngineInspectBufferGeneric, GetData);

--- a/src/detect-http-protocol.c
+++ b/src/detect-http-protocol.c
@@ -214,6 +214,8 @@ void DetectHttpProtocolRegister(void)
 
     sigmatch_table[DETECT_AL_HTTP_PROTOCOL].flags |= SIGMATCH_NOOPT ;
 
+    SCSetModule("detect-" KEYWORD_NAME);
+
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2,
             PrefilterTxHttpRequestProtocolRegister);
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2,

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -92,6 +92,8 @@ void DetectHttpRawHeaderRegister(void)
     sigmatch_table[DETECT_HTTP_RAW_HEADER].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_HTTP_RAW_HEADER].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
+    SCSetModule("detect-http.header.raw");
+
     DetectAppLayerInspectEngineRegister2("http_raw_header", ALPROTO_HTTP,
             SIG_FLAG_TOSERVER, HTP_REQUEST_HEADERS+1,
             DetectEngineInspectBufferGeneric, GetData);

--- a/src/detect-http-request-line.c
+++ b/src/detect-http-request-line.c
@@ -80,6 +80,8 @@ void DetectHttpRequestLineRegister(void)
     sigmatch_table[DETECT_AL_HTTP_REQUEST_LINE].Setup = DetectHttpRequestLineSetup;
     sigmatch_table[DETECT_AL_HTTP_REQUEST_LINE].RegisterTests = DetectHttpRequestLineRegisterTests;
 
+    SCSetModule("detect-http_request_line");
+
     sigmatch_table[DETECT_AL_HTTP_REQUEST_LINE].flags |= SIGMATCH_NOOPT;
 
     DetectAppLayerInspectEngineRegister2("http_request_line",

--- a/src/detect-http-response-line.c
+++ b/src/detect-http-response-line.c
@@ -84,6 +84,8 @@ void DetectHttpResponseLineRegister(void)
 
     sigmatch_table[DETECT_AL_HTTP_RESPONSE_LINE].flags |= SIGMATCH_NOOPT;
 
+    SCSetModule("detect-http_response_line");
+
     DetectAppLayerMpmRegister("http_response_line", SIG_FLAG_TOCLIENT, 2,
             PrefilterTxHttpResponseLineRegister);
 

--- a/src/detect-http-server-body.c
+++ b/src/detect-http-server-body.c
@@ -91,6 +91,8 @@ void DetectHttpServerBodyRegister(void)
     sigmatch_table[DETECT_HTTP_RESPONSE_BODY].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_HTTP_RESPONSE_BODY].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
+    SCSetModule("detect-http_server_body");
+
     g_file_data_buffer_id = DetectBufferTypeRegister("file_data");
 }
 

--- a/src/detect-http-start.c
+++ b/src/detect-http-start.c
@@ -303,6 +303,8 @@ void DetectHttpStartRegister(void)
 
     sigmatch_table[DETECT_AL_HTTP_START].flags |= SIGMATCH_NOOPT ;
 
+    SCSetModule("detect-" KEYWORD_NAME);
+
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2,
             PrefilterTxHttpRequestStartRegister);
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2,

--- a/src/detect-http-stat-code.c
+++ b/src/detect-http-stat-code.c
@@ -95,6 +95,8 @@ void DetectHttpStatCodeRegister (void)
     sigmatch_table[DETECT_HTTP_STAT_CODE].Setup = DetectHttpStatCodeSetupSticky;
     sigmatch_table[DETECT_HTTP_STAT_CODE].flags |= SIGMATCH_NOOPT;
 
+    SCSetModule("detect-http.stat_code");
+
     DetectAppLayerInspectEngineRegister2("http_stat_code", ALPROTO_HTTP,
             SIG_FLAG_TOCLIENT, HTP_RESPONSE_LINE,
             DetectEngineInspectBufferGeneric, GetData);

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -95,6 +95,8 @@ void DetectHttpStatMsgRegister (void)
     sigmatch_table[DETECT_HTTP_STAT_MSG].Setup = DetectHttpStatMsgSetupSticky;
     sigmatch_table[DETECT_HTTP_STAT_MSG].flags |= SIGMATCH_NOOPT;
 
+    SCSetModule("detect-http.stat_msg");
+
     DetectAppLayerInspectEngineRegister2("http_stat_msg", ALPROTO_HTTP,
             SIG_FLAG_TOCLIENT, HTP_RESPONSE_LINE,
             DetectEngineInspectBufferGeneric, GetData);

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -95,6 +95,8 @@ void DetectHttpUARegister(void)
     sigmatch_table[DETECT_HTTP_UA].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_HTTP_UA].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
+    SCSetModule("detect-http.user_agent");
+
     DetectAppLayerInspectEngineRegister2("http_user_agent", ALPROTO_HTTP,
             SIG_FLAG_TOSERVER, HTP_REQUEST_HEADERS,
             DetectEngineInspectBufferGeneric, GetData);

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -138,6 +138,8 @@ void DetectHttpUriRegister (void)
     sigmatch_table[DETECT_HTTP_URI_RAW].Setup = DetectHttpRawUriSetupSticky;
     sigmatch_table[DETECT_HTTP_URI_RAW].flags |= SIGMATCH_NOOPT;
 
+    SCSetModule("detect-http.uri.raw");
+
     DetectAppLayerInspectEngineRegister2("http_raw_uri", ALPROTO_HTTP,
             SIG_FLAG_TOSERVER, HTP_REQUEST_LINE,
             DetectEngineInspectBufferGeneric, GetRawData);

--- a/src/detect-icmp-id.c
+++ b/src/detect-icmp-id.c
@@ -67,6 +67,8 @@ void DetectIcmpIdRegister (void)
     sigmatch_table[DETECT_ICMP_ID].SupportsPrefilter = PrefilterIcmpIdIsPrefilterable;
     sigmatch_table[DETECT_ICMP_ID].SetupPrefilter = PrefilterSetupIcmpId;
 
+    SCSetModule("detect-icmp_id");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-icmp-seq.c
+++ b/src/detect-icmp-seq.c
@@ -67,6 +67,8 @@ void DetectIcmpSeqRegister (void)
     sigmatch_table[DETECT_ICMP_SEQ].SupportsPrefilter = PrefilterIcmpSeqIsPrefilterable;
     sigmatch_table[DETECT_ICMP_SEQ].SetupPrefilter = PrefilterSetupIcmpSeq;
 
+    SCSetModule("detect-icmp_seq");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-icode.c
+++ b/src/detect-icode.c
@@ -71,6 +71,8 @@ void DetectICodeRegister (void)
     sigmatch_table[DETECT_ICODE].SupportsPrefilter = PrefilterICodeIsPrefilterable;
     sigmatch_table[DETECT_ICODE].SetupPrefilter = PrefilterSetupICode;
 
+    SCSetModule("detect-icode");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-id.c
+++ b/src/detect-id.c
@@ -74,6 +74,8 @@ void DetectIdRegister (void)
     sigmatch_table[DETECT_ID].SupportsPrefilter = PrefilterIdIsPrefilterable;
     sigmatch_table[DETECT_ID].SetupPrefilter = PrefilterSetupId;
 
+    SCSetModule("detect-id");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -62,6 +62,8 @@ void DetectIpOptsRegister (void)
     sigmatch_table[DETECT_IPOPTS].Free  = DetectIpOptsFree;
     sigmatch_table[DETECT_IPOPTS].RegisterTests = IpOptsRegisterTests;
 
+    SCSetModule("detect-ipopts");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -66,6 +66,8 @@ void DetectIPProtoRegister(void)
     sigmatch_table[DETECT_IPPROTO].RegisterTests = DetectIPProtoRegisterTests;
     sigmatch_table[DETECT_IPPROTO].flags = SIGMATCH_QUOTES_OPTIONAL;
 
+    SCSetModule("detect-ip_proto");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-iprep.c
+++ b/src/detect-iprep.c
@@ -68,6 +68,8 @@ void DetectIPRepRegister (void)
     /* this is compatible to ip-only signatures */
     sigmatch_table[DETECT_IPREP].flags |= SIGMATCH_IPONLY_COMPAT;
 
+    SCSetModule("detect-iprep");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-isdataat.c
+++ b/src/detect-isdataat.c
@@ -81,6 +81,8 @@ void DetectIsdataatRegister(void)
     sigmatch_table[DETECT_ENDS_WITH].Setup = DetectEndsWithSetup;
     sigmatch_table[DETECT_ENDS_WITH].flags = SIGMATCH_NOOPT;
 
+    SCSetModule("detect-isdataat");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-itype.c
+++ b/src/detect-itype.c
@@ -71,6 +71,8 @@ void DetectITypeRegister (void)
     sigmatch_table[DETECT_ITYPE].SupportsPrefilter = PrefilterITypeIsPrefilterable;
     sigmatch_table[DETECT_ITYPE].SetupPrefilter = PrefilterSetupIType;
 
+    SCSetModule("detect-itype");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-l3proto.c
+++ b/src/detect-l3proto.c
@@ -58,6 +58,8 @@ void DetectL3ProtoRegister(void)
     sigmatch_table[DETECT_L3PROTO].Free  = NULL;
     sigmatch_table[DETECT_L3PROTO].RegisterTests = DetectL3protoRegisterTests;
 
+    SCSetModule("detect-l3_proto");
+
     return;
 }
 /**

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -120,6 +120,8 @@ void DetectLuaRegister(void)
     sigmatch_table[DETECT_LUA].Free  = DetectLuaFree;
     sigmatch_table[DETECT_LUA].RegisterTests = DetectLuaRegisterTests;
 
+    SCSetModule("detect-lua");
+
     g_smtp_generic_list_id = DetectBufferTypeRegister("smtp_generic");
 
     DetectAppLayerInspectEngineRegister("smtp_generic",

--- a/src/detect-mark.c
+++ b/src/detect-mark.c
@@ -59,6 +59,8 @@ void DetectMarkRegister (void)
     sigmatch_table[DETECT_MARK].Free  = DetectMarkDataFree;
     sigmatch_table[DETECT_MARK].RegisterTests = MarkRegisterTests;
 
+    SCSetModule("detect-nfq_set_mark");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-modbus.c
+++ b/src/detect-modbus.c
@@ -522,6 +522,8 @@ void DetectModbusRegister(void)
     sigmatch_table[DETECT_AL_MODBUS].Free          = DetectModbusFree;
     sigmatch_table[DETECT_AL_MODBUS].RegisterTests = DetectModbusRegisterTests;
 
+    SCSetModule("detect-modbus");
+
     DetectSetupParseRegexes(PARSE_REGEX_UNIT_ID,
             &unit_id_parse_regex, &unit_id_parse_regex_study);
     DetectSetupParseRegexes(PARSE_REGEX_FUNCTION,

--- a/src/detect-msg.c
+++ b/src/detect-msg.c
@@ -47,6 +47,8 @@ void DetectMsgRegister (void)
     sigmatch_table[DETECT_MSG].Free = NULL;
     sigmatch_table[DETECT_MSG].RegisterTests = DetectMsgRegisterTests;
     sigmatch_table[DETECT_MSG].flags = SIGMATCH_QUOTES_MANDATORY;
+
+    SCSetModule("detect-msg");
 }
 
 static int DetectMsgSetup (DetectEngineCtx *de_ctx, Signature *s, const char *msgstr)

--- a/src/detect-noalert.c
+++ b/src/detect-noalert.c
@@ -39,12 +39,14 @@ void DetectNoalertRegister (void)
     sigmatch_table[DETECT_NOALERT].RegisterTests = NULL;
 
     sigmatch_table[DETECT_NOALERT].flags |= SIGMATCH_NOOPT;
+
+    SCSetModule("detect-noalert");
 }
 
 static int DetectNoalertSetup (DetectEngineCtx *de_ctx, Signature *s, const char *nullstr)
 {
     if (nullstr != NULL) {
-        SCLogError(SC_ERR_INVALID_VALUE, "nocase has no value");
+        SCLogError(SC_ERR_INVALID_VALUE, "noalert has no value");
         return -1;
     }
 

--- a/src/detect-nocase.c
+++ b/src/detect-nocase.c
@@ -46,6 +46,8 @@ void DetectNocaseRegister(void)
     sigmatch_table[DETECT_NOCASE].RegisterTests = NULL;
 
     sigmatch_table[DETECT_NOCASE].flags |= SIGMATCH_NOOPT;
+
+    SCSetModule("detect-nocase");
 }
 
 /**

--- a/src/detect-offset.c
+++ b/src/detect-offset.c
@@ -51,6 +51,8 @@ void DetectOffsetRegister (void)
     sigmatch_table[DETECT_OFFSET].Setup = DetectOffsetSetup;
     sigmatch_table[DETECT_OFFSET].Free  = NULL;
     sigmatch_table[DETECT_OFFSET].RegisterTests = NULL;
+
+    SCSetModule("detect-offset");
 }
 
 int DetectOffsetSetup (DetectEngineCtx *de_ctx, Signature *s, const char *offsetstr)

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -94,6 +94,8 @@ void DetectPcreRegister (void)
     sigmatch_table[DETECT_PCRE].RegisterTests  = DetectPcreRegisterTests;
     sigmatch_table[DETECT_PCRE].flags = (SIGMATCH_QUOTES_OPTIONAL|SIGMATCH_HANDLE_NEGATION);
 
+    SCSetModule("detect-pcre");
+
     intmax_t val = 0;
 
     if (!ConfGetInt("pcre.match-limit", &val)) {

--- a/src/detect-pkt-data.c
+++ b/src/detect-pkt-data.c
@@ -57,6 +57,8 @@ void DetectPktDataRegister(void)
     sigmatch_table[DETECT_PKT_DATA].Free  = NULL;
     sigmatch_table[DETECT_PKT_DATA].RegisterTests = DetectPktDataTestRegister;
     sigmatch_table[DETECT_PKT_DATA].flags = SIGMATCH_NOOPT;
+
+    SCSetModule("detect-pkt_data");
 }
 
 /**

--- a/src/detect-pktvar.c
+++ b/src/detect-pktvar.c
@@ -52,6 +52,8 @@ void DetectPktvarRegister (void)
     sigmatch_table[DETECT_PKTVAR].Free  = NULL;
     sigmatch_table[DETECT_PKTVAR].RegisterTests  = NULL;
 
+    SCSetModule("detect-pktvar");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-prefilter.c
+++ b/src/detect-prefilter.c
@@ -45,6 +45,8 @@ void DetectPrefilterRegister(void)
     sigmatch_table[DETECT_PREFILTER].RegisterTests = NULL;
 
     sigmatch_table[DETECT_PREFILTER].flags |= SIGMATCH_NOOPT;
+
+    SCSetModule("detect-prefilter");
 }
 
 /**

--- a/src/detect-priority.c
+++ b/src/detect-priority.c
@@ -55,6 +55,8 @@ void DetectPriorityRegister (void)
     sigmatch_table[DETECT_PRIORITY].Free = NULL;
     sigmatch_table[DETECT_PRIORITY].RegisterTests = SCPriorityRegisterTests;
 
+    SCSetModule("detect-priority");
+
     DetectSetupParseRegexes(PARSE_REGEX, &regex, &regex_study);
 }
 

--- a/src/detect-rawbytes.c
+++ b/src/detect-rawbytes.c
@@ -45,6 +45,8 @@ void DetectRawbytesRegister (void)
     sigmatch_table[DETECT_RAWBYTES].name = "rawbytes";
     sigmatch_table[DETECT_RAWBYTES].Setup = DetectRawbytesSetup;
     sigmatch_table[DETECT_RAWBYTES].flags |= SIGMATCH_NOOPT;
+
+    SCSetModule("detect-rawbytes");
 }
 
 static int DetectRawbytesSetup (DetectEngineCtx *de_ctx, Signature *s, const char *nullstr)

--- a/src/detect-reference.c
+++ b/src/detect-reference.c
@@ -63,6 +63,8 @@ void DetectReferenceRegister(void)
     sigmatch_table[DETECT_REFERENCE].Free  = NULL;
     sigmatch_table[DETECT_REFERENCE].RegisterTests = ReferenceRegisterTests;
 
+    SCSetModule("detect-reference");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-replace.c
+++ b/src/detect-replace.c
@@ -70,6 +70,8 @@ void DetectReplaceRegister (void)
     sigmatch_table[DETECT_REPLACE].Free  = NULL;
     sigmatch_table[DETECT_REPLACE].RegisterTests = DetectReplaceRegisterTests;
     sigmatch_table[DETECT_REPLACE].flags = (SIGMATCH_QUOTES_MANDATORY|SIGMATCH_HANDLE_NEGATION);
+
+    SCSetModule("detect-replace");
 }
 
 int DetectReplaceSetup(DetectEngineCtx *de_ctx, Signature *s, const char *replacestr)

--- a/src/detect-rev.c
+++ b/src/detect-rev.c
@@ -40,6 +40,8 @@ void DetectRevRegister (void)
     sigmatch_table[DETECT_REV].Setup = DetectRevSetup;
     sigmatch_table[DETECT_REV].Free  = NULL;
     sigmatch_table[DETECT_REV].RegisterTests = NULL;
+
+    SCSetModule("detect-rev");
 }
 
 static int DetectRevSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)

--- a/src/detect-rpc.c
+++ b/src/detect-rpc.c
@@ -67,6 +67,8 @@ void DetectRpcRegister (void)
     sigmatch_table[DETECT_RPC].Free  = DetectRpcFree;
     sigmatch_table[DETECT_RPC].RegisterTests = DetectRpcRegisterTests;
 
+    SCSetModule("detect-rpc");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-seq.c
+++ b/src/detect-seq.c
@@ -60,6 +60,8 @@ void DetectSeqRegister(void)
 
     sigmatch_table[DETECT_SEQ].SupportsPrefilter = PrefilterTcpSeqIsPrefilterable;
     sigmatch_table[DETECT_SEQ].SetupPrefilter = PrefilterSetupTcpSeq;
+
+    SCSetModule("detect-seq");
 }
 
 /**

--- a/src/detect-sid.c
+++ b/src/detect-sid.c
@@ -44,6 +44,8 @@ void DetectSidRegister (void)
     sigmatch_table[DETECT_SID].Setup = DetectSidSetup;
     sigmatch_table[DETECT_SID].Free = NULL;
     sigmatch_table[DETECT_SID].RegisterTests = DetectSidRegisterTests;
+
+    SCSetModule("detect-sid");
 }
 
 static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, const char *sidstr)

--- a/src/detect-ssh-proto-version.c
+++ b/src/detect-ssh-proto-version.c
@@ -84,6 +84,8 @@ void DetectSshVersionRegister(void)
     sigmatch_table[DETECT_AL_SSH_PROTOVERSION].RegisterTests = DetectSshVersionRegisterTests;
     sigmatch_table[DETECT_AL_SSH_PROTOVERSION].flags = SIGMATCH_QUOTES_OPTIONAL;
 
+    SCSetModule("detect-ssh.protoversion");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 
     g_ssh_banner_list_id = DetectBufferTypeRegister("ssh_banner");

--- a/src/detect-ssh-software-version.c
+++ b/src/detect-ssh-software-version.c
@@ -98,6 +98,8 @@ void DetectSshSoftwareVersionRegister(void)
     sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].RegisterTests = DetectSshSoftwareVersionRegisterTests;
     sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].flags = SIGMATCH_QUOTES_OPTIONAL;
 
+    SCSetModule("detect-ssh.softwareversion");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 
     g_ssh_banner_list_id = DetectBufferTypeRegister("ssh_banner");

--- a/src/detect-ssl-state.c
+++ b/src/detect-ssl-state.c
@@ -88,6 +88,8 @@ void DetectSslStateRegister(void)
     DetectSetupParseRegexes(PARSE_REGEX1, &parse_regex1, &parse_regex1_study);
     DetectSetupParseRegexes(PARSE_REGEX2, &parse_regex2, &parse_regex2_study);
 
+    SCSetModule("detect-ssl_state");
+
     g_tls_generic_list_id = DetectBufferTypeRegister("tls_generic");
 
     DetectBufferTypeSetDescriptionByName("tls_generic",

--- a/src/detect-ssl-version.c
+++ b/src/detect-ssl-version.c
@@ -79,6 +79,8 @@ void DetectSslVersionRegister(void)
     sigmatch_table[DETECT_AL_SSL_VERSION].Free  = DetectSslVersionFree;
     sigmatch_table[DETECT_AL_SSL_VERSION].RegisterTests = DetectSslVersionRegisterTests;
 
+    SCSetModule("detect-ssl_version");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 
     g_tls_generic_list_id = DetectBufferTypeRegister("tls_generic");

--- a/src/detect-stream_size.c
+++ b/src/detect-stream_size.c
@@ -64,6 +64,8 @@ void DetectStreamSizeRegister(void)
     sigmatch_table[DETECT_STREAM_SIZE].Free = DetectStreamSizeFree;
     sigmatch_table[DETECT_STREAM_SIZE].RegisterTests = DetectStreamSizeRegisterTests;
 
+    SCSetModule("detect-stream_size");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-tag.c
+++ b/src/detect-tag.c
@@ -75,6 +75,8 @@ void DetectTagRegister(void)
     sigmatch_table[DETECT_TAG].RegisterTests = DetectTagRegisterTests;
     sigmatch_table[DETECT_TAG].flags |= SIGMATCH_IPONLY_COMPAT;
 
+    SCSetModule("detect-tag");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -85,6 +85,8 @@ void DetectThresholdRegister(void)
     /* this is compatible to ip-only signatures */
     sigmatch_table[DETECT_THRESHOLD].flags |= SIGMATCH_IPONLY_COMPAT;
 
+    SCSetModule("detect-threshold");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -81,6 +81,8 @@ void DetectTlsFingerprintRegister(void)
 
     sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].flags |= SIGMATCH_NOOPT;
 
+    SCSetModule("detect-tls_cert_fingerprint");
+
     DetectAppLayerInspectEngineRegister2("tls_cert_fingerprint", ALPROTO_TLS,
             SIG_FLAG_TOCLIENT, TLS_STATE_CERT_READY,
             DetectEngineInspectBufferGeneric, GetData);

--- a/src/detect-tls-cert-issuer.c
+++ b/src/detect-tls-cert-issuer.c
@@ -77,6 +77,8 @@ void DetectTlsIssuerRegister(void)
 
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].flags |= SIGMATCH_NOOPT;
 
+    SCSetModule("detect-tls_cert_issuer");
+
     DetectAppLayerInspectEngineRegister2("tls_cert_issuer", ALPROTO_TLS,
             SIG_FLAG_TOCLIENT, TLS_STATE_CERT_READY,
             DetectEngineInspectBufferGeneric, GetData);

--- a/src/detect-tls-cert-serial.c
+++ b/src/detect-tls-cert-serial.c
@@ -81,6 +81,8 @@ void DetectTlsSerialRegister(void)
 
     sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].flags |= SIGMATCH_NOOPT;
 
+    SCSetModule("detect-tls_cert_serial");
+
     DetectAppLayerInspectEngineRegister2("tls_cert_serial", ALPROTO_TLS,
             SIG_FLAG_TOCLIENT, TLS_STATE_CERT_READY,
             DetectEngineInspectBufferGeneric, GetData);

--- a/src/detect-tls-cert-subject.c
+++ b/src/detect-tls-cert-subject.c
@@ -77,6 +77,8 @@ void DetectTlsSubjectRegister(void)
 
     sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].flags |= SIGMATCH_NOOPT;
 
+    SCSetModule("detect-tls_cert_subject");
+
    DetectAppLayerInspectEngineRegister2("tls_cert_subject", ALPROTO_TLS,
             SIG_FLAG_TOCLIENT, TLS_STATE_CERT_READY,
             DetectEngineInspectBufferGeneric, GetData);

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -85,6 +85,8 @@ void DetectTlsJa3HashRegister(void)
 
     sigmatch_table[DETECT_AL_TLS_JA3_HASH].flags |= SIGMATCH_NOOPT;
 
+    SCSetModule("detect-ja3_hash");
+
     DetectAppLayerInspectEngineRegister2("ja3_hash", ALPROTO_TLS, SIG_FLAG_TOSERVER, 0,
             DetectEngineInspectBufferGeneric, GetData);
 

--- a/src/detect-tls-ja3-string.c
+++ b/src/detect-tls-ja3-string.c
@@ -81,6 +81,8 @@ void DetectTlsJa3StringRegister(void)
 
     sigmatch_table[DETECT_AL_TLS_JA3_STRING].flags |= SIGMATCH_NOOPT;
 
+    SCSetModule("detect-ja3_string");
+
     DetectAppLayerInspectEngineRegister2("ja3_string", ALPROTO_TLS, SIG_FLAG_TOSERVER, 0,
             DetectEngineInspectBufferGeneric, GetData);
 

--- a/src/detect-tls-sni.c
+++ b/src/detect-tls-sni.c
@@ -77,6 +77,8 @@ void DetectTlsSniRegister(void)
 
     sigmatch_table[DETECT_AL_TLS_SNI].flags |= SIGMATCH_NOOPT;
 
+    SCSetModule("detect-tls_sni");
+
     DetectAppLayerInspectEngineRegister2("tls_sni", ALPROTO_TLS, SIG_FLAG_TOSERVER, 0,
             DetectEngineInspectBufferGeneric, GetData);
 

--- a/src/detect-tls-version.c
+++ b/src/detect-tls-version.c
@@ -80,6 +80,8 @@ void DetectTlsVersionRegister (void)
     sigmatch_table[DETECT_AL_TLS_VERSION].Free  = DetectTlsVersionFree;
     sigmatch_table[DETECT_AL_TLS_VERSION].RegisterTests = DetectTlsVersionRegisterTests;
 
+    SCSetModule("detect-tls.version");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 
     g_tls_generic_list_id = DetectBufferTypeRegister("tls_generic");

--- a/src/detect-tls.c
+++ b/src/detect-tls.c
@@ -152,6 +152,8 @@ void DetectTlsRegister (void)
     sigmatch_table[DETECT_AL_TLS_STORE].RegisterTests = NULL;
     sigmatch_table[DETECT_AL_TLS_STORE].flags |= SIGMATCH_NOOPT;
 
+    SCSetModule("detect-tls");
+
     DetectSetupParseRegexes(PARSE_REGEX,
             &subject_parse_regex, &subject_parse_regex_study);
     DetectSetupParseRegexes(PARSE_REGEX,

--- a/src/detect-tos.c
+++ b/src/detect-tos.c
@@ -72,6 +72,8 @@ void DetectTosRegister(void)
     sigmatch_table[DETECT_TOS].url =
         DOC_URL DOC_VERSION "/rules/header-keywords.html#tos";
 
+    SCSetModule("detect-tos");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-ttl.c
+++ b/src/detect-ttl.c
@@ -71,6 +71,8 @@ void DetectTtlRegister(void)
     sigmatch_table[DETECT_TTL].SupportsPrefilter = PrefilterTtlIsPrefilterable;
     sigmatch_table[DETECT_TTL].SetupPrefilter = PrefilterSetupTtl;
 
+    SCSetModule("detect-ttl");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
     return;
 }

--- a/src/detect-uricontent.c
+++ b/src/detect-uricontent.c
@@ -74,6 +74,8 @@ void DetectUricontentRegister (void)
     sigmatch_table[DETECT_URICONTENT].RegisterTests = DetectUricontentRegisterTests;
     sigmatch_table[DETECT_URICONTENT].flags = (SIGMATCH_QUOTES_MANDATORY|SIGMATCH_HANDLE_NEGATION);
 
+    SCSetModule("detect-uricontent");
+
     g_http_uri_buffer_id = DetectBufferTypeRegister("http_uri");
 }
 

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -72,6 +72,8 @@ void DetectUrilenRegister(void)
     sigmatch_table[DETECT_AL_URILEN].Free = DetectUrilenFree;
     sigmatch_table[DETECT_AL_URILEN].RegisterTests = DetectUrilenRegisterTests;
 
+    SCSetModule("detect-urilen");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 
     g_http_uri_buffer_id = DetectBufferTypeRegister("http_uri");

--- a/src/detect-window.c
+++ b/src/detect-window.c
@@ -66,6 +66,8 @@ void DetectWindowRegister (void)
     sigmatch_table[DETECT_WINDOW].Free  = DetectWindowFree;
     sigmatch_table[DETECT_WINDOW].RegisterTests = DetectWindowRegisterTests;
 
+    SCSetModule("detect-window");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/detect-within.c
+++ b/src/detect-within.c
@@ -57,6 +57,8 @@ void DetectWithinRegister(void)
     sigmatch_table[DETECT_WITHIN].Setup = DetectWithinSetup;
     sigmatch_table[DETECT_WITHIN].Free  = NULL;
     sigmatch_table[DETECT_WITHIN].RegisterTests = DetectWithinRegisterTests;
+
+    SCSetModule("detect-within");
 }
 
 /** \brief Setup within pattern (content/uricontent) modifier.

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -74,6 +74,8 @@ void DetectXbitsRegister (void)
     /* this is compatible to ip-only signatures */
     sigmatch_table[DETECT_XBITS].flags |= SIGMATCH_IPONLY_COMPAT;
 
+    SCSetModule("detect-xbits");
+
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -592,6 +592,7 @@ static TmEcode FlowManagerThreadInit(ThreadVars *t, const void *initdata, void *
         return TM_ECODE_FAILED;
 
     ftd->instance = SC_ATOMIC_ADD(flowmgr_cnt, 1);
+    SCSetModule("flow-manager");
     SCLogDebug("flow manager instance %u", ftd->instance);
 
     /* set the min and max value used for hash row walking

--- a/src/flow.c
+++ b/src/flow.c
@@ -443,6 +443,7 @@ void FlowHandlePacket(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
  *  \warning Not thread safe */
 void FlowInitConfig(char quiet)
 {
+    SCSetModule("flow-engine");
     SCLogDebug("initializing flow engine...");
 
     memset(&flow_config,  0, sizeof(flow_config));

--- a/src/host.c
+++ b/src/host.c
@@ -167,6 +167,7 @@ void HostClearMemory(Host *h)
  *  \warning Not thread safe */
 void HostInitConfig(char quiet)
 {
+    SCSetModule("host");
     SCLogDebug("initializing host engine...");
     if (HostStorageSize() > 0)
         g_host_size = sizeof(Host) + HostStorageSize();

--- a/src/ippair.c
+++ b/src/ippair.c
@@ -163,6 +163,7 @@ void IPPairClearMemory(IPPair *h)
  *  \warning Not thread safe */
 void IPPairInitConfig(char quiet)
 {
+    SCSetModule("ippair");
     SCLogDebug("initializing ippair engine...");
     if (IPPairStorageSize() > 0)
         g_ippair_size = sizeof(IPPair) + IPPairStorageSize();

--- a/src/log-dnslog.c
+++ b/src/log-dnslog.c
@@ -374,6 +374,8 @@ void LogDnsLogRegister (void)
         LogDnsLogInitCtx, ALPROTO_DNS, LogDnsResponseLogger, 1, 1,
         LogDnsLogThreadInit, LogDnsLogThreadDeinit, LogDnsLogExitPrintStats);
 
+
+    SCSetModule("log-dnslog");
     /* enable the logger for the app layer */
     SCLogDebug("registered %s", MODULE_NAME);
 #endif /* !HAVE_RUST */

--- a/src/log-droplog.c
+++ b/src/log-droplog.c
@@ -496,6 +496,8 @@ void LogDropLogRegister (void)
     OutputRegisterPacketModule(LOGGER_DROP, MODULE_NAME, "drop",
         LogDropLogInitCtx, LogDropLogger, LogDropCondition,
         LogDropLogThreadInit, LogDropLogThreadDeinit, LogDropLogExitPrintStats);
+
+    SCSetModule("log-droplog");
 #ifdef UNITTESTS
     LogDropLogRegisterTests();
 #endif

--- a/src/log-filestore.c
+++ b/src/log-filestore.c
@@ -711,5 +711,7 @@ void LogFilestoreRegister (void)
 
     SC_ATOMIC_INIT(filestore_open_file_cnt);
     SC_ATOMIC_SET(filestore_open_file_cnt, 0);
+
+    SCSetModule("log-filestore");
     SCLogDebug("registered");
 }

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -68,6 +68,8 @@ void LogHttpLogRegister (void)
     OutputRegisterTxModule(LOGGER_HTTP, MODULE_NAME, "http-log",
         LogHttpLogInitCtx, ALPROTO_HTTP, LogHttpLogger, LogHttpLogThreadInit,
         LogHttpLogThreadDeinit, NULL);
+
+    SCSetModule("log-httplog");
 }
 
 #define LOG_HTTP_CF_REQUEST_HOST 'h'

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -209,6 +209,7 @@ void PcapLogRegister(void)
         PcapLogDataDeinit, NULL);
     PcapLogProfileSetup();
     SC_ATOMIC_INIT(thread_cnt);
+    SCSetModule("pcap-log");
     return;
 }
 

--- a/src/log-stats.c
+++ b/src/log-stats.c
@@ -292,4 +292,6 @@ void LogStatsLogRegister (void)
     OutputRegisterStatsModule(LOGGER_STATS, MODULE_NAME, "stats",
         LogStatsLogInitCtx, LogStatsLogger, LogStatsLogThreadInit,
         LogStatsLogThreadDeinit, NULL);
+
+    SCSetModule("log-stats");
 }

--- a/src/log-tcp-data.c
+++ b/src/log-tcp-data.c
@@ -66,6 +66,8 @@ void LogTcpDataLogRegister (void) {
     OutputRegisterStreamingModule(LOGGER_TCP_DATA, MODULE_NAME, "http-body-data",
         LogTcpDataLogInitCtx, LogTcpDataLogger, STREAMING_HTTP_BODIES,
         LogTcpDataLogThreadInit, LogTcpDataLogThreadDeinit, NULL);
+
+    SCSetModule("log-tcp-data");
 }
 
 typedef struct LogTcpDataFileCtx_ {

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -503,4 +503,6 @@ void LogTlsLogRegister(void)
         LogTlsLogInitCtx, ALPROTO_TLS, LogTlsLogger, TLS_HANDSHAKE_DONE,
         TLS_HANDSHAKE_DONE, LogTlsLogThreadInit, LogTlsLogThreadDeinit,
         LogTlsLogExitPrintStats);
+
+    SCSetModule("log-tlslog");
 }

--- a/src/log-tlsstore.c
+++ b/src/log-tlsstore.c
@@ -419,5 +419,7 @@ void LogTlsStoreRegister (void)
 
     SC_ATOMIC_INIT(cert_id);
 
+    SCSetModule("log-tlsstore");
+
     SCLogDebug("registered");
 }

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -1010,6 +1010,8 @@ void JsonAlertLogRegister (void)
         "eve-log.alert", JsonAlertLogInitCtxSub, JsonAlertLogger,
         JsonAlertLogCondition, JsonAlertLogThreadInit, JsonAlertLogThreadDeinit,
         NULL);
+
+    SCSetModule("output-json-alert");
 }
 
 #else

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -179,6 +179,8 @@ void JsonDHCPLogRegister(void)
         "eve-log.dhcp", OutputDHCPLogInitSub, ALPROTO_DHCP,
         JsonDHCPLogger, JsonDHCPLogThreadInit,
         JsonDHCPLogThreadDeinit, NULL);
+
+    SCSetModule("output-json-dhcp");
 }
 
 #else /* No JSON support. */

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -449,6 +449,8 @@ void JsonDNP3LogRegister(void)
         "JsonDNP3Log", "eve-log.dnp3", OutputDNP3LogInitSub, ALPROTO_DNP3,
         JsonDNP3LoggerToClient, 1, 1, JsonDNP3LogThreadInit,
         JsonDNP3LogThreadDeinit, NULL);
+
+    SCSetModule("output-json-dnp3");
 }
 
 #else

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -1446,6 +1446,8 @@ void JsonDnsLogRegister (void)
         MODULE_NAME, "eve-log.dns", JsonDnsLogInitCtxSub, ALPROTO_DNS,
         JsonDnsLoggerToClient, 1, 1, LogDnsLogThreadInit, LogDnsLogThreadDeinit,
         NULL);
+
+    SCSetModule("output-json-dns");
 }
 
 #else

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -447,6 +447,8 @@ void JsonDropLogRegister (void)
         "eve-log.drop", JsonDropLogInitCtxSub, JsonDropLogger,
         JsonDropLogCondition, JsonDropLogThreadInit, JsonDropLogThreadDeinit,
         NULL);
+
+    SCSetModule("output-json-drop");
 }
 
 #else

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -397,6 +397,8 @@ void JsonFileLogRegister (void)
     OutputRegisterFileSubModule(LOGGER_JSON_FILE, "eve-log", "JsonFileLog",
         "eve-log.files", OutputFileLogInitSub, JsonFileLogger,
         JsonFileLogThreadInit, JsonFileLogThreadDeinit, NULL);
+
+    SCSetModule("output-json-file");
 }
 
 #else

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -512,6 +512,8 @@ void JsonFlowLogRegister (void)
     OutputRegisterFlowSubModule(LOGGER_JSON_FLOW, "eve-log", "JsonFlowLog",
         "eve-log.flow", OutputFlowLogInitSub, JsonFlowLogger,
         JsonFlowLogThreadInit, JsonFlowLogThreadDeinit, NULL);
+
+    SCSetModule("output-json-flow");
 }
 
 #else

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -792,6 +792,8 @@ void JsonHttpLogRegister (void)
     OutputRegisterTxSubModule(LOGGER_JSON_HTTP, "eve-log", "JsonHttpLog",
         "eve-log.http", OutputHttpLogInitSub, ALPROTO_HTTP, JsonHttpLogger,
         JsonHttpLogThreadInit, JsonHttpLogThreadDeinit, NULL);
+
+    SCSetModule("output-json-http");
 }
 
 #else

--- a/src/output-json-ikev2.c
+++ b/src/output-json-ikev2.c
@@ -180,6 +180,8 @@ void JsonIKEv2LogRegister(void)
         JsonIKEv2LogThreadDeinit, NULL);
 
     SCLogDebug("IKEv2 JSON logger registered.");
+
+    SCSetModule("output-json-ikev2");
 }
 
 #else /* No JSON support. */

--- a/src/output-json-krb5.c
+++ b/src/output-json-krb5.c
@@ -180,6 +180,8 @@ void JsonKRB5LogRegister(void)
         JsonKRB5Logger, JsonKRB5LogThreadInit,
         JsonKRB5LogThreadDeinit, NULL);
 
+
+    SCSetModule("output-json-krb5");
     SCLogDebug("KRB5 JSON logger registered.");
 }
 

--- a/src/output-json-metadata.c
+++ b/src/output-json-metadata.c
@@ -289,6 +289,8 @@ void JsonMetadataLogRegister (void)
         "eve-log.vars", JsonMetadataLogInitCtxSub, JsonMetadataLogger,
         JsonMetadataLogCondition, JsonMetadataLogThreadInit,
         JsonMetadataLogThreadDeinit, NULL);
+
+    SCSetModule("output-json-metadata");
 }
 
 #else

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -469,6 +469,8 @@ void JsonNetFlowLogRegister(void)
     OutputRegisterFlowSubModule(LOGGER_JSON_NETFLOW, "eve-log", "JsonNetFlowLog",
         "eve-log.netflow", OutputNetFlowLogInitSub, JsonNetFlowLogger,
         JsonNetFlowLogThreadInit, JsonNetFlowLogThreadDeinit, NULL);
+
+    SCSetModule("output-json-netflow");
 }
 
 #else

--- a/src/output-json-nfs.c
+++ b/src/output-json-nfs.c
@@ -132,6 +132,8 @@ void JsonNFSLogRegister(void)
         JsonNFSLogger, JsonLogThreadInit,
         JsonLogThreadDeinit, NULL);
 
+    SCSetModule("output-json-nfs");
+
     SCLogDebug("NFS JSON logger registered.");
 }
 

--- a/src/output-json-smb.c
+++ b/src/output-json-smb.c
@@ -106,6 +106,8 @@ void JsonSMBLogRegister(void)
         JsonSMBLogger, JsonLogThreadInit,
         JsonLogThreadDeinit, NULL);
 
+    SCSetModule("output-json-smb");
+
     SCLogDebug("SMB JSON logger registered.");
 }
 

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -276,6 +276,9 @@ void JsonSmtpLogRegister (void) {
     OutputRegisterTxSubModule(LOGGER_JSON_SMTP, "eve-log", "JsonSmtpLog",
         "eve-log.smtp", OutputSmtpLogInitSub, ALPROTO_SMTP, JsonSmtpLogger,
         JsonSmtpLogThreadInit, JsonSmtpLogThreadDeinit, NULL);
+
+    SCSetModule("output-json-smtp");
+
 }
 
 #else

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -273,6 +273,8 @@ void JsonSshLogRegister (void)
         OutputSshLogInitSub, ALPROTO_SSH, JsonSshLogger,
         SSH_STATE_BANNER_DONE, SSH_STATE_BANNER_DONE,
         JsonSshLogThreadInit, JsonSshLogThreadDeinit, NULL);
+
+    SCSetModule("output-json-ssh");
 }
 
 #else

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -522,6 +522,8 @@ void JsonStatsLogRegister(void) {
     OutputRegisterStatsSubModule(LOGGER_JSON_STATS, "eve-log", MODULE_NAME,
         "eve-log.stats", OutputStatsLogInitSub, JsonStatsLogger,
         JsonStatsLogThreadInit, JsonStatsLogThreadDeinit, NULL);
+
+    SCSetModule("output-json-stats");
 }
 
 #else

--- a/src/output-json-template-rust.c
+++ b/src/output-json-template-rust.c
@@ -185,6 +185,8 @@ void JsonTemplateRustLogRegister(void)
         OutputTemplateLogInitSub, ALPROTO_TEMPLATE_RUST, JsonTemplateLogger,
         JsonTemplateLogThreadInit, JsonTemplateLogThreadDeinit, NULL);
 
+    SCSetModule("output-json-template-rust");
+
     SCLogNotice("Template JSON logger registered.");
 }
 

--- a/src/output-json-template.c
+++ b/src/output-json-template.c
@@ -203,6 +203,8 @@ void JsonTemplateLogRegister(void)
         JsonTemplateLogger, JsonTemplateLogThreadInit,
         JsonTemplateLogThreadDeinit, NULL);
 
+    SCSetModule("output-json-template");
+
     SCLogNotice("Template JSON logger registered.");
 }
 

--- a/src/output-json-tftp.c
+++ b/src/output-json-tftp.c
@@ -179,6 +179,8 @@ void JsonTFTPLogRegister(void)
                               JsonTFTPLogThreadInit, JsonTFTPLogThreadDeinit,
                               NULL);
 
+    SCSetModule("output-json-tftp");
+
     SCLogDebug("TFTP JSON logger registered.");
 }
 #else /* HAVE_RUST */

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -627,6 +627,8 @@ void JsonTlsLogRegister (void)
         "JsonTlsLog", "eve-log.tls", OutputTlsLogInitSub, ALPROTO_TLS,
         JsonTlsLogger, TLS_HANDSHAKE_DONE, TLS_HANDSHAKE_DONE,
         JsonTlsLogThreadInit, JsonTlsLogThreadDeinit, NULL);
+
+    SCSetModule("output-json-tls");
 }
 
 #else

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -104,6 +104,8 @@ void OutputJsonRegister (void)
 
     traffic_id_prefix_len = strlen(TRAFFIC_ID_PREFIX);
     traffic_label_prefix_len = strlen(TRAFFIC_LABEL_PREFIX);
+
+    SCSetModule("output-json");
 }
 
 json_t *SCJsonBool(int val)

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -952,6 +952,8 @@ static TmEcode LuaLogThreadDeinit(ThreadVars *t, void *data)
 void LuaLogRegister(void) {
     /* register as separate module */
     OutputRegisterModule(MODULE_NAME, "lua", OutputLuaLogInit);
+
+    SCSetModule("output-lua");
 }
 
 #else

--- a/src/output.c
+++ b/src/output.c
@@ -1036,6 +1036,9 @@ void OutputRegisterRootLoggers(void)
  */
 void OutputRegisterLoggers(void)
 {
+
+    SCSetModule("output");
+
     /* custom format log*/
     LogCustomFormatRegister();
 

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -69,6 +69,8 @@ const char *RunModeAFPGetDefaultMode(void)
 
 void RunModeIdsAFPRegister(void)
 {
+    SCSetModule("runmode-af-packet");
+
     RunModeRegisterNewRunMode(RUNMODE_AFP_DEV, "single",
                               "Single threaded af-packet mode",
                               RunModeIdsAFPSingle);

--- a/src/runmode-erf-dag.c
+++ b/src/runmode-erf-dag.c
@@ -51,6 +51,8 @@ void RunModeErfDagRegister(void)
 {
     default_mode = "autofp";
 
+    SCSetModule("runmode-erf-dag");
+
     RunModeRegisterNewRunMode(RUNMODE_DAG, "autofp",
         "Multi threaded DAG mode.  Packets from "
         "each flow are assigned to a single detect "

--- a/src/runmode-erf-file.c
+++ b/src/runmode-erf-file.c
@@ -42,6 +42,8 @@ void RunModeErfFileRegister(void)
 {
     default_mode = "autofp";
 
+    SCSetModule("runmode-erf-file");
+
     RunModeRegisterNewRunMode(RUNMODE_ERF_FILE, "single",
         "Single threaded ERF file mode",
         RunModeErfFileSingle);

--- a/src/runmode-ipfw.c
+++ b/src/runmode-ipfw.c
@@ -52,6 +52,8 @@ void RunModeIpsIPFWRegister(void)
 {
     default_mode = "autofp";
 
+    SCSetModule("runmode-ipfw");
+
     RunModeRegisterNewRunMode(RUNMODE_IPFW, "autofp",
                               "Multi threaded IPFW IPS mode with respect to flow",
                               RunModeIpsIPFWAutoFp);

--- a/src/runmode-napatech.c
+++ b/src/runmode-napatech.c
@@ -61,6 +61,9 @@ void RunModeNapatechRegister(void)
 {
 #ifdef HAVE_NAPATECH
     default_mode = "autofp";
+
+    SCSetModule("runmode-napatech");
+
     RunModeRegisterNewRunMode(RUNMODE_NAPATECH, "autofp",
             "Multi threaded Napatech mode.  Packets from "
             "each flow are assigned to a single detect "

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -64,6 +64,8 @@ const char *RunModeNetmapGetDefaultMode(void)
 
 void RunModeIdsNetmapRegister(void)
 {
+    SCSetModule("runmode-netmap");
+
     RunModeRegisterNewRunMode(RUNMODE_NETMAP, "single",
             "Single threaded netmap mode",
             RunModeIdsNetmapSingle);

--- a/src/runmode-nflog.c
+++ b/src/runmode-nflog.c
@@ -44,6 +44,9 @@ const char *RunModeIdsNflogGetDefaultMode(void)
 void RunModeIdsNflogRegister(void)
 {
     default_mode = "autofp";
+
+    SCSetModule("runmode-nflog");
+
     RunModeRegisterNewRunMode(RUNMODE_NFLOG, "autofp",
                               "Multi threaded nflog mode",
                               RunModeIdsNflogAutoFp);

--- a/src/runmode-nfq.c
+++ b/src/runmode-nfq.c
@@ -49,6 +49,9 @@ const char *RunModeIpsNFQGetDefaultMode(void)
 void RunModeIpsNFQRegister(void)
 {
     default_mode = "autofp";
+
+    SCSetModule("runmode-nfq");
+
     RunModeRegisterNewRunMode(RUNMODE_NFQ, "autofp",
                               "Multi threaded NFQ IPS mode with respect to flow",
                               RunModeIpsNFQAutoFp);

--- a/src/runmode-pcap-file.c
+++ b/src/runmode-pcap-file.c
@@ -41,6 +41,7 @@ const char *RunModeFilePcapGetDefaultMode(void)
 
 void RunModeFilePcapRegister(void)
 {
+    SCSetModule("runmode-pcap-file");
     RunModeRegisterNewRunMode(RUNMODE_PCAP_FILE, "single",
                               "Single threaded pcap file mode",
                               RunModeFilePcapSingle);

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -43,6 +43,7 @@ int RunModeIdsPcapWorkers(void);
 
 void RunModeIdsPcapRegister(void)
 {
+    SCSetModule("runmode-pcap");
     RunModeRegisterNewRunMode(RUNMODE_PCAP_DEV, "single",
                               "Single threaded pcap live mode",
                               RunModeIdsPcapSingle);

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -49,6 +49,8 @@ const char *RunModeIdsPfringGetDefaultMode(void)
 
 void RunModeIdsPfringRegister(void)
 {
+    SCSetModule("runmode-pfring");
+
     RunModeRegisterNewRunMode(RUNMODE_PFRING, "autofp",
                               "Multi threaded pfring mode.  Packets from "
                               "each flow are assigned to a single detect "

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -587,6 +587,8 @@ static TmEcode UnixSocketPcapFilesCheck(void *data)
 void RunModeUnixSocketRegister(void)
 {
 #ifdef BUILD_UNIX_SOCKET
+    SCSetModule("runmode-unix-socket");
+
     /* a bit of a hack, but register twice to --list-runmodes shows both */
     RunModeRegisterNewRunMode(RUNMODE_UNIX_SOCKET, "single",
                               "Unix socket mode",

--- a/src/runmode-windivert.c
+++ b/src/runmode-windivert.c
@@ -47,6 +47,8 @@ void RunModeIpsWinDivertRegister(void)
 {
     default_mode = "autofp";
 
+    SCSetModule("runmode-windrivert");
+
     RunModeRegisterNewRunMode(
             RUNMODE_WINDIVERT, "autofp",
             "Multi-threaded WinDivert IPS mode load-balanced by flow",

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -209,6 +209,8 @@ const char *RunModeGetMainMode(void)
  */
 void RunModeRegisterRunModes(void)
 {
+    SCSetModule("runmodes");
+
     memset(runmodes, 0, sizeof(runmodes));
 
     RunModeIdsPcapRegister();

--- a/src/rust.h
+++ b/src/rust.h
@@ -20,7 +20,7 @@
 
 typedef struct SuricataContext_ {
     SCError (*SCLogMessage)(const SCLogLevel, const char *, const unsigned int,
-            const char *, const SCError, const char *message);
+            const char *, const char *, const SCError, const char *message);
     void (*DetectEngineStateFree)(DetectEngineState *);
     void (*AppLayerDecoderEventsSetEventRaw)(AppLayerDecoderEvents **,
             uint8_t);

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2524,6 +2524,7 @@ static int AFPXDPBypassCallback(Packet *p)
  */
 TmEcode ReceiveAFPThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
+    SCSetSubsystem("receive-afp");
     SCEnter();
     AFPIfaceConfig *afpconfig = (AFPIfaceConfig *)initdata;
 

--- a/src/source-pcap-file-directory-helper.c
+++ b/src/source-pcap-file-directory-helper.c
@@ -496,6 +496,7 @@ TmEcode PcapDirectoryDispatchForTimeRange(PcapFileDirectoryVars *pv,
 TmEcode PcapDirectoryDispatch(PcapFileDirectoryVars *ptv)
 {
     SCEnter();
+    SCSetModule("pcap-dir-dispatch");
 
     DIR *directory_check = NULL;
 

--- a/src/source-pcap-file-directory-helper.c
+++ b/src/source-pcap-file-directory-helper.c
@@ -495,6 +495,8 @@ TmEcode PcapDirectoryDispatchForTimeRange(PcapFileDirectoryVars *pv,
 
 TmEcode PcapDirectoryDispatch(PcapFileDirectoryVars *ptv)
 {
+    SCSetModule("pcap-dir-dispatch");
+
     SCEnter();
     SCSetModule("pcap-dir-dispatch");
 

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -119,6 +119,7 @@ const char *PcapFileGetFilename(void)
 TmEcode PcapFileDispatch(PcapFileFileVars *ptv)
 {
     SCEnter();
+    SCSetModule("pcap-file-dispatch");
 
     int packet_q_len = 64;
     int r;

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -118,6 +118,8 @@ const char *PcapFileGetFilename(void)
  */
 TmEcode PcapFileDispatch(PcapFileFileVars *ptv)
 {
+    SCSetModule("pcap-file-dispatch");
+
     SCEnter();
     SCSetModule("pcap-file-dispatch");
 

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -188,6 +188,7 @@ TmEcode ReceivePcapFileLoop(ThreadVars *tv, void *data, void *slot)
 TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
     SCEnter();
+    SCSetModule("receive-pcap-file");
 
     TmEcode status = TM_ECODE_OK;
     const char *tmpstring = NULL;

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -187,6 +187,8 @@ TmEcode ReceivePcapFileLoop(ThreadVars *tv, void *data, void *slot)
 
 TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
+    SCSetModule("receive-pcap-file");
+
     SCEnter();
     SCSetModule("receive-pcap-file");
 

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -330,6 +330,8 @@ TmEcode ReceivePcapBreakLoop(ThreadVars *tv, void *data)
  */
 TmEcode ReceivePcapThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
+    SCSetModule("receive-pcap");
+
     SCEnter();
     SCSetModule("receive-pcap");
     PcapIfaceConfig *pcapconfig = (PcapIfaceConfig *)initdata;

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -331,6 +331,7 @@ TmEcode ReceivePcapBreakLoop(ThreadVars *tv, void *data)
 TmEcode ReceivePcapThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
     SCEnter();
+    SCSetModule("receive-pcap");
     PcapIfaceConfig *pcapconfig = (PcapIfaceConfig *)initdata;
 
     if (initdata == NULL) {

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -367,6 +367,7 @@ void StreamTcpInitConfig(char quiet)
     intmax_t value = 0;
     uint16_t rdrange = 10;
 
+    SCSetModule("stream-tcp");
     SCLogDebug("Initializing Stream");
 
     memset(&stream_config,  0, sizeof(stream_config));

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2871,7 +2871,7 @@ int main(int argc, char **argv)
     /* initialize the logging subsys */
     SCLogInitLogModule(NULL);
 
-    (void)SCSetThreadName("Suricata-Main");
+    (void)SCSetThreadName("Suricata-main");
 
     /* Set subsystem name - TLS for main thread */
     SCSetSubsystem("Suricata-main");

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2873,6 +2873,9 @@ int main(int argc, char **argv)
 
     (void)SCSetThreadName("Suricata-Main");
 
+    /* Set subsystem name - TLS for main thread */
+    SCSetSubsystem("Suricata-main");
+
     /* Ignore SIGUSR2 as early as possble. We redeclare interest
      * once we're done launching threads. The goal is to either die
      * completely or handle any and all SIGUSR2s correctly.

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -1803,6 +1803,7 @@ static void TmThreadFree(ThreadVars *tv)
         return;
 
     SCLogDebug("Freeing thread '%s'.", tv->name);
+    SCSetSubsystem(NULL);
 
     StatsThreadCleanup(tv);
 
@@ -1843,7 +1844,6 @@ void TmThreadSetGroupName(ThreadVars *tv, const char *name)
         return;
     }
     tv->thread_group_name = thread_group_name;
-    SCSetSubsystem(tv->thread_group_name);
 }
 
 void TmThreadClearThreadsFamily(int family)

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -268,6 +268,8 @@ static void *TmThreadsSlotPktAcqLoop(void *td)
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
 
+    SCSetSubsystem(tv->name);
+
     if (tv->thread_setup_flags != 0)
         TmThreadSetupOptions(tv);
 
@@ -401,6 +403,7 @@ static void *TmThreadsSlotPktAcqLoopAFL(void *td)
     TmEcode r = TM_ECODE_OK;
     TmSlot *slot = NULL;
 
+    SCSetSubsystem(tv->name);
     PacketPoolInit();
 
     /* check if we are setup properly */
@@ -519,6 +522,8 @@ static void *TmThreadsSlotVar(void *td)
     if (SCSetThreadName(tv->name) < 0) {
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
+
+    SCSetSubsystem(tv->name);
 
     if (tv->thread_setup_flags != 0)
         TmThreadSetupOptions(tv);
@@ -679,6 +684,7 @@ static void *TmThreadsManagement(void *td)
     if (tv->thread_setup_flags != 0)
         TmThreadSetupOptions(tv);
 
+    SCSetSubsystem(tv->name);
     /* Drop the capabilities for this thread */
     SCDropCaps(tv);
 
@@ -1837,6 +1843,7 @@ void TmThreadSetGroupName(ThreadVars *tv, const char *name)
         return;
     }
     tv->thread_group_name = thread_group_name;
+    SCSetSubsystem(tv->thread_group_name);
 }
 
 void TmThreadClearThreadsFamily(int family)

--- a/src/tmqh-flow.c
+++ b/src/tmqh-flow.c
@@ -54,6 +54,8 @@ void TmqhFlowRegister(void)
     tmqh_table[TMQH_FLOW].OutHandlerCtxFree = TmqhOutputFlowFreeCtx;
     tmqh_table[TMQH_FLOW].RegisterTests = TmqhFlowRegisterTests;
 
+    SCSetModule("tmqh-flow");
+
     const char *scheduler = NULL;
     if (ConfGet("autofp-scheduler", &scheduler) == 1) {
         if (strcasecmp(scheduler, "round-robin") == 0) {

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -210,8 +210,8 @@ static inline void SCLogPrintToSyslog(int syslog_log_level, const char *msg)
  */
 static int SCLogMessageJSON(struct timeval *tval, char *buffer, size_t buffer_size,
         SCLogLevel log_level, const char *file,
-        unsigned line, const char *function, SCError error_code,
-        const char *message)
+        unsigned line, const char *function, const char *module,
+        SCError error_code, const char *message)
 {
     json_t *js = json_object();
     if (unlikely(js == NULL))
@@ -450,13 +450,11 @@ static SCError SCLogMessageGetBuffer(
 
             case SC_LOG_FMT_SUBSYSTEM:
                 temp_fmt[0] = '\0';
-                const char *fmt_string = "%s%s%s%s";
-                if (_sc_subsystem || module) {
-                    if (_sc_subsystem && module) {
-                        fmt_string = "%s%s[%s:%s]%s";
-                    } else {
-                        fmt_string = "%s%s[%s%s]%s";
-                    }
+                const char *fmt_string;
+                if (_sc_subsystem && module) {
+                    fmt_string = "%s%s%s:%s%s";
+                } else {
+                    fmt_string = "%s%s%s%s%s";
                 }
                 cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer),
                               fmt_string, substr, green,

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -81,9 +81,9 @@ typedef enum {
 
 /* The default log_format, if it is not supplied by the user */
 #ifdef RELEASE
-#define SC_LOG_DEF_LOG_FORMAT "%t %S - <%d> - "
+#define SC_LOG_DEF_LOG_FORMAT "%t [%S] - <%d> - "
 #else
-#define SC_LOG_DEF_LOG_FORMAT "[%i] %t %S - (%f:%l) <%d> (%n) -- "
+#define SC_LOG_DEF_LOG_FORMAT "[%i] %t [%S] - (%f:%l) <%d> (%n) -- "
 #endif
 
 /* The maximum length of the log message */
@@ -203,7 +203,13 @@ typedef struct SCLogConfig_ {
 /* The log format prefix for the format specifiers */
 #define SC_LOG_FMT_PREFIX           '%'
 
-static const char *_sc_module;
+/* Module and thread tagging */
+
+/*
+ * Suppress unused variable warnings with attribute; this variable is
+ * used by some, but not all, source code modules
+ */
+static const char *_sc_module __attribute__((unused));
 
 /* The module name */
 #define SCSetModule(module_name)                                                \
@@ -214,7 +220,7 @@ static const char *_sc_module;
 /* The subsystem name, usually the thread's name */
 #define SCSetSubsystem(subsystem_name)                                          \
     do {                                                                        \
-        __thread extern const char *_sc_subsystem;                              \
+        extern __thread const char *_sc_subsystem;                              \
         _sc_subsystem = subsystem_name;                                         \
     } while(0)
 

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -81,9 +81,9 @@ typedef enum {
 
 /* The default log_format, if it is not supplied by the user */
 #ifdef RELEASE
-#define SC_LOG_DEF_LOG_FORMAT "%t - <%d> - "
+#define SC_LOG_DEF_LOG_FORMAT "%t %S - <%d> - "
 #else
-#define SC_LOG_DEF_LOG_FORMAT "[%i] %t - (%f:%l) <%d> (%n) -- "
+#define SC_LOG_DEF_LOG_FORMAT "[%i] %t %S - (%f:%l) <%d> (%n) -- "
 #endif
 
 /* The maximum length of the log message */
@@ -198,9 +198,25 @@ typedef struct SCLogConfig_ {
 #define SC_LOG_FMT_FILE_NAME        'f' /* File name */
 #define SC_LOG_FMT_LINE             'l' /* Line number */
 #define SC_LOG_FMT_FUNCTION         'n' /* Function */
+#define SC_LOG_FMT_SUBSYSTEM        'S' /* Subystem name */
 
 /* The log format prefix for the format specifiers */
 #define SC_LOG_FMT_PREFIX           '%'
+
+static const char *_sc_module;
+
+/* The module name */
+#define SCSetModule(module_name)                                                \
+    do {                                                                        \
+        _sc_module = module_name;                                               \
+    } while(0)
+
+/* The subsystem name, usually the thread's name */
+#define SCSetSubsystem(subsystem_name)                                          \
+    do {                                                                        \
+        __thread extern const char *_sc_subsystem;                              \
+        _sc_subsystem = subsystem_name;                                         \
+    } while(0)
 
 extern SCLogLevel sc_log_global_log_level;
 
@@ -223,7 +239,7 @@ extern int sc_log_module_cleaned;
             if (_sc_log_ret == SC_LOG_MAX_LOG_MSG_LEN)                          \
                 _sc_log_msg[SC_LOG_MAX_LOG_MSG_LEN - 1] = '\0';                 \
                                                                                 \
-            SCLogMessage(x, file, line, func, SC_OK, _sc_log_msg);              \
+            SCLogMessage(x, file, line, func, _sc_module, SC_OK, _sc_log_msg);  \
         }                                                                       \
     } while(0)
 
@@ -242,7 +258,7 @@ extern int sc_log_module_cleaned;
             if (_sc_log_ret == SC_LOG_MAX_LOG_MSG_LEN)                          \
                 _sc_log_msg[SC_LOG_MAX_LOG_MSG_LEN - 1] = '\0';                 \
                                                                                 \
-            SCLogMessage(x, file, line, func, err, _sc_log_msg);                \
+            SCLogMessage(x, file, line, func, _sc_module, err, _sc_log_msg);     \
         }                                                                       \
     } while(0)
 
@@ -352,9 +368,9 @@ extern int sc_log_module_cleaned;
 
 #define SCReturnPtr(x, type)            return x
 
+
 /* Please use it only for debugging purposes */
 #else
-
 
 /**
  * \brief Macro used to log DEBUG messages. Comes under the debugging subsystem,
@@ -512,6 +528,7 @@ extern int sc_log_module_cleaned;
                                   return x;                                  \
                               } while(0)
 
+
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
  *        debugging sybsystem, and hence will be enabled only in the presence
@@ -535,6 +552,7 @@ extern int sc_log_module_cleaned;
                               } while(0)
 
 #endif /* DEBUG */
+
 
 #define FatalError(x, ...) do {                                             \
     SCLogError(x, __VA_ARGS__);                                             \
@@ -571,7 +589,7 @@ void SCLogInitLogModule(SCLogInitData *);
 void SCLogDeInitLogModule(void);
 
 SCError SCLogMessage(const SCLogLevel, const char *, const unsigned int,
-                     const char *, const SCError, const char *message);
+                     const char *, const char *, const SCError, const char *message);
 
 SCLogOPBuffer *SCLogAllocLogOPBuffer(void);
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/2497 ticket:

Describe changes:
This PR adds a subsystem and module identifier to SCLog messages when the log format includes %S. Subsystem and module identifiers are intrinsic properties of threads and source code modules (respectively).

New threads are assigned a subsystem identifier when the thread is created; the identifier is a Thread-Local-Storage variable declared in util-debug.c; values are assigned to it as threads are created using SCSetSubsystem (a macro defined in util-debug.h).

Module identifiers are assigned using SCSetModule (macro defined in util-debug.h).

Subsystem and module identifiers are added to log messages when the format contains %S. The generated log message will substitute a tag built from

The subsystem identifier
(Optional) The module identifier will be included if set (not all source modules will set one)
The constructed tag is of the form [subsystem-id[:module-identifier]] (the first and last brackets are literal; the brackets surrounding the module-identifier indicate the module-identifier is optional).

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

