### PR TITLE
Use CAP_DAC_OVERRIDE for non-root user access to files and/or sockets

### DIFF
--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -60,6 +60,9 @@ void SCDropMainThreadCaps(uint32_t userid, uint32_t groupid)
 
     capng_clear(CAPNG_SELECT_BOTH);
 
+    /* Preserve ability to read configuration files or create log files or UNIX sockets */
+    capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED, CAP_DAC_OVERRIDE, -1);
+
     switch (run_mode) {
         case RUNMODE_PCAP_DEV:
         case RUNMODE_AFP_DEV:


### PR DESCRIPTION
Setting the capability when dropping privileges should fix bug #3126

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3126

Describe changes:
- always set CAP_DAC_OVERRIDE when dropping privileges

Probably capabilities management needs some redesign but currently it should fit all possible cases.