### PR TITLE
doc/userguide: align and update doc to reflect config file

### DIFF
--- a/doc/userguide/output/custom-http-logging.rst
+++ b/doc/userguide/output/custom-http-logging.rst
@@ -1,3 +1,5 @@
+.. _custom-http-log:
+
 Custom http logging
 ===================
 

--- a/doc/userguide/output/custom-tls-logging.rst
+++ b/doc/userguide/output/custom-tls-logging.rst
@@ -1,3 +1,5 @@
+.. _custom-tls-log:
+
 Custom tls logging
 ===================
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

https://redmine.openinfosecfoundation.org/issues/3046

Describe changes:
- This reorders the documentation parts to reflect the order in the actual config yaml file
- It adds all missing parts and sections that appear in the config file
- Content was updated to reflect some changes already happend
- Minor wording and related fixes
- Adding a lot of info to the default values as noted in the redmine, not yet all are covered
- inludes some TODO as comments that still need to be done (documented) or are open questions, so could be also called WIP somehow

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
