### PR TITLE
log: Add module and subsystem identifiers to log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -263,3 +263,9 @@ before_install:
         sudo pip install PyYAML
     fi
   - ./qa/travis-libhtp.sh
+
+after_failure:
+    - echo == Start of after failure logs ==
+    - find . -name config.log | xargs cat
+    - sleep 10
+    - echo == End of after failure logs ==

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: false
 language: c
 

--- a/configure.ac
+++ b/configure.ac
@@ -2473,6 +2473,10 @@ fi
         fi
     fi
 
+
+# Add diagnostic filename
+CPPFLAGS="${CPPFLAGS} -D__SCFILENAME__=\\\"\$(*F)\\\""
+
 AC_SUBST(CFLAGS)
 AC_SUBST(LDFLAGS)
 AC_SUBST(CPPFLAGS)

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -67,6 +67,7 @@ pub type SCLogMessageFunc =
                   filename: *const std::os::raw::c_char,
                   line: std::os::raw::c_uint,
                   function: *const std::os::raw::c_char,
+                  subsystem: *const std::os::raw::c_char,
                   code: std::os::raw::c_int,
                   message: *const std::os::raw::c_char) -> std::os::raw::c_int;
 

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -63,6 +63,7 @@ pub fn sclog(level: Level, file: &str, line: u32, function: &str,
                    filename,
                    line,
                    function,
+                   filename,
                    code,
                    message);
 }
@@ -149,6 +150,7 @@ pub fn sc_log_message(level: Level,
                       filename: &str,
                       line: std::os::raw::c_uint,
                       function: &str,
+                      module: &str,
                       code: std::os::raw::c_int,
                       message: &str) -> std::os::raw::c_int
 {
@@ -159,6 +161,7 @@ pub fn sc_log_message(level: Level,
                 to_safe_cstring(filename).as_ptr(),
                 line,
                 to_safe_cstring(function).as_ptr(),
+                to_safe_cstring(module).as_ptr(),
                 code,
                 to_safe_cstring(message).as_ptr());
         }

--- a/src/counters.c
+++ b/src/counters.c
@@ -361,6 +361,7 @@ static void *StatsMgmtThread(void *arg)
     if (SCSetThreadName(tv_local->name) < 0) {
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
+    SCSetSubsystem(tv_local->name);
 
     if (tv_local->thread_setup_flags != 0)
         TmThreadSetupOptions(tv_local);
@@ -444,6 +445,7 @@ static void *StatsWakeupThread(void *arg)
     if (SCSetThreadName(tv_local->name) < 0) {
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
+    SCSetSubsystem(tv_local->name);
 
     if (tv_local->thread_setup_flags != 0)
         TmThreadSetupOptions(tv_local);

--- a/src/rust.h
+++ b/src/rust.h
@@ -20,7 +20,7 @@
 
 typedef struct SuricataContext_ {
     SCError (*SCLogMessage)(const SCLogLevel, const char *, const unsigned int,
-            const char *, const SCError, const char *message);
+            const char *, const char *, const SCError, const char *message);
     void (*DetectEngineStateFree)(DetectEngineState *);
     void (*AppLayerDecoderEventsSetEventRaw)(AppLayerDecoderEvents **,
             uint8_t);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2912,7 +2912,10 @@ int main(int argc, char **argv)
 
     (void)SCSetThreadName("Suricata-Main");
 
-    /* Ignore SIGUSR2 as early as possble. We redeclare interest
+    /* Set subsystem name - TLS for main thread */
+    SCSetSubsystem("Suricata-main");
+
+    /* Ignore SIGUSR2 as early as possible. We redeclare interest
      * once we're done launching threads. The goal is to either die
      * completely or handle any and all SIGUSR2s correctly.
      */

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -270,6 +270,8 @@ static void *TmThreadsSlotPktAcqLoop(void *td)
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
 
+    SCSetSubsystem(tv->name);
+
     if (tv->thread_setup_flags != 0)
         TmThreadSetupOptions(tv);
 
@@ -522,6 +524,7 @@ static void *TmThreadsSlotVar(void *td)
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
 
+    SCSetSubsystem(tv->name);
     if (tv->thread_setup_flags != 0)
         TmThreadSetupOptions(tv);
 
@@ -678,6 +681,7 @@ static void *TmThreadsManagement(void *td)
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
 
+    SCSetSubsystem(tv->name);
     if (tv->thread_setup_flags != 0)
         TmThreadSetupOptions(tv);
 
@@ -1785,6 +1789,7 @@ static void TmThreadFree(ThreadVars *tv)
         return;
 
     SCLogDebug("Freeing thread '%s'.", tv->name);
+    SCSetSubsystem(NULL);
 
     StatsThreadCleanup(tv);
 

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -74,12 +74,19 @@ SCEnumCharMap sc_log_op_iface_map[ ] = {
     { NULL,             -1 }
 };
 
+__thread const char *_sc_subsystem;
+
 #if defined (OS_WIN32)
 /**
  * \brief Used for synchronous output on WIN32
  */
 static SCMutex sc_log_stream_lock;
 #endif /* OS_WIN32 */
+
+/**
+ * \brief Transform the module name into display module name for logging
+ */
+static int SCTransformModule(const char *module_name);
 
 /**
  * \brief Holds the config state for the logging module
@@ -208,8 +215,8 @@ static inline void SCLogPrintToSyslog(int syslog_log_level, const char *msg)
  */
 static int SCLogMessageJSON(struct timeval *tval, char *buffer, size_t buffer_size,
         SCLogLevel log_level, const char *file,
-        unsigned line, const char *function, SCError error_code,
-        const char *message)
+        unsigned line, const char *function, const char *module,
+        SCError error_code, const char *message)
 {
     json_t *js = json_object();
     if (unlikely(js == NULL))
@@ -268,6 +275,42 @@ error:
 }
 #endif /* HAVE_LIBJANSSON */
 
+/*
+ * \brief Transform the module name into display module name for logging
+ *
+ * The transformation is dependent upon the source code module names
+ * that use the dash character to separate incremental refinements of
+ * the subsystem.
+ *
+ * The transformation uses the local constant "max_segs" to determine
+ * how many segments to display; the transformed name will never consist
+ * of more than this many segments.
+ *
+ * E.g., "detect-http-content-len" ==> "detect-http" when the max is 2
+ *
+ * \param module_name The source code module name to be transformed.
+ *
+ * \retval The number of characters in module_name to display
+ * */
+static int SCTransformModule(const char *module_name)
+{
+    const int max_segs = 2; /* The maximum segment count to display */
+    int seg_cnt = 0;
+
+    char *last;
+    char *w = (char *) module_name;
+    while (w && (w = index(w, '-')) != NULL && seg_cnt < max_segs) {
+        seg_cnt++;
+        last = w;
+        w++; /* skip past '-' */
+    }
+
+    if (seg_cnt < max_segs)
+        return strlen(module_name);
+
+    return last - module_name;
+}
+
 /**
  * \brief Adds the global log_format to the outgoing buffer
  *
@@ -286,11 +329,12 @@ static SCError SCLogMessageGetBuffer(
 
                      const SCLogLevel log_level, const char *file,
                      const unsigned int line, const char *function,
-                     const SCError error_code, const char *message)
+                     const char *module, const SCError error_code,
+                     const char *message)
 {
 #ifdef HAVE_LIBJANSSON
     if (type == SC_LOG_OP_TYPE_JSON)
-        return SCLogMessageJSON(tval, buffer, buffer_size, log_level, file, line, function, error_code, message);
+        return SCLogMessageJSON(tval, buffer, buffer_size, log_level, file, line, function, module, error_code, message);
 #endif
 
     char *temp = buffer;
@@ -445,6 +489,27 @@ static SCError SCLogMessageGetBuffer(
                 substr++;
                 break;
 
+            case SC_LOG_FMT_SUBSYSTEM:
+                temp_fmt[0] = '\0';
+
+                /* Determine how much of module name to display */
+                int modlen = module ? SCTransformModule(module) : 0;
+
+                cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer),
+                             "%s%s%s%s%.*s%s", substr, green,
+                              _sc_subsystem == NULL ? "" : _sc_subsystem,
+                              _sc_subsystem == NULL ? "" : ":",
+                              modlen,
+                              module == NULL ? "" : module,
+                              reset);
+                if (cw < 0)
+                    return SC_ERR_SPRINTF;
+                temp += cw;
+                temp_fmt++;
+                substr = temp_fmt;
+                substr++;
+                break;
+
             case SC_LOG_FMT_FUNCTION:
                 temp_fmt[0] = '\0';
                 cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer),
@@ -547,7 +612,8 @@ static int SCLogReopen(SCLogOPIfaceCtx *op_iface_ctx)
  */
 SCError SCLogMessage(const SCLogLevel log_level, const char *file,
                      const unsigned int line, const char *function,
-                     const SCError error_code, const char *message)
+                     const char *module, const SCError error_code,
+                     const char *message)
 {
     char buffer[SC_LOG_MAX_LOG_MSG_LEN] = "";
     SCLogOPIfaceCtx *op_iface_ctx = NULL;
@@ -575,7 +641,7 @@ SCError SCLogMessage(const SCLogLevel log_level, const char *file,
                                           buffer, sizeof(buffer),
                                           op_iface_ctx->log_format ?
                                               op_iface_ctx->log_format : sc_log_config->log_format,
-                                          log_level, file, line, function,
+                                          log_level, file, line, function, module,
                                           error_code, message) == 0)
                 {
                     SCLogPrintToStream((log_level == SC_LOG_ERROR)? stderr: stdout, buffer);
@@ -585,7 +651,7 @@ SCError SCLogMessage(const SCLogLevel log_level, const char *file,
                 if (SCLogMessageGetBuffer(&tval, 0, op_iface_ctx->type, buffer, sizeof(buffer),
                                           op_iface_ctx->log_format ?
                                               op_iface_ctx->log_format : sc_log_config->log_format,
-                                          log_level, file, line, function,
+                                          log_level, file, line, function, module,
                                           error_code, message) == 0)
                 {
                     int r = 0;
@@ -608,7 +674,7 @@ SCError SCLogMessage(const SCLogLevel log_level, const char *file,
                 if (SCLogMessageGetBuffer(&tval, 0, op_iface_ctx->type, buffer, sizeof(buffer),
                                           op_iface_ctx->log_format ?
                                               op_iface_ctx->log_format : sc_log_config->log_format,
-                                          log_level, file, line, function,
+                                          log_level, file, line, function, module,
                                           error_code, message) == 0)
                 {
                     SCLogPrintToSyslog(SCLogMapLogLevelToSyslogLevel(log_level), buffer);

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -81,9 +81,9 @@ typedef enum {
 
 /* The default log_format, if it is not supplied by the user */
 #ifdef RELEASE
-#define SC_LOG_DEF_LOG_FORMAT "%t - <%d> - "
+#define SC_LOG_DEF_LOG_FORMAT "%t [%S] - <%d> - "
 #else
-#define SC_LOG_DEF_LOG_FORMAT "[%i] %t - (%f:%l) <%d> (%n) -- "
+#define SC_LOG_DEF_LOG_FORMAT "[%i] %t [%S] - (%f:%l) <%d> (%n) -- "
 #endif
 
 /* The maximum length of the log message */
@@ -198,9 +198,21 @@ typedef struct SCLogConfig_ {
 #define SC_LOG_FMT_FILE_NAME        'f' /* File name */
 #define SC_LOG_FMT_LINE             'l' /* Line number */
 #define SC_LOG_FMT_FUNCTION         'n' /* Function */
+#define SC_LOG_FMT_SUBSYSTEM        'S' /* Subsystem name */
 
 /* The log format prefix for the format specifiers */
 #define SC_LOG_FMT_PREFIX           '%'
+
+/* Module and thread tagging */
+/* The module name, usually the containing source-module name */
+static const char *_sc_module  __attribute__((unused)) = __SCFILENAME__;
+
+/* The subsystem name, usually the thread's name */
+#define SCSetSubsystem(subsystem_name)                                          \
+    do {                                                                        \
+        extern __thread const char *_sc_subsystem;                              \
+        _sc_subsystem = subsystem_name;                                         \
+    } while(0)
 
 extern SCLogLevel sc_log_global_log_level;
 
@@ -223,7 +235,7 @@ extern int sc_log_module_cleaned;
             if (_sc_log_ret == SC_LOG_MAX_LOG_MSG_LEN)                          \
                 _sc_log_msg[SC_LOG_MAX_LOG_MSG_LEN - 1] = '\0';                 \
                                                                                 \
-            SCLogMessage(x, file, line, func, SC_OK, _sc_log_msg);              \
+            SCLogMessage(x, file, line, func, _sc_module, SC_OK, _sc_log_msg);  \
         }                                                                       \
     } while(0)
 
@@ -242,7 +254,7 @@ extern int sc_log_module_cleaned;
             if (_sc_log_ret == SC_LOG_MAX_LOG_MSG_LEN)                          \
                 _sc_log_msg[SC_LOG_MAX_LOG_MSG_LEN - 1] = '\0';                 \
                                                                                 \
-            SCLogMessage(x, file, line, func, err, _sc_log_msg);                \
+            SCLogMessage(x, file, line, func, _sc_module, err, _sc_log_msg);     \
         }                                                                       \
     } while(0)
 
@@ -383,7 +395,7 @@ extern int sc_log_module_cleaned;
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that don't return
@@ -399,7 +411,7 @@ extern int sc_log_module_cleaned;
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns an
@@ -417,7 +429,7 @@ extern int sc_log_module_cleaned;
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns an
@@ -435,7 +447,7 @@ extern int sc_log_module_cleaned;
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns a
@@ -453,7 +465,7 @@ extern int sc_log_module_cleaned;
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns a var
@@ -471,7 +483,7 @@ extern int sc_log_module_cleaned;
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns a
@@ -493,7 +505,7 @@ extern int sc_log_module_cleaned;
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns a var
@@ -514,7 +526,7 @@ extern int sc_log_module_cleaned;
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns a
@@ -571,7 +583,7 @@ void SCLogInitLogModule(SCLogInitData *);
 void SCLogDeInitLogModule(void);
 
 SCError SCLogMessage(const SCLogLevel, const char *, const unsigned int,
-                     const char *, const SCError, const char *message);
+                     const char *, const char *, const SCError, const char *message);
 
 SCLogOPBuffer *SCLogAllocLogOPBuffer(void);
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -580,7 +580,7 @@ logging:
   # output section.  You can leave this out to get the default.
   #
   # This value is overridden by the SC_LOG_FORMAT env var.
-  #default-log-format: "[%i] %t - (%f:%l) <%d> (%n) -- "
+  #default-log-format: "[%i] %t [%S] - (%f:%l) <%d> (%n) -- "
 
   # A regex to filter output.  Can be overridden in an output section.
   # Defaults to empty (no filter).


### PR DESCRIPTION
This changeset provides subsystem and module identifiers in the log when
the log format string contains "%S". By convention, the log format
surrounds "%S" with brackets.

The subsystem name is generally the same as the thread name. The module
name is derived from the source code module name and usually consists of
the first one or 2 segments of the name using the dash character as the
segment delimiter.

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/2497 ticket:

Continued from #3979 with
1. Update CPPFLAGS instead of CFLAGS

Describe changes:
This PR adds a subsystem and module identifier to SCLog messages when the log format includes `%S`. Subsystem and module identifiers are intrinsic properties of threads and source code modules (respectively).

New threads are assigned a subsystem identifier when the thread is created; the identifier is a Thread-Local-Storage variable declared in util-debug.c; values are assigned to it as threads are created using SCSetSubsystem (a macro defined in util-debug.h).

Module identifiers are assigned using SCSetModule (macro defined in util-debug.h).

Subsystem and module identifiers are added to log messages when the format contains `%S`. The generated log message will substitute a tag built from

- The subsystem identifier. This corresponds to the calling thread which may be the Suricata main thread, or a subordinate thread for a task-specific function, e.g., `RX#01`.
- (Optional) The module identifier will be included if set (not all source modules will set one but most source modules have been modified to set one.)
The constructed tag is of the form `subsystem-id[:module-identifier]` (the brackets surrounding the module-identifier indicate the module-identifier is optional and are not included in the output; output formatting is strictly controlled by the log format in effect).

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

