### PR TITLE
Byteextractstr/part1/v2

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -45,6 +45,7 @@
 #include "util-pool.h"
 #include "util-radix-tree.h"
 #include "util-file.h"
+#include "util-byte.h"
 
 #include "stream-tcp-private.h"
 #include "stream-tcp-reassemble.h"
@@ -2778,11 +2779,12 @@ static void HTPConfigParseParameters(HTPCfgRec *cfg_prec, ConfNode *s,
                 cfg_prec->randomize = ConfValIsTrue(p->val);
             }
         } else if (strcasecmp("randomize-inspection-range", p->name) == 0) {
-            uint32_t range = atoi(p->val);
-            if (range > 100) {
-                SCLogError(SC_ERR_SIZE_PARSE, "Invalid value for randomize"
-                           " inspection range setting from conf file - %s."
-                           " It should be inferior to 100."
+            uint32_t range;
+            if (StringParseU32RangeCheck(&range, 10, 0,
+                                         (const char *)p->val, 0, 100) < 0) {
+                SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for randomize"
+                           "-inspection-range setting from conf file - \"%s\"."
+                           " It should be a valid integer less than 100."
                            " Killing engine",
                            p->val);
                 exit(EXIT_FAILURE);

--- a/src/counters.c
+++ b/src/counters.c
@@ -33,6 +33,7 @@
 #include "util-time.h"
 #include "util-unittest.h"
 #include "util-debug.h"
+#include "util-byte.h"
 #include "util-privs.h"
 #include "util-signal.h"
 #include "unix-manager.h"
@@ -251,7 +252,12 @@ static void StatsInitCtxPreOutput(void)
 
         const char *interval = ConfNodeLookupChildValue(stats, "interval");
         if (interval != NULL)
-            stats_tts = (uint32_t) atoi(interval);
+            if (StringParseUint32(&stats_tts, 10, 0, interval) < 0) {
+                SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
+                             "interval: \"%s\". Resetting to %d.", interval,
+                             STATS_MGMTT_TTS);
+                stats_tts = STATS_MGMTT_TTS;
+            }
 
         int b;
         int ret = ConfGetChildValueBool(stats, "decoder-events", &b);

--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -44,6 +44,7 @@
 #include "detect-engine-port.h"
 
 #include "util-debug.h"
+#include "util-byte.h"
 #include "util-print.h"
 #include "util-var.h"
 
@@ -483,10 +484,9 @@ static int DetectAddressParseString(DetectAddress *dd, const char *str)
                         goto error;
                 }
 
-                int cidr = atoi(mask);
-                if (cidr < 0 || cidr > 32)
+                int cidr;
+                if (StringParseI32RangeCheck(&cidr, 10, 0, (const char *)mask, 0, 32) < 0)
                     goto error;
-
                 netmask = CIDRGet(cidr);
             } else {
                 /* 1.2.3.4/255.255.255.0 format */
@@ -543,9 +543,9 @@ static int DetectAddressParseString(DetectAddress *dd, const char *str)
             ip[mask - ip] = '\0';
             mask++;
 
-            int cidr = atoi(mask);
-            if (cidr < 0 || cidr > 128)
-                    goto error;
+            int cidr;
+            if (StringParseI32RangeCheck(&cidr, 10, 0, (const char *)mask, 0, 128) < 0)
+                goto error;
 
             r = inet_pton(AF_INET6, ip, &in6);
             if (r <= 0)

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -53,6 +53,7 @@
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 #include "util-print.h"
+#include "util-byte.h"
 #include "util-profiling.h"
 #include "util-validate.h"
 
@@ -165,8 +166,8 @@ static int IPOnlyCIDRItemParseSingle(IPOnlyCIDRItem *dd, const char *str)
                         goto error;
                 }
 
-                int cidr = atoi(mask);
-                if (cidr < 0 || cidr > 32)
+                int cidr;
+                if (StringParseI32RangeCheck(&cidr, 10, 0, (const char *)mask, 0, 32) < 0)
                     goto error;
 
                 dd->netmask = cidr;
@@ -263,7 +264,10 @@ static int IPOnlyCIDRItemParseSingle(IPOnlyCIDRItem *dd, const char *str)
                 goto error;
 
             /* Format is cidr val */
-            dd->netmask = atoi(mask);
+            if (StringParseU8RangeCheck(&dd->netmask, 10, 0,
+                                        (const char *)mask, 0, 128) < 0) {
+                goto error;
+            }
 
             memcpy(dd->ip, &in6.s6_addr, sizeof(ip6addr));
         } else {

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2307,7 +2307,15 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
             }
 
             if (insp_recursion_limit != NULL) {
-                de_ctx->inspection_recursion_limit = atoi(insp_recursion_limit);
+                if (StringParseInt32(&de_ctx->inspection_recursion_limit, 10,
+                                     0, (const char *)insp_recursion_limit) < 0) {
+                    SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
+                                 "detect-engine.inspection-recursion-limit: %s "
+                                 "resetting to %d", insp_recursion_limit,
+                                 DETECT_ENGINE_DEFAULT_INSPECTION_RECURSION_LIMIT);
+                    de_ctx->inspection_recursion_limit =
+                        DETECT_ENGINE_DEFAULT_INSPECTION_RECURSION_LIMIT;
+                }
             } else {
                 de_ctx->inspection_recursion_limit =
                     DETECT_ENGINE_DEFAULT_INSPECTION_RECURSION_LIMIT;
@@ -4262,7 +4270,7 @@ static int DetectEngineTest02(void)
     if (de_ctx == NULL)
         goto end;
 
-    result = (de_ctx->inspection_recursion_limit == -1);
+    result = (de_ctx->inspection_recursion_limit == DETECT_ENGINE_DEFAULT_INSPECTION_RECURSION_LIMIT);
 
  end:
     if (de_ctx != NULL)

--- a/src/detect-id.c
+++ b/src/detect-id.c
@@ -38,6 +38,7 @@
 #include "flow-var.h"
 
 #include "util-debug.h"
+#include "util-byte.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 
@@ -150,12 +151,9 @@ static DetectIdData *DetectIdParse (const char *idstr)
     }
 
     /* ok, fill the id data */
-    temp = atoi((char *)tmp_str);
-
-    if (temp > DETECT_IPID_MAX) {
-        SCLogError(SC_ERR_INVALID_VALUE, "invalid id option '%s'. The id option "
-                    "value must be in the range %u - %u",
-                    idstr, DETECT_IPID_MIN, DETECT_IPID_MAX);
+    if (StringParseU32RangeCheck(&temp, 10, 0, (const char *)tmp_str,
+                                 DETECT_IPID_MIN, DETECT_IPID_MAX) < 0) {
+        SCLogError(SC_ERR_INVALID_VALUE, "invalid id option '%s'", tmp_str);
         return NULL;
     }
 

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -32,6 +32,7 @@
 #include "detect-xbits.h"
 #include "detect-hostbits.h"
 #include "util-spm.h"
+#include "util-byte.h"
 
 #include "detect-engine-sigorder.h"
 
@@ -196,7 +197,7 @@ static int DetectXbitParse(DetectEngineCtx *de_ctx,
     char fb_cmd_str[16] = "", fb_name[256] = "";
     char hb_dir_str[16] = "";
     enum VarTypes var_type = VAR_TYPE_NOT_SET;
-    int expire = DETECT_XBITS_EXPIRE_DEFAULT;
+    uint32_t expire = DETECT_XBITS_EXPIRE_DEFAULT;
 
     ret = DetectParsePcreExec(&parse_regex, rawstr,  0, 0, ov, MAX_SUBSTRINGS);
     if (ret != 2 && ret != 3 && ret != 4 && ret != 5) {
@@ -247,10 +248,9 @@ static int DetectXbitParse(DetectEngineCtx *de_ctx,
                     return -1;
                 }
                 SCLogDebug("expire_str %s", expire_str);
-                expire = atoi(expire_str);
-                if (expire < 0) {
-                    SCLogError(SC_ERR_INVALID_VALUE, "expire must be positive. "
-                            "Got %d (\"%s\")", expire, expire_str);
+                if (StringParseUint32(&expire, 10, 0, (const char *)expire_str) < 0) {
+                    SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
+                               "expire: \"%s\"", expire_str);
                     return -1;
                 }
                 if (expire == 0) {

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -28,6 +28,7 @@
 #include "suricata-common.h"
 #include "util-error.h"
 #include "util-debug.h"
+#include "util-byte.h"
 #include "util-ip.h"
 #include "util-radix-tree.h"
 #include "util-unittest.h"
@@ -251,10 +252,9 @@ static int SRepCatSplitLine(char *line, uint8_t *cat, char *shortname, size_t sh
 
     SCLogDebug("%s, %s", ptrs[0], ptrs[1]);
 
-    int c = atoi(ptrs[0]);
-    if (c < 0 || c >= SREP_MAX_CATS) {
+    int c;
+    if (StringParseI32RangeCheck(&c, 10, 0, (const char *)ptrs[0], 0, SREP_MAX_CATS + 1) < 0)
         return -1;
-    }
 
     *cat = (uint8_t)c;
     strlcpy(shortname, ptrs[1], shortname_len);
@@ -305,15 +305,12 @@ static int SRepSplitLine(SRepCIDRTree *cidr_ctx, char *line, Address *ip, uint8_
     if (strcmp(ptrs[0], "ip") == 0)
         return 1;
 
-    int c = atoi(ptrs[1]);
-    if (c < 0 || c >= SREP_MAX_CATS) {
+    int c, v;
+    if (StringParseI32RangeCheck(&c, 10, 0, (const char *)ptrs[1], 0, SREP_MAX_CATS + 1) < 0)
         return -1;
-    }
 
-    int v = atoi(ptrs[2]);
-    if (v < 0 || v > SREP_MAX_VAL) {
+    if (StringParseI32RangeCheck(&v, 10, 0, (const char *)ptrs[2], 0, SREP_MAX_VAL) < 0)
         return -1;
-    }
 
     if (strchr(ptrs[0], '/') != NULL) {
         SRepCIDRAddNetblock(cidr_ctx, ptrs[0], c, v);

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -294,11 +294,11 @@ static void *ParseAFPConfig(const char *iface)
     if (ConfGetChildValueWithDefault(if_root, if_default, "cluster-id", &tmpclusterid) != 1) {
         aconf->cluster_id = (uint16_t)(cluster_id_auto++);
     } else {
-        if (StringParseInt32(&aconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
+        if (StringParseUint16(&aconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
             SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid cluster_id, resetting to 0");
             aconf->cluster_id = 0;
         }
-        SCLogDebug("Going to use cluster-id %" PRId32, aconf->cluster_id);
+        SCLogDebug("Going to use cluster-id %" PRIu16, aconf->cluster_id);
     }
 
     if (ConfGetChildValueWithDefault(if_root, if_default, "cluster-type", &tmpctype) != 1) {

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -54,6 +54,7 @@
 #include "util-runmodes.h"
 #include "util-ioctl.h"
 #include "util-ebpf.h"
+#include "util-byte.h"
 
 #include "source-af-packet.h"
 
@@ -194,7 +195,11 @@ static void *ParseAFPConfig(const char *iface)
             if (strcmp(threadsstr, "auto") == 0) {
                 aconf->threads = 0;
             } else {
-                aconf->threads = atoi(threadsstr);
+                if (StringParseInt32(&aconf->threads, 10, 0, (const char *)threadsstr) < 0) {
+                    SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid number of "
+                                 "threads, resetting to default");
+                    aconf->threads = 0;
+                }
             }
         }
     }
@@ -289,7 +294,10 @@ static void *ParseAFPConfig(const char *iface)
     if (ConfGetChildValueWithDefault(if_root, if_default, "cluster-id", &tmpclusterid) != 1) {
         aconf->cluster_id = (uint16_t)(cluster_id_auto++);
     } else {
-        aconf->cluster_id = (uint16_t)atoi(tmpclusterid);
+        if (StringParseInt32(&aconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
+            SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid cluster_id, resetting to 0");
+            aconf->cluster_id = 0;
+        }
         SCLogDebug("Going to use cluster-id %" PRId32, aconf->cluster_id);
     }
 

--- a/src/runmode-napatech.c
+++ b/src/runmode-napatech.c
@@ -195,8 +195,12 @@ static void *NapatechConfigParser(const char *device)
         return NULL;
     }
 
-    /* device+5 is a pointer to the beginning of the stream id after the constant nt portion */
-    conf->stream_id = atoi(device + 2);
+    /* device+2 is a pointer to the beginning of the stream id after the constant nt portion */
+    if (StringParseUint16(&conf->stream_id, 10, 0, device + 2) < 0) {
+        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for stream_id: %s", device + 2);
+        SCFree(conf);
+        return NULL;
+    }
 
     /* Set the host buffer allowance for this stream
      * Right now we just look at the global default - there is no per-stream hba configuration

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -148,7 +148,11 @@ static int ParseNetmapSettings(NetmapIfaceSettings *ns, const char *iface,
             ns->threads = 0;
             ns->threads_auto = true;
         } else {
-            ns->threads = atoi(threadsstr);
+            if (StringParseUint16(&ns->threads, 10, 0, threadsstr) < 0) {
+                SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid config value for "
+                             "threads: %s, resetting to 0", threadsstr);
+                ns->threads = 0;
+            }
         }
     }
 

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -31,6 +31,7 @@
 #include "util-runmodes.h"
 #include "util-atomic.h"
 #include "util-misc.h"
+#include "util-byte.h"
 
 const char *RunModeIdsGetDefaultMode(void)
 {
@@ -144,7 +145,11 @@ static void *ParsePcapConfig(const char *iface)
         aconf->threads = 1;
     } else {
         if (threadsstr != NULL) {
-            aconf->threads = atoi(threadsstr);
+            if (StringParseInt32(&aconf->threads, 10, 0, (const char *)threadsstr) < 0) {
+                SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
+                             "pcap.threads: %s, resetting to 1", threadsstr);
+                aconf->threads = 1;
+            }
         }
     }
     if (aconf->threads == 0) {

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -123,7 +123,11 @@ static void *OldParsePfringConfig(const char *iface)
         pfconf->threads = 1;
     } else {
         if (threadsstr != NULL) {
-            pfconf->threads = atoi(threadsstr);
+            if (StringParseUint16(&pfconf->threads, 10, 0, threadsstr) < 0) {
+                SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
+                             "pfring.threads: '%s'. Resetting it to 1.", threadsstr);
+                pfconf->threads = 1;
+            }
         }
     }
     if (pfconf->threads == 0) {
@@ -141,7 +145,11 @@ static void *OldParsePfringConfig(const char *iface)
     } else if (ConfGet("pfring.cluster-id", &tmpclusterid) != 1) {
         SCLogError(SC_ERR_INVALID_ARGUMENT,"Could not get cluster-id from config");
     } else {
-        pfconf->cluster_id = (uint16_t)atoi(tmpclusterid);
+        if (StringParseUint16(&pfconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
+            SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
+                         "pfring.cluster_id: '%s'. Resetting to 1.", tmpclusterid);
+            pfconf->cluster_id = 1;
+        }
         pfconf->flags |= PFRING_CONF_FLAGS_CLUSTER;
         SCLogDebug("Going to use cluster-id %" PRId32, pfconf->cluster_id);
     }
@@ -255,7 +263,11 @@ static void *ParsePfringConfig(const char *iface)
                 }
             }
         } else {
-            pfconf->threads = atoi(threadsstr);
+            if (StringParseUint16(&pfconf->threads, 10, 0, (const char *)threadsstr) < 0) {
+                SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
+                             "pfring.threads: '%s'. Resetting to 1.", threadsstr);
+                pfconf->threads = 1;
+            }
         }
     }
     if (pfconf->threads <= 0) {
@@ -267,7 +279,11 @@ static void *ParsePfringConfig(const char *iface)
 
     /* command line value has precedence */
     if (ConfGet("pfring.cluster-id", &tmpclusterid) == 1) {
-        pfconf->cluster_id = (uint16_t)atoi(tmpclusterid);
+        if (StringParseUint16(&pfconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
+            SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
+                         "pfring.cluster-id: '%s'. Resetting to 1.", tmpclusterid);
+            pfconf->cluster_id = 1;
+        }
         pfconf->flags |= PFRING_CONF_FLAGS_CLUSTER;
         SCLogDebug("Going to use command-line provided cluster-id %" PRId32,
                    pfconf->cluster_id);
@@ -283,7 +299,11 @@ static void *ParsePfringConfig(const char *iface)
             SCLogError(SC_ERR_INVALID_ARGUMENT,
                        "Could not get cluster-id from config");
         } else {
-            pfconf->cluster_id = (uint16_t)atoi(tmpclusterid);
+            if (StringParseUint16(&pfconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
+                SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
+                             "pfring.cluster-id: '%s'. Resetting to 1.", tmpclusterid);
+                pfconf->cluster_id = 1;
+            }
             pfconf->flags |= PFRING_CONF_FLAGS_CLUSTER;
             SCLogDebug("Going to use cluster-id %" PRId32, pfconf->cluster_id);
         }

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -92,7 +92,7 @@ typedef struct AFPIfaceConfig_
     /* block timeout for tpacket_v3 in milliseconds */
     int block_timeout;
     /* cluster param */
-    int cluster_id;
+    uint16_t cluster_id;
     int cluster_type;
     /* promisc mode */
     int promisc;

--- a/src/util-byte.c
+++ b/src/util-byte.c
@@ -360,6 +360,101 @@ int StringParseUint8(uint8_t *res, int base, uint16_t len, const char *str)
 
     return ret;
 }
+
+int StringParseU64RangeCheck(uint64_t *res, int base, uint16_t len, const char *str,
+                             uint64_t min, uint64_t max)
+{
+    uint64_t u64;
+
+    int ret = ByteExtractString(&u64, base, len, str, true);
+    if (ret <= 0) {
+        return ret;
+    }
+
+    *res = u64;
+
+    if (*res < min || *res > max) {
+        return -1;
+    }
+
+    return ret;
+}
+
+int StringParseU32RangeCheck(uint32_t *res, int base, uint16_t len, const char *str,
+                             uint32_t min, uint32_t max)
+{
+    uint64_t u64;
+
+    int ret = ByteExtractString(&u64, base, len, str, true);
+    if (ret <= 0) {
+        return ret;
+    }
+
+    *res = (uint32_t)u64;
+
+    if (*res < min || *res > max) {
+        return -1;
+    }
+
+    if ((uint64_t)(*res) != u64) {
+        SCLogError(SC_ERR_NUMERIC_VALUE_ERANGE, "Numeric value out of range "
+                   "(%" PRIu64 " > %" PRIuMAX ")", u64, (uintmax_t)UINT_MAX);
+        return -1;
+    }
+
+    return ret;
+}
+
+int StringParseU16RangeCheck(uint16_t *res, int base, uint16_t len, const char *str,
+                             uint16_t min, uint16_t max)
+{
+    uint64_t u64;
+
+    int ret = ByteExtractString(&u64, base, len, str, true);
+    if (ret <= 0) {
+        return ret;
+    }
+
+    *res = (uint16_t)u64;
+
+    if (*res < min || *res > max) {
+        return -1;
+    }
+
+    if ((uint64_t)(*res) != u64) {
+        SCLogError(SC_ERR_NUMERIC_VALUE_ERANGE, "Numeric value out of range "
+                   "(%" PRIu64 " > %" PRIuMAX ")", u64, (uintmax_t)USHRT_MAX);
+        return -1;
+    }
+
+    return ret;
+}
+
+int StringParseU8RangeCheck(uint8_t *res, int base, uint16_t len, const char *str,
+                            uint8_t min, uint8_t max)
+{
+    uint64_t u64;
+
+    int ret = ByteExtractString(&u64, base, len, str, true);
+    if (ret <= 0) {
+        return ret;
+    }
+
+    *res = (uint8_t)u64;
+
+    if (*res < min || *res > max) {
+        return -1;
+    }
+
+    if ((uint64_t)(*res) != u64) {
+        SCLogError(SC_ERR_NUMERIC_VALUE_ERANGE, "Numeric value out of range "
+                   "(%" PRIu64 " > %" PRIuMAX ")", u64, (uintmax_t)UCHAR_MAX);
+        return -1;
+    }
+
+    return ret;
+}
+
 int ByteExtractStringSigned(int64_t *res, int base, uint16_t len, const char *str, bool strict)
 {
     const char *ptr = str;
@@ -541,6 +636,104 @@ int StringParseInt8(int8_t *res, int base, uint16_t len, const char *str)
 
     return ret;
 }
+
+int StringParseI64RangeCheck(int64_t *res, int base, uint16_t len, const char *str,
+                             int64_t min, int64_t max)
+{
+    int64_t i64;
+    int ret;
+
+    ret = ByteExtractStringSigned(&i64, base, len, str, true);
+    if (ret <= 0) {
+        return ret;
+    }
+
+    *res = i64;
+    if (*res < min || *res > max) {
+        return -1;
+    }
+
+    return ret;
+}
+
+int StringParseI32RangeCheck(int32_t *res, int base, uint16_t len, const char *str,
+                             int32_t min, int32_t max)
+{
+    int64_t i64;
+    int ret;
+
+    ret = ByteExtractStringSigned(&i64, base, len, str, true);
+    if (ret <= 0) {
+        return ret;
+    }
+
+    *res = (int32_t)i64;
+
+    if (*res < min || *res > max) {
+        return -1;
+    }
+
+    if ((int64_t)(*res) != i64) {
+        SCLogError(SC_ERR_NUMERIC_VALUE_ERANGE, "Numeric value out of range "
+                   "(%" PRIi64 " > %" PRIiMAX ")\n", i64, (intmax_t)INT_MAX);
+        return -1;
+    }
+
+    return ret;
+}
+
+int StringParseI16RangeCheck(int16_t *res, int base, uint16_t len, const char *str,
+                             int16_t min, int16_t max)
+{
+    int64_t i64;
+    int ret;
+
+    ret = ByteExtractStringSigned(&i64, base, len, str, true);
+    if (ret <= 0) {
+        return ret;
+    }
+
+    *res = (int16_t)i64;
+
+    if (*res < min || *res > max) {
+        return -1;
+    }
+
+    if ((int64_t)(*res) != i64) {
+        SCLogError(SC_ERR_NUMERIC_VALUE_ERANGE, "Numeric value out of range "
+                   "(%" PRIi64 " > %" PRIiMAX ")\n", i64, (intmax_t)SHRT_MAX);
+        return -1;
+    }
+
+    return ret;
+}
+
+int StringParseI8RangeCheck(int8_t *res, int base, uint16_t len, const char *str,
+                            int8_t min, int8_t max)
+{
+    int64_t i64;
+    int ret;
+
+    ret = ByteExtractStringSigned(&i64, base, len, str, true);
+    if (ret <= 0) {
+        return ret;
+    }
+
+    *res = (int8_t)i64;
+
+    if (*res < min || *res > max) {
+        return -1;
+    }
+
+    if ((int64_t)(*res) != i64) {
+        SCLogError(SC_ERR_NUMERIC_VALUE_ERANGE, "Numeric value out of range "
+                   "(%" PRIi64 " > %" PRIiMAX ")\n", i64, (intmax_t)CHAR_MAX);
+        return -1;
+    }
+
+    return ret;
+}
+
 /* UNITTESTS */
 #ifdef UNITTESTS
 

--- a/src/util-byte.h
+++ b/src/util-byte.h
@@ -360,6 +360,111 @@ int StringParseInt16(int16_t *res, int base, uint16_t len, const char *str);
  */
 int StringParseInt8(int8_t *res, int base, uint16_t len, const char *str);
 
+/**
+ * Extract unsigned integer value from a string as uint64_t strictly within the range.
+ *
+ * \param res Stores result
+ * \param base Base of the number to extract
+ * \param len Number of bytes to extract (23 max or 0 for unbounded)
+ * \param len Number of bytes to extract (23 max)
+ * \param str String to extract from
+ *
+ * \return n Number of bytes extracted on success
+ * \return -1 On error
+ */
+int StringParseU64RangeCheck(uint64_t *res, int base, uint16_t len, const char *str, uint64_t min, uint64_t max);
+
+/**
+ * Extract unsigned integer value from a string as uint32_t strictly within the range.
+ *
+ * \param res Stores result
+ * \param base Base of the number to extract
+ * \param len Number of bytes to extract (23 max or 0 for unbounded)
+ * \param str String to extract from
+ *
+ * \return n Number of bytes extracted on success
+ * \return -1 On error
+ */
+int StringParseU32RangeCheck(uint32_t *res, int base, uint16_t len, const char *str, uint32_t min, uint32_t max);
+
+/**
+ * Extract unsigned integer value from a string as uint16_t strictly within the range.
+ *
+ * \param res Stores result
+ * \param base Base of the number to extract
+ * \param len Number of bytes to extract (23 max or 0 for unbounded)
+ * \param str String to extract from
+ *
+ * \return n Number of bytes extracted on success
+ * \return -1 On error
+ */
+int StringParseU16RangeCheck(uint16_t *res, int base, uint16_t len, const char *str, uint16_t min, uint16_t max);
+
+/**
+ * Extract unsigned integer value from a string as uint8_t strictly within the range.
+ *
+ * \param res Stores result
+ * \param base Base of the number to extract
+ * \param len Number of bytes to extract (23 max or 0 for unbounded)
+ * \param str String to extract from
+ *
+ * \return n Number of bytes extracted on success
+ * \return -1 On error
+ */
+int StringParseU8RangeCheck(uint8_t *res, int base, uint16_t len, const char *str, uint8_t min, uint8_t max);
+
+/**
+ * Extract signed integer value from a string as int64_t strictly within the range.
+ *
+ * \param res Stores result
+ * \param base Base of the number to extract
+ * \param len Number of bytes to extract (23 max or 0 for unbounded)
+ * \param str String to extract from
+ *
+ * \return n Number of bytes extracted on success
+ * \return -1 On error
+ */
+int StringParseI64RangeCheck(int64_t *res, int base, uint16_t len, const char *str, int64_t min, int64_t max);
+
+/**
+ * Extract signed integer value from a string as int32_t strictly within the range.
+ *
+ * \param res Stores result
+ * \param base Base of the number to extract
+ * \param len Number of bytes to extract (23 max or 0 for unbounded)
+ * \param str String to extract from
+ *
+ * \return n Number of bytes extracted on success
+ * \return -1 On error
+ */
+int StringParseI32RangeCheck(int32_t *res, int base, uint16_t len, const char *str, int32_t min, int32_t max);
+
+/**
+ * Extract signed integer value from a string as int16_t strictly within the range.
+ *
+ * \param res Stores result
+ * \param base Base of the number to extract
+ * \param len Number of bytes to extract (23 max or 0 for unbounded)
+ * \param str String to extract from
+ *
+ * \return n Number of bytes extracted on success
+ * \return -1 On error
+ */
+int StringParseI16RangeCheck(int16_t *res, int base, uint16_t len, const char *str, int16_t min, int16_t max);
+
+/**
+ * Extract signed integer value from a string as int8_t strictly within the range.
+ *
+ * \param res Stores result
+ * \param base Base of the number to extract
+ * \param len Number of bytes to extract (23 max or 0 for unbounded)
+ * \param str String to extract from
+ *
+ * \return n Number of bytes extracted on success
+ * \return -1 On error
+ */
+int StringParseI8RangeCheck(int8_t *res, int base, uint16_t len, const char *str, int8_t min, int8_t max);
+
 #ifdef UNITTESTS
 void ByteRegisterTests(void);
 #endif /* UNITTESTS */


### PR DESCRIPTION
`StringParse` functions error out in case of trailing characters after the extracted int, `ByteExtractString` functions ignore that.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3053