### PR TITLE
Http range overflow 2999 v3

### DIFF
--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -1684,6 +1684,8 @@ end:
     return result;
 }
 
+void AppLayerHtpFileRegisterTests (void);
+#include "tests/app-layer-htp-file.c"
 #endif /* UNITTESTS */
 
 void HTPFileParserRegisterTests(void)

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -196,13 +196,13 @@ int HTPParseContentRange(bstr * rawvalue, HtpContentRange *range)
         // case with start and end
         range->start = bstr_util_mem_to_pint(data + pos, len - pos, 10, &last_pos);
         pos += last_pos;
-        if (len < pos || data[pos] != '-') {
+        if (len < pos + 1 || data[pos] != '-') {
             return -1;
         }
         pos++;
         range->end = bstr_util_mem_to_pint(data + pos, len - pos, 10, &last_pos);
         pos += last_pos;
-        if (len < pos || data[pos] != '/') {
+        if (len < pos + 1 || data[pos] != '/') {
             return -1;
         }
         pos++;

--- a/src/tests/app-layer-htp-file.c
+++ b/src/tests/app-layer-htp-file.c
@@ -1,0 +1,93 @@
+
+/* Copyright (C) 2019 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "../app-layer-htp-file.h"
+#include "../util-unittest.h"
+
+/**
+ * \test AppLayerHtpFileParseContentRangeTest01 is a test
+ * for setting up a valid range value.
+ */
+
+static int AppLayerHtpFileParseContentRangeTest01 (void)
+{
+    HtpContentRange range;
+    bstr * rawvalue = bstr_dup_c("bytes 12-25/100");
+    FAIL_IF_NOT(HTPParseContentRange(rawvalue, &range) == HTP_OK);
+    FAIL_IF_NOT(range.start == 12);
+    FAIL_IF_NOT(range.end == 25);
+    FAIL_IF_NOT(range.size == 100);
+    bstr_free(rawvalue);
+    PASS;
+}
+
+/**
+ * \test AppLayerHtpFileParseContentRangeTest02 is a regression test
+ * for setting up an invalid range value.
+ */
+
+static int AppLayerHtpFileParseContentRangeTest02 (void)
+{
+    HtpContentRange range;
+    bstr * rawvalue = bstr_dup_c("bytes 15335424-27514354/");
+    FAIL_IF(HTPParseContentRange(rawvalue, &range) == HTP_OK);
+    bstr_free(rawvalue);
+    PASS;
+}
+
+/**
+ * \test AppLayerHtpFileParseContentRangeTest03 is a regression test
+ * for setting up an invalid range value.
+ */
+
+static int AppLayerHtpFileParseContentRangeTest03 (void)
+{
+    HtpContentRange range;
+    bstr * rawvalue = bstr_dup_c("bytes 15335424-");
+    FAIL_IF(HTPParseContentRange(rawvalue, &range) == HTP_OK);
+    bstr_free(rawvalue);
+    PASS;
+}
+
+
+/**
+ * \test AppLayerHtpFileParseContentRangeTest04 is a test
+ * for setting up a valid range value without the size.
+ */
+
+static int AppLayerHtpFileParseContentRangeTest04 (void)
+{
+    HtpContentRange range;
+    bstr * rawvalue = bstr_dup_c("bytes 24-42/*");
+    FAIL_IF_NOT(HTPParseContentRange(rawvalue, &range) == HTP_OK);
+    FAIL_IF_NOT(range.start == 24);
+    FAIL_IF_NOT(range.end == 42);
+    bstr_free(rawvalue);
+    PASS;
+}
+
+/**
+ * \brief this function registers unit tests for AppLayerHtpFile
+ */
+void AppLayerHtpFileRegisterTests(void)
+{
+    UtRegisterTest("AppLayerHtpFileParseContentRangeTest01", AppLayerHtpFileParseContentRangeTest01);
+    UtRegisterTest("AppLayerHtpFileParseContentRangeTest02", AppLayerHtpFileParseContentRangeTest02);
+    UtRegisterTest("AppLayerHtpFileParseContentRangeTest03", AppLayerHtpFileParseContentRangeTest03);
+    UtRegisterTest("AppLayerHtpFileParseContentRangeTest04", AppLayerHtpFileParseContentRangeTest04);
+}


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2999

Describe changes:
- Fix overflow in `HTPParseContentRange`
- Adds test cases for `HTPParseContentRange` including regression test for this bug

I separated the commits for fixing the bug and adding the test cases.
Should I squash them ?

Modifies #3909 with rebase