### PR TITLE
protodetect: debug validation when multiple patterns match

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -41,6 +41,7 @@
 #include "util-pool.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
+#include "util-validate.h"
 
 #include "flow.h"
 #include "flow-util.h"
@@ -1506,6 +1507,7 @@ AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx,
         uint16_t pm_matches = AppLayerProtoDetectPMGetProto(tctx, f,
                 buf, buflen, direction, pm_results, reverse_flow);
         if (pm_matches > 0) {
+            DEBUG_VALIDATE_BUG_ON(pm_matches > 1);
             alproto = pm_results[0];
 
             /* HACK: if detected protocol is dcerpc/udp, we run PP as well


### PR DESCRIPTION
This PR is for discussion rather than straight merging.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2757

Describe changes:
- Adds debug validation when multiple patterns are found for protocol detection

Modifies #4607 : debug validation check instead of handling unreachable case
Modifies #5231 with fixed compilation