### PR TITLE
4.1.x: app-layer: add tx detect flags to Rust parsers - v3

### DIFF
--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -539,6 +539,8 @@ pub unsafe extern "C" fn rs_template_register_parser() {
         set_tx_mpm_id: None,
         get_files: None,
         get_tx_iterator: Some(rs_template_state_get_tx_iterator),
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
 
     let ip_proto_str = CString::new("tcp").unwrap();

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -424,6 +424,8 @@ pub unsafe extern "C" fn rs_dhcp_register_parser() {
         set_tx_mpm_id: None,
         get_files: None,
         get_tx_iterator: Some(rs_dhcp_state_get_tx_iterator),
+        set_tx_detect_flags: None,
+        get_tx_detect_flags: None,
     };
 
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -27,6 +27,7 @@ use parser::*;
 use std;
 use std::ffi::{CStr,CString};
 use std::mem::transmute;
+use applayer::TxDetectFlags;
 
 static mut ALPROTO_DHCP: AppProto = ALPROTO_UNKNOWN;
 
@@ -87,6 +88,7 @@ pub struct DHCPTransaction {
     logged: applayer::LoggerFlags,
     de_state: Option<*mut core::DetectEngineState>,
     events: *mut core::AppLayerDecoderEvents,
+    detect_flags: TxDetectFlags,
 }
 
 impl DHCPTransaction {
@@ -97,6 +99,7 @@ impl DHCPTransaction {
             logged: applayer::LoggerFlags::new(),
             de_state: None,
             events: std::ptr::null_mut(),
+            detect_flags: Default::default(),
         }
     }
 
@@ -389,6 +392,9 @@ pub extern "C" fn rs_dhcp_state_get_tx_iterator(
     }
 }
 
+export_tx_detect_flags_set!(rs_dhcp_tx_detect_flags_set, DHCPTransaction);
+export_tx_detect_flags_get!(rs_dhcp_tx_detect_flags_get, DHCPTransaction);
+
 const PARSER_NAME: &'static [u8] = b"dhcp\0";
 
 #[no_mangle]
@@ -424,8 +430,8 @@ pub unsafe extern "C" fn rs_dhcp_register_parser() {
         set_tx_mpm_id: None,
         get_files: None,
         get_tx_iterator: Some(rs_dhcp_state_get_tx_iterator),
-        set_tx_detect_flags: None,
-        get_tx_detect_flags: None,
+        set_tx_detect_flags: rs_dhcp_tx_detect_flags_set,
+        get_tx_detect_flags: rs_dhcp_tx_detect_flags_get,
     };
 
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -685,6 +685,8 @@ pub unsafe extern "C" fn rs_register_ikev2_parser() {
         set_tx_mpm_id     : None,
         get_files         : None,
         get_tx_iterator   : None,
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
 
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -100,6 +100,7 @@ pub struct IKEV2Transaction {
     events: *mut core::AppLayerDecoderEvents,
 
     logged: applayer::LoggerFlags,
+    detect_flags: applayer::TxDetectFlags,
 }
 
 
@@ -410,6 +411,7 @@ impl IKEV2Transaction {
             de_state: None,
             events: std::ptr::null_mut(),
             logged: applayer::LoggerFlags::new(),
+            detect_flags: applayer::TxDetectFlags::default(),
         }
     }
 
@@ -651,6 +653,9 @@ pub extern "C" fn rs_ikev2_probing_parser(_flow: *const Flow,
     }
 }
 
+export_tx_detect_flags_set!(rs_ikev2_tx_detect_flags_set, IKEV2Transaction);
+export_tx_detect_flags_get!(rs_ikev2_tx_detect_flags_get, IKEV2Transaction);
+
 const PARSER_NAME : &'static [u8] = b"ikev2\0";
 
 #[no_mangle]
@@ -685,8 +690,8 @@ pub unsafe extern "C" fn rs_register_ikev2_parser() {
         set_tx_mpm_id     : None,
         get_files         : None,
         get_tx_iterator   : None,
-        get_tx_detect_flags: None,
-        set_tx_detect_flags: None,
+        get_tx_detect_flags: rs_ikev2_tx_detect_flags_get,
+        set_tx_detect_flags: rs_ikev2_tx_detect_flags_set,
     };
 
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -79,6 +79,7 @@ pub struct KRB5Transaction {
     events: *mut core::AppLayerDecoderEvents,
 
     logged: applayer::LoggerFlags,
+    detect_flags: applayer::TxDetectFlags,
 }
 
 pub fn to_hex_string(bytes: &[u8]) -> String {
@@ -230,6 +231,7 @@ impl KRB5Transaction {
             de_state: None,
             events: std::ptr::null_mut(),
             logged: applayer::LoggerFlags::new(),
+            detect_flags: applayer::TxDetectFlags::default(),
         }
     }
 }
@@ -600,6 +602,8 @@ pub extern "C" fn rs_krb5_parse_response_tcp(_flow: *const core::Flow,
     status
 }
 
+export_tx_detect_flags_set!(rs_krb5_tx_detect_flags_set, KRB5Transaction);
+export_tx_detect_flags_get!(rs_krb5_tx_detect_flags_get, KRB5Transaction);
 
 const PARSER_NAME : &'static [u8] = b"krb5\0";
 
@@ -635,8 +639,8 @@ pub unsafe extern "C" fn rs_register_krb5_parser() {
         set_tx_mpm_id     : None,
         get_files         : None,
         get_tx_iterator   : None,
-        get_tx_detect_flags: None,
-        set_tx_detect_flags: None,
+        get_tx_detect_flags: rs_krb5_tx_detect_flags_get,
+        set_tx_detect_flags: rs_krb5_tx_detect_flags_set,
     };
     // register UDP parser
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -635,6 +635,8 @@ pub unsafe extern "C" fn rs_register_krb5_parser() {
         set_tx_mpm_id     : None,
         get_files         : None,
         get_tx_iterator   : None,
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
     // register UDP parser
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -397,6 +397,8 @@ pub unsafe extern "C" fn rs_register_ntp_parser() {
         set_tx_mpm_id     : None,
         get_files         : None,
         get_tx_iterator   : None,
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
 
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -67,6 +67,7 @@ pub struct NTPTransaction {
     events: *mut core::AppLayerDecoderEvents,
 
     logged: applayer::LoggerFlags,
+    detect_flags: applayer::TxDetectFlags,
 }
 
 
@@ -151,6 +152,7 @@ impl NTPTransaction {
             de_state: None,
             events: std::ptr::null_mut(),
             logged: applayer::LoggerFlags::new(),
+            detect_flags: applayer::TxDetectFlags::default(),
         }
     }
 
@@ -362,6 +364,8 @@ pub extern "C" fn ntp_probing_parser(_flow: *const Flow, input:*const u8, input_
         },
     }
 }
+export_tx_detect_flags_set!(rs_ntp_tx_detect_flags_set, NTPTransaction);
+export_tx_detect_flags_get!(rs_ntp_tx_detect_flags_get, NTPTransaction);
 
 const PARSER_NAME : &'static [u8] = b"ntp\0";
 
@@ -397,8 +401,8 @@ pub unsafe extern "C" fn rs_register_ntp_parser() {
         set_tx_mpm_id     : None,
         get_files         : None,
         get_tx_iterator   : None,
-        get_tx_detect_flags: None,
-        set_tx_detect_flags: None,
+        get_tx_detect_flags: rs_ntp_tx_detect_flags_get,
+        set_tx_detect_flags: rs_ntp_tx_detect_flags_set,
     };
 
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -156,8 +156,8 @@ pub type GetTxIteratorFn    = extern "C" fn (ipproto: u8, alproto: AppProto,
                                              max_tx_id: u64,
                                              istate: &mut u64)
                                              -> AppLayerGetTxIterTuple;
-pub type GetTxDetectFlagsFn = extern "C" fn(*mut c_void, u8) -> u64;
-pub type SetTxDetectFlagsFn = extern "C" fn(*mut c_void, u8, u64);
+pub type GetTxDetectFlagsFn = unsafe extern "C" fn(*mut c_void, u8) -> u64;
+pub type SetTxDetectFlagsFn = unsafe extern "C" fn(*mut c_void, u8, u64);
 
 // Defined in app-layer-register.h
 extern {

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -97,6 +97,12 @@ pub struct RustParser {
 
     /// Function to get the TX iterator
     pub get_tx_iterator:   Option<GetTxIteratorFn>,
+
+    // Function to set TX detect flags.
+    pub set_tx_detect_flags: SetTxDetectFlagsFn,
+
+    // Function to get TX detect flags.
+    pub get_tx_detect_flags: GetTxDetectFlagsFn,
 }
 
 
@@ -150,6 +156,8 @@ pub type GetTxIteratorFn    = extern "C" fn (ipproto: u8, alproto: AppProto,
                                              max_tx_id: u64,
                                              istate: &mut u64)
                                              -> AppLayerGetTxIterTuple;
+pub type GetTxDetectFlagsFn = extern "C" fn(*mut c_void, u8) -> u64;
+pub type SetTxDetectFlagsFn = extern "C" fn(*mut c_void, u8, u64);
 
 // Defined in app-layer-register.h
 extern {
@@ -173,4 +181,10 @@ extern {
     pub fn AppLayerParserStateSetFlag(state: *mut c_void, flag: u8);
     pub fn AppLayerParserStateIssetFlag(state: *mut c_void, flag: u8) -> c_int;
     pub fn AppLayerParserConfParserEnabled(ipproto: *const c_char, proto: *const c_char) -> c_int;
+    pub fn AppLayerParserRegisterDetectFlagsFuncs(
+        ipproto: u8,
+        alproto: AppProto,
+        GetTxDetectFlags: GetTxDetectFlagsFn,
+        SetTxDetectFlags: SetTxDetectFlagsFn,
+    );
 }

--- a/src/app-layer-register.c
+++ b/src/app-layer-register.c
@@ -167,6 +167,11 @@ int AppLayerRegisterParser(const struct AppLayerParser *p, AppProto alproto)
                 p->GetTxIterator);
     }
 
+    if (p->SetTxDetectFlags && p->GetTxDetectFlags) {
+        AppLayerParserRegisterDetectFlagsFuncs(p->ip_proto, alproto,
+                p->GetTxDetectFlags, p->SetTxDetectFlags);
+    }
+
     return 0;
 }
 

--- a/src/app-layer-register.h
+++ b/src/app-layer-register.h
@@ -69,6 +69,9 @@ typedef struct AppLayerParser {
     AppLayerGetTxIterTuple (*GetTxIterator)(const uint8_t ipproto,
             const AppProto alproto, void *alstate, uint64_t min_tx_id,
             uint64_t max_tx_id, AppLayerGetTxIterState *istate);
+
+    void (*SetTxDetectFlags)(void *, uint8_t, uint64_t);
+    uint64_t (*GetTxDetectFlags)(void *, uint8_t);
 } AppLayerParser;
 
 /**

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -277,6 +277,8 @@ void RegisterTFTPParsers(void)
                                            TFTPStateGetEventInfo);
         AppLayerParserRegisterGetEventsFunc(IPPROTO_UDP, ALPROTO_TFTP,
                                             TFTPGetEvents);
+
+        rs_tftp_register(ALPROTO_TFTP);
     }
     else {
         SCLogDebug("TFTP protocol parsing disabled.");


### PR DESCRIPTION
Adds transaction detect flags to Rust parsers that didn't
already have them registered.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/771
- https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/415