### PR TITLE
Reverted app-layer-expectation.c to the original suricata-6.0.0-beta1…

### DIFF
--- a/src/queue.h
+++ b/src/queue.h
@@ -30,10 +30,8 @@
  * SUCH DAMAGE.
  *
  *	@(#)queue.h	8.5 (Berkeley) 8/20/94
- */
-
-#ifndef	_SYS_QUEUE_H_
-#define	_SYS_QUEUE_H_
+ *      extended		       8/28/2020
+*/
 
 /*
  * This file defines five types of data structures: singly-linked lists,
@@ -179,40 +177,64 @@ struct {								\
 /*
  * List definitions.
  */
+#ifndef LIST_HEAD							
 #define LIST_HEAD(name, type)						\
 struct name {								\
 	struct type *lh_first;	/* first element */			\
-}
+}									
+#endif									
 
+#ifndef LIST_HEAD_INITIALIZER						
 #define LIST_HEAD_INITIALIZER(head)					\
-	{ NULL }
+	{ NULL }							
+#endif
 
+#ifndef LIST_ENTRY
 #define LIST_ENTRY(type)						\
 struct {								\
 	struct type *le_next;	/* next element */			\
 	struct type **le_prev;	/* address of previous next element */	\
 }
+#endif
 
 /*
  * List access methods
  */
+#ifndef LIST_FIRST
 #define	LIST_FIRST(head)		((head)->lh_first)
-#define	LIST_END(head)			NULL
-#define	LIST_EMPTY(head)		(LIST_FIRST(head) == LIST_END(head))
-#define	LIST_NEXT(elm, field)		((elm)->field.le_next)
+#endif
 
+#ifndef LIST_END
+#define	LIST_END(head)			NULL
+#endif
+
+#ifndef LIST_EMPTY
+#define	LIST_EMPTY(head)		(LIST_FIRST(head) == LIST_END(head))
+#endif
+
+#ifndef LIST_NEXT
+#define	LIST_NEXT(elm, field)		((elm)->field.le_next)
+#endif
+
+
+#ifndef LIST_FOREACH
 #define LIST_FOREACH(var, head, field)					\
 	for((var) = LIST_FIRST(head);					\
 	    (var)!= LIST_END(head);					\
 	    (var) = LIST_NEXT(var, field))
+#endif
 
 /*
  * List functions.
  */
+
+#ifndef LIST_INIT
 #define	LIST_INIT(head) do {						\
 	LIST_FIRST(head) = LIST_END(head);				\
 } while (0)
+#endif
 
+#ifndef LIST_INSERT_AFTER
 #define LIST_INSERT_AFTER(listelm, elm, field) do {			\
 	if (((elm)->field.le_next = (listelm)->field.le_next) != NULL)	\
 		(listelm)->field.le_next->field.le_prev =		\
@@ -220,21 +242,27 @@ struct {								\
 	(listelm)->field.le_next = (elm);				\
 	(elm)->field.le_prev = &(listelm)->field.le_next;		\
 } while (0)
+#endif
 
+#ifndef LIST_INSERT_BEFORE
 #define	LIST_INSERT_BEFORE(listelm, elm, field) do {			\
 	(elm)->field.le_prev = (listelm)->field.le_prev;		\
 	(elm)->field.le_next = (listelm);				\
 	*(listelm)->field.le_prev = (elm);				\
 	(listelm)->field.le_prev = &(elm)->field.le_next;		\
 } while (0)
+#endif
 
+#ifndef LIST_INSERT_HEAD
 #define LIST_INSERT_HEAD(head, elm, field) do {				\
 	if (((elm)->field.le_next = (head)->lh_first) != NULL)		\
 		(head)->lh_first->field.le_prev = &(elm)->field.le_next;\
 	(head)->lh_first = (elm);					\
 	(elm)->field.le_prev = &(head)->lh_first;			\
 } while (0)
+#endif
 
+#ifndef LIST_REMOVE
 #define LIST_REMOVE(elm, field) do {					\
 	if ((elm)->field.le_next != NULL)				\
 		(elm)->field.le_next->field.le_prev =			\
@@ -243,7 +271,9 @@ struct {								\
 	_Q_INVALIDATE((elm)->field.le_prev);				\
 	_Q_INVALIDATE((elm)->field.le_next);				\
 } while (0)
+#endif
 
+#ifndef LIST_REPLACE
 #define LIST_REPLACE(elm, elm2, field) do {				\
 	if (((elm2)->field.le_next = (elm)->field.le_next) != NULL)	\
 		(elm2)->field.le_next->field.le_prev =			\
@@ -253,125 +283,187 @@ struct {								\
 	_Q_INVALIDATE((elm)->field.le_prev);				\
 	_Q_INVALIDATE((elm)->field.le_next);				\
 } while (0)
+#endif
 
 /*
  * Simple queue definitions.
  */
+#ifndef SIMPLEQ_HEAD
 #define SIMPLEQ_HEAD(name, type)					\
 struct name {								\
 	struct type *sqh_first;	/* first element */			\
 	struct type **sqh_last;	/* addr of last next element */		\
 }
+#endif
 
+#ifndef SIMPLEQ_HEAD_INITIALIZER
 #define SIMPLEQ_HEAD_INITIALIZER(head)					\
 	{ NULL, &(head).sqh_first }
+#endif
 
+#ifndef SIMPLEQ_ENTRY
 #define SIMPLEQ_ENTRY(type)						\
 struct {								\
 	struct type *sqe_next;	/* next element */			\
 }
+#endif
 
 /*
  * Simple queue access methods.
  */
+#ifndef	SIMPLEQ_FIRST
 #define	SIMPLEQ_FIRST(head)	    ((head)->sqh_first)
-#define	SIMPLEQ_END(head)	    NULL
-#define	SIMPLEQ_EMPTY(head)	    (SIMPLEQ_FIRST(head) == SIMPLEQ_END(head))
-#define	SIMPLEQ_NEXT(elm, field)    ((elm)->field.sqe_next)
+#endif
 
+#ifndef	SIMPLEQ_END
+#define	SIMPLEQ_END(head)	    NULL
+#endif
+
+#ifndef SIMPLEQ_EMPTY
+#define	SIMPLEQ_EMPTY(head)	    (SIMPLEQ_FIRST(head) == SIMPLEQ_END(head))
+#endif
+
+#ifndef	SIMPLEQ_NEXT
+#define	SIMPLEQ_NEXT(elm, field)    ((elm)->field.sqe_next)
+#endif
+
+#ifndef SIMPLEQ_FOREACH
 #define SIMPLEQ_FOREACH(var, head, field)				\
 	for((var) = SIMPLEQ_FIRST(head);				\
 	    (var) != SIMPLEQ_END(head);					\
 	    (var) = SIMPLEQ_NEXT(var, field))
+#endif
 
 /*
  * Simple queue functions.
  */
+#ifndef	SIMPLEQ_INIT
 #define	SIMPLEQ_INIT(head) do {						\
 	(head)->sqh_first = NULL;					\
 	(head)->sqh_last = &(head)->sqh_first;				\
 } while (0)
+#endif
 
+#ifndef SIMPLEQ_INSERT_HEAD
 #define SIMPLEQ_INSERT_HEAD(head, elm, field) do {			\
 	if (((elm)->field.sqe_next = (head)->sqh_first) == NULL)	\
 		(head)->sqh_last = &(elm)->field.sqe_next;		\
 	(head)->sqh_first = (elm);					\
 } while (0)
+#endif
 
+#ifndef SIMPLEQ_INSERT_TAIL
 #define SIMPLEQ_INSERT_TAIL(head, elm, field) do {			\
 	(elm)->field.sqe_next = NULL;					\
 	*(head)->sqh_last = (elm);					\
 	(head)->sqh_last = &(elm)->field.sqe_next;			\
 } while (0)
+#endif
 
+#ifndef SIMPLEQ_INSERT_AFTER
 #define SIMPLEQ_INSERT_AFTER(head, listelm, elm, field) do {		\
 	if (((elm)->field.sqe_next = (listelm)->field.sqe_next) == NULL)\
 		(head)->sqh_last = &(elm)->field.sqe_next;		\
 	(listelm)->field.sqe_next = (elm);				\
 } while (0)
+#endif
 
+#ifndef SIMPLEQ_REMOVE_HEAD
 #define SIMPLEQ_REMOVE_HEAD(head, field) do {			\
 	if (((head)->sqh_first = (head)->sqh_first->field.sqe_next) == NULL) \
 		(head)->sqh_last = &(head)->sqh_first;			\
 } while (0)
+#endif
 
 /*
  * Tail queue definitions.
  */
+#ifndef TAILQ_HEAD
 #define TAILQ_HEAD(name, type)						\
 struct name {								\
 	struct type *tqh_first;	/* first element */			\
 	struct type **tqh_last;	/* addr of last next element */		\
 }
+#endif
 
+#ifndef TAILQ_HEAD_INITIALIZER
 #define TAILQ_HEAD_INITIALIZER(head)					\
 	{ NULL, &(head).tqh_first }
+#endif
 
+#ifndef TAILQ_ENTRY
 #define TAILQ_ENTRY(type)						\
 struct {								\
 	struct type *tqe_next;	/* next element */			\
 	struct type **tqe_prev;	/* address of previous next element */	\
 }
+#endif
 
 /*
  * tail queue access methods
  */
+#ifndef TAILQ_FIRST
 #define	TAILQ_FIRST(head)		((head)->tqh_first)
+#endif
+
+#ifndef TAILQ_END
 #define	TAILQ_END(head)			NULL
+#endif
+
+#ifndef	TAILQ_NEXT
 #define	TAILQ_NEXT(elm, field)		((elm)->field.tqe_next)
+#endif
+
+#ifndef TAILQ_LAST
 #define TAILQ_LAST(head, headname)					\
 	(*(((struct headname *)((head)->tqh_last))->tqh_last))
+#endif
+
 /* XXX */
+#ifndef TAILQ_PREV
 #define TAILQ_PREV(elm, headname, field)				\
 	(*(((struct headname *)((elm)->field.tqe_prev))->tqh_last))
+#endif
+
+#ifndef TAILQ_EMPTY
 #define	TAILQ_EMPTY(head)						\
 	(TAILQ_FIRST(head) == TAILQ_END(head))
+#endif
 
+#ifndef TAILQ_FOREACH
 #define TAILQ_FOREACH(var, head, field)					\
 	for((var) = TAILQ_FIRST(head);					\
 	    (var) != TAILQ_END(head);					\
 	    (var) = TAILQ_NEXT(var, field))
+#endif
 
 /* removal safe iterator using a temprary element has last param */
+#ifndef TAILQ_FOREACH_SAFE
 #define TAILQ_FOREACH_SAFE(var, head, field, tvar)					\
 	for((var) = TAILQ_FIRST(head), \
         (tvar) = TAILQ_FIRST(head) ? TAILQ_NEXT(TAILQ_FIRST(head), field): NULL ; \
 	    (var) != TAILQ_END(head);					\
 	    (var = tvar), (tvar) = var ? TAILQ_NEXT(var, field): NULL)
+#endif
 
+#ifndef TAILQ_FOREACH_REVERSE
 #define TAILQ_FOREACH_REVERSE(var, head, headname, field)		\
 	for((var) = TAILQ_LAST(head, headname);				\
 	    (var) != TAILQ_END(head);					\
 	    (var) = TAILQ_PREV(var, headname, field))
+#endif
 
 /*
  * Tail queue functions.
  */
+#ifndef TAILQ_INIT
 #define	TAILQ_INIT(head) do {						\
 	(head)->tqh_first = NULL;					\
 	(head)->tqh_last = &(head)->tqh_first;				\
 } while (0)
+#endif
 
+#ifndef TAILQ_INSERT_HEAD
 #define TAILQ_INSERT_HEAD(head, elm, field) do {			\
 	if (((elm)->field.tqe_next = (head)->tqh_first) != NULL)	\
 		(head)->tqh_first->field.tqe_prev =			\
@@ -381,7 +473,9 @@ struct {								\
 	(head)->tqh_first = (elm);					\
 	(elm)->field.tqe_prev = &(head)->tqh_first;			\
 } while (0)
+#endif
 
+#ifndef TAILQ_INSERT_TAIL
 #define TAILQ_INSERT_TAIL(head, elm, field) do {			\
 	_Q_ASSERT((elm));						\
 	_Q_ASSERT((head));						\
@@ -391,7 +485,9 @@ struct {								\
 	_Q_ASSERT(*(head)->tqh_last);					\
 	(head)->tqh_last = &(elm)->field.tqe_next;			\
 } while (0)
+#endif
 
+#ifndef TAILQ_INSERT_AFTER
 #define TAILQ_INSERT_AFTER(head, listelm, elm, field) do {		\
 	if (((elm)->field.tqe_next = (listelm)->field.tqe_next) != NULL)\
 		(elm)->field.tqe_next->field.tqe_prev =			\
@@ -401,14 +497,18 @@ struct {								\
 	(listelm)->field.tqe_next = (elm);				\
 	(elm)->field.tqe_prev = &(listelm)->field.tqe_next;		\
 } while (0)
+#endif
 
+#ifndef	TAILQ_INSERT_BEFORE
 #define	TAILQ_INSERT_BEFORE(listelm, elm, field) do {			\
 	(elm)->field.tqe_prev = (listelm)->field.tqe_prev;		\
 	(elm)->field.tqe_next = (listelm);				\
 	*(listelm)->field.tqe_prev = (elm);				\
 	(listelm)->field.tqe_prev = &(elm)->field.tqe_next;		\
 } while (0)
+#endif
 
+#ifndef TAILQ_REMOVE
 #define TAILQ_REMOVE(head, elm, field) do {				\
 	if (((elm)->field.tqe_next) != NULL)				\
 		(elm)->field.tqe_next->field.tqe_prev =			\
@@ -420,7 +520,9 @@ struct {								\
 	_Q_INVALIDATE((elm)->field.tqe_prev);				\
 	_Q_INVALIDATE((elm)->field.tqe_next);				\
 } while (0)
+#endif
 
+#ifndef TAILQ_REPLACE
 #define TAILQ_REPLACE(head, elm, elm2, field) do {			\
 	if (((elm2)->field.tqe_next = (elm)->field.tqe_next) != NULL)	\
 		(elm2)->field.tqe_next->field.tqe_prev =		\
@@ -432,54 +534,85 @@ struct {								\
 	_Q_INVALIDATE((elm)->field.tqe_prev);				\
 	_Q_INVALIDATE((elm)->field.tqe_next);				\
 } while (0)
+#endif
 
 /*
  * Circular queue definitions.
  */
+#ifndef CIRCLEQ_HEAD
 #define CIRCLEQ_HEAD(name, type)					\
 struct name {								\
 	struct type *cqh_first;		/* first element */		\
 	struct type *cqh_last;		/* last element */		\
 }
+#endif
 
+#ifndef CIRCLEQ_HEAD_INITIALIZER
 #define CIRCLEQ_HEAD_INITIALIZER(head)					\
 	{ CIRCLEQ_END(&head), CIRCLEQ_END(&head) }
+#endif
 
+#ifndef CIRCLEQ_ENTRY
 #define CIRCLEQ_ENTRY(type)						\
 struct {								\
 	struct type *cqe_next;		/* next element */		\
 	struct type *cqe_prev;		/* previous element */		\
 }
+#endif
 
 /*
  * Circular queue access methods
  */
+#ifndef	CIRCLEQ_FIRST
 #define	CIRCLEQ_FIRST(head)		((head)->cqh_first)
+#endif
+
+#ifndef	CIRCLEQ_LAST
 #define	CIRCLEQ_LAST(head)		((head)->cqh_last)
+#endif
+
+#ifndef CIRCLEQ_END
 #define	CIRCLEQ_END(head)		((void *)(head))
+#endif
+
+#ifndef	CIRCLEQ_NEXT
 #define	CIRCLEQ_NEXT(elm, field)	((elm)->field.cqe_next)
+#endif
+
+#ifndef	CIRCLEQ_PREV
 #define	CIRCLEQ_PREV(elm, field)	((elm)->field.cqe_prev)
+#endif
+
+#ifndef	CIRCLEQ_EMPTY
 #define	CIRCLEQ_EMPTY(head)						\
 	(CIRCLEQ_FIRST(head) == CIRCLEQ_END(head))
+#endif
 
+#ifndef CIRCLEQ_FOREACH
 #define CIRCLEQ_FOREACH(var, head, field)				\
 	for((var) = CIRCLEQ_FIRST(head);				\
 	    (var) != CIRCLEQ_END(head);					\
 	    (var) = CIRCLEQ_NEXT(var, field))
+#endif
 
+#ifndef CIRCLEQ_FOREACH_REVERSE
 #define CIRCLEQ_FOREACH_REVERSE(var, head, field)			\
 	for((var) = CIRCLEQ_LAST(head);					\
 	    (var) != CIRCLEQ_END(head);					\
 	    (var) = CIRCLEQ_PREV(var, field))
+#endif
 
 /*
  * Circular queue functions.
  */
+#ifndef	CIRCLEQ_INIT
 #define	CIRCLEQ_INIT(head) do {						\
 	(head)->cqh_first = CIRCLEQ_END(head);				\
 	(head)->cqh_last = CIRCLEQ_END(head);				\
 } while (0)
+#endif
 
+#ifndef CIRCLEQ_INSERT_AFTER
 #define CIRCLEQ_INSERT_AFTER(head, listelm, elm, field) do {		\
 	(elm)->field.cqe_next = (listelm)->field.cqe_next;		\
 	(elm)->field.cqe_prev = (listelm);				\
@@ -489,7 +622,9 @@ struct {								\
 		(listelm)->field.cqe_next->field.cqe_prev = (elm);	\
 	(listelm)->field.cqe_next = (elm);				\
 } while (0)
+#endif
 
+#ifndef CIRCLEQ_INSERT_BEFORE
 #define CIRCLEQ_INSERT_BEFORE(head, listelm, elm, field) do {		\
 	(elm)->field.cqe_next = (listelm);				\
 	(elm)->field.cqe_prev = (listelm)->field.cqe_prev;		\
@@ -499,7 +634,9 @@ struct {								\
 		(listelm)->field.cqe_prev->field.cqe_next = (elm);	\
 	(listelm)->field.cqe_prev = (elm);				\
 } while (0)
+#endif
 
+#ifndef CIRCLEQ_INSERT_HEAD
 #define CIRCLEQ_INSERT_HEAD(head, elm, field) do {			\
 	(elm)->field.cqe_next = (head)->cqh_first;			\
 	(elm)->field.cqe_prev = CIRCLEQ_END(head);			\
@@ -509,7 +646,9 @@ struct {								\
 		(head)->cqh_first->field.cqe_prev = (elm);		\
 	(head)->cqh_first = (elm);					\
 } while (0)
+#endif
 
+#ifndef CIRCLEQ_INSERT_TAIL
 #define CIRCLEQ_INSERT_TAIL(head, elm, field) do {			\
 	(elm)->field.cqe_next = CIRCLEQ_END(head);			\
 	(elm)->field.cqe_prev = (head)->cqh_last;			\
@@ -519,7 +658,9 @@ struct {								\
 		(head)->cqh_last->field.cqe_next = (elm);		\
 	(head)->cqh_last = (elm);					\
 } while (0)
+#endif
 
+#ifndef CIRCLEQ_REMOVE
 #define	CIRCLEQ_REMOVE(head, elm, field) do {				\
 	if ((elm)->field.cqe_next == CIRCLEQ_END(head))			\
 		(head)->cqh_last = (elm)->field.cqe_prev;		\
@@ -534,7 +675,9 @@ struct {								\
 	_Q_INVALIDATE((elm)->field.cqe_prev);				\
 	_Q_INVALIDATE((elm)->field.cqe_next);				\
 } while (0)
+#endif
 
+#ifndef CIRCLEQ_REPLACE
 #define CIRCLEQ_REPLACE(head, elm, elm2, field) do {			\
 	if (((elm2)->field.cqe_next = (elm)->field.cqe_next) ==		\
 	    CIRCLEQ_END(head))						\
@@ -549,17 +692,20 @@ struct {								\
 	_Q_INVALIDATE((elm)->field.cqe_prev);				\
 	_Q_INVALIDATE((elm)->field.cqe_next);				\
 } while (0)
+#endif
 
+#ifndef CIRCLEQ_FOREACH_SAFE
 #define	CIRCLEQ_FOREACH_SAFE(var, head, field, tvar)			\
     for ((var) = CIRCLEQ_FIRST(head);				\
         (var) != CIRCLEQ_END(head) &&				\
         ((tvar) = CIRCLEQ_NEXT(var, field), 1);			\
         (var) = (tvar))
+#endif
 
+#ifndef CIRCLEQ_FOREACH_REVERSE_SAFE
 #define	CIRCLEQ_FOREACH_REVERSE_SAFE(var, head, headname, field, tvar)	\
     for ((var) = CIRCLEQ_LAST(head, headname);			\
         (var) != CIRCLEQ_END(head) && 				\
         ((tvar) = CIRCLEQ_PREV(var, headname, field), 1);		\
         (var) = (tvar))
-
-#endif	/* !_SYS_QUEUE_H_ */
+#endif


### PR DESCRIPTION
… version and revised the queue.h for a cleaner solution to the previous build failures on FreeBSD 12.1 and 13 with clang10.0

Describe changes:
Updated the OISF included 1994 bsd src/queue.h header file to resolve build issues with Clang10 on both FreeBSD12.1-Release and FreeBSD13-Current. This fixes app-layer-expectation.c. If you noticed our previous pull request has now been deleted. It was chosen rather than to modify app-layer-expectation.c to the fix the queue.h header definitions instead which in turn should have also fixed the ctime errors reported after our initial commit/pull.