### PR TITLE
suricatasc: fix reconnect

### DIFF
--- a/python/suricata/sc/suricatasc.py
+++ b/python/suricata/sc/suricatasc.py
@@ -156,6 +156,8 @@ class SuricataSC:
 
     def connect(self):
         try:
+            if self.socket == None:
+                self.socket = socket(AF_UNIX)
             self.socket.connect(self.sck_path)
         except error as err:
             raise SuricataNetException(err)
@@ -193,6 +195,7 @@ class SuricataSC:
 
     def close(self):
         self.socket.close()
+        self.socket = None
 
     def execute(self, command):
         full_cmd = command.split()
@@ -252,6 +255,7 @@ class SuricataSC:
                     # try to reconnect and resend command
                     print("Connection lost, trying to reconnect")
                     try:
+                        self.close()
                         self.connect()
                     except SuricataNetException as err:
                         print("Can't reconnect to suricata socket, discarding command")


### PR DESCRIPTION
The reconnection system in suricatasc was not working properly. Restarting suricata was causing an error in suricatasc when trying to reopen the unix socket.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Fix reconnect

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/454
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/235
