### PR TITLE
Capture feature 120 v4

### DIFF
--- a/doc/userguide/output/index.rst
+++ b/doc/userguide/output/index.rst
@@ -9,3 +9,4 @@ Output
    custom-http-logging
    custom-tls-logging
    log-rotation
+   pcap-alert-output

--- a/doc/userguide/output/pcap-alert-output.rst
+++ b/doc/userguide/output/pcap-alert-output.rst
@@ -1,0 +1,53 @@
+Pcap Alert Output
+=================
+
+Suricata is able to provide a packet capture output upon the generation of an
+alert. This feature makes use of the "tag" keyword in a signature by searching
+for and dumping tagged packets that either have generated an alert or belong to
+the same session of a packet that has generated an alert. This feature must be
+enabled through the suricata.yaml file, but also requires a signature to have
+the "tag:session;" keyword for it to perform the capture. Signatures without
+"tag:session;" will not trigger a capture.
+
+Additionally, there is an option to enabled a session-dump in the suricata.yaml
+file. This causes all available tcp segments in the relevant session at the time
+of alert to be dumped to the capture file. This is recommended, as otherwise
+often the packet that generates an alert may not be captured due to a lag
+between the processing of a packet and the generation of an alert. This
+behaviour was only found in tcp based traffic. As a result, the session-dump
+option only relates to tcp based traffic.
+
+By default, the stream-pcap-log is not enabled.
+
+YAML
+----
+
+::
+
+  - stream-pcap-log:
+      enabled: yes/no
+      output_directory: /data/pcap# Defaults to default-log-dir
+      session-dump: yes/no # Dumps tcp session upon creation of pcap file.
+
+Example Signatures
+------------------
+
+.. container:: example-rule
+
+    alert tcp any any -> any any (msg:"Alert on HTTP GET request using content
+    match. Capturing session!"; content:"GET"; tag:session; sid:1; rev:1;)
+
+.. container:: example-rule
+
+    alert tcp any any -> any any (msg:"Alert on HTTP Get request using sticky
+    buffer. Capturing session!"; http.method; content:"GET"; tag:session; sid:2; rev:1;)
+
+.. container:: example-rule
+
+    alert snmp any any -> any any (msg:"SNMP get request. Capturing Session!";
+    snmp.pdu_type:0; tag:session; sid:3; rev:1;)
+
+.. container:: example-rule
+
+    alert udp any any -> any any (msg:"UDP Packet found. Capturing Session.";
+    tag:session; sid:4; rev:1;)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -277,6 +277,7 @@ detect-ssl-state.c detect-ssl-state.h \
 detect-ssl-version.c detect-ssl-version.h \
 detect-stream_size.c detect-stream_size.h \
 detect-tag.c detect-tag.h \
+detect-tag-pcap.c detect-tag-pcap.h \
 detect-target.c detect-target.h \
 detect-tcp-ack.c detect-tcp-ack.h \
 detect-tcp-flags.c detect-tcp-flags.h \
@@ -353,6 +354,7 @@ ippair-timeout.c ippair-timeout.h \
 log-cf-common.c log-cf-common.h \
 log-httplog.c log-httplog.h \
 log-pcap.c log-pcap.h \
+log-pcap-stream.c log-pcap-stream.h \
 log-stats.c log-stats.h \
 log-tcp-data.c log-tcp-data.h \
 log-tlslog.c log-tlslog.h \
@@ -402,6 +404,7 @@ output-tx.c output-tx.h \
 output-json.c output-json.h \
 output-json-common.c \
 packet-queue.c packet-queue.h \
+pcap-helper.c pcap-helper.h \
 pkt-var.c pkt-var.h \
 reputation.c reputation.h \
 respond-reject.c respond-reject.h \

--- a/src/detect-engine-tag.c
+++ b/src/detect-engine-tag.c
@@ -33,6 +33,7 @@
 #include "util-hashlist.h"
 #include "detect-engine-tag.h"
 #include "detect-tag.h"
+#include "detect-tag-pcap.h"
 #include "host.h"
 #include "host-storage.h"
 #include "flow-storage.h"
@@ -104,6 +105,7 @@ static DetectTagDataEntry *DetectTagDataCopy(DetectTagDataEntry *dtd)
 
     tde->first_ts = dtd->first_ts;
     tde->last_ts = dtd->last_ts;
+    tde->pcap_file = dtd->pcap_file;
     return tde;
 }
 
@@ -288,14 +290,14 @@ static void TagHandlePacketFlow(Flow *f, Packet *p)
                             tde = iter;
                             prev->next = iter->next;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         } else {
                             FlowSetStorageById(p->flow, flow_tag_id, iter->next);
                             tde = iter;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         }
@@ -315,14 +317,14 @@ static void TagHandlePacketFlow(Flow *f, Packet *p)
                             tde = iter;
                             prev->next = iter->next;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         } else {
                             FlowSetStorageById(p->flow, flow_tag_id, iter->next);
                             tde = iter;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         }
@@ -345,14 +347,14 @@ static void TagHandlePacketFlow(Flow *f, Packet *p)
                             tde = iter;
                             prev->next = iter->next;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         } else {
                             FlowSetStorageById(p->flow, flow_tag_id, iter->next);
                             tde = iter;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         }
@@ -408,13 +410,13 @@ static void TagHandlePacketHost(Host *host, Packet *p)
                             tde = iter;
                             prev->next = iter->next;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         } else {
                             tde = iter;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             HostSetStorageById(host, host_tag_id, iter);
                             continue;
@@ -434,13 +436,13 @@ static void TagHandlePacketHost(Host *host, Packet *p)
                             tde = iter;
                             prev->next = iter->next;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         } else {
                             tde = iter;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             HostSetStorageById(host, host_tag_id, iter);
                             continue;
@@ -464,13 +466,13 @@ static void TagHandlePacketHost(Host *host, Packet *p)
                             tde = iter;
                             prev->next = iter->next;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             continue;
                         } else {
                             tde = iter;
                             iter = iter->next;
-                            SCFree(tde);
+                            DetectTagDataEntryFree(tde);
                             (void) SC_ATOMIC_SUB(num_tags, 1);
                             HostSetStorageById(host, host_tag_id, iter);
                             continue;
@@ -568,7 +570,7 @@ int TagTimeoutCheck(Host *host, struct timeval *tv)
             tde = tmp;
             tmp = tde->next;
 
-            SCFree(tde);
+            DetectTagDataEntryFree(tde);
             (void) SC_ATOMIC_SUB(num_tags, 1);
         } else {
             HostSetStorageById(host, host_tag_id, tmp->next);
@@ -576,11 +578,20 @@ int TagTimeoutCheck(Host *host, struct timeval *tv)
             tde = tmp;
             tmp = tde->next;
 
-            SCFree(tde);
+            DetectTagDataEntryFree(tde);
             (void) SC_ATOMIC_SUB(num_tags, 1);
         }
     }
     return retval;
+}
+
+/**
+ *  \retval The linked list of tags for the specified flow if it exists.
+ *  \retval Null if no tags exist.
+ */
+DetectTagDataEntry *TagGetFlowTag(Flow* flow)
+{
+    return FlowGetStorageById(flow, flow_tag_id);
 }
 
 #ifdef UNITTESTS

--- a/src/detect-engine-tag.h
+++ b/src/detect-engine-tag.h
@@ -56,6 +56,8 @@ int TagTimeoutCheck(Host *, struct timeval *);
 
 int TagHostHasTag(Host *host);
 
+DetectTagDataEntry *TagGetFlowTag(Flow* flow);
+
 void DetectEngineTagRegisterTests(void);
 
 #endif /* __DETECT_ENGINE_TAG_H__ */

--- a/src/detect-tag-pcap.c
+++ b/src/detect-tag-pcap.c
@@ -1,0 +1,291 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+#include "detect-tag-pcap.h"
+#include "decode.h"
+#include "pcap-helper.h"
+#include "util-time.h"
+#include "stream-tcp-private.h"
+#include <pthread.h>
+#include <errno.h>
+
+#ifndef HOST_NAME_MAX
+#ifdef __APPLE__
+#define HOST_NAME_MAX 255
+#elif defined(_WIN32) || defined(_WIN64)
+#define HOST_NAME_MAX 255
+#endif
+#endif
+
+/* PCAP_SNAPLEN (snapshot length) is the amount of data available per capture.
+ * The default is 262144 bytes. Setting the snaplen to 0 will set it to
+ * this default value, but also allow for backwards compatibility for older
+ * versions of tcpdump. */
+#define PCAP_SNAPLEN 0
+
+typedef struct OutputConfig_ {
+    char g_hostname[HOST_NAME_MAX];
+    const char *g_output_dir;
+} OutputConfig;
+
+OutputConfig g_output_config;
+
+void GenerateStreamFilenameTimebuf(char *time_buf,size_t time_buf_size,
+                                   time_t packet_time);
+static void DumpTcpSegment(TcpSession *session, TcpSegment *seg,
+                          pcap_dumper_t *dump_handle, bool client);
+
+/**
+ * \brief Initializes filename for output pcap log.
+ * \param output_directory Configurable filename from suricata.yaml.
+ */
+void InitializePcapLogFilenameSupport(const char *output_directory)
+{
+    if(gethostname(g_output_config.g_hostname, sizeof(g_output_config.g_hostname))
+        != 0) {
+        FatalError(SC_ERR_HOST_INIT, "Error looking up hostname in "
+                                     "detect-tag-pcap.c Error: %s",
+                                     strerror(errno));
+    }
+
+    if (output_directory == NULL) {
+        g_output_config.g_output_dir = ConfigGetLogDirectory();
+    } else {
+        g_output_config.g_output_dir = output_directory;
+    }
+}
+
+/**
+ * \brief Fills the time_buf with a time string that will be used in the pcap
+ *  filename.
+ * \param time_buf buffer to hold the time string.
+ * \param time_buf_size length of the time buffer.
+ * \param packet_time time value that is used to generate the time string.
+ */
+void GenerateStreamFilenameTimebuf(char *time_buf, size_t time_buf_size,
+        time_t packet_time)
+{
+    time_t time = packet_time;
+    struct tm local_tm;
+    struct tm *t = SCLocalTime(time, &local_tm);
+
+    if (unlikely(t == NULL)) {
+        FatalError(SC_ERR_TS, "Unable to create time structure, ts-error");
+    }
+
+    char fmt_time_buf[64];
+    CreateFormattedTimeString(t, "%Y%m%d_%H%M%S.%%06u", fmt_time_buf,
+                              sizeof(fmt_time_buf));
+
+    int ret = snprintf(time_buf, time_buf_size,
+                       fmt_time_buf, packet_time);
+    if (ret < 0 || (size_t) ret >= time_buf_size) {
+        SCLogError(SC_ERR_INVALID_NUM_BYTES, "Provided buffer size is too "
+                                             "small to create full time "
+                                             "buffer. Error: %s",
+                   strerror(errno));
+    }
+}
+
+/**
+ *  \brief Fills the result_path_buf with a full file path that can be used
+ *   to create a file. InitializePcapLogFilenameSupport() must be run before
+ *   this is called.
+ *  \param result_path_buf buffer to hold the path string.
+ *  \param result_buf_size length of the filename buffer used.
+ *  \param p packet pointer.
+ *  \param signature that alerted.
+ *  \param thread_id unique id for the current thread.
+ *  \param unique_id counter incrementing over time to add entropy to filenames.
+ */
+void GenerateStreamFilepath(char *result_path_buf, size_t result_buf_size,
+        TaggedPcapEntry *tpe)
+{
+    if (tpe == NULL || result_path_buf == NULL) {
+        return;
+    }
+    char time_buf[FILENAME_TIMEBUF_SIZE];
+    GenerateStreamFilenameTimebuf(time_buf, FILENAME_TIMEBUF_SIZE, tpe->time);
+    int ret;
+
+    ret = snprintf(result_path_buf, result_buf_size,"%s/%u-%u.%s.%u.%s.pcap",
+            g_output_config.g_output_dir, tpe->thread_id, tpe->unique_id,
+            g_output_config.g_hostname, tpe->signature_id, time_buf);
+
+    if (ret < 0 || (size_t)ret >= result_buf_size) {
+        FatalError(SC_ERR_INVALID_NUM_BYTES, "Provided buffer size is too "
+                                             "small to create PCAP file path. "
+                                             "Error: %s", strerror(errno));
+    }
+}
+
+/**
+ *  \brief Registration for TaggedPcapEntry when writing the output to files.
+ *  \param p pointer to the packet being alerted on.
+ *  \param sig signature that triggered the alert.
+ *  \param thread_id id of the thread we're on; used for uniqueness in filename.
+ *  \param unique_id unique counter per thread that increments to increase
+ *  the entropy of filenames.
+ */
+TaggedPcapEntry *SetupTaggedPcap(const Packet *p, const Signature *sig, int
+        thread_id, int unique_id)
+{
+    char pcap_file_path[PATH_MAX];
+    TaggedPcapEntry *tpe = (TaggedPcapEntry*) SCCalloc(1,sizeof(*tpe));
+    if (unlikely(tpe == NULL)) {
+        return NULL;
+    }
+    /*
+     * Initialize tpe's id & time variables
+     */
+    tpe->time = p->ts.tv_usec;
+    tpe->thread_id = thread_id;
+    tpe->unique_id = unique_id;
+    tpe->signature_id = sig->id;
+
+    GenerateStreamFilepath(pcap_file_path, PATH_MAX, tpe);
+
+    tpe->pcap_dead_handle = pcap_open_dead(p->datalink, PCAP_SNAPLEN);
+    if (tpe->pcap_dead_handle == NULL) {
+        SCLogError(SC_ERR_PCAP_OPEN_OFFLINE, "Error opening dead pcap "
+                                             "handle: %s", pcap_geterr
+                                             (tpe->pcap_dead_handle));
+        SCFree(tpe);
+        return NULL;
+    }
+    tpe->pcap_dumper = pcap_dump_open(tpe->pcap_dead_handle,
+            pcap_file_path);
+    if (tpe->pcap_dumper == NULL) {
+        SCLogError(SC_ERR_PCAP_OPEN_OFFLINE, "Failed to create tag output "
+                                             "file at %s. Error: %s",
+                                             pcap_file_path,
+                                             pcap_geterr(tpe->pcap_dead_handle));
+        SCFree(tpe);
+        return NULL;
+    }
+    return tpe;
+}
+
+/**
+ *  \brief Frees memory associated with TagDataPcapEntry
+ *  \param tpe tagged pcap file object to clean up
+ */
+void CleanUpTaggedPcap(TaggedPcapEntry *tpe)
+{
+    if (tpe != NULL) {
+        pcap_dump_close(tpe->pcap_dumper);
+        pcap_close(tpe->pcap_dead_handle);
+        SCFree(tpe);
+    }
+}
+
+/**
+ *  \brief Log the packet passed in to the relevant TaggedPcapEntry. The
+ *   logging destination is a pcap dumper.
+ *  \param dump_handle pcap_dumper location.
+ *  \param p packet structure to log packets from.
+ */
+void DumpTaggedPacket(pcap_dumper_t *dump_handle, const Packet *p)
+{
+    struct pcap_pkthdr pcap_hdr;
+    pcap_hdr.ts.tv_sec = p->ts.tv_sec;
+    pcap_hdr.ts.tv_usec = p->ts.tv_usec;
+    pcap_hdr.caplen = GET_PKT_LEN(p);
+    pcap_hdr.len = GET_PKT_LEN(p);
+    pcap_dump((u_char *) dump_handle, &pcap_hdr, GET_PKT_DATA(p));
+}
+
+/**
+ *  \brief Logs TcpSession to pcap file. Should be called immediately after
+ *   creation of the pcap file. Scans through the TcpSegment RB Trees on both
+ *   client and server side and dumps the segments in order to pcap file.
+ *  \param session to be dumped to pcap.
+ *  \param dump_handle pcap_dumper location.
+ *  \param p Packet being processed at time of alert.
+ */
+void LogTcpSession(TcpSession *session, pcap_dumper_t *dump_handle, const
+        Packet *p)
+{
+    TcpSegment *server_node = session->server.seg_tree.rbh_root;
+    TcpSegment *client_node = session->client.seg_tree.rbh_root;
+
+    if (server_node == NULL && client_node == NULL) {
+        return;
+    }
+
+    while (server_node != NULL || client_node != NULL) {
+        if (server_node == NULL) {
+            /*
+             * This means the server side RB Tree has been completely searched,
+             * thus all that remains is to dump the TcpSegments on the client
+             * side.
+             */
+            DumpTcpSegment(session, client_node, dump_handle, true);
+            client_node = TCPSEG_RB_NEXT(client_node);
+        } else if (client_node == NULL) {
+            /*
+             * This means the client side RB Tree has been completely searched,
+             * thus all that remains is to dump the TcpSegments on the server
+             * side.
+             */
+            DumpTcpSegment(session, server_node, dump_handle, false);
+            server_node = TCPSEG_RB_NEXT(server_node);
+        } else {
+            if (client_node->pcap_hdr_storage->pcap_cnt <
+                    server_node->pcap_hdr_storage->pcap_cnt) {
+                DumpTcpSegment(session, client_node, dump_handle, true);
+                client_node = TCPSEG_RB_NEXT(client_node);
+            } else {
+                DumpTcpSegment(session, server_node, dump_handle, false);
+                server_node = TCPSEG_RB_NEXT(server_node);
+            }
+        }
+    }
+}
+
+/**
+ * \brief Dumps content of a TcpSegment to specified pcap output file.
+ * \param seg TcpSegment to be dumped to pcap.
+ * \param dump_handle pcap_dumper location.
+ * \bool client direction of segment (to client or to server).
+ */
+static void DumpTcpSegment(TcpSession *session, TcpSegment *seg,
+        pcap_dumper_t *dump_handle, bool client)
+{
+    if (seg->pcap_hdr_storage == NULL || seg->pcap_hdr_storage->pkt_hdr == NULL)
+    {
+        return;
+    }
+    struct pcap_pkthdr pcap_hdr;
+    uint32_t packet_len = seg->pcap_hdr_storage->pktlen;
+    uint32_t payload_len = seg->payload_len;
+    uint32_t packet_header_len = packet_len - payload_len;
+
+    pcap_hdr.ts.tv_sec = seg->pcap_hdr_storage->ts.tv_sec;
+    pcap_hdr.ts.tv_usec = seg->pcap_hdr_storage->ts.tv_usec;
+
+    if (client) {
+        SplitPcapDump((u_char *) dump_handle, &pcap_hdr,
+                seg->pcap_hdr_storage->pkt_hdr, packet_header_len,
+                session->client.sb.buf + seg->sbseg.stream_offset, payload_len);
+    } else {
+        SplitPcapDump((u_char *) dump_handle, &pcap_hdr,
+                seg->pcap_hdr_storage->pkt_hdr, packet_header_len,
+                session->server.sb.buf + seg->sbseg.stream_offset, payload_len);
+        }
+}

--- a/src/detect-tag-pcap.h
+++ b/src/detect-tag-pcap.h
@@ -1,0 +1,60 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ *  This adds support for creating .pcap output files for each tagged flow.
+ *  File information is stored with the tag, rather than the flow. The reasons
+ *  for this are multi-fold:
+ *  1) Flows are locking on changes while tags are not.
+ *  2) A flow may have multiple tags.
+ *  3) Tags know when to stop following the flow (Thus when to close the file)
+ *  4) A flow id can be used to lookup a flow's tags (Trivial and non-locking).
+ */
+#ifndef __DETECT_TAG_PCAP_H__
+#define __DETECT_TAG_PCAP_H__
+
+#include "suricata-common.h"
+#include "suricata.h"
+#include "decode.h"
+#include "detect.h"
+#include "log-pcap-stream.h"
+#include "pcap.h"
+#include "stream-tcp-private.h"
+
+#define FILENAME_TIMEBUF_SIZE 64
+
+typedef struct TaggedPcapEntry_ {
+    pcap_dumper_t *pcap_dumper;
+    pcap_t *pcap_dead_handle;
+    time_t time;
+    int thread_id;
+    uint32_t unique_id;
+    uint32_t signature_id;
+} TaggedPcapEntry;
+
+
+void InitializePcapLogFilenameSupport(const char *output_directory);
+void GenerateStreamFilepath(char *result_path_buf, size_t result_buf_size,
+      TaggedPcapEntry *tpe);
+TaggedPcapEntry *SetupTaggedPcap(const Packet *p, const Signature *sig, int
+        thread_id, int unique_id);
+void CleanUpTaggedPcap(TaggedPcapEntry *tpe);
+void DumpTaggedPacket(pcap_dumper_t *dump_handle, const Packet *p);
+void LogTcpSession(TcpSession *session, pcap_dumper_t *dump_handle, const
+        Packet *p);
+
+#endif /*__DETECT_TAG_PCAP_H__*/

--- a/src/detect-tag.c
+++ b/src/detect-tag.c
@@ -29,6 +29,7 @@
 #include "detect.h"
 #include "detect-parse.h"
 #include "detect-tag.h"
+#include "detect-tag-pcap.h"
 #include "detect-engine-tag.h"
 #include "detect-engine.h"
 #include "detect-engine-state.h"
@@ -303,16 +304,15 @@ int DetectTagSetup(DetectEngineCtx *de_ctx, Signature *s, const char *tagstr)
     return 0;
 }
 
-/** \internal
- *  \brief this function will free memory associated with
- *        DetectTagDataEntry
- *
+/**
+ *  \brief this function will free memory associated with DetectTagDataEntry
  *  \param td pointer to DetectTagDataEntry
  */
-static void DetectTagDataEntryFree(void *ptr)
+void DetectTagDataEntryFree(void *ptr)
 {
     if (ptr != NULL) {
         DetectTagDataEntry *dte = (DetectTagDataEntry *)ptr;
+        CleanUpTaggedPcap(dte->pcap_file);
         SCFree(dte);
     }
 }
@@ -459,3 +459,4 @@ void DetectTagRegisterTests(void)
     DetectEngineTagRegisterTests();
 }
 #endif /* UNITTESTS */
+

--- a/src/detect-tag.h
+++ b/src/detect-tag.h
@@ -25,8 +25,8 @@
 #ifndef __DETECT_TAG_H__
 #define __DETECT_TAG_H__
 
-#include "suricata-common.h"
 #include "suricata.h"
+#include "suricata-common.h"
 #include "util-time.h"
 
 /* Limit the number of times a session can be tagged by the
@@ -88,6 +88,7 @@ typedef struct DetectTagDataEntry_ {
 #if __WORDSIZE == 64
     uint32_t pad1;
 #endif
+    struct TaggedPcapEntry_ *pcap_file;
     struct DetectTagDataEntry_ *next;   /**< Pointer to the next tag of this
                                          *   session/src_host/dst_host (if any from other rule) */
 } DetectTagDataEntry;
@@ -99,6 +100,7 @@ typedef struct DetectTagDataEntry_ {
 /* prototypes */
 struct DetectEngineCtx_ ;
 void DetectTagRegister(void);
+void DetectTagDataEntryFree(void *ptr);
 void DetectTagDataFree(struct DetectEngineCtx_ *, void *ptr);
 void DetectTagDataListFree(void *ptr);
 

--- a/src/log-pcap-stream.c
+++ b/src/log-pcap-stream.c
@@ -1,0 +1,312 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ *  Pcap packet logging module.
+ *  Enabled through suricata.yaml:
+ *  - stream-pcap-log:
+ *      enabled: yes/no
+ *      output_directory: # Defaults to default-log-dir
+ *      session-dump: yes/no # Dumps tcp session upon creation of pcap file.
+ */
+#include "suricata-common.h"
+#include "detect-engine-tag.h"
+#include "detect-tag-pcap.h"
+#include "log-pcap-stream.h"
+#include "output.h"
+#include "stream-tcp-reassemble.h"
+#include "threads.h"
+#include "threadvars.h"
+#include "tm-threads.h"
+
+#define MODULE_NAME "PcapLogStream"
+
+/**
+ *  \brief Variable to store the output context. Contains the filename of the
+ *   output file.
+ */
+typedef struct StreamOutputCtx_ {
+    char filename[NAME_MAX];
+    bool session_dump_enabled;
+} StreamOutputCtx;
+
+/**
+ *  \brief Variables to maintain context on this thread.
+ */
+typedef struct StreamPcapLogThreadData_ {
+    uint32_t count;
+    StreamOutputCtx *stream_output_ctx;
+} StreamPcapLogThreadData;
+
+/* Forward declarations for registration. */
+
+static int StreamPcapLog(ThreadVars *tv, void *thread_data, const Packet *p);
+static int StreamPcapLogCondition(ThreadVars *tv, const Packet *p);
+static TmEcode StreamPcapLogThreadInit(ThreadVars *tv, const void *initdata,
+        void **data);
+static TmEcode StreamPcapLogThreadDeInit(ThreadVars *tv, void *thread_data);
+static OutputInitResult StreamPcapLogInitCtx(ConfNode *conf);
+static void StreamPcapLogFileDeInitCtx(OutputCtx *output_ctx);
+
+static StreamOutputCtx *GetStreamOutputCtx(const OutputCtx *output_ctx);
+static void GeneratePcapFiles(ThreadVars *tv, StreamPcapLogThreadData *td,
+        const Packet *p);
+
+/**
+ * \brief Stream pcap logging main function.
+ * \param tv thread-specific variables.
+ * \param thread_data thread module specific data.
+ * \param p Pointer to current packet being processed.
+ * \return TM_ECODE_OK on success.
+ */
+static int StreamPcapLog(ThreadVars *tv, void *thread_data, const Packet *p)
+{
+    StreamPcapLogThreadData *td = (StreamPcapLogThreadData *) thread_data;
+    td->count++;
+    GeneratePcapFiles(tv, thread_data, p);
+    return TM_ECODE_OK;
+}
+
+/**
+ * \brief Generate pcap events for the alerted packet. Handles single packet
+ *  protocols/alerts and multiple packet alerts. For single packet
+ *  alerts, the alert file or event message are created and output.
+ *  For multiple packet alerts, the pcap file is created.
+ * \param tv thread-specific variables.
+ * \param td thread data containing the output context.
+ * \param p Pointer to current packet being processed.
+ */
+static void GeneratePcapFiles(ThreadVars *tv, StreamPcapLogThreadData *td,
+        const Packet *p)
+{
+    if (!(p->flags & PKT_HAS_FLOW) && p->flags & PKT_HAS_TAG) {
+        /*
+         * Single packet protocols (eg. ICMP) won't have a flow created for
+         * them. A tagged rule alert can still trigger on the packet meaning
+         * we'd want to produce a PCAP.
+         */
+        for (uint16_t x = 0; x < p->alerts.cnt; x++) {
+            /* Is the alert from a tagged signature? */
+            if (p->alerts.alerts[x].s->sm_arrays[DETECT_SM_LIST_TMATCH] !=
+                NULL) {
+                TaggedPcapEntry *pcap_file = SetupTaggedPcap(p, p->alerts
+                .alerts->s, tv->id, td->count);
+                DumpTaggedPacket(pcap_file->pcap_dumper, p);
+                CleanUpTaggedPcap(pcap_file);
+            }
+        }
+    }
+
+    /**
+     *  The flow is locked during this method call. It's safe to read and
+     *  modify session tags.
+     */
+
+    DetectTagDataEntry *tags = TagGetFlowTag(p->flow);
+    /**
+     *  Log this packet to every tag's output PCAP stream. The detect-tag
+     *  code will handle cleanup and deletion of expired tags.
+     */
+    while (tags != NULL) {
+        DetectTagDataEntry *current_tag = tags;
+        tags = tags->next;
+        /* Initialize the tag's output(s) PCAP stream if not already done. */
+        if (current_tag->pcap_file == NULL) {
+            /**
+              * Find the Signature instance inside the packet that matches
+              * the tag's SID.
+              */
+            const PacketAlert *tag_alert = NULL;
+            for (uint16_t x=0; x < p->alerts.cnt; x++) {
+                if (p->alerts.alerts[x].s->id == current_tag->sid) {
+                    tag_alert = &p->alerts.alerts[x];
+                    break;
+                }
+            }
+            if (tag_alert == NULL) {
+                /**
+                   * This case happens when a rule hits its threshold
+                   * settings. The alert doesn't get generated but the
+                   * tagging will still occur. Skip the tag.
+                   */
+                continue;
+            }
+            current_tag->pcap_file = SetupTaggedPcap(p, tag_alert->s, tv->id,
+                    td->count);
+
+            if (td->stream_output_ctx->session_dump_enabled) {
+                TcpSession *session = (TcpSession *) p->flow->protoctx;
+                if (session != NULL) {
+                    LogTcpSession(session, current_tag->pcap_file->pcap_dumper,
+                            p);
+                }
+            }
+        }
+        DumpTaggedPacket(current_tag->pcap_file->pcap_dumper, p);
+    }
+}
+
+/**
+ *  \brief StreamPcapLogRegister Register the logger to the output-packet
+ *   root logger.
+ */
+void StreamPcapLogRegister(void)
+{
+    SCLogDebug("StreamPcapLogRegister Enter");
+    OutputRegisterPacketModule(LOGGER_PCAP,        // Logger ID
+            MODULE_NAME,                           // Logger name
+            "stream-pcap-log",                     // Configuration name
+            StreamPcapLogInitCtx,                  // Output init function
+            StreamPcapLog,                         // Packet logger function
+            StreamPcapLogCondition,                // Packet condition function
+            StreamPcapLogThreadInit,               // Thread init function
+            StreamPcapLogThreadDeInit,             // Thread deinit
+            NULL);                                 // Thread print stats
+}
+
+/**
+ * \brief Determines whether or not to log this packet.
+ * \param tv thread-specific variables.
+ * \param p Pointer to current packet being processed.
+ * \return TRUE if the packet should be logged.
+ * \return FALSE if we do not need to log the packet.
+ */
+static int StreamPcapLogCondition(ThreadVars *tv, const Packet *p)
+{
+    /* Flow is necessary for tag lookups. Reject invalid packets. */
+    if (((p->flags & (PKT_HAS_FLOW|PKT_IS_INVALID)) == PKT_HAS_FLOW) ||
+        p->alerts.cnt > 0) {
+        return TRUE;
+    }
+    return FALSE;
+}
+
+/**
+ *  \brief StreamPcapLogThreadInit Initialize the thread data.
+ *  \param tv thread-specific variables.
+ *  \param initdata Contains the output_ctx created by StreamPcapLogIitCtx
+ *  \param data Populated with the thread data structure.
+ *  \return TM_ECODE_OK On success.
+ *  \return TM_ECODE_FAILED On serious error.
+ */
+static TmEcode StreamPcapLogThreadInit(ThreadVars *tv, const void *initdata,
+        void **data)
+{
+    // Create and initialize the thread data.
+    if (initdata == NULL) {
+        SCLogDebug("Error getting context for StreamLogPcap. \"initdata\" "
+                   "argument NULL");
+        return TM_ECODE_FAILED;
+    }
+    StreamPcapLogThreadData *td = SCCalloc(1, sizeof(*td));
+    if (unlikely(td == NULL)) {
+        return TM_ECODE_FAILED;
+    }
+
+    StreamOutputCtx *stream_output_ctx = GetStreamOutputCtx((OutputCtx*)
+            initdata);
+    td->stream_output_ctx = stream_output_ctx;
+    td->count = 0;
+    *data = (void *)td;
+    return TM_ECODE_OK;
+}
+
+/**
+ * \brief Thread deinit function.
+ * \param thread_data StreamPcapLog thread data.
+ * \return TM_ECODE_OK On success.
+ */
+static TmEcode StreamPcapLogThreadDeInit(ThreadVars *tv, void *thread_data)
+{
+    StreamPcapLogThreadData *td = thread_data;
+    SCFree(td);
+    return TM_ECODE_OK;
+}
+
+/**
+ *  \brief Fill in stream-pcap logging struct from the provided ConfNode.
+ *  \param conf The configuration node for this output.
+ *  \return output_ctx: Output context (contains a StreamOutputCtx data member)
+ */
+static OutputInitResult StreamPcapLogInitCtx(ConfNode *conf)
+{
+    SCLogNotice("StreamPcapLogInitCtx enter");
+    OutputInitResult result =  {NULL, false};
+    /* Create the output context from the configuration node. */
+    StreamOutputCtx *stream_output_ctx =
+            SCCalloc(1, sizeof(*stream_output_ctx));
+    if (unlikely(stream_output_ctx == NULL)) {
+        SCReturnCT(result, "OutputInitResult");
+    }
+    OutputCtx *output_ctx = SCMalloc(sizeof(*output_ctx));
+    if (unlikely(output_ctx == NULL)) {
+        SCFree(stream_output_ctx);
+        SCReturnCT(result, "OutputInitResult");
+    }
+
+    /* Load output options. */
+    const char *output_directory = ConfNodeLookupChildValue(conf,
+            "output-directory");
+
+    InitializePcapLogFilenameSupport(output_directory);
+
+    if (ConfNodeChildValueIsTrue(conf, "session-dump")) {
+        stream_output_ctx->session_dump_enabled = true;
+        EnableTcpSessionDumping();
+    } else {
+        stream_output_ctx->session_dump_enabled = false;
+    }
+    output_ctx->data = stream_output_ctx;
+    output_ctx->DeInit = StreamPcapLogFileDeInitCtx;
+    result.ctx = output_ctx;
+    result.ok = true;
+    SCReturnCT(result, "OutputInitResult");
+}
+
+/**
+ *  \brief Helper function to extract the StreamOutputCtx from an
+ *   OutputCtx->data
+ *  \param output_ctx Structure that output modules use to maintain private data
+ *  \return *StreamOutputCtx on success.
+ *  \return NULL on failure or if output_ctx->data is NULL.
+ */
+static StreamOutputCtx *GetStreamOutputCtx(const OutputCtx *output_ctx)
+{
+    if (output_ctx == NULL) {
+        return NULL;
+    }
+    return (StreamOutputCtx *) output_ctx->data;
+}
+
+/**
+ * \brief StreamPcapLogFileDeInitCtx Free and close the output context
+ *  created by StreamPcapLogInitCtx.
+ * \param output_ctx The output context to free.
+ */
+static void StreamPcapLogFileDeInitCtx(OutputCtx *output_ctx)
+{
+    SCLogNotice("StreamPcapLogFileDeInitCtx Enter");
+    if (output_ctx == NULL) {
+        return;
+    }
+    if (output_ctx->data != NULL) {
+        StreamOutputCtx *stream_output_ctx_data = (StreamOutputCtx *)
+                output_ctx->data;
+        SCFree(stream_output_ctx_data);
+    }
+    SCFree(output_ctx);
+}

--- a/src/log-pcap-stream.h
+++ b/src/log-pcap-stream.h
@@ -1,0 +1,23 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef __LOG_PCAP_STREAM_H__
+#define __LOG_PCAP_STREAM_H__
+
+void StreamPcapLogRegister(void);
+
+#endif /*__LOG_PCAP_STREAM_H__*/

--- a/src/output.c
+++ b/src/output.c
@@ -59,6 +59,7 @@
 #include "output-json-tls.h"
 #include "output-json-ssh.h"
 #include "log-pcap.h"
+#include "log-pcap-stream.h"
 #include "output-json-file.h"
 #include "output-json-smtp.h"
 #include "output-json-stats.h"
@@ -1113,6 +1114,8 @@ void OutputRegisterLoggers(void)
     LogTcpDataLogRegister();
     /* log stats */
     LogStatsLogRegister();
+    /* stream pcap log */
+    StreamPcapLogRegister();
 
     JsonAlertLogRegister();
     JsonAnomalyLogRegister();

--- a/src/pcap-helper.c
+++ b/src/pcap-helper.c
@@ -1,0 +1,76 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+#include "pcap-helper.h"
+#include "util-error.h"
+
+void SplitPcapDump(u_char *user, struct pcap_pkthdr *libpcap_hdr,
+        const u_char *p1, bpf_u_int32 p1_len, const u_char *p2,
+        bpf_u_int32 p2_len) {
+    /*
+     * Check for overflow due to packet lengths.
+     */
+    if ((p1_len + p2_len) < p1_len) {
+        SCLogError(SC_ERR_PCAPLEN_OVERFLOW,"Error in SplitPcapDump. Overflow "
+                                           "due to packet lengths.");
+        return;
+    }
+    register FILE *f;
+    struct PcapSfPktHdr sf_hdr;
+    size_t ret;
+    f = (FILE *) user;
+
+    /*
+     * Better not try writing pcap files after 2038-01-19 03:14:07 UTC; switch
+     * to pcapng.
+     */
+    sf_hdr.ts.tv_sec = libpcap_hdr->ts.tv_sec;
+    sf_hdr.ts.tv_usec = libpcap_hdr->ts.tv_usec;
+    sf_hdr.caplen = p1_len + p2_len;
+    sf_hdr.len = p1_len + p2_len;
+
+    /*
+     * Write libpcap header.
+     */
+    ret = fwrite(&sf_hdr, sizeof(sf_hdr), 1, f);
+    if (ret != 1) {
+        SCLogError(SC_ERR_FWRITE, "Error writing libpcap header. Error: %s",
+                strerror(errno));
+        return;
+    }
+    /*
+     * Write the first part of the packet. In our use case this is the
+     * separately tracked packet header.
+     */
+    ret = fwrite(p1, p1_len, 1, f);
+    if (ret != 1) {
+        SCLogError(SC_ERR_FWRITE, "Error writing first portion of packet. "
+                                  "Error %s", strerror(errno));
+        return;
+    }
+    /*
+     * Write the second part of the packet. In our use case this is the packet
+     * payload.
+     */
+    ret = fwrite(p2, p2_len, 1, f);
+    if (ret != 1) {
+        SCLogError(SC_ERR_FWRITE, "Error writing second portion of packet. "
+                                  "Error %s", strerror(errno));
+    }
+}
+

--- a/src/pcap-helper.h
+++ b/src/pcap-helper.h
@@ -1,0 +1,36 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef __PCAP_HELPER_H__
+#define __PCAP_HELPER_H__
+
+struct TimevalHelper {
+    bpf_int32 tv_sec;
+    bpf_int32 tv_usec;
+};
+
+struct PcapSfPktHdr {
+    struct TimevalHelper ts;
+    bpf_u_int32 caplen;
+    bpf_u_int32 len;
+} __attribute__((packed));
+
+void SplitPcapDump(u_char *user, struct pcap_pkthdr *libpcap_hdr,
+        const u_char *p1, bpf_u_int32 p1_len, const u_char *p2,
+        bpf_u_int32 p2_len);
+
+#endif //__PCAP_HELPER_H

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -32,6 +32,8 @@
 #include "util-validate.h"
 
 static void StreamTcpRemoveSegmentFromStream(TcpStream *stream, TcpSegment *seg);
+static void StreamTcpSegmentAddPacketData(TcpSegment *seg, Packet *p,
+        ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx);
 
 static int check_overlap_different_data = 0;
 
@@ -565,6 +567,9 @@ int StreamTcpReassembleInsertSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
     /* insert segment into list. Note: doesn't handle the data */
     int r = DoInsertSegment (stream, seg, &dup_seg, p);
     SCLogDebug("DoInsertSegment returned %d", r);
+    if (IsTcpSessionDumpingEnabled()) {
+        StreamTcpSegmentAddPacketData(seg, p, tv, ra_ctx);
+    }
     if (r < 0) {
         StatsIncr(tv, ra_ctx->counter_tcp_reass_list_fail);
         StreamTcpSegmentReturntoPool(seg);
@@ -890,6 +895,53 @@ void StreamTcpPruneSession(Flow *f, uint8_t flags)
     SCReturn;
 }
 
+/**
+ * \brief Adds the following information to the TcpSegment from the current
+ *  packet being processed: time values, packet length, pcap_cnt, and the
+ *  header data of the packet. This information is added to the TcpSegment so
+ *  that it can be used in pcap capturing (log-pcap-stream) to dump the tcp
+ *  session at the beginning of the pcap capture.
+ * \param seg TcpSegment where information is being stored.
+ * \param p Packet being processed.
+ * \param tv Thread-specific variables.
+ * \param ra_ctx TcpReassembly thread-specific variables
+ */
+static void StreamTcpSegmentAddPacketData(TcpSegment *seg, Packet *p,
+        ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx)
+{
+    if (seg->pcap_hdr_storage == NULL || seg->pcap_hdr_storage->pkt_hdr == NULL) {
+        return;
+    }
+    if (GET_PKT_DATA(p) != NULL && GET_PKT_LEN(p) > p->payload_len) {
+        seg->pcap_hdr_storage->ts.tv_sec = p->ts.tv_sec;
+        seg->pcap_hdr_storage->ts.tv_usec = p->ts.tv_usec;
+        seg->pcap_hdr_storage->pktlen = GET_PKT_LEN(p);
+        seg->pcap_hdr_storage->pcap_cnt = p->pcap_cnt;
+        /*
+         * pkt_hdr members are initially allocated 64 bytes of memory. Thus,
+         * need to check that this is sufficient and allocate more memory if
+         * not.
+         */
+        if (GET_PKT_LEN(p) - p->payload_len > TCPSEG_PKT_HDR_DEFAULT_SIZE) {
+            uint8_t *tmp_pkt_hdr = SCRealloc(seg->pcap_hdr_storage->pkt_hdr,
+                    GET_PKT_LEN(p) - p->payload_len);
+            if (tmp_pkt_hdr == NULL) {
+                StatsIncr(tv, ra_ctx->counter_tcp_segment_add_data_realloc_fail);
+            } else {
+                seg->pcap_hdr_storage->pkt_hdr = tmp_pkt_hdr;
+            }
+        }
+
+        memcpy(seg->pcap_hdr_storage->pkt_hdr, GET_PKT_DATA(p),
+                (size_t) GET_PKT_LEN(p) - p->payload_len);
+
+    } else {
+        seg->pcap_hdr_storage->ts.tv_sec = 0;
+        seg->pcap_hdr_storage->ts.tv_usec = 0;
+        seg->pcap_hdr_storage->pktlen = 0;
+        seg->pcap_hdr_storage->pcap_cnt = 0;
+    }
+}
 
 /*
  *  unittests

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -58,12 +58,27 @@ int TcpSackCompare(struct StreamTcpSackRecord *a, struct StreamTcpSackRecord *b)
 RB_HEAD(TCPSACK, StreamTcpSackRecord);
 RB_PROTOTYPE(TCPSACK, StreamTcpSackRecord, rb, TcpSackCompare);
 
+#define TCPSEG_PKT_HDR_DEFAULT_SIZE 64
+
+/*
+ * Struct to add the additional information required to use TcpSegments to dump
+ * a packet capture to file with the stream-pcap-log output option. This is only
+ * used if the session-dump option is enabled.
+ */
+typedef struct TcpSegmentPcapHdrStorage_ {
+    struct timeval ts;
+    uint32_t pktlen;
+    uint64_t pcap_cnt;
+    uint8_t *pkt_hdr;
+} TcpSegmentPcapHdrStorage;
+
 typedef struct TcpSegment {
     PoolThreadReserved res;
     uint16_t payload_len;       /**< actual size of the payload */
     uint32_t seq;
     RB_ENTRY(TcpSegment) __attribute__((__packed__)) rb;
     StreamingBufferSegment sbseg;
+    TcpSegmentPcapHdrStorage *pcap_hdr_storage;
 } __attribute__((__packed__)) TcpSegment;
 
 /** \brief compare function for the Segment tree

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -77,6 +77,7 @@ typedef struct TcpReassemblyThreadCtx_ {
     uint16_t counter_tcp_reass_data_normal_fail;
     uint16_t counter_tcp_reass_data_overlap_fail;
     uint16_t counter_tcp_reass_list_fail;
+    uint16_t counter_tcp_segment_add_data_realloc_fail;
 } TcpReassemblyThreadCtx;
 
 #define OS_POLICY_DEFAULT   OS_POLICY_BSD
@@ -129,6 +130,8 @@ int StreamTcpCheckStreamContents(uint8_t *, uint16_t , TcpStream *);
 
 bool StreamReassembleRawHasDataReady(TcpSession *ssn, Packet *p);
 void StreamTcpReassemblySetMinInspectDepth(TcpSession *ssn, int direction, uint32_t depth);
+void EnableTcpSessionDumping(void);
+int IsTcpSessionDumpingEnabled(void);
 
 static inline bool STREAM_LASTACK_GT_BASESEQ(const TcpStream *stream)
 {

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5236,6 +5236,7 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->ra_ctx->counter_tcp_reass_data_normal_fail = StatsRegisterCounter("tcp.insert_data_normal_fail", tv);
     stt->ra_ctx->counter_tcp_reass_data_overlap_fail = StatsRegisterCounter("tcp.insert_data_overlap_fail", tv);
     stt->ra_ctx->counter_tcp_reass_list_fail = StatsRegisterCounter("tcp.insert_list_fail", tv);
+    stt->ra_ctx->counter_tcp_segment_add_data_realloc_fail = StatsRegisterCounter("tcp.segment_add_data_realloc_fail", tv);
 
 
     SCLogDebug("StreamTcp thread specific ctx online at %p, reassembly ctx %p",

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -375,6 +375,9 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_WARN_FILESTORE_CONFIG);
         CASE_CODE (SC_WARN_PATH_READ_ERROR);
         CASE_CODE (SC_ERR_PLUGIN);
+        CASE_CODE (SC_ERR_TS);
+        CASE_CODE (SC_ERR_RENAME);
+        CASE_CODE (SC_ERR_PCAPLEN_OVERFLOW);
 
         CASE_CODE (SC_ERR_MAX);
     }

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -365,6 +365,9 @@ typedef enum {
     SC_WARN_PATH_READ_ERROR,
     SC_ERR_HTTP2_LOG_GENERIC,
     SC_ERR_PLUGIN,
+    SC_ERR_TS, /** Error indicating a failure to create time struct.**/
+    SC_ERR_RENAME, /** Error indicating a failure to rename file. **/
+    SC_ERR_PCAPLEN_OVERFLOW,
 
     SC_ERR_MAX
 } SCError;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -79,6 +79,12 @@ outputs:
       append: yes
       #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
 
+  # Outputs a PCAP file per tagged alert.
+  - stream-pcap-log:
+      enabled: no
+      # output-directory: /data/pcap # Defaults to the default-log-dir.
+      # session-dump: yes # Dumps tcp session upon creation of PCAP file.
+
   # Extensible Event Format (nicknamed EVE) event log in JSON format
   - eve-log:
       enabled: @e_enable_evelog@


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/120

Describe changes:
- This is a new feature development to capture a session upon an alert. The ticket linked above guided the overall development.
- Capturing of a session relies on using the tag keyword in a signature. Specifically "tag:session".
- When output is being processed & this feature is enabled through the suricata.yaml file, a packet is scanned for these tags and is dumped to a .pcap file. 
- However, during development it was noticed that for TCP based protocols, the packet that generated an alert could not be reliably captured. I.e. by the time the alert was generated, this packet was no longer being processed and would not be captured. To overcome this, an option to dump the tcp session was created. In some limited testing, this option has shown success in capturing these packets that were originally "missed". 
- To accomplish this additional data, namely packet headers, time variables, and packet lengths were added to the existent TcpSegment structure to enrich these segments so that they would contain the necessary information for a successful packet capture. 
- The TcpSegment enrichment only will occur if the session-dump option is enabled in suricata.yaml nor will any allocations occur. 

Suggested Review Order/Guide:
- log-pcap-stream.c/.h
   - This file handle registration for the capture output module, initialization/de-initialization, and the main utility of scanning the alerted packets for tags and dumping them if a tag is found.
- detect-tag-pcap.c/h
   - This file contains the functions used for setting up file paths, dumping to these files, and cleaning them up. Additionally it contains the functions that handle the dumping of the enriched tcp segments. 
- pcap-helper.c/h
 - This is basically the same as the code for libpcaps pcap_dump(), but rewritten so that it could dump a packet in two parts, e.g. header and payload written separately. This is currently written in Suricata codestyle and is internal to Suricata, but I'm open to approaching the libpcap team to get this functionality added to their pcap API.
- stream-tcp .c/.h files
   - These files handle the enrichment of the tcp segments, i.e. adding to the TcpSegment struct, copying in new data, and freeing the new data.

These files make up the bulk of this pull request. 

Previous Pull Requests: 
https://github.com/OISF/suricata/pull/5128#partial-pull-merging
https://github.com/OISF/suricata/pull/5159
https://github.com/OISF/suricata/pull/5217

**Changes from capture-feature-120-v3:**
- I've chopped down the size of a few structures in the code to improve performance:
  - The TaggedPcapEntry no longer holds the whole file path. Now it just contains the information necessary to produce the file path on the fly when it is needed. 
  - In the previous version, most of the enriched TcpSegment data was held by adding members to the TcpSegment struct, which resulted in a size increase of 32 bytes. In this version, I've moved that information to a new struct, TcpSegmentPcapHdrStorage, which now holds the necessary information. TcpSegment now only holds an additional pointer to this. The TcpSegmentPcapHdrStorage is also initialized with the TcpSegment pool, so there are still very few allocations during packet processing. I've also dropped the overhead when TcpSegment dumping is not enabled so that not only is the AddPacketData function not triggered, the TcpSegmentPcapHdrStorage space is also not allocated in the first place.
- Additionally, I've removed the temporarily hidden file aspect to the .pcap output. I didn't have a strong justification for doing this in the first place and felt like it wasn't really necessary or inherent to the functionality of the session capture feature. 
- Otherwise, most of the other comments from the previous PR were nits, which I corrected across the board. I think this feature is pretty close to being ready, so let me know what else is needed to get it across the finish line 😄 