### PR TITLE
Some last minute fixups...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
     AC_CONFIG_HEADERS([config.h])
     AC_CONFIG_SRCDIR([src/suricata.c])
     AC_CONFIG_MACRO_DIR(m4)
-    AM_INIT_AUTOMAKE
+    AM_INIT_AUTOMAKE([tar-ustar])
 
     AC_LANG([C])
     AC_PROG_CC_C99

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -207,11 +207,51 @@ In the ``custom`` option values from both columns can be used. The
 DNS
 ~~~
 
-DNS records are logged one log record per query/answer record.
+.. note:: As of Suricata 5.0, the version 2 format of the EVE DNS log
+          is the default.
+
+DNS records are logged as one entry for the request, and one entry for
+the response.
 
 YAML::
 
         - dns:
+            # As of Suricata 5.0, version 2 of the eve dns output
+            # format is the default.
+            #version: 2
+
+            # Enable/disable this logger. Default: enabled.
+            #enabled: yes
+
+            # Control logging of requests and responses:
+            # - requests: enable logging of DNS queries
+            # - responses: enable logging of DNS answers
+            # By default both requests and responses are logged.
+            #requests: no
+            #responses: no
+
+            # Format of answer logging:
+            # - detailed: array item per answer
+            # - grouped: answers aggregated by type
+            # Default: all
+            #formats: [detailed, grouped]
+
+            # Types to log, based on the query type.
+            # Default: all.
+            #types: [a, aaaa, cname, mx, ns, ptr, txt]
+
+DNS v1 Format
+~~~~~~~~~~~~~
+
+The version 1 DNS output has been obsoleted by the version 2 output
+above. The v1 format logs a record per answer in the response possibly
+resulting in much more than 2 log records per request and response.
+
+YAML::
+
+        - dns:
+            # Must set the version to 1 to get the old style format.
+            version: 1
             # control logging of queries and answers
             # default yes, no to disable
             query: yes     # enable logging of DNS queries

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -200,16 +200,14 @@ outputs:
         - dns:
             # This configuration uses the new DNS logging format,
             # the old configuration is still available:
-            # http://suricata.readthedocs.io/en/latest/configuration/suricata-yaml.html#eve-extensible-event-format
-            # Use version 2 logging with the new format:
-            # DNS answers will be logged in one single event
-            # rather than an event for each of it.
-            # Without setting a version the version
-            # will fallback to 1 for backwards compatibility.
-            version: 2
+            # https://suricata.readthedocs.io/en/latest/output/eve/eve-json-output.html#dns-v1-format
+
+            # As of Suricata 5.0, version 2 of the eve dns output
+            # format is the default.
+            #version: 2
 
             # Enable/disable this logger. Default: enabled.
-            #enabled: no
+            #enabled: yes
 
             # Control logging of requests and responses:
             # - requests: enable logging of DNS queries
@@ -224,8 +222,8 @@ outputs:
             # Default: all
             #formats: [detailed, grouped]
 
-            # Answer types to log.
-            # Default: all
+            # Types to log, based on the query type.
+            # Default: all.
             #types: [a, aaaa, cname, mx, ns, ptr, txt]
         - tls:
             extended: yes     # enable this for extended logging information


### PR DESCRIPTION
Document EVE DNS v2 as being the default, and include its default
configuration in the manual.

Rename the current EVE DNS section to v1 format.

The idea here is to commit us to v2 being the new default for 5.0,
and documenting this as such.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
coming...