### PR TITLE
app-layer-protocol: match traffic with ALPROTO_UNKNOWN to failed

### DIFF
--- a/doc/userguide/rules/app-layer.rst
+++ b/doc/userguide/rules/app-layer.rst
@@ -18,7 +18,9 @@ Examples::
 
 A special value 'failed' can be used for matching on flows in which
 protocol detection failed. This can happen if Suricata doesn't know
-the protocol or when certain 'bail out' conditions happen.
+the protocol or when certain 'bail out' conditions happen. '!failed'
+will match on any flow in which detection of a known protocol was
+successful.
 
 .. _proto-detect-bail-out:
 

--- a/src/detect-app-layer-protocol.c
+++ b/src/detect-app-layer-protocol.c
@@ -75,6 +75,12 @@ static int DetectAppLayerProtocolPacketMatch(
 
         r = (data->negated) ? (f->alproto_tc != data->alproto) :
             (f->alproto_tc == data->alproto);
+    } else if (f->alproto == ALPROTO_UNKNOWN)
+    {
+        /* If rule specifies app-layer-protocol:failed match on unknown as well. */
+        SCLogDebug("packet %"PRIu64" unknown alproto, trying to match alproto_failed", p->pcap_cnt);
+        r = (data->alproto == ALPROTO_FAILED) ? !data->negated : 
+            data->negated;
     }
     else {
         SCLogDebug("packet %"PRIu64": default case: direction %02x, approtos %u/%u/%u",


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2858

Describe changes:
- Allows use of app-layer-protocol:failed to match traffic with unknown app-layer protocols.
- Packets with unknown app layer protocols will now also match under negation conditions of known protocols - e.g. app-layer-protocol:!tls;
