### PR TITLE
logging/anomaly: Support configuration filter types

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -91,14 +91,29 @@ values or that occur out of expected sequence.
 
 Metadata::
 
-        #- anomaly:
+        - anomaly:
             # Anomaly log records describe unexpected conditions such as truncated packets, packets with invalid
             # IP/UDP/TCP length values, and other events that render the packet invalid for further processing
             # or describe unexpected behavior on an established stream. Networks which experience high
             # occurrences of anomalies may experience packet processing degradation.
-
-            # Enable dumping of packet header
-            # packethdr: no            # enable dumping of packet header
+            #
+            # Choose one or more of the following protocol/parser choices. Note
+            # that packethdr requires protodecode to be enabled.
+            #
+            # Enable logging of protocol decode events
+            # protodecode: no
+            #
+            # Enable dumping of packet header; requires protodecode to be enabled
+            # packethdr: no         # enable dumping of packet header
+            #
+            # Enable logging of app-layer protocol parser events
+            # protoparser: no
+            #
+            # Enable logging of app-layer protocol detection events
+            # protodetect: no
+            #
+            # Enable logging of parser events
+            # parser: no
 
 HTTP
 ~~~~

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -86,34 +86,38 @@ Anomalies are event records created when packets with unexpected or anomalous
 values are handled. These events include conditions such as incorrect protocol
 values, incorrect protocol length values, and other conditions which render the
 packet suspect. Other conditions may occur during the normal progression of a stream;
-these are termed ```stream``` events are include control sequences with incorrect
+these are termed ``stream`` events are include control sequences with incorrect
 values or that occur out of expected sequence.
+
+Anomalies are reported by type:
+
+- Packet
+- Application layer.
 
 Metadata::
 
         - anomaly:
             # Anomaly log records describe unexpected conditions such as truncated packets, packets with invalid
-            # IP/UDP/TCP length values, and other events that render the packet invalid for further processing
+            # IP/UDP/TCP length values, and other events that render the packet invalid for further processing 
             # or describe unexpected behavior on an established stream. Networks which experience high
             # occurrences of anomalies may experience packet processing degradation.
             #
-            # Choose one or more of the following protocol/parser choices. Note
-            # that packethdr requires protodecode to be enabled.
+            # Anomalies are reported for the following:
+            # 1. Packet: Values and conditions that are detected while decoding individual packets. This includes
+            # invalid or unexpected values for low-level protocol lengths as well as stream related events (TCP 3-way
+            # handshake issues, unexpected sequence number, etc).
+            # 2. Application level: These denote application layer specific conditions that are unexpected, invalid or
+            # are unexpected given the application monitoring state.
             #
-            # Enable logging of protocol decode events
-            # protodecode: no
+            # By default, anomaly logging is disabled. When anomaly logging is enabled, application-layer anomaly
+            # reporting is enabled.
             #
-            # Enable dumping of packet header; requires protodecode to be enabled
-            # packethdr: no         # enable dumping of packet header
-            #
-            # Enable logging of app-layer protocol parser events
-            # protoparser: no
-            #
-            # Enable logging of app-layer protocol detection events
-            # protodetect: no
-            #
-            # Enable logging of parser events
-            # parser: no
+            # Choose one or both types of anomaly logging and whether to enable
+            # logging of the packet header for packet anomalies.
+            types:
+              # packet: no
+              # application-layer: yes
+            #packethdr: no
 
 HTTP
 ~~~~

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -64,6 +64,10 @@
 
 #define ANOMALY_EVENT_TYPE      "anomaly"
 #define LOG_JSON_PACKETHDR      BIT_U16(0)
+#define LOG_JSON_PARSER         BIT_U16(1)
+#define LOG_JSON_PROTODECODE    BIT_U16(2)
+#define LOG_JSON_PROTODETECT    BIT_U16(3)
+#define LOG_JSON_PROTOPARSER    BIT_U16(4)
 #define TX_ID_UNUSED UINT64_MAX
 
 typedef struct AnomalyJsonOutputCtx_ {
@@ -212,11 +216,15 @@ static int AnomalyAppLayerDecoderEventJson(JsonAnomalyLogThread *aft,
 static int JsonAnomalyTxLogger(ThreadVars *tv, void *thread_data, const Packet *p,
                                Flow *f, void *state, void *tx, uint64_t tx_id)
 {
+    JsonAnomalyLogThread *aft = thread_data;
+    if (!(aft->json_output_ctx->flags & LOG_JSON_PROTOPARSER)) {
+        return TM_ECODE_OK;
+    }
+
     AppLayerDecoderEvents *decoder_events;
     decoder_events = AppLayerParserGetEventsByTx(f->proto, f->alproto, tx);
     if (decoder_events && decoder_events->event_last_logged < decoder_events->cnt) {
         SCLogDebug("state %p, tx: %p, tx_id: %"PRIu64, state, tx, tx_id);
-        JsonAnomalyLogThread *aft = thread_data;
         AnomalyAppLayerDecoderEventJson(aft, p, decoder_events, false,
                                         "proto_parser", tx_id);
     }
@@ -239,23 +247,29 @@ static int AnomalyJson(ThreadVars *tv, JsonAnomalyLogThread *aft, const Packet *
 
     int rc = TM_ECODE_OK;
 
-    if (p->events.cnt) {
-        rc = AnomalyDecodeEventJson(tv, aft, p);
+    if (aft->json_output_ctx->flags & LOG_JSON_PROTODECODE) {
+        if (p->events.cnt) {
+            rc = AnomalyDecodeEventJson(tv, aft, p);
+        }
     }
 
-    /* app layer events */
-    if (rc == TM_ECODE_OK && AnomalyHasPacketAppLayerEvents(p)) {
-        rc = AnomalyAppLayerDecoderEventJson(aft, p, p->app_layer_events,
-                                             true, "proto_detect", TX_ID_UNUSED);
+    /* app layer proto detect events */
+    if (aft->json_output_ctx->flags & LOG_JSON_PROTODETECT) {
+        if (rc == TM_ECODE_OK && AnomalyHasPacketAppLayerEvents(p)) {
+            rc = AnomalyAppLayerDecoderEventJson(aft, p, p->app_layer_events,
+                                                 true, "proto_detect", TX_ID_UNUSED);
+        }
     }
 
     /* parser state events */
-    if (rc == TM_ECODE_OK && AnomalyHasParserEvents(p)) {
-        SCLogDebug("Checking for anomaly events; alproto %d", p->flow->alproto);
-        AppLayerDecoderEvents *parser_events = AppLayerParserGetDecoderEvents(p->flow->alparser);
-        if (parser_events && (parser_events->event_last_logged < parser_events->cnt)) {
-            rc = AnomalyAppLayerDecoderEventJson(aft, p, parser_events,
-                                                 false, "parser", TX_ID_UNUSED);
+    if (aft->json_output_ctx->flags & LOG_JSON_PARSER) {
+        if (rc == TM_ECODE_OK && AnomalyHasParserEvents(p)) {
+            SCLogDebug("Checking for anomaly events; alproto %d", p->flow->alproto);
+            AppLayerDecoderEvents *parser_events = AppLayerParserGetDecoderEvents(p->flow->alparser);
+            if (parser_events && (parser_events->event_last_logged < parser_events->cnt)) {
+                rc = AnomalyAppLayerDecoderEventJson(aft, p, parser_events,
+                                                     false, "parser", TX_ID_UNUSED);
+            }
         }
     }
 
@@ -348,9 +362,19 @@ static void SetFlag(const ConfNode *conf, const char *name, uint16_t flag, uint1
 static void JsonAnomalyLogConf(AnomalyJsonOutputCtx *json_output_ctx,
         ConfNode *conf)
 {
+    static bool _warn_no_flags = false;
     uint16_t flags = 0;
     if (conf != NULL) {
-        SetFlag(conf, "packethdr", LOG_JSON_PACKETHDR, &flags);
+        SetFlag(conf, "protoparser", LOG_JSON_PROTOPARSER, &flags);
+        SetFlag(conf, "parser",      LOG_JSON_PARSER,      &flags);
+        SetFlag(conf, "protodetect", LOG_JSON_PROTODETECT, &flags);
+        SetFlag(conf, "protodecode", LOG_JSON_PROTODECODE, &flags);
+        SetFlag(conf, "packethdr",   LOG_JSON_PACKETHDR,   &flags);
+    }
+    if (flags == 0 && !_warn_no_flags) {
+        SCLogNotice("Anomaly logging has been configured; however, no logging filters "
+                    "have been selected. Select one or more protocol/parser filters.");
+        _warn_no_flags = true;
     }
     json_output_ctx->flags |= flags;
 }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -160,9 +160,24 @@ outputs:
             # IP/UDP/TCP length values, and other events that render the packet invalid for further processing 
             # or describe unexpected behavior on an established stream. Networks which experience high
             # occurrences of anomalies may experience packet processing degradation.
-
-            # Enable dumping of packet header
-            # packethdr: no            # enable dumping of packet header
+            #
+            # Choose one or more of the following protocol/parser choices. Note
+            # that packethdr requires protodecode to be enabled.
+            #
+            # Enable logging of protocol decode events
+            # protodecode: no
+            #
+            # Enable dumping of packet header; requires protodecode to be enabled
+            # packethdr: no         # enable dumping of packet header
+            #
+            # Enable logging of app-layer protocol parser events
+            # protoparser: no
+            #
+            # Enable logging of app-layer protocol detection events
+            # protodetect: no
+            #
+            # Enable logging of parser events
+            # parser: no
         - http:
             extended: yes     # enable this for extended logging information
             # custom allows additional http fields to be included in eve-log

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -161,23 +161,22 @@ outputs:
             # or describe unexpected behavior on an established stream. Networks which experience high
             # occurrences of anomalies may experience packet processing degradation.
             #
-            # Choose one or more of the following protocol/parser choices. Note
-            # that packethdr requires protodecode to be enabled.
+            # Anomalies are reported for the following:
+            # 1. Packet: Values and conditions that are detected while decoding individual packets. This includes
+            # invalid or unexpected values for low-level protocol lengths as well as stream related events (TCP 3-way
+            # handshake issues, unexpected sequence number, etc).
+            # 2. Application level: These denote application layer specific conditions that are unexpected, invalid or
+            # are unexpected given the application monitoring state.
             #
-            # Enable logging of protocol decode events
-            # protodecode: no
+            # By default, anomaly logging is disabled. When anomaly logging is enabled, application-layer anomaly
+            # reporting is enabled.
             #
-            # Enable dumping of packet header; requires protodecode to be enabled
-            # packethdr: no         # enable dumping of packet header
-            #
-            # Enable logging of app-layer protocol parser events
-            # protoparser: no
-            #
-            # Enable logging of app-layer protocol detection events
-            # protodetect: no
-            #
-            # Enable logging of parser events
-            # parser: no
+            # Choose one or both types of anomaly logging and whether to enable
+            # logging of the packet header for packet anomalies.
+            types:
+              # packet: no
+              # application-layer: yes
+            #packethdr: no
         - http:
             extended: yes     # enable this for extended logging information
             # custom allows additional http fields to be included in eve-log


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [2958](https://redmine.openinfosecfoundation.org/issues/2958)

* Continuation of #4033  
* Requires [Suricata-verify PR #109](https://github.com/OISF/suricata-verify/pull/109) 

Updates since last PR:
- Reworked configuration settings controlling anomaly logging (see discussion in #4033)