### PR TITLE
Rust 2018 Edition Fix - v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,15 @@ cache:
 default-cflags: &default-cflags
   CFLAGS="-Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-function"
 
+env:
+  global:
+    # The version of Rust that will be used if not otherwise set.
+    - RUST_VERSION="stable"
+    # The minimum version of Rust supported.
+    - RUST_VERSION_MIN="1.34.0"
+    # A known recent working version of stable Rust
+    - RUST_VERSION_KNOWN="1.37.0"
+
 matrix:
   allow_failures:
     # Allow the rust-stable build to fail. These entries must match
@@ -84,7 +93,7 @@ matrix:
         - NAME="linux,gcc,rust-stable"
         - *default-cflags
         - RUST_VERSION="stable"
-        - ARGS="--enable-rust --enable-rust-strict"
+        - ARGS="--enable-rust-strict"
         - DO_CHECK_SETUP_SCRIPTS="yes"
         - DO_DISTCHECK="yes"
   include:
@@ -114,47 +123,27 @@ matrix:
         - NAME="linux,gcc,rust-stable"
         - *default-cflags
         - RUST_VERSION="stable"
-        - ARGS="--enable-rust --enable-rust-strict"
+        - ARGS="--enable-rust-strict"
         - DO_CHECK_SETUP_SCRIPTS="yes"
         - DO_DISTCHECK="yes"
     # Linux, gcc, Rust (auto detect).
-    # - Rust 1.31.0, the latest known working version.
+    # - Use latest known working version of Rust.
     - os: linux
       compiler: gcc
       env:
-        - NAME="linux,gcc,rust-1.31.0-disabled"
+        - NAME="linux,gcc,rust-${RUST_VERSION_KNOWN}"
         - *default-cflags
-        - RUST_VERSION="1.31.0"
-        - ARGS="--disable-rust"
+        - RUST_VERSION="${RUST_VERSION_KNOWN}"
+        - ARGS="--enable-rust-strict"
         - DO_DISTCHECK="yes"
-    # Linux, gcc, Rust (auto detect).
-    # - Rust 1.31.0, the latest known working version.
+    # Linux, gcc, Rust (oldest supported)
     - os: linux
       compiler: gcc
       env:
-        - NAME="linux,gcc,rust-1.31.0-auto"
+        - NAME="linux,gcc,rust-${RUST_VERSION_MIN}"
         - *default-cflags
-        - RUST_VERSION="1.31.0"
-        - ARGS=""
-        - DO_DISTCHECK="yes"
-    # Linux, gcc, Rust.
-    # - Rust 1.31.0, the latest known working version.
-    - os: linux
-      compiler: gcc
-      env:
-        - NAME="linux,gcc,rust-1.31.0"
-        - *default-cflags
-        - RUST_VERSION="1.31.0"
-        - ARGS="--enable-rust --enable-rust-strict"
-        - DO_DISTCHECK="yes"
-    # Linux, gcc, Rust (1.24.1 - oldest supported).
-    - os: linux
-      compiler: gcc
-      env:
-        - NAME="linux,gcc,rust-1.24.1"
-        - *default-cflags
-        - RUST_VERSION="1.24.1"
-        - ARGS="--enable-rust --enable-rust-strict"
+        - RUST_VERSION="${RUST_VERSION_MIN}"
+        - ARGS="--enable-rust-strict"
         - DO_DISTCHECK="yes"
     # Linux, gcc, -DNDEBUG.
     - os: linux
@@ -196,6 +185,13 @@ matrix:
         apt:
           packages:
             - *packages-without-jansson
+    # Too old version of Rust.
+    - os: linux
+      compiler: gcc
+      env:
+        - NAME="Unsupported Rust version"
+        - RUST_VERSION="1.33.0"
+        - CONFIGURE_SHOULD_FAIL="yes"
     # OSX 10.13, XCode 8.3
     - os: osx
       compiler: gcc
@@ -221,10 +217,12 @@ script: ./qa/travis.sh
 before_install:
   - export PATH=$HOME/.cargo/bin:$PATH
   - |
-    curl https://sh.rustup.rs -sSf | sh -s -- -y
-    if [[ "$RUST_VERSION" != "" ]]; then
-        rustup override set $RUST_VERSION
-    fi
+    # Install the desired Rust toolchain with rustup.
+    curl https://sh.rustup.rs -sSf | \
+        sh -s -- -y --default-toolchain "${RUST_VERSION}"
+    # Set the default, in case a cached version was used that doesn't
+    # match the requested version.
+    rustup default "${RUST_VERSION}"
     rustc --version
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/configure.ac
+++ b/configure.ac
@@ -2378,12 +2378,26 @@ fi
 
     enable_rust="yes"
     rust_compiler_version=$($RUSTC --version)
+    rustc_version=$(echo "$rust_compiler_version" | sed 's/^.*[[^0-9]]\([[0-9]]*\.[[0-9]]*\.[[0-9]]*\).*$/\1/')
     rust_cargo_version=$($CARGO --version)
+
+    AC_MSG_CHECKING(for Rust version 1.34.0 or newer)
+    AS_VERSION_COMPARE([$rustc_version], [1.34.0],
+        [
+            echo ""
+            echo "ERROR: Rust 1.34.0 or newer required."
+            echo ""
+            echo "Suricata now requires a minimum Rust version of 1.34.0."
+            echo "Rust version ${rustc_version} was found."
+            echo ""
+            exit 1
+	],
+	[],
+	[])
+    AC_MSG_RESULT(yes)
 
     rust_vendor_comment="# "
     have_rust_vendor="no"
-    rust_compiler_version="not set"
-    rust_cargo_version="not set"
 
     # We may require Python if the Rust header stubs are not already
     # generated.
@@ -2414,9 +2428,6 @@ fi
     if test "x$have_rust_vendor" = "xyes"; then
       rust_vendor_comment=""
     fi
-
-    rust_compiler_version=$(rustc --version)
-    rust_cargo_version=$(cargo --version)
 
     AC_SUBST(rust_vendor_comment)
     AM_CONDITIONAL([HAVE_RUST_VENDOR], [test "x$have_rust_vendor" = "xyes"])
@@ -2605,8 +2616,10 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   Rust support:                            ${enable_rust}
   Rust strict mode:                        ${enable_rust_strict}
   Rust debug mode:                         ${enable_rust_debug}
-  Rust compiler:                           ${rust_compiler_version}
-  Rust cargo:                              ${rust_cargo_version}
+  Rust compiler path:                      ${RUSTC}
+  Rust compiler version:                   ${rust_compiler_version}
+  Cargo path:                              ${CARGO}
+  Cargo version:                           ${rust_cargo_version}
 
   Python support:                          ${enable_python}
   Python path:                             ${python_path}

--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -1,2 +1,2 @@
-# Rust default is 100. Use 80 to bring in line with Suricata C code.
-max_width = 80
+# Rust format configuration file. If empty, then this is a message that
+# we expect the default formatting rules to be used.

--- a/rust/src/applayertemplate/logger.rs
+++ b/rust/src/applayertemplate/logger.rs
@@ -16,7 +16,7 @@
  */
 
 use std;
-use json::*;
+use crate::json::*;
 use super::template::TemplateTransaction;
 
 fn log_template(tx: &TemplateTransaction) -> Option<Json> {

--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -16,11 +16,11 @@
  */
 
 use std;
-use core::{self, ALPROTO_UNKNOWN, AppProto, Flow, IPPROTO_TCP};
-use log::*;
+use crate::core::{self, ALPROTO_UNKNOWN, AppProto, Flow, IPPROTO_TCP};
+use crate::log::*;
 use std::mem::transmute;
-use applayer::{self, LoggerFlags};
-use parser::*;
+use crate::applayer::{self, LoggerFlags};
+use crate::parser::*;
 use std::ffi::CString;
 use nom;
 use super::parser;

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -22,7 +22,7 @@ use std::ffi::{CString, CStr};
 use std::ptr;
 use std::str;
 
-use log::*;
+use crate::log::*;
 
 extern {
     fn ConfGet(key: *const c_char, res: *mut *const c_char) -> i8;

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -18,7 +18,7 @@
 // This file exposes items from the core "C" code to Rust.
 
 use std;
-use filecontainer::*;
+use crate::filecontainer::*;
 
 /// Opaque C types.
 pub enum Flow {}

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -15,13 +15,13 @@
  * 02110-1301, USA.
  */
 
-use applayer;
-use core;
-use core::{ALPROTO_UNKNOWN, AppProto, Flow, IPPROTO_UDP};
-use core::{sc_detect_engine_state_free, sc_app_layer_decoder_events_free_events};
-use dhcp::parser::*;
-use log::*;
-use parser::*;
+use crate::applayer;
+use crate::core;
+use crate::core::{ALPROTO_UNKNOWN, AppProto, Flow, IPPROTO_UDP};
+use crate::core::{sc_detect_engine_state_free, sc_app_layer_decoder_events_free_events};
+use crate::dhcp::parser::*;
+use crate::log::*;
+use crate::parser::*;
 use std;
 use std::ffi::{CStr,CString};
 use std::mem::transmute;

--- a/rust/src/dhcp/logger.rs
+++ b/rust/src/dhcp/logger.rs
@@ -18,11 +18,11 @@
 use std;
 use std::os::raw::c_void;
 
-use dhcp::dhcp::*;
-use dhcp::parser::{DHCPOptionWrapper,DHCPOptGeneric};
-use dns::log::dns_print_addr;
-use json::*;
-use conf::ConfNode;
+use crate::dhcp::dhcp::*;
+use crate::dhcp::parser::{DHCPOptionWrapper,DHCPOptGeneric};
+use crate::dns::log::dns_print_addr;
+use crate::json::*;
+use crate::conf::ConfNode;
 
 pub struct DHCPLogger {
     extended: bool,

--- a/rust/src/dhcp/parser.rs
+++ b/rust/src/dhcp/parser.rs
@@ -17,7 +17,7 @@
 
 use std::cmp::min;
 
-use dhcp::dhcp::*;
+use crate::dhcp::dhcp::*;
 use nom::*;
 
 pub struct DHCPMessage {
@@ -233,8 +233,8 @@ pub fn dhcp_parse(input: &[u8]) -> IResult<&[u8], DHCPMessage> {
 
 #[cfg(test)]
 mod tests {
-    use dhcp::dhcp::*;
-    use dhcp::parser::*;
+    use crate::dhcp::dhcp::*;
+    use crate::dhcp::parser::*;
 
     #[test]
     fn test_parse_discover() {

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -20,10 +20,10 @@ extern crate nom;
 use std;
 use std::mem::transmute;
 
-use log::*;
-use applayer::LoggerFlags;
-use core;
-use dns::parser;
+use crate::log::*;
+use crate::applayer::LoggerFlags;
+use crate::core;
+use crate::dns::parser;
 
 /// DNS record types.
 pub const DNS_RECORD_TYPE_A           : u16 = 1;
@@ -842,7 +842,7 @@ pub extern "C" fn rs_dns_probe_tcp(input: *const u8,
 #[cfg(test)]
 mod tests {
 
-    use dns::dns::DNSState;
+    use crate::dns::dns::DNSState;
 
     #[test]
     fn test_dns_parse_request_tcp_valid() {

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -19,8 +19,8 @@ use std;
 use std::string::String;
 use std::collections::HashMap;
 
-use json::*;
-use dns::dns::*;
+use crate::json::*;
+use crate::dns::dns::*;
 
 pub const LOG_QUERIES    : u64 = BIT_U64!(0);
 pub const LOG_ANSWER     : u64 = BIT_U64!(1);

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -19,7 +19,7 @@
 
 use nom::{IResult, be_u8, be_u16, be_u32};
 use nom;
-use dns::dns::*;
+use crate::dns::dns::*;
 
 // Parse a DNS header.
 named!(pub dns_parse_header<DNSHeader>,
@@ -304,8 +304,8 @@ pub fn dns_parse_request<'a>(input: &'a [u8]) -> IResult<&[u8], DNSRequest> {
 #[cfg(test)]
 mod tests {
 
-    use dns::dns::{DNSHeader,DNSAnswerEntry};
-    use dns::parser::*;
+    use crate::dns::dns::{DNSHeader,DNSAnswerEntry};
+    use crate::dns::parser::*;
 
     /// Parse a simple name with no pointers.
     #[test]

--- a/rust/src/filecontainer.rs
+++ b/rust/src/filecontainer.rs
@@ -18,8 +18,8 @@
 use std::ptr;
 use std::os::raw::{c_void};
 
-use log::*;
-use core::*;
+use crate::log::*;
+use crate::core::*;
 
 pub struct File;
 #[repr(C)]

--- a/rust/src/filetracker.rs
+++ b/rust/src/filetracker.rs
@@ -28,11 +28,11 @@
  * The tracker does continue to follow the file.
  */
 
-use log::*;
-use core::*;
+use crate::log::*;
+use crate::core::*;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
-use filecontainer::*;
+use crate::filecontainer::*;
 
 #[derive(Debug)]
 pub struct FileChunk {

--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -22,7 +22,7 @@ use std::str;
 use std;
 use std::str::FromStr;
 
-use log::*;
+use crate::log::*;
 
 // We transform an integer string into a i64, ignoring surrounding whitespaces
 // We look for a digit suite, and try to convert it.

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -17,16 +17,16 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
-use ikev2::ipsec_parser::*;
-use ikev2::state::IKEV2ConnectionState;
-use core;
-use core::{AppProto,Flow,ALPROTO_UNKNOWN,ALPROTO_FAILED,STREAM_TOSERVER,STREAM_TOCLIENT};
-use applayer;
-use parser::*;
+use crate::ikev2::ipsec_parser::*;
+use crate::ikev2::state::IKEV2ConnectionState;
+use crate::core;
+use crate::core::{AppProto,Flow,ALPROTO_UNKNOWN,ALPROTO_FAILED,STREAM_TOSERVER,STREAM_TOCLIENT};
+use crate::applayer;
+use crate::parser::*;
 use std;
 use std::ffi::{CStr,CString};
 
-use log::*;
+use crate::log::*;
 
 use nom;
 

--- a/rust/src/ikev2/log.rs
+++ b/rust/src/ikev2/log.rs
@@ -17,10 +17,10 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
-use json::*;
-use ikev2::ikev2::{IKEV2State,IKEV2Transaction};
+use crate::json::*;
+use crate::ikev2::ikev2::{IKEV2State,IKEV2Transaction};
 
-use ikev2::ipsec_parser::IKEV2_FLAG_INITIATOR;
+use crate::ikev2::ipsec_parser::IKEV2_FLAG_INITIATOR;
 
 #[no_mangle]
 pub extern "C" fn rs_ikev2_log_json_response(state: &mut IKEV2State, tx: &mut IKEV2Transaction) -> *mut JsonT

--- a/rust/src/json.rs
+++ b/rust/src/json.rs
@@ -156,7 +156,7 @@ fn to_cstring(val: &[u8]) -> CString {
 #[cfg(test)]
 mod tests {
 
-    use json::to_cstring;
+    use crate::json::to_cstring;
 
     #[test]
     fn test_to_string() {

--- a/rust/src/kerberos.rs
+++ b/rust/src/kerberos.rs
@@ -22,7 +22,7 @@ use nom::{ErrorKind, IResult, le_u16};
 use der_parser;
 use der_parser::parse_der_oid;
 
-use log::*;
+use crate::log::*;
 
 pub const SECBLOB_NOT_SPNEGO :  u32 = 128;
 pub const SECBLOB_KRB_FMT_ERR : u32 = 129;

--- a/rust/src/krb/detect.rs
+++ b/rust/src/krb/detect.rs
@@ -17,7 +17,7 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
-use krb::krb5::KRB5Transaction;
+use crate::krb::krb5::KRB5Transaction;
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_krb5_tx_get_msgtype(tx:  &mut KRB5Transaction,

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -24,12 +24,12 @@ use nom::be_u32;
 use der_parser::der_read_element_header;
 use kerberos_parser::krb5_parser;
 use kerberos_parser::krb5::{EncryptionType,ErrorCode,MessageType,PrincipalName,Realm};
-use applayer;
-use core;
-use core::{AppProto,Flow,ALPROTO_FAILED,ALPROTO_UNKNOWN,STREAM_TOCLIENT,STREAM_TOSERVER,sc_detect_engine_state_free};
-use parser::*;
+use crate::applayer;
+use crate::core;
+use crate::core::{AppProto,Flow,ALPROTO_FAILED,ALPROTO_UNKNOWN,STREAM_TOCLIENT,STREAM_TOSERVER,sc_detect_engine_state_free};
+use crate::parser::*;
 
-use log::*;
+use crate::log::*;
 
 #[repr(u32)]
 pub enum KRB5Event {

--- a/rust/src/krb/log.rs
+++ b/rust/src/krb/log.rs
@@ -17,8 +17,8 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
-use json::*;
-use krb::krb5::{KRB5State,KRB5Transaction,test_weak_encryption};
+use crate::json::*;
+use crate::krb::krb5::{KRB5State,KRB5Transaction,test_weak_encryption};
 
 #[no_mangle]
 pub extern "C" fn rs_krb5_log_json_response(_state: &mut KRB5State, tx: &mut KRB5Transaction) -> *mut JsonT

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -19,7 +19,7 @@ use std;
 use std::ffi::CString;
 use std::path::Path;
 
-use core::*;
+use crate::core::*;
 
 #[derive(Debug)]
 pub enum Level {

--- a/rust/src/nfs/log.rs
+++ b/rust/src/nfs/log.rs
@@ -16,9 +16,9 @@
  */
 
 use std::string::String;
-use json::*;
-use nfs::types::*;
-use nfs::nfs::*;
+use crate::json::*;
+use crate::nfs::types::*;
+use crate::nfs::nfs::*;
 use crc::crc32;
 
 #[no_mangle]

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -25,18 +25,18 @@ use std::ffi::CStr;
 
 use nom;
 
-use log::*;
-use applayer;
-use applayer::LoggerFlags;
-use core::*;
-use filetracker::*;
-use filecontainer::*;
+use crate::log::*;
+use crate::applayer;
+use crate::applayer::LoggerFlags;
+use crate::core::*;
+use crate::filetracker::*;
+use crate::filecontainer::*;
 
-use nfs::types::*;
-use nfs::rpc_records::*;
-use nfs::nfs_records::*;
-use nfs::nfs2_records::*;
-use nfs::nfs3_records::*;
+use crate::nfs::types::*;
+use crate::nfs::rpc_records::*;
+use crate::nfs::nfs_records::*;
+use crate::nfs::nfs2_records::*;
+use crate::nfs::nfs3_records::*;
 
 pub static mut SURICATA_NFS_FILE_CONFIG: Option<&'static SuricataFileContext> = None;
 

--- a/rust/src/nfs/nfs2.rs
+++ b/rust/src/nfs/nfs2.rs
@@ -18,12 +18,12 @@
 // written by Victor Julien
 
 use nom;
-use log::*;
+use crate::log::*;
 
-use nfs::nfs::*;
-use nfs::types::*;
-use nfs::rpc_records::*;
-use nfs::nfs2_records::*;
+use crate::nfs::nfs::*;
+use crate::nfs::types::*;
+use crate::nfs::rpc_records::*;
+use crate::nfs::nfs2_records::*;
 
 impl NFSState {
     /// complete request record

--- a/rust/src/nfs/nfs2_records.rs
+++ b/rust/src/nfs/nfs2_records.rs
@@ -17,7 +17,7 @@
 
 //! Nom parsers for NFSv2 records
 use nom::{be_u32, rest};
-use nfs::nfs_records::*;
+use crate::nfs::nfs_records::*;
 
 #[derive(Debug,PartialEq)]
 pub struct Nfs2Handle<'a> {

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -18,13 +18,13 @@
 // written by Victor Julien
 
 use nom;
-use log::*;
-use core::*;
+use crate::log::*;
+use crate::core::*;
 
-use nfs::nfs::*;
-use nfs::types::*;
-use nfs::rpc_records::*;
-use nfs::nfs3_records::*;
+use crate::nfs::nfs::*;
+use crate::nfs::types::*;
+use crate::nfs::rpc_records::*;
+use crate::nfs::nfs3_records::*;
 
 impl NFSState {
     /// complete NFS3 request record

--- a/rust/src/nfs/nfs3_records.rs
+++ b/rust/src/nfs/nfs3_records.rs
@@ -18,7 +18,7 @@
 //! Nom parsers for RPC & NFSv3
 
 use nom::{IResult, be_u32, be_u64, rest};
-use nfs::nfs_records::*;
+use crate::nfs::nfs_records::*;
 
 #[derive(Debug,PartialEq)]
 pub struct Nfs3Handle<'a> {

--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -20,16 +20,16 @@
 use nom;
 use nom::be_u32;
 
-use core::*;
-use log::*;
+use crate::core::*;
+use crate::log::*;
 
-use nfs::nfs::*;
-use nfs::types::*;
-use nfs::rpc_records::*;
-use nfs::nfs_records::*;
-use nfs::nfs4_records::*;
+use crate::nfs::nfs::*;
+use crate::nfs::types::*;
+use crate::nfs::rpc_records::*;
+use crate::nfs::nfs_records::*;
+use crate::nfs::nfs4_records::*;
 
-use kerberos;
+use crate::kerberos;
 
 named!(parse_req_gssapi<kerberos::Kerberos5Ticket>,
    do_parse!(

--- a/rust/src/nfs/nfs4_records.rs
+++ b/rust/src/nfs/nfs4_records.rs
@@ -18,7 +18,7 @@
 //! Nom parsers for NFSv4 records
 use nom::{be_u32, be_u64};
 
-use nfs::types::*;
+use crate::nfs::types::*;
 
 #[derive(Debug,PartialEq)]
 pub enum Nfs4RequestContent<'a> {

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -19,14 +19,14 @@
 
 extern crate ntp_parser;
 use self::ntp_parser::*;
-use core;
-use core::{AppProto,Flow,ALPROTO_UNKNOWN,ALPROTO_FAILED};
-use applayer;
-use parser::*;
+use crate::core;
+use crate::core::{AppProto,Flow,ALPROTO_UNKNOWN,ALPROTO_FAILED};
+use crate::applayer;
+use crate::parser::*;
 use std;
 use std::ffi::{CStr,CString};
 
-use log::*;
+use crate::log::*;
 
 use nom;
 

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -19,12 +19,12 @@
 
 //! Parser registration functions and common interface
 
-use core::{DetectEngineState,Flow,AppLayerEventType,AppLayerDecoderEvents,AppProto};
-use filecontainer::FileContainer;
-use applayer;
+use crate::core::{DetectEngineState,Flow,AppLayerEventType,AppLayerDecoderEvents,AppProto};
+use crate::filecontainer::FileContainer;
+use crate::applayer;
 
 use std::os::raw::{c_void,c_char,c_int};
-use applayer::{AppLayerGetTxIterTuple};
+use crate::applayer::{AppLayerGetTxIterTuple};
 
 /// Rust parser declaration
 #[repr(C)]

--- a/rust/src/smb/auth.rs
+++ b/rust/src/smb/auth.rs
@@ -15,11 +15,11 @@
  * 02110-1301, USA.
  */
 
-use kerberos::*;
+use crate::kerberos::*;
 
-use log::*;
-use smb::ntlmssp_records::*;
-use smb::smb::*;
+use crate::log::*;
+use crate::smb::ntlmssp_records::*;
+use crate::smb::smb::*;
 
 use nom;
 use nom::{IResult, ErrorKind};

--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -17,12 +17,12 @@
 
 // written by Victor Julien
 
-use log::*;
+use crate::log::*;
 
-use smb::smb::*;
-use smb::smb2::*;
-use smb::dcerpc_records::*;
-use smb::events::*;
+use crate::smb::smb::*;
+use crate::smb::smb2::*;
+use crate::smb::dcerpc_records::*;
+use crate::smb::events::*;
 
 pub const DCERPC_TYPE_REQUEST:              u8 = 0;
 pub const DCERPC_TYPE_PING:                 u8 = 1;

--- a/rust/src/smb/debug.rs
+++ b/rust/src/smb/debug.rs
@@ -15,7 +15,7 @@
  * 02110-1301, USA.
  */
 
-use smb::smb::*;
+use crate::smb::smb::*;
 
 #[cfg(feature = "debug")]
 use log::*;

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -17,9 +17,9 @@
 
 use std;
 use std::ptr;
-use core::*;
-use log::*;
-use smb::smb::*;
+use crate::core::*;
+use crate::log::*;
+use crate::smb::smb::*;
 
 #[no_mangle]
 pub extern "C" fn rs_smb_tx_get_share(tx: &mut SMBTransaction,

--- a/rust/src/smb/events.rs
+++ b/rust/src/smb/events.rs
@@ -15,9 +15,9 @@
  * 02110-1301, USA.
  */
 
-use core::*;
-use log::*;
-use smb::smb::*;
+use crate::core::*;
+use crate::log::*;
+use crate::smb::smb::*;
 
 #[repr(u32)]
 pub enum SMBEvent {

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -15,12 +15,12 @@
  * 02110-1301, USA.
  */
 
-use core::*;
-use log::*;
-use filetracker::*;
-use filecontainer::*;
+use crate::core::*;
+use crate::log::*;
+use crate::filetracker::*;
+use crate::filecontainer::*;
 
-use smb::smb::*;
+use crate::smb::smb::*;
 
 /// File tracking transaction. Single direction only.
 #[derive(Debug)]

--- a/rust/src/smb/log.rs
+++ b/rust/src/smb/log.rs
@@ -17,12 +17,12 @@
 
 use std::str;
 use std::string::String;
-use json::*;
-use smb::smb::*;
-use smb::smb1::*;
-use smb::smb2::*;
-use smb::dcerpc::*;
-use smb::funcs::*;
+use crate::json::*;
+use crate::smb::smb::*;
+use crate::smb::smb1::*;
+use crate::smb::smb2::*;
+use crate::smb::dcerpc::*;
+use crate::smb::funcs::*;
 
 #[cfg(not(feature = "debug"))]
 fn debug_add_progress(_js: &Json, _tx: &SMBTransaction) { }

--- a/rust/src/smb/session.rs
+++ b/rust/src/smb/session.rs
@@ -15,11 +15,11 @@
  * 02110-1301, USA.
  */
 
-use log::*;
-use kerberos::*;
-use smb::smb::*;
-use smb::smb1_session::*;
-use smb::auth::*;
+use crate::log::*;
+use crate::kerberos::*;
+use crate::smb::smb::*;
+use crate::smb::smb1_session::*;
+use crate::smb::auth::*;
 
 #[derive(Debug)]
 pub struct SMBTransactionSessionSetup {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -34,23 +34,23 @@ use std::collections::HashMap;
 
 use nom;
 
-use core::*;
-use log::*;
-use applayer;
-use applayer::LoggerFlags;
+use crate::core::*;
+use crate::log::*;
+use crate::applayer;
+use crate::applayer::LoggerFlags;
 
-use smb::nbss_records::*;
-use smb::smb1_records::*;
-use smb::smb2_records::*;
+use crate::smb::nbss_records::*;
+use crate::smb::smb1_records::*;
+use crate::smb::smb2_records::*;
 
-use smb::smb1::*;
-use smb::smb2::*;
-use smb::smb3::*;
-use smb::dcerpc::*;
-use smb::session::*;
-use smb::events::*;
-use smb::files::*;
-use smb::smb2_ioctl::*;
+use crate::smb::smb1::*;
+use crate::smb::smb2::*;
+use crate::smb::smb3::*;
+use crate::smb::dcerpc::*;
+use crate::smb::session::*;
+use crate::smb::events::*;
+use crate::smb::files::*;
+use crate::smb::smb2_ioctl::*;
 
 pub static mut SURICATA_SMB_FILE_CONFIG: Option<&'static SuricataFileContext> = None;
 

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -21,16 +21,16 @@
 
 use nom;
 
-use core::*;
-use log::*;
+use crate::core::*;
+use crate::log::*;
 
-use smb::smb::*;
-use smb::dcerpc::*;
-use smb::events::*;
-use smb::files::*;
+use crate::smb::smb::*;
+use crate::smb::dcerpc::*;
+use crate::smb::events::*;
+use crate::smb::files::*;
 
-use smb::smb1_records::*;
-use smb::smb1_session::*;
+use crate::smb::smb1_records::*;
+use crate::smb::smb1_session::*;
 
 // https://msdn.microsoft.com/en-us/library/ee441741.aspx
 pub const SMB1_COMMAND_CREATE_DIRECTORY:        u8 = 0x00;

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -15,10 +15,10 @@
  * 02110-1301, USA.
  */
 
-use log::*;
+use crate::log::*;
 use nom::{rest, le_u8, le_u16, le_u32, le_u64, IResult};
-use smb::smb::*;
-use smb::smb_records::*;
+use crate::smb::smb::*;
+use crate::smb::smb_records::*;
 
 fn smb_get_unicode_string_with_offset(i: &[u8], offset: usize) -> IResult<&[u8], Vec<u8>>
 {

--- a/rust/src/smb/smb1_session.rs
+++ b/rust/src/smb/smb1_session.rs
@@ -15,13 +15,13 @@
  * 02110-1301, USA.
  */
 
-use log::*;
+use crate::log::*;
 
-use smb::smb_records::*;
-use smb::smb1_records::*;
-use smb::smb::*;
-use smb::events::*;
-use smb::auth::*;
+use crate::smb::smb_records::*;
+use crate::smb::smb1_records::*;
+use crate::smb::smb::*;
+use crate::smb::events::*;
+use crate::smb::auth::*;
 
 #[derive(Debug)]
 pub struct SessionSetupRequest {

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -17,16 +17,16 @@
 
 use nom;
 
-use core::*;
-use log::*;
+use crate::core::*;
+use crate::log::*;
 
-use smb::smb::*;
-use smb::smb2_records::*;
-use smb::smb2_session::*;
-use smb::smb2_ioctl::*;
-use smb::dcerpc::*;
-use smb::events::*;
-use smb::files::*;
+use crate::smb::smb::*;
+use crate::smb::smb2_records::*;
+use crate::smb::smb2_session::*;
+use crate::smb::smb2_ioctl::*;
+use crate::smb::dcerpc::*;
+use crate::smb::events::*;
+use crate::smb::files::*;
 
 pub const SMB2_COMMAND_NEGOTIATE_PROTOCOL:      u16 = 0;
 pub const SMB2_COMMAND_SESSION_SETUP:           u16 = 1;

--- a/rust/src/smb/smb2_ioctl.rs
+++ b/rust/src/smb/smb2_ioctl.rs
@@ -15,13 +15,13 @@
  * 02110-1301, USA.
  */
 
-use log::*;
-use smb::smb::*;
-use smb::smb2::*;
-use smb::smb2_records::*;
-use smb::dcerpc::*;
-use smb::events::*;
-use smb::funcs::*;
+use crate::log::*;
+use crate::smb::smb::*;
+use crate::smb::smb2::*;
+use crate::smb::smb2_records::*;
+use crate::smb::dcerpc::*;
+use crate::smb::events::*;
+use crate::smb::funcs::*;
 
 #[derive(Debug)]
 pub struct SMBTransactionIoctl {

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -17,7 +17,7 @@
 
 use nom;
 use nom::{rest, le_u8, le_u16, le_u32, le_u64, IResult};
-use smb::smb::*;
+use crate::smb::smb::*;
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2SecBlobRecord<'a> {

--- a/rust/src/smb/smb2_session.rs
+++ b/rust/src/smb/smb2_session.rs
@@ -15,12 +15,12 @@
  * 02110-1301, USA.
  */
 
-use log::*;
+use crate::log::*;
 
-use smb::smb2_records::*;
-use smb::smb::*;
+use crate::smb::smb2_records::*;
+use crate::smb::smb::*;
 //use smb::events::*;
-use smb::auth::*;
+use crate::smb::auth::*;
 
 pub fn smb2_session_setup_request(state: &mut SMBState, r: &Smb2Record)
 {

--- a/rust/src/smb/smb_records.rs
+++ b/rust/src/smb/smb_records.rs
@@ -17,7 +17,7 @@
 
 use nom;
 use nom::{ErrorKind, IResult};
-use log::*;
+use crate::log::*;
 
 /// parse a UTF16 string that is null terminated. Normally by 2 null
 /// bytes, but at the end of the data it can also be a single null.

--- a/rust/src/snmp/detect.rs
+++ b/rust/src/snmp/detect.rs
@@ -17,7 +17,7 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
-use snmp::snmp::SNMPTransaction;
+use crate::snmp::snmp::SNMPTransaction;
 
 #[no_mangle]
 pub extern "C" fn rs_snmp_tx_get_version(tx: &mut SNMPTransaction,

--- a/rust/src/snmp/log.rs
+++ b/rust/src/snmp/log.rs
@@ -17,9 +17,9 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
-use json::*;
-use snmp::snmp::{SNMPState,SNMPTransaction};
-use snmp::snmp_parser::{NetworkAddress,PduType};
+use crate::json::*;
+use crate::snmp::snmp::{SNMPState,SNMPTransaction};
+use crate::snmp::snmp_parser::{NetworkAddress,PduType};
 use std::borrow::Cow;
 
 fn str_of_pdu_type(t:&PduType) -> Cow<str> {

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -17,16 +17,16 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
-use snmp::snmp_parser::*;
-use core;
-use core::{AppProto,Flow,ALPROTO_UNKNOWN,ALPROTO_FAILED,STREAM_TOSERVER,STREAM_TOCLIENT};
-use applayer;
-use parser::*;
+use crate::snmp::snmp_parser::*;
+use crate::core;
+use crate::core::{AppProto,Flow,ALPROTO_UNKNOWN,ALPROTO_FAILED,STREAM_TOSERVER,STREAM_TOCLIENT};
+use crate::applayer;
+use crate::parser::*;
 use std;
 use std::ffi::{CStr,CString};
 use std::mem::transmute;
 
-use log::*;
+use crate::log::*;
 
 use der_parser::{DerObjectContent,parse_der_sequence};
 use der_parser::oid::Oid;

--- a/rust/src/tftp/log.rs
+++ b/rust/src/tftp/log.rs
@@ -17,8 +17,8 @@
 
 // written by Clément Galland <clement.galland@epita.fr>
 
-use json::*;
-use tftp::tftp::*;
+use crate::json::*;
+use crate::tftp::tftp::*;
 
 #[no_mangle]
 pub extern "C" fn rs_tftp_log_json_request(tx: &mut TFTPTransaction) -> *mut JsonT

--- a/rust/src/tftp/tftp.rs
+++ b/rust/src/tftp/tftp.rs
@@ -23,7 +23,7 @@ use std::str;
 use std;
 use std::mem::transmute;
 
-use applayer::LoggerFlags;
+use crate::applayer::LoggerFlags;
 
 #[derive(Debug)]
 pub struct TFTPTransaction {


### PR DESCRIPTION
Migrate to Rust 2018 with `cargo fix`.  All modifications made by `cargo fix` from Rust v1.37. No manual edits.

Based on PR:
https://github.com/OISF/suricata/pull/4127

Credit to Danny Browning for first demontrating this:
https://github.com/OISF/suricata/pull/3604/commits
