### PR TITLE
rfb: handles incomplete asking for one more byte

### DIFF
--- a/rust/src/rfb/rfb.rs
+++ b/rust/src/rfb/rfb.rs
@@ -106,7 +106,7 @@ fn handle_incomplete(input: &[u8], current: &[u8], nom_needed: nom::Needed) -> A
         if let Some(consumed) = input.len().checked_sub(current.len()) {
             if let Some(needed) = current.len().checked_add(needed_size) {
                 if consumed <= (std::u32::MAX as usize) && needed <= (std::u32::MAX as usize) {
-                    return AppLayerResult::incomplete(consumed as u32, needed as u32);
+                    return AppLayerResult::incomplete(consumed as u32, (current.len() + 1) as u32);
                 }
             }
         }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Handles incomplete better for RFB parser (simply asking for one more byte at a time)

`parse_supported_security_types` returns `nom::Err::Incomplete(nom::Needed::Size(2))` if we give it a one byte input (whose value is 2)
when `parse_server_security_type` returns `nom::Err::Incomplete(nom::Needed::Size(4))` if we give it a one byte input

In the first case we need two additional bytes to the first byte
In the second case, we need a total of 4 bytes, including the first one we got

> Rust nom doesn't give you a usable number especially when their is a chain of parsers

cc @satta 
I think the behavior right now is not ok, but I am not sure about the best fix.