### PR TITLE
WIP: Ebpf xdp update 5.0 v4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2473,6 +2473,13 @@ fi
         fi
     fi
 
+if test "${enable_ebpf}" = "yes" || test "${enable_unittests}" = "yes"; then
+	AC_DEFINE([CAPTURE_OFFLOAD_MANAGER], [1],[Building flow bypass manager code])
+fi
+if test "${enable_ebpf}" = "yes" || test "${enable_nfqueue}" = "yes" || test "${enable_pfring}" = "yes" || test "${enable_unittests}" = "yes"; then
+	AC_DEFINE([CAPTURE_OFFLOAD], [1],[Building flow capture bypass code])
+fi
+
 AC_SUBST(CFLAGS)
 AC_SUBST(LDFLAGS)
 AC_SUBST(CPPFLAGS)

--- a/doc/userguide/capture-hardware/ebpf-xdp.rst
+++ b/doc/userguide/capture-hardware/ebpf-xdp.rst
@@ -331,7 +331,7 @@ Balance as much as you can
 Try to use the network's card balancing as much as possible ::
  
  for proto in tcp4 udp4 ah4 esp4 sctp4 tcp6 udp6 ah6 esp6 sctp6; do 
- 	/sbin/ethtool -N eth3 rx-flow-hash $proto sdfn
+    /sbin/ethtool -N eth3 rx-flow-hash $proto sd
  done
 
 The XDP CPU redirect case

--- a/doc/userguide/capture-hardware/ebpf-xdp.rst
+++ b/doc/userguide/capture-hardware/ebpf-xdp.rst
@@ -71,12 +71,17 @@ Kernel
 
 You need to run a kernel 4.13 or newer.
 
-Clang
-~~~~~
+Clang and dependencies
+~~~~~~~~~~~~~~~~~~~~~~
 
 Make sure you have clang (>=3.9) installed on the system  ::
 
- sudo apt-get install clang
+ sudo apt install clang
+
+Some i386 headers will also be needed as eBPF is not x86_64 and some include headers
+are architecture specific ::
+
+ sudo apt install  libc6-dev-i386 --no-install-recommends
 
 libbpf
 ~~~~~~
@@ -93,6 +98,8 @@ Now, you can build and install the library ::
  sudo make install_headers
  sudo ldconfig
 
+In some cases your system will not find the libbpf library that is installed under
+`/usr/lib64` so you may need to modify your ldconfig configuration.
 
 Compile and install Suricata
 ----------------------------

--- a/doc/userguide/capture-hardware/ebpf-xdp.rst
+++ b/doc/userguide/capture-hardware/ebpf-xdp.rst
@@ -445,7 +445,7 @@ XDP and pinned-maps
 
 This option can be used to expose the maps of a socket filter to other processes.
 This allows for example, the external handling of a accept list or block list of
-IP addresses. See `scbpf` tool avalable in the `ebpf/scpbf` directory for an example
+IP addresses. See `bpfctrl <https://github.com/StamusNetworks/bpfctrl/>`__ for an example
 of external list handling.
 
 In the case of XDP, the eBPF filter is attached to the interface so if you
@@ -490,7 +490,7 @@ The eBPF filter `filter.bpf` uses a `ipv4_drop` map that contains the set of IPv
 If `pinned-maps` is set to `true` in the interface configuration then the map will be pinned
 under `/sys/fs/bpf/suricata-eth0-ipv4_drop`.
 
-You can then use a tool to manage the IPv4 addresses in the map.
+You can then use a tool like `bpfctrl` to manage the IPv4 addresses in the map.
 
 Hardware bypass with Netronome
 ------------------------------

--- a/doc/userguide/capture-hardware/ebpf-xdp.rst
+++ b/doc/userguide/capture-hardware/ebpf-xdp.rst
@@ -338,15 +338,35 @@ The XDP CPU redirect case
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If ever your hardware is not able to do a symmetric load balancing but support XDP in driver mode, you
-can then use the CPU redirect map support available in the xdp_filter.bpf file. In this mode, the load
-balancing will be done by the XDP filter and each CPU will handle the whole packet treatment including
-the creation of the skb structure in kernel.
+can then use the CPU redirect map support available in the `xdp_filter.bpf` and `xdp_lb.bpf` file. In 
+this mode, the load balancing will be done by the XDP filter and each CPU will handle the whole packet
+treatment including the creation of the skb structure in kernel.
 
 You will need Linux 4.15 or newer to use that feature.
 
 To do so set the `xdp-cpu-redirect` variable in af-packet interface configuration to a set of CPUs.
 Then use the `cluster_cpu` as load balancing function. You will also need to set the affinity
-accordingly.
+to be sure CPU that will be assigned skb are used by Suricata.
+
+Also to avoid out of order packets, you need to set the RSS queue number to 1. So if our interface
+is `eth3` ::
+
+  /sbin/ethtool -L eth3 combined 1
+
+In case your system has more then 64 core, you need to set `CPUMAP_MAX_CPUS` to a value superior
+to this number in `xdp_lb.c` and `xdp_filter.c`.
+
+A sample configuration for pure XDP load balancing could look like ::
+
+  - interface: eth3
+    threads: 16
+    cluster-id: 97
+    cluster-type: cluster_cpu
+    xdp-mode: driver
+    xdp-filter-file:  /etc/suricata/ebpf/xdp_lb.bpf
+    xdp-cpu-redirect: ["1-17"] # or ["all"] to load balance on all CPUs
+    use-mmap: yes
+    ring-size: 200000
 
 It is possible to use `xdp_monitor` to have information about the behavior of CPU redirect. This
 program is available in Linux tree under the `samples/bpf` directory and will be build by the

--- a/ebpf/Makefile.am
+++ b/ebpf/Makefile.am
@@ -9,11 +9,12 @@ BPF_TARGETS  = lb.bpf
 BPF_TARGETS += filter.bpf
 BPF_TARGETS += bypass_filter.bpf
 BPF_TARGETS += xdp_filter.bpf
+BPF_TARGETS += xdp_lb.bpf
 BPF_TARGETS += vlan_filter.bpf
 
 all: $(BPF_TARGETS)
 
-EXTRA_DIST= include bypass_filter.c filter.c lb.c vlan_filter.c xdp_filter.c
+EXTRA_DIST= include bypass_filter.c filter.c lb.c vlan_filter.c xdp_filter.c xdp_lb.c
 
 $(BPF_TARGETS): %.bpf: %.c
 #      From C-code to LLVM-IR format suffix .ll (clang -S -emit-llvm)

--- a/ebpf/filter.c
+++ b/ebpf/filter.c
@@ -32,16 +32,24 @@
 #define LINUX_VERSION_CODE 263682
 
 struct bpf_map_def SEC("maps") ipv4_drop = {
-    .type = BPF_MAP_TYPE_HASH,
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
     .key_size = sizeof(__u32),
     .value_size = sizeof(__u32),
     .max_entries = 32768,
 };
 
-int SEC("filter") hashfilter(struct __sk_buff *skb) {
-    __u32 nhoff = ETH_HLEN;
-    __u32 ip = 0;
+struct vlan_hdr {
+    __u16   h_vlan_TCI;
+    __u16   h_vlan_encapsulated_proto;
+};
+
+static __always_inline int ipv4_filter(struct __sk_buff *skb)
+{
+    __u32 nhoff;
     __u32 *value;
+    __u32 ip = 0;
+
+    nhoff = skb->cb[0];
 
     ip = load_word(skb, nhoff + offsetof(struct iphdr, saddr));
     value = bpf_map_lookup_elem(&ipv4_drop, &ip);
@@ -50,7 +58,7 @@ int SEC("filter") hashfilter(struct __sk_buff *skb) {
         char fmt[] = "Found value for saddr: %u\n";
         bpf_trace_printk(fmt, sizeof(fmt), value);
 #endif
-        __sync_fetch_and_add(value, 1);
+        *value = *value + 1;
         return 0;
     }
 
@@ -61,7 +69,7 @@ int SEC("filter") hashfilter(struct __sk_buff *skb) {
         char fmt[] = "Found value for daddr: %u\n";
         bpf_trace_printk(fmt, sizeof(fmt), value);
 #endif
-        __sync_fetch_and_add(value, 1);
+        *value = *value + 1;
         return 0;
     }
 
@@ -69,6 +77,34 @@ int SEC("filter") hashfilter(struct __sk_buff *skb) {
     char fmt[] = "Nothing so ok\n";
     bpf_trace_printk(fmt, sizeof(fmt));
 #endif
+    return -1;
+}
+
+static __always_inline int ipv6_filter(struct __sk_buff *skb)
+{
+    return -1;
+}
+
+int SEC("filter") hashfilter(struct __sk_buff *skb) {
+    __u32 nhoff = ETH_HLEN;
+
+    __u16 proto = load_half(skb, offsetof(struct ethhdr, h_proto));
+
+    if (proto == ETH_P_8021AD || proto == ETH_P_8021Q) {
+        proto = load_half(skb, nhoff + offsetof(struct vlan_hdr,
+                          h_vlan_encapsulated_proto));
+        nhoff += sizeof(struct vlan_hdr);
+    }
+
+    skb->cb[0] = nhoff;
+    switch (proto) {
+        case ETH_P_IP:
+            return ipv4_filter(skb);
+        case ETH_P_IPV6:
+            return ipv6_filter(skb);
+        default:
+            break;
+    }
     return -1;
 }
 

--- a/ebpf/lb.c
+++ b/ebpf/lb.c
@@ -103,7 +103,9 @@ int  __section("loadbalancer") lb(struct __sk_buff *skb) {
                 skb->cb[0] = nhoff;
                 switch (proto) {
                     case ETH_P_IP:
+#if 0
                         { char fmt[] = "ipv4\n"; bpf_trace_printk(fmt, sizeof(fmt));}
+#endif
                         ret = ipv4_hash(skb);
                         break;
                     case ETH_P_IPV6:

--- a/ebpf/xdp_lb.c
+++ b/ebpf/xdp_lb.c
@@ -1,0 +1,173 @@
+/* Copyright (C) 2019 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#define KBUILD_MODNAME "foo"
+#include <stddef.h>
+#include <linux/bpf.h>
+
+#include <linux/in.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <linux/if_vlan.h>
+#include <linux/ip.h>
+#include <linux/ipv6.h>
+#include <linux/tcp.h>
+#include <linux/udp.h>
+#include "bpf_helpers.h"
+
+#include "hash_func01.h"
+
+#define LINUX_VERSION_CODE 263682
+
+/* Hashing initval */
+#define INITVAL 15485863
+
+/* Increase CPUMAP_MAX_CPUS if ever you have more than 64 CPUs */
+#define CPUMAP_MAX_CPUS     64
+
+struct vlan_hdr {
+    __u16	h_vlan_TCI;
+    __u16	h_vlan_encapsulated_proto;
+};
+
+/* Special map type that can XDP_REDIRECT frames to another CPU */
+struct bpf_map_def SEC("maps") cpu_map = {
+    .type		= BPF_MAP_TYPE_CPUMAP,
+    .key_size	= sizeof(__u32),
+    .value_size	= sizeof(__u32),
+    .max_entries	= CPUMAP_MAX_CPUS,
+};
+
+struct bpf_map_def SEC("maps") cpus_available = {
+    .type		= BPF_MAP_TYPE_ARRAY,
+    .key_size	= sizeof(__u32),
+    .value_size	= sizeof(__u32),
+    .max_entries	= CPUMAP_MAX_CPUS,
+};
+
+struct bpf_map_def SEC("maps") cpus_count = {
+    .type		= BPF_MAP_TYPE_ARRAY,
+    .key_size	= sizeof(__u32),
+    .value_size	= sizeof(__u32),
+    .max_entries	= 1,
+};
+
+static int __always_inline filter_ipv4(struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end)
+{
+    struct iphdr *iph = data + nh_off;
+    __u32 key0 = 0;
+    __u32 cpu_dest;
+    __u32 *cpu_max = bpf_map_lookup_elem(&cpus_count, &key0);
+    __u32 *cpu_selected;
+    __u32 cpu_hash;
+
+    if ((void *)(iph + 1) > data_end)
+        return XDP_PASS;
+
+    /* IP-pairs hit same CPU */
+    cpu_hash = iph->saddr + iph->daddr;
+    cpu_hash = SuperFastHash((char *)&cpu_hash, 4, INITVAL);
+
+    if (cpu_max && *cpu_max) {
+        cpu_dest = cpu_hash % *cpu_max;
+        cpu_selected = bpf_map_lookup_elem(&cpus_available, &cpu_dest);
+        if (!cpu_selected)
+            return XDP_ABORTED;
+        cpu_dest = *cpu_selected;
+        return bpf_redirect_map(&cpu_map, cpu_dest, 0);
+    } else {
+        return XDP_PASS;
+    }
+}
+
+static int __always_inline filter_ipv6(struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end)
+{
+    struct ipv6hdr *ip6h = data + nh_off;
+    __u32 key0 = 0;
+    __u32 cpu_dest;
+    int *cpu_max = bpf_map_lookup_elem(&cpus_count, &key0);
+    __u32 *cpu_selected;
+    __u32 cpu_hash;
+
+    if ((void *)(ip6h + 1) > data_end)
+        return XDP_PASS;
+
+    /* IP-pairs hit same CPU */
+    cpu_hash  = ip6h->saddr.s6_addr32[0] + ip6h->daddr.s6_addr32[0];
+    cpu_hash += ip6h->saddr.s6_addr32[1] + ip6h->daddr.s6_addr32[1];
+    cpu_hash += ip6h->saddr.s6_addr32[2] + ip6h->daddr.s6_addr32[2];
+    cpu_hash += ip6h->saddr.s6_addr32[3] + ip6h->daddr.s6_addr32[3];
+    cpu_hash = SuperFastHash((char *)&cpu_hash, 4, INITVAL);
+
+    if (cpu_max && *cpu_max) {
+        cpu_dest = cpu_hash % *cpu_max;
+        cpu_selected = bpf_map_lookup_elem(&cpus_available, &cpu_dest);
+        if (!cpu_selected)
+            return XDP_ABORTED;
+        cpu_dest = *cpu_selected;
+        return bpf_redirect_map(&cpu_map, cpu_dest, 0);
+    } else {
+        return XDP_PASS;
+    }
+
+    return XDP_PASS;
+}
+
+int SEC("xdp") xdp_loadfilter(struct xdp_md *ctx)
+{
+    void *data_end = (void *)(long)ctx->data_end;
+    void *data = (void *)(long)ctx->data;
+    struct ethhdr *eth = data;
+    __u16 h_proto;
+    __u64 nh_off;
+
+    nh_off = sizeof(*eth);
+    if (data + nh_off > data_end)
+        return XDP_PASS;
+
+    h_proto = eth->h_proto;
+
+    if (h_proto == __constant_htons(ETH_P_8021Q) || h_proto == __constant_htons(ETH_P_8021AD)) {
+        struct vlan_hdr *vhdr;
+
+        vhdr = data + nh_off;
+        nh_off += sizeof(struct vlan_hdr);
+        if (data + nh_off > data_end)
+            return XDP_PASS;
+        h_proto = vhdr->h_vlan_encapsulated_proto;
+    }
+    if (h_proto == __constant_htons(ETH_P_8021Q) || h_proto == __constant_htons(ETH_P_8021AD)) {
+        struct vlan_hdr *vhdr;
+
+        vhdr = data + nh_off;
+        nh_off += sizeof(struct vlan_hdr);
+        if (data + nh_off > data_end)
+            return XDP_PASS;
+        h_proto = vhdr->h_vlan_encapsulated_proto;
+    }
+
+    if (h_proto == __constant_htons(ETH_P_IP))
+        return filter_ipv4(ctx, data, nh_off, data_end);
+    else if (h_proto == __constant_htons(ETH_P_IPV6))
+        return filter_ipv6(ctx, data, nh_off, data_end);
+
+    return XDP_PASS;
+}
+
+char __license[] SEC("license") = "GPL";
+
+__u32 __version SEC("version") = LINUX_VERSION_CODE;

--- a/ebpf/xdp_lb.c
+++ b/ebpf/xdp_lb.c
@@ -23,6 +23,7 @@
 #include <linux/if_ether.h>
 #include <linux/if_packet.h>
 #include <linux/if_vlan.h>
+#include <linux/if_tunnel.h>
 #include <linux/ip.h>
 #include <linux/ipv6.h>
 #include <linux/tcp.h>
@@ -66,17 +67,17 @@ struct bpf_map_def SEC("maps") cpus_count = {
     .max_entries	= 1,
 };
 
-static int __always_inline filter_ipv4(struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end)
+static int __always_inline hash_ipv4(void *data, void *data_end)
 {
-    struct iphdr *iph = data + nh_off;
+    struct iphdr *iph = data;
+    if ((void *)(iph + 1) > data_end)
+        return XDP_PASS;
+
     __u32 key0 = 0;
     __u32 cpu_dest;
     __u32 *cpu_max = bpf_map_lookup_elem(&cpus_count, &key0);
     __u32 *cpu_selected;
     __u32 cpu_hash;
-
-    if ((void *)(iph + 1) > data_end)
-        return XDP_PASS;
 
     /* IP-pairs hit same CPU */
     cpu_hash = iph->saddr + iph->daddr;
@@ -94,17 +95,17 @@ static int __always_inline filter_ipv4(struct xdp_md *ctx, void *data, __u64 nh_
     }
 }
 
-static int __always_inline filter_ipv6(struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end)
+static int __always_inline hash_ipv6(void *data, void *data_end)
 {
-    struct ipv6hdr *ip6h = data + nh_off;
+    struct ipv6hdr *ip6h = data;
+    if ((void *)(ip6h + 1) > data_end)
+        return XDP_PASS;
+
     __u32 key0 = 0;
     __u32 cpu_dest;
     int *cpu_max = bpf_map_lookup_elem(&cpus_count, &key0);
     __u32 *cpu_selected;
     __u32 cpu_hash;
-
-    if ((void *)(ip6h + 1) > data_end)
-        return XDP_PASS;
 
     /* IP-pairs hit same CPU */
     cpu_hash  = ip6h->saddr.s6_addr32[0] + ip6h->daddr.s6_addr32[0];
@@ -127,6 +128,69 @@ static int __always_inline filter_ipv6(struct xdp_md *ctx, void *data, __u64 nh_
     return XDP_PASS;
 }
 
+static int __always_inline filter_ipv4(struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end)
+{
+    struct iphdr *iph = data + nh_off;
+    if ((void *)(iph + 1) > data_end)
+        return XDP_PASS;
+
+    if (iph->protocol == IPPROTO_GRE) {
+        __be16 proto;
+        struct gre_hdr {
+            __be16 flags;
+            __be16 proto;
+        };
+
+        nh_off += sizeof(struct iphdr);
+        struct gre_hdr *grhdr = (struct gre_hdr *)(iph + 1);
+
+        if ((void *)(grhdr + 1) > data_end)
+            return XDP_PASS;
+
+        if (grhdr->flags & (GRE_VERSION|GRE_ROUTING))
+            return XDP_PASS;
+
+        nh_off += 4;
+        proto = grhdr->proto;
+        if (grhdr->flags & GRE_CSUM)
+            nh_off += 4;
+        if (grhdr->flags & GRE_KEY)
+            nh_off += 4;
+        if (grhdr->flags & GRE_SEQ)
+            nh_off += 4;
+
+        if (data + nh_off > data_end)
+            return XDP_PASS;
+        if (bpf_xdp_adjust_head(ctx, 0 + nh_off))
+            return XDP_PASS;
+
+        data = (void *)(long)ctx->data;
+        data_end = (void *)(long)ctx->data_end;
+
+        if (proto == __constant_htons(ETH_P_8021Q)) {
+            struct vlan_hdr *vhdr = (struct vlan_hdr *)(data);
+            if ((void *)(vhdr + 1) > data_end)
+                return XDP_PASS;
+            proto = vhdr->h_vlan_encapsulated_proto;
+            nh_off += sizeof(struct vlan_hdr);
+        }
+
+        if (proto == __constant_htons(ETH_P_IP)) {
+            return hash_ipv4(data, data_end);
+        } else if (proto == __constant_htons(ETH_P_IPV6)) {
+            return hash_ipv6(data, data_end);
+        } else
+            return XDP_PASS;
+    }
+    return hash_ipv4(data + nh_off, data_end);
+}
+
+static int __always_inline filter_ipv6(struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end)
+{
+    struct ipv6hdr *ip6h = data + nh_off;
+    return hash_ipv6((void *)ip6h, data_end);
+}
+
 int SEC("xdp") xdp_loadfilter(struct xdp_md *ctx)
 {
     void *data_end = (void *)(long)ctx->data_end;
@@ -141,6 +205,12 @@ int SEC("xdp") xdp_loadfilter(struct xdp_md *ctx)
 
     h_proto = eth->h_proto;
 
+#if 0
+    if (h_proto != __constant_htons(ETH_P_IP)) {
+        char fmt[] = "Current proto: %u\n";
+        bpf_trace_printk(fmt, sizeof(fmt), h_proto);
+    }
+#endif
     if (h_proto == __constant_htons(ETH_P_8021Q) || h_proto == __constant_htons(ETH_P_8021AD)) {
         struct vlan_hdr *vhdr;
 

--- a/src/decode.c
+++ b/src/decode.c
@@ -400,6 +400,7 @@ void PacketDefragPktSetupParent(Packet *parent)
 
 void PacketBypassCallback(Packet *p)
 {
+#ifdef CAPTURE_OFFLOAD
     /* Don't try to bypass if flow is already out or
      * if we have failed to do it once */
     if (p->flow) {
@@ -424,6 +425,14 @@ void PacketBypassCallback(Packet *p)
             FlowUpdateState(p->flow, FLOW_STATE_LOCAL_BYPASSED);
         }
     }
+#else /* CAPTURE_OFFLOAD */
+    if (p->flow) {
+        int state = SC_ATOMIC_GET(p->flow->flow_state);
+        if (state == FLOW_STATE_LOCAL_BYPASSED)
+            return;
+        FlowUpdateState(p->flow, FLOW_STATE_LOCAL_BYPASSED);
+    }
+#endif
 }
 
 /** \brief switch direction of a packet */

--- a/src/flow-bypass.c
+++ b/src/flow-bypass.c
@@ -28,7 +28,7 @@
 #include "flow-private.h"
 #include "util-ebpf.h"
 
-#ifndef OS_WIN32
+#ifdef CAPTURE_OFFLOAD_MANAGER
 
 #define FLOW_BYPASS_DELAY       10
 
@@ -175,7 +175,7 @@ int BypassedFlowManagerRegisterUpdateFunc(BypassedUpdateFunc UpdateFunc,
 /** \brief spawn the flow bypass manager thread */
 void BypassedFlowManagerThreadSpawn()
 {
-#ifndef OS_WIN32
+#ifdef CAPTURE_OFFLOAD_MANAGER
 #ifdef AFLFUZZ_DISABLE_MGTTHREADS
     return;
 #endif
@@ -198,7 +198,7 @@ void BypassedFlowManagerThreadSpawn()
 
 void BypassedFlowUpdate(Flow *f, Packet *p)
 {
-#ifndef OS_WIN32
+#ifdef CAPTURE_OFFLOAD_MANAGER
     for (int i = 0; i < g_bypassed_update_max_index; i++) {
         if (updatefunclist[i].Func(f, p, updatefunclist[i].data)) {
             return;
@@ -209,7 +209,7 @@ void BypassedFlowUpdate(Flow *f, Packet *p)
 
 void TmModuleBypassedFlowManagerRegister (void)
 {
-#ifndef OS_WIN32
+#ifdef CAPTURE_OFFLOAD_MANAGER
     tmm_modules[TMM_BYPASSEDFLOWMANAGER].name = "BypassedFlowManager";
     tmm_modules[TMM_BYPASSEDFLOWMANAGER].ThreadInit = BypassedFlowManagerThreadInit;
     tmm_modules[TMM_BYPASSEDFLOWMANAGER].ThreadDeinit = BypassedFlowManagerThreadDeinit;

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -875,8 +875,10 @@ static Flow *FlowGetUsedFlow(ThreadVars *tv, DecodeThreadVars *dtv)
             f->flow_end_flags |= FLOW_END_FLAG_STATE_ESTABLISHED;
         else if (state == FLOW_STATE_CLOSED)
             f->flow_end_flags |= FLOW_END_FLAG_STATE_CLOSED;
+#if CAPTURE_OFFLOAD
         else if (state == FLOW_STATE_CAPTURE_BYPASSED)
             f->flow_end_flags |= FLOW_END_FLAG_STATE_BYPASSED;
+#endif
         else if (state == FLOW_STATE_LOCAL_BYPASSED)
             f->flow_end_flags |= FLOW_END_FLAG_STATE_BYPASSED;
 

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -725,7 +725,6 @@ Flow *FlowGetFromFlowKey(FlowKey *key, struct timespec *ttime, const uint32_t ha
     } else if (key->src.family == AF_INET6) {
         f->flags |= FLOW_IPV6;
     }
-    FlowUpdateState(f, FLOW_STATE_CAPTURE_BYPASSED);
 
     f->protomap = FlowGetProtoMapping(f->proto);
     /* set timestamp to now */

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -78,10 +78,12 @@ static inline TmEcode FlowUpdate(ThreadVars *tv, FlowWorkerThreadData *fw, Packe
 
     int state = SC_ATOMIC_GET(p->flow->flow_state);
     switch (state) {
+#ifdef CAPTURE_OFFLOAD
         case FLOW_STATE_CAPTURE_BYPASSED:
             StatsAddUI64(tv, fw->both_bypass_pkts, 1);
             StatsAddUI64(tv, fw->both_bypass_bytes, GET_PKT_LEN(p));
             return TM_ECODE_DONE;
+#endif
         case FLOW_STATE_LOCAL_BYPASSED:
             StatsAddUI64(tv, fw->local_bypass_pkts, 1);
             StatsAddUI64(tv, fw->local_bypass_bytes, GET_PKT_LEN(p));

--- a/src/flow.c
+++ b/src/flow.c
@@ -399,11 +399,14 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p)
 {
     SCLogDebug("packet %"PRIu64" -- flow %p", p->pcap_cnt, f);
 
+#if CAPTURE_OFFLOAD
     int state = SC_ATOMIC_GET(f->flow_state);
 
     if (state != FLOW_STATE_CAPTURE_BYPASSED) {
+#endif
         /* update the last seen timestamp of this flow */
         COPY_TIMESTAMP(&p->ts, &f->lastts);
+#if CAPTURE_OFFLOAD
     } else {
         /* still seeing packet, we downgrade to local bypass */
         if (p->ts.tv_sec - f->lastts.tv_sec > FLOW_BYPASSED_TIMEOUT / 2) {
@@ -418,7 +421,7 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p)
             }
         }
     }
-
+#endif
     /* update flags and counters */
     if (FlowGetPacketDirection(f, p) == TOSERVER) {
         f->todstpktcnt++;

--- a/src/flow.h
+++ b/src/flow.h
@@ -468,7 +468,9 @@ enum FlowState {
     FLOW_STATE_ESTABLISHED,
     FLOW_STATE_CLOSED,
     FLOW_STATE_LOCAL_BYPASSED,
+#ifdef CAPTURE_OFFLOAD
     FLOW_STATE_CAPTURE_BYPASSED,
+#endif
 };
 
 typedef struct FlowProtoTimeout_ {

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -274,10 +274,12 @@ static void JsonFlowLogJSON(JsonFlowLogThread *aft, json_t *js, Flow *f)
                 json_object_set_new(hjs, "bypass",
                         json_string("local"));
                 break;
+#ifdef CAPTURE_OFFLOAD
             case FLOW_STATE_CAPTURE_BYPASSED:
                 json_object_set_new(hjs, "bypass",
                         json_string("capture"));
                 break;
+#endif
             default:
                 SCLogError(SC_ERR_INVALID_VALUE,
                            "Invalid flow state: %d, contact developers",


### PR DESCRIPTION
Update of eBPF and XDP code. Main feature is a new xdp_lb.bpf filter that can be used for load balancing and decapsulate GRE.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Conditional build of bypass code
- XDP load balancing code via the use of CPU redirect
- GRE decapsulation in xdp_lb.c

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/473
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/254
