### PR TITLE
Transform urldecode 2689 v4

### DIFF
--- a/doc/userguide/rules/transforms.rst
+++ b/doc/userguide/rules/transforms.rst
@@ -106,3 +106,8 @@ Example::
 
 .. note:: depends on libnss being compiled into Suricata
 
+url_decode
+----------
+
+Decodes url-encoded data, ie replacing '+' with space and '%HH' with its value.
+This does not decode unicode '%uZZZZ' encoding

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -283,6 +283,7 @@ detect-transform-md5.c detect-transform-md5.h \
 detect-transform-sha1.c detect-transform-sha1.h \
 detect-transform-sha256.c detect-transform-sha256.h \
 detect-transform-dotprefix.c detect-transform-dotprefix.h \
+detect-transform-urldecode.c detect-transform-urldecode.h \
 detect-ttl.c detect-ttl.h \
 detect-uricontent.c detect-uricontent.h \
 detect-urilen.c detect-urilen.h \

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -202,6 +202,7 @@
 #include "detect-transform-sha1.h"
 #include "detect-transform-sha256.h"
 #include "detect-transform-dotprefix.h"
+#include "detect-transform-urldecode.h"
 
 #include "util-rule-vars.h"
 
@@ -572,6 +573,7 @@ void SigTableSetup(void)
     DetectTransformSha1Register();
     DetectTransformSha256Register();
     DetectTransformDotPrefixRegister();
+    DetectTransformUrlDecodeRegister();
 
     /* close keyword registration */
     DetectBufferTypeCloseRegistration();

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -259,6 +259,7 @@ enum DetectKeywordId {
     DETECT_TRANSFORM_SHA1,
     DETECT_TRANSFORM_SHA256,
     DETECT_TRANSFORM_DOTPREFIX,
+    DETECT_TRANSFORM_URL_DECODE,
 
     /* make sure this stays last */
     DETECT_TBLSIZE,

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -258,6 +258,7 @@ static InspectionBuffer *HttpClientBodyGetDataCallback(DetectEngineThreadCtx *de
     StreamingBufferGetDataAtOffset(body->sb,
             &data, &data_len, offset);
     InspectionBufferSetup(buffer, data, data_len);
+    InspectionBufferApplyTransforms(buffer, transforms);
     buffer->inspect_offset = offset;
 
     /* move inspected tracker to end of the data. HtpBodyPrune will consider

--- a/src/detect-transform-urldecode.c
+++ b/src/detect-transform-urldecode.c
@@ -1,0 +1,167 @@
+/* Copyright (C) 2019 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Philippe Antoine <p.antoine@catenacyber.fr>
+ *
+ * Implements the url_decode transform keyword
+ */
+
+#include "suricata-common.h"
+
+#include "detect.h"
+#include "detect-engine.h"
+#include "detect-engine-prefilter.h"
+#include "detect-parse.h"
+#include "detect-transform-urldecode.h"
+
+#include "util-unittest.h"
+#include "util-print.h"
+//isxdigit
+#include <ctype.h>
+
+static int DetectTransformUrlDecodeSetup (DetectEngineCtx *, Signature *, const char *);
+static void DetectTransformUrlDecodeRegisterTests(void);
+
+static void TransformUrlDecode(InspectionBuffer *buffer);
+
+void DetectTransformUrlDecodeRegister(void)
+{
+    sigmatch_table[DETECT_TRANSFORM_URL_DECODE].name = "url_decode";
+    sigmatch_table[DETECT_TRANSFORM_URL_DECODE].desc =
+        "modify buffer to decode urlencoded data before inspection";
+    sigmatch_table[DETECT_TRANSFORM_URL_DECODE].url =
+        DOC_URL DOC_VERSION "/rules/transforms.html#url-decode";
+    sigmatch_table[DETECT_TRANSFORM_URL_DECODE].Transform =
+        TransformUrlDecode;
+    sigmatch_table[DETECT_TRANSFORM_URL_DECODE].Setup =
+        DetectTransformUrlDecodeSetup;
+    sigmatch_table[DETECT_TRANSFORM_URL_DECODE].RegisterTests =
+        DetectTransformUrlDecodeRegisterTests;
+
+    sigmatch_table[DETECT_TRANSFORM_URL_DECODE].flags |= SIGMATCH_NOOPT;
+}
+
+/**
+ *  \internal
+ *  \brief Apply the transform keyword to the last pattern match
+ *  \param det_ctx detection engine ctx
+ *  \param s signature
+ *  \param nullstr should be null
+ *  \retval 0 ok
+ *  \retval -1 failure
+ */
+static int DetectTransformUrlDecodeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *nullstr)
+{
+    SCEnter();
+    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_URL_DECODE);
+    SCReturnInt(r);
+}
+
+// util function so as to ease reuse sometimes
+static uint32_t BufferUrlDecode(const uint8_t *input, const uint32_t input_len, uint8_t *output)
+{
+    uint8_t *oi = output;
+    //PrintRawDataFp(stdout, input, input_len);
+    for (uint32_t i = 0; i < input_len; i++) {
+        if (input[i] == '%') {
+            if (i + 2 < input_len) {
+                if ((isxdigit(input[i+1])) && (isxdigit(input[i+2]))) {
+                    // Decode %HH encoding.
+                    *oi = (input[i+1] >= 'A' ? ((input[i+1] & 0xdf) - 'A') + 10 : (input[i+1] - '0')) << 4;
+                    *oi |= (input[i+2] >= 'A' ? ((input[i+2] & 0xdf) - 'A') + 10 : (input[i+2] - '0'));
+                    oi++;
+                    // one more increment before looping
+                    i += 2;
+                } else {
+                    // leaves incorrect percent
+                    // does not handle unicode %u encoding
+                    *oi++ = input[i];
+                }
+            } else {
+                // leaves trailing incomplete percent
+                *oi++ = input[i];
+            }
+        } else if (input[i] == '+') {
+            *oi++ = ' ';
+        } else {
+            *oi++ = input[i];
+        }
+    }
+    return oi - output;
+}
+
+static void TransformUrlDecode(InspectionBuffer *buffer)
+{
+    const uint8_t *input = buffer->inspect;
+    const uint32_t input_len = buffer->inspect_len;
+    uint8_t output[input_len]; // we can only shrink
+
+    uint32_t output_size = BufferUrlDecode(input, input_len, output);
+
+    InspectionBufferCopy(buffer, output, output_size);
+}
+
+#ifdef UNITTESTS
+static int DetectTransformUrlDecodeTest01(void)
+{
+    const uint8_t *input = (const uint8_t *)"Suricata%20is+%27%61wesome%21%27%25%30%30%ZZ%4";
+    uint32_t input_len = strlen((char *)input);
+
+    InspectionBuffer buffer;
+    InspectionBufferInit(&buffer, 8);
+    InspectionBufferSetup(&buffer, input, input_len);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    TransformUrlDecode(&buffer);
+    PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
+    FAIL_IF (buffer.inspect_len != strlen("Suricata is 'awesome!'%00%ZZ%4"));
+    FAIL_IF (memcmp(buffer.inspect, "Suricata is 'awesome!'%00%ZZ%4", buffer.inspect_len) != 0);
+    InspectionBufferFree(&buffer);
+    PASS;
+}
+
+static int DetectTransformUrlDecodeTest02(void)
+{
+    const char rule[] = "alert http any any -> any any (http.request_body; url_decode; content:\"mail=test@oisf.net\"; sid:1;)";
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    memset(&th_v, 0, sizeof(th_v));
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, rule);
+    FAIL_IF_NULL(s);
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+#endif
+
+static void DetectTransformUrlDecodeRegisterTests(void)
+{
+#ifdef UNITTESTS
+    UtRegisterTest("DetectTransformUrlDecodeTest01",
+            DetectTransformUrlDecodeTest01);
+    UtRegisterTest("DetectTransformUrlDecodeTest02",
+            DetectTransformUrlDecodeTest02);
+#endif
+}

--- a/src/detect-transform-urldecode.h
+++ b/src/detect-transform-urldecode.h
@@ -1,0 +1,30 @@
+/* Copyright (C) 2019 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Philippe Antoine <p.antoine@catenacyber.fr>
+ */
+
+#ifndef __DETECT_TRANSFORM_URLDECODE_H__
+#define __DETECT_TRANSFORM_URLDECODE_H__
+
+/* prototypes */
+void DetectTransformUrlDecodeRegister (void);
+
+#endif /* __DETECT_TRANSFORM_URLDECODE_H__ */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2689

Describe changes:
- Adds url_decode transform keyword (and even updates the doc)

There are some open questions :
- should this PR limit the size of the input buffer ? as mentioned here https://redmine.openinfosecfoundation.org/issues/2689#note-1
- What should be the behavior in the case the transform fails ? (that is the buffer is not a valid url-encoded one and has patterns such as `%ZZ`) Right, now I keep undecoded data (like https://www.urldecoder.org for instance)
- The use of a transform looked good to me as it can get reused and is only computed if needed, but there is the suggestion to do it like `http_uri`

There is no reuse of libhtp code as libhtp `htp_decode_path_inplace` mixes more context, such as setting `response_status_expected_number` for the transaction...

Makes test https://github.com/OISF/suricata-verify/pull/146 pass

Modifies #4364 by taking comment into account and rebasing