### PR TITLE
Feat/appl records/v19

### DIFF
--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -302,7 +302,7 @@ pub extern "C" fn rs_template_parse_request(
     input_len: u32,
     _data: *const std::os::raw::c_void,
     _flags: u8,
-) -> i32 {
+) -> AppLayerResult {
     let eof = unsafe {
         if AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF) > 0 {
             true
@@ -317,10 +317,10 @@ pub extern "C" fn rs_template_parse_request(
 
     let state = cast_pointer!(state, TemplateState);
     let buf = build_slice!(input, input_len as usize);
-    if state.parse_request(buf) {
-        return 1;
+    if !state.parse_request(buf) {
+        return AppLayerResult::err();
     }
-    return -1;
+    AppLayerResult::ok()
 }
 
 #[no_mangle]
@@ -332,7 +332,7 @@ pub extern "C" fn rs_template_parse_response(
     input_len: u32,
     _data: *const std::os::raw::c_void,
     _flags: u8,
-) -> i32 {
+) -> AppLayerResult {
     let _eof = unsafe {
         if AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF) > 0 {
             true
@@ -342,10 +342,10 @@ pub extern "C" fn rs_template_parse_response(
     };
     let state = cast_pointer!(state, TemplateState);
     let buf = build_slice!(input, input_len as usize);
-    if state.parse_response(buf) {
-        return 1;
+    if !state.parse_response(buf) {
+        return AppLayerResult::err();
     }
-    return -1;
+    AppLayerResult::ok()
 }
 
 #[no_mangle]

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -293,7 +293,7 @@ pub extern "C" fn rs_dhcp_parse(_flow: *const core::Flow,
     let state = cast_pointer!(state, DHCPState);
     let buf = build_slice!(input, input_len as usize);
     if state.parse(buf) {
-        return 1;
+        return 0;
     }
     return -1;
 }

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -289,13 +289,13 @@ pub extern "C" fn rs_dhcp_parse(_flow: *const core::Flow,
                                 input: *const u8,
                                 input_len: u32,
                                 _data: *const std::os::raw::c_void,
-                                _flags: u8) -> i32 {
+                                _flags: u8) -> AppLayerResult {
     let state = cast_pointer!(state, DHCPState);
     let buf = build_slice!(input, input_len as usize);
     if state.parse(buf) {
-        return 0;
+        return AppLayerResult::ok();
     }
-    return -1;
+    return AppLayerResult::err();
 }
 
 #[no_mangle]

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -587,7 +587,7 @@ pub extern "C" fn rs_dns_parse_request(_flow: *mut core::Flow,
                                        -> i8 {
     let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
     if state.parse_request(buf) {
-        1
+        0
     } else {
         -1
     }
@@ -603,7 +603,7 @@ pub extern "C" fn rs_dns_parse_response(_flow: *mut core::Flow,
                                         -> i8 {
     let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
     if state.parse_response(buf) {
-        1
+        0
     } else {
         -1
     }
@@ -622,7 +622,8 @@ pub extern "C" fn rs_dns_parse_request_tcp(_flow: *mut core::Flow,
         if input != std::ptr::null_mut() {
             let buf = unsafe{
                 std::slice::from_raw_parts(input, input_len as usize)};
-            return state.parse_request_tcp(buf);
+            let _ = state.parse_request_tcp(buf);
+            return 0;
         }
         state.request_gap(input_len);
     }
@@ -641,7 +642,8 @@ pub extern "C" fn rs_dns_parse_response_tcp(_flow: *mut core::Flow,
         if input != std::ptr::null_mut() {
             let buf = unsafe{
                 std::slice::from_raw_parts(input, input_len as usize)};
-            return state.parse_response_tcp(buf);
+            let _ = state.parse_response_tcp(buf);
+            return 0;
         }
         state.response_gap(input_len);
     }

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -473,7 +473,11 @@ pub extern "C" fn rs_ikev2_parse_request(_flow: *const core::Flow,
                                        _flags: u8) -> i32 {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,IKEV2State);
-    state.parse(buf, STREAM_TOSERVER)
+    let res = state.parse(buf, STREAM_TOSERVER);
+    if res < 0 {
+        return res;
+    }
+    0
 }
 
 #[no_mangle]
@@ -494,7 +498,10 @@ pub extern "C" fn rs_ikev2_parse_response(_flow: *const core::Flow,
                                        APP_LAYER_PARSER_BYPASS_READY)
         };
     }
-    res
+    if res < 0 {
+        return res;
+    }
+    0
 }
 
 #[no_mangle]

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -470,14 +470,13 @@ pub extern "C" fn rs_ikev2_parse_request(_flow: *const core::Flow,
                                        input: *const u8,
                                        input_len: u32,
                                        _data: *const std::os::raw::c_void,
-                                       _flags: u8) -> i32 {
+                                       _flags: u8) -> AppLayerResult {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,IKEV2State);
-    let res = state.parse(buf, STREAM_TOSERVER);
-    if res < 0 {
-        return res;
+    if state.parse(buf, STREAM_TOSERVER) < 0 {
+        return AppLayerResult::err();
     }
-    0
+    return AppLayerResult::ok();
 }
 
 #[no_mangle]
@@ -487,7 +486,7 @@ pub extern "C" fn rs_ikev2_parse_response(_flow: *const core::Flow,
                                        input: *const u8,
                                        input_len: u32,
                                        _data: *const std::os::raw::c_void,
-                                       _flags: u8) -> i32 {
+                                       _flags: u8) -> AppLayerResult {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,IKEV2State);
     let res = state.parse(buf, STREAM_TOCLIENT);
@@ -499,9 +498,9 @@ pub extern "C" fn rs_ikev2_parse_response(_flow: *const core::Flow,
         };
     }
     if res < 0 {
-        return res;
+        return AppLayerResult::err();
     }
-    0
+    return AppLayerResult::ok();
 }
 
 #[no_mangle]

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -93,7 +93,7 @@ impl NTPState {
 impl NTPState {
     /// Parse an NTP request message
     ///
-    /// Returns The number of messages parsed, or -1 on error
+    /// Returns 0 if successful, or -1 on error
     fn parse(&mut self, i: &[u8], _direction: u8) -> i32 {
         match parse_ntp(i) {
             Ok((_,ref msg)) => {
@@ -205,10 +205,13 @@ pub extern "C" fn rs_ntp_parse_request(_flow: *const core::Flow,
                                        input: *const u8,
                                        input_len: u32,
                                        _data: *const std::os::raw::c_void,
-                                       _flags: u8) -> i32 {
+                                       _flags: u8) -> AppLayerResult {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,NTPState);
-    state.parse(buf, 0)
+    if state.parse(buf, 0) < 0 {
+        return AppLayerResult::err();
+    }
+    AppLayerResult::ok()
 }
 
 #[no_mangle]
@@ -218,10 +221,13 @@ pub extern "C" fn rs_ntp_parse_response(_flow: *const core::Flow,
                                        input: *const u8,
                                        input_len: u32,
                                        _data: *const std::os::raw::c_void,
-                                       _flags: u8) -> i32 {
+                                       _flags: u8) -> AppLayerResult {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,NTPState);
-    state.parse(buf, 1)
+    if state.parse(buf, 1) < 0 {
+        return AppLayerResult::err();
+    }
+    AppLayerResult::ok()
 }
 
 #[no_mangle]

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -104,7 +104,7 @@ impl NTPState {
                     tx.xid = msg.ref_id;
                     self.transactions.push(tx);
                 }
-                1
+                0
             },
             Err(nom::Err::Incomplete(_)) => {
                 SCLogDebug!("Insufficient data while parsing NTP data");
@@ -464,6 +464,6 @@ mod tests {
         ];
 
         let mut state = NTPState::new();
-        assert_eq!(1, state.parse(REQ, 0));
+        assert_eq!(0, state.parse(REQ, 0));
     }
 }

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -48,6 +48,13 @@ impl AppLayerResult {
             needed: 0,
         };
     }
+    pub fn incomplete(consumed: u32, needed: u32) -> AppLayerResult {
+        return AppLayerResult {
+            status: 1,
+            consumed: consumed,
+            needed: needed,
+        };
+    }
 }
 
 /// Rust parser declaration

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -26,6 +26,30 @@ use crate::applayer;
 use std::os::raw::{c_void,c_char,c_int};
 use crate::applayer::{AppLayerGetTxIterTuple};
 
+#[repr(C)]
+pub struct AppLayerResult {
+    pub status: i32,
+    pub consumed: u32,
+    pub needed: u32,
+}
+
+impl AppLayerResult {
+    pub fn ok() -> AppLayerResult {
+        return AppLayerResult {
+            status: 0,
+            consumed: 0,
+            needed: 0,
+        };
+    }
+    pub fn err() -> AppLayerResult {
+        return AppLayerResult {
+            status: -1,
+            consumed: 0,
+            needed: 0,
+        };
+    }
+}
+
 /// Rust parser declaration
 #[repr(C)]
 pub struct RustParser {
@@ -133,7 +157,7 @@ pub type ParseFn      = extern "C" fn (flow: *const Flow,
                                        input: *const u8,
                                        input_len: u32,
                                        data: *const c_void,
-                                       flags: u8) -> i32;
+                                       flags: u8) -> AppLayerResult;
 pub type ProbeFn      = extern "C" fn (flow: *const Flow,direction: u8,input:*const u8, input_len: u32, rdir: *mut u8) -> AppProto;
 pub type StateAllocFn = extern "C" fn () -> *mut c_void;
 pub type StateFreeFn  = extern "C" fn (*mut c_void);

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -466,7 +466,7 @@ pub extern "C" fn rs_rdp_parse_ts(
     let buf = build_slice!(input, input_len as usize);
     // attempt to parse bytes as `rdp` protocol
     if state.parse_ts(buf) {
-        return 1;
+        return 0;
     }
     // no need for further parsing
     return -1;
@@ -486,7 +486,7 @@ pub extern "C" fn rs_rdp_parse_tc(
     let buf = build_slice!(input, input_len as usize);
     // attempt to parse bytes as `rdp` protocol
     if state.parse_tc(buf) {
-        return 1;
+        return 0;
     }
     // no need for further parsing
     return -1;

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -461,15 +461,16 @@ pub extern "C" fn rs_rdp_parse_ts(
     input_len: u32,
     _data: *const std::os::raw::c_void,
     _flags: u8,
-) -> i32 {
+) -> AppLayerResult {
     let state = cast_pointer!(state, RdpState);
     let buf = build_slice!(input, input_len as usize);
     // attempt to parse bytes as `rdp` protocol
     if state.parse_ts(buf) {
-        return 0;
+        AppLayerResult::ok()
+    } else {
+        // no need for further parsing
+        AppLayerResult::err()
     }
-    // no need for further parsing
-    return -1;
 }
 
 #[no_mangle]
@@ -481,15 +482,16 @@ pub extern "C" fn rs_rdp_parse_tc(
     input_len: u32,
     _data: *const std::os::raw::c_void,
     _flags: u8,
-) -> i32 {
+) -> AppLayerResult {
     let state = cast_pointer!(state, RdpState);
     let buf = build_slice!(input, input_len as usize);
     // attempt to parse bytes as `rdp` protocol
     if state.parse_tc(buf) {
-        return 0;
+        AppLayerResult::ok()
+    } else {
+        // no need for further parsing
+        AppLayerResult::err()
     }
-    // no need for further parsing
-    return -1;
 }
 
 //

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -358,14 +358,13 @@ pub extern "C" fn rs_sip_parse_request(
     input_len: u32,
     _data: *const std::os::raw::c_void,
     _flags: u8,
-) -> i32 {
+) -> AppLayerResult {
     let buf = build_slice!(input, input_len as usize);
     let state = cast_pointer!(state, SIPState);
-    if state.parse_request(buf) {
-        0
-    } else {
-        -1
+    if !state.parse_request(buf) {
+        return AppLayerResult::err();
     }
+    AppLayerResult::ok()
 }
 
 #[no_mangle]
@@ -377,14 +376,13 @@ pub extern "C" fn rs_sip_parse_response(
     input_len: u32,
     _data: *const std::os::raw::c_void,
     _flags: u8,
-) -> i32 {
+) -> AppLayerResult {
     let buf = build_slice!(input, input_len as usize);
     let state = cast_pointer!(state, SIPState);
-    if state.parse_response(buf) {
-        0
-    } else {
-        -1
+    if !state.parse_response(buf) {
+        return AppLayerResult::err();
     }
+    AppLayerResult::ok()
 }
 
 const PARSER_NAME: &'static [u8] = b"sip\0";

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -362,7 +362,7 @@ pub extern "C" fn rs_sip_parse_request(
     let buf = build_slice!(input, input_len as usize);
     let state = cast_pointer!(state, SIPState);
     if state.parse_request(buf) {
-        1
+        0
     } else {
         -1
     }
@@ -381,7 +381,7 @@ pub extern "C" fn rs_sip_parse_response(
     let buf = build_slice!(input, input_len as usize);
     let state = cast_pointer!(state, SIPState);
     if state.parse_response(buf) {
-        1
+        0
     } else {
         -1
     }

--- a/rust/src/smb/debug.rs
+++ b/rust/src/smb/debug.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018 Open Information Security Foundation
+/* Copyright (C) 2018-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -73,6 +73,6 @@ impl SMBState {
 
     #[cfg(feature = "debug")]
     pub fn _debug_state_stats(&self) {
-        SCLogDebug!("ssn2vec_map {} guid2name_map {} ssn2vecoffset_map {} ssn2tree_map {} ssnguid2vec_map {} tcp_buffer_ts {} tcp_buffer_tc {} file_ts_guid {} file_tc_guid {} transactions {}", self.ssn2vec_map.len(), self.guid2name_map.len(), self.ssn2vecoffset_map.len(), self.ssn2tree_map.len(), self.ssnguid2vec_map.len(), self.tcp_buffer_ts.len(), self.tcp_buffer_tc.len(), self.file_ts_guid.len(), self.file_tc_guid.len(), self.transactions.len());
+        SCLogDebug!("ssn2vec_map {} guid2name_map {} ssn2vecoffset_map {} ssn2tree_map {} ssnguid2vec_map {} file_ts_guid {} file_tc_guid {} transactions {}", self.ssn2vec_map.len(), self.guid2name_map.len(), self.ssn2vecoffset_map.len(), self.ssn2tree_map.len(), self.ssnguid2vec_map.len(), self.file_ts_guid.len(), self.file_tc_guid.len(), self.transactions.len());
     }
 }

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1848,7 +1848,7 @@ pub extern "C" fn rs_smb_parse_request_tcp(flow: &mut Flow,
 
     state.ts = flow.get_last_time().as_secs();
     if state.parse_tcp_data_ts(buf) == 0 {
-        return 1;
+        return 0;
     } else {
         return -1;
     }
@@ -1861,7 +1861,7 @@ pub extern "C" fn rs_smb_parse_request_tcp_gap(
                                         -> i8
 {
     if state.parse_tcp_data_ts_gap(input_len as u32) == 0 {
-        return 1;
+        return 0;
     }
     return -1;
 }
@@ -1887,7 +1887,7 @@ pub extern "C" fn rs_smb_parse_response_tcp(flow: &mut Flow,
 
     state.ts = flow.get_last_time().as_secs();
     if state.parse_tcp_data_tc(buf) == 0 {
-        return 1;
+        return 0;
     } else {
         return -1;
     }
@@ -1900,7 +1900,7 @@ pub extern "C" fn rs_smb_parse_response_tcp_gap(
                                         -> i8
 {
     if state.parse_tcp_data_tc_gap(input_len as u32) == 0 {
-        return 1;
+        return 0;
     }
     return -1;
 }

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -38,6 +38,7 @@ use crate::core::*;
 use crate::log::*;
 use crate::applayer;
 use crate::applayer::LoggerFlags;
+use crate::parser::AppLayerResult;
 
 use crate::smb::nbss_records::*;
 use crate::smb::smb1_records::*;
@@ -761,10 +762,6 @@ pub struct SMBState<> {
     // requests for DCERPC.
     pub ssnguid2vec_map: HashMap<SMBHashKeyHdrGuid, Vec<u8>>,
 
-    /// TCP segments defragmentation buffer
-    pub tcp_buffer_ts: Vec<u8>,
-    pub tcp_buffer_tc: Vec<u8>,
-
     pub files: SMBFiles,
 
     skip_ts: u32,
@@ -817,8 +814,6 @@ impl SMBState {
             ssn2vecoffset_map:HashMap::new(),
             ssn2tree_map:HashMap::new(),
             ssnguid2vec_map:HashMap::new(),
-            tcp_buffer_ts:Vec::new(),
-            tcp_buffer_tc:Vec::new(),
             files: SMBFiles::new(),
             skip_ts:0,
             skip_tc:0,
@@ -1328,6 +1323,7 @@ impl SMBState {
 
                                 }
                             } else if smb.version == 0xfe_u8 { // SMB2
+                                SCLogDebug!("NBSS record {:?}", nbss_part_hdr);
                                 SCLogDebug!("SMBv2 record");
                                 match parse_smb2_request_record(&nbss_part_hdr.data) {
                                     Ok((_, ref smb_record)) => {
@@ -1336,6 +1332,7 @@ impl SMBState {
                                         if smb_record.command == SMB2_COMMAND_WRITE {
                                             smb2_write_request_record(self, smb_record);
                                             let consumed = input.len() - output.len();
+                                            SCLogDebug!("consumed {}", consumed);
                                             return consumed;
                                         }
                                     },
@@ -1355,35 +1352,14 @@ impl SMBState {
     }
 
     /// Parsing function, handling TCP chunks fragmentation
-    pub fn parse_tcp_data_ts<'b>(&mut self, i: &'b[u8]) -> u32
+    pub fn parse_tcp_data_ts<'b>(&mut self, i: &'b[u8]) -> AppLayerResult
     {
-        let mut v : Vec<u8>;
-        //println!("parse_tcp_data_ts ({})",i.len());
-        //println!("{:?}",i);
-        // Check if TCP data is being defragmented
-        let tcp_buffer = match self.tcp_buffer_ts.len() {
-            0 => i,
-            _ => {
-                v = self.tcp_buffer_ts.split_off(0);
-                if self.tcp_buffer_ts.len() + i.len() > 100000 {
-                    self.set_event(SMBEvent::RecordOverflow);
-                    return 1;
-                };
-                v.extend_from_slice(i);
-                v.as_slice()
-            },
-        };
-        //println!("tcp_buffer ({})",tcp_buffer.len());
-        let mut cur_i = tcp_buffer;
-        if cur_i.len() > 1000000 {
-            self.set_event(SMBEvent::RecordOverflow);
-            return 1;
-        }
+        let mut cur_i = i;
         let consumed = self.handle_skip(STREAM_TOSERVER, cur_i.len() as u32);
         if consumed > 0 {
             if consumed > cur_i.len() as u32 {
                 self.set_event(SMBEvent::InternalError);
-                return 1;
+                return AppLayerResult::err();
             }
             cur_i = &cur_i[consumed as usize..];
         }
@@ -1393,30 +1369,42 @@ impl SMBState {
         if consumed > 0 {
             if consumed > cur_i.len() as u32 {
                 self.set_event(SMBEvent::InternalError);
-                return 1;
+                return AppLayerResult::err();
             }
             cur_i = &cur_i[consumed as usize..];
+        }
+        if cur_i.len() == 0 {
+            return AppLayerResult::ok();
         }
         // gap
         if self.ts_gap {
             SCLogDebug!("TS trying to catch up after GAP (input {})", cur_i.len());
-            match search_smb_record(cur_i) {
-                Ok((_, pg)) => {
-                    SCLogDebug!("smb record found");
-                    let smb2_offset = cur_i.len() - pg.len();
-                    if smb2_offset < 4 {
-                        return 0;
-                    }
-                    let nbss_offset = smb2_offset - 4;
-                    cur_i = &cur_i[nbss_offset..];
+            while cur_i.len() > 0 { // min record size
+                match search_smb_record(cur_i) {
+                    Ok((_, pg)) => {
+                        SCLogDebug!("smb record found");
+                        let smb2_offset = cur_i.len() - pg.len();
+                        if smb2_offset < 4 {
+                            cur_i = &cur_i[smb2_offset+4..];
+                            continue; // see if we have another record in our data
+                        }
+                        let nbss_offset = smb2_offset - 4;
+                        cur_i = &cur_i[nbss_offset..];
 
-                    self.ts_gap = false;
-                },
-                _ => {
-                    SCLogDebug!("smb record NOT found");
-                    self.tcp_buffer_ts.extend_from_slice(cur_i);
-                    return 0;
-                },
+                        self.ts_gap = false;
+                        break;
+                    },
+                    _ => {
+                        let mut consumed = i.len();
+                        if consumed < 4 {
+                            consumed = 0;
+                        } else {
+                            consumed = consumed - 3;
+                        }
+                        SCLogDebug!("smb record NOT found");
+                        return AppLayerResult::incomplete(consumed as u32, 8);
+                    },
+                }
             }
         }
         while cur_i.len() > 0 { // min record size
@@ -1436,7 +1424,7 @@ impl SMBState {
                                         },
                                         _ => {
                                             self.set_event(SMBEvent::MalformedData);
-                                            return 1;
+                                            return AppLayerResult::err();
                                         },
                                     }
                                 } else if smb.version == 0xfe_u8 { // SMB2
@@ -1452,7 +1440,7 @@ impl SMBState {
                                             },
                                             _ => {
                                                 self.set_event(SMBEvent::MalformedData);
-                                                return 1;
+                                                return AppLayerResult::err();
                                             },
                                         }
                                     }
@@ -1466,7 +1454,7 @@ impl SMBState {
                                             },
                                             _ => {
                                                 self.set_event(SMBEvent::MalformedData);
-                                                return 1;
+                                                return AppLayerResult::err();
                                             },
                                         }
                                     }
@@ -1474,7 +1462,7 @@ impl SMBState {
                             },
                             _ => {
                                 self.set_event(SMBEvent::MalformedData);
-                                return 1;
+                                return AppLayerResult::err();
                             },
                         }
                     } else {
@@ -1482,16 +1470,34 @@ impl SMBState {
                     }
                     cur_i = rem;
                 },
-                Err(nom::Err::Incomplete(_)) => {
-                    let consumed = self.parse_tcp_data_ts_partial(cur_i);
-                    cur_i = &cur_i[consumed ..];
-
-                    self.tcp_buffer_ts.extend_from_slice(cur_i);
-                    break;
+                Err(nom::Err::Incomplete(needed)) => {
+                    if let nom::Needed::Size(n) = needed {
+                        // 512 is the minimum for parse_tcp_data_ts_partial
+                        if n >= 512 && cur_i.len() < 512 {
+                            let total_consumed = i.len() - cur_i.len();
+                            return AppLayerResult::incomplete(total_consumed as u32, 512);
+                        }
+                        let consumed = self.parse_tcp_data_ts_partial(cur_i);
+                        if consumed == 0 {
+                            // if we consumed none we will buffer the entire record
+                            let total_consumed = i.len() - cur_i.len();
+                            SCLogDebug!("setting consumed {} need {} needed {:?} total input {}",
+                                    total_consumed, n, needed, i.len());
+                            let need = n + 4; // Incomplete returns size of data minus NBSS header
+                            return AppLayerResult::incomplete(total_consumed as u32, need as u32);
+                        }
+                        // tracking a write record, which we don't need to
+                        // queue up at the stream level, but can feed to us
+                        // in small chunks
+                        return AppLayerResult::ok();
+                    } else {
+                        self.set_event(SMBEvent::InternalError);
+                        return AppLayerResult::err();
+                    }
                 },
                 Err(_) => {
                     self.set_event(SMBEvent::MalformedData);
-                    return 1;
+                    return AppLayerResult::err();
                 },
             }
         };
@@ -1500,7 +1506,7 @@ impl SMBState {
         if self.check_post_gap_file_txs {
             self.post_gap_housekeeping_for_files();
         }
-        0
+        AppLayerResult::ok()
     }
 
     /// return bytes consumed
@@ -1584,33 +1590,14 @@ impl SMBState {
     }
 
     /// Parsing function, handling TCP chunks fragmentation
-    pub fn parse_tcp_data_tc<'b>(&mut self, i: &'b[u8]) -> u32
+    pub fn parse_tcp_data_tc<'b>(&mut self, i: &'b[u8]) -> AppLayerResult
     {
-        let mut v : Vec<u8>;
-        // Check if TCP data is being defragmented
-        let tcp_buffer = match self.tcp_buffer_tc.len() {
-            0 => i,
-            _ => {
-                v = self.tcp_buffer_tc.split_off(0);
-                if self.tcp_buffer_tc.len() + i.len() > 100000 {
-                    self.set_event(SMBEvent::RecordOverflow);
-                    return 1;
-                };
-                v.extend_from_slice(i);
-                v.as_slice()
-            },
-        };
-        let mut cur_i = tcp_buffer;
-        SCLogDebug!("cur_i.len {}", cur_i.len());
-        if cur_i.len() > 100000 {
-            self.set_event(SMBEvent::RecordOverflow);
-            return 1;
-        }
+        let mut cur_i = i;
         let consumed = self.handle_skip(STREAM_TOCLIENT, cur_i.len() as u32);
         if consumed > 0 {
             if consumed > cur_i.len() as u32 {
                 self.set_event(SMBEvent::InternalError);
-                return 1;
+                return AppLayerResult::err();
             }
             cur_i = &cur_i[consumed as usize..];
         }
@@ -1620,30 +1607,42 @@ impl SMBState {
         if consumed > 0 {
             if consumed > cur_i.len() as u32 {
                 self.set_event(SMBEvent::InternalError);
-                return 1;
+                return AppLayerResult::err();
             }
             cur_i = &cur_i[consumed as usize..];
+        }
+        if cur_i.len() == 0 {
+            return AppLayerResult::ok();
         }
         // gap
         if self.tc_gap {
             SCLogDebug!("TC trying to catch up after GAP (input {})", cur_i.len());
-            match search_smb_record(cur_i) {
-                Ok((_, pg)) => {
-                    SCLogDebug!("smb record found");
-                    let smb2_offset = cur_i.len() - pg.len();
-                    if smb2_offset < 4 {
-                        return 0;
-                    }
-                    let nbss_offset = smb2_offset - 4;
-                    cur_i = &cur_i[nbss_offset..];
+            while cur_i.len() > 0 { // min record size
+                match search_smb_record(cur_i) {
+                    Ok((_, pg)) => {
+                        SCLogDebug!("smb record found");
+                        let smb2_offset = cur_i.len() - pg.len();
+                        if smb2_offset < 4 {
+                            cur_i = &cur_i[smb2_offset+4..];
+                            continue; // see if we have another record in our data
+                        }
+                        let nbss_offset = smb2_offset - 4;
+                        cur_i = &cur_i[nbss_offset..];
 
-                    self.tc_gap = false;
-                },
-                _ => {
-                    SCLogDebug!("smb record NOT found");
-                    self.tcp_buffer_tc.extend_from_slice(cur_i);
-                    return 0;
-                },
+                        self.tc_gap = false;
+                        break;
+                    },
+                    _ => {
+                        let mut consumed = i.len();
+                        if consumed < 4 {
+                            consumed = 0;
+                        } else {
+                            consumed = consumed - 3;
+                        }
+                        SCLogDebug!("smb record NOT found");
+                        return AppLayerResult::incomplete(consumed as u32, 8);
+                    },
+                }
             }
         }
         while cur_i.len() > 0 { // min record size
@@ -1663,7 +1662,7 @@ impl SMBState {
                                         },
                                         _ => {
                                             self.set_event(SMBEvent::MalformedData);
-                                            return 1;
+                                            return AppLayerResult::err();
                                         },
                                     }
                                 } else if smb.version == 0xfe_u8 { // SMB2
@@ -1677,7 +1676,7 @@ impl SMBState {
                                             },
                                             _ => {
                                                 self.set_event(SMBEvent::MalformedData);
-                                                return 1;
+                                                return AppLayerResult::err();
                                             },
                                         }
                                     }
@@ -1691,7 +1690,7 @@ impl SMBState {
                                             },
                                             _ => {
                                                 self.set_event(SMBEvent::MalformedData);
-                                                return 1;
+                                                return AppLayerResult::err();
                                             },
                                         }
                                     }
@@ -1703,7 +1702,7 @@ impl SMBState {
                             },
                             Err(_) => {
                                 self.set_event(SMBEvent::MalformedData);
-                                return 1;
+                                return AppLayerResult::err();
                             },
                         }
                     } else {
@@ -1713,16 +1712,33 @@ impl SMBState {
                 },
                 Err(nom::Err::Incomplete(needed)) => {
                     SCLogDebug!("INCOMPLETE have {} needed {:?}", cur_i.len(), needed);
-                    let consumed = self.parse_tcp_data_tc_partial(cur_i);
-                    cur_i = &cur_i[consumed ..];
-
-                    SCLogDebug!("INCOMPLETE have {}", cur_i.len());
-                    self.tcp_buffer_tc.extend_from_slice(cur_i);
-                    break;
+                    if let nom::Needed::Size(n) = needed {
+                        // 512 is the minimum for parse_tcp_data_tc_partial
+                        if n >= 512 && cur_i.len() < 512 {
+                            let total_consumed = i.len() - cur_i.len();
+                            return AppLayerResult::incomplete(total_consumed as u32, 512);
+                        }
+                        let consumed = self.parse_tcp_data_tc_partial(cur_i);
+                        if consumed == 0 {
+                            // if we consumed none we will buffer the entire record
+                            let total_consumed = i.len() - cur_i.len();
+                            SCLogDebug!("setting consumed {} need {} needed {:?} total input {}",
+                                    total_consumed, n, needed, i.len());
+                            let need = n + 4; // Incomplete returns size of data minus NBSS header
+                            return AppLayerResult::incomplete(total_consumed as u32, need as u32);
+                        }
+                        // tracking a read record, which we don't need to
+                        // queue up at the stream level, but can feed to us
+                        // in small chunks
+                        return AppLayerResult::ok();
+                    } else {
+                        self.set_event(SMBEvent::InternalError);
+                        return AppLayerResult::err();
+                    }
                 },
                 Err(_) => {
                     self.set_event(SMBEvent::MalformedData);
-                    return 1;
+                    return AppLayerResult::err();
                 },
             }
         };
@@ -1731,15 +1747,12 @@ impl SMBState {
             self.post_gap_housekeeping_for_files();
         }
         self._debug_tx_stats();
-        0
+        AppLayerResult::ok()
     }
 
     /// handle a gap in the TOSERVER direction
     /// returns: 0 ok, 1 unrecoverable error
     pub fn parse_tcp_data_ts_gap(&mut self, gap_size: u32) -> u32 {
-        if self.tcp_buffer_ts.len() > 0 {
-            self.tcp_buffer_ts.clear();
-        }
         let consumed = self.handle_skip(STREAM_TOSERVER, gap_size);
         if consumed < gap_size {
             let new_gap_size = gap_size - consumed;
@@ -1761,9 +1774,6 @@ impl SMBState {
     /// handle a gap in the TOCLIENT direction
     /// returns: 0 ok, 1 unrecoverable error
     pub fn parse_tcp_data_tc_gap(&mut self, gap_size: u32) -> u32 {
-        if self.tcp_buffer_tc.len() > 0 {
-            self.tcp_buffer_tc.clear();
-        }
         let consumed = self.handle_skip(STREAM_TOCLIENT, gap_size);
         if consumed < gap_size {
             let new_gap_size = gap_size - consumed;
@@ -1785,7 +1795,6 @@ impl SMBState {
     pub fn trunc_ts(&mut self) {
         SCLogDebug!("TRUNC TS");
         self.ts_trunc = true;
-        self.tcp_buffer_ts.clear();
 
         for tx in &mut self.transactions {
             if !tx.request_done {
@@ -1797,7 +1806,6 @@ impl SMBState {
     pub fn trunc_tc(&mut self) {
         SCLogDebug!("TRUNC TC");
         self.tc_trunc = true;
-        self.tcp_buffer_tc.clear();
 
         for tx in &mut self.transactions {
             if !tx.response_done {
@@ -1836,7 +1844,7 @@ pub extern "C" fn rs_smb_parse_request_tcp(flow: &mut Flow,
                                        input_len: u32,
                                        _data: *mut std::os::raw::c_void,
                                        flags: u8)
-                                       -> i8
+                                       -> AppLayerResult
 {
     let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
     SCLogDebug!("parsing {} bytes of request data", input_len);
@@ -1847,11 +1855,7 @@ pub extern "C" fn rs_smb_parse_request_tcp(flow: &mut Flow,
     }
 
     state.ts = flow.get_last_time().as_secs();
-    if state.parse_tcp_data_ts(buf) == 0 {
-        return 0;
-    } else {
-        return -1;
-    }
+    state.parse_tcp_data_ts(buf)
 }
 
 #[no_mangle]
@@ -1875,7 +1879,7 @@ pub extern "C" fn rs_smb_parse_response_tcp(flow: &mut Flow,
                                         input_len: u32,
                                         _data: *mut std::os::raw::c_void,
                                         flags: u8)
-                                        -> i8
+                                        -> AppLayerResult
 {
     SCLogDebug!("parsing {} bytes of response data", input_len);
     let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
@@ -1886,11 +1890,7 @@ pub extern "C" fn rs_smb_parse_response_tcp(flow: &mut Flow,
     }
 
     state.ts = flow.get_last_time().as_secs();
-    if state.parse_tcp_data_tc(buf) == 0 {
-        return 0;
-    } else {
-        return -1;
-    }
+    state.parse_tcp_data_tc(buf)
 }
 
 #[no_mangle]

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -186,7 +186,7 @@ impl SNMPState {
 
     /// Parse an SNMP request message
     ///
-    /// Returns The number of messages parsed, or -1 on error
+    /// Returns 0 if successful, or -1 on error
     fn parse(&mut self, i: &[u8], direction: u8) -> i32 {
         if self.version == 0 {
             match parse_pdu_enveloppe_version(i) {
@@ -323,10 +323,13 @@ pub extern "C" fn rs_snmp_parse_request(_flow: *const core::Flow,
                                        input: *const u8,
                                        input_len: u32,
                                        _data: *const std::os::raw::c_void,
-                                       _flags: u8) -> i32 {
+                                       _flags: u8) -> AppLayerResult {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,SNMPState);
-    state.parse(buf, STREAM_TOSERVER)
+    if state.parse(buf, STREAM_TOSERVER) < 0 {
+        return AppLayerResult::err();
+    }
+    AppLayerResult::ok()
 }
 
 #[no_mangle]
@@ -336,10 +339,13 @@ pub extern "C" fn rs_snmp_parse_response(_flow: *const core::Flow,
                                        input: *const u8,
                                        input_len: u32,
                                        _data: *const std::os::raw::c_void,
-                                       _flags: u8) -> i32 {
+                                       _flags: u8) -> AppLayerResult {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,SNMPState);
-    state.parse(buf, STREAM_TOCLIENT)
+    if state.parse(buf, STREAM_TOCLIENT) < 0 {
+        return AppLayerResult::err();
+    }
+    AppLayerResult::ok()
 }
 
 #[no_mangle]

--- a/rust/src/tftp/tftp.rs
+++ b/rust/src/tftp/tftp.rs
@@ -148,7 +148,7 @@ pub extern "C" fn rs_tftp_request(state: &mut TFTPState,
             state.tx_id += 1;
             rqst.id = state.tx_id;
             state.transactions.push(rqst);
-            1
+            0
         },
         _ => 0
     }

--- a/src/app-layer-dcerpc-udp.c
+++ b/src/app-layer-dcerpc-udp.c
@@ -725,9 +725,9 @@ static int DCERPCUDPParse(Flow *f, void *dcerpc_state,
     SCEnter();
 
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        SCReturnInt(1);
+        SCReturnInt(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
-        SCReturnInt(-1);
+        SCReturnInt(APP_LAYER_ERROR);
     }
 
     DCERPCUDPState *sstate = (DCERPCUDPState *) dcerpc_state;
@@ -779,9 +779,9 @@ static int DCERPCUDPParse(Flow *f, void *dcerpc_state,
         sstate->bytesprocessed = 0;
     }
     if (pstate == NULL)
-        SCReturnInt(-1);
+        SCReturnInt(APP_LAYER_ERROR);
 
-    SCReturnInt(1);
+    SCReturnInt(APP_LAYER_OK);
 }
 
 static void *DCERPCUDPStateAlloc(void)

--- a/src/app-layer-dcerpc-udp.c
+++ b/src/app-layer-dcerpc-udp.c
@@ -715,7 +715,7 @@ static int DCERPCUDPParseHeader(Flow *f, void *dcerpcudp_state,
     SCReturnInt((p - input));
 }
 
-static int DCERPCUDPParse(Flow *f, void *dcerpc_state,
+static AppLayerResult DCERPCUDPParse(Flow *f, void *dcerpc_state,
     AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
     void *local_data, const uint8_t flags)
 {
@@ -725,9 +725,9 @@ static int DCERPCUDPParse(Flow *f, void *dcerpc_state,
     SCEnter();
 
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        SCReturnInt(APP_LAYER_OK);
+        SCReturnStruct(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
-        SCReturnInt(APP_LAYER_ERROR);
+        SCReturnStruct(APP_LAYER_ERROR);
     }
 
     DCERPCUDPState *sstate = (DCERPCUDPState *) dcerpc_state;
@@ -736,7 +736,7 @@ static int DCERPCUDPParse(Flow *f, void *dcerpc_state,
             input_len);
         if (hdrretval == -1 || hdrretval > (int32_t)input_len) {
             sstate->bytesprocessed = 0;
-            SCReturnInt(hdrretval);
+            SCReturnStruct(APP_LAYER_ERROR);
         } else {
             parsed += hdrretval;
             input_len -= hdrretval;
@@ -779,9 +779,9 @@ static int DCERPCUDPParse(Flow *f, void *dcerpc_state,
         sstate->bytesprocessed = 0;
     }
     if (pstate == NULL)
-        SCReturnInt(APP_LAYER_ERROR);
+        SCReturnStruct(APP_LAYER_ERROR);
 
-    SCReturnInt(APP_LAYER_OK);
+    SCReturnStruct(APP_LAYER_OK);
 }
 
 static void *DCERPCUDPStateAlloc(void)

--- a/src/app-layer-dcerpc.c
+++ b/src/app-layer-dcerpc.c
@@ -1897,26 +1897,26 @@ static int DCERPCParse(Flow *f, void *dcerpc_state,
     DCERPCState *sstate = (DCERPCState *) dcerpc_state;
 
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        SCReturnInt(1);
+        SCReturnInt(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
-        SCReturnInt(-1);
+        SCReturnInt(APP_LAYER_ERROR);
     }
 
     if (sstate->dcerpc.bytesprocessed != 0 && sstate->data_needed_for_dir != dir) {
-        SCReturnInt(-1);
+        SCReturnInt(APP_LAYER_ERROR);
     }
 
     retval = DCERPCParser(&sstate->dcerpc, input, input_len);
     if (retval == -1) {
-        SCReturnInt(0);
+        SCReturnInt(APP_LAYER_OK);
     }
 
     sstate->data_needed_for_dir = dir;
 
     if (pstate == NULL)
-        SCReturnInt(-1);
+        SCReturnInt(APP_LAYER_ERROR);
 
-    SCReturnInt(1);
+    SCReturnInt(APP_LAYER_OK);
 }
 
 static int DCERPCParseRequest(Flow *f, void *dcerpc_state,

--- a/src/app-layer-dcerpc.c
+++ b/src/app-layer-dcerpc.c
@@ -1886,7 +1886,7 @@ int32_t DCERPCParser(DCERPC *dcerpc, const uint8_t *input, uint32_t input_len)
     SCReturnInt(parsed);
 }
 
-static int DCERPCParse(Flow *f, void *dcerpc_state,
+static AppLayerResult DCERPCParse(Flow *f, void *dcerpc_state,
                        AppLayerParserState *pstate,
                        const uint8_t *input, uint32_t input_len,
                        void *local_data, int dir)
@@ -1897,29 +1897,29 @@ static int DCERPCParse(Flow *f, void *dcerpc_state,
     DCERPCState *sstate = (DCERPCState *) dcerpc_state;
 
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        SCReturnInt(APP_LAYER_OK);
+        SCReturnStruct(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
-        SCReturnInt(APP_LAYER_ERROR);
+        SCReturnStruct(APP_LAYER_ERROR);
     }
 
     if (sstate->dcerpc.bytesprocessed != 0 && sstate->data_needed_for_dir != dir) {
-        SCReturnInt(APP_LAYER_ERROR);
+        SCReturnStruct(APP_LAYER_ERROR);
     }
 
     retval = DCERPCParser(&sstate->dcerpc, input, input_len);
     if (retval == -1) {
-        SCReturnInt(APP_LAYER_OK);
+        SCReturnStruct(APP_LAYER_OK);
     }
 
     sstate->data_needed_for_dir = dir;
 
     if (pstate == NULL)
-        SCReturnInt(APP_LAYER_ERROR);
+        SCReturnStruct(APP_LAYER_ERROR);
 
-    SCReturnInt(APP_LAYER_OK);
+    SCReturnStruct(APP_LAYER_OK);
 }
 
-static int DCERPCParseRequest(Flow *f, void *dcerpc_state,
+static AppLayerResult DCERPCParseRequest(Flow *f, void *dcerpc_state,
                               AppLayerParserState *pstate,
                               const uint8_t *input, uint32_t input_len,
                               void *local_data, const uint8_t flags)
@@ -1928,7 +1928,7 @@ static int DCERPCParseRequest(Flow *f, void *dcerpc_state,
                        local_data, 0);
 }
 
-static int DCERPCParseResponse(Flow *f, void *dcerpc_state,
+static AppLayerResult DCERPCParseResponse(Flow *f, void *dcerpc_state,
                                AppLayerParserState *pstate,
                                const uint8_t *input, uint32_t input_len,
                                void *local_data, const uint8_t flags)

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -1111,7 +1111,7 @@ error:
  * date if a segment does not contain a complete frame (or contains
  * multiple frames, but not the complete final frame).
  */
-static int DNP3ParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
+static AppLayerResult DNP3ParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
     const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
@@ -1121,7 +1121,7 @@ static int DNP3ParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
     int processed = 0;
 
     if (input_len == 0) {
-        SCReturnInt(APP_LAYER_OK);
+        SCReturnStruct(APP_LAYER_OK);
     }
 
     if (buffer->len) {
@@ -1159,12 +1159,12 @@ static int DNP3ParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
         }
     }
 
-    SCReturnInt(APP_LAYER_OK);
+    SCReturnStruct(APP_LAYER_OK);
 
 error:
     /* Reset the buffer. */
     DNP3BufferReset(buffer);
-    SCReturnInt(APP_LAYER_ERROR);
+    SCReturnStruct(APP_LAYER_ERROR);
 }
 
 /**
@@ -1251,7 +1251,7 @@ error:
  *
  * See DNP3ParseResponsePDUs for DNP3 frame handling.
  */
-static int DNP3ParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
+static AppLayerResult DNP3ParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
     const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
@@ -1300,13 +1300,13 @@ static int DNP3ParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
     }
 
 done:
-    SCReturnInt(APP_LAYER_OK);
+    SCReturnStruct(APP_LAYER_OK);
 
 error:
     /* An error occurred while processing DNP3 frames.  Dump the
      * buffer as we can't be assured that they are valid anymore. */
     DNP3BufferReset(buffer);
-    SCReturnInt(APP_LAYER_ERROR);
+    SCReturnStruct(APP_LAYER_ERROR);
 }
 
 static AppLayerDecoderEvents *DNP3GetEvents(void *tx)

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -1121,7 +1121,7 @@ static int DNP3ParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
     int processed = 0;
 
     if (input_len == 0) {
-        SCReturnInt(1);
+        SCReturnInt(APP_LAYER_OK);
     }
 
     if (buffer->len) {
@@ -1159,12 +1159,12 @@ static int DNP3ParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
         }
     }
 
-    SCReturnInt(1);
+    SCReturnInt(APP_LAYER_OK);
 
 error:
     /* Reset the buffer. */
     DNP3BufferReset(buffer);
-    SCReturnInt(-1);
+    SCReturnInt(APP_LAYER_ERROR);
 }
 
 /**
@@ -1300,13 +1300,13 @@ static int DNP3ParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
     }
 
 done:
-    SCReturnInt(1);
+    SCReturnInt(APP_LAYER_OK);
 
 error:
     /* An error occurred while processing DNP3 frames.  Dump the
      * buffer as we can't be assured that they are valid anymore. */
     DNP3BufferReset(buffer);
-    SCReturnInt(-1);
+    SCReturnInt(APP_LAYER_ERROR);
 }
 
 static AppLayerDecoderEvents *DNP3GetEvents(void *tx)

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -32,20 +32,28 @@
 static void RustDNSUDPParserRegisterTests(void);
 #endif
 
-static int RustDNSUDPParseRequest(Flow *f, void *state,
+static AppLayerResult RustDNSUDPParseRequest(Flow *f, void *state,
         AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
-    return rs_dns_parse_request(f, state, pstate, input, input_len,
+    int r = rs_dns_parse_request(f, state, pstate, input, input_len,
             local_data);
+    if (r < 0) {
+        SCReturnStruct(APP_LAYER_ERROR);
+    }
+    SCReturnStruct(APP_LAYER_OK);
 }
 
-static int RustDNSUDPParseResponse(Flow *f, void *state,
+static AppLayerResult RustDNSUDPParseResponse(Flow *f, void *state,
         AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
-    return rs_dns_parse_response(f, state, pstate, input, input_len,
+    int r = rs_dns_parse_response(f, state, pstate, input, input_len,
             local_data);
+    if (r < 0) {
+        SCReturnStruct(APP_LAYER_ERROR);
+    }
+    SCReturnStruct(APP_LAYER_OK);
 }
 
 static uint16_t DNSUDPProbe(Flow *f, uint8_t direction,
@@ -224,8 +232,9 @@ static int RustDNSUDPParserTest01 (void)
     f->alstate = rs_dns_state_new();
     FAIL_IF_NULL(f->alstate);
 
-    FAIL_IF_NOT(RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
-                    NULL, STREAM_START) == 0);
+    AppLayerResult r = RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
+                    NULL, STREAM_START);
+    FAIL_IF_NOT(r.status == 0);
 
     UTHFreeFlow(f);
     PASS;
@@ -255,8 +264,9 @@ static int RustDNSUDPParserTest02 (void)
     f->alstate = rs_dns_state_new();
     FAIL_IF_NULL(f->alstate);
 
-    FAIL_IF_NOT(RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
-                    NULL, STREAM_START) == 0);
+    AppLayerResult r = RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
+                    NULL, STREAM_START);
+    FAIL_IF_NOT(r.status == 0);
 
     UTHFreeFlow(f);
     PASS;
@@ -286,8 +296,9 @@ static int RustDNSUDPParserTest03 (void)
     f->alstate = rs_dns_state_new();
     FAIL_IF_NULL(f->alstate);
 
-    FAIL_IF_NOT(RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
-                    NULL, STREAM_START) == 0);
+    AppLayerResult r = RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
+                    NULL, STREAM_START);
+    FAIL_IF_NOT(r.status == 0);
 
     UTHFreeFlow(f);
     PASS;
@@ -320,8 +331,9 @@ static int RustDNSUDPParserTest04 (void)
     f->alstate = rs_dns_state_new();
     FAIL_IF_NULL(f->alstate);
 
-    FAIL_IF_NOT(RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
-                    NULL, STREAM_START) == 0);
+    AppLayerResult r = RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
+                    NULL, STREAM_START);
+    FAIL_IF_NOT(r.status == 0);
 
     UTHFreeFlow(f);
     PASS;
@@ -354,8 +366,9 @@ static int RustDNSUDPParserTest05 (void)
     f->alstate = rs_dns_state_new();
     FAIL_IF_NULL(f->alstate);
 
-    FAIL_IF(RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
-                    NULL, STREAM_START) != -1);
+    AppLayerResult r = RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
+                    NULL, STREAM_START);
+    FAIL_IF_NOT(r.status == -1);
 
     UTHFreeFlow(f);
     PASS;

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -225,7 +225,7 @@ static int RustDNSUDPParserTest01 (void)
     FAIL_IF_NULL(f->alstate);
 
     FAIL_IF_NOT(RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
-                    NULL, STREAM_START));
+                    NULL, STREAM_START) == 0);
 
     UTHFreeFlow(f);
     PASS;
@@ -256,7 +256,7 @@ static int RustDNSUDPParserTest02 (void)
     FAIL_IF_NULL(f->alstate);
 
     FAIL_IF_NOT(RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
-                    NULL, STREAM_START));
+                    NULL, STREAM_START) == 0);
 
     UTHFreeFlow(f);
     PASS;
@@ -287,7 +287,7 @@ static int RustDNSUDPParserTest03 (void)
     FAIL_IF_NULL(f->alstate);
 
     FAIL_IF_NOT(RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
-                    NULL, STREAM_START));
+                    NULL, STREAM_START) == 0);
 
     UTHFreeFlow(f);
     PASS;
@@ -321,7 +321,7 @@ static int RustDNSUDPParserTest04 (void)
     FAIL_IF_NULL(f->alstate);
 
     FAIL_IF_NOT(RustDNSUDPParseResponse(f, f->alstate, NULL, buf, buflen,
-                    NULL, STREAM_START));
+                    NULL, STREAM_START) == 0);
 
     UTHFreeFlow(f);
     PASS;

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -343,20 +343,20 @@ static int ENIPParse(Flow *f, void *state, AppLayerParserState *pstate,
     if (input == NULL && AppLayerParserStateIssetFlag(pstate,
             APP_LAYER_PARSER_EOF))
     {
-        SCReturnInt(1);
+        SCReturnInt(APP_LAYER_OK);
     } else if (input == NULL && input_len != 0) {
         // GAP
-        SCReturnInt(0);
+        SCReturnInt(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0)
     {
-        SCReturnInt(-1);
+        SCReturnInt(APP_LAYER_ERROR);
     }
 
     while (input_len > 0)
     {
         tx = ENIPTransactionAlloc(enip);
         if (tx == NULL)
-            SCReturnInt(0);
+            SCReturnInt(APP_LAYER_OK);
 
         SCLogDebug("ENIPParse input len %d", input_len);
         DecodeENIPPDU(input, input_len, tx);
@@ -379,7 +379,7 @@ static int ENIPParse(Flow *f, void *state, AppLayerParserState *pstate,
         }
     }
 
-    return 1;
+    SCReturnInt(APP_LAYER_OK);
 }
 
 

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -332,7 +332,7 @@ static void ENIPStateTransactionFree(void *state, uint64_t tx_id)
  *
  * \retval 1 when the command is parsed, 0 otherwise
  */
-static int ENIPParse(Flow *f, void *state, AppLayerParserState *pstate,
+static AppLayerResult ENIPParse(Flow *f, void *state, AppLayerParserState *pstate,
         const uint8_t *input, uint32_t input_len, void *local_data,
         const uint8_t flags)
 {
@@ -343,20 +343,20 @@ static int ENIPParse(Flow *f, void *state, AppLayerParserState *pstate,
     if (input == NULL && AppLayerParserStateIssetFlag(pstate,
             APP_LAYER_PARSER_EOF))
     {
-        SCReturnInt(APP_LAYER_OK);
+        SCReturnStruct(APP_LAYER_OK);
     } else if (input == NULL && input_len != 0) {
         // GAP
-        SCReturnInt(APP_LAYER_OK);
+        SCReturnStruct(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0)
     {
-        SCReturnInt(APP_LAYER_ERROR);
+        SCReturnStruct(APP_LAYER_ERROR);
     }
 
     while (input_len > 0)
     {
         tx = ENIPTransactionAlloc(enip);
         if (tx == NULL)
-            SCReturnInt(APP_LAYER_OK);
+            SCReturnStruct(APP_LAYER_OK);
 
         SCLogDebug("ENIPParse input len %d", input_len);
         DecodeENIPPDU(input, input_len, tx);
@@ -379,7 +379,7 @@ static int ENIPParse(Flow *f, void *state, AppLayerParserState *pstate,
         }
     }
 
-    SCReturnInt(APP_LAYER_OK);
+    SCReturnStruct(APP_LAYER_OK);
 }
 
 

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -577,7 +577,9 @@ static int FTPParseRequest(Flow *f, void *ftp_state,
     while (FTPGetLine(state) >= 0) {
         const FtpCommand *cmd_descriptor;
 
-        if (!FTPParseRequestCommand(thread_data, state->current_line, state->current_line_len, &cmd_descriptor)) {
+        if (!FTPParseRequestCommand(thread_data,
+                    state->current_line, state->current_line_len,
+                    &cmd_descriptor)) {
             state->command = FTP_COMMAND_UNKNOWN;
             continue;
         }
@@ -590,7 +592,8 @@ static int FTPParseRequest(Flow *f, void *ftp_state,
         state->curr_tx = tx;
 
         tx->command_descriptor = cmd_descriptor;
-        tx->request_length = CopyCommandLine(&tx->request, state->current_line, state->current_line_len);
+        tx->request_length = CopyCommandLine(&tx->request,
+                state->current_line, state->current_line_len);
 
         switch (state->command) {
             case FTP_COMMAND_EPRT:

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -841,7 +841,7 @@ error:
  *
  *  \retval On success returns 1 or on failure returns -1.
  */
-static int HTPHandleRequestData(Flow *f, void *htp_state,
+static AppLayerResult HTPHandleRequestData(Flow *f, void *htp_state,
                                 AppLayerParserState *pstate,
                                 const uint8_t *input, uint32_t input_len,
                                 void *local_data, const uint8_t flags)
@@ -856,7 +856,7 @@ static int HTPHandleRequestData(Flow *f, void *htp_state,
      */
     if (NULL == hstate->conn) {
         if (Setup(f, hstate) != 0) {
-            goto error;
+            SCReturnStruct(APP_LAYER_ERROR);
         }
     }
     DEBUG_VALIDATE_BUG_ON(hstate->connp == NULL);
@@ -885,10 +885,11 @@ static int HTPHandleRequestData(Flow *f, void *htp_state,
     }
 
     SCLogDebug("hstate->connp %p", hstate->connp);
-    SCReturnInt(ret);
 
-error:
-    SCReturnInt(-1);
+    if (ret < 0) {
+        SCReturnStruct(APP_LAYER_ERROR);
+    }
+    SCReturnStruct(APP_LAYER_OK);
 }
 
 /**
@@ -904,7 +905,7 @@ error:
  *
  *  \retval On success returns 1 or on failure returns -1
  */
-static int HTPHandleResponseData(Flow *f, void *htp_state,
+static AppLayerResult HTPHandleResponseData(Flow *f, void *htp_state,
                                  AppLayerParserState *pstate,
                                  const uint8_t *input, uint32_t input_len,
                                  void *local_data, const uint8_t flags)
@@ -919,7 +920,7 @@ static int HTPHandleResponseData(Flow *f, void *htp_state,
      */
     if (NULL == hstate->conn) {
         if (Setup(f, hstate) != 0) {
-            goto error;
+            SCReturnStruct(APP_LAYER_ERROR);
         }
     }
     DEBUG_VALIDATE_BUG_ON(hstate->connp == NULL);
@@ -946,9 +947,11 @@ static int HTPHandleResponseData(Flow *f, void *htp_state,
     }
 
     SCLogDebug("hstate->connp %p", hstate->connp);
-    SCReturnInt(ret);
-error:
-    SCReturnInt(-1);
+
+    if (ret < 0) {
+        SCReturnStruct(APP_LAYER_ERROR);
+    }
+    SCReturnStruct(APP_LAYER_OK);
 }
 
 /**

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -847,7 +847,7 @@ static int HTPHandleRequestData(Flow *f, void *htp_state,
                                 void *local_data, const uint8_t flags)
 {
     SCEnter();
-    int ret = 1;
+    int ret = 0;
     HtpState *hstate = (HtpState *)htp_state;
 
     /* On the first invocation, create the connection parser structure to
@@ -910,7 +910,7 @@ static int HTPHandleResponseData(Flow *f, void *htp_state,
                                  void *local_data, const uint8_t flags)
 {
     SCEnter();
-    int ret = 1;
+    int ret = 0;
     HtpState *hstate = (HtpState *)htp_state;
 
     /* On the first invocation, create the connection parser structure to

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1285,9 +1285,9 @@ static int ModbusParseHeader(ModbusState   *modbus,
  * \param input     Input line of the command
  * \param input_len Length of the request
  *
- * \retval 1 when the command is parsed, 0 otherwise
+ * \retval AppLayerResult APP_LAYER_OK or APP_LAYER_ERROR
  */
-static int ModbusParseRequest(Flow                  *f,
+static AppLayerResult ModbusParseRequest(Flow       *f,
                               void                  *state,
                               AppLayerParserState   *pstate,
                               const uint8_t         *input,
@@ -1301,9 +1301,9 @@ static int ModbusParseRequest(Flow                  *f,
     ModbusHeader        header;
 
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        SCReturnInt(APP_LAYER_OK);
+        SCReturnStruct(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
-        SCReturnInt(APP_LAYER_ERROR);
+        SCReturnStruct(APP_LAYER_ERROR);
     }
 
     while (input_len > 0) {
@@ -1312,17 +1312,17 @@ static int ModbusParseRequest(Flow                  *f,
 
         /* Extract MODBUS Header */
         if (ModbusParseHeader(modbus, &header, adu, adu_len))
-            SCReturnInt(APP_LAYER_OK);
+            SCReturnStruct(APP_LAYER_OK);
 
         /* Update ADU length with length in Modbus header. */
         adu_len = (uint32_t) sizeof(ModbusHeader) + (uint32_t) header.length - 1;
         if (adu_len > input_len)
-            SCReturnInt(APP_LAYER_OK);
+            SCReturnStruct(APP_LAYER_OK);
 
         /* Allocate a Transaction Context and add it to Transaction list */
         tx = ModbusTxAlloc(modbus);
         if (tx == NULL)
-            SCReturnInt(APP_LAYER_OK);
+            SCReturnStruct(APP_LAYER_OK);
 
         /* Check MODBUS Header */
         ModbusCheckHeader(modbus, &header);
@@ -1340,7 +1340,7 @@ static int ModbusParseRequest(Flow                  *f,
         input_len   -= adu_len;
     }
 
-    SCReturnInt(APP_LAYER_OK);
+    SCReturnStruct(APP_LAYER_OK);
 }
 
 /** \internal
@@ -1350,9 +1350,9 @@ static int ModbusParseRequest(Flow                  *f,
  * \param input     Input line of the command
  * \param input_len Length of the request
  *
- * \retval 1 when the command is parsed, 0 otherwise
+ * \retval AppLayerResult APP_LAYER_OK or APP_LAYER_ERROR
  */
-static int ModbusParseResponse(Flow                 *f,
+static AppLayerResult ModbusParseResponse(Flow      *f,
                                void                 *state,
                                AppLayerParserState  *pstate,
                                const uint8_t        *input,
@@ -1366,9 +1366,9 @@ static int ModbusParseResponse(Flow                 *f,
     ModbusTransaction   *tx;
 
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        SCReturnInt(APP_LAYER_OK);
+        SCReturnStruct(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
-        SCReturnInt(APP_LAYER_ERROR);
+        SCReturnStruct(APP_LAYER_ERROR);
     }
 
     while (input_len > 0) {
@@ -1377,12 +1377,12 @@ static int ModbusParseResponse(Flow                 *f,
 
         /* Extract MODBUS Header */
         if (ModbusParseHeader(modbus, &header, adu, adu_len))
-            SCReturnInt(APP_LAYER_OK);
+            SCReturnStruct(APP_LAYER_OK);
 
         /* Update ADU length with length in Modbus header. */
         adu_len = (uint32_t) sizeof(ModbusHeader) + (uint32_t) header.length - 1;
         if (adu_len > input_len)
-            SCReturnInt(APP_LAYER_OK);
+            SCReturnStruct(APP_LAYER_OK);
 
         /* Find the transaction context thanks to transaction ID (and function code) */
         tx = ModbusTxFindByTransaction(modbus, header.transactionId);
@@ -1391,7 +1391,7 @@ static int ModbusParseResponse(Flow                 *f,
             /* and add it to Transaction list */
             tx = ModbusTxAlloc(modbus);
             if (tx == NULL)
-                SCReturnInt(APP_LAYER_OK);
+                SCReturnStruct(APP_LAYER_OK);
 
             SCLogDebug("MODBUS_DECODER_EVENT_UNSOLICITED_RESPONSE");
             ModbusSetEvent(modbus, MODBUS_DECODER_EVENT_UNSOLICITED_RESPONSE);
@@ -1414,7 +1414,7 @@ static int ModbusParseResponse(Flow                 *f,
         input_len   -= adu_len;
     }
 
-    SCReturnInt(APP_LAYER_OK);
+    SCReturnStruct(APP_LAYER_OK);
 }
 
 /** \internal

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1301,9 +1301,9 @@ static int ModbusParseRequest(Flow                  *f,
     ModbusHeader        header;
 
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        SCReturnInt(1);
+        SCReturnInt(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
-        SCReturnInt(-1);
+        SCReturnInt(APP_LAYER_ERROR);
     }
 
     while (input_len > 0) {
@@ -1312,17 +1312,17 @@ static int ModbusParseRequest(Flow                  *f,
 
         /* Extract MODBUS Header */
         if (ModbusParseHeader(modbus, &header, adu, adu_len))
-            SCReturnInt(0);
+            SCReturnInt(APP_LAYER_OK);
 
         /* Update ADU length with length in Modbus header. */
         adu_len = (uint32_t) sizeof(ModbusHeader) + (uint32_t) header.length - 1;
         if (adu_len > input_len)
-            SCReturnInt(0);
+            SCReturnInt(APP_LAYER_OK);
 
         /* Allocate a Transaction Context and add it to Transaction list */
         tx = ModbusTxAlloc(modbus);
         if (tx == NULL)
-            SCReturnInt(0);
+            SCReturnInt(APP_LAYER_OK);
 
         /* Check MODBUS Header */
         ModbusCheckHeader(modbus, &header);
@@ -1340,7 +1340,7 @@ static int ModbusParseRequest(Flow                  *f,
         input_len   -= adu_len;
     }
 
-    SCReturnInt(1);
+    SCReturnInt(APP_LAYER_OK);
 }
 
 /** \internal
@@ -1366,9 +1366,9 @@ static int ModbusParseResponse(Flow                 *f,
     ModbusTransaction   *tx;
 
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        SCReturnInt(1);
+        SCReturnInt(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
-        SCReturnInt(-1);
+        SCReturnInt(APP_LAYER_ERROR);
     }
 
     while (input_len > 0) {
@@ -1377,12 +1377,12 @@ static int ModbusParseResponse(Flow                 *f,
 
         /* Extract MODBUS Header */
         if (ModbusParseHeader(modbus, &header, adu, adu_len))
-            SCReturnInt(0);
+            SCReturnInt(APP_LAYER_OK);
 
         /* Update ADU length with length in Modbus header. */
         adu_len = (uint32_t) sizeof(ModbusHeader) + (uint32_t) header.length - 1;
         if (adu_len > input_len)
-            SCReturnInt(0);
+            SCReturnInt(APP_LAYER_OK);
 
         /* Find the transaction context thanks to transaction ID (and function code) */
         tx = ModbusTxFindByTransaction(modbus, header.transactionId);
@@ -1391,7 +1391,7 @@ static int ModbusParseResponse(Flow                 *f,
             /* and add it to Transaction list */
             tx = ModbusTxAlloc(modbus);
             if (tx == NULL)
-                SCReturnInt(0);
+                SCReturnInt(APP_LAYER_OK);
 
             SCLogDebug("MODBUS_DECODER_EVENT_UNSOLICITED_RESPONSE");
             ModbusSetEvent(modbus, MODBUS_DECODER_EVENT_UNSOLICITED_RESPONSE);
@@ -1414,7 +1414,7 @@ static int ModbusParseResponse(Flow                 *f,
         input_len   -= adu_len;
     }
 
-    SCReturnInt(1);
+    SCReturnInt(APP_LAYER_OK);
 }
 
 /** \internal

--- a/src/app-layer-nfs-tcp.c
+++ b/src/app-layer-nfs-tcp.c
@@ -156,7 +156,7 @@ static AppProto NFSTCPProbingParser(Flow *f,
     return ALPROTO_UNKNOWN;
 }
 
-static int NFSTCPParseRequest(Flow *f, void *state,
+static AppLayerResult NFSTCPParseRequest(Flow *f, void *state,
     AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
     void *local_data, const uint8_t flags)
 {
@@ -169,10 +169,13 @@ static int NFSTCPParseRequest(Flow *f, void *state,
     } else {
         res = rs_nfs_parse_request(f, state, pstate, input, input_len, local_data);
     }
-    return res;
+    if (res < 0) {
+        SCReturnStruct(APP_LAYER_ERROR);
+    }
+    SCReturnStruct(APP_LAYER_OK);
 }
 
-static int NFSTCPParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
+static AppLayerResult NFSTCPParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
     const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
@@ -185,7 +188,10 @@ static int NFSTCPParseResponse(Flow *f, void *state, AppLayerParserState *pstate
     } else {
         res = rs_nfs_parse_response(f, state, pstate, input, input_len, local_data);
     }
-    return res;
+    if (res < 0) {
+        SCReturnStruct(APP_LAYER_ERROR);
+    }
+    SCReturnStruct(APP_LAYER_OK);
 }
 
 static uint64_t NFSTCPGetTxCnt(void *state)

--- a/src/app-layer-nfs-udp.c
+++ b/src/app-layer-nfs-udp.c
@@ -136,24 +136,32 @@ static AppProto NFSProbingParser(Flow *f, uint8_t direction,
     return ALPROTO_UNKNOWN;
 }
 
-static int NFSParseRequest(Flow *f, void *state,
+static AppLayerResult NFSParseRequest(Flow *f, void *state,
     AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
     void *local_data, const uint8_t flags)
 {
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOSERVER);
     rs_nfs_setfileflags(0, state, file_flags);
 
-    return rs_nfs_parse_request_udp(f, state, pstate, input, input_len, local_data);
+    int res = rs_nfs_parse_request_udp(f, state, pstate, input, input_len, local_data);
+    if (res < 0) {
+        SCReturnStruct(APP_LAYER_ERROR);
+    }
+    SCReturnStruct(APP_LAYER_OK);
 }
 
-static int NFSParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
+static AppLayerResult NFSParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
     const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOCLIENT);
     rs_nfs_setfileflags(1, state, file_flags);
 
-    return rs_nfs_parse_response_udp(f, state, pstate, input, input_len, local_data);
+    int res = rs_nfs_parse_response_udp(f, state, pstate, input, input_len, local_data);
+    if (res < 0) {
+        SCReturnStruct(APP_LAYER_ERROR);
+    }
+    SCReturnStruct(APP_LAYER_OK);
 }
 
 static uint64_t NFSGetTxCnt(void *state)

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1256,10 +1256,8 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
                 /* Used only if it's TCP */
                 TcpSession *ssn = f->protoctx;
                 if (ssn != NULL) {
-                    StreamTcpSetSessionNoReassemblyFlag(ssn,
-                            flags & STREAM_TOCLIENT ? 1 : 0);
-                    StreamTcpSetSessionNoReassemblyFlag(ssn,
-                            flags & STREAM_TOSERVER ? 1 : 0);
+                    StreamTcpSetSessionNoReassemblyFlag(ssn, 0);
+                    StreamTcpSetSessionNoReassemblyFlag(ssn, 1);
                 }
             }
             /* Set the bypass flag for both the stream in this TcpSession */

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1179,6 +1179,8 @@ void AppLayerParserSetTxDetectFlags(uint8_t ipproto, AppProto alproto, void *tx,
 
 /***** General *****/
 
+/** \retval int -1 in case of unrecoverable error. App-layer tracking stops for this flow.
+ *  \retval int 0 ok */
 int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow *f, AppProto alproto,
                         uint8_t flags, const uint8_t *input, uint32_t input_len)
 {
@@ -1190,6 +1192,8 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
     AppLayerParserProtoCtx *p = &alp_ctx.ctxs[f->protomap][alproto];
     void *alstate = NULL;
     uint64_t p_tx_cnt = 0;
+    uint32_t consumed = input_len;
+    const int direction = (flags & STREAM_TOSERVER) ? 0 : 1;
 
     /* we don't have the parser registered for this protocol */
     if (p->StateAlloc == NULL)
@@ -1234,7 +1238,7 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
     /* invoke the recursive parser, but only on data. We may get empty msgs on EOF */
     if (input_len > 0 || (flags & STREAM_EOF)) {
         /* invoke the parser */
-        AppLayerResult res = p->Parser[(flags & STREAM_TOSERVER) ? 0 : 1](f, alstate, pstate,
+        AppLayerResult res = p->Parser[direction](f, alstate, pstate,
                 input, input_len,
                 alp_tctx->alproto_local_storage[f->protomap][alproto],
                 flags);
@@ -1242,8 +1246,31 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
         {
             goto error;
         } else if (res.status > 0) {
-            SCLogNotice("%s: %d", AppLayerGetProtoName(alproto), res.status);
-            abort();
+            if (f->proto == IPPROTO_TCP && f->protoctx != NULL) {
+                TcpSession *ssn = f->protoctx;
+                SCLogDebug("direction %d/%s", direction,
+                        (flags & STREAM_TOSERVER) ? "toserver" : "toclient");
+                BUG_ON(res.consumed > input_len);
+                if (direction == 0) {
+                    /* parser told us how much data it needs on top of what it
+                     * consumed. So we need tell stream engine how much we need
+                     * before the next call */
+                    ssn->client.data_required = res.needed;
+                    SCLogDebug("setting data_required %u", ssn->client.data_required);
+                } else {
+                    /* parser told us how much data it needs on top of what it
+                     * consumed. So we need tell stream engine how much we need
+                     * before the next call */
+                    ssn->server.data_required = res.needed;
+                    SCLogDebug("setting data_required %u", ssn->server.data_required);
+                }
+            } else {
+                /* incomplete is only supported for TCP */
+                BUG_ON(f->proto != IPPROTO_TCP);
+            }
+            BUG_ON(res.needed + res.consumed < input_len);
+            BUG_ON(res.needed == 0);
+            consumed = res.consumed;
         }
     }
 
@@ -1300,6 +1327,12 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
         AppLayerParserStreamTruncated(f->proto, alproto, alstate, flags);
 
  end:
+    /* update app progress */
+    if (f->proto == IPPROTO_TCP && f->protoctx != NULL) {
+        TcpSession *ssn = f->protoctx;
+        StreamTcpUpdateAppLayerProgress(ssn, direction, consumed);
+    }
+
     SCReturnInt(0);
  error:
     /* Set the no app layer inspection flag for both

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1234,12 +1234,16 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
     /* invoke the recursive parser, but only on data. We may get empty msgs on EOF */
     if (input_len > 0 || (flags & STREAM_EOF)) {
         /* invoke the parser */
-        if (p->Parser[(flags & STREAM_TOSERVER) ? 0 : 1](f, alstate, pstate,
+        int parse_res = p->Parser[(flags & STREAM_TOSERVER) ? 0 : 1](f, alstate, pstate,
                 input, input_len,
                 alp_tctx->alproto_local_storage[f->protomap][alproto],
-                flags) < 0)
+                flags);
+        if (parse_res < 0)
         {
             goto error;
+        } else if (parse_res > 0) {
+            SCLogNotice("%s: %d", AppLayerGetProtoName(alproto), parse_res);
+            abort();
         }
     }
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1234,15 +1234,15 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
     /* invoke the recursive parser, but only on data. We may get empty msgs on EOF */
     if (input_len > 0 || (flags & STREAM_EOF)) {
         /* invoke the parser */
-        int parse_res = p->Parser[(flags & STREAM_TOSERVER) ? 0 : 1](f, alstate, pstate,
+        AppLayerResult res = p->Parser[(flags & STREAM_TOSERVER) ? 0 : 1](f, alstate, pstate,
                 input, input_len,
                 alp_tctx->alproto_local_storage[f->protomap][alproto],
                 flags);
-        if (parse_res < 0)
+        if (res.status < 0)
         {
             goto error;
-        } else if (parse_res > 0) {
-            SCLogNotice("%s: %d", AppLayerGetProtoName(alproto), parse_res);
+        } else if (res.status > 0) {
+            SCLogNotice("%s: %d", AppLayerGetProtoName(alproto), res.status);
             abort();
         }
     }
@@ -1992,12 +1992,12 @@ typedef struct TestState_ {
  *  \brief  Test parser function to test the memory deallocation of app layer
  *          parser of occurence of an error.
  */
-static int TestProtocolParser(Flow *f, void *test_state, AppLayerParserState *pstate,
+static AppLayerResult TestProtocolParser(Flow *f, void *test_state, AppLayerParserState *pstate,
                               const uint8_t *input, uint32_t input_len,
                               void *local_data, const uint8_t flags)
 {
     SCEnter();
-    SCReturnInt(-1);
+    SCReturnStruct(APP_LAYER_ERROR);
 }
 
 /** \brief Function to allocates the Test protocol state memory

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -51,6 +51,9 @@
  *  completely inspected */
 #define APP_LAYER_TX_PREFILTER_MASK             ~APP_LAYER_TX_INSPECTED_FLAG
 
+#define APP_LAYER_OK        0
+#define APP_LAYER_ERROR    -1
+
 int AppLayerParserProtoIsRegistered(uint8_t ipproto, AppProto alproto);
 
 /***** transaction handling *****/

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -53,6 +53,7 @@
 
 #define APP_LAYER_OK (AppLayerResult) { 0, 0, 0 }
 #define APP_LAYER_ERROR (AppLayerResult) { -1, 0, 0 }
+#define APP_LAYER_INCOMPLETE(c,n) (AppLayerResult) { 1, (c), (n) }
 
 int AppLayerParserProtoIsRegistered(uint8_t ipproto, AppProto alproto);
 

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -51,8 +51,8 @@
  *  completely inspected */
 #define APP_LAYER_TX_PREFILTER_MASK             ~APP_LAYER_TX_INSPECTED_FLAG
 
-#define APP_LAYER_OK        0
-#define APP_LAYER_ERROR    -1
+#define APP_LAYER_OK (AppLayerResult) { 0, 0, 0 }
+#define APP_LAYER_ERROR (AppLayerResult) { -1, 0, 0 }
 
 int AppLayerParserProtoIsRegistered(uint8_t ipproto, AppProto alproto);
 
@@ -93,7 +93,7 @@ int AppLayerParserConfParserEnabled(const char *ipproto,
                                     const char *alproto_name);
 
 /** \brief Prototype for parsing functions */
-typedef int (*AppLayerParserFPtr)(Flow *f, void *protocol_state,
+typedef AppLayerResult (*AppLayerParserFPtr)(Flow *f, void *protocol_state,
         AppLayerParserState *pstate,
         const uint8_t *buf, uint32_t buf_len,
         void *local_storage, const uint8_t flags);

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -45,7 +45,7 @@ static int SMBTCPParseRequest(Flow *f, void *state,
         res = rs_smb_parse_request_tcp(f, state, pstate, input, input_len,
             local_data, flags);
     }
-    if (res != 1) {
+    if (res != 0) {
         SCLogDebug("SMB request%s of %u bytes, retval %d",
                 (input == NULL && input_len > 0) ? " is GAP" : "", input_len, res);
     }
@@ -68,7 +68,7 @@ static int SMBTCPParseResponse(Flow *f, void *state,
         res = rs_smb_parse_response_tcp(f, state, pstate, input, input_len,
             local_data, flags);
     }
-    if (res != 1) {
+    if (res != 0) {
         SCLogDebug("SMB response%s of %u bytes, retval %d",
                 (input == NULL && input_len > 0) ? " is GAP" : "", input_len, res);
     }

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -30,7 +30,7 @@
 
 #define MIN_REC_SIZE 32+4 // SMB hdr + nbss hdr
 
-static int SMBTCPParseRequest(Flow *f, void *state,
+static AppLayerResult SMBTCPParseRequest(Flow *f, void *state,
         AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
@@ -48,11 +48,12 @@ static int SMBTCPParseRequest(Flow *f, void *state,
     if (res != 0) {
         SCLogDebug("SMB request%s of %u bytes, retval %d",
                 (input == NULL && input_len > 0) ? " is GAP" : "", input_len, res);
+        SCReturnStruct(APP_LAYER_ERROR);
     }
-    return res;
+    SCReturnStruct(APP_LAYER_OK);
 }
 
-static int SMBTCPParseResponse(Flow *f, void *state,
+static AppLayerResult SMBTCPParseResponse(Flow *f, void *state,
         AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
         void *local_data, const uint8_t flags)
 {
@@ -71,8 +72,9 @@ static int SMBTCPParseResponse(Flow *f, void *state,
     if (res != 0) {
         SCLogDebug("SMB response%s of %u bytes, retval %d",
                 (input == NULL && input_len > 0) ? " is GAP" : "", input_len, res);
+        SCReturnStruct(APP_LAYER_ERROR);
     }
-    return res;
+    SCReturnStruct(APP_LAYER_OK);
 }
 
 static uint16_t SMBTCPProbe(Flow *f, uint8_t direction,

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -38,19 +38,20 @@ static AppLayerResult SMBTCPParseRequest(Flow *f, void *state,
     uint16_t file_flags = FileFlowToFlags(f, STREAM_TOSERVER);
     rs_smb_setfileflags(0, state, file_flags|FILE_USE_DETECT);
 
-    int res;
     if (input == NULL && input_len > 0) {
-        res = rs_smb_parse_request_tcp_gap(state, input_len);
+        int res = rs_smb_parse_request_tcp_gap(state, input_len);
+        SCLogDebug("SMB request GAP of %u bytes, retval %d", input_len, res);
+        if (res != 0) {
+            SCReturnStruct(APP_LAYER_ERROR);
+        }
+        SCReturnStruct(APP_LAYER_OK);
     } else {
-        res = rs_smb_parse_request_tcp(f, state, pstate, input, input_len,
-            local_data, flags);
-    }
-    if (res != 0) {
+        AppLayerResult res = rs_smb_parse_request_tcp(f, state, pstate,
+                input, input_len, local_data, flags);
         SCLogDebug("SMB request%s of %u bytes, retval %d",
-                (input == NULL && input_len > 0) ? " is GAP" : "", input_len, res);
-        SCReturnStruct(APP_LAYER_ERROR);
+                (input == NULL && input_len > 0) ? " is GAP" : "", input_len, res.status);
+        SCReturnStruct(res);
     }
-    SCReturnStruct(APP_LAYER_OK);
 }
 
 static AppLayerResult SMBTCPParseResponse(Flow *f, void *state,
@@ -62,19 +63,19 @@ static AppLayerResult SMBTCPParseResponse(Flow *f, void *state,
     rs_smb_setfileflags(1, state, file_flags|FILE_USE_DETECT);
 
     SCLogDebug("SMBTCPParseResponse %p/%u", input, input_len);
-    int res;
     if (input == NULL && input_len > 0) {
-        res = rs_smb_parse_response_tcp_gap(state, input_len);
+        int res = rs_smb_parse_response_tcp_gap(state, input_len);
+        if (res != 0) {
+            SCLogDebug("SMB response%s of %u bytes, retval %d",
+                    (input == NULL && input_len > 0) ? " is GAP" : "", input_len, res);
+            SCReturnStruct(APP_LAYER_ERROR);
+        }
+        SCReturnStruct(APP_LAYER_OK);
     } else {
-        res = rs_smb_parse_response_tcp(f, state, pstate, input, input_len,
-            local_data, flags);
+        AppLayerResult res = rs_smb_parse_response_tcp(f, state, pstate,
+                input, input_len, local_data, flags);
+        SCReturnStruct(res);
     }
-    if (res != 0) {
-        SCLogDebug("SMB response%s of %u bytes, retval %d",
-                (input == NULL && input_len > 0) ? " is GAP" : "", input_len, res);
-        SCReturnStruct(APP_LAYER_ERROR);
-    }
-    SCReturnStruct(APP_LAYER_OK);
 }
 
 static uint16_t SMBTCPProbe(Flow *f, uint8_t direction,

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1353,7 +1353,7 @@ static int SMTPProcessRequest(SMTPState *state, Flow *f,
     }
 }
 
-static int SMTPParse(int direction, Flow *f, SMTPState *state,
+static AppLayerResult SMTPParse(int direction, Flow *f, SMTPState *state,
                      AppLayerParserState *pstate, const uint8_t *input,
                      uint32_t input_len,
                      SMTPThreadCtx *thread_data)
@@ -1361,9 +1361,9 @@ static int SMTPParse(int direction, Flow *f, SMTPState *state,
     SCEnter();
 
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        SCReturnInt(APP_LAYER_OK);
+        SCReturnStruct(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
-        SCReturnInt(APP_LAYER_ERROR);
+        SCReturnStruct(APP_LAYER_ERROR);
     }
 
     state->input = input;
@@ -1374,21 +1374,21 @@ static int SMTPParse(int direction, Flow *f, SMTPState *state,
     if (direction == 0) {
         while (SMTPGetLine(state) >= 0) {
             if (SMTPProcessRequest(state, f, pstate) == -1)
-                SCReturnInt(APP_LAYER_ERROR);
+                SCReturnStruct(APP_LAYER_ERROR);
         }
 
         /* toclient */
     } else {
         while (SMTPGetLine(state) >= 0) {
             if (SMTPProcessReply(state, f, pstate, thread_data) == -1)
-                SCReturnInt(APP_LAYER_ERROR);
+                SCReturnStruct(APP_LAYER_ERROR);
         }
     }
 
-    SCReturnInt(APP_LAYER_OK);
+    SCReturnStruct(APP_LAYER_OK);
 }
 
-static int SMTPParseClientRecord(Flow *f, void *alstate,
+static AppLayerResult SMTPParseClientRecord(Flow *f, void *alstate,
                                  AppLayerParserState *pstate,
                                  const uint8_t *input, uint32_t input_len,
                                  void *local_data, const uint8_t flags)
@@ -1399,7 +1399,7 @@ static int SMTPParseClientRecord(Flow *f, void *alstate,
     return SMTPParse(0, f, alstate, pstate, input, input_len, local_data);
 }
 
-static int SMTPParseServerRecord(Flow *f, void *alstate,
+static AppLayerResult SMTPParseServerRecord(Flow *f, void *alstate,
                                  AppLayerParserState *pstate,
                                  const uint8_t *input, uint32_t input_len,
                                  void *local_data, const uint8_t flags)

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1361,9 +1361,9 @@ static int SMTPParse(int direction, Flow *f, SMTPState *state,
     SCEnter();
 
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        SCReturnInt(1);
+        SCReturnInt(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
-        SCReturnInt(-1);
+        SCReturnInt(APP_LAYER_ERROR);
     }
 
     state->input = input;
@@ -1374,18 +1374,18 @@ static int SMTPParse(int direction, Flow *f, SMTPState *state,
     if (direction == 0) {
         while (SMTPGetLine(state) >= 0) {
             if (SMTPProcessRequest(state, f, pstate) == -1)
-                SCReturnInt(-1);
+                SCReturnInt(APP_LAYER_ERROR);
         }
 
         /* toclient */
     } else {
         while (SMTPGetLine(state) >= 0) {
             if (SMTPProcessReply(state, f, pstate, thread_data) == -1)
-                SCReturnInt(-1);
+                SCReturnInt(APP_LAYER_ERROR);
         }
     }
 
-    SCReturnInt(0);
+    SCReturnInt(APP_LAYER_OK);
 }
 
 static int SMTPParseClientRecord(Flow *f, void *alstate,

--- a/src/app-layer-ssh.c
+++ b/src/app-layer-ssh.c
@@ -428,9 +428,9 @@ static int SSHParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
     SshHeader *ssh_header = &ssh_state->cli_hdr;
 
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        SCReturnInt(1);
+        SCReturnInt(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
-        SCReturnInt(-1);
+        SCReturnInt(APP_LAYER_ERROR);
     }
 
     int r = SSHParseData(ssh_state, ssh_header, input, input_len);
@@ -442,7 +442,10 @@ static int SSHParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
         AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_BYPASS_READY);
     }
 
-    SCReturnInt(r);
+    if (r < 0) {
+        SCReturnInt(APP_LAYER_ERROR);
+    }
+    SCReturnInt(APP_LAYER_OK);
 }
 
 static int SSHParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
@@ -453,9 +456,9 @@ static int SSHParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
     SshHeader *ssh_header = &ssh_state->srv_hdr;
 
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        SCReturnInt(1);
+        SCReturnInt(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
-        SCReturnInt(-1);
+        SCReturnInt(APP_LAYER_ERROR);
     }
 
     int r = SSHParseData(ssh_state, ssh_header, input, input_len);
@@ -467,7 +470,10 @@ static int SSHParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
         AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_BYPASS_READY);
     }
 
-    SCReturnInt(r);
+    if (r < 0) {
+        SCReturnInt(APP_LAYER_ERROR);
+    }
+    SCReturnInt(APP_LAYER_OK);
 }
 
 /** \brief Function to allocates the SSH state memory

--- a/src/app-layer-ssh.c
+++ b/src/app-layer-ssh.c
@@ -420,7 +420,7 @@ static int SSHParseData(SshState *state, SshHeader *header,
     return 0;
 }
 
-static int SSHParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
+static AppLayerResult SSHParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
                            const uint8_t *input, uint32_t input_len,
                            void *local_data, const uint8_t flags)
 {
@@ -428,9 +428,9 @@ static int SSHParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
     SshHeader *ssh_header = &ssh_state->cli_hdr;
 
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        SCReturnInt(APP_LAYER_OK);
+        SCReturnStruct(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
-        SCReturnInt(APP_LAYER_ERROR);
+        SCReturnStruct(APP_LAYER_ERROR);
     }
 
     int r = SSHParseData(ssh_state, ssh_header, input, input_len);
@@ -443,12 +443,12 @@ static int SSHParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
     }
 
     if (r < 0) {
-        SCReturnInt(APP_LAYER_ERROR);
+        SCReturnStruct(APP_LAYER_ERROR);
     }
-    SCReturnInt(APP_LAYER_OK);
+    SCReturnStruct(APP_LAYER_OK);
 }
 
-static int SSHParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
+static AppLayerResult SSHParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
                             const uint8_t *input, uint32_t input_len,
                             void *local_data, const uint8_t flags)
 {
@@ -456,9 +456,9 @@ static int SSHParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
     SshHeader *ssh_header = &ssh_state->srv_hdr;
 
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        SCReturnInt(APP_LAYER_OK);
+        SCReturnStruct(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
-        SCReturnInt(APP_LAYER_ERROR);
+        SCReturnStruct(APP_LAYER_ERROR);
     }
 
     int r = SSHParseData(ssh_state, ssh_header, input, input_len);
@@ -471,9 +471,9 @@ static int SSHParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
     }
 
     if (r < 0) {
-        SCReturnInt(APP_LAYER_ERROR);
+        SCReturnStruct(APP_LAYER_ERROR);
     }
-    SCReturnInt(APP_LAYER_OK);
+    SCReturnStruct(APP_LAYER_OK);
 }
 
 /** \brief Function to allocates the SSH state memory

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2410,9 +2410,9 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
             AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
         /* flag session as finished if APP_LAYER_PARSER_EOF is set */
         ssl_state->flags |= SSL_AL_FLAG_STATE_FINISHED;
-        SCReturnInt(1);
+        SCReturnInt(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
-        SCReturnInt(-1);
+        SCReturnInt(APP_LAYER_ERROR);
     }
 
     if (direction == 0)
@@ -2434,7 +2434,7 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
             SSLParserReset(ssl_state);
             SSLSetEvent(ssl_state,
                         TLS_DECODER_EVENT_TOO_MANY_RECORDS_IN_PACKET);
-            return -1;
+            return APP_LAYER_ERROR;
         }
 
         /* ssl_state->bytes_processed is zero for a fresh record or
@@ -2454,7 +2454,7 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
                         SSLParserReset(ssl_state);
                         SSLSetEvent(ssl_state,
                                 TLS_DECODER_EVENT_INVALID_SSL_RECORD);
-                        return -1;
+                        return APP_LAYER_ERROR;
                     } else {
                         input_len -= retval;
                         input += retval;
@@ -2469,7 +2469,7 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
                         SSLParserReset(ssl_state);
                         SSLSetEvent(ssl_state,
                                 TLS_DECODER_EVENT_INVALID_SSL_RECORD);
-                        return -1;
+                        return APP_LAYER_ERROR;
                     } else {
                         input_len -= retval;
                         input += retval;
@@ -2495,7 +2495,7 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
                         SCLogDebug("Error parsing SSLv2.x.  Reseting parser "
                                    "state.  Let's get outta here");
                         SSLParserReset(ssl_state);
-                        return 0;
+                        return APP_LAYER_OK;
                     } else {
                         input_len -= retval;
                         input += retval;
@@ -2509,7 +2509,7 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
                         SCLogDebug("Error parsing SSLv3.x.  Reseting parser "
                                    "state.  Let's get outta here");
                         SSLParserReset(ssl_state);
-                        return 0;
+                        return APP_LAYER_OK;
                     } else {
                         if (retval > input_len) {
                             SCLogDebug("Error parsing SSLv3.x.  Reseting parser "
@@ -2541,7 +2541,7 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
     if (AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF))
         ssl_state->flags |= SSL_AL_FLAG_STATE_FINISHED;
 
-    return 1;
+    return APP_LAYER_OK;
 }
 
 static int SSLParseClientRecord(Flow *f, void *alstate, AppLayerParserState *pstate,

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2395,7 +2395,7 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
  *
  * \retval >=0 On success.
  */
-static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserState *pstate,
+static AppLayerResult SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserState *pstate,
                      const uint8_t *input, uint32_t ilen)
 {
     SSLState *ssl_state = (SSLState *)alstate;
@@ -2410,9 +2410,9 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
             AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
         /* flag session as finished if APP_LAYER_PARSER_EOF is set */
         ssl_state->flags |= SSL_AL_FLAG_STATE_FINISHED;
-        SCReturnInt(APP_LAYER_OK);
+        SCReturnStruct(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
-        SCReturnInt(APP_LAYER_ERROR);
+        SCReturnStruct(APP_LAYER_ERROR);
     }
 
     if (direction == 0)
@@ -2544,14 +2544,14 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
     return APP_LAYER_OK;
 }
 
-static int SSLParseClientRecord(Flow *f, void *alstate, AppLayerParserState *pstate,
+static AppLayerResult SSLParseClientRecord(Flow *f, void *alstate, AppLayerParserState *pstate,
                          const uint8_t *input, uint32_t input_len,
                          void *local_data, const uint8_t flags)
 {
     return SSLDecode(f, 0 /* toserver */, alstate, pstate, input, input_len);
 }
 
-static int SSLParseServerRecord(Flow *f, void *alstate, AppLayerParserState *pstate,
+static AppLayerResult SSLParseServerRecord(Flow *f, void *alstate, AppLayerParserState *pstate,
                          const uint8_t *input, uint32_t input_len,
                          void *local_data, const uint8_t flags)
 {

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -237,7 +237,7 @@ static AppProto TemplateProbingParserTc(Flow *f, uint8_t direction,
     return ALPROTO_UNKNOWN;
 }
 
-static int TemplateParseRequest(Flow *f, void *statev,
+static AppLayerResult TemplateParseRequest(Flow *f, void *statev,
     AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
     void *local_data, const uint8_t flags)
 {
@@ -248,13 +248,13 @@ static int TemplateParseRequest(Flow *f, void *statev,
     /* Likely connection closed, we can just return here. */
     if ((input == NULL || input_len == 0) &&
         AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        return 0;
+        SCReturnStruct(APP_LAYER_OK);
     }
 
     /* Probably don't want to create a transaction in this case
      * either. */
     if (input == NULL || input_len == 0) {
-        return 0;
+        SCReturnStruct(APP_LAYER_OK);
     }
 
     /* Normally you would parse out data here and store it in the
@@ -302,10 +302,10 @@ static int TemplateParseRequest(Flow *f, void *statev,
     }
 
 end:
-    return 0;
+    SCReturnStruct(APP_LAYER_OK);
 }
 
-static int TemplateParseResponse(Flow *f, void *statev, AppLayerParserState *pstate,
+static AppLayerResult TemplateParseResponse(Flow *f, void *statev, AppLayerParserState *pstate,
     const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
@@ -317,13 +317,13 @@ static int TemplateParseResponse(Flow *f, void *statev, AppLayerParserState *pst
     /* Likely connection closed, we can just return here. */
     if ((input == NULL || input_len == 0) &&
         AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        return 0;
+        SCReturnStruct(APP_LAYER_OK);
     }
 
     /* Probably don't want to create a transaction in this case
      * either. */
     if (input == NULL || input_len == 0) {
-        return 0;
+        SCReturnStruct(APP_LAYER_OK);
     }
 
     /* Look up the existing transaction for this response. In the case
@@ -371,7 +371,7 @@ static int TemplateParseResponse(Flow *f, void *statev, AppLayerParserState *pst
     tx->response_done = 1;
 
 end:
-    return 0;
+    SCReturnStruct(APP_LAYER_OK);
 }
 
 static uint64_t TemplateGetTxCnt(void *statev)

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -96,7 +96,7 @@ static AppProto TFTPProbingParser(Flow *f, uint8_t direction,
     return ALPROTO_UNKNOWN;
 }
 
-static int TFTPParseRequest(Flow *f, void *state,
+static AppLayerResult TFTPParseRequest(Flow *f, void *state,
     AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
     void *local_data, const uint8_t flags)
 {
@@ -105,26 +105,30 @@ static int TFTPParseRequest(Flow *f, void *state,
     /* Likely connection closed, we can just return here. */
     if ((input == NULL || input_len == 0) &&
         AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        return 0;
+        SCReturnStruct(APP_LAYER_OK);
     }
 
     /* Probably don't want to create a transaction in this case
      * either. */
     if (input == NULL || input_len == 0) {
-        return 0;
+        SCReturnStruct(APP_LAYER_OK);
     }
 
-    return rs_tftp_request(state, input, input_len);
+    int res = rs_tftp_request(state, input, input_len);
+    if (res < 0) {
+        SCReturnStruct(APP_LAYER_ERROR);
+    }
+    SCReturnStruct(APP_LAYER_OK);
 }
 
 /**
  * \brief Response parsing is not implemented
  */
-static int TFTPParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
+static AppLayerResult TFTPParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
     const uint8_t *input, uint32_t input_len, void *local_data,
     const uint8_t flags)
 {
-    return 0;
+    SCReturnStruct(APP_LAYER_OK);
 }
 
 static uint64_t TFTPGetTxCnt(void *state)

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2011 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -449,8 +449,6 @@ static int TCPProtoDetect(ThreadVars *tv,
         PACKET_PROFILING_APP_END(app_tctx, f->alproto);
         if (r < 0)
             goto failure;
-        (*stream)->app_progress_rel += data_len;
-
     } else {
         /* if the ssn is midstream, we may end up with a case where the
          * start of an HTTP request is missing. We won't detect HTTP based
@@ -519,9 +517,6 @@ static int TCPProtoDetect(ThreadVars *tv,
                             f->alproto, flags,
                             data, data_len);
                     PACKET_PROFILING_APP_END(app_tctx, f->alproto);
-                    if (r >= 0) {
-                        (*stream)->app_progress_rel += data_len;
-                    }
 
                     AppLayerDecoderEventsSetEventRaw(&p->app_layer_events,
                             APPLAYER_DETECT_PROTOCOL_ONLY_ONE_DIRECTION);
@@ -603,7 +598,6 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                 flags, data, data_len);
         PACKET_PROFILING_APP_END(app_tctx, f->alproto);
         /* ignore parser result for gap */
-        (*stream)->app_progress_rel += data_len;
         goto end;
     }
 
@@ -661,9 +655,6 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
             r = AppLayerParserParse(tv, app_tctx->alp_tctx, f, f->alproto,
                                     flags, data, data_len);
             PACKET_PROFILING_APP_END(app_tctx, f->alproto);
-            if (r >= 0) {
-                (*stream)->app_progress_rel += data_len;
-            }
         }
     }
 

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -117,6 +117,7 @@ typedef struct TcpStream_ {
 
     uint32_t min_inspect_depth;     /**< min inspect size set by the app layer, to make sure enough data
                                      *   remains available for inspection together with app layer buffers */
+    uint32_t data_required;         /**< data required from STREAM_APP_PROGRESS before calling app-layer again */
 
     StreamingBuffer sb;
     struct TCPSEG seg_tree;         /**< red black tree of TCP segments. Data is stored in TcpStream::sb */

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -94,9 +94,9 @@ int StreamTcpReassembleAppLayer (ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
 
 void StreamTcpCreateTestPacket(uint8_t *, uint8_t, uint8_t, uint8_t);
 
-void StreamTcpSetSessionNoReassemblyFlag (TcpSession *, char );
-void StreamTcpSetSessionBypassFlag (TcpSession *);
-void StreamTcpSetDisableRawReassemblyFlag (TcpSession *ssn, char direction);
+void StreamTcpSetSessionNoReassemblyFlag(TcpSession *, char);
+void StreamTcpSetSessionBypassFlag(TcpSession *);
+void StreamTcpSetDisableRawReassemblyFlag(TcpSession *, char);
 
 void StreamTcpSetOSPolicy(TcpStream *, Packet *);
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5857,7 +5857,7 @@ invalid:
  * \param ssn TCP Session to set the flag in
  * \param direction direction to set the flag in: 0 toserver, 1 toclient
  */
-void StreamTcpSetSessionNoReassemblyFlag (TcpSession *ssn, char direction)
+void StreamTcpSetSessionNoReassemblyFlag(TcpSession *ssn, char direction)
 {
     ssn->flags |= STREAMTCP_FLAG_APP_LAYER_DISABLED;
     if (direction) {
@@ -5873,7 +5873,7 @@ void StreamTcpSetSessionNoReassemblyFlag (TcpSession *ssn, char direction)
  * \param ssn TCP Session to set the flag in
  * \param direction direction to set the flag in: 0 toserver, 1 toclient
  */
-void StreamTcpSetDisableRawReassemblyFlag (TcpSession *ssn, char direction)
+void StreamTcpSetDisableRawReassemblyFlag(TcpSession *ssn, char direction)
 {
     direction ? (ssn->server.flags |= STREAMTCP_STREAM_FLAG_NEW_RAW_DISABLED) :
                 (ssn->client.flags |= STREAMTCP_STREAM_FLAG_NEW_RAW_DISABLED);
@@ -5884,7 +5884,7 @@ void StreamTcpSetDisableRawReassemblyFlag (TcpSession *ssn, char direction)
  * \param ssn TCP Session to set the flag in
  * \param direction direction to set the flag in: 0 toserver, 1 toclient
  */
-void StreamTcpSetSessionBypassFlag (TcpSession *ssn)
+void StreamTcpSetSessionBypassFlag(TcpSession *ssn)
 {
     ssn->flags |= STREAMTCP_FLAG_BYPASS;
 }

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5849,6 +5849,21 @@ invalid:
     SCReturnInt(-1);
 }
 
+/** \brief update reassembly progress
+
+ * \param ssn TCP Session
+ * \param direction direction to set the flag in: 0 toserver, 1 toclient
+ */
+void StreamTcpUpdateAppLayerProgress(TcpSession *ssn, char direction,
+        const uint32_t progress)
+{
+    if (direction) {
+        ssn->server.app_progress_rel += progress;
+    } else {
+        ssn->client.app_progress_rel += progress;
+    }
+}
+
 /** \brief disable reassembly
 
  *  Disable app layer and set raw inspect to no longer accept new data.

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -193,5 +193,8 @@ int StreamTcpInlineMode(void);
 
 int TcpSessionPacketSsnReuse(const Packet *p, const Flow *f, const void *tcp_ssn);
 
+void StreamTcpUpdateAppLayerProgress(TcpSession *ssn, char direction,
+        const uint32_t progress);
+
 #endif /* __STREAM_TCP_H__ */
 

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -354,6 +354,8 @@ extern int sc_log_module_cleaned;
 
 #define SCReturnBool(x)                 return x
 
+#define SCReturnStruct(x)                 return x
+
 /* Please use it only for debugging purposes */
 #else
 
@@ -549,6 +551,14 @@ extern int sc_log_module_cleaned;
 #define SCReturnBool(x)        do {                                           \
                                   if (sc_log_global_log_level >= SC_LOG_DEBUG) { \
                                       SCLogDebug("Returning: %s ... <<", x ? "true" : "false"); \
+                                      SCLogCheckFDFilterExit(__FUNCTION__);  \
+                                  }                                          \
+                                  return x;                                  \
+                              } while(0)
+
+#define SCReturnStruct(x)     do {                                           \
+                                  if (sc_log_global_log_level >= SC_LOG_DEBUG) { \
+                                      SCLogDebug("Returning: ... <<");       \
                                       SCLogCheckFDFilterExit(__FUNCTION__);  \
                                   }                                          \
                                   return x;                                  \


### PR DESCRIPTION
Initial support for pushing TCP buffering down to app-layer API.

Implementation for SMB to show how it is used.

Continuation #4671 with:
- removal of `abort()`
- rename `AppLayerReturn` to `AppLayerResult`
- minor style fixes

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed

Ticket: https://redmine.openinfosecfoundation.org/issues/3444