### PR TITLE
rust: only run cbindgen if needed - v2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2504,7 +2504,7 @@ fi
     fi
 
     RUST_LDADD="${RUST_SURICATA_LIB} ${RUST_LDADD}"
-    CFLAGS="${CFLAGS} -I\${srcdir}/../rust/gen"
+    CFLAGS="${CFLAGS} -I\${srcdir}/../rust/gen -I\${srcdir}/../rust/dist"
     AC_SUBST(RUST_SURICATA_LIB)
     AC_SUBST(RUST_LDADD)
     if test "x$CARGO_HOME" = "x"; then
@@ -2563,7 +2563,7 @@ fi
         have_cargo_vendor=$have_cargo_vendor_bin
     fi
 
-    AC_CHECK_FILES([$srcdir/rust/gen], [have_rust_headers="yes"])
+    AC_CHECK_FILES([$srcdir/rust/dist $srcdir/rust/gen], [have_rust_headers="yes"])
     AC_PATH_PROG(CBINDGEN, cbindgen, "no")
     if test "x$CBINDGEN" != "xno"; then
       cbindgen_version=$(cbindgen --version | cut -d' ' -f2-)
@@ -2581,6 +2581,8 @@ fi
         have_rust_headers="no"
       fi
     fi
+
+    AC_SUBST([CBINDGEN], [$CBINDGEN])
 
     # Require cbindgen if generated headers are not bundled.
     if test "x$have_rust_headers" != "xyes"; then

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -1,7 +1,7 @@
 EXTRA_DIST =	src \
 		.cargo/config.in \
 		cbindgen.toml \
-		gen/rust-bindings.h
+		dist/rust-bindings.h
 
 if HAVE_CARGO_VENDOR
 EXTRA_DIST +=	vendor
@@ -28,10 +28,6 @@ RUST_TARGET = --target $(host_triplet)
 endif
 
 all-local:
-if HAVE_CBINDGEN
-	cbindgen --config $(abs_top_srcdir)/rust/cbindgen.toml \
-		--quiet --output $(abs_top_builddir)/rust/gen/rust-bindings.h
-endif
 if HAVE_CYGPATH
 	@rustup_home@ \
 		CARGO_HOME="$(CARGO_HOME)" \
@@ -45,11 +41,12 @@ else
 		$(CARGO) build $(RELEASE) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)
 endif
+	$(MAKE) gen/rust-bindings.h
 
 clean-local:
 	rm -rf target
 if HAVE_CBINDGEN
-	rm -rf gen
+	rm -rf gen dist
 endif
 
 distclean-local:
@@ -70,9 +67,9 @@ else
 vendor:
 endif
 
-# Can only include the headers if we have Python to generate them.
 if HAVE_CBINDGEN
-gen/rust-bindings.h:
+gen/rust-bindings.h: $(RUST_SURICATA_LIB)
+	rm -f gen/rust-bindings.h
 	cbindgen --config $(abs_top_srcdir)/rust/cbindgen.toml \
 		--quiet --output $(abs_top_builddir)/rust/gen/rust-bindings.h
 else
@@ -81,3 +78,11 @@ endif
 
 doc:
 	CARGO_HOME=$(CARGO_HOME) $(CARGO) doc --all-features --no-deps
+
+if HAVE_CBINDGEN
+dist/rust-bindings.h:
+	cbindgen --config $(abs_top_srcdir)/rust/cbindgen.toml \
+		--quiet --output $(abs_top_builddir)/rust/dist/rust-bindings.h
+else
+dist/rust-bindings.h:
+endif


### PR DESCRIPTION
In short, fix "make && sudo make install" when sudo
provides a sanitized path (even with -E) and Rust is
installed with Rustup.

Only run cbindgen when necessary. This is a bit tricky. When
building a dist we want to unconditionally build the headers.
    
When going through a "make; sudo make install" type process,
cbindgen should not be run as the headers already exist, are
valid, and the environment under sudo is more often than
not suitable to pick up the Rust toolchains when installed
with rustup.
    
For the normal "make" case we have the gen/rust-bindings.h file
depend on library file, this will cause it to only be rebuilt
if the code was modified.
    
For "make dist" we unconditionally create "dist/rust-bindings.h".
This means the generated file could be in 2 locations, so update
configure.ac, and the library search find to find it.
   
The "gen/rust-bindings.h" should be picked up first if it exists,
for those who develop from a dist archive where "dist/rust-bindings.h"
also exists.
    
Not completely happy having the same file in 2 locations, but not
sure how else to get the dependency tracking correct.
