### PR TITLE
source: Fix parameters to TmThreadsCaptureHandleTimeout

### DIFF
--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -349,7 +349,7 @@ ReceiveErfDagLoop(ThreadVars *tv, void *data, void *slot)
         if (top == NULL) {
             if (errno == EAGAIN) {
                 if (dtv->dagstream & 0x1) {
-                    TmThreadsCaptureHandleTimeout(tv, dtv->slot, NULL);
+                    TmThreadsCaptureHandleTimeout(tv, NULL);
                     usleep(10 * 1000);
                     dtv->btm = dtv->top;
                 }

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -886,7 +886,7 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
         if (unlikely(
                 status == NT_STATUS_TIMEOUT || status == NT_STATUS_TRYAGAIN)) {
             if (status == NT_STATUS_TIMEOUT) {
-                TmThreadsCaptureHandleTimeout(tv, ntv->slot, NULL);
+                TmThreadsCaptureHandleTimeout(tv, NULL);
             }
             continue;
         } else if (unlikely(status != NT_SUCCESS)) {


### PR DESCRIPTION
This PR fixes the issue introduced in #4870 where the parameters passed to `TmThreadsCaptureHandleTimeout` were incorrect.

Describe changes:
- Correct parameters passed to `TmThreadsCaptureHandleTimeout` for DAG and Napatech.

