### PR TITLE
detect/analyzer: Improved fast pattern display

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -526,10 +526,18 @@ static void EngineAnalysisRulesPrintFP(const DetectEngineCtx *de_ctx, const Sign
         const char *name = DetectBufferTypeGetNameById(de_ctx, list_type);
         if (desc && name) {
             fprintf(rule_engine_analysis_FD, "%s (%s)", desc, name);
+        } else if (desc || name) {
+            fprintf(rule_engine_analysis_FD, "%s", desc ? desc : name);
         }
+
     }
 
-    fprintf(rule_engine_analysis_FD, "\" buffer.\n");
+    fprintf(rule_engine_analysis_FD, "\" ");
+    if (de_ctx->buffer_type_map[list_type] && de_ctx->buffer_type_map[list_type]->transforms.cnt) {
+        fprintf(rule_engine_analysis_FD, "(with %d transform(s)) ",
+                de_ctx->buffer_type_map[list_type]->transforms.cnt);
+    }
+    fprintf(rule_engine_analysis_FD, "buffer.\n");
 
     return;
 }
@@ -1056,6 +1064,7 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
 
                 rule_pcre_http++;
                 analyzer_items[item_slot].item_seen = true;
+
             } else if (sm->type == DETECT_CONTENT) {
                 if (item_slot == -1) {
                     rule_content++;


### PR DESCRIPTION
When transforms are part of a rule, improve information displayed with
fast patterns to include the original buffer name and whether any
transform(s) are applied.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:[3350](https://redmine.openinfosecfoundation.org/issues/3350)

Describe changes:
- When displaying information about a fast pattern, ensure that one of the buffer name or description is included.
