### PR TITLE
3339/1

### DIFF
--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -81,6 +81,7 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
         goto fail;
     }
 
+    EveAddCommonOptions(&thread->dhcplog_ctx->cfg, p, f, js);
     MemBufferReset(thread->buffer);
     OutputJsonBuilderBuffer(js, thread->dhcplog_ctx->file_ctx, &thread->buffer);
     jb_free(js);

--- a/src/output-json-rdp.c
+++ b/src/output-json-rdp.c
@@ -46,6 +46,7 @@
 typedef struct LogRdpFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t    flags;
+    OutputJsonCommonSettings cfg;
 } LogRdpFileCtx;
 
 typedef struct LogRdpLogThread_ {
@@ -70,6 +71,7 @@ static int JsonRdpLogger(ThreadVars *tv, void *thread_data,
     }
     json_object_set_new(js, "rdp", rdp_js);
 
+    JsonAddCommonOptions(&thread->rdplog_ctx->cfg, p, f, js);
     MemBufferReset(thread->buffer);
     OutputJSONBuffer(js, thread->rdplog_ctx->file_ctx, &thread->buffer);
     json_decref(js);
@@ -99,6 +101,7 @@ static OutputInitResult OutputRdpLogInitSub(ConfNode *conf,
         return result;
     }
     rdplog_ctx->file_ctx = ajt->file_ctx;
+    rdplog_ctx->cfg = ajt->cfg;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/output-json-smb.c
+++ b/src/output-json-smb.c
@@ -75,6 +75,7 @@ static int JsonSMBLogger(ThreadVars *tv, void *thread_data,
     }
     jb_close(jb);
 
+    EveAddCommonOptions(&thread->ctx->cfg, p, f, jb);
     MemBufferReset(thread->buffer);
     OutputJsonBuilderBuffer(jb, thread->ctx->file_ctx, &thread->buffer);
 

--- a/src/output-json-tftp.c
+++ b/src/output-json-tftp.c
@@ -53,6 +53,7 @@
 typedef struct LogTFTPFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t    flags;
+    OutputJsonCommonSettings cfg;
 } LogTFTPFileCtx;
 
 typedef struct LogTFTPLogThread_ {
@@ -78,6 +79,7 @@ static int JsonTFTPLogger(ThreadVars *tv, void *thread_data,
 
     json_object_set_new(js, "tftp", tftpjs);
 
+    JsonAddCommonOptions(&thread->tftplog_ctx->cfg, p, f, js);
     MemBufferReset(thread->buffer);
     OutputJSONBuffer(js, thread->tftplog_ctx->file_ctx, &thread->buffer);
 
@@ -107,6 +109,7 @@ static OutputInitResult OutputTFTPLogInitSub(ConfNode *conf,
         return result;
     }
     tftplog_ctx->file_ctx = ajt->file_ctx;
+    tftplog_ctx->cfg = ajt->cfg;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -137,10 +137,7 @@ static int64_t sensor_id = -1; /* -1 = not defined */
 
 void EveFileInfo(JsonBuilder *jb, const File *ff, const bool stored)
 {
-    size_t filename_size = ff->name_len * 2 + 1;
-    char filename_string[filename_size];
-    BytesToStringBuffer(ff->name, ff->name_len, filename_string, filename_size);
-    jb_set_string(jb, "filename", filename_string);
+    jb_set_string_from_bytes(jb, "filename", ff->name, ff->name_len);
 
     jb_open_array(jb, "sid");
     for (uint32_t i = 0; ff->sid != NULL && i < ff->sid_cnt; i++) {


### PR DESCRIPTION
This PR adds community id output to dhcp, smb, rdp, and tftp log output when the community id has been configured and it can be calculated.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3339](https://redmine.openinfosecfoundation.org/issues/3339)

Describe changes:
- Ported  changes from https://github.com/regit/suricata/tree/forensic-mode for community id handling.
- Streamlined fileinfo filename handling to use `jb_set_string_from_bytes`

#suricata-verify-pr: https://github.com/OISF/suricata-verify/pull/260
#suricata-verify-repo: https://github.com/jlucovsky/suricata-verify/
#suricata-verify-branch: 3339/1
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
