### PR TITLE
Batch backports to 5.0.x

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2037,7 +2037,7 @@ Example:
 ::
 
   [10703] 26/11/2010 -- 11:41:15 - (detect.c:560) <Info> (SigLoadSignatures)
-  -- Engine-Analyis for fast_pattern printed to file - /var/log/suricata/rules_fast_pattern.txt
+  -- Engine-Analysis for fast_pattern printed to file - /var/log/suricata/rules_fast_pattern.txt
 
   == Sid: 1292 ==
   Fast pattern matcher: content

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -335,6 +335,17 @@ int DetectContentSetup(DetectEngineCtx *de_ctx, Signature *s, const char *conten
     int sm_list = s->init_data->list;
     if (sm_list == DETECT_SM_LIST_NOTSET) {
         sm_list = DETECT_SM_LIST_PMATCH;
+    } else if (sm_list > DETECT_SM_LIST_MAX &&
+            0 == (cd->flags & DETECT_CONTENT_NEGATED)) {
+        /* Check transform compatibility */
+        const char *tstr;
+        if (!DetectBufferTypeValidateTransform(de_ctx, sm_list, cd->content,
+                    cd->content_len, &tstr)) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE,
+                    "content string \"%s\" incompatible with %s transform",
+                    contentstr, tstr);
+            goto error;
+        }
     }
 
     sm = SigMatchAlloc();

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2018 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -412,7 +412,7 @@ void CleanupFPAnalyzer(void)
 void CleanupRuleAnalyzer(void)
 {
     if (rule_engine_analysis_FD != NULL) {
-         SCLogInfo("Engine-Analyis for rules printed to file - %s", log_path);
+         SCLogInfo("Engine-Analysis for rules printed to file - %s", log_path);
         fclose(rule_engine_analysis_FD);
         rule_engine_analysis_FD = NULL;
     }

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1145,6 +1145,49 @@ void InspectionBufferCopy(InspectionBuffer *buffer, uint8_t *buf, uint32_t buf_l
     }
 }
 
+/** \brief Check content byte array compatibility with transforms
+ *
+ *  The "content" array is presented to the transforms so that each
+ *  transform may validate that it's compatible with the transform.
+ *
+ *  When a transform indicates the byte array is incompatible, none of the
+ *  subsequent transforms, if any, are invoked. This means the first positive
+ *  validation result terminates the loop.
+ *
+ *  \param de_ctx Detection engine context.
+ *  \param sm_list The SM list id.
+ *  \param content The byte array being validated
+ *  \param namestr returns the name of the transform that is incompatible with
+ *  content.
+ *
+ *  \retval true (false) If any of the transforms indicate the byte array is
+ *  (is not) compatible.
+ **/
+bool DetectBufferTypeValidateTransform(DetectEngineCtx *de_ctx, int sm_list,
+        const uint8_t *content, uint16_t content_len, const char **namestr)
+{
+    const DetectBufferType *dbt = DetectBufferTypeGetById(de_ctx, sm_list);
+    BUG_ON(dbt == NULL);
+
+    for (int i = 0; i < dbt->transforms.cnt; i++) {
+        const int t = dbt->transforms.transforms[i];
+        if (!sigmatch_table[t].TransformValidate)
+            continue;
+
+        if (sigmatch_table[t].TransformValidate(content, content_len)) {
+            continue;
+        }
+
+        if (namestr) {
+            *namestr = sigmatch_table[t].name;
+        }
+
+        return false;
+    }
+
+    return true;
+}
+
 void InspectionBufferApplyTransforms(InspectionBuffer *buffer,
         const DetectEngineTransforms *transforms)
 {

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -35,6 +35,8 @@ void InspectionBufferCheckAndExpand(InspectionBuffer *buffer, uint32_t min_size)
 void InspectionBufferCopy(InspectionBuffer *buffer, uint8_t *buf, uint32_t buf_len);
 void InspectionBufferApplyTransforms(InspectionBuffer *buffer,
         const DetectEngineTransforms *transforms);
+bool DetectBufferTypeValidateTransform(DetectEngineCtx *de_ctx, int sm_list,
+        const uint8_t *content, uint16_t content_len, const char **namestr);
 void InspectionBufferClean(DetectEngineThreadCtx *det_ctx);
 InspectionBuffer *InspectionBufferGet(DetectEngineThreadCtx *det_ctx, const int list_id);
 InspectionBuffer *InspectionBufferMultipleForListGet(InspectionBufferMultipleForList *fb, uint32_t local_id);

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -189,6 +189,7 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     if (DetectBufferSetActiveList(s, DetectBufferTypeGetByName("file_data")) < 0)
         return -1;
 
+    s->init_data->init_flags |= SIG_FLAG_INIT_FILEDATA;
     SetupDetectEngineConfig(de_ctx);
     return 0;
 }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1828,7 +1828,8 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
     }
 #endif
 
-    if ((s->flags & SIG_FLAG_FILESTORE) || s->file_flags != 0) {
+    if ((s->flags & SIG_FLAG_FILESTORE) || s->file_flags != 0 ||
+        (s->init_data->init_flags & SIG_FLAG_INIT_FILEDATA)) {
         if (s->alproto != ALPROTO_UNKNOWN &&
                 !AppLayerParserSupportsFiles(IPPROTO_TCP, s->alproto))
         {

--- a/src/detect-transform-strip-whitespace.c
+++ b/src/detect-transform-strip-whitespace.c
@@ -38,6 +38,7 @@ static int DetectTransformStripWhitespaceSetup (DetectEngineCtx *, Signature *, 
 static void DetectTransformStripWhitespaceRegisterTests(void);
 
 static void TransformStripWhitespace(InspectionBuffer *buffer);
+static bool TransformStripWhitespaceValidate(const uint8_t *content, uint16_t content_len);
 
 void DetectTransformStripWhitespaceRegister(void)
 {
@@ -48,6 +49,8 @@ void DetectTransformStripWhitespaceRegister(void)
         "/rules/transforms.html#strip-whitespace";
     sigmatch_table[DETECT_TRANSFORM_STRIP_WHITESPACE].Transform =
         TransformStripWhitespace;
+    sigmatch_table[DETECT_TRANSFORM_STRIP_WHITESPACE].TransformValidate =
+        TransformStripWhitespaceValidate;
     sigmatch_table[DETECT_TRANSFORM_STRIP_WHITESPACE].Setup =
         DetectTransformStripWhitespaceSetup;
     sigmatch_table[DETECT_TRANSFORM_STRIP_WHITESPACE].RegisterTests =
@@ -70,6 +73,26 @@ static int DetectTransformStripWhitespaceSetup (DetectEngineCtx *de_ctx, Signatu
     SCEnter();
     int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_STRIP_WHITESPACE);
     SCReturnInt(r);
+}
+
+/*
+ *  \brief Validate content bytes to see if it's compatible with this transform
+ *  \param content Byte array to check for compatibility
+ *  \param content_len Number of bytes to check
+ *  \retval false If the string contains spaces
+ *  \retval true Otherwise.
+ */
+static bool TransformStripWhitespaceValidate(const uint8_t *content,
+        uint16_t content_len)
+{
+    if (content) {
+        for (uint32_t i = 0; i < content_len; i++) {
+            if (isspace(*content++)) {
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 static void TransformStripWhitespace(InspectionBuffer *buffer)

--- a/src/detect.h
+++ b/src/detect.h
@@ -1182,6 +1182,7 @@ typedef struct SigTableElmt_ {
 
     /** InspectionBuffer transformation callback */
     void (*Transform)(InspectionBuffer *);
+    bool (*TransformValidate)(const uint8_t *content, uint16_t content_len);
 
     /** keyword setup function pointer */
     int (*Setup)(DetectEngineCtx *, Signature *, const char *);

--- a/src/detect.h
+++ b/src/detect.h
@@ -262,6 +262,7 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_INIT_STATE_MATCH           BIT_U32(6)  /**< signature has matches that require stateful inspection */
 #define SIG_FLAG_INIT_NEED_FLUSH            BIT_U32(7)
 #define SIG_FLAG_INIT_PRIO_EXPLICT          BIT_U32(8)  /**< priority is explicitly set by the priority keyword */
+#define SIG_FLAG_INIT_FILEDATA              BIT_U32(9)  /**< signature has filedata keyword */
 
 /* signature mask flags */
 /** \note: additions should be added to the rule analyzer as well */

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -51,6 +51,7 @@ typedef struct LogDHCPFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t    flags;
     void       *rs_logger;
+    OutputJsonCommonSettings cfg;
 } LogDHCPFileCtx;
 
 typedef struct LogDHCPLogThread_ {
@@ -76,6 +77,7 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
     }
     json_object_set_new(js, "dhcp", dhcp_js);
 
+    JsonAddCommonOptions(&thread->dhcplog_ctx->cfg, p, f, js);
     MemBufferReset(thread->buffer);
     OutputJSONBuffer(js, thread->dhcplog_ctx->file_ctx, &thread->buffer);
     json_decref(js);
@@ -106,6 +108,7 @@ static OutputInitResult OutputDHCPLogInitSub(ConfNode *conf,
         return result;
     }
     dhcplog_ctx->file_ctx = ajt->file_ctx;
+    dhcplog_ctx->cfg = ajt->cfg;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/output-json-rdp.c
+++ b/src/output-json-rdp.c
@@ -46,6 +46,7 @@
 typedef struct LogRdpFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t    flags;
+    OutputJsonCommonSettings cfg;
 } LogRdpFileCtx;
 
 typedef struct LogRdpLogThread_ {
@@ -70,6 +71,7 @@ static int JsonRdpLogger(ThreadVars *tv, void *thread_data,
     }
     json_object_set_new(js, "rdp", rdp_js);
 
+    JsonAddCommonOptions(&thread->rdplog_ctx->cfg, p, f, js);
     MemBufferReset(thread->buffer);
     OutputJSONBuffer(js, thread->rdplog_ctx->file_ctx, &thread->buffer);
     json_decref(js);
@@ -99,6 +101,7 @@ static OutputInitResult OutputRdpLogInitSub(ConfNode *conf,
         return result;
     }
     rdplog_ctx->file_ctx = ajt->file_ctx;
+    rdplog_ctx->cfg = ajt->cfg;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/output-json-smb.c
+++ b/src/output-json-smb.c
@@ -78,6 +78,7 @@ static int JsonSMBLogger(ThreadVars *tv, void *thread_data,
     }
     json_object_set_new(js, "smb", smbjs);
 
+    JsonAddCommonOptions(&thread->ctx->cfg, p, f, js);
     MemBufferReset(thread->buffer);
     OutputJSONBuffer(js, thread->ctx->file_ctx, &thread->buffer);
 

--- a/src/output-json-tftp.c
+++ b/src/output-json-tftp.c
@@ -54,6 +54,7 @@
 typedef struct LogTFTPFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t    flags;
+    OutputJsonCommonSettings cfg;
 } LogTFTPFileCtx;
 
 typedef struct LogTFTPLogThread_ {
@@ -79,6 +80,7 @@ static int JsonTFTPLogger(ThreadVars *tv, void *thread_data,
 
     json_object_set_new(js, "tftp", tftpjs);
 
+    JsonAddCommonOptions(&thread->tftplog_ctx->cfg, p, f, js);
     MemBufferReset(thread->buffer);
     OutputJSONBuffer(js, thread->tftplog_ctx->file_ctx, &thread->buffer);
 
@@ -108,6 +110,7 @@ static OutputInitResult OutputTFTPLogInitSub(ConfNode *conf,
         return result;
     }
     tftplog_ctx->file_ctx = ajt->file_ctx;
+    tftplog_ctx->cfg = ajt->cfg;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/util-log-redis.c
+++ b/src/util-log-redis.c
@@ -203,7 +203,11 @@ static int SCConfLogReopenAsyncRedis(LogFileCtx *log_ctx)
         return -1;
     }
 
-    ctx->async = redisAsyncConnect(redis_server, redis_port);
+    if (strchr(redis_server, '/') == NULL) {
+        ctx->async = redisAsyncConnect(redis_server, redis_port);
+    } else {
+        ctx->async = redisAsyncConnectUnix(redis_server);
+    }
 
     if (ctx->ev_base != NULL) {
         event_base_free(ctx->ev_base);
@@ -297,7 +301,12 @@ static int SCConfLogReopenSyncRedis(LogFileCtx *log_ctx)
     if (ctx->sync != NULL)  {
         redisFree(ctx->sync);
     }
-    ctx->sync = redisConnect(redis_server, redis_port);
+
+    if (strchr(redis_server, '/') == NULL) {
+        ctx->sync = redisConnect(redis_server, redis_port);
+    } else {
+        ctx->sync = redisConnectUnix(redis_server);
+    }
     if (ctx->sync == NULL) {
         SCLogError(SC_ERR_SOCKET, "Error connecting to redis server.");
         ctx->tried = time(NULL);

--- a/src/util-log-redis.c
+++ b/src/util-log-redis.c
@@ -67,6 +67,7 @@ static SCLogRedisContext *SCLogRedisContextAlloc(void)
     ctx->async   = NULL;
 #endif
     ctx->batch_count = 0;
+    ctx->last_push = 0;
     ctx->tried = 0;
 
     return ctx;
@@ -92,6 +93,7 @@ static SCLogRedisContext *SCLogRedisContextAsyncAlloc(void)
     ctx->ev_base = NULL;
     ctx->connected = 0;
     ctx->batch_count = 0;
+    ctx->last_push = 0;
     ctx->tried = 0;
 
     return ctx;
@@ -338,11 +340,14 @@ static int SCLogRedisWriteSync(LogFileCtx *file_ctx, const char *string)
                 file_ctx->redis_setup.command,
                 file_ctx->redis_setup.key,
                 string);
-        if (ctx->batch_count == file_ctx->redis_setup.batch_size) {
+        time_t now = time(NULL);
+        if ((ctx->batch_count == file_ctx->redis_setup.batch_size) || (ctx->last_push < now)) {
             redisReply *reply;
             int i;
+            int batch_size = ctx->batch_count;
             ctx->batch_count = 0;
-            for (i = 0; i <= file_ctx->redis_setup.batch_size; i++) {
+            ctx->last_push = now;
+            for (i = 0; i <= batch_size; i++) {
                 if (redisGetReply(redis, (void **)&reply) == REDIS_OK) {
                     freeReplyObject(reply);
                     ret = 0;

--- a/src/util-log-redis.c
+++ b/src/util-log-redis.c
@@ -360,6 +360,12 @@ static int SCLogRedisWriteSync(LogFileCtx *file_ctx, const char *string)
                             redis = ctx->sync;
                             if (redis) {
                                 SCLogInfo("Reconnected to redis server");
+                                redisAppendCommand(redis, "%s %s %s",
+                                        file_ctx->redis_setup.command,
+                                        file_ctx->redis_setup.key,
+                                        string);
+                                ctx->batch_count++;
+                                return 0;
                             } else {
                                 SCLogInfo("Unable to reconnect to redis server");
                                 return -1;

--- a/src/util-log-redis.h
+++ b/src/util-log-redis.h
@@ -55,6 +55,7 @@ typedef struct SCLogRedisContext_ {
 #endif /* HAVE_LIBEVENT */
     time_t tried;
     int  batch_count;
+    time_t last_push;
 } SCLogRedisContext;
 
 void SCLogRedisInit(void);


### PR DESCRIPTION
Batch backport to 5.0.x.

SV failure against [SV PR #260](https://github.com/OISF/suricata-verify/pull/260) under investigation: 
`===> output-eve-rdp-01: Sub test #1: FAIL : expected 3 matches; got 4 for filter {'count': 3, 'match': {'event_type': 'rdp', 'has-key': 'community_id'}}`
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) tickets:

Describe changes:
- [3745](https://redmine.openinfosecfoundation.org/issues/3745)
- [3784](https://redmine.openinfosecfoundation.org/issues/3784)
- [3786](https://redmine.openinfosecfoundation.org/issues/3786)
- [3795](https://redmine.openinfosecfoundation.org/issues/3795)
- [3804](https://redmine.openinfosecfoundation.org/issues/3804)
- [3806](https://redmine.openinfosecfoundation.org/issues/3806)

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
