### PR TITLE
ssh: fix incomplete return for ssh kex

### DIFF
--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -228,7 +228,7 @@ impl SSHState {
                                         // saving type of incomplete kex message
                                         hdr.record_left_msg = parser::MessageCode::SshMsgKexinit;
                                         return AppLayerResult::incomplete(
-                                            SSH_RECORD_HEADER_LEN as u32,
+                                            (il - rem.len()) as u32,
                                             hdr.record_left as u32
                                         );
                                     }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3820

Describe changes:
- Fix incomplete return for SSH parsing with an incomplete SshMsgKexinit after other complete records

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:

cf https://github.com/OISF/suricata/pull/5141#issuecomment-656097636