### PR TITLE
Fuzz v12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
     AC_CONFIG_HEADERS([config.h])
     AC_CONFIG_SRCDIR([src/suricata.c])
     AC_CONFIG_MACRO_DIR(m4)
-    AM_INIT_AUTOMAKE
+    AM_INIT_AUTOMAKE([subdir-objects])
 
     AC_LANG([C])
     AC_PROG_CC_C99
@@ -2368,6 +2368,20 @@ fi
     fi
     AM_CONDITIONAL([HAVE_PDFLATEX], [test "x$enable_pdflatex" != "xno"])
 
+    AC_CHECK_LIB(FuzzingEngine, main,, LIBFUZZINGENGINE="no")
+    if test "$LIBFUZZINGENGINE" = "no"; then
+        libfuzzingengine=no
+    fi
+    AM_CONDITIONAL([HAVE_LIBFUZZINGENGINE], [test "x$libfuzzingengine" != "xno"])
+
+    AC_ARG_ENABLE(fuzztargets,
+        AS_HELP_STRING([--enable-fuzztargets], [Enable fuzz targets]),[enable_fuzztargets=$enableval],[enable_fuzztargets=no])
+    AM_CONDITIONAL([BUILD_FUZZTARGETS], [test "x$enable_fuzztargets" = "xyes"])
+    AS_IF([test "x$enable_fuzztargets" = "xyes"], [
+        AC_DEFINE([AFLFUZZ_NO_RANDOM], [1], [Disable all use of random functions])
+    ])
+
+
 # Cargo/Rust
     AC_PATH_PROG(RUSTC, rustc, "no")
     if test "$RUSTC" = "no"; then
@@ -2417,7 +2431,6 @@ fi
     else
       RUST_SURICATA_LIB="../rust/target/release/${RUST_SURICATA_LIBNAME}"
     fi
-    RUST_LDADD="${RUST_SURICATA_LIB} ${RUST_LDADD}"
     CFLAGS="${CFLAGS} -I\${srcdir}/../rust/gen/c-headers"
     AC_SUBST(RUST_SURICATA_LIB)
     AC_SUBST(RUST_LDADD)

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -570,7 +570,7 @@ pub extern "C" fn rs_dns_state_tx_free(state: &mut DNSState,
 pub extern "C" fn rs_dns_parse_request(_flow: *mut core::Flow,
                                        state: &mut DNSState,
                                        _pstate: *mut std::os::raw::c_void,
-                                       input: *mut u8,
+                                       input: *const u8,
                                        input_len: u32,
                                        _data: *mut std::os::raw::c_void)
                                        -> i8 {
@@ -586,7 +586,7 @@ pub extern "C" fn rs_dns_parse_request(_flow: *mut core::Flow,
 pub extern "C" fn rs_dns_parse_response(_flow: *mut core::Flow,
                                         state: &mut DNSState,
                                         _pstate: *mut std::os::raw::c_void,
-                                        input: *mut u8,
+                                        input: *const u8,
                                         input_len: u32,
                                         _data: *mut std::os::raw::c_void)
                                         -> i8 {
@@ -603,7 +603,7 @@ pub extern "C" fn rs_dns_parse_response(_flow: *mut core::Flow,
 pub extern "C" fn rs_dns_parse_request_tcp(_flow: *mut core::Flow,
                                            state: &mut DNSState,
                                            _pstate: *mut std::os::raw::c_void,
-                                           input: *mut u8,
+                                           input: *const u8,
                                            input_len: u32,
                                            _data: *mut std::os::raw::c_void)
                                            -> i8 {
@@ -622,7 +622,7 @@ pub extern "C" fn rs_dns_parse_request_tcp(_flow: *mut core::Flow,
 pub extern "C" fn rs_dns_parse_response_tcp(_flow: *mut core::Flow,
                                             state: &mut DNSState,
                                             _pstate: *mut std::os::raw::c_void,
-                                            input: *mut u8,
+                                            input: *const u8,
                                             input_len: u32,
                                             _data: *mut std::os::raw::c_void)
                                             -> i8 {

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -1360,7 +1360,7 @@ pub extern "C" fn rs_nfs_state_free(state: *mut std::os::raw::c_void) {
 pub extern "C" fn rs_nfs_parse_request(_flow: *mut Flow,
                                        state: &mut NFSState,
                                        _pstate: *mut std::os::raw::c_void,
-                                       input: *mut u8,
+                                       input: *const u8,
                                        input_len: u32,
                                        _data: *mut std::os::raw::c_void)
                                        -> i8
@@ -1391,7 +1391,7 @@ pub extern "C" fn rs_nfs_parse_request_tcp_gap(
 pub extern "C" fn rs_nfs_parse_response(_flow: *mut Flow,
                                         state: &mut NFSState,
                                         _pstate: *mut std::os::raw::c_void,
-                                        input: *mut u8,
+                                        input: *const u8,
                                         input_len: u32,
                                         _data: *mut std::os::raw::c_void)
                                         -> i8
@@ -1423,7 +1423,7 @@ pub extern "C" fn rs_nfs_parse_response_tcp_gap(
 pub extern "C" fn rs_nfs_parse_request_udp(_flow: *mut Flow,
                                        state: &mut NFSState,
                                        _pstate: *mut std::os::raw::c_void,
-                                       input: *mut u8,
+                                       input: *const u8,
                                        input_len: u32,
                                        _data: *mut std::os::raw::c_void)
                                        -> i8
@@ -1442,7 +1442,7 @@ pub extern "C" fn rs_nfs_parse_request_udp(_flow: *mut Flow,
 pub extern "C" fn rs_nfs_parse_response_udp(_flow: *mut Flow,
                                         state: &mut NFSState,
                                         _pstate: *mut std::os::raw::c_void,
-                                        input: *mut u8,
+                                        input: *const u8,
                                         input_len: u32,
                                         _data: *mut std::os::raw::c_void)
                                         -> i8

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1796,7 +1796,7 @@ pub extern "C" fn rs_smb_state_free(state: *mut std::os::raw::c_void) {
 pub extern "C" fn rs_smb_parse_request_tcp(_flow: *mut Flow,
                                        state: &mut SMBState,
                                        _pstate: *mut std::os::raw::c_void,
-                                       input: *mut u8,
+                                       input: *const u8,
                                        input_len: u32,
                                        _data: *mut std::os::raw::c_void,
                                        flags: u8)
@@ -1834,7 +1834,7 @@ pub extern "C" fn rs_smb_parse_request_tcp_gap(
 pub extern "C" fn rs_smb_parse_response_tcp(_flow: *mut Flow,
                                         state: &mut SMBState,
                                         _pstate: *mut std::os::raw::c_void,
-                                        input: *mut u8,
+                                        input: *const u8,
                                         input_len: u32,
                                         _data: *mut std::os::raw::c_void,
                                         flags: u8)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,8 +6,14 @@ noinst_HEADERS = action-globals.h \
 	suricata-common.h threadvars.h tree.h \
     util-validate.h
 bin_PROGRAMS = suricata
+if BUILD_FUZZTARGETS
+    bin_PROGRAMS += fuzz_applayerprotodetectgetproto \
+    fuzz_applayerparserparse fuzz_siginit \
+    fuzz_confyamlloadstring fuzz_decodepcapfile \
+    fuzz_sigpcap
+endif
 
-suricata_SOURCES = \
+COMMON_SOURCES = \
 alert-debuglog.c alert-debuglog.h \
 alert-fastlog.c alert-fastlog.h \
 alert-prelude.c alert-prelude.h \
@@ -292,6 +298,7 @@ host-bit.c host-bit.h \
 host-queue.c host-queue.h \
 host-storage.c host-storage.h \
 host-timeout.c host-timeout.h \
+init.c \
 ippair.c ippair.h \
 ippair-bit.c ippair-bit.h \
 ippair-queue.c ippair-queue.h \
@@ -386,7 +393,6 @@ stream-tcp-list.c stream-tcp-list.h \
 stream-tcp-reassemble.c stream-tcp-reassemble.h \
 stream-tcp-sack.c stream-tcp-sack.h \
 stream-tcp-util.c stream-tcp-util.h \
-suricata.c suricata.h \
 threads.c threads.h \
 threads-debug.h threads-profile.h \
 tm-modules.c tm-modules.h \
@@ -519,13 +525,88 @@ EXTRA_DIST = tests
 # set the include path found by configure
 AM_CPPFLAGS = $(all_includes)
 
+suricata_SOURCES = suricata.c suricata.h $(COMMON_SOURCES)
+
 # the library search path.
 suricata_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
-suricata_LDADD = $(HTP_LDADD) $(RUST_LDADD)
+suricata_LDADD = $(RUST_SURICATA_LIB) $(HTP_LDADD) $(RUST_LDADD)
 
-if HAVE_RUST
-suricata_DEPENDENCIES = $(RUST_SURICATA_LIB)
+fuzz_applayerprotodetectgetproto_SOURCES = tests/fuzz/fuzz_applayerprotodetectgetproto.c $(COMMON_SOURCES)
+fuzz_applayerprotodetectgetproto_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
+fuzz_applayerprotodetectgetproto_LDADD = $(RUST_SURICATA_LIB) $(HTP_LDADD) $(RUST_LDADD)
+if HAVE_LIBFUZZINGENGINE
+    fuzz_applayerprotodetectgetproto_LDFLAGS += -lFuzzingEngine
+else
+    fuzz_applayerprotodetectgetproto_SOURCES += tests/fuzz/onefile.c
 endif
+# force usage of CXX for linker
+fuzz_applayerprotodetectgetproto_LINK=$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
+    $(LIBTOOLFLAGS) --mode=link $(CXX) $(AM_CXXFLAGS) $(CXXFLAGS) \
+    $(fuzz_applayerprotodetectgetproto_LDFLAGS) $(LDFLAGS) -o $@
+
+fuzz_applayerparserparse_SOURCES = tests/fuzz/fuzz_applayerparserparse.c $(COMMON_SOURCES)
+fuzz_applayerparserparse_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
+fuzz_applayerparserparse_LDADD = $(RUST_SURICATA_LIB) $(HTP_LDADD) $(RUST_LDADD)
+if HAVE_LIBFUZZINGENGINE
+    fuzz_applayerparserparse_LDFLAGS += -lFuzzingEngine
+else
+    fuzz_applayerparserparse_SOURCES += tests/fuzz/onefile.c
+endif
+fuzz_applayerparserparse_LINK=$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
+    $(LIBTOOLFLAGS) --mode=link $(CXX) $(AM_CXXFLAGS) $(CXXFLAGS) \
+    $(fuzz_applayerparserparse_LDFLAGS) $(LDFLAGS) -o $@
+
+fuzz_siginit_SOURCES = tests/fuzz/fuzz_siginit.c $(COMMON_SOURCES)
+fuzz_siginit_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
+fuzz_siginit_LDADD = $(RUST_SURICATA_LIB) $(HTP_LDADD) $(RUST_LDADD)
+if HAVE_LIBFUZZINGENGINE
+    fuzz_siginit_LDFLAGS += -lFuzzingEngine
+else
+    fuzz_siginit_SOURCES += tests/fuzz/onefile.c
+endif
+# force usage of CXX for linker
+fuzz_siginit_LINK=$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
+    $(LIBTOOLFLAGS) --mode=link $(CXX) $(AM_CXXFLAGS) $(CXXFLAGS) \
+    $(fuzz_siginit_LDFLAGS) $(LDFLAGS) -o $@
+
+fuzz_confyamlloadstring_SOURCES = tests/fuzz/fuzz_confyamlloadstring.c $(COMMON_SOURCES)
+fuzz_confyamlloadstring_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
+fuzz_confyamlloadstring_LDADD = $(RUST_SURICATA_LIB) $(HTP_LDADD) $(RUST_LDADD)
+if HAVE_LIBFUZZINGENGINE
+    fuzz_confyamlloadstring_LDFLAGS += -lFuzzingEngine
+else
+    fuzz_confyamlloadstring_SOURCES += tests/fuzz/onefile.c
+endif
+# force usage of CXX for linker
+fuzz_confyamlloadstring_LINK=$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
+    $(LIBTOOLFLAGS) --mode=link $(CXX) $(AM_CXXFLAGS) $(CXXFLAGS) \
+    $(fuzz_confyamlloadstring_LDFLAGS) $(LDFLAGS) -o $@
+
+fuzz_decodepcapfile_SOURCES = tests/fuzz/fuzz_decodepcapfile.c $(COMMON_SOURCES)
+fuzz_decodepcapfile_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
+fuzz_decodepcapfile_LDADD = $(RUST_SURICATA_LIB) $(HTP_LDADD) $(RUST_LDADD)
+if HAVE_LIBFUZZINGENGINE
+    fuzz_decodepcapfile_LDFLAGS += -lFuzzingEngine
+else
+    fuzz_decodepcapfile_SOURCES += tests/fuzz/onefile.c
+endif
+# force usage of CXX for linker
+fuzz_decodepcapfile_LINK=$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
+    $(LIBTOOLFLAGS) --mode=link $(CXX) $(AM_CXXFLAGS) $(CXXFLAGS) \
+    $(fuzz_decodepcapfile_LDFLAGS) $(LDFLAGS) -o $@
+
+fuzz_sigpcap_SOURCES = tests/fuzz/fuzz_sigpcap.c $(COMMON_SOURCES)
+fuzz_sigpcap_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
+fuzz_sigpcap_LDADD = $(RUST_SURICATA_LIB) $(HTP_LDADD) $(RUST_LDADD)
+if HAVE_LIBFUZZINGENGINE
+    fuzz_sigpcap_LDFLAGS += -lFuzzingEngine
+else
+    fuzz_sigpcap_SOURCES += tests/fuzz/onefile.c
+endif
+# force usage of CXX for linker
+fuzz_sigpcap_LINK=$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
+    $(LIBTOOLFLAGS) --mode=link $(CXX) $(AM_CXXFLAGS) $(CXXFLAGS) \
+    $(fuzz_sigpcap_LDFLAGS) $(LDFLAGS) -o $@
 
 # default CFLAGS
 AM_CFLAGS = ${OPTIMIZATION_CFLAGS} ${GCC_CFLAGS} ${CLANG_CFLAGS}            \

--- a/src/app-layer-dcerpc-common.h
+++ b/src/app-layer-dcerpc-common.h
@@ -235,7 +235,7 @@ typedef struct DCERPCUDP_ {
 #define USER_DATA_NOT_READABLE          6 /* not used */
 #define NO_PSAP_AVAILABLE               7 /* not used */
 
-int32_t DCERPCParser(DCERPC *, uint8_t *, uint32_t);
+int32_t DCERPCParser(DCERPC *, const uint8_t *, uint32_t);
 void hexdump(const void *buf, size_t len);
 void printUUID(const char *type, DCERPCUuidEntry *uuid);
 

--- a/src/app-layer-dcerpc-udp.c
+++ b/src/app-layer-dcerpc-udp.c
@@ -65,7 +65,7 @@ enum {
 /** \internal
  *  \retval stub_len or 0 in case of error */
 static uint32_t FragmentDataParser(Flow *f, void *dcerpcudp_state,
-    AppLayerParserState *pstate, uint8_t *input, uint32_t input_len)
+    AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
     DCERPCUDPState *sstate = (DCERPCUDPState *) dcerpcudp_state;
@@ -134,10 +134,10 @@ static uint32_t FragmentDataParser(Flow *f, void *dcerpcudp_state,
  * fragmented packets.
  */
 static int DCERPCUDPParseHeader(Flow *f, void *dcerpcudp_state,
-    AppLayerParserState *pstate, uint8_t *input, uint32_t input_len)
+    AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
     DCERPCUDPState *sstate = (DCERPCUDPState *) dcerpcudp_state;
     if (input_len) {
         switch (sstate->bytesprocessed) {
@@ -716,7 +716,7 @@ static int DCERPCUDPParseHeader(Flow *f, void *dcerpcudp_state,
 }
 
 static int DCERPCUDPParse(Flow *f, void *dcerpc_state,
-    AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+    AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
     void *local_data, const uint8_t flags)
 {
     uint32_t retval = 0;

--- a/src/app-layer-dcerpc.c
+++ b/src/app-layer-dcerpc.c
@@ -162,10 +162,10 @@ void printUUID(const char *type, DCERPCUuidEntry *uuid)
  * \brief DCERPCParseSecondaryAddr reads secondaryaddrlen bytes from the BIND_ACK
  * DCERPC call.
  */
-static uint32_t DCERPCParseSecondaryAddr(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static uint32_t DCERPCParseSecondaryAddr(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
     while (dcerpc->dcerpcbindbindack.secondaryaddrlenleft-- && input_len--) {
         SCLogDebug("0x%02x ", *p);
         p++;
@@ -174,10 +174,10 @@ static uint32_t DCERPCParseSecondaryAddr(DCERPC *dcerpc, uint8_t *input, uint32_
     SCReturnUInt((uint32_t)(p - input));
 }
 
-static uint32_t PaddingParser(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static uint32_t PaddingParser(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
     while (dcerpc->padleft-- && input_len--) {
         SCLogDebug("0x%02x ", *p);
         p++;
@@ -186,10 +186,10 @@ static uint32_t PaddingParser(DCERPC *dcerpc, uint8_t *input, uint32_t input_len
     SCReturnUInt((uint32_t)(p - input));
 }
 
-static uint32_t DCERPCGetCTXItems(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static uint32_t DCERPCGetCTXItems(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
     if (input_len) {
         switch (dcerpc->dcerpcbindbindack.ctxbytesprocessed) {
             case 0:
@@ -232,10 +232,10 @@ static uint32_t DCERPCGetCTXItems(DCERPC *dcerpc, uint8_t *input, uint32_t input
  * each UUID is added to a TAILQ.
  */
 
-static uint32_t DCERPCParseBINDCTXItem(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static uint32_t DCERPCParseBINDCTXItem(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
 
     if (input_len) {
         switch (dcerpc->dcerpcbindbindack.ctxbytesprocessed) {
@@ -664,10 +664,10 @@ static uint32_t DCERPCParseBINDCTXItem(DCERPC *dcerpc, uint8_t *input, uint32_t 
  * the BIND_ACK call. The result (Accepted or Rejected) is added to the
  * correct UUID from the BIND call.
  */
-static uint32_t DCERPCParseBINDACKCTXItem(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static uint32_t DCERPCParseBINDACKCTXItem(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
     DCERPCUuidEntry *uuid_entry;
 
     if (input_len) {
@@ -874,10 +874,10 @@ static uint32_t DCERPCParseBINDACKCTXItem(DCERPC *dcerpc, uint8_t *input, uint32
     SCReturnUInt((uint32_t)(p - input));
 }
 
-static uint32_t DCERPCParseBIND(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static uint32_t DCERPCParseBIND(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
     if (input_len) {
         switch (dcerpc->bytesprocessed) {
             case 16:
@@ -980,10 +980,10 @@ static uint32_t DCERPCParseBIND(DCERPC *dcerpc, uint8_t *input, uint32_t input_l
     SCReturnUInt((uint32_t)(p - input));
 }
 
-static uint32_t DCERPCParseBINDACK(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static uint32_t DCERPCParseBINDACK(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
 
     switch (dcerpc->bytesprocessed) {
         case 16:
@@ -1073,10 +1073,10 @@ static uint32_t DCERPCParseBINDACK(DCERPC *dcerpc, uint8_t *input, uint32_t inpu
     SCReturnUInt((uint32_t)(p - input));
 }
 
-static uint32_t DCERPCParseREQUEST(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static uint32_t DCERPCParseREQUEST(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
 
     switch (dcerpc->bytesprocessed) {
         case 16:
@@ -1257,10 +1257,10 @@ static uint32_t StubDataParser(DCERPC *dcerpc, const uint8_t *input, uint32_t in
  * \retval -1 if DCERPC Header does not validate
  * \retval Number of bytes processed
  */
-static int DCERPCParseHeader(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static int DCERPCParseHeader(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
 
     if (input_len) {
         SCLogDebug("dcerpc->bytesprocessed %u", dcerpc->bytesprocessed);
@@ -1430,7 +1430,7 @@ static inline void DCERPCResetStub(DCERPC *dcerpc)
     return;
 }
 
-static inline int DCERPCThrowOutExtraData(DCERPC *dcerpc, uint8_t *input,
+static inline int DCERPCThrowOutExtraData(DCERPC *dcerpc, const uint8_t *input,
                                            uint16_t input_len)
 {
     int parsed = 0;
@@ -1455,7 +1455,7 @@ static inline int DCERPCThrowOutExtraData(DCERPC *dcerpc, uint8_t *input,
  *         a condition where it has receives a segment with 2 pdus, while the
  *         first pdu in the segment is corrupt.
  */
-int32_t DCERPCParser(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+int32_t DCERPCParser(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
 
@@ -1888,7 +1888,7 @@ int32_t DCERPCParser(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
 
 static int DCERPCParse(Flow *f, void *dcerpc_state,
                        AppLayerParserState *pstate,
-                       uint8_t *input, uint32_t input_len,
+                       const uint8_t *input, uint32_t input_len,
                        void *local_data, int dir)
 {
     SCEnter();
@@ -1921,7 +1921,7 @@ static int DCERPCParse(Flow *f, void *dcerpc_state,
 
 static int DCERPCParseRequest(Flow *f, void *dcerpc_state,
                               AppLayerParserState *pstate,
-                              uint8_t *input, uint32_t input_len,
+                              const uint8_t *input, uint32_t input_len,
                               void *local_data, const uint8_t flags)
 {
     return DCERPCParse(f, dcerpc_state, pstate, input, input_len,
@@ -1930,7 +1930,7 @@ static int DCERPCParseRequest(Flow *f, void *dcerpc_state,
 
 static int DCERPCParseResponse(Flow *f, void *dcerpc_state,
                                AppLayerParserState *pstate,
-                               uint8_t *input, uint32_t input_len,
+                               const uint8_t *input, uint32_t input_len,
                                void *local_data, const uint8_t flags)
 {
     return DCERPCParse(f, dcerpc_state, pstate, input, input_len,

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -187,7 +187,7 @@ static AppProto AppLayerProtoDetectPMMatchSignature(
         const AppLayerProtoDetectPMSignature *s,
         AppLayerProtoDetectThreadCtx *tctx,
         Flow *f, uint8_t direction,
-        uint8_t *buf, uint16_t buflen, uint16_t searchlen,
+        const uint8_t *buf, uint16_t buflen, uint16_t searchlen,
         bool *rflow)
 {
     SCEnter();
@@ -203,7 +203,7 @@ static AppProto AppLayerProtoDetectPMMatchSignature(
         SCReturnUInt(ALPROTO_UNKNOWN);
     }
 
-    uint8_t *sbuf = buf + s->cd->offset;
+    const uint8_t *sbuf = buf + s->cd->offset;
     uint16_t ssearchlen = s->cd->depth - s->cd->offset;
     SCLogDebug("s->co->offset (%"PRIu16") s->cd->depth (%"PRIu16")",
                s->cd->offset, s->cd->depth);
@@ -262,7 +262,7 @@ static inline int PMGetProtoInspect(
         AppLayerProtoDetectThreadCtx *tctx,
         AppLayerProtoDetectPMCtx *pm_ctx,
         MpmThreadCtx *mpm_tctx,
-        Flow *f, uint8_t *buf, uint16_t buflen,
+        Flow *f, const uint8_t *buf, uint16_t buflen,
         uint8_t direction, AppProto *pm_results, bool *rflow)
 {
     int pm_matches = 0;
@@ -316,7 +316,7 @@ static inline int PMGetProtoInspect(
  *  \param pm_results[out] AppProto array of size ALPROTO_MAX */
 static AppProto AppLayerProtoDetectPMGetProto(
         AppLayerProtoDetectThreadCtx *tctx,
-        Flow *f, uint8_t *buf, uint16_t buflen,
+        Flow *f, const uint8_t *buf, uint16_t buflen,
         uint8_t direction, AppProto *pm_results, bool *rflow)
 {
     SCEnter();
@@ -447,7 +447,7 @@ static AppProto AppLayerProtoDetectPEGetProto(Flow *f, uint8_t ipproto,
 static inline AppProto PPGetProto(
         const AppLayerProtoDetectProbingParserElement *pe,
         Flow *f, uint8_t direction,
-        uint8_t *buf, uint32_t buflen,
+        const uint8_t *buf, uint32_t buflen,
         uint32_t *alproto_masks, uint8_t *rdir
 )
 {
@@ -485,7 +485,7 @@ static inline AppProto PPGetProto(
  *
  */
 static AppProto AppLayerProtoDetectPPGetProto(Flow *f,
-        uint8_t *buf, uint32_t buflen,
+        const uint8_t *buf, uint32_t buflen,
         uint8_t ipproto, const uint8_t idir,
         bool *reverse_flow)
 {
@@ -1488,7 +1488,7 @@ static int AppLayerProtoDetectPMRegisterPattern(uint8_t ipproto, AppProto alprot
 
 AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx,
                                      Flow *f,
-                                     uint8_t *buf, uint32_t buflen,
+                                     const uint8_t *buf, uint32_t buflen,
                                      uint8_t ipproto, uint8_t direction,
                                      bool *reverse_flow)
 {
@@ -2912,7 +2912,7 @@ static int AppLayerProtoDetectPPTestData(AppLayerProtoDetectProbingParser *pp,
 }
 
 static uint16_t ProbingParserDummyForTesting(Flow *f, uint8_t direction,
-                                             uint8_t *input,
+                                             const uint8_t *input,
                                              uint32_t input_len, uint8_t *rdir)
 {
     return 0;

--- a/src/app-layer-detect-proto.h
+++ b/src/app-layer-detect-proto.h
@@ -28,7 +28,7 @@
 typedef struct AppLayerProtoDetectThreadCtx_ AppLayerProtoDetectThreadCtx;
 
 typedef AppProto (*ProbingParserFPtr)(Flow *f, uint8_t dir,
-                                      uint8_t *input, uint32_t input_len,
+                                      const uint8_t *input, uint32_t input_len,
                                       uint8_t *rdir);
 
 /***** Protocol Retrieval *****/
@@ -48,7 +48,7 @@ typedef AppProto (*ProbingParserFPtr)(Flow *f, uint8_t dir,
  */
 AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx,
                                      Flow *f,
-                                     uint8_t *buf, uint32_t buflen,
+                                     const uint8_t *buf, uint32_t buflen,
                                      uint8_t ipproto, uint8_t direction,
                                      bool *reverse_flow);
 

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -265,7 +265,7 @@ static int DNP3ContainsBanner(const uint8_t *input, uint32_t len)
  * \brief DNP3 probing parser.
  */
 static uint16_t DNP3ProbingParser(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t len,
+        const uint8_t *input, uint32_t len,
         uint8_t *rdir)
 {
     DNP3LinkHeader *hdr = (DNP3LinkHeader *)input;
@@ -1112,7 +1112,7 @@ error:
  * multiple frames, but not the complete final frame).
  */
 static int DNP3ParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
     SCEnter();
@@ -1252,7 +1252,7 @@ error:
  * See DNP3ParseResponsePDUs for DNP3 frame handling.
  */
 static int DNP3ParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
     SCEnter();

--- a/src/app-layer-dns-tcp-rust.c
+++ b/src/app-layer-dns-tcp-rust.c
@@ -35,7 +35,7 @@ static void RustDNSTCPParserRegisterTests(void);
 #endif
 
 static int RustDNSTCPParseRequest(Flow *f, void *state,
-        AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+        AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
     SCLogDebug("RustDNSTCPParseRequest");
@@ -44,7 +44,7 @@ static int RustDNSTCPParseRequest(Flow *f, void *state,
 }
 
 static int RustDNSTCPParseResponse(Flow *f, void *state,
-        AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+        AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
     SCLogDebug("RustDNSTCPParseResponse");
@@ -53,7 +53,7 @@ static int RustDNSTCPParseResponse(Flow *f, void *state,
 }
 
 static uint16_t RustDNSTCPProbe(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t len, uint8_t *rdir)
+        const uint8_t *input, uint32_t len, uint8_t *rdir)
 {
     SCLogDebug("RustDNSTCPProbe");
     if (len == 0 || len < sizeof(DNSHeader)) {

--- a/src/app-layer-dns-udp-rust.c
+++ b/src/app-layer-dns-udp-rust.c
@@ -35,7 +35,7 @@ static void RustDNSUDPParserRegisterTests(void);
 #endif
 
 static int RustDNSUDPParseRequest(Flow *f, void *state,
-        AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+        AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
     return rs_dns_parse_request(f, state, pstate, input, input_len,
@@ -43,7 +43,7 @@ static int RustDNSUDPParseRequest(Flow *f, void *state,
 }
 
 static int RustDNSUDPParseResponse(Flow *f, void *state,
-        AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+        AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
     return rs_dns_parse_response(f, state, pstate, input, input_len,
@@ -51,7 +51,7 @@ static int RustDNSUDPParseResponse(Flow *f, void *state,
 }
 
 static uint16_t DNSUDPProbe(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t len, uint8_t *rdir)
+        const uint8_t *input, uint32_t len, uint8_t *rdir)
 {
     if (len == 0 || len < sizeof(DNSHeader)) {
         return ALPROTO_UNKNOWN;

--- a/src/app-layer-enip-common.c
+++ b/src/app-layer-enip-common.c
@@ -41,7 +41,7 @@
  * @param input
  * @param offset
  */
-static int ENIPExtractUint8(uint8_t *res, uint8_t *input, uint16_t *offset, uint32_t input_len)
+static int ENIPExtractUint8(uint8_t *res, const uint8_t *input, uint16_t *offset, uint32_t input_len)
 {
 
     if (input_len < sizeof(uint8_t) || *offset > (input_len - sizeof(uint8_t)))
@@ -61,7 +61,7 @@ static int ENIPExtractUint8(uint8_t *res, uint8_t *input, uint16_t *offset, uint
  * @param input
  * @param offset
  */
-static int ENIPExtractUint16(uint16_t *res, uint8_t *input, uint16_t *offset, uint32_t input_len)
+static int ENIPExtractUint16(uint16_t *res, const uint8_t *input, uint16_t *offset, uint32_t input_len)
 {
 
     if (input_len < sizeof(uint16_t) || *offset > (input_len - sizeof(uint16_t)))
@@ -82,7 +82,7 @@ static int ENIPExtractUint16(uint16_t *res, uint8_t *input, uint16_t *offset, ui
  * @param input
  * @param offset
  */
-static int ENIPExtractUint32(uint32_t *res, uint8_t *input, uint16_t *offset, uint32_t input_len)
+static int ENIPExtractUint32(uint32_t *res, const uint8_t *input, uint16_t *offset, uint32_t input_len)
 {
 
     if (input_len < sizeof(uint32_t) || *offset > (input_len - sizeof(uint32_t)))
@@ -103,7 +103,7 @@ static int ENIPExtractUint32(uint32_t *res, uint8_t *input, uint16_t *offset, ui
  * @param input
  * @param offset
  */
-static int ENIPExtractUint64(uint64_t *res, uint8_t *input, uint16_t *offset, uint32_t input_len)
+static int ENIPExtractUint64(uint64_t *res, const uint8_t *input, uint16_t *offset, uint32_t input_len)
 {
 
     if (input_len < sizeof(uint64_t) || *offset > (input_len - sizeof(uint64_t)))
@@ -182,7 +182,7 @@ static void CIPServiceFree(void *s)
  * @return 1 Packet ok
  * @return 0 Packet has errors
  */
-int DecodeENIPPDU(uint8_t *input, uint32_t input_len,
+int DecodeENIPPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data)
 {
     int ret = 1;
@@ -283,7 +283,7 @@ int DecodeENIPPDU(uint8_t *input, uint32_t input_len,
  * @return 1 Packet ok
  * @return 0 Packet has errors
  */
-int DecodeCommonPacketFormatPDU(uint8_t *input, uint32_t input_len,
+int DecodeCommonPacketFormatPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset)
 {
 
@@ -404,7 +404,7 @@ int DecodeCommonPacketFormatPDU(uint8_t *input, uint32_t input_len,
  * @return 0 Packet has errors
  */
 
-int DecodeCIPPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset)
 {
     int ret = 1;
@@ -448,7 +448,7 @@ int DecodeCIPPDU(uint8_t *input, uint32_t input_len,
  * @return 1 Packet ok
  * @return 0 Packet has errors
  */
-int DecodeCIPRequestPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPRequestPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset)
 {
     int ret = 1;
@@ -568,7 +568,7 @@ int DecodeCIPRequestPDU(uint8_t *input, uint32_t input_len,
  * @return 1 Packet matches
  * @return 0 Packet not match
  */
-int DecodeCIPRequestPathPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPRequestPathPDU(const uint8_t *input, uint32_t input_len,
         CIPServiceEntry *node, uint16_t offset)
 {
     //SCLogDebug("DecodeCIPRequestPath: service 0x%x size %d length %d",
@@ -741,7 +741,7 @@ int DecodeCIPRequestPathPDU(uint8_t *input, uint32_t input_len,
  * @return 1 Packet ok
  * @return 0 Packet has errors
  */
-int DecodeCIPResponsePDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPResponsePDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset)
 {
     int ret = 1;
@@ -860,7 +860,7 @@ int DecodeCIPResponsePDU(uint8_t *input, uint32_t input_len,
  * @return 1 Packet ok
  * @return 0 Packet has errors
  */
-int DecodeCIPRequestMSPPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPRequestMSPPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset)
 {
     int ret = 1;
@@ -907,7 +907,7 @@ int DecodeCIPRequestMSPPDU(uint8_t *input, uint32_t input_len,
  * @return 1 Packet ok
  * @return 0 Packet has errors
  */
-int DecodeCIPResponseMSPPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPResponseMSPPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset)
 {
     int ret = 1;

--- a/src/app-layer-enip-common.h
+++ b/src/app-layer-enip-common.h
@@ -230,21 +230,21 @@ typedef struct ENIPState_
     uint8_t *buffer;
 } ENIPState;
 
-int DecodeENIPPDU(uint8_t *input, uint32_t input_len,
+int DecodeENIPPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data);
-int DecodeCommonPacketFormatPDU(uint8_t *input, uint32_t input_len,
+int DecodeCommonPacketFormatPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset);
-int DecodeCIPPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset);
-int DecodeCIPRequestPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPRequestPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset);
-int DecodeCIPResponsePDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPResponsePDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset);
-int DecodeCIPRequestPathPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPRequestPathPDU(const uint8_t *input, uint32_t input_len,
         CIPServiceEntry *node, uint16_t offset);
-int DecodeCIPRequestMSPPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPRequestMSPPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset);
-int DecodeCIPResponseMSPPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPResponseMSPPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset);
 
 #endif /* __APP_LAYER_ENIP_COMMON_H__ */

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -313,7 +313,7 @@ static void ENIPStateTransactionFree(void *state, uint64_t tx_id)
  * \retval 1 when the command is parsed, 0 otherwise
  */
 static int ENIPParse(Flow *f, void *state, AppLayerParserState *pstate,
-        uint8_t *input, uint32_t input_len, void *local_data,
+        const uint8_t *input, uint32_t input_len, void *local_data,
         const uint8_t flags)
 {
     SCEnter();
@@ -365,7 +365,7 @@ static int ENIPParse(Flow *f, void *state, AppLayerParserState *pstate,
 
 
 static uint16_t ENIPProbingParser(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t input_len, uint8_t *rdir)
+        const uint8_t *input, uint32_t input_len, uint8_t *rdir)
 {
     // SCLogDebug("ENIPProbingParser %d", input_len);
     if (input_len < sizeof(ENIPEncapHdr))

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -428,7 +428,7 @@ static int FTPGetLine(FtpState *state)
  *
  * \retval 1 when the command is parsed, 0 otherwise
  */
-static int FTPParseRequestCommand(uint8_t *input, uint32_t input_len, const FtpCommand **cmd_descriptor)
+static int FTPParseRequestCommand(const uint8_t *input, uint32_t input_len, const FtpCommand **cmd_descriptor)
 {
     SCEnter();
 
@@ -470,7 +470,7 @@ static void FtpTransferCmdFree(void *data)
     FTPFree(cmd, sizeof(struct FtpTransferCmd));
 }
 
-static uint32_t CopyCommandLine(uint8_t **dest, uint8_t *src, uint32_t length)
+static uint32_t CopyCommandLine(uint8_t **dest, const uint8_t *src, uint32_t length)
 {
     if (likely(length)) {
         uint8_t *where = FTPCalloc(length + 1, sizeof(char));
@@ -508,7 +508,7 @@ static uint16_t ftp_validate_port(int computed_port_value)
  *
  * \retval 0 if a port number could not be extracted; otherwise, the dynamic port number
  */
-static uint16_t FTPGetV6PortNumber(uint8_t *input, uint32_t input_len)
+static uint16_t FTPGetV6PortNumber(const uint8_t *input, uint32_t input_len)
 {
     uint16_t res;
 
@@ -538,7 +538,7 @@ static uint16_t FTPGetV6PortNumber(uint8_t *input, uint32_t input_len)
  *
  * \retval 0 if a port number could not be extracted; otherwise, the dynamic port number
  */
-static uint16_t FTPGetV4PortNumber(uint8_t *input, uint32_t input_len)
+static uint16_t FTPGetV4PortNumber(const uint8_t *input, uint32_t input_len)
 {
     uint16_t part1, part2;
     uint8_t *ptr = memrchr(input, ',', input_len);
@@ -566,7 +566,7 @@ static uint16_t FTPGetV4PortNumber(uint8_t *input, uint32_t input_len)
  */
 static int FTPParseRequest(Flow *f, void *ftp_state,
                            AppLayerParserState *pstate,
-                           uint8_t *input, uint32_t input_len,
+                           const uint8_t *input, uint32_t input_len,
                            void *local_data, const uint8_t flags)
 {
     SCEnter();
@@ -683,7 +683,7 @@ static int FTPParseRequest(Flow *f, void *ftp_state,
     return 1;
 }
 
-static int FTPParsePassiveResponse(Flow *f, FtpState *state, uint8_t *input, uint32_t input_len)
+static int FTPParsePassiveResponse(Flow *f, FtpState *state, const uint8_t *input, uint32_t input_len)
 {
     uint16_t dyn_port =
 #ifdef HAVE_RUST
@@ -703,7 +703,7 @@ static int FTPParsePassiveResponse(Flow *f, FtpState *state, uint8_t *input, uin
     return 0;
 }
 
-static int FTPParsePassiveResponseV6(Flow *f, FtpState *state, uint8_t *input, uint32_t input_len)
+static int FTPParsePassiveResponseV6(Flow *f, FtpState *state, const uint8_t *input, uint32_t input_len)
 {
     uint16_t dyn_port =
 #ifdef HAVE_RUST
@@ -731,7 +731,7 @@ static int FTPParsePassiveResponseV6(Flow *f, FtpState *state, uint8_t *input, u
  *                The requested action is being initiated; expect another
  *                               reply before proceeding with a new command
  */
-static inline bool FTPIsPPR(uint8_t *input, uint32_t input_len)
+static inline bool FTPIsPPR(const uint8_t *input, uint32_t input_len)
 {
     return input_len >= 4 && isdigit(input[0]) && input[0] == '1' &&
            isdigit(input[1]) && isdigit(input[2]) && isspace(input[3]);
@@ -747,7 +747,7 @@ static inline bool FTPIsPPR(uint8_t *input, uint32_t input_len)
  * \retval 1 when the command is parsed, 0 otherwise
  */
 static int FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserState *pstate,
-                            uint8_t *input, uint32_t input_len,
+                            const uint8_t *input, uint32_t input_len,
                             void *local_data, const uint8_t flags)
 {
     FtpState *state = (FtpState *)ftp_state;
@@ -1069,7 +1069,7 @@ static StreamingBufferConfig sbcfg = STREAMING_BUFFER_CONFIG_INITIALIZER;
  */
 static int FTPDataParse(Flow *f, FtpDataState *ftpdata_state,
         AppLayerParserState *pstate,
-        uint8_t *input, uint32_t input_len,
+        const uint8_t *input, uint32_t input_len,
         void *local_data, int direction)
 {
     uint16_t flags = FileFlowToFlags(f, direction);
@@ -1160,7 +1160,7 @@ static LoggerId FTPStateGetTxLogged(void *state, void *vtx)
 }
 static int FTPDataParseRequest(Flow *f, void *ftp_state,
         AppLayerParserState *pstate,
-        uint8_t *input, uint32_t input_len,
+        const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
     return FTPDataParse(f, ftp_state, pstate, input, input_len,
@@ -1169,7 +1169,7 @@ static int FTPDataParseRequest(Flow *f, void *ftp_state,
 
 static int FTPDataParseResponse(Flow *f, void *ftp_state,
         AppLayerParserState *pstate,
-        uint8_t *input, uint32_t input_len,
+        const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
     return FTPDataParse(f, ftp_state, pstate, input, input_len,

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -163,7 +163,7 @@ typedef struct FTPTransaction_  {
 
 /** FTP State for app layer parser */
 typedef struct FtpState_ {
-    uint8_t *input;
+    const uint8_t *input;
     int32_t input_len;
     uint8_t direction;
     bool active;
@@ -174,7 +174,7 @@ typedef struct FtpState_ {
 
     /* --parser details-- */
     /** current line extracted by the parser from the call to FTPGetline() */
-    uint8_t *current_line;
+    const uint8_t *current_line;
     /** length of the line in current_line.  Doesn't include the delimiter */
     uint32_t current_line_len;
     uint8_t current_line_delimiter_len;

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -763,7 +763,7 @@ error:
  */
 static int HTPHandleRequestData(Flow *f, void *htp_state,
                                 AppLayerParserState *pstate,
-                                uint8_t *input, uint32_t input_len,
+                                const uint8_t *input, uint32_t input_len,
                                 void *local_data, const uint8_t flags)
 {
     SCEnter();
@@ -826,7 +826,7 @@ error:
  */
 static int HTPHandleResponseData(Flow *f, void *htp_state,
                                  AppLayerParserState *pstate,
-                                 uint8_t *input, uint32_t input_len,
+                                 const uint8_t *input, uint32_t input_len,
                                  void *local_data, const uint8_t flags)
 {
     SCEnter();

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -418,7 +418,7 @@ static void ModbusStateTxFree(void *state, uint64_t tx_id)
  */
 static int ModbusExtractUint8(ModbusState   *modbus,
                               uint8_t       *res,
-                              uint8_t       *input,
+                              const uint8_t *input,
                               uint32_t      input_len,
                               uint16_t      *offset) {
     SCEnter();
@@ -442,7 +442,7 @@ static int ModbusExtractUint8(ModbusState   *modbus,
  */
 static int ModbusExtractUint16(ModbusState  *modbus,
                                uint16_t     *res,
-                               uint8_t      *input,
+                               const uint8_t *input,
                                uint32_t     input_len,
                                uint16_t     *offset) {
     SCEnter();
@@ -513,7 +513,7 @@ static void ModbusCheckHeader(ModbusState       *modbus,
  */
 static void ModbusExceptionResponse(ModbusTransaction   *tx,
                                     ModbusState         *modbus,
-                                    uint8_t             *input,
+                                    const uint8_t       *input,
                                     uint32_t            input_len,
                                     uint16_t            *offset)
 {
@@ -566,7 +566,7 @@ static void ModbusExceptionResponse(ModbusTransaction   *tx,
  */
 static void ModbusParseReadRequest(ModbusTransaction   *tx,
                                    ModbusState         *modbus,
-                                   uint8_t             *input,
+                                   const uint8_t       *input,
                                    uint32_t            input_len,
                                    uint16_t            *offset)
 {
@@ -619,7 +619,7 @@ end:
  */
 static void ModbusParseReadResponse(ModbusTransaction   *tx,
                                     ModbusState         *modbus,
-                                    uint8_t             *input,
+                                    const uint8_t       *input,
                                     uint32_t            input_len,
                                     uint16_t            *offset)
 {
@@ -669,7 +669,7 @@ end:
  */
 static int ModbusParseWriteRequest(ModbusTransaction   *tx,
                                    ModbusState         *modbus,
-                                   uint8_t             *input,
+                                   const uint8_t       *input,
                                    uint32_t            input_len,
                                    uint16_t            *offset)
 {
@@ -796,7 +796,7 @@ end:
  */
 static void ModbusParseWriteResponse(ModbusTransaction   *tx,
                                      ModbusState         *modbus,
-                                     uint8_t             *input,
+                                     const uint8_t       *input,
                                      uint32_t            input_len,
                                      uint16_t            *offset)
 {
@@ -895,7 +895,7 @@ end:
  */
 static int ModbusParseDiagnosticRequest(ModbusTransaction   *tx,
                                         ModbusState         *modbus,
-                                        uint8_t             *input,
+                                        const uint8_t       *input,
                                         uint32_t            input_len,
                                         uint16_t            *offset)
 {
@@ -993,7 +993,7 @@ static ModbusFunctionCodeRange modbusFunctionCodeRanges[] = {
  */
 static void ModbusParseRequestPDU(ModbusTransaction *tx,
                                   ModbusState       *modbus,
-                                  uint8_t           *input,
+                                  const uint8_t     *input,
                                   uint32_t          input_len)
 {
     SCEnter();
@@ -1150,7 +1150,7 @@ end:
  */
 static void ModbusParseResponsePDU(ModbusTransaction    *tx,
                                    ModbusState          *modbus,
-                                   uint8_t              *input,
+                                   const uint8_t        *input,
                                    uint32_t             input_len)
 {
     SCEnter();
@@ -1223,7 +1223,7 @@ end:
  */
 static int ModbusParseHeader(ModbusState   *modbus,
                              ModbusHeader  *header,
-                             uint8_t       *input,
+                             const uint8_t *input,
                              uint32_t      input_len)
 {
     SCEnter();
@@ -1270,7 +1270,7 @@ static int ModbusParseHeader(ModbusState   *modbus,
 static int ModbusParseRequest(Flow                  *f,
                               void                  *state,
                               AppLayerParserState   *pstate,
-                              uint8_t               *input,
+                              const uint8_t         *input,
                               uint32_t              input_len,
                               void                  *local_data,
                               const uint8_t         flags)
@@ -1288,7 +1288,7 @@ static int ModbusParseRequest(Flow                  *f,
 
     while (input_len > 0) {
         uint32_t    adu_len = input_len;
-        uint8_t     *adu = input;
+        const uint8_t *adu = input;
 
         /* Extract MODBUS Header */
         if (ModbusParseHeader(modbus, &header, adu, adu_len))
@@ -1335,7 +1335,7 @@ static int ModbusParseRequest(Flow                  *f,
 static int ModbusParseResponse(Flow                 *f,
                                void                 *state,
                                AppLayerParserState  *pstate,
-                               uint8_t              *input,
+                               const uint8_t        *input,
                                uint32_t             input_len,
                                void                 *local_data,
                                const uint8_t        flags)
@@ -1353,7 +1353,7 @@ static int ModbusParseResponse(Flow                 *f,
 
     while (input_len > 0) {
         uint32_t    adu_len = input_len;
-        uint8_t     *adu = input;
+        const uint8_t *adu = input;
 
         /* Extract MODBUS Header */
         if (ModbusParseHeader(modbus, &header, adu, adu_len))
@@ -1434,7 +1434,7 @@ static void ModbusStateFree(void *state)
 
 static uint16_t ModbusProbingParser(Flow *f,
                                     uint8_t direction,
-                                    uint8_t     *input,
+                                    const uint8_t *input,
                                     uint32_t    input_len,
                                     uint8_t *rdir)
 {

--- a/src/app-layer-nfs-tcp.c
+++ b/src/app-layer-nfs-tcp.c
@@ -120,7 +120,7 @@ static AppLayerDecoderEvents *NFSTCPGetEvents(void *tx)
  */
 static AppProto NFSTCPProbingParserMidstream(Flow *f,
         uint8_t direction,
-        uint8_t *input, uint32_t input_len,
+        const uint8_t *input, uint32_t input_len,
         uint8_t *rdir)
 {
     if (input_len < NFSTCP_MIN_FRAME_LEN) {
@@ -146,7 +146,7 @@ static AppProto NFSTCPProbingParserMidstream(Flow *f,
  */
 static AppProto NFSTCPProbingParser(Flow *f,
         uint8_t direction,
-        uint8_t *input, uint32_t input_len,
+        const uint8_t *input, uint32_t input_len,
         uint8_t *rdir)
 {
     if (input_len < NFSTCP_MIN_FRAME_LEN) {
@@ -165,7 +165,7 @@ static AppProto NFSTCPProbingParser(Flow *f,
 }
 
 static int NFSTCPParseRequest(Flow *f, void *state,
-    AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+    AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
     void *local_data, const uint8_t flags)
 {
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOSERVER);
@@ -181,7 +181,7 @@ static int NFSTCPParseRequest(Flow *f, void *state,
 }
 
 static int NFSTCPParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOCLIENT);

--- a/src/app-layer-nfs-udp.c
+++ b/src/app-layer-nfs-udp.c
@@ -118,7 +118,7 @@ static AppLayerDecoderEvents *NFSGetEvents(void *tx)
  *     ALPROTO_UNKNOWN.
  */
 static AppProto NFSProbingParser(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t input_len, uint8_t *rdir)
+        const uint8_t *input, uint32_t input_len, uint8_t *rdir)
 {
     SCLogDebug("probing");
     if (input_len < NFS_MIN_FRAME_LEN) {
@@ -145,7 +145,7 @@ static AppProto NFSProbingParser(Flow *f, uint8_t direction,
 }
 
 static int NFSParseRequest(Flow *f, void *state,
-    AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+    AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
     void *local_data, const uint8_t flags)
 {
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOSERVER);
@@ -155,7 +155,7 @@ static int NFSParseRequest(Flow *f, void *state,
 }
 
 static int NFSParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOCLIENT);

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1153,7 +1153,7 @@ void AppLayerParserSetTxDetectFlags(uint8_t ipproto, AppProto alproto, void *tx,
 /***** General *****/
 
 int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow *f, AppProto alproto,
-                        uint8_t flags, uint8_t *input, uint32_t input_len)
+                        uint8_t flags, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
 #ifdef DEBUG_VALIDATION

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -91,7 +91,7 @@ int AppLayerParserConfParserEnabled(const char *ipproto,
 /** \brief Prototype for parsing functions */
 typedef int (*AppLayerParserFPtr)(Flow *f, void *protocol_state,
         AppLayerParserState *pstate,
-        uint8_t *buf, uint32_t buf_len,
+        const uint8_t *buf, uint32_t buf_len,
         void *local_storage, const uint8_t flags);
 
 typedef struct AppLayerGetTxIterTuple {
@@ -229,7 +229,7 @@ void AppLayerParserSetTxDetectFlags(uint8_t ipproto, AppProto alproto, void *tx,
 /***** General *****/
 
 int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *tctx, Flow *f, AppProto alproto,
-                   uint8_t flags, uint8_t *input, uint32_t input_len);
+                   uint8_t flags, const uint8_t *input, uint32_t input_len);
 void AppLayerParserSetEOF(AppLayerParserState *pstate);
 bool AppLayerParserHasDecoderEvents(AppLayerParserState *pstate);
 int AppLayerParserIsTxAware(AppProto alproto);

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -33,7 +33,7 @@
 #define MIN_REC_SIZE 32+4 // SMB hdr + nbss hdr
 
 static int SMBTCPParseRequest(Flow *f, void *state,
-        AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+        AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
     SCLogDebug("SMBTCPParseRequest");
@@ -55,7 +55,7 @@ static int SMBTCPParseRequest(Flow *f, void *state,
 }
 
 static int SMBTCPParseResponse(Flow *f, void *state,
-        AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+        AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
     SCLogDebug("SMBTCPParseResponse");
@@ -78,7 +78,7 @@ static int SMBTCPParseResponse(Flow *f, void *state,
 }
 
 static uint16_t SMBTCPProbe(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t len, uint8_t *rdir)
+        const uint8_t *input, uint32_t len, uint8_t *rdir)
 {
     SCLogDebug("SMBTCPProbe");
 
@@ -103,7 +103,7 @@ static uint16_t SMBTCPProbe(Flow *f, uint8_t direction,
  *         back to the port numbers for a hint
  */
 static uint16_t SMB3TCPProbe(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t len, uint8_t *rdir)
+        const uint8_t *input, uint32_t len, uint8_t *rdir)
 {
     SCEnter();
 

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1315,7 +1315,7 @@ static int SMTPProcessRequest(SMTPState *state, Flow *f,
 }
 
 static int SMTPParse(int direction, Flow *f, SMTPState *state,
-                     AppLayerParserState *pstate, uint8_t *input,
+                     AppLayerParserState *pstate, const uint8_t *input,
                      uint32_t input_len,
                      SMTPThreadCtx *thread_data)
 {
@@ -1351,7 +1351,7 @@ static int SMTPParse(int direction, Flow *f, SMTPState *state,
 
 static int SMTPParseClientRecord(Flow *f, void *alstate,
                                  AppLayerParserState *pstate,
-                                 uint8_t *input, uint32_t input_len,
+                                 const uint8_t *input, uint32_t input_len,
                                  void *local_data, const uint8_t flags)
 {
     SCEnter();
@@ -1362,7 +1362,7 @@ static int SMTPParseClientRecord(Flow *f, void *alstate,
 
 static int SMTPParseServerRecord(Flow *f, void *alstate,
                                  AppLayerParserState *pstate,
-                                 uint8_t *input, uint32_t input_len,
+                                 const uint8_t *input, uint32_t input_len,
                                  void *local_data, const uint8_t flags)
 {
     SCEnter();

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -111,13 +111,13 @@ typedef struct SMTPState_ {
     uint64_t tx_cnt;
 
     /* current input that is being parsed */
-    uint8_t *input;
+    const uint8_t *input;
     int32_t input_len;
     uint8_t direction;
 
     /* --parser details-- */
     /** current line extracted by the parser from the call to SMTPGetline() */
-    uint8_t *current_line;
+    const uint8_t *current_line;
     /** length of the line in current_line.  Doesn't include the delimiter */
     int32_t current_line_len;
     uint8_t current_line_delimiter_len;

--- a/src/app-layer-ssh.c
+++ b/src/app-layer-ssh.c
@@ -208,7 +208,7 @@ static int SSHParseRecordHeader(SshState *state, SshHeader *header,
  *  \param  input       Pointer the received input data
  *  \param  input_len   Length in bytes of the received data
  */
-static int SSHParseRecord(SshState *state, SshHeader *header, uint8_t *input, uint32_t input_len)
+static int SSHParseRecord(SshState *state, SshHeader *header, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
     int ret = 0;
@@ -339,7 +339,7 @@ again:
     SCReturnInt(0);
 }
 
-static int EnoughData(uint8_t *input, uint32_t input_len)
+static int EnoughData(const uint8_t *input, uint32_t input_len)
 {
     uint32_t u;
     for (u = 0; u < input_len; u++) {
@@ -352,7 +352,7 @@ static int EnoughData(uint8_t *input, uint32_t input_len)
 #define MAX_BANNER_LEN 256
 
 static int SSHParseData(SshState *state, SshHeader *header,
-                        uint8_t *input, uint32_t input_len)
+                        const uint8_t *input, uint32_t input_len)
 {
     /* we're looking for the banner */
     if (!(header->flags & SSH_FLAG_VERSION_PARSED))
@@ -421,7 +421,7 @@ static int SSHParseData(SshState *state, SshHeader *header,
 }
 
 static int SSHParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
-                           uint8_t *input, uint32_t input_len,
+                           const uint8_t *input, uint32_t input_len,
                            void *local_data, const uint8_t flags)
 {
     SshState *ssh_state = (SshState *)state;
@@ -446,7 +446,7 @@ static int SSHParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
 }
 
 static int SSHParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
-                            uint8_t *input, uint32_t input_len,
+                            const uint8_t *input, uint32_t input_len,
                             void *local_data, const uint8_t flags)
 {
     SshState *ssh_state = (SshState *)state;

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1363,11 +1363,11 @@ end:
     return 0;
 }
 
-static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
+static int SSLv3ParseHandshakeType(SSLState *ssl_state, const uint8_t *input,
                                    uint32_t input_len, uint8_t direction)
 {
     void *ptmp;
-    uint8_t *initial_input = input;
+    const uint8_t *initial_input = input;
     uint32_t parsed = 0;
     int rc;
 
@@ -1561,10 +1561,10 @@ static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
     }
 }
 
-static int SSLv3ParseHandshakeProtocol(SSLState *ssl_state, uint8_t *input,
+static int SSLv3ParseHandshakeProtocol(SSLState *ssl_state, const uint8_t *input,
                                        uint32_t input_len, uint8_t direction)
 {
-    uint8_t *initial_input = input;
+    const uint8_t *initial_input = input;
     int retval;
 
     if (input_len == 0 || ssl_state->curr_connp->bytes_processed ==
@@ -1636,7 +1636,7 @@ static int SSLv3ParseHandshakeProtocol(SSLState *ssl_state, uint8_t *input,
  *
  * \retval The number of bytes parsed on success, 0 if nothing parsed, -1 on failure.
  */
-static int SSLv3ParseHeartbeatProtocol(SSLState *ssl_state, uint8_t *input,
+static int SSLv3ParseHeartbeatProtocol(SSLState *ssl_state, const uint8_t *input,
                                        uint32_t input_len, uint8_t direction)
 {
     uint8_t hb_type;
@@ -1750,9 +1750,9 @@ static int SSLv3ParseHeartbeatProtocol(SSLState *ssl_state, uint8_t *input,
 }
 
 static int SSLv3ParseRecord(uint8_t direction, SSLState *ssl_state,
-                            uint8_t *input, uint32_t input_len)
+                            const uint8_t *input, uint32_t input_len)
 {
-    uint8_t *initial_input = input;
+    const uint8_t *initial_input = input;
 
     if (input_len == 0) {
         return 0;
@@ -1833,9 +1833,9 @@ static int SSLv3ParseRecord(uint8_t direction, SSLState *ssl_state,
 }
 
 static int SSLv2ParseRecord(uint8_t direction, SSLState *ssl_state,
-                            uint8_t *input, uint32_t input_len)
+                            const uint8_t *input, uint32_t input_len)
 {
-    uint8_t *initial_input = input;
+    const uint8_t *initial_input = input;
 
     if (input_len == 0) {
         return 0;
@@ -1917,11 +1917,11 @@ static int SSLv2ParseRecord(uint8_t direction, SSLState *ssl_state,
 }
 
 static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
-                       AppLayerParserState *pstate, uint8_t *input,
+                       AppLayerParserState *pstate, const uint8_t *input,
                        uint32_t input_len)
 {
     int retval = 0;
-    uint8_t *initial_input = input;
+    const uint8_t *initial_input = input;
 
     if (ssl_state->curr_connp->bytes_processed == 0) {
         if (input[0] & 0x80) {
@@ -2192,7 +2192,7 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
 }
 
 static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
-                       AppLayerParserState *pstate, uint8_t *input,
+                       AppLayerParserState *pstate, const uint8_t *input,
                        uint32_t input_len)
 {
     int retval = 0;
@@ -2390,7 +2390,7 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
  * \retval >=0 On success.
  */
 static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserState *pstate,
-                     uint8_t *input, uint32_t ilen)
+                     const uint8_t *input, uint32_t ilen)
 {
     SSLState *ssl_state = (SSLState *)alstate;
     int retval = 0;
@@ -2539,14 +2539,14 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
 }
 
 static int SSLParseClientRecord(Flow *f, void *alstate, AppLayerParserState *pstate,
-                         uint8_t *input, uint32_t input_len,
+                         const uint8_t *input, uint32_t input_len,
                          void *local_data, const uint8_t flags)
 {
     return SSLDecode(f, 0 /* toserver */, alstate, pstate, input, input_len);
 }
 
 static int SSLParseServerRecord(Flow *f, void *alstate, AppLayerParserState *pstate,
-                         uint8_t *input, uint32_t input_len,
+                         const uint8_t *input, uint32_t input_len,
                          void *local_data, const uint8_t flags)
 {
     return SSLDecode(f, 1 /* toclient */, alstate, pstate, input, input_len);
@@ -2639,7 +2639,7 @@ static void SSLStateTransactionFree(void *state, uint64_t tx_id)
 }
 
 static AppProto SSLProbingParser(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t ilen, uint8_t *rdir)
+        const uint8_t *input, uint32_t ilen, uint8_t *rdir)
 {
     /* probably a rst/fin sending an eof */
     if (ilen < 3)

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -202,7 +202,7 @@ static AppLayerDecoderEvents *TemplateGetEvents(void *tx)
  *     ALPROTO_UNKNOWN.
  */
 static AppProto TemplateProbingParser(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t input_len, uint8_t *rdir)
+        const uint8_t *input, uint32_t input_len, uint8_t *rdir)
 {
     /* Very simple test - if there is input, this is template. */
     if (input_len >= TEMPLATE_MIN_FRAME_LEN) {
@@ -215,7 +215,7 @@ static AppProto TemplateProbingParser(Flow *f, uint8_t direction,
 }
 
 static int TemplateParseRequest(Flow *f, void *statev,
-    AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+    AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
     void *local_data, const uint8_t flags)
 {
     TemplateState *state = statev;
@@ -283,7 +283,7 @@ end:
 }
 
 static int TemplateParseResponse(Flow *f, void *statev, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
     TemplateState *state = statev;

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -84,7 +84,7 @@ static AppLayerDecoderEvents *TFTPGetEvents(void *tx)
  *     ALPROTO_UNKNOWN.
  */
 static AppProto TFTPProbingParser(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t input_len, uint8_t *rdir)
+        const uint8_t *input, uint32_t input_len, uint8_t *rdir)
 {
     /* Very simple test - if there is input, this is tftp.
      * Also check if it's starting by a zero */
@@ -98,7 +98,7 @@ static AppProto TFTPProbingParser(Flow *f, uint8_t direction,
 }
 
 static int TFTPParseRequest(Flow *f, void *state,
-    AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+    AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
     void *local_data, const uint8_t flags)
 {
     SCLogDebug("Parsing echo request: len=%"PRIu32, input_len);
@@ -122,7 +122,7 @@ static int TFTPParseRequest(Flow *f, void *state,
  * \brief Response parsing is not implemented
  */
 static int TFTPParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
     return 0;

--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -195,15 +195,15 @@ ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq)
             yaml_version_directive_t *ver =
                 event.data.document_start.version_directive;
             if (ver == NULL) {
-                fprintf(stderr, "ERROR: Invalid configuration file.\n\n");
-                fprintf(stderr, "The configuration file must begin with the following two lines:\n\n");
-                fprintf(stderr, "%%YAML 1.1\n---\n\n");
+                SCLogError(SC_ERR_CONF_YAML_ERROR, "ERROR: Invalid configuration file.");
+                SCLogError(SC_ERR_CONF_YAML_ERROR,
+                           "The configuration file must begin with the following two lines: %%YAML 1.1 and ---");
                 goto fail;
             }
             int major = ver->major;
             int minor = ver->minor;
             if (!(major == YAML_VERSION_MAJOR && minor == YAML_VERSION_MINOR)) {
-                fprintf(stderr, "ERROR: Invalid YAML version.  Must be 1.1\n");
+                SCLogError(SC_ERR_CONF_YAML_ERROR, "ERROR: Invalid YAML version.  Must be 1.1");
                 goto fail;
             }
         }

--- a/src/decode.c
+++ b/src/decode.c
@@ -215,7 +215,7 @@ inline int PacketCallocExtPkt(Packet *p, int datalen)
  *  \param Pointer to the data to copy
  *  \param Length of the data to copy
  */
-inline int PacketCopyDataOffset(Packet *p, uint32_t offset, uint8_t *data, uint32_t datalen)
+inline int PacketCopyDataOffset(Packet *p, uint32_t offset, const uint8_t *data, uint32_t datalen)
 {
     if (unlikely(offset + datalen > MAX_PAYLOAD_SIZE)) {
         /* too big */
@@ -256,7 +256,7 @@ inline int PacketCopyDataOffset(Packet *p, uint32_t offset, uint8_t *data, uint3
  *  \param Pointer to the data to copy
  *  \param Length of the data to copy
  */
-inline int PacketCopyData(Packet *p, uint8_t *pktdata, uint32_t pktlen)
+inline int PacketCopyData(Packet *p, const uint8_t *pktdata, uint32_t pktlen)
 {
     SET_PKT_LEN(p, (size_t)pktlen);
     return PacketCopyDataOffset(p, 0, pktdata, pktlen);
@@ -641,13 +641,14 @@ void DecodeThreadVarsFree(ThreadVars *tv, DecodeThreadVars *dtv)
  *  \param Pointer to the data
  *  \param Length of the data
  */
-inline int PacketSetData(Packet *p, uint8_t *pktdata, uint32_t pktlen)
+inline int PacketSetData(Packet *p, const uint8_t *pktdata, uint32_t pktlen)
 {
     SET_PKT_LEN(p, (size_t)pktlen);
     if (unlikely(!pktdata)) {
         return -1;
     }
-    p->ext_pkt = pktdata;
+    // ext_pkt cannot be const (because we sometimes copy)
+    p->ext_pkt = (uint8_t *) pktdata;
     p->flags |= PKT_ZERO_COPY;
 
     return 0;

--- a/src/decode.h
+++ b/src/decode.h
@@ -909,9 +909,9 @@ void PacketUpdateEngineEventCounters(ThreadVars *tv,
 void PacketFree(Packet *p);
 void PacketFreeOrRelease(Packet *p);
 int PacketCallocExtPkt(Packet *p, int datalen);
-int PacketCopyData(Packet *p, uint8_t *pktdata, uint32_t pktlen);
-int PacketSetData(Packet *p, uint8_t *pktdata, uint32_t pktlen);
-int PacketCopyDataOffset(Packet *p, uint32_t offset, uint8_t *data, uint32_t datalen);
+int PacketCopyData(Packet *p, const uint8_t *pktdata, uint32_t pktlen);
+int PacketSetData(Packet *p, const uint8_t *pktdata, uint32_t pktlen);
+int PacketCopyDataOffset(Packet *p, uint32_t offset, const uint8_t *data, uint32_t datalen);
 const char *PktSrcToString(enum PktSrcEnum pkt_src);
 void PacketBypassCallback(Packet *p);
 void PacketSwap(Packet *p);

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -210,7 +210,7 @@ static int DetectLoadSigFile(DetectEngineCtx *de_ctx, char *sig_file,
  *  \param sig_file Filename (or pattern) holding signatures
  *  \retval -1 on error
  */
-static int ProcessSigFiles(DetectEngineCtx *de_ctx, char *pattern,
+static int ProcessSigFiles(DetectEngineCtx *de_ctx, const char *pattern,
         SigFileLoaderStat *st, int *good_sigs, int *bad_sigs)
 {
     int r = 0;
@@ -269,7 +269,7 @@ static int ProcessSigFiles(DetectEngineCtx *de_ctx, char *pattern,
  *  \param sig_file_exclusive File passed in 'sig_file' should be loaded exclusively.
  *  \retval -1 on error
  */
-int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_exclusive)
+int SigLoadSignatures(DetectEngineCtx *de_ctx, const char *sig_file, int sig_file_exclusive)
 {
     SCEnter();
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1465,7 +1465,7 @@ void SigAddressPrepareBidirectionals (DetectEngineCtx *);
 
 void DisableDetectFlowFileFlags(Flow *f);
 char *DetectLoadCompleteSigPath(const DetectEngineCtx *, const char *sig_file);
-int SigLoadSignatures (DetectEngineCtx *, char *, int);
+int SigLoadSignatures (DetectEngineCtx *, const char *, int);
 void SigMatchSignatures(ThreadVars *th_v, DetectEngineCtx *de_ctx,
                        DetectEngineThreadCtx *det_ctx, Packet *p);
 

--- a/src/init.c
+++ b/src/init.c
@@ -1,0 +1,836 @@
+/* Copyright (C) 2019 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+
+#include "suricata-common.h"
+#include "app-layer-parser.h"
+#include "flow-manager.h"
+#include "tm-threads.h"
+#include "flow-timeout.h"
+#include "ippair.h"
+#include "stream-tcp.h"
+#include "defrag.h"
+#include "app-layer.h"
+#include "suricata.h"
+#include "util-signal.h"
+#include "util-misc.h"
+#include "util-pidfile.h"
+#include "util-daemon.h"
+#include "util-privs.h"
+#include "util-ioctl.h"
+#include "util-byte.h"
+#include "util-host-os-info.h"
+#include "tm-queuehandlers.h"
+#include "util-cidr.h"
+#include "util-proto-name.h"
+#include "detect-engine-tag.h"
+#include "detect-engine-threshold.h"
+#include "host-bit.h"
+#include "ippair-bit.h"
+#include "detect-engine-address.h"
+#include "detect-engine-port.h"
+#include "app-layer-htp.h"
+#include "util-magic.h"
+#include "util-decode-asn1.h"
+#include "util-coredump-config.h"
+
+#include "flow-bypass.h"
+#include "source-nfq-prototypes.h"
+#include "source-pcap-file.h"
+#include "source-pfring.h"
+#include "source-erf-file.h"
+#include "source-erf-dag.h"
+#include "source-napatech.h"
+#include "respond-reject.h"
+#include "output.h"
+#include "source-windivert-prototypes.h"
+
+#ifdef HAVE_NSS
+#include <prinit.h>
+#include <nss.h>
+#endif
+
+#ifdef HAVE_RUST
+#include "rust.h"
+#include "rust-core-gen.h"
+#endif
+
+#ifndef AFLFUZZ_NO_RANDOM
+int g_disable_randomness = 0;
+#else
+int g_disable_randomness = 1;
+#endif
+
+/** Maximum packets to simultaneously process. */
+intmax_t max_pending_packets;
+
+/** global indicating if detection is enabled */
+int g_detect_disabled = 0;
+
+/** suricata engine control flags */
+volatile uint8_t suricata_ctl_flags = 0;
+
+/** Run mode selected */
+int run_mode = RUNMODE_UNKNOWN;
+
+enum EngineMode g_engine_mode = ENGINE_MODE_IDS;
+uint8_t host_mode = SURI_HOST_IS_SNIFFER_ONLY;
+
+/*
+ * Flag to indicate if the engine is at the initialization
+ * or already processing packets. 3 stages: SURICATA_INIT,
+ * SURICATA_RUNTIME and SURICATA_FINALIZE
+ */
+SC_ATOMIC_DECLARE(unsigned int, engine_stage);
+
+int coverage_unittests;
+int g_ut_modules;
+int g_ut_covered;
+
+/** set caps or not */
+int sc_set_caps = FALSE;
+
+/** highest mtu of the interfaces we monitor */
+int g_default_mtu = 0;
+
+/*
+ * we put this here, because we only use it here in init.
+ */
+volatile sig_atomic_t sigint_count = 0;
+volatile sig_atomic_t sighup_count = 0;
+volatile sig_atomic_t sigterm_count = 0;
+volatile sig_atomic_t sigusr2_count = 0;
+
+
+/* Max packets processed simultaniously per thread. */
+#define DEFAULT_MAX_PENDING_PACKETS 1024
+
+
+/** signal handlers
+ *
+ *  WARNING: don't use the SCLog* API in the handlers. The API is complex
+ *  with memory allocation possibly happening, calls to syslog, json message
+ *  construction, etc.
+ */
+
+void SignalHandlerSigint(/*@unused@*/ int sig)
+{
+    sigint_count = 1;
+}
+void SignalHandlerSigterm(/*@unused@*/ int sig)
+{
+    sigterm_count = 1;
+}
+#ifndef OS_WIN32
+/**
+ * SIGUSR2 handler.  Just set sigusr2_count.  The main loop will act on
+ * it.
+ */
+void SignalHandlerSigusr2(int sig)
+{
+    if (sigusr2_count < 2)
+        sigusr2_count++;
+}
+
+/**
+ * SIGHUP handler.  Just set sighup_count.  The main loop will act on
+ * it.
+ */
+void SignalHandlerSigHup(/*@unused@*/ int sig)
+{
+    sighup_count = 1;
+}
+#endif
+
+/**
+ * \brief Used to indicate that the current task is done.
+ *
+ * This is mainly used by pcap-file to tell it has finished
+ * to treat a pcap files when running in unix-socket mode.
+ */
+void EngineDone(void)
+{
+    suricata_ctl_flags |= SURICATA_DONE;
+}
+
+/** \brief make sure threads can stop the engine by calling this
+ *  function. Purpose: pcap file mode needs to be able to tell the
+ *  engine the file eof is reached. */
+void EngineStop(void)
+{
+    suricata_ctl_flags |= SURICATA_STOP;
+}
+
+int EngineModeIsIPS(void)
+{
+    return (g_engine_mode == ENGINE_MODE_IPS);
+}
+
+static void SCPrintElapsedTime(struct timeval *start_time)
+{
+    if (start_time == NULL)
+        return;
+    struct timeval end_time;
+    memset(&end_time, 0, sizeof(end_time));
+    gettimeofday(&end_time, NULL);
+    uint64_t milliseconds = ((end_time.tv_sec - start_time->tv_sec) * 1000) +
+        (((1000000 + end_time.tv_usec - start_time->tv_usec) / 1000) - 1000);
+    SCLogInfo("time elapsed %.3fs", (float)milliseconds/(float)1000);
+}
+
+/* clean up / shutdown code for both the main modes and for
+ * unix socket mode.
+ *
+ * Will be run once per pcap in unix-socket mode */
+void PostRunDeinit(const int runmode, struct timeval *start_time)
+{
+    if (runmode == RUNMODE_UNIX_SOCKET)
+        return;
+
+    /* needed by FlowForceReassembly */
+    PacketPoolInit();
+
+    /* handle graceful shutdown of the flow engine, it's helper
+     * threads and the packet threads */
+    FlowDisableFlowManagerThread();
+    TmThreadDisableReceiveThreads();
+    FlowForceReassembly();
+    TmThreadDisablePacketThreads();
+    SCPrintElapsedTime(start_time);
+    FlowDisableFlowRecyclerThread();
+
+    /* kill the stats threads */
+    TmThreadKillThreadsFamily(TVT_MGMT);
+    TmThreadClearThreadsFamily(TVT_MGMT);
+
+    /* kill packet threads -- already in 'disabled' state */
+    TmThreadKillThreadsFamily(TVT_PPT);
+    TmThreadClearThreadsFamily(TVT_PPT);
+
+    PacketPoolDestroy();
+
+    /* mgt and ppt threads killed, we can run non thread-safe
+     * shutdown functions */
+    StatsReleaseResources();
+    DecodeUnregisterCounters();
+    RunModeShutDown();
+    FlowShutdown();
+    IPPairShutdown();
+    HostCleanup();
+    StreamTcpFreeConfig(STREAM_VERBOSE);
+    DefragDestroy();
+
+    TmqResetQueues();
+#ifdef PROFILING
+    if (profiling_rules_enabled)
+    SCProfilingDump();
+    SCProfilingDestroy();
+#endif
+}
+
+
+/* initialization code for both the main modes and for
+ * unix socket mode.
+ *
+ * Will be run once per pcap in unix-socket mode */
+void PreRunInit(const int runmode)
+{
+    if (runmode == RUNMODE_UNIX_SOCKET)
+        return;
+
+    StatsInit();
+#ifdef PROFILING
+    SCProfilingRulesGlobalInit();
+    SCProfilingKeywordsGlobalInit();
+    SCProfilingPrefilterGlobalInit();
+    SCProfilingSghsGlobalInit();
+    SCProfilingInit();
+#endif /* PROFILING */
+    DefragInit();
+    FlowInitConfig(FLOW_QUIET);
+    IPPairInitConfig(FLOW_QUIET);
+    StreamTcpInitConfig(STREAM_VERBOSE);
+    AppLayerParserPostStreamSetup();
+    AppLayerRegisterGlobalCounters();
+}
+
+
+/* tasks we need to run before packets start flowing,
+ * but after we dropped privs */
+void PreRunPostPrivsDropInit(const int runmode)
+{
+    if (runmode == RUNMODE_UNIX_SOCKET)
+        return;
+
+    StatsSetupPostConfigPreOutput();
+    RunModeInitializeOutputs();
+    StatsSetupPostConfigPostOutput();
+}
+
+int RunmodeGetCurrent(void)
+{
+    return run_mode;
+}
+
+int RunmodeIsUnittests(void)
+{
+    if (run_mode == RUNMODE_UNITTEST)
+        return 1;
+
+    return 0;
+}
+
+int SuriHasSigFile(void)
+{
+    return (suricata.sig_file != NULL);
+}
+
+SuricataContext context;
+
+// Global initialization common to all runmodes
+int InitGlobal() {
+#ifdef HAVE_RUST
+    context.SCLogMessage = SCLogMessage;
+    context.DetectEngineStateFree = DetectEngineStateFree;
+    context.AppLayerDecoderEventsSetEventRaw =
+    AppLayerDecoderEventsSetEventRaw;
+    context.AppLayerDecoderEventsFreeEvents = AppLayerDecoderEventsFreeEvents;
+
+    context.FileOpenFileWithId = FileOpenFileWithId;
+    context.FileCloseFileById = FileCloseFileById;
+    context.FileAppendDataById = FileAppendDataById;
+    context.FileAppendGAPById = FileAppendGAPById;
+    context.FileContainerRecycle = FileContainerRecycle;
+    context.FilePrune = FilePrune;
+    context.FileSetTx = FileContainerSetTx;
+
+    rs_init(&context);
+#endif
+
+    SC_ATOMIC_INIT(engine_stage);
+
+    /* initialize the logging subsys */
+    SCLogInitLogModule(NULL);
+
+    (void)SCSetThreadName("Suricata-Main");
+
+    /* Ignore SIGUSR2 as early as possble. We redeclare interest
+     * once we're done launching threads. The goal is to either die
+     * completely or handle any and all SIGUSR2s correctly.
+     */
+#ifndef OS_WIN32
+    UtilSignalHandlerSetup(SIGUSR2, SIG_IGN);
+    if (UtilSignalBlock(SIGUSR2)) {
+        SCLogError(SC_ERR_INITIALIZATION, "SIGUSR2 initialization error");
+        return EXIT_FAILURE;
+    }
+#endif
+
+    ParseSizeInit();
+    RunModeRegisterRunModes();
+
+    /* Initialize the configuration module. */
+    ConfInit();
+
+    return 0;
+}
+
+static int MayDaemonize(SCInstance *suri)
+{
+    if (suri->daemon == 1 && suri->pid_filename == NULL) {
+        const char *pid_filename;
+
+        if (ConfGet("pid-file", &pid_filename) == 1) {
+            SCLogInfo("Use pid file %s from config file.", pid_filename);
+        } else {
+            pid_filename = DEFAULT_PID_FILENAME;
+        }
+        /* The pid file name may be in config memory, but is needed later. */
+        suri->pid_filename = SCStrdup(pid_filename);
+        if (suri->pid_filename == NULL) {
+            SCLogError(SC_ERR_MEM_ALLOC, "strdup failed: %s", strerror(errno));
+            return TM_ECODE_FAILED;
+        }
+    }
+
+    if (suri->pid_filename != NULL && SCPidfileTestRunning(suri->pid_filename) != 0) {
+        SCFree(suri->pid_filename);
+        suri->pid_filename = NULL;
+        return TM_ECODE_FAILED;
+    }
+
+    if (suri->daemon == 1) {
+        Daemonize();
+    }
+
+    if (suri->pid_filename != NULL) {
+        if (SCPidfileCreate(suri->pid_filename) != 0) {
+            SCFree(suri->pid_filename);
+            suri->pid_filename = NULL;
+            SCLogError(SC_ERR_PIDFILE_DAEMON,
+                    "Unable to create PID file, concurrent run of"
+                    " Suricata can occur.");
+            SCLogError(SC_ERR_PIDFILE_DAEMON,
+                    "PID file creation WILL be mandatory for daemon mode"
+                    " in future version");
+        }
+    }
+
+    return TM_ECODE_OK;
+}
+
+static int InitSignalHandler(SCInstance *suri)
+{
+    /* registering signals we use */
+    UtilSignalHandlerSetup(SIGINT, SignalHandlerSigint);
+    UtilSignalHandlerSetup(SIGTERM, SignalHandlerSigterm);
+#ifndef OS_WIN32
+    UtilSignalHandlerSetup(SIGHUP, SignalHandlerSigHup);
+    UtilSignalHandlerSetup(SIGPIPE, SIG_IGN);
+    UtilSignalHandlerSetup(SIGSYS, SIG_IGN);
+
+    /* Try to get user/group to run suricata as if
+       command line as not decide of that */
+    if (suri->do_setuid == FALSE && suri->do_setgid == FALSE) {
+        const char *id;
+        if (ConfGet("run-as.user", &id) == 1) {
+            suri->do_setuid = TRUE;
+            suri->user_name = id;
+        }
+        if (ConfGet("run-as.group", &id) == 1) {
+            suri->do_setgid = TRUE;
+            suri->group_name = id;
+        }
+    }
+    /* Get the suricata user ID to given user ID */
+    if (suri->do_setuid == TRUE) {
+        if (SCGetUserID(suri->user_name, suri->group_name,
+                        &suri->userid, &suri->groupid) != 0) {
+            SCLogError(SC_ERR_UID_FAILED, "failed in getting user ID");
+            return TM_ECODE_FAILED;
+        }
+
+        sc_set_caps = TRUE;
+    /* Get the suricata group ID to given group ID */
+    } else if (suri->do_setgid == TRUE) {
+        if (SCGetGroupID(suri->group_name, &suri->groupid) != 0) {
+            SCLogError(SC_ERR_GID_FAILED, "failed in getting group ID");
+            return TM_ECODE_FAILED;
+        }
+
+        sc_set_caps = TRUE;
+    }
+#endif /* OS_WIN32 */
+
+    return TM_ECODE_OK;
+}
+
+static int ConfigGetCaptureValue(SCInstance *suri)
+{
+    /* Pull the max pending packets from the config, if not found fall
+     * back on a sane default. */
+    if (ConfGetInt("max-pending-packets", &max_pending_packets) != 1)
+        max_pending_packets = DEFAULT_MAX_PENDING_PACKETS;
+    if (max_pending_packets >= 65535) {
+        SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
+                "Maximum max-pending-packets setting is 65534. "
+                "Please check %s for errors", suri->conf_filename);
+        return TM_ECODE_FAILED;
+    }
+
+    SCLogDebug("Max pending packets set to %"PRIiMAX, max_pending_packets);
+
+    /* Pull the default packet size from the config, if not found fall
+     * back on a sane default. */
+    const char *temp_default_packet_size;
+    if ((ConfGet("default-packet-size", &temp_default_packet_size)) != 1) {
+        int mtu = 0;
+        int lthread;
+        int nlive;
+        int strip_trailing_plus = 0;
+        switch (suri->run_mode) {
+#ifdef WINDIVERT
+            case RUNMODE_WINDIVERT:
+                /* by default, WinDivert collects from all devices */
+                mtu = GetGlobalMTUWin32();
+
+                if (mtu > 0) {
+                    g_default_mtu = mtu;
+                    /* SLL_HEADER_LEN is the longest header + 8 for VLAN */
+                    default_packet_size = mtu + SLL_HEADER_LEN + 8;
+                    break;
+                }
+
+                g_default_mtu = DEFAULT_MTU;
+                default_packet_size = DEFAULT_PACKET_SIZE;
+                break;
+#endif /* WINDIVERT */
+            case RUNMODE_NETMAP:
+                /* in netmap igb0+ has a special meaning, however the
+                 * interface really is igb0 */
+                strip_trailing_plus = 1;
+                /* fall through */
+            case RUNMODE_PCAP_DEV:
+            case RUNMODE_AFP_DEV:
+            case RUNMODE_PFRING:
+                nlive = LiveGetDeviceCount();
+                for (lthread = 0; lthread < nlive; lthread++) {
+                    const char *live_dev = LiveGetDeviceName(lthread);
+                    char dev[128]; /* need to be able to support GUID names on Windows */
+                    (void)strlcpy(dev, live_dev, sizeof(dev));
+
+                    if (strip_trailing_plus) {
+                        size_t len = strlen(dev);
+                        if (len &&
+                                (dev[len-1] == '+' ||
+                                 dev[len-1] == '^' ||
+                                 dev[len-1] == '*'))
+                        {
+                            dev[len-1] = '\0';
+                        }
+                    }
+                    mtu = GetIfaceMTU(dev);
+                    g_default_mtu = MAX(mtu, g_default_mtu);
+
+                    unsigned int iface_max_packet_size = GetIfaceMaxPacketSize(dev);
+                    if (iface_max_packet_size > default_packet_size)
+                        default_packet_size = iface_max_packet_size;
+                }
+                if (default_packet_size)
+                    break;
+                /* fall through */
+            default:
+                g_default_mtu = DEFAULT_MTU;
+                default_packet_size = DEFAULT_PACKET_SIZE;
+        }
+    } else {
+        if (ParseSizeStringU32(temp_default_packet_size, &default_packet_size) < 0) {
+            SCLogError(SC_ERR_SIZE_PARSE, "Error parsing max-pending-packets "
+                       "from conf file - %s.  Killing engine",
+                       temp_default_packet_size);
+            return TM_ECODE_FAILED;
+        }
+    }
+
+    SCLogDebug("Default packet size set to %"PRIu32, default_packet_size);
+
+    return TM_ECODE_OK;
+}
+
+static int PostDeviceFinalizedSetup(SCInstance *suri)
+{
+    SCEnter();
+
+#ifdef HAVE_AF_PACKET
+    if (suri->run_mode == RUNMODE_AFP_DEV) {
+        if (AFPRunModeIsIPS()) {
+            SCLogInfo("AF_PACKET: Setting IPS mode");
+            EngineModeSetIPS();
+        }
+    }
+#endif
+#ifdef HAVE_NETMAP
+    if (suri->run_mode == RUNMODE_NETMAP) {
+        if (NetmapRunModeIsIPS()) {
+            SCLogInfo("Netmap: Setting IPS mode");
+            EngineModeSetIPS();
+        }
+    }
+#endif
+
+    SCReturnInt(TM_ECODE_OK);
+}
+
+static void PostConfLoadedSetupHostMode(void)
+{
+    const char *hostmode = NULL;
+
+    if (ConfGetValue("host-mode", &hostmode) == 1) {
+        if (!strcmp(hostmode, "router")) {
+            host_mode = SURI_HOST_IS_ROUTER;
+        } else if (!strcmp(hostmode, "sniffer-only")) {
+            host_mode = SURI_HOST_IS_SNIFFER_ONLY;
+        } else {
+            if (strcmp(hostmode, "auto") != 0) {
+                WarnInvalidConfEntry("host-mode", "%s", "auto");
+            }
+            if (EngineModeIsIPS()) {
+                host_mode = SURI_HOST_IS_ROUTER;
+            } else {
+                host_mode = SURI_HOST_IS_SNIFFER_ONLY;
+            }
+        }
+    } else {
+        if (EngineModeIsIPS()) {
+            host_mode = SURI_HOST_IS_ROUTER;
+            SCLogInfo("No 'host-mode': suricata is in IPS mode, using "
+                      "default setting 'router'");
+        } else {
+            host_mode = SURI_HOST_IS_SNIFFER_ONLY;
+            SCLogInfo("No 'host-mode': suricata is in IDS mode, using "
+                      "default setting 'sniffer-only'");
+        }
+    }
+
+}
+
+/**
+ * This function is meant to contain code that needs
+ * to be run once the configuration has been loaded.
+ */
+int PostConfLoadedSetup(SCInstance *suri)
+{
+    /* do this as early as possible #1577 #1955 */
+#ifdef HAVE_LUAJIT
+    if (LuajitSetupStatesPool() != 0) {
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+#endif
+
+    /* load the pattern matchers */
+    MpmTableSetup();
+    SpmTableSetup();
+
+    int disable_offloading;
+    if (ConfGetBool("capture.disable-offloading", &disable_offloading) == 0)
+        disable_offloading = 1;
+    if (disable_offloading) {
+        LiveSetOffloadDisable();
+    } else {
+        LiveSetOffloadWarn();
+    }
+
+    if (suri->checksum_validation == -1) {
+        const char *cv = NULL;
+        if (ConfGetValue("capture.checksum-validation", &cv) == 1) {
+            if (strcmp(cv, "none") == 0) {
+                suri->checksum_validation = 0;
+            } else if (strcmp(cv, "all") == 0) {
+                suri->checksum_validation = 1;
+            }
+        }
+    }
+    switch (suri->checksum_validation) {
+        case 0:
+            ConfSet("stream.checksum-validation", "0");
+            break;
+        case 1:
+            ConfSet("stream.checksum-validation", "1");
+            break;
+    }
+
+    if (suri->runmode_custom_mode) {
+        ConfSet("runmode", suri->runmode_custom_mode);
+    }
+
+    StorageInit();
+#ifdef HAVE_PACKET_EBPF
+    EBPFRegisterExtension();
+    LiveDevRegisterExtension();
+#endif
+    RegisterFlowBypassInfo();
+    AppLayerSetup();
+
+    /* Suricata will use this umask if provided. By default it will use the
+       umask passed on from the shell. */
+    const char *custom_umask;
+    if (ConfGet("umask", &custom_umask) == 1) {
+        uint16_t mask;
+        if (ByteExtractStringUint16(&mask, 8, strlen(custom_umask),
+                                    custom_umask) > 0) {
+            umask((mode_t)mask);
+        }
+    }
+
+    /* Check for the existance of the default logging directory which we pick
+     * from suricata.yaml.  If not found, shut the engine down */
+    suri->log_dir = ConfigGetLogDirectory();
+
+    if (ConfigCheckLogDirectory(suri->log_dir) != TM_ECODE_OK) {
+        SCLogError(SC_ERR_LOGDIR_CONFIG, "The logging directory \"%s\" "
+                "supplied by %s (default-log-dir) doesn't exist. "
+                "Shutting down the engine", suri->log_dir, suri->conf_filename);
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+
+    if (ConfigGetCaptureValue(suri) != TM_ECODE_OK) {
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+
+#ifdef NFQ
+    if (suri->run_mode == RUNMODE_NFQ)
+        NFQInitConfig(FALSE);
+#endif
+
+    /* Load the Host-OS lookup. */
+    SCHInfoLoadFromConfig();
+
+    if (suri->run_mode == RUNMODE_ENGINE_ANALYSIS) {
+        SCLogInfo("== Carrying out Engine Analysis ==");
+        const char *temp = NULL;
+        if (ConfGet("engine-analysis", &temp) == 0) {
+            SCLogInfo("no engine-analysis parameter(s) defined in conf file.  "
+                      "Please define/enable them in the conf to use this "
+                      "feature.");
+            SCReturnInt(TM_ECODE_FAILED);
+        }
+    }
+
+    /* hardcoded initialization code */
+    SigTableSetup(); /* load the rule keywords */
+    TmqhSetup();
+
+    CIDRInit();
+    SCProtoNameInit();
+
+    TagInitCtx();
+    PacketAlertTagInit();
+    ThresholdInit();
+    HostBitInitCtx();
+    IPPairBitInitCtx();
+
+    if (DetectAddressTestConfVars() < 0) {
+        SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
+                "basic address vars test failed. Please check %s for errors",
+                suri->conf_filename);
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+    if (DetectPortTestConfVars() < 0) {
+        SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
+                "basic port vars test failed. Please check %s for errors",
+                suri->conf_filename);
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+
+    RegisterAllModules();
+
+    AppLayerHtpNeedFileInspection();
+
+    StorageFinalize();
+
+    TmModuleRunInit();
+
+    if (MayDaemonize(suri) != TM_ECODE_OK)
+        SCReturnInt(TM_ECODE_FAILED);
+
+    if (InitSignalHandler(suri) != TM_ECODE_OK)
+        SCReturnInt(TM_ECODE_FAILED);
+
+
+#ifdef HAVE_NSS
+    if (suri->run_mode != RUNMODE_CONF_TEST) {
+        /* init NSS for hashing */
+        PR_Init(PR_USER_THREAD, PR_PRIORITY_NORMAL, 0);
+        NSS_NoDB_Init(NULL);
+    }
+#endif
+
+    if (suri->disabled_detect) {
+        SCLogConfig("detection engine disabled");
+        /* disable raw reassembly */
+        (void)ConfSetFinal("stream.reassembly.raw", "false");
+    }
+
+    HostInitConfig(HOST_VERBOSE);
+#ifdef HAVE_MAGIC
+    if (MagicInit() != 0)
+        SCReturnInt(TM_ECODE_FAILED);
+#endif
+    SCAsn1LoadConfig();
+
+    CoredumpLoadConfig();
+
+    DecodeGlobalConfig();
+
+    LiveDeviceFinalize();
+
+    /* set engine mode if L2 IPS */
+    if (PostDeviceFinalizedSetup(&suricata) != TM_ECODE_OK) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* hostmode depends on engine mode being set */
+    PostConfLoadedSetupHostMode();
+
+    PreRunInit(suri->run_mode);
+
+    SCReturnInt(TM_ECODE_OK);
+}
+
+void RegisterAllModules(void)
+{
+    // zero all module storage
+    memset(tmm_modules, 0, TMM_SIZE * sizeof(TmModule));
+
+    /* commanders */
+    TmModuleUnixManagerRegister();
+    /* managers */
+    TmModuleFlowManagerRegister();
+    TmModuleFlowRecyclerRegister();
+    TmModuleBypassedFlowManagerRegister();
+    /* nfq */
+    TmModuleReceiveNFQRegister();
+    TmModuleVerdictNFQRegister();
+    TmModuleDecodeNFQRegister();
+    /* ipfw */
+    TmModuleReceiveIPFWRegister();
+    TmModuleVerdictIPFWRegister();
+    TmModuleDecodeIPFWRegister();
+    /* pcap live */
+    TmModuleReceivePcapRegister();
+    TmModuleDecodePcapRegister();
+    /* pcap file */
+    TmModuleReceivePcapFileRegister();
+    TmModuleDecodePcapFileRegister();
+    /* af-packet */
+    TmModuleReceiveAFPRegister();
+    TmModuleDecodeAFPRegister();
+    /* netmap */
+    TmModuleReceiveNetmapRegister();
+    TmModuleDecodeNetmapRegister();
+    /* pfring */
+    TmModuleReceivePfringRegister();
+    TmModuleDecodePfringRegister();
+    /* dag file */
+    TmModuleReceiveErfFileRegister();
+    TmModuleDecodeErfFileRegister();
+    /* dag live */
+    TmModuleReceiveErfDagRegister();
+    TmModuleDecodeErfDagRegister();
+    /* napatech */
+    TmModuleNapatechStreamRegister();
+    TmModuleNapatechDecodeRegister();
+
+    /* flow worker */
+    TmModuleFlowWorkerRegister();
+    /* respond-reject */
+    TmModuleRespondRejectRegister();
+
+    /* log api */
+    TmModuleLoggerRegister();
+    TmModuleStatsLoggerRegister();
+
+    TmModuleDebugList();
+    /* nflog */
+    TmModuleReceiveNFLOGRegister();
+    TmModuleDecodeNFLOGRegister();
+
+    /* windivert */
+    TmModuleReceiveWinDivertRegister();
+    TmModuleVerdictWinDivertRegister();
+    TmModuleDecodeWinDivertRegister();
+}

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -50,7 +50,6 @@
 #include "util-cpu.h"
 #include "util-action.h"
 #include "util-pidfile.h"
-#include "util-ioctl.h"
 #include "util-device.h"
 #include "util-misc.h"
 #include "util-running-modes.h"
@@ -59,63 +58,39 @@
 #include "detect-parse.h"
 #include "detect-fast-pattern.h"
 #include "detect-engine-tag.h"
-#include "detect-engine-threshold.h"
-#include "detect-engine-address.h"
-#include "detect-engine-port.h"
 #include "detect-engine-mpm.h"
 
 #include "tm-queuehandlers.h"
 #include "tm-queues.h"
-#include "tm-threads.h"
 
 #include "tmqh-flow.h"
 
 #include "conf.h"
 #include "conf-yaml-loader.h"
 
-#include "stream-tcp.h"
-
 #include "source-nfq.h"
-#include "source-nfq-prototypes.h"
 
 #include "source-nflog.h"
 
 #include "source-ipfw.h"
 
 #include "source-pcap.h"
-#include "source-pcap-file.h"
-
-#include "source-pfring.h"
-
-#include "source-erf-file.h"
-#include "source-erf-dag.h"
-#include "source-napatech.h"
 
 #include "source-af-packet.h"
 #include "source-netmap.h"
 
 #include "source-windivert.h"
-#include "source-windivert-prototypes.h"
-
-#include "respond-reject.h"
 
 #include "flow.h"
-#include "flow-timeout.h"
 #include "flow-manager.h"
-#include "flow-bypass.h"
 #include "flow-var.h"
 #include "flow-bit.h"
 #include "pkt-var.h"
-#include "host-bit.h"
-
-#include "ippair.h"
-#include "ippair-bit.h"
 
 #include "host.h"
 #include "unix-manager.h"
 
 #include "app-layer.h"
-#include "app-layer-parser.h"
 #include "app-layer-htp.h"
 #include "app-layer-ssl.h"
 #include "app-layer-dns-tcp.h"
@@ -132,8 +107,6 @@
 #include "util-decode-der.h"
 #include "util-ebpf.h"
 #include "util-radix-tree.h"
-#include "util-host-os-info.h"
-#include "util-cidr.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 #include "util-time.h"
@@ -145,27 +118,19 @@
 #include "util-magic.h"
 #include "util-signal.h"
 
-#include "util-coredump-config.h"
-
 #include "util-decode-mime.h"
-
-#include "defrag.h"
 
 #include "runmodes.h"
 #include "runmode-unittests.h"
 
-#include "util-decode-asn1.h"
 #include "util-debug.h"
 #include "util-error.h"
 #include "util-daemon.h"
-#include "util-byte.h"
 #include "reputation.h"
 
 #include "output.h"
 
 #include "util-privs.h"
-
-#include "tmqh-packetpool.h"
 
 #include "util-proto-name.h"
 #include "util-mpm-hs.h"
@@ -174,78 +139,14 @@
 
 #include "util-lua.h"
 
-#ifdef HAVE_RUST
-#include "rust.h"
-#include "rust-core-gen.h"
-#endif
 
-/*
- * we put this here, because we only use it here in main.
- */
-volatile sig_atomic_t sigint_count = 0;
-volatile sig_atomic_t sighup_count = 0;
-volatile sig_atomic_t sigterm_count = 0;
-volatile sig_atomic_t sigusr2_count = 0;
-
-/*
- * Flag to indicate if the engine is at the initialization
- * or already processing packets. 3 stages: SURICATA_INIT,
- * SURICATA_RUNTIME and SURICATA_FINALIZE
- */
-SC_ATOMIC_DECLARE(unsigned int, engine_stage);
-
-/* Max packets processed simultaniously per thread. */
-#define DEFAULT_MAX_PENDING_PACKETS 1024
-
-/** suricata engine control flags */
-volatile uint8_t suricata_ctl_flags = 0;
-
-/** Run mode selected */
-int run_mode = RUNMODE_UNKNOWN;
-
-/** Engine mode: inline (ENGINE_MODE_IPS) or just
-  * detection mode (ENGINE_MODE_IDS by default) */
-static enum EngineMode g_engine_mode = ENGINE_MODE_IDS;
-
-/** Host mode: set if box is sniffing only
- * or is a router */
-uint8_t host_mode = SURI_HOST_IS_SNIFFER_ONLY;
-
-/** Maximum packets to simultaneously process. */
-intmax_t max_pending_packets;
-
-/** global indicating if detection is enabled */
-int g_detect_disabled = 0;
-
-/** set caps or not */
-int sc_set_caps = FALSE;
-
-/** highest mtu of the interfaces we monitor */
-int g_default_mtu = 0;
-
-/** disable randomness to get reproducible results accross runs */
-#ifndef AFLFUZZ_NO_RANDOM
-int g_disable_randomness = 0;
-#else
-int g_disable_randomness = 1;
-#endif
+extern intmax_t max_pending_packets;
+extern int g_detect_disabled;
 
 /** determine (without branching) if we include the vlan_ids when hashing or
-  * comparing flows */
+ * comparing flows */
 uint16_t g_vlan_mask = 0xffff;
 
-/** Suricata instance */
-SCInstance suricata;
-
-int SuriHasSigFile(void)
-{
-    return (suricata.sig_file != NULL);
-}
-
-int EngineModeIsIPS(void)
-{
-    return (g_engine_mode == ENGINE_MODE_IPS);
-}
 
 int EngineModeIsIDS(void)
 {
@@ -261,55 +162,6 @@ void EngineModeSetIDS(void)
 {
     g_engine_mode = ENGINE_MODE_IDS;
 }
-
-int RunmodeIsUnittests(void)
-{
-    if (run_mode == RUNMODE_UNITTEST)
-        return 1;
-
-    return 0;
-}
-
-int RunmodeGetCurrent(void)
-{
-    return run_mode;
-}
-
-/** signal handlers
- *
- *  WARNING: don't use the SCLog* API in the handlers. The API is complex
- *  with memory allocation possibly happening, calls to syslog, json message
- *  construction, etc.
- */
-
-static void SignalHandlerSigint(/*@unused@*/ int sig)
-{
-    sigint_count = 1;
-}
-static void SignalHandlerSigterm(/*@unused@*/ int sig)
-{
-    sigterm_count = 1;
-}
-#ifndef OS_WIN32
-/**
- * SIGUSR2 handler.  Just set sigusr2_count.  The main loop will act on
- * it.
- */
-static void SignalHandlerSigusr2(int sig)
-{
-    if (sigusr2_count < 2)
-        sigusr2_count++;
-}
-
-/**
- * SIGHUP handler.  Just set sighup_count.  The main loop will act on
- * it.
- */
-static void SignalHandlerSigHup(/*@unused@*/ int sig)
-{
-    sighup_count = 1;
-}
-#endif
 
 #ifdef DBG_MEM_ALLOC
 #ifndef _GLOBAL_MEM_
@@ -418,25 +270,6 @@ static void GlobalsDestroy(SCInstance *suri)
     SCPidfileRemove(suri->pid_filename);
     SCFree(suri->pid_filename);
     suri->pid_filename = NULL;
-}
-
-/** \brief make sure threads can stop the engine by calling this
- *  function. Purpose: pcap file mode needs to be able to tell the
- *  engine the file eof is reached. */
-void EngineStop(void)
-{
-    suricata_ctl_flags |= SURICATA_STOP;
-}
-
-/**
- * \brief Used to indicate that the current task is done.
- *
- * This is mainly used by pcap-file to tell it has finished
- * to treat a pcap files when running in unix-socket mode.
- */
-void EngineDone(void)
-{
-    suricata_ctl_flags |= SURICATA_DONE;
 }
 
 static int SetBpfString(int argc, char *argv[])
@@ -862,74 +695,6 @@ static void PrintBuildInfo(void)
 #include "build-info.h"
 }
 
-int coverage_unittests;
-int g_ut_modules;
-int g_ut_covered;
-
-void RegisterAllModules(void)
-{
-    // zero all module storage
-    memset(tmm_modules, 0, TMM_SIZE * sizeof(TmModule));
-
-    /* commanders */
-    TmModuleUnixManagerRegister();
-    /* managers */
-    TmModuleFlowManagerRegister();
-    TmModuleFlowRecyclerRegister();
-    TmModuleBypassedFlowManagerRegister();
-    /* nfq */
-    TmModuleReceiveNFQRegister();
-    TmModuleVerdictNFQRegister();
-    TmModuleDecodeNFQRegister();
-    /* ipfw */
-    TmModuleReceiveIPFWRegister();
-    TmModuleVerdictIPFWRegister();
-    TmModuleDecodeIPFWRegister();
-    /* pcap live */
-    TmModuleReceivePcapRegister();
-    TmModuleDecodePcapRegister();
-    /* pcap file */
-    TmModuleReceivePcapFileRegister();
-    TmModuleDecodePcapFileRegister();
-    /* af-packet */
-    TmModuleReceiveAFPRegister();
-    TmModuleDecodeAFPRegister();
-    /* netmap */
-    TmModuleReceiveNetmapRegister();
-    TmModuleDecodeNetmapRegister();
-    /* pfring */
-    TmModuleReceivePfringRegister();
-    TmModuleDecodePfringRegister();
-    /* dag file */
-    TmModuleReceiveErfFileRegister();
-    TmModuleDecodeErfFileRegister();
-    /* dag live */
-    TmModuleReceiveErfDagRegister();
-    TmModuleDecodeErfDagRegister();
-    /* napatech */
-    TmModuleNapatechStreamRegister();
-    TmModuleNapatechDecodeRegister();
-
-    /* flow worker */
-    TmModuleFlowWorkerRegister();
-    /* respond-reject */
-    TmModuleRespondRejectRegister();
-
-    /* log api */
-    TmModuleLoggerRegister();
-    TmModuleStatsLoggerRegister();
-
-    TmModuleDebugList();
-    /* nflog */
-    TmModuleReceiveNFLOGRegister();
-    TmModuleDecodeNFLOGRegister();
-
-    /* windivert */
-    TmModuleReceiveWinDivertRegister();
-    TmModuleVerdictWinDivertRegister();
-    TmModuleDecodeWinDivertRegister();
-}
-
 static TmEcode LoadYamlConfig(SCInstance *suri)
 {
     SCEnter();
@@ -1083,18 +848,6 @@ static void SCSetStartTime(SCInstance *suri)
 {
     memset(&suri->start_time, 0, sizeof(suri->start_time));
     gettimeofday(&suri->start_time, NULL);
-}
-
-static void SCPrintElapsedTime(struct timeval *start_time)
-{
-    if (start_time == NULL)
-        return;
-    struct timeval end_time;
-    memset(&end_time, 0, sizeof(end_time));
-    gettimeofday(&end_time, NULL);
-    uint64_t milliseconds = ((end_time.tv_sec - start_time->tv_sec) * 1000) +
-        (((1000000 + end_time.tv_usec - start_time->tv_usec) / 1000) - 1000);
-    SCLogInfo("time elapsed %.3fs", (float)milliseconds/(float)1000);
 }
 
 static int ParseCommandLineAfpacket(SCInstance *suri, const char *in_arg)
@@ -2144,183 +1897,6 @@ static int WindowsInitService(int argc, char **argv)
 }
 #endif /* OS_WIN32 */
 
-static int MayDaemonize(SCInstance *suri)
-{
-    if (suri->daemon == 1 && suri->pid_filename == NULL) {
-        const char *pid_filename;
-
-        if (ConfGet("pid-file", &pid_filename) == 1) {
-            SCLogInfo("Use pid file %s from config file.", pid_filename);
-        } else {
-            pid_filename = DEFAULT_PID_FILENAME;
-        }
-        /* The pid file name may be in config memory, but is needed later. */
-        suri->pid_filename = SCStrdup(pid_filename);
-        if (suri->pid_filename == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC, "strdup failed: %s", strerror(errno));
-            return TM_ECODE_FAILED;
-        }
-    }
-
-    if (suri->pid_filename != NULL && SCPidfileTestRunning(suri->pid_filename) != 0) {
-        SCFree(suri->pid_filename);
-        suri->pid_filename = NULL;
-        return TM_ECODE_FAILED;
-    }
-
-    if (suri->daemon == 1) {
-        Daemonize();
-    }
-
-    if (suri->pid_filename != NULL) {
-        if (SCPidfileCreate(suri->pid_filename) != 0) {
-            SCFree(suri->pid_filename);
-            suri->pid_filename = NULL;
-            SCLogError(SC_ERR_PIDFILE_DAEMON,
-                    "Unable to create PID file, concurrent run of"
-                    " Suricata can occur.");
-            SCLogError(SC_ERR_PIDFILE_DAEMON,
-                    "PID file creation WILL be mandatory for daemon mode"
-                    " in future version");
-        }
-    }
-
-    return TM_ECODE_OK;
-}
-
-static int InitSignalHandler(SCInstance *suri)
-{
-    /* registering signals we use */
-    UtilSignalHandlerSetup(SIGINT, SignalHandlerSigint);
-    UtilSignalHandlerSetup(SIGTERM, SignalHandlerSigterm);
-#ifndef OS_WIN32
-    UtilSignalHandlerSetup(SIGHUP, SignalHandlerSigHup);
-    UtilSignalHandlerSetup(SIGPIPE, SIG_IGN);
-    UtilSignalHandlerSetup(SIGSYS, SIG_IGN);
-
-    /* Try to get user/group to run suricata as if
-       command line as not decide of that */
-    if (suri->do_setuid == FALSE && suri->do_setgid == FALSE) {
-        const char *id;
-        if (ConfGet("run-as.user", &id) == 1) {
-            suri->do_setuid = TRUE;
-            suri->user_name = id;
-        }
-        if (ConfGet("run-as.group", &id) == 1) {
-            suri->do_setgid = TRUE;
-            suri->group_name = id;
-        }
-    }
-    /* Get the suricata user ID to given user ID */
-    if (suri->do_setuid == TRUE) {
-        if (SCGetUserID(suri->user_name, suri->group_name,
-                        &suri->userid, &suri->groupid) != 0) {
-            SCLogError(SC_ERR_UID_FAILED, "failed in getting user ID");
-            return TM_ECODE_FAILED;
-        }
-
-        sc_set_caps = TRUE;
-    /* Get the suricata group ID to given group ID */
-    } else if (suri->do_setgid == TRUE) {
-        if (SCGetGroupID(suri->group_name, &suri->groupid) != 0) {
-            SCLogError(SC_ERR_GID_FAILED, "failed in getting group ID");
-            return TM_ECODE_FAILED;
-        }
-
-        sc_set_caps = TRUE;
-    }
-#endif /* OS_WIN32 */
-
-    return TM_ECODE_OK;
-}
-
-/* initialization code for both the main modes and for
- * unix socket mode.
- *
- * Will be run once per pcap in unix-socket mode */
-void PreRunInit(const int runmode)
-{
-    if (runmode == RUNMODE_UNIX_SOCKET)
-        return;
-
-    StatsInit();
-#ifdef PROFILING
-    SCProfilingRulesGlobalInit();
-    SCProfilingKeywordsGlobalInit();
-    SCProfilingPrefilterGlobalInit();
-    SCProfilingSghsGlobalInit();
-    SCProfilingInit();
-#endif /* PROFILING */
-    DefragInit();
-    FlowInitConfig(FLOW_QUIET);
-    IPPairInitConfig(FLOW_QUIET);
-    StreamTcpInitConfig(STREAM_VERBOSE);
-    AppLayerParserPostStreamSetup();
-    AppLayerRegisterGlobalCounters();
-}
-
-/* tasks we need to run before packets start flowing,
- * but after we dropped privs */
-void PreRunPostPrivsDropInit(const int runmode)
-{
-    if (runmode == RUNMODE_UNIX_SOCKET)
-        return;
-
-    StatsSetupPostConfigPreOutput();
-    RunModeInitializeOutputs();
-    StatsSetupPostConfigPostOutput();
-}
-
-/* clean up / shutdown code for both the main modes and for
- * unix socket mode.
- *
- * Will be run once per pcap in unix-socket mode */
-void PostRunDeinit(const int runmode, struct timeval *start_time)
-{
-    if (runmode == RUNMODE_UNIX_SOCKET)
-        return;
-
-    /* needed by FlowForceReassembly */
-    PacketPoolInit();
-
-    /* handle graceful shutdown of the flow engine, it's helper
-     * threads and the packet threads */
-    FlowDisableFlowManagerThread();
-    TmThreadDisableReceiveThreads();
-    FlowForceReassembly();
-    TmThreadDisablePacketThreads();
-    SCPrintElapsedTime(start_time);
-    FlowDisableFlowRecyclerThread();
-
-    /* kill the stats threads */
-    TmThreadKillThreadsFamily(TVT_MGMT);
-    TmThreadClearThreadsFamily(TVT_MGMT);
-
-    /* kill packet threads -- already in 'disabled' state */
-    TmThreadKillThreadsFamily(TVT_PPT);
-    TmThreadClearThreadsFamily(TVT_PPT);
-
-    PacketPoolDestroy();
-
-    /* mgt and ppt threads killed, we can run non thread-safe
-     * shutdown functions */
-    StatsReleaseResources();
-    DecodeUnregisterCounters();
-    RunModeShutDown();
-    FlowShutdown();
-    IPPairShutdown();
-    HostCleanup();
-    StreamTcpFreeConfig(STREAM_VERBOSE);
-    DefragDestroy();
-
-    TmqResetQueues();
-#ifdef PROFILING
-    if (profiling_rules_enabled)
-        SCProfilingDump();
-    SCProfilingDestroy();
-#endif
-}
-
 
 static int StartInternalRunMode(SCInstance *suri, int argc, char **argv)
 {
@@ -2431,98 +2007,6 @@ static int LoadSignatures(DetectEngineCtx *de_ctx, SCInstance *suri)
     return TM_ECODE_OK;
 }
 
-static int ConfigGetCaptureValue(SCInstance *suri)
-{
-    /* Pull the max pending packets from the config, if not found fall
-     * back on a sane default. */
-    if (ConfGetInt("max-pending-packets", &max_pending_packets) != 1)
-        max_pending_packets = DEFAULT_MAX_PENDING_PACKETS;
-    if (max_pending_packets >= 65535) {
-        SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
-                "Maximum max-pending-packets setting is 65534. "
-                "Please check %s for errors", suri->conf_filename);
-        return TM_ECODE_FAILED;
-    }
-
-    SCLogDebug("Max pending packets set to %"PRIiMAX, max_pending_packets);
-
-    /* Pull the default packet size from the config, if not found fall
-     * back on a sane default. */
-    const char *temp_default_packet_size;
-    if ((ConfGet("default-packet-size", &temp_default_packet_size)) != 1) {
-        int mtu = 0;
-        int lthread;
-        int nlive;
-        int strip_trailing_plus = 0;
-        switch (suri->run_mode) {
-#ifdef WINDIVERT
-            case RUNMODE_WINDIVERT:
-                /* by default, WinDivert collects from all devices */
-                mtu = GetGlobalMTUWin32();
-
-                if (mtu > 0) {
-                    g_default_mtu = mtu;
-                    /* SLL_HEADER_LEN is the longest header + 8 for VLAN */
-                    default_packet_size = mtu + SLL_HEADER_LEN + 8;
-                    break;
-                }
-
-                g_default_mtu = DEFAULT_MTU;
-                default_packet_size = DEFAULT_PACKET_SIZE;
-                break;
-#endif /* WINDIVERT */
-            case RUNMODE_NETMAP:
-                /* in netmap igb0+ has a special meaning, however the
-                 * interface really is igb0 */
-                strip_trailing_plus = 1;
-                /* fall through */
-            case RUNMODE_PCAP_DEV:
-            case RUNMODE_AFP_DEV:
-            case RUNMODE_PFRING:
-                nlive = LiveGetDeviceCount();
-                for (lthread = 0; lthread < nlive; lthread++) {
-                    const char *live_dev = LiveGetDeviceName(lthread);
-                    char dev[128]; /* need to be able to support GUID names on Windows */
-                    (void)strlcpy(dev, live_dev, sizeof(dev));
-
-                    if (strip_trailing_plus) {
-                        size_t len = strlen(dev);
-                        if (len &&
-                                (dev[len-1] == '+' ||
-                                 dev[len-1] == '^' ||
-                                 dev[len-1] == '*'))
-                        {
-                            dev[len-1] = '\0';
-                        }
-                    }
-                    mtu = GetIfaceMTU(dev);
-                    g_default_mtu = MAX(mtu, g_default_mtu);
-
-                    unsigned int iface_max_packet_size = GetIfaceMaxPacketSize(dev);
-                    if (iface_max_packet_size > default_packet_size)
-                        default_packet_size = iface_max_packet_size;
-                }
-                if (default_packet_size)
-                    break;
-                /* fall through */
-            default:
-                g_default_mtu = DEFAULT_MTU;
-                default_packet_size = DEFAULT_PACKET_SIZE;
-        }
-    } else {
-        if (ParseSizeStringU32(temp_default_packet_size, &default_packet_size) < 0) {
-            SCLogError(SC_ERR_SIZE_PARSE, "Error parsing max-pending-packets "
-                       "from conf file - %s.  Killing engine",
-                       temp_default_packet_size);
-            return TM_ECODE_FAILED;
-        }
-    }
-
-    SCLogDebug("Default packet size set to %"PRIu32, default_packet_size);
-
-    return TM_ECODE_OK;
-}
-
 static void PostRunStartedDetectSetup(const SCInstance *suri)
 {
 #ifndef OS_WIN32
@@ -2586,64 +2070,6 @@ static void PostConfLoadedDetectSetup(SCInstance *suri)
         DetectEngineBumpVersion();
     }
 }
-
-static int PostDeviceFinalizedSetup(SCInstance *suri)
-{
-    SCEnter();
-
-#ifdef HAVE_AF_PACKET
-    if (suri->run_mode == RUNMODE_AFP_DEV) {
-        if (AFPRunModeIsIPS()) {
-            SCLogInfo("AF_PACKET: Setting IPS mode");
-            EngineModeSetIPS();
-        }
-    }
-#endif
-#ifdef HAVE_NETMAP
-    if (suri->run_mode == RUNMODE_NETMAP) {
-        if (NetmapRunModeIsIPS()) {
-            SCLogInfo("Netmap: Setting IPS mode");
-            EngineModeSetIPS();
-        }
-    }
-#endif
-
-    SCReturnInt(TM_ECODE_OK);
-}
-
-static void PostConfLoadedSetupHostMode(void)
-{
-    const char *hostmode = NULL;
-
-    if (ConfGetValue("host-mode", &hostmode) == 1) {
-        if (!strcmp(hostmode, "router")) {
-            host_mode = SURI_HOST_IS_ROUTER;
-        } else if (!strcmp(hostmode, "sniffer-only")) {
-            host_mode = SURI_HOST_IS_SNIFFER_ONLY;
-        } else {
-            if (strcmp(hostmode, "auto") != 0) {
-                WarnInvalidConfEntry("host-mode", "%s", "auto");
-            }
-            if (EngineModeIsIPS()) {
-                host_mode = SURI_HOST_IS_ROUTER;
-            } else {
-                host_mode = SURI_HOST_IS_SNIFFER_ONLY;
-            }
-        }
-    } else {
-        if (EngineModeIsIPS()) {
-            host_mode = SURI_HOST_IS_ROUTER;
-            SCLogInfo("No 'host-mode': suricata is in IPS mode, using "
-                      "default setting 'router'");
-        } else {
-            host_mode = SURI_HOST_IS_SNIFFER_ONLY;
-            SCLogInfo("No 'host-mode': suricata is in IDS mode, using "
-                      "default setting 'sniffer-only'");
-        }
-    }
-
-}
-
 static void SetupUserMode(SCInstance *suri)
 {
     /* apply 'user mode' config updates here */
@@ -2655,189 +2081,6 @@ static void SetupUserMode(SCInstance *suri)
             }
         }
     }
-}
-
-/**
- * This function is meant to contain code that needs
- * to be run once the configuration has been loaded.
- */
-static int PostConfLoadedSetup(SCInstance *suri)
-{
-    /* do this as early as possible #1577 #1955 */
-#ifdef HAVE_LUAJIT
-    if (LuajitSetupStatesPool() != 0) {
-        SCReturnInt(TM_ECODE_FAILED);
-    }
-#endif
-
-    /* load the pattern matchers */
-    MpmTableSetup();
-    SpmTableSetup();
-
-    int disable_offloading;
-    if (ConfGetBool("capture.disable-offloading", &disable_offloading) == 0)
-        disable_offloading = 1;
-    if (disable_offloading) {
-        LiveSetOffloadDisable();
-    } else {
-        LiveSetOffloadWarn();
-    }
-
-    if (suri->checksum_validation == -1) {
-        const char *cv = NULL;
-        if (ConfGetValue("capture.checksum-validation", &cv) == 1) {
-            if (strcmp(cv, "none") == 0) {
-                suri->checksum_validation = 0;
-            } else if (strcmp(cv, "all") == 0) {
-                suri->checksum_validation = 1;
-            }
-        }
-    }
-    switch (suri->checksum_validation) {
-        case 0:
-            ConfSet("stream.checksum-validation", "0");
-            break;
-        case 1:
-            ConfSet("stream.checksum-validation", "1");
-            break;
-    }
-
-    if (suri->runmode_custom_mode) {
-        ConfSet("runmode", suri->runmode_custom_mode);
-    }
-
-    StorageInit();
-#ifdef HAVE_PACKET_EBPF
-    EBPFRegisterExtension();
-    LiveDevRegisterExtension();
-#endif
-    RegisterFlowBypassInfo();
-    AppLayerSetup();
-
-    /* Suricata will use this umask if provided. By default it will use the
-       umask passed on from the shell. */
-    const char *custom_umask;
-    if (ConfGet("umask", &custom_umask) == 1) {
-        uint16_t mask;
-        if (ByteExtractStringUint16(&mask, 8, strlen(custom_umask),
-                                    custom_umask) > 0) {
-            umask((mode_t)mask);
-        }
-    }
-
-    /* Check for the existance of the default logging directory which we pick
-     * from suricata.yaml.  If not found, shut the engine down */
-    suri->log_dir = ConfigGetLogDirectory();
-
-    if (ConfigCheckLogDirectory(suri->log_dir) != TM_ECODE_OK) {
-        SCLogError(SC_ERR_LOGDIR_CONFIG, "The logging directory \"%s\" "
-                "supplied by %s (default-log-dir) doesn't exist. "
-                "Shutting down the engine", suri->log_dir, suri->conf_filename);
-        SCReturnInt(TM_ECODE_FAILED);
-    }
-
-    if (ConfigGetCaptureValue(suri) != TM_ECODE_OK) {
-        SCReturnInt(TM_ECODE_FAILED);
-    }
-
-#ifdef NFQ
-    if (suri->run_mode == RUNMODE_NFQ)
-        NFQInitConfig(FALSE);
-#endif
-
-    /* Load the Host-OS lookup. */
-    SCHInfoLoadFromConfig();
-
-    if (suri->run_mode == RUNMODE_ENGINE_ANALYSIS) {
-        SCLogInfo("== Carrying out Engine Analysis ==");
-        const char *temp = NULL;
-        if (ConfGet("engine-analysis", &temp) == 0) {
-            SCLogInfo("no engine-analysis parameter(s) defined in conf file.  "
-                      "Please define/enable them in the conf to use this "
-                      "feature.");
-            SCReturnInt(TM_ECODE_FAILED);
-        }
-    }
-
-    /* hardcoded initialization code */
-    SigTableSetup(); /* load the rule keywords */
-    TmqhSetup();
-
-    CIDRInit();
-    SCProtoNameInit();
-
-    TagInitCtx();
-    PacketAlertTagInit();
-    ThresholdInit();
-    HostBitInitCtx();
-    IPPairBitInitCtx();
-
-    if (DetectAddressTestConfVars() < 0) {
-        SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
-                "basic address vars test failed. Please check %s for errors",
-                suri->conf_filename);
-        SCReturnInt(TM_ECODE_FAILED);
-    }
-    if (DetectPortTestConfVars() < 0) {
-        SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
-                "basic port vars test failed. Please check %s for errors",
-                suri->conf_filename);
-        SCReturnInt(TM_ECODE_FAILED);
-    }
-
-    RegisterAllModules();
-
-    AppLayerHtpNeedFileInspection();
-
-    StorageFinalize();
-
-    TmModuleRunInit();
-
-    if (MayDaemonize(suri) != TM_ECODE_OK)
-        SCReturnInt(TM_ECODE_FAILED);
-
-    if (InitSignalHandler(suri) != TM_ECODE_OK)
-        SCReturnInt(TM_ECODE_FAILED);
-
-
-#ifdef HAVE_NSS
-    if (suri->run_mode != RUNMODE_CONF_TEST) {
-        /* init NSS for hashing */
-        PR_Init(PR_USER_THREAD, PR_PRIORITY_NORMAL, 0);
-        NSS_NoDB_Init(NULL);
-    }
-#endif
-
-    if (suri->disabled_detect) {
-        SCLogConfig("detection engine disabled");
-        /* disable raw reassembly */
-        (void)ConfSetFinal("stream.reassembly.raw", "false");
-    }
-
-    HostInitConfig(HOST_VERBOSE);
-#ifdef HAVE_MAGIC
-    if (MagicInit() != 0)
-        SCReturnInt(TM_ECODE_FAILED);
-#endif
-    SCAsn1LoadConfig();
-
-    CoredumpLoadConfig();
-
-    DecodeGlobalConfig();
-
-    LiveDeviceFinalize();
-
-    /* set engine mode if L2 IPS */
-    if (PostDeviceFinalizedSetup(&suricata) != TM_ECODE_OK) {
-        exit(EXIT_FAILURE);
-    }
-
-    /* hostmode depends on engine mode being set */
-    PostConfLoadedSetupHostMode();
-
-    PreRunInit(suri->run_mode);
-
-    SCReturnInt(TM_ECODE_OK);
 }
 
 static void SuricataMainLoop(SCInstance *suri)
@@ -2892,46 +2135,9 @@ int main(int argc, char **argv)
 {
     SCInstanceInit(&suricata, argv[0]);
 
-#ifdef HAVE_RUST
-    SuricataContext context;
-    context.SCLogMessage = SCLogMessage;
-    context.DetectEngineStateFree = DetectEngineStateFree;
-    context.AppLayerDecoderEventsSetEventRaw =
-        AppLayerDecoderEventsSetEventRaw;
-    context.AppLayerDecoderEventsFreeEvents = AppLayerDecoderEventsFreeEvents;
-
-    context.FileOpenFileWithId = FileOpenFileWithId;
-    context.FileCloseFileById = FileCloseFileById;
-    context.FileAppendDataById = FileAppendDataById;
-    context.FileAppendGAPById = FileAppendGAPById;
-    context.FileContainerRecycle = FileContainerRecycle;
-    context.FilePrune = FilePrune;
-    context.FileSetTx = FileContainerSetTx;
-
-    rs_init(&context);
-#endif
-
-    SC_ATOMIC_INIT(engine_stage);
-
-    /* initialize the logging subsys */
-    SCLogInitLogModule(NULL);
-
-    (void)SCSetThreadName("Suricata-Main");
-
-    /* Ignore SIGUSR2 as early as possble. We redeclare interest
-     * once we're done launching threads. The goal is to either die
-     * completely or handle any and all SIGUSR2s correctly.
-     */
-#ifndef OS_WIN32
-    UtilSignalHandlerSetup(SIGUSR2, SIG_IGN);
-    if (UtilSignalBlock(SIGUSR2)) {
-        SCLogError(SC_ERR_INITIALIZATION, "SIGUSR2 initialization error");
+    if (InitGlobal() != 0) {
         exit(EXIT_FAILURE);
     }
-#endif
-
-    ParseSizeInit();
-    RunModeRegisterRunModes();
 
 #ifdef OS_WIN32
     /* service initialization */
@@ -2939,9 +2145,6 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 #endif /* OS_WIN32 */
-
-    /* Initialize the configuration module. */
-    ConfInit();
 
     if (ParseCommandLine(argc, argv, &suricata) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -176,6 +176,29 @@ extern volatile uint8_t suricata_ctl_flags;
 extern int g_disable_randomness;
 extern uint16_t g_vlan_mask;
 
+/** Engine mode: inline (ENGINE_MODE_IPS) or just
+ * detection mode (ENGINE_MODE_IDS by default) */
+extern enum EngineMode g_engine_mode;
+/** Host mode: set if box is sniffing only
+ * or is a router */
+extern uint8_t host_mode;
+/** Suricata instance */
+SCInstance suricata;
+
+int InitGlobal(void);
+int PostConfLoadedSetup(SCInstance *suri);
+
+extern volatile sig_atomic_t sigint_count;
+extern volatile sig_atomic_t sighup_count;
+extern volatile sig_atomic_t sigterm_count;
+extern volatile sig_atomic_t sigusr2_count;
+void SignalHandlerSigint(int sig);
+void SignalHandlerSigterm(int sig);
+#ifndef OS_WIN32
+void SignalHandlerSigusr2(int sig);
+void SignalHandlerSigHup(int sig);
+#endif
+
 #include <ctype.h>
 #define u8_tolower(c) tolower((uint8_t)(c))
 

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -135,7 +135,7 @@ typedef struct SCInstance_ {
     enum RunModes aux_run_mode;
 
     char pcap_dev[128];
-    char *sig_file;
+    const char *sig_file;
     int sig_file_exclusive;
     char *pid_filename;
     char *regex_arg;

--- a/src/tests/fuzz/README
+++ b/src/tests/fuzz/README
@@ -1,0 +1,11 @@
+How to run fuzzing ?
+
+- install docker
+- run git clone --branch suricata --depth 1 https://github.com/catenacyber/oss-fuzz
+(we will use the original google repo once we merge this)
+- change directory into cloned repository : cd oss-fuzz
+- run python infra/helper.py build_image suricata
+- run python infra/helper.py build_fuzzers --sanitizer address suricata
+You can use undefined sanitizer (memory sanitizer does not work yet see https://github.com/google/oss-fuzz/issues/2145#issuecomment-485781098
+- run python infra/helper.py run_fuzzer suricata fuzz_siginit
+(or another fuzz target, try ls build/out/suricata/fuzz_*)

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -1,0 +1,100 @@
+/**
+ * @file
+ * @author Philippe Antoine <contact@catenacyber.fr>
+ * fuzz target for AppLayerProtoDetectGetProto
+ */
+
+
+#include "suricata-common.h"
+#include "app-layer-detect-proto.h"
+#include "flow-util.h"
+#include "app-layer-parser.h"
+
+#define HEADER_LEN 6
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+AppLayerParserThreadCtx *alp_tctx = NULL;
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    Flow * f;
+    TcpSession ssn;
+
+    if (size < HEADER_LEN) {
+        return 0;
+    }
+
+    if (alp_tctx == NULL) {
+        InitGlobal();
+        run_mode = RUNMODE_UNITTEST;
+        FlowInitConfig(FLOW_QUIET);
+        MpmTableSetup();
+        SpmTableSetup();
+        AppLayerProtoDetectSetup();
+        AppLayerParserSetup();
+        AppLayerParserRegisterProtocolParsers();
+        alp_tctx = AppLayerParserThreadCtxAlloc();
+    }
+
+    if (data[0] >= ALPROTO_MAX) {
+        return 0;
+    }
+    f = FlowAlloc();
+    if (f == NULL) {
+        return 0;
+    }
+    f->flags |= FLOW_IPV4;
+    f->src.addr_data32[0] = 0x01020304;
+    f->dst.addr_data32[0] = 0x05060708;
+    f->sp = (data[2] << 8) | data[3];
+    f->dp = (data[4] << 8) | data[5];
+    f->proto = data[1];
+    memset(&ssn, 0, sizeof(TcpSession));
+    f->protoctx = &ssn;
+    f->protomap = FlowGetProtoMapping(f->proto);
+    f->alproto = data[0];
+
+    int start = 1;
+    int flip = 0;
+    size_t offset = HEADER_LEN;
+    while (1) {
+        int done = 0;
+        uint8_t flags = 0;
+        size_t onesize = 0;
+        if (flip) {
+            flags = STREAM_TOCLIENT;
+            flip = 0;
+        } else {
+            flags = STREAM_TOSERVER;
+            flip = 1;
+        }
+        if (start > 0) {
+            flags |= STREAM_START;
+            start = 0;
+        }
+        if (size < offset + 2) {
+            onesize = 0;
+            done = 1;
+        } else {
+            onesize = ((data[offset]) << 8) | (data[offset+1]);
+            offset += 2;
+            if (size < offset + onesize) {
+                onesize = size - offset;
+                done = 1;
+            }
+        }
+        if (done) {
+            flags |= STREAM_EOF;
+        }
+
+        (void) AppLayerParserParse(NULL, alp_tctx, f, f->alproto, flags, data+offset, onesize);
+        offset += onesize;
+        if (done)
+            break;
+
+    }
+
+    FlowFree(f);
+
+    return 0;
+}

--- a/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
+++ b/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
@@ -1,0 +1,57 @@
+/**
+ * @file
+ * @author Philippe Antoine <contact@catenacyber.fr>
+ * fuzz target for AppLayerProtoDetectGetProto
+ */
+
+
+#include "suricata-common.h"
+#include "app-layer-detect-proto.h"
+#include "flow-util.h"
+#include "app-layer-parser.h"
+
+
+#define HEADER_LEN 6
+
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+AppLayerProtoDetectThreadCtx *alpd_tctx = NULL;
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    Flow f;
+    TcpSession ssn;
+    bool reverse;
+
+    if (size < HEADER_LEN) {
+        return 0;
+    }
+
+    if (alpd_tctx == NULL) {
+        //global init
+        InitGlobal();
+        run_mode = RUNMODE_UNITTEST;
+        MpmTableSetup();
+        SpmTableSetup();
+        AppLayerProtoDetectSetup();
+        AppLayerParserSetup();
+        AppLayerParserRegisterProtocolParsers();
+        alpd_tctx = AppLayerProtoDetectGetCtxThread();
+    }
+
+    memset(&f, 0, sizeof(f));
+    FLOW_INITIALIZE(&f);
+    f.flags |= FLOW_IPV4;
+    f.src.addr_data32[0] = 0x01020304;
+    f.dst.addr_data32[0] = 0x05060708;
+    f.sp = (data[2] << 8) | data[3];
+    f.dp = (data[4] << 8) | data[5];
+    f.proto = data[1];
+    memset(&ssn, 0, sizeof(TcpSession));
+    f.protoctx = &ssn;
+    f.protomap = FlowGetProtoMapping(f.proto);
+
+    AppLayerProtoDetectGetProto(alpd_tctx, &f, data+HEADER_LEN, size-HEADER_LEN, f.proto, data[0], &reverse);
+
+    return 0;
+}

--- a/src/tests/fuzz/fuzz_confyamlloadstring.c
+++ b/src/tests/fuzz/fuzz_confyamlloadstring.c
@@ -1,0 +1,29 @@
+/**
+ * @file
+ * @author Philippe Antoine <contact@catenacyber.fr>
+ * fuzz target for ConfYamlLoadString
+ */
+
+
+#include "suricata-common.h"
+#include "conf-yaml-loader.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+static int initialized = 0;
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (initialized == 0) {
+        //Redirects logs to /dev/null
+        setenv("SC_LOG_OP_IFACE", "file", 0);
+        setenv("SC_LOG_FILE", "/dev/null", 0);
+        //global init
+        InitGlobal();
+        run_mode = RUNMODE_UNITTEST;
+        initialized = 1;
+    }
+
+    ConfYamlLoadString((const char *) data, size);
+
+    return 0;
+}

--- a/src/tests/fuzz/fuzz_decodepcapfile.c
+++ b/src/tests/fuzz/fuzz_decodepcapfile.c
@@ -1,0 +1,114 @@
+/**
+ * @file
+ * @author Philippe Antoine <contact@catenacyber.fr>
+ * fuzz target for AppLayerProtoDetectGetProto
+ */
+
+
+#include <pcap/pcap.h>
+
+#include "suricata-common.h"
+#include "app-layer-detect-proto.h"
+#include "defrag.h"
+#include "tm-modules.h"
+#include "source-pcap-file.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+static int bufferToFile(const char * name, const uint8_t *Data, size_t Size) {
+    FILE * fd;
+    if (remove(name) != 0) {
+        if (errno != ENOENT) {
+            printf("failed remove, errno=%d\n", errno);
+            return -1;
+        }
+    }
+    fd = fopen(name, "wb");
+    if (fd == NULL) {
+        printf("failed open, errno=%d\n", errno);
+        return -2;
+    }
+    if (fwrite (Data, 1, Size, fd) != Size) {
+        fclose(fd);
+        return -3;
+    }
+    fclose(fd);
+    return 0;
+}
+
+static int initialized = 0;
+ThreadVars tv;
+PacketQueue pq;
+DecodeThreadVars *dtv;
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    pcap_t * pkts;
+    char errbuf[PCAP_ERRBUF_SIZE];
+    const u_char *pkt;
+    struct pcap_pkthdr *header;
+    int r;
+    Packet *p;
+
+    if (initialized == 0) {
+        //Redirects logs to /dev/null
+        setenv("SC_LOG_OP_IFACE", "file", 0);
+        setenv("SC_LOG_FILE", "/dev/null", 0);
+
+        InitGlobal();
+        run_mode = RUNMODE_UNITTEST;
+
+        //TODO put in global init ?
+        MpmTableSetup();
+        SpmTableSetup();
+        AppLayerProtoDetectSetup();
+        DefragInit();
+        FlowInitConfig(FLOW_QUIET);
+
+        //redirect logs to /tmp
+        ConfigSetLogDirectory("/tmp/");
+        //disables checksums validation for fuzzing
+        suricata.checksum_validation = 0;
+
+        TmModuleDecodePcapFileRegister();
+
+        memset(&tv, 0, sizeof(tv));
+        dtv = DecodeThreadVarsAlloc(&tv);
+        DecodeRegisterPerfCounters(dtv, &tv);
+        StatsSetupPrivate(&tv);
+        memset(&pq, 0, sizeof(pq));
+
+        initialized = 1;
+    }
+
+    //rewrite buffer to a file as libpcap does not have buffer inputs
+    if (bufferToFile("/tmp/fuzz.pcap", data, size) < 0) {
+        return 0;
+    }
+
+    //initialize structure
+    pkts = pcap_open_offline("/tmp/fuzz.pcap", errbuf);
+    if (pkts == NULL) {
+        return 0;
+    }
+
+    //loop over packets
+    r = pcap_next_ex(pkts, &header, &pkt);
+    p = PacketGetFromAlloc();
+    p->datalink = pcap_datalink(pkts);
+    while (r > 0) {
+        PacketSetData(p, pkt, header->caplen);
+        //DecodePcapFile
+        tmm_modules[TMM_DECODEPCAPFILE].Func(&tv, p, dtv, &pq, NULL);
+        Packet *extra_p = PacketDequeue(&pq);
+        while (extra_p != NULL) {
+            PacketFree(extra_p);
+            extra_p = PacketDequeue(&pq);
+        }
+        r = pcap_next_ex(pkts, &header, &pkt);
+    }
+    //close structure
+    pcap_close(pkts);
+    PacketFree(p);
+
+    return 0;
+}

--- a/src/tests/fuzz/fuzz_siginit.c
+++ b/src/tests/fuzz/fuzz_siginit.c
@@ -1,0 +1,46 @@
+/**
+ * @file
+ * @author Philippe Antoine <contact@catenacyber.fr>
+ * fuzz target for SigInit
+ */
+
+
+#include "suricata-common.h"
+#include "util-reference-config.h"
+#include "util-classification-config.h"
+#include "detect-engine.h"
+#include "detect-parse.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+DetectEngineCtx *de_ctx = NULL;
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (de_ctx == NULL) {
+        setenv("SC_LOG_OP_IFACE", "file", 0);
+        setenv("SC_LOG_FILE", "/dev/null", 0);
+        //global init
+        InitGlobal();
+        run_mode = RUNMODE_UNITTEST;
+        MpmTableSetup();
+        SpmTableSetup();
+        SigTableSetup();
+        SCReferenceConfInit();
+        SCClassConfInit();
+        de_ctx = DetectEngineCtxInit();
+    }
+
+    char * buffer = malloc(size+1);
+    if (buffer) {
+        memcpy(buffer, data, size);
+        //null terminate string
+        buffer[size] = 0;
+        Signature *s = SigInit(de_ctx, buffer);
+        free(buffer);
+        if (s != NULL) {
+            SigFree(s);
+        }
+    }
+
+    return 0;
+}

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -1,0 +1,181 @@
+/**
+ * @file
+ * @author Philippe Antoine <contact@catenacyber.fr>
+ * fuzz target for AppLayerProtoDetectGetProto
+ */
+
+
+#include <pcap/pcap.h>
+
+#include "suricata-common.h"
+#include "source-pcap-file.h"
+#include "detect-engine.h"
+#include "util-classification-config.h"
+#include "util-reference-config.h"
+#include "app-layer.h"
+#include "tm-queuehandlers.h"
+#include "util-cidr.h"
+#include "util-proto-name.h"
+#include "detect-engine-tag.h"
+#include "detect-engine-threshold.h"
+#include "host-bit.h"
+#include "ippair-bit.h"
+#include "app-layer-htp.h"
+#include "util-decode-asn1.h"
+#include "detect-fast-pattern.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+static int bufferToFile(const char * name, const uint8_t *Data, size_t Size) {
+    FILE * fd;
+    if (remove(name) != 0) {
+        if (errno != ENOENT) {
+            printf("failed remove, errno=%d\n", errno);
+            return -1;
+        }
+    }
+    fd = fopen(name, "wb");
+    if (fd == NULL) {
+        printf("failed open, errno=%d\n", errno);
+        return -2;
+    }
+    if (fwrite (Data, 1, Size, fd) != Size) {
+        fclose(fd);
+        return -3;
+    }
+    fclose(fd);
+    return 0;
+}
+
+static int initialized = 0;
+ThreadVars tv;
+PacketQueue pq;
+DecodeThreadVars *dtv;
+//FlowWorkerThreadData
+void *fwd;
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    pcap_t * pkts;
+    char errbuf[PCAP_ERRBUF_SIZE];
+    const u_char *pkt;
+    struct pcap_pkthdr *header;
+    int r;
+    Packet *p;
+    size_t pos;
+
+    if (initialized == 0) {
+        //Redirects logs to /dev/null
+        setenv("SC_LOG_OP_IFACE", "file", 0);
+        setenv("SC_LOG_FILE", "/dev/null", 0);
+
+        InitGlobal();
+
+        run_mode = RUNMODE_PCAP_FILE;
+        //redirect logs to /tmp
+        ConfigSetLogDirectory("/tmp/");
+        //disables checksums validation for fuzzing
+        suricata.checksum_validation = 0;
+        ConfSet("stream.checksum-validation", "0");
+        suricata.sig_file = "/tmp/fuzz.rules";
+        suricata.sig_file_exclusive = 1;
+        //loads rules after init
+        suricata.delayed_detect = 1;
+
+        SupportFastPatternForSigMatchTypes();
+        PostConfLoadedSetup(&suricata);
+
+        //dummy init before DetectEngineReload
+        DetectEngineCtx * de_ctx = DetectEngineCtxInit();
+        DetectEngineAddToMaster(de_ctx);
+
+        memset(&tv, 0, sizeof(tv));
+        dtv = DecodeThreadVarsAlloc(&tv);
+        DecodeRegisterPerfCounters(dtv, &tv);
+        memset(&pq, 0, sizeof(pq));
+        tmm_modules[TMM_FLOWWORKER].ThreadInit(&tv, NULL, &fwd);
+        StatsSetupPrivate(&tv);
+
+        initialized = 1;
+    }
+
+    /* TODO add yaml config
+     for (pos = 0; pos < size; pos++) {
+        if (data[pos] == 0) {
+            break;
+        }
+    }
+    if (ConfYamlLoadString(data, pos) != 0) {
+        return 0;
+    }
+    if (pos < size) {
+        //skip zero
+        pos++;
+    }
+    data += pos;
+    size -= pos;*/
+
+    for (pos=0; pos < size; pos++) {
+        if (data[pos] == 0) {
+            break;
+        }
+    }
+    if (pos > 0 && pos < size) {
+        // dump signatures to a file so as to reuse SigLoadSignatures
+        if (bufferToFile(suricata.sig_file, data, pos-1) < 0) {
+            return 0;
+        }
+    } else {
+        if (bufferToFile(suricata.sig_file, data, pos) < 0) {
+            return 0;
+        }
+    }
+
+    if (DetectEngineReload(&suricata) < 0) {
+        return 0;
+    }
+    if (pos < size) {
+        //skip zero
+        pos++;
+    }
+    data += pos;
+    size -= pos;
+
+    //rewrite buffer to a file as libpcap does not have buffer inputs
+    if (bufferToFile("/tmp/fuzz.pcap", data, size) < 0) {
+        return 0;
+    }
+
+    //initialize structure
+    pkts = pcap_open_offline("/tmp/fuzz.pcap", errbuf);
+    if (pkts == NULL) {
+        return 0;
+    }
+
+    //loop over packets
+    r = pcap_next_ex(pkts, &header, &pkt);
+    p = PacketGetFromAlloc();
+    p->datalink = pcap_datalink(pkts);
+    while (r > 0) {
+        PacketCopyData(p, pkt, header->caplen);
+        //DecodePcapFile
+        tmm_modules[TMM_DECODEPCAPFILE].Func(&tv, p, dtv, &pq, NULL);
+        //TODO tmm_modules worker
+        Packet *extra_p = PacketDequeue(&pq);
+        while (extra_p != NULL) {
+            PacketFree(extra_p);
+            extra_p = PacketDequeue(&pq);
+        }
+        tmm_modules[TMM_FLOWWORKER].Func(&tv, p, fwd, &pq, NULL);
+        extra_p = PacketDequeue(&pq);
+        while (extra_p != NULL) {
+            PacketFree(extra_p);
+            extra_p = PacketDequeue(&pq);
+        }
+        r = pcap_next_ex(pkts, &header, &pkt);
+    }
+    //close structure
+    pcap_close(pkts);
+    PacketFree(p);
+
+    return 0;
+}

--- a/src/tests/fuzz/onefile.c
+++ b/src/tests/fuzz/onefile.c
@@ -1,0 +1,51 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
+
+int main(int argc, char** argv)
+{
+    FILE * fp;
+    uint8_t *Data;
+    size_t Size;
+
+    if (argc != 2) {
+        return 1;
+    }
+    //opens the file, get its size, and reads it into a buffer
+    fp = fopen(argv[1], "rb");
+    if (fp == NULL) {
+        return 2;
+    }
+    if (fseek(fp, 0L, SEEK_END) != 0) {
+        fclose(fp);
+        return 2;
+    }
+    Size = ftell(fp);
+    if (Size == (size_t) -1) {
+        fclose(fp);
+        return 2;
+    }
+    if (fseek(fp, 0L, SEEK_SET) != 0) {
+        fclose(fp);
+        return 2;
+    }
+    Data = malloc(Size);
+    if (Data == NULL) {
+        fclose(fp);
+        return 2;
+    }
+    if (fread(Data, Size, 1, fp) != 1) {
+        fclose(fp);
+        free(Data);
+        return 2;
+    }
+
+    //lauch fuzzer
+    LLVMFuzzerTestOneInput(Data, Size);
+    free(Data);
+    fclose(fp);
+    return 0;
+}
+

--- a/src/util-conf.c
+++ b/src/util-conf.c
@@ -28,7 +28,7 @@
 #include "runmodes.h"
 #include "util-conf.h"
 
-TmEcode ConfigSetLogDirectory(char *name)
+TmEcode ConfigSetLogDirectory(const char *name)
 {
     return ConfSetFinal("default-log-dir", name) ? TM_ECODE_OK : TM_ECODE_FAILED;
 }

--- a/src/util-conf.h
+++ b/src/util-conf.h
@@ -27,7 +27,7 @@
 
 #include "conf.h"
 
-TmEcode ConfigSetLogDirectory(char *name);
+TmEcode ConfigSetLogDirectory(const char *name);
 const char *ConfigGetLogDirectory(void);
 TmEcode ConfigCheckLogDirectory(const char *log_dir);
 

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -714,7 +714,7 @@ static inline SCLogOPIfaceCtx *SCLogInitFileOPIface(const char *file,
         exit(EXIT_FAILURE);
     }
 
-    if (file == NULL || log_format == NULL) {
+    if (file == NULL) {
         goto error;
     }
 
@@ -730,7 +730,7 @@ static inline SCLogOPIfaceCtx *SCLogInitFileOPIface(const char *file,
         goto error;
     }
 
-    if ((iface_ctx->log_format = SCStrdup(log_format)) == NULL) {
+    if (log_format != NULL && (iface_ctx->log_format = SCStrdup(log_format)) == NULL) {
         goto error;
     }
 

--- a/src/util-print.c
+++ b/src/util-print.c
@@ -39,7 +39,7 @@
  *  \param buf buffer to print from
  *  \param buflen length of the input buffer
  */
-void PrintBufferRawLineHex(char *nbuf, int *offset, int max_size, uint8_t *buf, uint32_t buflen)
+void PrintBufferRawLineHex(char *nbuf, int *offset, int max_size, const uint8_t *buf, uint32_t buflen)
 {
     uint32_t u = 0;
 
@@ -58,7 +58,7 @@ void PrintBufferRawLineHex(char *nbuf, int *offset, int max_size, uint8_t *buf, 
  *  \param buf buffer to print from
  *  \param buflen length of the input buffer
  */
-void PrintRawLineHexBuf(char *retbuf, uint32_t retbuflen, uint8_t *buf, uint32_t buflen)
+void PrintRawLineHexBuf(char *retbuf, uint32_t retbuflen, const uint8_t *buf, uint32_t buflen)
 {
     uint32_t offset = 0;
     uint32_t u = 0;

--- a/src/util-print.h
+++ b/src/util-print.h
@@ -41,7 +41,7 @@
         }                                                               \
     } while (0)
 
-void PrintBufferRawLineHex(char *, int *,int, uint8_t *, uint32_t);
+void PrintBufferRawLineHex(char *, int *,int, const uint8_t *, uint32_t);
 void PrintRawUriFp(FILE *, uint8_t *, uint32_t);
 void PrintRawUriBuf(char *, uint32_t *, uint32_t,
                     uint8_t *, uint32_t);
@@ -51,7 +51,7 @@ void PrintRawDataToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32
                           const uint8_t *src_buf, uint32_t src_buf_len);
 void PrintStringsToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32_t dst_buf_size,
                           const uint8_t *src_buf, const uint32_t src_buf_len);
-void PrintRawLineHexBuf(char *, uint32_t, uint8_t *, uint32_t );
+void PrintRawLineHexBuf(char *, uint32_t, const uint8_t *, uint32_t );
 const char *PrintInet(int , const void *, char *, socklen_t);
 
 #endif /* __UTIL_PRINT_H__ */


### PR DESCRIPTION
Link to redmine ticket:
https://redmine.openinfosecfoundation.org/issues/2859

Describe changes:
- Adds six fuzz targets
- Change compilation scheme so as to compile fuzz targets (option --enable-fuzztargets for configure)

Modifies #4050 with 
- commit rewording and squashing
- long line splitting
- adding `const` keyword to `ProbingParserDummyForTesting`

Some commits can be cherry-picked independently : log, config, style
