### PR TITLE
napatech: Fix compiler warnings, range parsing, CPP guards

### DIFF
--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -679,11 +679,11 @@ static void NapatechReleasePacket(struct Packet_ *p)
      * If the packet is to be dropped we need to set the wirelength
      * before releasing the Napatech buffer back to NTService.
      */
+#ifdef NAPATECH_ENABLE_BYPASS
     if (is_inline && PACKET_TEST_ACTION(p, ACTION_DROP)) {
         p->ntpv.dyn3->wireLength = 0;
     }
 
-#ifdef NAPATECH_ENABLE_BYPASS
     /*
      *  If this flow is to be programmed for hardware bypass we do it now.  This is done
      *  here because the action is not available in the packet structure at the time of the
@@ -847,11 +847,11 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
         SC_ATOMIC_ADD(stream_count, 1);
         if (SC_ATOMIC_GET(stream_count) == NapatechGetNumConfiguredStreams()) {
 
+#ifdef NAPATECH_ENABLE_BYPASS
             if (ConfGetBool("napatech.inline", &is_inline) == 0) {
                 is_inline = 0;
             }
 
-#ifdef NAPATECH_ENABLE_BYPASS
             /* Initialize the port map before we setup traffic filters */
             for (int i = 0; i < MAX_PORTS; ++i) {
                 inline_port_map[i] = -1;

--- a/src/util-napatech.c
+++ b/src/util-napatech.c
@@ -1385,7 +1385,9 @@ uint32_t NapatechSetupTraffic(uint32_t first_stream, uint32_t last_stream)
     NtConfigStream_t hconfig;
     char ntpl_cmd[512];
     int is_inline = 0;
+#ifdef NAPATECH_ENABLE_BYPASS
     int is_span_port[MAX_PORTS] = { 0 };
+#endif
 
     char span_ports[128];
     memset(span_ports, 0, sizeof(span_ports));

--- a/src/util-napatech.c
+++ b/src/util-napatech.c
@@ -1556,7 +1556,7 @@ uint32_t NapatechSetupTraffic(uint32_t first_stream, uint32_t last_stream)
                 }
                 stream_spec = CONFIG_SPECIFIER_INDIVIDUAL;
 
-                ByteExtractStringUint8(&ports_spec.first[iteration], 10,  0, port->val);
+                ByteExtractStringUint8(&ports_spec.first[iteration], 10, 0, port->val);
 
                 /* Determine the ports to use on the NTPL assign statement*/
                 if (iteration == 0) {

--- a/src/util-napatech.c
+++ b/src/util-napatech.c
@@ -931,7 +931,7 @@ int NapatechGetStreamConfig(NapatechStreamConfig stream_config[])
                                            "Napatech range and individual specifiers cannot be combined.");
                     }
                     stream_spec = CONFIG_SPECIFIER_INDIVIDUAL;
-                    if (StringParseUint16(&stream_config[instance_cnt].stream_id,
+                    if (StringParseUint8(&stream_config[instance_cnt].stream_id,
                                           10, 0, (const char *)stream->val) < 0) {
                         FatalError(SC_ERR_INVALID_VALUE, "Napatech invalid "
                                    "stream id: '%s'", stream->val);


### PR DESCRIPTION
This PR corrects issues found while using Napatech on 6.0.0-beta.

There are 3 classes of issues
- Compiler warnings due to type mismatch
- CPP guards for bypass incorrect
- Parsing of range values from Napatech configuration

Describe changes:
- Correct placement of CPP guards for disabling bypass 
- Fixed configuration value range parsing logic
- Use proper types with log messages
- Use proper function for stream id parsing.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
