### PR TITLE
Fixes/v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -149,6 +149,9 @@ jobs:
       - working-directory: suricata
         run: ./configure
       - working-directory: suricata
+        name: Check that Rust is using --frozen
+        run: grep -q '^FROZEN' rust/Makefile
+      - working-directory: suricata
         run: make -j2
       - working-directory: suricata
         run: make install

--- a/configure.ac
+++ b/configure.ac
@@ -2439,7 +2439,7 @@ fi
     AC_SUBST([RUSTUP_HOME_PATH], [$rustup_home_path])
     AC_SUBST([rustup_home])
 
-    if test -f "$srcdir/rust/vendor"; then
+    if test -e "$srcdir/rust/vendor"; then
       have_rust_vendor="yes"
     fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1598,12 +1598,12 @@
             echo
             exit 1
         fi
-        PKG_CHECK_MODULES(LIBHTPMINVERSION, [htp >= 0.5.31],[libhtp_minver_found="yes"],[libhtp_minver_found="no"])
+        PKG_CHECK_MODULES(LIBHTPMINVERSION, [htp >= 0.5.32],[libhtp_minver_found="yes"],[libhtp_minver_found="no"])
         if test "$libhtp_minver_found" = "no"; then
             PKG_CHECK_MODULES(LIBHTPDEVVERSION, [htp = 0.5.X],[libhtp_devver_found="yes"],[libhtp_devver_found="no"])
             if test "$libhtp_devver_found" = "no"; then
                 echo
-                echo "   ERROR! libhtp was found but it is neither >= 0.5.31, nor the dev 0.5.X"
+                echo "   ERROR! libhtp was found but it is neither >= 0.5.32, nor the dev 0.5.X"
                 echo
                 exit 1
             fi

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -877,7 +877,7 @@ static int HTPHandleRequestData(Flow *f, void *htp_state,
     if (AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF) &&
         !(hstate->flags & HTP_FLAG_STATE_CLOSED_TS))
     {
-        htp_connp_close(hstate->connp, &ts);
+        htp_connp_req_close(hstate->connp, &ts);
         hstate->flags |= HTP_FLAG_STATE_CLOSED_TS;
         SCLogDebug("stream eof encountered, closing htp handle for ts");
     }

--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -154,9 +154,10 @@ static void DecodeTCPOptions(Packet *p, const uint8_t *pkt, uint16_t pktlen)
                     break;
                 case TCP_OPT_TFO:
                     SCLogDebug("TFO option, len %u", olen);
-                    if (olen < TCP_OPT_TFO_MIN_LEN ||
+                    if ((olen != 2) &&
+                           (olen < TCP_OPT_TFO_MIN_LEN ||
                             olen > TCP_OPT_TFO_MAX_LEN ||
-                            !((olen - 2) % 8 == 0))
+                            !((olen - 2) % 8 == 0)))
                     {
                         ENGINE_SET_EVENT(p,TCP_OPT_INVALID_LEN);
                     } else {

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1025,7 +1025,11 @@ static int ReassembleUpdateAppLayer (ThreadVars *tv,
             continue;
         } else if (mydata == NULL || mydata_len == 0) {
             /* Possibly a gap, but no new data. */
-            return 0;
+            if ((p->flags & PKT_PSEUDO_STREAM_END) == 0 || ssn->state < TCP_CLOSED)
+                SCReturnInt(0);
+
+            mydata = NULL;
+            mydata_len = 0;
         }
         SCLogDebug("%"PRIu64" got %p/%u", p->pcap_cnt, mydata, mydata_len);
         break;


### PR DESCRIPTION
Required libhtp 0.5.32. Add some fixes for HTTP issues.

Includes #4437

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR victorjulien-pcap: https://buildbot.openinfosecfoundation.org/builders/victorjulien-pcap/builds/357
- PR victorjulien: https://buildbot.openinfosecfoundation.org/builders/victorjulien/builds/358
