### PR TITLE
Alerts: Add SNMP and RDP Metadata - v1

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -219,6 +219,20 @@ static void AlertJsonDns(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
     return;
 }
 
+static void AlertJsonSNMP(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
+{
+    void *snmp_state = (void *)FlowGetAppState(f);
+    if (snmp_state != NULL) {
+        void *tx = AppLayerParserGetTx(f->proto, ALPROTO_SNMP, snmp_state,
+                tx_id);
+        if (tx != NULL) {
+            jb_open_object(js, "snmp");
+            rs_snmp_log_json_response(js, snmp_state, tx);
+            jb_close(js);
+        }
+    }
+}
+
 static void AlertJsonSourceTarget(const Packet *p, const PacketAlert *pa,
                                   JsonBuilder *js, JsonAddrInfo *addr)
 {
@@ -482,6 +496,9 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
             if (!JsonMQTTAddMetadata(p->flow, tx_id, jb)) {
                 jb_restore_mark(jb, &mark);
             }
+            break;
+        case ALPROTO_SNMP:
+            AlertJsonSNMP(p->flow, tx_id, jb);
             break;
         default:
             break;

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -233,6 +233,22 @@ static void AlertJsonSNMP(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
     }
 }
 
+static void AlertJsonRDP(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
+{
+    void *rdp_state = (void *)FlowGetAppState(f);
+    if (rdp_state != NULL) {
+        void *tx = AppLayerParserGetTx(f->proto, ALPROTO_RDP, rdp_state,
+                tx_id);
+        if (tx != NULL) {
+            JsonBuilderMark mark = { 0, 0, 0 };
+            jb_get_mark(js, &mark);
+            if (!rs_rdp_to_json(tx, js)) {
+                jb_restore_mark(js, &mark);
+            }
+        }
+    }
+}
+
 static void AlertJsonSourceTarget(const Packet *p, const PacketAlert *pa,
                                   JsonBuilder *js, JsonAddrInfo *addr)
 {
@@ -499,6 +515,9 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
             break;
         case ALPROTO_SNMP:
             AlertJsonSNMP(p->flow, tx_id, jb);
+            break;
+        case ALPROTO_RDP:
+            AlertJsonRDP(p->flow, tx_id, jb);
             break;
         default:
             break;


### PR DESCRIPTION
Add SNMP and RDP metadata to EVE alerts.

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/3441

suricata-verify-pr: 294
