### PR TITLE
suricata: fix computing of default packet size

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2531,9 +2531,9 @@ static int ConfigGetCaptureValue(SCInstance *suri)
             case RUNMODE_PCAP_DEV:
             case RUNMODE_AFP_DEV:
             case RUNMODE_PFRING:
-                nlive = LiveGetDeviceCount();
+                nlive = LiveGetDeviceNameCount();
                 for (lthread = 0; lthread < nlive; lthread++) {
-                    const char *live_dev = LiveGetDeviceName(lthread);
+                    const char *live_dev = LiveGetDeviceNameName(lthread);
                     char dev[128]; /* need to be able to support GUID names on Windows */
                     (void)strlcpy(dev, live_dev, sizeof(dev));
 

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -190,6 +190,49 @@ const char *LiveGetDeviceName(int number)
     return NULL;
 }
 
+/**
+ *  \brief Get the number of pre registered devices
+ *
+ *  \retval cnt the number of pre registered devices
+ */
+int LiveGetDeviceNameCount(void)
+{
+    int i = 0;
+    LiveDeviceName *pd;
+
+    TAILQ_FOREACH(pd, &pre_live_devices, next) {
+        i++;
+    }
+
+    return i;
+}
+
+/**
+ *  \brief Get a pointer to the pre device name at idx
+ *
+ *  \param number idx of the pre device in our list
+ *
+ *  \retval ptr pointer to the string containing the device
+ *  \retval NULL on error
+ */
+const char *LiveGetDeviceNameName(int number)
+{
+    int i = 0;
+    LiveDeviceName *pd;
+
+    TAILQ_FOREACH(pd, &pre_live_devices, next) {
+        if (i == number) {
+            return pd->dev;
+        }
+
+        i++;
+    }
+
+    return NULL;
+}
+
+
+
 /** \internal
  *  \brief Shorten a device name that is to long
  *

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -63,6 +63,8 @@ typedef struct LiveDeviceName_ {
 void LiveDevRegisterExtension(void);
 
 int LiveRegisterDeviceName(const char *dev);
+int LiveGetDeviceNameCount(void);
+const char *LiveGetDeviceNameName(int number);
 int LiveRegisterDevice(const char *dev);
 int LiveDevUseBypass(LiveDevice *dev);
 void LiveDevSetBypassStats(LiveDevice *dev, uint64_t cnt, int family);


### PR DESCRIPTION
Update the default packet size computation to use LiveDeviceName
instead of LiveDevice as the LiveDevice list is not built when
the default packet size is built.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3386

Describe changes:
- Iterate on LiveDeviceName instead of LiveDevice to find biggest MTU

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/515
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/291
