### PR TITLE
New StringParse* functions

### DIFF
--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -202,7 +202,7 @@ void DefragInitConfig(char quiet)
     }
     if ((ConfGet("defrag.hash-size", &conf_val)) == 1)
     {
-        if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
+        if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             defrag_config.hash_size = configval;
         } else {
@@ -213,7 +213,7 @@ void DefragInitConfig(char quiet)
 
     if ((ConfGet("defrag.trackers", &conf_val)) == 1)
     {
-        if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
+        if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             defrag_config.prealloc = configval;
         } else {

--- a/src/detect-asn1.c
+++ b/src/detect-asn1.c
@@ -233,7 +233,7 @@ static DetectAsn1Data *DetectAsn1Parse(const char *instr)
             /* get the param */
             tok = strtok_r(NULL, ASN_DELIM, &saveptr);
             if ( tok == NULL ||
-                ByteExtractStringUint32(&ov_len, 10, 0, tok) <= 0)
+                StringParseUint32(&ov_len, 10, 0, tok) <= 0)
             {
                 SCLogError(SC_ERR_INVALID_VALUE, "Malformed value for "
                            "oversize_length: %s", tok);
@@ -244,7 +244,7 @@ static DetectAsn1Data *DetectAsn1Parse(const char *instr)
             /* get the param */
             tok = strtok_r(NULL, ASN_DELIM, &saveptr);
             if (tok == NULL ||
-                ByteExtractStringUint32(&abs_off, 10, 0, tok) <= 0)
+                StringParseUint32(&abs_off, 10, 0, tok) <= 0)
             {
                 SCLogError(SC_ERR_INVALID_VALUE, "Malformed value for "
                            "absolute_offset: %s", tok);
@@ -255,7 +255,7 @@ static DetectAsn1Data *DetectAsn1Parse(const char *instr)
             /* get the param */
             tok = strtok_r(NULL, ASN_DELIM, &saveptr);
             if (tok == NULL ||
-                ByteExtractStringInt32(&rel_off, 10, 0, tok) <= 0)
+                StringParseInt32(&rel_off, 10, 0, tok) <= 0)
             {
                 SCLogError(SC_ERR_INVALID_VALUE, "Malformed value for "
                            "relative_offset: %s", tok);

--- a/src/detect-base64-decode.c
+++ b/src/detect-base64-decode.c
@@ -121,7 +121,7 @@ static int DetectBase64DecodeParse(const char *str, uint32_t *bytes,
 
     if (pcre_rc >= 3) {
         if (pcre_get_substring((char *)str, ov, max, 2, &bytes_str) > 0) {
-            if (ByteExtractStringUint32(bytes, 10, 0, bytes_str) <= 0) {
+            if (StringParseUint32(bytes, 10, 0, bytes_str) <= 0) {
                 SCLogError(SC_ERR_INVALID_RULE_ARGUMENT,
                     "Bad value for bytes: \"%s\"", bytes_str);
                 goto error;
@@ -131,7 +131,7 @@ static int DetectBase64DecodeParse(const char *str, uint32_t *bytes,
 
     if (pcre_rc >= 5) {
         if (pcre_get_substring((char *)str, ov, max, 4, &offset_str)) {
-            if (ByteExtractStringUint32(offset, 10, 0, offset_str) <= 0) {
+            if (StringParseUint32(offset, 10, 0, offset_str) <= 0) {
                 SCLogError(SC_ERR_INVALID_RULE_ARGUMENT,
                     "Bad value for offset: \"%s\"", offset_str);
                 goto error;

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -390,7 +390,7 @@ static DetectBytejumpData *DetectBytejumpParse(const char *optstr, char **offset
      */
 
     /* Number of bytes */
-    if (ByteExtractStringUint32(&nbytes, 10, strlen(args[0]), args[0]) <= 0) {
+    if (StringParseUint32(&nbytes, 10, strlen(args[0]), args[0]) <= 0) {
         SCLogError(SC_ERR_INVALID_VALUE, "Malformed number of bytes: %s", optstr);
         goto error;
     }
@@ -407,7 +407,7 @@ static DetectBytejumpData *DetectBytejumpParse(const char *optstr, char **offset
         if (*offset == NULL)
             goto error;
     } else {
-        if (ByteExtractStringInt32(&data->offset, 0, strlen(args[1]), args[1]) <= 0) {
+        if (StringParseInt32(&data->offset, 0, strlen(args[1]), args[1]) <= 0) {
             SCLogError(SC_ERR_INVALID_VALUE, "Malformed offset: %s", optstr);
             goto error;
         }
@@ -438,7 +438,7 @@ static DetectBytejumpData *DetectBytejumpParse(const char *optstr, char **offset
         } else if (strcasecmp("align", args[i]) == 0) {
             data->flags |= DETECT_BYTEJUMP_ALIGN;
         } else if (strncasecmp("multiplier ", args[i], 11) == 0) {
-            if (ByteExtractStringUint32(&data->multiplier, 10,
+            if (StringParseUint32(&data->multiplier, 10,
                                         strlen(args[i]) - 11,
                                         args[i] + 11) <= 0)
             {
@@ -446,7 +446,7 @@ static DetectBytejumpData *DetectBytejumpParse(const char *optstr, char **offset
                 goto error;
             }
         } else if (strncasecmp("post_offset ", args[i], 12) == 0) {
-            if (ByteExtractStringInt32(&data->post_offset, 10,
+            if (StringParseInt32(&data->post_offset, 10,
                                        strlen(args[i]) - 12,
                                        args[i] + 12) <= 0)
             {

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -320,7 +320,7 @@ static DetectBytetestData *DetectBytetestParse(const char *optstr, char **value,
      */
 
     /* Number of bytes */
-    if (ByteExtractStringUint32(&nbytes, 10, 0, args[0]) <= 0) {
+    if (StringParseUint32(&nbytes, 10, 0, args[0]) <= 0) {
         SCLogError(SC_ERR_INVALID_VALUE, "Malformed number of bytes: %s", str_ptr);
         goto error;
     }
@@ -381,7 +381,7 @@ static DetectBytetestData *DetectBytetestParse(const char *optstr, char **value,
             if (*value == NULL)
                 goto error;
         } else {
-            if (ByteExtractStringUint64(&data->value, 0, 0, test_value) <= 0) {
+            if (StringParseUint64(&data->value, 0, 0, test_value) <= 0) {
                 SCLogError(SC_ERR_INVALID_VALUE, "Malformed value: %s", test_value);
                 goto error;
             }
@@ -410,7 +410,7 @@ static DetectBytetestData *DetectBytetestParse(const char *optstr, char **value,
             if (*offset == NULL)
                 goto error;
         } else {
-            if (ByteExtractStringInt32(&data->offset, 0, 0, data_offset) <= 0) {
+            if (StringParseInt32(&data->offset, 0, 0, data_offset) <= 0) {
                 SCLogError(SC_ERR_INVALID_VALUE, "Malformed offset: %s", data_offset);
                 goto error;
             }

--- a/src/detect-datarep.c
+++ b/src/detect-datarep.c
@@ -142,7 +142,7 @@ static int DetectDatarepParse(const char *str,
                 return -1;
             }
 
-            if (ByteExtractStringUint16(rep_value, 10, 0, key) != (int)strlen(key))
+            if (StringParseUint16(rep_value, 10, 0, key) < 0)
                 return -1;
 
             value_set = true;

--- a/src/detect-depth.c
+++ b/src/detect-depth.c
@@ -114,7 +114,7 @@ static int DetectDepthSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
         cd->depth = ((DetectByteExtractData *)bed_sm->ctx)->local_id;
         cd->flags |= DETECT_CONTENT_DEPTH_BE;
     } else {
-        if (ByteExtractStringUint16(&cd->depth, 0, 0, str) != (int)strlen(str))
+        if (StringParseUint16(&cd->depth, 0, 0, str) < 0)
         {
             SCLogError(SC_ERR_INVALID_SIGNATURE,
                       "invalid value for depth: %s.", str);

--- a/src/detect-detection-filter.c
+++ b/src/detect-detection-filter.c
@@ -162,12 +162,12 @@ static DetectThresholdData *DetectDetectionFilterParse (const char *rawstr)
         goto error;
     }
 
-    if (ByteExtractStringUint32(&df->count, 10, strlen(args[count_pos]),
+    if (StringParseUint32(&df->count, 10, strlen(args[count_pos]),
                 args[count_pos]) <= 0) {
         goto error;
     }
 
-    if (ByteExtractStringUint32(&df->seconds, 10, strlen(args[seconds_pos]),
+    if (StringParseUint32(&df->seconds, 10, strlen(args[seconds_pos]),
                 args[seconds_pos]) <= 0) {
         goto error;
     }

--- a/src/detect-distance.c
+++ b/src/detect-distance.c
@@ -113,7 +113,7 @@ static int DetectDistanceSetup (DetectEngineCtx *de_ctx, Signature *s,
         cd->distance = ((DetectByteExtractData *)bed_sm->ctx)->local_id;
         cd->flags |= DETECT_CONTENT_DISTANCE_BE;
     } else {
-        if (ByteExtractStringInt32(&cd->distance, 0, 0, str) != (int)strlen(str)) {
+        if (StringParseInt32(&cd->distance, 0, 0, str) < 0) {
             SCLogError(SC_ERR_INVALID_SIGNATURE,
                       "invalid value for distance: %s", str);
             goto end;

--- a/src/detect-dnp3.c
+++ b/src/detect-dnp3.c
@@ -195,7 +195,7 @@ static int DetectEngineInspectDNP3(ThreadVars *tv, DetectEngineCtx *de_ctx,
  */
 static int DetectDNP3FuncParseFunctionCode(const char *str, uint8_t *fc)
 {
-    if (ByteExtractStringUint8(fc, 10, strlen(str), str) >= 0) {
+    if (StringParseUint8(fc, 10, strlen(str), str) >= 0) {
         return 1;
     }
 
@@ -287,7 +287,7 @@ static int DetectDNP3IndParse(const char *str, uint16_t *flags)
 {
     *flags = 0;
 
-    if (ByteExtractStringUint16(flags, 0, strlen(str), str) > 0) {
+    if (StringParseUint16(flags, 0, strlen(str), str) > 0) {
         return 1;
     }
 
@@ -362,11 +362,11 @@ static int DetectDNP3ObjParse(const char *str, uint8_t *group, uint8_t *var)
     *sep = '\0';
     varstr = sep + 1;
 
-    if (ByteExtractStringUint8(group, 0, strlen(groupstr), groupstr) < 0) {
+    if (StringParseUint8(group, 0, strlen(groupstr), groupstr) < 0) {
         return 0;
     }
 
-    if (ByteExtractStringUint8(var, 0, strlen(varstr), varstr) < 0) {
+    if (StringParseUint8(var, 0, strlen(varstr), varstr) < 0) {
         return 0;
     }
 

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -207,7 +207,7 @@ static DetectDsizeData *DetectDsizeParse (const char *rawstr)
     }
 
     /** set the first dsize value */
-    if (ByteExtractStringUint16(&dd->dsize,10,strlen(value1),value1) <= 0) {
+    if (StringParseUint16(&dd->dsize,10,strlen(value1),value1) <= 0) {
         SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid size value1:\"%s\"", value1);
         goto error;
     }
@@ -219,7 +219,7 @@ static DetectDsizeData *DetectDsizeParse (const char *rawstr)
             goto error;
         }
 
-        if (ByteExtractStringUint16(&dd->dsize2,10,strlen(value2),value2) <= 0) {
+        if (StringParseUint16(&dd->dsize2,10,strlen(value2),value2) <= 0) {
             SCLogError(SC_ERR_INVALID_ARGUMENT,"Invalid size value2:\"%s\"",value2);
             goto error;
         }

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2225,7 +2225,7 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
                 }
             }
             if (max_uniq_toclient_groups_str != NULL) {
-                if (ByteExtractStringUint16(&de_ctx->max_uniq_toclient_groups, 10,
+                if (StringParseUint16(&de_ctx->max_uniq_toclient_groups, 10,
                     strlen(max_uniq_toclient_groups_str),
                     (const char *)max_uniq_toclient_groups_str) <= 0)
                 {
@@ -2242,7 +2242,7 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
             SCLogConfig("toclient-groups %u", de_ctx->max_uniq_toclient_groups);
 
             if (max_uniq_toserver_groups_str != NULL) {
-                if (ByteExtractStringUint16(&de_ctx->max_uniq_toserver_groups, 10,
+                if (StringParseUint16(&de_ctx->max_uniq_toserver_groups, 10,
                     strlen(max_uniq_toserver_groups_str),
                     (const char *)max_uniq_toserver_groups_str) <= 0)
                 {
@@ -3381,8 +3381,8 @@ static int DetectEngineMultiTenantSetupLoadLivedevMappings(const ConfNode *mappi
                 goto bad_mapping;
 
             uint32_t tenant_id = 0;
-            if (ByteExtractStringUint32(&tenant_id, 10, strlen(tenant_id_node->val),
-                        tenant_id_node->val) == -1)
+            if (StringParseUint32(&tenant_id, 10, strlen(tenant_id_node->val),
+                        tenant_id_node->val) < 0)
             {
                 SCLogError(SC_ERR_INVALID_ARGUMENT, "tenant-id  "
                         "of %s is invalid", tenant_id_node->val);
@@ -3441,8 +3441,8 @@ static int DetectEngineMultiTenantSetupLoadVlanMappings(const ConfNode *mappings
                 goto bad_mapping;
 
             uint32_t tenant_id = 0;
-            if (ByteExtractStringUint32(&tenant_id, 10, strlen(tenant_id_node->val),
-                        tenant_id_node->val) == -1)
+            if (StringParseUint32(&tenant_id, 10, strlen(tenant_id_node->val),
+                        tenant_id_node->val) < 0)
             {
                 SCLogError(SC_ERR_INVALID_ARGUMENT, "tenant-id  "
                         "of %s is invalid", tenant_id_node->val);
@@ -3450,8 +3450,8 @@ static int DetectEngineMultiTenantSetupLoadVlanMappings(const ConfNode *mappings
             }
 
             uint16_t vlan_id = 0;
-            if (ByteExtractStringUint16(&vlan_id, 10, strlen(vlan_id_node->val),
-                        vlan_id_node->val) == -1)
+            if (StringParseUint16(&vlan_id, 10, strlen(vlan_id_node->val),
+                        vlan_id_node->val) < 0)
             {
                 SCLogError(SC_ERR_INVALID_ARGUMENT, "vlan-id  "
                         "of %s is invalid", vlan_id_node->val);
@@ -3597,8 +3597,8 @@ int DetectEngineMultiTenantSetup(void)
                 }
 
                 uint32_t tenant_id = 0;
-                if (ByteExtractStringUint32(&tenant_id, 10, strlen(id_node->val),
-                            id_node->val) == -1)
+                if (StringParseUint32(&tenant_id, 10, strlen(id_node->val),
+                            id_node->val) < 0)
                 {
                     SCLogError(SC_ERR_INVALID_ARGUMENT, "tenant_id  "
                             "of %s is invalid", id_node->val);

--- a/src/detect-fragoffset.c
+++ b/src/detect-fragoffset.c
@@ -184,7 +184,7 @@ static DetectFragOffsetData *DetectFragOffsetParse (const char *fragoffsetstr)
         }
     }
 
-    if (ByteExtractStringUint16(&fragoff->frag_off, 10, 0, substr[1]) < 0) {
+    if (StringParseUint16(&fragoff->frag_off, 10, 0, substr[1]) < 0) {
         SCLogError(SC_ERR_INVALID_ARGUMENT, "specified frag offset %s is not "
                                         "valid", substr[1]);
         goto error;

--- a/src/detect-icmp-id.c
+++ b/src/detect-icmp-id.c
@@ -193,9 +193,8 @@ static DetectIcmpIdData *DetectIcmpIdParse (const char *icmpidstr)
         }
     }
 
-    /** \todo can ByteExtractStringUint16 do this? */
     uint16_t id = 0;
-    if (ByteExtractStringUint16(&id, 10, 0, substr[1]) < 0) {
+    if (StringParseUint16(&id, 10, 0, substr[1]) < 0) {
         SCLogError(SC_ERR_INVALID_ARGUMENT, "specified icmp id %s is not "
                                         "valid", substr[1]);
         goto error;

--- a/src/detect-icmp-seq.c
+++ b/src/detect-icmp-seq.c
@@ -197,7 +197,7 @@ static DetectIcmpSeqData *DetectIcmpSeqParse (const char *icmpseqstr)
     }
 
     uint16_t seq = 0;
-    if (ByteExtractStringUint16(&seq, 10, 0, substr[1]) < 0) {
+    if (StringParseUint16(&seq, 10, 0, substr[1]) < 0) {
         SCLogError(SC_ERR_INVALID_ARGUMENT, "specified icmp seq %s is not "
                                         "valid", substr[1]);
         goto error;

--- a/src/detect-icode.c
+++ b/src/detect-icode.c
@@ -182,7 +182,7 @@ static DetectICodeData *DetectICodeParse(const char *icodestr)
             goto error;
         }
         /* we have only a comparison ("<", ">") */
-        if (ByteExtractStringUint8(&icd->code1, 10, 0, args[1]) < 0) {
+        if (StringParseUint8(&icd->code1, 10, 0, args[1]) < 0) {
             SCLogError(SC_ERR_INVALID_ARGUMENT, "specified icmp code %s is not "
                                         "valid", args[1]);
             goto error;
@@ -193,12 +193,12 @@ static DetectICodeData *DetectICodeParse(const char *icodestr)
         /* we have a range ("<>") */
         if (args[2] != NULL) {
             icd->mode = (uint8_t) DETECT_ICODE_RN;
-            if (ByteExtractStringUint8(&icd->code1, 10, 0, args[1]) < 0) {
+            if (StringParseUint8(&icd->code1, 10, 0, args[1]) < 0) {
                 SCLogError(SC_ERR_INVALID_ARGUMENT, "specified icmp code %s is not "
                                             "valid", args[1]);
                 goto error;
             }
-            if (ByteExtractStringUint8(&icd->code2, 10, 0, args[2]) < 0) {
+            if (StringParseUint8(&icd->code2, 10, 0, args[2]) < 0) {
                 SCLogError(SC_ERR_INVALID_ARGUMENT, "specified icmp code %s is not "
                                             "valid", args[2]);
                 goto error;
@@ -212,7 +212,7 @@ static DetectICodeData *DetectICodeParse(const char *icodestr)
             }
         } else { /* we have an equality */
             icd->mode = DETECT_ICODE_EQ;
-            if (ByteExtractStringUint8(&icd->code1, 10, 0, args[1]) < 0) {
+            if (StringParseUint8(&icd->code1, 10, 0, args[1]) < 0) {
                 SCLogError(SC_ERR_INVALID_ARGUMENT, "specified icmp code %s is not "
                                                     "valid", args[1]);
                 goto error;

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -126,7 +126,7 @@ static DetectIPProtoData *DetectIPProtoParse(const char *optstr)
         data->proto = (uint8_t)pent->p_proto;
     }
     else {
-        if (ByteExtractStringUint8(&data->proto, 10, 0, args[1]) <= 0) {
+        if (StringParseUint8(&data->proto, 10, 0, args[1]) <= 0) {
             SCLogError(SC_ERR_INVALID_VALUE, "Malformed protocol number: %s",
                        str_ptr);
             goto error;

--- a/src/detect-isdataat.c
+++ b/src/detect-isdataat.c
@@ -150,7 +150,7 @@ static DetectIsdataatData *DetectIsdataatParse (const char *isdataatstr, char **
             if (*offset == NULL)
                 goto error;
         } else {
-            if (ByteExtractStringUint16(&idad->dataat, 10,
+            if (StringParseUint16(&idad->dataat, 10,
                                         strlen(args[0]), args[0]) < 0 ) {
                 SCLogError(SC_ERR_INVALID_VALUE, "isdataat out of range");
                 SCFree(idad);

--- a/src/detect-itype.c
+++ b/src/detect-itype.c
@@ -182,7 +182,7 @@ static DetectITypeData *DetectITypeParse(const char *itypestr)
             goto error;
         }
         /* we have only a comparison ("<", ">") */
-        if (ByteExtractStringUint8(&itd->type1, 10, 0, args[1]) < 0) {
+        if (StringParseUint8(&itd->type1, 10, 0, args[1]) < 0) {
             SCLogError(SC_ERR_INVALID_ARGUMENT, "specified icmp type %s is not "
                                                 "valid", args[1]);
             goto error;
@@ -193,12 +193,12 @@ static DetectITypeData *DetectITypeParse(const char *itypestr)
         /* we have a range ("<>") */
         if (args[2] != NULL) {
             itd->mode = (uint8_t) DETECT_ITYPE_RN;
-            if (ByteExtractStringUint8(&itd->type1, 10, 0, args[1]) < 0) {
+            if (StringParseUint8(&itd->type1, 10, 0, args[1]) < 0) {
                 SCLogError(SC_ERR_INVALID_ARGUMENT, "specified icmp type %s is not "
                                                     "valid", args[1]);
                 goto error;
             }
-            if (ByteExtractStringUint8(&itd->type2, 10, 0, args[2]) < 0) {
+            if (StringParseUint8(&itd->type2, 10, 0, args[2]) < 0) {
                 SCLogError(SC_ERR_INVALID_ARGUMENT, "specified icmp type %s is not "
                                                     "valid", args[2]);
                 goto error;
@@ -212,7 +212,7 @@ static DetectITypeData *DetectITypeParse(const char *itypestr)
             }
         } else { /* we have an equality */
             itd->mode = DETECT_ITYPE_EQ;
-            if (ByteExtractStringUint8(&itd->type1, 10, 0, args[1]) < 0) {
+            if (StringParseUint8(&itd->type1, 10, 0, args[1]) < 0) {
                 SCLogError(SC_ERR_INVALID_ARGUMENT, "specified icmp type %s is not "
                                                     "valid", args[1]);
                 goto error;

--- a/src/detect-offset.c
+++ b/src/detect-offset.c
@@ -106,7 +106,7 @@ int DetectOffsetSetup (DetectEngineCtx *de_ctx, Signature *s, const char *offset
         cd->offset = ((DetectByteExtractData *)bed_sm->ctx)->local_id;
         cd->flags |= DETECT_CONTENT_OFFSET_BE;
     } else {
-        if (ByteExtractStringUint16(&cd->offset, 0, 0, str) != (int)strlen(str))
+        if (StringParseUint16(&cd->offset, 0, 0, str) < 0)
         {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid value for offset: %s.", str);
             goto end;

--- a/src/detect-rpc.c
+++ b/src/detect-rpc.c
@@ -194,7 +194,7 @@ static DetectRpcData *DetectRpcParse (const char *rpcstr)
         if (args[i]) {
             switch (i) {
                 case 0:
-                    if (ByteExtractStringUint32(&rd->program, 10, strlen(args[i]), args[i]) <= 0) {
+                    if (StringParseUint32(&rd->program, 10, strlen(args[i]), args[i]) <= 0) {
                         SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid size specified for the rpc program:\"%s\"", args[i]);
                         goto error;
                     }
@@ -202,7 +202,7 @@ static DetectRpcData *DetectRpcParse (const char *rpcstr)
                     break;
                 case 1:
                     if (args[i][0] != '*') {
-                        if (ByteExtractStringUint32(&rd->program_version, 10, strlen(args[i]), args[i]) <= 0) {
+                        if (StringParseUint32(&rd->program_version, 10, strlen(args[i]), args[i]) <= 0) {
                             SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid size specified for the rpc version:\"%s\"", args[i]);
                             goto error;
                         }
@@ -211,7 +211,7 @@ static DetectRpcData *DetectRpcParse (const char *rpcstr)
                     break;
                 case 2:
                     if (args[i][0] != '*') {
-                        if (ByteExtractStringUint32(&rd->procedure, 10, strlen(args[i]), args[i]) <= 0) {
+                        if (StringParseUint32(&rd->procedure, 10, strlen(args[i]), args[i]) <= 0) {
                             SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid size specified for the rpc procedure:\"%s\"", args[i]);
                             goto error;
                         }

--- a/src/detect-tag.c
+++ b/src/detect-tag.c
@@ -194,7 +194,7 @@ static DetectTagData *DetectTagParse(const char *tagstr)
         }
 
         /* count */
-        if (ByteExtractStringUint32(&td.count, 10, strlen(str_ptr),
+        if (StringParseUint32(&td.count, 10, strlen(str_ptr),
                     str_ptr) <= 0) {
             SCLogError(SC_ERR_INVALID_VALUE, "Invalid argument for count. Must be a value in the range of 0 to %"PRIu32" (%s)", UINT32_MAX, tagstr);
             goto error;

--- a/src/detect-tcp-ack.c
+++ b/src/detect-tcp-ack.c
@@ -119,7 +119,7 @@ static int DetectAckSetup(DetectEngineCtx *de_ctx, Signature *s, const char *opt
 
     sm->type = DETECT_ACK;
 
-    if (-1 == ByteExtractStringUint32(&data->ack, 10, 0, optstr)) {
+    if (StringParseUint32(&data->ack, 10, 0, optstr) < 0) {
         goto error;
     }
     sm->ctx = (SigMatchCtx*)data;

--- a/src/detect-tcp-seq.c
+++ b/src/detect-tcp-seq.c
@@ -114,7 +114,7 @@ static int DetectSeqSetup (DetectEngineCtx *de_ctx, Signature *s, const char *op
 
     sm->type = DETECT_SEQ;
 
-    if (-1 == ByteExtractStringUint32(&data->seq, 10, 0, optstr)) {
+    if (StringParseUint32(&data->seq, 10, 0, optstr) < 0) {
         goto error;
     }
     sm->ctx = (SigMatchCtx*)data;

--- a/src/detect-tcp-window.c
+++ b/src/detect-tcp-window.c
@@ -145,7 +145,7 @@ static DetectWindowData *DetectWindowParse(const char *windowstr)
 
             /* Get the window size if it's a valid value (in packets, we
              * should alert if this doesn't happend from decode) */
-            if (-1 == ByteExtractStringUint16(&wd->size, 10, 0, copy_str)) {
+            if (StringParseUint16(&wd->size, 10, 0, copy_str) < 0) {
                 goto error;
             }
         }

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -184,12 +184,12 @@ static DetectThresholdData *DetectThresholdParse(const char *rawstr)
         goto error;
     }
 
-    if (ByteExtractStringUint32(&de->count, 10, strlen(args[count_pos]),
+    if (StringParseUint32(&de->count, 10, strlen(args[count_pos]),
                 args[count_pos]) <= 0) {
         goto error;
     }
 
-    if (ByteExtractStringUint32(&de->seconds, 10, strlen(args[second_pos]),
+    if (StringParseUint32(&de->seconds, 10, strlen(args[second_pos]),
                 args[second_pos]) <= 0) {
         goto error;
     }

--- a/src/detect-tos.c
+++ b/src/detect-tos.c
@@ -130,13 +130,11 @@ static DetectTosData *DetectTosParse(const char *arg, bool negate)
     int64_t tos = 0;
 
     if (tosbytes_str[0] == 'x' || tosbytes_str[0] == 'X') {
-        int r = ByteExtractStringInt64(&tos, 16, 0, &tosbytes_str[1]);
-        if (r < 0) {
+        if (StringParseInt64(&tos, 16, 0, &tosbytes_str[1]) < 0) {
             goto error;
         }
     } else {
-        int r = ByteExtractStringInt64(&tos, 10, 0, &tosbytes_str[0]);
-        if (r < 0) {
+        if (StringParseInt64(&tos, 10, 0, &tosbytes_str[0]) < 0) {
             goto error;
         }
     }

--- a/src/detect-tos.c
+++ b/src/detect-tos.c
@@ -130,12 +130,12 @@ static DetectTosData *DetectTosParse(const char *arg, bool negate)
     int64_t tos = 0;
 
     if (tosbytes_str[0] == 'x' || tosbytes_str[0] == 'X') {
-        int r = ByteExtractStringSigned(&tos, 16, 0, &tosbytes_str[1]);
+        int r = ByteExtractStringInt64(&tos, 16, 0, &tosbytes_str[1]);
         if (r < 0) {
             goto error;
         }
     } else {
-        int r = ByteExtractStringSigned(&tos, 10, 0, &tosbytes_str[0]);
+        int r = ByteExtractStringInt64(&tos, 10, 0, &tosbytes_str[0]);
         if (r < 0) {
             goto error;
         }

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -173,7 +173,7 @@ static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
     }
 
     /** set the first urilen value */
-    if (ByteExtractStringUint16(&urilend->urilen1,10,strlen(arg2),arg2) <= 0){
+    if (StringParseUint16(&urilend->urilen1,10,strlen(arg2),arg2) <= 0){
         SCLogError(SC_ERR_INVALID_ARGUMENT,"Invalid size :\"%s\"",arg2);
         goto error;
     }
@@ -186,7 +186,7 @@ static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
             goto error;
         }
 
-        if(ByteExtractStringUint16(&urilend->urilen2,10,strlen(arg4),arg4) <= 0)
+        if(StringParseUint16(&urilend->urilen2,10,strlen(arg4),arg4) <= 0)
         {
             SCLogError(SC_ERR_INVALID_ARGUMENT,"Invalid size :\"%s\"",arg4);
             goto error;

--- a/src/detect-within.c
+++ b/src/detect-within.c
@@ -113,7 +113,7 @@ static int DetectWithinSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
         cd->within = ((DetectByteExtractData *)bed_sm->ctx)->local_id;
         cd->flags |= DETECT_CONTENT_WITHIN_BE;
     } else {
-        if (ByteExtractStringInt32(&cd->within, 0, 0, str) != (int)strlen(str)) {
+        if (StringParseInt32(&cd->within, 0, 0, str) < 0) {
             SCLogError(SC_ERR_INVALID_SIGNATURE,
                       "invalid value for within: %s", str);
             goto end;

--- a/src/flow.c
+++ b/src/flow.c
@@ -588,7 +588,7 @@ void FlowInitConfig(char quiet)
 	    exit(EXIT_FAILURE);
         }
 
-        if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
+        if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             flow_config.hash_size = configval;
         }
@@ -600,7 +600,7 @@ void FlowInitConfig(char quiet)
 	    exit(EXIT_FAILURE);
         }
 
-        if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
+        if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             flow_config.prealloc = configval;
         }
@@ -805,51 +805,51 @@ void FlowInitFlowProto(void)
                 "emergency-bypassed");
 
             if (new != NULL &&
-                ByteExtractStringUint32(&configval, 10, strlen(new), new) > 0) {
+                StringParseUint32(&configval, 10, strlen(new), new) > 0) {
 
                     flow_timeouts_normal[FLOW_PROTO_DEFAULT].new_timeout = configval;
             }
             if (established != NULL &&
-                ByteExtractStringUint32(&configval, 10, strlen(established),
+                StringParseUint32(&configval, 10, strlen(established),
                                         established) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_DEFAULT].est_timeout = configval;
             }
             if (closed != NULL &&
-                ByteExtractStringUint32(&configval, 10, strlen(closed),
+                StringParseUint32(&configval, 10, strlen(closed),
                                         closed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_DEFAULT].closed_timeout = configval;
             }
             if (bypassed != NULL &&
-                    ByteExtractStringUint32(&configval, 10,
+                    StringParseUint32(&configval, 10,
                                             strlen(bypassed),
                                             bypassed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_DEFAULT].bypassed_timeout = configval;
             }
             if (emergency_new != NULL &&
-                ByteExtractStringUint32(&configval, 10, strlen(emergency_new),
+                StringParseUint32(&configval, 10, strlen(emergency_new),
                                         emergency_new) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_DEFAULT].new_timeout = configval;
             }
             if (emergency_established != NULL &&
-                    ByteExtractStringUint32(&configval, 10,
+                    StringParseUint32(&configval, 10,
                                             strlen(emergency_established),
                                             emergency_established) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_DEFAULT].est_timeout= configval;
             }
             if (emergency_closed != NULL &&
-                    ByteExtractStringUint32(&configval, 10,
+                    StringParseUint32(&configval, 10,
                                             strlen(emergency_closed),
                                             emergency_closed) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_DEFAULT].closed_timeout = configval;
             }
             if (emergency_bypassed != NULL &&
-                    ByteExtractStringUint32(&configval, 10,
+                    StringParseUint32(&configval, 10,
                                             strlen(emergency_bypassed),
                                             emergency_bypassed) > 0) {
 
@@ -873,51 +873,51 @@ void FlowInitFlowProto(void)
                 "emergency-bypassed");
 
             if (new != NULL &&
-                ByteExtractStringUint32(&configval, 10, strlen(new), new) > 0) {
+                StringParseUint32(&configval, 10, strlen(new), new) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_TCP].new_timeout = configval;
             }
             if (established != NULL &&
-                ByteExtractStringUint32(&configval, 10, strlen(established),
+                StringParseUint32(&configval, 10, strlen(established),
                                         established) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_TCP].est_timeout = configval;
             }
             if (closed != NULL &&
-                ByteExtractStringUint32(&configval, 10, strlen(closed),
+                StringParseUint32(&configval, 10, strlen(closed),
                                         closed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_TCP].closed_timeout = configval;
             }
             if (bypassed != NULL &&
-                    ByteExtractStringUint32(&configval, 10,
+                    StringParseUint32(&configval, 10,
                                             strlen(bypassed),
                                             bypassed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_TCP].bypassed_timeout = configval;
             }
             if (emergency_new != NULL &&
-                ByteExtractStringUint32(&configval, 10, strlen(emergency_new),
+                StringParseUint32(&configval, 10, strlen(emergency_new),
                                         emergency_new) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_TCP].new_timeout = configval;
             }
             if (emergency_established != NULL &&
-                ByteExtractStringUint32(&configval, 10,
+                StringParseUint32(&configval, 10,
                                         strlen(emergency_established),
                                         emergency_established) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_TCP].est_timeout = configval;
             }
             if (emergency_closed != NULL &&
-                ByteExtractStringUint32(&configval, 10,
+                StringParseUint32(&configval, 10,
                                         strlen(emergency_closed),
                                         emergency_closed) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_TCP].closed_timeout = configval;
             }
             if (emergency_bypassed != NULL &&
-                    ByteExtractStringUint32(&configval, 10,
+                    StringParseUint32(&configval, 10,
                                             strlen(emergency_bypassed),
                                             emergency_bypassed) > 0) {
 
@@ -938,38 +938,38 @@ void FlowInitFlowProto(void)
                 "emergency-bypassed");
 
             if (new != NULL &&
-                ByteExtractStringUint32(&configval, 10, strlen(new), new) > 0) {
+                StringParseUint32(&configval, 10, strlen(new), new) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_UDP].new_timeout = configval;
             }
             if (established != NULL &&
-                ByteExtractStringUint32(&configval, 10, strlen(established),
+                StringParseUint32(&configval, 10, strlen(established),
                                         established) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_UDP].est_timeout = configval;
             }
             if (bypassed != NULL &&
-                    ByteExtractStringUint32(&configval, 10,
+                    StringParseUint32(&configval, 10,
                                             strlen(bypassed),
                                             bypassed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_UDP].bypassed_timeout = configval;
             }
             if (emergency_new != NULL &&
-                ByteExtractStringUint32(&configval, 10, strlen(emergency_new),
+                StringParseUint32(&configval, 10, strlen(emergency_new),
                                         emergency_new) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_UDP].new_timeout = configval;
             }
             if (emergency_established != NULL &&
-                ByteExtractStringUint32(&configval, 10,
+                StringParseUint32(&configval, 10,
                                         strlen(emergency_established),
                                         emergency_established) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_UDP].est_timeout = configval;
             }
             if (emergency_bypassed != NULL &&
-                    ByteExtractStringUint32(&configval, 10,
+                    StringParseUint32(&configval, 10,
                                             strlen(emergency_bypassed),
                                             emergency_bypassed) > 0) {
 
@@ -990,38 +990,38 @@ void FlowInitFlowProto(void)
                 "emergency-bypassed");
 
             if (new != NULL &&
-                ByteExtractStringUint32(&configval, 10, strlen(new), new) > 0) {
+                StringParseUint32(&configval, 10, strlen(new), new) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_ICMP].new_timeout = configval;
             }
             if (established != NULL &&
-                ByteExtractStringUint32(&configval, 10, strlen(established),
+                StringParseUint32(&configval, 10, strlen(established),
                                         established) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_ICMP].est_timeout = configval;
             }
             if (bypassed != NULL &&
-                    ByteExtractStringUint32(&configval, 10,
+                    StringParseUint32(&configval, 10,
                                             strlen(bypassed),
                                             bypassed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_ICMP].bypassed_timeout = configval;
             }
             if (emergency_new != NULL &&
-                ByteExtractStringUint32(&configval, 10, strlen(emergency_new),
+                StringParseUint32(&configval, 10, strlen(emergency_new),
                                         emergency_new) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_ICMP].new_timeout = configval;
             }
             if (emergency_established != NULL &&
-                ByteExtractStringUint32(&configval, 10,
+                StringParseUint32(&configval, 10,
                                         strlen(emergency_established),
                                         emergency_established) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_ICMP].est_timeout = configval;
             }
             if (emergency_bypassed != NULL &&
-                    ByteExtractStringUint32(&configval, 10,
+                    StringParseUint32(&configval, 10,
                                             strlen(emergency_bypassed),
                                             emergency_bypassed) > 0) {
 

--- a/src/host.c
+++ b/src/host.c
@@ -211,7 +211,7 @@ void HostInitConfig(char quiet)
     }
     if ((ConfGetValue("host.hash-size", &conf_val)) == 1)
     {
-        if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
+        if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             host_config.hash_size = configval;
         }
@@ -219,7 +219,7 @@ void HostInitConfig(char quiet)
 
     if ((ConfGetValue("host.prealloc", &conf_val)) == 1)
     {
-        if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
+        if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             host_config.prealloc = configval;
         } else {

--- a/src/ippair.c
+++ b/src/ippair.c
@@ -206,7 +206,7 @@ void IPPairInitConfig(char quiet)
     }
     if ((ConfGet("ippair.hash-size", &conf_val)) == 1)
     {
-        if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
+        if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             ippair_config.hash_size = configval;
         }
@@ -214,7 +214,7 @@ void IPPairInitConfig(char quiet)
 
     if ((ConfGet("ippair.prealloc", &conf_val)) == 1)
     {
-        if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
+        if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             ippair_config.prealloc = configval;
         } else {

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -734,7 +734,7 @@ static int PcapLogGetTimeOfFile(const char *filename, uint64_t *secs,
                 1, buf, sizeof(buf)) < 0) {
             return 0;
         }
-        if (ByteExtractStringUint64(secs, 10, 0, buf) < 0) {
+        if (StringParseUint64(secs, 10, 0, buf) < 0) {
             return 0;
         }
     }
@@ -744,7 +744,7 @@ static int PcapLogGetTimeOfFile(const char *filename, uint64_t *secs,
                 3, buf, sizeof(buf)) < 0) {
             return 0;
         }
-        if (ByteExtractStringUint32(usecs, 10, 0, buf) < 0) {
+        if (StringParseUint32(usecs, 10, 0, buf) < 0) {
             return 0;
         }
     }
@@ -1430,7 +1430,7 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
         const char *max_number_of_files_s = NULL;
         max_number_of_files_s = ConfNodeLookupChildValue(conf, "max-files");
         if (max_number_of_files_s != NULL) {
-            if (ByteExtractStringUint32(&max_file_limit, 10, 0,
+            if (StringParseUint32(&max_file_limit, 10, 0,
                                         max_number_of_files_s) == -1) {
                 SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to initialize "
                            "pcap-log output, invalid number of files limit: %s",

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1006,7 +1006,7 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
 
         const char *sensor_id_s = ConfNodeLookupChildValue(conf, "sensor-id");
         if (sensor_id_s != NULL) {
-            if (ByteExtractStringUint64((uint64_t *)&sensor_id, 10, 0, sensor_id_s) == -1) {
+            if (StringParseUint64((uint64_t *)&sensor_id, 10, 0, sensor_id_s) < 0) {
                 SCLogError(SC_ERR_INVALID_ARGUMENT,
                            "Failed to initialize JSON output, "
                            "invalid sensor-id: %s", sensor_id_s);
@@ -1033,8 +1033,8 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
         }
         const char *cid_seed = ConfNodeLookupChildValue(conf, "community-id-seed");
         if (cid_seed != NULL) {
-            if (ByteExtractStringUint16(&json_ctx->cfg.community_id_seed,
-                        10, 0, cid_seed) == -1)
+            if (StringParseUint16(&json_ctx->cfg.community_id_seed,
+                        10, 0, cid_seed) < 0)
             {
                 SCLogError(SC_ERR_INVALID_ARGUMENT,
                            "Failed to initialize JSON output, "

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -710,7 +710,7 @@ int IPFWRegisterQueue(char *queue)
     IPFWQueueVars *nq = NULL;
     /* Extract the queue number from the specified command line argument */
     uint16_t port_num = 0;
-    if ((ByteExtractStringUint16(&port_num, 10, strlen(queue), queue)) < 0)
+    if ((StringParseUint16(&port_num, 10, strlen(queue), queue)) < 0)
     {
         SCLogError(SC_ERR_INVALID_ARGUMENT, "specified queue number %s is not "
                                         "valid", queue);

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -360,7 +360,7 @@ static int StreamTcpReassemblyConfig(char quiet)
     ConfNode *seg = ConfGetNode("stream.reassembly.segment-prealloc");
     if (seg) {
         uint32_t prealloc = 0;
-        if (ByteExtractStringUint32(&prealloc, 10, strlen(seg->val), seg->val) == -1)
+        if (StringParseUint32(&prealloc, 10, strlen(seg->val), seg->val) < 0)
         {
             SCLogError(SC_ERR_INVALID_ARGUMENT, "segment-prealloc of "
                     "%s is invalid", seg->val);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2463,7 +2463,7 @@ int PostConfLoadedSetup(SCInstance *suri)
     const char *custom_umask;
     if (ConfGet("umask", &custom_umask) == 1) {
         uint16_t mask;
-        if (ByteExtractStringUint16(&mask, 8, strlen(custom_umask),
+        if (StringParseUint16(&mask, 8, strlen(custom_umask),
                                     custom_umask) > 0) {
             umask((mode_t)mask);
         }

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -63,7 +63,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         alp_tctx = AppLayerParserThreadCtxAlloc();
         const char* forceLayerStr = getenv("FUZZ_APPLAYER");
         if (forceLayerStr) {
-            if (ByteExtractString(&forceLayer, 10, 0, forceLayerStr) < 0) {
+            if (ByteExtractStringUint64(&forceLayer, 10, 0, forceLayerStr) < 0) {
                 forceLayer = 0;
                 printf("Invalid numeric value for FUZZ_APPLAYER environment variable");
             }

--- a/src/util-byte.c
+++ b/src/util-byte.c
@@ -313,8 +313,8 @@ int StringParseUint32(uint32_t *res, int base, uint16_t len, const char *str)
     *res = (uint32_t)i64;
 
     if ((uint64_t)(*res) != i64) {
-        SCLogError("Numeric value out of range (%" PRIu64 " > %" PRIuMAX ")",
-                i64, (uintmax_t)UINT_MAX);
+        SCLogError(SC_ERR_NUMERIC_VALUE_ERANGE, "Numeric value out of range "
+                "(%" PRIu64 " > %" PRIuMAX ")", i64, (uintmax_t)UINT_MAX);
         return -1;
     }
 
@@ -333,8 +333,8 @@ int StringParseUint16(uint16_t *res, int base, uint16_t len, const char *str)
     *res = (uint16_t)i64;
 
     if ((uint64_t)(*res) != i64) {
-        SCLogError("Numeric value out of range (%" PRIu64 " > %" PRIuMAX ")",
-                i64, (uintmax_t)USHRT_MAX);
+        SCLogError(SC_ERR_NUMERIC_VALUE_ERANGE, "Numeric value out of range "
+                "(%" PRIu64 " > %" PRIuMAX ")", i64, (uintmax_t)USHRT_MAX);
         return -1;
     }
 
@@ -353,8 +353,8 @@ int StringParseUint8(uint8_t *res, int base, uint16_t len, const char *str)
     *res = (uint8_t)i64;
 
     if ((uint64_t)(*res) != i64) {
-        SCLogError("Numeric value out of range (%" PRIu64 " > %" PRIuMAX ")",
-                i64, (uintmax_t)UCHAR_MAX);
+        SCLogError(SC_ERR_NUMERIC_VALUE_ERANGE, "Numeric value out of range "
+                "(%" PRIu64 " > %" PRIuMAX ")", i64, (uintmax_t)UCHAR_MAX);
         return -1;
     }
 

--- a/src/util-byte.c
+++ b/src/util-byte.c
@@ -182,7 +182,7 @@ int ByteExtractUint16(uint16_t *res, int e, uint16_t len, const uint8_t *bytes)
     return ret;
 }
 
-int ByteExtractString(uint64_t *res, int base, uint16_t len, const char *str)
+int ByteExtractString(uint64_t *res, int base, uint16_t len, const char *str, bool strict)
 {
     const char *ptr = str;
     char *endptr = NULL;
@@ -223,29 +223,24 @@ int ByteExtractString(uint64_t *res, int base, uint16_t len, const char *str)
         SCLogDebug("invalid numeric value");
         return -1;
     }
-    /* This will interfere with some rules that do not know the length
-     * in advance and instead are just using the max.
-     */
-#if 0
-    else if (len && *endptr != '\0') {
-        fprintf(stderr, "ByteExtractString: Extra characters following numeric value\n");
+    else if (strict && len && *endptr != '\0') {
+        SCLogError(SC_ERR_INVALID_NUMERIC_VALUE, "Extra characters following numeric value");
         return -1;
     }
-#endif
 
     return (endptr - ptr);
 }
 
 int ByteExtractStringUint64(uint64_t *res, int base, uint16_t len, const char *str)
 {
-    return ByteExtractString(res, base, len, str);
+    return ByteExtractString(res, base, len, str, false);
 }
 
 int ByteExtractStringUint32(uint32_t *res, int base, uint16_t len, const char *str)
 {
     uint64_t i64;
 
-    int ret = ByteExtractString(&i64, base, len, str);
+    int ret = ByteExtractString(&i64, base, len, str, false);
     if (ret <= 0) {
         return ret;
     }
@@ -265,7 +260,7 @@ int ByteExtractStringUint16(uint16_t *res, int base, uint16_t len, const char *s
 {
     uint64_t i64;
 
-    int ret = ByteExtractString(&i64, base, len, str);
+    int ret = ByteExtractString(&i64, base, len, str, false);
     if (ret <= 0) {
         return ret;
     }
@@ -285,7 +280,7 @@ int ByteExtractStringUint8(uint8_t *res, int base, uint16_t len, const char *str
 {
     uint64_t i64;
 
-    int ret = ByteExtractString(&i64, base, len, str);
+    int ret = ByteExtractString(&i64, base, len, str, false);
     if (ret <= 0) {
         return ret;
     }
@@ -301,7 +296,71 @@ int ByteExtractStringUint8(uint8_t *res, int base, uint16_t len, const char *str
     return ret;
 }
 
-int ByteExtractStringSigned(int64_t *res, int base, uint16_t len, const char *str)
+int StringParseUint64(uint64_t *res, int base, uint16_t len, const char *str)
+{
+    return ByteExtractString(res, base, len, str, true);
+}
+
+int StringParseUint32(uint32_t *res, int base, uint16_t len, const char *str)
+{
+    uint64_t i64;
+
+    int ret = ByteExtractString(&i64, base, len, str, true);
+    if (ret <= 0) {
+        return ret;
+    }
+
+    *res = (uint32_t)i64;
+
+    if ((uint64_t)(*res) != i64) {
+        SCLogError("Numeric value out of range (%" PRIu64 " > %" PRIuMAX ")",
+                i64, (uintmax_t)UINT_MAX);
+        return -1;
+    }
+
+    return ret;
+}
+
+int StringParseUint16(uint16_t *res, int base, uint16_t len, const char *str)
+{
+    uint64_t i64;
+
+    int ret = ByteExtractString(&i64, base, len, str, true);
+    if (ret <= 0) {
+        return ret;
+    }
+
+    *res = (uint16_t)i64;
+
+    if ((uint64_t)(*res) != i64) {
+        SCLogError("Numeric value out of range (%" PRIu64 " > %" PRIuMAX ")",
+                i64, (uintmax_t)USHRT_MAX);
+        return -1;
+    }
+
+    return ret;
+}
+
+int StringParseUint8(uint8_t *res, int base, uint16_t len, const char *str)
+{
+    uint64_t i64;
+
+    int ret = ByteExtractString(&i64, base, len, str, true);
+    if (ret <= 0) {
+        return ret;
+    }
+
+    *res = (uint8_t)i64;
+
+    if ((uint64_t)(*res) != i64) {
+        SCLogError("Numeric value out of range (%" PRIu64 " > %" PRIuMAX ")",
+                i64, (uintmax_t)UCHAR_MAX);
+        return -1;
+    }
+
+    return ret;
+}
+int ByteExtractStringSigned(int64_t *res, int base, uint16_t len, const char *str, bool strict)
 {
     const char *ptr = str;
     char *endptr;
@@ -337,15 +396,10 @@ int ByteExtractStringSigned(int64_t *res, int base, uint16_t len, const char *st
         SCLogError(SC_ERR_INVALID_NUMERIC_VALUE, "Invalid numeric value");
         return -1;
     }
-    /* This will interfere with some rules that do not know the length
-     * in advance and instead are just using the max.
-     */
-#if 0
-    else if (len && *endptr != '\0') {
-        fprintf(stderr, "ByteExtractStringSigned: Extra characters following numeric value\n");
+    else if (strict && len && *endptr != '\0') {
+        SCLogError(SC_ERR_INVALID_NUMERIC_VALUE, "Extra characters following numeric value");
         return -1;
     }
-#endif
 
     //fprintf(stderr, "ByteExtractStringSigned: Extracted base %d: 0x%" PRIx64 "\n", base, *res);
 
@@ -354,7 +408,7 @@ int ByteExtractStringSigned(int64_t *res, int base, uint16_t len, const char *st
 
 int ByteExtractStringInt64(int64_t *res, int base, uint16_t len, const char *str)
 {
-    return ByteExtractStringSigned(res, base, len, str);
+    return ByteExtractStringSigned(res, base, len, str, false);
 }
 
 int ByteExtractStringInt32(int32_t *res, int base, uint16_t len, const char *str)
@@ -362,7 +416,7 @@ int ByteExtractStringInt32(int32_t *res, int base, uint16_t len, const char *str
     int64_t i64;
     int ret;
 
-    ret = ByteExtractStringSigned(&i64, base, len, str);
+    ret = ByteExtractStringSigned(&i64, base, len, str, false);
     if (ret <= 0) {
         return ret;
     }
@@ -383,7 +437,7 @@ int ByteExtractStringInt16(int16_t *res, int base, uint16_t len, const char *str
     int64_t i64;
     int ret;
 
-    ret = ByteExtractStringSigned(&i64, base, len, str);
+    ret = ByteExtractStringSigned(&i64, base, len, str, false);
     if (ret <= 0) {
         return ret;
     }
@@ -404,7 +458,7 @@ int ByteExtractStringInt8(int8_t *res, int base, uint16_t len, const char *str)
     int64_t i64;
     int ret;
 
-    ret = ByteExtractStringSigned(&i64, base, len, str);
+    ret = ByteExtractStringSigned(&i64, base, len, str, false);
     if (ret <= 0) {
         return ret;
     }
@@ -420,6 +474,73 @@ int ByteExtractStringInt8(int8_t *res, int base, uint16_t len, const char *str)
     return ret;
 }
 
+int StringParseInt64(int64_t *res, int base, uint16_t len, const char *str)
+{
+    return ByteExtractStringSigned(res, base, len, str, true);
+}
+
+int StringParseInt32(int32_t *res, int base, uint16_t len, const char *str)
+{
+    int64_t i64;
+    int ret;
+
+    ret = ByteExtractStringSigned(&i64, base, len, str, true);
+    if (ret <= 0) {
+        return ret;
+    }
+
+    *res = (int32_t)i64;
+
+    if ((int64_t)(*res) != i64) {
+        SCLogError(SC_ERR_NUMERIC_VALUE_ERANGE, "Numeric value out of range "
+                   "(%" PRIi64 " > %" PRIiMAX ")\n", i64, (intmax_t)INT_MAX);
+        return -1;
+    }
+
+    return ret;
+}
+
+int StringParseInt16(int16_t *res, int base, uint16_t len, const char *str)
+{
+    int64_t i64;
+    int ret;
+
+    ret = ByteExtractStringSigned(&i64, base, len, str, true);
+    if (ret <= 0) {
+        return ret;
+    }
+
+    *res = (int16_t)i64;
+
+    if ((int64_t)(*res) != i64) {
+        SCLogError(SC_ERR_NUMERIC_VALUE_ERANGE, "Numeric value out of range "
+                   "(%" PRIi64 " > %" PRIiMAX ")\n", i64, (intmax_t)SHRT_MAX);
+        return -1;
+    }
+
+    return ret;
+}
+
+int StringParseInt8(int8_t *res, int base, uint16_t len, const char *str)
+{
+    int64_t i64;
+    int ret;
+
+    ret = ByteExtractStringSigned(&i64, base, len, str, true);
+    if (ret <= 0) {
+        return ret;
+    }
+
+    *res = (int8_t)i64;
+
+    if ((int64_t)(*res) != i64) {
+        SCLogError(SC_ERR_NUMERIC_VALUE_ERANGE, "Numeric value out of range "
+                   "(%" PRIi64 " > %" PRIiMAX ")\n", i64, (intmax_t)CHAR_MAX);
+        return -1;
+    }
+
+    return ret;
+}
 /* UNITTESTS */
 #ifdef UNITTESTS
 

--- a/src/util-byte.h
+++ b/src/util-byte.h
@@ -129,11 +129,12 @@ int ByteExtractUint16(uint16_t *res, int e, uint16_t len, const uint8_t *bytes);
  * \param base Base of the number to extract
  * \param len Number of bytes to extract (23 max or 0 for unbounded)
  * \param str String to extract from
+ * \param bool Enable strict check for parsers
  *
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractString(uint64_t *res, int base, uint16_t len, const char *str);
+int ByteExtractString(uint64_t *res, int base, uint16_t len, const char *str, bool strict);
 
 /**
  * Extract unsigned integer value from a string as uint64_t.
@@ -195,11 +196,12 @@ int ByteExtractStringUint8(uint8_t *res, int base, uint16_t len, const char *str
  * \param base Base of the number to extract
  * \param len Number of bytes to extract (23 max or 0 for unbounded)
  * \param str String to extract from
+ * \param bool Enable strict check for parsers
  *
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringSigned(int64_t *res, int base, uint16_t len, const char *str);
+int ByteExtractStringSigned(int64_t *res, int base, uint16_t len, const char *str, bool strict);
 
 /**
  * Extract signed integer value from a string as uint64_t.
@@ -252,6 +254,111 @@ int ByteExtractStringInt16(int16_t *res, int base, uint16_t len, const char *str
  * \return -1 On error
  */
 int ByteExtractStringInt8(int8_t *res, int base, uint16_t len, const char *str);
+
+/**
+ * Extract unsigned integer value from a string as uint64_t strictly.
+ *
+ * \param res Stores result
+ * \param base Base of the number to extract
+ * \param len Number of bytes to extract (23 max or 0 for unbounded)
+ * \param len Number of bytes to extract (23 max)
+ * \param str String to extract from
+ *
+ * \return n Number of bytes extracted on success
+ * \return -1 On error
+ */
+int StringParseUint64(uint64_t *res, int base, uint16_t len, const char *str);
+
+/**
+ * Extract unsigned integer value from a string as uint32_t strictly.
+ *
+ * \param res Stores result
+ * \param base Base of the number to extract
+ * \param len Number of bytes to extract (23 max or 0 for unbounded)
+ * \param str String to extract from
+ *
+ * \return n Number of bytes extracted on success
+ * \return -1 On error
+ */
+int StringParseUint32(uint32_t *res, int base, uint16_t len, const char *str);
+
+/**
+ * Extract unsigned integer value from a string as uint16_t strictly.
+ *
+ * \param res Stores result
+ * \param base Base of the number to extract
+ * \param len Number of bytes to extract (23 max or 0 for unbounded)
+ * \param str String to extract from
+ *
+ * \return n Number of bytes extracted on success
+ * \return -1 On error
+ */
+int StringParseUint16(uint16_t *res, int base, uint16_t len, const char *str);
+
+/**
+ * Extract unsigned integer value from a string as uint8_t strictly.
+ *
+ * \param res Stores result
+ * \param base Base of the number to extract
+ * \param len Number of bytes to extract (23 max or 0 for unbounded)
+ * \param str String to extract from
+ *
+ * \return n Number of bytes extracted on success
+ * \return -1 On error
+ */
+int StringParseUint8(uint8_t *res, int base, uint16_t len, const char *str);
+
+/**
+ * Extract signed integer value from a string as int64_t strictly.
+ *
+ * \param res Stores result
+ * \param base Base of the number to extract
+ * \param len Number of bytes to extract (23 max or 0 for unbounded)
+ * \param str String to extract from
+ *
+ * \return n Number of bytes extracted on success
+ * \return -1 On error
+ */
+int StringParseInt64(int64_t *res, int base, uint16_t len, const char *str);
+
+/**
+ * Extract signed integer value from a string as int32_t strictly.
+ *
+ * \param res Stores result
+ * \param base Base of the number to extract
+ * \param len Number of bytes to extract (23 max or 0 for unbounded)
+ * \param str String to extract from
+ *
+ * \return n Number of bytes extracted on success
+ * \return -1 On error
+ */
+int StringParseInt32(int32_t *res, int base, uint16_t len, const char *str);
+
+/**
+ * Extract signed integer value from a string as int16_t strictly.
+ *
+ * \param res Stores result
+ * \param base Base of the number to extract
+ * \param len Number of bytes to extract (23 max or 0 for unbounded)
+ * \param str String to extract from
+ *
+ * \return n Number of bytes extracted on success
+ * \return -1 On error
+ */
+int StringParseInt16(int16_t *res, int base, uint16_t len, const char *str);
+
+/**
+ * Extract signed integer value from a string as int8_t strictly.
+ *
+ * \param res Stores result
+ * \param base Base of the number to extract
+ * \param len Number of bytes to extract (23 max or 0 for unbounded)
+ * \param str String to extract from
+ *
+ * \return n Number of bytes extracted on success
+ * \return -1 On error
+ */
+int StringParseInt8(int8_t *res, int base, uint16_t len, const char *str);
 
 #ifdef UNITTESTS
 void ByteRegisterTests(void);

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -376,7 +376,7 @@ SCConfLogOpenGeneric(ConfNode *conf,
     const char *filemode = ConfNodeLookupChildValue(conf, "filemode");
     uint32_t mode = 0;
     if (filemode != NULL &&
-            ByteExtractStringUint32(&mode, 8, strlen(filemode),
+            StringParseUint32(&mode, 8, strlen(filemode),
                                     filemode) > 0) {
         log_ctx->filemode = mode;
     }

--- a/src/util-profiling-rules.c
+++ b/src/util-profiling-rules.c
@@ -158,7 +158,7 @@ void SCProfilingRulesGlobalInit(void)
 
             val = ConfNodeLookupChildValue(conf, "limit");
             if (val != NULL) {
-                if (ByteExtractStringUint32(&profiling_rules_limit, 10,
+                if (StringParseUint32(&profiling_rules_limit, 10,
                             (uint16_t)strlen(val), val) <= 0) {
                     SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid limit: %s", val);
                     exit(EXIT_FAILURE);

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -230,7 +230,7 @@ static void THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
     GET_VAR(cnf_prefix, "hash-size");
     if ((ConfGet(varname, &conf_val)) == 1)
     {
-        if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
+        if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             ctx->config.hash_size = configval;
         }
@@ -239,7 +239,7 @@ static void THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
     GET_VAR(cnf_prefix, "prealloc");
     if ((ConfGet(varname, &conf_val)) == 1)
     {
-        if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
+        if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             ctx->config.prealloc = configval;
         } else {

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -875,7 +875,7 @@ static int ParseThresholdRule(DetectEngineCtx *de_ctx, char *rawstr,
 
                 /* TODO: implement option "apply_to" */
 
-                if (ByteExtractStringUint32(&parsed_timeout, 10, strlen(th_timeout), th_timeout) <= 0) {
+                if (StringParseUint32(&parsed_timeout, 10, strlen(th_timeout), th_timeout) <= 0) {
                     goto error;
                 }
 
@@ -923,7 +923,7 @@ static int ParseThresholdRule(DetectEngineCtx *de_ctx, char *rawstr,
                 goto error;
             }
 
-            if (ByteExtractStringUint32(&parsed_count, 10, strlen(th_count), th_count) <= 0) {
+            if (StringParseUint32(&parsed_count, 10, strlen(th_count), th_count) <= 0) {
                 goto error;
             }
             if (parsed_count == 0) {
@@ -931,7 +931,7 @@ static int ParseThresholdRule(DetectEngineCtx *de_ctx, char *rawstr,
                 goto error;
             }
 
-            if (ByteExtractStringUint32(&parsed_seconds, 10, strlen(th_seconds), th_seconds) <= 0) {
+            if (StringParseUint32(&parsed_seconds, 10, strlen(th_seconds), th_seconds) <= 0) {
                 goto error;
             }
 
@@ -954,11 +954,11 @@ static int ParseThresholdRule(DetectEngineCtx *de_ctx, char *rawstr,
             break;
     }
 
-    if (ByteExtractStringUint32(&id, 10, strlen(th_sid), th_sid) <= 0) {
+    if (StringParseUint32(&id, 10, strlen(th_sid), th_sid) <= 0) {
         goto error;
     }
 
-    if (ByteExtractStringUint32(&gid, 10, strlen(th_gid), th_gid) <= 0) {
+    if (StringParseUint32(&gid, 10, strlen(th_gid), th_gid) <= 0) {
         goto error;
     }
 


### PR DESCRIPTION
Add a new set of StringParse* functions and use them for strict parsing in all parser, configuration and setup functions.
Related to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3053