### PR TITLE
Batch Coverity fixes

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -767,6 +767,10 @@ static void DetectBufferTypeFreeFunc(void *data)
 {
     DetectBufferType *map = (DetectBufferType *)data;
 
+    if (map == NULL) {
+        return;
+    }
+
     /* Release transformation option memory, if any */
     for (int i = 0; i < map->transforms.cnt; i++) {
         if (map->transforms.transforms[i].options == NULL)
@@ -779,9 +783,8 @@ static void DetectBufferTypeFreeFunc(void *data)
         }
         sigmatch_table[map->transforms.transforms[i].transform].Free(NULL, map->transforms.transforms[i].options);
     }
-    if (map != NULL) {
-        SCFree(map);
-    }
+
+    SCFree(map);
 }
 
 static int DetectBufferTypeInit(void)

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -177,6 +177,7 @@ static void OutputFilestoreFinalizeFiles(ThreadVars *tv,
                 if (out != NULL) {
                     size_t js_len = jb_len(js_fileinfo);
                     fwrite(jb_ptr(js_fileinfo), js_len, 1, out);
+                    fclose(out);
                 }
                 jb_free(js_fileinfo);
             }

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -563,7 +563,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
         }
 
         /* including fileinfo data is configured by the metadata setting */
-        if (json_output_ctx->flags & LOG_JSON_RULE_METADATA) {
+        if (json_output_ctx->flags & LOG_JSON_RULE_METADATA && p->flow != NULL) {
             FileContainer *ffc = AppLayerParserGetFiles(p->flow,
                     p->flowflags & FLOW_PKT_TOSERVER ? STREAM_TOSERVER:STREAM_TOCLIENT);
             if (ffc != NULL) {

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -67,7 +67,7 @@ static void EveFTPLogCommand(Flow *f, FTPTransaction *tx, JsonBuilder *jb)
         js_resplist = jb_new_array();
 
         if (unlikely(js_resplist == NULL)) {
-            goto fail;
+            return;
         }
     }
     jb_set_string(jb, "command", tx->command_descriptor->command_name);
@@ -142,13 +142,6 @@ static void EveFTPLogCommand(Flow *f, FTPTransaction *tx, JsonBuilder *jb)
         JB_SET_STRING(jb, "reply_received", "yes");
     } else {
         JB_SET_STRING(jb, "reply_received", "no");
-    }
-
-    return;
-
-fail:
-    if (js_resplist) {
-        jb_free(js_resplist);
     }
 }
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1029,7 +1029,7 @@ void JsonFiveTuple(const Packet *p, enum OutputJsonLogDirection dir, json_t *js)
         json_object_set_new(js, "proto", json_string(known_proto[IP_GET_IPPROTO(p)]));
     } else {
         char proto[4];
-        snprintf(proto, sizeof(proto), "%"PRIu8"", IP_GET_IPPROTO(p));
+        snprintf(proto, sizeof(proto), "%"PRIu32"", IP_GET_IPPROTO(p));
         json_object_set_new(js, "proto", json_string(proto));
     }
 }


### PR DESCRIPTION
Batch fix for Coverity issues plus clang warning

Describe changes:
-  Null pointer deref: [3818](https://redmine.openinfosecfoundation.org/issues/3818)
- Resource leak: [3817](https://redmine.openinfosecfoundation.org/issues/3817)
- Null pointer deref: [3814](https://redmine.openinfosecfoundation.org/issues/3814)
- Control flow issue: [3815](https://redmine.openinfosecfoundation.org/issues/3815)
- Clang warning in output-json.c

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
