### PR TITLE
rust: Fix deprecation warnings

### DIFF
--- a/rust/src/applayertemplate/parser.rs
+++ b/rust/src/applayertemplate/parser.rs
@@ -24,7 +24,7 @@ fn parse_len(input: &str) -> Result<u32, std::num::ParseIntError> {
 named!(pub parse_message<String>,
        do_parse!(
            len:  map_res!(
-                 map_res!(take_until_s!(":"), std::str::from_utf8), parse_len) >>
+                 map_res!(take_until!(":"), std::str::from_utf8), parse_len) >>
            _sep: take!(1) >>
            msg:  take_str!(len) >>
                (

--- a/rust/src/dhcp/parser.rs
+++ b/rust/src/dhcp/parser.rs
@@ -199,7 +199,7 @@ pub fn dhcp_parse(input: &[u8]) -> IResult<&[u8], DHCPMessage> {
         Ok((rem, header)) => {
             let mut options = Vec::new();
             let mut next = rem;
-            let mut malformed_options = false;
+            let malformed_options = false;
             let mut truncated_options = false;
             loop {
                 match parse_option(next) {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -15,6 +15,7 @@
  * 02110-1301, USA.
  */
 
+#![allow(ellipsis_inclusive_range_patterns)]
 #![cfg_attr(feature = "strict", deny(warnings))]
 
 #[macro_use]


### PR DESCRIPTION
Since rustc 1.37.0-nightly (0beb2ba16 2019-07-02), there were some
deprecation warnings. This patch fixes them to make the compilation
smooth and at par with the new coding standards.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3072