### PR TITLE
Register missing app-layer parser loggers for TLS and SSH

### DIFF
--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -812,6 +812,7 @@ static OutputInitResult OutputLuaLogInit(ConfNode *conf)
             om->alproto = ALPROTO_TLS;
             om->tc_log_progress = TLS_HANDSHAKE_DONE;
             om->ts_log_progress = TLS_HANDSHAKE_DONE;
+            AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_TLS);
        } else if (opts.alproto == ALPROTO_DNS) {
             om->TxLogFunc = LuaTxLogger;
             om->alproto = ALPROTO_DNS;

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -825,6 +825,7 @@ static OutputInitResult OutputLuaLogInit(ConfNode *conf)
             om->alproto = ALPROTO_SSH;
             om->tc_log_progress = SSH_STATE_BANNER_DONE;
             om->ts_log_progress = SSH_STATE_BANNER_DONE;
+            AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_SSH);
         } else if (opts.alproto == ALPROTO_SMTP) {
             om->TxLogFunc = LuaTxLogger;
             om->alproto = ALPROTO_SMTP;


### PR DESCRIPTION
Fix so that it is possible to use a TLS or SSH Lua output script without having to have a logger enabled for the app-layer protocol.

https://redmine.openinfosecfoundation.org/issues/3162

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/190
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/190