### PR TITLE
Pcap read directories recursively v2

### DIFF
--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -54,6 +54,12 @@
    continuously feed files to a directory and have them cleaned up when done. If
    this option is not set, pcap files will not be deleted after processing.
 
+.. option:: --pcap-file-directory-depth
+   Used with the -r option when the path provided is a directory.  This option
+   sets the maximum depth of the directory traversal (between 0 and 255).  
+   The default value is 0. Symlinks are ignored. 
+   This option cannot be combined with the --pcap-file-continuous.  
+
 .. option::  -i <interface>
 
    After the -i option you can enter the interface card you would like

--- a/src/source-pcap-file-directory-helper.h
+++ b/src/source-pcap-file-directory-helper.h
@@ -43,6 +43,8 @@ typedef struct PcapFileDirectoryVars_
     DIR *directory;
     PcapFileFileVars *current_file;
     bool should_loop;
+    uint8_t cur_dir_depth;
+    uint8_t max_dir_depth;
     time_t delay;
     time_t poll_interval;
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -600,6 +600,7 @@ static void PrintUsage(const char *progname)
     printf("\t--pcap[=<dev>]                       : run in pcap mode, no value select interfaces from suricata.yaml\n");
     printf("\t--pcap-file-continuous               : when running in pcap mode with a directory, continue checking directory for pcaps until interrupted\n");
     printf("\t--pcap-file-delete                   : when running in replay mode (-r with directory or file), will delete pcap files that have been processed when done\n");
+    printf("\t--pcap-file-directory-depth          : when running in replay mode (-r) with a directory, will specify the maximum directory recursion depth\n");
 #ifdef HAVE_PCAP_SET_BUFF
     printf("\t--pcap-buffer-size                   : size of the pcap buffer value from 0 - %i\n",INT_MAX);
 #endif /* HAVE_SET_PCAP_BUFF */
@@ -1194,6 +1195,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         {"pcap", optional_argument, 0, 0},
         {"pcap-file-continuous", 0, 0, 0},
         {"pcap-file-delete", 0, 0, 0},
+        {"pcap-file-directory-depth", 1, 0, 0},
         {"simulate-ips", 0, 0 , 0},
         {"no-random", 0, &g_disable_randomness, 1},
         {"strict-rule-keywords", optional_argument, 0, 0},
@@ -1550,6 +1552,12 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             else if (strcmp((long_opts[option_index]).name, "pcap-file-delete") == 0) {
                 if (ConfSetFinal("pcap-file.delete-when-done", "true") != 1) {
                     SCLogError(SC_ERR_CMD_LINE, "Failed to set pcap-file.delete-when-done");
+                    return TM_ECODE_FAILED;
+                }
+            }
+            else if (strcmp((long_opts[option_index]).name, "pcap-file-directory-depth") == 0) {
+                if (ConfSetFinal("pcap-file.directory-depth", optarg) != 1) {
+                    SCLogError(SC_ERR_CMD_LINE, "ERROR: Failed to set pcap-file-directory-depth");
                     return TM_ECODE_FAILED;
                 }
             }


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2363

Describe changes:
- Added ability to recursively read pcap directories up to a maximum user specified depth
- src/suricata.c: addition of new command line parameter  --pcap-file-directory-depth
- src/source-pcap-file.c: parsing of the command line argument
- src/source-pcap-file-directory-helper.h: two thread vars tracking max depth and depth
- src/source-pcap-file-directory-helper.c: created JoinPath function to manage path resolution logic   
- src/source-pcap-file-directory-helper.c: added functions IsRegularFile and IsRegularDirectory to remove OS specific logic from PcapDirectoryPopulateBuffer
- Changes to doc/userguide/partials/options.rst for feature 2363 (reading pcaps recursively)
- v2 is rebased to master 

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
