### PR TITLE
detectproto: adding missing probing parsers

### DIFF
--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -1609,12 +1609,12 @@ void RegisterDNP3Parsers(void)
         if (RunmodeIsUnittests()) {
             AppLayerProtoDetectPPRegister(IPPROTO_TCP, DNP3_DEFAULT_PORT,
                 ALPROTO_DNP3, 0, sizeof(DNP3LinkHeader), STREAM_TOSERVER,
-                DNP3ProbingParser, NULL);
+                DNP3ProbingParser, DNP3ProbingParser);
         }
         else {
             if (!AppLayerProtoDetectPPParseConfPorts("tcp", IPPROTO_TCP,
                     proto_name, ALPROTO_DNP3, 0, sizeof(DNP3LinkHeader),
-                    DNP3ProbingParser, NULL)) {
+                    DNP3ProbingParser, DNP3ProbingParser)) {
 #ifndef AFLFUZZ_APPLAYER
                 return;
 #endif

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1482,14 +1482,14 @@ void RegisterModbusParsers(void)
                                           ALPROTO_MODBUS,
                                           0, sizeof(ModbusHeader),
                                           STREAM_TOSERVER,
-                                          ModbusProbingParser, NULL);
+                                          ModbusProbingParser, ModbusProbingParser);
         } else {
             /* If there is no app-layer section for Modbus, silently
              * leave it disabled. */
             if (!AppLayerProtoDetectPPParseConfPorts("tcp", IPPROTO_TCP,
                                                 proto_name, ALPROTO_MODBUS,
                                                 0, sizeof(ModbusHeader),
-                                                ModbusProbingParser, NULL)) {
+                                                ModbusProbingParser, ModbusProbingParser)) {
 #ifndef AFLFUZZ_APPLAYER
                 return;
 #endif

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -273,7 +273,7 @@ void RegisterSMBParsers(void)
         if (RunmodeIsUnittests()) {
             AppLayerProtoDetectPPRegister(IPPROTO_TCP, "445", ALPROTO_SMB, 0,
                     MIN_REC_SIZE, STREAM_TOSERVER, SMBTCPProbe,
-                    NULL);
+                    SMBTCPProbe);
         } else {
             int have_cfg = AppLayerProtoDetectPPParseConfPorts("tcp",
                     IPPROTO_TCP, proto_name, ALPROTO_SMB, 0,

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -472,21 +472,21 @@ void RegisterTemplateParsers(void)
             SCLogNotice("Unittest mode, registeringd default configuration.");
             AppLayerProtoDetectPPRegister(IPPROTO_TCP, TEMPLATE_DEFAULT_PORT,
                 ALPROTO_TEMPLATE, 0, TEMPLATE_MIN_FRAME_LEN, STREAM_TOSERVER,
-                TemplateProbingParser, NULL);
+                TemplateProbingParser, TemplateProbingParser);
 
         }
         else {
 
             if (!AppLayerProtoDetectPPParseConfPorts("tcp", IPPROTO_TCP,
                     proto_name, ALPROTO_TEMPLATE, 0, TEMPLATE_MIN_FRAME_LEN,
-                    TemplateProbingParser, NULL)) {
+                    TemplateProbingParser, TemplateProbingParser)) {
                 SCLogNotice("No template app-layer configuration, enabling echo"
                     " detection TCP detection on port %s.",
                     TEMPLATE_DEFAULT_PORT);
                 AppLayerProtoDetectPPRegister(IPPROTO_TCP,
                     TEMPLATE_DEFAULT_PORT, ALPROTO_TEMPLATE, 0,
                     TEMPLATE_MIN_FRAME_LEN, STREAM_TOSERVER,
-                    TemplateProbingParser, NULL);
+                    TemplateProbingParser, TemplateProbingParser);
             }
 
         }

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -203,12 +203,12 @@ void RegisterTFTPParsers(void)
             AppLayerProtoDetectPPRegister(IPPROTO_UDP, TFTP_DEFAULT_PORT,
                                           ALPROTO_TFTP, 0, TFTP_MIN_FRAME_LEN,
                                           STREAM_TOSERVER, TFTPProbingParser,
-                                          NULL);
+                                          TFTPProbingParser);
         } else {
             if (!AppLayerProtoDetectPPParseConfPorts("udp", IPPROTO_UDP,
                                                      proto_name, ALPROTO_TFTP,
                                                      0, TFTP_MIN_FRAME_LEN,
-                                                     TFTPProbingParser, NULL)) {
+                                                     TFTPProbingParser, TFTPProbingParser)) {
                 SCLogDebug("No echo app-layer configuration, enabling echo"
                            " detection UDP detection on port %s.",
                            TFTP_DEFAULT_PORT);
@@ -216,7 +216,7 @@ void RegisterTFTPParsers(void)
                                               TFTP_DEFAULT_PORT, ALPROTO_TFTP,
                                               0, TFTP_MIN_FRAME_LEN,
                                               STREAM_TOSERVER,TFTPProbingParser,
-                                              NULL);
+                                              TFTPProbingParser);
             }
         }
     } else {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2757

Describe changes:
- Adds missing probing parser in `TOCLIENT` direction

These are for symmetric protocols (at least symmetric enough for the header where the probing parsers stay)

app-layer-template.c is also modified not to have zero `TOCLIENT` probing parsers 
- Should we leave a comment that every protocol is not symmetric ? (For instance DNP3 is symmetric and HTTP is not)
- Or should we have `TemplateProbingParserTs` and `TemplateProbingParserTc` ?
