### PR TITLE
signature: fixes leak with duplicate signatures

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2184,6 +2184,18 @@ static inline int DetectEngineSignatureIsDuplicate(DetectEngineCtx *de_ctx,
     sw_dup->s = sig;
     sw_dup->s_prev = NULL;
 
+    if (de_ctx->sig_list != NULL) {
+        SigDuplWrapper sw_tmp;
+        memset(&sw_tmp, 0, sizeof(SigDuplWrapper));
+        sw_tmp.s = de_ctx->sig_list;
+        SigDuplWrapper *sw_old = HashListTableLookup(de_ctx->dup_sig_hash_table,
+                                                     (void *)&sw_tmp, 0);
+        if (sw_old->s != sw_dup->s) {
+            // Link on top of the list if there was another element
+            sw_old->s_prev = sig;
+        }
+    }
+
     /* this is duplicate, but a duplicate that replaced the existing sig entry */
     ret = 2;
 
@@ -4010,9 +4022,16 @@ static int SigParseBidirWithSameSrcAndDest02(void)
 
 #endif /* UNITTESTS */
 
+#ifdef UNITTESTS
+void DetectParseRegisterTests (void);
+#include "tests/detect-parse.c"
+#endif
+
 void SigParseRegisterTests(void)
 {
 #ifdef UNITTESTS
+    DetectParseRegisterTests();
+
     UtRegisterTest("SigParseTest01", SigParseTest01);
     UtRegisterTest("SigParseTest02", SigParseTest02);
     UtRegisterTest("SigParseTest03", SigParseTest03);

--- a/src/tests/detect-parse.c
+++ b/src/tests/detect-parse.c
@@ -1,0 +1,48 @@
+
+/* Copyright (C) 2007-2019 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "../detect-parse.h"
+#include "../util-unittest.h"
+
+/**
+ * \test DetectParseTest01 is a regression test against a memory leak
+ * in the case of multiple signatures with different revisions
+ * Leak happened in function DetectEngineSignatureIsDuplicate
+ */
+
+static int DetectParseTest01 (void)
+{
+    DetectEngineCtx * de_ctx = DetectEngineCtxInit();
+    FAIL_IF(DetectEngineAppendSig(de_ctx, "alert http any any -> any any (msg:\"sid 1 version 0\"; content:\"dummy1\"; sid:1;)") == NULL);
+    DetectEngineAppendSig(de_ctx, "alert http any any -> any any (msg:\"sid 2 version 0\"; content:\"dummy2\"; sid:2;)");
+    DetectEngineAppendSig(de_ctx, "alert http any any -> any any (msg:\"sid 1 version 1\"; content:\"dummy1.1\"; sid:1; rev:1;)");
+    DetectEngineAppendSig(de_ctx, "alert http any any -> any any (msg:\"sid 2 version 2\"; content:\"dummy2.1\"; sid:2; rev:1;)");
+    FAIL_IF(de_ctx->sig_list->next == NULL);
+    DetectEngineCtxFree(de_ctx);
+
+    PASS;
+}
+
+
+/**
+ * \brief this function registers unit tests for DetectParse
+ */
+void DetectParseRegisterTests(void)
+{
+    UtRegisterTest("DetectParseTest01", DetectParseTest01);
+}


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Fixes leak with duplicate signatures

I guess that we should add a test. What is the best place for it ?

The fuzzer generated this sample :
```
alert http any any -> any any (msg:"EICAR file data"; file_data; content:"EICAR-STANDARD-ANTIVIRUS-TEST-FILE"; sid:1;)
alert http any any -> any any (msg:"EICAR file data X"; file_data; content:"X5O!P%@AP[4"; sid:2;)
alert http any any -> any any (content:"curl"; http_user_agent; flowbits:set,traffic/label/cli-http; flowbits:set,traffic/id/curl; flowbits:set,junkbit; sid:1; rev:1;)
alert http any any -> any any (pcre:"/uid=(\d+)\(([^)]+)\)/, pkt:uid, pkt:username"; noalert; sid:2; rev:1;)
```

The important part are `sid` and `rev`

When signature 1 gets replaced with signature 1.1, the linked list fails adding a backward link from the previous signature (in this case 2) to this newly updated signature

And so, when we replace 2 by 2.1, we overwrite the beginning of the list, leaking the signature 1.1

The linked list at each import go
- 1
- 2, 1
- 1.1, 2
- 2.1

With this patch, the final step is 2.1, 1.1

Follow #3890 :
- Fixes compilation warning adding a prototype for `DetectParseRegisterTests`
