### PR TITLE
detectproto: adding missing probing parsers

### DIFF
--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -1609,12 +1609,12 @@ void RegisterDNP3Parsers(void)
         if (RunmodeIsUnittests()) {
             AppLayerProtoDetectPPRegister(IPPROTO_TCP, DNP3_DEFAULT_PORT,
                 ALPROTO_DNP3, 0, sizeof(DNP3LinkHeader), STREAM_TOSERVER,
-                DNP3ProbingParser, NULL);
+                DNP3ProbingParser, DNP3ProbingParser);
         }
         else {
             if (!AppLayerProtoDetectPPParseConfPorts("tcp", IPPROTO_TCP,
                     proto_name, ALPROTO_DNP3, 0, sizeof(DNP3LinkHeader),
-                    DNP3ProbingParser, NULL)) {
+                    DNP3ProbingParser, DNP3ProbingParser)) {
 #ifndef AFLFUZZ_APPLAYER
                 return;
 #endif

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1482,14 +1482,14 @@ void RegisterModbusParsers(void)
                                           ALPROTO_MODBUS,
                                           0, sizeof(ModbusHeader),
                                           STREAM_TOSERVER,
-                                          ModbusProbingParser, NULL);
+                                          ModbusProbingParser, ModbusProbingParser);
         } else {
             /* If there is no app-layer section for Modbus, silently
              * leave it disabled. */
             if (!AppLayerProtoDetectPPParseConfPorts("tcp", IPPROTO_TCP,
                                                 proto_name, ALPROTO_MODBUS,
                                                 0, sizeof(ModbusHeader),
-                                                ModbusProbingParser, NULL)) {
+                                                ModbusProbingParser, ModbusProbingParser)) {
 #ifndef AFLFUZZ_APPLAYER
                 return;
 #endif

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -273,7 +273,7 @@ void RegisterSMBParsers(void)
         if (RunmodeIsUnittests()) {
             AppLayerProtoDetectPPRegister(IPPROTO_TCP, "445", ALPROTO_SMB, 0,
                     MIN_REC_SIZE, STREAM_TOSERVER, SMBTCPProbe,
-                    NULL);
+                    SMBTCPProbe);
         } else {
             int have_cfg = AppLayerProtoDetectPPParseConfPorts("tcp",
                     IPPROTO_TCP, proto_name, ALPROTO_SMB, 0,

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -203,12 +203,12 @@ void RegisterTFTPParsers(void)
             AppLayerProtoDetectPPRegister(IPPROTO_UDP, TFTP_DEFAULT_PORT,
                                           ALPROTO_TFTP, 0, TFTP_MIN_FRAME_LEN,
                                           STREAM_TOSERVER, TFTPProbingParser,
-                                          NULL);
+                                          TFTPProbingParser);
         } else {
             if (!AppLayerProtoDetectPPParseConfPorts("udp", IPPROTO_UDP,
                                                      proto_name, ALPROTO_TFTP,
                                                      0, TFTP_MIN_FRAME_LEN,
-                                                     TFTPProbingParser, NULL)) {
+                                                     TFTPProbingParser, TFTPProbingParser)) {
                 SCLogDebug("No echo app-layer configuration, enabling echo"
                            " detection UDP detection on port %s.",
                            TFTP_DEFAULT_PORT);
@@ -216,7 +216,7 @@ void RegisterTFTPParsers(void)
                                               TFTP_DEFAULT_PORT, ALPROTO_TFTP,
                                               0, TFTP_MIN_FRAME_LEN,
                                               STREAM_TOSERVER,TFTPProbingParser,
-                                              NULL);
+                                              TFTPProbingParser);
             }
         }
     } else {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2757

Describe changes:
- Adds missing probing parser in `TOCLIENT` direction

These are for symmetric protocols (at least symmetric enough for the header where the probing parsers stay)

Modifies #4082 with
- having both `TemplateProbingParserTs` and `TemplateProbingParserTc` with a comment saying that we can use only one
- precision in comments on the returned value of these functions (which can return `ALPROTO_FAILED` with a different meaning than `AL_PROTO_UNKNOWN`)