### PR TITLE
Fix SEGFAULT in HashListTableFree

### DIFF
--- a/src/util-hash.c
+++ b/src/util-hash.c
@@ -422,6 +422,19 @@ end:
     if (ht != NULL) HashTableFree(ht);
     return result;
 }
+
+static int HashTableListTestFree01 (void)
+{
+	HashListTable* ht = SCMalloc(sizeof(HashListTable));
+	memset(ht, 0, sizeof(HashListTable));
+
+	ht->array_size = 1;
+
+	//Here goes fail
+	HashListTableFree(ht);
+
+	PASS;
+}
 #endif
 
 void HashTableRegisterTests(void)
@@ -439,6 +452,9 @@ void HashTableRegisterTests(void)
 
     UtRegisterTest("HashTableTestFull01", HashTableTestFull01);
     UtRegisterTest("HashTableTestFull02", HashTableTestFull02);
+
+
+    UtRegisterTest("HashTableListTestFree01", HashTableListTestFree01);
 #endif
 }
 

--- a/src/util-hashlist.c
+++ b/src/util-hashlist.c
@@ -86,15 +86,20 @@ void HashListTableFree(HashListTable *ht)
     if (ht == NULL)
         return;
 
-    /* free the buckets */
-    for (i = 0; i < ht->array_size; i++) {
-        HashListTableBucket *hashbucket = ht->array[i];
-        while (hashbucket != NULL) {
-            HashListTableBucket *next_hashbucket = hashbucket->bucknext;
-            if (ht->Free != NULL)
-                ht->Free(hashbucket->data);
-            SCFree(hashbucket);
-            hashbucket = next_hashbucket;
+    if (ht->array)
+    {
+        /* free the buckets */
+        for (i = 0; i < ht->array_size; i++)
+        {
+            HashListTableBucket *hashbucket = ht->array[i];
+            while (hashbucket != NULL)
+            {
+                HashListTableBucket *next_hashbucket = hashbucket->bucknext;
+                if (ht->Free != NULL)
+                    ht->Free(hashbucket->data);
+                SCFree(hashbucket);
+                hashbucket = next_hashbucket;
+            }
         }
     }
 


### PR DESCRIPTION
Check HashTableListTestFree01 test

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None
Describe changes:
Sometimes when writing test for rule parsing, I've got a SEGFAUL error. After some research, I've discover problem. In [HashListTableFree](https://github.com/OISF/suricata/blob/master/src/util-hashlist.c#L82) there were no check if array exist. 

In my case, array_size were 256 and no actual array present. So loop cause SEGFAULT.

I add test HashTableListTestFree01, witch simulate that condition. If run it without changes to HashListTableFree you get same error.



[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

