### PR TITLE
Forensic mode

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -277,7 +277,7 @@ The benefits here of using the extended logging is to see if this action for exa
 
 It is also possible to dump every header for HTTP requests/responses or both via the keyword ``dump-all-headers``.
 
-
+HTTP body and HTTP body printable can also be logged via the ``http-body`` and ``http-body-printable`` options.
 
 Examples
 ~~~~~~~~

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -62,6 +62,7 @@ Metadata::
             #packet: yes              # enable dumping of packet (without stream segments)
             #http-body: yes           # Requires metadata; enable dumping of http body in Base64
             #http-body-printable: yes # Requires metadata; enable dumping of http body in printable format
+            #http-headers: yes        # Requires metadata; enable dumping of http headers
 
             # metadata:
 
@@ -140,6 +141,10 @@ Config::
         # set this value to one among {both, request, response} to dump all
         # http headers for every http request and/or response
         # dump-all-headers: [both, request, response]
+        # Log request and response bodies with every request. This setup is
+        # recommended for forensic purpose only.
+        # http-body: yes
+        # http-body-printable: yes
 
 List of custom fields:
 
@@ -472,5 +477,18 @@ YAML::
       # Seed value for the ID output. Valid values are 0-65535.
       community-id-seed: 0
 
+
+Stream data
+~~~~~~~~~~~
+
+It is possible to include stream data in application layer events
+
+YAML::
+
+  
+  - eve-log:
+      # ....
+      stream-data: yes # log data as base64
+      stream-data-printable: yes # log printable data
 
 .. _deprecation policy: https://suricata-ids.org/about/deprecation-policy/

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -90,6 +90,7 @@
 #define LOG_JSON_HTTP_BODY_BASE64  BIT_U16(7)
 #define LOG_JSON_RULE_METADATA     BIT_U16(8)
 #define LOG_JSON_RULE              BIT_U16(9)
+#define LOG_JSON_HTTP_HEADERS      BIT_U16(10)
 
 #define METADATA_DEFAULTS ( LOG_JSON_FLOW |                        \
             LOG_JSON_APP_LAYER  |                                  \
@@ -433,6 +434,9 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                         }
                         if (json_output_ctx->flags & LOG_JSON_HTTP_BODY_BASE64) {
                             JsonHttpLogJSONBodyBase64(hjs, p->flow, pa->tx_id);
+                        }
+                        if (json_output_ctx->flags & LOG_JSON_HTTP_HEADERS) {
+                            JsonHttpLogAllJSONHeaders(hjs, p->flow, pa->tx_id);
                         }
                         json_object_set_new(js, "http", hjs);
                     }
@@ -831,6 +835,7 @@ static void JsonAlertLogSetupMetadata(AlertJsonOutputCtx *json_output_ctx,
         SetFlag(conf, "payload-printable", LOG_JSON_PAYLOAD, &flags);
         SetFlag(conf, "http-body-printable", LOG_JSON_HTTP_BODY, &flags);
         SetFlag(conf, "http-body", LOG_JSON_HTTP_BODY_BASE64, &flags);
+        SetFlag(conf, "http-headers", LOG_JSON_HTTP_HEADERS, &flags);
 
         /* Check for obsolete configuration flags to enable specific
          * protocols. These are now just aliases for enabling

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -406,7 +406,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 
-    JsonAddCommonOptions(&json_output_ctx->cfg, p, p->flow, js);
+    JsonAddCommonOptions(&json_output_ctx->cfg, p, p->flow, js, payload);
 
     for (i = 0; i < p->alerts.cnt; i++) {
         const PacketAlert *pa = &p->alerts.alerts[i];

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -120,7 +120,8 @@ static int AnomalyDecodeEventJson(ThreadVars *tv, JsonAnomalyLogThread *aft,
         if (!is_ip_pkt) {
             json_object_set_new(js, "timestamp", json_string(timebuf));
         } else {
-            JsonAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js);
+            JsonAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js,
+                                 aft->json_buffer);
         }
 
         if (aft->json_output_ctx->flags & LOG_JSON_PACKETHDR) {
@@ -180,7 +181,7 @@ static int AnomalyAppLayerDecoderEventJson(JsonAnomalyLogThread *aft,
             return TM_ECODE_OK;
         }
 
-        JsonAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js);
+        JsonAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js, aft->json_buffer);
 
         json_object_set_new(js, "app_proto", json_string(alprotoname));
 

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -51,6 +51,7 @@ typedef struct LogDHCPFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t    flags;
     void       *rs_logger;
+    OutputJsonCommonSettings cfg;
 } LogDHCPFileCtx;
 
 typedef struct LogDHCPLogThread_ {
@@ -76,6 +77,7 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
     }
     json_object_set_new(js, "dhcp", dhcp_js);
 
+    JsonAddCommonOptions(&thread->dhcplog_ctx->cfg, p, f, js, thread->buffer);
     MemBufferReset(thread->buffer);
     OutputJSONBuffer(js, thread->dhcplog_ctx->file_ctx, &thread->buffer);
     json_decref(js);
@@ -106,6 +108,7 @@ static OutputInitResult OutputDHCPLogInitSub(ConfNode *conf,
         return result;
     }
     dhcplog_ctx->file_ctx = ajt->file_ctx;
+    dhcplog_ctx->cfg = ajt->cfg;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -307,14 +307,14 @@ static int JsonDNP3LoggerToServer(ThreadVars *tv, void *thread_data,
 
     MemBuffer *buffer = (MemBuffer *)thread->buffer;
 
-    MemBufferReset(buffer);
     if (tx->has_request && tx->request_done) {
         json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "dnp3");
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
         }
 
-        JsonAddCommonOptions(&thread->dnp3log_ctx->cfg, p, f, js);
+        JsonAddCommonOptions(&thread->dnp3log_ctx->cfg, p, f, js, buffer);
+        MemBufferReset(buffer);
 
         json_t *dnp3js = JsonDNP3LogRequest(tx);
         if (dnp3js != NULL) {
@@ -336,14 +336,14 @@ static int JsonDNP3LoggerToClient(ThreadVars *tv, void *thread_data,
 
     MemBuffer *buffer = (MemBuffer *)thread->buffer;
 
-    MemBufferReset(buffer);
     if (tx->has_response && tx->response_done) {
         json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "dnp3");
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
         }
 
-        JsonAddCommonOptions(&thread->dnp3log_ctx->cfg, p, f, js);
+        JsonAddCommonOptions(&thread->dnp3log_ctx->cfg, p, f, js, buffer);
+        MemBufferReset(buffer);
 
         json_t *dnp3js = JsonDNP3LogResponse(tx);
         if (dnp3js != NULL) {

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -313,7 +313,7 @@ static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
         }
-        JsonAddCommonOptions(&dnslog_ctx->cfg, p, f, js);
+        JsonAddCommonOptions(&dnslog_ctx->cfg, p, f, js, td->buffer);
 
         json_t *dns = rs_dns_log_json_query(txptr, i, td->dnslog_ctx->flags);
         if (unlikely(dns == NULL)) {
@@ -345,7 +345,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 
-    JsonAddCommonOptions(&dnslog_ctx->cfg, p, f, js);
+    JsonAddCommonOptions(&dnslog_ctx->cfg, p, f, js, td->buffer);
 
     if (td->dnslog_ctx->version == DNS_VERSION_2) {
         json_t *answer = rs_dns_log_json_answer(txptr,

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -91,7 +91,7 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 
-    JsonAddCommonOptions(&drop_ctx->cfg, p, p->flow, js);
+    JsonAddCommonOptions(&drop_ctx->cfg, p, p->flow, js, NULL);
 
     json_t *djs = json_object();
     if (unlikely(djs == NULL)) {

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -305,7 +305,7 @@ static void JsonFlowLogJSON(JsonFlowLogThread *aft, json_t *js, Flow *f)
 
     json_object_set_new(js, "flow", hjs);
 
-    JsonAddCommonOptions(&flow_ctx->cfg, NULL, f, js);
+    JsonAddCommonOptions(&flow_ctx->cfg, NULL, f, js, NULL);
 
     /* TCP */
     if (f->proto == IPPROTO_TCP) {

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -161,7 +161,7 @@ static int JsonFTPLogger(ThreadVars *tv, void *thread_data,
 
     json_t *js = CreateJSONHeaderWithTxId(p, LOG_DIR_FLOW, event_type, tx_id);
     if (likely(js)) {
-        JsonAddCommonOptions(&ftp_ctx->cfg, p, f, js);
+        JsonAddCommonOptions(&ftp_ctx->cfg, p, f, js, thread->buffer);
         json_t *cjs = NULL;
         if (f->alproto == ALPROTO_FTPDATA) {
             cjs = JsonFTPDataAddMetadata(f);

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -75,14 +75,14 @@ typedef struct JsonHttpLogThread_ {
 #define MAX_SIZE_HEADER_NAME 256
 #define MAX_SIZE_HEADER_VALUE 2048
 
-#define LOG_HTTP_DEFAULT 0
-#define LOG_HTTP_EXTENDED 1
-#define LOG_HTTP_REQUEST 2 /* request field */
-#define LOG_HTTP_ARRAY 4 /* require array handling */
-#define LOG_HTTP_REQ_HEADERS 8
-#define LOG_HTTP_RES_HEADERS 16
-#define LOG_HTTP_BODY 32
-#define LOG_HTTP_BODY_PRINTABLE 64
+#define LOG_HTTP_DEFAULT        0
+#define LOG_HTTP_EXTENDED       BIT_U32(0)
+#define LOG_HTTP_REQUEST        BIT_U32(1) /* request field */
+#define LOG_HTTP_ARRAY          BIT_U32(2) /* require array handling */
+#define LOG_HTTP_REQ_HEADERS    BIT_U32(3)
+#define LOG_HTTP_RES_HEADERS    BIT_U32(4)
+#define LOG_HTTP_BODY           BIT_U32(5)
+#define LOG_HTTP_BODY_PRINTABLE BIT_U32(6)
 
 typedef enum {
     HTTP_FIELD_ACCEPT = 0,

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -582,6 +582,19 @@ json_t *JsonHttpAddMetadata(const Flow *f, uint64_t tx_id)
     return NULL;
 }
 
+void JsonHttpLogAllJSONHeaders(json_t *hjs, Flow *f, uint64_t tx_id)
+{
+
+    HtpState *htp_state = (HtpState *)FlowGetAppState(f);
+    if (htp_state) {
+        htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, tx_id);
+        if (tx) {
+            JsonHttpLogJSONHeaders(hjs, LOG_HTTP_REQ_HEADERS, tx);
+            JsonHttpLogJSONHeaders(hjs, LOG_HTTP_RES_HEADERS, tx);
+        }
+    }
+}
+
 static void OutputHttpLogDeinit(OutputCtx *output_ctx)
 {
     LogHttpFileCtx *http_ctx = output_ctx->data;

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2019 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -537,7 +537,7 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 
-    JsonAddCommonOptions(&jhl->httplog_ctx->cfg, p, f, js);
+    JsonAddCommonOptions(&jhl->httplog_ctx->cfg, p, f, js, jhl->buffer);
 
     SCLogDebug("got a HTTP request and now logging !!");
 

--- a/src/output-json-http.h
+++ b/src/output-json-http.h
@@ -29,6 +29,7 @@ void JsonHttpLogRegister(void);
 json_t *JsonHttpAddMetadata(const Flow *f, uint64_t tx_id);
 void JsonHttpLogJSONBodyPrintable(json_t *js, Flow *f, uint64_t tx_id);
 void JsonHttpLogJSONBodyBase64(json_t *js, Flow *f, uint64_t tx_id);
+void JsonHttpLogAllJSONHeaders(json_t *hjs, Flow *f, uint64_t tx_id);
 
 #endif /* __OUTPUT_JSON_HTTP_H__ */
 

--- a/src/output-json-ikev2.c
+++ b/src/output-json-ikev2.c
@@ -72,7 +72,8 @@ static int JsonIKEv2Logger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
-    JsonAddCommonOptions(&thread->ikev2log_ctx->cfg, p, f, js);
+    JsonAddCommonOptions(&thread->ikev2log_ctx->cfg, p, f, js,
+                         thread->buffer);
 
     ikev2js = rs_ikev2_log_json_response(state, ikev2tx);
     if (unlikely(ikev2js == NULL)) {

--- a/src/output-json-krb5.c
+++ b/src/output-json-krb5.c
@@ -72,7 +72,7 @@ static int JsonKRB5Logger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
-    JsonAddCommonOptions(&thread->krb5log_ctx->cfg, p, f, js);
+    JsonAddCommonOptions(&thread->krb5log_ctx->cfg, p, f, js, thread->buffer);
 
     krb5js = rs_krb5_log_json_response(state, krb5tx);
     if (unlikely(krb5js == NULL)) {

--- a/src/output-json-metadata.c
+++ b/src/output-json-metadata.c
@@ -85,7 +85,7 @@ static int MetadataJson(ThreadVars *tv, JsonMetadataLogThread *aft, const Packet
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 
-    JsonAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js);
+    JsonAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js, NULL);
     OutputJSONBuffer(js, aft->file_ctx, &aft->json_buffer);
     json_object_del(js, "metadata");
     json_object_clear(js);

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -304,7 +304,7 @@ static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
     JsonNetFlowLogJSONToServer(jhl, js, f);
-    JsonAddCommonOptions(&netflow_ctx->cfg, NULL, f, js);
+    JsonAddCommonOptions(&netflow_ctx->cfg, NULL, f, js, NULL);
     OutputJSONBuffer(js, jhl->flowlog_ctx->file_ctx, &jhl->buffer);
     json_object_del(js, "netflow");
     json_object_clear(js);
@@ -318,7 +318,7 @@ static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
         if (unlikely(js == NULL))
             return TM_ECODE_OK;
         JsonNetFlowLogJSONToClient(jhl, js, f);
-        JsonAddCommonOptions(&netflow_ctx->cfg, NULL, f, js);
+        JsonAddCommonOptions(&netflow_ctx->cfg, NULL, f, js, NULL);
         OutputJSONBuffer(js, jhl->flowlog_ctx->file_ctx, &jhl->buffer);
         json_object_del(js, "netflow");
         json_object_clear(js);

--- a/src/output-json-nfs.c
+++ b/src/output-json-nfs.c
@@ -89,7 +89,7 @@ static int JsonNFSLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
-    JsonAddCommonOptions(&thread->ctx->cfg, p, f, js);
+    JsonAddCommonOptions(&thread->ctx->cfg, p, f, js, thread->buffer);
 
     json_t *rpcjs = rs_rpc_log_json_response(tx);
     if (unlikely(rpcjs == NULL)) {

--- a/src/output-json-rdp.c
+++ b/src/output-json-rdp.c
@@ -46,6 +46,7 @@
 typedef struct LogRdpFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t    flags;
+    OutputJsonCommonSettings cfg;
 } LogRdpFileCtx;
 
 typedef struct LogRdpLogThread_ {
@@ -70,6 +71,7 @@ static int JsonRdpLogger(ThreadVars *tv, void *thread_data,
     }
     json_object_set_new(js, "rdp", rdp_js);
 
+    JsonAddCommonOptions(&thread->rdplog_ctx->cfg, p, f, js, thread->buffer);
     MemBufferReset(thread->buffer);
     OutputJSONBuffer(js, thread->rdplog_ctx->file_ctx, &thread->buffer);
     json_decref(js);
@@ -99,6 +101,7 @@ static OutputInitResult OutputRdpLogInitSub(ConfNode *conf,
         return result;
     }
     rdplog_ctx->file_ctx = ajt->file_ctx;
+    rdplog_ctx->cfg = ajt->cfg;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/output-json-sip.c
+++ b/src/output-json-sip.c
@@ -85,7 +85,7 @@ static int JsonSIPLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
-    JsonAddCommonOptions(&thread->siplog_ctx->cfg, p, f, js);
+    JsonAddCommonOptions(&thread->siplog_ctx->cfg, p, f, js, thread->buffer);
 
     sipjs = rs_sip_log_json(state, siptx);
     if (unlikely(sipjs == NULL)) {

--- a/src/output-json-smb.c
+++ b/src/output-json-smb.c
@@ -78,6 +78,7 @@ static int JsonSMBLogger(ThreadVars *tv, void *thread_data,
     }
     json_object_set_new(js, "smb", smbjs);
 
+    JsonAddCommonOptions(&thread->ctx->cfg, p, f, js, thread->buffer);
     MemBufferReset(thread->buffer);
     OutputJSONBuffer(js, thread->ctx->file_ctx, &thread->buffer);
 

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -90,10 +90,10 @@ static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 
+    JsonAddCommonOptions(&jhl->emaillog_ctx->cfg, p, f, js, jhl->buffer);
+
     /* reset */
     MemBufferReset(jhl->buffer);
-
-    JsonAddCommonOptions(&jhl->emaillog_ctx->cfg, p, f, js);
 
     json_t *sjs = JsonSmtpDataLogger(f, state, tx, tx_id);
     if (sjs) {

--- a/src/output-json-snmp.c
+++ b/src/output-json-snmp.c
@@ -72,7 +72,7 @@ static int JsonSNMPLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
-    JsonAddCommonOptions(&thread->snmplog_ctx->cfg, p, f, js);
+    JsonAddCommonOptions(&thread->snmplog_ctx->cfg, p, f, js, thread->buffer);
 
     snmpjs = rs_snmp_log_json_response(state, snmptx);
     if (unlikely(snmpjs == NULL)) {

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -107,7 +107,7 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
     if (unlikely(js == NULL))
         return 0;
 
-    JsonAddCommonOptions(&ssh_ctx->cfg, p, f, js);
+    JsonAddCommonOptions(&ssh_ctx->cfg, p, f, js, aft->buffer);
 
     json_t *tjs = json_object();
     if (tjs == NULL) {

--- a/src/output-json-tftp.c
+++ b/src/output-json-tftp.c
@@ -54,6 +54,7 @@
 typedef struct LogTFTPFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t    flags;
+    OutputJsonCommonSettings cfg;
 } LogTFTPFileCtx;
 
 typedef struct LogTFTPLogThread_ {
@@ -79,6 +80,7 @@ static int JsonTFTPLogger(ThreadVars *tv, void *thread_data,
 
     json_object_set_new(js, "tftp", tftpjs);
 
+    JsonAddCommonOptions(&thread->tftplog_ctx->cfg, p, f, js, thread->buffer);
     MemBufferReset(thread->buffer);
     OutputJSONBuffer(js, thread->tftplog_ctx->file_ctx, &thread->buffer);
 
@@ -108,6 +110,7 @@ static OutputInitResult OutputTFTPLogInitSub(ConfNode *conf,
         return result;
     }
     tftplog_ctx->file_ctx = ajt->file_ctx;
+    tftplog_ctx->cfg = ajt->cfg;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -416,7 +416,7 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         return 0;
     }
 
-    JsonAddCommonOptions(&tls_ctx->cfg, p, f, js);
+    JsonAddCommonOptions(&tls_ctx->cfg, p, f, js, aft->buffer);
 
     json_t *tjs = json_object();
     if (tjs == NULL) {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -72,6 +72,10 @@
 #define DEFAULT_ALERT_SYSLOG_LEVEL              LOG_INFO
 #define MODULE_NAME "OutputJSON"
 
+
+#define LOG_JSON_PAYLOAD           BIT_U16(0)
+#define LOG_JSON_PAYLOAD_BASE64    BIT_U16(1)
+
 #define MAX_JSON_SIZE 2048
 
 static void OutputJsonDeInitCtx(OutputCtx *);
@@ -387,12 +391,115 @@ static void JsonAddMetadata(const Packet *p, const Flow *f, json_t *js)
     }
 }
 
+static void JsonAddPayload(json_t *js, const Packet *p, uint16_t flags)
+{
+    if (flags & LOG_JSON_PAYLOAD_BASE64) {
+        unsigned long len = p->payload_len * 2 + 1;
+        uint8_t encoded[len];
+        if (Base64Encode(p->payload, p->payload_len, encoded, &len) == SC_BASE64_OK) {
+            json_object_set_new(js, "payload", json_string((char *)encoded));
+        }
+    }
+
+    if (flags & LOG_JSON_PAYLOAD) {
+        uint8_t printable_buf[p->payload_len + 1];
+        uint32_t offset = 0;
+        PrintStringsToBuffer(printable_buf, &offset,
+                p->payload_len + 1,
+                p->payload, p->payload_len);
+        printable_buf[p->payload_len] = '\0';
+        json_object_set_new(js, "payload_printable", json_string((char *)printable_buf));
+    }
+}
+
+
+
+/* Callback function to pack payload contents from a stream into a buffer
+ * so we can report them in JSON output. */
+static int JsonDumpStreamSegmentCallback(const Packet *p, void *data, const uint8_t *buf, uint32_t buflen)
+{
+    MemBuffer *payload = (MemBuffer *)data;
+    MemBufferWriteRaw(payload, buf, buflen);
+
+    return 1;
+}
+
+
+static void JsonAddStreamDataOneWay(const Packet *p, const Flow *f, json_t *js,
+                                    uint8_t flags, MemBuffer *payload, uint8_t flag)
+{
+    StreamSegmentForEach((const Packet *)p, flag,
+            JsonDumpStreamSegmentCallback,
+            (void *)payload);
+    if (payload->offset) {
+        if (flags & LOG_JSON_PAYLOAD_BASE64) {
+            unsigned long len = payload->offset * 2 + 1;
+            uint8_t encoded[len];
+            Base64Encode(payload->buffer, payload->offset, encoded, &len);
+            json_object_set_new(js, "payload", json_string((char *)encoded));
+        }
+
+        if (flags & LOG_JSON_PAYLOAD) {
+            uint8_t printable_buf[payload->offset + 1];
+            uint32_t offset = 0;
+            PrintStringsToBuffer(printable_buf, &offset,
+                    sizeof(printable_buf),
+                    payload->buffer, payload->offset);
+            json_object_set_new(js, "payload_printable",
+                    json_string((char *)printable_buf));
+        }
+    }
+}
+
+static void JsonAddStreamData(const Packet *p, const Flow *f, json_t *js,
+                              uint8_t flags, MemBuffer *payload)
+{
+    json_t *stream_js = json_object();
+    json_t *sjs = json_object();
+    json_t *cjs = json_object();
+
+    if (!stream_js || !cjs || !sjs)
+        return;
+
+    MemBufferReset(payload);
+    JsonAddStreamDataOneWay(p, f, sjs, flags, payload, FLOW_PKT_TOSERVER);
+    MemBufferReset(payload);
+    JsonAddStreamDataOneWay(p, f, cjs, flags, payload, FLOW_PKT_TOCLIENT);
+    if (json_object_size(sjs)) {
+        json_object_set_new(stream_js, "server", sjs);
+    } else {
+        json_decref(sjs);
+    }
+    if (json_object_size(cjs)) {
+        json_object_set_new(stream_js, "client", cjs);
+    } else {
+        json_decref(cjs);
+    }
+    if (json_object_size(stream_js)) {
+        json_object_set_new(js, "stream", stream_js);
+    } else {
+        json_decref(stream_js);
+        if (p->payload_len) {
+            /* Fallback on packet payload */
+            JsonAddPayload(js, p, flags);
+        }
+    }
+    MemBufferReset(payload);
+}
+
 void JsonAddCommonOptions(const OutputJsonCommonSettings *cfg,
-        const Packet *p, const Flow *f, json_t *js)
+        const Packet *p, const Flow *f, json_t *js, MemBuffer *payload)
 {
     if (cfg->include_metadata) {
         JsonAddMetadata(p, f, js);
     }
+
+    if (payload) {
+        if (cfg->include_streamdata) {
+            JsonAddStreamData(p, f, js, cfg->include_streamdata, payload);
+        }
+    }
+
     if (cfg->include_community_id && f != NULL) {
         CreateJSONCommunityFlowId(js, f, cfg->community_id_seed);
     }
@@ -1041,6 +1148,21 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
                            "invalid community-id-seed: %s", cid_seed);
                 exit(EXIT_FAILURE);
             }
+        }
+
+        json_ctx->cfg.include_streamdata = 0;
+        /* Check if stream data should be logged. */
+        const ConfNode *streamdata = ConfNodeLookupChild(conf, "stream-data");
+        if (streamdata && streamdata->val && ConfValIsTrue(streamdata->val)) {
+            SCLogConfig("Enabling eve stream data logging.");
+            json_ctx->cfg.include_streamdata |= LOG_JSON_PAYLOAD_BASE64;
+        }
+
+        /* Check if stream data should be logged. */
+        const ConfNode *streamdatap = ConfNodeLookupChild(conf, "stream-data-printable");
+        if (streamdatap && streamdatap->val && ConfValIsTrue(streamdatap->val)) {
+            SCLogConfig("Enabling eve stream data logging.");
+            json_ctx->cfg.include_streamdata |= LOG_JSON_PAYLOAD;
         }
 
         /* Do we have a global eve xff configuration? */

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -69,6 +69,7 @@ TmEcode JsonLogThreadDeinit(ThreadVars *t, void *data);
 typedef struct OutputJsonCommonSettings_ {
     bool include_metadata;
     bool include_community_id;
+    uint8_t include_streamdata;
     uint16_t community_id_seed;
 } OutputJsonCommonSettings;
 
@@ -93,6 +94,6 @@ json_t *JsonAddStringN(const char *string, size_t size);
 void SCJsonDecref(json_t *js);
 
 void JsonAddCommonOptions(const OutputJsonCommonSettings *cfg,
-        const Packet *p, const Flow *f, json_t *js);
+        const Packet *p, const Flow *f, json_t *js, MemBuffer *payload);
 
 #endif /* __OUTPUT_JSON_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -107,6 +107,9 @@ outputs:
 
       # Include top level metadata. Default yes.
       #metadata: no
+      # Include stream data in application layer events
+      #stream-data: yes
+      #stream-data-printable: yes
 
       # include the name of the input pcap file in pcap file processing mode
       pcap-file: false

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -151,6 +151,7 @@ outputs:
             # metadata: no             # enable inclusion of app layer metadata with alert. Default yes
             # http-body: yes           # Requires metadata; enable dumping of http body in Base64
             # http-body-printable: yes # Requires metadata; enable dumping of http body in printable format
+            # http-headers: yes        # Requires metadata; enable dumping of http headers
 
             # Enable the logging of tagged packets for rules using the
             # "tag" keyword.

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -197,7 +197,11 @@ outputs:
             #custom: [Accept-Encoding, Accept-Language, Authorization]
             # set this value to one among {both, request, response} to dump all
             # http headers for every http request and/or response
-            # dump-all-headers: [both, request, response]
+            #dump-all-headers: [both, request, response]
+            # Log request and response bodies with every request. This setup is
+            # recommended for forensic purpose only.
+            #http-body: yes
+            #http-body-printable: yes
         - dns:
             # This configuration uses the new DNS logging format,
             # the old configuration is still available:


### PR DESCRIPTION
This pull request adds some new features to logging.

The first one adds an option to log all HTTP headers in alert. As the alert is sometime on specific headers value, getting the all HTTP headers view in alert will help the analyst to understand the events.

The second feature adds HTTP body logging in HTTP events. This can be useful for forensic usage of Suricata.

The third feature adds stream data or payload logging to all NSM events. It is aiming at providing complete data for forensic study or for signature writers.

The output for an HTTP event looks like:

```JSON
  "stream": {
    "server": {
      "payload": "SFRUUC8xLjEgMjAwIE9LDQpEYXRlOiBXZWQsIDIyIE1hciAyMDE3IDA5OjExOjIyIEdNVA0KU2VydmVyOiBBcGFjaGUvMi40LjI1IChXaW4zMikgT3BlblNTTC8xLjAuMmogUEhQLzUuNi4zMA0KWC1Qb3dlcmVkLUJ5OiBQSFAvNS42LjMwDQpDb250ZW50LUxlbmd0aDogMjQ0DQpLZWVwLUFsaXZlOiB0aW1lb3V0PTUsIG1heD0xMDANCkNvbm5lY3Rpb246IEtlZXAtQWxpdmUNCkNvbnRlbnQtVHlwZTogdGV4dC9odG1sOyBjaGFyc2V0PVVURi04DQoNCjxiciAvPgo8Yj5Ob3RpY2U8L2I+OiAgVW5kZWZpbmVkIGluZGV4OiB2cyBpbiA8Yj5DOlx4YW1wcFxodGRvY3NcVG9ueV9TdGFyazJccG9zdC5waHA8L2I+IG9uIGxpbmUgPGI+MTE8L2I+PGJyIC8+CjxiciAvPgo8Yj5Ob3RpY2U8L2I+OiAgVW5kZWZpbmVkIHZhcmlhYmxlOiBzdWNjZXNzT1VkYW5nZXIgaW4gPGI+QzpceGFtcHBcaHRkb2NzXFRvbnlfU3RhcmsyXHBvc3QucGhwPC9iPiBvbiBsaW5lIDxiPjQ3PC9iPjxiciAvPgo=",
      "payload_printable": "HTTP/1.1 200 OK\r\nDate: Wed, 22 Mar 2017 09:11:22 GMT\r\nServer: Apache/2.4.25 (Win32) OpenSSL/1.0.2j PHP/5.6.30\r\nX-Powered-By: PHP/5.6.30\r\nContent-Length: 244\r\nKeep-Alive: timeout=5, max=100\r\nConnection: Keep-Alive\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n<br />\n<b>Notice</b>:  Undefined index: vs in <b>C:\\xampp\\htdocs\\Tony_Stark2\\post.php</b> on line <b>11</b><br />\n<br />\n<b>Notice</b>:  Undefined variable: successOUdanger in <b>C:\\xampp\\htdocs\\Tony_Stark2\\post.php</b> on line <b>47</b><br />\n"
    },
    "client": {
      "payload": "cGx1Z2luPVNlbStQbHVnaW4md2luZG93cz1XaW5kb3dzKzcrRW50ZXJwcmlzZSZ1c2VyPUFQSUFSWTctUEMmYXY9Tm8rQW50aXZpcnVzJmJzPU1pY3Jvc29mdCtFZGdl",
      "payload_printable": "plugin=Sem+Plugin&windows=Windows+7+Enterprise&user=APIARY7-PC&av=No+Antivirus&bs=Microsoft+Edge"
    }
  },
  "http": {
    "hostname": "contador.visitante-group-new.cf",
    "http_port": 8080,
    "url": "/Tony_Stark2/post.php",
    "http_user_agent": "Mozilla/3.0 (compatible; Indy Library)",
    "http_content_type": "text/html",
    "http_method": "POST",
    "protocol": "HTTP/1.0",
    "status": 200,
    "length": 244,
    "request_body": "cGx1Z2luPVNlbStQbHVnaW4md2luZG93cz1XaW5kb3dzKzcrRW50ZXJwcmlzZSZ1c2VyPUFQSUFSWTctUEMmYXY9Tm8rQW50aXZpcnVzJmJzPU1pY3Jvc29mdCtFZGdl",
    "response_body": "PGJyIC8+CjxiPk5vdGljZTwvYj46ICBVbmRlZmluZWQgaW5kZXg6IHZzIGluIDxiPkM6XHhhbXBwXGh0ZG9jc1xUb255X1N0YXJrMlxwb3N0LnBocDwvYj4gb24gbGluZSA8Yj4xMTwvYj48YnIgLz4KPGJyIC8+CjxiPk5vdGljZTwvYj46ICBVbmRlZmluZWQgdmFyaWFibGU6IHN1Y2Nlc3NPVWRhbmdlciBpbiA8Yj5DOlx4YW1wcFxodGRvY3NcVG9ueV9TdGFyazJccG9zdC5waHA8L2I+IG9uIGxpbmUgPGI+NDc8L2I+PGJyIC8+Cg==",
    "request_body_printable": "plugin=Sem+Plugin&windows=Windows+7+Enterprise&user=APIARY7-PC&av=No+Antivirus&bs=Microsoft+Edge",
    "response_body_printable": "<br />\n<b>Notice</b>:  Undefined index: vs in <b>C:\\xampp\\htdocs\\Tony_Stark2\\post.php</b> on line <b>11</b><br />\n<br />\n<b>Notice</b>:  Undefined variable: successOUdanger in <b>C:\\xampp\\htdocs\\Tony_Stark2\\post.php</b> on line <b>47</b><br />\n"
  }
}
```

For a protocol without stream like DNS we have:

```JSON
{
  "timestamp": "2016-10-15T08:58:37.457573+0200",
  "flow_id": 1166971934473061,
  "pcap_cnt": 4103,
  "event_type": "dns",
  "proto": "UDP",
  "payload": "Fw8BAAABAAAAAAAAA3d3dwVkaXZhcgJpcgAAAQAB",
  "payload_printable": ".............www.divar.ir.....",
  "dns": {
    "type": "query",
    "id": 5903,
    "rrname": "www.divar.ir",
    "rrtype": "A",
    "tx_id": 0
  }
}
```

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3339

Describe changes:
- option to log full HTTP headers in alert
- option to log HTTP body in HTTP events
- option to log stream data with NSM events
- fix #3339 by side effect

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/506
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/282
