### PR TITLE
signature: adds file flag for file_data keyword

### DIFF
--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -189,6 +189,7 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     if (DetectBufferSetActiveList(s, DetectBufferTypeGetByName("file_data")) < 0)
         return -1;
 
+    s->init_data->init_flags |= SIG_FLAG_INIT_FILEDATA;
     SetupDetectEngineConfig(de_ctx);
     return 0;
 }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1828,7 +1828,8 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
     }
 #endif
 
-    if ((s->flags & SIG_FLAG_FILESTORE) || s->file_flags != 0) {
+    if ((s->flags & SIG_FLAG_FILESTORE) || s->file_flags != 0 ||
+        (s->init_data->init_flags & SIG_FLAG_INIT_FILEDATA)) {
         if (s->alproto != ALPROTO_UNKNOWN &&
                 !AppLayerParserSupportsFiles(IPPROTO_TCP, s->alproto))
         {

--- a/src/detect.h
+++ b/src/detect.h
@@ -262,6 +262,7 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_INIT_STATE_MATCH           BIT_U32(6)  /**< signature has matches that require stateful inspection */
 #define SIG_FLAG_INIT_NEED_FLUSH            BIT_U32(7)
 #define SIG_FLAG_INIT_PRIO_EXPLICT          BIT_U32(8)  /**< priority is explicitly set by the priority keyword */
+#define SIG_FLAG_INIT_FILEDATA              BIT_U32(9)  /**< signature has filedata keyword */
 
 /* signature mask flags */
 /** \note: additions should be added to the rule analyzer as well */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3683

Describe changes:
- adds new signature flag `SIG_FLAG_FILEDATA` for `file_data` keyword

So that SigValidate can check if a protocol not supporting files was set after this keyword
with `if ((s->flags & SIG_FLAG_FILESTORE | SIG_FLAG_FILEDATA) || ) {`

Modifies #5038 with comments taken into account using `init_flags` and not `flags`