### PR TITLE
pfring: update bpf error handling to be consistent

### DIFF
--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2017 Open Information Security Foundation
+/* Copyright (C) 2007-2019 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -89,7 +89,7 @@ void TmModuleDecodePfringRegister (void)
 }
 
 /**
- * \brief this funciton prints an error message and exits.
+ * \brief this function prints an error message and exits.
  * \param tv pointer to ThreadVars
  * \param initdata pointer to the interface passed from the user
  * \param data pointer gets populated with PfringThreadVars
@@ -217,7 +217,7 @@ static inline void PfringDumpCounters(PfringThreadVars *ptv)
  * \brief Pfring Packet Process function.
  *
  * This function fills in our packet structure from libpfring.
- * From here the packets are picked up by the  DecodePfring thread.
+ * From here the packets are picked up by the DecodePfring thread.
  *
  * \param user pointer to PfringThreadVars
  * \param h pointer to pfring packet header
@@ -253,7 +253,7 @@ static inline void PfringProcessPacket(void *user, struct pfring_pkthdr *h, Pack
      * PF_RING should put it back in all cases, but as a extra
      * precaution keep the check here. If the vlan header is
      * part of the raw packet, the vlan_offset will be set.
-     * So is it is not set, use the parsed info from PF_RING's
+     * So if it is not set, use the parsed info from PF_RING's
      * extended header.
      */
     if ((!ptv->vlan_disabled) &&
@@ -614,8 +614,9 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, const void *initdata, void **dat
             SCMutexUnlock(&pfring_bpf_set_filter_lock);
 
             if (rc < 0) {
-                SCLogInfo("Set PF_RING bpf filter \"%s\" failed.",
-                          ptv->bpf_filter);
+                SCLogError(SC_ERR_INVALID_VALUE, "Failed to compile BPF \"%s\"",
+                           ptv->bpf_filter);
+                return TM_ECODE_FAILED;
             }
         }
     }


### PR DESCRIPTION
* updated bpf error handling to be consistent with af-packet
* minor internal doc updates

Signed-off-by: jason taylor <jtfas90@gmail.com>

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1013

Describe changes:
- updated pfring BPF error handling to be consistent with the way af-packet handles BPF errors 
- minor internal documentation updates
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

