### PR TITLE
Fixes/41x/v2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1528,12 +1528,12 @@
             echo
             exit 1
         fi
-        PKG_CHECK_MODULES(LIBHTPMINVERSION, [htp >= 0.5.20],[libhtp_minver_found="yes"],[libhtp_minver_found="no"])
+        PKG_CHECK_MODULES(LIBHTPMINVERSION, [htp >= 0.5.32],[libhtp_minver_found="yes"],[libhtp_minver_found="no"])
         if test "$libhtp_minver_found" = "no"; then
             PKG_CHECK_MODULES(LIBHTPDEVVERSION, [htp = 0.5.X],[libhtp_devver_found="yes"],[libhtp_devver_found="no"])
             if test "$libhtp_devver_found" = "no"; then
                 echo
-                echo "   ERROR! libhtp was found but it is neither >= 0.5.20, nor the dev 0.5.X"
+                echo "   ERROR! libhtp was found but it is neither >= 0.5.32, nor the dev 0.5.X"
                 echo
                 exit 1
             fi

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -821,7 +821,7 @@ static int HTPHandleRequestData(Flow *f, void *htp_state,
     if (AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF) &&
         !(hstate->flags & HTP_FLAG_STATE_CLOSED_TS))
     {
-        htp_connp_close(hstate->connp, &ts);
+        htp_connp_req_close(hstate->connp, &ts);
         hstate->flags |= HTP_FLAG_STATE_CLOSED_TS;
         SCLogDebug("stream eof encountered, closing htp handle for ts");
     }

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1027,7 +1027,11 @@ static int ReassembleUpdateAppLayer (ThreadVars *tv,
             continue;
         } else if (mydata == NULL || mydata_len == 0) {
             /* Possibly a gap, but no new data. */
-            return 0;
+            if ((p->flags & PKT_PSEUDO_STREAM_END) == 0 || ssn->state < TCP_CLOSED)
+                SCReturnInt(0);
+
+            mydata = NULL;
+            mydata_len = 0;
         }
         SCLogDebug("%"PRIu64" got %p/%u", p->pcap_cnt, mydata, mydata_len);
         break;


### PR DESCRIPTION
Required libhtp 0.5.32. Add some fixes for HTTP issues.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed