### PR TITLE
detect: Recognize ERSPAN Type I packets

### DIFF
--- a/src/decode-erspan.c
+++ b/src/decode-erspan.c
@@ -27,7 +27,7 @@
  *
  * \author Victor Julien <victor@inliniac.net>
  *
- * Decodes ERSPAN
+ * Decodes ERSPAN Types I and II
  */
 
 #include "suricata-common.h"
@@ -40,9 +40,22 @@
 #include "util-debug.h"
 
 /**
- * \brief Function to decode ERSPAN packets
+ * \brief Functions to decode ERSPAN Type I and II packets
  */
 
+/**
+ * \brief ERSPAN Type I
+ */
+int DecodeERSPANTypeI(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint32_t len, PacketQueue *pq)
+{
+    StatsIncr(tv, dtv->counter_erspan);
+
+    return DecodeEthernet(tv, dtv, p, pkt, len, pq);
+}
+
+/**
+ * \brief ERSPAN Type II
+ */
 int DecodeERSPAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint32_t len, PacketQueue *pq)
 {
     StatsIncr(tv, dtv->counter_erspan);

--- a/src/decode-gre.c
+++ b/src/decode-gre.c
@@ -252,8 +252,8 @@ int DecodeGRE(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *p
         case ETHERNET_TYPE_ERSPAN:
         {
             if (pq != NULL) {
-                Packet *tp = PacketTunnelPktSetup(tv, dtv, p, pkt + header_len,
-                        len - header_len, DECODE_TUNNEL_ERSPAN, pq);
+                Packet *tp = PacketTunnelPktSetup(tv, dtv, p, pkt + header_len, len - header_len,
+                        p->greh->version == 0 ? DECODE_TUNNEL_ERSPAN_TYPEI : DECODE_TUNNEL_ERSPAN, pq);
                 if (tp != NULL) {
                     PKT_SET_SRC(tp, PKT_SRC_DECODER_GRE);
                     PacketEnqueue(pq,tp);

--- a/src/decode.c
+++ b/src/decode.c
@@ -89,6 +89,8 @@ int DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             return DecodeEthernet(tv, dtv, p, pkt, len, pq);
         case DECODE_TUNNEL_ERSPAN:
             return DecodeERSPAN(tv, dtv, p, pkt, len, pq);
+        case DECODE_TUNNEL_ERSPAN_TYPEI:
+            return DecodeERSPANTypeI(tv, dtv, p, pkt, len, pq);
         default:
             SCLogDebug("FIXME: DecodeTunnel: protocol %" PRIu32 " not supported.", proto);
             break;

--- a/src/decode.c
+++ b/src/decode.c
@@ -28,7 +28,7 @@
  * example we have DecodeIPV4() for IPv4 and DecodePPP() for
  * PPP.
  *
- * These functions have all a pkt and and a len argument which
+ * These functions have all a pkt and a len argument which
  * are respectively a pointer to the protocol data and the length
  * of this protocol data.
  *
@@ -111,7 +111,7 @@ void PacketFree(Packet *p)
  * \brief Finalize decoding of a packet
  *
  * This function needs to be call at the end of decode
- * functions when decoding has been succesful.
+ * functions when decoding has been successful.
  *
  */
 void PacketDecodeFinalize(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
@@ -288,7 +288,7 @@ Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *pare
         SCReturnPtr(NULL, "Packet");
     }
 
-    /* copy packet and set lenght, proto */
+    /* copy packet and set length, proto */
     PacketCopyData(p, pkt, len);
     p->recursion_level = parent->recursion_level + 1;
     p->ts.tv_sec = parent->ts.tv_sec;
@@ -384,7 +384,7 @@ Packet *PacketDefragPktSetup(Packet *parent, const uint8_t *pkt, uint32_t len, u
 
 /**
  *  \brief inform defrag "parent" that a pseudo packet is
- *         now assosiated to it.
+ *         now associated to it.
  */
 void PacketDefragPktSetupParent(Packet *parent)
 {
@@ -646,7 +646,7 @@ void DecodeThreadVarsFree(ThreadVars *tv, DecodeThreadVars *dtv)
 }
 
 /**
- * \brief Set data for Packet and set length when zeo copy is used
+ * \brief Set data for Packet and set length when zero copy is used
  *
  *  \param Pointer to the Packet to modify
  *  \param Pointer to the data

--- a/src/decode.h
+++ b/src/decode.h
@@ -161,7 +161,7 @@ typedef struct Address_ {
         (a)->addr_data32[3] = 0; \
     } while (0)
 
-/* Set the IPv6 addressesinto the Addrs of the Packet.
+/* Set the IPv6 addresses into the Addrs of the Packet.
  * Make sure p->ip6h is initialized and validated. */
 #define SET_IPV6_SRC_ADDR(p, a) do {                    \
         (a)->family = AF_INET6;                         \
@@ -386,7 +386,7 @@ typedef struct PktProfiling_ {
 
 #endif /* PROFILING */
 
-/* forward declartion since Packet struct definition requires this */
+/* forward declaration since Packet struct definition requires this */
 struct PacketQueue_;
 
 /* sizes of the members:
@@ -1091,7 +1091,7 @@ void DecodeUnregisterCounters(void);
 #define PKT_ALLOC                       (1<<3)      /**< Packet was alloc'd this run, needs to be freed */
 #define PKT_HAS_TAG                     (1<<4)      /**< Packet has matched a tag */
 #define PKT_STREAM_ADD                  (1<<5)      /**< Packet payload was added to reassembled stream */
-#define PKT_STREAM_EST                  (1<<6)      /**< Packet is part of establised stream */
+#define PKT_STREAM_EST                  (1<<6)      /**< Packet is part of established stream */
 #define PKT_STREAM_EOF                  (1<<7)      /**< Stream is in eof state */
 #define PKT_HAS_FLOW                    (1<<8)
 #define PKT_PSEUDO_STREAM_END           (1<<9)      /**< Pseudo packet to end the stream */

--- a/src/decode.h
+++ b/src/decode.h
@@ -890,6 +890,7 @@ void CaptureStatsSetup(ThreadVars *tv, CaptureStats *s);
 enum DecodeTunnelProto {
     DECODE_TUNNEL_ETHERNET,
     DECODE_TUNNEL_ERSPAN,
+    DECODE_TUNNEL_ERSPAN_TYPEI,
     DECODE_TUNNEL_VLAN,
     DECODE_TUNNEL_IPV4,
     DECODE_TUNNEL_IPV6,
@@ -943,6 +944,7 @@ int DecodeVLAN(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint
 int DecodeVXLAN(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
 int DecodeMPLS(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
 int DecodeERSPAN(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
+int DecodeERSPANTypeI(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
 int DecodeTEMPLATE(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, PacketQueue *);
 
 #ifdef UNITTESTS


### PR DESCRIPTION
This PR adds support for ERSPAN Type I packets.

Continuation of #4466 

[This document](https://tools.ietf.org/tools/rfcdiff/rfcdiff.pyht?url1=http://tools.ietf.org/id/draft-foschiano-erspan-01.txt&url2=http://tools.ietf.org/id/draft-foschiano-erspan-02.txt) and wireshark were used as a reference for this work.

Link to redmine ticket:[3422](https://redmine.openinfosecfoundation.org/issues/3422)

Describe changes:
- Address review comments from #4466

Suricata-verify pr [169](https://github.com/OISF/suricata-verify/pull/169)