### PR TITLE
suricata: fix suricata alert metadata logging

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2308,11 +2308,12 @@ void PreRunInit(const int runmode)
  * but after we dropped privs */
 void PreRunPostPrivsDropInit(const int runmode)
 {
+    StatsSetupPostConfigPreOutput();
+    RunModeInitializeOutputs();
+
     if (runmode == RUNMODE_UNIX_SOCKET)
         return;
 
-    StatsSetupPostConfigPreOutput();
-    RunModeInitializeOutputs();
     StatsSetupPostConfigPostOutput();
 }
 


### PR DESCRIPTION
This changeset fixes a bug that was preventing suricata to dump
alert metadata info when running in unix-socket mode.
When running in unix-socket mode, suricata was skipping the
initialization of the output modules and, as a consequence,
the metadata output module was never invoked.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3467

Describe changes:
- Initialization of the output modules done also when suricata is running in unix socket mode. This
- allows to dump correctly alert metadata info.
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
