### PR TITLE
source-nfq.c: check for EAGAIN after recv() call in NFQRecvPkt()

### DIFF
--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -993,7 +993,7 @@ static void NFQRecvPkt(NFQQueueVars *t, NFQThreadVars *tv)
     rv = recv(t->fd, tv->data, tv->datalen, flag);
 
     if (rv < 0) {
-        if (errno == EINTR || errno == EWOULDBLOCK) {
+        if (errno == EINTR || errno == EWOULDBLOCK || errno == EAGAIN) {
             /* no error on timeout */
             if (flag)
                 NFQVerdictCacheFlush(t);


### PR DESCRIPTION
This should fix bug #3120

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3120

Describe changes:
- recv() may fail with EAGAIN under certain circumstances. NFQRecvPkt() has not taken this into account causing [non-critical] errors messages.