### PR TITLE
detect/asn1: Fixes definite long form parsing of length field - v2

### DIFF
--- a/src/detect-asn1.c
+++ b/src/detect-asn1.c
@@ -929,9 +929,9 @@ static int DetectAsn1Test05(void)
         buf[0] = '\x09';
         /* length, definite form, 2 octets */
         buf[1] = '\x82';
-        /* length is the sum of the following octets (257): */
-        buf[2] = '\xFE';
-        buf[3] = '\x03';
+        /* length is the representation of the following octets (257): */
+        buf[2] = '\x01';
+        buf[3] = '\x01';
 
         /* Fill the content of the number */
         uint16_t i = 4;
@@ -999,9 +999,9 @@ static int DetectAsn1Test06(void)
         buf[0] = '\x09';
         /* length, definite form, 2 octets */
         buf[1] = '\x82';
-        /* length is the sum of the following octets (256): */
-        buf[2] = '\xFE';
-        buf[3] = '\x02';
+        /* length is the representation of the following octets (256): */
+        buf[2] = '\x01';
+        buf[3] = '\x00';
 
         /* Fill the content of the number */
         uint16_t i = 4;
@@ -1217,9 +1217,9 @@ static int DetectAsn1TestReal03(void)
     buf[0] = '\x09';
     /* length, definite form, 2 octets */
     buf[1] = '\x82';
-    /* length is the sum of the following octets (257): */
-    buf[2] = '\xFE';
-    buf[3] = '\x03';
+    /* length is the representation of the following octets (257): */
+    buf[2] = '\x01';
+    buf[3] = '\x01';
 
     /* Fill the content of the number */
     uint16_t i = 4;

--- a/src/util-decode-asn1.c
+++ b/src/util-decode-asn1.c
@@ -146,15 +146,15 @@ static uint32_t SCAsn1GetLengthLongForm(Asn1Ctx *ac)
             return ASN1_PARSER_ERR;
         }
 
-        if ((uint64_t) ((uint64_t)content_len +
-            (uint64_t) ASN1_BER_GET_HIGH_TAG_NUM(raw_len)) > UINT32_MAX)
+        uint64_t tmp_len = ((uint64_t)content_len << 8) + (uint64_t) raw_len;
+        if (tmp_len > UINT32_MAX)
         {
             node->flags |= ASN1_BER_EVENT_LEN_TOO_LONG;
             ac->parser_status = ASN1_STATUS_INVALID;
             return ASN1_PARSER_ERR;
         }
 
-        content_len += raw_len;
+        content_len = tmp_len;
     }
 
     ac->iter++;
@@ -674,9 +674,9 @@ static int DecodeAsn1Test05(void)
 
     SCAsn1Decode(ac, ac->cur_frame);
     Asn1Node *node = ASN1CTX_GET_NODE(ac, 0);
-    if (node->len.len!= 32) {
+    if (node->len.len!= 4112) {
         ret = 0;
-        printf("Error, expected length 10, got %"PRIu32": ", node->len.len);
+        printf("Error, expected length 4112, got %"PRIu32": ", node->len.len);
         goto end;
     }
 
@@ -705,7 +705,7 @@ static int DecodeAsn1Test06(void)
     Asn1Node *node = ASN1CTX_GET_NODE(ac, 0);
     if (node->len.len != 38) {
         ret = 0;
-        printf("Error, expected length 10, got %"PRIu32": ", node->len.len);
+        printf("Error, expected length 38, got %"PRIu32": ", node->len.len);
         goto end;
     }
 


### PR DESCRIPTION
rebase'd to master

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3628

Describe changes:
- Changed definite long form parsing of length field from additive to decoding the bytes into a uint32_t
- Updated test cases

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

Previous PR: https://github.com/OISF/suricata/pull/4798