### PR TITLE
Include devguide in distributions plus tests - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -318,6 +318,15 @@ jobs:
                 software-properties-common \
                 zlib1g \
                 zlib1g-dev
+      - name: Install packages for generating documentation
+        run: |
+          DEBIAN_FRONTEND=noninteractive apt -y install \
+                sphinx-doc \
+                sphinx-common \
+                texlive-latex-base \
+                texlive-fonts-recommended \
+                texlive-fonts-extra \
+                texlive-latex-extra
       - name: Install Coccinelle
         run: |
           add-apt-repository -y ppa:npalix/coccinelle
@@ -333,6 +342,12 @@ jobs:
       - name: Running unit tests and cocci checks
         # Set the concurrency level for cocci.
         run: CONCURRENCY_LEVEL=2 make check
+      - run: make dist
+      - name: Checking that documentation was built
+        run: |
+          test -e doc/devguide/devguide.pdf
+          test -e doc/userguide/userguide.pdf
+          test -e doc/userguide/suricata.1
       - name: Fetching suricata-verify
         run: git clone https://github.com/OISF/suricata-verify.git
       - name: Running suricata-verify

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -85,19 +85,13 @@ jobs:
       - name: Configuring
         run: |
           ./autogen.sh
-          ./configure --enable-unittests \
-                --enable-debug \
-                --enable-lua \
-                --enable-geoip \
-                --enable-profiling \
-                --enable-profiling-locks
-      - name: Building
-        run: make -j2
-      - name: Running unittests
-        run: make check
-      - name: Building distribution
+          ./configure
+      - run: make -j2 distcheck
+        env:
+          DISTCHECK_CONFIGURE_FLAGS: "--enable-unittests --enable-debug --enable-lua --enable-geoip --enable-profiling --enable-profiling-locks"
+      - run: test -e doc/userguide/suricata.1
+      - name: Preparing distribution
         run: |
-          make dist
           mkdir dist
           mv suricata-*.tar.gz dist
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -246,6 +246,11 @@ jobs:
                 sudo \
                 which \
                 zlib-devel
+      - name: Installing packages to build documentation
+        run: |
+          dnf -y install \
+                python3-sphinx \
+                texlive-scheme-full
       - name: Install cbindgen
         run: cargo install --force cbindgen
       - run: echo "::add-path::$HOME/.cargo/bin"
@@ -255,6 +260,9 @@ jobs:
       - run: ./configure --enable-unittests
       - run: make -j2
       - run: make check
+      - run: make dist
+      - run: test -e doc/devguide/devguide.pdf
+      - run: test -e doc/userguide/userguide.pdf
       - run: make distcheck
       - name: Fetching suricata-verify
         run: git clone https://github.com/OISF/suricata-verify.git

--- a/doc/devguide/Makefile.am
+++ b/doc/devguide/Makefile.am
@@ -1,7 +1,15 @@
+EXTRA_DIST = \
+	conf.py \
+	_static \
+	index.rst \
+	code-submission-process.rst \
+	code-style.rst \
+	app-layer
+
 if HAVE_SPHINXBUILD
 
 if HAVE_PDFLATEX
-EXTRA_DIST = devguide.pdf
+EXTRA_DIST += devguide.pdf
 endif
 
 SPHINX_BUILD = sphinx-build -q


### PR DESCRIPTION
The devguide files were missing from EXTRA_DIST causing them not
to be shipped in a dist archive, as well as causing make dist to
fail if the documentation tooling was discovered during
./configure.

Update a few GitHub CI tests to check this.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/455
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/812