### PR TITLE
counters: Add new default for decoder events

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -100,7 +100,7 @@ static char stats_enabled = TRUE;
 
 /**< add decoder events as stats? enabled by default */
 bool stats_decoder_events = true;
-const char *stats_decoder_events_prefix = "decoder";
+const char *stats_decoder_events_prefix = "decoder.event";
 /**< add stream events as stats? disabled by default */
 bool stats_stream_events = false;
 
@@ -256,12 +256,7 @@ static void StatsInitCtxPreOutput(void)
 
         const char *prefix = NULL;
         if (ConfGet("stats.decoder-events-prefix", &prefix) != 1) {
-            prefix = "decoder";
-            SCLogWarning(SC_WARN_DEFAULT_WILL_CHANGE, "in 5.0 the default "
-                    "for decoder event stats will go from "
-                    "'decoder.<proto>.<event>' to 'decoder.event.<proto>.<event>'. "
-                    "See ticket #2225. To suppress this message, "
-                    "set stats.decoder-events-prefix in the yaml.");
+            prefix = "decoder.event";
         }
         stats_decoder_events_prefix = prefix;
     }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -65,7 +65,7 @@ stats:
   #decoder-events: true
   # Decoder event prefix in stats. Has been 'decoder' before, but that leads
   # to missing events in the eve.stats records. See issue #2225.
-  decoder-events-prefix: "decoder.event"
+  #decoder-events-prefix: "decoder.event"
   # Add stream events as stats.
   #stream-events: false
 


### PR DESCRIPTION
Set the new default for decoder events to `decoder.event` instead of the
previously used `decoder`. Remove the corresponding warning for 5.0.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3135
