### PR TITLE
rust/rdp: Fix use of incorrect buffer

### DIFF
--- a/rust/src/rdp/parser.rs
+++ b/rust/src/rdp/parser.rs
@@ -602,7 +602,7 @@ fn parse_negotiation_request(input: &[u8]) -> IResult<&[u8], NegotiationRequest,
 /// x.224-spec, section 13.3
 fn parse_x224_connection_confirm(input: &[u8]) -> IResult<&[u8], X224ConnectionConfirm, RdpError> {
     let (i1, length) = verify!(input, be_u8, |&x| x != 0xff)?; // 0xff is reserved
-    let (i2, cr_cdt) = take_4_4_bits(input)?;
+    let (i2, cr_cdt) = take_4_4_bits(i1)?;
     let _ = verify!(i1, value!(cr_cdt.0), |&x| x
         == X224Type::ConnectionConfirm as u8)?;
     let _ = verify!(i1, value!(cr_cdt.1), |&x| x == 0 || x == 1)?;


### PR DESCRIPTION
This commit updates the connection confirmation parsing function to use
the correct buffer when determining the packet type.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3813](https://redmine.openinfosecfoundation.org/issues/3813)

Describe changes:
- Fix issue with buffer used to check packet type

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr: 297 
#suricata-verify-repo: https://github.com/jlucovsky/suricata-verify
#suricata-verify-branch: 3339/2
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
