### PR TITLE
Opt/smb file tx/v3

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -21,7 +21,6 @@ use std;
 use crate::filecontainer::*;
 
 /// Opaque C types.
-pub enum Flow {}
 pub enum DetectEngineState {}
 pub enum AppLayerDecoderEvents {}
 
@@ -180,6 +179,29 @@ pub fn sc_app_layer_decoder_events_free_events(
     unsafe {
         if let Some(c) = SC {
             (c.AppLayerDecoderEventsFreeEvents)(events);
+        }
+    }
+}
+
+/// Opaque flow type (defined in C)
+pub enum Flow {}
+
+/// Extern functions operating on Flow.
+extern {
+    pub fn FlowGetLastTimeAsParts(flow: &Flow, secs: *mut u64, usecs: *mut u64);
+}
+
+/// Rust implementation of Flow.
+impl Flow {
+
+    /// Return the time of the last flow update as a `Duration`
+    /// since the epoch.
+    pub fn get_last_time(&mut self) -> std::time::Duration {
+        unsafe {
+            let mut secs: u64 = 0;
+            let mut usecs: u64 = 0;
+            FlowGetLastTimeAsParts(self, &mut secs, &mut usecs);
+            std::time::Duration::new(secs, usecs as u32 * 1000)
         }
     }
 }

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -30,6 +30,7 @@ pub struct SMBTransactionFile {
     pub file_name: Vec<u8>,
     pub share_name: Vec<u8>,
     pub file_tracker: FileTransferTracker,
+    pub post_gap_ts: u64,
 }
 
 impl SMBTransactionFile {
@@ -40,6 +41,7 @@ impl SMBTransactionFile {
             file_name: Vec::new(),
             share_name: Vec::new(),
             file_tracker: FileTransferTracker::new(),
+            post_gap_ts: 0,
         }
     }
 }
@@ -199,6 +201,11 @@ impl SMBState {
                             SCLogDebug!("QUEUED size {} while we've seen GAPs. Truncating file.", queued_data);
                             tdf.file_tracker.trunc(files, flags);
                         }
+                    }
+
+                    // reset timestamp if we get called after a gap
+                    if tdf.post_gap_ts > 0 {
+                        tdf.post_gap_ts = 0;
                     }
 
                     let file_data = &data[0..data_to_handle_len];

--- a/src/flow.c
+++ b/src/flow.c
@@ -1113,6 +1113,19 @@ void FlowUpdateState(Flow *f, enum FlowState s)
     }
 }
 
+/**
+ * \brief Get flow last time as individual values.
+ *
+ * Instead of returning a pointer to the timeval copy the timeval
+ * parts into output pointers to make it simpler to call from Rust
+ * over FFI using only basic data types.
+ */
+void FlowGetLastTimeAsParts(Flow *flow, uint64_t *secs, uint64_t *usecs)
+{
+    *secs = (uint64_t)flow->lastts.tv_sec;
+    *usecs = (uint64_t)flow->lastts.tv_usec;
+}
+
 /************************************Unittests*******************************/
 
 #ifdef UNITTESTS

--- a/src/flow.h
+++ b/src/flow.h
@@ -537,6 +537,8 @@ uint64_t FlowGetMemuse(void);
 int GetFlowBypassInfoID(void);
 void RegisterFlowBypassInfo(void);
 
+void FlowGetLastTimeAsParts(Flow *flow, uint64_t *secs, uint64_t *usecs);
+
 /** ----- Inline functions ----- */
 
 /** \brief Set the No Packet Inspection Flag without locking the flow.


### PR DESCRIPTION
After a GAP all normal transactions are closed. File transactions
are left open as they can handle GAPs in principle. However, the
GAP might have contained the closing of a file and therefore it
may remain active until the end of the flow.

This patch introduces a time based heuristic for these transactions.
After the GAP all file transactions are stamped with the current
timestamp. If 60 seconds later a file has seen no update, its marked
as closed.

This is meant to fix resource starvation issues observed in long
running SMB sessions where packet loss was causing GAPs.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3400

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed.