### PR TITLE
Fuzz fastpattern v1

### DIFF
--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -97,7 +97,11 @@ void SupportFastPatternForSigMatchList(int list_id, int priority)
             return;
         }
 
-        if (priority <= tmp->priority)
+        /* We need a strict check to be sure that the current list
+         * was not already registered
+         * and other lists with the same priority hide it.
+         */
+        if (priority < tmp->priority)
             break;
 
         ip = tmp;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3657

Describe changes:
- Fix insertion into linked list for `SupportFastPatternForSigMatchList` to be sure we do not insert twice the same list_id