### PR TITLE
Avoid to shutdown NSS if it is not initialized

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -394,8 +394,10 @@ static void GlobalsDestroy(SCInstance *suri)
     TmModuleRunDeInit();
     ParseSizeDeinit();
 #ifdef HAVE_NSS
-    NSS_Shutdown();
-    PR_Cleanup();
+    if (NSS_IsInitialized()) {
+        NSS_Shutdown();
+        PR_Cleanup();
+    }
 #endif
 
 #ifdef HAVE_AF_PACKET


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3164

Describe changes:
Only shut down NSS when it has been initialized. In Suricata test mode, NSS is not initialized. However, a bug introduced in 4.1.4 tries to shut it down when exiting. This triggers a crash because NSS pointers such as nssInitLock are not initialized and are empty and using them causes crashes.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

