### PR TITLE
doc: update ssh kewords documentation

### DIFF
--- a/doc/userguide/rules/ssh-keywords.rst
+++ b/doc/userguide/rules/ssh-keywords.rst
@@ -1,68 +1,78 @@
 SSH Keywords
 ============
-
 Suricata comes with several rule keywords to match on SSH connections.
+
 
 ssh.proto
 ---------
 
-Match on the version of the SSH protocol used.
+Match on the version of the SSH protocol used. ``ssh.proto`` is a sticky buffer, and can be used as a fast pattern. ``ssh.proto`` replaces the previous buffer name: ``ssh_proto``. You may continue to use the previous name, but it's recommended that existing rules be converted to use the new name.
 
-Example::
+Format::
 
-  alert ssh any any -> any any (msg:"match SSH protocol version"; \
-      ssh.proto; content:"2.0"; sid:1000010;)
+  ssh.proto;
+  
+Example:
+.. container:: example-rule
 
-The example above matches on SSH connections with SSH version 2.
+  alert ssh any any -> any any (msg:"match SSH protocol version"; :example-rule-emphasis:`ssh.proto;` content:"2.0"; sid:1000010;)
 
-``ssh.proto`` is a 'Sticky buffer'.
+The example above matches on SSH connections with SSH version 2.0.
 
-``ssh.proto`` can be used as ``fast_pattern``.
-
-``ssh.proto`` replaces the previous keyword name: ``ssh_proto``. You may continue
-to use the previous name, but it's recommended that rules be converted to use
-the new name.
 
 ssh.software
 ------------
 
-Match on the software string from the SSH banner.
+Match on the software string from the SSH banner. ``ssh.software`` is a sticky buffer, and can be used as fast pattern.
 
-Example::
+``ssh.software`` replaces the previous keyword names: ``ssh_software`` & 
+``ssh.softwareversion``. You may continue to use the previous name, but it's 
+recommended that rules be converted to use the new name.
 
-  alert ssh any any -> any any (msg:"match SSH software string"; \
-      ssh.software: content:"openssh"; nocase; sid:1000020;)
+Format::
+
+  ssh.software;
+  
+Example:
+.. container:: example-rule
+
+  alert ssh any any -> any any (msg:"match SSH software string"; :example-rule-emphasis:`ssh.software;` content:"openssh"; nocase; sid:1000020;)
 
 The example above matches on SSH connections where the software string contains "openssh".
 
-``ssh.software`` is a 'Sticky buffer'.
-
-``ssh.software`` can be used as ``fast_pattern``.
-
-``ssh.software`` replaces the previous keyword name: ``ssh_software``. You may continue
-to use the previous name, but it's recommended that rules be converted to use
-the new name.
 
 ssh.protoversion
 ----------------
+Matches on the version of the SSH protocol used. A value of ``2_compat`` includes SSH version 1.99.
 
-This is a legacy keyword. Use ``ssh_proto`` instead!
+Format::
 
-Match on the version of the SSH protocol used.
+  ssh.protoversion:[0-9](\.[0-9])?|2_compat;
 
-Example::
+Example:
+.. container:: example-rule
 
-  alert ssh any any -> any any (msg:"match SSH protocol version"; \
-      ssh.protoversion:"2.0"; sid:1000030;)
+  alert ssh any any -> any any (msg:"SSH v2 compatible"; :example-rule-emphasis:`ssh.protoversion:2_compat;` sid:1;)
+
+The example above matches on SSH connections with SSH version 2 or 1.99.
+
+.. container:: example-rule
+
+  alert ssh any any -> any any (msg:"SSH v1.10"; :example-rule-emphasis:`ssh.protoversion:1.10;` sid:1;)
+
+The example above matches on SSH connections with SSH version 1.10 only.
+
 
 ssh.softwareversion
 -------------------
 
-This is a legacy keyword. Use ``ssh_software`` instead!
+This keyword has been deprecated. Please use ``ssh.software`` instead.
 
 Match on the software string from the SSH banner.
 
-Example::
+Example:
+.. container:: example-rule
 
-  alert ssh any any -> any any (msg:"match SSH software string"; \
-      ssh.softwareversion:"OpenSSH"; sid:10000040;)
+  alert ssh any any -> any any (msg:"match SSH software string"; :example-rule-emphasis:`ssh.softwareversion:"OpenSSH";` sid:10000040;)
+
+

--- a/src/detect-ssh-proto.c
+++ b/src/detect-ssh-proto.c
@@ -50,8 +50,8 @@
 #define KEYWORD_NAME "ssh.proto"
 #define KEYWORD_NAME_LEGACY "ssh_proto"
 #define KEYWORD_DOC "ssh-keywords.html#ssh-proto"
-#define BUFFER_NAME "ssh_protocol"
-#define BUFFER_DESC "ssh protocol field"
+#define BUFFER_NAME "ssh.proto"
+#define BUFFER_DESC "ssh protocol version field"
 static int g_buffer_id = 0;
 
 static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,

--- a/src/detect-ssh-software.c
+++ b/src/detect-ssh-software.c
@@ -51,7 +51,7 @@
 #define KEYWORD_NAME_LEGACY "ssh_software"
 #define KEYWORD_DOC "ssh-keywords.html#ssh-software"
 #define BUFFER_NAME "ssh_software"
-#define BUFFER_DESC "ssh software"
+#define BUFFER_DESC "ssh software field"
 static int g_buffer_id = 0;
 
 static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,


### PR DESCRIPTION
Modifies ssh-keywords.rst to fix syntax error in example rule as well as
update descriptions to indicate older keywords have been deprecated.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- fixed PR https://github.com/OISF/suricata/pull/4055
