### PR TITLE
doc: Add manpages for suricatasc and suricatactl

### DIFF
--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -289,7 +289,13 @@ latex_documents = [
 man_pages = [
     # (master_doc, 'suricata', u'Suricata Documentation',
     #  [author], 1)
-    ("manpages/suricata", "suricata", "Suricata", [], 1)
+    ("manpages/suricata", "suricata", "Suricata", [], 1),
+    ("manpages/suricatasc", "suricatasc",
+     "Tool to interact via unix socket", [], 1),
+    ("manpages/suricatactl", "suricatactl",
+     "Suricata Control", [], 1),
+    ("manpages/suricatactl-filestore", "suricatactl-filestore",
+     "Perform actions on filestore", [], 1),
 ]
 
 # If true, show URL addresses after external links.

--- a/doc/userguide/manpages/index.rst
+++ b/doc/userguide/manpages/index.rst
@@ -5,3 +5,6 @@ Man Pages
    :maxdepth: 1
 
    suricata
+   suricatasc
+   suricatactl
+   suricatactl-filestore

--- a/doc/userguide/manpages/suricatactl-filestore.rst
+++ b/doc/userguide/manpages/suricatactl-filestore.rst
@@ -1,0 +1,67 @@
+Suricata Control Filestore
+==========================
+
+SYNOPSIS
+--------
+
+**suricatactl filestore** [-h] <command> [<args>]
+
+DESCRIPTION
+-----------
+
+This command lets you perform certain operations on Suricata filestore.
+
+
+OPTIONS
+--------
+
+.. Basic options
+
+.. option:: -h
+
+Get help about the available commands.
+
+
+COMMANDS
+---------
+
+**prune [-h|--help] [-n|--dry-run] [-v|verbose] [-q|--quiet] -d <DIRECTORY>
+--age <AGE>**
+
+Prune files older than a given age.
+
+-d <DIRECTORY> | --directory <DIRECTORY> is a required argument which tells
+that user must provide the suricata filestore directory on which all the
+specified operations are to be performed.
+
+--age <AGE> is a required argument asking the age of the files. Files older
+than the age mentioned with this option shall be pruned.
+
+-h | --help is an optional argument with which you can ask for help about the
+command usage.
+
+-n | --dry-run is an optional argument which makes the utility print only what
+would happen
+
+-v | --verbose is an optional argument to increase the verbosity of command.
+
+-q | --quiet is an optional argument that helps log errors and warnings only
+and keep silent about everything else.
+
+
+BUGS
+----
+
+Please visit Suricata's support page for information about submitting
+bugs or feature requests.
+
+NOTES
+-----
+
+* Suricata Home Page
+
+    https://suricata-ids.org/
+
+* Suricata Support Page
+
+    https://suricata-ids.org/support/

--- a/doc/userguide/manpages/suricatactl.rst
+++ b/doc/userguide/manpages/suricatactl.rst
@@ -1,0 +1,43 @@
+Suricata Control
+================
+
+SYNOPSIS
+--------
+
+**suricatactl** [-h] <command> [<args>]
+
+DESCRIPTION
+-----------
+
+This tool helps control Suricata's features.
+
+OPTIONS
+--------
+
+.. Basic options
+
+.. option:: -h
+
+Get help about the available commands.
+
+COMMANDS
+---------
+
+:manpage:`suricatactl-filestore(1)`
+
+BUGS
+----
+
+Please visit Suricata's support page for information about submitting
+bugs or feature requests.
+
+NOTES
+-----
+
+* Suricata Home Page
+
+    https://suricata-ids.org/
+
+* Suricata Support Page
+
+    https://suricata-ids.org/support/

--- a/doc/userguide/manpages/suricatasc.rst
+++ b/doc/userguide/manpages/suricatasc.rst
@@ -1,0 +1,40 @@
+Suricata Socket Control
+=======================
+
+SYNOPSIS
+--------
+
+**suricatasc**
+
+DESCRIPTION
+-----------
+
+Suricata socket control tool
+
+COMMANDS
+---------
+
+.. include:: ../partials/commands-sc.rst
+
+PCAP MODE COMMANDS
+-------------------
+
+.. include:: ../partials/commands-pcap-sc.rst
+
+
+BUGS
+----
+
+Please visit Suricata's support page for information about submitting
+bugs or feature requests.
+
+NOTES
+-----
+
+* Suricata Home Page
+
+    https://suricata-ids.org/
+
+* Suricata Support Page
+
+    https://suricata-ids.org/support/

--- a/doc/userguide/partials/commands-pcap-sc.rst
+++ b/doc/userguide/partials/commands-pcap-sc.rst
@@ -1,0 +1,32 @@
+.. option:: pcap-file <file> <dir> [tenant] [continuous] [delete-when-done]
+
+   Add pcap files to Suricata for sequential processing. The generated
+   log/alert files will be put into the directory specified as second argument.
+   Make sure to provide absolute path to the files and directory. It is
+   acceptable to add multiple files without waiting the result.
+
+.. option:: pcap-file-continuous <file> <dir> [tenant] [delete-when-done]
+
+   Add pcap files to Suricata for sequential processing. Directory will be
+   monitored for new files being added until there is a use of `pcap-interrupt`
+   or directory is moved or deleted.
+
+.. option:: pcap-file-number
+
+   Number of pcap files waiting to get processed.
+
+.. option:: pcap-file-list
+
+   List of queued pcap files.
+
+.. option:: pcap-last-processed
+
+   Processed time of last file in milliseconds since epoch.
+
+.. option:: pcap-interrupt
+
+   Terminate the current state by interrupting directory processing.
+
+.. option:: pcap-current
+
+   Currently processed file.

--- a/doc/userguide/partials/commands-sc.rst
+++ b/doc/userguide/partials/commands-sc.rst
@@ -1,0 +1,112 @@
+.. Start with the most common basic commands.
+
+.. option:: shutdown
+
+   Shut Suricata instance down.
+
+.. option:: command-list
+
+   List available commands.
+
+.. option:: help
+
+   Get help about the available commands.
+
+.. option:: version
+
+   Print the version of Suricata instance.
+
+.. option:: uptime
+
+   Display the uptime of Suricata.
+
+.. option:: running-mode
+
+   Display running mode. This can either be *workers*, *autofp* or *simple*.
+
+.. option:: capture-mode
+
+   Display the capture mode. This can either be *UNIX_SOCKET* or
+   *AF_PACKET_DEV*.
+
+.. option:: conf-get <variable>
+
+   Get configuration item for a given variable.
+
+.. option:: dump-counters
+
+   Dump Suricata's performance counters.
+
+.. option:: ruleset-reload-rules
+
+   Enable capture of packet using AF_PACKET on Linux. If no device is
+   supplied, the list of devices from the af-packet section in the
+   yaml is used.
+
+.. option:: reload-rules
+
+   Alias of option *ruleset-reload-rules*.
+
+.. option:: ruleset-reload-nonblocking
+
+   Reload ruleset and proceed without waiting.
+
+.. option:: ruleset-reload-time
+
+   Return time of last reload.
+
+.. option:: ruleset-stats
+
+   Display the number of rules loaded and failed.
+
+.. option:: ruleset-failed-rules
+
+   Display the list of failed rules.
+
+.. option:: register-tenant-handler <id> <htype> [hargs]
+
+   Register a tenant handler with the specified mapping.
+
+.. option:: unregister-tenant-handler <id> <htype> [hargs]
+
+   Unregister a tenant handler with the specified mapping.
+
+.. option:: register-tenant <id> <filename>
+
+   Register tenant with a particular ID and filename.
+
+.. option:: reload-tenant <id> <filename>
+
+   Reload a tenant with specified ID and filename.
+
+.. option:: unregister-tenant <id>
+
+   Unregister tenant with a particular ID.
+
+.. option:: add-hostbit <ipaddress> <hostbit> <expire>
+
+   Add hostbit on a host IP with a particular bit name and time of expiry.
+
+.. option:: remove-hostbit <ipaddress> <hostbit>
+
+   Remove hostbit on a host IP with specified IP address and bit name.
+
+.. option:: list-hostbit <ipaddress>
+
+   List hostbit for a particular host IP.
+
+.. option:: reopen-log-files
+
+   Reopen log files to be run after external log rotation.
+
+.. option:: memcap-set <config> <memcap>
+
+   Update memcap value of a specified item.
+
+.. option:: memcap-show <config>
+
+   Show memcap value of a specified item.
+
+.. option:: memcap-list
+
+   List all memcap values available.


### PR DESCRIPTION
Add the missing manpages and the corresponding Sphinx configuration
for the command line tools `suricatasc` and `suricatactl`.

These manpages have been given the structure following the manpages for `git-submodules`.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/884