### PR TITLE
Next/41x/415/v4

### DIFF
--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -245,7 +245,7 @@
 
 static void PrintFeatureList(const SigTableElmt *e, char sep)
 {
-    const uint8_t flags = e->flags;
+    const uint16_t flags = e->flags;
 
     int prev = 0;
     if (flags & SIGMATCH_NOOPT) {
@@ -262,6 +262,18 @@ static void PrintFeatureList(const SigTableElmt *e, char sep)
         if (prev == 1)
             printf("%c", sep);
         printf("compatible with decoder event only rule");
+        prev = 1;
+    }
+    if (flags & SIGMATCH_INFO_CONTENT_MODIFIER) {
+        if (prev == 1)
+            printf("%c", sep);
+        printf("content modifier");
+        prev = 1;
+    }
+    if (flags & SIGMATCH_INFO_STICKY_BUFFER) {
+        if (prev == 1)
+            printf("%c", sep);
+        printf("sticky buffer");
         prev = 1;
     }
     if (e->Transform) {
@@ -290,6 +302,9 @@ static void SigMultilinePrint(int i, const char *prefix)
     PrintFeatureList(&sigmatch_table[i], ',');
     if (sigmatch_table[i].url) {
         printf("\n%sDocumentation: %s", prefix, sigmatch_table[i].url);
+    }
+    if (sigmatch_table[i].alternative) {
+        printf("\n%sReplaced by: %s", prefix, sigmatch_table[sigmatch_table[i].alternative].name);
     }
     printf("\n");
 }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -641,6 +641,18 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
     }
     s->init_data->negated = false;
 
+    if (st->flags & SIGMATCH_INFO_DEPRECATED) {
+#define URL "https://suricata-ids.org/about/deprecation-policy/"
+        if (st->alternative == 0)
+            SCLogWarning(SC_WARN_DEPRECATED, "keyword '%s' is deprecated "
+                    "and will be removed soon. See %s", st->name, URL);
+        else
+            SCLogWarning(SC_WARN_DEPRECATED, "keyword '%s' is deprecated "
+                    "and will be removed soon. Use '%s' instead. "
+                    "See %s", st->name, sigmatch_table[st->alternative].name, URL);
+#undef URL
+    }
+
     /* Validate double quoting, trimming trailing white space along the way. */
     if (optvalue != NULL && strlen(optvalue) > 0) {
         size_t ovlen = strlen(optvalue);

--- a/src/detect-ssh-proto-version.c
+++ b/src/detect-ssh-proto-version.c
@@ -82,7 +82,8 @@ void DetectSshVersionRegister(void)
     sigmatch_table[DETECT_AL_SSH_PROTOVERSION].Setup = DetectSshVersionSetup;
     sigmatch_table[DETECT_AL_SSH_PROTOVERSION].Free  = DetectSshVersionFree;
     sigmatch_table[DETECT_AL_SSH_PROTOVERSION].RegisterTests = DetectSshVersionRegisterTests;
-    sigmatch_table[DETECT_AL_SSH_PROTOVERSION].flags = SIGMATCH_QUOTES_OPTIONAL;
+    sigmatch_table[DETECT_AL_SSH_PROTOVERSION].flags = SIGMATCH_QUOTES_OPTIONAL|SIGMATCH_INFO_DEPRECATED;
+    sigmatch_table[DETECT_AL_SSH_PROTOVERSION].alternative = DETECT_AL_SSH_PROTOCOL;
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 

--- a/src/detect-ssh-software-version.c
+++ b/src/detect-ssh-software-version.c
@@ -96,7 +96,8 @@ void DetectSshSoftwareVersionRegister(void)
     sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].Setup = DetectSshSoftwareVersionSetup;
     sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].Free  = DetectSshSoftwareVersionFree;
     sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].RegisterTests = DetectSshSoftwareVersionRegisterTests;
-    sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].flags = SIGMATCH_QUOTES_OPTIONAL;
+    sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].flags = SIGMATCH_QUOTES_OPTIONAL|SIGMATCH_INFO_DEPRECATED;
+    sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].alternative = DETECT_AL_SSH_SOFTWARE;
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1151,7 +1151,7 @@ typedef struct SigTableElmt_ {
     void (*Free)(void *);
     void (*RegisterTests)(void);
 
-    uint8_t flags;
+    uint16_t flags;
     /* coccinelle: SigTableElmt:flags:SIGMATCH_ */
 
     const char *name;     /**< keyword name alias */
@@ -1322,27 +1322,27 @@ typedef struct SigGroupHead_ {
 } SigGroupHead;
 
 /** sigmatch has no options, so the parser shouldn't expect any */
-#define SIGMATCH_NOOPT          (1 << 0)
+#define SIGMATCH_NOOPT              BIT_U16(0)
 /** sigmatch is compatible with a ip only rule */
-#define SIGMATCH_IPONLY_COMPAT  (1 << 1)
+#define SIGMATCH_IPONLY_COMPAT      BIT_U16(1)
 /** sigmatch is compatible with a decode event only rule */
-#define SIGMATCH_DEONLY_COMPAT  (1 << 2)
+#define SIGMATCH_DEONLY_COMPAT      BIT_U16(2)
 /**< Flag to indicate that the signature is not built-in */
-#define SIGMATCH_NOT_BUILT      (1 << 3)
+#define SIGMATCH_NOT_BUILT          BIT_U16(3)
 /** sigmatch may have options, so the parser should be ready to
  *  deal with both cases */
-#define SIGMATCH_OPTIONAL_OPT       (1 << 4)
+#define SIGMATCH_OPTIONAL_OPT       BIT_U16(4)
 /** input may be wrapped in double quotes. They will be stripped before
  *  input data is passed to keyword parser */
-#define SIGMATCH_QUOTES_OPTIONAL    (1 << 5)
+#define SIGMATCH_QUOTES_OPTIONAL    BIT_U16(5)
 /** input MUST be wrapped in double quotes. They will be stripped before
  *  input data is passed to keyword parser. Missing double quotes lead to
  *  error and signature invalidation. */
-#define SIGMATCH_QUOTES_MANDATORY   (1 << 6)
+#define SIGMATCH_QUOTES_MANDATORY   BIT_U16(6)
 /** negation parsing is handled by the rule parser. Signature::init_data::negated
  *  will be set to true or false prior to calling the keyword parser. Exclamation
  *  mark is stripped from the input to the keyword parser. */
-#define SIGMATCH_HANDLE_NEGATION    (1 << 7)
+#define SIGMATCH_HANDLE_NEGATION    BIT_U16(7)
 
 enum DetectEngineTenantSelectors
 {

--- a/src/detect.h
+++ b/src/detect.h
@@ -1350,6 +1350,8 @@ typedef struct SigGroupHead_ {
 #define SIGMATCH_INFO_CONTENT_MODIFIER  BIT_U16(8)
 /** keyword is a sticky buffer */
 #define SIGMATCH_INFO_STICKY_BUFFER     BIT_U16(9)
+/** keyword is deprecated: used to suggest an alternative */
+#define SIGMATCH_INFO_DEPRECATED        BIT_U16(10)
 
 enum DetectEngineTenantSelectors
 {

--- a/src/detect.h
+++ b/src/detect.h
@@ -1154,6 +1154,9 @@ typedef struct SigTableElmt_ {
     uint16_t flags;
     /* coccinelle: SigTableElmt:flags:SIGMATCH_ */
 
+    /** better keyword to replace the current one */
+    uint16_t alternative;
+
     const char *name;     /**< keyword name alias */
     const char *alias;    /**< name alias */
     const char *desc;
@@ -1322,27 +1325,31 @@ typedef struct SigGroupHead_ {
 } SigGroupHead;
 
 /** sigmatch has no options, so the parser shouldn't expect any */
-#define SIGMATCH_NOOPT              BIT_U16(0)
+#define SIGMATCH_NOOPT                  BIT_U16(0)
 /** sigmatch is compatible with a ip only rule */
-#define SIGMATCH_IPONLY_COMPAT      BIT_U16(1)
+#define SIGMATCH_IPONLY_COMPAT          BIT_U16(1)
 /** sigmatch is compatible with a decode event only rule */
-#define SIGMATCH_DEONLY_COMPAT      BIT_U16(2)
+#define SIGMATCH_DEONLY_COMPAT          BIT_U16(2)
 /**< Flag to indicate that the signature is not built-in */
-#define SIGMATCH_NOT_BUILT          BIT_U16(3)
+#define SIGMATCH_NOT_BUILT              BIT_U16(3)
 /** sigmatch may have options, so the parser should be ready to
  *  deal with both cases */
-#define SIGMATCH_OPTIONAL_OPT       BIT_U16(4)
+#define SIGMATCH_OPTIONAL_OPT           BIT_U16(4)
 /** input may be wrapped in double quotes. They will be stripped before
  *  input data is passed to keyword parser */
-#define SIGMATCH_QUOTES_OPTIONAL    BIT_U16(5)
+#define SIGMATCH_QUOTES_OPTIONAL        BIT_U16(5)
 /** input MUST be wrapped in double quotes. They will be stripped before
  *  input data is passed to keyword parser. Missing double quotes lead to
  *  error and signature invalidation. */
-#define SIGMATCH_QUOTES_MANDATORY   BIT_U16(6)
+#define SIGMATCH_QUOTES_MANDATORY       BIT_U16(6)
 /** negation parsing is handled by the rule parser. Signature::init_data::negated
  *  will be set to true or false prior to calling the keyword parser. Exclamation
  *  mark is stripped from the input to the keyword parser. */
-#define SIGMATCH_HANDLE_NEGATION    BIT_U16(7)
+#define SIGMATCH_HANDLE_NEGATION        BIT_U16(7)
+/** keyword is a content modifier */
+#define SIGMATCH_INFO_CONTENT_MODIFIER  BIT_U16(8)
+/** keyword is a sticky buffer */
+#define SIGMATCH_INFO_STICKY_BUFFER     BIT_U16(9)
 
 enum DetectEngineTenantSelectors
 {


### PR DESCRIPTION
Fix SSH mem leak. Add warning that old ssh keywords are deprecated.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed.
