### PR TITLE
smtp: recognizes protocol with server pattern

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1578,6 +1578,11 @@ static int SMTPRegisterPatternsForProtocolDetection(void)
     {
         return -1;
     }
+    if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_SMTP,
+                                               "220 ", 4, 0, STREAM_TOCLIENT) < 0)
+    {
+        return -1;
+    }
 
     return 0;
 }


### PR DESCRIPTION
Fixes #1125

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1125

Describe changes:
- Adds a pattern to recognize SMTP traffic from server

How can we test this ?
Should we try to recognize SMTP streams without seeing them start ? (In this case, we can add others patterns such as "250 ")