### PR TITLE
RFC: filestore: Warn if needed but not configured

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -291,6 +291,7 @@ detect-modbus.c detect-modbus.h \
 detect-xbits.c detect-xbits.h \
 detect-cipservice.c detect-cipservice.h \
 device-storage.c device-storage.h \
+feature.c feature.h \
 flow-bit.c flow-bit.h \
 flow.c flow.h \
 flow-bypass.c flow-bypass.h \

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -35,6 +35,8 @@
 #include "detect-engine-mpm.h"
 #include "detect-engine-state.h"
 
+#include "feature.h"
+
 #include "flow.h"
 #include "flow-var.h"
 #include "flow-util.h"
@@ -322,6 +324,17 @@ continue_after_realloc_fail:
 static int DetectFilestoreSetup (DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
     SCEnter();
+
+    bool warn_not_configured = false;
+
+    if (!warn_not_configured) {
+        if (!RequiresFeature("output::file-store")) {
+            SCLogWarning(SC_WARN_ALERT_CONFIG, "One or more rule(s) depends on the "
+                         "file-store output log which is not enabled. "
+                         "Enable the output \"file-store\".");
+        }
+        warn_not_configured = true;
+    }
 
     DetectFilestoreData *fd = NULL;
     SigMatch *sm = NULL;

--- a/src/feature.c
+++ b/src/feature.c
@@ -1,0 +1,141 @@
+/* Copyright (C) 2007-2010 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ *
+ * Implements feature tracking
+ */
+
+#include "suricata-common.h"
+#include "feature.h"
+#include "debug.h"
+
+#include "util-hash.h"
+
+typedef struct _FeatureEntryType {
+	uint16_t	id;
+	const char *feature;
+} FeatureEntryType;
+
+static SCMutex feature_table_mutex = SCMUTEX_INITIALIZER;
+static uint16_t feature_table_id = 0;
+static HashTable *feature_hash_table;
+
+static uint32_t FeatureHashFunc(HashTable *ht, void *data, uint16_t datalen)
+{
+    FeatureEntryType *f = (FeatureEntryType *)data;
+    uint32_t hash = 0;
+    int len = strlen(f->feature);
+
+    for (int i = 0; i < len; i++)
+        hash += tolower((unsigned char)f->feature[i]);
+
+    hash = hash % ht->array_size;
+    return hash;
+}
+
+static char FeatureHashCompareFunc(void *data1, uint16_t datalen1,
+                               void *data2, uint16_t datalen2)
+{
+    FeatureEntryType *f1 = (FeatureEntryType *)data1;
+    FeatureEntryType *f2 = (FeatureEntryType *)data2;
+    int len1 = 0;
+    int len2 = 0;
+
+    if (f1 == NULL || f2 == NULL)
+        return 0;
+
+    if (f1->feature == NULL || f2->feature == NULL)
+        return 0;
+
+    len1 = strlen(f1->feature);
+    len2 = strlen(f2->feature);
+
+    if (len1 == len2 && memcmp(f1->feature, f2->feature, len1) == 0) {
+        return 1;
+    }
+
+    return 0;
+}
+
+static void FeatureHashFreeFunc(void *data)
+{
+    FeatureEntryType *f = data;
+    if (f->feature) {
+        SCFree((void *)f->feature);
+    }
+    SCFree(data);
+}
+
+static void FeatureInit(void) {
+    feature_hash_table = HashTableInit(256, FeatureHashFunc,
+                                       FeatureHashCompareFunc,
+                                       FeatureHashFreeFunc);
+    BUG_ON(feature_hash_table == NULL);
+}
+
+static void FeatureAddEntry(const char *feature_name)
+{
+    FeatureEntryType *feature = SCCalloc(1, sizeof(*feature));
+    BUG_ON(feature == NULL);
+    feature->feature = SCStrdup(feature_name);
+    feature->id = feature_table_id++;
+    BUG_ON(HashTableAdd(feature_hash_table, feature, sizeof(*feature)) < 0);
+}
+
+void ProvidesFeature(const char *feature_name)
+{
+    FeatureEntryType f = { 0, feature_name };
+
+    SCMutexLock(&feature_table_mutex);
+
+    FeatureEntryType *feature = HashTableLookup(feature_hash_table, &f, sizeof(f));
+
+    if (!feature) {
+        FeatureAddEntry(feature_name);
+    }
+
+    SCMutexUnlock(&feature_table_mutex);
+}
+
+bool RequiresFeature(const char *feature_name)
+{
+    FeatureEntryType t = { 0, feature_name };
+
+    SCMutexLock(&feature_table_mutex);
+    FeatureEntryType *feature = HashTableLookup(feature_hash_table, &t, sizeof(t));
+    SCMutexUnlock(&feature_table_mutex);
+
+    return feature != NULL;
+}
+
+void FeatureTrackingRelease(void)
+{
+    if (feature_hash_table != NULL) {
+        HashTableFree(feature_hash_table);
+        feature_hash_table = NULL;
+        feature_table_id = 0;
+    }
+}
+
+void FeatureTrackingRegister(void)
+{
+    FeatureInit();
+}

--- a/src/feature.h
+++ b/src/feature.h
@@ -1,0 +1,33 @@
+/* Copyright (C) 2019 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ */
+
+#ifndef __FEATURE_H__
+#define __FEATURE_H__
+
+void ProvidesFeature(const char *);
+bool RequiresFeature(const char *);
+
+void FeatureTrackingRelease(void);
+void FeatureTrackingRegister(void);
+
+#endif /* __FEATURE_H__ */

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -22,6 +22,8 @@
 #include "app-layer-htp-xff.h"
 #include "app-layer-smtp.h"
 
+#include "feature.h"
+
 #include "output.h"
 #include "output-filestore.h"
 #include "output-json-file.h"
@@ -470,6 +472,8 @@ static OutputInitResult OutputFilestoreLogInitCtx(ConfNode *conf)
 
     /* The new filestore requires SHA256. */
     FileForceSha256Enable();
+
+    ProvidesFeature("output::file-store");
 
     const char *stream_depth_str = ConfNodeLookupChildValue(conf,
             "stream-depth");

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -39,6 +39,7 @@
 
 #include "suricata.h"
 #include "decode.h"
+#include "feature.h"
 #include "detect.h"
 #include "packet-queue.h"
 #include "threads.h"
@@ -379,6 +380,7 @@ static void GlobalsDestroy(SCInstance *suri)
 
     LiveDeviceListClean();
     OutputDeregisterAll();
+    FeatureTrackingRelease();
     TimeDeinit();
     SCProtoNameDeInit();
     if (!suri->disabled_detect) {
@@ -2833,6 +2835,7 @@ static int PostConfLoadedSetup(SCInstance *suri)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
+    FeatureTrackingRegister(); /* must occur prior to output mod registration */
     RegisterAllModules();
 
     AppLayerHtpNeedFileInspection();


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:[3406](https://redmine.openinfosecfoundation.org/issues/3406)

Describe changes:
- Adds a rudimentary feature tracking system where feature providers announce features
   that can be tracked by feature consumers
- Modified filestore output to register "output::file-store" as a provided feature
- Modified filestore detect code to check if "output::file-store" is available and warn, if not.
- Modified engine analyzer to issue warning when a rule requires filestore but it's not configured

Preview -- additional work still needed:
- suricata-verify tests
- comments
- testing (1 sv-test is failing).

