### PR TITLE
log: use SCLogError instead of fprintf

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1078,7 +1078,7 @@ static int SigParseBasics(DetectEngineCtx *de_ctx,
 
     /* Options. */
     if (index == NULL) {
-        fprintf(stderr, "no rule options.\n");
+        SCLogError(SC_ERR_INVALID_RULE_ARGUMENT, "no rule options.\n");
         goto error;
     }
     while (isspace(*index) || *index == '(') {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Replaces one use of `fprintf` by `SCLogError`
