### PR TITLE
configure.ac: fix --disable-geoip

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2061,7 +2061,7 @@
   # libmaxminddb
     AC_ARG_ENABLE(geoip,
 	        AS_HELP_STRING([--enable-geoip],[Enable GeoIP support]),
-	        [ enable_geoip="yes"],
+	        [ enable_geoip="$enableval"],
 	        [ enable_geoip="no"])
     AC_ARG_ENABLE(libgeoip,
         AS_HELP_STRING([--disable-libgeoip], [Disable libgeoip support]),


### PR DESCRIPTION
$enableval should be used to know if the user has passed --enable-geoip
or --disable-geoip

Fixes:
 - http://autobuild.buildroot.org/results/a7a34f760ae5fe0922fdb720b8234dbcd85ed222

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
(cherry picked from commit 61becb29bf2bcce5febd7f98e09b0006d217c8cb)


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed.
