### PR TITLE
Fix issue where the wrong packet structure is evaluated in PACKET_TES…

### DIFF
--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -958,7 +958,7 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
         while (rel_pkt != NULL) {
 #ifdef NAPATECH_ENABLE_BYPASS
             if (rel_pkt->ntpv.bypass == 1) {
-                if (PACKET_TEST_ACTION(p, ACTION_DROP)) {
+                if (PACKET_TEST_ACTION(rel_pkt, ACTION_DROP)) {
                     if (is_inline) {
                         rel_pkt->ntpv.dyn3->wireLength = 0;
                     }


### PR DESCRIPTION
This fixes an issue where the wrong packet structure is evaluated when determining if a drop or pass action should be facilitated by hardware.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)


Describe changes:
- Change the packet structure variable that is evaluated in the PACKET_TEST_ACTION() macro from p to rel|_pkt.

