### PR TITLE
dnp3: fixed wrong flow direction identification - v2

### DIFF
--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -271,18 +271,22 @@ static uint16_t DNP3ProbingParser(Flow *f, uint8_t direction,
         const uint8_t *input, uint32_t len,
         uint8_t *rdir)
 {
-    DNP3LinkHeader *hdr = (DNP3LinkHeader *)input;
+    const DNP3LinkHeader* const hdr = (const DNP3LinkHeader*)input;
+    const bool toserver = (direction & STREAM_TOSERVER) != 0;
+
+    /* May be a banner. */
+    if (DNP3ContainsBanner(input, len)) {
+        SCLogDebug("Packet contains a DNP3 banner.");
+        if (toserver) {
+            *rdir = STREAM_TOCLIENT;
+        }
+        return ALPROTO_DNP3;
+    }
 
     /* Check that we have the minimum amount of bytes. */
     if (len < sizeof(DNP3LinkHeader)) {
         SCLogDebug("Length too small to be a DNP3 header.");
         return ALPROTO_UNKNOWN;
-    }
-
-    /* May be a banner. */
-    if (DNP3ContainsBanner(input, len)) {
-        SCLogDebug("Packet contains a DNP3 banner.");
-        goto end;
     }
 
     /* Verify start value (from AN2013-004b). */
@@ -297,11 +301,9 @@ static uint16_t DNP3ProbingParser(Flow *f, uint8_t direction,
         return ALPROTO_FAILED;
     }
 
-end:
     // Test compatibility between direction and dnp3.ctl.direction
-    if ((DNP3_LINK_DIR(hdr->control) != 0) ^
-        ((direction & STREAM_TOCLIENT) != 0)) {
-        *rdir = 1;
+    if ((DNP3_LINK_DIR(hdr->control) != 0) != toserver) {
+        *rdir = toserver ? STREAM_TOCLIENT : STREAM_TOSERVER;
     }
     SCLogDebug("Detected DNP3.");
     return ALPROTO_DNP3;
@@ -2072,6 +2074,7 @@ static int DNP3ProbingParserTest(void)
     /* Send a banner. */
     char mybanner[] = "Welcome to DNP3 SCADA.";
     FAIL_IF(DNP3ProbingParser(NULL, STREAM_TOSERVER, (uint8_t *)mybanner, sizeof(mybanner), &rdir) != ALPROTO_DNP3);
+    FAIL_IF(rdir != STREAM_TOCLIENT);
 
     PASS;
 }


### PR DESCRIPTION
dnp3 is a communication between so-called master and outstation
in our terms master is a client and outstation is a server
DIR flag in dnp3 header is nonzero when a packet is from master
so if DIR is nonzero then packet is 'toserver'

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3772

Describe changes:

The condition when the direction is reversed is changed according to dnp3 specification.
The value of returned rdir is changed to follow the pattern used in the caller.

In a case of DNP3 banner direction may only be to client.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

suricata-verify-pr: 310
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
