### PR TITLE
doc: adds doc for ipv4.hdr signature keyword

### DIFF
--- a/doc/userguide/rules/header-keywords.rst
+++ b/doc/userguide/rules/header-keywords.rst
@@ -111,6 +111,20 @@ The named variant of that example would be::
 
     ip_proto:PIM
 
+ipv4.hdr
+^^^^^^^^
+
+Sticky buffer to match on the whole IPv4 header.
+
+Example rule:
+
+.. container:: example-rule
+
+    alert ip any any -> any any (:example-rule-emphasis:`ipv4.hdr; content:"|3A|"; offset:9; depth:1;` sid:1234; rev:5;)
+
+This example looks if byte 9 of IPv4 header has value 3A.
+That means that the IPv4 protocol is ICMPv6.
+
 ipv6.hdr
 ^^^^^^^^
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3335

Describe changes:
- Adds documentation for keyword `ipv4.hdr` with an example

A S-V test is already available from https://github.com/OISF/suricata-verify/pull/85
