### PR TITLE
detect-dsize: Add ! operator for dsize matching v2

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -289,7 +289,7 @@ overflows.
 
 Format::
 
-  dsize:<number>;
+  dsize:[<>!]number; || dsize:min<>max;
 
 Example of dsize in a rule:
 

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -83,13 +83,13 @@ DsizeMatch(const uint16_t psize, const uint8_t mode,
 {
     if (mode == DETECTDSIZE_EQ && dsize == psize)
         return 1;
-    else if (mode == DETECTDSIZE_NE && dsize != psize)
-        return 1;
     else if (mode == DETECTDSIZE_LT && psize < dsize)
         return 1;
     else if (mode == DETECTDSIZE_GT && psize > dsize)
         return 1;
     else if (mode == DETECTDSIZE_RA && psize > dsize && psize < dsize2)
+        return 1;
+    else if (mode == DETECTDSIZE_NE && dsize != psize)
         return 1;
 
     return 0;

--- a/src/detect-dsize.h
+++ b/src/detect-dsize.h
@@ -28,6 +28,7 @@
 #define DETECTDSIZE_EQ 1
 #define DETECTDSIZE_GT 2
 #define DETECTDSIZE_RA 3
+#define DETECTDSIZE_NE 4
 
 typedef struct DetectDsizeData_ {
     uint16_t dsize;

--- a/src/detect-dsize.h
+++ b/src/detect-dsize.h
@@ -43,5 +43,21 @@ int SigParseGetMaxDsize(const Signature *s);
 void SigParseSetDsizePair(Signature *s);
 void SigParseApplyDsizeToContent(Signature *s);
 
+/** Determine if a packet p should be kicked out during prefilter due
+ *  to dsize outside the range specified in signature s */
+static inline bool SigDsizePrefilter(const Packet *p, const Signature *s, uint32_t sflags)
+{
+if (unlikely(sflags & SIG_FLAG_DSIZE)) {
+    if (likely(p->payload_len < s->dsize_low || p->payload_len > s->dsize_high)) {
+        if (!(s->dsize_mode == DETECTDSIZE_NE)) {
+            SCLogDebug("kicked out as p->payload_len %u, dsize low %u, hi %u",
+                    p->payload_len, s->dsize_low, s->dsize_high);
+            return true;
+        }
+    }
+}
+return false;
+}
+
 #endif /* __DETECT_DSIZE_H__ */
 

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -532,26 +532,24 @@ static int SignatureCreateMask(Signature *s)
             case DETECT_DSIZE:
             {
                 DetectDsizeData *ds = (DetectDsizeData *)sm->ctx;
-                switch (ds->mode) {
-                    case DETECTDSIZE_LT:
-                        /* LT will include 0, so no payload.
-                         * if GT is used in the same rule the
-                         * flag will be set anyway. */
-                        break;
-                    case DETECTDSIZE_RA:
-                    case DETECTDSIZE_GT:
+                    /* LT will include 0, so no payload.
+                     * if GT is used in the same rule the
+                     * flag will be set anyway. */
+                if (ds->mode == DETECTDSIZE_RA ||
+                    ds->mode == DETECTDSIZE_GT ||
+                    ds->mode == DETECTDSIZE_NE) {
+
+                    s->mask |= SIG_MASK_REQUIRE_PAYLOAD;
+                    SCLogDebug("sig requires payload");
+
+                } else if (ds->mode == DETECTDSIZE_EQ) {
+                    if (ds->dsize > 0) {
                         s->mask |= SIG_MASK_REQUIRE_PAYLOAD;
                         SCLogDebug("sig requires payload");
-                        break;
-                    case DETECTDSIZE_EQ:
-                        if (ds->dsize > 0) {
-                            s->mask |= SIG_MASK_REQUIRE_PAYLOAD;
-                            SCLogDebug("sig requires payload");
-                        } else if (ds->dsize == 0) {
-                            s->mask |= SIG_MASK_REQUIRE_NO_PAYLOAD;
-                            SCLogDebug("sig requires no payload");
-                        }
-                        break;
+                    } else {
+                        s->mask |= SIG_MASK_REQUIRE_NO_PAYLOAD;
+                        SCLogDebug("sig requires no payload");
+                    }
                 }
                 break;
             }

--- a/src/detect.c
+++ b/src/detect.c
@@ -34,6 +34,7 @@
 #include "app-layer-parser.h"
 
 #include "detect.h"
+#include "detect-dsize.h"
 #include "detect-engine.h"
 #include "detect-engine-profile.h"
 
@@ -766,9 +767,11 @@ static inline void DetectRulePacketRules(
 
         if (unlikely(sflags & SIG_FLAG_DSIZE)) {
             if (likely(p->payload_len < s->dsize_low || p->payload_len > s->dsize_high)) {
-                SCLogDebug("kicked out as p->payload_len %u, dsize low %u, hi %u",
-                        p->payload_len, s->dsize_low, s->dsize_high);
-                goto next;
+                if (!(s->dsize_mode == DETECTDSIZE_NE)) {
+                    SCLogDebug("kicked out as p->payload_len %u, dsize low %u, hi %u",
+                            p->payload_len, s->dsize_low, s->dsize_high);
+                    goto next;
+                }
             }
         }
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -774,6 +774,9 @@ static inline void DetectRulePacketRules(
                 }
             }
         }
+        
+        if (SigDsizePrefilter(p, s, sflags))
+            goto next;
 
         /* if the sig has alproto and the session as well they should match */
         if (likely(sflags & SIG_FLAG_APPLAYER)) {

--- a/src/detect.c
+++ b/src/detect.c
@@ -765,16 +765,6 @@ static inline void DetectRulePacketRules(
             goto next;
         }
 
-        if (unlikely(sflags & SIG_FLAG_DSIZE)) {
-            if (likely(p->payload_len < s->dsize_low || p->payload_len > s->dsize_high)) {
-                if (!(s->dsize_mode == DETECTDSIZE_NE)) {
-                    SCLogDebug("kicked out as p->payload_len %u, dsize low %u, hi %u",
-                            p->payload_len, s->dsize_low, s->dsize_high);
-                    goto next;
-                }
-            }
-        }
-        
         if (SigDsizePrefilter(p, s, sflags))
             goto next;
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -531,6 +531,7 @@ typedef struct Signature_ {
 
     uint16_t dsize_low;
     uint16_t dsize_high;
+    uint8_t dsize_mode;
 
     SignatureMask mask;
     SigIntId num; /**< signature number, internal id */


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2538

Describe changes:
- Addressing the first request from the above ticket: added ! operator to dsize keyword allowing a user to match != values (e.g. dsize:!100;)
- Unit tests added for parsing and matching with ! operator.
- Requires some discussion: There is another approach to this that allows the combination of multiple dsize values and operators that satisfies the second request in the ticket i.e. "dsize:![100,150];". The approach involves changing to flags instead of a dsize mode and adding checks that could possibly reduce performance in detect.c. Is this something the Suricata devs would be interested in seeing?
- Updated to address typos and unit test macros.