### PR TITLE
signature: adds file flag for file_data keyword

### DIFF
--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -189,6 +189,7 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     if (DetectBufferSetActiveList(s, DetectBufferTypeGetByName("file_data")) < 0)
         return -1;
 
+    s->file_flags |= FILE_SIG_NEED_FILE;
     SetupDetectEngineConfig(de_ctx);
     return 0;
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3683

Describe changes:
- adds file flag for `file_data` keyword

So that SigValidate can check if a protocol not supporting files was set after this keyword
with `if ((s->flags & SIG_FLAG_FILESTORE) || s->file_flags != 0) {`

There is no specific use of `FILE_SIG_NEED_FILE`


