### PR TITLE
Suri bypass update

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -464,6 +464,7 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_flow_udp = StatsRegisterCounter("flow.udp", tv);
     dtv->counter_flow_icmp4 = StatsRegisterCounter("flow.icmpv4", tv);
     dtv->counter_flow_icmp6 = StatsRegisterCounter("flow.icmpv6", tv);
+    dtv->counter_flow_pkts_bypassed = StatsRegisterCounter("flow.pkts_bypassed", tv);
 
     dtv->counter_defrag_ipv4_fragments =
         StatsRegisterCounter("defrag.ipv4.fragments", tv);

--- a/src/decode.h
+++ b/src/decode.h
@@ -683,6 +683,7 @@ typedef struct DecodeThreadVars_
     uint16_t counter_flow_udp;
     uint16_t counter_flow_icmp4;
     uint16_t counter_flow_icmp6;
+    uint16_t counter_flow_pkts_bypassed;
 
     uint16_t counter_engine_events[DECODE_EVENT_MAX];
 

--- a/src/flow-bypass.c
+++ b/src/flow-bypass.c
@@ -126,7 +126,7 @@ void BypassedFlowManagerThreadSpawn()
 #endif
 
     ThreadVars *tv_flowmgr = NULL;
-    tv_flowmgr = TmThreadCreateMgmtThreadByName("BypassedFlowManager",
+    tv_flowmgr = TmThreadCreateMgmtThreadByName(thread_name_flow_bypass,
             "BypassedFlowManager", 0);
     BUG_ON(tv_flowmgr == NULL);
 

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -275,6 +275,8 @@ static int FlowManagerFlowTimedOut(Flow *f, struct timeval *ts)
     int server = 0, client = 0;
 
     if (!(f->flags & FLOW_TIMEOUT_REASSEMBLY_DONE) &&
+            SC_ATOMIC_GET(f->flow_state) != FLOW_STATE_CAPTURE_BYPASSED &&
+            SC_ATOMIC_GET(f->flow_state) != FLOW_STATE_LOCAL_BYPASSED &&
             FlowForceReassemblyNeedReassembly(f, &server, &client) == 1) {
         FlowForceReassemblyForFlow(f, server, client);
         return 0;

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -183,6 +183,7 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data, PacketQueue *pr
             DEBUG_ASSERT_FLOW_LOCKED(p->flow);
             if (FlowUpdate(p) == TM_ECODE_DONE) {
                 FLOWLOCK_UNLOCK(p->flow);
+                StatsIncr(tv, fw->dtv->counter_flow_pkts_bypassed);
                 return TM_ECODE_OK;
             }
         }

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -64,6 +64,7 @@ const char *thread_name_workers = "W";
 const char *thread_name_verdict = "TX";
 const char *thread_name_flow_mgr = "FM";
 const char *thread_name_flow_rec = "FR";
+const char *thread_name_flow_bypass = "FB";
 const char *thread_name_unix_socket = "US";
 const char *thread_name_detect_loader = "DL";
 const char *thread_name_counter_stats = "CS";

--- a/src/runmodes.h
+++ b/src/runmodes.h
@@ -65,6 +65,7 @@ extern const char *thread_name_single;
 extern const char *thread_name_workers;
 extern const char *thread_name_verdict;
 extern const char *thread_name_flow_mgr;
+extern const char *thread_name_flow_bypass;
 extern const char *thread_name_flow_rec;
 extern const char *thread_name_unix_socket;
 extern const char *thread_name_detect_loader;

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1767,6 +1767,13 @@ int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
                 ssn, stream, p->payload_len,
                 (stream->flags & STREAMTCP_STREAM_FLAG_NOREASSEMBLY) ? "true" : "false");
 
+        /* In the case of bypass Suricata has to honor the inspection for all packets
+         * before stream depth so we need to check the depth.By adding the stream depth
+         * reached flag, it will trigger the bypass. */
+        if (StreamTcpBypassEnabled()) {
+            StreamTcpReassembleCheckDepth(ssn, stream, TCP_GET_SEQ(p), p->payload_len);
+        }
+
     }
 
     /* if the STREAMTCP_STREAM_FLAG_DEPTH_REACHED is set, but not the

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4841,18 +4841,13 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
         /* check for conditions that may make us not want to log this packet */
 
         /* streams that hit depth */
-        if ((ssn->client.flags & STREAMTCP_STREAM_FLAG_DEPTH_REACHED) &&
+        if ((ssn->client.flags & STREAMTCP_STREAM_FLAG_DEPTH_REACHED) ||
              (ssn->server.flags & STREAMTCP_STREAM_FLAG_DEPTH_REACHED))
         {
             /* we can call bypass callback, if enabled */
             if (StreamTcpBypassEnabled()) {
                 PacketBypassCallback(p);
             }
-        }
-
-        if ((ssn->client.flags & STREAMTCP_STREAM_FLAG_DEPTH_REACHED) ||
-             (ssn->server.flags & STREAMTCP_STREAM_FLAG_DEPTH_REACHED))
-        {
             p->flags |= PKT_STREAM_NOPCAPLOG;
         }
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4859,10 +4859,7 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
         }
 
         if (ssn->flags & STREAMTCP_FLAG_BYPASS) {
-            /* we can call bypass callback, if enabled */
-            if (StreamTcpBypassEnabled()) {
-                PacketBypassCallback(p);
-            }
+            PacketBypassCallback(p);
 
         /* if stream is dead and we have no detect engine at all, bypass. */
         } else if (g_detect_disabled &&

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -784,7 +784,7 @@ app-layer:
       #
       # For best performance, select 'bypass'.
       #
-      #encrypt-handling: default
+      #encryption-handling: default
 
     dcerpc:
       enabled: yes


### PR DESCRIPTION
Extracted from #3716, this is the change on Suricata bypass strategy.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- More aggressive bypass strategy
- Thread renaming
- New counter for bypassed flow

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/439
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/220

