### PR TITLE
log/alert: Improve HTTP body logging documentation

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -60,8 +60,8 @@ Metadata::
             #payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             #payload-printable: yes   # enable dumping payload in printable (lossy) format
             #packet: yes              # enable dumping of packet (without stream segments)
-            #http-body: yes           # enable dumping of http body in Base64
-            #http-body-printable: yes # enable dumping of http body in printable format
+            #http-body: yes           # Requires metadata; enable dumping of http body in Base64
+            #http-body-printable: yes # Requires metadata; enable dumping of http body in printable format
 
             # metadata:
 

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -35,8 +35,8 @@ outputs:
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # packet: yes              # enable dumping of packet (without stream segments)
-            # http-body: yes           # enable dumping of http body in Base64
-            # http-body-printable: yes # enable dumping of http body in printable format
+            # http-body: yes           # Requires metadata; enable dumping of http body in Base64
+            # http-body-printable: yes # Requires metadata; enable dumping of http body in printable format
 
             # Enable the logging of tagged packets for rules using the
             # "tag" keyword.

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -97,6 +97,8 @@
             LOG_JSON_APP_LAYER  |                                  \
             LOG_JSON_RULE_METADATA)
 
+#define _JSON_BODY_LOGGING  (LOG_JSON_HTTP_BODY | LOG_JSON_HTTP_BODY_BASE64)
+
 #define JSON_STREAM_BUFFER_SIZE 4096
 
 typedef struct AlertJsonOutputCtx_ {
@@ -810,6 +812,7 @@ static void SetFlag(const ConfNode *conf, const char *name, uint16_t flag, uint1
 static void JsonAlertLogSetupMetadata(AlertJsonOutputCtx *json_output_ctx,
         ConfNode *conf)
 {
+    static bool _warn_no_meta = false;
     uint32_t payload_buffer_size = JSON_STREAM_BUFFER_SIZE;
     uint16_t flags = METADATA_DEFAULTS;
 
@@ -865,6 +868,15 @@ static void JsonAlertLogSetupMetadata(AlertJsonOutputCtx *json_output_ctx,
                 exit(EXIT_FAILURE);
             } else {
                 payload_buffer_size = value;
+            }
+        }
+
+        if (!_warn_no_meta && flags & _JSON_BODY_LOGGING) {
+            if (((flags & LOG_JSON_APP_LAYER) == 0)) {
+                SCLogWarning(SC_WARN_ALERT_CONFIG, "HTTP body logging has been configured, however, "
+                             "metadata logging has not been enabled. HTTP body logging will be disabled.");
+                flags &= ~_JSON_BODY_LOGGING;
+                _warn_no_meta = true;
             }
         }
 

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -364,6 +364,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_ERR_THASH_INIT);
         CASE_CODE (SC_ERR_DATASET);
         CASE_CODE (SC_WARN_ANOMALY_CONFIG);
+        CASE_CODE (SC_WARN_ALERT_CONFIG);
 
         CASE_CODE (SC_ERR_MAX);
     }

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -354,6 +354,7 @@ typedef enum {
     SC_ERR_THASH_INIT,
     SC_ERR_DATASET,
     SC_WARN_ANOMALY_CONFIG,
+    SC_WARN_ALERT_CONFIG,
 
     SC_ERR_MAX
 } SCError;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -148,9 +148,9 @@ outputs:
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # packet: yes              # enable dumping of packet (without stream segments)
-            # http-body: yes           # enable dumping of http body in Base64
-            # http-body-printable: yes # enable dumping of http body in printable format
             # metadata: no             # enable inclusion of app layer metadata with alert. Default yes
+            # http-body: yes           # Requires metadata; enable dumping of http body in Base64
+            # http-body-printable: yes # Requires metadata; enable dumping of http body in printable format
 
             # Enable the logging of tagged packets for rules using the
             # "tag" keyword.

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -182,9 +182,8 @@ outputs:
             # enabled.
             enabled: no
             #
-            # Choose one or both types of anomaly logging and whether
-            # to enable logging of the packet header for packet
-            # anomalies.
+            # Choose one or more types of anomaly logging and whether to enable
+            # logging of the packet header for packet anomalies.
             types:
               # decode: no
               # stream: no


### PR DESCRIPTION

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:[2640](https://redmine.openinfosecfoundation.org/issues/2640)

Describe changes:
- Clarify wording of HTTP body logging for alerts
- Warn if HTTP body logging is configured but metadata is not enabled.
