### PR TITLE
Fastlog icmp code 3266 v2

### DIFF
--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -150,12 +150,21 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)
             } else {
                 snprintf(proto, sizeof(proto), "PROTO:%03" PRIu32, IP_GET_IPPROTO(p));
             }
+            char srcPortOrIcmp[17] = "";
+            char dstPortOrIcmp[17] = "";
+            if (IP_GET_IPPROTO(p) == IPPROTO_ICMP) {
+                snprintf(srcPortOrIcmp, sizeof(srcPortOrIcmp), "type=%03" PRIu8 "code=%03" PRIu8, p->icmp_s.type, p->icmp_s.code);
+                snprintf(dstPortOrIcmp, sizeof(dstPortOrIcmp), "type=%03" PRIu8 "code=%03" PRIu8, p->icmp_d.type, p->icmp_d.code);
+            } else {
+                snprintf(srcPortOrIcmp, sizeof(srcPortOrIcmp), "%"PRIu32, p->sp);
+                snprintf(dstPortOrIcmp, sizeof(dstPortOrIcmp), "%"PRIu32, p->dp);
+            }
             PrintBufferData(alert_buffer, &size, MAX_FASTLOG_ALERT_SIZE,
                             "%s  %s[**] [%" PRIu32 ":%" PRIu32 ":%"
                             PRIu32 "] %s [**] [Classification: %s] [Priority: %"PRIu32"]"
-                            " {%s} %s:%" PRIu32 " -> %s:%" PRIu32 "\n", timebuf, action,
+                            " {%s} %s:%s -> %s:%s\n", timebuf, action,
                             pa->s->gid, pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
-                            proto, srcip, p->sp, dstip, p->dp);
+                            proto, srcip, srcPortOrIcmp, dstip, dstPortOrIcmp);
         } else {
             PrintBufferData(alert_buffer, &size, MAX_FASTLOG_ALERT_SIZE, 
                             "%s  %s[**] [%" PRIu32 ":%" PRIu32

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -141,19 +141,16 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)
             action = "[wDrop] ";
         }
 
-        char proto[16] = "";
+        /* Create the alert string without locking. */
+        int size = 0;
         if (likely(decoder_event == 0)) {
+            char proto[16] = "";
             if (SCProtoNameValid(IP_GET_IPPROTO(p)) == TRUE) {
                 strlcpy(proto, known_proto[IP_GET_IPPROTO(p)], sizeof(proto));
             } else {
                 snprintf(proto, sizeof(proto), "PROTO:%03" PRIu32, IP_GET_IPPROTO(p));
             }
-        }
-
-        /* Create the alert string without locking. */
-        int size = 0;
-        if (likely(decoder_event == 0)) {
-            PrintBufferData(alert_buffer, &size, MAX_FASTLOG_ALERT_SIZE, 
+            PrintBufferData(alert_buffer, &size, MAX_FASTLOG_ALERT_SIZE,
                             "%s  %s[**] [%" PRIu32 ":%" PRIu32 ":%"
                             PRIu32 "] %s [**] [Classification: %s] [Priority: %"PRIu32"]"
                             " {%s} %s:%" PRIu32 " -> %s:%" PRIu32 "\n", timebuf, action,


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3266

Describe changes:
- restricts one variable scope
- Uses imp type and code instead of port from union when logging to fast.log

Modifies #3266 with fixing format string and having enough space for temporary buffer