### PR TITLE
protodetect: continue when multiple patterns match

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1503,7 +1503,7 @@ AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx,
         AppProto pm_results[ALPROTO_MAX];
         uint16_t pm_matches = AppLayerProtoDetectPMGetProto(tctx, f,
                 buf, buflen, direction, pm_results, reverse_flow);
-        if (pm_matches > 0) {
+        if (pm_matches == 1) {
             alproto = pm_results[0];
 
             /* HACK: if detected protocol is dcerpc/udp, we run PP as well
@@ -1513,6 +1513,9 @@ AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx,
 
             pm_alproto = alproto;
 
+            /* fall through */
+        } else if (pm_matches > 1) {
+            SCLogWarning(SC_WARN_UNCOMMON, "Multiple pattern match for protocol detection : %u", pm_matches);
             /* fall through */
         }
     }


### PR DESCRIPTION
This PR is for discussion rather than straight merging.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2757

Describe changes:
- Keep searching when multiple patterns are found for protocol detection

For a proof of concept, this can happen for instance with SSH and SMB

We should not pick randomly one of the protocols.
But I am not sure about what we should do
Should we try the probing parsers of the protocols ? Try to fully parse ? Defer until more data has come ? Set an app layer event ?