### PR TITLE
source-nflog: fix memleaks

### DIFF
--- a/src/source-nflog.c
+++ b/src/source-nflog.c
@@ -368,6 +368,14 @@ TmEcode ReceiveNFLOGThreadDeinit(ThreadVars *tv, void *data)
         ntv->h = NULL;
     }
 
+    if (ntv->data != NULL) {
+        SCFree(ntv->data);
+        ntv->data = NULL;
+    }
+    ntv->datalen = 0;
+
+    SCFree(ntv);
+
     SCReturnInt(TM_ECODE_OK);
 }
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2912

Describe changes:
This fixes two memleaks found with ASAN.

```
Direct leak of 96 byte(s) in 1 object(s) allocated from:
   #0 0x7f59cf4a4d28 in malloc (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xc1d28)
   #1 0xd7f92f in ReceiveNFLOGThreadInit /home/glongo/suricata/src/source-nflog.c:221
   #2 0xe9c8eb in TmThreadsSlotPktAcqLoop /home/glongo/suricata/src/tm-threads.c:293
   #3 0x7f59cd7aa4a3 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x74a3)

Indirect leak of 70000 byte(s) in 1 object(s) allocated from:
   #0 0x7f59cf4a4d28 in malloc (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xc1d28)
   #1 0xd814ea in ReceiveNFLOGThreadInit /home/glongo/suricata/src/source-nflog.c:324
   #2 0xe9c8eb in TmThreadsSlotPktAcqLoop /home/glongo/suricata/src/tm-threads.c:293
   #3 0x7f59cd7aa4a3 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x74a3)

SUMMARY: AddressSanitizer: 70096 byte(s) leaked in 2 allocation(s).
```

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/207
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/71
