### PR TITLE
detect/ftp: FTP memory accounting fixes

### DIFF
--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -206,6 +206,7 @@ typedef struct FtpDataState_ {
     DetectEngineState *de_state;
     int32_t input_len;
     int16_t file_len;
+    int16_t file_mem_len;
     FtpRequestCommand command;
     uint8_t state;
     uint8_t direction;

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -99,7 +99,7 @@ static json_t *JsonFTPLogCommand(Flow *f, FTPTransaction *tx)
         TAILQ_FOREACH(response, &tx->response_list, next) {
             /* handle multiple lines within the response, \r\n delimited */
             uint8_t *where = response->str;
-            uint16_t length = response->len;
+            uint16_t length = (uint16_t) strlen((const char *)response->str);
             uint16_t pos;
             while ((pos = JsonGetNextLineFromBuffer((const char *)where, length)) != UINT16_MAX) {
                 uint16_t offset = 0;


### PR DESCRIPTION
Continuation of #4844 

This commit continues the work started by @vanlink and corrects the
accounting of FTP memory usage against the memcap limit.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3519](https://redmine.openinfosecfoundation.org/issues/3519)

Describe changes:
- Addressed review comments
Companion [Suricata-verify PR](https://github.com/OISF/suricata-verify/pull/219)
