### PR TITLE
Pcap read directories recursively v3

### DIFF
--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -54,6 +54,12 @@
    continuously feed files to a directory and have them cleaned up when done. If
    this option is not set, pcap files will not be deleted after processing.
 
+.. option:: --pcap-file-directory-depth
+   Used with the -r option when the path provided is a directory.  This option
+   sets the maximum depth of the directory traversal (between 0 and 255).  
+   The default value is 0. Symlinks are ignored. 
+   This option cannot be combined with the --pcap-file-continuous.  
+
 .. option::  -i <interface>
 
    After the -i option you can enter the interface card you would like

--- a/src/source-pcap-file-directory-helper.c
+++ b/src/source-pcap-file-directory-helper.c
@@ -26,11 +26,13 @@
 #include "source-pcap-file-directory-helper.h"
 #include "runmode-unix-socket.h"
 #include "util-mem.h"
+#include "util-path.h"
 #include "source-pcap-file.h"
 
 static void GetTime(struct timespec *tm);
 static void CopyTime(struct timespec *from, struct timespec *to);
 static int CompareTimes(struct timespec *left, struct timespec *right);
+static TmEcode JoinPath (char *out_buf, uint16_t buf_len, const char *const dir, const char *const fname);
 static TmEcode PcapRunStatus(PcapFileDirectoryVars *);
 static TmEcode PcapDirectoryFailure(PcapFileDirectoryVars *ptv);
 static TmEcode PcapDirectoryDone(PcapFileDirectoryVars *ptv);
@@ -72,6 +74,35 @@ int CompareTimes(struct timespec *left, struct timespec *right)
             return 0;
         }
     }
+}
+
+/**
+ * Wrapper to join a directory and filename and resolve using realpath
+ *   _fullpath is used for WIN32
+ * @param out_buf output buffer.  Up to PATH_MAX will be written.
+ * @param buf_len length of output buffer
+ * @param dir the directory
+ * @param fname the filename
+ * @return TM_ECODE_OK on success.  On failure TM_ECODE_FAILED is returned.
+ */
+TmEcode JoinPath (char *out_buf, uint16_t buf_len, const char *const dir, const char *const fname)
+{
+    memset(out_buf, 0, buf_len);
+    uint16_t max_path_len = (buf_len > PATH_MAX) ? PATH_MAX : buf_len;
+    int bytes_written = snprintf(out_buf, max_path_len, "%s/%s", dir, fname);
+    if (bytes_written <= 0) {
+        SCLogError(SC_ERR_SPRINTF, "Could not join filename to path");
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+    char *tmpBuf = SCRealPath(out_buf, NULL);
+    if (tmpBuf == NULL) {
+        SCLogError(SC_ERR_SPRINTF, "Error resolving path: %s", strerror(errno));
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+    memset(out_buf, 0, buf_len);
+    snprintf(out_buf, max_path_len, "%s", tmpBuf);
+    free(tmpBuf);
+    SCReturnInt(TM_ECODE_OK);
 }
 
 /**
@@ -314,82 +345,96 @@ TmEcode PcapDirectoryPopulateBuffer(PcapFileDirectoryVars *pv,
         SCLogError(SC_ERR_INVALID_ARGUMENT, "No directory filename was passed");
         SCReturnInt(TM_ECODE_FAILED);
     }
+    if (pv->cur_dir_depth > pv->max_dir_depth){
+        /* User defined limit reached.  Not an error. */
+        SCLogInfo("Directory depth of %d has been reached.  "
+                  "Ignoring subdirectory %s", pv->max_dir_depth, pv->filename);
+        SCReturnInt(TM_ECODE_OK);
+    }
     struct dirent * dir = NULL;
     PendingFile *file_to_add = NULL;
 
     while ((dir = readdir(pv->directory)) != NULL) {
-#ifndef OS_WIN32
-        if (dir->d_type != DT_REG) {
+        if (!SCIsRegularDirectory(dir) && !SCIsRegularFile(dir)) {
             continue;
         }
-#endif
-        if (strcmp(dir->d_name, ".") == 0 ||
-            strcmp(dir->d_name, "..") == 0) {
+        if (SCIsRegularDirectory(dir)){
+            DIR *cur_dir = pv->directory;
+            char *cur_path = pv->filename;
+
+            /* Create nested directory path */
+            char next_dir [PATH_MAX] = {0};
+            int result = JoinPath(next_dir, PATH_MAX, pv->filename, dir->d_name);
+            if (result != TM_ECODE_OK) {
+                return result;
+            }
+            /* Update pv to point to the nested directory */
+            pv->directory = opendir(next_dir);
+            pv->filename = next_dir;
+            /* Recursively descend into directory structure */
+            ++pv->cur_dir_depth;
+            PcapDirectoryPopulateBuffer(pv, older_than);
+            --pv->cur_dir_depth;
+            closedir(pv->directory);
+            pv->directory = cur_dir;
+            pv->filename = cur_path;
             continue;
         }
+        char pathbuff [PATH_MAX] = {0};
+        int result = JoinPath(pathbuff, PATH_MAX, pv->filename, dir->d_name);
+        if (result != TM_ECODE_OK) {
+            return result;
+        }
+        struct timespec temp_time;
+        memset(&temp_time, 0, sizeof(struct timespec));
 
-        char pathbuff[PATH_MAX] = {0};
+        if (PcapDirectoryGetModifiedTime(pathbuff, &temp_time) == 0) {
+            SCLogDebug("%" PRIuMAX " < %" PRIuMAX "(%s) < %" PRIuMAX ")",
+                       (uintmax_t)SCTimespecAsEpochMillis(&pv->shared->last_processed),
+                       (uintmax_t)SCTimespecAsEpochMillis(&temp_time),
+                       pathbuff,
+                       (uintmax_t)SCTimespecAsEpochMillis(older_than));
 
-        int written = 0;
-
-        written = snprintf(pathbuff, PATH_MAX, "%s/%s", pv->filename, dir->d_name);
-
-        if (written <= 0 || written >= PATH_MAX) {
-            SCLogError(SC_ERR_SPRINTF, "Could not write path");
-
-            SCReturnInt(TM_ECODE_FAILED);
-        } else {
-            struct timespec temp_time;
-            memset(&temp_time, 0, sizeof(struct timespec));
-
-            if (PcapDirectoryGetModifiedTime(pathbuff, &temp_time) == 0) {
-                SCLogDebug("%" PRIuMAX " < %" PRIuMAX "(%s) < %" PRIuMAX ")",
-                           (uintmax_t)SCTimespecAsEpochMillis(&pv->shared->last_processed),
-                           (uintmax_t)SCTimespecAsEpochMillis(&temp_time),
-                           pathbuff,
-                           (uintmax_t)SCTimespecAsEpochMillis(older_than));
-
-                // Skip files outside of our time range
-                if (CompareTimes(&temp_time, &pv->shared->last_processed) <= 0) {
-                    SCLogDebug("Skipping old file %s", pathbuff);
-                    continue;
-                }
-                else if (CompareTimes(&temp_time, older_than) >= 0) {
-                    SCLogDebug("Skipping new file %s", pathbuff);
-                    continue;
-                }
-            } else {
-                SCLogDebug("Unable to get modified time on %s, skipping", pathbuff);
+            // Skip files outside of our time range
+            if (CompareTimes(&temp_time, &pv->shared->last_processed) <= 0) {
+                SCLogDebug("Skipping old file %s", pathbuff);
                 continue;
             }
-
-            file_to_add = SCCalloc(1, sizeof(PendingFile));
-            if (unlikely(file_to_add == NULL)) {
-                SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate pending file");
-
-                SCReturnInt(TM_ECODE_FAILED);
+            else if (CompareTimes(&temp_time, older_than) >= 0) {
+                SCLogDebug("Skipping new file %s", pathbuff);
+                continue;
             }
+        } else {
+            SCLogDebug("Unable to get modified time on %s, skipping", pathbuff);
+            continue;
+        }
 
-            file_to_add->filename = SCStrdup(pathbuff);
-            if (unlikely(file_to_add->filename == NULL)) {
-                SCLogError(SC_ERR_MEM_ALLOC, "Failed to copy filename");
-                CleanupPendingFile(file_to_add);
+        file_to_add = SCCalloc(1, sizeof(PendingFile));
+        if (unlikely(file_to_add == NULL)) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate pending file");
 
-                SCReturnInt(TM_ECODE_FAILED);
-            }
+            SCReturnInt(TM_ECODE_FAILED);
+        }
 
-            memset(&file_to_add->modified_time, 0, sizeof(struct timespec));
-            CopyTime(&temp_time, &file_to_add->modified_time);
+        file_to_add->filename = SCStrdup(pathbuff);
+        if (unlikely(file_to_add->filename == NULL)) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Failed to copy filename");
+            CleanupPendingFile(file_to_add);
 
-            SCLogInfo("Found \"%s\" at %" PRIuMAX, file_to_add->filename,
-                       (uintmax_t)SCTimespecAsEpochMillis(&file_to_add->modified_time));
+            SCReturnInt(TM_ECODE_FAILED);
+        }
 
-            if (PcapDirectoryInsertFile(pv, file_to_add) == TM_ECODE_FAILED) {
-                SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to add file");
-                CleanupPendingFile(file_to_add);
+        memset(&file_to_add->modified_time, 0, sizeof(struct timespec));
+        CopyTime(&temp_time, &file_to_add->modified_time);
 
-                SCReturnInt(TM_ECODE_FAILED);
-            }
+        SCLogInfo("Found \"%s\" at %" PRIuMAX, file_to_add->filename,
+                   (uintmax_t)SCTimespecAsEpochMillis(&file_to_add->modified_time));
+
+        if (PcapDirectoryInsertFile(pv, file_to_add) == TM_ECODE_FAILED) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to add file");
+            CleanupPendingFile(file_to_add);
+
+            SCReturnInt(TM_ECODE_FAILED);
         }
     }
 

--- a/src/source-pcap-file-directory-helper.h
+++ b/src/source-pcap-file-directory-helper.h
@@ -43,6 +43,8 @@ typedef struct PcapFileDirectoryVars_
     DIR *directory;
     PcapFileFileVars *current_file;
     bool should_loop;
+    uint8_t cur_dir_depth;
+    uint8_t max_dir_depth;
     time_t delay;
     time_t poll_interval;
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -600,6 +600,7 @@ static void PrintUsage(const char *progname)
     printf("\t--pcap[=<dev>]                       : run in pcap mode, no value select interfaces from suricata.yaml\n");
     printf("\t--pcap-file-continuous               : when running in pcap mode with a directory, continue checking directory for pcaps until interrupted\n");
     printf("\t--pcap-file-delete                   : when running in replay mode (-r with directory or file), will delete pcap files that have been processed when done\n");
+    printf("\t--pcap-file-directory-depth          : when running in replay mode (-r) with a directory, will specify the maximum directory recursion depth\n");
 #ifdef HAVE_PCAP_SET_BUFF
     printf("\t--pcap-buffer-size                   : size of the pcap buffer value from 0 - %i\n",INT_MAX);
 #endif /* HAVE_SET_PCAP_BUFF */
@@ -1194,6 +1195,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         {"pcap", optional_argument, 0, 0},
         {"pcap-file-continuous", 0, 0, 0},
         {"pcap-file-delete", 0, 0, 0},
+        {"pcap-file-directory-depth", 1, 0, 0},
         {"simulate-ips", 0, 0 , 0},
         {"no-random", 0, &g_disable_randomness, 1},
         {"strict-rule-keywords", optional_argument, 0, 0},
@@ -1550,6 +1552,12 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             else if (strcmp((long_opts[option_index]).name, "pcap-file-delete") == 0) {
                 if (ConfSetFinal("pcap-file.delete-when-done", "true") != 1) {
                     SCLogError(SC_ERR_CMD_LINE, "Failed to set pcap-file.delete-when-done");
+                    return TM_ECODE_FAILED;
+                }
+            }
+            else if (strcmp((long_opts[option_index]).name, "pcap-file-directory-depth") == 0) {
+                if (ConfSetFinal("pcap-file.directory-depth", optarg) != 1) {
+                    SCLogError(SC_ERR_CMD_LINE, "ERROR: Failed to set pcap-file-directory-depth");
                     return TM_ECODE_FAILED;
                 }
             }

--- a/src/util-path.c
+++ b/src/util-path.c
@@ -137,3 +137,54 @@ bool SCPathExists(const char *path)
     }
     return false;
 }
+
+/**
+ * \brief OS independent wrapper for directory check
+ *
+ * \param dir_entry object to check
+ *
+ * \retval True if the object is a regular directory, otherwise false.  This directory
+ *          and parent directory will return false.
+ */
+bool SCIsRegularDirectory(const struct dirent *const dir_entry)
+{
+#ifndef OS_WIN32
+    if ((dir_entry->d_type == DT_DIR) &&
+        (strcmp(dir_entry->d_name, ".") != 0) &&
+        (strcmp(dir_entry->d_name, "..") != 0)) {
+        return true;
+    }
+#endif
+    return false;
+}
+/**
+ * \brief OS independent to check for regular file
+ *
+ * \param dir_entry object to check
+ *
+ * \retval True if the object is a regular file.  Otherwise false.
+ */
+bool SCIsRegularFile(const struct dirent *const dir_entry)
+{
+#ifndef OS_WIN32
+    return dir_entry->d_type == DT_REG;
+#endif
+    return false;
+}
+
+/**
+ * \brief OS independent wrapper for realpath
+ *
+ * \param path the path to resolve
+ * \param resolved_path the resolved path; if null, a buffer will be allocated
+ *
+ * \retval the resolved_path; or a pointer to a new resolved_path buffer
+ */
+char *SCRealPath(const char *path, char *resolved_path)
+{
+#ifdef OS_WIN32
+    return _fullpath(resolved_path, path, PATH_MAX);
+#else
+    return realpath(path, resolved_path);
+#endif
+}

--- a/src/util-path.h
+++ b/src/util-path.h
@@ -36,5 +36,8 @@ int PathIsRelative(const char *);
 int SCDefaultMkDir(const char *path);
 int SCCreateDirectoryTree(const char *path, const bool final);
 bool SCPathExists(const char *path);
+bool SCIsRegularDirectory(const struct dirent *const dir_entry);
+bool SCIsRegularFile(const struct dirent *const dir_entry);
+char *SCRealPath(const char *path, char *resolved_path);
 
 #endif /* __UTIL_PATH_H__ */


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2363

Describe changes:
- Added ability to recursively read pcap directories up to a maximum user specified depth
- src/suricata.c: addition of new command line parameter --pcap-file-directory-depth
- src/source-pcap-file.c: parsing of the command line argument
- src/source-pcap-file-directory-helper.h: two thread vars tracking max depth and depth
- src/source-pcap-file-directory-helper.c: created JoinPath function to manage path resolution logic   
- src/util-path.c / src/util-path.h: added 3 functions SCIsRegularFile and SCIsRegularDirectory to provide OS independent file / directory info.
    SCRealPath is an OS independent wrapper for realpath
- Redmine ticket: https://redmine.openinfosecfoundation.org/issues/2363
- v2 rebased to master
- v3 fixed WIN32 build issues

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
