### PR TITLE
detect: improve handling of rules with byte_extract variables

### DIFF
--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -246,6 +246,13 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
                 prev_buffer_offset = 0;
             }
 
+            /* If the value came from a variable, make sure to adjust the depth so it's relative
+             * to the offset value.
+             */
+            if (cd->flags & (DETECT_CONTENT_DISTANCE_BE|DETECT_CONTENT_OFFSET_BE|DETECT_CONTENT_DEPTH_BE)) {
+                 depth += offset;
+            }
+
             /* update offset with prev_offset if we're searching for
              * matches after the first occurence. */
             SCLogDebug("offset %"PRIu32", prev_offset %"PRIu32, offset, prev_offset);

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -611,6 +611,13 @@ static void PopulateMpmHelperAddPattern(MpmCtx *mpm_ctx,
         }
     }
 
+    /* We have to effectively "wild card" values that will be coming from
+     * byte_extract variables
+     */
+    if (cd->flags & (DETECT_CONTENT_DEPTH_BE | DETECT_CONTENT_OFFSET_BE)) {
+        pat_depth = pat_offset = 0;
+    }
+
     if (cd->flags & DETECT_CONTENT_NOCASE) {
         if (chop) {
             MpmAddPatternCI(mpm_ctx,


### PR DESCRIPTION
PR for backport of #4391 to release 4.1.x

This commit improves handling of byte_extract variables as highlighted in issue: (3369)[https://redmine.openinfosecfoundation.org/issues/3369]