### PR TITLE
detect/lua: Cleanup thread contextual info when needed

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1401,7 +1401,7 @@ static void AppLayerProtoDetectPMFreeSignature(AppLayerProtoDetectPMSignature *s
     if (sig == NULL)
         SCReturn;
     if (sig->cd)
-        DetectContentFree(sig->cd);
+        DetectContentFree(NULL, sig->cd);
     SCFree(sig);
     SCReturn;
 }
@@ -1480,7 +1480,7 @@ static int AppLayerProtoDetectPMRegisterPattern(uint8_t ipproto, AppProto alprot
 
     goto end;
  error:
-    DetectContentFree(cd);
+    DetectContentFree(NULL, cd);
     ret = -1;
  end:
     SCReturnInt(ret);

--- a/src/detect-app-layer-event.h
+++ b/src/detect-app-layer-event.h
@@ -34,7 +34,7 @@ typedef struct DetectAppLayerEventData_ {
     char *arg;
 } DetectAppLayerEventData;
 
-int DetectAppLayerEventPrepare(Signature *s);
+int DetectAppLayerEventPrepare(DetectEngineCtx *de_ctx, Signature *s);
 void DetectAppLayerEventRegister(void);
 
 #endif /* __DETECT_APP_LAYER_EVENT_H__ */

--- a/src/detect-app-layer-protocol.c
+++ b/src/detect-app-layer-protocol.c
@@ -176,7 +176,7 @@ error:
     return -1;
 }
 
-static void DetectAppLayerProtocolFree(void *ptr)
+static void DetectAppLayerProtocolFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCFree(ptr);
     return;
@@ -288,7 +288,7 @@ static int DetectAppLayerProtocolTest01(void)
     FAIL_IF_NULL(data);
     FAIL_IF(data->alproto != ALPROTO_HTTP);
     FAIL_IF(data->negated != 0);
-    DetectAppLayerProtocolFree(data);
+    DetectAppLayerProtocolFree(NULL, data);
     PASS;
 }
 
@@ -298,7 +298,7 @@ static int DetectAppLayerProtocolTest02(void)
     FAIL_IF_NULL(data);
     FAIL_IF(data->alproto != ALPROTO_HTTP);
     FAIL_IF(data->negated == 0);
-    DetectAppLayerProtocolFree(data);
+    DetectAppLayerProtocolFree(NULL, data);
     PASS;
 }
 
@@ -459,7 +459,7 @@ static int DetectAppLayerProtocolTest11(void)
     FAIL_IF_NULL(data);
     FAIL_IF(data->alproto != ALPROTO_FAILED);
     FAIL_IF(data->negated != 0);
-    DetectAppLayerProtocolFree(data);
+    DetectAppLayerProtocolFree(NULL, data);
     PASS;
 }
 
@@ -469,7 +469,7 @@ static int DetectAppLayerProtocolTest12(void)
     FAIL_IF_NULL(data);
     FAIL_IF(data->alproto != ALPROTO_FAILED);
     FAIL_IF(data->negated == 0);
-    DetectAppLayerProtocolFree(data);
+    DetectAppLayerProtocolFree(NULL, data);
     PASS;
 }
 

--- a/src/detect-asn1.c
+++ b/src/detect-asn1.c
@@ -46,7 +46,7 @@ static int DetectAsn1Match(DetectEngineThreadCtx *, Packet *,
                      const Signature *, const SigMatchCtx *);
 static int DetectAsn1Setup (DetectEngineCtx *, Signature *, const char *);
 static void DetectAsn1RegisterTests(void);
-static void DetectAsn1Free(void *);
+static void DetectAsn1Free(DetectEngineCtx *, void *);
 
 /**
  * \brief Registration function for asn1
@@ -321,7 +321,7 @@ static int DetectAsn1Setup(DetectEngineCtx *de_ctx, Signature *s, const char *as
 
 error:
     if (ad != NULL)
-        DetectAsn1Free(ad);
+        DetectAsn1Free(de_ctx, ad);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -333,7 +333,7 @@ error:
  *
  * \param ad pointer to DetectAsn1Data
  */
-static void DetectAsn1Free(void *ptr)
+static void DetectAsn1Free(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectAsn1Data *ad = (DetectAsn1Data *)ptr;
     SCFree(ad);
@@ -355,7 +355,7 @@ static int DetectAsn1TestParse01(void)
         if (ad->oversize_length == 1024 && (ad->flags & ASN1_OVERSIZE_LEN)) {
             result = 1;
         }
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
     }
 
     return result;
@@ -373,7 +373,7 @@ static int DetectAsn1TestParse02(void)
     ad = DetectAsn1Parse(str);
     if (ad != NULL && ad->absolute_offset == 1024
         && (ad->flags & ASN1_ABSOLUTE_OFFSET)) {
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
         result = 1;
     }
 
@@ -392,7 +392,7 @@ static int DetectAsn1TestParse03(void)
     ad = DetectAsn1Parse(str);
     if (ad != NULL && ad->relative_offset == 1024
         && (ad->flags & ASN1_RELATIVE_OFFSET)) {
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
         result = 1;
     }
 
@@ -410,7 +410,7 @@ static int DetectAsn1TestParse04(void)
 
     ad = DetectAsn1Parse(str);
     if (ad != NULL && (ad->flags & ASN1_BITSTRING_OVF)) {
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
         result = 1;
     }
 
@@ -428,7 +428,7 @@ static int DetectAsn1TestParse05(void)
 
     ad = DetectAsn1Parse(str);
     if (ad != NULL && (ad->flags & ASN1_DOUBLE_OVF)) {
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
         result = 1;
     }
 
@@ -446,7 +446,7 @@ static int DetectAsn1TestParse06(void)
 
     ad = DetectAsn1Parse(str);
     if (ad != NULL) {
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
         result = 0;
     }
 
@@ -464,7 +464,7 @@ static int DetectAsn1TestParse07(void)
 
     ad = DetectAsn1Parse(str);
     if (ad != NULL) {
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
         result = 0;
     }
 
@@ -482,7 +482,7 @@ static int DetectAsn1TestParse08(void)
 
     ad = DetectAsn1Parse(str);
     if (ad != NULL) {
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
         result = 0;
     }
 
@@ -503,7 +503,7 @@ static int DetectAsn1TestParse09(void)
     fd = DetectAsn1Parse(str);
     if (fd != NULL) {
         result = 0;
-        DetectAsn1Free(fd);
+        DetectAsn1Free(NULL, fd);
     }
 
     return result;
@@ -521,7 +521,7 @@ static int DetectAsn1TestParse10(void)
     fd = DetectAsn1Parse(str);
     if (fd != NULL) {
         result = 0;
-        DetectAsn1Free(fd);
+        DetectAsn1Free(NULL, fd);
     }
 
     return result;
@@ -542,7 +542,7 @@ static int DetectAsn1TestParse11(void)
         && ad->relative_offset == 10
         && (ad->flags & ASN1_RELATIVE_OFFSET))
     {
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
         result = 1;
     }
 
@@ -564,7 +564,7 @@ static int DetectAsn1TestParse12(void)
         && ad->absolute_offset == 10
         && (ad->flags & ASN1_ABSOLUTE_OFFSET))
     {
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
         result = 1;
     }
 
@@ -587,7 +587,7 @@ static int DetectAsn1TestParse13(void)
         && ad->absolute_offset == 10
         && (ad->flags & ASN1_ABSOLUTE_OFFSET))
     {
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
         result = 1;
     }
 
@@ -612,7 +612,7 @@ static int DetectAsn1TestParse14(void)
         && ad->absolute_offset == 10
         && (ad->flags & ASN1_ABSOLUTE_OFFSET))
     {
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
         result = 1;
     }
 
@@ -637,7 +637,7 @@ static int DetectAsn1TestParse15(void)
         && ad->relative_offset == 10
         && (ad->flags & ASN1_RELATIVE_OFFSET))
     {
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
         result = 1;
     }
 
@@ -697,7 +697,7 @@ static int DetectAsn1Test01(void)
     FAIL_IF(result != 1);
 
     SCAsn1CtxDestroy(ac);
-    DetectAsn1Free(ad);
+    DetectAsn1Free(NULL, ad);
 
     PASS;
 }
@@ -763,7 +763,7 @@ static int DetectAsn1Test02(void)
         }
 
         SCAsn1CtxDestroy(ac);
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
 
     }
 
@@ -818,7 +818,7 @@ static int DetectAsn1Test03(void)
         }
 
         SCAsn1CtxDestroy(ac);
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
 
     }
 
@@ -877,7 +877,7 @@ static int DetectAsn1Test04(void)
         }
 
         SCAsn1CtxDestroy(ac);
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
 
     }
 
@@ -950,7 +950,7 @@ static int DetectAsn1Test05(void)
         }
 
         SCAsn1CtxDestroy(ac);
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
 
     }
 
@@ -1020,7 +1020,7 @@ static int DetectAsn1Test06(void)
         }
 
         SCAsn1CtxDestroy(ac);
-        DetectAsn1Free(ad);
+        DetectAsn1Free(NULL, ad);
 
     }
 

--- a/src/detect-base64-decode.c
+++ b/src/detect-base64-decode.c
@@ -33,7 +33,7 @@ static const char decode_pattern[] = "\\s*(bytes\\s+(\\d+),?)?"
 static DetectParseRegex decode_pcre;
 
 static int DetectBase64DecodeSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectBase64DecodeFree(void *);
+static void DetectBase64DecodeFree(DetectEngineCtx *, void *);
 static void DetectBase64DecodeRegisterTests(void);
 
 void DetectBase64DecodeRegister(void)
@@ -239,7 +239,7 @@ error:
     return -1;
 }
 
-static void DetectBase64DecodeFree(void *ptr)
+static void DetectBase64DecodeFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectBase64Decode *data = ptr;
     SCFree(data);

--- a/src/detect-bsize.c
+++ b/src/detect-bsize.c
@@ -38,7 +38,7 @@
 
 /*prototypes*/
 static int DetectBsizeSetup (DetectEngineCtx *, Signature *, const char *);
-static void DetectBsizeFree (void *);
+static void DetectBsizeFree (DetectEngineCtx *, void *);
 #ifdef UNITTESTS
 static void DetectBsizeRegisterTests (void);
 #endif
@@ -302,7 +302,7 @@ static int DetectBsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
     SCReturnInt(0);
 
 error:
-    DetectBsizeFree(bsz);
+    DetectBsizeFree(de_ctx, bsz);
     SCReturnInt(-1);
 }
 
@@ -311,7 +311,7 @@ error:
  *
  * \param ptr pointer to DetectBsizeData
  */
-void DetectBsizeFree(void *ptr)
+void DetectBsizeFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr == NULL)
         return;

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -90,7 +90,7 @@ static DetectParseRegex parse_regex;
 
 static int DetectByteExtractSetup(DetectEngineCtx *, Signature *, const char *);
 static void DetectByteExtractRegisterTests(void);
-static void DetectByteExtractFree(void *);
+static void DetectByteExtractFree(DetectEngineCtx *, void *);
 
 /**
  * \brief Registers the keyword handlers for the "byte_extract" keyword.
@@ -202,12 +202,13 @@ int DetectByteExtractDoMatch(DetectEngineThreadCtx *det_ctx, const SigMatchData 
  * \internal
  * \brief Used to parse byte_extract arg.
  *
+ * \param de_ctx Pointer to the detection engine context
  * \arg The argument to parse.
  *
  * \param bed On success an instance containing the parsed data.
  *            On failure, NULL.
  */
-static inline DetectByteExtractData *DetectByteExtractParse(const char *arg)
+static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_ctx, const char *arg)
 {
     DetectByteExtractData *bed = NULL;
 #undef MAX_SUBSTRINGS
@@ -488,7 +489,7 @@ static inline DetectByteExtractData *DetectByteExtractParse(const char *arg)
     return bed;
  error:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(de_ctx, bed);
     return NULL;
 }
 
@@ -512,7 +513,7 @@ static int DetectByteExtractSetup(DetectEngineCtx *de_ctx, Signature *s, const c
     DetectByteExtractData *data = NULL;
     int ret = -1;
 
-    data = DetectByteExtractParse(arg);
+    data = DetectByteExtractParse(de_ctx, arg);
     if (data == NULL)
         goto error;
 
@@ -612,7 +613,7 @@ static int DetectByteExtractSetup(DetectEngineCtx *de_ctx, Signature *s, const c
     ret = 0;
     return ret;
  error:
-    DetectByteExtractFree(data);
+    DetectByteExtractFree(de_ctx, data);
     return ret;
 }
 
@@ -621,7 +622,7 @@ static int DetectByteExtractSetup(DetectEngineCtx *de_ctx, Signature *s, const c
  *
  * \param ptr Instance of DetectByteExtractData to be freed.
  */
-static void DetectByteExtractFree(void *ptr)
+static void DetectByteExtractFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr != NULL) {
         DetectByteExtractData *bed = ptr;
@@ -671,7 +672,7 @@ static int DetectByteExtractTest01(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one");
     if (bed == NULL)
         goto end;
 
@@ -689,7 +690,7 @@ static int DetectByteExtractTest01(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -697,7 +698,7 @@ static int DetectByteExtractTest02(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, relative");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, relative");
     if (bed == NULL)
         goto end;
 
@@ -715,7 +716,7 @@ static int DetectByteExtractTest02(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -723,7 +724,7 @@ static int DetectByteExtractTest03(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, multiplier 10");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, multiplier 10");
     if (bed == NULL)
         goto end;
 
@@ -741,7 +742,7 @@ static int DetectByteExtractTest03(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -749,7 +750,7 @@ static int DetectByteExtractTest04(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, relative, multiplier 10");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, relative, multiplier 10");
     if (bed == NULL)
         goto end;
 
@@ -768,7 +769,7 @@ static int DetectByteExtractTest04(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -776,7 +777,7 @@ static int DetectByteExtractTest05(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, big");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, big");
     if (bed == NULL)
         goto end;
 
@@ -794,7 +795,7 @@ static int DetectByteExtractTest05(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -802,7 +803,7 @@ static int DetectByteExtractTest06(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, little");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, little");
     if (bed == NULL)
         goto end;
 
@@ -820,7 +821,7 @@ static int DetectByteExtractTest06(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -828,7 +829,7 @@ static int DetectByteExtractTest07(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, dce");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, dce");
     if (bed == NULL)
         goto end;
 
@@ -846,7 +847,7 @@ static int DetectByteExtractTest07(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -854,7 +855,7 @@ static int DetectByteExtractTest08(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, string, hex");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, string, hex");
     if (bed == NULL)
         goto end;
 
@@ -872,7 +873,7 @@ static int DetectByteExtractTest08(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -880,7 +881,7 @@ static int DetectByteExtractTest09(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, string, oct");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, string, oct");
     if (bed == NULL)
         goto end;
 
@@ -898,7 +899,7 @@ static int DetectByteExtractTest09(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -906,7 +907,7 @@ static int DetectByteExtractTest10(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, string, dec");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, string, dec");
     if (bed == NULL)
         goto end;
 
@@ -924,7 +925,7 @@ static int DetectByteExtractTest10(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -932,7 +933,7 @@ static int DetectByteExtractTest11(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, align 4");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4");
     if (bed == NULL)
         goto end;
 
@@ -950,7 +951,7 @@ static int DetectByteExtractTest11(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -958,7 +959,7 @@ static int DetectByteExtractTest12(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, align 4, relative");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, relative");
     if (bed == NULL)
         goto end;
 
@@ -977,7 +978,7 @@ static int DetectByteExtractTest12(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -985,7 +986,7 @@ static int DetectByteExtractTest13(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, align 4, relative, big");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, relative, big");
     if (bed == NULL)
         goto end;
 
@@ -1005,7 +1006,7 @@ static int DetectByteExtractTest13(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1013,7 +1014,7 @@ static int DetectByteExtractTest14(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, align 4, relative, dce");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, relative, dce");
     if (bed == NULL)
         goto end;
 
@@ -1033,7 +1034,7 @@ static int DetectByteExtractTest14(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1041,7 +1042,7 @@ static int DetectByteExtractTest15(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, align 4, relative, little");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, relative, little");
     if (bed == NULL)
         goto end;
 
@@ -1061,7 +1062,7 @@ static int DetectByteExtractTest15(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1069,7 +1070,7 @@ static int DetectByteExtractTest16(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, align 4, relative, little, multiplier 2");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, relative, little, multiplier 2");
     if (bed == NULL)
         goto end;
 
@@ -1090,7 +1091,7 @@ static int DetectByteExtractTest16(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1098,7 +1099,7 @@ static int DetectByteExtractTest17(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, align 4, "
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
                                                         "relative, little, "
                                                         "multiplier 2, string hex");
     if (bed != NULL)
@@ -1107,7 +1108,7 @@ static int DetectByteExtractTest17(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1115,7 +1116,7 @@ static int DetectByteExtractTest18(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, align 4, "
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
                                                         "relative, little, "
                                                         "multiplier 2, "
                                                         "relative");
@@ -1125,7 +1126,7 @@ static int DetectByteExtractTest18(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1133,7 +1134,7 @@ static int DetectByteExtractTest19(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, align 4, "
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
                                                         "relative, little, "
                                                         "multiplier 2, "
                                                         "little");
@@ -1143,7 +1144,7 @@ static int DetectByteExtractTest19(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1151,7 +1152,7 @@ static int DetectByteExtractTest20(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, align 4, "
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
                                                         "relative, "
                                                         "multiplier 2, "
                                                         "align 2");
@@ -1161,7 +1162,7 @@ static int DetectByteExtractTest20(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1169,7 +1170,7 @@ static int DetectByteExtractTest21(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, align 4, "
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
                                                         "multiplier 2, "
                                                         "relative, "
                                                         "multiplier 2");
@@ -1179,7 +1180,7 @@ static int DetectByteExtractTest21(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1187,7 +1188,7 @@ static int DetectByteExtractTest22(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, align 4, "
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
                                                         "string hex, "
                                                         "relative, "
                                                         "string hex");
@@ -1197,7 +1198,7 @@ static int DetectByteExtractTest22(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1205,7 +1206,7 @@ static int DetectByteExtractTest23(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, align 4, "
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
                                                         "string hex, "
                                                         "relative, "
                                                         "string oct");
@@ -1215,7 +1216,7 @@ static int DetectByteExtractTest23(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1223,7 +1224,7 @@ static int DetectByteExtractTest24(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("24, 2, one, align 4, "
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "24, 2, one, align 4, "
                                                         "string hex, "
                                                         "relative");
     if (bed != NULL)
@@ -1232,7 +1233,7 @@ static int DetectByteExtractTest24(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1240,7 +1241,7 @@ static int DetectByteExtractTest25(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("9, 2, one, align 4, "
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "9, 2, one, align 4, "
                                                         "little, "
                                                         "relative");
     if (bed != NULL)
@@ -1249,7 +1250,7 @@ static int DetectByteExtractTest25(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1257,7 +1258,7 @@ static int DetectByteExtractTest26(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, align 4, "
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
                                                         "little, "
                                                         "relative, "
                                                         "multiplier 65536");
@@ -1267,7 +1268,7 @@ static int DetectByteExtractTest26(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1275,7 +1276,7 @@ static int DetectByteExtractTest27(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, align 4, "
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
                                                         "little, "
                                                         "relative, "
                                                         "multiplier 0");
@@ -1285,7 +1286,7 @@ static int DetectByteExtractTest27(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1293,14 +1294,14 @@ static int DetectByteExtractTest28(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("23, 2, one, string, oct");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "23, 2, one, string, oct");
     if (bed == NULL)
         goto end;
 
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1308,14 +1309,14 @@ static int DetectByteExtractTest29(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("24, 2, one, string, oct");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "24, 2, one, string, oct");
     if (bed != NULL)
         goto end;
 
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1323,14 +1324,14 @@ static int DetectByteExtractTest30(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("20, 2, one, string, dec");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "20, 2, one, string, dec");
     if (bed == NULL)
         goto end;
 
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1338,14 +1339,14 @@ static int DetectByteExtractTest31(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("21, 2, one, string, dec");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "21, 2, one, string, dec");
     if (bed != NULL)
         goto end;
 
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1353,14 +1354,14 @@ static int DetectByteExtractTest32(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("14, 2, one, string, hex");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "14, 2, one, string, hex");
     if (bed == NULL)
         goto end;
 
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -1368,14 +1369,14 @@ static int DetectByteExtractTest33(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("15, 2, one, string, hex");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "15, 2, one, string, hex");
     if (bed != NULL)
         goto end;
 
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -4657,7 +4658,7 @@ static int DetectByteExtractTest63(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, -2, one");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, -2, one");
     if (bed == NULL)
         goto end;
 
@@ -4675,7 +4676,7 @@ static int DetectByteExtractTest63(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 
@@ -4683,7 +4684,7 @@ static int DetectByteExtractTestParseNoBase(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse("4, 2, one, string");
+    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, string");
     if (bed == NULL)
         goto end;
 
@@ -4715,7 +4716,7 @@ static int DetectByteExtractTestParseNoBase(void)
     result = 1;
  end:
     if (bed != NULL)
-        DetectByteExtractFree(bed);
+        DetectByteExtractFree(NULL, bed);
     return result;
 }
 

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -61,9 +61,9 @@ static DetectParseRegex parse_regex;
 
 static int DetectBytejumpMatch(DetectEngineThreadCtx *det_ctx,
                         Packet *p, const Signature *s, const SigMatchCtx *ctx);
-static DetectBytejumpData *DetectBytejumpParse(const char *optstr, char **offset);
+static DetectBytejumpData *DetectBytejumpParse(DetectEngineCtx *de_ctx, const char *optstr, char **offset);
 static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char *optstr);
-static void DetectBytejumpFree(void *ptr);
+static void DetectBytejumpFree(DetectEngineCtx*, void *ptr);
 static void DetectBytejumpRegisterTests(void);
 
 void DetectBytejumpRegister (void)
@@ -310,7 +310,7 @@ static int DetectBytejumpMatch(DetectEngineThreadCtx *det_ctx,
     return 1;
 }
 
-static DetectBytejumpData *DetectBytejumpParse(const char *optstr, char **offset)
+static DetectBytejumpData *DetectBytejumpParse(DetectEngineCtx *de_ctx, const char *optstr, char **offset)
 {
     DetectBytejumpData *data = NULL;
     char args[10][64];
@@ -498,7 +498,7 @@ error:
         *offset = NULL;
     }
     if (data != NULL)
-        DetectBytejumpFree(data);
+        DetectBytejumpFree(de_ctx, data);
     return NULL;
 }
 
@@ -510,7 +510,7 @@ static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char
     char *offset = NULL;
     int ret = -1;
 
-    data = DetectBytejumpParse(optstr, &offset);
+    data = DetectBytejumpParse(de_ctx, optstr, &offset);
     if (data == NULL)
         goto error;
 
@@ -616,7 +616,7 @@ static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char
     if (offset != NULL) {
         SCFree(offset);
     }
-    DetectBytejumpFree(data);
+    DetectBytejumpFree(de_ctx, data);
     return ret;
 }
 
@@ -625,7 +625,7 @@ static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char
  *
  * \param data pointer to DetectBytejumpData
  */
-static void DetectBytejumpFree(void *ptr)
+static void DetectBytejumpFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr == NULL)
         return;
@@ -649,9 +649,9 @@ static int DetectBytejumpTestParse01(void)
 {
     int result = 0;
     DetectBytejumpData *data = NULL;
-    data = DetectBytejumpParse("4,0", NULL);
+    data = DetectBytejumpParse(NULL, "4,0", NULL);
     if (data != NULL) {
-        DetectBytejumpFree(data);
+        DetectBytejumpFree(NULL, data);
         result = 1;
     }
 
@@ -665,7 +665,7 @@ static int DetectBytejumpTestParse02(void)
 {
     int result = 0;
     DetectBytejumpData *data = NULL;
-    data = DetectBytejumpParse("4, 0", NULL);
+    data = DetectBytejumpParse(NULL, "4, 0", NULL);
     if (data != NULL) {
         if (   (data->nbytes == 4)
             && (data->offset == 0)
@@ -676,7 +676,7 @@ static int DetectBytejumpTestParse02(void)
         {
             result = 1;
         }
-        DetectBytejumpFree(data);
+        DetectBytejumpFree(NULL, data);
     }
 
     return result;
@@ -689,7 +689,7 @@ static int DetectBytejumpTestParse03(void)
 {
     int result = 0;
     DetectBytejumpData *data = NULL;
-    data = DetectBytejumpParse(" 4,0 , relative , little, string, "
+    data = DetectBytejumpParse(NULL, " 4,0 , relative , little, string, "
                                "dec, align, from_beginning", NULL);
     if (data != NULL) {
         if (   (data->nbytes == 4)
@@ -705,7 +705,7 @@ static int DetectBytejumpTestParse03(void)
         {
             result = 1;
         }
-        DetectBytejumpFree(data);
+        DetectBytejumpFree(NULL, data);
     }
 
     return result;
@@ -721,7 +721,7 @@ static int DetectBytejumpTestParse04(void)
 {
     int result = 0;
     DetectBytejumpData *data = NULL;
-    data = DetectBytejumpParse(" 4,0 , relative , little, string, "
+    data = DetectBytejumpParse(NULL, " 4,0 , relative , little, string, "
                                "dec, align, from_beginning , "
                                "multiplier 2 , post_offset -16 ", NULL);
     if (data != NULL) {
@@ -738,7 +738,7 @@ static int DetectBytejumpTestParse04(void)
         {
             result = 1;
         }
-        DetectBytejumpFree(data);
+        DetectBytejumpFree(NULL, data);
     }
 
     return result;
@@ -751,7 +751,7 @@ static int DetectBytejumpTestParse05(void)
 {
     int result = 0;
     DetectBytejumpData *data = NULL;
-    data = DetectBytejumpParse(" 4,0 , relative , little, dec, "
+    data = DetectBytejumpParse(NULL, " 4,0 , relative , little, dec, "
                                "align, from_beginning", NULL);
     if (data == NULL) {
         result = 1;
@@ -767,7 +767,7 @@ static int DetectBytejumpTestParse06(void)
 {
     int result = 0;
     DetectBytejumpData *data = NULL;
-    data = DetectBytejumpParse("9, 0", NULL);
+    data = DetectBytejumpParse(NULL, "9, 0", NULL);
     if (data == NULL) {
         result = 1;
     }
@@ -782,7 +782,7 @@ static int DetectBytejumpTestParse07(void)
 {
     int result = 0;
     DetectBytejumpData *data = NULL;
-    data = DetectBytejumpParse("24, 0, string, dec", NULL);
+    data = DetectBytejumpParse(NULL, "24, 0, string, dec", NULL);
     if (data == NULL) {
         result = 1;
     }
@@ -797,7 +797,7 @@ static int DetectBytejumpTestParse08(void)
 {
     int result = 0;
     DetectBytejumpData *data = NULL;
-    data = DetectBytejumpParse("4, 0xffffffffffffffff", NULL);
+    data = DetectBytejumpParse(NULL, "4, 0xffffffffffffffff", NULL);
     if (data == NULL) {
         result = 1;
     }
@@ -817,7 +817,7 @@ static int DetectBytejumpTestParse09(void)
     int result = 1;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_DCERPC) < 0) {
-        SigFree(s);
+        SigFree(NULL, s);
         return 0;
     }
 
@@ -837,7 +837,7 @@ static int DetectBytejumpTestParse09(void)
     result &= (DetectBytejumpSetup(NULL, s, "4,0, from_beginning, dce") == -1);
     result &= (s->sm_lists[g_dce_stub_data_buffer_id] == NULL && s->sm_lists[DETECT_SM_LIST_PMATCH] != NULL);
 
-    SigFree(s);
+    SigFree(NULL, s);
     return result;
 }
 

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -70,7 +70,7 @@ static DetectParseRegex parse_regex;
 static int DetectBytetestMatch(DetectEngineThreadCtx *det_ctx,
                         Packet *p, const Signature *s, const SigMatchCtx *ctx);
 static int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, const char *optstr);
-static void DetectBytetestFree(void *ptr);
+static void DetectBytetestFree(DetectEngineCtx *, void *ptr);
 static void DetectBytetestRegisterTests(void);
 
 void DetectBytetestRegister (void)
@@ -642,7 +642,7 @@ static int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         SCFree(offset);
     if (value)
         SCFree(value);
-    DetectBytetestFree(data);
+    DetectBytetestFree(de_ctx, data);
     return ret;
 }
 
@@ -651,7 +651,7 @@ static int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, const char
  *
  * \param data pointer to DetectBytetestData
  */
-static void DetectBytetestFree(void *ptr)
+static void DetectBytetestFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr == NULL)
         return;
@@ -679,7 +679,7 @@ static int DetectBytetestTestParse01(void)
     DetectBytetestData *data = NULL;
     data = DetectBytetestParse("4, =, 1 , 0", NULL, NULL);
     if (data != NULL) {
-        DetectBytetestFree(data);
+        DetectBytetestFree(NULL, data);
         result = 1;
     }
 
@@ -704,7 +704,7 @@ static int DetectBytetestTestParse02(void)
         {
             result = 1;
         }
-        DetectBytetestFree(data);
+        DetectBytetestFree(NULL, data);
     }
 
     return result;
@@ -729,7 +729,7 @@ static int DetectBytetestTestParse03(void)
         {
             result = 1;
         }
-        DetectBytetestFree(data);
+        DetectBytetestFree(NULL, data);
     }
 
     return result;
@@ -754,7 +754,7 @@ static int DetectBytetestTestParse04(void)
         {
             result = 1;
         }
-        DetectBytetestFree(data);
+        DetectBytetestFree(NULL, data);
     }
 
     return result;
@@ -778,7 +778,7 @@ static int DetectBytetestTestParse05(void)
         {
             result = 1;
         }
-        DetectBytetestFree(data);
+        DetectBytetestFree(NULL, data);
     }
 
     return result;
@@ -802,7 +802,7 @@ static int DetectBytetestTestParse06(void)
         {
             result = 1;
         }
-        DetectBytetestFree(data);
+        DetectBytetestFree(NULL, data);
     }
 
     return result;
@@ -826,7 +826,7 @@ static int DetectBytetestTestParse07(void)
         {
             result = 1;
         }
-        DetectBytetestFree(data);
+        DetectBytetestFree(NULL, data);
     }
 
     return result;
@@ -850,7 +850,7 @@ static int DetectBytetestTestParse08(void)
         {
             result = 1;
         }
-        DetectBytetestFree(data);
+        DetectBytetestFree(NULL, data);
     }
 
     return result;
@@ -874,7 +874,7 @@ static int DetectBytetestTestParse09(void)
         {
             result = 1;
         }
-        DetectBytetestFree(data);
+        DetectBytetestFree(NULL, data);
     }
 
     return result;
@@ -899,7 +899,7 @@ static int DetectBytetestTestParse10(void)
         {
             result = 1;
         }
-        DetectBytetestFree(data);
+        DetectBytetestFree(NULL, data);
     }
 
     return result;
@@ -926,7 +926,7 @@ static int DetectBytetestTestParse11(void)
         {
             result = 1;
         }
-        DetectBytetestFree(data);
+        DetectBytetestFree(NULL, data);
     }
 
     return result;
@@ -980,7 +980,7 @@ static int DetectBytetestTestParse14(void)
         {
             result = 1;
         }
-        DetectBytetestFree(data);
+        DetectBytetestFree(NULL, data);
     }
 
     return result;
@@ -1032,7 +1032,7 @@ static int DetectBytetestTestParse17(void)
              (data->flags & DETECT_BYTETEST_DCE) ) {
             result = 1;
         }
-        DetectBytetestFree(data);
+        DetectBytetestFree(NULL, data);
     }
 
     return result;
@@ -1054,7 +1054,7 @@ static int DetectBytetestTestParse18(void)
              !(data->flags & DETECT_BYTETEST_DCE) ) {
             result = 1;
         }
-        DetectBytetestFree(data);
+        DetectBytetestFree(NULL, data);
     }
 
     return result;
@@ -1072,7 +1072,7 @@ static int DetectBytetestTestParse19(void)
     int result = 1;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_DCERPC) < 0) {
-        SigFree(s);
+        SigFree(NULL, s);
         return 0;
     }
 
@@ -1084,7 +1084,7 @@ static int DetectBytetestTestParse19(void)
     result &= (DetectBytetestSetup(NULL, s, "1,=,1,6,oct,dce") == -1);
     result &= (DetectBytetestSetup(NULL, s, "1,=,1,6,dec,dce") == -1);
 
-    SigFree(s);
+    SigFree(NULL, s);
     return result;
 }
 
@@ -1383,7 +1383,7 @@ static int DetectBytetestTestParse23(void)
     FAIL_IF_NOT(data->bitmask == 0xf8);
     FAIL_IF_NOT(data->bitmask_shift_count == 3);
 
-    DetectBytetestFree(data);
+    DetectBytetestFree(NULL, data);
 
     PASS;
 }
@@ -1408,7 +1408,7 @@ static int DetectBytetestTestParse24(void)
     FAIL_IF_NOT(data->bitmask == 0xf8);
     FAIL_IF_NOT(data->bitmask_shift_count == 3);
 
-    DetectBytetestFree(data);
+    DetectBytetestFree(NULL, data);
 
     PASS;
 }

--- a/src/detect-cipservice.c
+++ b/src/detect-cipservice.c
@@ -40,7 +40,7 @@
  * \brief CIP Service Detect Prototypes
  */
 static int DetectCipServiceSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectCipServiceFree(void *);
+static void DetectCipServiceFree(DetectEngineCtx *, void *);
 static void DetectCipServiceRegisterTests(void);
 static int g_cip_buffer_id = 0;
 
@@ -227,7 +227,7 @@ static int DetectCipServiceSetup(DetectEngineCtx *de_ctx, Signature *s,
 
 error:
     if (cipserviced != NULL)
-        DetectCipServiceFree(cipserviced);
+        DetectCipServiceFree(de_ctx, cipserviced);
     if (sm != NULL)
         SCFree(sm);
     SCReturnInt(-1);
@@ -238,7 +238,7 @@ error:
  *
  * \param ptr pointer to DetectCipServiceData
  */
-static void DetectCipServiceFree(void *ptr)
+static void DetectCipServiceFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectCipServiceData *cipserviced = (DetectCipServiceData *) ptr;
     SCFree(cipserviced);
@@ -255,7 +255,7 @@ static int DetectCipServiceParseTest01 (void)
     cipserviced = DetectCipServiceParse("7");
     FAIL_IF_NULL(cipserviced);
     FAIL_IF(cipserviced->cipservice != 7);
-    DetectCipServiceFree(cipserviced);
+    DetectCipServiceFree(NULL, cipserviced);
     PASS;
 }
 
@@ -295,7 +295,7 @@ static void DetectCipServiceRegisterTests(void)
  * \brief ENIP Commond Detect Prototypes
  */
 static int DetectEnipCommandSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectEnipCommandFree(void *);
+static void DetectEnipCommandFree(DetectEngineCtx *, void *);
 static void DetectEnipCommandRegisterTests(void);
 static int g_enip_buffer_id = 0;
 
@@ -398,7 +398,7 @@ static int DetectEnipCommandSetup(DetectEngineCtx *de_ctx, Signature *s,
 
 error:
     if (enipcmdd != NULL)
-        DetectEnipCommandFree(enipcmdd);
+        DetectEnipCommandFree(de_ctx, enipcmdd);
     if (sm != NULL)
         SCFree(sm);
     SCReturnInt(-1);
@@ -409,7 +409,7 @@ error:
  *
  * \param ptr pointer to DetectEnipCommandData
  */
-static void DetectEnipCommandFree(void *ptr)
+static void DetectEnipCommandFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectEnipCommandData *enipcmdd = (DetectEnipCommandData *) ptr;
     SCFree(enipcmdd);
@@ -429,7 +429,7 @@ static int DetectEnipCommandParseTest01 (void)
     FAIL_IF_NULL(enipcmdd);
     FAIL_IF_NOT(enipcmdd->enipcommand == 1);
 
-    DetectEnipCommandFree(enipcmdd);
+    DetectEnipCommandFree(NULL, enipcmdd);
     PASS;
 }
 

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -347,7 +347,7 @@ int DetectContentSetup(DetectEngineCtx *de_ctx, Signature *s, const char *conten
     return 0;
 
 error:
-    DetectContentFree(cd);
+    DetectContentFree(de_ctx, cd);
     return -1;
 }
 
@@ -356,7 +356,7 @@ error:
  *
  * \param cd pointer to DetectContentData
  */
-void DetectContentFree(void *ptr)
+void DetectContentFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCEnter();
     DetectContentData *cd = (DetectContentData *)ptr;
@@ -753,7 +753,7 @@ static int DetectContentParseTest01 (void)
             PrintRawUriFp(stdout,cd->content,cd->content_len);
             SCLogDebug(": ");
             result = 0;
-            DetectContentFree(cd);
+            DetectContentFree(NULL, cd);
         }
     } else {
         SCLogDebug("expected %s got NULL: ", teststringparsed);
@@ -784,7 +784,7 @@ static int DetectContentParseTest02 (void)
             PrintRawUriFp(stdout,cd->content,cd->content_len);
             SCLogDebug(": ");
             result = 0;
-            DetectContentFree(cd);
+            DetectContentFree(NULL, cd);
         }
     } else {
         SCLogDebug("expected %s got NULL: ", teststringparsed);
@@ -815,7 +815,7 @@ static int DetectContentParseTest03 (void)
             PrintRawUriFp(stdout,cd->content,cd->content_len);
             SCLogDebug(": ");
             result = 0;
-            DetectContentFree(cd);
+            DetectContentFree(NULL, cd);
         }
     } else {
         SCLogDebug("expected %s got NULL: ", teststringparsed);
@@ -847,7 +847,7 @@ static int DetectContentParseTest04 (void)
             PrintRawUriFp(stdout,cd->content,cd->content_len);
             SCLogDebug(": ");
             result = 0;
-            DetectContentFree(cd);
+            DetectContentFree(NULL, cd);
         }
     } else {
         SCLogDebug("expected %s got NULL: ", teststringparsed);
@@ -876,7 +876,7 @@ static int DetectContentParseTest05 (void)
         PrintRawUriFp(stdout,cd->content,cd->content_len);
         SCLogDebug(": ");
         result = 0;
-        DetectContentFree(cd);
+        DetectContentFree(NULL, cd);
     }
     SpmDestroyGlobalThreadCtx(spm_global_thread_ctx);
     return result;
@@ -904,7 +904,7 @@ static int DetectContentParseTest06 (void)
             PrintRawUriFp(stdout,cd->content,cd->content_len);
             SCLogDebug(": ");
             result = 0;
-            DetectContentFree(cd);
+            DetectContentFree(NULL, cd);
         }
     } else {
         SCLogDebug("expected %s got NULL: ", teststringparsed);
@@ -931,7 +931,7 @@ static int DetectContentParseTest07 (void)
     if (cd != NULL) {
         SCLogDebug("expected NULL got %p: ", cd);
         result = 0;
-        DetectContentFree(cd);
+        DetectContentFree(NULL, cd);
     }
     SpmDestroyGlobalThreadCtx(spm_global_thread_ctx);
     return result;
@@ -954,7 +954,7 @@ static int DetectContentParseTest08 (void)
     if (cd != NULL) {
         SCLogDebug("expected NULL got %p: ", cd);
         result = 0;
-        DetectContentFree(cd);
+        DetectContentFree(NULL, cd);
     }
     SpmDestroyGlobalThreadCtx(spm_global_thread_ctx);
     return result;
@@ -1241,7 +1241,7 @@ static int DetectContentParseTest09(void)
 
     cd = DetectContentParse(spm_global_thread_ctx, teststring);
     FAIL_IF_NULL(cd);
-    DetectContentFree(cd);
+    DetectContentFree(NULL, cd);
     SpmDestroyGlobalThreadCtx(spm_global_thread_ctx);
     PASS;
 }
@@ -1292,7 +1292,7 @@ static int DetectContentParseTest18(void)
     result &= (DetectContentSetup(de_ctx, s, "one") == 0);
     result &= (s->sm_lists[g_dce_stub_data_buffer_id] == NULL && s->sm_lists[DETECT_SM_LIST_PMATCH] != NULL);
 
-    SigFree(s);
+    SigFree(de_ctx, s);
 
     s = SigAlloc();
     if (s == NULL)
@@ -1302,7 +1302,7 @@ static int DetectContentParseTest18(void)
     result &= (s->sm_lists[g_dce_stub_data_buffer_id] == NULL && s->sm_lists[DETECT_SM_LIST_PMATCH] != NULL);
 
  end:
-    SigFree(s);
+    SigFree(de_ctx, s);
     DetectEngineCtxFree(de_ctx);
 
     return result;
@@ -2332,7 +2332,7 @@ static int DetectContentParseTest41(void)
 
     SpmDestroyGlobalThreadCtx(spm_global_thread_ctx);
     SCFree(teststring);
-    DetectContentFree(cd);
+    DetectContentFree(NULL, cd);
     return result;
 }
 
@@ -2365,7 +2365,7 @@ static int DetectContentParseTest42(void)
 
     SpmDestroyGlobalThreadCtx(spm_global_thread_ctx);
     SCFree(teststring);
-    DetectContentFree(cd);
+    DetectContentFree(NULL, cd);
     return result;
 }
 
@@ -2399,7 +2399,7 @@ static int DetectContentParseTest43(void)
 
     SpmDestroyGlobalThreadCtx(spm_global_thread_ctx);
     SCFree(teststring);
-    DetectContentFree(cd);
+    DetectContentFree(NULL, cd);
     return result;
 }
 
@@ -2436,7 +2436,7 @@ static int DetectContentParseTest44(void)
 
     SpmDestroyGlobalThreadCtx(spm_global_thread_ctx);
     SCFree(teststring);
-    DetectContentFree(cd);
+    DetectContentFree(NULL, cd);
     return result;
 }
 

--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -119,7 +119,7 @@ DetectContentData *DetectContentParseEncloseQuotes(SpmGlobalThreadCtx *spm_globa
 int DetectContentSetup(DetectEngineCtx *de_ctx, Signature *s, const char *contentstr);
 void DetectContentPrint(DetectContentData *);
 
-void DetectContentFree(void *);
+void DetectContentFree(DetectEngineCtx *, void *);
 bool DetectContentPMATCHValidateCallback(const Signature *s);
 void DetectContentPropagateLimits(Signature *s);
 

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -43,43 +43,43 @@
 static int DetectIPV4CsumMatch(DetectEngineThreadCtx *,
         Packet *, const Signature *, const SigMatchCtx *);
 static int DetectIPV4CsumSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectIPV4CsumFree(void *);
+static void DetectIPV4CsumFree(DetectEngineCtx *, void *);
 
 /* prototypes for the "tcpv4-csum" rule keyword */
 static int DetectTCPV4CsumMatch(DetectEngineThreadCtx *,
         Packet *, const Signature *, const SigMatchCtx *);
 static int DetectTCPV4CsumSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectTCPV4CsumFree(void *);
+static void DetectTCPV4CsumFree(DetectEngineCtx *, void *);
 
 /* prototypes for the "tcpv6-csum" rule keyword */
 static int DetectTCPV6CsumMatch(DetectEngineThreadCtx *,
         Packet *, const Signature *, const SigMatchCtx *);
 static int DetectTCPV6CsumSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectTCPV6CsumFree(void *);
+static void DetectTCPV6CsumFree(DetectEngineCtx *, void *);
 
 /* prototypes for the "udpv4-csum" rule keyword */
 static int DetectUDPV4CsumMatch(DetectEngineThreadCtx *,
         Packet *, const Signature *, const SigMatchCtx *);
 static int DetectUDPV4CsumSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectUDPV4CsumFree(void *);
+static void DetectUDPV4CsumFree(DetectEngineCtx *, void *);
 
 /* prototypes for the "udpv6-csum" rule keyword */
 static int DetectUDPV6CsumMatch(DetectEngineThreadCtx *,
         Packet *, const Signature *, const SigMatchCtx *);
 static int DetectUDPV6CsumSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectUDPV6CsumFree(void *);
+static void DetectUDPV6CsumFree(DetectEngineCtx *de_ctx, void *);
 
 /* prototypes for the "icmpv4-csum" rule keyword */
 static int DetectICMPV4CsumMatch(DetectEngineThreadCtx *,
         Packet *, const Signature *, const SigMatchCtx *);
 static int DetectICMPV4CsumSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectICMPV4CsumFree(void *);
+static void DetectICMPV4CsumFree(DetectEngineCtx *, void *);
 
 /* prototypes for the "icmpv6-csum" rule keyword */
 static int DetectICMPV6CsumMatch(DetectEngineThreadCtx *,
         Packet *, const Signature *, const SigMatchCtx *);
 static int DetectICMPV6CsumSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectICMPV6CsumFree(void *);
+static void DetectICMPV6CsumFree(DetectEngineCtx *, void *);
 
 static void DetectCsumRegisterTests(void);
 
@@ -293,13 +293,13 @@ static int DetectIPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const char
     return 0;
 
 error:
-    if (cd != NULL) DetectIPV4CsumFree(cd);
+    if (cd != NULL) DetectIPV4CsumFree(de_ctx, cd);
     if (sm != NULL) SCFree(sm);
 
     return -1;
 }
 
-static void DetectIPV4CsumFree(void *ptr)
+static void DetectIPV4CsumFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectCsumData *cd = (DetectCsumData *)ptr;
 
@@ -390,13 +390,13 @@ static int DetectTCPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     return 0;
 
 error:
-    if (cd != NULL) DetectTCPV4CsumFree(cd);
+    if (cd != NULL) DetectTCPV4CsumFree(de_ctx, cd);
     if (sm != NULL) SCFree(sm);
 
     return -1;
 }
 
-static void DetectTCPV4CsumFree(void *ptr)
+static void DetectTCPV4CsumFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectCsumData *cd = (DetectCsumData *)ptr;
 
@@ -487,13 +487,13 @@ static int DetectTCPV6CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     return 0;
 
 error:
-    if (cd != NULL) DetectTCPV6CsumFree(cd);
+    if (cd != NULL) DetectTCPV6CsumFree(de_ctx, cd);
     if (sm != NULL) SCFree(sm);
 
     return -1;
 }
 
-static void DetectTCPV6CsumFree(void *ptr)
+static void DetectTCPV6CsumFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectCsumData *cd = (DetectCsumData *)ptr;
 
@@ -584,13 +584,13 @@ static int DetectUDPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     return 0;
 
 error:
-    if (cd != NULL) DetectUDPV4CsumFree(cd);
+    if (cd != NULL) DetectUDPV4CsumFree(de_ctx, cd);
     if (sm != NULL) SCFree(sm);
 
     return -1;
 }
 
-static void DetectUDPV4CsumFree(void *ptr)
+static void DetectUDPV4CsumFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectCsumData *cd = (DetectCsumData *)ptr;
 
@@ -681,13 +681,13 @@ static int DetectUDPV6CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     return 0;
 
 error:
-    if (cd != NULL) DetectUDPV6CsumFree(cd);
+    if (cd != NULL) DetectUDPV6CsumFree(de_ctx, cd);
     if (sm != NULL) SCFree(sm);
 
     return -1;
 }
 
-static void DetectUDPV6CsumFree(void *ptr)
+static void DetectUDPV6CsumFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectCsumData *cd = (DetectCsumData *)ptr;
 
@@ -776,13 +776,13 @@ static int DetectICMPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const ch
     return 0;
 
 error:
-    if (cd != NULL) DetectICMPV4CsumFree(cd);
+    if (cd != NULL) DetectICMPV4CsumFree(de_ctx, cd);
     if (sm != NULL) SCFree(sm);
 
     return -1;
 }
 
-static void DetectICMPV4CsumFree(void *ptr)
+static void DetectICMPV4CsumFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectCsumData *cd = (DetectCsumData *)ptr;
 
@@ -874,13 +874,13 @@ static int DetectICMPV6CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const ch
     return 0;
 
 error:
-    if (cd != NULL) DetectICMPV6CsumFree(cd);
+    if (cd != NULL) DetectICMPV6CsumFree(de_ctx, cd);
     if (sm != NULL) SCFree(sm);
 
     return -1;
 }
 
-static void DetectICMPV6CsumFree(void *ptr)
+static void DetectICMPV6CsumFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectCsumData *cd = (DetectCsumData *)ptr;
 

--- a/src/detect-datarep.c
+++ b/src/detect-datarep.c
@@ -45,7 +45,7 @@ static DetectParseRegex parse_regex;
 int DetectDatarepMatch (ThreadVars *, DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectDatarepSetup (DetectEngineCtx *, Signature *, const char *);
-void DetectDatarepFree (void *);
+void DetectDatarepFree (DetectEngineCtx *, void *);
 
 void DetectDatarepRegister (void)
 {
@@ -353,7 +353,7 @@ error:
     return -1;
 }
 
-void DetectDatarepFree (void *ptr)
+void DetectDatarepFree (DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectDatarepData *fd = (DetectDatarepData *)ptr;
 

--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -44,7 +44,7 @@ static DetectParseRegex parse_regex;
 int DetectDatasetMatch (ThreadVars *, DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectDatasetSetup (DetectEngineCtx *, Signature *, const char *);
-void DetectDatasetFree (void *);
+void DetectDatasetFree (DetectEngineCtx *, void *);
 
 void DetectDatasetRegister (void)
 {
@@ -407,7 +407,7 @@ error:
     return -1;
 }
 
-void DetectDatasetFree (void *ptr)
+void DetectDatasetFree (DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectDatasetData *fd = (DetectDatasetData *)ptr;
     if (fd == NULL)

--- a/src/detect-dce-iface.c
+++ b/src/detect-dce-iface.c
@@ -57,7 +57,7 @@ static int DetectDceIfaceMatchRust(DetectEngineThreadCtx *det_ctx,
         Flow *f, uint8_t flags, void *state, void *txv,
         const Signature *s, const SigMatchCtx *m);
 static int DetectDceIfaceSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectDceIfaceFree(void *);
+static void DetectDceIfaceFree(DetectEngineCtx *, void *);
 static void DetectDceIfaceRegisterTests(void);
 static int g_dce_generic_list_id = 0;
 
@@ -382,7 +382,7 @@ static int DetectDceIfaceSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     SigMatch *sm = SigMatchAlloc();
     if (sm == NULL) {
-        DetectDceIfaceFree(did);
+        DetectDceIfaceFree(de_ctx, did);
         return -1;
     }
 
@@ -393,7 +393,7 @@ static int DetectDceIfaceSetup(DetectEngineCtx *de_ctx, Signature *s, const char
     return 0;
 }
 
-static void DetectDceIfaceFree(void *ptr)
+static void DetectDceIfaceFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCFree(ptr);
 
@@ -443,7 +443,7 @@ static int DetectDceIfaceTestParse01(void)
     result &= (did->op == 0);
     result &= (did->any_frag == 0);
 
-    SigFree(s);
+    SigFree(NULL, s);
     SCReturnInt(result);
 }
 
@@ -486,7 +486,7 @@ static int DetectDceIfaceTestParse02(void)
     result &= (did->op == DETECT_DCE_IFACE_OP_GT);
     result &= (did->any_frag == 0);
 
-    SigFree(s);
+    SigFree(NULL, s);
     SCReturnInt(result);
 }
 
@@ -525,7 +525,7 @@ static int DetectDceIfaceTestParse03(void)
     result &= (did->op == DETECT_DCE_IFACE_OP_LT);
     result &= (did->any_frag == 0);
 
-    SigFree(s);
+    SigFree(NULL, s);
     SCReturnInt(result);
 }
 
@@ -568,7 +568,7 @@ static int DetectDceIfaceTestParse04(void)
     result &= (did->op == DETECT_DCE_IFACE_OP_NE);
     result &= (did->any_frag == 0);
 
-    SigFree(s);
+    SigFree(NULL, s);
     SCReturnInt(result);
 }
 
@@ -608,7 +608,7 @@ static int DetectDceIfaceTestParse05(void)
     result &= (did->op == DETECT_DCE_IFACE_OP_EQ);
     result &= (did->any_frag == 0);
 
-    SigFree(s);
+    SigFree(NULL, s);
     SCReturnInt(result);
 }
 
@@ -651,7 +651,7 @@ static int DetectDceIfaceTestParse06(void)
     result &= (did->op == 0);
     result &= (did->any_frag == 1);
 
-    SigFree(s);
+    SigFree(NULL, s);
     SCReturnInt(result);
 }
 
@@ -694,7 +694,7 @@ static int DetectDceIfaceTestParse07(void)
     result &= (did->op == DETECT_DCE_IFACE_OP_GT);
     result &= (did->any_frag == 1);
 
-    SigFree(s);
+    SigFree(NULL, s);
     SCReturnInt(result);
 }
 
@@ -735,7 +735,7 @@ static int DetectDceIfaceTestParse08(void)
     result &= (did->op == DETECT_DCE_IFACE_OP_LT);
     result &= (did->any_frag == 1);
 
-    SigFree(s);
+    SigFree(NULL, s);
     SCReturnInt(result);
 }
 
@@ -774,7 +774,7 @@ static int DetectDceIfaceTestParse09(void)
     result &= (did->op == DETECT_DCE_IFACE_OP_EQ);
     result &= (did->any_frag == 1);
 
-    SigFree(s);
+    SigFree(NULL, s);
     SCReturnInt(result);
 }
 
@@ -817,7 +817,7 @@ static int DetectDceIfaceTestParse10(void)
     result &= (did->op == DETECT_DCE_IFACE_OP_NE);
     result &= (did->any_frag == 1);
 
-    SigFree(s);
+    SigFree(NULL, s);
     SCReturnInt(result);
 }
 
@@ -841,7 +841,7 @@ static int DetectDceIfaceTestParse11(void)
     result &= (DetectDceIfaceSetup(NULL, s, "12345678-1234-1234-1234-123456789ABC,<0,any_frag") == -1);
     result &= (DetectDceIfaceSetup(NULL, s, "12345678-1234-1234-1234-123456789ABC,>65535,any_frag") == -1);
 
-    SigFree(s);
+    SigFree(NULL, s);
     return result;
 }
 

--- a/src/detect-dce-opnum.c
+++ b/src/detect-dce-opnum.c
@@ -58,7 +58,7 @@ static int DetectDceOpnumMatchRust(DetectEngineThreadCtx *det_ctx,
         Flow *f, uint8_t flags, void *state, void *txv,
         const Signature *s, const SigMatchCtx *m);
 static int DetectDceOpnumSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectDceOpnumFree(void *);
+static void DetectDceOpnumFree(DetectEngineCtx *, void *);
 static void DetectDceOpnumRegisterTests(void);
 static int g_dce_generic_list_id = 0;
 
@@ -98,13 +98,13 @@ static DetectDceOpnumRange *DetectDceOpnumAllocDetectDceOpnumRange(void)
 /**
  * \internal
  * \brief Parses the argument sent along with the "dce_opnum" keyword.
- *
+ * \param de_ctx Pointer to the detection engine context
  * \param arg Pointer to the string containing the argument to be parsed.
  *
  * \retval did Pointer to a DetectDceIfaceData instance that holds the data
  *             from the parsed arg.
  */
-static DetectDceOpnumData *DetectDceOpnumArgParse(const char *arg)
+static DetectDceOpnumData *DetectDceOpnumArgParse(DetectEngineCtx *de_ctx, const char *arg)
 {
     DetectDceOpnumData *dod = NULL;
 
@@ -220,7 +220,7 @@ static DetectDceOpnumData *DetectDceOpnumArgParse(const char *arg)
  error:
     if (dup_str_head != NULL)
         SCFree(dup_str_head);
-    DetectDceOpnumFree(dod);
+    DetectDceOpnumFree(de_ctx, dod);
     return NULL;
 }
 
@@ -324,7 +324,7 @@ static int DetectDceOpnumSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         return -1;
     }
 
-    DetectDceOpnumData *dod = DetectDceOpnumArgParse(arg);
+    DetectDceOpnumData *dod = DetectDceOpnumArgParse(de_ctx, arg);
     if (dod == NULL) {
         SCLogError(SC_ERR_INVALID_SIGNATURE, "Error parsing dce_opnum option in "
                    "signature");
@@ -333,7 +333,7 @@ static int DetectDceOpnumSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     SigMatch *sm = SigMatchAlloc();
     if (sm == NULL) {
-        DetectDceOpnumFree(dod);
+        DetectDceOpnumFree(de_ctx, dod);
         return -1;
     }
 
@@ -344,7 +344,7 @@ static int DetectDceOpnumSetup(DetectEngineCtx *de_ctx, Signature *s, const char
     return 0;
 }
 
-static void DetectDceOpnumFree(void *ptr)
+static void DetectDceOpnumFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectDceOpnumData *dod = ptr;
     DetectDceOpnumRange *dor = NULL;
@@ -381,7 +381,7 @@ static int DetectDceOpnumTestParse01(void)
     result &= (DetectDceOpnumSetup(NULL, s, "12-14,12,121,62-8") == -1);
 
     if (s->sm_lists[g_dce_generic_list_id] != NULL) {
-        SigFree(s);
+        SigFree(NULL, s);
         result &= 1;
     }
 
@@ -411,7 +411,7 @@ static int DetectDceOpnumTestParse02(void)
     }
 
  end:
-    SigFree(s);
+    SigFree(NULL, s);
     return result;
 }
 
@@ -438,7 +438,7 @@ static int DetectDceOpnumTestParse03(void)
     }
 
  end:
-    SigFree(s);
+    SigFree(NULL, s);
     return result;
 }
 
@@ -502,7 +502,7 @@ static int DetectDceOpnumTestParse04(void)
     }
 
  end:
-    SigFree(s);
+    SigFree(NULL, s);
     return result;
 }
 
@@ -566,7 +566,7 @@ static int DetectDceOpnumTestParse05(void)
     }
 
  end:
-    SigFree(s);
+    SigFree(NULL, s);
     return result;
 }
 
@@ -612,7 +612,7 @@ static int DetectDceOpnumTestParse06(void)
     }
 
  end:
-    SigFree(s);
+    SigFree(NULL, s);
     return result;
 }
 
@@ -663,7 +663,7 @@ static int DetectDceOpnumTestParse07(void)
     }
 
  end:
-    SigFree(s);
+    SigFree(NULL, s);
     return result;
 }
 

--- a/src/detect-detection-filter.c
+++ b/src/detect-detection-filter.c
@@ -54,7 +54,7 @@ static int DetectDetectionFilterMatch(DetectEngineThreadCtx *,
         Packet *, const Signature *, const SigMatchCtx *);
 static int DetectDetectionFilterSetup(DetectEngineCtx *, Signature *, const char *);
 static void DetectDetectionFilterRegisterTests(void);
-static void DetectDetectionFilterFree(void *);
+static void DetectDetectionFilterFree(DetectEngineCtx *, void *);
 
 /**
  * \brief Registration function for detection_filter: keyword
@@ -254,7 +254,7 @@ error:
  *
  * \param df_ptr pointer to DetectDetectionFilterData
  */
-static void DetectDetectionFilterFree(void *df_ptr)
+static void DetectDetectionFilterFree(DetectEngineCtx *de_ctx, void *df_ptr)
 {
     DetectThresholdData *df = (DetectThresholdData *)df_ptr;
     if (df)
@@ -282,7 +282,7 @@ static int DetectDetectionFilterTestParse01 (void)
     DetectThresholdData *df = NULL;
     df = DetectDetectionFilterParse("track by_dst,count 10,seconds 60");
     if (df && (df->track == TRACK_DST) && (df->count == 10) && (df->seconds == 60)) {
-        DetectDetectionFilterFree(df);
+        DetectDetectionFilterFree(NULL, df);
         return 1;
     }
 
@@ -300,7 +300,7 @@ static int DetectDetectionFilterTestParse02 (void)
     DetectThresholdData *df = NULL;
     df = DetectDetectionFilterParse("track both,count 10,seconds 60");
     if (df && (df->track == TRACK_DST || df->track == TRACK_SRC) && (df->count == 10) && (df->seconds == 60)) {
-        DetectDetectionFilterFree(df);
+        DetectDetectionFilterFree(NULL, df);
         return 0;
     }
 
@@ -318,7 +318,7 @@ static int DetectDetectionFilterTestParse03 (void)
     DetectThresholdData *df = NULL;
     df = DetectDetectionFilterParse("track by_dst, seconds 60, count 10");
     if (df && (df->track == TRACK_DST) && (df->count == 10) && (df->seconds == 60)) {
-        DetectDetectionFilterFree(df);
+        DetectDetectionFilterFree(NULL, df);
         return 1;
     }
 
@@ -337,7 +337,7 @@ static int DetectDetectionFilterTestParse04 (void)
     DetectThresholdData *df = NULL;
     df = DetectDetectionFilterParse("count 10, track by_dst, seconds 60, count 10");
     if (df && (df->track == TRACK_DST) && (df->count == 10) && (df->seconds == 60)) {
-        DetectDetectionFilterFree(df);
+        DetectDetectionFilterFree(NULL, df);
         return 0;
     }
 
@@ -355,7 +355,7 @@ static int DetectDetectionFilterTestParse05 (void)
     DetectThresholdData *df = NULL;
     df = DetectDetectionFilterParse("count 10, track by_dst, seconds 60");
     if (df && (df->track == TRACK_DST) && (df->count == 10) && (df->seconds == 60)) {
-        DetectDetectionFilterFree(df);
+        DetectDetectionFilterFree(NULL, df);
         return 1;
     }
 
@@ -373,7 +373,7 @@ static int DetectDetectionFilterTestParse06 (void)
     DetectThresholdData *df = NULL;
     df = DetectDetectionFilterParse("count 10, track by_dst, seconds 0");
     if (df && (df->track == TRACK_DST) && (df->count == 10) && (df->seconds == 0)) {
-        DetectDetectionFilterFree(df);
+        DetectDetectionFilterFree(NULL, df);
         return 0;
     }
 

--- a/src/detect-dnp3.c
+++ b/src/detect-dnp3.c
@@ -414,7 +414,7 @@ fail:
     SCReturnInt(0);
 }
 
-static void DetectDNP3Free(void *ptr)
+static void DetectDNP3Free(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCEnter();
     if (ptr != NULL) {

--- a/src/detect-dns-opcode.c
+++ b/src/detect-dns-opcode.c
@@ -24,7 +24,7 @@
 
 static int dns_opcode_list_id = 0;
 
-static void DetectDnsOpcodeFree(void *ptr);
+static void DetectDnsOpcodeFree(DetectEngineCtx *, void *ptr);
 
 static int DetectDnsOpcodeSetup(DetectEngineCtx *de_ctx, Signature *s,
    const char *str)
@@ -54,11 +54,11 @@ static int DetectDnsOpcodeSetup(DetectEngineCtx *de_ctx, Signature *s,
     SCReturnInt(0);
 
 error:
-    DetectDnsOpcodeFree(detect);
+    DetectDnsOpcodeFree(de_ctx, detect);
     SCReturnInt(-1);
 }
 
-static void DetectDnsOpcodeFree(void *ptr)
+static void DetectDnsOpcodeFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCEnter();
     if (ptr != NULL) {

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -53,7 +53,7 @@ static int DetectDsizeMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectDsizeSetup (DetectEngineCtx *, Signature *s, const char *str);
 static void DsizeRegisterTests(void);
-static void DetectDsizeFree(void *);
+static void DetectDsizeFree(DetectEngineCtx *, void *);
 
 static int PrefilterSetupDsize(DetectEngineCtx *de_ctx, SigGroupHead *sgh);
 static bool PrefilterDsizeIsPrefilterable(const Signature *s);
@@ -305,7 +305,7 @@ error:
  *
  * \param de pointer to DetectDsizeData
  */
-void DetectDsizeFree(void *de_ptr)
+void DetectDsizeFree(DetectEngineCtx *de_ctx, void *de_ptr)
 {
     DetectDsizeData *dd = (DetectDsizeData *)de_ptr;
     if(dd) SCFree(dd);
@@ -486,7 +486,7 @@ static int DsizeTestParse01 (void)
     DetectDsizeData *dd = NULL;
     dd = DetectDsizeParse("1");
     if (dd) {
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
         return 1;
     }
 
@@ -504,7 +504,7 @@ static int DsizeTestParse02 (void)
     DetectDsizeData *dd = NULL;
     dd = DetectDsizeParse(">10");
     if (dd) {
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
         return 1;
     }
 
@@ -522,7 +522,7 @@ static int DsizeTestParse03 (void)
     DetectDsizeData *dd = NULL;
     dd = DetectDsizeParse("<100");
     if (dd) {
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
         return 1;
     }
 
@@ -540,7 +540,7 @@ static int DsizeTestParse04 (void)
     DetectDsizeData *dd = NULL;
     dd = DetectDsizeParse("1<>2");
     if (dd) {
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
         return 1;
     }
 
@@ -562,7 +562,7 @@ static int DsizeTestParse05 (void)
         if (dd->dsize == 1)
             result = 1;
 
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
     }
 
     return result;
@@ -583,7 +583,7 @@ static int DsizeTestParse06 (void)
         if (dd->dsize == 10 && dd->mode == DETECTDSIZE_GT)
             result = 1;
 
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
     }
 
     return result;
@@ -604,7 +604,7 @@ static int DsizeTestParse07 (void)
         if (dd->dsize == 100 && dd->mode == DETECTDSIZE_LT)
             result = 1;
 
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
     }
 
     return result;
@@ -625,7 +625,7 @@ static int DsizeTestParse08 (void)
         if (dd->dsize == 1 && dd->dsize2 == 2 && dd->mode == DETECTDSIZE_RA)
             result = 1;
 
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
     }
 
     return result;
@@ -642,7 +642,7 @@ static int DsizeTestParse09 (void)
     DetectDsizeData *dd = NULL;
     dd = DetectDsizeParse("A");
     if (dd) {
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
         return 0;
     }
 
@@ -660,7 +660,7 @@ static int DsizeTestParse10 (void)
     DetectDsizeData *dd = NULL;
     dd = DetectDsizeParse(">10<>10");
     if (dd) {
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
         return 0;
     }
 
@@ -678,7 +678,7 @@ static int DsizeTestParse11 (void)
     DetectDsizeData *dd = NULL;
     dd = DetectDsizeParse("<>10");
     if (dd) {
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
         return 0;
     }
 
@@ -696,7 +696,7 @@ static int DsizeTestParse12 (void)
     DetectDsizeData *dd = NULL;
     dd = DetectDsizeParse("1<>");
     if (dd) {
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
         return 0;
     }
 
@@ -718,7 +718,7 @@ static int DsizeTestParse13 (void)
         if (dd->dsize2 == 0)
             result = 1;
 
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
     }
 
     return result;
@@ -735,7 +735,7 @@ static int DsizeTestParse14 (void)
     DetectDsizeData *dd = NULL;
     dd = DetectDsizeParse("");
     if (dd) {
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
         return 0;
     }
 
@@ -753,7 +753,7 @@ static int DsizeTestParse15 (void)
     DetectDsizeData *dd = NULL;
     dd = DetectDsizeParse(" ");
     if (dd) {
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
         return 0;
     }
 
@@ -771,7 +771,7 @@ static int DsizeTestParse16 (void)
     DetectDsizeData *dd = NULL;
     dd = DetectDsizeParse("2<>1");
     if (dd) {
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
         return 0;
     }
 
@@ -793,7 +793,7 @@ static int DsizeTestParse17 (void)
         if (dd->dsize == 1 && dd->dsize2 == 2 && dd->mode == DETECTDSIZE_RA)
             result = 1;
 
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
     }
 
     return result;
@@ -814,7 +814,7 @@ static int DsizeTestParse18 (void)
         if (dd->dsize == 2 && dd->mode == DETECTDSIZE_GT)
             result = 1;
 
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
     }
 
     return result;
@@ -835,7 +835,7 @@ static int DsizeTestParse19 (void)
         if (dd->dsize == 12 && dd->mode == DETECTDSIZE_LT)
             result = 1;
 
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
     }
 
     return result;
@@ -856,7 +856,7 @@ static int DsizeTestParse20 (void)
         if (dd->dsize == 12 && dd->mode == DETECTDSIZE_EQ)
             result = 1;
 
-        DetectDsizeFree(dd);
+        DetectDsizeFree(NULL, dd);
     }
 
     return result;

--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -1390,6 +1390,7 @@ static const DetectAddressMap *DetectAddressMapLookup(DetectEngineCtx *de_ctx,
  *        DetectAddressHead sent as the argument with the relevant address
  *        ranges from the parsed string.
  *
+ * \param de_ctx Pointer to the detection engine context
  * \param gh  Pointer to the DetectAddressHead.
  * \param str Pointer to the character string containing the address group
  *            that has to be parsed.

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -43,7 +43,7 @@ void SigCleanSignatures(DetectEngineCtx *de_ctx)
 
     for (Signature *s = de_ctx->sig_list; s != NULL;) {
         Signature *ns = s->next;
-        SigFree(s);
+        SigFree(de_ctx, s);
         s = ns;
     }
     de_ctx->sig_list = NULL;
@@ -1850,7 +1850,7 @@ static int SigMatchPrepare(DetectEngineCtx *de_ctx)
             SigMatch *sm = s->init_data->smlists[i];
             while (sm != NULL) {
                 SigMatch *nsm = sm->next;
-                SigMatchFree(sm);
+                SigMatchFree(de_ctx, sm);
                 sm = nsm;
             }
         }

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -51,7 +51,7 @@ static int DetectEngineEventMatch (DetectEngineThreadCtx *,
 static int DetectEngineEventSetup (DetectEngineCtx *, Signature *, const char *);
 static int DetectDecodeEventSetup (DetectEngineCtx *, Signature *, const char *);
 static int DetectStreamEventSetup (DetectEngineCtx *, Signature *, const char *);
-static void DetectEngineEventFree (void *);
+static void DetectEngineEventFree (DetectEngineCtx *, void *);
 void EngineEventRegisterTests(void);
 
 
@@ -211,7 +211,7 @@ static int DetectEngineEventSetup (DetectEngineCtx *de_ctx, Signature *s, const 
  *
  * \param de pointer to DetectEngineEventData
  */
-static void DetectEngineEventFree(void *ptr)
+static void DetectEngineEventFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectEngineEventData *de = (DetectEngineEventData *)ptr;
     if (de)
@@ -265,7 +265,7 @@ static int EngineEventTestParse01 (void)
     DetectEngineEventData *de = NULL;
     de = DetectEngineEventParse("decoder.ipv4.pkt_too_small");
     if (de) {
-        DetectEngineEventFree(de);
+        DetectEngineEventFree(NULL, de);
         return 1;
     }
 
@@ -281,7 +281,7 @@ static int EngineEventTestParse02 (void)
     DetectEngineEventData *de = NULL;
     de = DetectEngineEventParse("decoder.PPP.pkt_too_small");
     if (de) {
-        DetectEngineEventFree(de);
+        DetectEngineEventFree(NULL, de);
         return 1;
     }
 
@@ -296,7 +296,7 @@ static int EngineEventTestParse03 (void)
     DetectEngineEventData *de = NULL;
     de = DetectEngineEventParse("decoder.IPV6.PKT_TOO_SMALL");
     if (de) {
-        DetectEngineEventFree(de);
+        DetectEngineEventFree(NULL, de);
         return 1;
     }
 
@@ -311,7 +311,7 @@ static int EngineEventTestParse04 (void)
     DetectEngineEventData *de = NULL;
     de = DetectEngineEventParse("decoder.IPV6.INVALID_EVENT");
     if (de) {
-        DetectEngineEventFree(de);
+        DetectEngineEventFree(NULL, de);
         return 0;
     }
 
@@ -326,7 +326,7 @@ static int EngineEventTestParse05 (void)
     DetectEngineEventData *de = NULL;
     de = DetectEngineEventParse("decoder.IPV-6,INVALID_CHAR");
     if (de) {
-        DetectEngineEventFree(de);
+        DetectEngineEventFree(NULL, de);
         return 0;
     }
 

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -1582,7 +1582,7 @@ static int IPOnlyTestSig01(void)
     FAIL_IF(s == NULL);
 
     FAIL_IF(SignatureIsIPOnly(de_ctx, s) == 0);
-    SigFree(s);
+    SigFree(de_ctx, s);
     DetectEngineCtxFree(de_ctx);
     PASS;
 }
@@ -1602,7 +1602,7 @@ static int IPOnlyTestSig02 (void)
     FAIL_IF(s == NULL);
 
     FAIL_IF(SignatureIsIPOnly(de_ctx, s) == 0);
-    SigFree(s);
+    SigFree(de_ctx, s);
     DetectEngineCtxFree(de_ctx);
     PASS;
 }
@@ -1633,7 +1633,7 @@ static int IPOnlyTestSig03 (void)
         printf("got a IPOnly signature (content): ");
         result=0;
     }
-    SigFree(s);
+    SigFree(de_ctx, s);
 
     /* content */
     s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (content) \"; content:\"match something\"; classtype:misc-activity; sid:400001; rev:1;)");
@@ -1645,7 +1645,7 @@ static int IPOnlyTestSig03 (void)
         printf("got a IPOnly signature (content): ");
         result=0;
     }
-    SigFree(s);
+    SigFree(de_ctx, s);
 
     /* uricontent */
     s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (uricontent) \"; uricontent:\"match something\"; classtype:misc-activity; sid:400001; rev:1;)");
@@ -1657,7 +1657,7 @@ static int IPOnlyTestSig03 (void)
         printf("got a IPOnly signature (uricontent): ");
         result=0;
     }
-    SigFree(s);
+    SigFree(de_ctx, s);
 
     /* pcre */
     s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (pcre) \"; pcre:\"/e?idps rule[sz]/i\"; classtype:misc-activity; sid:400001; rev:1;)");
@@ -1669,7 +1669,7 @@ static int IPOnlyTestSig03 (void)
         printf("got a IPOnly signature (pcre): ");
         result=0;
     }
-    SigFree(s);
+    SigFree(de_ctx, s);
 
     /* flow */
     s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (flow) \"; flow:to_server; classtype:misc-activity; sid:400001; rev:1;)");
@@ -1681,7 +1681,7 @@ static int IPOnlyTestSig03 (void)
         printf("got a IPOnly signature (flow): ");
         result=0;
     }
-    SigFree(s);
+    SigFree(de_ctx, s);
 
     /* dsize */
     s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (dsize) \"; dsize:100; classtype:misc-activity; sid:400001; rev:1;)");
@@ -1693,7 +1693,7 @@ static int IPOnlyTestSig03 (void)
         printf("got a IPOnly signature (dsize): ");
         result=0;
     }
-    SigFree(s);
+    SigFree(de_ctx, s);
 
     /* flowbits */
     s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (flowbits) \"; flowbits:unset; classtype:misc-activity; sid:400001; rev:1;)");
@@ -1705,7 +1705,7 @@ static int IPOnlyTestSig03 (void)
         printf("got a IPOnly signature (flowbits): ");
         result=0;
     }
-    SigFree(s);
+    SigFree(de_ctx, s);
 
     /* flowvar */
     s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (flowvar) \"; pcre:\"/(?<flow_var>.*)/i\"; flowvar:var,\"str\"; classtype:misc-activity; sid:400001; rev:1;)");
@@ -1717,7 +1717,7 @@ static int IPOnlyTestSig03 (void)
         printf("got a IPOnly signature (flowvar): ");
         result=0;
     }
-    SigFree(s);
+    SigFree(de_ctx, s);
 
     /* pktvar */
     s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (pktvar) \"; pcre:\"/(?<pkt_var>.*)/i\"; pktvar:var,\"str\"; classtype:misc-activity; sid:400001; rev:1;)");
@@ -1729,7 +1729,7 @@ static int IPOnlyTestSig03 (void)
         printf("got a IPOnly signature (pktvar): ");
         result=0;
     }
-    SigFree(s);
+    SigFree(de_ctx, s);
 
 end:
     if (de_ctx != NULL)
@@ -2124,7 +2124,7 @@ static int IPOnlyTestSig13(void)
     FAIL_IF(s == NULL);
 
     FAIL_IF(SignatureIsIPOnly(de_ctx, s) == 0);
-    SigFree(s);
+    SigFree(de_ctx, s);
     DetectEngineCtxFree(de_ctx);
     PASS;
 }
@@ -2141,7 +2141,7 @@ static int IPOnlyTestSig14(void)
     FAIL_IF(s == NULL);
 
     FAIL_IF(SignatureIsIPOnly(de_ctx, s) == 1);
-    SigFree(s);
+    SigFree(de_ctx, s);
     DetectEngineCtxFree(de_ctx);
     PASS;
 }

--- a/src/detect-engine-port.c
+++ b/src/detect-engine-port.c
@@ -1222,6 +1222,7 @@ int DetectPortTestConfVars(void)
 /**
  * \brief Function for parsing port strings
  *
+ * \param de_ctx Pointer to the detection engine context
  * \param head Pointer to the head of the DetectPort group list
  * \param str Pointer to the port string
  *

--- a/src/detect-engine-sigorder.c
+++ b/src/detect-engine-sigorder.c
@@ -819,7 +819,7 @@ void SCSigSignatureOrderingModuleCleanup(DetectEngineCtx *de_ctx)
 
 DetectEngineCtx *DetectEngineCtxInit(void);
 Signature *SigInit(DetectEngineCtx *, const char *);
-void SigFree(Signature *);
+void SigFree(DetectEngineCtx *, Signature *);
 void DetectEngineCtxFree(DetectEngineCtx *);
 
 #ifdef UNITTESTS

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -664,7 +664,7 @@ next:
  *  double freeing, so it takes an approach to first fill an array
  *  of the to-free pointers before freeing them.
  */
-void DetectEngineAppInspectionEngineSignatureFree(Signature *s)
+void DetectEngineAppInspectionEngineSignatureFree(DetectEngineCtx *de_ctx, Signature *s)
 {
     int nlists = 0;
 
@@ -712,7 +712,7 @@ void DetectEngineAppInspectionEngineSignatureFree(Signature *s)
         SigMatchData *smd = ptrs[i];
         while(1) {
             if (sigmatch_table[smd->type].Free != NULL) {
-                sigmatch_table[smd->type].Free(smd->ctx);
+                sigmatch_table[smd->type].Free(de_ctx, smd->ctx);
             }
             if (smd->is_last)
                 break;

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2019 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -3004,6 +3004,43 @@ int DetectRegisterThreadCtxFuncs(DetectEngineCtx *de_ctx, const char *name, void
     return item->id;
 }
 
+/** \brief Remove Thread keyword context registration
+ *
+ *  \param de_ctx detection engine to deregister from
+ *  \param det_ctx detection engine thread context to deregister from
+ *  \param data keyword init data to pass to Func. Can be NULL.
+ *  \param name keyword name for error printing
+ *
+ *  \retval 1 Item unregistered
+ *  \retval 0 otherwise
+ *
+ *  \note make sure "data" remains valid and it free'd elsewhere. It's
+ *        recommended to store it in the keywords global ctx so that
+ *        it's freed when the de_ctx is freed.
+ */
+int DetectUnregisterThreadCtxFuncs(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, void *data, const char *name)
+{
+    BUG_ON(de_ctx == NULL);
+
+    DetectEngineThreadKeywordCtxItem *item = de_ctx->keyword_list;
+    DetectEngineThreadKeywordCtxItem *prev_item = NULL;
+    while (item != NULL) {
+        if (strcmp(name, item->name) == 0 && (data == item->data)) {
+            if (prev_item == NULL)
+                de_ctx->keyword_list = item->next;
+            else
+                prev_item->next = item->next;
+            if (det_ctx)
+                item->FreeFunc(det_ctx->keyword_ctxs_array[item->id]);
+            SCFree(item);
+            return 1;
+        }
+        prev_item = item;
+        item = item->next;
+    }
+    return 0;
+}
 /** \brief Retrieve thread local keyword ctx by id
  *
  *  \param det_ctx detection engine thread ctx to retrieve the ctx from

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -152,7 +152,7 @@ void DetectPktInspectEngineRegister(const char *name,
         InspectionBufferPktInspectFunc Callback);
 
 int DetectEngineAppInspectionEngine2Signature(DetectEngineCtx *de_ctx, Signature *s);
-void DetectEngineAppInspectionEngineSignatureFree(Signature *s);
+void DetectEngineAppInspectionEngineSignatureFree(DetectEngineCtx *, Signature *s);
 
 bool DetectEnginePktInspectionRun(ThreadVars *tv,
         DetectEngineThreadCtx *det_ctx, const Signature *s,

--- a/src/detect-file-hash-common.c
+++ b/src/detect-file-hash-common.c
@@ -292,7 +292,7 @@ static DetectFileHashData *DetectFileHashParse (const DetectEngineCtx *de_ctx,
 
 error:
     if (filehash != NULL)
-        DetectFileHashFree(filehash);
+        DetectFileHashFree((DetectEngineCtx *) de_ctx, filehash);
     if (fp != NULL)
         fclose(fp);
     if (filename != NULL)
@@ -349,7 +349,7 @@ int DetectFileHashSetup (DetectEngineCtx *de_ctx, Signature *s, const char *str,
 
 error:
     if (filehash != NULL)
-        DetectFileHashFree(filehash);
+        DetectFileHashFree(de_ctx, filehash);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -360,7 +360,7 @@ error:
  *
  * \param filehash pointer to DetectFileHashData
  */
-void DetectFileHashFree(void *ptr)
+void DetectFileHashFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr != NULL) {
         DetectFileHashData *filehash = (DetectFileHashData *)ptr;

--- a/src/detect-file-hash-common.h
+++ b/src/detect-file-hash-common.h
@@ -40,6 +40,6 @@ int LoadHashTable(ROHashTable *, const char *, const char *, int, uint32_t);
 int DetectFileHashMatch(DetectEngineThreadCtx *, Flow *, uint8_t,
         File *, const Signature *, const SigMatchCtx *);
 int DetectFileHashSetup(DetectEngineCtx *, Signature *, const char *, uint32_t, int);
-void DetectFileHashFree(void *);
+void DetectFileHashFree(DetectEngineCtx *, void *);
 
 #endif /* __UTIL_DETECT_FILE_HASH_H__ */

--- a/src/detect-fileext.c
+++ b/src/detect-fileext.c
@@ -55,7 +55,7 @@ static int DetectFileextMatch (DetectEngineThreadCtx *, Flow *,
         uint8_t, File *, const Signature *, const SigMatchCtx *);
 static int DetectFileextSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectFileextRegisterTests(void);
-static void DetectFileextFree(void *);
+static void DetectFileextFree(DetectEngineCtx *, void *);
 static int g_file_match_list_id = 0;
 
 /**
@@ -128,12 +128,13 @@ static int DetectFileextMatch (DetectEngineThreadCtx *det_ctx,
 /**
  * \brief This function is used to parse fileet
  *
+ * \param de_ctx Pointer to the detection engine context
  * \param str Pointer to the fileext value string
  *
  * \retval pointer to DetectFileextData on success
  * \retval NULL on failure
  */
-static DetectFileextData *DetectFileextParse (const char *str, bool negate)
+static DetectFileextData *DetectFileextParse (DetectEngineCtx *de_ctx, const char *str, bool negate)
 {
     DetectFileextData *fileext = NULL;
 
@@ -176,7 +177,7 @@ static DetectFileextData *DetectFileextParse (const char *str, bool negate)
 
 error:
     if (fileext != NULL)
-        DetectFileextFree(fileext);
+        DetectFileextFree(de_ctx, fileext);
     return NULL;
 
 }
@@ -197,7 +198,7 @@ static int DetectFileextSetup (DetectEngineCtx *de_ctx, Signature *s, const char
     DetectFileextData *fileext= NULL;
     SigMatch *sm = NULL;
 
-    fileext = DetectFileextParse(str, s->init_data->negated);
+    fileext = DetectFileextParse(de_ctx, str, s->init_data->negated);
     if (fileext == NULL)
         goto error;
 
@@ -217,7 +218,7 @@ static int DetectFileextSetup (DetectEngineCtx *de_ctx, Signature *s, const char
 
 error:
     if (fileext != NULL)
-        DetectFileextFree(fileext);
+        DetectFileextFree(de_ctx, fileext);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -229,7 +230,7 @@ error:
  *
  * \param fileext pointer to DetectFileextData
  */
-static void DetectFileextFree(void *ptr)
+static void DetectFileextFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr != NULL) {
         DetectFileextData *fileext = (DetectFileextData *)ptr;
@@ -246,9 +247,9 @@ static void DetectFileextFree(void *ptr)
  */
 static int DetectFileextTestParse01 (void)
 {
-    DetectFileextData *dfd = DetectFileextParse("doc", false);
+    DetectFileextData *dfd = DetectFileextParse(NULL, "doc", false);
     if (dfd != NULL) {
-        DetectFileextFree(dfd);
+        DetectFileextFree(NULL, dfd);
         return 1;
     }
     return 0;
@@ -261,13 +262,13 @@ static int DetectFileextTestParse02 (void)
 {
     int result = 0;
 
-    DetectFileextData *dfd = DetectFileextParse("tar.gz", false);
+    DetectFileextData *dfd = DetectFileextParse(NULL, "tar.gz", false);
     if (dfd != NULL) {
         if (dfd->len == 6 && memcmp(dfd->ext, "tar.gz", 6) == 0) {
             result = 1;
         }
 
-        DetectFileextFree(dfd);
+        DetectFileextFree(NULL, dfd);
         return result;
     }
     return 0;
@@ -280,13 +281,13 @@ static int DetectFileextTestParse03 (void)
 {
     int result = 0;
 
-    DetectFileextData *dfd = DetectFileextParse("pdf", false);
+    DetectFileextData *dfd = DetectFileextParse(NULL, "pdf", false);
     if (dfd != NULL) {
         if (dfd->len == 3 && memcmp(dfd->ext, "pdf", 3) == 0) {
             result = 1;
         }
 
-        DetectFileextFree(dfd);
+        DetectFileextFree(NULL, dfd);
         return result;
     }
     return 0;

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -82,7 +82,7 @@ static int DetectFilemagicMatch (DetectEngineThreadCtx *, Flow *,
         uint8_t, File *, const Signature *, const SigMatchCtx *);
 static int DetectFilemagicSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectFilemagicRegisterTests(void);
-static void DetectFilemagicFree(void *);
+static void DetectFilemagicFree(DetectEngineCtx *, void *);
 static int g_file_match_list_id = 0;
 
 static int DetectFilemagicSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str);
@@ -283,12 +283,13 @@ static int DetectFilemagicMatch (DetectEngineThreadCtx *det_ctx,
 /**
  * \brief Parse the filemagic keyword
  *
+ * \param de_ctx Pointer to the detection engine context
  * \param idstr Pointer to the user provided option
  *
  * \retval filemagic pointer to DetectFilemagicData on success
  * \retval NULL on failure
  */
-static DetectFilemagicData *DetectFilemagicParse (const char *str, bool negate)
+static DetectFilemagicData *DetectFilemagicParse (DetectEngineCtx *de_ctx, const char *str, bool negate)
 {
     DetectFilemagicData *filemagic = NULL;
 
@@ -333,7 +334,7 @@ static DetectFilemagicData *DetectFilemagicParse (const char *str, bool negate)
 
 error:
     if (filemagic != NULL)
-        DetectFilemagicFree(filemagic);
+        DetectFilemagicFree(de_ctx, filemagic);
     return NULL;
 }
 
@@ -411,7 +412,7 @@ static int DetectFilemagicSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
 {
     SigMatch *sm = NULL;
 
-    DetectFilemagicData *filemagic = DetectFilemagicParse(str, s->init_data->negated);
+    DetectFilemagicData *filemagic = DetectFilemagicParse(de_ctx, str, s->init_data->negated);
     if (filemagic == NULL)
         return -1;
 
@@ -438,7 +439,7 @@ static int DetectFilemagicSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
     return 0;
 
 error:
-    DetectFilemagicFree(filemagic);
+    DetectFilemagicFree(de_ctx, filemagic);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -449,7 +450,7 @@ error:
  *
  * \param filemagic pointer to DetectFilemagicData
  */
-static void DetectFilemagicFree(void *ptr)
+static void DetectFilemagicFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr != NULL) {
         DetectFilemagicData *filemagic = (DetectFilemagicData *)ptr;
@@ -644,9 +645,9 @@ static int PrefilterMpmFilemagicRegister(DetectEngineCtx *de_ctx,
  */
 static int DetectFilemagicTestParse01 (void)
 {
-    DetectFilemagicData *dnd = DetectFilemagicParse("secret.pdf", false);
+    DetectFilemagicData *dnd = DetectFilemagicParse(NULL, "secret.pdf", false);
     if (dnd != NULL) {
-        DetectFilemagicFree(dnd);
+        DetectFilemagicFree(NULL, dnd);
         return 1;
     }
     return 0;
@@ -659,13 +660,13 @@ static int DetectFilemagicTestParse02 (void)
 {
     int result = 0;
 
-    DetectFilemagicData *dnd = DetectFilemagicParse("backup.tar.gz", false);
+    DetectFilemagicData *dnd = DetectFilemagicParse(NULL, "backup.tar.gz", false);
     if (dnd != NULL) {
         if (dnd->len == 13 && memcmp(dnd->name, "backup.tar.gz", 13) == 0) {
             result = 1;
         }
 
-        DetectFilemagicFree(dnd);
+        DetectFilemagicFree(NULL, dnd);
         return result;
     }
     return 0;
@@ -678,13 +679,13 @@ static int DetectFilemagicTestParse03 (void)
 {
     int result = 0;
 
-    DetectFilemagicData *dnd = DetectFilemagicParse("cmd.exe", false);
+    DetectFilemagicData *dnd = DetectFilemagicParse(NULL, "cmd.exe", false);
     if (dnd != NULL) {
         if (dnd->len == 7 && memcmp(dnd->name, "cmd.exe", 7) == 0) {
             result = 1;
         }
 
-        DetectFilemagicFree(dnd);
+        DetectFilemagicFree(NULL, dnd);
         return result;
     }
     return 0;

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -59,7 +59,7 @@ static int DetectFilenameMatch (DetectEngineThreadCtx *, Flow *,
 static int DetectFilenameSetup (DetectEngineCtx *, Signature *, const char *);
 static int DetectFilenameSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str);
 static void DetectFilenameRegisterTests(void);
-static void DetectFilenameFree(void *);
+static void DetectFilenameFree(DetectEngineCtx *, void *);
 static int g_file_match_list_id = 0;
 static int g_file_name_buffer_id = 0;
 
@@ -215,12 +215,13 @@ static int DetectFilenameMatch (DetectEngineThreadCtx *det_ctx,
 /**
  * \brief Parse the filename keyword
  *
+ * \param de_ctx Pointer to the detection engine context
  * \param idstr Pointer to the user provided option
  *
  * \retval filename pointer to DetectFilenameData on success
  * \retval NULL on failure
  */
-static DetectFilenameData *DetectFilenameParse (const char *str, bool negate)
+static DetectFilenameData *DetectFilenameParse (DetectEngineCtx *de_ctx, const char *str, bool negate)
 {
     DetectFilenameData *filename = NULL;
 
@@ -265,7 +266,7 @@ static DetectFilenameData *DetectFilenameParse (const char *str, bool negate)
 
 error:
     if (filename != NULL)
-        DetectFilenameFree(filename);
+        DetectFilenameFree(de_ctx, filename);
     return NULL;
 }
 
@@ -285,7 +286,7 @@ static int DetectFilenameSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     DetectFilenameData *filename = NULL;
     SigMatch *sm = NULL;
 
-    filename = DetectFilenameParse(str, s->init_data->negated);
+    filename = DetectFilenameParse(de_ctx, str, s->init_data->negated);
     if (filename == NULL)
         goto error;
 
@@ -305,7 +306,7 @@ static int DetectFilenameSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
 
 error:
     if (filename != NULL)
-        DetectFilenameFree(filename);
+        DetectFilenameFree(de_ctx, filename);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -316,7 +317,7 @@ error:
  *
  * \param filename pointer to DetectFilenameData
  */
-static void DetectFilenameFree(void *ptr)
+static void DetectFilenameFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr != NULL) {
         DetectFilenameData *filename = (DetectFilenameData *)ptr;
@@ -508,9 +509,9 @@ static int DetectFilenameSignatureParseTest01(void)
  */
 static int DetectFilenameTestParse01 (void)
 {
-    DetectFilenameData *dnd = DetectFilenameParse("secret.pdf", false);
+    DetectFilenameData *dnd = DetectFilenameParse(NULL, "secret.pdf", false);
     if (dnd != NULL) {
-        DetectFilenameFree(dnd);
+        DetectFilenameFree(NULL, dnd);
         return 1;
     }
     return 0;
@@ -523,13 +524,13 @@ static int DetectFilenameTestParse02 (void)
 {
     int result = 0;
 
-    DetectFilenameData *dnd = DetectFilenameParse("backup.tar.gz", false);
+    DetectFilenameData *dnd = DetectFilenameParse(NULL, "backup.tar.gz", false);
     if (dnd != NULL) {
         if (dnd->len == 13 && memcmp(dnd->name, "backup.tar.gz", 13) == 0) {
             result = 1;
         }
 
-        DetectFilenameFree(dnd);
+        DetectFilenameFree(NULL, dnd);
         return result;
     }
     return 0;
@@ -542,13 +543,13 @@ static int DetectFilenameTestParse03 (void)
 {
     int result = 0;
 
-    DetectFilenameData *dnd = DetectFilenameParse("cmd.exe", false);
+    DetectFilenameData *dnd = DetectFilenameParse(NULL, "cmd.exe", false);
     if (dnd != NULL) {
         if (dnd->len == 7 && memcmp(dnd->name, "cmd.exe", 7) == 0) {
             result = 1;
         }
 
-        DetectFilenameFree(dnd);
+        DetectFilenameFree(NULL, dnd);
         return result;
     }
     return 0;

--- a/src/detect-filesize.c
+++ b/src/detect-filesize.c
@@ -52,7 +52,7 @@ static DetectParseRegex parse_regex;
 static int DetectFilesizeMatch (DetectEngineThreadCtx *det_ctx, Flow *f,
         uint8_t flags, File *file, const Signature *s, const SigMatchCtx *m);
 static int DetectFilesizeSetup (DetectEngineCtx *, Signature *, const char *);
-static void DetectFilesizeFree (void *);
+static void DetectFilesizeFree (DetectEngineCtx *, void *);
 static void DetectFilesizeRegisterTests (void);
 static int g_file_match_list_id = 0;
 
@@ -293,7 +293,7 @@ static int DetectFilesizeSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
 
 error:
     if (fsd != NULL)
-        DetectFilesizeFree(fsd);
+        DetectFilesizeFree(de_ctx, fsd);
     if (sm != NULL)
         SCFree(sm);
     SCReturnInt(-1);
@@ -304,7 +304,7 @@ error:
  *
  * \param ptr pointer to DetectFilesizeData
  */
-static void DetectFilesizeFree(void *ptr)
+static void DetectFilesizeFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectFilesizeData *fsd = (DetectFilesizeData *)ptr;
     SCFree(fsd);
@@ -329,7 +329,7 @@ static int DetectFilesizeParseTest01(void)
         if (fsd->size1 == 10 && fsd->mode == DETECT_FILESIZE_EQ)
             ret = 1;
 
-        DetectFilesizeFree(fsd);
+        DetectFilesizeFree(NULL, fsd);
     }
     return ret;
 }
@@ -345,7 +345,7 @@ static int DetectFilesizeParseTest02(void)
         if (fsd->size1 == 10 && fsd->mode == DETECT_FILESIZE_LT)
             ret = 1;
 
-        DetectFilesizeFree(fsd);
+        DetectFilesizeFree(NULL, fsd);
     }
     return ret;
 }
@@ -361,7 +361,7 @@ static int DetectFilesizeParseTest03(void)
         if (fsd->size1 == 10 && fsd->mode == DETECT_FILESIZE_GT)
             ret = 1;
 
-        DetectFilesizeFree(fsd);
+        DetectFilesizeFree(NULL, fsd);
     }
     return ret;
 }
@@ -378,7 +378,7 @@ static int DetectFilesizeParseTest04(void)
             fsd->mode == DETECT_FILESIZE_RA)
             ret = 1;
 
-        DetectFilesizeFree(fsd);
+        DetectFilesizeFree(NULL, fsd);
     }
     return ret;
 }
@@ -395,7 +395,7 @@ static int DetectFilesizeParseTest05(void)
             fsd->mode == DETECT_FILESIZE_RA)
             ret = 1;
 
-        DetectFilesizeFree(fsd);
+        DetectFilesizeFree(NULL, fsd);
     }
     return ret;
 }

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -66,7 +66,7 @@ static int DetectFilestoreMatch (DetectEngineThreadCtx *,
 static int DetectFilestorePostMatch(DetectEngineThreadCtx *det_ctx,
         Packet *p, const Signature *s, const SigMatchCtx *ctx);
 static int DetectFilestoreSetup (DetectEngineCtx *, Signature *, const char *);
-static void DetectFilestoreFree(void *);
+static void DetectFilestoreFree(DetectEngineCtx *, void *);
 static void DetectFilestoreRegisterTests(void);
 static int g_file_match_list_id = 0;
 
@@ -475,7 +475,7 @@ error:
     return -1;
 }
 
-static void DetectFilestoreFree(void *ptr)
+static void DetectFilestoreFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr != NULL) {
         SCFree(ptr);

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -51,7 +51,7 @@ static DetectParseRegex parse_regex;
 int DetectFlowbitMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectFlowbitSetup (DetectEngineCtx *, Signature *, const char *);
-void DetectFlowbitFree (void *);
+void DetectFlowbitFree (DetectEngineCtx *, void *);
 void FlowBitsRegisterTests(void);
 
 void DetectFlowbitsRegister (void)
@@ -292,7 +292,7 @@ error:
     return -1;
 }
 
-void DetectFlowbitFree (void *ptr)
+void DetectFlowbitFree (DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectFlowbitsData *fd = (DetectFlowbitsData *)ptr;
 

--- a/src/detect-flowint.c
+++ b/src/detect-flowint.c
@@ -55,7 +55,7 @@ static DetectParseRegex parse_regex;
 int DetectFlowintMatch(DetectEngineThreadCtx *, Packet *,
                        const Signature *, const SigMatchCtx *);
 static int DetectFlowintSetup(DetectEngineCtx *, Signature *, const char *);
-void DetectFlowintFree(void *);
+void DetectFlowintFree(DetectEngineCtx *, void *);
 void DetectFlowintRegisterTests(void);
 
 void DetectFlowintRegister(void)
@@ -400,7 +400,7 @@ static int DetectFlowintSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
 
 error:
     if (sfd)
-        DetectFlowintFree(sfd);
+        DetectFlowintFree(de_ctx, sfd);
     if (sm)
         SCFree(sm);
     return -1;
@@ -409,7 +409,7 @@ error:
 /**
  * \brief This function is used to free the data of DetectFlowintData
  */
-void DetectFlowintFree(void *tmp)
+void DetectFlowintFree(DetectEngineCtx *de_ctx, void *tmp)
 {
     DetectFlowintData *sfd =(DetectFlowintData*) tmp;
     if (sfd != NULL) {
@@ -468,7 +468,7 @@ static int DetectFlowintTestParseVal01(void)
             && sfd->modifier == FLOWINT_MODIFIER_SET) {
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     DetectEngineCtxFree(de_ctx);
 
@@ -499,7 +499,7 @@ static int DetectFlowintTestParseVar01(void)
 
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
     DetectEngineCtxFree(de_ctx);
 
     return result;
@@ -525,7 +525,7 @@ static int DetectFlowintTestParseVal02(void)
             && sfd->modifier == FLOWINT_MODIFIER_ADD) {
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     DetectEngineCtxFree(de_ctx);
 
@@ -556,7 +556,7 @@ static int DetectFlowintTestParseVar02(void)
 
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
     DetectEngineCtxFree(de_ctx);
 
     return result;
@@ -582,7 +582,7 @@ static int DetectFlowintTestParseVal03(void)
             && sfd->modifier == FLOWINT_MODIFIER_SUB) {
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     DetectEngineCtxFree(de_ctx);
 
@@ -613,7 +613,7 @@ static int DetectFlowintTestParseVar03(void)
 
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
     DetectEngineCtxFree(de_ctx);
 
     return result;
@@ -640,7 +640,7 @@ static int DetectFlowintTestParseVal04(void)
             && sfd->modifier == FLOWINT_MODIFIER_EQ) {
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     DetectEngineCtxFree(de_ctx);
 
@@ -671,7 +671,7 @@ static int DetectFlowintTestParseVar04(void)
 
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
     DetectEngineCtxFree(de_ctx);
 
     return result;
@@ -697,7 +697,7 @@ static int DetectFlowintTestParseVal05(void)
             && sfd->modifier == FLOWINT_MODIFIER_NE) {
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     DetectEngineCtxFree(de_ctx);
 
@@ -728,7 +728,7 @@ static int DetectFlowintTestParseVar05(void)
 
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
     DetectEngineCtxFree(de_ctx);
 
     return result;
@@ -754,7 +754,7 @@ static int DetectFlowintTestParseVal06(void)
             && sfd->modifier == FLOWINT_MODIFIER_GT) {
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     DetectEngineCtxFree(de_ctx);
 
@@ -785,7 +785,7 @@ static int DetectFlowintTestParseVar06(void)
 
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
     DetectEngineCtxFree(de_ctx);
 
     return result;
@@ -811,7 +811,7 @@ static int DetectFlowintTestParseVal07(void)
             && sfd->modifier == FLOWINT_MODIFIER_GE) {
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     DetectEngineCtxFree(de_ctx);
 
@@ -842,7 +842,7 @@ static int DetectFlowintTestParseVar07(void)
 
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
     DetectEngineCtxFree(de_ctx);
 
     return result;
@@ -868,7 +868,7 @@ static int DetectFlowintTestParseVal08(void)
             && sfd->modifier == FLOWINT_MODIFIER_LE) {
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     DetectEngineCtxFree(de_ctx);
 
@@ -899,7 +899,7 @@ static int DetectFlowintTestParseVar08(void)
 
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
     DetectEngineCtxFree(de_ctx);
 
     return result;
@@ -925,7 +925,7 @@ static int DetectFlowintTestParseVal09(void)
             && sfd->modifier == FLOWINT_MODIFIER_LT) {
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     DetectEngineCtxFree(de_ctx);
 
@@ -956,7 +956,7 @@ static int DetectFlowintTestParseVar09(void)
 
         result = 1;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
     DetectEngineCtxFree(de_ctx);
 
     return result;
@@ -987,7 +987,7 @@ static int DetectFlowintTestParseIsset10(void)
         result = 0;
     }
 
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
     sfd = DetectFlowintParse(de_ctx, "myvar, notset");
     DetectFlowintPrintData(sfd);
     if (sfd != NULL && !strcmp(sfd->name, "myvar")
@@ -999,7 +999,7 @@ static int DetectFlowintTestParseIsset10(void)
         result = 0;
     }
 
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
     DetectEngineCtxFree(de_ctx);
 
     return result;
@@ -1024,56 +1024,56 @@ static int DetectFlowintTestParseInvalidSyntaxis01(void)
         SCLogDebug("DetectFlowintTestParseInvalidSyntaxis01: ERROR: invalid option at myvar,=,9532458716234857");
         result = 0;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     sfd = DetectFlowintParse(de_ctx, "myvar,=,45targetvar");
     if (sfd != NULL) {
         SCLogDebug("DetectFlowintTestParseInvalidSyntaxis01: ERROR: invalid option at myvar,=,45targetvar ");
         result = 0;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     sfd = DetectFlowintParse(de_ctx, "657myvar,=,targetvar");
     if (sfd != NULL) {
         SCLogDebug("DetectFlowintTestParseInvalidSyntaxis01: ERROR: invalid option at 657myvar,=,targetvar ");
         result = 0;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     sfd = DetectFlowintParse(de_ctx, "myvar,=<,targetvar");
     if (sfd != NULL) {
         SCLogDebug("DetectFlowintTestParseInvalidSyntaxis01: ERROR: invalid option at myvar,=<,targetvar ");
         result = 0;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     sfd = DetectFlowintParse(de_ctx, "myvar,===,targetvar");
     if (sfd != NULL) {
         SCLogDebug("DetectFlowintTestParseInvalidSyntaxis01: ERROR: invalid option at myvar,===,targetvar ");
         result = 0;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     sfd = DetectFlowintParse(de_ctx, "myvar,==");
     if (sfd != NULL) {
         SCLogDebug("DetectFlowintTestParseInvalidSyntaxis01: ERROR: invalid option at myvar,==");
         result = 0;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     sfd = DetectFlowintParse(de_ctx, "myvar,");
     if (sfd != NULL) {
         SCLogDebug("DetectFlowintTestParseInvalidSyntaxis01: ERROR: invalid option at myvar,");
         result = 0;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     sfd = DetectFlowintParse(de_ctx, "myvar");
     if (sfd != NULL) {
         SCLogDebug("DetectFlowintTestParseInvalidSyntaxis01: ERROR: invalid option at myvar");
         result = 0;
     }
-    if (sfd) DetectFlowintFree(sfd);
+    if (sfd) DetectFlowintFree(NULL, sfd);
 
     DetectEngineCtxFree(de_ctx);
 

--- a/src/detect-flowvar.c
+++ b/src/detect-flowvar.c
@@ -49,7 +49,7 @@ int DetectFlowvarMatch (DetectEngineThreadCtx *, Packet *,
 static int DetectFlowvarSetup (DetectEngineCtx *, Signature *, const char *);
 static int DetectFlowvarPostMatch(DetectEngineThreadCtx *det_ctx,
         Packet *p, const Signature *s, const SigMatchCtx *ctx);
-static void DetectFlowvarDataFree(void *ptr);
+static void DetectFlowvarDataFree(DetectEngineCtx *, void *ptr);
 
 void DetectFlowvarRegister (void)
 {
@@ -74,7 +74,7 @@ void DetectFlowvarRegister (void)
  *
  * \param cd pointer to DetectCotentData
  */
-static void DetectFlowvarDataFree(void *ptr)
+static void DetectFlowvarDataFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr == NULL)
         SCReturn;
@@ -190,7 +190,7 @@ static int DetectFlowvarSetup (DetectEngineCtx *de_ctx, Signature *s, const char
 
 error:
     if (fd != NULL)
-        DetectFlowvarDataFree(fd);
+        DetectFlowvarDataFree(de_ctx, fd);
     if (sm != NULL)
         SCFree(sm);
     if (content != NULL)
@@ -255,7 +255,7 @@ int DetectVarStoreMatch(DetectEngineThreadCtx *det_ctx,
 /** \brief Setup a post-match for flowvar storage
  *  We're piggyback riding the DetectFlowvarData struct
  */
-int DetectFlowvarPostMatchSetup(Signature *s, uint32_t idx)
+int DetectFlowvarPostMatchSetup(DetectEngineCtx *de_ctx, Signature *s, uint32_t idx)
 {
     SigMatch *sm = NULL;
     DetectFlowvarData *fv = NULL;
@@ -279,7 +279,7 @@ int DetectFlowvarPostMatchSetup(Signature *s, uint32_t idx)
     return 0;
 error:
     if (fv != NULL)
-        DetectFlowvarDataFree(fv);
+        DetectFlowvarDataFree(de_ctx, fv);
     return -1;
 }
 

--- a/src/detect-flowvar.h
+++ b/src/detect-flowvar.h
@@ -35,7 +35,7 @@ typedef struct DetectFlowvarData_ {
 /* prototypes */
 void DetectFlowvarRegister (void);
 
-int DetectFlowvarPostMatchSetup(Signature *s, uint32_t idx);
+int DetectFlowvarPostMatchSetup(DetectEngineCtx *de_ctx, Signature *s, uint32_t idx);
 int DetectVarStoreMatch(DetectEngineThreadCtx *,
         uint32_t, uint8_t *, uint16_t, int);
 int DetectVarStoreMatchKeyValue(DetectEngineThreadCtx *,

--- a/src/detect-fragbits.c
+++ b/src/detect-fragbits.c
@@ -70,7 +70,7 @@ static DetectParseRegex parse_regex;
 static int DetectFragBitsMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectFragBitsSetup (DetectEngineCtx *, Signature *, const char *);
-static void DetectFragBitsFree(void *);
+static void DetectFragBitsFree(DetectEngineCtx *, void *);
 
 static int PrefilterSetupFragBits(DetectEngineCtx *de_ctx, SigGroupHead *sgh);
 static bool PrefilterFragBitsIsPrefilterable(const Signature *s);
@@ -308,7 +308,7 @@ error:
  *
  * \param de pointer to DetectFragBitsData
  */
-static void DetectFragBitsFree(void *de_ptr)
+static void DetectFragBitsFree(DetectEngineCtx *de_ctx, void *de_ptr)
 {
     DetectFragBitsData *de = (DetectFragBitsData *)de_ptr;
     if(de) SCFree(de);
@@ -392,7 +392,7 @@ static int FragBitsTestParse01 (void)
     DetectFragBitsData *de = NULL;
     de = DetectFragBitsParse("M");
     if (de && (de->fragbits == FRAGBITS_HAVE_MF) ) {
-        DetectFragBitsFree(de);
+        DetectFragBitsFree(NULL, de);
         return 1;
     }
 
@@ -410,7 +410,7 @@ static int FragBitsTestParse02 (void)
     DetectFragBitsData *de = NULL;
     de = DetectFragBitsParse("G");
     if (de) {
-        DetectFragBitsFree(de);
+        DetectFragBitsFree(NULL, de);
         return 0;
     }
 

--- a/src/detect-ftpbounce.c
+++ b/src/detect-ftpbounce.c
@@ -269,7 +269,7 @@ static int DetectFtpbounceTestSetup01(void)
     FAIL_IF(s->sm_lists[g_ftp_request_list_id] == NULL);
     FAIL_IF_NOT(s->sm_lists[g_ftp_request_list_id]->type & DETECT_FTPBOUNCE);
 
-    SigFree(s);
+    SigFree(de_ctx, s);
     PASS;
 }
 

--- a/src/detect-ftpdata.c
+++ b/src/detect-ftpdata.c
@@ -45,7 +45,7 @@ static int DetectFtpdataMatch(DetectEngineThreadCtx *,
         Flow *, uint8_t, void *, void *,
         const Signature *, const SigMatchCtx *);
 static int DetectFtpdataSetup (DetectEngineCtx *, Signature *, const char *);
-static void DetectFtpdataFree (void *);
+static void DetectFtpdataFree (DetectEngineCtx *, void *);
 static void DetectFtpdataRegisterTests (void);
 static int DetectEngineInspectFtpdataGeneric(ThreadVars *tv,
         DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
@@ -201,7 +201,7 @@ static int DetectFtpdataSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
 
     SigMatch *sm = SigMatchAlloc();
     if (sm == NULL) {
-        DetectFtpdataFree(ftpcommandd);
+        DetectFtpdataFree(de_ctx, ftpcommandd);
         return -1;
     }
     sm->type = DETECT_FTPDATA;
@@ -216,7 +216,7 @@ static int DetectFtpdataSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
  *
  * \param ptr pointer to DetectFtpdataData
  */
-static void DetectFtpdataFree(void *ptr) {
+static void DetectFtpdataFree(DetectEngineCtx *de_ctx, void *ptr) {
     DetectFtpdataData *ftpcommandd = (DetectFtpdataData *)ptr;
 
     /* do more specific cleanup here, if needed */
@@ -231,7 +231,7 @@ static int DetectFtpdataParseTest01(void)
     DetectFtpdataData *ftpcommandd = DetectFtpdataParse("stor");
     FAIL_IF_NULL(ftpcommandd);
     FAIL_IF(!(ftpcommandd->command == FTP_COMMAND_STOR));
-    DetectFtpdataFree(ftpcommandd);
+    DetectFtpdataFree(NULL, ftpcommandd);
     PASS;
 }
 

--- a/src/detect-geoip.c
+++ b/src/detect-geoip.c
@@ -70,7 +70,7 @@ static int DetectGeoipMatch(DetectEngineThreadCtx *, Packet *,
                             const Signature *, const SigMatchCtx *);
 static int DetectGeoipSetup(DetectEngineCtx *, Signature *, const char *);
 static void DetectGeoipRegisterTests(void);
-static void DetectGeoipDataFree(void *);
+static void DetectGeoipDataFree(DetectEngineCtx *, void *);
 
 /**
  * \brief Registration function for geoip keyword
@@ -284,12 +284,13 @@ static int DetectGeoipMatch(DetectEngineThreadCtx *det_ctx,
 /**
  * \brief This function is used to parse geoipdata
  *
+ * \param de_ctx Pointer to the detection engine context
  * \param str Pointer to the geoipdata value string
  *
  * \retval pointer to DetectGeoipData on success
  * \retval NULL on failure
  */
-static DetectGeoipData *DetectGeoipDataParse (const char *str)
+static DetectGeoipData *DetectGeoipDataParse (DetectEngineCtx *de_ctx, const char *str)
 {
     DetectGeoipData *geoipdata = NULL;
     uint16_t pos = 0;
@@ -388,7 +389,7 @@ static DetectGeoipData *DetectGeoipDataParse (const char *str)
 
 error:
     if (geoipdata != NULL)
-        DetectGeoipDataFree(geoipdata);
+        DetectGeoipDataFree(de_ctx, geoipdata);
     return NULL;
 }
 
@@ -408,7 +409,7 @@ static int DetectGeoipSetup(DetectEngineCtx *de_ctx, Signature *s, const char *o
     DetectGeoipData *geoipdata = NULL;
     SigMatch *sm = NULL;
 
-    geoipdata = DetectGeoipDataParse(optstr);
+    geoipdata = DetectGeoipDataParse(de_ctx, optstr);
     if (geoipdata == NULL)
         goto error;
 
@@ -427,7 +428,7 @@ static int DetectGeoipSetup(DetectEngineCtx *de_ctx, Signature *s, const char *o
 
 error:
     if (geoipdata != NULL)
-        DetectGeoipDataFree(geoipdata);
+        DetectGeoipDataFree(de_ctx, geoipdata);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -439,7 +440,7 @@ error:
  *
  * \param geoipdata pointer to DetectGeoipData
  */
-static void DetectGeoipDataFree(void *ptr)
+static void DetectGeoipDataFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr != NULL) {
         DetectGeoipData *geoipdata = (DetectGeoipData *)ptr;

--- a/src/detect-hostbits.c
+++ b/src/detect-hostbits.c
@@ -70,7 +70,7 @@ static DetectParseRegex parse_regex;
 static int DetectHostbitMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectHostbitSetup (DetectEngineCtx *, Signature *, const char *);
-void DetectHostbitFree (void *);
+void DetectHostbitFree (DetectEngineCtx *, void *);
 void HostBitsRegisterTests(void);
 
 void DetectHostbitsRegister (void)
@@ -433,7 +433,7 @@ error:
     return -1;
 }
 
-void DetectHostbitFree (void *ptr)
+void DetectHostbitFree (DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectXbitsData *fd = (DetectXbitsData *)ptr;
 

--- a/src/detect-icmp-id.c
+++ b/src/detect-icmp-id.c
@@ -46,7 +46,7 @@ static int DetectIcmpIdMatch(DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectIcmpIdSetup(DetectEngineCtx *, Signature *, const char *);
 void DetectIcmpIdRegisterTests(void);
-void DetectIcmpIdFree(void *);
+void DetectIcmpIdFree(DetectEngineCtx *, void *);
 static int PrefilterSetupIcmpId(DetectEngineCtx *de_ctx, SigGroupHead *sgh);
 static bool PrefilterIcmpIdIsPrefilterable(const Signature *s);
 
@@ -147,12 +147,13 @@ static int DetectIcmpIdMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
 /**
  * \brief This function is used to parse icmp_id option passed via icmp_id: keyword
  *
+ * \param de_ctx Pointer to the detection engine context
  * \param icmpidstr Pointer to the user provided icmp_id options
  *
  * \retval iid pointer to DetectIcmpIdData on success
  * \retval NULL on failure
  */
-static DetectIcmpIdData *DetectIcmpIdParse (const char *icmpidstr)
+static DetectIcmpIdData *DetectIcmpIdParse (DetectEngineCtx *de_ctx, const char *icmpidstr)
 {
     DetectIcmpIdData *iid = NULL;
     char *substr[3] = {NULL, NULL, NULL};
@@ -210,7 +211,7 @@ error:
     for (i = 0; i < 3; i++) {
         if (substr[i] != NULL) SCFree(substr[i]);
     }
-    if (iid != NULL) DetectIcmpIdFree(iid);
+    if (iid != NULL) DetectIcmpIdFree(de_ctx, iid);
     return NULL;
 
 }
@@ -230,7 +231,7 @@ static int DetectIcmpIdSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     DetectIcmpIdData *iid = NULL;
     SigMatch *sm = NULL;
 
-    iid = DetectIcmpIdParse(icmpidstr);
+    iid = DetectIcmpIdParse(de_ctx, icmpidstr);
     if (iid == NULL) goto error;
 
     sm = SigMatchAlloc();
@@ -245,7 +246,7 @@ static int DetectIcmpIdSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     return 0;
 
 error:
-    if (iid != NULL) DetectIcmpIdFree(iid);
+    if (iid != NULL) DetectIcmpIdFree(de_ctx, iid);
     if (sm != NULL) SCFree(sm);
     return -1;
 
@@ -256,7 +257,7 @@ error:
  *
  * \param ptr pointer to DetectIcmpIdData
  */
-void DetectIcmpIdFree (void *ptr)
+void DetectIcmpIdFree (DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectIcmpIdData *iid = (DetectIcmpIdData *)ptr;
     SCFree(iid);
@@ -326,9 +327,9 @@ static bool PrefilterIcmpIdIsPrefilterable(const Signature *s)
 static int DetectIcmpIdParseTest01 (void)
 {
     DetectIcmpIdData *iid = NULL;
-    iid = DetectIcmpIdParse("300");
+    iid = DetectIcmpIdParse(NULL, "300");
     if (iid != NULL && iid->id == htons(300)) {
-        DetectIcmpIdFree(iid);
+        DetectIcmpIdFree(NULL, iid);
         return 1;
     }
     return 0;
@@ -341,9 +342,9 @@ static int DetectIcmpIdParseTest01 (void)
 static int DetectIcmpIdParseTest02 (void)
 {
     DetectIcmpIdData *iid = NULL;
-    iid = DetectIcmpIdParse("  300  ");
+    iid = DetectIcmpIdParse(NULL, "  300  ");
     if (iid != NULL && iid->id == htons(300)) {
-        DetectIcmpIdFree(iid);
+        DetectIcmpIdFree(NULL, iid);
         return 1;
     }
     return 0;
@@ -356,9 +357,9 @@ static int DetectIcmpIdParseTest02 (void)
 static int DetectIcmpIdParseTest03 (void)
 {
     DetectIcmpIdData *iid = NULL;
-    iid = DetectIcmpIdParse("\"300\"");
+    iid = DetectIcmpIdParse(NULL, "\"300\"");
     if (iid != NULL && iid->id == htons(300)) {
-        DetectIcmpIdFree(iid);
+        DetectIcmpIdFree(NULL, iid);
         return 1;
     }
     return 0;
@@ -371,9 +372,9 @@ static int DetectIcmpIdParseTest03 (void)
 static int DetectIcmpIdParseTest04 (void)
 {
     DetectIcmpIdData *iid = NULL;
-    iid = DetectIcmpIdParse("   \"   300 \"");
+    iid = DetectIcmpIdParse(NULL, "   \"   300 \"");
     if (iid != NULL && iid->id == htons(300)) {
-        DetectIcmpIdFree(iid);
+        DetectIcmpIdFree(NULL, iid);
         return 1;
     }
     return 0;
@@ -386,9 +387,9 @@ static int DetectIcmpIdParseTest04 (void)
 static int DetectIcmpIdParseTest05 (void)
 {
     DetectIcmpIdData *iid = NULL;
-    iid = DetectIcmpIdParse("\"300");
+    iid = DetectIcmpIdParse(NULL, "\"300");
     if (iid == NULL) {
-        DetectIcmpIdFree(iid);
+        DetectIcmpIdFree(NULL, iid);
         return 1;
     }
     return 0;

--- a/src/detect-icmp-seq.c
+++ b/src/detect-icmp-seq.c
@@ -46,7 +46,7 @@ static int DetectIcmpSeqMatch(DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectIcmpSeqSetup(DetectEngineCtx *, Signature *, const char *);
 void DetectIcmpSeqRegisterTests(void);
-void DetectIcmpSeqFree(void *);
+void DetectIcmpSeqFree(DetectEngineCtx *, void *);
 static int PrefilterSetupIcmpSeq(DetectEngineCtx *de_ctx, SigGroupHead *sgh);
 static bool PrefilterIcmpSeqIsPrefilterable(const Signature *s);
 
@@ -149,12 +149,13 @@ static int DetectIcmpSeqMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
 /**
  * \brief This function is used to parse icmp_seq option passed via icmp_seq: keyword
  *
+ * \param de_ctx Pointer to the detection engine context
  * \param icmpseqstr Pointer to the user provided icmp_seq options
  *
  * \retval iseq pointer to DetectIcmpSeqData on success
  * \retval NULL on failure
  */
-static DetectIcmpSeqData *DetectIcmpSeqParse (const char *icmpseqstr)
+static DetectIcmpSeqData *DetectIcmpSeqParse (DetectEngineCtx *de_ctx, const char *icmpseqstr)
 {
     DetectIcmpSeqData *iseq = NULL;
     char *substr[3] = {NULL, NULL, NULL};
@@ -214,7 +215,7 @@ error:
     for (i = 0; i < 3; i++) {
         if (substr[i] != NULL) SCFree(substr[i]);
     }
-    if (iseq != NULL) DetectIcmpSeqFree(iseq);
+    if (iseq != NULL) DetectIcmpSeqFree(de_ctx, iseq);
     return NULL;
 
 }
@@ -234,7 +235,7 @@ static int DetectIcmpSeqSetup (DetectEngineCtx *de_ctx, Signature *s, const char
     DetectIcmpSeqData *iseq = NULL;
     SigMatch *sm = NULL;
 
-    iseq = DetectIcmpSeqParse(icmpseqstr);
+    iseq = DetectIcmpSeqParse(de_ctx, icmpseqstr);
     if (iseq == NULL) goto error;
 
     sm = SigMatchAlloc();
@@ -248,7 +249,7 @@ static int DetectIcmpSeqSetup (DetectEngineCtx *de_ctx, Signature *s, const char
     return 0;
 
 error:
-    if (iseq != NULL) DetectIcmpSeqFree(iseq);
+    if (iseq != NULL) DetectIcmpSeqFree(de_ctx, iseq);
     if (sm != NULL) SCFree(sm);
     return -1;
 
@@ -259,7 +260,7 @@ error:
  *
  * \param ptr pointer to DetectIcmpSeqData
  */
-void DetectIcmpSeqFree (void *ptr)
+void DetectIcmpSeqFree (DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectIcmpSeqData *iseq = (DetectIcmpSeqData *)ptr;
     SCFree(iseq);
@@ -330,9 +331,9 @@ static bool PrefilterIcmpSeqIsPrefilterable(const Signature *s)
 static int DetectIcmpSeqParseTest01 (void)
 {
     DetectIcmpSeqData *iseq = NULL;
-    iseq = DetectIcmpSeqParse("300");
+    iseq = DetectIcmpSeqParse(NULL, "300");
     if (iseq != NULL && htons(iseq->seq) == 300) {
-        DetectIcmpSeqFree(iseq);
+        DetectIcmpSeqFree(NULL, iseq);
         return 1;
     }
     return 0;
@@ -345,9 +346,9 @@ static int DetectIcmpSeqParseTest01 (void)
 static int DetectIcmpSeqParseTest02 (void)
 {
     DetectIcmpSeqData *iseq = NULL;
-    iseq = DetectIcmpSeqParse("  300  ");
+    iseq = DetectIcmpSeqParse(NULL, "  300  ");
     if (iseq != NULL && htons(iseq->seq) == 300) {
-        DetectIcmpSeqFree(iseq);
+        DetectIcmpSeqFree(NULL, iseq);
         return 1;
     }
     return 0;
@@ -359,9 +360,9 @@ static int DetectIcmpSeqParseTest02 (void)
 static int DetectIcmpSeqParseTest03 (void)
 {
     DetectIcmpSeqData *iseq = NULL;
-    iseq = DetectIcmpSeqParse("badc");
+    iseq = DetectIcmpSeqParse(NULL, "badc");
     if (iseq != NULL) {
-        DetectIcmpSeqFree(iseq);
+        DetectIcmpSeqFree(NULL, iseq);
         return 0;
     }
     return 1;

--- a/src/detect-icmpv6-mtu.c
+++ b/src/detect-icmpv6-mtu.c
@@ -34,7 +34,7 @@
 static int DetectICMPv6mtuMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectICMPv6mtuSetup (DetectEngineCtx *, Signature *, const char *);
-void DetectICMPv6mtuFree (void *);
+void DetectICMPv6mtuFree (DetectEngineCtx *de_ctx, void *);
 #ifdef UNITTESTS
 void DetectICMPv6mtuRegisterTests (void);
 #endif
@@ -118,7 +118,7 @@ static int DetectICMPv6mtuSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
 
     SigMatch *sm = SigMatchAlloc();
     if (sm == NULL) {
-        DetectICMPv6mtuFree(icmpv6mtud);
+        DetectICMPv6mtuFree(de_ctx, icmpv6mtud);
         return -1;
     }
 
@@ -137,7 +137,7 @@ static int DetectICMPv6mtuSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
  *
  * \param ptr pointer to DetectU32Data
  */
-void DetectICMPv6mtuFree(void *ptr)
+void DetectICMPv6mtuFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCFree(ptr);
 }

--- a/src/detect-id.c
+++ b/src/detect-id.c
@@ -52,7 +52,7 @@ static int DetectIdMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectIdSetup (DetectEngineCtx *, Signature *, const char *);
 void DetectIdRegisterTests(void);
-void DetectIdFree(void *);
+void DetectIdFree(DetectEngineCtx *, void *);
 
 static int PrefilterSetupId(DetectEngineCtx *de_ctx, SigGroupHead *sgh);
 static bool PrefilterIdIsPrefilterable(const Signature *s);
@@ -194,7 +194,7 @@ int DetectIdSetup (DetectEngineCtx *de_ctx, Signature *s, const char *idstr)
      * and put it in the Signature. */
     sm = SigMatchAlloc();
     if (sm == NULL) {
-        DetectIdFree(id_d);
+        DetectIdFree(de_ctx, id_d);
         return -1;
     }
 
@@ -211,7 +211,7 @@ int DetectIdSetup (DetectEngineCtx *de_ctx, Signature *s, const char *idstr)
  *
  * \param id_d pointer to DetectIdData
  */
-void DetectIdFree(void *ptr)
+void DetectIdFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectIdData *id_d = (DetectIdData *)ptr;
     SCFree(id_d);
@@ -285,7 +285,7 @@ static int DetectIdTestParse01 (void)
     DetectIdData *id_d = NULL;
     id_d = DetectIdParse(" 35402 ");
     if (id_d != NULL &&id_d->id==35402) {
-        DetectIdFree(id_d);
+        DetectIdFree(NULL, id_d);
         return 1;
     }
 
@@ -302,7 +302,7 @@ static int DetectIdTestParse02 (void)
     DetectIdData *id_d = NULL;
     id_d = DetectIdParse("65537");
     if (id_d == NULL) {
-        DetectIdFree(id_d);
+        DetectIdFree(NULL, id_d);
         return 1;
     }
 
@@ -319,7 +319,7 @@ static int DetectIdTestParse03 (void)
     DetectIdData *id_d = NULL;
     id_d = DetectIdParse("12what?");
     if (id_d == NULL) {
-        DetectIdFree(id_d);
+        DetectIdFree(NULL, id_d);
         return 1;
     }
 
@@ -336,7 +336,7 @@ static int DetectIdTestParse04 (void)
     /* yep, look if we trim blank spaces correctly and ignore "'s */
     id_d = DetectIdParse(" \"35402\" ");
     if (id_d != NULL &&id_d->id==35402) {
-        DetectIdFree(id_d);
+        DetectIdFree(NULL, id_d);
         return 1;
     }
 

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -46,7 +46,7 @@ static int DetectIpOptsMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectIpOptsSetup (DetectEngineCtx *, Signature *, const char *);
 void IpOptsRegisterTests(void);
-void DetectIpOptsFree(void *);
+void DetectIpOptsFree(DetectEngineCtx *, void *);
 
 /**
  * \brief Registration function for ipopts: keyword
@@ -202,7 +202,7 @@ error:
  *
  * \param de pointer to DetectIpOptsData
  */
-void DetectIpOptsFree(void *de_ptr)
+void DetectIpOptsFree(DetectEngineCtx *de_ctx, void *de_ptr)
 {
     DetectIpOptsData *de = (DetectIpOptsData *)de_ptr;
     if(de) SCFree(de);
@@ -224,7 +224,7 @@ static int IpOptsTestParse01 (void)
     DetectIpOptsData *de = NULL;
     de = DetectIpOptsParse("lsrr");
     if (de) {
-        DetectIpOptsFree(de);
+        DetectIpOptsFree(NULL, de);
         return 1;
     }
 
@@ -242,7 +242,7 @@ static int IpOptsTestParse02 (void)
     DetectIpOptsData *de = NULL;
     de = DetectIpOptsParse("invalidopt");
     if (de) {
-        DetectIpOptsFree(de);
+        DetectIpOptsFree(NULL, de);
         return 0;
     }
 

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -52,7 +52,7 @@ static DetectParseRegex parse_regex;
 
 static int DetectIPProtoSetup(DetectEngineCtx *, Signature *, const char *);
 static void DetectIPProtoRegisterTests(void);
-static void DetectIPProtoFree(void *);
+static void DetectIPProtoFree(DetectEngineCtx *, void *);
 
 void DetectIPProtoRegister(void)
 {
@@ -418,12 +418,12 @@ static int DetectIPProtoSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
 
  error:
 
-    DetectIPProtoFree(data);
+    DetectIPProtoFree(de_ctx, data);
     return -1;
 }
 
 
-void DetectIPProtoRemoveAllSMs(Signature *s)
+void DetectIPProtoRemoveAllSMs(DetectEngineCtx *de_ctx, Signature *s)
 {
     SigMatch *sm = s->init_data->smlists[DETECT_SM_LIST_MATCH];
 
@@ -434,14 +434,14 @@ void DetectIPProtoRemoveAllSMs(Signature *s)
         }
         SigMatch *tmp_sm = sm->next;
         SigMatchRemoveSMFromList(s, sm, DETECT_SM_LIST_MATCH);
-        SigMatchFree(sm);
+        SigMatchFree(de_ctx, sm);
         sm = tmp_sm;
     }
 
     return;
 }
 
-static void DetectIPProtoFree(void *ptr)
+static void DetectIPProtoFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectIPProtoData *data = (DetectIPProtoData *)ptr;
     if (data) {
@@ -494,7 +494,7 @@ static int DetectIPProtoTestSetup01(void)
     for (i = (value / 8) + 1; i < (256 / 8); i++) {
         FAIL_IF(sig->proto.proto[i] != 0);
     }
-    SigFree(sig);
+    SigFree(NULL, sig);
     PASS;
 }
 
@@ -535,7 +535,7 @@ static int DetectIPProtoTestSetup02(void)
 
  end:
     if (sig != NULL)
-        SigFree(sig);
+        SigFree(NULL, sig);
     return result;
 }
 
@@ -571,7 +571,7 @@ static int DetectIPProtoTestSetup03(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -607,7 +607,7 @@ static int DetectIPProtoTestSetup04(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -643,7 +643,7 @@ static int DetectIPProtoTestSetup05(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -670,7 +670,7 @@ static int DetectIPProtoTestSetup06(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -697,7 +697,7 @@ static int DetectIPProtoTestSetup07(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -724,7 +724,7 @@ static int DetectIPProtoTestSetup08(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -751,7 +751,7 @@ static int DetectIPProtoTestSetup09(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -778,7 +778,7 @@ static int DetectIPProtoTestSetup10(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -805,7 +805,7 @@ static int DetectIPProtoTestSetup11(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -832,7 +832,7 @@ static int DetectIPProtoTestSetup12(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -859,7 +859,7 @@ static int DetectIPProtoTestSetup13(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -883,7 +883,7 @@ static int DetectIPProtoTestSetup14(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -920,7 +920,7 @@ static int DetectIPProtoTestSetup15(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 
 }
@@ -958,7 +958,7 @@ static int DetectIPProtoTestSetup16(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 
 }
@@ -996,7 +996,7 @@ static int DetectIPProtoTestSetup17(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 
 }
@@ -1034,7 +1034,7 @@ static int DetectIPProtoTestSetup18(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 
 }
@@ -1075,7 +1075,7 @@ static int DetectIPProtoTestSetup19(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1112,7 +1112,7 @@ static int DetectIPProtoTestSetup20(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1152,7 +1152,7 @@ static int DetectIPProtoTestSetup21(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1192,7 +1192,7 @@ static int DetectIPProtoTestSetup22(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1229,7 +1229,7 @@ static int DetectIPProtoTestSetup23(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1269,7 +1269,7 @@ static int DetectIPProtoTestSetup24(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1309,7 +1309,7 @@ static int DetectIPProtoTestSetup33(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1350,7 +1350,7 @@ static int DetectIPProtoTestSetup34(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1390,7 +1390,7 @@ static int DetectIPProtoTestSetup36(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1434,7 +1434,7 @@ static int DetectIPProtoTestSetup43(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1474,7 +1474,7 @@ static int DetectIPProtoTestSetup44(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1518,7 +1518,7 @@ static int DetectIPProtoTestSetup45(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1558,7 +1558,7 @@ static int DetectIPProtoTestSetup56(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1595,7 +1595,7 @@ static int DetectIPProtoTestSetup75(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1632,7 +1632,7 @@ static int DetectIPProtoTestSetup76(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1669,7 +1669,7 @@ static int DetectIPProtoTestSetup129(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1706,7 +1706,7 @@ static int DetectIPProtoTestSetup130(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1743,7 +1743,7 @@ static int DetectIPProtoTestSetup131(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1780,7 +1780,7 @@ static int DetectIPProtoTestSetup132(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 
@@ -1850,7 +1850,7 @@ static int DetectIPProtoTestSetup145(void)
     result = 1;
 
  end:
-    SigFree(sig);
+    SigFree(NULL, sig);
     return result;
 }
 

--- a/src/detect-ipproto.h
+++ b/src/detect-ipproto.h
@@ -42,7 +42,7 @@ typedef struct DetectIPProtoData_ {
  * \brief Registration function for ip_proto keyword.
  */
 void DetectIPProtoRegister (void);
-void DetectIPProtoRemoveAllSMs(Signature *);
+void DetectIPProtoRemoveAllSMs(DetectEngineCtx *, Signature *);
 
 #endif /* __DETECT_IPPROTO_H__ */
 

--- a/src/detect-iprep.c
+++ b/src/detect-iprep.c
@@ -54,7 +54,7 @@ static DetectParseRegex parse_regex;
 static int DetectIPRepMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectIPRepSetup (DetectEngineCtx *, Signature *, const char *);
-void DetectIPRepFree (void *);
+void DetectIPRepFree (DetectEngineCtx *, void *);
 void IPRepRegisterTests(void);
 
 void DetectIPRepRegister (void)
@@ -375,7 +375,7 @@ error:
     return -1;
 }
 
-void DetectIPRepFree (void *ptr)
+void DetectIPRepFree (DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectIPRepData *fd = (DetectIPRepData *)ptr;
 

--- a/src/detect-krb5-errcode.c
+++ b/src/detect-krb5-errcode.c
@@ -43,7 +43,7 @@ static int DetectKrb5ErrCodeMatch (DetectEngineThreadCtx *, Flow *,
                                    uint8_t, void *, void *, const Signature *,
                                    const SigMatchCtx *);
 static int DetectKrb5ErrCodeSetup (DetectEngineCtx *, Signature *, const char *);
-static void DetectKrb5ErrCodeFree (void *);
+static void DetectKrb5ErrCodeFree (DetectEngineCtx *, void *);
 static void DetectKrb5ErrCodeRegisterTests (void);
 
 static int DetectEngineInspectKRB5Generic(ThreadVars *tv,
@@ -202,7 +202,7 @@ static int DetectKrb5ErrCodeSetup (DetectEngineCtx *de_ctx, Signature *s, const 
 
 error:
     if (krb5d != NULL)
-        DetectKrb5ErrCodeFree(krb5d);
+        DetectKrb5ErrCodeFree(de_ctx, krb5d);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -213,7 +213,7 @@ error:
  *
  * \param ptr pointer to DetectKrb5Data
  */
-static void DetectKrb5ErrCodeFree(void *ptr) {
+static void DetectKrb5ErrCodeFree(DetectEngineCtx *de_ctx, void *ptr) {
     DetectKrb5ErrCodeData *krb5d = (DetectKrb5ErrCodeData *)ptr;
 
     SCFree(krb5d);
@@ -230,7 +230,7 @@ static int DetectKrb5ErrCodeParseTest01 (void)
     DetectKrb5ErrCodeData *krb5d = DetectKrb5ErrCodeParse("10");
     FAIL_IF_NULL(krb5d);
     FAIL_IF(!(krb5d->err_code == 10));
-    DetectKrb5ErrCodeFree(krb5d);
+    DetectKrb5ErrCodeFree(NULL, krb5d);
     PASS;
 }
 

--- a/src/detect-krb5-msgtype.c
+++ b/src/detect-krb5-msgtype.c
@@ -43,7 +43,7 @@ static int DetectKrb5MsgTypeMatch (DetectEngineThreadCtx *, Flow *,
                                    uint8_t, void *, void *, const Signature *,
                                    const SigMatchCtx *);
 static int DetectKrb5MsgTypeSetup (DetectEngineCtx *, Signature *, const char *);
-static void DetectKrb5MsgTypeFree (void *);
+static void DetectKrb5MsgTypeFree (DetectEngineCtx *, void *);
 static void DetectKrb5MsgTypeRegisterTests (void);
 
 static int DetectEngineInspectKRB5Generic(ThreadVars *tv,
@@ -199,7 +199,7 @@ static int DetectKrb5MsgTypeSetup (DetectEngineCtx *de_ctx, Signature *s, const 
 
 error:
     if (krb5d != NULL)
-        DetectKrb5MsgTypeFree(krb5d);
+        DetectKrb5MsgTypeFree(de_ctx, krb5d);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -210,7 +210,7 @@ error:
  *
  * \param ptr pointer to DetectKrb5Data
  */
-static void DetectKrb5MsgTypeFree(void *ptr) {
+static void DetectKrb5MsgTypeFree(DetectEngineCtx *de_ctx, void *ptr) {
     DetectKrb5MsgTypeData *krb5d = (DetectKrb5MsgTypeData *)ptr;
 
     SCFree(krb5d);
@@ -227,7 +227,7 @@ static int DetectKrb5MsgTypeParseTest01 (void)
     DetectKrb5MsgTypeData *krb5d = DetectKrb5MsgTypeParse("10");
     FAIL_IF_NULL(krb5d);
     FAIL_IF(!(krb5d->msg_type == 10));
-    DetectKrb5MsgTypeFree(krb5d);
+    DetectKrb5MsgTypeFree(NULL, krb5d);
     PASS;
 }
 

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -98,7 +98,7 @@ static int DetectLuaAppTxMatch (DetectEngineThreadCtx *det_ctx,
                                 const SigMatchCtx *ctx);
 static int DetectLuaSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectLuaRegisterTests(void);
-static void DetectLuaFree(void *);
+static void DetectLuaFree(DetectEngineCtx *, void *);
 static int g_smtp_generic_list_id = 0;
 
 static int InspectSmtpGeneric(ThreadVars *tv,
@@ -660,12 +660,13 @@ static void DetectLuaThreadFree(void *ctx)
 /**
  * \brief Parse the lua keyword
  *
+ * \param de_ctx Pointer to the detection engine context
  * \param str Pointer to the user provided option
  *
  * \retval lua pointer to DetectLuaData on success
  * \retval NULL on failure
  */
-static DetectLuaData *DetectLuaParse (const DetectEngineCtx *de_ctx, const char *str)
+static DetectLuaData *DetectLuaParse (DetectEngineCtx *de_ctx, const char *str)
 {
     DetectLuaData *lua = NULL;
 
@@ -691,7 +692,7 @@ static DetectLuaData *DetectLuaParse (const DetectEngineCtx *de_ctx, const char 
 
 error:
     if (lua != NULL)
-        DetectLuaFree(lua);
+        DetectLuaFree(de_ctx, lua);
     return NULL;
 }
 
@@ -1077,7 +1078,7 @@ static int DetectLuaSetup (DetectEngineCtx *de_ctx, Signature *s, const char *st
 
 error:
     if (lua != NULL)
-        DetectLuaFree(lua);
+        DetectLuaFree(de_ctx, lua);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -1109,7 +1110,7 @@ void DetectLuaPostSetup(Signature *s)
  *
  * \param ptr pointer to DetectLuaData
  */
-static void DetectLuaFree(void *ptr)
+static void DetectLuaFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr != NULL) {
         DetectLuaData *lua = (DetectLuaData *)ptr;
@@ -1118,6 +1119,8 @@ static void DetectLuaFree(void *ptr)
             SCFree(lua->buffername);
         if (lua->filename)
             SCFree(lua->filename);
+
+        DetectUnregisterThreadCtxFuncs(de_ctx, NULL, lua, "lua");
 
         SCFree(lua);
     }

--- a/src/detect-mark.c
+++ b/src/detect-mark.c
@@ -44,7 +44,7 @@ static DetectParseRegex parse_regex;
 static int DetectMarkSetup (DetectEngineCtx *, Signature *, const char *);
 static int DetectMarkPacket(DetectEngineThreadCtx *det_ctx, Packet *p,
         const Signature *s, const SigMatchCtx *ctx);
-void DetectMarkDataFree(void *ptr);
+void DetectMarkDataFree(DetectEngineCtx *, void *ptr);
 
 /**
  * \brief Registration function for nfq_set_mark: keyword
@@ -191,7 +191,7 @@ static int DetectMarkSetup (DetectEngineCtx *de_ctx, Signature *s, const char *r
     }
     SigMatch *sm = SigMatchAlloc();
     if (sm == NULL) {
-        DetectMarkDataFree(data);
+        DetectMarkDataFree(de_ctx, data);
         return -1;
     }
 
@@ -205,7 +205,7 @@ static int DetectMarkSetup (DetectEngineCtx *de_ctx, Signature *s, const char *r
 #endif
 }
 
-void DetectMarkDataFree(void *ptr)
+void DetectMarkDataFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectMarkData *data = (DetectMarkData *)ptr;
     SCFree(data);
@@ -262,7 +262,7 @@ static int MarkTestParse01 (void)
         return 0;
     }
 
-    DetectMarkDataFree(data);
+    DetectMarkDataFree(NULL, data);
     return 1;
 }
 
@@ -282,7 +282,7 @@ static int MarkTestParse02 (void)
         return 1;
     }
 
-    DetectMarkDataFree(data);
+    DetectMarkDataFree(NULL, data);
     return 0;
 }
 
@@ -302,7 +302,7 @@ static int MarkTestParse03 (void)
         return 0;
     }
 
-    DetectMarkDataFree(data);
+    DetectMarkDataFree(NULL, data);
     return 1;
 }
 
@@ -322,7 +322,7 @@ static int MarkTestParse04 (void)
         return 1;
     }
 
-    DetectMarkDataFree(data);
+    DetectMarkDataFree(NULL, data);
     return 0;
 }
 

--- a/src/detect-modbus.c
+++ b/src/detect-modbus.c
@@ -85,7 +85,7 @@ void DetectModbusRegisterTests(void);
  *
  * \param ptr pointer to DetectModbus
  */
-static void DetectModbusFree(void *ptr) {
+static void DetectModbusFree(DetectEngineCtx *de_ctx, void *ptr) {
     SCEnter();
     DetectModbus *modbus = (DetectModbus *) ptr;
 
@@ -110,11 +110,12 @@ static void DetectModbusFree(void *ptr) {
  *
  * \brief This function is used to parse Modbus parameters in access mode
  *
+ * \param de_ctx Pointer to the detection engine context
  * \param str Pointer to the user provided id option
  *
  * \retval Pointer to DetectModbusData on success or NULL on failure
  */
-static DetectModbus *DetectModbusAccessParse(const char *str)
+static DetectModbus *DetectModbusAccessParse(DetectEngineCtx *de_ctx, const char *str)
 {
     SCEnter();
     DetectModbus *modbus = NULL;
@@ -267,7 +268,7 @@ static DetectModbus *DetectModbusAccessParse(const char *str)
 
 error:
     if (modbus != NULL)
-        DetectModbusFree(modbus);
+        DetectModbusFree(de_ctx, modbus);
 
     SCReturnPtr(NULL, "DetectModbus");
 }
@@ -281,7 +282,7 @@ error:
  * \retval id_d pointer to DetectModbusData on success
  * \retval NULL on failure
  */
-static DetectModbus *DetectModbusFunctionParse(const char *str)
+static DetectModbus *DetectModbusFunctionParse(DetectEngineCtx *de_ctx, const char *str)
 {
     SCEnter();
     DetectModbus *modbus = NULL;
@@ -361,7 +362,7 @@ static DetectModbus *DetectModbusFunctionParse(const char *str)
 
 error:
     if (modbus != NULL)
-        DetectModbusFree(modbus);
+        DetectModbusFree(de_ctx, modbus);
 
     SCReturnPtr(NULL, "DetectModbus");
 }
@@ -374,7 +375,7 @@ error:
  *
  * \retval Pointer to DetectModbusUnit on success or NULL on failure
  */
-static DetectModbus *DetectModbusUnitIdParse(const char *str)
+static DetectModbus *DetectModbusUnitIdParse(DetectEngineCtx *de_ctx, const char *str)
 {
     SCEnter();
     DetectModbus *modbus = NULL;
@@ -402,8 +403,8 @@ static DetectModbus *DetectModbusUnitIdParse(const char *str)
             goto error;
         }
 
-        if ((modbus = DetectModbusFunctionParse(str_ptr)) == NULL) {
-            if ((modbus = DetectModbusAccessParse(str_ptr)) == NULL) {
+        if ((modbus = DetectModbusFunctionParse(de_ctx, str_ptr)) == NULL) {
+            if ((modbus = DetectModbusAccessParse(de_ctx, str_ptr)) == NULL) {
                 SCLogError(SC_ERR_PCRE_MATCH, "invalid modbus option");
                 goto error;
             }
@@ -449,7 +450,7 @@ static DetectModbus *DetectModbusUnitIdParse(const char *str)
 
 error:
     if (modbus != NULL)
-        DetectModbusFree(modbus);
+        DetectModbusFree(de_ctx, modbus);
 
     SCReturnPtr(NULL, "DetectModbus");
 }
@@ -474,9 +475,9 @@ static int DetectModbusSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
     if (DetectSignatureSetAppProto(s, ALPROTO_MODBUS) != 0)
         return -1;
 
-    if ((modbus = DetectModbusUnitIdParse(str)) == NULL) {
-        if ((modbus = DetectModbusFunctionParse(str)) == NULL) {
-            if ((modbus = DetectModbusAccessParse(str)) == NULL) {
+    if ((modbus = DetectModbusUnitIdParse(de_ctx, str)) == NULL) {
+        if ((modbus = DetectModbusFunctionParse(de_ctx, str)) == NULL) {
+            if ((modbus = DetectModbusAccessParse(de_ctx, str)) == NULL) {
                 SCLogError(SC_ERR_PCRE_MATCH, "invalid modbus option");
                 goto error;
             }
@@ -497,7 +498,7 @@ static int DetectModbusSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
 
 error:
     if (modbus != NULL)
-        DetectModbusFree(modbus);
+        DetectModbusFree(de_ctx, modbus);
     if (sm != NULL)
         SCFree(sm);
     SCReturnInt(-1);

--- a/src/detect-msg.c
+++ b/src/detect-msg.c
@@ -143,7 +143,7 @@ static int DetectMsgParseTest01(void)
     result = 1;
 end:
     if (sig != NULL)
-        SigFree(sig);
+        SigFree(de_ctx, sig);
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
     return result;
@@ -170,7 +170,7 @@ static int DetectMsgParseTest02(void)
     result = 1;
 end:
     if (sig != NULL)
-        SigFree(sig);
+        SigFree(de_ctx, sig);
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
     return result;
@@ -200,7 +200,7 @@ static int DetectMsgParseTest03(void)
     result = 1;
 end:
     if (sig != NULL)
-        SigFree(sig);
+        SigFree(de_ctx, sig);
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
     return result;

--- a/src/detect-nfs-procedure.c
+++ b/src/detect-nfs-procedure.c
@@ -69,7 +69,7 @@ typedef struct DetectNfsProcedureData_ {
 
 static DetectNfsProcedureData *DetectNfsProcedureParse (const char *);
 static int DetectNfsProcedureSetup (DetectEngineCtx *, Signature *s, const char *str);
-static void DetectNfsProcedureFree(void *);
+static void DetectNfsProcedureFree(DetectEngineCtx *, void *);
 static void DetectNfsProcedureRegisterTests(void);
 static int g_nfs_request_buffer_id = 0;
 
@@ -358,7 +358,7 @@ static int DetectNfsProcedureSetup (DetectEngineCtx *de_ctx, Signature *s,
     return 0;
 
 error:
-    DetectNfsProcedureFree(dd);
+    DetectNfsProcedureFree(de_ctx, dd);
     return -1;
 }
 
@@ -368,7 +368,7 @@ error:
  *
  * \param de_ptr Pointer to DetectNfsProcedureData.
  */
-void DetectNfsProcedureFree(void *ptr)
+void DetectNfsProcedureFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCFree(ptr);
 }
@@ -387,7 +387,7 @@ static int ValidityTestParse01 (void)
     dd = DetectNfsProcedureParse("1430000000");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->lo == 1430000000 && dd->mode == PROCEDURE_EQ);
-    DetectNfsProcedureFree(dd);
+    DetectNfsProcedureFree(NULL, dd);
     PASS;
 }
 
@@ -403,7 +403,7 @@ static int ValidityTestParse02 (void)
     dd = DetectNfsProcedureParse(">1430000000");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->lo == 1430000000 && dd->mode == PROCEDURE_GT);
-    DetectNfsProcedureFree(dd);
+    DetectNfsProcedureFree(NULL, dd);
     PASS;
 }
 
@@ -419,7 +419,7 @@ static int ValidityTestParse03 (void)
     dd = DetectNfsProcedureParse("<1430000000");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->lo == 1430000000 && dd->mode == PROCEDURE_LT);
-    DetectNfsProcedureFree(dd);
+    DetectNfsProcedureFree(NULL, dd);
     PASS;
 }
 
@@ -436,7 +436,7 @@ static int ValidityTestParse04 (void)
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->lo == 1430000000 && dd->hi == 1470000000 &&
                 dd->mode == PROCEDURE_RA);
-    DetectNfsProcedureFree(dd);
+    DetectNfsProcedureFree(NULL, dd);
     PASS;
 }
 
@@ -551,7 +551,7 @@ static int ValidityTestParse12 (void)
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->lo == 1430000000 && dd->hi == 1490000000 &&
                 dd->mode == PROCEDURE_RA);
-    DetectNfsProcedureFree(dd);
+    DetectNfsProcedureFree(NULL, dd);
     PASS;
 }
 
@@ -567,7 +567,7 @@ static int ValidityTestParse13 (void)
     dd = DetectNfsProcedureParse("> 1430000000 ");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->lo == 1430000000 && dd->mode == PROCEDURE_GT);
-    DetectNfsProcedureFree(dd);
+    DetectNfsProcedureFree(NULL, dd);
     PASS;
 }
 
@@ -583,7 +583,7 @@ static int ValidityTestParse14 (void)
     dd = DetectNfsProcedureParse("<   1490000000 ");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->lo == 1490000000 && dd->mode == PROCEDURE_LT);
-    DetectNfsProcedureFree(dd);
+    DetectNfsProcedureFree(NULL, dd);
     PASS;
 }
 
@@ -599,7 +599,7 @@ static int ValidityTestParse15 (void)
     dd = DetectNfsProcedureParse("   1490000000 ");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->lo == 1490000000 && dd->mode == PROCEDURE_EQ);
-    DetectNfsProcedureFree(dd);
+    DetectNfsProcedureFree(NULL, dd);
     PASS;
 }
 

--- a/src/detect-nfs-version.c
+++ b/src/detect-nfs-version.c
@@ -69,7 +69,7 @@ typedef struct DetectNfsVersionData_ {
 
 static DetectNfsVersionData *DetectNfsVersionParse (const char *);
 static int DetectNfsVersionSetup (DetectEngineCtx *, Signature *s, const char *str);
-static void DetectNfsVersionFree(void *);
+static void DetectNfsVersionFree(DetectEngineCtx *de_ctx, void *);
 static void DetectNfsVersionRegisterTests(void);
 static int g_nfs_request_buffer_id = 0;
 
@@ -346,7 +346,7 @@ static int DetectNfsVersionSetup (DetectEngineCtx *de_ctx, Signature *s,
     return 0;
 
 error:
-    DetectNfsVersionFree(dd);
+    DetectNfsVersionFree(de_ctx, dd);
     return -1;
 }
 
@@ -356,7 +356,7 @@ error:
  *
  * \param de_ptr Pointer to DetectNfsVersionData.
  */
-void DetectNfsVersionFree(void *ptr)
+void DetectNfsVersionFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCFree(ptr);
 }
@@ -375,7 +375,7 @@ static int ValidityTestParse01 (void)
     dd = DetectNfsVersionParse("1430000000");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->lo == 1430000000 && dd->mode == PROCEDURE_EQ);
-    DetectNfsVersionFree(dd);
+    DetectNfsVersionFree(NULL, dd);
     PASS;
 }
 
@@ -391,7 +391,7 @@ static int ValidityTestParse02 (void)
     dd = DetectNfsVersionParse(">1430000000");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->lo == 1430000000 && dd->mode == PROCEDURE_GT);
-    DetectNfsVersionFree(dd);
+    DetectNfsVersionFree(NULL, dd);
     PASS;
 }
 
@@ -407,7 +407,7 @@ static int ValidityTestParse03 (void)
     dd = DetectNfsVersionParse("<1430000000");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->lo == 1430000000 && dd->mode == PROCEDURE_LT);
-    DetectNfsVersionFree(dd);
+    DetectNfsVersionFree(NULL, dd);
     PASS;
 }
 
@@ -424,7 +424,7 @@ static int ValidityTestParse04 (void)
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->lo == 1430000000 && dd->hi == 1470000000 &&
                 dd->mode == PROCEDURE_RA);
-    DetectNfsVersionFree(dd);
+    DetectNfsVersionFree(NULL, dd);
     PASS;
 }
 
@@ -539,7 +539,7 @@ static int ValidityTestParse12 (void)
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->lo == 1430000000 && dd->hi == 1490000000 &&
                 dd->mode == PROCEDURE_RA);
-    DetectNfsVersionFree(dd);
+    DetectNfsVersionFree(NULL, dd);
     PASS;
 }
 
@@ -555,7 +555,7 @@ static int ValidityTestParse13 (void)
     dd = DetectNfsVersionParse("> 1430000000 ");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->lo == 1430000000 && dd->mode == PROCEDURE_GT);
-    DetectNfsVersionFree(dd);
+    DetectNfsVersionFree(NULL, dd);
     PASS;
 }
 
@@ -571,7 +571,7 @@ static int ValidityTestParse14 (void)
     dd = DetectNfsVersionParse("<   1490000000 ");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->lo == 1490000000 && dd->mode == PROCEDURE_LT);
-    DetectNfsVersionFree(dd);
+    DetectNfsVersionFree(NULL, dd);
     PASS;
 }
 
@@ -587,7 +587,7 @@ static int ValidityTestParse15 (void)
     dd = DetectNfsVersionParse("   1490000000 ");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->lo == 1490000000 && dd->mode == PROCEDURE_EQ);
-    DetectNfsVersionFree(dd);
+    DetectNfsVersionFree(NULL, dd);
     PASS;
 }
 

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -50,7 +50,7 @@ typedef struct DetectParseRegex_ {
 
 /* prototypes */
 Signature *SigAlloc(void);
-void SigFree(Signature *s);
+void SigFree(DetectEngineCtx *de_ctx, Signature *s);
 Signature *SigInit(DetectEngineCtx *, const char *sigstr);
 Signature *SigInitReal(DetectEngineCtx *, const char *);
 SigMatchData* SigMatchList2DataArray(SigMatch *head);

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -107,7 +107,7 @@ static int DetectPcreExec(DetectEngineThreadCtx *det_ctx, DetectParseRegex *rege
 }
 
 static int DetectPcreSetup (DetectEngineCtx *, Signature *, const char *);
-static void DetectPcreFree(void *);
+static void DetectPcreFree(DetectEngineCtx *, void *);
 static void DetectPcreRegisterTests(void);
 
 void DetectPcreRegister (void)
@@ -689,7 +689,7 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx,
     return pd;
 
 error:
-    DetectPcreFree(pd);
+    DetectPcreFree(de_ctx, pd);
     return NULL;
 }
 
@@ -923,7 +923,7 @@ static int DetectPcreSetup (DetectEngineCtx *de_ctx, Signature *s, const char *r
 
     uint8_t x;
     for (x = 0; x < pd->idx; x++) {
-        if (DetectFlowvarPostMatchSetup(s, pd->capids[x]) < 0)
+        if (DetectFlowvarPostMatchSetup(de_ctx, s, pd->capids[x]) < 0)
             goto error_nofree;
     }
 
@@ -953,12 +953,12 @@ static int DetectPcreSetup (DetectEngineCtx *de_ctx, Signature *s, const char *r
     ret = 0;
     SCReturnInt(ret);
  error:
-    DetectPcreFree(pd);
+    DetectPcreFree(de_ctx, pd);
  error_nofree:
     SCReturnInt(ret);
 }
 
-static void DetectPcreFree(void *ptr)
+static void DetectPcreFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr == NULL)
         return;
@@ -1053,7 +1053,7 @@ static int DetectPcreParseTest04 (void)
     FAIL_IF_NULL(pd);
     FAIL_IF_NOT(alproto == ALPROTO_UNKNOWN);
 
-    DetectPcreFree(pd);
+    DetectPcreFree(NULL, pd);
     DetectEngineCtxFree(de_ctx);
     return result;
 }
@@ -1075,7 +1075,7 @@ static int DetectPcreParseTest05 (void)
     FAIL_IF_NULL(pd);
     FAIL_IF_NOT(alproto == ALPROTO_UNKNOWN);
 
-    DetectPcreFree(pd);
+    DetectPcreFree(NULL, pd);
     DetectEngineCtxFree(de_ctx);
     return result;
 }
@@ -1097,7 +1097,7 @@ static int DetectPcreParseTest06 (void)
     FAIL_IF_NULL(pd);
     FAIL_IF_NOT(alproto == ALPROTO_UNKNOWN);
 
-    DetectPcreFree(pd);
+    DetectPcreFree(NULL, pd);
     DetectEngineCtxFree(de_ctx);
     return result;
 }
@@ -1119,7 +1119,7 @@ static int DetectPcreParseTest07 (void)
     FAIL_IF_NULL(pd);
     FAIL_IF_NOT(alproto == ALPROTO_HTTP);
 
-    DetectPcreFree(pd);
+    DetectPcreFree(NULL, pd);
     DetectEngineCtxFree(de_ctx);
     return result;
 }
@@ -1141,7 +1141,7 @@ static int DetectPcreParseTest08 (void)
     FAIL_IF_NULL(pd);
     FAIL_IF_NOT(alproto == ALPROTO_UNKNOWN);
 
-    DetectPcreFree(pd);
+    DetectPcreFree(NULL, pd);
     DetectEngineCtxFree(de_ctx);
     return result;
 }
@@ -1162,7 +1162,7 @@ static int DetectPcreParseTest09 (void)
     pd = DetectPcreParse(de_ctx, teststring, &list, NULL, 0, false, &alproto);
     FAIL_IF_NULL(pd);
 
-    DetectPcreFree(pd);
+    DetectPcreFree(NULL, pd);
     DetectEngineCtxFree(de_ctx);
     PASS;
 }
@@ -1181,7 +1181,7 @@ static int DetectPcreParseTest10(void)
     FAIL_IF_NOT(DetectPcreSetup(de_ctx, s, "/bamboo/") == 0);
     FAIL_IF_NOT(s->sm_lists[g_dce_stub_data_buffer_id] == NULL && s->sm_lists[DETECT_SM_LIST_PMATCH] != NULL);
 
-    SigFree(s);
+    SigFree(de_ctx, s);
 
     s = SigAlloc();
     FAIL_IF_NULL(s);
@@ -1190,7 +1190,7 @@ static int DetectPcreParseTest10(void)
     FAIL_IF_NOT(DetectPcreSetup(de_ctx, s, "/bamboo/") == 0);
     FAIL_IF_NOT(s->sm_lists[g_dce_stub_data_buffer_id] == NULL && s->sm_lists[DETECT_SM_LIST_PMATCH] != NULL);
 
-    SigFree(s);
+    SigFree(de_ctx, s);
     DetectEngineCtxFree(de_ctx);
 
     PASS;
@@ -3509,7 +3509,7 @@ static int DetectPcreParseHttpHost(void)
 
     DetectPcreData *pd = DetectPcreParse(de_ctx, "/domain\\.com/W", &list, NULL, 0, false, &alproto);
     FAIL_IF(pd == NULL);
-    DetectPcreFree(pd);
+    DetectPcreFree(NULL, pd);
 
     list = DETECT_SM_LIST_NOTSET;
     pd = DetectPcreParse(de_ctx, "/dOmain\\.com/W", &list, NULL, 0, false, &alproto);
@@ -3519,7 +3519,7 @@ static int DetectPcreParseHttpHost(void)
     list = DETECT_SM_LIST_NOTSET;
     pd = DetectPcreParse(de_ctx, "/domain\\D+\\.com/W", &list, NULL, 0, false, &alproto);
     FAIL_IF(pd == NULL);
-    DetectPcreFree(pd);
+    DetectPcreFree(NULL, pd);
 
     /* This should not parse as the first \ escapes the second \, then
      * we have a D. */

--- a/src/detect-pktvar.c
+++ b/src/detect-pktvar.c
@@ -42,7 +42,7 @@ static DetectParseRegex parse_regex;
 static int DetectPktvarMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectPktvarSetup (DetectEngineCtx *, Signature *, const char *);
-static void DetectPktvarFree(void *data);
+static void DetectPktvarFree(DetectEngineCtx *, void *data);
 
 void DetectPktvarRegister (void)
 {
@@ -77,7 +77,7 @@ static int DetectPktvarMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
     return ret;
 }
 
-static void DetectPktvarFree(void *ptr)
+static void DetectPktvarFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectPktvarData *data = ptr;
     if (data != NULL) {
@@ -152,7 +152,7 @@ static int DetectPktvarSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
      * and put it in the Signature. */
     SigMatch *sm = SigMatchAlloc();
     if (unlikely(sm == NULL)) {
-        DetectPktvarFree(cd);
+        DetectPktvarFree(de_ctx, cd);
         return -1;
     }
     sm->type = DETECT_PKTVAR;

--- a/src/detect-rfb-secresult.c
+++ b/src/detect-rfb-secresult.c
@@ -43,7 +43,7 @@ static int DetectRfbSecresultMatch(DetectEngineThreadCtx *det_ctx,
                                    const SigMatchCtx *ctx);
 static int DetectRfbSecresultSetup (DetectEngineCtx *, Signature *, const char *);
 void RfbSecresultRegisterTests(void);
-void DetectRfbSecresultFree(void *);
+void DetectRfbSecresultFree(DetectEngineCtx *, void *);
 
 static int DetectEngineInspectRfbSecresultGeneric(ThreadVars *tv,
         DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
@@ -250,7 +250,7 @@ error:
  *
  * \param de pointer to DetectRfbSecresultData
  */
-void DetectRfbSecresultFree(void *de_ptr)
+void DetectRfbSecresultFree(DetectEngineCtx *de_ctx, void *de_ptr)
 {
     DetectRfbSecresultData *de = (DetectRfbSecresultData *)de_ptr;
     if(de) SCFree(de);
@@ -272,7 +272,7 @@ static int RfbSecresultTestParse01 (void)
     DetectRfbSecresultData *de = NULL;
     de = DetectRfbSecresultParse("fail");
     if (de) {
-        DetectRfbSecresultFree(de);
+        DetectRfbSecresultFree(NULL, de);
         return 1;
     }
 
@@ -290,7 +290,7 @@ static int RfbSecresultTestParse02 (void)
     DetectRfbSecresultData *de = NULL;
     de = DetectRfbSecresultParse("invalidopt");
     if (de) {
-        DetectRfbSecresultFree(de);
+        DetectRfbSecresultFree(NULL, de);
         return 0;
     }
 

--- a/src/detect-rfb-sectype.c
+++ b/src/detect-rfb-sectype.c
@@ -53,7 +53,7 @@ typedef struct {
 
 static DetectRfbSectypeData *DetectRfbSectypeParse (const char *);
 static int DetectRfbSectypeSetup (DetectEngineCtx *, Signature *s, const char *str);
-static void DetectRfbSectypeFree(void *);
+static void DetectRfbSectypeFree(DetectEngineCtx *, void *);
 static int g_rfb_sectype_buffer_id = 0;
 
 static int DetectEngineInspectRfbSectypeGeneric(ThreadVars *tv,
@@ -267,7 +267,7 @@ static int DetectRfbSectypeSetup (DetectEngineCtx *de_ctx, Signature *s, const c
     return 0;
 
 error:
-    DetectRfbSectypeFree(dd);
+    DetectRfbSectypeFree(de_ctx, dd);
     return -1;
 }
 
@@ -277,7 +277,7 @@ error:
  *
  * \param de_ptr Pointer to DetectRfbSectypeData.
  */
-static void DetectRfbSectypeFree(void *ptr)
+static void DetectRfbSectypeFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCFree(ptr);
 }

--- a/src/detect-rpc.c
+++ b/src/detect-rpc.c
@@ -51,7 +51,7 @@ static int DetectRpcMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectRpcSetup (DetectEngineCtx *, Signature *, const char *);
 void DetectRpcRegisterTests(void);
-void DetectRpcFree(void *);
+void DetectRpcFree(DetectEngineCtx *, void *);
 
 /**
  * \brief Registration function for rpc keyword
@@ -136,12 +136,13 @@ static int DetectRpcMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
 /**
  * \brief This function is used to parse rpc options passed via rpc keyword
  *
+ * \param de_ctx Pointer to the detection engine context
  * \param rpcstr Pointer to the user provided rpc options
  *
  * \retval rd pointer to DetectRpcData on success
  * \retval NULL on failure
  */
-static DetectRpcData *DetectRpcParse (const char *rpcstr)
+static DetectRpcData *DetectRpcParse (DetectEngineCtx *de_ctx, const char *rpcstr)
 {
     DetectRpcData *rd = NULL;
     char *args[3] = {NULL,NULL,NULL};
@@ -236,7 +237,7 @@ error:
             SCFree(args[i]);
     }
     if (rd != NULL)
-        DetectRpcFree(rd);
+        DetectRpcFree(de_ctx, rd);
     return NULL;
 
 }
@@ -257,7 +258,7 @@ int DetectRpcSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rpcstr)
     DetectRpcData *rd = NULL;
     SigMatch *sm = NULL;
 
-    rd = DetectRpcParse(rpcstr);
+    rd = DetectRpcParse(de_ctx, rpcstr);
     if (rd == NULL) goto error;
 
     sm = SigMatchAlloc();
@@ -273,7 +274,7 @@ int DetectRpcSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rpcstr)
     return 0;
 
 error:
-    if (rd != NULL) DetectRpcFree(rd);
+    if (rd != NULL) DetectRpcFree(de_ctx, rd);
     if (sm != NULL) SCFree(sm);
     return -1;
 
@@ -284,7 +285,7 @@ error:
  *
  * \param rd pointer to DetectRpcData
  */
-void DetectRpcFree(void *ptr)
+void DetectRpcFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCEnter();
 
@@ -307,9 +308,9 @@ static int DetectRpcTestParse01 (void)
 {
     int result = 0;
     DetectRpcData *rd = NULL;
-    rd = DetectRpcParse("123,444,555");
+    rd = DetectRpcParse(NULL, "123,444,555");
     if (rd != NULL) {
-        DetectRpcFree(rd);
+        DetectRpcFree(NULL, rd);
         result = 1;
     }
 
@@ -323,7 +324,7 @@ static int DetectRpcTestParse02 (void)
 {
     int result = 0;
     DetectRpcData *rd = NULL;
-    rd = DetectRpcParse("111,222,333");
+    rd = DetectRpcParse(NULL, "111,222,333");
     if (rd != NULL) {
         if (rd->flags & DETECT_RPC_CHECK_PROGRAM &&
             rd->flags & DETECT_RPC_CHECK_VERSION &&
@@ -334,7 +335,7 @@ static int DetectRpcTestParse02 (void)
         } else {
             SCLogDebug("Error: Flags: %d; program: %u, version: %u, procedure: %u", rd->flags, rd->program, rd->program_version, rd->procedure);
         }
-        DetectRpcFree(rd);
+        DetectRpcFree(NULL, rd);
     }
 
     return result;
@@ -348,7 +349,7 @@ static int DetectRpcTestParse03 (void)
 {
     int result = 1;
     DetectRpcData *rd = NULL;
-    rd = DetectRpcParse("111,*,333");
+    rd = DetectRpcParse(NULL, "111,*,333");
     if (rd == NULL)
         return 0;
 
@@ -360,9 +361,9 @@ static int DetectRpcTestParse03 (void)
             result = 0;
     SCLogDebug("rd1 Flags: %d; program: %u, version: %u, procedure: %u", rd->flags, rd->program, rd->program_version, rd->procedure);
 
-    DetectRpcFree(rd);
+    DetectRpcFree(NULL, rd);
 
-    rd = DetectRpcParse("111,222,*");
+    rd = DetectRpcParse(NULL, "111,222,*");
     if (rd == NULL)
         return 0;
 
@@ -374,9 +375,9 @@ static int DetectRpcTestParse03 (void)
             result = 0;
     SCLogDebug("rd2 Flags: %d; program: %u, version: %u, procedure: %u", rd->flags, rd->program, rd->program_version, rd->procedure);
 
-    DetectRpcFree(rd);
+    DetectRpcFree(NULL, rd);
 
-    rd = DetectRpcParse("111,*,*");
+    rd = DetectRpcParse(NULL, "111,*,*");
     if (rd == NULL)
         return 0;
 
@@ -388,9 +389,9 @@ static int DetectRpcTestParse03 (void)
             result = 0;
     SCLogDebug("rd2 Flags: %d; program: %u, version: %u, procedure: %u", rd->flags, rd->program, rd->program_version, rd->procedure);
 
-    DetectRpcFree(rd);
+    DetectRpcFree(NULL, rd);
 
-    rd = DetectRpcParse("111,222");
+    rd = DetectRpcParse(NULL, "111,222");
     if (rd == NULL)
         return 0;
 
@@ -402,9 +403,9 @@ static int DetectRpcTestParse03 (void)
             result = 0;
     SCLogDebug("rd2 Flags: %d; program: %u, version: %u, procedure: %u", rd->flags, rd->program, rd->program_version, rd->procedure);
 
-    DetectRpcFree(rd);
+    DetectRpcFree(NULL, rd);
 
-    rd = DetectRpcParse("111");
+    rd = DetectRpcParse(NULL, "111");
     if (rd == NULL)
         return 0;
 
@@ -416,7 +417,7 @@ static int DetectRpcTestParse03 (void)
             result = 0;
     SCLogDebug("rd2 Flags: %d; program: %u, version: %u, procedure: %u", rd->flags, rd->program, rd->program_version, rd->procedure);
 
-    DetectRpcFree(rd);
+    DetectRpcFree(NULL, rd);
     return result;
 }
 
@@ -427,12 +428,12 @@ static int DetectRpcTestParse04 (void)
 {
     int result = 0;
     DetectRpcData *rd = NULL;
-    rd = DetectRpcParse("");
+    rd = DetectRpcParse(NULL, "");
     if (rd == NULL) {
         result = 1;
     } else {
         SCLogDebug("Error: Flags: %d; program: %u, version: %u, procedure: %u", rd->flags, rd->program, rd->program_version, rd->procedure);
-        DetectRpcFree(rd);
+        DetectRpcFree(NULL, rd);
     }
 
     return result;
@@ -445,12 +446,12 @@ static int DetectRpcTestParse05 (void)
 {
     int result = 0;
     DetectRpcData *rd = NULL;
-    rd = DetectRpcParse("111,aaa,*");
+    rd = DetectRpcParse(NULL, "111,aaa,*");
     if (rd == NULL) {
         result = 1;
     } else {
         SCLogDebug("Error: Flags: %d; program: %u, version: %u, procedure: %u", rd->flags, rd->program, rd->program_version, rd->procedure);
-        DetectRpcFree(rd);
+        DetectRpcFree(NULL, rd);
     }
 
     return result;

--- a/src/detect-snmp-pdu_type.c
+++ b/src/detect-snmp-pdu_type.c
@@ -43,7 +43,7 @@ typedef struct DetectSNMPPduTypeData_ {
 
 static DetectSNMPPduTypeData *DetectSNMPPduTypeParse (const char *);
 static int DetectSNMPPduTypeSetup (DetectEngineCtx *, Signature *s, const char *str);
-static void DetectSNMPPduTypeFree(void *);
+static void DetectSNMPPduTypeFree(DetectEngineCtx *, void *);
 #ifdef UNITTESTS
 static void DetectSNMPPduTypeRegisterTests(void);
 #endif
@@ -218,7 +218,7 @@ static int DetectSNMPPduTypeSetup (DetectEngineCtx *de_ctx, Signature *s,
     return 0;
 
 error:
-    DetectSNMPPduTypeFree(dd);
+    DetectSNMPPduTypeFree(de_ctx, dd);
     return -1;
 }
 
@@ -228,7 +228,7 @@ error:
  *
  * \param de_ptr Pointer to DetectSNMPPduTypeData.
  */
-static void DetectSNMPPduTypeFree(void *ptr)
+static void DetectSNMPPduTypeFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCFree(ptr);
 }

--- a/src/detect-snmp-version.c
+++ b/src/detect-snmp-version.c
@@ -52,7 +52,7 @@ typedef struct DetectSNMPVersionData_ {
 
 static DetectSNMPVersionData *DetectSNMPVersionParse (const char *);
 static int DetectSNMPVersionSetup (DetectEngineCtx *, Signature *s, const char *str);
-static void DetectSNMPVersionFree(void *);
+static void DetectSNMPVersionFree(DetectEngineCtx *, void *);
 #ifdef UNITTESTS
 static void DetectSNMPVersionRegisterTests(void);
 #endif
@@ -285,7 +285,7 @@ static int DetectSNMPVersionSetup (DetectEngineCtx *de_ctx, Signature *s,
     return 0;
 
 error:
-    DetectSNMPVersionFree(dd);
+    DetectSNMPVersionFree(de_ctx, dd);
     return -1;
 }
 
@@ -295,7 +295,7 @@ error:
  *
  * \param de_ptr Pointer to DetectSNMPVersionData.
  */
-static void DetectSNMPVersionFree(void *ptr)
+static void DetectSNMPVersionFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCFree(ptr);
 }

--- a/src/detect-ssh-proto-version.c
+++ b/src/detect-ssh-proto-version.c
@@ -66,7 +66,7 @@ static int DetectSshVersionMatch (DetectEngineThreadCtx *,
         const Signature *, const SigMatchCtx *);
 static int DetectSshVersionSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectSshVersionRegisterTests(void);
-static void DetectSshVersionFree(void *);
+static void DetectSshVersionFree(DetectEngineCtx *, void *);
 static int g_ssh_banner_list_id = 0;
 
 /**
@@ -145,12 +145,13 @@ static int DetectSshVersionMatch (DetectEngineThreadCtx *det_ctx,
 /**
  * \brief This function is used to parse IPV4 ip_id passed via keyword: "id"
  *
+ * \param de_ctx Pointer to the detection engine context
  * \param idstr Pointer to the user provided id option
  *
  * \retval id_d pointer to DetectSshVersionData on success
  * \retval NULL on failure
  */
-static DetectSshVersionData *DetectSshVersionParse (const char *str)
+static DetectSshVersionData *DetectSshVersionParse (DetectEngineCtx *de_ctx, const char *str)
 {
     DetectSshVersionData *ssh = NULL;
     int ret = 0, res = 0;
@@ -202,7 +203,7 @@ static DetectSshVersionData *DetectSshVersionParse (const char *str)
 
 error:
     if (ssh != NULL)
-        DetectSshVersionFree(ssh);
+        DetectSshVersionFree(de_ctx, ssh);
     return NULL;
 
 }
@@ -226,7 +227,7 @@ static int DetectSshVersionSetup (DetectEngineCtx *de_ctx, Signature *s, const c
     if (DetectSignatureSetAppProto(s, ALPROTO_SSH) != 0)
         return -1;
 
-    ssh = DetectSshVersionParse(str);
+    ssh = DetectSshVersionParse(de_ctx, str);
     if (ssh == NULL)
         goto error;
 
@@ -244,7 +245,7 @@ static int DetectSshVersionSetup (DetectEngineCtx *de_ctx, Signature *s, const c
 
 error:
     if (ssh != NULL)
-        DetectSshVersionFree(ssh);
+        DetectSshVersionFree(de_ctx, ssh);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -256,7 +257,7 @@ error:
  *
  * \param id_d pointer to DetectSshVersionData
  */
-void DetectSshVersionFree(void *ptr)
+void DetectSshVersionFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectSshVersionData *sshd = (DetectSshVersionData *)ptr;
     SCFree(sshd->ver);
@@ -272,9 +273,9 @@ void DetectSshVersionFree(void *ptr)
 static int DetectSshVersionTestParse01 (void)
 {
     DetectSshVersionData *ssh = NULL;
-    ssh = DetectSshVersionParse("1.0");
+    ssh = DetectSshVersionParse(NULL, "1.0");
     if (ssh != NULL && strncmp((char *) ssh->ver, "1.0", 3) == 0) {
-        DetectSshVersionFree(ssh);
+        DetectSshVersionFree(NULL, ssh);
         return 1;
     }
 
@@ -288,9 +289,9 @@ static int DetectSshVersionTestParse01 (void)
 static int DetectSshVersionTestParse02 (void)
 {
     DetectSshVersionData *ssh = NULL;
-    ssh = DetectSshVersionParse("2_compat");
+    ssh = DetectSshVersionParse(NULL, "2_compat");
     if (ssh->flags & SSH_FLAG_PROTOVERSION_2_COMPAT) {
-        DetectSshVersionFree(ssh);
+        DetectSshVersionFree(NULL, ssh);
         return 1;
     }
 
@@ -304,24 +305,24 @@ static int DetectSshVersionTestParse02 (void)
 static int DetectSshVersionTestParse03 (void)
 {
     DetectSshVersionData *ssh = NULL;
-    ssh = DetectSshVersionParse("2_com");
+    ssh = DetectSshVersionParse(NULL, "2_com");
     if (ssh != NULL) {
-        DetectSshVersionFree(ssh);
+        DetectSshVersionFree(NULL, ssh);
         return 0;
     }
-    ssh = DetectSshVersionParse("");
+    ssh = DetectSshVersionParse(NULL, "");
     if (ssh != NULL) {
-        DetectSshVersionFree(ssh);
+        DetectSshVersionFree(NULL, ssh);
         return 0;
     }
-    ssh = DetectSshVersionParse(".1");
+    ssh = DetectSshVersionParse(NULL, ".1");
     if (ssh != NULL) {
-        DetectSshVersionFree(ssh);
+        DetectSshVersionFree(NULL, ssh);
         return 0;
     }
-    ssh = DetectSshVersionParse("lalala");
+    ssh = DetectSshVersionParse(NULL, "lalala");
     if (ssh != NULL) {
-        DetectSshVersionFree(ssh);
+        DetectSshVersionFree(NULL, ssh);
         return 0;
     }
 

--- a/src/detect-ssh-software-version.c
+++ b/src/detect-ssh-software-version.c
@@ -70,7 +70,7 @@ static int DetectSshSoftwareVersionMatch (DetectEngineThreadCtx *,
         const Signature *, const SigMatchCtx *);
 static int DetectSshSoftwareVersionSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectSshSoftwareVersionRegisterTests(void);
-static void DetectSshSoftwareVersionFree(void *);
+static void DetectSshSoftwareVersionFree(DetectEngineCtx *de_ctx, void *);
 static int g_ssh_banner_list_id = 0;
 
 static int InspectSshBanner(ThreadVars *tv,
@@ -148,12 +148,13 @@ static int DetectSshSoftwareVersionMatch (DetectEngineThreadCtx *det_ctx,
 /**
  * \brief This function is used to parse IPV4 ip_id passed via keyword: "id"
  *
+ * \param de_ctx Pointer to the detection engine context
  * \param idstr Pointer to the user provided id option
  *
  * \retval id_d pointer to DetectSshSoftwareVersionData on success
  * \retval NULL on failure
  */
-static DetectSshSoftwareVersionData *DetectSshSoftwareVersionParse (const char *str)
+static DetectSshSoftwareVersionData *DetectSshSoftwareVersionParse (DetectEngineCtx *de_ctx, const char *str)
 {
     DetectSshSoftwareVersionData *ssh = NULL;
     int ret = 0, res = 0;
@@ -194,7 +195,7 @@ static DetectSshSoftwareVersionData *DetectSshSoftwareVersionParse (const char *
 
 error:
     if (ssh != NULL)
-        DetectSshSoftwareVersionFree(ssh);
+        DetectSshSoftwareVersionFree(de_ctx, ssh);
     return NULL;
 
 }
@@ -218,7 +219,7 @@ static int DetectSshSoftwareVersionSetup (DetectEngineCtx *de_ctx, Signature *s,
     if (DetectSignatureSetAppProto(s, ALPROTO_SSH) != 0)
         return -1;
 
-    ssh = DetectSshSoftwareVersionParse(str);
+    ssh = DetectSshSoftwareVersionParse(NULL, str);
     if (ssh == NULL)
         goto error;
 
@@ -236,7 +237,7 @@ static int DetectSshSoftwareVersionSetup (DetectEngineCtx *de_ctx, Signature *s,
 
 error:
     if (ssh != NULL)
-        DetectSshSoftwareVersionFree(ssh);
+        DetectSshSoftwareVersionFree(de_ctx, ssh);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -248,7 +249,7 @@ error:
  *
  * \param id_d pointer to DetectSshSoftwareVersionData
  */
-static void DetectSshSoftwareVersionFree(void *ptr)
+static void DetectSshSoftwareVersionFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr == NULL)
         return;
@@ -268,9 +269,9 @@ static void DetectSshSoftwareVersionFree(void *ptr)
 static int DetectSshSoftwareVersionTestParse01 (void)
 {
     DetectSshSoftwareVersionData *ssh = NULL;
-    ssh = DetectSshSoftwareVersionParse("PuTTY_1.0");
+    ssh = DetectSshSoftwareVersionParse(NULL, "PuTTY_1.0");
     if (ssh != NULL && strncmp((char *) ssh->software_ver, "PuTTY_1.0", 9) == 0) {
-        DetectSshSoftwareVersionFree(ssh);
+        DetectSshSoftwareVersionFree(NULL, ssh);
         return 1;
     }
 
@@ -284,9 +285,9 @@ static int DetectSshSoftwareVersionTestParse01 (void)
 static int DetectSshSoftwareVersionTestParse02 (void)
 {
     DetectSshSoftwareVersionData *ssh = NULL;
-    ssh = DetectSshSoftwareVersionParse("\"SecureCRT-4.0\"");
+    ssh = DetectSshSoftwareVersionParse(NULL, "\"SecureCRT-4.0\"");
     if (ssh != NULL && strncmp((char *) ssh->software_ver, "SecureCRT-4.0", 13) == 0) {
-        DetectSshSoftwareVersionFree(ssh);
+        DetectSshSoftwareVersionFree(NULL, ssh);
         return 1;
     }
 
@@ -300,9 +301,9 @@ static int DetectSshSoftwareVersionTestParse02 (void)
 static int DetectSshSoftwareVersionTestParse03 (void)
 {
     DetectSshSoftwareVersionData *ssh = NULL;
-    ssh = DetectSshSoftwareVersionParse("");
+    ssh = DetectSshSoftwareVersionParse(NULL, "");
     if (ssh != NULL) {
-        DetectSshSoftwareVersionFree(ssh);
+        DetectSshSoftwareVersionFree(NULL, ssh);
         return 0;
     }
 

--- a/src/detect-ssl-state.c
+++ b/src/detect-ssl-state.c
@@ -64,7 +64,7 @@ static int DetectSslStateSetup(DetectEngineCtx *, Signature *, const char *);
 #ifdef UNITTESTS
 static void DetectSslStateRegisterTests(void);
 #endif
-static void DetectSslStateFree(void *);
+static void DetectSslStateFree(DetectEngineCtx *, void *);
 
 static int InspectTlsGeneric(ThreadVars *tv,
         DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
@@ -321,7 +321,7 @@ static int DetectSslStateSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
 error:
     if (ssd != NULL)
-        DetectSslStateFree(ssd);
+        DetectSslStateFree(de_ctx, ssd);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -332,7 +332,7 @@ error:
  *
  * \param ptr pointer to the data to be freed.
  */
-static void DetectSslStateFree(void *ptr)
+static void DetectSslStateFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr != NULL)
         SCFree(ptr);

--- a/src/detect-ssl-version.c
+++ b/src/detect-ssl-version.c
@@ -66,7 +66,7 @@ static int DetectSslVersionSetup(DetectEngineCtx *, Signature *, const char *);
 #ifdef UNITTESTS
 static void DetectSslVersionRegisterTests(void);
 #endif
-static void DetectSslVersionFree(void *);
+static void DetectSslVersionFree(DetectEngineCtx *, void *);
 static int g_tls_generic_list_id = 0;
 
 /**
@@ -186,12 +186,13 @@ static int DetectSslVersionMatch(DetectEngineThreadCtx *det_ctx,
  * \brief This function is used to parse ssl_version data passed via
  *        keyword: "ssl_version"
  *
+ * \param de_ctx Pointer to the detection engine context
  * \param str Pointer to the user provided options
  *
  * \retval ssl pointer to DetectSslVersionData on success
  * \retval NULL on failure
  */
-static DetectSslVersionData *DetectSslVersionParse(const char *str)
+static DetectSslVersionData *DetectSslVersionParse(DetectEngineCtx *de_ctx, const char *str)
 {
     DetectSslVersionData *ssl = NULL;
     int ret = 0, res = 0;
@@ -279,7 +280,7 @@ static DetectSslVersionData *DetectSslVersionParse(const char *str)
 
 error:
     if (ssl != NULL)
-        DetectSslVersionFree(ssl);
+        DetectSslVersionFree(de_ctx, ssl);
     return NULL;
 
 }
@@ -303,7 +304,7 @@ static int DetectSslVersionSetup (DetectEngineCtx *de_ctx, Signature *s, const c
     if (DetectSignatureSetAppProto(s, ALPROTO_TLS) != 0)
         return -1;
 
-    ssl = DetectSslVersionParse(str);
+    ssl = DetectSslVersionParse(de_ctx, str);
     if (ssl == NULL)
         goto error;
 
@@ -321,7 +322,7 @@ static int DetectSslVersionSetup (DetectEngineCtx *de_ctx, Signature *s, const c
 
 error:
     if (ssl != NULL)
-        DetectSslVersionFree(ssl);
+        DetectSslVersionFree(de_ctx, ssl);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -332,7 +333,7 @@ error:
  *
  * \param id_d pointer to DetectSslVersionData
  */
-void DetectSslVersionFree(void *ptr)
+void DetectSslVersionFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr != NULL)
         SCFree(ptr);

--- a/src/detect-tag.c
+++ b/src/detect-tag.c
@@ -60,7 +60,7 @@ static int DetectTagMatch(DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectTagSetup(DetectEngineCtx *, Signature *, const char *);
 void DetectTagRegisterTests(void);
-void DetectTagDataFree(void *);
+void DetectTagDataFree(DetectEngineCtx *, void *);
 
 /**
  * \brief Registration function for keyword tag
@@ -287,7 +287,7 @@ int DetectTagSetup(DetectEngineCtx *de_ctx, Signature *s, const char *tagstr)
 
     SigMatch *sm = SigMatchAlloc();
     if (sm == NULL) {
-        DetectTagDataFree(td);
+        DetectTagDataFree(de_ctx, td);
         return -1;
     }
 
@@ -339,7 +339,7 @@ void DetectTagDataListFree(void *ptr)
  *
  * \param td pointer to DetectTagData
  */
-void DetectTagDataFree(void *ptr)
+void DetectTagDataFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectTagData *td = (DetectTagData *)ptr;
     SCFree(td);
@@ -359,7 +359,7 @@ static int DetectTagTestParse01(void)
     if (td != NULL && td->type == DETECT_TAG_TYPE_SESSION
         && td->count == 123
         && td->metric == DETECT_TAG_METRIC_PACKET) {
-        DetectTagDataFree(td);
+        DetectTagDataFree(NULL, td);
         result = 1;
     }
 
@@ -379,7 +379,7 @@ static int DetectTagTestParse02(void)
         && td->metric == DETECT_TAG_METRIC_BYTES
         && td->direction == DETECT_TAG_DIR_SRC) {
             result = 1;
-        DetectTagDataFree(td);
+        DetectTagDataFree(NULL, td);
     }
 
     return result;
@@ -398,7 +398,7 @@ static int DetectTagTestParse03(void)
         && td->metric == DETECT_TAG_METRIC_BYTES
         && td->direction == DETECT_TAG_DIR_DST) {
             result = 1;
-        DetectTagDataFree(td);
+        DetectTagDataFree(NULL, td);
     }
 
     return result;
@@ -416,7 +416,7 @@ static int DetectTagTestParse04(void)
         && td->count == DETECT_TAG_MAX_PKTS
         && td->metric == DETECT_TAG_METRIC_PACKET) {
             result = 1;
-        DetectTagDataFree(td);
+        DetectTagDataFree(NULL, td);
     }
 
     return result;
@@ -435,7 +435,7 @@ static int DetectTagTestParse05(void)
         && td->metric == DETECT_TAG_METRIC_PACKET
         && td->direction == DETECT_TAG_DIR_DST) {
             result = 1;
-        DetectTagDataFree(td);
+        DetectTagDataFree(NULL, td);
     }
 
     return result;

--- a/src/detect-tag.h
+++ b/src/detect-tag.h
@@ -97,8 +97,9 @@ typedef struct DetectTagDataEntry_ {
 #define TAG_ENTRY_FLAG_SKIPPED_FIRST    0x04
 
 /* prototypes */
+struct DetectEngineCtx_ ;
 void DetectTagRegister(void);
-void DetectTagDataFree(void *ptr);
+void DetectTagDataFree(struct DetectEngineCtx_ *, void *ptr);
 void DetectTagDataListFree(void *ptr);
 
 #endif /* __DETECT_TAG_H__ */

--- a/src/detect-tcp-ack.c
+++ b/src/detect-tcp-ack.c
@@ -47,7 +47,7 @@ static int DetectAckSetup(DetectEngineCtx *, Signature *, const char *);
 static int DetectAckMatch(DetectEngineThreadCtx *,
                           Packet *, const Signature *, const SigMatchCtx *);
 static void DetectAckRegisterTests(void);
-static void DetectAckFree(void *);
+static void DetectAckFree(DetectEngineCtx *, void *);
 static int PrefilterSetupTcpAck(DetectEngineCtx *de_ctx, SigGroupHead *sgh);
 static bool PrefilterTcpAckIsPrefilterable(const Signature *s);
 
@@ -133,7 +133,7 @@ error:
     if (data)
         SCFree(data);
     if (sm)
-        SigMatchFree(sm);
+        SigMatchFree(de_ctx, sm);
     return -1;
 
 }
@@ -144,7 +144,7 @@ error:
  *
  * \param data pointer to ack configuration data
  */
-static void DetectAckFree(void *ptr)
+static void DetectAckFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectAckData *data = (DetectAckData *)ptr;
     SCFree(data);

--- a/src/detect-tcp-flags.c
+++ b/src/detect-tcp-flags.c
@@ -60,7 +60,7 @@ static DetectParseRegex parse_regex;
 static int DetectFlagsMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectFlagsSetup (DetectEngineCtx *, Signature *, const char *);
-static void DetectFlagsFree(void *);
+static void DetectFlagsFree(DetectEngineCtx *, void *);
 
 static bool PrefilterTcpFlagsIsPrefilterable(const Signature *s);
 static int PrefilterSetupTcpFlags(DetectEngineCtx *de_ctx, SigGroupHead *sgh);
@@ -498,7 +498,7 @@ error:
  *
  * \param de pointer to DetectFlagsData
  */
-static void DetectFlagsFree(void *de_ptr)
+static void DetectFlagsFree(DetectEngineCtx *de_ctx, void *de_ptr)
 {
     DetectFlagsData *de = (DetectFlagsData *)de_ptr;
     if(de) SCFree(de);
@@ -619,7 +619,7 @@ static int FlagsTestParse01 (void)
     DetectFlagsData *de = DetectFlagsParse("S");
     FAIL_IF_NULL(de);
     FAIL_IF_NOT(de->flags == TH_SYN);
-    DetectFlagsFree(de);
+    DetectFlagsFree(NULL, de);
     PASS;
 }
 
@@ -634,7 +634,7 @@ static int FlagsTestParse02 (void)
     DetectFlagsData *de = NULL;
     de = DetectFlagsParse("G");
     if (de) {
-        DetectFlagsFree(de);
+        DetectFlagsFree(NULL, de);
         return 0;
     }
 
@@ -1209,7 +1209,7 @@ static int FlagsTestParse13 (void)
     DetectFlagsData *de = NULL;
     de = DetectFlagsParse("+S*");
     if (de != NULL) {
-        DetectFlagsFree(de);
+        DetectFlagsFree(NULL, de);
         return 0;
     }
 
@@ -1226,7 +1226,7 @@ static int FlagsTestParse14(void)
 {
     DetectFlagsData *de = DetectFlagsParse("CE");
     if (de != NULL && (de->flags == (TH_CWR | TH_ECN)) ) {
-        DetectFlagsFree(de);
+        DetectFlagsFree(NULL, de);
         return 1;
     }
 

--- a/src/detect-tcp-seq.c
+++ b/src/detect-tcp-seq.c
@@ -44,7 +44,7 @@ static int DetectSeqSetup(DetectEngineCtx *, Signature *, const char *);
 static int DetectSeqMatch(DetectEngineThreadCtx *,
                           Packet *, const Signature *, const SigMatchCtx *);
 static void DetectSeqRegisterTests(void);
-static void DetectSeqFree(void *);
+static void DetectSeqFree(DetectEngineCtx *, void *);
 static int PrefilterSetupTcpSeq(DetectEngineCtx *de_ctx, SigGroupHead *sgh);
 static bool PrefilterTcpSeqIsPrefilterable(const Signature *s);
 
@@ -128,7 +128,7 @@ error:
     if (data)
         SCFree(data);
     if (sm)
-        SigMatchFree(sm);
+        SigMatchFree(de_ctx, sm);
     return -1;
 
 }
@@ -139,7 +139,7 @@ error:
  *
  * \param data pointer to seq configuration data
  */
-static void DetectSeqFree(void *ptr)
+static void DetectSeqFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectSeqData *data = (DetectSeqData *)ptr;
     SCFree(data);

--- a/src/detect-tcpmss.c
+++ b/src/detect-tcpmss.c
@@ -41,7 +41,7 @@ static DetectParseRegex parse_regex;
 static int DetectTcpmssMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectTcpmssSetup (DetectEngineCtx *, Signature *, const char *);
-void DetectTcpmssFree (void *);
+void DetectTcpmssFree (DetectEngineCtx *, void *);
 #ifdef UNITTESTS
 void DetectTcpmssRegisterTests (void);
 #endif
@@ -269,7 +269,7 @@ static int DetectTcpmssSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
 
     SigMatch *sm = SigMatchAlloc();
     if (sm == NULL) {
-        DetectTcpmssFree(tcpmssd);
+        DetectTcpmssFree(de_ctx, tcpmssd);
         return -1;
     }
 
@@ -287,7 +287,7 @@ static int DetectTcpmssSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
  *
  * \param ptr pointer to DetectTcpmssData
  */
-void DetectTcpmssFree(void *ptr)
+void DetectTcpmssFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectTcpmssData *tcpmssd = (DetectTcpmssData *)ptr;
     SCFree(tcpmssd);

--- a/src/detect-template.c
+++ b/src/detect-template.c
@@ -41,7 +41,7 @@ static DetectParseRegex parse_regex;
 static int DetectTemplateMatch (DetectEngineThreadCtx *,
         Packet *, const Signature *, const SigMatchCtx *);
 static int DetectTemplateSetup (DetectEngineCtx *, Signature *, const char *);
-static void DetectTemplateFree (void *);
+static void DetectTemplateFree (DetectEngineCtx *, void *);
 #ifdef UNITTESTS
 static void DetectTemplateRegisterTests (void);
 #endif
@@ -179,7 +179,7 @@ static int DetectTemplateSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
 
     SigMatch *sm = SigMatchAlloc();
     if (sm == NULL) {
-        DetectTemplateFree(templated);
+        DetectTemplateFree(de_ctx, templated);
         return -1;
     }
 
@@ -197,7 +197,7 @@ static int DetectTemplateSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
  *
  * \param ptr pointer to DetectTemplateData
  */
-static void DetectTemplateFree(void *ptr)
+static void DetectTemplateFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectTemplateData *templated = (DetectTemplateData *)ptr;
 

--- a/src/detect-template2.c
+++ b/src/detect-template2.c
@@ -41,7 +41,7 @@ static DetectParseRegex parse_regex;
 static int DetectTemplate2Match (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectTemplate2Setup (DetectEngineCtx *, Signature *, const char *);
-void DetectTemplate2Free (void *);
+void DetectTemplate2Free (DetectEngineCtx *, void *);
 #ifdef UNITTESTS
 void DetectTemplate2RegisterTests (void);
 #endif
@@ -276,7 +276,7 @@ static int DetectTemplate2Setup (DetectEngineCtx *de_ctx, Signature *s, const ch
 
     SigMatch *sm = SigMatchAlloc();
     if (sm == NULL) {
-        DetectTemplate2Free(template2d);
+        DetectTemplate2Free(de_ctx, template2d);
         return -1;
     }
 
@@ -294,7 +294,7 @@ static int DetectTemplate2Setup (DetectEngineCtx *de_ctx, Signature *s, const ch
  *
  * \param ptr pointer to DetectTemplate2Data
  */
-void DetectTemplate2Free(void *ptr)
+void DetectTemplate2Free(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectTemplate2Data *template2d = (DetectTemplate2Data *)ptr;
     SCFree(template2d);

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -66,7 +66,7 @@ static DetectParseRegex parse_regex;
 static int DetectThresholdMatch(DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectThresholdSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectThresholdFree(void *);
+static void DetectThresholdFree(DetectEngineCtx *, void *);
 
 /**
  * \brief Registration function for threshold: keyword
@@ -272,7 +272,7 @@ error:
  *
  * \param de pointer to DetectThresholdData
  */
-static void DetectThresholdFree(void *de_ptr)
+static void DetectThresholdFree(DetectEngineCtx *de_ctx, void *de_ptr)
 {
     DetectThresholdData *de = (DetectThresholdData *)de_ptr;
     if (de) {
@@ -301,7 +301,7 @@ static int ThresholdTestParse01(void)
     DetectThresholdData *de = NULL;
     de = DetectThresholdParse("type limit,track by_dst,count 10,seconds 60");
     if (de && (de->type == TYPE_LIMIT) && (de->track == TRACK_DST) && (de->count == 10) && (de->seconds == 60)) {
-        DetectThresholdFree(de);
+        DetectThresholdFree(NULL, de);
         return 1;
     }
 
@@ -319,7 +319,7 @@ static int ThresholdTestParse02(void)
     DetectThresholdData *de = NULL;
     de = DetectThresholdParse("type any,track by_dst,count 10,seconds 60");
     if (de && (de->type == TYPE_LIMIT) && (de->track == TRACK_DST) && (de->count == 10) && (de->seconds == 60)) {
-        DetectThresholdFree(de);
+        DetectThresholdFree(NULL, de);
         return 0;
     }
 
@@ -337,7 +337,7 @@ static int ThresholdTestParse03(void)
     DetectThresholdData *de = NULL;
     de = DetectThresholdParse("track by_dst, type limit, seconds 60, count 10");
     if (de && (de->type == TYPE_LIMIT) && (de->track == TRACK_DST) && (de->count == 10) && (de->seconds == 60)) {
-        DetectThresholdFree(de);
+        DetectThresholdFree(NULL, de);
         return 1;
     }
 
@@ -356,7 +356,7 @@ static int ThresholdTestParse04(void)
     DetectThresholdData *de = NULL;
     de = DetectThresholdParse("count 10, track by_dst, seconds 60, type both, count 10");
     if (de && (de->type == TYPE_BOTH) && (de->track == TRACK_DST) && (de->count == 10) && (de->seconds == 60)) {
-        DetectThresholdFree(de);
+        DetectThresholdFree(NULL, de);
         return 0;
     }
 
@@ -374,7 +374,7 @@ static int ThresholdTestParse05(void)
     DetectThresholdData *de = NULL;
     de = DetectThresholdParse("count 10, track by_dst, seconds 60, type both");
     if (de && (de->type == TYPE_BOTH) && (de->track == TRACK_DST) && (de->count == 10) && (de->seconds == 60)) {
-        DetectThresholdFree(de);
+        DetectThresholdFree(NULL, de);
         return 1;
     }
 
@@ -396,7 +396,7 @@ static int ThresholdTestParse06(void)
     FAIL_IF_NOT(de->track == TRACK_BOTH);
     FAIL_IF_NOT(de->count == 10);
     FAIL_IF_NOT(de->seconds == 60);
-    DetectThresholdFree(de);
+    DetectThresholdFree(NULL, de);
     PASS;
 }
 
@@ -415,7 +415,7 @@ static int ThresholdTestParse07(void)
     FAIL_IF_NOT(de->track == TRACK_RULE);
     FAIL_IF_NOT(de->count == 10);
     FAIL_IF_NOT(de->seconds == 60);
-    DetectThresholdFree(de);
+    DetectThresholdFree(NULL, de);
     PASS;
 }
 

--- a/src/detect-tls-cert-validity.c
+++ b/src/detect-tls-cert-validity.c
@@ -72,7 +72,7 @@ static void TlsNotAfterRegisterTests(void);
 static void TlsExpiredRegisterTests(void);
 static void TlsValidRegisterTests(void);
 #endif /* UNITTESTS */
-static void DetectTlsValidityFree(void *);
+static void DetectTlsValidityFree(DetectEngineCtx *, void *);
 static int g_tls_validity_buffer_id = 0;
 
 static int DetectEngineInspectTlsValidity(ThreadVars *tv,
@@ -465,7 +465,7 @@ static int DetectTlsExpiredSetup (DetectEngineCtx *de_ctx, Signature *s,
     return 0;
 
 error:
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(de_ctx, dd);
     if (sm)
         SCFree(sm);
     return -1;
@@ -516,7 +516,7 @@ static int DetectTlsValidSetup (DetectEngineCtx *de_ctx, Signature *s,
     return 0;
 
 error:
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(de_ctx, dd);
     if (sm)
         SCFree(sm);
     return -1;
@@ -612,7 +612,7 @@ static int DetectTlsValiditySetup (DetectEngineCtx *de_ctx, Signature *s,
     return 0;
 
 error:
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(de_ctx, dd);
     if (sm)
         SCFree(sm);
     return -1;
@@ -624,7 +624,7 @@ error:
  *
  * \param de_ptr Pointer to DetectTlsValidityData.
  */
-void DetectTlsValidityFree(void *de_ptr)
+void DetectTlsValidityFree(DetectEngineCtx *de_ctx, void *de_ptr)
 {
     DetectTlsValidityData *dd = (DetectTlsValidityData *)de_ptr;
     if (dd)

--- a/src/detect-tls-version.c
+++ b/src/detect-tls-version.c
@@ -65,7 +65,7 @@ static int DetectTlsVersionSetup (DetectEngineCtx *, Signature *, const char *);
 #ifdef UNITTESTS
 static void DetectTlsVersionRegisterTests(void);
 #endif
-static void DetectTlsVersionFree(void *);
+static void DetectTlsVersionFree(DetectEngineCtx *, void *);
 static int g_tls_generic_list_id = 0;
 
 /**
@@ -141,12 +141,13 @@ static int DetectTlsVersionMatch (DetectEngineThreadCtx *det_ctx,
 /**
  * \brief This function is used to parse IPV4 ip_id passed via keyword: "id"
  *
+ * \param de_ctx Pointer to the detection engine context
  * \param idstr Pointer to the user provided id option
  *
  * \retval id_d pointer to DetectTlsVersionData on success
  * \retval NULL on failure
  */
-static DetectTlsVersionData *DetectTlsVersionParse (const char *str)
+static DetectTlsVersionData *DetectTlsVersionParse (DetectEngineCtx *de_ctx, const char *str)
 {
     uint16_t temp;
     DetectTlsVersionData *tls = NULL;
@@ -207,7 +208,7 @@ static DetectTlsVersionData *DetectTlsVersionParse (const char *str)
 
 error:
     if (tls != NULL)
-        DetectTlsVersionFree(tls);
+        DetectTlsVersionFree(de_ctx, tls);
     return NULL;
 
 }
@@ -231,7 +232,7 @@ static int DetectTlsVersionSetup (DetectEngineCtx *de_ctx, Signature *s, const c
     if (DetectSignatureSetAppProto(s, ALPROTO_TLS) != 0)
         return -1;
 
-    tls = DetectTlsVersionParse(str);
+    tls = DetectTlsVersionParse(de_ctx, str);
     if (tls == NULL)
         goto error;
 
@@ -250,7 +251,7 @@ static int DetectTlsVersionSetup (DetectEngineCtx *de_ctx, Signature *s, const c
 
 error:
     if (tls != NULL)
-        DetectTlsVersionFree(tls);
+        DetectTlsVersionFree(de_ctx, tls);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -262,7 +263,7 @@ error:
  *
  * \param id_d pointer to DetectTlsVersionData
  */
-static void DetectTlsVersionFree(void *ptr)
+static void DetectTlsVersionFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectTlsVersionData *id_d = (DetectTlsVersionData *)ptr;
     SCFree(id_d);

--- a/src/detect-tls.c
+++ b/src/detect-tls.c
@@ -76,20 +76,20 @@ static int DetectTlsSubjectMatch (DetectEngineThreadCtx *,
         const Signature *, const SigMatchCtx *);
 static int DetectTlsSubjectSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectTlsSubjectRegisterTests(void);
-static void DetectTlsSubjectFree(void *);
+static void DetectTlsSubjectFree(DetectEngineCtx *, void *);
 
 static int DetectTlsIssuerDNMatch (DetectEngineThreadCtx *,
         Flow *, uint8_t, void *, void *,
         const Signature *, const SigMatchCtx *);
 static int DetectTlsIssuerDNSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectTlsIssuerDNRegisterTests(void);
-static void DetectTlsIssuerDNFree(void *);
+static void DetectTlsIssuerDNFree(DetectEngineCtx *, void *);
 
 static int DetectTlsFingerprintMatch (DetectEngineThreadCtx *,
         Flow *, uint8_t, void *, void *,
         const Signature *, const SigMatchCtx *);
 static int DetectTlsFingerprintSetup (DetectEngineCtx *, Signature *, const char *);
-static void DetectTlsFingerprintFree(void *);
+static void DetectTlsFingerprintFree(DetectEngineCtx *, void *);
 
 static int DetectTlsStoreSetup (DetectEngineCtx *, Signature *, const char *);
 static int DetectTlsStorePostMatch (DetectEngineThreadCtx *det_ctx,
@@ -223,12 +223,13 @@ static int DetectTlsSubjectMatch (DetectEngineThreadCtx *det_ctx,
 /**
  * \brief This function is used to parse IPV4 ip_id passed via keyword: "id"
  *
- * \param idstr Pointer to the user provided id option
+ * \param de_ctx Pointer to the detection engine context
+ * \param str Pointer to the user provided id option
  *
  * \retval id_d pointer to DetectTlsData on success
  * \retval NULL on failure
  */
-static DetectTlsData *DetectTlsSubjectParse (const char *str, bool negate)
+static DetectTlsData *DetectTlsSubjectParse (DetectEngineCtx *de_ctx, const char *str, bool negate)
 {
     DetectTlsData *tls = NULL;
     int ret = 0, res = 0;
@@ -289,7 +290,7 @@ error:
     if (orig != NULL)
         SCFree(orig);
     if (tls != NULL)
-        DetectTlsSubjectFree(tls);
+        DetectTlsSubjectFree(de_ctx, tls);
     return NULL;
 
 }
@@ -313,7 +314,7 @@ static int DetectTlsSubjectSetup (DetectEngineCtx *de_ctx, Signature *s, const c
     if (DetectSignatureSetAppProto(s, ALPROTO_TLS) != 0)
         return -1;
 
-    tls = DetectTlsSubjectParse(str, s->init_data->negated);
+    tls = DetectTlsSubjectParse(de_ctx, str, s->init_data->negated);
     if (tls == NULL)
         goto error;
 
@@ -331,7 +332,7 @@ static int DetectTlsSubjectSetup (DetectEngineCtx *de_ctx, Signature *s, const c
 
 error:
     if (tls != NULL)
-        DetectTlsSubjectFree(tls);
+        DetectTlsSubjectFree(de_ctx, tls);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -343,7 +344,7 @@ error:
  *
  * \param id_d pointer to DetectTlsData
  */
-static void DetectTlsSubjectFree(void *ptr)
+static void DetectTlsSubjectFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectTlsData *id_d = (DetectTlsData *)ptr;
     if (ptr == NULL)
@@ -420,12 +421,13 @@ static int DetectTlsIssuerDNMatch (DetectEngineThreadCtx *det_ctx,
 /**
  * \brief This function is used to parse IPV4 ip_id passed via keyword: "id"
  *
- * \param idstr Pointer to the user provided id option
+ * \param de_ctx Pointer to the detection engine context
+ * \param str Pointer to the user provided id option
  *
  * \retval id_d pointer to DetectTlsData on success
  * \retval NULL on failure
  */
-static DetectTlsData *DetectTlsIssuerDNParse(const char *str, bool negate)
+static DetectTlsData *DetectTlsIssuerDNParse(DetectEngineCtx *de_ctx, const char *str, bool negate)
 {
     DetectTlsData *tls = NULL;
     int ret = 0, res = 0;
@@ -487,7 +489,7 @@ error:
     if (orig != NULL)
         SCFree(orig);
     if (tls != NULL)
-        DetectTlsIssuerDNFree(tls);
+        DetectTlsIssuerDNFree(de_ctx, tls);
     return NULL;
 
 }
@@ -511,7 +513,7 @@ static int DetectTlsIssuerDNSetup (DetectEngineCtx *de_ctx, Signature *s, const 
     if (DetectSignatureSetAppProto(s, ALPROTO_TLS) != 0)
         return -1;
 
-    tls = DetectTlsIssuerDNParse(str, s->init_data->negated);
+    tls = DetectTlsIssuerDNParse(de_ctx, str, s->init_data->negated);
     if (tls == NULL)
         goto error;
 
@@ -529,7 +531,7 @@ static int DetectTlsIssuerDNSetup (DetectEngineCtx *de_ctx, Signature *s, const 
 
 error:
     if (tls != NULL)
-        DetectTlsIssuerDNFree(tls);
+        DetectTlsIssuerDNFree(de_ctx, tls);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -541,7 +543,7 @@ error:
  *
  * \param id_d pointer to DetectTlsData
  */
-static void DetectTlsIssuerDNFree(void *ptr)
+static void DetectTlsIssuerDNFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectTlsData *id_d = (DetectTlsData *)ptr;
     SCFree(id_d->issuerdn);
@@ -551,12 +553,13 @@ static void DetectTlsIssuerDNFree(void *ptr)
 /**
  * \brief This function is used to parse fingerprint passed via keyword: "fingerprint"
  *
- * \param idstr Pointer to the user provided fingerprint option
+ * \param de_ctx Pointer to the detection engine context
+ * \param str Pointer to the user provided fingerprint option
  *
  * \retval pointer to DetectTlsData on success
  * \retval NULL on failure
  */
-static DetectTlsData *DetectTlsFingerprintParse (const char *str, bool negate)
+static DetectTlsData *DetectTlsFingerprintParse (DetectEngineCtx *de_ctx, const char *str, bool negate)
 {
     DetectTlsData *tls = NULL;
     int ret = 0, res = 0;
@@ -616,7 +619,7 @@ static DetectTlsData *DetectTlsFingerprintParse (const char *str, bool negate)
 
 error:
     if (tls != NULL)
-        DetectTlsFingerprintFree(tls);
+        DetectTlsFingerprintFree(de_ctx, tls);
     return NULL;
 
 }
@@ -699,7 +702,7 @@ static int DetectTlsFingerprintSetup (DetectEngineCtx *de_ctx, Signature *s, con
     if (DetectSignatureSetAppProto(s, ALPROTO_TLS) != 0)
         return -1;
 
-    tls = DetectTlsFingerprintParse(str, s->init_data->negated);
+    tls = DetectTlsFingerprintParse(de_ctx, str, s->init_data->negated);
     if (tls == NULL)
         goto error;
 
@@ -717,7 +720,7 @@ static int DetectTlsFingerprintSetup (DetectEngineCtx *de_ctx, Signature *s, con
 
 error:
     if (tls != NULL)
-        DetectTlsFingerprintFree(tls);
+        DetectTlsFingerprintFree(de_ctx, tls);
     if (sm != NULL)
         SCFree(sm);
     return -1;
@@ -729,7 +732,7 @@ error:
  *
  * \param pointer to DetectTlsData
  */
-static void DetectTlsFingerprintFree(void *ptr)
+static void DetectTlsFingerprintFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectTlsData *id_d = (DetectTlsData *)ptr;
     if (id_d->fingerprint)

--- a/src/detect-tos.c
+++ b/src/detect-tos.c
@@ -51,7 +51,7 @@ static int DetectTosSetup(DetectEngineCtx *, Signature *, const char *);
 static int DetectTosMatch(DetectEngineThreadCtx *, Packet *,
                           const Signature *, const SigMatchCtx *);
 static void DetectTosRegisterTests(void);
-static void DetectTosFree(void *);
+static void DetectTosFree(DetectEngineCtx *, void *);
 
 #define DETECT_IPTOS_MIN 0
 #define DETECT_IPTOS_MAX 255
@@ -177,7 +177,7 @@ static int DetectTosSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg
 
     SigMatch *sm = SigMatchAlloc();
     if (sm == NULL) {
-        DetectTosFree(tosd);
+        DetectTosFree(de_ctx, tosd);
         return -1;
     }
 
@@ -194,7 +194,7 @@ static int DetectTosSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg
  *
  * \param tosd Data to be freed.
  */
-static void DetectTosFree(void *tosd)
+static void DetectTosFree(DetectEngineCtx *de_ctx, void *tosd)
 {
     SCFree(tosd);
 }
@@ -208,7 +208,7 @@ static int DetectTosTest01(void)
     DetectTosData *tosd = NULL;
     tosd = DetectTosParse("12", false);
     if (tosd != NULL && tosd->tos == 12 && !tosd->negated) {
-        DetectTosFree(tosd);
+        DetectTosFree(NULL, tosd);
         return 1;
     }
 
@@ -220,7 +220,7 @@ static int DetectTosTest02(void)
     DetectTosData *tosd = NULL;
     tosd = DetectTosParse("123", false);
     if (tosd != NULL && tosd->tos == 123 && !tosd->negated) {
-        DetectTosFree(tosd);
+        DetectTosFree(NULL, tosd);
         return 1;
     }
 
@@ -232,7 +232,7 @@ static int DetectTosTest04(void)
     DetectTosData *tosd = NULL;
     tosd = DetectTosParse("256", false);
     if (tosd != NULL) {
-        DetectTosFree(tosd);
+        DetectTosFree(NULL, tosd);
         return 0;
     }
 
@@ -244,7 +244,7 @@ static int DetectTosTest05(void)
     DetectTosData *tosd = NULL;
     tosd = DetectTosParse("boom", false);
     if (tosd != NULL) {
-        DetectTosFree(tosd);
+        DetectTosFree(NULL, tosd);
         return 0;
     }
 
@@ -256,7 +256,7 @@ static int DetectTosTest06(void)
     DetectTosData *tosd = NULL;
     tosd = DetectTosParse("x12", false);
     if (tosd != NULL && tosd->tos == 0x12 && !tosd->negated) {
-        DetectTosFree(tosd);
+        DetectTosFree(NULL, tosd);
         return 1;
     }
 
@@ -268,7 +268,7 @@ static int DetectTosTest07(void)
     DetectTosData *tosd = NULL;
     tosd = DetectTosParse("X12", false);
     if (tosd != NULL && tosd->tos == 0x12 && !tosd->negated) {
-        DetectTosFree(tosd);
+        DetectTosFree(NULL, tosd);
         return 1;
     }
 
@@ -280,7 +280,7 @@ static int DetectTosTest08(void)
     DetectTosData *tosd = NULL;
     tosd = DetectTosParse("x121", false);
     if (tosd != NULL) {
-        DetectTosFree(tosd);
+        DetectTosFree(NULL, tosd);
         return 0;
     }
 
@@ -292,7 +292,7 @@ static int DetectTosTest09(void)
     DetectTosData *tosd = NULL;
     tosd = DetectTosParse("12", true);
     if (tosd != NULL && tosd->tos == 12 && tosd->negated) {
-        DetectTosFree(tosd);
+        DetectTosFree(NULL, tosd);
         return 1;
     }
 
@@ -304,7 +304,7 @@ static int DetectTosTest10(void)
     DetectTosData *tosd = NULL;
     tosd = DetectTosParse("x12", true);
     if (tosd != NULL && tosd->tos == 0x12 && tosd->negated) {
-        DetectTosFree(tosd);
+        DetectTosFree(NULL, tosd);
         return 1;
     }
 

--- a/src/detect-ttl.c
+++ b/src/detect-ttl.c
@@ -45,7 +45,7 @@ static DetectParseRegex parse_regex;
 static int DetectTtlMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectTtlSetup (DetectEngineCtx *, Signature *, const char *);
-void DetectTtlFree (void *);
+void DetectTtlFree (DetectEngineCtx *, void *);
 #ifdef UNITTESTS
 void DetectTtlRegisterTests (void);
 #endif
@@ -267,7 +267,7 @@ static int DetectTtlSetup (DetectEngineCtx *de_ctx, Signature *s, const char *tt
 
     SigMatch *sm = SigMatchAlloc();
     if (sm == NULL) {
-        DetectTtlFree(ttld);
+        DetectTtlFree(de_ctx, ttld);
         return -1;
     }
 
@@ -284,7 +284,7 @@ static int DetectTtlSetup (DetectEngineCtx *de_ctx, Signature *s, const char *tt
  *
  * \param ptr pointer to DetectTtlData
  */
-void DetectTtlFree(void *ptr)
+void DetectTtlFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectTtlData *ttld = (DetectTtlData *)ptr;
     SCFree(ttld);

--- a/src/detect-uricontent.c
+++ b/src/detect-uricontent.c
@@ -58,7 +58,7 @@
 /* prototypes */
 static int DetectUricontentSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectUricontentRegisterTests(void);
-static void DetectUricontentFree(void *);
+static void DetectUricontentFree(DetectEngineCtx *de_ctx, void *);
 
 static int g_http_uri_buffer_id = 0;
 
@@ -85,7 +85,7 @@ void DetectUricontentRegister (void)
  *
  * \param cd pointer to DetectUricotentData
  */
-void DetectUricontentFree(void *ptr)
+void DetectUricontentFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCEnter();
     DetectContentData *cd = (DetectContentData *)ptr;

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -51,7 +51,7 @@ static DetectParseRegex parse_regex;
 
 /*prototypes*/
 static int DetectUrilenSetup (DetectEngineCtx *, Signature *, const char *);
-void DetectUrilenFree (void *);
+void DetectUrilenFree (DetectEngineCtx *, void *);
 void DetectUrilenRegisterTests (void);
 
 static int g_http_uri_buffer_id = 0;
@@ -265,7 +265,7 @@ static int DetectUrilenSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     SCReturnInt(0);
 
 error:
-    DetectUrilenFree(urilend);
+    DetectUrilenFree(de_ctx, urilend);
     SCReturnInt(-1);
 }
 
@@ -274,7 +274,7 @@ error:
  *
  * \param ptr pointer to DetectUrilenData
  */
-void DetectUrilenFree(void *ptr)
+void DetectUrilenFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr == NULL)
         return;
@@ -382,7 +382,7 @@ static int DetectUrilenParseTest01(void)
             !urilend->raw_buffer)
             ret = 1;
 
-        DetectUrilenFree(urilend);
+        DetectUrilenFree(NULL, urilend);
     }
     return ret;
 }
@@ -399,7 +399,7 @@ static int DetectUrilenParseTest02(void)
             !urilend->raw_buffer)
             ret = 1;
 
-        DetectUrilenFree(urilend);
+        DetectUrilenFree(NULL, urilend);
     }
     return ret;
 }
@@ -416,7 +416,7 @@ static int DetectUrilenParseTest03(void)
             !urilend->raw_buffer)
             ret = 1;
 
-        DetectUrilenFree(urilend);
+        DetectUrilenFree(NULL, urilend);
     }
     return ret;
 }
@@ -434,7 +434,7 @@ static int DetectUrilenParseTest04(void)
             !urilend->raw_buffer)
             ret = 1;
 
-        DetectUrilenFree(urilend);
+        DetectUrilenFree(NULL, urilend);
     }
     return ret;
 }
@@ -452,7 +452,7 @@ static int DetectUrilenParseTest05(void)
             !urilend->raw_buffer)
             ret = 1;
 
-        DetectUrilenFree(urilend);
+        DetectUrilenFree(NULL, urilend);
     }
     return ret;
 }
@@ -470,7 +470,7 @@ static int DetectUrilenParseTest06(void)
             urilend->raw_buffer)
             ret = 1;
 
-        DetectUrilenFree(urilend);
+        DetectUrilenFree(NULL, urilend);
     }
     return ret;
 }
@@ -487,7 +487,7 @@ static int DetectUrilenParseTest07(void)
             !urilend->raw_buffer)
             ret = 1;
 
-        DetectUrilenFree(urilend);
+        DetectUrilenFree(NULL, urilend);
     }
     return ret;
 }
@@ -504,7 +504,7 @@ static int DetectUrilenParseTest08(void)
             !urilend->raw_buffer)
             ret = 1;
 
-        DetectUrilenFree(urilend);
+        DetectUrilenFree(NULL, urilend);
     }
     return ret;
 }
@@ -521,7 +521,7 @@ static int DetectUrilenParseTest09(void)
             urilend->raw_buffer)
             ret = 1;
 
-        DetectUrilenFree(urilend);
+        DetectUrilenFree(NULL, urilend);
     }
     return ret;
 }
@@ -538,7 +538,7 @@ static int DetectUrilenParseTest10(void)
             urilend->raw_buffer)
             ret = 1;
 
-        DetectUrilenFree(urilend);
+        DetectUrilenFree(NULL, urilend);
     }
     return ret;
 }

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -58,7 +58,7 @@ static DetectParseRegex parse_regex;
 
 static int DetectXbitMatch (DetectEngineThreadCtx *, Packet *, const Signature *, const SigMatchCtx *);
 static int DetectXbitSetup (DetectEngineCtx *, Signature *, const char *);
-void DetectXbitFree (void *);
+void DetectXbitFree (DetectEngineCtx *, void *);
 void XBitsRegisterTests(void);
 
 void DetectXbitsRegister (void)
@@ -363,7 +363,7 @@ error:
     return -1;
 }
 
-void DetectXbitFree (void *ptr)
+void DetectXbitFree (DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectXbitsData *fd = (DetectXbitsData *)ptr;
 
@@ -421,7 +421,7 @@ static int XBitsTestParse01(void)
     FAIL_IF_NOT(cd->tracker == (trk));                      \
     FAIL_IF_NOT(cd->type == (typ));                         \
     FAIL_IF_NOT(cd->expire == (exp));                       \
-    DetectXbitFree(cd);                                     \
+    DetectXbitFree(NULL, cd);                               \
     cd = NULL;
 
     GOOD_INPUT("set,abc,track ip_pair",

--- a/src/detect.h
+++ b/src/detect.h
@@ -1189,7 +1189,7 @@ typedef struct SigTableElmt_ {
     bool (*SupportsPrefilter)(const Signature *s);
     int (*SetupPrefilter)(DetectEngineCtx *de_ctx, struct SigGroupHead_ *sgh);
 
-    void (*Free)(void *);
+    void (*Free)(DetectEngineCtx *, void *);
     void (*RegisterTests)(void);
 
     uint16_t flags;
@@ -1458,7 +1458,7 @@ Signature *SigFindSignatureBySidGid(DetectEngineCtx *, uint32_t, uint32_t);
 void SigMatchSignaturesBuildMatchArray(DetectEngineThreadCtx *,
                                        Packet *, SignatureMask,
                                        uint16_t);
-void SigMatchFree(SigMatch *sm);
+void SigMatchFree(DetectEngineCtx *, SigMatch *sm);
 
 void SigRegisterTests(void);
 void TmModuleDetectRegister (void);

--- a/src/detect.h
+++ b/src/detect.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1477,6 +1477,7 @@ const SigGroupHead *SigMatchSignaturesGetSgh(const DetectEngineCtx *de_ctx, cons
 Signature *DetectGetTagSignature(void);
 
 
+int DetectUnregisterThreadCtxFuncs(DetectEngineCtx *, DetectEngineThreadCtx *,void *data, const char *name);
 int DetectRegisterThreadCtxFuncs(DetectEngineCtx *, const char *name, void *(*InitFunc)(void *), void *data, void (*FreeFunc)(void *), int);
 void *DetectThreadCtxGetKeywordThreadCtx(DetectEngineThreadCtx *, int);
 

--- a/src/tests/detect-bsize.c
+++ b/src/tests/detect-bsize.c
@@ -21,7 +21,7 @@
     DetectBsizeData *bsz = DetectBsizeParse((str));     \
     FAIL_IF_NULL(bsz);                                  \
     FAIL_IF_NOT(bsz->mode == (m));                      \
-    DetectBsizeFree(bsz);                               \
+    DetectBsizeFree(NULL, bsz);                         \
     SCLogDebug("str %s OK", (str));                     \
 }
 #define TEST_FAIL(str) {                                \

--- a/src/tests/detect-snmp-pdu_type.c
+++ b/src/tests/detect-snmp-pdu_type.c
@@ -30,7 +30,7 @@ static int SNMPValidityTestParse01 (void)
     dd = DetectSNMPPduTypeParse("2");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->pdu_type == 2);
-    DetectSNMPPduTypeFree(dd);
+    DetectSNMPPduTypeFree(NULL, dd);
     PASS;
 }
 

--- a/src/tests/detect-snmp-version.c
+++ b/src/tests/detect-snmp-version.c
@@ -30,7 +30,7 @@ static int SNMPValidityTestParse01 (void)
     dd = DetectSNMPVersionParse("2");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->version == 2 && dd->mode == PROCEDURE_EQ);
-    DetectSNMPVersionFree(dd);
+    DetectSNMPVersionFree(NULL, dd);
     PASS;
 }
 
@@ -46,7 +46,7 @@ static int SNMPValidityTestParse02 (void)
     dd = DetectSNMPVersionParse(">2");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->version == 2 && dd->mode == PROCEDURE_GT);
-    DetectSNMPVersionFree(dd);
+    DetectSNMPVersionFree(NULL, dd);
     PASS;
 }
 

--- a/src/tests/detect-ssl-version.c
+++ b/src/tests/detect-ssl-version.c
@@ -29,10 +29,10 @@
 static int DetectSslVersionTestParse01(void)
 {
     DetectSslVersionData *ssl = NULL;
-    ssl = DetectSslVersionParse("SSlv3");
+    ssl = DetectSslVersionParse(NULL, "SSlv3");
     FAIL_IF_NULL(ssl);
     FAIL_IF_NOT(ssl->data[SSLv3].ver == SSL_VERSION_3);
-    DetectSslVersionFree(ssl);
+    DetectSslVersionFree(NULL, ssl);
     PASS;
 }
 
@@ -44,9 +44,9 @@ static int DetectSslVersionTestParse01(void)
 static int DetectSslVersionTestParse02(void)
 {
     DetectSslVersionData *ssl = NULL;
-    ssl = DetectSslVersionParse("2.5");
+    ssl = DetectSslVersionParse(NULL, "2.5");
     FAIL_IF_NOT_NULL(ssl);
-    DetectSslVersionFree(ssl);
+    DetectSslVersionFree(NULL, ssl);
     PASS;
 }
 
@@ -57,13 +57,13 @@ static int DetectSslVersionTestParse02(void)
 static int DetectSslVersionTestParse03(void)
 {
     DetectSslVersionData *ssl = NULL;
-    ssl = DetectSslVersionParse("SSlv3,tls1.0, !tls1.2");
+    ssl = DetectSslVersionParse(NULL, "SSlv3,tls1.0, !tls1.2");
     FAIL_IF_NULL(ssl);
     FAIL_IF_NOT(ssl->data[SSLv3].ver == SSL_VERSION_3);
     FAIL_IF_NOT(ssl->data[TLS10].ver == TLS_VERSION_10);
     FAIL_IF_NOT(ssl->data[TLS12].ver == TLS_VERSION_12);
     FAIL_IF_NOT(ssl->data[TLS12].flags & DETECT_SSL_VERSION_NEGATED);
-    DetectSslVersionFree(ssl);
+    DetectSslVersionFree(NULL, ssl);
     PASS;
 }
 

--- a/src/tests/detect-tcpmss.c
+++ b/src/tests/detect-tcpmss.c
@@ -37,7 +37,7 @@ static int DetectTcpmssParseTest01 (void)
     FAIL_IF_NOT(tcpmssd->arg1 == 10);
     FAIL_IF_NOT(tcpmssd->mode == DETECT_TCPMSS_EQ);
 
-    DetectTcpmssFree(tcpmssd);
+    DetectTcpmssFree(NULL, tcpmssd);
 
     PASS;
 }
@@ -54,7 +54,7 @@ static int DetectTcpmssParseTest02 (void)
     FAIL_IF_NOT(tcpmssd->arg1 == 10);
     FAIL_IF_NOT(tcpmssd->mode == DETECT_TCPMSS_LT);
 
-    DetectTcpmssFree(tcpmssd);
+    DetectTcpmssFree(NULL, tcpmssd);
 
     PASS;
 }
@@ -71,7 +71,7 @@ static int DetectTcpmssParseTest03 (void)
     FAIL_IF_NOT(tcpmssd->arg1 == 1);
     FAIL_IF_NOT(tcpmssd->mode == DETECT_TCPMSS_RA);
 
-    DetectTcpmssFree(tcpmssd);
+    DetectTcpmssFree(NULL, tcpmssd);
 
     PASS;
 }
@@ -89,7 +89,7 @@ static int DetectTcpmssParseTest04 (void)
     FAIL_IF_NOT(tcpmssd->arg1 == 10);
     FAIL_IF_NOT(tcpmssd->mode == DETECT_TCPMSS_GT);
 
-    DetectTcpmssFree(tcpmssd);
+    DetectTcpmssFree(NULL, tcpmssd);
 
     PASS;
 }
@@ -108,7 +108,7 @@ static int DetectTcpmssParseTest05 (void)
     FAIL_IF_NOT(tcpmssd->arg2 == 2);
     FAIL_IF_NOT(tcpmssd->mode == DETECT_TCPMSS_RA);
 
-    DetectTcpmssFree(tcpmssd);
+    DetectTcpmssFree(NULL, tcpmssd);
 
     PASS;
 }

--- a/src/tests/detect-template.c
+++ b/src/tests/detect-template.c
@@ -32,7 +32,7 @@ static int DetectTemplateParseTest01 (void)
     DetectTemplateData *templated = DetectTemplateParse("1,10");
     FAIL_IF_NULL(templated);
     FAIL_IF(!(templated->arg1 == 1 && templated->arg2 == 10));
-    DetectTemplateFree(templated);
+    DetectTemplateFree(NULL, templated);
     PASS;
 }
 

--- a/src/tests/detect-template2.c
+++ b/src/tests/detect-template2.c
@@ -37,7 +37,7 @@ static int DetectTemplate2ParseTest01 (void)
     FAIL_IF_NOT(template2d->arg1 == 10);
     FAIL_IF_NOT(template2d->mode == DETECT_TEMPLATE2_EQ);
 
-    DetectTemplate2Free(template2d);
+    DetectTemplate2Free(NULL, template2d);
 
     PASS;
 }
@@ -55,7 +55,7 @@ static int DetectTemplate2ParseTest02 (void)
     FAIL_IF_NOT(template2d->arg1 == 10);
     FAIL_IF_NOT(template2d->mode == DETECT_TEMPLATE2_LT);
 
-    DetectTemplate2Free(template2d);
+    DetectTemplate2Free(NULL, template2d);
 
     PASS;
 }
@@ -73,7 +73,7 @@ static int DetectTemplate2ParseTest03 (void)
     FAIL_IF_NOT(template2d->arg1 == 1);
     FAIL_IF_NOT(template2d->mode == DETECT_TEMPLATE2_RA);
 
-    DetectTemplate2Free(template2d);
+    DetectTemplate2Free(NULL, template2d);
 
     PASS;
 }
@@ -91,7 +91,7 @@ static int DetectTemplate2ParseTest04 (void)
     FAIL_IF_NOT(template2d->arg1 == 10);
     FAIL_IF_NOT(template2d->mode == DETECT_TEMPLATE2_GT);
 
-    DetectTemplate2Free(template2d);
+    DetectTemplate2Free(NULL, template2d);
 
     PASS;
 }
@@ -110,7 +110,7 @@ static int DetectTemplate2ParseTest05 (void)
     FAIL_IF_NOT(template2d->arg2 == 2);
     FAIL_IF_NOT(template2d->mode == DETECT_TEMPLATE2_RA);
 
-    DetectTemplate2Free(template2d);
+    DetectTemplate2Free(NULL, template2d);
 
     PASS;
 }

--- a/src/tests/detect-tls-cert-validity.c
+++ b/src/tests/detect-tls-cert-validity.c
@@ -34,7 +34,7 @@ static int ValidityTestParse01 (void)
     dd = DetectTlsValidityParse("1430000000");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->epoch == 1430000000 && dd->mode == DETECT_TLS_VALIDITY_EQ);
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(NULL, dd);
     PASS;
 }
 
@@ -50,7 +50,7 @@ static int ValidityTestParse02 (void)
     dd = DetectTlsValidityParse(">1430000000");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->epoch == 1430000000 && dd->mode == DETECT_TLS_VALIDITY_GT);
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(NULL, dd);
     PASS;
 }
 
@@ -66,7 +66,7 @@ static int ValidityTestParse03 (void)
     dd = DetectTlsValidityParse("<1430000000");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->epoch == 1430000000 && dd->mode == DETECT_TLS_VALIDITY_LT);
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(NULL, dd);
     PASS;
 }
 
@@ -83,7 +83,7 @@ static int ValidityTestParse04 (void)
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->epoch == 1430000000 && dd->epoch2 == 1470000000 &&
                 dd->mode == DETECT_TLS_VALIDITY_RA);
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(NULL, dd);
     PASS;
 }
 
@@ -198,7 +198,7 @@ static int ValidityTestParse12 (void)
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->epoch == 1430000000 && dd->epoch2 == 1490000000 &&
                 dd->mode == DETECT_TLS_VALIDITY_RA);
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(NULL, dd);
     PASS;
 }
 
@@ -214,7 +214,7 @@ static int ValidityTestParse13 (void)
     dd = DetectTlsValidityParse("> 1430000000 ");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->epoch == 1430000000 && dd->mode == DETECT_TLS_VALIDITY_GT);
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(NULL, dd);
     PASS;
 }
 
@@ -230,7 +230,7 @@ static int ValidityTestParse14 (void)
     dd = DetectTlsValidityParse("<   1490000000 ");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->epoch == 1490000000 && dd->mode == DETECT_TLS_VALIDITY_LT);
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(NULL, dd);
     PASS;
 }
 
@@ -246,7 +246,7 @@ static int ValidityTestParse15 (void)
     dd = DetectTlsValidityParse("   1490000000 ");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->epoch == 1490000000 && dd->mode == DETECT_TLS_VALIDITY_EQ);
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(NULL, dd);
     PASS;
 }
 
@@ -262,7 +262,7 @@ static int ValidityTestParse16 (void)
     dd = DetectTlsValidityParse("2015-10");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->epoch == 1443657600 && dd->mode == DETECT_TLS_VALIDITY_EQ);
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(NULL, dd);
     PASS;
 }
 
@@ -278,7 +278,7 @@ static int ValidityTestParse17 (void)
     dd = DetectTlsValidityParse(">2015-10-22");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->epoch == 1445472000 && dd->mode == DETECT_TLS_VALIDITY_GT);
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(NULL, dd);
     PASS;
 }
 
@@ -294,7 +294,7 @@ static int ValidityTestParse18 (void)
     dd = DetectTlsValidityParse("<2015-10-22 23");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->epoch == 1445554800 && dd->mode == DETECT_TLS_VALIDITY_LT);
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(NULL, dd);
     PASS;
 }
 
@@ -310,7 +310,7 @@ static int ValidityTestParse19 (void)
     dd = DetectTlsValidityParse("2015-10-22 23:59");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->epoch == 1445558340 && dd->mode == DETECT_TLS_VALIDITY_EQ);
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(NULL, dd);
     PASS;
 }
 
@@ -326,7 +326,7 @@ static int ValidityTestParse20 (void)
     dd = DetectTlsValidityParse("2015-10-22 23:59:59");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->epoch == 1445558399 && dd->mode == DETECT_TLS_VALIDITY_EQ);
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(NULL, dd);
     PASS;
 }
 
@@ -342,7 +342,7 @@ static int ValidityTestParse21 (void)
     dd = DetectTlsValidityParse("2015-10-22T23");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->epoch == 1445554800 && dd->mode == DETECT_TLS_VALIDITY_EQ);
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(NULL, dd);
     PASS;
 }
 
@@ -358,7 +358,7 @@ static int ValidityTestParse22 (void)
     dd = DetectTlsValidityParse("2015-10-22T23:59");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->epoch == 1445558340 && dd->mode == DETECT_TLS_VALIDITY_EQ);
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(NULL, dd);
     PASS;
 }
 
@@ -374,7 +374,7 @@ static int ValidityTestParse23 (void)
     dd = DetectTlsValidityParse("2015-10-22T23:59:59");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->epoch == 1445558399 && dd->mode == DETECT_TLS_VALIDITY_EQ);
-    DetectTlsValidityFree(dd);
+    DetectTlsValidityFree(NULL, dd);
     PASS;
 }
 

--- a/src/tests/detect-tls-version.c
+++ b/src/tests/detect-tls-version.c
@@ -29,10 +29,10 @@
 static int DetectTlsVersionTestParse01 (void)
 {
     DetectTlsVersionData *tls = NULL;
-    tls = DetectTlsVersionParse("1.0");
+    tls = DetectTlsVersionParse(NULL, "1.0");
     FAIL_IF_NULL(tls);
     FAIL_IF_NOT(tls->ver == TLS_VERSION_10);
-    DetectTlsVersionFree(tls);
+    DetectTlsVersionFree(NULL, tls);
     PASS;
 }
 
@@ -44,9 +44,9 @@ static int DetectTlsVersionTestParse01 (void)
 static int DetectTlsVersionTestParse02 (void)
 {
     DetectTlsVersionData *tls = NULL;
-    tls = DetectTlsVersionParse("2.5");
+    tls = DetectTlsVersionParse(NULL, "2.5");
     FAIL_IF_NOT_NULL(tls);
-    DetectTlsVersionFree(tls);
+    DetectTlsVersionFree(NULL, tls);
     PASS;
 }
 

--- a/src/tests/detect-ttl.c
+++ b/src/tests/detect-ttl.c
@@ -29,7 +29,7 @@ static int DetectTtlParseTest01 (void)
     FAIL_IF_NULL(ttld);
     FAIL_IF_NOT(ttld->ttl1 == 10);
     FAIL_IF_NOT(ttld->mode == DETECT_TTL_EQ);
-    DetectTtlFree(ttld);
+    DetectTtlFree(NULL, ttld);
     PASS;
 }
 
@@ -44,7 +44,7 @@ static int DetectTtlParseTest02 (void)
     FAIL_IF_NULL(ttld);
     FAIL_IF_NOT(ttld->ttl1 == 10);
     FAIL_IF_NOT(ttld->mode == DETECT_TTL_LT);
-    DetectTtlFree(ttld);
+    DetectTtlFree(NULL, ttld);
     PASS;
 }
 
@@ -60,7 +60,7 @@ static int DetectTtlParseTest03 (void)
     FAIL_IF_NOT(ttld->ttl1 == 1);
     FAIL_IF_NOT(ttld->ttl2 == 2);
     FAIL_IF_NOT(ttld->mode == DETECT_TTL_RA);
-    DetectTtlFree(ttld);
+    DetectTtlFree(NULL, ttld);
     PASS;
 }
 
@@ -75,7 +75,7 @@ static int DetectTtlParseTest04 (void)
     FAIL_IF_NULL(ttld);
     FAIL_IF_NOT(ttld->ttl1 == 10);
     FAIL_IF_NOT(ttld->mode == DETECT_TTL_GT);
-    DetectTtlFree(ttld);
+    DetectTtlFree(NULL, ttld);
     PASS;
 }
 
@@ -91,7 +91,7 @@ static int DetectTtlParseTest05 (void)
     FAIL_IF_NOT(ttld->ttl1 == 1);
     FAIL_IF_NOT(ttld->ttl2 == 2);
     FAIL_IF_NOT(ttld->mode == DETECT_TTL_RA);
-    DetectTtlFree(ttld);
+    DetectTtlFree(NULL, ttld);
     PASS;
 }
 

--- a/src/tests/fuzz/fuzz_siginit.c
+++ b/src/tests/fuzz/fuzz_siginit.c
@@ -50,10 +50,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         Signature *s = SigInit(de_ctx, buffer);
         free(buffer);
         if (s && s->next) {
-            SigFree(s->next);
+            SigFree(de_ctx, s->next);
             s->next = NULL;
         }
-        SigFree(s);
+        SigFree(de_ctx, s);
     }
 
     return 0;

--- a/src/util-rule-vars.c
+++ b/src/util-rule-vars.c
@@ -379,7 +379,7 @@ static int SCRuleVarsPositiveTest03(void)
     s = SigInit(de_ctx, "alert tcp [$HTTP_SERVERS,$HOME_NET,192.168.2.5] $HTTP_PORTS -> $EXTERNAL_NET [80,[!$HTTP_PORTS,$ORACLE_PORTS]] (msg:\"Rule Vars Test\"; sid:1;)");
     if (s == NULL)
         goto end;
-    SigFree(s);
+    SigFree(de_ctx, s);
 
     result = 1;
 
@@ -417,17 +417,17 @@ static int SCRuleVarsNegativeTest04(void)
     s = SigInit(de_ctx, "alert tcp $http_servers any -> any any (msg:\"Rule Vars Test\"; sid:1;)");
     if (s != NULL)
         goto end;
-    SigFree(s);
+    SigFree(de_ctx, s);
 
     s = SigInit(de_ctx, "alert tcp $http_servers any -> any $HTTP_PORTS (msg:\"Rule Vars Test\"; sid:1;)");
     if (s != NULL)
         goto end;
-    SigFree(s);
+    SigFree(de_ctx, s);
 
     s = SigInit(de_ctx, "alert tcp !$TELNET_SERVERS !80 -> any !$SSH_PORTS (msg:\"Rule Vars Test\"; sid:1;)");
     if (s != NULL)
         goto end;
-    SigFree(s);
+    SigFree(de_ctx, s);
 
     result = 1;
 

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -592,7 +592,7 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
                         DETECT_THRESHOLD, DETECT_DETECTION_FILTER, -1);
                 if (sm != NULL) {
                     SigMatchRemoveSMFromList(s, sm, DETECT_SM_LIST_THRESHOLD);
-                    SigMatchFree(sm);
+                    SigMatchFree(de_ctx, sm);
                     sm = NULL;
                 }
             }


### PR DESCRIPTION
Continuation of #4838

I used these rules -- the first rule demonstrated the issue. With this PR, memory is no longer overrun.
```
alert http any any -> any any (msg:"High entropy in file name download"; file.name; content:".exe"; endswith; fast_pattern;  bsize:<21; lua:any.lua; xbits: isset, urlentropy.detected; track ip_dst, expire 3600; target: dest_ip; sid:10; rev:1;)
alert http any any -> any any (msg:"High entropy in file name download"; file.name; content:".exe"; endswith; fast_pattern;  bsize:<21; lua:any.lua;   target: dest_ip; sid:11; rev:1;)
```

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3273](https://redmine.openinfosecfoundation.org/issues/3273)

Describe changes:
- Addressed review comments.