### PR TITLE
remove obsolete msn protocol detection/parser

### DIFF
--- a/doc/userguide/rules/differences-from-snort.rst
+++ b/doc/userguide/rules/differences-from-snort.rst
@@ -21,7 +21,6 @@ Automatic Protocol Detection
    -  imap (detection only by default; no parsing)
    -  ftp
    -  modbus (disabled by default; minimalist probe parser; can lead to false positives)
-   -  msn (detection only by default; no parsing)
    -  smb
    -  smb2 (disabled internally inside the engine)
    -  smtp

--- a/doc/userguide/rules/intro.rst
+++ b/doc/userguide/rules/intro.rst
@@ -73,7 +73,6 @@ you can pick from. These are:
 * ssh
 * smtp
 * imap
-* msn
 * modbus (disabled by default)
 * dnp3 (disabled by default)
 * enip (disabled by default)

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -837,8 +837,6 @@ static void AppLayerProtoDetectPrintProbingParsers(AppLayerProtoDetectProbingPar
                         printf("            alproto: ALPROTO_SSH\n");
                     else if (pp_pe->alproto == ALPROTO_IMAP)
                         printf("            alproto: ALPROTO_IMAP\n");
-                    else if (pp_pe->alproto == ALPROTO_MSN)
-                        printf("            alproto: ALPROTO_MSN\n");
                     else if (pp_pe->alproto == ALPROTO_JABBER)
                         printf("            alproto: ALPROTO_JABBER\n");
                     else if (pp_pe->alproto == ALPROTO_SMB)
@@ -912,8 +910,6 @@ static void AppLayerProtoDetectPrintProbingParsers(AppLayerProtoDetectProbingPar
                     printf("            alproto: ALPROTO_SSH\n");
                 else if (pp_pe->alproto == ALPROTO_IMAP)
                     printf("            alproto: ALPROTO_IMAP\n");
-                else if (pp_pe->alproto == ALPROTO_MSN)
-                    printf("            alproto: ALPROTO_MSN\n");
                 else if (pp_pe->alproto == ALPROTO_JABBER)
                     printf("            alproto: ALPROTO_JABBER\n");
                 else if (pp_pe->alproto == ALPROTO_SMB)

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1553,20 +1553,6 @@ void AppLayerParserRegisterProtocolParsers(void)
                   "imap");
     }
 
-    /** MSN Messenger */
-    AppLayerProtoDetectRegisterProtocol(ALPROTO_MSN, "msn");
-    if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", "msn")) {
-        if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_MSN,
-                                    "msn", 10, 6, STREAM_TOSERVER) < 0)
-        {
-            SCLogInfo("msn proto registration failure");
-            exit(EXIT_FAILURE);
-        }
-    } else {
-        SCLogInfo("Protocol detection and parser disabled for %s protocol.",
-                  "msn");
-    }
-
     ValidateParsers();
     return;
 }

--- a/src/app-layer-protos.c
+++ b/src/app-layer-protos.c
@@ -51,9 +51,6 @@ const char *AppProtoToString(AppProto alproto)
         case ALPROTO_IMAP:
             proto_name = "imap";
             break;
-        case ALPROTO_MSN:
-            proto_name = "msn";
-            break;
         case ALPROTO_JABBER:
             proto_name = "jabber";
             break;
@@ -138,7 +135,6 @@ AppProto StringToAppProto(const char *proto_name)
     if (strcmp(proto_name,"tls")==0) return ALPROTO_TLS;
     if (strcmp(proto_name,"ssh")==0) return ALPROTO_SSH;
     if (strcmp(proto_name,"imap")==0) return ALPROTO_IMAP;
-    if (strcmp(proto_name,"msn")==0) return ALPROTO_MSN;
     if (strcmp(proto_name,"jabber")==0) return ALPROTO_JABBER;
     if (strcmp(proto_name,"smb")==0) return ALPROTO_SMB;
     if (strcmp(proto_name,"dcerpc")==0) return ALPROTO_DCERPC;

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -33,7 +33,6 @@ enum AppProtoEnum {
     ALPROTO_TLS, /* SSLv2, SSLv3 & TLSv1 */
     ALPROTO_SSH,
     ALPROTO_IMAP,
-    ALPROTO_MSN,
     ALPROTO_JABBER,
     ALPROTO_SMB,
     ALPROTO_DCERPC,

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -785,8 +785,6 @@ app-layer:
         content-inspect-window: 4096
     imap:
       enabled: detection-only
-    msn:
-      enabled: detection-only
     smb:
       enabled: yes
       detection-ports:


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

https://redmine.openinfosecfoundation.org/issues/3216

Describe changes:
- Remove all code from obsolete MSN protocol detection/parser

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

