### PR TITLE
dag: Skip over ERF_TYPE_META records

### DIFF
--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -432,16 +432,17 @@ ProcessErfDagRecords(ErfDagThreadVars *ewtn, uint8_t *top, uint32_t *pkts_read)
 
         /* Only support ethernet at this time. */
         switch (hdr_type & 0x7f) {
-        case TYPE_PAD:
+        case ERF_TYPE_PAD:
+        case ERF_TYPE_META:
             /* Skip. */
             continue;
-        case TYPE_DSM_COLOR_ETH:
-        case TYPE_COLOR_ETH:
-        case TYPE_COLOR_HASH_ETH:
+        case ERF_TYPE_DSM_COLOR_ETH:
+        case ERF_TYPE_COLOR_ETH:
+        case ERF_TYPE_COLOR_HASH_ETH:
             /* In these types the color value overwrites the lctr
              * (drop count). */
             break;
-        case TYPE_ETH:
+        case ERF_TYPE_ETH:
             if (dr->lctr) {
                 StatsAddUI64(ewtn->tv, ewtn->drops, SCNtohs(dr->lctr));
             }


### PR DESCRIPTION
Suricata generates an error on unrecognised ERF types.
Suricata should ignore ERF 'Provenance' records with ERF_TYPE_META.

(cherry picked from commit 47082dd5df1b71485333039cd6af75b39cdfffeb)


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3534](https://redmine.openinfosecfoundation.org/issues/3534)

Describe changes:
- Backport of #4641 
