### PR TITLE
analyzer: Add recognition of missing HTTP values

### DIFF
--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -60,8 +60,8 @@ http_header                    Modifier                 Both
 http_raw_header                Modifier                 Both
 http_cookie                    Modifier                 Both
 http_server_body               Modifier                 Response
-http.server                    Sticky Buffer            Response
-http.location                  Sticky Buffer            Response
+http.server                    Modifier                 Response
+http.location                  Modifier                 Response
 file_data                      Sticky Buffer            Response
 http_content_type              Sticky Buffer            Both
 http_content_len               Sticky Buffer            Both

--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -60,8 +60,8 @@ http_header                    Modifier                 Both
 http_raw_header                Modifier                 Both
 http_cookie                    Modifier                 Both
 http_server_body               Modifier                 Response
-http.server                    Modifier                 Response
-http.location                  Modifier                 Response
+http.server                    Sticky Buffer            Response
+http.location                  Sticky Buffer            Response
 file_data                      Sticky Buffer            Response
 http_content_type              Sticky Buffer            Both
 http_content_len               Sticky Buffer            Both

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -876,6 +876,9 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
     uint32_t http_raw_uri_buf = 0;
     uint32_t http_ua_buf = 0;
     uint32_t http_host_buf = 0;
+    uint32_t http_rawhost_buf = 0;
+    uint32_t http_headernames_buf = 0;
+    uint32_t http_referer_buf = 0;
     uint32_t warn_pcre_no_content = 0;
     uint32_t warn_pcre_http_content = 0;
     uint32_t warn_pcre_http = 0;
@@ -907,6 +910,9 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
     const int httpclientbody_id = DetectBufferTypeGetByName("http_client_body");
     const int httprawuri_id = DetectBufferTypeGetByName("http_raw_uri");
     const int httphost_id = DetectBufferTypeGetByName("http_host");
+    const int httprawhost_id = DetectBufferTypeGetByName("http_raw_host");
+    const int httpreferer_id = DetectBufferTypeGetByName("http_referer");
+    const int httpheadernames_id = DetectBufferTypeGetByName("http_header_names");
 
     if (s->init_data->init_flags & SIG_FLAG_INIT_BIDIREC) {
         rule_bidirectional = 1;
@@ -990,6 +996,21 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
                     norm_http_buf += 1;
                     http_host_buf += 1;
                 }
+                else if (list_id == httprawhost_id) {
+                    rule_pcre_http += 1;
+                    raw_http_buf += 1;
+                    http_rawhost_buf += 1;
+                }
+                else if (list_id == httpheadernames_id) {
+                    rule_pcre_http += 1;
+                    raw_http_buf += 1;
+                    http_headernames_buf += 1;
+                }
+                else if (list_id == httpreferer_id) {
+                    rule_pcre_http += 1;
+                    raw_http_buf += 1;
+                    http_referer_buf += 1;
+                }
                 else {
                     rule_pcre += 1;
                 }
@@ -1055,6 +1076,26 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
                     rule_content_http += 1;
                     raw_http_buf += 1;
                     http_host_buf += 1;
+                }
+                else if (list_id == httpuseragent_id) {
+                    rule_content_http += 1;
+                    norm_http_buf += 1;
+                    http_ua_buf += 1;
+                }
+                else if (list_id == httprawhost_id) {
+                    rule_content_http += 1;
+                    raw_http_buf += 1;
+                    http_rawhost_buf += 1;
+                }
+                else if (list_id == httpheadernames_id) {
+                    rule_content_http += 1;
+                    raw_http_buf += 1;
+                    http_headernames_buf += 1;
+                }
+                else if (list_id == httpreferer_id) {
+                    rule_content_http += 1;
+                    raw_http_buf += 1;
+                    http_referer_buf += 1;
                 }
                 else if (list_id == DETECT_SM_LIST_PMATCH) {
                     rule_content += 1;
@@ -1206,6 +1247,9 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
         if (http_stat_code_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http stat code buffer.\n");
         if (http_ua_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http user agent buffer.\n");
         if (http_host_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http host buffer.\n");
+        if (http_rawhost_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http rawhost buffer.\n");
+        if (http_headernames_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http header names buffer.\n");
+        if (http_referer_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http header referer buffer.\n");
         if (s->alproto != ALPROTO_UNKNOWN) {
             fprintf(rule_engine_analysis_FD, "    App layer protocol is %s.\n", AppProtoToString(s->alproto));
         }


### PR DESCRIPTION
This changeset eliminates warnings based on (private) a specific set of rules. Those rule highlighted missing HTTP values that were not recognized by the engine analyzer.

Link to [2926](https://redmine.openinfosecfoundation.org/issues/2926) ticket

Continuation of #3881

Describe changes:
- Recognize additional HTTP values: server body, raw host, user agent, header names
