### PR TITLE
signature: fix memory leak in DetectBytejumpSetup

### DIFF
--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -586,6 +586,7 @@ static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         data->offset = ((DetectByteExtractData *)bed_sm->ctx)->local_id;
         data->flags |= DETECT_BYTEJUMP_OFFSET_BE;
         SCFree(offset);
+        offset = NULL;
     }
 
     sm = SigMatchAlloc();
@@ -613,6 +614,9 @@ static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char
     ret = 0;
     return ret;
  error:
+    if (offset != NULL) {
+        SCFree(offset);
+    }
     DetectBytejumpFree(data);
     return ret;
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Fixes memory leak in `DetectBytejumpSetup`

Example signature 
`alert udp any 67 -> any 68 (msg:"ET INFO Web|"; byte_jump:1,count0,relative,post_offset -9; conten16_06_24, updated_at 2016_06_24;)`

Modifies #3872 
- Avoids the leak in more failure cases