### PR TITLE
signature: fixes leak with duplicate signatures

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2184,6 +2184,16 @@ static inline int DetectEngineSignatureIsDuplicate(DetectEngineCtx *de_ctx,
     sw_dup->s = sig;
     sw_dup->s_prev = NULL;
 
+    SigDuplWrapper sw_tmp;
+    sw_tmp.s = de_ctx->sig_list;
+    SigDuplWrapper *sw_old = HashListTableLookup(de_ctx->dup_sig_hash_table,
+                                 (void *)&sw_tmp, 0);
+    if (sw_old != sw_dup) {
+        // Link on top of the list if there was another element
+        sw_old->s_prev = sig;
+    }
+
+
     /* this is duplicate, but a duplicate that replaced the existing sig entry */
     ret = 2;
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Fixes leak with duplicate signatures

I guess that we should add a test. What is the best place for it ?

The fuzzer generated this sample :
```
alert http any any -> any any (msg:"EICAR file data"; file_data; content:"EICAR-STANDARD-ANTIVIRUS-TEST-FILE"; sid:1;)
alert http any any -> any any (msg:"EICAR file data X"; file_data; content:"X5O!P%@AP[4"; sid:2;)
alert http any any -> any any (content:"curl"; http_user_agent; flowbits:set,traffic/label/cli-http; flowbits:set,traffic/id/curl; flowbits:set,junkbit; sid:1; rev:1;)
alert http any any -> any any (pcre:"/uid=(\d+)\(([^)]+)\)/, pkt:uid, pkt:username"; noalert; sid:2; rev:1;)
```

The important part are `sid` and `rev`

When signature 1 gets replaced with signature 1.1, the linked list fails adding a backward link from the previous signature (in this case 2) to this newly updated signature

And so, when we replace 2 by 2.1, we overwrite the beginning of the list, leaking the signature 1.1

The linked list at each import go
- 1
- 2, 1
- 1.1, 2
- 2.1

With this patch, the final step is 2.1, 1.1