### PR TITLE
doc/userguide: fix outdated xdp info

### DIFF
--- a/doc/userguide/capture-hardware/ebpf-xdp.rst
+++ b/doc/userguide/capture-hardware/ebpf-xdp.rst
@@ -526,11 +526,11 @@ To achieve this, edit the beginning of `ebpf/xdp_filter.c` and do ::
 Then build the bpf file with `make` and install it in the expected place.
 
 On Suricata configuration side, this is rather simple as you need to activate
-hardware mode and the `no-percpu-hash` option in the `af-packet` configuration
+hardware mode and the `use-percpu-hash` option in the `af-packet` configuration
 of the interface ::
 
     xdp-mode: hw
-    no-percpu-hash: true
+    use-percpu-hash: no
 
 The load  balancing will be done on IP pairs inside the eBPF code, so
 using `cluster_qm` as cluster type is a good idea ::


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [3799](https://redmine.openinfosecfoundation.org/issues/3799) ticket:

Describe changes:
- Rename deprecated keyword in XDP userguide to the correct one.
- no-percpu-hash -> use-percpu-hash  

