### PR TITLE
Mini fixes 20191012

### DIFF
--- a/doc/userguide/rules/base64-keywords.rst
+++ b/doc/userguide/rules/base64-keywords.rst
@@ -8,7 +8,7 @@ This is achieved by using two keywords, ``base64_decode`` and ``base64_data``. B
 base64_decode
 -------------
 
-Decodes base64_data from a buffer and makes it available for the base64_data function.
+Decodes base64 data from a buffer and makes it available for the base64_data function.
 
 Syntax::
 

--- a/doc/userguide/rules/base64-keywords.rst
+++ b/doc/userguide/rules/base64-keywords.rst
@@ -47,5 +47,14 @@ Example::
     http_uri = "GET /en/somestring&dGVzdAo=&not_base64"
 
     Rule:
-    alert http any any -> any any (msg:"Example"; content:"somestring"; base64_decode:bytes 8, offset 1, relative; \
-        http_uri; base64_content; content:"test"; sid:10001; rev:1;)
+    alert http any any -> any any (msg:"Example"; http.uri; content:"somestring"; \
+         base64_decode:bytes 8, offset 1, relative; \
+         base64_data; content:"test"; sid:10001; rev:1;)
+
+    Buffer content:
+    http_uri = "GET /en/somestring&dGVzdAo=&not_base64"
+
+    Rule:
+    alert http any any -> any any (msg:"Example"; content:"somestring"; http_uri; \
+         base64_decode:bytes 8, offset 1, relative; \
+         base64_data; content:"test"; sid:10001; rev:1;)

--- a/src/detect-base64-data.c
+++ b/src/detect-base64-data.c
@@ -33,7 +33,7 @@ void DetectBase64DataRegister(void)
     sigmatch_table[DETECT_BASE64_DATA].desc =
         "Content match base64 decoded data.";
     sigmatch_table[DETECT_BASE64_DATA].url =
-        DOC_URL DOC_VERSION "/rules/payload-keywords.html#base64-data";
+        DOC_URL DOC_VERSION "/rules/base64-keywords.html#base64-data";
     sigmatch_table[DETECT_BASE64_DATA].Setup = DetectBase64DataSetup;
     sigmatch_table[DETECT_BASE64_DATA].RegisterTests =
         DetectBase64DataRegisterTests;

--- a/src/detect-base64-decode.c
+++ b/src/detect-base64-decode.c
@@ -42,7 +42,7 @@ void DetectBase64DecodeRegister(void)
     sigmatch_table[DETECT_BASE64_DECODE].desc =
         "Decodes base64 encoded data.";
     sigmatch_table[DETECT_BASE64_DECODE].url =
-        DOC_URL DOC_VERSION "/rules/payload-keywords.html#base64-decode";
+        DOC_URL DOC_VERSION "/rules/base64-keywords.html#base64-decode";
     sigmatch_table[DETECT_BASE64_DECODE].Setup = DetectBase64DecodeSetup;
     sigmatch_table[DETECT_BASE64_DECODE].Free = DetectBase64DecodeFree;
     sigmatch_table[DETECT_BASE64_DECODE].RegisterTests =


### PR DESCRIPTION
Some base64 doc improvements.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Fix base64 doc
- Fix link to doc in list keywords

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/501
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/277

