### PR TITLE
Forensic mode rust v1.5

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -285,6 +285,7 @@ any bytes.
 It is also possible to dump every header for HTTP requests/responses or both
 via the keyword ``dump-all-headers``.
 
+HTTP body and HTTP body printable can also be logged via the ``http-body`` and ``http-body-printable`` options.
 
 Examples
 ~~~~~~~~

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -62,6 +62,7 @@ Metadata::
             #packet: yes              # enable dumping of packet (without stream segments)
             #http-body: yes           # Requires metadata; enable dumping of http body in Base64
             #http-body-printable: yes # Requires metadata; enable dumping of http body in printable format
+            #http-headers: yes        # Requires metadata; enable dumping of http headers
 
             # metadata:
 
@@ -140,6 +141,10 @@ Config::
         # set this value to one among {both, request, response} to dump all
         # http headers for every http request and/or response
         # dump-all-headers: [both, request, response]
+        # Log request and response bodies with every request. This setup is
+        # recommended for forensic purpose only.
+        # http-body: yes
+        # http-body-printable: yes
 
 List of custom fields:
 
@@ -473,4 +478,42 @@ YAML::
       community-id-seed: 0
 
 
+Stream data
+~~~~~~~~~~~
+
+It is possible to include stream data in application layer events
+
+YAML::
+
+  
+  - eve-log:
+      # ....
+      stream-data: yes # log data as base64
+      stream-data-printable: yes # log printable data
+
 .. _deprecation policy: https://suricata-ids.org/about/deprecation-policy/
+
+
+Conditional verbosity
+~~~~~~~~~~~~~~~~~~~~~
+
+Flows with alerts contains often interesting data and information. It is possible to use the ``full-log-alerted``
+option to increase the verbosity of log on flows with alerts. If activated, protocols like HTTP and TLS will have
+verbose logging if ever the flow has alerts.
+
+For TLS, extended logging is activated for flows with alerts. For HTTP, extended
+logging is activated, full headers are dumped and HTTP body is added.
+
+
+YAML::
+
+  - eve-log:
+      # ....
+      full-log-alerted: printable # log printable data
+
+Possible value of the option are:
+
+- ``no``: to disable the option (default value)
+- ``base64``: to log raw data in base64
+- ``printable``: to log raw data in printable format
+- ``both``: to log raw data in printable and base64 format

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -91,6 +91,7 @@
 #define LOG_JSON_HTTP_BODY_BASE64  BIT_U16(7)
 #define LOG_JSON_RULE_METADATA     BIT_U16(8)
 #define LOG_JSON_RULE              BIT_U16(9)
+#define LOG_JSON_HTTP_HEADERS      BIT_U16(10)
 
 #define METADATA_DEFAULTS ( LOG_JSON_FLOW |                        \
             LOG_JSON_APP_LAYER  |                                  \
@@ -485,6 +486,9 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                         if (json_output_ctx->flags & LOG_JSON_HTTP_BODY_BASE64) {
                             EveHttpLogJSONBodyBase64(jb, p->flow, pa->tx_id);
                         }
+                        if (json_output_ctx->flags & LOG_JSON_HTTP_HEADERS) {
+                            EveHttpLogAllJSONHeaders(jb, p->flow, pa->tx_id);
+                        }
                     }
                     jb_close(jb);
                     break;
@@ -860,6 +864,7 @@ static void JsonAlertLogSetupMetadata(AlertJsonOutputCtx *json_output_ctx,
         SetFlag(conf, "payload-printable", LOG_JSON_PAYLOAD, &flags);
         SetFlag(conf, "http-body-printable", LOG_JSON_HTTP_BODY, &flags);
         SetFlag(conf, "http-body", LOG_JSON_HTTP_BODY_BASE64, &flags);
+        SetFlag(conf, "http-headers", LOG_JSON_HTTP_HEADERS, &flags);
 
         /* Check for obsolete configuration flags to enable specific
          * protocols. These are now just aliases for enabling

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -460,7 +460,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
         JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "alert", &addr);
         if (unlikely(jb == NULL))
             return TM_ECODE_OK;
-        EveAddCommonOptions(&json_output_ctx->cfg, p, p->flow, jb);
+        EveAddCommonOptions(&json_output_ctx->cfg, p, p->flow, jb, NULL);
 
         MemBufferReset(aft->json_buffer);
 

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -115,7 +115,8 @@ static int AnomalyDecodeEventJson(ThreadVars *tv, JsonAnomalyLogThread *aft,
         if (!is_ip_pkt) {
             jb_set_string(js, "timestamp", timebuf);
         } else {
-            EveAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js);
+            EveAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js,
+                                aft->json_buffer);
         }
 
         if (event_code < DECODE_EVENT_MAX) {
@@ -168,7 +169,7 @@ static int AnomalyAppLayerDecoderEventJson(JsonAnomalyLogThread *aft,
             return TM_ECODE_OK;
         }
 
-        EveAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js);
+        EveAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js, aft->json_buffer);
 
         jb_open_object(js, ANOMALY_EVENT_TYPE);
 

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -74,7 +74,7 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
-    EveAddCommonOptions(&thread->dhcplog_ctx->cfg, p, f, js);
+    EveAddCommonOptions(&thread->dhcplog_ctx->cfg, p, f, js, thread->buffer);
 
     rs_dhcp_logger_log(ctx->rs_logger, tx, js);
     if (!jb_close(js)) {

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -307,14 +307,14 @@ static int JsonDNP3LoggerToServer(ThreadVars *tv, void *thread_data,
 
     MemBuffer *buffer = (MemBuffer *)thread->buffer;
 
-    MemBufferReset(buffer);
     if (tx->has_request && tx->request_done) {
         json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "dnp3", NULL);
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
         }
 
-        JsonAddCommonOptions(&thread->dnp3log_ctx->cfg, p, f, js);
+        JsonAddCommonOptions(&thread->dnp3log_ctx->cfg, p, f, js, buffer);
+        MemBufferReset(buffer);
 
         json_t *dnp3js = JsonDNP3LogRequest(tx);
         if (dnp3js != NULL) {
@@ -336,14 +336,14 @@ static int JsonDNP3LoggerToClient(ThreadVars *tv, void *thread_data,
 
     MemBuffer *buffer = (MemBuffer *)thread->buffer;
 
-    MemBufferReset(buffer);
     if (tx->has_response && tx->response_done) {
         json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "dnp3", NULL);
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
         }
 
-        JsonAddCommonOptions(&thread->dnp3log_ctx->cfg, p, f, js);
+        JsonAddCommonOptions(&thread->dnp3log_ctx->cfg, p, f, js, buffer);
+        MemBufferReset(buffer);
 
         json_t *dnp3js = JsonDNP3LogResponse(tx);
         if (dnp3js != NULL) {

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -322,7 +322,7 @@ static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
         if (unlikely(jb == NULL)) {
             return TM_ECODE_OK;
         }
-        EveAddCommonOptions(&dnslog_ctx->cfg, p, f, jb);
+        EveAddCommonOptions(&dnslog_ctx->cfg, p, f, jb, td->buffer);
 
         jb_open_object(jb, "dns");
         if (!rs_dns_log_json_query(txptr, i, td->dnslog_ctx->flags, jb)) {
@@ -357,7 +357,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
             if (unlikely(jb == NULL)) {
                 return TM_ECODE_OK;
             }
-            EveAddCommonOptions(&dnslog_ctx->cfg, p, f, jb);
+            EveAddCommonOptions(&dnslog_ctx->cfg, p, f, jb, td->buffer);
 
             jb_open_object(jb, "dns");
             rs_dns_log_json_answer(txptr, td->dnslog_ctx->flags, jb);
@@ -373,7 +373,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
             if (unlikely(jb == NULL)) {
                 return TM_ECODE_OK;
             }
-            EveAddCommonOptions(&dnslog_ctx->cfg, p, f, jb);
+            EveAddCommonOptions(&dnslog_ctx->cfg, p, f, jb, td->buffer);
 
             JsonBuilder *answer = rs_dns_log_json_answer_v1(txptr, i,
                     td->dnslog_ctx->flags);
@@ -393,7 +393,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
             if (unlikely(jb == NULL)) {
                 return TM_ECODE_OK;
             }
-            EveAddCommonOptions(&dnslog_ctx->cfg, p, f, jb);
+            EveAddCommonOptions(&dnslog_ctx->cfg, p, f, jb, td->buffer);
 
             JsonBuilder *answer = rs_dns_log_json_authority_v1(txptr, i,
                     td->dnslog_ctx->flags);

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -94,7 +94,7 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 
-    EveAddCommonOptions(&drop_ctx->cfg, p, p->flow, js);
+    EveAddCommonOptions(&drop_ctx->cfg, p, p->flow, js, NULL);
 
     jb_open_object(js, "drop");
 

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -285,7 +285,7 @@ static void EveFlowLogJSON(JsonFlowLogThread *aft, JsonBuilder *jb, Flow *f)
     /* Close flow. */
     jb_close(jb);
 
-    EveAddCommonOptions(&flow_ctx->cfg, NULL, f, jb);
+    EveAddCommonOptions(&flow_ctx->cfg, NULL, f, jb, NULL);
 
     /* TCP */
     if (f->proto == IPPROTO_TCP) {

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -161,7 +161,7 @@ static int JsonFTPLogger(ThreadVars *tv, void *thread_data,
 
     json_t *js = CreateJSONHeaderWithTxId(p, LOG_DIR_FLOW, event_type, tx_id);
     if (likely(js)) {
-        JsonAddCommonOptions(&ftp_ctx->cfg, p, f, js);
+        JsonAddCommonOptions(&ftp_ctx->cfg, p, f, js, thread->buffer);
         json_t *cjs = NULL;
         if (f->alproto == ALPROTO_FTPDATA) {
             cjs = JsonFTPDataAddMetadata(f);

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -488,20 +488,25 @@ static void EveHttpLogJSON(JsonHttpLogThread *aft, JsonBuilder *js, Flow * f, ht
     /* log custom fields if configured */
     if (http_ctx->fields != 0)
         EveHttpLogJSONCustom(http_ctx, js, tx);
-    if (http_ctx->flags & LOG_HTTP_EXTENDED)
+    if ((http_ctx->flags & LOG_HTTP_EXTENDED) ||
+        OutputJSONNeedFullLog(&aft->httplog_ctx->cfg, f, tx_id, LOG_TYPE_STRING))
         EveHttpLogJSONExtended(js, tx);
-    if (http_ctx->flags & LOG_HTTP_REQ_HEADERS)
+    if ((http_ctx->flags & LOG_HTTP_REQ_HEADERS) ||
+        OutputJSONNeedFullLog(&aft->httplog_ctx->cfg, f, tx_id, LOG_TYPE_STRING))
         EveHttpLogJSONHeaders(js, LOG_HTTP_REQ_HEADERS, tx);
-    if (http_ctx->flags & LOG_HTTP_RES_HEADERS)
+    if ((http_ctx->flags & LOG_HTTP_RES_HEADERS) ||
+        OutputJSONNeedFullLog(&aft->httplog_ctx->cfg, f, tx_id, LOG_TYPE_STRING))
         EveHttpLogJSONHeaders(js, LOG_HTTP_RES_HEADERS, tx);
-    if (http_ctx->flags & LOG_HTTP_BODY) {
+    if ((http_ctx->flags & LOG_HTTP_BODY) ||
+        OutputJSONNeedFullLog(&aft->httplog_ctx->cfg, f, tx_id, LOG_TYPE_BASE64)) {
         HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx);
         if (htud != NULL) {
             BodyBase64Buffer(js, &htud->request_body, "request_body");
             BodyBase64Buffer(js, &htud->response_body, "response_body");
         }
     }
-    if (http_ctx->flags & LOG_HTTP_BODY_PRINTABLE) {
+    if ((http_ctx->flags & LOG_HTTP_BODY_PRINTABLE) ||
+        OutputJSONNeedFullLog(&aft->httplog_ctx->cfg, f, tx_id, LOG_TYPE_PRINTABLE)) {
         HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx);
         if (htud != NULL) {
             BodyPrintableBuffer(js, &htud->request_body, "request_body_printable");

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -75,14 +75,14 @@ typedef struct JsonHttpLogThread_ {
 #define MAX_SIZE_HEADER_NAME 256
 #define MAX_SIZE_HEADER_VALUE 2048
 
-#define LOG_HTTP_DEFAULT 0
-#define LOG_HTTP_EXTENDED 1
-#define LOG_HTTP_REQUEST 2 /* request field */
-#define LOG_HTTP_ARRAY 4 /* require array handling */
-#define LOG_HTTP_REQ_HEADERS 8
-#define LOG_HTTP_RES_HEADERS 16
-#define LOG_HTTP_BODY 32
-#define LOG_HTTP_BODY_PRINTABLE 64
+#define LOG_HTTP_DEFAULT        0
+#define LOG_HTTP_EXTENDED       BIT_U32(0)
+#define LOG_HTTP_REQUEST        BIT_U32(1) /* request field */
+#define LOG_HTTP_ARRAY          BIT_U32(2) /* require array handling */
+#define LOG_HTTP_REQ_HEADERS    BIT_U32(3)
+#define LOG_HTTP_RES_HEADERS    BIT_U32(4)
+#define LOG_HTTP_BODY           BIT_U32(5)
+#define LOG_HTTP_BODY_PRINTABLE BIT_U32(6)
 
 typedef enum {
     HTTP_FIELD_ACCEPT = 0,

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -81,6 +81,8 @@ typedef struct JsonHttpLogThread_ {
 #define LOG_HTTP_ARRAY 4 /* require array handling */
 #define LOG_HTTP_REQ_HEADERS 8
 #define LOG_HTTP_RES_HEADERS 16
+#define LOG_HTTP_BODY 32
+#define LOG_HTTP_BODY_PRINTABLE 64
 
 typedef enum {
     HTTP_FIELD_ACCEPT = 0,
@@ -492,6 +494,20 @@ static void EveHttpLogJSON(JsonHttpLogThread *aft, JsonBuilder *js, Flow * f, ht
         EveHttpLogJSONHeaders(js, LOG_HTTP_REQ_HEADERS, tx);
     if (http_ctx->flags & LOG_HTTP_RES_HEADERS)
         EveHttpLogJSONHeaders(js, LOG_HTTP_RES_HEADERS, tx);
+    if (http_ctx->flags & LOG_HTTP_BODY) {
+        HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx);
+        if (htud != NULL) {
+            BodyBase64Buffer(js, &htud->request_body, "request_body");
+            BodyBase64Buffer(js, &htud->response_body, "response_body");
+        }
+    }
+    if (http_ctx->flags & LOG_HTTP_BODY_PRINTABLE) {
+        HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx);
+        if (htud != NULL) {
+            BodyPrintableBuffer(js, &htud->request_body, "request_body_printable");
+            BodyPrintableBuffer(js, &htud->response_body, "response_body_printable");
+        }
+    }
 
     jb_close(js);
 }
@@ -640,6 +656,19 @@ static OutputInitResult OutputHttpLogInit(ConfNode *conf)
                              all_headers);
             }
         }
+        const char *bodies = ConfNodeLookupChildValue(conf, "http-body");
+        if (bodies != NULL) {
+            if (ConfValIsTrue(bodies)) {
+                http_ctx->flags |= LOG_HTTP_BODY;
+            }
+        }
+        const char *bodiesprintable = ConfNodeLookupChildValue(
+                conf, "http-body-printable");
+        if (bodiesprintable != NULL) {
+            if (ConfValIsTrue(bodiesprintable)) {
+                http_ctx->flags |= LOG_HTTP_BODY_PRINTABLE;
+            }
+        }
     }
     http_ctx->xff_cfg = SCCalloc(1, sizeof(HttpXFFCfg));
     if (http_ctx->xff_cfg != NULL) {
@@ -728,6 +757,19 @@ static OutputInitResult OutputHttpLogInitSub(ConfNode *conf, OutputCtx *parent_c
                 http_ctx->flags |= LOG_HTTP_REQ_HEADERS;
             } else if (strncmp(all_headers, "response", 8) == 0) {
                 http_ctx->flags |= LOG_HTTP_RES_HEADERS;
+            }
+        }
+        const char *bodies = ConfNodeLookupChildValue(conf, "http-body");
+        if (bodies != NULL) {
+            if (ConfValIsTrue(bodies)) {
+                http_ctx->flags |= LOG_HTTP_BODY;
+            }
+        }
+        const char *bodiesprintable = ConfNodeLookupChildValue(
+                conf, "http-body-printable");
+        if (bodiesprintable != NULL) {
+            if (ConfValIsTrue(bodiesprintable)) {
+                http_ctx->flags |= LOG_HTTP_BODY_PRINTABLE;
             }
         }
     }

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -477,7 +477,7 @@ void EveHttpLogJSONBodyBase64(JsonBuilder *js, Flow *f, uint64_t tx_id)
 }
 
 /* JSON format logging */
-static void EveHttpLogJSON(JsonHttpLogThread *aft, JsonBuilder *js, htp_tx_t *tx, uint64_t tx_id)
+static void EveHttpLogJSON(JsonHttpLogThread *aft, JsonBuilder *js, Flow * f, htp_tx_t *tx, uint64_t tx_id)
 {
     LogHttpFileCtx *http_ctx = aft->httplog_ctx;
     jb_open_object(js, "http");
@@ -513,7 +513,7 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     /* reset */
     MemBufferReset(jhl->buffer);
 
-    EveHttpLogJSON(jhl, js, tx, tx_id);
+    EveHttpLogJSON(jhl, js, f, tx, tx_id);
     HttpXFFCfg *xff_cfg = jhl->httplog_ctx->xff_cfg != NULL ?
         jhl->httplog_ctx->xff_cfg : jhl->httplog_ctx->parent_xff_cfg;
 
@@ -558,6 +558,19 @@ bool EveHttpAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
     }
 
     return false;
+}
+
+void EveHttpLogAllJSONHeaders(JsonBuilder *js, Flow *f, uint64_t tx_id)
+{
+
+    HtpState *htp_state = (HtpState *)FlowGetAppState(f);
+    if (htp_state) {
+        htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, tx_id);
+        if (tx) {
+            EveHttpLogJSONHeaders(js, LOG_HTTP_REQ_HEADERS, tx);
+            EveHttpLogJSONHeaders(js, LOG_HTTP_RES_HEADERS, tx);
+        }
+    }
 }
 
 static void OutputHttpLogDeinit(OutputCtx *output_ctx)

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -522,7 +522,7 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     JsonBuilder *js = CreateEveHeaderWithTxId(p, LOG_DIR_FLOW, "http", NULL, tx_id);
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
-    EveAddCommonOptions(&jhl->httplog_ctx->cfg, p, f, js);
+    EveAddCommonOptions(&jhl->httplog_ctx->cfg, p, f, js, jhl->buffer);
 
     SCLogDebug("got a HTTP request and now logging !!");
 
@@ -578,7 +578,6 @@ bool EveHttpAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
 
 void EveHttpLogAllJSONHeaders(JsonBuilder *js, Flow *f, uint64_t tx_id)
 {
-
     HtpState *htp_state = (HtpState *)FlowGetAppState(f);
     if (htp_state) {
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, tx_id);

--- a/src/output-json-http.h
+++ b/src/output-json-http.h
@@ -29,6 +29,7 @@ void JsonHttpLogRegister(void);
 bool EveHttpAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js);
 void EveHttpLogJSONBodyPrintable(JsonBuilder *js, Flow *f, uint64_t tx_id);
 void EveHttpLogJSONBodyBase64(JsonBuilder *js, Flow *f, uint64_t tx_id);
+void EveHttpLogAllJSONHeaders(JsonBuilder *js, Flow *f, uint64_t tx_id);
 
 #endif /* __OUTPUT_JSON_HTTP_H__ */
 

--- a/src/output-json-ikev2.c
+++ b/src/output-json-ikev2.c
@@ -71,7 +71,8 @@ static int JsonIKEv2Logger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
-    JsonAddCommonOptions(&thread->ikev2log_ctx->cfg, p, f, js);
+    JsonAddCommonOptions(&thread->ikev2log_ctx->cfg, p, f, js,
+                         thread->buffer);
 
     ikev2js = rs_ikev2_log_json_response(state, ikev2tx);
     if (unlikely(ikev2js == NULL)) {

--- a/src/output-json-krb5.c
+++ b/src/output-json-krb5.c
@@ -71,7 +71,7 @@ static int JsonKRB5Logger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
-    JsonAddCommonOptions(&thread->krb5log_ctx->cfg, p, f, js);
+    JsonAddCommonOptions(&thread->krb5log_ctx->cfg, p, f, js, thread->buffer);
 
     krb5js = rs_krb5_log_json_response(state, krb5tx);
     if (unlikely(krb5js == NULL)) {

--- a/src/output-json-metadata.c
+++ b/src/output-json-metadata.c
@@ -85,7 +85,7 @@ static int MetadataJson(ThreadVars *tv, JsonMetadataLogThread *aft, const Packet
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 
-    JsonAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js);
+    JsonAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js, NULL);
     OutputJSONBuffer(js, aft->file_ctx, &aft->json_buffer);
     json_object_del(js, "metadata");
     json_object_clear(js);

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -304,7 +304,7 @@ static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
     JsonNetFlowLogJSONToServer(jhl, js, f);
-    JsonAddCommonOptions(&netflow_ctx->cfg, NULL, f, js);
+    JsonAddCommonOptions(&netflow_ctx->cfg, NULL, f, js, NULL);
     OutputJSONBuffer(js, jhl->flowlog_ctx->file_ctx, &jhl->buffer);
     json_object_del(js, "netflow");
     json_object_clear(js);
@@ -318,7 +318,7 @@ static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
         if (unlikely(js == NULL))
             return TM_ECODE_OK;
         JsonNetFlowLogJSONToClient(jhl, js, f);
-        JsonAddCommonOptions(&netflow_ctx->cfg, NULL, f, js);
+        JsonAddCommonOptions(&netflow_ctx->cfg, NULL, f, js, NULL);
         OutputJSONBuffer(js, jhl->flowlog_ctx->file_ctx, &jhl->buffer);
         json_object_del(js, "netflow");
         json_object_clear(js);

--- a/src/output-json-nfs.c
+++ b/src/output-json-nfs.c
@@ -88,7 +88,7 @@ static int JsonNFSLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
-    JsonAddCommonOptions(&thread->ctx->cfg, p, f, js);
+    JsonAddCommonOptions(&thread->ctx->cfg, p, f, js, thread->buffer);
 
     json_t *rpcjs = rs_rpc_log_json_response(tx);
     if (unlikely(rpcjs == NULL)) {

--- a/src/output-json-rdp.c
+++ b/src/output-json-rdp.c
@@ -46,6 +46,7 @@
 typedef struct LogRdpFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t    flags;
+    OutputJsonCommonSettings cfg;
 } LogRdpFileCtx;
 
 typedef struct LogRdpLogThread_ {
@@ -70,6 +71,7 @@ static int JsonRdpLogger(ThreadVars *tv, void *thread_data,
     }
     json_object_set_new(js, "rdp", rdp_js);
 
+    JsonAddCommonOptions(&thread->rdplog_ctx->cfg, p, f, js, thread->buffer);
     MemBufferReset(thread->buffer);
     OutputJSONBuffer(js, thread->rdplog_ctx->file_ctx, &thread->buffer);
     json_decref(js);
@@ -99,6 +101,7 @@ static OutputInitResult OutputRdpLogInitSub(ConfNode *conf,
         return result;
     }
     rdplog_ctx->file_ctx = ajt->file_ctx;
+    rdplog_ctx->cfg = ajt->cfg;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/output-json-sip.c
+++ b/src/output-json-sip.c
@@ -80,7 +80,7 @@ static int JsonSIPLogger(ThreadVars *tv, void *thread_data,
     if (unlikely(js == NULL)) {
         return TM_ECODE_OK;
     }
-    EveAddCommonOptions(&thread->siplog_ctx->cfg, p, f, js);
+    EveAddCommonOptions(&thread->siplog_ctx->cfg, p, f, js, thread->buffer);
 
     if (!rs_sip_log_json(siptx, js)) {
         goto error;

--- a/src/output-json-smb.c
+++ b/src/output-json-smb.c
@@ -77,6 +77,7 @@ static int JsonSMBLogger(ThreadVars *tv, void *thread_data,
     }
     json_object_set_new(js, "smb", smbjs);
 
+    JsonAddCommonOptions(&thread->ctx->cfg, p, f, js, thread->buffer);
     MemBufferReset(thread->buffer);
     OutputJSONBuffer(js, thread->ctx->file_ctx, &thread->buffer);
 

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -79,7 +79,7 @@ static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     JsonBuilder *jb = CreateEveHeaderWithTxId(p, LOG_DIR_FLOW, "smtp", NULL, tx_id);
     if (unlikely(jb == NULL))
         return TM_ECODE_OK;
-    EveAddCommonOptions(&jhl->emaillog_ctx->cfg, p, f, jb);
+    EveAddCommonOptions(&jhl->emaillog_ctx->cfg, p, f, jb, jhl->buffer);
 
     /* reset */
     MemBufferReset(jhl->buffer);

--- a/src/output-json-snmp.c
+++ b/src/output-json-snmp.c
@@ -71,7 +71,7 @@ static int JsonSNMPLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
-    JsonAddCommonOptions(&thread->snmplog_ctx->cfg, p, f, js);
+    JsonAddCommonOptions(&thread->snmplog_ctx->cfg, p, f, js, thread->buffer);
 
     snmpjs = rs_snmp_log_json_response(state, snmptx);
     if (unlikely(snmpjs == NULL)) {

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -79,7 +79,7 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
     if (unlikely(js == NULL))
         return 0;
 
-    JsonAddCommonOptions(&ssh_ctx->cfg, p, f, js);
+    JsonAddCommonOptions(&ssh_ctx->cfg, p, f, js, aft->buffer);
 
     /* reset */
     MemBufferReset(aft->buffer);

--- a/src/output-json-tftp.c
+++ b/src/output-json-tftp.c
@@ -53,6 +53,7 @@
 typedef struct LogTFTPFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t    flags;
+    OutputJsonCommonSettings cfg;
 } LogTFTPFileCtx;
 
 typedef struct LogTFTPLogThread_ {
@@ -78,6 +79,7 @@ static int JsonTFTPLogger(ThreadVars *tv, void *thread_data,
 
     json_object_set_new(js, "tftp", tftpjs);
 
+    JsonAddCommonOptions(&thread->tftplog_ctx->cfg, p, f, js, thread->buffer);
     MemBufferReset(thread->buffer);
     OutputJSONBuffer(js, thread->tftplog_ctx->file_ctx, &thread->buffer);
 
@@ -107,6 +109,7 @@ static OutputInitResult OutputTFTPLogInitSub(ConfNode *conf,
         return result;
     }
     tftplog_ctx->file_ctx = ajt->file_ctx;
+    tftplog_ctx->cfg = ajt->cfg;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -422,7 +422,8 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         JsonTlsLogJSONCustom(tls_ctx, js, ssl_state);
     }
     /* log extended */
-    else if (tls_ctx->flags & LOG_TLS_EXTENDED) {
+    else if ((tls_ctx->flags & LOG_TLS_EXTENDED) ||
+             OutputJSONNeedFullLog(&aft->tlslog_ctx->cfg, f, tx_id, LOG_TYPE_STRING)) {
         JsonTlsLogJSONExtended(js, ssl_state);
     }
     /* log basic */

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -410,7 +410,7 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         return 0;
     }
 
-    EveAddCommonOptions(&tls_ctx->cfg, p, f, js);
+    EveAddCommonOptions(&tls_ctx->cfg, p, f, js, aft->buffer);
 
     jb_open_object(js, "tls");
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -73,8 +73,10 @@
 #define MODULE_NAME "OutputJSON"
 
 
-#define JSONLOG_JSON_PAYLOAD           BIT_U16(0)
-#define JSONLOG_JSON_PAYLOAD_BASE64    BIT_U16(1)
+#define JSONLOG_JSON_PAYLOAD                    BIT_U16(0)
+#define JSONLOG_JSON_PAYLOAD_BASE64             BIT_U16(1)
+#define JSONLOG_JSON_FULL_ALERTED               BIT_U16(2)
+#define JSONLOG_JSON_FULL_ALERTED_BASE64        BIT_U16(3)
 
 #define MAX_JSON_SIZE 2048
 
@@ -1710,6 +1712,21 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
             json_ctx->cfg.include_streamdata |= JSONLOG_JSON_PAYLOAD;
         }
 
+        /* Check if verbosity of events should be max for alerted flows. */
+        const ConfNode *fulldatap = ConfNodeLookupChild(conf, "full-log-alerted");
+        if (fulldatap && fulldatap->val && !ConfValIsFalse(fulldatap->val)) {
+            SCLogConfig("Enabling full logging for alerted flows.");
+            if (!strcmp(fulldatap->val, "printable")) {
+                json_ctx->cfg.include_streamdata |= JSONLOG_JSON_FULL_ALERTED;
+            }
+            if (!strcmp(fulldatap->val, "base64")) {
+                json_ctx->cfg.include_streamdata |= JSONLOG_JSON_FULL_ALERTED_BASE64;
+            }
+            if (!strcmp(fulldatap->val, "both")) {
+                json_ctx->cfg.include_streamdata |= JSONLOG_JSON_FULL_ALERTED_BASE64|JSONLOG_JSON_FULL_ALERTED;
+            }
+        }
+
         /* Do we have a global eve xff configuration? */
         const ConfNode *xff = ConfNodeLookupChild(conf, "xff");
         if (xff != NULL) {
@@ -1752,4 +1769,27 @@ static void OutputJsonDeInitCtx(OutputCtx *output_ctx)
     LogFileFreeCtx(logfile_ctx);
     SCFree(json_ctx);
     SCFree(output_ctx);
+}
+
+bool OutputJSONNeedFullLog(const OutputJsonCommonSettings *cfg, const Flow *f,
+                           uint64_t tx_id, enum OutputJsonvalueType type)
+{
+    if (FlowHasAlerts(f)) {
+        if (type == LOG_TYPE_BASE64) {
+            if (cfg->include_streamdata & JSONLOG_JSON_FULL_ALERTED_BASE64)
+                return true;
+        }
+        if (type == LOG_TYPE_PRINTABLE) {
+            if (cfg->include_streamdata & JSONLOG_JSON_FULL_ALERTED)
+                return true;
+        }
+        if (type == LOG_TYPE_STRING) {
+            if (cfg->include_streamdata & (JSONLOG_JSON_FULL_ALERTED|JSONLOG_JSON_FULL_ALERTED_BASE64))
+                return true;
+        }
+        return false;
+    } else {
+        return false;
+    }
+    return false;
 }

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -98,6 +98,7 @@ TmEcode JsonLogThreadDeinit(ThreadVars *t, void *data);
 typedef struct OutputJsonCommonSettings_ {
     bool include_metadata;
     bool include_community_id;
+    uint16_t include_streamdata;
     uint16_t community_id_seed;
 } OutputJsonCommonSettings;
 
@@ -122,8 +123,8 @@ json_t *JsonAddStringN(const char *string, size_t size);
 void SCJsonDecref(json_t *js);
 
 void JsonAddCommonOptions(const OutputJsonCommonSettings *cfg,
-        const Packet *p, const Flow *f, json_t *js);
+        const Packet *p, const Flow *f, json_t *js, MemBuffer *payload);
 void EveAddCommonOptions(const OutputJsonCommonSettings *cfg,
-        const Packet *p, const Flow *f, JsonBuilder *js);
+        const Packet *p, const Flow *f, JsonBuilder *js, MemBuffer *payload);
 
 #endif /* __OUTPUT_JSON_H__ */

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -127,4 +127,13 @@ void JsonAddCommonOptions(const OutputJsonCommonSettings *cfg,
 void EveAddCommonOptions(const OutputJsonCommonSettings *cfg,
         const Packet *p, const Flow *f, JsonBuilder *js, MemBuffer *payload);
 
+enum OutputJsonvalueType {
+    LOG_TYPE_BASE64 = 0,
+    LOG_TYPE_PRINTABLE,
+    LOG_TYPE_STRING,
+};
+
+bool OutputJSONNeedFullLog(const OutputJsonCommonSettings *cfg, const Flow *f,
+                           uint64_t tx_id, enum OutputJsonvalueType type);
+
 #endif /* __OUTPUT_JSON_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -108,6 +108,9 @@ outputs:
 
       # Include top level metadata. Default yes.
       #metadata: no
+      # Include stream data in application layer events
+      #stream-data: yes
+      #stream-data-printable: yes
 
       # include the name of the input pcap file in pcap file processing mode
       pcap-file: false

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -111,6 +111,9 @@ outputs:
       # Include stream data in application layer events
       #stream-data: yes
       #stream-data-printable: yes
+      # Full log for alerted flow. Maximize verbosity of event when the flow
+      # has alerts. Disabled by default. Possible value no, printable, base64, both.
+      #full-log-alerted: printable
 
       # include the name of the input pcap file in pcap file processing mode
       pcap-file: false

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -199,6 +199,10 @@ outputs:
             # set this value to one and only one from {both, request, response}
             # to dump all HTTP headers for every HTTP request and/or response
             # dump-all-headers: none
+            # Log request and response bodies with every request. This setup is
+            # recommended for forensic purpose only.
+            #http-body: yes
+            #http-body-printable: yes
         - dns:
             # This configuration uses the new DNS logging format,
             # the old configuration is still available:

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -152,6 +152,7 @@ outputs:
             # metadata: no             # enable inclusion of app layer metadata with alert. Default yes
             # http-body: yes           # Requires metadata; enable dumping of HTTP body in Base64
             # http-body-printable: yes # Requires metadata; enable dumping of HTTP body in printable format
+            # http-headers: yes        # Requires metadata; enable dumping of HTTP headers
 
             # Enable the logging of tagged packets for rules using the
             # "tag" keyword.


### PR DESCRIPTION
This PR is an attempt to improve the generated events. It consists in two main changes:
- more logging in case of alerts
- verbose logging for forensic

Both features are optional and need to be activated in the yaml.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- alert: optional logging of full HTTP headers
- switch events logging to verbose for alerted flows
- forensic mode: stream data logging in most protocols

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/531
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/307