### PR TITLE
dcerpc: check app proto for signature keywords

### DIFF
--- a/src/detect-dce-iface.c
+++ b/src/detect-dce-iface.c
@@ -157,7 +157,9 @@ static int DetectDceIfaceSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 {
     SCEnter();
 
-    if (DetectSignatureSetAppProto(s, ALPROTO_DCERPC) != 0) {
+    if (s->alproto != ALPROTO_UNKNOWN && s->alproto != ALPROTO_DCERPC &&
+        s->alproto != ALPROTO_SMB) {
+        SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS, "rule contains conflicting keywords.");
         return -1;
     }
     void *did = rs_dcerpc_iface_parse(arg);

--- a/src/detect-dce-opnum.c
+++ b/src/detect-dce-opnum.c
@@ -129,6 +129,11 @@ static int DetectDceOpnumSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         return -1;
     }
 
+    if (s->alproto != ALPROTO_UNKNOWN && s->alproto != ALPROTO_DCERPC &&
+        s->alproto != ALPROTO_SMB) {
+        SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS, "rule contains conflicting keywords.");
+        return -1;
+    }
     void *dod = rs_dcerpc_opnum_parse(arg);
     if (dod == NULL) {
         SCLogError(SC_ERR_INVALID_SIGNATURE, "Error parsing dce_opnum option in "

--- a/src/detect-dce-stub-data.c
+++ b/src/detect-dce-stub-data.c
@@ -167,6 +167,11 @@ void DetectDceStubDataRegister(void)
 
 static int DetectDceStubDataSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
 {
+    if (s->alproto != ALPROTO_UNKNOWN && s->alproto != ALPROTO_DCERPC &&
+        s->alproto != ALPROTO_SMB) {
+        SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS, "rule contains conflicting keywords.");
+        return -1;
+    }
     if (DetectBufferSetActiveList(s, g_dce_stub_data_buffer_id) < 0)
         return -1;
     return 0;

--- a/src/detect-dce-stub-data.c
+++ b/src/detect-dce-stub-data.c
@@ -1898,6 +1898,18 @@ static int DetectDceStubDataTestParse05(void)
     return result;
 }
 
+// invalid signature because of invalid protocol
+static int DetectDceStubDataTestParse06(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    de_ctx->flags = DE_QUIET;
+    Signature *s = DetectEngineAppendSig(de_ctx,
+            "alert dns any any -> any any dce_stub_data;content:\"0\";");
+    FAIL_IF_NOT_NULL(s);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
 
 #endif
 
@@ -1914,6 +1926,8 @@ static void DetectDceStubDataRegisterTests(void)
                    DetectDceStubDataTestParse04);
     UtRegisterTest("DetectDceStubDataTestParse05",
                    DetectDceStubDataTestParse05);
+    UtRegisterTest("DetectDceStubDataTestParse06",
+                   DetectDceStubDataTestParse06);
 #endif
 
     return;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3826

Describe changes:
- Adds missing protocol checks for DCERPC/SMB keywords

Modifies #5178 by allowing both DCERPC and SMB, and adding a unit test for the invalid signature