### PR TITLE
dns: parse and log soa data - v4

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -401,11 +401,30 @@ Outline of fields seen in the different kinds of DNS events:
 * "rcode": (ex: NOERROR)
 * "rrname": Resource Record Name (ex: a domain name)
 * "rrtype": Resource Record Type (ex: A, AAAA, NS, PTR)
-* "rdata": Resource Data (ex. IP that domain name resolves to)
+* "rdata": Resource Data (ex: IP that domain name resolves to)
 * "ttl": Time-To-Live for this resource record
 
+More complex DNS record types may log additional fields for resource data:
 
-One can also control which RR types are logged explicitly from additional custom field enabled in the suricata.yaml file. If custom field is not specified, all RR types are logged. More than 50 values can be specified with the custom field and can be used as following:
+* "soa": Section containing fields for the SOA (start of authority) record type
+
+  * "mname": Primary name server for this zone
+  * "rname": Authority's mailbox
+  * "serial": Serial version number
+  * "refresh": Refresh interval (seconds)
+  * "retry": Retry interval (seconds)
+  * "expire": Upper time limit until zone is no longer authoritative (seconds)
+  * "minimum": Minimum ttl for records in this zone (seconds)
+
+* "sshfp": section containing fields for the SSHFP (ssh fingerprint) record type
+
+  * "fingerprint": Hex format of the fingerprint (ex: ``12:34:56:78:9a:bc:de:...``)
+  * "algo": Algorithm number (ex: 1 for RSA, 2 for DSS)
+  * "type": Fingerprint type (ex: 1 for SHA-1)
+
+One can control which RR types are logged by using the "types" field in the
+suricata.yaml file. If this field is not specified, all RR types are logged.
+More than 50 values can be specified with this field as shown below:
 
 
 ::
@@ -423,14 +442,16 @@ One can also control which RR types are logged explicitly from additional custom
         types:
           - alert
           - dns:
-            # control logging of queries and answers
-            # default yes, no to disable
-            query: yes     # enable logging of DNS queries
-            answer: yes    # enable logging of DNS answers
-            # control which RR types are logged
-            # all enabled if custom not specified
-            #custom: [a, aaaa, cname, mx, ns, ptr, txt]
-            custom: [a, ns, md, mf, cname, soa, mb, mg, mr, null,
+            # Control logging of requests and responses:
+            # - requests: enable logging of DNS queries
+            # - responses: enable logging of DNS answers
+            # By default both requests and responses are logged.
+            requests: yes
+            responses: yes
+            # DNS record types to log, based on the query type.
+            # Default: all.
+            #types: [a, aaaa, cname, mx, ns, ptr, txt]
+            types: [a, ns, md, mf, cname, soa, mb, mg, mr, null,
             wks, ptr, hinfo, minfo, mx, txt, rp, afsdb, x25, isdn,
             rt, nsap, nsapptr, sig, key, px, gpos, aaaa, loc, nxt,
             srv, atma, naptr, kx, cert, a6, dname, opt, apl, ds,

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -231,12 +231,46 @@ pub struct DNSQueryEntry {
 }
 
 #[derive(Debug,PartialEq)]
+pub struct DNSRDataSOA {
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug,PartialEq)]
+pub struct DNSRDataSSHFP {
+    /// Algorithm number
+    pub algo: u8,
+    /// Fingerprint type
+    pub fp_type: u8,
+    /// Fingerprint
+    pub fingerprint: Vec<u8>,
+}
+
+/// Represents RData of various formats
+#[derive(Debug,PartialEq)]
+pub enum DNSRData {
+    // RData is an address
+    A(Vec<u8>),
+    AAAA(Vec<u8>),
+    // RData is a domain name
+    CNAME(Vec<u8>),
+    PTR(Vec<u8>),
+    MX(Vec<u8>),
+    // RData is text
+    TXT(Vec<u8>),
+    // RData has several fields
+    SOA(DNSRDataSOA),
+    SSHFP(DNSRDataSSHFP),
+    // RData for remaining types is sometimes ignored
+    Unknown(Vec<u8>),
+}
+
+#[derive(Debug,PartialEq)]
 pub struct DNSAnswerEntry {
     pub name: Vec<u8>,
     pub rrtype: u16,
     pub rrclass: u16,
     pub ttl: u32,
-    pub data: Vec<u8>,
+    pub data: DNSRData,
 }
 
 #[derive(Debug)]

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -232,7 +232,20 @@ pub struct DNSQueryEntry {
 
 #[derive(Debug,PartialEq)]
 pub struct DNSRDataSOA {
-    pub data: Vec<u8>,
+    /// Primary name server for this zone
+    pub mname: Vec<u8>,
+    /// Authority's mailbox
+    pub rname: Vec<u8>,
+    /// Serial version number
+    pub serial: u32,
+    /// Refresh interval (seconds)
+    pub refresh: u32,
+    /// Retry interval (seconds)
+    pub retry: u32,
+    /// Upper time limit until zone is no longer authoritative (seconds)
+    pub expire: u32,
+    /// Minimum ttl for records in this zone (seconds)
+    pub minimum: u32,
 }
 
 #[derive(Debug,PartialEq)]

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -395,6 +395,21 @@ pub fn dns_print_addr(addr: &Vec<u8>) -> std::string::String {
     }
 }
 
+/// Log SOA section fields.
+fn dns_log_soa(soa: &DNSRDataSOA) -> Json {
+    let js = Json::object();
+
+    js.set_string_from_bytes("mname", &soa.mname);
+    js.set_string_from_bytes("rname", &soa.rname);
+    js.set_integer("serial", soa.serial as u64);
+    js.set_integer("refresh", soa.refresh as u64);
+    js.set_integer("retry", soa.retry as u64);
+    js.set_integer("expire", soa.expire as u64);
+    js.set_integer("minimum", soa.minimum as u64);
+
+    return js;
+}
+
 /// Log SSHFP section fields.
 fn dns_log_sshfp(sshfp: &DNSRDataSSHFP) -> Json {
     let js = Json::object();
@@ -427,6 +442,9 @@ fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Json
         DNSRData::TXT(bytes) |
         DNSRData::PTR(bytes) => {
             jsa.set_string_from_bytes("rdata", &bytes);
+        }
+        DNSRData::SOA(soa) => {
+            jsa.set("soa", dns_log_soa(&soa));
         }
         DNSRData::SSHFP(sshfp) => {
             jsa.set("sshfp", dns_log_sshfp(&sshfp));
@@ -501,6 +519,15 @@ fn dns_log_json_answer(response: &DNSResponse, flags: u64) -> Json
                         for a in &answer_types.get(&type_string) {
                             a.array_append(
                                 Json::string_from_bytes(&bytes));
+                        }
+                    },
+                    DNSRData::SOA(soa) => {
+                        if !answer_types.contains_key(&type_string) {
+                            answer_types.insert(type_string.to_string(),
+                                                Json::array());
+                        }
+                        for a in &answer_types.get(&type_string) {
+                            a.array_append(dns_log_soa(&soa));
                         }
                     },
                     DNSRData::SSHFP(sshfp) => {
@@ -628,6 +655,9 @@ fn dns_log_json_answer_v1(header: &DNSHeader, answer: &DNSAnswerEntry)
         DNSRData::TXT(bytes) |
         DNSRData::PTR(bytes) => {
             js.set_string_from_bytes("rdata", &bytes);
+        }
+        DNSRData::SOA(soa) => {
+            js.set("soa", dns_log_soa(&soa));
         }
         DNSRData::SSHFP(sshfp) => {
             js.set("sshfp", dns_log_sshfp(&sshfp));

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -186,9 +186,9 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
                     }
                 },
                 DNSRData::SOA(ref soa) => {
-                    if soa.data.len() > 0 {
+                    if soa.mname.len() > 0 {
                         lua.pushstring("addr");
-                        lua.pushstring(&String::from_utf8_lossy(&soa.data));
+                        lua.pushstring(&String::from_utf8_lossy(&soa.mname));
                         lua.settable(-3);
                     }
                 },

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -280,8 +280,25 @@ fn dns_parse_rdata_ptr<'a>(input: &'a [u8], message: &'a [u8])
 
 fn dns_parse_rdata_soa<'a>(input: &'a [u8], message: &'a [u8])
                            -> IResult<&'a [u8], DNSRData> {
-    dns_parse_name(input, message).map(|(input, name)|
-            (input, DNSRData::SOA(DNSRDataSOA{data: name})))
+    do_parse!(
+        input,
+        mname: call!(dns_parse_name, message) >>
+        rname: call!(dns_parse_name, message) >>
+        serial: be_u32 >>
+        refresh: be_u32 >>
+        retry: be_u32 >>
+        expire: be_u32 >>
+        minimum: be_u32 >>
+            (DNSRData::SOA(DNSRDataSOA{
+                mname,
+                rname,
+                serial,
+                refresh,
+                retry,
+                expire,
+                minimum,
+            }))
+    )
 }
 
 fn dns_parse_rdata_mx<'a>(input: &'a [u8], message: &'a [u8])
@@ -580,6 +597,71 @@ mod tests {
                     data: DNSRData::A([192, 0, 78, 25].to_vec()),
                 })
 
+            },
+            _ => {
+                assert!(false);
+            }
+        }
+    }
+
+    #[test]
+    fn test_dns_parse_response_nxdomain_soa() {
+        // DNS response with an SOA authority record from
+        // dns-udp-nxdomain-soa.pcap.
+        let pkt: &[u8] = &[
+                        0x82, 0x95, 0x81, 0x83, 0x00, 0x01, /* j....... */
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x03, 0x64, /* .......d */
+            0x6e, 0x65, 0x04, 0x6f, 0x69, 0x73, 0x66, 0x03, /* ne.oisf. */
+            0x6e, 0x65, 0x74, 0x00, 0x00, 0x01, 0x00, 0x01, /* net..... */
+            0xc0, 0x10, 0x00, 0x06, 0x00, 0x01, 0x00, 0x00, /* ........ */
+            0x03, 0x83, 0x00, 0x45, 0x06, 0x6e, 0x73, 0x2d, /* ...E.ns- */
+            0x31, 0x31, 0x30, 0x09, 0x61, 0x77, 0x73, 0x64, /* 110.awsd */
+            0x6e, 0x73, 0x2d, 0x31, 0x33, 0x03, 0x63, 0x6f, /* ns-13.co */
+            0x6d, 0x00, 0x11, 0x61, 0x77, 0x73, 0x64, 0x6e, /* m..awsdn */
+            0x73, 0x2d, 0x68, 0x6f, 0x73, 0x74, 0x6d, 0x61, /* s-hostma */
+            0x73, 0x74, 0x65, 0x72, 0x06, 0x61, 0x6d, 0x61, /* ster.ama */
+            0x7a, 0x6f, 0x6e, 0xc0, 0x3b, 0x00, 0x00, 0x00, /* zon.;... */
+            0x01, 0x00, 0x00, 0x1c, 0x20, 0x00, 0x00, 0x03, /* .... ... */
+            0x84, 0x00, 0x12, 0x75, 0x00, 0x00, 0x01, 0x51, /* ...u...Q */
+            0x80, 0x00, 0x00, 0x29, 0x02, 0x00, 0x00, 0x00, /* ...).... */
+            0x00, 0x00, 0x00, 0x00                          /* .... */
+        ];
+
+        let res = dns_parse_response(pkt);
+        match res {
+            Ok((rem, response)) => {
+
+                // For now we have some remainder data as there is an
+                // additional record type we don't parse yet.
+                assert!(rem.len() > 0);
+
+                assert_eq!(response.header, DNSHeader{
+                    tx_id: 0x8295,
+                    flags: 0x8183,
+                    questions: 1,
+                    answer_rr: 0,
+                    authority_rr: 1,
+                    additional_rr: 1,
+                });
+
+                assert_eq!(response.authorities.len(), 1);
+
+                let authority = &response.authorities[0];
+                assert_eq!(authority.name,
+                           "oisf.net".as_bytes().to_vec());
+                assert_eq!(authority.rrtype, 6);
+                assert_eq!(authority.rrclass, 1);
+                assert_eq!(authority.ttl, 899);
+                assert_eq!(authority.data,
+                           DNSRData::SOA(DNSRDataSOA{
+                               mname: "ns-110.awsdns-13.com".as_bytes().to_vec(),
+                               rname: "awsdns-hostmaster.amazon.com".as_bytes().to_vec(),
+                               serial: 1,
+                               refresh: 7200,
+                               retry: 900,
+                               expire: 1209600,
+                               minimum: 86400,
+                           }));
             },
             _ => {
                 assert!(false);

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -259,19 +259,11 @@ pub fn dns_parse_query<'a>(input: &'a [u8],
 }
 
 fn dns_parse_rdata_a<'a>(input: &'a [u8]) -> IResult<&'a [u8], DNSRData> {
-    do_parse!(
-        input,
-        data: take!(input.len()) >>
-            (DNSRData::A(data.to_vec()))
-    )
+    rest(input).map(|(input, data)| (input, DNSRData::A(data.to_vec())))
 }
 
 fn dns_parse_rdata_aaaa<'a>(input: &'a [u8]) -> IResult<&'a [u8], DNSRData> {
-    do_parse!(
-        input,
-        data: take!(input.len()) >>
-            (DNSRData::AAAA(data.to_vec()))
-    )
+    rest(input).map(|(input, data)| (input, DNSRData::AAAA(data.to_vec())))
 }
 
 fn dns_parse_rdata_cname<'a>(input: &'a [u8], message: &'a [u8])
@@ -331,11 +323,7 @@ fn dns_parse_rdata_sshfp<'a>(input: &'a [u8])
 
 fn dns_parse_rdata_unknown<'a>(input: &'a [u8])
                                -> IResult<&'a [u8], DNSRData> {
-    do_parse!(
-        input,
-        data: take!(input.len()) >>
-            (DNSRData::Unknown(data.to_vec()))
-    )
+    rest(input).map(|(input, data)| (input, DNSRData::Unknown(data.to_vec())))
 }
 
 pub fn dns_parse_rdata<'a>(input: &'a [u8], message: &'a [u8], rrtype: u16)


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
- [#2970](https://redmine.openinfosecfoundation.org/issues/2970)

Link to previous PR:
- [#4830](https://github.com/OISF/suricata/pull/4830)

Link to suricata-verify PR:
- [#216](https://github.com/OISF/suricata-verify/pull/216)

Relavant resources:
- [RFC 1035 - SOA RDATA Format](https://tools.ietf.org/html/rfc1035#section-3.3.13)
- [RFC 4255 - SSHFP RDATA Format](https://tools.ietf.org/html/rfc4255#section-3.1)

Describe changes since last pull request:
- Added one enum variant for each record type used in `DNSRData`.
- Moved parsing of SSHFP fields from `log.rs` to `parser.rs` and added test case. The lua module now outputs the fingerprint without the `algo` and `type` bytes.
- Changed rdata parsing functions to use `rest` instead of `do_parse`/`take` where appropriate.
- Added EVE Json Output documentation for SOA record fields.
- Updated documentation for SSHFP record fields and the outdated paragraph on the former `custom` field.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- Passes on local docker buildbot.
