### PR TITLE
init: pledge(2) needs "fattr" during suricata reload.

### DIFF
--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -239,7 +239,7 @@ int SCGetGroupID(const char *group_name, uint32_t *gid)
 #ifdef __OpenBSD__
 int SCPledge(void)
 {
-    int ret = pledge("stdio rpath wpath cpath unix dns bpf", NULL);
+    int ret = pledge("stdio rpath wpath cpath fattr unix dns bpf", NULL);
 
     if (ret != 0) {
         SCLogError(SC_ERR_PLEDGE_FAILED, "unable to pledge,"


### PR DESCRIPTION
When killed with SIGHUP, suricata reopens the log files.  If filemode
is set in the config, it needs pledge promise "fattr" to allow the
chmod(2) on OpenBSD.
