### PR TITLE
 detect/http_raw_header: Correct type mismatch

### DIFF
--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -186,7 +186,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             tx_ud->request_headers_raw : tx_ud->response_headers_raw;
         if (data == NULL)
             return NULL;
-        const uint8_t data_len = ts ?
+        const uint32_t data_len = ts ?
             tx_ud->request_headers_raw_len : tx_ud->response_headers_raw_len;
 
         InspectionBufferSetup(buffer, data, data_len);


### PR DESCRIPTION
This changeset fixes a bug on the computation of the buffer
lenght for raw http headers. The bug is due to a mismatch
on the data type of the length (uint8_t vs uint32_t) and it
was causing signature misses.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3504

Notice I did not create the ticket and I did not know how to assign it to me.
Describe changes:
- Fix the data type mismatch in InspectionBuffer *GetData (detect-http-raw-header.c)
-
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
