### PR TITLE
af-packet: remove rollover reference

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -336,6 +336,8 @@ static void *ParseAFPConfig(const char *iface)
     } else if (strcmp(tmpctype, "cluster_rollover") == 0) {
         SCLogConfig("Using rollover based cluster mode for AF_PACKET (iface %s)",
                 aconf->iface);
+        SCLogWarning(SC_WARN_UNCOMMON, "Rollover mode is causing severe flow "
+                                       "tracking issues, use it at your own risk.");
         aconf->cluster_type = PACKET_FANOUT_ROLLOVER;
         cluster_type = PACKET_FANOUT_ROLLOVER;
 #ifdef HAVE_PACKET_EBPF
@@ -355,6 +357,8 @@ static void *ParseAFPConfig(const char *iface)
         SCLogConfig("Using rollover kernel functionality for AF_PACKET (iface %s)",
                 aconf->iface);
         aconf->cluster_type |= PACKET_FANOUT_FLAG_ROLLOVER;
+        SCLogWarning(SC_WARN_UNCOMMON, "Rollover option is causing severe flow "
+                                       "tracking issues, use it at your own risk.");
     }
 
     /*load af_packet bpf filter*/

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -629,15 +629,10 @@ af-packet:
     # Default AF_PACKET cluster type. AF_PACKET can load balance per flow or per hash.
     # This is only supported for Linux kernel > 3.1
     # possible value are:
-    #  * cluster_round_robin: round robin load balancing
     #  * cluster_flow: all packets of a given flow are send to the same socket
     #  * cluster_cpu: all packets treated in kernel by a CPU are send to the same socket
     #  * cluster_qm: all packets linked by network card to a RSS queue are sent to the same
     #  socket. Requires at least Linux 3.14.
-    #  * cluster_random: packets are sent randomly to sockets but with an equipartition.
-    #  Requires at least Linux 3.14.
-    #  * cluster_rollover: kernel rotates between sockets filling each socket before moving
-    #  to the next. Requires at least Linux 3.10.
     #  * cluster_ebpf: eBPF file load balancing. See doc/userguide/capture-hardware/ebpf-xdp.rst for
     #  more info.
     # Recommended modes are cluster_flow on most boxes and cluster_cpu or cluster_qm on system
@@ -646,10 +641,6 @@ af-packet:
     # In some fragmentation case, the hash can not be computed. If "defrag" is set
     # to yes, the kernel will do the needed defragmentation before sending the packets.
     defrag: yes
-    # After Linux kernel 3.10 it is possible to activate the rollover option: if a socket is
-    # full then kernel will send the packet on the next socket with room available. This option
-    # can minimize packet drop and increase the treated bandwidth on single intensive flow.
-    #rollover: yes
     # To use the ring feature of AF_PACKET, set 'use-mmap' to yes
     #use-mmap: yes
     # Lock memory map to avoid it goes to swap. Be careful that over subscribing could lock
@@ -706,7 +697,6 @@ af-packet:
   - interface: default
     #threads: auto
     #use-mmap: no
-    #rollover: yes
     #tpacket-v3: yes
 
 # Cross platform libpcap capture support


### PR DESCRIPTION
This patch removes reference to rollover in the configuration file and add warnings when it is used.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Remove rollover related options from the configuration file
- Add "use it at your own risk" warning message

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/447
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/228
