### PR TITLE
magic: get rid of global lock

### DIFF
--- a/src/detect-filemagic.h
+++ b/src/detect-filemagic.h
@@ -39,7 +39,7 @@ typedef struct DetectFilemagicData {
 } DetectFilemagicData;
 
 /* prototypes */
-int FilemagicGlobalLookup(File *file);
+int FilemagicThreadLookup(magic_t *ctx, File *file);
 #endif
 void DetectFilemagicRegister (void);
 

--- a/src/output-filedata.c
+++ b/src/output-filedata.c
@@ -33,6 +33,7 @@
 #include "conf.h"
 #include "util-profiling.h"
 #include "util-validate.h"
+#include "util-magic.h"
 
 typedef struct OutputLoggerThreadStore_ {
     void *thread_data;
@@ -43,6 +44,9 @@ typedef struct OutputLoggerThreadStore_ {
  *  data for the packet loggers. */
 typedef struct OutputLoggerThreadData_ {
     OutputLoggerThreadStore *store;
+#ifdef HAVE_MAGIC
+    magic_t magic_ctx;
+#endif
 } OutputLoggerThreadData;
 
 /* logger instance, a module + a output ctx,
@@ -125,17 +129,18 @@ static int CallLoggers(ThreadVars *tv, OutputLoggerThreadStore *store_list,
     return file_logged;
 }
 
-static void OutputFiledataLogFfc(ThreadVars *tv, OutputLoggerThreadStore *store,
+static void OutputFiledataLogFfc(ThreadVars *tv, OutputLoggerThreadData *td,
         Packet *p, FileContainer *ffc, const uint8_t call_flags,
         const bool file_close, const bool file_trunc, const uint8_t dir)
 {
     if (ffc != NULL) {
+        OutputLoggerThreadStore *store = td->store;
         File *ff;
         for (ff = ffc->head; ff != NULL; ff = ff->next) {
             uint8_t file_flags = call_flags;
 #ifdef HAVE_MAGIC
             if (FileForceMagic() && ff->magic == NULL) {
-                FilemagicGlobalLookup(ff);
+                FilemagicThreadLookup(&td->magic_ctx, ff);
             }
 #endif
             SCLogDebug("ff %p", ff);
@@ -213,7 +218,6 @@ static TmEcode OutputFiledataLog(ThreadVars *tv, Packet *p, void *thread_data)
     }
 
     OutputLoggerThreadData *op_thread_data = (OutputLoggerThreadData *)thread_data;
-    OutputLoggerThreadStore *store = op_thread_data->store;
 
     /* no flow, no files */
     Flow * const f = p->flow;
@@ -230,9 +234,9 @@ static TmEcode OutputFiledataLog(ThreadVars *tv, Packet *p, void *thread_data)
     FileContainer *ffc_ts = AppLayerParserGetFiles(f, STREAM_TOSERVER);
     FileContainer *ffc_tc = AppLayerParserGetFiles(f, STREAM_TOCLIENT);
     SCLogDebug("ffc_ts %p", ffc_ts);
-    OutputFiledataLogFfc(tv, store, p, ffc_ts, STREAM_TOSERVER, file_close_ts, file_trunc, STREAM_TOSERVER);
+    OutputFiledataLogFfc(tv, op_thread_data, p, ffc_ts, STREAM_TOSERVER, file_close_ts, file_trunc, STREAM_TOSERVER);
     SCLogDebug("ffc_tc %p", ffc_tc);
-    OutputFiledataLogFfc(tv, store, p, ffc_tc, STREAM_TOCLIENT, file_close_tc, file_trunc, STREAM_TOCLIENT);
+    OutputFiledataLogFfc(tv, op_thread_data, p, ffc_tc, STREAM_TOCLIENT, file_close_tc, file_trunc, STREAM_TOCLIENT);
 
     return TM_ECODE_OK;
 }
@@ -303,6 +307,14 @@ static TmEcode OutputFiledataLogThreadInit(ThreadVars *tv, const void *initdata,
     memset(td, 0x00, sizeof(*td));
 
     *data = (void *)td;
+
+#ifdef HAVE_MAGIC
+    td->magic_ctx = MagicInitContext();
+    if (td->magic_ctx == NULL) {
+        SCFree(td);
+        return TM_ECODE_FAILED;
+    }
+#endif
 
     SCLogDebug("OutputFiledataLogThreadInit happy (*data %p)", *data);
 
@@ -412,6 +424,10 @@ static TmEcode OutputFiledataLogThreadDeinit(ThreadVars *tv, void *thread_data)
         g_waldo_deinit = 1;
     }
     SCMutexUnlock(&g_waldo_mutex);
+
+#ifdef HAVE_MAGIC
+    MagicDeinitContext(op_thread_data->magic_ctx);
+#endif
 
     SCFree(op_thread_data);
     return TM_ECODE_OK;

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -350,9 +350,6 @@ static void GlobalsDestroy(SCInstance *suri)
         SCReferenceConfDeinit();
         SCClassConfDeinit();
     }
-#ifdef HAVE_MAGIC
-    MagicDeinit();
-#endif
     TmqhCleanup();
     TmModuleRunDeInit();
     ParseSizeDeinit();
@@ -2566,10 +2563,6 @@ int PostConfLoadedSetup(SCInstance *suri)
     }
 
     HostInitConfig(HOST_VERBOSE);
-#ifdef HAVE_MAGIC
-    if (MagicInit() != 0)
-        SCReturnInt(TM_ECODE_FAILED);
-#endif
     SCAsn1LoadConfig();
 
     CoredumpLoadConfig();

--- a/src/util-magic.h
+++ b/src/util-magic.h
@@ -25,11 +25,11 @@
 #define __UTIL_MAGIC_H__
 
 #ifdef HAVE_MAGIC
-int MagicInit(void);
-void MagicDeinit(void);
-char *MagicGlobalLookup(const uint8_t *, uint32_t);
+magic_t MagicInitContext(void);
+void MagicDeinitContext(magic_t ctx);
+
 char *MagicThreadLookup(magic_t *, const uint8_t *, uint32_t);
 #endif
 void MagicRegisterTests(void);
 
-#endif /* __UTIL_MAGIC_H__ */
+#endif /* _ */


### PR DESCRIPTION
Global magic context was involving a lock that appear to be really costly for some traffic.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3732

Describe changes:
- remove the global magic lock and use a per thread context

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/529
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/305

