### PR TITLE
decode/teredo: implement port support

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2246,7 +2246,13 @@ The Teredo decoder can be disabled. It is enabled by default.
       # it will sometimes detect non-teredo as teredo.
       teredo:
         enabled: true
+        # ports to look for Teredo. Max 4 ports. If no ports are given, or
+        # the value is set to 'any', Teredo detection runs on _all_ UDP packets.
+        ports: $TEREDO_PORTS # syntax: '3544, 1234'
 
+Using this default configuration, Teredo detection will run on UDP port
+3544. If the `ports` parameter is missing, or set to `any`, all ports will be
+inspected for possible presence of Teredo.
 
 Advanced Options
 ----------------

--- a/src/decode-teredo.h
+++ b/src/decode-teredo.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2012 Open Information Security Foundation
+/* Copyright (C) 2012-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -21,5 +21,6 @@
 int DecodeTeredo(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                  const uint8_t *pkt, uint16_t len);
 void DecodeTeredoConfig(void);
+bool DecodeTeredoEnabledForPort(const uint16_t sp, const uint16_t dp);
 
 #endif

--- a/src/decode-udp.c
+++ b/src/decode-udp.c
@@ -84,7 +84,8 @@ int DecodeUDP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     SCLogDebug("UDP sp: %" PRIu32 " -> dp: %" PRIu32 " - HLEN: %" PRIu32 " LEN: %" PRIu32 "",
         UDP_GET_SRC_PORT(p), UDP_GET_DST_PORT(p), UDP_HEADER_LEN, p->payload_len);
 
-    if (unlikely(DecodeTeredo(tv, dtv, p, p->payload, p->payload_len) == TM_ECODE_OK)) {
+    if (DecodeTeredoEnabledForPort(p->sp, p->dp) &&
+            unlikely(DecodeTeredo(tv, dtv, p, p->payload, p->payload_len) == TM_ECODE_OK)) {
         /* Here we have a Teredo packet and don't need to handle app
          * layer */
         FlowSetupPacket(p);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -45,6 +45,7 @@ vars:
     FILE_DATA_PORTS: "[$HTTP_PORTS,110,143]"
     FTP_PORTS: 21
     VXLAN_PORTS: 4789
+    TEREDO_PORTS: 3544
 
 ##
 ## Step 2: Select outputs to enable
@@ -1328,6 +1329,10 @@ decoder:
   # as it will sometimes detect non-teredo as teredo.
   teredo:
     enabled: true
+    # ports to look for Teredo. Max 4 ports. If no ports are given, or
+    # the value is set to 'any', Teredo detection runs on _all_ UDP packets.
+    ports: $TEREDO_PORTS # syntax: '3544, 1234'
+
   # VXLAN decoder is assigned to up to 4 UDP ports. By default only the
   # IANA assigned port 4789 is enabled.
   vxlan:


### PR DESCRIPTION
Implement support for limiting Teredo detection and decoding to specific
UDP ports, with 3544 as the default.

If no ports are specified, the old behaviour of detecting/decoding on any
port is still in place. This can also be forced by specifying 'any' as the
port setting.

https://redmine.openinfosecfoundation.org/issues/3546

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed.