### PR TITLE
jsonbuilder: fix build error

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -473,7 +473,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 
         if (json_output_ctx->flags & LOG_JSON_APP_LAYER && p->flow != NULL) {
             const AppProto proto = FlowGetAppProtocol(p->flow);
-            JsonBuilderMark mark = { 0 };
+            JsonBuilderMark mark = { 0, 0, 0 };
             switch (proto) {
                 case ALPROTO_HTTP:
                     // TODO: Could result in an empty http object being logged.

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -179,7 +179,7 @@ static int JsonEmailAddToJsonArray(const uint8_t *val, size_t len, void *data)
 static void EveEmailLogJSONCustom(OutputJsonEmailCtx *email_ctx, JsonBuilder *js, SMTPTransaction *tx)
 {
     int f = 0;
-    JsonBuilderMark mark = { 0 };
+    JsonBuilderMark mark = { 0, 0, 0 };
     MimeDecField *field;
     MimeDecEntity *entity = tx->msg_tail;
     if (entity == NULL) {
@@ -234,7 +234,7 @@ static bool EveEmailLogJsonData(const Flow *f, void *state, void *vtx, uint64_t 
     SMTPState *smtp_state;
     MimeDecParseState *mime_state;
     MimeDecEntity *entity;
-    JsonBuilderMark mark = { 0 };
+    JsonBuilderMark mark = { 0, 0, 0 };
 
     /* check if we have SMTP state or not */
     AppProto proto = FlowGetAppProtocol(f);
@@ -365,7 +365,7 @@ TmEcode EveEmailLogJson(JsonEmailLogThread *aft, JsonBuilder *js, const Packet *
 {
     OutputJsonEmailCtx *email_ctx = aft->emaillog_ctx;
     SMTPTransaction *tx = (SMTPTransaction *) vtx;
-    JsonBuilderMark mark = { 0 };
+    JsonBuilderMark mark = { 0, 0, 0 };
 
     jb_get_mark(js, &mark);
     jb_open_object(js, "email");

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -122,7 +122,7 @@ JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
     if (unlikely(js == NULL))
         return NULL;
 
-    JsonBuilderMark mark = { 0 };
+    JsonBuilderMark mark = { 0, 0, 0 };
     switch (p->flow->alproto) {
         case ALPROTO_HTTP:
             jb_open_object(js, "http");


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
Clang's build in travis-ci is actually failing because of this error:

```
output-json-alert.c:476:40: error: missing field 'state_index' initializer [-Werror,-Wmissing-field-initializers]

JsonBuilderMark mark = { 0 };
```

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- https://buildbot.openinfosecfoundation.org/builders/glongo/builds/224
- https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/88