### PR TITLE
file: reassemble files from different transcations with range

### DIFF
--- a/rules/http-events.rules
+++ b/rules/http-events.rules
@@ -81,4 +81,7 @@ alert http any any -> any any (msg:"SURICATA HTTP duplicate content length field
 
 alert http any any -> any any (msg:"SURICATA HTTP compression bomb"; flow:established; app-layer-event:http.compression_bomb; flowint:http.anomaly.count,+,1; classtype:protocol-command-decode; sid:2221049; rev:1;)
 
-# next sid 2221050
+alert http any any -> any any (msg:"SURICATA HTTP invalid Range header value"; flow:established; app-layer-event:http.range_invalid; flowint:http.anomaly.count,+,1; classtype:protocol-command-decode; sid:2221050; rev:1;)
+alert http any any -> any any (msg:"SURICATA HTTP parallel Range downloads"; flow:established; app-layer-event:http.range_intersected; flowint:http.anomaly.count,+,1; classtype:protocol-command-decode; sid:2221051; rev:1;)
+alert http any any -> any any (msg:"SURICATA HTTP unordered Range downloads"; flow:established; app-layer-event:http.range_unordered; flowint:http.anomaly.count,+,1; classtype:protocol-command-decode; sid:2221052; rev:1;)
+# next sid 2221053

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -113,6 +113,12 @@ int HTPFileOpen(HtpState *s, const uint8_t *filename, uint16_t filename_len,
         }
 
         sbcfg = &s->cfg->response.sbcfg;
+        if (s->file_range_ids != 0) {
+            //TODO even better : handle intersected downloads
+            HTPSetEvent(s, NULL, direction, HTTP_DECODER_EVENT_RANGE_INTERSECTED);
+            FileCloseFileById(files, s->file_range_ids, NULL, 0, FILE_TRUNCATED);
+            s->file_range_ids = 0;
+        }
 
     } else {
         if (s->files_ts == NULL) {
@@ -225,9 +231,12 @@ int HTPParseContentRange(bstr * rawvalue, HtpContentRange *range)
  *  \retval -2 error parsing
  *  \retval -3 error negative end in range
  */
-int HTPFileSetRange(HtpState *s, bstr *rawvalue)
+int HTPFileOpenWithRange(HtpState *s,const uint8_t *filename, uint16_t filename_len,
+                         const uint8_t *data, uint32_t data_len,
+                         uint64_t txid, bstr *rawvalue, HtpTxUserData *htud)
 {
     SCEnter();
+    uint16_t flags;
 
     if (s == NULL) {
         SCReturnInt(-1);
@@ -235,20 +244,79 @@ int HTPFileSetRange(HtpState *s, bstr *rawvalue)
 
     FileContainer * files = s->files_tc;
     if (files == NULL) {
-        SCLogDebug("no files in state");
-        SCReturnInt(-1);
+        s->files_tc = FileContainerAlloc();
+        if (s->files_tc == NULL) {
+            SCReturnInt(-1);
+        }
+        files = s->files_tc;
     }
 
     HtpContentRange crparsed;
     if (HTPParseContentRange(rawvalue, &crparsed) != 0) {
-        SCLogDebug("parsing range failed");
-        SCReturnInt(-2);
+        AppLayerDecoderEventsSetEventRaw(&htud->decoder_events, HTTP_DECODER_EVENT_RANGE_INVALID);
+        s->events++;
+
+        SCLogDebug("parsing range failed, going back to normal file");
+        return HTPFileOpen(s, filename, (uint32_t)filename_len,
+                           data, data_len,
+                           txid, STREAM_TOCLIENT);
     }
-    if (crparsed.end <= 0) {
-        SCLogDebug("negative end in range");
-        SCReturnInt(-3);
+    if (crparsed.end <= 0 || crparsed.size <= 0) {
+        SCLogDebug("range without all information");
+        return HTPFileOpen(s, filename, (uint32_t)filename_len,
+                           data, data_len,
+                           txid, STREAM_TOCLIENT);
     }
-    int retval = FileSetRange(files, crparsed.start, crparsed.end);
+
+    flags = FileFlowToFlags(s->f, STREAM_TOCLIENT);
+    if ((s->flags & HTP_FLAG_STORE_FILES_TS) ||
+        ((s->flags & HTP_FLAG_STORE_FILES_TX_TS) && txid == s->store_tx_id)) {
+        flags |= FILE_STORE;
+        flags &= ~FILE_NOSTORE;
+    } else if (!(flags & FILE_STORE) && (s->f->file_flags & FLOWFILE_NO_STORE_TC)) {
+        flags |= FILE_NOSTORE;
+    }
+
+    if (crparsed.start == 0 && crparsed.end < crparsed.size - 1) {
+        // open another file for the whole ranges
+        if (s->file_range_ids != 0) {
+            //TODO even better : handle intersected downloads
+            AppLayerDecoderEventsSetEventRaw(&htud->decoder_events, HTTP_DECODER_EVENT_RANGE_INTERSECTED);
+            s->events++;
+            if (FileCloseFileById(files, s->file_range_ids, NULL, 0, FILE_TRUNCATED) != 0) {
+                SCLogDebug("close file for range failed");
+            }
+        }
+        s->file_track_id++;
+        s->file_range_ids = s->file_track_id;
+
+        if (FileOpenFileWithId(files, &s->cfg->response.sbcfg, s->file_range_ids,
+                               filename, filename_len,
+                               data, data_len, flags) != 0) {
+            SCLogDebug("open file for range failed");
+            SCReturnInt(-1);
+        }
+    } else if (s->file_range_ids != 0){
+        // check this is next range and same file
+        if (FileCheckNameAndOffsetById(files, s->file_range_ids,
+                                       filename, filename_len, crparsed.start) == 0) {
+            if (FileAppendDataById(files, s->file_range_ids, data, data_len) != 0) {
+                SCReturnInt(-1);
+            }
+        } else {
+            AppLayerDecoderEventsSetEventRaw(&htud->decoder_events, HTTP_DECODER_EVENT_RANGE_UNORDERED);
+            s->events++;
+            //TODO even better : handle unordered ranges download
+        }
+    }
+    if (FileOpenFileWithId(files, &s->cfg->response.sbcfg, s->file_track_id++,
+                           filename, filename_len,
+                           data, data_len, flags) != 0) {
+        SCReturnInt(-1);
+    }
+    FileSetTx(files->tail, txid);
+
+    int retval = FileSetRange(files, crparsed.start, crparsed.end, crparsed.size);
     if (retval == -1) {
         SCLogDebug("set range failed");
     }
@@ -292,6 +360,12 @@ int HTPFileStoreChunk(HtpState *s, const uint8_t *data, uint32_t data_len,
         goto end;
     }
 
+    if (s->file_range_ids != 0) {
+        result = FileAppendDataById(files, s->file_range_ids, data, data_len);
+        if (result != 0) {
+            return result;
+        }
+    }
     result = FileAppendData(files, data, data_len);
     if (result == -1) {
         SCLogDebug("appending data failed");
@@ -349,6 +423,17 @@ int HTPFileClose(HtpState *s, const uint8_t *data, uint32_t data_len,
         retval = -1;
     } else if (result == -2) {
         retval = -2;
+    }
+    if (s->file_range_ids != 0) {
+        File *f = files->tail;
+        if (f->end + 1 >= f->totalsize || (flags & FILE_TRUNCATED)) {
+            FileCloseFileById(files, s->file_range_ids, data, data_len, flags);
+            s->file_range_ids = 0;
+        } else {
+            if (FileAppendDataById(files, s->file_range_ids, data, data_len) != 0) {
+                SCReturnInt(-1);
+            }
+        }
     }
 
 end:

--- a/src/app-layer-htp-file.h
+++ b/src/app-layer-htp-file.h
@@ -33,7 +33,7 @@ typedef struct HtpContentRange_ {
 
 int HTPFileOpen(HtpState *, const uint8_t *, uint16_t, const uint8_t *, uint32_t, uint64_t, uint8_t);
 int HTPParseContentRange(bstr * rawvalue, HtpContentRange *range);
-int HTPFileSetRange(HtpState *, bstr *rawvalue);
+int HTPFileOpenWithRange(HtpState *, const uint8_t *, uint16_t, const uint8_t *, uint32_t, uint64_t, bstr *rawvalue, HtpTxUserData *htud);
 int HTPFileStoreChunk(HtpState *, const uint8_t *, uint32_t, uint8_t);
 int HTPFileClose(HtpState *, const uint8_t *, uint32_t, uint8_t, uint8_t);
 

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -190,6 +190,13 @@ SCEnumCharMap http_decoder_event_table[ ] = {
     { "COMPRESSION_BOMB",
         HTTP_DECODER_EVENT_COMPRESSION_BOMB},
 
+    { "RANGE_INVALID",
+        HTTP_DECODER_EVENT_RANGE_INVALID},
+    { "RANGE_INTERSECTED",
+        HTTP_DECODER_EVENT_RANGE_INTERSECTED},
+    { "RANGE_UNORDERED",
+        HTTP_DECODER_EVENT_RANGE_UNORDERED},
+
     /* suricata warnings/errors */
     { "MULTIPART_GENERIC_ERROR",
         HTTP_DECODER_EVENT_MULTIPART_GENERIC_ERROR},
@@ -286,7 +293,7 @@ static int HTPLookupPersonality(const char *str)
     return -1;
 }
 
-static void HTPSetEvent(HtpState *s, HtpTxUserData *htud,
+void HTPSetEvent(HtpState *s, HtpTxUserData *htud,
         const uint8_t dir, const uint8_t e)
 {
     SCLogDebug("setting event %u", e);
@@ -1767,8 +1774,19 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
         }
 
         if (filename != NULL) {
-            result = HTPFileOpen(hstate, filename, (uint32_t)filename_len,
-                    data, data_len, HtpGetActiveResponseTxID(hstate), STREAM_TOCLIENT);
+            //set range if present
+            htp_header_t *h_content_range = htp_table_get_c(tx->response_headers,
+                                                            "content-range");
+            if (h_content_range != NULL) {
+                result = HTPFileOpenWithRange(hstate, filename, (uint32_t)filename_len,
+                                              data, data_len,
+                                              HtpGetActiveResponseTxID(hstate),
+                                              h_content_range->value, htud);
+            } else {
+                result = HTPFileOpen(hstate, filename, (uint32_t)filename_len,
+                                     data, data_len,
+                                     HtpGetActiveResponseTxID(hstate), STREAM_TOCLIENT);
+            }
             SCLogDebug("result %d", result);
             if (result == -1) {
                 goto end;
@@ -1778,11 +1796,6 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
                 FlagDetectStateNewFile(htud, STREAM_TOCLIENT);
                 htud->tcflags |= HTP_FILENAME_SET;
                 htud->tcflags &= ~HTP_DONTSTORE;
-            }
-            //set range if present
-            htp_header_t *h_content_range = htp_table_get_c(tx->response_headers, "content-range");
-            if (h_content_range != NULL) {
-                HTPFileSetRange(hstate, h_content_range->value);
             }
         }
     }

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -128,6 +128,10 @@ enum {
     HTTP_DECODER_EVENT_LZMA_MEMLIMIT_REACHED,
     HTTP_DECODER_EVENT_COMPRESSION_BOMB,
 
+    HTTP_DECODER_EVENT_RANGE_INVALID,
+    HTTP_DECODER_EVENT_RANGE_INTERSECTED,
+    HTTP_DECODER_EVENT_RANGE_UNORDERED,
+
     /* suricata errors/warnings */
     HTTP_DECODER_EVENT_MULTIPART_GENERIC_ERROR,
     HTTP_DECODER_EVENT_MULTIPART_NO_FILEDATA,
@@ -257,6 +261,7 @@ typedef struct HtpState_ {
     uint16_t events;
     uint16_t htp_messages_offset; /**< offset into conn->messages list */
     uint32_t file_track_id;             /**< used to assign file track ids to files */
+    uint32_t file_range_ids;             /**< used to assign track ids to range file */
     uint64_t last_request_data_stamp;
     uint64_t last_response_data_stamp;
 } HtpState;
@@ -291,6 +296,9 @@ void HTPConfigure(void);
 
 void HtpConfigCreateBackup(void);
 void HtpConfigRestoreBackup(void);
+
+void HTPSetEvent(HtpState *s, HtpTxUserData *htud,
+                 const uint8_t dir, const uint8_t e);
 
 #endif	/* __APP_LAYER_HTP_H__ */
 

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -798,7 +798,7 @@ void FileSetInspectSizes(File *file, const uint32_t win, const uint32_t min)
  *  \retval  0 ok
  *  \retval -1 error
  */
-int FileSetRange(FileContainer *ffc, uint64_t start, uint64_t end)
+int FileSetRange(FileContainer *ffc, uint64_t start, uint64_t end, uint64_t totalsize)
 {
     SCEnter();
 
@@ -807,9 +807,42 @@ int FileSetRange(FileContainer *ffc, uint64_t start, uint64_t end)
     }
     ffc->tail->start = start;
     ffc->tail->end = end;
+    ffc->tail->totalsize = totalsize;
     SCReturnInt(0);
 }
 
+/**
+ *  \brief Checks a file specified by id has the right name and offset
+ *
+ *  \param ffc the container
+ *  \param track_id the file identifier
+ *  \param name file name
+ *  \param name_len file name length
+ *  \param start current offset
+ *
+ *  \retval 0 ok
+ *  \retval -1 error
+ *  \retval 1 differences
+ */
+int FileCheckNameAndOffsetById(FileContainer *ffc, uint32_t track_id,
+        const uint8_t *name, uint16_t name_len, uint64_t start) {
+    SCEnter();
+
+    if (ffc == NULL || ffc->tail == NULL) {
+        SCReturnInt(-1);
+    }
+
+    for (File *ff = ffc->head; ff != NULL; ff = ff->next) {
+        if (track_id == ff->file_track_id) {
+            if (ff->size != start) {
+                SCReturnInt(1);
+            }
+            SCReturnInt(SCBufferCmp(ff->name, ff->name_len, name, name_len));
+        }
+    }
+    SCReturnInt(-1);
+
+}
 /**
  *  \brief Open a new File
  *

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -91,6 +91,7 @@ typedef struct File_ {
     uint32_t inspect_min_size;
     uint64_t start;
     uint64_t end;
+    uint64_t totalsize;
 
     uint32_t *sid; /* signature id of a rule that triggered the filestore event */
     uint32_t sid_cnt;
@@ -168,6 +169,22 @@ int FileAppendDataById(FileContainer *, uint32_t track_id,
 int FileAppendGAPById(FileContainer *ffc, uint32_t track_id,
         const uint8_t *data, uint32_t data_len);
 
+/**
+ *  \brief Checks a file specified by id has the right name and offset
+ *
+ *  \param ffc the container
+ *  \param track_id the file identifier
+ *  \param name file name
+ *  \param name_len file name length
+ *  \param start current offset
+ *
+ *  \retval 0 ok
+ *  \retval -1 error
+ *  \retval 1 differences
+ */
+int FileCheckNameAndOffsetById(FileContainer *, uint32_t track_id,
+        const uint8_t *name, uint16_t name_len, uint64_t start);
+
 void FileSetInspectSizes(File *file, const uint32_t win, const uint32_t min);
 
 /**
@@ -176,11 +193,12 @@ void FileSetInspectSizes(File *file, const uint32_t win, const uint32_t min);
  *  \param ffc the container
  *  \param start start offset
  *  \param end end offset
+ *  \param total total size of file
  *
  *  \retval 0 ok
  *  \retval -1 error
  */
-int FileSetRange(FileContainer *, uint64_t start, uint64_t end);
+int FileSetRange(FileContainer *, uint64_t start, uint64_t end, uint64_t total);
 
 /**
  *  \brief Tag a file for storing

--- a/src/util-memcmp.h
+++ b/src/util-memcmp.h
@@ -377,5 +377,15 @@ static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t len)
 
 #endif /* SIMD */
 
+static inline int SCBufferCmp(const void *s1, size_t len1, const void *s2, size_t len2)
+{
+    if (len1 == len2) {
+        return SCMemcmp(s1, s2, len1);
+    } else if (len1 < len2) {
+        return -1;
+    }
+    return 1;
+}
+
 #endif /* __UTIL_MEMCMP_H__ */
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1576

Describe changes:
- adds `HTPFileOpenWithRange` to handle like `HTPFileOpen` if there is a range (replaces `HTPFileSetRange` on the way) : open 2 files, one for the whole reassembled, and one only for the current range
- Creates some file structure for the reassembled one identified with `file_range_ids`
- Stores chunks for both the reassembled file and the small range one
- Closes reassembled file if range chunk ends after size of reassembled file
- Adds util function `SCBufferCmp`
- Adds events for unsupported cases


Follows #4559 with :
- right check for whole file in one range request (end-1==size)
- do not set event for unsupported Content-Range values such as `Content-Range: bytes 200-1000/*`
cf https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range

It is working against https://github.com/OISF/suricata-verify/pull/171

The big remaining question for me is wether the "normal" use of Range is ordered or not cf
https://github.com/OISF/suricata/pull/4548#discussion_r379439262
If it is not ordered, we risk getting overflown by alerts...