### PR TITLE
detect/analyzer: Suppress direction warnings

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1189,9 +1189,13 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
         warn_no_direction += 1;
         rule_warning += 1;
     }
-    if ((s->flags & (SIG_FLAG_TOSERVER|SIG_FLAG_TOCLIENT)) == (SIG_FLAG_TOSERVER|SIG_FLAG_TOCLIENT)) {
-        warn_both_direction += 1;
-        rule_warning += 1;
+
+    /* No warning about direction for ICMP protos */
+    if (!(DetectProtoContainsProto(&s->proto, IPPROTO_ICMP) && DetectProtoContainsProto(&s->proto, IPPROTO_ICMP))) {
+        if ((s->flags & (SIG_FLAG_TOSERVER|SIG_FLAG_TOCLIENT)) == (SIG_FLAG_TOSERVER|SIG_FLAG_TOCLIENT)) {
+            warn_both_direction += 1;
+            rule_warning += 1;
+        }
     }
 
     if (!rule_warnings_only || (rule_warnings_only && rule_warning > 0)) {


### PR DESCRIPTION
This commit suppresses direction warnings by the rules analyzer for ICMP
and ICMPV6 since it's not actionable.


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:(3103)[https://redmine.openinfosecfoundation.org/issues/3103]

Describe changes:
- Suppress direction warnings for ICMP, ICMPv6
