### PR TITLE
defrag: set livedev on the reassembled packet (issue-3380) - v1

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -376,6 +376,7 @@ Packet *PacketDefragPktSetup(Packet *parent, const uint8_t *pkt, uint32_t len, u
     p->vlan_id[0] = parent->vlan_id[0];
     p->vlan_id[1] = parent->vlan_id[1];
     p->vlan_idx = parent->vlan_idx;
+    p->livedev = parent->livedev;
 
     SCReturnPtr(p, "Packet");
 }


### PR DESCRIPTION
Set the livedev on reassembled packets to that of the parent
packet. Fixes issues with multidetect, specifically a segfault
as reported in issue 3380.

Bug #3380.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3380

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/436
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/792