### PR TITLE
logging/anomaly: Support configuration filter types

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -122,10 +122,10 @@ when anomaly logging is enabled.
 Fields
 ------
 
-* "type": Either "packet", "stream" or "applayer". In rare cases, type will be "unknown".
+* "type": Either "decode", "stream" or "applayer". In rare cases, type will be "unknown".
   When this occurs, an additional field named "code" will be present. Events with type
   "applayer" are detected by the application layer parsers.
-* "event" The name of the anomalous event. Events of type "packet" are prefixed
+* "event" The name of the anomalous event. Events of type "decode" are prefixed
   with "decoder"; events of type "stream" are prefixed with "stream".
 * "code" If "type" is "unknown", than "code" contains the unrecognized event code. Otherwise,
   this field is not present.
@@ -147,18 +147,23 @@ Examples
 ::
 
     "anomaly": {
-      "type": "packet",
+      "type": "decode",
       "event": "decoder.icmpv4.unknown_type"
     }
 
     "anomaly": {
-      "type": "packet",
+      "type": "decode",
       "event": "decoder.udp.pkt_too_small"
     }
 
     "anomaly": {
-      "type": "packet",
+      "type": "decode",
       "event": "decoder.ipv4.wrong_ip_version"
+    }
+
+    "anomaly": {
+      "type": "stream",
+      "event": "stream.pkt_invalid_timestamp"
     }
 
     {
@@ -175,7 +180,7 @@ Examples
         "linktype": 1
       },
       "anomaly": {
-        "type": "packet",
+        "type": "decode",
         "event": "decoder.udp.pkt_too_small"
       }
     }

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -91,14 +91,29 @@ values or that occur out of expected sequence.
 
 Metadata::
 
-        #- anomaly:
+        - anomaly:
             # Anomaly log records describe unexpected conditions such as truncated packets, packets with invalid
             # IP/UDP/TCP length values, and other events that render the packet invalid for further processing
             # or describe unexpected behavior on an established stream. Networks which experience high
             # occurrences of anomalies may experience packet processing degradation.
-
-            # Enable dumping of packet header
-            # packethdr: no            # enable dumping of packet header
+            #
+            # Choose one or more of the following protocol/parser choices. Note
+            # that packethdr requires protodecode to be enabled.
+            #
+            # Enable logging of protocol decode events
+            # protodecode: no
+            #
+            # Enable dumping of packet header; requires protodecode to be enabled
+            # packethdr: no         # enable dumping of packet header
+            #
+            # Enable logging of app-layer protocol parser events
+            # protoparser: no
+            #
+            # Enable logging of app-layer protocol detection events
+            # protodetect: no
+            #
+            # Enable logging of parser events
+            # parser: no
 
 HTTP
 ~~~~

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -86,34 +86,43 @@ Anomalies are event records created when packets with unexpected or anomalous
 values are handled. These events include conditions such as incorrect protocol
 values, incorrect protocol length values, and other conditions which render the
 packet suspect. Other conditions may occur during the normal progression of a stream;
-these are termed ```stream``` events are include control sequences with incorrect
+these are termed ``stream`` events are include control sequences with incorrect
 values or that occur out of expected sequence.
+
+Anomalies are reported by and configured by type:
+
+- Decode
+- Stream
+- Application layer
 
 Metadata::
 
-        - anomaly:
-            # Anomaly log records describe unexpected conditions such as truncated packets, packets with invalid
-            # IP/UDP/TCP length values, and other events that render the packet invalid for further processing
-            # or describe unexpected behavior on an established stream. Networks which experience high
-            # occurrences of anomalies may experience packet processing degradation.
-            #
-            # Choose one or more of the following protocol/parser choices. Note
-            # that packethdr requires protodecode to be enabled.
-            #
-            # Enable logging of protocol decode events
-            # protodecode: no
-            #
-            # Enable dumping of packet header; requires protodecode to be enabled
-            # packethdr: no         # enable dumping of packet header
-            #
-            # Enable logging of app-layer protocol parser events
-            # protoparser: no
-            #
-            # Enable logging of app-layer protocol detection events
-            # protodetect: no
-            #
-            # Enable logging of parser events
-            # parser: no
+	- anomaly:
+		# Anomaly log records describe unexpected conditions such as truncated packets, packets
+        #  with invalid IP/UDP/TCP length values, and other events that render the packet
+        # invalid for further processing or describe unexpected behavior on an established stream.
+        # Networks which experience high occurrences of anomalies may experience packet processing
+        # degradation.
+		#
+		# Anomalies are reported for the following:
+		# 1. Decode: Values and conditions that are detected while decoding individual packets.
+        # This includes invalid or unexpected values for low-level protocol lengths as well
+        # as stream related events (TCP 3-way handshake issues, unexpected sequence number, etc).
+		# 2. Stream: This includes stream related events (TCP 3-way handshake issues, unexpected
+        # sequence number, etc).
+		# 3. Application layer: These denote application layer specific conditions that are unexpected,
+        # invalid or are unexpected given the application monitoring state.
+		#
+		# By default, anomaly logging is disabled. When anomaly logging is enabled, application-layer anomaly
+		# reporting is enabled.
+		#
+		# Choose one or both types of anomaly logging and whether to enable
+		# logging of the packet header for packet anomalies.
+		types:
+		  #decode: no
+		  #stream: no
+		  #applayer: yes
+		#packethdr: no
 
 HTTP
 ~~~~

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -363,6 +363,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_WARN_EVE_MISSING_EVENTS);
         CASE_CODE (SC_ERR_THASH_INIT);
         CASE_CODE (SC_ERR_DATASET);
+        CASE_CODE (SC_WARN_ANOMALY_CONFIG);
 
         CASE_CODE (SC_ERR_MAX);
     }

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -353,6 +353,7 @@ typedef enum {
     SC_ERR_FTP_LOG_GENERIC,
     SC_ERR_THASH_INIT,
     SC_ERR_DATASET,
+    SC_WARN_ANOMALY_CONFIG,
 
     SC_ERR_MAX
 } SCError;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -160,9 +160,25 @@ outputs:
             # IP/UDP/TCP length values, and other events that render the packet invalid for further processing 
             # or describe unexpected behavior on an established stream. Networks which experience high
             # occurrences of anomalies may experience packet processing degradation.
-
-            # Enable dumping of packet header
-            # packethdr: no            # enable dumping of packet header
+            #
+            # Anomalies are reported for the following:
+            # 1. Decode: Values and conditions that are detected while decoding individual packets. This includes
+            # invalid or unexpected values for low-level protocol lengths as well as stream related events (TCP 3-way
+            # handshake issues, unexpected sequence number, etc).
+            # 2. Stream: This includes stream related events (TCP 3-way handshake issues, unexpected sequence number, etc).
+            # 3. Application layer: These denote application layer specific conditions that are unexpected, invalid or
+            # are unexpected given the application monitoring state.
+            #
+            # By default, anomaly logging is disabled. When anomaly logging is enabled, applayer anomaly
+            # reporting is enabled.
+            #
+            # Choose one or both types of anomaly logging and whether to enable
+            # logging of the packet header for packet anomalies.
+            types:
+              # decode: no
+              # stream: no
+              # applayer: yes
+            #packethdr: no
         - http:
             extended: yes     # enable this for extended logging information
             # custom allows additional http fields to be included in eve-log


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [2958](https://redmine.openinfosecfoundation.org/issues/2958)

Continuation of #4192 

This PR changes the anomaly configuration options which will cause existing suricata-verify tests to fail. Thus, this PR requires [Suricata-verify PR #123](https://github.com/OISF/suricata-verify/pull/123)

Updates since last PR:
- Renamed configuration setting `application-layer` to `applayer`
- Splits single-line `if` across 2 lines (review feedback).