### PR TITLE
ftp: Optimize FTP command lookup

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1363,7 +1363,6 @@ void FTPAtExitPrintStats(void)
 }
 
 
-#ifdef HAVE_LIBJANSSON
 /*
  * \brief Returns the ending offset of the next line from a multi-line buffer.
  *
@@ -1417,7 +1416,6 @@ json_t *JsonFTPDataAddMetadata(const Flow *f)
     }
     return ftpd;
 }
-#endif /* HAVE_LIBJANSSON */
 
 /* UNITTESTS */
 #ifdef UNITTESTS

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1364,6 +1364,32 @@ void FTPAtExitPrintStats(void)
 
 
 #ifdef HAVE_LIBJANSSON
+/*
+ * \brief Returns the ending offset of the next line from a multi-line buffer.
+ *
+ * "Buffer" refers to a FTP response in a single buffer containing multiple lines.
+ * Here, "next line" is defined as terminating on
+ * - Newline character
+ * - Null character
+ *
+ * \param buffer Contains zero or more characters.
+ * \param len Size, in bytes, of buffer.
+ *
+ * \retval Offset from the start of buffer indicating the where the
+ * next "line ends". The characters between the input buffer and this
+ * value comprise the line.
+ *
+ * NULL is found first or a newline isn't found, then
+ */
+uint16_t JsonGetNextLineFromBuffer(const char *buffer, const uint16_t len)
+{
+        if (!buffer || *buffer == '\0')
+                    return UINT16_MAX;
+
+            char *c = strchr(buffer, '\n');
+                return c == NULL ? len : c - buffer + 1;
+}
+
 json_t *JsonFTPDataAddMetadata(const Flow *f)
 {
     const FtpDataState *ftp_state = NULL;

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -59,9 +59,7 @@
 #include "util-mem.h"
 #include "util-misc.h"
 
-#ifdef HAVE_RUST
 #include "rust-ftp-mod-gen.h"
-#endif
 
 #include "output-json.h"
 
@@ -738,12 +736,7 @@ static int FTPParseRequest(Flow *f, void *ftp_state,
 
 static int FTPParsePassiveResponse(Flow *f, FtpState *state, uint8_t *input, uint32_t input_len)
 {
-    uint16_t dyn_port =
-#ifdef HAVE_RUST
-            rs_ftp_pasv_response(input, input_len);
-#else
-            FTPGetV4PortNumber(input, input_len);
-#endif
+    uint16_t dyn_port = rs_ftp_pasv_response(input, input_len);
     if (dyn_port == 0) {
         return -1;
     }
@@ -758,12 +751,7 @@ static int FTPParsePassiveResponse(Flow *f, FtpState *state, uint8_t *input, uin
 
 static int FTPParsePassiveResponseV6(Flow *f, FtpState *state, uint8_t *input, uint32_t input_len)
 {
-    uint16_t dyn_port =
-#ifdef HAVE_RUST
-            rs_ftp_epsv_response(input, input_len);
-#else
-            FTPGetV6PortNumber(input, input_len);
-#endif
+    uint16_t dyn_port = rs_ftp_epsv_response(input, input_len);
     if (dyn_port == 0) {
         return -1;
     }

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -219,6 +219,7 @@ uint64_t FTPMemuseGlobalCounter(void);
 uint64_t FTPMemcapGlobalCounter(void);
 
 #ifdef HAVE_LIBJANSSON
+uint16_t JsonGetNextLineFromBuffer(const char *buffer, const uint16_t len);
 json_t *JsonFTPDataAddMetadata(const Flow *f);
 #endif
 

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -89,8 +89,7 @@ typedef enum {
 
 typedef struct FtpCommand_ {
     FtpRequestCommand command;
-    const char *command_name_upper;
-    const char *command_name_lower;
+    const char *command_name;
     const uint8_t command_length;
 } FtpCommand;
 extern const FtpCommand FtpCommands[FTP_COMMAND_MAX + 1];
@@ -215,6 +214,7 @@ typedef struct FtpDataState_ {
 void RegisterFTPParsers(void);
 void FTPParserRegisterTests(void);
 void FTPAtExitPrintStats(void);
+void FTPParserCleanup(void);
 uint64_t FTPMemuseGlobalCounter(void);
 uint64_t FTPMemcapGlobalCounter(void);
 

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -218,10 +218,8 @@ void FTPAtExitPrintStats(void);
 uint64_t FTPMemuseGlobalCounter(void);
 uint64_t FTPMemcapGlobalCounter(void);
 
-#ifdef HAVE_LIBJANSSON
 uint16_t JsonGetNextLineFromBuffer(const char *buffer, const uint16_t len);
 json_t *JsonFTPDataAddMetadata(const Flow *f);
-#endif
 
 #endif /* __APP_LAYER_FTP_H__ */
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -240,6 +240,7 @@ int AppLayerParserDeSetup(void)
 {
     SCEnter();
 
+    FTPParserCleanup();
     SMTPParserCleanup();
 
     SCReturnInt(0);

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -62,31 +62,6 @@ typedef struct LogFTPLogThread_ {
     MemBuffer          *buffer;
 } LogFTPLogThread;
 
-/*
- * \brief Returns the ending offset of the next line.
- *
- * Here, "next line" is defined as terminating on
- * - Newline character
- * - Null character
- *
- * \param buffer Contains zero or more characters.
- * \param len Size, in bytes, of buffer.
- *
- * \retval Offset from the start of buffer indicating the where the
- * next "line ends". The characters between the input buffer and this
- * value comprise the line.
- *
- * NULL is found first or a newline isn't found, then
- */
-static uint16_t JsonGetNextLineFromBuffer(const char *buffer, const uint16_t len)
-{
-    if (!buffer || *buffer == '\0')
-        return UINT16_MAX;
-
-    char *c = strchr(buffer, '\n');
-    return c == NULL ? len : c - buffer + 1;
-}
-
 static json_t *JsonFTPLogCommand(Flow *f, FTPTransaction *tx)
 {
     json_t *cjs = json_object();

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -86,8 +86,7 @@ static json_t *JsonFTPLogCommand(Flow *f, FTPTransaction *tx)
         }
     }
 
-    json_object_set_new(cjs, "command",
-                        json_string(tx->command_descriptor->command_name_upper));
+    json_object_set_new(cjs, "command", json_string(tx->command_descriptor->command_name));
     uint32_t min_length = tx->command_descriptor->command_length + 1; /* command + space */
     if (tx->request_length > min_length) {
         json_object_set_new(cjs, "command_data",


### PR DESCRIPTION
suricata/issues) ticket: [3077](https://redmine.openinfosecfoundation.org/issues/3077)

Describe changes:
- Use MPM for FTP command lookup instead of linear searching a command table
- Remove LIBJANSSON guards
- Remove RUST guards

