### PR TITLE
Fix parsing of smb1 create andx request filename

### DIFF
--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -543,7 +543,7 @@ named!(pub parse_smb_create_andx_request_record<SmbRequestCreateAndXRecord>,
        >> _skip3: take!(28)
        >> disposition: le_u32
        >> create_options: le_u32
-       >> _skip2: take!(8)
+       >> _skip2: take!(7)
        >> file_name: take!(file_name_len)
        >> _skip3: rest
        >> (SmbRequestCreateAndXRecord {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2894

Describe changes:
- Fixes parsing the filename for smb 1 create andx requests.