### PR TITLE
modbus: Fix Coverity discovered issue

### DIFF
--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1733,7 +1733,7 @@ static uint8_t readWriteMultipleRegistersRsp[] = {/* Transaction ID */          
                                                                                 0x00};
 
 /* Modbus Application Protocol Specification V1.1b3 6.8.1: 04 Force Listen Only Mode */
-/* Example of a request to to remote device to its Listen Only MOde for Modbus Communications. */
+/* Example of a request to to remote device to its Listen Only Mode for Modbus Communications. */
 static uint8_t forceListenOnlyMode[] = {/* Transaction ID */     0x0A, 0x00,
                                         /* Protocol ID */        0x00, 0x00,
                                         /* Length */             0x00, 0x06,

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -280,7 +280,7 @@ static void ModbusSetTxDetectFlags(void *vtx, uint8_t dir, uint64_t flags)
     if (dir & STREAM_TOSERVER) {
         tx->detect_flags_ts = flags;
     } else {
-        tx->detect_flags_ts = flags;
+        tx->detect_flags_tc = flags;
     }
 }
 


### PR DESCRIPTION
This PR contains a fix for the coverity discovered issue handling TX detection flags.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:[3431](https://redmine.openinfosecfoundation.org/issues/3434)

Describe changes:
- Update correct TX flags.
