### PR TITLE
Next/20200408/v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -441,6 +441,7 @@
     AM_CONDITIONAL([BUILD_FUZZTARGETS], [test "x$enable_fuzztargets" = "xyes"])
     AC_PROG_CXX
     AS_IF([test "x$enable_fuzztargets" = "xyes"], [
+        AC_DEFINE([FUZZ], [1], [Fuzz targets are enabled])
         AC_DEFINE([AFLFUZZ_NO_RANDOM], [1], [Disable all use of random functions])
         CFLAGS_ORIG=$CFLAGS
         CFLAGS="-Werror"
@@ -478,9 +479,6 @@ return 0;
   # enable the running of unit tests
     AC_ARG_ENABLE(unittests,
            AS_HELP_STRING([--enable-unittests], [Enable compilation of the unit tests]),[enable_unittests=$enableval],[enable_unittests=no])
-    AS_IF([test "x$enable_fuzztargets" = "xyes"], [
-        export enable_unittests="yes"
-    ])
     AS_IF([test "x$enable_unittests" = "xyes"], [
         AC_DEFINE([UNITTESTS],[1],[Enable built-in unittests])
     ])

--- a/src/counters.c
+++ b/src/counters.c
@@ -147,7 +147,7 @@ static void StatsPublicThreadContextCleanup(StatsPublicThreadContext *t)
 void StatsAddUI64(ThreadVars *tv, uint16_t id, uint64_t x)
 {
     StatsPrivateThreadContext *pca = &tv->perf_private_ctx;
-#ifdef UNITTESTS
+#if defined (UNITTESTS) || defined (FUZZ)
     if (pca->initialized == 0)
         return;
 #endif
@@ -168,7 +168,7 @@ void StatsAddUI64(ThreadVars *tv, uint16_t id, uint64_t x)
 void StatsIncr(ThreadVars *tv, uint16_t id)
 {
     StatsPrivateThreadContext *pca = &tv->perf_private_ctx;
-#ifdef UNITTESTS
+#if defined (UNITTESTS) || defined (FUZZ)
     if (pca->initialized == 0)
         return;
 #endif
@@ -190,7 +190,7 @@ void StatsIncr(ThreadVars *tv, uint16_t id)
 void StatsSetUI64(ThreadVars *tv, uint16_t id, uint64_t x)
 {
     StatsPrivateThreadContext *pca = &tv->perf_private_ctx;
-#ifdef UNITTESTS
+#if defined (UNITTESTS) || defined (FUZZ)
     if (pca->initialized == 0)
         return;
 #endif
@@ -996,7 +996,7 @@ uint16_t StatsRegisterMaxCounter(const char *name, struct ThreadVars_ *tv)
  */
 uint16_t StatsRegisterGlobalCounter(const char *name, uint64_t (*Func)(void))
 {
-#ifdef UNITTESTS
+#if defined (UNITTESTS) || defined (FUZZ)
     if (stats_ctx == NULL)
         return 0;
 #else

--- a/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
+++ b/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
@@ -45,7 +45,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         alpd_tctx = AppLayerProtoDetectGetCtxThread();
     }
 
-    f = UTHBuildFlow(AF_INET, "1.2.3.4", "5.6.7.8", (data[2] << 8) | data[3], (data[4] << 8) | data[5]);
+    f = TestHelperBuildFlow(AF_INET, "1.2.3.4", "5.6.7.8", (data[2] << 8) | data[3], (data[4] << 8) | data[5]);
     if (f == NULL) {
         return 0;
     }
@@ -69,7 +69,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             }
         }
     }
-    UTHFreeFlow(f);
+    FlowFree(f);
 
     return 0;
 }

--- a/src/tests/fuzz/fuzz_decodepcapfile.c
+++ b/src/tests/fuzz/fuzz_decodepcapfile.c
@@ -83,7 +83,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     }
 
     //rewrite buffer to a file as libpcap does not have buffer inputs
-    if (UTHbufferToFile("/tmp/fuzz.pcap", data, size) < 0) {
+    if (TestHelperBufferToFile("/tmp/fuzz.pcap", data, size) < 0) {
         return 0;
     }
 

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -119,11 +119,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     }
     if (pos > 0 && pos < size) {
         // dump signatures to a file so as to reuse SigLoadSignatures
-        if (UTHbufferToFile(suricata.sig_file, data, pos-1) < 0) {
+        if (TestHelperBufferToFile(suricata.sig_file, data, pos-1) < 0) {
             return 0;
         }
     } else {
-        if (UTHbufferToFile(suricata.sig_file, data, pos) < 0) {
+        if (TestHelperBufferToFile(suricata.sig_file, data, pos) < 0) {
             return 0;
         }
     }
@@ -139,7 +139,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     size -= pos;
 
     //rewrite buffer to a file as libpcap does not have buffer inputs
-    if (UTHbufferToFile("/tmp/fuzz.pcap", data, size) < 0) {
+    if (TestHelperBufferToFile("/tmp/fuzz.pcap", data, size) < 0) {
         return 0;
     }
 

--- a/src/util-unittest-helper.h
+++ b/src/util-unittest-helper.h
@@ -24,6 +24,10 @@
 #ifndef __UTIL_UNITTEST_HELPER__
 #define __UTIL_UNITTEST_HELPER__
 
+#if defined(UNITTESTS) || defined(FUZZ)
+Flow *TestHelperBuildFlow(int family, const char *src, const char *dst, Port sp, Port dp);
+int TestHelperBufferToFile(const char *name, const uint8_t *data, size_t size);
+#endif
 #ifdef UNITTESTS
 uint32_t UTHSetIPv4Address(const char *);
 
@@ -63,7 +67,6 @@ Packet *UTHBuildPacketIPV6Real(uint8_t *, uint16_t , uint8_t ipproto, const char
 
 void * UTHmemsearch(const void *big, size_t big_len, const void *little, size_t little_len);
 int UTHParseSignature(const char *str, bool expect);
-int UTHbufferToFile(const char * name, const uint8_t *data, size_t size);
 #endif
 
 void UTHRegisterTests(void);


### PR DESCRIPTION
Disable unittests dependency for fuzz targets to reduce code size and to allow `--enable-debug-validation` to be enabled.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed