### PR TITLE
JsonBuilder - Export set_string_from_bytes to C

### DIFF
--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -554,7 +554,7 @@ pub extern "C" fn jb_clone(js: &mut JsonBuilder) -> *mut JsonBuilder {
 
 #[no_mangle]
 pub unsafe extern "C" fn jb_free(js: &mut JsonBuilder) {
-    let _: Box<JsonBuilder> = std::mem::transmute(js);
+    let _ = Box::from_raw(js);
 }
 
 #[no_mangle]

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -606,6 +606,20 @@ pub unsafe extern "C" fn jb_set_string(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn jb_set_string_from_bytes(
+    js: &mut JsonBuilder, key: *const c_char, bytes: *const u8, len: u32,
+) -> bool {
+    if bytes == std::ptr::null() || len == 0 {
+        return false;
+    }
+    if let Ok(key) = CStr::from_ptr(key).to_str() {
+        let val = std::slice::from_raw_parts(bytes, len as usize);
+        return js.set_string_from_bytes(key, val).is_ok();
+    }
+    return false;
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn jb_set_jsont(
     jb: &mut JsonBuilder, key: *const c_char, jsont: &mut json::JsonT,
 ) -> bool {
@@ -639,6 +653,17 @@ pub unsafe extern "C" fn jb_append_string(js: &mut JsonBuilder, val: *const c_ch
         return js.append_string(val).is_ok();
     }
     return false;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn jb_append_string_from_bytes(
+    js: &mut JsonBuilder, bytes: *const u8, len: u32,
+) -> bool {
+    if bytes == std::ptr::null() || len == 0 {
+        return false;
+    }
+    let val = std::slice::from_raw_parts(bytes, len as usize);
+    return js.append_string_from_bytes(val).is_ok();
 }
 
 #[no_mangle]


### PR DESCRIPTION
1) Remove transmute in favour of Box::from_raw (I believe this is more correct).
2) Export jb_set_string_from_bytes to C
3) Export jb_append_string_from_bytes to C