### PR TITLE
rust/lua - fix datatype to lua_pushinteger - v3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2122,6 +2122,25 @@
 
     AM_CONDITIONAL([HAVE_LUA], [test "x$enable_lua" != "xno"])
 
+    # If Lua is enabled, test the integer size.
+    if test "x$enable_lua" = "xyes"; then
+        AC_MSG_CHECKING([size of lua integer])
+        AC_RUN_IFELSE([AC_LANG_PROGRAM([[ #include <lua.h> ]],
+            [[
+            if (sizeof(lua_Integer) == 8) {
+                exit(1);
+            }
+            exit(0);
+            ]])],
+            [
+                AC_MSG_RESULT([4])
+            ],
+            [
+                AC_MSG_RESULT([8])
+                AC_SUBST([LUA_INT8], ["lua_int8"])
+            ])
+    fi
+
   # libmaxminddb
     AC_ARG_ENABLE(geoip,
 	        AS_HELP_STRING([--enable-geoip],[Enable GeoIP2 support]),

--- a/configure.ac
+++ b/configure.ac
@@ -243,8 +243,7 @@
     #check for os
     AC_MSG_CHECKING([host os])
 
-    # lua pkg-config name differs per OS
-    LUA_PC_NAME="lua5.1"
+    # Default lua libname if not detected otherwise.
     LUA_LIB_NAME="lua5.1"
 
     # If no host os was detected, try with uname
@@ -260,7 +259,6 @@
     PCAP_LIB_NAME="pcap"
     case "$host" in
         *-*-*freebsd*)
-            LUA_PC_NAME="lua-5.1"
             LUA_LIB_NAME="lua-5.1"
             CFLAGS="${CFLAGS} -DOS_FREEBSD"
             CPPFLAGS="${CPPFLAGS} -I/usr/local/include -I/usr/local/include/libnet11"
@@ -268,14 +266,12 @@
             RUST_LDADD="-lrt -lm"
             ;;
         *-*-openbsd*)
-            LUA_PC_NAME="lua51"
             CFLAGS="${CFLAGS} -D__OpenBSD__"
             CPPFLAGS="${CPPFLAGS} -I/usr/local/include -I/usr/local/include/libnet-1.1"
             LDFLAGS="${LDFLAGS} -L/usr/local/lib -I/usr/local/lib/libnet-1.1"
             RUST_LDADD="-lm -lc++ -lc++abi"
             ;;
         *darwin*|*Darwin*)
-            LUA_PC_NAME="lua-5.1"
             LUA_LIB_NAME="lua-5.1"
             CFLAGS="${CFLAGS} -DOS_DARWIN"
             CPPFLAGS="${CPPFLAGS} -I/opt/local/include"
@@ -294,7 +290,6 @@
             RUST_LDADD="-luserenv -lshell32 -ladvapi32 -lgcc_eh"
             ;;
         *-*-cygwin)
-            LUA_PC_NAME="lua"
             LUA_LIB_NAME="lua"
             WINDOWS_PATH="yes"
             PCAP_LIB_NAME="wpcap"

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -11,6 +11,7 @@ debug = true
 
 [features]
 lua = []
+lua_int8 = ["lua"]
 strict = []
 debug = []
 

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -20,7 +20,7 @@ RELEASE = --release
 endif
 
 if HAVE_LUA
-RUST_FEATURES +=	lua
+RUST_FEATURES +=	lua $(LUA_INT8)
 endif
 
 if DEBUG

--- a/rust/src/lua.rs
+++ b/rust/src/lua.rs
@@ -19,6 +19,12 @@ use std::os::raw::c_char;
 use std::os::raw::c_int;
 use std::os::raw::c_long;
 
+#[cfg(feature = "lua_int8")]
+type LuaInteger = i64;
+
+#[cfg(not(feature = "lua_int8"))]
+type LuaInteger = i32;
+
 /// The Rust place holder for lua_State.
 pub enum CLuaState {}
 
@@ -26,7 +32,7 @@ extern {
     fn lua_createtable(lua: *mut CLuaState, narr: c_int, nrec: c_int);
     fn lua_settable(lua: *mut CLuaState, idx: c_long);
     fn lua_pushlstring(lua: *mut CLuaState, s: *const c_char, len: usize);
-    fn lua_pushinteger(lua: *mut CLuaState, n: c_long);
+    fn lua_pushinteger(lua: *mut CLuaState, n: LuaInteger);
 }
 
 pub struct LuaState {
@@ -55,7 +61,7 @@ impl LuaState {
 
     pub fn pushinteger(&self, val: i64) {
         unsafe {
-            lua_pushinteger(self.lua, val as c_long);
+            lua_pushinteger(self.lua, val as LuaInteger);
         }
     }
 }

--- a/src/util-magic.c
+++ b/src/util-magic.c
@@ -344,10 +344,7 @@ static int MagicDetectTest03(void)
     FAIL_IF_NULL(result);
 
     char *str = strstr(result, "OpenDocument Text");
-    if (str == NULL) {
-        printf("result %s, not \"OpenDocument Text\": ", str);
-        FAIL;
-    }
+    FAIL_IF_NULL(str);
 
     magic_close(magic_ctx);
     PASS;
@@ -517,10 +514,7 @@ static int MagicDetectTest07(void)
     FAIL_IF_NULL(result);
 
     char *str = strstr(result, "OpenDocument Text");
-    if (str == NULL) {
-        printf("result %s, not \"OpenDocument Text\": ", str);
-        FAIL;
-    }
+    FAIL_IF_NULL(str);
 
     MagicDeinit();
     PASS;


### PR DESCRIPTION
Previous PR:
https://github.com/OISF/suricata/pull/4248

Changes from last PR:
- Use FAIL_IF_NULL in test fixup
- Do size check instead of version check

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2955

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/384
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/740