### PR TITLE
Update minimum version of Rust to 1.34.0 - v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,15 @@ cache:
 default-cflags: &default-cflags
   CFLAGS="-Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-function"
 
+env:
+  global:
+    # The version of Rust that will be used if not otherwise set.
+    - RUST_VERSION="stable"
+    # The minimum version of Rust supported.
+    - RUST_VERSION_MIN="1.34.0"
+    # A known recent working version of stable Rust
+    - RUST_VERSION_KNOWN="1.37.0"
+
 matrix:
   allow_failures:
     # Allow the rust-stable build to fail. These entries must match
@@ -84,7 +93,7 @@ matrix:
         - NAME="linux,gcc,rust-stable"
         - *default-cflags
         - RUST_VERSION="stable"
-        - ARGS="--enable-rust --enable-rust-strict"
+        - ARGS="--enable-rust-strict"
         - DO_CHECK_SETUP_SCRIPTS="yes"
         - DO_DISTCHECK="yes"
   include:
@@ -114,47 +123,27 @@ matrix:
         - NAME="linux,gcc,rust-stable"
         - *default-cflags
         - RUST_VERSION="stable"
-        - ARGS="--enable-rust --enable-rust-strict"
+        - ARGS="--enable-rust-strict"
         - DO_CHECK_SETUP_SCRIPTS="yes"
         - DO_DISTCHECK="yes"
     # Linux, gcc, Rust (auto detect).
-    # - Rust 1.31.0, the latest known working version.
+    # - Use latest known working version of Rust.
     - os: linux
       compiler: gcc
       env:
-        - NAME="linux,gcc,rust-1.31.0-disabled"
+        - NAME="linux,gcc,rust-${RUST_VERSION_KNOWN}"
         - *default-cflags
-        - RUST_VERSION="1.31.0"
-        - ARGS="--disable-rust"
+        - RUST_VERSION="${RUST_VERSION_KNOWN}"
+        - ARGS="--enable-rust-strict"
         - DO_DISTCHECK="yes"
-    # Linux, gcc, Rust (auto detect).
-    # - Rust 1.31.0, the latest known working version.
+    # Linux, gcc, Rust (oldest supported)
     - os: linux
       compiler: gcc
       env:
-        - NAME="linux,gcc,rust-1.31.0-auto"
+        - NAME="linux,gcc,rust-${RUST_VERSION_MIN}"
         - *default-cflags
-        - RUST_VERSION="1.31.0"
-        - ARGS=""
-        - DO_DISTCHECK="yes"
-    # Linux, gcc, Rust.
-    # - Rust 1.31.0, the latest known working version.
-    - os: linux
-      compiler: gcc
-      env:
-        - NAME="linux,gcc,rust-1.31.0"
-        - *default-cflags
-        - RUST_VERSION="1.31.0"
-        - ARGS="--enable-rust --enable-rust-strict"
-        - DO_DISTCHECK="yes"
-    # Linux, gcc, Rust (1.24.1 - oldest supported).
-    - os: linux
-      compiler: gcc
-      env:
-        - NAME="linux,gcc,rust-1.24.1"
-        - *default-cflags
-        - RUST_VERSION="1.24.1"
-        - ARGS="--enable-rust --enable-rust-strict"
+        - RUST_VERSION="${RUST_VERSION_MIN}"
+        - ARGS="--enable-rust-strict"
         - DO_DISTCHECK="yes"
     # Linux, gcc, -DNDEBUG.
     - os: linux
@@ -196,6 +185,13 @@ matrix:
         apt:
           packages:
             - *packages-without-jansson
+    # Too old version of Rust.
+    - os: linux
+      compiler: gcc
+      env:
+        - NAME="Unsupported Rust version"
+        - RUST_VERSION="1.33.0"
+        - CONFIGURE_SHOULD_FAIL="yes"
     # OSX 10.13, XCode 8.3
     - os: osx
       compiler: gcc
@@ -221,10 +217,12 @@ script: ./qa/travis.sh
 before_install:
   - export PATH=$HOME/.cargo/bin:$PATH
   - |
-    curl https://sh.rustup.rs -sSf | sh -s -- -y
-    if [[ "$RUST_VERSION" != "" ]]; then
-        rustup override set $RUST_VERSION
-    fi
+    # Install the desired Rust toolchain with rustup.
+    curl https://sh.rustup.rs -sSf | \
+        sh -s -- -y --default-toolchain "${RUST_VERSION}"
+    # Set the default, in case a cached version was used that doesn't
+    # match the requested version.
+    rustup default "${RUST_VERSION}"
     rustc --version
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/configure.ac
+++ b/configure.ac
@@ -2378,12 +2378,26 @@ fi
 
     enable_rust="yes"
     rust_compiler_version=$($RUSTC --version)
+    rustc_version=$(echo "$rust_compiler_version" | sed 's/^.*[[^0-9]]\([[0-9]]*\.[[0-9]]*\.[[0-9]]*\).*$/\1/')
     rust_cargo_version=$($CARGO --version)
+
+    AC_MSG_CHECKING(for Rust version 1.34.0 or newer)
+    AS_VERSION_COMPARE([$rustc_version], [1.34.0],
+        [
+            echo ""
+            echo "ERROR: Rust 1.34.0 or newer required."
+            echo ""
+            echo "Suricata now requires a minimum Rust version of 1.34.0."
+            echo "Rust version ${rustc_version} was found."
+            echo ""
+            exit 1
+	],
+	[],
+	[])
+    AC_MSG_RESULT(yes)
 
     rust_vendor_comment="# "
     have_rust_vendor="no"
-    rust_compiler_version="not set"
-    rust_cargo_version="not set"
 
     # We may require Python if the Rust header stubs are not already
     # generated.
@@ -2414,9 +2428,6 @@ fi
     if test "x$have_rust_vendor" = "xyes"; then
       rust_vendor_comment=""
     fi
-
-    rust_compiler_version=$(rustc --version)
-    rust_cargo_version=$(cargo --version)
 
     AC_SUBST(rust_vendor_comment)
     AM_CONDITIONAL([HAVE_RUST_VENDOR], [test "x$have_rust_vendor" = "xyes"])
@@ -2605,8 +2616,10 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   Rust support:                            ${enable_rust}
   Rust strict mode:                        ${enable_rust_strict}
   Rust debug mode:                         ${enable_rust_debug}
-  Rust compiler:                           ${rust_compiler_version}
-  Rust cargo:                              ${rust_cargo_version}
+  Rust compiler path:                      ${RUSTC}
+  Rust compiler version:                   ${rust_compiler_version}
+  Cargo path:                              ${CARGO}
+  Cargo version:                           ${rust_cargo_version}
 
   Python support:                          ${enable_python}
   Python path:                             ${python_path}

--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -1,2 +1,2 @@
-# Rust default is 100. Use 80 to bring in line with Suricata C code.
-max_width = 80
+# Rust format configuration file. If empty, then this is a message that
+# we expect the default formatting rules to be used.


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2629

For 5.0 we are updating the minimum version of Rust to 1.34.

Describe changes:
- Add autoconf check for Rust version 1.34 or newer.
- Update Travis-CI for Rust 1.34.

Additionally:
- Use an empty rustfmt.toml to make it more clear we are currently using the default
rustfmt formatting rules.

The PRscript builder needs its version of Rust updated.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Build failure for jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/357
Build failure for jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/712
