### PR TITLE
build/configure cleanups - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,12 @@
     fi
     AM_CONDITIONAL([HAVE_PYTHON], [test "x$enable_python" = "xyes"])
 
+    # Get the Python major version. This is only for information
+    # messages displayed during configure.
+    if test "x$HAVE_PYTHON" != "xno"; then
+       pymv="$($HAVE_PYTHON -c 'import sys; print(sys.version_info.major);')"
+    fi
+
     # Check for python-distutils (setup).
     have_python_distutils="no"
     if test "x$enable_python" = "xyes"; then
@@ -139,7 +145,7 @@
        echo "    Warning: Python distutils not found. Python tools will"
        echo "        not be installed."
        echo ""
-       echo "    Ubuntu/Debian: apt install `basename ${HAVE_PYTHON}`-distutils"
+       echo "    Please install the distutils module for Python ${pymv}."
        echo ""
     fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -145,7 +145,8 @@
        echo "    Warning: Python distutils not found. Python tools will"
        echo "        not be installed."
        echo ""
-       echo "    Please install the distutils module for Python ${pymv}."
+       echo "    Install the distutils module for Python ${pymv} to enable"
+       echo "    the Python tools."
        echo ""
     fi
 
@@ -1523,11 +1524,10 @@
         if test "$have_python_yaml" != "yes"; then
 	    echo ""
 	    echo "    Warning: suricata-update will not be installed as the"
-	    echo "        depedency python-yaml is not installed."
+	    echo "        Python yaml module is not installed.."
 	    echo ""
-	    echo "    Debian/Ubuntu: apt install python-yaml"
-	    echo "    Fedora: dnf install python-yaml"
-	    echo "    CentOS/RHEL: yum install python-yaml"
+            echo "    Install the yaml module for Python ${pymv} to enable"
+            echo "    suricata-update."
 	    echo
 	else
             SURICATA_UPDATE_DIR="suricata-update"

--- a/configure.ac
+++ b/configure.ac
@@ -2407,6 +2407,23 @@ fi
     else
       AC_SUBST([CARGO_HOME], [$CARGO_HOME])
     fi
+
+    # Check for rustup. RUSTUP_HOME needs to be set if rustup is in
+    # use, and a user uses sudo (depending on configuration), or su to
+    # perform the install
+    rustup_home="no"
+    if test "x$RUSTUP_HOME" != "x"; then
+        rustup_home="$RUSTUP_HOME"
+    else
+        AC_PATH_PROG(have_rustup, rustup, "no")
+        if test "x$have_rustup" != "xno"; then
+            rustup_home=$($have_rustup show home)
+        fi
+    fi
+    if test "x$rustup_home" != "xno"; then
+        AC_SUBST([RUSTUP_HOME], [$rustup_home])
+    fi
+
     AC_CHECK_FILES([$srcdir/rust/vendor], [have_rust_vendor="yes"])
     if test "x$have_rust_vendor" = "xyes"; then
       rust_vendor_comment=""

--- a/configure.ac
+++ b/configure.ac
@@ -97,7 +97,6 @@
         exit 1
     fi
 
-    python_version="not set"
     python_path="not set"
 
     AC_ARG_ENABLE(python,
@@ -109,13 +108,15 @@
         AC_PATH_PROGS(HAVE_PYTHON, python3 python2.7 python2 python, "no")
         if test "$HAVE_PYTHON" = "no"; then
             echo
-            echo "   Warning! python not found, you will not be     "
-            echo "   able to install suricatasc unix socket client   "
+            echo "   Warning! Python not found."
+            echo
+            echo "   Python is required for additional tools like"
+            echo "   suricatasc, suricatactl and suricata-update."
+            echo "   It is also required when building from git."
             echo
             enable_python="no"
 	else
 	    python_path="$HAVE_PYTHON"
-	    python_version="$($HAVE_PYTHON --version)"
         fi
     fi
     AM_CONDITIONAL([HAVE_PYTHON], [test "x$enable_python" = "xyes"])
@@ -2589,7 +2590,6 @@ SURICATA_BUILD_CONF="Suricata Configuration:
 
   Python support:                          ${enable_python}
   Python path:                             ${python_path}
-  Python version:                          ${python_version}
   Python distutils                         ${have_python_distutils}
   Python yaml                              ${have_python_yaml}
   Install suricatactl:                     ${install_suricatactl}

--- a/configure.ac
+++ b/configure.ac
@@ -1542,7 +1542,7 @@
     if test "x$enable_python" != "xyes"; then
         install_suricatactl="requires python"
     elif test "x$have_python_distutils" != "xyes"; then
-        install_suricatactl="requires distutils"
+        install_suricatactl="no, requires distutils"
     else
         install_suricatactl="yes"
     fi
@@ -1551,11 +1551,11 @@
     if test "x$have_suricata_update" != "xyes"; then
         install_suricata_update="not bundled"
     elif test "x$enable_python" != "xyes"; then
-        install_suricata_update="requires python"
+        install_suricata_update="no, requires python"
     elif test "x$have_python_distutils" != "xyes"; then
-        install_suricata_update="requires distutils"
+        install_suricata_update="no, requires distutils"
     elif test "x$have_python_yaml" != "xyes"; then
-        install_suricata_update="requires pyyaml"
+        install_suricata_update="no, requires pyyaml"
     else
         install_suricata_update="yes"
     fi

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -34,12 +34,14 @@ endif
 if HAVE_CYGPATH
 	rustpath=`cygpath -a -t mixed $(abs_top_builddir)`
 	cd $(top_srcdir)/rust && \
+		RUSTUP_HOME=$(RUSTUP_HOME) \
 		CARGO_HOME=$(CARGO_HOME) \
 		CARGO_TARGET_DIR="$$rustpath/rust/target" \
 		$(CARGO) build $(RELEASE) $(FROZEN) \
 			--features "$(RUST_FEATURES)"
 else
 	cd $(top_srcdir)/rust && \
+		RUSTUP_HOME=$(RUSTUP_HOME) \
 		CARGO_HOME=$(CARGO_HOME) \
 		CARGO_TARGET_DIR=$(abs_top_builddir)/rust/target \
 		$(CARGO) build $(RELEASE) $(FROZEN) \
@@ -53,14 +55,15 @@ distclean-local: clean-local
 	rm -rf vendor gen Cargo.lock
 
 check:
-	CARGO_HOME=$(CARGO_HOME) $(CARGO) test
+	RUSTUP_HOME=$(RUSTUP_HOME) CARGO_HOME=$(CARGO_HOME) $(CARGO) test
 
 Cargo.lock: Cargo.toml
-	CARGO_HOME=$(CARGO_HOME) $(CARGO) generate-lockfile
+	RUSTUP_HOME=$(RUSTUP_HOME) CARGO_HOME=$(CARGO_HOME) $(CARGO) \
+		generate-lockfile
 
 if HAVE_CARGO_VENDOR
 vendor:
-	CARGO_HOME=$(CARGO_HOME) $(CARGO) vendor > /dev/null
+	RUSTUP_HOME=$(RUSTUP_HOME) CARGO_HOME=$(CARGO_HOME) $(CARGO) vendor > /dev/null
 else
 vendor:
 endif

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -55,7 +55,9 @@ distclean-local: clean-local
 	rm -rf vendor gen Cargo.lock
 
 check:
-	RUSTUP_HOME=$(RUSTUP_HOME) CARGO_HOME=$(CARGO_HOME) $(CARGO) test
+	RUSTUP_HOME=$(RUSTUP_HOME) \
+		CARGO_HOME=$(CARGO_HOME) \
+		$(CARGO) test --features "$(RUST_FEATURES)"
 
 Cargo.lock: Cargo.toml
 	RUSTUP_HOME=$(RUSTUP_HOME) CARGO_HOME=$(CARGO_HOME) $(CARGO) \

--- a/suricata-update/Makefile.am
+++ b/suricata-update/Makefile.am
@@ -2,6 +2,10 @@ if HAVE_PYTHON
 if HAVE_PYTHON_DISTUTILS
 if HAVE_PYTHON_YAML
 
+all-local:
+	cd $(srcdir) && \
+		$(HAVE_PYTHON) setup.py build --build-base $(abs_builddir)
+
 install-exec-local:
 	cd $(srcdir) && \
 		$(HAVE_PYTHON) setup.py build --build-base $(abs_builddir) \


### PR DESCRIPTION
Python related:

- Fixed Python version being empty on Python 2 systems by just removing this information, its not required.
- Use a small Python script to get the major version, but its used in informational messages only.
- Remove instructions on how to install specific Python modules with the distribution package manager (yum, apt, etc) and give a more generic instruction including the major version of Python.  The matrix of package names is increasing, I think this is simpler. We could have a Wiki page with more detail.

Rust:

With a strict sudo configuration (where -E won't work) the 'make; sudo make
install' pattern doesn't work when Rust is installed with rustup. This happens
on RedHat 8 for example. To fix this, detect the rustup home during configure
and set the RUSTUP_HOME variable so all the information required to complete
the build with sudo is in the generated Makefile.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/398
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/754