### PR TITLE
http: fix overflow in HTPParseContentRange

### DIFF
--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -196,13 +196,13 @@ int HTPParseContentRange(bstr * rawvalue, HtpContentRange *range)
         // case with start and end
         range->start = bstr_util_mem_to_pint(data + pos, len - pos, 10, &last_pos);
         pos += last_pos;
-        if (len < pos || data[pos] != '-') {
+        if (len < pos + 1 || data[pos] != '-') {
             return -1;
         }
         pos++;
         range->end = bstr_util_mem_to_pint(data + pos, len - pos, 10, &last_pos);
         pos += last_pos;
-        if (len < pos || data[pos] != '/') {
+        if (len < pos + 1 || data[pos] != '/') {
             return -1;
         }
         pos++;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2999

Describe changes:
- Fix overflow in `HTPParseContentRange`

I guess that we should add unit tests for this...
But here is the fix quickly