### PR TITLE
python: prepare for publishing to PyPI - v1

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -5,3 +5,6 @@ lib/
 scripts-*/
 suricata/config/defaults.py
 !suricata/config/defaults.py.in
+MANIFEST
+VERSION
+dist

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,0 +1,1 @@
+include VERSION

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -19,7 +19,7 @@ uninstall-local:
 	rm -f $(DESTDIR)$(bindir)/suricatasc
 	rm -rf $(DESTDIR)$(prefix)/lib*/python*/site-packages/suricata
 	rm -rf $(DESTDIR)$(prefix)/lib*/python*/site-packages/suricatasc
-	rm -rf $(DESTDIR)$(prefix)/lib*/python*/site-packages/suricata-[0-9]*.egg-info
+	rm -rf $(DESTDIR)$(prefix)/lib*/python*/site-packages/suricatactl-[0-9]*.egg-info
 
 clean-local:
 	cd $(srcdir) && \

--- a/python/setup.py
+++ b/python/setup.py
@@ -67,7 +67,7 @@ install them without installing Suricata.
 """
 
 setup(
-    name="suricata",
+    name="suricatactl",
     description="Suricata control tools",
     long_description=long_description,
     version=version,

--- a/python/setup.py
+++ b/python/setup.py
@@ -10,6 +10,7 @@ from distutils.command.build_py import build_py
 
 # Get the Suricata version from configure.ac.
 version = None
+overwrite_version = False
 if os.path.exists("../configure.ac"):
     with open("../configure.ac", "r") as conf:
         for line in conf:
@@ -17,14 +18,25 @@ if os.path.exists("../configure.ac"):
                 m = re.search("AC_INIT\(\[suricata\],\[(\d.+)\]\)", line)
                 if m:
                     version = m.group(1)
+                    overwrite_version = True
                     break
                 else:
                     print("error: failed to parse Suricata version from: %s" % (
                         line.strip()), file=sys.stderr)
                     sys.exit(1)
+elif os.path.exists("VERSION"):
+    with open("./VERSION") as f:
+        version = f.read().strip()
 if version is None:
     print("error: failed to find Suricata version", file=sys.stderr)
     sys.exit(1)
+
+# Write the version file so it can be included in the Python sdist
+# allowing this Python code to be pip installable. We only do this for
+# sdist as it causes issues when doing an out of tree autoconf build.
+if "sdist" in sys.argv and overwrite_version:
+    with open("./VERSION", "w") as f:
+        f.write("{}\n".format(version))
 
 class do_build(build_py):
     def run(self):
@@ -41,9 +53,23 @@ class do_build(build_py):
                 print("error: failed to find defaults.py")
                 sys.exit(1)
 
+# Long description, this is what will show up on PyPI.
+long_description = """
+
+This package contains the Python support tools and libraries for
+Suricata.
+
+It is important to note that these tools are bundled and installed by
+Suricata, so you likely don't need to install this package, unless you
+need access to the libraries inside a virtualenv, or have a need to
+install them without installing Suricata.
+
+"""
+
 setup(
     name="suricata",
     description="Suricata control tools",
+    long_description=long_description,
     version=version,
     author='OISF Developers, Eric Leblond',
     author_email='oisf-devel@lists.openinfosecfoundation.org, eric@regit.org',


### PR DESCRIPTION
- Renames our Python package from suricata to suricatactl.
- Drop a VERSION file when building sdist so installation
  can happen outside of the Suriata source tree where there
  is no configure.ac to parse the version from.
  Note: sdist still needs to be built in tree.

With this we can now "python setup.py sdist" then push it up
to PyPI with twine which will make our Python libraries installable
with pip: pip install suricatactl

This is mainly useful for applications that import our socket
control module.

I would also like to have this backported to 5.0.x so we can publish a release version sooner than later.

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/3629

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/470
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/827