### PR TITLE
detect/ftp: FTP memory accounting fixes

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -344,7 +344,7 @@ static void FTPTransactionFree(FTPTransaction *tx)
         FTPStringFree(str);
     }
 
-    SCFree(tx);
+    FTPFree(tx, sizeof(*tx));
 }
 
 static int FTPGetLineForDirection(FtpState *state, FtpLineState *line_state)
@@ -513,7 +513,7 @@ static void FtpTransferCmdFree(void *data)
     if (cmd == NULL)
         return;
     if (cmd->file_name) {
-        FTPFree(cmd->file_name, cmd->file_len);
+        FTPFree(cmd->file_name, cmd->file_len + 1);
     }
     FTPFree(cmd, sizeof(struct FtpTransferCmd));
 }
@@ -536,7 +536,7 @@ static uint32_t CopyCommandLine(uint8_t **dest, const uint8_t *src, uint32_t len
         *dest = where;
     }
     /* either 0 or actual */
-    return length;
+    return length ? length + 1 : 0;
 }
 
 
@@ -1195,12 +1195,12 @@ static void FTPDataStateFree(void *s)
         DetectEngineStateFree(fstate->de_state);
     }
     if (fstate->file_name != NULL) {
-        FTPFree(fstate->file_name, fstate->file_len);
+        FTPFree(fstate->file_name, fstate->file_len + 1);
     }
 
     FileContainerFree(fstate->files);
 
-    SCFree(s);
+    FTPFree(s, sizeof(FtpDataState));
 #ifdef DEBUG
     SCMutexLock(&ftpdata_state_mem_lock);
     ftpdata_state_memcnt--;

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -99,7 +99,7 @@ static json_t *JsonFTPLogCommand(Flow *f, FTPTransaction *tx)
         TAILQ_FOREACH(response, &tx->response_list, next) {
             /* handle multiple lines within the response, \r\n delimited */
             uint8_t *where = response->str;
-            uint16_t length = response->len;
+            uint16_t length = response->len ? response->len -1 : 0;
             uint16_t pos;
             while ((pos = JsonGetNextLineFromBuffer((const char *)where, length)) != UINT16_MAX) {
                 uint16_t offset = 0;


### PR DESCRIPTION
Continuation of #4854

This commit continues the work started by @vanlink and corrects the
accounting of FTP memory usage against the memcap limit.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3519](https://redmine.openinfosecfoundation.org/issues/3519)

Describe changes:
- Addressed review comments

Companion [Suricata-verify PR](https://github.com/OISF/suricata-verify/pull/219)
