### PR TITLE
doc: Improve tos description

### DIFF
--- a/doc/userguide/rules/header-keywords.rst
+++ b/doc/userguide/rules/header-keywords.rst
@@ -259,6 +259,13 @@ field. The tos keyword can be have a value from 0 - 255. This field of the
 IP header has been updated by `rfc2474 <https://tools.ietf.org/html/rfc2474>`_
 to include functionality for
 `Differentiated services <https://en.wikipedia.org/wiki/Differentiated_services>`_.
+Note that the value of the field has been defined with the right-most 2 bits having
+the value 0. When specifying a value for tos, ensure that the value follows this.
+
+E.g, instead of specifying the decimal value 34 (hex 22), right shift twice and use
+decimal 136 (hex 88).
+
+You can specify hexadecimal values as with a leading `x`, e.g, `x88`.
 
 Format of tos::
 


### PR DESCRIPTION
This commit improves the description of the `tos` keyword by emphasizing
that the value used should adhere to the guidelines in RFC2474. Instead
of specifying the DSCP value directly, right shift the DSCP value and
use that.


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3638](https://redmine.openinfosecfoundation.org/issues/3638)

Describe changes:
- Emphasize how to specify DSCP values and ensure RFC is adhered to.
