### PR TITLE
util-running-mode: --list-app-layer-protos respects -c arg

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2067,7 +2067,11 @@ static int StartInternalRunMode(SCInstance *suri, int argc, char **argv)
             ListKeywords(suri->keyword_info);
             return TM_ECODE_DONE;
         case RUNMODE_LIST_APP_LAYERS:
-            ListAppLayerProtocols();
+            if (suri->conf_filename != NULL) {
+                ListAppLayerProtocols(suri->conf_filename);
+            } else {
+                ListAppLayerProtocols(DEFAULT_CONF_FILE);
+            }
             return TM_ECODE_DONE;
         case RUNMODE_PRINT_VERSION:
             PrintVersion();

--- a/src/util-running-modes.c
+++ b/src/util-running-modes.c
@@ -41,9 +41,9 @@ int ListKeywords(const char *keyword_info)
     exit(EXIT_SUCCESS);
 }
 
-int ListAppLayerProtocols()
+int ListAppLayerProtocols(const char *conf_filename)
 {
-    if (ConfYamlLoadFile(DEFAULT_CONF_FILE) != -1)
+    if (ConfYamlLoadFile(conf_filename) != -1)
         SCLogLoadConfig(0, 0);
     MpmTableSetup();
     SpmTableSetup();

--- a/src/util-running-modes.h
+++ b/src/util-running-modes.h
@@ -24,6 +24,6 @@
 #define __UTIL_RUNNING_MODES_H__
 
 int ListKeywords(const char *keyword_info);
-int ListAppLayerProtocols(void);
+int ListAppLayerProtocols(const char *conf_filename);
 
 #endif /* __UTIL_RUNNING_MODES_H__ */


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3282

Describe changes:
- If --list-app-layer-protos arg is provided alongside the -c arg app layer protocols will be listed from the targeted config file. If -c is not provided app layer protocols will be listed from the default config file.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):