### PR TITLE
dcerpc: set app proto for signature keywords

### DIFF
--- a/src/detect-dce-opnum.c
+++ b/src/detect-dce-opnum.c
@@ -130,6 +130,9 @@ static int DetectDceOpnumSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         return -1;
     }
 
+    if (DetectSignatureSetAppProto(s, ALPROTO_DCERPC) < 0)
+        return -1;
+
     void *dod = rs_dcerpc_opnum_parse(arg);
     if (dod == NULL) {
         SCLogError(SC_ERR_INVALID_SIGNATURE, "Error parsing dce_opnum option in "

--- a/src/detect-dce-stub-data.c
+++ b/src/detect-dce-stub-data.c
@@ -167,6 +167,9 @@ void DetectDceStubDataRegister(void)
 
 static int DetectDceStubDataSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
 {
+    if (DetectSignatureSetAppProto(s, ALPROTO_DCERPC) < 0)
+        return -1;
+
     if (DetectBufferSetActiveList(s, g_dce_stub_data_buffer_id) < 0)
         return -1;
     return 0;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3826

Describe changes:
- Adds missing calls to `DetectSignatureSetAppProto` for DCERPC keywords


#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
