### PR TITLE
Privdrop without libcap ng

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1441,7 +1441,9 @@ static int AFPTryReopen(AFPThreadVars *ptv)
         return -1;
     }
 
+    SCPrivsRaise();
     int afp_activate_r = AFPCreateSocket(ptv, ptv->iface, 0);
+    SCPrivsDrop();
     if (afp_activate_r != 0) {
         if (ptv->down_count % AFP_DOWN_COUNTER_INTERVAL == 0) {
             SCLogWarning(SC_ERR_AFP_CREATE, "Can not open iface '%s'",
@@ -1490,7 +1492,9 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
                 break;
             }
         }
+        SCPrivsRaise();
         r = AFPCreateSocket(ptv, ptv->iface, 1);
+        SCPrivsDrop();
         if (r < 0) {
             switch (-r) {
                 case AFP_FATAL_ERROR:
@@ -1687,7 +1691,10 @@ int AFPGetLinkType(const char *ifname)
 {
     int ltype;
 
+    SCPrivsRaise();
     int fd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+    SCPrivsDrop();
+
     if (fd == -1) {
         SCLogError(SC_ERR_AFP_CREATE, "Couldn't create a AF_PACKET socket, error %s", strerror(errno));
         return LINKTYPE_RAW;

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -438,7 +438,9 @@ TmEcode ReceivePcapThreadInit(ThreadVars *tv, const void *initdata, void **data)
 #endif /* HAVE_PCAP_SET_BUFF */
 
     /* activate the handle */
+    SCPrivsRaise();
     int pcap_activate_r = pcap_activate(ptv->pcap_handle);
+    SCPrivsDrop();
     //printf("ReceivePcapThreadInit: pcap_activate(%p) returned %" PRId32 "\n", ptv->pcap_handle, pcap_activate_r);
     if (pcap_activate_r != 0) {
         SCLogError(SC_ERR_PCAP_ACTIVATE_HANDLE, "Couldn't activate the pcap handler, error %s", pcap_geterr(ptv->pcap_handle));

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2793,7 +2793,7 @@ static int PostConfLoadedSetup(SCInstance *suri)
     if (InitSignalHandler(suri) != TM_ECODE_OK)
         SCReturnInt(TM_ECODE_FAILED);
 
-#ifndef HAVE_LIBCAP_NG
+#if !defined(HAVE_LIBCAP_NG) && !defined(OS_WIN32)
     /* RUNMODE_AFP_DEV does not run reliably when privileges without retaining
      * the appropriate capabilities. If the AFP interface goes down if will not
      * having enough permission to reopen a AF_PACKET socket.
@@ -2811,7 +2811,7 @@ static int PostConfLoadedSetup(SCInstance *suri)
         default:
             break;
     }
-#endif /* HAVE_LIBCAP_NG */
+#endif /* !defined(HAVE_LIBCAP_NG) && !defined(OS_WIN32) */
 
 #ifdef HAVE_NSS
     if (suri->run_mode != RUNMODE_CONF_TEST) {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -3042,7 +3042,17 @@ int main(int argc, char **argv)
 #endif
 #endif
 
-    SCSetUserID(suricata.userid, suricata.groupid);
+    /* The user must have enough permissions to change the process group ID.
+     * Once done, the user ID can be changed to finalize privilege drops.
+     */
+    if (suricata.do_setgid == TRUE) {
+	SCSetGroupID(suricata.groupid);
+    }
+
+    if (suricata.do_setuid == TRUE) {
+	SCSetUserID(suricata.userid);
+    }
+
     SCPledge();
     SuricataMainLoop(&suricata);
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -3023,6 +3023,7 @@ int main(int argc, char **argv)
 #endif
 #endif
 
+    SCSetUserID(suricata.userid, suricata.groupid);
     SCPledge();
     SuricataMainLoop(&suricata);
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -645,10 +645,10 @@ static void PrintUsage(const char *progname)
     printf("\t--pfring-cluster-type <type>         : pfring cluster type for PF_RING 4.1.2 and later cluster_round_robin|cluster_flow\n");
 #endif /* HAVE_PFRING */
     printf("\t--simulate-ips                       : force engine into IPS mode. Useful for QA\n");
-#ifdef HAVE_LIBCAP_NG
+#ifndef OS_WIN32
     printf("\t--user <user>                        : run suricata as this user after init\n");
     printf("\t--group <group>                      : run suricata as this group after init\n");
-#endif /* HAVE_LIBCAP_NG */
+#endif /* !OS_WIN32 */
     printf("\t--erf-in <path>                      : process an ERF file\n");
 #ifdef HAVE_DAG
     printf("\t--dag <dagX:Y>                       : process ERF records from DAG interface X, stream Y\n");
@@ -1710,12 +1710,24 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #endif /* UNITTESTS */
             }
             else if(strcmp((long_opts[option_index]).name, "user") == 0) {
+#ifdef OS_WIN32
+                SCLogError(SC_ERR_INVALID_ARGUMENTS, "--user option cannot be"
+                        " used on Windows platforms.");
+                return TM_ECODE_FAILED;
+#else
                 suri->user_name = optarg;
                 suri->do_setuid = TRUE;
+#endif /* OS_WIN32 */
             }
             else if(strcmp((long_opts[option_index]).name, "group") == 0) {
+#ifdef OS_WIN32
+                SCLogError(SC_ERR_INVALID_ARGUMENTS, "--group option cannot be"
+                        " used on Windows platforms.");
+                return TM_ECODE_FAILED;
+#else
                 suri->group_name = optarg;
                 suri->do_setgid = TRUE;
+#endif /* OS_WIN32 */
             }
             else if (strcmp((long_opts[option_index]).name, "erf-in") == 0) {
                 suri->run_mode = RUNMODE_ERF_FILE;

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1710,24 +1710,12 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #endif /* UNITTESTS */
             }
             else if(strcmp((long_opts[option_index]).name, "user") == 0) {
-#ifndef HAVE_LIBCAP_NG
-                SCLogError(SC_ERR_LIBCAP_NG_REQUIRED, "libcap-ng is required to"
-                        " drop privileges, but it was not compiled into Suricata.");
-                return TM_ECODE_FAILED;
-#else
                 suri->user_name = optarg;
                 suri->do_setuid = TRUE;
-#endif /* HAVE_LIBCAP_NG */
             }
             else if(strcmp((long_opts[option_index]).name, "group") == 0) {
-#ifndef HAVE_LIBCAP_NG
-                SCLogError(SC_ERR_LIBCAP_NG_REQUIRED, "libcap-ng is required to"
-                        " drop privileges, but it was not compiled into Suricata.");
-                return TM_ECODE_FAILED;
-#else
                 suri->group_name = optarg;
                 suri->do_setgid = TRUE;
-#endif /* HAVE_LIBCAP_NG */
             }
             else if (strcmp((long_opts[option_index]).name, "erf-in") == 0) {
                 suri->run_mode = RUNMODE_ERF_FILE;

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -3042,6 +3042,7 @@ int main(int argc, char **argv)
 #endif
 #endif
 
+#ifndef OS_WIN32
     /* The user must have enough permissions to change the process group ID.
      * Once done, the user ID can be changed to finalize privilege drops.
      */
@@ -3052,6 +3053,7 @@ int main(int argc, char **argv)
     if (suricata.do_setuid == TRUE) {
 	SCSetUserID(suricata.userid);
     }
+#endif /* !OS_WIN32 */
 
     SCPledge();
     SuricataMainLoop(&suricata);

--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -236,7 +236,14 @@ int SCGetGroupID(const char *group_name, uint32_t *gid)
     return 0;
 }
 
-int SCSetUserID(const uint32_t uid, const uint32_t gid)
+/**
+ * \brief   Function to set real, effective and saved group ID
+ *
+ * \param   gid  value of the given group id
+ *
+ * \retval  upon success it returns 0
+ */
+int SCSetGroupID(const uint32_t gid)
 {
     int ret = setresgid(gid, gid, gid);
 
@@ -246,7 +253,19 @@ int SCSetUserID(const uint32_t uid, const uint32_t gid)
         exit(EXIT_FAILURE);
     }
 
-    ret = setresuid(uid, uid, uid);
+    return 0;
+}
+
+/**
+ * \brief   Function to set real, effective and saved user ID
+ *
+ * \param   uid  value of the given user id
+ *
+ * \retval  upon success it returns 0
+ */
+int SCSetUserID(const uint32_t uid)
+{
+    int ret = setresuid(uid, uid, uid);
 
     if (ret != 0) {
         SCLogError(SC_ERR_UID_FAILED, "unable to set the user ID,"

--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -371,7 +371,7 @@ void SCPrivsInit(const uint8_t do_setuid, const uint8_t do_setgid, const uid_t u
 #ifdef __OpenBSD__
 int SCPledge(void)
 {
-    int ret = pledge("stdio rpath wpath cpath unix dns bpf", NULL);
+    int ret = pledge("stdio rpath wpath cpath unix dns bpf id", NULL);
 
     if (ret != 0) {
         SCLogError(SC_ERR_PLEDGE_FAILED, "unable to pledge,"

--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -236,6 +236,26 @@ int SCGetGroupID(const char *group_name, uint32_t *gid)
     return 0;
 }
 
+int SCSetUserID(const uint32_t uid, const uint32_t gid)
+{
+    int ret = setresgid(gid, gid, gid);
+
+    if (ret != 0) {
+        SCLogError(SC_ERR_GID_FAILED, "unable to set the group ID,"
+                " check permissions!! gid=%u ret=%i errno=%i", gid, ret, errno);
+        exit(EXIT_FAILURE);
+    }
+
+    ret = setresuid(uid, uid, uid);
+
+    if (ret != 0) {
+        SCLogError(SC_ERR_UID_FAILED, "unable to set the user ID,"
+                " check permissions!! uid=%u ret=%i errno=%i", uid, ret, errno);
+    }
+
+    return 0;
+}
+
 #ifdef __OpenBSD__
 int SCPledge(void)
 {

--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -28,7 +28,12 @@
 
 #include <grp.h>
 #include <pwd.h>
+
 #include "suricata-common.h"
+/* suricata-common.h defines _GNU_SOURCE needed <unistd.h> */
+#include <sys/types.h>
+#include <unistd.h>
+
 #include "util-debug.h"
 #include "suricata.h"
 

--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -250,7 +250,7 @@ int SCGetGroupID(const char *group_name, uint32_t *gid)
  */
 int SCSetGroupID(const uint32_t gid)
 {
-    int ret = setresgid(gid, gid, gid);
+    int ret = setegid(gid);
 
     if (ret != 0) {
         SCLogError(SC_ERR_GID_FAILED, "unable to set the group ID,"
@@ -270,7 +270,7 @@ int SCSetGroupID(const uint32_t gid)
  */
 int SCSetUserID(const uint32_t uid)
 {
-    int ret = setresuid(uid, uid, uid);
+    int ret = seteuid(uid);
 
     if (ret != 0) {
         SCLogError(SC_ERR_UID_FAILED, "unable to set the user ID,"

--- a/src/util-privs.h
+++ b/src/util-privs.h
@@ -93,7 +93,12 @@ void SCDropMainThreadCaps(uint32_t , uint32_t );
 
 int SCGetUserID(const char *, const char *, uint32_t *, uint32_t *);
 int SCGetGroupID(const char *, uint32_t *);
+
+#ifdef OS_WIN32
+#define SCSetUserID(...)
+#else /* OS_WIN32 */
 int SCSetUserID(const uint32_t uid, const uint32_t gid);
+#endif /* OS_WIN32 */
 
 #ifdef __OpenBSD__
 int SCPledge(void);

--- a/src/util-privs.h
+++ b/src/util-privs.h
@@ -93,6 +93,7 @@ void SCDropMainThreadCaps(uint32_t , uint32_t );
 
 int SCGetUserID(const char *, const char *, uint32_t *, uint32_t *);
 int SCGetGroupID(const char *, uint32_t *);
+int SCSetUserID(const uint32_t uid, const uint32_t gid);
 
 #ifdef __OpenBSD__
 int SCPledge(void);

--- a/src/util-privs.h
+++ b/src/util-privs.h
@@ -103,6 +103,8 @@ int SCGetGroupID(const char *, uint32_t *);
 
 #ifdef OS_WIN32
 #define SCPrivsInit(...)
+#define SCPrivsRaise(...)
+#define SCPrivsDrop(...)
 #else /* OS_WIN32 */
 void SCPrivsInit(const uint8_t do_setuid, const uint8_t do_setgid, const uid_t uid, const gid_t gid);
 #endif /* OS_WIN32 */

--- a/src/util-privs.h
+++ b/src/util-privs.h
@@ -36,6 +36,10 @@
 #ifndef HAVE_LIBCAP_NG
 #define SCDropCaps(...)
 #define SCDropMainThreadCaps(...)
+
+void SCPrivsRaise(void);
+void SCPrivsDrop(void);
+
 #else
 #include "threadvars.h"
 #include "util-debug.h"
@@ -89,17 +93,18 @@ void SCDropCaps(ThreadVars *tv);
 */
 void SCDropMainThreadCaps(uint32_t , uint32_t );
 
+#define SCPrivsRaise(...)
+#define SCPrivsDrop(...)
+
 #endif /* HAVE_LIBCAP_NG */
 
 int SCGetUserID(const char *, const char *, uint32_t *, uint32_t *);
 int SCGetGroupID(const char *, uint32_t *);
 
 #ifdef OS_WIN32
-#define SCSetUserID(...)
-#define SCSetGroupID(...)
+#define SCPrivsInit(...)
 #else /* OS_WIN32 */
-int SCSetUserID(const uint32_t uid);
-int SCSetGroupID(const uint32_t gid);
+void SCPrivsInit(const uint8_t do_setuid, const uint8_t do_setgid, const uid_t uid, const gid_t gid);
 #endif /* OS_WIN32 */
 
 #ifdef __OpenBSD__

--- a/src/util-privs.h
+++ b/src/util-privs.h
@@ -96,8 +96,10 @@ int SCGetGroupID(const char *, uint32_t *);
 
 #ifdef OS_WIN32
 #define SCSetUserID(...)
+#define SCSetGroupID(...)
 #else /* OS_WIN32 */
-int SCSetUserID(const uint32_t uid, const uint32_t gid);
+int SCSetUserID(const uint32_t uid);
+int SCSetGroupID(const uint32_t gid);
 #endif /* OS_WIN32 */
 
 #ifdef __OpenBSD__


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2931

Describe changes:
- Allow suricata to drop privileges on platform without libcap-ng support
- Prevent suricata to start in `RUNMODE_AFP_DEV` with dropped privileges without libcap-ng support
- Enable `--user` and `--group` CLI parameters to be used without libcap-ng support

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable): N/A

