### PR TITLE
make: Remove rust generated headers during clean

### DIFF
--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -49,7 +49,7 @@ else
 endif
 
 clean-local:
-	-rm -rf target
+	-rm -rf target gen
 
 distclean-local: clean-local
 	rm -rf vendor gen Cargo.lock


### PR DESCRIPTION
Rust generated C-headers are not tidied up during `make clean`. This changeset ensures that the generated headers directory `rust/gen` is removed during `make clean`