### PR TITLE
detect/bsize: Ensure numeric values fit

### DIFF
--- a/src/detect-bsize.c
+++ b/src/detect-bsize.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -177,7 +177,7 @@ static DetectBsizeData *DetectBsizeParse (const char *str)
     char str1[11], *p = str1;
     memset(str1, 0, sizeof(str1));
     while (*str && isdigit(*str)) {
-        if (p - str1 >= (int)sizeof(str1))
+        if (p - str1 >= ((int)sizeof(str1) - 1))
             return NULL;
         *p++ = *str++;
     }
@@ -224,7 +224,7 @@ static DetectBsizeData *DetectBsizeParse (const char *str)
         p = str2;
         memset(str2, 0, sizeof(str2));
         while (*str && isdigit(*str)) {
-            if (p - str2 >= (int)sizeof(str2))
+            if (p - str2 >= ((int)sizeof(str2) - 1))
                 return NULL;
             *p++ = *str++;
         }

--- a/src/tests/detect-bsize.c
+++ b/src/tests/detect-bsize.c
@@ -40,6 +40,8 @@ static int DetectBsizeTest01(void)
     TEST_FAIL("AA");
     TEST_FAIL("5A");
     TEST_FAIL("A5");
+    TEST_FAIL("10000000001");
+    TEST_OK("  1000000001  ", DETECT_BSIZE_EQ, 1000000001, 0);
     PASS;
 }
 


### PR DESCRIPTION
Continuation of #4753 

This PR adds validation for string numeric values to ensure that they'll fit within the containers used to hold them. Previously, the `NULL` terminating byte was ignored.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3567](https://redmine.openinfosecfoundation.org/issues/3567)

Describe changes:
- Check collected size vs container size, accounting for null termination.