### PR TITLE
file: reassemble files from different transcations with range

### DIFF
--- a/src/app-layer-htp-file.h
+++ b/src/app-layer-htp-file.h
@@ -33,7 +33,7 @@ typedef struct HtpContentRange_ {
 
 int HTPFileOpen(HtpState *, const uint8_t *, uint16_t, const uint8_t *, uint32_t, uint64_t, uint8_t);
 int HTPParseContentRange(bstr * rawvalue, HtpContentRange *range);
-int HTPFileSetRange(HtpState *, bstr *rawvalue);
+int HTPFileOpenWithRange(HtpState *, const uint8_t *, uint16_t, const uint8_t *, uint32_t, uint64_t, bstr *rawvalue);
 int HTPFileStoreChunk(HtpState *, const uint8_t *, uint32_t, uint8_t);
 int HTPFileClose(HtpState *, const uint8_t *, uint32_t, uint8_t, uint8_t);
 

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1765,8 +1765,15 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
         }
 
         if (filename != NULL) {
-            result = HTPFileOpen(hstate, filename, (uint32_t)filename_len,
-                    data, data_len, HtpGetActiveResponseTxID(hstate), STREAM_TOCLIENT);
+            //set range if present
+            htp_header_t *h_content_range = htp_table_get_c(tx->response_headers, "content-range");
+            if (h_content_range != NULL) {
+                result = HTPFileOpenWithRange(hstate, filename, (uint32_t)filename_len,
+                                              data, data_len, HtpGetActiveResponseTxID(hstate), h_content_range->value);
+            } else {
+                result = HTPFileOpen(hstate, filename, (uint32_t)filename_len,
+                                     data, data_len, HtpGetActiveResponseTxID(hstate), STREAM_TOCLIENT);
+            }
             SCLogDebug("result %d", result);
             if (result == -1) {
                 goto end;
@@ -1776,11 +1783,6 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
                 FlagDetectStateNewFile(htud, STREAM_TOCLIENT);
                 htud->tcflags |= HTP_FILENAME_SET;
                 htud->tcflags &= ~HTP_DONTSTORE;
-            }
-            //set range if present
-            htp_header_t *h_content_range = htp_table_get_c(tx->response_headers, "content-range");
-            if (h_content_range != NULL) {
-                HTPFileSetRange(hstate, h_content_range->value);
             }
         }
     }

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -257,6 +257,7 @@ typedef struct HtpState_ {
     uint16_t events;
     uint16_t htp_messages_offset; /**< offset into conn->messages list */
     uint32_t file_track_id;             /**< used to assign file track ids to files */
+    uint32_t file_range_id;             /**< used to assign track ids to range file */
     uint64_t last_request_data_stamp;
     uint64_t last_response_data_stamp;
 } HtpState;

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -786,7 +786,7 @@ void FileSetInspectSizes(File *file, const uint32_t win, const uint32_t min)
  *  \retval  0 ok
  *  \retval -1 error
  */
-int FileSetRange(FileContainer *ffc, uint64_t start, uint64_t end)
+int FileSetRange(FileContainer *ffc, uint64_t start, uint64_t end, uint64_t totalsize)
 {
     SCEnter();
 
@@ -795,6 +795,7 @@ int FileSetRange(FileContainer *ffc, uint64_t start, uint64_t end)
     }
     ffc->tail->start = start;
     ffc->tail->end = end;
+    ffc->tail->totalsize = totalsize;
     SCReturnInt(0);
 }
 

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -91,6 +91,7 @@ typedef struct File_ {
     uint32_t inspect_min_size;
     uint64_t start;
     uint64_t end;
+    uint64_t totalsize;
 
     uint32_t *sid; /* signature id of a rule that triggered the filestore event */
     uint32_t sid_cnt;
@@ -176,11 +177,12 @@ void FileSetInspectSizes(File *file, const uint32_t win, const uint32_t min);
  *  \param ffc the container
  *  \param start start offset
  *  \param end end offset
+ *  \param total total size of file
  *
  *  \retval 0 ok
  *  \retval -1 error
  */
-int FileSetRange(FileContainer *, uint64_t start, uint64_t end);
+int FileSetRange(FileContainer *, uint64_t start, uint64_t end, uint64_t total);
 
 /**
  *  \brief Tag a file for storing


### PR DESCRIPTION
For discussion ,not to be merged yet

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1576

Describe changes:
- adds `HTPFileOpenWithRange` to handle like `HTPFileOpen` if there is a range (replaces `HTPFileSetRange` on the way) : open 2 files, one for the whole reassembled, and one only for the current range
- Creates some file structure for the reassembled one identified with `file_range_id`
- Stores chunks for both the reassembled file and the small range one
- Closes reassembled file if range chunk ends after size of reassembled file

Follows #4427 with a working implementation

This is very basic and there are checks and features still missing (cf TODOs comments).
At least, it is now working against https://github.com/OISF/suricata-verify/pull/171
Is this the right way to go ?

Another solution I think of would be to give some external program the ability to inject some kinds of pseudo packets (with the reassembled file)
This way, we would be robust if the range requests come over multiple flows, and we still can run suricata rules on the reassembled file