### PR TITLE
http: fixes overflow in range parsing

### DIFF
--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -186,7 +186,7 @@ int HTPParseContentRange(bstr * rawvalue, HtpContentRange *range)
 
     if (data[pos] == '*') {
         // case with size only
-        if (len < pos + 1 || data[pos+1] != '/') {
+        if (len <= pos + 1 || data[pos+1] != '/') {
             range->size = -1;
             return -1;
         }
@@ -196,13 +196,13 @@ int HTPParseContentRange(bstr * rawvalue, HtpContentRange *range)
         // case with start and end
         range->start = bstr_util_mem_to_pint(data + pos, len - pos, 10, &last_pos);
         pos += last_pos;
-        if (len < pos + 1 || data[pos] != '-') {
+        if (len <= pos + 1 || data[pos] != '-') {
             return -1;
         }
         pos++;
         range->end = bstr_util_mem_to_pint(data + pos, len - pos, 10, &last_pos);
         pos += last_pos;
-        if (len < pos + 1 || data[pos] != '/') {
+        if (len <= pos + 1 || data[pos] != '/') {
             return -1;
         }
         pos++;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Fixes off-by-one overflow in HTTP range parsing

For instance `if (len < pos + 1 || data[pos+1] != '/')`
Meant that when 
- `len == pos+1`
- first sub condition was false
- so we tried the seance one
- so we accessed `data[pos+1] == data[len]` which is one byte overflow

Continues #4002 with review taken into account