### PR TITLE
Next/20190903/v5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -243,6 +243,7 @@ before_install:
         packages="$packages pcre"
         packages="$packages hiredis"
         packages="$packages jq"
+        packages="$packages xz"
         for package in $packages; do
             if brew ls $package --versions > /dev/null; then
                 brew unlink $package

--- a/configure.ac
+++ b/configure.ac
@@ -603,24 +603,22 @@
                 if test "$with_liblzma_libraries" != "no"; then
                     LDFLAGS="${LDFLAGS}  -L${with_liblzma_libraries}"
                     LIBS="${TMPLIBS} -llzma"
-		else
-		    LIBS="${TMPLIBS} -llzma"
+                else
+                    LIBS="${TMPLIBS} -llzma"
                 fi
             fi]),LIBLZMA="no")
 
     if test "$LIBLZMA" != "yes"; then
         echo
-        echo "   Warning! liblzma library not found, you will not be"
-        echo "   able to decompress flash file compressed with lzma."
+        echo "   Error! liblzma library not found.|, you will not be"
         echo "   Debian/Ubuntu: apt install liblzma-dev"
         echo "   Fedora: dnf install xz-devel"
         echo "   CentOS/RHEL: yum install xz-devel"
         echo
-        enable_liblzma=no
-    else
-        enable_liblzma=yes
-        LIBS="${TMPLIBS} -llzma"
+        exit 1
     fi
+    enable_liblzma=yes
+    LIBS="${TMPLIBS} -llzma"
 
   #libpcre
     AC_ARG_WITH(libpcre_includes,

--- a/configure.ac
+++ b/configure.ac
@@ -1638,12 +1638,12 @@
             echo
             exit 1
         fi
-        PKG_CHECK_MODULES(LIBHTPMINVERSION, [htp >= 0.5.20],[libhtp_minver_found="yes"],[libhtp_minver_found="no"])
+        PKG_CHECK_MODULES(LIBHTPMINVERSION, [htp >= 0.5.30],[libhtp_minver_found="yes"],[libhtp_minver_found="no"])
         if test "$libhtp_minver_found" = "no"; then
             PKG_CHECK_MODULES(LIBHTPDEVVERSION, [htp = 0.5.X],[libhtp_devver_found="yes"],[libhtp_devver_found="no"])
             if test "$libhtp_devver_found" = "no"; then
                 echo
-                echo "   ERROR! libhtp was found but it is neither >= 0.5.20, nor the dev 0.5.X"
+                echo "   ERROR! libhtp was found but it is neither >= 0.5.30, nor the dev 0.5.X"
                 echo
                 exit 1
             fi

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -570,7 +570,7 @@ pub extern "C" fn rs_dns_state_tx_free(state: &mut DNSState,
 pub extern "C" fn rs_dns_parse_request(_flow: *mut core::Flow,
                                        state: &mut DNSState,
                                        _pstate: *mut std::os::raw::c_void,
-                                       input: *mut u8,
+                                       input: *const u8,
                                        input_len: u32,
                                        _data: *mut std::os::raw::c_void)
                                        -> i8 {
@@ -586,7 +586,7 @@ pub extern "C" fn rs_dns_parse_request(_flow: *mut core::Flow,
 pub extern "C" fn rs_dns_parse_response(_flow: *mut core::Flow,
                                         state: &mut DNSState,
                                         _pstate: *mut std::os::raw::c_void,
-                                        input: *mut u8,
+                                        input: *const u8,
                                         input_len: u32,
                                         _data: *mut std::os::raw::c_void)
                                         -> i8 {
@@ -603,7 +603,7 @@ pub extern "C" fn rs_dns_parse_response(_flow: *mut core::Flow,
 pub extern "C" fn rs_dns_parse_request_tcp(_flow: *mut core::Flow,
                                            state: &mut DNSState,
                                            _pstate: *mut std::os::raw::c_void,
-                                           input: *mut u8,
+                                           input: *const u8,
                                            input_len: u32,
                                            _data: *mut std::os::raw::c_void)
                                            -> i8 {
@@ -622,7 +622,7 @@ pub extern "C" fn rs_dns_parse_request_tcp(_flow: *mut core::Flow,
 pub extern "C" fn rs_dns_parse_response_tcp(_flow: *mut core::Flow,
                                             state: &mut DNSState,
                                             _pstate: *mut std::os::raw::c_void,
-                                            input: *mut u8,
+                                            input: *const u8,
                                             input_len: u32,
                                             _data: *mut std::os::raw::c_void)
                                             -> i8 {

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -1360,7 +1360,7 @@ pub extern "C" fn rs_nfs_state_free(state: *mut std::os::raw::c_void) {
 pub extern "C" fn rs_nfs_parse_request(_flow: *mut Flow,
                                        state: &mut NFSState,
                                        _pstate: *mut std::os::raw::c_void,
-                                       input: *mut u8,
+                                       input: *const u8,
                                        input_len: u32,
                                        _data: *mut std::os::raw::c_void)
                                        -> i8
@@ -1391,7 +1391,7 @@ pub extern "C" fn rs_nfs_parse_request_tcp_gap(
 pub extern "C" fn rs_nfs_parse_response(_flow: *mut Flow,
                                         state: &mut NFSState,
                                         _pstate: *mut std::os::raw::c_void,
-                                        input: *mut u8,
+                                        input: *const u8,
                                         input_len: u32,
                                         _data: *mut std::os::raw::c_void)
                                         -> i8
@@ -1423,7 +1423,7 @@ pub extern "C" fn rs_nfs_parse_response_tcp_gap(
 pub extern "C" fn rs_nfs_parse_request_udp(_flow: *mut Flow,
                                        state: &mut NFSState,
                                        _pstate: *mut std::os::raw::c_void,
-                                       input: *mut u8,
+                                       input: *const u8,
                                        input_len: u32,
                                        _data: *mut std::os::raw::c_void)
                                        -> i8
@@ -1442,7 +1442,7 @@ pub extern "C" fn rs_nfs_parse_request_udp(_flow: *mut Flow,
 pub extern "C" fn rs_nfs_parse_response_udp(_flow: *mut Flow,
                                         state: &mut NFSState,
                                         _pstate: *mut std::os::raw::c_void,
-                                        input: *mut u8,
+                                        input: *const u8,
                                         input_len: u32,
                                         _data: *mut std::os::raw::c_void)
                                         -> i8

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1796,7 +1796,7 @@ pub extern "C" fn rs_smb_state_free(state: *mut std::os::raw::c_void) {
 pub extern "C" fn rs_smb_parse_request_tcp(_flow: *mut Flow,
                                        state: &mut SMBState,
                                        _pstate: *mut std::os::raw::c_void,
-                                       input: *mut u8,
+                                       input: *const u8,
                                        input_len: u32,
                                        _data: *mut std::os::raw::c_void,
                                        flags: u8)
@@ -1834,7 +1834,7 @@ pub extern "C" fn rs_smb_parse_request_tcp_gap(
 pub extern "C" fn rs_smb_parse_response_tcp(_flow: *mut Flow,
                                         state: &mut SMBState,
                                         _pstate: *mut std::os::raw::c_void,
-                                        input: *mut u8,
+                                        input: *const u8,
                                         input_len: u32,
                                         _data: *mut std::os::raw::c_void,
                                         flags: u8)

--- a/src/app-layer-dcerpc-common.h
+++ b/src/app-layer-dcerpc-common.h
@@ -235,7 +235,7 @@ typedef struct DCERPCUDP_ {
 #define USER_DATA_NOT_READABLE          6 /* not used */
 #define NO_PSAP_AVAILABLE               7 /* not used */
 
-int32_t DCERPCParser(DCERPC *, uint8_t *, uint32_t);
+int32_t DCERPCParser(DCERPC *, const uint8_t *, uint32_t);
 void hexdump(const void *buf, size_t len);
 void printUUID(const char *type, DCERPCUuidEntry *uuid);
 

--- a/src/app-layer-dcerpc-udp.c
+++ b/src/app-layer-dcerpc-udp.c
@@ -65,7 +65,7 @@ enum {
 /** \internal
  *  \retval stub_len or 0 in case of error */
 static uint32_t FragmentDataParser(Flow *f, void *dcerpcudp_state,
-    AppLayerParserState *pstate, uint8_t *input, uint32_t input_len)
+    AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
     DCERPCUDPState *sstate = (DCERPCUDPState *) dcerpcudp_state;
@@ -134,10 +134,10 @@ static uint32_t FragmentDataParser(Flow *f, void *dcerpcudp_state,
  * fragmented packets.
  */
 static int DCERPCUDPParseHeader(Flow *f, void *dcerpcudp_state,
-    AppLayerParserState *pstate, uint8_t *input, uint32_t input_len)
+    AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
     DCERPCUDPState *sstate = (DCERPCUDPState *) dcerpcudp_state;
     if (input_len) {
         switch (sstate->bytesprocessed) {
@@ -716,7 +716,7 @@ static int DCERPCUDPParseHeader(Flow *f, void *dcerpcudp_state,
 }
 
 static int DCERPCUDPParse(Flow *f, void *dcerpc_state,
-    AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+    AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
     void *local_data, const uint8_t flags)
 {
     uint32_t retval = 0;

--- a/src/app-layer-dcerpc.c
+++ b/src/app-layer-dcerpc.c
@@ -162,10 +162,10 @@ void printUUID(const char *type, DCERPCUuidEntry *uuid)
  * \brief DCERPCParseSecondaryAddr reads secondaryaddrlen bytes from the BIND_ACK
  * DCERPC call.
  */
-static uint32_t DCERPCParseSecondaryAddr(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static uint32_t DCERPCParseSecondaryAddr(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
     while (dcerpc->dcerpcbindbindack.secondaryaddrlenleft-- && input_len--) {
         SCLogDebug("0x%02x ", *p);
         p++;
@@ -174,10 +174,10 @@ static uint32_t DCERPCParseSecondaryAddr(DCERPC *dcerpc, uint8_t *input, uint32_
     SCReturnUInt((uint32_t)(p - input));
 }
 
-static uint32_t PaddingParser(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static uint32_t PaddingParser(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
     while (dcerpc->padleft-- && input_len--) {
         SCLogDebug("0x%02x ", *p);
         p++;
@@ -186,10 +186,10 @@ static uint32_t PaddingParser(DCERPC *dcerpc, uint8_t *input, uint32_t input_len
     SCReturnUInt((uint32_t)(p - input));
 }
 
-static uint32_t DCERPCGetCTXItems(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static uint32_t DCERPCGetCTXItems(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
     if (input_len) {
         switch (dcerpc->dcerpcbindbindack.ctxbytesprocessed) {
             case 0:
@@ -232,10 +232,10 @@ static uint32_t DCERPCGetCTXItems(DCERPC *dcerpc, uint8_t *input, uint32_t input
  * each UUID is added to a TAILQ.
  */
 
-static uint32_t DCERPCParseBINDCTXItem(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static uint32_t DCERPCParseBINDCTXItem(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
 
     if (input_len) {
         switch (dcerpc->dcerpcbindbindack.ctxbytesprocessed) {
@@ -664,10 +664,10 @@ static uint32_t DCERPCParseBINDCTXItem(DCERPC *dcerpc, uint8_t *input, uint32_t 
  * the BIND_ACK call. The result (Accepted or Rejected) is added to the
  * correct UUID from the BIND call.
  */
-static uint32_t DCERPCParseBINDACKCTXItem(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static uint32_t DCERPCParseBINDACKCTXItem(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
     DCERPCUuidEntry *uuid_entry;
 
     if (input_len) {
@@ -874,10 +874,10 @@ static uint32_t DCERPCParseBINDACKCTXItem(DCERPC *dcerpc, uint8_t *input, uint32
     SCReturnUInt((uint32_t)(p - input));
 }
 
-static uint32_t DCERPCParseBIND(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static uint32_t DCERPCParseBIND(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
     if (input_len) {
         switch (dcerpc->bytesprocessed) {
             case 16:
@@ -980,10 +980,10 @@ static uint32_t DCERPCParseBIND(DCERPC *dcerpc, uint8_t *input, uint32_t input_l
     SCReturnUInt((uint32_t)(p - input));
 }
 
-static uint32_t DCERPCParseBINDACK(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static uint32_t DCERPCParseBINDACK(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
 
     switch (dcerpc->bytesprocessed) {
         case 16:
@@ -1073,10 +1073,10 @@ static uint32_t DCERPCParseBINDACK(DCERPC *dcerpc, uint8_t *input, uint32_t inpu
     SCReturnUInt((uint32_t)(p - input));
 }
 
-static uint32_t DCERPCParseREQUEST(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static uint32_t DCERPCParseREQUEST(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
 
     switch (dcerpc->bytesprocessed) {
         case 16:
@@ -1257,10 +1257,10 @@ static uint32_t StubDataParser(DCERPC *dcerpc, const uint8_t *input, uint32_t in
  * \retval -1 if DCERPC Header does not validate
  * \retval Number of bytes processed
  */
-static int DCERPCParseHeader(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+static int DCERPCParseHeader(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
-    uint8_t *p = input;
+    const uint8_t *p = input;
 
     if (input_len) {
         SCLogDebug("dcerpc->bytesprocessed %u", dcerpc->bytesprocessed);
@@ -1430,7 +1430,7 @@ static inline void DCERPCResetStub(DCERPC *dcerpc)
     return;
 }
 
-static inline int DCERPCThrowOutExtraData(DCERPC *dcerpc, uint8_t *input,
+static inline int DCERPCThrowOutExtraData(DCERPC *dcerpc, const uint8_t *input,
                                            uint16_t input_len)
 {
     int parsed = 0;
@@ -1455,7 +1455,7 @@ static inline int DCERPCThrowOutExtraData(DCERPC *dcerpc, uint8_t *input,
  *         a condition where it has receives a segment with 2 pdus, while the
  *         first pdu in the segment is corrupt.
  */
-int32_t DCERPCParser(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
+int32_t DCERPCParser(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
 
@@ -1888,7 +1888,7 @@ int32_t DCERPCParser(DCERPC *dcerpc, uint8_t *input, uint32_t input_len)
 
 static int DCERPCParse(Flow *f, void *dcerpc_state,
                        AppLayerParserState *pstate,
-                       uint8_t *input, uint32_t input_len,
+                       const uint8_t *input, uint32_t input_len,
                        void *local_data, int dir)
 {
     SCEnter();
@@ -1921,7 +1921,7 @@ static int DCERPCParse(Flow *f, void *dcerpc_state,
 
 static int DCERPCParseRequest(Flow *f, void *dcerpc_state,
                               AppLayerParserState *pstate,
-                              uint8_t *input, uint32_t input_len,
+                              const uint8_t *input, uint32_t input_len,
                               void *local_data, const uint8_t flags)
 {
     return DCERPCParse(f, dcerpc_state, pstate, input, input_len,
@@ -1930,7 +1930,7 @@ static int DCERPCParseRequest(Flow *f, void *dcerpc_state,
 
 static int DCERPCParseResponse(Flow *f, void *dcerpc_state,
                                AppLayerParserState *pstate,
-                               uint8_t *input, uint32_t input_len,
+                               const uint8_t *input, uint32_t input_len,
                                void *local_data, const uint8_t flags)
 {
     return DCERPCParse(f, dcerpc_state, pstate, input, input_len,

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -187,7 +187,7 @@ static AppProto AppLayerProtoDetectPMMatchSignature(
         const AppLayerProtoDetectPMSignature *s,
         AppLayerProtoDetectThreadCtx *tctx,
         Flow *f, uint8_t direction,
-        uint8_t *buf, uint16_t buflen, uint16_t searchlen,
+        const uint8_t *buf, uint16_t buflen, uint16_t searchlen,
         bool *rflow)
 {
     SCEnter();
@@ -203,7 +203,7 @@ static AppProto AppLayerProtoDetectPMMatchSignature(
         SCReturnUInt(ALPROTO_UNKNOWN);
     }
 
-    uint8_t *sbuf = buf + s->cd->offset;
+    const uint8_t *sbuf = buf + s->cd->offset;
     uint16_t ssearchlen = s->cd->depth - s->cd->offset;
     SCLogDebug("s->co->offset (%"PRIu16") s->cd->depth (%"PRIu16")",
                s->cd->offset, s->cd->depth);
@@ -262,7 +262,7 @@ static inline int PMGetProtoInspect(
         AppLayerProtoDetectThreadCtx *tctx,
         AppLayerProtoDetectPMCtx *pm_ctx,
         MpmThreadCtx *mpm_tctx,
-        Flow *f, uint8_t *buf, uint16_t buflen,
+        Flow *f, const uint8_t *buf, uint16_t buflen,
         uint8_t direction, AppProto *pm_results, bool *rflow)
 {
     int pm_matches = 0;
@@ -316,7 +316,7 @@ static inline int PMGetProtoInspect(
  *  \param pm_results[out] AppProto array of size ALPROTO_MAX */
 static AppProto AppLayerProtoDetectPMGetProto(
         AppLayerProtoDetectThreadCtx *tctx,
-        Flow *f, uint8_t *buf, uint16_t buflen,
+        Flow *f, const uint8_t *buf, uint16_t buflen,
         uint8_t direction, AppProto *pm_results, bool *rflow)
 {
     SCEnter();
@@ -447,7 +447,7 @@ static AppProto AppLayerProtoDetectPEGetProto(Flow *f, uint8_t ipproto,
 static inline AppProto PPGetProto(
         const AppLayerProtoDetectProbingParserElement *pe,
         Flow *f, uint8_t direction,
-        uint8_t *buf, uint32_t buflen,
+        const uint8_t *buf, uint32_t buflen,
         uint32_t *alproto_masks, uint8_t *rdir
 )
 {
@@ -485,7 +485,7 @@ static inline AppProto PPGetProto(
  *
  */
 static AppProto AppLayerProtoDetectPPGetProto(Flow *f,
-        uint8_t *buf, uint32_t buflen,
+        const uint8_t *buf, uint32_t buflen,
         uint8_t ipproto, const uint8_t idir,
         bool *reverse_flow)
 {
@@ -1488,7 +1488,7 @@ static int AppLayerProtoDetectPMRegisterPattern(uint8_t ipproto, AppProto alprot
 
 AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx,
                                      Flow *f,
-                                     uint8_t *buf, uint32_t buflen,
+                                     const uint8_t *buf, uint32_t buflen,
                                      uint8_t ipproto, uint8_t direction,
                                      bool *reverse_flow)
 {
@@ -2912,7 +2912,7 @@ static int AppLayerProtoDetectPPTestData(AppLayerProtoDetectProbingParser *pp,
 }
 
 static uint16_t ProbingParserDummyForTesting(Flow *f, uint8_t direction,
-                                             uint8_t *input,
+                                             const uint8_t *input,
                                              uint32_t input_len, uint8_t *rdir)
 {
     return 0;

--- a/src/app-layer-detect-proto.h
+++ b/src/app-layer-detect-proto.h
@@ -28,7 +28,7 @@
 typedef struct AppLayerProtoDetectThreadCtx_ AppLayerProtoDetectThreadCtx;
 
 typedef AppProto (*ProbingParserFPtr)(Flow *f, uint8_t dir,
-                                      uint8_t *input, uint32_t input_len,
+                                      const uint8_t *input, uint32_t input_len,
                                       uint8_t *rdir);
 
 /***** Protocol Retrieval *****/
@@ -48,7 +48,7 @@ typedef AppProto (*ProbingParserFPtr)(Flow *f, uint8_t dir,
  */
 AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx,
                                      Flow *f,
-                                     uint8_t *buf, uint32_t buflen,
+                                     const uint8_t *buf, uint32_t buflen,
                                      uint8_t ipproto, uint8_t direction,
                                      bool *reverse_flow);
 

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -265,7 +265,7 @@ static int DNP3ContainsBanner(const uint8_t *input, uint32_t len)
  * \brief DNP3 probing parser.
  */
 static uint16_t DNP3ProbingParser(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t len,
+        const uint8_t *input, uint32_t len,
         uint8_t *rdir)
 {
     DNP3LinkHeader *hdr = (DNP3LinkHeader *)input;
@@ -1112,7 +1112,7 @@ error:
  * multiple frames, but not the complete final frame).
  */
 static int DNP3ParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
     SCEnter();
@@ -1252,7 +1252,7 @@ error:
  * See DNP3ParseResponsePDUs for DNP3 frame handling.
  */
 static int DNP3ParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
     SCEnter();

--- a/src/app-layer-dns-tcp-rust.c
+++ b/src/app-layer-dns-tcp-rust.c
@@ -35,7 +35,7 @@ static void RustDNSTCPParserRegisterTests(void);
 #endif
 
 static int RustDNSTCPParseRequest(Flow *f, void *state,
-        AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+        AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
     SCLogDebug("RustDNSTCPParseRequest");
@@ -44,7 +44,7 @@ static int RustDNSTCPParseRequest(Flow *f, void *state,
 }
 
 static int RustDNSTCPParseResponse(Flow *f, void *state,
-        AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+        AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
     SCLogDebug("RustDNSTCPParseResponse");
@@ -53,7 +53,7 @@ static int RustDNSTCPParseResponse(Flow *f, void *state,
 }
 
 static uint16_t RustDNSTCPProbe(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t len, uint8_t *rdir)
+        const uint8_t *input, uint32_t len, uint8_t *rdir)
 {
     SCLogDebug("RustDNSTCPProbe");
     if (len == 0 || len < sizeof(DNSHeader)) {

--- a/src/app-layer-dns-udp-rust.c
+++ b/src/app-layer-dns-udp-rust.c
@@ -35,7 +35,7 @@ static void RustDNSUDPParserRegisterTests(void);
 #endif
 
 static int RustDNSUDPParseRequest(Flow *f, void *state,
-        AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+        AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
     return rs_dns_parse_request(f, state, pstate, input, input_len,
@@ -43,7 +43,7 @@ static int RustDNSUDPParseRequest(Flow *f, void *state,
 }
 
 static int RustDNSUDPParseResponse(Flow *f, void *state,
-        AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+        AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
     return rs_dns_parse_response(f, state, pstate, input, input_len,
@@ -51,7 +51,7 @@ static int RustDNSUDPParseResponse(Flow *f, void *state,
 }
 
 static uint16_t DNSUDPProbe(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t len, uint8_t *rdir)
+        const uint8_t *input, uint32_t len, uint8_t *rdir)
 {
     if (len == 0 || len < sizeof(DNSHeader)) {
         return ALPROTO_UNKNOWN;

--- a/src/app-layer-enip-common.c
+++ b/src/app-layer-enip-common.c
@@ -41,7 +41,7 @@
  * @param input
  * @param offset
  */
-static int ENIPExtractUint8(uint8_t *res, uint8_t *input, uint16_t *offset, uint32_t input_len)
+static int ENIPExtractUint8(uint8_t *res, const uint8_t *input, uint16_t *offset, uint32_t input_len)
 {
 
     if (input_len < sizeof(uint8_t) || *offset > (input_len - sizeof(uint8_t)))
@@ -61,7 +61,7 @@ static int ENIPExtractUint8(uint8_t *res, uint8_t *input, uint16_t *offset, uint
  * @param input
  * @param offset
  */
-static int ENIPExtractUint16(uint16_t *res, uint8_t *input, uint16_t *offset, uint32_t input_len)
+static int ENIPExtractUint16(uint16_t *res, const uint8_t *input, uint16_t *offset, uint32_t input_len)
 {
 
     if (input_len < sizeof(uint16_t) || *offset > (input_len - sizeof(uint16_t)))
@@ -82,7 +82,7 @@ static int ENIPExtractUint16(uint16_t *res, uint8_t *input, uint16_t *offset, ui
  * @param input
  * @param offset
  */
-static int ENIPExtractUint32(uint32_t *res, uint8_t *input, uint16_t *offset, uint32_t input_len)
+static int ENIPExtractUint32(uint32_t *res, const uint8_t *input, uint16_t *offset, uint32_t input_len)
 {
 
     if (input_len < sizeof(uint32_t) || *offset > (input_len - sizeof(uint32_t)))
@@ -103,7 +103,7 @@ static int ENIPExtractUint32(uint32_t *res, uint8_t *input, uint16_t *offset, ui
  * @param input
  * @param offset
  */
-static int ENIPExtractUint64(uint64_t *res, uint8_t *input, uint16_t *offset, uint32_t input_len)
+static int ENIPExtractUint64(uint64_t *res, const uint8_t *input, uint16_t *offset, uint32_t input_len)
 {
 
     if (input_len < sizeof(uint64_t) || *offset > (input_len - sizeof(uint64_t)))
@@ -182,7 +182,7 @@ static void CIPServiceFree(void *s)
  * @return 1 Packet ok
  * @return 0 Packet has errors
  */
-int DecodeENIPPDU(uint8_t *input, uint32_t input_len,
+int DecodeENIPPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data)
 {
     int ret = 1;
@@ -283,7 +283,7 @@ int DecodeENIPPDU(uint8_t *input, uint32_t input_len,
  * @return 1 Packet ok
  * @return 0 Packet has errors
  */
-int DecodeCommonPacketFormatPDU(uint8_t *input, uint32_t input_len,
+int DecodeCommonPacketFormatPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset)
 {
 
@@ -404,7 +404,7 @@ int DecodeCommonPacketFormatPDU(uint8_t *input, uint32_t input_len,
  * @return 0 Packet has errors
  */
 
-int DecodeCIPPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset)
 {
     int ret = 1;
@@ -448,7 +448,7 @@ int DecodeCIPPDU(uint8_t *input, uint32_t input_len,
  * @return 1 Packet ok
  * @return 0 Packet has errors
  */
-int DecodeCIPRequestPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPRequestPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset)
 {
     int ret = 1;
@@ -568,7 +568,7 @@ int DecodeCIPRequestPDU(uint8_t *input, uint32_t input_len,
  * @return 1 Packet matches
  * @return 0 Packet not match
  */
-int DecodeCIPRequestPathPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPRequestPathPDU(const uint8_t *input, uint32_t input_len,
         CIPServiceEntry *node, uint16_t offset)
 {
     //SCLogDebug("DecodeCIPRequestPath: service 0x%x size %d length %d",
@@ -741,7 +741,7 @@ int DecodeCIPRequestPathPDU(uint8_t *input, uint32_t input_len,
  * @return 1 Packet ok
  * @return 0 Packet has errors
  */
-int DecodeCIPResponsePDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPResponsePDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset)
 {
     int ret = 1;
@@ -860,7 +860,7 @@ int DecodeCIPResponsePDU(uint8_t *input, uint32_t input_len,
  * @return 1 Packet ok
  * @return 0 Packet has errors
  */
-int DecodeCIPRequestMSPPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPRequestMSPPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset)
 {
     int ret = 1;
@@ -907,7 +907,7 @@ int DecodeCIPRequestMSPPDU(uint8_t *input, uint32_t input_len,
  * @return 1 Packet ok
  * @return 0 Packet has errors
  */
-int DecodeCIPResponseMSPPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPResponseMSPPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset)
 {
     int ret = 1;

--- a/src/app-layer-enip-common.h
+++ b/src/app-layer-enip-common.h
@@ -230,21 +230,21 @@ typedef struct ENIPState_
     uint8_t *buffer;
 } ENIPState;
 
-int DecodeENIPPDU(uint8_t *input, uint32_t input_len,
+int DecodeENIPPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data);
-int DecodeCommonPacketFormatPDU(uint8_t *input, uint32_t input_len,
+int DecodeCommonPacketFormatPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset);
-int DecodeCIPPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset);
-int DecodeCIPRequestPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPRequestPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset);
-int DecodeCIPResponsePDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPResponsePDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset);
-int DecodeCIPRequestPathPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPRequestPathPDU(const uint8_t *input, uint32_t input_len,
         CIPServiceEntry *node, uint16_t offset);
-int DecodeCIPRequestMSPPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPRequestMSPPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset);
-int DecodeCIPResponseMSPPDU(uint8_t *input, uint32_t input_len,
+int DecodeCIPResponseMSPPDU(const uint8_t *input, uint32_t input_len,
         ENIPTransaction *enip_data, uint16_t offset);
 
 #endif /* __APP_LAYER_ENIP_COMMON_H__ */

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -313,7 +313,7 @@ static void ENIPStateTransactionFree(void *state, uint64_t tx_id)
  * \retval 1 when the command is parsed, 0 otherwise
  */
 static int ENIPParse(Flow *f, void *state, AppLayerParserState *pstate,
-        uint8_t *input, uint32_t input_len, void *local_data,
+        const uint8_t *input, uint32_t input_len, void *local_data,
         const uint8_t flags)
 {
     SCEnter();
@@ -365,7 +365,7 @@ static int ENIPParse(Flow *f, void *state, AppLayerParserState *pstate,
 
 
 static uint16_t ENIPProbingParser(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t input_len, uint8_t *rdir)
+        const uint8_t *input, uint32_t input_len, uint8_t *rdir)
 {
     // SCLogDebug("ENIPProbingParser %d", input_len);
     if (input_len < sizeof(ENIPEncapHdr))

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -479,7 +479,7 @@ static int FTPGetLine(FtpState *state)
  * \retval 1 when the command is parsed, 0 otherwise
  */
 static int FTPParseRequestCommand(FTPThreadCtx *td,
-                                  uint8_t *input, uint32_t input_len,
+                                  const uint8_t *input, uint32_t input_len,
                                   const FtpCommand **cmd_descriptor)
 {
     SCEnter();
@@ -519,7 +519,7 @@ static void FtpTransferCmdFree(void *data)
     FTPFree(cmd, sizeof(struct FtpTransferCmd));
 }
 
-static uint32_t CopyCommandLine(uint8_t **dest, uint8_t *src, uint32_t length)
+static uint32_t CopyCommandLine(uint8_t **dest, const uint8_t *src, uint32_t length)
 {
     if (likely(length)) {
         uint8_t *where = FTPCalloc(length + 1, sizeof(char));
@@ -557,7 +557,7 @@ static uint16_t ftp_validate_port(int computed_port_value)
  *
  * \retval 0 if a port number could not be extracted; otherwise, the dynamic port number
  */
-static uint16_t FTPGetV6PortNumber(uint8_t *input, uint32_t input_len)
+static uint16_t FTPGetV6PortNumber(const uint8_t *input, uint32_t input_len)
 {
     uint16_t res;
 
@@ -587,7 +587,7 @@ static uint16_t FTPGetV6PortNumber(uint8_t *input, uint32_t input_len)
  *
  * \retval 0 if a port number could not be extracted; otherwise, the dynamic port number
  */
-static uint16_t FTPGetV4PortNumber(uint8_t *input, uint32_t input_len)
+static uint16_t FTPGetV4PortNumber(const uint8_t *input, uint32_t input_len)
 {
     uint16_t part1, part2;
     uint8_t *ptr = memrchr(input, ',', input_len);
@@ -615,7 +615,7 @@ static uint16_t FTPGetV4PortNumber(uint8_t *input, uint32_t input_len)
  */
 static int FTPParseRequest(Flow *f, void *ftp_state,
                            AppLayerParserState *pstate,
-                           uint8_t *input, uint32_t input_len,
+                           const uint8_t *input, uint32_t input_len,
                            void *local_data, const uint8_t flags)
 {
     FTPThreadCtx *thread_data = local_data;
@@ -734,7 +734,7 @@ static int FTPParseRequest(Flow *f, void *ftp_state,
     return 1;
 }
 
-static int FTPParsePassiveResponse(Flow *f, FtpState *state, uint8_t *input, uint32_t input_len)
+static int FTPParsePassiveResponse(Flow *f, FtpState *state, const uint8_t *input, uint32_t input_len)
 {
     uint16_t dyn_port = rs_ftp_pasv_response(input, input_len);
     if (dyn_port == 0) {
@@ -749,7 +749,7 @@ static int FTPParsePassiveResponse(Flow *f, FtpState *state, uint8_t *input, uin
     return 0;
 }
 
-static int FTPParsePassiveResponseV6(Flow *f, FtpState *state, uint8_t *input, uint32_t input_len)
+static int FTPParsePassiveResponseV6(Flow *f, FtpState *state, const uint8_t *input, uint32_t input_len)
 {
     uint16_t dyn_port = rs_ftp_epsv_response(input, input_len);
     if (dyn_port == 0) {
@@ -772,7 +772,7 @@ static int FTPParsePassiveResponseV6(Flow *f, FtpState *state, uint8_t *input, u
  *                The requested action is being initiated; expect another
  *                               reply before proceeding with a new command
  */
-static inline bool FTPIsPPR(uint8_t *input, uint32_t input_len)
+static inline bool FTPIsPPR(const uint8_t *input, uint32_t input_len)
 {
     return input_len >= 4 && isdigit(input[0]) && input[0] == '1' &&
            isdigit(input[1]) && isdigit(input[2]) && isspace(input[3]);
@@ -788,7 +788,7 @@ static inline bool FTPIsPPR(uint8_t *input, uint32_t input_len)
  * \retval 1 when the command is parsed, 0 otherwise
  */
 static int FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserState *pstate,
-                            uint8_t *input, uint32_t input_len,
+                            const uint8_t *input, uint32_t input_len,
                             void *local_data, const uint8_t flags)
 {
     FtpState *state = (FtpState *)ftp_state;
@@ -1110,7 +1110,7 @@ static StreamingBufferConfig sbcfg = STREAMING_BUFFER_CONFIG_INITIALIZER;
  */
 static int FTPDataParse(Flow *f, FtpDataState *ftpdata_state,
         AppLayerParserState *pstate,
-        uint8_t *input, uint32_t input_len,
+        const uint8_t *input, uint32_t input_len,
         void *local_data, int direction)
 {
     uint16_t flags = FileFlowToFlags(f, direction);
@@ -1201,7 +1201,7 @@ static LoggerId FTPStateGetTxLogged(void *state, void *vtx)
 }
 static int FTPDataParseRequest(Flow *f, void *ftp_state,
         AppLayerParserState *pstate,
-        uint8_t *input, uint32_t input_len,
+        const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
     return FTPDataParse(f, ftp_state, pstate, input, input_len,
@@ -1210,7 +1210,7 @@ static int FTPDataParseRequest(Flow *f, void *ftp_state,
 
 static int FTPDataParseResponse(Flow *f, void *ftp_state,
         AppLayerParserState *pstate,
-        uint8_t *input, uint32_t input_len,
+        const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
     return FTPDataParse(f, ftp_state, pstate, input, input_len,

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -162,7 +162,7 @@ typedef struct FTPTransaction_  {
 
 /** FTP State for app layer parser */
 typedef struct FtpState_ {
-    uint8_t *input;
+    const uint8_t *input;
     int32_t input_len;
     uint8_t direction;
     bool active;
@@ -173,7 +173,7 @@ typedef struct FtpState_ {
 
     /* --parser details-- */
     /** current line extracted by the parser from the call to FTPGetline() */
-    uint8_t *current_line;
+    const uint8_t *current_line;
     /** length of the line in current_line.  Doesn't include the delimiter */
     uint32_t current_line_len;
     uint8_t current_line_delimiter_len;

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -763,7 +763,7 @@ error:
  */
 static int HTPHandleRequestData(Flow *f, void *htp_state,
                                 AppLayerParserState *pstate,
-                                uint8_t *input, uint32_t input_len,
+                                const uint8_t *input, uint32_t input_len,
                                 void *local_data, const uint8_t flags)
 {
     SCEnter();
@@ -826,7 +826,7 @@ error:
  */
 static int HTPHandleResponseData(Flow *f, void *htp_state,
                                  AppLayerParserState *pstate,
-                                 uint8_t *input, uint32_t input_len,
+                                 const uint8_t *input, uint32_t input_len,
                                  void *local_data, const uint8_t flags)
 {
     SCEnter();

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1638,8 +1638,12 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
 
     int result = 0;
 
-    /* see if we need to open the file */
-    if (!(htud->tcflags & HTP_FILENAME_SET))
+    /* see if we need to open the file
+     * we check for tx->response_line in case of junk
+     * interpreted as body before response line
+     */
+    if (!(htud->tcflags & HTP_FILENAME_SET) &&
+        (tx->response_line != NULL || tx->is_protocol_0_9))
     {
         SCLogDebug("setting up file name");
 
@@ -1684,7 +1688,7 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
             }
         }
     }
-    else
+    else if (tx->response_line != NULL || tx->is_protocol_0_9)
     {
         /* otherwise, just store the data */
 

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -418,7 +418,7 @@ static void ModbusStateTxFree(void *state, uint64_t tx_id)
  */
 static int ModbusExtractUint8(ModbusState   *modbus,
                               uint8_t       *res,
-                              uint8_t       *input,
+                              const uint8_t *input,
                               uint32_t      input_len,
                               uint16_t      *offset) {
     SCEnter();
@@ -442,7 +442,7 @@ static int ModbusExtractUint8(ModbusState   *modbus,
  */
 static int ModbusExtractUint16(ModbusState  *modbus,
                                uint16_t     *res,
-                               uint8_t      *input,
+                               const uint8_t *input,
                                uint32_t     input_len,
                                uint16_t     *offset) {
     SCEnter();
@@ -513,7 +513,7 @@ static void ModbusCheckHeader(ModbusState       *modbus,
  */
 static void ModbusExceptionResponse(ModbusTransaction   *tx,
                                     ModbusState         *modbus,
-                                    uint8_t             *input,
+                                    const uint8_t       *input,
                                     uint32_t            input_len,
                                     uint16_t            *offset)
 {
@@ -566,7 +566,7 @@ static void ModbusExceptionResponse(ModbusTransaction   *tx,
  */
 static void ModbusParseReadRequest(ModbusTransaction   *tx,
                                    ModbusState         *modbus,
-                                   uint8_t             *input,
+                                   const uint8_t       *input,
                                    uint32_t            input_len,
                                    uint16_t            *offset)
 {
@@ -619,7 +619,7 @@ end:
  */
 static void ModbusParseReadResponse(ModbusTransaction   *tx,
                                     ModbusState         *modbus,
-                                    uint8_t             *input,
+                                    const uint8_t       *input,
                                     uint32_t            input_len,
                                     uint16_t            *offset)
 {
@@ -669,7 +669,7 @@ end:
  */
 static int ModbusParseWriteRequest(ModbusTransaction   *tx,
                                    ModbusState         *modbus,
-                                   uint8_t             *input,
+                                   const uint8_t       *input,
                                    uint32_t            input_len,
                                    uint16_t            *offset)
 {
@@ -796,7 +796,7 @@ end:
  */
 static void ModbusParseWriteResponse(ModbusTransaction   *tx,
                                      ModbusState         *modbus,
-                                     uint8_t             *input,
+                                     const uint8_t       *input,
                                      uint32_t            input_len,
                                      uint16_t            *offset)
 {
@@ -895,7 +895,7 @@ end:
  */
 static int ModbusParseDiagnosticRequest(ModbusTransaction   *tx,
                                         ModbusState         *modbus,
-                                        uint8_t             *input,
+                                        const uint8_t       *input,
                                         uint32_t            input_len,
                                         uint16_t            *offset)
 {
@@ -993,7 +993,7 @@ static ModbusFunctionCodeRange modbusFunctionCodeRanges[] = {
  */
 static void ModbusParseRequestPDU(ModbusTransaction *tx,
                                   ModbusState       *modbus,
-                                  uint8_t           *input,
+                                  const uint8_t     *input,
                                   uint32_t          input_len)
 {
     SCEnter();
@@ -1150,7 +1150,7 @@ end:
  */
 static void ModbusParseResponsePDU(ModbusTransaction    *tx,
                                    ModbusState          *modbus,
-                                   uint8_t              *input,
+                                   const uint8_t        *input,
                                    uint32_t             input_len)
 {
     SCEnter();
@@ -1223,7 +1223,7 @@ end:
  */
 static int ModbusParseHeader(ModbusState   *modbus,
                              ModbusHeader  *header,
-                             uint8_t       *input,
+                             const uint8_t *input,
                              uint32_t      input_len)
 {
     SCEnter();
@@ -1270,7 +1270,7 @@ static int ModbusParseHeader(ModbusState   *modbus,
 static int ModbusParseRequest(Flow                  *f,
                               void                  *state,
                               AppLayerParserState   *pstate,
-                              uint8_t               *input,
+                              const uint8_t         *input,
                               uint32_t              input_len,
                               void                  *local_data,
                               const uint8_t         flags)
@@ -1288,7 +1288,7 @@ static int ModbusParseRequest(Flow                  *f,
 
     while (input_len > 0) {
         uint32_t    adu_len = input_len;
-        uint8_t     *adu = input;
+        const uint8_t     *adu = input;
 
         /* Extract MODBUS Header */
         if (ModbusParseHeader(modbus, &header, adu, adu_len))
@@ -1335,7 +1335,7 @@ static int ModbusParseRequest(Flow                  *f,
 static int ModbusParseResponse(Flow                 *f,
                                void                 *state,
                                AppLayerParserState  *pstate,
-                               uint8_t              *input,
+                               const uint8_t        *input,
                                uint32_t             input_len,
                                void                 *local_data,
                                const uint8_t        flags)
@@ -1353,7 +1353,7 @@ static int ModbusParseResponse(Flow                 *f,
 
     while (input_len > 0) {
         uint32_t    adu_len = input_len;
-        uint8_t     *adu = input;
+        const uint8_t     *adu = input;
 
         /* Extract MODBUS Header */
         if (ModbusParseHeader(modbus, &header, adu, adu_len))
@@ -1434,7 +1434,7 @@ static void ModbusStateFree(void *state)
 
 static uint16_t ModbusProbingParser(Flow *f,
                                     uint8_t direction,
-                                    uint8_t     *input,
+                                    const uint8_t *input,
                                     uint32_t    input_len,
                                     uint8_t *rdir)
 {

--- a/src/app-layer-nfs-tcp.c
+++ b/src/app-layer-nfs-tcp.c
@@ -120,7 +120,7 @@ static AppLayerDecoderEvents *NFSTCPGetEvents(void *tx)
  */
 static AppProto NFSTCPProbingParserMidstream(Flow *f,
         uint8_t direction,
-        uint8_t *input, uint32_t input_len,
+        const uint8_t *input, uint32_t input_len,
         uint8_t *rdir)
 {
     if (input_len < NFSTCP_MIN_FRAME_LEN) {
@@ -146,7 +146,7 @@ static AppProto NFSTCPProbingParserMidstream(Flow *f,
  */
 static AppProto NFSTCPProbingParser(Flow *f,
         uint8_t direction,
-        uint8_t *input, uint32_t input_len,
+        const uint8_t *input, uint32_t input_len,
         uint8_t *rdir)
 {
     if (input_len < NFSTCP_MIN_FRAME_LEN) {
@@ -165,7 +165,7 @@ static AppProto NFSTCPProbingParser(Flow *f,
 }
 
 static int NFSTCPParseRequest(Flow *f, void *state,
-    AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+    AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
     void *local_data, const uint8_t flags)
 {
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOSERVER);
@@ -181,7 +181,7 @@ static int NFSTCPParseRequest(Flow *f, void *state,
 }
 
 static int NFSTCPParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOCLIENT);

--- a/src/app-layer-nfs-udp.c
+++ b/src/app-layer-nfs-udp.c
@@ -118,7 +118,7 @@ static AppLayerDecoderEvents *NFSGetEvents(void *tx)
  *     ALPROTO_UNKNOWN.
  */
 static AppProto NFSProbingParser(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t input_len, uint8_t *rdir)
+        const uint8_t *input, uint32_t input_len, uint8_t *rdir)
 {
     SCLogDebug("probing");
     if (input_len < NFS_MIN_FRAME_LEN) {
@@ -145,7 +145,7 @@ static AppProto NFSProbingParser(Flow *f, uint8_t direction,
 }
 
 static int NFSParseRequest(Flow *f, void *state,
-    AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+    AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
     void *local_data, const uint8_t flags)
 {
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOSERVER);
@@ -155,7 +155,7 @@ static int NFSParseRequest(Flow *f, void *state,
 }
 
 static int NFSParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOCLIENT);

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1154,7 +1154,7 @@ void AppLayerParserSetTxDetectFlags(uint8_t ipproto, AppProto alproto, void *tx,
 /***** General *****/
 
 int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow *f, AppProto alproto,
-                        uint8_t flags, uint8_t *input, uint32_t input_len)
+                        uint8_t flags, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
 #ifdef DEBUG_VALIDATION
@@ -1958,7 +1958,7 @@ typedef struct TestState_ {
  *          parser of occurence of an error.
  */
 static int TestProtocolParser(Flow *f, void *test_state, AppLayerParserState *pstate,
-                              uint8_t *input, uint32_t input_len,
+                              const uint8_t *input, uint32_t input_len,
                               void *local_data, const uint8_t flags)
 {
     SCEnter();

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -91,7 +91,7 @@ int AppLayerParserConfParserEnabled(const char *ipproto,
 /** \brief Prototype for parsing functions */
 typedef int (*AppLayerParserFPtr)(Flow *f, void *protocol_state,
         AppLayerParserState *pstate,
-        uint8_t *buf, uint32_t buf_len,
+        const uint8_t *buf, uint32_t buf_len,
         void *local_storage, const uint8_t flags);
 
 typedef struct AppLayerGetTxIterTuple {
@@ -229,7 +229,7 @@ void AppLayerParserSetTxDetectFlags(uint8_t ipproto, AppProto alproto, void *tx,
 /***** General *****/
 
 int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *tctx, Flow *f, AppProto alproto,
-                   uint8_t flags, uint8_t *input, uint32_t input_len);
+                   uint8_t flags, const uint8_t *input, uint32_t input_len);
 void AppLayerParserSetEOF(AppLayerParserState *pstate);
 bool AppLayerParserHasDecoderEvents(AppLayerParserState *pstate);
 int AppLayerParserIsTxAware(AppProto alproto);

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -33,7 +33,7 @@
 #define MIN_REC_SIZE 32+4 // SMB hdr + nbss hdr
 
 static int SMBTCPParseRequest(Flow *f, void *state,
-        AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+        AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
     SCLogDebug("SMBTCPParseRequest");
@@ -55,7 +55,7 @@ static int SMBTCPParseRequest(Flow *f, void *state,
 }
 
 static int SMBTCPParseResponse(Flow *f, void *state,
-        AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+        AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
     SCLogDebug("SMBTCPParseResponse");
@@ -78,7 +78,7 @@ static int SMBTCPParseResponse(Flow *f, void *state,
 }
 
 static uint16_t SMBTCPProbe(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t len, uint8_t *rdir)
+        const uint8_t *input, uint32_t len, uint8_t *rdir)
 {
     SCLogDebug("SMBTCPProbe");
 
@@ -103,7 +103,7 @@ static uint16_t SMBTCPProbe(Flow *f, uint8_t direction,
  *         back to the port numbers for a hint
  */
 static uint16_t SMB3TCPProbe(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t len, uint8_t *rdir)
+        const uint8_t *input, uint32_t len, uint8_t *rdir)
 {
     SCEnter();
 

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1315,7 +1315,7 @@ static int SMTPProcessRequest(SMTPState *state, Flow *f,
 }
 
 static int SMTPParse(int direction, Flow *f, SMTPState *state,
-                     AppLayerParserState *pstate, uint8_t *input,
+                     AppLayerParserState *pstate, const uint8_t *input,
                      uint32_t input_len,
                      SMTPThreadCtx *thread_data)
 {
@@ -1351,7 +1351,7 @@ static int SMTPParse(int direction, Flow *f, SMTPState *state,
 
 static int SMTPParseClientRecord(Flow *f, void *alstate,
                                  AppLayerParserState *pstate,
-                                 uint8_t *input, uint32_t input_len,
+                                 const uint8_t *input, uint32_t input_len,
                                  void *local_data, const uint8_t flags)
 {
     SCEnter();
@@ -1362,7 +1362,7 @@ static int SMTPParseClientRecord(Flow *f, void *alstate,
 
 static int SMTPParseServerRecord(Flow *f, void *alstate,
                                  AppLayerParserState *pstate,
-                                 uint8_t *input, uint32_t input_len,
+                                 const uint8_t *input, uint32_t input_len,
                                  void *local_data, const uint8_t flags)
 {
     SCEnter();

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -111,13 +111,13 @@ typedef struct SMTPState_ {
     uint64_t tx_cnt;
 
     /* current input that is being parsed */
-    uint8_t *input;
+    const uint8_t *input;
     int32_t input_len;
     uint8_t direction;
 
     /* --parser details-- */
     /** current line extracted by the parser from the call to SMTPGetline() */
-    uint8_t *current_line;
+    const uint8_t *current_line;
     /** length of the line in current_line.  Doesn't include the delimiter */
     int32_t current_line_len;
     uint8_t current_line_delimiter_len;

--- a/src/app-layer-ssh.c
+++ b/src/app-layer-ssh.c
@@ -208,7 +208,7 @@ static int SSHParseRecordHeader(SshState *state, SshHeader *header,
  *  \param  input       Pointer the received input data
  *  \param  input_len   Length in bytes of the received data
  */
-static int SSHParseRecord(SshState *state, SshHeader *header, uint8_t *input, uint32_t input_len)
+static int SSHParseRecord(SshState *state, SshHeader *header, const uint8_t *input, uint32_t input_len)
 {
     SCEnter();
     int ret = 0;
@@ -339,7 +339,7 @@ again:
     SCReturnInt(0);
 }
 
-static int EnoughData(uint8_t *input, uint32_t input_len)
+static int EnoughData(const uint8_t *input, uint32_t input_len)
 {
     uint32_t u;
     for (u = 0; u < input_len; u++) {
@@ -352,7 +352,7 @@ static int EnoughData(uint8_t *input, uint32_t input_len)
 #define MAX_BANNER_LEN 256
 
 static int SSHParseData(SshState *state, SshHeader *header,
-                        uint8_t *input, uint32_t input_len)
+                        const uint8_t *input, uint32_t input_len)
 {
     /* we're looking for the banner */
     if (!(header->flags & SSH_FLAG_VERSION_PARSED))
@@ -421,7 +421,7 @@ static int SSHParseData(SshState *state, SshHeader *header,
 }
 
 static int SSHParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
-                           uint8_t *input, uint32_t input_len,
+                           const uint8_t *input, uint32_t input_len,
                            void *local_data, const uint8_t flags)
 {
     SshState *ssh_state = (SshState *)state;
@@ -446,7 +446,7 @@ static int SSHParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
 }
 
 static int SSHParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
-                            uint8_t *input, uint32_t input_len,
+                            const uint8_t *input, uint32_t input_len,
                             void *local_data, const uint8_t flags)
 {
     SshState *ssh_state = (SshState *)state;

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1363,11 +1363,11 @@ end:
     return 0;
 }
 
-static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
+static int SSLv3ParseHandshakeType(SSLState *ssl_state, const uint8_t *input,
                                    uint32_t input_len, uint8_t direction)
 {
     void *ptmp;
-    uint8_t *initial_input = input;
+    const uint8_t *initial_input = input;
     uint32_t parsed = 0;
     int rc;
 
@@ -1561,10 +1561,10 @@ static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
     }
 }
 
-static int SSLv3ParseHandshakeProtocol(SSLState *ssl_state, uint8_t *input,
+static int SSLv3ParseHandshakeProtocol(SSLState *ssl_state, const uint8_t *input,
                                        uint32_t input_len, uint8_t direction)
 {
-    uint8_t *initial_input = input;
+    const uint8_t *initial_input = input;
     int retval;
 
     if (input_len == 0 || ssl_state->curr_connp->bytes_processed ==
@@ -1636,7 +1636,7 @@ static int SSLv3ParseHandshakeProtocol(SSLState *ssl_state, uint8_t *input,
  *
  * \retval The number of bytes parsed on success, 0 if nothing parsed, -1 on failure.
  */
-static int SSLv3ParseHeartbeatProtocol(SSLState *ssl_state, uint8_t *input,
+static int SSLv3ParseHeartbeatProtocol(SSLState *ssl_state, const uint8_t *input,
                                        uint32_t input_len, uint8_t direction)
 {
     uint8_t hb_type;
@@ -1750,9 +1750,9 @@ static int SSLv3ParseHeartbeatProtocol(SSLState *ssl_state, uint8_t *input,
 }
 
 static int SSLv3ParseRecord(uint8_t direction, SSLState *ssl_state,
-                            uint8_t *input, uint32_t input_len)
+                            const uint8_t *input, uint32_t input_len)
 {
-    uint8_t *initial_input = input;
+    const uint8_t *initial_input = input;
 
     if (input_len == 0) {
         return 0;
@@ -1833,9 +1833,9 @@ static int SSLv3ParseRecord(uint8_t direction, SSLState *ssl_state,
 }
 
 static int SSLv2ParseRecord(uint8_t direction, SSLState *ssl_state,
-                            uint8_t *input, uint32_t input_len)
+                            const uint8_t *input, uint32_t input_len)
 {
-    uint8_t *initial_input = input;
+    const uint8_t *initial_input = input;
 
     if (input_len == 0) {
         return 0;
@@ -1917,11 +1917,11 @@ static int SSLv2ParseRecord(uint8_t direction, SSLState *ssl_state,
 }
 
 static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
-                       AppLayerParserState *pstate, uint8_t *input,
+                       AppLayerParserState *pstate, const uint8_t *input,
                        uint32_t input_len)
 {
     int retval = 0;
-    uint8_t *initial_input = input;
+    const uint8_t *initial_input = input;
 
     if (ssl_state->curr_connp->bytes_processed == 0) {
         if (input[0] & 0x80) {
@@ -2192,7 +2192,7 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
 }
 
 static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
-                       AppLayerParserState *pstate, uint8_t *input,
+                       AppLayerParserState *pstate, const uint8_t *input,
                        uint32_t input_len)
 {
     int retval = 0;
@@ -2390,7 +2390,7 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
  * \retval >=0 On success.
  */
 static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserState *pstate,
-                     uint8_t *input, uint32_t ilen)
+                     const uint8_t *input, uint32_t ilen)
 {
     SSLState *ssl_state = (SSLState *)alstate;
     int retval = 0;
@@ -2539,14 +2539,14 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
 }
 
 static int SSLParseClientRecord(Flow *f, void *alstate, AppLayerParserState *pstate,
-                         uint8_t *input, uint32_t input_len,
+                         const uint8_t *input, uint32_t input_len,
                          void *local_data, const uint8_t flags)
 {
     return SSLDecode(f, 0 /* toserver */, alstate, pstate, input, input_len);
 }
 
 static int SSLParseServerRecord(Flow *f, void *alstate, AppLayerParserState *pstate,
-                         uint8_t *input, uint32_t input_len,
+                         const uint8_t *input, uint32_t input_len,
                          void *local_data, const uint8_t flags)
 {
     return SSLDecode(f, 1 /* toclient */, alstate, pstate, input, input_len);
@@ -2639,7 +2639,7 @@ static void SSLStateTransactionFree(void *state, uint64_t tx_id)
 }
 
 static AppProto SSLProbingParser(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t ilen, uint8_t *rdir)
+        const uint8_t *input, uint32_t ilen, uint8_t *rdir)
 {
     /* probably a rst/fin sending an eof */
     if (ilen < 3)

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -203,7 +203,7 @@ static AppLayerDecoderEvents *TemplateGetEvents(void *tx)
  *     otherwise ALPROTO_UNKNOWN.
  */
 static AppProto TemplateProbingParserTs(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t input_len, uint8_t *rdir)
+        const uint8_t *input, uint32_t input_len, uint8_t *rdir)
 {
     /* Very simple test - if there is input, this is template. */
     if (input_len >= TEMPLATE_MIN_FRAME_LEN) {
@@ -225,7 +225,7 @@ static AppProto TemplateProbingParserTs(Flow *f, uint8_t direction,
  *     otherwise ALPROTO_UNKNOWN.
  */
 static AppProto TemplateProbingParserTc(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t input_len, uint8_t *rdir)
+        const uint8_t *input, uint32_t input_len, uint8_t *rdir)
 {
     /* Very simple test - if there is input, this is template. */
     if (input_len >= TEMPLATE_MIN_FRAME_LEN) {
@@ -238,7 +238,7 @@ static AppProto TemplateProbingParserTc(Flow *f, uint8_t direction,
 }
 
 static int TemplateParseRequest(Flow *f, void *statev,
-    AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+    AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
     void *local_data, const uint8_t flags)
 {
     TemplateState *state = statev;
@@ -306,7 +306,7 @@ end:
 }
 
 static int TemplateParseResponse(Flow *f, void *statev, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
     TemplateState *state = statev;

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -84,7 +84,7 @@ static AppLayerDecoderEvents *TFTPGetEvents(void *tx)
  *     ALPROTO_UNKNOWN.
  */
 static AppProto TFTPProbingParser(Flow *f, uint8_t direction,
-        uint8_t *input, uint32_t input_len, uint8_t *rdir)
+        const uint8_t *input, uint32_t input_len, uint8_t *rdir)
 {
     /* Very simple test - if there is input, this is tftp.
      * Also check if it's starting by a zero */
@@ -98,7 +98,7 @@ static AppProto TFTPProbingParser(Flow *f, uint8_t direction,
 }
 
 static int TFTPParseRequest(Flow *f, void *state,
-    AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+    AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
     void *local_data, const uint8_t flags)
 {
     SCLogDebug("Parsing echo request: len=%"PRIu32, input_len);
@@ -122,7 +122,7 @@ static int TFTPParseRequest(Flow *f, void *state,
  * \brief Response parsing is not implemented
  */
 static int TFTPParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
-    uint8_t *input, uint32_t input_len, void *local_data,
+    const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
     return 0;

--- a/src/decode-afl.c
+++ b/src/decode-afl.c
@@ -38,6 +38,16 @@
 #include "flow.h"
 
 #ifdef AFLFUZZ_DECODER
+int AFLDecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint32_t len, PacketQueue *pq)
+{
+    return DecodeIPV4(tv, dtv, p, pkt, (uint16_t)len, pq);
+}
+int AFLDecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint32_t len, PacketQueue *pq)
+{
+    return DecodeIPV6(tv, dtv, p, pkt, (uint16_t)len, pq);
+}
 
 /* stateful processing of data as packets. Because AFL in case of a
  * crash will only safe the last input, we dump all the inputs to a

--- a/src/decode-erspan.c
+++ b/src/decode-erspan.c
@@ -43,7 +43,7 @@
  * \brief Function to decode ERSPAN packets
  */
 
-int DecodeERSPAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint32_t len, PacketQueue *pq)
+int DecodeERSPAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint32_t len, PacketQueue *pq)
 {
     StatsIncr(tv, dtv->counter_erspan);
 

--- a/src/decode-ethernet.c
+++ b/src/decode-ethernet.c
@@ -39,7 +39,7 @@
 #include "util-debug.h"
 
 int DecodeEthernet(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
-                   uint8_t *pkt, uint32_t len, PacketQueue *pq)
+                   const uint8_t *pkt, uint32_t len, PacketQueue *pq)
 {
     StatsIncr(tv, dtv->counter_eth);
 

--- a/src/decode-gre.c
+++ b/src/decode-gre.c
@@ -43,7 +43,7 @@
  * \brief Function to decode GRE packets
  */
 
-int DecodeGRE(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint32_t len, PacketQueue *pq)
+int DecodeGRE(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint32_t len, PacketQueue *pq)
 {
     uint32_t header_len = GRE_HDR_LEN;
     GRESreHdr *gsre = NULL;

--- a/src/decode-icmpv4.c
+++ b/src/decode-icmpv4.c
@@ -152,7 +152,7 @@ static int DecodePartialIPV4(Packet* p, uint8_t* partial_packet, uint16_t len)
 /** DecodeICMPV4
  *  \brief Main ICMPv4 decoding function
  */
-int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint32_t len, PacketQueue *pq)
+int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint32_t len, PacketQueue *pq)
 {
     StatsIncr(tv, dtv->counter_icmpv4);
 
@@ -168,7 +168,7 @@ int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt,
     p->proto = IPPROTO_ICMP;
     p->icmp_s.type = p->icmpv4h->type;
     p->icmp_s.code = p->icmpv4h->code;
-    p->payload = pkt + ICMPV4_HEADER_LEN;
+    p->payload = (uint8_t *)pkt + ICMPV4_HEADER_LEN;
     p->payload_len = len - ICMPV4_HEADER_LEN;
 
     int ctype = ICMPv4GetCounterpart(p->icmp_s.type);

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -187,7 +187,7 @@ int ICMPv6GetCounterpart(uint8_t type)
  * \retval void No return value
  */
 int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
-                  uint8_t *pkt, uint32_t len, PacketQueue *pq)
+                 const uint8_t *pkt, uint32_t len, PacketQueue *pq)
 {
     int full_hdr = 0;
     StatsIncr(tv, dtv->counter_icmpv6);
@@ -203,7 +203,7 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     p->icmp_s.type = p->icmpv6h->type;
     p->icmp_s.code = p->icmpv6h->code;
     p->payload_len = len - ICMPV6_HEADER_LEN;
-    p->payload = pkt + ICMPV6_HEADER_LEN;
+    p->payload = (uint8_t *)pkt + ICMPV6_HEADER_LEN;
 
     int ctype = ICMPv6GetCounterpart(p->icmp_s.type);
     if (ctype != -1) {
@@ -509,7 +509,7 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     if (!full_hdr) {
         if (p->payload_len >= 4) {
             p->payload_len -= 4;
-            p->payload = pkt + 4;
+            p->payload = (uint8_t *)pkt + 4;
         } else {
             p->payload_len = 0;
             p->payload = NULL;

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -186,7 +186,7 @@ static int IPV4OptValidateTimestamp(Packet *p, const IPV4Opt *o)
 static int IPV4OptValidateCIPSO(Packet *p, const IPV4Opt *o)
 {
 //    uint32_t doi;
-    uint8_t *tag;
+    const uint8_t *tag;
     uint16_t len;
 
     /* Check length */
@@ -299,7 +299,7 @@ typedef struct IPV4Options_ {
 /**
  * Decode/Validate IPv4 Options.
  */
-static void DecodeIPV4Options(Packet *p, uint8_t *pkt, uint16_t len, IPV4Options *opts)
+static void DecodeIPV4Options(Packet *p, const uint8_t *pkt, uint16_t len, IPV4Options *opts)
 {
     uint16_t plen = len;
 
@@ -484,7 +484,7 @@ static void DecodeIPV4Options(Packet *p, uint8_t *pkt, uint16_t len, IPV4Options
 
 }
 
-static int DecodeIPV4Packet(Packet *p, uint8_t *pkt, uint16_t len)
+static int DecodeIPV4Packet(Packet *p, const uint8_t *pkt, uint16_t len)
 {
     if (unlikely(len < IPV4_HEADER_LEN)) {
         ENGINE_SET_INVALID_EVENT(p, IPV4_PKT_TOO_SMALL);
@@ -529,7 +529,8 @@ static int DecodeIPV4Packet(Packet *p, uint8_t *pkt, uint16_t len)
     return 0;
 }
 
-int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
+int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint16_t len, PacketQueue *pq)
 {
     StatsIncr(tv, dtv->counter_ipv4);
 

--- a/src/decode-ipv4.h
+++ b/src/decode-ipv4.h
@@ -64,7 +64,7 @@ typedef struct IPV4Opt_ {
      */
     uint8_t type;         /**< option type */
     uint8_t len;          /**< option length (type+len+data) */
-    uint8_t *data;        /**< option data */
+    const uint8_t *data;  /**< option data */
 } IPV4Opt;
 
 typedef struct IPV4Hdr_

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -48,7 +48,7 @@
  * \brief Function to decode IPv4 in IPv6 packets
  *
  */
-static void DecodeIPv4inIPv6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t plen, PacketQueue *pq)
+static void DecodeIPv4inIPv6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint16_t plen, PacketQueue *pq)
 {
 
     if (unlikely(plen < IPV4_HEADER_LEN)) {
@@ -76,7 +76,8 @@ static void DecodeIPv4inIPv6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, u
  * \brief Function to decode IPv6 in IPv6 packets
  *
  */
-static int DecodeIP6inIP6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t plen, PacketQueue *pq)
+static int DecodeIP6inIP6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint16_t plen, PacketQueue *pq)
 {
 
     if (unlikely(plen < IPV6_HEADER_LEN)) {
@@ -101,7 +102,7 @@ static int DecodeIP6inIP6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint
 #ifndef UNITTESTS // ugly, but we need this in defrag tests
 static inline
 #endif
-void DecodeIPV6FragHeader(Packet *p, uint8_t *pkt,
+void DecodeIPV6FragHeader(Packet *p, const uint8_t *pkt,
                           uint16_t hdrextlen, uint16_t plen,
                           uint16_t prev_hdrextlen)
 {
@@ -142,11 +143,12 @@ void DecodeIPV6FragHeader(Packet *p, uint8_t *pkt,
 }
 
 static void
-DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
+DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint16_t len, PacketQueue *pq)
 {
     SCEnter();
 
-    uint8_t *orig_pkt = pkt;
+    const uint8_t *orig_pkt = pkt;
     uint8_t nh = IPV6_GET_NH(p); /* careful, 0 is actually a real type */
     uint16_t hdrextlen = 0;
     uint16_t plen = len;
@@ -246,7 +248,7 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                     SCReturn;
                 }
 
-                uint8_t *ptr = pkt + 2; /* +2 to go past nxthdr and len */
+                const uint8_t *ptr = pkt + 2; /* +2 to go past nxthdr and len */
 
                 /* point the pointers to right structures
                  * in Packet. */
@@ -554,7 +556,7 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
     SCReturn;
 }
 
-static int DecodeIPV6Packet (ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len)
+static int DecodeIPV6Packet (ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint16_t len)
 {
     if (unlikely(len < IPV6_HEADER_LEN)) {
         return -1;
@@ -580,7 +582,7 @@ static int DecodeIPV6Packet (ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, u
     return 0;
 }
 
-int DecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
+int DecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint16_t len, PacketQueue *pq)
 {
     StatsIncr(tv, dtv->counter_ipv6);
 

--- a/src/decode-mpls.c
+++ b/src/decode-mpls.c
@@ -44,8 +44,8 @@
 #define MPLS_PROTO_IPV4         4
 #define MPLS_PROTO_IPV6         6
 
-int DecodeMPLS(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt,
-    uint32_t len, PacketQueue *pq)
+int DecodeMPLS(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint32_t len, PacketQueue *pq)
 {
     uint32_t shim;
     int label;

--- a/src/decode-null.c
+++ b/src/decode-null.c
@@ -45,7 +45,8 @@
 
 #define HDR_SIZE 4
 
-int DecodeNull(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint32_t len, PacketQueue *pq)
+int DecodeNull(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint32_t len, PacketQueue *pq)
 {
     StatsIncr(tv, dtv->counter_null);
 

--- a/src/decode-ppp.c
+++ b/src/decode-ppp.c
@@ -40,7 +40,8 @@
 #include "util-unittest.h"
 #include "util-debug.h"
 
-int DecodePPP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint32_t len, PacketQueue *pq)
+int DecodePPP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint32_t len, PacketQueue *pq)
 {
     StatsIncr(tv, dtv->counter_ppp);
 

--- a/src/decode-pppoe.c
+++ b/src/decode-pppoe.c
@@ -47,7 +47,8 @@
 /**
  * \brief Main decoding function for PPPOE Discovery packets
  */
-int DecodePPPOEDiscovery(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint32_t len, PacketQueue *pq)
+int DecodePPPOEDiscovery(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint32_t len, PacketQueue *pq)
 {
     StatsIncr(tv, dtv->counter_pppoe);
 
@@ -126,7 +127,8 @@ int DecodePPPOEDiscovery(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8
 /**
  * \brief Main decoding function for PPPOE Session packets
  */
-int DecodePPPOESession(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint32_t len, PacketQueue *pq)
+int DecodePPPOESession(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint32_t len, PacketQueue *pq)
 {
     StatsIncr(tv, dtv->counter_pppoe);
 

--- a/src/decode-raw.c
+++ b/src/decode-raw.c
@@ -43,7 +43,8 @@
 #include "host.h"
 
 
-int DecodeRaw(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint32_t len, PacketQueue *pq)
+int DecodeRaw(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint32_t len, PacketQueue *pq)
 {
     StatsIncr(tv, dtv->counter_raw);
 

--- a/src/decode-sctp.c
+++ b/src/decode-sctp.c
@@ -39,7 +39,7 @@
 #include "util-optimize.h"
 #include "flow.h"
 
-static int DecodeSCTPPacket(ThreadVars *tv, Packet *p, uint8_t *pkt, uint16_t len)
+static int DecodeSCTPPacket(ThreadVars *tv, Packet *p, const uint8_t *pkt, uint16_t len)
 {
     if (unlikely(len < SCTP_HEADER_LEN)) {
         ENGINE_SET_INVALID_EVENT(p, SCTP_PKT_TOO_SMALL);
@@ -51,7 +51,7 @@ static int DecodeSCTPPacket(ThreadVars *tv, Packet *p, uint8_t *pkt, uint16_t le
     SET_SCTP_SRC_PORT(p,&p->sp);
     SET_SCTP_DST_PORT(p,&p->dp);
 
-    p->payload = pkt + sizeof(SCTPHdr);
+    p->payload = (uint8_t *)pkt + sizeof(SCTPHdr);
     p->payload_len = len - sizeof(SCTPHdr);
 
     p->proto = IPPROTO_SCTP;
@@ -59,7 +59,8 @@ static int DecodeSCTPPacket(ThreadVars *tv, Packet *p, uint8_t *pkt, uint16_t le
     return 0;
 }
 
-int DecodeSCTP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
+int DecodeSCTP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint16_t len, PacketQueue *pq)
 {
     StatsIncr(tv, dtv->counter_sctp);
 

--- a/src/decode-sll.c
+++ b/src/decode-sll.c
@@ -36,7 +36,8 @@
 #include "decode-events.h"
 #include "util-debug.h"
 
-int DecodeSll(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint32_t len, PacketQueue *pq)
+int DecodeSll(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint32_t len, PacketQueue *pq)
 {
     StatsIncr(tv, dtv->counter_sll);
 

--- a/src/decode-tcp.h
+++ b/src/decode-tcp.h
@@ -129,7 +129,7 @@
 typedef struct TCPOpt_ {
     uint8_t type;
     uint8_t len;
-    uint8_t *data;
+    const uint8_t *data;
 } TCPOpt;
 
 typedef struct TCPOptSackRecord_ {

--- a/src/decode-teredo.c
+++ b/src/decode-teredo.c
@@ -60,12 +60,13 @@ void DecodeTeredoConfig(void)
  *
  * \retval TM_ECODE_FAILED if packet is not a Teredo packet, TM_ECODE_OK if it is
  */
-int DecodeTeredo(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
+int DecodeTeredo(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint16_t len, PacketQueue *pq)
 {
     if (!g_teredo_enabled)
         return TM_ECODE_FAILED;
 
-    uint8_t *start = pkt;
+    const uint8_t *start = pkt;
 
     /* Is this packet to short to contain an IPv6 packet ? */
     if (len < IPV6_HEADER_LEN)

--- a/src/decode-teredo.h
+++ b/src/decode-teredo.h
@@ -19,7 +19,7 @@
 #define __DECODE_TEREDO_H__
 
 int DecodeTeredo(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
-                 uint8_t *pkt, uint16_t len, PacketQueue *pq);
+                 const uint8_t *pkt, uint16_t len, PacketQueue *pq);
 void DecodeTeredoConfig(void);
 
 #endif

--- a/src/decode-udp.c
+++ b/src/decode-udp.c
@@ -41,7 +41,7 @@
 #include "flow.h"
 #include "app-layer.h"
 
-static int DecodeUDPPacket(ThreadVars *t, Packet *p, uint8_t *pkt, uint16_t len)
+static int DecodeUDPPacket(ThreadVars *t, Packet *p, const uint8_t *pkt, uint16_t len)
 {
     if (unlikely(len < UDP_HEADER_LEN)) {
         ENGINE_SET_INVALID_EVENT(p, UDP_HLEN_TOO_SMALL);
@@ -63,7 +63,7 @@ static int DecodeUDPPacket(ThreadVars *t, Packet *p, uint8_t *pkt, uint16_t len)
     SET_UDP_SRC_PORT(p,&p->sp);
     SET_UDP_DST_PORT(p,&p->dp);
 
-    p->payload = pkt + UDP_HEADER_LEN;
+    p->payload = (uint8_t *)pkt + UDP_HEADER_LEN;
     p->payload_len = len - UDP_HEADER_LEN;
 
     p->proto = IPPROTO_UDP;
@@ -71,11 +71,12 @@ static int DecodeUDPPacket(ThreadVars *t, Packet *p, uint8_t *pkt, uint16_t len)
     return 0;
 }
 
-int DecodeUDP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
+int DecodeUDP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint16_t len, PacketQueue *pq)
 {
     StatsIncr(tv, dtv->counter_udp);
 
-    if (unlikely(DecodeUDPPacket(tv, p,pkt,len) < 0)) {
+    if (unlikely(DecodeUDPPacket(tv, p, pkt,len) < 0)) {
         p->udph = NULL;
         return TM_ECODE_FAILED;
     }

--- a/src/decode-vlan.c
+++ b/src/decode-vlan.c
@@ -45,7 +45,7 @@
 #include "host.h"
 
 static int DecodeIEEE8021ah(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
-        uint8_t *pkt, uint16_t len, PacketQueue *pq);
+        const uint8_t *pkt, uint16_t len, PacketQueue *pq);
 
 /**
  * \internal
@@ -59,7 +59,8 @@ static int DecodeIEEE8021ah(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
  * \param pq pointer to the packet queue
  *
  */
-int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint32_t len, PacketQueue *pq)
+int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint32_t len, PacketQueue *pq)
 {
     uint32_t proto;
 
@@ -157,7 +158,8 @@ typedef struct IEEE8021ahHdr_ {
 
 #define IEEE8021AH_HEADER_LEN sizeof(IEEE8021ahHdr)
 
-static int DecodeIEEE8021ah(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, uint16_t len, PacketQueue *pq)
+static int DecodeIEEE8021ah(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint16_t len, PacketQueue *pq)
 {
     StatsIncr(tv, dtv->counter_ieee8021ah);
 

--- a/src/decode-vxlan.c
+++ b/src/decode-vxlan.c
@@ -116,8 +116,8 @@ typedef struct VXLANHeader_ {
 /** \param pkt payload data directly above UDP header
  *  \param len length in bytes of pkt
  */
-int DecodeVXLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt,
-        uint32_t len, PacketQueue *pq)
+int DecodeVXLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint32_t len, PacketQueue *pq)
 {
     if (unlikely(!g_vxlan_enabled))
         return TM_ECODE_FAILED;

--- a/src/decode.c
+++ b/src/decode.c
@@ -73,7 +73,7 @@ const char *stats_decoder_events_prefix;
 extern bool stats_stream_events;
 
 int DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
-        uint8_t *pkt, uint32_t len, PacketQueue *pq, enum DecodeTunnelProto proto)
+        const uint8_t *pkt, uint32_t len, PacketQueue *pq, enum DecodeTunnelProto proto)
 {
     switch (proto) {
         case DECODE_TUNNEL_PPP:
@@ -215,7 +215,7 @@ inline int PacketCallocExtPkt(Packet *p, int datalen)
  *  \param Pointer to the data to copy
  *  \param Length of the data to copy
  */
-inline int PacketCopyDataOffset(Packet *p, uint32_t offset, uint8_t *data, uint32_t datalen)
+inline int PacketCopyDataOffset(Packet *p, uint32_t offset, const uint8_t *data, uint32_t datalen)
 {
     if (unlikely(offset + datalen > MAX_PAYLOAD_SIZE)) {
         /* too big */
@@ -256,7 +256,7 @@ inline int PacketCopyDataOffset(Packet *p, uint32_t offset, uint8_t *data, uint3
  *  \param Pointer to the data to copy
  *  \param Length of the data to copy
  */
-inline int PacketCopyData(Packet *p, uint8_t *pktdata, uint32_t pktlen)
+inline int PacketCopyData(Packet *p, const uint8_t *pktdata, uint32_t pktlen)
 {
     SET_PKT_LEN(p, (size_t)pktlen);
     return PacketCopyDataOffset(p, 0, pktdata, pktlen);
@@ -273,7 +273,7 @@ inline int PacketCopyData(Packet *p, uint8_t *pktdata, uint32_t pktlen)
  *  \retval p the pseudo packet or NULL if out of memory
  */
 Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *parent,
-                             uint8_t *pkt, uint32_t len, enum DecodeTunnelProto proto,
+                             const uint8_t *pkt, uint32_t len, enum DecodeTunnelProto proto,
                              PacketQueue *pq)
 {
     int ret;
@@ -346,7 +346,7 @@ Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *pare
  *
  *  \retval p the pseudo packet or NULL if out of memory
  */
-Packet *PacketDefragPktSetup(Packet *parent, uint8_t *pkt, uint32_t len, uint8_t proto)
+Packet *PacketDefragPktSetup(Packet *parent, const uint8_t *pkt, uint32_t len, uint8_t proto)
 {
     SCEnter();
 
@@ -650,13 +650,13 @@ void DecodeThreadVarsFree(ThreadVars *tv, DecodeThreadVars *dtv)
  *  \param Pointer to the data
  *  \param Length of the data
  */
-inline int PacketSetData(Packet *p, uint8_t *pktdata, uint32_t pktlen)
+inline int PacketSetData(Packet *p, const uint8_t *pktdata, uint32_t pktlen)
 {
     SET_PKT_LEN(p, (size_t)pktlen);
     if (unlikely(!pktdata)) {
         return -1;
     }
-    p->ext_pkt = pktdata;
+    p->ext_pkt = (uint8_t *)pktdata;
     p->flags |= PKT_ZERO_COPY;
 
     return 0;

--- a/src/decode.h
+++ b/src/decode.h
@@ -897,8 +897,8 @@ enum DecodeTunnelProto {
 };
 
 Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *parent,
-                             uint8_t *pkt, uint32_t len, enum DecodeTunnelProto proto, PacketQueue *pq);
-Packet *PacketDefragPktSetup(Packet *parent, uint8_t *pkt, uint32_t len, uint8_t proto);
+                             const uint8_t *pkt, uint32_t len, enum DecodeTunnelProto proto, PacketQueue *pq);
+Packet *PacketDefragPktSetup(Packet *parent, const uint8_t *pkt, uint32_t len, uint8_t proto);
 void PacketDefragPktSetupParent(Packet *parent);
 void DecodeRegisterPerfCounters(DecodeThreadVars *, ThreadVars *);
 Packet *PacketGetFromQueueOrAlloc(void);
@@ -909,9 +909,9 @@ void PacketUpdateEngineEventCounters(ThreadVars *tv,
 void PacketFree(Packet *p);
 void PacketFreeOrRelease(Packet *p);
 int PacketCallocExtPkt(Packet *p, int datalen);
-int PacketCopyData(Packet *p, uint8_t *pktdata, uint32_t pktlen);
-int PacketSetData(Packet *p, uint8_t *pktdata, uint32_t pktlen);
-int PacketCopyDataOffset(Packet *p, uint32_t offset, uint8_t *data, uint32_t datalen);
+int PacketCopyData(Packet *p, const uint8_t *pktdata, uint32_t pktlen);
+int PacketSetData(Packet *p, const uint8_t *pktdata, uint32_t pktlen);
+int PacketCopyDataOffset(Packet *p, uint32_t offset, const uint8_t *data, uint32_t datalen);
 const char *PktSrcToString(enum PktSrcEnum pkt_src);
 void PacketBypassCallback(Packet *p);
 void PacketSwap(Packet *p);
@@ -922,30 +922,30 @@ void DecodeUpdatePacketCounters(ThreadVars *tv,
                                 const DecodeThreadVars *dtv, const Packet *p);
 
 /* decoder functions */
-int DecodeEthernet(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint32_t, PacketQueue *);
-int DecodeSll(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint32_t, PacketQueue *);
-int DecodePPP(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint32_t, PacketQueue *);
-int DecodePPPOESession(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint32_t, PacketQueue *);
-int DecodePPPOEDiscovery(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint32_t, PacketQueue *);
-int DecodeTunnel(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint32_t, PacketQueue *, enum DecodeTunnelProto) __attribute__ ((warn_unused_result));
-int DecodeNull(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint32_t, PacketQueue *);
-int DecodeRaw(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint32_t, PacketQueue *);
-int DecodeIPV4(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
-int DecodeIPV6(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
-int DecodeICMPV4(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint32_t, PacketQueue *);
-int DecodeICMPV6(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint32_t, PacketQueue *);
-int DecodeTCP(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
-int DecodeUDP(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
-int DecodeSCTP(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
-int DecodeGRE(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint32_t, PacketQueue *);
-int DecodeVLAN(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint32_t, PacketQueue *);
-int DecodeVXLAN(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint32_t, PacketQueue *);
-int DecodeMPLS(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint32_t, PacketQueue *);
-int DecodeERSPAN(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint32_t, PacketQueue *);
+int DecodeEthernet(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
+int DecodeSll(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
+int DecodePPP(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
+int DecodePPPOESession(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
+int DecodePPPOEDiscovery(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
+int DecodeTunnel(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *, enum DecodeTunnelProto) __attribute__ ((warn_unused_result));
+int DecodeNull(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
+int DecodeRaw(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
+int DecodeIPV4(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint16_t, PacketQueue *);
+int DecodeIPV6(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint16_t, PacketQueue *);
+int DecodeICMPV4(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
+int DecodeICMPV6(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
+int DecodeTCP(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint16_t, PacketQueue *);
+int DecodeUDP(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint16_t, PacketQueue *);
+int DecodeSCTP(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint16_t, PacketQueue *);
+int DecodeGRE(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
+int DecodeVLAN(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
+int DecodeVXLAN(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
+int DecodeMPLS(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
+int DecodeERSPAN(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
 int DecodeTEMPLATE(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
 
 #ifdef UNITTESTS
-void DecodeIPV6FragHeader(Packet *p, uint8_t *pkt,
+void DecodeIPV6FragHeader(Packet *p, const uint8_t *pkt,
                           uint16_t hdrextlen, uint16_t plen,
                           uint16_t prev_hdrextlen);
 #endif

--- a/src/decode.h
+++ b/src/decode.h
@@ -952,10 +952,13 @@ void DecodeIPV6FragHeader(Packet *p, uint8_t *pkt,
 
 void AddressDebugPrint(Address *);
 
-#ifdef AFLFUZZ_DECODER
 typedef int (*DecoderFunc)(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
-         uint8_t *pkt, uint32_t len, PacketQueue *pq);
-
+         const uint8_t *pkt, uint32_t len, PacketQueue *pq);
+#ifdef AFLFUZZ_DECODER
+int AFLDecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint32_t len, PacketQueue *pq);
+int AFLDecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+        const uint8_t *pkt, uint32_t len, PacketQueue *pq);
 int DecoderParseDataFromFile(char *filename, DecoderFunc Decoder);
 int DecoderParseDataFromFileSerie(char *fileprefix, DecoderFunc Decoder);
 #endif

--- a/src/detect-base64-decode.c
+++ b/src/detect-base64-decode.c
@@ -54,7 +54,7 @@ void DetectBase64DecodeRegister(void)
 }
 
 int DetectBase64DecodeDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
-    const SigMatchData *smd, uint8_t *payload, uint32_t payload_len)
+    const SigMatchData *smd, const uint8_t *payload, uint32_t payload_len)
 {
     DetectBase64Decode *data = (DetectBase64Decode *)smd->ctx;
     int decode_len;

--- a/src/detect-base64-decode.h
+++ b/src/detect-base64-decode.h
@@ -28,6 +28,6 @@ typedef struct DetectBase64Decode_ {
 
 void DetectBase64DecodeRegister(void);
 int DetectBase64DecodeDoMatch(DetectEngineThreadCtx *, const Signature *,
-    const SigMatchData *, uint8_t *, uint32_t);
+    const SigMatchData *, const uint8_t *, uint32_t);
 
 #endif /* __DETECT_BASE64_DECODE_H__ */

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -108,12 +108,12 @@ void DetectByteExtractRegister(void)
 }
 
 int DetectByteExtractDoMatch(DetectEngineThreadCtx *det_ctx, const SigMatchData *smd,
-                             const Signature *s, uint8_t *payload,
+                             const Signature *s, const uint8_t *payload,
                              uint16_t payload_len, uint64_t *value,
                              uint8_t endian)
 {
     DetectByteExtractData *data = (DetectByteExtractData *)smd->ctx;
-    uint8_t *ptr = NULL;
+    const uint8_t *ptr = NULL;
     int32_t len = 0;
     uint64_t val = 0;
     int extbytes;

--- a/src/detect-byte-extract.h
+++ b/src/detect-byte-extract.h
@@ -63,6 +63,6 @@ void DetectByteExtractRegister(void);
 
 SigMatch *DetectByteExtractRetrieveSMVar(const char *, const Signature *);
 int DetectByteExtractDoMatch(DetectEngineThreadCtx *, const SigMatchData *, const Signature *,
-                             uint8_t *, uint16_t, uint64_t *, uint8_t);
+                             const uint8_t *, uint16_t, uint64_t *, uint8_t);
 
 #endif /* __DETECT_BYTEEXTRACT_H__ */

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -88,14 +88,14 @@ void DetectBytejumpRegister (void)
  *  \retval 0 no match
  */
 int DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
-                          const SigMatchCtx *ctx, uint8_t *payload, uint32_t payload_len,
+                          const SigMatchCtx *ctx, const uint8_t *payload, uint32_t payload_len,
                           uint8_t flags, int32_t offset)
 {
     SCEnter();
 
     const DetectBytejumpData *data = (const DetectBytejumpData *)ctx;
-    uint8_t *ptr = NULL;
-    uint8_t *jumpptr = NULL;
+    const uint8_t *ptr = NULL;
+    const uint8_t *jumpptr = NULL;
     int32_t len = 0;
     uint64_t val = 0;
     int extbytes;
@@ -186,7 +186,7 @@ int DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
 
 #ifdef DEBUG
     if (SCLogDebugEnabled()) {
-        uint8_t *sptr = (flags & DETECT_BYTEJUMP_BEGIN) ? payload : ptr;
+        const uint8_t *sptr = (flags & DETECT_BYTEJUMP_BEGIN) ? payload : ptr;
         SCLogDebug("jumping %" PRId64 " bytes from %p (%08x) to %p (%08x)",
                val, sptr, (int)(sptr - payload),
                jumpptr, (int)(jumpptr - payload));
@@ -203,8 +203,8 @@ static int DetectBytejumpMatch(DetectEngineThreadCtx *det_ctx,
                         Packet *p, const Signature *s, const SigMatchCtx *ctx)
 {
     const DetectBytejumpData *data = (const DetectBytejumpData *)ctx;
-    uint8_t *ptr = NULL;
-    uint8_t *jumpptr = NULL;
+    const uint8_t *ptr = NULL;
+    const uint8_t *jumpptr = NULL;
     uint16_t len = 0;
     uint64_t val = 0;
     int extbytes;
@@ -295,7 +295,7 @@ static int DetectBytejumpMatch(DetectEngineThreadCtx *det_ctx,
 
 #ifdef DEBUG
     if (SCLogDebugEnabled()) {
-        uint8_t *sptr = (data->flags & DETECT_BYTEJUMP_BEGIN) ? p->payload
+        const uint8_t *sptr = (data->flags & DETECT_BYTEJUMP_BEGIN) ? p->payload
                                                               : ptr;
         SCLogDebug("jumping %" PRId64 " bytes from %p (%08x) to %p (%08x)",
                val, sptr, (int)(sptr - p->payload),

--- a/src/detect-bytejump.h
+++ b/src/detect-bytejump.h
@@ -76,7 +76,7 @@ void DetectBytejumpRegister (void);
  *       error as a match.
  */
 int DetectBytejumpDoMatch(DetectEngineThreadCtx *, const Signature *, const SigMatchCtx *,
-                          uint8_t *, uint32_t, uint8_t, int32_t);
+                          const uint8_t *, uint32_t, uint8_t, int32_t);
 
 #endif /* __DETECT_BYTEJUMP_H__ */
 

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -93,13 +93,13 @@ void DetectBytetestRegister (void)
  */
 int DetectBytetestDoMatch(DetectEngineThreadCtx *det_ctx,
                           const Signature *s, const SigMatchCtx *ctx,
-                          uint8_t *payload, uint32_t payload_len,
+                          const uint8_t *payload, uint32_t payload_len,
                           uint8_t flags, int32_t offset, uint64_t value)
 {
     SCEnter();
 
     const DetectBytetestData *data = (const DetectBytetestData *)ctx;
-    uint8_t *ptr = NULL;
+    const uint8_t *ptr = NULL;
     int32_t len = 0;
     uint64_t val = 0;
     int extbytes;

--- a/src/detect-bytetest.h
+++ b/src/detect-bytetest.h
@@ -68,7 +68,7 @@ typedef struct DetectBytetestData_ {
 void DetectBytetestRegister (void);
 
 int DetectBytetestDoMatch(DetectEngineThreadCtx *, const Signature *,
-                          const SigMatchCtx *ctx, uint8_t *, uint32_t,
+                          const SigMatchCtx *ctx, const uint8_t *, uint32_t,
                           uint8_t, int32_t, uint64_t);
 
 #endif /* __DETECT_BYTETEST_H__ */

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -101,7 +101,7 @@
 int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
                                   const Signature *s, const SigMatchData *smd,
                                   Packet *p, Flow *f,
-                                  uint8_t *buffer, uint32_t buffer_len,
+                                  const uint8_t *buffer, uint32_t buffer_len,
                                   uint32_t stream_start_offset, uint8_t flags,
                                   uint8_t inspection_mode)
 {
@@ -141,7 +141,7 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
 
         /* search for our pattern, checking the matches recursively.
          * if we match we look for the next SigMatch as well */
-        uint8_t *found = NULL;
+        const uint8_t *found = NULL;
         uint32_t offset = 0;
         uint32_t depth = buffer_len;
         uint32_t prev_offset = 0; /**< used in recursive searching */
@@ -266,7 +266,7 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
                 }
             }
 
-            uint8_t *sbuffer = buffer + offset;
+            const uint8_t *sbuffer = buffer + offset;
             uint32_t sbuffer_len = depth - offset;
             uint32_t match_offset = 0;
             SCLogDebug("sbuffer_len %"PRIu32, sbuffer_len);
@@ -313,8 +313,9 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
                     /* Match branch, add replace to the list if needed */
                     if (cd->flags & DETECT_CONTENT_REPLACE) {
                         if (inspection_mode == DETECT_ENGINE_CONTENT_INSPECTION_MODE_PAYLOAD) {
-                            /* we will need to replace content if match is confirmed */
-                            det_ctx->replist = DetectReplaceAddToList(det_ctx->replist, found, cd);
+                            /* we will need to replace content if match is confirmed
+                             * cast to non-const as replace writes to it. */
+                            det_ctx->replist = DetectReplaceAddToList(det_ctx->replist, (uint8_t *)found, cd);
                         } else {
                             SCLogWarning(SC_ERR_INVALID_VALUE, "Can't modify payload without packet");
                         }

--- a/src/detect-engine-content-inspection.h
+++ b/src/detect-engine-content-inspection.h
@@ -48,7 +48,7 @@ enum {
 int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
                                   const Signature *s, const SigMatchData *smd,
                                   Packet *p, Flow *f,
-                                  uint8_t *buffer, uint32_t buffer_len,
+                                  const uint8_t *buffer, uint32_t buffer_len,
                                   uint32_t stream_start_offset, uint8_t flags,
                                   uint8_t inspection_mode);
 

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -215,7 +215,7 @@ void LuaDumpStack(lua_State *state)
 
 int DetectLuaMatchBuffer(DetectEngineThreadCtx *det_ctx,
         const Signature *s, const SigMatchData *smd,
-        uint8_t *buffer, uint32_t buffer_len, uint32_t offset,
+        const uint8_t *buffer, uint32_t buffer_len, uint32_t offset,
         Flow *f)
 {
     SCEnter();

--- a/src/detect-lua.h
+++ b/src/detect-lua.h
@@ -57,7 +57,7 @@ typedef struct DetectLuaData {
 void DetectLuaRegister (void);
 int DetectLuaMatchBuffer(DetectEngineThreadCtx *det_ctx,
         const Signature *s, const SigMatchData *smd,
-        uint8_t *buffer, uint32_t buffer_len, uint32_t offset,
+        const uint8_t *buffer, uint32_t buffer_len, uint32_t offset,
         Flow *f);
 
 void DetectLuaPostSetup(Signature *s);

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -170,13 +170,13 @@ void DetectPcreRegister (void)
  */
 int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
                            const SigMatchData *smd, Packet *p, Flow *f,
-                           uint8_t *payload, uint32_t payload_len)
+                           const uint8_t *payload, uint32_t payload_len)
 {
     SCEnter();
 #define MAX_SUBSTRINGS 30
     int ret = 0;
     int ov[MAX_SUBSTRINGS];
-    uint8_t *ptr = NULL;
+    const uint8_t *ptr = NULL;
     uint16_t len = 0;
     uint16_t capture_len = 0;
 

--- a/src/detect-pcre.h
+++ b/src/detect-pcre.h
@@ -49,11 +49,8 @@ typedef struct DetectPcreData_ {
 
 int DetectPcrePayloadMatch(DetectEngineThreadCtx *,
         const Signature *, const SigMatchData *,
-        Packet *, Flow *, uint8_t *, uint32_t);
+        Packet *, Flow *, const uint8_t *, uint32_t);
 
-int DetectPcrePacketPayloadMatch(DetectEngineThreadCtx *, Packet *, Signature *, SigMatch *);
-int DetectPcrePayloadDoMatch(DetectEngineThreadCtx *, Signature *, SigMatch *,
-                             Packet *, uint8_t *, uint16_t);
 void DetectPcreRegister (void);
 
 #endif /* __DETECT_PCRE_H__ */

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -194,12 +194,12 @@ TmEcode InitPcapFile(PcapFileFileVars *pfv)
     pfv->datalink = pcap_datalink(pfv->pcap_handle);
     SCLogDebug("datalink %" PRId32 "", pfv->datalink);
 
-    Decoder temp;
+    DecoderFunc temp;
     TmEcode validated = ValidateLinkType(pfv->datalink, &temp);
     SCReturnInt(validated);
 }
 
-TmEcode ValidateLinkType(int datalink, Decoder *decoder)
+TmEcode ValidateLinkType(int datalink, DecoderFunc *decoder)
 {
     switch (datalink) {
         case LINKTYPE_LINUX_SLL:

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -76,8 +76,6 @@ typedef struct PcapFileFileVars_
     PcapFileSharedVars *shared;
 } PcapFileFileVars;
 
-typedef int (*Decoder)(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint32_t, PacketQueue *);
-
 /**
  * Dispatch a file for processing, where the information necessary to process that
  * file is as PcapFileFileVars object.
@@ -106,6 +104,6 @@ void CleanupPcapFileFileVars(PcapFileFileVars *pfv);
  * @param decoder Pointer to decoder to set if valid
  * @return TM_ECODE_OK if valid datalink type and decoder has been set.
  */
-TmEcode ValidateLinkType(int datalink, Decoder *decoder);
+TmEcode ValidateLinkType(int datalink, DecoderFunc *decoder);
 
 #endif /* __SOURCE_PCAP_FILE_HELPER_H__ */

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -410,7 +410,7 @@ TmEcode DecodePcapFile(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, P
         FlowWakeupFlowManagerThread();
     }
 
-    Decoder decoder;
+    DecoderFunc decoder;
     if(ValidateLinkType(p->datalink, &decoder) == TM_ECODE_OK) {
 
         /* call the decoder */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1371,18 +1371,18 @@ static void ParseCommandLineAFL(const char *opt_name, char *opt_arg)
         SpmTableSetup();
         AppLayerProtoDetectSetup();
         if (strcmp(opt_name, "afl-decoder-ipv4") == 0)
-            exit(DecoderParseDataFromFile(opt_arg, DecodeIPV4));
+            exit(DecoderParseDataFromFile(opt_arg, AFLDecodeIPV4));
         else
-            exit(DecoderParseDataFromFileSerie(opt_arg, DecodeIPV4));
+            exit(DecoderParseDataFromFileSerie(opt_arg, AFLDecodeIPV4));
     } else if(strstr(opt_name, "afl-decoder-ipv6") != NULL) {
         StatsInit();
         MpmTableSetup();
         SpmTableSetup();
         AppLayerProtoDetectSetup();
         if (strcmp(opt_name, "afl-decoder-ipv6") == 0)
-            exit(DecoderParseDataFromFile(opt_arg, DecodeIPV6));
+            exit(DecoderParseDataFromFile(opt_arg, AFLDecodeIPV6));
         else
-            exit(DecoderParseDataFromFileSerie(opt_arg, DecodeIPV6));
+            exit(DecoderParseDataFromFileSerie(opt_arg, AFLDecodeIPV6));
     } else if(strstr(opt_name, "afl-decoder-ethernet") != NULL) {
         StatsInit();
         MpmTableSetup();

--- a/src/tests/detect-http-server-body.c
+++ b/src/tests/detect-http-server-body.c
@@ -5690,8 +5690,7 @@ static int DetectHttpServerBodyTest07(void)
         "HTTP/1.0 200 ok\r\n"
         "Content-Type: text/html\r\n"
         "Content-Length: 14\r\n"
-        "\r\n"
-        "message";
+        "\r\n";
     uint32_t http_len2 = sizeof(http_buf2) - 1;
     uint8_t http_buf3[] =
         "message";
@@ -5742,7 +5741,7 @@ static int DetectHttpServerBodyTest07(void)
 
     FLOWLOCK_WRLOCK(&f);
     int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
-                                STREAM_TOSERVER | STREAM_START | STREAM_EOF,
+                                STREAM_TOSERVER | STREAM_START,
                                 http_buf1,
                                 http_len1);
     if (r != 0) {
@@ -6070,7 +6069,7 @@ static int DetectHttpServerBodyTest09(void)
 
     FLOWLOCK_WRLOCK(&f);
     r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
-                            STREAM_TOCLIENT | STREAM_EOF, http_buf3,
+                            STREAM_TOCLIENT, http_buf3,
                             http_len3);
     if (r != 0) {
         printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
@@ -6229,7 +6228,7 @@ static int DetectHttpServerBodyTest10(void)
 
     FLOWLOCK_WRLOCK(&f);
     r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
-                            STREAM_TOCLIENT | STREAM_EOF, http_buf3,
+                            STREAM_TOCLIENT, http_buf3,
                             http_len3);
     if (r != 0) {
         printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
@@ -7785,8 +7784,7 @@ static int DetectHttpServerBodyFileDataTest02(void)
         "HTTP/1.0 200 ok\r\n"
         "Content-Type: text/html\r\n"
         "Content-Length: 14\r\n"
-        "\r\n"
-        "message";
+        "\r\n";
     uint32_t http_len2 = sizeof(http_buf2) - 1;
     uint8_t http_buf3[] =
         "message";
@@ -7837,7 +7835,7 @@ static int DetectHttpServerBodyFileDataTest02(void)
 
     FLOWLOCK_WRLOCK(&f);
     int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
-                                STREAM_TOSERVER | STREAM_START | STREAM_EOF,
+                                STREAM_TOSERVER | STREAM_START,
                                 http_buf1,
                                 http_len1);
     if (r != 0) {
@@ -8168,7 +8166,7 @@ static int DetectHttpServerBodyFileDataTest04(void)
 
     FLOWLOCK_WRLOCK(&f);
     r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
-                            STREAM_TOCLIENT | STREAM_EOF, http_buf3,
+                            STREAM_TOCLIENT, http_buf3,
                             http_len3);
     if (r != 0) {
         printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
@@ -8327,7 +8325,7 @@ static int DetectHttpServerBodyFileDataTest05(void)
 
     FLOWLOCK_WRLOCK(&f);
     r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
-                            STREAM_TOCLIENT | STREAM_EOF, http_buf3,
+                            STREAM_TOCLIENT, http_buf3,
                             http_len3);
     if (r != 0) {
         printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);

--- a/src/tests/detect-http-server-body.c
+++ b/src/tests/detect-http-server-body.c
@@ -4638,7 +4638,6 @@ libhtp:\n\
 
 static int DetectEngineHttpServerBodyFileDataTest24(void)
 {
-#ifdef HAVE_LIBLZMA
     char input[] = "\
 %YAML 1.1\n\
 ---\n\
@@ -4763,9 +4762,6 @@ libhtp:\n\
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
     PASS;
-#else
-    PASS;
-#endif /* HAVE_LIBLZMA */
 }
 
 static int DetectEngineHttpServerBodyFileDataTest25(void)
@@ -4895,7 +4891,6 @@ libhtp:\n\
 
 static int DetectEngineHttpServerBodyFileDataTest26(void)
 {
-#ifdef HAVE_LIBLZMA
     char input[] = "\
 %YAML 1.1\n\
 ---\n\
@@ -5019,9 +5014,6 @@ libhtp:\n\
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
     PASS;
-#else
-    PASS;
-#endif /* HAVE_LIBLZMA */
 }
 
 static int DetectEngineHttpServerBodyFileDataTest27(void)

--- a/src/util-decode-asn1.c
+++ b/src/util-decode-asn1.c
@@ -240,7 +240,7 @@ uint8_t SCAsn1DecodeLength(Asn1Ctx *ac)
         node->len.len = 0;
         ac->iter++;
 
-        uint8_t *tmp_iter = ac->iter;
+        const uint8_t *tmp_iter = ac->iter;
 
         /* Check that e-o-c is in bounds */
         for (; tmp_iter < ac->end - 1; tmp_iter++) {
@@ -419,7 +419,7 @@ static Asn1Node *SCAsn1CtxNewFrame(Asn1Ctx *ac, uint16_t node)
  *
  * \retval void
  */
-void SCAsn1CtxInit(Asn1Ctx *ac, uint8_t *data, uint16_t length)
+void SCAsn1CtxInit(Asn1Ctx *ac, const uint8_t *data, uint16_t length)
 {
     ac->data = data;
     ac->iter = data;

--- a/src/util-decode-asn1.h
+++ b/src/util-decode-asn1.h
@@ -149,18 +149,18 @@ enum {
 typedef struct Asn1Len_ {
     uint8_t form;
     uint32_t len;
-    uint8_t *ptr;
+    const uint8_t *ptr;
 } Asn1Len;
 
 typedef struct Asn1Id_ {
-    uint8_t *ptr;
+    const uint8_t *ptr;
     uint8_t class_tag;
     uint8_t tag_type;
     uint32_t tag_num;
 } Asn1Id;
 
 typedef struct Asn1Data_ {
-    uint8_t *ptr;
+    const uint8_t *ptr;
     uint32_t len;
     uint8_t type;
 } Asn1Data;
@@ -175,11 +175,11 @@ typedef struct Asn1Node_ {
 } Asn1Node;
 
 typedef struct Asn1Ctx_ {
-    uint8_t *data;
-    uint8_t *end;
+    const uint8_t *data;
+    const uint8_t *end;
     uint16_t len;
 
-    uint8_t *iter;
+    const uint8_t *iter;
 
     uint16_t cur_frame;
     Asn1Node *asn1_stack2[ASN1_MAX_FRAMES];
@@ -203,7 +203,7 @@ typedef struct Asn1Ctx_ {
 void SCPrintByteBin(uint8_t);
 
 Asn1Ctx *SCAsn1CtxNew(void);
-void SCAsn1CtxInit(Asn1Ctx *, uint8_t *, uint16_t);
+void SCAsn1CtxInit(Asn1Ctx *, const uint8_t *, uint16_t);
 void SCAsn1CtxDestroy(Asn1Ctx *);
 
 uint8_t SCAsn1Decode(Asn1Ctx *, uint16_t);

--- a/src/util-file-decompression.c
+++ b/src/util-file-decompression.c
@@ -165,9 +165,6 @@ int FileSwfDecompression(const uint8_t *buffer, uint32_t buffer_len,
     } else if ((swf_type == HTTP_SWF_COMPRESSION_LZMA || swf_type == HTTP_SWF_COMPRESSION_BOTH) &&
                compression_type == FILE_SWF_LZMA_COMPRESSION)
     {
-#ifndef HAVE_LIBLZMA
-        goto error;
-#else
         /* we need to setup the lzma header */
         /*
          * | 5 bytes         | 8 bytes             | n bytes         |
@@ -190,7 +187,6 @@ int FileSwfDecompression(const uint8_t *buffer, uint32_t buffer_len,
                                      out_buffer->buf + 8, out_buffer->len - 8);
         if (r == 0)
             goto error;
-#endif
     } else {
         goto error;
     }

--- a/src/util-file-swf-decompression.c
+++ b/src/util-file-swf-decompression.c
@@ -34,9 +34,7 @@
 
 #include <zlib.h>
 
-#ifdef HAVE_LIBLZMA
 #include <lzma.h>
-#endif
 
 #define MAX_SWF_DECOMPRESSED_LEN 50000000
 /*
@@ -130,7 +128,6 @@ int FileSwfZlibDecompression(DetectEngineThreadCtx *det_ctx,
  * | 4 bytes         | 4 bytes    | 4 bytes        | 5 bytes    | n bytes   | 6 bytes         |
  * | 'ZWS' + version | script len | compressed len | LZMA props | LZMA data | LZMA end marker |
  */
-#ifdef HAVE_LIBLZMA
 int FileSwfLzmaDecompression(DetectEngineThreadCtx *det_ctx,
                              uint8_t *compressed_data, uint32_t compressed_data_len,
                              uint8_t *decompressed_data, uint32_t decompressed_data_len)
@@ -183,4 +180,3 @@ int FileSwfLzmaDecompression(DetectEngineThreadCtx *det_ctx,
     lzma_end(&strm);
     return ret;
 }
-#endif /* HAVE_LIBLZMA */

--- a/src/util-file-swf-decompression.h
+++ b/src/util-file-swf-decompression.h
@@ -35,10 +35,8 @@ uint32_t FileGetSwfDecompressedLen(const uint8_t *buffer, uint32_t buffr_len);
 int FileSwfZlibDecompression(DetectEngineThreadCtx *det_ctx,
                              uint8_t *compressed_data, uint32_t compressed_data_len,
                              uint8_t *decompressed_data, uint32_t decompressed_data_len);
-#ifdef HAVE_LIBLZMA
 int FileSwfLzmaDecompression(DetectEngineThreadCtx *det_ctx,
                              uint8_t *compressed_data, uint32_t compressed_data_len,
                              uint8_t *decompressed_data, uint32_t decompressed_data_len);
-#endif
 
 #endif /* __UTIL_FILE_SWF_DECOMPRESSION_H__ */


### PR DESCRIPTION
#3873
Make liblzma mandatory for Suricata
Require at least libhtp 0.5.30
AFL mode compile fixes
Constify decoder, app-layer, detect funcs

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

