### PR TITLE
Output Capture: Capture session on alert v1

### DIFF
--- a/doc/userguide/output/pcap-alert-output.rst
+++ b/doc/userguide/output/pcap-alert-output.rst
@@ -1,0 +1,29 @@
+Pcap Alert Output
+=================
+
+Suricata is able to provide a packet capture output upon the generation of an alert. This feature makes use of the "tag" keyword in a signature by searching for and dumping tagged packets that either have generated an alert or belong to the same session of a packet that has generated an alert. This feature must be enabled through the suricata.yaml file, but also requires a signature to have the "tag:session;" keyword for it to perform the capture. Signatures without "tag:session;" will not trigger a capture.
+
+Additionally, there is an option to enabled a session-dump in the suricata.yaml file. This causes all available tcp segments in the relevant session at the time of alert to be dumped to the capture file. This is recommended, as otherwise often the packet that generates an alert may not be captured due to a lag between the processing of a packet and the generation of an alert. This behaviour was only found in tcp based traffic. As a result, the session-dump option only relates to tcp based traffic.
+
+By default, the stream-pcap-log is not enabled.
+
+YAML
+----
+
+::
+
+  - stream-pcap-log:
+      enabled: yes/no
+      output_directory: /data/pcap# Defaults to default-log-dir
+      session-dump: yes/no # Dumps tcp session upon creation of pcap file.
+
+Example Signatures
+------------------
+
+alert tcp any any -> any any (msg:"Alert on HTTP GET request using content match. Capturing session!"; content:"GET"; tag:session; sid:1; rev:1;)
+
+alert tcp any any -> any any (msg:"Alert on HTTP Get request using sticky buffer. Capturing session!"; http.method; content:"GET"; tag:session; sid:2; rev:1;)
+
+alert snmp any any -> any any (msg:"SNMP get request. Capturing Session!"; snmp.pdu_type:0; tag:session; sid:3; rev:1;)
+
+alert udp any any -> any any (msg:"UDP Packet found. Capturing Session."; tag:session; sid:4; rev:1;)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -267,6 +267,7 @@ detect-ssl-state.c detect-ssl-state.h \
 detect-ssl-version.c detect-ssl-version.h \
 detect-stream_size.c detect-stream_size.h \
 detect-tag.c detect-tag.h \
+detect-tag-pcap.c detect-tag-pcap.h \
 detect-target.c detect-target.h \
 detect-tcp-ack.c detect-tcp-ack.h \
 detect-tcp-flags.c detect-tcp-flags.h \
@@ -325,6 +326,7 @@ ippair-timeout.c ippair-timeout.h \
 log-cf-common.c log-cf-common.h \
 log-httplog.c log-httplog.h \
 log-pcap.c log-pcap.h \
+log-pcap-stream.c log-pcap-stream.h \
 log-stats.c log-stats.h \
 log-tcp-data.c log-tcp-data.h \
 log-tlslog.c log-tlslog.h \

--- a/src/detect-engine-tag.c
+++ b/src/detect-engine-tag.c
@@ -33,6 +33,7 @@
 #include "util-hashlist.h"
 #include "detect-engine-tag.h"
 #include "detect-tag.h"
+#include "detect-tag-pcap.h"
 #include "host.h"
 #include "host-storage.h"
 #include "flow-storage.h"
@@ -106,6 +107,7 @@ static DetectTagDataEntry *DetectTagDataCopy(DetectTagDataEntry *dtd)
 
     tde->first_ts = dtd->first_ts;
     tde->last_ts = dtd->last_ts;
+    tde->pcap_file = dtd->pcap_file;
     return tde;
 }
 
@@ -290,14 +292,14 @@ static void TagHandlePacketFlow(Flow *f, Packet *p)
                             tde = iter;
                             prev->next = iter->next;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         } else {
                             FlowSetStorageById(p->flow, flow_tag_id, iter->next);
                             tde = iter;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         }
@@ -317,14 +319,14 @@ static void TagHandlePacketFlow(Flow *f, Packet *p)
                             tde = iter;
                             prev->next = iter->next;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         } else {
                             FlowSetStorageById(p->flow, flow_tag_id, iter->next);
                             tde = iter;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         }
@@ -347,14 +349,14 @@ static void TagHandlePacketFlow(Flow *f, Packet *p)
                             tde = iter;
                             prev->next = iter->next;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         } else {
                             FlowSetStorageById(p->flow, flow_tag_id, iter->next);
                             tde = iter;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         }
@@ -410,13 +412,13 @@ static void TagHandlePacketHost(Host *host, Packet *p)
                             tde = iter;
                             prev->next = iter->next;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         } else {
                             tde = iter;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             HostSetStorageById(host, host_tag_id, iter);
                             continue;
@@ -436,13 +438,13 @@ static void TagHandlePacketHost(Host *host, Packet *p)
                             tde = iter;
                             prev->next = iter->next;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         } else {
                             tde = iter;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             HostSetStorageById(host, host_tag_id, iter);
                             continue;
@@ -466,13 +468,13 @@ static void TagHandlePacketHost(Host *host, Packet *p)
                             tde = iter;
                             prev->next = iter->next;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         } else {
                             tde = iter;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             HostSetStorageById(host, host_tag_id, iter);
                             continue;
@@ -570,7 +572,7 @@ int TagTimeoutCheck(Host *host, struct timeval *tv)
             tde = tmp;
             tmp = tde->next;
 
-            SCFree(tde);
+            DetectTagDataEntryFree(tde);
             (void) SC_ATOMIC_SUB(num_tags, 1);
         } else {
             HostSetStorageById(host, host_tag_id, tmp->next);
@@ -578,11 +580,20 @@ int TagTimeoutCheck(Host *host, struct timeval *tv)
             tde = tmp;
             tmp = tde->next;
 
-            SCFree(tde);
+            DetectTagDataEntryFree(tde);
             (void) SC_ATOMIC_SUB(num_tags, 1);
         }
     }
     return retval;
+}
+
+/**
+ *  \retval The linked list of tags for the specified flow if it exists.
+ *  \retval Null if no tags exist.
+ */
+DetectTagDataEntry* TagGetFlowTag(Flow* flow)
+{
+    return FlowGetStorageById(flow, flow_tag_id);
 }
 
 #ifdef UNITTESTS

--- a/src/detect-engine-tag.h
+++ b/src/detect-engine-tag.h
@@ -56,6 +56,8 @@ int TagTimeoutCheck(Host *, struct timeval *);
 
 int TagHostHasTag(Host *host);
 
+DetectTagDataEntry* TagGetFlowTag(Flow* flow);
+
 void DetectEngineTagRegisterTests(void);
 
 #endif /* __DETECT_ENGINE_TAG_H__ */

--- a/src/detect-tag-pcap.c
+++ b/src/detect-tag-pcap.c
@@ -1,0 +1,340 @@
+/* Copyright (C) 2007-2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+#include "detect-tag-pcap.h"
+#include "decode.h"
+#include "util-path.h"
+#include "util-time.h"
+#include "stream-tcp-private.h"
+#include <pthread.h>
+#include <errno.h>
+
+/* PCAP_SNAPLEN (snapshot length) is the amount of data available per capture.
+ * The default is 262144 bytes. Setting the snaplen to 0 will set it to
+ * this default value, but also allow for backwards compatibility for older
+ * versions of tcpdump. */
+#define PCAP_SNAPLEN 0
+
+/**
+ *
+ */
+typedef struct OutputConfig_ {
+    char g_hostname[HOST_NAME_MAX];
+    const char *g_output_dir;
+} OutputConfig;
+
+OutputConfig g_output_config;
+
+static void DumpTcpSegment(TcpSession *session, TcpSegment *seg,
+                          pcap_dumper_t *dump_handle, bool client);
+static TcpSegment* LogOldestTcpSegment(TcpSession *session, pcap_dumper_t
+*dump_handle);
+static TcpSegment* FindAndLogTcpSegment(TcpSession *session, pcap_dumper_t
+*dump_handle, uint32_t pcap_cnt);
+static TcpSegment* TcpRBLookup(struct TCPSEG *rbTree, uint32_t pcap_cnt);
+
+/**
+ * \brief Initializes filename for output pcap log.
+ * \param output_directory Configurable filename from suricata.yaml.
+ */
+void InitializePcapLogFilenameSupport(const char* output_directory)
+{
+    if(gethostname(g_output_config.g_hostname, sizeof(g_output_config.g_hostname))
+        != 0) {
+        SCLogError(SC_ERR_HOST_INIT, "Error looking up hostname in "
+                                     "detect-tag-pcap.c\nError: %s",
+                                     strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    if (output_directory == NULL) {
+        g_output_config.g_output_dir = ConfigGetLogDirectory();
+    } else {
+        g_output_config.g_output_dir = output_directory;
+    }
+}
+
+/**
+ *  \brief Fills the result_path_buf with a full file path that can be used
+ *   to create a file. InitializePcapLogFilenameSupport() must be run before
+ *   this is called.
+ *  \param result_path_buf buffer to hold the path string.
+ *  \param result_buf_size length of the filename buffer used.
+ *  \param p packet pointer.
+ *  \param signature that alerted.
+ *  \param thread_id unique id for the current thread.
+ *  \param unique_id counter incrementing over time to add entropy to filenames.
+ */
+void GenerateStreamFilepath(char *result_path_buf, size_t result_buf_size,
+        const Packet *p, const Signature *sig, int thread_id, uint32_t
+        unique_id)
+{
+    time_t time = p->ts.tv_usec;
+    struct tm local_tm;
+    struct tm *t = SCLocalTime(time, &local_tm);
+    if (unlikely(t == NULL)) {
+        SCLogError(SC_ERR_TS, "Unable to create time structure, ts-error");
+        exit(EXIT_FAILURE);
+    }
+
+    char fmt_time_buf[64];
+    CreateFormattedTimeString(t, "%Y%m%d_%H%M%S.%%06u", fmt_time_buf,
+            sizeof(fmt_time_buf));
+
+    char time_buf[64];
+    int ret = snprintf(time_buf, sizeof(time_buf),
+            fmt_time_buf, p->ts.tv_usec);
+    if (ret < 0 || (size_t) ret >= sizeof(time_buf)) {
+        SCLogError(SC_ERR_INVALID_NUM_BYTES, "Provided buffer size is too small"
+                                             "to create full time buffer."
+                                             "\nError: %s", strerror(errno));
+    }
+
+    ret = snprintf(result_path_buf, result_buf_size,"%s/.%u-%u.%s.%u.%s.pcap",
+            g_output_config.g_output_dir, thread_id, unique_id,
+            g_output_config.g_hostname, sig->id, time_buf);
+
+    if (ret < 0 || (size_t)ret >= result_buf_size) {
+        SCLogError(SC_ERR_INVALID_NUM_BYTES, "Provided buffer size is too "
+                                             "small to create PCAP file path."
+                                             "\n Error: %s", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+}
+
+/**
+ *  \brief Registration for TaggedPcapEntry when writing the output to files.
+ *  \param p pointer to the packet being alerted on.
+ *  \param sig signature that triggered the alert.
+ *  \param thread_id id of the thread we're on; used for uniqueness in filename.
+ *  \param unique_id unique counter per thread that increments to increase
+ *  the entropy of filenames.
+ */
+TaggedPcapEntry *SetupTaggedPcap(const Packet *p, const Signature *sig, int
+        thread_id, int unique_id)
+{
+     TaggedPcapEntry *tpe = (TaggedPcapEntry*) SCMalloc(sizeof(*tpe));
+     if (unlikely(tpe == NULL)) {
+         return NULL;
+     }
+     tpe->pcap_file_path[0] = '\0';
+
+     GenerateStreamFilepath(tpe->pcap_file_path, PATH_MAX, p, sig,
+             thread_id, unique_id);
+
+     tpe->pcap_dead_handle = pcap_open_dead(p->datalink, PCAP_SNAPLEN);
+     if (tpe->pcap_dead_handle == NULL) {
+         SCLogError(SC_ERR_PCAP_OPEN_OFFLINE, "Error opening dead pcap "
+                                              "handle: %s", pcap_geterr
+                                              (tpe->pcap_dead_handle));
+         SCFree(tpe);
+         exit(EXIT_FAILURE);
+     }
+
+     tpe->pcap_dumper = pcap_dump_open(tpe->pcap_dead_handle,
+             tpe->pcap_file_path);
+     if (tpe->pcap_dumper == NULL) {
+         SCLogError(SC_ERR_PCAP_OPEN_OFFLINE, "Failed to create tag output "
+                                              "file at %s.\nError: %s",
+                                              tpe->pcap_file_path,
+                                              pcap_geterr(tpe->pcap_dead_handle));
+         SCFree(tpe);
+         exit(EXIT_FAILURE);
+     }
+     return tpe;
+}
+
+/**
+ *  \brief Frees memory associated with TagDataPcapEntry
+ *  \param tpe tagged pcap file object to clean up
+ */
+void CleanUpTaggedPcap(TaggedPcapEntry *tpe)
+{
+    if (tpe != NULL) {
+        pcap_dump_close(tpe->pcap_dumper);
+        pcap_close(tpe->pcap_dead_handle);
+        SCUndotFilepath(tpe->pcap_file_path);
+        SCFree(tpe);
+    }
+}
+
+/**
+ *  \brief Log the packet passed in to the relevant TaggedPcapEntry. The
+ *   logging destination is a pcap_dumper.
+ *  \param tpe tagged pcap file object to dump packets to.
+ *  \param p packet structure to log packets from.
+ */
+void DumpTaggedPacket(pcap_dumper_t *dump_handle, const Packet *p)
+{
+    struct pcap_pkthdr pcapHdr;
+    pcapHdr.ts.tv_sec = p->ts.tv_sec;
+    pcapHdr.ts.tv_usec = p->ts.tv_usec;
+    pcapHdr.caplen = GET_PKT_LEN(p);
+    pcapHdr.len = GET_PKT_LEN(p);
+    pcap_dump((u_char *) dump_handle, &pcapHdr, GET_PKT_DATA(p));
+}
+
+/**
+ *  \brief Logs TcpSession to pcap file. Should be called immediately after
+ *   creation of the pcap file.
+ *  \param session to be dumped to pcap.
+ *  \param dump_handle pcap_dumper location.
+ *  \param p Packet being processed at time of alert.
+ */
+void LogTcpSession(TcpSession *session, pcap_dumper_t *dump_handle, const
+        Packet* p)
+{
+    uint32_t current_pcap_cnt = 0;
+
+    TcpSegment *segmentLog = NULL;
+
+    /*
+     * First, the oldest tcp segment available is found. Packets need to be
+     * dumped in order so this is how we begin dumping the segments of the tcp
+     * session. The remaining segments are found and dumped in order
+     * (oldest->newest) in the while loop below.
+     */
+    segmentLog = LogOldestTcpSegment(session, dump_handle);
+    current_pcap_cnt = segmentLog->pcap_cnt;
+
+    while(current_pcap_cnt++ < p->pcap_cnt) {
+        segmentLog = FindAndLogTcpSegment(session, dump_handle,
+                current_pcap_cnt);
+    }
+}
+
+/**
+ * \brief Dumps content of a TcpSegment to specified pcap output file.
+ * \param tcpSegment to be dumped to pcap.
+ * \param dump_handle pcap_dumper location.
+ * \bool client direction of segment (to client or to server).
+ */
+static void DumpTcpSegment(TcpSession *session, TcpSegment *seg,
+        pcap_dumper_t *dump_handle, bool client)
+{
+    struct pcap_pkthdr pcapHdr;
+    uint32_t packet_len = seg->pktlen;
+    uint32_t payload_len = seg->payload_len;
+    uint32_t packet_header_len = packet_len - payload_len;
+
+    pcapHdr.ts.tv_sec = seg->ts.tv_sec;
+    pcapHdr.ts.tv_usec = seg->ts.tv_usec;
+    pcapHdr.caplen = packet_len;
+    pcapHdr.len = packet_len;
+
+    uint8_t *packet_data = (uint8_t*) SCMalloc(packet_len);
+    if (packet_data != NULL && seg->pkt_hdr != NULL) {
+        memcpy(packet_data, seg->pkt_hdr, packet_header_len);
+        if (client) {
+            memcpy(packet_data + packet_header_len, session->client.sb.buf +
+                seg->sbseg.stream_offset, payload_len);
+        } else {
+            memcpy(packet_data + packet_header_len, session->server.sb.buf +
+                seg->sbseg.stream_offset, payload_len);
+        }
+        pcap_dump((u_char *) dump_handle, &pcapHdr, packet_data);
+    } else {
+        return;
+    }
+    SCFree(packet_data);
+}
+
+/**
+ * \brief A helper function that finds and logs the oldest TCP segment in the
+ *  session to begin processing the whole session.
+ * \param session to be dumped to pcap.
+ * \param dump_handle pcap_dumper location.
+ * \retval The oldest tcp segment if it exists, otherwise NULL.
+ */
+static TcpSegment* LogOldestTcpSegment(TcpSession *session, pcap_dumper_t
+        *dump_handle)
+{
+    TcpSegment *server_node = session->server.seg_tree.rbh_root;
+    TcpSegment *client_node = session->client.seg_tree.rbh_root;
+
+    if (client_node == NULL || server_node == NULL) {
+        return NULL;
+    }
+
+    while (RB_LEFT(server_node, rb) != NULL) {
+        server_node = RB_LEFT(server_node, rb);
+    }
+    while (RB_LEFT(client_node,rb) != NULL) {
+        client_node = RB_LEFT(client_node,rb);
+    }
+    if (server_node->pcap_cnt < client_node->pcap_cnt) {
+        DumpTcpSegment(session, server_node, dump_handle, false);
+        return server_node;
+    } else {
+        DumpTcpSegment(session, client_node, dump_handle, true);
+        return client_node;
+    }
+}
+
+/**
+ * \brief Searches through the RB trees of tcp segments in both directions
+ *  (to server and to client) for the tcp segment with the specified pcap_cnt
+ *  value. If found, the segment is logged to output pcap file.
+ * \param session to be dumped to pcap.
+ * \param dump_handle pcap_dumper location.
+ * \param pcap_cnt A value added to tcp segment to keep track of the original
+ *  packet processing order.
+ * \return The tcp segment if it exists. Otherwise NULL.
+ */
+static TcpSegment* FindAndLogTcpSegment(TcpSession *session, pcap_dumper_t
+        *dump_handle, uint32_t pcap_cnt)
+{
+    TcpSegment *seg = NULL;
+    // Search server RB tree first
+    seg = TcpRBLookup(&session->server.seg_tree, pcap_cnt);
+    if (seg != NULL) {
+        // Segment was found in server RB tree.
+        DumpTcpSegment(session, seg, dump_handle, false);
+        return seg;
+    }
+    // Search client RB tree.
+    seg = TcpRBLookup(&session->client.seg_tree, pcap_cnt);
+    if (seg != NULL) {
+        // Segment was found in client RB tree.
+        DumpTcpSegment(session, seg, dump_handle, true);
+        return seg;
+    }
+    return NULL;
+}
+
+/**
+ * \brief Traverses the RB tree to find the tcp segment whose pcap_cnt
+ *         variable matches with the pcap_cnt argument passed.
+ * /param rbTree The RB tree for the tcp session.
+ * /param pcap_cnt The pcap_cnt of the desired segment.
+ * /retval The tcp segment if it exists. NULL otherwise.
+ */
+static TcpSegment* TcpRBLookup(struct TCPSEG *rbTree, uint32_t pcap_cnt)
+{
+    TcpSegment *node = RB_ROOT(rbTree);
+    while (node != NULL) {
+        if (node->pcap_cnt == pcap_cnt) {
+            return node;
+        } else if (pcap_cnt < node->pcap_cnt) {
+            node = RB_LEFT(node, rb);
+        } else {
+            node = RB_RIGHT(node, rb);
+        }
+    }
+    return node;
+}

--- a/src/detect-tag-pcap.h
+++ b/src/detect-tag-pcap.h
@@ -1,0 +1,56 @@
+/* Copyright (C) 2007-2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ *  This adds support for creating .pcap output files for each tagged flow.
+ *  File information is stored with the tag, rather than the flow. The reasons
+ *  for this are multi-fold:
+ *  1) Flows are locking on changes while tags are not.
+ *  2) A flow may have multiple tags.
+ *  3) Tags know when to stop following the flow (Thus when to close the file)
+ *  4) A flow id can be used to lookup a flow's tags (Trivial and non-locking).
+ */
+#ifndef __DETECT_TAG_PCAP_H__
+#define __DETECT_TAG_PCAP_H__
+
+#include "suricata-common.h"
+#include "suricata.h"
+#include "decode.h"
+#include "log-pcap-stream.h"
+#include "pcap.h"
+
+typedef struct Signature_ Signature;
+typedef struct TcpSession_ TcpSession;
+
+typedef struct TaggedPcapEntry_ {
+    pcap_dumper_t *pcap_dumper;
+    pcap_t *pcap_dead_handle;
+    char pcap_file_path[PATH_MAX];
+} TaggedPcapEntry;
+
+
+void InitializePcapLogFilenameSupport(const char* output_directory);
+void GenerateStreamFilepath(char *result_path_buf, size_t result_buf_size,
+        const Packet *p, const Signature *sig, int thread_id, uint32_t
+        unique_id);
+TaggedPcapEntry *SetupTaggedPcap(const Packet *p, const Signature *sig, int
+        thread_id, int unique_id);
+void CleanUpTaggedPcap(TaggedPcapEntry *tpe);
+void DumpTaggedPacket(pcap_dumper_t *dump_handle, const Packet *p);
+void LogTcpSession(TcpSession *session, pcap_dumper_t *dump_handle, const
+Packet* p);
+#endif /*__DETECT_TAG_PCAP_H__*/

--- a/src/detect-tag.c
+++ b/src/detect-tag.c
@@ -29,6 +29,7 @@
 #include "detect.h"
 #include "detect-parse.h"
 #include "detect-tag.h"
+#include "detect-tag-pcap.h"
 #include "detect-engine-tag.h"
 #include "detect-engine.h"
 #include "detect-engine-state.h"
@@ -48,6 +49,7 @@
 #include "util-unittest-helper.h"
 #include "util-debug.h"
 #include "threads.h"
+
 
 SC_ATOMIC_EXTERN(unsigned int, num_tags);
 
@@ -299,16 +301,15 @@ int DetectTagSetup(DetectEngineCtx *de_ctx, Signature *s, const char *tagstr)
     return 0;
 }
 
-/** \internal
- *  \brief this function will free memory associated with
- *        DetectTagDataEntry
- *
+/**
+ *  \brief this function will free memory associated with DetectTagDataEntry
  *  \param td pointer to DetectTagDataEntry
  */
-static void DetectTagDataEntryFree(void *ptr)
+void DetectTagDataEntryFree(void *ptr)
 {
     if (ptr != NULL) {
         DetectTagDataEntry *dte = (DetectTagDataEntry *)ptr;
+        CleanUpTaggedPcap(dte->pcap_file);
         SCFree(dte);
     }
 }

--- a/src/detect-tag.h
+++ b/src/detect-tag.h
@@ -25,8 +25,9 @@
 #ifndef __DETECT_TAG_H__
 #define __DETECT_TAG_H__
 
-#include "suricata-common.h"
+#include "detect-tag-pcap.h"
 #include "suricata.h"
+#include "suricata-common.h"
 #include "util-time.h"
 
 /* Limit the number of times a session can be tagged by the
@@ -85,6 +86,7 @@ typedef struct DetectTagDataEntry_ {
     };
     uint32_t first_ts;                  /**< First time seen (for metric = seconds) */
     uint32_t last_ts;                   /**< Last time seen (to prune old sessions) */
+    TaggedPcapEntry *pcap_file;
 #if __WORDSIZE == 64
     uint32_t pad1;
 #endif
@@ -99,6 +101,7 @@ typedef struct DetectTagDataEntry_ {
 /* prototypes */
 struct DetectEngineCtx_ ;
 void DetectTagRegister(void);
+void DetectTagDataEntryFree(void *ptr);
 void DetectTagDataFree(struct DetectEngineCtx_ *, void *ptr);
 void DetectTagDataListFree(void *ptr);
 

--- a/src/log-pcap-stream.c
+++ b/src/log-pcap-stream.c
@@ -1,0 +1,311 @@
+/* Copyright (C) 2007-2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ *  Pcap packet logging module.
+ *  Enabled through suricata.yaml:
+ *  - stream-pcap-log:
+ *      enabled: yes/no
+ *      output_directory: # Defaults to default-log-dir
+ *      session-dump: yes/no # Dumps tcp session upon creation of pcap file.
+ */
+#include "suricata-common.h"
+#include "threads.h"
+#include "threadvars.h"
+#include "tm-threads.h"
+#include "log-pcap-stream.h"
+#include "util-atomic.h"
+#include "output.h"
+#include "detect-engine-tag.h"
+
+#define MODULE_NAME "PcapLogStream"
+
+/**
+ *  \brief Variable to store the output context. Contains the filename of the
+ *   output file.
+ */
+typedef struct StreamOutputCtx_ {
+    char filename[NAME_MAX];
+    bool session_dump_enabled;
+} StreamOutputCtx;
+
+/**
+ *  \brief Variables to maintain context on this thread.
+ */
+typedef struct StreamPcapLogThreadData_ {
+    uint32_t count;
+    StreamOutputCtx *stream_output_ctx;
+} StreamPcapLogThreadData;
+
+/* Forward declarations for registration. */
+
+static int StreamPcapLog(ThreadVars *tv, void *thread_data, const Packet *p);
+static int StreamPcapLogCondition(ThreadVars *tv, const Packet *p);
+static TmEcode StreamPcapLogThreadInit(ThreadVars *tv, const void *initdata,
+                                       void **data);
+static TmEcode StreamPcapLogThreadDeInit(ThreadVars *tv, void *thread_data);
+static OutputInitResult StreamPcapLogInitCtx(ConfNode *conf);
+static void StreamPcapLogFileDeInitCtx(OutputCtx *output_ctx);
+
+static StreamOutputCtx *getStreamOutputCtx(const OutputCtx *output_ctx);
+static void GeneratePcapFiles(ThreadVars *tv, StreamPcapLogThreadData *td,
+                              const Packet* p);
+
+/**
+ * \brief Stream pcap logging main function.
+ * \param tv thread-specific variables.
+ * \param thread_data thread module specific data.
+ * \param p Pointer to current packet being processed.
+ * \return TM_ECODE_OK on success.
+ */
+static int StreamPcapLog(ThreadVars *tv, void *thread_data, const Packet *p)
+{
+    StreamPcapLogThreadData *td = (StreamPcapLogThreadData *) thread_data;
+    td->count++;
+    GeneratePcapFiles(tv, thread_data, p);
+    return TM_ECODE_OK;
+}
+
+/**
+ * \brief Generate pcap events for the alerted packet. Handles single packet
+ *  protocols/alerts and multiple packet alerts. For single packet
+ *  alerts, the alert file or event message are created and output.
+ *  For multiple packet alerts, the pcap file is created.
+ * \param tv thread-specific variables.
+ * \param td thread data containing the output context.
+ * \param p Pointer to current packet being processed.
+ */
+static void GeneratePcapFiles(ThreadVars *tv, StreamPcapLogThreadData *td,
+        const Packet* p)
+{
+    if (!(p->flags & PKT_HAS_FLOW)) {
+        /*
+         * Single packet protocols (eg. ICMP) won't have a flow created for
+         * them. A tagged rule alert can still trigger on the packet meaning
+         * we'd want to produce a PCAP.
+         */
+        for (uint16_t x = 0; x < p->alerts.cnt; x++) {
+            /* Is the alert from a tagged signature? */
+            if (p->alerts.alerts[x].s->sm_arrays[DETECT_SM_LIST_TMATCH] !=
+            NULL) {
+                TaggedPcapEntry *pcap_file = SetupTaggedPcap(p, p->alerts
+                .alerts->s, tv->id, td->count);
+                DumpTaggedPacket(pcap_file->pcap_dumper, p);
+                CleanUpTaggedPcap(pcap_file);
+            }
+        }
+        return;
+    }
+
+    /**
+     *  The flow is locked during this method call. It's safe to read and
+     *  modify session tags.
+     */
+     DetectTagDataEntry *tags = TagGetFlowTag(p->flow);
+     /**
+      *  Log this packet to every tag's output PCAP stream. The detect-tag
+      *  code will handle cleanup and deletion of expired tags.
+      */
+      while (tags != NULL) {
+          DetectTagDataEntry *current_tag = tags;
+          tags = tags->next;
+          /* Initialize the tag's output(s) PCAP stream if not already done. */
+          if (current_tag->pcap_file == NULL) {
+              /**
+               * Find the Signature instance inside the packet that matches
+               * the tag's SID.
+               */
+               const PacketAlert* tagAlert = NULL;
+               for (uint16_t x=0; x < p->alerts.cnt; x++) {
+                   if (p->alerts.alerts[x].s->id == current_tag->sid) {
+                       tagAlert = &p->alerts.alerts[x];
+                       break;
+                   }
+               }
+               if (tagAlert == NULL) {
+                   /**
+                    * This case happens when a rule hits its threshold
+                    * settings. The alert doesn't get generated but the
+                    * tagging will still occur. Skip the tag.
+                    */
+                    continue;
+               }
+               current_tag->pcap_file = SetupTaggedPcap(p, tagAlert->s,
+                       tv->id, td->count);
+
+               if (td->stream_output_ctx->session_dump_enabled) {
+                   TcpSession *session = (TcpSession *) p->flow->protoctx;
+                   if (session != NULL) {
+                       LogTcpSession(session,
+                               current_tag->pcap_file->pcap_dumper,
+                               p);
+                   }
+               }
+          }
+          DumpTaggedPacket(current_tag->pcap_file->pcap_dumper, p);
+      }
+}
+
+/**
+ *  \brief StreamPcapLogRegister Register the logger to the output-packet
+ *   root logger.
+ */
+void StreamPcapLogRegister(void)
+{
+    SCLogNotice("StreamPcapLogRegister Enter");
+    OutputRegisterPacketModule(LOGGER_PCAP,        // Logger ID
+            MODULE_NAME,                           // Logger name
+            "stream-pcap-log",                     // Configuration name
+            StreamPcapLogInitCtx,                  // Output init function
+            StreamPcapLog,                         // Packet logger function
+            StreamPcapLogCondition,                // Packet condition function
+            StreamPcapLogThreadInit,               // Thread init function
+            StreamPcapLogThreadDeInit,             // Thread deinit
+            NULL);                                 // Thread print stats
+}
+
+/**
+ * \brief Determines whether or not to log this packet.
+ * \param tv thread-specific variables.
+ * \param p Pointer to current packet being processed.
+ * \return TRUE if the packet should be logged.
+ * \return FALSE if we do not need to log the packet.
+ */
+static int StreamPcapLogCondition(ThreadVars *tv, const Packet *p)
+{
+    /* Flow is necessary for tag lookups. Reject invalid packets. */
+    if ((p->ethh && p->flags & PKT_HAS_FLOW && !(p->flags & PKT_IS_INVALID)) ||
+        p->alerts.cnt > 0) {
+        return TRUE;
+    }
+    return FALSE;
+}
+
+/**
+ *  \brief StreamPcapLogThreadInit Initialize the thread data.
+ *  \param initdata Contains the output_ctx created by StreamPcapLogIitCtx
+ *  \param data Populated with the thread data structure.
+ *  \return TM_ECODE_OK On success.
+ *  \return TM_ECODE_FAILED On serious error.
+ */
+static TmEcode StreamPcapLogThreadInit(ThreadVars *tv, const void *initdata,
+        void **data)
+{
+    // Create and initialize the thread data.
+    if (initdata == NULL) {
+        SCLogDebug("Error getting context for StreamLogPcap. \"initdata\" "
+                   "argument NULL");
+        return TM_ECODE_FAILED;
+    }
+    StreamOutputCtx *stream_output_ctx = getStreamOutputCtx((OutputCtx*)
+            initdata);
+    StreamPcapLogThreadData *td = SCMalloc(sizeof(*td));
+    if (unlikely(td == NULL)) {
+        return TM_ECODE_FAILED;
+    }
+    td->stream_output_ctx = stream_output_ctx;
+    td->count = 0;
+    *data = (void *)td;
+    return TM_ECODE_OK;
+}
+
+/**
+ * \brief Thread deinit function.
+ * \param thread_data StreamPcapLog thread data.
+ * \return TM_ECODE_OK On success.
+ */
+static TmEcode StreamPcapLogThreadDeInit(ThreadVars *tv, void *thread_data)
+{
+    StreamPcapLogThreadData *td = thread_data;
+    SCFree(td);
+    return TM_ECODE_OK;
+}
+
+/**
+ *  \brief Fill in stream-pcap logging struct from the provided ConfNode.
+ *  \param conf The configuration node for this output.
+ *  \return output_ctx: Output context (contains a StreamOutputCtx data member)
+ */
+static OutputInitResult StreamPcapLogInitCtx(ConfNode *conf)
+{
+    SCLogNotice("StreamPcapLogInitCtx enter");
+    OutputInitResult result =  {NULL, false};
+    /* Create the output context from the configuration node. */
+    StreamOutputCtx *stream_output_ctx =
+            SCMalloc(sizeof(*stream_output_ctx));
+    if (unlikely(stream_output_ctx == NULL)) {
+        SCReturnCT(result, "OutputInitResult");
+    }
+    OutputCtx *output_ctx = SCMalloc(sizeof(*output_ctx));
+    if (unlikely(output_ctx == NULL)) {
+        SCFree(stream_output_ctx);
+        SCReturnCT(result, "OutputInitResult");
+    }
+    /* Initialize filename */
+    stream_output_ctx->filename[0] = '\0';
+
+    /* Load output options. */
+    const char *outputDirectory = ConfNodeLookupChildValue(conf,
+            "output-directory");
+
+    InitializePcapLogFilenameSupport(outputDirectory);
+
+    if (ConfNodeChildValueIsTrue(conf, "session-dump")) {
+        stream_output_ctx->session_dump_enabled = true;
+    } else {
+        stream_output_ctx->session_dump_enabled = false;
+    }
+    output_ctx->data = stream_output_ctx;
+    output_ctx->DeInit = StreamPcapLogFileDeInitCtx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    SCReturnCT(result, "OutputInitResult");
+}
+
+/**
+ *  \brief Helper function to extract the StreamOutputCtx from an
+ *   OutputCtx->data
+ *  \param output_ctx Structure that output modules use to maintain private data
+ *  \return *StreamOutputCtx on success.
+ *  \return NULL on failure or if output_ctx->data is NULL.
+ */
+static StreamOutputCtx *getStreamOutputCtx(const OutputCtx *output_ctx)
+{
+    if (output_ctx == NULL) {
+        return NULL;
+    }
+    return (StreamOutputCtx *) output_ctx->data;
+}
+
+/**
+ * \brief StreamPcapLogFileDeInitCtx Free and close the output context
+ *  created by StreamPcapLogInitCtx.
+ * \param output_ctx The output context to free.
+ */
+static void StreamPcapLogFileDeInitCtx(OutputCtx *output_ctx)
+{
+    SCLogNotice("StreamPcapLogFileDeInitCtx Enter");
+    if (output_ctx == NULL) {
+        return;
+    }
+    if (output_ctx->data != NULL) {
+        StreamOutputCtx *stream_output_ctx_data = (StreamOutputCtx *)
+                output_ctx->data;
+        SCFree(stream_output_ctx_data);
+    }
+    SCFree(output_ctx);
+}

--- a/src/log-pcap-stream.h
+++ b/src/log-pcap-stream.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,27 +15,9 @@
  * 02110-1301, USA.
  */
 
-/**
- * \file
- *
- * \author Victor Julien <victor@inliniac.net>
- *
- */
+#ifndef __LOG_PCAP_STREAM_H__
+#define __LOG_PCAP_STREAM_H__
 
-#ifndef __UTIL_PATH_H__
-#define __UTIL_PATH_H__
+void StreamPcapLogRegister(void);
 
-#ifndef HAVE_NON_POSIX_MKDIR
-    #define SCMkDir(a, b) mkdir(a, b)
-#else
-    #define SCMkDir(a, b) mkdir(a)
-#endif
-
-int PathIsAbsolute(const char *);
-int PathIsRelative(const char *);
-int SCDefaultMkDir(const char *path);
-int SCCreateDirectoryTree(const char *path, const bool final);
-bool SCPathExists(const char *path);
-void SCUndotFilepath(const char* dotted_filepath);
-
-#endif /* __UTIL_PATH_H__ */
+#endif /*__LOG_PCAP_STREAM_H__*/

--- a/src/output.c
+++ b/src/output.c
@@ -59,6 +59,7 @@
 #include "output-json-tls.h"
 #include "output-json-ssh.h"
 #include "log-pcap.h"
+#include "log-pcap-stream.h"
 #include "output-json-file.h"
 #include "output-json-smtp.h"
 #include "output-json-stats.h"
@@ -1123,6 +1124,8 @@ void OutputRegisterLoggers(void)
     LogTcpDataLogRegister();
     /* log stats */
     LogStatsLogRegister();
+    /* stream pcap log */
+    StreamPcapLogRegister();
 
     JsonAlertLogRegister();
     JsonAnomalyLogRegister();

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -64,6 +64,10 @@ typedef struct TcpSegment {
     uint32_t seq;
     RB_ENTRY(TcpSegment) __attribute__((__packed__)) rb;
     StreamingBufferSegment sbseg;
+    struct timeval ts;
+    uint8_t *pkt_hdr;
+    uint32_t pktlen;
+    uint64_t pcap_cnt;
 } __attribute__((__packed__)) TcpSegment;
 
 /** \brief compare function for the Segment tree

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -316,6 +316,9 @@ void StreamTcpReturnStreamSegments (TcpStream *stream)
     TcpSegment *seg = NULL, *safe = NULL;
     RB_FOREACH_SAFE(seg, TCPSEG, &stream->seg_tree, safe)
     {
+        if (seg) {
+            SCFree(seg->pkt_hdr);
+        }
         RB_REMOVE(TCPSEG, &stream->seg_tree, seg);
         StreamTcpSegmentReturntoPool(seg);
     }

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -370,6 +370,8 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_WARN_REGISTRATION_FAILED);
         CASE_CODE (SC_ERR_ERF_BAD_RLEN);
         CASE_CODE (SC_WARN_ERSPAN_CONFIG);
+        CASE_CODE (SC_ERR_TS);
+        CASE_CODE (SC_ERR_RENAME);
 
         CASE_CODE (SC_ERR_MAX);
     }

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -360,6 +360,8 @@ typedef enum {
     SC_WARN_REGISTRATION_FAILED,
     SC_ERR_ERF_BAD_RLEN,
     SC_WARN_ERSPAN_CONFIG,
+    SC_ERR_TS, /** Error indicating a failure to create time struct.**/
+    SC_ERR_RENAME, /** Error indicating a failure to rename file. **/
 
     SC_ERR_MAX
 } SCError;

--- a/src/util-path.c
+++ b/src/util-path.c
@@ -137,3 +137,51 @@ bool SCPathExists(const char *path)
     }
     return false;
 }
+
+/**
+ *  \brief Renames the specified fully-qualified dotted file path to its
+ *   non-dotted equivalent. This function was originally written for
+ *   detect-tag-pcap.c, but was moved to util-path.c as its utility is not
+ *   restricted to the packet dumping feature.
+ *  \param dotted_filepath fully-qualified path to the hidden temporary file
+ *   to unmask.
+ */
+void SCUndotFilepath(const char* dotted_filepath)
+{
+    char undotted_path[PATH_MAX];
+
+    /*
+     * Copy the dotted file path so that it can be modified into the
+     * destination undotted path.
+     */
+    size_t len = strlcpy(undotted_path, dotted_filepath, sizeof(undotted_path));
+    if (len >= sizeof(undotted_path)) {
+        SCLogError(SC_ERR_INVALID_NUM_BYTES, "Provided buffer size is too "
+                                             "small to undot file path: "
+                                             "%s\nError: %s",
+                   dotted_filepath, strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    /*
+     * Shift characters left by one until a '/' is found. The filename is
+     * temporarily hidden, i.e. prefixed with a '.', while packets are being
+     * dumped. This shifting is done to find that '.' and remove it so the
+     * file is no longer hidden.
+     */
+    char last_replaced_char = undotted_path[len];
+    size_t x = len;
+    while (undotted_path[--x] != '/' && x > 0) {
+        char tmp = undotted_path[x];
+        undotted_path[x] = last_replaced_char;
+        last_replaced_char = tmp;
+    }
+
+    if (rename(dotted_filepath, undotted_path) != 0) {
+        SCLogError(SC_ERR_RENAME, "Failed to rename dotted file: %s to %s: "
+                                  "\n Error: %s", dotted_filepath,
+                   undotted_path, strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+}
+

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -79,6 +79,12 @@ outputs:
       append: yes
       #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
 
+  # Outputs a PCAP file per tagged alert.
+  - stream-pcap-log:
+      enabled: no
+      # output-directory: /data/pcap # Defaults to the default-log-dir.
+      # session-dump: yes # Dumps tcp session upon creation of PCAP file.
+
   # Extensible Event Format (nicknamed EVE) event log in JSON format
   - eve-log:
       enabled: @e_enable_evelog@


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/120

Describe changes:
- This is a new feature development to capture a session upon an alert. The ticket linked above guided the overall development.
- Capturing of a session relies on using the tag keyword in a signature. Specifically "tag:session".
- When output is being processed & this feature is enabled through the suricata.yaml file, a packet is scanned for these tags and is dumped to a .pcap file. 
- This basic functionality should come at no expense when not enabled. 
- However, during development it was noticed that for TCP based protocols, the packet that generated an alert could not be reliably captured. I.e. by the time the alert was generated, this packet was no longer being processed and would not be captured. To overcome this, an option to dump the tcp session was created. In some limited testing, this option has shown success in capturing these packets that were originally "missed". 
- To accomplish this additional data, namely packet headers, time variables, and packet lengths were added to the existent TcpSegment structure to enrich these segments so that they would contain the necessary information for a successful packet capture. 
- In this initial version, the tcp-segment enrichment is always occurring, regardless of whether packet capture is enabled or disabled. 

Suggested Review Order/Guide:
- log-pcap-stream.c/.h
   - This file handle registration for the capture output module, initialization/de-initialization, and the main utility of scanning the alerted packets for tags and dumping them if a tag is found.
- detect-tag-pcap.c/h
   - This file contains the functions used for setting up file paths, dumping to these files, and cleaning them up. Additionally it contains the functions that handle the dumping of the enriched tcp segments. 
- stream-tcp .c/.h files
   - These files handle the enrichment of the tcp segments, i.e. adding to the TcpSegment struct, copying in new data, and freeing the new data.
- util-path.c
   - The only change here is an added function that undots a temporarily hidden file. This was originally being used detect-tag-pcap.c as a way to prevent incomplete captures from being handled, but was moved as it could have some general use. 

These files make up the bulk of this pull request. 

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch: