### PR TITLE
dns: handle mid stream pickup on response packet - v2

### DIFF
--- a/src/app-layer-dns-tcp-rust.c
+++ b/src/app-layer-dns-tcp-rust.c
@@ -61,7 +61,7 @@ static uint16_t RustDNSTCPProbe(Flow *f, uint8_t direction,
     }
 
     // Validate and return ALPROTO_FAILED if needed.
-    if (!rs_dns_probe_tcp(input, len)) {
+    if (!rs_dns_probe_tcp(direction, input, len, rdir)) {
         return ALPROTO_FAILED;
     }
 
@@ -126,7 +126,7 @@ void RegisterRustDNSTCPParsers(void)
         if (RunmodeIsUnittests()) {
             AppLayerProtoDetectPPRegister(IPPROTO_TCP, "53", ALPROTO_DNS, 0,
                     sizeof(DNSHeader) + 2, STREAM_TOSERVER, RustDNSTCPProbe,
-                    NULL);
+                    RustDNSTCPProbe);
         } else {
             int have_cfg = AppLayerProtoDetectPPParseConfPorts("tcp",
                     IPPROTO_TCP, proto_name, ALPROTO_DNS, 0,

--- a/src/app-layer-dns-udp-rust.c
+++ b/src/app-layer-dns-udp-rust.c
@@ -58,7 +58,7 @@ static uint16_t DNSUDPProbe(Flow *f, uint8_t direction,
     }
 
     // Validate and return ALPROTO_FAILED if needed.
-    if (!rs_dns_probe(input, len)) {
+    if (!rs_dns_probe(input, len, rdir)) {
         return ALPROTO_FAILED;
     }
 
@@ -132,11 +132,11 @@ void RegisterRustDNSUDPParsers(void)
         if (RunmodeIsUnittests()) {
             AppLayerProtoDetectPPRegister(IPPROTO_UDP, "53", ALPROTO_DNS, 0,
                     sizeof(DNSHeader), STREAM_TOSERVER, DNSUDPProbe,
-                    NULL);
+                    DNSUDPProbe);
         } else {
             int have_cfg = AppLayerProtoDetectPPParseConfPorts("udp",
                     IPPROTO_UDP, proto_name, ALPROTO_DNS, 0, sizeof(DNSHeader),
-                    DNSUDPProbe, NULL);
+                    DNSUDPProbe, DNSUDPProbe);
 
             /* If no config, enable on port 53. */
             if (!have_cfg) {
@@ -146,7 +146,7 @@ void RegisterRustDNSUDPParsers(void)
 #endif
                 AppLayerProtoDetectPPRegister(IPPROTO_UDP, "53", ALPROTO_DNS,
                         0, sizeof(DNSHeader), STREAM_TOSERVER,
-                        DNSUDPProbe, NULL);
+                        DNSUDPProbe, DNSUDPProbe);
             }
         }
     } else {


### PR DESCRIPTION
On DNS probe, reverse the flow direction if the frame is detected as a response instead of a request.

Related Redmine issue:
https://redmine.openinfosecfoundation.org/issues/2146

Prscript failed to start.