### PR TITLE
detect: Validate content with transforms

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1936,7 +1936,7 @@ Example:
 ::
 
   [10703] 26/11/2010 -- 11:41:15 - (detect.c:560) <Info> (SigLoadSignatures)
-  -- Engine-Analyis for fast_pattern printed to file - /var/log/suricata/rules_fast_pattern.txt
+  -- Engine-Analysis for fast_pattern printed to file - /var/log/suricata/rules_fast_pattern.txt
 
   == Sid: 1292 ==
   Fast pattern matcher: content

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -335,6 +335,16 @@ int DetectContentSetup(DetectEngineCtx *de_ctx, Signature *s, const char *conten
     int sm_list = s->init_data->list;
     if (sm_list == DETECT_SM_LIST_NOTSET) {
         sm_list = DETECT_SM_LIST_PMATCH;
+    } else if (sm_list > DETECT_SM_LIST_MAX &&
+            0 == (cd->flags & DETECT_CONTENT_NEGATED)) {
+        /* Check transform compatibility */
+        const char *tstr;
+        if (!DetectBufferTypeValidateTransform(de_ctx, sm_list, contentstr, &tstr)) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE,
+                    "content string \"%s\" incompatible with %s transform",
+                    contentstr, tstr);
+            goto error;
+        }
     }
 
     sm = SigMatchAlloc();

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2018 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -413,7 +413,7 @@ void CleanupFPAnalyzer(void)
 void CleanupRuleAnalyzer(void)
 {
     if (rule_engine_analysis_FD != NULL) {
-         SCLogInfo("Engine-Analyis for rules printed to file - %s", log_path);
+         SCLogInfo("Engine-Analysis for rules printed to file - %s", log_path);
         fclose(rule_engine_analysis_FD);
         rule_engine_analysis_FD = NULL;
     }

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1161,6 +1161,47 @@ void InspectionBufferCopy(InspectionBuffer *buffer, uint8_t *buf, uint32_t buf_l
     }
 }
 
+/** \brief Check content string compatibility with transforms
+ *
+ *  The "checkstr" is presented to the transforms so that each transform may
+ *  validate that it's compatible with the transform.
+ *
+ *  When a transform indicates the string is incompatible, none of the subsequent
+ *  transforms, if any, are checked.
+ *
+ *  \param de_ctx Detection engine context.
+ *  \param sm_list The SM list id.
+ *  \param checkstr the content string being validated
+ *  \param namestr returns the name of the transform that is incompatible with checkstr.
+ *
+ *  \retval true (false) If any of the transforms indicate the string is not
+ *  compatible.
+ **/
+bool DetectBufferTypeValidateTransform(DetectEngineCtx *de_ctx, int sm_list,
+        const char *checkstr, const char **namestr)
+{
+    const DetectBufferType *dbt = DetectBufferTypeGetById(de_ctx, sm_list);
+    BUG_ON(dbt == NULL);
+
+    for (int i = 0; i < dbt->transforms.cnt; i++) {
+        const TransformData *t = &dbt->transforms.transforms[i];
+        if (!sigmatch_table[t->transform].TransformValidate)
+            continue;
+
+        if (sigmatch_table[t->transform].TransformValidate(checkstr, t->options)) {
+            continue;
+        }
+
+        if (namestr) {
+            *namestr = sigmatch_table[t->transform].name;
+        }
+
+        return false;
+        }
+
+    return true;
+}
+
 void InspectionBufferApplyTransforms(InspectionBuffer *buffer,
         const DetectEngineTransforms *transforms)
 {

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -35,6 +35,7 @@ void InspectionBufferCheckAndExpand(InspectionBuffer *buffer, uint32_t min_size)
 void InspectionBufferCopy(InspectionBuffer *buffer, uint8_t *buf, uint32_t buf_len);
 void InspectionBufferApplyTransforms(InspectionBuffer *buffer,
         const DetectEngineTransforms *transforms);
+bool DetectBufferTypeValidateTransform(DetectEngineCtx *de_ctx, int list_id, const char *, const char **namestr);
 void InspectionBufferClean(DetectEngineThreadCtx *det_ctx);
 InspectionBuffer *InspectionBufferGet(DetectEngineThreadCtx *det_ctx, const int list_id);
 InspectionBuffer *InspectionBufferMultipleForListGet(InspectionBufferMultipleForList *fb, uint32_t local_id);

--- a/src/detect-transform-strip-whitespace.c
+++ b/src/detect-transform-strip-whitespace.c
@@ -38,6 +38,7 @@ static int DetectTransformStripWhitespaceSetup (DetectEngineCtx *, Signature *, 
 static void DetectTransformStripWhitespaceRegisterTests(void);
 
 static void TransformStripWhitespace(InspectionBuffer *buffer, void *options);
+static bool TransformStripWhitespaceValidate(const char *string, void *options);
 
 void DetectTransformStripWhitespaceRegister(void)
 {
@@ -48,6 +49,8 @@ void DetectTransformStripWhitespaceRegister(void)
         "/rules/transforms.html#strip-whitespace";
     sigmatch_table[DETECT_TRANSFORM_STRIP_WHITESPACE].Transform =
         TransformStripWhitespace;
+    sigmatch_table[DETECT_TRANSFORM_STRIP_WHITESPACE].TransformValidate =
+        TransformStripWhitespaceValidate;
     sigmatch_table[DETECT_TRANSFORM_STRIP_WHITESPACE].Setup =
         DetectTransformStripWhitespaceSetup;
     sigmatch_table[DETECT_TRANSFORM_STRIP_WHITESPACE].RegisterTests =
@@ -70,6 +73,16 @@ static int DetectTransformStripWhitespaceSetup (DetectEngineCtx *de_ctx, Signatu
     SCEnter();
     int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_STRIP_WHITESPACE, NULL);
     SCReturnInt(r);
+}
+
+static bool TransformStripWhitespaceValidate(const char *string, void *options)
+{
+    while (string && *string) {
+        if (isspace(*string++)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 static void TransformStripWhitespace(InspectionBuffer *buffer, void *options)

--- a/src/detect.h
+++ b/src/detect.h
@@ -1189,6 +1189,7 @@ typedef struct SigTableElmt_ {
 
     /** InspectionBuffer transformation callback */
     void (*Transform)(InspectionBuffer *, void *context);
+    bool (*TransformValidate)(const char *contentstr, void *context);
 
     /** keyword setup function pointer */
     int (*Setup)(DetectEngineCtx *, Signature *, const char *);


### PR DESCRIPTION
This PR addresses content validation with transforms. A new API has been created to allow buffer validation with transforms as they may have behavior that could render a content match impossible. These incompatibilities can be detected when parsing rules.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3661](https://redmine.openinfosecfoundation.org/issues/3661)

Describe changes:
- Add API for content validation by transforms
- Content -- validate with transforms during setup
- Add `strip-whitespace` validation

#suricata-verify-pr: https://github.com/OISF/suricata-verify/pull/249
#suricata-verify-repo: https://github.com/jlucovsky/suricata-verify
#suricata-verify-branch: 3661/1
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
