### PR TITLE
enip: duplicate detect and alert on a transaction

### DIFF
--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -343,7 +343,12 @@ static AppLayerResult ENIPParse(Flow *f, void *state, AppLayerParserState *pstat
         tx = ENIPTransactionAlloc(enip);
         if (tx == NULL)
             SCReturnStruct(APP_LAYER_OK);
-
+        if (flags & STREAM_TOSERVER)
+        {
+            tx->tx_data.detect_flags_tc |= APP_LAYER_TX_INSPECTED_FLAG;
+        } else {
+            tx->tx_data.detect_flags_ts |= APP_LAYER_TX_INSPECTED_FLAG;
+        }
         SCLogDebug("ENIPParse input len %d", input_len);
         DecodeENIPPDU(input, input_len, tx);
         uint32_t pkt_len = tx->header.length + sizeof(ENIPEncapHdr);


### PR DESCRIPTION
Enip's parsing function registers ENIPParse in both the request direction and response direction, so each direction corresponds to an independent transaction. However, the transaction analysis engine analyzes both the request and response directions for each transaction, which results in duplication of detection and alert events, and the original IP and destination IP of the alert event are confused.
We can use this simple rule to verify enip messages with only one request and response：
alert enip any any -> any any (msg:"SURICATA enip test ";enip_command:99 ;sid:6450008; rev:1;)
We only expect two alerts, but 6 were reported：
08/19/2020-15:48:38.084428  [**] [1:6450008:1] SURICATA enip test  [**] [Classification: (null)] [Priority: 3] {TCP} 172.25.23.2:44818 -> 172.25.23.1:31304
08/19/2020-15:48:38.125584  [**] [1:6450008:1] SURICATA enip test  [**] [Classification: (null)] [Priority: 3] {TCP} 172.25.23.1:31304 -> 172.25.23.2:44818
08/19/2020-15:48:38.125584  [**] [1:6450008:1] SURICATA enip test  [**] [Classification: (null)] [Priority: 3] {TCP} 172.25.23.1:31304 -> 172.25.23.2:44818
08/19/2020-15:48:42.160720  [**] [1:6450008:1] SURICATA enip test  [**] [Classification: (null)] [Priority: 3] {TCP} 172.25.23.2:44818 -> 172.25.23.1:31304
08/19/2020-15:48:38.125584  [**] [1:6450008:1] SURICATA enip test  [**] [Classification: (null)] [Priority: 3] {TCP} 172.25.23.1:31304 -> 172.25.23.2:44818
08/19/2020-15:48:42.160720  [**] [1:6450008:1] SURICATA enip test  [**] [Classification: (null)] [Priority: 3] {TCP} 172.25.23.2:44818 -> 172.25.23.1:31304
In fact, all protocols that do not associate a request with a response have this problem.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-duplicate detect and alert on a transaction
-
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
