### PR TITLE
stream/reassembly: fix data overlap check

### DIFF
--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -141,7 +141,7 @@ static inline bool CheckOverlap(struct TCPSEG *tree, TcpSegment *seg)
             return true;
         // prev's right edge is beyond our seq, overlap
         const uint32_t prev_re = SEG_SEQ_RIGHT_EDGE(prev);
-        if (SEQ_GT(prev_re, prev->seq))
+        if (SEQ_GT(prev_re, seg->seq))
             return true;
     }
 


### PR DESCRIPTION
#4483

Fix function CheckOverlap bug.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed.
