### PR TITLE
signature: error for rules with illegal port

### DIFF
--- a/src/detect-engine-port.c
+++ b/src/detect-engine-port.c
@@ -1465,7 +1465,10 @@ error:
  */
 int DetectPortIsValidRange(char *port)
 {
-    if(atoi(port) >= 0 && atoi(port) <= 65535)
+    char *end;
+    long r = strtol(port, &end, 10);
+
+    if(*end == 0 && r >= 0 && r <= 65535)
         return 1;
     else
         return 0;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2080

Describe changes:
- Uses `strtol` instead of `atoi` for better error handling while parsing a port in a signature

Should we add a test for this ?

See https://wiki.sei.cmu.edu/confluence/display/c/ERR34-C.+Detect+errors+when+converting+a+string+to+a+number