### PR TITLE
(RFC) rust: mark extern "C" (ffi) functions as unsafe

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -67,7 +67,7 @@ impl LoggerFlags {
 macro_rules!export_tx_get_detect_state {
     ($name:ident, $type:ty) => (
         #[no_mangle]
-        pub extern "C" fn $name(tx: *mut std::os::raw::c_void)
+        pub unsafe extern "C" fn $name(tx: *mut std::os::raw::c_void)
             -> *mut core::DetectEngineState
         {
             let tx = cast_pointer!(tx, $type);
@@ -88,7 +88,7 @@ macro_rules!export_tx_get_detect_state {
 macro_rules!export_tx_set_detect_state {
     ($name:ident, $type:ty) => (
         #[no_mangle]
-        pub extern "C" fn $name(tx: *mut std::os::raw::c_void,
+        pub unsafe extern "C" fn $name(tx: *mut std::os::raw::c_void,
                 de_state: &mut core::DetectEngineState) -> std::os::raw::c_int
         {
             let tx = cast_pointer!(tx, $type);

--- a/rust/src/applayertemplate/logger.rs
+++ b/rust/src/applayertemplate/logger.rs
@@ -31,7 +31,7 @@ fn log_template(tx: &TemplateTransaction) -> Option<Json> {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_template_logger_log(tx: *mut std::os::raw::c_void) -> *mut JsonT {
+pub unsafe extern "C" fn rs_template_logger_log(tx: *mut std::os::raw::c_void) -> *mut JsonT {
     let tx = cast_pointer!(tx, TemplateTransaction);
     match log_template(tx) {
         Some(js) => js.unwrap(),

--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -254,7 +254,7 @@ export_tx_set_detect_state!(
 
 /// C entry point for a probing parser.
 #[no_mangle]
-pub extern "C" fn rs_template_probing_parser(
+pub unsafe extern "C" fn rs_template_probing_parser(
     _flow: *const Flow,
     _direction: u8,
     input: *const u8,
@@ -285,7 +285,7 @@ pub extern "C" fn rs_template_state_free(state: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_template_state_tx_free(
+pub unsafe extern "C" fn rs_template_state_tx_free(
     state: *mut std::os::raw::c_void,
     tx_id: u64,
 ) {
@@ -294,7 +294,7 @@ pub extern "C" fn rs_template_state_tx_free(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_template_parse_request(
+pub unsafe extern "C" fn rs_template_parse_request(
     _flow: *const Flow,
     state: *mut std::os::raw::c_void,
     pstate: *mut std::os::raw::c_void,
@@ -324,7 +324,7 @@ pub extern "C" fn rs_template_parse_request(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_template_parse_response(
+pub unsafe extern "C" fn rs_template_parse_response(
     _flow: *const Flow,
     state: *mut std::os::raw::c_void,
     pstate: *mut std::os::raw::c_void,
@@ -349,7 +349,7 @@ pub extern "C" fn rs_template_parse_response(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_template_state_get_tx(
+pub unsafe extern "C" fn rs_template_state_get_tx(
     state: *mut std::os::raw::c_void,
     tx_id: u64,
 ) -> *mut std::os::raw::c_void {
@@ -365,7 +365,7 @@ pub extern "C" fn rs_template_state_get_tx(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_template_state_get_tx_count(
+pub unsafe extern "C" fn rs_template_state_get_tx_count(
     state: *mut std::os::raw::c_void,
 ) -> u64 {
     let state = cast_pointer!(state, TemplateState);
@@ -381,7 +381,7 @@ pub extern "C" fn rs_template_state_progress_completion_status(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_template_tx_get_alstate_progress(
+pub unsafe extern "C" fn rs_template_tx_get_alstate_progress(
     tx: *mut std::os::raw::c_void,
     _direction: u8,
 ) -> std::os::raw::c_int {
@@ -395,7 +395,7 @@ pub extern "C" fn rs_template_tx_get_alstate_progress(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_template_tx_get_logged(
+pub unsafe extern "C" fn rs_template_tx_get_logged(
     _state: *mut std::os::raw::c_void,
     tx: *mut std::os::raw::c_void,
 ) -> u32 {
@@ -404,7 +404,7 @@ pub extern "C" fn rs_template_tx_get_logged(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_template_tx_set_logged(
+pub unsafe extern "C" fn rs_template_tx_set_logged(
     _state: *mut std::os::raw::c_void,
     tx: *mut std::os::raw::c_void,
     logged: u32,
@@ -414,7 +414,7 @@ pub extern "C" fn rs_template_tx_set_logged(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_template_state_get_events(
+pub unsafe extern "C" fn rs_template_state_get_events(
     tx: *mut std::os::raw::c_void
 ) -> *mut core::AppLayerDecoderEvents {
     let tx = cast_pointer!(tx, TemplateTransaction);
@@ -438,7 +438,7 @@ pub extern "C" fn rs_template_state_get_event_info_by_id(_event_id: std::os::raw
     return -1;
 }
 #[no_mangle]
-pub extern "C" fn rs_template_state_get_tx_iterator(
+pub unsafe extern "C" fn rs_template_state_get_tx_iterator(
     _ipproto: u8,
     _alproto: AppProto,
     state: *mut std::os::raw::c_void,
@@ -468,7 +468,7 @@ pub extern "C" fn rs_template_state_get_tx_iterator(
 /// No required for parsing, but an example function for retrieving a
 /// pointer to the request buffer from C for detection.
 #[no_mangle]
-pub extern "C" fn rs_template_get_request_buffer(
+pub unsafe extern "C" fn rs_template_get_request_buffer(
     tx: *mut std::os::raw::c_void,
     buf: *mut *const u8,
     len: *mut u32,
@@ -489,7 +489,7 @@ pub extern "C" fn rs_template_get_request_buffer(
 
 /// Get the response buffer for a transaction from C.
 #[no_mangle]
-pub extern "C" fn rs_template_get_response_buffer(
+pub unsafe extern "C" fn rs_template_get_response_buffer(
     tx: *mut std::os::raw::c_void,
     buf: *mut *const u8,
     len: *mut u32,

--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -265,7 +265,7 @@ pub unsafe extern "C" fn rs_template_probing_parser(
     if input_len > 1 && input != std::ptr::null_mut() {
         let slice = build_slice!(input, input_len as usize);
         if probe(slice) {
-            return unsafe { ALPROTO_TEMPLATE };
+            return ALPROTO_TEMPLATE;
         }
     }
     return ALPROTO_UNKNOWN;
@@ -303,7 +303,7 @@ pub unsafe extern "C" fn rs_template_parse_request(
     _data: *const std::os::raw::c_void,
     _flags: u8,
 ) -> i32 {
-    let eof = unsafe {
+    let eof = {
         if AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF) > 0 {
             true
         } else {
@@ -333,7 +333,7 @@ pub unsafe extern "C" fn rs_template_parse_response(
     _data: *const std::os::raw::c_void,
     _flags: u8,
 ) -> i32 {
-    let _eof = unsafe {
+    let _eof = {
         if AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF) > 0 {
             true
         } else {
@@ -356,7 +356,7 @@ pub unsafe extern "C" fn rs_template_state_get_tx(
     let state = cast_pointer!(state, TemplateState);
     match state.get_tx(tx_id) {
         Some(tx) => {
-            return unsafe { transmute(tx) };
+            return transmute(tx);
         }
         None => {
             return std::ptr::null_mut();
@@ -449,7 +449,7 @@ pub unsafe extern "C" fn rs_template_state_get_tx_iterator(
     let state = cast_pointer!(state, TemplateState);
     match state.tx_iterator(min_tx_id, istate) {
         Some((tx, out_tx_id, has_next)) => {
-            let c_tx = unsafe { transmute(tx) };
+            let c_tx = transmute(tx);
             let ires = applayer::AppLayerGetTxIterTuple::with_values(
                 c_tx,
                 out_tx_id,
@@ -477,10 +477,8 @@ pub unsafe extern "C" fn rs_template_get_request_buffer(
     let tx = cast_pointer!(tx, TemplateTransaction);
     if let Some(ref request) = tx.request {
         if request.len() > 0 {
-            unsafe {
-                *len = request.len() as u32;
-                *buf = request.as_ptr();
-            }
+            *len = request.len() as u32;
+            *buf = request.as_ptr();
             return 1;
         }
     }
@@ -498,10 +496,8 @@ pub unsafe extern "C" fn rs_template_get_response_buffer(
     let tx = cast_pointer!(tx, TemplateTransaction);
     if let Some(ref response) = tx.response {
         if response.len() > 0 {
-            unsafe {
-                *len = response.len() as u32;
-                *buf = response.as_ptr();
-            }
+            *len = response.len() as u32;
+            *buf = response.as_ptr();
             return 1;
         }
     }

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -240,7 +240,7 @@ pub unsafe extern "C" fn rs_dhcp_probing_parser(_flow: *const Flow,
     let slice = build_slice!(input, input_len as usize);
     match parse_header(slice) {
         Ok((_, _)) => {
-            return unsafe { ALPROTO_DHCP };
+            return ALPROTO_DHCP;
         }
         _ => {
             return ALPROTO_UNKNOWN;
@@ -268,7 +268,7 @@ pub unsafe extern "C" fn rs_dhcp_state_get_tx(state: *mut std::os::raw::c_void,
     let state = cast_pointer!(state, DHCPState);
     match state.get_tx(tx_id) {
         Some(tx) => {
-            return unsafe { transmute(tx) };
+            return transmute(tx);
         }
         None => {
             return std::ptr::null_mut();
@@ -405,7 +405,7 @@ pub unsafe extern "C" fn rs_dhcp_state_get_tx_iterator(
     let state = cast_pointer!(state, DHCPState);
     match state.get_tx_iterator(min_tx_id, istate) {
         Some((tx, out_tx_id, has_next)) => {
-            let c_tx = unsafe { transmute(tx) };
+            let c_tx = transmute(tx);
             let ires = applayer::AppLayerGetTxIterTuple::with_values(
                 c_tx, out_tx_id, has_next);
             return ires;

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -227,7 +227,7 @@ impl DHCPState {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dhcp_probing_parser(_flow: *const Flow,
+pub unsafe extern "C" fn rs_dhcp_probing_parser(_flow: *const Flow,
                                          _direction: u8,
                                          input: *const u8,
                                          input_len: u32,
@@ -263,7 +263,7 @@ pub extern "C" fn rs_dhcp_state_progress_completion_status(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dhcp_state_get_tx(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_dhcp_state_get_tx(state: *mut std::os::raw::c_void,
                                        tx_id: u64) -> *mut std::os::raw::c_void {
     let state = cast_pointer!(state, DHCPState);
     match state.get_tx(tx_id) {
@@ -277,13 +277,13 @@ pub extern "C" fn rs_dhcp_state_get_tx(state: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dhcp_state_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
+pub unsafe extern "C" fn rs_dhcp_state_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
     let state = cast_pointer!(state, DHCPState);
     return state.tx_id;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dhcp_parse(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_dhcp_parse(_flow: *const core::Flow,
                                 state: *mut std::os::raw::c_void,
                                 _pstate: *mut std::os::raw::c_void,
                                 input: *const u8,
@@ -299,7 +299,7 @@ pub extern "C" fn rs_dhcp_parse(_flow: *const core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dhcp_state_tx_free(
+pub unsafe extern "C" fn rs_dhcp_state_tx_free(
     state: *mut std::os::raw::c_void,
     tx_id: u64)
 {
@@ -323,13 +323,13 @@ pub extern "C" fn rs_dhcp_state_free(state: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dhcp_tx_get_logged(_state: *mut std::os::raw::c_void, tx: *mut std::os::raw::c_void) -> u32 {
+pub unsafe extern "C" fn rs_dhcp_tx_get_logged(_state: *mut std::os::raw::c_void, tx: *mut std::os::raw::c_void) -> u32 {
     let tx = cast_pointer!(tx, DHCPTransaction);
     return tx.logged.get();
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dhcp_tx_set_logged(_state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_dhcp_tx_set_logged(_state: *mut std::os::raw::c_void,
                                         tx: *mut std::os::raw::c_void,
                                         logged: u32) {
     let tx = cast_pointer!(tx, DHCPTransaction);
@@ -357,7 +357,7 @@ pub extern "C" fn rs_dhcp_state_get_event_info_by_id(event_id: std::os::raw::c_i
     }
 }
 #[no_mangle]
-pub extern "C" fn rs_dhcp_state_get_events(tx: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_dhcp_state_get_events(tx: *mut std::os::raw::c_void)
                                            -> *mut core::AppLayerDecoderEvents
 {
     let tx = cast_pointer!(tx, DHCPTransaction);
@@ -393,7 +393,7 @@ pub extern "C" fn rs_dhcp_state_get_event_info(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dhcp_state_get_tx_iterator(
+pub unsafe extern "C" fn rs_dhcp_state_get_tx_iterator(
     _ipproto: u8,
     _alproto: AppProto,
     state: *mut std::os::raw::c_void,

--- a/rust/src/dhcp/logger.rs
+++ b/rust/src/dhcp/logger.rs
@@ -265,7 +265,7 @@ pub extern "C" fn rs_dhcp_logger_free(logger: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dhcp_logger_log(logger: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_dhcp_logger_log(logger: *mut std::os::raw::c_void,
                                      tx: *mut std::os::raw::c_void) -> *mut JsonT {
     let logger = cast_pointer!(logger, DHCPLogger);
     let tx = cast_pointer!(tx, DHCPTransaction);

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -755,7 +755,7 @@ pub extern "C" fn rs_dns_state_get_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_state_get_events(tx: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_dns_state_get_events(tx: *mut std::os::raw::c_void)
                                           -> *mut core::AppLayerDecoderEvents
 {
     let tx = cast_pointer!(tx, DNSTransaction);

--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -77,7 +77,7 @@ named!(pub ftp_pasv_response<u16>,
 
 
 #[no_mangle]
-pub extern "C" fn rs_ftp_active_port(input: *const u8, len: u32) -> u16 {
+pub unsafe extern "C" fn rs_ftp_active_port(input: *const u8, len: u32) -> u16 {
     let buf = build_slice!(input, len as usize);
     match ftp_active_port(buf) {
         Ok((_, dport)) => {
@@ -143,7 +143,7 @@ named!(pub ftp_active_eprt<u16>,
 );
 
 #[no_mangle]
-pub extern "C" fn rs_ftp_active_eprt(input: *const u8, len: u32) -> u16 {
+pub unsafe extern "C" fn rs_ftp_active_eprt(input: *const u8, len: u32) -> u16 {
     let buf = build_slice!(input, len as usize);
     match ftp_active_eprt(buf) {
         Ok((_, dport)) => {

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -488,11 +488,9 @@ pub unsafe extern "C" fn rs_ikev2_parse_response(_flow: *const core::Flow,
     let state = cast_pointer!(state,IKEV2State);
     let res = state.parse(buf, STREAM_TOCLIENT);
     if state.connection_state == IKEV2ConnectionState::ParsingDone {
-        unsafe{
-            AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_INSPECTION |
-                                       APP_LAYER_PARSER_NO_REASSEMBLY |
-                                       APP_LAYER_PARSER_BYPASS_READY)
-        };
+        AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_INSPECTION |
+                                   APP_LAYER_PARSER_NO_REASSEMBLY |
+                                   APP_LAYER_PARSER_BYPASS_READY);
     }
     res
 }
@@ -504,7 +502,7 @@ pub unsafe extern "C" fn rs_ikev2_state_get_tx(state: *mut std::os::raw::c_void,
 {
     let state = cast_pointer!(state,IKEV2State);
     match state.get_tx_by_id(tx_id) {
-        Some(tx) => unsafe{std::mem::transmute(tx)},
+        Some(tx) => std::mem::transmute(tx),
         None     => std::ptr::null_mut(),
     }
 }
@@ -667,22 +665,22 @@ pub unsafe extern "C" fn rs_ikev2_probing_parser(_flow: *const Flow,
         _rdir: *mut u8) -> AppProto
 {
     let slice = build_slice!(input,input_len as usize);
-    let alproto = unsafe{ ALPROTO_IKEV2 };
+    let alproto = ALPROTO_IKEV2;
     match parse_ikev2_header(slice) {
         Ok((_, ref hdr)) => {
             if hdr.maj_ver != 2 || hdr.min_ver != 0 {
                 SCLogDebug!("ipsec_probe: could be ipsec, but with unsupported/invalid version {}.{}",
                         hdr.maj_ver, hdr.min_ver);
-                return unsafe{ALPROTO_FAILED};
+                return ALPROTO_FAILED;
             }
             if hdr.exch_type.0 < 34 || hdr.exch_type.0 > 37 {
                 SCLogDebug!("ipsec_probe: could be ipsec, but with unsupported/invalid exchange type {}",
                        hdr.exch_type.0);
-                return unsafe{ALPROTO_FAILED};
+                return ALPROTO_FAILED;
             }
             if hdr.length as usize != slice.len() {
                 SCLogDebug!("ipsec_probe: could be ipsec, but length does not match");
-                return unsafe{ALPROTO_FAILED};
+                return ALPROTO_FAILED;
             }
             return alproto;
         },
@@ -690,7 +688,7 @@ pub unsafe extern "C" fn rs_ikev2_probing_parser(_flow: *const Flow,
             return ALPROTO_UNKNOWN;
         },
         Err(_) => {
-            return unsafe{ALPROTO_FAILED};
+            return ALPROTO_FAILED;
         },
     }
 }

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -464,7 +464,7 @@ pub extern "C" fn rs_ikev2_state_free(state: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ikev2_parse_request(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_ikev2_parse_request(_flow: *const core::Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        input: *const u8,
@@ -477,7 +477,7 @@ pub extern "C" fn rs_ikev2_parse_request(_flow: *const core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ikev2_parse_response(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_ikev2_parse_response(_flow: *const core::Flow,
                                        state: *mut std::os::raw::c_void,
                                        pstate: *mut std::os::raw::c_void,
                                        input: *const u8,
@@ -498,7 +498,7 @@ pub extern "C" fn rs_ikev2_parse_response(_flow: *const core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ikev2_state_get_tx(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_ikev2_state_get_tx(state: *mut std::os::raw::c_void,
                                       tx_id: u64)
                                       -> *mut std::os::raw::c_void
 {
@@ -510,7 +510,7 @@ pub extern "C" fn rs_ikev2_state_get_tx(state: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ikev2_state_get_tx_count(state: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_ikev2_state_get_tx_count(state: *mut std::os::raw::c_void)
                                             -> u64
 {
     let state = cast_pointer!(state,IKEV2State);
@@ -518,7 +518,7 @@ pub extern "C" fn rs_ikev2_state_get_tx_count(state: *mut std::os::raw::c_void)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ikev2_state_tx_free(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_ikev2_state_tx_free(state: *mut std::os::raw::c_void,
                                        tx_id: u64)
 {
     let state = cast_pointer!(state,IKEV2State);
@@ -546,7 +546,7 @@ pub extern "C" fn rs_ikev2_tx_get_alstate_progress(_tx: *mut std::os::raw::c_voi
 
 
 #[no_mangle]
-pub extern "C" fn rs_ikev2_tx_set_logged(_state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_ikev2_tx_set_logged(_state: *mut std::os::raw::c_void,
                                        tx: *mut std::os::raw::c_void,
                                        logged: u32)
 {
@@ -555,7 +555,7 @@ pub extern "C" fn rs_ikev2_tx_set_logged(_state: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ikev2_tx_get_logged(_state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_ikev2_tx_get_logged(_state: *mut std::os::raw::c_void,
                                        tx: *mut std::os::raw::c_void)
                                        -> u32
 {
@@ -565,7 +565,7 @@ pub extern "C" fn rs_ikev2_tx_get_logged(_state: *mut std::os::raw::c_void,
 
 
 #[no_mangle]
-pub extern "C" fn rs_ikev2_state_set_tx_detect_state(
+pub unsafe extern "C" fn rs_ikev2_state_set_tx_detect_state(
     tx: *mut std::os::raw::c_void,
     de_state: &mut core::DetectEngineState) -> std::os::raw::c_int
 {
@@ -575,7 +575,7 @@ pub extern "C" fn rs_ikev2_state_set_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ikev2_state_get_tx_detect_state(
+pub unsafe extern "C" fn rs_ikev2_state_get_tx_detect_state(
     tx: *mut std::os::raw::c_void)
     -> *mut core::DetectEngineState
 {
@@ -588,7 +588,7 @@ pub extern "C" fn rs_ikev2_state_get_tx_detect_state(
 
 
 #[no_mangle]
-pub extern "C" fn rs_ikev2_state_get_events(tx: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_ikev2_state_get_events(tx: *mut std::os::raw::c_void)
                                           -> *mut core::AppLayerDecoderEvents
 {
     let tx = cast_pointer!(tx, IKEV2Transaction);
@@ -661,7 +661,7 @@ pub extern "C" fn rs_ikev2_state_get_event_info(event_name: *const std::os::raw:
 static mut ALPROTO_IKEV2 : AppProto = ALPROTO_UNKNOWN;
 
 #[no_mangle]
-pub extern "C" fn rs_ikev2_probing_parser(_flow: *const Flow,
+pub unsafe extern "C" fn rs_ikev2_probing_parser(_flow: *const Flow,
         _direction: u8,
         input:*const u8, input_len: u32,
         _rdir: *mut u8) -> AppProto

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -293,7 +293,7 @@ pub extern "C" fn rs_krb5_state_free(state: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_state_get_tx(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_krb5_state_get_tx(state: *mut std::os::raw::c_void,
                                       tx_id: u64)
                                       -> *mut std::os::raw::c_void
 {
@@ -305,7 +305,7 @@ pub extern "C" fn rs_krb5_state_get_tx(state: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_state_get_tx_count(state: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_krb5_state_get_tx_count(state: *mut std::os::raw::c_void)
                                             -> u64
 {
     let state = cast_pointer!(state,KRB5State);
@@ -313,7 +313,7 @@ pub extern "C" fn rs_krb5_state_get_tx_count(state: *mut std::os::raw::c_void)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_state_tx_free(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_krb5_state_tx_free(state: *mut std::os::raw::c_void,
                                        tx_id: u64)
 {
     let state = cast_pointer!(state,KRB5State);
@@ -337,7 +337,7 @@ pub extern "C" fn rs_krb5_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_tx_set_logged(_state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_krb5_tx_set_logged(_state: *mut std::os::raw::c_void,
                                        tx: *mut std::os::raw::c_void,
                                        logged: u32)
 {
@@ -346,7 +346,7 @@ pub extern "C" fn rs_krb5_tx_set_logged(_state: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_tx_get_logged(_state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_krb5_tx_get_logged(_state: *mut std::os::raw::c_void,
                                        tx: *mut std::os::raw::c_void)
                                        -> u32
 {
@@ -356,7 +356,7 @@ pub extern "C" fn rs_krb5_tx_get_logged(_state: *mut std::os::raw::c_void,
 
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_state_set_tx_detect_state(
+pub unsafe extern "C" fn rs_krb5_state_set_tx_detect_state(
     tx: *mut std::os::raw::c_void,
     de_state: &mut core::DetectEngineState) -> std::os::raw::c_int
 {
@@ -366,7 +366,7 @@ pub extern "C" fn rs_krb5_state_set_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_state_get_tx_detect_state(
+pub unsafe extern "C" fn rs_krb5_state_get_tx_detect_state(
     tx: *mut std::os::raw::c_void)
     -> *mut core::DetectEngineState
 {
@@ -399,7 +399,7 @@ pub extern "C" fn rs_krb5_state_get_event_info_by_id(event_id: std::os::raw::c_i
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_state_get_events(tx: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_krb5_state_get_events(tx: *mut std::os::raw::c_void)
                                           -> *mut core::AppLayerDecoderEvents
 {
     let tx = cast_pointer!(tx, KRB5Transaction);
@@ -433,7 +433,7 @@ pub extern "C" fn rs_krb5_state_get_event_info(event_name: *const std::os::raw::
 static mut ALPROTO_KRB5 : AppProto = ALPROTO_UNKNOWN;
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_probing_parser(_flow: *const Flow,
+pub unsafe extern "C" fn rs_krb5_probing_parser(_flow: *const Flow,
         _direction: u8,
         input:*const u8, input_len: u32,
         _rdir: *mut u8) -> AppProto
@@ -471,7 +471,7 @@ pub extern "C" fn rs_krb5_probing_parser(_flow: *const Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_probing_parser_tcp(_flow: *const Flow,
+pub unsafe extern "C" fn rs_krb5_probing_parser_tcp(_flow: *const Flow,
         direction: u8,
         input:*const u8, input_len: u32,
         rdir: *mut u8) -> AppProto
@@ -495,7 +495,7 @@ pub extern "C" fn rs_krb5_probing_parser_tcp(_flow: *const Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_parse_request(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_krb5_parse_request(_flow: *const core::Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        input: *const u8,
@@ -508,7 +508,7 @@ pub extern "C" fn rs_krb5_parse_request(_flow: *const core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_parse_response(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_krb5_parse_response(_flow: *const core::Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        input: *const u8,
@@ -521,7 +521,7 @@ pub extern "C" fn rs_krb5_parse_response(_flow: *const core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_parse_request_tcp(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_krb5_parse_request_tcp(_flow: *const core::Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        input: *const u8,
@@ -579,7 +579,7 @@ pub extern "C" fn rs_krb5_parse_request_tcp(_flow: *const core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_parse_response_tcp(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_krb5_parse_response_tcp(_flow: *const core::Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        input: *const u8,

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -299,7 +299,7 @@ pub unsafe extern "C" fn rs_krb5_state_get_tx(state: *mut std::os::raw::c_void,
 {
     let state = cast_pointer!(state,KRB5State);
     match state.get_tx_by_id(tx_id) {
-        Some(tx) => unsafe{std::mem::transmute(tx)},
+        Some(tx) => std::mem::transmute(tx),
         None     => std::ptr::null_mut(),
     }
 }
@@ -439,16 +439,16 @@ pub unsafe extern "C" fn rs_krb5_probing_parser(_flow: *const Flow,
         _rdir: *mut u8) -> AppProto
 {
     let slice = build_slice!(input,input_len as usize);
-    let alproto = unsafe{ ALPROTO_KRB5 };
-    if slice.len() <= 10 { return unsafe{ALPROTO_FAILED}; }
+    let alproto = ALPROTO_KRB5;
+    if slice.len() <= 10 { return ALPROTO_FAILED; }
     match der_read_element_header(slice) {
         Ok((rem, ref hdr)) => {
             // Kerberos messages start with an APPLICATION header
-            if hdr.class != 0b01 { return unsafe{ALPROTO_FAILED}; }
+            if hdr.class != 0b01 { return ALPROTO_FAILED; }
             // Tag number should be <= 30
-            if hdr.tag.0 >= 30 { return unsafe{ALPROTO_FAILED}; }
+            if hdr.tag.0 >= 30 { return ALPROTO_FAILED; }
             // Kerberos messages contain sequences
-            if rem.is_empty() || rem[0] != 0x30 { return unsafe{ALPROTO_FAILED}; }
+            if rem.is_empty() || rem[0] != 0x30 { return ALPROTO_FAILED; }
             // Check kerberos version
             if let Ok((rem,_hdr)) = der_read_element_header(rem) {
                 if rem.len() > 5 {
@@ -459,13 +459,13 @@ pub unsafe extern "C" fn rs_krb5_probing_parser(_flow: *const Flow,
                     }
                 }
             }
-            return unsafe{ALPROTO_FAILED};
+            return ALPROTO_FAILED;
         },
         Err(nom::Err::Incomplete(_)) => {
             return ALPROTO_UNKNOWN;
         },
         Err(_) => {
-            return unsafe{ALPROTO_FAILED};
+            return ALPROTO_FAILED;
         },
     }
 }
@@ -477,11 +477,11 @@ pub unsafe extern "C" fn rs_krb5_probing_parser_tcp(_flow: *const Flow,
         rdir: *mut u8) -> AppProto
 {
     let slice = build_slice!(input,input_len as usize);
-    if slice.len() <= 14 { return unsafe{ALPROTO_FAILED}; }
+    if slice.len() <= 14 { return ALPROTO_FAILED; }
     match be_u32(slice) as IResult<&[u8],u32> {
         Ok((rem, record_mark)) => {
             // protocol implementations forbid very large requests
-            if record_mark > 16384 { return unsafe{ALPROTO_FAILED}; }
+            if record_mark > 16384 { return ALPROTO_FAILED; }
             return rs_krb5_probing_parser(_flow, direction,
                     rem.as_ptr(), rem.len() as u32, rdir);
         },
@@ -489,7 +489,7 @@ pub unsafe extern "C" fn rs_krb5_probing_parser_tcp(_flow: *const Flow,
             return ALPROTO_UNKNOWN;
         },
         Err(_) => {
-            return unsafe{ALPROTO_FAILED};
+            return ALPROTO_FAILED;
         },
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -17,6 +17,13 @@
 
 #![cfg_attr(feature = "strict", deny(warnings))]
 
+// Clippy lints we want to suppress due to style, or simply too noisy
+// and not a priority right now.
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::needless_return)]
+#![allow(clippy::redundant_field_names)]
+#![allow(clippy::len_zero)]
+
 #[macro_use]
 extern crate nom;
 

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -1697,7 +1697,7 @@ pub extern "C" fn rs_nfs_tx_get_detect_flags(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_get_events(tx: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_nfs_state_get_events(tx: *mut std::os::raw::c_void)
                                           -> *mut AppLayerDecoderEvents
 {
     let tx = cast_pointer!(tx, NFSTransaction);
@@ -1916,7 +1916,7 @@ pub fn nfs_probe_udp(i: &[u8], direction: u8) -> i8 {
 
 /// MIDSTREAM
 #[no_mangle]
-pub extern "C" fn rs_nfs_probe_ms(
+pub unsafe extern "C" fn rs_nfs_probe_ms(
         direction: u8, input: *const u8,
         len: u32, rdir: *mut u8) -> i8
 {
@@ -1950,7 +1950,7 @@ pub extern "C" fn rs_nfs_probe_ms(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_probe(direction: u8,
+pub unsafe extern "C" fn rs_nfs_probe(direction: u8,
         input: *const u8, len: u32)
     -> i8
 {
@@ -1961,7 +1961,7 @@ pub extern "C" fn rs_nfs_probe(direction: u8,
 
 /// TOSERVER probe function
 #[no_mangle]
-pub extern "C" fn rs_nfs_probe_udp_ts(input: *const u8, len: u32)
+pub unsafe extern "C" fn rs_nfs_probe_udp_ts(input: *const u8, len: u32)
                                -> i8
 {
     let slice: &[u8] = build_slice!(input, len as usize);
@@ -1970,7 +1970,7 @@ pub extern "C" fn rs_nfs_probe_udp_ts(input: *const u8, len: u32)
 
 /// TOCLIENT probe function
 #[no_mangle]
-pub extern "C" fn rs_nfs_probe_udp_tc(input: *const u8, len: u32)
+pub unsafe extern "C" fn rs_nfs_probe_udp_tc(input: *const u8, len: u32)
                                -> i8
 {
     let slice: &[u8] = build_slice!(input, len as usize);

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -1934,7 +1934,7 @@ pub unsafe extern "C" fn rs_nfs_probe_ms(
             if r == 1 {
                 SCLogDebug!("nfs_probe success: dir {:02x} adir {:02x}", direction, adirection);
                 if (direction & (STREAM_TOSERVER|STREAM_TOCLIENT)) != adirection {
-                    unsafe { *rdir = adirection; }
+                    *rdir = adirection;
                 }
                 return 1;
             }

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -231,7 +231,7 @@ pub unsafe extern "C" fn rs_ntp_state_get_tx(state: *mut std::os::raw::c_void,
 {
     let state = cast_pointer!(state,NTPState);
     match state.get_tx_by_id(tx_id) {
-        Some(tx) => unsafe{std::mem::transmute(tx)},
+        Some(tx) => std::mem::transmute(tx),
         None     => std::ptr::null_mut(),
     }
 }

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -199,7 +199,7 @@ pub extern "C" fn rs_ntp_state_free(state: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_parse_request(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_ntp_parse_request(_flow: *const core::Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        input: *const u8,
@@ -212,7 +212,7 @@ pub extern "C" fn rs_ntp_parse_request(_flow: *const core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_parse_response(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_ntp_parse_response(_flow: *const core::Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        input: *const u8,
@@ -225,7 +225,7 @@ pub extern "C" fn rs_ntp_parse_response(_flow: *const core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_state_get_tx(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_ntp_state_get_tx(state: *mut std::os::raw::c_void,
                                       tx_id: u64)
                                       -> *mut std::os::raw::c_void
 {
@@ -237,7 +237,7 @@ pub extern "C" fn rs_ntp_state_get_tx(state: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_state_get_tx_count(state: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_ntp_state_get_tx_count(state: *mut std::os::raw::c_void)
                                             -> u64
 {
     let state = cast_pointer!(state,NTPState);
@@ -245,7 +245,7 @@ pub extern "C" fn rs_ntp_state_get_tx_count(state: *mut std::os::raw::c_void)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_state_tx_free(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_ntp_state_tx_free(state: *mut std::os::raw::c_void,
                                        tx_id: u64)
 {
     let state = cast_pointer!(state,NTPState);
@@ -290,7 +290,7 @@ pub extern "C" fn rs_ntp_tx_get_logged(_state: &mut NTPState,
 
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_state_set_tx_detect_state(
+pub unsafe extern "C" fn rs_ntp_state_set_tx_detect_state(
     tx: *mut std::os::raw::c_void,
     de_state: &mut core::DetectEngineState) -> std::os::raw::c_int
 {
@@ -300,7 +300,7 @@ pub extern "C" fn rs_ntp_state_set_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_state_get_tx_detect_state(
+pub unsafe extern "C" fn rs_ntp_state_get_tx_detect_state(
     tx: *mut std::os::raw::c_void)
     -> *mut core::DetectEngineState
 {
@@ -335,7 +335,7 @@ pub extern "C" fn rs_ntp_state_get_event_info_by_id(event_id: std::os::raw::c_in
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_state_get_events(tx: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_ntp_state_get_events(tx: *mut std::os::raw::c_void)
                                           -> *mut core::AppLayerDecoderEvents
 {
     let tx = cast_pointer!(tx, NTPTransaction);

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -116,7 +116,7 @@ pub struct RustParser {
 /// UNSAFE !
 #[macro_export]
 macro_rules! build_slice {
-    ($buf:ident, $len:expr) => ( unsafe{ std::slice::from_raw_parts($buf, $len) } );
+    ($buf:ident, $len:expr) => ( { std::slice::from_raw_parts($buf, $len) } );
 }
 
 /// Cast pointer to a variable, as a mutable reference to an object
@@ -124,37 +124,37 @@ macro_rules! build_slice {
 /// UNSAFE !
 #[macro_export]
 macro_rules! cast_pointer {
-    ($ptr:ident, $ty:ty) => ( unsafe{ &mut *($ptr as *mut $ty) } );
+    ($ptr:ident, $ty:ty) => ( { &mut *($ptr as *mut $ty) } );
 }
 
-pub type ParseFn      = extern "C" fn (flow: *const Flow,
+pub type ParseFn      = unsafe extern "C" fn (flow: *const Flow,
                                        state: *mut c_void,
                                        pstate: *mut c_void,
                                        input: *const u8,
                                        input_len: u32,
                                        data: *const c_void,
                                        flags: u8) -> i32;
-pub type ProbeFn      = extern "C" fn (flow: *const Flow,direction: u8,input:*const u8, input_len: u32, rdir: *mut u8) -> AppProto;
+pub type ProbeFn      = unsafe extern "C" fn (flow: *const Flow,direction: u8,input:*const u8, input_len: u32, rdir: *mut u8) -> AppProto;
 pub type StateAllocFn = extern "C" fn () -> *mut c_void;
 pub type StateFreeFn  = extern "C" fn (*mut c_void);
-pub type StateTxFreeFn  = extern "C" fn (*mut c_void, u64);
-pub type StateGetTxFn            = extern "C" fn (*mut c_void, u64) -> *mut c_void;
-pub type StateGetTxCntFn         = extern "C" fn (*mut c_void) -> u64;
+pub type StateTxFreeFn  = unsafe extern "C" fn (*mut c_void, u64);
+pub type StateGetTxFn            = unsafe extern "C" fn (*mut c_void, u64) -> *mut c_void;
+pub type StateGetTxCntFn         = unsafe extern "C" fn (*mut c_void) -> u64;
 pub type StateGetTxCompletionStatusFn = extern "C" fn (u8) -> c_int;
-pub type StateGetProgressFn = extern "C" fn (*mut c_void, u8) -> c_int;
-pub type GetDetectStateFn   = extern "C" fn (*mut c_void) -> *mut DetectEngineState;
-pub type SetDetectStateFn   = extern "C" fn (*mut c_void, &mut DetectEngineState) -> c_int;
+pub type StateGetProgressFn = unsafe extern "C" fn (*mut c_void, u8) -> c_int;
+pub type GetDetectStateFn   = unsafe extern "C" fn (*mut c_void) -> *mut DetectEngineState;
+pub type SetDetectStateFn   = unsafe extern "C" fn (*mut c_void, &mut DetectEngineState) -> c_int;
 pub type GetEventInfoFn     = extern "C" fn (*const c_char, *mut c_int, *mut AppLayerEventType) -> c_int;
 pub type GetEventInfoByIdFn = extern "C" fn (c_int, *mut *const c_char, *mut AppLayerEventType) -> i8;
-pub type GetEventsFn        = extern "C" fn (*mut c_void) -> *mut AppLayerDecoderEvents;
-pub type GetTxLoggedFn      = extern "C" fn (*mut c_void, *mut c_void) -> u32;
-pub type SetTxLoggedFn      = extern "C" fn (*mut c_void, *mut c_void, u32);
+pub type GetEventsFn        = unsafe extern "C" fn (*mut c_void) -> *mut AppLayerDecoderEvents;
+pub type GetTxLoggedFn      = unsafe extern "C" fn (*mut c_void, *mut c_void) -> u32;
+pub type SetTxLoggedFn      = unsafe extern "C" fn (*mut c_void, *mut c_void, u32);
 pub type LocalStorageNewFn  = extern "C" fn () -> *mut c_void;
 pub type LocalStorageFreeFn = extern "C" fn (*mut c_void);
 pub type GetTxMpmIDFn       = extern "C" fn (*mut c_void) -> u64;
 pub type SetTxMpmIDFn       = extern "C" fn (*mut c_void, u64) -> c_int;
 pub type GetFilesFn         = extern "C" fn (*mut c_void, u8) -> *mut FileContainer;
-pub type GetTxIteratorFn    = extern "C" fn (ipproto: u8, alproto: AppProto,
+pub type GetTxIteratorFn    = unsafe extern "C" fn (ipproto: u8, alproto: AppProto,
                                              state: *mut c_void,
                                              min_tx_id: u64,
                                              max_tx_id: u64,
@@ -181,7 +181,7 @@ pub const APP_LAYER_PARSER_NO_REASSEMBLY : u8 = 0b10;
 pub const APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD : u8 = 0b100;
 pub const APP_LAYER_PARSER_BYPASS_READY : u8 = 0b1000;
 
-pub type AppLayerGetTxIteratorFn = extern "C" fn (ipproto: u8,
+pub type AppLayerGetTxIteratorFn = unsafe extern "C" fn (ipproto: u8,
                                                   alproto: AppProto,
                                                   alstate: *mut c_void,
                                                   min_tx_id: u64,

--- a/rust/src/rdp/log.rs
+++ b/rust/src/rdp/log.rs
@@ -25,7 +25,7 @@ use std;
 use x509_parser::parse_x509_der;
 
 #[no_mangle]
-pub extern "C" fn rs_rdp_to_json(tx: *mut std::os::raw::c_void) -> *mut JsonT {
+pub unsafe extern "C" fn rs_rdp_to_json(tx: *mut std::os::raw::c_void) -> *mut JsonT {
     let tx = cast_pointer!(tx, RdpTransaction);
     match to_json(tx) {
         Some(js) => js.unwrap(),

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -90,7 +90,7 @@ pub unsafe extern "C" fn rs_rdp_state_get_tx(
     let state = cast_pointer!(state, RdpState);
     match state.get_tx(tx_id) {
         Some(tx) => {
-            return unsafe { transmute(tx) };
+            return transmute(tx);
         }
         None => {
             return std::ptr::null_mut();

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -83,7 +83,7 @@ impl Drop for RdpTransaction {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rdp_state_get_tx(
+pub unsafe extern "C" fn rs_rdp_state_get_tx(
     state: *mut std::os::raw::c_void,
     tx_id: u64,
 ) -> *mut std::os::raw::c_void {
@@ -99,7 +99,7 @@ pub extern "C" fn rs_rdp_state_get_tx(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rdp_state_get_tx_count(
+pub unsafe extern "C" fn rs_rdp_state_get_tx_count(
     state: *mut std::os::raw::c_void,
 ) -> u64 {
     let state = cast_pointer!(state, RdpState);
@@ -396,7 +396,7 @@ pub extern "C" fn rs_rdp_state_free(state: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rdp_state_tx_free(
+pub unsafe extern "C" fn rs_rdp_state_tx_free(
     state: *mut std::os::raw::c_void,
     tx_id: u64,
 ) {
@@ -422,7 +422,7 @@ fn probe_rdp(input: &[u8]) -> bool {
 
 /// probe for T.123 message, whether to client or to server
 #[no_mangle]
-pub extern "C" fn rs_rdp_probe_ts_tc(
+pub unsafe extern "C" fn rs_rdp_probe_ts_tc(
     _flow: *const Flow,
     _direction: u8,
     input: *const u8,
@@ -437,7 +437,7 @@ pub extern "C" fn rs_rdp_probe_ts_tc(
         // https://wiki.wireshark.org/SampleCaptures?action=AttachFile&do=view&target=rdp-ssl.pcap.gz
         // but this callback will not be exercised, so `probe_tls_handshake` not needed here.
         if probe_rdp(slice) {
-            return unsafe { ALPROTO_RDP };
+            return ALPROTO_RDP;
         }
     }
     return ALPROTO_UNKNOWN;
@@ -453,7 +453,7 @@ fn probe_tls_handshake(input: &[u8]) -> bool {
 //
 
 #[no_mangle]
-pub extern "C" fn rs_rdp_parse_ts(
+pub unsafe extern "C" fn rs_rdp_parse_ts(
     _flow: *const Flow,
     state: *mut std::os::raw::c_void,
     _pstate: *mut std::os::raw::c_void,
@@ -473,7 +473,7 @@ pub extern "C" fn rs_rdp_parse_ts(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rdp_parse_tc(
+pub unsafe extern "C" fn rs_rdp_parse_tc(
     _flow: *const Flow,
     state: *mut std::os::raw::c_void,
     _pstate: *mut std::os::raw::c_void,

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -191,7 +191,7 @@ pub unsafe extern "C" fn rs_sip_state_get_tx(
 ) -> *mut std::os::raw::c_void {
     let state = cast_pointer!(state, SIPState);
     match state.get_tx_by_id(tx_id) {
-        Some(tx) => unsafe { std::mem::transmute(tx) },
+        Some(tx) => std::mem::transmute(tx),
         None => std::ptr::null_mut(),
     }
 }
@@ -329,7 +329,7 @@ pub unsafe extern "C" fn rs_sip_probing_parser_ts(
 ) -> AppProto {
     let buf = build_slice!(input, input_len as usize);
     if sip_parse_request(buf).is_ok() {
-        return unsafe { ALPROTO_SIP };
+        return ALPROTO_SIP;
     }
     return ALPROTO_UNKNOWN;
 }
@@ -344,7 +344,7 @@ pub unsafe extern "C" fn rs_sip_probing_parser_tc(
 ) -> AppProto {
     let buf = build_slice!(input, input_len as usize);
     if sip_parse_response(buf).is_ok() {
-        return unsafe { ALPROTO_SIP };
+        return ALPROTO_SIP;
     }
     return ALPROTO_UNKNOWN;
 }

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -185,7 +185,7 @@ pub extern "C" fn rs_sip_state_free(state: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_state_get_tx(
+pub unsafe extern "C" fn rs_sip_state_get_tx(
     state: *mut std::os::raw::c_void,
     tx_id: u64,
 ) -> *mut std::os::raw::c_void {
@@ -197,13 +197,13 @@ pub extern "C" fn rs_sip_state_get_tx(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_state_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
+pub unsafe extern "C" fn rs_sip_state_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
     let state = cast_pointer!(state, SIPState);
     state.tx_id
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_state_tx_free(state: *mut std::os::raw::c_void, tx_id: u64) {
+pub unsafe extern "C" fn rs_sip_state_tx_free(state: *mut std::os::raw::c_void, tx_id: u64) {
     let state = cast_pointer!(state, SIPState);
     state.free_tx(tx_id);
 }
@@ -222,7 +222,7 @@ pub extern "C" fn rs_sip_tx_get_alstate_progress(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_tx_set_logged(
+pub unsafe extern "C" fn rs_sip_tx_set_logged(
     _state: *mut std::os::raw::c_void,
     tx: *mut std::os::raw::c_void,
     logged: u32,
@@ -232,7 +232,7 @@ pub extern "C" fn rs_sip_tx_set_logged(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_tx_get_logged(
+pub unsafe extern "C" fn rs_sip_tx_get_logged(
     _state: *mut std::os::raw::c_void,
     tx: *mut std::os::raw::c_void,
 ) -> u32 {
@@ -241,7 +241,7 @@ pub extern "C" fn rs_sip_tx_get_logged(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_state_set_tx_detect_state(
+pub unsafe extern "C" fn rs_sip_state_set_tx_detect_state(
     tx: *mut std::os::raw::c_void,
     de_state: &mut core::DetectEngineState,
 ) -> std::os::raw::c_int {
@@ -251,7 +251,7 @@ pub extern "C" fn rs_sip_state_set_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_state_get_tx_detect_state(
+pub unsafe extern "C" fn rs_sip_state_get_tx_detect_state(
     tx: *mut std::os::raw::c_void,
 ) -> *mut core::DetectEngineState {
     let tx = cast_pointer!(tx, SIPTransaction);
@@ -262,7 +262,7 @@ pub extern "C" fn rs_sip_state_get_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_state_get_events(
+pub unsafe extern "C" fn rs_sip_state_get_events(
     tx: *mut std::os::raw::c_void,
 ) -> *mut core::AppLayerDecoderEvents {
     let tx = cast_pointer!(tx, SIPTransaction);
@@ -320,7 +320,7 @@ pub extern "C" fn rs_sip_state_get_event_info_by_id(
 static mut ALPROTO_SIP: AppProto = ALPROTO_UNKNOWN;
 
 #[no_mangle]
-pub extern "C" fn rs_sip_probing_parser_ts(
+pub unsafe extern "C" fn rs_sip_probing_parser_ts(
     _flow: *const Flow,
     _direction: u8,
     input: *const u8,
@@ -335,7 +335,7 @@ pub extern "C" fn rs_sip_probing_parser_ts(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_probing_parser_tc(
+pub unsafe extern "C" fn rs_sip_probing_parser_tc(
     _flow: *const Flow,
     _direction: u8,
     input: *const u8,
@@ -350,7 +350,7 @@ pub extern "C" fn rs_sip_probing_parser_tc(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_parse_request(
+pub unsafe extern "C" fn rs_sip_parse_request(
     _flow: *const core::Flow,
     state: *mut std::os::raw::c_void,
     _pstate: *mut std::os::raw::c_void,
@@ -369,7 +369,7 @@ pub extern "C" fn rs_sip_parse_request(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_parse_response(
+pub unsafe extern "C" fn rs_sip_parse_response(
     _flow: *const core::Flow,
     state: *mut std::os::raw::c_void,
     _pstate: *mut std::os::raw::c_void,

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1908,7 +1908,7 @@ pub extern "C" fn rs_smb_parse_response_tcp_gap(
 // probing parser
 // return 1 if found, 0 is not found
 #[no_mangle]
-pub extern "C" fn rs_smb_probe_tcp(direction: u8,
+pub unsafe extern "C" fn rs_smb_probe_tcp(direction: u8,
         input: *const u8, len: u32,
         rdir: *mut u8)
     -> i8
@@ -2142,7 +2142,7 @@ pub extern "C" fn rs_smb_state_truncate(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_state_get_events(tx: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_smb_state_get_events(tx: *mut std::os::raw::c_void)
                                           -> *mut AppLayerDecoderEvents
 {
     let tx = cast_pointer!(tx, SMBTransaction);

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1927,12 +1927,12 @@ pub unsafe extern "C" fn rs_smb_probe_tcp(direction: u8,
                                 if smb_record.flags & 0x80 != 0 {
                                     SCLogDebug!("RESPONSE {:02x}", smb_record.flags);
                                     if direction & STREAM_TOSERVER != 0 {
-                                        unsafe { *rdir = STREAM_TOCLIENT; }
+                                        *rdir = STREAM_TOCLIENT;
                                     }
                                 } else {
                                     SCLogDebug!("REQUEST {:02x}", smb_record.flags);
                                     if direction & STREAM_TOCLIENT != 0 {
-                                        unsafe { *rdir = STREAM_TOSERVER; }
+                                        *rdir = STREAM_TOSERVER;
                                     }
                                 }
                                 return 1;
@@ -1946,12 +1946,12 @@ pub unsafe extern "C" fn rs_smb_probe_tcp(direction: u8,
                                 if direction & STREAM_TOSERVER != 0 {
                                     SCLogDebug!("direction STREAM_TOSERVER smb_record {:?}", smb_record);
                                     if !smb_record.request {
-                                        unsafe { *rdir = STREAM_TOCLIENT; }
+                                        *rdir = STREAM_TOCLIENT;
                                     }
                                 } else {
                                     SCLogDebug!("direction STREAM_TOCLIENT smb_record {:?}", smb_record);
                                     if smb_record.request {
-                                        unsafe { *rdir = STREAM_TOSERVER; }
+                                        *rdir = STREAM_TOSERVER;
                                     }
                                 }
                             },

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -349,7 +349,7 @@ pub unsafe extern "C" fn rs_snmp_state_get_tx(state: *mut std::os::raw::c_void,
 {
     let state = cast_pointer!(state,SNMPState);
     match state.get_tx_by_id(tx_id) {
-        Some(tx) => unsafe{std::mem::transmute(tx)},
+        Some(tx) => std::mem::transmute(tx),
         None     => std::ptr::null_mut(),
     }
 }
@@ -520,7 +520,7 @@ pub unsafe extern "C" fn rs_snmp_get_tx_iterator(_ipproto: u8,
     let state = cast_pointer!(alstate,SNMPState);
     match state.get_tx_iterator(min_tx_id, istate) {
         Some((tx, out_tx_id, has_next)) => {
-            let c_tx = unsafe { transmute(tx) };
+            let c_tx = transmute(tx);
             let ires = applayer::AppLayerGetTxIterTuple::with_values(c_tx, out_tx_id, has_next);
             return ires;
         }
@@ -567,12 +567,12 @@ pub unsafe extern "C" fn rs_snmp_probing_parser(_flow: *const Flow,
                                          input_len: u32,
                                          _rdir: *mut u8) -> AppProto {
     let slice = build_slice!(input,input_len as usize);
-    let alproto = unsafe{ ALPROTO_SNMP };
-    if slice.len() < 4 { return unsafe{ALPROTO_FAILED}; }
+    let alproto = ALPROTO_SNMP;
+    if slice.len() < 4 { return ALPROTO_FAILED; }
     match parse_pdu_enveloppe_version(slice) {
         Ok((_,_))                    => alproto,
         Err(nom::Err::Incomplete(_)) => ALPROTO_UNKNOWN,
-        _                            => unsafe{ALPROTO_FAILED},
+        _                            => ALPROTO_FAILED,
     }
 }
 

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -317,7 +317,7 @@ pub extern "C" fn rs_snmp_state_free(state: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_parse_request(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_snmp_parse_request(_flow: *const core::Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        input: *const u8,
@@ -330,7 +330,7 @@ pub extern "C" fn rs_snmp_parse_request(_flow: *const core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_parse_response(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_snmp_parse_response(_flow: *const core::Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        input: *const u8,
@@ -343,7 +343,7 @@ pub extern "C" fn rs_snmp_parse_response(_flow: *const core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_state_get_tx(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_snmp_state_get_tx(state: *mut std::os::raw::c_void,
                                       tx_id: u64)
                                       -> *mut std::os::raw::c_void
 {
@@ -355,7 +355,7 @@ pub extern "C" fn rs_snmp_state_get_tx(state: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_state_get_tx_count(state: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_snmp_state_get_tx_count(state: *mut std::os::raw::c_void)
                                             -> u64
 {
     let state = cast_pointer!(state,SNMPState);
@@ -363,7 +363,7 @@ pub extern "C" fn rs_snmp_state_get_tx_count(state: *mut std::os::raw::c_void)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_state_tx_free(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_snmp_state_tx_free(state: *mut std::os::raw::c_void,
                                        tx_id: u64)
 {
     let state = cast_pointer!(state,SNMPState);
@@ -391,7 +391,7 @@ pub extern "C" fn rs_snmp_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void
 
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_tx_set_logged(_state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_snmp_tx_set_logged(_state: *mut std::os::raw::c_void,
                                        tx: *mut std::os::raw::c_void,
                                        logged: u32)
 {
@@ -400,7 +400,7 @@ pub extern "C" fn rs_snmp_tx_set_logged(_state: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_tx_get_logged(_state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_snmp_tx_get_logged(_state: *mut std::os::raw::c_void,
                                        tx: *mut std::os::raw::c_void)
                                        -> u32
 {
@@ -410,7 +410,7 @@ pub extern "C" fn rs_snmp_tx_get_logged(_state: *mut std::os::raw::c_void,
 
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_state_set_tx_detect_state(
+pub unsafe extern "C" fn rs_snmp_state_set_tx_detect_state(
     tx: *mut std::os::raw::c_void,
     de_state: &mut core::DetectEngineState) -> std::os::raw::c_int
 {
@@ -420,7 +420,7 @@ pub extern "C" fn rs_snmp_state_set_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_state_get_tx_detect_state(
+pub unsafe extern "C" fn rs_snmp_state_get_tx_detect_state(
     tx: *mut std::os::raw::c_void)
     -> *mut core::DetectEngineState
 {
@@ -433,7 +433,7 @@ pub extern "C" fn rs_snmp_state_get_tx_detect_state(
 
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_state_get_events(tx: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_snmp_state_get_events(tx: *mut std::os::raw::c_void)
                                            -> *mut core::AppLayerDecoderEvents
 {
     let tx = cast_pointer!(tx, SNMPTransaction);
@@ -510,7 +510,7 @@ pub extern "C" fn rs_snmp_state_get_tx_iterator(
 
 // for use with the C API call StateGetTxIterator
 #[no_mangle]
-pub extern "C" fn rs_snmp_get_tx_iterator(_ipproto: u8,
+pub unsafe extern "C" fn rs_snmp_get_tx_iterator(_ipproto: u8,
                                           _alproto: AppProto,
                                           alstate: *mut std::os::raw::c_void,
                                           min_tx_id: u64,
@@ -561,7 +561,7 @@ fn parse_pdu_enveloppe_version(i:&[u8]) -> IResult<&[u8],u32> {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_probing_parser(_flow: *const Flow,
+pub unsafe extern "C" fn rs_snmp_probing_parser(_flow: *const Flow,
                                          _direction: u8,
                                          input:*const u8,
                                          input_len: u32,


### PR DESCRIPTION
Currently the macros build_slice and cast_pointer wrap their code in unsafe not
requiring the containing function to be unsafe, but clippy recommends that any
public function working with raw pointers be marked unsafe. To comply with this
idiom, remove unsafe from the macros, requiring any function that uses these
macros to be unsafe itself.

Reference: 
https://rust-lang.github.io/rust-clippy/master/index.html#not_unsaf

The next step would be to find the ffi funcations that use an unsafe block
and mark them unsafe, removing the unsafe blocks.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/448
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/805