### PR TITLE
detect-dsize: Add ! operator for dsize matching

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -289,7 +289,7 @@ overflows.
 
 Format::
 
-  dsize:<number>;
+  dsize:[<>!]number; || dsize:min<>max;
 
 Example of dsize in a rule:
 

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -44,9 +44,9 @@
 #include "util-profiling.h"
 
 /**
- *  dsize:[<>]<0-65535>[<><0-65535>];
+ *  dsize:[<>!]<0-65535>[<><0-65535>];
  */
-#define PARSE_REGEX "^\\s*(<|>)?\\s*([0-9]{1,5})\\s*(?:(<>)\\s*([0-9]{1,5}))?\\s*$"
+#define PARSE_REGEX "^\\s*(<|>|!)?\\s*([0-9]{1,5})\\s*(?:(<>)\\s*([0-9]{1,5}))?\\s*$"
 static DetectParseRegex parse_regex;
 
 static int DetectDsizeMatch (DetectEngineThreadCtx *, Packet *,
@@ -82,6 +82,8 @@ DsizeMatch(const uint16_t psize, const uint8_t mode,
             const uint16_t dsize, const uint16_t dsize2)
 {
     if (mode == DETECTDSIZE_EQ && dsize == psize)
+        return 1;
+    else if (mode == DETECTDSIZE_NE && dsize != psize)
         return 1;
     else if (mode == DETECTDSIZE_LT && psize < dsize)
         return 1;
@@ -187,16 +189,7 @@ static DetectDsizeData *DetectDsizeParse (const char *rawstr)
         goto error;
     dd->dsize = 0;
     dd->dsize2 = 0;
-    dd->mode = DETECTDSIZE_EQ; // default
-
-    if (strlen(mode) > 0) {
-        if (mode[0] == '<')
-            dd->mode = DETECTDSIZE_LT;
-        else if (mode[0] == '>')
-            dd->mode = DETECTDSIZE_GT;
-        else
-            dd->mode = DETECTDSIZE_EQ;
-    }
+    dd->mode = 0;
 
     if (strcmp("<>", range) == 0) {
         if (strlen(mode) != 0) {
@@ -204,6 +197,17 @@ static DetectDsizeData *DetectDsizeParse (const char *rawstr)
             goto error;
         }
         dd->mode = DETECTDSIZE_RA;
+    } else if (strlen(mode) > 0) {
+        if (mode[0] == '<')
+            dd->mode = DETECTDSIZE_LT;
+        else if (mode[0] == '>')
+            dd->mode = DETECTDSIZE_GT;
+        else if (mode[0] == '!')
+            dd->mode = DETECTDSIZE_NE;
+        else
+            dd->mode = DETECTDSIZE_EQ;
+    } else {
+        dd->mode = DETECTDSIZE_EQ; // default
     }
 
     /** set the first dsize value */
@@ -384,6 +388,7 @@ int SigParseGetMaxDsize(const Signature *s)
         switch (dd->mode) {
             case DETECTDSIZE_LT:
             case DETECTDSIZE_EQ:
+            case DETECTDSIZE_NE:
                 return dd->dsize;
             case DETECTDSIZE_RA:
                 return dd->dsize2;
@@ -412,6 +417,7 @@ void SigParseSetDsizePair(Signature *s)
                 high = dd->dsize;
                 break;
             case DETECTDSIZE_EQ:
+            case DETECTDSIZE_NE:
                 low = dd->dsize;
                 high = dd->dsize;
                 break;
@@ -424,10 +430,11 @@ void SigParseSetDsizePair(Signature *s)
                 high = 65535;
                 break;
         }
+        s->dsize_mode = dd->mode;
         s->dsize_low = low;
         s->dsize_high = high;
 
-        SCLogDebug("low %u, high %u", low, high);
+        SCLogDebug("low %u, high %u, mode %u", low, high, dd->mode);
     }
 }
 
@@ -863,6 +870,96 @@ static int DsizeTestParse20 (void)
 }
 
 /**
+ * \test this is a test for a valid dsize value !1
+ *
+ *  \retval 1 on succces
+ *  \retval 0 on failure
+ */
+static int DsizeTestParse21 (void)
+{
+    DetectDsizeData *dd = NULL;
+    dd = DetectDsizeParse("!1");
+    if (dd) {
+        DetectDsizeFree(NULL, dd);
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
+ * \test this is a test for a valid dsize value ! 1
+ *
+ *  \retval 1 on succces
+ *  \retval 0 on failure
+ */
+static int DsizeTestParse22 (void)
+{
+    DetectDsizeData *dd = NULL;
+    dd = DetectDsizeParse("! 1");
+    if (dd) {
+        DetectDsizeFree(NULL, dd);
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
+ * \test this is a test for a invalid dsize value 1!
+ *
+ *  \retval 1 on succces
+ *  \retval 0 on failure
+ */
+static int DsizeTestParse23 (void)
+{
+    DetectDsizeData *dd = NULL;
+    dd = DetectDsizeParse("1!");
+    if (dd) {
+        DetectDsizeFree(NULL, dd);
+        return 0;
+    }
+
+    return 1;
+}
+
+/**
+ * \test this is a test for positive ! dsize matching
+ *
+ *  \retval 1 on succces
+ *  \retval 0 on failure
+ */
+static int DsizeTestMatch01 (void)
+{
+    uint16_t psize = 1;
+    uint16_t dsizelow = 2;
+    uint16_t dsizehigh = 0;
+    int result = 0;
+
+    result = DsizeMatch(psize, DETECTDSIZE_NE, dsizelow, dsizehigh);
+
+    return result;
+}
+
+/**
+ * \test this is a test for negative ! dsize matching
+ *
+ *  \retval 1 on succces
+ *  \retval 0 on failure
+ */
+static int DsizeTestMatch02 (void)
+{
+    uint16_t psize = 1;
+    uint16_t dsizelow = 1;
+    uint16_t dsizehigh = 0;
+    int result = 0;
+
+    result = !DsizeMatch(psize, DETECTDSIZE_NE, dsizelow, dsizehigh);
+
+    return result;
+}
+
+/**
  * \test DetectDsizeIcmpv6Test01 is a test for checking the working of
  *       dsize keyword by creating 2 rules and matching a crafted packet
  *       against them. Only the first one shall trigger.
@@ -982,6 +1079,11 @@ static void DsizeRegisterTests(void)
     UtRegisterTest("DsizeTestParse18", DsizeTestParse18);
     UtRegisterTest("DsizeTestParse19", DsizeTestParse19);
     UtRegisterTest("DsizeTestParse20", DsizeTestParse20);
+    UtRegisterTest("DsizeTestParse21", DsizeTestParse21);
+    UtRegisterTest("DsizeTestParse22", DsizeTestParse22);
+    UtRegisterTest("DsizeTestParse23", DsizeTestParse23);
+    UtRegisterTest("DsizeTestMatch01", DsizeTestMatch01);
+    UtRegisterTest("DsizeTestMatch02", DsizeTestMatch02);
 
     UtRegisterTest("DetectDsizeIcmpv6Test01", DetectDsizeIcmpv6Test01);
 #endif /* UNITTESTS */

--- a/src/detect-dsize.h
+++ b/src/detect-dsize.h
@@ -28,6 +28,7 @@
 #define DETECTDSIZE_EQ 1
 #define DETECTDSIZE_GT 2
 #define DETECTDSIZE_RA 3
+#define DETECTDSIZE_NE 4
 
 typedef struct DetectDsizeData_ {
     uint16_t dsize;

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -532,26 +532,24 @@ static int SignatureCreateMask(Signature *s)
             case DETECT_DSIZE:
             {
                 DetectDsizeData *ds = (DetectDsizeData *)sm->ctx;
-                switch (ds->mode) {
-                    case DETECTDSIZE_LT:
-                        /* LT will include 0, so no payload.
-                         * if GT is used in the same rule the
-                         * flag will be set anyway. */
-                        break;
-                    case DETECTDSIZE_RA:
-                    case DETECTDSIZE_GT:
+                    /* LT will include 0, so no payload.
+                     * if GT is used in the same rule the
+                     * flag will be set anyway. */
+                if (ds->mode == DETECTDSIZE_RA ||
+                    ds ->mode == DETECTDSIZE_GT ||
+                    ds ->mode == DETECTDSIZE_NE) {
+
+                    s->mask |= SIG_MASK_REQUIRE_PAYLOAD;
+                    SCLogDebug("sig requires payload");
+
+                } else if (ds->mode == DETECTDSIZE_EQ) {
+                    if (ds->dsize > 0) {
                         s->mask |= SIG_MASK_REQUIRE_PAYLOAD;
                         SCLogDebug("sig requires payload");
-                        break;
-                    case DETECTDSIZE_EQ:
-                        if (ds->dsize > 0) {
-                            s->mask |= SIG_MASK_REQUIRE_PAYLOAD;
-                            SCLogDebug("sig requires payload");
-                        } else if (ds->dsize == 0) {
-                            s->mask |= SIG_MASK_REQUIRE_NO_PAYLOAD;
-                            SCLogDebug("sig requires no payload");
-                        }
-                        break;
+                        } else {
+                        s->mask |= SIG_MASK_REQUIRE_NO_PAYLOAD;
+                        SCLogDebug("sig requires no payload");
+                    }
                 }
                 break;
             }

--- a/src/detect.c
+++ b/src/detect.c
@@ -34,6 +34,7 @@
 #include "app-layer-parser.h"
 
 #include "detect.h"
+#include "detect-dsize.h"
 #include "detect-engine.h"
 #include "detect-engine-profile.h"
 
@@ -766,9 +767,11 @@ static inline void DetectRulePacketRules(
 
         if (unlikely(sflags & SIG_FLAG_DSIZE)) {
             if (likely(p->payload_len < s->dsize_low || p->payload_len > s->dsize_high)) {
-                SCLogDebug("kicked out as p->payload_len %u, dsize low %u, hi %u",
-                        p->payload_len, s->dsize_low, s->dsize_high);
-                goto next;
+                if (!(s->dsize_mode == DETECTDSIZE_NE)) {
+                    SCLogDebug("kicked out as p->payload_len %u, dsize low %u, hi %u",
+                            p->payload_len, s->dsize_low, s->dsize_high);
+                    goto next;
+                }
             }
         }
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -527,6 +527,7 @@ typedef struct Signature_ {
 
     uint16_t dsize_low;
     uint16_t dsize_high;
+    uint8_t dsize_mode;
 
     SignatureMask mask;
     SigIntId num; /**< signature number, internal id */


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2538

Describe changes:
- Addressing the first request from the above ticket: added ! operator to dsize keyword allowing a user to match != values (e.g. dsize:!100;)
- Unit tests added for parsing and matching with ! operator.
- Requires some discussion: There is another approach to this that allows the combination of multiple dsize values and operators that satisfies the second request in the ticket i.e. "dsize:![100,150];". The approach involves changing to flags instead of a dsize mode and adding checks that could possibly reduce performance in detect.c. Is this something the Suricata devs would be interested in seeing?