### PR TITLE
Fix out-of-source offline builds with vendored sources - v2

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -145,8 +145,6 @@ jobs:
           name: dist
       - run: tar zxvf ./dist/suricata-*.tar.gz --strip-components=1
       - run: ./configure
-      - name: Check that Rust is using --frozen
-        run: grep -q '^FROZEN' rust/Makefile
       - run: make -j2
       - run: make install
       - run: make install-conf

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -249,6 +249,7 @@ jobs:
       - run: ./configure --enable-unittests
       - run: make -j2
       - run: make check
+      - run: make distcheck
       - name: Fetching suricata-verify
         run: git clone https://github.com/OISF/suricata-verify.git
       - name: Running suricata-verify

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -143,20 +143,14 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: dist
-      - run: mkdir suricata
-      - working-directory: suricata
-        run: tar zxvf ../dist/suricata-*.tar.gz --strip-components=1
-      - working-directory: suricata
-        run: ./configure
-      - working-directory: suricata
-        name: Check that Rust is using --frozen
+      - run: tar zxvf ./dist/suricata-*.tar.gz --strip-components=1
+      - run: ./configure
+      - name: Check that Rust is using --frozen
         run: grep -q '^FROZEN' rust/Makefile
-      - working-directory: suricata
-        run: make -j2
-      - working-directory: suricata
-        run: make install
-      - working-directory: suricata
-        run: make install-conf
+      - run: make -j2
+      - run: make install
+      - run: make install-conf
+      - run: make distcheck
 
   centos-6:
     name: CentOS 6

--- a/configure.ac
+++ b/configure.ac
@@ -85,7 +85,7 @@
     AC_PROG_GREP
 
     AC_PATH_PROG(HAVE_CYGPATH, cygpath, "no")
-    AM_CONDITIONAL([HAVE_CYGPATH], [test "x$enable_cygpath" = "xyes"])
+    AM_CONDITIONAL([HAVE_CYGPATH], [test "x$HAVE_CYGPATH" != "xno"])
 
     AC_PATH_PROG(HAVE_PKG_CONFIG, pkg-config, "no")
     if test "$HAVE_PKG_CONFIG" = "no"; then
@@ -2415,7 +2415,12 @@ fi
     AC_SUBST(RUST_SURICATA_LIB)
     AC_SUBST(RUST_LDADD)
     if test "x$CARGO_HOME" = "x"; then
-      AC_SUBST([CARGO_HOME], [~/.cargo])
+        if test "x$HAVE_CYGPATH" != "no"; then
+          CYGPATH_CARGO_HOME=$(cygpath -a -t mixed ~/.cargo)
+          AC_SUBST([CARGO_HOME], [$CYGPATH_CARGO_HOME])
+        else
+          AC_SUBST([CARGO_HOME], [~/.cargo])
+        fi
     else
       AC_SUBST([CARGO_HOME], [$CARGO_HOME])
     fi

--- a/rust/.cargo/config.in
+++ b/rust/.cargo/config.in
@@ -5,4 +5,4 @@
 @rust_vendor_comment@replace-with = 'vendored-sources'
 @rust_vendor_comment@
 @rust_vendor_comment@[source.vendored-sources]
-@rust_vendor_comment@directory = '@abs_top_srcdir@/rust/vendor'
+@rust_vendor_comment@directory = '@e_rustdir@/vendor'

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -1,14 +1,9 @@
-EXTRA_DIST =	Cargo.lock \
-		src \
+EXTRA_DIST =	src \
 		.cargo/config.in \
 		gen-c-headers.py
 
 if HAVE_CARGO_VENDOR
 EXTRA_DIST +=	vendor
-endif
-
-if HAVE_RUST_VENDOR
-FROZEN = --frozen
 endif
 
 if !DEBUG
@@ -33,16 +28,16 @@ if HAVE_PYTHON
 endif
 if HAVE_CYGPATH
 	rustpath=`cygpath -a -t mixed $(abs_top_builddir)`
-	cd $(top_srcdir)/rust && @rustup_home@ \
+	@rustup_home@ \
 		CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$$rustpath/rust/target" \
-		$(CARGO) build $(RELEASE) $(FROZEN) \
+		$(CARGO) build $(RELEASE) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)
 else
-	cd $(top_srcdir)/rust && @rustup_home@ \
+	@rustup_home@ \
 		CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$(abs_top_builddir)/rust/target" \
-		$(CARGO) build $(RELEASE) $(FROZEN) \
+		$(CARGO) build $(RELEASE) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)
 endif
 
@@ -53,12 +48,9 @@ distclean-local: clean-local
 	rm -rf vendor gen Cargo.lock
 
 check:
-	CARGO_HOME="$(CARGO_HOME)" @rustup_home@
-		$(CARGO) test --features "$(RUST_FEATURES)"
-
-Cargo.lock: Cargo.toml
-	CARGO_HOME="$(CARGO_HOME)" @rustup_home@ $(CARGO) \
-		generate-lockfile
+	CARGO_HOME="$(CARGO_HOME)" @rustup_home@ \
+		CARGO_TARGET_DIR="$(abs_top_builddir)/rust/target" \
+		$(CARGO) test $(RELEASE) --features "$(RUST_FEATURES)"
 
 if HAVE_CARGO_VENDOR
 vendor:

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -27,10 +27,9 @@ if HAVE_PYTHON
 	cd $(top_srcdir)/rust && $(HAVE_PYTHON) ./gen-c-headers.py
 endif
 if HAVE_CYGPATH
-	rustpath=`cygpath -a -t mixed $(abs_top_builddir)`
 	@rustup_home@ \
 		CARGO_HOME="$(CARGO_HOME)" \
-		CARGO_TARGET_DIR="$$rustpath/rust/target" \
+		CARGO_TARGET_DIR="$(e_rustdir)/target" \
 		$(CARGO) build $(RELEASE) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)
 else

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -1,4 +1,4 @@
-EXTRA_DIST = Cargo.toml Cargo.lock \
+EXTRA_DIST =	Cargo.lock \
 		src \
 		.cargo/config.in \
 		gen-c-headers.py


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/4486
But based on: https://github.com/OISF/suricata/pull/4489

Just fixes the FROZEN check on the CentOS 7 GitHub CI
build.

Also tested on a CentOS 8 system that was completley
offline with Rust 1.33 to verify that Cargo.lock
could be generated from vendored sources without
going online.