### PR TITLE
mqtt: fixed wrong slice access that results in rust panic when mqtt ping is processed

### DIFF
--- a/rust/src/mqtt/parser.rs
+++ b/rust/src/mqtt/parser.rs
@@ -628,7 +628,7 @@ pub fn parse_message(input: &[u8], protocol_version: u8, max_msg_size: usize) ->
                             _ => MQTTOperation::UNASSIGNED,
                         },
                     };
-                    return Ok((&rem[skiplen+len..], msg));
+                    return Ok((&input[skiplen+len..], msg));
                 }
                 MQTTTypeCode::DISCONNECT => match parse_disconnect(rem, len, protocol_version) {
                     Ok((_rem, disco)) => {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:

Fixed access of the wrong slice with insufficient size. Probably typo that results in rust panic.
The file with the reproducer is attached. Please note stream.midstream must be enabled since pcap file only contains ping packets without TCP handshake.
[mqtt_ping.zip](https://github.com/OISF/suricata/files/5091873/mqtt_ping.zip)

.


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

suricata-verify-pr: 303
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
