### PR TITLE
http: adds debug check against too many warnings

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -689,6 +689,11 @@ static void HTPHandleError(HtpState *s, const uint8_t dir)
 
     size_t size = htp_list_size(s->conn->messages);
     size_t msg;
+    if(size >= 0x10000) {
+        DEBUG_VALIDATE_BUG_ON("Overflowing htp_messages_offset");
+        // ignore further messages
+        return;
+    }
 
     for (msg = s->htp_messages_offset; msg < size; msg++) {
         htp_log_t *log = htp_list_get(s->conn->messages, msg);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes: various fixes found by fuzzing
- adds a debug guard for HTTP against too many warnings from libhtp (and having unsigned overflow causing bad performance)

Follows #4824 without already merged commits, and improving handling of libhtp too many warnings