### PR TITLE
yaml: clarify comment about dump-all-headers

### DIFF
--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -643,6 +643,10 @@ static OutputInitResult OutputHttpLogInit(ConfNode *conf)
                 http_ctx->flags |= LOG_HTTP_REQ_HEADERS;
             } else if (strcmp(all_headers, "response") == 0) {
                 http_ctx->flags |= LOG_HTTP_RES_HEADERS;
+            } else if (strcmp(all_headers, "none") != 0) {
+                SCLogWarning(SC_WARN_ANOMALY_CONFIG,
+                             "unhandled value for dump-all-headers configuration : %s",
+                             all_headers);
             }
         }
     }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -194,9 +194,9 @@ outputs:
             # custom allows additional http fields to be included in eve-log
             # the example below adds three additional fields when uncommented
             #custom: [Accept-Encoding, Accept-Language, Authorization]
-            # set this value to one among {both, request, response} to dump all
-            # http headers for every http request and/or response
-            # dump-all-headers: [both, request, response]
+            # set this value to one and only one among {both, request, response}
+            # to dump all http headers for every http request and/or response
+            # dump-all-headers: none
         - dns:
             # This configuration uses the new DNS logging format,
             # the old configuration is still available:


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2810

Describe changes:
- clarify comment about dump-all-headers in suricata.yaml template
- Logs a warning if the value is unknown
