### PR TITLE
Events counter

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -148,6 +148,7 @@ json_t *JsonAddStringN(const char *string, size_t size)
 
     return SCJsonString(tmpbuf);
 }
+
 static void JsonAddPacketvars(const Packet *p, json_t *js_vars)
 {
     if (p == NULL || p->pktvar == NULL) {

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -32,6 +32,7 @@
 #include "app-layer-htp-xff.h"
 
 void OutputJsonRegister(void);
+void OutputJsonRegisterGlobalCounters(void);
 
 enum OutputJsonLogDirection {
     LOG_DIR_PACKET = 0,

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -75,6 +75,8 @@
 
 #include "datasets.h"
 
+#include "output-json.h"
+
 #include "stream-tcp.h"
 
 #include "source-nfq.h"
@@ -2309,6 +2311,7 @@ void PreRunInit(const int runmode)
     StreamTcpInitConfig(STREAM_VERBOSE);
     AppLayerParserPostStreamSetup();
     AppLayerRegisterGlobalCounters();
+    OutputJsonRegisterGlobalCounters();
 }
 
 /* tasks we need to run before packets start flowing,


### PR DESCRIPTION
This patchset adds basic counters on JSON events. Getting the number of generated events was the main reason behind this patch as it is an important measure when dealing with log shipping and storage.

Counters added are:
- events
- bytes
- min_size
- max_size
- avg_size

Sample output:

```
tail -n1 /tmp/eve.json | jq '.stats.json'
{
  "events": 254144,
  "bytes": 125368383,
  "min_size": 231,
  "max_size": 4998,
  "avg_size": 493
}
```

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Add new counters for JSON output

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/518
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/294

