### PR TITLE
file: reassemble files from different transcations with range

### DIFF
--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -113,6 +113,13 @@ int HTPFileOpen(HtpState *s, const uint8_t *filename, uint16_t filename_len,
         }
 
         sbcfg = &s->cfg->response.sbcfg;
+        if (s->file_range_ids != 0) {
+            //TODO set an event ? or event better : handle intersected downloads
+            SCLogWarning(SC_ERR_NOT_SUPPORTED,
+                         "Regular download during HTTP Range file reassembly.");
+            FileCloseFileById(files, s->file_range_ids, NULL, 0, FILE_TRUNCATED);
+            s->file_range_ids = 0;
+        }
 
     } else {
         if (s->files_ts == NULL) {
@@ -225,9 +232,12 @@ int HTPParseContentRange(bstr * rawvalue, HtpContentRange *range)
  *  \retval -2 error parsing
  *  \retval -3 error negative end in range
  */
-int HTPFileSetRange(HtpState *s, bstr *rawvalue)
+int HTPFileOpenWithRange(HtpState *s,const uint8_t *filename, uint16_t filename_len,
+                         const uint8_t *data, uint32_t data_len,
+                         uint64_t txid, bstr *rawvalue)
 {
     SCEnter();
+    uint16_t flags;
 
     if (s == NULL) {
         SCReturnInt(-1);
@@ -235,20 +245,75 @@ int HTPFileSetRange(HtpState *s, bstr *rawvalue)
 
     FileContainer * files = s->files_tc;
     if (files == NULL) {
-        SCLogDebug("no files in state");
-        SCReturnInt(-1);
+        s->files_tc = FileContainerAlloc();
+        if (s->files_tc == NULL) {
+            SCReturnInt(-1);
+        }
+        files = s->files_tc;
     }
 
     HtpContentRange crparsed;
     if (HTPParseContentRange(rawvalue, &crparsed) != 0) {
-        SCLogDebug("parsing range failed");
-        SCReturnInt(-2);
+        SCLogDebug("parsing range failed, going back to normal file");
+        return HTPFileOpen(s, filename, (uint32_t)filename_len,
+                           data, data_len,
+                           txid, STREAM_TOCLIENT);
     }
     if (crparsed.end <= 0) {
         SCLogDebug("negative end in range");
-        SCReturnInt(-3);
+        return HTPFileOpen(s, filename, (uint32_t)filename_len,
+                           data, data_len,
+                           txid, STREAM_TOCLIENT);
     }
-    int retval = FileSetRange(files, crparsed.start, crparsed.end);
+
+    flags = FileFlowToFlags(s->f, STREAM_TOCLIENT);
+    if ((s->flags & HTP_FLAG_STORE_FILES_TS) ||
+        ((s->flags & HTP_FLAG_STORE_FILES_TX_TS) && txid == s->store_tx_id)) {
+        flags |= FILE_STORE;
+        flags &= ~FILE_NOSTORE;
+    } else if (!(flags & FILE_STORE) && (s->f->file_flags & FLOWFILE_NO_STORE_TC)) {
+        flags |= FILE_NOSTORE;
+    }
+
+    if (crparsed.start == 0 && crparsed.end < crparsed.size) {
+        // open another file for the whole ranges
+        if (s->file_range_ids != 0) {
+            //TODO set an event ? or even better : handle intersected downloads
+            SCLogWarning(SC_ERR_NOT_SUPPORTED,
+                         "Multiple different HTTP Range file reassemblies.");
+            if (FileCloseFileById(files, s->file_range_ids, NULL, 0, FILE_TRUNCATED) != 0) {
+                SCLogDebug("close file for range failed");
+            }
+        }
+        s->file_range_ids = FLAG_FILE_RANGES | s->file_track_id;
+
+        if (FileOpenFileWithId(files, &s->cfg->response.sbcfg, s->file_range_ids,
+                               filename, filename_len,
+                               data, data_len, flags) != 0) {
+            SCLogDebug("open file for range failed");
+            SCReturnInt(-1);
+        }
+    } else if (s->file_range_ids != 0){
+        // TODO check this is next range and same file
+        if (FileCheckNameAndOffsetById(files, s->file_range_ids,
+                                       filename, filename_len, crparsed.start) == 0) {
+            if (FileAppendDataById(files, s->file_range_ids, data, data_len) != 0) {
+                SCReturnInt(-1);
+            }
+        } else {
+            //TODO set an event ? or even better : handle unordered ranges download
+            SCLogWarning(SC_ERR_NOT_SUPPORTED,
+                         "Unordered HTTP Range file reassembly.");
+        }
+    }
+    if (FileOpenFileWithId(files, &s->cfg->response.sbcfg, s->file_track_id++,
+                           filename, filename_len,
+                           data, data_len, flags) != 0) {
+        SCReturnInt(-1);
+    }
+    FileSetTx(files->tail, txid);
+
+    int retval = FileSetRange(files, crparsed.start, crparsed.end, crparsed.size);
     if (retval == -1) {
         SCLogDebug("set range failed");
     }
@@ -292,6 +357,12 @@ int HTPFileStoreChunk(HtpState *s, const uint8_t *data, uint32_t data_len,
         goto end;
     }
 
+    if (s->file_range_ids != 0) {
+        result = FileAppendDataById(files, s->file_range_ids, data, data_len);
+        if (result != 0) {
+            return result;
+        }
+    }
     result = FileAppendData(files, data, data_len);
     if (result == -1) {
         SCLogDebug("appending data failed");
@@ -349,6 +420,17 @@ int HTPFileClose(HtpState *s, const uint8_t *data, uint32_t data_len,
         retval = -1;
     } else if (result == -2) {
         retval = -2;
+    }
+    if (s->file_range_ids != 0) {
+        File *f = files->tail;
+        if (f->end + 1 >= f->totalsize || (flags & FILE_TRUNCATED)) {
+            FileCloseFileById(files, s->file_range_ids, data, data_len, flags);
+            s->file_range_ids = 0;
+        } else {
+            if (FileAppendDataById(files, s->file_range_ids, data, data_len) != 0) {
+                SCReturnInt(-1);
+            }
+        }
     }
 
 end:

--- a/src/app-layer-htp-file.h
+++ b/src/app-layer-htp-file.h
@@ -33,7 +33,7 @@ typedef struct HtpContentRange_ {
 
 int HTPFileOpen(HtpState *, const uint8_t *, uint16_t, const uint8_t *, uint32_t, uint64_t, uint8_t);
 int HTPParseContentRange(bstr * rawvalue, HtpContentRange *range);
-int HTPFileSetRange(HtpState *, bstr *rawvalue);
+int HTPFileOpenWithRange(HtpState *, const uint8_t *, uint16_t, const uint8_t *, uint32_t, uint64_t, bstr *rawvalue);
 int HTPFileStoreChunk(HtpState *, const uint8_t *, uint32_t, uint8_t);
 int HTPFileClose(HtpState *, const uint8_t *, uint32_t, uint8_t, uint8_t);
 

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1765,8 +1765,19 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
         }
 
         if (filename != NULL) {
-            result = HTPFileOpen(hstate, filename, (uint32_t)filename_len,
-                    data, data_len, HtpGetActiveResponseTxID(hstate), STREAM_TOCLIENT);
+            //set range if present
+            htp_header_t *h_content_range = htp_table_get_c(tx->response_headers,
+                                                            "content-range");
+            if (h_content_range != NULL) {
+                result = HTPFileOpenWithRange(hstate, filename, (uint32_t)filename_len,
+                                              data, data_len,
+                                              HtpGetActiveResponseTxID(hstate),
+                                              h_content_range->value);
+            } else {
+                result = HTPFileOpen(hstate, filename, (uint32_t)filename_len,
+                                     data, data_len,
+                                     HtpGetActiveResponseTxID(hstate), STREAM_TOCLIENT);
+            }
             SCLogDebug("result %d", result);
             if (result == -1) {
                 goto end;
@@ -1776,11 +1787,6 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
                 FlagDetectStateNewFile(htud, STREAM_TOCLIENT);
                 htud->tcflags |= HTP_FILENAME_SET;
                 htud->tcflags &= ~HTP_DONTSTORE;
-            }
-            //set range if present
-            htp_header_t *h_content_range = htp_table_get_c(tx->response_headers, "content-range");
-            if (h_content_range != NULL) {
-                HTPFileSetRange(hstate, h_content_range->value);
             }
         }
     }

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -257,9 +257,13 @@ typedef struct HtpState_ {
     uint16_t events;
     uint16_t htp_messages_offset; /**< offset into conn->messages list */
     uint32_t file_track_id;             /**< used to assign file track ids to files */
+    uint32_t file_range_ids;             /**< used to assign track ids to range file */
     uint64_t last_request_data_stamp;
     uint64_t last_response_data_stamp;
 } HtpState;
+
+/** Flag to track reassembled file from multiple ranges */
+#define FLAG_FILE_RANGES 0x80000000
 
 /** part of the engine needs the request body (e.g. http_client_body keyword) */
 #define HTP_REQUIRE_REQUEST_BODY        (1 << 0)

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -91,6 +91,7 @@ typedef struct File_ {
     uint32_t inspect_min_size;
     uint64_t start;
     uint64_t end;
+    uint64_t totalsize;
 
     uint32_t *sid; /* signature id of a rule that triggered the filestore event */
     uint32_t sid_cnt;
@@ -168,6 +169,22 @@ int FileAppendDataById(FileContainer *, uint32_t track_id,
 int FileAppendGAPById(FileContainer *ffc, uint32_t track_id,
         const uint8_t *data, uint32_t data_len);
 
+/**
+ *  \brief Checks a file specified by id has the right name and offset
+ *
+ *  \param ffc the container
+ *  \param track_id the file identifier
+ *  \param name file name
+ *  \param name_len file name length
+ *  \param start current offset
+ *
+ *  \retval 0 ok
+ *  \retval -1 error
+ *  \retval 1 differences
+ */
+int FileCheckNameAndOffsetById(FileContainer *, uint32_t track_id,
+        const uint8_t *name, uint16_t name_len, uint64_t start);
+
 void FileSetInspectSizes(File *file, const uint32_t win, const uint32_t min);
 
 /**
@@ -176,11 +193,12 @@ void FileSetInspectSizes(File *file, const uint32_t win, const uint32_t min);
  *  \param ffc the container
  *  \param start start offset
  *  \param end end offset
+ *  \param total total size of file
  *
  *  \retval 0 ok
  *  \retval -1 error
  */
-int FileSetRange(FileContainer *, uint64_t start, uint64_t end);
+int FileSetRange(FileContainer *, uint64_t start, uint64_t end, uint64_t total);
 
 /**
  *  \brief Tag a file for storing


### PR DESCRIPTION
For discussion ,not to be merged yet

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1576

Describe changes:
- adds `HTPFileOpenWithRange` to handle like `HTPFileOpen` if there is a range (replaces `HTPFileSetRange` on the way) : open 2 files, one for the whole reassembled, and one only for the current range
- Creates some file structure for the reassembled one identified with `file_range_ids`
- Stores chunks for both the reassembled file and the small range one
- Closes reassembled file if range chunk ends after size of reassembled file

Follows #4491 with addressed comments and TODOs

This is basic and can be improved (cf TODOs comments).
It is working against https://github.com/OISF/suricata-verify/pull/171

PS : Another solution I think of would be to give some external program the ability to inject some kinds of pseudo packets (with the reassembled file)
This way, we would be robust if the range requests come over multiple flows, and we still can run suricata rules on the reassembled file