### PR TITLE
Don't run suricata-update if not installed - v1

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,8 +37,8 @@ if INSTALL_SURICATA_UPDATE
 		--suricata-conf $(DESTDIR)$(sysconfdir)/suricata/suricata.yaml \
 		--no-test --no-reload
 else
-	echo "error: rules not installed as suricata-update not available"
-	exit 1
+	@echo "error: rules not installed as suricata-update not available"
+	@exit 1
 endif
 	@echo ""
 	@echo "You can now start suricata by running as root something like:"

--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,7 @@ install-conf:
 	install -m 770 -d "$(DESTDIR)$(e_localstatedir)"
 
 install-rules:
-if HAVE_SURICATA_UPDATE
+if INSTALL_SURICATA_UPDATE
 	LD_LIBRARY_PATH=$(libdir) $(DESTDIR)$(bindir)/suricata-update \
 		--suricata $(DESTDIR)$(bindir)/suricata \
 		--suricata-conf $(DESTDIR)$(sysconfdir)/suricata/suricata.yaml \

--- a/configure.ac
+++ b/configure.ac
@@ -1517,8 +1517,6 @@
       AC_CHECK_FILE([$srcdir/suricata-update/setup.py], [
           have_suricata_update="yes"], [])
     fi
-    AM_CONDITIONAL([HAVE_SURICATA_UPDATE],
-        [test "x$have_suricata_update" != "xno"])
 
     if test "$have_suricata_update" = "yes"; then
         if test "$have_python_yaml" != "yes"; then
@@ -1559,6 +1557,9 @@
     else
         install_suricata_update="yes"
     fi
+
+    AM_CONDITIONAL([INSTALL_SURICATA_UPDATE],
+        [test "x$install_suricata_update" = "xyes"])
 
   # libhtp
     AC_ARG_ENABLE(non-bundled-htp,


### PR DESCRIPTION
Current make install-rules will attempt to run Suricata-Update if
its bundled, but not installed. This can happen when a required
Python module is detected.

Change the check to only run if Suricata Update was actually installed.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/400
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/756
