### PR TITLE
Improve rule keyword alproto registration

### DIFF
--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -538,7 +538,8 @@ static int DetectByteExtractSetup(DetectEngineCtx *de_ctx, Signature *s, const c
             sm_list = DETECT_SM_LIST_PMATCH;
         }
 
-        s->alproto = ALPROTO_DCERPC;
+        if (DetectSignatureSetAppProto(s, ALPROTO_DCERPC) < 0)
+            goto error;
         s->flags |= SIG_FLAG_APPLAYER;
 
     } else if (data->flags & DETECT_BYTE_EXTRACT_FLAG_RELATIVE) {

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -817,7 +817,10 @@ static int DetectBytejumpTestParse09(void)
 
     int result = 1;
 
-    s->alproto = ALPROTO_DCERPC;
+    if (DetectSignatureSetAppProto(s, ALPROTO_DCERPC) < 0) {
+        SigFree(s);
+        return 0;
+    }
 
     result &= (DetectBytejumpSetup(NULL, s, "4,0, align, multiplier 2, "
                                    "post_offset -16,dce") == 0);

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -982,7 +982,10 @@ static int DetectBytetestTestParse19(void)
 
     int result = 1;
 
-    s->alproto = ALPROTO_DCERPC;
+    if (DetectSignatureSetAppProto(s, ALPROTO_DCERPC) < 0) {
+        SigFree(s);
+        return 0;
+    }
 
     result &= (DetectBytetestSetup(NULL, s, "1,=,1,6,dce") == 0);
     result &= (DetectBytetestSetup(NULL, s, "1,=,1,6,string,dce") == -1);

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -1286,7 +1286,8 @@ static int DetectContentParseTest18(void)
         goto end;
     }
 
-    s->alproto = ALPROTO_DCERPC;
+    if (DetectSignatureSetAppProto(s, ALPROTO_DCERPC) < 0)
+        goto end;
 
     result &= (DetectContentSetup(de_ctx, s, "one") == 0);
     result &= (s->sm_lists[g_dce_stub_data_buffer_id] == NULL && s->sm_lists[DETECT_SM_LIST_PMATCH] != NULL);

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -155,7 +155,9 @@ static int DetectHttpCookieSetupSticky(DetectEngineCtx *de_ctx, Signature *s, co
     if (DetectBufferSetActiveList(s, g_http_cookie_buffer_id) < 0)
         return -1;
 
-    s->alproto = ALPROTO_HTTP;
+    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP) < 0)
+        return -1;
+
     return 0;
 }
 

--- a/src/detect-http-stat-code.c
+++ b/src/detect-http-stat-code.c
@@ -142,7 +142,8 @@ static int DetectHttpStatCodeSetupSticky(DetectEngineCtx *de_ctx, Signature *s, 
 {
     if (DetectBufferSetActiveList(s, g_http_stat_code_buffer_id) < 0)
         return -1;
-    s->alproto = ALPROTO_HTTP;
+    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP) < 0)
+        return -1;
     return 0;
 }
 

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -142,7 +142,8 @@ static int DetectHttpStatMsgSetupSticky(DetectEngineCtx *de_ctx, Signature *s, c
 {
     if (DetectBufferSetActiveList(s, g_http_stat_msg_buffer_id) < 0)
         return -1;
-    s->alproto = ALPROTO_HTTP;
+    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP) < 0)
+        return -1;
     return 0;
 }
 

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -204,7 +204,8 @@ static int DetectHttpUriSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const
 {
     if (DetectBufferSetActiveList(s, g_http_uri_buffer_id) < 0)
         return -1;
-    s->alproto = ALPROTO_HTTP;
+    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP) < 0)
+        return -1;
     return 0;
 }
 
@@ -277,7 +278,8 @@ static int DetectHttpRawUriSetupSticky(DetectEngineCtx *de_ctx, Signature *s, co
 {
     if (DetectBufferSetActiveList(s, g_http_raw_uri_buffer_id) < 0)
         return -1;
-    s->alproto = ALPROTO_HTTP;
+    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP) < 0)
+        return -1;
     return 0;
 }
 

--- a/src/detect-isdataat.c
+++ b/src/detect-isdataat.c
@@ -397,14 +397,20 @@ static int DetectIsdataatTestParse04(void)
     Signature *s = SigAlloc();
     int result = 1;
 
-    s->alproto = ALPROTO_DCERPC;
+    if (DetectSignatureSetAppProto(s, ALPROTO_DCERPC) < 0) {
+        SigFree(s);
+        return 0;
+    }
 
     result &= (DetectIsdataatSetup(NULL, s, "30") == 0);
     result &= (s->sm_lists[g_dce_stub_data_buffer_id] == NULL && s->sm_lists[DETECT_SM_LIST_PMATCH] != NULL);
     SigFree(s);
 
     s = SigAlloc();
-    s->alproto = ALPROTO_DCERPC;
+    if (DetectSignatureSetAppProto(s, ALPROTO_DCERPC) < 0) {
+        SigFree(s);
+        return 0;
+    }
     /* failure since we have no preceding content/pcre/bytejump */
     result &= (DetectIsdataatSetup(NULL, s, "30,relative") == 0);
     result &= (s->sm_lists[g_dce_stub_data_buffer_id] == NULL && s->sm_lists[DETECT_SM_LIST_PMATCH] != NULL);

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -69,7 +69,7 @@ SigMatch *DetectGetLastSMByListPtr(const Signature *s, SigMatch *sm_list, ...);
 SigMatch *DetectGetLastSMByListId(const Signature *s, int list_id, ...);
 
 int DetectSignatureAddTransform(Signature *s, int transform);
-int DetectSignatureSetAppProto(Signature *s, AppProto alproto);
+int WARN_UNUSED DetectSignatureSetAppProto(Signature *s, AppProto alproto);
 
 /* parse regex setup and free util funcs */
 

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -1136,7 +1136,7 @@ static int DetectPcreParseTest10(void)
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
 
-    s->alproto = ALPROTO_DCERPC;
+    FAIL_IF(DetectSignatureSetAppProto(s, ALPROTO_DCERPC) < 0);
 
     FAIL_IF_NOT(DetectPcreSetup(de_ctx, s, "/bamboo/") == 0);
     FAIL_IF_NOT(s->sm_lists[g_dce_stub_data_buffer_id] == NULL && s->sm_lists[DETECT_SM_LIST_PMATCH] != NULL);
@@ -1654,7 +1654,6 @@ static int DetectPcreTestSig01(void)
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     f->alproto = ALPROTO_HTTP;
-
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF(de_ctx == NULL);
 


### PR DESCRIPTION
1. Set `WARN_UNUSED` macro on DetectSignatureSetAppProto.
2. Replace all direct 'sets' of Signature::alproto from keyword registration.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3006