### PR TITLE
[RFC] conf: add value checks for datasets hash/prealloc

### DIFF
--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -204,6 +204,19 @@ static void THashDataFree(THashTableContext *ctx, THashData *h)
 #define GET_VAR(prefix,name) \
     snprintf(varname, sizeof(varname), "%s.%s", (prefix), (name))
 
+static void THashConfigValidate(const char *confvalue, char *varname)
+{
+  int varlen = strlen(confvalue);
+  for (int i=0; i<varlen; i++)
+    if (!isdigit(confvalue[i]))
+    {
+      SCLogError(SC_ERR_SIZE_PARSE, "Error parsing %s "
+                 "from key %s. Killing Engine",
+                 confvalue, varname);
+      exit(EXIT_FAILURE);
+    }
+}
+
 /** \brief initialize the configuration
  *  \warning Not thread safe */
 static void THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
@@ -230,6 +243,9 @@ static void THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
     GET_VAR(cnf_prefix, "hash-size");
     if ((ConfGet(varname, &conf_val)) == 1)
     {
+        /* validate hash-size value is a numerical value */
+        THashConfigValidate(conf_val, varname);
+
         if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             ctx->config.hash_size = configval;
@@ -239,6 +255,9 @@ static void THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
     GET_VAR(cnf_prefix, "prealloc");
     if ((ConfGet(varname, &conf_val)) == 1)
     {
+        /* validate prealloc value is a numerical value */
+        THashConfigValidate(conf_val, varname);
+
         if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             ctx->config.prealloc = configval;


### PR DESCRIPTION
Signed-off-by: jason taylor <jtfas90@gmail.com>

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3240
Describe changes:
- add function to check for values of configuration values in yaml for hash
- have hash-size use validation function
- have prealloc use validation function

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

