### PR TITLE
signature: Fixes memory leak in parsing app layer event

### DIFF
--- a/src/detect-app-layer-event.c
+++ b/src/detect-app-layer-event.c
@@ -328,8 +328,9 @@ static int DetectAppLayerEventSetupP1(DetectEngineCtx *de_ctx, Signature *s, con
     return 0;
 
 error:
-    if (data)
-        SCFree(data);
+    if (data) {
+        DetectAppLayerEventFree(data);
+    }
     if (sm) {
         sm->ctx = NULL;
         SigMatchFree(sm);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Fixes memory leak from `DetectAppLayerEventSetupP1` error case

Found by fuzzing.

Modifies #4341 with use of `DetectAppLayerEventFree`