### PR TITLE
Restructure Packet/Hostbuffer release

### DIFF
--- a/src/util-napatech.h
+++ b/src/util-napatech.h
@@ -30,6 +30,7 @@ typedef struct NapatechPacketVars_
 {
     uint64_t stream_id;
     NtNetBuf_t nt_packet_buf;
+    NtNetStreamRx_t rx_stream;
     ThreadVars *tv;
 #ifdef NAPATECH_ENABLE_BYPASS
     NtDyn3Descr_t *dyn3;


### PR DESCRIPTION
The end-of-processing has been restructured so that Packet and Hostbuffer
data structures are now released within the NapatechReleasePacket() callback
function.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- The main packet processing loop has been restructured to simplify the release of packet and hostbuffer resources.  This was originally implemented using a queue structure between the Release Callback and the main processing loop to insure that the Napatech host buffer was released in the same processing thread on which the buffer was allocated.  However, since this code always runs in worker mode, the callback is already in the same thread as the main loop and it is safe to release the hostbuffer in the callback.  This is much cleaner.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

