### PR TITLE
decode: prevent segfault on bypass without flow

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -399,6 +399,9 @@ void PacketDefragPktSetupParent(Packet *parent)
 
 void PacketBypassCallback(Packet *p)
 {
+    if (p->flow == NULL) {
+        return;
+    }
     /* Don't try to bypass if flow is already out or
      * if we have failed to do it once */
     int state = SC_ATOMIC_GET(p->flow->flow_state);


### PR DESCRIPTION
When using a rule like:
pass ip any any -> any any (msg:"Bypass"; sid:1; rev:1;)

We could get a match even in case of flow exhaustion where the Packet has no Flow attached.

This is a segfault preventing patch for master-4.1.x. Trying to bypass traffic in case of Flow exhaustion will be too intrusive. Improved solution will be developed on top of master.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2953

Describe changes:
- Prevent segfault

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- https://buildbot.openinfosecfoundation.org/builders/regit/builds/453
- https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/234

