### PR TITLE
dnp3: fixed wrong flow direction identification

### DIFF
--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -299,9 +299,11 @@ static uint16_t DNP3ProbingParser(Flow *f, uint8_t direction,
 
 end:
     // Test compatibility between direction and dnp3.ctl.direction
-    if ((DNP3_LINK_DIR(hdr->control) != 0) ^
-        ((direction & STREAM_TOCLIENT) != 0)) {
-        *rdir = 1;
+    {
+        const bool toserver = (direction & STREAM_TOSERVER) != 0;
+        if ((DNP3_LINK_DIR(hdr->control) != 0) != toserver) {
+            *rdir = toserver ? STREAM_TOCLIENT : STREAM_TOSERVER;
+        }
     }
     SCLogDebug("Detected DNP3.");
     return ALPROTO_DNP3;


### PR DESCRIPTION
dnp3 is communication between so-called master and outstation
in our terms master is a client and outstation is a server
DIR flag in dnp3 header is nonzero when a packet is from master
so if DIR is nonzero then the packet is 'toserver'

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
The condition when the direction is reversed is changed according to dnp3 specification.
The value of returned rdir is changed to follow the pattern used in the caller.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

suricata-verify-pr: 304
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
