### PR TITLE
log-pcap.c: Free copy in LZ4 error paths

### DIFF
--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -650,6 +650,8 @@ static PcapLogData *PcapLogDataCopy(const PcapLogData *pl)
         if (copy_comp->buffer == NULL) {
             SCLogError(SC_ERR_MEM_ALLOC, "SCMalloc failed: %s",
                     strerror(errno));
+            SCFree(copy->h);
+            SCFree(copy);
             return NULL;
         }
         copy_comp->pcap_buf = SCMalloc(copy_comp->pcap_buf_size);
@@ -657,6 +659,8 @@ static PcapLogData *PcapLogDataCopy(const PcapLogData *pl)
             SCLogError(SC_ERR_MEM_ALLOC, "SCMalloc failed: %s",
                     strerror(errno));
             SCFree(copy_comp->buffer);
+            SCFree(copy->h);
+            SCFree(copy);
             return NULL;
         }
         copy_comp->pcap_buf_wrapper = SCFmemopen(copy_comp->pcap_buf,
@@ -665,6 +669,8 @@ static PcapLogData *PcapLogDataCopy(const PcapLogData *pl)
             SCLogError(SC_ERR_FOPEN, "SCFmemopen failed: %s", strerror(errno));
             SCFree(copy_comp->buffer);
             SCFree(copy_comp->pcap_buf);
+            SCFree(copy->h);
+            SCFree(copy);
             return NULL;
         }
 
@@ -679,6 +685,8 @@ static PcapLogData *PcapLogDataCopy(const PcapLogData *pl)
             fclose(copy_comp->pcap_buf_wrapper);
             SCFree(copy_comp->buffer);
             SCFree(copy_comp->pcap_buf);
+            SCFree(copy->h);
+            SCFree(copy);
             return NULL;
         }
 


### PR DESCRIPTION
- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2870

Describe changes:
- Fix a memory leak in log-pcap.c: in PcapLogDataCopy, copy and copy->h are not freed in the lz4 error paths.