### PR TITLE
Add NULL pointer guard on fclose when reopening.

### DIFF
--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -500,7 +500,9 @@ int SCConfLogReopen(LogFileCtx *log_ctx)
         return -1;
     }
 
-    fclose(log_ctx->fp);
+    if (log_ctx->fp != NULL) {
+        fclose(log_ctx->fp);
+    }
 
     /* Reopen the file. Append is forced in case the file was not
      * moved as part of a rotation process. */


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Fix segfault on logrotate

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable): N/A

