### PR TITLE
fuzz: build compatibility with oss-fuzz flags

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -6482,6 +6482,8 @@ static int HTPParserTest16(void)
         goto end;
     }
 
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+//these events are disabled during fuzzing as they are too noisy and consume much resource
     FLOWLOCK_WRLOCK(f);
     void *txtmp = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP,f->alstate, 0);
     AppLayerDecoderEvents *decoder_events = AppLayerParserGetEventsByTx(IPPROTO_TCP, ALPROTO_HTTP, txtmp);
@@ -6501,6 +6503,7 @@ static int HTPParserTest16(void)
         printf("HTTP_DECODER_EVENT_URI_DELIM_NON_COMPLIANT not set: ");
         goto end;
     }
+#endif
 
     result = 1;
 end:

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -281,6 +281,7 @@ int RunmodeGetCurrent(void)
  *  construction, etc.
  */
 
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 static void SignalHandlerSigint(/*@unused@*/ int sig)
 {
     sigint_count = 1;
@@ -289,6 +290,8 @@ static void SignalHandlerSigterm(/*@unused@*/ int sig)
 {
     sigterm_count = 1;
 }
+#endif
+
 #ifndef OS_WIN32
 /**
  * SIGUSR2 handler.  Just set sigusr2_count.  The main loop will act on


### PR DESCRIPTION
No redmine ticket

Describe changes:
- Fix build warning with C define `FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION`
- Fix unit test failure with C define `FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION` in libhtp
