### PR TITLE
af-packet: increase block size default order to accommodate bigger frames

### DIFF
--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -74,9 +74,9 @@ struct ebpf_timeout_config {
 
 /* In kernel the allocated block size is allocated using the formula
  * page_size << order. So default value is using the same formula with
- * an order of 3 which guarantee we have some room in the block compared
- * to standard frame size */
-#define AFP_BLOCK_SIZE_DEFAULT_ORDER 3
+ * an order of 5 which guarantee we have some room in the block compared
+ * to standard frame size and default localhost frame size */
+#define AFP_BLOCK_SIZE_DEFAULT_ORDER 5
 
 typedef struct AFPIfaceConfig_
 {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

https://redmine.openinfosecfoundation.org/issues/3889

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [#3889](https://redmine.openinfosecfoundation.org/issues/3889)

Describe changes:

- af-packet: increase block size default order to accomodate bigger frames

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
