### PR TITLE
signature: fix overflow in parsing

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1032,6 +1032,10 @@ static inline int SigParseList(char **input, char *output,
             }
         }
     }
+    if (i == len) {
+        *input = NULL;
+        return 0;
+    }
     (*input)[i] = '\0';
     strlcpy(output, *input, output_size);
     *input = *input + i + 1;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Fixes an overflow in SigInit / SigParseBasics / SigParseList

An unfinished list would make us overflow the buffer with `*input = *input + i + 1;`