### PR TITLE
detect: return failure instead of aborting

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -533,7 +533,9 @@ int DetectAddressParseString(DetectAddress *dd, const char *str)
         str++;
 
     /* shouldn't see 'any' here */
-    BUG_ON(strcasecmp(str, "any") == 0);
+    if(strcasecmp(str, "any") == 0) {
+        return -1;
+    }
 
     strlcpy(ipstr, str, sizeof(ipstr));
     SCLogDebug("str %s", str);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- `DetectAddressParseString` returns failure instead of aborting

Found by fuzzing

