### PR TITLE
Fixes/pcap timing/v18

### DIFF
--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -740,6 +740,12 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
 */
     memset(&ts, 0, sizeof(ts));
 
+    /* don't start our activities until time is setup */
+    while (!TimeModeIsReady()) {
+        if (suricata_ctl_flags != 0)
+            return TM_ECODE_OK;
+    }
+
     while (1)
     {
         if (TmThreadsCheckFlag(th_v, THV_PAUSE)) {

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -201,34 +201,32 @@ TmEcode InitPcapFile(PcapFileFileVars *pfv)
     SCReturnInt(validated);
 }
 
-TmEcode ValidateLinkType(int datalink, DecoderFunc *decoder)
+TmEcode ValidateLinkType(int datalink, DecoderFunc *DecoderFn)
 {
     switch (datalink) {
         case LINKTYPE_LINUX_SLL:
-            *decoder = DecodeSll;
+            *DecoderFn = DecodeSll;
             break;
         case LINKTYPE_ETHERNET:
-            *decoder = DecodeEthernet;
+            *DecoderFn = DecodeEthernet;
             break;
         case LINKTYPE_PPP:
-            *decoder = DecodePPP;
+            *DecoderFn = DecodePPP;
             break;
         case LINKTYPE_IPV4:
         case LINKTYPE_RAW:
         case LINKTYPE_RAW2:
         case LINKTYPE_GRE_OVER_IP:
-            *decoder = DecodeRaw;
+            *DecoderFn = DecodeRaw;
             break;
         case LINKTYPE_NULL:
-            *decoder = DecodeNull;
+            *DecoderFn = DecodeNull;
             break;
 
         default:
-            SCLogError(
-                    SC_ERR_UNIMPLEMENTED,
-                    "datalink type %" PRId32 " not (yet) supported in module PcapFile.",
-                    datalink
-            );
+            SCLogError(SC_ERR_UNIMPLEMENTED,
+                    "datalink type %"PRId32" not (yet) supported in module PcapFile.",
+                    datalink);
             SCReturnInt(TM_ECODE_FAILED);
     }
 

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -74,6 +74,12 @@ typedef struct PcapFileFileVars_
     struct bpf_program filter;
 
     PcapFileSharedVars *shared;
+
+    /* fields used to get the first packets timestamp early,
+     * so it can be used to setup the time subsys. */
+    const u_char *first_pkt_data;
+    struct pcap_pkthdr *first_pkt_hdr;
+    struct timeval first_pkt_ts;
 } PcapFileFileVars;
 
 /**

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -2101,7 +2101,8 @@ typedef struct Thread_ {
     int type;
     int in_use;         /**< bool to indicate this is in use */
 
-    struct timeval ts;  /**< current time of this thread (offline mode) */
+    struct timeval pktts;   /**< current packet time of this thread
+                             *   (offline mode) */
 } Thread;
 
 typedef struct Threads_ {
@@ -2224,7 +2225,7 @@ void TmThreadsSetThreadTimestamp(const int id, const struct timeval *ts)
 
     int idx = id - 1;
     Thread *t = &thread_store.threads[idx];
-    COPY_TIMESTAMP(ts, &t->ts);
+    COPY_TIMESTAMP(ts, &t->pktts);
     SCMutexUnlock(&thread_store_lock);
 }
 
@@ -2235,7 +2236,7 @@ void TmThreadsInitThreadsTimestamp(const struct timeval *ts)
         Thread *t = &thread_store.threads[s];
         if (!t->in_use)
             break;
-        COPY_TIMESTAMP(ts, &t->ts);
+        COPY_TIMESTAMP(ts, &t->pktts);
     }
     SCMutexUnlock(&thread_store_lock);
 }
@@ -2253,14 +2254,14 @@ void TmThreadsGetMinimalTimestamp(struct timeval *ts)
         Thread *t = &thread_store.threads[s];
         if (t == NULL || t->in_use == 0)
             continue;
-        if (!(timercmp(&t->ts, &nullts, ==))) {
+        if (!(timercmp(&t->pktts, &nullts, ==))) {
             if (!set) {
-                local.tv_sec = t->ts.tv_sec;
-                local.tv_usec = t->ts.tv_usec;
+                local.tv_sec = t->pktts.tv_sec;
+                local.tv_usec = t->pktts.tv_usec;
                 set = 1;
             } else {
-                if (timercmp(&t->ts, &local, <)) {
-                    COPY_TIMESTAMP(&t->ts, &local);
+                if (timercmp(&t->pktts, &local, <)) {
+                    COPY_TIMESTAMP(&t->pktts, &local);
                 }
             }
         }

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -2213,6 +2213,7 @@ end:
     SCMutexUnlock(&thread_store_lock);
 }
 
+#define COPY_TIMESTAMP(src,dst) ((dst)->tv_sec = (src)->tv_sec, (dst)->tv_usec = (src)->tv_usec) // XXX unify with flow-util.h
 void TmThreadsSetThreadTimestamp(const int id, const struct timeval *ts)
 {
     SCMutexLock(&thread_store_lock);
@@ -2223,12 +2224,22 @@ void TmThreadsSetThreadTimestamp(const int id, const struct timeval *ts)
 
     int idx = id - 1;
     Thread *t = &thread_store.threads[idx];
-    t->ts.tv_sec = ts->tv_sec;
-    t->ts.tv_usec = ts->tv_usec;
+    COPY_TIMESTAMP(ts, &t->ts);
     SCMutexUnlock(&thread_store_lock);
 }
 
-#define COPY_TIMESTAMP(src,dst) ((dst)->tv_sec = (src)->tv_sec, (dst)->tv_usec = (src)->tv_usec) // XXX unify with flow-util.h
+void TmThreadsInitThreadsTimestamp(const struct timeval *ts)
+{
+    SCMutexLock(&thread_store_lock);
+    for (size_t s = 0; s < thread_store.threads_size; s++) {
+        Thread *t = &thread_store.threads[s];
+        if (!t->in_use)
+            break;
+        COPY_TIMESTAMP(ts, &t->ts);
+    }
+    SCMutexUnlock(&thread_store_lock);
+}
+
 void TmThreadsGetMinimalTimestamp(struct timeval *ts)
 {
     struct timeval local, nullts;

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -2103,6 +2103,8 @@ typedef struct Thread_ {
 
     struct timeval pktts;   /**< current packet time of this thread
                              *   (offline mode) */
+    uint32_t sys_sec_stamp; /**< timestamp in seconds of the real system
+                             *   time when the pktts was last updated. */
 } Thread;
 
 typedef struct Threads_ {
@@ -2226,17 +2228,40 @@ void TmThreadsSetThreadTimestamp(const int id, const struct timeval *ts)
     int idx = id - 1;
     Thread *t = &thread_store.threads[idx];
     COPY_TIMESTAMP(ts, &t->pktts);
+    struct timeval systs;
+    gettimeofday(&systs, NULL);
+    t->sys_sec_stamp = (uint32_t)systs.tv_sec;
     SCMutexUnlock(&thread_store_lock);
+}
+
+bool TmThreadsTimeSubsysIsReady(void)
+{
+    bool ready = true;
+    SCMutexLock(&thread_store_lock);
+    for (size_t s = 0; s < thread_store.threads_size; s++) {
+        Thread *t = &thread_store.threads[s];
+        if (!t->in_use)
+            break;
+        if (t->sys_sec_stamp == 0) {
+            ready = false;
+            break;
+        }
+    }
+    SCMutexUnlock(&thread_store_lock);
+    return ready;
 }
 
 void TmThreadsInitThreadsTimestamp(const struct timeval *ts)
 {
+    struct timeval systs;
+    gettimeofday(&systs, NULL);
     SCMutexLock(&thread_store_lock);
     for (size_t s = 0; s < thread_store.threads_size; s++) {
         Thread *t = &thread_store.threads[s];
         if (!t->in_use)
             break;
         COPY_TIMESTAMP(ts, &t->pktts);
+        t->sys_sec_stamp = (uint32_t)systs.tv_sec;
     }
     SCMutexUnlock(&thread_store_lock);
 }
@@ -2248,13 +2273,19 @@ void TmThreadsGetMinimalTimestamp(struct timeval *ts)
     memset(&nullts, 0, sizeof(nullts));
     int set = 0;
     size_t s;
+    struct timeval systs;
+    gettimeofday(&systs, NULL);
 
     SCMutexLock(&thread_store_lock);
     for (s = 0; s < thread_store.threads_size; s++) {
         Thread *t = &thread_store.threads[s];
-        if (t == NULL || t->in_use == 0)
-            continue;
+        if (t->in_use == 0)
+            break;
         if (!(timercmp(&t->pktts, &nullts, ==))) {
+            /* ignore sleeping threads */
+            if (t->sys_sec_stamp + 1 < (uint32_t)systs.tv_sec)
+                continue;
+
             if (!set) {
                 local.tv_sec = t->pktts.tv_sec;
                 local.tv_usec = t->pktts.tv_usec;

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -2229,7 +2229,7 @@ void TmThreadsSetThreadTimestamp(const int id, const struct timeval *ts)
 }
 
 #define COPY_TIMESTAMP(src,dst) ((dst)->tv_sec = (src)->tv_sec, (dst)->tv_usec = (src)->tv_usec) // XXX unify with flow-util.h
-void TmreadsGetMinimalTimestamp(struct timeval *ts)
+void TmThreadsGetMinimalTimestamp(struct timeval *ts)
 {
     struct timeval local, nullts;
     memset(&local, 0, sizeof(local));

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -243,5 +243,6 @@ int TmThreadsInjectPacketsById(Packet **, int id);
 void TmThreadsInitThreadsTimestamp(const struct timeval *ts);
 void TmThreadsSetThreadTimestamp(const int id, const struct timeval *ts);
 void TmThreadsGetMinimalTimestamp(struct timeval *ts);
+bool TmThreadsTimeSubsysIsReady(void);
 
 #endif /* __TM_THREADS_H__ */

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -241,6 +241,6 @@ void TmThreadsUnregisterThread(const int id);
 int TmThreadsInjectPacketsById(Packet **, int id);
 
 void TmThreadsSetThreadTimestamp(const int id, const struct timeval *ts);
-void TmreadsGetMinimalTimestamp(struct timeval *ts);
+void TmThreadsGetMinimalTimestamp(struct timeval *ts);
 
 #endif /* __TM_THREADS_H__ */

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -240,6 +240,7 @@ int TmThreadsRegisterThread(ThreadVars *tv, const int type);
 void TmThreadsUnregisterThread(const int id);
 int TmThreadsInjectPacketsById(Packet **, int id);
 
+void TmThreadsInitThreadsTimestamp(const struct timeval *ts);
 void TmThreadsSetThreadTimestamp(const int id, const struct timeval *ts);
 void TmThreadsGetMinimalTimestamp(struct timeval *ts);
 

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -69,7 +69,7 @@ static struct timeval current_time = { 0, 0 };
 #endif
 //static SCMutex current_time_mutex = SCMUTEX_INITIALIZER;
 static SCSpinlock current_time_spinlock;
-static char live = TRUE;
+static bool live_time_tracking = true;
 
 struct tm *SCLocalTime(time_t timep, struct tm *result);
 struct tm *SCUtcTime(time_t timep, struct tm *result);
@@ -89,24 +89,24 @@ void TimeDeinit(void)
 
 void TimeModeSetLive(void)
 {
-    live = TRUE;
+    live_time_tracking = true;
     SCLogDebug("live time mode enabled");
 }
 
 void TimeModeSetOffline (void)
 {
-    live = FALSE;
+    live_time_tracking = false;
     SCLogDebug("offline time mode enabled");
 }
 
-int TimeModeIsLive(void)
+bool TimeModeIsLive(void)
 {
-    return live;
+    return live_time_tracking;
 }
 
 void TimeSetByThread(const int thread_id, const struct timeval *tv)
 {
-    if (live == TRUE)
+    if (live_time_tracking)
         return;
 
     TmThreadsSetThreadTimestamp(thread_id, tv);
@@ -115,7 +115,7 @@ void TimeSetByThread(const int thread_id, const struct timeval *tv)
 #ifdef UNITTESTS
 void TimeSet(struct timeval *tv)
 {
-    if (live == TRUE)
+    if (live_time_tracking)
         return;
 
     if (tv == NULL)
@@ -148,7 +148,7 @@ void TimeGet(struct timeval *tv)
     if (tv == NULL)
         return;
 
-    if (live == TRUE) {
+    if (live_time_tracking) {
         gettimeofday(tv, NULL);
     } else {
 #ifdef UNITTESTS

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -87,6 +87,13 @@ void TimeDeinit(void)
     SCSpinDestroy(&current_time_spinlock);
 }
 
+bool TimeModeIsReady(void)
+{
+    if (live_time_tracking)
+        return true;
+    return TmThreadsTimeSubsysIsReady();
+}
+
 void TimeModeSetLive(void)
 {
     live_time_tracking = true;

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -159,7 +159,7 @@ void TimeGet(struct timeval *tv)
             SCSpinUnlock(&current_time_spinlock);
         } else {
 #endif
-            TmreadsGetMinimalTimestamp(tv);
+            TmThreadsGetMinimalTimestamp(tv);
 #ifdef UNITTESTS
         }
 #endif

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -39,6 +39,7 @@ void TimeSetToCurrentTime(void);
 void TimeSetIncrementTime(uint32_t);
 #endif
 
+bool TimeModeIsReady(void);
 void TimeModeSetLive(void);
 void TimeModeSetOffline (void);
 bool TimeModeIsLive(void);

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -51,7 +51,7 @@ void TimeSetIncrementTime(uint32_t);
 
 void TimeModeSetLive(void);
 void TimeModeSetOffline (void);
-int TimeModeIsLive(void);
+bool TimeModeIsLive(void);
 
 struct tm *SCLocalTime(time_t timep, struct tm *result);
 void CreateTimeString(const struct timeval *ts, char *str, size_t size);

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -24,16 +24,6 @@
 #ifndef __UTIL_TIME_H__
 #define __UTIL_TIME_H__
 
-/**
- * A timeval with 32 bit fields.
- *
- * Used by the unified on disk file format.
- */
-typedef struct SCTimeval32_ {
-    uint32_t tv_sec;
-    uint32_t tv_usec;
-} SCTimeval32;
-
 void TimeInit(void);
 void TimeDeinit(void);
 


### PR DESCRIPTION
Fixes concurrency issues in 'autofp' mode while processing pcaps. See https://github.com/OISF/suricata/commit/9f1922e1756017b66c7161d49202a4120dd7f231 and https://github.com/OISF/suricata/commit/1e9333288f06ddc2f469053205a5d6662bf32ed7 for further explanations.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed.
