### PR TITLE
Ftp split v4

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -755,27 +755,28 @@ static AppLayerResult FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserS
         }
 
         state->curr_tx = tx;
-        if (state->command == FTP_COMMAND_AUTH_TLS) {
-            if (state->current_line_len >= 4 && SCMemcmp("234 ", state->current_line, 4) == 0) {
-                AppLayerRequestProtocolTLSUpgrade(f);
-            }
-        }
+        uint16_t dyn_port;
+        switch (state->command) {
+            case FTP_COMMAND_AUTH_TLS:
+                if (state->current_line_len >= 4 && SCMemcmp("234 ", state->current_line, 4) == 0) {
+                    AppLayerRequestProtocolTLSUpgrade(f);
+                }
+                break;
 
-        if (state->command == FTP_COMMAND_EPRT) {
-            uint16_t dyn_port = rs_ftp_active_eprt(state->port_line, state->port_line_len);
-            if (dyn_port == 0) {
-                goto tx_complete;
-            }
-            state->dyn_port = dyn_port;
-            state->active = true;
-            tx->dyn_port = dyn_port;
-            tx->active = true;
-            SCLogDebug("FTP active mode (v6): dynamic port %"PRIu16"", dyn_port);
-        }
+            case FTP_COMMAND_EPRT:
+                dyn_port = rs_ftp_active_eprt(state->port_line, state->port_line_len);
+                if (dyn_port == 0) {
+                    goto tx_complete;
+                }
+                state->dyn_port = dyn_port;
+                state->active = true;
+                tx->dyn_port = dyn_port;
+                tx->active = true;
+                SCLogDebug("FTP active mode (v6): dynamic port %"PRIu16"", dyn_port);
+                break;
 
-        if (state->command == FTP_COMMAND_PORT) {
-            if ((flags & STREAM_TOCLIENT)) {
-                uint16_t dyn_port = rs_ftp_active_port(state->port_line, state->port_line_len);
+            case FTP_COMMAND_PORT:
+                dyn_port = rs_ftp_active_port(state->port_line, state->port_line_len);
                 if (dyn_port == 0) {
                     goto tx_complete;
                 }
@@ -784,19 +785,21 @@ static AppLayerResult FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserS
                 tx->dyn_port = state->dyn_port;
                 tx->active = true;
                 SCLogDebug("FTP active mode (v4): dynamic port %"PRIu16"", dyn_port);
-            }
-        }
+                break;
 
-        if (state->command == FTP_COMMAND_PASV) {
-            if (state->current_line_len >= 4 && SCMemcmp("227 ", state->current_line, 4) == 0) {
-                FTPParsePassiveResponse(f, ftp_state, state->current_line, state->current_line_len);
-            }
-        }
+            case FTP_COMMAND_PASV:
+                if (state->current_line_len >= 4 && SCMemcmp("227 ", state->current_line, 4) == 0) {
+                    FTPParsePassiveResponse(f, ftp_state, state->current_line, state->current_line_len);
+                }
+                break;
 
-        if (state->command == FTP_COMMAND_EPSV) {
-            if (state->current_line_len >= 4 && SCMemcmp("229 ", state->current_line, 4) == 0) {
-                FTPParsePassiveResponseV6(f, ftp_state, state->current_line, state->current_line_len);
-            }
+            case FTP_COMMAND_EPSV:
+                if (state->current_line_len >= 4 && SCMemcmp("229 ", state->current_line, 4) == 0) {
+                    FTPParsePassiveResponseV6(f, ftp_state, state->current_line, state->current_line_len);
+                }
+                break;
+            default:
+                break;
         }
 
         if (likely(state->current_line_len)) {

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -996,13 +996,13 @@ static int FTPGetAlstateProgress(void *vtx, uint8_t direction)
     SCLogDebug("tx %p", vtx);
     FTPTransaction *tx = vtx;
 
-    if (direction == STREAM_TOSERVER &&
-        tx->command_descriptor->command == FTP_COMMAND_PORT) {
-        return FTP_STATE_PORT_DONE;
-    }
-
-    if (!tx->done)
+    if (!tx->done) {
+        if (direction == STREAM_TOSERVER &&
+            tx->command_descriptor->command == FTP_COMMAND_PORT) {
+            return FTP_STATE_PORT_DONE;
+        }
         return FTP_STATE_IN_PROGRESS;
+    }
 
     return FTP_STATE_FINISHED;
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None yet

Describe changes:
- Fixes FTP parser against packet split evasion
- use a `switch` for faster code when parsing FTP responses against different FTP commands
- Fixes bug in `FTPGetAlstateProgress` ending up in not logging certain FTP PORT commands
- Remove unnecessary condition `if ((flags & STREAM_TOCLIENT)) 

Problem happens for responses parsing where we do not control the end of response/end of line

Problem found while running suricata-verify test `output-eve-ftp` against Suricata compiled with this patch
```
diff --git a/src/app-layer.c b/src/app-layer.c
index b614f2712..0149d6b4f 100644
--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -658,8 +658,15 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
          * a start msg should have gotten us one */
         if (f->alproto != ALPROTO_UNKNOWN) {
             PACKET_PROFILING_APP_START(app_tctx, f->alproto);
+#ifndef LOLSPLIT
+            for (size_t i = 0; i < data_len; i++) {
+                r = AppLayerParserParse(tv, app_tctx->alp_tctx, f, f->alproto,
+                                        flags, data+i, 1);
+            }
+#else
             r = AppLayerParserParse(tv, app_tctx->alp_tctx, f, f->alproto,
                                     flags, data, data_len);
+#endif
             PACKET_PROFILING_APP_END(app_tctx, f->alproto);
             if (r >= 0) {
                 (*stream)->app_progress_rel += data_len;
```

Similar to #4645 

Makes S-V fix https://github.com/OISF/suricata-verify/pull/199 work

For review purposes, I put in two commits :
- adding a loop for parsing response lines
- indentation (adding 4 spaces everywhere)

Modifies #4686 with rebasing and commit better description