### PR TITLE
Backports/50x/v3

### DIFF
--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -59,7 +59,7 @@ http.response_line             Sticky Buffer            Response
 http.header                    Sticky Buffer            Both
 http.header.raw                Sticky Buffer            Both
 http.cookie                    Sticky Buffer            Both
-http.server_body               Sticky Buffer            Response
+http.response_body             Sticky Buffer            Response
 http.server                    Sticky Buffer            Response
 http.location                  Sticky Buffer            Response
 file_data                      Sticky Buffer            Response

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -238,8 +238,11 @@ OutputInitResult AlertFastLogInitCtx(ConfNode *conf)
     }
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
-    if (unlikely(output_ctx == NULL))
+    if (unlikely(output_ctx == NULL)) {
+        LogFileFreeCtx(logfile_ctx);
         return result;
+    }
+
     output_ctx->data = logfile_ctx;
     output_ctx->DeInit = AlertFastLogDeInitCtx;
 

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -204,6 +204,17 @@ static void THashDataFree(THashTableContext *ctx, THashData *h)
 #define GET_VAR(prefix,name) \
     snprintf(varname, sizeof(varname), "%s.%s", (prefix), (name))
 
+static void THashConfigValidate(const char *confvalue, const char *varname)
+{
+    for (size_t i = 0; i < strlen(confvalue); i++) {
+        if (!isdigit(confvalue[i])) {
+            FatalError(SC_ERR_SIZE_PARSE, "Error parsing %s "
+                    "from key %s. Killing Engine",
+                    confvalue, varname);
+        }
+    }
+}
+
 /** \brief initialize the configuration
  *  \warning Not thread safe */
 static void THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
@@ -230,6 +241,9 @@ static void THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
     GET_VAR(cnf_prefix, "hash-size");
     if ((ConfGet(varname, &conf_val)) == 1)
     {
+        /* validate hash-size value is a numerical value */
+        THashConfigValidate(conf_val, varname);
+
         if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             ctx->config.hash_size = configval;
@@ -239,6 +253,9 @@ static void THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
     GET_VAR(cnf_prefix, "prealloc");
     if ((ConfGet(varname, &conf_val)) == 1)
     {
+        /* validate prealloc value is a numerical value */
+        THashConfigValidate(conf_val, varname);
+
         if (ByteExtractStringUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             ctx->config.prealloc = configval;


### PR DESCRIPTION
#4316 with minor fixes
#4871 (backport)
fix for unlikely fastlog setup failure memleak

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed
