### PR TITLE
detect/transform: add tld and domain transforms

### DIFF
--- a/doc/userguide/rules/transforms.rst
+++ b/doc/userguide/rules/transforms.rst
@@ -36,6 +36,16 @@ compress_whitespace
 
 Compresses all consecutive whitespace into a single space.
 
+tld
+---
+
+Takes the buffer, and returns the top level domain, if any and passes it on.
+
+Example::
+
+    alert dns any any -> any any (dns.query; tld; \
+        content:"com"; sid:1;)
+
 to_md5
 ------
 

--- a/doc/userguide/rules/transforms.rst
+++ b/doc/userguide/rules/transforms.rst
@@ -21,6 +21,16 @@ Example::
 
 .. note:: not all sticky buffers support transformations yet
 
+domain
+------
+
+Takes the buffer, and returns the domain, if any and passes it on.
+
+Example::
+
+    alert http any any -> any any (dns.query; domain; \
+        content:"update.microsoft.com"; sid:1;)
+
 strip_whitespace
 ----------------
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -268,6 +268,7 @@ detect-transform-strip-whitespace.c detect-transform-strip-whitespace.h \
 detect-transform-md5.c detect-transform-md5.h \
 detect-transform-sha1.c detect-transform-sha1.h \
 detect-transform-sha256.c detect-transform-sha256.h \
+detect-transform-tld.c detect-transform-tld.h \
 detect-ttl.c detect-ttl.h \
 detect-uricontent.c detect-uricontent.h \
 detect-urilen.c detect-urilen.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -269,6 +269,7 @@ detect-transform-md5.c detect-transform-md5.h \
 detect-transform-sha1.c detect-transform-sha1.h \
 detect-transform-sha256.c detect-transform-sha256.h \
 detect-transform-tld.c detect-transform-tld.h \
+detect-transform-domain.c detect-transform-domain.h \
 detect-ttl.c detect-ttl.h \
 detect-uricontent.c detect-uricontent.h \
 detect-urilen.c detect-urilen.h \

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -192,6 +192,7 @@
 #include "detect-transform-sha1.h"
 #include "detect-transform-sha256.h"
 #include "detect-transform-tld.h"
+#include "detect-transform-domain.h"
 
 #include "util-rule-vars.h"
 
@@ -552,6 +553,7 @@ void SigTableSetup(void)
     DetectTransformSha1Register();
     DetectTransformSha256Register();
     DetectTransformTLDRegister();
+    DetectTransformDomainRegister();
 
     /* close keyword registration */
     DetectBufferTypeCloseRegistration();

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -191,6 +191,7 @@
 #include "detect-transform-md5.h"
 #include "detect-transform-sha1.h"
 #include "detect-transform-sha256.h"
+#include "detect-transform-tld.h"
 
 #include "util-rule-vars.h"
 
@@ -550,6 +551,7 @@ void SigTableSetup(void)
     DetectTransformMd5Register();
     DetectTransformSha1Register();
     DetectTransformSha256Register();
+    DetectTransformTLDRegister();
 
     /* close keyword registration */
     DetectBufferTypeCloseRegistration();

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -247,6 +247,7 @@ enum {
     DETECT_TRANSFORM_MD5,
     DETECT_TRANSFORM_SHA1,
     DETECT_TRANSFORM_SHA256,
+    DETECT_TRANSFORM_TLD,
 
     /* make sure this stays last */
     DETECT_TBLSIZE,

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -248,6 +248,7 @@ enum {
     DETECT_TRANSFORM_SHA1,
     DETECT_TRANSFORM_SHA256,
     DETECT_TRANSFORM_TLD,
+    DETECT_TRANSFORM_DOMAIN,
 
     /* make sure this stays last */
     DETECT_TBLSIZE,

--- a/src/detect-transform-domain.c
+++ b/src/detect-transform-domain.c
@@ -1,0 +1,223 @@
+/* Copyright (C) 2019 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ *
+ * Implements the domain transformation
+ */
+
+#include "suricata-common.h"
+
+#include "detect.h"
+#include "detect-engine.h"
+#include "detect-engine-prefilter.h"
+#include "detect-parse.h"
+#include "detect-transform-domain.h"
+
+#include "util-unittest.h"
+#include "util-print.h"
+#include "util-memrchr.h"
+#include "util-memcpy.h"
+
+static int DetectTransformDomainSetup (DetectEngineCtx *, Signature *, const char *);
+static void DetectTransformDomainRegisterTests(void);
+
+static void TransformDomain(InspectionBuffer *buffer);
+
+void DetectTransformDomainRegister(void)
+{
+    sigmatch_table[DETECT_TRANSFORM_DOMAIN].name = "domain";
+    sigmatch_table[DETECT_TRANSFORM_DOMAIN].desc =
+        "modify buffer to extract the domain";
+    sigmatch_table[DETECT_TRANSFORM_DOMAIN].url =
+        DOC_URL DOC_VERSION "/rules/transforms.html#domain";
+    sigmatch_table[DETECT_TRANSFORM_DOMAIN].Transform =
+        TransformDomain;
+    sigmatch_table[DETECT_TRANSFORM_DOMAIN].Setup =
+        DetectTransformDomainSetup;
+    sigmatch_table[DETECT_TRANSFORM_DOMAIN].RegisterTests =
+        DetectTransformDomainRegisterTests;
+
+    sigmatch_table[DETECT_TRANSFORM_DOMAIN].flags |= SIGMATCH_NOOPT;
+}
+
+/**
+ *  \internal
+ *  \brief Apply the nocase keyword to the last pattern match, either content or uricontent
+ *  \param det_ctx detection engine ctx
+ *  \param s signature
+ *  \param nullstr should be null
+ *  \retval 0 ok
+ *  \retval -1 failure
+ */
+static int DetectTransformDomainSetup (DetectEngineCtx *de_ctx, Signature *s, const char *nullstr)
+{
+    SCEnter();
+    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_DOMAIN);
+    SCReturnInt(r);
+}
+
+static void TransformDomain(InspectionBuffer *buffer)
+{
+    const uint8_t *input = buffer->inspect;
+    const uint32_t input_len = buffer->inspect_len;
+    uint8_t output[input_len]; // we can only shrink
+    uint8_t *os = output;
+
+    SCLogDebug("Transforming %.*s", input_len, input);
+
+    uint8_t *dot = memchr(input, '.', input_len);
+    if (!dot) {
+        return;
+    }
+
+    uint32_t rem = input_len - (dot - input) - 1;
+    if (!rem) {
+        return;
+    }
+
+    memcpy(os, dot + 1, rem);
+    SCLogDebug("Domain is %.*s", rem, os);
+
+    InspectionBufferCopy(buffer, os, rem);
+}
+
+#ifdef UNITTESTS
+static int DetectTransformDomainTest01(void)
+{
+    const uint8_t *input = (const uint8_t *)"example.com";
+    uint32_t input_len = strlen((char *)input);
+
+    const char *result = "com";
+    uint32_t result_len = strlen((char *)result);
+
+    InspectionBuffer buffer;
+    InspectionBufferInit(&buffer, input_len);
+    InspectionBufferSetup(&buffer, input, input_len);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    TransformDomain(&buffer);
+    FAIL_IF_NOT(buffer.inspect_len == result_len);
+    FAIL_IF_NOT(strncmp(result, (const char *)buffer.inspect, result_len) == 0);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    InspectionBufferFree(&buffer);
+    PASS;
+}
+
+static int DetectTransformDomainTest02(void)
+{
+    const uint8_t *input = (const uint8_t *)"suricon.conference.net";
+    uint32_t input_len = strlen((char *)input);
+
+    const char *result = "conference.net";
+    uint32_t result_len = strlen((char *)result);
+
+    InspectionBuffer buffer;
+    InspectionBufferInit(&buffer, input_len);
+    InspectionBufferSetup(&buffer, input, input_len);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    TransformDomain(&buffer);
+    FAIL_IF_NOT(buffer.inspect_len == result_len);
+    FAIL_IF_NOT(strncmp(result, (const char *)buffer.inspect, result_len) == 0);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    PASS;
+}
+
+static int DetectTransformDomainTest03(void)
+{
+    const uint8_t *input = (const uint8_t *)"suricon-conference-net";
+    uint32_t input_len = strlen((char *)input);
+
+    InspectionBuffer buffer;
+    InspectionBufferInit(&buffer, input_len);
+    InspectionBufferSetup(&buffer, input, input_len);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    TransformDomain(&buffer);
+    /* expect unchanged */
+    FAIL_IF_NOT(buffer.inspect_len == input_len);
+    FAIL_IF_NOT(strncmp((const char *)input, (const char *)buffer.inspect, input_len) == 0);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    PASS;
+}
+
+static int DetectTransformDomainTest04(void)
+{
+    const uint8_t *input = (const uint8_t *)"suricon.conference.";
+    uint32_t input_len = strlen((char *)input);
+
+    InspectionBuffer buffer;
+    InspectionBufferInit(&buffer, input_len);
+    InspectionBufferSetup(&buffer, input, input_len);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    TransformDomain(&buffer);
+    /* expect unchanged */
+    FAIL_IF_NOT(buffer.inspect_len == input_len);
+    FAIL_IF_NOT(strncmp((const char *)input, (const char *)buffer.inspect, input_len) == 0);
+    PASS;
+}
+
+static int DetectTransformDomainTest05(void)
+{
+    const uint8_t *input = (const uint8_t *)"windows.update.microsoft.com";
+    uint32_t input_len = strlen((char *)input);
+
+    const char *result = "update.microsoft.com";
+    uint32_t result_len = strlen((char *)result);
+
+    InspectionBuffer buffer;
+    InspectionBufferInit(&buffer, input_len);
+    InspectionBufferSetup(&buffer, input, input_len);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    TransformDomain(&buffer);
+    FAIL_IF_NOT(buffer.inspect_len == result_len);
+    FAIL_IF_NOT(strncmp(result, (const char *)buffer.inspect, result_len) == 0);
+    PASS;
+}
+
+static int DetectTransformDomainTest06(void)
+{
+    const char rule[] = "alert dns any any -> any any (dns.query; domain; content:\"org\"; sid:1;)";
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    memset(&th_v, 0, sizeof(th_v));
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, rule);
+    FAIL_IF_NULL(s);
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+#endif
+
+static void DetectTransformDomainRegisterTests(void)
+{
+#ifdef UNITTESTS
+    UtRegisterTest("DetectTransformDomainTest01", DetectTransformDomainTest01);
+    UtRegisterTest("DetectTransformDomainTest02", DetectTransformDomainTest02);
+    UtRegisterTest("DetectTransformDomainTest03", DetectTransformDomainTest03);
+    UtRegisterTest("DetectTransformDomainTest04", DetectTransformDomainTest04);
+    UtRegisterTest("DetectTransformDomainTest05", DetectTransformDomainTest05);
+    UtRegisterTest("DetectTransformDomainTest06", DetectTransformDomainTest06);
+#endif
+}

--- a/src/detect-transform-domain.h
+++ b/src/detect-transform-domain.h
@@ -1,0 +1,30 @@
+/* Copyright (C) 2019 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ */
+
+#ifndef __DETECT_TRANSFORM_DOMAIN_H__
+#define __DETECT_TRANSFORM_DOMAIN_H__
+
+/* prototypes */
+void DetectTransformDomainRegister (void);
+
+#endif /* __DETECT_TRANSFORM_DOMAIN_H__ */

--- a/src/detect-transform-tld.c
+++ b/src/detect-transform-tld.c
@@ -1,0 +1,206 @@
+/* Copyright (C) 2019 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ *
+ * Implements the tld transformation
+ */
+
+#include "suricata-common.h"
+
+#include "detect.h"
+#include "detect-engine.h"
+#include "detect-engine-prefilter.h"
+#include "detect-parse.h"
+#include "detect-transform-tld.h"
+
+#include "util-unittest.h"
+#include "util-print.h"
+#include "util-memrchr.h"
+#include "util-memcpy.h"
+
+static int DetectTransformTLDSetup (DetectEngineCtx *, Signature *, const char *);
+static void DetectTransformTLDRegisterTests(void);
+
+static void TransformTLD(InspectionBuffer *buffer);
+
+void DetectTransformTLDRegister(void)
+{
+    sigmatch_table[DETECT_TRANSFORM_TLD].name = "tld";
+    sigmatch_table[DETECT_TRANSFORM_TLD].desc =
+        "modify buffer to extract the tld";
+    sigmatch_table[DETECT_TRANSFORM_TLD].url =
+        DOC_URL DOC_VERSION "/rules/transforms.html#tld";
+    sigmatch_table[DETECT_TRANSFORM_TLD].Transform =
+        TransformTLD;
+    sigmatch_table[DETECT_TRANSFORM_TLD].Setup =
+        DetectTransformTLDSetup;
+    sigmatch_table[DETECT_TRANSFORM_TLD].RegisterTests =
+        DetectTransformTLDRegisterTests;
+
+    sigmatch_table[DETECT_TRANSFORM_TLD].flags |= SIGMATCH_NOOPT;
+}
+
+/**
+ *  \internal
+ *  \brief Apply the nocase keyword to the last pattern match, either content or uricontent
+ *  \param det_ctx detection engine ctx
+ *  \param s signature
+ *  \param nullstr should be null
+ *  \retval 0 ok
+ *  \retval -1 failure
+ */
+static int DetectTransformTLDSetup (DetectEngineCtx *de_ctx, Signature *s, const char *nullstr)
+{
+    SCEnter();
+    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_TLD);
+    SCReturnInt(r);
+}
+
+static void TransformTLD(InspectionBuffer *buffer)
+{
+    const uint8_t *input = buffer->inspect;
+    const uint32_t input_len = buffer->inspect_len;
+    uint8_t output[input_len]; // we can only shrink
+    uint8_t *os = output;
+
+    /* from end, scan back for dot */
+    uint8_t *dot = memrchr(input, '.', input_len);
+
+    /* no dot found */
+    if (!dot) {
+        return;
+    }
+
+    uint32_t output_size = input_len - (dot - input) - 1;
+    /* no chars following dot */
+    if (!output_size) {
+        return;
+    }
+
+    dot++;
+    memcpy(os, dot, output_size);
+
+    InspectionBufferCopy(buffer, os, output_size);
+}
+
+#ifdef UNITTESTS
+static int DetectTransformTLDTest01(void)
+{
+    const uint8_t *input = (const uint8_t *)"example.com";
+    uint32_t input_len = strlen((char *)input);
+
+    const char *result = "com";
+    uint32_t result_len = strlen((char *)result);
+
+    InspectionBuffer buffer;
+    InspectionBufferInit(&buffer, input_len);
+    InspectionBufferSetup(&buffer, input, input_len);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    TransformTLD(&buffer);
+    FAIL_IF_NOT(buffer.inspect_len == result_len);
+    FAIL_IF_NOT(strncmp(result, (const char *)buffer.inspect, result_len) == 0);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    InspectionBufferFree(&buffer);
+    PASS;
+}
+
+static int DetectTransformTLDTest02(void)
+{
+    const uint8_t *input = (const uint8_t *)"suricon.conference.net";
+    uint32_t input_len = strlen((char *)input);
+
+    const char *result = "net";
+    uint32_t result_len = strlen((char *)result);
+
+    InspectionBuffer buffer;
+    InspectionBufferInit(&buffer, input_len);
+    InspectionBufferSetup(&buffer, input, input_len);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    TransformTLD(&buffer);
+    FAIL_IF_NOT(buffer.inspect_len == result_len);
+    FAIL_IF_NOT(strncmp(result, (const char *)buffer.inspect, result_len) == 0);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    PASS;
+}
+
+static int DetectTransformTLDTest03(void)
+{
+    const uint8_t *input = (const uint8_t *)"suricon-conference-net";
+    uint32_t input_len = strlen((char *)input);
+
+    InspectionBuffer buffer;
+    InspectionBufferInit(&buffer, input_len);
+    InspectionBufferSetup(&buffer, input, input_len);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    TransformTLD(&buffer);
+    /* expect unchanged */
+    FAIL_IF_NOT(buffer.inspect_len == input_len);
+    FAIL_IF_NOT(strncmp((const char *)input, (const char *)buffer.inspect, input_len) == 0);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    PASS;
+}
+
+static int DetectTransformTLDTest04(void)
+{
+    const uint8_t *input = (const uint8_t *)"suricon.conference.";
+    uint32_t input_len = strlen((char *)input);
+
+    InspectionBuffer buffer;
+    InspectionBufferInit(&buffer, input_len);
+    InspectionBufferSetup(&buffer, input, input_len);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    TransformTLD(&buffer);
+    /* expect unchanged */
+    FAIL_IF_NOT(buffer.inspect_len == input_len);
+    FAIL_IF_NOT(strncmp((const char *)input, (const char *)buffer.inspect, input_len) == 0);
+    PASS;
+}
+
+static int DetectTransformTLDTest05(void)
+{
+    const char rule[] = "alert dns any any -> any any (dns.query; tld; content:\"org\"; sid:1;)";
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    memset(&th_v, 0, sizeof(th_v));
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, rule);
+    FAIL_IF_NULL(s);
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+#endif
+
+static void DetectTransformTLDRegisterTests(void)
+{
+#ifdef UNITTESTS
+    UtRegisterTest("DetectTransformTLDTest01", DetectTransformTLDTest01);
+    UtRegisterTest("DetectTransformTLDTest02", DetectTransformTLDTest02);
+    UtRegisterTest("DetectTransformTLDTest03", DetectTransformTLDTest03);
+    UtRegisterTest("DetectTransformTLDTest04", DetectTransformTLDTest04);
+    UtRegisterTest("DetectTransformTLDTest05", DetectTransformTLDTest05);
+#endif
+}

--- a/src/detect-transform-tld.h
+++ b/src/detect-transform-tld.h
@@ -1,0 +1,30 @@
+/* Copyright (C) 2019 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ */
+
+#ifndef __DETECT_TRANSFORM_TLD_H__
+#define __DETECT_TRANSFORM_TLD_H__
+
+/* prototypes */
+void DetectTransformTLDRegister (void);
+
+#endif /* __DETECT_TRANSFORM_TLD_H__ */


### PR DESCRIPTION
This PR adds transforms for:
1. tld - Returns the top-level-domain and passes it on
1. domain - Returns the domain and passes it on.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
