### PR TITLE
sticky: Modernize TLS keywords

### DIFF
--- a/doc/userguide/rules/ja3-keywords.rst
+++ b/doc/userguide/rules/ja3-keywords.rst
@@ -5,7 +5,7 @@ Suricata comes with a JA3 integration (https://github.com/salesforce/ja3). JA3 i
 
 JA3 must be enabled in the Suricata config file (set 'app-layer.protocols.tls.ja3-fingerprints' to 'yes').
 
-ja3_hash
+ja3.hash
 --------
 
 Match on JA3 hash (md5).
@@ -13,14 +13,18 @@ Match on JA3 hash (md5).
 Example::
 
   alert tls any any -> any any (msg:"match JA3 hash"; \
-      ja3_hash; content:"e7eca2baf4458d095b7f45da28c16c34"; \
+      ja3.hash; content:"e7eca2baf4458d095b7f45da28c16c34"; \
       sid:100001;)
 
-``ja3_hash`` is a 'Sticky buffer'.
+``ja3.hash`` is a 'Sticky buffer'.
 
-``ja3_hash`` can be used as ``fast_pattern``.
+``ja3.hash`` can be used as ``fast_pattern``.
 
-ja3_string
+``ja3.hash`` replaces the previous keyword name: ``ja3_hash``. You may continue
+to use the previous name, but it's recommended that rules be converted to use
+the new name.
+
+ja3.string
 ----------
 
 Match on JA3 string.
@@ -28,9 +32,13 @@ Match on JA3 string.
 Example::
 
   alert tls any any -> any any (msg:"match JA3 string"; \
-      ja3_string; content:"19-20-21-22"; \
+      ja3.string; content:"19-20-21-22"; \
       sid:100002;)
 
-``ja3_string`` is a 'Sticky buffer'.
+``ja3.string`` is a 'Sticky buffer'.
 
-``ja3_string`` can be used as ``fast_pattern``.
+``ja3.string`` can be used as ``fast_pattern``.
+
+``ja3.string`` replaces the previous keyword name: ``ja3_string``. You may continue
+to use the previous name, but it's recommended that rules be converted to use
+the new name.

--- a/doc/userguide/rules/ssh-keywords.rst
+++ b/doc/userguide/rules/ssh-keywords.rst
@@ -19,7 +19,7 @@ The example above matches on SSH connections with SSH version 2.
 
 ``ssh.proto`` can be used as ``fast_pattern``.
 
-``ssh.proto`` replaces the previous keyword name: ```ssh_proto``. You may continue
+``ssh.proto`` replaces the previous keyword name: ``ssh_proto``. You may continue
 to use the previous name, but it's recommended that rules be converted to use
 the new name.
 
@@ -39,7 +39,7 @@ The example above matches on SSH connections where the software string contains 
 
 ``ssh.software`` can be used as ``fast_pattern``.
 
-``ssh.software`` replaces the previous keyword name: ```ssh_software``. You may continue
+``ssh.software`` replaces the previous keyword name: ``ssh_software``. You may continue
 to use the previous name, but it's recommended that rules be converted to use
 the new name.
 

--- a/doc/userguide/rules/tls-keywords.rst
+++ b/doc/userguide/rules/tls-keywords.rst
@@ -73,7 +73,7 @@ Example::
 
 ``tls.cert_fingerprint`` can be used as ``fast_pattern``.
 
-``tls.cert_fingerprint`` replaces the previous keyword name: ``tls_cert_fingerprint may continue
+``tls.cert_fingerprint`` replaces the previous keyword name: ``tls_cert_fingerprint`` may continue
 to use the previous name, but it's recommended that rules be converted to use
 the new name.
 

--- a/doc/userguide/rules/tls-keywords.rst
+++ b/doc/userguide/rules/tls-keywords.rst
@@ -3,35 +3,43 @@ SSL/TLS Keywords
 
 Suricata comes with several rule keywords to match on various properties of TLS/SSL handshake. Matches are string inclusion matches.
 
-tls_cert_subject
+tls.cert_subject
 ----------------
 
 Match TLS/SSL certificate Subject field.
 
 Examples::
 
-  tls_cert_subject; content:"CN=*.googleusercontent.com"; isdataat:!1,relative;
-  tls_cert_subject; content:"google.com"; nocase; pcre:"/google.com$/";
+  tls.cert_subject; content:"CN=*.googleusercontent.com"; isdataat:!1,relative;
+  tls.cert_subject; content:"google.com"; nocase; pcre:"/google.com$/";
 
-``tls_cert_subject`` is a 'Sticky buffer'.
+``tls.cert_subject`` is a 'Sticky buffer'.
 
-``tls_cert_subject`` can be used as ``fast_pattern``.
+``tls.cert_subject`` can be used as ``fast_pattern``.
 
-tls_cert_issuer
+``tls.cert_subject`` replaces the previous keyword name: ``tls_cert_subject``. You may continue
+to use the previous name, but it's recommended that rules be converted to use
+the new name.
+
+tls.cert_issuer
 ---------------
 
 Match TLS/SSL certificate Issuer field.
 
 Examples::
 
-  tls_cert_issuer; content:"WoSign"; nocase; isdataat:!1,relative;
-  tls_cert_issuer; content:"StartCom"; nocase; pcre:"/StartCom$/";
+  tls.cert_issuer; content:"WoSign"; nocase; isdataat:!1,relative;
+  tls.cert_issuer; content:"StartCom"; nocase; pcre:"/StartCom$/";
 
-``tls_cert_issuer`` is a 'Sticky buffer'.
+``tls.cert_issuer`` is a 'Sticky buffer'.
 
-``tls_cert_issuer`` can be used as ``fast_pattern``.
+``tls.cert_issuer`` can be used as ``fast_pattern``.
 
-tls_cert_serial
+``tls.cert_issuer`` replaces the previous keyword name: ``tls_cert_issuer``. You may continue
+to use the previous name, but it's recommended that rules be converted to use
+the new name.
+
+tls.cert_serial
 ---------------
 
 Match on the serial number in a certificate.
@@ -39,13 +47,17 @@ Match on the serial number in a certificate.
 Example::
 
   alert tls any any -> any any (msg:"match cert serial"; \
-    tls_cert_serial; content:"5C:19:B7:B1:32:3B:1C:A1"; sid:200012;)
+    tls.cert_serial; content:"5C:19:B7:B1:32:3B:1C:A1"; sid:200012;)
 
-``tls_cert_serial`` is a 'Sticky buffer'.
+``tls.cert_serial`` is a 'Sticky buffer'.
 
-``tls_cert_serial`` can be used as ``fast_pattern``.
+``tls.cert_serial`` can be used as ``fast_pattern``.
 
-tls_cert_fingerprint
+``tls.cert_serial`` replaces the previous keyword name: ``tls_cert_serial``. You may continue
+to use the previous name, but it's recommended that rules be converted to use
+the new name.
+
+tls.cert_fingerprint
 --------------------
 
 Match on the SHA-1 fingerprint of the certificate.
@@ -53,27 +65,35 @@ Match on the SHA-1 fingerprint of the certificate.
 Example::
 
   alert tls any any -> any any (msg:"match cert fingerprint"; \
-    tls_cert_fingerprint; \
+    tls.cert_fingerprint; \
     content:"4a:a3:66:76:82:cb:6b:23:bb:c3:58:47:23:a4:63:a7:78:a4:a1:18"; \
     sid:200023;)
 
-``tls_cert_fingerprint`` is a 'Sticky buffer'.
+``tls.cert_fingerprint`` is a 'Sticky buffer'.
 
-``tls_cert_fingerprint`` can be used as ``fast_pattern``.
+``tls.cert_fingerprint`` can be used as ``fast_pattern``.
 
-tls_sni
+``tls.cert_fingerprint`` replaces the previous keyword name: ``tls_cert_fingerprint may continue
+to use the previous name, but it's recommended that rules be converted to use
+the new name.
+
+tls.sni
 -------
 
 Match TLS/SSL Server Name Indication field.
 
 Examples::
 
-  tls_sni; content:"oisf.net"; nocase; isdataat:!1,relative;
-  tls_sni; content:"oisf.net"; nocase; pcre:"/oisf.net$/";
+  tls.sni; content:"oisf.net"; nocase; isdataat:!1,relative;
+  tls.sni; content:"oisf.net"; nocase; pcre:"/oisf.net$/";
 
-``tls_sni`` is a 'Sticky buffer'.
+``tls.sni`` is a 'Sticky buffer'.
 
-``tls_sni`` can be used as ``fast_pattern``.
+``tls.sni`` can be used as ``fast_pattern``.
+
+``tls.sni`` replaces the previous keyword name: ``tls_sni``. You may continue
+to use the previous name, but it's recommended that rules be converted to use
+the new name.
 
 tls_cert_notbefore
 ------------------
@@ -166,7 +186,7 @@ example:
 
 Case sensitive, can't use 'nocase'.
 
-Legacy keyword. ``tls_cert_subject`` is the replacement.
+Legacy keyword. ``tls.cert_subject`` is the replacement.
 
 tls.issuerdn
 ------------
@@ -182,7 +202,7 @@ example:
 
 Case sensitive, can't use 'nocase'.
 
-Legacy keyword. ``tls_cert_issuer`` is the replacement.
+Legacy keyword. ``tls.cert_issuer`` is the replacement.
 
 tls.fingerprint
 ---------------

--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -67,11 +67,12 @@ static _Bool DetectTlsFingerprintValidateCallback(const Signature *s,
 static int g_tls_cert_fingerprint_buffer_id = 0;
 
 /**
- * \brief Registration function for keyword: tls_cert_fingerprint
+ * \brief Registration function for keyword: tls.cert_fingerprint
  */
 void DetectTlsFingerprintRegister(void)
 {
-    sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].name = "tls_cert_fingerprint";
+    sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].name = "tls.cert_fingerprint";
+    sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].alias = "tls_cert_fingerprint";
     sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].desc = "content modifier to match the TLS cert fingerprint buffer";
     sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].url = DOC_URL DOC_VERSION "/rules/tls-keywords.html#tls-cert-fingerprint";
     sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].Match = NULL;
@@ -80,25 +81,26 @@ void DetectTlsFingerprintRegister(void)
     sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].RegisterTests = DetectTlsFingerprintRegisterTests;
 
     sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].flags |= SIGMATCH_NOOPT;
+    sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
-    DetectAppLayerInspectEngineRegister2("tls_cert_fingerprint", ALPROTO_TLS,
+    DetectAppLayerInspectEngineRegister2("tls.cert_fingerprint", ALPROTO_TLS,
             SIG_FLAG_TOCLIENT, TLS_STATE_CERT_READY,
             DetectEngineInspectBufferGeneric, GetData);
 
-    DetectAppLayerMpmRegister2("tls_cert_fingerprint", SIG_FLAG_TOCLIENT, 2,
+    DetectAppLayerMpmRegister2("tls.cert_fingerprint", SIG_FLAG_TOCLIENT, 2,
             PrefilterGenericMpmRegister, GetData, ALPROTO_TLS,
             TLS_STATE_CERT_READY);
 
-    DetectBufferTypeSetDescriptionByName("tls_cert_fingerprint",
+    DetectBufferTypeSetDescriptionByName("tls.cert_fingerprint",
             "TLS certificate fingerprint");
 
-    DetectBufferTypeRegisterSetupCallback("tls_cert_fingerprint",
+    DetectBufferTypeRegisterSetupCallback("tls.cert_fingerprint",
             DetectTlsFingerprintSetupCallback);
 
-    DetectBufferTypeRegisterValidateCallback("tls_cert_fingerprint",
+    DetectBufferTypeRegisterValidateCallback("tls.cert_fingerprint",
             DetectTlsFingerprintValidateCallback);
 
-    g_tls_cert_fingerprint_buffer_id = DetectBufferTypeGetByName("tls_cert_fingerprint");
+    g_tls_cert_fingerprint_buffer_id = DetectBufferTypeGetByName("tls.cert_fingerprint");
 }
 
 /**
@@ -173,14 +175,14 @@ static _Bool DetectTlsFingerprintValidateCallback(const Signature *s,
 
         if (have_delimiters == FALSE) {
             *sigerror = "No colon delimiters ':' detected in content after "
-                        "tls_cert_fingerprint. This rule will therefore "
+                        "tls.cert_fingerprint. This rule will therefore "
                         "never match.";
             SCLogWarning(SC_WARN_POOR_RULE, "rule %u: %s", s->id, *sigerror);
             return FALSE;
         }
 
         if (cd->flags & DETECT_CONTENT_NOCASE) {
-            *sigerror = "tls_cert_fingerprint should not be used together "
+            *sigerror = "tls.cert_fingerprint should not be used together "
                         "with nocase, since the rule is automatically "
                         "lowercased anyway which makes nocase redundant.";
             SCLogWarning(SC_WARN_POOR_RULE, "rule %u: %s", s->id, *sigerror);
@@ -236,8 +238,8 @@ static int DetectTlsFingerprintTest01(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tls any any -> any any "
-                               "(msg:\"Testing tls_cert_fingerprint\"; "
-                               "tls_cert_fingerprint; "
+                               "(msg:\"Testing tls.cert_fingerprint\"; "
+                               "tls.cert_fingerprint; "
                                "content:\"11:22:33:44:55:66:77:88:99:00:11:22:33:44:55:66:77:88:99:00\"; "
                                "sid:1;)");
     FAIL_IF_NULL(de_ctx->sig_list);
@@ -514,8 +516,8 @@ static int DetectTlsFingerprintTest02(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx, "alert tls any any -> any any "
-                              "(msg:\"Test tls_cert_fingerprint\"; "
-                              "tls_cert_fingerprint; "
+                              "(msg:\"Test tls.cert_fingerprint\"; "
+                              "tls.cert_fingerprint; "
                               "content:\"4a:a3:66:76:82:cb:6b:23:bb:c3:58:47:23:a4:63:a7:78:a4:a1:18\"; "
                               "sid:1;)");
     FAIL_IF_NULL(s);

--- a/src/detect-tls-cert-issuer.c
+++ b/src/detect-tls-cert-issuer.c
@@ -20,7 +20,7 @@
  *
  * \author Mats Klepsland <mats.klepsland@gmail.com>
  *
- * Implements support for tls_cert_issuer keyword.
+ * Implements support for tls.cert_issuer keyword.
  */
 
 #include "suricata-common.h"
@@ -63,11 +63,12 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 static int g_tls_cert_issuer_buffer_id = 0;
 
 /**
- * \brief Registration function for keyword: tls_cert_issuer
+ * \brief Registration function for keyword: tls.cert_issuer
  */
 void DetectTlsIssuerRegister(void)
 {
-    sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].name = "tls_cert_issuer";
+    sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].name = "tls.cert_issuer";
+    sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].alias = "tls_cert_issuer";
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].desc = "content modifier to match specifically and only on the TLS cert issuer buffer";
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].url = DOC_URL DOC_VERSION "/rules/tls-keywords.html#tls-cert-issuer";
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].Match = NULL;
@@ -76,19 +77,20 @@ void DetectTlsIssuerRegister(void)
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].RegisterTests = DetectTlsIssuerRegisterTests;
 
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].flags |= SIGMATCH_NOOPT;
+    sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
-    DetectAppLayerInspectEngineRegister2("tls_cert_issuer", ALPROTO_TLS,
+    DetectAppLayerInspectEngineRegister2("tls.cert_issuer", ALPROTO_TLS,
             SIG_FLAG_TOCLIENT, TLS_STATE_CERT_READY,
             DetectEngineInspectBufferGeneric, GetData);
 
-    DetectAppLayerMpmRegister2("tls_cert_issuer", SIG_FLAG_TOCLIENT, 2,
+    DetectAppLayerMpmRegister2("tls.cert_issuer", SIG_FLAG_TOCLIENT, 2,
             PrefilterGenericMpmRegister, GetData, ALPROTO_TLS,
             TLS_STATE_CERT_READY);
 
-    DetectBufferTypeSetDescriptionByName("tls_cert_issuer",
+    DetectBufferTypeSetDescriptionByName("tls.cert_issuer",
             "TLS certificate issuer");
 
-    g_tls_cert_issuer_buffer_id = DetectBufferTypeGetByName("tls_cert_issuer");
+    g_tls_cert_issuer_buffer_id = DetectBufferTypeGetByName("tls.cert_issuer");
 }
 
 
@@ -146,8 +148,8 @@ static int DetectTlsIssuerTest01(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tls any any -> any any "
-                               "(msg:\"Testing tls_cert_issuer\"; "
-                               "tls_cert_issuer; content:\"test\"; sid:1;)");
+                               "(msg:\"Testing tls.cert_issuer\"; "
+                               "tls.cert_issuer; content:\"test\"; sid:1;)");
     FAIL_IF_NULL(de_ctx->sig_list);
 
     /* sm should not be in the MATCH list */
@@ -423,8 +425,8 @@ static int DetectTlsIssuerTest02(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx, "alert tls any any -> any any "
-                              "(msg:\"Test tls_cert_issuer\"; "
-                              "tls_cert_issuer; content:\"google\"; nocase; "
+                              "(msg:\"Test tls.cert_issuer\"; "
+                              "tls.cert_issuer; content:\"google\"; nocase; "
                               "sid:1;)");
     FAIL_IF_NULL(s);
 

--- a/src/detect-tls-cert-serial.c
+++ b/src/detect-tls-cert-serial.c
@@ -20,7 +20,7 @@
  *
  * \author Mats Klepsland <mats.klepsland@gmail.com>
  *
- * Implements support for tls_cert_serial keyword.
+ * Implements support for tls.cert_serial keyword.
  */
 
 #include "suricata-common.h"
@@ -67,11 +67,12 @@ static _Bool DetectTlsSerialValidateCallback(const Signature *s,
 static int g_tls_cert_serial_buffer_id = 0;
 
 /**
- * \brief Registration function for keyword: tls_cert_serial
+ * \brief Registration function for keyword: tls.cert_serial
  */
 void DetectTlsSerialRegister(void)
 {
-    sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].name = "tls_cert_serial";
+    sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].name = "tls.cert_serial";
+    sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].alias = "tls_cert_serial";
     sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].desc = "content modifier to match the TLS cert serial buffer";
     sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].url = DOC_URL DOC_VERSION "/rules/tls-keywords.html#tls-cert-serial";
     sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].Match = NULL;
@@ -80,25 +81,26 @@ void DetectTlsSerialRegister(void)
     sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].RegisterTests = DetectTlsSerialRegisterTests;
 
     sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].flags |= SIGMATCH_NOOPT;
+    sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
-    DetectAppLayerInspectEngineRegister2("tls_cert_serial", ALPROTO_TLS,
+    DetectAppLayerInspectEngineRegister2("tls.cert_serial", ALPROTO_TLS,
             SIG_FLAG_TOCLIENT, TLS_STATE_CERT_READY,
             DetectEngineInspectBufferGeneric, GetData);
 
-    DetectAppLayerMpmRegister2("tls_cert_serial", SIG_FLAG_TOCLIENT, 2,
+    DetectAppLayerMpmRegister2("tls.cert_serial", SIG_FLAG_TOCLIENT, 2,
             PrefilterGenericMpmRegister, GetData, ALPROTO_TLS,
             TLS_STATE_CERT_READY);
 
-    DetectBufferTypeSetDescriptionByName("tls_cert_serial",
+    DetectBufferTypeSetDescriptionByName("tls.cert_serial",
             "TLS certificate serial number");
 
-    DetectBufferTypeRegisterSetupCallback("tls_cert_serial",
+    DetectBufferTypeRegisterSetupCallback("tls.cert_serial",
             DetectTlsSerialSetupCallback);
 
-    DetectBufferTypeRegisterValidateCallback("tls_cert_serial",
+    DetectBufferTypeRegisterValidateCallback("tls.cert_serial",
             DetectTlsSerialValidateCallback);
 
-    g_tls_cert_serial_buffer_id = DetectBufferTypeGetByName("tls_cert_serial");
+    g_tls_cert_serial_buffer_id = DetectBufferTypeGetByName("tls.cert_serial");
 }
 
 /**
@@ -154,7 +156,7 @@ static _Bool DetectTlsSerialValidateCallback(const Signature *s,
         const DetectContentData *cd = (DetectContentData *)sm->ctx;
 
         if (cd->flags & DETECT_CONTENT_NOCASE) {
-            *sigerror = "tls_cert_serial should not be used together "
+            *sigerror = "tls.cert_serial should not be used together "
                         "with nocase, since the rule is automatically "
                         "uppercased anyway which makes nocase redundant.";
             SCLogWarning(SC_WARN_POOR_RULE, "rule %u: %s", s->id, *sigerror);
@@ -170,7 +172,7 @@ static _Bool DetectTlsSerialValidateCallback(const Signature *s,
                 return TRUE;
 
         *sigerror = "No colon delimiters ':' detected in content after "
-                    "tls_cert_serial. This rule will therefore never "
+                    "tls.cert_serial. This rule will therefore never "
                     "match.";
         SCLogWarning(SC_WARN_POOR_RULE, "rule %u: %s", s->id, *sigerror);
 
@@ -213,7 +215,7 @@ static void DetectTlsSerialSetupCallback(const DetectEngineCtx *de_ctx,
 #ifdef UNITTESTS
 
 /**
- * \test Test that a signature containing tls_cert_serial is correctly parsed
+ * \test Test that a signature containing tls.cert_serial is correctly parsed
  *       and that the keyword is registered.
  */
 static int DetectTlsSerialTest01(void)
@@ -226,8 +228,8 @@ static int DetectTlsSerialTest01(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tls any any -> any any "
-                               "(msg:\"Testing tls_cert_serial\"; "
-                               "tls_cert_serial; content:\"XX:XX:XX\"; sid:1;)");
+                               "(msg:\"Testing tls.cert_serial\"; "
+                               "tls.cert_serial; content:\"XX:XX:XX\"; sid:1;)");
     FAIL_IF_NULL(de_ctx->sig_list);
 
     /* sm should not be in the MATCH list */
@@ -502,8 +504,8 @@ static int DetectTlsSerialTest02(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx, "alert tls any any -> any any "
-                              "(msg:\"Test tls_cert_serial\"; "
-                              "tls_cert_serial; "
+                              "(msg:\"Test tls.cert_serial\"; "
+                              "tls.cert_serial; "
                               "content:\"5C:19:B7:B1:32:3B:1C:A1\"; "
                               "sid:1;)");
     FAIL_IF_NULL(s);

--- a/src/detect-tls-cert-subject.c
+++ b/src/detect-tls-cert-subject.c
@@ -20,7 +20,7 @@
  *
  * \author Mats Klepsland <mats.klepsland@gmail.com>
  *
- * Implements support for tls_cert_subject keyword.
+ * Implements support for tls.cert_subject keyword.
  */
 
 #include "suricata-common.h"
@@ -63,11 +63,12 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 static int g_tls_cert_subject_buffer_id = 0;
 
 /**
- * \brief Registration function for keyword: tls_cert_subject
+ * \brief Registration function for keyword: tls.cert_subject
  */
 void DetectTlsSubjectRegister(void)
 {
-    sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].name = "tls_cert_subject";
+    sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].name = "tls.cert_subject";
+    sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].alias = "tls_cert_subject";
     sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].desc = "content modifier to match specifically and only on the TLS cert subject buffer";
     sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].url = DOC_URL DOC_VERSION "/rules/tls-keywords.html#tls-cert-subject";
     sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].Match = NULL;
@@ -76,23 +77,24 @@ void DetectTlsSubjectRegister(void)
     sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].RegisterTests = DetectTlsSubjectRegisterTests;
 
     sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].flags |= SIGMATCH_NOOPT;
+    sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
-   DetectAppLayerInspectEngineRegister2("tls_cert_subject", ALPROTO_TLS,
+   DetectAppLayerInspectEngineRegister2("tls.cert_subject", ALPROTO_TLS,
             SIG_FLAG_TOCLIENT, TLS_STATE_CERT_READY,
             DetectEngineInspectBufferGeneric, GetData);
 
-    DetectAppLayerMpmRegister2("tls_cert_subject", SIG_FLAG_TOCLIENT, 2,
+    DetectAppLayerMpmRegister2("tls.cert_subject", SIG_FLAG_TOCLIENT, 2,
             PrefilterGenericMpmRegister, GetData, ALPROTO_TLS,
             TLS_STATE_CERT_READY);
 
-    DetectBufferTypeSetDescriptionByName("tls_cert_subject",
+    DetectBufferTypeSetDescriptionByName("tls.cert_subject",
             "TLS certificate subject");
 
-    g_tls_cert_subject_buffer_id = DetectBufferTypeGetByName("tls_cert_subject");
+    g_tls_cert_subject_buffer_id = DetectBufferTypeGetByName("tls.cert_subject");
 }
 
 /**
- * \brief this function setup the tls_cert_subject modifier keyword used in the rule
+ * \brief this function setup the tls.cert_subject modifier keyword used in the rule
  *
  * \param de_ctx   Pointer to the Detection Engine Context
  * \param s        Pointer to the Signature to which the current keyword belongs
@@ -132,7 +134,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 #ifdef UNITTESTS
 
 /**
- * \test Test that a signature containing a tls_cert_subject is correctly parsed
+ * \test Test that a signature containing a tls.cert_subject is correctly parsed
  *       and that the keyword is registered.
  */
 static int DetectTlsSubjectTest01(void)
@@ -145,8 +147,8 @@ static int DetectTlsSubjectTest01(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tls any any -> any any "
-                               "(msg:\"Testing tls_cert_subject\"; "
-                               "tls_cert_subject; content:\"test\"; sid:1;)");
+                               "(msg:\"Testing tls.cert_subject\"; "
+                               "tls.cert_subject; content:\"test\"; sid:1;)");
     FAIL_IF_NULL(de_ctx->sig_list);
 
     /* sm should not be in the MATCH list */
@@ -422,8 +424,8 @@ static int DetectTlsSubjectTest02(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx, "alert tls any any -> any any "
-                              "(msg:\"Test tls_cert_subject\"; "
-                              "tls_cert_subject; content:\"google\"; nocase; "
+                              "(msg:\"Test tls.cert_subject\"; "
+                              "tls.cert_subject; content:\"google\"; nocase; "
                               "sid:1;)");
     FAIL_IF_NULL(s);
 

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -20,7 +20,7 @@
  *
  * \author Mats Klepsland <mats.klepsland@gmail.com>
  *
- * Implements support for ja3_hash keyword.
+ * Implements support for ja3.hash keyword.
  */
 
 #include "suricata-common.h"
@@ -75,7 +75,8 @@ static int g_tls_ja3_hash_buffer_id = 0;
  */
 void DetectTlsJa3HashRegister(void)
 {
-    sigmatch_table[DETECT_AL_TLS_JA3_HASH].name = "ja3_hash";
+    sigmatch_table[DETECT_AL_TLS_JA3_HASH].name = "ja3.hash";
+    sigmatch_table[DETECT_AL_TLS_JA3_HASH].alias = "ja3_hash";
     sigmatch_table[DETECT_AL_TLS_JA3_HASH].desc = "content modifier to match the JA3 hash buffer";
     sigmatch_table[DETECT_AL_TLS_JA3_HASH].url = DOC_URL DOC_VERSION "/rules/ja3-keywords.html#ja3-hash";
     sigmatch_table[DETECT_AL_TLS_JA3_HASH].Match = NULL;
@@ -84,26 +85,27 @@ void DetectTlsJa3HashRegister(void)
     sigmatch_table[DETECT_AL_TLS_JA3_HASH].RegisterTests = DetectTlsJa3HashRegisterTests;
 
     sigmatch_table[DETECT_AL_TLS_JA3_HASH].flags |= SIGMATCH_NOOPT;
+    sigmatch_table[DETECT_AL_TLS_JA3_HASH].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
-    DetectAppLayerInspectEngineRegister2("ja3_hash", ALPROTO_TLS, SIG_FLAG_TOSERVER, 0,
+    DetectAppLayerInspectEngineRegister2("ja3.hash", ALPROTO_TLS, SIG_FLAG_TOSERVER, 0,
             DetectEngineInspectBufferGeneric, GetData);
 
-    DetectAppLayerMpmRegister2("ja3_hash", SIG_FLAG_TOSERVER, 2,
+    DetectAppLayerMpmRegister2("ja3.hash", SIG_FLAG_TOSERVER, 2,
             PrefilterGenericMpmRegister, GetData, ALPROTO_TLS, 0);
 
-    DetectBufferTypeSetDescriptionByName("ja3_hash", "TLS JA3 hash");
+    DetectBufferTypeSetDescriptionByName("ja3.hash", "TLS JA3 hash");
 
-    DetectBufferTypeRegisterSetupCallback("ja3_hash",
+    DetectBufferTypeRegisterSetupCallback("ja3.hash",
             DetectTlsJa3HashSetupCallback);
 
-    DetectBufferTypeRegisterValidateCallback("ja3_hash",
+    DetectBufferTypeRegisterValidateCallback("ja3.hash",
             DetectTlsJa3HashValidateCallback);
 
-    g_tls_ja3_hash_buffer_id = DetectBufferTypeGetByName("ja3_hash");
+    g_tls_ja3_hash_buffer_id = DetectBufferTypeGetByName("ja3.hash");
 }
 
 /**
- * \brief this function setup the ja3_hash modifier keyword used in the rule
+ * \brief this function setup the ja3.hash modifier keyword used in the rule
  *
  * \param de_ctx Pointer to the Detection Engine Context
  * \param s      Pointer to the Signature to which the current keyword belongs
@@ -160,7 +162,7 @@ static _Bool DetectTlsJa3HashValidateCallback(const Signature *s,
         const DetectContentData *cd = (DetectContentData *)sm->ctx;
 
         if (cd->flags & DETECT_CONTENT_NOCASE) {
-            *sigerror = "ja3_hash should not be used together with "
+            *sigerror = "ja3.hash should not be used together with "
                         "nocase, since the rule is automatically "
                         "lowercased anyway which makes nocase redundant.";
             SCLogWarning(SC_WARN_POOR_RULE, "rule %u: %s", s->id, *sigerror);
@@ -281,7 +283,7 @@ static int DetectTlsJa3HashTest01(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx, "alert tls any any -> any any "
-                              "(msg:\"Test ja3_hash\"; ja3_hash; "
+                              "(msg:\"Test ja3.hash\"; ja3.hash; "
                               "content:\"e7eca2baf4458d095b7f45da28c16c34\"; "
                               "sid:1;)");
     FAIL_IF_NULL(s);
@@ -381,7 +383,7 @@ static int DetectTlsJa3HashTest02(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx, "alert tls any any -> any any "
-                              "(msg:\"Test ja3_hash\"; ja3_hash; "
+                              "(msg:\"Test ja3.hash\"; ja3.hash; "
                               "content:\"bc6c386f480ee97b9d9e52d472b772d8\"; "
                               "sid:1;)");
     FAIL_IF_NULL(s);

--- a/src/detect-tls-ja3-string.c
+++ b/src/detect-tls-ja3-string.c
@@ -20,7 +20,7 @@
  *
  * \author Mats Klepsland <mats.klepsland@gmail.com>
  *
- * Implements support for ja3_string keyword.
+ * Implements support for ja3.string keyword.
  */
 
 #include "suricata-common.h"
@@ -67,11 +67,12 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 static int g_tls_ja3_str_buffer_id = 0;
 
 /**
- * \brief Registration function for keyword: ja3_string
+ * \brief Registration function for keyword: ja3.string
  */
 void DetectTlsJa3StringRegister(void)
 {
-    sigmatch_table[DETECT_AL_TLS_JA3_STRING].name = "ja3_string";
+    sigmatch_table[DETECT_AL_TLS_JA3_STRING].name = "ja3.string";
+    sigmatch_table[DETECT_AL_TLS_JA3_STRING].alias = "ja3_string";
     sigmatch_table[DETECT_AL_TLS_JA3_STRING].desc = "content modifier to match the JA3 string buffer";
     sigmatch_table[DETECT_AL_TLS_JA3_STRING].url = DOC_URL DOC_VERSION "/rules/ja3-keywords.html#ja3-string";
     sigmatch_table[DETECT_AL_TLS_JA3_STRING].Match = NULL;
@@ -80,20 +81,21 @@ void DetectTlsJa3StringRegister(void)
     sigmatch_table[DETECT_AL_TLS_JA3_STRING].RegisterTests = DetectTlsJa3StringRegisterTests;
 
     sigmatch_table[DETECT_AL_TLS_JA3_STRING].flags |= SIGMATCH_NOOPT;
+    sigmatch_table[DETECT_AL_TLS_JA3_STRING].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
-    DetectAppLayerInspectEngineRegister2("ja3_string", ALPROTO_TLS, SIG_FLAG_TOSERVER, 0,
+    DetectAppLayerInspectEngineRegister2("ja3.string", ALPROTO_TLS, SIG_FLAG_TOSERVER, 0,
             DetectEngineInspectBufferGeneric, GetData);
 
-    DetectAppLayerMpmRegister2("ja3_string", SIG_FLAG_TOSERVER, 2,
+    DetectAppLayerMpmRegister2("ja3.string", SIG_FLAG_TOSERVER, 2,
             PrefilterGenericMpmRegister, GetData, ALPROTO_TLS, 0);
 
-    DetectBufferTypeSetDescriptionByName("ja3_string", "TLS JA3 string");
+    DetectBufferTypeSetDescriptionByName("ja3.string", "TLS JA3 string");
 
-    g_tls_ja3_str_buffer_id = DetectBufferTypeGetByName("ja3_string");
+    g_tls_ja3_str_buffer_id = DetectBufferTypeGetByName("ja3.string");
 }
 
 /**
- * \brief this function setup the ja3_string modifier keyword used in the rule
+ * \brief this function setup the ja3.string modifier keyword used in the rule
  *
  * \param de_ctx Pointer to the Detection Engine Context
  * \param s      Pointer to the Signature to which the current keyword belongs
@@ -211,7 +213,7 @@ static int DetectTlsJa3StringTest01(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx, "alert tls any any -> any any "
-            "(msg:\"Test ja3_string\"; ja3_string; "
+            "(msg:\"Test ja3.string\"; ja3.string; "
             "content:\"-65-68-69-102-103-104-105-106-107-132-135-255,0,,\"; "
             "sid:1;)");
     FAIL_IF_NULL(s);

--- a/src/detect-tls-sni.c
+++ b/src/detect-tls-sni.c
@@ -20,7 +20,7 @@
  *
  * \author Mats Klepsland <mats.klepsland@gmail.com>
  *
- * Implements support for tls_sni keyword.
+ * Implements support for tls.sni keyword.
  */
 
 #include "suricata-common.h"
@@ -63,11 +63,12 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 static int g_tls_sni_buffer_id = 0;
 
 /**
- * \brief Registration function for keyword: tls_sni
+ * \brief Registration function for keyword: tls.sni
  */
 void DetectTlsSniRegister(void)
 {
-    sigmatch_table[DETECT_AL_TLS_SNI].name = "tls_sni";
+    sigmatch_table[DETECT_AL_TLS_SNI].name = "tls.sni";
+    sigmatch_table[DETECT_AL_TLS_SNI].alias = "tls_sni";
     sigmatch_table[DETECT_AL_TLS_SNI].desc = "content modifier to match specifically and only on the TLS SNI buffer";
     sigmatch_table[DETECT_AL_TLS_SNI].url = DOC_URL DOC_VERSION "/rules/tls-keywords.html#tls-sni";
     sigmatch_table[DETECT_AL_TLS_SNI].Match = NULL;
@@ -76,22 +77,23 @@ void DetectTlsSniRegister(void)
     sigmatch_table[DETECT_AL_TLS_SNI].RegisterTests = DetectTlsSniRegisterTests;
 
     sigmatch_table[DETECT_AL_TLS_SNI].flags |= SIGMATCH_NOOPT;
+    sigmatch_table[DETECT_AL_TLS_SNI].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
-    DetectAppLayerInspectEngineRegister2("tls_sni", ALPROTO_TLS, SIG_FLAG_TOSERVER, 0,
+    DetectAppLayerInspectEngineRegister2("tls.sni", ALPROTO_TLS, SIG_FLAG_TOSERVER, 0,
             DetectEngineInspectBufferGeneric, GetData);
 
-    DetectAppLayerMpmRegister2("tls_sni", SIG_FLAG_TOSERVER, 2,
+    DetectAppLayerMpmRegister2("tls.sni", SIG_FLAG_TOSERVER, 2,
             PrefilterGenericMpmRegister, GetData, ALPROTO_TLS, 0);
 
-    DetectBufferTypeSetDescriptionByName("tls_sni",
+    DetectBufferTypeSetDescriptionByName("tls.sni",
             "TLS Server Name Indication (SNI) extension");
 
-    g_tls_sni_buffer_id = DetectBufferTypeGetByName("tls_sni");
+    g_tls_sni_buffer_id = DetectBufferTypeGetByName("tls.sni");
 }
 
 
 /**
- * \brief this function setup the tls_sni modifier keyword used in the rule
+ * \brief this function setup the tls.sni modifier keyword used in the rule
  *
  * \param de_ctx   Pointer to the Detection Engine Context
  * \param s        Pointer to the Signature to which the current keyword belongs
@@ -190,8 +192,8 @@ static int DetectTlsSniTest01(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx, "alert tls any any -> any any "
-                              "(msg:\"Test tls_sni option\"; "
-                              "tls_sni; content:\"google.com\"; sid:1;)");
+                              "(msg:\"Test tls.sni option\"; "
+                              "tls.sni; content:\"google.com\"; sid:1;)");
     FAIL_IF_NULL(s);
 
     SigGroupBuild(de_ctx);
@@ -282,14 +284,14 @@ static int DetectTlsSniTest02(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx, "alert tls any any -> any any "
-                              "(msg:\"Test tls_sni option\"; "
-                              "tls_sni; content:\"google\"; nocase; "
+                              "(msg:\"Test tls.sni option\"; "
+                              "tls.sni; content:\"google\"; nocase; "
                               "pcre:\"/google\\.com$/i\"; sid:1;)");
     FAIL_IF_NULL(s);
 
     s = DetectEngineAppendSig(de_ctx, "alert tls any any -> any any "
-                              "(msg:\"Test tls_sni option\"; "
-                              "tls_sni; content:\"google\"; nocase; "
+                              "(msg:\"Test tls.sni option\"; "
+                              "tls.sni; content:\"google\"; nocase; "
                               "pcre:\"/^\\.[a-z]{2,3}$/iR\"; sid:2;)");
     FAIL_IF_NULL(s);
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues ticket): [2914](https://redmine.openinfosecfoundation.org/issues/2914)

Describe changes:
- Modernize TLS keywords, including ja3 keywords
- Keyword documentation update.

Continuation of #3785