### PR TITLE
python:  add --with-target-python option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -150,6 +150,13 @@
        echo ""
     fi
 
+    # Allow the user to specify what is the target python to use in the python
+    # scripts (can be useful when cross-compiling)
+    AC_ARG_WITH(target-python,
+           AS_HELP_STRING([--with-target-python], [Target python to use in python scripts]),
+           [TARGET_PYTHON=$withval],[TARGET_PYTHON=$HAVE_PYTHON])
+    AC_SUBST(TARGET_PYTHON)
+
     # Check for python-yaml.
     have_python_yaml="no"
     if test "x$enable_python" = "xyes"; then
@@ -2639,6 +2646,7 @@ SURICATA_BUILD_CONF="Suricata Configuration:
 
   Python support:                          ${enable_python}
   Python path:                             ${python_path}
+  Target python:                           ${TARGET_PYTHON}
   Python distutils                         ${have_python_distutils}
   Python yaml                              ${have_python_yaml}
   Install suricatactl:                     ${install_suricatactl}

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -7,11 +7,11 @@ if HAVE_PYTHON
 if HAVE_PYTHON_DISTUTILS
 all-local:
 	cd $(srcdir) && \
-		$(HAVE_PYTHON) setup.py build --build-base "$(abs_builddir)"
+		$(HAVE_PYTHON) setup.py build -e "$(TARGET_PYTHON)" --build-base "$(abs_builddir)"
 
 install-exec-local:
 	cd $(srcdir) && \
-		$(HAVE_PYTHON) setup.py build --build-base "$(abs_builddir)" \
+		$(HAVE_PYTHON) setup.py build -e "$(TARGET_PYTHON)" --build-base "$(abs_builddir)" \
 		install --prefix $(DESTDIR)$(prefix)
 
 uninstall-local:

--- a/suricata-update/Makefile.am
+++ b/suricata-update/Makefile.am
@@ -4,11 +4,11 @@ if HAVE_PYTHON_YAML
 
 all-local:
 	cd $(srcdir) && \
-		$(HAVE_PYTHON) setup.py build --build-base $(abs_builddir)
+		$(HAVE_PYTHON) setup.py build -e "$(TARGET_PYTHON)" --build-base $(abs_builddir)
 
 install-exec-local:
 	cd $(srcdir) && \
-		$(HAVE_PYTHON) setup.py build --build-base "$(abs_builddir)" \
+		$(HAVE_PYTHON) setup.py build -e "$(TARGET_PYTHON)" --build-base "$(abs_builddir)" \
 		install --prefix $(DESTDIR)$(prefix)
 
 uninstall-local:


### PR DESCRIPTION
When installing python scripts, distutils would use the python used to
run setup.py as shebang for the scripts it installs.

However, when cross-compiling, this is most often not correct.

Instead, add a --with-target-python option to allow the user to set its
own value such as '/usr/bin/env python'. To keep current behavior,
$TARGET_PYTHON is set to $HAVE_PYTHON by default

Link to ticket: https://redmine.openinfosecfoundation.org/issues/3432