### PR TITLE
signature: adds file flag for file_data keyword

### DIFF
--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -189,6 +189,7 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     if (DetectBufferSetActiveList(s, DetectBufferTypeGetByName("file_data")) < 0)
         return -1;
 
+    s->flags |= SIG_FLAG_FILEDATA;
     SetupDetectEngineConfig(de_ctx);
     return 0;
 }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1828,7 +1828,8 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
     }
 #endif
 
-    if ((s->flags & SIG_FLAG_FILESTORE) || s->file_flags != 0) {
+    if ((s->flags & ( SIG_FLAG_FILESTORE | SIG_FLAG_FILEDATA))
+        || s->file_flags != 0) {
         if (s->alproto != ALPROTO_UNKNOWN &&
                 !AppLayerParserSupportsFiles(IPPROTO_TCP, s->alproto))
         {

--- a/src/detect.h
+++ b/src/detect.h
@@ -250,6 +250,8 @@ typedef struct DetectPort_ {
 /** Info for Source and Target identification */
 #define SIG_FLAG_DEST_IS_TARGET         BIT_U32(26)
 
+#define SIG_FLAG_FILEDATA               BIT_U32(27) /**< signature has filedata keyword */
+
 #define SIG_FLAG_HAS_TARGET             (SIG_FLAG_DEST_IS_TARGET|SIG_FLAG_SRC_IS_TARGET)
 
 /* signature init flags */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3683

Describe changes:
- adds new signature flag `SIG_FLAG_FILEDATA` for `file_data` keyword

So that SigValidate can check if a protocol not supporting files was set after this keyword
with `if ((s->flags & SIG_FLAG_FILESTORE | SIG_FLAG_FILEDATA) || ) {`
Modifies #4908 with comments taken into account using `flags` and not `file_flags`