### PR TITLE
doc: precise -i is useable several times

### DIFF
--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -46,7 +46,8 @@
 
    After the -i option you can enter the interface card you would like
    to use to sniff packets from.  This option will try to use the best
-   capture method available.
+   capture method available. Can be used several times to sniff packets from
+   several interfaces.
 
 .. option:: --pcap[=<device>]
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2885

Describe changes:
- Clarify the usage of -i (iface) option by precising it can be used several times

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

