### PR TITLE
python: fix parsing Suricata version from configure.ac

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -8,18 +8,23 @@ import shutil
 from distutils.core import setup
 from distutils.command.build_py import build_py
 
+# Get the Suricata version from configure.ac.
 version = None
 if os.path.exists("../configure.ac"):
     with open("../configure.ac", "r") as conf:
         for line in conf:
-            m = re.search("AC_INIT\(suricata,\s+(\d.+)\)", line)
-            if m:
-                version = m.group(1)
-                break
+            if line.find("AC_INIT") > 1:
+                m = re.search("AC_INIT\(\[suricata\],\[(\d.+)\]\)", line)
+                if m:
+                    version = m.group(1)
+                    break
+                else:
+                    print("error: failed to parse Suricata version from: %s" % (
+                        line.strip()), file=sys.stderr)
+                    sys.exit(1)
 if version is None:
-    print("error: failed to parse Suricata version, will use 0.0.0",
-          file=sys.stderr)
-    version = "0.0.0"
+    print("error: failed to find Suricata version", file=sys.stderr)
+    sys.exit(1)
 
 class do_build(build_py):
     def run(self):


### PR DESCRIPTION
Fix parsing the Suricata version in configure.ac in the Python setup.py. Introduced by the configure.ac cleanup in commit 0795dc1e143c7751d2233c73ca61946c49854415.

Also, if parsing the version fails, or no version is found, fail instead of defaulting to a version of 0.0.0. Which will prevent this from happening again.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/355
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/710
