### PR TITLE
Next/41x/20200129/v2

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -22,7 +22,6 @@ extern crate libc;
 use filecontainer::*;
 
 /// Opaque C types.
-pub enum Flow {}
 pub enum DetectEngineState {}
 pub enum AppLayerDecoderEvents {}
 
@@ -178,6 +177,29 @@ pub fn sc_app_layer_decoder_events_free_events(
     unsafe {
         if let Some(c) = SC {
             (c.AppLayerDecoderEventsFreeEvents)(events);
+        }
+    }
+}
+
+/// Opaque flow type (defined in C)
+pub enum Flow {}
+
+/// Extern functions operating on Flow.
+extern {
+    pub fn FlowGetLastTimeAsParts(flow: &Flow, secs: *mut u64, usecs: *mut u64);
+}
+
+/// Rust implementation of Flow.
+impl Flow {
+
+    /// Return the time of the last flow update as a `Duration`
+    /// since the epoch.
+    pub fn get_last_time(&mut self) -> std::time::Duration {
+        unsafe {
+            let mut secs: u64 = 0;
+            let mut usecs: u64 = 0;
+            FlowGetLastTimeAsParts(self, &mut secs, &mut usecs);
+            std::time::Duration::new(secs, usecs as u32 * 1000)
         }
     }
 }

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -783,6 +783,10 @@ pub struct SMBState<> {
     pub ts_trunc: bool, // no more data for TOSERVER
     pub tc_trunc: bool, // no more data for TOCLIENT
 
+    /// true as long as we have file txs that are in a post-gap
+    /// state. It means we'll do extra house keeping for those.
+    check_post_gap_file_txs: bool,
+
     /// transactions list
     pub transactions: Vec<SMBTransaction>,
 
@@ -797,6 +801,10 @@ pub struct SMBState<> {
     /// dcerpc interfaces, stored here to be able to match
     /// them while inspecting DCERPC REQUEST txs
     pub dcerpc_ifaces: Option<Vec<DCERPCIface>>,
+
+    /// Timestamp in seconds of last update. This is packet time,
+    /// potentially coming from pcaps.
+    ts: u64,
 }
 
 impl SMBState {
@@ -823,11 +831,13 @@ impl SMBState {
             tc_gap: false,
             ts_trunc: false,
             tc_trunc: false,
+            check_post_gap_file_txs: false,
             transactions: Vec::new(),
             tx_id:0,
             dialect:0,
             dialect_vec: None,
             dcerpc_ifaces: None,
+            ts: 0,
         }
     }
 
@@ -1142,9 +1152,29 @@ impl SMBState {
         (&name, is_dcerpc)
     }
 
+    fn post_gap_housekeeping_for_files(&mut self)
+    {
+        let mut post_gap_txs = false;
+        for tx in &mut self.transactions {
+            if let Some(SMBTransactionTypeData::FILE(ref f)) = tx.type_data {
+                if f.post_gap_ts > 0 {
+                    if self.ts > f.post_gap_ts {
+                        tx.request_done = true;
+                        tx.response_done = true;
+                    } else {
+                        post_gap_txs = true;
+                    }
+                }
+            }
+        }
+        self.check_post_gap_file_txs = post_gap_txs;
+    }
+
     /* after a gap we will consider all transactions complete for our
      * direction. File transfer transactions are an exception. Those
-     * can handle gaps. */
+     * can handle gaps. For the file transactions we set the current
+     * (flow) time and prune them in 60 seconds if no update for them
+     * was received. */
     fn post_gap_housekeeping(&mut self, dir: u8)
     {
         if self.ts_ssn_gap && dir == STREAM_TOSERVER {
@@ -1153,8 +1183,13 @@ impl SMBState {
                     SCLogDebug!("post_gap_housekeeping: done");
                     break;
                 }
-                if let Some(SMBTransactionTypeData::FILE(_)) = tx.type_data {
-                    // leaving FILE txs open as they can deal with gaps.
+                if let Some(SMBTransactionTypeData::FILE(ref mut f)) = tx.type_data {
+                    // leaving FILE txs open as they can deal with gaps. We
+                    // remove them after 60 seconds of no activity though.
+                    if f.post_gap_ts == 0 {
+                        f.post_gap_ts = self.ts + 60;
+                        self.check_post_gap_file_txs = true;
+                    }
                 } else {
                     SCLogDebug!("post_gap_housekeeping: tx {} marked as done TS", tx.id);
                     tx.request_done = true;
@@ -1166,8 +1201,13 @@ impl SMBState {
                     SCLogDebug!("post_gap_housekeeping: done");
                     break;
                 }
-                if let Some(SMBTransactionTypeData::FILE(_)) = tx.type_data {
-                    // leaving FILE txs open as they can deal with gaps.
+                if let Some(SMBTransactionTypeData::FILE(ref mut f)) = tx.type_data {
+                    // leaving FILE txs open as they can deal with gaps. We
+                    // remove them after 60 seconds of no activity though.
+                    if f.post_gap_ts == 0 {
+                        f.post_gap_ts = self.ts + 60;
+                        self.check_post_gap_file_txs = true;
+                    }
                 } else {
                     SCLogDebug!("post_gap_housekeeping: tx {} marked as done TC", tx.id);
                     tx.request_done = true;
@@ -1456,6 +1496,9 @@ impl SMBState {
         };
 
         self.post_gap_housekeeping(STREAM_TOSERVER);
+        if self.check_post_gap_file_txs {
+            self.post_gap_housekeeping_for_files();
+        }
         0
     }
 
@@ -1683,6 +1726,9 @@ impl SMBState {
             }
         };
         self.post_gap_housekeeping(STREAM_TOCLIENT);
+        if self.check_post_gap_file_txs {
+            self.post_gap_housekeeping_for_files();
+        }
         self._debug_tx_stats();
         0
     }
@@ -1782,7 +1828,7 @@ pub extern "C" fn rs_smb_state_free(state: *mut libc::c_void) {
 
 /// C binding parse a SMB request. Returns 1 on success, -1 on failure.
 #[no_mangle]
-pub extern "C" fn rs_smb_parse_request_tcp(_flow: *mut Flow,
+pub extern "C" fn rs_smb_parse_request_tcp(flow: &mut Flow,
                                        state: &mut SMBState,
                                        _pstate: *mut libc::c_void,
                                        input: *mut u8,
@@ -1799,6 +1845,7 @@ pub extern "C" fn rs_smb_parse_request_tcp(_flow: *mut Flow,
         state.ts_gap = true;
     }
 
+    state.ts = flow.get_last_time().as_secs();
     if state.parse_tcp_data_ts(buf) == 0 {
         return 1;
     } else {
@@ -1820,7 +1867,7 @@ pub extern "C" fn rs_smb_parse_request_tcp_gap(
 
 
 #[no_mangle]
-pub extern "C" fn rs_smb_parse_response_tcp(_flow: *mut Flow,
+pub extern "C" fn rs_smb_parse_response_tcp(flow: &mut Flow,
                                         state: &mut SMBState,
                                         _pstate: *mut libc::c_void,
                                         input: *mut u8,
@@ -1837,6 +1884,7 @@ pub extern "C" fn rs_smb_parse_response_tcp(_flow: *mut Flow,
         state.tc_gap = true;
     }
 
+    state.ts = flow.get_last_time().as_secs();
     if state.parse_tcp_data_tc(buf) == 0 {
         return 1;
     } else {

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -274,7 +274,7 @@ static void ModbusSetTxDetectFlags(void *vtx, uint8_t dir, uint64_t flags)
     if (dir & STREAM_TOSERVER) {
         tx->detect_flags_ts = flags;
     } else {
-        tx->detect_flags_ts = flags;
+        tx->detect_flags_tc = flags;
     }
 }
 

--- a/src/flow.c
+++ b/src/flow.c
@@ -1042,6 +1042,19 @@ void FlowUpdateState(Flow *f, enum FlowState s)
     }
 }
 
+/**
+ * \brief Get flow last time as individual values.
+ *
+ * Instead of returning a pointer to the timeval copy the timeval
+ * parts into output pointers to make it simpler to call from Rust
+ * over FFI using only basic data types.
+ */
+void FlowGetLastTimeAsParts(Flow *flow, uint64_t *secs, uint64_t *usecs)
+{
+    *secs = (uint64_t)flow->lastts.tv_sec;
+    *usecs = (uint64_t)flow->lastts.tv_usec;
+}
+
 /************************************Unittests*******************************/
 
 #ifdef UNITTESTS

--- a/src/flow.h
+++ b/src/flow.h
@@ -519,6 +519,8 @@ int FlowSetMemcap(uint64_t size);
 uint64_t FlowGetMemcap(void);
 uint64_t FlowGetMemuse(void);
 
+void FlowGetLastTimeAsParts(Flow *flow, uint64_t *secs, uint64_t *usecs);
+
 /** ----- Inline functions ----- */
 
 /** \brief Set the No Packet Inspection Flag without locking the flow.


### PR DESCRIPTION
Backport #4504 and #4480

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed.
