### PR TITLE
configure: correctly display nss/nspr status

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1878,6 +1878,7 @@ return 0;
             echo "   Fedora: dnf install nspr-devel"
             echo "   CentOS/RHEL: yum install nspr-devel"
             echo
+            enable_nspr="no"
         fi
     fi
 
@@ -1930,6 +1931,7 @@ return 0;
             echo "   Fedora: dnf install nss-devel"
             echo "   CentOS/RHEL: yum install nss-devel"
             echo
+            enable_nss="no"
         fi
     fi
 


### PR DESCRIPTION
If autodiscovery of libnss was used (default), then the line
 libnss support:                          yes
was never set to no.

Same behavior for libnspr.

Broken by commit 'configure: fix nspr check logic' (7ea269a212a3a2209effc3cc9300873d6a06859e)

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3465

Describe changes:
- fix configure output

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/525
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/301
