### PR TITLE
Fix issues reported by Coverity - v1

### DIFF
--- a/src/detect-engine-uint.c
+++ b/src/detect-engine-uint.c
@@ -77,7 +77,9 @@ int DetectU32Match(const uint32_t parg, const DetectU32Data *du32)
 
 DetectU32Data *DetectU32Parse (const char *u32str)
 {
-    DetectU32Data u32da;
+    /* We initialize these to please static checkers, these values will
+       either be updated or not used later on */
+    DetectU32Data u32da = {0, 0, 0};
     DetectU32Data *u32d = NULL;
     char arg1[16] = "";
     char arg2[16] = "";
@@ -269,7 +271,9 @@ int DetectU8Match(const uint8_t parg, const DetectU8Data *du8)
 
 DetectU8Data *DetectU8Parse (const char *u8str)
 {
-    DetectU8Data u8da;
+    /* We initialize these to please static checkers, these values will
+       either be updated or not used later on */
+    DetectU8Data u8da = {0, 0, 0};
     DetectU8Data *u8d = NULL;
     char arg1[16] = "";
     char arg2[16] = "";

--- a/src/detect-mqtt-connack-sessionpresent.c
+++ b/src/detect-mqtt-connack-sessionpresent.c
@@ -135,7 +135,7 @@ static bool *DetectMQTTConnackSessionPresentParse(const char *rawstr)
     bool *de = NULL;
     de = SCMalloc(sizeof(bool));
     if (unlikely(de == NULL))
-        return NULL;
+        goto error;
     *de = false;
 
     if (strcmp(rawstr, "yes") == 0) {


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3855

Describe changes:
- Initialize structs `u8da` and `u32da`. This is basically just to please static checkers, values set at the beginning will always be overwritten or not used afterwards.
- Rework error handling in some MQTT keyword parsing code to unify the path to the error case.
- Use the more idiomatic `SCStrdup()` instead of using standard library functions.

Please note that I currently do not have access to the Coverity service, so this was a best effort to address the issue the checker is raising.
