### PR TITLE
Avoid use-after-free during pid file cleanup.

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -398,6 +398,9 @@ static void GlobalsDestroy(SCInstance *suri)
     MpmHSGlobalCleanup();
 #endif
 
+    /* The pid file name may be in config memory, but is needed later. */
+    if (suri->pid_filename != NULL)
+        suri->pid_filename = strdup(suri->pid_filename);
     ConfDeInit();
 #ifdef HAVE_LUAJIT
     LuajitFreeStatesPool();
@@ -407,6 +410,8 @@ static void GlobalsDestroy(SCInstance *suri)
     SCThresholdConfGlobalFree();
 
     SCPidfileRemove(suri->pid_filename);
+    free((char *)suri->pid_filename);
+    suri->pid_filename = NULL;
 }
 
 /** \brief make sure threads can stop the engine by calling this


### PR DESCRIPTION
In case the pid file is given in the config file, the file name is
stored in volatile memory.  Removal of the pid file happens after
cleanup of config memory, so we need a temporary copy.