### PR TITLE
source-pfring.c: Fix kernel version in comment

### DIFF
--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -628,7 +628,7 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, const void *initdata, void **dat
             ptv->tv);
 #endif
 
-    /* If kernel is older than 3.8, VLAN is not stripped so we don't
+    /* If kernel is older than 3.0, VLAN is not stripped so we don't
      * get the info from packt extended header but we will use a standard
      * parsing */
     ptv->vlan_in_ext_header = 1;


### PR DESCRIPTION
- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- No documentation update needed

Describe changes:
- Bring the kernel version in the comment in line with the version that the code actually checks for