### PR TITLE
configure.ac: prevent empty if block (llc check) - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -462,9 +462,10 @@
                              printf("llc-%s.%s llc-%s llc", v[[1]], v[[2]], v[[1]])
                            }')
                     AC_CHECK_PROGS([LLC], [$llc_candidates], "no")
-                    AS_IF([test "$LLC" != "no"],
-                          [AC_SUBST(LLC)],
-                          [AC_MSG_ERROR([unable to find any of $llc_candidates needed to build ebpf files])])
+                    if test "$LLC" = "no"; then
+                        AC_MSG_ERROR([unable to find any of $llc_candidates needed to build ebpf files])
+                    fi
+                    AC_SUBST(LLC)
                   ],
                   [AC_MSG_ERROR([clang needed to build ebpf files])])
           ])


### PR DESCRIPTION
As AC_SUBST doesn't expand to anything in the shell script, this
will generate a bad script on older versions of autoconf.

Change the logic to eliminate the possibility of an empty
if or else block.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/3124

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/359
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/714
