### PR TITLE
Issue 3345: Add TX detect flags to DHCP - v1

### DIFF
--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -544,6 +544,8 @@ pub unsafe extern "C" fn rs_template_register_parser() {
         set_tx_mpm_id: None,
         get_files: None,
         get_tx_iterator: Some(rs_template_state_get_tx_iterator),
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
 
     let ip_proto_str = CString::new("tcp").unwrap();

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -452,6 +452,8 @@ pub unsafe extern "C" fn rs_dhcp_register_parser() {
         set_tx_mpm_id      : None,
         get_files          : None,
         get_tx_iterator    : Some(rs_dhcp_state_get_tx_iterator),
+        set_tx_detect_flags: None,
+        get_tx_detect_flags: None,
     };
 
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -730,6 +730,8 @@ pub unsafe extern "C" fn rs_register_ikev2_parser() {
         set_tx_mpm_id      : None,
         get_files          : None,
         get_tx_iterator    : None,
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
 
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -669,6 +669,8 @@ pub unsafe extern "C" fn rs_register_krb5_parser() {
         set_tx_mpm_id      : None,
         get_files          : None,
         get_tx_iterator    : None,
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
     // register UDP parser
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -429,6 +429,8 @@ pub unsafe extern "C" fn rs_register_ntp_parser() {
         set_tx_mpm_id      : None,
         get_files          : None,
         get_tx_iterator    : None,
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
 
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -100,6 +100,12 @@ pub struct RustParser {
 
     /// Function to get the TX iterator
     pub get_tx_iterator:    Option<GetTxIteratorFn>,
+
+    // Function to set TX detect flags.
+    pub set_tx_detect_flags: Option<SetTxDetectFlagsFn>,
+
+    // Function to get TX detect flags.
+    pub get_tx_detect_flags: Option<GetTxDetectFlagsFn>,
 }
 
 
@@ -154,6 +160,8 @@ pub type GetTxIteratorFn    = extern "C" fn (ipproto: u8, alproto: AppProto,
                                              max_tx_id: u64,
                                              istate: &mut u64)
                                              -> AppLayerGetTxIterTuple;
+pub type GetTxDetectFlagsFn = extern "C" fn(*mut c_void, u8) -> u64;
+pub type SetTxDetectFlagsFn = extern "C" fn(*mut c_void, u8, u64);
 
 // Defined in app-layer-register.h
 extern {
@@ -185,4 +193,10 @@ extern {
     pub fn AppLayerParserStateIssetFlag(state: *mut c_void, flag: u8) -> c_int;
     pub fn AppLayerParserConfParserEnabled(ipproto: *const c_char, proto: *const c_char) -> c_int;
     pub fn AppLayerParserRegisterGetTxIterator(ipproto: u8, alproto: AppProto, fun: AppLayerGetTxIteratorFn);
+    pub fn AppLayerParserRegisterDetectFlagsFuncs(
+        ipproto: u8,
+        alproto: AppProto,
+        GetTxDetectFlats: GetTxDetectFlagsFn,
+        SetTxDetectFlags: SetTxDetectFlagsFn,
+    );
 }

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -531,6 +531,8 @@ pub unsafe extern "C" fn rs_rdp_register_parser() {
         set_tx_mpm_id: None,
         get_files: None,
         get_tx_iterator: None,
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
 
     /* For 5.0 we want this disabled by default, so check that it

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -422,6 +422,8 @@ pub unsafe extern "C" fn rs_sip_register_parser() {
         set_tx_mpm_id: None,
         get_files: None,
         get_tx_iterator: None,
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
 
     /* For 5.0 we want this disabled by default, so check that it

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -607,6 +607,8 @@ pub unsafe extern "C" fn rs_register_snmp_parser() {
         set_tx_mpm_id      : None,
         get_files          : None,
         get_tx_iterator    : None,
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
     let ip_proto_str = CString::new("udp").unwrap();
     if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {

--- a/src/app-layer-register.c
+++ b/src/app-layer-register.c
@@ -171,6 +171,11 @@ int AppLayerRegisterParser(const struct AppLayerParser *p, AppProto alproto)
                 p->GetTxIterator);
     }
 
+    if (p->SetTxDetectFlags && p->GetTxDetectFlags) {
+        AppLayerParserRegisterDetectFlagsFuncs(p->ip_proto, alproto,
+                p->GetTxDetectFlags, p->SetTxDetectFlags);
+    }
+
     return 0;
 }
 

--- a/src/app-layer-register.h
+++ b/src/app-layer-register.h
@@ -71,6 +71,9 @@ typedef struct AppLayerParser {
     AppLayerGetTxIterTuple (*GetTxIterator)(const uint8_t ipproto,
             const AppProto alproto, void *alstate, uint64_t min_tx_id,
             uint64_t max_tx_id, AppLayerGetTxIterState *istate);
+
+    void (*SetTxDetectFlags)(void *, uint8_t, uint64_t);
+    uint64_t (*GetTxDetectFlags)(void *, uint8_t);
 } AppLayerParser;
 
 /**


### PR DESCRIPTION
Add TX detect flag callbacks to the DHCP parser for proper
transaction cleanup. Addresses performance issue:

Ticket 3345:
https://redmine.openinfosecfoundation.org/issues/3345

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/412
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/768