### PR TITLE
output: Improve protocol output handling

### DIFF
--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -126,10 +126,12 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)
     char alert_buffer[MAX_FASTLOG_BUFFER_SIZE];
 
     char proto[16] = "";
-    if (SCProtoNameValid(IP_GET_IPPROTO(p)) == TRUE) {
-        strlcpy(proto, known_proto[IP_GET_IPPROTO(p)], sizeof(proto));
+    char *protoptr;
+    if (SCProtoNameValid(IP_GET_IPPROTO(p))) {
+        protoptr = known_proto[IP_GET_IPPROTO(p)];
     } else {
         snprintf(proto, sizeof(proto), "PROTO:%03" PRIu32, IP_GET_IPPROTO(p));
+        protoptr = proto;
     }
     uint16_t src_port_or_icmp = p->sp;
     uint16_t dst_port_or_icmp = p->dp;
@@ -158,7 +160,7 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)
                             PRIu32 "] %s [**] [Classification: %s] [Priority: %"PRIu32"]"
                             " {%s} %s:%" PRIu32 " -> %s:%" PRIu32 "\n", timebuf, action,
                             pa->s->gid, pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
-                            proto, srcip, src_port_or_icmp, dstip, dst_port_or_icmp);
+                            protoptr, srcip, src_port_or_icmp, dstip, dst_port_or_icmp);
         } else {
             PrintBufferData(alert_buffer, &size, MAX_FASTLOG_ALERT_SIZE, 
                             "%s  %s[**] [%" PRIu32 ":%" PRIu32

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -209,6 +209,15 @@ static TmEcode AlertSyslogIPv4(ThreadVars *tv, const Packet *p, void *data)
     if (p->alerts.cnt == 0)
         return TM_ECODE_OK;
 
+    char proto[16] = "";
+    char *protoptr;
+    if (SCProtoNameValid(IPV4_GET_IPPROTO(p))) {
+        protoptr = known_proto[IPV4_GET_IPPROTO(p)];
+    } else {
+        snprintf(proto, sizeof(proto), "PROTO:%03" PRIu32, IPV4_GET_IPPROTO(p));
+        protoptr = proto;
+    }
+
     /* Not sure if this mutex is needed around calls to syslog. */
     SCMutexLock(&ast->file_ctx->fp_mutex);
 
@@ -229,19 +238,11 @@ static TmEcode AlertSyslogIPv4(ThreadVars *tv, const Packet *p, void *data)
             action = "[wDrop] ";
         }
 
-        if (SCProtoNameValid(IPV4_GET_IPPROTO(p)) == TRUE) {
-            syslog(alert_syslog_level, "%s[%" PRIu32 ":%" PRIu32 ":%"
-                    PRIu32 "] %s [Classification: %s] [Priority: %"PRIu32"]"
-                    " {%s} %s:%" PRIu32 " -> %s:%" PRIu32 "", action, pa->s->gid,
-                    pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
-                    known_proto[IPV4_GET_IPPROTO(p)], srcip, p->sp, dstip, p->dp);
-        } else {
-            syslog(alert_syslog_level, "%s[%" PRIu32 ":%" PRIu32 ":%"
-                    PRIu32 "] %s [Classification: %s] [Priority: %"PRIu32"]"
-                    " {PROTO:%03" PRIu32 "} %s:%" PRIu32 " -> %s:%" PRIu32 "",
-                    action, pa->s->gid, pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg,
-                    pa->s->prio, IPV4_GET_IPPROTO(p), srcip, p->sp, dstip, p->dp);
-        }
+        syslog(alert_syslog_level, "%s[%" PRIu32 ":%" PRIu32 ":%"
+                PRIu32 "] %s [Classification: %s] [Priority: %"PRIu32"]"
+                " {%s} %s:%" PRIu32 " -> %s:%" PRIu32 "", action, pa->s->gid,
+                pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio,
+                protoptr,  srcip, p->sp, dstip, p->dp);
     }
     SCMutexUnlock(&ast->file_ctx->fp_mutex);
 
@@ -266,6 +267,15 @@ static TmEcode AlertSyslogIPv6(ThreadVars *tv, const Packet *p, void *data)
     if (p->alerts.cnt == 0)
         return TM_ECODE_OK;
 
+    char proto[16] = "";
+    char *protoptr;
+    if (SCProtoNameValid(IPV6_GET_L4PROTO(p))) {
+        protoptr = known_proto[IPV6_GET_L4PROTO(p)];
+    } else {
+        snprintf(proto, sizeof(proto), "PROTO:03%" PRIu32, IPV6_GET_L4PROTO(p));
+        protoptr = proto;
+    }
+
     SCMutexLock(&ast->file_ctx->fp_mutex);
 
     for (i = 0; i < p->alerts.cnt; i++) {
@@ -285,21 +295,12 @@ static TmEcode AlertSyslogIPv6(ThreadVars *tv, const Packet *p, void *data)
             action = "[wDrop] ";
         }
 
-        if (SCProtoNameValid(IPV6_GET_L4PROTO(p)) == TRUE) {
-            syslog(alert_syslog_level, "%s[%" PRIu32 ":%" PRIu32 ":%"
-                    "" PRIu32 "] %s [Classification: %s] [Priority: %"
-                    "" PRIu32 "] {%s} %s:%" PRIu32 " -> %s:%" PRIu32 "",
-                    action, pa->s->gid, pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg,
-                    pa->s->prio, known_proto[IPV6_GET_L4PROTO(p)], srcip, p->sp,
-                    dstip, p->dp);
-
-        } else {
-            syslog(alert_syslog_level, "%s[%" PRIu32 ":%" PRIu32 ":%"
-                    "" PRIu32 "] %s [Classification: %s] [Priority: %"
-                    "" PRIu32 "] {PROTO:%03" PRIu32 "} %s:%" PRIu32 " -> %s:%" PRIu32 "",
-                    action, pa->s->gid, pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg,
-                    pa->s->prio, IPV6_GET_L4PROTO(p), srcip, p->sp, dstip, p->dp);
-        }
+        syslog(alert_syslog_level, "%s[%" PRIu32 ":%" PRIu32 ":%"
+                "" PRIu32 "] %s [Classification: %s] [Priority: %"
+                "" PRIu32 "] {%s} %s:%" PRIu32 " -> %s:%" PRIu32 "",
+                action, pa->s->gid, pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg,
+                pa->s->prio, protoptr, srcip, p->sp,
+                dstip, p->dp);
 
     }
     SCMutexUnlock(&ast->file_ctx->fp_mutex);

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -101,13 +101,6 @@ static JsonBuilder *CreateEveHeaderFromFlow(const Flow *f, const char *event_typ
         dp = f->sp;
     }
 
-    char proto[16];
-    if (SCProtoNameValid(f->proto) == TRUE) {
-        strlcpy(proto, known_proto[f->proto], sizeof(proto));
-    } else {
-        snprintf(proto, sizeof(proto), "%03" PRIu32, f->proto);
-    }
-
     /* time */
     jb_set_string(jb, "timestamp", timebuf);
 
@@ -159,7 +152,13 @@ static JsonBuilder *CreateEveHeaderFromFlow(const Flow *f, const char *event_typ
             jb_set_uint(jb, "dest_port", dp);
             break;
     }
-    jb_set_string(jb, "proto", proto);
+
+    if (SCProtoNameValid(f->proto)) {
+        jb_set_string(jb, "proto", known_proto[f->proto]);
+    } else {
+        jb_set_uint(jb, "proto", f->proto);
+    }
+
     switch (f->proto) {
         case IPPROTO_ICMP:
         case IPPROTO_ICMPV6:

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Open Information Security Foundation
+/* Copyright (C) 2014-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -107,13 +107,6 @@ static json_t *CreateJSONHeaderFromFlow(const Flow *f, const char *event_type, i
         dp = f->sp;
     }
 
-    char proto[16];
-    if (SCProtoNameValid(f->proto) == TRUE) {
-        strlcpy(proto, known_proto[f->proto], sizeof(proto));
-    } else {
-        snprintf(proto, sizeof(proto), "%03" PRIu32, f->proto);
-    }
-
     /* time */
     json_object_set_new(js, "timestamp", json_string(timebuf));
 
@@ -165,7 +158,12 @@ static json_t *CreateJSONHeaderFromFlow(const Flow *f, const char *event_type, i
             json_object_set_new(js, "dest_port", json_integer(dp));
             break;
     }
-    json_object_set_new(js, "proto", json_string(proto));
+    if (SCProtoNameValid(f->proto)) {
+        json_object_set_new(js, "proto", json_string(known_proto[f->proto]));
+    } else {
+        json_object_set_new(js, "proto", json_integer(f->proto));
+    }
+
     switch (f->proto) {
         case IPPROTO_ICMP:
         case IPPROTO_ICMPV6: {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -721,7 +721,6 @@ void JsonAddrInfoInit(const Packet *p, enum OutputJsonLogDirection dir, JsonAddr
 {
     char srcip[46] = {0}, dstip[46] = {0};
     Port sp, dp;
-    char proto[16];
 
     switch (dir) {
         case LOG_DIR_PACKET:
@@ -810,11 +809,6 @@ void JsonAddrInfoInit(const Packet *p, enum OutputJsonLogDirection dir, JsonAddr
             return;
     }
 
-    if (SCProtoNameValid(IP_GET_IPPROTO(p)) == TRUE) {
-        strlcpy(proto, known_proto[IP_GET_IPPROTO(p)], sizeof(proto));
-    } else {
-        snprintf(proto, sizeof(proto), "%03" PRIu32, IP_GET_IPPROTO(p));
-    }
 
     strlcpy(addr->src_ip, srcip, JSON_ADDR_LEN);
 
@@ -840,7 +834,11 @@ void JsonAddrInfoInit(const Packet *p, enum OutputJsonLogDirection dir, JsonAddr
             break;
     }
 
-    strlcpy(addr->proto, proto, JSON_PROTO_LEN);
+    if (SCProtoNameValid(IP_GET_IPPROTO(p))) {
+        strlcpy(addr->proto, known_proto[IP_GET_IPPROTO(p)], sizeof(addr->proto));
+    } else {
+        snprintf(addr->proto, sizeof(addr->proto), "%" PRIu32, IP_GET_IPPROTO(p));
+    }
 }
 
 /**
@@ -854,7 +852,6 @@ void JsonFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, json_t *js)
 {
     char srcip[46] = {0}, dstip[46] = {0};
     Port sp, dp;
-    char proto[16];
 
     switch (dir) {
         case LOG_DIR_PACKET:
@@ -943,11 +940,6 @@ void JsonFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, json_t *js)
             return;
     }
 
-    if (SCProtoNameValid(IP_GET_IPPROTO(p)) == TRUE) {
-        strlcpy(proto, known_proto[IP_GET_IPPROTO(p)], sizeof(proto));
-    } else {
-        snprintf(proto, sizeof(proto), "%03" PRIu32, IP_GET_IPPROTO(p));
-    }
 
     json_object_set_new(js, "src_ip", json_string(srcip));
 
@@ -973,7 +965,11 @@ void JsonFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, json_t *js)
             break;
     }
 
-    json_object_set_new(js, "proto", json_string(proto));
+    if (SCProtoNameValid(IP_GET_IPPROTO(p))) {
+        json_object_set_new(js, "proto", json_string(known_proto[IP_GET_IPPROTO(p)]));
+    } else {
+        json_object_set_new(js, "proto", json_integer(IP_GET_IPPROTO(p)));
+    }
 }
 
 #define COMMUNITY_ID_BUF_SIZE 64

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Open Information Security Foundation
+/* Copyright (C) 2014-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -195,13 +195,6 @@ static int LuaPacketLoggerAlerts(ThreadVars *tv, void *thread_data, const Packet
         goto not_supported;
     }
 
-    char proto[16] = "";
-    if (SCProtoNameValid(IP_GET_IPPROTO(p)) == TRUE) {
-        strlcpy(proto, known_proto[IP_GET_IPPROTO(p)], sizeof(proto));
-    } else {
-        snprintf(proto, sizeof(proto), "PROTO:%03" PRIu32, IP_GET_IPPROTO(p));
-    }
-
     /* loop through alerts stored in the packet */
     SCMutexLock(&td->lua_ctx->m);
     uint16_t cnt;
@@ -265,13 +258,6 @@ static int LuaPacketLogger(ThreadVars *tv, void *thread_data, const Packet *p)
     }
 
     CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
-
-    char proto[16] = "";
-    if (SCProtoNameValid(IP_GET_IPPROTO(p)) == TRUE) {
-        strlcpy(proto, known_proto[IP_GET_IPPROTO(p)], sizeof(proto));
-    } else {
-        snprintf(proto, sizeof(proto), "PROTO:%03" PRIu32, IP_GET_IPPROTO(p));
-    }
 
     /* loop through alerts stored in the packet */
     SCMutexLock(&td->lua_ctx->m);

--- a/src/util-proto-name.c
+++ b/src/util-proto-name.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -92,17 +92,11 @@ void SCProtoNameInit()
  *          we have corresponding name entry for this number or not.
  *
  * \param proto Protocol number to be validated
- * \retval ret On success returns TRUE otherwise FALSE
+ * \retval ret On success returns true otherwise false
  */
-uint8_t SCProtoNameValid(uint16_t proto)
+bool SCProtoNameValid(uint16_t proto)
 {
-    uint8_t ret = FALSE;
-
-    if (proto <= 255 && known_proto[proto] != NULL) {
-        ret = TRUE;
-    }
-
-    return ret;
+    return (proto <= 255 && known_proto[proto] != NULL);
 }
 
 /**

--- a/src/util-proto-name.h
+++ b/src/util-proto-name.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -34,7 +34,7 @@
  *  in /etc/protocols */
 extern char *known_proto[256];
 
-uint8_t SCProtoNameValid(uint16_t);
+bool SCProtoNameValid(uint16_t);
 void SCProtoNameInit(void);
 void SCProtoNameDeInit(void);
 


### PR DESCRIPTION
Continuation of #5019

This PR improves the output of unknown protocol values. Values that were zero-padded will no longer have leading 0's, e.g., `006` becomes `6`.

For compatibility no output changes are made to the fast nor syslog outputs.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Address review comments -- copy avoidance.
