### PR TITLE
Bug-3053/part3/v1

### DIFF
--- a/src/detect-cipservice.c
+++ b/src/detect-cipservice.c
@@ -346,14 +346,18 @@ static DetectEnipCommandData *DetectEnipCommandParse(const char *rulestr)
         goto error;
     }
 
-    unsigned long cmd = atol(rulestr);
-    if (cmd > MAX_ENIP_CMD) //if command greater than 16 bit
-    {
-        SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid ENIP command %lu", cmd);
+    uint16_t cmd;
+    if (ByteExtractStringUint16(&cmd, 10, 0, rulestr) < 0) {
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid ENIP command"
+                ": \"%s\"", rulestr);
         goto error;
     }
-
-    enipcmdd->enipcommand = (uint16_t) atoi(rulestr);
+    if (cmd > MAX_ENIP_CMD) //if command greater than 16 bit
+    {
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid ENIP command %"PRIu16, cmd);
+        goto error;
+    }
+    enipcmdd->enipcommand = cmd;
 
     return enipcmdd;
 

--- a/src/detect-dce-opnum.c
+++ b/src/detect-dce-opnum.c
@@ -175,16 +175,25 @@ static DetectDceOpnumData *DetectDceOpnumArgParse(const char *arg)
         if ((hyphen_token = strchr(dup_str_temp, '-')) != NULL) {
             hyphen_token[0] = '\0';
             hyphen_token++;
-            dor->range1 = atoi(dup_str_temp);
+            if (ByteExtractStringUint32(&dor->range1, 10, 0,
+                                        (const char *)dup_str_temp) < 0) {
+                goto error;
+            }
             if (dor->range1 > DCE_OPNUM_RANGE_MAX)
                 goto error;
-            dor->range2 = atoi(hyphen_token);
+            if (ByteExtractStringUint32(&dor->range2, 10, 0,
+                                        (const char *)hyphen_token) < 0) {
+                goto error;
+            }
             if (dor->range2 > DCE_OPNUM_RANGE_MAX)
                 goto error;
             if (dor->range1 > dor->range2)
                 goto error;
         }
-        dor->range1 = atoi(dup_str_temp);
+        if (ByteExtractStringUint32(&dor->range1, 10, 0,
+                                    (const char *)dup_str_temp) < 0) {
+            goto error;
+        }
         if (dor->range1 > DCE_OPNUM_RANGE_MAX)
             goto error;
 
@@ -203,16 +212,25 @@ static DetectDceOpnumData *DetectDceOpnumArgParse(const char *arg)
     if ( (hyphen_token = strchr(dup_str, '-')) != NULL) {
         hyphen_token[0] = '\0';
         hyphen_token++;
-        dor->range1 = atoi(dup_str);
+        if (ByteExtractStringUint32(&dor->range1, 10, 0,
+                                    (const char *)dup_str) < 0) {
+            goto error;
+        }
         if (dor->range1 > DCE_OPNUM_RANGE_MAX)
             goto error;
-        dor->range2 = atoi(hyphen_token);
+        if (ByteExtractStringUint32(&dor->range2, 10, 0,
+                                    (const char *)hyphen_token) < 0) {
+            goto error;
+        }
         if (dor->range2 > DCE_OPNUM_RANGE_MAX)
             goto error;
         if (dor->range1 > dor->range2)
             goto error;
     }
-    dor->range1 = atoi(dup_str);
+    if (ByteExtractStringUint32(&dor->range1, 10, 0,
+                                (const char *)dup_str) < 0) {
+        goto error;
+    }
     if (dor->range1 > DCE_OPNUM_RANGE_MAX)
         goto error;
 

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -481,7 +481,8 @@ static int DetectIPProtoTestParse02(void)
 static int DetectIPProtoTestSetup01(void)
 {
     const char *value_str = "14";
-    int value = atoi(value_str);
+    int32_t value;
+    FAIL_IF(ByteExtractStringInt32(&value, 10, 0, (const char *)value_str) < 0);
     int i;
 
     Signature *sig = SigAlloc();

--- a/src/detect-iprep.c
+++ b/src/detect-iprep.c
@@ -41,6 +41,7 @@
 #include "detect-engine-state.h"
 
 #include "util-debug.h"
+#include "util-byte.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 #include "util-fmemopen.h"
@@ -323,10 +324,12 @@ int DetectIPRepSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
     }
 
     if (value != NULL && strlen(value) > 0) {
-        int ival = atoi(value);
-        if (ival < 0 || ival > 127)
+        uint8_t ival;
+        if (ByteExtractStringUint8(&ival, 10, 0, (const char *)value) < 0)
             goto error;
-        val = (uint8_t)ival;
+        if (ival > 127)
+            goto error;
+        val = ival;
     }
 
     cd = SCMalloc(sizeof(DetectIPRepData));

--- a/src/detect-krb5-errcode.c
+++ b/src/detect-krb5-errcode.c
@@ -23,6 +23,7 @@
 
 #include "suricata-common.h"
 #include "util-unittest.h"
+#include "util-byte.h"
 
 #include "detect-parse.h"
 #include "detect-engine.h"
@@ -160,7 +161,10 @@ static DetectKrb5ErrCodeData *DetectKrb5ErrCodeParse (const char *krb5str)
     krb5d = SCMalloc(sizeof (DetectKrb5ErrCodeData));
     if (unlikely(krb5d == NULL))
         goto error;
-    krb5d->err_code = (int32_t)atoi(arg1);
+    if (ByteExtractStringInt32(&krb5d->err_code, 10, 0,
+                               (const char *)arg1) < 0) {
+        goto error;
+    }
 
     return krb5d;
 

--- a/src/detect-krb5-msgtype.c
+++ b/src/detect-krb5-msgtype.c
@@ -23,6 +23,7 @@
 
 #include "suricata-common.h"
 #include "util-unittest.h"
+#include "util-byte.h"
 
 #include "detect-parse.h"
 #include "detect-engine.h"
@@ -157,8 +158,10 @@ static DetectKrb5MsgTypeData *DetectKrb5MsgTypeParse (const char *krb5str)
     krb5d = SCMalloc(sizeof (DetectKrb5MsgTypeData));
     if (unlikely(krb5d == NULL))
         goto error;
-    krb5d->msg_type = (uint8_t)atoi(arg1);
-
+    if (ByteExtractStringUint8(&krb5d->msg_type, 10, 0,
+                               (const char *)arg1) < 0) {
+        goto error;
+    }
     return krb5d;
 
 error:

--- a/src/detect-modbus.c
+++ b/src/detect-modbus.c
@@ -51,6 +51,7 @@
 #include "detect-engine-modbus.h"
 
 #include "util-debug.h"
+#include "util-byte.h"
 
 #include "app-layer-modbus.h"
 
@@ -195,13 +196,28 @@ static DetectModbus *DetectModbusAccessParse(const char *str)
                 goto error;
 
             if (arg[0] == '>') {
-                modbus->address->min    = atoi((const char*) (arg+1));
+                if (ByteExtractStringUint16(&modbus->address->min, 10, 0,
+                                            (const char*) (arg + 1)) < 0) {
+                    SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for min "
+                            "address: %s", arg + 1);
+                    goto error;
+                }
                 modbus->address->mode   = DETECT_MODBUS_GT;
             } else if (arg[0] == '<') {
-                modbus->address->min    = atoi((const char*) (arg+1));
+                if (ByteExtractStringUint16(&modbus->address->min, 10, 0,
+                                            (const char*) (arg + 1)) < 0) {
+                    SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for min "
+                            "address: %s", arg + 1);
+                    goto error;
+                }
                 modbus->address->mode   = DETECT_MODBUS_LT;
             } else {
-                modbus->address->min    = atoi((const char*) arg);
+                if (ByteExtractStringUint16(&modbus->address->min, 10, 0,
+                                            (const char*) (arg)) < 0) {
+                    SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for min "
+                            "address: %s", arg);
+                    goto error;
+                }
             }
             SCLogDebug("and min/equal address %d", modbus->address->min);
 
@@ -213,7 +229,12 @@ static DetectModbus *DetectModbusAccessParse(const char *str)
                 }
 
                 if (*arg != '\0') {
-                    modbus->address->max    = atoi((const char*) (arg+2));
+                    if (ByteExtractStringUint16(&modbus->address->max, 10, 0,
+                                                (const char*) (arg + 2)) < 0) {
+                        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for max"
+                                " address: %s", arg + 2);
+                        goto error;
+                    }
                     modbus->address->mode   = DETECT_MODBUS_RA;
                     SCLogDebug("and max address %d", modbus->address->max);
                 }
@@ -240,13 +261,28 @@ static DetectModbus *DetectModbusAccessParse(const char *str)
                         goto error;
 
                     if (arg[0] == '>') {
-                        modbus->data->min   = atoi((const char*) (arg+1));
+                        if (ByteExtractStringUint16(&modbus->data->min, 10, 0,
+                                                    (const char*) (arg + 1)) < 0) {
+                            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value "
+                                    "for min data: %s", arg + 1);
+                            goto error;
+                        }
                         modbus->data->mode  = DETECT_MODBUS_GT;
                     } else if (arg[0] == '<') {
-                        modbus->data->min   = atoi((const char*) (arg+1));
+                        if (ByteExtractStringUint16(&modbus->data->min, 10, 0,
+                                                    (const char*) (arg + 1)) < 0) {
+                            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value "
+                                    "for min data: %s", arg + 1);
+                            goto error;
+                        }
                         modbus->data->mode  = DETECT_MODBUS_LT;
                     } else {
-                        modbus->data->min   = atoi((const char*) arg);
+                        if (ByteExtractStringUint16(&modbus->data->min, 10, 0,
+                                                    (const char*)arg) < 0) {
+                            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value "
+                                    "for min data: %s", arg);
+                            goto error;
+                        }
                     }
                     SCLogDebug("and min/equal value %d", modbus->data->min);
 
@@ -258,7 +294,12 @@ static DetectModbus *DetectModbusAccessParse(const char *str)
                         }
 
                         if (*arg != '\0') {
-                            modbus->data->max   = atoi((const char*) (arg+2));
+                            if (ByteExtractStringUint16(&modbus->data->max,
+                                                        10, 0, (const char*) (arg + 2)) < 0) {
+                                SCLogError(SC_ERR_INVALID_VALUE, "Invalid "
+                                        "value for max data: %s", arg + 2);
+                                goto error;
+                            }
                             modbus->data->mode  = DETECT_MODBUS_RA;
                             SCLogDebug("and max value %d", modbus->data->max);
                         }
@@ -311,7 +352,11 @@ static DetectModbus *DetectModbusFunctionParse(const char *str)
         goto error;
 
     if (isdigit((unsigned char)ptr[0])) {
-        modbus->function = atoi((const char*) ptr);
+        if (ByteExtractStringUint8(&modbus->function, 10, 0, (const char *)ptr) < 0) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                       "modbus function: %s", ptr);
+            goto error;
+        }
         /* Function code 0 is managed by decoder_event INVALID_FUNCTION_CODE */
         if (modbus->function == MODBUS_FUNC_NONE) {
             SCLogError(SC_ERR_INVALID_SIGNATURE,
@@ -333,8 +378,12 @@ static DetectModbus *DetectModbusFunctionParse(const char *str)
             modbus->subfunction =(uint16_t *) SCCalloc(1, sizeof(uint16_t));
             if (modbus->subfunction == NULL)
                 goto error;
+            if (ByteExtractStringUint16(&(*modbus->subfunction), 10, 0, (const char *)arg) < 0) {
+                SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                           "modbus subfunction: %s", arg);
+                goto error;
+            }
 
-            *(modbus->subfunction) = atoi((const char*) arg);
             SCLogDebug("and subfunction %d", *(modbus->subfunction));
         }
     } else {
@@ -428,13 +477,25 @@ static DetectModbus *DetectModbusUnitIdParse(const char *str)
         goto error;
 
     if (arg[0] == '>') {
-        modbus->unit_id->min   = atoi((const char*) (arg+1));
+        if (ByteExtractStringUint16(&modbus->unit_id->min, 10, 0, (const char *) (arg + 1)) < 0) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                       "modbus min unit id: %s", arg[1]);
+            goto error;
+        }
         modbus->unit_id->mode  = DETECT_MODBUS_GT;
     } else if (arg[0] == '<') {
-        modbus->unit_id->min   = atoi((const char*) (arg+1));
+        if (ByteExtractStringUint16(&modbus->unit_id->min, 10, 0, (const char *) (arg + 1)) < 0) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                       "modbus min unit id: %s", arg[1]);
+            goto error;
+        }
         modbus->unit_id->mode  = DETECT_MODBUS_LT;
     } else {
-        modbus->unit_id->min   = atoi((const char*) arg);
+        if (ByteExtractStringUint16(&modbus->unit_id->min, 10, 0, (const char *)arg) < 0) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                       "modbus min unit id: %s", arg[0]);
+            goto error;
+        }
     }
     SCLogDebug("and min/equal unit id %d", modbus->unit_id->min);
 
@@ -446,7 +507,11 @@ static DetectModbus *DetectModbusUnitIdParse(const char *str)
         }
 
         if (*arg != '\0') {
-            modbus->unit_id->max   = atoi((const char*) (arg+2));
+            if (ByteExtractStringUint16(&modbus->unit_id->max, 10, 0, (const char *) (arg + 2)) < 0) {
+                SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                           "modbus max unit id: %s", arg[2]);
+                goto error;
+            }
             modbus->unit_id->mode  = DETECT_MODBUS_RA;
             SCLogDebug("and max unit id %d", modbus->unit_id->max);
         }

--- a/src/detect-nfs-procedure.c
+++ b/src/detect-nfs-procedure.c
@@ -42,6 +42,7 @@
 
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
+#include "util-byte.h"
 
 #include "app-layer-nfs-tcp.h"
 #include "rust.h"
@@ -291,7 +292,10 @@ static DetectNfsProcedureData *DetectNfsProcedureParse (const char *rawstr)
     }
 
     /* set the first value */
-    dd->lo = atoi(value1); //TODO
+    if (ByteExtractStringUint32(&dd->lo, 10, 0, (const char *)value1) < 0) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid first value: \"%s\"", value1);
+        goto error;
+    }
 
     /* set the second value if specified */
     if (strlen(value2) > 0) {
@@ -302,7 +306,10 @@ static DetectNfsProcedureData *DetectNfsProcedureParse (const char *rawstr)
         }
 
         //
-        dd->hi = atoi(value2); // TODO
+        if (ByteExtractStringUint32(&dd->hi, 10, 0, (const char *)value2) < 0) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid second value: \"%s\"", value2);
+            goto error;
+        }
 
         if (dd->hi <= dd->lo) {
             SCLogError(SC_ERR_INVALID_ARGUMENT,


### PR DESCRIPTION
atoi() and related functions lack a mechanism for reporting errors for
invalid values. Replace them with calls to the appropriate
ByteExtractString* functions.

Partially closes redmine ticket https://redmine.openinfosecfoundation.org/issues/3053