### PR TITLE
Ssh rust v9

### DIFF
--- a/rules/ssh-events.rules
+++ b/rules/ssh-events.rules
@@ -1,0 +1,10 @@
+# SSH app layer event rules
+#
+# SID's fall in the 2228000+ range. See https://redmine.openinfosecfoundation.org/projects/suricata/wiki/AppLayer
+#
+# These sigs fire at most once per connection.
+#
+
+alert ssh any any -> any any (msg:"SURICATA SSH invalid banner"; flow:established; app-layer-event:ssh.invalid_banner; classtype:protocol-command-decode; sid:2228000; rev:1;)
+alert ssh any any -> any any (msg:"SURICATA SSH too long banner"; flow:established; app-layer-event:ssh.long_banner; classtype:protocol-command-decode; sid:2228001; rev:1;)
+alert ssh any any -> any any (msg:"SURICATA SSH invalid record"; flow:established; app-layer-event:ssh.invalid_record; classtype:protocol-command-decode; sid:2228002; rev:1;)

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -110,7 +110,7 @@ exclude = [
 # * "functions":
 #
 # default: []
-item_types = ["structs","opaque","functions"]
+item_types = ["enums","structs","opaque","functions"]
 
 # Whether applying rules in export.rename prevents export.prefix from applying.
 #

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -70,3 +70,4 @@ pub mod dhcp;
 pub mod sip;
 pub mod applayertemplate;
 pub mod rdp;
+pub mod ssh;

--- a/rust/src/ssh/detect.rs
+++ b/rust/src/ssh/detect.rs
@@ -1,0 +1,98 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use super::ssh::SSHTransaction;
+use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
+use std::ptr;
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_tx_get_protocol(
+    tx: *mut std::os::raw::c_void,
+    buffer: *mut *const u8,
+    buffer_len: *mut u32,
+    direction: u8,
+) -> u8 {
+    let tx = cast_pointer!(tx, SSHTransaction);
+    match direction {
+        STREAM_TOSERVER => {
+            let m = &tx.cli_hdr.protover;
+            if m.len() > 0 {
+                unsafe {
+                    *buffer = m.as_ptr();
+                    *buffer_len = m.len() as u32;
+                }
+                return 1;
+            }
+        }
+        STREAM_TOCLIENT => {
+            let m = &tx.srv_hdr.protover;
+            if m.len() > 0 {
+                unsafe {
+                    *buffer = m.as_ptr();
+                    *buffer_len = m.len() as u32;
+                }
+                return 1;
+            }
+        }
+        _ => {}
+    }
+    unsafe {
+        *buffer = ptr::null();
+        *buffer_len = 0;
+    }
+
+    return 0;
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_tx_get_software(
+    tx: *mut std::os::raw::c_void,
+    buffer: *mut *const u8,
+    buffer_len: *mut u32,
+    direction: u8,
+) -> u8 {
+    let tx = cast_pointer!(tx, SSHTransaction);
+    match direction {
+        STREAM_TOSERVER => {
+            let m = &tx.cli_hdr.swver;
+            if m.len() > 0 {
+                unsafe {
+                    *buffer = m.as_ptr();
+                    *buffer_len = m.len() as u32;
+                }
+                return 1;
+            }
+        }
+        STREAM_TOCLIENT => {
+            let m = &tx.srv_hdr.swver;
+            if m.len() > 0 {
+                unsafe {
+                    *buffer = m.as_ptr();
+                    *buffer_len = m.len() as u32;
+                }
+                return 1;
+            }
+        }
+        _ => {}
+    }
+    unsafe {
+        *buffer = ptr::null();
+        *buffer_len = 0;
+    }
+
+    return 0;
+}

--- a/rust/src/ssh/logger.rs
+++ b/rust/src/ssh/logger.rs
@@ -1,0 +1,65 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use super::ssh::SSHTransaction;
+use crate::json::*;
+use std;
+
+fn log_ssh(tx: &SSHTransaction) -> Option<Json> {
+    if tx.cli_hdr.protover.len() == 0 && tx.srv_hdr.protover.len() == 0 {
+        return None;
+    }
+    let js = Json::object();
+    if tx.cli_hdr.protover.len() > 0 {
+        let cjs = Json::object();
+        cjs.set_string(
+            "proto_version",
+            std::str::from_utf8(&tx.cli_hdr.protover).unwrap(),
+        );
+        if tx.cli_hdr.swver.len() > 0 {
+            cjs.set_string(
+                "software_version",
+                std::str::from_utf8(&tx.cli_hdr.swver).unwrap(),
+            );
+        }
+        js.set("client", cjs);
+    }
+    if tx.srv_hdr.protover.len() > 0 {
+        let sjs = Json::object();
+        sjs.set_string(
+            "proto_version",
+            std::str::from_utf8(&tx.srv_hdr.protover).unwrap(),
+        );
+        if tx.srv_hdr.swver.len() > 0 {
+            sjs.set_string(
+                "software_version",
+                std::str::from_utf8(&tx.srv_hdr.swver).unwrap(),
+            );
+        }
+        js.set("server", sjs);
+    }
+    return Some(js);
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_log_json(tx: *mut std::os::raw::c_void) -> *mut JsonT {
+    let tx = cast_pointer!(tx, SSHTransaction);
+    match log_ssh(tx) {
+        Some(js) => js.unwrap(),
+        None => std::ptr::null_mut(),
+    }
+}

--- a/rust/src/ssh/mod.rs
+++ b/rust/src/ssh/mod.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,18 +15,7 @@
  * 02110-1301, USA.
  */
 
-/**
- * \file
- *
- * \author Pablo Rincon <pablo.rincon.crespo@gmail.com>
- * \author Victor Julien <victor@inliniac.net>
- */
-
-#ifndef __APP_LAYER_SSH_H__
-#define __APP_LAYER_SSH_H__
-
-void RegisterSSHParsers(void);
-void SSHParserRegisterTests(void);
-
-#endif /* __APP_LAYER_SSH_H__ */
-
+pub mod detect;
+pub mod logger;
+mod parser;
+pub mod ssh;

--- a/rust/src/ssh/parser.rs
+++ b/rust/src/ssh/parser.rs
@@ -1,0 +1,187 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use nom::number::streaming::{be_u32, be_u8};
+use nom::combinator::rest;
+
+#[inline]
+fn is_not_lineend(b: u8) -> bool {
+    if b == 10 || b == 13 {
+        return false;
+    }
+    return true;
+}
+
+//may leave \r at the end to be removed
+named!(pub ssh_parse_line<&[u8], &[u8]>,
+    terminated!(
+        take_while!(is_not_lineend),
+        alt!( tag!("\n") | tag!("\r\n") |
+              do_parse!(
+                    bytes: tag!("\r") >>
+                    not!(eof!()) >> (bytes)
+                )
+            )
+    )
+);
+
+#[derive(PartialEq)]
+pub struct SshBanner<'a> {
+    pub protover: &'a [u8],
+    pub swver: &'a [u8],
+}
+
+impl<'a> SshBanner<'a> {}
+
+// Could be simplified adding dummy \n at the end
+// or use nom5 nom::bytes::complete::is_not
+named!(pub ssh_parse_banner<SshBanner>,
+    do_parse!(
+        tag!("SSH-") >>
+        protover: is_not!("-") >>
+        char!('-') >>
+        swver: alt!( complete!( is_not!(" \r") ) | rest ) >>
+        //remaning after space is comments
+        (SshBanner{protover, swver})
+    )
+);
+
+#[derive(PartialEq)]
+pub struct SshRecordHeader {
+    pub pkt_len: u32,
+    padding_len: u8,
+    pub msg_code: u8,
+}
+
+named!(pub ssh_parse_record_header<SshRecordHeader>,
+    do_parse!(
+        pkt_len: verify!(be_u32, |&val| val > 1) >>
+        padding_len: be_u8 >>
+        msg_code: be_u8 >>
+        (SshRecordHeader{pkt_len, padding_len, msg_code})
+    )
+);
+
+//test for evasion against pkt_len=0or1...
+named!(pub ssh_parse_record<SshRecordHeader>,
+    do_parse!(
+        pkt_len: verify!(be_u32, |&val| val > 1) >>
+        padding_len: be_u8 >>
+        msg_code: be_u8 >>
+        take!((pkt_len-2) as usize) >>
+        (SshRecordHeader{pkt_len, padding_len, msg_code})
+    )
+);
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    /// Simple test of some valid data.
+    #[test]
+    fn test_ssh_parse_banner() {
+        let buf = b"SSH-Single-";
+        let result = ssh_parse_banner(buf);
+        match result {
+            Ok((_, message)) => {
+                // Check the first message.
+                assert_eq!(message.protover, b"Single");
+                assert_eq!(message.swver, b"");
+            }
+            Err(err) => {
+                panic!("Result should not be an error: {:?}.", err);
+            }
+        }
+        let buf2 = b"SSH-2.0-Soft";
+        let result2 = ssh_parse_banner(buf2);
+        match result2 {
+            Ok((_, message)) => {
+                // Check the first message.
+                assert_eq!(message.protover, b"2.0");
+                assert_eq!(message.swver, b"Soft");
+            }
+            Err(err) => {
+                panic!("Result should not be an error: {:?}.", err);
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_line() {
+        let buf = b"SSH-Single\n";
+        let result = ssh_parse_line(buf);
+        match result {
+            Ok((_, message)) => {
+                // Check the first message.
+                assert_eq!(message, b"SSH-Single");
+            }
+            Err(err) => {
+                panic!("Result should not be an error: {:?}.", err);
+            }
+        }
+        let buf2 = b"SSH-Double\r\n";
+        let result2 = ssh_parse_line(buf2);
+        match result2 {
+            Ok((_, message)) => {
+                // Check the first message.
+                assert_eq!(message, b"SSH-Double");
+            }
+            Err(err) => {
+                panic!("Result should not be an error: {:?}.", err);
+            }
+        }
+        let buf3 = b"SSH-Oops\rMore\r\n";
+        let result3 = ssh_parse_line(buf3);
+        match result3 {
+            Ok((rem, message)) => {
+                // Check the first message.
+                assert_eq!(message, b"SSH-Oops");
+                assert_eq!(rem, b"More\r\n");
+            }
+            Err(err) => {
+                panic!("Result should not be an error: {:?}.", err);
+            }
+        }
+        let buf4 = b"SSH-Miss\r";
+        let result4 = ssh_parse_line(buf4);
+        match result4 {
+            Ok((_, _)) => {
+                panic!("Expected incomplete result");
+            }
+            Err(nom::Err::Incomplete(_)) => {
+                //OK
+                assert_eq!(1, 1);
+            }
+            Err(err) => {
+                panic!("Result should not be an error: {:?}.", err);
+            }
+        }
+        let buf5 = b"\n";
+        let result5 = ssh_parse_line(buf5);
+        match result5 {
+            Ok((_, message)) => {
+                // Check empty line
+                assert_eq!(message, b"");
+            }
+            Err(err) => {
+                panic!("Result should not be an error: {:?}.", err);
+            }
+        }
+    }
+
+}

--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -1,0 +1,589 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use super::parser;
+use crate::applayer::{LoggerFlags, TxDetectFlags};
+use crate::core::STREAM_TOSERVER;
+use crate::core::{self, AppProto, Flow, ALPROTO_UNKNOWN, IPPROTO_TCP};
+use crate::log::*;
+use crate::parser::*;
+use std;
+use std::ffi::{CStr, CString};
+use std::mem::transmute;
+
+static mut ALPROTO_SSH: AppProto = ALPROTO_UNKNOWN;
+
+#[repr(u32)]
+pub enum SSHEvent {
+    InvalidBanner = 0,
+    LongBanner,
+    InvalidRecord,
+}
+
+impl SSHEvent {
+    fn from_i32(value: i32) -> Option<SSHEvent> {
+        match value {
+            0 => Some(SSHEvent::InvalidBanner),
+            1 => Some(SSHEvent::LongBanner),
+            2 => Some(SSHEvent::InvalidRecord),
+            _ => None,
+        }
+    }
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, PartialOrd, PartialEq)]
+pub enum SSHConnectionState {
+    SshStateInProgress = 0,
+    SshStateBannerDone = 1,
+    SshStateFinished = 2,
+}
+
+const SSH_MAX_BANNER_LEN: usize = 256;
+const SSH_RECORD_HEADER_LEN: usize = 6;
+//TODO complete enum and parse messages contents
+const SSH_MSG_NEWKEYS: u8 = 21;
+
+pub struct SshHeader {
+    record_left: u32,
+    record_buf: Vec<u8>,
+    flags: SSHConnectionState,
+    banner: Vec<u8>,
+    //can we have these be references to banner, with start offset and size
+    pub protover: Vec<u8>,
+    pub swver: Vec<u8>,
+}
+
+impl SshHeader {
+    pub fn new() -> SshHeader {
+        SshHeader {
+            record_left: 0,
+            record_buf: Vec::with_capacity(SSH_RECORD_HEADER_LEN),
+            flags: SSHConnectionState::SshStateInProgress,
+            banner: Vec::with_capacity(SSH_MAX_BANNER_LEN),
+            protover: Vec::new(),
+            swver: Vec::new(),
+        }
+    }
+}
+
+pub struct SSHTransaction {
+    pub srv_hdr: SshHeader,
+    pub cli_hdr: SshHeader,
+
+    logged: LoggerFlags,
+    de_state: Option<*mut core::DetectEngineState>,
+    detect_flags: TxDetectFlags,
+    events: *mut core::AppLayerDecoderEvents,
+}
+
+impl SSHTransaction {
+    pub fn new() -> SSHTransaction {
+        SSHTransaction {
+            srv_hdr: SshHeader::new(),
+            cli_hdr: SshHeader::new(),
+            logged: LoggerFlags::new(),
+            de_state: None,
+            detect_flags: TxDetectFlags::default(),
+            events: std::ptr::null_mut(),
+        }
+    }
+
+    pub fn free(&mut self) {
+        if self.events != std::ptr::null_mut() {
+            core::sc_app_layer_decoder_events_free_events(&mut self.events);
+        }
+        if let Some(state) = self.de_state {
+            core::sc_detect_engine_state_free(state);
+        }
+    }
+}
+
+impl Drop for SSHTransaction {
+    fn drop(&mut self) {
+        self.free();
+    }
+}
+
+pub struct SSHState {
+    transaction: SSHTransaction,
+}
+
+impl SSHState {
+    pub fn new() -> Self {
+        Self {
+            transaction: SSHTransaction::new(),
+        }
+    }
+
+    fn set_event(&mut self, event: SSHEvent) {
+        let ev = event as u8;
+        core::sc_app_layer_decoder_events_set_event_raw(&mut self.transaction.events, ev);
+    }
+
+    fn parse_record(&mut self, mut input: &[u8], resp: bool) -> bool {
+        //TODO add SCLogDebug ?
+        let mut hdr = if !resp {
+            &mut self.transaction.cli_hdr
+        } else {
+            &mut self.transaction.srv_hdr
+        };
+        //first skip record left bytes
+        if hdr.record_left > 0 {
+            //should we check for overflow ?
+            let ilen = input.len() as u32;
+            if hdr.record_left >= ilen {
+                hdr.record_left -= ilen;
+                return true;
+            } else {
+                let start = hdr.record_left as usize;
+                input = &input[start..];
+                hdr.record_left = 0;
+            }
+        } else if hdr.record_buf.len() > 0 {
+            //complete already present record_buf
+            if hdr.record_buf.len() + input.len() < SSH_RECORD_HEADER_LEN {
+                hdr.record_buf.extend(input);
+                return true;
+            } else {
+                let needed = SSH_RECORD_HEADER_LEN - hdr.record_buf.len();
+                hdr.record_buf.extend(&input[..needed]);
+                input = &input[needed..];
+            }
+        }
+        // Should we make the code with less duplicates ?
+        if hdr.record_buf.len() > 0 {
+            //parse header out of completed record_buf
+            match parser::ssh_parse_record_header(&hdr.record_buf) {
+                Ok((_, head)) => {
+                    hdr.record_left = head.pkt_len - 2;
+                    if head.msg_code == SSH_MSG_NEWKEYS {
+                        hdr.flags = SSHConnectionState::SshStateFinished;
+                    }
+                    //header with input as maybe incomplete data
+                }
+                Err(_) => {
+                    self.set_event(SSHEvent::InvalidRecord);
+                    return false;
+                }
+            }
+            //empty buffer
+            hdr.record_buf.clear();
+            if hdr.record_left > 0 {
+                let ilen = input.len() as u32;
+                if hdr.record_left >= ilen {
+                    hdr.record_left -= ilen;
+                    return true;
+                } else {
+                    let start = hdr.record_left as usize;
+                    input = &input[start..];
+                    hdr.record_left = 0;
+                }
+            }
+        }
+        //parse records out of input
+        while input.len() > 0 {
+            match parser::ssh_parse_record(input) {
+                Ok((rem, head)) => {
+                    input = rem;
+                    if head.msg_code == SSH_MSG_NEWKEYS {
+                        hdr.flags = SSHConnectionState::SshStateFinished;
+                    }
+                    //header and complete data (not returned)
+                }
+                Err(nom::Err::Incomplete(_)) => {
+                    match parser::ssh_parse_record_header(input) {
+                        Ok((rem, head)) => {
+                            let remlen = rem.len() as u32;
+                            hdr.record_left = head.pkt_len - 2 - remlen;
+                            //header with rem as incomplete data
+                            if head.msg_code == SSH_MSG_NEWKEYS {
+                                hdr.flags = SSHConnectionState::SshStateFinished;
+                            }
+                            return true;
+                        }
+                        Err(nom::Err::Incomplete(_)) => {
+                            hdr.record_buf.extend(input);
+                            return true;
+                        }
+                        Err(_) => {
+                            self.set_event(SSHEvent::InvalidRecord);
+                            return false;
+                        }
+                    }
+                }
+                Err(_) => {
+                    self.set_event(SSHEvent::InvalidRecord);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    fn parse_banner(&mut self, input: &[u8], resp: bool) -> bool {
+        let mut hdr = if !resp {
+            &mut self.transaction.cli_hdr
+        } else {
+            &mut self.transaction.srv_hdr
+        };
+        let mut iline = input;
+        let mut vec = vec![13u8];
+        if hdr.banner.len() > 0 {
+            if hdr.banner[hdr.banner.len() - 1] == 13 {
+                vec.extend(input);
+                iline = &vec[..];
+            }
+        }
+        match parser::ssh_parse_line(iline) {
+            Ok((rem, line)) => {
+                let mut set_event_long = false;
+                if hdr.banner.len() + line.len() <= SSH_MAX_BANNER_LEN {
+                    hdr.banner.extend(line);
+                } else if hdr.banner.len() < SSH_MAX_BANNER_LEN {
+                    hdr.banner
+                        .extend(&line[0..SSH_MAX_BANNER_LEN - hdr.banner.len()]);
+                    set_event_long = true;
+                }
+                match parser::ssh_parse_banner(&hdr.banner) {
+                    Ok((_, banner)) => {
+                        hdr.protover.extend(banner.protover);
+                        if banner.swver.len() > 0 {
+                            hdr.swver.extend(banner.swver);
+                        }
+                        hdr.flags = SSHConnectionState::SshStateBannerDone;
+                    }
+                    Err(_) => {
+                        self.set_event(SSHEvent::InvalidBanner);
+                        return false;
+                    }
+                }
+                if set_event_long {
+                    self.set_event(SSHEvent::LongBanner);
+                }
+                return self.parse_record(rem, resp);
+            }
+            Err(nom::Err::Incomplete(_)) => {
+                if hdr.banner.len() + input.len() <= SSH_MAX_BANNER_LEN {
+                    hdr.banner.extend(input);
+                } else if hdr.banner.len() < SSH_MAX_BANNER_LEN {
+                    hdr.banner
+                        .extend(&input[0..SSH_MAX_BANNER_LEN - hdr.banner.len()]);
+                    self.set_event(SSHEvent::LongBanner);
+                }
+                return true;
+            }
+            Err(_) => {
+                self.set_event(SSHEvent::InvalidBanner);
+                return false;
+            }
+        }
+    }
+}
+
+// C exports.
+
+export_tx_get_detect_state!(rs_ssh_tx_get_detect_state, SSHTransaction);
+export_tx_set_detect_state!(rs_ssh_tx_set_detect_state, SSHTransaction);
+
+export_tx_detect_flags_set!(rs_ssh_set_tx_detect_flags, SSHTransaction);
+export_tx_detect_flags_get!(rs_ssh_get_tx_detect_flags, SSHTransaction);
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_state_get_events(
+    tx: *mut std::os::raw::c_void,
+) -> *mut core::AppLayerDecoderEvents {
+    let tx = cast_pointer!(tx, SSHTransaction);
+    return tx.events;
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_state_get_event_info(
+    event_name: *const std::os::raw::c_char,
+    event_id: *mut std::os::raw::c_int,
+    event_type: *mut core::AppLayerEventType,
+) -> std::os::raw::c_int {
+    if event_name == std::ptr::null() {
+        return -1;
+    }
+    let c_event_name: &CStr = unsafe { CStr::from_ptr(event_name) };
+    let event = match c_event_name.to_str() {
+        Ok(s) => {
+            match s {
+                "invalid_banner" => SSHEvent::InvalidBanner as i32,
+                "long_banner" => SSHEvent::LongBanner as i32,
+                "invalid_record" => SSHEvent::InvalidRecord as i32,
+                _ => -1, // unknown event
+            }
+        }
+        Err(_) => -1, // UTF-8 conversion failed
+    };
+    unsafe {
+        *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
+        *event_id = event as std::os::raw::c_int;
+    };
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_state_get_event_info_by_id(
+    event_id: std::os::raw::c_int,
+    event_name: *mut *const std::os::raw::c_char,
+    event_type: *mut core::AppLayerEventType,
+) -> i8 {
+    if let Some(e) = SSHEvent::from_i32(event_id as i32) {
+        let estr = match e {
+            SSHEvent::InvalidBanner => "invalid_banner\0",
+            SSHEvent::LongBanner => "long_banner\0",
+            SSHEvent::InvalidRecord => "invalid_record\0",
+        };
+        unsafe {
+            *event_name = estr.as_ptr() as *const std::os::raw::c_char;
+            *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
+        };
+        0
+    } else {
+        -1
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_state_new() -> *mut std::os::raw::c_void {
+    let state = SSHState::new();
+    let boxed = Box::new(state);
+    return unsafe { transmute(boxed) };
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_state_free(state: *mut std::os::raw::c_void) {
+    // Just unbox...
+    let _drop: Box<SSHState> = unsafe { transmute(state) };
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_state_tx_free(_state: *mut std::os::raw::c_void, _tx_id: u64) {
+    //do nothing
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_parse_request(
+    _flow: *const Flow,
+    state: *mut std::os::raw::c_void,
+    pstate: *mut std::os::raw::c_void,
+    input: *const u8,
+    input_len: u32,
+    _data: *const std::os::raw::c_void,
+    _flags: u8,
+) -> i32 {
+    let state = &mut cast_pointer!(state, SSHState);
+    let buf = build_slice!(input, input_len as usize);
+    let hdr = &mut state.transaction.cli_hdr;
+    let mut rv = -1;
+    if hdr.flags < SSHConnectionState::SshStateBannerDone {
+        if state.parse_banner(buf, false) {
+            rv = 1;
+        }
+    } else {
+        if state.parse_record(buf, false) {
+            rv = 1;
+        }
+    }
+    if state.transaction.cli_hdr.flags >= SSHConnectionState::SshStateFinished
+        && state.transaction.srv_hdr.flags >= SSHConnectionState::SshStateFinished
+    {
+        unsafe {
+            AppLayerParserStateSetFlag(
+                pstate,
+                APP_LAYER_PARSER_NO_INSPECTION
+                    | APP_LAYER_PARSER_NO_REASSEMBLY
+                    | APP_LAYER_PARSER_BYPASS_READY,
+            );
+        }
+    }
+
+    return rv;
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_parse_response(
+    _flow: *const Flow,
+    state: *mut std::os::raw::c_void,
+    pstate: *mut std::os::raw::c_void,
+    input: *const u8,
+    input_len: u32,
+    _data: *const std::os::raw::c_void,
+    _flags: u8,
+) -> i32 {
+    let state = &mut cast_pointer!(state, SSHState);
+    let buf = build_slice!(input, input_len as usize);
+    let hdr = &mut state.transaction.srv_hdr;
+    let mut rv = -1;
+    if hdr.flags < SSHConnectionState::SshStateBannerDone {
+        if state.parse_banner(buf, true) {
+            rv = 1;
+        }
+    } else {
+        if state.parse_record(buf, true) {
+            rv = 1;
+        }
+    }
+    if state.transaction.cli_hdr.flags >= SSHConnectionState::SshStateFinished
+        && state.transaction.srv_hdr.flags >= SSHConnectionState::SshStateFinished
+    {
+        unsafe {
+            AppLayerParserStateSetFlag(
+                pstate,
+                APP_LAYER_PARSER_NO_INSPECTION
+                    | APP_LAYER_PARSER_NO_REASSEMBLY
+                    | APP_LAYER_PARSER_BYPASS_READY,
+            );
+        }
+    }
+    return rv;
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_state_get_tx(
+    state: *mut std::os::raw::c_void,
+    _tx_id: u64,
+) -> *mut std::os::raw::c_void {
+    let state = cast_pointer!(state, SSHState);
+    return unsafe { transmute(&state.transaction) };
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_state_get_tx_count(_state: *mut std::os::raw::c_void) -> u64 {
+    return 1;
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_state_progress_completion_status(_direction: u8) -> std::os::raw::c_int {
+    return SSHConnectionState::SshStateFinished as i32;
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_tx_get_flags(
+    tx: *mut std::os::raw::c_void,
+    direction: u8,
+) -> SSHConnectionState {
+    let tx = cast_pointer!(tx, SSHTransaction);
+    if direction == STREAM_TOSERVER {
+        return tx.cli_hdr.flags;
+    } else {
+        return tx.srv_hdr.flags;
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_tx_get_alstate_progress(
+    tx: *mut std::os::raw::c_void,
+    direction: u8,
+) -> std::os::raw::c_int {
+    let tx = cast_pointer!(tx, SSHTransaction);
+
+    if tx.cli_hdr.flags >= SSHConnectionState::SshStateFinished
+        && tx.srv_hdr.flags >= SSHConnectionState::SshStateFinished
+    {
+        return SSHConnectionState::SshStateFinished as i32;
+    }
+
+    if direction == STREAM_TOSERVER {
+        if tx.cli_hdr.flags >= SSHConnectionState::SshStateBannerDone {
+            return SSHConnectionState::SshStateBannerDone as i32;
+        }
+    } else {
+        if tx.srv_hdr.flags >= SSHConnectionState::SshStateBannerDone {
+            return SSHConnectionState::SshStateBannerDone as i32;
+        }
+    }
+
+    return SSHConnectionState::SshStateInProgress as i32;
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_tx_get_logged(
+    _state: *mut std::os::raw::c_void,
+    tx: *mut std::os::raw::c_void,
+) -> u32 {
+    let tx = cast_pointer!(tx, SSHTransaction);
+    return tx.logged.get();
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ssh_tx_set_logged(
+    _state: *mut std::os::raw::c_void,
+    tx: *mut std::os::raw::c_void,
+    logged: u32,
+) {
+    let tx = cast_pointer!(tx, SSHTransaction);
+    tx.logged.set(logged);
+}
+
+// Parser name as a C style string.
+const PARSER_NAME: &'static [u8] = b"ssh\0";
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_ssh_register_parser() {
+    let default_port = CString::new("[22]").unwrap();
+    let parser = RustParser {
+        name: PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
+        default_port: default_port.as_ptr(),
+        ipproto: IPPROTO_TCP,
+        //simple patterns, no probing
+        probe_ts: None,
+        probe_tc: None,
+        min_depth: 0,
+        max_depth: 0,
+        state_new: rs_ssh_state_new,
+        state_free: rs_ssh_state_free,
+        tx_free: rs_ssh_state_tx_free,
+        parse_ts: rs_ssh_parse_request,
+        parse_tc: rs_ssh_parse_response,
+        get_tx_count: rs_ssh_state_get_tx_count,
+        get_tx: rs_ssh_state_get_tx,
+        tx_get_comp_st: rs_ssh_state_progress_completion_status,
+        tx_get_progress: rs_ssh_tx_get_alstate_progress,
+        get_tx_logged: Some(rs_ssh_tx_get_logged),
+        set_tx_logged: Some(rs_ssh_tx_set_logged),
+        get_de_state: rs_ssh_tx_get_detect_state,
+        set_de_state: rs_ssh_tx_set_detect_state,
+        get_events: Some(rs_ssh_state_get_events),
+        get_eventinfo: Some(rs_ssh_state_get_event_info),
+        get_eventinfo_byid: Some(rs_ssh_state_get_event_info_by_id),
+        localstorage_new: None,
+        localstorage_free: None,
+        get_tx_mpm_id: None,
+        set_tx_mpm_id: None,
+        get_files: None,
+        get_tx_iterator: None,
+        get_tx_detect_flags: Some(rs_ssh_get_tx_detect_flags),
+        set_tx_detect_flags: Some(rs_ssh_set_tx_detect_flags),
+    };
+
+    let ip_proto_str = CString::new("tcp").unwrap();
+
+    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+        let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
+        ALPROTO_SSH = alproto;
+        if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+            let _ = AppLayerRegisterParser(&parser, alproto);
+        }
+        SCLogNotice!("Rust ssh parser registered.");
+    } else {
+        SCLogNotice!("Protocol detector and parser disabled for SSH.");
+    }
+}

--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -724,16 +724,16 @@ static void PacketToDataProtoTLS(const Packet *p, const PacketAlert *pa, idmef_a
 static void PacketToDataProtoSSH(const Packet *p, const PacketAlert *pa, idmef_alert_t *alert)
 {
     json_t *js, *s_js;
-    SshState *ssh_state = (SshState *)FlowGetAppState(p->flow);
+    void *ssh_state = FlowGetAppState(p->flow);
 
     if (ssh_state == NULL)
         return;
 
-    js = json_object();
-    if (js == NULL)
+    void *tx_ptr = rs_ssh_state_get_tx(ssh_state, 0);
+    BUG_ON(tx_ptr == NULL);
+    js = rs_ssh_log_json(tx_ptr);
+    if (unlikely(js == NULL))
         return;
-
-    JsonSshLogJSON(js, ssh_state);
 
     s_js = json_object_get(js, "server");
     if (s_js != NULL) {

--- a/src/app-layer-ssh.c
+++ b/src/app-layer-ssh.c
@@ -41,6 +41,7 @@
 #include "app-layer-protos.h"
 #include "app-layer-parser.h"
 #include "app-layer-ssh.h"
+#include "rust.h"
 
 #include "conf.h"
 
@@ -51,557 +52,6 @@
 
 #include "util-byte.h"
 #include "util-memcmp.h"
-
-/** \internal
- *  \brief Function to parse the SSH version string of the client
- *
- *  The input to this function is a byte buffer starting with SSH-
- *
- *  \param  ssh_state   Pointer the state in which the value to be stored
- *  \param  input       Pointer the received input data
- *  \param  input_len   Length in bytes of the received data
- *
- *  \retval len remaining length in input
- */
-static int SSHParseBanner(SshState *state, SshHeader *header, const uint8_t *input, uint32_t input_len)
-{
-    const uint8_t *line_ptr = input;
-    uint32_t line_len = input_len;
-
-    /* is it the version line? */
-    if (line_len < 4) {
-        SCReturnInt(-1);
-    }
-    if (SCMemcmp("SSH-", line_ptr, 4) != 0) {
-        SCReturnInt(-1);
-    }
-
-    const uint8_t *banner_end = BasicSearch(line_ptr, line_len, (uint8_t*)"\r", 1);
-    if (banner_end == NULL) {
-        banner_end = BasicSearch(line_ptr, line_len, (uint8_t*)"\n", 1);
-        if (banner_end == NULL) {
-            SCLogDebug("No EOL at the end of banner buffer");
-            SCReturnInt(-1);
-        }
-    }
-
-    if ((banner_end - line_ptr) > 255) {
-        SCLogDebug("Invalid version string, it should be less than 255 "
-                "characters including <CR><NL>, input value is %"PRIuMAX,
-                (uintmax_t)(banner_end - line_ptr));
-        SCReturnInt(-1);
-    }
-
-    /* don't search things behind the end of banner */
-    line_len = banner_end - line_ptr;
-
-    /* ok, we have found the version line/string, skip it and parse proto version */
-    line_ptr += 4;
-    line_len -= 4;
-
-    uint8_t *proto_end = BasicSearch(line_ptr, line_len, (uint8_t*)"-", 1);
-    if (proto_end == NULL) {
-        /* Strings starting with SSH- are not allowed
-         * if they are not the real version string */
-        SCLogDebug("Info Version String for SSH (invalid usage of SSH- prefix)");
-        SCReturnInt(-1);
-    }
-    uint64_t proto_ver_len = (uint64_t)(proto_end - line_ptr);
-    header->proto_version = SCMalloc(proto_ver_len + 1);
-    if (header->proto_version == NULL) {
-        SCReturnInt(-1);
-    }
-    memcpy(header->proto_version, line_ptr, proto_ver_len);
-    header->proto_version[proto_ver_len] = '\0';
-
-    /* Now lets parse the software & version */
-    line_ptr += proto_ver_len + 1;
-    line_len -= proto_ver_len + 1;
-    if (line_len < 1) {
-        SCLogDebug("No software version specified (weird)");
-        header->flags |= SSH_FLAG_VERSION_PARSED;
-        /* Return the remaining length */
-        SCReturnInt(0);
-    }
-
-    uint64_t sw_ver_len = (uint64_t)(banner_end - line_ptr);
-    /* sanity check on this arithmetic */
-    if ((sw_ver_len <= 1) || (sw_ver_len >= input_len)) {
-        SCLogDebug("Should not have sw version length '%" PRIu64 "'", sw_ver_len);
-        header->flags |= SSH_FLAG_VERSION_PARSED;
-        SCReturnInt(-1);
-    }
-
-    header->software_version = SCMalloc(sw_ver_len + 1);
-    if (header->software_version == NULL) {
-        header->flags |= SSH_FLAG_VERSION_PARSED;
-        SCReturnInt(-1);
-    }
-    memcpy(header->software_version, line_ptr, sw_ver_len);
-    header->software_version[sw_ver_len] = '\0';
-    if (header->software_version[sw_ver_len - 1] == 0x0d)
-        header->software_version[sw_ver_len - 1] = '\0';
-
-    header->flags |= SSH_FLAG_VERSION_PARSED;
-
-    /* Return the remaining length */
-    int len = input_len - (banner_end - input);
-    SCReturnInt(len);
-}
-
-static int SSHParseRecordHeader(SshState *state, SshHeader *header,
-        const uint8_t *input, uint32_t input_len)
-{
-#ifdef DEBUG
-    BUG_ON(input_len != 6);
-#else
-    if (input_len < 6)
-        SCReturnInt(-1);
-#endif
-    /* input and input_len now point past initial line */
-    uint32_t pkt_len = 0;
-    int r = ByteExtractUint32(&pkt_len, BYTE_BIG_ENDIAN,
-            4, input);
-    if (r != 4) {
-        SCLogDebug("xtract 4 bytes failed %d", r);
-        SCReturnInt(-1);
-    }
-    if (pkt_len < 2) {
-        SCReturnInt(-1);
-    }
-
-    header->pkt_len = pkt_len;
-    SCLogDebug("pkt len: %"PRIu32, pkt_len);
-
-    input += 4;
-    //input_len -= 4;
-
-    header->padding_len = *input;
-
-    input += 1;
-    //input_len -= 1;
-
-    SCLogDebug("padding: %u", header->padding_len);
-
-    header->msg_code = *input;
-
-    SCLogDebug("msg code: %u", header->msg_code);
-
-    if (header->msg_code == SSH_MSG_NEWKEYS) {
-        /* done */
-        SCLogDebug("done");
-        header->flags |= SSH_FLAG_PARSER_DONE;
-    } else {
-        /* not yet done */
-        SCLogDebug("not done");
-    }
-    SCReturnInt(0);
-}
-
-/** \internal
- *  \brief Function to parse the SSH field in packet received from the client
- *
- *  Input to this function is a byte buffer starting with SSH- up to at least
- *  a \r or \n character.
- *
- *  \param  ssh_state   Pointer the state in which the value to be stored
- *  \param  input       Pointer the received input data
- *  \param  input_len   Length in bytes of the received data
- */
-static int SSHParseRecord(SshState *state, SshHeader *header, const uint8_t *input, uint32_t input_len)
-{
-    SCEnter();
-    int ret = 0;
-
-    if (header->flags & SSH_FLAG_PARSER_DONE) {
-        SCReturnInt(0);
-    }
-
-    SCLogDebug("state %p, input %p,input_len %" PRIu32,
-               state, input, input_len);
-    //PrintRawDataFp(stdout, input, input_len);
-
-    if (!(header->flags & SSH_FLAG_VERSION_PARSED)) {
-        ret = SSHParseBanner(state, header, input, input_len);
-        if (ret < 0) {
-            SCLogDebug("Invalid version string");
-            SCReturnInt(-1);
-        } else if (header->flags & SSH_FLAG_VERSION_PARSED) {
-            SCLogDebug("Version string parsed, remaining length %d", ret);
-            input += input_len - ret;
-            input_len -= (input_len - ret);
-
-            uint32_t u = 0;
-            while (u < input_len && (input[u] == '\r' || input[u] == '\n')) {
-                u++;
-            }
-            SCLogDebug("skipping %u EOL bytes", u);
-            input += u;
-            input_len -= u;
-
-            if (input_len == 0)
-                SCReturnInt(0);
-
-        } else {
-            BUG_ON(1);// we only call this when we have enough data
-            SCLogDebug("Version string not parsed yet");
-            //pstate->parse_field = 0;
-            SCReturnInt(0);
-        }
-    } else {
-        SCLogDebug("Version string already parsed");
-    }
-
-    /* skip bytes from the current record if we have to */
-    if (header->record_left > 0) {
-        SCLogDebug("skipping bytes part of the current record");
-        if (header->record_left > input_len) {
-            header->record_left -= input_len;
-            SCLogDebug("all input skipped, %u left in record", header->record_left);
-            SCReturnInt(0);
-        } else {
-            input_len -= header->record_left;
-            input += header->record_left;
-            header->record_left = 0;
-
-            if (input_len == 0) {
-                SCLogDebug("all input skipped");
-                SCReturnInt(0);
-            }
-        }
-    }
-
-again:
-    /* input is too small, even when combined with stored bytes */
-    if (header->buf_offset + input_len < 6) {
-        memcpy(header->buf + header->buf_offset, input, input_len);
-        header->buf_offset += input_len;
-        SCReturnInt(0);
-
-    /* we have enough bytes to parse 6 bytes, lets see if we have
-     * previously stored some */
-    } else if (header->buf_offset > 0) {
-        uint8_t needed = 6 - header->buf_offset;
-
-        SCLogDebug("parse stored");
-        memcpy(header->buf + header->buf_offset, input, needed);
-        header->buf_offset = 6;
-
-        // parse the 6
-        if (SSHParseRecordHeader(state, header, header->buf, 6) < 0)
-            SCReturnInt(-1);
-        header->buf_offset = 0;
-
-        uint32_t record_left = header->pkt_len - 2;
-        input_len -= needed;
-        input += needed;
-
-        if (record_left > input_len) {
-            header->record_left = record_left - input_len;
-        } else {
-            input_len -= record_left;
-            if (input_len == 0)
-                SCReturnInt(0);
-
-            input += record_left;
-
-            SCLogDebug("we have %u left to parse", input_len);
-            goto again;
-
-        }
-
-    /* nothing stored, lets parse this directly */
-    } else {
-        SCLogDebug("parse direct");
-        //PrintRawDataFp(stdout, input, input_len);
-        if (SSHParseRecordHeader(state, header, input, 6) < 0)
-            SCReturnInt(-1);
-
-        uint32_t record_left = header->pkt_len - 2;
-        SCLogDebug("record left %u", record_left);
-        input_len -= 6;
-        input += 6;
-
-        if (record_left > input_len) {
-            header->record_left = record_left - input_len;
-        } else {
-            input_len -= record_left;
-            if (input_len == 0)
-                SCReturnInt(0);
-            input += record_left;
-            //PrintRawDataFp(stdout, input, input_len);
-
-            SCLogDebug("we have %u left to parse", input_len);
-            goto again;
-        }
-    }
-
-    SCReturnInt(0);
-}
-
-static int EnoughData(const uint8_t *input, uint32_t input_len)
-{
-    uint32_t u;
-    for (u = 0; u < input_len; u++) {
-        if (input[u] == '\r' || input[u] == '\n')
-            return TRUE;
-    }
-    return FALSE;
-}
-
-#define MAX_BANNER_LEN 256
-
-static int SSHParseData(SshState *state, SshHeader *header,
-                        const uint8_t *input, uint32_t input_len)
-{
-    /* we're looking for the banner */
-    if (!(header->flags & SSH_FLAG_VERSION_PARSED))
-    {
-        int banner_eol = EnoughData(input, input_len);
-
-        /* fast track normal case: no buffering */
-        if (header->banner_buffer == NULL && banner_eol)
-        {
-            SCLogDebug("enough data, parse now");
-            // parse now
-            int r = SSHParseRecord(state, header, input, input_len);
-            SCReturnInt(r);
-
-        /* banner EOL with existing buffer present. Time for magic. */
-        } else if (banner_eol) {
-            SCLogDebug("banner EOL with existing buffer");
-
-            uint32_t tocopy = MAX_BANNER_LEN - header->banner_len;
-            if (tocopy > input_len)
-                tocopy = input_len;
-
-            SCLogDebug("tocopy %u input_len %u", tocopy, input_len);
-            memcpy(header->banner_buffer + header->banner_len, input, tocopy);
-            header->banner_len += tocopy;
-
-            SCLogDebug("header->banner_len %u", header->banner_len);
-            int r = SSHParseRecord(state, header,
-                    header->banner_buffer, header->banner_len);
-            if (r == 0) {
-                input += tocopy;
-                input_len -= tocopy;
-                if (input_len > 0) {
-                    SCLogDebug("handling remaining data %u", input_len);
-                    r = SSHParseRecord(state, header, input, input_len);
-                }
-            }
-            SCReturnInt(r);
-
-        /* no banner EOL, so we need to buffer */
-        } else if (!banner_eol) {
-            if (header->banner_buffer == NULL) {
-                header->banner_buffer = SCMalloc(MAX_BANNER_LEN);
-                if (header->banner_buffer == NULL)
-                    SCReturnInt(-1);
-            }
-
-            uint32_t tocopy = MAX_BANNER_LEN - header->banner_len;
-            if (tocopy > input_len)
-                tocopy = input_len;
-            SCLogDebug("tocopy %u", tocopy);
-
-            memcpy(header->banner_buffer + header->banner_len, input, tocopy);
-            header->banner_len += tocopy;
-            SCLogDebug("header->banner_len %u", header->banner_len);
-        }
-
-    /* we have a banner, the rest is just records */
-    } else {
-        int r = SSHParseRecord(state, header, input, input_len);
-        SCReturnInt(r);
-    }
-
-    //PrintRawDataFp(stdout, input, input_len);
-    return 0;
-}
-
-static int SSHParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
-                           const uint8_t *input, uint32_t input_len,
-                           void *local_data, const uint8_t flags)
-{
-    SshState *ssh_state = (SshState *)state;
-    SshHeader *ssh_header = &ssh_state->cli_hdr;
-
-    if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        SCReturnInt(1);
-    } else if (input == NULL || input_len == 0) {
-        SCReturnInt(-1);
-    }
-
-    int r = SSHParseData(ssh_state, ssh_header, input, input_len);
-
-    if (ssh_state->cli_hdr.flags & SSH_FLAG_PARSER_DONE &&
-        ssh_state->srv_hdr.flags & SSH_FLAG_PARSER_DONE) {
-        AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_INSPECTION);
-        AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_REASSEMBLY);
-        AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_BYPASS_READY);
-    }
-
-    SCReturnInt(r);
-}
-
-static int SSHParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
-                            const uint8_t *input, uint32_t input_len,
-                            void *local_data, const uint8_t flags)
-{
-    SshState *ssh_state = (SshState *)state;
-    SshHeader *ssh_header = &ssh_state->srv_hdr;
-
-    if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
-        SCReturnInt(1);
-    } else if (input == NULL || input_len == 0) {
-        SCReturnInt(-1);
-    }
-
-    int r = SSHParseData(ssh_state, ssh_header, input, input_len);
-
-    if (ssh_state->cli_hdr.flags & SSH_FLAG_PARSER_DONE &&
-        ssh_state->srv_hdr.flags & SSH_FLAG_PARSER_DONE) {
-        AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_INSPECTION);
-        AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_REASSEMBLY);
-        AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_BYPASS_READY);
-    }
-
-    SCReturnInt(r);
-}
-
-/** \brief Function to allocates the SSH state memory
- */
-static void *SSHStateAlloc(void)
-{
-    void *s = SCMalloc(sizeof(SshState));
-    if (unlikely(s == NULL))
-        return NULL;
-
-    memset(s, 0, sizeof(SshState));
-    return s;
-}
-
-/** \brief Function to free the SSH state memory
- */
-static void SSHStateFree(void *state)
-{
-    SshState *s = (SshState *)state;
-    if (s->cli_hdr.proto_version != NULL)
-        SCFree(s->cli_hdr.proto_version);
-    if (s->cli_hdr.software_version != NULL)
-        SCFree(s->cli_hdr.software_version);
-    if (s->cli_hdr.banner_buffer != NULL)
-        SCFree(s->cli_hdr.banner_buffer);
-
-    if (s->srv_hdr.proto_version != NULL)
-        SCFree(s->srv_hdr.proto_version);
-    if (s->srv_hdr.software_version != NULL)
-        SCFree(s->srv_hdr.software_version);
-    if (s->srv_hdr.banner_buffer != NULL)
-        SCFree(s->srv_hdr.banner_buffer);
-
-    //AppLayerDecoderEventsFreeEvents(&s->decoder_events);
-
-    if (s->de_state != NULL) {
-        DetectEngineStateFree(s->de_state);
-    }
-
-    SCFree(s);
-}
-
-static int SSHSetTxDetectState(void *vtx, DetectEngineState *de_state)
-{
-    SshState *ssh_state = (SshState *)vtx;
-    ssh_state->de_state = de_state;
-    return 0;
-}
-
-static DetectEngineState *SSHGetTxDetectState(void *vtx)
-{
-    SshState *ssh_state = (SshState *)vtx;
-    return ssh_state->de_state;
-}
-
-static void SSHStateTransactionFree(void *state, uint64_t tx_id)
-{
-    /* do nothing */
-}
-
-static void *SSHGetTx(void *state, uint64_t tx_id)
-{
-    SshState *ssh_state = (SshState *)state;
-    return ssh_state;
-}
-
-static uint64_t SSHGetTxCnt(void *state)
-{
-    /* single tx */
-    return 1;
-}
-
-static void SSHSetTxLogged(void *state, void *tx, LoggerId logged)
-{
-    SshState *ssh_state = (SshState *)state;
-    if (ssh_state)
-        ssh_state->logged = logged;
-}
-
-static LoggerId SSHGetTxLogged(void *state, void *tx)
-{
-    SshState *ssh_state = (SshState *)state;
-    if (ssh_state) {
-        return ssh_state->logged;
-    }
-    return 0;
-}
-
-static uint64_t SSHGetTxDetectFlags(void *vtx, uint8_t dir)
-{
-    SshState *ssh_state = (SshState *)vtx;
-    if (dir & STREAM_TOSERVER) {
-        return ssh_state->detect_flags_ts;
-    } else {
-        return ssh_state->detect_flags_tc;
-    }
-}
-
-static void SSHSetTxDetectFlags(void *vtx, uint8_t dir, uint64_t flags)
-{
-    SshState *ssh_state = (SshState *)vtx;
-    if (dir & STREAM_TOSERVER) {
-        ssh_state->detect_flags_ts = flags;
-    } else {
-        ssh_state->detect_flags_tc = flags;
-    }
-}
-
-static int SSHGetAlstateProgressCompletionStatus(uint8_t direction)
-{
-    return SSH_STATE_FINISHED;
-}
-
-static int SSHGetAlstateProgress(void *tx, uint8_t direction)
-{
-    SshState *ssh_state = (SshState *)tx;
-
-    if (ssh_state->cli_hdr.flags & SSH_FLAG_PARSER_DONE &&
-        ssh_state->srv_hdr.flags & SSH_FLAG_PARSER_DONE) {
-        return SSH_STATE_FINISHED;
-    }
-
-    if (direction == STREAM_TOSERVER) {
-        if (ssh_state->cli_hdr.flags & SSH_FLAG_VERSION_PARSED) {
-            return SSH_STATE_BANNER_DONE;
-        }
-    } else {
-        if (ssh_state->srv_hdr.flags & SSH_FLAG_VERSION_PARSED) {
-            return SSH_STATE_BANNER_DONE;
-        }
-    }
-
-    return SSH_STATE_IN_PROGRESS;
-}
 
 static int SSHRegisterPatternsForProtocolDetection(void)
 {
@@ -630,36 +80,9 @@ void RegisterSSHParsers(void)
             return;
     }
 
-    if (AppLayerParserConfParserEnabled("tcp", proto_name)) {
-        AppLayerParserRegisterParser(IPPROTO_TCP, ALPROTO_SSH, STREAM_TOSERVER,
-                                     SSHParseRequest);
-        AppLayerParserRegisterParser(IPPROTO_TCP, ALPROTO_SSH, STREAM_TOCLIENT,
-                                     SSHParseResponse);
-        AppLayerParserRegisterStateFuncs(IPPROTO_TCP, ALPROTO_SSH, SSHStateAlloc, SSHStateFree);
-        AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_TCP,
-                ALPROTO_SSH, STREAM_TOSERVER|STREAM_TOCLIENT);
+    SCLogNotice("Registring Rust SSH parser.");
+    rs_ssh_register_parser();
 
-        AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_SSH, SSHStateTransactionFree);
-
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_SSH,
-                                               SSHGetTxDetectState, SSHSetTxDetectState);
-
-        AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_SSH, SSHGetTx);
-
-        AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_SSH, SSHGetTxCnt);
-
-        AppLayerParserRegisterGetStateProgressFunc(IPPROTO_TCP, ALPROTO_SSH, SSHGetAlstateProgress);
-
-        AppLayerParserRegisterLoggerFuncs(IPPROTO_TCP, ALPROTO_SSH, SSHGetTxLogged, SSHSetTxLogged);
-        AppLayerParserRegisterDetectFlagsFuncs(IPPROTO_TCP, ALPROTO_SSH,
-                SSHGetTxDetectFlags, SSHSetTxDetectFlags);
-
-        AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_SSH,
-                                                               SSHGetAlstateProgressCompletionStatus);
-    } else {
-//        SCLogInfo("Parsed disabled for %s protocol. Protocol detection"
-//                  "still on.", proto_name);
-    }
 
 #ifdef UNITTESTS
     AppLayerParserRegisterProtocolUnittests(IPPROTO_TCP, ALPROTO_SSH, SSHParserRegisterTests);
@@ -669,6 +92,47 @@ void RegisterSSHParsers(void)
 /* UNITTESTS */
 #ifdef UNITTESTS
 #include "flow-util.h"
+
+static int SSHParserTestUtilCheck(const char *protoexp, const char *softexp, void *tx, uint8_t flags) {
+    const uint8_t *protocol = NULL;
+    uint32_t p_len = 0;
+    const uint8_t *software = NULL;
+    uint32_t s_len = 0;
+
+    if (rs_ssh_tx_get_protocol(tx, &protocol, &p_len, flags) != 1) {
+        printf("Version string not parsed correctly return: ");
+        return 1;
+    }
+    if (protocol == NULL) {
+        printf("Version string not parsed correctly NULL: ");
+        return 1;
+    }
+
+    if (p_len != strlen(protoexp)) {
+        printf("Version string not parsed correctly length: ");
+        return 1;
+    }
+    if (memcmp(protocol, protoexp, strlen(protoexp)) != 0) {
+        printf("Version string not parsed correctly: ");
+        return 1;
+    }
+
+    if (softexp != NULL) {
+        if (rs_ssh_tx_get_software(tx, &software, &s_len, flags) != 1)
+            return 1;
+        if (software == NULL)
+            return 1;
+        if (s_len != strlen(softexp)) {
+            printf("Software string not parsed correctly length: ");
+            return 1;
+        }
+        if (memcmp(software, softexp, strlen(softexp)) != 0) {
+            printf("Software string not parsed correctly: ");
+            return 1;
+        }
+    }
+    return 0;
+}
 
 /** \test Send a version string in one chunk (client version str). */
 static int SSHParserTest01(void)
@@ -695,36 +159,20 @@ static int SSHParserTest01(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
 
-    if ( !(ssh_state->cli_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOSERVER) != SshStateBannerDone ) {
         printf("Client version string not parsed: ");
         goto end;
     }
 
-    if (ssh_state->cli_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
+    if (SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOSERVER))
         goto end;
-    }
-
-    if (ssh_state->cli_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.software_version, "MySSHClient-0.5.1", strlen("MySSHClient-0.5.1")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
 
     result = 1;
 end:
@@ -762,36 +210,19 @@ static int SSHParserTest02(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
 
-    if ( !(ssh_state->cli_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
+    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOSERVER) != SshStateBannerDone ) {
         printf("Client version string not parsed: ");
         goto end;
     }
-
-    if (ssh_state->cli_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
+    if (SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOSERVER))
         goto end;
-    }
-
-    if (ssh_state->cli_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.software_version, "MySSHClient-0.5.1", strlen("MySSHClient-0.5.1")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
 
     result = 1;
 end:
@@ -829,24 +260,23 @@ static int SSHParserTest03(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
 
-    if (ssh_state->cli_hdr.flags & SSH_FLAG_VERSION_PARSED) {
+    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOSERVER) == SshStateBannerDone ) {
         printf("Client version string parsed? It's not a valid string: ");
         goto end;
     }
-
-    if (ssh_state->cli_hdr.proto_version != NULL) {
+    const uint8_t *dummy = NULL;
+    uint32_t dummy_len = 0;
+    if (rs_ssh_tx_get_protocol(tx, &dummy, &dummy_len, STREAM_TOSERVER) != 0)
         goto end;
-    }
-
-    if (ssh_state->cli_hdr.software_version != NULL) {
+    if (rs_ssh_tx_get_software(tx, &dummy, &dummy_len, STREAM_TOSERVER) != 0)
         goto end;
-    }
 
     result = 1;
 end:
@@ -882,36 +312,19 @@ static int SSHParserTest04(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
 
-    if (!(ssh_state->srv_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
+    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOCLIENT) != SshStateBannerDone ) {
         printf("Client version string not parsed: ");
         goto end;
     }
-
-    if (ssh_state->srv_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
+    if (SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOCLIENT))
         goto end;
-    }
-
-    if (ssh_state->srv_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->srv_hdr.software_version, "MySSHClient-0.5.1", strlen("MySSHClient-0.5.1")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->srv_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
 
     result = 1;
 
@@ -949,36 +362,19 @@ static int SSHParserTest05(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
 
-    if (!(ssh_state->srv_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
+    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOCLIENT) != SshStateBannerDone ) {
         printf("Client version string not parsed: ");
         goto end;
     }
-
-    if (ssh_state->srv_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
+    if (SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOCLIENT))
         goto end;
-    }
-
-    if (ssh_state->srv_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->srv_hdr.software_version, "MySSHClient-0.5.1", strlen("MySSHClient-0.5.1")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->srv_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
 
     result = 1;
 end:
@@ -1016,24 +412,24 @@ static int SSHParserTest06(void)
     }
     /* Ok, it returned an error. Let's make sure we didn't parse the string at all */
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
 
-    if (ssh_state->srv_hdr.flags & SSH_FLAG_VERSION_PARSED) {
+    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOCLIENT) == SshStateBannerDone ) {
         printf("Client version string parsed? It's not a valid string: ");
         goto end;
     }
-
-    if (ssh_state->srv_hdr.proto_version != NULL) {
+    const uint8_t *dummy = NULL;
+    uint32_t dummy_len = 0;
+    if (rs_ssh_tx_get_protocol(tx, &dummy, &dummy_len, STREAM_TOCLIENT) != 0)
         goto end;
-    }
-
-    if (ssh_state->srv_hdr.software_version != NULL) {
+    if (rs_ssh_tx_get_software(tx, &dummy, &dummy_len, STREAM_TOCLIENT) != 0)
         goto end;
-    }
+
 
     result = 1;
 end:
@@ -1076,36 +472,19 @@ static int SSHParserTest07(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
-
-    if ( !(ssh_state->cli_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOSERVER) != SshStateBannerDone ) {
         printf("Client version string not parsed: ");
         goto end;
     }
 
-    if (ssh_state->cli_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
+    if (SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOSERVER))
         goto end;
-    }
-
-    if (ssh_state->cli_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.software_version, "MySSHClient-0.5.1", strlen("MySSHClient-0.5.1")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
 
     result = 1;
 
@@ -1158,36 +537,19 @@ static int SSHParserTest08(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
-
-    if ( !(ssh_state->cli_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOSERVER) != SshStateBannerDone ) {
         printf("Client version string not parsed: ");
         goto end;
     }
 
-    if (ssh_state->cli_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
+    if (SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOSERVER))
         goto end;
-    }
-
-    if (ssh_state->cli_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.software_version, "MySSHClient-0.5.1", strlen("MySSHClient-0.5.1")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
 
     result = 1;
 end:
@@ -1230,36 +592,19 @@ static int SSHParserTest09(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
 
-    if (!(ssh_state->srv_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
+    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOCLIENT) != SshStateBannerDone ) {
         printf("Client version string not parsed: ");
         goto end;
     }
-
-    if (ssh_state->srv_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
+    if (SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOCLIENT))
         goto end;
-    }
-
-    if (ssh_state->srv_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->srv_hdr.software_version, "MySSHClient-0.5.1", strlen("MySSHClient-0.5.1")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->srv_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
 
     result = 1;
 
@@ -1312,36 +657,19 @@ static int SSHParserTest10(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
 
-    if (!(ssh_state->srv_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
+    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOCLIENT) != SshStateBannerDone ) {
         printf("Client version string not parsed: ");
         goto end;
     }
-
-    if (ssh_state->srv_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
+    if (SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOCLIENT))
         goto end;
-    }
-
-    if (ssh_state->srv_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->srv_hdr.software_version, "MySSHClient-0.5.1", strlen("MySSHClient-0.5.1")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->srv_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
 
     result = 1;
 end:
@@ -1385,41 +713,18 @@ static int SSHParserTest11(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
-
-    if ( !(ssh_state->cli_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->cli_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->cli_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.software_version, "MySSHClient-0.5.1", strlen("MySSHClient-0.5.1")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if ( !(ssh_state->cli_hdr.flags & SSH_FLAG_PARSER_DONE)) {
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    if ( rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SshStateFinished ) {
         printf("Didn't detect the msg code of new keys (ciphered data starts): ");
         goto end;
     }
+    if (SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOSERVER))
+        goto end;
 
     result = 1;
 end:
@@ -1471,41 +776,18 @@ static int SSHParserTest12(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
-
-    if ( !(ssh_state->cli_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->cli_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->cli_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.software_version, "MySSHClient-0.5.1", strlen("MySSHClient-0.5.1")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if ( !(ssh_state->cli_hdr.flags & SSH_FLAG_PARSER_DONE)) {
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    if ( rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SshStateFinished ) {
         printf("Didn't detect the msg code of new keys (ciphered data starts): ");
         goto end;
     }
+    if (SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOSERVER))
+        goto end;
 
     result = 1;
 end:
@@ -1561,41 +843,18 @@ static int SSHParserTest13(void)
             goto end;
         }
     }
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
-
-    if ( !(ssh_state->cli_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->cli_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->cli_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.software_version, "MySSHClient-0.5.1", strlen("MySSHClient-0.5.1")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if ( !(ssh_state->cli_hdr.flags & SSH_FLAG_PARSER_DONE)) {
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    if ( rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SshStateFinished ) {
         printf("Didn't detect the msg code of new keys (ciphered data starts): ");
         goto end;
     }
+    if (SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOSERVER))
+        goto end;
 
     result = 1;
 end:
@@ -1666,41 +925,18 @@ static int SSHParserTest14(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
-
-    if ( !(ssh_state->cli_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->cli_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->cli_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.software_version, "MySSHClient-0.5.1", strlen("MySSHClient-0.5.1")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if ( !(ssh_state->cli_hdr.flags & SSH_FLAG_PARSER_DONE)) {
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    if ( rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SshStateFinished ) {
         printf("Didn't detect the msg code of new keys (ciphered data starts): ");
         goto end;
     }
+    if (SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOSERVER))
+        goto end;
 
     result = 1;
 end:
@@ -1771,41 +1007,18 @@ static int SSHParserTest15(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
-
-    if ( !(ssh_state->cli_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->cli_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->cli_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.software_version, "MySSHClient-0.5.1", strlen("MySSHClient-0.5.1")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->cli_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if ( !(ssh_state->cli_hdr.flags & SSH_FLAG_PARSER_DONE)) {
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    if ( rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SshStateFinished ) {
         printf("Didn't detect the msg code of new keys (ciphered data starts): ");
         goto end;
     }
+    if (SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOSERVER))
+        goto end;
 
     result = 1;
 end:
@@ -1857,41 +1070,18 @@ static int SSHParserTest16(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
-
-    if (!(ssh_state->srv_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->srv_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->srv_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->srv_hdr.software_version, "MySSHClient-0.5.1", strlen("MySSHClient-0.5.1")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->srv_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if ( !(ssh_state->srv_hdr.flags & SSH_FLAG_PARSER_DONE)) {
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    if ( rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SshStateFinished ) {
         printf("Didn't detect the msg code of new keys (ciphered data starts): ");
         goto end;
     }
+    if (SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOCLIENT))
+        goto end;
 
     result = 1;
 end:
@@ -1951,41 +1141,18 @@ static int SSHParserTest17(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
-
-    if (!(ssh_state->srv_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->srv_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->srv_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->srv_hdr.software_version, "MySSHClient-0.5.1", strlen("MySSHClient-0.5.1")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->srv_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if ( !(ssh_state->srv_hdr.flags & SSH_FLAG_PARSER_DONE)) {
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    if ( rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SshStateFinished ) {
         printf("Didn't detect the msg code of new keys (ciphered data starts): ");
         goto end;
     }
+    if (SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOCLIENT))
+        goto end;
 
     result = 1;
 end:
@@ -2060,18 +1227,13 @@ static int SSHParserTest18(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
-
-    if ( !(ssh_state->cli_hdr.flags & SSH_FLAG_PARSER_DONE)) {
-        printf("Didn't detect the msg code of new keys (ciphered data starts): ");
-        goto end;
-    }
-
-    if ( !(ssh_state->srv_hdr.flags & SSH_FLAG_PARSER_DONE)) {
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOCLIENT) != SshStateFinished ) {
         printf("Didn't detect the msg code of new keys (ciphered data starts): ");
         goto end;
     }
@@ -2149,24 +1311,14 @@ static int SSHParserTest19(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
-
-    if (!(ssh_state->srv_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->srv_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->srv_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    if ( rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SshStateFinished ) {
+        printf("Didn't detect the msg code of new keys (ciphered data starts): %d", rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT));
         goto end;
     }
 
@@ -2176,20 +1328,8 @@ static int SSHParserTest19(void)
     strlcpy(name, (char *)sshbuf3, 256);
     name[strlen(name) - 1] = '\0'; // strip \r
 
-    if (strcmp((char*)ssh_state->srv_hdr.software_version, name) != 0) {
-        printf("Client version string not parsed correctly: ");
+    if (SSHParserTestUtilCheck("2.0", name, tx, STREAM_TOCLIENT))
         goto end;
-    }
-
-    if (strncmp((char*)ssh_state->srv_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if ( !(ssh_state->srv_hdr.flags & SSH_FLAG_PARSER_DONE)) {
-        printf("Didn't detect the msg code of new keys (ciphered data starts): ");
-        goto end;
-    }
 
     result = 1;
 end:
@@ -2262,36 +1402,20 @@ static int SSHParserTest20(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
-
-    if (!(ssh_state->srv_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
-        printf("Client version string not parsed: ");
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    if ( rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SshStateBannerDone ) {
+        printf("Didn't detect the msg code of new keys (ciphered data starts): ");
         goto end;
     }
 
-    if (ssh_state->srv_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
+    if (SSHParserTestUtilCheck("2.0", NULL, tx, STREAM_TOCLIENT))
         goto end;
-    }
 
-    if (ssh_state->srv_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->srv_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if ((ssh_state->srv_hdr.flags & SSH_FLAG_PARSER_DONE)) {
-        printf("detected the msg code of new keys (ciphered data starts): ");
-        goto end;
-    }
     result = 1;
 end:
     if (alp_tctx != NULL)
@@ -2361,36 +1485,18 @@ static int SSHParserTest21(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
-
-    if (!(ssh_state->srv_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->srv_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->srv_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->srv_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if ( !(ssh_state->srv_hdr.flags & SSH_FLAG_PARSER_DONE)) {
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    if ( rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SshStateFinished ) {
         printf("Didn't detect the msg code of new keys (ciphered data starts): ");
         goto end;
     }
+    if (SSHParserTestUtilCheck("2.0", NULL, tx, STREAM_TOCLIENT))
+        goto end;
 
     result = 1;
 end:
@@ -2488,36 +1594,18 @@ static int SSHParserTest22(void)
         goto end;
     }
 #endif
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
-
-    if (!(ssh_state->srv_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->srv_hdr.software_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (ssh_state->srv_hdr.proto_version == NULL) {
-        printf("Client version string not parsed: ");
-        goto end;
-    }
-
-    if (strncmp((char*)ssh_state->srv_hdr.proto_version, "2.0", strlen("2.0")) != 0) {
-        printf("Client version string not parsed correctly: ");
-        goto end;
-    }
-
-    if ( !(ssh_state->srv_hdr.flags & SSH_FLAG_PARSER_DONE)) {
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    if ( rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SshStateFinished ) {
         printf("Didn't detect the msg code of new keys (ciphered data starts): ");
         goto end;
     }
+    if (SSHParserTestUtilCheck("2.0", "libssh", tx, STREAM_TOCLIENT))
+        goto end;
 
     result = 1;
 end:
@@ -2587,21 +1675,18 @@ static int SSHParserTest24(void)
         goto end;
     }
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
     }
-
-    if ( !(ssh_state->cli_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
-        printf("Client version string not parsed: ");
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    if ( rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SshStateBannerDone ) {
+        printf("Didn't detect the msg code of new keys (ciphered data starts): ");
         goto end;
     }
-
-    if (ssh_state->cli_hdr.software_version) {
-        printf("Client version string should not be parsed: ");
+    if (SSHParserTestUtilCheck("2.0", NULL, tx, STREAM_TOSERVER))
         goto end;
-    }
 
     result = 1;
 end:
@@ -2634,11 +1719,13 @@ static int SSHParserTest25(void)
                                 STREAM_TOSERVER | STREAM_EOF, sshbuf, sshlen);
     FAIL_IF(r != -1);
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     FAIL_IF_NULL(ssh_state);
-
-    FAIL_IF_NOT(!(ssh_state->cli_hdr.flags & SSH_FLAG_VERSION_PARSED));
-    FAIL_IF(ssh_state->cli_hdr.software_version);
+    void * tx = rs_ssh_state_get_tx(ssh_state, 0);
+    FAIL_IF( rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) == SshStateBannerDone );
+    const uint8_t *dummy = NULL;
+    uint32_t dummy_len = 0;
+    FAIL_IF (rs_ssh_tx_get_software(tx, &dummy, &dummy_len, STREAM_TOCLIENT) != 0);
 
     AppLayerParserThreadCtxFree(alp_tctx);
     StreamTcpFreeConfig(TRUE);

--- a/src/detect-ssh-proto-version.c
+++ b/src/detect-ssh-proto-version.c
@@ -51,6 +51,7 @@
 #include "app-layer-parser.h"
 #include "app-layer-ssh.h"
 #include "detect-ssh-proto-version.h"
+#include "rust.h"
 
 #include "stream-tcp.h"
 
@@ -110,34 +111,35 @@ static int DetectSshVersionMatch (DetectEngineThreadCtx *det_ctx,
     SCLogDebug("lets see");
 
     DetectSshVersionData *ssh = (DetectSshVersionData *)m;
-    SshState *ssh_state = (SshState *)state;
-    if (ssh_state == NULL) {
+    if (state == NULL) {
         SCLogDebug("no ssh state, no match");
         SCReturnInt(0);
     }
 
     int ret = 0;
-    if ((flags & STREAM_TOCLIENT) && (ssh_state->srv_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
-        if (ssh->flags & SSH_FLAG_PROTOVERSION_2_COMPAT) {
-            SCLogDebug("looking for ssh server protoversion 2 compat");
-            if (strncmp((char *) ssh_state->srv_hdr.proto_version, "2", 1) == 0 ||
-                strncmp((char *) ssh_state->srv_hdr.proto_version, "2.", 2) == 0 ||
-                strncmp((char *) ssh_state->srv_hdr.proto_version, "1.99", 4) == 0)
+    const uint8_t *protocol = NULL;
+    uint32_t b_len = 0;
+
+    if (rs_ssh_tx_get_protocol(txv, &protocol, &b_len, flags) != 1)
+        SCReturnInt(0);
+    if (protocol == NULL || b_len == 0)
+        SCReturnInt(0);
+
+    if (ssh->flags & SSH_FLAG_PROTOVERSION_2_COMPAT) {
+        SCLogDebug("looking for ssh protoversion 2 compat");
+        if (protocol[0] == '2') {
+            ret = 1;
+        } else if (b_len >= 4) {
+            if (memcmp(protocol, "1.99", 4) == 0)    {
                 ret = 1;
-        } else {
-            SCLogDebug("looking for ssh server protoversion %s length %"PRIu16"", ssh->ver, ssh->len);
-            ret = (strncmp((char *) ssh_state->srv_hdr.proto_version, (char *) ssh->ver, ssh->len) == 0)? 1 : 0;
+            }
         }
-    } else if ((flags & STREAM_TOSERVER) && (ssh_state->cli_hdr.flags & SSH_FLAG_VERSION_PARSED)) {
-        if (ssh->flags & SSH_FLAG_PROTOVERSION_2_COMPAT) {
-            SCLogDebug("looking for client ssh client protoversion 2 compat");
-            if (strncmp((char *) ssh_state->cli_hdr.proto_version, "2", 1) == 0 ||
-                strncmp((char *) ssh_state->cli_hdr.proto_version, "2.", 2) == 0 ||
-                strncmp((char *) ssh_state->cli_hdr.proto_version, "1.99", 4) == 0)
+    } else {
+        SCLogDebug("looking for ssh protoversion %s length %"PRIu16"", ssh->ver, ssh->len);
+        if (b_len == ssh->len) {
+            if (memcmp(protocol, ssh->ver, ssh->len) == 0) {
                 ret = 1;
-        } else {
-            SCLogDebug("looking for ssh client protoversion %s length %"PRIu16"", ssh->ver, ssh->len);
-            ret = (strncmp((char *) ssh_state->cli_hdr.proto_version, (char *) ssh->ver, ssh->len) == 0)? 1 : 0;
+            }
         }
     }
     SCReturnInt(ret);
@@ -402,7 +404,7 @@ static int DetectSshVersionTestDetect01(void)
                             sshbuf4, sshlen4);
     FAIL_IF(r != 0);
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     FAIL_IF_NULL(ssh_state);
 
     /* do detect */
@@ -506,7 +508,7 @@ static int DetectSshVersionTestDetect02(void)
     }
     FLOWLOCK_UNLOCK(&f);
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -623,7 +625,7 @@ static int DetectSshVersionTestDetect03(void)
     }
     FLOWLOCK_UNLOCK(&f);
 
-    SshState *ssh_state = f.alstate;
+    void *ssh_state = f.alstate;
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;

--- a/src/detect-ssh-software.c
+++ b/src/detect-ssh-software.c
@@ -46,6 +46,7 @@
 #include "app-layer-parser.h"
 #include "app-layer-ssh.h"
 #include "detect-ssh-software.h"
+#include "rust.h"
 
 #define KEYWORD_NAME "ssh.software"
 #define KEYWORD_NAME_LEGACY "ssh_software"
@@ -63,27 +64,17 @@ static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
 
     if (buffer->inspect == NULL) {
-        uint8_t *software = NULL;
-        SshState *ssh_state = (SshState *) txv;
+        const uint8_t *software = NULL;
+        uint32_t b_len = 0;
 
-        if (flow_flags & STREAM_TOSERVER)
-            software = ssh_state->cli_hdr.software_version;
-        else if (flow_flags & STREAM_TOCLIENT)
-            software = ssh_state->srv_hdr.software_version;
-
-        if (software == NULL) {
-            SCLogDebug("SSL software version not set");
+        if (rs_ssh_tx_get_software(txv, &software, &b_len, flow_flags) != 1)
+            return NULL;
+        if (software == NULL || b_len == 0) {
+            SCLogDebug("SSH software version not set");
             return NULL;
         }
 
-        uint32_t data_len = strlen((char *)software);
-        uint8_t *data = software;
-        if (data == NULL || data_len == 0) {
-            SCLogDebug("SSL software version not present");
-            return NULL;
-        }
-
-        InspectionBufferSetup(buffer, data, data_len);
+        InspectionBufferSetup(buffer, software, b_len);
         InspectionBufferApplyTransforms(buffer, transforms);
     }
 
@@ -113,16 +104,16 @@ void DetectSshSoftwareRegister(void)
 
     DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOSERVER, 2,
             PrefilterGenericMpmRegister, GetSshData,
-			ALPROTO_SSH, SSH_STATE_BANNER_DONE),
+			ALPROTO_SSH, SshStateBannerDone),
     DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2,
             PrefilterGenericMpmRegister, GetSshData,
-			ALPROTO_SSH, SSH_STATE_BANNER_DONE),
+			ALPROTO_SSH, SshStateBannerDone),
 
     DetectAppLayerInspectEngineRegister2(BUFFER_NAME,
-            ALPROTO_SSH, SIG_FLAG_TOSERVER, SSH_STATE_BANNER_DONE,
+            ALPROTO_SSH, SIG_FLAG_TOSERVER, SshStateBannerDone,
             DetectEngineInspectBufferGeneric, GetSshData);
     DetectAppLayerInspectEngineRegister2(BUFFER_NAME,
-            ALPROTO_SSH, SIG_FLAG_TOCLIENT, SSH_STATE_BANNER_DONE,
+            ALPROTO_SSH, SIG_FLAG_TOCLIENT, SshStateBannerDone,
             DetectEngineInspectBufferGeneric, GetSshData);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -61,6 +61,7 @@
 #include "output-json-http.h"
 #include "output-json-tls.h"
 #include "output-json-ssh.h"
+#include "rust.h"
 #include "output-json-smtp.h"
 #include "output-json-email-common.h"
 #include "output-json-nfs.h"
@@ -144,13 +145,12 @@ static void AlertJsonTls(const Flow *f, json_t *js)
 
 static void AlertJsonSsh(const Flow *f, json_t *js)
 {
-    SshState *ssh_state = (SshState *)FlowGetAppState(f);
+    void *ssh_state = FlowGetAppState(f);
     if (ssh_state) {
-        json_t *tjs = json_object();
+        void *tx_ptr = rs_ssh_state_get_tx(ssh_state, 0);
+        json_t *tjs = rs_ssh_log_json(tx_ptr);
         if (unlikely(tjs == NULL))
             return;
-
-        JsonSshLogJSON(tjs, ssh_state);
 
         json_object_set_new(js, "ssh", tjs);
     }

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -49,6 +49,7 @@
 
 #include "output-json.h"
 #include "output-json-ssh.h"
+#include "rust.h"
 
 #define MODULE_NAME "LogSshLog"
 
@@ -64,44 +65,15 @@ typedef struct JsonSshLogThread_ {
 } JsonSshLogThread;
 
 
-void JsonSshLogJSON(json_t *tjs, SshState *ssh_state)
-{
-    json_t *cjs = json_object();
-    if (cjs != NULL) {
-        json_object_set_new(cjs, "proto_version",
-                SCJsonString((char *)ssh_state->cli_hdr.proto_version));
-
-        json_object_set_new(cjs, "software_version",
-                SCJsonString((char *)ssh_state->cli_hdr.software_version));
-    }
-    json_object_set_new(tjs, "client", cjs);
-
-    json_t *sjs = json_object();
-    if (sjs != NULL) {
-        json_object_set_new(sjs, "proto_version",
-                SCJsonString((char *)ssh_state->srv_hdr.proto_version));
-
-        json_object_set_new(sjs, "software_version",
-                SCJsonString((char *)ssh_state->srv_hdr.software_version));
-    }
-    json_object_set_new(tjs, "server", sjs);
-
-}
-
 static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
                          Flow *f, void *state, void *txptr, uint64_t tx_id)
 {
     JsonSshLogThread *aft = (JsonSshLogThread *)thread_data;
     OutputSshCtx *ssh_ctx = aft->sshlog_ctx;
 
-    SshState *ssh_state = (SshState *)state;
-    if (unlikely(ssh_state == NULL)) {
+    if (unlikely(state == NULL)) {
         return 0;
     }
-
-    if (ssh_state->cli_hdr.software_version == NULL ||
-        ssh_state->srv_hdr.software_version == NULL)
-        return 0;
 
     json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "ssh");
     if (unlikely(js == NULL))
@@ -109,17 +81,14 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
 
     JsonAddCommonOptions(&ssh_ctx->cfg, p, f, js);
 
-    json_t *tjs = json_object();
-    if (tjs == NULL) {
-        free(js);
-        return 0;
-    }
-
     /* reset */
     MemBufferReset(aft->buffer);
 
-    JsonSshLogJSON(tjs, ssh_state);
-
+    json_t *tjs = rs_ssh_log_json(txptr);
+    if (unlikely(tjs == NULL)) {
+        free(js);
+        return 0;
+    }
     json_object_set_new(js, "ssh", tjs);
 
     OutputJSONBuffer(js, ssh_ctx->file_ctx, &aft->buffer);
@@ -261,13 +230,13 @@ void JsonSshLogRegister (void)
     OutputRegisterTxModuleWithProgress(LOGGER_JSON_SSH,
         "JsonSshLog", "ssh-json-log",
         OutputSshLogInit, ALPROTO_SSH, JsonSshLogger,
-        SSH_STATE_BANNER_DONE, SSH_STATE_BANNER_DONE,
+        SshStateBannerDone, SshStateBannerDone,
         JsonSshLogThreadInit, JsonSshLogThreadDeinit, NULL);
 
     /* also register as child of eve-log */
     OutputRegisterTxSubModuleWithProgress(LOGGER_JSON_SSH,
         "eve-log", "JsonSshLog", "eve-log.ssh",
         OutputSshLogInitSub, ALPROTO_SSH, JsonSshLogger,
-        SSH_STATE_BANNER_DONE, SSH_STATE_BANNER_DONE,
+        SshStateBannerDone, SshStateBannerDone,
         JsonSshLogThreadInit, JsonSshLogThreadDeinit, NULL);
 }

--- a/src/output-json-ssh.h
+++ b/src/output-json-ssh.h
@@ -26,8 +26,4 @@
 
 void JsonSshLogRegister(void);
 
-#include "app-layer-ssh.h"
-
-void JsonSshLogJSON(json_t *js, SshState *tx);
-
 #endif /* __OUTPUT_JSON_SSH_H__ */

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -823,8 +823,8 @@ static OutputInitResult OutputLuaLogInit(ConfNode *conf)
         } else if (opts.alproto == ALPROTO_SSH) {
             om->TxLogFunc = LuaTxLogger;
             om->alproto = ALPROTO_SSH;
-            om->tc_log_progress = SSH_STATE_BANNER_DONE;
-            om->ts_log_progress = SSH_STATE_BANNER_DONE;
+            om->tc_log_progress = SshStateBannerDone;
+            om->ts_log_progress = SshStateBannerDone;
             AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_SSH);
         } else if (opts.alproto == ALPROTO_SMTP) {
             om->TxLogFunc = LuaTxLogger;

--- a/src/util-lua-ssh.c
+++ b/src/util-lua-ssh.c
@@ -47,6 +47,7 @@
 #include "util-proto-name.h"
 #include "util-logopenfile.h"
 #include "util-time.h"
+#include "rust.h"
 
 #ifdef HAVE_LUA
 
@@ -63,14 +64,17 @@ static int GetServerProtoVersion(lua_State *luastate, const Flow *f)
     void *state = FlowGetAppState(f);
     if (state == NULL)
         return LuaCallbackError(luastate, "error: no app layer state");
+    const uint8_t *protocol = NULL;
+    uint32_t b_len = 0;
 
-    SshState *ssh_state = (SshState *)state;
-
-    if (ssh_state->srv_hdr.proto_version == NULL)
+    void *tx = rs_ssh_state_get_tx(state, 0);
+    if (rs_ssh_tx_get_protocol(tx, &protocol, &b_len, STREAM_TOCLIENT) != 1)
         return LuaCallbackError(luastate, "error: no server proto version");
+    if (protocol == NULL || b_len == 0) {
+        return LuaCallbackError(luastate, "error: no server proto version");
+    }
 
-    return LuaPushStringBuffer(luastate, ssh_state->srv_hdr.proto_version,
-                               strlen((char *)ssh_state->srv_hdr.proto_version));
+    return LuaPushStringBuffer(luastate, protocol, b_len);
 }
 
 static int SshGetServerProtoVersion(lua_State *luastate)
@@ -95,13 +99,17 @@ static int GetServerSoftwareVersion(lua_State *luastate, const Flow *f)
     if (state == NULL)
         return LuaCallbackError(luastate, "error: no app layer state");
 
-    SshState *ssh_state = (SshState *)state;
+    const uint8_t *software = NULL;
+    uint32_t b_len = 0;
 
-    if (ssh_state->srv_hdr.software_version == NULL)
+    void *tx = rs_ssh_state_get_tx(state, 0);
+    if (rs_ssh_tx_get_software(tx, &software, &b_len, STREAM_TOCLIENT) != 1)
         return LuaCallbackError(luastate, "error: no server software version");
+    if (software == NULL || b_len == 0) {
+        return LuaCallbackError(luastate, "error: no server software version");
+    }
 
-    return LuaPushStringBuffer(luastate, ssh_state->srv_hdr.software_version,
-                               strlen((char *)ssh_state->srv_hdr.software_version));
+    return LuaPushStringBuffer(luastate, software, b_len);
 }
 
 static int SshGetServerSoftwareVersion(lua_State *luastate)
@@ -126,13 +134,17 @@ static int GetClientProtoVersion(lua_State *luastate, const Flow *f)
     if (state == NULL)
         return LuaCallbackError(luastate, "error: no app layer state");
 
-    SshState *ssh_state = (SshState *)state;
+    const uint8_t *protocol = NULL;
+    uint32_t b_len = 0;
 
-    if (ssh_state->cli_hdr.proto_version == NULL)
+    void *tx = rs_ssh_state_get_tx(state, 0);
+    if (rs_ssh_tx_get_protocol(tx, &protocol, &b_len, STREAM_TOSERVER) != 1)
         return LuaCallbackError(luastate, "error: no client proto version");
+    if (protocol == NULL || b_len == 0) {
+        return LuaCallbackError(luastate, "error: no client proto version");
+    }
 
-    return LuaPushStringBuffer(luastate, ssh_state->cli_hdr.proto_version,
-                               strlen((char *)ssh_state->cli_hdr.proto_version));
+    return LuaPushStringBuffer(luastate, protocol, b_len);
 }
 
 static int SshGetClientProtoVersion(lua_State *luastate)
@@ -157,13 +169,17 @@ static int GetClientSoftwareVersion(lua_State *luastate, const Flow *f)
     if (state == NULL)
         return LuaCallbackError(luastate, "error: no app layer state");
 
-    SshState *ssh_state = (SshState *)state;
+    const uint8_t *software = NULL;
+    uint32_t b_len = 0;
 
-    if (ssh_state->cli_hdr.software_version == NULL)
+    void *tx = rs_ssh_state_get_tx(state, 0);
+    if (rs_ssh_tx_get_software(tx, &software, &b_len, STREAM_TOSERVER) != 1)
         return LuaCallbackError(luastate, "error: no client software version");
+    if (software == NULL || b_len == 0) {
+        return LuaCallbackError(luastate, "error: no client software version");
+    }
 
-    return LuaPushStringBuffer(luastate, ssh_state->cli_hdr.software_version,
-                               strlen((char *)ssh_state->cli_hdr.software_version));
+    return LuaPushStringBuffer(luastate, software, b_len);
 }
 
 static int SshGetClientSoftwareVersion(lua_State *luastate)


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3445

Describe changes:
- Translates SSH C Parser to a Rust parser

This looks good

This is meant to be an exact translation. We want to add features later.
https://github.com/rusticata/ssh-parser might help for this

One difference though is the handling of end of line(s) at the end of the banner. This Rust version should be robust against packet splitting between CR and LF (which should be accepted by openssh), when the current version is vulnerable because end of lines skipping https://github.com/OISF/suricata/blob/master/src/app-layer-ssh.c#L235 is only done if the first packet contains the whole banner with end of lines. I made a suricata-verify test for this https://github.com/OISF/suricata-verify/pull/176

Modifies #4670 with comments taken into account

Can be improved and rebased when #4677 gets merged
