### PR TITLE
ci: enables fuzz targets in one build

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -453,7 +453,7 @@ jobs:
               tar zxvf - --strip-components=1
         working-directory: suricata-update
       - run: ./autogen.sh
-      - run: ./configure --enable-unittests
+      - run: ./configure --enable-unittests --enable-fuzztargets
       - run: make -j2
       - run: make check
       - name: Fetching suricata-verify


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2859

Describe changes:
- Enables fuzz targets build in one build (GitHub workflow Debian)

So as we don't accidentally break it