### PR TITLE
4.1.x - configure: assume cargo vendor if cargo >= 1.37 - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2381,14 +2381,26 @@ fi
     AM_CONDITIONAL([HAVE_RUST_VENDOR], [test "x$have_rust_vendor" = "xyes"])
 
     if test "x$enable_rust" = "xyes" || test "x$enable_rust" = "xyes (default)"; then
-      AC_PATH_PROG(HAVE_CARGO_VENDOR, cargo-vendor, "no")
-      if test "x$HAVE_CARGO_VENDOR" = "xno"; then
-        echo "   Warning: cargo-vendor not found, but it is only required"
-        echo "       for building the distribution"
-        echo "   To install: cargo install cargo-vendor"
+      cargo_version=$(echo "$rust_cargo_version" | sed 's/^.*[[^0-9]]\([[0-9]]*\.[[0-9]]*\.[[0-9]]*\).*$/\1/')
+      echo "$rust_cargo_version"
+      echo "$cargo_version"
+
+      # With Rust/Cargo 1.37 and greater, cargo-vendor is built-in.
+      AC_MSG_CHECKING(for cargo vendor support)
+      AS_VERSION_COMPARE([$cargo_version], [1.37.0],
+          [have_cargo_vendor="no"],
+          [have_cargo_vendor="yes"],
+          [have_cargo_vendor="yes"])
+      AC_MSG_RESULT($have_cargo_vendor)
+
+      # If Rust is older than 1.37, check for cargo-vendor as an
+      # external sub-command.
+      if test "x$have_cargo_vendor" != "xyes"; then
+          AC_CHECK_PROG(have_cargo_vendor_bin, cargo-vendor, yes, no)
+          have_cargo_vendor=$have_cargo_vendor_bin
       fi
     fi
-    AM_CONDITIONAL([HAVE_CARGO_VENDOR], [test "x$HAVE_CARGO_VENDOR" != "xno"])
+    AM_CONDITIONAL([HAVE_CARGO_VENDOR], [test "x$have_cargo_vendor" != "xno"])
 
     AC_ARG_ENABLE(rust_strict,
            AS_HELP_STRING([--enable-rust-strict], [Rust warnings as errors]),[enable_rust_strict=$enableval],[enable_rust_strict=no])
@@ -2538,6 +2550,7 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   Rust debug mode:                         ${enable_rust_debug}
   Rust compiler:                           ${rust_compiler_version}
   Rust cargo:                              ${rust_cargo_version}
+  Cargo vendor:                            ${have_cargo_vendor}
 
   Install suricatasc:                      ${enable_python}
   Install suricata-update:                 ${install_suricata_update}

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1269,7 +1269,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                 filedata_len = form_end - filedata;
             } else if (form_end != NULL && form_end == header_start) {
                 filedata_len = form_end - filedata - 2; /* 0d 0a */
-            } else if (tx_progress > HTP_RESPONSE_BODY) {
+            } else if (tx_progress > HTP_REQUEST_BODY) {
                 filedata_len = chunks_buffer_len;
                 flags = FILE_TRUNCATED;
             }


### PR DESCRIPTION
Rust/Cargo 1.37 and great has vendor support built-in.

This is a backport to 4.1.x:
https://redmine.openinfosecfoundation.org/issues/3364

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/778
- https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/422