### PR TITLE
Plugins - Remove RustContext and dynamically link at runtime - v2

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -4,7 +4,7 @@ version = "@PACKAGE_VERSION@"
 edition = "2018"
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "rlib"]
 path = "@e_rustdir@/src/lib.rs"
 
 [profile.release]

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -39,6 +39,7 @@ snmp-parser = "0.6"
 tls-parser = "0.9"
 x509-parser = "0.6.5"
 libc = "0.2.67"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 test-case = "1.0"

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -96,11 +96,14 @@ exclude = [
     "NTPTransaction",
     "SNMPState",
     "SNMPTransaction",
-    "SuricataContext",
     "SuricataFileContext",
     "TFTPState",
     "TFTPTransaction",
     "free",
+
+    # Our definitions conflict with the Windows definitions in mingw.
+    "GetModuleHandleA",
+    "GetProcAddress",
 ]
 
 # Types of items that we'll generate. If empty, then all types of item are emitted.

--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -17,7 +17,6 @@
 
 use std;
 use crate::core::{self, ALPROTO_UNKNOWN, AppProto, Flow, IPPROTO_TCP};
-use crate::log::*;
 use std::mem::transmute;
 use crate::applayer::{self, *};
 use std::ffi::CString;

--- a/rust/src/asn1/parse_rules.rs
+++ b/rust/src/asn1/parse_rules.rs
@@ -15,7 +15,6 @@
  * 02110-1301, USA.
  */
 
-use crate::log::*;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::{digit1, multispace0, multispace1};

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -22,8 +22,6 @@ use std::ffi::{CString, CStr};
 use std::ptr;
 use std::str;
 
-use crate::log::*;
-
 extern {
     fn ConfGet(key: *const c_char, res: *mut *const c_char) -> i8;
     fn ConfGetChildValue(conf: *const c_void, key: *const c_char,

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -19,7 +19,6 @@ use std::mem::transmute;
 use crate::applayer::{AppLayerResult, AppLayerTxData};
 use crate::core;
 use crate::dcerpc::parser;
-use crate::log::*;
 use nom::error::ErrorKind;
 use nom::number::Endianness;
 use nom;

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -23,7 +23,6 @@ use crate::dcerpc::dcerpc::{
     DCERPCTransaction, DCERPCUuidEntry, DCERPC_TYPE_REQUEST, DCERPC_TYPE_RESPONSE, PFC_FIRST_FRAG,
 };
 use crate::dcerpc::parser;
-use crate::log::*;
 use std::cmp;
 
 // Constant DCERPC UDP Header length

--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -19,7 +19,6 @@ use super::dcerpc::{
     DCERPCState, DCERPCTransaction, DCERPC_TYPE_REQUEST, DCERPC_TYPE_RESPONSE,
     DCERPC_UUID_ENTRY_FLAG_FF,
 };
-use crate::log::*;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
 use uuid::Uuid;

--- a/rust/src/dcerpc/parser.rs
+++ b/rust/src/dcerpc/parser.rs
@@ -18,7 +18,6 @@ use crate::dcerpc::dcerpc::{
     BindCtxItem, DCERPCBind, DCERPCBindAck, DCERPCBindAckResult, DCERPCHdr, DCERPCRequest, Uuid,
 };
 use crate::dcerpc::dcerpc_udp::DCERPCHdrUdp;
-use crate::log::*;
 use nom::number::complete::{le_u16, le_u32, le_u8};
 use nom::number::Endianness;
 

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -20,7 +20,6 @@ use crate::core;
 use crate::core::{ALPROTO_UNKNOWN, AppProto, Flow, IPPROTO_UDP};
 use crate::core::{sc_detect_engine_state_free, sc_app_layer_decoder_events_free_events};
 use crate::dhcp::parser::*;
-use crate::log::*;
 use std;
 use std::ffi::{CStr,CString};
 use std::mem::transmute;

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -23,7 +23,6 @@ use std::mem::transmute;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 
-use crate::log::*;
 use crate::applayer::*;
 use crate::core::{self, AppProto, ALPROTO_UNKNOWN, IPPROTO_UDP, IPPROTO_TCP};
 use crate::dns::parser;

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -1,0 +1,147 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// As we're working with FFI here, suppress some compiler warnings that
+// are purely about style.
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+
+use lazy_static::lazy_static;
+
+use crate::filecontainer::*;
+
+/// Opaque C types.
+pub enum DetectEngineState {}
+pub enum AppLayerDecoderEvents {}
+pub enum SuricataStreamingBufferConfig {}
+
+pub type SCLogMessageFunc = extern "C" fn(
+    level: std::os::raw::c_int,
+    filename: *const std::os::raw::c_char,
+    line: std::os::raw::c_uint,
+    function: *const std::os::raw::c_char,
+    code: std::os::raw::c_int,
+    message: *const std::os::raw::c_char,
+) -> std::os::raw::c_int;
+
+pub type DetectEngineStateFreeFunc = extern "C" fn(state: *mut DetectEngineState);
+
+pub type AppLayerDecoderEventsSetEventRawFunc =
+    extern "C" fn(events: *mut *mut AppLayerDecoderEvents, event: u8);
+
+pub type AppLayerDecoderEventsFreeEventsFunc =
+    extern "C" fn(events: *mut *mut AppLayerDecoderEvents);
+
+pub type SCFileOpenFileWithId = extern "C" fn(
+    file_container: &FileContainer,
+    sbcfg: &SuricataStreamingBufferConfig,
+    track_id: u32,
+    name: *const u8,
+    name_len: u16,
+    data: *const u8,
+    data_len: u32,
+    flags: u16,
+) -> i32;
+
+pub type SCFileCloseFileById = extern "C" fn(
+    file_container: &FileContainer,
+    track_id: u32,
+    data: *const u8,
+    data_len: u32,
+    flags: u16,
+) -> i32;
+
+pub type SCFileAppendDataById = extern "C" fn(
+    file_container: &FileContainer,
+    track_id: u32,
+    data: *const u8,
+    data_len: u32,
+) -> i32;
+
+pub type SCFileAppendGAPById = extern "C" fn(
+    file_container: &FileContainer,
+    track_id: u32,
+    data: *const u8,
+    data_len: u32,
+) -> i32;
+
+pub type SCFilePrune = extern "C" fn(file_container: &FileContainer);
+
+pub type SCFileContainerRecycle = extern "C" fn(file_container: &FileContainer);
+
+pub type SCFileSetTx = extern "C" fn(file: &FileContainer, tx_id: u64);
+
+/// Windows API functions for getting symbols from a process. Equivalent to dlopen/dlsym on Unix.
+#[cfg(target_os = "windows")]
+extern "C" {
+    fn GetModuleHandleA(name: *const std::os::raw::c_char) -> *mut std::os::raw::c_void;
+    fn GetProcAddress(
+        module: *const std::os::raw::c_void, name: *const std::os::raw::c_char,
+    ) -> *mut std::os::raw::c_void;
+}
+
+#[cfg(not(target_os = "windows"))]
+unsafe fn load_symbol(name: &str) -> Option<*mut std::os::raw::c_void> {
+    let cname = std::ffi::CString::new(name).unwrap();
+    let sym = libc::dlsym(libc::RTLD_DEFAULT, cname.as_ptr());
+    if sym != std::ptr::null_mut() {
+        Some(sym)
+    } else {
+        None
+    }
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn load_symbol(name: &str) -> Option<*mut std::os::raw::c_void> {
+    let name = std::ffi::CString::new(name).unwrap();
+    let handle = GetModuleHandleA(std::ptr::null_mut());
+    if handle == std::ptr::null_mut() {
+        return None;
+    }
+    let addr = GetProcAddress(handle, name.as_ptr());
+    if addr != std::ptr::null_mut() {
+        Some(addr)
+    } else {
+        None
+    }
+}
+
+fn link_fn<T>(name: &str) -> Option<T> {
+    let fun = unsafe { load_symbol(name).map(|sym| std::mem::transmute_copy(&sym)) };
+    if fun.is_none() {
+        println!("RUST-FFI-ERROR No function found with name {}", name);
+    }
+    fun
+}
+
+lazy_static! {
+    pub static ref SCLogMessage: Option<SCLogMessageFunc> = link_fn("SCLogMessage");
+    pub static ref DetectEngineStateFree: Option<DetectEngineStateFreeFunc> =
+        link_fn("DetectEngineStateFree");
+    pub static ref AppLayerDecoderEventsSetEventRaw: Option<AppLayerDecoderEventsSetEventRawFunc> =
+        link_fn("AppLayerDecoderEventsSetEventRaw");
+    pub static ref AppLayerDecoderEventsFreeEvents: Option<AppLayerDecoderEventsFreeEventsFunc> =
+        link_fn("AppLayerDecoderEventsFreeEvents");
+    pub static ref FileOpenFile: Option<SCFileOpenFileWithId> = link_fn("FileOpenFileWithId");
+    pub static ref FileCloseFile: Option<SCFileCloseFileById> = link_fn("FileCloseFileById");
+    pub static ref FileAppendData: Option<SCFileAppendDataById> = link_fn("FileAppendDataById");
+    pub static ref FileAppendGAP: Option<SCFileAppendGAPById> = link_fn("FileAppendGAPById");
+    pub static ref FileContainerRecycle: Option<SCFileContainerRecycle> =
+        link_fn("FileContainerRecycle");
+    pub static ref FilePrune: Option<SCFilePrune> = link_fn("FilePrune");
+    pub static ref FileSetTx: Option<SCFileSetTx> = link_fn("FileContainerSetTx");
+}

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -144,4 +144,6 @@ lazy_static! {
         link_fn("FileContainerRecycle");
     pub static ref FilePrune: Option<SCFilePrune> = link_fn("FilePrune");
     pub static ref FileSetTx: Option<SCFileSetTx> = link_fn("FileContainerSetTx");
+    pub static ref LOG_LEVEL: Option<i32> =
+        unsafe { load_symbol("sc_log_global_log_level").map(|sym| *(sym as *mut i32)) };
 }

--- a/rust/src/filecontainer.rs
+++ b/rust/src/filecontainer.rs
@@ -40,25 +40,22 @@ impl FileContainer {
     }
     pub fn free(&mut self) {
         SCLogDebug!("freeing self");
-        match unsafe {SC} {
-            None => panic!("BUG no suricata_config"),
-            Some(c) => {
-                (c.FileContainerRecycle)(&self);
-            },
+        if let Some(f) = *crate::ffi::FileContainerRecycle {
+            f(&self);
+        } else {
+            panic!("FileContainerRecycle function pointer not set");
         }
     }
 
     pub fn file_open(&mut self, cfg: &'static SuricataFileContext, track_id: &u32, name: &[u8], flags: u16) -> i32 {
-        match unsafe {SC} {
-            None => panic!("BUG no suricata_config"),
-            Some(c) => {
-                SCLogDebug!("FILE {:p} OPEN flags {:04X}", &self, flags);
-
-                let res = (c.FileOpenFile)(&self, cfg.files_sbcfg, *track_id,
-                        name.as_ptr(), name.len() as u16,
-                        ptr::null(), 0u32, flags);
-                res
-            }
+        if let Some(f) = *crate::ffi::FileOpenFile {
+            SCLogDebug!("FILE {:p} OPEN flags {:04X}", &self, flags);
+            let res = f(&self, cfg.files_sbcfg, *track_id,
+                    name.as_ptr(), name.len() as u16,
+                    ptr::null(), 0u32, flags);
+            res
+        } else {
+            panic!("FileOpenFile function pointer not set");
         }
     }
 
@@ -67,57 +64,46 @@ impl FileContainer {
         if data.len() == 0 {
             return 0
         }
-        match unsafe {SC} {
-            None => panic!("BUG no suricata_config"),
-            Some(c) => {
-                let res = match is_gap {
-                    false => {
-                        SCLogDebug!("appending file data");
-                        let r = (c.FileAppendData)(&self, *track_id,
-                                data.as_ptr(), data.len() as u32);
-                        r
-                    },
-                    true => {
-                        SCLogDebug!("appending GAP");
-                        let r = (c.FileAppendGAP)(&self, *track_id,
-                                data.as_ptr(), data.len() as u32);
-                        r
-                    },
-                };
-                res
+        if is_gap {
+            SCLogDebug!("appending GAP");
+            if let Some(f) = *crate::ffi::FileAppendGAP {
+                f(&self, *track_id, data.as_ptr(), data.len() as u32)
+            } else {
+                panic!("FileAppendGAP function pointer not set");
+            }
+        } else {
+            SCLogDebug!("appending file data");
+            if let Some(f) = *crate::ffi::FileAppendData {
+                f(&self, *track_id, data.as_ptr(), data.len() as u32)
+            } else {
+                panic!("FileAppendData function pointer net set");
             }
         }
     }
 
     pub fn file_close(&mut self, track_id: &u32, flags: u16) -> i32 {
         SCLogDebug!("FILECONTAINER: CLOSEing");
-
-        match unsafe {SC} {
-            None => panic!("BUG no suricata_config"),
-            Some(c) => {
-                let res = (c.FileCloseFile)(&self, *track_id, ptr::null(), 0u32, flags);
-                res
-            }
+        if let Some(f) = *crate::ffi::FileCloseFile {
+            f(&self, *track_id, ptr::null(), 0u32, flags)
+        } else {
+            panic!("FileCloseFile function pointer not set");
         }
-
     }
 
     pub fn files_prune(&mut self) {
         SCLogDebug!("FILECONTAINER: pruning");
-        match unsafe {SC} {
-            None => panic!("BUG no suricata_config"),
-            Some(c) => {
-                (c.FilePrune)(&self);
-            }
+        if let Some(f) = *crate::ffi::FilePrune {
+            f(&self);
+        } else {
+            panic!("FilePrune function pointer not set");
         }
     }
 
     pub fn file_set_txid_on_last_file(&mut self, tx_id: u64) {
-        match unsafe {SC} {
-            None => panic!("BUG no suricata_config"),
-            Some(c) => {
-                (c.FileSetTx)(&self, tx_id);
-            }
+        if let Some(f) = *crate::ffi::FileSetTx {
+            f(&self, tx_id);
+        } else {
+            panic!("FileSetTx function pointer not set");
         }
     }
 }

--- a/rust/src/filecontainer.rs
+++ b/rust/src/filecontainer.rs
@@ -18,7 +18,6 @@
 use std::ptr;
 use std::os::raw::{c_void};
 
-use crate::log::*;
 use crate::core::*;
 
 // Defined in util-file.h

--- a/rust/src/filetracker.rs
+++ b/rust/src/filetracker.rs
@@ -28,7 +28,6 @@
  * The tracker does continue to follow the file.
  */
 
-use crate::log::*;
 use crate::core::*;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};

--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -22,8 +22,6 @@ use std::str;
 use std;
 use std::str::FromStr;
 
-use crate::log::*;
-
 // We transform an integer string into a i64, ignoring surrounding whitespaces
 // We look for a digit suite, and try to convert it.
 // If either str::from_utf8 or FromStr::from_str fail,

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -24,7 +24,6 @@ use crate::core::{
 };
 use crate::filecontainer::*;
 use crate::filetracker::*;
-use crate::log::*;
 use nom;
 use std;
 use std::ffi::{CStr, CString};

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -25,8 +25,6 @@ use crate::applayer::{self, *};
 use std;
 use std::ffi::{CStr,CString};
 
-use crate::log::*;
-
 use nom;
 
 #[repr(u32)]

--- a/rust/src/kerberos.rs
+++ b/rust/src/kerberos.rs
@@ -25,8 +25,6 @@ use der_parser;
 use der_parser::error::BerError;
 use der_parser::der::parse_der_oid;
 
-use crate::log::*;
-
 #[derive(Debug)]
 pub enum SecBlobError {
     NotSpNego,

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -30,8 +30,6 @@ use crate::applayer::{self, *};
 use crate::core;
 use crate::core::{AppProto,Flow,ALPROTO_FAILED,ALPROTO_UNKNOWN,STREAM_TOCLIENT,STREAM_TOSERVER,sc_detect_engine_state_free};
 
-use crate::log::*;
-
 #[repr(u32)]
 pub enum KRB5Event {
     MalformedData = 0,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -82,3 +82,4 @@ pub mod x509;
 pub mod asn1;
 pub mod ssh;
 pub mod http2;
+pub mod ffi;

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -68,6 +68,7 @@ pub fn sclog(level: Level, file: &str, line: u32, function: &str,
 /// Return the function name, but for now just return <rust> as Rust
 /// has no macro to return the function name, but may in the future,
 /// see: https://github.com/rust-lang/rfcs/pull/1719
+#[macro_export(local_inner_macros)]
 macro_rules!function {
     () => {{ "<rust>" }}
 }
@@ -76,8 +77,8 @@ macro_rules!function {
 macro_rules!do_log {
     ($level:expr, $file:expr, $line:expr, $function:expr, $code:expr,
      $($arg:tt)*) => {
-        if get_log_level() >= $level as i32 {
-            sclog($level, $file, $line, $function, $code,
+        if $crate::log::get_log_level() >= $level as i32 {
+            $crate::log::sclog($level, $file, $line, $function, $code,
                   &(format!($($arg)*)));
         }
     }
@@ -86,35 +87,35 @@ macro_rules!do_log {
 #[macro_export]
 macro_rules!SCLogNotice {
     ($($arg:tt)*) => {
-        do_log!(Level::Notice, file!(), line!(), function!(), 0, $($arg)*);
+        $crate::do_log!($crate::log::Level::Notice, file!(), line!(), $crate::function!(), 0, $($arg)*);
     }
 }
 
 #[macro_export]
 macro_rules!SCLogInfo {
     ($($arg:tt)*) => {
-        do_log!(Level::Info, file!(), line!(), function!(), 0, $($arg)*);
+        $crate::do_log!($crate::log::Level::Info, file!(), line!(), $crate::function!(), 0, $($arg)*);
     }
 }
 
 #[macro_export]
 macro_rules!SCLogPerf {
     ($($arg:tt)*) => {
-        do_log!(Level::Perf, file!(), line!(), function!(), 0, $($arg)*);
+        $crate::do_log!($crate::log::Level::Perf, file!(), line!(), $crate::function!(), 0, $($arg)*);
     }
 }
 
 #[macro_export]
 macro_rules!SCLogConfig {
     ($($arg:tt)*) => {
-        do_log!(Level::Config, file!(), line!(), function!(), 0, $($arg)*);
+        $crate::do_log!($crate::log::Level::Config, file!(), line!(), $crate::function!(), 0, $($arg)*);
     }
 }
 
 #[macro_export]
 macro_rules!SCLogError {
     ($($arg:tt)*) => {
-        do_log!(Level::Error, file!(), line!(), function!(), 0, $($arg)*);
+        $crate::do_log!($crate::log::Level::Error, file!(), line!(), $crate::function!(), 0, $($arg)*);
     }
 }
 
@@ -123,7 +124,7 @@ macro_rules!SCLogError {
 #[macro_export]
 macro_rules!SCLogDebug {
     ($($arg:tt)*) => {
-        do_log!(Level::Debug, file!(), line!(), function!(), 0, $($arg)*);
+        do_log!($crate::log::Level::Debug, file!(), line!(), $crate::function!(), 0, $($arg)*);
     }
 }
 
@@ -132,7 +133,7 @@ macro_rules!SCLogDebug {
 #[cfg(not(feature = "debug"))]
 #[macro_export]
 macro_rules!SCLogDebug {
-    ($last:expr) => { let _ = &$last; let _ = Level::Debug; };
+    ($last:expr) => { let _ = &$last; let _ = $crate::log::Level::Debug; };
     ($one:expr, $($arg:tt)*) => { let _ = &$one; SCLogDebug!($($arg)*); };
 }
 

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -19,8 +19,6 @@ use std;
 use std::ffi::CString;
 use std::path::Path;
 
-use crate::core::*;
-
 #[derive(Debug)]
 pub enum Level {
     NotSet = -1,
@@ -159,16 +157,14 @@ pub fn sc_log_message(level: Level,
                       code: std::os::raw::c_int,
                       message: &str) -> std::os::raw::c_int
 {
-    unsafe {
-        if let Some(c) = SC {
-            return (c.SCLogMessage)(
-                level as i32,
-                to_safe_cstring(filename).as_ptr(),
-                line,
-                to_safe_cstring(function).as_ptr(),
-                code,
-                to_safe_cstring(message).as_ptr());
-        }
+    if let Some(fun) = *crate::ffi::SCLogMessage {
+        return fun(
+            level as i32,
+            to_safe_cstring(filename).as_ptr(),
+            line,
+            to_safe_cstring(function).as_ptr(),
+            code,
+            to_safe_cstring(message).as_ptr());
     }
 
     // Fall back if the Suricata C context is not registered which is

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -35,12 +35,11 @@ pub enum Level {
     Debug,
 }
 
-pub static mut LEVEL: i32 = Level::NotSet as i32;
+// Default to Notice if unable to get the log level from the main C process.
+pub static DEFAULT_LEVEL: i32 = Level::Notice as i32;
 
 pub fn get_log_level() -> i32 {
-    unsafe {
-        LEVEL
-    }
+    (*crate::ffi::LOG_LEVEL).unwrap_or(DEFAULT_LEVEL)
 }
 
 fn basename(filename: &str) -> &str {
@@ -135,17 +134,6 @@ macro_rules!SCLogDebug {
 macro_rules!SCLogDebug {
     ($last:expr) => { let _ = &$last; let _ = $crate::log::Level::Debug; };
     ($one:expr, $($arg:tt)*) => { let _ = &$one; SCLogDebug!($($arg)*); };
-}
-
-#[no_mangle]
-pub extern "C" fn rs_log_set_level(level: i32) {
-    unsafe {
-        LEVEL = level;
-    }
-}
-
-pub fn log_set_level(level: Level) {
-    rs_log_set_level(level as i32);
 }
 
 /// SCLogMessage wrapper. If the Suricata C context is not registered

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -22,7 +22,6 @@ use super::parser::*;
 use crate::applayer::{self, LoggerFlags};
 use crate::applayer::*;
 use crate::core::{self, AppProto, Flow, ALPROTO_FAILED, ALPROTO_UNKNOWN, IPPROTO_TCP};
-use crate::log::*;
 use num_traits::FromPrimitive;
 use nom;
 use std;

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -25,7 +25,6 @@ use std::ffi::CStr;
 
 use nom;
 
-use crate::log::*;
 use crate::applayer;
 use crate::applayer::{AppLayerResult, AppLayerTxData};
 use crate::core::*;

--- a/rust/src/nfs/nfs2.rs
+++ b/rust/src/nfs/nfs2.rs
@@ -17,8 +17,6 @@
 
 // written by Victor Julien
 
-use crate::log::*;
-
 use crate::nfs::nfs::*;
 use crate::nfs::types::*;
 use crate::nfs::rpc_records::*;

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -17,7 +17,6 @@
 
 // written by Victor Julien
 
-use crate::log::*;
 use crate::core::*;
 
 use crate::nfs::nfs::*;

--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -21,8 +21,6 @@ use nom;
 use nom::number::streaming::be_u32;
 
 use crate::core::*;
-use crate::log::*;
-
 use crate::nfs::nfs::*;
 use crate::nfs::types::*;
 use crate::nfs::rpc_records::*;

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -25,8 +25,6 @@ use crate::applayer::{self, *};
 use std;
 use std::ffi::{CStr,CString};
 
-use crate::log::*;
-
 use nom;
 
 #[repr(u32)]

--- a/rust/src/rfb/rfb.rs
+++ b/rust/src/rfb/rfb.rs
@@ -21,7 +21,6 @@ use std;
 use std::ffi::CString;
 use std::mem::transmute;
 use crate::core::{self, ALPROTO_UNKNOWN, AppProto, Flow, IPPROTO_TCP};
-use crate::log::*;
 use crate::applayer;
 use crate::applayer::*;
 use nom;

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -22,7 +22,6 @@ extern crate nom;
 use crate::applayer::{self, *};
 use crate::core;
 use crate::core::{sc_detect_engine_state_free, AppProto, Flow, ALPROTO_UNKNOWN};
-use crate::log::*;
 use crate::sip::parser::*;
 use std;
 use std::ffi::{CStr, CString};

--- a/rust/src/smb/auth.rs
+++ b/rust/src/smb/auth.rs
@@ -17,7 +17,6 @@
 
 use crate::kerberos::*;
 
-use crate::log::*;
 use crate::smb::ntlmssp_records::*;
 use crate::smb::smb::*;
 

--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -17,7 +17,6 @@
 
 // written by Victor Julien
 
-use crate::log::*;
 use uuid;
 use crate::smb::smb::*;
 use crate::smb::smb2::*;

--- a/rust/src/smb/debug.rs
+++ b/rust/src/smb/debug.rs
@@ -17,9 +17,6 @@
 
 use crate::smb::smb::*;
 
-#[cfg(feature = "debug")]
-use crate::log::*;
-
 impl SMBState {
     #[cfg(not(feature = "debug"))]
     pub fn _debug_tx_stats(&self) { }

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -17,7 +17,6 @@
 
 use std::ptr;
 use crate::core::*;
-use crate::log::*;
 use crate::smb::smb::*;
 use crate::dcerpc::detect::{DCEIfaceData, DCEOpnumData, DETECT_DCE_OPNUM_RANGE_UNINITIALIZED};
 

--- a/rust/src/smb/events.rs
+++ b/rust/src/smb/events.rs
@@ -16,7 +16,6 @@
  */
 
 use crate::core::*;
-use crate::log::*;
 use crate::smb::smb::*;
 
 #[repr(u32)]

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -16,7 +16,6 @@
  */
 
 use crate::core::*;
-use crate::log::*;
 use crate::filetracker::*;
 use crate::filecontainer::*;
 

--- a/rust/src/smb/session.rs
+++ b/rust/src/smb/session.rs
@@ -15,7 +15,6 @@
  * 02110-1301, USA.
  */
 
-use crate::log::*;
 use crate::kerberos::*;
 use crate::smb::smb::*;
 use crate::smb::smb1_session::*;

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -35,7 +35,6 @@ use std::collections::HashMap;
 use nom;
 
 use crate::core::*;
-use crate::log::*;
 use crate::applayer;
 use crate::applayer::{AppLayerResult, AppLayerTxData};
 

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -22,7 +22,6 @@
 use nom;
 
 use crate::core::*;
-use crate::log::*;
 
 use crate::smb::smb::*;
 use crate::smb::dcerpc::*;

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -16,7 +16,6 @@
  */
 
 use crate::smb::error::SmbError;
-use crate::log::*;
 use nom::IResult;
 use nom::combinator::rest;
 use nom::number::streaming::{le_u8, le_u16, le_u32, le_u64};

--- a/rust/src/smb/smb1_session.rs
+++ b/rust/src/smb/smb1_session.rs
@@ -15,8 +15,6 @@
  * 02110-1301, USA.
  */
 
-use crate::log::*;
-
 use crate::smb::smb_records::*;
 use crate::smb::smb1_records::*;
 use crate::smb::smb::*;

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -18,7 +18,6 @@
 use nom;
 
 use crate::core::*;
-use crate::log::*;
 
 use crate::smb::smb::*;
 use crate::smb::smb2_records::*;

--- a/rust/src/smb/smb2_ioctl.rs
+++ b/rust/src/smb/smb2_ioctl.rs
@@ -15,7 +15,6 @@
  * 02110-1301, USA.
  */
 
-use crate::log::*;
 use crate::smb::smb::*;
 use crate::smb::smb2::*;
 use crate::smb::smb2_records::*;

--- a/rust/src/smb/smb2_session.rs
+++ b/rust/src/smb/smb2_session.rs
@@ -15,8 +15,6 @@
  * 02110-1301, USA.
  */
 
-use crate::log::*;
-
 use crate::smb::smb2_records::*;
 use crate::smb::smb::*;
 //use smb::events::*;

--- a/rust/src/smb/smb_records.rs
+++ b/rust/src/smb/smb_records.rs
@@ -18,7 +18,6 @@
 use crate::smb::error::SmbError;
 use nom;
 use nom::IResult;
-use crate::log::*;
 
 /// parse a UTF16 string that is null terminated. Normally by 2 null
 /// bytes, but at the end of the data it can also be a single null.

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -25,8 +25,6 @@ use std;
 use std::ffi::{CStr,CString};
 use std::mem::transmute;
 
-use crate::log::*;
-
 use der_parser::ber::BerObjectContent;
 use der_parser::der::parse_der_sequence;
 use der_parser::oid::Oid;

--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -19,7 +19,6 @@ use super::parser;
 use crate::applayer::*;
 use crate::core::STREAM_TOSERVER;
 use crate::core::{self, AppProto, Flow, ALPROTO_UNKNOWN, IPPROTO_TCP};
-use crate::log::*;
 use std::ffi::{CStr, CString};
 use std::mem::transmute;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/rust-context.h
+++ b/src/rust-context.h
@@ -25,29 +25,6 @@
 #include "app-layer-snmp.h" //SNMPState, SNMPTransaction
 #include "app-layer-tftp.h" //TFTPState, TFTPTransaction
 
-typedef struct SuricataContext_ {
-    SCError (*SCLogMessage)(const SCLogLevel, const char *, const unsigned int,
-            const char *, const SCError, const char *message);
-    void (*DetectEngineStateFree)(DetectEngineState *);
-    void (*AppLayerDecoderEventsSetEventRaw)(AppLayerDecoderEvents **,
-            uint8_t);
-    void (*AppLayerDecoderEventsFreeEvents)(AppLayerDecoderEvents **);
-
-    int (*FileOpenFileWithId)(FileContainer *, const StreamingBufferConfig *,
-        uint32_t track_id, const uint8_t *name, uint16_t name_len,
-        const uint8_t *data, uint32_t data_len, uint16_t flags);
-    int (*FileCloseFileById)(FileContainer *, uint32_t track_id,
-            const uint8_t *data, uint32_t data_len, uint16_t flags);
-    int (*FileAppendDataById)(FileContainer *, uint32_t track_id,
-            const uint8_t *data, uint32_t data_len);
-    int (*FileAppendGAPById)(FileContainer *, uint32_t track_id,
-            const uint8_t *data, uint32_t data_len);
-    void (*FileContainerRecycle)(FileContainer *ffc);
-    void (*FilePrune)(FileContainer *ffc);
-    void (*FileSetTx)(FileContainer *, uint64_t);
-
-} SuricataContext;
-
 typedef struct SuricataFileContext_ {
 
     const StreamingBufferConfig *sbcfg;

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2663,8 +2663,6 @@ static void SuricataMainLoop(SCInstance *suri)
     }
 }
 
-SuricataContext context;
-
 /**
  * \brief Global initialization common to all runmodes.
  *
@@ -2672,21 +2670,7 @@ SuricataContext context;
  */
 
 int InitGlobal(void) {
-    context.SCLogMessage = SCLogMessage;
-    context.DetectEngineStateFree = DetectEngineStateFree;
-    context.AppLayerDecoderEventsSetEventRaw =
-        AppLayerDecoderEventsSetEventRaw;
-    context.AppLayerDecoderEventsFreeEvents = AppLayerDecoderEventsFreeEvents;
-
-    context.FileOpenFileWithId = FileOpenFileWithId;
-    context.FileCloseFileById = FileCloseFileById;
-    context.FileAppendDataById = FileAppendDataById;
-    context.FileAppendGAPById = FileAppendGAPById;
-    context.FileContainerRecycle = FileContainerRecycle;
-    context.FilePrune = FilePrune;
-    context.FileSetTx = FileContainerSetTx;
-
-    rs_init(&context);
+    rs_init();
 
     SC_ATOMIC_INIT(engine_stage);
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1203,7 +1203,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         {"strict-rule-keywords", optional_argument, 0, 0},
 
         {"capture-plugin", required_argument, 0, 0},
-        {"cpature-plugin-args", required_argument, 0, 0},
+        {"capture-plugin-args", required_argument, 0, 0},
 
 #ifdef BUILD_UNIX_SOCKET
         {"unix-socket", optional_argument, 0, 0},

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -1325,7 +1325,6 @@ void SCLogInitLogModule(SCLogInitData *sc_lid)
 
     //SCOutputPrint(sc_did->startup_message);
 
-    rs_log_set_level(sc_log_global_log_level);
     return;
 }
 


### PR DESCRIPTION
The root of this problem is that Rust code that is part of a plugin will not see the function pointers that are passed in the `RustContext` object during `rs_init()`.  Right now there are not many functions that a plugin would need to call, but logging is one of these. There are 3 ways to fix this:

1) Get rid of the RustContext. For Rust tests to pass, we'd also have to link with the Suricata C code compiled to a library. This complicates the build a little as we'd have to build all C, and all Rust before running the Rust tests.  I did get this to work, but not successfully with ASAN, but ultimately its where we want to end up, and probably what we have to get to for a "libsuricata.so" type thing.
2) On plugin initialiation, the plugin could execute some boilerplate that essentially sets up this context. This might have been the simpler approach, but I really didn't want to introduce this boilerplate into the plugin.  Suricata can't call this code on behalf of the plugin, the plugin must call it iself. Like some "BootStrapPlugin" method. It would only need to be Rust.
3) The approach I took which removes the boilerplate and removes the RustContext and sets up the function pointers as `lazy_static` references.  Essentially on first use, say `SCLogMessage`, we use `dlsym` to find this symbol then link up the function pointer, otherwise set it to no. So there is a small cost on first use. This isn't that different from what we do know where we check if the RustContext is set or not, and call the function based on that.

These changes allow a pure Rust plugin to be written:
https://github.com/jasonish/suricata-example-plugins/blob/rust-plugin/rust/src/lib.rs

Its still not that pleasant to look at, but its easier fixes to clean that up.
