### PR TITLE
analyzer: Add recognition of missing HTTP values

### DIFF
--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -60,8 +60,8 @@ http_header                    Modifier                 Both
 http_raw_header                Modifier                 Both
 http_cookie                    Modifier                 Both
 http_server_body               Modifier                 Response
-http.server                    Modifier                 Response
-http.location                  Modifier                 Response
+http.server                    Sticky Buffer            Response
+http.location                  Sticky Buffer            Response
 file_data                      Sticky Buffer            Response
 http_content_type              Sticky Buffer            Both
 http_content_len               Sticky Buffer            Both

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -876,6 +876,10 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
     uint32_t http_raw_uri_buf = 0;
     uint32_t http_ua_buf = 0;
     uint32_t http_host_buf = 0;
+    uint32_t http_rawhost_buf = 0;
+    uint32_t http_serverbody_buf = 0;
+    uint32_t http_headernames_buf = 0;
+    uint32_t http_referer_buf = 0;
     uint32_t warn_pcre_no_content = 0;
     uint32_t warn_pcre_http_content = 0;
     uint32_t warn_pcre_http = 0;
@@ -907,6 +911,10 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
     const int httpclientbody_id = DetectBufferTypeGetByName("http_client_body");
     const int httprawuri_id = DetectBufferTypeGetByName("http_raw_uri");
     const int httphost_id = DetectBufferTypeGetByName("http_host");
+    const int httprawhost_id = DetectBufferTypeGetByName("http_raw_host");
+    const int httpserverbody_id = DetectBufferTypeGetByName("http_server_body");
+    const int httpreferer_id = DetectBufferTypeGetByName("http_referer");
+    const int httpheadernames_id = DetectBufferTypeGetByName("http_header_names");
 
     if (s->init_data->init_flags & SIG_FLAG_INIT_BIDIREC) {
         rule_bidirectional = 1;
@@ -990,6 +998,26 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
                     norm_http_buf += 1;
                     http_host_buf += 1;
                 }
+                else if (list_id == httprawhost_id) {
+                    rule_pcre_http += 1;
+                    raw_http_buf += 1;
+                    http_rawhost_buf += 1;
+                }
+                else if (list_id == httpserverbody_id) {
+                    rule_pcre_http += 1;
+                    raw_http_buf += 1;
+                    http_serverbody_buf += 1;
+                }
+                else if (list_id == httpheadernames_id) {
+                    rule_pcre_http += 1;
+                    raw_http_buf += 1;
+                    http_headernames_buf += 1;
+                }
+                else if (list_id == httpreferer_id) {
+                    rule_pcre_http += 1;
+                    raw_http_buf += 1;
+                    http_referer_buf += 1;
+                }
                 else {
                     rule_pcre += 1;
                 }
@@ -1055,6 +1083,31 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
                     rule_content_http += 1;
                     raw_http_buf += 1;
                     http_host_buf += 1;
+                }
+                else if (list_id == httpuseragent_id) {
+                    rule_content_http += 1;
+                    norm_http_buf += 1;
+                    http_ua_buf += 1;
+                }
+                else if (list_id == httprawhost_id) {
+                    rule_content_http += 1;
+                    raw_http_buf += 1;
+                    http_rawhost_buf += 1;
+                }
+                else if (list_id == httpserverbody_id) {
+                    rule_content_http += 1;
+                    raw_http_buf += 1;
+                    http_serverbody_buf += 1;
+                }
+                else if (list_id == httpheadernames_id) {
+                    rule_content_http += 1;
+                    raw_http_buf += 1;
+                    http_headernames_buf += 1;
+                }
+                else if (list_id == httpreferer_id) {
+                    rule_content_http += 1;
+                    raw_http_buf += 1;
+                    http_referer_buf += 1;
                 }
                 else if (list_id == DETECT_SM_LIST_PMATCH) {
                     rule_content += 1;
@@ -1206,6 +1259,10 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
         if (http_stat_code_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http stat code buffer.\n");
         if (http_ua_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http user agent buffer.\n");
         if (http_host_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http host buffer.\n");
+        if (http_rawhost_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http rawhost buffer.\n");
+        if (http_serverbody_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http server body buffer.\n");
+        if (http_headernames_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http header names buffer.\n");
+        if (http_referer_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http header referer buffer.\n");
         if (s->alproto != ALPROTO_UNKNOWN) {
             fprintf(rule_engine_analysis_FD, "    App layer protocol is %s.\n", AppProtoToString(s->alproto));
         }

--- a/src/detect-http-server-body.c
+++ b/src/detect-http-server-body.c
@@ -64,7 +64,7 @@ static int DetectHttpServerBodySetupSticky(DetectEngineCtx *de_ctx, Signature *s
 #ifdef UNITTESTS
 static void DetectHttpServerBodyRegisterTests(void);
 #endif
-static int g_file_data_buffer_id = 0;
+static int g_http_server_body_buffer_id = 0;
 
 /**
  * \brief Registers the keyword handlers for the "http_server_body" keyword.
@@ -91,7 +91,7 @@ void DetectHttpServerBodyRegister(void)
     sigmatch_table[DETECT_HTTP_RESPONSE_BODY].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_HTTP_RESPONSE_BODY].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
-    g_file_data_buffer_id = DetectBufferTypeRegister("file_data");
+    g_http_server_body_buffer_id = DetectBufferTypeRegister("http_server_body");
 }
 
 /**
@@ -111,7 +111,7 @@ int DetectHttpServerBodySetup(DetectEngineCtx *de_ctx, Signature *s, const char 
 {
     return DetectEngineContentModifierBufferSetup(de_ctx, s, arg,
                                                   DETECT_AL_HTTP_SERVER_BODY,
-                                                  g_file_data_buffer_id,
+                                                  g_http_server_body_buffer_id,
                                                   ALPROTO_HTTP);
 }
 
@@ -126,7 +126,7 @@ int DetectHttpServerBodySetup(DetectEngineCtx *de_ctx, Signature *s, const char 
  */
 static int DetectHttpServerBodySetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    if (DetectBufferSetActiveList(s, g_file_data_buffer_id) < 0)
+    if (DetectBufferSetActiveList(s, g_http_server_body_buffer_id) < 0)
         return -1;
     if (DetectSignatureSetAppProto(s, ALPROTO_HTTP) < 0)
         return -1;

--- a/src/tests/detect-http-server-body.c
+++ b/src/tests/detect-http-server-body.c
@@ -5426,7 +5426,7 @@ static int DetectHttpServerBodyTest01(void)
         goto end;
     }
 
-    sm = de_ctx->sig_list->sm_lists[g_file_data_buffer_id];
+    sm = de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id];
     if (sm == NULL) {
         goto end;
     }
@@ -7031,15 +7031,15 @@ static int DetectHttpServerBodyTest22(void)
         goto end;
     }
 
-    if (de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL) {
-        printf("de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL\n");
+    if (de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL) {
+        printf("de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL\n");
         goto end;
     }
 
     DetectContentData *cd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->prev->ctx;
     DetectContentData *cd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx;
-    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev->ctx;
-    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->ctx;
+    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev->ctx;
+    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->ctx;
     if (cd1->flags != 0 || memcmp(cd1->content, "one", cd1->content_len) != 0 ||
         cd2->flags != 0 || memcmp(cd2->content, "four", cd2->content_len) != 0 ||
         hsbd1->flags != DETECT_CONTENT_RELATIVE_NEXT ||
@@ -7086,15 +7086,15 @@ static int DetectHttpServerBodyTest23(void)
         goto end;
     }
 
-    if (de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL) {
-        printf("de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL\n");
+    if (de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL) {
+        printf("de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL\n");
         goto end;
     }
 
     DetectPcreData *pd1 = (DetectPcreData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->prev->ctx;
     DetectContentData *cd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx;
-    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev->ctx;
-    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->ctx;
+    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev->ctx;
+    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->ctx;
     if (pd1->flags != 0 ||
         cd2->flags != 0 || memcmp(cd2->content, "four", cd2->content_len) != 0 ||
         hsbd1->flags != DETECT_CONTENT_RELATIVE_NEXT ||
@@ -7140,15 +7140,15 @@ static int DetectHttpServerBodyTest24(void)
         goto end;
     }
 
-    if (de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL) {
-        printf("de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL\n");
+    if (de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL) {
+        printf("de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL\n");
         goto end;
     }
 
     DetectPcreData *pd1 = (DetectPcreData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->prev->ctx;
     DetectContentData *cd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx;
-    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev->ctx;
-    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->ctx;
+    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev->ctx;
+    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->ctx;
     if (pd1->flags != 0 ||
         cd2->flags != 0 || memcmp(cd2->content, "four", cd2->content_len) != 0 ||
         hsbd1->flags != DETECT_CONTENT_RELATIVE_NEXT ||
@@ -7195,15 +7195,15 @@ static int DetectHttpServerBodyTest25(void)
         goto end;
     }
 
-    if (de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL) {
-        printf("de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL\n");
+    if (de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL) {
+        printf("de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL\n");
         goto end;
     }
 
     DetectPcreData *pd1 = (DetectPcreData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->prev->ctx;
     DetectContentData *cd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx;
-    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev->ctx;
-    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->ctx;
+    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev->ctx;
+    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->ctx;
     if (pd1->flags != DETECT_PCRE_RELATIVE_NEXT ||
         cd2->flags != DETECT_CONTENT_DISTANCE ||
         memcmp(cd2->content, "four", cd2->content_len) != 0 ||
@@ -7251,15 +7251,15 @@ static int DetectHttpServerBodyTest26(void)
         goto end;
     }
 
-    if (de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL) {
-        printf("de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL\n");
+    if (de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL) {
+        printf("de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL\n");
         goto end;
     }
 
     DetectPcreData *pd1 = (DetectPcreData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->prev->ctx;
     DetectContentData *cd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx;
-    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev->ctx;
-    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->ctx;
+    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev->ctx;
+    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->ctx;
     if (pd1->flags != (DETECT_PCRE_RELATIVE_NEXT) ||
         cd2->flags != DETECT_CONTENT_DISTANCE ||
         memcmp(cd2->content, "four", cd2->content_len) != 0 ||
@@ -7334,15 +7334,15 @@ static int DetectHttpServerBodyTest28(void)
         goto end;
     }
 
-    if (de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL) {
-        printf("de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL\n");
+    if (de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL) {
+        printf("de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL\n");
         goto end;
     }
 
     DetectPcreData *pd1 = (DetectPcreData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->prev->ctx;
     DetectContentData *cd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx;
-    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev->ctx;
-    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->ctx;
+    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev->ctx;
+    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->ctx;
     if (pd1->flags != (DETECT_PCRE_RELATIVE_NEXT) ||
         cd2->flags != DETECT_CONTENT_DISTANCE ||
         memcmp(cd2->content, "four", cd2->content_len) != 0 ||
@@ -7389,13 +7389,13 @@ static int DetectHttpServerBodyTest29(void)
         goto end;
     }
 
-    if (de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL) {
-        printf("de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL\n");
+    if (de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL) {
+        printf("de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL\n");
         goto end;
     }
 
-    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev->ctx;
-    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->ctx;
+    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev->ctx;
+    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->ctx;
     if (hsbd1->flags != DETECT_CONTENT_RELATIVE_NEXT ||
         memcmp(hsbd1->content, "one", hsbd1->content_len) != 0 ||
         hsbd2->flags != DETECT_CONTENT_DISTANCE ||
@@ -7433,13 +7433,13 @@ static int DetectHttpServerBodyTest30(void)
         goto end;
     }
 
-    if (de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL) {
-        printf("de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL\n");
+    if (de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL) {
+        printf("de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL\n");
         goto end;
     }
 
-    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev->ctx;
-    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->ctx;
+    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev->ctx;
+    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->ctx;
     if (hsbd1->flags != DETECT_CONTENT_RELATIVE_NEXT ||
         memcmp(hsbd1->content, "one", hsbd1->content_len) != 0 ||
         hsbd2->flags != DETECT_CONTENT_WITHIN ||
@@ -7543,21 +7543,21 @@ static int DetectHttpServerBodyTest34(void)
 
     FAIL_IF_NOT_NULL(de_ctx->sig_list->sm_lists[DETECT_SM_LIST_PMATCH]);
 
-    if (de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL) {
-        printf("de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL\n");
+    if (de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL) {
+        printf("de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL\n");
         goto end;
     }
 
-    if (de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id] == NULL ||
-        de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->type != DETECT_CONTENT ||
-        de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev == NULL ||
-        de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev->type != DETECT_PCRE) {
+    if (de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id] == NULL ||
+        de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->type != DETECT_CONTENT ||
+        de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev == NULL ||
+        de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev->type != DETECT_PCRE) {
 
         goto end;
     }
 
-    DetectPcreData *pd1 = (DetectPcreData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev->ctx;
-    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->ctx;
+    DetectPcreData *pd1 = (DetectPcreData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev->ctx;
+    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->ctx;
     if (pd1->flags != (DETECT_PCRE_RELATIVE_NEXT) ||
         hsbd2->flags != DETECT_CONTENT_WITHIN ||
         memcmp(hsbd2->content, "two", hsbd2->content_len) != 0) {
@@ -7594,21 +7594,21 @@ static int DetectHttpServerBodyTest35(void)
         goto end;
     }
 
-    if (de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL) {
-        printf("de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL\n");
+    if (de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL) {
+        printf("de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL\n");
         goto end;
     }
 
-    if (de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id] == NULL ||
-        de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->type != DETECT_PCRE ||
-        de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev == NULL ||
-        de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev->type != DETECT_CONTENT) {
+    if (de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id] == NULL ||
+        de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->type != DETECT_PCRE ||
+        de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev == NULL ||
+        de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev->type != DETECT_CONTENT) {
 
         goto end;
     }
 
-    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev->ctx;
-    DetectPcreData *pd2 = (DetectPcreData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->ctx;
+    DetectContentData *hsbd1 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev->ctx;
+    DetectPcreData *pd2 = (DetectPcreData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->ctx;
     if (pd2->flags != (DETECT_PCRE_RELATIVE) ||
         hsbd1->flags != DETECT_CONTENT_RELATIVE_NEXT ||
         memcmp(hsbd1->content, "two", hsbd1->content_len) != 0) {
@@ -7645,21 +7645,21 @@ static int DetectHttpServerBodyTest36(void)
         goto end;
     }
 
-    if (de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL) {
-        printf("de_ctx->sig_list->sm_lists[g_file_data_buffer_id] == NULL\n");
+    if (de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL) {
+        printf("de_ctx->sig_list->sm_lists[g_http_server_body_buffer_id] == NULL\n");
         goto end;
     }
 
-    if (de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id] == NULL ||
-        de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->type != DETECT_CONTENT ||
-        de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev == NULL ||
-        de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev->type != DETECT_PCRE) {
+    if (de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id] == NULL ||
+        de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->type != DETECT_CONTENT ||
+        de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev == NULL ||
+        de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev->type != DETECT_PCRE) {
 
         goto end;
     }
 
-    DetectPcreData *pd1 = (DetectPcreData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->prev->ctx;
-    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_file_data_buffer_id]->ctx;
+    DetectPcreData *pd1 = (DetectPcreData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->prev->ctx;
+    DetectContentData *hsbd2 = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[g_http_server_body_buffer_id]->ctx;
     if (pd1->flags != (DETECT_PCRE_RELATIVE_NEXT) ||
         hsbd2->flags != DETECT_CONTENT_DISTANCE ||
         memcmp(hsbd2->content, "two", hsbd2->content_len) != 0) {


### PR DESCRIPTION
This changeset eliminates warnings based on (private) a specific set of rules. Those rule highlighted missing HTTP values that were not recognized by the engine analyzer.

Link to [2926](https://redmine.openinfosecfoundation.org/issues/2926) ticket:

Describe changes:
- Recognize additional HTTP values: server body, raw host, user agent, header names
