### PR TITLE
Fix stack overflow in DetectFlowbitsAnalyze

### DIFF
--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1418,7 +1418,9 @@ int SigAddressPrepareStage1(DetectEngineCtx *de_ctx)
         SCLogConfig("building signature grouping structure, stage 1: "
                "preprocessing rules... complete");
     }
-    DetectFlowbitsAnalyze(de_ctx);
+
+    if(DetectFlowbitsAnalyze(de_ctx) != 0)
+        goto error;
 
     return 0;
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1493,7 +1493,7 @@ void DetectSignatureApplyActions(Packet *p, const Signature *s, const uint8_t);
 void RuleMatchCandidateTxArrayInit(DetectEngineThreadCtx *det_ctx, uint32_t size);
 void RuleMatchCandidateTxArrayFree(DetectEngineThreadCtx *det_ctx);
 
-void DetectFlowbitsAnalyze(DetectEngineCtx *de_ctx);
+int DetectFlowbitsAnalyze(DetectEngineCtx *de_ctx);
 
 int DetectMetadataHashInit(DetectEngineCtx *de_ctx);
 void DetectMetadataHashFree(DetectEngineCtx *de_ctx);


### PR DESCRIPTION
Use dynamically allocated array instead of stack and free it after it is no longer needed.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:  https://redmine.openinfosecfoundation.org/issues/3783

Describe changes:
- Fix stack overflow in DetectFlowbitsAnalyze: Use dynamically allocated array instead of stack