### PR TITLE
htp: need htp_config.h for new lzma function

### DIFF
--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -40,6 +40,7 @@
 #include "util-streaming-buffer.h"
 
 #include <htp/htp.h>
+#include <htp/htp_config.h>
 
 /* default request body limit */
 #define HTP_CONFIG_DEFAULT_REQUEST_BODY_LIMIT           4096U


### PR DESCRIPTION
`app-layer-htp.c` needs function declaration of `htp_config_set_lzma_memlimit`