### PR TITLE
fix bug #3523 suricata alert metadata logging

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2308,11 +2308,11 @@ void PreRunInit(const int runmode)
  * but after we dropped privs */
 void PreRunPostPrivsDropInit(const int runmode)
 {
+    RunModeInitializeOutputs();
     if (runmode == RUNMODE_UNIX_SOCKET)
         return;
 
     StatsSetupPostConfigPreOutput();
-    RunModeInitializeOutputs();
     StatsSetupPostConfigPostOutput();
 }
 


### PR DESCRIPTION
This changeset fixes a bug that was preventing suricata to dump
alert metadata info when running in unix socket mode.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ x ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ x ] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ x ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3523

Describe changes:
- Initialization of the output modules done also when suricata is running in unix socket mode. This 
- allows to dump correctly alert metadata info.
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

