### PR TITLE
App-layer TX detect flag fixups - v3

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -16,6 +16,7 @@
  */
 
 use std;
+use core::{STREAM_TOSERVER};
 
 #[repr(C)]
 pub struct AppLayerGetTxIterTuple {
@@ -95,4 +96,50 @@ macro_rules!export_tx_set_detect_state {
             0
         }
     )
+}
+
+#[derive(Debug,Default)]
+pub struct TxDetectFlags {
+    ts: u64,
+    tc: u64,
+}
+
+impl TxDetectFlags {
+    pub fn set(&mut self, direction: u8, flags: u64) {
+        if direction & STREAM_TOSERVER != 0 {
+            self.ts = flags;
+        } else {
+            self.tc = flags;
+        }
+    }
+
+    pub fn get(&self, direction: u8) -> u64 {
+        if (direction & STREAM_TOSERVER) != 0 {
+            self.ts
+        } else {
+            self.tc
+        }
+    }
+}
+
+#[macro_export]
+macro_rules!export_tx_detect_flags_set {
+    ($name:ident, $type:ty) => {
+        #[no_mangle]
+        pub unsafe extern "C" fn $name(tx: *mut std::os::raw::c_void, direction: u8, flags: u64) {
+            let tx = &mut *(tx as *mut $type);
+            tx.detect_flags.set(direction, flags);
+        }
+    }
+}
+
+#[macro_export]
+macro_rules!export_tx_detect_flags_get {
+    ($name:ident, $type:ty) => {
+        #[no_mangle]
+        pub unsafe extern "C" fn $name(tx: *mut std::os::raw::c_void, direction: u8) -> u64 {
+            let tx = &mut *(tx as *mut $type);
+            return tx.detect_flags.get(direction);
+        }
+    }
 }

--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -544,6 +544,8 @@ pub unsafe extern "C" fn rs_template_register_parser() {
         set_tx_mpm_id: None,
         get_files: None,
         get_tx_iterator: Some(rs_template_state_get_tx_iterator),
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
 
     let ip_proto_str = CString::new("tcp").unwrap();

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -452,6 +452,8 @@ pub unsafe extern "C" fn rs_dhcp_register_parser() {
         set_tx_mpm_id      : None,
         get_files          : None,
         get_tx_iterator    : Some(rs_dhcp_state_get_tx_iterator),
+        set_tx_detect_flags: None,
+        get_tx_detect_flags: None,
     };
 
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -730,6 +730,8 @@ pub unsafe extern "C" fn rs_register_ikev2_parser() {
         set_tx_mpm_id      : None,
         get_files          : None,
         get_tx_iterator    : None,
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
 
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -669,6 +669,8 @@ pub unsafe extern "C" fn rs_register_krb5_parser() {
         set_tx_mpm_id      : None,
         get_files          : None,
         get_tx_iterator    : None,
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
     // register UDP parser
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -89,6 +89,7 @@ pub struct KRB5Transaction {
     events: *mut core::AppLayerDecoderEvents,
 
     logged: applayer::LoggerFlags,
+    detect_flags: applayer::TxDetectFlags,
 }
 
 pub fn to_hex_string(bytes: &[u8]) -> String {
@@ -240,6 +241,7 @@ impl KRB5Transaction {
             de_state: None,
             events: std::ptr::null_mut(),
             logged: applayer::LoggerFlags::new(),
+            detect_flags: applayer::TxDetectFlags::default(),
         }
     }
 }
@@ -633,6 +635,8 @@ pub extern "C" fn rs_krb5_parse_response_tcp(_flow: *const core::Flow,
     status
 }
 
+export_tx_detect_flags_set!(rs_krb5_tx_detect_flags_set, KRB5Transaction);
+export_tx_detect_flags_get!(rs_krb5_tx_detect_flags_get, KRB5Transaction);
 
 const PARSER_NAME : &'static [u8] = b"krb5\0";
 
@@ -669,8 +673,8 @@ pub unsafe extern "C" fn rs_register_krb5_parser() {
         set_tx_mpm_id      : None,
         get_files          : None,
         get_tx_iterator    : None,
-        get_tx_detect_flags: None,
-        set_tx_detect_flags: None,
+        get_tx_detect_flags: Some(rs_krb5_tx_detect_flags_get),
+        set_tx_detect_flags: Some(rs_krb5_tx_detect_flags_set),
     };
     // register UDP parser
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -429,6 +429,8 @@ pub unsafe extern "C" fn rs_register_ntp_parser() {
         set_tx_mpm_id      : None,
         get_files          : None,
         get_tx_iterator    : None,
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
 
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -100,6 +100,12 @@ pub struct RustParser {
 
     /// Function to get the TX iterator
     pub get_tx_iterator:    Option<GetTxIteratorFn>,
+
+    // Function to set TX detect flags.
+    pub set_tx_detect_flags: Option<SetTxDetectFlagsFn>,
+
+    // Function to get TX detect flags.
+    pub get_tx_detect_flags: Option<GetTxDetectFlagsFn>,
 }
 
 
@@ -154,6 +160,8 @@ pub type GetTxIteratorFn    = extern "C" fn (ipproto: u8, alproto: AppProto,
                                              max_tx_id: u64,
                                              istate: &mut u64)
                                              -> AppLayerGetTxIterTuple;
+pub type GetTxDetectFlagsFn = unsafe extern "C" fn(*mut c_void, u8) -> u64;
+pub type SetTxDetectFlagsFn = unsafe extern "C" fn(*mut c_void, u8, u64);
 
 // Defined in app-layer-register.h
 extern {
@@ -185,4 +193,10 @@ extern {
     pub fn AppLayerParserStateIssetFlag(state: *mut c_void, flag: u8) -> c_int;
     pub fn AppLayerParserConfParserEnabled(ipproto: *const c_char, proto: *const c_char) -> c_int;
     pub fn AppLayerParserRegisterGetTxIterator(ipproto: u8, alproto: AppProto, fun: AppLayerGetTxIteratorFn);
+    pub fn AppLayerParserRegisterDetectFlagsFuncs(
+        ipproto: u8,
+        alproto: AppProto,
+        GetTxDetectFlats: GetTxDetectFlagsFn,
+        SetTxDetectFlags: SetTxDetectFlagsFn,
+    );
 }

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -531,6 +531,8 @@ pub unsafe extern "C" fn rs_rdp_register_parser() {
         set_tx_mpm_id: None,
         get_files: None,
         get_tx_iterator: None,
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
 
     /* For 5.0 we want this disabled by default, so check that it

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -422,6 +422,8 @@ pub unsafe extern "C" fn rs_sip_register_parser() {
         set_tx_mpm_id: None,
         get_files: None,
         get_tx_iterator: None,
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
 
     /* For 5.0 we want this disabled by default, so check that it

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -97,6 +97,7 @@ pub struct SNMPTransaction {
     events: *mut core::AppLayerDecoderEvents,
 
     logged: applayer::LoggerFlags,
+    detect_flags: applayer::TxDetectFlags,
 }
 
 
@@ -274,6 +275,7 @@ impl SNMPTransaction {
             de_state: None,
             events: std::ptr::null_mut(),
             logged: applayer::LoggerFlags::new(),
+            detect_flags: applayer::TxDetectFlags::default(),
         }
     }
 
@@ -572,6 +574,9 @@ pub extern "C" fn rs_snmp_probing_parser(_flow: *const Flow,
     }
 }
 
+export_tx_detect_flags_set!(rs_snmp_set_tx_detect_flags, SNMPTransaction);
+export_tx_detect_flags_get!(rs_snmp_get_tx_detect_flags, SNMPTransaction);
+
 const PARSER_NAME : &'static [u8] = b"snmp\0";
 
 #[no_mangle]
@@ -607,8 +612,8 @@ pub unsafe extern "C" fn rs_register_snmp_parser() {
         set_tx_mpm_id      : None,
         get_files          : None,
         get_tx_iterator    : None,
-        get_tx_detect_flags: None,
-        set_tx_detect_flags: None,
+        get_tx_detect_flags: Some(rs_snmp_get_tx_detect_flags),
+        set_tx_detect_flags: Some(rs_snmp_set_tx_detect_flags),
     };
     let ip_proto_str = CString::new("udp").unwrap();
     if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -607,6 +607,8 @@ pub unsafe extern "C" fn rs_register_snmp_parser() {
         set_tx_mpm_id      : None,
         get_files          : None,
         get_tx_iterator    : None,
+        get_tx_detect_flags: None,
+        set_tx_detect_flags: None,
     };
     let ip_proto_str = CString::new("udp").unwrap();
     if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {

--- a/src/app-layer-dcerpc.c
+++ b/src/app-layer-dcerpc.c
@@ -2039,6 +2039,26 @@ static int DCERPCGetAlstateProgress(void *tx, uint8_t direction)
     return 0;
 }
 
+static void DCERPCSetTxDetectFlags(void *vtx, uint8_t dir, uint64_t flags)
+{
+    DCERPCState *dcerpc_state = (DCERPCState *)vtx;
+    if (dir & STREAM_TOSERVER) {
+        dcerpc_state->detect_flags_ts = flags;
+    } else {
+        dcerpc_state->detect_flags_tc = flags;
+    }
+}
+
+static uint64_t DCERPCGetTxDetectFlags(void *vtx, uint8_t dir)
+{
+    DCERPCState *dcerpc_state = (DCERPCState *)vtx;
+    if (dir & STREAM_TOSERVER) {
+        return dcerpc_state->detect_flags_ts;
+    } else {
+        return dcerpc_state->detect_flags_tc;
+    }
+}
+
 static int DCERPCRegisterPatternsForProtocolDetection(void)
 {
     if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_DCERPC,
@@ -2092,6 +2112,8 @@ void RegisterDCERPCParsers(void)
 
         AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_DCERPC,
                                                                DCERPCGetAlstateProgressCompletionStatus);
+        AppLayerParserRegisterDetectFlagsFuncs(IPPROTO_TCP, ALPROTO_DCERPC,
+                DCERPCGetTxDetectFlags, DCERPCSetTxDetectFlags);
     } else {
         SCLogInfo("Parsed disabled for %s protocol. Protocol detection"
                   "still on.", proto_name);

--- a/src/app-layer-dcerpc.h
+++ b/src/app-layer-dcerpc.h
@@ -35,6 +35,8 @@ typedef struct DCERPCState_ {
     DCERPC dcerpc;
     uint8_t data_needed_for_dir;
     DetectEngineState *de_state;
+    uint64_t detect_flags_ts;
+    uint64_t detect_flags_tc;
 } DCERPCState;
 
 void DCERPCInit(DCERPC *dcerpc);

--- a/src/app-layer-enip-common.h
+++ b/src/app-layer-enip-common.h
@@ -210,6 +210,8 @@ typedef struct ENIPTransaction_
 
     TAILQ_ENTRY(ENIPTransaction_) next;
     DetectEngineState *de_state;
+    uint64_t detect_flags_ts;
+    uint64_t detect_flags_tc;
 } ENIPTransaction;
 
 /** \brief Per flow ENIP state container */

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -88,6 +88,26 @@ static int ENIPSetTxDetectState(void *vtx, DetectEngineState *s)
     return 0;
 }
 
+static uint64_t ENIPGetTxDetectFlags(void *vtx, uint8_t dir)
+{
+    ENIPTransaction *tx = (ENIPTransaction *)vtx;
+    if (dir & STREAM_TOSERVER) {
+        return tx->detect_flags_ts;
+    } else {
+        return tx->detect_flags_tc;
+    }
+}
+
+static void ENIPSetTxDetectFlags(void *vtx, uint8_t dir, uint64_t flags)
+{
+    ENIPTransaction *tx = (ENIPTransaction *)vtx;
+    if (dir &STREAM_TOSERVER) {
+        tx->detect_flags_ts = flags;
+    } else {
+        tx->detect_flags_tc = flags;
+    }
+}
+
 static void *ENIPGetTx(void *alstate, uint64_t tx_id)
 {
     ENIPState         *enip = (ENIPState *) alstate;
@@ -450,6 +470,8 @@ void RegisterENIPUDPParsers(void)
 
         AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_UDP,
                 ALPROTO_ENIP, STREAM_TOSERVER | STREAM_TOCLIENT);
+        AppLayerParserRegisterDetectFlagsFuncs(IPPROTO_UDP, ALPROTO_ENIP,
+                ENIPGetTxDetectFlags, ENIPSetTxDetectFlags);
 
     } else
     {
@@ -533,6 +555,8 @@ void RegisterENIPTCPParsers(void)
         /* This parser accepts gaps. */
         AppLayerParserRegisterOptionFlags(IPPROTO_TCP, ALPROTO_ENIP,
                 APP_LAYER_PARSER_OPT_ACCEPT_GAPS);
+        AppLayerParserRegisterDetectFlagsFuncs(IPPROTO_TCP, ALPROTO_ENIP,
+                ENIPGetTxDetectFlags, ENIPSetTxDetectFlags);
 
     } else
     {

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1211,6 +1211,26 @@ static DetectEngineState *FTPDataGetTxDetectState(void *vtx)
     return ftp_state->de_state;
 }
 
+static void FTPDataSetTxDetectFlags(void *vtx, uint8_t dir, uint64_t flags)
+{
+    FtpDataState *ftp_state = (FtpDataState *)vtx;
+    if (dir & STREAM_TOSERVER) {
+        ftp_state->detect_flags_ts = flags;
+    } else {
+        ftp_state->detect_flags_tc = flags;
+    }
+}
+
+static uint64_t FTPDataGetTxDetectFlags(void *vtx, uint8_t dir)
+{
+    FtpDataState *ftp_state = (FtpDataState *)vtx;
+    if (dir & STREAM_TOSERVER) {
+        return ftp_state->detect_flags_ts;
+    } else {
+        return ftp_state->detect_flags_tc;
+    }
+}
+
 static void FTPDataStateTransactionFree(void *state, uint64_t tx_id)
 {
     /* do nothing */
@@ -1337,6 +1357,8 @@ void RegisterFTPParsers(void)
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_FTPDATA, FTPDataStateTransactionFree);
         AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_FTPDATA,
                 FTPDataGetTxDetectState, FTPDataSetTxDetectState);
+        AppLayerParserRegisterDetectFlagsFuncs(IPPROTO_TCP, ALPROTO_FTPDATA,
+                FTPDataGetTxDetectFlags, FTPDataSetTxDetectFlags);
 
         AppLayerParserRegisterGetFilesFunc(IPPROTO_TCP, ALPROTO_FTPDATA, FTPDataStateGetFiles);
 

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -209,6 +209,8 @@ typedef struct FtpDataState_ {
     FtpRequestCommand command;
     uint8_t state;
     uint8_t direction;
+    uint64_t detect_flags_ts;
+    uint64_t detect_flags_tc;
 } FtpDataState;
 
 void RegisterFTPParsers(void);

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -274,6 +274,26 @@ static LoggerId ModbusGetTxLogged(void *alstate, void *vtx)
     return tx->logged;
 }
 
+static void ModbusSetTxDetectFlags(void *vtx, uint8_t dir, uint64_t flags)
+{
+    ModbusTransaction *tx = (ModbusTransaction *)vtx;
+    if (dir & STREAM_TOSERVER) {
+        tx->detect_flags_ts = flags;
+    } else {
+        tx->detect_flags_ts = flags;
+    }
+}
+
+static uint64_t ModbusGetTxDetectFlags(void *vtx, uint8_t dir)
+{
+    ModbusTransaction *tx = (ModbusTransaction *)vtx;
+    if (dir & STREAM_TOSERVER) {
+        return tx->detect_flags_ts;
+    } else {
+        return tx->detect_flags_tc;
+    }
+}
+
 static uint64_t ModbusGetTxCnt(void *alstate)
 {
     return ((uint64_t) ((ModbusState *) alstate)->transaction_max);
@@ -1547,6 +1567,8 @@ void RegisterModbusParsers(void)
         AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_MODBUS, ModbusStateGetEventInfoById);
 
         AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_TCP, ALPROTO_MODBUS, STREAM_TOSERVER);
+        AppLayerParserRegisterDetectFlagsFuncs(IPPROTO_TCP, ALPROTO_MODBUS,
+                ModbusGetTxDetectFlags, ModbusSetTxDetectFlags);
 
         AppLayerParserSetStreamDepth(IPPROTO_TCP, ALPROTO_MODBUS, stream_depth);
     } else {

--- a/src/app-layer-modbus.h
+++ b/src/app-layer-modbus.h
@@ -114,6 +114,8 @@ typedef struct ModbusTransaction_ {
 
     AppLayerDecoderEvents *decoder_events;  /**< per tx events */
     DetectEngineState *de_state;
+    uint64_t detect_flags_ts;
+    uint64_t detect_flags_tc;
 
     TAILQ_ENTRY(ModbusTransaction_) next;
 } ModbusTransaction;

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1497,6 +1497,9 @@ static void ValidateParserProto(AppProto alproto, uint8_t ipproto)
     if (!(BOTH_SET_OR_BOTH_UNSET(ctx->GetTxDetectState, ctx->SetTxDetectState))) {
         goto bad;
     }
+    if (!(BOTH_SET_OR_BOTH_UNSET(ctx->GetTxDetectFlags, ctx->SetTxDetectFlags))) {
+        goto bad;
+    }
 
     return;
 bad:

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1149,6 +1149,17 @@ int AppLayerParserSetTxDetectState(const Flow *f,
     SCReturnInt(r);
 }
 
+bool AppLayerParserSupportsTxDetectFlags(AppProto alproto)
+{
+    SCEnter();
+    for (uint8_t p = 0; p < FLOW_PROTO_APPLAYER_MAX; p++) {
+        if (alp_ctx.ctxs[p][alproto].GetTxDetectFlags != NULL) {
+            SCReturnBool(true);
+        }
+    }
+    SCReturnBool(false);
+}
+
 uint64_t AppLayerParserGetTxDetectFlags(uint8_t ipproto, AppProto alproto, void *tx, uint8_t dir)
 {
     SCEnter();

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -227,6 +227,7 @@ int AppLayerParserSetTxDetectState(const Flow *f, void *tx, DetectEngineState *s
 
 uint64_t AppLayerParserGetTxDetectFlags(uint8_t ipproto, AppProto alproto, void *tx, uint8_t dir);
 void AppLayerParserSetTxDetectFlags(uint8_t ipproto, AppProto alproto, void *tx, uint8_t dir, uint64_t);
+bool AppLayerParserSupportsTxDetectFlags(AppProto alproto);
 
 /***** General *****/
 

--- a/src/app-layer-register.c
+++ b/src/app-layer-register.c
@@ -171,6 +171,11 @@ int AppLayerRegisterParser(const struct AppLayerParser *p, AppProto alproto)
                 p->GetTxIterator);
     }
 
+    if (p->SetTxDetectFlags && p->GetTxDetectFlags) {
+        AppLayerParserRegisterDetectFlagsFuncs(p->ip_proto, alproto,
+                p->GetTxDetectFlags, p->SetTxDetectFlags);
+    }
+
     return 0;
 }
 

--- a/src/app-layer-register.h
+++ b/src/app-layer-register.h
@@ -71,6 +71,9 @@ typedef struct AppLayerParser {
     AppLayerGetTxIterTuple (*GetTxIterator)(const uint8_t ipproto,
             const AppProto alproto, void *alstate, uint64_t min_tx_id,
             uint64_t max_tx_id, AppLayerGetTxIterState *istate);
+
+    void (*SetTxDetectFlags)(void *, uint8_t, uint64_t);
+    uint64_t (*GetTxDetectFlags)(void *, uint8_t);
 } AppLayerParser;
 
 /**

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -171,6 +171,13 @@ void DetectAppLayerInspectEngineRegister(const char *name,
         AppProto alproto, uint32_t dir,
         int progress, InspectEngineFuncPtr Callback)
 {
+    if (AppLayerParserIsTxAware(alproto)) {
+        if (!AppLayerParserSupportsTxDetectFlags(alproto)) {
+            FatalError(SC_ERR_INITIALIZATION,
+                "Inspect engine registered for app-layer protocol without "
+                "TX detect flag support: %s", AppProtoToString(alproto));
+        }
+    }
     DetectBufferTypeRegister(name);
     const int sm_list = DetectBufferTypeGetByName(name);
     if (sm_list == -1) {

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -352,6 +352,8 @@ extern int sc_log_module_cleaned;
 
 #define SCReturnPtr(x, type)            return x
 
+#define SCReturnBool(x)                 return x
+
 /* Please use it only for debugging purposes */
 #else
 
@@ -529,6 +531,24 @@ extern int sc_log_module_cleaned;
                                   if (sc_log_global_log_level >= SC_LOG_DEBUG) { \
                                       SCLogDebug("Returning pointer %p of "  \
                                               "type %s ... <<", x, type);    \
+                                      SCLogCheckFDFilterExit(__FUNCTION__);  \
+                                  }                                          \
+                                  return x;                                  \
+                              } while(0)
+
+/**
+ * \brief Macro used to log debug messages on function exit.  Comes under the
+ *        debugging sybsystem, and hence will be enabled only in the presence
+ *        of the DEBUG macro.  Apart from logging function_exit logs, it also
+ *        processes the FD filters, if any FD filters are registered.  This
+ *        function_exit macro should be used for functions that returns a
+ *        boolean value.
+ *
+ * \retval x Variable of type 'bool' that has to be returned
+ */
+#define SCReturnBool(x)        do {                                           \
+                                  if (sc_log_global_log_level >= SC_LOG_DEBUG) { \
+                                      SCLogDebug("Returning: %s ... <<", x ? "true" : "false"); \
                                       SCLogCheckFDFilterExit(__FUNCTION__);  \
                                   }                                          \
                                   return x;                                  \


### PR DESCRIPTION
When a detect engine is being registered, first check that
there is a parser registered for the AL proto, and if so,
make sure it has TX detect flag support.

The check to make sure the AL proto has a parser registered
is to avoid the error message when the parser is disabled
in the configuration file. I feel like there might
be a cleaner way to do this.

Note that this check is mainly for development time, and
we should not see this error in any release.

Add TX detect flags to app-layer parsers that were
missing them and register detection engines.

Previous PR:
https://github.com/OISF/suricata/pull/4401

Changes from last PR:
- Address comments.

Related Redmine issues:
https://redmine.openinfosecfoundation.org/issues/3356

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/418
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/774
