### PR TITLE
ssh : code style consistency

### DIFF
--- a/src/app-layer-ssh.c
+++ b/src/app-layer-ssh.c
@@ -125,11 +125,13 @@ static int SSHParseBanner(SshState *state, SshHeader *header, const uint8_t *inp
     /* sanity check on this arithmetic */
     if ((sw_ver_len <= 1) || (sw_ver_len >= input_len)) {
         SCLogDebug("Should not have sw version length '%" PRIu64 "'", sw_ver_len);
+        header->flags |= SSH_FLAG_VERSION_PARSED;
         SCReturnInt(-1);
     }
 
     header->software_version = SCMalloc(sw_ver_len + 1);
     if (header->software_version == NULL) {
+        header->flags |= SSH_FLAG_VERSION_PARSED;
         SCReturnInt(-1);
     }
     memcpy(header->software_version, line_ptr, sw_ver_len);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Adds SSH_FLAG_VERSION_PARSED to flags before each return
This way, we are sure SSHParseBanner does not get called again
And proto_version does not get leaked

Another way could be to call `SCFree(header->proto_version);` instead of `header->flags |= SSH_FLAG_VERSION_PARSED;`

Maybe we should return 0 instead of -1 if `(sw_ver_len <= 1)` so as to continue ssh parsing...

This was found by fuzzing as a potential leak (not present in suricata as returning -1 ensures we stop parsing)