### PR TITLE
Fix for bug #2423 "Napatech crashing"

### DIFF
--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -655,8 +655,9 @@ static PacketQueue packets_to_release[MAX_STREAMS];
  */
 static void NapatechReleasePacket(struct Packet_ *p)
 {
-    PacketFreeOrRelease(p);
-    PacketEnqueue(&packets_to_release[p->ntpv.stream_id], p);
+    if (!PKT_IS_PSEUDOPKT(p)) {
+    	PacketEnqueue(&packets_to_release[p->ntpv.stream_id], p);
+    }
 }
 
 /**
@@ -966,6 +967,7 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
                 ProgramFlow(rel_pkt, is_inline);
             }
 #endif
+            PacketFreeOrRelease(rel_pkt);
             NT_NetRxRelease(ntv->rx_stream, rel_pkt->ntpv.nt_packet_buf);
             rel_pkt = PacketDequeue(&packets_to_release[ntv->stream_id]);
         }


### PR DESCRIPTION
This fixes https://redmine.openinfosecfoundation.org/issues/2423 where
a specific traffic pattern resulted in Suricata's TmThreadsSlotProcessPkt()
function to get stuck in a loop trying to read from an empty queue.  This
was the result of the packet data structure being released too soon.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
    [Bug #2423: Suricata 4.0.3 and Napatech crashing](https://redmine.openinfosecfoundation.org/issues/2423)

Describe changes:
-    Moved the PacketFreeOrRelease() function from the Packet Release callback function to a point after the completion of TmThreadsSlotProcessPkt().  See, the Redmine bug report for details.

