### PR TITLE
flow: expose last time as a function - v2

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -21,7 +21,6 @@ use std;
 use crate::filecontainer::*;
 
 /// Opaque C types.
-pub enum Flow {}
 pub enum DetectEngineState {}
 pub enum AppLayerDecoderEvents {}
 
@@ -180,6 +179,29 @@ pub fn sc_app_layer_decoder_events_free_events(
     unsafe {
         if let Some(c) = SC {
             (c.AppLayerDecoderEventsFreeEvents)(events);
+        }
+    }
+}
+
+/// Opaque flow type (defined in C)
+pub enum Flow {}
+
+/// Extern functions operating on Flow.
+extern {
+    pub fn FlowGetLastTimeAsParts(flow: &Flow, secs: *mut u64, usecs: *mut u64);
+}
+
+/// Rust implementation of Flow.
+impl Flow {
+
+    /// Return the time of the last flow update as a `Duration`
+    /// since the epoch.
+    pub fn get_last_time(&mut self) -> std::time::Duration {
+        unsafe {
+            let mut secs: u64 = 0;
+            let mut usecs: u64 = 0;
+            FlowGetLastTimeAsParts(self, &mut secs, &mut usecs);
+            std::time::Duration::new(secs, usecs as u32 * 1000)
         }
     }
 }

--- a/src/flow.c
+++ b/src/flow.c
@@ -1113,6 +1113,19 @@ void FlowUpdateState(Flow *f, enum FlowState s)
     }
 }
 
+/**
+ * \brief Get flow last time as individual values.
+ *
+ * Instead of returning a pointer to the timeval copy the timeval
+ * parts into output pointers to make it simpler to call from Rust
+ * over FFI using only basic data types.
+ */
+void FlowGetLastTimeAsParts(Flow *flow, uint64_t *secs, uint64_t *usecs)
+{
+    *secs = flow->lastts.tv_sec;
+    *usecs = flow->lastts.tv_usec;
+}
+
 /************************************Unittests*******************************/
 
 #ifdef UNITTESTS

--- a/src/flow.h
+++ b/src/flow.h
@@ -537,6 +537,8 @@ uint64_t FlowGetMemuse(void);
 int GetFlowBypassInfoID(void);
 void RegisterFlowBypassInfo(void);
 
+void FlowGetLastTimeAsParts(Flow *flow, uint64_t *secs, uint64_t *usecs);
+
 /** ----- Inline functions ----- */
 
 /** \brief Set the No Packet Inspection Flag without locking the flow.


### PR DESCRIPTION
This function returns the individual components
of the timeval in output pointers making it suitable
for use over Rust FFI.