### PR TITLE
Feat/user mode/v4

### DIFF
--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -823,7 +823,7 @@ void RunModeInitializeOutputs(void)
                 OutputInitResult r = module->InitFunc(output_config);
                 if (!r.ok) {
                     FatalErrorOnInit(SC_ERR_INVALID_ARGUMENT,
-                        "output module setup failed");
+                        "output module \"%s\": setup failed", output->val);
                     continue;
                 } else if (r.ctx == NULL) {
                     continue;

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -492,6 +492,19 @@ int RunModeOutputFiledataEnabled(void)
     return filedata_logger_count > 0;
 }
 
+bool IsRunModeSystem(enum RunModes run_mode_to_check)
+{
+    switch (run_mode_to_check) {
+        case RUNMODE_PCAP_FILE:
+        case RUNMODE_ERF_FILE:
+        case RUNMODE_ENGINE_ANALYSIS:
+            return false;
+            break;
+        default:
+            return true;
+    }
+}
+
 bool IsRunModeOffline(int run_mode_to_check)
 {
     switch(run_mode_to_check) {

--- a/src/runmodes.h
+++ b/src/runmodes.h
@@ -90,6 +90,7 @@ int RunModeOutputFileEnabled(void);
 int RunModeOutputFiledataEnabled(void);
 /** bool indicating if run mode is offline */
 bool IsRunModeOffline(int run_mode_to_check);
+bool IsRunModeSystem(enum RunModes run_mode_to_check);
 
 void RunModeEnablesBypassManager(void);
 int RunModeNeedsBypassManager(void);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1058,14 +1058,18 @@ static TmEcode PrintVersion(void)
     return TM_ECODE_OK;
 }
 
-static TmEcode LogVersion(void)
+static TmEcode LogVersion(SCInstance *suri)
 {
+    const char *mode = suri->system ? "SYSTEM" : "USER";
 #ifdef REVISION
-    SCLogNotice("This is %s version %s (rev %s)", PROG_NAME, PROG_VER, xstr(REVISION));
+    SCLogNotice("This is %s version %s (rev %s) running in %s mode",
+            PROG_NAME, PROG_VER, xstr(REVISION), mode);
 #elif defined RELEASE
-    SCLogNotice("This is %s version %s RELEASE", PROG_NAME, PROG_VER);
+    SCLogNotice("This is %s version %s RELEASE running in %s mode",
+            PROG_NAME, PROG_VER, mode);
 #else
-    SCLogNotice("This is %s version %s", PROG_NAME, PROG_VER);
+    SCLogNotice("This is %s version %s running in %s mode",
+            PROG_NAME, PROG_VER, mode);
 #endif
     return TM_ECODE_OK;
 }
@@ -2952,7 +2956,7 @@ int main(int argc, char **argv)
      * logging module. */
     SCLogLoadConfig(suricata.daemon, suricata.verbose);
 
-    LogVersion();
+    LogVersion(&suricata);
     UtilCpuPrintSummary();
 
     if (ParseInterfacesList(suricata.aux_run_mode, suricata.pcap_dev) != TM_ECODE_OK) {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2096,6 +2096,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         suri->run_mode = RUNMODE_ENGINE_ANALYSIS;
 
     suri->offline = IsRunModeOffline(suri->run_mode);
+    suri->system = IsRunModeSystem(suri->run_mode);
 
     ret = SetBpfString(optind, argv);
     if (ret != TM_ECODE_OK)

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -150,7 +150,10 @@ typedef struct SCInstance_ {
     uint32_t userid;
     uint32_t groupid;
 #endif /* OS_WIN32 */
+
     bool system;
+    bool set_logdir;
+
     int delayed_detect;
     int disabled_detect;
     int daemon;

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -150,6 +150,7 @@ typedef struct SCInstance_ {
     uint32_t userid;
     uint32_t groupid;
 #endif /* OS_WIN32 */
+    bool system;
     int delayed_detect;
     int disabled_detect;
     int daemon;

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -99,7 +99,7 @@ typedef enum {
 #define SC_LOG_DEF_LOG_OP_IFACE SC_LOG_OP_IFACE_CONSOLE
 
 /* The default log file to be used */
-#define SC_LOG_DEF_LOG_FILE "sc_ids_log.log"
+#define SC_LOG_DEF_LOG_FILE "suricata.log"
 
 /* The default syslog facility to be used */
 #define SC_LOG_DEF_SYSLOG_FACILITY_STR "local0"

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -133,11 +133,9 @@ static int SCLogFileWriteSocket(const char *buffer, int buffer_len,
     int tries = 0;
     int ret = 0;
     bool reopen = false;
-#ifdef BUILD_WITH_UNIXSOCKET
     if (ctx->fp == NULL && ctx->is_sock) {
         SCLogUnixSocketReconnect(ctx);
     }
-#endif
 tryagain:
     ret = -1;
     reopen = 0;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -596,7 +596,7 @@ logging:
   - file:
       enabled: yes
       level: info
-      filename: @e_logdir@suricata.log
+      filename: suricata.log
       # type: json
   - syslog:
       enabled: no


### PR DESCRIPTION
Add a distinction between SYSTEM and USER modes when running. This is based on the runmode, where reading a pcap leads to user mode.

Currently the only consequence of the user mode is that the default-log-dir from the yaml is ignored and is set to '.' instead. If -l is used on the commandline, that still takes precedence.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/245
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/247

