### PR TITLE
Log tenant_id for all eve-json messages

### DIFF
--- a/doc/userguide/configuration/multi-tenant.rst
+++ b/doc/userguide/configuration/multi-tenant.rst
@@ -215,3 +215,10 @@ unregister-tenant-handler <tenant id> vlan <vlan id>
 
 The registration of tenant and tenant handlers can be done on a
 running engine.
+
+Eve JSON output
+---------------
+
+When multi-tenant support is configured and the detect engine is active then
+all EVE-types that report based on flows will also report the corresponding
+``tenant_id`` for events matching a tenant configuration.

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -501,5 +501,12 @@ YAML::
       # Seed value for the ID output. Valid values are 0-65535.
       community-id-seed: 0
 
+Multi Tenancy
+-------------
+
+Suricata can be configured to support multiple tenants with different detection
+engine configurations. When these tenants are configured and the detection
+engine is running then all EVE logging will also report the ``tenant_id`` field
+for traffic matching a specific tenant.
 
 .. _deprecation policy: https://suricata-ids.org/about/deprecation-policy/

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -455,6 +455,9 @@ void EveAddCommonOptions(const OutputJsonCommonSettings *cfg,
     if (cfg->include_community_id && f != NULL) {
         CreateEveCommunityFlowId(js, f, cfg->community_id_seed);
     }
+    if (f != NULL && f->tenant_id > 0) {
+        jb_set_uint(js, "tenant_id", f->tenant_id);
+    }
 }
 
 /**


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [#3701](https://redmine.openinfosecfoundation.org/issues/3701)

Describe changes:
- Log `tenant_id` for all eve-log types

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

(wouldn't work, but our CI had no problems with the patched version, for what that is worth)

Traceback (most recent call last):
  File "qa/prscript.py", line 254, in <module>
    ret = TestGithubSync(args.branch)
  File "qa/prscript.py", line 144, in TestGithubSync
    request = urllib2.Request(GITHUB_BASE_URI + username + "/" + args.repository + "/commits?sha=" + branch + "&per_page=1")
TypeError: cannot concatenate 'str' and 'NoneType' objects
