### PR TITLE
buildbot-pcaps: remove redundant sudo

### DIFF
--- a/qa/docker/buildbot.cfg
+++ b/qa/docker/buildbot.cfg
@@ -128,14 +128,14 @@ factory_stress_pcap = SuriBuildFactory()
 factory_stress_pcap.addStep(ShellCommand(command=["./autogen.sh"]))
 factory_stress_pcap.addStep(ShellCommand(command=["./configure","--enable-debug-validation"],env={"CFLAGS" : "-fsanitize=address -fno-omit-frame-pointer"}))
 factory_stress_pcap.addStep(ShellCommand(command=["make"]))
-factory_stress_pcap.addStep(ShellCommand(command=["sudo", "make","install"]))
-factory_stress_pcap.addStep(ShellCommand(command=["sudo", "rm", "-f", "/usr/local/etc/suricata/suricata.yaml"]))
-factory_stress_pcap.addStep(ShellCommand(command=["sudo", "make","install-conf"]))
+factory_stress_pcap.addStep(ShellCommand(command=["make","install"]))
+factory_stress_pcap.addStep(ShellCommand(command=["rm", "-f", "/usr/local/etc/suricata/suricata.yaml"]))
+factory_stress_pcap.addStep(ShellCommand(command=["make","install-conf"]))
 factory_stress_pcap.addStep(ShellCommand(command=["make","clean"]))
-factory_stress_pcap.addStep(ShellCommand(command=["sudo", "ldconfig"]))
+factory_stress_pcap.addStep(ShellCommand(command=["ldconfig"]))
 for pfile in pcaps_list:
-    factory_stress_pcap.addStep(ShellCommand(command=["sudo", "/usr/local/bin/suricata","-r",pfile,"--init-errors-fatal","-S","/data/oisf/rules/http-events.rules"]))
-factory_stress_pcap.addStep(ShellCommand(command=["sudo", "rm", "-rf", "/usr/local/var/log/suricata/"]))
+    factory_stress_pcap.addStep(ShellCommand(command=["/usr/local/bin/suricata","-r",pfile,"--init-errors-fatal","-S","/data/oisf/rules/http-events.rules"]))
+factory_stress_pcap.addStep(ShellCommand(command=["rm", "-rf", "/usr/local/var/log/suricata/"]))
 
 from buildbot.config import BuilderConfig
 


### PR DESCRIPTION
- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Removed redundant sudo from buildbot.cfg pcaps stage. All commands run as root by default in the docker image. This fixes path issues when compiling 6.0.0-dev with cbindgen




