### PR TITLE
Byteextractstr/part4/v1

### DIFF
--- a/qa/coccinelle/banned-functions.cocci
+++ b/qa/coccinelle/banned-functions.cocci
@@ -3,7 +3,7 @@ identifier i;
 position p1;
 @@
 
-\(strtok@i\|sprintf@i\|strcat@i\|strcpy@i\|strncpy@i\|strncat@i\|strchrnul@i\|rand@i\|rand_r@i\|index@i\|rindex@i\|bzero@i\)(...)@p1
+\(strtok@i\|sprintf@i\|strcat@i\|strcpy@i\|strncpy@i\|strncat@i\|strchrnul@i\|atoi@i\|rand@i\|rand_r@i\|index@i\|rindex@i\|bzero@i\)(...)@p1
 
 @script:python@
 p1 << banned.p1;

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -43,6 +43,7 @@
 #include "util-debug.h"
 #include "util-spm-bm.h"
 #include "util-print.h"
+#include "util-byte.h"
 
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
@@ -280,8 +281,15 @@ int DetectLuaMatchBuffer(DetectEngineThreadCtx *det_ctx,
                 SCLogDebug("k='%s', v='%s'", k, v);
 
                 if (strcmp(k, "retval") == 0) {
-                    if (atoi(v) == 1)
+                    int val;
+                    if (StringParseInt32(&val, 10, 0, (const char *)v) < 0) {
+                        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value "
+                                   "for \"retval\" from LUA return table: '%s'", v);
+                        ret = 0;
+                    }
+                    else if (val == 1) {
                         ret = 1;
+                    }
                 } else {
                     /* set flow var? */
                 }
@@ -428,8 +436,16 @@ static int DetectLuaMatch (DetectEngineThreadCtx *det_ctx,
                 SCLogDebug("k='%s', v='%s'", k, v);
 
                 if (strcmp(k, "retval") == 0) {
-                    if (atoi(v) == 1)
+                    int val;
+                    if (StringParseInt32(&val, 10, 0,
+                                         (const char *)v) < 0) {
+                        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value "
+                                   "for \"retval\" from LUA return table: '%s'", v);
+                        ret = 0;
+                    }
+                    else if (val == 1) {
                         ret = 1;
+                    }
                 } else {
                     /* set flow var? */
                 }
@@ -530,8 +546,16 @@ static int DetectLuaAppMatchCommon (DetectEngineThreadCtx *det_ctx,
                 SCLogDebug("k='%s', v='%s'", k, v);
 
                 if (strcmp(k, "retval") == 0) {
-                    if (atoi(v) == 1)
+                    int val;
+                    if (StringParseInt32(&val, 10, 0,
+                                         (const char *)v) < 0) {
+                        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value "
+                                   "for \"retval\" from LUA return table: '%s'", v);
+                        ret = 0;
+                    }
+                    else if (val == 1) {
                         ret = 1;
+                    }
                 } else {
                     /* set flow var? */
                 }

--- a/src/detect-nfs-procedure.c
+++ b/src/detect-nfs-procedure.c
@@ -42,6 +42,7 @@
 
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
+#include "util-byte.h"
 
 #include "app-layer-nfs-tcp.h"
 #include "rust.h"
@@ -287,8 +288,10 @@ static DetectNfsProcedureData *DetectNfsProcedureParse (const char *rawstr)
     }
 
     /* set the first value */
-    dd->lo = atoi(value1); //TODO
-
+    if (StringParseUint32(&dd->lo, 10, 0, (const char *)value1) < 0) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid first value: \"%s\"", value1);
+        goto error;
+    }
     /* set the second value if specified */
     if (strlen(value2) > 0) {
         if (!(dd->mode == PROCEDURE_RA)) {
@@ -297,8 +300,10 @@ static DetectNfsProcedureData *DetectNfsProcedureParse (const char *rawstr)
             goto error;
         }
 
-        //
-        dd->hi = atoi(value2); // TODO
+        if (StringParseUint32(&dd->hi, 10, 0, (const char *)value2) < 0) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid second value: \"%s\"", value2);
+            goto error;
+        }
 
         if (dd->hi <= dd->lo) {
             SCLogError(SC_ERR_INVALID_ARGUMENT,

--- a/src/detect-nfs-version.c
+++ b/src/detect-nfs-version.c
@@ -42,6 +42,7 @@
 
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
+#include "util-byte.h"
 
 #include "app-layer-nfs-tcp.h"
 #include "rust.h"
@@ -278,8 +279,10 @@ static DetectNfsVersionData *DetectNfsVersionParse (const char *rawstr)
     }
 
     /* set the first value */
-    dd->lo = atoi(value1); //TODO
-
+    if (StringParseUint32(&dd->lo, 10, 0, (const char *)value1) < 0) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid first value: \"%s\"", value1);
+        goto error;
+    }
     /* set the second value if specified */
     if (strlen(value2) > 0) {
         if (!(dd->mode == PROCEDURE_RA)) {
@@ -288,9 +291,10 @@ static DetectNfsVersionData *DetectNfsVersionParse (const char *rawstr)
             goto error;
         }
 
-        //
-        dd->hi = atoi(value2); // TODO
-
+        if (StringParseUint32(&dd->hi, 10, 0, (const char *)value2) < 0) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid second value: \"%s\"", value2);
+            goto error;
+        }
         if (dd->hi <= dd->lo) {
             SCLogError(SC_ERR_INVALID_ARGUMENT,
                 "Second value in range must not be smaller than the first");

--- a/src/detect-stream_size.c
+++ b/src/detect-stream_size.c
@@ -34,6 +34,7 @@
 #include "detect-stream_size.h"
 #include "stream-tcp-private.h"
 #include "util-debug.h"
+#include "util-byte.h"
 
 /**
  * \brief Regex for parsing our flow options
@@ -244,8 +245,10 @@ static DetectStreamSizeData *DetectStreamSizeParse (DetectEngineCtx *de_ctx, con
     }
 
     /* set the value */
-    sd->ssize = (uint32_t)atoi(value);
-
+    if (StringParseUint32(&sd->ssize, 10, 0, (const char *)value) < 0) {
+        SCLogError(SC_ERR_INVALID_VALUE, "Invalid value for stream size: %s", value);
+        goto error;
+    }
     /* inspect our options and set the flags */
     if (strcmp(arg, "server") == 0) {
         sd->flags |= STREAM_SIZE_SERVER;

--- a/src/detect-tcpmss.c
+++ b/src/detect-tcpmss.c
@@ -27,6 +27,7 @@
 #include "detect.h"
 #include "detect-parse.h"
 #include "detect-engine-prefilter-common.h"
+#include "util-byte.h"
 
 #include "detect-tcpmss.h"
 
@@ -178,8 +179,10 @@ static DetectTcpmssData *DetectTcpmssParse (const char *tcpmssstr)
                     goto error;
 
                 tcpmssd->mode = DETECT_TCPMSS_LT;
-                tcpmssd->arg1 = (uint16_t) atoi(arg3);
-
+                if (StringParseUint16(&tcpmssd->arg1, 10, 0, (const char *)arg3) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg: %s", arg3);
+                    goto error;
+                }
                 SCLogDebug("tcpmss is %"PRIu16"",tcpmssd->arg1);
                 if (strlen(arg1) > 0)
                     goto error;
@@ -190,8 +193,10 @@ static DetectTcpmssData *DetectTcpmssParse (const char *tcpmssstr)
                     goto error;
 
                 tcpmssd->mode = DETECT_TCPMSS_GT;
-                tcpmssd->arg1 = (uint16_t) atoi(arg3);
-
+                if (StringParseUint16(&tcpmssd->arg1, 10, 0, (const char *)arg3) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg: %s", arg3);
+                    goto error;
+                }
                 SCLogDebug("tcpmss is %"PRIu16"",tcpmssd->arg1);
                 if (strlen(arg1) > 0)
                     goto error;
@@ -204,9 +209,14 @@ static DetectTcpmssData *DetectTcpmssParse (const char *tcpmssstr)
                     goto error;
 
                 tcpmssd->mode = DETECT_TCPMSS_RA;
-                tcpmssd->arg1 = (uint16_t) atoi(arg1);
-
-                tcpmssd->arg2 = (uint16_t) atoi(arg3);
+                if (StringParseUint16(&tcpmssd->arg1, 10, 0, (const char *)arg1) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg: %s", arg1);
+                    goto error;
+                }
+                if (StringParseUint16(&tcpmssd->arg2, 10, 0, (const char *)arg3) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid second arg: %s", arg3);
+                    goto error;
+                }
                 SCLogDebug("tcpmss is %"PRIu16" to %"PRIu16"",tcpmssd->arg1, tcpmssd->arg2);
                 if (tcpmssd->arg1 >= tcpmssd->arg2) {
                     SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid tcpmss range. ");
@@ -221,7 +231,10 @@ static DetectTcpmssData *DetectTcpmssParse (const char *tcpmssstr)
                     (arg1 == NULL ||strlen(arg1) == 0))
                     goto error;
 
-                tcpmssd->arg1 = (uint16_t) atoi(arg1);
+                if (StringParseUint16(&tcpmssd->arg1, 10, 0, (const char *)arg1) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg: %s", arg1);
+                    goto error;
+                }
                 break;
         }
     } else {
@@ -231,7 +244,10 @@ static DetectTcpmssData *DetectTcpmssParse (const char *tcpmssstr)
             (arg1 == NULL ||strlen(arg1) == 0))
             goto error;
 
-        tcpmssd->arg1 = (uint16_t) atoi(arg1);
+        if (StringParseUint16(&tcpmssd->arg1, 10, 0, (const char *)arg1) < 0) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg: %s", arg1);
+            goto error;
+        }
     }
 
     SCFree(arg1);

--- a/src/detect-template.c
+++ b/src/detect-template.c
@@ -25,6 +25,7 @@
 
 #include "suricata-common.h"
 #include "util-unittest.h"
+#include "util-byte.h"
 
 #include "detect-parse.h"
 #include "detect-engine.h"
@@ -154,9 +155,14 @@ static DetectTemplateData *DetectTemplateParse (const char *templatestr)
     if (unlikely(templated == NULL))
         return NULL;
 
-    templated->arg1 = (uint8_t)atoi(arg1);
-    templated->arg2 = (uint8_t)atoi(arg2);
-
+    if (ByteExtractStringUint8(&templated->arg1, 10, 0, (const char *)arg1) < 0) {
+        SCFree(templated);
+        return NULL;
+    }
+    if (ByteExtractStringUint8(&templated->arg2, 10, 0, (const char *)arg2) < 0) {
+        SCFree(templated);
+        return NULL;
+    }
     return templated;
 }
 

--- a/src/detect-template2.c
+++ b/src/detect-template2.c
@@ -23,6 +23,7 @@
  */
 
 #include "suricata-common.h"
+#include "util-byte.h"
 
 #include "detect.h"
 #include "detect-parse.h"
@@ -185,8 +186,11 @@ static DetectTemplate2Data *DetectTemplate2Parse (const char *template2str)
                     goto error;
 
                 template2d->mode = DETECT_TEMPLATE2_LT;
-                template2d->arg1 = (uint8_t) atoi(arg3);
-
+                if (StringParseUint8(&template2d->arg1, 10, 0, (const char *)arg3) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg:"
+                               " \"%s\"", arg3);
+                    goto error;
+                }
                 SCLogDebug("template2 is %"PRIu8"",template2d->arg1);
                 if (strlen(arg1) > 0)
                     goto error;
@@ -197,8 +201,11 @@ static DetectTemplate2Data *DetectTemplate2Parse (const char *template2str)
                     goto error;
 
                 template2d->mode = DETECT_TEMPLATE2_GT;
-                template2d->arg1 = (uint8_t) atoi(arg3);
-
+                if (StringParseUint8(&template2d->arg1, 10, 0, (const char *)arg3) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg:"
+                               " \"%s\"", arg3);
+                    goto error;
+                }
                 SCLogDebug("template2 is %"PRIu8"",template2d->arg1);
                 if (strlen(arg1) > 0)
                     goto error;
@@ -211,9 +218,16 @@ static DetectTemplate2Data *DetectTemplate2Parse (const char *template2str)
                     goto error;
 
                 template2d->mode = DETECT_TEMPLATE2_RA;
-                template2d->arg1 = (uint8_t) atoi(arg1);
-
-                template2d->arg2 = (uint8_t) atoi(arg3);
+                if (StringParseUint8(&template2d->arg1, 10, 0, (const char *)arg1) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg:"
+                               " \"%s\"", arg1);
+                    goto error;
+                }
+                if (StringParseUint8(&template2d->arg2, 10, 0, (const char *)arg3) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid second arg:"
+                               " \"%s\"", arg3);
+                    goto error;
+                }
                 SCLogDebug("template2 is %"PRIu8" to %"PRIu8"",template2d->arg1, template2d->arg2);
                 if (template2d->arg1 >= template2d->arg2) {
                     SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid template2 range. ");
@@ -228,7 +242,11 @@ static DetectTemplate2Data *DetectTemplate2Parse (const char *template2str)
                     (arg1 == NULL ||strlen(arg1) == 0))
                     goto error;
 
-                template2d->arg1 = (uint8_t) atoi(arg1);
+                if (StringParseUint8(&template2d->arg1, 10, 0, (const char *)arg1) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg:"
+                               " \"%s\"", arg1);
+                    goto error;
+                }
                 break;
         }
     } else {
@@ -238,7 +256,11 @@ static DetectTemplate2Data *DetectTemplate2Parse (const char *template2str)
             (arg1 == NULL ||strlen(arg1) == 0))
             goto error;
 
-        template2d->arg1 = (uint8_t) atoi(arg1);
+        if (StringParseUint8(&template2d->arg1, 10, 0, (const char *)arg1) < 0) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first arg:"
+                       " \"%s\"", arg1);
+            goto error;
+        }
     }
 
     SCFree(arg1);

--- a/src/detect-ttl.c
+++ b/src/detect-ttl.c
@@ -169,8 +169,8 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
         }
     }
 
-    int ttl1 = 0;
-    int ttl2 = 0;
+    uint8_t ttl1 = 0;
+    uint8_t ttl2 = 0;
     int mode = 0;
 
     if (strlen(arg2) > 0) {
@@ -180,7 +180,7 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
                     return NULL;
 
                 mode = DETECT_TTL_LT;
-                if (StringParseInt32(&ttl1, 10, 0, (const char *)arg3) < 0) {
+                if (StringParseUint8(&ttl1, 10, 0, (const char *)arg3) < 0) {
                     SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first ttl "
                                "value: \"%s\"", arg3);
                     return NULL;
@@ -195,7 +195,7 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
                     return NULL;
 
                 mode = DETECT_TTL_GT;
-                if (StringParseInt32(&ttl1, 10, 0, (const char *)arg3) < 0) {
+                if (StringParseUint8(&ttl1, 10, 0, (const char *)arg3) < 0) {
                     SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first ttl "
                                "value: \"%s\"", arg3);
                     return NULL;
@@ -211,12 +211,12 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
 
                 mode = DETECT_TTL_RA;
 
-                if (StringParseInt32(&ttl1, 10, 0, (const char *)arg1) < 0) {
+                if (StringParseUint8(&ttl1, 10, 0, (const char *)arg1) < 0) {
                     SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first ttl "
                                "value: \"%s\"", arg1);
                     return NULL;
                 }
-                if (StringParseInt32(&ttl2, 10, 0, (const char *)arg3) < 0) {
+                if (StringParseUint8(&ttl2, 10, 0, (const char *)arg3) < 0) {
                     SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid second ttl "
                                "value: \"%s\"", arg3);
                     return NULL;
@@ -234,7 +234,7 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
                     (strlen(arg3) > 0) ||
                     (strlen(arg1) == 0))
                     return NULL;
-                if (StringParseInt32(&ttl1, 10, 0, (const char *)arg1) < 0) {
+                if (StringParseUint8(&ttl1, 10, 0, (const char *)arg1) < 0) {
                     SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first ttl "
                                "value: \"%s\"", arg1);
                     return NULL;
@@ -247,17 +247,11 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
         if ((strlen(arg3) > 0) ||
             (strlen(arg1) == 0))
             return NULL;
-        if (StringParseInt32(&ttl1, 10, 0, (const char *)arg1) < 0) {
+        if (StringParseUint8(&ttl1, 10, 0, (const char *)arg1) < 0) {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first ttl "
                         "value: \"%s\"", arg1);
             return NULL;
         }
-    }
-
-    if (ttl1 < 0 || ttl1 > UCHAR_MAX ||
-        ttl2 < 0 || ttl2 > UCHAR_MAX) {
-        SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid ttl value(s)");
-        return NULL;
     }
 
     DetectTtlData *ttld = SCMalloc(sizeof(DetectTtlData));

--- a/src/detect-ttl.c
+++ b/src/detect-ttl.c
@@ -33,6 +33,7 @@
 
 #include "detect-ttl.h"
 #include "util-debug.h"
+#include "util-byte.h"
 
 /**
  * \brief Regex for parsing our ttl options
@@ -179,8 +180,11 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
                     return NULL;
 
                 mode = DETECT_TTL_LT;
-                ttl1 = atoi(arg3);
-
+                if (StringParseInt32(&ttl1, 10, 0, (const char *)arg3) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first ttl "
+                               "value: \"%s\"", arg3);
+                    return NULL;
+                }
                 SCLogDebug("ttl is %d",ttl1);
                 if (strlen(arg1) > 0)
                     return NULL;
@@ -191,8 +195,11 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
                     return NULL;
 
                 mode = DETECT_TTL_GT;
-                ttl1 = atoi(arg3);
-
+                if (StringParseInt32(&ttl1, 10, 0, (const char *)arg3) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first ttl "
+                               "value: \"%s\"", arg3);
+                    return NULL;
+                }
                 SCLogDebug("ttl is %d",ttl1);
                 if (strlen(arg1) > 0)
                     return NULL;
@@ -203,9 +210,17 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
                     return NULL;
 
                 mode = DETECT_TTL_RA;
-                ttl1 = atoi(arg1);
-                ttl2 = atoi(arg3);
 
+                if (StringParseInt32(&ttl1, 10, 0, (const char *)arg1) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first ttl "
+                               "value: \"%s\"", arg1);
+                    return NULL;
+                }
+                if (StringParseInt32(&ttl2, 10, 0, (const char *)arg3) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid second ttl "
+                               "value: \"%s\"", arg3);
+                    return NULL;
+                }
                 SCLogDebug("ttl is %d to %d",ttl1, ttl2);
                 if (ttl1 >= ttl2) {
                     SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid ttl range");
@@ -219,8 +234,11 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
                     (strlen(arg3) > 0) ||
                     (strlen(arg1) == 0))
                     return NULL;
-
-                ttl1 = atoi(arg1);
+                if (StringParseInt32(&ttl1, 10, 0, (const char *)arg1) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first ttl "
+                               "value: \"%s\"", arg1);
+                    return NULL;
+                }
                 break;
         }
     } else {
@@ -229,8 +247,11 @@ static DetectTtlData *DetectTtlParse (const char *ttlstr)
         if ((strlen(arg3) > 0) ||
             (strlen(arg1) == 0))
             return NULL;
-
-        ttl1 = atoi(arg1);
+        if (StringParseInt32(&ttl1, 10, 0, (const char *)arg1) < 0) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid first ttl "
+                        "value: \"%s\"", arg1);
+            return NULL;
+        }
     }
 
     if (ttl1 < 0 || ttl1 > UCHAR_MAX ||

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -124,7 +124,7 @@ static void *OldParsePfringConfig(const char *iface)
         pfconf->threads = 1;
     } else {
         if (threadsstr != NULL) {
-            if (StringParseUint16(&pfconf->threads, 10, 0, threadsstr) < 0) {
+            if (StringParseInt32(&pfconf->threads, 10, 0, threadsstr) < 0) {
                 SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
                              "pfring.threads: '%s'. Resetting to 1.", threadsstr);
                 pfconf->threads = 1;
@@ -146,7 +146,7 @@ static void *OldParsePfringConfig(const char *iface)
     } else if (ConfGet("pfring.cluster-id", &tmpclusterid) != 1) {
         SCLogError(SC_ERR_INVALID_ARGUMENT,"Could not get cluster-id from config");
     } else {
-        if (StringParseUint16(&pfconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
+        if (StringParseInt32(&pfconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
             SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
                          "pfring.cluster_id: '%s'. Resetting to 1.", tmpclusterid);
             pfconf->cluster_id = 1;
@@ -280,7 +280,7 @@ static void *ParsePfringConfig(const char *iface)
 
     /* command line value has precedence */
     if (ConfGet("pfring.cluster-id", &tmpclusterid) == 1) {
-        if (StringParseUint16(&pfconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
+        if (StringParseInt32(&pfconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
             SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
                          "pfring.cluster-id: '%s'. Resetting to 1.", tmpclusterid);
             pfconf->cluster_id = 1;
@@ -300,7 +300,7 @@ static void *ParsePfringConfig(const char *iface)
             SCLogError(SC_ERR_INVALID_ARGUMENT,
                        "Could not get cluster-id from config");
         } else {
-            if (StringParseUint16(&pfconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
+            if (StringParseInt32(&pfconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
                 SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for "
                              "pfring.cluster-id: '%s'. Resetting to 1.", tmpclusterid);
                 pfconf->cluster_id = 1;


### PR DESCRIPTION
atoi() and related functions lack a mechanism for reporting errors for
invalid values. Replace them with calls to the appropriate
ByteExtractString* functions.

Partially closes redmine ticket 3053.