### PR TITLE
Ci maketags v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -314,6 +314,9 @@ jobs:
         run: |
           add-apt-repository -y ppa:npalix/coccinelle
           apt -y install coccinelle
+      - name: Install etags
+        run: |
+          apt install -y xemacs21-bin
       - name: Install cbindgen
         run: cargo install --force cbindgen
       - run: echo "::add-path::$HOME/.cargo/bin"

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -322,6 +322,7 @@ jobs:
       - run: ./autogen.sh
       - run: ./configure --enable-unittests --enable-coccinelle
       - run: make -j2
+      - run: make tags
       - name: Running unit tests and cocci checks
         # Set the concurrency level for cocci.
         run: CONCURRENCY_LEVEL=2 make check


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Adds command `make tags` in one of the CI builds

Cf regression fixed in #4750 
