### PR TITLE
Byteextractstr/part2/v6

### DIFF
--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -26,6 +26,7 @@
 #define _THREAD_AFFINITY
 #include "util-affinity.h"
 #include "util-cpu.h"
+#include "util-byte.h"
 #include "conf.h"
 #include "threads.h"
 #include "queue.h"
@@ -280,7 +281,10 @@ void AffinitySetupLoadFromConfig()
 
         node = ConfNodeLookupChild(affinity->head.tqh_first, "threads");
         if (node != NULL) {
-            taf->nb_threads = atoi(node->val);
+            if (StringParseInt32(&taf->nb_threads, 10, 0, (const char *)node->val) < 0) {
+                FatalError(SC_ERR_INVALID_ARGUMENT, "invalid value for threads "
+                           "count: '%s'", node->val);
+            }
             if (! taf->nb_threads) {
                 SCLogError(SC_ERR_INVALID_ARGUMENT, "bad value for threads count");
                 exit(EXIT_FAILURE);

--- a/src/util-byte.c
+++ b/src/util-byte.c
@@ -152,6 +152,9 @@ int ByteExtractUint32(uint32_t *res, int e, uint16_t len, const uint8_t *bytes)
     }
 
     ret = ByteExtract(&i64, e, len, bytes);
+    if (i64 > UINT32_MAX) {
+        return -1;
+    }
     if (ret <= 0) {
         return ret;
     }
@@ -173,6 +176,9 @@ int ByteExtractUint16(uint16_t *res, int e, uint16_t len, const uint8_t *bytes)
     }
 
     ret = ByteExtract(&i64, e, len, bytes);
+    if (i64 > UINT16_MAX) {
+        return -1;
+    }
     if (ret <= 0) {
         return ret;
     }
@@ -244,6 +250,9 @@ int ByteExtractStringUint32(uint32_t *res, int base, uint16_t len, const char *s
     if (ret <= 0) {
         return ret;
     }
+    if (i64 > UINT32_MAX) {
+        return -1;
+    }
 
     *res = (uint32_t)i64;
 
@@ -264,6 +273,9 @@ int ByteExtractStringUint16(uint16_t *res, int base, uint16_t len, const char *s
     if (ret <= 0) {
         return ret;
     }
+    if (i64 > UINT16_MAX) {
+        return -1;
+    }
 
     *res = (uint16_t)i64;
 
@@ -283,6 +295,9 @@ int ByteExtractStringUint8(uint8_t *res, int base, uint16_t len, const char *str
     int ret = ByteExtractString(&i64, base, len, str, false);
     if (ret <= 0) {
         return ret;
+    }
+    if (i64 > UINT8_MAX) {
+        return -1;
     }
 
     *res = (uint8_t)i64;
@@ -309,6 +324,9 @@ int StringParseUint32(uint32_t *res, int base, uint16_t len, const char *str)
     if (ret <= 0) {
         return ret;
     }
+    if (i64 > UINT32_MAX) {
+        return -1;
+    }
 
     *res = (uint32_t)i64;
 
@@ -329,6 +347,9 @@ int StringParseUint16(uint16_t *res, int base, uint16_t len, const char *str)
     if (ret <= 0) {
         return ret;
     }
+    if (i64 > UINT16_MAX) {
+        return -1;
+    }
 
     *res = (uint16_t)i64;
 
@@ -348,6 +369,9 @@ int StringParseUint8(uint8_t *res, int base, uint16_t len, const char *str)
     int ret = ByteExtractString(&i64, base, len, str, true);
     if (ret <= 0) {
         return ret;
+    }
+    if (i64 > UINT8_MAX) {
+        return -1;
     }
 
     *res = (uint8_t)i64;
@@ -389,6 +413,9 @@ int StringParseU32RangeCheck(uint32_t *res, int base, uint16_t len, const char *
     if (ret <= 0) {
         return ret;
     }
+    if (u64 > UINT32_MAX) {
+        return -1;
+    }
 
     *res = (uint32_t)u64;
 
@@ -414,6 +441,9 @@ int StringParseU16RangeCheck(uint16_t *res, int base, uint16_t len, const char *
     if (ret <= 0) {
         return ret;
     }
+    if (u64 > UINT16_MAX) {
+        return -1;
+    }
 
     *res = (uint16_t)u64;
 
@@ -438,6 +468,9 @@ int StringParseU8RangeCheck(uint8_t *res, int base, uint16_t len, const char *st
     int ret = ByteExtractString(&u64, base, len, str, true);
     if (ret <= 0) {
         return ret;
+    }
+    if (u64 > UINT8_MAX) {
+        return -1;
     }
 
     *res = (uint8_t)u64;
@@ -515,6 +548,9 @@ int ByteExtractStringInt32(int32_t *res, int base, uint16_t len, const char *str
     if (ret <= 0) {
         return ret;
     }
+    if (i64 < INT32_MIN || i64 > INT32_MAX) {
+        return -1;
+    }
 
     *res = (int32_t)i64;
 
@@ -536,6 +572,9 @@ int ByteExtractStringInt16(int16_t *res, int base, uint16_t len, const char *str
     if (ret <= 0) {
         return ret;
     }
+    if (i64 < INT16_MIN || i64 > INT16_MAX) {
+        return -1;
+    }
 
     *res = (int16_t)i64;
 
@@ -556,6 +595,9 @@ int ByteExtractStringInt8(int8_t *res, int base, uint16_t len, const char *str)
     ret = ByteExtractStringSigned(&i64, base, len, str, false);
     if (ret <= 0) {
         return ret;
+    }
+    if (i64 < INT8_MIN || i64 > INT8_MAX) {
+        return -1;
     }
 
     *res = (int8_t)i64;
@@ -583,6 +625,9 @@ int StringParseInt32(int32_t *res, int base, uint16_t len, const char *str)
     if (ret <= 0) {
         return ret;
     }
+    if (i64 < INT32_MIN || i64 > INT32_MAX) {
+        return -1;
+    }
 
     *res = (int32_t)i64;
 
@@ -604,6 +649,9 @@ int StringParseInt16(int16_t *res, int base, uint16_t len, const char *str)
     if (ret <= 0) {
         return ret;
     }
+    if (i64 < INT16_MIN || i64 > INT16_MAX) {
+        return -1;
+    }
 
     *res = (int16_t)i64;
 
@@ -624,6 +672,9 @@ int StringParseInt8(int8_t *res, int base, uint16_t len, const char *str)
     ret = ByteExtractStringSigned(&i64, base, len, str, true);
     if (ret <= 0) {
         return ret;
+    }
+    if (i64 < INT8_MIN || i64 > INT8_MAX) {
+        return -1;
     }
 
     *res = (int8_t)i64;
@@ -666,6 +717,9 @@ int StringParseI32RangeCheck(int32_t *res, int base, uint16_t len, const char *s
     if (ret <= 0) {
         return ret;
     }
+    if (i64 < INT32_MIN || i64 > INT32_MAX) {
+        return -1;
+    }
 
     *res = (int32_t)i64;
 
@@ -692,6 +746,9 @@ int StringParseI16RangeCheck(int16_t *res, int base, uint16_t len, const char *s
     if (ret <= 0) {
         return ret;
     }
+    if (i64 < INT16_MIN || i64 > INT16_MAX) {
+        return -1;
+    }
 
     *res = (int16_t)i64;
 
@@ -717,6 +774,9 @@ int StringParseI8RangeCheck(int8_t *res, int base, uint16_t len, const char *str
     ret = ByteExtractStringSigned(&i64, base, len, str, true);
     if (ret <= 0) {
         return ret;
+    }
+    if (i64 < INT8_MIN || i64 > INT8_MAX) {
+        return -1;
     }
 
     *res = (int8_t)i64;

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -34,6 +34,7 @@
 #include "util-error.h"
 #include "util-debug.h"
 #include "util-fmemopen.h"
+#include "util-byte.h"
 
 /* Regex to parse the classtype argument from a Signature.  The first substring
  * holds the classtype name, the second substring holds the classtype the
@@ -281,11 +282,9 @@ int SCClassConfAddClasstype(DetectEngineCtx *de_ctx, char *rawstr, uint16_t inde
         SCLogInfo("pcre_copy_substring() failed");
         goto error;
     }
-    if (strlen(ct_priority_str) == 0) {
+    if (StringParseInt32(&ct_priority, 10, 0, (const char *)ct_priority_str) < 0) {
         goto error;
     }
-
-    ct_priority = atoi(ct_priority_str);
 
     /* Create a new instance of the parsed Classtype string */
     ct_new = SCClassConfAllocClasstype(ct_id, ct_name, ct_desc, ct_priority);

--- a/src/util-cpu.c
+++ b/src/util-cpu.c
@@ -27,6 +27,7 @@
 #include "util-error.h"
 #include "util-debug.h"
 #include "util-cpu.h"
+#include "util-byte.h"
 
 /**
  * Ok, if they should use sysconf, check that they have the macro's
@@ -75,9 +76,15 @@ uint16_t UtilCpuGetNumProcessorsConfigured(void)
 
     return (uint16_t)nprocs;
 #elif OS_WIN32
-	long nprocs = -1;
-	const char* envvar = getenv("NUMBER_OF_PROCESSORS");
-	nprocs = (NULL != envvar) ? atoi(envvar) : 0;
+    int64_t nprocs = 0;
+    const char* envvar = getenv("NUMBER_OF_PROCESSORS");
+    if (envvar != NULL) {
+        if (StringParseInt64(&nprocs, 10, 0, envvar) < 0) {
+            SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for number of "
+                         "processors: %s", envvar);
+            return 0;
+        }
+    }
     if (nprocs < 1) {
         SCLogError(SC_ERR_SYSCALL, "Couldn't retrieve the number of cpus "
                    "configured from the NUMBER_OF_PROCESSORS environment variable");

--- a/src/util-host-os-info.c
+++ b/src/util-host-os-info.c
@@ -29,6 +29,7 @@
 #include "util-debug.h"
 #include "util-ip.h"
 #include "util-radix-tree.h"
+#include "util-byte.h"
 #include "stream-tcp-private.h"
 #include "stream-tcp-reassemble.h"
 
@@ -186,8 +187,7 @@ int SCHInfoAddHostOSInfo(const char *host_os, const char *host_os_ip_range, int 
             SCRadixAddKeyIPV4((uint8_t *)ipv4_addr, sc_hinfo_tree,
                               (void *)user_data);
         } else {
-            netmask_value = atoi(netmask_str);
-            if (netmask_value < 0 || netmask_value > 32) {
+            if (StringParseI32RangeCheck(&netmask_value, 10, 0, (const char *)netmask_str, 0, 32) < 0) {
                 SCLogError(SC_ERR_INVALID_IP_NETBLOCK, "Invalid IPV4 Netblock");
                 SCHInfoFreeUserDataOSPolicy(user_data);
                 SCFree(ipv4_addr);
@@ -212,8 +212,7 @@ int SCHInfoAddHostOSInfo(const char *host_os, const char *host_os_ip_range, int 
             SCRadixAddKeyIPV6((uint8_t *)ipv6_addr, sc_hinfo_tree,
                               (void *)user_data);
         } else {
-            netmask_value = atoi(netmask_str);
-            if (netmask_value < 0 || netmask_value > 128) {
+            if (StringParseI32RangeCheck(&netmask_value, 10, 0, (const char *)netmask_str, 0, 128) < 0) {
                 SCLogError(SC_ERR_INVALID_IP_NETBLOCK, "Invalid IPV6 Netblock");
                 SCHInfoFreeUserDataOSPolicy(user_data);
                 SCFree(ipv6_addr);

--- a/src/util-ip.c
+++ b/src/util-ip.c
@@ -26,6 +26,7 @@
 
 #include "suricata-common.h"
 #include "util-ip.h"
+#include "util-byte.h"
 
 /** \brief determine if a string is a valid ipv4 address
  *  \retval bool is addr valid?
@@ -65,9 +66,9 @@ bool IPv4AddressStringIsValid(const char *str)
 
     addr[dots][alen] = '\0';
     for (int x = 0; x < 4; x++) {
-        int a = atoi(addr[x]);
-        if (a < 0 || a >= 256) {
-            SCLogDebug("out of range");
+        int32_t a;
+        if (StringParseI32RangeCheck(&a, 10, 0, (const char *)addr[x], 0, 255) < 0) {
+            SCLogDebug("invalid value for address byte: %s", addr[x]);
             return false;
         }
     }

--- a/src/util-log-redis.c
+++ b/src/util-log-redis.c
@@ -26,6 +26,7 @@
 #include "suricata-common.h" /* errno.h, string.h, etc. */
 #include "util-log-redis.h"
 #include "util-logopenfile.h"
+#include "util-byte.h"
 
 #ifdef HAVE_LIBHIREDIS
 
@@ -534,7 +535,9 @@ int SCConfLogOpenRedis(ConfNode *redis_node, void *lf_ctx)
         SCLogError(SC_ERR_MEM_ALLOC, "Error allocating redis server string");
         exit(EXIT_FAILURE);
     }
-    log_ctx->redis_setup.port = atoi(redis_port);
+    if (StringParseUint16(&log_ctx->redis_setup.port, 10, 0, (const char *)redis_port) < 0) {
+        FatalError(SC_ERR_INVALID_VALUE, "Invalid value for redis port: %s", redis_port);
+    }
     log_ctx->Close = SCLogFileCloseRedis;
 
 #ifdef HAVE_LIBEVENT

--- a/src/util-log-redis.h
+++ b/src/util-log-redis.h
@@ -41,7 +41,7 @@ typedef struct RedisSetup_ {
     const char *command;
     const char *key;
     const char *server;
-    int  port;
+    uint16_t  port;
     int is_async;
     int  batch_size;
 } RedisSetup;

--- a/src/util-napatech.c
+++ b/src/util-napatech.c
@@ -768,10 +768,20 @@ static uint32_t CountWorkerThreads(void)
 
                         char copystr[16];
                         strlcpy(copystr, lnode->val, 16);
-
-                        ByteExtractStringUint8(&start, 10,  0, copystr);
-                        ByteExtractStringUint8(&end, 10,  0, strchr(copystr, '-') + 1);
-
+                        if (StringParseUint8(&start, 10, 0, (const char *)copystr) < 0) {
+                            FatalError(SC_ERR_INVALID_VALUE, "Napatech invalid"
+                                       " worker range start: '%s'", copystr);
+                        }
+                        char *end_str = strchr(copystr, '-');
+                        if ((end_str == NULL) || (end_str != NULL && StringParseUint8(&end,
+                                        10, 0, (const char *) (end_str + 1)) < 0)) {
+                            FatalError(SC_ERR_INVALID_VALUE, "Napatech invalid"
+                                       " worker range end: '%s'", (end_str != NULL) ? (const char *)(end_str + 1) : "Null");
+                        }
+                        if (end < start) {
+                            FatalError(SC_ERR_INVALID_VALUE, "Napatech invalid"
+                                       " worker range start: '%s' is greater than end: '%s'", start, end);
+                        }
                         worker_count = end - start + 1;
 
                     } else {
@@ -916,8 +926,16 @@ int NapatechGetStreamConfig(NapatechStreamConfig stream_config[])
 
                     char copystr[16];
                     strlcpy(copystr, stream->val, 16);
-                    ByteExtractStringUint16(&start, 10,  0, copystr);
-                    ByteExtractStringUint16(&end, 10,  0, strchr(copystr, '-') + 1);
+                    if (StringParseUint8(&start, 10, 0, (const char *)copystr) < 0) {
+                        FatalError(SC_ERR_INVALID_VALUE, "Napatech invalid "
+                                   "stream_id start: '%s'", copystr);
+                    }
+                    char *end_str = strchr(copystr, '-');
+                    if ((end_str == NULL) || (end_str != NULL && StringParseUint8(&end,
+                                    10, 0, (const char *) (end_str + 1)) < 0)) {
+                        FatalError(SC_ERR_INVALID_VALUE, "Napatech invalid "
+                                   "stream_id end: '%s'", (end_str != NULL) ? (const char *)(end_str + 1) : "Null");
+                    }
                 } else {
                     if (stream_spec == CONFIG_SPECIFIER_RANGE) {
                         SCLogError(SC_ERR_NAPATECH_PARSE_CONFIG,
@@ -925,7 +943,11 @@ int NapatechGetStreamConfig(NapatechStreamConfig stream_config[])
                         exit(EXIT_FAILURE);
                     }
                     stream_spec = CONFIG_SPECIFIER_INDIVIDUAL;
-                    ByteExtractStringUint16(&stream_config[instance_cnt].stream_id, 10,  0, stream->val);
+                    if (StringParseUint16(&stream_config[instance_cnt].stream_id,
+                                          10, 0, (const char *)stream->val) < 0) {
+                        FatalError(SC_ERR_INVALID_VALUE, "Napatech invalid "
+                                   "stream id: '%s'", stream->val);
+                    }
                     start = stream_config[instance_cnt].stream_id;
                     end = stream_config[instance_cnt].stream_id;
                 }

--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -31,6 +31,7 @@
 #include "suricata.h"
 
 #include "util-privs.h"
+#include "util-byte.h"
 
 #ifdef HAVE_LIBCAP_NG
 
@@ -154,7 +155,9 @@ int SCGetUserID(const char *user_name, const char *group_name, uint32_t *uid, ui
 
     /* Get the user ID */
     if (isdigit((unsigned char)user_name[0]) != 0) {
-        userid = atoi(user_name);
+        if (ByteExtractStringUint32(&userid, 10, 0, (const char *)user_name) < 0) {
+            FatalError(SC_ERR_UID_FAILED, "invalid user id value: '%s'", user_name);
+        }
         pw = getpwuid(userid);
        if (pw == NULL) {
             SCLogError(SC_ERR_UID_FAILED, "unable to get the user ID, "
@@ -176,7 +179,9 @@ int SCGetUserID(const char *user_name, const char *group_name, uint32_t *uid, ui
         struct group *gp;
 
         if (isdigit((unsigned char)group_name[0]) != 0) {
-            groupid = atoi(group_name);
+            if (ByteExtractStringUint32(&groupid, 10, 0, (const char *)group_name) < 0) {
+                FatalError(SC_ERR_GID_FAILED, "invalid group id: '%s'", group_name);
+            }
         } else {
             gp = getgrnam(group_name);
             if (gp == NULL) {
@@ -216,7 +221,9 @@ int SCGetGroupID(const char *group_name, uint32_t *gid)
 
     /* Get the group ID */
     if (isdigit((unsigned char)group_name[0]) != 0) {
-        grpid = atoi(group_name);
+        if (ByteExtractStringUint32(&grpid, 10, 0, (const char *)group_name) < 0) {
+            FatalError(SC_ERR_GID_FAILED, "invalid group id: '%s'", group_name);
+        }
     } else {
         gp = getgrnam(group_name);
         if (gp == NULL) {

--- a/src/util-proto-name.c
+++ b/src/util-proto-name.c
@@ -26,6 +26,7 @@
 
 #include "suricata-common.h"
 #include "util-proto-name.h"
+#include "util-byte.h"
 
 /** Lookup array to hold the information related to known protocol
  *  in /etc/protocols */
@@ -60,10 +61,9 @@ void SCProtoNameInit()
             if (proto_ch == NULL)
                 continue;
 
-            int proto = atoi(proto_ch);
-            if (proto >= 255)
+            uint8_t proto;
+            if (StringParseU8RangeCheck(&proto, 10, 0, (const char *)proto_ch, 0, 255) < 0)
                 continue;
-
             char *cname = strtok_r(NULL, " \t", &ptr);
 
             if (known_proto[proto] != NULL) {

--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -30,6 +30,7 @@
 #include "util-ip.h"
 #include "util-unittest.h"
 #include "util-memcmp.h"
+#include "util-byte.h"
 
 /**
  * \brief Allocates and returns a new instance of SCRadixUserData.
@@ -947,7 +948,7 @@ SCRadixNode *SCRadixAddKeyIPV4String(const char *str, SCRadixTree *tree, void *u
 
     /* Does it have a mask? */
     if (NULL != (mask_str = strchr(ip_str, '/'))) {
-        int cidr;
+        uint8_t cidr;
         *(mask_str++) = '\0';
 
         /* Dotted type netmask not supported (yet) */
@@ -956,10 +957,10 @@ SCRadixNode *SCRadixAddKeyIPV4String(const char *str, SCRadixTree *tree, void *u
         }
 
         /* Get binary values for cidr mask */
-        cidr = atoi(mask_str);
-        if ((cidr < 0) || (cidr > 32)) {
+        if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask_str, 0, 32) < 0) {
             return NULL;
         }
+
         netmask = (uint8_t)cidr;
     }
 
@@ -995,7 +996,7 @@ SCRadixNode *SCRadixAddKeyIPV6String(const char *str, SCRadixTree *tree, void *u
 
     /* Does it have a mask? */
     if (NULL != (mask_str = strchr(ip_str, '/'))) {
-        int cidr;
+        uint8_t cidr;
         *(mask_str++) = '\0';
 
         /* Dotted type netmask not supported (yet) */
@@ -1004,10 +1005,10 @@ SCRadixNode *SCRadixAddKeyIPV6String(const char *str, SCRadixTree *tree, void *u
         }
 
         /* Get binary values for cidr mask */
-        cidr = atoi(mask_str);
-        if ((cidr < 0) || (cidr > 128)) {
+        if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask_str, 0, 128) < 0) {
             return NULL;
         }
+
         netmask = (uint8_t)cidr;
     }
 


### PR DESCRIPTION
atoi() and related functions lack a mechanism for reporting errors for
invalid values. Replace them with calls to the appropriate
ByteExtractString* and StringParse* functions.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3053

Rework of #4970 