### PR TITLE
(Draft) - First attempt at output plugin support - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
     AC_INIT([suricata],[6.0.0-dev])
     m4_ifndef([AM_SILENT_RULES], [m4_define([AM_SILENT_RULES],[])])AM_SILENT_RULES([yes])
-    AC_CONFIG_HEADERS([config.h])
+    AC_CONFIG_HEADERS([src/config.h])
     AC_CONFIG_SRCDIR([src/suricata.c])
     AC_CONFIG_MACRO_DIR(m4)
     AM_INIT_AUTOMAKE([tar-ustar subdir-objects])

--- a/configure.ac
+++ b/configure.ac
@@ -185,6 +185,7 @@
     AC_CHECK_HEADERS([libgen.h])
     AC_CHECK_HEADERS([mach/mach.h])
     AC_CHECK_HEADERS([stdatomic.h])
+    AC_CHECK_HEADERS([dlfcn.h])
 
     AC_CHECK_HEADERS([sys/socket.h net/if.h sys/mman.h linux/if_arp.h], [], [],
     [[#ifdef HAVE_SYS_SOCKET_H

--- a/plugins/example-output/.gitignore
+++ b/plugins/example-output/.gitignore
@@ -1,0 +1,1 @@
+!Makefile

--- a/plugins/example-output/Makefile
+++ b/plugins/example-output/Makefile
@@ -1,0 +1,12 @@
+SRCS :=		dummy.c
+
+SURICATA_SRC ?=	../..
+
+CPPFLAGS +=	-DSURICATA_PLUGIN -I$(SURICATA_SRC)/src
+
+all:
+	gcc -fPIC $(CPPFLAGS) -o libdummy.so -shared $(SRCS)
+
+clean:
+	rm -f *.so *~
+

--- a/plugins/example-output/dummy.c
+++ b/plugins/example-output/dummy.c
@@ -1,0 +1,56 @@
+#include <stdio.h>
+#include "suricata-plugin.h"
+#include "dummy.h"
+
+#define OUTPUT_NAME "plugin:dummy"
+
+typedef struct Context_ {
+} Context;
+
+static int dummy_write(const char *buffer, int buffer_len, LogFileCtx *ctx) {
+    printf("dummy_write\n");
+    printf("dummy_write: rotate=%d\n", ctx->rotation_flag);
+    return 0;
+}
+
+static void dummy_close(LogFileCtx *ctx) {
+    printf("dummy_close\n");
+    SCFree(ctx->plugin);
+}
+
+static int dummy_open(LogFileCtx *ctx, ConfNode *conf) {
+    printf("conf: %p\n", conf);
+    Context *context = SCCalloc(1, sizeof(Context));
+    ctx->Write = dummy_write;
+    ctx->Close = dummy_close;
+    ctx->plugin = context;
+    return 0;
+}
+
+/**
+ * Called by Suricata to initialize the module. This module registers
+ * new file type to the JSON logger.
+ */
+void sc_plugin_init(void)
+{
+    PluginFileType *my_output = SCCalloc(1, sizeof(PluginFileType));
+    my_output->name = OUTPUT_NAME;
+    my_output->Open = dummy_open;
+    RegisterPluginFileType(my_output);
+}
+
+/**
+ * This function will be called by Suricata after it has loaded the
+ * module. Here we register some details of the module as well as the
+ * initialization function.
+ *
+ * This is really just a courtesy by the plugin author where they can
+ * register some details of their module and follow a convention we
+ * set out.
+ */
+void sc_plugin_register(SCPlugin *plugin) {
+    plugin->name = "dummy-output-plugin";
+    plugin->author = "Jason Ish <jason.ish@oisf.net>";
+    plugin->license = "GPLv2";
+    plugin->Init = sc_plugin_init;
+}

--- a/plugins/example-output/dummy.h
+++ b/plugins/example-output/dummy.h
@@ -1,0 +1,4 @@
+#ifndef DUMMY_PLUGIN_H
+#define DUMMY_PLUGIN_H
+
+#endif /* DUMMY_PLUGIN_H */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -541,7 +541,7 @@ win32-misc.c win32-misc.h \
 win32-service.c win32-service.h \
 win32-syslog.h
 
-EXTRA_DIST = tests
+EXTRA_DIST = tests pluginsyms.txt
 
 # set the include path found by configure
 AM_CPPFLAGS = $(all_includes)
@@ -549,7 +549,7 @@ AM_CPPFLAGS = $(all_includes)
 suricata_SOURCES = main.c $(COMMON_SOURCES)
 
 # the library search path.
-suricata_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
+suricata_LDFLAGS = $(all_libraries) ${SECLDFLAGS} -Wl,--dynamic-list=$(srcdir)/pluginsyms.txt
 suricata_LDADD = $(HTP_LDADD) $(RUST_LDADD)
 suricata_DEPENDENCIES = $(RUST_SURICATA_LIB)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,7 +3,7 @@ noinst_HEADERS = action-globals.h \
     debug.h \
 	flow-private.h queue.h source-nfq-prototypes.h \
 	source-windivert-prototypes.h \
-	suricata-common.h threadvars.h tree.h \
+	suricata-common.h suricata-plugin.h threadvars.h tree.h \
     util-validate.h
 bin_PROGRAMS = suricata
 if BUILD_FUZZTARGETS
@@ -495,6 +495,7 @@ util-optimize.h \
 util-pages.c util-pages.h \
 util-path.c util-path.h \
 util-pidfile.c util-pidfile.h \
+util-plugin.c util-plugin.h \
 util-pool.c util-pool.h \
 util-pool-thread.c util-pool-thread.h \
 util-prefilter.c util-prefilter.h \

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -30,6 +30,7 @@
 #include "output.h"
 
 #include "app-layer-htp-xff.h"
+#include "suricata-plugin.h"
 
 void OutputJsonRegister(void);
 
@@ -80,6 +81,7 @@ typedef struct OutputJsonCtx_ {
     enum LogFileType json_out;
     OutputJsonCommonSettings cfg;
     HttpXFFCfg *xff_cfg;
+    PluginFileType *plugin;
 } OutputJsonCtx;
 
 typedef struct OutputJsonThreadCtx_ {

--- a/src/pluginsyms.txt
+++ b/src/pluginsyms.txt
@@ -1,0 +1,4 @@
+{
+	SCCallocFunc;
+	RegisterOutputType;
+};

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -489,7 +489,9 @@ typedef enum {
 } LoggerId;
 
 #include "util-optimize.h"
+#ifndef SURICATA_PLUGIN
 #include <htp/htp.h>
+#endif
 #include "threads.h"
 #include "tm-threads-common.h"
 #include "util-debug.h"

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -9,6 +9,7 @@
 #endif
 
 #include "suricata-common.h"
+#include "util-logopenfile.h"
 
 typedef struct SCPlugin_ {
     char *name;
@@ -17,5 +18,13 @@ typedef struct SCPlugin_ {
 
     void (*Init)(void);
 } SCPlugin;
+
+typedef struct PluginFileType_ {
+    char *name;
+    int (*Open)(LogFileCtx *ctx, ConfNode *conf);
+    TAILQ_ENTRY(PluginFileType_) entries;
+} PluginFileType;
+
+void RegisterPluginFileType(PluginFileType *);
 
 #endif /* __SURICATA_PLUGIN_H */

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -1,0 +1,21 @@
+#ifndef __SURICATA_PLUGIN_H__
+#define __SURICATA_PLUGIN_H__
+
+#include <config.h>
+
+#ifdef SURICATA_PLUGIN
+#undef HAVE_LUA
+#undef HAVE_NSS
+#endif
+
+#include "suricata-common.h"
+
+typedef struct SCPlugin_ {
+    char *name;
+    char *license;
+    char *author;
+
+    void (*Init)(void);
+} SCPlugin;
+
+#endif /* __SURICATA_PLUGIN_H */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -174,6 +174,8 @@
 
 #include "util-lua.h"
 
+#include "util-plugin.h"
+
 #include "rust.h"
 
 /*
@@ -2511,6 +2513,8 @@ int PostConfLoadedSetup(SCInstance *suri)
 
     FeatureTrackingRegister(); /* must occur prior to output mod registration */
     RegisterAllModules();
+
+    PluginsLoad();
 
     AppLayerHtpNeedFileInspection();
 

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -590,6 +590,10 @@ int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer)
         SCMutexUnlock(&file_ctx->fp_mutex);
     }
 #endif
+    else if (file_ctx->type == LOGFILE_TYPE_PLUGIN) {
+        file_ctx->Write((const char *)MEMBUFFER_BUFFER(buffer),
+                        MEMBUFFER_OFFSET(buffer), file_ctx);
+    }
 
     return 0;
 }

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -37,11 +37,13 @@ typedef struct {
     uint16_t fileno;
 } PcieFile;
 
-enum LogFileType { LOGFILE_TYPE_FILE,
+enum LogFileType { LOGFILE_TYPE_NONE,
+                   LOGFILE_TYPE_FILE,
                    LOGFILE_TYPE_SYSLOG,
                    LOGFILE_TYPE_UNIX_DGRAM,
                    LOGFILE_TYPE_UNIX_STREAM,
-                   LOGFILE_TYPE_REDIS };
+                   LOGFILE_TYPE_REDIS,
+                   LOGFILE_TYPE_PLUGIN };
 
 typedef struct SyslogSetup_ {
     int alert_syslog_level;
@@ -53,6 +55,7 @@ typedef struct LogFileCtx_ {
     union {
         FILE *fp;
         PcieFile *pcie_fp;
+        void *plugin;
 #ifdef HAVE_LIBHIREDIS
         void *redis;
 #endif

--- a/src/util-plugin.c
+++ b/src/util-plugin.c
@@ -1,0 +1,75 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+#include "util-plugin.h"
+#include "suricata-plugin.h"
+
+#ifdef HAVE_DLFCN_H
+
+#include <dlfcn.h>
+
+static void InitPlugin(char *path)
+{
+    void *lib = dlopen(path, RTLD_LAZY);
+    if (lib != NULL) {
+        SCLogNotice("Loading plugin %s", path);
+        void (*registerf)(SCPlugin *) = dlsym(lib, "sc_plugin_register");
+        if (registerf == NULL) {
+            SCLogNotice("Plugin missing registration function: %s", path);
+        } else {
+            SCPlugin plugin;
+            memset(&plugin, 0, sizeof(plugin));
+            (*registerf)(&plugin);
+            BUG_ON(plugin.name == NULL);
+            BUG_ON(plugin.author == NULL);
+            BUG_ON(plugin.license == NULL);
+            BUG_ON(plugin.Init == NULL);
+            SCLogNotice("Initializing plugin %s; author=%s; license=%s",
+                plugin.name, plugin.author, plugin.license);
+            (*plugin.Init)();
+        }
+    }
+}
+
+void PluginsLoad(void)
+{
+    DIR *dir = NULL;
+    struct dirent *entry;
+    char path[PATH_MAX];
+    const char plugindir[] = "./plugins";
+
+    dir = opendir(plugindir);
+    if (dir == NULL) {
+        return;
+    }
+    while ((entry = readdir(dir)) != NULL) {
+        if (strstr(entry->d_name, ".so") != NULL) {
+            snprintf(path, sizeof(path), "%s/%s", plugindir, entry->d_name);
+            InitPlugin(path);
+        }
+    }
+    free(dir);
+}
+
+#else
+
+void PluginsLoad(void)
+{
+}
+
+#endif

--- a/src/util-plugin.h
+++ b/src/util-plugin.h
@@ -1,0 +1,23 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef __UTIL_PLUGIN_H__
+#define __UTIL_PLUGIN_H__
+
+void PluginsLoad(void);
+
+#endif /* __UTIL_PLUGIN_H__ */


### PR DESCRIPTION
A an initial draft of what plugins could look like, with an
example of a pluggable file types for Eve logging.

Some notes:
- This is Linux only. Plugins on Windows are quite different
  requiring building your plugin along with full Suricata source,
  or a Suricata DLL being made available. I'm not sure about
  the Mac.
- We explicitly list the symbols that plugins can call. This
  may limit some cool plugins, but allows us to restrict what
  is called to an API we would consider stable.
- Plugins are loaded from a hard codec directory. I expect to
  use a configuration section like:
```
plugins:
  enabled: true
  directories:
    - /usr/lib/suricata/plugins
    - /var/lib/suricata/plugins
```
- We currently pass the whole LogFileCtx into the plugin. May
  want to consider only passing what is needed for the plugin,
  this would also help keep the ABI stable.
- I expect multi-threaded logging to change the calling convention
  for this file type plugs a bit
  (https://redmine.openinfosecfoundation.org/issues/3293)
- Maybe internal file types should be registered in much
  the same way (fairly large refactor). I'll probably try
  this with the Redis output.