### PR TITLE
doc: removal of disable-rust and path typo for suricatasc

### DIFF
--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -57,10 +57,6 @@ Common configure options
 
     Enables GeoIP support for detection.
 
-.. option:: --disable-rust
-
-    Disables Rust support. Rust support is enabled by default if rustc/cargo
-    are available.
 
 Dependencies
 ^^^^^^^^^^^^

--- a/doc/userguide/unix-socket.rst
+++ b/doc/userguide/unix-socket.rst
@@ -50,7 +50,7 @@ example to write custom scripts:
 
 Commands in standard running mode
 ---------------------------------
-You may need to install suricatasc if you have not done so, running the following command from scripts/suricatasc
+You may need to install suricatasc if you have not done so, running the following command from python/suricatasc
 
 ::
 


### PR DESCRIPTION
doc: removal of outdated information (disable-rust, suricatasc python path),
since 5.0.0, rust is mandatory to build suricata.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- removal a few details from doc

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

