### PR TITLE
ssl/tls: Fix operation of ssl_version negation (!)

### DIFF
--- a/src/detect-ssl-version.h
+++ b/src/detect-ssl-version.h
@@ -41,7 +41,6 @@ enum {
 
 typedef struct SSLVersionData_ {
     uint16_t ver; /** ssl version to match */
-    uint8_t flags;
 } SSLVersionData;
 
 typedef struct DetectSslVersionData_ {


### PR DESCRIPTION
- [O] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [O] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [O] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3220

Describe changes:
- Fix ssl_version negation operation
- before: !sslv2 has no effect (meaningless)
- after: !sslv2 means except sslv2

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

