### PR TITLE
Fix autoreconf in distribution archive - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -202,6 +202,8 @@ jobs:
         run: |
           yum -y install epel-release
           yum -y install \
+                autoconf \
+                automake \
                 cargo \
                 diffutils \
                 file-devel \
@@ -233,6 +235,12 @@ jobs:
         with:
           name: dist
       - run: tar zxvf suricata-*.tar.gz --strip-components=1
+      # This isn't really needed as we are building from a prepared
+      # package, but some package managers like RPM and Debian like to
+      # run this command even on prepared packages, so make sure it
+      # works.
+      - name: Test autoreconf
+        run: autoreconf -fv --install
       - run: ./configure
       - run: make -j2
       - run: make install

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,8 @@ ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST = ChangeLog COPYING LICENSE suricata.yaml.in \
              threshold.config \
              $(SURICATA_UPDATE_DIR) \
-	     lua
+	     lua \
+	     acsite.m4
 SUBDIRS = $(HTP_DIR) rust src qa rules doc contrib etc python ebpf \
           $(SURICATA_UPDATE_DIR)
 


### PR DESCRIPTION
automake: add acsite.m4 to EXTRA_DIST
   
This file is required to successfully re-run autoreconf, which many packaging
tools will do even on a prepared distribution archive.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3871
