### PR TITLE
Feat/classtype unknown/v9

### DIFF
--- a/src/alert-unified2-alert.c
+++ b/src/alert-unified2-alert.c
@@ -948,7 +948,7 @@ static int Unified2IPv6TypeAlert(ThreadVars *t, const Packet *p, void *data)
         phdr->generator_id = htonl(pa->s->gid);
         phdr->signature_id = htonl(pa->s->id);
         phdr->signature_revision = htonl(pa->s->rev);
-        phdr->classification_id = htonl(pa->s->class);
+        phdr->classification_id = htonl(pa->s->class_id);
         phdr->priority_id = htonl(pa->s->prio);
 
         SCMutexLock(&file_ctx->fp_mutex);
@@ -1136,7 +1136,7 @@ static int Unified2IPv4TypeAlert (ThreadVars *tv, const Packet *p, void *data)
         phdr->generator_id = htonl(pa->s->gid);
         phdr->signature_id = htonl(pa->s->id);
         phdr->signature_revision = htonl(pa->s->rev);
-        phdr->classification_id = htonl(pa->s->class);
+        phdr->classification_id = htonl(pa->s->class_id);
         phdr->priority_id = htonl(pa->s->prio);
 
         /* check and enforce the filesize limit */

--- a/src/detect-classtype.c
+++ b/src/detect-classtype.c
@@ -116,12 +116,13 @@ static int DetectClasstypeSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     SCClassConfClasstype *ct = SCClassConfGetClasstype(parsed_ct_name, de_ctx);
     if (ct == NULL) {
         SCLogWarning(SC_ERR_UNKNOWN_VALUE, "unknown classtype: \"%s\", "
-                "using default priority 3", parsed_ct_name);
+                "using default priority %d",
+                parsed_ct_name, DETECT_DEFAULT_PRIO);
 
         char str[2048];
         snprintf(str, sizeof(str),
-                "config classification: %s,Unknown Classtype,3\n",
-                parsed_ct_name);
+                "config classification: %s,Unknown Classtype,%d\n",
+                parsed_ct_name, DETECT_DEFAULT_PRIO);
 
         if (SCClassConfAddClasstype(de_ctx, str, 0) < 0)
             return -1;

--- a/src/detect-classtype.c
+++ b/src/detect-classtype.c
@@ -106,7 +106,6 @@ static int DetectClasstypeParseRawString(const char *rawstr, char *out, size_t o
 static int DetectClasstypeSetup(DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     char parsed_ct_name[1024] = "";
-    SCClassConfClasstype *ct = NULL;
 
     if ((s->class > 0) || (s->class_msg != NULL)) {
         SCLogWarning(SC_ERR_CONFLICTING_RULE_KEYWORDS, "duplicated 'classtype' "
@@ -117,14 +116,14 @@ static int DetectClasstypeSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     if (DetectClasstypeParseRawString(rawstr, parsed_ct_name, sizeof(parsed_ct_name)) < 0) {
         SCLogError(SC_ERR_PCRE_PARSE, "invalid value for classtype keyword: "
                 "\"%s\"", rawstr);
-        goto error;
+        return -1;
     }
 
-    ct = SCClassConfGetClasstype(parsed_ct_name, de_ctx);
+    SCClassConfClasstype *ct = SCClassConfGetClasstype(parsed_ct_name, de_ctx);
     if (ct == NULL) {
         SCLogError(SC_ERR_UNKNOWN_VALUE, "Unknown Classtype: \"%s\".  Invalidating the Signature",
                    parsed_ct_name);
-        goto error;
+        return -1;
     }
 
     /* if we have retrieved the classtype, assign the message to be displayed
@@ -139,9 +138,6 @@ static int DetectClasstypeSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
         s->prio = ct->priority;
 
     return 0;
-
- error:
-    return -1;
 }
 
 /*------------------------------Unittests-------------------------------------*/

--- a/src/detect-classtype.c
+++ b/src/detect-classtype.c
@@ -101,7 +101,7 @@ static int DetectClasstypeSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
 {
     char parsed_ct_name[1024] = "";
 
-    if ((s->class > 0) || (s->class_msg != NULL)) {
+    if ((s->class_id > 0) || (s->class_msg != NULL)) {
         SCLogWarning(SC_ERR_CONFLICTING_RULE_KEYWORDS, "duplicated 'classtype' "
                 "keyword detected. Using instance with highest priority");
     }
@@ -121,16 +121,16 @@ static int DetectClasstypeSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
 
     if ((s->init_data->init_flags & SIG_FLAG_INIT_PRIO_EXPLICT) != 0) {
         /* don't touch Signature::prio */
-        s->class = ct->classtype_id;
+        s->class_id = ct->classtype_id;
         s->class_msg = ct->classtype_desc;
     } else if (s->prio == -1) {
         s->prio = ct->priority;
-        s->class = ct->classtype_id;
+        s->class_id = ct->classtype_id;
         s->class_msg = ct->classtype_desc;
     } else {
         if (ct->priority < s->prio) {
             s->prio = ct->priority;
-            s->class = ct->classtype_id;
+            s->class_id = ct->classtype_id;
             s->class_msg = ct->classtype_desc;
         }
     }

--- a/src/detect-classtype.c
+++ b/src/detect-classtype.c
@@ -108,6 +108,12 @@ static int DetectClasstypeSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     char parsed_ct_name[1024] = "";
     SCClassConfClasstype *ct = NULL;
 
+    if ((s->class > 0) || (s->class_msg != NULL)) {
+        SCLogWarning(SC_ERR_CONFLICTING_RULE_KEYWORDS, "duplicated 'classtype' "
+                "keyword detected. Using first occurence in the rule");
+        return 0;
+    }
+
     if (DetectClasstypeParseRawString(rawstr, parsed_ct_name, sizeof(parsed_ct_name)) < 0) {
         SCLogError(SC_ERR_PCRE_PARSE, "invalid value for classtype keyword: "
                 "\"%s\"", rawstr);
@@ -118,12 +124,6 @@ static int DetectClasstypeSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     if (ct == NULL) {
         SCLogError(SC_ERR_UNKNOWN_VALUE, "Unknown Classtype: \"%s\".  Invalidating the Signature",
                    parsed_ct_name);
-        goto error;
-    }
-
-    if ((s->class > 0) || (s->class_msg != NULL))
-    {
-        SCLogError(SC_ERR_INVALID_RULE_ARGUMENT, "duplicated 'classtype' keyword detected");
         goto error;
     }
 

--- a/src/detect-classtype.c
+++ b/src/detect-classtype.c
@@ -115,9 +115,23 @@ static int DetectClasstypeSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     bool real_ct = true;
     SCClassConfClasstype *ct = SCClassConfGetClasstype(parsed_ct_name, de_ctx);
     if (ct == NULL) {
-        SCLogWarning(SC_ERR_UNKNOWN_VALUE, "unknown classtype: \"%s\", "
-                "using default priority %d",
-                parsed_ct_name, DETECT_DEFAULT_PRIO);
+        if (s->id > 0) {
+            SCLogWarning(SC_ERR_UNKNOWN_VALUE, "signature sid:%u uses "
+                    "unknown classtype: \"%s\", using default priority %d. "
+                    "This message won't be shown again for this classtype",
+                    s->id, parsed_ct_name, DETECT_DEFAULT_PRIO);
+        } else if (de_ctx->rule_file != NULL) {
+            SCLogWarning(SC_ERR_UNKNOWN_VALUE, "signature at %s:%u uses "
+                    "unknown classtype: \"%s\", using default priority %d. "
+                    "This message won't be shown again for this classtype",
+                    de_ctx->rule_file, de_ctx->rule_line,
+                    parsed_ct_name, DETECT_DEFAULT_PRIO);
+        } else {
+            SCLogWarning(SC_ERR_UNKNOWN_VALUE, "unknown classtype: \"%s\", "
+                    "using default priority %d. "
+                    "This message won't be shown again for this classtype",
+                    parsed_ct_name, DETECT_DEFAULT_PRIO);
+        }
 
         char str[2048];
         snprintf(str, sizeof(str),

--- a/src/detect-classtype.c
+++ b/src/detect-classtype.c
@@ -99,7 +99,7 @@ static int DetectClasstypeParseRawString(const char *rawstr, char *out, size_t o
  */
 static int DetectClasstypeSetup(DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
-    char parsed_ct_name[1024] = "";
+    char parsed_ct_name[CLASSTYPE_NAME_MAX_LEN] = "";
 
     if ((s->class_id > 0) || (s->class_msg != NULL)) {
         SCLogWarning(SC_ERR_CONFLICTING_RULE_KEYWORDS, "duplicated 'classtype' "
@@ -133,7 +133,7 @@ static int DetectClasstypeSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
                     parsed_ct_name, DETECT_DEFAULT_PRIO);
         }
 
-        char str[2048];
+        char str[256];
         snprintf(str, sizeof(str),
                 "config classification: %s,Unknown Classtype,%d\n",
                 parsed_ct_name, DETECT_DEFAULT_PRIO);

--- a/src/detect-classtype.c
+++ b/src/detect-classtype.c
@@ -108,9 +108,9 @@ static int DetectClasstypeSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     char parsed_ct_name[1024] = "";
     SCClassConfClasstype *ct = NULL;
 
-    if (DetectClasstypeParseRawString(rawstr, parsed_ct_name, sizeof(parsed_ct_name)) < -1) {
-        SCLogError(SC_ERR_PCRE_PARSE, "Error parsing classtype argument supplied with the "
-                   "classtype keyword");
+    if (DetectClasstypeParseRawString(rawstr, parsed_ct_name, sizeof(parsed_ct_name)) < 0) {
+        SCLogError(SC_ERR_PCRE_PARSE, "invalid value for classtype keyword: "
+                "\"%s\"", rawstr);
         goto error;
     }
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1800,7 +1800,7 @@ static Signature *SigInitHelper(DetectEngineCtx *de_ctx, const char *sigstr,
 
     /* signature priority hasn't been overwritten.  Using default priority */
     if (sig->prio == -1)
-        sig->prio = 3;
+        sig->prio = DETECT_DEFAULT_PRIO;
 
     sig->num = de_ctx->signum;
     de_ctx->signum++;

--- a/src/detect-priority.c
+++ b/src/detect-priority.c
@@ -50,9 +50,7 @@ void DetectPriorityRegister (void)
     sigmatch_table[DETECT_PRIORITY].name = "priority";
     sigmatch_table[DETECT_PRIORITY].desc = "rules with a higher priority will be examined first";
     sigmatch_table[DETECT_PRIORITY].url = DOC_URL DOC_VERSION "/rules/meta.html#priority";
-    sigmatch_table[DETECT_PRIORITY].Match = NULL;
     sigmatch_table[DETECT_PRIORITY].Setup = DetectPrioritySetup;
-    sigmatch_table[DETECT_PRIORITY].Free = NULL;
     sigmatch_table[DETECT_PRIORITY].RegisterTests = SCPriorityRegisterTests;
 
     DetectSetupParseRegexes(PARSE_REGEX, &regex, &regex_study);

--- a/src/detect.h
+++ b/src/detect.h
@@ -57,6 +57,10 @@
 
 #define DETECT_TRANSFORMS_MAX 16
 
+/** default rule priority if not set through priority keyword or via
+ *  classtype. */
+#define DETECT_DEFAULT_PRIO 3
+
 /* forward declarations for the structures from detect-engine-sigorder.h */
 struct SCSigOrderFunc_;
 struct SCSigSignatureWrapper_;

--- a/src/detect.h
+++ b/src/detect.h
@@ -249,14 +249,14 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_HAS_TARGET             (SIG_FLAG_DEST_IS_TARGET|SIG_FLAG_SRC_IS_TARGET)
 
 /* signature init flags */
-#define SIG_FLAG_INIT_DEONLY                (1<<0)  /**< decode event only signature */
-#define SIG_FLAG_INIT_PACKET                (1<<1)  /**< signature has matches against a packet (as opposed to app layer) */
-#define SIG_FLAG_INIT_FLOW                  (1<<2)  /**< signature has a flow setting */
-#define SIG_FLAG_INIT_BIDIREC               (1<<3)  /**< signature has bidirectional operator */
-#define SIG_FLAG_INIT_FIRST_IPPROTO_SEEN    (1<<4)  /** < signature has seen the first ip_proto keyword */
-#define SIG_FLAG_INIT_HAS_TRANSFORM         (1<<5)
-#define SIG_FLAG_INIT_STATE_MATCH           (1<<6)  /**< signature has matches that require stateful inspection */
-#define SIG_FLAG_INIT_NEED_FLUSH            (1<<7)
+#define SIG_FLAG_INIT_DEONLY                BIT_U32(0)  /**< decode event only signature */
+#define SIG_FLAG_INIT_PACKET                BIT_U32(1)  /**< signature has matches against a packet (as opposed to app layer) */
+#define SIG_FLAG_INIT_FLOW                  BIT_U32(2)  /**< signature has a flow setting */
+#define SIG_FLAG_INIT_BIDIREC               BIT_U32(3)  /**< signature has bidirectional operator */
+#define SIG_FLAG_INIT_FIRST_IPPROTO_SEEN    BIT_U32(4)  /** < signature has seen the first ip_proto keyword */
+#define SIG_FLAG_INIT_HAS_TRANSFORM         BIT_U32(5)
+#define SIG_FLAG_INIT_STATE_MATCH           BIT_U32(6)  /**< signature has matches that require stateful inspection */
+#define SIG_FLAG_INIT_NEED_FLUSH            BIT_U32(7)
 
 /* signature mask flags */
 /** \note: additions should be added to the rule analyzer as well */

--- a/src/detect.h
+++ b/src/detect.h
@@ -257,6 +257,7 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_INIT_HAS_TRANSFORM         BIT_U32(5)
 #define SIG_FLAG_INIT_STATE_MATCH           BIT_U32(6)  /**< signature has matches that require stateful inspection */
 #define SIG_FLAG_INIT_NEED_FLUSH            BIT_U32(7)
+#define SIG_FLAG_INIT_PRIO_EXPLICT          BIT_U32(8)  /**< priority is explicitly set by the priority keyword */
 
 /* signature mask flags */
 /** \note: additions should be added to the rule analyzer as well */

--- a/src/detect.h
+++ b/src/detect.h
@@ -535,7 +535,7 @@ typedef struct Signature_ {
     DetectProto proto;
 
     /** classification id **/
-    uint8_t class;
+    uint16_t class_id;
 
     /** ipv4 match arrays */
     uint16_t addr_dst_match4_cnt;

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -823,23 +823,16 @@ static int SCClassConfTest06(void)
     return result;
 }
 
-#endif /* UNITTESTS */
-
 /**
  * \brief This function registers unit tests for Classification Config API.
  */
 void SCClassConfRegisterTests(void)
 {
-
-#ifdef UNITTESTS
-
     UtRegisterTest("SCClassConfTest01", SCClassConfTest01);
     UtRegisterTest("SCClassConfTest02", SCClassConfTest02);
     UtRegisterTest("SCClassConfTest03", SCClassConfTest03);
     UtRegisterTest("SCClassConfTest04", SCClassConfTest04);
     UtRegisterTest("SCClassConfTest05", SCClassConfTest05);
     UtRegisterTest("SCClassConfTest06", SCClassConfTest06);
-
-#endif /* UNITTESTS */
-
 }
+#endif /* UNITTESTS */

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -574,7 +574,7 @@ SCClassConfClasstype *SCClassConfGetClasstype(const char *ct_name,
         name[s] = tolower((unsigned char)ct_name[s]);
     name[s] = '\0';
 
-    SCClassConfClasstype ct_lookup = {0, name, NULL, 0 };
+    SCClassConfClasstype ct_lookup = {0, 0, name, NULL };
     SCClassConfClasstype *lookup_ct_info = HashTableLookup(de_ctx->class_conf_ht,
                                                            &ct_lookup, 0);
     return lookup_ct_info;

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -56,7 +56,7 @@ char SCClassConfClasstypeHashCompareFunc(void *data1, uint16_t datalen1,
 void SCClassConfClasstypeHashFree(void *ch);
 static const char *SCClassConfGetConfFilename(const DetectEngineCtx *de_ctx);
 
-static SCClassConfClasstype *SCClassConfAllocClasstype(uint8_t classtype_id,
+static SCClassConfClasstype *SCClassConfAllocClasstype(uint16_t classtype_id,
         const char *classtype, const char *classtype_desc, int priority);
 static void SCClassConfDeAllocClasstype(SCClassConfClasstype *ct);
 
@@ -248,13 +248,13 @@ static char *SCClassConfStringToLowercase(const char *str)
  * \retval  0 On success.
  * \retval -1 On failure.
  */
-static int SCClassConfAddClasstype(char *rawstr, uint8_t index, DetectEngineCtx *de_ctx)
+static int SCClassConfAddClasstype(char *rawstr, uint16_t index, DetectEngineCtx *de_ctx)
 {
     char ct_name[64];
     char ct_desc[512];
     char ct_priority_str[16];
     int ct_priority = 0;
-    uint8_t ct_id = index;
+    uint16_t ct_id = index;
 
     SCClassConfClasstype *ct_new = NULL;
     SCClassConfClasstype *ct_lookup = NULL;
@@ -359,7 +359,7 @@ static int SCClassConfIsLineBlankOrComment(char *line)
 static void SCClassConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
 {
     char line[1024];
-    uint8_t i = 1;
+    uint16_t i = 1;
 
     while (fgets(line, sizeof(line), fd) != NULL) {
         if (SCClassConfIsLineBlankOrComment(line))
@@ -389,7 +389,7 @@ static void SCClassConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
  * \retval ct Pointer to the new instance of SCClassConfClasstype on success;
  *            NULL on failure.
  */
-static SCClassConfClasstype *SCClassConfAllocClasstype(uint8_t classtype_id,
+static SCClassConfClasstype *SCClassConfAllocClasstype(uint16_t classtype_id,
                                                 const char *classtype,
                                                 const char *classtype_desc,
                                                 int priority)

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -250,8 +250,8 @@ static char *SCClassConfStringToLowercase(const char *str)
  */
 int SCClassConfAddClasstype(DetectEngineCtx *de_ctx, char *rawstr, uint16_t index)
 {
-    char ct_name[64];
-    char ct_desc[512];
+    char ct_name[CLASSTYPE_NAME_MAX_LEN];
+    char ct_desc[CLASSTYPE_DESC_MAX_LEN];
     char ct_priority_str[16];
     int ct_priority = 0;
     uint16_t ct_id = index;

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -56,6 +56,10 @@ char SCClassConfClasstypeHashCompareFunc(void *data1, uint16_t datalen1,
 void SCClassConfClasstypeHashFree(void *ch);
 static const char *SCClassConfGetConfFilename(const DetectEngineCtx *de_ctx);
 
+static SCClassConfClasstype *SCClassConfAllocClasstype(uint8_t classtype_id,
+        const char *classtype, const char *classtype_desc, int priority);
+static void SCClassConfDeAllocClasstype(SCClassConfClasstype *ct);
+
 void SCClassConfInit(void)
 {
     const char *eb = NULL;
@@ -374,6 +378,7 @@ static void SCClassConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
 }
 
 /**
+ * \internal
  * \brief Returns a new SCClassConfClasstype instance.  The classtype string
  *        is converted into lowercase, before being assigned to the instance.
  *
@@ -384,7 +389,7 @@ static void SCClassConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
  * \retval ct Pointer to the new instance of SCClassConfClasstype on success;
  *            NULL on failure.
  */
-SCClassConfClasstype *SCClassConfAllocClasstype(uint8_t classtype_id,
+static SCClassConfClasstype *SCClassConfAllocClasstype(uint8_t classtype_id,
                                                 const char *classtype,
                                                 const char *classtype_desc,
                                                 int priority)
@@ -420,11 +425,12 @@ SCClassConfClasstype *SCClassConfAllocClasstype(uint8_t classtype_id,
 }
 
 /**
+ * \internal
  * \brief Frees a SCClassConfClasstype instance
  *
  * \param Pointer to the SCClassConfClasstype instance that has to be freed
  */
-void SCClassConfDeAllocClasstype(SCClassConfClasstype *ct)
+static void SCClassConfDeAllocClasstype(SCClassConfClasstype *ct)
 {
     if (ct != NULL) {
         if (ct->classtype != NULL)

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -248,7 +248,7 @@ static char *SCClassConfStringToLowercase(const char *str)
  * \retval  0 On success.
  * \retval -1 On failure.
  */
-static int SCClassConfAddClasstype(char *rawstr, uint16_t index, DetectEngineCtx *de_ctx)
+int SCClassConfAddClasstype(DetectEngineCtx *de_ctx, char *rawstr, uint16_t index)
 {
     char ct_name[64];
     char ct_desc[512];
@@ -365,7 +365,7 @@ static void SCClassConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
         if (SCClassConfIsLineBlankOrComment(line))
             continue;
 
-        SCClassConfAddClasstype(line, i, de_ctx);
+        SCClassConfAddClasstype(de_ctx, line, i);
         i++;
     }
 

--- a/src/util-classification-config.h
+++ b/src/util-classification-config.h
@@ -46,14 +46,16 @@ void SCClassConfLoadClassficationConfigFile(DetectEngineCtx *, FILE *fd);
 SCClassConfClasstype *SCClassConfGetClasstype(const char *,
                                               DetectEngineCtx *);
 void SCClassConfDeInitContext(DetectEngineCtx *);
-void SCClassConfRegisterTests(void);
-
-/* for unittests */
-FILE *SCClassConfGenerateValidDummyClassConfigFD01(void);
-FILE *SCClassConfGenerateInValidDummyClassConfigFD02(void);
-FILE *SCClassConfGenerateInValidDummyClassConfigFD03(void);
 
 void SCClassConfInit(void);
 void SCClassConfDeinit(void);
+
+/* for unittests */
+#ifdef UNITTESTS
+void SCClassConfRegisterTests(void);
+FILE *SCClassConfGenerateValidDummyClassConfigFD01(void);
+FILE *SCClassConfGenerateInValidDummyClassConfigFD02(void);
+FILE *SCClassConfGenerateInValidDummyClassConfigFD03(void);
+#endif
 
 #endif /* __UTIL_CLASSIFICATION_CONFIG_H__ */

--- a/src/util-classification-config.h
+++ b/src/util-classification-config.h
@@ -31,15 +31,15 @@ typedef struct SCClassConfClasstype_ {
     /* The index of the classification within classification.confg */
     uint8_t classtype_id;
 
+    /* The priority this classification type carries */
+    int priority;
+
     /* The classtype name.  This is the primary key for a Classification. */
     char *classtype;
 
     /* Description for a classification.  Would be used while printing out
      * the classification info for a Signature, by the fast-log module. */
     char *classtype_desc;
-
-    /* The priority this classification type carries */
-    int priority;
 } SCClassConfClasstype;
 
 void SCClassConfLoadClassficationConfigFile(DetectEngineCtx *, FILE *fd);

--- a/src/util-classification-config.h
+++ b/src/util-classification-config.h
@@ -42,9 +42,6 @@ typedef struct SCClassConfClasstype_ {
     int priority;
 } SCClassConfClasstype;
 
-SCClassConfClasstype *SCClassConfAllocClasstype(uint8_t, const char *,
-                                                const char *, int);
-void SCClassConfDeAllocClasstype(SCClassConfClasstype *);
 void SCClassConfLoadClassficationConfigFile(DetectEngineCtx *, FILE *fd);
 SCClassConfClasstype *SCClassConfGetClasstype(const char *,
                                               DetectEngineCtx *);

--- a/src/util-classification-config.h
+++ b/src/util-classification-config.h
@@ -43,6 +43,7 @@ typedef struct SCClassConfClasstype_ {
 } SCClassConfClasstype;
 
 void SCClassConfLoadClassficationConfigFile(DetectEngineCtx *, FILE *fd);
+int SCClassConfAddClasstype(DetectEngineCtx *de_ctx, char *rawstr, uint16_t index);
 SCClassConfClasstype *SCClassConfGetClasstype(const char *,
                                               DetectEngineCtx *);
 void SCClassConfDeInitContext(DetectEngineCtx *);

--- a/src/util-classification-config.h
+++ b/src/util-classification-config.h
@@ -29,7 +29,7 @@
  */
 typedef struct SCClassConfClasstype_ {
     /* The index of the classification within classification.confg */
-    uint8_t classtype_id;
+    uint16_t classtype_id;
 
     /* The priority this classification type carries */
     int priority;

--- a/src/util-classification-config.h
+++ b/src/util-classification-config.h
@@ -24,6 +24,9 @@
 #ifndef __UTIL_CLASSIFICATION_CONFIG_H__
 #define __UTIL_CLASSIFICATION_CONFIG_H__
 
+#define CLASSTYPE_NAME_MAX_LEN 64
+#define CLASSTYPE_DESC_MAX_LEN 512
+
 /**
  * \brief Container for a Classtype from the Classification.config file.
  */


### PR DESCRIPTION
Makes missing classtypes in rules non-fatal. Instead creates a warning, once per unique missing classtype.

Consequence is that -T no longer errors out missing classtypes.

Perhaps another commandline option, e.g. something like ```--strict-rule-parsing``` or ```--strict-classtype-parsing``` could be added to make -T error out again in this case.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/316
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/317

