### PR TITLE
signature: fix memory leak in DetectBytejumpSetup

### DIFF
--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -581,6 +581,7 @@ static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         if (bed_sm == NULL) {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "Unknown byte_extract var "
                        "seen in byte_jump - %s\n", offset);
+            SCFree(offset);
             goto error;
         }
         data->offset = ((DetectByteExtractData *)bed_sm->ctx)->local_id;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Fixes memory leak in `DetectBytejumpSetup`

Example signature 
`alert udp any 67 -> any 68 (msg:"ET INFO Web|"; byte_jump:1,count0,relative,post_offset -9; conten16_06_24, updated_at 2016_06_24;)`