### PR TITLE
Http gap 3359 v1

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1155,9 +1155,9 @@ static int HTTPParseContentTypeHeader(uint8_t *name, size_t name_len,
  *  If the request contains a multipart message, this function will
  *  set the HTP_BOUNDARY_SET in the transaction.
  */
-static int HtpRequestBodySetupMultipart(htp_tx_data_t *d, HtpTxUserData *htud)
+static int HtpRequestBodySetupMultipart(htp_tx_t *tx, HtpTxUserData *htud)
 {
-    htp_header_t *h = (htp_header_t *)htp_table_get_c(d->tx->request_headers,
+    htp_header_t *h = (htp_header_t *)htp_table_get_c(tx->request_headers,
             "Content-Type");
     if (h != NULL && bstr_len(h->value) > 0) {
         uint8_t *boundary = NULL;
@@ -1861,7 +1861,7 @@ static int HTPCallbackRequestBodyData(htp_tx_data_t *d)
 
         if (d->tx->request_method_number == HTP_M_POST) {
             SCLogDebug("POST");
-            int r = HtpRequestBodySetupMultipart(d, tx_ud);
+            int r = HtpRequestBodySetupMultipart(d->tx, tx_ud);
             if (r == 1) {
                 tx_ud->request_body_type = HTP_BODY_REQUEST_MULTIPART;
             } else if (r == 0) {

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1841,7 +1841,7 @@ static int HTPCallbackRequestBodyData(htp_tx_data_t *d)
     if (!(SC_ATOMIC_GET(htp_config_flags) & HTP_REQUIRE_REQUEST_BODY))
         SCReturnInt(HTP_OK);
 
-    if (d->data == NULL || d->len == 0)
+    if (d->len == 0)
         SCReturnInt(HTP_OK);
 
 #ifdef PRINT
@@ -3227,6 +3227,9 @@ void RegisterHTPParsers(void)
         AppLayerParserRegisterParser(IPPROTO_TCP, ALPROTO_HTTP, STREAM_TOCLIENT,
                                      HTPHandleResponseData);
         SC_ATOMIC_INIT(htp_config_flags);
+        /* This parser accepts gaps. */
+        AppLayerParserRegisterOptionFlags(IPPROTO_TCP, ALPROTO_HTTP,
+                                          APP_LAYER_PARSER_OPT_ACCEPT_GAPS);
         AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_TCP,
                 ALPROTO_HTTP, STREAM_TOSERVER|STREAM_TOCLIENT);
         HTPConfigure();

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1629,19 +1629,6 @@ end:
     return 0;
 }
 
-/** \brief setup things for put request
- *  \todo really needed? */
-static int HtpRequestBodySetupPUT(htp_tx_data_t *d, HtpTxUserData *htud)
-{
-//    if (d->tx->parsed_uri == NULL || d->tx->parsed_uri->path == NULL) {
-//        return -1;
-//    }
-
-    /* filename is d->tx->parsed_uri->path */
-
-    return 0;
-}
-
 /** \internal
  *  \brief Handle POST, no multipart body data
  */
@@ -1882,9 +1869,7 @@ static int HTPCallbackRequestBodyData(htp_tx_data_t *d)
                 SCLogDebug("not multipart");
             }
         } else if (d->tx->request_method_number == HTP_M_PUT) {
-            if (HtpRequestBodySetupPUT(d, tx_ud) == 0) {
-                tx_ud->request_body_type = HTP_BODY_REQUEST_PUT;
-            }
+            tx_ud->request_body_type = HTP_BODY_REQUEST_PUT;
         }
     }
 

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1630,63 +1630,9 @@ end:
 }
 
 /** \internal
- *  \brief Handle POST, no multipart body data
+ *  \brief Handle POST or PUT, no multipart body data
  */
-static int HtpRequestBodyHandlePOST(HtpState *hstate, HtpTxUserData *htud,
-        htp_tx_t *tx, uint8_t *data, uint32_t data_len)
-{
-    int result = 0;
-
-    /* see if we need to open the file */
-    if (!(htud->tsflags & HTP_FILENAME_SET))
-    {
-        uint8_t *filename = NULL;
-        size_t filename_len = 0;
-
-        /* get the name */
-        if (tx->parsed_uri != NULL && tx->parsed_uri->path != NULL) {
-            filename = (uint8_t *)bstr_ptr(tx->parsed_uri->path);
-            filename_len = bstr_len(tx->parsed_uri->path);
-        }
-
-        if (filename != NULL) {
-            result = HTPFileOpen(hstate, filename, (uint32_t)filename_len, data, data_len,
-                    HtpGetActiveRequestTxID(hstate), STREAM_TOSERVER);
-            if (result == -1) {
-                goto end;
-            } else if (result == -2) {
-                htud->tsflags |= HTP_DONTSTORE;
-            } else {
-                FlagDetectStateNewFile(htud, STREAM_TOSERVER);
-                htud->tsflags |= HTP_FILENAME_SET;
-                htud->tsflags &= ~HTP_DONTSTORE;
-            }
-        }
-    }
-    else
-    {
-        /* otherwise, just store the data */
-
-        if (!(htud->tsflags & HTP_DONTSTORE)) {
-            result = HTPFileStoreChunk(hstate, data, data_len, STREAM_TOSERVER);
-            if (result == -1) {
-                goto end;
-            } else if (result == -2) {
-                /* we know for sure we're not storing the file */
-                htud->tsflags |= HTP_DONTSTORE;
-            }
-        }
-    }
-
-    return 0;
-end:
-    return -1;
-}
-
-/** \internal
- *  \brief Handle PUT body data
- */
-static int HtpRequestBodyHandlePUT(HtpState *hstate, HtpTxUserData *htud,
+static int HtpRequestBodyHandlePOSTorPUT(HtpState *hstate, HtpTxUserData *htud,
         htp_tx_t *tx, uint8_t *data, uint32_t data_len)
 {
     int result = 0;
@@ -1912,10 +1858,9 @@ static int HTPCallbackRequestBodyData(htp_tx_data_t *d)
 
             HtpRequestBodyHandleMultipart(hstate, tx_ud, d->tx, chunks_buffer, chunks_buffer_len);
 
-        } else if (tx_ud->request_body_type == HTP_BODY_REQUEST_POST) {
-            HtpRequestBodyHandlePOST(hstate, tx_ud, d->tx, (uint8_t *)d->data, (uint32_t)d->len);
-        } else if (tx_ud->request_body_type == HTP_BODY_REQUEST_PUT) {
-            HtpRequestBodyHandlePUT(hstate, tx_ud, d->tx, (uint8_t *)d->data, (uint32_t)d->len);
+        } else if (tx_ud->request_body_type == HTP_BODY_REQUEST_POST ||
+                   tx_ud->request_body_type == HTP_BODY_REQUEST_PUT) {
+            HtpRequestBodyHandlePOSTorPUT(hstate, tx_ud, d->tx, (uint8_t *)d->data, (uint32_t)d->len);
         }
 
     } else {

--- a/src/util-print.c
+++ b/src/util-print.c
@@ -143,6 +143,10 @@ void PrintRawDataFp(FILE *fp, const uint8_t *buf, uint32_t buflen)
     int ch = 0;
     uint32_t u = 0;
 
+    if (buf == NULL) {
+        fprintf(fp, " (null)\n");
+        return;
+    }
     for (u = 0; u < buflen; u+=16) {
         fprintf(fp ," %04X  ", u);
         for (ch = 0; (u+ch) < buflen && ch < 16; ch++) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3559

Describe changes:
- Handles gaps during HTTP parsing (when possible, mostly body responses with content-length)
- To do so, modifies util-file to handle gaps (and `PrintRawDataFp`) 
- Code cleaning in app-layer-htp.c so as to make it easier to reason on this

Needs libhtp patch https://github.com/OISF/libhtp/pull/295

What testing should we do ?
I think of a simple S-V test with one removed packet to show that parsing keeps going on ok
Any ideas ?
