### PR TITLE
plugin: fix typo in long_opts struct

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1203,7 +1203,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         {"strict-rule-keywords", optional_argument, 0, 0},
 
         {"capture-plugin", required_argument, 0, 0},
-        {"cpature-plugin-args", required_argument, 0, 0},
+        {"capture-plugin-args", required_argument, 0, 0},
 
 #ifdef BUILD_UNIX_SOCKET
         {"unix-socket", optional_argument, 0, 0},


### PR DESCRIPTION
Link to redmine ticket:
https://redmine.openinfosecfoundation.org/issues/3882

Describe changes:

FIxing typo in long_opts struct 
cpature-plugin-args to capture-plugin-args