### PR TITLE
dns: log addresses in flow direction, not packet - v1

### DIFF
--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -309,7 +309,7 @@ static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
     }
 
     for (uint16_t i = 0; i < 0xffff; i++) {
-        js = CreateJSONHeader(p, LOG_DIR_PACKET, "dns");
+        js = CreateJSONHeader(p, LOG_DIR_FLOW, "dns");
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
         }
@@ -341,7 +341,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
         return TM_ECODE_OK;
     }
 
-    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "dns");
+    json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "dns");
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 


### PR DESCRIPTION
Ticket 3340.
https://redmine.openinfosecfoundation.org/issues/3340

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/766
https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/410