### PR TITLE
protodetect: retry when both sides do not agree

### DIFF
--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -617,6 +617,38 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                            data, data_len, flags) != 0) {
             goto failure;
         }
+    } else if (f->alproto_ts != f->alproto_tc &&
+               f->alproto_ts != ALPROTO_UNKNOWN && f->alproto_ts != ALPROTO_FAILED &&
+               f->alproto_tc != ALPROTO_UNKNOWN && f->alproto_tc != ALPROTO_FAILED) {
+        bool reverse_flow = false;
+        AppProto alproto_otherdir = (flags & STREAM_TOSERVER) ? f->alproto_tc : f->alproto_ts;
+
+        //partial reset for protocol detection
+        FLOW_RESET_PM_DONE(f, flags);
+        FLOW_RESET_PP_DONE(f, flags);
+        f->probing_parser_toserver_alproto_masks = 0;
+        f->probing_parser_toclient_alproto_masks = 0;
+
+        //test if we are now agreed with other side
+        AppProto newproto = AppLayerProtoDetectGetProto(app_tctx->alpd_tctx,
+                                                        f, data, data_len,
+                                                        IPPROTO_TCP, flags, &reverse_flow);
+        if (newproto == alproto_otherdir) {
+            //change app layer proto and parse data
+            f->alproto_ts = newproto;
+            f->alproto_tc = newproto;
+            if (f->alproto != newproto) {
+                AppLayerParserStateCleanup(f, f->alstate, f->alparser);
+                f->alstate = NULL;
+                f->alparser = NULL;
+                f->alproto = newproto;
+            }
+        }
+        PACKET_PROFILING_APP_START(app_tctx, f->alproto);
+        r = AppLayerParserParse(tv, app_tctx->alp_tctx, f, f->alproto,
+                                flags, data, data_len);
+        PACKET_PROFILING_APP_END(app_tctx, f->alproto);
+        (*stream)->app_progress_rel += data_len;
     } else if (alproto != ALPROTO_UNKNOWN && FlowChangeProto(f)) {
         f->alproto_orig = f->alproto;
         SCLogDebug("protocol change, old %s", AppProtoToString(f->alproto_orig));


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2757

Describe changes:
- Retry protocol detection above TCP when both sides (client and server) do not agree

Makes test https://github.com/OISF/suricata-verify/pull/117 pass

There is likely a performance impact to be assessed
We keep retrying until both sides agree. Maybe we could fix a threshold on the number of retries.
I am not using `AppLayerParserParse` results as it is designed for relaxed parsing.

This should be done for UDP as well after merging #4058 

Replaces #4217 with rebase and updated git commit message