### PR TITLE
krb: removes warning

### DIFF
--- a/src/detect-krb5-cname.c
+++ b/src/detect-krb5-cname.c
@@ -70,7 +70,7 @@ static InspectionBuffer *GetKrb5CNameData(DetectEngineThreadCtx *det_ctx,
         return buffer;
 
     uint32_t b_len = 0;
-    uint8_t *b = NULL;
+    const uint8_t *b = NULL;
 
     if (rs_krb5_tx_get_cname(cbdata->txv, (uint16_t)cbdata->local_id, &b, &b_len) != 1)
         return NULL;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Removes a compiler warning :
```
detect-krb5-cname.c:75:71: warning: passing 'uint8_t **' (aka 'unsigned char **') to parameter of type 'const uint8_t **' (aka 'const unsigned char **') discards qualifiers in nested pointer types
      [-Wincompatible-pointer-types-discards-qualifiers]
    if (rs_krb5_tx_get_cname(cbdata->txv, (uint16_t)cbdata->local_id, &b, &b_len) != 1)
                                                                      ^~
./../rust/gen/c-headers/rust-krb-detect-gen.h:27:81: note: passing argument to parameter 'buffer' here
uint8_t rs_krb5_tx_get_cname(KRB5Transaction * tx, uint16_t i, const uint8_t ** buffer, uint32_t * buffer_len);
```