### PR TITLE
http: adds debug check against too many warnings

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -87,6 +87,9 @@ static SCRadixTree *cfgtree;
 /** List of HTP configurations. */
 static HTPCfgRec cfglist;
 
+/** Limit to the number of libhtp messages that can be handled */
+#define HTP_MAX_MESSAGES 512
+
 SC_ATOMIC_DECLARE(uint32_t, htp_config_flags);
 
 #ifdef DEBUG
@@ -689,6 +692,11 @@ static void HTPHandleError(HtpState *s, const uint8_t dir)
 
     size_t size = htp_list_size(s->conn->messages);
     size_t msg;
+    if(size >= HTP_MAX_MESSAGES) {
+        DEBUG_VALIDATE_BUG_ON("Too many libhtp messages");
+        // ignore further messages
+        return;
+    }
 
     for (msg = s->htp_messages_offset; msg < size; msg++) {
         htp_log_t *log = htp_list_get(s->conn->messages, msg);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes: various fixes found by fuzzing
- adds a debug guard for HTTP against too many warnings from libhtp (and having unsigned overflow causing bad performance)

Follows #4828 by taking comments into account