### PR TITLE
Bug 3476/v1

### DIFF
--- a/src/datasets.c
+++ b/src/datasets.c
@@ -538,7 +538,7 @@ static bool DatasetIsStatic(const char *save, const char *load)
     /* A set is static if it does not have any dynamic properties like
      * save and/or state defined but has load defined.
      * */
-    if ((load != NULL || strlen(load) > 0) &&
+    if ((load != NULL && strlen(load) > 0) &&
             (save == NULL || strlen(save) == 0)) {
         return true;
     }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1990,6 +1990,8 @@ static int InitSignalHandler(SCInstance *suri)
  * Will be run once per pcap in unix-socket mode */
 void PreRunInit(const int runmode)
 {
+    /* Initialize Datasets to be able to use them with unix socket */
+    DatasetsInit();
     if (runmode == RUNMODE_UNIX_SOCKET)
         return;
 
@@ -2001,7 +2003,6 @@ void PreRunInit(const int runmode)
     SCProfilingSghsGlobalInit();
     SCProfilingInit();
 #endif /* PROFILING */
-    DatasetsInit();
     DefragInit();
     FlowInitConfig(FLOW_QUIET);
     IPPairInitConfig(FLOW_QUIET);


### PR DESCRIPTION
No existing tests seem to be failing and this change ensures that datasets are loaded from the yaml file even in the unix socket mode. Logs show up something like:
```
[130868] 3/8/2020 -- 18:01:58 - (datasets.c:517) <Debug> (DatasetGet) -- set 0x2496c20/ua-seen type 1 save  load 
[130868] 3/8/2020 -- 18:01:58 - (datasets.c:664) <Debug> (DatasetsInit) -- dataset ua-seen: id 0 type string
[130868] 3/8/2020 -- 18:01:58 - (datasets.c:386) <Debug> (DatasetGetPath) -- data-dir '/var/lib/suricata/data': No such file or directory
[130868] 3/8/2020 -- 18:01:58 - (datasets.c:642) <Debug> (DatasetsInit) -- (1) set dns-sha256-seen type sha256. Conf datasets.1.dns-sha256-seen
[130868] 3/8/2020 -- 18:01:58 - (datasets.c:517) <Debug> (DatasetGet) -- set 0x24f04b0/dns-sha256-seen type 3 save  load 
[130868] 3/8/2020 -- 18:01:58 - (datasets.c:656) <Debug> (DatasetsInit) -- dataset dns-sha256-seen: id 1 type sha256
[130868] 3/8/2020 -- 18:01:58 - (datasets.c:672) <Debug> (DatasetsInit) -- datasets done: 0x2390250
[130868] 3/8/2020 -- 22:05:16 - (datasets.c:559) <Debug> (DatasetReload) -- Not a static set, skipping dns-sha256-seen
```
Redmine ticket: https://redmine.openinfosecfoundation.org/issues/3476