### PR TITLE
general: Improve grammar in error messages

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -1265,14 +1265,14 @@ int DetectAddressTestConfVars(void)
         if (r < 0) {
             SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
                         "failed to parse address var \"%s\" with value \"%s\". "
-                        "Please check it's syntax", seq_node->name, seq_node->val);
+                        "Please check its syntax", seq_node->name, seq_node->val);
             goto error;
         }
 
         if (DetectAddressIsCompleteIPSpace(ghn)) {
             SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
                        "address var - \"%s\" has the complete IP space negated "
-                       "with it's value \"%s\".  Rule address range is NIL. "
+                       "with its value \"%s\".  Rule address range is NIL. "
                        "Probably have a !any or an address range that supplies "
                        "a NULL address range", seq_node->name, seq_node->val);
             goto error;

--- a/src/detect-engine-port.c
+++ b/src/detect-engine-port.c
@@ -1201,14 +1201,14 @@ int DetectPortTestConfVars(void)
             DetectPortCleanupList(NULL, gh);
             SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
                         "failed to parse port var \"%s\" with value \"%s\". "
-                        "Please check it's syntax", seq_node->name, seq_node->val);
+                        "Please check its syntax", seq_node->name, seq_node->val);
             goto error;
         }
 
         if (DetectPortIsCompletePortSpace(ghn)) {
             SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
                        "Port var - \"%s\" has the complete Port range negated "
-                       "with it's value \"%s\".  Port space range is NIL. "
+                       "with its value \"%s\".  Port space range is NIL. "
                        "Probably have a !any or a port range that supplies "
                        "a NULL address range", seq_node->name, seq_node->val);
             DetectPortCleanupList(NULL, gh);


### PR DESCRIPTION
This commit corrects a minor grammar issue in address/port error
messages.

Describe changes:
- Grammar update in error messages

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
