### PR TITLE
configure: update configure.ac to reflect modern autoconf syntax

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,13 @@
-    AC_INIT(suricata, 5.0.0-dev)
+    AC_INIT([suricata],[5.0.0-dev])
     m4_ifndef([AM_SILENT_RULES], [m4_define([AM_SILENT_RULES],[])])AM_SILENT_RULES([yes])
     AC_CONFIG_HEADERS([config.h])
     AC_CONFIG_SRCDIR([src/suricata.c])
     AC_CONFIG_MACRO_DIR(m4)
     AM_INIT_AUTOMAKE
 
-    AC_LANG_C
+    AC_LANG([C])
     AC_PROG_CC_C99
-    AC_PROG_LIBTOOL
+    LT_INIT
     PKG_PROG_PKG_CONFIG
 
     dnl Taken from https://llvm.org/svn/llvm-project/llvm/trunk/autoconf/configure.ac
@@ -33,14 +33,14 @@
         clang)
             CLANG_CFLAGS="-Wextra -Werror-implicit-function-declaration -Wno-error=unused-command-line-argument"
             AC_MSG_CHECKING([clang __sync_bool_compare_and_swap support])
-            AC_TRY_COMPILE([#include <stdio.h>],
-                [ unsigned int i = 0; (void)__sync_bool_compare_and_swap(&i, 1, 1);],
+            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>]], 
+                [[ unsigned int i = 0; (void)__sync_bool_compare_and_swap(&i, 1, 1);]])],
                 [
                     AC_DEFINE([__GCC_HAVE_SYNC_COMPARE_AND_SWAP_1], [1], [Fake GCC atomic support])
                     AC_DEFINE([__GCC_HAVE_SYNC_COMPARE_AND_SWAP_2], [1], [Fake GCC atomic support])
                     AC_DEFINE([__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4], [1], [Fake GCC atomic support])
                     AC_DEFINE([__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8], [1], [Fake GCC atomic support])
-                    AC_MSG_RESULT([yes]) ],
+                    AC_MSG_RESULT([yes])],
                 [AC_MSG_RESULT([no])])
             AC_SUBST(CLANG_CFLAGS)
             ;;
@@ -330,10 +330,10 @@
     AS_IF([test "x$enable_tls" = "xyes"], [
         # check if our target supports thread local storage
         AC_MSG_CHECKING(for thread local storage __thread support)
-        AC_TRY_COMPILE([#include <stdlib.h>],
-            [ static __thread int i; i = 1; i++; ],
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdlib.h>]],
+            [[ static __thread int i; i = 1; i++; ]])],
             [AC_DEFINE([TLS], [1], [Thread local storage])
-             AC_MSG_RESULT([yes]) ],
+             AC_MSG_RESULT([yes])],
             [AC_MSG_RESULT([no])])
     ])
 
@@ -349,45 +349,45 @@
         AC_MSG_CHECKING(for -fstack-protector)
         TMPCFLAGS="${CFLAGS}"
         CFLAGS="${CFLAGS} -fstack-protector"
-        AC_TRY_LINK(,,SECCFLAGS="-fstack-protector"
-            AC_MSG_RESULT(yes),
-            AC_MSG_RESULT(no))
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[]])],[SECCFLAGS="-fstack-protector"
+            AC_MSG_RESULT(yes)],
+            [AC_MSG_RESULT(no)])
         CFLAGS="${TMPCFLAGS}"
 
         #compile-time best-practices errors for certain libc functions, provides checks of buffer lengths and memory regions
         AC_MSG_CHECKING(for -D_FORTIFY_SOURCE=2)
         TMPCFLAGS="${CFLAGS}"
         CFLAGS="${CFLAGS} -D_FORTIFY_SOURCE=2"
-        AC_TRY_COMPILE(,,SECCFLAGS="${SECCFLAGS} -D_FORTIFY_SOURCE=2"
-            AC_MSG_RESULT(yes),
-            AC_MSG_RESULT(no))
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],[SECCFLAGS="${SECCFLAGS} -D_FORTIFY_SOURCE=2"
+            AC_MSG_RESULT(yes)],
+            [AC_MSG_RESULT(no)])
         CFLAGS="${TMPCFLAGS}"
 
         #compile-time warnings about misuse of format strings
         AC_MSG_CHECKING(for -Wformat -Wformat-security)
         TMPCFLAGS="${CFLAGS}"
         CFLAGS="${CFLAGS} -Wformat -Wformat-security"
-        AC_TRY_COMPILE(,,SECCFLAGS="${SECCFLAGS} -Wformat -Wformat-security"
-            AC_MSG_RESULT(yes),
-            AC_MSG_RESULT(no))
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],[SECCFLAGS="${SECCFLAGS} -Wformat -Wformat-security"
+            AC_MSG_RESULT(yes)],
+            [AC_MSG_RESULT(no)])
         CFLAGS="${TMPCFLAGS}"
 
         #provides a read-only relocation table area in the final ELF
         AC_MSG_CHECKING(for -z relro)
         TMPLDFLAGS="${LDFLAGS}"
         LDFLAGS="${LDFLAGS} -z relro"
-        AC_TRY_LINK(,,SECLDFLAGS="${SECLDFLAGS} -z relro"
-            AC_MSG_RESULT(yes),
-            AC_MSG_RESULT(no))
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[]])],[SECLDFLAGS="${SECLDFLAGS} -z relro"
+            AC_MSG_RESULT(yes)],
+            [AC_MSG_RESULT(no)])
         LDFLAGS="${TMPLDFLAGS}"
 
         #forces all relocations to be resolved at run-time
         AC_MSG_CHECKING(for -z now)
         TMPLDFLAGS="${LDFLAGS}"
         LDFLAGS="${LDFLAGS} -z now"
-        AC_TRY_LINK(,,SECLDFLAGS="${SECLDFLAGS} -z now"
-            AC_MSG_RESULT(yes),
-            AC_MSG_RESULT(no))
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[]])],[SECLDFLAGS="${SECLDFLAGS} -z now"
+            AC_MSG_RESULT(yes)],
+            [AC_MSG_RESULT(no)])
         LDFLAGS="${TMPLDFLAGS}"
 
         AC_SUBST(SECCFLAGS)
@@ -650,7 +650,7 @@
     if test "$with_libpcre_includes" != "no"; then
         CPPFLAGS="${CPPFLAGS} -I${with_libpcre_includes}"
     fi
-    AC_CHECK_HEADER(pcre.h,,[AC_ERROR(pcre.h not found ...)])
+    AC_CHECK_HEADER(pcre.h,,[AC_MSG_ERROR(pcre.h not found ...)])
 
     if test "$with_libpcre_libraries" != "no"; then
         LDFLAGS="${LDFLAGS} -L${with_libpcre_libraries}"
@@ -699,9 +699,9 @@
     fi
     LIBS="${TMPLIBS}"
 
-    AC_TRY_COMPILE([ #include <pcre.h> ],
-        [ int eo = 0; eo |= PCRE_EXTRA_MATCH_LIMIT_RECURSION; ],
-        [ pcre_match_limit_recursion_available=yes ], [:]
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ #include <pcre.h> ]],
+        [[ int eo = 0; eo |= PCRE_EXTRA_MATCH_LIMIT_RECURSION; ]])],
+        [ pcre_match_limit_recursion_available=yes ],[:]
     )
     if test "$pcre_match_limit_recursion_available" != "yes"; then
         echo
@@ -715,20 +715,19 @@
 
     TMPCFLAGS="${CFLAGS}"
     CFLAGS="-O0 -g -Werror -Wall"
-    AC_TRY_COMPILE([ #include <pcre.h> ],
-        [ pcre_extra *extra = NULL; pcre_free_study(extra); ],
-        [ AC_DEFINE([HAVE_PCRE_FREE_STUDY], [1], [Pcre pcre_free_study supported])], [:]
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ #include <pcre.h> ]],
+        [[ pcre_extra *extra = NULL; pcre_free_study(extra); ]])],
+        [ AC_DEFINE([HAVE_PCRE_FREE_STUDY], [1], [Pcre pcre_free_study supported])],[:]
     )
     CFLAGS="${TMPCFLAGS}"
 
     #enable support for PCRE-jit available since pcre-8.20
     AC_MSG_CHECKING(for PCRE JIT support)
-    AC_TRY_COMPILE([ #include <pcre.h> ],
-        [
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ #include <pcre.h> ]],
+        [[
         int jit = 0;
         pcre_config(PCRE_CONFIG_JIT, &jit);
-        ],
-        [ pcre_jit_available=yes ], [ pcre_jit_available=no ]
+        ]])],[ pcre_jit_available=yes ],[ pcre_jit_available=no ]
         )
 
     case $host in
@@ -755,8 +754,8 @@
        AC_DEFINE([PCRE_HAVE_JIT], [1], [Pcre with JIT compiler support enabled])
 
        AC_MSG_CHECKING(for PCRE JIT support usability)
-       AC_TRY_COMPILE([ #include <pcre.h> ],
-           [
+       AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ #include <pcre.h> ]],
+           [[
            const char* regexstr = "(a|b|c|d)";
            pcre *re;
            const char *error;
@@ -771,8 +770,7 @@
            if (ret != 0 || jit != 1)
                exit(EXIT_FAILURE);
            exit(EXIT_SUCCESS);
-           ],
-           [ pcre_jit_works=yes ], [:]
+           ]])],[ pcre_jit_works=yes ],[:]
        )
        if test "x$pcre_jit_works" != "xyes"; then
            AC_MSG_RESULT(no)
@@ -873,7 +871,7 @@
         CPPFLAGS="${CPPFLAGS} -I${with_libpthread_includes}"
     fi
 
-    dnl AC_CHECK_HEADER(pthread.h,,[AC_ERROR(pthread.h not found ...)])
+    dnl AC_CHECK_HEADER(pthread.h,,[AC_MSG_ERROR(pthread.h not found ...)])
 
     if test "$with_libpthread_libraries" != "no"; then
         LDFLAGS="${LDFLAGS}  -L${with_libpthread_libraries}"
@@ -1041,7 +1039,7 @@
             CPPFLAGS="${CPPFLAGS} -I${with_libnetfilter_queue_includes}"
         fi
 
-        AC_CHECK_HEADER(libnetfilter_queue/libnetfilter_queue.h,,[AC_ERROR(libnetfilter_queue/libnetfilter_queue.h not found ...)])
+        AC_CHECK_HEADER(libnetfilter_queue/libnetfilter_queue.h,,[AC_MSG_ERROR(libnetfilter_queue/libnetfilter_queue.h not found ...)])
 
         if test "$with_libnetfilter_queue_libraries" != "no"; then
             LDFLAGS="${LDFLAGS}  -L${with_libnetfilter_queue_libraries}"
@@ -1108,7 +1106,7 @@
             CPPFLAGS="${CPPFLAGS} -I${with_libnetfilter_log_includes}"
         fi
 
-        AC_CHECK_HEADER(libnetfilter_log/libnetfilter_log.h,,[AC_ERROR(libnetfilter_log.h not found ...)])
+        AC_CHECK_HEADER(libnetfilter_log/libnetfilter_log.h,,[AC_MSG_ERROR(libnetfilter_log.h not found ...)])
 
         if test "$with_libnetfilter_log_libraries" != "no"; then
             LDFLAGS="${LDFLAGS}  -L${with_libnetfilter_log_libraries}"
@@ -1321,7 +1319,7 @@
         CPPFLAGS="${CPPFLAGS} -I${with_libpcap_includes}"
     fi
 
-    AC_CHECK_HEADER(pcap.h,,[AC_ERROR(pcap.h not found ...)])
+    AC_CHECK_HEADER(pcap.h,,[AC_MSG_ERROR(pcap.h not found ...)])
 
     if test "$with_libpcap_libraries" != "no"; then
         LDFLAGS="${LDFLAGS}  -L${with_libpcap_libraries}"
@@ -1387,7 +1385,7 @@
     AS_IF([test "x$enable_pfring" = "xyes"], [
         AC_DEFINE([HAVE_PFRING],[1],(PF_RING support enabled))
 
-        #We have to set CFLAGS for AC_TRY_COMPILE as it doesn't pay attention to CPPFLAGS
+        #We have to set CFLAGS for AC_COMPILE_IFELSE as it doesn't pay attention to CPPFLAGS
         AC_ARG_WITH(libpfring_includes,
                 [  --with-libpfring-includes=DIR  libpfring include directory],
                 [with_libpfring_includes="$withval"],[with_libpfring_includes=no])
@@ -1496,7 +1494,7 @@
             CPPFLAGS="${CPPFLAGS} -I${with_netmap_includes}"
         fi
 
-        AC_CHECK_HEADER(net/netmap_user.h,,[AC_ERROR(net/netmap_user.h not found ...)],)
+        AC_CHECK_HEADER(net/netmap_user.h,,[AC_MSG_ERROR(net/netmap_user.h not found ...)],)
 
         have_recent_netmap="no"
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
@@ -1592,7 +1590,8 @@
 	else
             SURICATA_UPDATE_DIR="suricata-update"
             AC_SUBST(SURICATA_UPDATE_DIR)
-            AC_OUTPUT(suricata-update/Makefile)
+            AC_CONFIG_FILES(suricata-update/Makefile)
+            AC_OUTPUT
             ruledirprefix="$localstatedir/lib"
             no_suricata_update_comment=""
             has_suricata_update_comment="#"
@@ -1646,7 +1645,7 @@
             LDFLAGS="${LDFLAGS} -L${with_libhtp_libraries}"
         fi
 
-        AC_CHECK_HEADER(htp/htp.h,,[AC_ERROR(htp/htp.h not found ...)])
+        AC_CHECK_HEADER(htp/htp.h,,[AC_MSG_ERROR(htp/htp.h not found ...)])
 
         LIBHTP=""
         AC_CHECK_LIB(htp, htp_conn_create,, LIBHTP="no")
@@ -1686,7 +1685,7 @@
             # make sure libhtp is added to the includes
             CPPFLAGS="-I\${srcdir}/../libhtp/ ${CPPFLAGS}"
 
-            AC_CHECK_HEADER(iconv.h,,[AC_ERROR(iconv.h not found ...)])
+            AC_CHECK_HEADER(iconv.h,,[AC_MSG_ERROR(iconv.h not found ...)])
             AC_CHECK_LIB(iconv, libiconv_close)
             AC_DEFINE_UNQUOTED([HAVE_HTP_URI_NORMALIZE_HOOK],[1],[Assuming htp_config_register_request_uri_normalize function in bundled libhtp])
             AC_DEFINE_UNQUOTED([HAVE_HTP_TX_GET_RESPONSE_HEADERS_RAW],[1],[Assuming htp_tx_get_response_headers_raw function in bundled libhtp])
@@ -2567,7 +2566,14 @@ AC_SUBST(CONFIGURE_LOCALSTATEDIR)
 AC_SUBST(CONFIGURE_DATAROOTDIR)
 AC_SUBST(PACKAGE_VERSION)
 
-AC_OUTPUT(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile suricata.yaml etc/Makefile etc/suricata.logrotate etc/suricata.service python/Makefile python/suricata/config/defaults.py ebpf/Makefile)
+AC_CONFIG_FILES(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config)
+AC_CONFIG_FILES(qa/Makefile qa/coccinelle/Makefile)
+AC_CONFIG_FILES(rules/Makefile doc/Makefile doc/userguide/Makefile)
+AC_CONFIG_FILES(contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile)
+AC_CONFIG_FILES(suricata.yaml etc/Makefile etc/suricata.logrotate etc/suricata.service)
+AC_CONFIG_FILES(python/Makefile python/suricata/config/defaults.py)
+AC_CONFIG_FILES(ebpf/Makefile)
+AC_OUTPUT
 
 SURICATA_BUILD_CONF="Suricata Configuration:
   AF_PACKET support:                       ${enable_af_packet}


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

https://redmine.openinfosecfoundation.org/issues/879

Describe changes:

- This updates configure.ac to the newest autoconf syntax. It's tested on OISF Buildbot, ArchLinux and Ubuntu 18.04 LTS.
- Followup of #2904 
- If you run autoupdate on the configure.ac no changes will happen anymore, this can also be something we can require that new commits aren't allowed to result in changes when autoupdate is run.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/70
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/72