### PR TITLE
signature: Fixes memory leak in parsing app layer event

### DIFF
--- a/src/detect-app-layer-event.c
+++ b/src/detect-app-layer-event.c
@@ -328,8 +328,10 @@ static int DetectAppLayerEventSetupP1(DetectEngineCtx *de_ctx, Signature *s, con
     return 0;
 
 error:
-    if (data)
+    if (data) {
+        SCFree(data->arg);
         SCFree(data);
+    }
     if (sm) {
         sm->ctx = NULL;
         SigMatchFree(sm);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Fixes memory leak from `DetectAppLayerEventSetupP1` error case

Found by fuzzing.
Reproducer signatures file is 
```
#?? Response (answeew )r didn't see a Request for. Could be packet loss.
alert http any any -> any any (msg:"EICAR file data"; file_data; content:"EICAR-STANDARD-ANTIVIRUS-TEST-FILE"; sid:didn't see a Request for. Could be packet loss.
alert http any any -> any any (msg:"EICAR file data"; file_data; content:"EICAR-STANDARD-ANTIVIRUS-TrEST-FILE"; sid:1;)
alert http any any -> any any (msg:"EICAR filany (msg:"EICAR file data"; file_dataSURICATA DNS malformed request data"; flow:to_server; app-layer-event:dns.malformed_data; sid:22or. Could be packet loss.
alert http any any -> any any (msg:"EICAR file data"; ?ile_da; flow:to_client; app-layer-eve2;)
alert http any any -> any any (msg:"EICAR fiormed request data"; flow:to_server; app-layer-event:dns.malformed_data; sid:22or. Could be packet loss.
alert http any any -> any any (msg:"EICAR file data"; ?ile_da; flow:to_client; app-layer-eve2;)
allany (msg:"EICAR file data"; file_data; content:"|58354f2150alert dns any any -> ay any (msg:"SURICATA DNS malformed request data"; flow:to_server; app-layer-event:dns.malformed_data; si`:22or. Could be packet loss.
alert http any any -> any any (msg:"EICAR file data"; ?ile_da; flow:to_client; app-layer-event:dns.malformed_data; sid:2240003; rev:1;SURICATA DNS malformed request 
```