### PR TITLE
util: removes warning about double conversion

### DIFF
--- a/src/util-misc.c
+++ b/src/util-misc.c
@@ -209,7 +209,7 @@ int ParseSizeStringU64(const char *size, uint64_t *res)
     if (r < 0)
         return r;
 
-    if (temp_res > UINT64_MAX)
+    if (temp_res > (double) UINT64_MAX)
         return -1;
 
     *res = temp_res;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Explicist cast to remove new clang 10 warning : From clang 10 : `implicit conversion from 'unsigned long' to 'double' changes value from 18446744073709551615 to 18446744073709551616`
