### PR TITLE
signature: leak fix in DetectAddressParse2

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -911,8 +911,12 @@ static int DetectAddressParse2(const DetectEngineCtx *de_ctx,
                         DetectAddressPrint(tmp_ad);
                     }
 #endif
-                    if (DetectAddressMergeNot(&tmp_gh, &tmp_ghn) < 0)
+                    if (DetectAddressMergeNot(&tmp_gh, &tmp_ghn) < 0) {
+                        DetectAddressHeadCleanup(&tmp_ghn);
+                        DetectAddressHeadCleanup(&tmp_gh);
                         goto error;
+                    }
+                    DetectAddressHeadCleanup(&tmp_ghn);
 
                     SCLogDebug("merged succesfully");
 
@@ -922,6 +926,7 @@ static int DetectAddressParse2(const DetectEngineCtx *de_ctx,
                         tmp_ad2 = DetectAddressCopy(tmp_ad);
                         if (tmp_ad2 == NULL) {
                             SCLogDebug("DetectAddressCopy failed");
+                            DetectAddressHeadCleanup(&tmp_gh);
                             goto error;
                         }
                         DetectAddressPrint(tmp_ad2);
@@ -934,6 +939,7 @@ static int DetectAddressParse2(const DetectEngineCtx *de_ctx,
                         tmp_ad2 = DetectAddressCopy(tmp_ad);
                         if (tmp_ad2 == NULL) {
                             SCLogDebug("DetectAddressCopy failed");
+                            DetectAddressHeadCleanup(&tmp_gh);
                             goto error;
                         }
                         DetectAddressPrint(tmp_ad2);
@@ -941,7 +947,6 @@ static int DetectAddressParse2(const DetectEngineCtx *de_ctx,
                     }
 
                     DetectAddressHeadCleanup(&tmp_gh);
-                    DetectAddressHeadCleanup(&tmp_ghn);
                 }
                 n_set = 0;
             }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Fixes memory leaks from `DetectAddressParse2` : the temporary structures must be cleaned even if there is an error

Found by fuzzing