### PR TITLE
config: minor update lzma size notation to match other size notation

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -977,9 +977,9 @@ app-layer:
 
            #lzma-enabled: yes
            # LZMA decompression memory limit.
-           #lzma-memlimit: 1 Mb
+           #lzma-memlimit: 1mb
            # Compression bomb output limit.
-           #compression-bomb-limit: 1 Mb
+           #compression-bomb-limit: 1mb
 
          server-config:
 


### PR DESCRIPTION
Signed-off-by: jason taylor <jtfas90@gmail.com>

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- have lzma memory references match other memory/size references in config file
-
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

