### PR TITLE
parse/tls: fix date format parsing

### DIFF
--- a/doc/userguide/rules/tls-keywords.rst
+++ b/doc/userguide/rules/tls-keywords.rst
@@ -115,6 +115,12 @@ Example::
   alert tls any any -> any any (msg:"match cert NotAfter"; \
     tls_cert_notafter:>2015; sid:200006;)
 
+For ommited formats, the first date is assumed.
+
+``YYYY-DD`` => ``YYYY-DD-01``.
+
+``YYYY`` => ``YYYY-01-01``.
+
 tls_cert_expired
 ----------------
 

--- a/src/detect-tls-cert-validity.c
+++ b/src/detect-tls-cert-validity.c
@@ -254,6 +254,7 @@ static time_t DateStringToEpoch (char *string)
     struct tm tm;
     const char *patterns[] = {
             /* ISO 8601 */
+            "%Y",
             "%Y-%m",
             "%Y-%m-%d",
             "%Y-%m-%d %H",
@@ -285,15 +286,15 @@ static time_t DateStringToEpoch (char *string)
         string = tmp;
     }
 
-    time_t epoch = StringIsEpoch(string);
-    if (epoch != -1) {
-        return epoch;;
-    }
+    r = SCStringPatternToTime(string, patterns, 11, &tm);
 
-    r = SCStringPatternToTime(string, patterns, 10, &tm);
-
-    if (r != 0)
+    if (r != 0) {
+        time_t epoch = StringIsEpoch(string);
+        if (epoch != -1) {
+            return epoch;;
+        }
         return -1;
+    }
 
     return SCMkTimeUtc(&tm);
 }

--- a/src/tests/detect-tls-cert-validity.c
+++ b/src/tests/detect-tls-cert-validity.c
@@ -379,6 +379,41 @@ static int ValidityTestParse23 (void)
 }
 
 /**
+
+ * \test This is a test for a valid value <2015.
+ *
+ * \retval 1 on success.
+ * \retval 0 on failure.
+ */
+static int ValidityTestParse24 (void)
+{
+    DetectTlsValidityData *dd = NULL;
+    dd = DetectTlsValidityParse("<2015");
+    FAIL_IF_NULL(dd);
+    FAIL_IF_NOT(dd->epoch == 1422748800 && dd->mode == DETECT_TLS_VALIDITY_LT);
+    DetectTlsValidityFree(dd);
+    PASS;
+}
+
+/**
+
+ * \test This is a test for a valid value >2020.
+ *
+ * \retval 1 on success.
+ * \retval 0 on failure.
+ */
+static int ValidityTestParse25 (void)
+{
+    DetectTlsValidityData *dd = NULL;
+    dd = DetectTlsValidityParse(">2020");
+    FAIL_IF_NULL(dd);
+    FAIL_IF_NOT(dd->epoch == 1580515200 && dd->mode == DETECT_TLS_VALIDITY_GT);
+    DetectTlsValidityFree(dd);
+    PASS;
+}
+
+
+/**
  * \test Test matching on validity dates in a certificate.
  *
  * \retval 1 on success.
@@ -1341,6 +1376,7 @@ void TlsNotBeforeRegisterTests(void)
     UtRegisterTest("ValidityTestParse19", ValidityTestParse19);
     UtRegisterTest("ValidityTestParse21", ValidityTestParse21);
     UtRegisterTest("ValidityTestParse23", ValidityTestParse23);
+    UtRegisterTest("ValidityTestParse25", ValidityTestParse25);
     UtRegisterTest("ValidityTestDetect01", ValidityTestDetect01);
 }
 
@@ -1360,6 +1396,7 @@ void TlsNotAfterRegisterTests(void)
     UtRegisterTest("ValidityTestParse18", ValidityTestParse18);
     UtRegisterTest("ValidityTestParse20", ValidityTestParse20);
     UtRegisterTest("ValidityTestParse22", ValidityTestParse22);
+    UtRegisterTest("ValidityTestParse24", ValidityTestParse24);
 }
 
 /**

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -498,6 +498,13 @@ int SCStringPatternToTime (char *string, const char **patterns, int num_patterns
             tp->tm_mday <= 0)
         tp->tm_mday = 1;
 
+    /* The first date of the year is assumed, if only year
+       is given */
+    if (tp->tm_year != INT_MIN && tp->tm_mon <= 0 &&
+            tp->tm_mday <= 0) {
+        tp->tm_mday = 1;
+        tp->tm_mon = 1;
+    }
     return 0;
 }
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [O] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [O] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [O] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3065

Describe changes:
- Fix tls_cert_noafter/before options to support "[<|>]YYYY" format
(https://suricata.readthedocs.io/en/suricata-4.1.4/rules/tls-keywords.html#tls-cert-notafter)
- You may not chose to apply this PR, and just fix the manual not to support such format.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):  Not applicable. (not provided the id&pwd)

