### PR TITLE
doc: http.host keyword note for matching on port

### DIFF
--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -648,6 +648,10 @@ to specify a lowercase pattern.
 Notes
 ~~~~~
 
+-  ``http.host`` does not contain the port associated with 
+   the host (i.e. abc.com:1234). To match on the host and port
+   or negate a host and port use ``http.host.raw``.
+
 -  The ``http.host`` and ``http.host.raw`` buffers are populated
    from either the URI (if the full URI is present in the request like
    in a proxy request) or the HTTP Host header. If both are present, the


### PR DESCRIPTION
Signed-off-by: jason taylor <jtfas90@gmail.com>

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- added note about matching or negating on host port when using http.host/http.host.raw keywords
-
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
