### PR TITLE
cleanup: eliminate warnings/errors with debug build on macos

### DIFF
--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -459,8 +459,8 @@ static void IPOnlyCIDRListPrint(IPOnlyCIDRItem *tmphead)
 
     while (tmphead != NULL) {
         i++;
-        SCLogDebug("Item %"PRIu32" has netmask %"PRIu16" negated:"
-                   " %s; IP: %s; signum: %"PRIu16, i, tmphead->netmask,
+        SCLogDebug("Item %"PRIu32" has netmask %"PRIu8" negated:"
+                   " %s; IP: %s; signum: %"PRIu32, i, tmphead->netmask,
                    (tmphead->negated) ? "yes":"no",
                    inet_ntoa(*(struct in_addr*)&tmphead->ip[0]),
                    tmphead->signum);

--- a/src/detect-flowint.c
+++ b/src/detect-flowint.c
@@ -436,7 +436,7 @@ static void DetectFlowintPrintData(DetectFlowintData *sfd)
         return;
     }
 
-    SCLogDebug("Varname: %s, modifier: %"PRIu8", idx: %"PRIu16" Target: ",
+    SCLogDebug("Varname: %s, modifier: %"PRIu8", idx: %"PRIu32" Target: ",
                 sfd->name, sfd->modifier, sfd->idx);
     switch(sfd->targettype) {
         case FLOWINT_TARGET_VAR:

--- a/src/detect-tcpmss.c
+++ b/src/detect-tcpmss.c
@@ -183,7 +183,7 @@ static DetectTcpmssData *DetectTcpmssParse (const char *tcpmssstr)
                 tcpmssd->mode = DETECT_TCPMSS_LT;
                 tcpmssd->arg1 = (uint16_t) atoi(arg3);
 
-                SCLogDebug("tcpmss is %"PRIu8"",tcpmssd->arg1);
+                SCLogDebug("tcpmss is %"PRIu16"",tcpmssd->arg1);
                 if (strlen(arg1) > 0)
                     goto error;
 
@@ -195,7 +195,7 @@ static DetectTcpmssData *DetectTcpmssParse (const char *tcpmssstr)
                 tcpmssd->mode = DETECT_TCPMSS_GT;
                 tcpmssd->arg1 = (uint16_t) atoi(arg3);
 
-                SCLogDebug("tcpmss is %"PRIu8"",tcpmssd->arg1);
+                SCLogDebug("tcpmss is %"PRIu16"",tcpmssd->arg1);
                 if (strlen(arg1) > 0)
                     goto error;
 


### PR DESCRIPTION
This PR corrects several compilation errors that occurred when building with  `--enable-debugging` on macOS 10.14.