### PR TITLE
Replace libjannson with Rust JsonBuilder - v12

### DIFF
--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -1,0 +1,609 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#![allow(clippy::missing_safety_doc)]
+
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+use std::str::Utf8Error;
+
+#[derive(Debug, PartialEq)]
+pub enum JsonError {
+    InvalidState,
+    Utf8Error(Utf8Error),
+}
+
+impl std::error::Error for JsonError {}
+
+impl std::fmt::Display for JsonError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            JsonError::InvalidState => write!(f, "invalid state"),
+            JsonError::Utf8Error(ref e) => e.fmt(f),
+        }
+    }
+}
+
+impl From<Utf8Error> for JsonError {
+    fn from(e: Utf8Error) -> Self {
+        JsonError::Utf8Error(e)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum State {
+    None,
+    ObjectFirst,
+    ObjectNth,
+    ArrayFirst,
+    ArrayNth,
+}
+
+#[derive(Debug)]
+pub struct JsonBuilder {
+    buf: String,
+    state: Vec<State>,
+}
+
+impl JsonBuilder {
+    /// Returns a new JsonBuilder in object state.
+    pub fn new_object() -> Self {
+        let mut buf = String::with_capacity(32768);
+        buf.push('{');
+        Self {
+            buf: buf,
+            state: vec![State::None, State::ObjectFirst],
+        }
+    }
+
+    /// Returns a new JsonBuilder in array state.
+    pub fn new_array() -> Self {
+        let mut buf = String::with_capacity(32768);
+        buf.push('[');
+        Self {
+            buf: buf,
+            state: vec![State::None, State::ArrayFirst],
+        }
+    }
+
+    // Closes the currently open datatype (object or array).
+    pub fn close(&mut self) -> Result<&mut Self, JsonError> {
+        match self.current_state() {
+            State::ObjectFirst | State::ObjectNth => {
+                self.buf.push('}');
+                self.pop_state();
+                Ok(self)
+            }
+            State::ArrayFirst | State::ArrayNth => {
+                self.buf.push(']');
+                self.pop_state();
+                Ok(self)
+            }
+            _ => Err(JsonError::InvalidState),
+        }
+    }
+
+    // Return the current state of the JsonBuilder.
+    fn current_state(&self) -> State {
+        if self.state.is_empty() {
+            State::None
+        } else {
+            self.state[self.state.len() - 1]
+        }
+    }
+
+    /// Move to a new state.
+    fn push_state(&mut self, state: State) {
+        self.state.push(state);
+    }
+
+    /// Go back to the previous state.
+    fn pop_state(&mut self) {
+        self.state.pop();
+    }
+
+    /// Change the current state.
+    fn set_state(&mut self, state: State) {
+        let n = self.state.len() - 1;
+        self.state[n] = state;
+    }
+
+    /// Open an object under the given key.
+    ///
+    /// For example:
+    ///     Before: {
+    ///     After:  {"key": {
+    pub fn open_object(&mut self, key: &str) -> Result<&mut Self, JsonError> {
+        match self.current_state() {
+            State::ObjectFirst => {
+                self.buf.push('"');
+                self.set_state(State::ObjectNth);
+            }
+            State::ObjectNth => {
+                self.buf.push_str(",\"");
+            }
+            _ => {
+                return Err(JsonError::InvalidState);
+            }
+        }
+        self.buf.push_str(key);
+        self.buf.push_str("\":{");
+        self.push_state(State::ObjectFirst);
+        Ok(self)
+    }
+
+    /// Start an object.
+    ///
+    /// Like open_object but does not create the object under a key. An
+    /// error will be returned if starting an object does not make
+    /// sense for the current state.
+    pub fn start_object(&mut self) -> Result<&mut Self, JsonError> {
+        match self.current_state() {
+            State::ArrayFirst => {}
+            State::ArrayNth => {
+                self.buf.push_str(",");
+            }
+            _ => {
+                return Err(JsonError::InvalidState);
+            }
+        }
+        self.buf.push_str("{");
+        self.set_state(State::ArrayNth);
+        self.push_state(State::ObjectFirst);
+        Ok(self)
+    }
+
+    /// Open an array under the given key.
+    ///
+    /// For example:
+    ///     Before: {
+    ///     After:  {"key": [
+    pub fn open_array(&mut self, key: &str) -> Result<&mut Self, JsonError> {
+        match self.current_state() {
+            State::ObjectFirst => {}
+            State::ObjectNth => {
+                self.buf.push_str(",");
+            }
+            _ => {
+                return Err(JsonError::InvalidState);
+            }
+        }
+        self.buf.push_str(&format!(r#""{}":["#, key));
+        self.set_state(State::ObjectNth);
+        self.push_state(State::ArrayFirst);
+        Ok(self)
+    }
+
+    /// Add a string to an array.
+    pub fn add_string(&mut self, val: &str) -> Result<&mut Self, JsonError> {
+        match self.current_state() {
+            State::ArrayFirst => {
+                self.encode_string(val)?;
+                self.set_state(State::ArrayNth);
+                Ok(self)
+            }
+            State::ArrayNth => {
+                self.buf.push_str(&format!(r#","{}""#, val));
+                Ok(self)
+            }
+            _ => Err(JsonError::InvalidState),
+        }
+    }
+
+    /// Add an unsigned integer to an array.
+    pub fn add_uint(&mut self, val: u64) -> Result<&mut Self, JsonError> {
+        match self.current_state() {
+            State::ArrayFirst => {
+                self.set_state(State::ArrayNth);
+            }
+            State::ArrayNth => {
+                self.buf.push(',');
+            }
+            _ => {
+                return Err(JsonError::InvalidState);
+            }
+        }
+        self.buf.push_str(&val.to_string());
+        Ok(self)
+    }
+
+    pub fn set_object(&mut self, key: &str, js: &JsonBuilder) -> Result<&mut Self, JsonError> {
+        match self.current_state() {
+            State::ObjectNth => {
+                self.buf.push(',');
+            }
+            State::ObjectFirst => {
+                self.set_state(State::ObjectNth);
+            }
+            _ => {
+                return Err(JsonError::InvalidState);
+            }
+        }
+        self.buf.push('"');
+        self.buf.push_str(key);
+        self.buf.push_str("\":");
+        self.buf.push_str(&js.buf);
+        Ok(self)
+    }
+
+    /// Set a key and string value type on an object.
+    pub fn set_string(&mut self, key: &str, val: &str) -> Result<&mut Self, JsonError> {
+        match self.current_state() {
+            State::ObjectNth => {
+                self.buf.push(',');
+            }
+            State::ObjectFirst => {
+                self.set_state(State::ObjectNth);
+            }
+            _ => {
+                return Err(JsonError::InvalidState);
+            }
+        }
+        self.buf.push('"');
+        self.buf.push_str(key);
+        self.buf.push_str("\":");
+        self.encode_string(val)?;
+        Ok(self)
+    }
+
+    /// Set a key and a string value (from bytes) on an object.
+    pub fn set_string_from_bytes(&mut self, key: &str, val: &[u8]) -> Result<&mut Self, JsonError> {
+        match std::str::from_utf8(val) {
+            Ok(s) => self.set_string(key, s),
+            Err(_) => self.set_string(key, "<failed to convert bytes to string>"),
+        }
+    }
+
+    /// Set a key and an unsigned integer type on an object.
+    pub fn set_uint(&mut self, key: &str, val: u64) -> Result<&mut Self, JsonError> {
+        match self.current_state() {
+            State::ObjectNth => {
+                self.buf.push(',');
+            }
+            State::ObjectFirst => {
+                self.set_state(State::ObjectNth);
+            }
+            _ => {
+                return Err(JsonError::InvalidState);
+            }
+        }
+        self.buf.push('"');
+        self.buf.push_str(key);
+        self.buf.push_str("\":");
+        self.buf.push_str(&val.to_string());
+        Ok(self)
+    }
+
+    /// Encode a string into the buffer, escaping as needed.
+    fn encode_string(&mut self, val: &str) -> Result<(), JsonError> {
+        let mut out = vec![0; (val.len() * 2) + 2];
+        let mut offset = 0;
+        out[offset] = b'"';
+        offset += 1;
+        for c in val.chars() {
+            match c {
+                '"' | '\\' | '/' => {
+                    out[offset] = b'\\';
+                    offset += 1;
+                    out[offset] = c as u8;
+                    offset += 1;
+                }
+                '\n' => {
+                    out[offset] = b'\\';
+                    offset += 1;
+                    out[offset] = b'n';
+                    offset += 1;
+                }
+                '\r' => {
+                    out[offset] = b'\\';
+                    offset += 1;
+                    out[offset] = b'r';
+                    offset += 1;
+                }
+                '\t' => {
+                    out[offset] = b'\\';
+                    offset += 1;
+                    out[offset] = b't';
+                    offset += 1;
+                }
+                // Form feed.
+                '\u{000c}' => {
+                    out[offset] = b'\\';
+                    offset += 1;
+                    out[offset] = b'f';
+                    offset += 1;
+                }
+                // Backspace.
+                '\u{0008}' => {
+                    out[offset] = b'\\';
+                    offset += 1;
+                    out[offset] = b'b';
+                    offset += 1;
+                }
+                _ => {
+                    out[offset] = c as u8;
+                    offset += 1
+                }
+            }
+        }
+        out[offset] = b'"';
+        offset += 1;
+        self.buf.push_str(std::str::from_utf8(&out[0..offset])?);
+        Ok(())
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn jb_new_object() -> *mut JsonBuilder {
+    let boxed = Box::new(JsonBuilder::new_object());
+    Box::into_raw(boxed)
+}
+
+#[no_mangle]
+pub extern "C" fn jb_new_array() -> *mut JsonBuilder {
+    let boxed = Box::new(JsonBuilder::new_array());
+    Box::into_raw(boxed)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn jb_free(js: &mut JsonBuilder) {
+    let _: Box<JsonBuilder> = std::mem::transmute(js);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn jb_open_object(js: &mut JsonBuilder, key: *const c_char) -> bool {
+    if let Ok(s) = CStr::from_ptr(key).to_str() {
+        js.open_object(s).is_ok()
+    } else {
+        false
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn jb_start_object(js: &mut JsonBuilder) -> bool {
+    js.start_object().is_ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn jb_open_array(js: &mut JsonBuilder, key: *const c_char) -> bool {
+    if let Ok(s) = CStr::from_ptr(key).to_str() {
+        js.open_array(s).is_ok()
+    } else {
+        false
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn jb_set_string(
+    js: &mut JsonBuilder,
+    key: *const c_char,
+    val: *const c_char,
+) -> bool {
+    if let Ok(key) = CStr::from_ptr(key).to_str() {
+        if let Ok(val) = CStr::from_ptr(val).to_str() {
+            return js.set_string(key, val).is_ok();
+        }
+    }
+    return false;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn jb_set_object(
+    js: &mut JsonBuilder,
+    key: *const c_char,
+    val: &mut JsonBuilder,
+) -> bool {
+    if let Ok(key) = CStr::from_ptr(key).to_str() {
+        return js.set_object(key, val).is_ok();
+    }
+    return false;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn jb_add_string(js: &mut JsonBuilder, val: *const c_char) -> bool {
+    if let Ok(val) = CStr::from_ptr(val).to_str() {
+        return js.add_string(val).is_ok();
+    }
+    return false;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn jb_add_uint(js: &mut JsonBuilder, val: u64) -> bool {
+    return js.add_uint(val).is_ok();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn jb_set_uint(js: &mut JsonBuilder, key: *const c_char, val: u64) -> bool {
+    if let Ok(key) = CStr::from_ptr(key).to_str() {
+        return js.set_uint(key, val).is_ok();
+    }
+    return false;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn jb_close(js: &mut JsonBuilder) -> bool {
+    js.close().is_ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn jb_tostring(js: &mut JsonBuilder) -> *mut c_char {
+    if let Ok(s) = CString::new(js.buf.as_bytes()) {
+        s.into_raw()
+    } else {
+        std::ptr::null_mut()
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn jb_to_cstring(js: &mut JsonBuilder, len: &mut usize) -> *mut c_char {
+    if let Ok(s) = CString::new(js.buf.as_bytes()) {
+        *len = js.buf.len();
+        s.into_raw()
+    } else {
+        std::ptr::null_mut()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_object_in_object() -> Result<(), JsonError> {
+        let mut js = JsonBuilder::new_object();
+
+        js.open_object("object")?;
+        assert_eq!(js.current_state(), State::ObjectFirst);
+        assert_eq!(js.buf, r#"{"object":{"#);
+
+        js.set_string("one", "one")?;
+        assert_eq!(js.current_state(), State::ObjectNth);
+        assert_eq!(js.buf, r#"{"object":{"one":"one""#);
+
+        js.close()?;
+        assert_eq!(js.current_state(), State::ObjectNth);
+        assert_eq!(js.buf, r#"{"object":{"one":"one"}"#);
+
+        js.close()?;
+        assert_eq!(js.current_state(), State::None);
+        assert_eq!(js.buf, r#"{"object":{"one":"one"}}"#);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_array_in_object() -> Result<(), JsonError> {
+        let mut js = JsonBuilder::new_object();
+
+        js.open_array("array")?;
+        assert_eq!(js.current_state(), State::ArrayFirst);
+
+        js.close()?;
+        assert_eq!(js.current_state(), State::ObjectNth);
+        assert_eq!(js.buf, r#"{"array":[]"#);
+
+        js.close()?;
+        assert_eq!(js.buf, r#"{"array":[]}"#);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_array_in_object() -> Result<(), JsonError> {
+        let mut js = JsonBuilder::new_object();
+
+        // Attempt to add an item, should fail.
+        assert_eq!(
+            js.add_string("will fail").err().unwrap(),
+            JsonError::InvalidState
+        );
+
+        js.open_array("array")?;
+        assert_eq!(js.current_state(), State::ArrayFirst);
+
+        js.add_string("one")?;
+        assert_eq!(js.current_state(), State::ArrayNth);
+        assert_eq!(js.buf, r#"{"array":["one""#);
+
+        js.add_string("two")?;
+        assert_eq!(js.current_state(), State::ArrayNth);
+        assert_eq!(js.buf, r#"{"array":["one","two""#);
+
+        js.add_uint(3)?;
+        assert_eq!(js.current_state(), State::ArrayNth);
+        assert_eq!(js.buf, r#"{"array":["one","two",3"#);
+
+        js.close()?;
+        assert_eq!(js.current_state(), State::ObjectNth);
+        assert_eq!(js.buf, r#"{"array":["one","two",3]"#);
+
+        js.close()?;
+        assert_eq!(js.current_state(), State::None);
+        assert_eq!(js.buf, r#"{"array":["one","two",3]}"#);
+
+        Ok(())
+    }
+
+    #[test]
+    fn basic_test() -> Result<(), JsonError> {
+        let mut js = JsonBuilder::new_object();
+        assert_eq!(js.current_state(), State::ObjectFirst);
+        assert_eq!(js.buf, "{");
+
+        js.set_string("one", "one")?;
+        assert_eq!(js.current_state(), State::ObjectNth);
+        assert_eq!(js.buf, r#"{"one":"one""#);
+
+        js.set_string("two", "two")?;
+        assert_eq!(js.current_state(), State::ObjectNth);
+        assert_eq!(js.buf, r#"{"one":"one","two":"two""#);
+
+        js.close()?;
+        assert_eq!(js.current_state(), State::None);
+        assert_eq!(js.buf, r#"{"one":"one","two":"two"}"#);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_combine() -> Result<(), JsonError> {
+        let mut main = JsonBuilder::new_object();
+        let mut obj = JsonBuilder::new_object();
+        obj.close()?;
+
+        let mut array = JsonBuilder::new_array();
+        array.add_string("one")?;
+        array.add_uint(2)?;
+        array.close()?;
+        main.set_object("object", &obj)?;
+        main.set_object("array", &array)?;
+        main.close()?;
+
+        assert_eq!(main.buf, r#"{"object":{},"array":["one",2]}"#);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_objects_in_array() -> Result<(), JsonError> {
+        let mut js = JsonBuilder::new_array();
+        assert_eq!(js.buf, r#"["#);
+
+        js.start_object()?;
+        assert_eq!(js.buf, r#"[{"#);
+
+        js.set_string("uid", "0")?;
+        assert_eq!(js.buf, r#"[{"uid":"0""#);
+
+        js.close()?;
+        assert_eq!(js.buf, r#"[{"uid":"0"}"#);
+
+        js.start_object()?;
+        assert_eq!(js.buf, r#"[{"uid":"0"},{"#);
+
+        js.set_string("username", "root")?;
+        assert_eq!(js.buf, r#"[{"uid":"0"},{"username":"root""#);
+
+        js.close()?;
+        assert_eq!(js.buf, r#"[{"uid":"0"},{"username":"root"}"#);
+
+        js.close()?;
+        assert_eq!(js.buf, r#"[{"uid":"0"},{"username":"root"}]"#);
+
+        Ok(())
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -44,6 +44,7 @@ pub mod core;
 pub mod common;
 pub mod conf;
 pub mod json;
+pub mod jsonbuilder;
 #[macro_use]
 pub mod applayer;
 pub mod filecontainer;

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -51,6 +51,7 @@ typedef struct LogDHCPFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t    flags;
     void       *rs_logger;
+    OutputJsonCommonSettings cfg;
 } LogDHCPFileCtx;
 
 typedef struct LogDHCPLogThread_ {
@@ -73,6 +74,8 @@ static int DHCPEveLogger(ThreadVars *tv, void *thread_data,
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }
+
+    EveAddCommonOptions(&thread->dhcplog_ctx->cfg, p, f, js);
 
     rs_dhcp_logger_log(ctx->rs_logger, tx, js);
     if (!jb_close(js)) {
@@ -109,6 +112,7 @@ static OutputInitResult OutputDHCPLogInitSub(ConfNode *conf,
         return result;
     }
     dhcplog_ctx->file_ctx = ajt->file_ctx;
+    dhcplog_ctx->cfg = ajt->cfg;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -578,6 +578,135 @@ void JsonFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, json_t *js)
     json_object_set_new(js, "proto", json_string(proto));
 }
 
+/**
+ * Version of JsonFiveTuple for JsonBuilder.
+ */
+void EveFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, JsonBuilder *js)
+{
+    char srcip[46] = {0}, dstip[46] = {0};
+    Port sp, dp;
+    char proto[16];
+
+    switch (dir) {
+        case LOG_DIR_PACKET:
+            if (PKT_IS_IPV4(p)) {
+                PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                        srcip, sizeof(srcip));
+                PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                        dstip, sizeof(dstip));
+            } else if (PKT_IS_IPV6(p)) {
+                PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                        srcip, sizeof(srcip));
+                PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                        dstip, sizeof(dstip));
+            } else {
+                /* Not an IP packet so don't do anything */
+                return;
+            }
+            sp = p->sp;
+            dp = p->dp;
+            break;
+        case LOG_DIR_FLOW:
+        case LOG_DIR_FLOW_TOSERVER:
+            if ((PKT_IS_TOSERVER(p))) {
+                if (PKT_IS_IPV4(p)) {
+                    PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                            dstip, sizeof(dstip));
+                } else if (PKT_IS_IPV6(p)) {
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                            dstip, sizeof(dstip));
+                }
+                sp = p->sp;
+                dp = p->dp;
+            } else {
+                if (PKT_IS_IPV4(p)) {
+                    PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                            dstip, sizeof(dstip));
+                } else if (PKT_IS_IPV6(p)) {
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                            dstip, sizeof(dstip));
+                }
+                sp = p->dp;
+                dp = p->sp;
+            }
+            break;
+        case LOG_DIR_FLOW_TOCLIENT:
+            if ((PKT_IS_TOCLIENT(p))) {
+                if (PKT_IS_IPV4(p)) {
+                    PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                            dstip, sizeof(dstip));
+                } else if (PKT_IS_IPV6(p)) {
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                            dstip, sizeof(dstip));
+                }
+                sp = p->sp;
+                dp = p->dp;
+            } else {
+                if (PKT_IS_IPV4(p)) {
+                    PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                            dstip, sizeof(dstip));
+                } else if (PKT_IS_IPV6(p)) {
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                            srcip, sizeof(srcip));
+                    PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                            dstip, sizeof(dstip));
+                }
+                sp = p->dp;
+                dp = p->sp;
+            }
+            break;
+        default:
+            DEBUG_VALIDATE_BUG_ON(1);
+            return;
+    }
+
+    if (SCProtoNameValid(IP_GET_IPPROTO(p)) == TRUE) {
+        strlcpy(proto, known_proto[IP_GET_IPPROTO(p)], sizeof(proto));
+    } else {
+        snprintf(proto, sizeof(proto), "%03" PRIu32, IP_GET_IPPROTO(p));
+    }
+
+    jb_set_string(js, "src_ip", srcip);
+
+    switch(p->proto) {
+        case IPPROTO_ICMP:
+            break;
+        case IPPROTO_UDP:
+        case IPPROTO_TCP:
+        case IPPROTO_SCTP:
+            jb_set_uint(js, "src_port", sp);
+            break;
+    }
+
+    jb_set_string(js, "dest_ip", dstip);
+
+    switch(p->proto) {
+        case IPPROTO_ICMP:
+            break;
+        case IPPROTO_UDP:
+        case IPPROTO_TCP:
+        case IPPROTO_SCTP:
+            jb_set_uint(js, "dest_port", dp);
+            break;
+    }
+
+    jb_set_string(js, "proto", proto);
+}
+
 static void CreateJSONCommunityFlowIdv4(json_t *js, const Flow *f,
         const uint16_t seed)
 {
@@ -707,6 +836,89 @@ void CreateJSONFlowId(json_t *js, const Flow *f)
     }
 }
 
+/**
+ * Variation of CreateJSONFlowId but for JsonBuilder.
+ */
+void EveSetFlowId(JsonBuilder *js, const Flow *f)
+{
+    if (f == NULL) {
+        return;
+    }
+    int64_t flow_id = FlowGetId(f);
+    jb_set_uint(js, "flow_id", flow_id);
+    if (f->parent_id) {
+        jb_set_uint(js, "parent_id", f->parent_id);
+    }
+}
+
+JsonBuilder *EveOpenHeader(const Packet *p, enum OutputJsonLogDirection dir,
+    const char *event_type)
+{
+    char timebuf[64];
+    const Flow *f = (const Flow *)p->flow;
+
+    JsonBuilder *js = jb_new_object();
+    if (unlikely(js == NULL)) {
+        return NULL;
+    }
+
+    CreateIsoTimeString(&p->ts, timebuf, sizeof(timebuf));
+
+    jb_set_string(js, "timestamp", timebuf);
+
+    EveSetFlowId(js, f);
+
+    /* sensor id */
+    if (sensor_id >= 0) {
+        jb_set_uint(js, "sensor_id", sensor_id);
+    }
+
+    /* input interface */
+    if (p->livedev) {
+        jb_set_string(js, "in_iface", p->livedev->dev);
+    }
+
+    /* pcap_cnt */
+    if (p->pcap_cnt != 0) {
+        jb_set_uint(js, "pcap_cnt", p->pcap_cnt);
+    }
+
+    if (event_type) {
+        jb_set_string(js, "event_type", event_type);
+    }
+
+    /* vlan */
+    if (p->vlan_idx > 0) {
+        jb_open_array(js, "vlan");
+        jb_add_uint(js, p->vlan_id[0]);
+        if (p->vlan_idx > 1) {
+            jb_add_uint(js, p->vlan_id[1]);
+        }
+        jb_close(js);
+    }
+
+    /* 5-tuple */
+    EveFiveTuple(p, dir, js);
+
+    /* icmp */
+    switch (p->proto) {
+        case IPPROTO_ICMP:
+            if (p->icmpv4h) {
+                jb_set_uint(js, "icmp_type", p->icmpv4h->type);
+                jb_set_uint(js, "icmp_code", p->icmpv4h->code);
+            }
+            break;
+        case IPPROTO_ICMPV6:
+            if (p->icmpv6h) {
+                jb_set_uint(js, "icmp_type", p->icmpv6h->type);
+                jb_set_uint(js, "icmp_code", p->icmpv6h->code);
+            }
+            break;
+    }
+
+    return js;
+}
+
 json_t *CreateJSONHeader(const Packet *p, enum OutputJsonLogDirection dir,
                          const char *event_type)
 {
@@ -832,6 +1044,39 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer)
         return TM_ECODE_OK;
 
     LogFileWrite(file_ctx, *buffer);
+    return 0;
+}
+
+int OutputSCJSONBuffer(JsonBuilder *js, LogFileCtx *file_ctx, MemBuffer **buffer)
+{
+    if (file_ctx->sensor_name) {
+        jb_set_string(js, "host", file_ctx->sensor_name);
+    }
+
+    if (file_ctx->is_pcap_offline) {
+        jb_set_string(js, "pcap_filename", PcapFileGetFilename());
+    }
+
+    if (file_ctx->prefix) {
+        MemBufferWriteRaw((*buffer), file_ctx->prefix, file_ctx->prefix_len);
+    }
+
+    /* We can probably do better here... */
+    size_t slen = 0;
+    char *s = jb_to_cstring(js, &slen);
+    if (unlikely(s == NULL)) {
+        /* TODO: How to indicate error? */
+        return 0;
+    }
+
+    if (MEMBUFFER_OFFSET(*buffer) + slen >= MEMBUFFER_SIZE(*buffer)) {
+        MemBufferExpand(buffer, slen);
+    }
+
+    MemBufferWriteRaw((*buffer), s, slen);
+    LogFileWrite(file_ctx, *buffer);
+
+    free(s);
     return 0;
 }
 

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -30,6 +30,7 @@
 #include "output.h"
 
 #include "app-layer-htp-xff.h"
+#include "rust.h"
 
 void OutputJsonRegister(void);
 
@@ -94,5 +95,11 @@ void SCJsonDecref(json_t *js);
 
 void JsonAddCommonOptions(const OutputJsonCommonSettings *cfg,
         const Packet *p, const Flow *f, json_t *js);
+
+JsonBuilder *EveOpenHeader(const Packet *p, enum OutputJsonLogDirection dir,
+    const char *event_type);
+void EveFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, JsonBuilder *js);
+void EveSetFlowId(JsonBuilder *js, const Flow *f);
+int OutputSCJSONBuffer(JsonBuilder *js, LogFileCtx *file_ctx, MemBuffer **buffer);
 
 #endif /* __OUTPUT_JSON_H__ */

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -95,6 +95,8 @@ void SCJsonDecref(json_t *js);
 
 void JsonAddCommonOptions(const OutputJsonCommonSettings *cfg,
         const Packet *p, const Flow *f, json_t *js);
+void EveAddCommonOptions(const OutputJsonCommonSettings *cfg,
+        const Packet *p, const Flow *f, JsonBuilder *js);
 
 JsonBuilder *EveOpenHeader(const Packet *p, enum OutputJsonLogDirection dir,
     const char *event_type);


### PR DESCRIPTION
Introduces a new JsonBuilder module to take the place of libjannson
for creating JSON logs.

Converts DHCP and SIP for demonstration purposes.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/2726

Previous PR: https://github.com/OISF/suricata/pull/4481

Changes from last PR:
- Convert SIP logging.
- Add methods for logging metadata like pktvars, community-id.

Notes:
- For SIP we have to keep the old style logger until alert logging
  has been migrated, due to metadata logging.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/446
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/803