### PR TITLE
analysis: exit if table entries are stale

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -963,6 +963,12 @@ static void EngineAnalysisItemsInit(void)
         DetectEngineAnalyzerItems *analyzer_item = &analyzer_items[i];
 
         analyzer_item->item_id = DetectBufferTypeGetByName(analyzer_item->item_name);
+        if (analyzer_item->item_id == -1) {
+            /* Mismatch between the analyzer_items array and what's supported */
+            FatalError(SC_ERR_INITIALIZATION,
+                       "unable to initialize engine-analysis table: detect buffer \"%s\" not recognized.",
+                       analyzer_item->item_name);
+        }
         analyzer_item->item_seen = false;
 
         if (analyzer_item->export_item_seen) {


### PR DESCRIPTION
This commit causes Suricata to exit when a buffer from the analyzer
table is not recognized.

Since the table must match what's registered, exiting will bring noticed
to the condition.


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:[3433](https://redmine.openinfosecfoundation.org/issues/3433)

Describe changes:
- Exit with error message if a buffer name is not recognized.
