### PR TITLE
Protocol detection 2757 v1

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -523,6 +523,10 @@ fn probe(input: &[u8]) -> bool {
     parser::dns_parse_request(input).is_ok()
 }
 
+fn probe_srv(input: &[u8]) -> bool {
+    parser::dns_parse_response(input).is_ok()
+}
+
 /// Probe TCP input to see if it looks like DNS.
 pub fn probe_tcp(input: &[u8]) -> bool {
     match nom::be_u16(input) {
@@ -820,6 +824,19 @@ pub extern "C" fn rs_dns_probe(input: *const u8, len: u32)
         std::slice::from_raw_parts(input as *mut u8, len as usize)
     };
     if probe(slice) {
+        return 1;
+    }
+    return 0;
+}
+
+#[no_mangle]
+pub extern "C" fn rs_dns_probe_srv(input: *const u8, len: u32)
+                                   -> u8
+{
+    let slice: &[u8] = unsafe {
+        std::slice::from_raw_parts(input as *mut u8, len as usize)
+    };
+    if probe_srv(slice) {
         return 1;
     }
     return 0;

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -532,7 +532,11 @@ again_midstream:
     } else {
         /* first try the destination port */
         pp_port_dp = AppLayerProtoDetectGetProbingParsers(alpd_ctx.ctx_pp, ipproto, dp);
-        alproto_masks = &f->probing_parser_toclient_alproto_masks;
+        if (dir == idir) {
+            // do not update alproto_masks to let a chance to second packet
+            // for instance when sending a junk packet to a DNS server
+            alproto_masks = &f->probing_parser_toclient_alproto_masks;
+        }
         if (pp_port_dp != NULL) {
             SCLogDebug("toclient - Probing parser found for destination port %"PRIu16, dp);
 

--- a/src/app-layer-dns-udp-rust.c
+++ b/src/app-layer-dns-udp-rust.c
@@ -65,6 +65,21 @@ static uint16_t DNSUDPProbe(Flow *f, uint8_t direction,
     return ALPROTO_DNS;
 }
 
+static uint16_t DNSUDPProbeSrv(Flow *f, uint8_t direction,
+        uint8_t *input, uint32_t len, uint8_t *rdir)
+{
+    if (len == 0 || len < sizeof(DNSHeader)) {
+        return ALPROTO_UNKNOWN;
+    }
+
+    // Validate and return ALPROTO_FAILED if needed.
+    if (!rs_dns_probe_srv(input, len)) {
+        return ALPROTO_FAILED;
+    }
+
+    return ALPROTO_DNS;
+}
+
 static int RustDNSGetAlstateProgress(void *tx, uint8_t direction)
 {
     return rs_dns_tx_get_alstate_progress(tx, direction);
@@ -132,11 +147,11 @@ void RegisterRustDNSUDPParsers(void)
         if (RunmodeIsUnittests()) {
             AppLayerProtoDetectPPRegister(IPPROTO_UDP, "53", ALPROTO_DNS, 0,
                     sizeof(DNSHeader), STREAM_TOSERVER, DNSUDPProbe,
-                    NULL);
+                    DNSUDPProbeSrv);
         } else {
             int have_cfg = AppLayerProtoDetectPPParseConfPorts("udp",
                     IPPROTO_UDP, proto_name, ALPROTO_DNS, 0, sizeof(DNSHeader),
-                    DNSUDPProbe, NULL);
+                    DNSUDPProbe, DNSUDPProbeSrv);
 
             /* If no config, enable on port 53. */
             if (!have_cfg) {
@@ -146,7 +161,7 @@ void RegisterRustDNSUDPParsers(void)
 #endif
                 AppLayerProtoDetectPPRegister(IPPROTO_UDP, "53", ALPROTO_DNS,
                         0, sizeof(DNSHeader), STREAM_TOSERVER,
-                        DNSUDPProbe, NULL);
+                        DNSUDPProbe, DNSUDPProbeSrv);
             }
         }
     } else {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2757

Describe changes:
- Use both directions for protocol detection over UDP (as is done with TCP)
- Adds a probing function for protocol `DNS` for direction to client (for UDP)
- Changes `AppLayerProtoDetectPPGetProto` so that first packet does not bit mask away a protocol for both directions when config option midstream is activated 

The main goal was the first one (use both directions for UDP)
I added DNS probing function to test this functionality
And then I came across this unwanted behavior from `AppLayerProtoDetectPPGetProto` :
When the first packet is no valid DNS but on port 53 (for instance a junk request), second packet (error response from server) does not get checked for DNS as first packet bit masked away DNS for both directions (ie `probing_parser_toclient_alproto_masks` and `probing_parser_toserver_alproto_masks`)

There remains more to be done for the redmine ticket
https://redmine.openinfosecfoundation.org/issues/2757
such as "Support when multiple protocols have patterns matching (such as USER for FTP and IRC)"
But this can already be merged independently I guess...

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
