### PR TITLE
draft/output: Multi-threaded eve.json output

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013-2014 Open Information Security Foundation
+/* Copyright (C) 2013-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -35,6 +35,7 @@
 #include "threadvars.h"
 #include "util-debug.h"
 
+#include "util-logopenfile.h"
 #include "util-misc.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
@@ -739,37 +740,47 @@ static int JsonAlertLogCondition(ThreadVars *tv, const Packet *p)
 
 static TmEcode JsonAlertLogThreadInit(ThreadVars *t, const void *initdata, void **data)
 {
-    JsonAlertLogThread *aft = SCMalloc(sizeof(JsonAlertLogThread));
+    JsonAlertLogThread *aft = SCCalloc(1, sizeof(JsonAlertLogThread));
     if (unlikely(aft == NULL))
         return TM_ECODE_FAILED;
-    memset(aft, 0, sizeof(JsonAlertLogThread));
-    if(initdata == NULL)
+
+    if (initdata == NULL)
     {
         SCLogDebug("Error getting context for EveLogAlert.  \"initdata\" argument NULL");
-        SCFree(aft);
-        return TM_ECODE_FAILED;
+        goto error_exit;
     }
 
     aft->json_buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
     if (aft->json_buffer == NULL) {
-        SCFree(aft);
-        return TM_ECODE_FAILED;
+        goto error_exit;
     }
 
     /** Use the Output Context (file pointer and mutex) */
     AlertJsonOutputCtx *json_output_ctx = ((OutputCtx *)initdata)->data;
-    aft->file_ctx = json_output_ctx->file_ctx;
-    aft->json_output_ctx = json_output_ctx;
 
     aft->payload_buffer = MemBufferCreateNew(json_output_ctx->payload_buffer_size);
     if (aft->payload_buffer == NULL) {
-        MemBufferFree(aft->json_buffer);
-        SCFree(aft);
-        return TM_ECODE_FAILED;
+        goto error_exit;
     }
+    aft->file_ctx = LogFileEnsureExists(json_output_ctx->file_ctx, t->id);
+    if (!aft->file_ctx) {
+        goto error_exit;
+    }
+
+    aft->json_output_ctx = json_output_ctx;
 
     *data = (void *)aft;
     return TM_ECODE_OK;
+
+error_exit:
+    if (aft->json_buffer != NULL) {
+        MemBufferFree(aft->json_buffer);
+    }
+    if (aft->payload_buffer != NULL) {
+        MemBufferFree(aft->payload_buffer);
+    }
+    SCFree(aft);
+    return TM_ECODE_FAILED;
 }
 
 static TmEcode JsonAlertLogThreadDeinit(ThreadVars *t, void *data)

--- a/src/output-json-dcerpc.c
+++ b/src/output-json-dcerpc.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2018 Open Information Security Foundation
+/* Copyright (C) 2017-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -58,7 +58,7 @@ static int JsonDCERPCLogger(ThreadVars *tv, void *thread_data,
     jb_close(jb);
 
     MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(jb, thread->ctx->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(jb, thread->file_ctx, &thread->buffer);
 
     jb_free(jb);
     return TM_ECODE_OK;

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -266,8 +266,7 @@ typedef struct LogDnsFileCtx_ {
 typedef struct LogDnsLogThread_ {
     LogDnsFileCtx *dnslog_ctx;
     /** LogFileCtx has the pointer to the file and a mutex to allow multithreading */
-    uint32_t dns_cnt;
-
+    LogFileCtx *file_ctx;
     MemBuffer *buffer;
 } LogDnsLogThread;
 
@@ -332,7 +331,7 @@ static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
         jb_close(jb);
 
         MemBufferReset(td->buffer);
-        OutputJsonBuilderBuffer(jb, td->dnslog_ctx->file_ctx, &td->buffer);
+        OutputJsonBuilderBuffer(jb, td->file_ctx, &td->buffer);
         jb_free(jb);
     }
 
@@ -363,7 +362,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
             rs_dns_log_json_answer(txptr, td->dnslog_ctx->flags, jb);
             jb_close(jb);
             MemBufferReset(td->buffer);
-            OutputJsonBuilderBuffer(jb, td->dnslog_ctx->file_ctx, &td->buffer);
+            OutputJsonBuilderBuffer(jb, td->file_ctx, &td->buffer);
             jb_free(jb);
         }
     } else {
@@ -384,7 +383,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
             jb_set_object(jb, "dns", answer);
 
             MemBufferReset(td->buffer);
-            OutputJsonBuilderBuffer(jb, td->dnslog_ctx->file_ctx, &td->buffer);
+            OutputJsonBuilderBuffer(jb, td->file_ctx, &td->buffer);
             jb_free(jb);
         }
         /* Log authorities. */
@@ -404,7 +403,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
             jb_set_object(jb, "dns", answer);
 
             MemBufferReset(td->buffer);
-            OutputJsonBuilderBuffer(jb, td->dnslog_ctx->file_ctx, &td->buffer);
+            OutputJsonBuilderBuffer(jb, td->file_ctx, &td->buffer);
             jb_free(jb);
         }
     }
@@ -414,29 +413,37 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
 
 static TmEcode LogDnsLogThreadInit(ThreadVars *t, const void *initdata, void **data)
 {
-    LogDnsLogThread *aft = SCMalloc(sizeof(LogDnsLogThread));
+    LogDnsLogThread *aft = SCCalloc(1, sizeof(LogDnsLogThread));
     if (unlikely(aft == NULL))
         return TM_ECODE_FAILED;
-    memset(aft, 0, sizeof(LogDnsLogThread));
 
     if(initdata == NULL)
     {
         SCLogDebug("Error getting context for EveLogDNS.  \"initdata\" argument NULL");
-        SCFree(aft);
-        return TM_ECODE_FAILED;
+        goto error_exit;
     }
 
     aft->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
     if (aft->buffer == NULL) {
-        SCFree(aft);
-        return TM_ECODE_FAILED;
+        goto error_exit;
     }
 
     /* Use the Ouptut Context (file pointer and mutex) */
     aft->dnslog_ctx= ((OutputCtx *)initdata)->data;
+    aft->file_ctx = LogFileEnsureExists(aft->dnslog_ctx->file_ctx, t->id);
+    if (!aft->file_ctx) {
+        goto error_exit;
+    }
 
     *data = (void *)aft;
     return TM_ECODE_OK;
+
+error_exit:
+    if (aft->buffer != NULL) {
+        MemBufferFree(aft->buffer);
+    }
+    SCFree(aft);
+    return TM_ECODE_FAILED;
 }
 
 static TmEcode LogDnsLogThreadDeinit(ThreadVars *t, void *data)

--- a/src/output-json-email-common.h
+++ b/src/output-json-email-common.h
@@ -32,6 +32,7 @@ typedef struct OutputJsonEmailCtx_ {
 } OutputJsonEmailCtx;
 
 typedef struct JsonEmailLogThread_ {
+    LogFileCtx *file_ctx;
     OutputJsonEmailCtx *emaillog_ctx;
     MemBuffer *buffer;
 } JsonEmailLogThread;

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -54,8 +54,8 @@ typedef struct LogFTPFileCtx_ {
 } LogFTPFileCtx;
 
 typedef struct LogFTPLogThread_ {
+    LogFileCtx *file_ctx;
     LogFTPFileCtx *ftplog_ctx;
-    uint32_t            count;
     MemBuffer          *buffer;
 } LogFTPLogThread;
 
@@ -176,7 +176,7 @@ static int JsonFTPLogger(ThreadVars *tv, void *thread_data,
         }
 
         MemBufferReset(thread->buffer);
-        OutputJsonBuilderBuffer(jb, thread->ftplog_ctx->file_ctx, &thread->buffer);
+        OutputJsonBuilderBuffer(jb, thread->file_ctx, &thread->buffer);
 
         jb_free(jb);
     }
@@ -235,20 +235,30 @@ static TmEcode JsonFTPLogThreadInit(ThreadVars *t, const void *initdata, void **
 
     if (initdata == NULL) {
         SCLogDebug("Error getting context for EveLogFTP.  \"initdata\" is NULL.");
-        SCFree(thread);
-        return TM_ECODE_FAILED;
+        goto error_exit;
     }
 
     thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
     if (unlikely(thread->buffer == NULL)) {
-        SCFree(thread);
-        return TM_ECODE_FAILED;
+        goto error_exit;
     }
 
     thread->ftplog_ctx = ((OutputCtx *)initdata)->data;
+    thread->file_ctx = LogFileEnsureExists(thread->ftplog_ctx->file_ctx, t->id);
+    if (!thread->file_ctx) {
+        goto error_exit;
+    }
+
     *data = (void *)thread;
 
     return TM_ECODE_OK;
+
+error_exit:
+    if (thread->buffer != NULL) {
+        MemBufferFree(thread->buffer);
+    }
+    SCFree(thread);
+    return TM_ECODE_FAILED;
 }
 
 static TmEcode JsonFTPLogThreadDeinit(ThreadVars *t, void *data)

--- a/src/output-json-krb5.c
+++ b/src/output-json-krb5.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018 Open Information Security Foundation
+/* Copyright (C) 2018-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -55,6 +55,7 @@ typedef struct LogKRB5FileCtx_ {
 } LogKRB5FileCtx;
 
 typedef struct LogKRB5LogThread_ {
+    LogFileCtx *file_ctx;
     LogKRB5FileCtx *krb5log_ctx;
     MemBuffer          *buffer;
 } LogKRB5LogThread;
@@ -79,7 +80,7 @@ static int JsonKRB5Logger(ThreadVars *tv, void *thread_data,
     jb_close(jb);
 
     MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(jb, thread->krb5log_ctx->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(jb, thread->file_ctx, &thread->buffer);
 
     jb_free(jb);
     return TM_ECODE_OK;
@@ -136,20 +137,29 @@ static TmEcode JsonKRB5LogThreadInit(ThreadVars *t, const void *initdata, void *
 
     if (initdata == NULL) {
         SCLogDebug("Error getting context for EveLogKRB5.  \"initdata\" is NULL.");
-        SCFree(thread);
-        return TM_ECODE_FAILED;
+        goto error_exit;
     }
 
     thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
     if (unlikely(thread->buffer == NULL)) {
-        SCFree(thread);
-        return TM_ECODE_FAILED;
+        goto error_exit;
     }
 
     thread->krb5log_ctx = ((OutputCtx *)initdata)->data;
+    thread->file_ctx = LogFileEnsureExists(thread->krb5log_ctx->file_ctx, t->id);
+    if (!thread->file_ctx) {
+        goto error_exit;
+    }
     *data = (void *)thread;
 
     return TM_ECODE_OK;
+
+error_exit:
+    if (thread->buffer != NULL) {
+        MemBufferFree(thread->buffer);
+    }
+    SCFree(thread);
+    return TM_ECODE_FAILED;
 }
 
 static TmEcode JsonKRB5LogThreadDeinit(ThreadVars *t, void *data)

--- a/src/output-json-nfs.c
+++ b/src/output-json-nfs.c
@@ -96,7 +96,7 @@ static int JsonNFSLogger(ThreadVars *tv, void *thread_data,
     jb_close(jb);
 
     MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(jb, thread->ctx->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(jb, thread->file_ctx, &thread->buffer);
     jb_free(jb);
     return TM_ECODE_OK;
 }

--- a/src/output-json-rdp.c
+++ b/src/output-json-rdp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Open Information Security Foundation
+/* Copyright (C) 2019-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -51,7 +51,7 @@ typedef struct LogRdpFileCtx_ {
 
 typedef struct LogRdpLogThread_ {
     LogRdpFileCtx *rdplog_ctx;
-    uint32_t         count;
+    LogFileCtx *file_ctx;
     MemBuffer       *buffer;
 } LogRdpLogThread;
 
@@ -70,7 +70,7 @@ static int JsonRdpLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
     MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(js, thread->rdplog_ctx->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(js, thread->file_ctx, &thread->buffer);
 
     jb_free(js);
     return TM_ECODE_OK;
@@ -127,14 +127,24 @@ static TmEcode JsonRdpLogThreadInit(ThreadVars *t, const void *initdata, void **
 
     thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
     if (unlikely(thread->buffer == NULL)) {
-        SCFree(thread);
-        return TM_ECODE_FAILED;
+        goto error_exit;
     }
 
     thread->rdplog_ctx = ((OutputCtx *)initdata)->data;
-    *data = (void *)thread;
+    thread->file_ctx = LogFileEnsureExists(thread->rdplog_ctx->file_ctx, t->id);
+    if (!thread->file_ctx) {
+        goto error_exit;
+    }
 
+    *data = (void *)thread;
     return TM_ECODE_OK;
+
+error_exit:
+    if (thread->buffer != NULL) {
+        MemBufferFree(thread->buffer);
+    }
+    SCFree(thread);
+    return TM_ECODE_FAILED;
 }
 
 static TmEcode JsonRdpLogThreadDeinit(ThreadVars *t, void *data)

--- a/src/output-json-rfb.c
+++ b/src/output-json-rfb.c
@@ -53,7 +53,7 @@ typedef struct LogRFBFileCtx_ {
 
 typedef struct LogRFBLogThread_ {
     LogRFBFileCtx *rfblog_ctx;
-    uint32_t            count;
+    LogFileCtx *file_ctx;
     MemBuffer          *buffer;
 } LogRFBLogThread;
 
@@ -85,7 +85,7 @@ static int JsonRFBLogger(ThreadVars *tv, void *thread_data,
     }
 
     MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(js, thread->rfblog_ctx->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(js, thread->file_ctx, &thread->buffer);
     jb_free(js);
 
     return TM_ECODE_OK;
@@ -143,14 +143,24 @@ static TmEcode JsonRFBLogThreadInit(ThreadVars *t, const void *initdata, void **
 
     thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
     if (unlikely(thread->buffer == NULL)) {
-        SCFree(thread);
-        return TM_ECODE_FAILED;
+        goto error_exit;
     }
 
     thread->rfblog_ctx = ((OutputCtx *)initdata)->data;
+    thread->file_ctx = LogFileEnsureExists(thread->rfblog_ctx->file_ctx, t->id);
+    if (!thread->file_ctx) {
+        goto error_exit;
+    }
     *data = (void *)thread;
 
     return TM_ECODE_OK;
+
+error_exit:
+    if (thread->buffer != NULL) {
+        MemBufferFree(thread->buffer);
+    }
+    SCFree(thread);
+    return TM_ECODE_FAILED;
 }
 
 static TmEcode JsonRFBLogThreadDeinit(ThreadVars *t, void *data)

--- a/src/output-json-smb.c
+++ b/src/output-json-smb.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2018 Open Information Security Foundation
+/* Copyright (C) 2017-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -77,7 +77,7 @@ static int JsonSMBLogger(ThreadVars *tv, void *thread_data,
 
     EveAddCommonOptions(&thread->ctx->cfg, p, f, jb);
     MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(jb, thread->ctx->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(jb, thread->file_ctx, &thread->buffer);
 
     jb_free(jb);
     return TM_ECODE_OK;

--- a/src/output-json-template-rust.c
+++ b/src/output-json-template-rust.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018 Open Information Security Foundation
+/* Copyright (C) 2018-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -61,6 +61,7 @@ typedef struct LogTemplateFileCtx_ {
 
 typedef struct LogTemplateLogThread_ {
     LogTemplateFileCtx *templatelog_ctx;
+    LogFileCtx *file_ctx;
     uint32_t            count;
     MemBuffer          *buffer;
 } LogTemplateLogThread;
@@ -83,7 +84,7 @@ static int JsonTemplateLogger(ThreadVars *tv, void *thread_data,
     jb_close(js);
 
     MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(js, thread->templatelog_ctx->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(js, thread->file_ctx, &thread->buffer);
     jb_free(js);
 
     return TM_ECODE_OK;
@@ -138,20 +139,29 @@ static TmEcode JsonTemplateLogThreadInit(ThreadVars *t, const void *initdata, vo
 
     if (initdata == NULL) {
         SCLogDebug("Error getting context for EveLogTemplate.  \"initdata\" is NULL.");
-        SCFree(thread);
-        return TM_ECODE_FAILED;
+        goto error_exit;
     }
 
     thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
     if (unlikely(thread->buffer == NULL)) {
-        SCFree(thread);
-        return TM_ECODE_FAILED;
+        goto error_exit;
     }
 
     thread->templatelog_ctx = ((OutputCtx *)initdata)->data;
+    thread->file_ctx = LogFileEnsureExists(thread->templatelog_ctx->file_ctx, t->id);
+    if (!thread->file_ctx) {
+        goto error_exit;
+    }
     *data = (void *)thread;
 
     return TM_ECODE_OK;
+
+error_exit:
+    if (thread->buffer != NULL) {
+        MemBufferFree(thread->buffer);
+    }
+    SCFree(thread);
+    return TM_ECODE_FAILED;
 }
 
 static TmEcode JsonTemplateLogThreadDeinit(ThreadVars *t, void *data)

--- a/src/output-json-template.c
+++ b/src/output-json-template.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015 Open Information Security Foundation
+/* Copyright (C) 2015-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -59,8 +59,8 @@ typedef struct LogTemplateFileCtx_ {
 } LogTemplateFileCtx;
 
 typedef struct LogTemplateLogThread_ {
+    LogFileCtx *file_ctx;
     LogTemplateFileCtx *templatelog_ctx;
-    uint32_t            count;
     MemBuffer          *buffer;
 } LogTemplateLogThread;
 
@@ -95,7 +95,7 @@ static int JsonTemplateLogger(ThreadVars *tv, void *thread_data,
     jb_close(js);
 
     MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(js, thread->templatelog_ctx->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(js, thread->file_ctx, &thread->buffer);
 
     jb_free(js);
     return TM_ECODE_OK;
@@ -146,20 +146,29 @@ static TmEcode JsonTemplateLogThreadInit(ThreadVars *t, const void *initdata, vo
 
     if (initdata == NULL) {
         SCLogDebug("Error getting context for EveLogTemplate.  \"initdata\" is NULL.");
-        SCFree(thread);
-        return TM_ECODE_FAILED;
+        goto error_exit;
     }
 
     thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
     if (unlikely(thread->buffer == NULL)) {
-        SCFree(thread);
-        return TM_ECODE_FAILED;
+        goto error_exit;
     }
 
     thread->templatelog_ctx = ((OutputCtx *)initdata)->data;
+    thread->file_ctx = LogFileEnsureExists(thread->templatelog_ctx->file_ctx, t->id);
+    if (!thread->file_ctx) {
+        goto error_exit;
+    }
     *data = (void *)thread;
 
     return TM_ECODE_OK;
+
+error_exit:
+    if (thread->buffer != NULL) {
+        MemBufferFree(thread->buffer);
+    }
+    SCFree(thread);
+    return TM_ECODE_FAILED;
 }
 
 static TmEcode JsonTemplateLogThreadDeinit(ThreadVars *t, void *data)

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -106,6 +106,7 @@ typedef struct OutputTlsCtx_ {
 
 
 typedef struct JsonTlsLogThread_ {
+    LogFileCtx *file_ctx;
     OutputTlsCtx *tlslog_ctx;
     MemBuffer *buffer;
 } JsonTlsLogThread;
@@ -440,7 +441,7 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
     /* Close the tls object. */
     jb_close(js);
 
-    OutputJsonBuilderBuffer(js, tls_ctx->file_ctx, &aft->buffer);
+    OutputJsonBuilderBuffer(js, aft->file_ctx, &aft->buffer);
     jb_free(js);
 
     return 0;
@@ -448,30 +449,37 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
 
 static TmEcode JsonTlsLogThreadInit(ThreadVars *t, const void *initdata, void **data)
 {
-    JsonTlsLogThread *aft = SCMalloc(sizeof(JsonTlsLogThread));
+    JsonTlsLogThread *aft = SCCalloc(1, sizeof(JsonTlsLogThread));
     if (unlikely(aft == NULL)) {
         return TM_ECODE_FAILED;
     }
 
-    memset(aft, 0, sizeof(JsonTlsLogThread));
-
     if (initdata == NULL) {
         SCLogDebug("Error getting context for eve-log tls 'initdata' argument NULL");
-        SCFree(aft);
-        return TM_ECODE_FAILED;
+        goto error_exit;
+    }
+
+    aft->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
+    if (aft->buffer == NULL) {
+        goto error_exit;
     }
 
     /* use the Output Context (file pointer and mutex) */
     aft->tlslog_ctx = ((OutputCtx *)initdata)->data;
 
-    aft->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (aft->buffer == NULL) {
-        SCFree(aft);
-        return TM_ECODE_FAILED;
+    aft->file_ctx = LogFileEnsureExists(aft->tlslog_ctx->file_ctx, t->id);
+    if (!aft->file_ctx) {
+        goto error_exit;
     }
-
     *data = (void *)aft;
     return TM_ECODE_OK;
+
+error_exit:
+    if (aft->buffer != NULL) {
+        MemBufferFree(aft->buffer);
+    }
+    SCFree(aft);
+    return TM_ECODE_FAILED;
 }
 
 static TmEcode JsonTlsLogThreadDeinit(ThreadVars *t, void *data)

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1558,6 +1558,17 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
             json_ctx->json_out == LOGFILE_TYPE_UNIX_DGRAM ||
             json_ctx->json_out == LOGFILE_TYPE_UNIX_STREAM)
         {
+            if (json_ctx->json_out == LOGFILE_TYPE_FILE) {
+                /* Threaded file output */
+                const ConfNode *threaded = ConfNodeLookupChild(conf, "threaded");
+                if (threaded && threaded->val && ConfValIsTrue(threaded->val)) {
+                    SCLogConfig("Enabling threaded eve logging.");
+                    json_ctx->file_ctx->threaded = true;
+                } else {
+                    json_ctx->file_ctx->threaded = false;
+                }
+            }
+
             if (SCConfLogOpenGeneric(conf, json_ctx->file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
                 LogFileFreeCtx(json_ctx->file_ctx);
                 SCFree(json_ctx);
@@ -1565,6 +1576,7 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
                 return result;
             }
             OutputRegisterFileRotationFlag(&json_ctx->file_ctx->rotation_flag);
+
         }
 #ifndef OS_WIN32
 	else if (json_ctx->json_out == LOGFILE_TYPE_SYSLOG) {

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -114,6 +114,7 @@ typedef struct OutputJsonCtx_ {
 
 typedef struct OutputJsonThreadCtx_ {
     OutputJsonCtx *ctx;
+    LogFileCtx *file_ctx;
     MemBuffer *buffer;
 } OutputJsonThreadCtx;
 

--- a/src/output-packet.c
+++ b/src/output-packet.c
@@ -143,6 +143,7 @@ static TmEcode OutputPacketLogThreadInit(ThreadVars *tv, const void *initdata, v
 
     OutputPacketLogger *logger = list;
     while (logger) {
+        SCLogNotice("Thread %d - %s", tv->id, logger->name);
         if (logger->ThreadInit) {
             void *retptr = NULL;
             if (logger->ThreadInit(tv, (void *)logger->output_ctx, &retptr) == TM_ECODE_OK) {

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -1,5 +1,5 @@
 /* vi: set et ts=4: */
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -25,11 +25,9 @@
  */
 
 #include "suricata-common.h" /* errno.h, string.h, etc. */
-#include "tm-modules.h"      /* LogFileCtx */
 #include "conf.h"            /* ConfNode, etc. */
 #include "output.h"          /* DEFAULT_LOG_* */
 #include "util-byte.h"
-#include "util-path.h"
 #include "util-logopenfile.h"
 
 #if defined(HAVE_SYS_UN_H) && defined(HAVE_SYS_SOCKET_H) && defined(HAVE_SYS_TYPES_H)
@@ -42,6 +40,9 @@
 #ifdef HAVE_LIBHIREDIS
 #include "util-log-redis.h"
 #endif /* HAVE_LIBHIREDIS */
+
+static bool LogFileNewThreadedCtx(LogFileCtx *parent_ctx, const char *log_path, const char *append, int i);
+static bool SCLogOpenThreadedFileFp(const char *log_path, const char *append, LogFileCtx *parent_ctx, int count);
 
 #ifdef BUILD_WITH_UNIXSOCKET
 /** \brief connect to the indicated local stream socket, logging any errors
@@ -179,6 +180,40 @@ tryagain:
 
 /**
  * \brief Write buffer to log file.
+ * \retval 0 on failure; otherwise, the return value of fwrite_unlocked (number of
+ * characters successfully written).
+ */
+static int SCLogFileWriteNoLock(const char *buffer, int buffer_len, LogFileCtx *log_ctx)
+{
+    int ret = 0;
+
+    BUG_ON(log_ctx->is_sock);
+
+    /* Check for rotation. */
+    if (log_ctx->rotation_flag) {
+        log_ctx->rotation_flag = 0;
+        SCConfLogReopen(log_ctx);
+    }
+
+    if (log_ctx->flags & LOGFILE_ROTATE_INTERVAL) {
+        time_t now = time(NULL);
+        if (now >= log_ctx->rotate_time) {
+            SCConfLogReopen(log_ctx);
+            log_ctx->rotate_time = now + log_ctx->rotate_interval;
+        }
+    }
+
+    if (log_ctx->fp) {
+        clearerr(log_ctx->fp);
+        ret = fwrite_unlocked(buffer, buffer_len, 1, log_ctx->fp);
+        fflush(log_ctx->fp);
+    }
+
+    return ret;
+}
+
+/**
+ * \brief Write buffer to log file.
  * \retval 0 on failure; otherwise, the return value of fwrite (number of
  * characters successfully written).
  */
@@ -216,7 +251,6 @@ static int SCLogFileWrite(const char *buffer, int buffer_len, LogFileCtx *log_ct
     }
 
     SCMutexUnlock(&log_ctx->fp_mutex);
-
     return ret;
 }
 
@@ -241,10 +275,64 @@ static char *SCLogFilenameFromPattern(const char *pattern)
     return filename;
 }
 
-static void SCLogFileClose(LogFileCtx *log_ctx)
+static void SCLogFileCloseNoLock(LogFileCtx *log_ctx)
 {
     if (log_ctx->fp)
         fclose(log_ctx->fp);
+}
+
+
+static void SCLogFileClose(LogFileCtx *log_ctx)
+{
+    SCMutexLock(&log_ctx->fp_mutex);
+    if (log_ctx->fp)
+        fclose(log_ctx->fp);
+    SCMutexUnlock(&log_ctx->fp_mutex);
+}
+
+static bool
+SCLogOpenThreadedFileFp(const char *log_path, const char *append, LogFileCtx *parent_ctx, int count)
+{
+        parent_ctx->threads = SCCalloc(1, sizeof(LogThreadedFileCtx));
+        if (!parent_ctx->threads) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate threads container");
+            return false;
+        }
+        parent_ctx->threads->append = SCStrdup(append);
+        if (!parent_ctx->threads->append) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate threads append setting");
+            goto error_exit;
+        }
+
+        parent_ctx->threads->count = count;
+        parent_ctx->threads->lf_slots = SCCalloc(count, sizeof(LogFileCtx *));
+        if (!parent_ctx->threads->lf_slots) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate thread slots");
+            goto error_exit;
+        }
+        SCLogDebug("Allocated %d file context pointers for threaded array",
+                    parent_ctx->threads->count);
+        int slot = 1;
+        for (; slot < parent_ctx->threads->count; slot++) {
+            if (!LogFileNewThreadedCtx(parent_ctx, log_path, append, slot)) {
+                /* TODO: clear allocated entries [1, slot) */
+                goto error_exit;
+            }
+        }
+        SCMutexInit(&parent_ctx->threads->mutex, NULL);
+        return true;
+
+error_exit:
+
+        if (parent_ctx->threads->lf_slots) {
+            SCFree(parent_ctx->threads->lf_slots);
+        }
+        if (parent_ctx->threads->append) {
+            SCFree(parent_ctx->threads->append);
+        }
+        SCFree(parent_ctx->threads);
+        parent_ctx->threads = NULL;
+        return false;
 }
 
 /** \brief open the indicated file, logging any errors
@@ -254,7 +342,7 @@ static void SCLogFileClose(LogFileCtx *log_ctx)
  *  \retval FILE* on success
  *  \retval NULL on error
  */
-static FILE *
+FILE *
 SCLogOpenFileFp(const char *path, const char *append_setting, uint32_t mode)
 {
     FILE *ret = NULL;
@@ -432,10 +520,16 @@ SCConfLogOpenGeneric(ConfNode *conf,
 #endif
     } else if (strcasecmp(filetype, DEFAULT_LOG_FILETYPE) == 0 ||
                strcasecmp(filetype, "file") == 0) {
-        log_ctx->fp = SCLogOpenFileFp(log_path, append, log_ctx->filemode);
-        if (log_ctx->fp == NULL)
-            return -1; // Error already logged by Open...Fp routine
         log_ctx->is_regular = 1;
+        if (!log_ctx->threaded) {
+            log_ctx->fp = SCLogOpenFileFp(log_path, append, log_ctx->filemode);
+            if (log_ctx->fp == NULL)
+                return -1; // Error already logged by Open...Fp routine
+        } else {
+            if (!SCLogOpenThreadedFileFp(log_path, append, log_ctx, 1)) {
+                return -1;
+            }
+        }
         if (rotate) {
             OutputRegisterFileRotationFlag(&log_ctx->rotation_flag);
         }
@@ -511,29 +605,128 @@ int SCConfLogReopen(LogFileCtx *log_ctx)
 }
 
 /** \brief LogFileNewCtx() Get a new LogFileCtx
- *  \retval LogFileCtx * pointer if succesful, NULL if error
+ *  \retval LogFileCtx * pointer if successful, NULL if error
  *  */
 LogFileCtx *LogFileNewCtx(void)
 {
     LogFileCtx* lf_ctx;
-    lf_ctx = (LogFileCtx*)SCMalloc(sizeof(LogFileCtx));
+    lf_ctx = (LogFileCtx*)SCCalloc(1, sizeof(LogFileCtx));
 
     if (lf_ctx == NULL)
         return NULL;
-    memset(lf_ctx, 0, sizeof(LogFileCtx));
 
-    SCMutexInit(&lf_ctx->fp_mutex,NULL);
-
-    // Default Write and Close functions
     lf_ctx->Write = SCLogFileWrite;
     lf_ctx->Close = SCLogFileClose;
 
     return lf_ctx;
 }
 
+/** \brief LogFileEnsureExists() Ensure a log file context for the thread exists
+ * \param parent_ctx
+ * \param thread_id
+ * \retval LogFileCtx * pointer if successful; NULL otherwise
+ */
+LogFileCtx *LogFileEnsureExists(LogFileCtx *parent_ctx, int thread_id)
+{
+    if (!parent_ctx->threaded)
+        return parent_ctx;
+
+    SCLogDebug("Adding reference %d to file ctx %p", thread_id, parent_ctx);
+    SCMutexLock(&parent_ctx->threads->mutex);
+    /* are there enough context slots already */
+    if (thread_id < parent_ctx->threads->count) {
+        /* has it been opened yet? */
+        if (!parent_ctx->threads->lf_slots[thread_id]) {
+            SCLogDebug("Opening new file for %d reference to file ctx %p", thread_id, parent_ctx);
+            LogFileNewThreadedCtx(parent_ctx, parent_ctx->filename, parent_ctx->threads->append, thread_id);
+        }
+        SCLogDebug("Existing file for %d reference to file ctx %p", thread_id, parent_ctx);
+        SCMutexUnlock(&parent_ctx->threads->mutex);
+        return parent_ctx->threads->lf_slots[thread_id];
+    }
+
+    /* ensure there's a slot for the caller */
+    int new_size = MAX(parent_ctx->threads->count << 1, thread_id + 1);
+    SCLogDebug("Increasing slot count; current %d, trying %d",
+            parent_ctx->threads->count, new_size);
+    LogFileCtx **new_array = SCRealloc(parent_ctx->threads->lf_slots, new_size * sizeof(LogFileCtx *));
+    if (new_array == NULL) {
+        /* Try one more time */
+        SCLogDebug("Unable to increase file context array size to %d; trying %d",
+                new_size, thread_id + 1);
+        new_size = thread_id + 1;
+        new_array = SCRealloc(parent_ctx->threads->lf_slots, new_size * sizeof(LogFileCtx *));
+    }
+
+    if (new_array == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Unable to increase file context array size to %d", new_size);
+        SCMutexUnlock(&parent_ctx->threads->mutex);
+        return NULL;
+    }
+
+    parent_ctx->threads->lf_slots = new_array;
+    /* initialize newly added slots */
+    for (int i = parent_ctx->threads->count; i < new_size; i++) {
+        parent_ctx->threads->lf_slots[i] = NULL;
+    }
+    parent_ctx->threads->count = new_size;
+    LogFileNewThreadedCtx(parent_ctx, parent_ctx->filename, parent_ctx->threads->append, thread_id);
+
+    SCMutexUnlock(&parent_ctx->threads->mutex);
+
+    return parent_ctx->threads->lf_slots[thread_id];
+}
+
+/** \brief LogFileNewThreadedCtx() Create file context for threaded output
+ * \param parent_ctx
+ * \param log_path
+ * \param append
+ * \param thread_id
+ */
+static bool LogFileNewThreadedCtx(LogFileCtx *parent_ctx, const char *log_path, const char *append, int thread_id)
+{
+    LogFileCtx *thread = SCCalloc(1, sizeof(LogFileCtx));
+    if (!thread) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate thread file context slot %d", thread_id);
+        return false;
+    }
+
+    *thread = *parent_ctx;
+    char fname[NAME_MAX];
+    snprintf(fname, sizeof(fname), "%s.%d", log_path, thread_id);
+    SCLogDebug("Thread open -- using name %s [replaces %s]", fname, log_path);
+    thread->fp = SCLogOpenFileFp(fname, append, thread->filemode);
+    if (thread->fp == NULL) {
+        goto error;
+    }
+    thread->filename = SCStrdup(fname);
+    if (!thread->filename) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Unable to duplicate filename for context slot %d", thread_id);
+        goto error;
+    }
+
+    thread->threaded = false;
+    thread->parent = parent_ctx;
+    thread->id = thread_id;
+    thread->Write = SCLogFileWriteNoLock;
+
+    parent_ctx->threads->lf_slots[thread_id] = thread;
+    return true;
+
+error:
+    if (thread->fp) {
+        thread->Close(thread);
+    }
+    if (thread) {
+        SCFree(thread);
+    }
+    parent_ctx->threads->lf_slots[thread_id] = NULL;
+    return false;
+}
+
 /** \brief LogFileFreeCtx() Destroy a LogFileCtx (Close the file and free memory)
- *  \param motcx pointer to the OutputCtx
- *  \retval int 1 if succesful, 0 if error
+ *  \param lf_ctx pointer to the OutputCtx
+ *  \retval int 1 if successful, 0 if error
  *  */
 int LogFileFreeCtx(LogFileCtx *lf_ctx)
 {
@@ -541,13 +734,28 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
         SCReturnInt(0);
     }
 
-    if (lf_ctx->fp != NULL) {
-        SCMutexLock(&lf_ctx->fp_mutex);
-        lf_ctx->Close(lf_ctx);
-        SCMutexUnlock(&lf_ctx->fp_mutex);
+    if (lf_ctx->threaded) {
+        SCMutexDestroy(&lf_ctx->threads->mutex);
+        for(int i = 0; i < lf_ctx->threads->count; i++) {
+            if (lf_ctx->threads->lf_slots[i]) {
+                SCFree(lf_ctx->threads->lf_slots[i]->filename);
+                SCFree(lf_ctx->threads->lf_slots[i]);
+            }
+        }
+        SCFree(lf_ctx->threads->lf_slots);
+        SCFree(lf_ctx->threads->append);
+        SCFree(lf_ctx->threads);
+    } else {
+        SCMutexDestroy(&lf_ctx->fp_mutex);
+        if (lf_ctx->fp != NULL) {
+            lf_ctx->Close(lf_ctx);
+        }
+        if (lf_ctx->parent) {
+            SCMutexLock(&lf_ctx->parent->threads->mutex);
+            lf_ctx->parent->threads->lf_slots[lf_ctx->id] = NULL;
+            SCMutexUnlock(&lf_ctx->parent->threads->mutex);
+        }
     }
-
-    SCMutexDestroy(&lf_ctx->fp_mutex);
 
     if (lf_ctx->prefix != NULL) {
         SCFree(lf_ctx->prefix);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -84,6 +84,9 @@ outputs:
       enabled: @e_enable_evelog@
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
+      # Enable for multi-threaded eve.json output; output files are suffixed
+      # with an identifier, e.g., eve.json.9.
+      #threaded: false
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"


### PR DESCRIPTION
This is a single commit for POC purposes to gather feedback on the
approach and implementation.

Enable `outputs.eve-log.threaded` for lockless output to eve.json
files. A file is created for each thread -- the file is suffixed with
the thread id, e.g., `eve.json.7`. The entirety of `eve.json` files
(`eve.json.*`) must be aggregated and time-stitched into a single
(logical) eve.json container for upstream access.


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3293](https://redmine.openinfosecfoundation.org/issues/3293)

Describe changes:
- New configuration option: `outputs.eve-log.threaded: [on|off]` 
- Log file support for threaded file context containers
- JSON output loggers modified to use threaded/non-threaded file context.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
