### PR TITLE
Make the rule action available to lua output scripts

### DIFF
--- a/doc/userguide/lua/lua-functions.rst
+++ b/doc/userguide/lua/lua-functions.rst
@@ -792,6 +792,15 @@ SCRuleIds
 
   sid, rev, gid = SCRuleIds()
 
+SCRuleAction
+~~~~~~~~~~~~
+
+::
+
+  action = SCRuleAction()
+
+returns one of 'pass', 'reject', 'drop' or 'alert'
+
 SCRuleMsg
 ~~~~~~~~~
 


### PR DESCRIPTION
Useful for those that want to do custom logging from lua

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Add rule action to LUA functions so that it can be used in custom logging from LUA
-
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
