### PR TITLE
Plugins - Remove RustContext and dynamically link at runtime - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -19,6 +19,9 @@ env:
 
   DEFAULT_CFLAGS: "-Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-function"
 
+  # Apt sometimes likes to ask for user input, this will prevent that.
+  DEBIAN_FRONTEND: "noninteractive"
+
 jobs:
 
   prep:
@@ -428,6 +431,67 @@ jobs:
       - run: test -e doc/devguide/devguide.pdf
       - run: test -e doc/userguide/userguide.pdf
       - run: make distcheck
+      - name: Extracting suricata-verify
+        run: tar xf prep/suricata-verify.tar.gz
+      - name: Running suricata-verify
+        run: python3 ./suricata-verify/run.py
+
+  ubuntu-20-04:
+    name: Ubuntu 20.04 (no nss, no nspr)
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
+    needs: prep
+    steps:
+      - name: Install dependencies
+        run: |
+          apt update
+          apt -y install \
+                libpcre3 \
+                libpcre3-dev \
+                build-essential \
+                autoconf \
+                automake \
+                git \
+                jq \
+                libtool \
+                libpcap-dev \
+                libnet1-dev \
+                libyaml-0-2 \
+                libyaml-dev \
+                libcap-ng-dev \
+                libcap-ng0 \
+                libmagic-dev \
+                libnetfilter-queue-dev \
+                libnetfilter-queue1 \
+                libnfnetlink-dev \
+                libnfnetlink0 \
+                libhiredis-dev \
+                libjansson-dev \
+                libevent-dev \
+                libevent-pthreads-2.1-7 \
+                libjansson-dev \
+                libpython2.7 \
+                make \
+                parallel \
+                python3-yaml \
+                rustc \
+                software-properties-common \
+                zlib1g \
+                zlib1g-dev \
+                exuberant-ctags
+      - name: Install cbindgen
+        run: cargo install --force --debug --version 0.14.1 cbindgen
+      - run: echo "::add-path::$HOME/.cargo/bin"
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/libhtp.tar.gz
+      - run: ./autogen.sh
+      - run: ./configure --enable-unittests --disable-nss --disable-nspr
+      - run: make -j2
+      - run: make dist
       - name: Extracting suricata-verify
         run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -497,6 +497,69 @@ jobs:
       - name: Running suricata-verify
         run: python3 ./suricata-verify/run.py
 
+  ubuntu-20-04-ndebug:
+    name: Ubuntu 20.04 (-DNDEBUG)
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
+    needs: prep
+    steps:
+
+      - name: Install dependencies
+        run: |
+          apt update
+          apt -y install \
+                build-essential \
+                autoconf \
+                automake \
+                git \
+                jq \
+                libtool \
+                libpcap-dev \
+                libnet1-dev \
+                libyaml-0-2 \
+                libyaml-dev \
+                libcap-ng-dev \
+                libcap-ng0 \
+                libmagic-dev \
+                libnetfilter-queue-dev \
+                libnetfilter-queue1 \
+                libnfnetlink-dev \
+                libnfnetlink0 \
+                libhiredis-dev \
+                libjansson-dev \
+                libevent-dev \
+                libevent-pthreads-2.1-7 \
+                libjansson-dev \
+                libpython2.7 \
+                libpcre3 \
+                libpcre3-dev \
+                make \
+                parallel \
+                python3-yaml \
+                rustc \
+                software-properties-common \
+                zlib1g \
+                zlib1g-dev \
+                exuberant-ctags
+      - name: Install cbindgen
+        run: cargo install --force --debug --version 0.14.1 cbindgen
+      - run: echo "::add-path::$HOME/.cargo/bin"
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/libhtp.tar.gz
+      - run: ./autogen.sh
+      - run: CFLAGS="$DEFAULT_CFLAGS -DNDEBUG" ./configure --enable-unittests
+      - run: make -j2
+      - run: make check
+      - run: make dist
+      - name: Extracting suricata-verify
+        run: tar xf prep/suricata-verify.tar.gz
+      - name: Running suricata-verify
+        run: python3 ./suricata-verify/run.py
+
   ubuntu-18-04-debug-validation:
     name: Ubuntu 18.04 (Debug Validation)
     runs-on: ubuntu-18.04

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -17,6 +17,8 @@ env:
   DEFAULT_SV_BRANCH: master
   DEFAULT_SV_PR:
 
+  DEFAULT_CFLAGS: "-Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-function"
+
 jobs:
 
   prep:
@@ -282,6 +284,78 @@ jobs:
       - name: Building Rust documentation
         run: make doc
         working-directory: rust
+
+  fedora-32:
+    name: Fedora 32 (clang, asan, wshadow, rust-strict)
+    runs-on: ubuntu-latest
+    container: fedora:32
+    needs: prep
+    steps:
+
+      # Cache Rust stuff.
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry
+
+      - run: |
+          dnf -y install \
+                autoconf \
+                automake \
+                cargo \
+                ccache \
+                clang \
+                diffutils \
+                file-devel \
+                gcc \
+                gcc-c++ \
+                git \
+                jansson-devel \
+                jq \
+                lua-devel \
+                libasan \
+                libtool \
+                libyaml-devel \
+                libnfnetlink-devel \
+                libnetfilter_queue-devel \
+                libnet-devel \
+                libcap-ng-devel \
+                libevent-devel \
+                libmaxminddb-devel \
+                libpcap-devel \
+                libtool \
+                lz4-devel \
+                make \
+                nspr-devel \
+                nss-devel \
+                nss-softokn-devel \
+                pcre-devel \
+                pkgconfig \
+                python3-yaml \
+                sudo \
+                which \
+                zlib-devel
+      - run: |
+          cargo install --debug cbindgen
+          echo "::add-path::$HOME/.cargo/bin"
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/libhtp.tar.gz
+      - run: ./autogen.sh
+      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-unittests --disable-shared --enable-rust-strict
+        env:
+          ac_cv_func_realloc_0_nonnull: "yes"
+          ac_cv_func_malloc_0_nonnull: "yes"
+      - run: make -j2
+      - run: ASAN_OPTIONS="detect_leaks=0" ./src/suricata -u -l .
+      - name: Extracting suricata-verify
+        run: tar xf prep/suricata-verify.tar.gz
+      - name: Running suricata-verify
+        run: python3 ./suricata-verify/run.py
 
   fedora-31:
     name: Fedora 31

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -560,6 +560,58 @@ jobs:
       - name: Running suricata-verify
         run: python3 ./suricata-verify/run.py
 
+  ubuntu-20-04-too-old-rust:
+    name: Ubuntu 20.04 (unsupported rust)
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
+    needs: centos-8
+    steps:
+      - name: Install dependencies
+        run: |
+          apt update
+          apt -y install \
+                build-essential \
+                curl \
+                libtool \
+                libpcap-dev \
+                libnet1-dev \
+                libyaml-0-2 \
+                libyaml-dev \
+                libcap-ng-dev \
+                libcap-ng0 \
+                libmagic-dev \
+                libnetfilter-queue-dev \
+                libnetfilter-queue1 \
+                libnfnetlink-dev \
+                libnfnetlink0 \
+                libhiredis-dev \
+                libjansson-dev \
+                libevent-dev \
+                libevent-pthreads-2.1-7 \
+                libjansson-dev \
+                libpython2.7 \
+                libpcre3 \
+                libpcre3-dev \
+                make \
+                python3-yaml \
+                software-properties-common \
+                zlib1g \
+                zlib1g-dev \
+      - run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.33.0 -y
+      - run: echo "::add-path::$HOME/.cargo/bin"
+      - name: Download suricata.tar.gz
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+      - run: tar zxvf suricata-*.tar.gz --strip-components=1
+      - run: |
+          if ./configure; then
+            echo "error: configure should have failed"
+            exit 1
+          else
+            exit 0
+          fi
+
   ubuntu-18-04-debug-validation:
     name: Ubuntu 18.04 (Debug Validation)
     runs-on: ubuntu-18.04


### PR DESCRIPTION
The root of this problem is that Rust code that is part of a plugin will not see the function pointers that are passed in the `RustContext` object during `rs_init()`.  Right now there are not many functions that a plugin would need to call, but logging is one of these. There are 3 ways to fix this:

1) Get rid of the RustContext. For Rust tests to pass, we'd also have to link with the Suricata C code compiled to a library. This complicates the build a little as we'd have to build all C, and all Rust before running the Rust tests.  I did get this to work, but not successfully with ASAN, but ultimately its where we want to end up, and probably what we have to get to for a "libsuricata.so" type thing.
2) On plugin initialiation, the plugin could execute some boilerplate that essentially sets up this context. This might have been the simpler approach, but I really didn't want to introduce this boilerplate into the plugin.  Suricata can't call this code on behalf of the plugin, the plugin must call it iself. Like some "BootStrapPlugin" method. It would only need to be Rust.
3) The approach I took which removes the boilerplate and removes the RustContext and sets up the function pointers as `lazy_static` references.  Essentially on first use, say `SCLogMessage`, we use `dlsym` to find this symbol then link up the function pointer, otherwise set it to no. So there is a small cost on first use. This isn't that different from what we do know where we check if the RustContext is set or not, and call the function based on that.

These changes allow a pure Rust plugin to be written:
https://github.com/jasonish/suricata-example-plugins/blob/rust-plugin/rust/src/lib.rs

Its still not that pleasant to look at, but its easier fixes to clean that up.
