### PR TITLE
Bug 2857: NFQ ASAN 'heap-use-after-free' error.

### DIFF
--- a/src/source-nfq.h
+++ b/src/source-nfq.h
@@ -96,6 +96,7 @@ int NFQGetQueueCount(void);
 void *NFQGetQueue(int number);
 int NFQGetQueueNum(int number);
 void *NFQGetThread(int number);
+void NFQContextsClean(void);
 #endif /* NFQ */
 #endif /* __SOURCE_NFQ_H__ */
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -392,6 +392,10 @@ static void GlobalsDestroy(SCInstance *suri)
     AFPPeersListClean();
 #endif
 
+#ifdef NFQ
+    NFQContextsClean();
+#endif
+
     SC_ATOMIC_DESTROY(engine_stage);
 
 #ifdef BUILD_HYPERSCAN


### PR DESCRIPTION
Global NFQ contexts were not freed properly causing 'use-after-free' error. Moving contexts cleanup to a
separate NFQContextsCleanup() and calling it from GlobalsDestroy(), like it's done for AFPacket, solves
the problem.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2857

Describe changes:
- Moved NFQ global contexts cleanup to a separate function which is called on exit.
- Made NFQGetQueue() and NFQGetThread() more errorproof.