### PR TITLE
Privdrop without libcap ng v2

### DIFF
--- a/doc/userguide/configuration/dropping-privileges.rst
+++ b/doc/userguide/configuration/dropping-privileges.rst
@@ -1,8 +1,23 @@
 Dropping Privileges After Startup
 =================================
 
-Currently, libcap-ng is needed for dropping privileges on Suricata
-after startup. For libcap, see status of feature request number #276
+Currently, dropping privileges can be either done via libcap-ng or with POSIX
+seteuid()/setegid().
+
+When the privilege drop is done by libcap-ng, the process real, effective and saved
+user/group ID is set to the values provided by the user configuration.
+Furthermore, process capabilities are set ensure that operations requiring
+higher permissions can be performed properly.
+Once done, the privilege level stays unchanged for the lifetime of the process.
+
+When libcap-ng support is disabled, privilege drop is done via
+seteuid()/setegid() on startup. Operations requiring higher permissions are
+placed between the functions SCPrivsRaise()/SCPrivsDrop().
+
+Between SCPrivsRaise() and SCPrivsDrop(), the process privileges are raised back
+to the saved user/group level during the process runtime.
+
+For libcap, see status of feature request number #276
 -- Libcap support for dropping privileges.
 
 Most distributions have ``libcap-ng`` in their repositories.

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1441,7 +1441,9 @@ static int AFPTryReopen(AFPThreadVars *ptv)
         return -1;
     }
 
+    SCPrivsRaise();
     int afp_activate_r = AFPCreateSocket(ptv, ptv->iface, 0);
+    SCPrivsDrop();
     if (afp_activate_r != 0) {
         if (ptv->down_count % AFP_DOWN_COUNTER_INTERVAL == 0) {
             SCLogWarning(SC_ERR_AFP_CREATE, "Can not open iface '%s'",
@@ -1490,7 +1492,9 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
                 break;
             }
         }
+        SCPrivsRaise();
         r = AFPCreateSocket(ptv, ptv->iface, 1);
+        SCPrivsDrop();
         if (r < 0) {
             switch (-r) {
                 case AFP_FATAL_ERROR:
@@ -1687,7 +1691,10 @@ int AFPGetLinkType(const char *ifname)
 {
     int ltype;
 
+    SCPrivsRaise();
     int fd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+    SCPrivsDrop();
+
     if (fd == -1) {
         SCLogError(SC_ERR_AFP_CREATE, "Couldn't create a AF_PACKET socket, error %s", strerror(errno));
         return LINKTYPE_RAW;

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -438,7 +438,9 @@ TmEcode ReceivePcapThreadInit(ThreadVars *tv, const void *initdata, void **data)
 #endif /* HAVE_PCAP_SET_BUFF */
 
     /* activate the handle */
+    SCPrivsRaise();
     int pcap_activate_r = pcap_activate(ptv->pcap_handle);
+    SCPrivsDrop();
     //printf("ReceivePcapThreadInit: pcap_activate(%p) returned %" PRId32 "\n", ptv->pcap_handle, pcap_activate_r);
     if (pcap_activate_r != 0) {
         SCLogError(SC_ERR_PCAP_ACTIVATE_HANDLE, "Couldn't activate the pcap handler, error %s", pcap_geterr(ptv->pcap_handle));

--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -28,11 +28,24 @@
 
 #include <grp.h>
 #include <pwd.h>
+#include <sys/types.h>
+#include <unistd.h>
+
 #include "suricata-common.h"
 #include "util-debug.h"
 #include "suricata.h"
 
 #include "util-privs.h"
+
+static struct PrivsCtx {
+    SCMutex lock;
+    uid_t uid;
+    gid_t gid;
+    uid_t svuid;
+    gid_t svgid;
+    uint8_t do_setuid;
+    uint8_t do_setgid;
+} g_privs_ctx;
 
 #ifdef HAVE_LIBCAP_NG
 
@@ -136,6 +149,84 @@ void SCDropCaps(ThreadVars *tv)
 #endif
 }
 
+#define SCPrivsRaise(...)
+#define SCPrivsDrop(...)
+#define _SCPrivsDrop(...)
+
+#else /* HAVE_LIBCAP_NG */
+
+static void SCSetGroupID(const uint32_t gid)
+{
+    int ret = setegid(gid);
+
+    if (ret != 0) {
+        SCLogError(SC_ERR_GID_FAILED, "unable to set the group ID,"
+                " check permissions!! gid=%u ret=%i errno=%i", gid, ret, errno);
+        exit(EXIT_FAILURE);
+    }
+}
+
+static void SCSetUserID(const uint32_t uid)
+{
+    int ret = seteuid(uid);
+
+    if (ret != 0) {
+        SCLogError(SC_ERR_UID_FAILED, "unable to set the user ID,"
+                " check permissions!! uid=%u ret=%i errno=%i", uid, ret, errno);
+        exit(EXIT_FAILURE);
+    }
+}
+
+/**
+ * \brief   Function to temporarily elevate privileges
+ *
+ * This is call restores the effective user ID and group ID from the saved
+ * set-user-ID and saved set-group-ID.
+ * \see SCPrivsDrop
+ */
+void SCPrivsRaise(void)
+{
+    SCMutexLock(&g_privs_ctx.lock);
+
+    if (g_privs_ctx.do_setuid == TRUE) {
+        SCSetUserID(g_privs_ctx.svuid);
+    }
+
+    if (g_privs_ctx.do_setuid == TRUE || g_privs_ctx.do_setgid == TRUE) {
+        SCSetGroupID(g_privs_ctx.svgid);
+    }
+}
+
+static void _SCPrivsDrop(void)
+{
+    /* The user must have enough permissions to change the process group ID.
+     * Once done, the user ID can be changed to finalize privilege drops.
+     */
+    if (g_privs_ctx.do_setuid == TRUE || g_privs_ctx.do_setgid == TRUE) {
+        SCSetGroupID(g_privs_ctx.gid);
+    }
+
+    if (g_privs_ctx.do_setuid == TRUE) {
+        SCSetUserID(g_privs_ctx.uid);
+    }
+}
+
+/**
+ * \brief   Function to drop privileges
+ *
+ * This is call change the effective user ID and group ID to the value provided
+ * in the configuration.
+ * If the configuration specifies a user by no group, the user default group id
+ * will be applied instead.
+ * 
+ * \see SCPrivsRaise
+ */
+void SCPrivsDrop(void)
+{
+    _SCPrivsDrop();
+    SCMutexUnlock(&g_privs_ctx.lock);
+}
+
 #endif /* HAVE_LIBCAP_NG */
 
 /**
@@ -234,6 +325,47 @@ int SCGetGroupID(const char *group_name, uint32_t *gid)
     *gid = grpid;
 
     return 0;
+}
+
+/**
+ * \brief   Function to initialize privilege handling
+ *
+ * \param   do_setuid   true if the process must change its uid settings
+ * \param   do_setgid   true if the process must change its gid settings
+ * \param   uid         value to set the effective user ID when privileges are dropped
+ * \param   gid         value to set the effective group ID when privileges are dropped
+ *
+ * This is call is required to initialize suricata privilege handling.
+ *
+ * If libcap-ng support is disabled, the privileges are dropped by setting the
+ * effective UID/GID. If an operation is requiring higher privileges is needed,
+ * SCPrivsRaise() can be used to temporarily raise the permissions to the saved
+ * user/group ID level.
+ * Once done, SCPrivsDrop() must be called to drop privileges back to reduced
+ * levels.
+ * As the effective uid/gid is set per-process, SCPrivsRaise() and SCPrivsDrop()
+ * are coupled with a mutex.
+ * 
+ * If libcap-ng support is on, the process capabilities are set and the user ID/
+ * group ID are set accordingly to ensure high privileges are dropped.
+ * In such case, the process UID/GID are stable for the lifetime of the process.
+ * 
+ */
+void SCPrivsInit(const uint8_t do_setuid, const uint8_t do_setgid, const uid_t uid, const gid_t gid)
+{
+    SCMutexInit(&g_privs_ctx.lock, NULL);
+
+    g_privs_ctx.do_setuid = do_setuid;
+    g_privs_ctx.do_setgid = do_setgid;
+
+    g_privs_ctx.uid = uid;
+    g_privs_ctx.svuid = geteuid();
+
+    g_privs_ctx.gid = gid;
+    g_privs_ctx.svgid = getegid();
+
+    SCDropMainThreadCaps(g_privs_ctx.uid, g_privs_ctx.gid);
+    _SCPrivsDrop();
 }
 
 #ifdef __OpenBSD__

--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -371,7 +371,7 @@ void SCPrivsInit(const uint8_t do_setuid, const uint8_t do_setgid, const uid_t u
 #ifdef __OpenBSD__
 int SCPledge(void)
 {
-    int ret = pledge("stdio rpath wpath cpath unix dns bpf", NULL);
+    int ret = pledge("stdio rpath wpath cpath unix dns bpf id", NULL);
 
     if (ret != 0) {
         SCLogError(SC_ERR_PLEDGE_FAILED, "unable to pledge,"

--- a/src/util-privs.h
+++ b/src/util-privs.h
@@ -36,6 +36,10 @@
 #ifndef HAVE_LIBCAP_NG
 #define SCDropCaps(...)
 #define SCDropMainThreadCaps(...)
+
+void SCPrivsRaise(void);
+void SCPrivsDrop(void);
+
 #else
 #include "threadvars.h"
 #include "util-debug.h"
@@ -89,10 +93,21 @@ void SCDropCaps(ThreadVars *tv);
 */
 void SCDropMainThreadCaps(uint32_t , uint32_t );
 
+#define SCPrivsRaise(...)
+#define SCPrivsDrop(...)
+
 #endif /* HAVE_LIBCAP_NG */
 
 int SCGetUserID(const char *, const char *, uint32_t *, uint32_t *);
 int SCGetGroupID(const char *, uint32_t *);
+
+#ifdef OS_WIN32
+#define SCPrivsInit(...)
+#define SCPrivsRaise(...)
+#define SCPrivsDrop(...)
+#else /* OS_WIN32 */
+void SCPrivsInit(const uint8_t do_setuid, const uint8_t do_setgid, const uid_t uid, const gid_t gid);
+#endif /* OS_WIN32 */
 
 #ifdef __OpenBSD__
 int SCPledge(void);


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2931

Describe changes:
- Introduces `SCPrivsInit()` to allow suricata to drop privileges and apply capabilities (when enabled)
- Introduces `SCPrivsRaise()` to allow suricata to raise privileges to original state, based the process saved UID/GID for specific code path during processing/teardown
- Introduces `SCPrivsDrop()` to drop privileges down again once the privileged code section is over.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable): N/A

