### PR TITLE
configure: Improved cross compilation support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2252,7 +2252,7 @@ return 0;
     AM_CONDITIONAL([HAVE_LUA], [test "x$enable_lua" != "xno"])
 
     # If Lua is enabled, test the integer size.
-    if test "x$enable_lua" = "xyes"; then
+    if test "x$enable_lua" = "xyes" -a "$cross_compiling" != "yes"; then
         TMPLIBS="$LIBS"
         LIBS=""
 

--- a/configure.ac
+++ b/configure.ac
@@ -793,32 +793,33 @@ return 0;
 
     if test "x$pcre_jit_works" = "xyes"; then
 
-       AC_MSG_CHECKING(for PCRE JIT EXEC support usability)
-       AC_RUN_IFELSE([AC_LANG_PROGRAM([[
-                          #include <pcre.h>
-                          #include <string.h>
-                          ]],
-           [[
-           const char *error;
-           int err_offset;
-           pcre *re = pcre_compile("(a|b|c|d)", 0, &error, &err_offset,NULL);
-           pcre_extra *study = pcre_study(re, PCRE_STUDY_JIT_COMPILE, &error);
-           if (study == NULL)
-               exit(EXIT_FAILURE);
-           pcre_jit_stack *stack = pcre_jit_stack_alloc(32*1024,40*1024);
-           if (stack == 0)
-               exit(EXIT_FAILURE);
-           int ret = pcre_jit_exec(re, study, "apple", 5, 0, 0, NULL, 0, stack);
-           if (ret != 0)
-               exit(EXIT_FAILURE);
-           exit(EXIT_SUCCESS);
-           ]])],[ pcre_jit_exec_works=yes ],[:]
-       )
-       if test "x$pcre_jit_exec_works" != "xyes"; then
+       AC_MSG_CHECKING(for PCRE JIT exec availability)
+       AC_LINK_IFELSE(
+           [AC_LANG_PROGRAM(
+               [
+                  #include <pcre.h>
+                  #include <string.h>
+               ],
+               [
+                   const char *error;
+                   int err_offset;
+                   pcre *re = pcre_compile("(a|b|c|d)", 0, &error, &err_offset,NULL);
+                   pcre_extra *study = pcre_study(re, PCRE_STUDY_JIT_COMPILE, &error);
+                   if (study == NULL)
+                       exit(EXIT_FAILURE);
+                   pcre_jit_stack *stack = pcre_jit_stack_alloc(32*1024,40*1024);
+                   if (stack == 0)
+                       exit(EXIT_FAILURE);
+                   int ret = pcre_jit_exec(re, study, "apple", 5, 0, 0, NULL, 0, stack);
+                   exit(ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
+               ])],
+           [pcre_jit_exec_available="yes" ],
+           [pcre_jit_exec_available="no" ])
+       if test "x$pcre_jit_exec_available" != "xyes"; then
            AC_MSG_RESULT(no)
        else
            AC_MSG_RESULT(yes)
-           AC_DEFINE([PCRE_HAVE_JIT_EXEC], [1], [Pcre with JIT compiler support enabled supporting pcre_jit_exec])
+           AC_DEFINE([PCRE_HAVE_JIT_EXEC], [1], [PCRE with JIT compiler support enabled supporting pcre_jit_exec])
        fi
     else
         AC_MSG_RESULT(no)


### PR DESCRIPTION
Continuation of #5338 

This PR changes the run-time check for PCRE's "JIT exec" from a run-time to a compile time check for better support in cross compilation environments. Additionally, the run-time check to determine the size of a Lua integer is now guarded so it won't run on cross-compilation environments.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3872](https://redmine.openinfosecfoundation.org/issues/3872)

Describe changes:
- Uses `AC_LINK_ELSEIF`

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
