### PR TITLE
Fuzz dnp3 fixes v1

### DIFF
--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -298,6 +298,11 @@ static uint16_t DNP3ProbingParser(Flow *f, uint8_t direction,
     }
 
 end:
+    // Test compatibility between direction and dnp3.ctl.direction
+    if ((DNP3_LINK_DIR(hdr->control) != 0) ^
+        ((direction & STREAM_TOCLIENT) != 0)) {
+        *rdir = 1;
+    }
     SCLogDebug("Detected DNP3.");
     return ALPROTO_DNP3;
 }

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -2648,6 +2648,37 @@ static int DNP3ParserUnknownEventAlertTest(void)
     PASS;
 }
 
+/**
+* \brief Test that an alert is raised on incorrect data.
+*/
+static int DNP3ParserIncorrectUserData(void)
+{
+    uint8_t packet_bytes[] = {
+        0x05, 0x64, 0x08, 0xc4, 0x03, 0x00, 0x04, 0x00,
+        0xbf, 0xe9, 0xc1, 0xc1, 0x82, 0xc5, 0xee
+    };
+
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    Flow flow;
+    TcpSession ssn;
+    memset(&flow, 0, sizeof(flow));
+    memset(&ssn, 0, sizeof(ssn));
+    flow.protoctx = (void *)&ssn;
+    flow.proto = IPPROTO_TCP;
+    flow.alproto = ALPROTO_DNP3;
+    StreamTcpInitConfig(TRUE);
+
+    int r = AppLayerParserParse(NULL, alp_tctx, &flow, ALPROTO_DNP3,
+                                STREAM_TOCLIENT, packet_bytes, sizeof(packet_bytes));
+
+    FAIL_IF(r == 0);
+
+    AppLayerParserThreadCtxFree(alp_tctx);
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&flow);
+    PASS;
+}
+
 #endif
 
 void DNP3ParserRegisterTests(void)
@@ -2674,5 +2705,6 @@ void DNP3ParserRegisterTests(void)
     UtRegisterTest("DNP3ParserDecodeG70V3Test", DNP3ParserDecodeG70V3Test);
     UtRegisterTest("DNP3ParserUnknownEventAlertTest",
         DNP3ParserUnknownEventAlertTest);
+    UtRegisterTest("DNP3ParserIncorrectUserData", DNP3ParserIncorrectUserData);
 #endif
 }

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -559,9 +559,9 @@ static int DNP3IsUserData(const DNP3LinkHeader *header)
  *
  * \retval 1 if user data exists, otherwise 0.
  */
-static int DNP3HasUserData(const DNP3LinkHeader *header)
+static int DNP3HasUserData(const DNP3LinkHeader *header, uint8_t direction)
 {
-    if (DNP3_LINK_DIR(header->control)) {
+    if (direction == STREAM_TOSERVER) {
         return header->len >= DNP3_LINK_HDR_LEN + sizeof(DNP3TransportHeader) +
             sizeof(DNP3ApplicationHeader);
     }
@@ -1084,7 +1084,7 @@ static int DNP3HandleRequestLinkLayer(DNP3State *dnp3, const uint8_t *input,
 
         /* Make sure the header length is large enough for transport and
          * application headers. */
-        if (!DNP3HasUserData(header)) {
+        if (!DNP3HasUserData(header, STREAM_TOSERVER)) {
             DNP3SetEvent(dnp3, DNP3_DECODER_EVENT_LEN_TOO_SMALL);
             goto next;
         }
@@ -1223,7 +1223,7 @@ static int DNP3HandleResponseLinkLayer(DNP3State *dnp3, const uint8_t *input,
 
         /* Make sure the header length is large enough for transport and
          * application headers. */
-        if (!DNP3HasUserData(header)) {
+        if (!DNP3HasUserData(header, STREAM_TOCLIENT)) {
             DNP3SetEvent(dnp3, DNP3_DECODER_EVENT_LEN_TOO_SMALL);
             goto error;
         }
@@ -1264,6 +1264,7 @@ static AppLayerResult DNP3ParseResponse(Flow *f, void *state, AppLayerParserStat
     const uint8_t flags)
 {
     SCEnter();
+
     DNP3State *dnp3 = (DNP3State *)state;
     DNP3Buffer *buffer = &dnp3->response_buffer;
     int processed;

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -175,6 +175,9 @@ static uint16_t DNP3ComputeCRC(const uint8_t *buf, uint32_t len)
  */
 static int DNP3CheckCRC(const uint8_t *block, uint32_t len)
 {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    return 1;
+#endif
     uint32_t crc_offset;
     uint16_t crc;
 

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -126,6 +126,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             free(isolatedBuffer);
             flags &= ~(STREAM_START);
             if (f->alparser && AppLayerParserStateIssetFlag(f->alparser, APP_LAYER_PARSER_EOF)) {
+                //no final chunk
+                alsize = 0;
                 break;
             }
         }
@@ -137,6 +139,15 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         alnext = memmem(albuffer, alsize, separator, 4);
     }
     if (alsize > 0 ) {
+        if (flip) {
+            flags |= STREAM_TOCLIENT;
+            flags &= ~(STREAM_TOSERVER);
+            flip = 0;
+        } else {
+            flags |= STREAM_TOSERVER;
+            flags &= ~(STREAM_TOCLIENT);
+            flip = 1;
+        }
         flags |= STREAM_EOF;
         isolatedBuffer = malloc(alsize);
         if (isolatedBuffer == NULL) {


### PR DESCRIPTION
Does not proceed final chunk if we got an error previously
Flips the direction for last chunk as usual

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) tickets:
https://redmine.openinfosecfoundation.org/issues/3772
https://redmine.openinfosecfoundation.org/issues/3773
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=22832

Describe changes:
- Fixes fuzz target `fuzz_applayerparserparse` by _not_ processing a last chunk if we had an error previously
- Improves DNP3 fuzzing by not checking CRC while fuzzing
- Improves DNP3 probing parser by fixing direction based on header field
- Fixes DNP3 response parsing, as reported in #5063 

So, this is a mix of DNP3 and fuzzing, and can be split between different Pull Requests

Should I make a S-V test for the probing parser ?

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
