### PR TITLE
log: Add module and subsystem identifiers to log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -263,3 +263,9 @@ before_install:
         sudo pip install PyYAML
     fi
   - ./qa/travis-libhtp.sh
+
+after_failure:
+    - echo == Start of after failure logs ==
+    - find . -name config.log | xargs cat
+    - sleep 10
+    - echo == End of after failure logs ==

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: false
 language: c
 

--- a/configure.ac
+++ b/configure.ac
@@ -2473,6 +2473,10 @@ fi
         fi
     fi
 
+
+# Add diagnostic filename
+CPPFLAGS="${CPPFLAGS} -D__SCFILENAME__=\\\"\$(*F)\\\""
+
 AC_SUBST(CFLAGS)
 AC_SUBST(LDFLAGS)
 AC_SUBST(CPPFLAGS)

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -67,6 +67,7 @@ pub type SCLogMessageFunc =
                   filename: *const std::os::raw::c_char,
                   line: std::os::raw::c_uint,
                   function: *const std::os::raw::c_char,
+                  subsystem: *const std::os::raw::c_char,
                   code: std::os::raw::c_int,
                   message: *const std::os::raw::c_char) -> std::os::raw::c_int;
 

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -59,10 +59,12 @@ pub fn sclog(level: Level, file: &str, line: u32, function: &str,
          code: i32, message: &str)
 {
     let filename = basename(file);
+    let noext = &filename[0..filename.len() - 3];
     sc_log_message(level,
                    filename,
                    line,
                    function,
+                   noext,
                    code,
                    message);
 }
@@ -149,6 +151,7 @@ pub fn sc_log_message(level: Level,
                       filename: &str,
                       line: std::os::raw::c_uint,
                       function: &str,
+                      module: &str,
                       code: std::os::raw::c_int,
                       message: &str) -> std::os::raw::c_int
 {
@@ -159,6 +162,7 @@ pub fn sc_log_message(level: Level,
                 to_safe_cstring(filename).as_ptr(),
                 line,
                 to_safe_cstring(function).as_ptr(),
+                to_safe_cstring(module).as_ptr(),
                 code,
                 to_safe_cstring(message).as_ptr());
         }

--- a/src/counters.c
+++ b/src/counters.c
@@ -361,6 +361,7 @@ static void *StatsMgmtThread(void *arg)
     if (SCSetThreadName(tv_local->name) < 0) {
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
+    SCSetSubsystem(tv_local->name);
 
     if (tv_local->thread_setup_flags != 0)
         TmThreadSetupOptions(tv_local);
@@ -444,6 +445,7 @@ static void *StatsWakeupThread(void *arg)
     if (SCSetThreadName(tv_local->name) < 0) {
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
+    SCSetSubsystem(tv_local->name);
 
     if (tv_local->thread_setup_flags != 0)
         TmThreadSetupOptions(tv_local);

--- a/src/rust.h
+++ b/src/rust.h
@@ -20,7 +20,7 @@
 
 typedef struct SuricataContext_ {
     SCError (*SCLogMessage)(const SCLogLevel, const char *, const unsigned int,
-            const char *, const SCError, const char *message);
+            const char *, const char *, const SCError, const char *message);
     void (*DetectEngineStateFree)(DetectEngineState *);
     void (*AppLayerDecoderEventsSetEventRaw)(AppLayerDecoderEvents **,
             uint8_t);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2912,7 +2912,10 @@ int main(int argc, char **argv)
 
     (void)SCSetThreadName("Suricata-Main");
 
-    /* Ignore SIGUSR2 as early as possble. We redeclare interest
+    /* Set subsystem name - TLS for main thread */
+    SCSetSubsystem("Suricata-main");
+
+    /* Ignore SIGUSR2 as early as possible. We redeclare interest
      * once we're done launching threads. The goal is to either die
      * completely or handle any and all SIGUSR2s correctly.
      */

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -270,6 +270,8 @@ static void *TmThreadsSlotPktAcqLoop(void *td)
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
 
+    SCSetSubsystem(tv->name);
+
     if (tv->thread_setup_flags != 0)
         TmThreadSetupOptions(tv);
 
@@ -522,6 +524,8 @@ static void *TmThreadsSlotVar(void *td)
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
 
+    SCSetSubsystem(tv->name);
+
     if (tv->thread_setup_flags != 0)
         TmThreadSetupOptions(tv);
 
@@ -677,6 +681,8 @@ static void *TmThreadsManagement(void *td)
     if (SCSetThreadName(tv->name) < 0) {
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
+
+    SCSetSubsystem(tv->name);
 
     if (tv->thread_setup_flags != 0)
         TmThreadSetupOptions(tv);
@@ -1806,6 +1812,8 @@ static void TmThreadFree(ThreadVars *tv)
     }
 
     TmThreadsUnregisterThread(tv->id);
+
+    SCSetSubsystem(NULL);
     SCFree(tv);
 }
 

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -81,9 +81,9 @@ typedef enum {
 
 /* The default log_format, if it is not supplied by the user */
 #ifdef RELEASE
-#define SC_LOG_DEF_LOG_FORMAT "%t - <%d> - "
+#define SC_LOG_DEF_LOG_FORMAT "%t [%S] - <%d> - "
 #else
-#define SC_LOG_DEF_LOG_FORMAT "[%i] %t - (%f:%l) <%d> (%n) -- "
+#define SC_LOG_DEF_LOG_FORMAT "[%i] %t [%S] - (%f:%l) <%d> (%n) -- "
 #endif
 
 /* The maximum length of the log message */
@@ -198,9 +198,21 @@ typedef struct SCLogConfig_ {
 #define SC_LOG_FMT_FILE_NAME        'f' /* File name */
 #define SC_LOG_FMT_LINE             'l' /* Line number */
 #define SC_LOG_FMT_FUNCTION         'n' /* Function */
+#define SC_LOG_FMT_SUBSYSTEM        'S' /* Subsystem name */
 
 /* The log format prefix for the format specifiers */
 #define SC_LOG_FMT_PREFIX           '%'
+
+/* Module and thread tagging */
+/* The module name, usually the containing source-module name */
+static const char *_sc_module  __attribute__((unused)) = __SCFILENAME__;
+
+/* The subsystem name, usually the thread's name */
+#define SCSetSubsystem(subsystem_name)                                          \
+    do {                                                                        \
+        extern __thread const char *_sc_subsystem;                              \
+        _sc_subsystem = subsystem_name;                                         \
+    } while(0)
 
 extern SCLogLevel sc_log_global_log_level;
 
@@ -223,7 +235,7 @@ extern int sc_log_module_cleaned;
             if (_sc_log_ret == SC_LOG_MAX_LOG_MSG_LEN)                          \
                 _sc_log_msg[SC_LOG_MAX_LOG_MSG_LEN - 1] = '\0';                 \
                                                                                 \
-            SCLogMessage(x, file, line, func, SC_OK, _sc_log_msg);              \
+            SCLogMessage(x, file, line, func, _sc_module, SC_OK, _sc_log_msg);  \
         }                                                                       \
     } while(0)
 
@@ -242,7 +254,7 @@ extern int sc_log_module_cleaned;
             if (_sc_log_ret == SC_LOG_MAX_LOG_MSG_LEN)                          \
                 _sc_log_msg[SC_LOG_MAX_LOG_MSG_LEN - 1] = '\0';                 \
                                                                                 \
-            SCLogMessage(x, file, line, func, err, _sc_log_msg);                \
+            SCLogMessage(x, file, line, func, _sc_module, err, _sc_log_msg);     \
         }                                                                       \
     } while(0)
 
@@ -383,7 +395,7 @@ extern int sc_log_module_cleaned;
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that don't return
@@ -399,7 +411,7 @@ extern int sc_log_module_cleaned;
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns an
@@ -417,7 +429,7 @@ extern int sc_log_module_cleaned;
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns an
@@ -435,7 +447,7 @@ extern int sc_log_module_cleaned;
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns a
@@ -453,7 +465,7 @@ extern int sc_log_module_cleaned;
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns a var
@@ -471,7 +483,7 @@ extern int sc_log_module_cleaned;
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns a
@@ -493,7 +505,7 @@ extern int sc_log_module_cleaned;
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns a var
@@ -514,7 +526,7 @@ extern int sc_log_module_cleaned;
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns a
@@ -571,7 +583,7 @@ void SCLogInitLogModule(SCLogInitData *);
 void SCLogDeInitLogModule(void);
 
 SCError SCLogMessage(const SCLogLevel, const char *, const unsigned int,
-                     const char *, const SCError, const char *message);
+                     const char *, const char *, const SCError, const char *message);
 
 SCLogOPBuffer *SCLogAllocLogOPBuffer(void);
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -580,7 +580,7 @@ logging:
   # output section.  You can leave this out to get the default.
   #
   # This value is overridden by the SC_LOG_FORMAT env var.
-  #default-log-format: "[%i] %t - (%f:%l) <%d> (%n) -- "
+  #default-log-format: "[%i] %t [%S] - (%f:%l) <%d> (%n) -- "
 
   # A regex to filter output.  Can be overridden in an output section.
   # Defaults to empty (no filter).


### PR DESCRIPTION
This changeset provides subsystem and module identifiers in the log when
the log format string contains `"%S"`. By convention, the log format
surrounds `"%S"` with brackets.

The subsystem name is generally the same as the thread name. The module
name is derived from the source code module name and usually consists of
the first one or 2 segments of the name using the dash character as the
segment delimiter.

Issue 2497: [redmine](https://redmine.openinfosecfoundation.org/issues/2497)

Continued from #39801 with
1. The transform function returns a pointer and len indicating how much of the pointer is for display.

Describe changes:
This PR adds a subsystem and module identifier to SCLog messages when the log format includes `%S`. Subsystem and module identifiers are intrinsic properties of threads and source code modules (respectively).

New threads are assigned a subsystem identifier when the thread is created; the identifier is a Thread-Local-Storage variable declared in util-debug.c; values are assigned to it as threads are created using SCSetSubsystem (a macro defined in util-debug.h).

Module identifiers are derived from the source code module emitting the log message. A new CPP define `__SCFILENAME__` is assigned to `_sc_module` (`util-debug.h`) at compile time. Rust source module names are determined dynamically during the calls to the log function.

Subsystem and module identifiers are added to log messages when the format contains `%S`. The generated log message will substitute a tag built from

- The subsystem identifier. This corresponds to the calling thread which may be the Suricata main thread, or a subordinate thread for a task-specific function, e.g., `RX#01`.
- (Optional) The module identifier will be included if set (not all source modules will set one but most source modules have been modified to set one.)
The constructed tag is of the form `subsystem-id[:module-identifier]` (the brackets surrounding the module-identifier indicate the module-identifier is optional and are not included in the output; output formatting is strictly controlled by the log format in effect).

Also, two travis related changes are included in this PR
1. Update Travis to use Xenial (16.04) rather than Trusty (14.04)
1. Update to display config.log when Travis build errors occur.