### PR TITLE
http: disable lzma decompression from configuration

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2697,6 +2697,12 @@ static void HTPConfigParseParameters(HTPCfgRec *cfg_prec, ConfNode *s,
             SCLogConfig("Setting HTTP LZMA memory limit to %"PRIu32" bytes", limit);
             htp_config_set_lzma_memlimit(cfg_prec->cfg, (size_t)limit);
 #endif
+#ifdef HAVE_HTP_CONFIG_SET_LZMA_MEMLIMIT
+        } else if (strcasecmp("lzma-enabled", p->name) == 0) {
+            if (ConfValIsFalse(p->val)) {
+                htp_config_set_lzma_memlimit(cfg_prec->cfg, 0);
+            }
+#endif
         } else if (strcasecmp("randomize-inspection-sizes", p->name) == 0) {
             if (!g_disable_randomness) {
                 cfg_prec->randomize = ConfValIsTrue(p->val);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -977,6 +977,7 @@ app-layer:
 
            # LZMA decompression memory limit.
            #lzma-memlimit: 1 Mb
+           #lzma-enabled: yes
 
          server-config:
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
none

Describe changes:
- Makes lzma decompression in HTTP optional, and it can be disabled from configuration file

See https://github.com/OISF/libhtp/pull/256

Modifies #4223 by commenting default option in suricata.yaml.in