### PR TITLE
plugins - rust plugin bootstrap support - v3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2516,6 +2516,12 @@ fi
 	[])
     AC_MSG_RESULT(yes)
 
+    RUST_FEATURES=""
+    AS_VERSION_COMPARE([$rustc_version], [1.38.0],
+        [],
+	[RUST_FEATURES="$RUST_FEATURES function-macro"],
+	[RUST_FEATURES="$RUST_FEATURES function-macro"])
+
     rust_vendor_comment="# "
     have_rust_vendor="no"
 
@@ -2749,6 +2755,7 @@ AC_SUBST(CONFIGURE_SYSCONDIR)
 AC_SUBST(CONFIGURE_LOCALSTATEDIR)
 AC_SUBST(CONFIGURE_DATAROOTDIR)
 AC_SUBST(PACKAGE_VERSION)
+AC_SUBST(RUST_FEATURES)
 
 AC_CONFIG_FILES(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config)
 AC_CONFIG_FILES(qa/Makefile qa/coccinelle/Makefile)

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -4,7 +4,7 @@ version = "@PACKAGE_VERSION@"
 edition = "2018"
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "rlib"]
 path = "@e_rustdir@/src/lib.rs"
 
 [profile.release]

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -16,6 +16,7 @@ lua_int8 = ["lua"]
 strict = []
 debug = []
 debug-validate = []
+function-macro = []
 
 [dependencies]
 nom = "= 5.1.1"

--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -17,7 +17,6 @@
 
 use std;
 use crate::core::{self, ALPROTO_UNKNOWN, AppProto, Flow, IPPROTO_TCP};
-use crate::log::*;
 use std::mem::transmute;
 use crate::applayer::{self, *};
 use std::ffi::CString;

--- a/rust/src/asn1/parse_rules.rs
+++ b/rust/src/asn1/parse_rules.rs
@@ -15,7 +15,6 @@
  * 02110-1301, USA.
  */
 
-use crate::log::*;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::{digit1, multispace0, multispace1};

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -22,8 +22,6 @@ use std::ffi::{CString, CStr};
 use std::ptr;
 use std::str;
 
-use crate::log::*;
-
 extern {
     fn ConfGet(key: *const c_char, res: *mut *const c_char) -> i8;
     fn ConfGetChildValue(conf: *const c_void, key: *const c_char,

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -84,7 +84,7 @@ pub type AppLayerDecoderEventsSetEventRawFunc =
 pub type AppLayerDecoderEventsFreeEventsFunc =
     extern "C" fn (events: *mut *mut AppLayerDecoderEvents);
 
-pub struct SuricataStreamingBufferConfig;
+pub enum SuricataStreamingBufferConfig {}
 
 pub type SCFileOpenFileWithId = extern "C" fn (
         file_container: &FileContainer,
@@ -145,15 +145,25 @@ pub struct SuricataFileContext {
     pub files_sbcfg: &'static SuricataStreamingBufferConfig,
 }
 
+extern {
+    pub fn SCGetContext() -> &'static mut SuricataContext;
+    pub fn SCLogGetLogLevel() -> i32;
+}
+
 pub static mut SC: Option<&'static SuricataContext> = None;
 
-#[no_mangle]
-pub extern "C" fn rs_init(context: &'static mut SuricataContext)
+pub fn init_ffi(context: &'static mut SuricataContext)
 {
     unsafe {
         SC = Some(context);
         ALPROTO_FAILED = StringToAppProto("failed\0".as_ptr());
     }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_init(context: &'static mut SuricataContext)
+{
+    init_ffi(context);
 }
 
 /// DetectEngineStateFree wrapper.

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -19,7 +19,6 @@ use std::mem::transmute;
 use crate::applayer::{AppLayerResult, AppLayerTxData};
 use crate::core;
 use crate::dcerpc::parser;
-use crate::log::*;
 use nom::error::ErrorKind;
 use nom::number::Endianness;
 use nom;

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -23,7 +23,6 @@ use crate::dcerpc::dcerpc::{
     DCERPCTransaction, DCERPCUuidEntry, DCERPC_TYPE_REQUEST, DCERPC_TYPE_RESPONSE, PFC_FIRST_FRAG,
 };
 use crate::dcerpc::parser;
-use crate::log::*;
 use std::cmp;
 
 // Constant DCERPC UDP Header length

--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -19,7 +19,6 @@ use super::dcerpc::{
     DCERPCState, DCERPCTransaction, DCERPC_TYPE_REQUEST, DCERPC_TYPE_RESPONSE,
     DCERPC_UUID_ENTRY_FLAG_FF,
 };
-use crate::log::*;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
 use uuid::Uuid;

--- a/rust/src/dcerpc/parser.rs
+++ b/rust/src/dcerpc/parser.rs
@@ -18,7 +18,6 @@ use crate::dcerpc::dcerpc::{
     BindCtxItem, DCERPCBind, DCERPCBindAck, DCERPCBindAckResult, DCERPCHdr, DCERPCRequest, Uuid,
 };
 use crate::dcerpc::dcerpc_udp::DCERPCHdrUdp;
-use crate::log::*;
 use nom::number::complete::{le_u16, le_u32, le_u8};
 use nom::number::Endianness;
 

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -20,7 +20,6 @@ use crate::core;
 use crate::core::{ALPROTO_UNKNOWN, AppProto, Flow, IPPROTO_UDP};
 use crate::core::{sc_detect_engine_state_free, sc_app_layer_decoder_events_free_events};
 use crate::dhcp::parser::*;
-use crate::log::*;
 use std;
 use std::ffi::{CStr,CString};
 use std::mem::transmute;

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -23,7 +23,6 @@ use std::mem::transmute;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 
-use crate::log::*;
 use crate::applayer::*;
 use crate::core::{self, AppProto, ALPROTO_UNKNOWN, IPPROTO_UDP, IPPROTO_TCP};
 use crate::dns::parser;

--- a/rust/src/filecontainer.rs
+++ b/rust/src/filecontainer.rs
@@ -18,7 +18,6 @@
 use std::ptr;
 use std::os::raw::{c_void};
 
-use crate::log::*;
 use crate::core::*;
 
 // Defined in util-file.h

--- a/rust/src/filetracker.rs
+++ b/rust/src/filetracker.rs
@@ -28,7 +28,6 @@
  * The tracker does continue to follow the file.
  */
 
-use crate::log::*;
 use crate::core::*;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};

--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -22,8 +22,6 @@ use std::str;
 use std;
 use std::str::FromStr;
 
-use crate::log::*;
-
 // We transform an integer string into a i64, ignoring surrounding whitespaces
 // We look for a digit suite, and try to convert it.
 // If either str::from_utf8 or FromStr::from_str fail,

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -24,7 +24,6 @@ use crate::core::{
 };
 use crate::filecontainer::*;
 use crate::filetracker::*;
-use crate::log::*;
 use nom;
 use std;
 use std::ffi::{CStr, CString};

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -25,8 +25,6 @@ use crate::applayer::{self, *};
 use std;
 use std::ffi::{CStr,CString};
 
-use crate::log::*;
-
 use nom;
 
 #[repr(u32)]

--- a/rust/src/kerberos.rs
+++ b/rust/src/kerberos.rs
@@ -25,8 +25,6 @@ use der_parser;
 use der_parser::error::BerError;
 use der_parser::der::parse_der_oid;
 
-use crate::log::*;
-
 #[derive(Debug)]
 pub enum SecBlobError {
     NotSpNego,

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -30,8 +30,6 @@ use crate::applayer::{self, *};
 use crate::core;
 use crate::core::{AppProto,Flow,ALPROTO_FAILED,ALPROTO_UNKNOWN,STREAM_TOCLIENT,STREAM_TOSERVER,sc_detect_engine_state_free};
 
-use crate::log::*;
-
 #[repr(u32)]
 pub enum KRB5Event {
     MalformedData = 0,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -82,3 +82,4 @@ pub mod x509;
 pub mod asn1;
 pub mod ssh;
 pub mod http2;
+pub mod plugin;

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -68,9 +68,28 @@ pub fn sclog(level: Level, file: &str, line: u32, function: &str,
                    message);
 }
 
-/// Return the function name, but for now just return <rust> as Rust
-/// has no macro to return the function name, but may in the future,
-/// see: https://github.com/rust-lang/rfcs/pull/1719
+// This macro returns the function name.
+//
+// This macro has been borrowed from https://github.com/popzxc/stdext-rs, which
+// is released under the MIT license as there is currently no macro in Rust
+// to provide the function name.
+#[cfg(feature = "function-macro")]
+#[macro_export(local_inner_macros)]
+macro_rules!function {
+    () => {{
+         // Okay, this is ugly, I get it. However, this is the best we can get on a stable rust.
+         fn __f() {}
+         fn type_name_of<T>(_: T) -> &'static str {
+             std::any::type_name::<T>()
+         }
+         let name = type_name_of(__f);
+         &name[..name.len() - 5]
+    }}
+}
+
+// Rust versions less than 1.38 can not use the above macro, so keep the old
+// macro around for a while.
+#[cfg(not(feature = "function-macro"))]
 #[macro_export(local_inner_macros)]
 macro_rules!function {
     () => {{ "<rust>" }}

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -70,6 +70,7 @@ pub fn sclog(level: Level, file: &str, line: u32, function: &str,
 /// Return the function name, but for now just return <rust> as Rust
 /// has no macro to return the function name, but may in the future,
 /// see: https://github.com/rust-lang/rfcs/pull/1719
+#[macro_export(local_inner_macros)]
 macro_rules!function {
     () => {{ "<rust>" }}
 }
@@ -78,8 +79,8 @@ macro_rules!function {
 macro_rules!do_log {
     ($level:expr, $file:expr, $line:expr, $function:expr, $code:expr,
      $($arg:tt)*) => {
-        if get_log_level() >= $level as i32 {
-            sclog($level, $file, $line, $function, $code,
+        if $crate::log::get_log_level() >= $level as i32 {
+            $crate::log::sclog($level, $file, $line, $function, $code,
                   &(format!($($arg)*)));
         }
     }
@@ -88,35 +89,35 @@ macro_rules!do_log {
 #[macro_export]
 macro_rules!SCLogNotice {
     ($($arg:tt)*) => {
-        do_log!(Level::Notice, file!(), line!(), function!(), 0, $($arg)*);
+        $crate::do_log!($crate::log::Level::Notice, file!(), line!(), $crate::function!(), 0, $($arg)*);
     }
 }
 
 #[macro_export]
 macro_rules!SCLogInfo {
     ($($arg:tt)*) => {
-        do_log!(Level::Info, file!(), line!(), function!(), 0, $($arg)*);
+        $crate::do_log!($crate::log::Level::Info, file!(), line!(), $crate::function!(), 0, $($arg)*);
     }
 }
 
 #[macro_export]
 macro_rules!SCLogPerf {
     ($($arg:tt)*) => {
-        do_log!(Level::Perf, file!(), line!(), function!(), 0, $($arg)*);
+        $crate::do_log!($crate::log::Level::Perf, file!(), line!(), $crate::function!(), 0, $($arg)*);
     }
 }
 
 #[macro_export]
 macro_rules!SCLogConfig {
     ($($arg:tt)*) => {
-        do_log!(Level::Config, file!(), line!(), function!(), 0, $($arg)*);
+        $crate::do_log!($crate::log::Level::Config, file!(), line!(), $crate::function!(), 0, $($arg)*);
     }
 }
 
 #[macro_export]
 macro_rules!SCLogError {
     ($($arg:tt)*) => {
-        do_log!(Level::Error, file!(), line!(), function!(), 0, $($arg)*);
+        $crate::do_log!($crate::log::Level::Error, file!(), line!(), $crate::function!(), 0, $($arg)*);
     }
 }
 
@@ -125,7 +126,7 @@ macro_rules!SCLogError {
 #[macro_export]
 macro_rules!SCLogDebug {
     ($($arg:tt)*) => {
-        do_log!(Level::Debug, file!(), line!(), function!(), 0, $($arg)*);
+        do_log!($crate::log::Level::Debug, file!(), line!(), $crate::function!(), 0, $($arg)*);
     }
 }
 
@@ -134,7 +135,7 @@ macro_rules!SCLogDebug {
 #[cfg(not(feature = "debug"))]
 #[macro_export]
 macro_rules!SCLogDebug {
-    ($last:expr) => { let _ = &$last; let _ = Level::Debug; };
+    ($last:expr) => { let _ = &$last; let _ = $crate::log::Level::Debug; };
     ($one:expr, $($arg:tt)*) => { let _ = &$one; SCLogDebug!($($arg)*); };
 }
 

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -22,6 +22,7 @@ use std::path::Path;
 use crate::core::*;
 
 #[derive(Debug)]
+#[repr(C)]
 pub enum Level {
     NotSet = -1,
     None = 0,
@@ -141,13 +142,13 @@ macro_rules!SCLogDebug {
 
 #[no_mangle]
 pub extern "C" fn rs_log_set_level(level: i32) {
+    log_set_level(level);
+}
+
+pub fn log_set_level(level: i32) {
     unsafe {
         LEVEL = level;
     }
-}
-
-pub fn log_set_level(level: Level) {
-    rs_log_set_level(level as i32);
 }
 
 /// SCLogMessage wrapper. If the Suricata C context is not registered

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -46,6 +46,17 @@ pub fn get_log_level() -> i32 {
     }
 }
 
+pub fn log_set_level(level: i32) {
+    unsafe {
+        LEVEL = level;
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_log_set_level(level: i32) {
+    log_set_level(level);
+}
+
 fn basename(filename: &str) -> &str {
     let path = Path::new(filename);
     for os_str in path.file_name() {
@@ -157,17 +168,6 @@ macro_rules!SCLogDebug {
 macro_rules!SCLogDebug {
     ($last:expr) => { let _ = &$last; let _ = $crate::log::Level::Debug; };
     ($one:expr, $($arg:tt)*) => { let _ = &$one; SCLogDebug!($($arg)*); };
-}
-
-#[no_mangle]
-pub extern "C" fn rs_log_set_level(level: i32) {
-    log_set_level(level);
-}
-
-pub fn log_set_level(level: i32) {
-    unsafe {
-        LEVEL = level;
-    }
 }
 
 /// SCLogMessage wrapper. If the Suricata C context is not registered

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -22,7 +22,6 @@ use super::parser::*;
 use crate::applayer::{self, LoggerFlags};
 use crate::applayer::*;
 use crate::core::{self, AppProto, Flow, ALPROTO_FAILED, ALPROTO_UNKNOWN, IPPROTO_TCP};
-use crate::log::*;
 use num_traits::FromPrimitive;
 use nom;
 use std;

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -25,7 +25,6 @@ use std::ffi::CStr;
 
 use nom;
 
-use crate::log::*;
 use crate::applayer;
 use crate::applayer::{AppLayerResult, AppLayerTxData};
 use crate::core::*;

--- a/rust/src/nfs/nfs2.rs
+++ b/rust/src/nfs/nfs2.rs
@@ -17,8 +17,6 @@
 
 // written by Victor Julien
 
-use crate::log::*;
-
 use crate::nfs::nfs::*;
 use crate::nfs::types::*;
 use crate::nfs::rpc_records::*;

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -17,7 +17,6 @@
 
 // written by Victor Julien
 
-use crate::log::*;
 use crate::core::*;
 
 use crate::nfs::nfs::*;

--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -21,8 +21,6 @@ use nom;
 use nom::number::streaming::be_u32;
 
 use crate::core::*;
-use crate::log::*;
-
 use crate::nfs::nfs::*;
 use crate::nfs::types::*;
 use crate::nfs::rpc_records::*;

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -25,8 +25,6 @@ use crate::applayer::{self, *};
 use std;
 use std::ffi::{CStr,CString};
 
-use crate::log::*;
-
 use nom;
 
 #[repr(u32)]

--- a/rust/src/plugin.rs
+++ b/rust/src/plugin.rs
@@ -1,0 +1,26 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+pub fn init() {
+    unsafe {
+        let context = super::core::SCGetContext();
+        super::core::init_ffi(context);
+
+        let level = super::core::SCLogGetLogLevel();
+        super::log::log_set_level(level);
+    }
+}

--- a/rust/src/rfb/rfb.rs
+++ b/rust/src/rfb/rfb.rs
@@ -21,7 +21,6 @@ use std;
 use std::ffi::CString;
 use std::mem::transmute;
 use crate::core::{self, ALPROTO_UNKNOWN, AppProto, Flow, IPPROTO_TCP};
-use crate::log::*;
 use crate::applayer;
 use crate::applayer::*;
 use nom;

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -22,7 +22,6 @@ extern crate nom;
 use crate::applayer::{self, *};
 use crate::core;
 use crate::core::{sc_detect_engine_state_free, AppProto, Flow, ALPROTO_UNKNOWN};
-use crate::log::*;
 use crate::sip::parser::*;
 use std;
 use std::ffi::{CStr, CString};

--- a/rust/src/smb/auth.rs
+++ b/rust/src/smb/auth.rs
@@ -17,7 +17,6 @@
 
 use crate::kerberos::*;
 
-use crate::log::*;
 use crate::smb::ntlmssp_records::*;
 use crate::smb::smb::*;
 

--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -17,7 +17,6 @@
 
 // written by Victor Julien
 
-use crate::log::*;
 use uuid;
 use crate::smb::smb::*;
 use crate::smb::smb2::*;

--- a/rust/src/smb/debug.rs
+++ b/rust/src/smb/debug.rs
@@ -17,9 +17,6 @@
 
 use crate::smb::smb::*;
 
-#[cfg(feature = "debug")]
-use crate::log::*;
-
 impl SMBState {
     #[cfg(not(feature = "debug"))]
     pub fn _debug_tx_stats(&self) { }

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -17,7 +17,6 @@
 
 use std::ptr;
 use crate::core::*;
-use crate::log::*;
 use crate::smb::smb::*;
 use crate::dcerpc::detect::{DCEIfaceData, DCEOpnumData, DETECT_DCE_OPNUM_RANGE_UNINITIALIZED};
 

--- a/rust/src/smb/events.rs
+++ b/rust/src/smb/events.rs
@@ -16,7 +16,6 @@
  */
 
 use crate::core::*;
-use crate::log::*;
 use crate::smb::smb::*;
 
 #[repr(u32)]

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -16,7 +16,6 @@
  */
 
 use crate::core::*;
-use crate::log::*;
 use crate::filetracker::*;
 use crate::filecontainer::*;
 

--- a/rust/src/smb/session.rs
+++ b/rust/src/smb/session.rs
@@ -15,7 +15,6 @@
  * 02110-1301, USA.
  */
 
-use crate::log::*;
 use crate::kerberos::*;
 use crate::smb::smb::*;
 use crate::smb::smb1_session::*;

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -35,7 +35,6 @@ use std::collections::HashMap;
 use nom;
 
 use crate::core::*;
-use crate::log::*;
 use crate::applayer;
 use crate::applayer::{AppLayerResult, AppLayerTxData};
 

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -22,7 +22,6 @@
 use nom;
 
 use crate::core::*;
-use crate::log::*;
 
 use crate::smb::smb::*;
 use crate::smb::dcerpc::*;

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -16,7 +16,6 @@
  */
 
 use crate::smb::error::SmbError;
-use crate::log::*;
 use nom::IResult;
 use nom::combinator::rest;
 use nom::number::streaming::{le_u8, le_u16, le_u32, le_u64};

--- a/rust/src/smb/smb1_session.rs
+++ b/rust/src/smb/smb1_session.rs
@@ -15,8 +15,6 @@
  * 02110-1301, USA.
  */
 
-use crate::log::*;
-
 use crate::smb::smb_records::*;
 use crate::smb::smb1_records::*;
 use crate::smb::smb::*;

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -18,7 +18,6 @@
 use nom;
 
 use crate::core::*;
-use crate::log::*;
 
 use crate::smb::smb::*;
 use crate::smb::smb2_records::*;

--- a/rust/src/smb/smb2_ioctl.rs
+++ b/rust/src/smb/smb2_ioctl.rs
@@ -15,7 +15,6 @@
  * 02110-1301, USA.
  */
 
-use crate::log::*;
 use crate::smb::smb::*;
 use crate::smb::smb2::*;
 use crate::smb::smb2_records::*;

--- a/rust/src/smb/smb2_session.rs
+++ b/rust/src/smb/smb2_session.rs
@@ -15,8 +15,6 @@
  * 02110-1301, USA.
  */
 
-use crate::log::*;
-
 use crate::smb::smb2_records::*;
 use crate::smb::smb::*;
 //use smb::events::*;

--- a/rust/src/smb/smb_records.rs
+++ b/rust/src/smb/smb_records.rs
@@ -18,7 +18,6 @@
 use crate::smb::error::SmbError;
 use nom;
 use nom::IResult;
-use crate::log::*;
 
 /// parse a UTF16 string that is null terminated. Normally by 2 null
 /// bytes, but at the end of the data it can also be a single null.

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -25,8 +25,6 @@ use std;
 use std::ffi::{CStr,CString};
 use std::mem::transmute;
 
-use crate::log::*;
-
 use der_parser::ber::BerObjectContent;
 use der_parser::der::parse_der_sequence;
 use der_parser::oid::Oid;

--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -19,7 +19,6 @@ use super::parser;
 use crate::applayer::*;
 use crate::core::STREAM_TOSERVER;
 use crate::core::{self, AppProto, Flow, ALPROTO_UNKNOWN, IPPROTO_TCP};
-use crate::log::*;
 use std::ffi::{CStr, CString};
 use std::mem::transmute;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -422,7 +422,7 @@ runmode-unix-socket.c runmode-unix-socket.h \
 runmode-windivert.c runmode-windivert.h \
 runmodes.c runmodes.h \
 rust.h \
-rust-context.h \
+rust-context.c rust-context.h \
 source-af-packet.c source-af-packet.h \
 source-erf-dag.c source-erf-dag.h \
 source-erf-file.c source-erf-file.h \

--- a/src/rust-context.c
+++ b/src/rust-context.c
@@ -1,0 +1,26 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+#include "rust-context.h"
+
+SuricataContext suricata_context;
+
+SuricataContext *SCGetContext(void)
+{
+    return &suricata_context;
+}

--- a/src/rust-context.h
+++ b/src/rust-context.h
@@ -54,9 +54,4 @@ typedef struct SuricataFileContext_ {
 
 } SuricataFileContext;
 
-struct _Store;
-typedef struct _Store Store;
-
-/** Opaque Rust types. */
-
 #endif /* !__RUST_CONTEXT_H__ */

--- a/src/rust-context.h
+++ b/src/rust-context.h
@@ -48,10 +48,14 @@ typedef struct SuricataContext_ {
 
 } SuricataContext;
 
+extern SuricataContext suricata_context;
+
 typedef struct SuricataFileContext_ {
 
     const StreamingBufferConfig *sbcfg;
 
 } SuricataFileContext;
+
+SuricataContext *SCGetContext(void);
 
 #endif /* !__RUST_CONTEXT_H__ */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2663,8 +2663,6 @@ static void SuricataMainLoop(SCInstance *suri)
     }
 }
 
-SuricataContext context;
-
 /**
  * \brief Global initialization common to all runmodes.
  *
@@ -2672,21 +2670,21 @@ SuricataContext context;
  */
 
 int InitGlobal(void) {
-    context.SCLogMessage = SCLogMessage;
-    context.DetectEngineStateFree = DetectEngineStateFree;
-    context.AppLayerDecoderEventsSetEventRaw =
+    suricata_context.SCLogMessage = SCLogMessage;
+    suricata_context.DetectEngineStateFree = DetectEngineStateFree;
+    suricata_context.AppLayerDecoderEventsSetEventRaw =
         AppLayerDecoderEventsSetEventRaw;
-    context.AppLayerDecoderEventsFreeEvents = AppLayerDecoderEventsFreeEvents;
+    suricata_context.AppLayerDecoderEventsFreeEvents = AppLayerDecoderEventsFreeEvents;
 
-    context.FileOpenFileWithId = FileOpenFileWithId;
-    context.FileCloseFileById = FileCloseFileById;
-    context.FileAppendDataById = FileAppendDataById;
-    context.FileAppendGAPById = FileAppendGAPById;
-    context.FileContainerRecycle = FileContainerRecycle;
-    context.FilePrune = FilePrune;
-    context.FileSetTx = FileContainerSetTx;
+    suricata_context.FileOpenFileWithId = FileOpenFileWithId;
+    suricata_context.FileCloseFileById = FileCloseFileById;
+    suricata_context.FileAppendDataById = FileAppendDataById;
+    suricata_context.FileAppendGAPById = FileAppendGAPById;
+    suricata_context.FileContainerRecycle = FileContainerRecycle;
+    suricata_context.FilePrune = FilePrune;
+    suricata_context.FileSetTx = FileContainerSetTx;
 
-    rs_init(&context);
+    rs_init(&suricata_context);
 
     SC_ATOMIC_INIT(engine_stage);
 

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -971,6 +971,11 @@ static inline void SCLogSetLogLevel(SCLogInitData *sc_lid, SCLogConfig *sc_lc)
     return;
 }
 
+SCLogLevel SCLogGetLogLevel(void)
+{
+    return sc_log_global_log_level;
+}
+
 static inline const char *SCLogGetDefaultLogFormat(void)
 {
     const char *prog_ver = GetProgramVersion();

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -575,4 +575,6 @@ void SCLogRegisterTests(void);
 
 void SCLogLoadConfig(int daemon, int verbose);
 
+SCLogLevel SCLogGetLogLevel(void);
+
 #endif /* __UTIL_DEBUG_H__ */


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/5320

Abandon the idea of linking things up at runtime. It depends
on plugin style support, even if we haven't figure out plugins
on the target platform, like Windows.

Instead Rust plugins will have to call a "suricata::plugin::init()"
method to bootstrap their support on plugins.

Further, plugins must now define a function, SCPluginRegister() which
returns an SCPlugin struct instead of having an SCPluginSpec variable
name that the plugin loader expects to find. This make it much
simpler to define a plugin in Rust.
