### PR TITLE
af-packet: fix build on recent Linux kernels

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -65,6 +65,8 @@
 #include <sys/ioctl.h>
 #endif
 
+#include <linux/sockios.h>
+
 #ifdef HAVE_PACKET_EBPF
 #include "util-ebpf.h"
 #include <bpf/libbpf.h>


### PR DESCRIPTION
Fix for issue https://redmine.openinfosecfoundation.org/issues/3089

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
- https://redmine.openinfosecfoundation.org/issues/3089

Describe changes:
- Fix af-packet build for recent kernel


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/476
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/257

