### PR TITLE
detect/analyzer: Suppress direction warnings

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1199,7 +1199,7 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
     }
 
     /* No warning about direction for ICMP protos */
-    if (!(DetectProtoContainsProto(&s->proto, IPPROTO_ICMP) && DetectProtoContainsProto(&s->proto, IPPROTO_ICMP))) {
+    if (!(DetectProtoContainsProto(&s->proto, IPPROTO_ICMPV6) && DetectProtoContainsProto(&s->proto, IPPROTO_ICMP))) {
         if ((s->flags & (SIG_FLAG_TOSERVER|SIG_FLAG_TOCLIENT)) == (SIG_FLAG_TOSERVER|SIG_FLAG_TOCLIENT)) {
             warn_both_direction += 1;
             rule_warning += 1;


### PR DESCRIPTION
This commit ensures direction warnings for ICMP v4 and v6
are suppressed and corrects check so that both protocols
are checked (instead of the same protocol being checked twice).

This fixes the change from #4402 which made checked for ICMP (twice) .

Describe changes:
- Check for both v4 and v6 ICMP protocols.

