### PR TITLE
detect/analyzer: Improve warning message

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1299,7 +1299,7 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
             fprintf(rule_engine_analysis_FD, "    Warning: Rule has no direction indicator.\n");
         }
         if (warn_both_direction) {
-            fprintf(rule_engine_analysis_FD, "    Warning: Rule is inspecting both directions.\n");
+            fprintf(rule_engine_analysis_FD, "    Warning: Rule is inspecting both the request and the response.\n");
         }
         if (rule_warning == 0) {
             fprintf(rule_engine_analysis_FD, "    No warnings for this rule.\n");


### PR DESCRIPTION
This changeset modifies the warning printed when a rule
is determined to detect in both directions.

This is for issue [2847](https://redmine.openinfosecfoundation.org/issues/2847)

## Example
```
-------------------------------------------------------------------
Date: 9/5/2019 -- 16:10:31
-------------------------------------------------------------------
== Sid: 2847 ==
alert udp $HOME_NET any -> $EXTERNAL_NET 53 (msg:"ET INFO DYNAMIC_DNS Query to a Suspicious *.ez-dns.com Domain"; content:"|01 00 00 01 00 00 00 00 00 00|"; depth:10; offset:2; content:"|06|ez-dns|03|com"; fast_pattern; nocase; distance:0; sid:2847; rev:1;)
    Rule contains 2 content options, 0 http content options, 0 pcre options, and 0 pcre options with http modifiers.
    Fast Pattern "\x06ez-dns\x03com" on "payload" buffer.
    Warning: Rule is inspecting both the request and the response.
```