### PR TITLE
rust/lua: fix datatype to lua_pushinteger - v1

### DIFF
--- a/rust/src/lua.rs
+++ b/rust/src/lua.rs
@@ -26,7 +26,7 @@ extern {
     fn lua_createtable(lua: *mut CLuaState, narr: c_int, nrec: c_int);
     fn lua_settable(lua: *mut CLuaState, idx: c_long);
     fn lua_pushlstring(lua: *mut CLuaState, s: *const c_char, len: usize);
-    fn lua_pushinteger(lua: *mut CLuaState, n: c_long);
+    fn lua_pushinteger(lua: *mut CLuaState, n: i64);
 }
 
 pub struct LuaState {
@@ -55,7 +55,7 @@ impl LuaState {
 
     pub fn pushinteger(&self, val: i64) {
         unsafe {
-            lua_pushinteger(self.lua, val as c_long);
+            lua_pushinteger(self.lua, val);
         }
     }
 }


### PR DESCRIPTION
Lua integers are 64 bit on 32 bit and 64 bit machines, so use
Rust's i64 here instead of the architecture dependent c_long.

Fixes Redmine issue:
https://redmine.openinfosecfoundation.org/issues/2955

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/381
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/737
