### PR TITLE
threshold: Fix memory leak when parsing threshold rule

### DIFF
--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -669,6 +669,7 @@ static int ParseThresholdRule(DetectEngineCtx *de_ctx, char *rawstr,
     int ov[MAX_SUBSTRINGS];
     uint32_t id = 0, gid = 0;
     ThresholdRuleType rule_type;
+    int res = -1;
 
     if (de_ctx == NULL)
         return -1;
@@ -941,7 +942,9 @@ static int ParseThresholdRule(DetectEngineCtx *de_ctx, char *rawstr,
     *ret_parsed_seconds = parsed_seconds;
     *ret_parsed_timeout = parsed_timeout;
     *ret_th_ip = th_ip;
-    return 0;
+    th_ip = NULL;
+    /* Success */
+    res = 0;
 error:
     if (th_track != NULL)
         SCFree((char *)th_track);
@@ -953,7 +956,7 @@ error:
         SCFree((char *)th_type);
     if (th_ip != NULL)
         SCFree((char *)th_ip);
-    return -1;
+    return res;
 }
 
 /**


### PR DESCRIPTION
Make sure strings allocated by pcre_get_substring are
freed in the success as well as error cases.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2433

Describe changes:
- Make sure strings allocated by pcre_get_substring are freed in the success as well as error case
-
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
