### PR TITLE
http: updates suricata.yaml comments

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1325,13 +1325,13 @@ The library Libhtp is being used by Suricata to parse HTTP-sessions.
 
 While processing HTTP-traffic, Suricata has to deal with different
 kind of servers which each process anomalies in HTTP-traffic
-differently. The most common web-server is Apache. This is a open
-source web -server program.
+differently. The most common web-server is Apache. This is an open
+source web-server program.
 
-Beside Apache, IIS (Internet Information Services/Server)a web-server
+Besides Apache, IIS (Internet Information Services/Server) a web-server
 program of Microsoft is also well-known.
 
-Like with host-os-policy, it is important for Suricata to which
+Like with host-os-policy, it is important for Suricata to know which
 IP-address/network-address is used by which server. In Libhtp this
 assigning of web-servers to IP-and network addresses is called
 personality.
@@ -1352,27 +1352,23 @@ Currently Available Personalities:
 
 You can assign names to each block of settings. Which in this case
 is -apache and -iis7. Under these names you can set IP-addresses,
-network-addresses the personality and the request-body-limit.
+network-addresses the personality and a set of features.
 
 The version-specific personalities know exactly how web servers
-behave, and emulate that. The IDS personality (will be GENERIC in the
-future) would try to implement a best-effort approach that would work
-reasonably well in the cases where you do not know the specifics.
+behave, and emulate that. The IDS personality would try to implement
+a best-effort approach that would work reasonably well in the cases
+where you do not know the specifics.
 
 The default configuration also applies to every IP-address for which
 no specific setting is available.
 
-HTTP request body's are often big, so they take a lot of time to
+HTTP request bodies are often big, so they take a lot of time to
 process which has a significant impact on the performance. With the
 option 'request-body-limit' you can set the limit (in bytes) of the
 client-body that will be inspected. Setting it to 0 will inspect all
 of the body.
 
-HTTP response body's are often big, so they take a lot of time to
-process which has a significant impact on the performance. With the
-option 'response-body-limit' you can set the limit (in bytes) of the
-server-body that will be inspected. Setting it to 0 will inspect all
-of the body.
+The same goes for HTTP response bodies.
 
 ::
 
@@ -1398,8 +1394,7 @@ of the body.
            request-body-limit: 4096
            response-body-limit: 8192
 
-As of 1.4, Suricata makes available the whole set of libhtp
-customisations for its users.
+Suricata makes available the whole set of libhtp customisations for its users.
 
 You can now use these parameters in the conf to customise suricata's
 use of libhtp.
@@ -1410,7 +1405,16 @@ use of libhtp.
        # separators. They are not on Unix systems, but are on Windows systems.
        # If this setting is enabled, a path such as "/one\two/three" will be
        # converted to "/one/two/three".  Accepted values - yes, no.
-       #path-backslash-separators: yes
+       #path-convert-backslash-separators: yes
+
+       # Configures whether input data will be converted to lowercase.
+       #path-convert-lowercase: yes
+
+       # Configures how the server reacts to encoded NUL bytes.
+       #path-nul-encoded-terminates: no
+
+       # Configures how the server reacts to raw NUL bytes.
+       #path-nul-raw-terminates: no
 
        # Configures whether consecutive path segment separators will be
        # compressed. When enabled, a path such as "/one//two" will be normalized
@@ -1419,19 +1423,7 @@ use of libhtp.
        # backslash_separators and decode_separators are both enabled, the path
        # "/one\\/two\/%5cthree/%2f//four" will be converted to
        # "/one/two/three/four".  Accepted values - yes, no.
-       #path-compress-separators: yes
-
-       # This parameter is used to predict how a server will react when control
-       # characters are present in a request path, but does not affect path
-       # normalization.  Accepted values - none or status_400 */
-       #path-control-char-handling: none
-
-       # Controls the UTF-8 treatment of request paths. One option is to only
-       # validate path as UTF-8. In this case, the UTF-8 flags will be raised
-       # as appropriate, and the path will remain in UTF-8 (if it was UTF-8 in
-       # the first place). The other option is to convert a UTF-8 path into a
-       # single byte stream using best-fit mapping.  Accepted values - yes, no.
-       #path-convert-utf8: yes
+       #path-separators-compress: yes
 
        # Configures whether encoded path segment separators will be decoded.
        # Apache does not do this, but IIS does. If enabled, a path such as
@@ -1439,47 +1431,88 @@ use of libhtp.
        # backslash_separators option is also enabled, encoded backslash
        # characters will be converted too (and subsequently normalized to
        # forward slashes).  Accepted values - yes, no.
-       #path-decode-separators: yes
+       #path-separators-decode: yes
 
        # Configures whether %u-encoded sequences in path will be decoded. Such
        # sequences will be treated as invalid URL encoding if decoding is not
        # desireable.  Accepted values - yes, no.
-       #path-decode-u-encoding: yes
+       #path-u-encoding-decode: yes
 
        # Configures how server reacts to invalid encoding in path.  Accepted
        # values - preserve_percent, remove_percent, decode_invalid, status_400
-       #path-invalid-encoding-handling: preserve_percent
+       #path-url-encoding-invalid-handling: preserve_percent
 
-       # Configures how server reacts to invalid UTF-8 characters in path.
-       # This setting will not affect path normalization; it only controls what
-       # response status we expect for a request that contains invalid UTF-8
-       # characters.  Accepted values - none, status_400.
-       #path-invalid-utf8-handling: none
-
-       # Configures how server reacts to encoded NUL bytes. Some servers will
-       # terminate path at NUL, while some will respond with 400 or 404. When
-       # the termination option is not used, the NUL byte will remain in the
-       # path.  Accepted values - none, terminate, status_400, status_404.
-       # path-nul-encoded-handling: none
-
-       # Configures how server reacts to raw NUL bytes. Some servers will
-       # terminate path at NUL, while some will respond with 400 or 404. When
-       # the termination option is not used, the NUL byte will remain in the
-       # path.  Accepted values - none, terminate, status_400, status_404.
-       path-nul-raw-handling: none
+       # Controls whether the data should be treated as UTF-8 and converted
+       # to a single-byte stream using best-fit mapping
+       #path-utf8-convert-bestfit:yes
 
        # Sets the replacement character that will be used to in the lossy
        # best-fit mapping from Unicode characters into single-byte streams.
        # The question mark is the default replacement character.
-       #set-path-replacement-char: ?
+       #path-bestfit-replacement-char: ?
 
-       # Controls what the library does when it encounters an Unicode character
-       # where only a single-byte would do (e.g., the %u-encoded characters).
-       # Conversion always takes place; this parameter is used to correctly
-       # predict the status code used in response. In the future there will
-       # probably be an option to convert such characters to UCS-2 or UTF-8.
-       # Accepted values - bestfit, status_400 and status_404.
-       #set-path-unicode-mapping: bestfit
+       # Configures whether plus characters are converted to spaces
+       # when decoding URL-encoded strings.
+       #query-plusspace-decode: yes
+
+       #   response-body-decompress-layer-limit:
+       #                           Limit to how many layers of compression will be
+       #                           decompressed. Defaults to 2.
+
+       #   uri-include-all:        Include all parts of the URI. By default the
+       #                           'scheme', username/password, hostname and port
+       #                           are excluded.
+
+       #   meta-field-limit:       Hard size limit for request and response size
+       #                           limits.
+
+       # inspection limits
+           request-body-minimal-inspect-size: 32kb
+           request-body-inspect-window: 4kb
+           response-body-minimal-inspect-size: 40kb
+           response-body-inspect-window: 16kb
+
+       # auto will use http-body-inline mode in IPS mode, yes or no set it statically
+           http-body-inline: auto
+
+       # Decompress SWF files.
+       # 2 types: 'deflate', 'lzma', 'both' will decompress deflate and lzma
+       # compress-depth:
+       # Specifies the maximum amount of data to decompress,
+       # set 0 for unlimited.
+       # decompress-depth:
+       # Specifies the maximum amount of decompressed data to obtain,
+       # set 0 for unlimited.
+           swf-decompression:
+             enabled: yes
+             type: both
+             compress-depth: 0
+             decompress-depth: 0
+
+       # Take a random value for inspection sizes around the specified value.
+       # This lower the risk of some evasion technics but could lead
+       # detection change between runs. It is set to 'yes' by default.
+       #randomize-inspection-sizes: yes
+       # If randomize-inspection-sizes is active, the value of various
+       # inspection size will be choosen in the [1 - range%, 1 + range%]
+       # range
+       # Default value of randomize-inspection-range is 10.
+       #randomize-inspection-range: 10
+
+       # Can disable LZMA decompression
+       #lzma-enabled: yes
+       # Memory limit usage for LZMA decompression dictionary
+       # Data is decompressed until dictionary reaches this size
+       #lzma-memlimit: 1 Mb
+       # Maximum decompressed size with a compression ratio
+       # above 2048 (only reachable by LZMA)
+       #compression-bomb-limit: 1 Mb
+
+Other parameters are customizable from Suricata.
+::
+
+      #   double-decode-path:     Double decode path section of the URI
+      #   double-decode-query:    Double decode query section of the URI
 
 Configure SMB (Rust)
 ~~~~~~~~~~~~~~~~~~~~

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -818,7 +818,8 @@ app-layer:
           dp: 53
     http:
       enabled: yes
-      # memcap: 64mb
+      # memcap:                   Maximum memory capacity for http
+      #                           Default is unlimited, value can be such as 64mb
 
       # default-config:           Used when no server-config matches
       #   personality:            List of personalities used by default
@@ -826,37 +827,15 @@ app-layer:
       #                           by http_client_body & pcre /P option.
       #   response-body-limit:    Limit reassembly of response body for inspection
       #                           by file_data, http_server_body & pcre /Q option.
-      #   double-decode-path:     Double decode path section of the URI
-      #   double-decode-query:    Double decode query section of the URI
-      #   response-body-decompress-layer-limit:
-      #                           Limit to how many layers of compression will be
-      #                           decompressed. Defaults to 2.
       #
+      #   For advanced options, see the user guide
+
+
       # server-config:            List of server configurations to use if address matches
       #   address:                List of IP addresses or networks for this block
       #   personalitiy:           List of personalities used by this block
-      #   request-body-limit:     Limit reassembly of request body for inspection
-      #                           by http_client_body & pcre /P option.
-      #   response-body-limit:    Limit reassembly of response body for inspection
-      #                           by file_data, http_server_body & pcre /Q option.
-      #   double-decode-path:     Double decode path section of the URI
-      #   double-decode-query:    Double decode query section of the URI
       #
-      #   uri-include-all:        Include all parts of the URI. By default the
-      #                           'scheme', username/password, hostname and port
-      #                           are excluded. Setting this option to true adds
-      #                           all of them to the normalized uri as inspected
-      #                           by http_uri, urilen, pcre with /U and the other
-      #                           keywords that inspect the normalized uri.
-      #                           Note that this does not affect http_raw_uri.
-      #                           Also, note that including all was the default in
-      #                           1.4 and 2.0beta1.
-      #
-      #   meta-field-limit:       Hard size limit for request and response size
-      #                           limits. Applies to request line and headers,
-      #                           response line and headers. Does not apply to
-      #                           request or response bodies. Default is 18k.
-      #                           If this limit is reached an event is raised.
+      #                           Then, all the fields from default-config can be overloaded
       #
       # Currently Available Personalities:
       #   Minimal, Generic, IDS (default), IIS_4_0, IIS_5_0, IIS_5_1, IIS_6_0,
@@ -910,11 +889,14 @@ app-layer:
            double-decode-path: no
            double-decode-query: no
 
+           # Can disable LZMA decompression
            #lzma-enabled: yes
-           # LZMA decompression memory limit.
-           #lzma-memlimit: 1mb
-           # Compression bomb output limit.
-           #compression-bomb-limit: 1mb
+           # Memory limit usage for LZMA decompression dictionary
+           # Data is decompressed until dictionary reaches this size
+           #lzma-memlimit: 1 Mb
+           # Maximum decompressed size with a compression ratio
+           # above 2048 (only LZMA can reach this ratio, deflate cannot)
+           #compression-bomb-limit: 1 Mb
 
          server-config:
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3207

Describe changes:
- Updates suricata.yaml template with more comments about every keyword about HTTP parsing
- Updates Userguide about configuration of suricata.yaml to have the good list of keywords about HTTP parsing

Modifies #4255 with doc review corrections