### PR TITLE
Redis update

### DIFF
--- a/src/util-log-redis.c
+++ b/src/util-log-redis.c
@@ -369,6 +369,12 @@ static int SCLogRedisWriteSync(LogFileCtx *file_ctx, const char *string)
                             redis = ctx->sync;
                             if (redis) {
                                 SCLogInfo("Reconnected to redis server");
+                                redisAppendCommand(redis, "%s %s %s",
+                                        file_ctx->redis_setup.command,
+                                        file_ctx->redis_setup.key,
+                                        string);
+                                ctx->batch_count++;
+                                return 0;
                             } else {
                                 SCLogInfo("Unable to reconnect to redis server");
                                 return -1;

--- a/src/util-log-redis.c
+++ b/src/util-log-redis.c
@@ -201,7 +201,11 @@ static int SCConfLogReopenAsyncRedis(LogFileCtx *log_ctx)
         return -1;
     }
 
-    ctx->async = redisAsyncConnect(redis_server, redis_port);
+    if (strchr(redis_server, '/') == NULL) {
+        ctx->async = redisAsyncConnect(redis_server, redis_port);
+    } else {
+        ctx->async = redisAsyncConnectUnix(redis_server);
+    }
 
     if (ctx->ev_base != NULL) {
         event_base_free(ctx->ev_base);
@@ -295,7 +299,12 @@ static int SCConfLogReopenSyncRedis(LogFileCtx *log_ctx)
     if (ctx->sync != NULL)  {
         redisFree(ctx->sync);
     }
-    ctx->sync = redisConnect(redis_server, redis_port);
+
+    if (strchr(redis_server, '/') == NULL) {
+        ctx->sync = redisConnect(redis_server, redis_port);
+    } else {
+        ctx->sync = redisConnectUnix(redis_server);
+    }
     if (ctx->sync == NULL) {
         SCLogError(SC_ERR_SOCKET, "Error connecting to redis server.");
         ctx->tried = time(NULL);

--- a/src/util-log-redis.h
+++ b/src/util-log-redis.h
@@ -55,6 +55,7 @@ typedef struct SCLogRedisContext_ {
 #endif /* HAVE_LIBEVENT */
     time_t tried;
     int  batch_count;
+    time_t last_push;
 } SCLogRedisContext;
 
 void SCLogRedisInit(void);


### PR DESCRIPTION
A small series of patches on redis support. The main one is the redis unix socket support that provide a slight boost in term of logging performance .

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
- https://redmine.openinfosecfoundation.org/issues/3733
- https://redmine.openinfosecfoundation.org/issues/3749
- https://redmine.openinfosecfoundation.org/issues/3750

Describe changes:
- unix socket support for redis
- fix reconnect in batch mode
- ensure a dump per second

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/528
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/304
