### PR TITLE
cleanups: build with spaces, rustup for sudo - v5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2407,6 +2407,26 @@ fi
     else
       AC_SUBST([CARGO_HOME], [$CARGO_HOME])
     fi
+
+    # Check for rustup. RUSTUP_HOME needs to be set if rustup is in
+    # use, and a user uses sudo (depending on configuration), or su to
+    # perform the install
+    rustup_home_path="no"
+    if test "x$RUSTUP_HOME" != "x"; then
+        rustup_home_path="$RUSTUP_HOME"
+    else
+        AC_PATH_PROG(have_rustup, rustup, "no")
+        if test "x$have_rustup" != "xno"; then
+            rustup_home_path=$($have_rustup show home 2>/dev/null || echo "no")
+        fi
+    fi
+    rustup_home=""
+    if test "x$rustup_home_path" != "xno"; then
+        rustup_home="RUSTUP_HOME=\$(RUSTUP_HOME_PATH)"
+    fi
+    AC_SUBST([RUSTUP_HOME_PATH], [$rustup_home_path])
+    AC_SUBST([rustup_home])
+
     AC_CHECK_FILES([$srcdir/rust/vendor], [have_rust_vendor="yes"])
     if test "x$have_rust_vendor" = "xyes"; then
       rust_vendor_comment=""

--- a/configure.ac
+++ b/configure.ac
@@ -124,7 +124,7 @@
     # Get the Python major version. This is only for information
     # messages displayed during configure.
     if test "x$HAVE_PYTHON" != "xno"; then
-       pymv="$($HAVE_PYTHON -c 'import sys; print(sys.version_info.major);')"
+       pymv="$($HAVE_PYTHON -c 'import sys; print(sys.version_info[[0]]);')"
     fi
 
     # Check for python-distutils (setup).

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -7,11 +7,11 @@ if HAVE_PYTHON
 if HAVE_PYTHON_DISTUTILS
 all-local:
 	cd $(srcdir) && \
-		$(HAVE_PYTHON) setup.py build --build-base $(abs_builddir)
+		$(HAVE_PYTHON) setup.py build --build-base "$(abs_builddir)"
 
 install-exec-local:
 	cd $(srcdir) && \
-		$(HAVE_PYTHON) setup.py build --build-base $(abs_builddir) \
+		$(HAVE_PYTHON) setup.py build --build-base "$(abs_builddir)" \
 		install --prefix $(DESTDIR)$(prefix)
 
 uninstall-local:
@@ -24,7 +24,7 @@ uninstall-local:
 clean-local:
 	cd $(srcdir) && \
 		$(HAVE_PYTHON) setup.py clean \
-		--build-base $(abs_builddir)
+		--build-base "$(abs_builddir)"
 	rm -rf scripts-* lib* build
 	find . -name \*.pyc -print0 | xargs -0 rm -f
 

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -34,14 +34,14 @@ endif
 if HAVE_CYGPATH
 	rustpath=`cygpath -a -t mixed $(abs_top_builddir)`
 	cd $(top_srcdir)/rust && \
-		CARGO_HOME=$(CARGO_HOME) \
+		CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$$rustpath/rust/target" \
 		$(CARGO) build $(RELEASE) $(FROZEN) \
 			--features "$(RUST_FEATURES)"
 else
 	cd $(top_srcdir)/rust && \
-		CARGO_HOME=$(CARGO_HOME) \
-		CARGO_TARGET_DIR=$(abs_top_builddir)/rust/target \
+		CARGO_HOME="$(CARGO_HOME)" \
+		CARGO_TARGET_DIR="$(abs_top_builddir)/rust/target" \
 		$(CARGO) build $(RELEASE) $(FROZEN) \
 			--features "$(RUST_FEATURES)"
 endif
@@ -53,14 +53,14 @@ distclean-local: clean-local
 	rm -rf vendor gen Cargo.lock
 
 check:
-	CARGO_HOME=$(CARGO_HOME) $(CARGO) test
+	CARGO_HOME="$(CARGO_HOME)" $(CARGO) test
 
 Cargo.lock: Cargo.toml
-	CARGO_HOME=$(CARGO_HOME) $(CARGO) generate-lockfile
+	CARGO_HOME="$(CARGO_HOME)" $(CARGO) generate-lockfile
 
 if HAVE_CARGO_VENDOR
 vendor:
-	CARGO_HOME=$(CARGO_HOME) $(CARGO) vendor > /dev/null
+	CARGO_HOME="$(CARGO_HOME)" $(CARGO) vendor > /dev/null
 else
 vendor:
 endif

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -33,13 +33,13 @@ if HAVE_PYTHON
 endif
 if HAVE_CYGPATH
 	rustpath=`cygpath -a -t mixed $(abs_top_builddir)`
-	cd $(top_srcdir)/rust && \
+	cd $(top_srcdir)/rust && @rustup_home@ \
 		CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$$rustpath/rust/target" \
 		$(CARGO) build $(RELEASE) $(FROZEN) \
 			--features "$(RUST_FEATURES)"
 else
-	cd $(top_srcdir)/rust && \
+	cd $(top_srcdir)/rust && @rustup_home@ \
 		CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$(abs_top_builddir)/rust/target" \
 		$(CARGO) build $(RELEASE) $(FROZEN) \
@@ -53,14 +53,15 @@ distclean-local: clean-local
 	rm -rf vendor gen Cargo.lock
 
 check:
-	CARGO_HOME="$(CARGO_HOME)" $(CARGO) test
+	CARGO_HOME="$(CARGO_HOME)" @rustup_home@ $(CARGO) test
 
 Cargo.lock: Cargo.toml
-	CARGO_HOME="$(CARGO_HOME)" $(CARGO) generate-lockfile
+	CARGO_HOME="$(CARGO_HOME)" @rustup_home@ $(CARGO) \
+		generate-lockfile
 
 if HAVE_CARGO_VENDOR
 vendor:
-	CARGO_HOME="$(CARGO_HOME)" $(CARGO) vendor > /dev/null
+	CARGO_HOME="$(CARGO_HOME)" @rustup_home@ $(CARGO) vendor > /dev/null
 else
 vendor:
 endif

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -53,7 +53,8 @@ distclean-local: clean-local
 	rm -rf vendor gen Cargo.lock
 
 check:
-	CARGO_HOME="$(CARGO_HOME)" @rustup_home@ $(CARGO) test
+	CARGO_HOME="$(CARGO_HOME)" @rustup_home@
+		$(CARGO) test --features "$(RUST_FEATURES)"
 
 Cargo.lock: Cargo.toml
 	CARGO_HOME="$(CARGO_HOME)" @rustup_home@ $(CARGO) \

--- a/suricata-update/Makefile.am
+++ b/suricata-update/Makefile.am
@@ -8,7 +8,7 @@ all-local:
 
 install-exec-local:
 	cd $(srcdir) && \
-		$(HAVE_PYTHON) setup.py build --build-base $(abs_builddir) \
+		$(HAVE_PYTHON) setup.py build --build-base "$(abs_builddir)" \
 		install --prefix $(DESTDIR)$(prefix)
 
 uninstall-local:
@@ -19,7 +19,7 @@ uninstall-local:
 clean-local:
 	cd $(srcdir) && \
 		$(HAVE_PYTHON) setup.py clean \
-		--build-base $(abs_builddir)
+		--build-base "$(abs_builddir)"
 	rm -rf scripts-* lib* build
 	find . -name \*.pyc -print0 | xargs -0 rm -f
 


### PR DESCRIPTION
Fix builds where the source path has spaces in it. Fixes were required for
Python and Rust.

Previous PR:
https://github.com/OISF/suricata/pull/4233

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/2668

Fix installs in strict sudo environments where the following pattern
may be used: make && sudo make install. This requires setting the
RUSTUP_HOME variable if rustup is being used. If a system wide
Rust installation is in use, this is not an issue.

Previous PR:
https://github.com/OISF/suricata/pull/4289

Changes from last PR:
- Handle "rustup show home" failing.
- Use an automake substitution to limit the chance of
  the Makefile output breaking the build (for example
  setting of RUSTUP_HOME to empty.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/399
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/755