### PR TITLE
detect/transform: add domain transform

### DIFF
--- a/doc/userguide/rules/transforms.rst
+++ b/doc/userguide/rules/transforms.rst
@@ -21,6 +21,36 @@ Example::
 
 .. note:: not all sticky buffers support transformations yet
 
+domain
+------
+
+Takes the buffer, and prepends a ``.`` character providing concise domain checks. For example,
+an input string of ``hello.google.com`` would be modified and become ``.hello.google.com``.
+
+Example::
+
+    alert http any any -> any any (dns.query; domain; \
+        content:".microsoft.com"; sid:1;)
+
+This example will match on ``windows.update.microsoft.com`` and
+``maps.microsoft.com.au`` but not ``windows.update.fakemicrosoft.com``.
+
+This rule can be used to match on the domain only; example::
+
+    alert http any any -> any any (dns.query; domain; \
+        content:".microsoft.com"; endswith; sid:1;)
+
+This example will match on ``windows.update.microsoft.com`` but not
+`windows.update.microsoft.com.au``.
+
+Finally, this rule can be used to match on the TLD only; example::
+
+    alert http any any -> any any (dns.query; domain; \
+        content:".co.uk"; endswith; sid:1;)
+
+This example will match on ``maps.google.co.uk`` but not
+`maps.google.co.nl``.
+
 strip_whitespace
 ----------------
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -268,6 +268,7 @@ detect-transform-strip-whitespace.c detect-transform-strip-whitespace.h \
 detect-transform-md5.c detect-transform-md5.h \
 detect-transform-sha1.c detect-transform-sha1.h \
 detect-transform-sha256.c detect-transform-sha256.h \
+detect-transform-domain.c detect-transform-domain.h \
 detect-ttl.c detect-ttl.h \
 detect-uricontent.c detect-uricontent.h \
 detect-urilen.c detect-urilen.h \

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -191,6 +191,7 @@
 #include "detect-transform-md5.h"
 #include "detect-transform-sha1.h"
 #include "detect-transform-sha256.h"
+#include "detect-transform-domain.h"
 
 #include "util-rule-vars.h"
 
@@ -550,6 +551,7 @@ void SigTableSetup(void)
     DetectTransformMd5Register();
     DetectTransformSha1Register();
     DetectTransformSha256Register();
+    DetectTransformDomainRegister();
 
     /* close keyword registration */
     DetectBufferTypeCloseRegistration();

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -247,6 +247,7 @@ enum {
     DETECT_TRANSFORM_MD5,
     DETECT_TRANSFORM_SHA1,
     DETECT_TRANSFORM_SHA256,
+    DETECT_TRANSFORM_DOMAIN,
 
     /* make sure this stays last */
     DETECT_TBLSIZE,

--- a/src/detect-transform-domain.c
+++ b/src/detect-transform-domain.c
@@ -1,0 +1,182 @@
+/* Copyright (C) 2019 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ *
+ * Implements the domain transformation
+ */
+
+#include "suricata-common.h"
+
+#include "detect.h"
+#include "detect-engine.h"
+#include "detect-engine-prefilter.h"
+#include "detect-parse.h"
+#include "detect-transform-domain.h"
+
+#include "util-unittest.h"
+#include "util-print.h"
+#include "util-memrchr.h"
+#include "util-memcpy.h"
+
+static int DetectTransformDomainSetup (DetectEngineCtx *, Signature *, const char *);
+static void DetectTransformDomainRegisterTests(void);
+
+static void TransformDomain(InspectionBuffer *buffer);
+
+void DetectTransformDomainRegister(void)
+{
+    sigmatch_table[DETECT_TRANSFORM_DOMAIN].name = "domain";
+    sigmatch_table[DETECT_TRANSFORM_DOMAIN].desc =
+        "modify buffer to extract the domain";
+    sigmatch_table[DETECT_TRANSFORM_DOMAIN].url =
+        DOC_URL DOC_VERSION "/rules/transforms.html#domain";
+    sigmatch_table[DETECT_TRANSFORM_DOMAIN].Transform = TransformDomain;
+    sigmatch_table[DETECT_TRANSFORM_DOMAIN].Setup = DetectTransformDomainSetup;
+    sigmatch_table[DETECT_TRANSFORM_DOMAIN].RegisterTests =
+        DetectTransformDomainRegisterTests;
+
+    sigmatch_table[DETECT_TRANSFORM_DOMAIN].flags |= SIGMATCH_NOOPT;
+}
+
+/**
+ *  \internal
+ *  \brief Extract the domain, if any, the last pattern match, either content or uricontent
+ *  \param det_ctx detection engine ctx
+ *  \param s signature
+ *  \param nullstr should be null
+ *  \retval 0 ok
+ *  \retval -1 failure
+ */
+static int DetectTransformDomainSetup (DetectEngineCtx *de_ctx, Signature *s, const char *nullstr)
+{
+    SCEnter();
+    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_DOMAIN);
+    SCReturnInt(r);
+}
+
+static void TransformDomain(InspectionBuffer *buffer)
+/**
+ * \brief Return the domain, if any, in the last pattern match.
+ *
+ * Input values are modified by prefixing with a ".".
+ *
+ * Rule: "alert dns any any -> any any (dns_query; domain; content:".google.com"; sid:1;)"
+ * 1. hello.google.com --> match
+ * 2. hey.agoogle.com --> no match
+ * 3. agoogle.com --> no match
+ * 4. something.google.com.au --> match
+ *
+ * To match on the domain only:
+ * Rule: "alert dns any any -> any any (dns_query; domain; content:".google.com"; endswith; sid:1;)"
+ *
+ * 1. hello.google.com --> match
+ * 2. hey.agoogle.com --> no match
+ * 3. aggogle.com --> no match
+ * 4. something.google.com.au --> no match
+ *
+ * To match on a TLD:
+ * Rule: "alert dns any any -> any any (dns_query; domain; content:".co.uk"; endswith; sid:1;)"
+ *
+ * 1. hello.google.com --> no match
+ * 2. hey.agoogle.com --> no match
+ * 3. aggogle.com --> no match
+ * 4. something.google.co.uk --> match
+ */
+{
+    const size_t input_len = buffer->inspect_len;
+
+    if (input_len) {
+        uint8_t output[input_len + 1]; // For the leading '.'
+
+        output[0] = '.';
+        memcpy(&output[1], buffer->inspect, input_len);
+        InspectionBufferCopy(buffer, output, input_len + 1);
+    }
+}
+
+#ifdef UNITTESTS
+static int DetectTransformDomainTest01(void)
+{
+    const uint8_t *input = (const uint8_t *)"example.com";
+    uint32_t input_len = strlen((char *)input);
+
+    const char *result = ".example.com";
+    uint32_t result_len = strlen((char *)result);
+
+    InspectionBuffer buffer;
+    InspectionBufferInit(&buffer, input_len);
+    InspectionBufferSetup(&buffer, input, input_len);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    TransformDomain(&buffer);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    FAIL_IF_NOT(buffer.inspect_len == result_len);
+    FAIL_IF_NOT(strncmp(result, (const char *)buffer.inspect, result_len) == 0);
+    InspectionBufferFree(&buffer);
+    PASS;
+}
+
+static int DetectTransformDomainTest02(void)
+{
+    const uint8_t *input = (const uint8_t *)"hello.example.com";
+    uint32_t input_len = strlen((char *)input);
+
+    const char *result = ".hello.example.com";
+    uint32_t result_len = strlen((char *)result);
+
+    InspectionBuffer buffer;
+    InspectionBufferInit(&buffer, input_len);
+    InspectionBufferSetup(&buffer, input, input_len);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    TransformDomain(&buffer);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    FAIL_IF_NOT(buffer.inspect_len == result_len);
+    FAIL_IF_NOT(strncmp(result, (const char *)buffer.inspect, result_len) == 0);
+    InspectionBufferFree(&buffer);
+    PASS;
+}
+
+static int DetectTransformDomainTest03(void)
+{
+    const char rule[] = "alert dns any any -> any any (dns.query; domain; content:\".google.com\"; sid:1;)";
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    memset(&th_v, 0, sizeof(th_v));
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, rule);
+    FAIL_IF_NULL(s);
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+#endif
+
+static void DetectTransformDomainRegisterTests(void)
+{
+#ifdef UNITTESTS
+    UtRegisterTest("DetectTransformDomainTest01", DetectTransformDomainTest01);
+    UtRegisterTest("DetectTransformDomainTest02", DetectTransformDomainTest02);
+    UtRegisterTest("DetectTransformDomainTest03", DetectTransformDomainTest03);
+#endif
+}

--- a/src/detect-transform-domain.h
+++ b/src/detect-transform-domain.h
@@ -1,0 +1,30 @@
+/* Copyright (C) 2019 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ */
+
+#ifndef __DETECT_TRANSFORM_DOMAIN_H__
+#define __DETECT_TRANSFORM_DOMAIN_H__
+
+/* prototypes */
+void DetectTransformDomainRegister (void);
+
+#endif /* __DETECT_TRANSFORM_DOMAIN_H__ */


### PR DESCRIPTION
This PR adds a transform for:
1. domain - Returns the domain and passes it on.

Continuation of #4063 

This update:
1. Incorporates new logic for transformation (See defect)
1. Removes support for the `tld` transform due to issues with a heuristics-only approach. Proper TLD transformation requires a data store for validation and checks.
1. Adds additional test cases.

Companion PR to suricata-verify` repo; https://github.com/OISF/suricata-verify/pull/111

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:  [3074](https://redmine.openinfosecfoundation.org/issues/3074) 
