### PR TITLE
ssh/eve: convert to jsonbuilder

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -147,12 +147,10 @@ static void AlertJsonSsh(const Flow *f, JsonBuilder *js)
     void *ssh_state = FlowGetAppState(f);
     if (ssh_state) {
         void *tx_ptr = rs_ssh_state_get_tx(ssh_state, 0);
-        json_t *tjs = rs_ssh_log_json(tx_ptr);
-        if (unlikely(tjs == NULL))
-            return;
-
-        jb_set_jsont(js, "ssh", tjs);
-        json_decref(tjs);
+        jb_open_object(js, "ssh");
+        // log even if no data
+        rs_ssh_log_json(tx_ptr, js);
+        jb_close(js);
     }
 
     return;

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -75,25 +75,25 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         return 0;
     }
 
-    json_t *js = CreateJSONHeader(p, LOG_DIR_FLOW, "ssh", NULL);
+    JsonBuilder *js = CreateEveHeaderWithTxId(p, LOG_DIR_FLOW, "ssh", NULL, tx_id);
     if (unlikely(js == NULL))
         return 0;
 
-    JsonAddCommonOptions(&ssh_ctx->cfg, p, f, js);
+    EveAddCommonOptions(&ssh_ctx->cfg, p, f, js);
 
     /* reset */
     MemBufferReset(aft->buffer);
 
-    json_t *tjs = rs_ssh_log_json(txptr);
-    if (unlikely(tjs == NULL)) {
-        free(js);
+    jb_open_object(js, "ssh");
+    if (!rs_ssh_log_json(txptr, js)) {
+        jb_free(js);
         return 0;
     }
-    json_object_set_new(js, "ssh", tjs);
+    if (jb_close(js)) {
+        OutputJsonBuilderBuffer(js, ssh_ctx->file_ctx, &aft->buffer);
+    }
 
-    OutputJSONBuffer(js, ssh_ctx->file_ctx, &aft->buffer);
-    json_object_clear(js);
-    json_decref(js);
+    jb_free(js);
 
     return 0;
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3708

Describe changes:
- convert ssh to jsonbuilder

Modifies #5031 with comments taken into account

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:

I am not sure there are any S-V tests with SSH by the way.
Tested with https://github.com/OISF/suricata-verify/pull/176