### PR TITLE
[preview] Cleanup thread contextual info when needed

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2996,6 +2996,26 @@ int DetectRegisterThreadCtxFuncs(DetectEngineCtx *de_ctx, const char *name, void
     return item->id;
 }
 
+int DetectFreeThreadCtxFuncs(DetectEngineCtx *de_ctx, const char *name)
+{
+    BUG_ON(de_ctx == NULL);
+
+    DetectEngineThreadKeywordCtxItem *item = de_ctx->keyword_list;
+    DetectEngineThreadKeywordCtxItem *prev_item = NULL;
+    while (item != NULL) {
+        if (strcmp(name, item->name) == 0) {
+            if (prev_item == NULL)
+                de_ctx->keyword_list = item->next;
+            else
+                prev_item = item->next;
+            SCFree(item);
+            return 1;
+        }
+        prev_item = item;
+        item = item->next;
+    }
+    return 0;
+}
 /** \brief Retrieve thread local keyword ctx by id
  *
  *  \param det_ctx detection engine thread ctx to retrieve the ctx from

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -687,6 +687,7 @@ static DetectLuaData *DetectLuaParse (const DetectEngineCtx *de_ctx, const char 
         goto error;
     }
 
+    lua->de_ctx = (DetectEngineCtx *)de_ctx;
     return lua;
 
 error:
@@ -1113,6 +1114,8 @@ static void DetectLuaFree(void *ptr)
 {
     if (ptr != NULL) {
         DetectLuaData *lua = (DetectLuaData *)ptr;
+
+        DetectFreeThreadCtxFuncs(lua->de_ctx, "lua");
 
         if (lua->buffername)
             SCFree(lua->buffername);

--- a/src/detect-lua.h
+++ b/src/detect-lua.h
@@ -49,6 +49,8 @@ typedef struct DetectLuaData {
     uint32_t sid;
     uint32_t rev;
     uint32_t gid;
+
+    DetectEngineCtx *de_ctx;
 } DetectLuaData;
 
 #endif /* HAVE_LUA */

--- a/src/detect.h
+++ b/src/detect.h
@@ -1477,6 +1477,7 @@ const SigGroupHead *SigMatchSignaturesGetSgh(const DetectEngineCtx *de_ctx, cons
 Signature *DetectGetTagSignature(void);
 
 
+int DetectFreeThreadCtxFuncs(DetectEngineCtx *, const char *name);
 int DetectRegisterThreadCtxFuncs(DetectEngineCtx *, const char *name, void *(*InitFunc)(void *), void *data, void (*FreeFunc)(void *), int);
 void *DetectThreadCtxGetKeywordThreadCtx(DetectEngineThreadCtx *, int);
 


### PR DESCRIPTION
@victorjulien and @pevma This is a preview PR that corrects the issues in 3273. Please comment upon the approach.

I used these rules -- the first rule demonstrated the issue. With this PR, memory is no longer overrun.
```
alert http any any -> any any (msg:"High entropy in file name download"; file.name; content:".exe"; endswith; fast_pattern;  bsize:<21; lua:any.lua; xbits: isset, urlentropy.detected; track ip_dst, expire 3600; target: dest_ip; sid:10; rev:1;)
alert http any any -> any any (msg:"High entropy in file name download"; file.name; content:".exe"; endswith; fast_pattern;  bsize:<21; lua:any.lua;   target: dest_ip; sid:11; rev:1;)
```

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3273](https://redmine.openinfosecfoundation.org/issues/3273)

Describe changes:
- New function to free per-thread keyword items
- Free per-thread keyword items when freeing outer lua context
