### PR TITLE
Restore libgeoip in master-4.1.x - v2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2085,14 +2085,6 @@
                 LDFLAGS="${LDFLAGS} -L${with_libgeoip_libraries}"
             fi
             AC_CHECK_LIB(GeoIP, GeoIP_country_code_by_ipnum,, GEOIP="no")
-            if test "$GEOIP" = "no"; then
-                echo "   ERROR!  libgeoip library not found, go get it"
-                echo "   from http://www.maxmind.com/en/geolite or your distribution:"
-                echo
-                echo "   Ubuntu: apt-get install libgeoip-dev"
-                echo "   Fedora: dnf install GeoIP-devel"
-                echo "   CentOS/RHEL: yum install GeoIP-devel"
-            fi
             AC_DEFINE([HAVE_GEOIP],[1],[libgeoip available])
             AC_DEFINE([HAVE_LIBGEOIP],[1],[using old libgeoip])
             enable_geoip="yes, legacy libgeoip"

--- a/configure.ac
+++ b/configure.ac
@@ -2079,7 +2079,7 @@
             fi
 
             AC_DEFINE([HAVE_GEOIP],[1],[libmaxminddb available])
-            enable_geoip="yes"
+            enable_geoip="yes, libmaxminddb"
         else
             if test "$with_libgeoip_libraries" != "no"; then
                 LDFLAGS="${LDFLAGS} -L${with_libgeoip_libraries}"
@@ -2095,7 +2095,7 @@
             fi
             AC_DEFINE([HAVE_GEOIP],[1],[libgeoip available])
             AC_DEFINE([HAVE_LIBGEOIP],[1],[using old libgeoip])
-            enable_geoip="yes"
+            enable_geoip="yes, legacy libgeoip"
         fi
     fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -2037,6 +2037,9 @@
 	        AS_HELP_STRING([--enable-geoip],[Enable GeoIP support]),
 	        [ enable_geoip="yes"],
 	        [ enable_geoip="no"])
+    AC_ARG_ENABLE(libgeoip,
+        AS_HELP_STRING([--disable-libgeoip], [Disable libgeoip support]),
+        [enable_libgeoip="$enableval"], [enable_libgeoip=yes])
     AC_ARG_WITH(libgeoip_includes,
             [  --with-libgeoip-includes=DIR  libgeoip include directory],
             [with_libgeoip_includes="$withval"],[with_libgeoip_includes="no"])
@@ -2057,7 +2060,11 @@
         if test "$with_libmaxminddb_includes" != "no"; then
             CPPFLAGS="${CPPFLAGS} -I${with_libmaxminddb_includes}"
         fi
-        AC_CHECK_HEADER(GeoIP.h,GEOIP="yes",GEOIP="no")
+        if test "$enable_libgeoip" != "no"; then
+            AC_CHECK_HEADER(GeoIP.h,GEOIP="yes",GEOIP="no")
+        else
+            GEOIP="no"
+        fi
         if test "$GEOIP" = "no"; then
             AC_CHECK_HEADER(maxminddb.h,GEOIP="yes",GEOIP="no")
             if test "$GEOIP" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -2034,9 +2034,15 @@
 
   # libmaxminddb
     AC_ARG_ENABLE(geoip,
-	        AS_HELP_STRING([--enable-geoip],[Enable GeoIP2 support]),
+	        AS_HELP_STRING([--enable-geoip],[Enable GeoIP support]),
 	        [ enable_geoip="yes"],
 	        [ enable_geoip="no"])
+    AC_ARG_WITH(libgeoip_includes,
+            [  --with-libgeoip-includes=DIR  libgeoip include directory],
+            [with_libgeoip_includes="$withval"],[with_libgeoip_includes="no"])
+    AC_ARG_WITH(libgeoip_libraries,
+            [  --with-libgeoip-libraries=DIR    libgeoip library directory],
+            [with_libgeoip_libraries="$withval"],[with_libgeoip_libraries="no"])    
     AC_ARG_WITH(libmaxminddb_includes,
             [  --with-libmaxminddb-includes=DIR  libmaxminddb include directory],
             [with_libmaxminddb_includes="$withval"],[with_libmaxminddb_includes="no"])
@@ -2045,31 +2051,52 @@
             [with_libmaxminddb_libraries="$withval"],[with_libmaxminddb_libraries="no"])
 
     if test "$enable_geoip" = "yes"; then
+        if test "$with_libgeoip_includes" != "no"; then
+            CPPFLAGS="${CPPFLAGS} -I${with_libgeoip_includes}"
+        fi	    
         if test "$with_libmaxminddb_includes" != "no"; then
             CPPFLAGS="${CPPFLAGS} -I${with_libmaxminddb_includes}"
         fi
-
-        AC_CHECK_HEADER(maxminddb.h,GEOIP="yes",GEOIP="no")
-        if test "$GEOIP" = "yes"; then
-            if test "$with_libmaxminddb_libraries" != "no"; then
-                LDFLAGS="${LDFLAGS} -L${with_libmaxminddb_libraries}"
-            fi
-            AC_CHECK_LIB(maxminddb, MMDB_open,, GEOIP="no")
-        fi
+        AC_CHECK_HEADER(GeoIP.h,GEOIP="yes",GEOIP="no")
         if test "$GEOIP" = "no"; then
-            echo
-            echo "   ERROR!  libmaxminddb GeoIP2 library not found, go get it"
-            echo "   from https://github.com/maxmind/libmaxminddb or your distribution:"
-            echo
-            echo "   Ubuntu: apt-get install libmaxminddb-dev"
-            echo "   Fedora: dnf install libmaxminddb-devel"
-            echo "   CentOS/RHEL: yum install libmaxminddb-devel"
-            echo
-            exit 1
-        fi
+            AC_CHECK_HEADER(maxminddb.h,GEOIP="yes",GEOIP="no")
+            if test "$GEOIP" = "yes"; then
+                if test "$with_libmaxminddb_libraries" != "no"; then
+                    LDFLAGS="${LDFLAGS} -L${with_libmaxminddb_libraries}"
+                fi
+                AC_CHECK_LIB(maxminddb, MMDB_open,, GEOIP="no")
+            fi
+            if test "$GEOIP" = "no"; then
+                echo
+                echo "   ERROR! libmaxminddb (or libgeoip) GeoIP2 library not found, go get it"
+                echo "   from https://github.com/maxmind/libmaxminddb or your distribution:"
+                echo
+                echo "   Ubuntu: apt-get install libmaxminddb-dev"
+                echo "   Fedora: dnf install libmaxminddb-devel"
+                echo "   CentOS/RHEL: yum install libmaxminddb-devel"
+                echo
+                exit 1
+            fi
 
-        AC_DEFINE([HAVE_GEOIP],[1],[libmaxminddb available])
-        enable_geoip="yes"
+            AC_DEFINE([HAVE_GEOIP],[1],[libmaxminddb available])
+            enable_geoip="yes"
+        else
+            if test "$with_libgeoip_libraries" != "no"; then
+                LDFLAGS="${LDFLAGS} -L${with_libgeoip_libraries}"
+            fi
+            AC_CHECK_LIB(GeoIP, GeoIP_country_code_by_ipnum,, GEOIP="no")
+            if test "$GEOIP" = "no"; then
+                echo "   ERROR!  libgeoip library not found, go get it"
+                echo "   from http://www.maxmind.com/en/geolite or your distribution:"
+                echo
+                echo "   Ubuntu: apt-get install libgeoip-dev"
+                echo "   Fedora: dnf install GeoIP-devel"
+                echo "   CentOS/RHEL: yum install GeoIP-devel"
+            fi
+            AC_DEFINE([HAVE_GEOIP],[1],[libgeoip available])
+            AC_DEFINE([HAVE_LIBGEOIP],[1],[using old libgeoip])
+            enable_geoip="yes"
+        fi
     fi
 
   # Position Independent Executable
@@ -2474,7 +2501,7 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   PCRE jit:                                ${pcre_jit_available}
   LUA support:                             ${enable_lua}
   libluajit:                               ${enable_luajit}
-  GeoIP2 support:                          ${enable_geoip}
+  GeoIP support:                           ${enable_geoip}
   Non-bundled htp:                         ${enable_non_bundled_htp}
   Old barnyard2 support:                   ${enable_old_barnyard2}
   Hyperscan support:                       ${enable_hyperscan}

--- a/doc/userguide/rules/header-keywords.rst
+++ b/doc/userguide/rules/header-keywords.rst
@@ -142,11 +142,11 @@ API of MaxMind.
 
 The syntax of geoip::
 
-  geoip: src, RU;
-  geoip: both, CN, RU;
-  geoip: dst, CN, RU, IR;
-  geoip: both, US, CA, UK;
-  geoip: any, CN, IR;
+  geoip: src,RU;
+  geoip: both,CN,RU;
+  geoip: dst,CN,RU,IR;
+  geoip: both,US,CA,UK;
+  geoip: any,CN,IR;
 
 So, you can see you can use the following to make clear on which
 direction you would like to match::

--- a/src/detect-geoip.h
+++ b/src/detect-geoip.h
@@ -27,7 +27,11 @@
 
 #ifdef HAVE_GEOIP
 
+#ifdef HAVE_LIBGEOIP
+#include <GeoIP.h>
+#else
 #include <maxminddb.h>
+#endif
 #include "util-spm-bm.h"
 
 #define GEOOPTION_MAXSIZE 3 /* Country Code (2 chars) + NULL */
@@ -37,8 +41,12 @@ typedef struct DetectGeoipData_ {
     uint8_t location[GEOOPTION_MAXLOCATIONS][GEOOPTION_MAXSIZE];  /** country code for now, null term.*/
     int nlocations;  /** number of location strings parsed */
     uint32_t flags;
+#ifdef HAVE_LIBGEOIP
+    GeoIP *geoengine;
+#else
     int mmdb_status; /** Status of DB open call, MMDB_SUCCESS or error */
     MMDB_s mmdb;     /** MaxMind DB file handle structure */
+#endif
 } DetectGeoipData;
 
 #endif


### PR DESCRIPTION
Previous PR by @regit:
https://github.com/OISF/suricata/pull/4080

Changes from last PR:
- Display which geoip library is being used.
- Option to disable libgeoip so libmaxminddb is picked up if both are installed.

PRscript:
- https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/721
- https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/366
