### PR TITLE
detect/file_data: Apply transforms

### DIFF
--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2018 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -304,6 +304,7 @@ static InspectionBuffer *HttpServerBodyGetDataCallback(DetectEngineThreadCtx *de
             &data, &data_len, offset);
     InspectionBufferSetup(buffer, data, data_len);
     buffer->inspect_offset = offset;
+    InspectionBufferApplyTransforms(buffer, transforms);
 
     /* built-in 'transformation' */
     if (htp_state->cfg->swf_decompression_enabled) {

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -248,7 +248,7 @@ static InspectionBuffer *HttpServerBodyGetDataCallback(DetectEngineThreadCtx *de
 
     HtpBodyChunk *cur = body->first;
     if (cur == NULL) {
-        SCLogDebug("No http chunks to inspect for this transacation");
+        SCLogDebug("No http chunks to inspect for this transaction");
         return NULL;
     }
 


### PR DESCRIPTION
This PR ensures that transforms, if any, are applied to HTTP response body data.


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3691](https://redmine.openinfosecfoundation.org/issues/3691)

Describe changes:
- Apply transforms to the inspection buffer for HTTP response body data

Companion [Suricata-verify PR #230](https://github.com/OISF/suricata-verify/pull/230)