### PR TITLE
detect/bsize: Validate against `content` buffer when available

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -267,17 +267,39 @@ You can also use the negation (!) before isdataat.
 bsize
 -----
 
-With the bsize keyword, you can match on the length of the buffer. This adds precision to the content match, previously this could have been done with isdataat.
+With the ``bsize`` keyword, you can match on the length of the buffer. This adds precision to the content match, previously this could have been done with isdataat.
+
+An optional operator can be specified; if no operator is present, the operator will default to '='. When a relational
+operator is used, e.g., '<', '>' or '<>' (range), the bsize value will be compared using the relational operator.
+
+If one or more ``content`` keywords precedes ``bsize``, each occurrence of ``content`` will be inspected and an error
+will be raised if the content length and the bsize value prevent a match.
 
 Format::
 
   bsize:<number>;
+  bsize:=<number>;
+  bsize:<<number>;
+  bsize:><number>;
+  bsize:<lo-number><><hi-number>;
 
-Example of bsize in a rule:
+Examples of ``bsize`` in a rule:
 
 .. container:: example-rule
 
    alert dns any any -> any any (msg:"test bsize rule"; dns.query; content:"google.com"; bsize:10; sid:123; rev:1;)
+
+.. container:: example-rule
+
+   alert dns any any -> any any (msg:"test bsize rule"; dns.query; content:"short"; bsize:<10; sid:124; rev:1;)
+
+.. container:: example-rule
+
+   alert dns any any -> any any (msg:"test bsize rule"; dns.query; content:"longer string"; bsize:>10; sid:125; rev:1;)
+
+.. container:: example-rule
+
+   alert dns any any -> any any (msg:"test bsize rule"; dns.query; content:"middle"; bsize:5<>15; sid:126; rev:1;)
 
 dsize
 -----

--- a/src/tests/detect-bsize.c
+++ b/src/tests/detect-bsize.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -119,6 +119,20 @@ static int DetectBsizeSigTest01(void)
     TEST_FAIL("alert tcp any any -> any any (content:\"abc\"; bsize:10; sid:3;)");
     TEST_FAIL("alert http any any -> any any (content:\"GET\"; http_method; bsize:10; sid:4;)");
     TEST_FAIL("alert http any any -> any any (http_request_line; content:\"GET\"; bsize:<10>; sid:5;)");
+
+    /* bsize validation with buffer */
+    TEST_OK  ("alert http any any -> any any (http.uri; content:\"/index.php\"; bsize:>1024; sid:6;)");
+    TEST_OK  ("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"g\"; bsize:1; sid:7;)");
+    TEST_OK  ("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"g\"; bsize:4; sid:8;)");
+    TEST_OK  ("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:<20; sid:9;)");
+    TEST_OK  ("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:15<>25; sid:10;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:2; sid:11;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:<13; sid:12;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:10<>15; sid:13;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefghi123456\"; offset:12;  bsize:3; sid:14;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abc\"; offset:3; depth:3; bsize:3; sid:15;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"gh\"; bsize:1; sid:16;)");
+
     PASS;
 }
 


### PR DESCRIPTION
Continuation of #4963

This PR adds additional validation when using the `bsize` keyword. If a one or more `content` keywords immediately precedes `bsize`, then the `bsize` value is checked against each to see if a match is possible using the operation (`=, <, >, <>`) and the value.

An error is raised if `bsize` value prevents a match, e.g., the content length exceeds the `bsize` value. The `bsize` operation and values are used to do the evaluation.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3682](https://redmine.openinfosecfoundation.org/issues/3682)

Describe changes:
- Addressed review comments.

Companion [Suricata PR #233](https://github.com/OISF/suricata-verify/pull/233)