### PR TITLE
Fix out-of-source offline builds with vendored sources - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -249,6 +249,7 @@ jobs:
       - run: ./configure --enable-unittests
       - run: make -j2
       - run: make check
+      - run: make distcheck
       - name: Fetching suricata-verify
         run: git clone https://github.com/OISF/suricata-verify.git
       - name: Running suricata-verify

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -143,20 +143,14 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: dist
-      - run: mkdir suricata
-      - working-directory: suricata
-        run: tar zxvf ../dist/suricata-*.tar.gz --strip-components=1
-      - working-directory: suricata
-        run: ./configure
-      - working-directory: suricata
-        name: Check that Rust is using --frozen
+      - run: tar zxvf ./dist/suricata-*.tar.gz --strip-components=1
+      - run: ./configure
+      - name: Check that Rust is using --frozen
         run: grep -q '^FROZEN' rust/Makefile
-      - working-directory: suricata
-        run: make -j2
-      - working-directory: suricata
-        run: make install
-      - working-directory: suricata
-        run: make install-conf
+      - run: make -j2
+      - run: make install
+      - run: make install-conf
+      - run: make distcheck
 
   centos-6:
     name: CentOS 6

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -1,14 +1,9 @@
-EXTRA_DIST =	Cargo.lock \
-		src \
+EXTRA_DIST =	src \
 		.cargo/config.in \
 		gen-c-headers.py
 
 if HAVE_CARGO_VENDOR
 EXTRA_DIST +=	vendor
-endif
-
-if HAVE_RUST_VENDOR
-FROZEN = --frozen
 endif
 
 if !DEBUG
@@ -33,16 +28,16 @@ if HAVE_PYTHON
 endif
 if HAVE_CYGPATH
 	rustpath=`cygpath -a -t mixed $(abs_top_builddir)`
-	cd $(top_srcdir)/rust && @rustup_home@ \
+	@rustup_home@ \
 		CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$$rustpath/rust/target" \
-		$(CARGO) build $(RELEASE) $(FROZEN) \
+		$(CARGO) build $(RELEASE) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)
 else
-	cd $(top_srcdir)/rust && @rustup_home@ \
+	@rustup_home@ \
 		CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$(abs_top_builddir)/rust/target" \
-		$(CARGO) build $(RELEASE) $(FROZEN) \
+		$(CARGO) build $(RELEASE) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)
 endif
 
@@ -53,12 +48,9 @@ distclean-local: clean-local
 	rm -rf vendor gen Cargo.lock
 
 check:
-	CARGO_HOME="$(CARGO_HOME)" @rustup_home@
-		$(CARGO) test --features "$(RUST_FEATURES)"
-
-Cargo.lock: Cargo.toml
-	CARGO_HOME="$(CARGO_HOME)" @rustup_home@ $(CARGO) \
-		generate-lockfile
+	CARGO_HOME="$(CARGO_HOME)" @rustup_home@ \
+		CARGO_TARGET_DIR="$(abs_top_builddir)/rust/target" \
+		$(CARGO) test $(RELEASE) --features "$(RUST_FEATURES)"
 
 if HAVE_CARGO_VENDOR
 vendor:

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -1,4 +1,4 @@
-EXTRA_DIST = Cargo.toml Cargo.lock \
+EXTRA_DIST =	Cargo.lock \
 		src \
 		.cargo/config.in \
 		gen-c-headers.py


### PR DESCRIPTION
Hopefully better handling of builds done from distribution
archives with vendored sources.

- Don't include Cargo.toml, its always regenerated.
- Don't include Cargo.lock, it was only included
  when sources were vendored, and can be generate
  from the vendored sources.
- Do the build from the build directory, instead
  of from the source directory. This needs to be
  done to pick up the .cargo/config that is generated
  by ./configure. We previously did the cd to pick
  up the Cargo.lock, which meant the generated
  cargo config wasn't being picked up, and there
  currently exists no command line option to tell
  it where to look.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- Failed to connect to buildbot.