### PR TITLE
ssl: register probing for port 443 if no config

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2853,10 +2853,20 @@ void RegisterSSLParsers(void)
                                           STREAM_TOSERVER,
                                           SSLProbingParser, NULL);
         } else {
-            AppLayerProtoDetectPPParseConfPorts("tcp", IPPROTO_TCP,
-                                                proto_name, ALPROTO_TLS,
-                                                0, 3,
-                                                SSLProbingParser, NULL);
+            if (AppLayerProtoDetectPPParseConfPorts("tcp", IPPROTO_TCP,
+                                                    proto_name, ALPROTO_TLS,
+                                                    0, 3,
+                                                    SSLProbingParser, NULL) == 0) {
+                SCLogWarning(SC_ERR_SMB_CONFIG, "no TLS config found, "
+                                                "enabling TLS detection on "
+                                                "port 443.");
+                AppLayerProtoDetectPPRegister(IPPROTO_TCP,
+                                              "443",
+                                              ALPROTO_TLS,
+                                              0, 3,
+                                              STREAM_TOSERVER,
+                                              SSLProbingParser, NULL);
+            }
         }
     } else {
         SCLogInfo("Protocol detection and parser disabled for %s protocol",


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3070

Describe changes:
- Register TLS probing parser for port 443 in case of configuration missing

If `AppLayerProtoDetectPPParseConfPorts` fails, it means there is no configuration for TLS.

See SMB for another example