### PR TITLE
filestore: Ensure configured steam-depth is gte stream.depth

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2169,7 +2169,7 @@ Finally, if ``encrypt-handling`` is set to ``full``, Suricata will process the
 flow as normal, without inspection limitations or bypass.
 
 The option has replaced the ``no-reassemble`` option. If ``no-reassemble`` is
-present, and ``encrypt-handling`` is not, ``false`` is intepreted as
+present, and ``encrypt-handling`` is not, ``false`` is interpreted as
 ``encrypt-handling: default`` and ``true`` is interpreted as
 ``encrypt-handling: bypass``.
 

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -623,7 +623,8 @@ The following shows the configuration options for version 2 of the
       #force-filestore: yes
 
       # Override the global stream-depth for sessions in which we want
-      # to perform file extraction. Set to 0 for unlimited.
+      # to perform file extraction. Set to 0 for unlimited; otherwise,
+      # must be greater than the global stream-depth value to be used.
       #stream-depth: 0
 
       # Uncomment the following variable to define how many files can

--- a/doc/userguide/file-extraction/file-extraction.rst
+++ b/doc/userguide/file-extraction/file-extraction.rst
@@ -25,7 +25,7 @@ Settings
 
 *stream.checksum_validation* controls whether or not the stream engine rejects packets with invalid checksums. A good idea normally, but the network interface performs checksum offloading a lot of packets may seem to be broken. This setting is enabled by default, and can be disabled by setting to "no". Note that the checksum handling can be controlled per interface, see "checksum_checks" in example configuration.
 
-*file-store.stream-depth* controls how far into a stream reassembly is done. Beyond this value no reassembly will be done. This means that after this value the HTTP session will no longer be tracked. By default a settings of 1 Megabyte is used. 0 sets it to unlimited. If set to no, it is disabled and stream.reassembly.depth is considered.
+*file-store.stream-depth* controls how far into a stream reassembly is done. Beyond this value no reassembly will be done. This means that after this value the HTTP session will no longer be tracked. By default a setting of 1 Megabyte is used. 0 sets it to unlimited. If set to no, it is disabled and stream.reassembly.depth is considered. Non-zero values must be greater than ``stream.stream-depth`` to be used.
 
 *libhtp.default-config.request-body-limit* / *libhtp.server-config.<config>.request-body-limit* controls how much of the HTTP request body is tracked for inspection by the http_client_body keyword, but also used to limit file inspection. A value of 0 means unlimited.
 
@@ -74,7 +74,9 @@ If not enabled, ``stream.reassembly.depth`` will be considered.
 Setting ``file-store.stream-depth`` to 0 permits to store any files.
 
 ``file-store.stream-depth`` will always override ``stream.reassembly.depth``
-when filestore keyword is used.
+when filestore keyword is used. However, it is not possible to set ``file-store.stream-depth``
+to a value less than ``stream.reassembly.depth``. Values less than this amount are ignored
+and a warning message will be displayed.
 
 A protocol parser, like modbus, could permit to set a different
 store-depth value and use it rather than ``file-store.stream-depth``.

--- a/doc/userguide/file-extraction/file-extraction.rst
+++ b/doc/userguide/file-extraction/file-extraction.rst
@@ -97,7 +97,7 @@ stored file to be closed and ``<ID>`` is a unique ID for the runtime
 of the Suricata instance. These values should not be depended on, and
 are simply used to ensure uniqueness.
 
-These ``fileinfo`` records are idential to the ``fileinfo`` records
+These ``fileinfo`` records are identical to the ``fileinfo`` records
 logged to the ``eve`` output.
 
 See :ref:`suricata-yaml-file-store` for more information on

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -17,6 +17,7 @@
 
 #include "suricata-common.h"
 
+#include "stream-tcp.h"
 #include "app-layer-parser.h"
 #include "app-layer-htp.h"
 #include "app-layer-htp-xff.h"
@@ -482,9 +483,15 @@ static OutputInitResult OutputFilestoreLogInitCtx(ConfNode *conf)
                        "from conf file - %s.  Killing engine",
                        stream_depth_str);
             exit(EXIT_FAILURE);
-        } else {
-            FileReassemblyDepthEnable(stream_depth);
         }
+        if (stream_depth && stream_depth <= stream_config.reassembly_depth) {
+            SCLogWarning(SC_WARN_FILESTORE_CONFIG, "file-store.stream-depth value "
+                       "%"PRIu32" must be larger than %"PRIu32"."
+                       " Using %"PRIu32" instead",
+                       stream_depth, stream_config.reassembly_depth, stream_config.reassembly_depth);
+            stream_depth = stream_config.reassembly_depth;
+        } 
+        FileReassemblyDepthEnable(stream_depth);
     }
 
     const char *file_count_str = ConfNodeLookupChildValue(conf,

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -503,7 +503,7 @@ static OutputInitResult OutputFilestoreLogInitCtx(ConfNode *conf)
             SCLogError(SC_ERR_SIZE_PARSE, "Error parsing "
                        "file-store.max-open-files "
                        "from conf file - %s.  Killing engine",
-                       stream_depth_str);
+                       file_count_str);
             exit(EXIT_FAILURE);
         } else {
             if (file_count != 0) {

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -364,6 +364,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_ERR_THASH_INIT);
         CASE_CODE (SC_ERR_DATASET);
         CASE_CODE (SC_WARN_ANOMALY_CONFIG);
+        CASE_CODE (SC_WARN_FILESTORE_CONFIG);
 
         CASE_CODE (SC_ERR_MAX);
     }

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -354,6 +354,7 @@ typedef enum {
     SC_ERR_THASH_INIT,
     SC_ERR_DATASET,
     SC_WARN_ANOMALY_CONFIG,
+    SC_WARN_FILESTORE_CONFIG,
 
     SC_ERR_MAX
 } SCError;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -497,7 +497,8 @@ outputs:
       #force-filestore: yes
 
       # Override the global stream-depth for sessions in which we want
-      # to perform file extraction. Set to 0 for unlimited.
+      # to perform file extraction. Set to 0 for unlimited; otherwise,
+      # must be greater than the global stream-depth value to be used.
       #stream-depth: 0
 
       # Uncomment the following variable to define how many files can
@@ -552,7 +553,8 @@ outputs:
       #force-hash: [md5]
       force-filestore: no # force storing of all files
       # override global stream-depth for sessions in which we want to
-      # perform file extraction. Set to 0 for unlimited.
+      # perform file extraction. Set to 0 for unlimited; otherwise,
+      # must be greater than the global stream-depth value to be used.
       #stream-depth: 0
       #waldo: file.waldo # waldo file to store the file_id across runs
       # uncomment to disable meta file writing

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -450,7 +450,7 @@ outputs:
   # a line based alerts log similar to fast.log into syslog
   - syslog:
       enabled: no
-      # reported identity to syslog. If ommited the program name (usually
+      # reported identity to syslog. If omitted the program name (usually
       # suricata) will be used.
       #identity: "suricata"
       facility: local5
@@ -728,7 +728,7 @@ af-packet:
 # Cross platform libpcap capture support
 pcap:
   - interface: eth0
-    # On Linux, pcap will try to use mmaped capture and will use buffer-size
+    # On Linux, pcap will try to use mmapped capture and will use buffer-size
     # as total of memory used by the ring. So set this to something bigger
     # than 1% of your bandwidth.
     #buffer-size: 16777216
@@ -828,7 +828,7 @@ app-layer:
       mime:
         # Decode MIME messages from SMTP transactions
         # (may be resource intensive)
-        # This field supercedes all others because it turns the entire
+        # This field supersedes all others because it turns the entire
         # process on or off
         decode-mime: yes
 
@@ -968,7 +968,7 @@ app-layer:
            # detection change between runs. It is set to 'yes' by default.
            #randomize-inspection-sizes: yes
            # If randomize-inspection-sizes is active, the value of various
-           # inspection size will be choosen in the [1 - range%, 1 + range%]
+           # inspection size will be chosen in the [1 - range%, 1 + range%]
            # range
            # Default value of randomize-inspection-range is 10.
            #randomize-inspection-range: 10
@@ -1360,7 +1360,7 @@ flow-timeouts:
 #                               # this size.  Can be specified in kb, mb,
 #                               # gb.  Just a number indicates it's in bytes.
 #     randomize-chunk-size: yes # Take a random value for chunk size around the specified value.
-#                               # This lower the risk of some evasion technics but could lead
+#                               # This lower the risk of some evasion techniques but could lead
 #                               # detection change between runs. It is set to 'yes' by default.
 #     randomize-chunk-range: 10 # If randomize-chunk-size is active, the value of chunk-size is
 #                               # a random value between (1 - randomize-chunk-range/100)*toserver-chunk-size


### PR DESCRIPTION
_Request for comments only_  Would like comments on the solution and if the solution is complete.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [2506](https://redmine.openinfosecfoundation.org/projects/suricata/issues/2506) 

Describe changes:
- Ensure configured stream depth for filestore (v1 and v2) is either 0 or greater than configured stream depth. Configured values, if non-zero, are compared against `stream.depth` ... a warning log record is written when the value is not greater than `stream.depth` and the value for `file-store.stream-depth` is set to `stream.depth`

*NOTES*
1. With a configured `file-store.stream-depth = 100600` and `stream.depth = 100000`, files larger than `100600` were created. I don't think this is proper behavior.
