### PR TITLE
Debug validate for JsonBuilder - v1

### DIFF
--- a/rust/src/common.rs
+++ b/rust/src/common.rs
@@ -30,6 +30,23 @@ macro_rules! debug_validate_bug_on (
   };
 );
 
+#[cfg(not(feature = "debug-validate"))]
+#[macro_export]
+macro_rules! debug_validate_fail (
+  ($msg:expr) => {};
+);
+
+#[cfg(feature = "debug-validate")]
+#[macro_export]
+macro_rules! debug_validate_fail (
+  ($msg:expr) => {
+    // Wrap in a conditional to prevent unreachable code warning in caller.
+    if true {
+      panic!($msg);
+    }
+  };
+);
+
 /// Convert a String to C-compatible string
 ///
 /// This function will consume the provided data and use the underlying bytes to construct a new

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -164,7 +164,10 @@ impl JsonBuilder {
                 self.pop_state();
                 Ok(self)
             }
-            _ => Err(JsonError::InvalidState),
+            State::None => {
+                debug_validate_fail!("invalid state");
+                Err(JsonError::InvalidState)
+            },
         }
     }
 
@@ -226,6 +229,7 @@ impl JsonBuilder {
                 self.buf.push_str(",\"");
             }
             _ => {
+                debug_validate_fail!("invalid state");
                 return Err(JsonError::InvalidState);
             }
         }
@@ -247,6 +251,7 @@ impl JsonBuilder {
                 self.buf.push(',');
             }
             _ => {
+                debug_validate_fail!("invalid state");
                 return Err(JsonError::InvalidState);
             }
         }
@@ -268,6 +273,7 @@ impl JsonBuilder {
                 self.buf.push(',');
             }
             _ => {
+                debug_validate_fail!("invalid state");
                 return Err(JsonError::InvalidState);
             }
         }
@@ -292,7 +298,10 @@ impl JsonBuilder {
                 self.encode_string(val)?;
                 Ok(self)
             }
-            _ => Err(JsonError::InvalidState),
+            _ => {
+                debug_validate_fail!("invalid state");
+                Err(JsonError::InvalidState)
+            }
         }
     }
 
@@ -313,6 +322,7 @@ impl JsonBuilder {
                 self.buf.push(',');
             }
             _ => {
+                debug_validate_fail!("invalid state");
                 return Err(JsonError::InvalidState);
             }
         }
@@ -329,6 +339,7 @@ impl JsonBuilder {
                 self.set_state(State::ObjectNth);
             }
             _ => {
+                debug_validate_fail!("invalid state");
                 return Err(JsonError::InvalidState);
             }
         }
@@ -352,6 +363,7 @@ impl JsonBuilder {
                 self.buf.push(',');
             }
             _ => {
+                debug_validate_fail!("invalid state");
                 return Err(JsonError::InvalidState);
             }
         }
@@ -365,7 +377,10 @@ impl JsonBuilder {
         match self.current_state() {
             State::ObjectNth => self.buf.push(','),
             State::ObjectFirst => self.set_state(State::ObjectNth),
-            _ => return Err(JsonError::InvalidState),
+            _ => {
+                debug_validate_fail!("invalid state");
+                return Err(JsonError::InvalidState);
+            }
         }
         self.buf.push('"');
         self.buf.push_str(key);
@@ -395,6 +410,7 @@ impl JsonBuilder {
                 self.set_state(State::ObjectNth);
             }
             _ => {
+                debug_validate_fail!("invalid state");
                 return Err(JsonError::InvalidState);
             }
         }
@@ -414,6 +430,7 @@ impl JsonBuilder {
                 self.set_state(State::ObjectNth);
             }
             _ => {
+                debug_validate_fail!("invalid state");
                 return Err(JsonError::InvalidState);
             }
         }
@@ -439,6 +456,7 @@ impl JsonBuilder {
                 self.set_state(State::ObjectNth);
             }
             _ => {
+                debug_validate_fail!("invalid state");
                 return Err(JsonError::InvalidState);
             }
         }
@@ -458,6 +476,7 @@ impl JsonBuilder {
                 self.set_state(State::ObjectNth);
             }
             _ => {
+                debug_validate_fail!("invalid state");
                 return Err(JsonError::InvalidState);
             }
         }

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -77,19 +77,12 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
     EveAddCommonOptions(&thread->dhcplog_ctx->cfg, p, f, js);
 
     rs_dhcp_logger_log(ctx->rs_logger, tx, js);
-    if (!jb_close(js)) {
-        goto fail;
-    }
 
     MemBufferReset(thread->buffer);
     OutputJsonBuilderBuffer(js, thread->dhcplog_ctx->file_ctx, &thread->buffer);
     jb_free(js);
 
     return TM_ECODE_OK;
-
-fail:
-    jb_free(js);
-    return TM_ECODE_FAILED;
 }
 
 static void OutputDHCPLogDeInitCtxSub(OutputCtx *output_ctx)


### PR DESCRIPTION
With --enable-debug-validation on, JsonBuilder will now panic if something is done in an invalid state, such as closing an already closed object which can lead to items not being logged.
