### PR TITLE
configure: fix detection of netfilter_queue with older headers - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1079,7 +1079,13 @@ return 0;
             CPPFLAGS="${CPPFLAGS} -I${with_libnetfilter_queue_includes}"
         fi
 
-        AC_CHECK_HEADER(libnetfilter_queue/libnetfilter_queue.h,,[AC_MSG_ERROR(libnetfilter_queue/libnetfilter_queue.h not found ...)])
+        AC_CHECK_HEADER(libnetfilter_queue/libnetfilter_queue.h,,
+            [AC_MSG_ERROR(libnetfilter_queue/libnetfilter_queue.h not found ...)],
+            [
+                #define _GNU_SOURCE
+                #include <sys/types.h>
+                #include <stdint.h>
+            ])
 
         if test "$with_libnetfilter_queue_libraries" != "no"; then
             LDFLAGS="${LDFLAGS}  -L${with_libnetfilter_queue_libraries}"
@@ -1103,6 +1109,9 @@ return 0;
         AC_COMPILE_IFELSE(
             [AC_LANG_PROGRAM(
                 [
+                    #define _GNU_SOURCE
+                    #include <sys/types.h>
+                    #include <stdint.h>
                     #include <stdio.h>
                     #include <libnetfilter_queue/libnetfilter_queue.h>
                 ],


### PR DESCRIPTION
Define _GNU_SOURCE and include sys/types.h so older
netfilter_queue headers can be detected properly, as they are
using u_int_xx style integers.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3874
