### PR TITLE
dataset: fix return value check on isnotset

### DIFF
--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -83,7 +83,7 @@ int DetectDatasetBufferMatch(DetectEngineThreadCtx *det_ctx,
             //PrintRawDataFp(stdout, data, data_len);
             int r = DatasetLookup(sd->set, data, data_len);
             SCLogDebug("r %d", r);
-            if (r == 0)
+            if (r < 1)
                 return 1;
             break;
         }


### PR DESCRIPTION
The dataset api returns -1 for not found.

Associated suricata-verify test PR:
https://github.com/OISF/suricata-verify/pull/135

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/390
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/746