### PR TITLE
Exp/versions/v2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-    AC_INIT([suricata],[5.0.0-dev])
+    AC_INIT([suricata],[5.0.1-dev])
     m4_ifndef([AM_SILENT_RULES], [m4_define([AM_SILENT_RULES],[])])AM_SILENT_RULES([yes])
     AC_CONFIG_HEADERS([config.h])
     AC_CONFIG_SRCDIR([src/suricata.c])

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -688,13 +688,7 @@ static void PrintBuildInfo(void)
     char features[2048] = "";
     const char *tls = "pthread key";
 
-#ifdef REVISION
-    printf("This is %s version %s (%s)\n", PROG_NAME, PROG_VER, xstr(REVISION));
-#elif defined RELEASE
-    printf("This is %s version %s RELEASE\n", PROG_NAME, PROG_VER);
-#else
-    printf("This is %s version %s\n", PROG_NAME, PROG_VER);
-#endif
+    printf("This is %s version %s\n", PROG_NAME, GetProgramVersion());
 
 #ifdef DEBUG
     strlcat(features, "DEBUG ", sizeof(features));
@@ -1052,31 +1046,42 @@ static void SCInstanceInit(SCInstance *suri, const char *progname)
 #endif
 }
 
+/** \brief get string with program version
+ *
+ *  Get the program version as passed to us from AC_INIT
+ *
+ *  Add 'RELEASE' is no '-dev' in the version. Add the REVISION if passed
+ *  to us.
+ *
+ *  Possible outputs:
+ *  release:      '5.0.1 RELEASE'
+ *  dev with rev: '5.0.1-dev (64a789bbf 2019-10-18)'
+ *  dev w/o rev:  '5.0.1-dev'
+ */
+const char *GetProgramVersion(void)
+{
+    if (strstr(PROG_VER, "-dev") == NULL) {
+        return PROG_VER " RELEASE";
+    } else {
+#ifdef REVISION
+        return PROG_VER " (" xstr(REVISION) ")";
+#else
+        return PROG_VER;
+#endif
+    }
+}
+
 static TmEcode PrintVersion(void)
 {
-#ifdef REVISION
-    printf("This is %s version %s (%s)\n", PROG_NAME, PROG_VER, xstr(REVISION));
-#elif defined RELEASE
-    printf("This is %s version %s RELEASE\n", PROG_NAME, PROG_VER);
-#else
-    printf("This is %s version %s\n", PROG_NAME, PROG_VER);
-#endif
+    printf("This is %s version %s\n", PROG_NAME, GetProgramVersion());
     return TM_ECODE_OK;
 }
 
 static TmEcode LogVersion(SCInstance *suri)
 {
     const char *mode = suri->system ? "SYSTEM" : "USER";
-#ifdef REVISION
-    SCLogNotice("This is %s version %s (%s) running in %s mode",
-            PROG_NAME, PROG_VER, xstr(REVISION), mode);
-#elif defined RELEASE
-    SCLogNotice("This is %s version %s RELEASE running in %s mode",
-            PROG_NAME, PROG_VER, mode);
-#else
     SCLogNotice("This is %s version %s running in %s mode",
-            PROG_NAME, PROG_VER, mode);
-#endif
+            PROG_NAME, GetProgramVersion(), mode);
     return TM_ECODE_OK;
 }
 

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -198,5 +198,7 @@ void PreRunPostPrivsDropInit(const int runmode);
 void PostRunDeinit(const int runmode, struct timeval *start_time);
 void RegisterAllModules(void);
 
+const char *GetProgramVersion(void);
+
 #endif /* __SURICATA_H__ */
 

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -694,15 +694,7 @@ static TmEcode UnixManagerVersionCommand(json_t *cmd,
                                    json_t *server_msg, void *data)
 {
     SCEnter();
-    json_object_set_new(server_msg, "message", json_string(
-#ifdef REVISION
-                        PROG_VER " (" xstr(REVISION) ")"
-#elif defined RELEASE
-                        PROG_VER " RELEASE"
-#else
-                        PROG_VER
-#endif
-                        ));
+    json_object_set_new(server_msg, "message", json_string(GetProgramVersion()));
     SCReturnInt(TM_ECODE_OK);
 }
 


### PR DESCRIPTION
@jasonish see this simpler approach that makes things only depend on PROG_VER (which is actually PACKAGE_VERSION from AC_INIT).

As #4322 but with a different name to try to avoid a name clash on mingw.