### PR TITLE
RFC: dns srv support

### DIFF
--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -433,6 +433,7 @@ fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Json
         DNS_RECORD_TYPE_CNAME |
         DNS_RECORD_TYPE_MX |
         DNS_RECORD_TYPE_TXT |
+        DNS_RECORD_TYPE_SRV |
         DNS_RECORD_TYPE_PTR => {
             jsa.set_string_from_bytes("rdata", &answer.data);
         },
@@ -503,6 +504,7 @@ fn dns_log_json_answer(response: &DNSResponse, flags: u64) -> Json
                     DNS_RECORD_TYPE_CNAME |
                     DNS_RECORD_TYPE_MX |
                     DNS_RECORD_TYPE_TXT |
+                    DNS_RECORD_TYPE_SRV |
                     DNS_RECORD_TYPE_PTR => {
                         if !answer_types.contains_key(&type_string) {
                             answer_types.insert(type_string.to_string(),
@@ -637,6 +639,7 @@ fn dns_log_json_answer_v1(header: &DNSHeader, answer: &DNSAnswerEntry)
         DNS_RECORD_TYPE_CNAME |
         DNS_RECORD_TYPE_MX |
         DNS_RECORD_TYPE_TXT |
+        DNS_RECORD_TYPE_SRV |
         DNS_RECORD_TYPE_PTR => {
             js.set_string_from_bytes("rdata", &answer.data);
         },

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -252,6 +252,13 @@ pub fn dns_parse_query<'a>(input: &'a [u8],
     ))(input);
 }
 
+pub fn dns_format_service<'a>(name: Vec<u8>, port: u16)
+    -> Vec<u8>
+{
+    let vname = String::from_utf8(name).unwrap();
+    format!("{}:{}", vname, port).into_bytes()
+}
+
 pub fn dns_parse_rdata<'a>(input: &'a [u8], message: &'a [u8], rrtype: u16)
     -> IResult<&'a [u8], Vec<u8>>
 {
@@ -276,9 +283,9 @@ pub fn dns_parse_rdata<'a>(input: &'a [u8], message: &'a [u8], rrtype: u16)
             closure!(&'a [u8], do_parse!(
                 be_u16 >>
                 be_u16 >>
-                be_u16 >> // port we will need to parse it
+                port: be_u16 >>
                 name: apply!(dns_parse_name, message) >>
-                    (name)
+                    (dns_format_service(name, port))
             ))(input)
         },
         DNS_RECORD_TYPE_TXT => {

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -270,6 +270,17 @@ pub fn dns_parse_rdata<'a>(input: &'a [u8], message: &'a [u8], rrtype: u16)
                     (name)
             ))(input)
         },
+        DNS_RECORD_TYPE_SRV => {
+            // For SRV we skip over priority, weight and port (prov) fields before
+            // parsing out the name.
+            closure!(&'a [u8], do_parse!(
+                be_u16 >>
+                be_u16 >>
+                be_u16 >> // port we will need to parse it
+                name: apply!(dns_parse_name, message) >>
+                    (name)
+            ))(input)
+        },
         DNS_RECORD_TYPE_TXT => {
             closure!(&'a [u8], do_parse!(
                 len: be_u8 >>


### PR DESCRIPTION
Here is a small PR adding support for SRV answer parsing in DNS protocol. This field has something different from the other ones as it has 2 part in the answer rdata: port and hostname. I did not really know how to handle it. Should we do as it is here logging '$host:$port' in rdata ? or should we have 2 logged fields ?

Currently we have:
```JSON
  "dns": {
    "type": "answer",
    "rrname": "_kerberos._tcp.SAMBA.WINDOWS8.PRIVATE",
    "rrtype": "SRV",
    "rcode": "NOERROR",
    "answers": [
      {
        "rrname": "_kerberos._tcp.SAMBA.WINDOWS8.PRIVATE",
        "rrtype": "SRV",
        "ttl": 900,
        "rdata": "s4dc1.samba.windows8.private:88"
      }
    ],
    "grouped": {
      "SRV": [
        "s4dc1.samba.windows8.private:88"
      ]
    }
  }
```

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- log DNS srv
- append port to hostname in rdata

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/459
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/240

