### PR TITLE
configure: Add date with rev information

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2468,6 +2468,8 @@ fi
         if test "$HAVE_GIT_CMD" != "no"; then
             if [ test -d .git ]; then
                 REVISION=`git rev-parse --short HEAD`
+                DATE=`git log -1 --date=short --pretty=format:%cd`
+                REVISION="$REVISION $DATE"
                 AC_DEFINE_UNQUOTED([REVISION],[${REVISION}],[Git revision])
             fi
         fi

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -581,7 +581,7 @@ static void SetBpfStringFromFile(char *filename)
 static void PrintUsage(const char *progname)
 {
 #ifdef REVISION
-    printf("%s %s (rev %s)\n", PROG_NAME, PROG_VER, xstr(REVISION));
+    printf("%s %s (%s)\n", PROG_NAME, PROG_VER, xstr(REVISION));
 #else
     printf("%s %s\n", PROG_NAME, PROG_VER);
 #endif
@@ -684,7 +684,7 @@ static void PrintBuildInfo(void)
     const char *tls = "pthread key";
 
 #ifdef REVISION
-    printf("This is %s version %s (rev %s)\n", PROG_NAME, PROG_VER, xstr(REVISION));
+    printf("This is %s version %s (%s)\n", PROG_NAME, PROG_VER, xstr(REVISION));
 #elif defined RELEASE
     printf("This is %s version %s RELEASE\n", PROG_NAME, PROG_VER);
 #else
@@ -1054,7 +1054,7 @@ static void SCInstanceInit(SCInstance *suri, const char *progname)
 static TmEcode PrintVersion(void)
 {
 #ifdef REVISION
-    printf("This is %s version %s (rev %s)\n", PROG_NAME, PROG_VER, xstr(REVISION));
+    printf("This is %s version %s (%s)\n", PROG_NAME, PROG_VER, xstr(REVISION));
 #elif defined RELEASE
     printf("This is %s version %s RELEASE\n", PROG_NAME, PROG_VER);
 #else
@@ -1067,7 +1067,7 @@ static TmEcode LogVersion(SCInstance *suri)
 {
     const char *mode = suri->system ? "SYSTEM" : "USER";
 #ifdef REVISION
-    SCLogNotice("This is %s version %s (rev %s) running in %s mode",
+    SCLogNotice("This is %s version %s (%s) running in %s mode",
             PROG_NAME, PROG_VER, xstr(REVISION), mode);
 #elif defined RELEASE
     SCLogNotice("This is %s version %s RELEASE running in %s mode",


### PR DESCRIPTION
Date makes it even clearer that when was the last commit for the build
that one is running. Add this info alongwith rev. Change inspired by
rustc.

Before
```
$ suricata -V
This is Suricata version 5.0.0-dev (rev 2d217e666)
```

After
```
This is Suricata version 5.0.0-dev (2d217e666 2019-07-12)
```

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3092