### PR TITLE
ftp: Improved FTP active mode handling

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -520,7 +520,7 @@ static int FTPParseRequest(Flow *f, void *ftp_state,
                         SCReturnInt(-1);
                     } else {
                         SCLogDebug("Expectation created [direction: %s, dynamic port %"PRIu16"].",
-                            direction == STREAM_TOCLIENT ? "to client" : "to server",
+                            state->active ? "to server" : "to client",
                             state->dyn_port);
                     }
 

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -78,7 +78,8 @@ typedef enum {
     FTP_COMMAND_SYST,
     FTP_COMMAND_TYPE,
     FTP_COMMAND_UMASK,
-    FTP_COMMAND_USER
+    FTP_COMMAND_USER,
+    FTP_COMMAND_EPRT
     /** \todo more if missing.. */
 } FtpRequestCommand;
 typedef uint32_t FtpRequestCommandArgOfs;
@@ -115,6 +116,7 @@ typedef struct FtpState_ {
     uint8_t *input;
     int32_t input_len;
     uint8_t direction;
+    uint8_t active;
 
     /* --parser details-- */
     /** current line extracted by the parser from the call to FTPGetline() */

--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -47,7 +47,7 @@
     (dst).len  = (src).len; \
     (dst).data = (src).data
 
-static int DecodeTCPOptions(Packet *p, uint8_t *pkt, uint16_t pktlen)
+static void DecodeTCPOptions(Packet *p, uint8_t *pkt, uint16_t pktlen)
 {
     uint8_t tcp_opt_cnt = 0;
     TCPOpt tcp_opts[TCP_OPTMAX];
@@ -77,7 +77,7 @@ static int DecodeTCPOptions(Packet *p, uint8_t *pkt, uint16_t pktlen)
              * Also check for invalid lengths 0 and 1. */
             if (unlikely(olen > plen || olen < 2)) {
                 ENGINE_SET_INVALID_EVENT(p, TCP_OPT_INVALID_LEN);
-                return -1;
+                return;
             }
 
             tcp_opts[tcp_opt_cnt].type = type;
@@ -158,7 +158,6 @@ static int DecodeTCPOptions(Packet *p, uint8_t *pkt, uint16_t pktlen)
             tcp_opt_cnt++;
         }
     }
-    return 0;
 }
 
 static int DecodeTCPPacket(ThreadVars *tv, Packet *p, uint8_t *pkt, uint16_t len)

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -811,7 +811,7 @@ static int SigParseProto(Signature *s, const char *protostr)
         else {
             SCLogError(SC_ERR_UNKNOWN_PROTOCOL, "protocol \"%s\" cannot be used "
                        "in a signature.  Either detection for this protocol "
-                       "supported yet OR detection has been disabled for "
+                       "is not yet supported OR detection has been disabled for "
                        "protocol through the yaml option "
                        "app-layer.protocols.%s.detection-enabled", protostr,
                        protostr);


### PR DESCRIPTION
Link to redmine ticket:

https://redmine.openinfosecfoundation.org/issues/2459
https://redmine.openinfosecfoundation.org/issues/2527
Describe changes:

- Detect FTP active mode over IPv4 and IPv6
- Create expectation based on mode
- Remove return type from TCP, ipv4 options and update tests
- Improve unknown protocol message

Suricata-verify tests: https://github.com/OISF/suricata-verify/pull/28