### PR TITLE
doc: tcp.flags keyword documentation

### DIFF
--- a/doc/userguide/rules/header-keywords.rst
+++ b/doc/userguide/rules/header-keywords.rst
@@ -17,7 +17,7 @@ For example::
   ttl:10;
 
 At the end of the ttl keyword you can enter the value on which you
-want to match.  The Time-to-live value determines the maximal amount
+want to match. The Time-to-live value determines the maximal amount
 of time a packet can be in the Internet-system. If this field is set
 to 0, then the packet has to be destroyed. The time-to-live is based
 on hop count. Each hop/router the packet passes subtracts one of the
@@ -71,7 +71,7 @@ sameip
 ^^^^^^
 
 Every packet has a source IP-address and a destination IP-address. It
-can be that the source IP is the same as the destination IP.  With the
+can be that the source IP is the same as the destination IP. With the
 sameip keyword you can check if the IP address of the source is the
 same as the IP address of the destination. The format of the sameip
 keyword is::
@@ -114,7 +114,7 @@ The named variant of that example would be::
 id
 ^^
 
-With the id keyword, you can match on a specific IP ID value.  The ID
+With the id keyword, you can match on a specific IP ID value. The ID
 identifies each packet sent by a host and increments usually with one
 with each packet that is being send. The IP ID is used as a fragment
 identification number. Each packet has an IP ID, and when the packet
@@ -439,7 +439,7 @@ Example of the itype keyword in a signature:
 The following lists all ICMP types known at the time of writing. A recent table can be found `at the website of IANA <https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml>`_
 
 ==========  ==========================================================
-ICMP Type   Name
+ICMP Type  Name
 ==========  ==========================================================
 0           Echo Reply
 3           Destination Unreachable
@@ -474,7 +474,7 @@ ICMP Type   Name
 icode
 ^^^^^
 
-With the icode keyword you can match on a specific ICMP code.  The
+With the icode keyword you can match on a specific ICMP code. The
 code of a ICMP message clarifies the message. Together with the
 ICMP-type it indicates with what kind of problem you are dealing with.
 A code has a different purpose with every ICMP-type.

--- a/src/detect-dce-iface.c
+++ b/src/detect-dce-iface.c
@@ -50,7 +50,7 @@
 #include "rust.h"
 #include "rust-smb-detect-gen.h"
 
-#define PARSE_REGEX "^\\s*([0-9a-zA-Z]{8}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{12})(?:\\s*,(<|>|=|!)([0-9]{1,5}))?(?:\\s*,(any_frag))?\\s*$"
+#define PARSE_REGEX "^\\s*([0-9a-zA-Z]{8}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{12})(?:\\s*,\\s*(<|>|=|!)([0-9]{1,5}))?(?:\\s*,\\s*(any_frag))?\\s*$"
 
 static pcre *parse_regex = NULL;
 static pcre_extra *parse_regex_study = NULL;
@@ -379,7 +379,7 @@ static int DetectDceIfaceSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 {
     DetectDceIfaceData *did = DetectDceIfaceArgParse(arg);
     if (did == NULL) {
-        SCLogError(SC_ERR_INVALID_SIGNATURE, "Error parsing dec_iface option in "
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "Error parsing dce_iface option in "
                    "signature");
         return -1;
     }

--- a/src/detect-tcp-flags.c
+++ b/src/detect-tcp-flags.c
@@ -74,6 +74,8 @@ void DetectFlagsRegister (void)
 {
     sigmatch_table[DETECT_FLAGS].name = "tcp.flags";
     sigmatch_table[DETECT_FLAGS].alias = "flags";
+    sigmatch_table[DETECT_FLAGS].desc = "detect which flags are set in the TCP header";
+    sigmatch_table[DETECT_FLAGS].url = DOC_URL DOC_VERSION "/rules/header-keywords.html#tcp-flags";
     sigmatch_table[DETECT_FLAGS].Match = DetectFlagsMatch;
     sigmatch_table[DETECT_FLAGS].Setup = DetectFlagsSetup;
     sigmatch_table[DETECT_FLAGS].Free  = DetectFlagsFree;


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3014

Describe changes:
- fix whitespace issues described in #4165
- fix whitespace issues described in https://github.com/OISF/suricata/pull/4172
- standardize all whitespace on 2 crlf before major sections
- standardize all whitespace on 1 \x20 between sentences


