### PR TITLE
warnings: fixes integer sizes in format strings

### DIFF
--- a/src/decode-icmpv4.c
+++ b/src/decode-icmpv4.c
@@ -85,7 +85,7 @@ static int DecodePartialIPV4(Packet* p, uint8_t* partial_packet, uint16_t len)
                 p->icmpv4vars.emb_ip4_proto = IPPROTO_TCP;
 
                 SCLogDebug("DecodePartialIPV4: ICMPV4->IPV4->TCP header sport: "
-                           "%"PRIu8" dport %"PRIu8"", p->icmpv4vars.emb_sport,
+                           "%"PRIu16" dport %"PRIu16"", p->icmpv4vars.emb_sport,
                             p->icmpv4vars.emb_dport);
             } else if (len >= IPV4_HEADER_LEN + 4) {
                 /* only access th_sport and th_dport */
@@ -96,7 +96,7 @@ static int DecodePartialIPV4(Packet* p, uint8_t* partial_packet, uint16_t len)
                 p->icmpv4vars.emb_dport = SCNtohs(emb_tcph->th_dport);
                 p->icmpv4vars.emb_ip4_proto = IPPROTO_TCP;
                 SCLogDebug("DecodePartialIPV4: ICMPV4->IPV4->TCP partial header sport: "
-                           "%"PRIu8" dport %"PRIu8"", p->icmpv4vars.emb_sport,
+                           "%"PRIu16" dport %"PRIu16"", p->icmpv4vars.emb_sport,
                             p->icmpv4vars.emb_dport);
             } else {
                 SCLogDebug("DecodePartialIPV4: Warning, ICMPV4->IPV4->TCP "
@@ -114,7 +114,7 @@ static int DecodePartialIPV4(Packet* p, uint8_t* partial_packet, uint16_t len)
                 p->icmpv4vars.emb_ip4_proto = IPPROTO_UDP;
 
                 SCLogDebug("DecodePartialIPV4: ICMPV4->IPV4->UDP header sport: "
-                           "%"PRIu8" dport %"PRIu8"", p->icmpv4vars.emb_sport,
+                           "%"PRIu16" dport %"PRIu16"", p->icmpv4vars.emb_sport,
                             p->icmpv4vars.emb_dport);
             } else {
                 SCLogDebug("DecodePartialIPV4: Warning, ICMPV4->IPV4->UDP "

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -101,7 +101,7 @@ static void DecodePartialIPV6(Packet *p, uint8_t *partial_packet, uint16_t len )
                 p->icmpv6vars.emb_dport = p->icmpv6vars.emb_tcph->th_dport;
 
                 SCLogDebug("ICMPV6->IPV6->TCP header sport: "
-                           "%"PRIu8" dport %"PRIu8"", p->icmpv6vars.emb_sport,
+                           "%"PRIu16" dport %"PRIu16"", p->icmpv6vars.emb_sport,
                             p->icmpv6vars.emb_dport);
             } else {
                 SCLogDebug("Warning, ICMPV6->IPV6->TCP "
@@ -118,7 +118,7 @@ static void DecodePartialIPV6(Packet *p, uint8_t *partial_packet, uint16_t len )
                 p->icmpv6vars.emb_dport = p->icmpv6vars.emb_udph->uh_dport;
 
                 SCLogDebug("ICMPV6->IPV6->UDP header sport: "
-                           "%"PRIu8" dport %"PRIu8"", p->icmpv6vars.emb_sport,
+                           "%"PRIu16" dport %"PRIu16"", p->icmpv6vars.emb_sport,
                             p->icmpv6vars.emb_dport);
             } else {
                 SCLogDebug("Warning, ICMPV6->IPV6->UDP "

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -329,12 +329,12 @@ static void DecodeIPV4Options(Packet *p, uint8_t *pkt, uint16_t len, IPV4Options
         /* single byte options */
         if (*pkt == IPV4_OPT_EOL) {
             /** \todo What if more data exist after EOL (possible covert channel or data leakage)? */
-            SCLogDebug("IPV4OPT %" PRIu16 " len 1 @ %" PRIu16 "/%" PRIu16 "",
+            SCLogDebug("IPV4OPT %" PRIu8 " len 1 @ %d/%d",
                    *pkt, (len - plen), (len - 1));
             p->ip4vars.opts_set |= IPV4_OPT_FLAG_EOL;
             break;
         } else if (*pkt == IPV4_OPT_NOP) {
-            SCLogDebug("IPV4OPT %" PRIu16 " len 1 @ %" PRIu16 "/%" PRIu16 "",
+            SCLogDebug("IPV4OPT %" PRIu8 " len 1 @ %d/%d",
                    *pkt, (len - plen), (len - 1));
             pkt++;
             plen--;
@@ -492,7 +492,7 @@ static int DecodeIPV4Packet(Packet *p, uint8_t *pkt, uint16_t len)
     }
 
     if (unlikely(IP_GET_RAW_VER(pkt) != 4)) {
-        SCLogDebug("wrong ip version %" PRIu8 "",IP_GET_RAW_VER(pkt));
+        SCLogDebug("wrong ip version %d",IP_GET_RAW_VER(pkt));
         ENGINE_SET_INVALID_EVENT(p, IPV4_WRONG_IP_VER);
         return -1;
     }

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -201,7 +201,7 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                 IPV6_SET_L4PROTO(p,nh);
                 hdrextlen = 8 + (*(pkt+1) * 8);  /* 8 bytes + length in 8 octet units */
 
-                SCLogDebug("hdrextlen %"PRIu8, hdrextlen);
+                SCLogDebug("hdrextlen %"PRIu16, hdrextlen);
 
                 if (hdrextlen > plen) {
                     ENGINE_SET_INVALID_EVENT(p, IPV6_TRUNC_EXTHDR);
@@ -494,7 +494,7 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                 if (*(pkt+1) > 0)
                     hdrextlen += ((*(pkt+1) - 1) * 4);
 
-                SCLogDebug("hdrextlen %"PRIu8, hdrextlen);
+                SCLogDebug("hdrextlen %"PRIu16, hdrextlen);
 
                 if (hdrextlen > plen) {
                     ENGINE_SET_INVALID_EVENT(p, IPV6_TRUNC_EXTHDR);
@@ -562,7 +562,7 @@ static int DecodeIPV6Packet (ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, u
     }
 
     if (unlikely(IP_GET_RAW_VER(pkt) != 6)) {
-        SCLogDebug("wrong ip version %" PRIu8 "",IP_GET_RAW_VER(pkt));
+        SCLogDebug("wrong ip version %d",IP_GET_RAW_VER(pkt));
         ENGINE_SET_INVALID_EVENT(p, IPV6_WRONG_IP_VER);
         return -1;
     }

--- a/src/decode-raw.c
+++ b/src/decode-raw.c
@@ -68,7 +68,7 @@ int DecodeRaw(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, ui
         SCLogDebug("IPV6 Packet");
         DecodeIPV6(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
     } else {
-        SCLogDebug("Unknown ip version %" PRIu8 "", IP_GET_RAW_VER(pkt));
+        SCLogDebug("Unknown ip version %d", IP_GET_RAW_VER(pkt));
         ENGINE_SET_EVENT(p,IPRAW_INVALID_IPV);
     }
     return TM_ECODE_OK;

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -241,7 +241,7 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
     int i = 0;
 
     while (i < p->alerts.cnt) {
-        SCLogDebug("Sig->num: %"PRIu16, p->alerts.alerts[i].num);
+        SCLogDebug("Sig->num: %"PRIu32, p->alerts.alerts[i].num);
         const Signature *s = de_ctx->sig_array[p->alerts.alerts[i].num];
 
         int res = PacketAlertHandle(de_ctx, det_ctx, s, p, &p->alerts.alerts[i]);

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -1070,7 +1070,7 @@ void IPOnlyMatchPacket(ThreadVars *tv,
                         continue;
                     }
 
-                    SCLogDebug("Signum %"PRIu16" match (sid: %"PRIu16", msg: %s)",
+                    SCLogDebug("Signum %"PRIu32" match (sid: %"PRIu32", msg: %s)",
                                u * 8 + i, s->id, s->msg);
 
                     if (s->sm_arrays[DETECT_SM_LIST_POSTMATCH] != NULL) {
@@ -1325,8 +1325,8 @@ void IPOnlyPrepare(DetectEngineCtx *de_ctx)
         if (dst->family == AF_INET) {
 
             SCLogDebug("To IPv4");
-            SCLogDebug("Item has netmask %"PRIu16" negated: %s; IP: %s; signum:"
-                       " %"PRIu16"", dst->netmask, (dst->negated)?"yes":"no",
+            SCLogDebug("Item has netmask %"PRIu8" negated: %s; IP: %s; signum:"
+                       " %"PRIu32"", dst->netmask, (dst->negated)?"yes":"no",
                        inet_ntoa(*(struct in_addr*)&dst->ip[0]), dst->signum);
 
             void *user_data = NULL;

--- a/src/detect-flowint.c
+++ b/src/detect-flowint.c
@@ -119,7 +119,7 @@ int DetectFlowintMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         targetval = sfd->target.value;
     }
 
-    SCLogDebug("Our var %s is at idx: %"PRIu16"", sfd->name, sfd->idx);
+    SCLogDebug("Our var %s is at idx: %"PRIu32"", sfd->name, sfd->idx);
 
     if (sfd->modifier == FLOWINT_MODIFIER_SET) {
         FlowVarAddIntNoLock(p->flow, sfd->idx, targetval);

--- a/src/detect-tls-version.c
+++ b/src/detect-tls-version.c
@@ -212,7 +212,7 @@ static DetectTlsVersionData *DetectTlsVersionParse (const char *str)
 
         SCFree(orig);
 
-        SCLogDebug("will look for tls %"PRIu8"", tls->ver);
+        SCLogDebug("will look for tls %"PRIu16"", tls->ver);
     }
 
     return tls;

--- a/src/detect-ttl.c
+++ b/src/detect-ttl.c
@@ -183,7 +183,7 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
                 mode = DETECT_TTL_LT;
                 ttl1 = atoi(arg3);
 
-                SCLogDebug("ttl is %"PRIu8"",ttl1);
+                SCLogDebug("ttl is %d",ttl1);
                 if (strlen(arg1) > 0)
                     return NULL;
 
@@ -195,7 +195,7 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
                 mode = DETECT_TTL_GT;
                 ttl1 = atoi(arg3);
 
-                SCLogDebug("ttl is %"PRIu8"",ttl1);
+                SCLogDebug("ttl is %d",ttl1);
                 if (strlen(arg1) > 0)
                     return NULL;
 
@@ -208,7 +208,7 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
                 ttl1 = atoi(arg1);
                 ttl2 = atoi(arg3);
 
-                SCLogDebug("ttl is %"PRIu8" to %"PRIu8"",ttl1, ttl2);
+                SCLogDebug("ttl is %d to %d",ttl1, ttl2);
                 if (ttl1 >= ttl2) {
                     SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid ttl range");
                     return NULL;

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -245,10 +245,10 @@ enum
 
 #define StreamTcpSetEvent(p, e) {                                           \
     if ((p)->flags & PKT_STREAM_NO_EVENTS) {                                \
-        SCLogDebug("not setting event %"PRIu8" on pkt %p (%"PRIu64"), "     \
+        SCLogDebug("not setting event %d on pkt %p (%"PRIu64"), "     \
                    "stream in known bad condition", (e), p, (p)->pcap_cnt); \
     } else {                                                                \
-        SCLogDebug("setting event %"PRIu8" on pkt %p (%"PRIu64")",          \
+        SCLogDebug("setting event %d on pkt %p (%"PRIu64")",          \
                     (e), p, (p)->pcap_cnt);                                 \
         ENGINE_SET_EVENT((p), (e));                                         \
     }                                                                       \

--- a/src/util-cpu.c
+++ b/src/util-cpu.c
@@ -67,7 +67,7 @@ uint16_t UtilCpuGetNumProcessorsConfigured(void)
     }
 
     if (nprocs > UINT16_MAX) {
-        SCLogDebug("It seems that there are more than %"PRIu16" CPUs "
+        SCLogDebug("It seems that there are more than %d CPUs "
                    "configured on this system. You can modify util-cpu.{c,h} "
                    "to use uint32_t to support it", UINT16_MAX);
         return UINT16_MAX;
@@ -108,7 +108,7 @@ uint16_t UtilCpuGetNumProcessorsOnline(void)
     }
 
     if (nprocs > UINT16_MAX) {
-        SCLogDebug("It seems that there are more than %"PRIu16" CPUs online. "
+        SCLogDebug("It seems that there are more than %d CPUs online. "
                    "You can modify util-cpu.{c,h} to use uint32_t to "
                    "support it", UINT16_MAX);
         return UINT16_MAX;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3009

Describe changes:
- Fixes integer sizes in format strings

Warnings found by compiling with Apple LLVM version 10.0.0 (clang-1000.11.45.5)