### PR TITLE
kerberos: fix against packet split in record size

### DIFF
--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -528,7 +528,6 @@ pub extern "C" fn rs_krb5_parse_request_tcp(_flow: *const core::Flow,
                                        input_len: u32,
                                        _data: *const std::os::raw::c_void,
                                        _flags: u8) -> i32 {
-    if input_len < 4 { return -1; }
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,KRB5State);
 
@@ -556,6 +555,10 @@ pub extern "C" fn rs_krb5_parse_request_tcp(_flow: *const core::Flow,
                     state.record_ts = record as usize;
                     cur_i = rem;
                 },
+                Err(nom::Err::Incomplete(_)) => {
+                    state.defrag_buf_ts.extend_from_slice(cur_i);
+                    return 0;
+                }
                 _ => {
                     SCLogDebug!("rs_krb5_parse_request_tcp: reading record mark failed!");
                     return 1;
@@ -586,7 +589,6 @@ pub extern "C" fn rs_krb5_parse_response_tcp(_flow: *const core::Flow,
                                        input_len: u32,
                                        _data: *const std::os::raw::c_void,
                                        _flags: u8) -> i32 {
-    if input_len < 4 { return -1; }
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,KRB5State);
 
@@ -614,6 +616,10 @@ pub extern "C" fn rs_krb5_parse_response_tcp(_flow: *const core::Flow,
                     state.record_tc = record as usize;
                     cur_i = rem;
                 },
+                Err(nom::Err::Incomplete(_)) => {
+                    state.defrag_buf_tc.extend_from_slice(cur_i);
+                    return 0;
+                }
                 _ => {
                     SCLogNotice!("rs_krb5_parse_response_tcp: reading record mark failed!");
                     return 1;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Fixes kerberos TCP parser against packet split evasion

Problem happens if the split happens in the middle of a record size
Another problems happens if the buffer size is less than 4

Problem found while running suricata-verify tests against Suricata compiled with this patch
```
diff --git a/src/app-layer.c b/src/app-layer.c
index b614f2712..0149d6b4f 100644
--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -658,8 +658,15 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
          * a start msg should have gotten us one */
         if (f->alproto != ALPROTO_UNKNOWN) {
             PACKET_PROFILING_APP_START(app_tctx, f->alproto);
+#ifndef LOLSPLIT
+            for (size_t i = 0; i < data_len; i++) {
+                r = AppLayerParserParse(tv, app_tctx->alp_tctx, f, f->alproto,
+                                        flags, data+i, 1);
+            }
+#else
             r = AppLayerParserParse(tv, app_tctx->alp_tctx, f, f->alproto,
                                     flags, data, data_len);
+#endif
             PACKET_PROFILING_APP_END(app_tctx, f->alproto);
             if (r >= 0) {
                 (*stream)->app_progress_rel += data_len;
```