### PR TITLE
scbpf: add basic eBPF map handling tool

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1672,6 +1672,7 @@
 	        AS_HELP_STRING([--enable-ebpf],[Enable eBPF support]),
 	        [ enable_ebpf="$enableval"],
 	        [ enable_ebpf="no"])
+    AM_CONDITIONAL([HAVE_EBPF], [test "x$enable_ebpf" != "xno"])
 
     have_xdp="no"
     if test "$enable_ebpf" = "yes"; then
@@ -2497,7 +2498,7 @@ AC_SUBST(CONFIGURE_LOCALSTATEDIR)
 AC_SUBST(CONFIGURE_DATAROOTDIR)
 AC_SUBST(PACKAGE_VERSION)
 
-AC_OUTPUT(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile suricata.yaml etc/Makefile etc/suricata.logrotate etc/suricata.service python/Makefile python/suricata/config/defaults.py ebpf/Makefile)
+AC_OUTPUT(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile suricata.yaml etc/Makefile etc/suricata.logrotate etc/suricata.service python/Makefile python/suricata/config/defaults.py ebpf/Makefile ebpf/scbpf/Makefile)
 
 SURICATA_BUILD_CONF="Suricata Configuration:
   AF_PACKET support:                       ${enable_af_packet}

--- a/ebpf/Makefile.am
+++ b/ebpf/Makefile.am
@@ -1,3 +1,5 @@
+SUBDIRS = scbpf
+
 if BUILD_EBPF
 
 # Maintaining a local copy of UAPI linux/bpf.h

--- a/ebpf/scbpf/Makefile.am
+++ b/ebpf/scbpf/Makefile.am
@@ -1,0 +1,6 @@
+if HAVE_EBPF
+bin_PROGRAMS = scbpf
+
+scbpf_SOURCES = scbpf.c
+endif
+

--- a/ebpf/scbpf/scbpf.c
+++ b/ebpf/scbpf/scbpf.c
@@ -1,0 +1,96 @@
+#include <linux/unistd.h>
+#include <linux/bpf.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+
+#include <bpf/bpf.h>
+
+#define BPF_F_ADD	(1 << 0)
+#define BPF_F_GET	(1 << 1)
+
+#define BPF_F_KEY	(1 << 2)
+#define BPF_F_VAL	(1 << 3)
+#define BPF_F_KEY_VAL	(BPF_F_KEY | BPF_F_VAL)
+
+static void usage(void)
+{
+	printf("Usage: scbpf [...]\n");
+	printf("       -F <file>   File to pin/get object\n");
+	printf("       -A          |- add key\n");
+	printf("       -G          |- get object\n");
+	printf("       -k <key>    |- map key\n");
+	printf("       -h          Display this help.\n");
+}
+
+static int bpf_do_map(const char *file, uint32_t flags, uint32_t key,
+		      uint32_t value)
+{
+	int fd, ret;
+
+	fd = bpf_obj_get(file);
+	printf("bpf: get fd:%d (%s)\n", fd, strerror(errno));
+	assert(fd > 0);
+
+	if ((flags & BPF_F_ADD) == BPF_F_ADD) {
+		ret = bpf_map_update_elem(fd, &key, &value, 0);
+		printf("bpf: fd:%d u->(%u:%u) ret:(%d,%s)\n", fd, key, value,
+		       ret, strerror(errno));
+		assert(ret == 0);
+	} else if (flags & BPF_F_GET) {
+		ret = bpf_map_lookup_elem(fd, &key, &value);
+		printf("bpf: fd:%d l->(%u):%u ret:(%d,%s)\n", fd, key, value,
+		       ret, strerror(errno));
+		assert(ret == 0);
+	}
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	const char *file = NULL, *object = NULL;
+	uint32_t key = 0, flags = 0;
+	uint32_t value;
+	int opt;
+
+	while ((opt = getopt(argc, argv, "F:GAk:h")) != -1) {
+		switch (opt) {
+		/* General args */
+		case 'F':
+			file = optarg;
+			break;
+		case 'G':
+			flags |= BPF_F_GET;
+			break;
+		case 'A':
+			flags |= BPF_F_ADD;
+			break;
+		case 'k':
+			key = ntohl(inet_addr(optarg));
+			printf("%u\n", key);
+			flags |= BPF_F_KEY;
+			break;
+		default:
+			goto out;
+		}
+	}
+
+	return bpf_do_map(file, flags, key, value);
+out:
+	usage();
+	return -1;
+}


### PR DESCRIPTION
SCbpf part of #3716 

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- basic tool to handle IPv4 maps

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/440
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/221


