### PR TITLE
Byteextractstr/part3/v1

### DIFF
--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -239,7 +239,12 @@ static inline DetectByteExtractData *DetectByteExtractParse(const char *arg)
                    "for arg 1 for byte_extract");
         goto error;
     }
-    bed->nbytes = atoi(nbytes_str);
+    if (StringParseUint8(&bed->nbytes, 10, 0,
+                               (const char *)nbytes_str) < 0) {
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid value for number of bytes"
+                   " to be extracted: \"%s\".", nbytes_str);
+        goto error;
+    }
 
     /* offset */
     char offset_str[64] = "";
@@ -250,7 +255,11 @@ static inline DetectByteExtractData *DetectByteExtractParse(const char *arg)
                    "for arg 2 for byte_extract");
         goto error;
     }
-    int offset = atoi(offset_str);
+    int offset;
+    if (StringParseInt32(&offset, 10, 0, (const char *)offset_str) < 0) {
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid value for offset: \"%s\".", offset_str);
+        goto error;
+    }
     if (offset < -65535 || offset > 65535) {
         SCLogError(SC_ERR_INVALID_SIGNATURE, "byte_extract offset invalid - %d.  "
                    "The right offset range is -65535 to 65535", offset);
@@ -306,7 +315,13 @@ static inline DetectByteExtractData *DetectByteExtractParse(const char *arg)
                            "for arg %d for byte_extract", i);
                 goto error;
             }
-            int multiplier = atoi(multiplier_str);
+            int32_t multiplier;
+            if (StringParseInt32(&multiplier, 10, 0,
+                                 (const char *)multiplier_str) < 0) {
+                SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid value for"
+                        "multiplier: \"%s\".", multiplier_str);
+                goto error;
+            }
             if (multiplier < DETECT_BYTE_EXTRACT_MULTIPLIER_MIN_LIMIT ||
                 multiplier > DETECT_BYTE_EXTRACT_MULTIPLIER_MAX_LIMIT) {
                 SCLogError(SC_ERR_INVALID_SIGNATURE, "multipiler_value invalid "
@@ -410,7 +425,12 @@ static inline DetectByteExtractData *DetectByteExtractParse(const char *arg)
                            "for arg %d in byte_extract", i);
                 goto error;
             }
-            bed->align_value = atoi(align_str);
+            if (StringParseUint8(&bed->align_value, 10, 0,
+                                       (const char *)align_str) < 0) {
+                SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid align_value: "
+                           "\"%s\".", align_str);
+                goto error;
+            }
             if (!(bed->align_value == 2 || bed->align_value == 4)) {
                 SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid align_value for "
                            "byte_extract - \"%d\"", bed->align_value);

--- a/src/detect-cipservice.c
+++ b/src/detect-cipservice.c
@@ -346,14 +346,14 @@ static DetectEnipCommandData *DetectEnipCommandParse(const char *rulestr)
         goto error;
     }
 
-    unsigned long cmd = atol(rulestr);
-    if (cmd > MAX_ENIP_CMD) //if command greater than 16 bit
-    {
-        SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid ENIP command %lu", cmd);
+    uint16_t cmd;
+    if (StringParseUint16(&cmd, 10, 0, rulestr) < 0) {
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid ENIP command"
+                   ": \"%s\"", rulestr);
         goto error;
     }
 
-    enipcmdd->enipcommand = (uint16_t) atoi(rulestr);
+    enipcmdd->enipcommand = cmd;
 
     return enipcmdd;
 

--- a/src/detect-dce-iface.c
+++ b/src/detect-dce-iface.c
@@ -166,8 +166,8 @@ static DetectDceIfaceData *DetectDceIfaceArgParse(const char *arg)
     if (ret == 3 || ret == 5)
         did->any_frag = 1;
 
-    /* if the regex has 4 or 5, version/operator is present in the signature */
-    if (ret == 4 || ret == 5) {
+    /* if the regex has 4 or 5, version/operator might be present in the signature */
+    if (ret == 4 || (ret == 5 && ov[4] != -1)) {
         /* first handle the version number, so that we can do some additional
          * validations of the version number, wrt. the operator */
         res = pcre_copy_substring(arg, ov, MAX_SUBSTRINGS, 3, copy_str, sizeof(copy_str));

--- a/src/detect-dce-iface.c
+++ b/src/detect-dce-iface.c
@@ -124,7 +124,7 @@ static DetectDceIfaceData *DetectDceIfaceArgParse(const char *arg)
     int i = 0, j = 0;
     int len = 0;
     char temp_str[3] = "";
-    int version;
+    uint16_t version;
 
     ret = DetectParsePcreExec(&parse_regex, arg, 0, 0, ov, MAX_SUBSTRINGS);
     if (ret < 2) {
@@ -175,11 +175,9 @@ static DetectDceIfaceData *DetectDceIfaceArgParse(const char *arg)
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
             goto error;
         }
-
-        version = atoi(copy_str);
-        if (version > UINT16_MAX) {
+        if (StringParseUint16(&version, 10, 0, (const char *)copy_str) < 0) {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "DCE_IFACE interface version "
-                       "invalid: %d\n", version);
+                       "invalid: %s\n", copy_str);
             goto error;
         }
         did->version = version;

--- a/src/detect-dce-opnum.c
+++ b/src/detect-dce-opnum.c
@@ -171,16 +171,25 @@ static DetectDceOpnumData *DetectDceOpnumArgParse(const char *arg)
         if ((hyphen_token = strchr(dup_str_temp, '-')) != NULL) {
             hyphen_token[0] = '\0';
             hyphen_token++;
-            dor->range1 = atoi(dup_str_temp);
+            if (StringParseUint32(&dor->range1, 10, 0,
+                                  (const char *)dup_str_temp) < 0) {
+                goto error;
+            }
             if (dor->range1 > DCE_OPNUM_RANGE_MAX)
                 goto error;
-            dor->range2 = atoi(hyphen_token);
+            if (StringParseUint32(&dor->range2, 10, 0,
+                                  (const char *)hyphen_token) < 0) {
+                goto error;
+            }
             if (dor->range2 > DCE_OPNUM_RANGE_MAX)
                 goto error;
             if (dor->range1 > dor->range2)
                 goto error;
         }
-        dor->range1 = atoi(dup_str_temp);
+        if (StringParseUint32(&dor->range1, 10, 0,
+                              (const char *)dup_str_temp) < 0) {
+            goto error;
+        }
         if (dor->range1 > DCE_OPNUM_RANGE_MAX)
             goto error;
 
@@ -199,16 +208,25 @@ static DetectDceOpnumData *DetectDceOpnumArgParse(const char *arg)
     if ( (hyphen_token = strchr(dup_str, '-')) != NULL) {
         hyphen_token[0] = '\0';
         hyphen_token++;
-        dor->range1 = atoi(dup_str);
+        if (StringParseUint32(&dor->range1, 10, 0,
+                              (const char *)dup_str) < 0) {
+            goto error;
+        }
         if (dor->range1 > DCE_OPNUM_RANGE_MAX)
             goto error;
-        dor->range2 = atoi(hyphen_token);
+        if (StringParseUint32(&dor->range2, 10, 0,
+                              (const char *)hyphen_token) < 0) {
+            goto error;
+        }
         if (dor->range2 > DCE_OPNUM_RANGE_MAX)
             goto error;
         if (dor->range1 > dor->range2)
             goto error;
     }
-    dor->range1 = atoi(dup_str);
+    if (StringParseUint32(&dor->range1, 10, 0,
+                          (const char *)dup_str) < 0) {
+        goto error;
+    }
     if (dor->range1 > DCE_OPNUM_RANGE_MAX)
         goto error;
 

--- a/src/detect-engine-port.c
+++ b/src/detect-engine-port.c
@@ -51,12 +51,13 @@
 #include "host.h"
 #include "util-profiling.h"
 #include "util-var.h"
+#include "util-byte.h"
 
 static int DetectPortCutNot(DetectPort *, DetectPort **);
 static int DetectPortCut(DetectEngineCtx *, DetectPort *, DetectPort *,
                          DetectPort **);
 DetectPort *PortParse(const char *str);
-int DetectPortIsValidRange(char *);
+static int DetectPortIsValidRange(char *);
 
 /**
  * \brief Alloc a DetectPort structure and update counters
@@ -1286,21 +1287,25 @@ DetectPort *PortParse(const char *str)
     }
 
     /* see if the address is an ipv4 or ipv6 address */
-    if ((port2 = strchr(port, ':')) != NULL)  {
+    if ((port2 = strchr(port, ':')) != NULL) {
         /* 80:81 range format */
         port2[0] = '\0';
         port2++;
 
-        if (DetectPortIsValidRange(port))
-            dp->port = atoi(port);
-        else
-            goto error;
+        if (strcmp(port, "") != 0) {
+            int res = DetectPortIsValidRange(port);
+            if (res == -1)
+                goto error;
+            dp->port = res;
+        } else {
+            dp->port = 0;
+        }
 
         if (strcmp(port2, "") != 0) {
-            if (DetectPortIsValidRange(port2))
-                dp->port2 = atoi(port2);
-            else
+            int res = DetectPortIsValidRange(port2);
+            if (res == -1)
                 goto error;
+            dp->port2 = res;
         } else {
             dp->port2 = 65535;
         }
@@ -1312,10 +1317,11 @@ DetectPort *PortParse(const char *str)
         if (strcasecmp(port,"any") == 0) {
             dp->port = 0;
             dp->port2 = 65535;
-        } else if(DetectPortIsValidRange(port)){
-            dp->port = dp->port2 = atoi(port);
         } else {
-            goto error;
+            int res = DetectPortIsValidRange(port);
+            if (res == -1)
+                goto error;
+            dp->port = dp->port2 = res;
         }
     }
 
@@ -1336,15 +1342,12 @@ error:
  * \retval 1 if port is in the valid range
  * \retval 0 if invalid
  */
-int DetectPortIsValidRange(char *port)
+static int DetectPortIsValidRange(char *port)
 {
-    char *end;
-    long r = strtol(port, &end, 10);
-
-    if(*end == 0 && r >= 0 && r <= 65535)
-        return 1;
-    else
-        return 0;
+    uint16_t val;
+    if (StringParseUint16(&val, 10, 0, (const char *)port) < 0)
+        return -1;
+    return val;
 }
 
 /********************** End parsing routines ********************/

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2226,15 +2226,14 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
             }
             if (max_uniq_toclient_groups_str != NULL) {
                 if (StringParseUint16(&de_ctx->max_uniq_toclient_groups, 10,
-                    strlen(max_uniq_toclient_groups_str),
-                    (const char *)max_uniq_toclient_groups_str) <= 0)
+                                      strlen(max_uniq_toclient_groups_str),
+                    (                 const char *)max_uniq_toclient_groups_str) <= 0)
                 {
                     de_ctx->max_uniq_toclient_groups = 20;
-
                     SCLogWarning(SC_ERR_SIZE_PARSE, "parsing '%s' for "
-                            "toclient-groups failed, using %u",
-                            max_uniq_toclient_groups_str,
-                            de_ctx->max_uniq_toclient_groups);
+                                 "toclient-groups failed, using %u",
+                                 max_uniq_toclient_groups_str,
+                                 de_ctx->max_uniq_toclient_groups);
                 }
             } else {
                 de_ctx->max_uniq_toclient_groups = 20;
@@ -2243,15 +2242,14 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
 
             if (max_uniq_toserver_groups_str != NULL) {
                 if (StringParseUint16(&de_ctx->max_uniq_toserver_groups, 10,
-                    strlen(max_uniq_toserver_groups_str),
-                    (const char *)max_uniq_toserver_groups_str) <= 0)
+                                      strlen(max_uniq_toserver_groups_str),
+                                      (const char *)max_uniq_toserver_groups_str) <= 0)
                 {
                     de_ctx->max_uniq_toserver_groups = 40;
-
                     SCLogWarning(SC_ERR_SIZE_PARSE, "parsing '%s' for "
-                            "toserver-groups failed, using %u",
-                            max_uniq_toserver_groups_str,
-                            de_ctx->max_uniq_toserver_groups);
+                                 "toserver-groups failed, using %u",
+                                 max_uniq_toserver_groups_str,
+                                 de_ctx->max_uniq_toserver_groups);
                 }
             } else {
                 de_ctx->max_uniq_toserver_groups = 40;
@@ -2299,7 +2297,16 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
             }
 
             if (insp_recursion_limit != NULL) {
-                de_ctx->inspection_recursion_limit = atoi(insp_recursion_limit);
+                if (StringParseInt32(&de_ctx->inspection_recursion_limit,
+                                     10, 0, (const char *)insp_recursion_limit) < 0) {
+                    SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
+                                 "detect-engine.inspection-recursion-limit: %s, "
+                                 "resetting to %d",
+                                 insp_recursion_limit,
+                                 DETECT_ENGINE_DEFAULT_INSPECTION_RECURSION_LIMIT);
+                    de_ctx->inspection_recursion_limit =
+                        DETECT_ENGINE_DEFAULT_INSPECTION_RECURSION_LIMIT;
+                }
             } else {
                 de_ctx->inspection_recursion_limit =
                     DETECT_ENGINE_DEFAULT_INSPECTION_RECURSION_LIMIT;
@@ -4254,7 +4261,7 @@ static int DetectEngineTest02(void)
     if (de_ctx == NULL)
         goto end;
 
-    result = (de_ctx->inspection_recursion_limit == -1);
+    result = (de_ctx->inspection_recursion_limit == DETECT_ENGINE_DEFAULT_INSPECTION_RECURSION_LIMIT);
 
  end:
     if (de_ctx != NULL)

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -33,6 +33,7 @@
 #include "detect-fast-pattern.h"
 
 #include "util-error.h"
+#include "util-byte.h"
 #include "util-debug.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
@@ -279,10 +280,11 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, const c
                        "for fast_pattern offset");
             goto error;
         }
-        int offset = atoi(arg_substr);
-        if (offset > 65535) {
-            SCLogError(SC_ERR_INVALID_SIGNATURE, "Fast pattern offset exceeds "
-                       "limit");
+        uint16_t offset;
+        if (StringParseUint16(&offset, 10, 0,
+                              (const char *)arg_substr) < 0) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid fast pattern offset:"
+                       " \"%s\"", arg_substr);
             goto error;
         }
 
@@ -293,10 +295,11 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, const c
                        "for fast_pattern offset");
             goto error;
         }
-        int length = atoi(arg_substr);
-        if (length > 65535) {
-            SCLogError(SC_ERR_INVALID_SIGNATURE, "Fast pattern length exceeds "
-                       "limit");
+        uint16_t length;
+        if (StringParseUint16(&length, 10, 0,
+                              (const char *)arg_substr) < 0) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid value for fast "
+                       "pattern: \"%s\"", arg_substr);
             goto error;
         }
 

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -478,7 +478,8 @@ static int DetectIPProtoTestParse02(void)
 static int DetectIPProtoTestSetup01(void)
 {
     const char *value_str = "14";
-    int value = atoi(value_str);
+    int value;
+    FAIL_IF(StringParseInt32(&value, 10, 0, (const char *)value_str) < 0);
     int i;
 
     Signature *sig = SigAlloc();

--- a/src/detect-iprep.c
+++ b/src/detect-iprep.c
@@ -41,6 +41,7 @@
 #include "detect-engine-state.h"
 
 #include "util-debug.h"
+#include "util-byte.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 #include "util-fmemopen.h"
@@ -321,8 +322,8 @@ int DetectIPRepSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
     }
 
     if (value != NULL && strlen(value) > 0) {
-        int ival = atoi(value);
-        if (ival < 0 || ival > 127)
+        int8_t ival;
+        if (StringParseInt8(&ival, 10, 0, (const char *)value) < 0)
             goto error;
         val = (uint8_t)ival;
     }

--- a/src/detect-krb5-errcode.c
+++ b/src/detect-krb5-errcode.c
@@ -23,6 +23,7 @@
 
 #include "suricata-common.h"
 #include "util-unittest.h"
+#include "util-byte.h"
 
 #include "detect-parse.h"
 #include "detect-engine.h"
@@ -156,8 +157,10 @@ static DetectKrb5ErrCodeData *DetectKrb5ErrCodeParse (const char *krb5str)
     krb5d = SCMalloc(sizeof (DetectKrb5ErrCodeData));
     if (unlikely(krb5d == NULL))
         goto error;
-    krb5d->err_code = (int32_t)atoi(arg1);
-
+    if (StringParseInt32(&krb5d->err_code, 10, 0,
+                         (const char *)arg1) < 0) {
+        goto error;
+    }
     return krb5d;
 
 error:

--- a/src/detect-krb5-msgtype.c
+++ b/src/detect-krb5-msgtype.c
@@ -23,6 +23,7 @@
 
 #include "suricata-common.h"
 #include "util-unittest.h"
+#include "util-byte.h"
 
 #include "detect-parse.h"
 #include "detect-engine.h"
@@ -153,8 +154,10 @@ static DetectKrb5MsgTypeData *DetectKrb5MsgTypeParse (const char *krb5str)
     krb5d = SCMalloc(sizeof (DetectKrb5MsgTypeData));
     if (unlikely(krb5d == NULL))
         goto error;
-    krb5d->msg_type = (uint8_t)atoi(arg1);
-
+    if (StringParseUint8(&krb5d->msg_type, 10, 0,
+                         (const char *)arg1) < 0) {
+        goto error;
+    }
     return krb5d;
 
 error:

--- a/src/detect-modbus.c
+++ b/src/detect-modbus.c
@@ -51,6 +51,7 @@
 #include "detect-engine-modbus.h"
 
 #include "util-debug.h"
+#include "util-byte.h"
 
 #include "app-layer-modbus.h"
 
@@ -190,13 +191,28 @@ static DetectModbus *DetectModbusAccessParse(const char *str)
                 goto error;
 
             if (arg[0] == '>') {
-                modbus->address->min    = atoi((const char*) (arg+1));
+                if (StringParseUint16(&modbus->address->min, 10, 0,
+                                      (const char*) (arg + 1)) < 0) {
+                    SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for min "
+                               "address: %s", (const char *)(arg + 1));
+                    goto error;
+                }
                 modbus->address->mode   = DETECT_MODBUS_GT;
             } else if (arg[0] == '<') {
-                modbus->address->min    = atoi((const char*) (arg+1));
+                if (StringParseUint16(&modbus->address->min, 10, 0,
+                                      (const char*) (arg + 1)) < 0) {
+                    SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for min "
+                               "address: %s", (const char*)(arg + 1));
+                    goto error;
+                }
                 modbus->address->mode   = DETECT_MODBUS_LT;
             } else {
-                modbus->address->min    = atoi((const char*) arg);
+                if (StringParseUint16(&modbus->address->min, 10, 0,
+                                      (const char*) arg) < 0) {
+                    SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for min "
+                               "address: %s", arg);
+                    goto error;
+                }
             }
             SCLogDebug("and min/equal address %d", modbus->address->min);
 
@@ -208,7 +224,12 @@ static DetectModbus *DetectModbusAccessParse(const char *str)
                 }
 
                 if (*arg != '\0') {
-                    modbus->address->max    = atoi((const char*) (arg+2));
+                    if (StringParseUint16(&modbus->address->max, 10, 0,
+                                         (const char*) (arg + 2)) < 0) {
+                        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for max "
+                                   "address: %s", (const char*)(arg + 2));
+                        goto error;
+                    }
                     modbus->address->mode   = DETECT_MODBUS_RA;
                     SCLogDebug("and max address %d", modbus->address->max);
                 }
@@ -235,13 +256,28 @@ static DetectModbus *DetectModbusAccessParse(const char *str)
                         goto error;
 
                     if (arg[0] == '>') {
-                        modbus->data->min   = atoi((const char*) (arg+1));
+                        if (StringParseUint16(&modbus->data->min, 10, 0,
+                                              (const char*) (arg + 1)) < 0) {
+                            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                                       "min data: %s", (const char*)(arg + 1));
+                            goto error;
+                        }
                         modbus->data->mode  = DETECT_MODBUS_GT;
                     } else if (arg[0] == '<') {
-                        modbus->data->min   = atoi((const char*) (arg+1));
+                        if (StringParseUint16(&modbus->data->min, 10, 0,
+                                              (const char*) (arg + 1)) < 0) {
+                            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value "
+                                       "for min data: %s", (const char*)(arg + 1));
+                            goto error;
+                        }
                         modbus->data->mode  = DETECT_MODBUS_LT;
                     } else {
-                        modbus->data->min   = atoi((const char*) arg);
+                        if (StringParseUint16(&modbus->data->min, 10, 0,
+                                              (const char*)arg) < 0) {
+                            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value "
+                                       "for min data: %s", (const char*)arg);
+                            goto error;
+                        }
                     }
                     SCLogDebug("and min/equal value %d", modbus->data->min);
 
@@ -253,7 +289,13 @@ static DetectModbus *DetectModbusAccessParse(const char *str)
                         }
 
                         if (*arg != '\0') {
-                            modbus->data->max   = atoi((const char*) (arg+2));
+                            if (StringParseUint16(&modbus->data->max,
+                                                  10, 0, (const char*) (arg + 2)) < 0) {
+                                SCLogError(SC_ERR_INVALID_VALUE,
+                                           "Invalid value for max data: %s",
+                                           (const char*)(arg + 2));
+                                goto error;
+                            }
                             modbus->data->mode  = DETECT_MODBUS_RA;
                             SCLogDebug("and max value %d", modbus->data->max);
                         }
@@ -305,7 +347,11 @@ static DetectModbus *DetectModbusFunctionParse(const char *str)
         goto error;
 
     if (isdigit((unsigned char)ptr[0])) {
-        modbus->function = atoi((const char*) ptr);
+        if (StringParseUint8(&modbus->function, 10, 0, (const char *)ptr) < 0) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                       "modbus function: %s", (const char *)ptr);
+            goto error;
+        }
         /* Function code 0 is managed by decoder_event INVALID_FUNCTION_CODE */
         if (modbus->function == MODBUS_FUNC_NONE) {
             SCLogError(SC_ERR_INVALID_SIGNATURE,
@@ -328,7 +374,12 @@ static DetectModbus *DetectModbusFunctionParse(const char *str)
             if (modbus->subfunction == NULL)
                 goto error;
 
-            *(modbus->subfunction) = atoi((const char*) arg);
+            if (StringParseUint16(&(*modbus->subfunction), 10, 0, (const char *)arg) < 0) {
+                SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                           "modbus subfunction: %s", (const char*)arg);
+                goto error;
+            }
+
             SCLogDebug("and subfunction %d", *(modbus->subfunction));
         }
     } else {
@@ -421,13 +472,25 @@ static DetectModbus *DetectModbusUnitIdParse(const char *str)
         goto error;
 
     if (arg[0] == '>') {
-        modbus->unit_id->min   = atoi((const char*) (arg+1));
+        if (StringParseUint16(&modbus->unit_id->min, 10, 0, (const char *) (arg + 1)) < 0) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                       "modbus min unit id: %s", (const char*)(arg + 1));
+            goto error;
+        }
         modbus->unit_id->mode  = DETECT_MODBUS_GT;
     } else if (arg[0] == '<') {
-        modbus->unit_id->min   = atoi((const char*) (arg+1));
+        if (StringParseUint16(&modbus->unit_id->min, 10, 0, (const char *) (arg + 1)) < 0) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                       "modbus min unit id: %s", (const char*)(arg + 1));
+            goto error;
+        }
         modbus->unit_id->mode  = DETECT_MODBUS_LT;
     } else {
-        modbus->unit_id->min   = atoi((const char*) arg);
+        if (StringParseUint16(&modbus->unit_id->min, 10, 0, (const char *)arg) < 0) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                       "modbus min unit id: %s", (const char*)arg);
+            goto error;
+        }
     }
     SCLogDebug("and min/equal unit id %d", modbus->unit_id->min);
 
@@ -439,7 +502,11 @@ static DetectModbus *DetectModbusUnitIdParse(const char *str)
         }
 
         if (*arg != '\0') {
-            modbus->unit_id->max   = atoi((const char*) (arg+2));
+            if (StringParseUint16(&modbus->unit_id->max, 10, 0, (const char *) (arg + 2)) < 0) {
+                SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                           "modbus max unit id: %s", (const char*)(arg + 2));
+                goto error;
+            }
             modbus->unit_id->mode  = DETECT_MODBUS_RA;
             SCLogDebug("and max unit id %d", modbus->unit_id->max);
         }


### PR DESCRIPTION
`StringParse` functions error out in case of trailing characters after the extracted int, `ByteExtractString` functions ignore that.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3053