### PR TITLE
detect: validate dsize and distance values

### DIFF
--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -379,13 +379,13 @@ _Bool DetectContentPMATCHValidateCallback(const Signature *s)
     if (!(s->flags & SIG_FLAG_DSIZE)) {
         return TRUE;
     }
-
     int max_right_edge_i = SigParseGetMaxDsize(s);
     if (max_right_edge_i < 0) {
         return TRUE;
     }
 
     uint32_t max_right_edge = (uint32_t)max_right_edge_i;
+    int content_temp_length = 0;
 
     const SigMatch *sm = s->init_data->smlists[DETECT_SM_LIST_PMATCH];
     for ( ; sm != NULL; sm = sm->next) {
@@ -393,6 +393,15 @@ _Bool DetectContentPMATCHValidateCallback(const Signature *s)
             continue;
         const DetectContentData *cd = (const DetectContentData *)sm->ctx;
         uint32_t right_edge = cd->content_len + cd->offset;
+
+        int previous_content_length;
+        int content_total_length;
+	int distance_size = cd->distance;
+
+        previous_content_length = content_temp_length;	
+	content_temp_length = cd->content_len;
+	content_total_length = previous_content_length + content_temp_length;
+        
         if (cd->content_len > max_right_edge) {
             SCLogError(SC_ERR_INVALID_SIGNATURE,
                     "signature can't match as content length %u is bigger than dsize %u.",
@@ -405,6 +414,12 @@ _Bool DetectContentPMATCHValidateCallback(const Signature *s)
                     cd->content_len, cd->offset, right_edge, max_right_edge);
             return FALSE;
         }
+	if (distance_size > (max_right_edge_i - content_total_length)) {
+	    SCLogError(SC_ERR_INVALID_SIGNATURE,
+	            "signature can't match as dsize %u, content %d, distance %d.",
+		    max_right_edge_i, content_total_length, distance_size);
+	    return FALSE;
+	}
     }
     return TRUE;
 }


### PR DESCRIPTION
Signed-off-by: jason taylor <jtfas90@gmail.com>

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- update from v2: removed initial values for content_total_length and previous_content_length (thanks @jlucovsky )
- update from v2: moved previous_content_length and content_total_length into loop (thanks @victorjulien )
- test cases https://github.com/OISF/suricata-verify/pull/104

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
https://redmine.openinfosecfoundation.org/issues/2982

