### PR TITLE
doc: typo: http.server_body should be http.response_body

### DIFF
--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -59,7 +59,7 @@ http.response_line             Sticky Buffer            Response
 http.header                    Sticky Buffer            Both
 http.header.raw                Sticky Buffer            Both
 http.cookie                    Sticky Buffer            Both
-http.server_body               Sticky Buffer            Response
+http.response_body             Sticky Buffer            Response
 http.server                    Sticky Buffer            Response
 http.location                  Sticky Buffer            Response
 file_data                      Sticky Buffer            Response


### PR DESCRIPTION
Thanks to Jason Williams for pointing this out.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

Cleanly cherry-picks to master-5.0.x.