### PR TITLE
Make Rust, and libjansson required - v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ addons:
       - libnfnetlink-dev
       - libnfnetlink0
       - libhiredis-dev
-      - libjansson-dev
       - libevent-dev
       - libevent-pthreads-2.0-5
     # Now define the default set of packages which is those above, and
@@ -166,8 +165,9 @@ matrix:
     - os: linux
       compiler: gcc
       env:
-        - NAME="linux,gcc,no-json"
+        - NAME="linux,gcc,no-jansson"
         - *default-cflags
+        - CONFIGURE_SHOULD_FAIL="yes"
       addons:
         apt:
           packages:
@@ -182,14 +182,22 @@ matrix:
         - *default-cflags
 
 script:
-  - sh ./autogen.sh
   - |
+    sh ./autogen.sh
+
     if [[ "${NO_UNITTESTS}" != "yes" ]]; then
         ARGS="${ARGS} --enable-unittests"
     fi
+
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         export CFLAGS="${CFLAGS} ${EXTRA_CFLAGS}"
-        ./configure --enable-nfqueue --enable-hiredis ${ARGS}
+        if ! ./configure --enable-nfqueue --enable-hiredis ${ARGS}; then
+            if [[ "${CONFIGURE_SHOULD_FAIL}" = "yes" ]]; then
+                EXIT_CODE=0
+            else
+                EXIT_CODE=1
+            fi
+        fi
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         export CFLAGS="${CFLAGS} ${EXTRA_CFLAGS}"
         ./configure --enable-hiredis --enable-ipfw \
@@ -201,13 +209,17 @@ script:
             --with-libnspr-includes=/usr/local/opt/nspr/include/nspr \
             --with-libnspr-libraries=/usr/local/opt/nspr/lib ${ARGS}
     fi
-  - |
+
+    if [[ "${EXIT_CODE}" ]]; then
+        exit "${EXIT_CODE}"
+    fi
+
     # Linux container builds have 2 cores, make use of them.
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         j="-j 2"
     fi
     make ${j}
-  - |
+
     # Like "make check", but fail on first error. We redirect the output
     # so Travis doesn't fail the build with a too much output error.
     if [[ "${NO_UNITTESTS}" != "yes" ]]; then
@@ -219,16 +231,17 @@ script:
             exit 1
         fi
     fi
+
     (cd qa/coccinelle && make check)
-  - |
+
     if [[ "$DO_DISTCHECK" == "yes" ]]; then
         make distcheck DISTCHECK_CONFIGURE_FLAGS="${ARGS}"
     fi
-  - |
+
     if [[ "$DO_CHECK_SETUP_SCRIPTS" == "yes" ]]; then
         (cd scripts && ./check-setup.sh)
     fi
-  - |
+
     git clone https://github.com/OISF/suricata-verify.git verify
     python ./verify/run.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ matrix:
     - env:
         - NAME="linux,gcc,rust-stable"
         - *default-cflags
-        - ENABLE_RUST="yes"
         - RUST_VERSION="stable"
         - ARGS="--enable-rust --enable-rust-strict"
         - DO_CHECK_SETUP_SCRIPTS="yes"
@@ -84,7 +83,6 @@ matrix:
       env:
         - NAME="linux,gcc,rust-stable"
         - *default-cflags
-        - ENABLE_RUST="yes"
         - RUST_VERSION="stable"
         - ARGS="--enable-rust --enable-rust-strict"
         - DO_CHECK_SETUP_SCRIPTS="yes"
@@ -96,7 +94,6 @@ matrix:
       env:
         - NAME="linux,gcc,rust-1.31.0-disabled"
         - *default-cflags
-        - ENABLE_RUST="yes"
         - RUST_VERSION="1.31.0"
         - ARGS="--disable-rust"
         - DO_DISTCHECK="yes"
@@ -107,7 +104,6 @@ matrix:
       env:
         - NAME="linux,gcc,rust-1.31.0-auto"
         - *default-cflags
-        - ENABLE_RUST="yes"
         - RUST_VERSION="1.31.0"
         - ARGS=""
         - DO_DISTCHECK="yes"
@@ -118,7 +114,6 @@ matrix:
       env:
         - NAME="linux,gcc,rust-1.31.0"
         - *default-cflags
-        - ENABLE_RUST="yes"
         - RUST_VERSION="1.31.0"
         - ARGS="--enable-rust --enable-rust-strict"
         - DO_DISTCHECK="yes"
@@ -128,7 +123,6 @@ matrix:
       env:
         - NAME="linux,gcc,rust-1.24.1"
         - *default-cflags
-        - ENABLE_RUST="yes"
         - RUST_VERSION="1.24.1"
         - ARGS="--enable-rust --enable-rust-strict"
         - DO_DISTCHECK="yes"
@@ -248,13 +242,11 @@ script:
 before_install:
   - export PATH=$HOME/.cargo/bin:$PATH
   - |
-    if [[ "$ENABLE_RUST" == "yes" ]]; then
-        curl https://sh.rustup.rs -sSf | sh -s -- -y
-        if [[ "$RUST_VERSION" != "" ]]; then
-            rustup override set $RUST_VERSION
-        fi
-        rustc --version
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+    if [[ "$RUST_VERSION" != "" ]]; then
+        rustup override set $RUST_VERSION
     fi
+    rustc --version
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         brew update

--- a/configure.ac
+++ b/configure.ac
@@ -886,7 +886,6 @@
     fi
 
   # libjansson
-    enable_jansson="no"
     AC_ARG_WITH(libjansson_includes,
             [  --with-libjansson-includes=DIR  libjansson include directory],
             [with_libjansson_includes="$withval"],[with_libjansson_includes=no])
@@ -898,19 +897,34 @@
         CPPFLAGS="${CPPFLAGS} -I${with_libjansson_includes}"
     fi
 
-    enable_jansson="no"
+    if test "$with_libjansson_libraries" != "no"; then
+        LDFLAGS="${LDFLAGS}  -L${with_libjansson_libraries}"
+    fi
+
+    AC_CHECK_HEADER(jansson.h,JANSSON="yes",JANSSON="no")
+    AC_CHECK_LIB(jansson, json_dump_callback,, JANSSON="no")
+
+    if test "$JANSSON" = "no"; then
+       echo ""
+       echo "    ERROR: Jannson is now required."
+       echo ""
+       echo "    Go get it from your distribution or from:"
+       echo "      http://www.digip.org/jansson/"
+       echo ""
+       echo "    Ubuntu/Debian: apt install libjansson-dev"
+       echo "    CentOS: yum install jansson-devel"
+       echo "    Fedora: dnf install jansson-devel"
+       echo ""
+       exit 1
+    fi
+
+    enable_jansson="yes"
     enable_unixsocket="no"
 
     AC_ARG_ENABLE(unix-socket,
            AS_HELP_STRING([--enable-unix-socket], [Enable unix socket [default=test]]),[enable_unixsocket="$enableval"],[enable_unixsocket=test])
 
-    AC_CHECK_HEADER(jansson.h,JANSSON="yes",JANSSON="no")
     if test "$JANSSON" = "yes"; then
-        if test "$with_libjansson_libraries" != "no"; then
-            LDFLAGS="${LDFLAGS}  -L${with_libjansson_libraries}"
-        fi
-
-	    AC_CHECK_LIB(jansson, json_dump_callback,, JANSSON="no")
         enable_jansson="yes"
         if test "$JANSSON" = "no"; then
             echo

--- a/configure.ac
+++ b/configure.ac
@@ -2345,120 +2345,73 @@ fi
     fi
     AM_CONDITIONAL([HAVE_PDFLATEX], [test "x$enable_pdflatex" != "xno"])
 
-# Cargo/Rust.
-    AC_ARG_ENABLE([rust], AS_HELP_STRING([--enable-rust], [Enable Rust support]),
-            [enable_rust="$enableval"], [enable_rust="yes (default)"])
+# Cargo/Rust
+    AC_PATH_PROG(RUSTC, rustc, "no")
+    if test "RUSTC" = "no"; then
+        echo ""
+        echo "    ERROR: Suricata now requires Rust to build."
+        echo ""
+        echo "    Ubuntu/Debian: apt install rustc cargo"
+        echo "    Fedora: dnf install rustc cargo"
+        echo "    CentOS: yum install rustc cargo (requires EPEL)"
+        echo ""
+        echo "    Rustup works as well: https://rustup.rs/"
+        echo ""
+        exit 1
+    fi
 
-    rust_config_enabled="no"        # used in suricata.yaml.in to enable/disable app-layers
-    rust_config_comment="#"         # used in suricata.yaml.in to enable/disable eve loggers
+    AC_PATH_PROG(CARGO, cargo, "no")
+    if test "CARGO" = "no"; then
+        AC_MSG_ERROR([cargo required])
+    fi
+
+    AC_DEFINE([HAVE_RUST],[1],[Enable Rust language])
+    AM_CONDITIONAL([HAVE_RUST],true)
+    AC_SUBST([CARGO], [$CARGO])
+
+    enable_rust="yes"
+    rust_compiler_version=$($RUSTC --version)
+    rust_cargo_version=$($CARGO --version)
+
     rust_vendor_comment="# "
     have_rust_vendor="no"
     rust_compiler_version="not set"
     rust_cargo_version="not set"
 
-
-    if test "x$enable_rust" != "xyes" && test "x$enable_rust" != "xyes (default)"; then
-      enable_rust="no"
-    elif test "x$enable_python" != "xyes" && test ! -f rust/gen/c-headers/rust-core-gen.h; then
-      if test "x$enable_rust" = "xyes"; then
+    # We may require Python if the Rust header stubs are not already
+    # generated.
+    if test "x$enable_python" != "xyes" && test ! -f rust/gen/c-headers/rust-core-gen.h; then
         echo ""
         echo "   ERROR! Rust support requires Python."
         echo
         echo "   Ubuntu: apt install python"
         echo
         exit 1
-      fi
-      enable_rust="no"
-    else
-      # Rust require jansson (json support).
-      if test "x$enable_jansson" = "xno"; then
-        echo ""
-        echo "   ERROR! Rust support requires libjansson."
-        echo
-        echo "   Ubuntu: apt-get install libjansson-dev"
-        echo "   Fedora: dnf install jansson-devel"
-        echo "   CentOS/RHEL: yum install jansson-devel"
-        echo
-        if test "x$enable_rust" = "xyes"; then
-            exit 1
-        fi
-        echo "   Rust support will be disabled."
-        enable_rust="no"
-      fi
-
-      AC_PATH_PROG(HAVE_CARGO, cargo, "no")
-      AC_PATH_PROG(HAVE_RUSTC, rustc, "no")
-
-      # Deal with the case where Rust was requested but rustc or cargo
-      # cannot be found.
-      if test "x$HAVE_CARGO" = "xno"; then
-        echo ""
-        echo "   ERROR! Rust support requested but cargo not found."
-        echo
-        echo "   Ubuntu: apt-get install cargo"
-        echo "   Fedora: dnf install cargo"
-        echo "   CentOS/RHEL: yum install cargo"
-        echo
-        if test "x$enable_rust" = "xyes"; then
-            exit 1
-        fi
-        echo "   Rust support will be disabled."
-        enable_rust="no"
-      fi
-      if test "x$HAVE_RUST" = "xno"; then
-        echo ""
-        echo "   ERROR! Rust support requested but rustc not found."
-        echo
-        echo "   Ubuntu: apt-get install rustc"
-        echo "   Debian <= 9: use rustup to install"
-        echo "   Debian 10: apt-get install rustc"
-        echo "   Fedora: dnf install rust"
-        echo "   CentOS/RHEL: yum install rust"
-        echo
-        if test "x$enable_rust" = "xyes"; then
-            exit 1
-        fi
-        echo "   Rust support will be disabled."
-        enable_rust="no"
-      fi
-
-      if test "x$enable_rust" != "xno"; then
-        if test "x$HAVE_CARGO" != "xno"; then
-          if test "x$HAVE_RUSTC" != "xno"; then
-            AC_DEFINE([HAVE_RUST],[1],[Enable Rust language])
-            if test "x$enable_debug" = "xyes"; then
-              RUST_SURICATA_LIB="../rust/target/debug/${RUST_SURICATA_LIBNAME}"
-            else
-              RUST_SURICATA_LIB="../rust/target/release/${RUST_SURICATA_LIBNAME}"
-            fi
-            RUST_LDADD="${RUST_SURICATA_LIB} ${RUST_LDADD}"
-            CFLAGS="${CFLAGS} -I\${srcdir}/../rust/gen/c-headers"
-            AC_SUBST(RUST_SURICATA_LIB)
-            AC_SUBST(RUST_LDADD)
-            AC_SUBST([CARGO], [$HAVE_CARGO])
-            if test "x$CARGO_HOME" = "x"; then
-              AC_SUBST([CARGO_HOME], [~/.cargo])
-            else
-	          AC_SUBST([CARGO_HOME], [$CARGO_HOME])
-            fi
-            AC_CHECK_FILES([$srcdir/rust/vendor], [have_rust_vendor="yes"])
-            if test "x$have_rust_vendor" = "xyes"; then
-	          rust_vendor_comment=""
-            fi
-
-            rust_config_enabled="yes"
-            rust_config_comment=""
-            rust_compiler_version=$(rustc --version)
-            rust_cargo_version=$(cargo --version)
-          fi
-        fi
-      fi
     fi
 
-    AM_CONDITIONAL([HAVE_RUST], [test "x$enable_rust" = "xyes" || test "x$enable_rust" = "xyes (default)"])
+    if test "x$enable_debug" = "xyes"; then
+      RUST_SURICATA_LIB="../rust/target/debug/${RUST_SURICATA_LIBNAME}"
+    else
+      RUST_SURICATA_LIB="../rust/target/release/${RUST_SURICATA_LIBNAME}"
+    fi
+    RUST_LDADD="${RUST_SURICATA_LIB} ${RUST_LDADD}"
+    CFLAGS="${CFLAGS} -I\${srcdir}/../rust/gen/c-headers"
+    AC_SUBST(RUST_SURICATA_LIB)
+    AC_SUBST(RUST_LDADD)
+    if test "x$CARGO_HOME" = "x"; then
+      AC_SUBST([CARGO_HOME], [~/.cargo])
+    else
+      AC_SUBST([CARGO_HOME], [$CARGO_HOME])
+    fi
+    AC_CHECK_FILES([$srcdir/rust/vendor], [have_rust_vendor="yes"])
+    if test "x$have_rust_vendor" = "xyes"; then
+      rust_vendor_comment=""
+    fi
+
+    rust_compiler_version=$(rustc --version)
+    rust_cargo_version=$(cargo --version)
+
     AC_SUBST(rust_vendor_comment)
-    AC_SUBST(rust_config_enabled)
-    AC_SUBST(rust_config_comment)
     AM_CONDITIONAL([HAVE_RUST_VENDOR], [test "x$have_rust_vendor" = "xyes"])
 
     if test "x$enable_rust" = "xyes" || test "x$enable_rust" = "xyes (default)"; then

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -165,7 +165,7 @@ outputs:
             deltas: no        # include delta values
         - dhcp:
             # DHCP logging requires Rust.
-            enabled: @rust_config_enabled@
+            enabled: yes
             # When extended mode is on, all DHCP messages are logged
             # with full detail. When extended mode is off (the
             # default), just enough information to map a MAC address

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -223,14 +223,13 @@ outputs:
             #md5: [body, subject]
 
         #- dnp3
-        @rust_config_comment@- nfs
-        @rust_config_comment@- smb
-        @rust_config_comment@- tftp
-        @rust_config_comment@- ikev2
-        @rust_config_comment@- krb5
+        - nfs
+        - smb
+        - tftp
+        - ikev2
+        - krb5
         - dhcp:
-            # DHCP logging requires Rust.
-            enabled: @rust_config_enabled@
+            enabled: yes
             # When extended mode is on, all DHCP messages are logged
             # with full detail. When extended mode is off (the
             # default), just enough information to map a MAC address
@@ -761,7 +760,7 @@ pcap-file:
 app-layer:
   protocols:
     krb5:
-      enabled: @rust_config_enabled@
+      enabled: yes
     ikev2:
       enabled: yes
     tls:
@@ -826,8 +825,6 @@ app-layer:
       enabled: detection-only
     msn:
       enabled: detection-only
-    # Note: --enable-rust is required for full SMB1/2 support. W/o rust
-    # only minimal SMB1 support is available.
     smb:
       enabled: yes
       detection-ports:
@@ -836,12 +833,10 @@ app-layer:
       # Stream reassembly size for SMB streams. By default track it completely.
       #stream-depth: 0
 
-    # Note: NFS parser depends on Rust support: pass --enable-rust
-    # to configure.
     nfs:
-      enabled: @rust_config_enabled@
+      enabled: yes
     tftp:
-      enabled: @rust_config_enabled@
+      enabled: yes
     dns:
       # memcaps. Globally and per flow/state.
       #global-memcap: 16mb
@@ -1012,12 +1007,11 @@ app-layer:
         dp: 44818
         sp: 44818
 
-    # Note: parser depends on Rust support
     ntp:
-      enabled: @rust_config_enabled@
+      enabled: yes
 
     dhcp:
-      enabled: @rust_config_enabled@
+      enabled: yes
 
 # Limit for the maximum number of asn1 frames to decode (default 256)
 asn1-max-frames: 256


### PR DESCRIPTION
This PR makes libjansson and Rust required. As a first cut it does about the minimum in configure.in to make both required without rippling into everywhere conditions are checked for jansson and Rust being enabled.

Travis CI tests have been updated to require Rust.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- Build failure for jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/347
- Build failure for jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/701
