### PR TITLE
output-json: add MAC addresses to EVE-JSON logs - v5

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -14,6 +14,9 @@ where all these logs go into a single file.
 Each alert, http log, etc will go into this one file: 'eve.json'. This file
 can then be processed by 3rd party tools like Logstash (ELK) or jq.
 
+If ``ethernet`` is set to yes, then ethernet headers will be added to events
+if available.
+
 Output types
 ~~~~~~~~~~~~
 
@@ -30,6 +33,7 @@ Output types::
       #facility: local5
       #level: Info ## possible levels: Emergency, Alert, Critical,
                    ## Error, Warning, Notice, Info, Debug
+      #ethernet: yes  # log ethernet header in events when available
       #redis:
       #  server: 127.0.0.1
       #  port: 6379

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -468,6 +468,7 @@ util-lua-ja3.c util-lua-ja3.h \
 util-lua-tls.c util-lua-tls.h \
 util-lua-ssh.c util-lua-ssh.h \
 util-lua-smtp.c util-lua-smtp.h \
+util-macset.c util-macset.h \
 util-magic.c util-magic.h \
 util-memcmp.c util-memcmp.h \
 util-memcpy.h \

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -201,6 +201,12 @@ void FlowInit(Flow *f, const Packet *p)
 
     f->protomap = FlowGetProtoMapping(f->proto);
 
+    if (f->macset != NULL) {
+        MacSetReset(f->macset);
+    } else {
+        f->macset = MacSetInit(10);
+    }
+
     SCReturn;
 }
 

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -73,6 +73,7 @@
         (f)->hprev = NULL; \
         (f)->lnext = NULL; \
         (f)->lprev = NULL; \
+        (f)->macset = NULL; \
         RESET_COUNTERS((f)); \
     } while (0)
 
@@ -115,6 +116,7 @@
         (f)->sgh_toclient = NULL; \
         GenericVarFree((f)->flowvar); \
         (f)->flowvar = NULL; \
+        MacSetReset((f)->macset); \
         RESET_COUNTERS((f)); \
     } while(0)
 
@@ -125,6 +127,7 @@
         \
         FLOWLOCK_DESTROY((f)); \
         GenericVarFree((f)->flowvar); \
+        MacSetFree((f)->macset); \
     } while(0)
 
 /** \brief check if a memory alloc would fit in the memcap

--- a/src/flow.c
+++ b/src/flow.c
@@ -452,6 +452,8 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p)
             f->flags &= ~FLOW_PROTO_DETECT_TS_DONE;
             p->flags |= PKT_PROTO_DETECT_TS_DONE;
         }
+        if (f->macset != NULL && p->ethh != NULL)
+            MacSetAdd(f->macset, p->ethh->eth_src, p->ethh->eth_dst);
     } else {
         f->tosrcpktcnt++;
         f->tosrcbytecnt += GET_PKT_LEN(p);
@@ -467,6 +469,8 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p)
             f->flags &= ~FLOW_PROTO_DETECT_TC_DONE;
             p->flags |= PKT_PROTO_DETECT_TC_DONE;
         }
+        if (f->macset != NULL && p->ethh != NULL)
+            MacSetAdd(f->macset, p->ethh->eth_dst, p->ethh->eth_src);
     }
 
     if (SC_ATOMIC_GET(f->flow_state) == FLOW_STATE_ESTABLISHED) {

--- a/src/flow.h
+++ b/src/flow.h
@@ -29,6 +29,7 @@
 #include "util-atomic.h"
 #include "util-device.h"
 #include "detect-tag.h"
+#include "util-macset.h"
 #include "util-optimize.h"
 
 /* Part of the flow structure, so we declare it here.
@@ -475,6 +476,8 @@ typedef struct Flow_
     uint32_t tosrcpktcnt;
     uint64_t todstbytecnt;
     uint64_t tosrcbytecnt;
+
+    MacSet *macset;
 } Flow;
 
 enum FlowState {

--- a/src/output-json-smb.c
+++ b/src/output-json-smb.c
@@ -71,6 +71,8 @@ static int JsonSMBLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
+    JsonAddCommonOptions(&thread->ctx->cfg, p, f, js);
+
     smbjs = rs_smb_log_json_response(state, tx);
     if (unlikely(smbjs == NULL)) {
         goto error;

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -393,6 +393,9 @@ void JsonAddCommonOptions(const OutputJsonCommonSettings *cfg,
     if (cfg->include_metadata) {
         JsonAddMetadata(p, f, js);
     }
+    if (cfg->include_ethernet) {
+        CreateJSONEther(js, p, f);
+    }
     if (cfg->include_community_id && f != NULL) {
         CreateJSONCommunityFlowId(js, f, cfg->community_id_seed);
     }
@@ -705,6 +708,76 @@ void CreateJSONFlowId(json_t *js, const Flow *f)
     if (f->parent_id) {
         json_object_set_new(js, "parent_id", json_integer(f->parent_id));
     }
+}
+
+static inline void JSONFormatAndAddMACAddr(json_t *parent, const char *key,
+                                   uint8_t *val, bool is_array)
+{
+    char eth_addr[19];
+    (void) snprintf(eth_addr, 19, "%02x:%02x:%02x:%02x:%02x:%02x",
+                    val[0], val[1], val[2], val[3], val[4], val[5]);
+    if (is_array) {
+        json_array_append_new(parent, json_string(eth_addr));
+    } else {
+        json_object_set_new(parent, key, json_string(eth_addr));
+    }
+}
+
+/* only required to traverse the MAC address set */
+typedef struct JSONMACAddrInfo {
+    json_t *src, *dst;
+} JSONMACAddrInfo;
+
+static int JSONFlowAppendMACAddrs(uint8_t *val, MacSetSide side, void *data)
+{
+    JSONMACAddrInfo *info = (JSONMACAddrInfo*) data;
+    if (side == MAC_SET_DST) {
+        JSONFormatAndAddMACAddr(info->dst, NULL, val, true);
+    } else {
+        JSONFormatAndAddMACAddr(info->src, NULL, val, true);
+    }
+    return 0;
+}
+
+int CreateJSONEther(json_t *parent, const Packet *p, const Flow *f)
+{
+    json_t *ejs = json_object();
+    if (unlikely(ejs == NULL))
+        return 0;
+    if (p == NULL) {
+        /* we are creating an ether object in a flow context, so we need to
+           append to arrays */
+        if (f != NULL && f->macset && MacSetSize(f->macset) > 0) {
+            JSONMACAddrInfo info;
+            int ret;
+            info.dst = json_array();
+            info.src = json_array();
+            ret = MacSetForEach(f->macset, JSONFlowAppendMACAddrs, &info);
+            if (unlikely(ret != 0)) {
+                /* should not happen, JSONFlowAppendMACAddrs is sane */
+                json_decref(info.dst);
+                json_decref(info.src);
+                return ret;
+            }
+            json_object_set_new(ejs, "dest_macs", info.dst);
+            json_object_set_new(ejs, "src_macs", info.src);
+        }
+    } else {
+        /* this is a packet context, so we need to add scalar fields */
+        uint8_t *src, *dst;
+        if ((PKT_IS_TOCLIENT(p))) {
+            src = p->ethh->eth_dst;
+            dst = p->ethh->eth_src;
+        } else {
+            src = p->ethh->eth_src;
+            dst = p->ethh->eth_dst;
+        }
+        json_object_set_new(ejs, "type", json_integer(ntohs(p->ethh->eth_type)));
+        JSONFormatAndAddMACAddr(ejs, "src_mac", src, false);
+        JSONFormatAndAddMACAddr(ejs, "dest_mac", dst, false);
+    }
+    json_object_set_new(parent, "ether", ejs);
+    return 0;
 }
 
 json_t *CreateJSONHeader(const Packet *p, enum OutputJsonLogDirection dir,
@@ -1023,6 +1096,15 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
             json_ctx->cfg.include_metadata = true;
         }
 
+        /* Check if ethernet information should be logged. */
+        const ConfNode *ethernet = ConfNodeLookupChild(conf, "ethernet");
+        if (ethernet && ethernet->val && ConfValIsTrue(ethernet->val)) {
+            SCLogConfig("Enabling Ethernet MAC address logging.");
+            json_ctx->cfg.include_ethernet = true;
+        } else {
+            json_ctx->cfg.include_ethernet = false;
+        }
+
         /* See if we want to enable the community id */
         const ConfNode *community_id = ConfNodeLookupChild(conf, "community-id");
         if (community_id && community_id->val && ConfValIsTrue(community_id->val)) {
@@ -1061,7 +1143,6 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
 
         json_ctx->file_ctx->type = json_ctx->json_out;
     }
-
 
     SCLogDebug("returning output_ctx %p", output_ctx);
 

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -55,6 +55,7 @@ void CreateJSONFlowId(json_t *js, const Flow *f);
 void JsonTcpFlags(uint8_t flags, json_t *js);
 void JsonPacket(const Packet *p, json_t *js, unsigned long max_length);
 void JsonFiveTuple(const Packet *, enum OutputJsonLogDirection, json_t *);
+int CreateJSONEther(json_t *parent, const Packet *p, const Flow *f);
 json_t *CreateJSONHeader(const Packet *p,
         enum OutputJsonLogDirection dir, const char *event_type);
 json_t *CreateJSONHeaderWithTxId(const Packet *p,
@@ -69,6 +70,7 @@ TmEcode JsonLogThreadDeinit(ThreadVars *t, void *data);
 typedef struct OutputJsonCommonSettings_ {
     bool include_metadata;
     bool include_community_id;
+    bool include_ethernet;
     uint16_t community_id_seed;
 } OutputJsonCommonSettings;
 

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -92,6 +92,7 @@
 #include "util-pool.h"
 #include "util-byte.h"
 #include "util-proto-name.h"
+#include "util-macset.h"
 #include "util-memrchr.h"
 
 #include "util-mpm-ac.h"
@@ -200,6 +201,7 @@ static void RegisterUnittests(void)
     AppLayerUnittestsRegister();
     MimeDecRegisterTests();
     StreamingBufferRegisterTests();
+    MacSetRegisterTests();
 #ifdef OS_WIN32
     Win32SyscallRegisterTests();
 #endif

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -113,7 +113,7 @@ typedef struct LogFileCtx_ {
     uint8_t send_flags;
 
     /* Flag if file is a regular file or not.  Only regular files
-     * allow for rotataion. */
+     * allow for rotation. */
     uint8_t is_regular;
 
     /* JSON flags */

--- a/src/util-macset.c
+++ b/src/util-macset.c
@@ -1,0 +1,391 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Sascha Steinbiss <sascha.steinbiss@dcso.de>
+ *
+ * Set-like data store for MAC addresses. Implemented as array for memory
+ * locality reasons as the expected number of items is typically low.
+ *
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+#include "flow-util.h"
+#include "flow-private.h"
+#include "util-macset.h"
+#include "util-unittest.h"
+#include "util-unittest-helper.h"
+
+typedef uint8_t MacAddr[6];
+typedef enum {
+    EMPTY_SET,  /* no address inserted yet */
+    SINGLE_MAC, /* we have a single pair of addresses (likely) */
+    MULTI_MAC   /* we have multiple addresses per flow */
+} MacSetState;
+
+struct MacSet_ {
+    /* static store for a single MAC address per side */
+    MacAddr singles[2];
+    /* state determines how addresses are stored per side:
+         - SINGLE_MAC uses static locations allocated with the MacSet
+           itself to store a single address (most likely case)
+         - MULTI_MAC is used when more than one distinct address
+           is detected (causes another allocation and linear-time add) */
+    MacSetState state[2];
+    /* buffer for multiple MACs per flow and direction */
+    MacAddr *buf[2];
+    int size,
+        last[2];
+};
+
+MacSet *MacSetInit(int size)
+{
+    MacSet *ms = NULL;
+    if (!FLOW_CHECK_MEMCAP(sizeof(ms))) {
+        return NULL;
+    }
+    ms = SCCalloc(1, sizeof(*ms));
+    if (unlikely(ms == NULL)) {
+        FatalError(SC_ERR_MEM_ALLOC, "Unable to allocate MacSet memory");
+    }
+    ms->state[MAC_SET_SRC] = ms->state[MAC_SET_DST] = EMPTY_SET;
+    if (size < 3) {
+        /* we want to make sure we have at space for at least 3 items to
+           fit MACs during the initial extension to MULTI_MAC storage */
+        size = 3;
+    }
+    ms->size = size;
+    ms->last[MAC_SET_SRC] = ms->last[MAC_SET_DST] = 0;
+    return ms;
+}
+
+static inline void MacUpdateEntry(MacSet *ms, uint8_t *addr, int side)
+{
+    switch (ms->state[side]) {
+        case EMPTY_SET:
+            memcpy(ms->singles[side], addr, sizeof(MacAddr));;
+            ms->state[side] = SINGLE_MAC;
+            break;
+        case SINGLE_MAC:
+            if (unlikely(memcmp(addr, ms->singles[side], sizeof(MacAddr)) != 0)) {
+                if (ms->buf[side] == NULL) {
+                    if (!FLOW_CHECK_MEMCAP(ms->size * sizeof(MacAddr))) {
+                        /* in this case there is not much we can do */
+                        return;
+                    }
+                    ms->buf[side] = SCCalloc(ms->size, sizeof(MacAddr));
+                    if (unlikely(ms->buf[side] == NULL)) {
+                        FatalError(SC_ERR_MEM_ALLOC, "Unable to allocate "
+                                                     "MacSet memory");
+                    }
+                }
+                memcpy(ms->buf[side], ms->singles[side], sizeof(MacAddr));
+                memcpy(ms->buf[side] + 1, addr, sizeof(MacAddr));
+                ms->last[side] = 2;
+                ms->state[side] = MULTI_MAC;
+            }
+            break;
+        case MULTI_MAC:
+            if (unlikely(ms->last[side] == ms->size)) {
+                /* MacSet full, ignore item. We intentionally do not output
+                   any warning in order not to stall packet processing */
+                return;
+            }
+            /* If the set is non-empty... */
+            if (ms->last[side] > 0) {
+                /* ...we search for duplicates in the set to decide whether
+                   we need to insert the curent item. We do this backwards,
+                   since we expect the latest item to match more likely than
+                   the first */
+                for (int i = ms->last[side] - 1; i >= 0; i--) {
+                    uint8_t *addr2 = (uint8_t*) ((ms->buf[side]) + i);
+                    /* If we find a match, we return early with no action */
+                    if (likely(memcmp(addr2, addr, sizeof(MacAddr)) == 0)) {
+                        return;
+                    }
+                }
+            }
+            /* Otherwise, we insert the new address at the end */
+            memcpy(ms->buf[side] + ms->last[side], addr, sizeof(MacAddr));
+            ms->last[side]++;
+            break;
+    }
+}
+
+void MacSetAdd(MacSet *ms, uint8_t *src_addr, uint8_t *dst_addr)
+{
+    if (ms == NULL)
+        return;
+    MacUpdateEntry(ms, src_addr, MAC_SET_SRC);
+    MacUpdateEntry(ms, dst_addr, MAC_SET_DST);
+}
+
+static inline int MacSetIterateSide(MacSet *ms, MacSetIteratorFunc IterFunc,
+                                    MacSetSide side, void *data)
+{
+    int ret = 0;
+    switch (ms->state[side]) {
+        case EMPTY_SET:
+            return 0;
+        case SINGLE_MAC:
+            ret = IterFunc((uint8_t*) ms->singles[side], side, data);
+            if (unlikely(ret != 0)) {
+                return ret;
+            }
+            break;
+        case MULTI_MAC:
+            for (int i = 0; i < ms->last[side]; i++) {
+                ret = IterFunc((uint8_t*) ms->buf[side][i], side, data);
+                if (unlikely(ret != 0)) {
+                    return ret;
+                }
+            }
+            break;
+    }
+    return 0;
+}
+
+int MacSetForEach(MacSet *ms, MacSetIteratorFunc IterFunc, void *data)
+{
+    int ret = 0;
+    if (ms == NULL)
+        return 0;
+
+    ret = MacSetIterateSide(ms, IterFunc, MAC_SET_SRC, data);
+    if (ret != 0) {
+        return ret;
+    }
+    return MacSetIterateSide(ms, IterFunc, MAC_SET_DST, data);
+}
+
+int MacSetSize(MacSet *ms)
+{
+    int size = 0;
+    if (ms == NULL)
+        return 0;
+
+    switch(ms->state[MAC_SET_SRC]) {
+        case EMPTY_SET:
+            /* pass */
+            break;
+        case SINGLE_MAC:
+            size += 1;
+            break;
+        case MULTI_MAC:
+            size += ms->last[MAC_SET_SRC];
+            break;
+    }
+    switch(ms->state[MAC_SET_DST]) {
+        case EMPTY_SET:
+            /* pass */
+            break;
+        case SINGLE_MAC:
+            size += 1;
+            break;
+        case MULTI_MAC:
+            size += ms->last[MAC_SET_DST];
+            break;
+    }
+    return size;
+}
+
+void MacSetReset(MacSet *ms)
+{
+    if (ms == NULL)
+        return;
+    ms->state[MAC_SET_SRC] = ms->state[MAC_SET_DST] = EMPTY_SET;
+    ms->last[MAC_SET_SRC] = ms->last[MAC_SET_DST] = 0;
+}
+
+void MacSetFree(MacSet *ms)
+{
+    if (ms == NULL)
+        return;
+    if (ms->buf[MAC_SET_SRC] != NULL) {
+        SCFree(ms->buf[MAC_SET_SRC]);
+    }
+    if (ms->buf[MAC_SET_DST] != NULL) {
+        SCFree(ms->buf[MAC_SET_DST]);
+    }
+    SCFree(ms);
+}
+
+#ifdef UNITTESTS
+
+static int CheckTest1Membership(uint8_t *addr, MacSetSide side, void *data)
+{
+    int *i = (int*) data;
+    switch (*i) {
+        case 0:
+            if (addr[5] != 1) return 1;
+            break;
+        case 1:
+            if (addr[5] != 2) return 1;
+            break;
+        case 2:
+            if (addr[5] != 3) return 1;
+            break;
+    }
+    (*i)++;
+    return 0;
+}
+
+static int MacSetTest01(void)
+{
+    MacSet *ms = NULL;
+    int ret = 0, i = 0;
+    MacAddr addr1 = {0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+            addr2 = {0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+            addr3 = {0x0, 0x0, 0x0, 0x0, 0x0, 0x3};
+    SC_ATOMIC_SET(flow_config.memcap, 10000);
+
+    ms = MacSetInit(10);
+    FAIL_IF_NULL(ms);
+    FAIL_IF_NOT(MacSetSize(ms) == 0);
+
+    ret = MacSetForEach(ms, CheckTest1Membership, &i);
+    FAIL_IF_NOT(ret == 0);
+
+    MacSetAdd(ms, addr1, addr2);
+    FAIL_IF_NOT(MacSetSize(ms) == 2);
+
+    ret = MacSetForEach(ms, CheckTest1Membership, &i);
+    FAIL_IF_NOT(ret == 0);
+
+    MacSetAdd(ms, addr1, addr3);
+    FAIL_IF_NOT(MacSetSize(ms) == 3);
+
+    i = 0;
+    ret = MacSetForEach(ms, CheckTest1Membership, &i);
+    FAIL_IF_NOT(ret == 0);
+
+    MacSetReset(ms);
+    FAIL_IF_NOT(MacSetSize(ms) == 0);
+
+    MacSetAdd(ms, addr2, addr3);
+    FAIL_IF_NOT(MacSetSize(ms) == 2);
+
+    i = 1;
+    ret = MacSetForEach(ms, CheckTest1Membership, &i);
+    FAIL_IF_NOT(ret == 0);
+
+    MacSetFree(ms);
+    return 1;
+}
+
+static int MacSetTest02(void)
+{
+    MacSet *ms = NULL;
+    int ret = 0, i = 0;
+    SC_ATOMIC_SET(flow_config.memcap, 10000);
+
+    ms = MacSetInit(10);
+    FAIL_IF_NULL(ms);
+    FAIL_IF_NOT(MacSetSize(ms) == 0);
+
+    for (i = 1; i < 100; i++) {
+        MacAddr addr1 = {0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+                addr2 = {0x1, 0x0, 0x0, 0x0, 0x0, 0x2};
+        MacSetAdd(ms, addr1, addr2);
+    }
+    FAIL_IF_NOT(MacSetSize(ms) == 2);
+
+    ret = MacSetForEach(ms, CheckTest1Membership, &i);
+    FAIL_IF_NOT(ret == 0);
+
+    MacSetFree(ms);
+    return 1;
+}
+
+static int MacSetTest03(void)
+{
+    MacSet *ms = NULL;
+    int i = 0;
+    SC_ATOMIC_SET(flow_config.memcap, 10000);
+
+    ms = MacSetInit(10);
+    FAIL_IF_NULL(ms);
+    FAIL_IF_NOT(MacSetSize(ms) == 0);
+
+    for (i = 1; i < 100; i++) {
+        MacAddr addr1 = {0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+                addr2 = {0x1, 0x0, 0x0, 0x0, 0x0, 0x1};
+        addr1[5] = i;
+        addr2[5] = i;
+        MacSetAdd(ms, addr1, addr2);
+    }
+    FAIL_IF_NOT(MacSetSize(ms) == 20);
+
+    MacSetFree(ms);
+    return 1;
+}
+
+static int MacSetTest04(void)
+{
+    MacSet *ms = NULL;
+    SC_ATOMIC_SET(flow_config.memcap, 2);
+
+    ms = MacSetInit(10);
+    FAIL_IF_NOT_NULL(ms);
+
+    return 1;
+}
+
+static int MacSetTest05(void)
+{
+    MacSet *ms = NULL;
+    int ret = 0, i = 0;
+    SC_ATOMIC_SET(flow_config.memcap, 10);
+
+    ms = MacSetInit(10);
+    FAIL_IF_NULL(ms);
+    FAIL_IF_NOT(MacSetSize(ms) == 0);
+
+    for (i = 1; i < 100; i++) {
+        MacAddr addr1 = {0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+                addr2 = {0x1, 0x0, 0x0, 0x0, 0x0, 0x1};
+        addr1[5] = i;
+        addr2[5] = i;
+        MacSetAdd(ms, addr1, addr2);
+    }
+    FAIL_IF_NOT(MacSetSize(ms) == 2);
+
+    ret = MacSetForEach(ms, CheckTest1Membership, &i);
+    FAIL_IF_NOT(ret == 0);
+
+    MacSetFree(ms);
+    return 1;
+}
+
+#endif /* UNITTESTS */
+
+void MacSetRegisterTests(void)
+{
+
+#ifdef UNITTESTS
+    UtRegisterTest("MacSetTest01", MacSetTest01);
+    UtRegisterTest("MacSetTest02", MacSetTest02);
+    UtRegisterTest("MacSetTest03", MacSetTest03);
+    UtRegisterTest("MacSetTest04", MacSetTest04);
+    UtRegisterTest("MacSetTest04", MacSetTest05);
+#endif
+
+    return;
+}

--- a/src/util-macset.h
+++ b/src/util-macset.h
@@ -1,0 +1,43 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Sascha Steinbiss <sascha.steinbiss@dcso.de>
+ */
+
+#ifndef __UTIL_MACSET_H__
+#define __UTIL_MACSET_H__
+
+typedef struct MacSet_ MacSet;
+typedef enum {
+    MAC_SET_SRC = 0,
+    MAC_SET_DST
+} MacSetSide;
+
+typedef int (*MacSetIteratorFunc)(uint8_t *addr, MacSetSide side, void*);
+
+MacSet *MacSetInit(int size);
+void    MacSetAdd(MacSet*, uint8_t *src_addr, uint8_t *dst_addr);
+int     MacSetForEach(MacSet*, MacSetIteratorFunc, void*);
+int     MacSetSize(MacSet*);
+void    MacSetReset(MacSet*);
+void    MacSetFree(MacSet*);
+void    MacSetRegisterTests(void);
+
+#endif /* __UTIL_MACSET_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -89,6 +89,7 @@ outputs:
       #facility: local5
       #level: Info ## possible levels: Emergency, Alert, Critical,
                    ## Error, Warning, Notice, Info, Debug
+      #ethernet: yes  # log ethernet header in events when available
       #redis:
       #  server: 127.0.0.1
       #  port: 6379


### PR DESCRIPTION
Previous PR: #4678 

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [#962](https://redmine.openinfosecfoundation.org/issues/962)

Describe changes (to previous PR):
- Fix unlikely but potential memory leak.
- Change wording of config log message.
- Adjust code formatting and type use.
- Add informative comments where non-trivial actions are done.
- Use capitalized names for function pointers.
- Put allocations under flow memcap constraints.
- Use static memory for the likely case of only two MAC adresses per flow and allocate memory for more only when more are seen.
- Add addresses for both sides of a flow within a single call.
- Add unit tests for `MacSet` data structure.