### PR TITLE
rfb: make sure size calculations do not overflow

### DIFF
--- a/rust/src/rfb/rfb.rs
+++ b/rust/src/rfb/rfb.rs
@@ -100,6 +100,18 @@ pub struct RFBState {
     state: parser::RFBGlobalState
 }
 
+#[inline]
+fn handle_incomplete(input: &[u8], current: &[u8], nom_needed: usize) -> AppLayerResult {
+    if let Some(consumed) = input.len().checked_sub(current.len()) {
+        if let Some(needed) = current.len().checked_add(nom_needed) {
+            if consumed <= (std::u32::MAX as usize) && needed <= (std::u32::MAX as usize) {
+                return AppLayerResult::incomplete(consumed as u32, needed as u32);
+            }
+        }
+    }
+    return AppLayerResult::err();
+}
+
 impl RFBState {
     pub fn new() -> Self {
         Self {
@@ -184,8 +196,7 @@ impl RFBState {
                         }
                         Err(nom::Err::Incomplete(v)) => {
                             if let nom::Needed::Size(n) = v {
-                                return AppLayerResult::incomplete((input.len() - current.len()) as u32,
-                                                                  (current.len() + n) as u32);
+                                return handle_incomplete(input, current, n);
                             }
                             return AppLayerResult::err();
                         }
@@ -215,8 +226,7 @@ impl RFBState {
                         }
                         Err(nom::Err::Incomplete(v)) => {
                             if let nom::Needed::Size(n) = v {
-                                return AppLayerResult::incomplete((input.len() - current.len()) as u32,
-                                                                  (current.len() + n) as u32);
+                                return handle_incomplete(input, current, n);
                             }
                             return AppLayerResult::err();
                         }
@@ -240,8 +250,7 @@ impl RFBState {
                         }
                         Err(nom::Err::Incomplete(v)) => {
                             if let nom::Needed::Size(n) = v {
-                                return AppLayerResult::incomplete((input.len() - current.len()) as u32,
-                                                                  (current.len() + n) as u32);
+                                return handle_incomplete(input, current, n);
                             }
                             return AppLayerResult::err();
                         }
@@ -264,8 +273,7 @@ impl RFBState {
                         }
                         Err(nom::Err::Incomplete(v)) => {
                             if let nom::Needed::Size(n) = v {
-                                return AppLayerResult::incomplete((input.len() - current.len()) as u32,
-                                                                  (current.len() + n) as u32);
+                                return handle_incomplete(input, current, n);
                             }
                             return AppLayerResult::err();
                         }
@@ -319,8 +327,7 @@ impl RFBState {
                         }
                         Err(nom::Err::Incomplete(v)) => {
                             if let nom::Needed::Size(n) = v {
-                                return AppLayerResult::incomplete((input.len() - current.len()) as u32,
-                                                                  (current.len() + n) as u32);
+                                return handle_incomplete(input, current, n);
                             }
                             return AppLayerResult::err();
                         }
@@ -351,8 +358,7 @@ impl RFBState {
                         }
                         Err(nom::Err::Incomplete(v)) => {
                             if let nom::Needed::Size(n) = v {
-                                return AppLayerResult::incomplete((input.len() - current.len()) as u32,
-                                                                  (current.len() + n) as u32);
+                                return handle_incomplete(input, current, n);
                             }
                             return AppLayerResult::err();
                         }
@@ -387,8 +393,7 @@ impl RFBState {
                         }
                         Err(nom::Err::Incomplete(v)) => {
                             if let nom::Needed::Size(n) = v {
-                                return AppLayerResult::incomplete((input.len() - current.len()) as u32,
-                                                                  (current.len() + n) as u32);
+                                return handle_incomplete(input, current, n);
                             }
                             return AppLayerResult::err();
                         }
@@ -412,8 +417,7 @@ impl RFBState {
                         }
                         Err(nom::Err::Incomplete(v)) => {
                             if let nom::Needed::Size(n) = v {
-                                return AppLayerResult::incomplete((input.len() - current.len()) as u32,
-                                                                  (current.len() + n) as u32);
+                                return handle_incomplete(input, current, n);
                             }
                             return AppLayerResult::err();
                         }
@@ -443,8 +447,7 @@ impl RFBState {
                         }
                         Err(nom::Err::Incomplete(v)) => {
                             if let nom::Needed::Size(n) = v {
-                                return AppLayerResult::incomplete((input.len() - current.len()) as u32,
-                                                                  (current.len() + n) as u32);
+                                return handle_incomplete(input, current, n);
                             }
                             return AppLayerResult::err();
                         }
@@ -465,8 +468,7 @@ impl RFBState {
                         }
                         Err(nom::Err::Incomplete(v)) => {
                             if let nom::Needed::Size(n) = v {
-                                return AppLayerResult::incomplete((input.len() - current.len()) as u32,
-                                                                  (current.len() + n) as u32);
+                                return handle_incomplete(input, current, n);
                             }
                             return AppLayerResult::err();
                         }
@@ -491,8 +493,7 @@ impl RFBState {
                         }
                         Err(nom::Err::Incomplete(v)) => {
                             if let nom::Needed::Size(n) = v {
-                                return AppLayerResult::incomplete((input.len() - current.len()) as u32,
-                                                                  (current.len() + n) as u32);
+                                return handle_incomplete(input, current, n);
                             }
                             return AppLayerResult::err();
                         }


### PR DESCRIPTION
Addresses #3570 by extra checking of calculated size requests.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [#3570](https://redmine.openinfosecfoundation.org/issues/3570)

Describe changes:
- Add more extensive checking size request calculations for `AppLayerResult::incomplete()`. This fixes a bug caused by an unchecked integer overflow; brought to light by fuzzing.
