### PR TITLE
Dev feat3439 bpf filter v0.4

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -53,6 +53,7 @@
 #include "util-device.h"
 #include "util-runmodes.h"
 #include "util-ioctl.h"
+#include "util-bpf.h"
 #include "util-ebpf.h"
 
 #include "source-af-packet.h"
@@ -89,6 +90,9 @@ static void AFPDerefConfig(void *conf)
     AFPIfaceConfig *pfp = (AFPIfaceConfig *)conf;
     /* Pcap config is used only once but cost of this low. */
     if (SC_ATOMIC_SUB(pfp->ref, 1) == 0) {
+        if (pfp->bpf_filter) {
+            SCFree(pfp->bpf_filter);
+        }
         SCFree(pfp);
     }
 }
@@ -118,7 +122,7 @@ static void *ParseAFPConfig(const char *iface)
     const char *copymodestr;
     intmax_t value;
     int boolval;
-    const char *bpf_filter = NULL;
+    char *bpf_filter = NULL;
     const char *out_iface = NULL;
     int cluster_type = PACKET_FANOUT_HASH;
     const char *ebpf_file = NULL;
@@ -155,14 +159,6 @@ static void *ParseAFPConfig(const char *iface)
 #ifdef HAVE_PACKET_EBPF
     aconf->ebpf_t_config.cpus_count = UtilCpuGetNumProcessorsConfigured();
 #endif
-
-    if (ConfGet("bpf-filter", &bpf_filter) == 1) {
-        if (strlen(bpf_filter) > 0) {
-            aconf->bpf_filter = bpf_filter;
-            SCLogConfig("Going to use command-line provided bpf filter '%s'",
-                       aconf->bpf_filter);
-        }
-    }
 
     /* Find initial node */
     af_packet_node = ConfGetNode("af-packet");
@@ -361,14 +357,9 @@ static void *ParseAFPConfig(const char *iface)
     }
 
     /*load af_packet bpf filter*/
-    /* command line value has precedence */
-    if (ConfGet("bpf-filter", &bpf_filter) != 1) {
-        if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &bpf_filter) == 1) {
-            if (strlen(bpf_filter) > 0) {
-                aconf->bpf_filter = bpf_filter;
-                SCLogConfig("Going to use bpf filter %s", aconf->bpf_filter);
-            }
-        }
+    if (ParseBpfConfig(if_root, &bpf_filter) == 1) {
+        aconf->bpf_filter = bpf_filter;
+        SCLogConfig("Going to use bpf filter %s", aconf->bpf_filter);
     }
 
     if (ConfGetChildValueWithDefault(if_root, if_default, "ebpf-lb-file", &ebpf_file) != 1) {

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -31,6 +31,7 @@
 #include "util-runmodes.h"
 #include "util-atomic.h"
 #include "util-misc.h"
+#include "util-bpf.h"
 
 const char *RunModeIdsGetDefaultMode(void)
 {
@@ -64,6 +65,9 @@ static void PcapDerefConfig(void *conf)
     PcapIfaceConfig *pfp = (PcapIfaceConfig *)conf;
     /* Pcap config is used only once but cost of this low. */
     if (SC_ATOMIC_SUB(pfp->ref, 1) == 0) {
+        if (pfp->bpf_filter) {
+            SCFree(pfp->bpf_filter);
+        }
         SCFree(pfp);
     }
 }
@@ -75,7 +79,7 @@ static void *ParsePcapConfig(const char *iface)
     ConfNode *if_default = NULL;
     ConfNode *pcap_node;
     PcapIfaceConfig *aconf = SCMalloc(sizeof(*aconf));
-    const char *tmpbpf;
+    char *tmpbpf;
     const char *tmpctype;
     intmax_t value;
     int promisc = 0;
@@ -108,9 +112,6 @@ static void *ParsePcapConfig(const char *iface)
 
     aconf->checksum_mode = CHECKSUM_VALIDATION_AUTO;
     aconf->bpf_filter = NULL;
-    if ((ConfGet("bpf-filter", &tmpbpf)) == 1) {
-        aconf->bpf_filter = tmpbpf;
-    }
 
     SC_ATOMIC_INIT(aconf->ref);
     aconf->DerefFunc = PcapDerefConfig;
@@ -179,15 +180,9 @@ static void *ParsePcapConfig(const char *iface)
         }
     }
 
-    if (aconf->bpf_filter == NULL) {
-        /* set bpf filter if we have one */
-        if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &tmpbpf) != 1) {
-            SCLogDebug("could not get bpf or none specified");
-        } else {
-            aconf->bpf_filter = tmpbpf;
-        }
-    } else {
-        SCLogInfo("BPF filter set from command line or via old 'bpf-filter' option.");
+    if (ParseBpfConfig(if_root, &tmpbpf) == 1) {
+        aconf->bpf_filter = tmpbpf;
+        SCLogConfig("Going to use bpf filter %s", aconf->bpf_filter);
     }
 
     if (ConfGetChildValueWithDefault(if_root, if_default, "checksum-checks", &tmpctype) == 1) {

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -100,7 +100,7 @@ typedef struct AFPIfaceConfig_
     unsigned int flags;
     int copy_mode;
     ChecksumValidationMode checksum_mode;
-    const char *bpf_filter;
+    char *bpf_filter;
     const char *ebpf_lb_file;
     int ebpf_lb_fd;
     const char *ebpf_filter_file;

--- a/src/source-netmap.h
+++ b/src/source-netmap.h
@@ -51,7 +51,7 @@ typedef struct NetmapIfaceSettings_
     int threads;
     int copy_mode;
     ChecksumValidationMode checksum_mode;
-    const char *bpf_filter;
+    char *bpf_filter;
 } NetmapIfaceSettings;
 
 typedef struct NetmapIfaceConfig_

--- a/src/source-pcap.h
+++ b/src/source-pcap.h
@@ -53,7 +53,7 @@ typedef struct PcapIfaceConfig_
     /* promiscuous value */
     int promisc;
     /* BPF filter */
-    const char *bpf_filter;
+    char *bpf_filter;
     ChecksumValidationMode checksum_mode;
     SC_ATOMIC_DECLARE(unsigned int, ref);
     void (*DerefFunc)(void *);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -54,6 +54,7 @@
 #include "util-ioctl.h"
 #include "util-device.h"
 #include "util-misc.h"
+#include "util-bpf.h"
 #include "util-running-modes.h"
 
 #include "detect-engine.h"
@@ -407,145 +408,6 @@ void EngineStop(void)
 void EngineDone(void)
 {
     suricata_ctl_flags |= SURICATA_DONE;
-}
-
-static int SetBpfString(int argc, char *argv[])
-{
-    char *bpf_filter = NULL;
-    uint32_t bpf_len = 0;
-    int tmpindex = 0;
-
-    /* attempt to parse remaining args as bpf filter */
-    tmpindex = argc;
-    while(argv[tmpindex] != NULL) {
-        bpf_len+=strlen(argv[tmpindex]) + 1;
-        tmpindex++;
-    }
-
-    if (bpf_len == 0)
-        return TM_ECODE_OK;
-
-    if (EngineModeIsIPS()) {
-        SCLogError(SC_ERR_NOT_SUPPORTED,
-                   "BPF filter not available in IPS mode."
-                   " Use firewall filtering if possible.");
-        return TM_ECODE_FAILED;
-    }
-
-    bpf_filter = SCMalloc(bpf_len);
-    if (unlikely(bpf_filter == NULL))
-        return TM_ECODE_OK;
-    memset(bpf_filter, 0x00, bpf_len);
-
-    tmpindex = optind;
-    while(argv[tmpindex] != NULL) {
-        strlcat(bpf_filter, argv[tmpindex],bpf_len);
-        if(argv[tmpindex + 1] != NULL) {
-            strlcat(bpf_filter," ", bpf_len);
-        }
-        tmpindex++;
-    }
-
-    if(strlen(bpf_filter) > 0) {
-        if (ConfSetFinal("bpf-filter", bpf_filter) != 1) {
-            SCLogError(SC_ERR_FATAL, "Failed to set bpf filter.");
-            SCFree(bpf_filter);
-            return TM_ECODE_FAILED;
-        }
-    }
-    SCFree(bpf_filter);
-
-    return TM_ECODE_OK;
-}
-
-static void SetBpfStringFromFile(char *filename)
-{
-    char *bpf_filter = NULL;
-    char *bpf_comment_tmp = NULL;
-    char *bpf_comment_start =  NULL;
-    uint32_t bpf_len = 0;
-#ifdef OS_WIN32
-    struct _stat st;
-#else
-    struct stat st;
-#endif /* OS_WIN32 */
-    FILE *fp = NULL;
-    size_t nm = 0;
-
-    if (EngineModeIsIPS()) {
-        SCLogError(SC_ERR_NOT_SUPPORTED,
-                   "BPF filter not available in IPS mode."
-                   " Use firewall filtering if possible.");
-        exit(EXIT_FAILURE);
-    }
-
-#ifdef OS_WIN32
-    if(_stat(filename, &st) != 0) {
-#else
-    if(stat(filename, &st) != 0) {
-#endif /* OS_WIN32 */
-        SCLogError(SC_ERR_FOPEN, "Failed to stat file %s", filename);
-        exit(EXIT_FAILURE);
-    }
-    bpf_len = st.st_size + 1;
-
-    // coverity[toctou : FALSE]
-    fp = fopen(filename,"r");
-    if (fp == NULL) {
-        SCLogError(SC_ERR_FOPEN, "Failed to open file %s", filename);
-        exit(EXIT_FAILURE);
-    }
-
-    bpf_filter = SCMalloc(bpf_len * sizeof(char));
-    if (unlikely(bpf_filter == NULL)) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate buffer for bpf filter in file %s", filename);
-        exit(EXIT_FAILURE);
-    }
-    memset(bpf_filter, 0x00, bpf_len);
-
-    nm = fread(bpf_filter, 1, bpf_len - 1, fp);
-    if ((ferror(fp) != 0) || (nm != (bpf_len - 1))) {
-        SCLogError(SC_ERR_BPF, "Failed to read complete BPF file %s", filename);
-        SCFree(bpf_filter);
-        fclose(fp);
-        exit(EXIT_FAILURE);
-    }
-    fclose(fp);
-    bpf_filter[nm] = '\0';
-
-    if(strlen(bpf_filter) > 0) {
-        /*replace comments with space*/
-        bpf_comment_start = bpf_filter;
-        while((bpf_comment_tmp = strchr(bpf_comment_start, '#')) != NULL) {
-            while((*bpf_comment_tmp !='\0') &&
-                (*bpf_comment_tmp != '\r') && (*bpf_comment_tmp != '\n'))
-            {
-                *bpf_comment_tmp++ = ' ';
-            }
-            bpf_comment_start = bpf_comment_tmp;
-        }
-        /*remove remaining '\r' and '\n' */
-        while((bpf_comment_tmp = strchr(bpf_filter, '\r')) != NULL) {
-            *bpf_comment_tmp = ' ';
-        }
-        while((bpf_comment_tmp = strchr(bpf_filter, '\n')) != NULL) {
-            *bpf_comment_tmp = ' ';
-        }
-        /* cut trailing spaces */
-        while (strlen(bpf_filter) > 0 &&
-                bpf_filter[strlen(bpf_filter)-1] == ' ')
-        {
-            bpf_filter[strlen(bpf_filter)-1] = '\0';
-        }
-        if (strlen(bpf_filter) > 0) {
-            if(ConfSetFinal("bpf-filter", bpf_filter) != 1) {
-                SCLogError(SC_ERR_FOPEN, "ERROR: Failed to set bpf filter!");
-                SCFree(bpf_filter);
-                exit(EXIT_FAILURE);
-            }
-        }
-    }
-    SCFree(bpf_filter);
 }
 
 static void PrintUsage(const char *progname)
@@ -1161,7 +1023,6 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
     int build_info = 0;
     int conf_test = 0;
     int engine_analysis = 0;
-    int ret = TM_ECODE_OK;
 
 #ifdef UNITTESTS
     coverage_unittests = 0;
@@ -1768,8 +1629,10 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 SCLogError(SC_ERR_INITIALIZATION, "no option argument (optarg) for -F");
                 return TM_ECODE_FAILED;
             }
-
-            SetBpfStringFromFile(optarg);
+            if (SetBpfStringFromFile(optarg) != TM_ECODE_OK) {
+                SCLogError(SC_ERR_INITIALIZATION, "failed to parse the provide BPF file");
+                return TM_ECODE_FAILED;
+            }
             break;
         case 'v':
             suri->verbose++;
@@ -1826,9 +1689,10 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
     suri->offline = IsRunModeOffline(suri->run_mode);
     g_system = suri->system = IsRunModeSystem(suri->run_mode);
 
-    ret = SetBpfString(optind, argv);
-    if (ret != TM_ECODE_OK)
-        return ret;
+    if (SetBpfString(optind, argv) != TM_ECODE_OK) {
+        SCLogError(SC_ERR_INITIALIZATION, "failed to parse the provide BPF");
+        return TM_ECODE_FAILED;
+    }
 
     return TM_ECODE_OK;
 }

--- a/src/util-bpf.c
+++ b/src/util-bpf.c
@@ -290,7 +290,7 @@ int SetBpfStringFromFile(const char *filename)
  * \retval 1 will be returned if the BPF is parsed, otherwise
  *   0 will be returned.
  */
-int ParseBpfConfig(ConfNode *if_root, const char **vptr)
+int ParseBpfConfig(ConfNode *if_root, char **vptr)
 {
     ConfNode *if_default = NULL;
     const char *bpf_filter = NULL;

--- a/src/util-bpf.c
+++ b/src/util-bpf.c
@@ -75,3 +75,276 @@ int SCBPFCompile(int snaplen_arg, int linktype_arg, struct bpf_program *program,
 }
 
 #endif /* Not __OpenBSD__ */
+
+/**
+ * \brief Set the BPF based on the provided BPF file.
+ *
+ * Parses a BPF from the specified file. Note that in case of success
+ * the caller is the one responsible for freeing the allocated BPF.
+ * 
+ * \param vptr Pointer that will be set to the BPF value.
+ *
+ * \retval TM_ECODE_OK will be returned if the BPF is parsed, otherwise
+ *   TM_ECODE_FAILED will be returned.
+ */
+static int ParseBpfFromFile(const char *filename, const char **vptr)
+{
+    char *bpf_filter = NULL;
+    char *bpf_comment_tmp = NULL;
+    char *bpf_comment_start =  NULL;
+    uint32_t bpf_len = 0;
+#ifdef OS_WIN32
+    struct _stat st;
+#else
+    struct stat st;
+#endif /* OS_WIN32 */
+    FILE *fp = NULL;
+    size_t nm = 0;
+
+    if (EngineModeIsIPS()) {
+        SCLogError(SC_ERR_NOT_SUPPORTED,
+                   "BPF not available in IPS mode."
+                   " Use firewall filtering if possible.");
+        return TM_ECODE_FAILED;
+    }
+
+#ifdef OS_WIN32
+    if(_stat(filename, &st) != 0) {
+#else
+    if(stat(filename, &st) != 0) {
+#endif /* OS_WIN32 */
+        SCLogError(SC_ERR_FOPEN, "Failed to stat file %s", filename);
+        return TM_ECODE_FAILED;
+    }
+    bpf_len = st.st_size + 1;
+
+    // coverity[toctou : FALSE]
+    fp = fopen(filename,"r");
+    if (fp == NULL) {
+        SCLogError(SC_ERR_FOPEN, "Failed to open file %s", filename);
+        return TM_ECODE_FAILED;
+    }
+
+    bpf_filter = SCMalloc(bpf_len * sizeof(char));
+    if (unlikely(bpf_filter == NULL)) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate buffer for BPF in file %s", filename);
+        return TM_ECODE_FAILED;
+    }
+    memset(bpf_filter, 0x00, bpf_len);
+
+    nm = fread(bpf_filter, 1, bpf_len - 1, fp);
+    if ((ferror(fp) != 0) || (nm != (bpf_len - 1))) {
+        SCLogError(SC_ERR_BPF, "Failed to read complete BPF file %s", filename);
+        SCFree(bpf_filter);
+        fclose(fp);
+        return TM_ECODE_FAILED;
+    }
+    fclose(fp);
+    bpf_filter[nm] = '\0';
+
+    if(strlen(bpf_filter) > 0) {
+        /*replace comments with space*/
+        bpf_comment_start = bpf_filter;
+        while((bpf_comment_tmp = strchr(bpf_comment_start, '#')) != NULL) {
+            while((*bpf_comment_tmp !='\0') &&
+                (*bpf_comment_tmp != '\r') && (*bpf_comment_tmp != '\n'))
+            {
+                *bpf_comment_tmp++ = ' ';
+            }
+            bpf_comment_start = bpf_comment_tmp;
+        }
+        /*remove remaining '\r' and '\n' */
+        while((bpf_comment_tmp = strchr(bpf_filter, '\r')) != NULL) {
+            *bpf_comment_tmp = ' ';
+        }
+        while((bpf_comment_tmp = strchr(bpf_filter, '\n')) != NULL) {
+            *bpf_comment_tmp = ' ';
+        }
+        /* cut trailing spaces */
+        while (strlen(bpf_filter) > 0 &&
+                bpf_filter[strlen(bpf_filter)-1] == ' ')
+        {
+            bpf_filter[strlen(bpf_filter)-1] = '\0';
+        }
+
+        if (strlen(bpf_filter) > 0) {
+            *vptr = bpf_filter;
+        }
+        else {
+            SCLogError(SC_ERR_BPF, "Extracted BPF from %s is empty", filename);
+            SCFree(bpf_filter);
+            return TM_ECODE_FAILED;
+        }
+    }
+    else {
+        SCLogError(SC_ERR_BPF, "Empty BPF file provided %s", filename);
+        SCFree(bpf_filter);
+        return TM_ECODE_FAILED;
+    }
+
+    return TM_ECODE_OK;
+}
+
+/**
+ * \brief Set the BPF based on the provided command line.
+ *
+ * Sets the "bpf-filter" configuration option with the command line provided
+ * BPF.
+ * 
+ * \param argc Number of command line arguments.
+ * \param argv Actual command line arguments.
+ *
+ * \retval TM_ECODE_OK will be returned if the BPF is set, otherwise
+ *   TM_ECODE_FAILED will be returned.
+ */
+int SetBpfString(int argc, char *argv[])
+{
+    char *bpf_filter = NULL;
+    uint32_t bpf_len = 0;
+    int tmpindex = 0;
+
+    /* attempt to parse remaining args as bpf */
+    tmpindex = argc;
+    while(argv[tmpindex] != NULL) {
+        bpf_len+=strlen(argv[tmpindex]) + 1;
+        tmpindex++;
+    }
+
+    if (bpf_len == 0)
+        return TM_ECODE_OK;
+
+    if (EngineModeIsIPS()) {
+        SCLogError(SC_ERR_NOT_SUPPORTED,
+                   "BPF not available in IPS mode."
+                   " Use firewall filtering if possible.");
+        return TM_ECODE_FAILED;
+    }
+
+    bpf_filter = SCMalloc(bpf_len);
+    if (unlikely(bpf_filter == NULL))
+        return TM_ECODE_OK;
+    memset(bpf_filter, 0x00, bpf_len);
+
+    tmpindex = optind;
+    while(argv[tmpindex] != NULL) {
+        strlcat(bpf_filter, argv[tmpindex],bpf_len);
+        if(argv[tmpindex + 1] != NULL) {
+            strlcat(bpf_filter," ", bpf_len);
+        }
+        tmpindex++;
+    }
+
+    if(strlen(bpf_filter) > 0) {
+        if (ConfSetFinal("bpf-filter", bpf_filter) != 1) {
+            SCLogError(SC_ERR_FATAL, "Failed to set BPF.");
+            SCFree(bpf_filter);
+            return TM_ECODE_FAILED;
+        }
+    }
+    SCFree(bpf_filter);
+
+    return TM_ECODE_OK;
+}
+
+/**
+ * \brief Set the BPF based on the specified file.
+ *
+ * Make use of the ParseBpfFromFile function to parse the BPF and sets
+ * the "bpf-filter" configuration option with the result.
+ * 
+ * \param filename Name of the file containing the BPF.
+ *
+ * \retval TM_ECODE_OK will be returned if the BPF is parsed, otherwise
+ *   TM_ECODE_FAILED will be returned.
+ */
+int SetBpfStringFromFile(const char *filename)
+{
+    const char *bpf_filter = NULL;
+
+    int ret = ParseBpfFromFile(filename, &bpf_filter);
+
+    if (ret == TM_ECODE_OK) {
+        if(ConfSetFinal("bpf-filter", bpf_filter) != 1) {
+            SCLogError(SC_ERR_FOPEN, "ERROR: Failed to set the BPF!");
+            ret = TM_ECODE_FAILED;
+        }
+    }
+    
+    if (bpf_filter != NULL) {
+        SCFree((char *)bpf_filter);
+    }
+
+    return ret;
+}
+
+/**
+ * \brief Parse the BPF from the Suricata configuration file.
+ *
+ * This function parses the "bpf-filter" configuration option and
+ * supports files as well as BPF expressions. Two notes, first the command
+ * line value has precedence, second the pointer retuned in vptr needs to be
+ * freed by the caller in case of success.
+ * 
+ * \param vptr Pointer that will be set to the configuration value parameter.
+ *
+ * \retval 1 will be returned if the BPF is parsed, otherwise
+ *   0 will be returned.
+ */
+int ParseBpfConfig(ConfNode *if_root, const char **vptr)
+{
+    ConfNode *if_default = NULL;
+    const char *bpf_filter = NULL;
+    const char *bpf_tmp = NULL;
+#ifdef OS_WIN32
+    struct _stat st;
+#else
+    struct stat st;
+#endif /* OS_WIN32 */
+
+    if (ConfGet("bpf-filter", &bpf_filter) == 1) {
+        if (strlen(bpf_filter) > 0) {
+            *vptr = SCStrdup(bpf_filter);
+
+            if (unlikely(*vptr == NULL)) {
+                SCLogError(SC_ERR_MEM_ALLOC,
+                           "Can't allocate BPF string");
+            } else {
+                SCLogDebug("Going to use command-line provided BPF %s",
+                           bpf_filter);
+
+                return 1;
+            }
+        }
+    } else {
+        if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &bpf_tmp) == 1) {
+            if (strlen(bpf_tmp) > 0) {
+#ifdef OS_WIN32
+                if (_stat(bpf_tmp, &st) == 0) {
+#else
+                if (stat(bpf_tmp, &st) == 0) {
+#endif /* OS_WIN32 */
+                    if (ParseBpfFromFile(bpf_tmp, &bpf_filter) == TM_ECODE_FAILED) {
+                        return 0;
+                    }
+                }
+                else {
+                    bpf_filter = bpf_tmp;
+                }
+
+                *vptr = SCStrdup(bpf_filter);
+
+                if (unlikely(*vptr == NULL)) {
+                    SCLogError(SC_ERR_MEM_ALLOC,
+                               "Can't allocate BPF string");
+                } else {
+                    SCLogDebug("Going to use BPF %s",
+                               bpf_filter);
+
+                    return 1;
+                }
+            }
+        }
+    }
+
+    return 0;
+}

--- a/src/util-bpf.h
+++ b/src/util-bpf.h
@@ -33,4 +33,11 @@ int SCBPFCompile(int snaplen_arg, int linktype_arg, struct bpf_program *program,
 void SCBPFFree(struct bpf_program *program);
 
 #endif /* Not __OpenBSD__ */
+
+int SetBpfString(int argc, char *argv[]);
+
+int SetBpfStringFromFile(const char *filename);
+
+int ParseBpfConfig(ConfNode *if_root, const char **bpf_filter);
+
 #endif /* __UTIL_BPF_H__ */

--- a/src/util-bpf.h
+++ b/src/util-bpf.h
@@ -38,6 +38,6 @@ int SetBpfString(int argc, char *argv[]);
 
 int SetBpfStringFromFile(const char *filename);
 
-int ParseBpfConfig(ConfNode *if_root, const char **bpf_filter);
+int ParseBpfConfig(ConfNode *if_root, char **bpf_filter);
 
 #endif /* __UTIL_BPF_H__ */


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3439

Describe changes:
- Added support for specifying BPF files on the per-packet capture method bpf-filter option in `suricata.yaml`.
- Unified the bpf-filter option and BPF file parsing code in util-bpf.c.
- Changed the behaviour a little. The original function `SetBpfStringFromFile` doesn't fail if the parsed BPF filter is empty, it simply doesn't set the configuration option. This is no longer the case.
