### PR TITLE
rules: move old way of install rules to new Makefile target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,12 @@ if HAVE_SURICATA_UPDATE
 		--suricata-conf $(DESTDIR)$(sysconfdir)/suricata/suricata.yaml \
 		--no-test --no-reload
 else
+	echo "error: rules not installed as suricata-update not available"
+	exit 1
+endif
+
+# The old way of installing rules, before Suricata-Update was available.
+install-rules-legacy:
 	install -d "$(DESTDIR)$(e_sysconfrulesdir)"
 if HAVE_FETCH_COMMAND
 if HAVE_WGET_COMMAND
@@ -71,4 +77,3 @@ endif
 	@echo "While rules are installed now, it's highly recommended to use a rule manager for maintaining rules."
 	@echo "The three most common are Suricata-Update, Oinkmaster and Pulledpork. For a guide see:"
 	@echo "https://suricata.readthedocs.io/en/latest/rule-management/index.html"
-endif


### PR DESCRIPTION
Stop falling back to the old method of installing rules into
/etc/suricata/rules if Suricata-Update is not available.

The goal here is to move away from the behaviour of installing
rules to /etc/suricata/rules as part of the default install
process. The engine provided rules are already installed to
/usr/share/suricata/rules, which can then be used as input
to rule management tools such as Suricata-Update.

This does not change the behaviour for Suricata release users
with the bundled Suricata-Update, but does expose the old
behaviour under a new Makefile target: install-rules-legacy.

**Note**: I'm really not sure about leaving the legacy behaviour here at all.  With 5.0 I feel like its time to move on and only put rule files in /usr/share/suricata/rules, and optionally run Suricata-Update.

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/3138

PRscript output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/361
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/716
