### PR TITLE
Restructure Packet/Hostbuffer release

### DIFF
--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -250,6 +250,7 @@ struct tcp_hdr
 
 #define COLOR_IS_SPAN                       0x00001000
 
+static int is_inline = 0;
 static int inline_port_map[MAX_PORTS] = { -1 };
 
 /**
@@ -642,21 +643,40 @@ TmEcode NapatechStreamThreadInit(ThreadVars *tv, const void *initdata, void **da
     SCReturnInt(TM_ECODE_OK);
 }
 
-static PacketQueue packets_to_release[MAX_STREAMS];
-
 /**
  * \brief Callback to indicate that the packet buffer can be returned to the hardware.
  *
- *  Called when Suricata is done processing the packet.  The packet is placed into
- *  a queue so that it can be retrieved and released by the packet processing thread.
+ *  Called when Suricata is done processing the packet.  Before the packet is released
+ *  this also checks the action to see if the packet should be dropped and programs the
+ *  flow hardware if the flow is to be bypassed and the Napatech packet buffer is released.
+ *
  *
  * \param p Packet to return to the system.
  *
  */
 static void NapatechReleasePacket(struct Packet_ *p)
 {
+    /*
+     * If the packet is to be dropped when need to set the wirelength
+     * before releasing the Napatech buffer back to NTService.
+     */
+    if (is_inline && PACKET_TEST_ACTION(p, ACTION_DROP)) {
+        p->ntpv.dyn3->wireLength = 0;
+    }
+
+#ifdef NAPATECH_ENABLE_BYPASS
+    /*
+     *  If this flow is to be programmed for hardware bypass we do it now.  This is done
+     *  here because the action is not available in the packet structure at the time of the
+     *  bypass callback and it needs to be done before we release the packet structure.
+     */
+    if (p->ntpv.bypass == 1) {
+        ProgramFlow(p, is_inline);
+    }
+#endif
+
+    NT_NetRxRelease(p->ntpv.rx_stream, p->ntpv.nt_packet_buf);
     PacketFreeOrRelease(p);
-    PacketEnqueue(&packets_to_release[p->ntpv.stream_id], p);
 }
 
 /**
@@ -756,15 +776,11 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
     int numa_node = -1;
     int set_cpu_affinity = 0;
     int closer = 0;
-    int is_inline = 0;
     int is_autoconfig = 0;
 
     /* This just keeps the startup output more orderly. */
     usleep(200000 * ntv->stream_id);
 
-    if (ConfGetBool("napatech.inline", &is_inline) == 0) {
-        is_inline = 0;
-    }
     if (ConfGetBool("napatech.auto-config", &is_autoconfig) == 0) {
         is_autoconfig = 0;
     }
@@ -800,7 +816,11 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
         SC_ATOMIC_ADD(stream_count, 1);
         if (SC_ATOMIC_GET(stream_count) == NapatechGetNumConfiguredStreams()) {
 
-#ifdef NAPATECH_ENABLE_BYPASS
+            if (ConfGetBool("napatech.inline", &is_inline) == 0) {
+                is_inline = 0;
+            }
+
+            #ifdef NAPATECH_ENABLE_BYPASS
             /* Initialize the port map before we setup traffic filters */
             for (int i = 0; i < MAX_PORTS; ++i) {
                 inline_port_map[i] = -1;
@@ -874,15 +894,16 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
         }
 
         Packet *p = PacketGetFromQueueOrAlloc();
-#ifdef NAPATECH_ENABLE_BYPASS
-        p->ntpv.bypass = 0;
-#endif
-
         if (unlikely(p == NULL)) {
             NT_NetRxRelease(ntv->rx_stream, packet_buffer);
             SCReturnInt(TM_ECODE_FAILED);
         }
 
+#ifdef NAPATECH_ENABLE_BYPASS
+        p->ntpv.bypass = 0;
+#endif
+
+        p->ntpv.rx_stream = ntv->rx_stream;
         pkt_ts = NT_NET_GET_PKT_TIMESTAMP(packet_buffer);
 
         /*
@@ -893,7 +914,7 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
         switch (NT_NET_GET_PKT_TIMESTAMP_TYPE(packet_buffer)) {
             case NT_TIMESTAMP_TYPE_NATIVE_UNIX:
                 p->ts.tv_sec = pkt_ts / 100000000;
-                p->ts.tv_usec = ((pkt_ts % 100000000) / 100) + (pkt_ts % 100) > 50 ? 1 : 0;
+                p->ts.tv_usec = ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0);
                 break;
             case NT_TIMESTAMP_TYPE_PCAP:
                 p->ts.tv_sec = pkt_ts >> 32;
@@ -901,12 +922,12 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
                 break;
             case NT_TIMESTAMP_TYPE_PCAP_NANOTIME:
                 p->ts.tv_sec = pkt_ts >> 32;
-                p->ts.tv_usec = ((pkt_ts & 0xFFFFFFFF) / 1000) + (pkt_ts % 1000) > 500 ? 1 : 0;
+                p->ts.tv_usec = ((pkt_ts & 0xFFFFFFFF) / 1000) + ((pkt_ts % 1000) > 500 ? 1 : 0);
                 break;
             case NT_TIMESTAMP_TYPE_NATIVE_NDIS:
                 /* number of seconds between 1/1/1601 and 1/1/1970 */
                 p->ts.tv_sec = (pkt_ts / 100000000) - 11644473600;
-                p->ts.tv_usec = ((pkt_ts % 100000000) / 100) + (pkt_ts % 100) > 50 ? 1 : 0;
+                p->ts.tv_usec = ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0);
                 break;
             default:
                 SCLogError(SC_ERR_NAPATECH_TIMESTAMP_TYPE_NOT_SUPPORTED,
@@ -953,22 +974,11 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
             SCReturnInt(TM_ECODE_FAILED);
         }
 
-        /* Release any packets that were returned by the callback function */
-        Packet *rel_pkt = PacketDequeue(&packets_to_release[ntv->stream_id]);
-        while (rel_pkt != NULL) {
-#ifdef NAPATECH_ENABLE_BYPASS
-            if (rel_pkt->ntpv.bypass == 1) {
-                if (PACKET_TEST_ACTION(p, ACTION_DROP)) {
-                    if (is_inline) {
-                        rel_pkt->ntpv.dyn3->wireLength = 0;
-                    }
-                }
-                ProgramFlow(rel_pkt, is_inline);
-            }
-#endif
-            NT_NetRxRelease(ntv->rx_stream, rel_pkt->ntpv.nt_packet_buf);
-            rel_pkt = PacketDequeue(&packets_to_release[ntv->stream_id]);
-        }
+        /*
+         * At this point the packet and the Napatech Packet Buffer have been returned
+         * to the system in the NapatechReleasePacket() Callback.
+         */
+
         StatsSyncCountersIfSignalled(tv);
     } // while
 

--- a/src/util-napatech.h
+++ b/src/util-napatech.h
@@ -30,6 +30,7 @@ typedef struct NapatechPacketVars_
 {
     uint64_t stream_id;
     NtNetBuf_t nt_packet_buf;
+    NtNetStreamRx_t rx_stream;
     ThreadVars *tv;
 #ifdef NAPATECH_ENABLE_BYPASS
     NtDyn3Descr_t *dyn3;


### PR DESCRIPTION
The end-of-processing has been restructured so that Packet and Hostbuffer
data structures are now released within the NapatechReleasePacket() callback
function.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- The main packet processing loop has been restructured to simplify the release of packet and hostbuffer resources.  This was originally implemented using a queue structure between the Release Callback and the main processing loop to insure that the Napatech host buffer was released in the same processing thread on which the buffer was allocated.  However, since this code always runs in worker mode, the callback is in the same thread as the main loop and it is safe to release the hostbuffer in the callback.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

