### PR TITLE
tls-log: fix so buffer is reset on custom logging

### DIFF
--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -451,12 +451,12 @@ static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         return 0;
     }
 
+    MemBufferReset(aft->buffer);
+
     /* Custom format */
     if (hlog->flags & LOG_TLS_CUSTOM) {
         LogTlsLogCustom(aft, ssl_state, &p->ts, srcip, sp, dstip, dp);
     } else {
-
-        MemBufferReset(aft->buffer);
         CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
         MemBufferWriteString(aft->buffer,
                              "%s %s:%d -> %s:%d  TLS:",


### PR DESCRIPTION
Move MemBufferReset() so it also works when using custom TLS logging. This avoids duplicate entries in the tls-log.

https://redmine.openinfosecfoundation.org/issues/3177

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/191
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/191