### PR TITLE
detect/transform: Transform options and pcrexform (new transform)

### DIFF
--- a/doc/userguide/rules/transforms.rst
+++ b/doc/userguide/rules/transforms.rst
@@ -1,7 +1,8 @@
 Transformations
 ===============
 
-Transformation keywords turn the data at a sticky buffer into something else.
+Transformation keywords turn the data at a sticky buffer into something else. Some transformations
+support options for greater control over the transformation process
 
 Example::
 
@@ -12,7 +13,7 @@ This example will match on traffic even if there are one or more spaces between
 the ``navigate`` and ``(``.
 
 The transforms can be chained. They are processed in the order in which they
-appear in a rule. Each transforms output acts as input for the next one.
+appear in a rule. Each transform's output acts as input for the next one.
 
 Example::
 
@@ -105,4 +106,18 @@ Example::
         content:"|54A9 7A8A B09C 1B81 3725 2214 51D3 F997 F015 9DD7 049E E5AD CED3 945A FC79 7401|"; sid:1;)
 
 .. note:: depends on libnss being compiled into Suricata
+
+pcrexform
+---------
+
+Takes the buffer, applies the required regular expression, and outputs the *first captured expression*.
+
+.. note:: this transform requires a mandatory option string containing a regular expression.
+
+
+This example alerts if ``http.request_line`` contains ``/dropper.php``
+Example::
+
+    alert http any any -> any any (msg:"HTTP with pcrexform"; http.request_line; \
+        pcrexform:"[a-zA-Z]+\s+(.*)\s+HTTP"; content:"/dropper.php"; sid:1;)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -291,6 +291,7 @@ detect-transform-md5.c detect-transform-md5.h \
 detect-transform-sha1.c detect-transform-sha1.h \
 detect-transform-sha256.c detect-transform-sha256.h \
 detect-transform-dotprefix.c detect-transform-dotprefix.h \
+detect-transform-pcrexform.c detect-transform-pcrexform.h \
 detect-ttl.c detect-ttl.h \
 detect-uricontent.c detect-uricontent.h \
 detect-urilen.c detect-urilen.h \

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -173,7 +173,7 @@ void DetectAppLayerMpmRegisterByParentId(DetectEngineCtx *de_ctx,
                 for (int i = 0; i < transforms->cnt; i++) {
                     char ttstr[64];
                     (void)snprintf(ttstr,sizeof(ttstr), "%s,",
-                            sigmatch_table[transforms->transforms[i]].name);
+                            sigmatch_table[transforms->transforms[i].transform].name);
                     strlcat(xforms, ttstr, sizeof(xforms));
                 }
                 xforms[strlen(xforms)-1] = '\0';

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -207,6 +207,7 @@
 #include "detect-transform-sha1.h"
 #include "detect-transform-sha256.h"
 #include "detect-transform-dotprefix.h"
+#include "detect-transform-pcrexform.h"
 
 #include "util-rule-vars.h"
 
@@ -582,6 +583,7 @@ void SigTableSetup(void)
     DetectTransformSha1Register();
     DetectTransformSha256Register();
     DetectTransformDotPrefixRegister();
+    DetectTransformPcrexformRegister();
 
     /* close keyword registration */
     DetectBufferTypeCloseRegistration();

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -263,6 +263,7 @@ enum DetectKeywordId {
     DETECT_TRANSFORM_SHA1,
     DETECT_TRANSFORM_SHA256,
     DETECT_TRANSFORM_DOTPREFIX,
+    DETECT_TRANSFORM_PCREXFORM,
 
     /* make sure this stays last */
     DETECT_TBLSIZE,

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -55,7 +55,7 @@ void DetectBufferTypeRegisterValidateCallback(const char *name,
         bool (*ValidateCallback)(const Signature *, const char **sigerror));
 
 int DetectBufferTypeGetByIdTransforms(DetectEngineCtx *de_ctx, const int id,
-        int *transforms, int transform_cnt);
+        TransformData *transforms, int transform_cnt);
 const char *DetectBufferTypeGetNameById(const DetectEngineCtx *de_ctx, const int id);
 bool DetectBufferTypeSupportsMpmGetById(const DetectEngineCtx *de_ctx, const int id);
 bool DetectBufferTypeSupportsPacketGetById(const DetectEngineCtx *de_ctx, const int id);

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -84,7 +84,7 @@ static void SigMatchTransferSigMatchAcrossLists(SigMatch *sm,
 typedef struct SigDuplWrapper_ {
     /* the signature we want to wrap */
     Signature *s;
-    /* the signature right before the above signatue in the det_ctx->sig_list */
+    /* the signature right before the above signature in the det_ctx->sig_list */
     Signature *s_prev;
 } SigDuplWrapper;
 
@@ -1066,7 +1066,7 @@ static inline int SigParseToken(char **input, char *output,
  * Parses rule tokens that may be lists such as addresses and ports
  * handling the case when they may not be lists.
  *
- * \param input ouble pointer to input buffer, will be advanced as input is
+ * \param input double pointer to input buffer, will be advanced as input is
  *     parsed.
  * \param output buffer to copy token into.
  * \param output_size length of output buffer.
@@ -1292,7 +1292,7 @@ Signature *SigAlloc (void)
 
 /**
  * \internal
- * \brief Free Medadata list
+ * \brief Free Metadata list
  *
  * \param s Pointer to the signature
  */
@@ -1591,7 +1591,7 @@ static int SigMatchListLen(SigMatch *sm)
 }
 
 /** \brief convert SigMatch list to SigMatchData array
- *  \note ownership of sm->ctx is transfered to smd->ctx
+ *  \note ownership of sm->ctx is transferred to smd->ctx
  */
 SigMatchData* SigMatchList2DataArray(SigMatch *head)
 {
@@ -2300,7 +2300,7 @@ end:
  *        If the signature is bidirectional it should append two signatures
  *        (with the addresses switched) into the list.  Also handle duplicate
  *        signatures.  In case of duplicate sigs, use the ones that have the
- *        latest revision.  We use the sid and the msg to identifiy duplicate
+ *        latest revision.  We use the sid and the msg to identify duplicate
  *        sigs.  If 2 sigs have the same sid and gid, they are duplicates.
  *
  * \param de_ctx Pointer to the Detection Engine Context.
@@ -4071,7 +4071,7 @@ static int SigParseBidirWithSameSrcAndDest02(void)
 
     SigFree(de_ctx, s);
 
-    // Source is a subset of destinationn
+    // Source is a subset of destination
     s = SigInit(de_ctx,
             "alert tcp [1.2.3.4, ::1] [80, 81, 82] <> [1.2.3.4, ::1] [80, 81] (sid:1; rev:1;)");
     FAIL_IF_NULL(s);

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -83,7 +83,7 @@ SigMatch *DetectGetLastSMFromLists(const Signature *s, ...);
 SigMatch *DetectGetLastSMByListPtr(const Signature *s, SigMatch *sm_list, ...);
 SigMatch *DetectGetLastSMByListId(const Signature *s, int list_id, ...);
 
-int DetectSignatureAddTransform(Signature *s, int transform);
+int DetectSignatureAddTransform(Signature *s, int transform, void *options);
 int WARN_UNUSED DetectSignatureSetAppProto(Signature *s, AppProto alproto);
 
 /* parse regex setup and free util funcs */

--- a/src/detect-pkt-data.c
+++ b/src/detect-pkt-data.c
@@ -71,7 +71,7 @@ void DetectPktDataRegister(void)
 static int DetectPktDataSetup (DetectEngineCtx *de_ctx, Signature *s, const char *unused)
 {
     SCEnter();
-    if (s->init_data->transform_cnt) {
+    if (s->init_data->transforms.cnt) {
         SCLogError(SC_ERR_INVALID_SIGNATURE,
                 "previous transforms not consumed before 'pkt_data'");
         SCReturnInt(-1);

--- a/src/detect-transform-compress-whitespace.c
+++ b/src/detect-transform-compress-whitespace.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-transform-compress-whitespace.c
+++ b/src/detect-transform-compress-whitespace.c
@@ -37,7 +37,7 @@
 static int DetectTransformCompressWhitespaceSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectTransformCompressWhitespaceRegisterTests(void);
 
-static void TransformCompressWhitespace(InspectionBuffer *buffer);
+static void TransformCompressWhitespace(InspectionBuffer *buffer, void *options);
 
 void DetectTransformCompressWhitespaceRegister(void)
 {
@@ -69,11 +69,11 @@ void DetectTransformCompressWhitespaceRegister(void)
 static int DetectTransformCompressWhitespaceSetup (DetectEngineCtx *de_ctx, Signature *s, const char *nullstr)
 {
     SCEnter();
-    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_COMPRESS_WHITESPACE);
+    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_COMPRESS_WHITESPACE, NULL);
     SCReturnInt(r);
 }
 
-static void TransformCompressWhitespace(InspectionBuffer *buffer)
+static void TransformCompressWhitespace(InspectionBuffer *buffer, void *options)
 {
     const uint8_t *input = buffer->inspect;
     const uint32_t input_len = buffer->inspect_len;
@@ -133,7 +133,7 @@ static int DetectTransformCompressWhitespaceTest01(void)
     InspectionBufferInit(&buffer, 8);
     InspectionBufferSetup(&buffer, input, input_len);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformCompressWhitespace(&buffer);
+    TransformCompressWhitespace(&buffer, NULL);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
     InspectionBufferFree(&buffer);
     PASS;
@@ -152,7 +152,7 @@ static int DetectTransformCompressWhitespaceTest02(void)
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
     TransformDoubleWhitespace(&buffer);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformCompressWhitespace(&buffer);
+    TransformCompressWhitespace(&buffer, NULL);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
     InspectionBufferFree(&buffer);
     PASS;

--- a/src/detect-transform-compress-whitespace.c
+++ b/src/detect-transform-compress-whitespace.c
@@ -20,7 +20,7 @@
  *
  * \author Victor Julien <victor@inliniac.net>
  *
- * Implements the compress_whitespace tranform keyword
+ * Implements the compress_whitespace transform keyword
  */
 
 #include "suricata-common.h"

--- a/src/detect-transform-dotprefix.c
+++ b/src/detect-transform-dotprefix.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Open Information Security Foundation
+/* Copyright (C) 2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-transform-dotprefix.c
+++ b/src/detect-transform-dotprefix.c
@@ -39,7 +39,8 @@
 static int DetectTransformDotPrefixSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectTransformDotPrefixRegisterTests(void);
 
-static void TransformDotPrefix(InspectionBuffer *buffer);
+static void TransformDotPrefix(InspectionBuffer *buffer, void *options);
+static void DetectTransformDotPrefixFree(void *);
 
 void DetectTransformDotPrefixRegister(void)
 {
@@ -68,7 +69,7 @@ void DetectTransformDotPrefixRegister(void)
 static int DetectTransformDotPrefixSetup (DetectEngineCtx *de_ctx, Signature *s, const char *nullstr)
 {
     SCEnter();
-    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_DOTPREFIX);
+    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_DOTPREFIX, NULL);
     SCReturnInt(r);
 }
 
@@ -102,7 +103,7 @@ static int DetectTransformDotPrefixSetup (DetectEngineCtx *de_ctx, Signature *s,
  * 4. something.google.co.uk --> match
  * 5. google.com --> no match
  */
-static void TransformDotPrefix(InspectionBuffer *buffer)
+static void TransformDotPrefix(InspectionBuffer *buffer, void *options)
 {
     const size_t input_len = buffer->inspect_len;
 
@@ -128,7 +129,7 @@ static int DetectTransformDotPrefixTest01(void)
     InspectionBufferInit(&buffer, input_len);
     InspectionBufferSetup(&buffer, input, input_len);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformDotPrefix(&buffer);
+    TransformDotPrefix(&buffer, NULL);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
     FAIL_IF_NOT(buffer.inspect_len == result_len);
     FAIL_IF_NOT(strncmp(result, (const char *)buffer.inspect, result_len) == 0);
@@ -148,7 +149,7 @@ static int DetectTransformDotPrefixTest02(void)
     InspectionBufferInit(&buffer, input_len);
     InspectionBufferSetup(&buffer, input, input_len);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformDotPrefix(&buffer);
+    TransformDotPrefix(&buffer, NULL);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
     FAIL_IF_NOT(buffer.inspect_len == result_len);
     FAIL_IF_NOT(strncmp(result, (const char *)buffer.inspect, result_len) == 0);

--- a/src/detect-transform-md5.c
+++ b/src/detect-transform-md5.c
@@ -37,7 +37,7 @@
 static int DetectTransformToMd5Setup (DetectEngineCtx *, Signature *, const char *);
 #ifdef HAVE_NSS
 static void DetectTransformToMd5RegisterTests(void);
-static void TransformToMd5(InspectionBuffer *buffer);
+static void TransformToMd5(InspectionBuffer *buffer, void *options);
 #endif
 
 void DetectTransformMd5Register(void)
@@ -78,11 +78,11 @@ static int DetectTransformToMd5Setup (DetectEngineCtx *de_ctx, Signature *s, con
 static int DetectTransformToMd5Setup (DetectEngineCtx *de_ctx, Signature *s, const char *nullstr)
 {
     SCEnter();
-    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_MD5);
+    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_MD5, NULL);
     SCReturnInt(r);
 }
 
-static void TransformToMd5(InspectionBuffer *buffer)
+static void TransformToMd5(InspectionBuffer *buffer, void *options)
 {
     const uint8_t *input = buffer->inspect;
     const uint32_t input_len = buffer->inspect_len;
@@ -112,7 +112,7 @@ static int DetectTransformToMd5Test01(void)
     InspectionBufferInit(&buffer, 8);
     InspectionBufferSetup(&buffer, input, input_len);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformToMd5(&buffer);
+    TransformToMd5(&buffer, NULL);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
     InspectionBufferFree(&buffer);
     PASS;

--- a/src/detect-transform-md5.c
+++ b/src/detect-transform-md5.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2018 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-transform-pcrexform.c
+++ b/src/detect-transform-pcrexform.c
@@ -1,0 +1,110 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ *
+ * Implements the pcrexform transform keyword with option support
+ */
+
+#include "suricata-common.h"
+
+#include "detect.h"
+#include "detect-engine.h"
+#include "detect-parse.h"
+#include "detect-transform-pcrexform.h"
+
+typedef DetectParseRegex DetectTransformPcrexformData;
+
+static int DetectTransformPcrexformSetup (DetectEngineCtx *, Signature *, const char *);
+static void DetectTransformPcrexformFree(DetectEngineCtx *, void *);
+static void DetectTransformPcrexform(InspectionBuffer *buffer, void *options);
+
+void DetectTransformPcrexformRegister(void)
+{
+    sigmatch_table[DETECT_TRANSFORM_PCREXFORM].name = "pcrexform";
+    sigmatch_table[DETECT_TRANSFORM_PCREXFORM].desc =
+        "modify buffer via PCRE before inspection";
+    sigmatch_table[DETECT_TRANSFORM_PCREXFORM].url = "/rules/transforms.html#pcre-xform";
+    sigmatch_table[DETECT_TRANSFORM_PCREXFORM].Transform =
+        DetectTransformPcrexform;
+    sigmatch_table[DETECT_TRANSFORM_PCREXFORM].Free =
+        DetectTransformPcrexformFree;
+    sigmatch_table[DETECT_TRANSFORM_PCREXFORM].Setup =
+        DetectTransformPcrexformSetup;
+    sigmatch_table[DETECT_TRANSFORM_PCREXFORM].flags |= SIGMATCH_QUOTES_MANDATORY;
+}
+
+static void DetectTransformPcrexformFree(DetectEngineCtx *de_ctx, void *ptr)
+{
+    if (ptr != NULL) {
+        DetectTransformPcrexformData *pxd = (DetectTransformPcrexformData *) ptr;
+        SCFree(pxd);
+    }
+}
+/**
+ *  \internal
+ *  \brief Apply the pcrexform keyword to the last pattern match
+ *  \param det_ctx detection engine ctx
+ *  \param s signature
+ *  \param regexstr options string
+ *  \retval 0 ok
+ *  \retval -1 failure
+ */
+static int DetectTransformPcrexformSetup (DetectEngineCtx *de_ctx, Signature *s, const char *regexstr)
+{
+    SCEnter();
+
+    // Create pxd from regexstr
+    DetectTransformPcrexformData *pxd = SCCalloc(sizeof(*pxd), 1);
+    if (pxd == NULL) {
+        SCLogDebug("pxd allocation failed");
+        SCReturnInt(-1);
+    }
+
+    DetectSetupParseRegexes(regexstr, pxd);
+
+    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_PCREXFORM, pxd);
+    if (r != 0) {
+        SCFree(pxd);
+    }
+
+    SCReturnInt(r);
+}
+
+static void DetectTransformPcrexform(InspectionBuffer *buffer, void *options)
+{
+    const char *input = (const char *)buffer->inspect;
+    const uint32_t input_len = buffer->inspect_len;
+    DetectTransformPcrexformData *pxd = options;
+
+    int ov[MAX_SUBSTRINGS];
+    int ret = DetectParsePcreExecLen(pxd, input, input_len, 0, 0, ov, MAX_SUBSTRINGS);
+
+    if (ret > 0) {
+        const char *str;
+        ret = pcre_get_substring((char *) buffer->inspect, ov,
+                                  MAX_SUBSTRINGS, ret - 1, &str);
+
+        if (ret >= 0) {
+            InspectionBufferCopy(buffer, (uint8_t *)str, (uint32_t) ret);
+            pcre_free_substring(str);
+        }
+    }
+}

--- a/src/detect-transform-pcrexform.h
+++ b/src/detect-transform-pcrexform.h
@@ -1,0 +1,30 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org
+ */
+
+#ifndef __DETECT_TRANSFORM_PCREXFORM_H__
+#define __DETECT_TRANSFORM_PCREXFORM_H__
+
+/* prototypes */
+void DetectTransformPcrexformRegister (void);
+
+#endif /* __DETECT_TRANSFORM_PCREXFORM_H__ */

--- a/src/detect-transform-sha1.c
+++ b/src/detect-transform-sha1.c
@@ -37,7 +37,7 @@
 static int DetectTransformToSha1Setup (DetectEngineCtx *, Signature *, const char *);
 #ifdef HAVE_NSS
 static void DetectTransformToSha1RegisterTests(void);
-static void TransformToSha1(InspectionBuffer *buffer);
+static void TransformToSha1(InspectionBuffer *buffer, void *options);
 #endif
 
 void DetectTransformSha1Register(void)
@@ -78,11 +78,11 @@ static int DetectTransformToSha1Setup (DetectEngineCtx *de_ctx, Signature *s, co
 static int DetectTransformToSha1Setup (DetectEngineCtx *de_ctx, Signature *s, const char *nullstr)
 {
     SCEnter();
-    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_SHA1);
+    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_SHA1, NULL);
     SCReturnInt(r);
 }
 
-static void TransformToSha1(InspectionBuffer *buffer)
+static void TransformToSha1(InspectionBuffer *buffer, void *options)
 {
     const uint8_t *input = buffer->inspect;
     const uint32_t input_len = buffer->inspect_len;
@@ -112,7 +112,7 @@ static int DetectTransformToSha1Test01(void)
     InspectionBufferInit(&buffer, 8);
     InspectionBufferSetup(&buffer, input, input_len);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformToSha1(&buffer);
+    TransformToSha1(&buffer, NULL);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
     InspectionBufferFree(&buffer);
     PASS;

--- a/src/detect-transform-sha1.c
+++ b/src/detect-transform-sha1.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2018 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-transform-sha256.c
+++ b/src/detect-transform-sha256.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-transform-sha256.c
+++ b/src/detect-transform-sha256.c
@@ -37,7 +37,7 @@
 static int DetectTransformToSha256Setup (DetectEngineCtx *, Signature *, const char *);
 #ifdef HAVE_NSS
 static void DetectTransformToSha256RegisterTests(void);
-static void TransformToSha256(InspectionBuffer *buffer);
+static void TransformToSha256(InspectionBuffer *buffer, void *options);
 #endif
 
 void DetectTransformSha256Register(void)
@@ -78,11 +78,11 @@ static int DetectTransformToSha256Setup (DetectEngineCtx *de_ctx, Signature *s, 
 static int DetectTransformToSha256Setup (DetectEngineCtx *de_ctx, Signature *s, const char *nullstr)
 {
     SCEnter();
-    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_SHA256);
+    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_SHA256, NULL);
     SCReturnInt(r);
 }
 
-static void TransformToSha256(InspectionBuffer *buffer)
+static void TransformToSha256(InspectionBuffer *buffer, void *options)
 {
     const uint8_t *input = buffer->inspect;
     const uint32_t input_len = buffer->inspect_len;
@@ -112,7 +112,7 @@ static int DetectTransformToSha256Test01(void)
     InspectionBufferInit(&buffer, 8);
     InspectionBufferSetup(&buffer, input, input_len);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformToSha256(&buffer);
+    TransformToSha256(&buffer, NULL);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
     InspectionBufferFree(&buffer);
     PASS;

--- a/src/detect-transform-strip-whitespace.c
+++ b/src/detect-transform-strip-whitespace.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-transform-strip-whitespace.c
+++ b/src/detect-transform-strip-whitespace.c
@@ -37,7 +37,7 @@
 static int DetectTransformStripWhitespaceSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectTransformStripWhitespaceRegisterTests(void);
 
-static void TransformStripWhitespace(InspectionBuffer *buffer);
+static void TransformStripWhitespace(InspectionBuffer *buffer, void *options);
 
 void DetectTransformStripWhitespaceRegister(void)
 {
@@ -68,11 +68,11 @@ void DetectTransformStripWhitespaceRegister(void)
 static int DetectTransformStripWhitespaceSetup (DetectEngineCtx *de_ctx, Signature *s, const char *nullstr)
 {
     SCEnter();
-    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_STRIP_WHITESPACE);
+    int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_STRIP_WHITESPACE, NULL);
     SCReturnInt(r);
 }
 
-static void TransformStripWhitespace(InspectionBuffer *buffer)
+static void TransformStripWhitespace(InspectionBuffer *buffer, void *options)
 {
     const uint8_t *input = buffer->inspect;
     const uint32_t input_len = buffer->inspect_len;
@@ -124,7 +124,7 @@ static int DetectTransformStripWhitespaceTest01(void)
     InspectionBufferInit(&buffer, 8);
     InspectionBufferSetup(&buffer, input, input_len);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformStripWhitespace(&buffer);
+    TransformStripWhitespace(&buffer, NULL);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
     InspectionBufferFree(&buffer);
     PASS;
@@ -143,7 +143,7 @@ static int DetectTransformStripWhitespaceTest02(void)
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
     TransformDoubleWhitespace(&buffer);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformStripWhitespace(&buffer);
+    TransformStripWhitespace(&buffer, NULL);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
     InspectionBufferFree(&buffer);
     PASS;

--- a/src/detect.h
+++ b/src/detect.h
@@ -366,8 +366,13 @@ typedef struct InspectionBufferMultipleForList {
     uint32_t init:1;    /**< first time used this run. Used for clean logic */
 } InspectionBufferMultipleForList;
 
+typedef struct TransformData_ {
+    int transform;
+    void *options;
+} TransformData;
+
 typedef struct DetectEngineTransforms {
-    int transforms[DETECT_TRANSFORMS_MAX];
+    TransformData transforms[DETECT_TRANSFORMS_MAX];
     int cnt;
 } DetectEngineTransforms;
 
@@ -498,8 +503,7 @@ typedef struct SignatureInitData_ {
     int list;
     bool list_set;
 
-    int transforms[DETECT_TRANSFORMS_MAX];
-    int transform_cnt;
+    DetectEngineTransforms transforms;
 
     /** score to influence rule grouping. A higher value leads to a higher
      *  likelihood of a rulegroup with this sig ending up as a contained
@@ -1181,7 +1185,7 @@ typedef struct SigTableElmt_ {
         uint8_t flags, File *, const Signature *, const SigMatchCtx *);
 
     /** InspectionBuffer transformation callback */
-    void (*Transform)(InspectionBuffer *);
+    void (*Transform)(InspectionBuffer *, void *context);
 
     /** keyword setup function pointer */
     int (*Setup)(DetectEngineCtx *, Signature *, const char *);


### PR DESCRIPTION
Note: this PR is based on #4647; when that PR is merged, this work will be rebased on `master`.

This PR is a continuation of #4651

This PR adds  transform `pcrexform` -- a new transform supporting transform options introduced in (#4647). Transform options are supported _when the transform implementation supports them_. This means that the transform infrastructure will provide the transform-specific options container to the transform evaluation logic. When no longer needed, the infrastructure will invoke the transform's `Free` function to release the options container.

`pcrexform` applies a (mandatory) RE to the transformation buffer and emits the first capture, if any, into the transformation buffer. If there is not a match, the transformation buffer is unmodified.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
- [3199](https://redmine.openinfosecfoundation.org/issues/3199)
- [3200](https://redmine.openinfosecfoundation.org/issues/3200)

Describe changes:
- Rebase
Companion [Suricata-verify PR #196](https://github.com/OISF/suricata-verify/pull/196)