### PR TITLE
(RFC) logging: app-layer and proto detect layer events

### DIFF
--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -1522,6 +1522,24 @@ static int DNP3StateGetEventInfo(const char *event_name, int *event_id,
 /**
  * \brief App-layer support.
  */
+static int DNP3StateGetEventInfoById(int event_id, const char **event_name,
+                                     AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, dnp3_decoder_event_table);
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "Event \"%d\" not present in "
+            "the DNP3 enum event map table.", event_id);
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
+/**
+ * \brief App-layer support.
+ */
 static DetectEngineState *DNP3GetTxDetectState(void *vtx)
 {
     DNP3Transaction *tx = vtx;
@@ -1654,6 +1672,8 @@ void RegisterDNP3Parsers(void)
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_DNP3,
             DNP3StateGetEventInfo);
+        AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_DNP3,
+            DNP3StateGetEventInfoById);
 
         AppLayerParserRegisterLoggerFuncs(IPPROTO_TCP, ALPROTO_DNP3,
             DNP3GetTxLogged, DNP3SetTxLogged);

--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -52,9 +52,32 @@ int DNSStateGetEventInfo(const char *event_name,
     return 0;
 }
 
+int DNSStateGetEventInfoById(int event_id, const char **event_name,
+                             AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, dns_decoder_event_table);
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%d\" not present in "
+                   "dns's enum map table.",  event_id);
+        /* this should be treated as fatal */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
 void DNSAppLayerRegisterGetEventInfo(uint8_t ipproto, AppProto alproto)
 {
     AppLayerParserRegisterGetEventInfo(ipproto, alproto, DNSStateGetEventInfo);
+
+    return;
+}
+
+void DNSAppLayerRegisterGetEventInfoById(uint8_t ipproto, AppProto alproto)
+{
+    AppLayerParserRegisterGetEventInfoById(ipproto, alproto, DNSStateGetEventInfoById);
 
     return;
 }

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -136,7 +136,10 @@ typedef struct DNSHeader_ {
 
 int DNSStateGetEventInfo(const char *event_name,
                          int *event_id, AppLayerEventType *event_type);
+int DNSStateGetEventInfoById(int event_id, const char **event_name,
+                             AppLayerEventType *event_type);
 void DNSAppLayerRegisterGetEventInfo(uint8_t ipproto, AppProto alproto);
+void DNSAppLayerRegisterGetEventInfoById(uint8_t ipproto, AppProto alproto);
 
 void DNSCreateTypeString(uint16_t type, char *str, size_t str_size);
 void DNSCreateRcodeString(uint8_t rcode, char *str, size_t str_size);

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -144,6 +144,22 @@ static int ENIPStateGetEventInfo(const char *event_name, int *event_id, AppLayer
     return 0;
 }
 
+static int ENIPStateGetEventInfoById(int event_id, const char **event_name,
+                                     AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, enip_decoder_event_table);
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%d\" not present in "
+                   "enip's enum map table.",  event_id);
+        /* yes this is fatal */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
 /** \brief Allocate enip state
  *
  *  return state
@@ -441,6 +457,7 @@ void RegisterENIPUDPParsers(void)
         AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_ENIP, ENIPGetAlstateProgressCompletionStatus);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_UDP, ALPROTO_ENIP, ENIPStateGetEventInfo);
+        AppLayerParserRegisterGetEventInfoById(IPPROTO_UDP, ALPROTO_ENIP, ENIPStateGetEventInfoById);
 
         AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_UDP,
                 ALPROTO_ENIP, STREAM_TOSERVER | STREAM_TOCLIENT);

--- a/src/app-layer-events.c
+++ b/src/app-layer-events.c
@@ -48,6 +48,22 @@ SCEnumCharMap app_layer_event_pkt_table[ ] = {
       -1 },
 };
 
+int AppLayerGetEventInfoById(int event_id, const char **event_name,
+                                     AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, app_layer_event_pkt_table);
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%d\" not present in "
+                   "app-layer-event's enum map table.",  event_id);
+        /* yes this is fatal */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_PACKET;
+
+    return 0;
+}
+
 int AppLayerGetPktEventInfo(const char *event_name, int *event_id)
 {
     *event_id = SCMapEnumNameToValue(event_name, app_layer_event_pkt_table);

--- a/src/app-layer-events.h
+++ b/src/app-layer-events.h
@@ -58,6 +58,8 @@ typedef enum AppLayerEventType_ {
 
 int AppLayerGetPktEventInfo(const char *event_name, int *event_id);
 
+int AppLayerGetEventInfoById(int event_id, const char **event_name,
+                             AppLayerEventType *event_type);
 void AppLayerDecoderEventsSetEventRaw(AppLayerDecoderEvents **sevents, uint8_t event);
 void AppLayerDecoderEventsSetEvent(Flow *f, uint8_t event);
 

--- a/src/app-layer-events.h
+++ b/src/app-layer-events.h
@@ -38,6 +38,8 @@ struct AppLayerDecoderEvents_ {
     uint8_t cnt;
     /* current event buffer size */
     uint8_t events_buffer_size;
+    /* last logged */
+    uint8_t event_last_logged;
 };
 
 /* app layer pkt level events */

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2858,6 +2858,22 @@ static int HTPStateGetEventInfo(const char *event_name,
     return 0;
 }
 
+static int HTPStateGetEventInfoById(int event_id, const char **event_name,
+                                    AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, http_decoder_event_table);
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%d\" not present in "
+                   "http's enum map table.",  event_id);
+        /* this should be treated as fatal */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
 static void HTPStateTruncate(void *state, uint8_t direction)
 {
     FileContainer *fc = HTPStateGetFiles(state, direction);
@@ -3003,6 +3019,7 @@ void RegisterHTPParsers(void)
                                                                HTPStateGetAlstateProgressCompletionStatus);
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_HTTP, HTPGetEvents);
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_HTTP, HTPStateGetEventInfo);
+        AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_HTTP, HTPStateGetEventInfoById);
 
         AppLayerParserRegisterTruncateFunc(IPPROTO_TCP, ALPROTO_HTTP, HTPStateTruncate);
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_HTTP,

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -215,7 +215,7 @@ typedef struct HtpTxUserData_ {
 
     AppLayerDecoderEvents *decoder_events;          /**< per tx events */
 
-    /** Holds the boundary identificator string if any (used on
+    /** Holds the boundary identification string if any (used on
      *  multipart/form-data only)
      */
     uint8_t *boundary;
@@ -234,7 +234,7 @@ typedef struct HtpState_ {
     htp_connp_t *connp;
     /* Connection structure for each connection */
     htp_conn_t *conn;
-    Flow *f;                /**< Needed to retrieve the original flow when usin HTPLib callbacks */
+    Flow *f;                /**< Needed to retrieve the original flow when using HTPLib callbacks */
     uint64_t transaction_cnt;
     uint64_t store_tx_id;
     FileContainer *files_ts;

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -186,6 +186,23 @@ static int ModbusStateGetEventInfo(const char *event_name, int *event_id, AppLay
     return 0;
 }
 
+static int ModbusStateGetEventInfoById(int event_id, const char **event_name,
+                                       AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, modbus_decoder_event_table);
+
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%d\" not present in "
+                   "modbus's enum map table.",  event_id);
+        /* yes this is fatal */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
 static void ModbusSetEvent(ModbusState *modbus, uint8_t e)
 {
     if (modbus && modbus->curr) {
@@ -1538,6 +1555,7 @@ void RegisterModbusParsers(void)
                                                                 ModbusGetAlstateProgressCompletionStatus);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_MODBUS, ModbusStateGetEventInfo);
+        AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_MODBUS, ModbusStateGetEventInfoById);
 
         AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_TCP, ALPROTO_MODBUS, STREAM_TOSERVER);
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1044,8 +1044,10 @@ int AppLayerParserGetStateProgressCompletionStatus(AppProto alproto,
 {
     SCEnter();
     int r = 0;
-    r = alp_ctx.ctxs[FLOW_PROTO_DEFAULT][alproto].
-                StateGetProgressCompletionStatus(direction);
+    if (alproto != ALPROTO_UNKNOWN) {
+        r = alp_ctx.ctxs[FLOW_PROTO_DEFAULT][alproto].
+                    StateGetProgressCompletionStatus(direction);
+    }
     SCReturnInt(r);
 }
 

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -161,6 +161,9 @@ void AppLayerParserRegisterGetStateProgressCompletionStatus(AppProto alproto,
 void AppLayerParserRegisterGetEventInfo(uint8_t ipproto, AppProto alproto,
     int (*StateGetEventInfo)(const char *event_name, int *event_id,
                              AppLayerEventType *event_type));
+void AppLayerParserRegisterGetEventInfoById(uint8_t ipproto, AppProto alproto,
+    int (*StateGetEventInfoById)(int event_id, const char **event_name,
+                                 AppLayerEventType *event_type));
 void AppLayerParserRegisterDetectStateFuncs(uint8_t ipproto, AppProto alproto,
         DetectEngineState *(*GetTxDetectState)(void *tx),
         int (*SetTxDetectState)(void *tx, DetectEngineState *));
@@ -208,6 +211,8 @@ void *AppLayerParserGetTx(uint8_t ipproto, AppProto alproto, void *alstate, uint
 int AppLayerParserGetStateProgressCompletionStatus(AppProto alproto, uint8_t direction);
 int AppLayerParserGetEventInfo(uint8_t ipproto, AppProto alproto, const char *event_name,
                     int *event_id, AppLayerEventType *event_type);
+int AppLayerParserGetEventInfoById(uint8_t ipproto, AppProto alproto, int event_id,
+                    const char **event_name, AppLayerEventType *event_type);
 
 uint64_t AppLayerParserGetTransactionActive(const Flow *f, AppLayerParserState *pstate, uint8_t direction);
 

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1569,6 +1569,22 @@ static int SMTPStateGetEventInfo(const char *event_name,
     return 0;
 }
 
+static int SMTPStateGetEventInfoById(int event_id, const char **event_name,
+                                     AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, smtp_decoder_event_table);
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%d\" not present in "
+                   "smtp's enum map table.",  event_id);
+        /* yes this is fatal */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
 static int SMTPRegisterPatternsForProtocolDetection(void)
 {
     if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_SMTP,
@@ -1759,6 +1775,7 @@ void RegisterSMTPParsers(void)
                                      SMTPParseServerRecord);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetEventInfo);
+        AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetEventInfoById);
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_SMTP, SMTPGetEvents);
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_SMTP,
                                                SMTPGetTxDetectState, SMTPSetTxDetectState);

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2669,6 +2669,22 @@ static int SSLStateGetEventInfo(const char *event_name,
     return 0;
 }
 
+static int SSLStateGetEventInfoById(int event_id, const char **event_name,
+                                    AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, tls_decoder_event_table);
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%d\" not present in "
+                   "ssl's enum map table.",  event_id);
+        /* yes this is fatal */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
 static int SSLRegisterPatternsForProtocolDetection(void)
 {
     if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
@@ -2855,6 +2871,7 @@ void RegisterSSLParsers(void)
                                      SSLParseServerRecord);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_TLS, SSLStateGetEventInfo);
+        AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_TLS, SSLStateGetEventInfoById);
 
         AppLayerParserRegisterStateFuncs(IPPROTO_TCP, ALPROTO_TLS, SSLStateAlloc, SSLStateFree);
 

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -174,6 +174,22 @@ static int TemplateStateGetEventInfo(const char *event_name, int *event_id,
     return 0;
 }
 
+static int TemplateStateGetEventInfoById(int event_id, const char **event_name,
+                                         AppLayerEventType *event_type)
+{
+    *event_name = SCMapEnumValueToName(event_id, template_decoder_event_table);
+    if (*event_name == NULL) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%d\" not present in "
+                   "template enum map table.",  event_id);
+        /* This should be treated as fatal. */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
 static AppLayerDecoderEvents *TemplateGetEvents(void *statev, uint64_t tx_id)
 {
     TemplateState *state = statev;
@@ -534,6 +550,8 @@ void RegisterTemplateParsers(void)
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_TEMPLATE,
             TemplateStateGetEventInfo);
+        AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_TEMPLATE,
+            TemplateStateGetEventInfoById);
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_TEMPLATE,
             TemplateGetEvents);
     }

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -104,7 +104,6 @@ static int AnomalyDecodeEventJson(ThreadVars *tv, JsonAnomalyLogThread *aft,
         if (!is_ip_pkt) {
             json_object_set_new(js, "timestamp", json_string(timebuf));
         } else {
-            JsonFiveTuple((const Packet *)p, LOG_DIR_PACKET, js);
             JsonAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js);
         }
 
@@ -120,12 +119,8 @@ static int AnomalyDecodeEventJson(ThreadVars *tv, JsonAnomalyLogThread *aft,
                                     json_string("packet") : json_string("stream"));
             json_object_set_new(ajs, "event", json_string(event));
         } else {
-            /* include event code with unrecognized events */
-            uint32_t offset = 0;
-            char unknown_event_buf[8];
             json_object_set_new(ajs, "type", json_string("unknown"));
-            PrintBufferData(unknown_event_buf, &offset, 8, "%d", event_code);
-            json_object_set_new(ajs, "code", json_string(unknown_event_buf));
+            json_object_set_new(ajs, "code", json_integer(event_code));
         }
 
         /* anomaly */
@@ -143,13 +138,23 @@ static int AnomalyAppLayerDecoderEventJson(JsonAnomalyLogThread *aft,
                         const Packet *p, AppLayerDecoderEvents *decoder_events,
                         bool is_applayer, const char *layer, uint64_t tx_id)
 {
-    const char *alprotoname;
-    alprotoname = AppLayerGetProtoName(p->flow->alproto);
+    const char *alprotoname = AppLayerGetProtoName(p->flow->alproto);
 
-    for (int i = 0; i < decoder_events->cnt; i++) {
+    SCLogDebug("decoder_events %p event_count %d (last logged %d) %s",
+                decoder_events, decoder_events->cnt,
+                decoder_events->event_last_logged,
+                tx_id != ((uint64_t)-1) ? "tx" : "no-tx");
+
+    for (int i = decoder_events->event_last_logged; i < decoder_events->cnt; i++) {
         MemBufferReset(aft->json_buffer);
 
-        json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, ANOMALY_EVENT_TYPE);
+        json_t *js;
+        if (tx_id != (uint64_t) -1) {
+            js = CreateJSONHeaderWithTxId(p, LOG_DIR_PACKET,
+                                          ANOMALY_EVENT_TYPE, tx_id);
+        } else {
+            js = CreateJSONHeader(p, LOG_DIR_PACKET, ANOMALY_EVENT_TYPE);
+        }
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
         }
@@ -160,7 +165,6 @@ static int AnomalyAppLayerDecoderEventJson(JsonAnomalyLogThread *aft,
             return TM_ECODE_OK;
         }
 
-        JsonFiveTuple((const Packet *)p, LOG_DIR_PACKET, js);
         JsonAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js);
 
         /* Use app layer proto name if available */
@@ -191,15 +195,11 @@ static int AnomalyAppLayerDecoderEventJson(JsonAnomalyLogThread *aft,
             json_object_set_new(ajs, "code", json_integer(event_code));
         }
 
-        /* log event number (and total */
-        uint32_t offset = 0;
-        char event_no_buf[32];
-        PrintBufferData(event_no_buf, &offset, 32, "%d (of %d)",
+        /* log event number (and total) */
+        char event_no_buf[16];
+        snprintf(event_no_buf, sizeof(event_no_buf), "%d (of %d)",
                         i+1, decoder_events->cnt);
         json_object_set_new(ajs, "event_no", json_string(event_no_buf));
-
-        if (tx_id != (uint64_t) -1)
-            json_object_set_new(ajs, "tx_id", json_integer(tx_id));
         json_object_set_new(ajs, "layer", json_string(layer));
 
         /* anomaly */
@@ -208,6 +208,9 @@ static int AnomalyAppLayerDecoderEventJson(JsonAnomalyLogThread *aft,
 
         json_object_clear(js);
         json_decref(js);
+
+        /* Current implementation assumes a single owner for this value */
+        ++decoder_events->event_last_logged;
     }
 
     return TM_ECODE_OK;
@@ -216,16 +219,16 @@ static int AnomalyAppLayerDecoderEventJson(JsonAnomalyLogThread *aft,
 static int JsonAnomalyTxLogger(ThreadVars *tv, void *thread_data, const Packet *p,
                                Flow *f, void *state, void *tx, uint64_t tx_id)
 {
-    SCLogDebug("state %p, tx: %p, tx_id: %"PRIu64, state, tx, tx_id);
-
     JsonAnomalyLogThread *aft = thread_data;
     uint8_t proto = f->proto;
     AppProto alproto = f->alproto;
     AppLayerDecoderEvents *decoder_events;
     decoder_events = AppLayerParserGetEventsByTx(proto, alproto, state, tx_id);
-    if (decoder_events)
+    if (decoder_events && (decoder_events->event_last_logged < decoder_events->cnt)) {
+        SCLogDebug("state %p, tx: %p, tx_id: %"PRIu64, state, tx, tx_id);
         AnomalyAppLayerDecoderEventJson(aft, p, decoder_events, false,
                                         "applayer_parser", tx_id);
+    }
     return TM_ECODE_OK;
 }
 
@@ -245,16 +248,16 @@ static int AnomalyJson(ThreadVars *tv, JsonAnomalyLogThread *aft, const Packet *
     }
 
     /* app layer events */
-    if (p->app_layer_events && p->app_layer_events->cnt) {
+    if (rc == TM_ECODE_OK && p->app_layer_events && p->app_layer_events->cnt) {
         rc = AnomalyAppLayerDecoderEventJson(aft, p, p->app_layer_events,
                                              true, "app_layer", -1);
     }
 
     /* parser state events */
-    if (AnomalyHasParserEvents(p)) {
-        SCLogDebug("Checking for anomaly events for alproto %d", p->flow->alproto);
+    if (rc == TM_ECODE_OK && AnomalyHasParserEvents(p)) {
+        SCLogDebug("Checking for anomaly events; alproto %d", p->flow->alproto);
         AppLayerDecoderEvents *parser_events = AppLayerParserGetDecoderEvents(p->flow->alparser);
-        if (parser_events && parser_events->cnt) {
+        if (parser_events && (parser_events->event_last_logged < parser_events->cnt)) {
             rc = AnomalyAppLayerDecoderEventJson(aft, p, parser_events,
                                                  false, "parser", -1);
         }

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -71,7 +71,7 @@ int OutputRegisterTxLogger(LoggerId id, const char *name, AppProto alproto,
                            ThreadDeinitFunc ThreadDeinit,
                            void (*ThreadExitPrintStats)(ThreadVars *, void *))
 {
-    if (!(AppLayerParserIsTxAware(alproto))) {
+    if (alproto != ALPROTO_UNKNOWN && !(AppLayerParserIsTxAware(alproto))) {
         SCLogNotice("%s logger not enabled: protocol %s is disabled",
             name, AppProtoToString(alproto));
         return -1;
@@ -201,13 +201,15 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
         while (logger && store) {
             BUG_ON(logger->LogFunc == NULL);
 
-            SCLogDebug("logger %p, LogCondition %p, ts_log_progress %d "
-                    "tc_log_progress %d", logger, logger->LogCondition,
+            SCLogDebug("logger %p, Alproto %d LogCondition %p, ts_log_progress %d "
+                    "tc_log_progress %d", logger, logger->alproto, logger->LogCondition,
                     logger->ts_log_progress, logger->tc_log_progress);
-            if (logger->alproto == alproto &&
-                (tx_logged_old & (1<<logger->logger_id)) == 0)
-            {
-                SCLogDebug("alproto match, logging tx_id %"PRIu64, tx_id);
+            /* always invoke "wild card" tx loggers */
+            if (logger->alproto == ALPROTO_UNKNOWN || 
+                (logger->alproto == alproto &&
+                 (tx_logged_old & (1<<logger->logger_id)) == 0)) {
+
+                SCLogDebug("alproto match %d, logging tx_id %"PRIu64, logger->alproto, tx_id);
 
                 if (!(AppLayerParserStateIssetFlag(f->alparser,
                                                    APP_LAYER_PARSER_EOF))) {
@@ -230,13 +232,14 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
                     }
                 }
 
-                SCLogDebug("Logging tx_id %"PRIu64" to logger %d", tx_id,
-                    logger->logger_id);
+                SCLogDebug("Logging tx_id %"PRIu64" to logger %d", tx_id, logger->logger_id);
                 PACKET_PROFILING_LOGGER_START(p, logger->logger_id);
                 logger->LogFunc(tv, store->thread_data, p, f, alstate, tx, tx_id);
                 PACKET_PROFILING_LOGGER_END(p, logger->logger_id);
 
-                tx_logged |= (1<<logger->logger_id);
+                if (alproto != ALPROTO_UNKNOWN) {
+                    tx_logged |= (1<<logger->logger_id);
+                }
             }
 
 next_logger:

--- a/src/output.c
+++ b/src/output.c
@@ -307,7 +307,7 @@ static void OutputRegisterTxSubModuleWrapper(LoggerId id, const char *parent_nam
     module->ThreadExitPrintStats = ThreadExitPrintStats;
     TAILQ_INSERT_TAIL(&output_modules, module, entries);
 
-    SCLogDebug("Tx logger \"%s\" registered.", name);
+    SCLogDebug("Tx logger for alproto %d \"%s\" registered.", alproto, name);
     return;
 error:
     SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -588,7 +588,10 @@ static void SetupOutput(const char *name, OutputModule *module, OutputCtx *outpu
                 module->ts_log_progress, module->TxLogCondition,
                 module->ThreadInit, module->ThreadDeinit,
                 module->ThreadExitPrintStats);
-        logger_bits[module->alproto] |= (1<<module->logger_id);
+        /* Not used with wild card loggers */
+        if (module->alproto != ALPROTO_UNKNOWN) {
+            logger_bits[module->alproto] |= (1<<module->logger_id);
+        }
     } else if (module->FiledataLogFunc) {
         SCLogDebug("%s is a filedata logger", module->name);
         OutputRegisterFiledataLogger(module->logger_id, module->name,


### PR DESCRIPTION
_Request for comments_

This PR includes changes for 2 issues:
- [2941](https://redmine.openinfosecfoundation.org/issues/2941)
- [2942](https://redmine.openinfosecfoundation.org/issues/2942)

Continuation of #3867 

App-layer events and protocol detection events are now logged to the anomaly log with changes in this pr.

App-layer events are logged by adding a "wild card" application layer logger. This logger is invoked while traversing the TX loggers and is invoked for all TX, regardless of the `alproto`; hence, the term "wild-card". This logger may be invoked multiple times for the same TX; a mechanism to track which events have been logged previously is employed to avoid logging an individual event twice.

Protocol detection events are logged when `app_layer_events` has an event posted. Parser events are logged when posted to the (flow) `alparser` area.

App layer parsers have been amended to include a function to translate an application layer parser specific event id into a display string.

### TODO
- Extend each app-layer-parser to support the new `GetEventInfoById` function that translates an app layer parser event value into a display string.
- Documentation updates.

#### Observations
Each transaction has an event set; for a given transaction, there are sometimes multiple, back-to-back events recorded that are the same. 

Would like some feedback on the approach as well as the content/key naming of generated log records (below).

### Protocol Detection Event
```
{
  "timestamp": "2014-09-09T18:29:28.179967-0700",
  "flow_id": 1831982488608705,
  "pcap_cnt": 1077,
  "event_type": "anomaly",
  "src_ip": "172.16.165.134",
  "src_port": 25,
  "dest_ip": "172.16.165.133",
  "dest_port": 49200,
  "proto": "TCP",
  "anomaly": {
    "alproto": "smtp",
    "type": "packet",
    "event": "APPLAYER_DETECT_PROTOCOL_ONLY_ONE_DIRECTION",
    "event_no": "1 (of 1)",
    "layer": "app_layer"
  }
}
```

### App layer events
```
{
  "timestamp": "2014-10-06T16:10:03.482379-0700",
  "flow_id": 1831982488608705,
  "event_type": "anomaly",
  "src_ip": "172.16.165.134",
  "src_port": 25,
  "dest_ip": "172.16.165.133",
  "dest_port": 49200,
  "proto": "TCP",
  "tx_id": 0,
  "anomaly": {
    "alproto": "smtp",
    "type": "transaction",
    "event": "INVALID_REPLY",
    "event_no": "1 (of 1)",
    "layer": "applayer_parser"
  }
}
{
  "timestamp": "2015-01-06T14:27:26.548474-0800",
  "flow_id": 833463658664645,
  "pcap_cnt": 636813,
  "event_type": "anomaly",
  "src_ip": "108.61.179.182",
  "src_port": 443,
  "dest_ip": "192.168.138.163",
  "dest_port": 49168,
  "proto": "TCP",
  "tx_id": 0,
  "anomaly": {
    "alproto": "http",
    "type": "transaction",
    "event": "REQUEST_AUTH_UNRECOGNIZED",
    "event_no": "1 (of 1)",
    "layer": "applayer_parser"
  }
}
{
  "timestamp": "2015-01-06T14:27:27.959384-0800",
  "flow_id": 833463658664645,
  "pcap_cnt": 636816,
  "event_type": "anomaly",
  "src_ip": "192.168.138.163",
  "src_port": 49168,
  "dest_ip": "108.61.179.182",
  "dest_port": 443,
  "proto": "TCP",
  "tx_id": 0,
  "anomaly": {
    "alproto": "http",
    "type": "transaction",
    "event": "GZIP_DECOMPRESSION_FAILED",
    "event_no": "2 (of 5)",
    "layer": "applayer_parser"
  }
}
{
  "timestamp": "2011-01-25T10:54:08.507043-0800",
  "flow_id": 1685566832748781,
  "pcap_cnt": 4232,
  "event_type": "anomaly",
  "src_ip": "194.165.188.79",
  "src_port": 443,
  "dest_ip": "172.16.255.1",
  "dest_port": 10627,
  "proto": "TCP",
  "tx_id": 0,
  "anomaly": {
    "alproto": "tls",
    "type": "transaction",
    "event": "INVALID_SSL_RECORD",
    "event_no": "4 (of 4)",
    "layer": "applayer_parser"
  }
}
```
