### PR TITLE
Avoid use-after-free during pid file cleanup.

### DIFF
--- a/src/suricata.h
+++ b/src/suricata.h
@@ -137,7 +137,7 @@ typedef struct SCInstance_ {
     char pcap_dev[128];
     char *sig_file;
     int sig_file_exclusive;
-    const char *pid_filename;
+    char *pid_filename;
     char *regex_arg;
 
     char *keyword_info;


### PR DESCRIPTION
In case the pid file is given in the config file, the file name is
stored in volatile memory.  Removal of the pid file happens after
cleanup of config memory.  Create a copy of the name which will be
freed after the pid file has been removed.
