### PR TITLE
ebpf: make sure 'make dist' include eBPF files

### DIFF
--- a/ebpf/Makefile.am
+++ b/ebpf/Makefile.am
@@ -1,3 +1,6 @@
+EXTRA_DIST= include bypass_filter.c filter.c lb.c vlan_filter.c xdp_filter.c \
+	    xdp_lb.c bpf_helpers.h hash_func01.h
+
 if BUILD_EBPF
 
 # Maintaining a local copy of UAPI linux/bpf.h
@@ -12,7 +15,6 @@ BPF_TARGETS += vlan_filter.bpf
 
 all: $(BPF_TARGETS)
 
-EXTRA_DIST= include bypass_filter.c filter.c lb.c vlan_filter.c xdp_filter.c xdp_lb.c
 
 $(BPF_TARGETS): %.bpf: %.c
 #      From C-code to LLVM-IR format suffix .ll (clang -S -emit-llvm)


### PR DESCRIPTION
Fix make dist.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3196

Describe changes:
- Fix make dist so eBPF files are present

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/498
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/274

