### PR TITLE
leak: fixes leak in DetectAddressParse2

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -885,8 +885,11 @@ static int DetectAddressParse2(const DetectEngineCtx *de_ctx,
                     DetectAddressHead tmp_gh = { NULL, NULL };
                     DetectAddressHead tmp_ghn = { NULL, NULL };
 
-                    if (DetectAddressParse2(de_ctx, &tmp_gh, &tmp_ghn, address, 0, var_list) < 0)
+                    if (DetectAddressParse2(de_ctx, &tmp_gh, &tmp_ghn, address, 0, var_list) < 0) {
+                        DetectAddressHeadCleanup(&tmp_gh);
+                        DetectAddressHeadCleanup(&tmp_ghn);
                         goto error;
+                    }
 
                     DetectAddress *tmp_ad;
                     DetectAddress *tmp_ad2;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Fixes leak in `DetectAddressParse2` releasing pointer to `DetectAddress` allocated by `DetectAddressInit` and then put into `DetectAddressHead` structure by `DetectAddressInsert` in case of error

Found by fuzzing with signature
`alert ip [209.51.32.0/30,209.66.128.0/19,209.95.192.0/19,209.99.128.0/18,209.145.0.0/19,209.182.64.0/19,209.229.0.0alert!tcp [199.247.20.188,199.247.21.157,199.247.6.158,199.254.238.44,199.255*223.88,199.58.81.140,2001:0470:0021:0841:0001:0000:0020:0c00,2001:0470:0007:0b74:0000:0000:0000:0002,2001:2470:0008:0bf8:e3f0:d941:2f74:37ae,2001:0:0bf8:fdcb:1437:e730:f29d] any -> $HOME_NET any (msg:"ET TOR Known Tor(((((((((((((((((((((((((((((((/16,209.242.192.0/19,212.60.16.0/22,216.83.208.0/20,216.137.176.0/21,220.154.0.0/16,221.132.192.0/18,223.0.0.0/15,223.169.0.0/16,223.173.0.0/16,223.254.0.0/16] any -> $HOME_NET any (msg:"ET DROP Spamhaus DROP Listed Traffic id:2400030; rev:2705; meta((((((((((((((((((((((((((((((((((((dated_at 2019_07_02;)
data:affected_product Any, attack_target1 Any, deployment Perimeter, tag Dshield, signature_severitypkt:or, created_at 2010_12_30, updated_at 2019_05_05;)`