### PR TITLE
boyermoore: avoid one tolower call

### DIFF
--- a/src/suricata.h
+++ b/src/suricata.h
@@ -178,6 +178,7 @@ extern uint16_t g_vlan_mask;
 
 #include <ctype.h>
 #define u8_tolower(c) tolower((uint8_t)(c))
+#define u8_toupper(c) toupper((uint8_t)(c))
 
 void EngineStop(void);
 void EngineDone(void);

--- a/src/util-spm-bm.c
+++ b/src/util-spm-bm.c
@@ -229,6 +229,7 @@ static void PreBmBcNocase(const uint8_t *x, uint16_t m, uint16_t *bmBc)
     }
     for (i = 0; i < m - 1; ++i) {
         bmBc[u8_tolower((unsigned char)x[i])] = m - 1 - i;
+        bmBc[u8_toupper((unsigned char)x[i])] = m - 1 - i;
     }
 }
 
@@ -380,7 +381,7 @@ uint8_t *BoyerMooreNocase(const uint8_t *x, uint16_t m, const uint8_t *y, uint32
         if (i < 0) {
             return (uint8_t *)(y + j);
         } else {
-            j += (m1 = bmGs[i]) > (m2 = bmBc[u8_tolower(y[i + j])] - m + 1 + i)?
+            j += (m1 = bmGs[i]) > (m2 = bmBc[y[i + j]] - m + 1 + i)?
                 m1: m2;
         }
     }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1218

Describe changes:
- Updates `PreBmBcNocase` so that both upper and lower character give the same jump entry
- the characters had already been lowered by previous call to `BoyerMooreCtxToNocase`
- Updates `BoyerMooreNocase` so that we do not call `tolower` for the jump entries

For performance impact, I do not know if certain compilers managed to optimize away the second call to `tolower`

Modifies #3918 fixing the case where the needle has upper characters checked against lower characters