### PR TITLE
log: output file mode in octal on chmod warning

### DIFF
--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -285,7 +285,7 @@ SCLogOpenFileFp(const char *path, const char *append_setting, uint32_t mode)
         if (mode != 0) {
             int r = chmod(filename, mode);
             if (r < 0) {
-                SCLogWarning(SC_WARN_CHMOD, "Could not chmod %s to %u: %s",
+                SCLogWarning(SC_WARN_CHMOD, "Could not chmod %s to %o: %s",
                              filename, mode, strerror(errno));
             }
         }


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2921

Describe changes:
- The mode input in chmod is an octal integer. However when the warning is logged,
the file mode is printed in decimal which is confusing.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable): N/A

