### PR TITLE
doc: convert fancy quotes to straight quotes

### DIFF
--- a/doc/userguide/capture-hardware/myricom.rst
+++ b/doc/userguide/capture-hardware/myricom.rst
@@ -3,7 +3,7 @@ Myricom
 
 From: https://blog.inliniac.net/2012/07/10/suricata-on-myricom-capture-cards/
 
-In this guide I’ll describe using the Myricom libpcap support. I’m going to assume you installed the card properly, installed the Sniffer driver and made sure that all works. Make sure that in your dmesg you see that the card is in sniffer mode:
+In this guide I'll describe using the Myricom libpcap support. I'm going to assume you installed the card properly, installed the Sniffer driver and made sure that all works. Make sure that in your dmesg you see that the card is in sniffer mode:
 
 ::
 
@@ -13,7 +13,7 @@ In this guide I’ll describe using the Myricom libpcap support. I’m going to 
 
 I have installed the Myricom runtime and libraries in /opt/snf
 
-Compile Suricata against Myricom’s libpcap:
+Compile Suricata against Myricom's libpcap:
 
 
 ::
@@ -23,7 +23,7 @@ Compile Suricata against Myricom’s libpcap:
   make
   sudo make install
 
-Next, configure the amount of ringbuffers. I’m going to work with 8 here, as my quad core + hyper threading has 8 logical CPU’s. *See below* for additional information about the buffer-size parameter.
+Next, configure the amount of ringbuffers. I'm going to work with 8 here, as my quad core + hyper threading has 8 logical CPUs. *See below* for additional information about the buffer-size parameter.
 
 
 ::
@@ -35,7 +35,7 @@ Next, configure the amount of ringbuffers. I’m going to work with 8 here, as m
       buffer-size: 512kb
       checksum-checks: no
 
-The 8 threads setting makes Suricata create 8 reader threads for eth5. The Myricom driver makes sure each of those is attached to it’s own ringbuffer.
+The 8 threads setting makes Suricata create 8 reader threads for eth5. The Myricom driver makes sure each of those is attached to its own ringbuffer.
 
 Then start Suricata as follows:
 
@@ -44,7 +44,7 @@ Then start Suricata as follows:
 
   SNF_NUM_RINGS=8 SNF_FLAGS=0x1 suricata -c suricata.yaml -i eth5 --runmode=workers
 
-If you want 16 ringbuffers, update the “threads” variable in your yaml to 16 and start Suricata:
+If you want 16 ringbuffers, update the "threads" variable in your yaml to 16 and start Suricata:
 
 ::
 
@@ -56,7 +56,7 @@ Note that the pcap.buffer-size yaml setting shown above is currently ignored whe
 ::
 
 
-  “The libpcap interface to Sniffer10G ignores the pcap_set_buffer_size() value.  The call to snf_open() uses zero as the dataring_size which informs the Sniffer library to use a default value or the value from the SNF_DATARING_SIZE environment variable."
+  "The libpcap interface to Sniffer10G ignores the pcap_set_buffer_size() value.  The call to snf_open() uses zero as the dataring_size which informs the Sniffer library to use a default value or the value from the SNF_DATARING_SIZE environment variable."
 
 The following pull request opened by Myricom in the libpcap project indicates that a future SNF software release could provide support for setting the SNF_DATARING_SIZE via the pcap.buffer-size yaml setting:
 

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1533,7 +1533,7 @@ A logging line exists of two parts. First it displays meta information
 
   [27708] 15/10/2010 -- 11:40:07 - (suricata.c:425) <Info> (main) – This is Suricata version 1.0.2
 
-(Here the part until the – is the meta info, “This is Suricata 1.0.2”
+(Here the part until the – is the meta info, "This is Suricata 1.0.2"
 is the actual message.)
 
 It is possible to determine which information will be displayed in

--- a/doc/userguide/licenses/cc-nc-4.0.rst
+++ b/doc/userguide/licenses/cc-nc-4.0.rst
@@ -154,11 +154,11 @@ d. Nothing in this Public License constitutes or may be interpreted as a limitat
 **Creative Commons is not a party to its public
 licenses. Notwithstanding, Creative Commons may elect to apply one of
 its public licenses to material it publishes and in those instances
-will be considered the “Licensor.” Except for the limited purpose of
+will be considered the "Licensor." Except for the limited purpose of
 indicating that material is shared under a Creative Commons public
 license or as otherwise permitted by the Creative Commons policies
 published at creativecommons.org/policies, Creative Commons does not
-authorize the use of the trademark “Creative Commons” or any other
+authorize the use of the trademark "Creative Commons" or any other
 trademark or logo of Creative Commons without its prior written
 consent including, without limitation, in connection with any
 unauthorized modifications to any of its public licenses or any other

--- a/doc/userguide/performance/tcmalloc.rst
+++ b/doc/userguide/performance/tcmalloc.rst
@@ -1,8 +1,8 @@
 Tcmalloc
 ========
 
-‘tcmalloc’ is a library Google created as part of the google-perftools
-suite for improving memory handling in a threaded program. It’s very
+'tcmalloc' is a library Google created as part of the google-perftools
+suite for improving memory handling in a threaded program. It's very
 simple to use and does work fine with Suricata. It leads to minor
 speed ups and also reduces memory usage quite a bit.
 
@@ -30,7 +30,7 @@ Ubuntu:
 
 ::
 
-  LD_PRELOAD=”/usr/lib/libtcmalloc_minimal.so.0" suricata -c suricata.yaml -i eth0
+  LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.0" suricata -c suricata.yaml -i eth0
 
 Fedora:
 

--- a/doc/userguide/rule-management/oinkmaster.rst
+++ b/doc/userguide/rule-management/oinkmaster.rst
@@ -168,7 +168,7 @@ At the part where you can modify rules, type:
 
 ::
 
-  modifysid 2010495 “alert” | “drop”
+  modifysid 2010495 "alert" | "drop"
 
 The sid 2010495 is an example. Type the sid of the rule you desire to
 change, instead.

--- a/doc/userguide/rules/differences-from-snort.rst
+++ b/doc/userguide/rules/differences-from-snort.rst
@@ -332,7 +332,7 @@ Relative PCRE
 
      content:".php?sign="; http_uri; pcre:"/^[a-zA-Z0-9]{8}$/UR";
 
--  With Snort you can't combine the “relative” PCRE option ('R') with other buffer options like normalized URI ('U') – you get a syntax error.
+-  With Snort you can't combine the "relative" PCRE option ('R') with other buffer options like normalized URI ('U') – you get a syntax error.
 
 ``tls*`` Keywords
 ------------------

--- a/doc/userguide/rules/flow-keywords.rst
+++ b/doc/userguide/rules/flow-keywords.rst
@@ -158,9 +158,9 @@ in the stream.
 
 So we'll get an alert ONLY if usernamecount is over five.
 
-So now let’s say we want to get an alert as above but NOT if there
+So now let's say we want to get an alert as above but NOT if there
 have been more occurrences of that username logging out. Assuming this
-particular protocol indicates a log out with "jonkman logout", let’s
+particular protocol indicates a log out with "jonkman logout", let's
 try:
 
 ::
@@ -176,7 +176,7 @@ of what such a simple function can do for rule writing. I see a lot of
 applications in things like login tracking, IRC state machines,
 malware tracking, and brute force login detection.
 
-Let’s say we're tracking a protocol that normally allows five login
+Let's say we're tracking a protocol that normally allows five login
 fails per connection, but we have vulnerability where an attacker can
 continue to login after that five attempts and we need to know about
 it.

--- a/doc/userguide/rules/header-keywords.rst
+++ b/doc/userguide/rules/header-keywords.rst
@@ -151,8 +151,8 @@ The syntax of geoip::
 So, you can see you can use the following to make clear on which
 direction you would like to match::
 
-  both: both directions have to match with the given geoip (geopip’s)
-  any: one of the directions have to match with the given geoip (’s).
+  both: both directions have to match with the given geoip (geopip's)
+  any: one of the directions have to match with the given geoip ('s).
   dest: if the destination matches with the given geoip.
   src: the source matches with the given geoip.
 

--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -12,7 +12,7 @@ The content keyword is very important in signatures. Between the
 quotation marks you can write on what you would like the signature to
 match. The most simple format of content is::
 
-  content: ”............”;
+  content: "............";
 
 It is possible to use several contents in a signature.
 
@@ -38,7 +38,7 @@ There are characters you can not use in the content because they are
 already important in the signature. For matching on these characters
 you should use the heximal notation. These are::
 
-  “	|22|
+  "	|22|
   ;	|3B|
   :	|3A|
   |	|7C|
@@ -46,16 +46,16 @@ you should use the heximal notation. These are::
 It is a convention to write the heximal notation in upper case characters.
 
 To write for instance ``http://`` in the content of a signature, you
-should write it like this: ``content: “http|3A|//”;`` If you use a
+should write it like this: ``content: "http|3A|//";`` If you use a
 heximal notation in a signature, make sure you always place it between
 pipes. Otherwise the notation will be taken literally as part of the
 content.
 
 A few examples::
 
-  content:“a|0D|bc”;
-  content:”|61 0D 62 63|";
-  content:”a|0D|b|63|”;
+  content:"a|0D|bc";
+  content:"|61 0D 62 63|";
+  content:"a|0D|b|63|";
 
 It is possible to let a signature check the whole payload for a match with the content or to let it check specific parts of the payload. We come to that later.
 If you add nothing special to the signature, it will try to find a match in all the bytes of the payload.
@@ -83,7 +83,7 @@ For example::
   content:"Firefox/3."; distance:0; content:!"Firefox/3.6.13";
   distance:-10; sid:9000000; rev:1;)
 
-You see ``content:!”Firefox/3.6.13”;``. This means an alert will be
+You see ``content:!"Firefox/3.6.13";``. This means an alert will be
 generated if the used version of Firefox is not 3.6.13.
 
 .. note:: The following characters must be escaped inside the content:
@@ -102,7 +102,7 @@ The format of this keyword is::
 
 You have to place it after the content you want to modify, like::
 
-  content: “abc”; nocase;
+  content: "abc"; nocase;
 
 Example nocase:
 
@@ -157,7 +157,7 @@ The keywords offset and depth can be combined and are often used together.
 
 For example::
 
-  content:“def”; offset:3; depth:3;
+  content:"def"; offset:3; depth:3;
 
 If this was used in a signature, it would check the payload from the
 third byte till the sixth byte.
@@ -516,7 +516,7 @@ These qualities can be modified with the following characters::
 These options are perl compatible modifiers. To use these modifiers,
 you should add them to pcre, behind regex. Like this::
 
-  pcre: “/<regex>/i”;
+  pcre: "/<regex>/i";
 
 *Pcre compatible modifiers*
 

--- a/doc/userguide/rules/prefilter-keywords.rst
+++ b/doc/userguide/rules/prefilter-keywords.rst
@@ -24,8 +24,8 @@ For instance::
 
   User-agent: Mozilla/5.0 Badness;
 
-  content:”User-Agent|3A|”;
-  content:”Badness”; distance:0;
+  content:"User-Agent|3A|";
+  content:"Badness"; distance:0;
 
 In this example you see the first content is longer and more varied
 than the second one, so you know Suricata will use this content for
@@ -35,8 +35,8 @@ use the second content by using 'fast_pattern'.
 
 ::
 
-  content:”User-Agent|3A|”;
-  content:”Badness”; distance:0; fast_pattern;
+  content:"User-Agent|3A|";
+  content:"Badness"; distance:0; fast_pattern;
 
 The keyword fast_pattern modifies the content previous to it.
 
@@ -63,7 +63,7 @@ fast_pattern 'chop'.
 
 For example::
 
-  content: “aaaaaaaaabc”; fast_pattern:8,4;
+  content: "aaaaaaaaabc"; fast_pattern:8,4;
 
 This way, MPM uses only the last four characters.
 

--- a/doc/userguide/unix-socket.rst
+++ b/doc/userguide/unix-socket.rst
@@ -136,7 +136,7 @@ Pcap processing mode
 This mode is one of main motivation behind this code. The idea is to
 be able to ask to Suricata to treat different pcap files without
 having to restart Suricata between the files. This provides you a huge
-gain in time as you don’t need to wait for the signature engine to
+gain in time as you don't need to wait for the signature engine to
 initialize.
 
 To use this mode, start suricata with your preferred YAML file and
@@ -178,7 +178,7 @@ You can add multiple files without waiting the result: they will be
 sequentially processed and the generated log/alert files will be put
 into the directory specified as second arguments of the pcap-file
 command. You need to provide absolute path to the files and directory
-as Suricata doesn’t know from where the script has been run. If you pass
+as Suricata doesn't know from where the script has been run. If you pass
 a directory instead of a file, all files in the directory will be processed. If
 using ``pcap-file-continuous`` and passing in a directory, the directory will
 be monitored for new files being added until you use ``pcap-interrupt`` or


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

https://redmine.openinfosecfoundation.org/issues/2686

Describe changes:
- This converts the fancy single/double quotes to the default straight single/double quotes

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

