### PR TITLE
Fuzz fix v1

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -713,6 +713,7 @@ static void HTPHandleError(HtpState *s, const uint8_t dir)
             HTPSetEvent(s, htud, dir, id);
         }
     }
+    BUG_ON(msg >= 0x10000);
     s->htp_messages_offset = (uint16_t)msg;
     SCLogDebug("s->htp_messages_offset %u", s->htp_messages_offset);
 }

--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -185,8 +185,9 @@ ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int rlevel)
     int retval = 0;
 
     if (rlevel++ > RECURSION_LIMIT) {
-        FatalError(SC_ERR_FATAL, "Recursion limit reached while parsing "
+        SCLogError(SC_ERR_CONF_YAML_ERROR, "Recursion limit reached while parsing "
                 "configuration file, aborting.");
+        return -1;
     }
 
     while (!done) {

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -125,6 +125,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             (void) AppLayerParserParse(NULL, alp_tctx, f, f->alproto, flags, isolatedBuffer, alnext - albuffer);
             free(isolatedBuffer);
             flags &= ~(STREAM_START);
+            if (AppLayerParserStateIssetFlag(f->alparser, APP_LAYER_PARSER_EOF)) {
+                break;
+            }
         }
         alsize -= alnext - albuffer + 4;
         albuffer = alnext + 4;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes: various fixes found by fuzzing
- `return` instead of `exit` from `ConfYamlParse`
- fixes fuzz target applayerparse by stopping on EOF/failure as Suricata does
- adds a debug guard for HTTP against too many warnings from libhtp (and having unsigned overflow causing bad performance)

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

