### PR TITLE
Clang format proposal v5

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,51 @@
+﻿# Suricata settings as per 
+#   doc/devguide/codebase/code-style.rst
+#
+# This file is set up for clang 9. For the settings available, see
+#   https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+#
+# For the settings available in the latest clang release, see
+#   https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+---
+BasedOnStyle: LLVM
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: Right
+# clang 10: AllowShortBlocksOnASingleLine: Never
+# clang 11: AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+# BreakBeforeBraces: Mozilla is closest, but does not split empty functions/structs
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: true
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+BreakBeforeBraces: Custom
+Cpp11BracedListStyle: false
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+ForEachMacros: ['json_array_foreach', 'json_object_foreach', 'SLIST_FOREACH',
+                'SLIST_FOREACH_PREVPTR', 'LIST_FOREACH', 'SIMPLEQ_FOREACH', 'TAILQ_FOREACH',
+                'TAILQ_FOREACH_SAFE', 'TAILQ_FOREACH_REVERSE', 'CIRCLEQ_FOREACH',
+                'CIRCLEQ_FOREACH_REVERSE', 'CIRCLEQ_FOREACH_SAFE', 'CIRCLEQ_FOREACH_REVERSE_SAFE',
+                'SPLAY_FOREACH, RB_FOREACH', 'RB_FOREACH_FROM', 'RB_FOREACH_SAFE',
+                'RB_FOREACH_REVERSE', 'RB_FOREACH_REVERSE_FROM', 'RB_FOREACH_REVERSE_SAFE' ]
+IndentCaseLabels: true
+IndentWidth: 4
+ReflowComments: true
+SortIncludes: false
+
+# implicit by LLVM style
+#BreakBeforeTernaryOperators: true
+#UseTab: Never
+#TabWidth: 8
+
+...

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,0 +1,142 @@
+name: formatting-check
+
+on:
+  push:
+    # Only run on pushes to pull request branches
+    branches-ignore:
+      - 'master'
+      - 'master-*'
+  pull_request:
+
+jobs:
+
+  # Checking for correct formatting of branch for C code changes
+  check-formatting:
+    name: Formatting Check (clang 9)
+    runs-on: ubuntu-18.04
+    container: ubuntu:18.04
+    continue-on-error: true
+    steps:
+
+      # Cache Rust stuff.
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry
+
+      - name: Install dependencies
+        run: |
+          apt update
+          apt -y install \
+                libpcre3 \
+                libpcre3-dev \
+                build-essential \
+                autoconf \
+                automake \
+                git \
+                libtool \
+                libpcap-dev \
+                libnet1-dev \
+                libyaml-0-2 \
+                libyaml-dev \
+                libcap-ng-dev \
+                libcap-ng0 \
+                libmagic-dev \
+                libnetfilter-queue-dev \
+                libnetfilter-queue1 \
+                libnfnetlink-dev \
+                libnfnetlink0 \
+                libhiredis-dev \
+                libjansson-dev \
+                libpython2.7 \
+                make \
+                python \
+                rustc \
+                software-properties-common \
+                wget \
+                zlib1g \
+                zlib1g-dev
+      - name: Install packages for clang-format 9
+        run: |
+          # no need to install full clang
+          apt-get install -y clang-format-9
+      - name: Install cbindgen
+        run: cargo install --force --debug --version 0.14.1 cbindgen
+      - run: echo "::add-path::$HOME/.cargo/bin"
+      # Checking out the branch is not as simple as "checking out".
+      #
+      # In case master has any new commits since we branched off, github will
+      # automatically add a "merge commit" from our branch to master and check
+      # this out instead of the original last commit on the branch.
+      #
+      # This screws up git clang-format as it'll also format the "merge commit"
+      # and essentially report any formatting issues in the "merge commit".
+      # However, we really don't care about any of the new commits on master.
+      #
+      # There are supposed to be ways to use with/ref to fix that and while
+      # they work perfectly well for pull requests within the forked repo, none
+      # of the ones tried worked for pull requests from forks to the OISF repo.
+      #
+      # My patience simply ran too short to keep on looking. See follow-on
+      # action to manually fix this up.
+      - name: Checkout - might be merge commit!
+        uses: actions/checkout@v1
+        # Use last commit of branch, not potential merge commit!
+        #
+        # This works perfectly well on pull requests within forked repos, but
+        # not for pull requests from forks to the OISF repo as the latter one
+        # does not know the branch (from the forked repo). Argh.
+#        with:
+#          ref: ${{ github.head_ref }} # check out branch
+
+      # Manually ignore the merge commit as none of the with/ref things tried
+      # with actions/checkout seemed to work for pull requests from forks into
+      # the OISF repo.
+      - name: Peel off potential merge request
+        run: |
+          # The "merge commit" has a distinct subject that we can look for.
+          # If we find it, ignore it by checking out the "real last commit".
+          #
+          # Note, github uses the non-abbreviated sha for the commit subject.
+          #
+          # Commit history example in case github added merge, i.e. if you did
+          # git log --pretty=oneline -2:
+          #   sha_1 Merge sha_2 into latest_sha_on_master
+          #   sha_2 This is the real last commit on branch
+          echo "Last two commits on checkout:"
+          git log --pretty=oneline -2
+          last_commit_subject=$(git log --pretty=%s -1)
+          second_last_commit_sha=$(git log --pretty=%H -2 |tail -1)
+          echo "$last_commit_subject" | grep -e "^Merge $second_last_commit_sha into [0-9a-fA-F]*$" > /dev/null 2>&1
+          if [ $? -eq 0 ]; then
+              # Last commit was a merge to master - ignore
+              echo "Found github merge commit - checking out real last commit instead..."
+              git checkout $second_last_commit_sha
+          else
+              echo "No github merge commit found"
+          fi
+        shell: bash {0}
+      - run: git clone https://github.com/OISF/libhtp -b 0.5.x
+      - run: ./autogen.sh
+      - run: ./configure --enable-unittests
+      - name: Check formatting
+        run: |
+          ./scripts/clang-format.sh check-branch --diffstat --show-commits  >> check_formatting_log.txt 2>&1
+          rc=$?
+          if [ $rc -eq 0 ]; then
+              cat check_formatting_log.txt
+              echo "Formatting is following code style guide"
+          elif [ $rc -eq 1 ]; then
+              # limit output as it might be a lot in the worst case
+              tail -n 100 check_formatting_log.txt
+              echo "::error ::Formatting is not following code style guide!"
+              exit 1
+          else
+              cat check_formatting_log.txt
+              # use last output line as error
+              last_line=$(tail -n 1 check_formatting_log.txt)
+              echo "::error ::$last_line"
+              exit 1
+          fi
+        shell: bash {0}

--- a/doc/devguide/codebase/code-style.rst
+++ b/doc/devguide/codebase/code-style.rst
@@ -6,12 +6,191 @@ Suricata uses a fairly strict coding style. This document describes it.
 Formatting
 ~~~~~~~~~~
 
+clang-format
+^^^^^^^^^^^^
+``clang-format`` is configured to help you with formatting C code.
+
+.. Argh, github does not support admonitions such as .. note::
+
++-------------------------------------------------------+
+| **Note**                                              |
+|                                                       |
+| The ``.clang-format`` file requires clang 9 or newer. |
++-------------------------------------------------------+
+
+Format your Changes
+*******************
+Before opening a pull request, please also try to ensure it is formatted
+properly. We use ``clang-format`` for this, which has git integration through the
+``git-clang-format`` script to only format your changes.
+On some systems, it may already be installed (or be installable via your package
+manager). If so, you can simply run it.
+
+It is recommended to format each commit as you go. However, you can always
+reformat your whole branch after the fact.
+
+.. Argh, github does not support admonitions such as .. note::
+
++----------------------------------------------------------------------------+
+| **Note**                                                                   |
+|                                                                            |
+| Depending on your installation, you might have to use the version-specific |
+| ``git clang-format`` in the commands below, e.g. ``git clang-format-9``,   |
+| and possibly even provide the ``clang-format`` binary with                 |
+| ``--binary clang-format-9``.                                               |
+|                                                                            |
+| As an alternative, you can use the provided ``scripts/clang-format.sh``    |
+| that isolates you from the different versions.                             |
++----------------------------------------------------------------------------+
+
+Formatting the most recent commit only
+""""""""""""""""""""""""""""""""""""""
+The following command will format only the code changed in the most recent commit:
+
+.. code-block:: bash
+
+    $ git clang-format HEAD^
+    # Or with script:
+    $ scripts/clang-format.sh commit
+
+Note that this modifies the files, but doesn’t commit them – you’ll likely want to run
+
+.. code-block:: bash
+
+    $ git commit --amend -a
+
+in order to update the last commit with all pending changes.
+
+Formatting code in staging
+""""""""""""""""""""""""""
+The following command will format the changes in staging, i.e. files you ``git add``-ed:
+
+.. code-block:: bash
+
+    $ git clang-format
+    # Or with script:
+    $ scripts/clang-format.sh cached
+
+If you also want to change the unstaged changes, do:
+
+.. code-block:: bash
+
+    $ git clang-format --force
+    # Or with script:
+    $ scripts/clang-format.sh cached --force
+
+Formatting your branch' commits
+"""""""""""""""""""""""""""""""
+In case you have multiple commits on your branch already and forgot to
+format them you can fix that up as well.
+
+The following command will format every commit in your branch off master and
+rewrite history using the existing commit metadata.
+
+Tip: Create a new version of your branch first and run this off the new version.
+
+.. code-block:: bash
+
+    # In a new version of your pull request:
+    $ scripts/clang-format.sh rewrite-branch
+
+You could also add the formatting as an additional commit "at the end". However,
+this is frowned upon. It's preferred to use ``rewrite-branch`` instead.
+
+.. code-block:: bash
+
+    # It's preferred to use rewrite-branch instead of this:
+    $ git clang-format first_commit_on_your_branch^
+    # Or with script:
+    $ scripts/clang-format.sh branch
+
+Note the usage of ``first_commit_on_your_branch^``, not ``master``, to avoid picking up
+new commits on master in case you've updated master since you've branched.
+
+Check formatting
+""""""""""""""""
+Check if your branch changes' formatting is correct with:
+
+.. code-block:: bash
+
+    $ scripts/clang-format.sh check-branch
+
+Add the ``--diffstat`` parameter if you want to see the files needing formatting.
+Add the ``--diff`` parameter if you want to see the actual diff of the formatting
+change.
+
+Formatting a whole file
+"""""""""""""""""""""""
+
+.. Argh, github does not support admonitions such as .. note::
+
++--------------------------------------------------------------------+
+| **Note**                                                           |
+|                                                                    |
+| Do not reformat whole files by default, i.e. do not use            |
+| ``clang-format`` proper in general.                                |
++--------------------------------------------------------------------+
+
+If you were ever to do so, formatting changes of existing code with clang-format
+shall be a different commit and must not be mixed with actual code changes.
+
+.. code-block:: bash
+
+    $ clang-format -i {file}
+
+Disabling clang-format
+**********************
+
+There might be times, where the clang-format's formatting might not please.
+This might mostly happen with macros, arrays (single or multi-dimensional ones),
+struct initialization, or where one manually formatted code.
+
+You can always disable clang-format.
+
+.. code-block:: c
+
+    /* clang-format off */
+    #define APP_LAYER_INCOMPLETE(c, n) (AppLayerResult){1, (c), (n)}
+    /* clang-format on */
+
+Installing clang-format and git-clang-format
+********************************************
+clang-format 9 or newer is required.
+
+On ubuntu 18.04:
+
+- It is sufficient to only install clang-format, e.g.
+
+    .. code-block:: bash
+
+        $ sudo apt-get install clang-format-9
+
+- See http://apt.llvm.org for other releases in case the clang-format version
+  is not found in the default repos.
+
+On fedora:
+
+- Install the ``clang``  and ``git-clang-format`` packages with
+
+    .. code-block:: bash
+
+        $ sudo dnf install clang git-clang-format
+
+
 Line length
 ^^^^^^^^^^^
 
-There is a soft limit of ~80 characters.
+Limit line lengths to 100 characters.
 
-When wrapping lines that are too long, they should be indented at least 8 spaces from previous line. You should attempt to wrap the minimal portion of the line to meet the 80 character limit.
+When wrapping lines that are too long, they should be indented at least 8
+spaces from previous line. You should attempt to wrap the minimal portion of
+the line to meet the 100 character limit.
+
+clang-format:
+ - ColumnLimit: 100
+ - ContinuationIndentWidth: 8
+ - ReflowComments: true
+
 
 Indent
 ^^^^^^
@@ -21,7 +200,7 @@ We use 4 space indentation.
 .. code-block:: c
 
     int DecodeEthernet(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
-        uint8_t *pkt, uint16_t len, PacketQueue *pq)
+            uint8_t *pkt, uint16_t len, PacketQueue *pq)
     {
         SCPerfCounterIncr(dtv->counter_eth, tv->sc_perf_pca);
 
@@ -29,6 +208,35 @@ We use 4 space indentation.
             ENGINE_SET_INVALID_EVENT(p, ETHERNET_PKT_TOO_SMALL);
             return TM_ECODE_FAILED;
         }
+
+        ...
+
+        DecodeNetworkLayer(tv, dtv, SCNtohs(p->ethh->eth_type), p,
+                pkt + ETHERNET_HEADER_LEN, len - ETHERNET_HEADER_LEN);
+
+        return TM_ECODE_OK;
+    }
+
+Use 8 space indentation when wrapping function parameters, loops and if statements.
+
+Use 4 space indentation when wrapping variable definitions.
+
+.. code-block:: c
+
+    const SCPlugin PluginSpec = {
+        .name = OUTPUT_NAME,
+        .author = "Some Developer",
+        .license = "GPLv2",
+        .Init = TemplateInit,
+    };
+
+
+clang-format:
+ - AlignAfterOpenBracket: DontAlign
+ - Cpp11BracedListStyle: false
+ - IndentWidth: 4
+ - TabWidth: 8 [llvm]_
+ - UseTab: Never [llvm]_
 
 Braces
 ^^^^^^
@@ -42,14 +250,25 @@ Functions should have the opening brace on a newline:
         DoSomething();
     }
 
+Note: this is a fairly new requirement, so you'll encounter a lot of non-compliant code.
 
-Control statements should have the opening brace on the same line:
+Control and loop statements should have the opening brace on the same line:
 
 .. code-block:: c
 
     if (unlikely(len < ETHERNET_HEADER_LEN)) {
         ENGINE_SET_INVALID_EVENT(p, ETHERNET_PKT_TOO_SMALL);
         return TM_ECODE_FAILED;
+    }
+
+    for (ascii_code = 0; ascii_code < 256; ascii_code++) {
+        ctx->goto_table[ctx->state_count][ascii_code] = SC_AC_FAIL;
+    }
+
+    while (funcs != NULL) {
+        temp = funcs;
+        funcs = funcs->next;
+        SCFree(temp);
     }
 
 Opening and closing braces go on the same line as as the _else_ (also known as a "cuddled else").
@@ -62,6 +281,41 @@ Opening and closing braces go on the same line as as the _else_ (also known as a
         DoThat();
     }
 
+Structs, unions and enums should have the opening brace on the same line:
+
+.. code-block:: c
+
+    union {
+        TCPVars tcpvars;
+        ICMPV4Vars icmpv4vars;
+        ICMPV6Vars icmpv6vars;
+    } l4vars;
+
+    struct {
+        uint8_t type;
+        uint8_t code;
+    } icmp_s;
+
+    enum {
+        DETECT_TAG_TYPE_SESSION,
+        DETECT_TAG_TYPE_HOST,
+        DETECT_TAG_TYPE_MAX
+    };
+
+clang-format:
+ - BreakBeforeBraces: Custom [breakbeforebraces]_
+ - BraceWrapping:
+
+   - AfterClass:      true
+   - AfterControlStatement: false
+   - AfterEnum:       false
+   - AfterFunction:   true
+   - AfterStruct:     false
+   - AfterUnion:      false
+   - AfterExternBlock: true
+   - BeforeElse:      false
+   - IndentBraces:    false
+
 Flow
 ~~~~
 
@@ -73,6 +327,24 @@ Don't use conditions and statements on the same line. E.g.
 
     if (a)
         b = a; // <- right
+
+    for (int i = 0; i < 32; ++i) f(i); // <- wrong
+
+    for (int i = 0; i < 32; ++i)
+        f(i); // <- right
+
+Don't put short or empty functions and structs on one line.
+
+.. code-block:: c
+
+    void empty_function(void)
+    {
+    }
+
+    int short_function(void)
+    {
+        return 1;
+    }
 
 Don't use unnecessary branching. E.g.:
 
@@ -93,6 +365,61 @@ Can be written as:
         goto error;
     }
     a = b;
+
+clang-format:
+ - AllowShortBlocksOnASingleLine: false [llvm]_
+ - AllowShortBlocksOnASingleLine: Never [llvm]_ (breaking change in clang 10!) [clang10]_
+ - AllowShortEnumsOnASingleLine: false [clang11]_
+ - AllowShortFunctionsOnASingleLine: None
+ - AllowShortIfStatementsOnASingleLine: Never [llvm]_
+ - AllowShortLoopsOnASingleLine: false [llvm]_
+ - BreakBeforeBraces: Custom [breakbeforebraces]_
+ - BraceWrapping:
+
+   - SplitEmptyFunction: true
+   - SplitEmptyRecord: true
+
+Alignment
+~~~~~~~~~
+
+Pointers
+^^^^^^^^
+Pointers shall be right aligned.
+
+.. code-block:: c
+
+    void *ptr;
+    void f(int *a, const char *b);
+    void (*foo)(int *);
+
+clang-format:
+ - PointerAlignment: Right
+ - DerivePointerAlignment: false
+
+Declarations and Comments
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Trailing comments should be aligned for consecutive lines.
+
+.. code-block:: c
+
+    struct bla {
+        int a;       /* comment */
+        unsigned bb; /* comment */
+        int *ccc;    /* comment */
+    };
+
+    void alignment()
+    {
+        // multiple consecutive vars
+        int a = 13;           /* comment */
+        int32_t abc = 1312;   /* comment */
+        int abcdefghikl = 13; /* comment */
+    }
+
+clang-format:
+ - AlignConsecutiveAssignments: false
+ - AlignConsecutiveDeclarations: false
+ - AlignTrailingComments: true
 
 Functions
 ~~~~~~~~~
@@ -121,20 +448,6 @@ inline
 
 The inlining of functions should be used only in critical paths.
 
-curly braces / brackets
-^^^^^^^^^^^^^^^^^^^^^^^
-
-Functions should have the opening bracket on a newline:
-
-.. code-block:: c
-
-    int SomeFunction(void)
-    {
-        DoSomething();
-    }
-
-Note: this is a fairly new requirement, so you'll encounter a lot of non-compliant code.
-
 Variables
 ~~~~~~~~~
 
@@ -159,7 +472,34 @@ TODO
 Macros
 ~~~~~~
 
-TODO
+Macro names are ALL_CAPS_WITH_UNDERSCORES.
+Enclose parameters in parens on each usage inside the macro.
+
+Align macro values on consecutive lines.
+
+.. code-block:: c
+
+    #define ACTION_ALERT       0x01
+    #define ACTION_DROP        0x02
+    #define ACTION_REJECT      0x04
+    #define ACTION_REJECT_DST  0x08
+    #define ACTION_REJECT_BOTH 0x10
+    #define ACTION_PASS        0x20
+
+Align escape for multi-line macros right-most at ColumnLimit.
+
+.. code-block:: c
+
+    #define MULTILINE_DEF(a, b)                                              \
+        if ((a) > 2) {                                                       \
+            auto temp = (b) / 2;                                             \
+            (b) += 10;                                                       \
+            someFunctionCall((a), (b));                                      \
+        }
+
+clang-format:
+ - AlignConsecutiveMacros: true [clang9]_
+ - AlignEscapedNewlines: Right
 
 Comments
 ~~~~~~~~
@@ -205,7 +545,24 @@ Some cases have a multi-layer prefix, e.g. ``util-mpm-ac.c``
 Enums
 ~~~~~
 
-TODO
+Use a common prefix for all enum values. Value names are ALL_CAPS_WITH_UNDERSCORES.
+
+Put each enum values on a separate line.
+Tip: Add a trailing comma to the last element to force "one-value-per-line"
+formatting in clang-format.
+
+.. code-block:: c
+
+    enum { VALUE_ONE, VALUE_TWO };  // <- wrong
+
+    // right
+    enum {
+        VALUE_ONE,
+        VALUE_TWO, // <- force one-value-per-line
+    };
+
+clang-format:
+ - AllowShortEnumsOnASingleLine: false [clang11]_
 
 Structures and typedefs
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -241,6 +598,34 @@ Fall through cases will be commented with ``/* fall through */``. E.g.:
             default:
                 default_packet_size = DEFAULT_PACKET_SIZE;
 
+
+Do not put short case labels on one line.
+Put opening brace on same line as case statement.
+
+.. code-block:: c
+
+    switch (a) {
+        case 13: {
+            int a = bla();
+            break;
+        }
+        case 15:
+            blu();
+            break;
+        default:
+            gugus();
+    }
+
+
+clang-format:
+ - IndentCaseLabels: true
+ - IndentCaseBlocks: false [clang11]_
+ - AllowShortCaseLabelsOnASingleLine: false [llvm]_
+ - BreakBeforeBraces: Custom [breakbeforebraces]_
+ - BraceWrapping:
+
+   - AfterCaseLabel:  false (default)
+
 const
 ~~~~~
 
@@ -275,10 +660,38 @@ Goto statements should be used with care. Generally, we use it primarily for err
         return NULL;
     }
 
+Put goto labels at brace level.
+
+.. code-block:: c
+
+    int goto_style_nested()
+    {
+        if (foo()) {
+        label1:
+            bar();
+        }
+
+    label2:
+        return 1;
+    }
+
+clang-format:
+ - IndentGotoLabels: true (default) [clang10]_
+
+Includes
+~~~~~~~~
+
+TODO
+
+A .c file shall include it's own header first.
+
+clang-format:
+ - SortIncludes: false
+
 Unittests
 ~~~~~~~~~
 
-When writing unittests that use  when using a data array containing a protocol message, please put an explanatory comment that contain the readable content of the message
+When writing unittests that use a data array containing a protocol message, please put an explanatory comment that contain the readable content of the message
 
 So instead of:
 
@@ -332,3 +745,11 @@ Banned functions
 
 Also, check the existing code. If yours is wildly different, it's wrong.
 Example: https://github.com/oisf/suricata/blob/master/src/decode-ethernet.c
+
+.. rubric:: Footnotes
+
+.. [llvm] Default LLVM clang-format Style
+.. [clang9] Requires clang 9
+.. [clang10] Requires clang 10
+.. [clang11] Requires clang 11
+.. [breakbeforebraces] BreakBeforeBraces: Mozilla is closest, but does not split empty functions/structs

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -1,0 +1,642 @@
+#!/bin/bash
+#
+# Script to clang-format suricata C code changes
+#
+# Rewriting branch parts of it is inspired by
+# https://www.thetopsites.net/article/53885283.shtml
+
+#set -x
+
+# We verify the minimal clang-format version for better error messaging as older clang-format
+# will barf on unknown settings with a generic error.
+CLANG_FORMAT_REQUIRED_VERSION=9
+
+EXIT_CODE_ERROR=2
+EXIT_CODE_FORMATTING_REQUIRED=1
+EXIT_CODE_OK=0
+
+PRINT_DEBUG=0
+# Debug output if PRINT_DEBUG is 1
+function Debug {
+    if [ $PRINT_DEBUG -ne 0 ]; then
+        echo "DEBUG: $@"
+    fi
+}
+
+# ignore text formatting by default
+bold=
+normal=
+italic=
+# $TERM is set to dumb when calling scripts in github actions.
+if [ -n "$TERM" -a "$TERM" != "dumb" ]; then
+    Debug "TERM: '$TERM'"
+    # tput, albeit unlikely, might not be installed
+    command -v tput >/dev/null 2>&1 # built-in which
+    if [ $? -eq 0 ]; then
+        Debug "Setting text formatting"
+        bold=$(tput bold)
+        normal=$(tput sgr0)
+        italic=$(echo -e '\E[3m')
+    fi
+else
+    Debug "No text formatting"
+fi
+
+EXEC=$(basename $0)
+pushd . >/dev/null # we might change dir - save so that we can revert
+
+USAGE=$(cat << EOM
+usage: $EXEC --help
+       $EXEC help <command>
+       $EXEC <command> [<args>]
+
+Format selected changes using clang-format.
+
+Note: This does ONLY format the changed code, not the whole file! It
+uses ${italic}git-clang-format${normal} for the actual formatting. If you want to format
+whole files, use ${italic}clang-format -i <file>${normal}.
+
+It auto-detects the correct clang-format version and compared to ${italic}git-clang-format${normal}
+proper it provides additional functionality such as reformatting of all commits on a branch.
+
+Commands used in various situations:
+
+Formatting branch changes (compared to master):
+    branch          Format all changes in branch as additional commit
+    rewrite-branch  Format every commit in branch and rewrite history
+
+Formatting single changes:
+    cached          Format changes in git staging
+    commit          Format changes in most recent commit
+
+Checking if formatting is correct:
+    check-branch    Checks if formatting for branch changes is correct
+
+More info an a command:
+    help            Display more info for a particular <command>
+EOM
+)
+
+HELP_BRANCH=$(cat << EOM
+${bold}NAME${normal}
+        $EXEC branch - Format all changes in branch as additional commit
+
+${bold}SYNOPSIS${normal}
+        $EXEC branch [--force]
+
+${bold}DESCRIPTION${normal}
+        Format all changes in your branch enabling you to add it as an additional
+        formatting commit. It automatically detects all commits on your branch.
+
+        Requires that all changes are committed unless --force is provided.
+
+        You will need to commit the reformatted code.
+
+        This is equivalent to calling:
+            $ git clang-format --extensions c,h [--force] first_commit_on_current_branch^
+
+${bold}OPTIONS${normal}
+        -f, --force
+            Allow changes to unstaged files.
+
+${bold}EXAMPLES${normal}
+        On your branch whose changes you want to reformat:
+
+            $ $EXEC branch
+
+${bold}EXIT STATUS${normal}
+       $EXEC exits with a status of zero if the changes were successfully
+       formatted, or if no formatting change was required. A status of two will
+       be returned if any errors were encountered.
+EOM
+)
+
+HELP_CACHED=$(cat << EOM
+${bold}NAME${normal}
+        $EXEC cached - Format changes in git staging
+
+${bold}SYNOPSIS${normal}
+        $EXEC cached [--force]
+
+${bold}DESCRIPTION${normal}
+        Format staged changes using clang-format.
+
+        You will need to commit the reformatted code.
+
+        This is equivalent to calling:
+            $ git clang-format --extensions c,h [--force]
+
+${bold}OPTIONS${normal}
+        -f, --force
+            Allow changes to unstaged files.
+
+${bold}EXAMPLES${normal}
+        Format all changes in staging, i.e. in files added with ${italic}git add <file>${normal}.
+
+            $ $EXEC cached
+
+${bold}EXIT STATUS${normal}
+       $EXEC exits with a status of zero if the changes were successfully
+       formatted, or if no formatting change was required. A status of two will
+       be returned if any errors were encountered.
+EOM
+)
+
+HELP_CHECK_BRANCH=$(cat << EOM
+${bold}NAME${normal}
+        $EXEC check-branch - Checks if formatting for branch changes is correct
+
+${bold}SYNOPSIS${normal}
+        $EXEC check-branch [--show-commits] [--quiet]
+        $EXEC check-branch --diff [--show-commits] [--quiet]
+        $EXEC check-branch --diffstat [--show-commits] [--quiet]
+
+${bold}DESCRIPTION${normal}
+        Check if all branch changes are correctly formatted.
+
+        Note, it does not check every commit's formatting, but rather the
+        overall diff between HEAD and master.
+
+        Returns 1 if formatting is off, 0 if it is correct.
+
+${bold}OPTIONS${normal}
+        -d, --diff
+            Print formatting diff, i.e. diff of each file with correct formatting.
+        -s, --diffstat
+            Print formatting diffstat output, i.e. files with wrong formatting. 
+        -c, --show-commits
+            Print branch commits.
+        -q, --quiet
+            Do not print any error if formatting is off, only set exit code.
+
+${bold}EXIT STATUS${normal}
+       $EXEC exits with a status of zero if the formatting is correct. A
+       status of one will be returned if the formatting is not correct. A status
+       of two will be returned if any errors were encountered.
+EOM
+)
+
+HELP_COMMIT=$(cat << EOM
+${bold}NAME${normal}
+        $EXEC commit - Format changes in most recent commit
+
+${bold}SYNOPSIS${normal}
+        $EXEC commit
+
+${bold}DESCRIPTION${normal}
+        Format changes in most recent commit using clang-format.
+
+        You will need to commit the reformatted code.
+
+        This is equivalent to calling:
+            $ git clang-format --extensions c,h HEAD^
+
+${bold}EXAMPLES${normal}
+        Format all changes in most recent commit:
+
+            $ $EXEC commit
+
+        Note that this modifies the files, but doesn’t commit them – you’ll likely want to run
+
+            $ git commit --amend -a
+
+${bold}EXIT STATUS${normal}
+       $EXEC exits with a status of zero if the changes were successfully
+       formatted, or if no formatting change was required. A status of two will
+       be returned if any errors were encountered.
+EOM
+)
+
+HELP_REWRITE_BRANCH=$(cat << EOM
+${bold}NAME${normal}
+        $EXEC rewrite-branch - Format every commit in branch and rewrite history
+
+${bold}SYNOPSIS${normal}
+        $EXEC rewrite-branch
+
+${bold}DESCRIPTION${normal}
+        Reformat all commits in branch off master one-by-one. This will ${bold}rewrite
+        the branch history${normal} using the existing commit metadata!
+        It automatically detects all commits on your branch.
+
+        This is handy in case you want to format all of your branch commits
+        while keeping the commits.
+
+        This can also be helpful if you have multiple commits in your branch and
+        the changed files have been reformatted, i.e. where a git rebase would
+        fail in many ways over-and-over again.
+
+        You can achieve the same manually on a separate branch by:
+        ${italic}git checkout -n <original_commit>${normal},
+        ${italic}git clang-format${normal} and ${italic}git commit${normal} for each original commit in your branch.
+
+${bold}OPTIONS${normal}
+        None
+
+${bold}EXAMPLES${normal}
+        In your branch that you want to reformat. Commit all your changes prior
+        to calling:
+
+            $ $EXEC rewrite-branch
+
+${bold}EXIT STATUS${normal}
+       $EXEC exits with a status of zero if the changes were successfully
+       formatted, or if no formatting change was required. A status of two will
+       be returned if any errors were encountered.
+EOM
+)
+
+# Error message on stderr
+function Error {
+    echo "${bold}ERROR${normal}: $@" 1>&2
+}
+
+# Exit program (and reset path)
+function ExitWith {
+    popd >/dev/null # we might have changed dir
+
+    if [ $# -ne 1 ]; then
+        # Huh? No exit value provided?
+        Error "Internal: ExitWith requires parameter"
+        exit $EXIT_CODE_ERROR
+    else
+        exit $1
+    fi
+}
+
+# Failure exit with error message
+function Die {
+    Error $@
+    ExitWith $EXIT_CODE_ERROR
+}
+
+# Ensure required program exists. Exits with failure if not found.
+# Call with
+#   RequireProgram ENVVAR_TO_SET program ...
+# One can provide multiple alternative programs. Returns first program found in
+# provided list.
+function RequireProgram {
+    if [ $# -lt 2 ]; then
+        Die "Internal - RequireProgram: Need env and program parameters"
+    fi
+
+    # eat variable to set
+    local envvar=$1
+    shift
+
+    for program in $@; do
+        command -v $program >/dev/null 2>&1 # built-in which
+        if [ $? -eq 0 ]; then
+            eval "$envvar=$(command -v $program)"
+            return
+        fi
+    done
+
+    if [ $# -eq 1 ]; then
+        Die "$1 not found"
+    else
+        Die "None of $@ found"
+    fi
+}
+
+# Make sure we are running from the top-level git directory.
+# Same approach as for setup-decoder.sh. Good enough.
+# We could probably use git rev-parse --show-toplevel to do so, as long as we
+# handle the libhtp subfolder correctly.
+function SetTopLevelDir {
+    if [ -e ./src/suricata.c ]; then
+        # Do nothing.
+        true
+    elif [ -e ./suricata.c -o -e ../src/suricata.c ]; then
+        cd ..
+    else
+        Die "This does not appear to be a suricata source directory."
+    fi
+}
+
+# print help for given command
+function HelpCommand {
+    local help_command=$1
+    local HELP_COMMAND=$(echo "HELP_$help_command" | sed "s/-/_/g" | tr [:lower:] [:upper:])
+    case $help_command in
+        branch|cached|check-branch|commit|rewrite-branch)
+            echo "${!HELP_COMMAND}";
+            ;;
+
+        "")
+            echo "$USAGE";
+            ;;
+
+        *)
+            echo "$USAGE";
+            echo "";
+            Die "No manual entry for $help_command"
+            ;;
+    esac
+}
+
+# Return first commit of branch (off master).
+#
+# Use $first_commit^ if you need the commit on master we branched off.
+# Do not compare with master directly as it will diff with the latest commit
+# on master. If our branch has not been rebased on the latest master, this
+# would result in including all new commits on master!
+function FirstCommitOfBranch {
+    local first_commit=$(git rev-list origin/master..HEAD | tail -n 1)
+    echo $first_commit
+}
+
+# Check if branch formatting is correct.
+# Compares with master branch as baseline which means it's limited to branches
+# other than master.
+# Exits with 1 if not, 0 if ok.
+function CheckBranch {
+    # check parameters
+    local quiet=0
+    local show_diff=0
+    local show_diffstat=0
+    local show_commits=0
+    local git_clang_format="$GIT_CLANG_FORMAT --diff"
+    while [[ $# -gt 0 ]]
+    do
+    case "$1" in
+        -q|--quiet)
+            quiet=1
+            shift
+            ;;
+
+        -d|--diff)
+            show_diff=1
+            shift
+            ;;
+
+        -s|--diffstat)
+            show_diffstat=1
+            git_clang_format="$GIT_CLANG_FORMAT_DIFFSTAT --diffstat"
+            shift
+            ;;
+
+        -c|--show-commits)
+            show_commits=1
+            shift
+            ;;
+
+        *)    # unknown option
+            echo "$HELP_CHECK_BRANCH";
+            echo "";
+            Die "Unknown $command option: $1"
+            ;;
+    esac
+    done
+
+    if [ $show_diffstat -eq 1 -a $show_diff -eq 1 ]; then
+        echo "$HELP_CHECK_BRANCH";
+        echo "";
+        Die "Cannot combine $command options --diffstat with --diff"
+    fi
+
+    # Find first commit on branch. Use $first_commit^ if you need the
+    # commit on master we branched off.
+    local first_commit=$(FirstCommitOfBranch)
+
+    # git-clang-format is a python script that does not like SIGPIPE shut down
+    # by "| head" prematurely. Use work-around with writing to tmpfile first.
+    local format_changes="$git_clang_format --extensions c,h $first_commit^"
+    local tmpfile=$(mktemp /tmp/clang-format.check.XXXXXX)
+    $format_changes > $tmpfile
+    local changes=$(cat $tmpfile | head -1)
+    if [ $show_diff -eq 1 -o $show_diffstat -eq 1 ]; then
+        cat $tmpfile
+        echo ""
+    fi
+    rm $tmpfile
+
+    # Branch commits can help with trouble shooting. Print after diff/diffstat
+    # as output might be tail'd
+    if [ $show_commits -eq 1 ]; then
+        echo "Commits on branch (new -> old):"
+        git log --oneline $first_commit^..HEAD
+        echo ""
+    else
+        if [ $quiet -ne 1 ]; then
+            echo "First commit on branch: $first_commit"
+        fi
+    fi
+
+    # Exit code of git-clang-format is useless as it's 0 no matter if files
+    # changed or not. Check actual output. Not ideal, but works.
+    if [ "${changes}" != "no modified files to format" -a \
+         "${changes}" != "clang-format did not modify any files" ]; then
+        if [ $quiet -ne 1 ]; then
+            Error "Branch requires formatting"
+            Debug "View required changes with clang-format: ${italic}$format_changes${normal}"
+            Error "View required changes with: ${italic}$EXEC $command --diff${normal}"
+            Error "Use ${italic}$EXEC rewrite-branch${normal} or ${italic}$EXEC branch${normal} to fix formatting"
+            ExitWith $EXIT_CODE_FORMATTING_REQUIRED
+        else
+            return $EXIT_CODE_FORMATTING_REQUIRED
+        fi
+    else
+        if [ $quiet -ne 1 ]; then
+            echo "no modified files to format"
+        fi
+        return $EXIT_CODE_OK
+    fi
+}
+
+# Reformat all changes in branch as a separate commit.
+function ReformatBranch {
+    # check parameters
+    local with_unstaged=
+    if [ $# -gt 1 ]; then
+        echo "$HELP_BRANCH";
+        echo "";
+        Die "Too many $command options: $1"
+    elif [ $# -eq 1 ]; then
+        if [ "$1" == "--force" -o  "$1" == "-f" ]; then
+            with_unstaged='--force'
+        else
+            echo "$HELP_BRANCH";
+            echo "";
+            Die "Unknown $command option: $1"
+        fi
+    fi
+
+    # Find first commit on branch. Use $first_commit^ if you need the
+    # commit on master we branched off.
+    local first_commit=$(FirstCommitOfBranch)
+    echo "First commit on branch: $first_commit"
+
+    $GIT_CLANG_FORMAT --style file --extensions c,h $with_unstaged $first_commit^
+    if [ $? -ne 0 ]; then
+        Die "Cannot reformat branch. git clang-format failed"
+    fi
+}
+
+# Reformat changes in commit
+function ReformatCommit {
+    # check parameters
+    local commit=HEAD^ # only most recent for now
+    if [ $# -gt 0 ]; then
+        echo "$HELP_MOST_RECENT";
+        echo "";
+        Die "Too many $command options: $1"
+    fi
+
+    $GIT_CLANG_FORMAT --style file --extensions c,h $commit
+    if [ $? -ne 0 ]; then
+        Die "Cannot reformat most recent commit. git clang-format failed"
+    fi
+}
+
+# Reformat currently staged changes
+function ReformatCached {
+    # check parameters
+    local with_unstaged=
+    if [ $# -gt 1 ]; then
+        echo "$HELP_CACHED";
+        echo "";
+        Die "Too many $command options: $1"
+    elif [ $# -eq 1 ]; then
+        if [ "$1" == "--force" -o  "$1" == "-f" ]; then
+            with_unstaged='--force'
+        else
+            echo "$HELP_CACHED";
+            echo "";
+            Die "Unknown $command option: $1"
+        fi
+    fi
+
+    $GIT_CLANG_FORMAT --style file --extensions c,h $with_unstaged
+    if [ $? -ne 0 ]; then
+        Die "Cannot reformat staging. git clang-format failed"
+    fi
+}
+
+# Reformat all commits of a branch (compared with master) and rewrites
+# the history with the formatted commits one-by-one.
+# This is helpful for quickly reformatting branches with multiple commits,
+# or where the master version of a file has been reformatted.
+#
+# You can achieve the same manually by git checkout -n <commit>, git clang-format
+# for each commit in your branch.
+function ReformatCommitsOnBranch {
+    # Do not allow rewriting of master.
+    # CheckBranch below will also tell us there are no changes compared with
+    # master, but let's make this foolproof and explicit here.
+    local current_branch=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$current_branch" == "master" ]; then
+        Die "Must not rewrite master branch history."
+    fi
+
+    CheckBranch "--quiet"
+    if [ $? -eq 0 ]; then
+        echo "no modified files to format"
+    else
+        # Only rewrite if there are changes
+        # Squelch warning. Our usage of git filter-branch is limited and should be ok.
+        # Should investigate using git-filter-repo in the future instead.
+        export FILTER_BRANCH_SQUELCH_WARNING=1
+
+        # Find first commit on branch. Use $first_commit^ if you need the
+        # commit on master we branched off.
+        local first_commit=$(FirstCommitOfBranch)
+        echo "First commit on branch: $first_commit"
+        # Use --force in case it's run a second time on the same branch
+        git filter-branch --force --tree-filter "$GIT_CLANG_FORMAT $first_commit^" -- $first_commit..HEAD
+        if [ $? -ne 0 ]; then
+            Die "Cannot rewrite branch. git filter-branch failed"
+        fi
+    fi
+}
+
+if [ $# -eq 0 ]; then
+    echo "$USAGE";
+    Die "Missing arguments. Call with one argument"
+fi
+
+SetTopLevelDir
+
+RequireProgram GIT git
+# ubuntu uses clang-format-{version} name for newer versions. fedora not.
+RequireProgram GIT_CLANG_FORMAT git-clang-format-11 git-clang-format-10 git-clang-format-9 git-clang-format
+GIT_CLANG_FORMAT_BINARY=clang-format
+if [[ $GIT_CLANG_FORMAT =~ .*git-clang-format-11$ ]]; then
+    # default binary is clang-format, specify the correct version.
+    # Alternative: git config clangformat.binary "clang-format-11"
+    GIT_CLANG_FORMAT_BINARY="clang-format-11"
+elif [[ $GIT_CLANG_FORMAT =~ .*git-clang-format-10$ ]]; then
+    # default binary is clang-format, specify the correct version.
+    # Alternative: git config clangformat.binary "clang-format-10"
+    GIT_CLANG_FORMAT_BINARY="clang-format-10"
+elif [[ $GIT_CLANG_FORMAT =~ .*git-clang-format-9$ ]]; then
+    # default binary is clang-format, specify the correct version.
+    # Alternative: git config clangformat.binary "clang-format-9"
+    GIT_CLANG_FORMAT_BINARY="clang-format-9"
+elif [[ $GIT_CLANG_FORMAT =~ .*git-clang-format$ ]]; then
+    Debug "Using regular clang-format"
+else
+    Debug "Internal: unhandled clang-format version"
+fi
+
+# enforce minimal clang-format version as required by .clang-format
+clang_format_version=$($GIT_CLANG_FORMAT_BINARY --version | sed 's/.*clang-format version \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/')
+Debug "Found clang-format version: $clang_format_version"
+clang_format_version_major=$(echo $clang_format_version | sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\).*/\1/')
+Debug "clang-format version major: $clang_format_version_major"
+if [ $((clang_format_version_major + 0)) -lt $((CLANG_FORMAT_REQUIRED_VERSION + 0)) ]; then
+    Die "Require clang version $CLANG_FORMAT_REQUIRED_VERSION, found $clang_format_version_major ($clang_format_version)."
+fi
+
+# overwite git-clang-version for --diffstat as upstream does not have that yet
+RequireProgram GIT_CLANG_FORMAT_DIFFSTAT scripts/git-clang-format-custom
+if [ "$GIT_CLANG_FORMAT_BINARY" != "clang-format" ]; then
+    GIT_CLANG_FORMAT="$GIT_CLANG_FORMAT --binary $GIT_CLANG_FORMAT_BINARY"
+    GIT_CLANG_FORMAT_DIFFSTAT="$GIT_CLANG_FORMAT_DIFFSTAT --binary $GIT_CLANG_FORMAT_BINARY"
+fi
+Debug "Using $GIT_CLANG_FORMAT"
+Debug "Using $GIT_CLANG_FORMAT_DIFFSTAT"
+
+command_rc=0
+command=$1
+case $command in
+    branch)
+        shift;
+        ReformatBranch "$@";
+        ;;
+  
+    check-branch)
+        shift;
+        CheckBranch "$@";
+        command_rc=$?;
+        ;;
+
+    cached)
+        shift;
+        ReformatCached "$@";
+        ;;
+
+    commit)
+        shift;
+        ReformatCommit "$@";
+        ;;
+
+    rewrite-branch)
+        ReformatCommitsOnBranch
+        ;;
+
+    help)
+        shift;
+        HelpCommand $1;
+        ;;
+
+    -h|--help)
+        echo "$USAGE";
+        ;;
+
+    *)
+        Die "$EXEC: '$command' is not a command. See '$EXEC --help'"
+        ;;
+esac
+
+ExitWith $command_rc

--- a/scripts/git-clang-format-custom
+++ b/scripts/git-clang-format-custom
@@ -1,0 +1,600 @@
+#!/usr/bin/env python
+# Copy of https://github.com/llvm-mirror/clang/blob/master/tools/clang-format/git-clang-format
+# Adds a --diffstat option to show the files needing formatting.
+# This change will be upstreamed, but the current git-clang-format does not
+# have it yet. We use it in the internal scripts/clang-format.sh
+#
+#===- git-clang-format - ClangFormat Git Integration ---------*- python -*--===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===------------------------------------------------------------------------===#
+
+r"""
+clang-format git integration
+============================
+
+This file provides a clang-format integration for git. Put it somewhere in your
+path and ensure that it is executable. Then, "git clang-format" will invoke
+clang-format on the changes in current files or a specific commit.
+
+For further details, run:
+git clang-format -h
+
+Requires Python 2.7 or Python 3
+"""
+
+from __future__ import absolute_import, division, print_function
+import argparse
+import collections
+import contextlib
+import errno
+import os
+import re
+import subprocess
+import sys
+
+usage = 'git clang-format [OPTIONS] [<commit>] [<commit>] [--] [<file>...]'
+
+desc = '''
+If zero or one commits are given, run clang-format on all lines that differ
+between the working directory and <commit>, which defaults to HEAD.  Changes are
+only applied to the working directory.
+
+If two commits are given (requires --diff), run clang-format on all lines in the
+second <commit> that differ from the first <commit>.
+
+The following git-config settings set the default of the corresponding option:
+  clangFormat.binary
+  clangFormat.commit
+  clangFormat.extensions
+  clangFormat.style
+'''
+
+# Name of the temporary index file in which save the output of clang-format.
+# This file is created within the .git directory.
+temp_index_basename = 'clang-format-index'
+
+
+Range = collections.namedtuple('Range', 'start, count')
+
+
+def main():
+  config = load_git_config()
+
+  # In order to keep '--' yet allow options after positionals, we need to
+  # check for '--' ourselves.  (Setting nargs='*' throws away the '--', while
+  # nargs=argparse.REMAINDER disallows options after positionals.)
+  argv = sys.argv[1:]
+  try:
+    idx = argv.index('--')
+  except ValueError:
+    dash_dash = []
+  else:
+    dash_dash = argv[idx:]
+    argv = argv[:idx]
+
+  default_extensions = ','.join([
+      # From clang/lib/Frontend/FrontendOptions.cpp, all lower case
+      'c', 'h',  # C
+      'm',  # ObjC
+      'mm',  # ObjC++
+      'cc', 'cp', 'cpp', 'c++', 'cxx', 'hh', 'hpp', 'hxx',  # C++
+      'cu',  # CUDA
+      # Other languages that clang-format supports
+      'proto', 'protodevel',  # Protocol Buffers
+      'java',  # Java
+      'js',  # JavaScript
+      'ts',  # TypeScript
+      'cs',  # C Sharp
+      ])
+
+  p = argparse.ArgumentParser(
+    usage=usage, formatter_class=argparse.RawDescriptionHelpFormatter,
+    description=desc)
+  p.add_argument('--binary',
+                 default=config.get('clangformat.binary', 'clang-format'),
+                 help='path to clang-format'),
+  p.add_argument('--commit',
+                 default=config.get('clangformat.commit', 'HEAD'),
+                 help='default commit to use if none is specified'),
+  p.add_argument('--diff', action='store_true',
+                 help='print a diff instead of applying the changes')
+  p.add_argument('--diffstat', action='store_true',
+                 help='print diffstat instead of applying the changes')
+  p.add_argument('--extensions',
+                 default=config.get('clangformat.extensions',
+                                    default_extensions),
+                 help=('comma-separated list of file extensions to format, '
+                       'excluding the period and case-insensitive')),
+  p.add_argument('-f', '--force', action='store_true',
+                 help='allow changes to unstaged files')
+  p.add_argument('-p', '--patch', action='store_true',
+                 help='select hunks interactively')
+  p.add_argument('-q', '--quiet', action='count', default=0,
+                 help='print less information')
+  p.add_argument('--style',
+                 default=config.get('clangformat.style', None),
+                 help='passed to clang-format'),
+  p.add_argument('-v', '--verbose', action='count', default=0,
+                 help='print extra information')
+  # We gather all the remaining positional arguments into 'args' since we need
+  # to use some heuristics to determine whether or not <commit> was present.
+  # However, to print pretty messages, we make use of metavar and help.
+  p.add_argument('args', nargs='*', metavar='<commit>',
+                 help='revision from which to compute the diff')
+  p.add_argument('ignored', nargs='*', metavar='<file>...',
+                 help='if specified, only consider differences in these files')
+  opts = p.parse_args(argv)
+
+  opts.verbose -= opts.quiet
+  del opts.quiet
+
+  commits, files = interpret_args(opts.args, dash_dash, opts.commit)
+  if len(commits) > 1:
+    if not opts.diff:
+      die('--diff is required when two commits are given')
+  else:
+    if len(commits) > 2:
+      die('at most two commits allowed; %d given' % len(commits))
+  changed_lines = compute_diff_and_extract_lines(commits, files)
+  if opts.verbose >= 1:
+    ignored_files = set(changed_lines)
+  filter_by_extension(changed_lines, opts.extensions.lower().split(','))
+  if opts.verbose >= 1:
+    ignored_files.difference_update(changed_lines)
+    if ignored_files:
+      print('Ignoring changes in the following files (wrong extension):')
+      for filename in ignored_files:
+        print('    %s' % filename)
+    if changed_lines:
+      print('Running clang-format on the following files:')
+      for filename in changed_lines:
+        print('    %s' % filename)
+  if not changed_lines:
+    print('no modified files to format')
+    return
+  # The computed diff outputs absolute paths, so we must cd before accessing
+  # those files.
+  cd_to_toplevel()
+  if len(commits) > 1:
+    old_tree = commits[1]
+    new_tree = run_clang_format_and_save_to_tree(changed_lines,
+                                                 revision=commits[1],
+                                                 binary=opts.binary,
+                                                 style=opts.style)
+  else:
+    old_tree = create_tree_from_workdir(changed_lines)
+    new_tree = run_clang_format_and_save_to_tree(changed_lines,
+                                                 binary=opts.binary,
+                                                 style=opts.style)
+  if opts.verbose >= 1:
+    print('old tree: %s' % old_tree)
+    print('new tree: %s' % new_tree)
+  if old_tree == new_tree:
+    if opts.verbose >= 0:
+      print('clang-format did not modify any files')
+  elif opts.diff:
+    print_diff(old_tree, new_tree)
+  elif opts.diffstat:
+    print_diffstat(old_tree, new_tree)
+  else:
+    changed_files = apply_changes(old_tree, new_tree, force=opts.force,
+                                  patch_mode=opts.patch)
+    if (opts.verbose >= 0 and not opts.patch) or opts.verbose >= 1:
+      print('changed files:')
+      for filename in changed_files:
+        print('    %s' % filename)
+
+
+def load_git_config(non_string_options=None):
+  """Return the git configuration as a dictionary.
+
+  All options are assumed to be strings unless in `non_string_options`, in which
+  is a dictionary mapping option name (in lower case) to either "--bool" or
+  "--int"."""
+  if non_string_options is None:
+    non_string_options = {}
+  out = {}
+  for entry in run('git', 'config', '--list', '--null').split('\0'):
+    if entry:
+      name, value = entry.split('\n', 1)
+      if name in non_string_options:
+        value = run('git', 'config', non_string_options[name], name)
+      out[name] = value
+  return out
+
+
+def interpret_args(args, dash_dash, default_commit):
+  """Interpret `args` as "[commits] [--] [files]" and return (commits, files).
+
+  It is assumed that "--" and everything that follows has been removed from
+  args and placed in `dash_dash`.
+
+  If "--" is present (i.e., `dash_dash` is non-empty), the arguments to its
+  left (if present) are taken as commits.  Otherwise, the arguments are checked
+  from left to right if they are commits or files.  If commits are not given,
+  a list with `default_commit` is used."""
+  if dash_dash:
+    if len(args) == 0:
+      commits = [default_commit]
+    else:
+      commits = args
+    for commit in commits:
+      object_type = get_object_type(commit)
+      if object_type not in ('commit', 'tag'):
+        if object_type is None:
+          die("'%s' is not a commit" % commit)
+        else:
+          die("'%s' is a %s, but a commit was expected" % (commit, object_type))
+    files = dash_dash[1:]
+  elif args:
+    commits = []
+    while args:
+      if not disambiguate_revision(args[0]):
+        break
+      commits.append(args.pop(0))
+    if not commits:
+      commits = [default_commit]
+    files = args
+  else:
+    commits = [default_commit]
+    files = []
+  return commits, files
+
+
+def disambiguate_revision(value):
+  """Returns True if `value` is a revision, False if it is a file, or dies."""
+  # If `value` is ambiguous (neither a commit nor a file), the following
+  # command will die with an appropriate error message.
+  run('git', 'rev-parse', value, verbose=False)
+  object_type = get_object_type(value)
+  if object_type is None:
+    return False
+  if object_type in ('commit', 'tag'):
+    return True
+  die('`%s` is a %s, but a commit or filename was expected' %
+      (value, object_type))
+
+
+def get_object_type(value):
+  """Returns a string description of an object's type, or None if it is not
+  a valid git object."""
+  cmd = ['git', 'cat-file', '-t', value]
+  p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  stdout, stderr = p.communicate()
+  if p.returncode != 0:
+    return None
+  return convert_string(stdout.strip())
+
+
+def compute_diff_and_extract_lines(commits, files):
+  """Calls compute_diff() followed by extract_lines()."""
+  diff_process = compute_diff(commits, files)
+  changed_lines = extract_lines(diff_process.stdout)
+  diff_process.stdout.close()
+  diff_process.wait()
+  if diff_process.returncode != 0:
+    # Assume error was already printed to stderr.
+    sys.exit(2)
+  return changed_lines
+
+
+def compute_diff(commits, files):
+  """Return a subprocess object producing the diff from `commits`.
+
+  The return value's `stdin` file object will produce a patch with the
+  differences between the working directory and the first commit if a single
+  one was specified, or the difference between both specified commits, filtered
+  on `files` (if non-empty).  Zero context lines are used in the patch."""
+  git_tool = 'diff-index'
+  if len(commits) > 1:
+    git_tool = 'diff-tree'
+  cmd = ['git', git_tool, '-p', '-U0'] + commits + ['--']
+  cmd.extend(files)
+  p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+  p.stdin.close()
+  return p
+
+
+def extract_lines(patch_file):
+  """Extract the changed lines in `patch_file`.
+
+  The return value is a dictionary mapping filename to a list of (start_line,
+  line_count) pairs.
+
+  The input must have been produced with ``-U0``, meaning unidiff format with
+  zero lines of context.  The return value is a dict mapping filename to a
+  list of line `Range`s."""
+  matches = {}
+  for line in patch_file:
+    line = convert_string(line)
+    match = re.search(r'^\+\+\+\ [^/]+/(.*)', line)
+    if match:
+      filename = match.group(1).rstrip('\r\n')
+    match = re.search(r'^@@ -[0-9,]+ \+(\d+)(,(\d+))?', line)
+    if match:
+      start_line = int(match.group(1))
+      line_count = 1
+      if match.group(3):
+        line_count = int(match.group(3))
+      if line_count > 0:
+        matches.setdefault(filename, []).append(Range(start_line, line_count))
+  return matches
+
+
+def filter_by_extension(dictionary, allowed_extensions):
+  """Delete every key in `dictionary` that doesn't have an allowed extension.
+
+  `allowed_extensions` must be a collection of lowercase file extensions,
+  excluding the period."""
+  allowed_extensions = frozenset(allowed_extensions)
+  for filename in list(dictionary.keys()):
+    base_ext = filename.rsplit('.', 1)
+    if len(base_ext) == 1 and '' in allowed_extensions:
+        continue
+    if len(base_ext) == 1 or base_ext[1].lower() not in allowed_extensions:
+      del dictionary[filename]
+
+
+def cd_to_toplevel():
+  """Change to the top level of the git repository."""
+  toplevel = run('git', 'rev-parse', '--show-toplevel')
+  os.chdir(toplevel)
+
+
+def create_tree_from_workdir(filenames):
+  """Create a new git tree with the given files from the working directory.
+
+  Returns the object ID (SHA-1) of the created tree."""
+  return create_tree(filenames, '--stdin')
+
+
+def run_clang_format_and_save_to_tree(changed_lines, revision=None,
+                                      binary='clang-format', style=None):
+  """Run clang-format on each file and save the result to a git tree.
+
+  Returns the object ID (SHA-1) of the created tree."""
+  def iteritems(container):
+      try:
+          return container.iteritems() # Python 2
+      except AttributeError:
+          return container.items() # Python 3
+  def index_info_generator():
+    for filename, line_ranges in iteritems(changed_lines):
+      if revision:
+        git_metadata_cmd = ['git', 'ls-tree',
+                            '%s:%s' % (revision, os.path.dirname(filename)),
+                            os.path.basename(filename)]
+        git_metadata = subprocess.Popen(git_metadata_cmd, stdin=subprocess.PIPE,
+                                        stdout=subprocess.PIPE)
+        stdout = git_metadata.communicate()[0]
+        mode = oct(int(stdout.split()[0], 8))
+      else:
+        mode = oct(os.stat(filename).st_mode)
+      # Adjust python3 octal format so that it matches what git expects
+      if mode.startswith('0o'):
+          mode = '0' + mode[2:]
+      blob_id = clang_format_to_blob(filename, line_ranges,
+                                     revision=revision,
+                                     binary=binary,
+                                     style=style)
+      yield '%s %s\t%s' % (mode, blob_id, filename)
+  return create_tree(index_info_generator(), '--index-info')
+
+
+def create_tree(input_lines, mode):
+  """Create a tree object from the given input.
+
+  If mode is '--stdin', it must be a list of filenames.  If mode is
+  '--index-info' is must be a list of values suitable for "git update-index
+  --index-info", such as "<mode> <SP> <sha1> <TAB> <filename>".  Any other mode
+  is invalid."""
+  assert mode in ('--stdin', '--index-info')
+  cmd = ['git', 'update-index', '--add', '-z', mode]
+  with temporary_index_file():
+    p = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+    for line in input_lines:
+      p.stdin.write(to_bytes('%s\0' % line))
+    p.stdin.close()
+    if p.wait() != 0:
+      die('`%s` failed' % ' '.join(cmd))
+    tree_id = run('git', 'write-tree')
+    return tree_id
+
+
+def clang_format_to_blob(filename, line_ranges, revision=None,
+                         binary='clang-format', style=None):
+  """Run clang-format on the given file and save the result to a git blob.
+
+  Runs on the file in `revision` if not None, or on the file in the working
+  directory if `revision` is None.
+
+  Returns the object ID (SHA-1) of the created blob."""
+  clang_format_cmd = [binary]
+  if style:
+    clang_format_cmd.extend(['-style='+style])
+  clang_format_cmd.extend([
+      '-lines=%s:%s' % (start_line, start_line+line_count-1)
+      for start_line, line_count in line_ranges])
+  if revision:
+    clang_format_cmd.extend(['-assume-filename='+filename])
+    git_show_cmd = ['git', 'cat-file', 'blob', '%s:%s' % (revision, filename)]
+    git_show = subprocess.Popen(git_show_cmd, stdin=subprocess.PIPE,
+                                stdout=subprocess.PIPE)
+    git_show.stdin.close()
+    clang_format_stdin = git_show.stdout
+  else:
+    clang_format_cmd.extend([filename])
+    git_show = None
+    clang_format_stdin = subprocess.PIPE
+  try:
+    clang_format = subprocess.Popen(clang_format_cmd, stdin=clang_format_stdin,
+                                    stdout=subprocess.PIPE)
+    if clang_format_stdin == subprocess.PIPE:
+      clang_format_stdin = clang_format.stdin
+  except OSError as e:
+    if e.errno == errno.ENOENT:
+      die('cannot find executable "%s"' % binary)
+    else:
+      raise
+  clang_format_stdin.close()
+  hash_object_cmd = ['git', 'hash-object', '-w', '--path='+filename, '--stdin']
+  hash_object = subprocess.Popen(hash_object_cmd, stdin=clang_format.stdout,
+                                 stdout=subprocess.PIPE)
+  clang_format.stdout.close()
+  stdout = hash_object.communicate()[0]
+  if hash_object.returncode != 0:
+    die('`%s` failed' % ' '.join(hash_object_cmd))
+  if clang_format.wait() != 0:
+    die('`%s` failed' % ' '.join(clang_format_cmd))
+  if git_show and git_show.wait() != 0:
+    die('`%s` failed' % ' '.join(git_show_cmd))
+  return convert_string(stdout).rstrip('\r\n')
+
+
+@contextlib.contextmanager
+def temporary_index_file(tree=None):
+  """Context manager for setting GIT_INDEX_FILE to a temporary file and deleting
+  the file afterward."""
+  index_path = create_temporary_index(tree)
+  old_index_path = os.environ.get('GIT_INDEX_FILE')
+  os.environ['GIT_INDEX_FILE'] = index_path
+  try:
+    yield
+  finally:
+    if old_index_path is None:
+      del os.environ['GIT_INDEX_FILE']
+    else:
+      os.environ['GIT_INDEX_FILE'] = old_index_path
+    os.remove(index_path)
+
+
+def create_temporary_index(tree=None):
+  """Create a temporary index file and return the created file's path.
+
+  If `tree` is not None, use that as the tree to read in.  Otherwise, an
+  empty index is created."""
+  gitdir = run('git', 'rev-parse', '--git-dir')
+  path = os.path.join(gitdir, temp_index_basename)
+  if tree is None:
+    tree = '--empty'
+  run('git', 'read-tree', '--index-output='+path, tree)
+  return path
+
+
+def print_diff(old_tree, new_tree):
+  """Print the diff between the two trees to stdout."""
+  # We use the porcelain 'diff' and not plumbing 'diff-tree' because the output
+  # is expected to be viewed by the user, and only the former does nice things
+  # like color and pagination.
+  #
+  # We also only print modified files since `new_tree` only contains the files
+  # that were modified, so unmodified files would show as deleted without the
+  # filter.
+  subprocess.check_call(['git', 'diff', '--diff-filter=M', old_tree, new_tree,
+                         '--'])
+
+def print_diffstat(old_tree, new_tree):
+  """Print the diffstat between the two trees to stdout."""
+  # We use the porcelain 'diff' and not plumbing 'diff-tree' because the output
+  # is expected to be viewed by the user, and only the former does nice things
+  # like color and pagination.
+  #
+  # We also only print modified files since `new_tree` only contains the files
+  # that were modified, so unmodified files would show as deleted without the
+  # filter.
+  subprocess.check_call(['git', 'diff', '--diff-filter=M', '--stat', old_tree, new_tree,
+                         '--'])
+
+
+def apply_changes(old_tree, new_tree, force=False, patch_mode=False):
+  """Apply the changes in `new_tree` to the working directory.
+
+  Bails if there are local changes in those files and not `force`.  If
+  `patch_mode`, runs `git checkout --patch` to select hunks interactively."""
+  changed_files = run('git', 'diff-tree', '--diff-filter=M', '-r', '-z',
+                      '--name-only', old_tree,
+                      new_tree).rstrip('\0').split('\0')
+  if not force:
+    unstaged_files = run('git', 'diff-files', '--name-status', *changed_files)
+    if unstaged_files:
+      print('The following files would be modified but '
+                'have unstaged changes:', file=sys.stderr)
+      print(unstaged_files, file=sys.stderr)
+      print('Please commit, stage, or stash them first.', file=sys.stderr)
+      sys.exit(2)
+  if patch_mode:
+    # In patch mode, we could just as well create an index from the new tree
+    # and checkout from that, but then the user will be presented with a
+    # message saying "Discard ... from worktree".  Instead, we use the old
+    # tree as the index and checkout from new_tree, which gives the slightly
+    # better message, "Apply ... to index and worktree".  This is not quite
+    # right, since it won't be applied to the user's index, but oh well.
+    with temporary_index_file(old_tree):
+      subprocess.check_call(['git', 'checkout', '--patch', new_tree])
+    index_tree = old_tree
+  else:
+    with temporary_index_file(new_tree):
+      run('git', 'checkout-index', '-a', '-f')
+  return changed_files
+
+
+def run(*args, **kwargs):
+  stdin = kwargs.pop('stdin', '')
+  verbose = kwargs.pop('verbose', True)
+  strip = kwargs.pop('strip', True)
+  for name in kwargs:
+    raise TypeError("run() got an unexpected keyword argument '%s'" % name)
+  p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                       stdin=subprocess.PIPE)
+  stdout, stderr = p.communicate(input=stdin)
+
+  stdout = convert_string(stdout)
+  stderr = convert_string(stderr)
+
+  if p.returncode == 0:
+    if stderr:
+      if verbose:
+        print('`%s` printed to stderr:' % ' '.join(args), file=sys.stderr)
+      print(stderr.rstrip(), file=sys.stderr)
+    if strip:
+      stdout = stdout.rstrip('\r\n')
+    return stdout
+  if verbose:
+    print('`%s` returned %s' % (' '.join(args), p.returncode), file=sys.stderr)
+  if stderr:
+    print(stderr.rstrip(), file=sys.stderr)
+  sys.exit(2)
+
+
+def die(message):
+  print('error:', message, file=sys.stderr)
+  sys.exit(2)
+
+
+def to_bytes(str_input):
+    # Encode to UTF-8 to get binary data.
+    if isinstance(str_input, bytes):
+        return str_input
+    return str_input.encode('utf-8')
+
+
+def to_string(bytes_input):
+    if isinstance(bytes_input, str):
+        return bytes_input
+    return bytes_input.encode('utf-8')
+
+
+def convert_string(bytes_input):
+    try:
+        return to_string(bytes_input.decode('utf-8'))
+    except AttributeError: # 'str' object has no attribute 'decode'.
+        return str(bytes_input)
+    except UnicodeError:
+        return str(bytes_input)
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
Continuation of #5186

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the developer guide (in doc/devguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3736

Describe changes:
- Updated with review comments. Lots of small formatting adjustment, e.g.
- 100 chars line length @victorjulien 
- 4 chars indentation for variable definitions @jasonish 
- Unify "foreach" macro formatting including TAILQ_FOREACH and all others I found. @jasonish 
- Added link to documentation in .clang-format @jasonish 

Main other changes are...
- Error in case of wrong formatting as per discussion
- Ignoring the "merge commit" for merges to OISF repo to not complain about wrong formatting on newer commits on master
- Using minimal .clang-format file
- Removed sample file as well
- Removed make targets, updated devguide to refer to helper script instead

### Wrong Formatting is an Error
As per https://github.com/OISF/suricata/pull/5186#discussion_r458120863, formatting produces a github action error. This will provide a better visual and show the formatting-check action as failed in your pull request...

Example formatting-check action error: https://github.com/OISF/suricata/runs/914986617?check_suite_focus=true

One can chose which actions must pass in "Branch prediction Rules" in the repo settings. You could require all actions but the "formatting-check" to pass to still allow merging even if formatting is not correct:

> _it seems one can pick which status checks that have to pass in your "Branch Protection Rules", see https://docs.github.com/en/github/administering-a-repository/enabling-required-status-checks_
> 
> _So as long as you don't require the formatting-check to pass, you can merge pull requests._
> 
> _Hence, I'd recommend the formatting-check to error out in case of wrong formatting problems and not pick it as a required "status check" for merging purposes. That way, you'd see the red failure indication in the pull request, yet your merging is not blocked. I.e. it's up to you as maintainers to decide whether to request a formatting change on the pull request or merge something in anyways._