### PR TITLE
configure.ac: fix static build with pcap

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1311,6 +1311,7 @@
     AC_CHECK_HEADERS([pcap.h pcap/pcap.h pcap/bpf.h])
 
     LIBPCAP=""
+    PKG_CHECK_MODULES([PCAP],libpcap,[CPPFLAGS="${CPPFLAGS} ${PCAP_CFLAGS}" LIBS="${LIBS} ${PCAP_LIBS}"],[])
     AC_CHECK_LIB(${PCAP_LIB_NAME}, pcap_open_live,, LIBPCAP="no")
     if test "$LIBPCAP" = "no"; then
         echo


### PR DESCRIPTION
pcap can depends on nl-3 so use pkg-config to find these dependencies
otherwise all AC_CHECK_LIB calls will fail when building statically

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>