### PR TITLE
fix Bug #3726 suricata crash on rule reloading

### DIFF
--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -416,13 +416,11 @@ static int DetectFilemagicSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
     if (filemagic == NULL)
         return -1;
 
-    if (g_magic_thread_ctx_id == -1) {
-        g_magic_thread_ctx_id = DetectRegisterThreadCtxFuncs(de_ctx, "filemagic",
-                DetectFilemagicThreadInit, (void *)filemagic,
-                DetectFilemagicThreadFree, 1);
-        if (g_magic_thread_ctx_id == -1)
-            goto error;
-    }
+    g_magic_thread_ctx_id = DetectRegisterThreadCtxFuncs(de_ctx, "filemagic",
+            DetectFilemagicThreadInit, (void *)filemagic,
+            DetectFilemagicThreadFree, 1);
+    if (g_magic_thread_ctx_id == -1)
+        goto error;
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */


### PR DESCRIPTION
This changseset fixes a bug causing a segmentation fault.
When rules are reloaded and a rule using libmagic matches, suricata
crashes due to an improper reinitialization of the thread contexts.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3726

Describe changes:
- When invoking DetectFilemagicSetup we always call DetectRegisterThreadCtxFuncs 
- otherwise when rules are reloaded g_magic_thread_ctx_id will point to the wrong struct
- and it will lead to a segmentation fault.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

