### PR TITLE
configure: fixing rust/cargo cross compile command

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2338,6 +2338,7 @@ fi
     AM_CONDITIONAL([HAVE_PDFLATEX], [test "x$enable_pdflatex" != "xno"])
 
 # Cargo/Rust
+    AM_CONDITIONAL([RUST_CROSS_COMPILE], [test "x$cross_compiling" = "xyes"])
     AC_PATH_PROG(RUSTC, rustc, "no")
     if test "$RUSTC" = "no"; then
         echo ""
@@ -2394,10 +2395,17 @@ fi
         echo
         exit 1
     fi
-    if test "x$enable_debug" = "xyes"; then
-      RUST_SURICATA_LIB="../rust/target/debug/${RUST_SURICATA_LIBNAME}"
+
+    if test "x$cross_compiling" = "xyes"; then
+      RUST_SURICATA_LIB_XC_DIR="${host_alias}/"
     else
-      RUST_SURICATA_LIB="../rust/target/release/${RUST_SURICATA_LIBNAME}"
+      RUST_SURICATA_LIB_XC_DIR=
+    fi
+
+    if test "x$enable_debug" = "xyes"; then
+      RUST_SURICATA_LIB="../rust/target/${RUST_SURICATA_LIB_XC_DIR}debug/${RUST_SURICATA_LIBNAME}"
+    else
+      RUST_SURICATA_LIB="../rust/target/${RUST_SURICATA_LIB_XC_DIR}release/${RUST_SURICATA_LIBNAME}"
     fi
 
     RUST_LDADD="${RUST_SURICATA_LIB} ${RUST_LDADD}"
@@ -2429,7 +2437,12 @@ fi
     AC_SUBST([RUSTUP_HOME_PATH], [$rustup_home_path])
     AC_SUBST([rustup_home])
 
-    AC_CHECK_FILES([$srcdir/rust/vendor], [have_rust_vendor="yes"])
+    if test "x$cross_compiling" != "xyes"; then
+      AC_CHECK_FILES([$srcdir/rust/vendor], [have_rust_vendor="yes"])
+    else
+      AS_IF([test -d "$srcdir/rust/vendor"], have_rust_vendor="yes", [])
+    fi
+
     if test "x$have_rust_vendor" = "xyes"; then
       rust_vendor_comment=""
     fi

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -23,6 +23,10 @@ if DEBUG
 RUST_FEATURES +=	debug
 endif
 
+if RUST_CROSS_COMPILE 
+RUST_TARGET = --target $(host_triplet)
+endif
+
 all-local:
 if HAVE_PYTHON
 	cd $(top_srcdir)/rust && $(HAVE_PYTHON) ./gen-c-headers.py
@@ -33,13 +37,13 @@ if HAVE_CYGPATH
 		CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$$rustpath/rust/target" \
 		$(CARGO) build $(RELEASE) $(FROZEN) \
-			--features "$(RUST_FEATURES)"
+			--features "$(RUST_FEATURES)" $(RUST_TARGET)
 else
 	cd $(top_srcdir)/rust && @rustup_home@ \
 		CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$(abs_top_builddir)/rust/target" \
 		$(CARGO) build $(RELEASE) $(FROZEN) \
-			--features "$(RUST_FEATURES)"
+			--features "$(RUST_FEATURES)" $(RUST_TARGET)
 endif
 
 clean-local:


### PR DESCRIPTION
adding --target argument to cargo command line when cross compiling

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- configure.ac: added RUST_CROSS_COMPILE variable when cross compiling used inside rust/Makefile.am
- configure.ac: added rust cross compile directory to the lib dir
- configure.ac: integrated changes from: https://redmine.openinfosecfoundation.org/issues/3073 when checking for rust vendor while cross compiling
- Makefile.am: added --target cmd line parameter to cargo command line when cross compiling (RUST_CROSS_COMPILE)

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

