### PR TITLE
Always store vlan id

### DIFF
--- a/src/decode-erspan.c
+++ b/src/decode-erspan.c
@@ -64,7 +64,7 @@ int DecodeERSPAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt,
         return TM_ECODE_FAILED;
     }
 
-    if (vlan_id > 0 && dtv->vlan_disabled == 0) {
+    if (vlan_id > 0) {
         if (p->vlan_idx >= 2) {
             ENGINE_SET_EVENT(p,ERSPAN_TOO_MANY_VLAN_LAYERS);
             return TM_ECODE_FAILED;

--- a/src/decode-vlan.c
+++ b/src/decode-vlan.c
@@ -77,21 +77,17 @@ int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, u
         return TM_ECODE_FAILED;
     }
 
-    p->vlanh[p->vlan_idx] = (VLANHdr *)pkt;
-    if(p->vlanh[p->vlan_idx] == NULL)
+    VLANHdr *vlan_hdr = (VLANHdr *)pkt;
+    if(vlan_hdr == NULL)
         return TM_ECODE_FAILED;
 
-    proto = GET_VLAN_PROTO(p->vlanh[p->vlan_idx]);
+    proto = GET_VLAN_PROTO(vlan_hdr);
 
     SCLogDebug("p %p pkt %p VLAN protocol %04x VLAN PRI %d VLAN CFI %d VLAN ID %d Len: %" PRIu32 "",
-            p, pkt, proto, GET_VLAN_PRIORITY(p->vlanh[p->vlan_idx]),
-            GET_VLAN_CFI(p->vlanh[p->vlan_idx]), GET_VLAN_ID(p->vlanh[p->vlan_idx]), len);
+            p, pkt, proto, GET_VLAN_PRIORITY(vlan_hdr), GET_VLAN_CFI(vlan_hdr),
+            GET_VLAN_ID(vlan_hdr), len);
 
-    /* only store the id for flow hashing if it's not disabled. */
-    if (dtv->vlan_disabled == 0)
-        p->vlan_id[p->vlan_idx] = (uint16_t)GET_VLAN_ID(p->vlanh[p->vlan_idx]);
-
-    p->vlan_idx++;
+    p->vlan_id[p->vlan_idx++] = (uint16_t)GET_VLAN_ID(vlan_hdr);
 
     switch (proto)   {
         case ETHERNET_TYPE_IP:
@@ -146,11 +142,8 @@ uint16_t DecodeVLANGetId(const Packet *p, uint8_t layer)
 {
     if (unlikely(layer > 1))
         return 0;
-
-    if (p->vlanh[layer] == NULL && (p->vlan_idx >= (layer + 1))) {
+    if (p->vlan_idx > layer) {
         return p->vlan_id[layer];
-    } else {
-        return GET_VLAN_ID(p->vlanh[layer]);
     }
     return 0;
 }
@@ -288,7 +281,7 @@ static int DecodeVLANtest03 (void)
     DecodeVLAN(&tv, &dtv, p, raw_vlan, sizeof(raw_vlan), NULL);
 
 
-    if(p->vlanh[0] == NULL) {
+    if(p->vlan_id[0] == 0) {
         goto error;
     }
 

--- a/src/decode.c
+++ b/src/decode.c
@@ -618,13 +618,6 @@ DecodeThreadVars *DecodeThreadVarsAlloc(ThreadVars *tv)
         return NULL;
     }
 
-    /** set config defaults */
-    int vlanbool = 0;
-    if ((ConfGetBool("vlan.use-for-tracking", &vlanbool)) == 1 && vlanbool == 0) {
-        dtv->vlan_disabled = 1;
-    }
-    SCLogDebug("vlan tracking is %s", dtv->vlan_disabled == 0 ? "enabled" : "disabled");
-
     return dtv;
 }
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -535,8 +535,6 @@ typedef struct Packet_
 
     GREHdr *greh;
 
-    VLANHdr *vlanh[2];
-
     /* ptr to the payload of the packet
      * with it's length. */
     uint8_t *payload;
@@ -795,8 +793,6 @@ void CaptureStatsSetup(ThreadVars *tv, CaptureStats *s);
         (p)->pppoesh = NULL;                    \
         (p)->pppoedh = NULL;                    \
         (p)->greh = NULL;                       \
-        (p)->vlanh[0] = NULL;                   \
-        (p)->vlanh[1] = NULL;                   \
         (p)->payload = NULL;                    \
         (p)->payload_len = 0;                   \
         (p)->BypassPacketsFlow = NULL;          \

--- a/src/decode.h
+++ b/src/decode.h
@@ -634,8 +634,6 @@ typedef struct DecodeThreadVars_
     /** Specific context for udp protocol detection (here atm) */
     AppLayerThreadCtx *app_tctx;
 
-    int vlan_disabled;
-
     /** stats/counters */
     uint16_t counter_pkts;
     uint16_t counter_bytes;

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -135,8 +135,10 @@ static inline uint32_t FlowGetHash(const Packet *p)
 
             fhk.proto = (uint16_t)p->proto;
             fhk.recur = (uint16_t)p->recursion_level;
-            fhk.vlan_id[0] = p->vlan_id[0];
-            fhk.vlan_id[1] = p->vlan_id[1];
+            /* g_vlan_mask sets the vlan_ids to 0 if vlan.use-for-tracking
+             * is disabled. */
+            fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
+            fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
 
             hash = hashword(fhk.u32, 5, flow_config.hash_rand);
 
@@ -155,8 +157,8 @@ static inline uint32_t FlowGetHash(const Packet *p)
 
             fhk.proto = (uint16_t)ICMPV4_GET_EMB_PROTO(p);
             fhk.recur = (uint16_t)p->recursion_level;
-            fhk.vlan_id[0] = p->vlan_id[0];
-            fhk.vlan_id[1] = p->vlan_id[1];
+            fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
+            fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
 
             hash = hashword(fhk.u32, 5, flow_config.hash_rand);
 
@@ -169,8 +171,8 @@ static inline uint32_t FlowGetHash(const Packet *p)
             fhk.ports[1] = 0xbeef;
             fhk.proto = (uint16_t)p->proto;
             fhk.recur = (uint16_t)p->recursion_level;
-            fhk.vlan_id[0] = p->vlan_id[0];
-            fhk.vlan_id[1] = p->vlan_id[1];
+            fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
+            fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
 
             hash = hashword(fhk.u32, 5, flow_config.hash_rand);
         }
@@ -201,8 +203,8 @@ static inline uint32_t FlowGetHash(const Packet *p)
         fhk.ports[pi] = p->dp;
         fhk.proto = (uint16_t)p->proto;
         fhk.recur = (uint16_t)p->recursion_level;
-        fhk.vlan_id[0] = p->vlan_id[0];
-        fhk.vlan_id[1] = p->vlan_id[1];
+        fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
+        fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
 
         hash = hashword(fhk.u32, 11, flow_config.hash_rand);
     }
@@ -234,8 +236,8 @@ uint32_t FlowKeyGetHash(FlowKey *fk)
 
         fhk.proto = (uint16_t)fk->proto;
         fhk.recur = (uint16_t)fk->recursion_level;
-        fhk.vlan_id[0] = fk->vlan_id[0];
-        fhk.vlan_id[1] = fk->vlan_id[1];
+        fhk.vlan_id[0] = fk->vlan_id[0] & g_vlan_mask;
+        fhk.vlan_id[1] = fk->vlan_id[1] & g_vlan_mask;
 
         hash = hashword(fhk.u32, 5, flow_config.hash_rand);
     } else {
@@ -266,8 +268,8 @@ uint32_t FlowKeyGetHash(FlowKey *fk)
         fhk.ports[pi] = fk->dp;
         fhk.proto = (uint16_t)fk->proto;
         fhk.recur = (uint16_t)fk->recursion_level;
-        fhk.vlan_id[0] = fk->vlan_id[0];
-        fhk.vlan_id[1] = fk->vlan_id[1];
+        fhk.vlan_id[0] = fk->vlan_id[0] & g_vlan_mask;
+        fhk.vlan_id[1] = fk->vlan_id[1] & g_vlan_mask;
 
         hash = hashword(fhk.u32, 11, flow_config.hash_rand);
     }
@@ -296,7 +298,8 @@ static inline bool CmpAddrsAndPorts(const uint32_t src1[4],
 
 static inline bool CmpVlanIds(const uint16_t vlan_id1[2], const uint16_t vlan_id2[2])
 {
-    return vlan_id1[0] == vlan_id2[0] && vlan_id1[1] == vlan_id2[1];
+    return ((vlan_id1[0] ^ vlan_id2[0]) & g_vlan_mask) == 0 &&
+        ((vlan_id1[1] ^ vlan_id2[1]) & g_vlan_mask) == 0;
 }
 
 /* Since two or more flows can have the same hash key, we need to compare

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -952,7 +952,6 @@ static int AFPReadFromRing(AFPThreadVars *ptv)
             (h.h2->tp_status & TP_STATUS_VLAN_VALID || h.h2->tp_vlan_tci)) {
             p->vlan_id[0] = h.h2->tp_vlan_tci & 0x0fff;
             p->vlan_idx = 1;
-            p->vlanh[0] = NULL;
         }
 
         if (ptv->flags & AFP_ZERO_COPY) {
@@ -1076,7 +1075,6 @@ static inline int AFPParsePacketV3(AFPThreadVars *ptv, struct tpacket_block_desc
             (ppd->tp_status & TP_STATUS_VLAN_VALID || ppd->hv1.tp_vlan_tci)) {
         p->vlan_id[0] = ppd->hv1.tp_vlan_tci & 0x0fff;
         p->vlan_idx = 1;
-        p->vlanh[0] = NULL;
     }
 
     if (ptv->flags & AFP_ZERO_COPY) {

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -60,7 +60,7 @@ struct ebpf_timeout_config {
 #define AFP_SOCK_PROTECT (1<<2)
 #define AFP_EMERGENCY_MODE (1<<3)
 #define AFP_TPACKET_V3 (1<<4)
-#define AFP_VLAN_DISABLED (1<<5)
+#define AFP_VLAN_IN_HEADER (1<<5)
 #define AFP_MMAP_LOCKED (1<<6)
 #define AFP_BYPASS   (1<<7)
 #define AFP_XDPBYPASS   (1<<8)

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -262,7 +262,6 @@ static inline void PfringProcessPacket(void *user, struct pfring_pkthdr *h, Pack
     {
         p->vlan_id[0] = h->extended_hdr.parsed_pkt.vlan_id & 0x0fff;
         p->vlan_idx = 1;
-        p->vlanh[0] = NULL;
 
         if (!ptv->vlan_hdr_warned) {
             SCLogWarning(SC_ERR_PF_RING_VLAN, "no VLAN header in the raw "

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -10284,7 +10284,7 @@ static int StreamTcpTest40(void)
 
     DecodeVLAN(&tv, &dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), NULL);
 
-    FAIL_IF(p->vlanh[0] == NULL);
+    FAIL_IF(p->vlan_id[0] == 0);
 
     FAIL_IF(p->tcph == NULL);
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -230,6 +230,10 @@ int g_disable_randomness = 0;
 int g_disable_randomness = 1;
 #endif
 
+/** determine (without branching) if we include the vlan_ids when hashing or
+  * comparing flows */
+uint16_t g_vlan_mask = 0xffff;
+
 /** Suricata instance */
 SCInstance suricata;
 
@@ -2963,6 +2967,12 @@ int main(int argc, char **argv)
     if (suricata.run_mode == RUNMODE_DUMP_CONFIG) {
         ConfDump();
         exit(EXIT_SUCCESS);
+    }
+
+    int vlan_tracking = 1;
+    if (ConfGetBool("vlan.use-for-tracking", &vlan_tracking) == 1 && !vlan_tracking) {
+        /* Ignore vlan_ids when comparing flows. */
+        g_vlan_mask = 0x0000;
     }
 
     SetupUserMode(&suricata);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2974,6 +2974,7 @@ int main(int argc, char **argv)
         /* Ignore vlan_ids when comparing flows. */
         g_vlan_mask = 0x0000;
     }
+    SCLogDebug("vlan tracking is %s", vlan_tracking == 1 ? "enabled" : "disabled");
 
     SetupUserMode(&suricata);
 

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -174,6 +174,7 @@ void GlobalsInitPreConfig(void);
 
 extern volatile uint8_t suricata_ctl_flags;
 extern int g_disable_randomness;
+extern uint16_t g_vlan_mask;
 
 #include <ctype.h>
 #define u8_tolower(c) tolower((uint8_t)(c))


### PR DESCRIPTION
If the setting vlan.use-for-tracking was set to false, suricata would
in some cases ignore the vlan information of packets and leave them 0
for FlowHash calculations and Flow comparisons. This commit instead
always fills in the vlan_id field, but passes 0 for the vlan_id in the
FlowHash calculation and Flow comparison. This is done using a bitmask
to avoid introducing additional branches, as suggested by Victor Julien
in the suricata IRC.

Also turned FLOW_CMP from a macro into an inline function at Victor's
request.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- No documentation changes needed

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3076

Describe changes:
- In source-pfring.c, source-af-packet.c and decode-vlan.c, copy the vlan to the vlan_id field in the Packet struct regardless of the `vlan.use-for-tracking setting`.
- In suricata.c, check the `vlan.use-for-tracking` setting and set a new global variable `g_vlan_mask` to `0` if false. If true, it is set `0xffff`.
- In flow-hash.c, use `g_vlan_mask` to zero the vlan_ids in the hash and comparison functions if we don't want to use them for tracking. This is to avoid introducing additional branches.
- Replace the CMP_FLOW macro with inline functions.

Updates https://github.com/OISF/suricata/pull/4005
- Split up into smaller commits
- Use the correct function naming convention