### PR TITLE
Napatech bug fix 01

### DIFF
--- a/src/runmode-napatech.c
+++ b/src/runmode-napatech.c
@@ -252,7 +252,7 @@ static int NapatechInit(int runmode)
 
     if (use_hw_bypass) {
 #ifdef NAPATECH_ENABLE_BYPASS
-        if (NapatechInitFlowStreams()) {
+        if (NapatechVerifyBypassSupport()) {
             SCLogInfo("Napatech Hardware Bypass is supported and enabled.");
         } else {
             SCLogError(SC_ERR_NAPATECH_PARSE_CONFIG,

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -455,7 +455,7 @@ static int ProgramFlow(Packet *p, int is_inline)
                 v4Tuple.sa = pIPv4_hdr->src_addr;
                 v4Tuple.da = pIPv4_hdr->dst_addr;
             } else {
-                do_swap = (pIPv4_hdr->src_addr > pIPv4_hdr->dst_addr);
+                do_swap = (htonl(pIPv4_hdr->src_addr) > htonl(pIPv4_hdr->dst_addr));
                 if (!do_swap) {
                     /* already in order */
                     v4Tuple.sa = pIPv4_hdr->src_addr;

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -360,6 +360,35 @@ static int CompareIPv6Addr(uint8_t addr_a[16], uint8_t addr_b[16]) {
 }
 
 /**
+ * \brief  Initializes the FlowStreams used to program flow data.
+ *
+ * Opens a FlowStream on the adapter associated with the rx port.  This
+ * FlowStream is subsequently used to program the adapter with
+ * flows to bypass.
+ *
+ * \return the flow stream handle, NULL if failure.
+ */
+static NtFlowStream_t InitFlowStream(int adapter, int stream_id)
+{
+    int status;
+    NtFlowStream_t hFlowStream;
+
+        NtFlowAttr_t attr;
+        char flow_name[80];
+
+        NT_FlowOpenAttrInit(&attr);
+        NT_FlowOpenAttrSetAdapterNo(&attr, adapter);
+
+        snprintf(flow_name, sizeof(flow_name), "Flow_stream_%d", stream_id );
+        SCLogDebug("Opening flow programming stream:  %s", flow_name);
+        if ((status = NT_FlowOpen_Attr(&hFlowStream, flow_name, &attr)) != NT_SUCCESS) {
+            SCLogWarning(SC_WARN_COMPATIBILITY, "Napatech bypass functionality not supported by the FPGA version on adapter %d - disabling support.", adapter);
+            return NULL;
+        }
+        return hFlowStream;
+}
+
+/**
  * \brief Callback function to process Bypass events on Napatech Adapter.
  *
  * Callback function that sets up the Flow tables on the Napatech card
@@ -373,16 +402,10 @@ static int CompareIPv6Addr(uint8_t addr_a[16], uint8_t addr_b[16]) {
  */
 static int ProgramFlow(Packet *p, int is_inline)
 {
-    int status;
     NtFlow_t flow_match;
     memset(&flow_match, 0, sizeof(flow_match));
 
     NapatechPacketVars *ntpv = &(p->ntpv);
-
-    int adapter = NapatechGetAdapter(ntpv->dyn3->rxPort);
-
-    NtFlowStream_t *phFlowStream = NapatechGetFlowStreamPtr(adapter);
-
 
     /*
      * The hardware decoder will "color" the packets according to the protocols
@@ -428,7 +451,6 @@ static int ProgramFlow(Packet *p, int is_inline)
         case RTE_PTYPE_L3_IPV4:
         {
             pIPv4_hdr = (struct ipv4_hdr *) (packet + ntpv->dyn3->offset0);
-
             if (!is_span) {
                 v4Tuple.sa = pIPv4_hdr->src_addr;
                 v4Tuple.da = pIPv4_hdr->dst_addr;
@@ -571,10 +593,7 @@ static int ProgramFlow(Packet *p, int is_inline)
         }
     }
 
-    status = NT_FlowWrite(*phFlowStream, &flow_match, -1);
-    if (status == NT_STATUS_TIMEOUT) {
-        SCLogInfo("NT_FlowWrite returned NT_STATUS_TIMEOUT");
-    } else if (status != NT_SUCCESS) {
+    if (NT_FlowWrite(ntpv->flow_stream, &flow_match, -1) != NT_SUCCESS) {
         SCLogError(SC_ERR_NAPATECH_OPEN_FAILED,"NT_FlowWrite failed!.");
         exit(EXIT_FAILURE);
     }
@@ -770,6 +789,7 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
     uint64_t pkt_ts;
     NtNetBuf_t packet_buffer;
     NapatechThreadVars *ntv = (NapatechThreadVars *) data;
+    NtFlowStream_t flow_stream[MAX_ADAPTERS];
     uint64_t hba_pkt_drops = 0;
     uint64_t hba_byte_drops = 0;
     uint16_t hba_pkt = 0;
@@ -777,9 +797,20 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
     int set_cpu_affinity = 0;
     int closer = 0;
     int is_autoconfig = 0;
+    int adapter = 0;
 
     /* This just keeps the startup output more orderly. */
     usleep(200000 * ntv->stream_id);
+
+#ifdef NAPATECH_ENABLE_BYPASS
+    /* Get a FlowStream handle for each adapter so we can efficiently find the
+     * correct handle corresponding to the port on which a packet is received.
+     */
+    memset(&flow_stream, 0, sizeof(flow_stream));
+    for (adapter = 0; adapter < NapatechGetNumAdapters(); ++adapter) {
+        flow_stream[adapter] = InitFlowStream(adapter, ntv->stream_id);
+    }
+#endif
 
     if (ConfGetBool("napatech.auto-config", &is_autoconfig) == 0) {
         is_autoconfig = 0;
@@ -820,7 +851,7 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
                 is_inline = 0;
             }
 
-            #ifdef NAPATECH_ENABLE_BYPASS
+#ifdef NAPATECH_ENABLE_BYPASS
             /* Initialize the port map before we setup traffic filters */
             for (int i = 0; i < MAX_PORTS; ++i) {
                 inline_port_map[i] = -1;
@@ -961,7 +992,10 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
         p->ntpv.dyn3 = _NT_NET_GET_PKT_DESCR_PTR_DYN3(packet_buffer);
         p->BypassPacketsFlow = (NapatechIsBypassSupported() ? NapatechBypassCallback : NULL);
         NT_NET_SET_PKT_TXPORT(packet_buffer, inline_port_map[p->ntpv.dyn3->rxPort]);
+        p->ntpv.flow_stream = flow_stream[NapatechGetAdapter(p->ntpv.dyn3->rxPort)];
+
 #endif
+
         p->ReleasePacket = NapatechReleasePacket;
         p->ntpv.nt_packet_buf = packet_buffer;
         p->ntpv.stream_id = ntv->stream_id;
@@ -987,9 +1021,6 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
     } // while
 
     if (closer) {
-#ifdef NAPATECH_ENABLE_BYPASS
-        NapatechCloseFlowStreams();
-#endif
         NapatechDeleteFilters();
     }
 

--- a/src/util-napatech.h
+++ b/src/util-napatech.h
@@ -31,6 +31,7 @@ typedef struct NapatechPacketVars_
     uint64_t stream_id;
     NtNetBuf_t nt_packet_buf;
     NtNetStreamRx_t rx_stream;
+    NtFlowStream_t flow_stream;
     ThreadVars *tv;
 #ifdef NAPATECH_ENABLE_BYPASS
     NtDyn3Descr_t *dyn3;
@@ -112,9 +113,11 @@ uint32_t NapatechDeleteFilters(void);
 #define NAPATECH_FLOWTYPE_DROP 7
 #define NAPATECH_FLOWTYPE_PASS 8
 
-int NapatechInitFlowStreams(void);
+int NapatechVerifyBypassSupport(void);
 NtFlowStream_t *NapatechGetFlowStreamPtr(int device);
 int NapatechCloseFlowStreams(void);
+int NapatechGetNumAdapters(void);
+
 
 int NapatechIsBypassSupported(void);
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- This fixes an issue where flows programmed to the card sometimes failed to be entered into the flow table with no indication of an error.  The root cause was a handle that was shared between different threads.  Having each thread get it's own handle fixes the issue.

- Fix an issue with SPAN port configuration where comparing the byte order of the src and dest address in an IPv4 address was incorrect due to endian issues.  wrapping these addresses in htonl() fixes the issue.


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

