### PR TITLE
doc: explicit header normalization further

### DIFF
--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -277,6 +277,9 @@ modifiers, like ``depth``, ``distance``, ``offset``, ``nocase`` and
     **Note**: the header buffer is *normalized*. Any trailing
     whitespace and tab characters are removed. See:
     https://lists.openinfosecfoundation.org/pipermail/oisf-users/2011-October/000935.html.
+    If there are multiple values for the same header name, they are
+    concatenated with a comma and space (", ") between each of them.
+    See RFC 2616 4.2 Message Headers.
     To avoid that, use the ``http.header.raw`` keyword.
 
 Example of a header in a HTTP request:


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1275

Describe changes:
- Adds a bit of documentation on HTTP headers concatenation

quoting RFC 2616 :
> Multiple message-header fields with the same field-name MAY be present in a message if and only if the entire field-value for that header field is defined as a comma-separated list [i.e., #(values)]. It MUST be possible to combine the multiple header fields into one "field-name: field-value" pair, without changing the semantics of the message, by appending each subsequent field-value to the first, each separated by a comma. The order in which header fields with the same field-name are received is therefore significant to the interpretation of the combined field value, and thus a proxy MUST NOT change the order of these field values when a message is forwarded.