### PR TITLE
decode: prevent segfault on bypass without flow

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -399,6 +399,9 @@ void PacketDefragPktSetupParent(Packet *parent)
 
 void PacketBypassCallback(Packet *p)
 {
+    if (p->flow == NULL) {
+        return;
+    }
     /* Don't try to bypass if flow is already out or
      * if we have failed to do it once */
     int state = SC_ATOMIC_GET(p->flow->flow_state);


### PR DESCRIPTION
When using a rule like:
pass ip any any -> any any (msg:"Bypass"; sid:1; rev:1;)

We could get a match even in case of flow exhaustion where the
Packet has no Flow attached.

Rebase of #3886

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed.