### PR TITLE
http: logs content range

### DIFF
--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -261,6 +261,13 @@ static void JsonHttpLogJSONBasic(json_t *js, htp_tx_t *tx)
                 *p = '\0';
             json_object_set_new(js, "http_content_type", SCJsonString(string));
         }
+        htp_header_t *h_content_range = htp_table_get_c(tx->response_headers, "content-range");
+        if (h_content_range != NULL) {
+            const size_t size = bstr_len(h_content_range->value) * 2 + 1;
+            char string[size];
+            BytesToStringBuffer(bstr_ptr(h_content_range->value), bstr_len(h_content_range->value), string, size);
+            json_object_set_new(js, "http_content_range", SCJsonString(string));
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #2485

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2485

Describe changes:
- Logs http content-range header value (in responses) in json output

This is a first easy step to provide the data.
Maybe it makes more sense to transfer it in the `fileinfo` section

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range for 