### PR TITLE
Generate Rust documentation - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -179,6 +179,9 @@ jobs:
         env:
           DISTCHECK_CONFIGURE_FLAGS: "--enable-unittests --enable-debug --enable-lua --enable-geoip --enable-profiling --enable-profiling-locks"
       - run: test -e doc/userguide/suricata.1
+      - name: Building Rust documentation
+        run: make doc
+        working-directory: rust
       - name: Preparing distribution
         run: |
           mkdir dist
@@ -276,6 +279,9 @@ jobs:
       - run: make -j2
       - run: make install
       - run: make install-conf
+      - name: Building Rust documentation
+        run: make doc
+        working-directory: rust
 
   fedora-31:
     name: Fedora 31

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -78,3 +78,6 @@ gen/rust-bindings.h:
 else
 gen/rust-bindings.h:
 endif
+
+doc:
+	CARGO_HOME=$(CARGO_HOME) $(CARGO) doc --all-features --no-deps


### PR DESCRIPTION
A trivial example of generating rustdoc.  In the `rust` directory a `make doc` will output HTML documentation in `target/doc`.

But in the more general documentation topic, I'm thinking of a script (or a makefile target) that would generate the rustdoc, doxygen doc, userguide and devguide all in html, and dump them in a common directory.  Could even go so far as starting a small http server to serve up the docs for local usage.

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/3363