### PR TITLE
Expectation fix v1.3

### DIFF
--- a/src/app-layer-expectation.c
+++ b/src/app-layer-expectation.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/app-layer-expectation.c
+++ b/src/app-layer-expectation.c
@@ -144,7 +144,7 @@ static inline int GetFlowAddresses(Flow *f, Address *ip_src, Address *ip_dst)
     return 0;
 }
 
-static Expectation *AppLayerExpectationLookup(Flow *f, int direction, IPPair **ipp)
+static Expectation *AppLayerExpectationLookup(Flow *f, IPPair **ipp)
 {
     Address ip_src, ip_dst;
     if (GetFlowAddresses(f, &ip_src, &ip_dst) == -1)
@@ -282,7 +282,7 @@ AppProto AppLayerExpectationHandle(Flow *f, int direction)
     }
 
     /* Call will take reference of the ip pair in 'ipp' */
-    Expectation *exp = AppLayerExpectationLookup(f, direction, &ipp);
+    Expectation *exp = AppLayerExpectationLookup(f, &ipp);
     if (exp == NULL)
         goto out;
 

--- a/src/app-layer-expectation.h
+++ b/src/app-layer-expectation.h
@@ -30,6 +30,8 @@ int AppLayerExpectationCreate(Flow *f, int direction, Port src, Port dst,
 AppProto AppLayerExpectationHandle(Flow *f, int direction);
 int AppLayerExpectationGetDataId(void);
 
+void AppLayerExpectationClean(Flow *f);
+
 uint64_t ExpectationGetCounter(void);
 
 #endif /* __APP_LAYER_EXPECTATION__H__ */

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -61,6 +61,7 @@
 #include "stream.h"
 
 #include "app-layer-parser.h"
+#include "app-layer-expectation.h"
 
 #include "host-timeout.h"
 #include "defrag-timeout.h"
@@ -994,6 +995,8 @@ static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
 
                 (void)OutputFlowLog(th_v, ftd->output_thread_data, f);
 
+                if (f->flags & FLOW_HAS_EXPECTATION)
+                    AppLayerExpectationClean(f);
                 FlowClearMemory (f, f->protomap);
                 FLOWLOCK_UNLOCK(f);
                 FlowMoveToSpare(f);

--- a/src/flow.h
+++ b/src/flow.h
@@ -104,6 +104,8 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 #define FLOW_WRONG_THREAD               BIT_U32(25)
 /** Protocol detection told us flow is picked up in wrong direction (midstream) */
 #define FLOW_DIR_REVERSED               BIT_U32(26)
+/** Indicate that the flow did trigger an expectation creation */
+#define FLOW_HAS_EXPECTATION            BIT_U32(27)
 
 /* File flags */
 

--- a/src/queue.h
+++ b/src/queue.h
@@ -550,4 +550,16 @@ struct {								\
 	_Q_INVALIDATE((elm)->field.cqe_next);				\
 } while (0)
 
+#define	CIRCLEQ_FOREACH_SAFE(var, head, field, tvar)			\
+    for ((var) = CIRCLEQ_FIRST(head);				\
+        (var) != CIRCLEQ_END(head) &&				\
+        ((tvar) = CIRCLEQ_NEXT(var, field), 1);			\
+        (var) = (tvar))
+
+#define	CIRCLEQ_FOREACH_REVERSE_SAFE(var, head, headname, field, tvar)	\
+    for ((var) = CIRCLEQ_LAST(head, headname);			\
+        (var) != CIRCLEQ_END(head) && 				\
+        ((tvar) = CIRCLEQ_PREV(var, headname, field), 1);		\
+        (var) = (tvar))
+
 #endif	/* !_SYS_QUEUE_H_ */


### PR DESCRIPTION
This PR adds a limitation for expectation number for IPPair and brings some cleaning methods. 

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3378

Describe changes:
- Use circle list for expectations
- Limit number of expectations per IP pair
- Clean expectation at flow end

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/520
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/296

