### PR TITLE
detect/byte_jump: Implement "from_end" option

### DIFF
--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -90,7 +90,7 @@ void DetectBytejumpRegister (void)
  */
 int DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
                           const SigMatchCtx *ctx, const uint8_t *payload, uint32_t payload_len,
-                          uint8_t flags, int32_t offset)
+                          uint16_t flags, int32_t offset)
 {
     SCEnter();
 

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -726,7 +726,7 @@ static int DetectBytejumpTestParse03(void)
  * \test DetectBytejumpTestParse04 is a test for setting the optional flags
  *       with parameters
  *
- * \todo This fails becuase we can only have 9 captures and there are 10.
+ * \todo This fails because we can only have 9 captures and there are 10.
  */
 static int DetectBytejumpTestParse04(void)
 {

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -168,8 +168,10 @@ int DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
     if (flags & DETECT_BYTEJUMP_BEGIN) {
         jumpptr = payload + val;
         //printf("NEWVAL: payload %p + %ld = %p\n", p->payload, val, jumpptr);
-    }
-    else {
+    } else if (flags & DETECT_BYTEJUMP_END) {
+        jumpptr = payload + payload_len + val;
+        //printf("NEWVAL: payload %p + %ld = %p\n", p->payload, val, jumpptr);
+    } else {
         val += extbytes;
         jumpptr = ptr + val;
         //printf("NEWVAL: ptr %p + %ld = %p\n", ptr, val, jumpptr);
@@ -435,6 +437,8 @@ static DetectBytejumpData *DetectBytejumpParse(DetectEngineCtx *de_ctx, const ch
             data->flags |= DETECT_BYTEJUMP_LITTLE;
         } else if (strcasecmp("from_beginning", args[i]) == 0) {
             data->flags |= DETECT_BYTEJUMP_BEGIN;
+        } else if (strcasecmp("from_end", args[i]) == 0) {
+            data->flags |= DETECT_BYTEJUMP_END;
         } else if (strcasecmp("align", args[i]) == 0) {
             data->flags |= DETECT_BYTEJUMP_ALIGN;
         } else if (strncasecmp("multiplier ", args[i], 11) == 0) {
@@ -459,6 +463,12 @@ static DetectBytejumpData *DetectBytejumpParse(DetectEngineCtx *de_ctx, const ch
             SCLogError(SC_ERR_INVALID_VALUE, "Unknown option: \"%s\"", args[i]);
             goto error;
         }
+    }
+
+    if ((data->flags & DETECT_BYTEJUMP_END) && (data->flags & DETECT_BYTEJUMP_BEGIN)) {
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "'from_end' and 'from_beginning' "
+                "cannot be used in the same byte_jump statement");
+        goto error;
     }
 
     if (data->flags & DETECT_BYTEJUMP_STRING) {
@@ -566,6 +576,7 @@ static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char
             (data->flags & DETECT_BYTEJUMP_LITTLE) ||
             (data->flags & DETECT_BYTEJUMP_BIG) ||
             (data->flags & DETECT_BYTEJUMP_BEGIN) ||
+            (data->flags & DETECT_BYTEJUMP_END) ||
             (data->base == DETECT_BYTEJUMP_BASE_DEC) ||
             (data->base == DETECT_BYTEJUMP_BASE_HEX) ||
             (data->base == DETECT_BYTEJUMP_BASE_OCT) ) {
@@ -579,7 +590,7 @@ static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(offset, s);
         if (bed_sm == NULL) {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "Unknown byte_extract var "
-                       "seen in byte_jump - %s\n", offset);
+                       "seen in byte_jump - %s", offset);
             goto error;
         }
         data->offset = ((DetectByteExtractData *)bed_sm->ctx)->local_id;
@@ -1094,6 +1105,29 @@ static int DetectBytejumpTestParse12(void)
     return result;
 }
 
+static int DetectBytejumpTestParse13(void)
+{
+    DetectBytejumpData *data = DetectBytejumpParse(NULL,
+            " 4,0 , relative , little, string, dec, " "align, from_end", NULL);
+    FAIL_IF_NULL(data);
+    FAIL_IF_NOT(data->flags & DETECT_BYTEJUMP_END);
+
+    DetectBytejumpFree(NULL, data);
+
+    PASS;
+}
+
+static int DetectBytejumpTestParse14(void)
+{
+    DetectBytejumpData *data = DetectBytejumpParse(NULL,
+            " 4,0 , relative , little, string, dec, "
+            "align, from_beginning, from_end", NULL);
+
+    FAIL_IF_NOT_NULL(data);
+
+    PASS;
+}
+
 /**
  * \test DetectByteJumpTestPacket01 is a test to check matches of
  * byte_jump and byte_jump relative works if the previous keyword is pcre
@@ -1283,6 +1317,27 @@ end:
     return result;
 }
 
+/**
+ * \test check matches of with from_end
+ */
+static int DetectByteJumpTestPacket08 (void)
+{
+    uint8_t *buf = (uint8_t *)"XX04abcdABCD";
+    uint16_t buflen = strlen((char *)buf);
+    Packet *p = UTHBuildPacket((uint8_t *)buf, buflen, IPPROTO_TCP);
+
+    FAIL_IF_NULL(p);
+
+    char sig[] = "alert tcp any any -> any any (content:\"XX\"; byte_jump:2,0,"
+        "relative,string,dec,from_end, post_offset -8; content:\"ABCD\";  sid:1; rev:1;)";
+
+    FAIL_IF_NOT(UTHPacketMatchSig(p, sig));
+
+    UTHFreePacket(p);
+
+    PASS;
+}
+
 #endif /* UNITTESTS */
 
 
@@ -1307,6 +1362,8 @@ static void DetectBytejumpRegisterTests(void)
     UtRegisterTest("DetectBytejumpTestParse10", DetectBytejumpTestParse10);
     UtRegisterTest("DetectBytejumpTestParse11", DetectBytejumpTestParse11);
     UtRegisterTest("DetectBytejumpTestParse12", DetectBytejumpTestParse12);
+    UtRegisterTest("DetectBytejumpTestParse13", DetectBytejumpTestParse13);
+    UtRegisterTest("DetectBytejumpTestParse14", DetectBytejumpTestParse14);
 
     UtRegisterTest("DetectByteJumpTestPacket01", DetectByteJumpTestPacket01);
     UtRegisterTest("DetectByteJumpTestPacket02", DetectByteJumpTestPacket02);
@@ -1315,6 +1372,7 @@ static void DetectBytejumpRegisterTests(void)
     UtRegisterTest("DetectByteJumpTestPacket05", DetectByteJumpTestPacket05);
     UtRegisterTest("DetectByteJumpTestPacket06", DetectByteJumpTestPacket06);
     UtRegisterTest("DetectByteJumpTestPacket07", DetectByteJumpTestPacket07);
+    UtRegisterTest("DetectByteJumpTestPacket08", DetectByteJumpTestPacket08);
 #endif /* UNITTESTS */
 }
 

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -153,7 +153,7 @@ int DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
         }
     }
 
-    //printf("VAL: (%" PRIu64 " x %" PRIu32 ") + %d + %" PRId32 "\n", val, data->multiplier, extbytes, data->post_offset);
+    SCLogDebug("VAL: (%" PRIu64 " x %" PRIu32 ") + %d + %" PRId32, val, data->multiplier, extbytes, data->post_offset);
 
     /* Adjust the jump value based on flags */
     val *= data->multiplier;
@@ -167,14 +167,14 @@ int DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
     /* Calculate the jump location */
     if (flags & DETECT_BYTEJUMP_BEGIN) {
         jumpptr = payload + val;
-        //printf("NEWVAL: payload %p + %ld = %p\n", p->payload, val, jumpptr);
+        SCLogDebug("NEWVAL: payload %p + %" PRIu64 "= %p", payload, val, jumpptr);
     } else if (flags & DETECT_BYTEJUMP_END) {
         jumpptr = payload + payload_len + val;
-        //printf("NEWVAL: payload %p + %ld = %p\n", p->payload, val, jumpptr);
+        SCLogDebug("NEWVAL: payload %p + %" PRIu32 " - %" PRIu64 " = %p", payload, payload_len, val, jumpptr);
     } else {
         val += extbytes;
         jumpptr = ptr + val;
-        //printf("NEWVAL: ptr %p + %ld = %p\n", ptr, val, jumpptr);
+        SCLogDebug("NEWVAL: ptr %p + %" PRIu64 " = %p", ptr, val, jumpptr);
     }
 
 

--- a/src/detect-bytejump.h
+++ b/src/detect-bytejump.h
@@ -39,11 +39,12 @@
 #define DETECT_BYTEJUMP_ALIGN    0x20 /**< "align" offset */
 #define DETECT_BYTEJUMP_DCE      0x40 /**< "dce" enabled */
 #define DETECT_BYTEJUMP_OFFSET_BE 0x80 /**< "byte extract" enabled */
+#define DETECT_BYTEJUMP_END      0x100 /**< "from_end" jump */
 
 typedef struct DetectBytejumpData_ {
     uint8_t nbytes;                   /**< Number of bytes to compare */
     uint8_t base;                     /**< String value base (oct|dec|hex) */
-    uint8_t flags;                    /**< Flags (big|little|relative|string) */
+    uint16_t flags;                    /**< Flags (big|little|relative|string) */
     uint32_t multiplier;              /**< Multiplier for nbytes (multiplier n)*/
     int32_t offset;                   /**< Offset in payload to extract value */
     int32_t post_offset;              /**< Offset to adjust post-jump */

--- a/src/detect-bytejump.h
+++ b/src/detect-bytejump.h
@@ -77,7 +77,7 @@ void DetectBytejumpRegister (void);
  *       error as a match.
  */
 int DetectBytejumpDoMatch(DetectEngineThreadCtx *, const Signature *, const SigMatchCtx *,
-                          const uint8_t *, uint32_t, uint8_t, int32_t);
+                          const uint8_t *, uint32_t, uint16_t, int32_t);
 
 #endif /* __DETECT_BYTEJUMP_H__ */
 

--- a/src/detect-bytejump.h
+++ b/src/detect-bytejump.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -31,20 +31,20 @@
 #define DETECT_BYTEJUMP_BASE_HEX   16 /**< "hex" type value string */
 
 /** Bytejump Flags */
-#define DETECT_BYTEJUMP_BEGIN    0x01 /**< "from_beginning" jump */
-#define DETECT_BYTEJUMP_LITTLE   0x02 /**< "little" endian value */
-#define DETECT_BYTEJUMP_BIG      0x04 /**< "big" endian value */
-#define DETECT_BYTEJUMP_STRING   0x08 /**< "string" value */
-#define DETECT_BYTEJUMP_RELATIVE 0x10 /**< "relative" offset */
-#define DETECT_BYTEJUMP_ALIGN    0x20 /**< "align" offset */
-#define DETECT_BYTEJUMP_DCE      0x40 /**< "dce" enabled */
-#define DETECT_BYTEJUMP_OFFSET_BE 0x80 /**< "byte extract" enabled */
-#define DETECT_BYTEJUMP_END      0x100 /**< "from_end" jump */
+#define DETECT_BYTEJUMP_BEGIN     BIT_U16(0) /**< "from_beginning" jump */
+#define DETECT_BYTEJUMP_LITTLE    BIT_U16(1) /**< "little" endian value */
+#define DETECT_BYTEJUMP_BIG       BIT_U16(2) /**< "big" endian value */
+#define DETECT_BYTEJUMP_STRING    BIT_U16(3) /**< "string" value */
+#define DETECT_BYTEJUMP_RELATIVE  BIT_U16(4) /**< "relative" offset */
+#define DETECT_BYTEJUMP_ALIGN     BIT_U16(5) /**< "align" offset */
+#define DETECT_BYTEJUMP_DCE       BIT_U16(6) /**< "dce" enabled */
+#define DETECT_BYTEJUMP_OFFSET_BE BIT_U16(7) /**< "byte extract" enabled */
+#define DETECT_BYTEJUMP_END       BIT_U16(8) /**< "from_end" jump */
 
 typedef struct DetectBytejumpData_ {
     uint8_t nbytes;                   /**< Number of bytes to compare */
     uint8_t base;                     /**< String value base (oct|dec|hex) */
-    uint16_t flags;                    /**< Flags (big|little|relative|string) */
+    uint16_t flags;                   /**< Flags (big|little|relative|string) */
     uint32_t multiplier;              /**< Multiplier for nbytes (multiplier n)*/
     int32_t offset;                   /**< Offset in payload to extract value */
     int32_t post_offset;              /**< Offset to adjust post-jump */

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -486,7 +486,7 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
 
     } else if (smd->type == DETECT_BYTEJUMP) {
         DetectBytejumpData *bjd = (DetectBytejumpData *)smd->ctx;
-        uint8_t bjflags = bjd->flags;
+        uint16_t bjflags = bjd->flags;
         int32_t offset = bjd->offset;
 
         if (bjflags & DETECT_BYTEJUMP_OFFSET_BE) {


### PR DESCRIPTION
Continuation of #4952

This PR adds support for `from_end` to the existing `byte_jump`. Although documented, it was not implemented.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3626](https://redmine.openinfosecfoundation.org/issues/3626)

Describe changes:
- Address review comments.

Companion [Suricata-verify PR #232](https://github.com/OISF/suricata-verify/pull/232)