### PR TITLE
userguide: remove old reference to rule-reload option

### DIFF
--- a/doc/userguide/reputation/ipreputation/ip-reputation-config.rst
+++ b/doc/userguide/reputation/ipreputation/ip-reputation-config.rst
@@ -59,7 +59,7 @@ Depending on the number of hosts reputation information is available for, the me
 Reloads
 ~~~~~~~
 
-If the "rule-reloads" option is enabled, sending Suricata a USR2 signal will reload the IP reputation data, along with the normal rules reload.
+Sending Suricata a USR2 signal will reload the IP reputation data, along with the normal rules reload.
 
 During the reload the host table will be updated to contain the new data. The iprep information is versioned. When the reload is complete, Suricata will automatically clean up the old iprep information.
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

https://redmine.openinfosecfoundation.org/issues/3098

Describe changes:
removes the old reference to the rule-reload option

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

