### PR TITLE
smtp: rset command resets bdat chunks length

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1275,6 +1275,11 @@ static int SMTPProcessRequest(SMTPState *state, Flow *f,
                 SCReturnInt(-1);
             }
             state->current_command = SMTP_COMMAND_OTHER_CMD;
+        } else if (state->current_line_len >= 4 &&
+                   SCMemcmpLowercase("rset", state->current_line, 4) == 0) {
+            // Resets chunk index in case of connection reuse
+            state->bdat_chunk_idx = 0;
+            state->curr_tx->done = 1;
         } else {
             state->current_command = SMTP_COMMAND_OTHER_CMD;
         }


### PR DESCRIPTION
Fixes #1860

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1860

Describe changes:
- SMTP RSET command resets bdat chunk length (and sets transaction to done)

So it avoids false positives for `BDAT_CHUNK_LEN_EXCEEDED` event
