### PR TITLE
dns-log: remove from config

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -329,14 +329,6 @@ outputs:
       enabled: no
       #certs-log-dir: certs # directory to store the certificates files
 
-  # a line based log of DNS requests and/or replies (no alerts)
-  # Note: not available when Rust is enabled (--enable-rust).
-  - dns-log:
-      enabled: no
-      filename: dns.log
-      append: yes
-      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
-
   # Packet log... log packets in pcap format. 3 modes of operation: "normal"
   # "multi" and "sguil".
   #


### PR DESCRIPTION
dns-log has been removed from the code.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/2297

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/354
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/709

