### PR TITLE
Http log range v2

### DIFF
--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -151,6 +151,40 @@ end:
 }
 
 /**
+ *  \brief Sets range for a file
+ *
+ *  \param s http state
+ *  \param start start offset
+ *  \param end end offset
+ *
+ *  \retval 0 ok
+ *  \retval -1 error
+ */
+int HTPFileSetRange(HtpState *s, uint64_t start, uint64_t end)
+{
+    SCEnter();
+
+    int retval;
+    FileContainer *files;
+
+    if (s == NULL) {
+        SCReturnInt(-1);
+    }
+
+    files = s->files_tc;
+    if (files == NULL) {
+        SCLogDebug("no files in state");
+        SCReturnInt(-1);
+    }
+
+    retval = FileSetRange(files, start, end);
+    if (retval == -1) {
+        SCLogDebug("set range failed");
+    }
+    SCReturnInt(retval);
+}
+
+/**
  *  \brief Store a chunk of data in the flow
  *
  *  \param s http state

--- a/src/app-layer-htp-file.h
+++ b/src/app-layer-htp-file.h
@@ -26,6 +26,7 @@
 #define __APP_LAYER_HTP_FILE_H__
 
 int HTPFileOpen(HtpState *, const uint8_t *, uint16_t, const uint8_t *, uint32_t, uint64_t, uint8_t);
+int HTPFileSetRange(HtpState *, uint64_t start, uint64_t end);
 int HTPFileStoreChunk(HtpState *, const uint8_t *, uint32_t, uint8_t);
 int HTPFileClose(HtpState *, const uint8_t *, uint32_t, uint8_t, uint8_t);
 

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1633,6 +1633,16 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
                 htud->tcflags |= HTP_FILENAME_SET;
                 htud->tcflags &= ~HTP_DONTSTORE;
             }
+            //set range if present
+            htp_header_t *h_content_range = htp_table_get_c(tx->response_headers, "content-range");
+            if (h_content_range != NULL) {
+                htp_content_range_t crparsed;
+                if (htp_parse_content_range(h_content_range->value, &crparsed) == HTP_OK) {
+                    if (crparsed.end > 0) {
+                        HTPFileSetRange(hstate, crparsed.start, crparsed.end);
+                    }
+                }
+            }
         }
     }
     else

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -217,6 +217,10 @@ json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
         json_object_set_new(fjs, "file_id", json_integer(ff->file_store_id));
     }
     json_object_set_new(fjs, "size", json_integer(FileTrackedSize(ff)));
+    if (ff->end > 0) {
+        json_object_set_new(fjs, "start", json_integer(ff->start));
+        json_object_set_new(fjs, "end", json_integer(ff->end));
+    }
     json_object_set_new(fjs, "tx_id", json_integer(ff->txid));
 
     /* xff header */

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -739,6 +739,28 @@ int FileAppendGAPById(FileContainer *ffc, uint32_t track_id,
 }
 
 /**
+ *  \brief Sets the offset range for a file.
+ *
+ *  \param ffc the container
+ *  \param start start offset
+ *  \param end end offset
+ *
+ *  \retval  0 ok
+ *  \retval -1 error
+ */
+int FileSetRange(FileContainer *ffc, uint64_t start, uint64_t end)
+{
+    SCEnter();
+
+    if (ffc == NULL || ffc->tail == NULL) {
+        SCReturnInt(-1);
+    }
+    ffc->tail->start = start;
+    ffc->tail->end = end;
+    SCReturnInt(0);
+}
+
+/**
  *  \brief Open a new File
  *
  *  \param ffc flow container

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -89,6 +89,8 @@ typedef struct File_ {
                                      *   flag is set */
     uint64_t content_stored;
     uint64_t size;
+    uint64_t start;
+    uint64_t end;
 
     uint32_t *sid; /* signature id of a rule that triggered the filestore event */
     uint32_t sid_cnt;
@@ -168,6 +170,18 @@ int FileAppendDataById(FileContainer *, uint32_t track_id,
         const uint8_t *data, uint32_t data_len);
 int FileAppendGAPById(FileContainer *ffc, uint32_t track_id,
         const uint8_t *data, uint32_t data_len);
+
+/**
+ *  \brief Sets the offset range for a file.
+ *
+ *  \param ffc the container
+ *  \param start start offset
+ *  \param end end offset
+ *
+ *  \retval 0 ok
+ *  \retval -1 error
+ */
+int FileSetRange(FileContainer *, uint64_t start, uint64_t end);
 
 /**
  *  \brief Tag a file for storing


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2485

Describe changes:
- Logs http content-range header value (in responses) in json output

Follows #3773 
- Parses content-range so as to log integer values for start, end and size
- Puts these data in the file info record (separate commit)