### PR TITLE
dns: parse and log soa data - v1

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -231,12 +231,37 @@ pub struct DNSQueryEntry {
 }
 
 #[derive(Debug,PartialEq)]
+pub struct DNSRDataSOA {
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug,PartialEq)]
+pub struct DNSRDataSSHFP {
+    pub data: Vec<u8>,
+}
+
+/// Represents RData of various formats
+#[derive(Debug,PartialEq)]
+pub enum DNSRData {
+    /// Formatted as an address (e.g. A or AAAA types)
+    Addr(Vec<u8>),
+    /// Formatted as a string (e.g. CNAME, MX, PTR, TXT types)
+    Str(Vec<u8>),
+    /// SOA type format
+    SOA(DNSRDataSOA),
+    /// SSHFP type format
+    SSHFP(DNSRDataSSHFP),
+    /// RData is ignored and not logged
+    Unknown(Vec<u8>),
+}
+
+#[derive(Debug,PartialEq)]
 pub struct DNSAnswerEntry {
     pub name: Vec<u8>,
     pub rrtype: u16,
     pub rrclass: u16,
     pub ttl: u32,
-    pub data: Vec<u8>,
+    pub data: DNSRData,
 }
 
 #[derive(Debug)]

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -232,7 +232,20 @@ pub struct DNSQueryEntry {
 
 #[derive(Debug,PartialEq)]
 pub struct DNSRDataSOA {
-    pub data: Vec<u8>,
+    /// Primary name server for this zone
+    pub mname: Vec<u8>,
+    /// Authority's mailbox
+    pub rname: Vec<u8>,
+    /// Serial version number
+    pub serial: u32,
+    /// Refresh interval (seconds)
+    pub refresh: u32,
+    /// Retry interval (seconds)
+    pub retry: u32,
+    /// Upper time limit until zone is no longer authoritative (seconds)
+    pub expire: u32,
+    /// Minimum ttl for records in this zone (seconds)
+    pub minimum: u32,
 }
 
 #[derive(Debug,PartialEq)]

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -395,25 +395,24 @@ pub fn dns_print_addr(addr: &Vec<u8>) -> std::string::String {
     }
 }
 
-///  Log the SSHPF in an DNSAnswerEntry.
-fn dns_log_sshfp(answer: &DNSAnswerEntry) -> Option<Json>
-{
+/// Log SSHFP section fields.
+fn dns_log_sshfp(sshfp: &DNSRDataSSHFP) -> Option<Json> {
     // Need at least 3 bytes - TODO: log something if we don't?
-    if answer.data.len() < 3 {
+    if sshfp.data.len() < 3 {
         return None
     }
 
-    let sshfp = Json::object();
+    let js = Json::object();
 
     let mut hex = Vec::new();
-    for byte in &answer.data[2..] {
+    for byte in &sshfp.data[2..] {
         hex.push(format!("{:02x}", byte));
     }
-    sshfp.set_string("fingerprint", &hex.join(":"));
-    sshfp.set_integer("algo", answer.data[0] as u64);
-    sshfp.set_integer("type", answer.data[1] as u64);
+    js.set_string("fingerprint", &hex.join(":"));
+    js.set_integer("algo", sshfp.data[0] as u64);
+    js.set_integer("type", sshfp.data[1] as u64);
 
-    return Some(sshfp);
+    return Some(js);
 }
 
 fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Json
@@ -424,18 +423,11 @@ fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Json
     jsa.set_string("rrtype", &dns_rrtype_string(answer.rrtype));
     jsa.set_integer("ttl", answer.ttl as u64);
 
-    match answer.rrtype {
-        DNS_RECORD_TYPE_A | DNS_RECORD_TYPE_AAAA => {
-            jsa.set_string("rdata", &dns_print_addr(&answer.data));
-        }
-        DNS_RECORD_TYPE_CNAME |
-        DNS_RECORD_TYPE_MX |
-        DNS_RECORD_TYPE_TXT |
-        DNS_RECORD_TYPE_PTR => {
-            jsa.set_string_from_bytes("rdata", &answer.data);
-        },
-        DNS_RECORD_TYPE_SSHFP => {
-            for sshfp in dns_log_sshfp(&answer) {
+    match &answer.data {
+        DNSRData::Addr(addr) => jsa.set_string("rdata", &dns_print_addr(&addr)),
+        DNSRData::Str(bytes) => jsa.set_string_from_bytes("rdata", &bytes),
+        DNSRData::SSHFP(sshfp) => {
+            for sshfp in dns_log_sshfp(&sshfp) {
                 jsa.set("sshfp", sshfp);
             }
         },
@@ -487,37 +479,34 @@ fn dns_log_json_answer(response: &DNSResponse, flags: u64) -> Json
 
             if flags & LOG_FORMAT_GROUPED != 0 {
                 let type_string = dns_rrtype_string(answer.rrtype);
-                match answer.rrtype {
-                    DNS_RECORD_TYPE_A | DNS_RECORD_TYPE_AAAA => {
+                match &answer.data {
+                    DNSRData::Addr(addr) => {
                         if !answer_types.contains_key(&type_string) {
                             answer_types.insert(type_string.to_string(),
                                                 Json::array());
                         }
                         for a in &answer_types.get(&type_string) {
                             a.array_append(
-                                Json::string(&dns_print_addr(&answer.data)));
+                                Json::string(&dns_print_addr(&addr)));
                         }
                     }
-                    DNS_RECORD_TYPE_CNAME |
-                    DNS_RECORD_TYPE_MX |
-                    DNS_RECORD_TYPE_TXT |
-                    DNS_RECORD_TYPE_PTR => {
+                    DNSRData::Str(bytes) => {
                         if !answer_types.contains_key(&type_string) {
                             answer_types.insert(type_string.to_string(),
                                                 Json::array());
                         }
                         for a in &answer_types.get(&type_string) {
                             a.array_append(
-                                Json::string_from_bytes(&answer.data));
+                                Json::string_from_bytes(&bytes));
                         }
                     },
-                    DNS_RECORD_TYPE_SSHFP => {
+                    DNSRData::SSHFP(sshfp) => {
                         if !answer_types.contains_key(&type_string) {
                             answer_types.insert(type_string.to_string(),
                                                 Json::array());
                         }
                         for a in &answer_types.get(&type_string) {
-                            for sshfp in dns_log_sshfp(&answer) {
+                            for sshfp in dns_log_sshfp(&sshfp) {
                                 a.array_append(sshfp);
                             }
                         }
@@ -628,18 +617,15 @@ fn dns_log_json_answer_v1(header: &DNSHeader, answer: &DNSAnswerEntry)
     js.set_string("rrtype", &dns_rrtype_string(answer.rrtype));
     js.set_integer("ttl", answer.ttl as u64);
 
-    match answer.rrtype {
-        DNS_RECORD_TYPE_A | DNS_RECORD_TYPE_AAAA => {
-            js.set_string("rdata", &dns_print_addr(&answer.data));
+    match &answer.data {
+        DNSRData::Addr(addr) => {
+            js.set_string("rdata", &dns_print_addr(&addr));
         }
-        DNS_RECORD_TYPE_CNAME |
-        DNS_RECORD_TYPE_MX |
-        DNS_RECORD_TYPE_TXT |
-        DNS_RECORD_TYPE_PTR => {
-            js.set_string_from_bytes("rdata", &answer.data);
-        },
-        DNS_RECORD_TYPE_SSHFP => {
-            if let Some(sshfp) = dns_log_sshfp(&answer) {
+        DNSRData::Str(bytes) => {
+            js.set_string_from_bytes("rdata", &bytes);
+        }
+        DNSRData::SSHFP(sshfp) => {
+            if let Some(sshfp) = dns_log_sshfp(&sshfp) {
                 js.set("sshfp", sshfp);
             }
         },

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -182,9 +182,9 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
                     }
                 },
                 DNSRData::SOA(ref soa) => {
-                    if soa.data.len() > 0 {
+                    if soa.mname.len() > 0 {
                         lua.pushstring("addr");
-                        lua.pushstring(&String::from_utf8_lossy(&soa.data));
+                        lua.pushstring(&String::from_utf8_lossy(&soa.mname));
                         lua.settable(-3);
                     }
                 },

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -165,17 +165,36 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
             lua.pushstring(&String::from_utf8_lossy(&answer.name));
             lua.settable(-3);
 
-            if answer.data.len() > 0 {
-                lua.pushstring("addr");
-                match answer.rrtype {
-                    DNS_RECORD_TYPE_A | DNS_RECORD_TYPE_AAAA => {
-                        lua.pushstring(&dns_print_addr(&answer.data));
+            match answer.data {
+                DNSRData::Addr(ref bytes) => {
+                    if bytes.len() > 0 {
+                        lua.pushstring("addr");
+                        lua.pushstring(&dns_print_addr(&bytes));
+                        lua.settable(-3);
                     }
-                    _ => {
-                        lua.pushstring(&String::from_utf8_lossy(&answer.data));
+                },
+                DNSRData::Str(ref bytes)
+                | DNSRData::Unknown(ref bytes) => {
+                    if bytes.len() > 0 {
+                        lua.pushstring("addr");
+                        lua.pushstring(&String::from_utf8_lossy(&bytes));
+                        lua.settable(-3);
                     }
-                }
-                lua.settable(-3);
+                },
+                DNSRData::SOA(ref soa) => {
+                    if soa.data.len() > 0 {
+                        lua.pushstring("addr");
+                        lua.pushstring(&String::from_utf8_lossy(&soa.data));
+                        lua.settable(-3);
+                    }
+                },
+                DNSRData::SSHFP(ref sshfp) => {
+                    if sshfp.data.len() > 0 {
+                        lua.pushstring("addr");
+                        lua.pushstring(&String::from_utf8_lossy(&sshfp.data));
+                        lua.settable(-3);
+                    }
+                },
             }
             lua.settable(-3);
         }


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
- [#2970](https://redmine.openinfosecfoundation.org/issues/2970)

Describe changes:
- Parses and logs the RDATA of a SOA (start of authority) DNS record. See [RFC 1035](https://tools.ietf.org/html/rfc1035#section-3.3.13).
- Added an enum `DNSRData` to represent rdata of various types. This used to be a single byte slice which didn't allow for parsing of more complex rdata types like SOA. This is not a one-to-one mapping of resource record types to reduce the number of code changed.
  - Should we create one `DNSRData` enum variant/struct for each known (i.e. logged) resource record type (preferred)?
  - Should we revert rdata back to a byte slice and do additional rdata parsing in log.rs like how SSHFP is being handled (not my preference)?
- Logs to an `"soa"` sub-object in the eve json event to maintain consistency with how sshfp is logged. Another option would be to log both sshfp and soa to an `"rdata"` sub-object.
- Modified the lua module to be compatible with the `DNSRData` enum without changing previous behaviour.
  - Should we be pushing the `"addr"` key-value pair as a lossy string for all records except A and AAAA? Pushing an `"rdata"` field only for known record types only would be more consistent with the `dns::log` module.
- Added [suricata-verify test](https://github.com/OISF/suricata-verify/pull/216).
- Looking forward to your initial feedback after which I will update the docs.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- passes on local docker buildbot

Example eve dns v2 json event before change:
```json
{
    "timestamp": "2017-01-27T16:03:18.709160+0000",
    "flow_id": 105378889499125,
    "pcap_cnt": 2,
    "event_type": "dns",
    "src_ip": "10.16.1.11",
    "src_port": 59465,
    "dest_ip": "8.8.4.4",
    "dest_port": 53,
    "proto": "UDP",
    "dns": {
        "version": 2,
        "type": "answer",
        "id": 33429,
        "flags": "8183",
        "qr": true,
        "rd": true,
        "ra": true,
        "rrname": "dne.oisf.net",
        "rrtype": "A",
        "rcode": "NXDOMAIN",
        "authorities": [
            {
                "rrname": "oisf.net",
                "rrtype": "SOA",
                "ttl": 899
            }
        ]
    },
    "pcap_filename": "data\/dns-udp-nxdomain-soa.pcap"
}
```

Example eve dns v2 json event after change:
```json
{
    "timestamp": "2017-01-27T16:03:18.709160+0000",
    "flow_id": 1103243673764341,
    "pcap_cnt": 2,
    "event_type": "dns",
    "src_ip": "10.16.1.11",
    "src_port": 59465,
    "dest_ip": "8.8.4.4",
    "dest_port": 53,
    "proto": "UDP",
    "dns": {
        "version": 2,
        "type": "answer",
        "id": 33429,
        "flags": "8183",
        "qr": true,
        "rd": true,
        "ra": true,
        "rrname": "dne.oisf.net",
        "rrtype": "A",
        "rcode": "NXDOMAIN",
        "authorities": [
            {
                "rrname": "oisf.net",
                "rrtype": "SOA",
                "ttl": 899,
                "soa": {
                    "mname": "ns-110.awsdns-13.com",
                    "rname": "awsdns-hostmaster.amazon.com",
                    "serial": 1,
                    "refresh": 7200,
                    "retry": 900,
                    "expire": 1209600,
                    "minimum": 86400
                }
            }
        ]
    },
    "pcap_filename": "data\/dns-udp-nxdomain-soa.pcap"
}
```