### PR TITLE
doc: add ssh protocol in eve log section

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -778,3 +778,28 @@ Example::
       ]
     }
   }
+
+
+Event type: SSH
+----------------
+
+Fields
+~~~~~~
+
+* "proto_version": The protocol version transported with the ssh protocol (1.x, 2.x)
+* "software_version": The software version used by end user
+
+Example of SSH logging:
+
+::
+
+  "ssh": {
+    "client": {
+        "proto_version": "2.0",
+        "software_version": "OpenSSH_6.7",
+     },
+    "server": {
+        "proto_version": "2.0",
+        "software_version": "OpenSSH_6.7",
+     }
+  }


### PR DESCRIPTION
Add details in eve json format guide for SSH protocol logged by suricata.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- update eve log section in userguide for SSH network security monitoring


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

