### PR TITLE
output/tftp: Convert to JsonBuilder

### DIFF
--- a/rust/src/tftp/log.rs
+++ b/rust/src/tftp/log.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -17,19 +17,27 @@
 
 // written by Clément Galland <clement.galland@epita.fr>
 
-use crate::json::*;
-use crate::tftp::tftp::*;
+use crate::jsonbuilder::{JsonBuilder, JsonError};
+use crate::tftp::tftp::TFTPTransaction;
+
+fn tftp_log_request(tx: &mut TFTPTransaction,
+                    jb: &mut JsonBuilder)
+                    -> Result<(), JsonError>
+{
+    match tx.opcode {
+        1 => jb.set_string("packet", "read")?,
+        2 => jb.set_string("packet", "write")?,
+        _ => jb.set_string("packet", "error")?
+    };
+    jb.set_string("file", tx.filename.as_str())?;
+    jb.set_string("mode", tx.mode.as_str())?;
+    Ok(())
+}
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_log_json_request(tx: &mut TFTPTransaction) -> *mut JsonT
+pub extern "C" fn rs_tftp_log_json_request(tx: &mut TFTPTransaction,
+                                           jb: &mut JsonBuilder)
+                                           -> bool
 {
-    let js = Json::object();
-    match tx.opcode {
-        1 => js.set_string("packet", "read"),
-        2 => js.set_string("packet", "write"),
-        _ => js.set_string("packet", "error")
-    };
-    js.set_string("file", tx.filename.as_str());
-    js.set_string("mode", tx.mode.as_str());
-    js.unwrap()
+    tftp_log_request(tx, jb).is_ok()
 }

--- a/src/output-json-tftp.c
+++ b/src/output-json-tftp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -67,27 +67,26 @@ static int JsonTFTPLogger(ThreadVars *tv, void *thread_data,
 {
     LogTFTPLogThread *thread = thread_data;
 
-    json_t *js = CreateJSONHeader(p, LOG_DIR_PACKET, "tftp", NULL);
-    if (unlikely(js == NULL)) {
+    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "tftp", NULL);
+    if (unlikely(jb == NULL)) {
         return TM_ECODE_FAILED;
     }
 
-    json_t *tftpjs = rs_tftp_log_json_request(tx);
-    if (unlikely(tftpjs == NULL)) {
+    jb_open_object(jb, "tftp");
+    if (unlikely(!rs_tftp_log_json_request(tx, jb))) {
         goto error;
     }
+    jb_close(jb);
 
-    json_object_set_new(js, "tftp", tftpjs);
-
-    JsonAddCommonOptions(&thread->tftplog_ctx->cfg, p, f, js);
+    EveAddCommonOptions(&thread->tftplog_ctx->cfg, p, f, jb);
     MemBufferReset(thread->buffer);
-    OutputJSONBuffer(js, thread->tftplog_ctx->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(jb, thread->tftplog_ctx->file_ctx, &thread->buffer);
 
-    json_decref(js);
+    jb_free(jb);
     return TM_ECODE_OK;
 
 error:
-    json_decref(js);
+    jb_free(jb);
     return TM_ECODE_FAILED;
 }
 


### PR DESCRIPTION
Continuation of #5123 

This commit converts the TFTP logging mechanisms to JsonBuilder.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3764](https://redmine.openinfosecfoundation.org/issues/3764)

Describe changes:
- Address review comments.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
