### PR TITLE
fuzz: improves sigpcap target

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2282,7 +2282,7 @@ static void PostRunStartedDetectSetup(const SCInstance *suri)
     }
 }
 
-static void PostConfLoadedDetectSetup(SCInstance *suri)
+void PostConfLoadedDetectSetup(SCInstance *suri)
 {
     DetectEngineCtx *de_ctx = NULL;
     if (!suri->disabled_detect) {

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -186,6 +186,7 @@ extern int run_mode;
 int SuricataMain(int argc, char **argv);
 int InitGlobal(void);
 int PostConfLoadedSetup(SCInstance *suri);
+void PostConfLoadedDetectSetup(SCInstance *suri);
 
 void PreRunInit(const int runmode);
 void PreRunPostPrivsDropInit(const int runmode);

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -147,6 +147,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
         InitGlobal();
 
+        GlobalsInitPreConfig();
         run_mode = RUNMODE_PCAP_FILE;
         //redirect logs to /tmp
         ConfigSetLogDirectory("/tmp/");
@@ -159,14 +160,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         //loads rules after init
         suricata.delayed_detect = 1;
 
-        SupportFastPatternForSigMatchTypes();
         PostConfLoadedSetup(&suricata);
         PreRunPostPrivsDropInit(run_mode);
-
-        //dummy init before DetectEngineReload
-        DetectEngineCtx * de_ctx = DetectEngineCtxInit();
-        de_ctx->flags |= DE_QUIET;
-        DetectEngineAddToMaster(de_ctx);
+        PostConfLoadedDetectSetup(&suricata);
 
         memset(&tv, 0, sizeof(tv));
         dtv = DecodeThreadVarsAlloc(&tv);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- improves sigpcap fuzz target so that it can cover alert generation
ie in function DetectRun, get past `scratch.sgh == NULL` condition

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

Modifies #4933 by removing unneeded `#ifdef`