### PR TITLE
threads/runmode: Changes to thread config behaviour

### DIFF
--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -243,6 +243,7 @@ int TmThreadsInjectPacketsById(Packet **, int id);
 void TmThreadsInitThreadsTimestamp(const struct timeval *ts);
 void TmThreadsSetThreadTimestamp(const int id, const struct timeval *ts);
 void TmThreadsGetMinimalTimestamp(struct timeval *ts);
+uint16_t TmThreadsGetWorkerThreadMax(void);
 bool TmThreadsTimeSubsysIsReady(void);
 
 #endif /* __TM_THREADS_H__ */


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3108

Describe changes:
- Previously defining receive thread (RX) counts and worker thread (W) counts displayed counterintuitive behaviour where config values could be ignored or overridden. 
- Factored out a new function in threads.c to return a desired worker thread count compliant with existing queue creation/assignment.
- Runmode autofp RX thread count is now independent of W thread count and is set under interface settings in the config file. Runmode autofp W thread count can be changed from default by enabling CPU affinity settings and specifying number of desired threads under worker-cpu-set.
- Runmode workers W thread count is determined by interface settings in the config file or thread affinity settings (lowest value).
- This is one possible interpretation of a desirable thread count configuration methodology. Others are possible (e.g. allowing "auto" settings to determine W/RX threads as a ratio or e.g. W = MaxThreads - RX, etc.) but desire discussion.
- This does not address any potential NUMA considerations, as mentioned in https://redmine.openinfosecfoundation.org/issues/3695

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

