### PR TITLE
Fuzz prep v6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -238,6 +238,12 @@
             #include <sys/random.h> 
             ])
 
+    AC_CHECK_DECL([memmem],
+        AC_DEFINE([HAVE_MEMMEM], [1], [Use memmem]),
+        [], [
+            #include <string.h>
+            ])
+
     AC_CHECK_FUNCS([utime])
 
     OCFLAGS=$CFLAGS

--- a/qa/coccinelle/banned-functions.cocci
+++ b/qa/coccinelle/banned-functions.cocci
@@ -3,7 +3,7 @@ identifier i;
 position p1;
 @@
 
-\(strtok@i\|sprintf@i\|strcat@i\|strcpy@i\|strncpy@i\|strncat@i\|strchrnul@i\|rand@i\|rand_r@i\|memmem@i\|index@i\|rindex@i\|bzero@i\)(...)@p1
+\(strtok@i\|sprintf@i\|strcat@i\|strcpy@i\|strncpy@i\|strncat@i\|strchrnul@i\|rand@i\|rand_r@i\|index@i\|rindex@i\|bzero@i\)(...)@p1
 
 @script:python@
 p1 << banned.p1;

--- a/src/decode.c
+++ b/src/decode.c
@@ -656,7 +656,8 @@ inline int PacketSetData(Packet *p, const uint8_t *pktdata, uint32_t pktlen)
     if (unlikely(!pktdata)) {
         return -1;
     }
-    p->ext_pkt = (uint8_t *)pktdata;
+    // ext_pkt cannot be const (because we sometimes copy)
+    p->ext_pkt = (uint8_t *) pktdata;
     p->flags |= PKT_ZERO_COPY;
 
     return 0;

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -178,6 +178,9 @@ extern volatile uint8_t suricata_ctl_flags;
 extern int g_disable_randomness;
 extern uint16_t g_vlan_mask;
 
+int InitGlobal(void);
+int PostConfLoadedSetup(SCInstance *suri);
+
 #include <ctype.h>
 #define u8_tolower(c) tolower((uint8_t)(c))
 #define u8_toupper(c) toupper((uint8_t)(c))

--- a/src/util-conf.c
+++ b/src/util-conf.c
@@ -28,7 +28,7 @@
 #include "runmodes.h"
 #include "util-conf.h"
 
-TmEcode ConfigSetLogDirectory(char *name)
+TmEcode ConfigSetLogDirectory(const char *name)
 {
     return ConfSetFinal("default-log-dir", name) ? TM_ECODE_OK : TM_ECODE_FAILED;
 }

--- a/src/util-conf.h
+++ b/src/util-conf.h
@@ -27,7 +27,7 @@
 
 #include "conf.h"
 
-TmEcode ConfigSetLogDirectory(char *name);
+TmEcode ConfigSetLogDirectory(const char *name);
 const char *ConfigGetLogDirectory(void);
 TmEcode ConfigCheckLogDirectoryExists(const char *log_dir);
 

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -707,7 +707,7 @@ static inline SCLogOPIfaceCtx *SCLogInitFileOPIface(const char *file,
         exit(EXIT_FAILURE);
     }
 
-    if (file == NULL || log_format == NULL) {
+    if (file == NULL) {
         goto error;
     }
 
@@ -723,7 +723,7 @@ static inline SCLogOPIfaceCtx *SCLogInitFileOPIface(const char *file,
         goto error;
     }
 
-    if ((iface_ctx->log_format = SCStrdup(log_format)) == NULL) {
+    if (log_format != NULL && (iface_ctx->log_format = SCStrdup(log_format)) == NULL) {
         goto error;
     }
 

--- a/src/util-print.c
+++ b/src/util-print.c
@@ -39,7 +39,7 @@
  *  \param buf buffer to print from
  *  \param buflen length of the input buffer
  */
-void PrintBufferRawLineHex(char *nbuf, int *offset, int max_size, uint8_t *buf, uint32_t buflen)
+void PrintBufferRawLineHex(char *nbuf, int *offset, int max_size, const uint8_t *buf, uint32_t buflen)
 {
     uint32_t u = 0;
 
@@ -58,7 +58,7 @@ void PrintBufferRawLineHex(char *nbuf, int *offset, int max_size, uint8_t *buf, 
  *  \param buf buffer to print from
  *  \param buflen length of the input buffer
  */
-void PrintRawLineHexBuf(char *retbuf, uint32_t retbuflen, uint8_t *buf, uint32_t buflen)
+void PrintRawLineHexBuf(char *retbuf, uint32_t retbuflen, const uint8_t *buf, uint32_t buflen)
 {
     uint32_t offset = 0;
     uint32_t u = 0;

--- a/src/util-print.h
+++ b/src/util-print.h
@@ -41,7 +41,7 @@
         }                                                               \
     } while (0)
 
-void PrintBufferRawLineHex(char *, int *,int, uint8_t *, uint32_t);
+void PrintBufferRawLineHex(char *, int *,int, const uint8_t *, uint32_t);
 void PrintRawUriFp(FILE *, uint8_t *, uint32_t);
 void PrintRawUriBuf(char *, uint32_t *, uint32_t,
                     uint8_t *, uint32_t);
@@ -51,7 +51,7 @@ void PrintRawDataToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32
                           const uint8_t *src_buf, uint32_t src_buf_len);
 void PrintStringsToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32_t dst_buf_size,
                           const uint8_t *src_buf, const uint32_t src_buf_len);
-void PrintRawLineHexBuf(char *, uint32_t, uint8_t *, uint32_t );
+void PrintRawLineHexBuf(char *, uint32_t, const uint8_t *, uint32_t );
 const char *PrintInet(int , const void *, char *, socklen_t);
 
 #endif /* __UTIL_PRINT_H__ */

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -995,6 +995,18 @@ static int CheckUTHTestPacket(Packet *p, uint8_t ipproto)
     return 1;
 }
 
+#ifdef HAVE_MEMMEM
+#include <string.h>
+void * UTHmemsearch(const void *big, size_t big_len, const void *little, size_t little_len) {
+    return memmem(big, big_len, little, little_len);
+}
+#else
+#include "util-spm-bs.h"
+void * UTHmemsearch(const void *big, size_t big_len, const void *little, size_t little_len) {
+    return BasicSearch(big, big_len, little, little_len);
+}
+#endif //HAVE_MEMMEM
+
 /**
  * \brief UTHBuildPacketRealTest01 wrapper to check packets for unittests
  */

--- a/src/util-unittest-helper.h
+++ b/src/util-unittest-helper.h
@@ -61,6 +61,7 @@ uint32_t UTHBuildPacketOfFlows(uint32_t, uint32_t, uint8_t);
 Packet *UTHBuildPacketIPV6Real(uint8_t *, uint16_t , uint8_t ipproto, const char *, const char *,
                            uint16_t , uint16_t );
 
+void * UTHmemsearch(const void *big, size_t big_len, const void *little, size_t little_len);
 int UTHParseSignature(const char *str, bool expect);
 #endif
 


### PR DESCRIPTION
Link to redmine ticket:
https://redmine.openinfosecfoundation.org/issues/2859

Describe changes: preparation for fuzzing
- Using more `const` keywords
- log can use a file set from env variable
- adds a util `UTHmemsearch` function to be able to use `memmem` for fuzz targets

Modifies #4454 with :
- removing init.c file
- adds `InitGlobal` function to suricata.c (changing some order for windows)
- have a new file main.c for `main` which is just a wrapper to the previous function renamed `SC_main`


Another way is proposed in v7 #4484 : hack not to use `main` while fuzzing with `#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION`

I am not sure about the `SCInstance suricata` variable :
It seems to be a global variable
But some functions expect it as a parameter, even if it always refer to the global variable
Should fuzz targets use their own global variable ? (to call `PostConfLoadedSetup`)
