### PR TITLE
file: reassemble files from different transcations with range

### DIFF
--- a/src/util-file.c
+++ b/src/util-file.c
@@ -313,6 +313,9 @@ static int FilePruneFile(File *file)
         SCLogDebug("file->flags & FILE_NOMAGIC == true");
     }
 #endif
+    if (file->flags & FILE_KEEP_PART) {
+        SCReturnInt(0);
+    }
     uint64_t left_edge = file->content_stored;
     if (file->flags & FILE_NOSTORE) {
         left_edge = FileDataSize(file);
@@ -746,7 +749,7 @@ int FileAppendGAPById(FileContainer *ffc, uint32_t track_id,
  *  \retval  0 ok
  *  \retval -1 error
  */
-int FileSetRange(FileContainer *ffc, uint64_t start, uint64_t end)
+int FileSetRange(FileContainer *ffc, uint64_t start, uint64_t end, uint64_t totalsize)
 {
     SCEnter();
 
@@ -755,6 +758,10 @@ int FileSetRange(FileContainer *ffc, uint64_t start, uint64_t end)
     }
     ffc->tail->start = start;
     ffc->tail->end = end;
+    ffc->tail->totalsize = totalsize;
+    if (start > 0 || end < totalsize) {
+        ffc->tail->flags |= FILE_KEEP_PART;
+    }
     SCReturnInt(0);
 }
 

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -47,6 +47,7 @@
 #define FILE_STORED     BIT_U16(11)
 #define FILE_NOTRACK    BIT_U16(12) /**< track size of file */
 #define FILE_USE_DETECT BIT_U16(13) /**< use content_inspected tracker */
+#define FILE_KEEP_PART  BIT_U16(14)
 #define FILE_HAS_GAPS   BIT_U16(15)
 
 typedef enum FileState_ {
@@ -89,6 +90,7 @@ typedef struct File_ {
     uint64_t size;
     uint64_t start;
     uint64_t end;
+    uint64_t totalsize;
 
     uint32_t *sid; /* signature id of a rule that triggered the filestore event */
     uint32_t sid_cnt;
@@ -172,11 +174,12 @@ int FileAppendGAPById(FileContainer *ffc, uint32_t track_id,
  *  \param ffc the container
  *  \param start start offset
  *  \param end end offset
+ *  \param total total size of file
  *
  *  \retval 0 ok
  *  \retval -1 error
  */
-int FileSetRange(FileContainer *, uint64_t start, uint64_t end);
+int FileSetRange(FileContainer *, uint64_t start, uint64_t end, uint64_t total);
 
 /**
  *  \brief Tag a file for storing


### PR DESCRIPTION
Not to be merged

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1576

Describe changes:
- Adds flag `FILE_KEEP_PART` to keep file container and not get it pruned after end of transaction
- call `HTPReassembleRanges` on end of transaction
  + check if we have a file with HTTP `Range` header
  + check if we have enough bytes in the different files
  + check that we cover all the offsets
  + create a new file
And fail to append the data to it as it got forgotten

This is very basic and there are checks and features still missing.
And it is not yet working.
But is this the right way to go ?