### PR TITLE
doc/install: refer to buster as Debian stable

### DIFF
--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -127,18 +127,19 @@ To use it::
 Debian
 ^^^^^^
 
-In Debian 9 (Stretch) do::
+In Debian 9 (stretch) and later do::
 
-    apt-get install suricata
+    sudo apt-get install suricata
 
-In Debian Jessie Suricata is out of date, but an updated version is in Debian Backports.
+In Debian stable Suricata is usually not the latest version, but an updated version is available from Debian backports.
+To use backports, the backports repository for the current stable distribution needs to be added to the system-wide sources list.
 
-As root do::
+For Debian 10 (buster), for instance, run the following as root::
 
-    echo "deb http://http.debian.net/debian jessie-backports main" > \
+    echo "deb http://http.debian.net/debian buster-backports main" > \
         /etc/apt/sources.list.d/backports.list
     apt-get update
-    apt-get install suricata -t jessie-backports
+    apt-get install suricata -t buster-backports
 
 Fedora
 ^^^^^^


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Stop mentioning stretch and jessie in Debian install documentation. Buster is the current stable.
