### PR TITLE
Expectation fix v1.1

### DIFF
--- a/src/app-layer-expectation.c
+++ b/src/app-layer-expectation.c
@@ -164,7 +164,9 @@ static Expectation *AppLayerExpectationLookup(Flow *f, IPPair **ipp)
  * Create an entry in expectation list
  *
  * Create a expectation from an existing Flow. Currently, only Flow between
- * the two original IP addresses are supported.
+ * the two original IP addresses are supported. In case of success, the
+ * ownership of the data pointer is taken. In case of error, the pointer
+ * to data has to be freed by the caller.
  *
  * \param f a pointer to the original Flow
  * \param direction the direction of the data in the expectation flow

--- a/src/app-layer-expectation.c
+++ b/src/app-layer-expectation.c
@@ -215,6 +215,7 @@ int AppLayerExpectationCreate(Flow *f, int direction, Port src, Port dst,
         IPPairSetStorageById(ipp, g_expectation_id, exp);
 
         SC_ATOMIC_ADD(expectation_count, 1);
+        f->flags |= FLOW_HAS_EXPECTATION;
     }
     /* As we are creating the expectation, we release lock on IPPair without
      * setting the ref count to 0. This way the IPPair will be kept till
@@ -346,6 +347,9 @@ void AppLayerExpectationClean(Flow *f)
     IPPair *ipp = NULL;
     Expectation *lexp = NULL;
     Expectation *pexp = NULL;
+
+    if (!(f->flags & FLOW_HAS_EXPECTATION))
+        return;
 
     int x = SC_ATOMIC_GET(expectation_count);
     if (x == 0) {

--- a/src/app-layer-expectation.c
+++ b/src/app-layer-expectation.c
@@ -144,7 +144,7 @@ static inline int GetFlowAddresses(Flow *f, Address *ip_src, Address *ip_dst)
     return 0;
 }
 
-static Expectation *AppLayerExpectationLookup(Flow *f, int direction, IPPair **ipp)
+static Expectation *AppLayerExpectationLookup(Flow *f, IPPair **ipp)
 {
     Address ip_src, ip_dst;
     if (GetFlowAddresses(f, &ip_src, &ip_dst) == -1)
@@ -282,7 +282,7 @@ AppProto AppLayerExpectationHandle(Flow *f, int direction)
     }
 
     /* Call will take reference of the ip pair in 'ipp' */
-    Expectation *exp = AppLayerExpectationLookup(f, direction, &ipp);
+    Expectation *exp = AppLayerExpectationLookup(f, &ipp);
     if (exp == NULL)
         goto out;
 

--- a/src/app-layer-expectation.h
+++ b/src/app-layer-expectation.h
@@ -30,6 +30,8 @@ int AppLayerExpectationCreate(Flow *f, int direction, Port src, Port dst,
 AppProto AppLayerExpectationHandle(Flow *f, int direction);
 int AppLayerExpectationGetDataId(void);
 
+void AppLayerExpectationClean(Flow *f);
+
 uint64_t ExpectationGetCounter(void);
 
 #endif /* __APP_LAYER_EXPECTATION__H__ */

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -61,6 +61,7 @@
 #include "stream.h"
 
 #include "app-layer-parser.h"
+#include "app-layer-expectation.h"
 
 #include "host-timeout.h"
 #include "defrag-timeout.h"
@@ -994,6 +995,7 @@ static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
 
                 (void)OutputFlowLog(th_v, ftd->output_thread_data, f);
 
+                AppLayerExpectationClean(f);
                 FlowClearMemory (f, f->protomap);
                 FLOWLOCK_UNLOCK(f);
                 FlowMoveToSpare(f);

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -995,6 +995,7 @@ static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
 
                 (void)OutputFlowLog(th_v, ftd->output_thread_data, f);
 
+                if (f->flags & FLOW_HAS_EXPECTATION)
                 AppLayerExpectationClean(f);
                 FlowClearMemory (f, f->protomap);
                 FLOWLOCK_UNLOCK(f);

--- a/src/flow.h
+++ b/src/flow.h
@@ -104,6 +104,8 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 #define FLOW_WRONG_THREAD               BIT_U32(25)
 /** Protocol detection told us flow is picked up in wrong direction (midstream) */
 #define FLOW_DIR_REVERSED               BIT_U32(26)
+/** Indicate that the flow did trigger an expectation creation */
+#define FLOW_HAS_EXPECTATION            BIT_U32(27)
 
 /* File flags */
 


### PR DESCRIPTION
Some fixes and improvement on the expectation system to avoid some problems and fix a rare memory leak (see Redmine issue).

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3378

Describe changes:
- limit expectation count to contain memory pressure
- clean expectation for flow at cleaning of the flow

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/517
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/293