### PR TITLE
iprep: Avoid incorrectly decrementing host use_cnt

### DIFF
--- a/src/detect-iprep.c
+++ b/src/detect-iprep.c
@@ -91,15 +91,14 @@ static uint8_t GetHostRepSrc(Packet *p, uint8_t cat, uint32_t version)
         h = HostLookupHostFromHash(&(p->src));
 
         p->flags |= PKT_HOST_SRC_LOOKED_UP;
+        p->host_src = h;
 
         if (h == NULL)
             return 0;
-
-        HostReference(&p->host_src, h);
     }
 
     if (h->iprep == NULL) {
-        HostRelease(h);
+        HostUnlock(h);
         return 0;
     }
 
@@ -112,7 +111,7 @@ static uint8_t GetHostRepSrc(Packet *p, uint8_t cat, uint32_t version)
     else
         SCLogDebug("version mismatch %u != %u", r->version, version);
 
-    HostRelease(h);
+    HostUnlock(h);
     return val;
 }
 
@@ -130,16 +129,15 @@ static uint8_t GetHostRepDst(Packet *p, uint8_t cat, uint32_t version)
         h = HostLookupHostFromHash(&(p->dst));
 
         p->flags |= PKT_HOST_DST_LOOKED_UP;
+        p->host_dst = h;
 
         if (h == NULL) {
             return 0;
         }
-
-        HostReference(&p->host_dst, h);
     }
 
     if (h->iprep == NULL) {
-        HostRelease(h);
+        HostUnlock(h);
         return 0;
     }
 
@@ -152,7 +150,7 @@ static uint8_t GetHostRepDst(Packet *p, uint8_t cat, uint32_t version)
     else
         SCLogDebug("version mismatch %u != %u", r->version, version);
 
-    HostRelease(h);
+    HostUnlock(h);
     return val;
 }
 


### PR DESCRIPTION
If the packet already has the host_src or host_dst entry
set then the attached host entry is locked without increasing
the use_cnt. If the host is not already linked to the packet
then the use_cnt was incremented firstly in HostLookupHostFromHash
and then secondly in HostReference. We can avoid extra increment
and just unlock the host on function exit.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
May relate to https://redmine.openinfosecfoundation.org/issues/2802

Describe changes:
- Assign the host to the packet without double incrementing the host use_cnt and just unlock on function exit
- 
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
