### PR TITLE
Sticky lua

### DIFF
--- a/doc/userguide/rules/rule-lua-scripting.rst
+++ b/doc/userguide/rules/rule-lua-scripting.rst
@@ -30,6 +30,7 @@ inspection. Currently the following are available:
 
 * packet -- entire packet, including headers
 * payload -- packet payload (not stream)
+* buffer -- the current sticky buffer
 * http.uri
 * http.uri.raw
 * http.request_line

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -69,7 +69,7 @@ void DetectFilemagicRegister(void)
 {
     sigmatch_table[DETECT_FILEMAGIC].name = "filemagic";
     sigmatch_table[DETECT_FILEMAGIC].desc = "match on the information libmagic returns about a file";
-    sigmatch_table[DETECT_FILEMAGIC].url = "https://suricata.readthedocs.io/en/latest/rules/file-keywords.html#filemagic";
+    sigmatch_table[DETECT_FILEMAGIC].url = DOC_URL DOC_VERSION "/rules/file-keywords.html#filemagic";
     sigmatch_table[DETECT_FILEMAGIC].Setup = DetectFilemagicSetupNoSupport;
     sigmatch_table[DETECT_FILEMAGIC].flags = SIGMATCH_QUOTES_MANDATORY|SIGMATCH_HANDLE_NEGATION;
 }

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -418,7 +418,7 @@ static int DetectEngineInspectFilename(
     if (r == 1)
         return DETECT_ENGINE_INSPECT_SIG_MATCH;
     else
-        return DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
+        return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH_FILESTORE;
 }
 
 typedef struct PrefilterMpmFilename {

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -113,7 +113,7 @@ void DetectLuaRegister(void)
     sigmatch_table[DETECT_LUA].name = "lua";
     sigmatch_table[DETECT_LUA].alias = "luajit";
     sigmatch_table[DETECT_LUA].desc = "match via a lua script";
-    sigmatch_table[DETECT_LUA].url = "https://suricata.readthedocs.io/en/latest/rules/rule-lua-scripting.html";
+    sigmatch_table[DETECT_LUA].url = DOC_URL DOC_VERSION "/rules/rule-lua-scripting.html";
     sigmatch_table[DETECT_LUA].Match = DetectLuaMatch;
     sigmatch_table[DETECT_LUA].AppLayerTxMatch = DetectLuaAppTxMatch;
     sigmatch_table[DETECT_LUA].Setup = DetectLuaSetup;

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -172,7 +172,7 @@ static int InspectSmtpGeneric(ThreadVars *tv,
 #define DATATYPE_SSH                        (1<<19)
 #define DATATYPE_SMTP                       (1<<20)
 
-#define DATATYPE_DNP3                       (1<<20)
+#define DATATYPE_DNP3                       (1<<21)
 
 #if 0
 /** \brief dump stack from lua state to screen */


### PR DESCRIPTION
This small patchset adds the capability for a lua script to ask for the current sticky buffer.

It can be used in signature like that:
```
alert smb any any -> any any (file.name; content:"toto"; lua:buffer.lua; sid: 1;)
```

and in the lua script, the init function ask for the `buffer` field like that:
```lua
function init (args)
    local needs = {}
    needs["buffer"] = tostring(true)
    return needs
end
```
- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2937

Describe changes:
- implement 'buffer' needs variable
- update filename keyword to avoid multiple inspections of same content

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output: 
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/445
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/226
