### PR TITLE
Fuzz bettertargets v1

### DIFF
--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -298,6 +298,11 @@ static uint16_t DNP3ProbingParser(Flow *f, uint8_t direction,
     }
 
 end:
+    // Test compatibility between direction and dnp3.ctl.direction
+    if ((DNP3_LINK_DIR(hdr->control) != 0) ^
+        ((direction & STREAM_TOCLIENT) != 0)) {
+        *rdir = 1;
+    }
     SCLogDebug("Detected DNP3.");
     return ALPROTO_DNP3;
 }

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -175,6 +175,9 @@ static uint16_t DNP3ComputeCRC(const uint8_t *buf, uint32_t len)
  */
 static int DNP3CheckCRC(const uint8_t *block, uint32_t len)
 {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    return 1;
+#endif
     uint32_t crc_offset;
     uint16_t crc;
 

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -126,6 +126,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             free(isolatedBuffer);
             flags &= ~(STREAM_START);
             if (f->alparser && AppLayerParserStateIssetFlag(f->alparser, APP_LAYER_PARSER_EOF)) {
+                //no final chunk
+                alsize = 0;
                 break;
             }
         }
@@ -137,6 +139,15 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         alnext = memmem(albuffer, alsize, separator, 4);
     }
     if (alsize > 0 ) {
+        if (flip) {
+            flags |= STREAM_TOCLIENT;
+            flags &= ~(STREAM_TOSERVER);
+            flip = 0;
+        } else {
+            flags |= STREAM_TOSERVER;
+            flags &= ~(STREAM_TOCLIENT);
+            flip = 1;
+        }
         flags |= STREAM_EOF;
         isolatedBuffer = malloc(alsize);
         if (isolatedBuffer == NULL) {


### PR DESCRIPTION
Does not proceed final chunk if we got an error previously
Flips the direction for last chunk as usual

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) tickets:
https://redmine.openinfosecfoundation.org/issues/3772
https://redmine.openinfosecfoundation.org/issues/3773
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=22832

Describe changes:
- Fixes fuzz target `fuzz_applayerparserparse` by _not_ processing a last chunk if we had an error previously
- Improves DNP3 fuzzing by not checking CRC while fuzzing
- Improves DNP3 probing parser by fixing direction based on header field

Should I make a S-V test for the last one ?

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
