### PR TITLE
dataset: fix hash computation

### DIFF
--- a/src/datasets-string.c
+++ b/src/datasets-string.c
@@ -89,8 +89,9 @@ uint32_t StringHash(void *s)
 {
     uint32_t hash = 5381;
     int c;
+    uint8_t *sptr = ((StringType *)s)->ptr;
 
-    while ((c = *(char *)s++))
+    while ((c = *sptr++))
         hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
 
     return hash;


### PR DESCRIPTION
Fix hash key computation for dataset of type string. This boosts dataset load time and match time.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Fix hash computation function

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/502
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/278

