### PR TITLE
fix build on m68k with uclibc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -889,6 +889,8 @@
         exit 1
     fi
 
+    AC_CHECK_FUNCS([pthread_spin_unlock])
+
   # libjansson
     AC_ARG_WITH(libjansson_includes,
             [  --with-libjansson-includes=DIR  libjansson include directory],

--- a/src/threads.h
+++ b/src/threads.h
@@ -155,7 +155,7 @@ enum {
 #define SCCtrlCondDestroy pthread_cond_destroy
 
 /* spinlocks */
-#if ((_POSIX_SPIN_LOCKS - 200112L) < 0L) || defined HELGRIND
+#if ((_POSIX_SPIN_LOCKS - 200112L) < 0L) || defined HELGRIND || !defined(HAVE_PTHREAD_SPIN_UNLOCK)
 #define SCSpinlock                              SCMutex
 #define SCSpinLock(spin)                        SCMutexLock((spin))
 #define SCSpinTrylock(spin)                     SCMutexTrylock((spin))


### PR DESCRIPTION
uclibc on m68k defines _POSIX_SPIN_LOCKS but does not define
pthread_spin_unlock so check for this function before using
pthread_spin_xxx functions

Fixes:
 - http://autobuild.buildroot.org/results/ed923bcc1454ce90444b8dac7c064b5f4ea4a0a5

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>

Link to [redmine] ticket: https://redmine.openinfosecfoundation.org/issues/2992