### PR TITLE
rust: remove unnecessary parents (Rust 1.40 fixup) - v1

### DIFF
--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -194,7 +194,7 @@ impl SMBTransactionDCERPC {
 
 impl SMBState {
     fn new_dcerpc_tx(&mut self, hdr: SMBCommonHdr, vercmd: SMBVerCmdStat, cmd: u8, call_id: u32)
-        -> (&mut SMBTransaction)
+        -> &mut SMBTransaction
     {
         let mut tx = self.new_tx();
         tx.hdr = hdr;
@@ -209,7 +209,7 @@ impl SMBState {
     }
 
     fn new_dcerpc_tx_for_response(&mut self, hdr: SMBCommonHdr, vercmd: SMBVerCmdStat, call_id: u32)
-        -> (&mut SMBTransaction)
+        -> &mut SMBTransaction
     {
         let mut tx = self.new_tx();
         tx.hdr = hdr;

--- a/rust/src/smb/session.rs
+++ b/rust/src/smb/session.rs
@@ -42,7 +42,7 @@ impl SMBTransactionSessionSetup {
 
 impl SMBState {
     pub fn new_sessionsetup_tx(&mut self, hdr: SMBCommonHdr)
-        -> (&mut SMBTransaction)
+        -> &mut SMBTransaction
     {
         let mut tx = self.new_tx();
 

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -394,7 +394,7 @@ impl SMBTransactionSetFilePathInfo {
 impl SMBState {
     pub fn new_setfileinfo_tx(&mut self, filename: Vec<u8>, fid: Vec<u8>,
             subcmd: u16, loi: u16, delete_on_close: bool)
-        -> (&mut SMBTransaction)
+        -> &mut SMBTransaction
     {
         let mut tx = self.new_tx();
 
@@ -412,7 +412,7 @@ impl SMBState {
 
     pub fn new_setpathinfo_tx(&mut self, filename: Vec<u8>,
             subcmd: u16, loi: u16, delete_on_close: bool)
-        -> (&mut SMBTransaction)
+        -> &mut SMBTransaction
     {
         let mut tx = self.new_tx();
 
@@ -447,7 +447,7 @@ impl SMBTransactionRename {
 
 impl SMBState {
     pub fn new_rename_tx(&mut self, fuid: Vec<u8>, oldname: Vec<u8>, newname: Vec<u8>)
-        -> (&mut SMBTransaction)
+        -> &mut SMBTransaction
     {
         let mut tx = self.new_tx();
 
@@ -924,7 +924,7 @@ impl SMBState {
      * track a single cmd request/reply pair. */
 
     pub fn new_generic_tx(&mut self, smb_ver: u8, smb_cmd: u16, key: SMBCommonHdr)
-        -> (&mut SMBTransaction)
+        -> &mut SMBTransaction
     {
         let mut tx = self.new_tx();
         if smb_ver == 1 && smb_cmd <= 255 {
@@ -998,7 +998,7 @@ impl SMBState {
     }
 
     pub fn new_negotiate_tx(&mut self, smb_ver: u8)
-        -> (&mut SMBTransaction)
+        -> &mut SMBTransaction
     {
         let mut tx = self.new_tx();
         if smb_ver == 1 {
@@ -1040,7 +1040,7 @@ impl SMBState {
     }
 
     pub fn new_treeconnect_tx(&mut self, hdr: SMBCommonHdr, name: Vec<u8>)
-        -> (&mut SMBTransaction)
+        -> &mut SMBTransaction
     {
         let mut tx = self.new_tx();
 

--- a/rust/src/smb/smb2_ioctl.rs
+++ b/rust/src/smb/smb2_ioctl.rs
@@ -38,7 +38,7 @@ impl SMBTransactionIoctl {
 
 impl SMBState {
     pub fn new_ioctl_tx(&mut self, hdr: SMBCommonHdr, func: u32)
-        -> (&mut SMBTransaction)
+        -> &mut SMBTransaction
     {
         let mut tx = self.new_tx();
         tx.hdr = hdr;


### PR DESCRIPTION
Rust 1.40 in strict mode will now fail the build on the
presence of unnecessary parentheses.

warning: unnecessary parentheses around type
  --> src/smb/smb2_ioctl.rs:41:12
   |
41 |         -> (&mut SMBTransaction)
   |            ^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
   |
   = note: `#[warn(unused_parens)]` on by default


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/428
- https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/784