### PR TITLE
http: logs content range

### DIFF
--- a/src/app-layer-htp-file.h
+++ b/src/app-layer-htp-file.h
@@ -25,7 +25,15 @@
 #ifndef __APP_LAYER_HTP_FILE_H__
 #define __APP_LAYER_HTP_FILE_H__
 
+typedef struct HtpContentRange_ {
+    int64_t start;
+    int64_t end;
+    int64_t size;
+} HtpContentRange_t;
+
 int HTPFileOpen(HtpState *, const uint8_t *, uint16_t, const uint8_t *, uint32_t, uint64_t, uint8_t);
+int HTPParseContentRange(bstr * rawvalue, HtpContentRange_t *range);
+int HTPFileSetRange(HtpState *, bstr *rawvalue);
 int HTPFileStoreChunk(HtpState *, const uint8_t *, uint32_t, uint8_t);
 int HTPFileClose(HtpState *, const uint8_t *, uint32_t, uint8_t, uint8_t);
 

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1633,6 +1633,11 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
                 htud->tcflags |= HTP_FILENAME_SET;
                 htud->tcflags &= ~HTP_DONTSTORE;
             }
+            //set range if present
+            htp_header_t *h_content_range = htp_table_get_c(tx->response_headers, "content-range");
+            if (h_content_range != NULL) {
+                HTPFileSetRange(hstate, h_content_range->value);
+            }
         }
     }
     else

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -217,6 +217,10 @@ json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
         json_object_set_new(fjs, "file_id", json_integer(ff->file_store_id));
     }
     json_object_set_new(fjs, "size", json_integer(FileTrackedSize(ff)));
+    if (ff->end > 0) {
+        json_object_set_new(fjs, "start", json_integer(ff->start));
+        json_object_set_new(fjs, "end", json_integer(ff->end));
+    }
     json_object_set_new(fjs, "tx_id", json_integer(ff->txid));
 
     /* xff header */

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -739,6 +739,28 @@ int FileAppendGAPById(FileContainer *ffc, uint32_t track_id,
 }
 
 /**
+ *  \brief Sets the offset range for a file.
+ *
+ *  \param ffc the container
+ *  \param start start offset
+ *  \param end end offset
+ *
+ *  \retval  0 ok
+ *  \retval -1 error
+ */
+int FileSetRange(FileContainer *ffc, uint64_t start, uint64_t end)
+{
+    SCEnter();
+
+    if (ffc == NULL || ffc->tail == NULL) {
+        SCReturnInt(-1);
+    }
+    ffc->tail->start = start;
+    ffc->tail->end = end;
+    SCReturnInt(0);
+}
+
+/**
  *  \brief Open a new File
  *
  *  \param ffc flow container

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -89,6 +89,8 @@ typedef struct File_ {
                                      *   flag is set */
     uint64_t content_stored;
     uint64_t size;
+    uint64_t start;
+    uint64_t end;
 
     uint32_t *sid; /* signature id of a rule that triggered the filestore event */
     uint32_t sid_cnt;
@@ -168,6 +170,18 @@ int FileAppendDataById(FileContainer *, uint32_t track_id,
         const uint8_t *data, uint32_t data_len);
 int FileAppendGAPById(FileContainer *ffc, uint32_t track_id,
         const uint8_t *data, uint32_t data_len);
+
+/**
+ *  \brief Sets the offset range for a file.
+ *
+ *  \param ffc the container
+ *  \param start start offset
+ *  \param end end offset
+ *
+ *  \retval 0 ok
+ *  \retval -1 error
+ */
+int FileSetRange(FileContainer *, uint64_t start, uint64_t end);
 
 /**
  *  \brief Tag a file for storing


### PR DESCRIPTION
Fixes #2485

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2485

Describe changes:
- Logs http content-range header value (in responses) in json output

Follows #3805 
- Minor changes requested by Victor (indentation, renaming...)
- Moves parsing content range (`HTPParseContentRange`) code from libhtp to suricata (so there is no longer a libhtp pull request)