### PR TITLE
fix ( theoretically but highly unlikely exploitable ) config-/runtime…

### DIFF
--- a/src/tmqh-flow.c
+++ b/src/tmqh-flow.c
@@ -220,7 +220,7 @@ void TmqhOutputFlowFreeCtx(void *ctx)
 
 void TmqhOutputFlowHash(ThreadVars *tv, Packet *p)
 {
-    int16_t qid = 0;
+    uint16_t qid = 0;
 
     TmqhFlowCtx *ctx = (TmqhFlowCtx *)tv->outctx;
 
@@ -251,7 +251,7 @@ void TmqhOutputFlowHash(ThreadVars *tv, Packet *p)
  */
 void TmqhOutputFlowIPPair(ThreadVars *tv, Packet *p)
 {
-    int16_t qid = 0;
+    uint16_t qid = 0;
     uint32_t addr_hash = 0;
     int i;
 
@@ -265,8 +265,6 @@ void TmqhOutputFlowIPPair(ThreadVars *tv, Packet *p)
         addr_hash = p->src.addr_data32[0] + p->dst.addr_data32[0];
     }
 
-    /* we don't have to worry about possible overflow, since
-     * ctx->size will be lesser than 2 ** 31 for sure */
     qid = addr_hash % ctx->size;
 
     PacketQueue *q = ctx->queues[qid].q;


### PR DESCRIPTION

let `ctx->size := 32769` with `addr_hash := 32768` you get `qid => -32768` for example. although unlikely to be exploitable, still awkward to see. i removed the bogus and wrong comment as well.

note: to get ctx size = 32769 you would need to specifiy this many queues in auto_fp mode. not a realistic scenario. creating a fake packet with "matching" hash is trivial though.