### PR TITLE
detect/analyzer: Refactor engine analysis code 

### DIFF
--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -494,5 +494,8 @@ char *strptime(const char * __restrict, const char * __restrict, struct tm * __r
 extern int coverage_unittests;
 extern int g_ut_modules;
 extern int g_ut_covered;
+
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+
 #endif /* __SURICATA_COMMON_H__ */
 


### PR DESCRIPTION
Continuation of #3537 

This commit changes the analysis code to be table driven to better
identify the rule elements covered by the analysis.

This PR includes the fix required for [3237](https://redmine.openinfosecfoundation.org/issues/3237)

Describe changes:
-Address review comments.
