### PR TITLE
Feature 2694 thresholds by_rule by_both v3

### DIFF
--- a/doc/userguide/configuration/global-thresholds.rst
+++ b/doc/userguide/configuration/global-thresholds.rst
@@ -20,7 +20,7 @@ Syntax:
 ::
 
   threshold gen_id <gid>, sig_id <sid>, type <threshold|limit|both>, \
-    track <by_src|by_dst>, count <N>, seconds <T>
+    track <by_src|by_dst|by_rule|by_both>, count <N>, seconds <T>
 
 rate_filter
 ~~~~~~~~~~~

--- a/doc/userguide/rules/thresholding.rst
+++ b/doc/userguide/rules/thresholding.rst
@@ -16,7 +16,7 @@ frequency. It has 3 modes: threshold, limit and both.
 
 Syntax::
 
-  threshold: type <threshold|limit|both>, track <by_src|by_dst>, count <N>, seconds <T>
+  threshold: type <threshold|limit|both>, track <by_src|by_dst|by_rule|by_both>, count <N>, seconds <T>
 
 type "threshold"
 ~~~~~~~~~~~~~~~~
@@ -97,7 +97,7 @@ again.
 
 Syntax::
 
-  detection_filter: track <by_src|by_dst>, count <N>, seconds <T>
+  detection_filter: track <by_src|by_dst|by_rule|by_both>, count <N>, seconds <T>
 
 Example::
 

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -673,6 +673,32 @@ void ThresholdHashInit(DetectEngineCtx *de_ctx)
 }
 
 /**
+ * \brief Realloc threshold context hash tables
+ *
+ * \param de_ctx Detection Context
+ */
+void ThresholdHashRealloc(DetectEngineCtx *de_ctx)
+{
+    /* Return if we are already big enough */
+    uint32_t num = de_ctx->signum + 1;
+    if (num <= de_ctx->ths_ctx.th_size)
+        return;
+
+    void *ptmp = SCRealloc(de_ctx->ths_ctx.th_entry, num * sizeof(DetectThresholdEntry *));
+    if (ptmp == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory for rule thresholds"
+                " (tried to allocate %"PRIu32" th_entrys for rule tracking)", num);
+        exit(EXIT_FAILURE);
+    } else {
+        de_ctx->ths_ctx.th_entry = ptmp;
+        for (uint32_t i = de_ctx->ths_ctx.th_size; i < num; ++i) {
+            de_ctx->ths_ctx.th_entry[i] = NULL;
+        }
+        de_ctx->ths_ctx.th_size = num;
+    }
+}
+
+/**
  * \brief Destroy threshold context hash tables
  *
  * \param de_ctx Dectection Context

--- a/src/detect-engine-threshold.h
+++ b/src/detect-engine-threshold.h
@@ -43,6 +43,7 @@ int PacketAlertThreshold(DetectEngineCtx *, DetectEngineThreadCtx *,
         const Signature *, PacketAlert *);
 
 void ThresholdHashInit(DetectEngineCtx *);
+void ThresholdHashRealloc(DetectEngineCtx *);
 void ThresholdContextDestroy(DetectEngineCtx *);
 
 int ThresholdHostTimeoutCheck(Host *, struct timeval *);

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -389,12 +389,13 @@ static int ThresholdTestParse06(void)
 {
     DetectThresholdData *de = NULL;
     de = DetectThresholdParse("count 10, track by_both, seconds 60, type limit");
-    if (de && (de->type == TYPE_LIMIT) && (de->track == TRACK_BOTH) && (de->count == 10) && (de->seconds == 60)) {
-        DetectThresholdFree(de);
-        return 1;
-    }
-
-    return 0;
+    FAIL_IF_NULL(de);
+    FAIL_IF_NOT(de->type == TYPE_LIMIT);
+    FAIL_IF_NOT(de->track == TRACK_BOTH);
+    FAIL_IF_NOT(de->count == 10);
+    FAIL_IF_NOT(de->seconds == 60);
+    DetectThresholdFree(de);
+    PASS;
 }
 
 /**
@@ -407,13 +408,15 @@ static int ThresholdTestParse07(void)
 {
     DetectThresholdData *de = NULL;
     de = DetectThresholdParse("count 10, track by_rule, seconds 60, type limit");
-    if (de && (de->type == TYPE_LIMIT) && (de->track == TRACK_RULE) && (de->count == 10) && (de->seconds == 60)) {
-        DetectThresholdFree(de);
-        return 1;
-    }
-
-    return 0;
+    FAIL_IF_NULL(de);
+    FAIL_IF_NOT(de->type == TYPE_LIMIT);
+    FAIL_IF_NOT(de->track == TRACK_RULE);
+    FAIL_IF_NOT(de->count == 10);
+    FAIL_IF_NOT(de->seconds == 60);
+    DetectThresholdFree(de);
+    PASS;
 }
+
 /**
  * \test DetectThresholdTestSig1 is a test for checking the working of limit keyword
  *       by setting up the signature and later testing its working by matching
@@ -1514,6 +1517,160 @@ end:
     return result;
 }
 
+/**
+ * \test DetectThresholdTestSig13 is a test for checking the working by_rule limits
+ *       by setting up the signature and later testing its working by matching
+ *       received packets against the sig.
+ *
+ *  \retval 1 on succces
+ *  \retval 0 on failure
+ */
+
+static int DetectThresholdTestSig13(void)
+{
+    Packet *p = NULL;
+    Signature *s = NULL;
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx;
+    int alerts = 0;
+
+    HostInitConfig(HOST_QUIET);
+
+    memset(&th_v, 0, sizeof(th_v));
+    p = UTHBuildPacketReal((uint8_t *)"A",1,IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
+    FAIL_IF_NULL(p);
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    de_ctx->flags |= DE_QUIET;
+
+    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"Threshold limit sid 1\"; threshold: type limit, track by_rule, count 2, seconds 60; sid:1;)");
+    FAIL_IF_NULL(s);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+    ThresholdHashRealloc(de_ctx);
+
+    /* should alert twice */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
+    alerts += PacketAlertCheck(p, 1);
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
+    alerts += PacketAlertCheck(p, 1);
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
+    alerts += PacketAlertCheck(p, 1);
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
+    alerts += PacketAlertCheck(p, 1);
+
+    FAIL_IF(alerts != 2);
+
+    TimeSetIncrementTime(70);
+    TimeGet(&p->ts);
+
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
+    alerts += PacketAlertCheck(p, 1);
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
+    alerts += PacketAlertCheck(p, 1);
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
+    alerts += PacketAlertCheck(p, 1);
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
+    alerts += PacketAlertCheck(p, 1);
+
+    FAIL_IF(alerts != 4);
+
+    SigGroupCleanup(de_ctx);
+    SigCleanSignatures(de_ctx);
+    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    DetectEngineCtxFree(de_ctx);
+    UTHFreePackets(&p, 1);
+    HostShutdown();
+    PASS;
+}
+
+/**
+ * \test DetectThresholdTestSig14 is a test for checking the working by_both limits
+ *       by setting up the signature and later testing its working by matching
+ *       received packets against the sig.
+ *
+ *  \retval 1 on succces
+ *  \retval 0 on failure
+ */
+
+static int DetectThresholdTestSig14(void)
+{
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    Signature *s = NULL;
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx;
+    int alerts1 = 0;
+    int alerts2 = 0;
+
+    HostInitConfig(HOST_QUIET);
+    IPPairInitConfig(IPPAIR_QUIET);
+
+    memset(&th_v, 0, sizeof(th_v));
+    p1 = UTHBuildPacketReal((uint8_t *)"A",1,IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
+    p2 = UTHBuildPacketReal((uint8_t *)"A",1,IPPROTO_TCP, "1.1.1.1", "3.3.3.3", 1024, 80);
+    FAIL_IF_NULL(p1);
+    FAIL_IF_NULL(p2);
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    de_ctx->flags |= DE_QUIET;
+
+    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"Threshold limit sid 1\"; threshold: type limit, track by_both, count 2, seconds 60; sid:1;)");
+    FAIL_IF_NULL(s);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    /* Both p1 and p2 should alert twice */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+    alerts1 += PacketAlertCheck(p1, 1);
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+    alerts1 += PacketAlertCheck(p1, 1);
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+    alerts1 += PacketAlertCheck(p1, 1);
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+    alerts1 += PacketAlertCheck(p1, 1);
+
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+    alerts2 += PacketAlertCheck(p2, 1);
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+    alerts2 += PacketAlertCheck(p2, 1);
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+    alerts2 += PacketAlertCheck(p2, 1);
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+    alerts2 += PacketAlertCheck(p2, 1);
+
+    FAIL_IF(alerts1 != 2);
+    FAIL_IF(alerts2 != 2);
+
+    TimeSetIncrementTime(70);
+    TimeGet(&p1->ts);
+    TimeGet(&p2->ts);
+
+    /* Now they should both alert again after previous alerts expire */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+    alerts1 += PacketAlertCheck(p1, 1);
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+    alerts2 += PacketAlertCheck(p2, 1);
+
+    FAIL_IF(alerts1 != 3);
+    FAIL_IF(alerts2 != 3);
+
+    SigGroupCleanup(de_ctx);
+    SigCleanSignatures(de_ctx);
+    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    DetectEngineCtxFree(de_ctx);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    HostShutdown();
+    PASS;
+}
+
 #endif /* UNITTESTS */
 
 void ThresholdRegisterTests(void)
@@ -1539,6 +1696,8 @@ void ThresholdRegisterTests(void)
     UtRegisterTest("DetectThresholdTestSig10", DetectThresholdTestSig10);
     UtRegisterTest("DetectThresholdTestSig11", DetectThresholdTestSig11);
     UtRegisterTest("DetectThresholdTestSig12", DetectThresholdTestSig12);
+    UtRegisterTest("DetectThresholdTestSig13", DetectThresholdTestSig13);
+    UtRegisterTest("DetectThresholdTestSig14", DetectThresholdTestSig14);
 #endif /* UNITTESTS */
 }
 

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -244,6 +244,9 @@ static int DetectThresholdSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     if (de == NULL)
         goto error;
 
+    if (de->track == TRACK_RULE)
+        ThresholdHashRealloc(de_ctx);
+
     sm = SigMatchAlloc();
     if (sm == NULL)
         goto error;

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -59,7 +59,7 @@
 #include "util-cpu.h"
 #endif
 
-#define PARSE_REGEX "^\\s*(track|type|count|seconds)\\s+(limit|both|threshold|by_dst|by_src|\\d+)\\s*,\\s*(track|type|count|seconds)\\s+(limit|both|threshold|by_dst|by_src|\\d+)\\s*,\\s*(track|type|count|seconds)\\s+(limit|both|threshold|by_dst|by_src|\\d+)\\s*,\\s*(track|type|count|seconds)\\s+(limit|both|threshold|by_dst|by_src|\\d+)\\s*"
+#define PARSE_REGEX "^\\s*(track|type|count|seconds)\\s+(limit|both|threshold|by_dst|by_src|by_both|by_rule|\\d+)\\s*,\\s*(track|type|count|seconds)\\s+(limit|both|threshold|by_dst|by_src|by_both|by_rule|\\d+)\\s*,\\s*(track|type|count|seconds)\\s+(limit|both|threshold|by_dst|by_src|by_both|by_rule|\\d+)\\s*,\\s*(track|type|count|seconds)\\s+(limit|both|threshold|by_dst|by_src|by_both|by_rule|\\d+)\\s*"
 
 static pcre *parse_regex;
 static pcre_extra *parse_regex_study;
@@ -177,6 +177,10 @@ static DetectThresholdData *DetectThresholdParse(const char *rawstr)
             de->track = TRACK_DST;
         if (strncasecmp(args[i],"by_src",strlen("by_src")) == 0)
             de->track = TRACK_SRC;
+        if (strncasecmp(args[i],"by_both",strlen("by_both")) == 0)
+            de->track = TRACK_BOTH;
+        if (strncasecmp(args[i],"by_rule",strlen("by_rule")) == 0)
+            de->track = TRACK_RULE;
         if (strncasecmp(args[i],"count",strlen("count")) == 0)
             count_pos = i+1;
         if (strncasecmp(args[i],"seconds",strlen("seconds")) == 0)
@@ -372,7 +376,41 @@ static int ThresholdTestParse05(void)
     return 0;
 }
 
+/**
+ * \test ThresholdTestParse06 is a test for thresholding by_both
+ *
+ *  \retval 1 on succces
+ *  \retval 0 on failure
+ */
+static int ThresholdTestParse06(void)
+{
+    DetectThresholdData *de = NULL;
+    de = DetectThresholdParse("count 10, track by_both, seconds 60, type limit");
+    if (de && (de->type == TYPE_LIMIT) && (de->track == TRACK_BOTH) && (de->count == 10) && (de->seconds == 60)) {
+        DetectThresholdFree(de);
+        return 1;
+    }
 
+    return 0;
+}
+
+/**
+ * \test ThresholdTestParse07 is a test for thresholding by_rule
+ *
+ *  \retval 1 on succces
+ *  \retval 0 on failure
+ */
+static int ThresholdTestParse07(void)
+{
+    DetectThresholdData *de = NULL;
+    de = DetectThresholdParse("count 10, track by_rule, seconds 60, type limit");
+    if (de && (de->type == TYPE_LIMIT) && (de->track == TRACK_RULE) && (de->count == 10) && (de->seconds == 60)) {
+        DetectThresholdFree(de);
+        return 1;
+    }
+
+    return 0;
+}
 /**
  * \test DetectThresholdTestSig1 is a test for checking the working of limit keyword
  *       by setting up the signature and later testing its working by matching
@@ -1483,6 +1521,8 @@ void ThresholdRegisterTests(void)
     UtRegisterTest("ThresholdTestParse03", ThresholdTestParse03);
     UtRegisterTest("ThresholdTestParse04", ThresholdTestParse04);
     UtRegisterTest("ThresholdTestParse05", ThresholdTestParse05);
+    UtRegisterTest("ThresholdTestParse06", ThresholdTestParse06);
+    UtRegisterTest("ThresholdTestParse07", ThresholdTestParse07);
     UtRegisterTest("DetectThresholdTestSig1", DetectThresholdTestSig1);
     UtRegisterTest("DetectThresholdTestSig2", DetectThresholdTestSig2);
     UtRegisterTest("DetectThresholdTestSig3", DetectThresholdTestSig3);

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -38,6 +38,7 @@
 #include "detect.h"
 #include "detect-engine.h"
 #include "detect-engine-address.h"
+#include "detect-engine-threshold.h"
 #include "detect-threshold.h"
 #include "detect-parse.h"
 
@@ -453,7 +454,6 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectThresholdData *de = NULL;
-    void *ptmp;
 
     BUG_ON(parsed_type == TYPE_SUPPRESS);
 
@@ -505,17 +505,7 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
             sm->ctx = (void *)de;
 
             if (parsed_track == TRACK_RULE) {
-                ptmp = SCRealloc(de_ctx->ths_ctx.th_entry, (de_ctx->ths_ctx.th_size + 1) * sizeof(DetectThresholdEntry *));
-                if (ptmp == NULL) {
-                    SCFree(de_ctx->ths_ctx.th_entry);
-                    de_ctx->ths_ctx.th_entry = NULL;
-                    SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory for threshold config"
-                    " (tried to allocate %"PRIu32"th_entrys for rule tracking with rate_filter)", de_ctx->ths_ctx.th_size + 1);
-                } else {
-                    de_ctx->ths_ctx.th_entry = ptmp;
-                    de_ctx->ths_ctx.th_entry[de_ctx->ths_ctx.th_size] = NULL;
-                    de_ctx->ths_ctx.th_size++;
-                }
+                ThresholdHashRealloc(de_ctx);
             }
             SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD);
         }
@@ -558,17 +548,7 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
                 sm->ctx = (void *)de;
 
                 if (parsed_track == TRACK_RULE) {
-                    ptmp = SCRealloc(de_ctx->ths_ctx.th_entry, (de_ctx->ths_ctx.th_size + 1) * sizeof(DetectThresholdEntry *));
-                    if (ptmp == NULL) {
-                        SCFree(de_ctx->ths_ctx.th_entry);
-                        de_ctx->ths_ctx.th_entry = NULL;
-                        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory for threshold config"
-                        " (tried to allocate %"PRIu32"th_entrys for rule tracking with rate_filter)", de_ctx->ths_ctx.th_size + 1);
-                    } else {
-                        de_ctx->ths_ctx.th_entry = ptmp;
-                        de_ctx->ths_ctx.th_entry[de_ctx->ths_ctx.th_size] = NULL;
-                        de_ctx->ths_ctx.th_size++;
-                    }
+                    ThresholdHashRealloc(de_ctx);
                 }
                 SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD);
             }
@@ -642,17 +622,7 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
             sm->ctx = (void *)de;
 
             if (parsed_track == TRACK_RULE) {
-                 ptmp = SCRealloc(de_ctx->ths_ctx.th_entry, (de_ctx->ths_ctx.th_size + 1) * sizeof(DetectThresholdEntry *));
-                if (ptmp == NULL) {
-                    SCFree(de_ctx->ths_ctx.th_entry);
-                    de_ctx->ths_ctx.th_entry = NULL;
-                    SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory for threshold config"
-                    " (tried to allocate %"PRIu32"th_entrys for rule tracking with rate_filter)", de_ctx->ths_ctx.th_size + 1);
-                } else {
-                    de_ctx->ths_ctx.th_entry = ptmp;
-                    de_ctx->ths_ctx.th_entry[de_ctx->ths_ctx.th_size] = NULL;
-                    de_ctx->ths_ctx.th_size++;
-                }
+                ThresholdHashRealloc(de_ctx);
             }
 
             SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD);


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/2694) ticket: 2694

Describe changes:
- Accept by_rule and by_both in rule thresholds.
- Refactor threshold application to separate threshold table storage from threshold calculation.
- Ensure the by_rule threshold table is initialized when needed.
- Add tests for threshold parsing and application.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

