### PR TITLE
JsonBuilder updates: formatted data handling - v2

### DIFF
--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -554,7 +554,7 @@ pub extern "C" fn jb_clone(js: &mut JsonBuilder) -> *mut JsonBuilder {
 
 #[no_mangle]
 pub unsafe extern "C" fn jb_free(js: &mut JsonBuilder) {
-    let _: Box<JsonBuilder> = std::mem::transmute(js);
+    let _ = Box::from_raw(js);
 }
 
 #[no_mangle]

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -606,6 +606,20 @@ pub unsafe extern "C" fn jb_set_string(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn jb_set_string_from_bytes(
+    js: &mut JsonBuilder, key: *const c_char, bytes: *const u8, len: u32,
+) -> bool {
+    if bytes == std::ptr::null() || len == 0 {
+        return false;
+    }
+    if let Ok(key) = CStr::from_ptr(key).to_str() {
+        let val = std::slice::from_raw_parts(bytes, len as usize);
+        return js.set_string_from_bytes(key, val).is_ok();
+    }
+    return false;
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn jb_set_jsont(
     jb: &mut JsonBuilder, key: *const c_char, jsont: &mut json::JsonT,
 ) -> bool {
@@ -639,6 +653,17 @@ pub unsafe extern "C" fn jb_append_string(js: &mut JsonBuilder, val: *const c_ch
         return js.append_string(val).is_ok();
     }
     return false;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn jb_append_string_from_bytes(
+    js: &mut JsonBuilder, bytes: *const u8, len: u32,
+) -> bool {
+    if bytes == std::ptr::null() || len == 0 {
+        return false;
+    }
+    let val = std::slice::from_raw_parts(bytes, len as usize);
+    return js.append_string_from_bytes(val).is_ok();
 }
 
 #[no_mangle]

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -405,6 +405,22 @@ impl JsonBuilder {
         Ok(self)
     }
 
+    pub fn set_formatted(&mut self, formatted: &str) -> Result<&mut Self, JsonError> {
+        match self.current_state() {
+            State::ObjectNth => {
+                self.buf.push(',');
+            }
+            State::ObjectFirst => {
+                self.set_state(State::ObjectNth);
+            }
+            _ => {
+                return Err(JsonError::InvalidState);
+            }
+        }
+        self.buf.push_str(formatted);
+        Ok(self)
+    }
+
     /// Set a key and a string value (from bytes) on an object.
     pub fn set_string_from_bytes(&mut self, key: &str, val: &[u8]) -> Result<&mut Self, JsonError> {
         match std::str::from_utf8(val) {
@@ -615,6 +631,14 @@ pub unsafe extern "C" fn jb_set_string_from_bytes(
     if let Ok(key) = CStr::from_ptr(key).to_str() {
         let val = std::slice::from_raw_parts(bytes, len as usize);
         return js.set_string_from_bytes(key, val).is_ok();
+    }
+    return false;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn jb_set_formatted(js: &mut JsonBuilder, formatted: *const c_char) -> bool {
+    if let Ok(formatted) = CStr::from_ptr(formatted).to_str() {
+        return js.set_formatted(formatted).is_ok();
     }
     return false;
 }
@@ -975,6 +999,17 @@ mod test {
         assert_eq!(jb.buf, r#"{"foo":"bar""#);
         assert_eq!(jb.current_state(), State::ObjectNth);
         assert_eq!(jb.state.len(), 2);
+    }
+
+    #[test]
+    fn test_set_formatted() {
+        let mut jb = JsonBuilder::new_object();
+        jb.set_formatted("\"foo\":\"bar\"").unwrap();
+        assert_eq!(jb.buf, r#"{"foo":"bar""#);
+        jb.set_formatted("\"bar\":\"foo\"").unwrap();
+        assert_eq!(jb.buf, r#"{"foo":"bar","bar":"foo""#);
+        jb.close().unwrap();
+        assert_eq!(jb.buf, r#"{"foo":"bar","bar":"foo"}"#);
     }
 }
 

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -218,13 +218,13 @@ JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
 #endif
             break;
         case FILE_STATE_TRUNCATED:
-            jb_set_string(js, "state", "TRUNCATED");
+            JB_SET_STRING(js, "state", "TRUNCATED");
             break;
         case FILE_STATE_ERROR:
-            jb_set_string(js, "state", "ERROR");
+            JB_SET_STRING(js, "state", "ERROR");
             break;
         default:
-            jb_set_string(js, "state", "UNKNOWN");
+            JB_SET_STRING(js, "state", "UNKNOWN");
             break;
     }
 

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -239,7 +239,7 @@ static void EveFlowLogJSON(JsonFlowLogThread *aft, JsonBuilder *jb, Flow *f)
     jb_set_uint(jb, "age", age);
 
     if (f->flow_end_flags & FLOW_END_FLAG_EMERGENCY)
-        jb_set_bool(jb, "emergency", true);
+        JB_SET_TRUE(jb, "emergency");
     const char *state = NULL;
     if (f->flow_end_flags & FLOW_END_FLAG_STATE_NEW)
         state = "new";
@@ -280,7 +280,7 @@ static void EveFlowLogJSON(JsonFlowLogThread *aft, JsonBuilder *jb, Flow *f)
 
     jb_set_bool(jb, "alerted", FlowHasAlerts(f));
     if (f->flags & FLOW_WRONG_THREAD)
-        jb_set_bool(jb, "wrong_thread", true);
+        JB_SET_TRUE(jb, "wrong_thread");
 
     /* Close flow. */
     jb_close(jb);
@@ -350,9 +350,9 @@ static void EveFlowLogJSON(JsonFlowLogThread *aft, JsonBuilder *jb, Flow *f)
             }
             jb_set_string(jb, "state", tcp_state);
             if (ssn->client.flags & STREAMTCP_STREAM_FLAG_GAP)
-                jb_set_bool(jb, "gap_ts", true);
+                JB_SET_TRUE(jb, "gap_ts");
             if (ssn->server.flags & STREAMTCP_STREAM_FLAG_GAP)
-                jb_set_bool(jb, "gap_tc", true);
+                JB_SET_TRUE(jb, "gap_tc");
         }
 
         /* Close tcp. */

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -700,21 +700,21 @@ void JsonTcpFlags(uint8_t flags, json_t *js)
 void EveTcpFlags(const uint8_t flags, JsonBuilder *js)
 {
     if (flags & TH_SYN)
-        jb_set_bool(js, "syn", true);
+        JB_SET_TRUE(js, "syn");
     if (flags & TH_FIN)
-        jb_set_bool(js, "fin", true);
+        JB_SET_TRUE(js, "fin");
     if (flags & TH_RST)
-        jb_set_bool(js, "rst", true);
+        JB_SET_TRUE(js, "rst");
     if (flags & TH_PUSH)
-        jb_set_bool(js, "psh", true);
+        JB_SET_TRUE(js, "psh");
     if (flags & TH_ACK)
-        jb_set_bool(js, "ack", true);
+        JB_SET_TRUE(js, "ack");
     if (flags & TH_URG)
-        jb_set_bool(js, "urg", true);
+        JB_SET_TRUE(js, "urg");
     if (flags & TH_ECN)
-        jb_set_bool(js, "ecn", true);
+        JB_SET_TRUE(js, "ecn");
     if (flags & TH_CWR)
-        jb_set_bool(js, "cwr", true);
+        JB_SET_TRUE(js, "cwr");
 }
 
 void JsonAddrInfoInit(const Packet *p, enum OutputJsonLogDirection dir, JsonAddrInfo *addr)

--- a/src/rust.h
+++ b/src/rust.h
@@ -21,4 +21,7 @@
 #include "rust-context.h"
 #include "rust-bindings.h"
 
+#define JB_SET_STRING(jb, key, val) jb_set_formatted((jb), "\"" key "\":\"" val "\"")
+#define JB_SET_TRUE(jb, key) jb_set_formatted((jb), "\"" key "\":true")
+
 #endif /* !__RUST_H__ */


### PR DESCRIPTION
C macros to optimize setting of state data. For example:

jb_set_bool(jb, "syn", true) -> JB_SET_TRUE(jb, "syn");
jb_set_string(jb, "command", "RETR") -> JB_SET_STRING(jb, "command", "RETR");

These wrap JsonBuilder::set_formatted that takes a preformatted key/value
and adds it to the underlying buffer.
