### PR TITLE
rust: Fix deprecation warnings

### DIFF
--- a/rust/src/applayertemplate/parser.rs
+++ b/rust/src/applayertemplate/parser.rs
@@ -24,7 +24,7 @@ fn parse_len(input: &str) -> Result<u32, std::num::ParseIntError> {
 named!(pub parse_message<String>,
        do_parse!(
            len:  map_res!(
-                 map_res!(take_until_s!(":"), std::str::from_utf8), parse_len) >>
+                 map_res!(take_until!(":"), std::str::from_utf8), parse_len) >>
            _sep: take!(1) >>
            msg:  take_str!(len) >>
                (

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -16,6 +16,9 @@
  */
 
 #![cfg_attr(feature = "strict", deny(warnings))]
+// See https://redmine.openinfosecfoundation.org/issues/3072
+// This should be removed when 1.24 is not the MSRV
+#![allow(ellipsis_inclusive_range_patterns)]
 
 #[macro_use]
 extern crate nom;


### PR DESCRIPTION
Fix the following warnings by compiler,
(1) warning: use of deprecated item 'take_until_s': Please use `take_until` instead
(2) warning: `...` range patterns are deprecated

For the second warning, the builtin lint
"ellipsis_inclusive_range_pattern" has been added which causes the
following warning to show up with rustc 1.24.

warning: unknown lint: `ellipsis_inclusive_range_patterns`
  --> /home/travis/build/OISF/suricata/suricata-5.0.0-dev/rust/src/lib.rs:18:10
   |
18 | #![allow(ellipsis_inclusive_range_patterns)]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(unknown_lints)] on by default

Since there is no other way to fix this, the above warning shall stay.
We need to take care of modifying this if and when the support for 1.24
as MSRV is dropped.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3072