### PR TITLE
Byteextractstr/part3/v3

### DIFF
--- a/src/app-layer-enip-common.h
+++ b/src/app-layer-enip-common.h
@@ -29,8 +29,6 @@
 #include "flow.h"
 #include "queue.h"
 
-#define MAX_ENIP_CMD    65535
-
 // EtherNet/IP commands
 #define NOP                0x0000
 #define LIST_SERVICES      0x0004

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -240,7 +240,12 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
                    "for arg 1 for byte_extract");
         goto error;
     }
-    bed->nbytes = atoi(nbytes_str);
+    if (StringParseUint8(&bed->nbytes, 10, 0,
+                               (const char *)nbytes_str) < 0) {
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid value for number of bytes"
+                   " to be extracted: \"%s\".", nbytes_str);
+        goto error;
+    }
 
     /* offset */
     char offset_str[64] = "";
@@ -251,10 +256,9 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
                    "for arg 2 for byte_extract");
         goto error;
     }
-    int offset = atoi(offset_str);
-    if (offset < -65535 || offset > 65535) {
-        SCLogError(SC_ERR_INVALID_SIGNATURE, "byte_extract offset invalid - %d.  "
-                   "The right offset range is -65535 to 65535", offset);
+    int32_t offset;
+    if (StringParseI32RangeCheck(&offset, 10, 0, (const char *)offset_str, -65535, 65535) < 0) {
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid value for offset: \"%s\".", offset_str);
         goto error;
     }
     bed->offset = offset;
@@ -307,14 +311,13 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
                            "for arg %d for byte_extract", i);
                 goto error;
             }
-            int multiplier = atoi(multiplier_str);
-            if (multiplier < DETECT_BYTE_EXTRACT_MULTIPLIER_MIN_LIMIT ||
-                multiplier > DETECT_BYTE_EXTRACT_MULTIPLIER_MAX_LIMIT) {
-                SCLogError(SC_ERR_INVALID_SIGNATURE, "multipiler_value invalid "
-                           "- %d.  The range is %d-%d",
-                           multiplier,
-                           DETECT_BYTE_EXTRACT_MULTIPLIER_MIN_LIMIT,
-                           DETECT_BYTE_EXTRACT_MULTIPLIER_MAX_LIMIT);
+            int32_t multiplier;
+            if (StringParseI32RangeCheck(&multiplier, 10, 0,
+                                 (const char *)multiplier_str,
+                                 DETECT_BYTE_EXTRACT_MULTIPLIER_MIN_LIMIT,
+                                 DETECT_BYTE_EXTRACT_MULTIPLIER_MAX_LIMIT) < 0) {
+                SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid value for"
+                        "multiplier: \"%s\".", multiplier_str);
                 goto error;
             }
             bed->multiplier_value = multiplier;
@@ -411,7 +414,12 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
                            "for arg %d in byte_extract", i);
                 goto error;
             }
-            bed->align_value = atoi(align_str);
+            if (StringParseUint8(&bed->align_value, 10, 0,
+                                       (const char *)align_str) < 0) {
+                SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid align_value: "
+                           "\"%s\".", align_str);
+                goto error;
+            }
             if (!(bed->align_value == 2 || bed->align_value == 4)) {
                 SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid align_value for "
                            "byte_extract - \"%d\"", bed->align_value);

--- a/src/detect-cipservice.c
+++ b/src/detect-cipservice.c
@@ -346,14 +346,14 @@ static DetectEnipCommandData *DetectEnipCommandParse(const char *rulestr)
         goto error;
     }
 
-    unsigned long cmd = atol(rulestr);
-    if (cmd > MAX_ENIP_CMD) //if command greater than 16 bit
-    {
-        SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid ENIP command %lu", cmd);
+    uint16_t cmd;
+    if (StringParseUint16(&cmd, 10, 0, rulestr) < 0) {
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid ENIP command"
+                   ": \"%s\"", rulestr);
         goto error;
     }
 
-    enipcmdd->enipcommand = (uint16_t) atoi(rulestr);
+    enipcmdd->enipcommand = cmd;
 
     return enipcmdd;
 

--- a/src/detect-engine-modbus.c
+++ b/src/detect-engine-modbus.c
@@ -230,10 +230,10 @@ int DetectEngineInspectModbus(ThreadVars            *tv,
         if (modbus->category == MODBUS_CAT_NONE) {
             if (modbus->function != MODBUS_FUNC_NONE) {
                 if (modbus->function == tx->function) {
-                    if (modbus->subfunction != NULL) {
+                    if (modbus->has_subfunction) {
                         SCLogDebug("looking for Modbus server function %d and subfunction %d",
-                                   modbus->function, *(modbus->subfunction));
-                        ret = (*(modbus->subfunction) == (tx->subFunction))? 1 : 0;
+                                   modbus->function, modbus->subfunction);
+                        ret = (modbus->subfunction == (tx->subFunction))? 1 : 0;
                     } else {
                         SCLogDebug("looking for Modbus server function %d", modbus->function);
                         ret = 1;

--- a/src/detect-engine-port.c
+++ b/src/detect-engine-port.c
@@ -51,12 +51,13 @@
 #include "host.h"
 #include "util-profiling.h"
 #include "util-var.h"
+#include "util-byte.h"
 
 static int DetectPortCutNot(DetectPort *, DetectPort **);
 static int DetectPortCut(DetectEngineCtx *, DetectPort *, DetectPort *,
                          DetectPort **);
 DetectPort *PortParse(const char *str);
-int DetectPortIsValidRange(char *);
+static bool DetectPortIsValidRange(char *, uint16_t *);
 
 /**
  * \brief Alloc a DetectPort structure and update counters
@@ -1295,20 +1296,20 @@ DetectPort *PortParse(const char *str)
     }
 
     /* see if the address is an ipv4 or ipv6 address */
-    if ((port2 = strchr(port, ':')) != NULL)  {
+    if ((port2 = strchr(port, ':')) != NULL) {
         /* 80:81 range format */
         port2[0] = '\0';
         port2++;
 
-        if (DetectPortIsValidRange(port))
-            dp->port = atoi(port);
-        else
-            goto error;
+        if (strcmp(port, "") != 0) {
+            if (!DetectPortIsValidRange(port, &dp->port))
+                goto error;
+        } else {
+            dp->port = 0;
+        }
 
         if (strcmp(port2, "") != 0) {
-            if (DetectPortIsValidRange(port2))
-                dp->port2 = atoi(port2);
-            else
+            if (!DetectPortIsValidRange(port2, &dp->port2))
                 goto error;
         } else {
             dp->port2 = 65535;
@@ -1321,10 +1322,10 @@ DetectPort *PortParse(const char *str)
         if (strcasecmp(port,"any") == 0) {
             dp->port = 0;
             dp->port2 = 65535;
-        } else if(DetectPortIsValidRange(port)){
-            dp->port = dp->port2 = atoi(port);
         } else {
-            goto error;
+            if (!DetectPortIsValidRange(port, &dp->port))
+                goto error;
+            dp->port2 = dp->port;
         }
     }
 
@@ -1342,18 +1343,16 @@ error:
  *
  * \param str Pointer to the port string
  *
- * \retval 1 if port is in the valid range
- * \retval 0 if invalid
+ *
+ * \retval true if port is in the valid range
+ * \retval false if invalid
  */
-int DetectPortIsValidRange(char *port)
+static bool DetectPortIsValidRange(char *port, uint16_t *port_val)
 {
-    char *end;
-    long r = strtol(port, &end, 10);
+    if (StringParseUint16(port_val, 10, 0, (const char *)port) < 0)
+        return false;
 
-    if(*end == 0 && r >= 0 && r <= 65535)
-        return 1;
-    else
-        return 0;
+    return true;
 }
 
 /********************** End parsing routines ********************/

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -478,7 +478,8 @@ static int DetectIPProtoTestParse02(void)
 static int DetectIPProtoTestSetup01(void)
 {
     const char *value_str = "14";
-    int value = atoi(value_str);
+    int value;
+    FAIL_IF(StringParseInt32(&value, 10, 0, (const char *)value_str) < 0);
     int i;
 
     Signature *sig = SigAlloc();

--- a/src/detect-iprep.c
+++ b/src/detect-iprep.c
@@ -41,6 +41,7 @@
 #include "detect-engine-state.h"
 
 #include "util-debug.h"
+#include "util-byte.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 #include "util-fmemopen.h"
@@ -321,10 +322,8 @@ int DetectIPRepSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
     }
 
     if (value != NULL && strlen(value) > 0) {
-        int ival = atoi(value);
-        if (ival < 0 || ival > 127)
+        if (StringParseU8RangeCheck(&val, 10, 0, (const char *)value, 0, 127) < 0)
             goto error;
-        val = (uint8_t)ival;
     }
 
     cd = SCMalloc(sizeof(DetectIPRepData));

--- a/src/detect-krb5-errcode.c
+++ b/src/detect-krb5-errcode.c
@@ -23,6 +23,7 @@
 
 #include "suricata-common.h"
 #include "util-unittest.h"
+#include "util-byte.h"
 
 #include "detect-parse.h"
 #include "detect-engine.h"
@@ -156,8 +157,10 @@ static DetectKrb5ErrCodeData *DetectKrb5ErrCodeParse (const char *krb5str)
     krb5d = SCMalloc(sizeof (DetectKrb5ErrCodeData));
     if (unlikely(krb5d == NULL))
         goto error;
-    krb5d->err_code = (int32_t)atoi(arg1);
-
+    if (StringParseInt32(&krb5d->err_code, 10, 0,
+                         (const char *)arg1) < 0) {
+        goto error;
+    }
     return krb5d;
 
 error:

--- a/src/detect-krb5-msgtype.c
+++ b/src/detect-krb5-msgtype.c
@@ -23,6 +23,7 @@
 
 #include "suricata-common.h"
 #include "util-unittest.h"
+#include "util-byte.h"
 
 #include "detect-parse.h"
 #include "detect-engine.h"
@@ -153,8 +154,10 @@ static DetectKrb5MsgTypeData *DetectKrb5MsgTypeParse (const char *krb5str)
     krb5d = SCMalloc(sizeof (DetectKrb5MsgTypeData));
     if (unlikely(krb5d == NULL))
         goto error;
-    krb5d->msg_type = (uint8_t)atoi(arg1);
-
+    if (StringParseUint8(&krb5d->msg_type, 10, 0,
+                         (const char *)arg1) < 0) {
+        goto error;
+    }
     return krb5d;
 
 error:

--- a/src/detect-modbus.c
+++ b/src/detect-modbus.c
@@ -91,9 +91,6 @@ static void DetectModbusFree(DetectEngineCtx *de_ctx, void *ptr) {
     DetectModbus *modbus = (DetectModbus *) ptr;
 
     if(modbus) {
-        if (modbus->subfunction)
-            SCFree(modbus->subfunction);
-
         if (modbus->unit_id)
             SCFree(modbus->unit_id);
 
@@ -355,18 +352,14 @@ static DetectModbus *DetectModbusFunctionParse(DetectEngineCtx *de_ctx, const ch
                 goto error;
             }
 
-            /* We have a correct address option */
-            modbus->subfunction =(uint16_t *) SCCalloc(1, sizeof(uint16_t));
-            if (modbus->subfunction == NULL)
-                goto error;
-
-            if (StringParseUint16(&(*modbus->subfunction), 10, 0, (const char *)arg) < 0) {
+            if (StringParseUint16(&modbus->subfunction, 10, 0, (const char *)arg) < 0) {
                 SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for "
                            "modbus subfunction: %s", (const char*)arg);
                 goto error;
             }
+            modbus->has_subfunction = true;
 
-            SCLogDebug("and subfunction %d", *(modbus->subfunction));
+            SCLogDebug("and subfunction %d", modbus->subfunction);
         }
     } else {
         uint8_t neg = 0;
@@ -627,7 +620,7 @@ static int DetectModbusTest02(void)
     modbus = (DetectModbus *) de_ctx->sig_list->sm_lists_tail[g_modbus_buffer_id]->ctx;
 
     FAIL_IF_NOT(modbus->function == 8);
-    FAIL_IF_NOT(*modbus->subfunction == 4);
+    FAIL_IF_NOT(modbus->subfunction == 4);
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
@@ -908,7 +901,7 @@ static int DetectModbusTest11(void)
     FAIL_IF_NOT((*modbus->unit_id).min == 10);
     FAIL_IF_NOT((*modbus->unit_id).mode == mode);
     FAIL_IF_NOT(modbus->function == 8);
-    FAIL_IF_NOT((*modbus->subfunction) == 4);
+    FAIL_IF_NOT(modbus->subfunction == 4);
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);

--- a/src/detect-modbus.h
+++ b/src/detect-modbus.h
@@ -50,14 +50,14 @@ typedef struct DetectModbusValue_ {
 } DetectModbusValue;
 
 typedef struct DetectModbus_ {
-    uint8_t             category;       /** < Modbus function code category to match */
-    uint8_t             function;       /** < Modbus function code to match */
-    uint16_t            subfunction;    /** < Modbus subfunction to match */
-    bool                has_subfunction; /** < Modbus subfunction indicator */
-    uint8_t             type;           /** < Modbus access type to match */
-    DetectModbusValue   *unit_id;       /** < Modbus unit id to match */
-    DetectModbusValue   *address;       /** < Modbus address to match */
-    DetectModbusValue   *data;          /** < Modbus data to match */
+    uint8_t             category;          /** < Modbus function code category to match */
+    uint8_t             function;          /** < Modbus function code to match */
+    uint16_t            subfunction;      /** < Modbus subfunction to match */
+    bool                has_subfunction;   /** < Modbus subfunction indicator */
+    uint8_t             type;              /** < Modbus access type to match */
+    DetectModbusValue   *unit_id;          /** < Modbus unit id to match */
+    DetectModbusValue   *address;          /** < Modbus address to match */
+    DetectModbusValue   *data;             /** < Modbus data to match */
 } DetectModbus;
 
 /* prototypes */

--- a/src/detect-modbus.h
+++ b/src/detect-modbus.h
@@ -52,7 +52,8 @@ typedef struct DetectModbusValue_ {
 typedef struct DetectModbus_ {
     uint8_t             category;       /** < Modbus function code category to match */
     uint8_t             function;       /** < Modbus function code to match */
-    uint16_t            *subfunction;   /** < Modbus subfunction to match */
+    uint16_t            subfunction;    /** < Modbus subfunction to match */
+    bool                has_subfunction; /** < Modbus subfunction indicator */
     uint8_t             type;           /** < Modbus access type to match */
     DetectModbusValue   *unit_id;       /** < Modbus unit id to match */
     DetectModbusValue   *address;       /** < Modbus address to match */


### PR DESCRIPTION
atoi() and related functions lack a mechanism for reporting errors for
invalid values. Replace them with calls to the appropriate
ByteExtractString* functions.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3053