### PR TITLE
fuzz: do not reuse global variable named suricata

### DIFF
--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -29,7 +29,7 @@ AppLayerParserThreadCtx *alp_tctx = NULL;
  * destination port (uint16_t) */
 
 const uint8_t separator[] = {0x01, 0xD5, 0xCA, 0x7A};
-SCInstance suricata;
+SCInstance surifuzz;
 uint64_t forceLayer = 0;
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
@@ -59,7 +59,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         //redirect logs to /tmp
         ConfigSetLogDirectory("/tmp/");
 
-        PostConfLoadedSetup(&suricata);
+        PostConfLoadedSetup(&surifuzz);
         alp_tctx = AppLayerParserThreadCtxAlloc();
         const char* forceLayerStr = getenv("FUZZ_APPLAYER");
         if (forceLayerStr) {

--- a/src/tests/fuzz/fuzz_decodepcapfile.c
+++ b/src/tests/fuzz/fuzz_decodepcapfile.c
@@ -16,7 +16,7 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 
 static int initialized = 0;
-SCInstance suricata;
+SCInstance surifuzz;
 
 const char configNoChecksum[] = "\
 %YAML 1.1\n\
@@ -48,7 +48,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             abort();
         }
 
-        PostConfLoadedSetup(&suricata);
+        PostConfLoadedSetup(&surifuzz);
 
         RunModeInitialize();
         TimeModeSetOffline();

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -32,7 +32,7 @@ ThreadVars tv;
 DecodeThreadVars *dtv;
 //FlowWorkerThreadData
 void *fwd;
-SCInstance suricata;
+SCInstance surifuzz;
 
 const char configNoChecksum[] = "\
 %YAML 1.1\n\
@@ -154,13 +154,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         if (ConfYamlLoadString(configNoChecksum, strlen(configNoChecksum)) != 0) {
             abort();
         }
-        suricata.sig_file = strdup("/tmp/fuzz.rules");
-        suricata.sig_file_exclusive = 1;
+        surifuzz.sig_file = strdup("/tmp/fuzz.rules");
+        surifuzz.sig_file_exclusive = 1;
         //loads rules after init
-        suricata.delayed_detect = 1;
+        surifuzz.delayed_detect = 1;
 
         SupportFastPatternForSigMatchTypes();
-        PostConfLoadedSetup(&suricata);
+        PostConfLoadedSetup(&surifuzz);
         PreRunPostPrivsDropInit(run_mode);
 
         //dummy init before DetectEngineReload
@@ -201,16 +201,16 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     }
     if (pos > 0 && pos < size) {
         // dump signatures to a file so as to reuse SigLoadSignatures
-        if (TestHelperBufferToFile(suricata.sig_file, data, pos-1) < 0) {
+        if (TestHelperBufferToFile(surifuzz.sig_file, data, pos-1) < 0) {
             return 0;
         }
     } else {
-        if (TestHelperBufferToFile(suricata.sig_file, data, pos) < 0) {
+        if (TestHelperBufferToFile(surifuzz.sig_file, data, pos) < 0) {
             return 0;
         }
     }
 
-    if (DetectEngineReload(&suricata) < 0) {
+    if (DetectEngineReload(&surifuzz) < 0) {
         return 0;
     }
     if (pos < size) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
No redonne but https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=22259

Describe changes:
- Changes global variable name in fuzz targets so as not to reuse `suricata`

Fixes oss-fuzz builds (using a new feature of clang apparently)
