### PR TITLE
Backport 5.0.x: ftp split changes 

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -997,13 +997,13 @@ static int FTPGetAlstateProgress(void *vtx, uint8_t direction)
     SCLogDebug("tx %p", vtx);
     FTPTransaction *tx = vtx;
 
-    if (direction == STREAM_TOSERVER &&
-        tx->command_descriptor->command == FTP_COMMAND_PORT) {
-        return FTP_STATE_PORT_DONE;
-    }
-
-    if (!tx->done)
+    if (!tx->done) {
+        if (direction == STREAM_TOSERVER &&
+            tx->command_descriptor->command == FTP_COMMAND_PORT) {
+            return FTP_STATE_PORT_DONE;
+        }
         return FTP_STATE_IN_PROGRESS;
+    }
 
     return FTP_STATE_FINISHED;
 }

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -741,48 +741,40 @@ static int FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserState *pstat
     state->direction = 1;
 
     while (FTPGetLine(state) >= 0) {
-    FTPTransaction *tx = FTPGetOldestTx(state);
-    if (tx == NULL) {
-        tx = FTPTransactionCreate(state);
-    }
-    if (unlikely(tx == NULL)) {
-        return -1;
-    }
-    if (state->command == FTP_COMMAND_UNKNOWN || tx->command_descriptor == NULL) {
-        /* unknown */
-        tx->command_descriptor = &FtpCommands[FTP_COMMAND_MAX -1];
-    }
-
-    state->curr_tx = tx;
-    if (state->command == FTP_COMMAND_AUTH_TLS) {
-        if (state->current_line_len >= 4 && SCMemcmp("234 ", state->current_line, 4) == 0) {
-            AppLayerRequestProtocolTLSUpgrade(f);
+        FTPTransaction *tx = FTPGetOldestTx(state);
+        if (tx == NULL) {
+            tx = FTPTransactionCreate(state);
         }
-    }
+        if (unlikely(tx == NULL)) {
+            return -1;
+        }
+        if (state->command == FTP_COMMAND_UNKNOWN || tx->command_descriptor == NULL) {
+            /* unknown */
+            tx->command_descriptor = &FtpCommands[FTP_COMMAND_MAX -1];
+        }
 
         state->curr_tx = tx;
-        uint16_t dyn_port;
-        switch (state->command) {
-            case FTP_COMMAND_AUTH_TLS:
-                if (state->current_line_len >= 4 && SCMemcmp("234 ", state->current_line, 4) == 0) {
-                    AppLayerRequestProtocolTLSUpgrade(f);
-                }
-                break;
+        if (state->command == FTP_COMMAND_AUTH_TLS) {
+            if (state->current_line_len >= 4 && SCMemcmp("234 ", state->current_line, 4) == 0) {
+                AppLayerRequestProtocolTLSUpgrade(f);
+            }
+        }
 
-            case FTP_COMMAND_EPRT:
-                dyn_port = rs_ftp_active_eprt(state->port_line, state->port_line_len);
-                if (dyn_port == 0) {
-                    goto tx_complete;
-                }
-                state->dyn_port = dyn_port;
-                state->active = true;
-                tx->dyn_port = dyn_port;
-                tx->active = true;
-                SCLogDebug("FTP active mode (v6): dynamic port %"PRIu16"", dyn_port);
-                break;
+        if (state->command == FTP_COMMAND_EPRT) {
+            uint16_t dyn_port = rs_ftp_active_eprt(state->port_line, state->port_line_len);
+            if (dyn_port == 0) {
+                goto tx_complete;
+            }
+            state->dyn_port = dyn_port;
+            state->active = true;
+            tx->dyn_port = dyn_port;
+            tx->active = true;
+            SCLogDebug("FTP active mode (v6): dynamic port %"PRIu16"", dyn_port);
+        }
 
-            case FTP_COMMAND_PORT:
-                dyn_port = rs_ftp_active_port(state->port_line, state->port_line_len);
+        if (state->command == FTP_COMMAND_PORT) {
+            if ((flags & STREAM_TOCLIENT)) {
+                uint16_t dyn_port = rs_ftp_active_port(state->port_line, state->port_line_len);
                 if (dyn_port == 0) {
                     goto tx_complete;
                 }
@@ -791,37 +783,35 @@ static int FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserState *pstat
                 tx->dyn_port = state->dyn_port;
                 tx->active = true;
                 SCLogDebug("FTP active mode (v4): dynamic port %"PRIu16"", dyn_port);
-                break;
-
-            case FTP_COMMAND_PASV:
-                if (state->current_line_len >= 4 && SCMemcmp("227 ", state->current_line, 4) == 0) {
-                    FTPParsePassiveResponse(f, ftp_state, state->current_line, state->current_line_len);
-                }
-                break;
-
-            case FTP_COMMAND_EPSV:
-                if (state->current_line_len >= 4 && SCMemcmp("229 ", state->current_line, 4) == 0) {
-                    FTPParsePassiveResponseV6(f, ftp_state, state->current_line, state->current_line_len);
-                }
-                break;
-            default:
-                break;
+            }
         }
 
-    if (likely(state->current_line_len)) {
-        FTPString *response = FTPStringAlloc();
-        if (likely(response)) {
-            response->len = CopyCommandLine(&response->str, state->current_line, state->current_line_len);
-            TAILQ_INSERT_TAIL(&tx->response_list, response, next);
+        if (state->command == FTP_COMMAND_PASV) {
+            if (state->current_line_len >= 4 && SCMemcmp("227 ", state->current_line, 4) == 0) {
+                FTPParsePassiveResponse(f, ftp_state, state->current_line, state->current_line_len);
+            }
         }
-    }
 
-    /* Handle preliminary replies -- keep tx open */
-    if (FTPIsPPR(state->current_line, state->current_line_len)) {
-        continue;
-    }
-tx_complete:
-    tx->done = true;
+        if (state->command == FTP_COMMAND_EPSV) {
+            if (state->current_line_len >= 4 && SCMemcmp("229 ", state->current_line, 4) == 0) {
+                FTPParsePassiveResponseV6(f, ftp_state, state->current_line, state->current_line_len);
+            }
+        }
+
+        if (likely(state->current_line_len)) {
+            FTPString *response = FTPStringAlloc();
+            if (likely(response)) {
+                response->len = CopyCommandLine(&response->str, state->current_line, state->current_line_len);
+                TAILQ_INSERT_TAIL(&tx->response_list, response, next);
+            }
+        }
+
+        /* Handle preliminary replies -- keep tx open */
+        if (FTPIsPPR(state->current_line, state->current_line_len)) {
+            continue;
+        }
+    tx_complete:
+        tx->done = true;
     }
 
     return retcode;

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -735,7 +735,12 @@ static int FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserState *pstat
     if (unlikely(input_len == 0)) {
         return 1;
     }
+    state->input = input;
+    state->input_len = input_len;
+    /* toclient stream */
+    state->direction = 1;
 
+    while (FTPGetLine(state) >= 0) {
     FTPTransaction *tx = FTPGetOldestTx(state);
     if (tx == NULL) {
         tx = FTPTransactionCreate(state);
@@ -750,7 +755,7 @@ static int FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserState *pstat
 
     state->curr_tx = tx;
     if (state->command == FTP_COMMAND_AUTH_TLS) {
-        if (input_len >= 4 && SCMemcmp("234 ", input, 4) == 0) {
+        if (state->current_line_len >= 4 && SCMemcmp("234 ", state->current_line, 4) == 0) {
             AppLayerRequestProtocolTLSUpgrade(f);
         }
     }
@@ -784,32 +789,33 @@ static int FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserState *pstat
     }
 
     if (state->command == FTP_COMMAND_PASV) {
-        if (input_len >= 4 && SCMemcmp("227 ", input, 4) == 0) {
-            FTPParsePassiveResponse(f, ftp_state, input, input_len);
+        if (state->current_line_len >= 4 && SCMemcmp("227 ", state->current_line, 4) == 0) {
+            FTPParsePassiveResponse(f, ftp_state, state->current_line, state->current_line_len);
         }
     }
 
     if (state->command == FTP_COMMAND_EPSV) {
-        if (input_len >= 4 && SCMemcmp("229 ", input, 4) == 0) {
-            FTPParsePassiveResponseV6(f, ftp_state, input, input_len);
+        if (state->current_line_len >= 4 && SCMemcmp("229 ", state->current_line, 4) == 0) {
+            FTPParsePassiveResponseV6(f, ftp_state, state->current_line, state->current_line_len);
         }
     }
 
-    if (likely(input_len)) {
+    if (likely(state->current_line_len)) {
         FTPString *response = FTPStringAlloc();
         if (likely(response)) {
-            response->len = CopyCommandLine(&response->str, input, input_len);
+            response->len = CopyCommandLine(&response->str, state->current_line, state->current_line_len);
             TAILQ_INSERT_TAIL(&tx->response_list, response, next);
         }
     }
 
     /* Handle preliminary replies -- keep tx open */
-    if (FTPIsPPR(input, input_len)) {
-        return retcode;
+    if (FTPIsPPR(state->current_line, state->current_line_len)) {
+        continue;
     }
-
 tx_complete:
     tx->done = true;
+    }
+
     return retcode;
 }
 

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -760,45 +760,53 @@ static int FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserState *pstat
         }
     }
 
-    if (state->command == FTP_COMMAND_EPRT) {
-        uint16_t dyn_port = rs_ftp_active_eprt(state->port_line, state->port_line_len);
-        if (dyn_port == 0) {
-            retcode = 0;
-            goto tx_complete;
-        }
-        state->dyn_port = dyn_port;
-        state->active = true;
-        tx->dyn_port = dyn_port;
-        tx->active = true;
-        SCLogDebug("FTP active mode (v6): dynamic port %"PRIu16"", dyn_port);
-    }
+        state->curr_tx = tx;
+        uint16_t dyn_port;
+        switch (state->command) {
+            case FTP_COMMAND_AUTH_TLS:
+                if (state->current_line_len >= 4 && SCMemcmp("234 ", state->current_line, 4) == 0) {
+                    AppLayerRequestProtocolTLSUpgrade(f);
+                }
+                break;
 
-    if (state->command == FTP_COMMAND_PORT) {
-        if ((flags & STREAM_TOCLIENT)) {
-            uint16_t dyn_port = rs_ftp_active_port(state->port_line, state->port_line_len);
-            if (dyn_port == 0) {
-                retcode = 0;
-                goto tx_complete;
-            }
-            state->dyn_port = dyn_port;
-            state->active = true;
-            tx->dyn_port = state->dyn_port;
-            tx->active = true;
-            SCLogDebug("FTP active mode (v4): dynamic port %"PRIu16"", dyn_port);
-        }
-    }
+            case FTP_COMMAND_EPRT:
+                dyn_port = rs_ftp_active_eprt(state->port_line, state->port_line_len);
+                if (dyn_port == 0) {
+                    goto tx_complete;
+                }
+                state->dyn_port = dyn_port;
+                state->active = true;
+                tx->dyn_port = dyn_port;
+                tx->active = true;
+                SCLogDebug("FTP active mode (v6): dynamic port %"PRIu16"", dyn_port);
+                break;
 
-    if (state->command == FTP_COMMAND_PASV) {
-        if (state->current_line_len >= 4 && SCMemcmp("227 ", state->current_line, 4) == 0) {
-            FTPParsePassiveResponse(f, ftp_state, state->current_line, state->current_line_len);
-        }
-    }
+            case FTP_COMMAND_PORT:
+                dyn_port = rs_ftp_active_port(state->port_line, state->port_line_len);
+                if (dyn_port == 0) {
+                    goto tx_complete;
+                }
+                state->dyn_port = dyn_port;
+                state->active = true;
+                tx->dyn_port = state->dyn_port;
+                tx->active = true;
+                SCLogDebug("FTP active mode (v4): dynamic port %"PRIu16"", dyn_port);
+                break;
 
-    if (state->command == FTP_COMMAND_EPSV) {
-        if (state->current_line_len >= 4 && SCMemcmp("229 ", state->current_line, 4) == 0) {
-            FTPParsePassiveResponseV6(f, ftp_state, state->current_line, state->current_line_len);
+            case FTP_COMMAND_PASV:
+                if (state->current_line_len >= 4 && SCMemcmp("227 ", state->current_line, 4) == 0) {
+                    FTPParsePassiveResponse(f, ftp_state, state->current_line, state->current_line_len);
+                }
+                break;
+
+            case FTP_COMMAND_EPSV:
+                if (state->current_line_len >= 4 && SCMemcmp("229 ", state->current_line, 4) == 0) {
+                    FTPParsePassiveResponseV6(f, ftp_state, state->current_line, state->current_line_len);
+                }
+                break;
+            default:
+                break;
         }
-    }
 
     if (likely(state->current_line_len)) {
         FTPString *response = FTPStringAlloc();


### PR DESCRIPTION
Continuation of #4842

This PR contains a backport of the FTP split commands from #4839 


