### PR TITLE
configure.ac: fix --disable-geoip

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2143,7 +2143,7 @@
   # libmaxminddb
     AC_ARG_ENABLE(geoip,
 	        AS_HELP_STRING([--enable-geoip],[Enable GeoIP2 support]),
-	        [ enable_geoip="yes"],
+	        [ enable_geoip="$enableval"],
 	        [ enable_geoip="no"])
     AC_ARG_WITH(libmaxminddb_includes,
             [  --with-libmaxminddb-includes=DIR  libmaxminddb include directory],


### PR DESCRIPTION
$enableval should be used to know if the user has passed --enable-geoip
or --disable-geoip

Link to redmine ticket: https://redmine.openinfosecfoundation.org/issues/3223

Fixes:
 - http://autobuild.buildroot.org/results/a7a34f760ae5fe0922fdb720b8234dbcd85ed222

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>