### PR TITLE
detect: validate dsize and distance values

### DIFF
--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -379,7 +379,6 @@ _Bool DetectContentPMATCHValidateCallback(const Signature *s)
     if (!(s->flags & SIG_FLAG_DSIZE)) {
         return TRUE;
     }
-
     int max_right_edge_i = SigParseGetMaxDsize(s);
     if (max_right_edge_i < 0) {
         return TRUE;
@@ -393,6 +392,8 @@ _Bool DetectContentPMATCHValidateCallback(const Signature *s)
             continue;
         const DetectContentData *cd = (const DetectContentData *)sm->ctx;
         uint32_t right_edge = cd->content_len + cd->offset;
+        int distance_size = cd->distance;
+
         if (cd->content_len > max_right_edge) {
             SCLogError(SC_ERR_INVALID_SIGNATURE,
                     "signature can't match as content length %u is bigger than dsize %u.",
@@ -405,6 +406,12 @@ _Bool DetectContentPMATCHValidateCallback(const Signature *s)
                     cd->content_len, cd->offset, right_edge, max_right_edge);
             return FALSE;
         }
+	if (max_right_edge_i == distance_size) {
+	    SCLogError(SC_ERR_INVALID_SIGNATURE,
+	            "signature can't match as depth %u can't be the same as distance %d.",
+		    max_right_edge_i, distance_size);
+	    return FALSE;
+	}
     }
     return TRUE;
 }


### PR DESCRIPTION
I am not sure this is the right place in the code to fix this but this does work in my testing and sample bad rule. Feedback/pointers more than welcome and thanks in advance!

Signed-off-by: jason taylor <jtfas90@gmail.com>

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2982

Describe changes:
- This change adds logic to fail rules that have a dsize value that matches a distance value.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

