### PR TITLE
output/proto Improved output of unknown protocols

### DIFF
--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -126,10 +126,10 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)
     char alert_buffer[MAX_FASTLOG_BUFFER_SIZE];
 
     char proto[16] = "";
-    if (SCProtoNameValid(IP_GET_IPPROTO(p)) == TRUE) {
+    if (SCProtoNameValid(IP_GET_IPPROTO(p))) {
         strlcpy(proto, known_proto[IP_GET_IPPROTO(p)], sizeof(proto));
     } else {
-        snprintf(proto, sizeof(proto), "PROTO:%03" PRIu32, IP_GET_IPPROTO(p));
+        snprintf(proto, sizeof(proto), "PROTO:%" PRIu32, IP_GET_IPPROTO(p));
     }
     uint16_t src_port_or_icmp = p->sp;
     uint16_t dst_port_or_icmp = p->dp;

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -209,6 +209,13 @@ static TmEcode AlertSyslogIPv4(ThreadVars *tv, const Packet *p, void *data)
     if (p->alerts.cnt == 0)
         return TM_ECODE_OK;
 
+    char proto[16] = "";
+    if (SCProtoNameValid(IPV4_GET_IPPROTO(p))) {
+        strlcpy(proto, known_proto[IPV4_GET_IPPROTO(p)], sizeof(proto));
+    } else {
+        snprintf(proto, sizeof(proto), "PROTO:%" PRIu32, IPV4_GET_IPPROTO(p));
+    }
+
     /* Not sure if this mutex is needed around calls to syslog. */
     SCMutexLock(&ast->file_ctx->fp_mutex);
 
@@ -229,19 +236,11 @@ static TmEcode AlertSyslogIPv4(ThreadVars *tv, const Packet *p, void *data)
             action = "[wDrop] ";
         }
 
-        if (SCProtoNameValid(IPV4_GET_IPPROTO(p)) == TRUE) {
-            syslog(alert_syslog_level, "%s[%" PRIu32 ":%" PRIu32 ":%"
-                    PRIu32 "] %s [Classification: %s] [Priority: %"PRIu32"]"
-                    " {%s} %s:%" PRIu32 " -> %s:%" PRIu32 "", action, pa->s->gid,
-                    pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
-                    known_proto[IPV4_GET_IPPROTO(p)], srcip, p->sp, dstip, p->dp);
-        } else {
-            syslog(alert_syslog_level, "%s[%" PRIu32 ":%" PRIu32 ":%"
-                    PRIu32 "] %s [Classification: %s] [Priority: %"PRIu32"]"
-                    " {PROTO:%03" PRIu32 "} %s:%" PRIu32 " -> %s:%" PRIu32 "",
-                    action, pa->s->gid, pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg,
-                    pa->s->prio, IPV4_GET_IPPROTO(p), srcip, p->sp, dstip, p->dp);
-        }
+        syslog(alert_syslog_level, "%s[%" PRIu32 ":%" PRIu32 ":%"
+                PRIu32 "] %s [Classification: %s] [Priority: %"PRIu32"]"
+                " {%s} %s:%" PRIu32 " -> %s:%" PRIu32 "", action, pa->s->gid,
+                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
+                proto,  srcip, p->sp, dstip, p->dp);
     }
     SCMutexUnlock(&ast->file_ctx->fp_mutex);
 
@@ -266,6 +265,13 @@ static TmEcode AlertSyslogIPv6(ThreadVars *tv, const Packet *p, void *data)
     if (p->alerts.cnt == 0)
         return TM_ECODE_OK;
 
+    char proto[16] = "";
+    if (SCProtoNameValid(IPV6_GET_L4PROTO(p))) {
+        strlcpy(proto, known_proto[IPV6_GET_L4PROTO(p)], sizeof(proto));
+    } else {
+        snprintf(proto, sizeof(proto), "PROTO:%" PRIu32, IPV6_GET_L4PROTO(p));
+    }
+
     SCMutexLock(&ast->file_ctx->fp_mutex);
 
     for (i = 0; i < p->alerts.cnt; i++) {
@@ -285,21 +291,12 @@ static TmEcode AlertSyslogIPv6(ThreadVars *tv, const Packet *p, void *data)
             action = "[wDrop] ";
         }
 
-        if (SCProtoNameValid(IPV6_GET_L4PROTO(p)) == TRUE) {
-            syslog(alert_syslog_level, "%s[%" PRIu32 ":%" PRIu32 ":%"
-                    "" PRIu32 "] %s [Classification: %s] [Priority: %"
-                    "" PRIu32 "] {%s} %s:%" PRIu32 " -> %s:%" PRIu32 "",
-                    action, pa->s->gid, pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg,
-                    pa->s->prio, known_proto[IPV6_GET_L4PROTO(p)], srcip, p->sp,
-                    dstip, p->dp);
-
-        } else {
-            syslog(alert_syslog_level, "%s[%" PRIu32 ":%" PRIu32 ":%"
-                    "" PRIu32 "] %s [Classification: %s] [Priority: %"
-                    "" PRIu32 "] {PROTO:%03" PRIu32 "} %s:%" PRIu32 " -> %s:%" PRIu32 "",
-                    action, pa->s->gid, pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg,
-                    pa->s->prio, IPV6_GET_L4PROTO(p), srcip, p->sp, dstip, p->dp);
-        }
+        syslog(alert_syslog_level, "%s[%" PRIu32 ":%" PRIu32 ":%"
+                "" PRIu32 "] %s [Classification: %s] [Priority: %"
+                "" PRIu32 "] {%s} %s:%" PRIu32 " -> %s:%" PRIu32 "",
+                action, pa->s->gid, pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg,
+                pa->s->prio, proto, srcip, p->sp,
+                dstip, p->dp);
 
     }
     SCMutexUnlock(&ast->file_ctx->fp_mutex);

--- a/src/log-droplog.c
+++ b/src/log-droplog.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -222,10 +222,10 @@ static int LogDropLogNetFilter (ThreadVars *tv, const Packet *p, void *data)
         proto = IPV6_GET_L4PROTO(p);
     }
 
-    if (SCProtoNameValid(proto) == TRUE) {
+    if (SCProtoNameValid(proto)) {
         fprintf(dlt->file_ctx->fp, " PROTO=%s",known_proto[proto]);
     } else {
-        fprintf(dlt->file_ctx->fp, " PROTO=%03"PRIu16"",proto);
+        fprintf(dlt->file_ctx->fp, " PROTO=%"PRIu16"",proto);
     }
 
     switch (proto) {

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -100,13 +100,6 @@ static json_t *CreateJSONHeaderFromFlow(const Flow *f, const char *event_type)
         dp = f->sp;
     }
 
-    char proto[16];
-    if (SCProtoNameValid(f->proto) == TRUE) {
-        strlcpy(proto, known_proto[f->proto], sizeof(proto));
-    } else {
-        snprintf(proto, sizeof(proto), "%03" PRIu32, f->proto);
-    }
-
     /* time */
     json_object_set_new(js, "timestamp", json_string(timebuf));
 
@@ -158,7 +151,12 @@ static json_t *CreateJSONHeaderFromFlow(const Flow *f, const char *event_type)
             json_object_set_new(js, "dest_port", json_integer(dp));
             break;
     }
-    json_object_set_new(js, "proto", json_string(proto));
+
+    if (SCProtoNameValid(f->proto)) {
+        json_object_set_new(js, "proto", json_string(known_proto[f->proto]));
+    } else {
+        json_object_set_new(js, "proto", json_integer(f->proto));
+    }
     switch (f->proto) {
         case IPPROTO_ICMP:
         case IPPROTO_ICMPV6:

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Open Information Security Foundation
+/* Copyright (C) 2014-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -107,13 +107,6 @@ static json_t *CreateJSONHeaderFromFlow(const Flow *f, const char *event_type, i
         dp = f->sp;
     }
 
-    char proto[16];
-    if (SCProtoNameValid(f->proto) == TRUE) {
-        strlcpy(proto, known_proto[f->proto], sizeof(proto));
-    } else {
-        snprintf(proto, sizeof(proto), "%03" PRIu32, f->proto);
-    }
-
     /* time */
     json_object_set_new(js, "timestamp", json_string(timebuf));
 
@@ -165,7 +158,12 @@ static json_t *CreateJSONHeaderFromFlow(const Flow *f, const char *event_type, i
             json_object_set_new(js, "dest_port", json_integer(dp));
             break;
     }
-    json_object_set_new(js, "proto", json_string(proto));
+    if (SCProtoNameValid(f->proto)) {
+        json_object_set_new(js, "proto", json_string(known_proto[f->proto]));
+    } else {
+        json_object_set_new(js, "proto", json_integer(f->proto));
+    }
+
     switch (f->proto) {
         case IPPROTO_ICMP:
         case IPPROTO_ICMPV6: {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -456,7 +456,6 @@ void JsonFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, json_t *js)
 {
     char srcip[46] = {0}, dstip[46] = {0};
     Port sp, dp;
-    char proto[16];
 
     switch (dir) {
         case LOG_DIR_PACKET:
@@ -545,11 +544,6 @@ void JsonFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, json_t *js)
             return;
     }
 
-    if (SCProtoNameValid(IP_GET_IPPROTO(p)) == TRUE) {
-        strlcpy(proto, known_proto[IP_GET_IPPROTO(p)], sizeof(proto));
-    } else {
-        snprintf(proto, sizeof(proto), "%03" PRIu32, IP_GET_IPPROTO(p));
-    }
 
     json_object_set_new(js, "src_ip", json_string(srcip));
 
@@ -575,7 +569,11 @@ void JsonFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, json_t *js)
             break;
     }
 
-    json_object_set_new(js, "proto", json_string(proto));
+    if (SCProtoNameValid(IP_GET_IPPROTO(p))) {
+        json_object_set_new(js, "proto", json_string(known_proto[IP_GET_IPPROTO(p)]));
+    } else {
+        json_object_set_new(js, "proto", json_integer(IP_GET_IPPROTO(p)));
+    }
 }
 
 static void CreateJSONCommunityFlowIdv4(json_t *js, const Flow *f,

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Open Information Security Foundation
+/* Copyright (C) 2014-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -195,13 +195,6 @@ static int LuaPacketLoggerAlerts(ThreadVars *tv, void *thread_data, const Packet
         goto not_supported;
     }
 
-    char proto[16] = "";
-    if (SCProtoNameValid(IP_GET_IPPROTO(p)) == TRUE) {
-        strlcpy(proto, known_proto[IP_GET_IPPROTO(p)], sizeof(proto));
-    } else {
-        snprintf(proto, sizeof(proto), "PROTO:%03" PRIu32, IP_GET_IPPROTO(p));
-    }
-
     /* loop through alerts stored in the packet */
     SCMutexLock(&td->lua_ctx->m);
     uint16_t cnt;
@@ -265,13 +258,6 @@ static int LuaPacketLogger(ThreadVars *tv, void *thread_data, const Packet *p)
     }
 
     CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
-
-    char proto[16] = "";
-    if (SCProtoNameValid(IP_GET_IPPROTO(p)) == TRUE) {
-        strlcpy(proto, known_proto[IP_GET_IPPROTO(p)], sizeof(proto));
-    } else {
-        snprintf(proto, sizeof(proto), "PROTO:%03" PRIu32, IP_GET_IPPROTO(p));
-    }
 
     /* loop through alerts stored in the packet */
     SCMutexLock(&td->lua_ctx->m);

--- a/src/util-proto-name.c
+++ b/src/util-proto-name.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -92,17 +92,11 @@ void SCProtoNameInit()
  *          we have corresponding name entry for this number or not.
  *
  * \param proto Protocol number to be validated
- * \retval ret On success returns TRUE otherwise FALSE
+ * \retval ret On success returns true otherwise false
  */
-uint8_t SCProtoNameValid(uint16_t proto)
+bool SCProtoNameValid(uint16_t proto)
 {
-    uint8_t ret = FALSE;
-
-    if (proto <= 255 && known_proto[proto] != NULL) {
-        ret = TRUE;
-    }
-
-    return ret;
+    return (proto <= 255 && known_proto[proto] != NULL);
 }
 
 /**

--- a/src/util-proto-name.h
+++ b/src/util-proto-name.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -34,7 +34,7 @@
  *  in /etc/protocols */
 extern char *known_proto[256];
 
-uint8_t SCProtoNameValid(uint16_t);
+bool SCProtoNameValid(uint16_t);
 void SCProtoNameInit(void);
 void SCProtoNameDeInit(void);
 


### PR DESCRIPTION
This PR improves the output of unknown protocol values. Values that were zero-padded will no longer have leading 0's, e.g., `006` becomes `6`.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Remove zero-padding from unknown protocol values
- Remove unnecessary protocol label handling
- Move protocol handling outside of loops

