### PR TITLE
Always store the vlan id of packets

### DIFF
--- a/src/decode-erspan.c
+++ b/src/decode-erspan.c
@@ -64,7 +64,7 @@ int DecodeERSPAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt,
         return TM_ECODE_FAILED;
     }
 
-    if (vlan_id > 0 && dtv->vlan_disabled == 0) {
+    if (vlan_id > 0) {
         if (p->vlan_idx >= 2) {
             ENGINE_SET_EVENT(p,ERSPAN_TOO_MANY_VLAN_LAYERS);
             return TM_ECODE_FAILED;

--- a/src/decode.c
+++ b/src/decode.c
@@ -618,13 +618,6 @@ DecodeThreadVars *DecodeThreadVarsAlloc(ThreadVars *tv)
         return NULL;
     }
 
-    /** set config defaults */
-    int vlanbool = 0;
-    if ((ConfGetBool("vlan.use-for-tracking", &vlanbool)) == 1 && vlanbool == 0) {
-        dtv->vlan_disabled = 1;
-    }
-    SCLogDebug("vlan tracking is %s", dtv->vlan_disabled == 0 ? "enabled" : "disabled");
-
     return dtv;
 }
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -535,8 +535,6 @@ typedef struct Packet_
 
     GREHdr *greh;
 
-    VLANHdr *vlanh[2];
-
     /* ptr to the payload of the packet
      * with it's length. */
     uint8_t *payload;
@@ -635,8 +633,6 @@ typedef struct DecodeThreadVars_
 {
     /** Specific context for udp protocol detection (here atm) */
     AppLayerThreadCtx *app_tctx;
-
-    int vlan_disabled;
 
     /** stats/counters */
     uint16_t counter_pkts;
@@ -795,8 +791,6 @@ void CaptureStatsSetup(ThreadVars *tv, CaptureStats *s);
         (p)->pppoesh = NULL;                    \
         (p)->pppoedh = NULL;                    \
         (p)->greh = NULL;                       \
-        (p)->vlanh[0] = NULL;                   \
-        (p)->vlanh[1] = NULL;                   \
         (p)->payload = NULL;                    \
         (p)->payload_len = 0;                   \
         (p)->BypassPacketsFlow = NULL;          \

--- a/src/flow-hash.h
+++ b/src/flow-hash.h
@@ -74,6 +74,7 @@ typedef struct FlowBucket_ {
 
 /* prototypes */
 
+void FlowHashInit(void);
 Flow *FlowGetFlowFromHash(ThreadVars *tv, DecodeThreadVars *dtv, const Packet *, Flow **);
 
 Flow *FlowGetFromFlowKey(FlowKey *key, struct timespec *ttime, const uint32_t hash);

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -952,7 +952,6 @@ static int AFPReadFromRing(AFPThreadVars *ptv)
             (h.h2->tp_status & TP_STATUS_VLAN_VALID || h.h2->tp_vlan_tci)) {
             p->vlan_id[0] = h.h2->tp_vlan_tci & 0x0fff;
             p->vlan_idx = 1;
-            p->vlanh[0] = NULL;
         }
 
         if (ptv->flags & AFP_ZERO_COPY) {
@@ -1076,7 +1075,6 @@ static inline int AFPParsePacketV3(AFPThreadVars *ptv, struct tpacket_block_desc
             (ppd->tp_status & TP_STATUS_VLAN_VALID || ppd->hv1.tp_vlan_tci)) {
         p->vlan_id[0] = ppd->hv1.tp_vlan_tci & 0x0fff;
         p->vlan_idx = 1;
-        p->vlanh[0] = NULL;
     }
 
     if (ptv->flags & AFP_ZERO_COPY) {
@@ -2808,14 +2806,6 @@ TmEcode ReceiveAFPThreadInit(ThreadVars *tv, const void *initdata, void **data)
     *data = (void *)ptv;
 
     afpconfig->DerefFunc(afpconfig);
-
-    /* A bit strange to have this here but we only have vlan information
-     * during reading so we need to know if we want to keep vlan during
-     * the capture phase */
-    int vlanbool = 0;
-    if ((ConfGetBool("vlan.use-for-tracking", &vlanbool)) == 1 && vlanbool == 0) {
-        ptv->flags |= AFP_VLAN_DISABLED;
-    }
 
     /* If kernel is older than 3.0, VLAN is not stripped so we don't
      * get the info from packet extended header but we will use a standard

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -10284,7 +10284,7 @@ static int StreamTcpTest40(void)
 
     DecodeVLAN(&tv, &dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), NULL);
 
-    FAIL_IF(p->vlanh[0] == NULL);
+    FAIL_IF(p->vlan_id[0] == 0);
 
     FAIL_IF(p->tcph == NULL);
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -230,6 +230,10 @@ int g_disable_randomness = 0;
 int g_disable_randomness = 1;
 #endif
 
+/** determine if we include the vlan_ids when hashing or comparing flows
+  * without branching. */
+uint16_t g_vlan_mask = 0xffff;
+
 /** Suricata instance */
 SCInstance suricata;
 
@@ -2964,6 +2968,13 @@ int main(int argc, char **argv)
         ConfDump();
         exit(EXIT_SUCCESS);
     }
+
+    int vlan_tracking = 1;
+    if (ConfGetBool("vlan.use-for-tracking", &vlan_tracking) == 1 && !vlan_tracking) {
+        /* Ignore vlan_ids when comparing flows. */
+        g_vlan_mask = 0x0000;
+    }
+    SCLogDebug("vlan tracking is %s", vlan_tracking == 1 ? "enabled" : "disabled");
 
     SetupUserMode(&suricata);
 

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -174,6 +174,7 @@ void GlobalsInitPreConfig(void);
 
 extern volatile uint8_t suricata_ctl_flags;
 extern int g_disable_randomness;
+extern uint16_t g_vlan_mask;
 
 #include <ctype.h>
 #define u8_tolower(c) tolower((uint8_t)(c))


### PR DESCRIPTION
If the setting vlan.use-for-tracking was set to false, suricata would
in some cases ignore the vlan information of packets and leave them 0
for FlowHash calculations and Flow comparisons. This commit instead
always fills in the vlan_id field, but passes 0 for the vlan_id in the
FlowHash calculation and Flow comparison. This is done using a bitmask
to avoid introducing additional branches, as suggested by Victor Julien
in the suricata IRC.

Also turned FLOW_CMP from a macro into an inline function at Victor's
request.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- No documentation changes needed

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3076

Describe changes:
- In source-pfring.c, source-af-packet.c and decode-vlan.c, copy the vlan to the vlan_id field in the Packet struct regardless of the `vlan.use-for-tracking setting`.
- In suricata.c, check the `vlan.use-for-tracking` setting and set a new global variable `g_vlan_mask` to `0` if false. If true, it is set `0xffff`.
- In flow-hash.c, use `g_vlan_mask` to zero the vlan_ids in the hash and comparison functions if we don't want to use them for tracking. This is to avoid introducing additional branches.
- Replace the CMP_FLOW macro with inline functions.