### PR TITLE
fuzz: improves fuzz target applayerparserparse

### DIFF
--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -126,6 +126,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             free(isolatedBuffer);
             flags &= ~(STREAM_START);
             if (f->alparser && AppLayerParserStateIssetFlag(f->alparser, APP_LAYER_PARSER_EOF)) {
+                //no final chunk
+                alsize = 0;
                 break;
             }
         }
@@ -137,6 +139,15 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         alnext = memmem(albuffer, alsize, separator, 4);
     }
     if (alsize > 0 ) {
+        if (flip) {
+            flags |= STREAM_TOCLIENT;
+            flags &= ~(STREAM_TOSERVER);
+            flip = 0;
+        } else {
+            flags |= STREAM_TOSERVER;
+            flags &= ~(STREAM_TOCLIENT);
+            flip = 1;
+        }
         flags |= STREAM_EOF;
         isolatedBuffer = malloc(alsize);
         if (isolatedBuffer == NULL) {


### PR DESCRIPTION
Does not proceed final chunk if we got an error previously
Flips the direction for last chunk as usual

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=22832

Describe changes:
- Fixes fuzz target `fuzz_applayerparserparse` by _not_ processing a last chunk if we had an error previously

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
