### PR TITLE
build: allows use of env variable CARGO_BUILD_TARGET

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2488,7 +2488,11 @@ fi
     if test "x$cross_compiling" = "xyes"; then
       RUST_SURICATA_LIB_XC_DIR="${host_alias}/"
     else
-      RUST_SURICATA_LIB_XC_DIR=
+      if test "x$CARGO_BUILD_TARGET" = "x"; then
+        RUST_SURICATA_LIB_XC_DIR=
+      else
+        RUST_SURICATA_LIB_XC_DIR="${CARGO_BUILD_TARGET}/"
+      fi
     fi
 
     if test "x$enable_debug" = "xyes"; then


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None but https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=22429

Describe changes:
- changes path to look for Rust built suricata library when environment variable `CARGO_BUILD_TARGET` is set

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

