### PR TITLE
ssh/eve: convert to jsonbuilder

### DIFF
--- a/rust/src/ssh/logger.rs
+++ b/rust/src/ssh/logger.rs
@@ -16,49 +16,36 @@
  */
 
 use super::ssh::SSHTransaction;
-use crate::json::*;
+use crate::jsonbuilder::{JsonBuilder, JsonError};
 
-fn log_ssh(tx: &SSHTransaction) -> Option<Json> {
+fn log_ssh(tx: &SSHTransaction, js: &mut JsonBuilder) -> Result<bool, JsonError> {
     if tx.cli_hdr.protover.len() == 0 && tx.srv_hdr.protover.len() == 0 {
-        return None;
+        return Ok(false);
     }
-    let js = Json::object();
     if tx.cli_hdr.protover.len() > 0 {
-        let cjs = Json::object();
-        cjs.set_string_from_bytes(
-            "proto_version",
-            &tx.cli_hdr.protover,
-        );
+        js.open_object("client")?;
+        js.set_string_from_bytes("proto_version", &tx.cli_hdr.protover)?;
         if tx.cli_hdr.swver.len() > 0 {
-            cjs.set_string_from_bytes(
-                "software_version",
-                &tx.cli_hdr.swver,
-            );
+            js.set_string_from_bytes("software_version", &tx.cli_hdr.swver)?;
         }
-        js.set("client", cjs);
+        js.close()?;
     }
     if tx.srv_hdr.protover.len() > 0 {
-        let sjs = Json::object();
-        sjs.set_string_from_bytes(
-            "proto_version",
-            &tx.srv_hdr.protover,
-        );
+        js.open_object("server")?;
+        js.set_string_from_bytes("proto_version", &tx.srv_hdr.protover)?;
         if tx.srv_hdr.swver.len() > 0 {
-            sjs.set_string_from_bytes(
-                "software_version",
-                &tx.srv_hdr.swver,
-            );
+            js.set_string_from_bytes("software_version", &tx.srv_hdr.swver)?;
         }
-        js.set("server", sjs);
+        js.close()?;
     }
-    return Some(js);
+    return Ok(true);
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_log_json(tx: *mut std::os::raw::c_void) -> *mut JsonT {
+pub extern "C" fn rs_ssh_log_json(tx: *mut std::os::raw::c_void, js: &mut JsonBuilder) -> bool {
     let tx = cast_pointer!(tx, SSHTransaction);
-    match log_ssh(tx) {
-        Some(js) => js.unwrap(),
-        None => std::ptr::null_mut(),
+    if let Ok(x) = log_ssh(tx, js) {
+        return x;
     }
+    return false;
 }

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -146,13 +146,15 @@ static void AlertJsonSsh(const Flow *f, JsonBuilder *js)
 {
     void *ssh_state = FlowGetAppState(f);
     if (ssh_state) {
+        JsonBuilderMark mark = { 0, 0, 0 };
         void *tx_ptr = rs_ssh_state_get_tx(ssh_state, 0);
-        json_t *tjs = rs_ssh_log_json(tx_ptr);
-        if (unlikely(tjs == NULL))
-            return;
-
-        jb_set_jsont(js, "ssh", tjs);
-        json_decref(tjs);
+        jb_get_mark(js, &mark);
+        jb_open_object(js, "ssh");
+        if (rs_ssh_log_json(tx_ptr, js)) {
+            jb_close(js);
+        } else {
+            jb_restore_mark(js, &mark);
+        }
     }
 
     return;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3708

Describe changes:
- convert ssh to jsonbuilder

Modifies #5033 with @jasonish comments taken into account (thanks)

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:

I am not sure there are any S-V tests with SSH by the way.
Tested with https://github.com/OISF/suricata-verify/pull/176