### PR TITLE
src: use FatalError whenever possible

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1661,11 +1661,9 @@ int AppLayerProtoDetectPPParseConfPorts(const char *ipproto_name,
     r = snprintf(param, sizeof(param), "%s%s%s", "app-layer.protocols.",
                  alproto_name, ".detection-ports");
     if (r < 0) {
-        SCLogError(SC_ERR_FATAL, "snprintf failure.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "snprintf failure.");
     } else if (r > (int)sizeof(param)) {
-        SCLogError(SC_ERR_FATAL, "buffer not big enough to write param.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "buffer not big enough to write param.");
     }
     node = ConfGetNode(param);
     if (node == NULL) {
@@ -1673,11 +1671,9 @@ int AppLayerProtoDetectPPParseConfPorts(const char *ipproto_name,
         r = snprintf(param, sizeof(param), "%s%s%s%s%s", "app-layer.protocols.",
                      alproto_name, ".", ipproto_name, ".detection-ports");
         if (r < 0) {
-            SCLogError(SC_ERR_FATAL, "snprintf failure.");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "snprintf failure.");
         } else if (r > (int)sizeof(param)) {
-            SCLogError(SC_ERR_FATAL, "buffer not big enough to write param.");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "buffer not big enough to write param.");
         }
         node = ConfGetNode(param);
         if (node == NULL)
@@ -1775,8 +1771,7 @@ int AppLayerProtoDetectSetup(void)
 
     alpd_ctx.spm_global_thread_ctx = SpmInitGlobalThreadCtx(spm_matcher);
     if (alpd_ctx.spm_global_thread_ctx == NULL) {
-        SCLogError(SC_ERR_FATAL, "Unable to alloc SpmGlobalThreadCtx.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to alloc SpmGlobalThreadCtx.");
     }
 
     for (i = 0; i < FLOW_PROTO_DEFAULT; i++) {
@@ -1905,11 +1900,9 @@ int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto,
     r = snprintf(param, sizeof(param), "%s%s%s", "app-layer.protocols.",
                  alproto, ".enabled");
     if (r < 0) {
-        SCLogError(SC_ERR_FATAL, "snprintf failure.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "snprintf failure.");
     } else if (r > (int)sizeof(param)) {
-        SCLogError(SC_ERR_FATAL, "buffer not big enough to write param.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "buffer not big enough to write param.");
     }
 
     node = ConfGetNode(param);
@@ -1918,11 +1911,9 @@ int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto,
         r = snprintf(param, sizeof(param), "%s%s%s%s%s", "app-layer.protocols.",
                      alproto, ".", ipproto, ".enabled");
         if (r < 0) {
-            SCLogError(SC_ERR_FATAL, "snprintf failure.");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "snprintf failure.");
         } else if (r > (int)sizeof(param)) {
-            SCLogError(SC_ERR_FATAL, "buffer not big enough to write param.");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "buffer not big enough to write param.");
         }
 
         node = ConfGetNode(param);

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2747,9 +2747,8 @@ static void HTPConfigParseParameters(HTPCfgRec *cfg_prec, ConfNode *s,
                 exit(EXIT_FAILURE);
             }
             if (limit == 0) {
-                SCLogError(SC_ERR_SIZE_PARSE, "Error meta-field-limit "
+                FatalError(SC_ERR_FATAL, "Error meta-field-limit "
                            "from conf file cannot be 0.  Killing engine");
-                exit(EXIT_FAILURE);
             }
             /* set default soft-limit with our new hard limit */
             htp_config_set_field_limits(cfg_prec->cfg,
@@ -2890,8 +2889,7 @@ void HTPConfigure(void)
     /* Default Config */
     cfglist.cfg = htp_config_create();
     if (NULL == cfglist.cfg) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Failed to create HTP default config");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Failed to create HTP default config");
     }
     SCLogDebug("LIBHTP default config: %p", cfglist.cfg);
     HTPConfigSetDefaultsPhase1(&cfglist);
@@ -2939,8 +2937,7 @@ void HTPConfigure(void)
         cfglist.next->next = nextrec;
         cfglist.next->cfg = htp_config_create();
         if (NULL == cfglist.next->cfg) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Failed to create HTP server config");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Failed to create HTP server config");
         }
 
         HTPConfigSetDefaultsPhase1(htprec);

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -315,11 +315,9 @@ int AppLayerParserConfParserEnabled(const char *ipproto,
     r = snprintf(param, sizeof(param), "%s%s%s", "app-layer.protocols.",
                  alproto_name, ".enabled");
     if (r < 0) {
-        SCLogError(SC_ERR_FATAL, "snprintf failure.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "snprintf failure.");
     } else if (r > (int)sizeof(param)) {
-        SCLogError(SC_ERR_FATAL, "buffer not big enough to write param.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "buffer not big enough to write param.");
     }
 
     node = ConfGetNode(param);
@@ -328,11 +326,9 @@ int AppLayerParserConfParserEnabled(const char *ipproto,
         r = snprintf(param, sizeof(param), "%s%s%s%s%s", "app-layer.protocols.",
                      alproto_name, ".", ipproto, ".enabled");
         if (r < 0) {
-            SCLogError(SC_ERR_FATAL, "snprintf failure.");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "snprintf failure.");
         } else if (r > (int)sizeof(param)) {
-            SCLogError(SC_ERR_FATAL, "buffer not big enough to write param.");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "buffer not big enough to write param.");
         }
 
         node = ConfGetNode(param);

--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -92,17 +92,15 @@ ConfYamlSetConfDirname(const char *filename)
     if (ep == NULL) {
         conf_dirname = SCStrdup(".");
         if (conf_dirname == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC,
-               "ERROR: Failed to allocate memory while loading configuration.");
-            exit(EXIT_FAILURE);
+               FatalError(SC_ERR_FATAL,
+                          "ERROR: Failed to allocate memory while loading configuration.");
         }
     }
     else {
         conf_dirname = SCStrdup(filename);
         if (conf_dirname == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC,
-               "ERROR: Failed to allocate memory while loading configuration.");
-            exit(EXIT_FAILURE);
+               FatalError(SC_ERR_FATAL,
+                          "ERROR: Failed to allocate memory while loading configuration.");
         }
         conf_dirname[ep - filename] = '\0';
     }

--- a/src/conf.c
+++ b/src/conf.c
@@ -118,10 +118,9 @@ void ConfInit(void)
     }
     root = ConfNodeNew();
     if (root == NULL) {
-        SCLogError(SC_ERR_MEM_ALLOC,
-            "ERROR: Failed to allocate memory for root configuration node, "
-            "aborting.");
-        exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL,
+                       "ERROR: Failed to allocate memory for root configuration node, "
+                       "aborting.");
     }
     SCLogDebug("configuration module initialized");
 }

--- a/src/counters.c
+++ b/src/counters.c
@@ -286,8 +286,7 @@ static void StatsInitCtxPostOutput(void)
 
     /* init the lock used by StatsThreadStore */
     if (SCMutexInit(&stats_ctx->sts_lock, NULL) != 0) {
-        SCLogError(SC_ERR_INITIALIZATION, "error initializing sts mutex");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "error initializing sts mutex");
     }
 
     if (stats_enabled && !OutputStatsLoggersRegistered()) {
@@ -863,8 +862,8 @@ void StatsInit(void)
 {
     BUG_ON(stats_ctx != NULL);
     if ( (stats_ctx = SCMalloc(sizeof(StatsGlobalContext))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in StatsInitCtx. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in StatsInitCtx. Exiting...");
     }
     memset(stats_ctx, 0, sizeof(StatsGlobalContext));
 
@@ -903,30 +902,25 @@ void StatsSpawnThreads(void)
     tv_wakeup = TmThreadCreateMgmtThread(thread_name_counter_wakeup,
                                          StatsWakeupThread, 1);
     if (tv_wakeup == NULL) {
-        SCLogError(SC_ERR_THREAD_CREATE, "TmThreadCreateMgmtThread "
+        FatalError(SC_ERR_FATAL, "TmThreadCreateMgmtThread "
                    "failed");
-        exit(EXIT_FAILURE);
     }
 
     if (TmThreadSpawn(tv_wakeup) != 0) {
-        SCLogError(SC_ERR_THREAD_SPAWN, "TmThreadSpawn failed for "
+        FatalError(SC_ERR_FATAL, "TmThreadSpawn failed for "
                    "StatsWakeupThread");
-        exit(EXIT_FAILURE);
     }
 
     /* spawn the stats mgmt thread */
     tv_mgmt = TmThreadCreateMgmtThread(thread_name_counter_stats,
                                        StatsMgmtThread, 1);
     if (tv_mgmt == NULL) {
-        SCLogError(SC_ERR_THREAD_CREATE,
-                   "TmThreadCreateMgmtThread failed");
-        exit(EXIT_FAILURE);
+                   FatalError(SC_ERR_FATAL, "TmThreadCreateMgmtThread failed");
     }
 
     if (TmThreadSpawn(tv_mgmt) != 0) {
-        SCLogError(SC_ERR_THREAD_SPAWN, "TmThreadSpawn failed for "
+        FatalError(SC_ERR_FATAL, "TmThreadSpawn failed for "
                    "StatsWakeupThread");
-        exit(EXIT_FAILURE);
     }
 
     SCReturn;

--- a/src/defrag-config.c
+++ b/src/defrag-config.c
@@ -47,8 +47,7 @@ static void DefragPolicyAddHostInfo(char *host_ip_range, uint64_t timeout)
     uint64_t *user_data = NULL;
 
     if ( (user_data = SCMalloc(sizeof(uint64_t))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Error allocating memory. Exiting");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory. Exiting");
     }
 
     *user_data = timeout;
@@ -137,9 +136,8 @@ void DefragPolicyLoadFromConfig(void)
 
     defrag_tree = SCRadixCreateRadixTree(DefragPolicyFreeUserData, NULL);
     if (defrag_tree == NULL) {
-        SCLogError(SC_ERR_MEM_ALLOC,
-            "Can't alloc memory for the defrag config tree.");
-        exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL,
+                       "Can't alloc memory for the defrag config tree.");
     }
 
     ConfNode *server_config = ConfGetNode("defrag.host-config");

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -236,8 +236,8 @@ void DefragInitConfig(char quiet)
     }
     defragtracker_hash = SCCalloc(defrag_config.hash_size, sizeof(DefragTrackerHashRow));
     if (unlikely(defragtracker_hash == NULL)) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in DefragTrackerInitConfig. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in DefragTrackerInitConfig. Exiting...");
     }
     memset(defragtracker_hash, 0, defrag_config.hash_size * sizeof(DefragTrackerHashRow));
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -196,14 +196,12 @@ DefragContextNew(void)
         sizeof(Frag),
         NULL, DefragFragInit, dc, NULL, NULL);
     if (dc->frag_pool == NULL) {
-        SCLogError(SC_ERR_MEM_ALLOC,
-            "Defrag: Failed to initialize fragment pool.");
-        exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL,
+                       "Defrag: Failed to initialize fragment pool.");
     }
     if (SCMutexInit(&dc->frag_pool_lock, NULL) != 0) {
-        SCLogError(SC_ERR_MUTEX,
-            "Defrag: Failed to initialize frag pool mutex.");
-        exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL,
+                       "Defrag: Failed to initialize frag pool mutex.");
     }
 
     /* Set the default timeout. */
@@ -213,14 +211,12 @@ DefragContextNew(void)
     }
     else {
         if (timeout < TIMEOUT_MIN) {
-            SCLogError(SC_ERR_INVALID_ARGUMENT,
-                "defrag: Timeout less than minimum allowed value.");
-            exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL,
+                           "defrag: Timeout less than minimum allowed value.");
         }
         else if (timeout > TIMEOUT_MAX) {
-            SCLogError(SC_ERR_INVALID_ARGUMENT,
-                "defrag: Tiemout greater than maximum allowed value.");
-            exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL,
+                           "defrag: Tiemout greater than maximum allowed value.");
         }
         dc->timeout = timeout;
     }
@@ -1078,9 +1074,8 @@ DefragInit(void)
     /* Allocate the DefragContext. */
     defrag_context = DefragContextNew();
     if (defrag_context == NULL) {
-        SCLogError(SC_ERR_MEM_ALLOC,
-            "Failed to allocate memory for the Defrag module.");
-        exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL,
+                       "Failed to allocate memory for the Defrag module.");
     }
 
     DefragSetDefaultTimeout(defrag_context->timeout);

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -238,8 +238,7 @@ void EngineAnalysisFP(const DetectEngineCtx *de_ctx, const Signature *s, char *l
     uint16_t patlen = fp_cd->content_len;
     uint8_t *pat = SCMalloc(fp_cd->content_len + 1);
     if (unlikely(pat == NULL)) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     memcpy(pat, fp_cd->content, fp_cd->content_len);
     pat[fp_cd->content_len] = '\0';
@@ -486,8 +485,7 @@ static void EngineAnalysisRulesPrintFP(const DetectEngineCtx *de_ctx, const Sign
     uint16_t patlen = fp_cd->content_len;
     uint8_t *pat = SCMalloc(fp_cd->content_len + 1);
     if (unlikely(pat == NULL)) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     memcpy(pat, fp_cd->content, fp_cd->content_len);
     pat[fp_cd->content_len] = '\0';
@@ -634,8 +632,7 @@ static void DumpMatches(RuleAnalyzer *ctx, json_t *js, const SigMatchData *smd)
                     const DetectContentData *cd = (const DetectContentData *)smd->ctx;
                     uint8_t *pat = SCMalloc(cd->content_len + 1);
                     if (unlikely(pat == NULL)) {
-                        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-                        exit(EXIT_FAILURE);
+                        FatalError(SC_ERR_FATAL, "Error allocating memory");
                     }
                     memcpy(pat, cd->content, cd->content_len);
                     pat[cd->content_len] = '\0';

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1897,35 +1897,29 @@ int SigGroupBuild(DetectEngineCtx *de_ctx)
     SigInitStandardMpmFactoryContexts(de_ctx);
 
     if (SigAddressPrepareStage1(de_ctx) != 0) {
-        SCLogError(SC_ERR_DETECT_PREPARE, "initializing the detection engine failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "initializing the detection engine failed");
     }
 
     if (SigAddressPrepareStage2(de_ctx) != 0) {
-        SCLogError(SC_ERR_DETECT_PREPARE, "initializing the detection engine failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "initializing the detection engine failed");
     }
 
     if (SigAddressPrepareStage3(de_ctx) != 0) {
-        SCLogError(SC_ERR_DETECT_PREPARE, "initializing the detection engine failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "initializing the detection engine failed");
     }
     if (SigAddressPrepareStage4(de_ctx) != 0) {
-        SCLogError(SC_ERR_DETECT_PREPARE, "initializing the detection engine failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "initializing the detection engine failed");
     }
 
     int r = DetectMpmPrepareBuiltinMpms(de_ctx);
     r |= DetectMpmPrepareAppMpms(de_ctx);
     r |= DetectMpmPreparePktMpms(de_ctx);
     if (r != 0) {
-        SCLogError(SC_ERR_DETECT_PREPARE, "initializing the detection engine failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "initializing the detection engine failed");
     }
 
     if (SigMatchPrepare(de_ctx) != 0) {
-        SCLogError(SC_ERR_DETECT_PREPARE, "initializing the detection engine failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "initializing the detection engine failed");
     }
 
 #ifdef PROFILING

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -531,8 +531,8 @@ static SigNumArray *SigNumArrayNew(DetectEngineCtx *de_ctx,
     SigNumArray *new = SCMalloc(sizeof(SigNumArray));
 
     if (unlikely(new == NULL)) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in SigNumArrayNew. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in SigNumArrayNew. Exiting...");
     }
     memset(new, 0, sizeof(SigNumArray));
 
@@ -562,8 +562,8 @@ static SigNumArray *SigNumArrayCopy(SigNumArray *orig)
     SigNumArray *new = SCMalloc(sizeof(SigNumArray));
 
     if (unlikely(new == NULL)) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in SigNumArrayCopy. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in SigNumArrayCopy. Exiting...");
     }
 
     memset(new, 0, sizeof(SigNumArray));
@@ -874,8 +874,8 @@ void IPOnlyInit(DetectEngineCtx *de_ctx, DetectEngineIPOnlyCtx *io_ctx)
     io_ctx->sig_init_size = DetectEngineGetMaxSigId(de_ctx) / 8 + 1;
 
     if ( (io_ctx->sig_init_array = SCMalloc(io_ctx->sig_init_size)) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in IPOnlyInit. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in IPOnlyInit. Exiting...");
     }
 
     memset(io_ctx->sig_init_array, 0, io_ctx->sig_init_size);

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -624,9 +624,8 @@ uint16_t PatternMatchDefaultMatcher(void)
         if (mpm_algo != NULL) {
 #if __BYTE_ORDER == __BIG_ENDIAN
             if (strcmp(mpm_algo, "ac-ks") == 0) {
-                SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY, "ac-ks does "
-                        "not work on big endian systems at this time.");
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL, "ac-ks does "
+                           "not work on big endian systems at this time.");
             }
 #endif
             if (strcmp("auto", mpm_algo) == 0) {

--- a/src/detect-engine-sigorder.c
+++ b/src/detect-engine-sigorder.c
@@ -97,8 +97,8 @@ static void SCSigRegisterSignatureOrderingFunc(DetectEngineCtx *de_ctx,
     }
 
     if ( (temp = SCMalloc(sizeof(SCSigOrderFunc))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in SCSigRegisterSignatureOrderingFunc. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in SCSigRegisterSignatureOrderingFunc. Exiting...");
     }
     memset(temp, 0, sizeof(SCSigOrderFunc));
 

--- a/src/detect-engine-tag.c
+++ b/src/detect-engine-tag.c
@@ -54,13 +54,11 @@ void TagInitCtx(void)
 
     host_tag_id = HostStorageRegister("tag", sizeof(void *), NULL, DetectTagDataListFree);
     if (host_tag_id == -1) {
-        SCLogError(SC_ERR_HOST_INIT, "Can't initiate host storage for tag");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Can't initiate host storage for tag");
     }
     flow_tag_id = FlowStorageRegister("tag", sizeof(void *), NULL, DetectTagDataListFree);
     if (flow_tag_id == -1) {
-        SCLogError(SC_ERR_FLOW_INIT, "Can't initiate flow storage for tag");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Can't initiate flow storage for tag");
     }
 }
 

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -81,13 +81,13 @@ void ThresholdInit(void)
 {
     host_threshold_id = HostStorageRegister("threshold", sizeof(void *), NULL, ThresholdListFree);
     if (host_threshold_id == -1) {
-        SCLogError(SC_ERR_HOST_INIT, "Can't initiate host storage for thresholding");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Can't initiate host storage for thresholding");
     }
     ippair_threshold_id = IPPairStorageRegister("threshold", sizeof(void *), NULL, ThresholdListFree);
     if (ippair_threshold_id == -1) {
-        SCLogError(SC_ERR_HOST_INIT, "Can't initiate IP pair storage for thresholding");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Can't initiate IP pair storage for thresholding");
     }
 }
 
@@ -652,9 +652,8 @@ int PacketAlertThreshold(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
 void ThresholdHashInit(DetectEngineCtx *de_ctx)
 {
     if (SCMutexInit(&de_ctx->ths_ctx.threshold_table_lock, NULL) != 0) {
-        SCLogError(SC_ERR_MEM_ALLOC,
-                "Threshold: Failed to initialize hash table mutex.");
-        exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL,
+                           "Threshold: Failed to initialize hash table mutex.");
     }
 }
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1610,8 +1610,7 @@ SigMatchData* SigMatchList2DataArray(SigMatch *head)
 
     SigMatchData *smd = (SigMatchData *)SCCalloc(len, sizeof(SigMatchData));
     if (smd == NULL) {
-        SCLogError(SC_ERR_DETECT_PREPARE, "initializing the detection engine failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "initializing the detection engine failed");
     }
     SigMatchData *out = smd;
 

--- a/src/flow.c
+++ b/src/flow.c
@@ -570,8 +570,7 @@ void FlowInitConfig(char quiet)
     if ((ConfGet("flow.memcap", &conf_val)) == 1)
     {
         if (conf_val == NULL) {
-            SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,"Invalid value for flow.memcap: NULL");
-	    exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Invalid value for flow.memcap: NULL");
         }
 
         if (ParseSizeStringU64(conf_val, &flow_memcap_copy) < 0) {
@@ -586,8 +585,7 @@ void FlowInitConfig(char quiet)
     if ((ConfGet("flow.hash-size", &conf_val)) == 1)
     {
         if (conf_val == NULL) {
-            SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,"Invalid value for flow.hash-size: NULL");
-	    exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Invalid value for flow.hash-size: NULL");
         }
 
         if (StringParseUint32(&configval, 10, strlen(conf_val),
@@ -598,8 +596,7 @@ void FlowInitConfig(char quiet)
     if ((ConfGet("flow.prealloc", &conf_val)) == 1)
     {
         if (conf_val == NULL) {
-            SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,"Invalid value for flow.prealloc: NULL");
-	    exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Invalid value for flow.prealloc: NULL");
         }
 
         if (StringParseUint32(&configval, 10, strlen(conf_val),
@@ -624,8 +621,8 @@ void FlowInitConfig(char quiet)
     }
     flow_hash = SCMallocAligned(flow_config.hash_size * sizeof(FlowBucket), CLS);
     if (unlikely(flow_hash == NULL)) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in FlowInitConfig. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in FlowInitConfig. Exiting...");
     }
     memset(flow_hash, 0, flow_config.hash_size * sizeof(FlowBucket));
 

--- a/src/host-bit.c
+++ b/src/host-bit.c
@@ -50,8 +50,7 @@ void HostBitInitCtx(void)
 {
     host_bit_id = HostStorageRegister("bit", sizeof(void *), NULL, HostBitFreeAll);
     if (host_bit_id == -1) {
-        SCLogError(SC_ERR_HOST_INIT, "Can't initiate host storage for bits");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Can't initiate host storage for bits");
     }
 }
 

--- a/src/host.c
+++ b/src/host.c
@@ -241,8 +241,8 @@ void HostInitConfig(char quiet)
     }
     host_hash = SCMallocAligned(host_config.hash_size * sizeof(HostHashRow), CLS);
     if (unlikely(host_hash == NULL)) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in HostInitConfig. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in HostInitConfig. Exiting...");
     }
     memset(host_hash, 0, host_config.hash_size * sizeof(HostHashRow));
 

--- a/src/ippair-bit.c
+++ b/src/ippair-bit.c
@@ -50,8 +50,7 @@ void IPPairBitInitCtx(void)
 {
     ippair_bit_id = IPPairStorageRegister("bit", sizeof(void *), NULL, XBitFreeAll);
     if (ippair_bit_id == -1) {
-        SCLogError(SC_ERR_IPPAIR_INIT, "Can't initiate ippair storage for bits");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Can't initiate ippair storage for bits");
     }
 }
 

--- a/src/ippair.c
+++ b/src/ippair.c
@@ -236,8 +236,8 @@ void IPPairInitConfig(char quiet)
     }
     ippair_hash = SCMallocAligned(ippair_config.hash_size * sizeof(IPPairHashRow), CLS);
     if (unlikely(ippair_hash == NULL)) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in IPPairInitConfig. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in IPPairInitConfig. Exiting...");
     }
     memset(ippair_hash, 0, ippair_config.hash_size * sizeof(IPPairHashRow));
 

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -1170,16 +1170,14 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
 
     PcapLogData *pl = SCMalloc(sizeof(PcapLogData));
     if (unlikely(pl == NULL)) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate Memory for PcapLogData");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Failed to allocate Memory for PcapLogData");
     }
     memset(pl, 0, sizeof(PcapLogData));
 
     pl->h = SCMalloc(sizeof(*pl->h));
     if (pl->h == NULL) {
-        SCLogError(SC_ERR_MEM_ALLOC,
-            "Failed to allocate Memory for pcap header struct");
-        exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL,
+                       "Failed to allocate Memory for pcap header struct");
     }
 
     /* Set the defaults */
@@ -1246,10 +1244,9 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
                 uint64_t size = pl->size_limit * 1024 * 1024;
                 pl->size_limit = size;
             } else if (pl->size_limit < MIN_LIMIT) {
-                SCLogError(SC_ERR_INVALID_ARGUMENT,
-                    "Fail to initialize pcap-log output, limit less than "
-                    "allowed minimum.");
-                exit(EXIT_FAILURE);
+                    FatalError(SC_ERR_FATAL,
+                               "Fail to initialize pcap-log output, limit less than "
+                               "allowed minimum.");
             }
         }
     }
@@ -1277,10 +1274,9 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
         }
         if (s_dir == NULL) {
             if (pl->mode == LOGMODE_SGUIL) {
-                SCLogError(SC_ERR_LOGPCAP_SGUIL_BASE_DIR_MISSING,
-                    "log-pcap \"sguil\" mode requires \"sguil-base-dir\" "
-                    "option to be set.");
-                exit(EXIT_FAILURE);
+                    FatalError(SC_ERR_FATAL,
+                               "log-pcap \"sguil\" mode requires \"sguil-base-dir\" "
+                               "option to be set.");
             } else {
                 const char *log_dir = NULL;
                 log_dir = ConfigGetLogDirectory();
@@ -1394,9 +1390,8 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
 
             comp->buffer = SCMalloc(comp->buffer_size);
             if (unlikely(comp->buffer == NULL)) {
-                SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate memory for "
-                    "lz4 output buffer.");
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL, "Failed to allocate memory for "
+                           "lz4 output buffer.");
             }
 
             comp->bytes_in_block = 0;
@@ -1438,10 +1433,9 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
                            max_number_of_files_s);
                 exit(EXIT_FAILURE);
             } else if (max_file_limit < 1) {
-                SCLogError(SC_ERR_INVALID_ARGUMENT,
-                    "Failed to initialize pcap-log output, limit less than "
-                    "allowed minimum.");
-                exit(EXIT_FAILURE);
+                    FatalError(SC_ERR_FATAL,
+                               "Failed to initialize pcap-log output, limit less than "
+                               "allowed minimum.");
             } else {
                 pl->max_files = max_file_limit;
                 pl->use_ringbuffer = RING_BUFFER_MODE_ENABLED;
@@ -1474,9 +1468,8 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
         } else if (ConfValIsTrue(use_stream_depth)) {
             pl->use_stream_depth = USE_STREAM_DEPTH_ENABLED;
         } else {
-            SCLogError(SC_ERR_INVALID_ARGUMENT,
-                "log-pcap use_stream_depth specified is invalid must be");
-            exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL,
+                           "log-pcap use_stream_depth specified is invalid must be");
         }
     }
 
@@ -1490,9 +1483,8 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
         } else if (ConfValIsTrue(honor_pass_rules)) {
             pl->honor_pass_rules = HONOR_PASS_RULES_ENABLED;
         } else {
-            SCLogError(SC_ERR_INVALID_ARGUMENT,
-                "log-pcap honor-pass-rules specified is invalid");
-            exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL,
+                           "log-pcap honor-pass-rules specified is invalid");
         }
     }
 
@@ -1500,8 +1492,7 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate memory for OutputCtx.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Failed to allocate memory for OutputCtx.");
     }
     output_ctx->data = pl;
     output_ctx->DeInit = PcapLogFileDeInitCtx;
@@ -1828,8 +1819,7 @@ void PcapLogProfileSetup(void)
 
             profiling_pcaplog_file_name = SCMalloc(PATH_MAX);
             if (unlikely(profiling_pcaplog_file_name == NULL)) {
-                SCLogError(SC_ERR_MEM_ALLOC, "can't duplicate file name");
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL, "can't duplicate file name");
             }
 
             snprintf(profiling_pcaplog_file_name, PATH_MAX, "%s/%s", log_dir, filename);

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1531,9 +1531,8 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
                 SCLogRedisInit();
                 json_ctx->json_out = LOGFILE_TYPE_REDIS;
 #else
-                SCLogError(SC_ERR_INVALID_ARGUMENT,
-                           "redis JSON output option is not compiled");
-                exit(EXIT_FAILURE);
+                           FatalError(SC_ERR_FATAL,
+                                      "redis JSON output option is not compiled");
 #endif
             } else {
                 SCLogError(SC_ERR_INVALID_ARGUMENT,
@@ -1549,9 +1548,8 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
             json_ctx->file_ctx->prefix = SCStrdup(prefix);
             if (json_ctx->file_ctx->prefix == NULL)
             {
-                SCLogError(SC_ERR_MEM_ALLOC,
-                    "Failed to allocate memory for eve-log.prefix setting.");
-                exit(EXIT_FAILURE);
+                    FatalError(SC_ERR_FATAL,
+                               "Failed to allocate memory for eve-log.prefix setting.");
             }
             json_ctx->file_ctx->prefix_len = strlen(prefix);
         }

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -857,10 +857,9 @@ error:
         SCLogDebug("ConfGetBool could not load the value.");
     }
     if (failure_fatal) {
-        SCLogError(SC_ERR_LUA_ERROR,
-                   "Error during setup of lua output. Details should be "
-                   "described in previous error messages. Shutting down...");
-        exit(EXIT_FAILURE);
+                   FatalError(SC_ERR_FATAL,
+                              "Error during setup of lua output. Details should be "
+                              "described in previous error messages. Shutting down...");
     }
 
     return result;

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -120,8 +120,7 @@ int OutputRegisterTxLogger(LoggerId id, const char *name, AppProto alproto,
         while (t->next)
             t = t->next;
         if (t->id * 2 > UINT32_MAX) {
-            SCLogError(SC_ERR_FATAL, "Too many loggers registered.");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Too many loggers registered.");
         }
         op->id = t->id * 2;
         t->next = op;

--- a/src/output.c
+++ b/src/output.c
@@ -156,8 +156,8 @@ void OutputRegisterModule(const char *name, const char *conf_name,
     return;
 
 error:
-    SCLogError(SC_ERR_FATAL, "Fatal error encountered in OutputRegisterModule. Exiting...");
-    exit(EXIT_FAILURE);
+    FatalError(SC_ERR_FATAL,
+               "Fatal error encountered in OutputRegisterModule. Exiting...");
 }
 
 /**
@@ -197,8 +197,7 @@ void OutputRegisterPacketModule(LoggerId id, const char *name,
     SCLogDebug("Packet logger \"%s\" registered.", name);
     return;
 error:
-    SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
-    exit(EXIT_FAILURE);
+    FatalError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
 }
 
 /**
@@ -239,8 +238,7 @@ void OutputRegisterPacketSubModule(LoggerId id, const char *parent_name,
     SCLogDebug("Packet logger \"%s\" registered.", name);
     return;
 error:
-    SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
-    exit(EXIT_FAILURE);
+    FatalError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
 }
 
 /**
@@ -284,8 +282,7 @@ static void OutputRegisterTxModuleWrapper(LoggerId id, const char *name,
     SCLogDebug("Tx logger \"%s\" registered.", name);
     return;
 error:
-    SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
-    exit(EXIT_FAILURE);
+    FatalError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
 }
 
 static void OutputRegisterTxSubModuleWrapper(LoggerId id, const char *parent_name,
@@ -322,8 +319,7 @@ static void OutputRegisterTxSubModuleWrapper(LoggerId id, const char *parent_nam
     SCLogDebug("Tx logger for alproto %d \"%s\" registered.", alproto, name);
     return;
 error:
-    SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
-    exit(EXIT_FAILURE);
+    FatalError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
 }
 
 /**
@@ -453,8 +449,7 @@ void OutputRegisterFileModule(LoggerId id, const char *name,
     SCLogDebug("File logger \"%s\" registered.", name);
     return;
 error:
-    SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
-    exit(EXIT_FAILURE);
+    FatalError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
 }
 
 /**
@@ -494,8 +489,7 @@ void OutputRegisterFileSubModule(LoggerId id, const char *parent_name,
     SCLogDebug("File logger \"%s\" registered.", name);
     return;
 error:
-    SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
-    exit(EXIT_FAILURE);
+    FatalError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
 }
 
 /**
@@ -534,8 +528,7 @@ void OutputRegisterFiledataModule(LoggerId id, const char *name,
     SCLogDebug("Filedata logger \"%s\" registered.", name);
     return;
 error:
-    SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
-    exit(EXIT_FAILURE);
+    FatalError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
 }
 
 /**
@@ -575,8 +568,7 @@ void OutputRegisterFiledataSubModule(LoggerId id, const char *parent_name,
     SCLogDebug("Filedata logger \"%s\" registered.", name);
     return;
 error:
-    SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
-    exit(EXIT_FAILURE);
+    FatalError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
 }
 
 /**
@@ -614,8 +606,7 @@ void OutputRegisterFlowModule(LoggerId id, const char *name,
     SCLogDebug("Flow logger \"%s\" registered.", name);
     return;
 error:
-    SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
-    exit(EXIT_FAILURE);
+    FatalError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
 }
 
 /**
@@ -655,8 +646,7 @@ void OutputRegisterFlowSubModule(LoggerId id, const char *parent_name,
     SCLogDebug("Flow logger \"%s\" registered.", name);
     return;
 error:
-    SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
-    exit(EXIT_FAILURE);
+    FatalError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
 }
 
 /**
@@ -697,8 +687,7 @@ void OutputRegisterStreamingModule(LoggerId id, const char *name,
     SCLogDebug("Streaming logger \"%s\" registered.", name);
     return;
 error:
-    SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
-    exit(EXIT_FAILURE);
+    FatalError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
 }
 
 /**
@@ -739,8 +728,7 @@ void OutputRegisterStreamingSubModule(LoggerId id, const char *parent_name,
     SCLogDebug("Streaming logger \"%s\" registered.", name);
     return;
 error:
-    SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
-    exit(EXIT_FAILURE);
+    FatalError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
 }
 
 /**
@@ -778,8 +766,7 @@ void OutputRegisterStatsModule(LoggerId id, const char *name,
     SCLogDebug("Stats logger \"%s\" registered.", name);
     return;
 error:
-    SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
-    exit(EXIT_FAILURE);
+    FatalError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
 }
 
 /**
@@ -819,8 +806,7 @@ void OutputRegisterStatsSubModule(LoggerId id, const char *parent_name,
     SCLogDebug("Stats logger \"%s\" registered.", name);
     return;
 error:
-    SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
-    exit(EXIT_FAILURE);
+    FatalError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
 }
 
 /**

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -80,8 +80,7 @@ static void SRepCIDRAddNetblock(SRepCIDRTree *cidr_ctx, char *ip, int cat, int v
 {
     SReputation *user_data = NULL;
     if ((user_data = SCMalloc(sizeof(SReputation))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Error allocating memory. Exiting");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory. Exiting");
     }
     memset(user_data, 0x00, sizeof(SReputation));
 

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -815,8 +815,7 @@ int RunModeIdsAFPAutoFp(void)
     SCLogDebug("live_dev %s", live_dev);
 
     if (AFPPeersListInit() != TM_ECODE_OK) {
-        SCLogError(SC_ERR_RUNMODE, "Unable to init peers list.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to init peers list.");
     }
 
     ret = RunModeSetLiveCaptureAutoFp(ParseAFPConfig,
@@ -825,14 +824,12 @@ int RunModeIdsAFPAutoFp(void)
                               "DecodeAFP", thread_name_autofp,
                               live_dev);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to start runmode");
     }
 
     /* In IPS mode each threads must have a peer */
     if (AFPPeersListCheck() != TM_ECODE_OK) {
-        SCLogError(SC_ERR_RUNMODE, "Some IPS capture threads did not peer.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Some IPS capture threads did not peer.");
     }
 
     SCLogDebug("RunModeIdsAFPAutoFp initialised");
@@ -857,8 +854,7 @@ int RunModeIdsAFPSingle(void)
     (void)ConfGet("af-packet.live-interface", &live_dev);
 
     if (AFPPeersListInit() != TM_ECODE_OK) {
-        SCLogError(SC_ERR_RUNMODE, "Unable to init peers list.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to init peers list.");
     }
 
     ret = RunModeSetLiveCaptureSingle(ParseAFPConfig,
@@ -867,14 +863,12 @@ int RunModeIdsAFPSingle(void)
                                     "DecodeAFP", thread_name_single,
                                     live_dev);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to start runmode");
     }
 
     /* In IPS mode each threads must have a peer */
     if (AFPPeersListCheck() != TM_ECODE_OK) {
-        SCLogError(SC_ERR_RUNMODE, "Some IPS capture threads did not peer.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Some IPS capture threads did not peer.");
     }
 
     SCLogDebug("RunModeIdsAFPSingle initialised");
@@ -902,8 +896,7 @@ int RunModeIdsAFPWorkers(void)
     (void)ConfGet("af-packet.live-interface", &live_dev);
 
     if (AFPPeersListInit() != TM_ECODE_OK) {
-        SCLogError(SC_ERR_RUNMODE, "Unable to init peers list.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to init peers list.");
     }
 
     ret = RunModeSetLiveCaptureWorkers(ParseAFPConfig,
@@ -912,14 +905,12 @@ int RunModeIdsAFPWorkers(void)
                                     "DecodeAFP", thread_name_workers,
                                     live_dev);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to start runmode");
     }
 
     /* In IPS mode each threads must have a peer */
     if (AFPPeersListCheck() != TM_ECODE_OK) {
-        SCLogError(SC_ERR_RUNMODE, "Some IPS capture threads did not peer.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Some IPS capture threads did not peer.");
     }
 
     SCLogDebug("RunModeIdsAFPWorkers initialised");

--- a/src/runmode-erf-dag.c
+++ b/src/runmode-erf-dag.c
@@ -84,8 +84,7 @@ int RunModeIdsErfDagSingle(void)
         thread_name_single,
         NULL);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "DAG single runmode failed to start");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "DAG single runmode failed to start");
     }
 
     SCLogInfo("RunModeIdsDagSingle initialised");
@@ -110,8 +109,7 @@ int RunModeIdsErfDagAutoFp(void)
         thread_name_autofp,
         NULL);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "DAG autofp runmode failed to start");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "DAG autofp runmode failed to start");
     }
 
     SCLogInfo("RunModeIdsDagAutoFp initialised");
@@ -136,8 +134,7 @@ int RunModeIdsErfDagWorkers(void)
         thread_name_workers,
         NULL);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "DAG workers runmode failed to start");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "DAG workers runmode failed to start");
     }
 
     SCLogInfo("RunModeIdsErfDagWorkers initialised");

--- a/src/runmode-erf-file.c
+++ b/src/runmode-erf-file.c
@@ -57,8 +57,7 @@ int RunModeErfFileSingle(void)
     SCEnter();
 
     if (ConfGet("erf-file.file", &file) == 0) {
-        SCLogError(SC_ERR_RUNMODE, "Failed to get erf-file.file from config.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Failed to get erf-file.file from config.");
     }
 
     RunModeInitialize();
@@ -92,8 +91,7 @@ int RunModeErfFileSingle(void)
 
     tm_module = TmModuleGetByName("FlowWorker");
     if (tm_module == NULL) {
-        SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName for FlowWorker failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "TmModuleGetByName for FlowWorker failed");
     }
     TmSlotSetFuncAppend(tv, tm_module, NULL);
 
@@ -120,9 +118,8 @@ int RunModeErfFileAutoFp(void)
 
     const char *file = NULL;
     if (ConfGet("erf-file.file", &file) == 0) {
-        SCLogError(SC_ERR_RUNMODE,
-            "Failed retrieving erf-file.file from config");
-        exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL,
+                       "Failed retrieving erf-file.file from config");
     }
 
     TimeModeSetOffline();
@@ -146,8 +143,8 @@ int RunModeErfFileAutoFp(void)
 
     queues = RunmodeAutoFpCreatePickupQueuesString(thread_max);
     if (queues == NULL) {
-        SCLogError(SC_ERR_RUNMODE, "RunmodeAutoFpCreatePickupQueuesString failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "RunmodeAutoFpCreatePickupQueuesString failed");
     }
 
     /* create the threads */
@@ -207,8 +204,8 @@ int RunModeErfFileAutoFp(void)
 
         tm_module = TmModuleGetByName("FlowWorker");
         if (tm_module == NULL) {
-            SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName for FlowWorker failed");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL,
+                       "TmModuleGetByName for FlowWorker failed");
         }
         TmSlotSetFuncAppend(tv_detect_ncpu, tm_module, NULL);
 

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -423,8 +423,7 @@ int RunModeIdsNetmapAutoFp(void)
                               "DecodeNetmap", thread_name_autofp,
                               live_dev);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to start runmode");
     }
 
     SCLogDebug("RunModeIdsNetmapAutoFp initialised");
@@ -456,8 +455,7 @@ int RunModeIdsNetmapSingle(void)
                                     "DecodeNetmap", thread_name_single,
                                     live_dev);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to start runmode");
     }
 
     SCLogDebug("RunModeIdsNetmapSingle initialised");
@@ -492,8 +490,7 @@ int RunModeIdsNetmapWorkers(void)
                                     "DecodeNetmap", thread_name_workers,
                                     live_dev);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to start runmode");
     }
 
     SCLogDebug("RunModeIdsNetmapWorkers initialised");

--- a/src/runmode-nflog.c
+++ b/src/runmode-nflog.c
@@ -103,8 +103,7 @@ static void *ParseNflogConfig(const char *group)
     strlcpy(nflogconf->numgroup, group, sizeof(nflogconf->numgroup));
 
     if (ParseSizeStringU16(group, &nflogconf->group) < 0) {
-        SCLogError(SC_ERR_NFLOG_GROUP, "NFLOG's group number invalid.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "NFLOG's group number invalid.");
     }
 
     boolval = ConfGetChildValueIntWithDefault(group_root, group_default,
@@ -185,8 +184,7 @@ int RunModeIdsNflogAutoFp(void)
                                       thread_name_autofp,
                                       live_dev);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to start runmode");
     }
 
     SCLogInfo("RunModeIdsNflogAutoFp initialised");
@@ -213,8 +211,7 @@ int RunModeIdsNflogSingle(void)
                                       thread_name_single,
                                       live_dev);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to start runmode");
     }
 
     SCLogInfo("RunModeIdsNflogSingle initialised");
@@ -241,8 +238,7 @@ int RunModeIdsNflogWorkers(void)
                                        thread_name_workers,
                                        live_dev);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to start runmode");
     }
 
     SCLogInfo("RunModeIdsNflogWorkers initialised");

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -251,8 +251,7 @@ int RunModeIdsPcapSingle(void)
                                     "DecodePcap", thread_name_single,
                                     live_dev);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Runmode start failed");
     }
 
     SCLogInfo("RunModeIdsPcapSingle initialised");
@@ -292,8 +291,7 @@ int RunModeIdsPcapAutoFp(void)
                               "DecodePcap", thread_name_autofp,
                               live_dev);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Runmode start failed");
     }
 
     SCLogInfo("RunModeIdsPcapAutoFp initialised");
@@ -324,8 +322,7 @@ int RunModeIdsPcapWorkers(void)
                                     "DecodePcap", thread_name_workers,
                                     live_dev);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to start runmode");
     }
 
     SCLogInfo("RunModeIdsPcapWorkers initialised");

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -470,9 +470,8 @@ int RunModeIdsPfringAutoFp(void)
 
     ret = GetDevAndParser(&live_dev, &tparser);
     if (ret != 0) {
-        SCLogError(SC_ERR_MISSING_CONFIG_PARAM,
-                "Unable to get parser and interface params");
-        exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL,
+                           "Unable to get parser and interface params");
     }
 
     ret = RunModeSetLiveCaptureAutoFp(tparser,
@@ -481,8 +480,7 @@ int RunModeIdsPfringAutoFp(void)
                               "DecodePfring", thread_name_autofp,
                               live_dev);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Runmode start failed");
     }
 
     SCLogInfo("RunModeIdsPfringAutoFp initialised");
@@ -507,9 +505,8 @@ int RunModeIdsPfringSingle(void)
 
     ret = GetDevAndParser(&live_dev, &tparser);
     if (ret != 0) {
-        SCLogError(SC_ERR_MISSING_CONFIG_PARAM,
-                "Unable to get parser and interface params");
-        exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL,
+                           "Unable to get parser and interface params");
     }
 
     ret = RunModeSetLiveCaptureSingle(tparser,
@@ -518,8 +515,7 @@ int RunModeIdsPfringSingle(void)
                               "DecodePfring", thread_name_single,
                               live_dev);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Runmode start failed");
     }
 
     SCLogInfo("RunModeIdsPfringSingle initialised");
@@ -544,9 +540,8 @@ int RunModeIdsPfringWorkers(void)
 
     ret = GetDevAndParser(&live_dev, &tparser);
     if (ret != 0) {
-        SCLogError(SC_ERR_MISSING_CONFIG_PARAM,
-                "Unable to get parser and interface params");
-        exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL,
+                           "Unable to get parser and interface params");
     }
 
     ret = RunModeSetLiveCaptureWorkers(tparser,
@@ -555,8 +550,7 @@ int RunModeIdsPfringWorkers(void)
                               "DecodePfring", thread_name_workers,
                               live_dev);
     if (ret != 0) {
-        SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Runmode start failed");
     }
 
     SCLogInfo("RunModeIdsPfringWorkers initialised");

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -298,8 +298,7 @@ void RunUnittests(int list_unittests, const char *regex_arg)
 
     exit(EXIT_SUCCESS);
 #else
-    SCLogError(SC_ERR_NOT_SUPPORTED, "Unittests are not build-in");
-    exit(EXIT_FAILURE);
+    FatalError(SC_ERR_FATAL, "Unittests are not build-in");
 #endif /* UNITTESTS */
 }
 

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -334,8 +334,7 @@ void RunModeDispatch(int runmode, const char *custom_mode)
                 break;
 #endif
             default:
-                SCLogError(SC_ERR_UNKNOWN_RUN_MODE, "Unknown runtime mode. Aborting");
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL, "Unknown runtime mode. Aborting");
         }
     } else { /* if (custom_mode == NULL) */
         /* Add compability with old 'worker' name */
@@ -344,8 +343,7 @@ void RunModeDispatch(int runmode, const char *custom_mode)
                          "to 'workers', please modify your setup.");
             local_custom_mode = SCStrdup("workers");
             if (unlikely(local_custom_mode == NULL)) {
-                SCLogError(SC_ERR_MEM_ALLOC, "Unable to dup custom mode");
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL, "Unable to dup custom mode");
             }
             custom_mode = local_custom_mode;
         }
@@ -366,8 +364,7 @@ void RunModeDispatch(int runmode, const char *custom_mode)
     }
     active_runmode = SCStrdup(custom_mode);
     if (unlikely(active_runmode == NULL)) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Unable to dup active mode");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to dup active mode");
     }
 
     if (strcasecmp(active_runmode, "autofp") == 0) {

--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -192,9 +192,8 @@ ReceiveErfDagThreadInit(ThreadVars *tv, void *initdata, void **data)
 
     ErfDagThreadVars *ewtn = SCMalloc(sizeof(ErfDagThreadVars));
     if (unlikely(ewtn == NULL)) {
-        SCLogError(SC_ERR_MEM_ALLOC,
-            "Failed to allocate memory for ERF DAG thread vars.");
-        exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL,
+                       "Failed to allocate memory for ERF DAG thread vars.");
     }
 
     memset(ewtn, 0, sizeof(*ewtn));

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -652,8 +652,8 @@ TmEcode NapatechStreamThreadInit(ThreadVars *tv, const void *initdata, void **da
 
     NapatechThreadVars *ntv = SCCalloc(1, sizeof (NapatechThreadVars));
     if (unlikely(ntv == NULL)) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate memory for NAPATECH  thread vars.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Failed to allocate memory for NAPATECH  thread vars.");
     }
 
     memset(ntv, 0, sizeof (NapatechThreadVars));
@@ -874,9 +874,8 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
                 exit(EXIT_FAILURE);
 
             } else if (status == 0x20000008) {
-                SCLogError(SC_ERR_NAPATECH_STREAMS_REGISTER_FAILED,
-                        "Check napatech.ports in the suricata config file.");
-                exit(EXIT_FAILURE);
+                        FatalError(SC_ERR_FATAL,
+                                   "Check napatech.ports in the suricata config file.");
             }
             RecommendNUMAConfig(SC_LOG_PERF);
             SCLogNotice("Napatech packet input engine started.");
@@ -890,9 +889,8 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
     if (ntv->hba > 0) {
         char *s_hbad_pkt = SCCalloc(1, 32);
         if (unlikely(s_hbad_pkt == NULL)) {
-            SCLogError(SC_ERR_MEM_ALLOC,
-                    "Failed to allocate memory for NAPATECH stream counter.");
-            exit(EXIT_FAILURE);
+                    FatalError(SC_ERR_FATAL,
+                               "Failed to allocate memory for NAPATECH stream counter.");
         }
         snprintf(s_hbad_pkt, 32, "nt%d.hba_drop", ntv->stream_id);
         hba_pkt = StatsRegisterCounter(s_hbad_pkt, tv);

--- a/src/source-nflog.c
+++ b/src/source-nflog.c
@@ -242,12 +242,10 @@ TmEcode ReceiveNFLOGThreadInit(ThreadVars *tv, const void *initdata, void **data
     SCLogDebug("binding netfilter_log as nflog handler for AF_INET and AF_INET6");
 
     if (nflog_bind_pf(ntv->h, AF_INET) < 0) {
-        SCLogError(SC_ERR_NFLOG_BIND, "nflog_bind_pf() for AF_INET failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "nflog_bind_pf() for AF_INET failed");
     }
     if (nflog_bind_pf(ntv->h, AF_INET6) < 0) {
-        SCLogError(SC_ERR_NFLOG_BIND, "nflog_bind_pf() for AF_INET6 failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "nflog_bind_pf() for AF_INET6 failed");
     }
 
     ntv->gh = nflog_bind_group(ntv->h, ntv->group);
@@ -348,13 +346,11 @@ TmEcode ReceiveNFLOGThreadDeinit(ThreadVars *tv, void *data)
 
     SCLogDebug("closing nflog group %d", ntv->group);
     if (nflog_unbind_pf(ntv->h, AF_INET) < 0) {
-        SCLogError(SC_ERR_NFLOG_UNBIND, "nflog_unbind_pf() for AF_INET failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "nflog_unbind_pf() for AF_INET failed");
     }
 
     if (nflog_unbind_pf(ntv->h, AF_INET6) < 0) {
-        SCLogError(SC_ERR_NFLOG_UNBIND, "nflog_unbind_pf() for AF_INET6 failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "nflog_unbind_pf() for AF_INET6 failed");
     }
 
     if (ntv->gh) {

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -226,8 +226,7 @@ void NFQInitConfig(char quiet)
         }  else if (!strcmp("route", nfq_mode)) {
             nfq_config.mode = NFQ_ROUTE_MODE;
         } else {
-            SCLogError(SC_ERR_INVALID_ARGUMENT, "Unknown nfq.mode");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Unknown nfq.mode");
         }
     }
 
@@ -591,24 +590,20 @@ static TmEcode NFQInitThread(NFQThreadVars *t, uint32_t queue_maxlen)
          * run. Ignoring the error seems to have no bad effects. */
         SCLogDebug("unbinding existing nf_queue handler for AF_INET (if any)");
         if (nfq_unbind_pf(q->h, AF_INET) < 0) {
-            SCLogError(SC_ERR_NFQ_UNBIND, "nfq_unbind_pf() for AF_INET failed");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "nfq_unbind_pf() for AF_INET failed");
         }
         if (nfq_unbind_pf(q->h, AF_INET6) < 0) {
-            SCLogError(SC_ERR_NFQ_UNBIND, "nfq_unbind_pf() for AF_INET6 failed");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "nfq_unbind_pf() for AF_INET6 failed");
         }
         nfq_g.unbind = 1;
 
         SCLogDebug("binding nfnetlink_queue as nf_queue handler for AF_INET and AF_INET6");
 
         if (nfq_bind_pf(q->h, AF_INET) < 0) {
-            SCLogError(SC_ERR_NFQ_BIND, "nfq_bind_pf() for AF_INET failed");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "nfq_bind_pf() for AF_INET failed");
         }
         if (nfq_bind_pf(q->h, AF_INET6) < 0) {
-            SCLogError(SC_ERR_NFQ_BIND, "nfq_bind_pf() for AF_INET6 failed");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "nfq_bind_pf() for AF_INET6 failed");
         }
     }
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -569,10 +569,9 @@ void StreamTcpInitConfig(char quiet)
                         temp_rdrange);
                 exit(EXIT_FAILURE);
             } else if (rdrange >= 100) {
-                SCLogError(SC_ERR_INVALID_VALUE,
-                           "stream.reassembly.randomize-chunk-range "
-                           "must be lower than 100");
-                exit(EXIT_FAILURE);
+                           FatalError(SC_ERR_FATAL,
+                                      "stream.reassembly.randomize-chunk-range "
+                                      "must be lower than 100");
             }
         }
     }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -467,10 +467,9 @@ static void SetBpfStringFromFile(char *filename)
     size_t nm = 0;
 
     if (EngineModeIsIPS()) {
-        SCLogError(SC_ERR_NOT_SUPPORTED,
-                   "BPF filter not available in IPS mode."
-                   " Use firewall filtering if possible.");
-        exit(EXIT_FAILURE);
+                   FatalError(SC_ERR_FATAL,
+                              "BPF filter not available in IPS mode."
+                              " Use firewall filtering if possible.");
     }
 
 #ifdef OS_WIN32
@@ -1549,9 +1548,8 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                     /* Quick validation. */
                     char *val = strchr(optarg, '=');
                     if (val == NULL) {
-                        SCLogError(SC_ERR_CMD_LINE,
-                                "Invalid argument for --set, must be key=val.");
-                        exit(EXIT_FAILURE);
+                                FatalError(SC_ERR_FATAL,
+                                           "Invalid argument for --set, must be key=val.");
                     }
                     if (!ConfSetFromString(optarg, 1)) {
                         fprintf(stderr, "Failed to set configuration value %s.",
@@ -2315,9 +2313,8 @@ void PostConfLoadedDetectSetup(SCInstance *suri)
         if (mt_enabled)
             (void)ConfGetBool("multi-detect.default", &default_tenant);
         if (DetectEngineMultiTenantSetup() == -1) {
-            SCLogError(SC_ERR_INITIALIZATION, "initializing multi-detect "
-                    "detection engine contexts failed.");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "initializing multi-detect "
+                       "detection engine contexts failed.");
         }
         if (suri->delayed_detect && suri->run_mode != RUNMODE_CONF_TEST) {
             de_ctx = DetectEngineCtxInitStubForDD();
@@ -2327,9 +2324,8 @@ void PostConfLoadedDetectSetup(SCInstance *suri)
             de_ctx = DetectEngineCtxInit();
         }
         if (de_ctx == NULL) {
-            SCLogError(SC_ERR_INITIALIZATION, "initializing detection engine "
-                    "context failed.");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "initializing detection engine "
+                       "context failed.");
         }
 
         if (de_ctx->type == DETECT_ENGINE_TYPE_NORMAL) {
@@ -2788,9 +2784,8 @@ int SuricataMain(int argc, char **argv)
 
     /* Wait till all the threads have been initialized */
     if (TmThreadWaitOnThreadInit() == TM_ECODE_FAILED) {
-        SCLogError(SC_ERR_INITIALIZATION, "Engine initialization failed, "
+        FatalError(SC_ERR_FATAL, "Engine initialization failed, "
                    "aborting...");
-        exit(EXIT_FAILURE);
     }
 
     SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -1663,9 +1663,9 @@ TmEcode TmThreadSpawn(ThreadVars *tv)
 void TmThreadInitMC(ThreadVars *tv)
 {
     if ( (tv->ctrl_mutex = SCMalloc(sizeof(*tv->ctrl_mutex))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in TmThreadInitMC.  "
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in TmThreadInitMC.  "
                    "Exiting...");
-        exit(EXIT_FAILURE);
     }
 
     if (SCCtrlMutexInit(tv->ctrl_mutex, NULL) != 0) {
@@ -1674,15 +1674,14 @@ void TmThreadInitMC(ThreadVars *tv)
     }
 
     if ( (tv->ctrl_cond = SCMalloc(sizeof(*tv->ctrl_cond))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in TmThreadInitMC.  "
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in TmThreadInitMC.  "
                    "Exiting...");
-        exit(EXIT_FAILURE);
     }
 
     if (SCCtrlCondInit(tv->ctrl_cond, NULL) != 0) {
-        SCLogError(SC_ERR_FATAL, "Error initializing the tv->cond condition "
+        FatalError(SC_ERR_FATAL, "Error initializing the tv->cond condition "
                    "variable");
-        exit(EXIT_FAILURE);
     }
 
     return;

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -322,8 +322,8 @@ void PacketPoolInit(void)
     for (i = 0; i < max_pending_packets; i++) {
         Packet *p = PacketGetFromAlloc();
         if (unlikely(p == NULL)) {
-            SCLogError(SC_ERR_FATAL, "Fatal error encountered while allocating a packet. Exiting...");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL,
+                       "Fatal error encountered while allocating a packet. Exiting...");
         }
         PacketPoolStorePacket(p);
     }

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -1043,9 +1043,8 @@ int UnixManagerInit(void)
             SCLogDebug("ConfGetBool could not load the value.");
         }
         if (failure_fatal) {
-            SCLogError(SC_ERR_INITIALIZATION,
-                    "Unable to create unix command socket");
-            exit(EXIT_FAILURE);
+                    FatalError(SC_ERR_FATAL,
+                               "Unable to create unix command socket");
         } else {
             SCLogWarning(SC_ERR_INITIALIZATION,
                     "Unable to create unix command socket");
@@ -1160,17 +1159,14 @@ void UnixManagerThreadSpawn(int mode)
                                           "UnixManager", 0);
 
     if (tv_unixmgr == NULL) {
-        SCLogError(SC_ERR_INITIALIZATION, "TmThreadsCreate failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "TmThreadsCreate failed");
     }
     if (TmThreadSpawn(tv_unixmgr) != TM_ECODE_OK) {
-        SCLogError(SC_ERR_INITIALIZATION, "TmThreadSpawn failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "TmThreadSpawn failed");
     }
     if (mode == 1) {
         if (TmThreadsCheckFlag(tv_unixmgr, THV_RUNNING_DONE)) {
-            SCLogError(SC_ERR_INITIALIZATION, "Unix socket init failed");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Unix socket init failed");
         }
     }
     return;

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -211,8 +211,7 @@ void AffinitySetupLoadFromConfig()
         ConfNode *nprio = NULL;
 
         if (taf == NULL) {
-            SCLogError(SC_ERR_INVALID_ARGUMENT, "unknown cpu-affinity type");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "unknown cpu-affinity type");
         } else {
             SCLogConfig("Found affinity definition for \"%s\"", setname);
         }
@@ -259,8 +258,7 @@ void AffinitySetupLoadFromConfig()
                 } else if (!strcmp(node->val, "high")) {
                     taf->prio = PRIO_HIGH;
                 } else {
-                    SCLogError(SC_ERR_INVALID_ARGUMENT, "unknown cpu_affinity prio");
-                    exit(EXIT_FAILURE);
+                    FatalError(SC_ERR_FATAL, "unknown cpu_affinity prio");
                 }
                 SCLogConfig("Using default prio '%s' for set '%s'",
                         node->val, setname);
@@ -274,8 +272,7 @@ void AffinitySetupLoadFromConfig()
             } else if (!strcmp(node->val, "balanced")) {
                 taf->mode_flag = BALANCED_AFFINITY;
             } else {
-                SCLogError(SC_ERR_INVALID_ARGUMENT, "unknown cpu_affinity node");
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL, "unknown cpu_affinity node");
             }
         }
 
@@ -286,8 +283,7 @@ void AffinitySetupLoadFromConfig()
                            "count: '%s'", node->val);
             }
             if (! taf->nb_threads) {
-                SCLogError(SC_ERR_INVALID_ARGUMENT, "bad value for threads count");
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL, "bad value for threads count");
             }
         }
     }

--- a/src/util-daemon.c
+++ b/src/util-daemon.c
@@ -70,8 +70,7 @@ static void WaitForChild (pid_t pid)
         if (waitpid(pid, &status, WNOHANG)) {
             /* Check if the child is still there, otherwise the parent should exit */
             if (WIFEXITED(status) || WIFSIGNALED(status)) {
-                SCLogError(SC_ERR_DAEMON, "Child died unexpectedly");
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL, "Child died unexpectedly");
             }
         }
         /* sigsuspend(); */
@@ -115,22 +114,20 @@ void Daemonize (void)
 
     if (pid < 0) {
         /* Fork error */
-        SCLogError(SC_ERR_DAEMON, "Error forking the process");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error forking the process");
     } else if (pid == 0) {
         /* Child continues here */
         const char *daemondir;
 
         sid = setsid();
         if (sid < 0) {
-            SCLogError(SC_ERR_DAEMON, "Error creating new session");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error creating new session");
         }
 
         if (ConfGet("daemon-directory", &daemondir) == 1) {
             if ((chdir(daemondir)) < 0) {
-                SCLogError(SC_ERR_DAEMON, "Error changing to working directory");
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL,
+                           "Error changing to working directory");
             }
         }
 #ifndef OS_WIN32

--- a/src/util-debug-filters.c
+++ b/src/util-debug-filters.c
@@ -862,8 +862,8 @@ void SCLogAddToFGFFileList(SCLogFGFilterFile *fgf_file,
     SCLogFGFilterLine *fgf_line_temp = NULL;
 
     if ( (fgf_file_temp = SCMalloc(sizeof(SCLogFGFilterFile))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in SCLogAddToFGFFileList. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in SCLogAddToFGFFileList. Exiting...");
     }
     memset(fgf_file_temp, 0, sizeof(SCLogFGFilterFile));
 
@@ -873,8 +873,8 @@ void SCLogAddToFGFFileList(SCLogFGFilterFile *fgf_file,
     }
 
     if ( (fgf_func_temp = SCMalloc(sizeof(SCLogFGFilterFunc))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in SCLogAddToFGFFileList. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in SCLogAddToFGFFileList. Exiting...");
     }
     memset(fgf_func_temp, 0, sizeof(SCLogFGFilterFunc));
 
@@ -884,8 +884,8 @@ void SCLogAddToFGFFileList(SCLogFGFilterFile *fgf_file,
     }
 
     if ( (fgf_line_temp = SCMalloc(sizeof(SCLogFGFilterLine))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in SCLogAddToFGFFileList. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in SCLogAddToFGFFileList. Exiting...");
     }
     memset(fgf_line_temp, 0, sizeof(SCLogFGFilterLine));
 
@@ -926,8 +926,8 @@ void SCLogAddToFGFFuncList(SCLogFGFilterFile *fgf_file,
     SCLogFGFilterLine *fgf_line_temp = NULL;
 
     if ( (fgf_func_temp = SCMalloc(sizeof(SCLogFGFilterFunc))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in SCLogAddToFGFFuncList. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in SCLogAddToFGFFuncList. Exiting...");
     }
     memset(fgf_func_temp, 0, sizeof(SCLogFGFilterFunc));
 
@@ -937,8 +937,8 @@ void SCLogAddToFGFFuncList(SCLogFGFilterFile *fgf_file,
     }
 
     if ( (fgf_line_temp = SCMalloc(sizeof(SCLogFGFilterLine))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in SCLogAddToFGFFuncList. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in SCLogAddToFGFFuncList. Exiting...");
     }
     memset(fgf_line_temp, 0, sizeof(SCLogFGFilterLine));
 
@@ -975,8 +975,8 @@ void SCLogAddToFGFLineList(SCLogFGFilterFunc *fgf_func,
     SCLogFGFilterLine *fgf_line_temp = NULL;
 
     if ( (fgf_line_temp = SCMalloc(sizeof(SCLogFGFilterLine))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in SCLogAddToFGFLineList. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in SCLogAddToFGFLineList. Exiting...");
     }
     memset(fgf_line_temp, 0, sizeof(SCLogFGFilterLine));
 

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -686,8 +686,8 @@ SCLogOPBuffer *SCLogAllocLogOPBuffer(void)
 
     if ( (buffer = SCMalloc(sc_log_config->op_ifaces_cnt *
                           sizeof(SCLogOPBuffer))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in SCLogAllocLogOPBuffer. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in SCLogAllocLogOPBuffer. Exiting...");
     }
 
     op_iface_ctx = sc_log_config->op_ifaces;
@@ -714,8 +714,8 @@ static inline SCLogOPIfaceCtx *SCLogAllocLogOPIfaceCtx(void)
     SCLogOPIfaceCtx *iface_ctx = NULL;
 
     if ( (iface_ctx = SCMalloc(sizeof(SCLogOPIfaceCtx))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in SCLogallocLogOPIfaceCtx. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in SCLogallocLogOPIfaceCtx. Exiting...");
     }
     memset(iface_ctx, 0, sizeof(SCLogOPIfaceCtx));
 
@@ -741,8 +741,8 @@ static inline SCLogOPIfaceCtx *SCLogInitFileOPIface(const char *file,
     SCLogOPIfaceCtx *iface_ctx = SCLogAllocLogOPIfaceCtx();
 
     if (iface_ctx == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in SCLogInitFileOPIface. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in SCLogInitFileOPIface. Exiting...");
     }
 
     if (file == NULL) {
@@ -806,8 +806,8 @@ static inline SCLogOPIfaceCtx *SCLogInitConsoleOPIface(const char *log_format,
     SCLogOPIfaceCtx *iface_ctx = SCLogAllocLogOPIfaceCtx();
 
     if (iface_ctx == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in SCLogInitConsoleOPIface. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in SCLogInitConsoleOPIface. Exiting...");
     }
 
     iface_ctx->iface = SC_LOG_OP_IFACE_CONSOLE;
@@ -872,8 +872,8 @@ static inline SCLogOPIfaceCtx *SCLogInitSyslogOPIface(int facility,
     SCLogOPIfaceCtx *iface_ctx = SCLogAllocLogOPIfaceCtx();
 
     if ( iface_ctx == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in SCLogInitSyslogOPIface. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in SCLogInitSyslogOPIface. Exiting...");
     }
 
     iface_ctx->iface = SC_LOG_OP_IFACE_SYSLOG;
@@ -1304,15 +1304,14 @@ void SCLogInitLogModule(SCLogInitData *sc_lid)
 
 #if defined (OS_WIN32)
     if (SCMutexInit(&sc_log_stream_lock, NULL) != 0) {
-        SCLogError(SC_ERR_MUTEX, "Failed to initialize log mutex.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Failed to initialize log mutex.");
     }
 #endif /* OS_WIN32 */
 
     /* sc_log_config is a global variable */
     if ( (sc_log_config = SCMalloc(sizeof(SCLogConfig))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in SCLogInitLogModule. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in SCLogInitLogModule. Exiting...");
     }
     memset(sc_log_config, 0, sizeof(SCLogConfig));
 
@@ -1429,9 +1428,8 @@ void SCLogLoadConfig(int daemon, int verbose)
         else if (strcmp(output->name, "file") == 0) {
             const char *filename = ConfNodeLookupChildValue(output, "filename");
             if (filename == NULL) {
-                SCLogError(SC_ERR_MISSING_CONFIG_PARAM,
-                    "Logging to file requires a filename");
-                exit(EXIT_FAILURE);
+                    FatalError(SC_ERR_FATAL,
+                               "Logging to file requires a filename");
             }
             char *path = NULL;
             if (!(PathIsAbsolute(filename))) {

--- a/src/util-host-os-info.c
+++ b/src/util-host-os-info.c
@@ -78,8 +78,7 @@ static void *SCHInfoAllocUserDataOSPolicy(const char *host_os)
     int *user_data = NULL;
 
     if ( (user_data = SCMalloc(sizeof(int))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Error allocating memory. Exiting");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory. Exiting");
     }
 
     /* the host os flavour that has to be sent as user data */
@@ -157,8 +156,7 @@ int SCHInfoAddHostOSInfo(const char *host_os, const char *host_os_ip_range, int 
     }
 
     if ( (ip_str = SCStrdup(host_os_ip_range)) == NULL) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
 
     /* check if we have more addresses in the host_os_ip_range */

--- a/src/util-ip.c
+++ b/src/util-ip.c
@@ -134,8 +134,8 @@ struct in_addr *ValidateIPV4Address(const char *addr_str)
         return NULL;
 
     if ( (addr = SCMalloc(sizeof(struct in_addr))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in ValidateIPV4Address. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in ValidateIPV4Address. Exiting...");
     }
 
     if (inet_pton(AF_INET, addr_str, addr) <= 0) {
@@ -164,8 +164,8 @@ struct in6_addr *ValidateIPV6Address(const char *addr_str)
         return NULL;
 
     if ( (addr = SCMalloc(sizeof(struct in6_addr))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in ValidateIPV6Address. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in ValidateIPV6Address. Exiting...");
     }
 
     if (inet_pton(AF_INET6, addr_str, addr) <= 0) {

--- a/src/util-log-redis.c
+++ b/src/util-log-redis.c
@@ -59,8 +59,7 @@ static SCLogRedisContext *SCLogRedisContextAlloc(void)
 {
     SCLogRedisContext* ctx = (SCLogRedisContext*) SCCalloc(1, sizeof(SCLogRedisContext));
     if (ctx == NULL) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis context");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to allocate redis context");
     }
     ctx->sync = NULL;
 #if HAVE_LIBEVENT
@@ -85,8 +84,7 @@ static SCLogRedisContext *SCLogRedisContextAsyncAlloc(void)
 {
     SCLogRedisContext* ctx = (SCLogRedisContext*) SCCalloc(1, sizeof(SCLogRedisContext));
     if (unlikely(ctx == NULL)) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis context");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to allocate redis context");
     }
 
     ctx->sync = NULL;
@@ -526,14 +524,12 @@ int SCConfLogOpenRedis(ConfNode *redis_node, void *lf_ctx)
     } else if(!strcmp(redis_mode,"channel") || !strcmp(redis_mode,"publish")) {
         log_ctx->redis_setup.command = redis_publish_cmd;
     } else {
-        SCLogError(SC_ERR_REDIS_CONFIG,"Invalid redis mode");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Invalid redis mode");
     }
 
     /* store server params for reconnection */
     if (!log_ctx->redis_setup.server) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating redis server string");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating redis server string");
     }
     if (StringParseUint16(&log_ctx->redis_setup.port, 10, 0, (const char *)redis_port) < 0) {
         FatalError(SC_ERR_INVALID_VALUE, "Invalid value for redis port: %s", redis_port);

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -361,9 +361,8 @@ SCConfLogOpenGeneric(ConfNode *conf,
         else {
             log_ctx->rotate_interval = SCParseTimeSizeString(rotate_int);
             if (log_ctx->rotate_interval == 0) {
-                SCLogError(SC_ERR_INVALID_NUMERIC_VALUE,
-                           "invalid rotate-interval value");
-                exit(EXIT_FAILURE);
+                           FatalError(SC_ERR_FATAL,
+                                      "invalid rotate-interval value");
             }
             log_ctx->rotate_time = now + log_ctx->rotate_interval;
         }

--- a/src/util-mpm-ac-bs.c
+++ b/src/util-mpm-ac-bs.c
@@ -147,8 +147,7 @@ static inline int SCACBSInitNewState(MpmCtx *mpm_ctx)
     if (ptmp == NULL) {
         SCFree(ctx->goto_table);
         ctx->goto_table = NULL;
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     ctx->goto_table = ptmp;
 
@@ -163,8 +162,7 @@ static inline int SCACBSInitNewState(MpmCtx *mpm_ctx)
     if (ptmp == NULL) {
         SCFree(ctx->output_table);
         ctx->output_table = NULL;
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     ctx->output_table = ptmp;
 
@@ -206,8 +204,7 @@ static void SCACBSSetOutputState(int32_t state, uint32_t pid, MpmCtx *mpm_ctx)
     if (ptmp == NULL) {
         SCFree(output_state->pids);
         output_state->pids = NULL;
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     output_state->pids = ptmp;
 
@@ -399,8 +396,7 @@ static inline void SCACBSClubOutputStates(int32_t dst_state, int32_t src_state,
             if (ptmp == NULL) {
                 SCFree(output_dst_state->pids);
                 output_dst_state->pids = NULL;
-                SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL, "Error allocating memory");
             }
             else {
                 output_dst_state->pids = ptmp;
@@ -434,8 +430,7 @@ static inline void SCACBSCreateFailureTable(MpmCtx *mpm_ctx)
      * every state(SCACBSCtx->state_count) */
     ctx->failure_table = SCMalloc(ctx->state_count * sizeof(int32_t));
     if (ctx->failure_table == NULL) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     memset(ctx->failure_table, 0, ctx->state_count * sizeof(int32_t));
 
@@ -487,8 +482,7 @@ static inline void SCACBSCreateDeltaTable(MpmCtx *mpm_ctx)
         ctx->state_table_u16 = SCMalloc(ctx->state_count *
                                         sizeof(SC_AC_BS_STATE_TYPE_U16) * 256);
         if (ctx->state_table_u16 == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
         }
         memset(ctx->state_table_u16, 0,
                ctx->state_count * sizeof(SC_AC_BS_STATE_TYPE_U16) * 256);
@@ -528,8 +522,7 @@ static inline void SCACBSCreateDeltaTable(MpmCtx *mpm_ctx)
         ctx->state_table_u32 = SCMalloc(ctx->state_count *
                                         sizeof(SC_AC_BS_STATE_TYPE_U32) * 256);
         if (ctx->state_table_u32 == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
         }
         memset(ctx->state_table_u32, 0,
                ctx->state_count * sizeof(SC_AC_BS_STATE_TYPE_U32) * 256);
@@ -697,8 +690,7 @@ static inline void SCACBSCreateModDeltaTable(MpmCtx *mpm_ctx)
                  256 * sizeof(SC_AC_BS_STATE_TYPE_U16) * 1);
         ctx->state_table_mod = SCMalloc(size);
         if (ctx->state_table_mod == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
         }
         memset(ctx->state_table_mod, 0, size);
 
@@ -709,8 +701,7 @@ static inline void SCACBSCreateModDeltaTable(MpmCtx *mpm_ctx)
          * directly to access its state data */
         ctx->state_table_mod_pointers = SCMalloc(ctx->state_count * sizeof(uint8_t *));
         if (ctx->state_table_mod_pointers == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
         }
         memset(ctx->state_table_mod_pointers, 0,
                ctx->state_count * sizeof(uint8_t *));
@@ -771,8 +762,7 @@ static inline void SCACBSCreateModDeltaTable(MpmCtx *mpm_ctx)
                  256 * sizeof(SC_AC_BS_STATE_TYPE_U32) * 1);
         ctx->state_table_mod = SCMalloc(size);
         if (ctx->state_table_mod == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
         }
         memset(ctx->state_table_mod, 0, size);
 
@@ -783,8 +773,7 @@ static inline void SCACBSCreateModDeltaTable(MpmCtx *mpm_ctx)
          * directly to access its state data */
         ctx->state_table_mod_pointers = SCMalloc(ctx->state_count * sizeof(uint8_t *));
         if (ctx->state_table_mod_pointers == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
         }
         memset(ctx->state_table_mod_pointers, 0,
                ctx->state_count * sizeof(uint8_t *));
@@ -925,8 +914,7 @@ int SCACBSPreparePatterns(MpmCtx *mpm_ctx)
     /* handle no case patterns */
     ctx->pid_pat_list = SCMalloc((mpm_ctx->max_pat_id + 1)* sizeof(SCACBSPatternList));
     if (ctx->pid_pat_list == NULL) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     memset(ctx->pid_pat_list, 0, (mpm_ctx->max_pat_id + 1) * sizeof(SCACBSPatternList));
 
@@ -934,8 +922,7 @@ int SCACBSPreparePatterns(MpmCtx *mpm_ctx)
         if (!(ctx->parray[i]->flags & MPM_PATTERN_FLAG_NOCASE)) {
             ctx->pid_pat_list[ctx->parray[i]->id].cs = SCMalloc(ctx->parray[i]->len);
             if (ctx->pid_pat_list[ctx->parray[i]->id].cs == NULL) {
-                SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL, "Error allocating memory");
             }
             memcpy(ctx->pid_pat_list[ctx->parray[i]->id].cs,
                    ctx->parray[i]->original_pat, ctx->parray[i]->len);

--- a/src/util-mpm-ac-ks.c
+++ b/src/util-mpm-ac-ks.c
@@ -235,8 +235,7 @@ static void SCACTileReallocOutputTable(SCACTileCtx *ctx, int new_state_count)
     if (ptmp == NULL) {
         SCFree(ctx->output_table);
         ctx->output_table = NULL;
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     ctx->output_table = ptmp;
 }
@@ -249,8 +248,7 @@ static void SCACTileReallocState(SCACTileCtx *ctx, int new_state_count)
     if (ptmp == NULL) {
         SCFree(ctx->goto_table);
         ctx->goto_table = NULL;
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     ctx->goto_table = ptmp;
 
@@ -323,8 +321,7 @@ static void SCACTileSetOutputState(int32_t state, MpmPatternIndex pindex, MpmCtx
     if (ptmp == NULL) {
         SCFree(output_state->patterns);
         output_state->patterns = NULL;
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     output_state->patterns = ptmp;
 
@@ -484,8 +481,7 @@ static void SCACTileClubOutputStates(int32_t dst_state,
             if (ptmp == NULL) {
                 SCFree(output_dst_state->patterns);
                 output_dst_state->patterns = NULL;
-                SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL, "Error allocating memory");
             }
             output_dst_state->patterns = ptmp;
 
@@ -517,8 +513,7 @@ static void SCACTileCreateFailureTable(MpmCtx *mpm_ctx)
      * every state(SCACTileCtx->state_count) */
     ctx->failure_table = SCMalloc(ctx->state_count * sizeof(int32_t));
     if (ctx->failure_table == NULL) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     memset(ctx->failure_table, 0, ctx->state_count * sizeof(int32_t));
 
@@ -562,8 +557,7 @@ static void SCACTileSetState1Byte(SCACTileCtx *ctx, int state, int aa,
     uint8_t encoded_next_state = next_state;
 
     if (next_state == SC_AC_TILE_FAIL) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Error FAIL state in output");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error FAIL state in output");
     }
 
     if (outputs == 0)
@@ -582,8 +576,7 @@ static void SCACTileSetState2Bytes(SCACTileCtx *ctx, int state, int aa,
     uint16_t encoded_next_state = next_state;
 
     if (next_state == SC_AC_TILE_FAIL) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Error FAIL state in output");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error FAIL state in output");
     }
 
     if (outputs == 0)
@@ -602,8 +595,7 @@ static void SCACTileSetState4Bytes(SCACTileCtx *ctx, int state, int aa,
     uint32_t encoded_next_state = next_state;
 
     if (next_state == SC_AC_TILE_FAIL) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Error FAIL state in output");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error FAIL state in output");
     }
 
     if (outputs == 0)
@@ -720,8 +712,7 @@ static void SCACTileClubOutputStatePresenceWithDeltaTable(MpmCtx *mpm_ctx)
     int size = ctx->state_count * ctx->bytes_per_state * ctx->alphabet_storage;
     void *state_table = SCMalloc(size);
     if (unlikely(state_table == NULL)) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     memset(state_table, 0, size);
     ctx->state_table = state_table;
@@ -927,8 +918,7 @@ int SCACTilePreparePatterns(MpmCtx *mpm_ctx)
     size_t mem_size = string_space_needed + pattern_list_size;
     void *mem_block = SCCalloc(1, mem_size);
     if (mem_block == NULL) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     mpm_ctx->memory_cnt++;
     mpm_ctx->memory_size += mem_size;

--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -153,8 +153,7 @@ static inline int SCACReallocState(SCACCtx *ctx, uint32_t cnt)
     if (ptmp == NULL) {
         SCFree(ctx->goto_table);
         ctx->goto_table = NULL;
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     ctx->goto_table = ptmp;
 
@@ -171,8 +170,7 @@ static inline int SCACReallocState(SCACCtx *ctx, uint32_t cnt)
     if (ptmp == NULL) {
         SCFree(ctx->output_table);
         ctx->output_table = NULL;
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     ctx->output_table = ptmp;
 
@@ -210,8 +208,7 @@ static void SCACShrinkState(SCACCtx *ctx)
     if (ptmp == NULL) {
         SCFree(ctx->output_table);
         ctx->output_table = NULL;
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     ctx->output_table = ptmp;
 }
@@ -271,8 +268,7 @@ static void SCACSetOutputState(int32_t state, uint32_t pid, MpmCtx *mpm_ctx)
     if (ptmp == NULL) {
         SCFree(output_state->pids);
         output_state->pids = NULL;
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     output_state->pids = ptmp;
 
@@ -485,8 +481,7 @@ static inline void SCACClubOutputStates(int32_t dst_state, int32_t src_state,
             if (ptmp == NULL) {
                 SCFree(output_dst_state->pids);
                 output_dst_state->pids = NULL;
-                SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL, "Error allocating memory");
             }
             output_dst_state->pids = ptmp;
 
@@ -518,8 +513,7 @@ static inline void SCACCreateFailureTable(MpmCtx *mpm_ctx)
      * every state(SCACCtx->state_count) */
     ctx->failure_table = SCMalloc(ctx->state_count * sizeof(int32_t));
     if (ctx->failure_table == NULL) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     memset(ctx->failure_table, 0, ctx->state_count * sizeof(int32_t));
 
@@ -571,8 +565,7 @@ static inline void SCACCreateDeltaTable(MpmCtx *mpm_ctx)
         ctx->state_table_u16 = SCMalloc(ctx->state_count *
                                         sizeof(SC_AC_STATE_TYPE_U16) * 256);
         if (ctx->state_table_u16 == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
         }
         memset(ctx->state_table_u16, 0,
                ctx->state_count * sizeof(SC_AC_STATE_TYPE_U16) * 256);
@@ -614,8 +607,7 @@ static inline void SCACCreateDeltaTable(MpmCtx *mpm_ctx)
         ctx->state_table_u32 = SCMalloc(ctx->state_count *
                                         sizeof(SC_AC_STATE_TYPE_U32) * 256);
         if (ctx->state_table_u32 == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
         }
         memset(ctx->state_table_u32, 0,
                ctx->state_count * sizeof(SC_AC_STATE_TYPE_U32) * 256);
@@ -811,8 +803,7 @@ int SCACPreparePatterns(MpmCtx *mpm_ctx)
     /* handle no case patterns */
     ctx->pid_pat_list = SCMalloc((mpm_ctx->max_pat_id + 1)* sizeof(SCACPatternList));
     if (ctx->pid_pat_list == NULL) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
     }
     memset(ctx->pid_pat_list, 0, (mpm_ctx->max_pat_id + 1) * sizeof(SCACPatternList));
 
@@ -820,8 +811,7 @@ int SCACPreparePatterns(MpmCtx *mpm_ctx)
         if (!(ctx->parray[i]->flags & MPM_PATTERN_FLAG_NOCASE)) {
             ctx->pid_pat_list[ctx->parray[i]->id].cs = SCMalloc(ctx->parray[i]->len);
             if (ctx->pid_pat_list[ctx->parray[i]->id].cs == NULL) {
-                SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL, "Error allocating memory");
             }
             memcpy(ctx->pid_pat_list[ctx->parray[i]->id].cs,
                    ctx->parray[i]->original_pat, ctx->parray[i]->len);

--- a/src/util-mpm-hs.c
+++ b/src/util-mpm-hs.c
@@ -107,8 +107,7 @@ static void SCHSSetAllocators(void)
 {
     hs_error_t err = hs_set_allocator(SCHSMalloc, SCHSFree);
     if (err != HS_SUCCESS) {
-        SCLogError(SC_ERR_FATAL, "Failed to set Hyperscan allocator.");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Failed to set Hyperscan allocator.");
     }
 }
 
@@ -784,14 +783,12 @@ void SCHSInitThreadCtx(MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx)
     SCMutexUnlock(&g_scratch_proto_mutex);
 
     if (err != HS_SUCCESS) {
-        SCLogError(SC_ERR_FATAL, "Unable to clone scratch prototype");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to clone scratch prototype");
     }
 
     err = hs_scratch_size(ctx->scratch, &ctx->scratch_size);
     if (err != HS_SUCCESS) {
-        SCLogError(SC_ERR_FATAL, "Unable to query scratch size");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Unable to query scratch size");
     }
 
     mpm_thread_ctx->memory_cnt++;

--- a/src/util-mpm.c
+++ b/src/util-mpm.c
@@ -62,15 +62,13 @@ int32_t MpmFactoryRegisterMpmCtxProfile(DetectEngineCtx *de_ctx, const char *nam
     if (de_ctx->mpm_ctx_factory_container == NULL) {
         de_ctx->mpm_ctx_factory_container = SCMalloc(sizeof(MpmCtxFactoryContainer));
         if (de_ctx->mpm_ctx_factory_container == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
         }
         memset(de_ctx->mpm_ctx_factory_container, 0, sizeof(MpmCtxFactoryContainer));
 
         MpmCtxFactoryItem *item = SCMalloc(sizeof(MpmCtxFactoryItem));
         if (unlikely(item == NULL)) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
         }
 
         item[0].name = name;
@@ -78,8 +76,7 @@ int32_t MpmFactoryRegisterMpmCtxProfile(DetectEngineCtx *de_ctx, const char *nam
         /* toserver */
         item[0].mpm_ctx_ts = SCMalloc(sizeof(MpmCtx));
         if (item[0].mpm_ctx_ts == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
         }
         memset(item[0].mpm_ctx_ts, 0, sizeof(MpmCtx));
         item[0].mpm_ctx_ts->flags |= MPMCTX_FLAGS_GLOBAL;
@@ -87,8 +84,7 @@ int32_t MpmFactoryRegisterMpmCtxProfile(DetectEngineCtx *de_ctx, const char *nam
         /* toclient */
         item[0].mpm_ctx_tc = SCMalloc(sizeof(MpmCtx));
         if (item[0].mpm_ctx_tc == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
         }
         memset(item[0].mpm_ctx_tc, 0, sizeof(MpmCtx));
         item[0].mpm_ctx_tc->flags |= MPMCTX_FLAGS_GLOBAL;
@@ -112,8 +108,7 @@ int32_t MpmFactoryRegisterMpmCtxProfile(DetectEngineCtx *de_ctx, const char *nam
                 if (items[i].mpm_ctx_ts == NULL) {
                     items[i].mpm_ctx_ts = SCMalloc(sizeof(MpmCtx));
                     if (items[i].mpm_ctx_ts == NULL) {
-                        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-                        exit(EXIT_FAILURE);
+                        FatalError(SC_ERR_FATAL, "Error allocating memory");
                     }
                     memset(items[i].mpm_ctx_ts, 0, sizeof(MpmCtx));
                     items[i].mpm_ctx_ts->flags |= MPMCTX_FLAGS_GLOBAL;
@@ -121,8 +116,7 @@ int32_t MpmFactoryRegisterMpmCtxProfile(DetectEngineCtx *de_ctx, const char *nam
                 if (items[i].mpm_ctx_tc == NULL) {
                     items[i].mpm_ctx_tc = SCMalloc(sizeof(MpmCtx));
                     if (items[i].mpm_ctx_tc == NULL) {
-                        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-                        exit(EXIT_FAILURE);
+                        FatalError(SC_ERR_FATAL, "Error allocating memory");
                     }
                     memset(items[i].mpm_ctx_tc, 0, sizeof(MpmCtx));
                     items[i].mpm_ctx_tc->flags |= MPMCTX_FLAGS_GLOBAL;
@@ -137,8 +131,7 @@ int32_t MpmFactoryRegisterMpmCtxProfile(DetectEngineCtx *de_ctx, const char *nam
         if (unlikely(ptmp == NULL)) {
             SCFree(items);
             items = NULL;
-            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
         }
         items = ptmp;
 
@@ -150,8 +143,7 @@ int32_t MpmFactoryRegisterMpmCtxProfile(DetectEngineCtx *de_ctx, const char *nam
         /* toserver */
         new_item[0].mpm_ctx_ts = SCMalloc(sizeof(MpmCtx));
         if (new_item[0].mpm_ctx_ts == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
         }
         memset(new_item[0].mpm_ctx_ts, 0, sizeof(MpmCtx));
         new_item[0].mpm_ctx_ts->flags |= MPMCTX_FLAGS_GLOBAL;
@@ -159,8 +151,7 @@ int32_t MpmFactoryRegisterMpmCtxProfile(DetectEngineCtx *de_ctx, const char *nam
         /* toclient */
         new_item[0].mpm_ctx_tc = SCMalloc(sizeof(MpmCtx));
         if (new_item[0].mpm_ctx_tc == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
         }
         memset(new_item[0].mpm_ctx_tc, 0, sizeof(MpmCtx));
         new_item[0].mpm_ctx_tc->flags |= MPMCTX_FLAGS_GLOBAL;
@@ -197,8 +188,7 @@ MpmCtx *MpmFactoryGetMpmCtxForProfile(const DetectEngineCtx *de_ctx, int32_t id,
     if (id == MPM_CTX_FACTORY_UNIQUE_CONTEXT) {
         MpmCtx *mpm_ctx = SCMalloc(sizeof(MpmCtx));
         if (unlikely(mpm_ctx == NULL)) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
         }
         memset(mpm_ctx, 0, sizeof(MpmCtx));
         return mpm_ctx;

--- a/src/util-napatech.c
+++ b/src/util-napatech.c
@@ -555,9 +555,8 @@ static void *NapatechStatsLoop(void *arg)
         for (int i = 0; i < stream_cnt; ++i) {
             char *pkts_buf = SCCalloc(1, 32);
             if (unlikely(pkts_buf == NULL)) {
-                SCLogError(SC_ERR_MEM_ALLOC,
-                        "Failed to allocate memory for NAPATECH stream counter.");
-                exit(EXIT_FAILURE);
+                        FatalError(SC_ERR_FATAL,
+                                   "Failed to allocate memory for NAPATECH stream counter.");
             }
 
             snprintf(pkts_buf, 32, "napa%d.pkts", stream_config[i].stream_id);
@@ -565,27 +564,24 @@ static void *NapatechStatsLoop(void *arg)
 
             char *byte_buf = SCCalloc(1, 32);
             if (unlikely(byte_buf == NULL)) {
-                SCLogError(SC_ERR_MEM_ALLOC,
-                        "Failed to allocate memory for NAPATECH stream counter.");
-                exit(EXIT_FAILURE);
+                        FatalError(SC_ERR_FATAL,
+                                   "Failed to allocate memory for NAPATECH stream counter.");
             }
             snprintf(byte_buf, 32, "napa%d.bytes", stream_config[i].stream_id);
             stream_counters[i].byte = StatsRegisterCounter(byte_buf, tv);
 
             char *drop_pkts_buf = SCCalloc(1, 32);
             if (unlikely(drop_pkts_buf == NULL)) {
-                SCLogError(SC_ERR_MEM_ALLOC,
-                        "Failed to allocate memory for NAPATECH stream counter.");
-                exit(EXIT_FAILURE);
+                        FatalError(SC_ERR_FATAL,
+                                   "Failed to allocate memory for NAPATECH stream counter.");
             }
             snprintf(drop_pkts_buf, 32, "napa%d.drop_pkts", stream_config[i].stream_id);
             stream_counters[i].drop_pkts = StatsRegisterCounter(drop_pkts_buf, tv);
 
             char *drop_byte_buf = SCCalloc(1, 32);
             if (unlikely(drop_byte_buf == NULL)) {
-                SCLogError(SC_ERR_MEM_ALLOC,
-                        "Failed to allocate memory for NAPATECH stream counter.");
-                exit(EXIT_FAILURE);
+                        FatalError(SC_ERR_FATAL,
+                                   "Failed to allocate memory for NAPATECH stream counter.");
             }
             snprintf(drop_byte_buf, 32, "napa%d.drop_byte", stream_config[i].stream_id);
             stream_counters[i].drop_byte = StatsRegisterCounter(drop_byte_buf, tv);
@@ -751,18 +747,16 @@ static uint32_t CountWorkerThreads(void)
                     if (strncmp(lnode->val, "all", 4) == 0) {
                         /* check that the sting in the config file is correctly specified */
                         if (cpu_spec != CONFIG_SPECIFIER_UNDEFINED) {
-                            SCLogError(SC_ERR_NAPATECH_PARSE_CONFIG,
-                                    "Only one Napatech port specifier type allowed.");
-                            exit(EXIT_FAILURE);
+                                    FatalError(SC_ERR_FATAL,
+                                               "Only one Napatech port specifier type allowed.");
                         }
                         cpu_spec = CONFIG_SPECIFIER_RANGE;
                         worker_count = UtilCpuGetNumProcessorsConfigured();
                     } else if (strchr(lnode->val, '-')) {
                         /* check that the sting in the config file is correctly specified */
                         if (cpu_spec != CONFIG_SPECIFIER_UNDEFINED) {
-                            SCLogError(SC_ERR_NAPATECH_PARSE_CONFIG,
-                                    "Only one Napatech port specifier type allowed.");
-                            exit(EXIT_FAILURE);
+                                    FatalError(SC_ERR_FATAL,
+                                               "Only one Napatech port specifier type allowed.");
                         }
                         cpu_spec = CONFIG_SPECIFIER_RANGE;
 
@@ -787,9 +781,8 @@ static uint32_t CountWorkerThreads(void)
                     } else {
                         /* check that the sting in the config file is correctly specified */
                         if (cpu_spec == CONFIG_SPECIFIER_RANGE) {
-                            SCLogError(SC_ERR_NAPATECH_PARSE_CONFIG,
-                                    "Napatech port range specifiers cannot be combined with individual stream specifiers.");
-                            exit(EXIT_FAILURE);
+                                    FatalError(SC_ERR_FATAL,
+                                               "Napatech port range specifiers cannot be combined with individual stream specifiers.");
                         }
                         cpu_spec = CONFIG_SPECIFIER_INDIVIDUAL;
                         ++worker_count;
@@ -938,9 +931,8 @@ int NapatechGetStreamConfig(NapatechStreamConfig stream_config[])
                     }
                 } else {
                     if (stream_spec == CONFIG_SPECIFIER_RANGE) {
-                        SCLogError(SC_ERR_NAPATECH_PARSE_CONFIG,
-                                "Napatech range and individual specifiers cannot be combined.");
-                        exit(EXIT_FAILURE);
+                                FatalError(SC_ERR_FATAL,
+                                           "Napatech range and individual specifiers cannot be combined.");
                     }
                     stream_spec = CONFIG_SPECIFIER_INDIVIDUAL;
                     if (StringParseUint16(&stream_config[instance_cnt].stream_id,
@@ -1202,15 +1194,13 @@ void NapatechStartStats(void)
             "custom", NapatechStatsLoop, 0);
 
     if (stats_tv == NULL) {
-        SCLogError(SC_ERR_THREAD_CREATE,
-                "Error creating a thread for NapatechStats - Killing engine.");
-        exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL,
+                           "Error creating a thread for NapatechStats - Killing engine.");
     }
 
     if (TmThreadSpawn(stats_tv) != 0) {
-        SCLogError(SC_ERR_THREAD_SPAWN,
-                "Failed to spawn thread for NapatechStats - Killing engine.");
-        exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL,
+                           "Failed to spawn thread for NapatechStats - Killing engine.");
     }
 
 #ifdef NAPATECH_ENABLE_BYPASS
@@ -1225,15 +1215,13 @@ void NapatechStartStats(void)
             "custom", NapatechBufMonitorLoop, 0);
 
     if (buf_monitor_tv == NULL) {
-        SCLogError(SC_ERR_THREAD_CREATE,
-                "Error creating a thread for NapatechBufMonitor - Killing engine.");
-        exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL,
+                           "Error creating a thread for NapatechBufMonitor - Killing engine.");
     }
 
     if (TmThreadSpawn(buf_monitor_tv) != 0) {
-        SCLogError(SC_ERR_THREAD_SPAWN,
-                "Failed to spawn thread for NapatechBufMonitor - Killing engine.");
-        exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL,
+                           "Failed to spawn thread for NapatechBufMonitor - Killing engine.");
     }
 
 
@@ -1439,8 +1427,8 @@ uint32_t NapatechSetupTraffic(uint32_t first_stream, uint32_t last_stream)
     }
 
     if (is_inline) {
-         SCLogError(SC_ERR_RUNMODE, "Napatech inline mode not supported.  (Only available when Hardware Bypass support is enabled.)");
-         exit(EXIT_FAILURE);
+         FatalError(SC_ERR_FATAL,
+                    "Napatech inline mode not supported.  (Only available when Hardware Bypass support is enabled.)");
     }
 #endif
 
@@ -1455,8 +1443,7 @@ uint32_t NapatechSetupTraffic(uint32_t first_stream, uint32_t last_stream)
      * the array of streams from the conf
      */
     if ((ntports = ConfGetNode("napatech.ports")) == NULL) {
-        SCLogError(SC_ERR_RUNMODE, "Failed retrieving napatech.ports from Conf");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "Failed retrieving napatech.ports from Conf");
     }
 
     /* Loop through all ports in the array */
@@ -1470,9 +1457,8 @@ uint32_t NapatechSetupTraffic(uint32_t first_stream, uint32_t last_stream)
     TAILQ_FOREACH(port, &ntports->head, next)
     {
         if (port == NULL) {
-            SCLogError(SC_ERR_NAPATECH_STREAMS_REGISTER_FAILED,
-                    "Couldn't Parse Port Configuration");
-            exit(EXIT_FAILURE);
+                    FatalError(SC_ERR_FATAL,
+                               "Couldn't Parse Port Configuration");
         }
 
         if (NapatechUseHWBypass()) {
@@ -1487,9 +1473,8 @@ uint32_t NapatechSetupTraffic(uint32_t first_stream, uint32_t last_stream)
 
                 if (ports_spec.first[iteration] == ports_spec.second[iteration]) {
                     if (is_inline) {
-                        SCLogError(SC_ERR_NAPATECH_PARSE_CONFIG,
-                                "Error with napatec.ports in conf file.  When running in inline mode the two ports specifying a segment must be different.");
-                        exit(EXIT_FAILURE);
+                                FatalError(SC_ERR_FATAL,
+                                           "Error with napatec.ports in conf file.  When running in inline mode the two ports specifying a segment must be different.");
                     } else {
                         /* SPAN port configuration */
                         is_span_port[ports_spec.first[iteration]] = 1;
@@ -1541,18 +1526,16 @@ uint32_t NapatechSetupTraffic(uint32_t first_stream, uint32_t last_stream)
                     strlcat(ports_spec.str, temp, sizeof(ports_spec.str));
                 }
             } else {
-                SCLogError(SC_ERR_NAPATECH_PARSE_CONFIG,
-                        "When using hardware flow bypass ports must be specified as segments. E.g. ports: [0-1, 0-2]");
-                exit(EXIT_FAILURE);
+                        FatalError(SC_ERR_FATAL,
+                                   "When using hardware flow bypass ports must be specified as segments. E.g. ports: [0-1, 0-2]");
             }
 #endif
         } else { // !NapatechUseHWBypass()
             if (strncmp(port->val, "all", 3) == 0) {
                 /* check that the sting in the config file is correctly specified */
                 if (stream_spec != CONFIG_SPECIFIER_UNDEFINED) {
-                    SCLogError(SC_ERR_NAPATECH_PARSE_CONFIG,
-                            "Only one Napatech port specifier type is allowed.");
-                    exit(EXIT_FAILURE);
+                            FatalError(SC_ERR_FATAL,
+                                       "Only one Napatech port specifier type is allowed.");
                 }
                 stream_spec = CONFIG_SPECIFIER_RANGE;
 
@@ -1561,9 +1544,8 @@ uint32_t NapatechSetupTraffic(uint32_t first_stream, uint32_t last_stream)
             } else if (strchr(port->val, '-')) {
                 /* check that the sting in the config file is correctly specified */
                 if (stream_spec != CONFIG_SPECIFIER_UNDEFINED) {
-                    SCLogError(SC_ERR_NAPATECH_PARSE_CONFIG,
-                            "Only one Napatech port specifier is allowed when hardware bypass is disabled. (E.g. ports: [0-4], NOT ports: [0-1,2-3])");
-                    exit(EXIT_FAILURE);
+                            FatalError(SC_ERR_FATAL,
+                                       "Only one Napatech port specifier is allowed when hardware bypass is disabled. (E.g. ports: [0-4], NOT ports: [0-1,2-3])");
                 }
                 stream_spec = CONFIG_SPECIFIER_RANGE;
 
@@ -1575,9 +1557,8 @@ uint32_t NapatechSetupTraffic(uint32_t first_stream, uint32_t last_stream)
             } else {
                 /* check that the sting in the config file is correctly specified */
                 if (stream_spec == CONFIG_SPECIFIER_RANGE) {
-                    SCLogError(SC_ERR_NAPATECH_PARSE_CONFIG,
-                            "Napatech port range specifiers cannot be combined with individual stream specifiers.");
-                    exit(EXIT_FAILURE);
+                            FatalError(SC_ERR_FATAL,
+                                       "Napatech port range specifiers cannot be combined with individual stream specifiers.");
                 }
                 stream_spec = CONFIG_SPECIFIER_INDIVIDUAL;
 
@@ -1827,9 +1808,8 @@ uint32_t NapatechSetupTraffic(uint32_t first_stream, uint32_t last_stream)
         }
     } else {
         if (is_inline) {
-            SCLogError(SC_WARN_COMPATIBILITY,
-                    "Napatech Inline operation not supported by this FPGA version.");
-            exit(EXIT_FAILURE);
+                    FatalError(SC_ERR_FATAL,
+                               "Napatech Inline operation not supported by this FPGA version.");
         }
 
         if (NapatechIsAutoConfigEnabled()){

--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -85,9 +85,8 @@ void SCDropMainThreadCaps(uint32_t userid, uint32_t groupid)
     if (capng_change_id(userid, groupid, CAPNG_DROP_SUPP_GRP |
             CAPNG_CLEAR_BOUNDING) < 0)
     {
-        SCLogError(SC_ERR_CHANGING_CAPS_FAILED, "capng_change_id for main thread"
-                " failed");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "capng_change_id for main thread"
+                   " failed");
     }
 
     SCLogInfo("dropped the caps for main thread");
@@ -160,16 +159,14 @@ int SCGetUserID(const char *user_name, const char *group_name, uint32_t *uid, ui
         }
         pw = getpwuid(userid);
        if (pw == NULL) {
-            SCLogError(SC_ERR_UID_FAILED, "unable to get the user ID, "
-                    "check if user exist!!");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "unable to get the user ID, "
+                       "check if user exist!!");
         }
     } else {
         pw = getpwnam(user_name);
         if (pw == NULL) {
-            SCLogError(SC_ERR_UID_FAILED, "unable to get the user ID, "
-                    "check if user exist!!");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "unable to get the user ID, "
+                       "check if user exist!!");
         }
         userid = pw->pw_uid;
     }
@@ -185,9 +182,8 @@ int SCGetUserID(const char *user_name, const char *group_name, uint32_t *uid, ui
         } else {
             gp = getgrnam(group_name);
             if (gp == NULL) {
-                SCLogError(SC_ERR_GID_FAILED, "unable to get the group"
-                        " ID, check if group exist!!");
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_FATAL, "unable to get the group"
+                           " ID, check if group exist!!");
             }
             groupid = gp->gr_gid;
         }
@@ -227,9 +223,8 @@ int SCGetGroupID(const char *group_name, uint32_t *gid)
     } else {
         gp = getgrnam(group_name);
         if (gp == NULL) {
-            SCLogError(SC_ERR_GID_FAILED, "unable to get the group ID,"
-                    " check if group exist!!");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL, "unable to get the group ID,"
+                       " check if group exist!!");
         }
         grpid = gp->gr_gid;
     }

--- a/src/util-profiling-keywords.c
+++ b/src/util-profiling-keywords.c
@@ -256,9 +256,8 @@ static SCProfileKeywordDetectCtx *SCProfilingKeywordInitCtx(void)
         memset(ctx, 0x00, sizeof(SCProfileKeywordDetectCtx));
 
         if (pthread_mutex_init(&ctx->data_m, NULL) != 0) {
-            SCLogError(SC_ERR_MUTEX,
-                    "Failed to initialize hash table mutex.");
-            exit(EXIT_FAILURE);
+                    FatalError(SC_ERR_FATAL,
+                               "Failed to initialize hash table mutex.");
         }
     }
 

--- a/src/util-profiling-prefilter.c
+++ b/src/util-profiling-prefilter.c
@@ -201,9 +201,8 @@ static SCProfilePrefilterDetectCtx *SCProfilingPrefilterInitCtx(void)
         memset(ctx, 0x00, sizeof(SCProfilePrefilterDetectCtx));
 
         if (pthread_mutex_init(&ctx->data_m, NULL) != 0) {
-            SCLogError(SC_ERR_MUTEX,
-                    "Failed to initialize hash table mutex.");
-            exit(EXIT_FAILURE);
+                    FatalError(SC_ERR_FATAL,
+                               "Failed to initialize hash table mutex.");
         }
     }
 

--- a/src/util-profiling-rulegroups.c
+++ b/src/util-profiling-rulegroups.c
@@ -290,9 +290,7 @@ static SCProfileSghDetectCtx *SCProfilingSghInitCtx(void)
     SCProfileSghDetectCtx *ctx = SCCalloc(1, sizeof(SCProfileSghDetectCtx));
     if (ctx != NULL) {
         if (pthread_mutex_init(&ctx->data_m, NULL) != 0) {
-            SCLogError(SC_ERR_MUTEX,
-                    "Failed to initialize mutex.");
-            exit(EXIT_FAILURE);
+                    FatalError(SC_ERR_FATAL, "Failed to initialize mutex.");
         }
     }
 

--- a/src/util-profiling-rules.c
+++ b/src/util-profiling-rules.c
@@ -577,9 +577,8 @@ static SCProfileDetectCtx *SCProfilingRuleInitCtx(void)
         memset(ctx, 0x00, sizeof(SCProfileDetectCtx));
 
         if (pthread_mutex_init(&ctx->data_m, NULL) != 0) {
-            SCLogError(SC_ERR_MUTEX,
-                    "Failed to initialize hash table mutex.");
-            exit(EXIT_FAILURE);
+                    FatalError(SC_ERR_FATAL,
+                               "Failed to initialize hash table mutex.");
         }
     }
 

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -159,9 +159,8 @@ SCProfilingInit(void)
             profiling_packets_enabled = 1;
 
             if (pthread_mutex_init(&packet_profile_lock, NULL) != 0) {
-                SCLogError(SC_ERR_MUTEX,
-                        "Failed to initialize packet profiling mutex.");
-                exit(EXIT_FAILURE);
+                        FatalError(SC_ERR_FATAL,
+                                   "Failed to initialize packet profiling mutex.");
             }
             memset(&packet_profile_data4, 0, sizeof(packet_profile_data4));
             memset(&packet_profile_data6, 0, sizeof(packet_profile_data6));
@@ -208,8 +207,7 @@ SCProfilingInit(void)
 
                 profiling_csv_file_name = SCMalloc(PATH_MAX);
                 if (unlikely(profiling_csv_file_name == NULL)) {
-                    SCLogError(SC_ERR_MEM_ALLOC, "out of memory");
-                    exit(EXIT_FAILURE);
+                    FatalError(SC_ERR_FATAL, "out of memory");
                 }
                 snprintf(profiling_csv_file_name, PATH_MAX, "%s/%s", log_dir, filename);
 
@@ -243,8 +241,7 @@ SCProfilingInit(void)
 
                 profiling_locks_file_name = SCMalloc(PATH_MAX);
                 if (unlikely(profiling_locks_file_name == NULL)) {
-                    SCLogError(SC_ERR_MEM_ALLOC, "can't duplicate file name");
-                    exit(EXIT_FAILURE);
+                    FatalError(SC_ERR_FATAL, "can't duplicate file name");
                 }
 
                 snprintf(profiling_locks_file_name, PATH_MAX, "%s/%s", log_dir, filename);

--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -87,8 +87,7 @@ static void SCRadixAppendToSCRadixUserDataList(SCRadixUserData *new,
     SCRadixUserData *prev = NULL;
 
     if (new == NULL || list == NULL) {
-        SCLogError(SC_ERR_INVALID_ARGUMENTS, "new or list supplied as NULL");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "new or list supplied as NULL");
     }
 
     /* add to the list in descending order.  The reason we do this is for
@@ -187,8 +186,7 @@ static void SCRadixAddNetmaskUserDataToPrefix(SCRadixPrefix *prefix,
                                               void *user)
 {
     if (prefix == NULL || user == NULL) {
-        SCLogError(SC_ERR_INVALID_ARGUMENTS, "prefix or user NULL");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "prefix or user NULL");
     }
 
     SCRadixAppendToSCRadixUserDataList(SCRadixAllocSCRadixUserData(netmask, user),
@@ -211,8 +209,7 @@ static void SCRadixRemoveNetmaskUserDataFromPrefix(SCRadixPrefix *prefix,
     SCRadixUserData *temp = NULL, *prev = NULL;
 
     if (prefix == NULL) {
-        SCLogError(SC_ERR_INVALID_ARGUMENTS, "prefix NULL");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL, "prefix NULL");
     }
 
     prev = temp = prefix->user_data;
@@ -429,8 +426,8 @@ SCRadixTree *SCRadixCreateRadixTree(void (*Free)(void*), void (*PrintData)(void*
     SCRadixTree *tree = NULL;
 
     if ( (tree = SCMalloc(sizeof(SCRadixTree))) == NULL) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in SCRadixCreateRadixTree. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in SCRadixCreateRadixTree. Exiting...");
     }
     memset(tree, 0, sizeof(SCRadixTree));
 
@@ -800,8 +797,8 @@ static SCRadixNode *SCRadixAddKey(uint8_t *key_stream, uint16_t key_bitlen,
                                                         sizeof(uint8_t)))) == NULL) {
             SCFree(node->netmasks);
             node->netmasks = NULL;
-            SCLogError(SC_ERR_FATAL, "Fatal error encountered in SCRadixAddKey. Exiting...");
-            exit(EXIT_FAILURE);
+            FatalError(SC_ERR_FATAL,
+                       "Fatal error encountered in SCRadixAddKey. Exiting...");
         }
         node->netmasks = ptmp;
 

--- a/src/util-spm-bm.c
+++ b/src/util-spm-bm.c
@@ -78,8 +78,8 @@ BmCtx *BoyerMooreCtxInit(const uint8_t *needle, uint16_t needle_len)
 {
     BmCtx *new = SCMalloc(sizeof(BmCtx) + sizeof(uint16_t) * (needle_len + 1));
     if (unlikely(new == NULL)) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in BoyerMooreCtxInit. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in BoyerMooreCtxInit. Exiting...");
     }
 
     /* Prepare bad chars */
@@ -87,8 +87,8 @@ BmCtx *BoyerMooreCtxInit(const uint8_t *needle, uint16_t needle_len)
 
     /* Prepare good Suffixes */
     if (PreBmGs(needle, needle_len, new->bmGs) == -1) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in BooyerMooreCtxInit. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in BooyerMooreCtxInit. Exiting...");
     }
 
 

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -258,8 +258,8 @@ static void THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
     }
     ctx->array = SCMallocAligned(ctx->config.hash_size * sizeof(THashHashRow), CLS);
     if (unlikely(ctx->array == NULL)) {
-        SCLogError(SC_ERR_FATAL, "Fatal error encountered in THashInitConfig. Exiting...");
-        exit(EXIT_FAILURE);
+        FatalError(SC_ERR_FATAL,
+                   "Fatal error encountered in THashInitConfig. Exiting...");
     }
     memset(ctx->array, 0, ctx->config.hash_size * sizeof(THashHashRow));
 


### PR DESCRIPTION
Replaces all patterns of SCLogError() followed by exit() with
FatalError(). Cocci script to do this:

```
@@
constant C;
constant char[] msg;
@@

- SCLogError(C,
+ FatalError(SC_ERR_FATAL,
  msg);
- exit(EXIT_FAILURE);
```

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3188