### PR TITLE
stream-tcp-list: fixed typo in CheckOverlap function

### DIFF
--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -141,7 +141,7 @@ static inline bool CheckOverlap(struct TCPSEG *tree, TcpSegment *seg)
             return true;
         // prev's right edge is beyond our seq, overlap
         const uint32_t prev_re = SEG_SEQ_RIGHT_EDGE(prev);
-        if (SEQ_GT(prev_re, prev->seq))
+        if (SEQ_GT(prev_re, seg->seq))
             return true;
     }
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
It looks like prev's right edge is tested against prev->seq due to typo.
It must be compared to seg->seq.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

