### PR TITLE
output: Remove registration of standalone output logging where EVE is also used.

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -1055,9 +1055,6 @@ error:
 
 void JsonAlertLogRegister (void)
 {
-    OutputRegisterPacketModule(LOGGER_JSON_ALERT, MODULE_NAME, "alert-json-log",
-        JsonAlertLogInitCtx, JsonAlertLogger, JsonAlertLogCondition,
-        JsonAlertLogThreadInit, JsonAlertLogThreadDeinit, NULL);
     OutputRegisterPacketSubModule(LOGGER_JSON_ALERT, "eve-log", MODULE_NAME,
         "eve-log.alert", JsonAlertLogInitCtxSub, JsonAlertLogger,
         JsonAlertLogCondition, JsonAlertLogThreadInit, JsonAlertLogThreadDeinit,

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -712,16 +712,6 @@ static OutputInitResult JsonDnsLogInitCtx(ConfNode *conf)
 #define MODULE_NAME "JsonDnsLog"
 void JsonDnsLogRegister (void)
 {
-    /* Logger for requests. */
-    OutputRegisterTxModuleWithProgress(LOGGER_JSON_DNS_TS, MODULE_NAME,
-        "dns-json-log", JsonDnsLogInitCtx, ALPROTO_DNS, JsonDnsLoggerToServer,
-        0, 1, LogDnsLogThreadInit, LogDnsLogThreadDeinit, NULL);
-
-    /* Logger for replies. */
-    OutputRegisterTxModuleWithProgress(LOGGER_JSON_DNS_TC, MODULE_NAME,
-        "dns-json-log", JsonDnsLogInitCtx, ALPROTO_DNS, JsonDnsLoggerToClient,
-        1, 1, LogDnsLogThreadInit, LogDnsLogThreadDeinit, NULL);
-
     /* Sub-logger for requests. */
     OutputRegisterTxSubModuleWithProgress(LOGGER_JSON_DNS_TS, "eve-log",
         MODULE_NAME, "eve-log.dns", JsonDnsLogInitCtxSub, ALPROTO_DNS,

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -445,9 +445,6 @@ static int JsonDropLogCondition(ThreadVars *tv, const Packet *p)
 
 void JsonDropLogRegister (void)
 {
-    OutputRegisterPacketModule(LOGGER_JSON_DROP, MODULE_NAME, "drop-json-log",
-        JsonDropLogInitCtx, JsonDropLogger, JsonDropLogCondition,
-        JsonDropLogThreadInit, JsonDropLogThreadDeinit, NULL);
     OutputRegisterPacketSubModule(LOGGER_JSON_DROP, "eve-log", MODULE_NAME,
         "eve-log.drop", JsonDropLogInitCtxSub, JsonDropLogger,
         JsonDropLogCondition, JsonDropLogThreadInit, JsonDropLogThreadDeinit,

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -477,12 +477,7 @@ static TmEcode JsonFlowLogThreadDeinit(ThreadVars *t, void *data)
 
 void JsonFlowLogRegister (void)
 {
-    /* register as separate module */
-    OutputRegisterFlowModule(LOGGER_JSON_FLOW, "JsonFlowLog", "flow-json-log",
-        OutputFlowLogInit, JsonFlowLogger, JsonFlowLogThreadInit,
-        JsonFlowLogThreadDeinit, NULL);
-
-    /* also register as child of eve-log */
+    /* register as child of eve-log */
     OutputRegisterFlowSubModule(LOGGER_JSON_FLOW, "eve-log", "JsonFlowLog",
         "eve-log.flow", OutputFlowLogInitSub, JsonFlowLogger,
         JsonFlowLogThreadInit, JsonFlowLogThreadDeinit, NULL);

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -793,12 +793,7 @@ static TmEcode JsonHttpLogThreadDeinit(ThreadVars *t, void *data)
 
 void JsonHttpLogRegister (void)
 {
-    /* register as separate module */
-    OutputRegisterTxModule(LOGGER_JSON_HTTP, "JsonHttpLog", "http-json-log",
-        OutputHttpLogInit, ALPROTO_HTTP, JsonHttpLogger, JsonHttpLogThreadInit,
-        JsonHttpLogThreadDeinit, NULL);
-
-    /* also register as child of eve-log */
+    /* register as child of eve-log */
     OutputRegisterTxSubModule(LOGGER_JSON_HTTP, "eve-log", "JsonHttpLog",
         "eve-log.http", OutputHttpLogInitSub, ALPROTO_HTTP, JsonHttpLogger,
         JsonHttpLogThreadInit, JsonHttpLogThreadDeinit, NULL);

--- a/src/output-json-metadata.c
+++ b/src/output-json-metadata.c
@@ -270,20 +270,12 @@ error:
 
 void JsonMetadataLogRegister (void)
 {
-    OutputRegisterPacketModule(LOGGER_JSON_METADATA, MODULE_NAME,
-        "metadata-json-log", JsonMetadataLogInitCtx, JsonMetadataLogger,
-        JsonMetadataLogCondition, JsonMetadataLogThreadInit,
-        JsonMetadataLogThreadDeinit, NULL);
     OutputRegisterPacketSubModule(LOGGER_JSON_METADATA, "eve-log", MODULE_NAME,
         "eve-log.metadata", JsonMetadataLogInitCtxSub, JsonMetadataLogger,
         JsonMetadataLogCondition, JsonMetadataLogThreadInit,
         JsonMetadataLogThreadDeinit, NULL);
 
     /* Kept for compatibility. */
-    OutputRegisterPacketModule(LOGGER_JSON_METADATA, MODULE_NAME,
-        "vars-json-log", JsonMetadataLogInitCtx, JsonMetadataLogger,
-        JsonMetadataLogCondition, JsonMetadataLogThreadInit,
-        JsonMetadataLogThreadDeinit, NULL);
     OutputRegisterPacketSubModule(LOGGER_JSON_METADATA, "eve-log", MODULE_NAME,
         "eve-log.vars", JsonMetadataLogInitCtxSub, JsonMetadataLogger,
         JsonMetadataLogCondition, JsonMetadataLogThreadInit,

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -437,12 +437,7 @@ static TmEcode JsonNetFlowLogThreadDeinit(ThreadVars *t, void *data)
 
 void JsonNetFlowLogRegister(void)
 {
-    /* register as separate module */
-    OutputRegisterFlowModule(LOGGER_JSON_NETFLOW, "JsonNetFlowLog",
-        "netflow-json-log", OutputNetFlowLogInit, JsonNetFlowLogger,
-        JsonNetFlowLogThreadInit, JsonNetFlowLogThreadDeinit, NULL);
-
-    /* also register as child of eve-log */
+    /* register as child of eve-log */
     OutputRegisterFlowSubModule(LOGGER_JSON_NETFLOW, "eve-log", "JsonNetFlowLog",
         "eve-log.netflow", OutputNetFlowLogInitSub, JsonNetFlowLogger,
         JsonNetFlowLogThreadInit, JsonNetFlowLogThreadDeinit, NULL);

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -254,12 +254,7 @@ static TmEcode JsonSmtpLogThreadDeinit(ThreadVars *t, void *data)
 }
 
 void JsonSmtpLogRegister (void) {
-    /* register as separate module */
-    OutputRegisterTxModule(LOGGER_JSON_SMTP, "JsonSmtpLog", "smtp-json-log",
-        OutputSmtpLogInit, ALPROTO_SMTP, JsonSmtpLogger, JsonSmtpLogThreadInit,
-        JsonSmtpLogThreadDeinit, NULL);
-
-    /* also register as child of eve-log */
+    /* register as child of eve-log */
     OutputRegisterTxSubModule(LOGGER_JSON_SMTP, "eve-log", "JsonSmtpLog",
         "eve-log.smtp", OutputSmtpLogInitSub, ALPROTO_SMTP, JsonSmtpLogger,
         JsonSmtpLogThreadInit, JsonSmtpLogThreadDeinit, NULL);

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -233,13 +233,7 @@ static OutputInitResult OutputSshLogInitSub(ConfNode *conf, OutputCtx *parent_ct
 
 void JsonSshLogRegister (void)
 {
-    /* register as separate module */
-    OutputRegisterTxModuleWithCondition(LOGGER_JSON_SSH,
-        "JsonSshLog", "ssh-json-log",
-        OutputSshLogInit, ALPROTO_SSH, JsonSshLogger,
-        SSHTxLogCondition, JsonSshLogThreadInit, JsonSshLogThreadDeinit, NULL);
-
-    /* also register as child of eve-log */
+    /* register as child of eve-log */
     OutputRegisterTxSubModuleWithCondition(LOGGER_JSON_SSH,
         "eve-log", "JsonSshLog", "eve-log.ssh",
         OutputSshLogInitSub, ALPROTO_SSH, JsonSshLogger,

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -534,12 +534,7 @@ static OutputInitResult OutputStatsLogInitSub(ConfNode *conf, OutputCtx *parent_
 }
 
 void JsonStatsLogRegister(void) {
-    /* register as separate module */
-    OutputRegisterStatsModule(LOGGER_JSON_STATS, MODULE_NAME, "stats-json",
-        OutputStatsLogInit, JsonStatsLogger, JsonStatsLogThreadInit,
-        JsonStatsLogThreadDeinit, NULL);
-
-    /* also register as child of eve-log */
+    /* register as child of eve-log */
     OutputRegisterStatsSubModule(LOGGER_JSON_STATS, "eve-log", MODULE_NAME,
         "eve-log.stats", OutputStatsLogInitSub, JsonStatsLogger,
         JsonStatsLogThreadInit, JsonStatsLogThreadDeinit, NULL);

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -649,13 +649,7 @@ static OutputInitResult OutputTlsLogInitSub(ConfNode *conf, OutputCtx *parent_ct
 
 void JsonTlsLogRegister (void)
 {
-    /* register as separate module */
-    OutputRegisterTxModuleWithProgress(LOGGER_JSON_TLS, "JsonTlsLog",
-        "tls-json-log", OutputTlsLogInit, ALPROTO_TLS, JsonTlsLogger,
-        TLS_HANDSHAKE_DONE, TLS_HANDSHAKE_DONE, JsonTlsLogThreadInit,
-        JsonTlsLogThreadDeinit, NULL);
-
-    /* also register as child of eve-log */
+    /* register as child of eve-log */
     OutputRegisterTxSubModuleWithProgress(LOGGER_JSON_TLS, "eve-log",
         "JsonTlsLog", "eve-log.tls", OutputTlsLogInitSub, ALPROTO_TLS,
         JsonTlsLogger, TLS_HANDSHAKE_DONE, TLS_HANDSHAKE_DONE,

--- a/src/output.c
+++ b/src/output.c
@@ -574,44 +574,6 @@ error:
 }
 
 /**
- * \brief Register a flow output module.
- *
- * This function will register an output module so it can be
- * configured with the configuration file.
- *
- * \retval Returns 0 on success, -1 on failure.
- */
-void OutputRegisterFlowModule(LoggerId id, const char *name,
-    const char *conf_name, OutputInitFunc InitFunc, FlowLogger FlowLogFunc,
-    ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit,
-    ThreadExitPrintStatsFunc ThreadExitPrintStats)
-{
-    if (unlikely(FlowLogFunc == NULL)) {
-        goto error;
-    }
-
-    OutputModule *module = SCCalloc(1, sizeof(*module));
-    if (unlikely(module == NULL)) {
-        goto error;
-    }
-
-    module->logger_id = id;
-    module->name = name;
-    module->conf_name = conf_name;
-    module->InitFunc = InitFunc;
-    module->FlowLogFunc = FlowLogFunc;
-    module->ThreadInit = ThreadInit;
-    module->ThreadDeinit = ThreadDeinit;
-    module->ThreadExitPrintStats = ThreadExitPrintStats;
-    TAILQ_INSERT_TAIL(&output_modules, module, entries);
-
-    SCLogDebug("Flow logger \"%s\" registered.", name);
-    return;
-error:
-    FatalError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
-}
-
-/**
  * \brief Register a flow output sub-module.
  *
  * This function will register an output module so it can be

--- a/src/output.h
+++ b/src/output.h
@@ -151,11 +151,6 @@ void OutputRegisterFiledataSubModule(LoggerId, const char *parent_name,
     ThreadDeinitFunc ThreadDeinit,
     ThreadExitPrintStatsFunc ThreadExitPrintStats);
 
-void OutputRegisterFlowModule(LoggerId id, const char *name,
-    const char *conf_name, OutputInitFunc InitFunc,
-    FlowLogger FlowLogFunc, ThreadInitFunc ThreadInit,
-    ThreadDeinitFunc ThreadDeinit,
-    ThreadExitPrintStatsFunc ThreadExitPrintStats);
 void OutputRegisterFlowSubModule(LoggerId id, const char *parent_name,
     const char *name, const char *conf_name, OutputInitSubFunc InitFunc,
     FlowLogger FlowLogFunc, ThreadInitFunc ThreadInit,


### PR DESCRIPTION
This PR removes the standalone output logging registrations where they are no longer relevant due to EVE multi instance handling.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3178](https://redmine.openinfosecfoundation.org/issues/3178)

Describe changes:
- Remove standalone output registrations
- Remove unused output registration functions

suricata-verify-pr: 299
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
