### PR TITLE
Feature 2694 thresholds by_rule by_both v2

### DIFF
--- a/doc/userguide/configuration/global-thresholds.rst
+++ b/doc/userguide/configuration/global-thresholds.rst
@@ -20,7 +20,7 @@ Syntax:
 ::
 
   threshold gen_id <gid>, sig_id <sid>, type <threshold|limit|both>, \
-    track <by_src|by_dst>, count <N>, seconds <T>
+    track <by_src|by_dst|by_rule|by_both>, count <N>, seconds <T>
 
 rate_filter
 ~~~~~~~~~~~

--- a/doc/userguide/rules/thresholding.rst
+++ b/doc/userguide/rules/thresholding.rst
@@ -16,7 +16,7 @@ frequency. It has 3 modes: threshold, limit and both.
 
 Syntax::
 
-  threshold: type <threshold|limit|both>, track <by_src|by_dst>, count <N>, seconds <T>
+  threshold: type <threshold|limit|both>, track <by_src|by_dst|by_rule|by_both>, count <N>, seconds <T>
 
 type "threshold"
 ~~~~~~~~~~~~~~~~
@@ -97,7 +97,7 @@ again.
 
 Syntax::
 
-  detection_filter: track <by_src|by_dst>, count <N>, seconds <T>
+  detection_filter: track <by_src|by_dst|by_rule|by_both>, count <N>, seconds <T>
 
 Example::
 

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -673,6 +673,32 @@ void ThresholdHashInit(DetectEngineCtx *de_ctx)
 }
 
 /**
+ * \brief Realloc threshold context hash tables
+ *
+ * \param de_ctx Detection Context
+ */
+void ThresholdHashRealloc(DetectEngineCtx *de_ctx)
+{
+    /* Return if we are already big enough */
+    uint32_t num = de_ctx->signum + 1;
+    if (num <= de_ctx->ths_ctx.th_size)
+        return;
+
+    void *ptmp = SCRealloc(de_ctx->ths_ctx.th_entry, num * sizeof(DetectThresholdEntry *));
+    if (ptmp == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory for rule thresholds"
+                " (tried to allocate %"PRIu32" th_entrys for rule tracking)", num);
+        exit(EXIT_FAILURE);
+    } else {
+        de_ctx->ths_ctx.th_entry = ptmp;
+        for (uint32_t i = de_ctx->ths_ctx.th_size; i < num; ++i) {
+            de_ctx->ths_ctx.th_entry[i] = NULL;
+        }
+        de_ctx->ths_ctx.th_size = num;
+    }
+}
+
+/**
  * \brief Destroy threshold context hash tables
  *
  * \param de_ctx Dectection Context

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -69,6 +69,11 @@
 #include "util-var-name.h"
 #include "tm-threads.h"
 
+#define TIME_DIFF_SEC(p, lookup_tsh) \
+    (uint64_t)((((uint64_t)p->ts.tv_sec * 1000000 + p->ts.tv_usec) - \
+                ((uint64_t)lookup_tsh->tv_sec1 * 1000000 + lookup_tsh->tv_usec1)) / \
+               1000000)
+
 static int host_threshold_id = -1; /**< host storage id for thresholds */
 static int ippair_threshold_id = -1; /**< ip pair storage id for thresholds */
 
@@ -370,71 +375,43 @@ static int IsThresholdReached(DetectThresholdEntry* lookup_tsh, const DetectThre
     return ret;
 }
 
-static void AddEntryToHostStorage(Host *h, DetectThresholdEntry *e, uint32_t packet_time)
+static void AddEntryToHostStorage(Host *h, DetectThresholdEntry *e, struct timeval packet_time)
 {
     if (h && e) {
         e->current_count = 1;
-        e->tv_sec1 = packet_time;
+        e->tv_sec1 = packet_time.tv_sec;
+        e->tv_usec1 = packet_time.tv_usec;
         e->tv_timeout = 0;
         e->next = HostGetStorageById(h, host_threshold_id);
         HostSetStorageById(h, host_threshold_id, e);
     }
 }
 
-static void AddEntryToIPPairStorage(IPPair *pair, DetectThresholdEntry *e, uint32_t packet_time)
+static void AddEntryToIPPairStorage(IPPair *pair, DetectThresholdEntry *e, struct timeval packet_time)
 {
     if (pair && e) {
         e->current_count = 1;
-        e->tv_sec1 = packet_time;
+        e->tv_sec1 = packet_time.tv_sec;
+        e->tv_usec1 = packet_time.tv_usec;
         e->tv_timeout = 0;
         e->next = IPPairGetStorageById(pair, ippair_threshold_id);
         IPPairSetStorageById(pair, ippair_threshold_id, e);
     }
 }
 
-static int ThresholdHandlePacketIPPair(IPPair *pair, Packet *p, const DetectThresholdData *td,
-    uint32_t sid, uint32_t gid, PacketAlert *pa)
-{
-    int ret = 0;
-
-    DetectThresholdEntry *lookup_tsh = ThresholdIPPairLookupEntry(pair, sid, gid);
-    SCLogDebug("ippair lookup_tsh %p sid %u gid %u", lookup_tsh, sid, gid);
-
-    switch (td->type) {
-        case TYPE_RATE:
-        {
-            SCLogDebug("rate_filter");
-            ret = 1;
-            if (lookup_tsh && IsThresholdReached(lookup_tsh, td, p->ts.tv_sec)) {
-                RateFilterSetAction(p, pa, td->new_action);
-            } else if (!lookup_tsh) {
-                DetectThresholdEntry *e = DetectThresholdEntryAlloc(td, p, sid, gid);
-                AddEntryToIPPairStorage(pair, e, p->ts.tv_sec);
-            }
-            break;
-        }
-        default:
-        {
-            SCLogError(SC_ERR_INVALID_VALUE, "type %d is not supported", td->type);
-            break;
-        }
-    }
-
-    return ret;
-}
-
 /**
  *  \retval 2 silent match (no alert but apply actions)
  *  \retval 1 normal match
  *  \retval 0 no match
+ *
+ *  If a new DetectThresholdEntry is generated to track the threshold
+ *  for this rule, then it will be returned in new_tsh.
  */
-static int ThresholdHandlePacketHost(Host *h, Packet *p, const DetectThresholdData *td,
+static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
+        DetectThresholdEntry **new_tsh, const DetectThresholdData *td,
         uint32_t sid, uint32_t gid, PacketAlert *pa)
 {
     int ret = 0;
-
-    DetectThresholdEntry *lookup_tsh = ThresholdHostLookupEntry(h, sid, gid);
-    SCLogDebug("lookup_tsh %p sid %u gid %u", lookup_tsh, sid, gid);
 
     switch(td->type)   {
         case TYPE_LIMIT:
@@ -442,7 +419,7 @@ static int ThresholdHandlePacketHost(Host *h, Packet *p, const DetectThresholdDa
             SCLogDebug("limit");
 
             if (lookup_tsh != NULL)  {
-                if ((p->ts.tv_sec - lookup_tsh->tv_sec1) < td->seconds) {
+                if (TIME_DIFF_SEC(p, lookup_tsh) < td->seconds) {
                     lookup_tsh->current_count++;
 
                     if (lookup_tsh->current_count <= td->count) {
@@ -458,17 +435,9 @@ static int ThresholdHandlePacketHost(Host *h, Packet *p, const DetectThresholdDa
                 }
             } else {
                 DetectThresholdEntry *e = DetectThresholdEntryAlloc(td, p, sid, gid);
-                if (e == NULL) {
-                    break;
-                }
-
-                e->tv_sec1 = p->ts.tv_sec;
-                e->current_count = 1;
+                *new_tsh = e;
 
                 ret = 1;
-
-                e->next = HostGetStorageById(h, host_threshold_id);
-                HostSetStorageById(h, host_threshold_id, e);
             }
             break;
         }
@@ -477,7 +446,7 @@ static int ThresholdHandlePacketHost(Host *h, Packet *p, const DetectThresholdDa
             SCLogDebug("threshold");
 
             if (lookup_tsh != NULL)  {
-                if ((p->ts.tv_sec - lookup_tsh->tv_sec1) < td->seconds) {
+                if (TIME_DIFF_SEC(p, lookup_tsh) < td->seconds) {
                     lookup_tsh->current_count++;
 
                     if (lookup_tsh->current_count >= td->count) {
@@ -493,15 +462,7 @@ static int ThresholdHandlePacketHost(Host *h, Packet *p, const DetectThresholdDa
                     ret = 1;
                 } else {
                     DetectThresholdEntry *e = DetectThresholdEntryAlloc(td, p, sid, gid);
-                    if (e == NULL) {
-                        break;
-                    }
-
-                    e->current_count = 1;
-                    e->tv_sec1 = p->ts.tv_sec;
-
-                    e->next = HostGetStorageById(h, host_threshold_id);
-                    HostSetStorageById(h, host_threshold_id, e);
+                    *new_tsh = e;
                 }
             }
             break;
@@ -511,7 +472,7 @@ static int ThresholdHandlePacketHost(Host *h, Packet *p, const DetectThresholdDa
             SCLogDebug("both");
 
             if (lookup_tsh != NULL) {
-                if ((p->ts.tv_sec - lookup_tsh->tv_sec1) < td->seconds) {
+                if (TIME_DIFF_SEC(p, lookup_tsh) < td->seconds) {
                     /* within time limit */
 
                     lookup_tsh->current_count++;
@@ -533,15 +494,7 @@ static int ThresholdHandlePacketHost(Host *h, Packet *p, const DetectThresholdDa
                 }
             } else {
                 DetectThresholdEntry *e = DetectThresholdEntryAlloc(td, p, sid, gid);
-                if (e == NULL) {
-                    break;
-                }
-
-                e->current_count = 1;
-                e->tv_sec1 = p->ts.tv_sec;
-
-                e->next = HostGetStorageById(h, host_threshold_id);
-                HostSetStorageById(h, host_threshold_id, e);
+                *new_tsh = e;
 
                 /* for the first match we return 1 to
                  * indicate we should alert */
@@ -557,35 +510,21 @@ static int ThresholdHandlePacketHost(Host *h, Packet *p, const DetectThresholdDa
             SCLogDebug("detection_filter");
 
             if (lookup_tsh != NULL) {
-                long double time_diff = ((p->ts.tv_sec + p->ts.tv_usec/1000000.0) -
-                                         (lookup_tsh->tv_sec1 + lookup_tsh->tv_usec1/1000000.0));
-
-                if (time_diff < td->seconds) {
+                if (TIME_DIFF_SEC(p, lookup_tsh) < td->seconds) {
                     /* within timeout */
-
                     lookup_tsh->current_count++;
                     if (lookup_tsh->current_count > td->count) {
                         ret = 1;
                     }
                 } else {
                     /* expired, reset */
-
                     lookup_tsh->tv_sec1 = p->ts.tv_sec;
                     lookup_tsh->tv_usec1 = p->ts.tv_usec;
                     lookup_tsh->current_count = 1;
                 }
             } else {
                 DetectThresholdEntry *e = DetectThresholdEntryAlloc(td, p, sid, gid);
-                if (e == NULL) {
-                    break;
-                }
-
-                e->current_count = 1;
-                e->tv_sec1 = p->ts.tv_sec;
-                e->tv_usec1 = p->ts.tv_usec;
-
-                e->next = HostGetStorageById(h, host_threshold_id);
-                HostSetStorageById(h, host_threshold_id, e);
+                *new_tsh = e;
             }
             break;
         }
@@ -598,7 +537,7 @@ static int ThresholdHandlePacketHost(Host *h, Packet *p, const DetectThresholdDa
                 RateFilterSetAction(p, pa, td->new_action);
             } else if (!lookup_tsh) {
                 DetectThresholdEntry *e = DetectThresholdEntryAlloc(td, p, sid, gid);
-                AddEntryToHostStorage(h, e, p->ts.tv_sec);
+                *new_tsh = e;
             }
             break;
         }
@@ -606,7 +545,43 @@ static int ThresholdHandlePacketHost(Host *h, Packet *p, const DetectThresholdDa
         default:
             SCLogError(SC_ERR_INVALID_VALUE, "type %d is not supported", td->type);
     }
+    return ret;
+}
 
+static int ThresholdHandlePacketIPPair(IPPair *pair, Packet *p, const DetectThresholdData *td,
+    uint32_t sid, uint32_t gid, PacketAlert *pa)
+{
+    int ret = 0;
+
+    DetectThresholdEntry *lookup_tsh = ThresholdIPPairLookupEntry(pair, sid, gid);
+    SCLogDebug("ippair lookup_tsh %p sid %u gid %u", lookup_tsh, sid, gid);
+
+    DetectThresholdEntry *new_tsh = NULL;
+    ret = ThresholdHandlePacket(p, lookup_tsh, &new_tsh, td, sid, gid, pa);
+    if (new_tsh != NULL) {
+        AddEntryToIPPairStorage(pair, new_tsh, p->ts);
+    }
+
+    return ret;
+}
+
+/**
+ *  \retval 2 silent match (no alert but apply actions)
+ *  \retval 1 normal match
+ *  \retval 0 no match
+ */
+static int ThresholdHandlePacketHost(Host *h, Packet *p, const DetectThresholdData *td,
+        uint32_t sid, uint32_t gid, PacketAlert *pa)
+{
+    int ret = 0;
+    DetectThresholdEntry *lookup_tsh = ThresholdHostLookupEntry(h, sid, gid);
+    SCLogDebug("lookup_tsh %p sid %u gid %u", lookup_tsh, sid, gid);
+
+    DetectThresholdEntry *new_tsh = NULL;
+    ret = ThresholdHandlePacket(p, lookup_tsh, &new_tsh, td, sid, gid, pa);
+    if (new_tsh != NULL) {
+        AddEntryToHostStorage(h, new_tsh, p->ts);
+    }
     return ret;
 }
 
@@ -618,30 +593,14 @@ static int ThresholdHandlePacketRule(DetectEngineCtx *de_ctx, Packet *p,
     DetectThresholdEntry* lookup_tsh = (DetectThresholdEntry *)de_ctx->ths_ctx.th_entry[s->num];
     SCLogDebug("by_rule lookup_tsh %p num %u", lookup_tsh, s->num);
 
-    switch (td->type) {
-        case TYPE_RATE:
-        {
-            ret = 1;
-            if (lookup_tsh && IsThresholdReached(lookup_tsh, td, p->ts.tv_sec)) {
-                RateFilterSetAction(p, pa, td->new_action);
-            }
-            else if (!lookup_tsh) {
-                DetectThresholdEntry *e = DetectThresholdEntryAlloc(td, p, s->id, s->gid);
-                if (e != NULL) {
-                    e->current_count = 1;
-                    e->tv_sec1 = p->ts.tv_sec;
-                    e->tv_timeout = 0;
-
-                    de_ctx->ths_ctx.th_entry[s->num] = e;
-                }
-            }
-            break;
-        }
-        default:
-        {
-            SCLogError(SC_ERR_INVALID_VALUE, "type %d is not supported", td->type);
-            break;
-        }
+    DetectThresholdEntry *new_tsh = NULL;
+    ret = ThresholdHandlePacket(p, lookup_tsh, &new_tsh, td, s->id, s->gid, pa);
+    if (new_tsh != NULL) {
+        new_tsh->tv_sec1 = p->ts.tv_sec;
+        new_tsh->tv_usec1 = p->ts.tv_usec;
+        new_tsh->current_count = 1;
+        new_tsh->tv_timeout = 0;
+        de_ctx->ths_ctx.th_entry[s->num] = new_tsh;
     }
 
     return ret;

--- a/src/detect-engine-threshold.h
+++ b/src/detect-engine-threshold.h
@@ -43,6 +43,7 @@ int PacketAlertThreshold(DetectEngineCtx *, DetectEngineThreadCtx *,
         const Signature *, PacketAlert *);
 
 void ThresholdHashInit(DetectEngineCtx *);
+void ThresholdHashRealloc(DetectEngineCtx *);
 void ThresholdContextDestroy(DetectEngineCtx *);
 
 int ThresholdHostTimeoutCheck(Host *, struct timeval *);

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -244,6 +244,9 @@ static int DetectThresholdSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     if (de == NULL)
         goto error;
 
+    if (de->track == TRACK_RULE)
+        ThresholdHashRealloc(de_ctx);
+
     sm = SigMatchAlloc();
     if (sm == NULL)
         goto error;

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -59,7 +59,7 @@
 #include "util-cpu.h"
 #endif
 
-#define PARSE_REGEX "^\\s*(track|type|count|seconds)\\s+(limit|both|threshold|by_dst|by_src|\\d+)\\s*,\\s*(track|type|count|seconds)\\s+(limit|both|threshold|by_dst|by_src|\\d+)\\s*,\\s*(track|type|count|seconds)\\s+(limit|both|threshold|by_dst|by_src|\\d+)\\s*,\\s*(track|type|count|seconds)\\s+(limit|both|threshold|by_dst|by_src|\\d+)\\s*"
+#define PARSE_REGEX "^\\s*(track|type|count|seconds)\\s+(limit|both|threshold|by_dst|by_src|by_both|by_rule|\\d+)\\s*,\\s*(track|type|count|seconds)\\s+(limit|both|threshold|by_dst|by_src|by_both|by_rule|\\d+)\\s*,\\s*(track|type|count|seconds)\\s+(limit|both|threshold|by_dst|by_src|by_both|by_rule|\\d+)\\s*,\\s*(track|type|count|seconds)\\s+(limit|both|threshold|by_dst|by_src|by_both|by_rule|\\d+)\\s*"
 
 static pcre *parse_regex;
 static pcre_extra *parse_regex_study;
@@ -177,6 +177,10 @@ static DetectThresholdData *DetectThresholdParse(const char *rawstr)
             de->track = TRACK_DST;
         if (strncasecmp(args[i],"by_src",strlen("by_src")) == 0)
             de->track = TRACK_SRC;
+        if (strncasecmp(args[i],"by_both",strlen("by_both")) == 0)
+            de->track = TRACK_BOTH;
+        if (strncasecmp(args[i],"by_rule",strlen("by_rule")) == 0)
+            de->track = TRACK_RULE;
         if (strncasecmp(args[i],"count",strlen("count")) == 0)
             count_pos = i+1;
         if (strncasecmp(args[i],"seconds",strlen("seconds")) == 0)
@@ -372,7 +376,41 @@ static int ThresholdTestParse05(void)
     return 0;
 }
 
+/**
+ * \test ThresholdTestParse06 is a test for thresholding by_both
+ *
+ *  \retval 1 on succces
+ *  \retval 0 on failure
+ */
+static int ThresholdTestParse06(void)
+{
+    DetectThresholdData *de = NULL;
+    de = DetectThresholdParse("count 10, track by_both, seconds 60, type limit");
+    if (de && (de->type == TYPE_LIMIT) && (de->track == TRACK_BOTH) && (de->count == 10) && (de->seconds == 60)) {
+        DetectThresholdFree(de);
+        return 1;
+    }
 
+    return 0;
+}
+
+/**
+ * \test ThresholdTestParse07 is a test for thresholding by_rule
+ *
+ *  \retval 1 on succces
+ *  \retval 0 on failure
+ */
+static int ThresholdTestParse07(void)
+{
+    DetectThresholdData *de = NULL;
+    de = DetectThresholdParse("count 10, track by_rule, seconds 60, type limit");
+    if (de && (de->type == TYPE_LIMIT) && (de->track == TRACK_RULE) && (de->count == 10) && (de->seconds == 60)) {
+        DetectThresholdFree(de);
+        return 1;
+    }
+
+    return 0;
+}
 /**
  * \test DetectThresholdTestSig1 is a test for checking the working of limit keyword
  *       by setting up the signature and later testing its working by matching
@@ -1483,6 +1521,8 @@ void ThresholdRegisterTests(void)
     UtRegisterTest("ThresholdTestParse03", ThresholdTestParse03);
     UtRegisterTest("ThresholdTestParse04", ThresholdTestParse04);
     UtRegisterTest("ThresholdTestParse05", ThresholdTestParse05);
+    UtRegisterTest("ThresholdTestParse06", ThresholdTestParse06);
+    UtRegisterTest("ThresholdTestParse07", ThresholdTestParse07);
     UtRegisterTest("DetectThresholdTestSig1", DetectThresholdTestSig1);
     UtRegisterTest("DetectThresholdTestSig2", DetectThresholdTestSig2);
     UtRegisterTest("DetectThresholdTestSig3", DetectThresholdTestSig3);

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -38,6 +38,7 @@
 #include "detect.h"
 #include "detect-engine.h"
 #include "detect-engine-address.h"
+#include "detect-engine-threshold.h"
 #include "detect-threshold.h"
 #include "detect-parse.h"
 
@@ -453,7 +454,6 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectThresholdData *de = NULL;
-    void *ptmp;
 
     BUG_ON(parsed_type == TYPE_SUPPRESS);
 
@@ -505,17 +505,7 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
             sm->ctx = (void *)de;
 
             if (parsed_track == TRACK_RULE) {
-                ptmp = SCRealloc(de_ctx->ths_ctx.th_entry, (de_ctx->ths_ctx.th_size + 1) * sizeof(DetectThresholdEntry *));
-                if (ptmp == NULL) {
-                    SCFree(de_ctx->ths_ctx.th_entry);
-                    de_ctx->ths_ctx.th_entry = NULL;
-                    SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory for threshold config"
-                    " (tried to allocate %"PRIu32"th_entrys for rule tracking with rate_filter)", de_ctx->ths_ctx.th_size + 1);
-                } else {
-                    de_ctx->ths_ctx.th_entry = ptmp;
-                    de_ctx->ths_ctx.th_entry[de_ctx->ths_ctx.th_size] = NULL;
-                    de_ctx->ths_ctx.th_size++;
-                }
+                ThresholdHashRealloc(de_ctx);
             }
             SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD);
         }
@@ -558,17 +548,7 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
                 sm->ctx = (void *)de;
 
                 if (parsed_track == TRACK_RULE) {
-                    ptmp = SCRealloc(de_ctx->ths_ctx.th_entry, (de_ctx->ths_ctx.th_size + 1) * sizeof(DetectThresholdEntry *));
-                    if (ptmp == NULL) {
-                        SCFree(de_ctx->ths_ctx.th_entry);
-                        de_ctx->ths_ctx.th_entry = NULL;
-                        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory for threshold config"
-                        " (tried to allocate %"PRIu32"th_entrys for rule tracking with rate_filter)", de_ctx->ths_ctx.th_size + 1);
-                    } else {
-                        de_ctx->ths_ctx.th_entry = ptmp;
-                        de_ctx->ths_ctx.th_entry[de_ctx->ths_ctx.th_size] = NULL;
-                        de_ctx->ths_ctx.th_size++;
-                    }
+                    ThresholdHashRealloc(de_ctx);
                 }
                 SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD);
             }
@@ -642,17 +622,7 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
             sm->ctx = (void *)de;
 
             if (parsed_track == TRACK_RULE) {
-                 ptmp = SCRealloc(de_ctx->ths_ctx.th_entry, (de_ctx->ths_ctx.th_size + 1) * sizeof(DetectThresholdEntry *));
-                if (ptmp == NULL) {
-                    SCFree(de_ctx->ths_ctx.th_entry);
-                    de_ctx->ths_ctx.th_entry = NULL;
-                    SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory for threshold config"
-                    " (tried to allocate %"PRIu32"th_entrys for rule tracking with rate_filter)", de_ctx->ths_ctx.th_size + 1);
-                } else {
-                    de_ctx->ths_ctx.th_entry = ptmp;
-                    de_ctx->ths_ctx.th_entry[de_ctx->ths_ctx.th_size] = NULL;
-                    de_ctx->ths_ctx.th_size++;
-                }
+                ThresholdHashRealloc(de_ctx);
             }
 
             SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD);


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/2694) ticket: 2694

Describe changes:
- Accept by_rule and by_both in rule thresholds.
- Refactor threshold application to separate threshold table storage from threshold calculation.
- Ensure the by_rule threshold table is initialized when needed.
- Add tests for threshold parsing and application.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

