### PR TITLE
Pin Nom to 5.1.1

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -18,7 +18,7 @@ debug = []
 debug-validate = []
 
 [dependencies]
-nom = "5.0"
+nom = "= 5.1.1"
 bitflags = "1.0"
 byteorder = "1.3"
 uuid = "0.8"


### PR DESCRIPTION
Nom 5.1.2 pulls in a dependency that doesn't build on Rust 1.34,
a version of Rust we need to support for Debian.
