### PR TITLE
detect/analyzer: Add handling for http_accept

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -897,6 +897,7 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
     uint32_t packet_buf = 0;
     uint32_t http_header_buf = 0;
     uint32_t http_accept_enc_buf = 0;
+    uint32_t http_accept_buf = 0;
     uint32_t http_uri_buf = 0;
     uint32_t http_method_buf = 0;
     uint32_t http_cookie_buf = 0;
@@ -940,6 +941,7 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
     const int httpstatmsg_id = DetectBufferTypeGetByName("http_stat_msg");
     const int httpheader_id = DetectBufferTypeGetByName("http_header");
     const int httpacceptenc_id = DetectBufferTypeGetByName("http_accept_enc");
+    const int httpaccept_id = DetectBufferTypeGetByName("http_accept");
     const int httprawheader_id = DetectBufferTypeGetByName("http_raw_header");
     const int httpclientbody_id = DetectBufferTypeGetByName("http_client_body");
     const int httprawuri_id = DetectBufferTypeGetByName("http_raw_uri");
@@ -989,6 +991,11 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
                     rule_pcre_http += 1;
                     norm_http_buf += 1;
                     http_accept_enc_buf += 1;
+                }
+                else if (list_id == httpaccept_id) {
+                    rule_pcre_http += 1;
+                    norm_http_buf += 1;
+                    http_accept_buf += 1;
                 }
                 else if (list_id == httpcookie_id) {
                     rule_pcre_http += 1;
@@ -1287,6 +1294,7 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
         if (http_uri_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http uri buffer.\n");
         if (http_header_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http header buffer.\n");
         if (http_accept_enc_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http accept enc buffer.\n");
+        if (http_accept_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http accept buffer.\n");
         if (http_cookie_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http cookie buffer.\n");
         if (http_content_type_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http content type buffer.\n");
         if (http_raw_uri_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on http raw uri buffer.\n");


### PR DESCRIPTION
This commit adds handling for `http_accept` as highlighted in issue 3237

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:[3237](https://redmine.openinfosecfoundation.org/issues/3237)

Describe changes:
- Add handling for `http_accept` in the rules analysis.

