### PR TITLE
output/ssh: Use correct file context

### DIFF
--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -90,7 +90,7 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         goto end;
     }
     jb_close(js);
-    OutputJsonBuilderBuffer(js, ssh_ctx->file_ctx, &aft->buffer);
+    OutputJsonBuilderBuffer(js, aft->file_ctx, &aft->buffer);
 
 end:
     jb_free(js);


### PR DESCRIPTION
This commit corrects an issue with the SSH output module that resulted
in a SEGV when SSH output is logged.


Describe changes:
- SEGV caused by using incorrect file context for output.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
