### PR TITLE
output/ikev2: Convert to JsonBuilder

### DIFF
--- a/src/output-json-ikev2.c
+++ b/src/output-json-ikev2.c
@@ -64,29 +64,28 @@ static int JsonIKEv2Logger(ThreadVars *tv, void *thread_data,
 {
     IKEV2Transaction *ikev2tx = tx;
     LogIKEv2LogThread *thread = thread_data;
-    json_t *js, *ikev2js;
 
-    js = CreateJSONHeader((Packet *)p, LOG_DIR_PACKET, "ikev2", NULL);
-    if (unlikely(js == NULL)) {
+    JsonBuilder *jb = CreateEveHeader((Packet *)p, LOG_DIR_PACKET, "ikev2", NULL);
+    if (unlikely(jb == NULL)) {
         return TM_ECODE_FAILED;
     }
 
-    JsonAddCommonOptions(&thread->ikev2log_ctx->cfg, p, f, js);
+    EveAddCommonOptions(&thread->ikev2log_ctx->cfg, p, f, jb);
 
-    ikev2js = rs_ikev2_log_json_response(state, ikev2tx);
-    if (unlikely(ikev2js == NULL)) {
+    jb_open_object(jb, "ikev2");
+    if (unlikely(!rs_ikev2_log_json_response(state, ikev2tx, jb))) {
         goto error;
     }
-    json_object_set_new(js, "ikev2", ikev2js);
+    jb_close(jb);
 
     MemBufferReset(thread->buffer);
-    OutputJSONBuffer(js, thread->ikev2log_ctx->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(jb, thread->ikev2log_ctx->file_ctx, &thread->buffer);
 
-    json_decref(js);
+    jb_free(jb);
     return TM_ECODE_OK;
 
 error:
-    json_decref(js);
+    jb_free(jb);
     return TM_ECODE_FAILED;
 }
 


### PR DESCRIPTION
Convert the IKEV2 Json logging to use JsonBuilder.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:[3755](https://redmine.openinfosecfoundation.org/issues/3764)

Describe changes:
-Convert Rust logger to JsonBuilder
- Update ikev2 logger to use JsonBuilder

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
