### PR TITLE
detect: hash keywords depend on filestore - v1

### DIFF
--- a/src/detect-file-hash-common.c
+++ b/src/detect-file-hash-common.c
@@ -345,6 +345,10 @@ int DetectFileHashSetup (DetectEngineCtx *de_ctx, Signature *s, const char *str,
     if (type == DETECT_FILESHA256) {
         s->file_flags |= FILE_SIG_NEED_SHA256;
     }
+
+    /* Matching on a hash require filestore. */
+    s->flags |= SIG_FLAG_FILESTORE;
+
     return 0;
 
 error:


### PR DESCRIPTION
Keywords like filemd5 require the filestore to be enabled, and
will not trigger if it is not enabled, nor will it give
an indication that they will not trigger.

For these keywords, set the filestore flag as if the filestore
option had been provided.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/2490

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/380
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/736
