### PR TITLE
detect/analyzer: Recognize `http_content_type` keyword.

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -901,6 +901,7 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
     uint32_t http_uri_buf = 0;
     uint32_t http_method_buf = 0;
     uint32_t http_cookie_buf = 0;
+    uint32_t http_content_type_buf = 0;
     uint32_t http_client_body_buf = 0;
     uint32_t http_server_body_buf = 0;
     uint32_t http_stat_code_buf = 0;
@@ -934,6 +935,7 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
     const int httpmethod_id = DetectBufferTypeGetByName("http_method");
     const int httpuri_id = DetectBufferTypeGetByName("http_uri");
     const int httpuseragent_id = DetectBufferTypeGetByName("http_user_agent");
+    const int httpcontenttype_id = DetectBufferTypeGetByName("http_content_type");
     const int httpcookie_id = DetectBufferTypeGetByName("http_cookie");
     const int httpstatcode_id = DetectBufferTypeGetByName("http_stat_code");
     const int httpstatmsg_id = DetectBufferTypeGetByName("http_stat_msg");
@@ -987,6 +989,11 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
                     rule_pcre_http += 1;
                     norm_http_buf += 1;
                     http_cookie_buf += 1;
+                }
+                else if (list_id == httpcontenttype_id) {
+                    rule_pcre_http += 1;
+                    norm_http_buf += 1;
+                    http_content_type_buf += 1;
                 }
                 else if (list_id == filedata_id) {
                     rule_pcre_http += 1;
@@ -1073,6 +1080,11 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
                     rule_content_http += 1;
                     raw_http_buf += 1;
                     http_client_body_buf += 1;
+                }
+                else if (list_id == httpcontenttype_id) {
+                    rule_content_http += 1;
+                    raw_http_buf += 1;
+                    http_content_type_buf += 1;
                 }
                 else if (list_id == filedata_id) {
                     rule_content_http += 1;
@@ -1270,6 +1282,7 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
         if (http_uri_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http uri buffer.\n");
         if (http_header_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http header buffer.\n");
         if (http_cookie_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http cookie buffer.\n");
+        if (http_content_type_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http content type buffer.\n");
         if (http_raw_uri_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http raw uri buffer.\n");
         if (http_raw_header_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http raw header buffer.\n");
         if (http_method_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http method buffer.\n");

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -471,7 +471,6 @@ void EngineAnalysisRulesFailure(char *line, char *file, int lineno)
     fprintf(rule_engine_analysis_FD, "\n");
 }
 
-#ifdef HAVE_LIBJANSSON
 #include "util-buffer.h"
 #include "output-json.h"
 
@@ -859,7 +858,6 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
     json_decref(ctx.js);
     SCReturn;
 }
-#endif /* HAVE_LIBJANSSON */
 
 /**
  * \brief Prints analysis of loaded rules.

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -581,7 +581,7 @@ static void DumpMatches(RuleAnalyzer *ctx, json_t *js, const SigMatchData *smd)
 
                         json_object_set_new(js_match_content, "fast_pattern", json_boolean(cd->flags & DETECT_CONTENT_FAST_PATTERN));
                         if (cd->flags & DETECT_CONTENT_FAST_PATTERN_ONLY) {
-                            AnalyzerNote(ctx, (char *)"'fast_pattern:only' option is silently ignored and is intepreted as regular 'fast_pattern'");
+                            AnalyzerNote(ctx, (char *)"'fast_pattern:only' option is silently ignored and is interpreted as regular 'fast_pattern'");
                         }
 
                         json_object_set_new(js_match, "content", js_match_content);

--- a/src/detect-engine-analyzer.h
+++ b/src/detect-engine-analyzer.h
@@ -41,8 +41,6 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
         const Signature *s, const char *line);
 void EngineAnalysisRulesFailure(char *line, char *file, int lineno);
 
-#ifdef HAVE_LIBJANSSON
 void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s);
-#endif
 
 #endif /* __DETECT_ENGINE_ANALYZER_H__ */


### PR DESCRIPTION

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3112](https://redmine.openinfosecfoundation.org/issues/3112)

Describe changes:
- Recognize `http_content_type` keyword.

