### PR TITLE
detect/parse: move spaces skip up the stack

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -529,9 +529,6 @@ int DetectAddressParseString(DetectAddress *dd, const char *str)
     int r = 0;
     char ipstr[256];
 
-    while (*str != '\0' && *str == ' ')
-        str++;
-
     /* shouldn't see 'any' here */
     BUG_ON(strcasecmp(str, "any") == 0);
 
@@ -737,6 +734,9 @@ error:
 static int DetectAddressSetup(DetectAddressHead *gh, const char *s)
 {
     SCLogDebug("gh %p, s %s", gh, s);
+
+    while (*s != '\0' && isspace(*s))
+        s++;
 
     if (strcasecmp(s, "any") == 0) {
         SCLogDebug("adding 0.0.0.0/0 and ::/0 as we\'re handling \'any\'");


### PR DESCRIPTION
Switch to isspace() as well.

(cherry picked from commit 52970d850858bb9784fe562422e9cf2c3aec4230)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:[3491](https://redmine.openinfosecfoundation.org/issues/3491)

Describe changes:
- Back-port of #4560
