### PR TITLE
enip: record direction in transaction and fixup detect - v1

### DIFF
--- a/src/app-layer-enip-common.h
+++ b/src/app-layer-enip-common.h
@@ -198,6 +198,7 @@ typedef struct ENIPTransaction_
     uint16_t tx_num;                            /**< internal: id */
     uint16_t tx_id;                             /**< transaction id */
     uint16_t service_count;
+    uint8_t direction;
 
     ENIPEncapHdr header;                        /**< encapsulation header */
     ENIPEncapDataHdr encap_data_header;         /**< encapsulation data header */

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -343,6 +343,7 @@ static AppLayerResult ENIPParse(Flow *f, void *state, AppLayerParserState *pstat
         tx = ENIPTransactionAlloc(enip);
         if (tx == NULL)
             SCReturnStruct(APP_LAYER_OK);
+        tx->direction = (flags & STREAM_TOSERVER) | (flags & STREAM_TOCLIENT);
 
         SCLogDebug("ENIPParse input len %d", input_len);
         DecodeENIPPDU(input, input_len, tx);

--- a/src/detect-engine-enip.c
+++ b/src/detect-engine-enip.c
@@ -267,6 +267,10 @@ int DetectEngineInspectENIP(ThreadVars *tv,
     ENIPTransaction *tx = (ENIPTransaction *) txv;
     DetectEnipCommandData *enipcmdd = (DetectEnipCommandData *) smd->ctx;
 
+    if ((flags & (STREAM_TOSERVER|STREAM_TOCLIENT)) != tx->direction) {
+        SCReturnInt(0);
+    }
+
     if (enipcmdd == NULL)
     {
         SCLogDebug("no enipcommand state, no match");


### PR DESCRIPTION
An alternative solution to https://github.com/OISF/suricata/pull/5313.

Record the direction in the transaction, and skip detection if the
direction does not match.
