### PR TITLE
flows: add active flow counter

### DIFF
--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -476,6 +476,7 @@ static inline void FlowUpdateCounter(ThreadVars *tv, DecodeThreadVars *dtv,
                 StatsIncr(tv, dtv->counter_flow_icmp6);
                 break;
         }
+        FlowManagerIncrActiveFlows(1);
 #ifdef UNITTESTS
     }
 #endif

--- a/src/flow-manager.h
+++ b/src/flow-manager.h
@@ -33,5 +33,8 @@ void FlowRecyclerThreadSpawn(void);
 void FlowDisableFlowRecyclerThread(void);
 void TmModuleFlowManagerRegister (void);
 void TmModuleFlowRecyclerRegister (void);
+uint64_t FlowManagerGetActiveFlows(void);
+void FlowManagerIncrActiveFlows(uint32_t n);
+void FlowManagerDecrActiveFlows(uint32_t n);
 
 #endif /* __FLOW_MANAGER_H__ */

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -51,6 +51,8 @@
 
 typedef DetectEngineThreadCtx *DetectEngineThreadCtxPtr;
 
+SC_ATOMIC_EXTERN(uint64_t, active_flow_cnt);
+
 typedef struct FlowTimeoutCounters {
     uint32_t flows_aside_needs_work;
     uint32_t flows_aside_pkt_inject;
@@ -459,6 +461,7 @@ static inline void FlowWorkerProcessLocalFlows(ThreadVars *tv,
     FLOWWORKER_PROFILING_START(p, PROFILE_FLOWWORKER_FLOW_EVICTED);
     if (fw->fls.work_queue.len) {
         StatsAddUI64(tv, fw->cnt.flows_removed, (uint64_t)fw->fls.work_queue.len);
+        FlowManagerDecrActiveFlows((uint64_t)fw->fls.work_queue.len);
 
         FlowTimeoutCounters counters = { 0, 0, };
         CheckWorkQueue(tv, fw, detect_thread, &counters, &fw->fls.work_queue);


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [1478](https://redmine.openinfosecfoundation.org/issues/1478)

Describe changes:
- Adds a global counter "flow_mgr.active_flows" tracking active flows The counter is global to support multiple flow manager threads.