### PR TITLE
eve/dns: don't log warning if dns log version not set - v1

### DIFF
--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -510,28 +510,36 @@ static DnsVersion JsonDnsParseVersion(ConfNode *conf)
 
     DnsVersion version = DNS_VERSION_DEFAULT;
     intmax_t config_version;
-    if (ConfGetChildValueInt(conf, "version", &config_version)) {
-        switch(config_version) {
-            case 1:
-                version = DNS_VERSION_1;
-                break;
-            case 2:
-                version = DNS_VERSION_2;
-                break;
-            default:
-                SCLogWarning(SC_ERR_INVALID_ARGUMENT,
-                        "invalid eve-log dns version option: %"PRIuMAX", "
-                        "forcing it to version %u",
-                        config_version, DNS_VERSION_DEFAULT);
-                version = DNS_VERSION_DEFAULT;
-                break;
+    const ConfNode *has_version = ConfNodeLookupChild(conf, "version");
+
+    if (has_version != NULL) {
+        bool invalid = false;
+        if (ConfGetChildValueInt(conf, "version", &config_version)) {
+            switch(config_version) {
+                case 1:
+                    version = DNS_VERSION_1;
+                    break;
+                case 2:
+                    version = DNS_VERSION_2;
+                    break;
+                default:
+                    invalid = true;
+                    break;
+            }
+        } else {
+            invalid = true;
+        }
+        if (invalid) {
+            SCLogWarning(SC_ERR_INVALID_ARGUMENT,
+                    "invalid eve-log dns version option: %s, "
+                    "defaulting to version %u",
+                    has_version->val, version);
         }
     } else {
-        SCLogWarning(SC_ERR_INVALID_ARGUMENT,
-                "eve-log dns version not found, forcing it to version %u",
-                DNS_VERSION_DEFAULT);
-        version = DNS_VERSION_DEFAULT;
+        SCLogConfig("eve-log dns version not set, defaulting to version %u",
+                version);
     }
+
     return version;
 }
 


### PR DESCRIPTION
If the DNS log version is not set, we default to v2. This should
not be warning, but better logged at the config level.

A warning will still be logged if the value is set but is not
1 or 2.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/402
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/758
