### PR TITLE
Feat/pd midstream/v19

### DIFF
--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -257,8 +257,10 @@ export_tx_set_detect_state!(
 #[no_mangle]
 pub extern "C" fn rs_template_probing_parser(
     _flow: *const Flow,
+    _direction: u8,
     input: *const libc::uint8_t,
     input_len: u32,
+    _rdir: *mut u8
 ) -> AppProto {
     // Need at least 2 bytes.
     if input_len > 1 && input != std::ptr::null_mut() {

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -219,8 +219,11 @@ impl DHCPState {
 
 #[no_mangle]
 pub extern "C" fn rs_dhcp_probing_parser(_flow: *const Flow,
+                                         _direction: u8,
                                          input: *const libc::uint8_t,
-                                         input_len: u32) -> AppProto {
+                                         input_len: u32,
+                                         _rdir: *mut u8) -> AppProto
+{
     if input_len < DHCP_MIN_FRAME_LEN {
         return ALPROTO_UNKNOWN;
     }

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -624,7 +624,11 @@ pub extern "C" fn rs_ikev2_state_get_event_info(event_name: *const libc::c_char,
 static mut ALPROTO_IKEV2 : AppProto = ALPROTO_UNKNOWN;
 
 #[no_mangle]
-pub extern "C" fn rs_ikev2_probing_parser(_flow: *const Flow, input:*const libc::uint8_t, input_len: u32) -> AppProto {
+pub extern "C" fn rs_ikev2_probing_parser(_flow: *const Flow,
+        _direction: u8,
+        input:*const libc::uint8_t, input_len: u32,
+        _rdir: *mut u8) -> AppProto
+{
     let slice = build_slice!(input,input_len as usize);
     let alproto = unsafe{ ALPROTO_IKEV2 };
     match parse_ikev2_header(slice) {

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -343,7 +343,11 @@ pub extern "C" fn rs_ntp_state_get_event_info(event_name: *const libc::c_char,
 static mut ALPROTO_NTP : AppProto = ALPROTO_UNKNOWN;
 
 #[no_mangle]
-pub extern "C" fn ntp_probing_parser(_flow: *const Flow, input:*const u8, input_len: u32) -> AppProto {
+pub extern "C" fn ntp_probing_parser(_flow: *const Flow,
+        _direction: u8,
+        input:*const u8, input_len: u32,
+        _rdir: *mut u8) -> AppProto
+{
     let slice: &[u8] = unsafe { std::slice::from_raw_parts(input as *mut u8, input_len as usize) };
     let alproto = unsafe{ ALPROTO_NTP };
     match parse_ntp(slice) {

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -125,7 +125,7 @@ pub type ParseFn      = extern "C" fn (flow: *const Flow,
                                        input_len: u32,
                                        data: *const c_void,
                                        flags: u8) -> i32;
-pub type ProbeFn      = extern "C" fn (flow: *const Flow,input:*const u8, input_len: u32) -> AppProto;
+pub type ProbeFn      = extern "C" fn (flow: *const Flow,direction: u8,input:*const u8, input_len: u32, rdir: *mut u8) -> AppProto;
 pub type StateAllocFn = extern "C" fn () -> *mut c_void;
 pub type StateFreeFn  = extern "C" fn (*mut c_void);
 pub type StateTxFreeFn  = extern "C" fn (*mut c_void, u64);

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -33,6 +33,21 @@ named!(pub parse_smb2_sec_blob<Smb2SecBlobRecord>,
 ));
 
 #[derive(Debug,PartialEq)]
+pub struct Smb2RecordDir<> {
+    pub request: bool,
+}
+
+named!(pub parse_smb2_record_direction<Smb2RecordDir>,
+    do_parse!(
+            _server_component: tag!(b"\xfeSMB")
+        >>  _skip: take!(12)
+        >>  flags: le_u8
+        >> (Smb2RecordDir {
+                request: flags & 0x01 == 0,
+           })
+));
+
+#[derive(Debug,PartialEq)]
 pub struct Smb2Record<'a> {
     pub direction: u8,    // 0 req, 1 res
     pub nt_status: u32,

--- a/src/app-layer-detect-proto.h
+++ b/src/app-layer-detect-proto.h
@@ -27,8 +27,9 @@
 
 typedef struct AppLayerProtoDetectThreadCtx_ AppLayerProtoDetectThreadCtx;
 
-typedef AppProto (*ProbingParserFPtr)(Flow *f,
-                                      uint8_t *input, uint32_t input_len);
+typedef AppProto (*ProbingParserFPtr)(Flow *f, uint8_t dir,
+                                      uint8_t *input, uint32_t input_len,
+                                      uint8_t *rdir);
 
 /***** Protocol Retrieval *****/
 
@@ -41,13 +42,15 @@ typedef AppProto (*ProbingParserFPtr)(Flow *f,
  * \param buflen The length of the above buffer.
  * \param ipproto The ip protocol.
  * \param direction The direction bitfield - STREAM_TOSERVER/STREAM_TOCLIENT.
+ * \param[out] reverse_flow true if flow is detected to be reversed
  *
  * \retval The app layer protocol.
  */
 AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx,
                                      Flow *f,
                                      uint8_t *buf, uint32_t buflen,
-                                     uint8_t ipproto, uint8_t direction);
+                                     uint8_t ipproto, uint8_t direction,
+                                     bool *reverse_flow);
 
 /***** State Preparation *****/
 
@@ -84,9 +87,14 @@ int AppLayerProtoDetectPPParseConfPorts(const char *ipproto_name,
  * \brief Registers a case-sensitive pattern for protocol detection.
  */
 int AppLayerProtoDetectPMRegisterPatternCS(uint8_t ipproto, AppProto alproto,
-                                           const char *pattern,
-                                           uint16_t depth, uint16_t offset,
-                                           uint8_t direction);
+        const char *pattern, uint16_t depth, uint16_t offset,
+        uint8_t direction);
+int AppLayerProtoDetectPMRegisterPatternCSwPP(uint8_t ipproto, AppProto alproto,
+        const char *pattern, uint16_t depth, uint16_t offset,
+        uint8_t direction,
+        ProbingParserFPtr PPFunc,
+        uint16_t pp_min_depth, uint16_t pp_max_depth);
+
 /**
  * \brief Registers a case-insensitive pattern for protocol detection.
  */

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -264,7 +264,9 @@ static int DNP3ContainsBanner(const uint8_t *input, uint32_t len)
 /**
  * \brief DNP3 probing parser.
  */
-static uint16_t DNP3ProbingParser(Flow *f, uint8_t *input, uint32_t len)
+static uint16_t DNP3ProbingParser(Flow *f, uint8_t direction,
+        uint8_t *input, uint32_t len,
+        uint8_t *rdir)
 {
     DNP3LinkHeader *hdr = (DNP3LinkHeader *)input;
 
@@ -2041,27 +2043,28 @@ static int DNP3ProbingParserTest(void)
         0x05, 0x64, 0x05, 0xc9, 0x03, 0x00, 0x04, 0x00,
         0xbd, 0x71
     };
+    uint8_t rdir = 0;
 
     /* Valid frame. */
-    FAIL_IF(DNP3ProbingParser(NULL, pkt, sizeof(pkt)) != ALPROTO_DNP3);
+    FAIL_IF(DNP3ProbingParser(NULL, STREAM_TOSERVER, pkt, sizeof(pkt), &rdir) != ALPROTO_DNP3);
 
     /* Send too little bytes. */
-    FAIL_IF(DNP3ProbingParser(NULL, pkt, sizeof(DNP3LinkHeader) - 1) != ALPROTO_UNKNOWN);
+    FAIL_IF(DNP3ProbingParser(NULL, STREAM_TOSERVER, pkt, sizeof(DNP3LinkHeader) - 1, &rdir) != ALPROTO_UNKNOWN);
 
     /* Bad start bytes. */
     pkt[0] = 0x06;
-    FAIL_IF(DNP3ProbingParser(NULL, pkt, sizeof(pkt)) != ALPROTO_FAILED);
+    FAIL_IF(DNP3ProbingParser(NULL, STREAM_TOSERVER, pkt, sizeof(pkt), &rdir) != ALPROTO_FAILED);
 
     /* Restore start byte. */
     pkt[0] = 0x05;
 
     /* Set the length to a value less than the minimum length of 5. */
     pkt[2] = 0x03;
-    FAIL_IF(DNP3ProbingParser(NULL, pkt, sizeof(pkt)) != ALPROTO_FAILED);
+    FAIL_IF(DNP3ProbingParser(NULL, STREAM_TOSERVER, pkt, sizeof(pkt), &rdir) != ALPROTO_FAILED);
 
     /* Send a banner. */
     char mybanner[] = "Welcome to DNP3 SCADA.";
-    FAIL_IF(DNP3ProbingParser(NULL, (uint8_t *)mybanner, sizeof(mybanner)) != ALPROTO_DNP3);
+    FAIL_IF(DNP3ProbingParser(NULL, STREAM_TOSERVER, (uint8_t *)mybanner, sizeof(mybanner), &rdir) != ALPROTO_DNP3);
 
     PASS;
 }

--- a/src/app-layer-dns-tcp-rust.c
+++ b/src/app-layer-dns-tcp-rust.c
@@ -52,7 +52,8 @@ static int RustDNSTCPParseResponse(Flow *f, void *state,
             local_data);
 }
 
-static uint16_t RustDNSTCPProbe(Flow *f, uint8_t *input, uint32_t len)
+static uint16_t RustDNSTCPProbe(Flow *f, uint8_t direction,
+        uint8_t *input, uint32_t len, uint8_t *rdir)
 {
     SCLogDebug("RustDNSTCPProbe");
     if (len == 0 || len < sizeof(DNSHeader)) {

--- a/src/app-layer-dns-udp-rust.c
+++ b/src/app-layer-dns-udp-rust.c
@@ -50,7 +50,8 @@ static int RustDNSUDPParseResponse(Flow *f, void *state,
             local_data);
 }
 
-static uint16_t DNSUDPProbe(Flow *f, uint8_t *input, uint32_t len)
+static uint16_t DNSUDPProbe(Flow *f, uint8_t direction,
+        uint8_t *input, uint32_t len, uint8_t *rdir)
 {
     if (len == 0 || len < sizeof(DNSHeader)) {
         return ALPROTO_UNKNOWN;

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -331,7 +331,8 @@ insufficient_data:
     SCReturnInt(-1);
 }
 
-static uint16_t DNSUdpProbingParser(Flow *f, uint8_t *input, uint32_t ilen)
+static uint16_t DNSUdpProbingParser(Flow *f, uint8_t direction,
+        uint8_t *input, uint32_t ilen, uint8_t *rdir)
 {
     if (ilen == 0 || ilen < sizeof(DNSHeader)) {
         SCLogDebug("ilen too small, hoped for at least %"PRIuMAX, (uintmax_t)sizeof(DNSHeader));

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -359,7 +359,8 @@ static int ENIPParse(Flow *f, void *state, AppLayerParserState *pstate,
 
 
 
-static uint16_t ENIPProbingParser(Flow *f, uint8_t *input, uint32_t input_len)
+static uint16_t ENIPProbingParser(Flow *f, uint8_t direction,
+        uint8_t *input, uint32_t input_len, uint8_t *rdir)
 {
     // SCLogDebug("ENIPProbingParser %d", input_len);
     if (input_len < sizeof(ENIPEncapHdr))

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1427,8 +1427,10 @@ static void ModbusStateFree(void *state)
 }
 
 static uint16_t ModbusProbingParser(Flow *f,
+                                    uint8_t direction,
                                     uint8_t     *input,
-                                    uint32_t    input_len)
+                                    uint32_t    input_len,
+                                    uint8_t *rdir)
 {
     ModbusHeader *header = (ModbusHeader *) input;
 

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -68,6 +68,11 @@ enum AppProtoEnum {
 /* not using the enum as that is a unsigned int, so 4 bytes */
 typedef uint16_t AppProto;
 
+static inline bool AppProtoIsValid(AppProto a)
+{
+    return ((a > ALPROTO_UNKNOWN && a < ALPROTO_FAILED));
+}
+
 /**
  * \brief Maps the ALPROTO_*, to its string equivalent.
  *

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -1512,7 +1512,8 @@ static int SMBGetAlstateProgress(void *tx, uint8_t direction)
 
 #define SMB_PROBING_PARSER_MIN_DEPTH 8
 
-static uint16_t SMBProbingParser(Flow *f, uint8_t *input, uint32_t ilen)
+static uint16_t SMBProbingParser(Flow *f, uint8_t direction,
+        uint8_t *input, uint32_t ilen, uint8_t *rdir)
 {
     int32_t len;
     int32_t input_len = ilen;
@@ -2298,10 +2299,11 @@ static int SMBParserTest05(void)
     AppLayerProtoDetectPrepareState();
     alpd_tctx = AppLayerProtoDetectGetCtxThread();
 
+    bool reverse_flow = false;
     alproto = AppLayerProtoDetectGetProto(alpd_tctx,
                                           &f,
                                           smbbuf1, smblen1,
-                                          IPPROTO_TCP, STREAM_TOSERVER);
+                                          IPPROTO_TCP, STREAM_TOSERVER, &reverse_flow);
     if (alproto != ALPROTO_UNKNOWN) {
         printf("alproto is %"PRIu16 ".  Should be ALPROTO_UNKNOWN\n",
                alproto);
@@ -2311,7 +2313,7 @@ static int SMBParserTest05(void)
     alproto = AppLayerProtoDetectGetProto(alpd_tctx,
                                           &f,
                                           smbbuf2, smblen2,
-                                          IPPROTO_TCP, STREAM_TOSERVER);
+                                          IPPROTO_TCP, STREAM_TOSERVER, &reverse_flow);
     if (alproto != ALPROTO_SMB) {
         printf("alproto is %"PRIu16 ".  Should be ALPROTO_SMB\n",
                alproto);
@@ -2382,10 +2384,11 @@ static int SMBParserTest06(void)
     AppLayerProtoDetectPrepareState();
     alpd_tctx = AppLayerProtoDetectGetCtxThread();
 
+    bool reverse_flow = false;
     alproto = AppLayerProtoDetectGetProto(alpd_tctx,
                                           &f,
                                           smbbuf1, smblen1,
-                                          IPPROTO_TCP, STREAM_TOSERVER);
+                                          IPPROTO_TCP, STREAM_TOSERVER, &reverse_flow);
     if (alproto != ALPROTO_UNKNOWN) {
         printf("alproto is %"PRIu16 ".  Should be ALPROTO_UNKNOWN\n",
                alproto);
@@ -2395,7 +2398,7 @@ static int SMBParserTest06(void)
     alproto = AppLayerProtoDetectGetProto(alpd_tctx,
                                           &f,
                                           smbbuf2, smblen2,
-                                          IPPROTO_TCP, STREAM_TOSERVER);
+                                          IPPROTO_TCP, STREAM_TOSERVER, &reverse_flow);
     if (alproto != ALPROTO_SMB) {
         printf("alproto is %"PRIu16 ".  Should be ALPROTO_SMB\n",
                alproto);

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2624,7 +2624,8 @@ static void SSLStateTransactionFree(void *state, uint64_t tx_id)
     /* do nothing */
 }
 
-static uint16_t SSLProbingParser(Flow *f, uint8_t *input, uint32_t ilen)
+static AppProto SSLProbingParser(Flow *f, uint8_t direction,
+        uint8_t *input, uint32_t ilen, uint8_t *rdir)
 {
     /* probably a rst/fin sending an eof */
     if (ilen == 0)

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -194,7 +194,8 @@ static AppLayerDecoderEvents *TemplateGetEvents(void *statev, uint64_t tx_id)
  * \retval ALPROTO_TEMPLATE if it looks like template, otherwise
  *     ALPROTO_UNKNOWN.
  */
-static AppProto TemplateProbingParser(Flow *f, uint8_t *input, uint32_t input_len)
+static AppProto TemplateProbingParser(Flow *f, uint8_t direction,
+        uint8_t *input, uint32_t input_len, uint8_t *rdir)
 {
     /* Very simple test - if there is input, this is template. */
     if (input_len >= TEMPLATE_MIN_FRAME_LEN) {

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -112,7 +112,8 @@ static AppLayerDecoderEvents *TFTPGetEvents(void *state, uint64_t tx_id)
  * \retval ALPROTO_TFTP if it looks like echo, otherwise
  *     ALPROTO_UNKNOWN.
  */
-static AppProto TFTPProbingParser(Flow *f, uint8_t *input, uint32_t input_len)
+static AppProto TFTPProbingParser(Flow *f, uint8_t direction,
+        uint8_t *input, uint32_t input_len, uint8_t *rdir)
 {
     /* Very simple test - if there is input, this is tftp.
      * Also check if it's starting by a zero */


### PR DESCRIPTION
When Suricata picks up a flow it assumes the first packet is
toserver. In a perfect world without packet loss and where all
sessions neatly start after Suricata itself started, this would be
true. However, in reality we have to account for packet loss and
Suricata starting to get packets for flows already active be for
Suricata is (re)started.

The protocol records on the wire would often be able to tell us more
though. For example in SMB1 and SMB2 records there is a flag that
indicates whether the record is a request or a response. This patch
is enabling the procotol detection engine to utilize this information
to 'reverse' the flow.

There are three ways in which this is supported in this patch:

1. patterns for detection are registered per direction. If the proto
   was not recognized in the traffic direction, and midstream is
   enabled, the pattern set for the opposing direction is also
   evaluated. If that matches, the flow is considered to be in the
   wrong direction and is reversed.

2. probing parsers now have a way to feed back their understanding
   of the flow direction. They are now passed the direction as
   Suricata sees the traffic when calling the probing parsers. The
   parser can then see if its own observation matches that, and
   pass back it's own view to the caller.

3. a new pattern + probing parser set up: probing parsers can now
   be registered with a pattern, so that when the pattern matches
   the probing parser is called as well. The probing parser can
   then provide the protocol detection engine with the direction
   of the traffic.

The process of reversing takes a multi step approach as well:

a. reverse the current packets direction
b. reverse most of the flows direction sensitive flags
c. tag the flow as 'reversed'. This is because the 5 tuple is
   *not* reversed, since it is immutable after the flows creation.

Most of the currently registered parsers benefit already:

- HTTP/SMTP/FTP/TLS patterns are registered per direction already
  so they will benefit from the pattern midstream logic in (1)
  above.

- the Rust based SMB parser uses a mix of pattern + probing parser
  as described in (3) above.

- the NFS detection is purely done by probing parser and is updated
  to consider the direction in that parser.

Other protocols, such as DNS, are still to do.

Ticket: #2572

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/240
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/242

