### PR TITLE
signature: avoids overflow from VariableNameHash

### DIFF
--- a/src/util-var-name.c
+++ b/src/util-var-name.c
@@ -65,6 +65,9 @@ typedef struct VariableName_ {
     uint32_t idx;
 } VariableName;
 
+#define VARNAME_HASHSIZE 0x1000
+#define VARID_HASHSIZE 0x1000
+
 static uint32_t VariableNameHash(HashListTable *ht, void *buf, uint16_t buflen)
 {
      VariableName *fn = (VariableName *)buf;
@@ -75,7 +78,7 @@ static uint32_t VariableNameHash(HashListTable *ht, void *buf, uint16_t buflen)
          hash += fn->name[u];
      }
 
-     return hash;
+     return (hash % VARNAME_HASHSIZE);
 }
 
 static char VariableNameCompare(void *buf1, uint16_t len1, void *buf2, uint16_t len2)
@@ -96,7 +99,7 @@ static uint32_t VariableIdxHash(HashListTable *ht, void *buf, uint16_t buflen)
 {
     VariableName *fn = (VariableName *)buf;
     uint32_t hash = fn->idx + fn->type;
-    return hash;
+    return (hash % VARID_HASHSIZE);
 }
 
 static char VariableIdxCompare(void *buf1, uint16_t len1, void *buf2, uint16_t len2)
@@ -136,13 +139,13 @@ static VarNameStore *VarNameStoreInit(void)
     if (v == NULL)
         return NULL;
 
-    v->names = HashListTableInit(4096, VariableNameHash, VariableNameCompare, VariableNameFree);
+    v->names = HashListTableInit(VARNAME_HASHSIZE, VariableNameHash, VariableNameCompare, VariableNameFree);
     if (v->names == NULL) {
         SCFree(v);
         return NULL;
     }
 
-    v->ids = HashListTableInit(4096, VariableIdxHash, VariableIdxCompare, NULL);
+    v->ids = HashListTableInit(VARID_HASHSIZE, VariableIdxHash, VariableIdxCompare, NULL);
     if (v->ids == NULL) {
         HashListTableFree(v->names);
         SCFree(v);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Avoids a read heap buffer overflow due to `VariableNameHash` not limiting its hash size

Found by fuzzing `SigInit`

Modifies #4083 by changing `VariableIdxHash` the same way

Stack trace is following
=================================================================
==12==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x62d000030400 at pc 0x000000ae8bc6 bp 0x7ffd627f4a30 sp 0x7ffd627f4a28
READ of size 8 at 0x62d000030400 thread T0 (Suricata-Main)
SCARINESS: 23 (8-byte-read-heap-buffer-overflow)
    #0 0xae8bc5 in HashListTableAdd /src/suricata/src/util-hashlist.c:135:9
    #1 0xb9f0d5 in VariableNameGetIdx /src/suricata/src/util-var-name.c:193:9
    #2 0xb9ed4f in VarNameStoreSetupAdd /src/suricata/src/util-var-name.c:324:10
    #3 0x7e7f27 in DetectFlowbitSetup /src/suricata/src/detect-flowbits.c:249:15
    #4 0x855dad in SigParseOptions /src/suricata/src/detect-parse.c:742:13
    #5 0x84df20 in SigParse /src/suricata/src/detect-parse.c:1174:19
    #6 0x84a55a in SigInitHelper /src/suricata/src/detect-parse.c:1798:9
    #7 0x849fbe in SigInit /src/suricata/src/detect-parse.c:1944:16