### PR TITLE
snmp detect: fix segfaults with invalid SNMP keywords

### DIFF
--- a/src/detect-snmp-pdu_type.c
+++ b/src/detect-snmp-pdu_type.c
@@ -72,7 +72,6 @@ void DetectSNMPPduTypeRegister(void)
 #ifdef UNITTESTS
     sigmatch_table[DETECT_AL_SNMP_PDU_TYPE].RegisterTests = DetectSNMPPduTypeRegisterTests;
 #endif
-    sigmatch_table[DETECT_AL_SNMP_PDU_TYPE].flags |= SIGMATCH_NOOPT;
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 

--- a/src/detect-snmp-version.c
+++ b/src/detect-snmp-version.c
@@ -84,7 +84,6 @@ void DetectSNMPVersionRegister (void)
 #ifdef UNITTESTS
     sigmatch_table[DETECT_AL_SNMP_VERSION].RegisterTests = DetectSNMPVersionRegisterTests;
 #endif
-    sigmatch_table[DETECT_AL_SNMP_VERSION].flags |= SIGMATCH_NOOPT;
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 

--- a/src/detect-snmp-version.c
+++ b/src/detect-snmp-version.c
@@ -41,9 +41,9 @@ static pcre_extra *parse_regex_study;
 enum DetectSNMPVersionMode {
     PROCEDURE_EQ = 1, /* equal */
     PROCEDURE_LT, /* less than */
-    PROCEDURE_LE, /* less than */
+    PROCEDURE_LE, /* less than or equal */
     PROCEDURE_GT, /* greater than */
-    PROCEDURE_GE, /* greater than */
+    PROCEDURE_GE, /* greater than or equal */
 };
 
 typedef struct DetectSNMPVersionData_ {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [#3490](https://redmine.openinfosecfoundation.org/issues/3490)


Describe changes:
- Make sure to not set `SIGMATCH_NOOPT` on `snmp.pdu_type` and `snmp.version` keywords. This option would cause rules using these keywords incorrectly (e.g. omitting the version specification, such as `alert snmp any any -> any any (msg:"SNMP test1"; snmp.version; sid:1000003;)`) to trigger a segfault due to a NULL pointer being dereferenced.