### PR TITLE
configure: Fix failure with --enable-rust-debug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2413,7 +2413,7 @@ fi
         exit 1
     fi
 
-    if test "x$enable_debug" = "xyes"; then
+    if test "x$enable_rust_debug" = "xyes"; then
       RUST_SURICATA_LIB="../rust/target/debug/${RUST_SURICATA_LIBNAME}"
     else
       RUST_SURICATA_LIB="../rust/target/release/${RUST_SURICATA_LIBNAME}"


### PR DESCRIPTION
Build was failing with --enable-rust-debug option as the check in
configure was for enable-debug and not enable-rust-debuf because of
which everytime, rust suricata lib path was set to rust/target/release.
Fix it by using the correct variable for check.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3054