### PR TITLE
4.1.x: travis: remove cocci and macos builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,23 +55,6 @@ matrix:
         - DO_CHECK_SETUP_SCRIPTS="yes"
         - DO_DISTCHECK="yes"
   include:
-    # Linux, gcc, coccinelle.
-    - os: linux
-      compiler: gcc-7
-      env:
-        - NAME="linux,gcc-7,cocci"
-        - *default-cflags
-        - NO_UNITTESTS=yes
-      addons:
-        apt:
-          sources:
-            - sourceline: ppa:npalix/coccinelle
-            # For gcc-7.
-            - sourceline: ppa:ubuntu-toolchain-r/test
-          packages:
-            - *packages
-            - coccinelle
-            - gcc-7
     # Linux, gcc, Rust (latest stable).
     # This is allowed to fail, update allow_failures if the env changes.
     - os: linux
@@ -166,14 +149,6 @@ matrix:
         apt:
           packages:
             - *packages-without-jansson
-    # OSX 10.12, XCode 8.1
-    - os: osx
-      compiler: gcc
-      osx_image: xcode8.1
-      sudo: true
-      env:
-        - NAME="osx,gcc"
-        - *default-cflags
 
 script:
   - sh ./autogen.sh
@@ -181,26 +156,11 @@ script:
     if [[ "${NO_UNITTESTS}" != "yes" ]]; then
         ARGS="${ARGS} --enable-unittests"
     fi
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        export CFLAGS="${CFLAGS} ${EXTRA_CFLAGS}"
-        ./configure --enable-nfqueue --enable-hiredis ${ARGS}
-    elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        export CFLAGS="${CFLAGS} ${EXTRA_CFLAGS}"
-        ./configure --enable-hiredis --enable-ipfw \
-            --enable-lua --with-libpcre-includes=/usr/local/include \
-            --with-libpcre-includes=/usr/local/include \
-            --with-libpcre-libraries=/usr/local/lib \
-            --with-libnss-includes=/usr/local/opt/nss/include/nss \
-            --with-libnss-libraries=/usr/local/opt/nss/lib \
-            --with-libnspr-includes=/usr/local/opt/nspr/include/nspr \
-            --with-libnspr-libraries=/usr/local/opt/nspr/lib ${ARGS}
-    fi
+    export CFLAGS="${CFLAGS} ${EXTRA_CFLAGS}"
+    ./configure --enable-nfqueue --enable-hiredis ${ARGS}
   - |
     # Linux container builds have 2 cores, make use of them.
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        j="-j 2"
-    fi
-    make ${j}
+    make -j 2
   - |
     # Like "make check", but fail on first error. We redirect the output
     # so Travis doesn't fail the build with a too much output error.
@@ -231,36 +191,5 @@ before_install:
             rustup override set $RUST_VERSION
         fi
         rustc --version
-    fi
-  - |
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        brew update
-
-        # Unlink and install each dependency to avoid errors where a
-        # formula might already be installed but is not the current
-        # version.
-        packages=""
-        packages="$packages pkg-config"
-        packages="$packages libmagic"
-        packages="$packages libyaml"
-        packages="$packages nss"
-        packages="$packages nspr"
-        packages="$packages jansson"
-        packages="$packages libnet"
-        packages="$packages lua"
-        packages="$packages pcre"
-        packages="$packages hiredis"
-        for package in $packages; do
-            if brew ls $package --versions > /dev/null; then
-                brew unlink $package
-            fi
-        done
-
-        # Now install.
-        brew install $packages
-
-        # Now relink, becuase if a newer version of a package wasn't
-        # installed above, it will remain unlinked.
-        brew link $packages
     fi
   - ./qa/travis-libhtp.sh


### PR DESCRIPTION
These tests are covered by Github actions and removing
them may speed up the Travis builds to get results sooner.

Its still worth keeping some of these builds as they test
more compile time options than the Github Actions currently
do.

Backport of 222a81f85dfea32f518f68eda51d9f45e1bcc46a.