### PR TITLE
app-layer-parser: move inspection id forward if a completed transaction is last in the list.

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1980,7 +1980,7 @@ static int TestProtocolParser(Flow *f, void *test_state, AppLayerParserState *ps
                               void *local_data, const uint8_t flags)
 {
     SCEnter();
-    SCReturnInt((input != NULL && input_len != 0 && input[0] == 0x11) ? -1 : 0);
+    SCReturnInt(((input != NULL && input_len != 0 && input[0] == 0x11) ? -1 : 0));
 }
 
 /** \brief Function to allocates the Test protocol state memory


### PR DESCRIPTION
The original implementation does not increment inspection id if the completed transaction is last in the list.
As a result transactions iteration is started next time from the already inspected one.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:

Inspection id is incremented before exiting from the loop clause.
So the calculated new inspection id points to the next transaction instead of already inspected one.

Please note SIP related tests fail with this fix. However, the reason of the fail is the incorrect number of events currently supplied in the reference data. Most of the transactions are processed twice and generate an unnecessary second event. So the fix is exactly intended to suppress such duplicated events.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

