### PR TITLE
Qa docker update v3

### DIFF
--- a/qa/docker/buildbot.cfg
+++ b/qa/docker/buildbot.cfg
@@ -130,6 +130,8 @@ factory_stress_pcap.addStep(ShellCommand(command=["make"]))
 factory_stress_pcap.addStep(ShellCommand(command=["sudo", "make","install"]))
 factory_stress_pcap.addStep(ShellCommand(command=["sudo", "rm", "-f", "/usr/local/etc/suricata/suricata.yaml"]))
 factory_stress_pcap.addStep(ShellCommand(command=["sudo", "make","install-conf"]))
+if os.path.exists('/data/oisf/qa/suricata-verify/run.py'):
+    factory_stress_pcap.addStep(ShellCommand(command=["/data/oisf/qa/suricata-verify/run.py","--outdir","/tmp"]))
 factory_stress_pcap.addStep(ShellCommand(command=["make","clean"]))
 factory_stress_pcap.addStep(ShellCommand(command=["sudo", "ldconfig"]))
 for pfile in pcaps_list:

--- a/qa/docker/buildbot.cfg
+++ b/qa/docker/buildbot.cfg
@@ -125,7 +125,7 @@ pcaps_list = [ os.path.join(PCAP_PATH, pcap) for pcap in pcaps_list if pcap.ends
 factory_stress_pcap = SuriBuildFactory()
 # run the tests (note that this will require that 'trial' is installed)
 factory_stress_pcap.addStep(ShellCommand(command=["./autogen.sh"]))
-factory_stress_pcap.addStep(ShellCommand(command=["./configure","--enable-debug-validation"],env={"CFLAGS" : "-fsanitize=address -fno-omit-frame-pointer"}))
+factory_stress_pcap.addStep(ShellCommand(command=["./configure","--enable-debug-validation", "ac_cv_func_malloc_0_nonnull=yes","ac_cv_func_realloc_0_nonnull=yes"],env={"CFLAGS" : "-fsanitize=address -fno-omit-frame-pointer"}))
 factory_stress_pcap.addStep(ShellCommand(command=["make"]))
 factory_stress_pcap.addStep(ShellCommand(command=["sudo", "make","install"]))
 factory_stress_pcap.addStep(ShellCommand(command=["sudo", "rm", "-f", "/usr/local/etc/suricata/suricata.yaml"]))

--- a/qa/docker/buildbot.cfg
+++ b/qa/docker/buildbot.cfg
@@ -11,15 +11,14 @@ c = BuildmasterConfig = {}
 ####### BUILDSLAVES
 
 # The 'slaves' list defines the set of recognized buildslaves. Each element is
-# a BuildSlave object, specifying a unique slave name and password.  The same
+# a Worker object, specifying a unique slave name and password.  The same
 # slave name and password must be configured on the slave.
-from buildbot.buildslave import BuildSlave
-c['slaves'] = [BuildSlave("buildslave", "Suridocker")]
+from buildbot.worker import Worker
+c['workers'] = [Worker("buildslave", "Suridocker")]
 
-# 'slavePortnum' defines the TCP port to listen on for connections from slaves.
 # This must match the value configured into the buildslaves (with their
 # --master option)
-c['slavePortnum'] = 9989
+c['protocols'] = {'pb': {'port': 9989}}
 
 ####### CHANGESOURCES
 
@@ -39,20 +38,20 @@ c['change_source'].append(GitPoller(
 # case, just kick off a 'runtests' build
 
 from buildbot.schedulers.basic import SingleBranchScheduler
-#from buildbot.schedulers.forcesched import ForceScheduler
+from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.changes import filter
 c['schedulers'] = []
 c['schedulers'].append(SingleBranchScheduler(
                             name="master",
                             change_filter=filter.ChangeFilter(branch='master'),
                             treeStableTimer=None,
-                            builderNames=["features","profiling","clang"]))
+                            builderNames=["features","profiling","clang","gcc","pcaps","debug"]))
 
-#c['schedulers'].append(ForceScheduler(
-#                            name="force",
-#                            builderNames=["builds","debug"]))
+c['schedulers'].append(ForceScheduler(
+                            name="userbuild",
+                            builderNames=["features","profiling","clang","gcc","pcaps","debug"]))
 
-####### BUILDERS
+####### 
 
 # The 'builders' list defines the Builders, which tell Buildbot how to perform a build:
 # what steps, and which slaves can execute them.  Note that any particular build will
@@ -60,12 +59,12 @@ c['schedulers'].append(SingleBranchScheduler(
 
 from buildbot.process.factory import BuildFactory
 #from buildbot.steps.source.git import Git
-from buildbot.steps.source import Git
+from buildbot.plugins import steps
 from buildbot.steps.shell import ShellCommand
 
 def SuriBuildFactory(repo='/data/oisf/'):
     factory = BuildFactory()
-    factory.addStep(Git(repourl=repo, mode='copy'))
+    factory.addStep(steps.Git(repourl=repo, mode='full'))
     factory.addStep(ShellCommand(command=["rm", "-rf", "libhtp"]))
     factory.addStep(ShellCommand(command=["git", "clone", "-b", "0.5.x", "/data/oisf/libhtp/.git/", "libhtp"]))
     return factory
@@ -120,7 +119,7 @@ factory_features.addStep(ShellCommand(command=["make", "distcheck"],env={'DISTCH
 
 import os
 PCAP_PATH='/data/oisf/qa/docker/pcaps/'
-(_, _, pcaps_list) = os.walk(PCAP_PATH).next()
+(_, _, pcaps_list) = next(os.walk(PCAP_PATH))
 pcaps_list = [ os.path.join(PCAP_PATH, pcap) for pcap in pcaps_list if pcap.endswith(".pcap") ]
 
 factory_stress_pcap = SuriBuildFactory()
@@ -140,15 +139,15 @@ factory_stress_pcap.addStep(ShellCommand(command=["sudo", "rm", "-rf", "/usr/loc
 from buildbot.config import BuilderConfig
 
 def SuriBuilderConfig(*args, **kwargs):
-    if not kwargs.has_key('category'):
-        kwargs['category']='default'
+    if not 'tags' in kwargs:
+        kwargs['tags'] = [ 'default' ]
     return BuilderConfig(*args, **kwargs)
 
 c['builders'] = []
 
 c['builders'].append(
     SuriBuilderConfig(name="gcc",
-      slavename="buildslave",
+      workername="buildslave",
       factory=factory))
 c['schedulers'].append(SingleBranchScheduler(
                             name="build",
@@ -158,7 +157,7 @@ c['schedulers'].append(SingleBranchScheduler(
 
 c['builders'].append(
     SuriBuilderConfig(name="debug",
-      slavename="buildslave",
+      workername="buildslave",
       factory=factory_devel))
 c['schedulers'].append(SingleBranchScheduler(
                             name="debug",
@@ -168,46 +167,27 @@ c['schedulers'].append(SingleBranchScheduler(
 
 c['builders'].append(
     SuriBuilderConfig(name="profiling",
-      slavename="buildslave",
+      workername="buildslave",
       factory=factory_profiling))
 c['builders'].append(
     SuriBuilderConfig(name="clang",
-      slavename="buildslave",
+      workername="buildslave",
       factory=factory_clang_32))
 c['builders'].append(
     SuriBuilderConfig(name="features",
-      slavename="buildslave",
+      workername="buildslave",
       factory=factory_features))
 c['builders'].append(
     SuriBuilderConfig(name="pcaps",
-      slavename="buildslave",
+      workername="buildslave",
       factory=factory_stress_pcap))
 
 from buildbot import locks
-build_lock = locks.SlaveLock("slave_builds", maxCount = 1)
+build_lock = locks.WorkerLock("worker_builds", maxCount = 1)
 
 
 from buildbot.schedulers.forcesched import *
 c['schedulers'].append(ForceScheduler(name="force", builderNames = [ builder.getConfigDict()['name'] for builder in c['builders'] ]))
-
-c['status'] = []
-
-from buildbot.status import html
-from buildbot.status.web import authz, auth
-
-authz_cfg=authz.Authz(
-    # change any of these to True to enable; see the manual for more
-    # options
-    #auth=auth.BasicAuth(users),
-    gracefulShutdown = False,
-    forceBuild = True, # use this to test your slave once it is set up
-    forceAllBuilds = True,
-    pingBuilder = True,
-    stopBuild = True,
-    stopAllBuilds = True,
-    cancelPendingBuild = True,
-)
-c['status'].append(html.WebStatus(http_port=8010, authz=authz_cfg))
 
 ####### PROJECT IDENTITY
 
@@ -225,6 +205,11 @@ c['titleURL'] = "https://redmine.openinfosecfoundation.org/projects/suricata"
 # without some help.
 
 c['buildbotURL'] = "http://localhost:8010/"
+
+c['www'] = {
+    'port': 8010,
+    'plugins': {'waterfall_view': True}
+}
 
 ####### DB URL
 

--- a/qa/prscript.py
+++ b/qa/prscript.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# Copyright(C) 2013, 2014, 2015 Open Information Security Foundation
+#!/usr/bin/env python3
+# Copyright(C) 2013, 2014, 2015, 2019 Open Information Security Foundation
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,12 +20,13 @@
 # or the buildbot will not be able to access to the data in /data/oisf
 # and the git step will fail.
 
-import urllib, urllib2, cookielib
+import urllib.error
+import urllib.request
+import urllib.error
+import urllib.parse
+import http.cookiejar
 import requests
-try:
-    import simplejson as json
-except:
-    import json
+import json
 import time
 import argparse
 import sys
@@ -36,7 +37,7 @@ from subprocess import Popen, PIPE
 GOT_NOTIFY = True
 try:
     import pynotify
-except:
+except ImportError:
     GOT_NOTIFY = False
 
 GOT_DOCKER = True
@@ -52,7 +53,7 @@ try:
         try:
             from docker import Client
         except ImportError:
-            GOT_DOCKER = FALSE
+            GOT_DOCKER = False
 except ImportError:
     GOT_DOCKER = False
 
@@ -60,7 +61,7 @@ except ImportError:
 #  - github user
 #  - buildbot user and password
 
-BASE_URI="https://buildbot.openinfosecfoundation.org/"
+BASE_URI = "https://buildbot.openinfosecfoundation.org/"
 GITHUB_BASE_URI = "https://api.github.com/repos/"
 GITHUB_MASTER_URI = "https://api.github.com/repos/OISF/suricata/commits?sha=master"
 
@@ -98,12 +99,12 @@ if args.create or args.start or args.stop or args.rm:
         args.docker = True
         args.local = True
     else:
-        print "You need to install python docker to use docker handling features."
+        print("You need to install python docker to use docker handling features.")
         sys.exit(-1)
 
 if not args.local:
     if not args.username:
-        print "You need to specify a github username (-u option) for this mode (or use -l to disable)"
+        print("You need to specify a github username (-u option) for this mode (or use -l to disable)")
         sys.exit(-1)
 
 if args.docker:
@@ -128,8 +129,8 @@ def SendNotification(title, text):
     n.show()
 
 def TestRepoSync(branch):
-    request = urllib2.Request(GITHUB_MASTER_URI)
-    page = urllib2.urlopen(request)
+    request = urllib.request.Request(GITHUB_MASTER_URI)
+    page = urllib.request.urlopen(request)
     json_result = json.loads(page.read())
     sha_orig = json_result[0]["sha"]
     check_command = ["git", "branch", "--contains", sha_orig ]
@@ -142,10 +143,10 @@ def TestRepoSync(branch):
     return 0
 
 def TestGithubSync(branch):
-    request = urllib2.Request(GITHUB_BASE_URI + username + "/" + args.repository + "/commits?sha=" + branch + "&per_page=1")
+    request = urllib.request.Request(GITHUB_BASE_URI + username + "/" + args.repository + "/commits?sha=" + branch + "&per_page=1")
     try:
-        page = urllib2.urlopen(request)
-    except urllib2.HTTPError, e:
+        page = urllib.request.urlopen(request)
+    except urllib.error.HTTPError as e:
         if e.code == 404:
             return -2
         else:
@@ -155,45 +156,45 @@ def TestGithubSync(branch):
     check_command = ["git", "rev-parse", branch]
     p1 = Popen(check_command, stdout=PIPE)
     sha_local = p1.communicate()[0].rstrip()
-    if sha_local != sha_github:
+    if sha_local.decode('ascii') != sha_github:
         return -1
     return 0
 
 def OpenBuildbotSession():
     auth_params = { 'username':username,'passwd':password, 'name':'login'}
-    cookie = cookielib.LWPCookieJar()
-    params = urllib.urlencode(auth_params)
-    opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookie))
-    urllib2.install_opener(opener)
-    request = urllib2.Request(BASE_URI + 'login', params)
-    page = urllib2.urlopen(request)
+    cookie = http.cookiejar.LWPCookieJar()
+    params = urllib.parse.urlencode(auth_params)
+    opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cookie))
+    urllib.request.install_opener(opener)
+    request = urllib.request.Request(BASE_URI + 'login', bytes(params, "utf-8"))
+    page = urllib.request.urlopen(request)
     return cookie
 
 
 def SubmitBuild(branch, extension = "", builder_name = None):
     raw_params = {'branch':branch,'reason':'Testing ' + branch, 'name':'force_build', 'forcescheduler':'force'}
-    params = urllib.urlencode(raw_params)
+    params = urllib.parse.urlencode(raw_params)
     if not args.docker:
-        opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookie))
-        urllib2.install_opener(opener)
+        opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cookie))
+        urllib.request.install_opener(opener)
     if builder_name == None:
         builder_name = username + extension
-    request = urllib2.Request(BUILDERS_URI + builder_name + '/force', params)
-    page = urllib2.urlopen(request)
+    request = urllib.request.Request(BUILDERS_URI + builder_name + '/force', bytes(params, "utf-8"))
+    page = urllib.request.urlopen(request)
 
-    result = page.read()
+    result = str(page.read())
     if args.verbose:
-        print "=== response ==="
-        print result
-        print "=== end of response ==="
+        print("=== response ===")
+        print(result)
+        print("=== end of response ===")
     if args.docker:
         if "<h2>Pending Build Requests:</h2>" in result:
-            print "Build '" + builder_name + "' submitted"
+            print("Build '" + builder_name + "' submitted")
             return 0
         else:
             return -1
     if "Current Builds" in result:
-        print "Build '" + builder_name + "' submitted"
+        print("Build '" + builder_name + "' submitted")
         return 0
     else:
         return -1
@@ -201,10 +202,10 @@ def SubmitBuild(branch, extension = "", builder_name = None):
 # TODO honor the branch argument
 def FindBuild(branch, extension = "", builder_name = None):
     if builder_name == None:
-        request = urllib2.Request(JSON_BUILDERS_URI + username + extension + '/')
+        request = urllib.request.Request(JSON_BUILDERS_URI + username + extension + '/')
     else:
-        request = urllib2.Request(JSON_BUILDERS_URI + builder_name + '/')
-    page = urllib2.urlopen(request)
+        request = urllib.request.Request(JSON_BUILDERS_URI + builder_name + '/')
+    page = urllib.request.urlopen(request)
     json_result = json.loads(page.read())
     # Pending build is unnumbered
     if json_result["pendingBuilds"]:
@@ -219,13 +220,13 @@ def GetBuildStatus(builder, buildid, extension="", builder_name = None):
     if builder_name == None:
         builder_name = username + extension
     # https://buildbot.suricata-ids.org/json/builders/build%20deb6/builds/11
-    request = urllib2.Request(JSON_BUILDERS_URI + builder_name + '/builds/' + str(buildid))
-    page = urllib2.urlopen(request)
+    request = urllib.request.Request(JSON_BUILDERS_URI + builder_name + '/builds/' + str(buildid))
+    page = urllib.request.urlopen(request)
     result = page.read()
     if args.verbose:
-        print "=== response ==="
-        print result
-        print "=== end of response ==="
+        print("=== response ===")
+        print(result)
+        print("=== end of response ===")
     json_result = json.loads(result)
     if json_result["currentStep"]:
         return 1
@@ -245,9 +246,9 @@ def WaitForBuildResult(builder, buildid, extension="", builder_name = None):
 
     # return the result
     if res == 0:
-        print "Build successful for " + builder_name
+        print("Build successful for " + builder_name)
     else:
-        print "Build failure for " + builder_name + ": " + BUILDERS_URI + builder_name + '/builds/' + str(buildid)
+        print("Build failure for " + builder_name + ": " + BUILDERS_URI + builder_name + '/builds/' + str(buildid))
     return res
 
     # check that github branch and OISF master branch are sync
@@ -255,23 +256,23 @@ if not args.local:
     ret = TestGithubSync(args.branch)
     if ret != 0:
         if ret == -2:
-            print "Branch " + args.branch + " is not pushed to Github."
+            print("Branch " + args.branch + " is not pushed to Github.")
             sys.exit(-1)
         if args.norebase:
-            print "Branch " + args.branch + " is not in sync with corresponding Github branch. Continuing due to --norebase option."
+            print("Branch " + args.branch + " is not in sync with corresponding Github branch. Continuing due to --norebase option.")
         else:
-            print "Branch " + args.branch + " is not in sync with corresponding Github branch. Push may be needed."
+            print("Branch " + args.branch + " is not in sync with corresponding Github branch. Push may be needed.")
             sys.exit(-1)
     if TestRepoSync(args.branch) != 0:
         if args.norebase:
-            print "Branch " + args.branch + " is not in sync with OISF's master branch. Continuing due to --norebase option."
+            print("Branch " + args.branch + " is not in sync with OISF's master branch. Continuing due to --norebase option.")
         else:
-            print "Branch " + args.branch + " is not in sync with OISF's master branch. Rebase needed."
+            print("Branch " + args.branch + " is not in sync with OISF's master branch. Rebase needed.")
             sys.exit(-1)
 
 def CreateContainer():
     # FIXME check if existing
-    print "Pulling docking image, first run should take long"
+    print("Pulling docking image, first run should take long")
     if GOT_DOCKERPY_API < 2:
         cli = Client()
         cli.pull('regit/suri-buildbot')
@@ -280,13 +281,13 @@ def CreateContainer():
         cli = DockerClient()
         cli.images.pull('regit/suri-buildbot')
         suri_src_dir = os.path.split(os.path.dirname(os.path.realpath(__file__)))[0]
-        print "Using base src dir: " + suri_src_dir
+        print("Using base src dir: " + suri_src_dir)
         cli.containers.create('regit/suri-buildbot', name='suri-buildbot', ports={'8010/tcp': 8010, '22/tcp': None} , volumes={suri_src_dir: { 'bind': '/data/oisf', 'mode': 'ro'}, os.path.join(suri_src_dir,'qa','docker','buildbot.cfg'): { 'bind': '/data/buildbot/master/master.cfg', 'mode': 'ro'}}, detach = True, cap_add=["SYS_PTRACE"])
     sys.exit(0)
 
 def StartContainer():
     suri_src_dir = os.path.split(os.path.dirname(os.path.realpath(__file__)))[0]
-    print "Using base src dir: " + suri_src_dir
+    print("Using base src dir: " + suri_src_dir)
     if GOT_DOCKERPY_API < 2:
         cli = Client()
         cli.start('suri-buildbot', port_bindings={8010:8010, 22:None}, binds={suri_src_dir: { 'bind': '/data/oisf', 'ro': True}, os.path.join(suri_src_dir,'qa','docker','buildbot.cfg'): { 'bind': '/data/buildbot/master/master.cfg', 'ro': True}} )
@@ -310,12 +311,12 @@ def RmContainer():
         try:
             cli.remove_container('suri-buildbot')
         except:
-            print "Unable to remove suri-buildbot container"
+            print("Unable to remove suri-buildbot container")
             pass
         try:
             cli.remove_image('regit/suri-buildbot:latest')
         except:
-            print "Unable to remove suri-buildbot images"
+            print("Unable to remove suri-buildbot images")
             pass
     else:
         cli = DockerClient()
@@ -334,7 +335,7 @@ if GOT_DOCKER:
         RmContainer()
 
 if not args.branch:
-    print "You need to specify a branch for this mode"
+    print("You need to specify a branch for this mode")
     sys.exit(-1)
 
 buildids = {}
@@ -344,12 +345,12 @@ if not args.check:
     if not args.docker:
         cookie = OpenBuildbotSession()
         if cookie == None:
-            print "Unable to connect to buildbot with provided credentials"
+            print("Unable to connect to buildbot with provided credentials")
             sys.exit(-1)
         for build in BUILDERS_LIST:
             res = SubmitBuild(args.branch, builder_name = build)
             if res == -1:
-                print "Unable to start build. Check command line parameters"
+                print("Unable to start build. Check command line parameters")
                 sys.exit(-1)
     else:
         data = {"jsonrpc": "2.0", "method": "force", "id": 1, "params": {"revision": "HEAD", "branch": args.branch}}
@@ -365,7 +366,7 @@ if not args.check:
                 builder['buildrequestid'] = build_tasks[str(builder['builderid'])]
             buildids = builders
         except IOError:
-            print "Invalid return: %s" % (res)
+            print("Invalid return: %s" % (res))
             sys.exit(-1)
 
 
@@ -376,20 +377,20 @@ else:
     for build in BUILDERS_LIST:
         buildid = FindBuild(args.branch, builder_name = build)
         if buildid == -1:
-            print "Pending build tracking is not supported. Follow build by browsing " + BUILDERS_URI + build
+            print("Pending build tracking is not supported. Follow build by browsing " + BUILDERS_URI + build)
         elif buildid == -2:
-            print "No build found for " + BUILDERS_URI + build
+            print("No build found for " + BUILDERS_URI + build)
             sys.exit(0)
         else:
             if not args.docker:
-                print "You can watch build progress at " + BUILDERS_URI + build + "/builds/" + str(buildid)
+                print("You can watch build progress at " + BUILDERS_URI + build + "/builds/" + str(buildid))
             buildids[build] = buildid
 
 if args.docker:
-    print "You can watch build progress at " + BASE_URI
+    print("You can watch build progress at " + BASE_URI)
 
 if len(buildids):
-    print "Waiting for build completion"
+    print("Waiting for build completion")
 else:
     sys.exit(0)
 
@@ -403,7 +404,7 @@ if args.docker:
             try:
                 res = json.loads(r.text)['builds'][0]
             except IndexError:
-                print "No task yet for %s (%s)" % (build['name'], url)
+                print("No task yet for %s (%s)" % (build['name'], url))
                 continue
             if res['complete']:
                 ret = res['results']
@@ -414,21 +415,21 @@ if args.docker:
                         remains = " (remaining builds: " + ', '.join([b['name'] for b in up_buildids]) + ")"
                     else:
                         remains = ""
-                    print "Build failure for " + build['name'] + remains
+                    print("Build failure for " + build['name'] + remains)
                 else:
                     up_buildids.remove(build)
                     if len(up_buildids):
                         remains = " (remaining builds: " + ', '.join([b['name'] for b in up_buildids]) + ")"
                     else:
                         remains = ""
-                    print "Build successful for " + build['name'] + remains
+                    print("Build successful for " + build['name'] + remains)
         time.sleep(5)
         buildids = up_buildids
     if buildres == -1:
         SendNotification("PRscript failure", "Some builds have failed. Check <a href='" + BASE_URI + "waterfall'>waterfall</a> for results.")
         sys.exit(-1)
     else:
-        print "PRscript completed successfully"
+        print("PRscript completed successfully")
         SendNotification("PRscript success", "Congrats! All builds have passed.")
         sys.exit(0)
 else:
@@ -439,9 +440,9 @@ else:
 
 if buildres == 0:
     if not args.norebase and not args.docker:
-        print "You can copy/paste following lines into github PR"
+        print("You can copy/paste following lines into github PR")
         for build in buildids:
-            print "- PR " + build + ": " + BUILDERS_URI + build + "/builds/" + str(buildids[build])
+            print("- PR " + build + ": " + BUILDERS_URI + build + "/builds/" + str(buildids[build]))
     SendNotification("OISF PRscript success", "Congrats! All builds have passed.")
     sys.exit(0)
 else:

--- a/qa/prscript.py
+++ b/qa/prscript.py
@@ -21,6 +21,7 @@
 # and the git step will fail.
 
 import urllib, urllib2, cookielib
+import requests
 try:
     import simplejson as json
 except:
@@ -280,7 +281,7 @@ def CreateContainer():
         cli.images.pull('regit/suri-buildbot')
         suri_src_dir = os.path.split(os.path.dirname(os.path.realpath(__file__)))[0]
         print "Using base src dir: " + suri_src_dir
-        cli.containers.create('regit/suri-buildbot', name='suri-buildbot', ports={'8010/tcp': 8010, '22/tcp': None} , volumes={suri_src_dir: { 'bind': '/data/oisf', 'mode': 'ro'}, os.path.join(suri_src_dir,'qa','docker','buildbot.cfg'): { 'bind': '/data/buildbot/master/master.cfg', 'mode': 'ro'}}, detach = True)
+        cli.containers.create('regit/suri-buildbot', name='suri-buildbot', ports={'8010/tcp': 8010, '22/tcp': None} , volumes={suri_src_dir: { 'bind': '/data/oisf', 'mode': 'ro'}, os.path.join(suri_src_dir,'qa','docker','buildbot.cfg'): { 'bind': '/data/buildbot/master/master.cfg', 'mode': 'ro'}}, detach = True, cap_add=["SYS_PTRACE"])
     sys.exit(0)
 
 def StartContainer():
@@ -336,6 +337,8 @@ if not args.branch:
     print "You need to specify a branch for this mode"
     sys.exit(-1)
 
+buildids = {}
+
 # submit buildbot form to build current branch on the devel builder
 if not args.check:
     if not args.docker:
@@ -343,32 +346,47 @@ if not args.check:
         if cookie == None:
             print "Unable to connect to buildbot with provided credentials"
             sys.exit(-1)
-    for build in BUILDERS_LIST:
-        res = SubmitBuild(args.branch, builder_name = build)
-        if res == -1:
-            print "Unable to start build. Check command line parameters"
+        for build in BUILDERS_LIST:
+            res = SubmitBuild(args.branch, builder_name = build)
+            if res == -1:
+                print "Unable to start build. Check command line parameters"
+                sys.exit(-1)
+    else:
+        data = {"jsonrpc": "2.0", "method": "force", "id": 1, "params": {"revision": "HEAD", "branch": args.branch}}
+        url = BASE_URI + "api/v2/forceschedulers/userbuild"
+        r = requests.post(url, json = data, headers = {'Content-Type': 'application/json'})
+        res = json.loads(r.text)
+        try:
+            build_tasks = res['result'][1]
+            url = BASE_URI + "api/v2/builders"
+            r = requests.get(url, headers = {'Content-Type': 'application/json'})
+            builders = json.loads(r.text)['builders']
+            for builder in builders:
+                builder['buildrequestid'] = build_tasks[str(builder['builderid'])]
+            buildids = builders
+        except IOError:
+            print "Invalid return: %s" % (res)
             sys.exit(-1)
 
-buildids = {}
 
 if args.docker:
-    time.sleep(2)
-
-# get build number and exit if we don't have
-for build in BUILDERS_LIST:
-    buildid = FindBuild(args.branch, builder_name = build)
-    if buildid == -1:
-        print "Pending build tracking is not supported. Follow build by browsing " + BUILDERS_URI + build
-    elif buildid == -2:
-        print "No build found for " + BUILDERS_URI + build
-        sys.exit(0)
-    else:
-        if not args.docker:
-            print "You can watch build progress at " + BUILDERS_URI + build + "/builds/" + str(buildid)
-        buildids[build] = buildid
+    time.sleep(3)
+else:
+    # get build number and exit if we don't have
+    for build in BUILDERS_LIST:
+        buildid = FindBuild(args.branch, builder_name = build)
+        if buildid == -1:
+            print "Pending build tracking is not supported. Follow build by browsing " + BUILDERS_URI + build
+        elif buildid == -2:
+            print "No build found for " + BUILDERS_URI + build
+            sys.exit(0)
+        else:
+            if not args.docker:
+                print "You can watch build progress at " + BUILDERS_URI + build + "/builds/" + str(buildid)
+            buildids[build] = buildid
 
 if args.docker:
-    print "You can watch build progress at " + BASE_URI + "waterfall"
+    print "You can watch build progress at " + BASE_URI
 
 if len(buildids):
     print "Waiting for build completion"
@@ -380,25 +398,33 @@ if args.docker:
     while len(buildids):
         up_buildids = copy.copy(buildids)
         for build in buildids:
-            ret = GetBuildStatus(build, buildids[build], builder_name = build)
-            if ret == -1:
-                buildres = -1
-                up_buildids.pop(build, None)
-                if len(up_buildids):
-                    remains = " (remaining builds: " + ', '.join(up_buildids.keys()) + ")"
+            url = "%sapi/v2/builders/%d/builds?buildrequestid=%d" % (BASE_URI, build['builderid'], build['buildrequestid'])
+            r = requests.get(url, headers = {'Content-Type': 'application/json'})
+            try:
+                res = json.loads(r.text)['builds'][0]
+            except IndexError:
+                print "No task yet for %s (%s)" % (build['name'], url)
+                continue
+            if res['complete']:
+                ret = res['results']
+                if ret != 0:
+                    buildres = -1
+                    up_buildids.remove(build)
+                    if len(up_buildids):
+                        remains = " (remaining builds: " + ', '.join([b['name'] for b in up_buildids]) + ")"
+                    else:
+                        remains = ""
+                    print "Build failure for " + build['name'] + remains
                 else:
-                    remains = ""
-                print "Build failure for " + build + ": " + BUILDERS_URI + build + '/builds/' + str(buildids[build]) + remains
-            elif ret == 0:
-                up_buildids.pop(build, None)
-                if len(up_buildids):
-                    remains = " (remaining builds: " + ', '.join(up_buildids.keys()) + ")"
-                else:
-                    remains = ""
-                print "Build successful for " + build + remains
+                    up_buildids.remove(build)
+                    if len(up_buildids):
+                        remains = " (remaining builds: " + ', '.join([b['name'] for b in up_buildids]) + ")"
+                    else:
+                        remains = ""
+                    print "Build successful for " + build['name'] + remains
         time.sleep(5)
         buildids = up_buildids
-    if res == -1:
+    if buildres == -1:
         SendNotification("PRscript failure", "Some builds have failed. Check <a href='" + BASE_URI + "waterfall'>waterfall</a> for results.")
         sys.exit(-1)
     else:


### PR DESCRIPTION
This Patchset ports prscript to python 3 and updates docker QA buildbot config to latest buildbot version.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Port prscript to python 3
- Update prscript to support latest buildbot

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/497
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/273

