### PR TITLE
pfring: update PfringThreadVars_ for gcc 4.x

### DIFF
--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -120,7 +120,7 @@ static SCMutex pfring_bpf_set_filter_lock = SCMUTEX_INITIALIZER;
 /**
  * \brief Structure to hold thread specific variables.
  */
-typedef struct PfringThreadVars_
+struct PfringThreadVars_
 {
     /* thread specific handle */
     pfring *pd;
@@ -154,7 +154,7 @@ typedef struct PfringThreadVars_
      ChecksumValidationMode checksum_mode;
 
     bool vlan_hdr_warned;
-} PfringThreadVars;
+};
 
 /**
  * \brief Registration Function for RecievePfring.


### PR DESCRIPTION
Signed-off-by: jason taylor <jtfas90@gmail.com>

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2899

Describe changes:
- In the 4.4.7 version of gcc on el6 there is stricter checking via -pedantic than newer versions. This change removes the duplicate typedef keyword and relies on the definition in the header file.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

