### PR TITLE
Request for Comments #2: App layer/proto detection anomaly event logging

### DIFF
--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -1522,6 +1522,24 @@ static int DNP3StateGetEventInfo(const char *event_name, int *event_id,
 /**
  * \brief App-layer support.
  */
+static int DNP3StateGetEventInfoById(int event_id, const char **event_name,
+                                     AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, dnp3_decoder_event_table);
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "Event \"%d\" not present in "
+            "the DNP3 enum event map table.", event_id);
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
+/**
+ * \brief App-layer support.
+ */
 static DetectEngineState *DNP3GetTxDetectState(void *vtx)
 {
     DNP3Transaction *tx = vtx;
@@ -1654,6 +1672,8 @@ void RegisterDNP3Parsers(void)
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_DNP3,
             DNP3StateGetEventInfo);
+        AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_DNP3,
+            DNP3StateGetEventInfoById);
 
         AppLayerParserRegisterLoggerFuncs(IPPROTO_TCP, ALPROTO_DNP3,
             DNP3GetTxLogged, DNP3SetTxLogged);

--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -52,9 +52,32 @@ int DNSStateGetEventInfo(const char *event_name,
     return 0;
 }
 
+int DNSStateGetEventInfoById(int event_id, const char **event_name,
+                             AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, dns_decoder_event_table);
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%d\" not present in "
+                   "dns's enum map table.",  event_id);
+        /* this should be treated as fatal */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
 void DNSAppLayerRegisterGetEventInfo(uint8_t ipproto, AppProto alproto)
 {
     AppLayerParserRegisterGetEventInfo(ipproto, alproto, DNSStateGetEventInfo);
+
+    return;
+}
+
+void DNSAppLayerRegisterGetEventInfoById(uint8_t ipproto, AppProto alproto)
+{
+    AppLayerParserRegisterGetEventInfoById(ipproto, alproto, DNSStateGetEventInfoById);
 
     return;
 }

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -136,7 +136,10 @@ typedef struct DNSHeader_ {
 
 int DNSStateGetEventInfo(const char *event_name,
                          int *event_id, AppLayerEventType *event_type);
+int DNSStateGetEventInfoById(int event_id, const char **event_name,
+                             AppLayerEventType *event_type);
 void DNSAppLayerRegisterGetEventInfo(uint8_t ipproto, AppProto alproto);
+void DNSAppLayerRegisterGetEventInfoById(uint8_t ipproto, AppProto alproto);
 
 void DNSCreateTypeString(uint16_t type, char *str, size_t str_size);
 void DNSCreateRcodeString(uint8_t rcode, char *str, size_t str_size);

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -144,6 +144,22 @@ static int ENIPStateGetEventInfo(const char *event_name, int *event_id, AppLayer
     return 0;
 }
 
+static int ENIPStateGetEventInfoById(int event_id, const char **event_name,
+                                     AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, enip_decoder_event_table);
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%d\" not present in "
+                   "enip's enum map table.",  event_id);
+        /* yes this is fatal */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
 /** \brief Allocate enip state
  *
  *  return state
@@ -441,6 +457,7 @@ void RegisterENIPUDPParsers(void)
         AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_ENIP, ENIPGetAlstateProgressCompletionStatus);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_UDP, ALPROTO_ENIP, ENIPStateGetEventInfo);
+        AppLayerParserRegisterGetEventInfoById(IPPROTO_UDP, ALPROTO_ENIP, ENIPStateGetEventInfoById);
 
         AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_UDP,
                 ALPROTO_ENIP, STREAM_TOSERVER | STREAM_TOCLIENT);

--- a/src/app-layer-events.c
+++ b/src/app-layer-events.c
@@ -48,6 +48,22 @@ SCEnumCharMap app_layer_event_pkt_table[ ] = {
       -1 },
 };
 
+int AppLayerGetEventInfoById(int event_id, const char **event_name,
+                                     AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, app_layer_event_pkt_table);
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%d\" not present in "
+                   "app-layer-event's enum map table.",  event_id);
+        /* yes this is fatal */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_PACKET;
+
+    return 0;
+}
+
 int AppLayerGetPktEventInfo(const char *event_name, int *event_id)
 {
     *event_id = SCMapEnumNameToValue(event_name, app_layer_event_pkt_table);

--- a/src/app-layer-events.h
+++ b/src/app-layer-events.h
@@ -58,6 +58,8 @@ typedef enum AppLayerEventType_ {
 
 int AppLayerGetPktEventInfo(const char *event_name, int *event_id);
 
+int AppLayerGetEventInfoById(int event_id, const char **event_name,
+                             AppLayerEventType *event_type);
 void AppLayerDecoderEventsSetEventRaw(AppLayerDecoderEvents **sevents, uint8_t event);
 void AppLayerDecoderEventsSetEvent(Flow *f, uint8_t event);
 

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2840,6 +2840,22 @@ static int HTPStateGetEventInfo(const char *event_name,
     return 0;
 }
 
+static int HTPStateGetEventInfoById(int event_id, const char **event_name,
+                                    AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, http_decoder_event_table);
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%d\" not present in "
+                   "http's enum map table.",  event_id);
+        /* this should be treated as fatal */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
 static void HTPStateTruncate(void *state, uint8_t direction)
 {
     FileContainer *fc = HTPStateGetFiles(state, direction);
@@ -2985,6 +3001,7 @@ void RegisterHTPParsers(void)
                                                                HTPStateGetAlstateProgressCompletionStatus);
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_HTTP, HTPGetEvents);
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_HTTP, HTPStateGetEventInfo);
+        AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_HTTP, HTPStateGetEventInfoById);
 
         AppLayerParserRegisterTruncateFunc(IPPROTO_TCP, ALPROTO_HTTP, HTPStateTruncate);
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_HTTP,

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -209,7 +209,7 @@ typedef struct HtpTxUserData_ {
 
     AppLayerDecoderEvents *decoder_events;          /**< per tx events */
 
-    /** Holds the boundary identificator string if any (used on
+    /** Holds the boundary identification string if any (used on
      *  multipart/form-data only)
      */
     uint8_t *boundary;
@@ -228,7 +228,7 @@ typedef struct HtpState_ {
     htp_connp_t *connp;
     /* Connection structure for each connection */
     htp_conn_t *conn;
-    Flow *f;                /**< Needed to retrieve the original flow when usin HTPLib callbacks */
+    Flow *f;                /**< Needed to retrieve the original flow when using HTPLib callbacks */
     uint64_t transaction_cnt;
     uint64_t store_tx_id;
     FileContainer *files_ts;

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -186,6 +186,23 @@ static int ModbusStateGetEventInfo(const char *event_name, int *event_id, AppLay
     return 0;
 }
 
+static int ModbusStateGetEventInfoById(int event_id, const char **event_name,
+                                       AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, modbus_decoder_event_table);
+
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%d\" not present in "
+                   "modbus's enum map table.",  event_id);
+        /* yes this is fatal */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
 static void ModbusSetEvent(ModbusState *modbus, uint8_t e)
 {
     if (modbus && modbus->curr) {
@@ -1538,6 +1555,7 @@ void RegisterModbusParsers(void)
                                                                 ModbusGetAlstateProgressCompletionStatus);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_MODBUS, ModbusStateGetEventInfo);
+        AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_MODBUS, ModbusStateGetEventInfoById);
 
         AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_TCP, ALPROTO_MODBUS, STREAM_TOSERVER);
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1044,8 +1044,10 @@ int AppLayerParserGetStateProgressCompletionStatus(AppProto alproto,
 {
     SCEnter();
     int r = 0;
-    r = alp_ctx.ctxs[FLOW_PROTO_DEFAULT][alproto].
-                StateGetProgressCompletionStatus(direction);
+    if (alproto != ALPROTO_UNKNOWN) {
+        r = alp_ctx.ctxs[FLOW_PROTO_DEFAULT][alproto].
+                    StateGetProgressCompletionStatus(direction);
+    }
     SCReturnInt(r);
 }
 

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -161,6 +161,9 @@ void AppLayerParserRegisterGetStateProgressCompletionStatus(AppProto alproto,
 void AppLayerParserRegisterGetEventInfo(uint8_t ipproto, AppProto alproto,
     int (*StateGetEventInfo)(const char *event_name, int *event_id,
                              AppLayerEventType *event_type));
+void AppLayerParserRegisterGetEventInfoById(uint8_t ipproto, AppProto alproto,
+    int (*StateGetEventInfoById)(int event_id, const char **event_name,
+                                 AppLayerEventType *event_type));
 void AppLayerParserRegisterDetectStateFuncs(uint8_t ipproto, AppProto alproto,
         DetectEngineState *(*GetTxDetectState)(void *tx),
         int (*SetTxDetectState)(void *tx, DetectEngineState *));
@@ -208,6 +211,8 @@ void *AppLayerParserGetTx(uint8_t ipproto, AppProto alproto, void *alstate, uint
 int AppLayerParserGetStateProgressCompletionStatus(AppProto alproto, uint8_t direction);
 int AppLayerParserGetEventInfo(uint8_t ipproto, AppProto alproto, const char *event_name,
                     int *event_id, AppLayerEventType *event_type);
+int AppLayerParserGetEventInfoById(uint8_t ipproto, AppProto alproto, int event_id,
+                    const char **event_name, AppLayerEventType *event_type);
 
 uint64_t AppLayerParserGetTransactionActive(const Flow *f, AppLayerParserState *pstate, uint8_t direction);
 

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1569,6 +1569,22 @@ static int SMTPStateGetEventInfo(const char *event_name,
     return 0;
 }
 
+static int SMTPStateGetEventInfoById(int event_id, const char **event_name,
+                                     AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, smtp_decoder_event_table);
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%d\" not present in "
+                   "smtp's enum map table.",  event_id);
+        /* yes this is fatal */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
 static int SMTPRegisterPatternsForProtocolDetection(void)
 {
     if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_SMTP,
@@ -1759,6 +1775,7 @@ void RegisterSMTPParsers(void)
                                      SMTPParseServerRecord);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetEventInfo);
+        AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetEventInfoById);
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_SMTP, SMTPGetEvents);
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_SMTP,
                                                SMTPGetTxDetectState, SMTPSetTxDetectState);

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2656,6 +2656,22 @@ static int SSLStateGetEventInfo(const char *event_name,
     return 0;
 }
 
+static int SSLStateGetEventInfoById(int event_id, const char **event_name,
+                                    AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, tls_decoder_event_table);
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%d\" not present in "
+                   "ssl's enum map table.",  event_id);
+        /* yes this is fatal */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
 static int SSLRegisterPatternsForProtocolDetection(void)
 {
     if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
@@ -2842,6 +2858,7 @@ void RegisterSSLParsers(void)
                                      SSLParseServerRecord);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_TLS, SSLStateGetEventInfo);
+        AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_TLS, SSLStateGetEventInfoById);
 
         AppLayerParserRegisterStateFuncs(IPPROTO_TCP, ALPROTO_TLS, SSLStateAlloc, SSLStateFree);
 

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -174,6 +174,22 @@ static int TemplateStateGetEventInfo(const char *event_name, int *event_id,
     return 0;
 }
 
+static int TemplateStateGetEventInfoById(int event_id, const char **event_name,
+                                         AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, template_decoder_event_table);
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%d\" not present in "
+                   "template enum map table.",  event_id);
+        /* This should be treated as fatal. */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
 static AppLayerDecoderEvents *TemplateGetEvents(void *statev, uint64_t tx_id)
 {
     TemplateState *state = statev;
@@ -534,6 +550,8 @@ void RegisterTemplateParsers(void)
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_TEMPLATE,
             TemplateStateGetEventInfo);
+        AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_TEMPLATE,
+            TemplateStateGetEventInfoById);
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_TEMPLATE,
             TemplateGetEvents);
     }

--- a/src/output.c
+++ b/src/output.c
@@ -307,7 +307,7 @@ static void OutputRegisterTxSubModuleWrapper(LoggerId id, const char *parent_nam
     module->ThreadExitPrintStats = ThreadExitPrintStats;
     TAILQ_INSERT_TAIL(&output_modules, module, entries);
 
-    SCLogDebug("Tx logger \"%s\" registered.", name);
+    SCLogDebug("Tx logger for alproto %d \"%s\" registered.", alproto, name);
     return;
 error:
     SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -588,7 +588,14 @@ static void SetupOutput(const char *name, OutputModule *module, OutputCtx *outpu
                 module->ts_log_progress, module->TxLogCondition,
                 module->ThreadInit, module->ThreadDeinit,
                 module->ThreadExitPrintStats);
-        logger_bits[module->alproto] |= (1<<module->logger_id);
+        /* Ensure TX logger is applied to all app layer protocols */
+        if (module->alproto == ALPROTO_UNKNOWN) {
+            for (int a = 0; a < ALPROTO_MAX; a++) {
+                logger_bits[a] |= (1<<module->logger_id);
+            }
+        } else {
+            logger_bits[module->alproto] |= (1<<module->logger_id);
+        }
     } else if (module->FiledataLogFunc) {
         SCLogDebug("%s is a filedata logger", module->name);
         OutputRegisterFiledataLogger(module->logger_id, module->name,


### PR DESCRIPTION
_Request for comments only #2_ (work in progress); continuation of #3860

This PR includes changes for 2 issues:
- [2941](https://redmine.openinfosecfoundation.org/issues/2941)
- [2942](https://redmine.openinfosecfoundation.org/issues/2942)

Posted for early feedback ....

App layer events are logged via the transactional logging support with a "wild card" application layer protocol. This leverages the existing transactional handling in the logger and ensures that each transaction is only inspected a single time. This logging requires the capability of translating the recorded event (code) into a string. Additions to the app layer parser infrastructure provide that capability and many (but not all) of the app layer protocols have been modified to translate event ids into event strings.

Protocol and parser detection events are handled by reviewing the `app_layer_parser` field of the packet and the parser state, respectively.

### Update
This PR includes changes that apply the "wild card" logger to all protocols; this is used during the logger output loop when traversing transactions and loggers.

The second change adds logic such that a wild card logger only receives the transaction if none of the other loggers have deferred handling the transaction. This ensures that the anomaly logger receives the transaction when it's deemed complete.

### TODO
- Ensure each app layer protocol's decoder events or equivalent can be translated from and event id into a string.
- Documentation updates

#### Observations
Each transaction has an event set; for a given transaction, there are sometimes multiple, back-to-back events recorded that are the same. 

Would like some feedback on the approach as well as the content/key naming of generated log records (below).

### Protocol Detection Event
```
{
  "timestamp": "2011-01-25T10:56:06.114451-0800",
  "flow_id": 796744833386293,
  "pcap_cnt": 10968,
  "event_type": "anomaly",
  "src_ip": "10.0.2.15",
  "src_port": 2526,
  "dest_ip": "65.54.186.19",
  "dest_port": 5443,
  "proto": "TCP",
  "anomaly": {
    "alproto": "tls",
    "type": "packet",
    "event": "APPLAYER_DETECT_PROTOCOL_ONLY_ONE_DIRECTION",
    "event_no": "1 (of 1)",
    "layer": "app_layer"
  }
}
```

### App layer events
```
{
  "timestamp": "2011-01-25T10:54:08.507043-0800",
  "flow_id": 1901021719668973,
  "pcap_cnt": 4232,
  "event_type": "anomaly",
  "src_ip": "194.165.188.79",
  "src_port": 443,
  "dest_ip": "172.16.255.1",
  "dest_port": 10627,
  "proto": "TCP",
  "anomaly": {
    "alproto": "tls",
    "type": "transaction",
    "event": "INVALID_SSL_RECORD",
    "event_no": "1 (of 4)",
    "tx_id": 0,
    "layer": "applayer_parser"
  }
}
{
  "timestamp": "2011-01-25T10:54:08.507043-0800",
  "flow_id": 1901021719668973,
  "pcap_cnt": 4232,
  "event_type": "anomaly",
  "src_ip": "194.165.188.79",
  "src_port": 443,
  "dest_ip": "172.16.255.1",
  "dest_port": 10627,
  "proto": "TCP",
  "anomaly": {
    "alproto": "tls",
    "type": "transaction",
    "event": "INVALID_HANDSHAKE_MESSAGE",
    "event_no": "2 (of 4)",
    "tx_id": 0,
    "layer": "applayer_parser"
  }
}
```
