### PR TITLE
Pr/4523/pierre/nom5/v9

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -162,7 +162,7 @@ jobs:
     needs: centos-8
     steps:
       - name: Install Rust
-        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.33.0 -y
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.34.2 -y
       - run: echo "::add-path::$HOME/.cargo/bin"
       - name: Install system dependencies
         run: |
@@ -366,7 +366,7 @@ jobs:
                 zlib1g \
                 zlib1g-dev
       - name: Install Rust
-        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.33.0 -y
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.34.2 -y
       - run: echo "::add-path::$HOME/.cargo/bin"
       - name: Download suricata.tar.gz
         uses: actions/download-artifact@v1
@@ -502,7 +502,7 @@ jobs:
                 zlib1g \
                 zlib1g-dev
       - name: Install Rust
-        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.33.0 -y
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.34.2 -y
       - run: echo "::add-path::$HOME/.cargo/bin"
       - name: Install cbindgen
         run: cargo install --force cbindgen

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ env:
     # The version of Rust that will be used if not otherwise set.
     - RUST_VERSION="stable"
     # The minimum version of Rust supported.
-    - RUST_VERSION_MIN="1.33.0"
+    - RUST_VERSION_MIN="1.34.2"
     # A known recent working version of stable Rust
     - RUST_VERSION_KNOWN="1.37.0"
 

--- a/configure.ac
+++ b/configure.ac
@@ -2394,7 +2394,7 @@ fi
     cargo_version_output=$($CARGO --version)
     cargo_version=$(echo "$cargo_version_output" | sed 's/^.*[[^0-9]]\([[0-9]]*\.[[0-9]]*\.[[0-9]]*\).*$/\1/')
 
-    MIN_RUSTC_VERSION="1.33.0"
+    MIN_RUSTC_VERSION="1.34.2"
     AC_MSG_CHECKING(for Rust version $MIN_RUSTC_VERSION or newer)
     AS_VERSION_COMPARE([$rustc_version], [$MIN_RUSTC_VERSION],
         [

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -17,7 +17,7 @@ strict = []
 debug = []
 
 [dependencies]
-nom = "4.2"
+nom = "5.0"
 bitflags = "1.0"
 byteorder = "1.3"
 crc = "1.8"
@@ -27,11 +27,11 @@ num-derive = "0.2"
 num-traits = "0.2"
 widestring = "0.4"
 
-der-parser = "1.1"
-kerberos-parser = "0.2"
+der-parser = "3.0"
+kerberos-parser = "0.4"
 
-ntp-parser = "0.3"
-ipsec-parser = "0.4"
-snmp-parser = "0.3.0"
-tls-parser = "0.8"
-x509-parser = "0.4"
+ntp-parser = "0.4"
+ipsec-parser = "0.5"
+snmp-parser = "0.5"
+tls-parser = "0.9"
+x509-parser = "0.6"

--- a/rust/src/common.rs
+++ b/rust/src/common.rs
@@ -1,0 +1,12 @@
+#[macro_export]
+macro_rules! take_until_and_consume (
+ ( $i:expr, $needle:expr ) => (
+    {
+      let input: &[u8] = $i;
+
+      let (rem, res) = ::nom::take_until!(input, $needle)?;
+      let (rem, _) = ::nom::take!(rem, $needle.len())?;
+      Ok((rem, res))
+    }
+  );
+);

--- a/rust/src/dhcp/parser.rs
+++ b/rust/src/dhcp/parser.rs
@@ -18,7 +18,9 @@
 use std::cmp::min;
 
 use crate::dhcp::dhcp::*;
-use nom::*;
+use nom::IResult;
+use nom::combinator::rest;
+use nom::number::complete::{be_u8, be_u16, be_u32};
 
 pub struct DHCPMessage {
     pub header: DHCPHeader,
@@ -121,7 +123,7 @@ named!(pub parse_header<DHCPHeader>,
 named!(pub parse_clientid_option<DHCPOption>,
        do_parse!(
            code:   be_u8 >>
-           len: verify!(be_u8, |v| v > 1) >>
+           len: verify!(be_u8, |&v| v > 1) >>
            _htype: be_u8 >>
            data:   take!(len - 1) >>
                (

--- a/rust/src/dhcp/parser.rs
+++ b/rust/src/dhcp/parser.rs
@@ -20,7 +20,7 @@ use std::cmp::min;
 use crate::dhcp::dhcp::*;
 use nom::IResult;
 use nom::combinator::rest;
-use nom::number::complete::{be_u8, be_u16, be_u32};
+use nom::number::streaming::{be_u8, be_u16, be_u32};
 
 pub struct DHCPMessage {
     pub header: DHCPHeader,

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -25,6 +25,8 @@ use crate::applayer::LoggerFlags;
 use crate::core;
 use crate::dns::parser;
 
+use nom::number::complete::be_u16;
+
 /// DNS record types.
 pub const DNS_RECORD_TYPE_A           : u16 = 1;
 pub const DNS_RECORD_TYPE_NS          : u16 = 2;
@@ -443,7 +445,7 @@ impl DNSState {
 
         let mut count = 0;
         while self.request_buffer.len() > 0 {
-            let size = match nom::be_u16(&self.request_buffer) {
+            let size = match be_u16(&self.request_buffer) {
                 Ok((_, len)) => len,
                 _ => 0
             } as usize;
@@ -484,7 +486,7 @@ impl DNSState {
 
         let mut count = 0;
         while self.response_buffer.len() > 0 {
-            let size = match nom::be_u16(&self.response_buffer) {
+            let size = match be_u16(&self.response_buffer) {
                 Ok((_, len)) => len,
                 _ => 0
             } as usize;
@@ -533,7 +535,7 @@ fn probe(input: &[u8]) -> (bool, bool) {
 
 /// Probe TCP input to see if it looks like DNS.
 pub fn probe_tcp(input: &[u8]) -> (bool, bool) {
-    match nom::be_u16(input) {
+    match be_u16(input) {
         Ok((rem, _)) => {
             return probe(rem);
         },

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -26,7 +26,7 @@ use crate::core;
 use crate::dns::parser;
 
 use nom::IResult;
-use nom::number::complete::be_u16;
+use nom::number::streaming::be_u16;
 
 /// DNS record types.
 pub const DNS_RECORD_TYPE_A           : u16 = 1;

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -19,6 +19,7 @@
 
 use nom::IResult;
 use nom::error::ErrorKind;
+use nom::multi::length_data;
 use nom::number::complete::{be_u8, be_u16, be_u32};
 use nom;
 use crate::dns::dns::*;
@@ -69,7 +70,7 @@ pub fn dns_parse_name<'a, 'b>(start: &'b [u8],
             pos = &pos[1..];
             break;
         } else if len & 0b1100_0000 == 0 {
-            match length_data!(pos, be_u8) {
+            match length_data(be_u8)(pos) as IResult<&[u8],_> {
                 Ok((rem, label)) => {
                     if name.len() > 0 {
                         name.push('.' as u8);
@@ -83,14 +84,14 @@ pub fn dns_parse_name<'a, 'b>(start: &'b [u8],
                 }
             }
         } else if len & 0b1100_0000 == 0b1100_0000 {
-            match be_u16(pos) {
+            match be_u16(pos) as IResult<&[u8],_> {
                 Ok((rem, leader)) => {
-                    let offset = leader & 0x3fff;
-                    if offset as usize > message.len() {
+                    let offset = usize::from(leader) & 0x3fff;
+                    if offset > message.len() {
                         return Err(nom::Err::Error(
                             error_position!(pos, ErrorKind::OctDigit)));
                     }
-                    pos = &message[offset as usize..];
+                    pos = &message[offset..];
                     if pivot == start {
                         pivot = rem;
                     }

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -17,7 +17,9 @@
 
 //! Nom parsers for DNS.
 
-use nom::{IResult, be_u8, be_u16, be_u32};
+use nom::IResult;
+use nom::error::ErrorKind;
+use nom::number::complete::{be_u8, be_u16, be_u32};
 use nom;
 use crate::dns::dns::*;
 
@@ -67,7 +69,7 @@ pub fn dns_parse_name<'a, 'b>(start: &'b [u8],
             pos = &pos[1..];
             break;
         } else if len & 0b1100_0000 == 0 {
-            match length_bytes!(pos, be_u8) {
+            match length_data!(pos, be_u8) {
                 Ok((rem, label)) => {
                     if name.len() > 0 {
                         name.push('.' as u8);
@@ -77,7 +79,7 @@ pub fn dns_parse_name<'a, 'b>(start: &'b [u8],
                 }
                 _ => {
                     return Err(nom::Err::Error(
-                        error_position!(pos, nom::ErrorKind::OctDigit)));
+                        error_position!(pos, ErrorKind::OctDigit)));
                 }
             }
         } else if len & 0b1100_0000 == 0b1100_0000 {
@@ -86,7 +88,7 @@ pub fn dns_parse_name<'a, 'b>(start: &'b [u8],
                     let offset = leader & 0x3fff;
                     if offset as usize > message.len() {
                         return Err(nom::Err::Error(
-                            error_position!(pos, nom::ErrorKind::OctDigit)));
+                            error_position!(pos, ErrorKind::OctDigit)));
                     }
                     pos = &message[offset as usize..];
                     if pivot == start {
@@ -95,19 +97,19 @@ pub fn dns_parse_name<'a, 'b>(start: &'b [u8],
                 }
                 _ => {
                     return Err(nom::Err::Error(
-                        error_position!(pos, nom::ErrorKind::OctDigit)));
+                        error_position!(pos, ErrorKind::OctDigit)));
                 }
             }
         } else {
             return Err(nom::Err::Error(
-                error_position!(pos, nom::ErrorKind::OctDigit)));
+                error_position!(pos, ErrorKind::OctDigit)));
         }
 
         // Return error if we've looped a certain number of times.
         count += 1;
         if count > 255 {
             return Err(nom::Err::Error(
-                error_position!(pos, nom::ErrorKind::OctDigit)));
+                error_position!(pos, ErrorKind::OctDigit)));
         }
 
     }

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -20,7 +20,7 @@
 use nom::IResult;
 use nom::error::ErrorKind;
 use nom::multi::length_data;
-use nom::number::complete::{be_u8, be_u16, be_u32};
+use nom::number::streaming::{be_u8, be_u16, be_u32};
 use nom;
 use crate::dns::dns::*;
 

--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -31,7 +31,7 @@ use crate::log::*;
 named!(getu16<u16>,
     map_res!(
       map_res!(
-        sep!(digit1, multispace0),
+        delimited!(multispace0, digit1, multispace0),
         str::from_utf8
       ),
       FromStr::from_str
@@ -46,7 +46,7 @@ named!(parse_u16<u16>,
 named!(pub ftp_active_port<u16>,
        do_parse!(
             tag!("PORT") >>
-            sep!(digit1, multispace0) >> tag!(",") >> digit1 >> tag!(",") >>
+            delimited!(multispace0, digit1, multispace0) >> tag!(",") >> digit1 >> tag!(",") >>
             digit1 >> tag!(",") >> digit1 >> tag!(",") >>
             part1: verify!(parse_u16, |&v| v <= std::u8::MAX as u16) >>
             tag!(",") >>

--- a/rust/src/kerberos.rs
+++ b/rust/src/kerberos.rs
@@ -20,7 +20,7 @@ use kerberos_parser::krb5::{ApReq,Realm,PrincipalName};
 use nom;
 use nom::IResult;
 use nom::error::{ErrorKind, ParseError};
-use nom::number::complete::le_u16;
+use nom::number::streaming::le_u16;
 use der_parser;
 use der_parser::error::BerError;
 use der_parser::der::parse_der_oid;

--- a/rust/src/kerberos.rs
+++ b/rust/src/kerberos.rs
@@ -18,9 +18,11 @@
 use kerberos_parser::krb5_parser::parse_ap_req;
 use kerberos_parser::krb5::{ApReq,Realm,PrincipalName};
 use nom;
-use nom::{ErrorKind, IResult, le_u16};
+use nom::IResult;
+use nom::error::ErrorKind;
+use nom::number::complete::le_u16;
 use der_parser;
-use der_parser::parse_der_oid;
+use der_parser::der::parse_der_oid;
 
 use crate::log::*;
 

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -20,8 +20,8 @@
 use std;
 use std::ffi::{CStr,CString};
 use nom;
-use nom::be_u32;
-use der_parser::der_read_element_header;
+use nom::number::complete::be_u32;
+use der_parser::der::der_read_element_header;
 use kerberos_parser::krb5_parser;
 use kerberos_parser::krb5::{EncryptionType,ErrorCode,MessageType,PrincipalName,Realm};
 use crate::applayer;
@@ -121,9 +121,9 @@ impl KRB5State {
             Ok((_rem,hdr)) => {
                 // Kerberos messages start with an APPLICATION header
                 if hdr.class != 0b01 { return 1; }
-                match hdr.tag {
+                match hdr.tag.0 {
                     10 => {
-                        self.req_id = hdr.tag;
+                        self.req_id = 10;
                     },
                     11 => {
                         let res = krb5_parser::parse_as_rep(i);
@@ -142,7 +142,7 @@ impl KRB5State {
                         self.req_id = 0;
                     },
                     12 => {
-                        self.req_id = hdr.tag;
+                        self.req_id = 12;
                     },
                     13 => {
                         let res = krb5_parser::parse_tgs_rep(i);
@@ -161,7 +161,7 @@ impl KRB5State {
                         self.req_id = 0;
                     },
                     14 => {
-                        self.req_id = hdr.tag;
+                        self.req_id = 14;
                     },
                     15 => {
                         self.req_id = 0;
@@ -445,7 +445,7 @@ pub extern "C" fn rs_krb5_probing_parser(_flow: *const Flow,
             // Kerberos messages start with an APPLICATION header
             if hdr.class != 0b01 { return unsafe{ALPROTO_FAILED}; }
             // Tag number should be <= 30
-            if hdr.tag >= 30 { return unsafe{ALPROTO_FAILED}; }
+            if hdr.tag.0 >= 30 { return unsafe{ALPROTO_FAILED}; }
             // Kerberos messages contain sequences
             if rem.is_empty() || rem[0] != 0x30 { return unsafe{ALPROTO_FAILED}; }
             // Check kerberos version

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -20,6 +20,7 @@
 use std;
 use std::ffi::{CStr,CString};
 use nom;
+use nom::IResult;
 use nom::number::complete::be_u32;
 use der_parser::der::der_read_element_header;
 use kerberos_parser::krb5_parser;
@@ -477,7 +478,7 @@ pub extern "C" fn rs_krb5_probing_parser_tcp(_flow: *const Flow,
 {
     let slice = build_slice!(input,input_len as usize);
     if slice.len() <= 14 { return unsafe{ALPROTO_FAILED}; }
-    match be_u32(slice) {
+    match be_u32(slice) as IResult<&[u8],u32> {
         Ok((rem, record_mark)) => {
             // protocol implementations forbid very large requests
             if record_mark > 16384 { return unsafe{ALPROTO_FAILED}; }
@@ -550,7 +551,7 @@ pub extern "C" fn rs_krb5_parse_request_tcp(_flow: *const core::Flow,
     let mut cur_i = tcp_buffer;
     while cur_i.len() > 0 {
         if state.record_ts == 0 {
-            match be_u32(cur_i) {
+            match be_u32(cur_i) as IResult<&[u8],u32> {
                 Ok((rem,record)) => {
                     state.record_ts = record as usize;
                     cur_i = rem;
@@ -608,7 +609,7 @@ pub extern "C" fn rs_krb5_parse_response_tcp(_flow: *const core::Flow,
     let mut cur_i = tcp_buffer;
     while cur_i.len() > 0 {
         if state.record_tc == 0 {
-            match be_u32(cur_i) {
+            match be_u32(cur_i) as IResult<&[u8],_> {
                 Ok((rem,record)) => {
                     state.record_tc = record as usize;
                     cur_i = rem;

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -21,7 +21,7 @@ use std;
 use std::ffi::{CStr,CString};
 use nom;
 use nom::IResult;
-use nom::number::complete::be_u32;
+use nom::number::streaming::be_u32;
 use der_parser::der::der_read_element_header;
 use kerberos_parser::krb5_parser;
 use kerberos_parser::krb5::{EncryptionType,ErrorCode,MessageType,PrincipalName,Realm};

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -40,6 +40,8 @@ pub mod log;
 #[macro_use]
 pub mod core;
 
+#[macro_use]
+pub mod common;
 pub mod conf;
 pub mod json;
 #[macro_use]

--- a/rust/src/nfs/nfs2.rs
+++ b/rust/src/nfs/nfs2.rs
@@ -24,6 +24,7 @@ use crate::nfs::types::*;
 use crate::nfs::rpc_records::*;
 use crate::nfs::nfs2_records::*;
 
+use nom::IResult;
 use nom::number::complete::be_u32;
 
 impl NFSState {
@@ -109,7 +110,7 @@ impl NFSState {
                 },
             }
         } else {
-            let stat = match be_u32(&r.prog_data) {
+            let stat = match be_u32(&r.prog_data) as IResult<&[u8],_> {
                 Ok((_, stat)) => {
                     stat as u32
                 }

--- a/rust/src/nfs/nfs2.rs
+++ b/rust/src/nfs/nfs2.rs
@@ -25,7 +25,7 @@ use crate::nfs::rpc_records::*;
 use crate::nfs::nfs2_records::*;
 
 use nom::IResult;
-use nom::number::complete::be_u32;
+use nom::number::streaming::be_u32;
 
 impl NFSState {
     /// complete request record

--- a/rust/src/nfs/nfs2.rs
+++ b/rust/src/nfs/nfs2.rs
@@ -17,13 +17,14 @@
 
 // written by Victor Julien
 
-use nom;
 use crate::log::*;
 
 use crate::nfs::nfs::*;
 use crate::nfs::types::*;
 use crate::nfs::rpc_records::*;
 use crate::nfs::nfs2_records::*;
+
+use nom::number::complete::be_u32;
 
 impl NFSState {
     /// complete request record
@@ -108,7 +109,7 @@ impl NFSState {
                 },
             }
         } else {
-            let stat = match nom::be_u32(&r.prog_data) {
+            let stat = match be_u32(&r.prog_data) {
                 Ok((_, stat)) => {
                     stat as u32
                 }

--- a/rust/src/nfs/nfs2.rs
+++ b/rust/src/nfs/nfs2.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2018 Open Information Security Foundation
+/* Copyright (C) 2017-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -125,5 +125,4 @@ impl NFSState {
 
         0
     }
-
 }

--- a/rust/src/nfs/nfs2_records.rs
+++ b/rust/src/nfs/nfs2_records.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/rust/src/nfs/nfs2_records.rs
+++ b/rust/src/nfs/nfs2_records.rs
@@ -17,7 +17,7 @@
 
 //! Nom parsers for NFSv2 records
 use nom::combinator::rest;
-use nom::number::complete::be_u32;
+use nom::number::streaming::be_u32;
 use crate::nfs::nfs_records::*;
 
 #[derive(Debug,PartialEq)]

--- a/rust/src/nfs/nfs2_records.rs
+++ b/rust/src/nfs/nfs2_records.rs
@@ -16,7 +16,8 @@
  */
 
 //! Nom parsers for NFSv2 records
-use nom::{be_u32, rest};
+use nom::combinator::rest;
+use nom::number::complete::be_u32;
 use crate::nfs::nfs_records::*;
 
 #[derive(Debug,PartialEq)]

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -25,6 +25,7 @@ use crate::nfs::types::*;
 use crate::nfs::rpc_records::*;
 use crate::nfs::nfs3_records::*;
 
+use nom::IResult;
 use nom::number::complete::be_u32;
 
 impl NFSState {
@@ -327,7 +328,7 @@ impl NFSState {
         }
         // for all other record types only parse the status
         else {
-            let stat = match be_u32(&r.prog_data) {
+            let stat = match be_u32(&r.prog_data) as IResult<&[u8],_> {
                 Ok((_, stat)) => {
                     stat as u32
                 }

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -17,7 +17,6 @@
 
 // written by Victor Julien
 
-use nom;
 use crate::log::*;
 use crate::core::*;
 
@@ -25,6 +24,8 @@ use crate::nfs::nfs::*;
 use crate::nfs::types::*;
 use crate::nfs::rpc_records::*;
 use crate::nfs::nfs3_records::*;
+
+use nom::number::complete::be_u32;
 
 impl NFSState {
     /// complete NFS3 request record
@@ -326,7 +327,7 @@ impl NFSState {
         }
         // for all other record types only parse the status
         else {
-            let stat = match nom::be_u32(&r.prog_data) {
+            let stat = match be_u32(&r.prog_data) {
                 Ok((_, stat)) => {
                     stat as u32
                 }

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -26,7 +26,7 @@ use crate::nfs::rpc_records::*;
 use crate::nfs::nfs3_records::*;
 
 use nom::IResult;
-use nom::number::complete::be_u32;
+use nom::number::streaming::be_u32;
 
 impl NFSState {
     /// complete NFS3 request record

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2018 Open Information Security Foundation
+/* Copyright (C) 2017-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -297,24 +297,18 @@ impl NFSState {
                     // store all handle/filename mappings
                     match many0_nfs3_response_readdirplus_entries(d) {
                         Ok((_, ref entries)) => {
+                            SCLogDebug!("READDIRPLUS ENTRIES reply {:?}", entries);
                             for ce in entries {
                                 SCLogDebug!("ce {:?}", ce);
-                                match ce.entry {
-                                    Some(ref e) => {
-                                        SCLogDebug!("e {:?}", e);
-                                        match e.handle {
-                                            Some(ref h) => {
-                                                SCLogDebug!("h {:?}", h);
-                                                self.namemap.insert(h.value.to_vec(), e.name_vec.to_vec());
-                                            },
-                                            _ => { },
-                                        }
-                                    },
-                                    _ => { },
+                                if let Some(ref e) = ce.entry {
+                                    SCLogDebug!("e {:?}", e);
+                                    if let Some(ref h) = e.handle {
+                                        SCLogDebug!("h {:?}", h);
+                                        self.namemap.insert(h.value.to_vec(),
+                                                e.name_vec.to_vec());
+                                    }
                                 }
                             }
-
-                            SCLogDebug!("READDIRPLUS ENTRIES reply {:?}", entries);
                         },
                         _ => {
                             self.set_event(NFSEvent::MalformedData);
@@ -345,6 +339,4 @@ impl NFSState {
 
         0
     }
-
 }
-

--- a/rust/src/nfs/nfs3_records.rs
+++ b/rust/src/nfs/nfs3_records.rs
@@ -17,7 +17,9 @@
 
 //! Nom parsers for RPC & NFSv3
 
-use nom::{IResult, be_u32, be_u64, rest};
+use nom::IResult;
+use nom::combinator::rest;
+use nom::number::complete::{be_u32, be_u64};
 use crate::nfs::nfs_records::*;
 
 #[derive(Debug,PartialEq)]

--- a/rust/src/nfs/nfs3_records.rs
+++ b/rust/src/nfs/nfs3_records.rs
@@ -19,7 +19,7 @@
 
 use nom::IResult;
 use nom::combinator::rest;
-use nom::number::complete::{be_u32, be_u64};
+use nom::number::streaming::{be_u32, be_u64};
 use crate::nfs::nfs_records::*;
 
 #[derive(Debug,PartialEq)]

--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -18,7 +18,7 @@
 // written by Victor Julien
 
 use nom;
-use nom::be_u32;
+use nom::number::complete::be_u32;
 
 use crate::core::*;
 use crate::log::*;

--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018 Open Information Security Foundation
+/* Copyright (C) 2018-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -29,12 +29,12 @@ use crate::nfs::rpc_records::*;
 use crate::nfs::nfs_records::*;
 use crate::nfs::nfs4_records::*;
 
-use crate::kerberos;
+use crate::kerberos::{parse_kerberos5_request, Kerberos5Ticket, SecBlobError};
 
-named!(parse_req_gssapi<kerberos::Kerberos5Ticket>,
+named!(parse_req_gssapi<&[u8], Kerberos5Ticket, SecBlobError>,
    do_parse!(
         len: be_u32
-    >>  ap: flat_map!(take!(len), call!(kerberos::parse_kerberos5_request))
+    >>  ap: flat_map!(take!(len), parse_kerberos5_request)
     >> ( ap )
 ));
 

--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -18,7 +18,7 @@
 // written by Victor Julien
 
 use nom;
-use nom::number::complete::be_u32;
+use nom::number::streaming::be_u32;
 
 use crate::core::*;
 use crate::log::*;

--- a/rust/src/nfs/nfs4_records.rs
+++ b/rust/src/nfs/nfs4_records.rs
@@ -16,7 +16,7 @@
  */
 
 //! Nom parsers for NFSv4 records
-use nom::number::complete::{be_u32, be_u64};
+use nom::number::streaming::{be_u32, be_u64};
 
 use crate::nfs::types::*;
 

--- a/rust/src/nfs/nfs4_records.rs
+++ b/rust/src/nfs/nfs4_records.rs
@@ -16,7 +16,7 @@
  */
 
 //! Nom parsers for NFSv4 records
-use nom::{be_u32, be_u64};
+use nom::number::complete::{be_u32, be_u64};
 
 use crate::nfs::types::*;
 

--- a/rust/src/nfs/rpc_records.rs
+++ b/rust/src/nfs/rpc_records.rs
@@ -17,7 +17,8 @@
 
 //! Nom parsers for RPCv2
 
-use nom::{be_u32, rest};
+use nom::combinator::rest;
+use nom::number::complete::be_u32;
 
 #[derive(Debug,PartialEq)]
 pub enum RpcRequestCreds<'a> {
@@ -122,8 +123,8 @@ pub struct RpcPacketHeader<> {
 named!(pub parse_rpc_packet_header<RpcPacketHeader>,
     do_parse!(
         fraghdr: bits!(tuple!(
-                take_bits!(u8, 1),       // is_last
-                take_bits!(u32, 31)))    // len
+                take_bits!(1u8),       // is_last
+                take_bits!(31u32)))    // len
 
         >> xid: be_u32
         >> msgtype: be_u32

--- a/rust/src/nfs/rpc_records.rs
+++ b/rust/src/nfs/rpc_records.rs
@@ -17,6 +17,7 @@
 
 //! Nom parsers for RPCv2
 
+use nom::IResult;
 use nom::combinator::rest;
 use nom::number::complete::be_u32;
 
@@ -120,12 +121,16 @@ pub struct RpcPacketHeader<> {
     pub msgtype: u32,
 }
 
+fn parse_bits(i:&[u8]) -> IResult<&[u8],(u8,u32)> {
+    bits!(i,
+        tuple!(
+            take_bits!(1u8),       // is_last
+            take_bits!(31u32)))    // len
+}
+
 named!(pub parse_rpc_packet_header<RpcPacketHeader>,
     do_parse!(
-        fraghdr: bits!(tuple!(
-                take_bits!(1u8),       // is_last
-                take_bits!(31u32)))    // len
-
+        fraghdr: parse_bits
         >> xid: be_u32
         >> msgtype: be_u32
         >> (

--- a/rust/src/nfs/rpc_records.rs
+++ b/rust/src/nfs/rpc_records.rs
@@ -19,7 +19,7 @@
 
 use nom::IResult;
 use nom::combinator::rest;
-use nom::number::complete::be_u32;
+use nom::number::streaming::be_u32;
 
 #[derive(Debug,PartialEq)]
 pub enum RpcRequestCreds<'a> {

--- a/rust/src/rdp/error.rs
+++ b/rust/src/rdp/error.rs
@@ -16,7 +16,27 @@
  */
 
 // Author: Zach Kelly <zach.kelly@lmco.com>
+// Author: Pierre Chifflier <chifflier@wzdftpd.net>
+use nom::error::{ErrorKind, ParseError};
 
-// custom errors the parser can emit
-pub const RDP_UNIMPLEMENTED_LENGTH_DETERMINANT: u32 = 128;
-pub const RDP_NOT_X224_CLASS_0_ERROR: u32 = 129;
+#[derive(Debug, PartialEq)]
+pub enum RdpError {
+    UnimplementedLengthDeterminant,
+    NotX224Class0Error,
+    NomError(ErrorKind),
+}
+
+impl<I> ParseError<I> for RdpError {
+    fn from_error_kind(_input: I, kind: ErrorKind) -> Self {
+        RdpError::NomError(kind)
+    }
+    fn append(_input: I, kind: ErrorKind, _other: Self) -> Self {
+        RdpError::NomError(kind)
+    }
+}
+
+impl nom::ErrorConvert<RdpError> for ((&[u8], usize), ErrorKind) {
+    fn convert(self) -> RdpError {
+        RdpError::NomError(self.1)
+    }
+}

--- a/rust/src/rdp/parser.rs
+++ b/rust/src/rdp/parser.rs
@@ -29,7 +29,7 @@
 use nom::IResult;
 use nom::bytes::complete::take;
 use nom::combinator::{opt, map_opt, map_res};
-use nom::number::complete::{be_u16, be_u8, le_u16, le_u32, le_u8};
+use nom::number::streaming::{be_u16, be_u8, le_u16, le_u32, le_u8};
 use crate::rdp::error::RdpError;
 use crate::rdp::util::{
     le_slice_to_string, parse_per_length_determinant, utf7_slice_to_string,

--- a/rust/src/rdp/parser.rs
+++ b/rust/src/rdp/parser.rs
@@ -490,7 +490,7 @@ fn parse_x224_connection_request(
     input: &[u8],
 ) -> IResult<&[u8], X224ConnectionRequest, RdpError> {
     let (i1, length) = verify!(input, be_u8, |&x| x != 0xff)?; // 0xff is reserved
-    let (i2, cr_cdt) = take_4_4_bits(input)?;
+    let (i2, cr_cdt) = take_4_4_bits(i1)?;
     let _ = verify!(i1, value!(cr_cdt.0), |&x| x
                 == X224Type::ConnectionRequest as u8)?;
     let _ = verify!(i1, value!(cr_cdt.1), |&x| x == 0 || x == 1)?;

--- a/rust/src/rdp/parser.rs
+++ b/rust/src/rdp/parser.rs
@@ -27,7 +27,7 @@
 //! * x.691-spec: <https://www.itu.int/rec/T-REC-X.691/en>
 
 use nom::IResult;
-use nom::bytes::complete::take;
+use nom::bytes::streaming::take;
 use nom::combinator::{opt, map_opt, map_res};
 use nom::number::streaming::{be_u16, be_u8, le_u16, le_u32, le_u8};
 use crate::rdp::error::RdpError;

--- a/rust/src/rdp/util.rs
+++ b/rust/src/rdp/util.rs
@@ -20,7 +20,8 @@
 use byteorder::ReadBytesExt;
 use memchr::memchr;
 use nom;
-use nom::{ErrorKind, IResult, Needed};
+use nom::{IResult, Needed};
+use nom::error::ErrorKind;
 use crate::rdp::error::RDP_UNIMPLEMENTED_LENGTH_DETERMINANT;
 use std::io::Cursor;
 use widestring::U16CString;

--- a/rust/src/sip/parser.rs
+++ b/rust/src/sip/parser.rs
@@ -18,7 +18,9 @@
 // written by Giuseppe Longo <giuseppe@glono.it>
 
 use nom::*;
-use nom::{crlf, IResult};
+use nom::IResult;
+use nom::character::{is_alphabetic, is_alphanumeric, is_space};
+use nom::character::complete::crlf;
 use std;
 use std::collections::HashMap;
 

--- a/rust/src/sip/parser.rs
+++ b/rust/src/sip/parser.rs
@@ -20,7 +20,7 @@
 use nom::*;
 use nom::IResult;
 use nom::character::{is_alphabetic, is_alphanumeric, is_space};
-use nom::character::complete::crlf;
+use nom::character::streaming::crlf;
 use std;
 use std::collections::HashMap;
 

--- a/rust/src/sip/parser.rs
+++ b/rust/src/sip/parser.rs
@@ -161,7 +161,7 @@ named!(pub sip_take_line<&[u8], Option<String> >,
 pub fn parse_headers(mut input: &[u8]) -> IResult<&[u8], HashMap<String, String>> {
     let mut headers_map: HashMap<String, String> = HashMap::new();
     loop {
-        match crlf(input) {
+        match crlf(input) as IResult<&[u8],_> {
             Ok((_, _)) => {
                 break;
             }

--- a/rust/src/smb/dcerpc_records.rs
+++ b/rust/src/smb/dcerpc_records.rs
@@ -20,7 +20,7 @@ use nom;
 use nom::IResult;
 use nom::combinator::rest;
 use nom::number::Endianness;
-use nom::number::complete::{be_u16, le_u8, le_u16, le_u32};
+use nom::number::streaming::{be_u16, le_u8, le_u16, le_u32};
 
 #[derive(Debug,PartialEq)]
 pub struct DceRpcResponseRecord<'a> {

--- a/rust/src/smb/dcerpc_records.rs
+++ b/rust/src/smb/dcerpc_records.rs
@@ -16,7 +16,11 @@
  */
 
 use nom;
-use nom::{rest, le_u8, be_u16, le_u16, le_u32, IResult, ErrorKind, Endianness};
+use nom::IResult;
+use nom::error::ErrorKind;
+use nom::combinator::rest;
+use nom::number::Endianness;
+use nom::number::complete::{be_u16, le_u8, le_u16, le_u32};
 
 #[derive(Debug,PartialEq)]
 pub struct DceRpcResponseRecord<'a> {
@@ -208,13 +212,13 @@ named!(pub parse_dcerpc_record<DceRpcRecord>,
         >>  version_minor: le_u8
         >>  packet_type: le_u8
         >>  packet_flags: bits!(tuple!(
-               take_bits!(u8, 6),
-               take_bits!(u8, 1),   // last (1)
-               take_bits!(u8, 1)))  // first (2)
+               take_bits!(6u8),
+               take_bits!(1u8),   // last (1)
+               take_bits!(1u8)))  // first (2)
         >>  data_rep: bits!(tuple!(
-                take_bits!(u32, 3),
-                take_bits!(u32, 1),     // endianess
-                take_bits!(u32, 28)))
+                take_bits!(3u32),
+                take_bits!(1u32),     // endianess
+                take_bits!(28u32)))
         >>  endian: value!(if data_rep.1 == 0 { Endianness::Big } else { Endianness::Little })
         >>  frag_len: u16!(endian)
         >>  _auth: u16!(endian)

--- a/rust/src/smb/dcerpc_records.rs
+++ b/rust/src/smb/dcerpc_records.rs
@@ -15,9 +15,9 @@
  * 02110-1301, USA.
  */
 
+use crate::smb::error::SmbError;
 use nom;
 use nom::IResult;
-use nom::error::ErrorKind;
 use nom::combinator::rest;
 use nom::number::Endianness;
 use nom::number::complete::{be_u16, le_u8, le_u16, le_u32};
@@ -30,10 +30,10 @@ pub struct DceRpcResponseRecord<'a> {
 /// parse a packet type 'response' DCERPC record. Implemented
 /// as function to be able to pass the fraglen in.
 pub fn parse_dcerpc_response_record(i:&[u8], frag_len: u16 )
-    -> IResult<&[u8], DceRpcResponseRecord>
+    -> IResult<&[u8], DceRpcResponseRecord, SmbError>
 {
     if frag_len < 24 {
-        return Err(nom::Err::Error(error_position!(i,ErrorKind::Custom(128))));
+        return Err(nom::Err::Error(SmbError::RecordTooSmall));
     }
     do_parse!(i,
                 take!(8)
@@ -53,10 +53,10 @@ pub struct DceRpcRequestRecord<'a> {
 /// parse a packet type 'request' DCERPC record. Implemented
 /// as function to be able to pass the fraglen in.
 pub fn parse_dcerpc_request_record(i:&[u8], frag_len: u16, little: bool)
-    -> IResult<&[u8], DceRpcRequestRecord>
+    -> IResult<&[u8], DceRpcRequestRecord, SmbError>
 {
     if frag_len < 24 {
-        return Err(nom::Err::Error(error_position!(i,ErrorKind::Custom(128))));
+        return Err(nom::Err::Error(SmbError::RecordTooSmall));
     }
     do_parse!(i,
                 take!(6)

--- a/rust/src/smb/error.rs
+++ b/rust/src/smb/error.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2019 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,30 +15,21 @@
  * 02110-1301, USA.
  */
 
-pub mod error;
-pub mod smb_records;
-pub mod smb1_records;
-pub mod smb2_records;
-pub mod nbss_records;
-pub mod dcerpc_records;
-pub mod ntlmssp_records;
+// Author: Pierre Chifflier <chifflier@wzdftpd.net>
+use nom::error::{ErrorKind, ParseError};
 
-pub mod smb;
-pub mod smb1;
-pub mod smb1_session;
-pub mod smb2;
-pub mod smb2_session;
-pub mod smb2_ioctl;
-pub mod smb3;
-pub mod dcerpc;
-pub mod session;
-pub mod log;
-pub mod detect;
-pub mod debug;
-pub mod events;
-pub mod auth;
-pub mod files;
-pub mod funcs;
+#[derive(Debug)]
+pub enum SmbError {
+    BadEncoding,
+    RecordTooSmall,
+    NomError(ErrorKind),
+}
 
-//#[cfg(feature = "lua")]
-//pub mod lua;
+impl<I> ParseError<I> for SmbError {
+    fn from_error_kind(_input: I, kind: ErrorKind) -> Self {
+        SmbError::NomError(kind)
+    }
+    fn append(_input: I, kind: ErrorKind, _other: Self) -> Self {
+        SmbError::NomError(kind)
+    }
+}

--- a/rust/src/smb/nbss_records.rs
+++ b/rust/src/smb/nbss_records.rs
@@ -15,7 +15,7 @@
  * 02110-1301, USA.
  */
 
-use nom::{rest};
+use nom::combinator::rest;
 
 pub const NBSS_MSGTYPE_SESSION_MESSAGE:         u8 = 0x00;
 pub const NBSS_MSGTYPE_SESSION_REQUEST:         u8 = 0x81;
@@ -62,8 +62,8 @@ impl<'a> NbssRecord<'a> {
 named!(pub parse_nbss_record<NbssRecord>,
    do_parse!(
        type_and_len: bits!(tuple!(
-               take_bits!(u8, 8),
-               take_bits!(u32, 24)))
+               take_bits!(8u8),
+               take_bits!(24u32)))
        >> data: take!(type_and_len.1 as usize)
        >> (NbssRecord {
             message_type:type_and_len.0,
@@ -75,8 +75,8 @@ named!(pub parse_nbss_record<NbssRecord>,
 named!(pub parse_nbss_record_partial<NbssRecord>,
    do_parse!(
        type_and_len: bits!(tuple!(
-               take_bits!(u8, 8),
-               take_bits!(u32, 24)))
+               take_bits!(8u8),
+               take_bits!(24u32)))
        >> data: rest
        >> (NbssRecord {
             message_type:type_and_len.0,

--- a/rust/src/smb/ntlmssp_records.rs
+++ b/rust/src/smb/ntlmssp_records.rs
@@ -15,7 +15,8 @@
  * 02110-1301, USA.
  */
 
-use nom::{rest, le_u8, le_u16, le_u32};
+use nom::combinator::rest;
+use nom::number::complete::{le_u8, le_u16, le_u32};
 
 #[derive(Debug,PartialEq)]
 pub struct NTLMSSPVersion {
@@ -82,7 +83,7 @@ named!(pub parse_ntlm_auth_record<NTLMSSPAuthRecord>,
          >> _ssnkey_blob_maxlen: le_u16
          >> _ssnkey_blob_offset: le_u32
 
-         >> nego_flags: bits!(tuple!(take_bits!(u8, 6),take_bits!(u8,1),take_bits!(u32,25)))
+         >> nego_flags: bits!(tuple!(take_bits!(6u8),take_bits!(1u8),take_bits!(25u32)))
          >> version: cond!(nego_flags.1==1, parse_ntlm_auth_version)
 
          // subtrack 12 as idenfier (8) and type (4) are cut before we are called
@@ -112,7 +113,8 @@ pub struct NTLMSSPRecord<'a> {
 
 named!(pub parse_ntlmssp<NTLMSSPRecord>,
     do_parse!(
-            take_until_and_consume!("NTLMSSP\x00")
+            take_until!("NTLMSSP\x00")
+        >>  tag!("NTLMSSP\x00")
         >>  msg_type: le_u32
         >>  data: rest
         >>  (NTLMSSPRecord {

--- a/rust/src/smb/ntlmssp_records.rs
+++ b/rust/src/smb/ntlmssp_records.rs
@@ -17,7 +17,7 @@
 
 use nom::IResult;
 use nom::combinator::rest;
-use nom::number::complete::{le_u8, le_u16, le_u32};
+use nom::number::streaming::{le_u8, le_u16, le_u32};
 
 #[derive(Debug,PartialEq)]
 pub struct NTLMSSPVersion {

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -19,7 +19,7 @@ use crate::smb::error::SmbError;
 use crate::log::*;
 use nom::IResult;
 use nom::combinator::rest;
-use nom::number::complete::{le_u8, le_u16, le_u32, le_u64};
+use nom::number::streaming::{le_u8, le_u16, le_u32, le_u64};
 use crate::smb::smb::*;
 use crate::smb::smb_records::*;
 

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -18,7 +18,7 @@
 use nom;
 use nom::IResult;
 use nom::combinator::rest;
-use nom::number::complete::{le_u8, le_u16, le_u32, le_u64};
+use nom::number::streaming::{le_u8, le_u16, le_u32, le_u64};
 use crate::smb::smb::*;
 
 #[derive(Debug,PartialEq)]

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -16,7 +16,9 @@
  */
 
 use nom;
-use nom::{rest, le_u8, le_u16, le_u32, le_u64, IResult};
+use nom::IResult;
+use nom::combinator::rest;
+use nom::number::complete::{le_u8, le_u16, le_u32, le_u64};
 use crate::smb::smb::*;
 
 #[derive(Debug,PartialEq)]
@@ -75,14 +77,14 @@ named!(pub parse_smb2_request_record<Smb2Record>,
         >>  command: le_u16
         >>  _credits_requested: le_u16
         >>  flags: bits!(tuple!(
-                take_bits!(u8, 2),      // reserved / unused
-                take_bits!(u8, 1),      // replay op
-                take_bits!(u8, 1),      // dfs op
-                take_bits!(u32, 24),    // reserved / unused
-                take_bits!(u8, 1),      // signing
-                take_bits!(u8, 1),      // chained
-                take_bits!(u8, 1),      // async
-                take_bits!(u8, 1)       // response
+                take_bits!(2u8),      // reserved / unused
+                take_bits!(1u8),      // replay op
+                take_bits!(1u8),      // dfs op
+                take_bits!(24u32),    // reserved / unused
+                take_bits!(1u8),      // signing
+                take_bits!(1u8),      // chained
+                take_bits!(1u8),      // async
+                take_bits!(1u8)       // response
             ))
         >> chain_offset: le_u32
         >> message_id: le_u64
@@ -379,7 +381,7 @@ named!(pub parse_smb2_request_write<Smb2WriteRequestRecord>,
         >>  _remaining_bytes: le_u32
         >>  _write_flags: le_u32
         >>  _skip2: take!(4)
-        >>  data: apply!(parse_smb2_data, wr_len)
+        >>  data: call!(parse_smb2_data, wr_len)
         >>  (Smb2WriteRequestRecord {
                 wr_len:wr_len,
                 wr_offset:wr_offset,
@@ -439,7 +441,7 @@ named!(pub parse_smb2_response_read<Smb2ReadResponseRecord>,
         >>  rd_len: le_u32
         >>  _rd_rem: le_u32
         >>  _padding: take!(4)
-        >>  data: apply!(parse_smb2_data, rd_len)
+        >>  data: call!(parse_smb2_data, rd_len)
         >>  (Smb2ReadResponseRecord {
                 len : rd_len,
                 data : data,
@@ -506,14 +508,14 @@ named!(pub parse_smb2_response_record<Smb2Record>,
         >>  command: le_u16
         >>  _credit_granted: le_u16
         >>  flags: bits!(tuple!(
-                take_bits!(u8, 2),      // reserved / unused
-                take_bits!(u8, 1),      // replay op
-                take_bits!(u8, 1),      // dfs op
-                take_bits!(u32, 24),    // reserved / unused
-                take_bits!(u8, 1),      // signing
-                take_bits!(u8, 1),      // chained
-                take_bits!(u8, 1),      // async
-                take_bits!(u8, 1)       // response
+                take_bits!(2u8),      // reserved / unused
+                take_bits!(1u8),      // replay op
+                take_bits!(1u8),      // dfs op
+                take_bits!(24u32),    // reserved / unused
+                take_bits!(1u8),      // signing
+                take_bits!(1u8),      // chained
+                take_bits!(1u8),      // async
+                take_bits!(1u8)       // response
             ))
         >> chain_offset: le_u32
         >> message_id: le_u64

--- a/rust/src/smb/smb3.rs
+++ b/rust/src/smb/smb3.rs
@@ -15,7 +15,7 @@
  * 02110-1301, USA.
  */
 
-use nom::{le_u16, le_u32, le_u64};
+use nom::number::complete::{le_u16, le_u32, le_u64};
 
 #[derive(Debug,PartialEq)]
 pub struct Smb3TransformRecord<'a> {

--- a/rust/src/smb/smb3.rs
+++ b/rust/src/smb/smb3.rs
@@ -15,7 +15,7 @@
  * 02110-1301, USA.
  */
 
-use nom::number::complete::{le_u16, le_u32, le_u64};
+use nom::number::streaming::{le_u16, le_u32, le_u64};
 
 #[derive(Debug,PartialEq)]
 pub struct Smb3TransformRecord<'a> {

--- a/rust/src/smb/smb_records.rs
+++ b/rust/src/smb/smb_records.rs
@@ -16,7 +16,8 @@
  */
 
 use nom;
-use nom::{ErrorKind, IResult};
+use nom::IResult;
+use nom::error::ErrorKind;
 use crate::log::*;
 
 /// parse a UTF16 string that is null terminated. Normally by 2 null

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -28,10 +28,12 @@ use std::mem::transmute;
 
 use crate::log::*;
 
-use der_parser::{DerObjectContent,parse_der_sequence};
+use der_parser::ber::BerObjectContent;
+use der_parser::der::parse_der_sequence;
 use der_parser::oid::Oid;
 use nom;
-use nom::{ErrorKind,IResult};
+use nom::IResult;
+use nom::error::ErrorKind;
 
 #[repr(u32)]
 pub enum SNMPEvent {
@@ -537,7 +539,7 @@ fn parse_pdu_enveloppe_version(i:&[u8]) -> IResult<&[u8],u32> {
     match parse_der_sequence(i) {
         Ok((_,x))     => {
             match x.content {
-                DerObjectContent::Sequence(ref v) => {
+                BerObjectContent::Sequence(ref v) => {
                     if v.len() == 3 {
                         match v[0].as_u32()  {
                             Ok(0) => { return Ok((i,1)); }, // possibly SNMPv1


### PR DESCRIPTION
#4523 rebased
minor fixes/improvements
bump Rust min-version to 1.34.2 (1.34 is needed by a indirect dependency (base64 crate))

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed.