### PR TITLE
output-json: add MAC addresses to EVE-JSON logs - v1

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -14,6 +14,9 @@ where all these logs go into a single file.
 Each alert, http log, etc will go into this one file: 'eve.json'. This file
 can then be processed by 3rd party tools like Logstash (ELK) or jq.
 
+If ``log-ethernet`` is set to yes, then ethernet headers will be added to events
+if available.
+
 Output types
 ~~~~~~~~~~~~
 
@@ -30,6 +33,7 @@ Output types::
       #facility: local5
       #level: Info ## possible levels: Emergency, Alert, Critical,
                    ## Error, Warning, Notice, Info, Debug
+      #log-ethernet: yes  # log ethernet header in events when available
       #redis:
       #  server: 127.0.0.1
       #  port: 6379

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -472,6 +472,7 @@ util-lua-ja3.c util-lua-ja3.h \
 util-lua-tls.c util-lua-tls.h \
 util-lua-ssh.c util-lua-ssh.h \
 util-lua-smtp.c util-lua-smtp.h \
+util-macset.c util-macset.h \
 util-magic.c util-magic.h \
 util-memcmp.c util-memcmp.h \
 util-memcpy.h \

--- a/src/detect-engine-profile.c
+++ b/src/detect-engine-profile.c
@@ -59,7 +59,7 @@ SCMutex g_rule_dump_write_m = SCMUTEX_INITIALIZER;
 void RulesDumpMatchArray(const DetectEngineThreadCtx *det_ctx,
         const SigGroupHead *sgh, const Packet *p)
 {
-    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "inspectedrules");
+    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "inspectedrules", 0);
     if (js == NULL)
         return;
     json_t *ir = json_object();

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -201,6 +201,12 @@ void FlowInit(Flow *f, const Packet *p)
 
     f->protomap = FlowGetProtoMapping(f->proto);
 
+    if (f->macset != NULL) {
+        MacSetReset(f->macset);
+    } else {
+        f->macset = MacSetInit(10);
+    }
+
     SCReturn;
 }
 

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -73,6 +73,7 @@
         (f)->hprev = NULL; \
         (f)->lnext = NULL; \
         (f)->lprev = NULL; \
+        (f)->macset = NULL; \
         RESET_COUNTERS((f)); \
     } while (0)
 
@@ -115,6 +116,7 @@
         (f)->sgh_toclient = NULL; \
         GenericVarFree((f)->flowvar); \
         (f)->flowvar = NULL; \
+        MacSetReset((f)->macset); \
         RESET_COUNTERS((f)); \
     } while(0)
 
@@ -125,6 +127,7 @@
         \
         FLOWLOCK_DESTROY((f)); \
         GenericVarFree((f)->flowvar); \
+        MacSetFree((f)->macset); \
     } while(0)
 
 /** \brief check if a memory alloc would fit in the memcap

--- a/src/flow.c
+++ b/src/flow.c
@@ -452,6 +452,10 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p)
             f->flags &= ~FLOW_PROTO_DETECT_TS_DONE;
             p->flags |= PKT_PROTO_DETECT_TS_DONE;
         }
+        if (f->macset != NULL && p->ethh != NULL) {
+            MacSetAdd(f->macset, p->ethh->eth_dst, TOSERVER);
+            MacSetAdd(f->macset, p->ethh->eth_src, TOCLIENT);
+        }
     } else {
         f->tosrcpktcnt++;
         f->tosrcbytecnt += GET_PKT_LEN(p);
@@ -466,6 +470,10 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p)
         if (f->flags & FLOW_PROTO_DETECT_TC_DONE) {
             f->flags &= ~FLOW_PROTO_DETECT_TC_DONE;
             p->flags |= PKT_PROTO_DETECT_TC_DONE;
+        }
+        if (f->macset != NULL && p->ethh != NULL) {
+            MacSetAdd(f->macset, p->ethh->eth_dst, TOCLIENT);
+            MacSetAdd(f->macset, p->ethh->eth_src, TOSERVER);
         }
     }
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -29,6 +29,7 @@
 #include "util-atomic.h"
 #include "util-device.h"
 #include "detect-tag.h"
+#include "util-macset.h"
 #include "util-optimize.h"
 
 /* Part of the flow structure, so we declare it here.
@@ -475,6 +476,8 @@ typedef struct Flow_
     uint32_t tosrcpktcnt;
     uint64_t todstbytecnt;
     uint64_t tosrcbytecnt;
+
+    MacSet *macset;
 } Flow;
 
 enum FlowState {

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -170,7 +170,7 @@ static void OutputFilestoreFinalizeFiles(ThreadVars *tv,
                 "Failed to write file info record. Output filename truncated.");
         } else {
             json_t *js_fileinfo = JsonBuildFileInfoRecord(p, ff, true, dir,
-                    ctx->xff_cfg);
+                    ctx->xff_cfg, 0);
             if (likely(js_fileinfo != NULL)) {
                 json_dump_file(js_fileinfo, js_metadata_filename, 0);
                 json_decref(js_fileinfo);

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -401,7 +401,8 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
     if (p->alerts.cnt == 0 && !(p->flags & PKT_HAS_TAG))
         return TM_ECODE_OK;
 
-    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "alert");
+    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "alert",
+                                  json_output_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 
@@ -602,7 +603,8 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
     if ((p->flags & PKT_HAS_TAG) && (json_output_ctx->flags &
             LOG_JSON_TAGGED_PACKETS)) {
         MemBufferReset(aft->json_buffer);
-        json_t *packetjs = CreateJSONHeader(p, LOG_DIR_PACKET, "packet");
+        json_t *packetjs = CreateJSONHeader(p, LOG_DIR_PACKET, "packet",
+                                            json_output_ctx->file_ctx->options_flags);
         if (unlikely(packetjs != NULL)) {
             JsonPacket(p, packetjs, 0);
             OutputJSONBuffer(packetjs, aft->file_ctx, &aft->json_buffer);

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -105,7 +105,7 @@ static int AnomalyDecodeEventJson(ThreadVars *tv, JsonAnomalyLogThread *aft,
 
         MemBufferReset(aft->json_buffer);
 
-        json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, ANOMALY_EVENT_TYPE);
+        json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, ANOMALY_EVENT_TYPE, aft->json_output_ctx->file_ctx->options_flags);
 
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
@@ -166,9 +166,11 @@ static int AnomalyAppLayerDecoderEventJson(JsonAnomalyLogThread *aft,
         json_t *js;
         if (tx_id != TX_ID_UNUSED) {
             js = CreateJSONHeaderWithTxId(p, LOG_DIR_PACKET,
-                                          ANOMALY_EVENT_TYPE, tx_id);
+                                          ANOMALY_EVENT_TYPE,
+                                          aft->json_output_ctx->file_ctx->options_flags, tx_id);
         } else {
-            js = CreateJSONHeader(p, LOG_DIR_PACKET, ANOMALY_EVENT_TYPE);
+            js = CreateJSONHeader(p, LOG_DIR_PACKET, ANOMALY_EVENT_TYPE,
+                                  aft->json_output_ctx->file_ctx->options_flags);
         }
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -65,7 +65,8 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
     LogDHCPLogThread *thread = thread_data;
     LogDHCPFileCtx *ctx = thread->dhcplog_ctx;
 
-    json_t *js = CreateJSONHeader((Packet *)p, 0, "dhcp");
+    json_t *js = CreateJSONHeader((Packet *)p, 0, "dhcp",
+                                  thread->dhcplog_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -309,7 +309,7 @@ static int JsonDNP3LoggerToServer(ThreadVars *tv, void *thread_data,
 
     MemBufferReset(buffer);
     if (tx->has_request && tx->request_done) {
-        json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "dnp3");
+        json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "dnp3", thread->dnp3log_ctx->file_ctx->options_flags);
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
         }
@@ -338,7 +338,7 @@ static int JsonDNP3LoggerToClient(ThreadVars *tv, void *thread_data,
 
     MemBufferReset(buffer);
     if (tx->has_response && tx->response_done) {
-        json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "dnp3");
+        json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "dnp3", thread->dnp3log_ctx->file_ctx->options_flags);
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
         }

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -308,7 +308,7 @@ static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
     }
 
     for (uint16_t i = 0; i < 0xffff; i++) {
-        js = CreateJSONHeader(p, LOG_DIR_FLOW, "dns");
+        js = CreateJSONHeader(p, LOG_DIR_FLOW, "dns", dnslog_ctx->file_ctx->options_flags);
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
         }
@@ -340,7 +340,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
         return TM_ECODE_OK;
     }
 
-    json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "dns");
+    json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "dns", dnslog_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -87,7 +87,8 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
 {
     JsonDropOutputCtx *drop_ctx = aft->drop_ctx;
 
-    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "drop");
+    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "drop",
+                                  aft->drop_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -81,7 +81,8 @@ typedef struct JsonFileLogThread_ {
 } JsonFileLogThread;
 
 json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
-        const bool stored, uint8_t dir, HttpXFFCfg *xff_cfg)
+        const bool stored, uint8_t dir, HttpXFFCfg *xff_cfg,
+        uint8_t flags)
 {
     json_t *hjs = NULL;
     enum OutputJsonLogDirection fdir = LOG_DIR_FLOW;
@@ -98,7 +99,7 @@ json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
             break;
     }
 
-    json_t *js = CreateJSONHeader(p, fdir, "fileinfo");
+    json_t *js = CreateJSONHeader(p, fdir, "fileinfo", flags);
     if (unlikely(js == NULL))
         return NULL;
 
@@ -258,7 +259,8 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p,
     HttpXFFCfg *xff_cfg = aft->filelog_ctx->xff_cfg != NULL ?
         aft->filelog_ctx->xff_cfg : aft->filelog_ctx->parent_xff_cfg;;
     json_t *js = JsonBuildFileInfoRecord(p, ff,
-            ff->flags & FILE_STORED ? true : false, dir, xff_cfg);
+            ff->flags & FILE_STORED ? true : false, dir, xff_cfg,
+            aft->filelog_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL)) {
         return;
     }

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -159,7 +159,7 @@ static int JsonFTPLogger(ThreadVars *tv, void *thread_data,
     LogFTPLogThread *thread = thread_data;
     LogFTPFileCtx *ftp_ctx = thread->ftplog_ctx;
 
-    json_t *js = CreateJSONHeaderWithTxId(p, LOG_DIR_FLOW, event_type, tx_id);
+    json_t *js = CreateJSONHeaderWithTxId(p, LOG_DIR_FLOW, event_type, thread->ftplog_ctx->file_ctx->options_flags, tx_id);
     if (likely(js)) {
         JsonAddCommonOptions(&ftp_ctx->cfg, p, f, js);
         json_t *cjs = NULL;

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -517,7 +517,8 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     htp_tx_t *tx = txptr;
     JsonHttpLogThread *jhl = (JsonHttpLogThread *)thread_data;
 
-    json_t *js = CreateJSONHeaderWithTxId(p, LOG_DIR_FLOW, "http", tx_id);
+    json_t *js = CreateJSONHeaderWithTxId(p, LOG_DIR_FLOW, "http", 
+                                          jhl->httplog_ctx->file_ctx->options_flags, tx_id);
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 

--- a/src/output-json-ikev2.c
+++ b/src/output-json-ikev2.c
@@ -66,7 +66,8 @@ static int JsonIKEv2Logger(ThreadVars *tv, void *thread_data,
     LogIKEv2LogThread *thread = thread_data;
     json_t *js, *ikev2js;
 
-    js = CreateJSONHeader((Packet *)p, LOG_DIR_PACKET, "ikev2");
+    js = CreateJSONHeader((Packet *)p, LOG_DIR_PACKET, "ikev2",
+                          thread->ikev2log_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-krb5.c
+++ b/src/output-json-krb5.c
@@ -66,7 +66,8 @@ static int JsonKRB5Logger(ThreadVars *tv, void *thread_data,
     LogKRB5LogThread *thread = thread_data;
     json_t *js, *krb5js;
 
-    js = CreateJSONHeader(p, LOG_DIR_PACKET, "krb5");
+    js = CreateJSONHeader(p, LOG_DIR_PACKET, "krb5",
+                          thread->krb5log_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-metadata.c
+++ b/src/output-json-metadata.c
@@ -81,7 +81,8 @@ typedef struct JsonMetadataLogThread_ {
 
 static int MetadataJson(ThreadVars *tv, JsonMetadataLogThread *aft, const Packet *p)
 {
-    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "metadata");
+    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "metadata",
+                                  aft->file_ctx->options_flags);
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 

--- a/src/output-json-nfs.c
+++ b/src/output-json-nfs.c
@@ -83,7 +83,8 @@ static int JsonNFSLogger(ThreadVars *tv, void *thread_data,
     if (rs_nfs_tx_logging_is_filtered(state, nfstx))
         return TM_ECODE_OK;
 
-    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "nfs");
+    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "nfs",
+                                  thread->ctx->file_ctx->options_flags);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-rdp.c
+++ b/src/output-json-rdp.c
@@ -59,7 +59,8 @@ static int JsonRdpLogger(ThreadVars *tv, void *thread_data,
 {
     LogRdpLogThread *thread = thread_data;
 
-    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "rdp");
+    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "rdp",
+                                  thread->rdplog_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-sip.c
+++ b/src/output-json-sip.c
@@ -79,7 +79,8 @@ static int JsonSIPLogger(ThreadVars *tv, void *thread_data,
     LogSIPLogThread *thread = thread_data;
     json_t *js, *sipjs;
 
-    js = CreateJSONHeader(p, LOG_DIR_PACKET, "sip");
+    js = CreateJSONHeader(p, LOG_DIR_PACKET, "sip",
+                          thread->siplog_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-smb.c
+++ b/src/output-json-smb.c
@@ -66,7 +66,8 @@ static int JsonSMBLogger(ThreadVars *tv, void *thread_data,
     OutputJsonThreadCtx *thread = thread_data;
     json_t *js, *smbjs;
 
-    js = CreateJSONHeader(p, LOG_DIR_FLOW, "smb");
+    js = CreateJSONHeader(p, LOG_DIR_FLOW, "smb",
+                          thread->ctx->file_ctx->options_flags);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -86,7 +86,8 @@ static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     SCEnter();
     JsonEmailLogThread *jhl = (JsonEmailLogThread *)thread_data;
 
-    json_t *js = CreateJSONHeaderWithTxId(p, LOG_DIR_FLOW, "smtp", tx_id);
+    json_t *js = CreateJSONHeaderWithTxId(p, LOG_DIR_FLOW, "smtp",
+                                          jhl->emaillog_ctx->file_ctx->options_flags, tx_id);
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 

--- a/src/output-json-snmp.c
+++ b/src/output-json-snmp.c
@@ -66,7 +66,8 @@ static int JsonSNMPLogger(ThreadVars *tv, void *thread_data,
     LogSNMPLogThread *thread = thread_data;
     json_t *js, *snmpjs;
 
-    js = CreateJSONHeader(p, LOG_DIR_PACKET, "snmp");
+    js = CreateJSONHeader(p, LOG_DIR_PACKET, "snmp",
+                          thread->snmplog_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -103,7 +103,8 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         ssh_state->srv_hdr.software_version == NULL)
         return 0;
 
-    json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "ssh");
+    json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "ssh",
+                                  ssh_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL))
         return 0;
 

--- a/src/output-json-template-rust.c
+++ b/src/output-json-template-rust.c
@@ -71,7 +71,8 @@ static int JsonTemplateLogger(ThreadVars *tv, void *thread_data,
     SCLogNotice("JsonTemplateLogger");
     LogTemplateLogThread *thread = thread_data;
 
-    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "template-rust");
+    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "template-rust",
+                                  thread->templatelog_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-template.c
+++ b/src/output-json-template.c
@@ -72,7 +72,8 @@ static int JsonTemplateLogger(ThreadVars *tv, void *thread_data,
 
     SCLogNotice("Logging template transaction %"PRIu64".", templatetx->tx_id);
 
-    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "template");
+    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "template",
+                                  thread->templatelog_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-tftp.c
+++ b/src/output-json-tftp.c
@@ -66,7 +66,8 @@ static int JsonTFTPLogger(ThreadVars *tv, void *thread_data,
 {
     LogTFTPLogThread *thread = thread_data;
 
-    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "tftp");
+    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "tftp",
+                                 thread->tftplog_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -411,7 +411,8 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         return 0;
     }
 
-    json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "tls");
+    json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "tls",
+                                  tls_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL)) {
         return 0;
     }

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -56,9 +56,9 @@ void JsonTcpFlags(uint8_t flags, json_t *js);
 void JsonPacket(const Packet *p, json_t *js, unsigned long max_length);
 void JsonFiveTuple(const Packet *, enum OutputJsonLogDirection, json_t *);
 json_t *CreateJSONHeader(const Packet *p,
-        enum OutputJsonLogDirection dir, const char *event_type);
+        enum OutputJsonLogDirection dir, const char *event_type, uint8_t options_flags);
 json_t *CreateJSONHeaderWithTxId(const Packet *p,
-        enum OutputJsonLogDirection dir, const char *event_type, uint64_t tx_id);
+        enum OutputJsonLogDirection dir, const char *event_type, uint8_t options_flags, uint64_t tx_id);
 int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer);
 OutputInitResult OutputJsonInitCtx(ConfNode *);
 

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -112,8 +112,11 @@ typedef struct LogFileCtx_ {
     /* flags to set when sending over a socket */
     uint8_t send_flags;
 
+    /* flag to store the options */
+    uint8_t options_flags; /* coccinelle: LogFileCtx:option_flags:LOGFILE_LOG */
+
     /* Flag if file is a regular file or not.  Only regular files
-     * allow for rotataion. */
+     * allow for rotation. */
     uint8_t is_regular;
 
     /* JSON flags */
@@ -140,6 +143,8 @@ typedef struct LogFileCtx_ {
 #define LOGFILE_HEADER_WRITTEN  0x01
 #define LOGFILE_ALERTS_PRINTED  0x02
 #define LOGFILE_ROTATE_INTERVAL 0x04
+
+#define LOGFILE_LOG_ETHERNET    BIT_U8(0)
 
 LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);

--- a/src/util-macset.c
+++ b/src/util-macset.c
@@ -1,0 +1,120 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Sascha Steinbiss <sascha.steinbiss@dcso.de>
+ *
+ * Set-like data store for MAC addresses. Implemented as array for memory
+ * locality reasons as the expected number of items is typically low.
+ *
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+#include "util-macset.h"
+
+typedef uint8_t MacAddr[6];
+
+struct MacSet_ {
+    MacAddr *buf[2];
+    unsigned long size[2],
+                  last[2];
+};
+
+MacSet* MacSetInit(int size)
+{
+    MacSet *ms = SCCalloc(1, sizeof(*ms));
+    if (unlikely(ms == NULL)) {
+        FatalError(SC_ERR_MEM_ALLOC, "Unable to allocate MacSet memory.");
+    }
+    ms->buf[TOSERVER] = SCCalloc(size, sizeof(MacAddr));
+    if (unlikely(ms->buf[TOSERVER] == NULL)) {
+        FatalError(SC_ERR_MEM_ALLOC, "Unable to allocate MacSet memory.");
+    }
+    ms->buf[TOCLIENT] = SCCalloc(size, sizeof(MacAddr));
+    if (unlikely(ms->buf[TOCLIENT] == NULL)) {
+        FatalError(SC_ERR_MEM_ALLOC, "Unable to allocate MacSet memory.");
+    }
+    ms->size[TOSERVER] = ms->size[TOCLIENT] = size;
+    ms->last[TOSERVER] = ms->last[TOCLIENT] = 0;
+    return ms;
+}
+
+int MacSetAdd(MacSet *ms, uint8_t *addr, int direction)
+{
+    unsigned long i = 0;
+    if (ms == NULL)
+        return 0;
+    if (unlikely(ms->last[direction] == ms->size[direction])) {
+        /* MacSet full */
+        return 0;
+    }
+    if (ms->last[direction] > 0) {
+        for (i = ms->last[direction]-1; i < ms->size[direction]; i--) {
+            uint8_t *addr2 = (uint8_t*) ((ms->buf[direction])+i);
+            if (likely(memcmp(addr2, addr, sizeof(MacAddr)) == 0)) {
+                return 0;
+            }
+        }
+    }
+    memcpy(ms->buf[direction]+(ms->last[direction]++), addr, sizeof(MacAddr));
+    return 0;
+}
+
+int MacSetForEach(MacSet *ms, MacSetIteratorFunc func, void *data)
+{
+    unsigned long i = 0;
+    if (ms == NULL)
+        return 0;
+    for (i = 0; i < ms->last[TOSERVER]; i++) {
+        int ret = func((uint8_t*) ms->buf[TOSERVER][i], TOSERVER, data);
+        if (unlikely(ret != 0)) {
+            return ret;
+        }
+    }
+    for (i = 0; i < ms->last[TOCLIENT]; i++) {
+        int ret = func((uint8_t*) ms->buf[TOCLIENT][i], TOCLIENT, data);
+        if (unlikely(ret != 0)) {
+            return ret;
+        }
+    }
+    return 0;
+}
+
+unsigned long MacSetSize(MacSet *ms) {
+    if (ms == NULL)
+        return 0;
+    return ms->last[TOCLIENT] + ms->last[TOSERVER];
+}
+
+void MacSetReset(MacSet *ms) {
+    if (ms == NULL)
+        return;
+    ms->last[TOCLIENT] = 0;
+    ms->last[TOSERVER] = 0;
+}
+
+void MacSetFree(MacSet *ms)
+{
+    if (ms == NULL)
+        return;
+    SCFree(ms->buf[TOSERVER]);
+    SCFree(ms->buf[TOCLIENT]);
+    SCFree(ms);
+}

--- a/src/util-macset.h
+++ b/src/util-macset.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -18,17 +18,23 @@
 /**
  * \file
  *
- * \author Tom DeCanio <td@npulsetech.com>
+ * \author Sascha Steinbiss <sascha.steinbiss@dcso.de>
  */
 
-#ifndef __OUTPUT_JSON_FILE_H__
-#define __OUTPUT_JSON_FILE_H__
+#ifndef __MACSET_H__
+#define __MACSET_H__
 
-#include "app-layer-htp-xff.h"
+#include <stdint.h>
 
-void JsonFileLogRegister(void);
-json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
-        const bool stored, uint8_t dir, HttpXFFCfg *xff_cfg,
-        uint8_t options_flags);
+typedef struct MacSet_ MacSet;
 
-#endif /* __OUTPUT_JSON_FILE_H__ */
+typedef int (*MacSetIteratorFunc)(uint8_t *addr, int direction, void*);
+
+MacSet*       MacSetInit(int size);
+int           MacSetAdd(MacSet*, uint8_t *addr, int direction);
+int           MacSetForEach(MacSet*, MacSetIteratorFunc, void*);
+unsigned long MacSetSize(MacSet*);
+void          MacSetReset(MacSet*);
+void          MacSetFree(MacSet*);
+
+#endif /* __MACSET_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -89,6 +89,7 @@ outputs:
       #facility: local5
       #level: Info ## possible levels: Emergency, Alert, Critical,
                    ## Error, Warning, Notice, Info, Debug
+      #log-ethernet: yes  # log ethernet header in events when available
       #redis:
       #  server: 127.0.0.1
       #  port: 6379
@@ -104,6 +105,7 @@ outputs:
       #  pipelining:
       #    enabled: yes ## set enable to yes to enable query pipelining
       #    batch-size: 10 ## number of entry to keep in buffer
+      
 
       # Include top level metadata. Default yes.
       #metadata: no


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
[#962](https://redmine.openinfosecfoundation.org/issues/962)

Describe changes:
- Introduce a set-like data store for MAC addresses. It is implemented as an array for better memory locality, with _O_(|set size|) time for the add operation, but since we expect MACs to be predominantly static I assume the overhead will be negligible. Set stores are reset efficiently as flows are recycled, so heap allocations are minimized as far as possible. I understand this code is in a hot path, so I'd be happy to do improvements if required.
- Add MAC addresses to JSON output in `ether` sub-object if enabled. We follow the remarks made in the Redmine ticket: for packets, log MAC src/dst as a scalar field in EVE; for flows, log MAC src/dst as lists in EVE. Field names are different to avoid type confusion (`src_mac` vs. `src_macs`). Configuration approach and JSON representation is taken from previous PR #2700.

Example of packet-based with MAC information:
```json
{
  "timestamp": "2016-09-12T11:26:11.907594+0200",
  "flow_id": 736835809808681,
  "ether": {
    "type": 2048,
    "src_mac": "00:17:88:24:76:ff",
    "dst_mac": "38:0b:40:ef:85:41"
  },
  "pcap_cnt": 125,
  "event_type": "http",
  "src_ip": "10.10.10.30",
  "src_port": 45045,
  "dest_ip": "10.10.10.6",
  "dest_port": 80,
  "proto": "TCP",
  "tx_id": 0,
  "http": {
    "hostname": "10.10.10.6",
    "url": "/api/1d7a2f22157658516ebbad4748c9f43/sensors/new",
    "http_user_agent": "Dalvik/2.1.0 (Linux; U; Android 5.1.1; SM-N7505 Build/LMY47X)",
    "http_content_type": "application/json",
    "http_method": "GET",
    "protocol": "HTTP/1.1",
    "status": 200,
    "length": 22
  }
}
```
Flow-based JSON:
```json
{
  "timestamp": "2016-05-23T18:02:32.582547+0200",
  "flow_id": 844411863633275,
  "ether": {
    "src_macs": [
      "00:17:88:24:76:ff"
    ],
    "dst_macs": [
      "38:0b:40:ef:85:41"
    ]
  },
  "event_type": "flow",
  "src_ip": "10.10.10.30",
  "src_port": 60162,
  "dest_ip": "10.10.10.6",
  "dest_port": 80,
  "proto": "TCP",
  "app_proto": "http",
  "flow": {
    "pkts_toserver": 6,
    "pkts_toclient": 5,
    "bytes_toserver": 605,
    "bytes_toclient": 1210,
    "start": "2016-09-12T11:28:13.134523+0200",
    "end": "2016-09-12T11:28:13.152103+0200",
    "age": 0,
    "state": "closed",
    "reason": "shutdown",
    "alerted": false
  },
  "tcp": {
    "tcp_flags": "1b",
    "tcp_flags_ts": "1b",
    "tcp_flags_tc": "1b",
    "syn": true,
    "fin": true,
    "psh": true,
    "ack": true,
    "state": "closed"
  }
}
```

The intention of this PR is primarily to get feedback on and discuss the overall approach. Can add suricata-verify pcaps I made with Scapy to test cases with multiple MACs per flow later.