### PR TITLE
detect: improve handling of rules with byte_extract variables

### DIFF
--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -247,6 +247,10 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
                 prev_buffer_offset = 0;
             }
 
+            if (cd->flags & (DETECT_CONTENT_DISTANCE_BE|DETECT_CONTENT_OFFSET_BE| DETECT_CONTENT_DEPTH_BE)) {
+                 depth += offset;
+            }
+
             /* update offset with prev_offset if we're searching for
              * matches after the first occurence. */
             SCLogDebug("offset %"PRIu32", prev_offset %"PRIu32, offset, prev_offset);

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -252,7 +252,7 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
             }
 
             /* update offset with prev_offset if we're searching for
-             * matches after the first occurence. */
+             * matches after the first occurrence. */
             SCLogDebug("offset %"PRIu32", prev_offset %"PRIu32, offset, prev_offset);
             if (prev_offset != 0)
                 offset = prev_offset;
@@ -336,7 +336,7 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
                     KEYWORD_PROFILING_END(det_ctx, smd->type, 1);
 
                     /* see if the next buffer keywords match. If not, we will
-                     * search for another occurence of this content and see
+                     * search for another occurrence of this content and see
                      * if the others match then until we run out of matches */
                     int r = DetectEngineContentInspection(de_ctx, det_ctx, s, smd+1,
                             p, f, buffer, buffer_len, stream_start_offset, flags,
@@ -437,7 +437,7 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
             prev_offset = det_ctx->pcre_match_start_offset;
 
             /* see if the next payload keywords match. If not, we will
-             * search for another occurence of this pcre and see
+             * search for another occurrence of this pcre and see
              * if the others match, until we run out of matches */
             r = DetectEngineContentInspection(de_ctx, det_ctx, s, smd+1,
                     p, f, buffer, buffer_len, stream_start_offset, flags,

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -74,7 +74,7 @@ const char *builtin_mpms[] = {
 
     NULL };
 
-/* Registery for mpm keywords
+/* Registry for mpm keywords
  *
  * Keywords are registered at engine start up
  */
@@ -690,7 +690,7 @@ void PatternMatchThreadPrepare(MpmThreadCtx *mpm_thread_ctx, uint16_t mpm_matche
  *  Longer patterns score better than short patters.
  *
  *  \param pat pattern
- *  \param patlen length of the patternn
+ *  \param patlen length of the pattern
  *
  *  \retval s pattern score
  */
@@ -1756,7 +1756,7 @@ int DetectSetFastPatternAndItsId(DetectEngineCtx *de_ctx)
     if (struct_total_size + content_total_size == 0)
         return 0;
 
-    /* array hash buffer - i've run out of ideas to name it */
+    /* array hash buffer - I've run out of ideas to name it */
     uint8_t *ahb = SCMalloc(sizeof(uint8_t) * (struct_total_size + content_total_size));
     if (unlikely(ahb == NULL))
         return -1;
@@ -1827,7 +1827,7 @@ int DetectSetFastPatternAndItsId(DetectEngineCtx *de_ctx)
                 /* Need to store case-insensitive patterns as lower case
                  * because SCMemcmpLowercase() above assumes that all
                  * patterns are stored lower case so that it doesn't
-                 * need to relower its first argument.
+                 * need to re-lower its first argument.
                  */
                 memcpy_tolower(struct_offset->content, content, content_len);
             } else {

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -736,6 +736,10 @@ static void PopulateMpmHelperAddPattern(MpmCtx *mpm_ctx,
         }
     }
 
+    if (cd->flags & (DETECT_CONTENT_DEPTH_BE | DETECT_CONTENT_OFFSET_BE)) {
+            pat_depth = pat_offset = 0;
+    }
+
     if (cd->flags & DETECT_CONTENT_NOCASE) {
         if (chop) {
             MpmAddPatternCI(mpm_ctx,


### PR DESCRIPTION
This commit improves handling of byte_extract variables as highlighted in issue 3047

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:(3047)[https://redmine.openinfosecfoundation.org/issues/3047]

Describe changes:
-  Ensure that depth is updated if coming from a variable
- Adjust depth and offset for MpM adds when value comes from a variable.

There are existing suricata-verify tests: https://github.com/OISF/suricata-verify/pull/86
