### PR TITLE
fix typo on example

### DIFF
--- a/doc/userguide/rules/dnp3-keywords.rst
+++ b/doc/userguide/rules/dnp3-keywords.rst
@@ -146,4 +146,4 @@ Example
 
 ::
 
-  dnp3_data; content:|c3 06|;
+  dnp3_data; content:"|c3 06|";


### PR DESCRIPTION
the quotes have been forgotten in the example, which throws an SC_ERR_INVALID_SIGNATURE(39)

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- fixed a typo (forgotten quotes) in the documentation

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

