### PR TITLE
smtp: recognizes protocol with server pattern

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1566,6 +1566,43 @@ static int SMTPStateGetEventInfo(const char *event_name,
     return 0;
 }
 
+static AppProto SMTPProbingParserTc(Flow *f, uint8_t direction,
+        uint8_t *input, uint32_t ilen, uint8_t *rdir)
+{
+    // Server banner is 220, space or hyphen, name, protocol, server agent
+    // protocol can be either SMTP or ESTMP (extended SMTP)
+    // Examples :
+    //220-xc90.websitewelcome.com ESMTP Exim 4.69 #1 Mon, 05 Oct 2009 01:05:54 -0500
+    //220 Air-de-catena.localdomain ESMTP Postfix
+    //220 smtp001.mail.xxx.xxxxx.com ESMTP
+
+    // Skips response code
+    size_t pos = 4;
+    if (ilen < 4)
+        return ALPROTO_UNKNOWN;
+
+    // Skips name
+    while (pos < ilen && input[pos] != ' ')
+        pos++;
+    pos++;
+    if (pos + 4 >= ilen) {
+        return ALPROTO_UNKNOWN;
+    }
+    // Checks protocol
+    if (memcmp(input+pos, "SMTP", 4) == 0) {
+        return ALPROTO_SMTP;
+    }
+    if (pos + 5 >= ilen) {
+        // We will be called again with more data
+        return ALPROTO_UNKNOWN;
+    }
+    if (memcmp(input+pos, "ESMTP", 5) == 0) {
+        return ALPROTO_SMTP;
+    }
+
+    return ALPROTO_FAILED;
+}
+
 static int SMTPRegisterPatternsForProtocolDetection(void)
 {
     if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_SMTP,
@@ -1580,6 +1617,19 @@ static int SMTPRegisterPatternsForProtocolDetection(void)
     }
     if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_SMTP,
                                                "QUIT", 4, 0, STREAM_TOSERVER) < 0)
+    {
+        return -1;
+    }
+    // limits banner detection to 256 characters
+    if (AppLayerProtoDetectPMRegisterPatternCSwPP(IPPROTO_TCP, ALPROTO_SMTP,
+                                                  "220 ", 4, 0, STREAM_TOCLIENT,
+                                                  SMTPProbingParserTc, 4, 256) < 0)
+    {
+        return -1;
+    }
+    if (AppLayerProtoDetectPMRegisterPatternCSwPP(IPPROTO_TCP, ALPROTO_SMTP,
+                                                  "220-", 4, 0, STREAM_TOCLIENT,
+                                                  SMTPProbingParserTc, 4, 256) < 0)
     {
         return -1;
     }


### PR DESCRIPTION
Use of SMTPProbingParserTc to distinguish from FTP after pattern recognition

Link to redmine ticket:
https://redmine.openinfosecfoundation.org/issues/1125

Describe changes:
- Adds a pattern and a probing parser to recognize SMTP traffic from server

Modified from #3823 :

Added examples in comments of expected lines
Return `ALPROTO_UNKNOWN` if we do not have enough data to be sure to recognize 