### PR TITLE
Backports/416/v2

### DIFF
--- a/rust/src/filetracker.rs
+++ b/rust/src/filetracker.rs
@@ -111,7 +111,6 @@ impl FileTransferTracker {
         }
         self.file_open = false;
         self.tracked = 0;
-        files.files_prune();
     }
 
     pub fn trunc (&mut self, files: &mut FileContainer, flags: u16) {
@@ -121,7 +120,6 @@ impl FileTransferTracker {
         let myflags = flags | 1; // TODO util-file.c::FILE_TRUNCATED
         files.file_close(&self.track_id, myflags);
         SCLogDebug!("truncated file");
-        files.files_prune();
         self.file_is_truncated = true;
     }
 
@@ -323,7 +321,6 @@ impl FileTransferTracker {
                 consumed += data.len();
             }
         }
-        files.files_prune();
         consumed as u32
     }
 

--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -323,6 +323,7 @@ pub fn smb_write_dcerpc_record<'b>(state: &mut SMBState,
                         },
                         _ => {
                             tx.set_event(SMBEvent::MalformedData);
+                            tx.request_done = true;
                         },
                     }
                 },
@@ -355,17 +356,21 @@ pub fn smb_write_dcerpc_record<'b>(state: &mut SMBState,
                                 }
                                 bind_ifaces = Some(ifaces);
                             }
-                            tx.request_done = true;
                         },
                         _ => {
                             tx.set_event(SMBEvent::MalformedData);
                         },
                     }
+                    tx.request_done = true;
                 }
                 21...255 => {
                     tx.set_event(SMBEvent::MalformedData);
+                    tx.request_done = true;
                 },
-                _ => { }, // valid type w/o special processing
+                _ => {
+                    // valid type w/o special processing
+                    tx.request_done = true;
+                },
             }
         },
         _ => {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1127,6 +1127,7 @@ impl SMBState {
                     Ok("lsarpc") => ("lsarpc", true),
                     Ok("samr") => ("samr", true),
                     Ok("spoolss") => ("spoolss", true),
+                    Ok("winreg") => ("winreg", true),
                     Ok("suricata::dcerpc") => ("unknown", true),
                     Err(_) => ("MALFORMED", false),
                     Ok(&_) => {

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -1048,21 +1048,19 @@ fn smb1_request_record_generic<'b>(state: &mut SMBState, r: &SmbRecord<'b>, even
 /// on the response. We only create a tx for the response side
 /// if we didn't already update a tx, and we have to set events
 fn smb1_response_record_generic<'b>(state: &mut SMBState, r: &SmbRecord<'b>, events: Vec<SMBEvent>) {
-    // see if we want a tx per command
-    if smb1_create_new_tx(r.command) {
-        let tx_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
-        let tx = state.get_generic_tx(1, r.command as u16, &tx_key);
-        if let Some(tx) = tx {
+    let tx_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
+    match state.get_generic_tx(1, r.command as u16, &tx_key) {
+        Some(tx) => {
             tx.request_done = true;
             tx.response_done = true;
             SCLogDebug!("tx {} cmd {} is done", tx.id, r.command);
             tx.set_status(r.nt_status, r.is_dos_error);
             tx.set_events(events);
             return;
-        }
+        },
+        None => {},
     }
     if events.len() > 0 {
-        let tx_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
         let tx = state.new_generic_tx(1, r.command as u16, tx_key);
         tx.request_done = true;
         tx.response_done = true;

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -264,7 +264,7 @@ named!(pub parse_smb_trans_request_record_params<(SmbRecordTransRequestParams, O
        >> data_offset: le_u16
        >> setup_cnt: le_u8
        >> take!(1) // reserved
-       >> pipe: cond!(wct == 16 && setup_cnt == 2, parse_smb_trans_request_record_pipe)
+       >> pipe: cond!(wct == 16 && setup_cnt == 2 && data_cnt > 0, parse_smb_trans_request_record_pipe)
        >> bcc: le_u16
        >> (( SmbRecordTransRequestParams {
                 max_data_cnt:max_data_cnt,

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -800,9 +800,6 @@ static int FTPDataParse(Flow *f, FtpDataState *ftpdata_state,
     }
 
 out:
-    if (ftpdata_state->files) {
-        FilePrune(ftpdata_state->files);
-    }
     return ret;
 }
 

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -146,7 +146,6 @@ int HTPFileOpen(HtpState *s, const uint8_t *filename, uint16_t filename_len,
 
     FileSetTx(files->tail, txid);
 
-    FilePrune(files);
 end:
     SCReturnInt(retval);
 }
@@ -196,7 +195,6 @@ int HTPFileStoreChunk(HtpState *s, const uint8_t *data, uint32_t data_len,
         retval = -2;
     }
 
-    FilePrune(files);
 end:
     SCReturnInt(retval);
 }
@@ -248,7 +246,6 @@ int HTPFileClose(HtpState *s, const uint8_t *data, uint32_t data_len,
         retval = -2;
     }
 
-    FilePrune(files);
 end:
     SCReturnInt(retval);
 }

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -766,9 +766,9 @@ void AppLayerParserSetTransactionInspectId(const Flow *f, AppLayerParserState *p
                         tx, idx, flags & STREAM_TOSERVER ? "toserver" : "toclient", detect_flags);
             }
         }
+        idx++;
         if (!ires.has_next)
             break;
-        idx++;
     }
     pstate->inspect_id[direction] = idx;
     SCLogDebug("inspect_id now %"PRIu64, pstate->inspect_id[direction]);

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -507,7 +507,6 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
 
     if (files != NULL) {
         SMTPPruneFiles(files);
-        FilePrune(files);
     }
 
     SCReturnInt(ret);

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -55,6 +55,7 @@
 
 #include "util-mem.h"
 #include "util-misc.h"
+#include "util-validate.h"
 
 /* content-limit default value */
 #define FILEDATA_CONTENT_LIMIT 100000
@@ -366,6 +367,23 @@ static void FlagDetectStateNewFile(SMTPTransaction *tx)
     }
 }
 
+static void SMTPNewFile(SMTPTransaction *tx, File *file)
+{
+    DEBUG_VALIDATE_BUG_ON(tx == NULL);
+    DEBUG_VALIDATE_BUG_ON(file == NULL);
+#ifdef UNITTESTS
+    if (RunmodeIsUnittests()) {
+        if (tx == NULL || file == NULL) {
+            return;
+        }
+    }
+#endif
+    FlagDetectStateNewFile(tx);
+    FileSetTx(file, tx->tx_id);
+    file->inspect_window = smtp_config.content_inspect_window;
+    file->inspect_min_size = smtp_config.content_inspect_min_size;
+}
+
 int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
         MimeDecParseState *state)
 {
@@ -418,9 +436,7 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
                 ret = MIME_DEC_ERR_DATA;
                 SCLogDebug("FileOpenFile() failed");
             }
-            FlagDetectStateNewFile(smtp_state->curr_tx);
-            files->tail->inspect_window = smtp_config.content_inspect_window;
-            files->tail->inspect_min_size = smtp_config.content_inspect_min_size;
+            SMTPNewFile(smtp_state->curr_tx, files->tail);
 
             /* If close in the same chunk, then pass in empty bytes */
             if (state->body_end) {

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -380,8 +380,12 @@ static void SMTPNewFile(SMTPTransaction *tx, File *file)
 #endif
     FlagDetectStateNewFile(tx);
     FileSetTx(file, tx->tx_id);
-    file->inspect_window = smtp_config.content_inspect_window;
-    file->inspect_min_size = smtp_config.content_inspect_min_size;
+
+    /* set inspect sizes used in file pruning logic.
+     * TODO consider moving this to the file.data code that
+     * would actually have use for this. */
+    FileSetInspectSizes(file, smtp_config.content_inspect_window,
+            smtp_config.content_inspect_min_size);
 }
 
 int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -1108,6 +1108,8 @@ static int DeStateSigTest08(void)
     FAIL_IF_NULL(files);
     file = files->head;
     FAIL_IF_NULL(file);
+    file = file->next;
+    FAIL_IF_NULL(file);
     FAIL_IF_NOT(file->flags & FILE_STORE);
 
     AppLayerParserThreadCtxFree(alp_tctx);

--- a/src/output-file.c
+++ b/src/output-file.c
@@ -178,11 +178,6 @@ static TmEcode OutputFileLog(ThreadVars *tv, Packet *p, void *thread_data)
     OutputFileLogFfc(tv, op_thread_data, p, ffc_ts, file_close_ts, file_trunc, STREAM_TOSERVER);
     OutputFileLogFfc(tv, op_thread_data, p, ffc_tc, file_close_tc, file_trunc, STREAM_TOCLIENT);
 
-    if (ffc_ts && (p->flowflags & FLOW_PKT_TOSERVER))
-        FilePrune(ffc_ts);
-    if (ffc_tc && (p->flowflags & FLOW_PKT_TOCLIENT))
-        FilePrune(ffc_tc);
-
     return TM_ECODE_OK;
 }
 

--- a/src/output-filedata.c
+++ b/src/output-filedata.c
@@ -199,8 +199,6 @@ static void OutputFiledataLogFfc(ThreadVars *tv, OutputLoggerThreadStore *store,
                 }
             }
         }
-
-        FilePrune(ffc);
     }
 }
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1040,7 +1040,8 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
         const char *pcapfile_s = ConfNodeLookupChildValue(conf, "pcap-file");
         if (pcapfile_s != NULL && ConfValIsTrue(pcapfile_s)) {
             json_ctx->file_ctx->is_pcap_offline =
-                (RunmodeGetCurrent() == RUNMODE_PCAP_FILE);
+                (RunmodeGetCurrent() == RUNMODE_PCAP_FILE ||
+                 RunmodeGetCurrent() == RUNMODE_UNIX_SOCKET);
         }
 
         json_ctx->file_ctx->type = json_ctx->json_out;

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -37,6 +37,8 @@
 #include "app-layer-parser.h"
 #include "util-validate.h"
 
+extern int g_detect_disabled;
+
 /** \brief switch to force filestore on all files
  *         regardless of the rules.
  */
@@ -804,7 +806,7 @@ static File *FileOpenFile(FileContainer *ffc, const StreamingBufferConfig *sbcfg
         SCLogDebug("not doing sha256 for this file");
         ff->flags |= FILE_NOSHA256;
     }
-    if (flags & FILE_USE_DETECT) {
+    if (!g_detect_disabled && flags & FILE_USE_DETECT) {
         SCLogDebug("considering content_inspect tracker when pruning");
         ff->flags |= FILE_USE_DETECT;
     }

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -332,10 +332,7 @@ static int FilePruneFile(File *file)
     SCLogDebug("file->state %d. Is >= FILE_STATE_CLOSED: %s", file->state, (file->state >= FILE_STATE_CLOSED) ? "yes" : "no");
 
     /* file is done when state is closed+, logging/storing is done (if any) */
-    if (file->state >= FILE_STATE_CLOSED &&
-        (!RunModeOutputFileEnabled() || (file->flags & FILE_LOGGED)) &&
-        (!RunModeOutputFiledataEnabled() || (file->flags & (FILE_STORED|FILE_NOSTORE))))
-    {
+    if (file->state >= FILE_STATE_CLOSED) {
         SCReturnInt(1);
     } else {
         SCReturnInt(0);

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -761,6 +761,12 @@ int FileAppendGAPById(FileContainer *ffc, uint32_t track_id,
     SCReturnInt(-1);
 }
 
+void FileSetInspectSizes(File *file, const uint32_t win, const uint32_t min)
+{
+    file->inspect_window = win;
+    file->inspect_min_size = min;
+}
+
 /**
  *  \brief Open a new File
  *

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -841,7 +841,6 @@ int FileOpenFileWithId(FileContainer *ffc, const StreamingBufferConfig *sbcfg,
         return -1;
 
     ff->file_track_id = track_id;
-    ff->flags |= FILE_USE_TRACKID;
     return 0;
 }
 

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -47,7 +47,6 @@
 #define FILE_STORED     BIT_U16(11)
 #define FILE_NOTRACK    BIT_U16(12) /**< track size of file */
 #define FILE_USE_DETECT BIT_U16(13) /**< use content_inspected tracker */
-#define FILE_USE_TRACKID    BIT_U16(14) /**< File::file_track_id field is in use */
 #define FILE_HAS_GAPS   BIT_U16(15)
 
 typedef enum FileState_ {
@@ -67,8 +66,7 @@ typedef struct File_ {
     FileState state;
     StreamingBuffer *sb;
     uint64_t txid;                  /**< tx this file is part of */
-    uint32_t file_track_id;         /**< id used by protocol parser. Optional
-                                     *   only used if FILE_USE_TRACKID flag set */
+    uint32_t file_track_id;         /**< id used by protocol parser */
     uint32_t file_store_id;         /**< id used in store file name file.<id> */
     int fd;                         /**< file descriptor for filestore, not
                                         open if equal to -1 */

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -87,6 +87,8 @@ typedef struct File_ {
                                      *   flag is set */
     uint64_t content_stored;
     uint64_t size;
+    uint32_t inspect_window;
+    uint32_t inspect_min_size;
 } File;
 
 typedef struct FileContainer_ {

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -162,6 +162,8 @@ int FileAppendDataById(FileContainer *, uint32_t track_id,
 int FileAppendGAPById(FileContainer *ffc, uint32_t track_id,
         const uint8_t *data, uint32_t data_len);
 
+void FileSetInspectSizes(File *file, const uint32_t win, const uint32_t min);
+
 /**
  *  \brief Tag a file for storing
  *


### PR DESCRIPTION
Bug #3402: smb: post-GAP some transactions never close (4.1.x) | Actions
Bug #3403: smb1: 'event only' transactions for bad requests never close (4.1.x)
Bug #3404: smtp: file tracking issues when more than one attachment in a tx (4.1.x)
Bug #3405: Filehash rule does not fire without filestore keyword

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed
