### PR TITLE
src/detect: check DetectBufferSetActiveList return code

### DIFF
--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -164,7 +164,7 @@ void DetectEngineSetParseMetadata(void);
 void DetectEngineUnsetParseMetadata(void);
 int DetectEngineMustParseMetadata(void);
 
-int DetectBufferSetActiveList(Signature *s, const int list);
+int WARN_UNUSED DetectBufferSetActiveList(Signature *s, const int list);
 int DetectBufferGetActiveList(DetectEngineCtx *de_ctx, Signature *s);
 
 #endif /* __DETECT_ENGINE_H__ */

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -190,7 +190,8 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
         return -1;
     }
 
-    DetectBufferSetActiveList(s, DetectBufferTypeGetByName("file_data"));
+    if (DetectBufferSetActiveList(s, DetectBufferTypeGetByName("file_data")) < 0)
+        return -1;
 
     SetupDetectEngineConfig(de_ctx);
     return 0;

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -152,7 +152,9 @@ static int DetectHttpCookieSetup(DetectEngineCtx *de_ctx, Signature *s, const ch
  */
 static int DetectHttpCookieSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    DetectBufferSetActiveList(s, g_http_cookie_buffer_id);
+    if (DetectBufferSetActiveList(s, g_http_cookie_buffer_id) < 0)
+        return -1;
+
     s->alproto = ALPROTO_HTTP;
     return 0;
 }

--- a/src/detect-http-stat-code.c
+++ b/src/detect-http-stat-code.c
@@ -140,7 +140,8 @@ static int DetectHttpStatCodeSetup(DetectEngineCtx *de_ctx, Signature *s, const 
  */
 static int DetectHttpStatCodeSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    DetectBufferSetActiveList(s, g_http_stat_code_buffer_id);
+    if (DetectBufferSetActiveList(s, g_http_stat_code_buffer_id) < 0)
+        return -1;
     s->alproto = ALPROTO_HTTP;
     return 0;
 }

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -140,7 +140,8 @@ static int DetectHttpStatMsgSetup(DetectEngineCtx *de_ctx, Signature *s, const c
  */
 static int DetectHttpStatMsgSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    DetectBufferSetActiveList(s, g_http_stat_msg_buffer_id);
+    if (DetectBufferSetActiveList(s, g_http_stat_msg_buffer_id) < 0)
+        return -1;
     s->alproto = ALPROTO_HTTP;
     return 0;
 }

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -202,7 +202,8 @@ static void DetectHttpUriSetupCallback(const DetectEngineCtx *de_ctx,
  */
 static int DetectHttpUriSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    DetectBufferSetActiveList(s, g_http_uri_buffer_id);
+    if (DetectBufferSetActiveList(s, g_http_uri_buffer_id) < 0)
+        return -1;
     s->alproto = ALPROTO_HTTP;
     return 0;
 }
@@ -274,7 +275,8 @@ static void DetectHttpRawUriSetupCallback(const DetectEngineCtx *de_ctx,
  */
 static int DetectHttpRawUriSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    DetectBufferSetActiveList(s, g_http_raw_uri_buffer_id);
+    if (DetectBufferSetActiveList(s, g_http_raw_uri_buffer_id) < 0)
+        return -1;
     s->alproto = ALPROTO_HTTP;
     return 0;
 }


### PR DESCRIPTION
Make sure to always check the return codes of DetectBufferSetActiveList.
Also, force this warning on function prototype.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3005