### PR TITLE
output-json: add MAC addresses to EVE-JSON logs - v3

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -14,6 +14,9 @@ where all these logs go into a single file.
 Each alert, http log, etc will go into this one file: 'eve.json'. This file
 can then be processed by 3rd party tools like Logstash (ELK) or jq.
 
+If ``ethernet`` is set to yes, then ethernet headers will be added to events
+if available.
+
 Output types
 ~~~~~~~~~~~~
 
@@ -30,6 +33,7 @@ Output types::
       #facility: local5
       #level: Info ## possible levels: Emergency, Alert, Critical,
                    ## Error, Warning, Notice, Info, Debug
+      #ethernet: yes  # log ethernet header in events when available
       #redis:
       #  server: 127.0.0.1
       #  port: 6379

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -472,6 +472,7 @@ util-lua-ja3.c util-lua-ja3.h \
 util-lua-tls.c util-lua-tls.h \
 util-lua-ssh.c util-lua-ssh.h \
 util-lua-smtp.c util-lua-smtp.h \
+util-macset.c util-macset.h \
 util-magic.c util-magic.h \
 util-memcmp.c util-memcmp.h \
 util-memcpy.h \

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -201,6 +201,12 @@ void FlowInit(Flow *f, const Packet *p)
 
     f->protomap = FlowGetProtoMapping(f->proto);
 
+    if (f->macset != NULL) {
+        MacSetReset(f->macset);
+    } else {
+        f->macset = MacSetInit(10);
+    }
+
     SCReturn;
 }
 

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -73,6 +73,7 @@
         (f)->hprev = NULL; \
         (f)->lnext = NULL; \
         (f)->lprev = NULL; \
+        (f)->macset = NULL; \
         RESET_COUNTERS((f)); \
     } while (0)
 
@@ -115,6 +116,7 @@
         (f)->sgh_toclient = NULL; \
         GenericVarFree((f)->flowvar); \
         (f)->flowvar = NULL; \
+        MacSetReset((f)->macset); \
         RESET_COUNTERS((f)); \
     } while(0)
 
@@ -125,6 +127,7 @@
         \
         FLOWLOCK_DESTROY((f)); \
         GenericVarFree((f)->flowvar); \
+        MacSetFree((f)->macset); \
     } while(0)
 
 /** \brief check if a memory alloc would fit in the memcap

--- a/src/flow.c
+++ b/src/flow.c
@@ -452,6 +452,10 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p)
             f->flags &= ~FLOW_PROTO_DETECT_TS_DONE;
             p->flags |= PKT_PROTO_DETECT_TS_DONE;
         }
+        if (f->macset != NULL && p->ethh != NULL) {
+            MacSetAdd(f->macset, p->ethh->eth_dst, TOSERVER);
+            MacSetAdd(f->macset, p->ethh->eth_src, TOCLIENT);
+        }
     } else {
         f->tosrcpktcnt++;
         f->tosrcbytecnt += GET_PKT_LEN(p);
@@ -466,6 +470,10 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p)
         if (f->flags & FLOW_PROTO_DETECT_TC_DONE) {
             f->flags &= ~FLOW_PROTO_DETECT_TC_DONE;
             p->flags |= PKT_PROTO_DETECT_TC_DONE;
+        }
+        if (f->macset != NULL && p->ethh != NULL) {
+            MacSetAdd(f->macset, p->ethh->eth_dst, TOCLIENT);
+            MacSetAdd(f->macset, p->ethh->eth_src, TOSERVER);
         }
     }
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -29,6 +29,7 @@
 #include "util-atomic.h"
 #include "util-device.h"
 #include "detect-tag.h"
+#include "util-macset.h"
 #include "util-optimize.h"
 
 /* Part of the flow structure, so we declare it here.
@@ -475,6 +476,8 @@ typedef struct Flow_
     uint32_t tosrcpktcnt;
     uint64_t todstbytecnt;
     uint64_t tosrcbytecnt;
+
+    MacSet *macset;
 } Flow;
 
 enum FlowState {

--- a/src/output-json-smb.c
+++ b/src/output-json-smb.c
@@ -71,6 +71,8 @@ static int JsonSMBLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
+    JsonAddCommonOptions(&thread->ctx->cfg, p, f, js);
+
     smbjs = rs_smb_log_json_response(state, tx);
     if (unlikely(smbjs == NULL)) {
         goto error;

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -393,6 +393,9 @@ void JsonAddCommonOptions(const OutputJsonCommonSettings *cfg,
     if (cfg->include_metadata) {
         JsonAddMetadata(p, f, js);
     }
+    if (cfg->include_ethernet) {
+        CreateJSONEther(js, p, f);
+    }
     if (cfg->include_community_id && f != NULL) {
         CreateJSONCommunityFlowId(js, f, cfg->community_id_seed);
     }
@@ -705,6 +708,70 @@ void CreateJSONFlowId(json_t *js, const Flow *f)
     if (f->parent_id) {
         json_object_set_new(js, "parent_id", json_integer(f->parent_id));
     }
+}
+
+static inline void JSONFormatAndAddMACAddr(json_t *parent, const char *key,
+                                   uint8_t *val, bool is_array) {
+    char eth_addr[19];
+    (void) snprintf(eth_addr, 19, "%02x:%02x:%02x:%02x:%02x:%02x",
+                    val[0], val[1], val[2], val[3], val[4], val[5]);
+    if (is_array) {
+        json_array_append_new(parent, json_string(eth_addr));
+    } else {
+        json_object_set_new(parent, key, json_string(eth_addr));
+    }
+}
+
+/* only required to traverse the MAC address set */
+typedef struct JSONMACAddrInfo {
+    json_t *src, *dst;
+} JSONMACAddrInfo;
+
+static int JSONFlowAppendMACAddrs(uint8_t *val, int direction, void *data) {
+    JSONMACAddrInfo *info = (JSONMACAddrInfo*) data;
+    if (direction == TOSERVER) {
+        JSONFormatAndAddMACAddr(info->dst, NULL, val, true);
+    } else {
+        JSONFormatAndAddMACAddr(info->src, NULL, val, true);
+    }
+    return 0;
+}
+
+int CreateJSONEther(json_t *parent, const Packet *p, const Flow *f) {
+    json_t *ejs = json_object();
+    if (ejs == NULL)
+        return 0;
+    if (p == NULL) {
+        /* we are creating an ether object in a flow context, so we need to
+           append to arrays */
+        if (f != NULL && f->macset && MacSetSize(f->macset) > 0) {
+            JSONMACAddrInfo info;
+            int ret;
+            info.dst = json_array();
+            info.src = json_array();
+            ret = MacSetForEach(f->macset, JSONFlowAppendMACAddrs, &info);
+            /* should not happen, JSONFlowAppendMACAddrs is sane */
+            if (ret != 0)
+                return ret;
+            json_object_set_new(ejs, "dest_macs", info.dst);
+            json_object_set_new(ejs, "src_macs", info.src);
+        }
+    } else {
+        /* this is a packet context, so we need to add scalar fields */
+        uint8_t *src, *dst;
+        if ((PKT_IS_TOCLIENT(p))) {
+            src = p->ethh->eth_dst;
+            dst = p->ethh->eth_src;
+        } else {
+            src = p->ethh->eth_src;
+            dst = p->ethh->eth_dst;
+        }
+        json_object_set_new(ejs, "type", json_integer(ntohs(p->ethh->eth_type)));
+        JSONFormatAndAddMACAddr(ejs, "src_mac", src, false);
+        JSONFormatAndAddMACAddr(ejs, "dest_mac", dst, false);
+    }
+    json_object_set_new(parent, "ether", ejs);
+    return 0;
 }
 
 json_t *CreateJSONHeader(const Packet *p, enum OutputJsonLogDirection dir,
@@ -1023,6 +1090,15 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
             json_ctx->cfg.include_metadata = true;
         }
 
+        /* Check if ethernet information should be logged. */
+        const ConfNode *ethernet = ConfNodeLookupChild(conf, "ethernet");
+        if (ethernet && ethernet->val && ConfValIsTrue(ethernet->val)) {
+            SCLogConfig("Enabling Ethernet logging.");
+            json_ctx->cfg.include_ethernet = true;
+        } else {
+            json_ctx->cfg.include_ethernet = false;
+        }
+
         /* See if we want to enable the community id */
         const ConfNode *community_id = ConfNodeLookupChild(conf, "community-id");
         if (community_id && community_id->val && ConfValIsTrue(community_id->val)) {
@@ -1061,7 +1137,6 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
 
         json_ctx->file_ctx->type = json_ctx->json_out;
     }
-
 
     SCLogDebug("returning output_ctx %p", output_ctx);
 

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -55,6 +55,7 @@ void CreateJSONFlowId(json_t *js, const Flow *f);
 void JsonTcpFlags(uint8_t flags, json_t *js);
 void JsonPacket(const Packet *p, json_t *js, unsigned long max_length);
 void JsonFiveTuple(const Packet *, enum OutputJsonLogDirection, json_t *);
+int CreateJSONEther(json_t *parent, const Packet *p, const Flow *f);
 json_t *CreateJSONHeader(const Packet *p,
         enum OutputJsonLogDirection dir, const char *event_type);
 json_t *CreateJSONHeaderWithTxId(const Packet *p,
@@ -69,6 +70,7 @@ TmEcode JsonLogThreadDeinit(ThreadVars *t, void *data);
 typedef struct OutputJsonCommonSettings_ {
     bool include_metadata;
     bool include_community_id;
+    bool include_ethernet;
     uint16_t community_id_seed;
 } OutputJsonCommonSettings;
 

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -113,7 +113,7 @@ typedef struct LogFileCtx_ {
     uint8_t send_flags;
 
     /* Flag if file is a regular file or not.  Only regular files
-     * allow for rotataion. */
+     * allow for rotation. */
     uint8_t is_regular;
 
     /* JSON flags */

--- a/src/util-macset.c
+++ b/src/util-macset.c
@@ -1,0 +1,121 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Sascha Steinbiss <sascha.steinbiss@dcso.de>
+ *
+ * Set-like data store for MAC addresses. Implemented as array for memory
+ * locality reasons as the expected number of items is typically low.
+ *
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+#include "util-macset.h"
+
+typedef uint8_t MacAddr[6];
+
+struct MacSet_ {
+    MacAddr *buf[2];
+    unsigned long size,
+                  last[2];
+};
+
+MacSet* MacSetInit(int size)
+{
+    MacSet *ms = SCCalloc(1, sizeof(*ms));
+    if (unlikely(ms == NULL)) {
+        FatalError(SC_ERR_MEM_ALLOC, "Unable to allocate MacSet memory.");
+    }
+    ms->buf[TOSERVER] = SCCalloc(size, sizeof(MacAddr));
+    if (unlikely(ms->buf[TOSERVER] == NULL)) {
+        FatalError(SC_ERR_MEM_ALLOC, "Unable to allocate MacSet memory.");
+    }
+    ms->buf[TOCLIENT] = SCCalloc(size, sizeof(MacAddr));
+    if (unlikely(ms->buf[TOCLIENT] == NULL)) {
+        FatalError(SC_ERR_MEM_ALLOC, "Unable to allocate MacSet memory.");
+    }
+    ms->size = size;
+    ms->last[TOSERVER] = ms->last[TOCLIENT] = 0;
+    return ms;
+}
+
+int MacSetAdd(MacSet *ms, uint8_t *addr, int direction)
+{
+    unsigned long i = 0;
+    if (ms == NULL)
+        return 0;
+    if (unlikely(ms->last[direction] == ms->size)) {
+        /* MacSet full */
+        return 0;
+    }
+    if (ms->last[direction] > 0) {
+        for (i = ms->last[direction]-1; i < ms->size; i--) {
+            uint8_t *addr2 = (uint8_t*) ((ms->buf[direction])+i);
+            if (likely(memcmp(addr2, addr, sizeof(MacAddr)) == 0)) {
+                return 0;
+            }
+        }
+    }
+    memcpy(ms->buf[direction] + ms->last[direction], addr, sizeof(MacAddr));
+    ms->last[direction]++;
+    return 0;
+}
+
+int MacSetForEach(MacSet *ms, MacSetIteratorFunc func, void *data)
+{
+    unsigned long i = 0;
+    if (ms == NULL)
+        return 0;
+    for (i = 0; i < ms->last[TOSERVER]; i++) {
+        int ret = func((uint8_t*) ms->buf[TOSERVER][i], TOSERVER, data);
+        if (unlikely(ret != 0)) {
+            return ret;
+        }
+    }
+    for (i = 0; i < ms->last[TOCLIENT]; i++) {
+        int ret = func((uint8_t*) ms->buf[TOCLIENT][i], TOCLIENT, data);
+        if (unlikely(ret != 0)) {
+            return ret;
+        }
+    }
+    return 0;
+}
+
+unsigned long MacSetSize(MacSet *ms) {
+    if (ms == NULL)
+        return 0;
+    return ms->last[TOCLIENT] + ms->last[TOSERVER];
+}
+
+void MacSetReset(MacSet *ms) {
+    if (ms == NULL)
+        return;
+    ms->last[TOCLIENT] = 0;
+    ms->last[TOSERVER] = 0;
+}
+
+void MacSetFree(MacSet *ms)
+{
+    if (ms == NULL)
+        return;
+    SCFree(ms->buf[TOSERVER]);
+    SCFree(ms->buf[TOCLIENT]);
+    SCFree(ms);
+}

--- a/src/util-macset.h
+++ b/src/util-macset.h
@@ -1,0 +1,40 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Sascha Steinbiss <sascha.steinbiss@dcso.de>
+ */
+
+#ifndef __MACSET_H__
+#define __MACSET_H__
+
+#include <stdint.h>
+
+typedef struct MacSet_ MacSet;
+
+typedef int (*MacSetIteratorFunc)(uint8_t *addr, int direction, void*);
+
+MacSet*       MacSetInit(int size);
+int           MacSetAdd(MacSet*, uint8_t *addr, int direction);
+int           MacSetForEach(MacSet*, MacSetIteratorFunc, void*);
+unsigned long MacSetSize(MacSet*);
+void          MacSetReset(MacSet*);
+void          MacSetFree(MacSet*);
+
+#endif /* __MACSET_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -89,6 +89,7 @@ outputs:
       #facility: local5
       #level: Info ## possible levels: Emergency, Alert, Critical,
                    ## Error, Warning, Notice, Info, Debug
+      #ethernet: yes  # log ethernet header in events when available
       #redis:
       #  server: 127.0.0.1
       #  port: 6379


### PR DESCRIPTION
Previous PR: #4654

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [#962](https://redmine.openinfosecfoundation.org/issues/962)

Describe changes (to previous PR):
- Change `dst_*` JSON keys to `dest_*`.
- Minor whitespace and formatting fixes.
- Clarify name of function to mention MAC addresses (`JSONFormatAndAddMACAddr`).
- Add suricata-verify cases (https://github.com/OISF/suricata-verify/pull/197)