### PR TITLE
Detect return vs abort v3

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -444,9 +444,6 @@ static int DetectAddressParseString(DetectAddress *dd, const char *str)
     int r = 0;
     char ipstr[256];
 
-    while (*str != '\0' && *str == ' ')
-        str++;
-
     /* shouldn't see 'any' here */
     BUG_ON(strcasecmp(str, "any") == 0);
 
@@ -646,6 +643,9 @@ static DetectAddress *DetectAddressParseSingle(const char *str)
 static int DetectAddressSetup(DetectAddressHead *gh, const char *s)
 {
     SCLogDebug("gh %p, s %s", gh, s);
+
+    while (*s != '\0' && *s == ' ')
+        s++;
 
     if (strcasecmp(s, "any") == 0) {
         SCLogDebug("adding 0.0.0.0/0 and ::/0 as we\'re handling \'any\'");

--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -644,7 +644,7 @@ static int DetectAddressSetup(DetectAddressHead *gh, const char *s)
 {
     SCLogDebug("gh %p, s %s", gh, s);
 
-    while (*s != '\0' && *s == ' ')
+    while (*s != '\0' && isspace(*s))
         s++;
 
     if (strcasecmp(s, "any") == 0) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3468

Describe changes:
- `DetectAddressSetup` skips spaces before comparison (instead of skipping spaces later in `DetectAddressParseString

Modifies #4540 by now using `isspace` instead of `== '  '`

Found by fuzzing
