### PR TITLE
detect/snmp: Improve handling for NULL value strings

### DIFF
--- a/src/detect-snmp-pdu_type.c
+++ b/src/detect-snmp-pdu_type.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2019 Open Information Security Foundation
+/* Copyright (C) 2015-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -198,6 +198,11 @@ static int DetectSNMPPduTypeSetup (DetectEngineCtx *de_ctx, Signature *s,
 {
     DetectSNMPPduTypeData *dd = NULL;
     SigMatch *sm = NULL;
+
+    if (rawstr == NULL) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT,"snmp.pdu_type requires a value");
+        return -1;
+    }
 
     if (DetectSignatureSetAppProto(s, ALPROTO_SNMP) != 0)
         return -1;

--- a/src/detect-snmp-version.c
+++ b/src/detect-snmp-version.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2019 Open Information Security Foundation
+/* Copyright (C) 2015-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -265,6 +265,11 @@ static int DetectSNMPVersionSetup (DetectEngineCtx *de_ctx, Signature *s,
 {
     DetectSNMPVersionData *dd = NULL;
     SigMatch *sm = NULL;
+
+    if (rawstr == NULL) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT,"snmp.version requires a value");
+        return -1;
+    }
 
     if (DetectSignatureSetAppProto(s, ALPROTO_SNMP) != 0)
         return -1;


### PR DESCRIPTION
Improve handling of NULL value strings for SNMP `pdu_type` and `version` keywords.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3490](https://redmine.openinfosecfoundation.org/issues/3490)

Describe changes:
- Ensure only non-NULL values are parsed.

Companion [Suricata-verify PR](https://github.com/OISF/suricata-verify/pull/182)