### PR TITLE
autoconf/python - check for distutils - v2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -85,22 +85,26 @@
         exit 1
     fi
 
+    python_version="not set"
+    python_path="not set"
+
     AC_ARG_ENABLE(python,
-           AS_HELP_STRING([--enable-python], [Enable python]),[enable_python=$enableval],[enable_python=yes])
-    AC_PATH_PROGS(HAVE_PYTHON, python python2 python2.7, "no")
-    if test "x$enable_python" = "xno" ; then
-        echo
-        echo "   Warning! python disabled, you will not be      "
-        echo "   able to install suricatasc unix socket client   "
-        echo
+           AS_HELP_STRING([--enable-python], [Enable python]),
+	   [enable_python=$enableval],[enable_python=yes])
+    if test "x$enable_python" != "xyes"; then
         enable_python="no"
-    fi
-    if test "$HAVE_PYTHON" = "no"; then
-        echo
-        echo "   Warning! python not found, you will not be     "
-        echo "   able to install suricatasc unix socket client   "
-        echo
-        enable_python="no"
+    else
+        AC_PATH_PROGS(HAVE_PYTHON, python3 python2.7 python2 python, "no")
+        if test "$HAVE_PYTHON" = "no"; then
+            echo
+            echo "   Warning! python not found, you will not be     "
+            echo "   able to install suricatasc unix socket client   "
+            echo
+            enable_python="no"
+	else
+	    python_path="$HAVE_PYTHON"
+	    python_version="$($HAVE_PYTHON --version)"
+        fi
     fi
     AM_CONDITIONAL([HAVE_PYTHON], [test "x$enable_python" = "xyes"])
 
@@ -2539,6 +2543,9 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   Rust compiler:                           ${rust_compiler_version}
   Rust cargo:                              ${rust_cargo_version}
 
+  Python support:                          ${enable_python}
+  Python path:                             ${python_path}
+  Python version:                          ${python_version}
   Install suricatasc:                      ${enable_python}
   Install suricata-update:                 ${install_suricata_update}
 

--- a/configure.ac
+++ b/configure.ac
@@ -108,6 +108,28 @@
     fi
     AM_CONDITIONAL([HAVE_PYTHON], [test "x$enable_python" = "xyes"])
 
+    # Check for python-distutils (setup).
+    have_python_distutils="no"
+    if test "x$enable_python" = "xyes"; then
+        AC_MSG_CHECKING([for python-distutils])
+	if $HAVE_PYTHON -c "import distutils; from distutils.core import setup" 2>/dev/null; then
+	   AC_MSG_RESULT([yes])
+	   have_python_distutils="yes"
+	else
+	   AC_MSG_RESULT([no])
+	fi
+    fi
+    AM_CONDITIONAL([HAVE_PYTHON_DISTUTILS],
+	[test "x$have_python_distutils" = "xyes"])
+    if test "$have_python_distutils" = "no"; then
+       echo ""
+       echo "    Warning: Python distutils not found. Python tools will"
+       echo "        not be installed."
+       echo ""
+       echo "    Ubuntu/Debian: apt install `basename ${HAVE_PYTHON}`-distutils"
+       echo ""
+    fi
+
     # Check for python-yaml.
     have_python_yaml="no"
     if test "x$enable_python" = "xyes"; then
@@ -1518,7 +1540,6 @@
     AM_CONDITIONAL([HAVE_SURICATA_UPDATE],
         [test "x$have_suricata_update" != "xno"])
 
-    install_suricata_update="no"
     if test "$have_suricata_update" = "yes"; then
         if test "$have_python_yaml" != "yes"; then
 	    echo ""
@@ -1530,7 +1551,6 @@
 	    echo "    CentOS/RHEL: yum install python-yaml"
 	    echo ""
 	else
-	    install_suricata_update="yes"
             SURICATA_UPDATE_DIR="suricata-update"
             AC_SUBST(SURICATA_UPDATE_DIR)
             AC_OUTPUT(suricata-update/Makefile)
@@ -1538,6 +1558,28 @@
             no_suricata_update_comment=""
             has_suricata_update_comment="#"
 	fi
+    fi
+
+    # Test to see if suricatactl (and suricatasc) can be installed.
+    if test "x$enable_python" != "xyes"; then
+        install_suricatactl="requires python"
+    elif test "x$have_python_distutils" != "xyes"; then
+        install_suricatactl="requires distutils"
+    else
+        install_suricatactl="yes"
+    fi
+
+    # Test to see if suricata-update can be installed.
+    if test "x$have_suricata_update" != "xyes"; then
+        install_suricata_update="not bundled"
+    elif test "x$enable_python" != "xyes"; then
+        install_suricata_update="requires python"
+    elif test "x$have_python_distutils" != "xyes"; then
+        install_suricata_update="requires distutils"
+    elif test "x$have_python_yaml" != "xyes"; then
+        install_suricata_update="requires pyyaml"
+    else
+        install_suricata_update="yes"
     fi
 
   # libhtp
@@ -2546,7 +2588,10 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   Python support:                          ${enable_python}
   Python path:                             ${python_path}
   Python version:                          ${python_version}
-  Install suricatasc:                      ${enable_python}
+  Python distutils                         ${have_python_distutils}
+  Python yaml                              ${have_python_yaml}
+  Install suricatactl:                     ${install_suricatactl}
+  Install suricatasc:                      ${install_suricatactl}
   Install suricata-update:                 ${install_suricata_update}
 
   Profiling enabled:                       ${enable_profiling}

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -4,6 +4,7 @@ EXTRA_DIST =	setup.py \
 		suricatasc
 
 if HAVE_PYTHON
+if HAVE_PYTHON_DISTUTILS
 all-local:
 	cd $(srcdir) && \
 		$(HAVE_PYTHON) setup.py build --build-base $(abs_builddir)
@@ -29,4 +30,5 @@ clean-local:
 
 distclean-local:
 	rm -f version
+endif
 endif

--- a/suricata-update/Makefile.am
+++ b/suricata-update/Makefile.am
@@ -1,4 +1,5 @@
 if HAVE_PYTHON
+if HAVE_PYTHON_DISTUTILS
 if HAVE_PYTHON_YAML
 
 install-exec-local:
@@ -20,5 +21,6 @@ clean-local:
 
 distclean-local:
 
+endif
 endif
 endif


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/3682

Changes from last PR:
- Add a check for the Python distutils module.
- Only install suricatactl/suricatasc if we have Python and distutils.
- Only install suricata-update if we have distutils and pyyaml (and its bundled).

What I'm not sure about is if we should error out here at all, or what autoconf parameters should cause it to error out instead of continuuing without installing the Python tools.

PRScript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/346
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/700
