### PR TITLE
source: Check for out-of-band control operations when packets aren't available

### DIFF
--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2010-2014 Open Information Security Foundation
+/* Copyright (C) 2010-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -349,6 +349,7 @@ ReceiveErfDagLoop(ThreadVars *tv, void *data, void *slot)
         if (top == NULL) {
             if (errno == EAGAIN) {
                 if (dtv->dagstream & 0x1) {
+                    TmThreadsCaptureHandleTimeout(tv, dtv->slot, NULL);
                     usleep(10 * 1000);
                     dtv->btm = dtv->top;
                 }

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2012-2017 Open Information Security Foundation
+/* Copyright (C) 2012-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -865,6 +865,9 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
         status = NT_NetRxGet(ntv->rx_stream, &packet_buffer, 1000);
         if (unlikely(
                 status == NT_STATUS_TIMEOUT || status == NT_STATUS_TRYAGAIN)) {
+            if (status == NT_STATUS_TIMEOUT) {
+                TmThreadsCaptureHandleTimeout(tv, ntv->slot, NULL);
+            }
             continue;
         } else if (unlikely(status != NT_SUCCESS)) {
             NAPATECH_ERROR(SC_ERR_NAPATECH_OPEN_FAILED, status);

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -896,7 +896,7 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
         switch (NT_NET_GET_PKT_TIMESTAMP_TYPE(packet_buffer)) {
             case NT_TIMESTAMP_TYPE_NATIVE_UNIX:
                 p->ts.tv_sec = pkt_ts / 100000000;
-                p->ts.tv_usec = ((pkt_ts % 100000000) / 100) + (pkt_ts % 100) > 50 ? 1 : 0;
+                p->ts.tv_usec = ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0);
                 break;
             case NT_TIMESTAMP_TYPE_PCAP:
                 p->ts.tv_sec = pkt_ts >> 32;
@@ -904,12 +904,12 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
                 break;
             case NT_TIMESTAMP_TYPE_PCAP_NANOTIME:
                 p->ts.tv_sec = pkt_ts >> 32;
-                p->ts.tv_usec = ((pkt_ts & 0xFFFFFFFF) / 1000) + (pkt_ts % 1000) > 500 ? 1 : 0;
+                p->ts.tv_usec = ((pkt_ts & 0xFFFFFFFF) / 1000) + ((pkt_ts % 1000) > 500 ? 1 : 0);
                 break;
             case NT_TIMESTAMP_TYPE_NATIVE_NDIS:
                 /* number of seconds between 1/1/1601 and 1/1/1970 */
                 p->ts.tv_sec = (pkt_ts / 100000000) - 11644473600;
-                p->ts.tv_usec = ((pkt_ts % 100000000) / 100) + (pkt_ts % 100) > 50 ? 1 : 0;
+                p->ts.tv_usec = ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0);
                 break;
             default:
                 SCLogError(SC_ERR_NAPATECH_TIMESTAMP_TYPE_NOT_SUPPORTED,


### PR DESCRIPTION
This PR fixes an issue seen when using Napatech hardware that results in the Suricata manager and unix-socket threads hanging. The same issue is in the dag packet source.

Describe changes:
- dag/napatech -- check for out-of-band control ops when packets aren't immediately available
- napatech: Fix timestamp conversion for usecs.

