### PR TITLE
Http evader v2

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1627,8 +1627,12 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
 
     int result = 0;
 
-    /* see if we need to open the file */
-    if (!(htud->tcflags & HTP_FILENAME_SET))
+    /* see if we need to open the file
+     * we check for tx->response_line in case of junk
+     * interpreted as body before response line
+     */
+    if (!(htud->tcflags & HTP_FILENAME_SET) &&
+        (tx->response_line != NULL || tx->is_protocol_0_9))
     {
         SCLogDebug("setting up file name");
 
@@ -1673,7 +1677,7 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
             }
         }
     }
-    else
+    else if (tx->response_line != NULL || tx->is_protocol_0_9)
     {
         /* otherwise, just store the data */
 

--- a/src/tests/detect-http-server-body.c
+++ b/src/tests/detect-http-server-body.c
@@ -5690,8 +5690,7 @@ static int DetectHttpServerBodyTest07(void)
         "HTTP/1.0 200 ok\r\n"
         "Content-Type: text/html\r\n"
         "Content-Length: 14\r\n"
-        "\r\n"
-        "message";
+        "\r\n";
     uint32_t http_len2 = sizeof(http_buf2) - 1;
     uint8_t http_buf3[] =
         "message";
@@ -5742,7 +5741,7 @@ static int DetectHttpServerBodyTest07(void)
 
     FLOWLOCK_WRLOCK(&f);
     int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
-                                STREAM_TOSERVER | STREAM_START | STREAM_EOF,
+                                STREAM_TOSERVER | STREAM_START,
                                 http_buf1,
                                 http_len1);
     if (r != 0) {
@@ -6070,7 +6069,7 @@ static int DetectHttpServerBodyTest09(void)
 
     FLOWLOCK_WRLOCK(&f);
     r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
-                            STREAM_TOCLIENT | STREAM_EOF, http_buf3,
+                            STREAM_TOCLIENT, http_buf3,
                             http_len3);
     if (r != 0) {
         printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
@@ -6229,7 +6228,7 @@ static int DetectHttpServerBodyTest10(void)
 
     FLOWLOCK_WRLOCK(&f);
     r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
-                            STREAM_TOCLIENT | STREAM_EOF, http_buf3,
+                            STREAM_TOCLIENT, http_buf3,
                             http_len3);
     if (r != 0) {
         printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
@@ -7785,8 +7784,7 @@ static int DetectHttpServerBodyFileDataTest02(void)
         "HTTP/1.0 200 ok\r\n"
         "Content-Type: text/html\r\n"
         "Content-Length: 14\r\n"
-        "\r\n"
-        "message";
+        "\r\n";
     uint32_t http_len2 = sizeof(http_buf2) - 1;
     uint8_t http_buf3[] =
         "message";
@@ -7837,7 +7835,7 @@ static int DetectHttpServerBodyFileDataTest02(void)
 
     FLOWLOCK_WRLOCK(&f);
     int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
-                                STREAM_TOSERVER | STREAM_START | STREAM_EOF,
+                                STREAM_TOSERVER | STREAM_START,
                                 http_buf1,
                                 http_len1);
     if (r != 0) {
@@ -8168,7 +8166,7 @@ static int DetectHttpServerBodyFileDataTest04(void)
 
     FLOWLOCK_WRLOCK(&f);
     r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
-                            STREAM_TOCLIENT | STREAM_EOF, http_buf3,
+                            STREAM_TOCLIENT, http_buf3,
                             http_len3);
     if (r != 0) {
         printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
@@ -8327,7 +8325,7 @@ static int DetectHttpServerBodyFileDataTest05(void)
 
     FLOWLOCK_WRLOCK(&f);
     r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
-                            STREAM_TOCLIENT | STREAM_EOF, http_buf3,
+                            STREAM_TOCLIENT, http_buf3,
                             http_len3);
     if (r != 0) {
         printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);


### PR DESCRIPTION
See http evader case 481
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1656

Describe changes:
- Waits for request line (if not HTTP0.9) before looking for filename and storing file contents
- This allows to handle junk before response line, like in http evader case 481

Modifies #3764 :
- modifies HTTP unit tests to fix stream flags (removing STREAM_EOF when this is not the last packet)