### PR TITLE
Pcap read directories recursively v4

### DIFF
--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -54,6 +54,12 @@
    continuously feed files to a directory and have them cleaned up when done. If
    this option is not set, pcap files will not be deleted after processing.
 
+.. option:: --pcap-file-recursive
+   Used with the -r option when the path provided is a directory.  This option
+   enables recursive traversal into subdirectories to a maximum depth of 255.
+   This option cannot be combined with --pcap-file-continuous.  Symlinks are
+   ignored.
+
 .. option::  -i <interface>
 
    After the -i option you can enter the interface card you would like

--- a/src/source-pcap-file-directory-helper.c
+++ b/src/source-pcap-file-directory-helper.c
@@ -26,6 +26,7 @@
 #include "source-pcap-file-directory-helper.h"
 #include "runmode-unix-socket.h"
 #include "util-mem.h"
+#include "util-path.h"
 #include "source-pcap-file.h"
 
 static void GetTime(struct timespec *tm);
@@ -41,6 +42,7 @@ static TmEcode PcapDirectoryPopulateBuffer(PcapFileDirectoryVars *ptv,
                                            struct timespec * older_than);
 static TmEcode PcapDirectoryDispatchForTimeRange(PcapFileDirectoryVars *pv,
                                                  struct timespec *older_than);
+static const uint8_t max_directory_recursion = UINT8_MAX;
 
 void GetTime(struct timespec *tm)
 {
@@ -314,82 +316,101 @@ TmEcode PcapDirectoryPopulateBuffer(PcapFileDirectoryVars *pv,
         SCLogError(SC_ERR_INVALID_ARGUMENT, "No directory filename was passed");
         SCReturnInt(TM_ECODE_FAILED);
     }
+    if ((pv->should_recurse == false) && (pv->cur_dir_depth > 0)) {
+        /* User has not enabled recursion; this is a subdirectory */
+        SCLogInfo("Subdirectory %s will be ignored.  Enable recursive mode using --pcap-file-recursive.", pv->filename);
+        SCReturnInt(TM_ECODE_OK);
+    }
+    if ((pv->should_recurse == true) && (pv->cur_dir_depth > max_directory_recursion)){
+        /* User defined limit reached.  Not an error. */
+        SCLogInfo("Directory depth of %d has been reached.  "
+                  "Ignoring subdirectory %s", max_directory_recursion, pv->filename);
+        SCReturnInt(TM_ECODE_OK);
+    }
     struct dirent * dir = NULL;
     PendingFile *file_to_add = NULL;
 
     while ((dir = readdir(pv->directory)) != NULL) {
-#ifndef OS_WIN32
-        if (dir->d_type != DT_REG) {
+        if (!SCIsRegularDirectory(dir) && !SCIsRegularFile(dir)) {
             continue;
         }
-#endif
-        if (strcmp(dir->d_name, ".") == 0 ||
-            strcmp(dir->d_name, "..") == 0) {
+        if (SCIsRegularDirectory(dir)){
+            DIR *cur_dir = pv->directory;
+            char *cur_path = pv->filename;
+
+            /* Create nested directory path */
+            char next_dir [PATH_MAX] = {0};
+            int result = PathJoin(next_dir, PATH_MAX, pv->filename, dir->d_name);
+            if (result != TM_ECODE_OK) {
+                return result;
+            }
+            /* Update pv to point to the nested directory */
+            pv->directory = opendir(next_dir);
+            pv->filename = next_dir;
+            /* Recursively descend into directory structure */
+            ++pv->cur_dir_depth;
+            PcapDirectoryPopulateBuffer(pv, older_than);
+            --pv->cur_dir_depth;
+            closedir(pv->directory);
+            pv->directory = cur_dir;
+            pv->filename = cur_path;
             continue;
         }
+        char pathbuff [PATH_MAX] = {0};
+        int result = PathJoin(pathbuff, PATH_MAX, pv->filename, dir->d_name);
+        if (result != TM_ECODE_OK) {
+            return result;
+        }
+        struct timespec temp_time;
+        memset(&temp_time, 0, sizeof(struct timespec));
 
-        char pathbuff[PATH_MAX] = {0};
+        if (PcapDirectoryGetModifiedTime(pathbuff, &temp_time) == 0) {
+            SCLogDebug("%" PRIuMAX " < %" PRIuMAX "(%s) < %" PRIuMAX ")",
+                       (uintmax_t)SCTimespecAsEpochMillis(&pv->shared->last_processed),
+                       (uintmax_t)SCTimespecAsEpochMillis(&temp_time),
+                       pathbuff,
+                       (uintmax_t)SCTimespecAsEpochMillis(older_than));
 
-        int written = 0;
-
-        written = snprintf(pathbuff, PATH_MAX, "%s/%s", pv->filename, dir->d_name);
-
-        if (written <= 0 || written >= PATH_MAX) {
-            SCLogError(SC_ERR_SPRINTF, "Could not write path");
-
-            SCReturnInt(TM_ECODE_FAILED);
-        } else {
-            struct timespec temp_time;
-            memset(&temp_time, 0, sizeof(struct timespec));
-
-            if (PcapDirectoryGetModifiedTime(pathbuff, &temp_time) == 0) {
-                SCLogDebug("%" PRIuMAX " < %" PRIuMAX "(%s) < %" PRIuMAX ")",
-                           (uintmax_t)SCTimespecAsEpochMillis(&pv->shared->last_processed),
-                           (uintmax_t)SCTimespecAsEpochMillis(&temp_time),
-                           pathbuff,
-                           (uintmax_t)SCTimespecAsEpochMillis(older_than));
-
-                // Skip files outside of our time range
-                if (CompareTimes(&temp_time, &pv->shared->last_processed) <= 0) {
-                    SCLogDebug("Skipping old file %s", pathbuff);
-                    continue;
-                }
-                else if (CompareTimes(&temp_time, older_than) >= 0) {
-                    SCLogDebug("Skipping new file %s", pathbuff);
-                    continue;
-                }
-            } else {
-                SCLogDebug("Unable to get modified time on %s, skipping", pathbuff);
+            // Skip files outside of our time range
+            if (CompareTimes(&temp_time, &pv->shared->last_processed) <= 0) {
+                SCLogDebug("Skipping old file %s", pathbuff);
                 continue;
             }
-
-            file_to_add = SCCalloc(1, sizeof(PendingFile));
-            if (unlikely(file_to_add == NULL)) {
-                SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate pending file");
-
-                SCReturnInt(TM_ECODE_FAILED);
+            else if (CompareTimes(&temp_time, older_than) >= 0) {
+                SCLogDebug("Skipping new file %s", pathbuff);
+                continue;
             }
+        } else {
+            SCLogDebug("Unable to get modified time on %s, skipping", pathbuff);
+            continue;
+        }
 
-            file_to_add->filename = SCStrdup(pathbuff);
-            if (unlikely(file_to_add->filename == NULL)) {
-                SCLogError(SC_ERR_MEM_ALLOC, "Failed to copy filename");
-                CleanupPendingFile(file_to_add);
+        file_to_add = SCCalloc(1, sizeof(PendingFile));
+        if (unlikely(file_to_add == NULL)) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate pending file");
 
-                SCReturnInt(TM_ECODE_FAILED);
-            }
+            SCReturnInt(TM_ECODE_FAILED);
+        }
 
-            memset(&file_to_add->modified_time, 0, sizeof(struct timespec));
-            CopyTime(&temp_time, &file_to_add->modified_time);
+        file_to_add->filename = SCStrdup(pathbuff);
+        if (unlikely(file_to_add->filename == NULL)) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Failed to copy filename");
+            CleanupPendingFile(file_to_add);
 
-            SCLogInfo("Found \"%s\" at %" PRIuMAX, file_to_add->filename,
-                       (uintmax_t)SCTimespecAsEpochMillis(&file_to_add->modified_time));
+            SCReturnInt(TM_ECODE_FAILED);
+        }
 
-            if (PcapDirectoryInsertFile(pv, file_to_add) == TM_ECODE_FAILED) {
-                SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to add file");
-                CleanupPendingFile(file_to_add);
+        memset(&file_to_add->modified_time, 0, sizeof(struct timespec));
+        CopyTime(&temp_time, &file_to_add->modified_time);
 
-                SCReturnInt(TM_ECODE_FAILED);
-            }
+        SCLogInfo("Found \"%s\" at %" PRIuMAX, file_to_add->filename,
+                   (uintmax_t)SCTimespecAsEpochMillis(&file_to_add->modified_time));
+
+        if (PcapDirectoryInsertFile(pv, file_to_add) == TM_ECODE_FAILED) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to add file");
+            CleanupPendingFile(file_to_add);
+
+            SCReturnInt(TM_ECODE_FAILED);
         }
     }
 

--- a/src/source-pcap-file-directory-helper.h
+++ b/src/source-pcap-file-directory-helper.h
@@ -43,6 +43,8 @@ typedef struct PcapFileDirectoryVars_
     DIR *directory;
     PcapFileFileVars *current_file;
     bool should_loop;
+    bool should_recurse;
+    uint8_t cur_dir_depth;
     time_t delay;
     time_t poll_interval;
 

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -292,11 +292,24 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
             CleanupPcapFileThreadVars(ptv);
             SCReturnInt(TM_ECODE_OK);
         }
+        pv->cur_dir_depth = 0;
+
+        int should_recurse = 0;
+        pv->should_recurse = false;
+        if (ConfGetBool("pcap-file.recursive", &should_recurse) == 1) {
+            pv->should_recurse = should_recurse == 1;
+        }
 
         int should_loop = 0;
         pv->should_loop = false;
         if (ConfGetBool("pcap-file.continuous", &should_loop) == 1) {
             pv->should_loop = should_loop == 1;
+        }
+
+        if (pv->should_recurse == 1 && pv->should_loop == 1) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "Error, --pcap-file-continuous and --pcap-file-recursive "
+                                                "cannot be used together.");
+            SCReturnInt(TM_ECODE_FAILED);
         }
 
         pv->delay = 30;

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -599,6 +599,7 @@ static void PrintUsage(const char *progname)
     printf("\t--pcap[=<dev>]                       : run in pcap mode, no value select interfaces from suricata.yaml\n");
     printf("\t--pcap-file-continuous               : when running in pcap mode with a directory, continue checking directory for pcaps until interrupted\n");
     printf("\t--pcap-file-delete                   : when running in replay mode (-r with directory or file), will delete pcap files that have been processed when done\n");
+    printf("\t--pcap-file-recursive                : will descend into subdirectories when running in replay mode (-r)\n");
 #ifdef HAVE_PCAP_SET_BUFF
     printf("\t--pcap-buffer-size                   : size of the pcap buffer value from 0 - %i\n",INT_MAX);
 #endif /* HAVE_SET_PCAP_BUFF */
@@ -1196,6 +1197,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         {"pcap", optional_argument, 0, 0},
         {"pcap-file-continuous", 0, 0, 0},
         {"pcap-file-delete", 0, 0, 0},
+        {"pcap-file-recursive", 0, 0, 0},
         {"simulate-ips", 0, 0 , 0},
         {"no-random", 0, &g_disable_randomness, 1},
         {"strict-rule-keywords", optional_argument, 0, 0},
@@ -1569,6 +1571,12 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             else if (strcmp((long_opts[option_index]).name, "pcap-file-delete") == 0) {
                 if (ConfSetFinal("pcap-file.delete-when-done", "true") != 1) {
                     SCLogError(SC_ERR_CMD_LINE, "Failed to set pcap-file.delete-when-done");
+                    return TM_ECODE_FAILED;
+                }
+            }
+            else if (strcmp((long_opts[option_index]).name, "pcap-file-recursive") == 0) {
+                if (ConfSetFinal("pcap-file.recursive", "true") != 1) {
+                    SCLogError(SC_ERR_CMD_LINE, "ERROR: Failed to set pcap-file.recursive");
                     return TM_ECODE_FAILED;
                 }
             }

--- a/src/util-path.h
+++ b/src/util-path.h
@@ -33,8 +33,12 @@
 
 int PathIsAbsolute(const char *);
 int PathIsRelative(const char *);
+TmEcode PathJoin (char *out_buf, uint16_t buf_len, const char *const dir, const char *const fname);
 int SCDefaultMkDir(const char *path);
 int SCCreateDirectoryTree(const char *path, const bool final);
 bool SCPathExists(const char *path);
+bool SCIsRegularDirectory(const struct dirent *const dir_entry);
+bool SCIsRegularFile(const struct dirent *const dir_entry);
+char *SCRealPath(const char *path, char *resolved_path);
 
 #endif /* __UTIL_PATH_H__ */


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2363

Describe changes:
- Updated from version 3: https://github.com/OISF/suricata/pull/5157
- Added ability to recursively read pcap directories
- src/suricata.c: addition of new command line parameter “--pcap-file-recursive”
- src/source-pcap-file.c: parsing of the command line argument
- src/source-pcap-file-directory-helper.h: two thread vars tracking directory depth and should_recurse
- src/util-path.c / src/util-path.h: added 4 functions
    - SCIsRegularFile and SCIsRegularDirectory to provide OS independent file / directory info.
    - SCRealPath is an OS independent wrapper for realpath
    - PathJoin to manage path resolution logic


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
