### PR TITLE
Fuzz ci v2

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -453,7 +453,7 @@ jobs:
               tar zxvf - --strip-components=1
         working-directory: suricata-update
       - run: ./autogen.sh
-      - run: ./configure --enable-unittests
+      - run: ./configure --enable-unittests --enable-fuzztargets
       - run: make -j2
       - run: make check
       - name: Fetching suricata-verify

--- a/configure.ac
+++ b/configure.ac
@@ -465,9 +465,12 @@
     AC_PROG_CXX
     AS_IF([test "x$enable_fuzztargets" = "xyes"], [
         AC_DEFINE([AFLFUZZ_NO_RANDOM], [1], [Disable all use of random functions])
+        CFLAGS_ORIG=$CFLAGS
+        CFLAGS="-Werror"
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[while (__AFL_LOOP(1000))]])],
                 [AC_DEFINE([AFLFUZZ_PERSISTANT_MODE], [1], [Enable AFL PERSISTANT_MODE])],
                 [])
+        CFLAGS=$CFLAGS_ORIG
         AC_LANG_PUSH(C++)
         tmp_saved_flags=$[]_AC_LANG_PREFIX[]FLAGS
         AS_IF([test "x$LIB_FUZZING_ENGINE" = "x"], [


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2859

Describe changes:
- Enables fuzz targets build in one build (GitHub workflow Debian)
- Fix configure test to set `AFLFUZZ_PERSISTANT_MODE`

So as we don't accidentally break the fuzz targets build

Modifies #4729 by having right test for `AFLFUZZ_PERSISTANT_MODE`