### PR TITLE
4.1.x - configure: add python3 to python's to look for - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -87,7 +87,7 @@
 
     AC_ARG_ENABLE(python,
            AS_HELP_STRING([--enable-python], [Enable python]),[enable_python=$enableval],[enable_python=yes])
-    AC_PATH_PROGS(HAVE_PYTHON, python python2 python2.7, "no")
+    AC_PATH_PROGS(HAVE_PYTHON, python python2 python2.7 python3, "no")
     if test "x$enable_python" = "xno" ; then
         echo
         echo "   Warning! python disabled, you will not be      "


### PR DESCRIPTION
When looking for a Python binary, also look for python3.
This is getting more and more likely to be the case
like on a minimal install of Fedora 31.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/775
https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/419