### PR TITLE
src: remove multiple uses of atoi

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -545,11 +545,15 @@ static uint16_t FTPGetV4PortNumber(uint8_t *input, uint32_t input_len)
     if (ptr == NULL)
         return 0;
 
-    part2 = atoi((char *)ptr + 1);
+    if (ByteExtractStringUint16(&part2, 10, 0, (const char *)ptr + 1) < 0) {
+        return 0;
+    }
     ptr = memrchr(input, ',', (ptr - input) - 1);
     if (ptr == NULL)
         return 0;
-    part1 = atoi((char *)ptr + 1);
+    if (ByteExtractStringUint16(&part1, 10, 0, (const char *)ptr + 1) < 0) {
+        return 0;
+    }
 
     return ftp_validate_port(256 * part1 + part2);
 }

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -45,6 +45,7 @@
 #include "util-pool.h"
 #include "util-radix-tree.h"
 #include "util-file.h"
+#include "util-byte.h"
 
 #include "stream-tcp-private.h"
 #include "stream-tcp-reassemble.h"
@@ -2636,7 +2637,16 @@ static void HTPConfigParseParameters(HTPCfgRec *cfg_prec, ConfNode *s,
                 cfg_prec->randomize = ConfValIsTrue(p->val);
             }
         } else if (strcasecmp("randomize-inspection-range", p->name) == 0) {
-            uint32_t range = atoi(p->val);
+            uint32_t range;
+            if (ByteExtractStringUint32(&range, 10, 0,
+                                        (const char *)p->val) < 0) {
+                SCLogError(SC_ERR_SIZE_PARSE, "Invalid value for randomize"
+                           " inspection range setting from conf file - \"%s\"."
+                           " It should be a valid integer less than 100."
+                           " Killing engine",
+                           p->val);
+                exit(EXIT_FAILURE);
+            }
             if (range > 100) {
                 SCLogError(SC_ERR_SIZE_PARSE, "Invalid value for randomize"
                            " inspection range setting from conf file - %s."

--- a/src/counters.c
+++ b/src/counters.c
@@ -33,6 +33,7 @@
 #include "util-time.h"
 #include "util-unittest.h"
 #include "util-debug.h"
+#include "util-byte.h"
 #include "util-privs.h"
 #include "util-signal.h"
 #include "unix-manager.h"
@@ -242,7 +243,12 @@ static void StatsInitCtxPreOutput(void)
         }
         const char *interval = ConfNodeLookupChildValue(stats, "interval");
         if (interval != NULL)
-            stats_tts = (uint32_t) atoi(interval);
+            if (ByteExtractStringUint32(&stats_tts, 10, 0, interval) < 0) {
+                SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
+                        "interval: \"%s\". Resetting to %d.", interval,
+                        STATS_MGMTT_TTS);
+                stats_tts = STATS_MGMTT_TTS;
+            }
 
         int b;
         int ret = ConfGetChildValueBool(stats, "decoder-events", &b);

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -238,8 +238,12 @@ static inline DetectByteExtractData *DetectByteExtractParse(const char *arg)
                    "for arg 1 for byte_extract");
         goto error;
     }
-    bed->nbytes = atoi(nbytes_str);
-
+    if (ByteExtractStringUint8(&bed->nbytes, 10, 0,
+                               (const char *)nbytes_str) < 0) {
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid value for number of bytes"
+                "to be extracted: \"%s\".", nbytes_str);
+        goto error;
+    }
     /* offset */
     char offset_str[64] = "";
     res = pcre_copy_substring((char *)arg, ov,
@@ -249,7 +253,11 @@ static inline DetectByteExtractData *DetectByteExtractParse(const char *arg)
                    "for arg 2 for byte_extract");
         goto error;
     }
-    int offset = atoi(offset_str);
+    int offset;
+    if (ByteExtractStringInt32(&offset, 10, 0, (const char *)offset_str) < 0) {
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid value for offset: \"%s\".", offset_str);
+        goto error;
+    }
     if (offset < -65535 || offset > 65535) {
         SCLogError(SC_ERR_INVALID_SIGNATURE, "byte_extract offset invalid - %d.  "
                    "The right offset range is -65535 to 65535", offset);
@@ -305,7 +313,13 @@ static inline DetectByteExtractData *DetectByteExtractParse(const char *arg)
                            "for arg %d for byte_extract", i);
                 goto error;
             }
-            int multiplier = atoi(multiplier_str);
+            int multiplier;
+            if (ByteExtractStringInt32(&multiplier, 10, 0,
+                                       (const char *)multiplier_str) < 0) {
+                SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid value for"
+                        "multiplier: \"%s\".", multiplier_str);
+                goto error;
+            }
             if (multiplier < DETECT_BYTE_EXTRACT_MULTIPLIER_MIN_LIMIT ||
                 multiplier > DETECT_BYTE_EXTRACT_MULTIPLIER_MAX_LIMIT) {
                 SCLogError(SC_ERR_INVALID_SIGNATURE, "multipiler_value invalid "
@@ -409,7 +423,12 @@ static inline DetectByteExtractData *DetectByteExtractParse(const char *arg)
                            "for arg %d in byte_extract", i);
                 goto error;
             }
-            bed->align_value = atoi(align_str);
+            if (ByteExtractStringUint8(&bed->align_value, 10, 0,
+                                       (const char *)align_str) < 0) {
+                SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid value for"
+                        "align_str: \"%s\".", align_str);
+                goto error;
+            }
             if (!(bed->align_value == 2 || bed->align_value == 4)) {
                 SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid align_value for "
                            "byte_extract - \"%d\"", bed->align_value);

--- a/src/detect-cipservice.c
+++ b/src/detect-cipservice.c
@@ -345,13 +345,21 @@ static DetectEnipCommandData *DetectEnipCommandParse(const char *rulestr)
     }
 
     unsigned long cmd = atol(rulestr);
+    if (ByteExtractStringUint64(&cmd, 10, 0, rulestr) < 0) {
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid ENIP command"
+                ": \"%s\"", rulestr);
+        goto error;
+    }
     if (cmd > MAX_ENIP_CMD) //if command greater than 16 bit
     {
         SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid ENIP command %lu", cmd);
         goto error;
     }
-
-    enipcmdd->enipcommand = (uint16_t) atoi(rulestr);
+    if (ByteExtractStringUint16(&enipcmdd->enipcommand, 10, 0, rulestr) < 0) {
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid ENIP command"
+                ": \"%s\"", rulestr);
+        goto error;
+    }
 
     return enipcmdd;
 

--- a/src/detect-dce-iface.c
+++ b/src/detect-dce-iface.c
@@ -180,8 +180,12 @@ static DetectDceIfaceData *DetectDceIfaceArgParse(const char *arg)
             goto error;
         }
 
-        version = atoi(copy_str);
-        if (version > UINT16_MAX) {
+        if (ByteExtractStringInt32(&version, 10, 0, (const char *)copy_str) < 0) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "DCE_IFACE interface version "
+                       "invalid: \"%s\n\"", copy_str);
+            goto error;
+        }
+        if (version < 0 || version > UINT16_MAX) {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "DCE_IFACE interface version "
                        "invalid: %d\n", version);
             goto error;

--- a/src/detect-dce-opnum.c
+++ b/src/detect-dce-opnum.c
@@ -175,16 +175,25 @@ static DetectDceOpnumData *DetectDceOpnumArgParse(const char *arg)
         if ((hyphen_token = index(dup_str_temp, '-')) != NULL) {
             hyphen_token[0] = '\0';
             hyphen_token++;
-            dor->range1 = atoi(dup_str_temp);
+            if (ByteExtractStringUint32(&dor->range1, 10, 0,
+                                        (const char *)dup_str_temp) < 0) {
+                goto error;
+            }
             if (dor->range1 > DCE_OPNUM_RANGE_MAX)
                 goto error;
-            dor->range2 = atoi(hyphen_token);
+            if (ByteExtractStringUint32(&dor->range2, 10, 0,
+                                        (const char *)hyphen_token) < 0) {
+                goto error;
+            }
             if (dor->range2 > DCE_OPNUM_RANGE_MAX)
                 goto error;
             if (dor->range1 > dor->range2)
                 goto error;
         }
-        dor->range1 = atoi(dup_str_temp);
+        if (ByteExtractStringUint32(&dor->range1, 10, 0,
+                                    (const char *)dup_str_temp) < 0) {
+            goto error;
+        }
         if (dor->range1 > DCE_OPNUM_RANGE_MAX)
             goto error;
 
@@ -203,16 +212,25 @@ static DetectDceOpnumData *DetectDceOpnumArgParse(const char *arg)
     if ( (hyphen_token = index(dup_str, '-')) != NULL) {
         hyphen_token[0] = '\0';
         hyphen_token++;
-        dor->range1 = atoi(dup_str);
+        if (ByteExtractStringUint32(&dor->range1, 10, 0,
+                                    (const char *)dup_str) < 0) {
+            goto error;
+        }
         if (dor->range1 > DCE_OPNUM_RANGE_MAX)
             goto error;
-        dor->range2 = atoi(hyphen_token);
+        if (ByteExtractStringUint32(&dor->range2, 10, 0,
+                                    (const char *)hyphen_token) < 0) {
+            goto error;
+        }
         if (dor->range2 > DCE_OPNUM_RANGE_MAX)
             goto error;
         if (dor->range1 > dor->range2)
             goto error;
     }
-    dor->range1 = atoi(dup_str);
+    if (ByteExtractStringUint32(&dor->range1, 10, 0,
+                                (const char *)dup_str) < 0) {
+        goto error;
+    }
     if (dor->range1 > DCE_OPNUM_RANGE_MAX)
         goto error;
 

--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -44,6 +44,7 @@
 #include "detect-engine-port.h"
 
 #include "util-debug.h"
+#include "util-byte.h"
 #include "util-print.h"
 #include "util-var.h"
 
@@ -571,7 +572,8 @@ int DetectAddressParseString(DetectAddress *dd, const char *str)
                         goto error;
                 }
 
-                int cidr = atoi(mask);
+                int cidr;
+                ByteExtractStringInt32(&cidr, 10, 0, (const char *)mask);
                 if (cidr < 0 || cidr > 32)
                     goto error;
 
@@ -631,7 +633,8 @@ int DetectAddressParseString(DetectAddress *dd, const char *str)
             ip[mask - ip] = '\0';
             mask++;
 
-            int cidr = atoi(mask);
+            int cidr;
+            ByteExtractStringInt32(&cidr, 10, 0, (const char *)mask);
             if (cidr < 0 || cidr > 128)
                     goto error;
 

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -53,6 +53,7 @@
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 #include "util-print.h"
+#include "util-byte.h"
 #include "util-profiling.h"
 #include "util-validate.h"
 
@@ -165,7 +166,8 @@ static int IPOnlyCIDRItemParseSingle(IPOnlyCIDRItem *dd, const char *str)
                         goto error;
                 }
 
-                int cidr = atoi(mask);
+                int cidr;
+                ByteExtractStringInt32(&cidr, 10, 0, (const char *)mask);
                 if (cidr < 0 || cidr > 32)
                     goto error;
 
@@ -261,7 +263,10 @@ static int IPOnlyCIDRItemParseSingle(IPOnlyCIDRItem *dd, const char *str)
                 goto error;
 
             /* Format is cidr val */
-            dd->netmask = atoi(mask);
+            if (ByteExtractStringUint8(&dd->netmask, 10, 0,
+                                       (const char *)mask) < 0) {
+                goto error;
+            }
 
             memcpy(dd->ip, &in6.s6_addr, sizeof(ip6addr));
         } else {

--- a/src/detect-engine-port.c
+++ b/src/detect-engine-port.c
@@ -51,6 +51,7 @@
 #include "pkt-var.h"
 #include "host.h"
 #include "util-profiling.h"
+#include "util-byte.h"
 #include "util-var.h"
 
 static int DetectPortCutNot(DetectPort *, DetectPort **);
@@ -1418,14 +1419,20 @@ DetectPort *PortParse(const char *str)
         port2[0] = '\0';
         port2++;
 
-        if(DetectPortIsValidRange(port))
-            dp->port = atoi(port);
+        if (DetectPortIsValidRange(port)) {
+            if (ByteExtractStringUint16(&dp->port, 10, 0,
+                                        (const char *)port) < 0)
+                goto error;
+        }
         else
             goto error;
 
         if (strcmp(port2, "") != 0) {
-            if (DetectPortIsValidRange(port2))
-                dp->port2 = atoi(port2);
+            if (DetectPortIsValidRange(port2)) {
+                if (ByteExtractStringUint16(&dp->port2, 10, 0,
+                                            (const char *)port2) < 0)
+                    goto error;
+            }
             else
                 goto error;
         } else {
@@ -1440,7 +1447,12 @@ DetectPort *PortParse(const char *str)
             dp->port = 0;
             dp->port2 = 65535;
         } else if(DetectPortIsValidRange(port)){
-            dp->port = dp->port2 = atoi(port);
+            if ((ByteExtractStringUint16(&dp->port, 10, 0,
+                                         (const char *)port) < 0) ||
+                (ByteExtractStringUint16(&dp->port2, 10, 0,
+                                         (const char *)port) < 0))
+                goto error;
+
         } else {
             goto error;
         }

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2342,7 +2342,15 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
             }
 
             if (insp_recursion_limit != NULL) {
-                de_ctx->inspection_recursion_limit = atoi(insp_recursion_limit);
+                if (ByteExtractStringInt32(&de_ctx->inspection_recursion_limit,
+                    10, 0, (const char *)insp_recursion_limit) < 0) {
+                    SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
+                            "detect-engine.inspection-recursion-limit, "
+                            "resetting to %d",
+                            DETECT_ENGINE_DEFAULT_INSPECTION_RECURSION_LIMIT);
+                    de_ctx->inspection_recursion_limit =
+                        DETECT_ENGINE_DEFAULT_INSPECTION_RECURSION_LIMIT;
+                }
             } else {
                 de_ctx->inspection_recursion_limit =
                     DETECT_ENGINE_DEFAULT_INSPECTION_RECURSION_LIMIT;

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -33,6 +33,7 @@
 #include "detect-fast-pattern.h"
 
 #include "util-error.h"
+#include "util-byte.h"
 #include "util-debug.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
@@ -282,10 +283,16 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, const c
                        "for fast_pattern offset");
             goto error;
         }
-        int offset = atoi(arg_substr);
-        if (offset > 65535) {
-            SCLogError(SC_ERR_INVALID_SIGNATURE, "Fast pattern offset exceeds "
-                       "limit");
+        int offset;
+        if (ByteExtractStringInt32(&offset, 10, 0,
+                                   (const char *)arg_substr) < 0) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid fast pattern offset:"
+                       " \"%s\"", arg_substr);
+            goto error;
+        }
+        if (offset < 0 || offset > 65535) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "Fast pattern offset outside "
+                       "[0, 65535)");
             goto error;
         }
 
@@ -296,10 +303,16 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, const c
                        "for fast_pattern offset");
             goto error;
         }
-        int length = atoi(arg_substr);
-        if (length > 65535) {
-            SCLogError(SC_ERR_INVALID_SIGNATURE, "Fast pattern length exceeds "
-                       "limit");
+        int length;
+        if (ByteExtractStringInt32(&length, 10, 0,
+                                   (const char *)arg_substr) < 0) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid value for fast "
+                    "pattern: \"%s\"", arg_substr);
+            goto error;
+        }
+        if (length <0 || length > 65535) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "Fast pattern length outside "
+                       "range [0, 65535)");
             goto error;
         }
 

--- a/src/detect-id.c
+++ b/src/detect-id.c
@@ -38,6 +38,7 @@
 #include "flow-var.h"
 
 #include "util-debug.h"
+#include "util-byte.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 
@@ -153,7 +154,10 @@ static DetectIdData *DetectIdParse (const char *idstr)
     }
 
     /* ok, fill the id data */
-    temp = atoi((char *)tmp_str);
+    if (ByteExtractStringUint32(&temp, 10, 0, (const char *)tmp_str) < 0) {
+        SCLogError(SC_ERR_INVALID_VALUE, "invalid id option '%s'", tmp_str);
+        return NULL;
+    }
 
     if (temp > DETECT_IPID_MAX) {
         SCLogError(SC_ERR_INVALID_VALUE, "invalid id option '%s'. The id option "

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -481,7 +481,8 @@ static int DetectIPProtoTestParse02(void)
 static int DetectIPProtoTestSetup01(void)
 {
     const char *value_str = "14";
-    int value = atoi(value_str);
+    int value;
+    FAIL_IF(ByteExtractStringInt32(&value, 10, 0, (const char *)value_str) < 0);
     int i;
 
     Signature *sig = SigAlloc();

--- a/src/detect-iprep.c
+++ b/src/detect-iprep.c
@@ -41,6 +41,7 @@
 #include "detect-engine-state.h"
 
 #include "util-debug.h"
+#include "util-byte.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 #include "util-fmemopen.h"
@@ -321,7 +322,8 @@ int DetectIPRepSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
     }
 
     if (value != NULL && strlen(value) > 0) {
-        int ival = atoi(value);
+        int ival;
+        ByteExtractStringInt32(&ival, 10, 0, (const char *)value);
         if (ival < 0 || ival > 127)
             goto error;
         val = (uint8_t)ival;

--- a/src/detect-krb5-errcode.c
+++ b/src/detect-krb5-errcode.c
@@ -23,6 +23,7 @@
 
 #include "suricata-common.h"
 #include "util-unittest.h"
+#include "util-byte.h"
 
 #include "detect-parse.h"
 #include "detect-engine.h"
@@ -162,7 +163,10 @@ static DetectKrb5ErrCodeData *DetectKrb5ErrCodeParse (const char *krb5str)
     krb5d = SCMalloc(sizeof (DetectKrb5ErrCodeData));
     if (unlikely(krb5d == NULL))
         goto error;
-    krb5d->err_code = (int32_t)atoi(arg1);
+    if (ByteExtractStringInt32(&krb5d->err_code, 10, 0,
+                               (const char *)arg1) < 0) {
+        goto error;
+    }
 
     return krb5d;
 

--- a/src/detect-krb5-msgtype.c
+++ b/src/detect-krb5-msgtype.c
@@ -23,6 +23,7 @@
 
 #include "suricata-common.h"
 #include "util-unittest.h"
+#include "util-byte.h"
 
 #include "detect-parse.h"
 #include "detect-engine.h"
@@ -159,8 +160,10 @@ static DetectKrb5MsgTypeData *DetectKrb5MsgTypeParse (const char *krb5str)
     krb5d = SCMalloc(sizeof (DetectKrb5MsgTypeData));
     if (unlikely(krb5d == NULL))
         goto error;
-    krb5d->msg_type = (uint8_t)atoi(arg1);
-
+    if (ByteExtractStringUint8(&krb5d->msg_type, 10, 0,
+                               (const char *)arg1) < 0) {
+        goto error;
+    }
     return krb5d;
 
 error:

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -43,6 +43,7 @@
 #include "util-debug.h"
 #include "util-spm-bm.h"
 #include "util-print.h"
+#include "util-byte.h"
 
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
@@ -278,7 +279,14 @@ int DetectLuaMatchBuffer(DetectEngineThreadCtx *det_ctx,
                 SCLogDebug("k='%s', v='%s'", k, v);
 
                 if (strcmp(k, "retval") == 0) {
-                    if (atoi(v) == 1)
+                    int val;
+                    if (ByteExtractStringInt32(&val, 10, 0,
+                                               (const char *)v) < 0) {
+                        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value in "
+                                   "the table: '%s'", v);
+                        ret = 0;
+                    }
+                    if (val == 1)
                         ret = 1;
                 } else {
                     /* set flow var? */
@@ -426,7 +434,14 @@ static int DetectLuaMatch (DetectEngineThreadCtx *det_ctx,
                 SCLogDebug("k='%s', v='%s'", k, v);
 
                 if (strcmp(k, "retval") == 0) {
-                    if (atoi(v) == 1)
+                    int val;
+                    if (ByteExtractStringInt32(&val, 10, 0,
+                                               (const char *)v) < 0) {
+                        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value in "
+                                   "the table: '%s'", v);
+                        ret = 0;
+                    }
+                    if (val == 1)
                         ret = 1;
                 } else {
                     /* set flow var? */
@@ -528,7 +543,14 @@ static int DetectLuaAppMatchCommon (DetectEngineThreadCtx *det_ctx,
                 SCLogDebug("k='%s', v='%s'", k, v);
 
                 if (strcmp(k, "retval") == 0) {
-                    if (atoi(v) == 1)
+                    int val;
+                    if (ByteExtractStringInt32(&val, 10, 0,
+                                               (const char *)v) < 0) {
+                        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value in "
+                                   "the table: '%s'", v);
+                        ret = 0;
+                    }
+                    if (val == 1)
                         ret = 1;
                 } else {
                     /* set flow var? */

--- a/src/detect-modbus.c
+++ b/src/detect-modbus.c
@@ -51,6 +51,7 @@
 #include "detect-engine-modbus.h"
 
 #include "util-debug.h"
+#include "util-byte.h"
 
 #include "app-layer-modbus.h"
 
@@ -195,13 +196,28 @@ static DetectModbus *DetectModbusAccessParse(const char *str)
                 goto error;
 
             if (arg[0] == '>') {
-                modbus->address->min    = atoi((const char*) (arg+1));
+                if (ByteExtractStringUint16(&modbus->address->min, 10, 0,
+                                            (const char*) (arg + 1)) < 0) {
+                    SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for min "
+                               "address: '%d'", arg[1]);
+                    goto error;
+                }
                 modbus->address->mode   = DETECT_MODBUS_GT;
             } else if (arg[0] == '<') {
-                modbus->address->min    = atoi((const char*) (arg+1));
+                if (ByteExtractStringUint16(&modbus->address->min, 10, 0,
+                                            (const char*) (arg + 1)) < 0) {
+                    SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for min "
+                               "address: '%d'", arg[1]);
+                    goto error;
+                }
                 modbus->address->mode   = DETECT_MODBUS_LT;
             } else {
-                modbus->address->min    = atoi((const char*) arg);
+                if (ByteExtractStringUint16(&modbus->address->min, 10, 0,
+                                            (const char*) (arg)) < 0) {
+                    SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for min "
+                               "address: '%d'", arg[0]);
+                    goto error;
+                }
             }
             SCLogDebug("and min/equal address %d", modbus->address->min);
 
@@ -213,7 +229,12 @@ static DetectModbus *DetectModbusAccessParse(const char *str)
                 }
 
                 if (*arg != '\0') {
-                    modbus->address->max    = atoi((const char*) (arg+2));
+                    if (ByteExtractStringUint16(&modbus->address->max, 10, 0,
+                                                (const char*) (arg + 2)) < 0) {
+                        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                                "max address: '%d'", arg[2]);
+                        goto error;
+                    }
                     modbus->address->mode   = DETECT_MODBUS_RA;
                     SCLogDebug("and max address %d", modbus->address->max);
                 }
@@ -240,13 +261,28 @@ static DetectModbus *DetectModbusAccessParse(const char *str)
                         goto error;
 
                     if (arg[0] == '>') {
-                        modbus->data->min   = atoi((const char*) (arg+1));
+                        if (ByteExtractStringUint16(&modbus->data->min, 10, 0,
+                                                    (const char*) (arg + 1)) < 0) {
+                        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for min "
+                                "address: '%d'", arg[1]);
+                        goto error;
+                        }
                         modbus->data->mode  = DETECT_MODBUS_GT;
                     } else if (arg[0] == '<') {
-                        modbus->data->min   = atoi((const char*) (arg+1));
+                        if (ByteExtractStringUint16(&modbus->data->min, 10, 0,
+                                                    (const char*) (arg + 1)) < 0) {
+                        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for min "
+                                   "address: '%d'", arg[1]);
+                        goto error;
+                        }
                         modbus->data->mode  = DETECT_MODBUS_LT;
                     } else {
-                        modbus->data->min   = atoi((const char*) arg);
+                        if (ByteExtractStringUint16(&modbus->data->min, 10, 0,
+                                                    (const char*)arg) < 0) {
+                        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for min "
+                                   "address: '%d'", arg[0]);
+                        goto error;
+                        }
                     }
                     SCLogDebug("and min/equal value %d", modbus->data->min);
 
@@ -258,7 +294,12 @@ static DetectModbus *DetectModbusAccessParse(const char *str)
                         }
 
                         if (*arg != '\0') {
-                            modbus->data->max   = atoi((const char*) (arg+2));
+                            if (ByteExtractStringUint16(&modbus->data->max,
+                                                        10, 0, (const char*) (arg + 2)) < 0) {
+                                SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                                        "max address: '%d'", arg[2]);
+                                goto error;
+                            }
                             modbus->data->mode  = DETECT_MODBUS_RA;
                             SCLogDebug("and max value %d", modbus->data->max);
                         }
@@ -311,7 +352,11 @@ static DetectModbus *DetectModbusFunctionParse(const char *str)
         goto error;
 
     if (isdigit((unsigned char)ptr[0])) {
-        modbus->function = atoi((const char*) ptr);
+        if (ByteExtractStringUint8(&modbus->function, 10, 0, (const char *)ptr) < 0) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                       "modbus function: '%d'", ptr[0]);
+            goto error;
+        }
         /* Function code 0 is managed by decoder_event INVALID_FUNCTION_CODE */
         if (modbus->function == MODBUS_FUNC_NONE) {
             SCLogError(SC_ERR_INVALID_SIGNATURE,
@@ -333,8 +378,12 @@ static DetectModbus *DetectModbusFunctionParse(const char *str)
             modbus->subfunction =(uint16_t *) SCCalloc(1, sizeof(uint16_t));
             if (modbus->subfunction == NULL)
                 goto error;
+            if (ByteExtractStringUint16(&(*modbus->subfunction), 10, 0, (const char *)arg) < 0) {
+                SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                           "modbus subfunction: '%d'", arg[0]);
+                goto error;
+            }
 
-            *(modbus->subfunction) = atoi((const char*) arg);
             SCLogDebug("and subfunction %d", *(modbus->subfunction));
         }
     } else {
@@ -428,13 +477,25 @@ static DetectModbus *DetectModbusUnitIdParse(const char *str)
         goto error;
 
     if (arg[0] == '>') {
-        modbus->unit_id->min   = atoi((const char*) (arg+1));
+        if (ByteExtractStringUint16(&modbus->unit_id->min, 10, 0, (const char *) (arg + 1)) < 0) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                       "modbus min unit id: '%d'", arg[1]);
+            goto error;
+        }
         modbus->unit_id->mode  = DETECT_MODBUS_GT;
     } else if (arg[0] == '<') {
-        modbus->unit_id->min   = atoi((const char*) (arg+1));
+        if (ByteExtractStringUint16(&modbus->unit_id->min, 10, 0, (const char *) (arg + 1)) < 0) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                       "modbus min unit id: '%d'", arg[1]);
+            goto error;
+        }
         modbus->unit_id->mode  = DETECT_MODBUS_LT;
     } else {
-        modbus->unit_id->min   = atoi((const char*) arg);
+        if (ByteExtractStringUint16(&modbus->unit_id->min, 10, 0, (const char *)arg) < 0) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                       "modbus min unit id: '%d'", arg[0]);
+            goto error;
+        }
     }
     SCLogDebug("and min/equal unit id %d", modbus->unit_id->min);
 
@@ -446,7 +507,11 @@ static DetectModbus *DetectModbusUnitIdParse(const char *str)
         }
 
         if (*arg != '\0') {
-            modbus->unit_id->max   = atoi((const char*) (arg+2));
+            if (ByteExtractStringUint16(&modbus->unit_id->max, 10, 0, (const char *) (arg + 2)) < 0) {
+                SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                           "modbus max unit id: '%d'", arg[2]);
+                goto error;
+            }
             modbus->unit_id->mode  = DETECT_MODBUS_RA;
             SCLogDebug("and max unit id %d", modbus->unit_id->max);
         }

--- a/src/detect-nfs-procedure.c
+++ b/src/detect-nfs-procedure.c
@@ -42,6 +42,7 @@
 
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
+#include "util-byte.h"
 
 #include "app-layer-nfs-tcp.h"
 #include "rust.h"
@@ -291,7 +292,10 @@ static DetectNfsProcedureData *DetectNfsProcedureParse (const char *rawstr)
     }
 
     /* set the first value */
-    dd->lo = atoi(value1); //TODO
+    if (ByteExtractStringUint32(&dd->lo, 10, 0, (const char *)value1) < 0) { //TODO
+        SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid first value: '%s'", value1);
+        goto error;
+    }
 
     /* set the second value if specified */
     if (strlen(value2) > 0) {
@@ -302,7 +306,10 @@ static DetectNfsProcedureData *DetectNfsProcedureParse (const char *rawstr)
         }
 
         //
-        dd->hi = atoi(value2); // TODO
+        if (ByteExtractStringUint32(&dd->hi, 10, 0, (const char *)value2) < 0) { //TODO
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid second value: '%s'", value2);
+            goto error;
+        }
 
         if (dd->hi <= dd->lo) {
             SCLogError(SC_ERR_INVALID_ARGUMENT,

--- a/src/detect-nfs-version.c
+++ b/src/detect-nfs-version.c
@@ -42,6 +42,7 @@
 
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
+#include "util-byte.h"
 
 #include "app-layer-nfs-tcp.h"
 #include "rust.h"
@@ -282,7 +283,10 @@ static DetectNfsVersionData *DetectNfsVersionParse (const char *rawstr)
     }
 
     /* set the first value */
-    dd->lo = atoi(value1); //TODO
+    if (ByteExtractStringUint32(&dd->lo, 10, 0, (const char *)value1) < 0) { //TODO
+        SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid first value: '%s'", value1);
+        goto error;
+    }
 
     /* set the second value if specified */
     if (strlen(value2) > 0) {
@@ -292,8 +296,10 @@ static DetectNfsVersionData *DetectNfsVersionParse (const char *rawstr)
             goto error;
         }
 
-        //
-        dd->hi = atoi(value2); // TODO
+        if (ByteExtractStringUint32(&dd->hi, 10, 0, (const char *)value2) < 0) { //TODO
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid second value: '%s'", value2);
+            goto error;
+        }
 
         if (dd->hi <= dd->lo) {
             SCLogError(SC_ERR_INVALID_ARGUMENT,

--- a/src/detect-stream_size.c
+++ b/src/detect-stream_size.c
@@ -34,6 +34,7 @@
 #include "detect-stream_size.h"
 #include "stream-tcp-private.h"
 #include "util-debug.h"
+#include "util-byte.h"
 
 /**
  * \brief Regex for parsing our flow options
@@ -245,7 +246,10 @@ static DetectStreamSizeData *DetectStreamSizeParse (const char *streamstr)
     }
 
     /* set the value */
-    sd->ssize = (uint32_t)atoi(value);
+    if (ByteExtractStringUint32(&sd->ssize, 10, 0, (const char *)value) < 0) {
+        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for stream size: '%s'", value);
+        goto error;
+    }
 
     /* inspect our options and set the flags */
     if (strcmp(arg, "server") == 0) {

--- a/src/detect-tcpmss.c
+++ b/src/detect-tcpmss.c
@@ -27,6 +27,7 @@
 #include "detect.h"
 #include "detect-parse.h"
 #include "detect-engine-prefilter-common.h"
+#include "util-byte.h"
 
 #include "detect-tcpmss.h"
 
@@ -181,7 +182,9 @@ static DetectTcpmssData *DetectTcpmssParse (const char *tcpmssstr)
                     goto error;
 
                 tcpmssd->mode = DETECT_TCPMSS_LT;
-                tcpmssd->arg1 = (uint16_t) atoi(arg3);
+                if (ByteExtractStringUint16(&tcpmssd->arg1, 10, 0, (const char *)arg3) < 0) {
+                    goto error;
+                }
 
                 SCLogDebug("tcpmss is %"PRIu16"",tcpmssd->arg1);
                 if (strlen(arg1) > 0)
@@ -193,7 +196,9 @@ static DetectTcpmssData *DetectTcpmssParse (const char *tcpmssstr)
                     goto error;
 
                 tcpmssd->mode = DETECT_TCPMSS_GT;
-                tcpmssd->arg1 = (uint16_t) atoi(arg3);
+                if (ByteExtractStringUint16(&tcpmssd->arg1, 10, 0, (const char *)arg3) < 0) {
+                    goto error;
+                }
 
                 SCLogDebug("tcpmss is %"PRIu16"",tcpmssd->arg1);
                 if (strlen(arg1) > 0)
@@ -207,9 +212,14 @@ static DetectTcpmssData *DetectTcpmssParse (const char *tcpmssstr)
                     goto error;
 
                 tcpmssd->mode = DETECT_TCPMSS_RA;
-                tcpmssd->arg1 = (uint16_t) atoi(arg1);
-
-                tcpmssd->arg2 = (uint16_t) atoi(arg3);
+                if (ByteExtractStringUint16(&tcpmssd->arg1, 10, 0, (const char *)arg1) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg: '%s'", arg1);
+                    goto error;
+                }
+                if (ByteExtractStringUint16(&tcpmssd->arg2, 10, 0, (const char *)arg3) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid second arg: '%s'", arg3);
+                    goto error;
+                }
                 SCLogDebug("tcpmss is %"PRIu16" to %"PRIu16"",tcpmssd->arg1, tcpmssd->arg2);
                 if (tcpmssd->arg1 >= tcpmssd->arg2) {
                     SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid tcpmss range. ");
@@ -223,8 +233,10 @@ static DetectTcpmssData *DetectTcpmssParse (const char *tcpmssstr)
                     (arg3 != NULL && strlen(arg3) > 0) ||
                     (arg1 == NULL ||strlen(arg1) == 0))
                     goto error;
-
-                tcpmssd->arg1 = (uint16_t) atoi(arg1);
+                if (ByteExtractStringUint16(&tcpmssd->arg1, 10, 0, (const char *)arg1) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg: '%s'", arg1);
+                    goto error;
+                }
                 break;
         }
     } else {
@@ -233,8 +245,10 @@ static DetectTcpmssData *DetectTcpmssParse (const char *tcpmssstr)
         if ((arg3 != NULL && strlen(arg3) > 0) ||
             (arg1 == NULL ||strlen(arg1) == 0))
             goto error;
-
-        tcpmssd->arg1 = (uint16_t) atoi(arg1);
+        if (ByteExtractStringUint16(&tcpmssd->arg1, 10, 0, (const char *)arg1) < 0) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg: '%s'", arg1);
+            goto error;
+        }
     }
 
     SCFree(arg1);

--- a/src/detect-template.c
+++ b/src/detect-template.c
@@ -25,6 +25,7 @@
 
 #include "suricata-common.h"
 #include "util-unittest.h"
+#include "util-byte.h"
 
 #include "detect-parse.h"
 #include "detect-engine.h"
@@ -158,8 +159,14 @@ static DetectTemplateData *DetectTemplateParse (const char *templatestr)
     if (unlikely(templated == NULL))
         return NULL;
 
-    templated->arg1 = (uint8_t)atoi(arg1);
-    templated->arg2 = (uint8_t)atoi(arg2);
+    if (ByteExtractStringUint8(&templated->arg1, 10, 0, (const char *)arg1) < 0) {
+        SCFree(templated);
+        return NULL;
+    }
+    if (ByteExtractStringUint8(&templated->arg2, 10, 0, (const char *)arg2) < 0) {
+        SCFree(templated);
+        return NULL;
+    }
 
     return templated;
 }

--- a/src/detect-template2.c
+++ b/src/detect-template2.c
@@ -23,6 +23,7 @@
  */
 
 #include "suricata-common.h"
+#include "util-byte.h"
 
 #include "detect.h"
 #include "detect-parse.h"
@@ -187,7 +188,11 @@ static DetectTemplate2Data *DetectTemplate2Parse (const char *template2str)
                     goto error;
 
                 template2d->mode = DETECT_TEMPLATE2_LT;
-                template2d->arg1 = (uint8_t) atoi(arg3);
+                if (ByteExtractStringUint8(&template2d->arg1, 10, 0, (const char *)arg3) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg:"
+                               " '%s'", arg3);
+                    goto error;
+                }
 
                 SCLogDebug("template2 is %"PRIu8"",template2d->arg1);
                 if (strlen(arg1) > 0)
@@ -199,7 +204,11 @@ static DetectTemplate2Data *DetectTemplate2Parse (const char *template2str)
                     goto error;
 
                 template2d->mode = DETECT_TEMPLATE2_GT;
-                template2d->arg1 = (uint8_t) atoi(arg3);
+                if (ByteExtractStringUint8(&template2d->arg1, 10, 0, (const char *)arg3) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg:"
+                               " '%s'", arg3);
+                    goto error;
+                }
 
                 SCLogDebug("template2 is %"PRIu8"",template2d->arg1);
                 if (strlen(arg1) > 0)
@@ -213,9 +222,17 @@ static DetectTemplate2Data *DetectTemplate2Parse (const char *template2str)
                     goto error;
 
                 template2d->mode = DETECT_TEMPLATE2_RA;
-                template2d->arg1 = (uint8_t) atoi(arg1);
+                if (ByteExtractStringUint8(&template2d->arg1, 10, 0, (const char *)arg1) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg:"
+                               " '%s'", arg1);
+                    goto error;
+                }
+                if (ByteExtractStringUint8(&template2d->arg2, 10, 0, (const char *)arg3) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid second arg:"
+                               " '%s'", arg3);
+                    goto error;
+                }
 
-                template2d->arg2 = (uint8_t) atoi(arg3);
                 SCLogDebug("template2 is %"PRIu8" to %"PRIu8"",template2d->arg1, template2d->arg2);
                 if (template2d->arg1 >= template2d->arg2) {
                     SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid template2 range. ");
@@ -230,7 +247,12 @@ static DetectTemplate2Data *DetectTemplate2Parse (const char *template2str)
                     (arg1 == NULL ||strlen(arg1) == 0))
                     goto error;
 
-                template2d->arg1 = (uint8_t) atoi(arg1);
+                if (ByteExtractStringUint8(&template2d->arg1, 10, 0, (const char *)arg1) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg:"
+                               " '%s'", arg1);
+                    goto error;
+                }
+
                 break;
         }
     } else {
@@ -239,8 +261,11 @@ static DetectTemplate2Data *DetectTemplate2Parse (const char *template2str)
         if ((arg3 != NULL && strlen(arg3) > 0) ||
             (arg1 == NULL ||strlen(arg1) == 0))
             goto error;
-
-        template2d->arg1 = (uint8_t) atoi(arg1);
+        if (ByteExtractStringUint8(&template2d->arg1, 10, 0, (const char *)arg1) < 0) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg:"
+                       " '%s'", arg1);
+            goto error;
+        }
     }
 
     SCFree(arg1);

--- a/src/detect-ttl.c
+++ b/src/detect-ttl.c
@@ -33,6 +33,7 @@
 
 #include "detect-ttl.h"
 #include "util-debug.h"
+#include "util-byte.h"
 
 /**
  * \brief Regex for parsing our ttl options
@@ -181,7 +182,11 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
                     return NULL;
 
                 mode = DETECT_TTL_LT;
-                ttl1 = atoi(arg3);
+                if (ByteExtractStringInt32(&ttl1, 10, 0, (const char *)arg3) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first ttl "
+                               "value: '%s'", arg3);
+                    return NULL;
+                }
 
                 SCLogDebug("ttl is %d",ttl1);
                 if (strlen(arg1) > 0)
@@ -193,7 +198,11 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
                     return NULL;
 
                 mode = DETECT_TTL_GT;
-                ttl1 = atoi(arg3);
+                if (ByteExtractStringInt32(&ttl1, 10, 0, (const char *)arg3) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first ttl "
+                               "value: '%s'", arg3);
+                    return NULL;
+                }
 
                 SCLogDebug("ttl is %d",ttl1);
                 if (strlen(arg1) > 0)
@@ -205,8 +214,16 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
                     return NULL;
 
                 mode = DETECT_TTL_RA;
-                ttl1 = atoi(arg1);
-                ttl2 = atoi(arg3);
+                if (ByteExtractStringInt32(&ttl1, 10, 0, (const char *)arg1) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first ttl "
+                               "value: '%s'", arg1);
+                    return NULL;
+                }
+                if (ByteExtractStringInt32(&ttl2, 10, 0, (const char *)arg3) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid second ttl "
+                               "value: '%s'", arg3);
+                    return NULL;
+                }
 
                 SCLogDebug("ttl is %d to %d",ttl1, ttl2);
                 if (ttl1 >= ttl2) {
@@ -222,7 +239,12 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
                     (strlen(arg1) == 0))
                     return NULL;
 
-                ttl1 = atoi(arg1);
+                if (ByteExtractStringInt32(&ttl1, 10, 0, (const char *)arg1) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first ttl "
+                               "value: '%s'", arg1);
+                    return NULL;
+                }
+
                 break;
         }
     } else {
@@ -231,8 +253,11 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
         if ((strlen(arg3) > 0) ||
             (strlen(arg1) == 0))
             return NULL;
-
-        ttl1 = atoi(arg1);
+        if (ByteExtractStringInt32(&ttl1, 10, 0, (const char *)arg1) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first ttl "
+                               "value: '%s'", arg1);
+                    return NULL;
+        }
     }
 
     if (ttl1 < 0 || ttl1 > UCHAR_MAX ||

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -32,6 +32,7 @@
 #include "detect-xbits.h"
 #include "detect-hostbits.h"
 #include "util-spm.h"
+#include "util-byte.h"
 
 #include "detect-engine-sigorder.h"
 
@@ -249,7 +250,11 @@ static int DetectXbitParse(DetectEngineCtx *de_ctx,
                     return -1;
                 }
                 SCLogDebug("expire_str %s", expire_str);
-                expire = atoi(expire_str);
+                if (ByteExtractStringInt32(&expire, 10, 0, (const char *)expire_str) < 0) {
+                    SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                               "expire: '%s'", expire_str);
+                    return -1;
+                }
                 if (expire < 0) {
                     SCLogError(SC_ERR_INVALID_VALUE, "expire must be positive. "
                             "Got %d (\"%s\")", expire, expire_str);

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -28,6 +28,7 @@
 #include "suricata-common.h"
 #include "util-error.h"
 #include "util-debug.h"
+#include "util-byte.h"
 #include "util-ip.h"
 #include "util-radix-tree.h"
 #include "util-unittest.h"
@@ -251,7 +252,8 @@ static int SRepCatSplitLine(char *line, uint8_t *cat, char *shortname, size_t sh
 
     SCLogDebug("%s, %s", ptrs[0], ptrs[1]);
 
-    int c = atoi(ptrs[0]);
+    int c;
+    ByteExtractStringInt32(&c, 10, 0, (const char *)ptrs[0]);
     if (c < 0 || c >= SREP_MAX_CATS) {
         return -1;
     }
@@ -305,12 +307,14 @@ static int SRepSplitLine(SRepCIDRTree *cidr_ctx, char *line, Address *ip, uint8_
     if (strcmp(ptrs[0], "ip") == 0)
         return 1;
 
-    int c = atoi(ptrs[1]);
+    int c;
+    ByteExtractStringInt32(&c, 10, 0, (const char *)ptrs[1]);
     if (c < 0 || c >= SREP_MAX_CATS) {
         return -1;
     }
 
-    int v = atoi(ptrs[2]);
+    int v;
+    ByteExtractStringInt32(&v, 10, 0, (const char *)ptrs[2]);
     if (v < 0 || v > SREP_MAX_VAL) {
         return -1;
     }

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -55,6 +55,7 @@
 #include "util-runmodes.h"
 #include "util-ioctl.h"
 #include "util-ebpf.h"
+#include "util-byte.h"
 
 #include "source-af-packet.h"
 
@@ -195,7 +196,9 @@ static void *ParseAFPConfig(const char *iface)
             if (strcmp(threadsstr, "auto") == 0) {
                 aconf->threads = 0;
             } else {
-                aconf->threads = atoi(threadsstr);
+                if (ByteExtractStringInt32(&aconf->threads, 10, 0, (const char *)threadsstr) < 0) {
+                    goto finalize;
+                }
             }
         }
     }
@@ -290,7 +293,9 @@ static void *ParseAFPConfig(const char *iface)
     if (ConfGetChildValueWithDefault(if_root, if_default, "cluster-id", &tmpclusterid) != 1) {
         aconf->cluster_id = (uint16_t)(cluster_id_auto++);
     } else {
-        aconf->cluster_id = (uint16_t)atoi(tmpclusterid);
+        if (ByteExtractStringInt32(&aconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
+            goto finalize;
+        }
         SCLogDebug("Going to use cluster-id %" PRId32, aconf->cluster_id);
     }
 

--- a/src/runmode-napatech.c
+++ b/src/runmode-napatech.c
@@ -169,7 +169,10 @@ static void *NapatechConfigParser(const char *device)
     }
 
     /* device+5 is a pointer to the beginning of the stream id after the constant nt portion */
-    conf->stream_id = atoi(device + 2);
+    if (ByteExtractStringUint16(&conf->stream_id, 10, 0, (const char *)(device + 2)) < 0) {
+        SCFree(conf);
+        return NULL;
+    }
 
     /* Set the host buffer allowance for this stream
      * Right now we just look at the global default - there is no per-stream hba configuration

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -149,7 +149,9 @@ static int ParseNetmapSettings(NetmapIfaceSettings *ns, const char *iface,
             ns->threads = 0;
             ns->threads_auto = true;
         } else {
-            ns->threads = atoi(threadsstr);
+            if (ByteExtractStringUint16(&ns->threads, 10, 0, (const char *)threadsstr) < 0) {
+                goto finalize;
+            }
         }
     }
 

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -31,6 +31,7 @@
 #include "util-runmodes.h"
 #include "util-atomic.h"
 #include "util-misc.h"
+#include "util-byte.h"
 
 const char *RunModeIdsGetDefaultMode(void)
 {
@@ -144,7 +145,11 @@ static void *ParsePcapConfig(const char *iface)
         aconf->threads = 1;
     } else {
         if (threadsstr != NULL) {
-            aconf->threads = atoi(threadsstr);
+            if (ByteExtractStringInt32(&aconf->threads, 10, 0, (const char *)threadsstr) < 0) {
+                SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for aconf "
+                             "threads: '%s'. Resetting to 1.", threadsstr);
+                aconf->threads = 1;
+            }
         }
     }
     if (aconf->threads == 0) {

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -123,7 +123,11 @@ static void *OldParsePfringConfig(const char *iface)
         pfconf->threads = 1;
     } else {
         if (threadsstr != NULL) {
-            pfconf->threads = atoi(threadsstr);
+            if (ByteExtractStringUint16(&pfconf->threads, 10, 0, (const char *)threadsstr) < 0) {
+                SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for pfconf "
+                             "threads: '%s'. Resetting it to 1.", threadsstr);
+                pfconf->threads = 1;
+            }
         }
     }
     if (pfconf->threads == 0) {
@@ -141,7 +145,11 @@ static void *OldParsePfringConfig(const char *iface)
     } else if (ConfGet("pfring.cluster-id", &tmpclusterid) != 1) {
         SCLogError(SC_ERR_INVALID_ARGUMENT,"Could not get cluster-id from config");
     } else {
-        pfconf->cluster_id = (uint16_t)atoi(tmpclusterid);
+        if (ByteExtractStringUint16(&pfconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid value for cluster "
+                       "id: '%s'. Resetting to 1.", tmpclusterid);
+            pfconf->cluster_id = 1;
+        }
         pfconf->flags |= PFRING_CONF_FLAGS_CLUSTER;
         SCLogDebug("Going to use cluster-id %" PRId32, pfconf->cluster_id);
     }
@@ -255,7 +263,11 @@ static void *ParsePfringConfig(const char *iface)
                 }
             }
         } else {
-            pfconf->threads = atoi(threadsstr);
+            if (ByteExtractStringUint16(&pfconf->threads, 10, 0, (const char *)threadsstr) < 0) {
+                SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
+                             "threads: '%s'. Resetting to 1.", threadsstr);
+                pfconf->threads = 1;
+            }
         }
     }
     if (pfconf->threads <= 0) {
@@ -267,7 +279,11 @@ static void *ParsePfringConfig(const char *iface)
 
     /* command line value has precedence */
     if (ConfGet("pfring.cluster-id", &tmpclusterid) == 1) {
-        pfconf->cluster_id = (uint16_t)atoi(tmpclusterid);
+        if (ByteExtractStringUint16(&pfconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
+            SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
+                         "cluster id: '%s'. Resetting to 1.", tmpclusterid);
+            pfconf->cluster_id = 1;
+        }
         pfconf->flags |= PFRING_CONF_FLAGS_CLUSTER;
         SCLogDebug("Going to use command-line provided cluster-id %" PRId32,
                    pfconf->cluster_id);
@@ -283,7 +299,11 @@ static void *ParsePfringConfig(const char *iface)
             SCLogError(SC_ERR_INVALID_ARGUMENT,
                        "Could not get cluster-id from config");
         } else {
-            pfconf->cluster_id = (uint16_t)atoi(tmpclusterid);
+            if (ByteExtractStringUint16(&pfconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
+                SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
+                             "cluster id: '%s'. Resetting to 1.", tmpclusterid);
+                pfconf->cluster_id = 1;
+            }
             pfconf->flags |= PFRING_CONF_FLAGS_CLUSTER;
             SCLogDebug("Going to use cluster-id %" PRId32, pfconf->cluster_id);
         }

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -26,6 +26,7 @@
 #define _THREAD_AFFINITY
 #include "util-affinity.h"
 #include "util-cpu.h"
+#include "util-byte.h"
 #include "conf.h"
 #include "threads.h"
 #include "queue.h"
@@ -280,7 +281,11 @@ void AffinitySetupLoadFromConfig()
 
         node = ConfNodeLookupChild(affinity->head.tqh_first, "threads");
         if (node != NULL) {
-            taf->nb_threads = atoi(node->val);
+            if (ByteExtractStringInt32(&taf->nb_threads, 10, 0, (const char *)node->val) < 0) {
+                SCLogError(SC_ERR_INVALID_VALUE, "invalid value for threads "
+                           "count: '%s'", node->val);
+                exit(EXIT_FAILURE);
+            }
             if (! taf->nb_threads) {
                 SCLogError(SC_ERR_INVALID_ARGUMENT, "bad value for threads count");
                 exit(EXIT_FAILURE);

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -34,6 +34,7 @@
 #include "util-error.h"
 #include "util-debug.h"
 #include "util-fmemopen.h"
+#include "util-byte.h"
 
 /* Regex to parse the classtype argument from a Signature.  The first substring
  * holds the classtype name, the second substring holds the classtype the
@@ -289,8 +290,9 @@ static int SCClassConfAddClasstype(char *rawstr, uint8_t index, DetectEngineCtx 
     if (strlen(ct_priority_str) == 0) {
         goto error;
     }
-
-    ct_priority = atoi(ct_priority_str);
+    if (ByteExtractStringInt32(&ct_priority, 10, 0, (const char *)ct_priority_str) < 0) {
+        goto error;
+    }
 
     /* Create a new instance of the parsed Classtype string */
     ct_new = SCClassConfAllocClasstype(ct_id, ct_name, ct_desc, ct_priority);

--- a/src/util-cpu.c
+++ b/src/util-cpu.c
@@ -27,6 +27,7 @@
 #include "util-error.h"
 #include "util-debug.h"
 #include "util-cpu.h"
+#include "util-byte.h"
 
 /**
  * Ok, if they should use sysconf, check that they have the macro's
@@ -77,7 +78,16 @@ uint16_t UtilCpuGetNumProcessorsConfigured(void)
 #elif OS_WIN32
 	long nprocs = -1;
 	const char* envvar = getenv("NUMBER_OF_PROCESSORS");
-	nprocs = (NULL != envvar) ? atoi(envvar) : 0;
+    if (envvar != NULL) {
+        if (ByteExtractStringInt64(&nprocs, 10, 0, (const char *)envvar) < 0) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for the number of "
+                       "cpus: '%s'", envvar);
+            return 0;
+        }
+    }
+    else {
+        nprocs = 0;
+    }
     if (nprocs < 1) {
         SCLogError(SC_ERR_SYSCALL, "Couldn't retrieve the number of cpus "
                    "configured from the NUMBER_OF_PROCESSORS environment variable");

--- a/src/util-host-info.c
+++ b/src/util-host-info.c
@@ -27,6 +27,7 @@
 #include "suricata-common.h"
 #include "config.h"
 #include "util-host-info.h"
+#include "util-byte.h"
 
 #ifndef OS_WIN32
 #include <sys/utsname.h>
@@ -83,12 +84,22 @@ int SCKernelVersionIsAtLeast(int major, int minor)
 
     pcre_get_substring_list(kuname.release, ov, ret, &list);
 
-    kmajor = atoi(list[1]);
-    kminor = atoi(list[2]);
+    bool err = false;
+    if (ByteExtractStringInt32(&kmajor, 10, 0, (const char *)list[1]) < 0) {
+        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for kmajor: '%s'", list[1]);
+        err = true;
+    }
+    if (ByteExtractStringInt32(&kminor, 10, 0, (const char *)list[2]) < 0) {
+        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for kminor: '%s'", list[2]);
+        err = true;
+    }
 
     pcre_free_substring_list(list);
     pcre_free_study(version_regex_study);
     pcre_free(version_regex);
+
+    if (err)
+        goto error;
 
     if (kmajor > major)
         return 1;

--- a/src/util-host-os-info.c
+++ b/src/util-host-os-info.c
@@ -29,6 +29,7 @@
 #include "util-debug.h"
 #include "util-ip.h"
 #include "util-radix-tree.h"
+#include "util-byte.h"
 #include "stream-tcp-private.h"
 #include "stream-tcp-reassemble.h"
 
@@ -186,7 +187,7 @@ int SCHInfoAddHostOSInfo(const char *host_os, const char *host_os_ip_range, int 
             SCRadixAddKeyIPV4((uint8_t *)ipv4_addr, sc_hinfo_tree,
                               (void *)user_data);
         } else {
-            netmask_value = atoi(netmask_str);
+            ByteExtractStringInt32(&netmask_value, 10, 0, (const char *)netmask_str);
             if (netmask_value < 0 || netmask_value > 32) {
                 SCLogError(SC_ERR_INVALID_IP_NETBLOCK, "Invalid IPV4 Netblock");
                 SCHInfoFreeUserDataOSPolicy(user_data);
@@ -212,7 +213,7 @@ int SCHInfoAddHostOSInfo(const char *host_os, const char *host_os_ip_range, int 
             SCRadixAddKeyIPV6((uint8_t *)ipv6_addr, sc_hinfo_tree,
                               (void *)user_data);
         } else {
-            netmask_value = atoi(netmask_str);
+            ByteExtractStringInt32(&netmask_value, 10, 0, (const char *)netmask_str);
             if (netmask_value < 0 || netmask_value > 128) {
                 SCLogError(SC_ERR_INVALID_IP_NETBLOCK, "Invalid IPV6 Netblock");
                 SCHInfoFreeUserDataOSPolicy(user_data);

--- a/src/util-ip.c
+++ b/src/util-ip.c
@@ -26,6 +26,7 @@
 
 #include "suricata-common.h"
 #include "util-ip.h"
+#include "util-byte.h"
 
 /** \brief determine if a string is a valid ipv4 address
  *  \retval bool is addr valid?
@@ -65,7 +66,8 @@ bool IPv4AddressStringIsValid(const char *str)
 
     addr[dots][alen] = '\0';
     for (int x = 0; x < 4; x++) {
-        int a = atoi(addr[x]);
+        int a;
+        ByteExtractStringInt32(&a, 10, 0, (const char *)addr[x]);
         if (a < 0 || a >= 256) {
             SCLogDebug("out of range");
             return false;

--- a/src/util-log-redis.c
+++ b/src/util-log-redis.c
@@ -26,6 +26,7 @@
 #include "suricata-common.h" /* errno.h, string.h, etc. */
 #include "util-log-redis.h"
 #include "util-logopenfile.h"
+#include "util-byte.h"
 
 #ifdef HAVE_LIBHIREDIS
 
@@ -514,7 +515,11 @@ int SCConfLogOpenRedis(ConfNode *redis_node, void *lf_ctx)
         SCLogError(SC_ERR_MEM_ALLOC, "Error allocating redis server string");
         exit(EXIT_FAILURE);
     }
-    log_ctx->redis_setup.port = atoi(redis_port);
+    if (ByteExtractStringInt32(&log_ctx->redis_setup.port, 10, 0, (const char *)redis_port) < 0) {
+        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for redis port: '%s'. "
+                   "Resetting to 6379.", redis_port);
+        log_ctx->redis_setup.port = 6379;
+    }
     log_ctx->Close = SCLogFileCloseRedis;
 
 #ifdef HAVE_LIBEVENT

--- a/src/util-napatech.c
+++ b/src/util-napatech.c
@@ -369,9 +369,14 @@ static uint32_t CountWorkerThreads(void)
 
                         char copystr[16];
                         strlcpy(copystr, lnode->val, 16);
-
-                        start = atoi(copystr);
-                        end = atoi(strchr(copystr, '-') + 1);
+                        bool err = false;
+                        if ((ByteExtractStringUint8(&start, 10, 0, (const char *)copystr) < 0) || \
+                           (ByteExtractStringUint8(&end, 10, 0, (const char *) (strchr(copystr, '-') + 1)) < 0))
+                            err = true;
+                        if (err) {
+                            SCLogError(SC_ERR_INVALID_VALUE, "Invalid worker count");
+                            exit(EXIT_FAILURE);
+                        }
                         worker_count = end - start + 1;
 
                     } else {
@@ -517,9 +522,13 @@ int NapatechGetStreamConfig(NapatechStreamConfig stream_config[])
 
                     char copystr[16];
                     strlcpy(copystr, stream->val, 16);
-
-                    start = atoi(copystr);
-                    end = atoi(strchr(copystr, '-') + 1);
+                    if ((ByteExtractStringUint8(&start, 10, 0, (const char *)copystr) < 0) || \
+                       (ByteExtractStringUint8(&end, 10, 0, (const char *) (strchr(copystr, '-') + 1)) < 0))
+                        err = true;
+                    if (err) {
+                        SCLogError(SC_ERR_INVALID_VALUE, "Invalid worker count");
+                        exit(EXIT_FAILURE);
+                    }
                 } else {
                     if (stream_spec == CONFIG_SPECIFIER_RANGE) {
                         SCLogError(SC_ERR_NAPATECH_PARSE_CONFIG,
@@ -528,7 +537,11 @@ int NapatechGetStreamConfig(NapatechStreamConfig stream_config[])
                     }
                     stream_spec = CONFIG_SPECIFIER_INDIVIDUAL;
 
-                    stream_config[instance_cnt].stream_id = atoi(stream->val);
+                    if (ByteExtractStringUint16(&stream_config[instance_cnt].stream_id,
+                                                10, 0, (const char *)stream->val) < 0) {
+                        SCLogError(SC_ERR_INVALID_VALUE, "Invalid stream id: '%s'", stream->val);
+                        exit(EXIT_FAILURE);
+                    }
                     start = stream_config[instance_cnt].stream_id;
                     end = stream_config[instance_cnt].stream_id;
                 }
@@ -978,9 +991,13 @@ uint32_t NapatechSetupTraffic(uint32_t first_stream, uint32_t last_stream,
 
             char copystr[16];
             strlcpy(copystr, port->val, sizeof(copystr));
-
-            start = atoi(copystr);
-            end = atoi(strchr(copystr, '-') + 1);
+            if ((ByteExtractStringUint8(&start, 10, 0, (const char *)copystr) < 0) || \
+               (ByteExtractStringUint8(&end, 10, 0, (const char *) (strchr(copystr, '-') + 1)) < 0))
+                err = true;
+            if (err) {
+                SCLogError(SC_ERR_INVALID_VALUE, "Invalid worker count");
+                exit(EXIT_FAILURE);
+            }
             snprintf(ports_spec, sizeof(ports_spec), "port == (%d..%d)", start, end);
 
         } else {

--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -33,6 +33,7 @@
 #include "suricata.h"
 
 #include "util-privs.h"
+#include "util-byte.h"
 
 #ifdef HAVE_LIBCAP_NG
 
@@ -155,7 +156,10 @@ int SCGetUserID(const char *user_name, const char *group_name, uint32_t *uid, ui
 
     /* Get the user ID */
     if (isdigit((unsigned char)user_name[0]) != 0) {
-        userid = atoi(user_name);
+        if (ByteExtractStringUint32(&userid, 10, 0, (const char *)user_name) < 0) {
+            SCLogError(SC_ERR_UID_FAILED, "Invalid user name: '%s'", user_name);
+            exit(EXIT_FAILURE);
+        }
         pw = getpwuid(userid);
        if (pw == NULL) {
             SCLogError(SC_ERR_UID_FAILED, "unable to get the user ID, "
@@ -177,7 +181,10 @@ int SCGetUserID(const char *user_name, const char *group_name, uint32_t *uid, ui
         struct group *gp;
 
         if (isdigit((unsigned char)group_name[0]) != 0) {
-            groupid = atoi(group_name);
+            if (ByteExtractStringUint32(&groupid, 10, 0, (const char *)group_name) < 0) {
+                SCLogError(SC_ERR_GID_FAILED, "invalid group id: '%s'", group_name);
+                exit(EXIT_FAILURE);
+            }
         } else {
             gp = getgrnam(group_name);
             if (gp == NULL) {
@@ -217,7 +224,10 @@ int SCGetGroupID(const char *group_name, uint32_t *gid)
 
     /* Get the group ID */
     if (isdigit((unsigned char)group_name[0]) != 0) {
-        grpid = atoi(group_name);
+        if (ByteExtractStringUint32(&grpid, 10, 0, (const char *)group_name) < 0) {
+            SCLogError(SC_ERR_GID_FAILED, "invalid group id: '%s'", group_name);
+            exit(EXIT_FAILURE);
+        }
     } else {
         gp = getgrnam(group_name);
         if (gp == NULL) {

--- a/src/util-proto-name.c
+++ b/src/util-proto-name.c
@@ -26,6 +26,7 @@
 
 #include "suricata-common.h"
 #include "util-proto-name.h"
+#include "util-byte.h"
 
 static int init_once = 0;
 
@@ -57,8 +58,9 @@ void SCProtoNameInit()
             if (proto_ch == NULL)
                 continue;
 
-            int proto = atoi(proto_ch);
-            if (proto >= 255)
+            int proto;
+            ByteExtractStringInt32(&proto, 10, 0, (const char *)proto_ch);
+            if (proto < 0 || proto >= 255)
                 continue;
 
             char *cname = strtok_r(NULL, " \t", &ptr);

--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -30,6 +30,7 @@
 #include "util-ip.h"
 #include "util-unittest.h"
 #include "util-memcmp.h"
+#include "util-byte.h"
 
 /**
  * \brief Allocates and returns a new instance of SCRadixUserData.
@@ -956,7 +957,7 @@ SCRadixNode *SCRadixAddKeyIPV4String(const char *str, SCRadixTree *tree, void *u
         }
 
         /* Get binary values for cidr mask */
-        cidr = atoi(mask_str);
+        ByteExtractStringInt32(&cidr, 10, 0, (const char *)mask_str);
         if ((cidr < 0) || (cidr > 32)) {
             return NULL;
         }
@@ -1004,7 +1005,7 @@ SCRadixNode *SCRadixAddKeyIPV6String(const char *str, SCRadixTree *tree, void *u
         }
 
         /* Get binary values for cidr mask */
-        cidr = atoi(mask_str);
+        ByteExtractStringInt32(&cidr, 10, 0, (const char *)mask_str);
         if ((cidr < 0) || (cidr > 128)) {
             return NULL;
         }


### PR DESCRIPTION
atoi() and related functions lack a mechanism for reporting errors for
invalid values. Replace them with calls to the appropriate
ByteExtractString* functions.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3053