### PR TITLE
detect/pcre: Use the keyword context for JIT stack

### DIFF
--- a/src/detect-pcre.h
+++ b/src/detect-pcre.h
@@ -39,6 +39,11 @@
 typedef struct DetectPcreData_ {
     /* pcre options */
     DetectParseRegex parse_regex;
+
+#ifdef PCRE_HAVE_JIT_EXEC
+    /* JIT stack thread context id */
+    int thread_ctx_jit_stack_id;
+#endif
     int opts;
     uint16_t flags;
     uint8_t idx;


### PR DESCRIPTION
Continuation of #4962

When PCRE `jit` is available, store the JIT stack in the keyword context
instead of on a global id. This ensures proper cleanup and
re-initialization over a rule reload.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3681)[https://redmine.openinfosecfoundation.org/issues/3681)

Describe changes:
- Address review comments