### PR TITLE
rust: Get rid of unneeded macros, fix warnings

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -15,7 +15,6 @@
  * 02110-1301, USA.
  */
 
-#![allow(ellipsis_inclusive_range_patterns)] // TODO: Remove when MSRV is higher than 1.24
 #![cfg_attr(feature = "strict", deny(warnings))]
 
 #[macro_use]

--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -360,7 +360,7 @@ pub fn smb_write_dcerpc_record<'b>(state: &mut SMBState,
                         },
                     }
                 }
-                21...255 => {
+                21..=255 => {
                     tx.set_event(SMBEvent::MalformedData);
                 },
                 _ => { }, // valid type w/o special processing
@@ -478,7 +478,7 @@ fn dcerpc_response_handle<'b>(tx: &mut SMBTransaction,
         DCERPC_TYPE_BINDACK => {
             // handled elsewhere
         },
-        21...255 => {
+        21..=255 => {
             if let Some(SMBTransactionTypeData::DCERPC(ref mut tdn)) = tx.type_data {
                 tdn.set_result(dcer.packet_type);
             }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3136