### PR TITLE
Issue 1271 - Coredump after privilege drop - v1

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -3014,6 +3014,10 @@ int main(int argc, char **argv)
     }
 
     SCDropMainThreadCaps(suricata.userid, suricata.groupid);
+
+    /* Re-enable coredumps after privileges are dropped. */
+    CoredumpEnable();
+
     PreRunPostPrivsDropInit(suricata.run_mode);
 
     PostConfLoadedDetectSetup(&suricata);

--- a/src/util-coredump-config.h
+++ b/src/util-coredump-config.h
@@ -26,6 +26,7 @@
 
 #include "suricata-common.h"
 
-int32_t CoredumpLoadConfig (void);
+int32_t CoredumpLoadConfig(void);
+void CoredumpEnable(void);
 
 #endif /* __COREDUMP_CONFIG_H__ */


### PR DESCRIPTION
I came up with this refactor of https://github.com/OISF/suricata/pull/3362 after testing that only coredumps have to be enabled after dropping privileges, and not the whole coredump size configuration.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1271

Somethings to note after re-enabling coredumps after dropping privileges:
- The ownership of /proc/<PID> changes to the user. Without this PR, these remain owned by root and the user the process runs as is limited in what they can do in here (if anything at all)
- The user suricata is now running as can now kill the process. Previously the user couldn't.
- A coredump will be generated. Previously it wasn't.

I think all this is acceptable. The reason for disabling coredumps after dropping privileges appears to be more for the use case where the app is setuid, where any users starts the process with elevated privileges to start. I don't see this as a common, or even recommended use case for Suricata.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/375
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/731
