### PR TITLE
Issue 2961: Fix memleak in filestore plus ifdef removal - v2

### DIFF
--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -158,7 +158,6 @@ static void OutputFilestoreFinalizeFiles(ThreadVars *tv,
         return;
     }
 
-#ifdef HAVE_LIBJANSSON
     if (ctx->fileinfo) {
         char js_metadata_filename[PATH_MAX];
         if (snprintf(js_metadata_filename, sizeof(js_metadata_filename),
@@ -176,7 +175,6 @@ static void OutputFilestoreFinalizeFiles(ThreadVars *tv,
             }
         }
     }
-#endif
 }
 
 static int OutputFilestoreLogger(ThreadVars *tv, void *thread_data,
@@ -451,13 +449,8 @@ static OutputInitResult OutputFilestoreLogInitCtx(ConfNode *conf)
     const char *write_fileinfo = ConfNodeLookupChildValue(conf,
             "write-fileinfo");
     if (write_fileinfo != NULL && ConfValIsTrue(write_fileinfo)) {
-#ifdef HAVE_LIBJANSSON
         SCLogConfig("Filestore (v2) will output fileinfo records.");
         ctx->fileinfo = true;
-#else
-        SCLogWarning(SC_ERR_NO_JSON_SUPPORT,
-                "Filestore (v2) requires JSON support to log fileinfo records");
-#endif
     }
 
     const char *force_filestore = ConfNodeLookupChildValue(conf,

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -68,8 +68,6 @@
 #include "util-memcmp.h"
 #include "stream-tcp-reassemble.h"
 
-#ifdef HAVE_LIBJANSSON
-
 typedef struct OutputFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t file_cnt;
@@ -118,7 +116,6 @@ json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
             if (hjs)
                 json_object_set_new(js, "email", hjs);
             break;
-#ifdef HAVE_RUST
         case ALPROTO_NFS:
             hjs = JsonNFSAddMetadataRPC(p->flow, ff->txid);
             if (hjs)
@@ -132,7 +129,6 @@ json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
             if (hjs)
                 json_object_set_new(js, "smb", hjs);
             break;
-#endif
     }
 
     json_object_set_new(js, "app_proto",
@@ -402,11 +398,3 @@ void JsonFileLogRegister (void)
         "eve-log.files", OutputFileLogInitSub, JsonFileLogger,
         JsonFileLogThreadInit, JsonFileLogThreadDeinit, NULL);
 }
-
-#else
-
-void JsonFileLogRegister (void)
-{
-}
-
-#endif

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -156,7 +156,7 @@ json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
     }
 
     for (uint32_t i = 0; ff->sid != NULL && i < ff->sid_cnt; i++) {
-        json_array_append(sig_ids, json_integer(ff->sid[i]));
+        json_array_append_new(sig_ids, json_integer(ff->sid[i]));
     }
     json_object_set_new(fjs, "sid", sig_ids);
 

--- a/src/output-json-file.h
+++ b/src/output-json-file.h
@@ -24,13 +24,10 @@
 #ifndef __OUTPUT_JSON_FILE_H__
 #define __OUTPUT_JSON_FILE_H__
 
-void JsonFileLogRegister(void);
-
-#ifdef HAVE_LIBJANSSON
 #include "app-layer-htp-xff.h"
 
+void JsonFileLogRegister(void);
 json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
         const bool stored, uint8_t dir, HttpXFFCfg *xff_cfg);
-#endif
 
 #endif /* __OUTPUT_JSON_FILE_H__ */


### PR DESCRIPTION
Fix leak in file metadata by using json_array_append_new instead of json_array_append to transfer ownership of an integer to the json object so its freed along with the json object.

While in file/filestore, remove Rust and Jansson ifdefs.

Redmine issue:
- https://redmine.openinfosecfoundation.org/issues/2961

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/352
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/707
