### PR TITLE
Http2 upgrade v3

### DIFF
--- a/rules/http2-events.rules
+++ b/rules/http2-events.rules
@@ -13,3 +13,4 @@ alert http2 any any -> any any (msg:"SURICATA HTTP2 invalid frame length"; flow:
 alert http2 any any -> any any (msg:"SURICATA HTTP2 header frame with extra data"; flow:established; app-layer-event:http2.extra_header_data; classtype:protocol-command-decode; sid:2290005; rev:1;)
 alert http2 any any -> any any (msg:"SURICATA HTTP2 too long frame data"; flow:established; app-layer-event:http2.long_frame_data; classtype:protocol-command-decode; sid:2290006; rev:1;)
 alert http2 any any -> any any (msg:"SURICATA HTTP2 stream identifier reuse"; flow:established; app-layer-event:http2.stream_id_reuse; classtype:protocol-command-decode; sid:2290007; rev:1;)
+alert http2 any any -> any any (msg:"SURICATA HTTP2 invalid HTTP1 settings during upgrade"; flow:established; app-layer-event:http2.invalid_http1_settings; classtype:protocol-command-decode; sid:2290008; rev:1;)

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -194,6 +194,7 @@ pub enum Flow {}
 /// Extern functions operating on Flow.
 extern {
     pub fn FlowGetLastTimeAsParts(flow: &Flow, secs: *mut u64, usecs: *mut u64);
+    pub fn FlowChangeProto(flow: *const Flow) -> std::os::raw::c_int;
 }
 
 /// Rust implementation of Flow.

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -16,11 +16,10 @@
  */
 
 use super::http2::{
-    HTTP2Frame, HTTP2FrameTypeData, HTTP2State, HTTP2Transaction, HTTP2TransactionState,
+    HTTP2Event, HTTP2Frame, HTTP2FrameTypeData, HTTP2State, HTTP2Transaction, HTTP2TransactionState,
 };
 use super::parser;
 use crate::core::STREAM_TOSERVER;
-use crate::log::*;
 use std::ffi::CStr;
 use std::mem::transmute;
 use std::str::FromStr;
@@ -593,6 +592,141 @@ pub extern "C" fn rs_http2_tx_set_uri(state: &mut HTTP2State, buffer: *const u8,
     http2_tx_set_header(state, ":path".as_bytes(), slice)
 }
 
+#[derive(Debug, PartialEq)]
+pub enum Http2Base64Error {
+    InvalidBase64,
+}
+
+impl std::error::Error for Http2Base64Error {}
+
+impl std::fmt::Display for Http2Base64Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "invalid base64")
+    }
+}
+
+fn http2_base64_map(input: u8) -> Result<u8, Http2Base64Error> {
+    match input {
+        43 => Ok(62),  // +
+        47 => Ok(63),  // /
+        48 => Ok(52),  // 0
+        49 => Ok(53),  // 1
+        50 => Ok(54),  // 2
+        51 => Ok(55),  // 3
+        52 => Ok(56),  // 4
+        53 => Ok(57),  // 5
+        54 => Ok(58),  // 6
+        55 => Ok(59),  // 7
+        56 => Ok(60),  // 8
+        57 => Ok(61),  // 9
+        65 => Ok(0),   // A
+        66 => Ok(1),   // B
+        67 => Ok(2),   // C
+        68 => Ok(3),   // D
+        69 => Ok(4),   // E
+        70 => Ok(5),   // F
+        71 => Ok(6),   // G
+        72 => Ok(7),   // H
+        73 => Ok(8),   // I
+        74 => Ok(9),   // J
+        75 => Ok(10),  // K
+        76 => Ok(11),  // L
+        77 => Ok(12),  // M
+        78 => Ok(13),  // N
+        79 => Ok(14),  // O
+        80 => Ok(15),  // P
+        81 => Ok(16),  // Q
+        82 => Ok(17),  // R
+        83 => Ok(18),  // S
+        84 => Ok(19),  // T
+        85 => Ok(20),  // U
+        86 => Ok(21),  // V
+        87 => Ok(22),  // W
+        88 => Ok(23),  // X
+        89 => Ok(24),  // Y
+        90 => Ok(25),  // Z
+        97 => Ok(26),  // a
+        98 => Ok(27),  // b
+        99 => Ok(28),  // c
+        100 => Ok(29), // d
+        101 => Ok(30), // e
+        102 => Ok(31), // f
+        103 => Ok(32), // g
+        104 => Ok(33), // h
+        105 => Ok(34), // i
+        106 => Ok(35), // j
+        107 => Ok(36), // k
+        108 => Ok(37), // l
+        109 => Ok(38), // m
+        110 => Ok(39), // n
+        111 => Ok(40), // o
+        112 => Ok(41), // p
+        113 => Ok(42), // q
+        114 => Ok(43), // r
+        115 => Ok(44), // s
+        116 => Ok(45), // t
+        117 => Ok(46), // u
+        118 => Ok(47), // v
+        119 => Ok(48), // w
+        120 => Ok(49), // x
+        121 => Ok(50), // y
+        122 => Ok(51), // z
+        _ => Err(Http2Base64Error::InvalidBase64),
+    }
+}
+
+fn http2_decode_base64(input: &[u8]) -> Result<Vec<u8>, Http2Base64Error> {
+    if input.len() % 4 != 0 {
+        return Err(Http2Base64Error::InvalidBase64);
+    }
+    let mut r = vec![0; (input.len() * 3) / 4];
+    for i in 0..input.len() / 4 {
+        let i1 = http2_base64_map(input[4 * i])?;
+        let i2 = http2_base64_map(input[4 * i + 1])?;
+        let i3 = http2_base64_map(input[4 * i + 2])?;
+        let i4 = http2_base64_map(input[4 * i + 3])?;
+        r[3 * i] = (i1 << 2) | (i2 >> 4);
+        r[3 * i + 1] = (i2 << 4) | (i3 >> 2);
+        r[3 * i + 2] = (i3 << 6) | i4;
+    }
+    return Ok(r);
+}
+
+fn http2_tx_set_settings(state: &mut HTTP2State, input: &[u8]) {
+    match http2_decode_base64(input) {
+        Ok(dec) => {
+            if dec.len() % 6 != 0 {
+                state.set_event(HTTP2Event::InvalidHTTP1Settings);
+            }
+
+            let head = parser::HTTP2FrameHeader {
+                length: dec.len() as u32,
+                ftype: parser::HTTP2FrameType::SETTINGS as u8,
+                flags: 0,
+                reserved: 0,
+                stream_id: 0,
+            };
+
+            match parser::http2_parse_frame_settings(&dec) {
+                Ok((_, set)) => {
+                    let txdata = HTTP2FrameTypeData::SETTINGS(set);
+                    let tx = state.find_or_create_tx(&head, &txdata, STREAM_TOSERVER);
+                    tx.frames_ts.push(HTTP2Frame {
+                        header: head,
+                        data: txdata,
+                    });
+                }
+                Err(_) => {
+                    state.set_event(HTTP2Event::InvalidHTTP1Settings);
+                }
+            }
+        }
+        Err(_) => {
+            state.set_event(HTTP2Event::InvalidHTTP1Settings);
+        }
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn rs_http2_tx_add_header(
     state: &mut HTTP2State, name: *const u8, name_len: u32, value: *const u8, value_len: u32,
@@ -600,7 +734,7 @@ pub extern "C" fn rs_http2_tx_add_header(
     let slice_name = build_slice!(name, name_len as usize);
     let slice_value = build_slice!(value, value_len as usize);
     if slice_name == "HTTP2-Settings".as_bytes() {
-        SCLogNotice!("lol seetings TODO");
+        http2_tx_set_settings(state, slice_value)
     } else {
         http2_tx_set_header(state, slice_name, slice_value)
     }

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -15,9 +15,12 @@
  * 02110-1301, USA.
  */
 
-use super::http2::{HTTP2FrameTypeData, HTTP2Transaction};
+use super::http2::{
+    HTTP2Frame, HTTP2FrameTypeData, HTTP2State, HTTP2Transaction, HTTP2TransactionState,
+};
 use super::parser;
 use crate::core::STREAM_TOSERVER;
+use crate::log::*;
 use std::ffi::CStr;
 use std::mem::transmute;
 use std::str::FromStr;
@@ -543,4 +546,62 @@ pub unsafe extern "C" fn rs_http2_tx_get_header(
     }
 
     return 0;
+}
+
+fn http2_tx_set_header(state: &mut HTTP2State, name: &[u8], input: &[u8]) {
+    let head = parser::HTTP2FrameHeader {
+        length: 0,
+        ftype: parser::HTTP2FrameType::HEADERS as u8,
+        flags: 0,
+        reserved: 0,
+        stream_id: 1,
+    };
+    let mut blocks = Vec::new();
+    let b = parser::HTTP2FrameHeaderBlock {
+        name: name.to_vec(),
+        value: input.to_vec(),
+        error: parser::HTTP2HeaderDecodeStatus::HTTP2HeaderDecodeSuccess,
+        sizeupdate: 0,
+    };
+    blocks.push(b);
+    let hs = parser::HTTP2FrameHeaders {
+        padlength: None,
+        priority: None,
+        blocks: blocks,
+    };
+    let txdata = HTTP2FrameTypeData::HEADERS(hs);
+    let tx = state.find_or_create_tx(&head, &txdata, STREAM_TOSERVER);
+    tx.frames_ts.push(HTTP2Frame {
+        header: head,
+        data: txdata,
+    });
+    //we do not expect more data from client
+    tx.state = HTTP2TransactionState::HTTP2StateHalfClosedClient;
+}
+
+#[no_mangle]
+pub extern "C" fn rs_http2_tx_set_method(
+    state: &mut HTTP2State, buffer: *const u8, buffer_len: u32,
+) {
+    let slice = build_slice!(buffer, buffer_len as usize);
+    http2_tx_set_header(state, ":method".as_bytes(), slice)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_http2_tx_set_uri(state: &mut HTTP2State, buffer: *const u8, buffer_len: u32) {
+    let slice = build_slice!(buffer, buffer_len as usize);
+    http2_tx_set_header(state, ":path".as_bytes(), slice)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_http2_tx_add_header(
+    state: &mut HTTP2State, name: *const u8, name_len: u32, value: *const u8, value_len: u32,
+) {
+    let slice_name = build_slice!(name, name_len as usize);
+    let slice_value = build_slice!(value, value_len as usize);
+    if slice_name == "HTTP2-Settings".as_bytes() {
+        SCLogNotice!("lol seetings TODO");
+    } else {
+        http2_tx_set_header(state, slice_name, slice_value)
+    }
 }

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -118,7 +118,7 @@ pub struct HTTP2Frame {
 pub struct HTTP2Transaction {
     tx_id: u64,
     pub stream_id: u32,
-    state: HTTP2TransactionState,
+    pub state: HTTP2TransactionState,
     child_stream_id: u32,
 
     pub frames_tc: Vec<HTTP2Frame>,
@@ -374,7 +374,7 @@ impl HTTP2State {
         return self.transactions.last_mut().unwrap();
     }
 
-    fn find_or_create_tx(
+    pub fn find_or_create_tx(
         &mut self, header: &parser::HTTP2FrameHeader, data: &HTTP2FrameTypeData, dir: u8,
     ) -> &mut HTTP2Transaction {
         if header.stream_id == 0 {

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -247,6 +247,7 @@ pub enum HTTP2Event {
     ExtraHeaderData,
     LongFrameData,
     StreamIdReuse,
+    InvalidHTTP1Settings,
 }
 
 impl HTTP2Event {
@@ -260,6 +261,7 @@ impl HTTP2Event {
             5 => Some(HTTP2Event::ExtraHeaderData),
             6 => Some(HTTP2Event::LongFrameData),
             7 => Some(HTTP2Event::StreamIdReuse),
+            8 => Some(HTTP2Event::InvalidHTTP1Settings),
             _ => None,
         }
     }
@@ -298,7 +300,7 @@ impl HTTP2State {
         self.files.free();
     }
 
-    fn set_event(&mut self, event: HTTP2Event) {
+    pub fn set_event(&mut self, event: HTTP2Event) {
         let len = self.transactions.len();
         if len == 0 {
             return;
@@ -979,6 +981,7 @@ pub extern "C" fn rs_http2_state_get_event_info(
                 "extra_header_data" => HTTP2Event::ExtraHeaderData as i32,
                 "long_frame_data" => HTTP2Event::LongFrameData as i32,
                 "stream_id_reuse" => HTTP2Event::StreamIdReuse as i32,
+                "invalid_http1_settings" => HTTP2Event::InvalidHTTP1Settings as i32,
                 _ => -1, // unknown event
             }
         }
@@ -1006,6 +1009,7 @@ pub extern "C" fn rs_http2_state_get_event_info_by_id(
             HTTP2Event::ExtraHeaderData => "extra_header_data\0",
             HTTP2Event::LongFrameData => "long_frame_data\0",
             HTTP2Event::StreamIdReuse => "stream_id_reuse\0",
+            HTTP2Event::InvalidHTTP1Settings => "invalid_http1_settings\0",
         };
         unsafe {
             *event_name = estr.as_ptr() as *const std::os::raw::c_char;

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -840,7 +840,6 @@ export_tx_set_detect_state!(rs_http2_tx_set_detect_state, HTTP2Transaction);
 
 export_tx_data_get!(rs_http2_get_tx_data, HTTP2Transaction);
 
-//TODOnext connection upgrade from HTTP1 cf SMTP STARTTLS
 /// C entry point for a probing parser.
 #[no_mangle]
 pub extern "C" fn rs_http2_probing_parser_tc(
@@ -1052,8 +1051,7 @@ const PARSER_NAME: &'static [u8] = b"http2\0";
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_http2_register_parser() {
-    //TODOend default port
-    let default_port = CString::new("[3000]").unwrap();
+    let default_port = CString::new("[80]").unwrap();
     let parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
         default_port: default_port.as_ptr(),

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1878,7 +1878,7 @@ void AppLayerProtoDetectReset(Flow *f)
     f->probing_parser_toserver_alproto_masks = 0;
     f->probing_parser_toclient_alproto_masks = 0;
 
-    AppLayerParserStateCleanup(f, f->alstate, f->alparser);
+    // Does not free the structures for the parser
     f->alstate = NULL;
     f->alparser = NULL;
     f->alproto    = ALPROTO_UNKNOWN;

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1868,7 +1868,6 @@ void AppLayerRequestProtocolTLSUpgrade(Flow *f)
 
 void AppLayerProtoDetectReset(Flow *f)
 {
-    FlowUnsetChangeProtoFlag(f);
     FLOW_RESET_PM_DONE(f, STREAM_TOSERVER);
     FLOW_RESET_PM_DONE(f, STREAM_TOCLIENT);
     FLOW_RESET_PP_DONE(f, STREAM_TOSERVER);

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -973,8 +973,6 @@ static AppLayerResult HTPHandleResponseData(Flow *f, void *htp_state,
                                 htp_connp_close(hstate->connp, &ts);
                                 hstate->flags |= HTP_FLAG_STATE_CLOSED_TC;
                             }
-                            // TODO mimic HTTP1 request into HTTP2
-
                             // During HTTP2 upgrade, we may consume the HTTP1 part of the data
                             // and we need to parser the remaining part with HTTP2
                             if (consumed > 0 && consumed < input_len) {
@@ -2956,6 +2954,22 @@ static void *HTPStateGetTx(void *alstate, uint64_t tx_id)
         return htp_list_get(http_state->conn->transactions, tx_id);
     else
         return NULL;
+}
+
+void *HtpGetTxForH2(void *alstate)
+{
+    HtpState *http_state = (HtpState *)alstate;
+    // gets last transaction (and remove it)
+    htp_tx_t *tx = (htp_tx_t *)htp_list_array_pop(http_state->conn->transactions);
+    // remove the link to the connection
+    tx->conn = NULL;
+    tx->connp = NULL;
+    return tx;
+}
+
+void HtpFreeTxFromH2(void *tx)
+{
+    htp_tx_destroy(tx);
 }
 
 static int HTPStateGetAlstateProgressCompletionStatus(uint8_t direction)

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -947,11 +947,44 @@ static AppLayerResult HTPHandleResponseData(Flow *f, void *htp_state,
     DEBUG_VALIDATE_BUG_ON(hstate->connp == NULL);
 
     htp_time_t ts = { f->lastts.tv_sec, f->lastts.tv_usec };
+    htp_tx_t *tx = NULL;
+    size_t consumed = 0;
     if (input_len > 0) {
         const int r = htp_connp_res_data(hstate->connp, &ts, input, input_len);
         switch (r) {
             case HTP_STREAM_ERROR:
                 ret = -1;
+                break;
+            case HTP_STREAM_TUNNEL:
+                tx = htp_connp_get_out_tx(hstate->connp);
+                if (tx != NULL && tx->response_status_number == 101) {
+                    htp_header_t *h =
+                            (htp_header_t *)htp_table_get_c(tx->response_headers, "Upgrade");
+                    if (h != NULL) {
+                        if (bstr_cmp_c(h->value, "h2c") == 0) {
+                            uint16_t dp = 0;
+                            if (tx->request_port_number != -1) {
+                                dp = (uint16_t)tx->request_port_number;
+                            }
+                            consumed = htp_connp_res_data_consumed(hstate->connp);
+                            AppLayerRequestProtocolChange(hstate->f, dp, ALPROTO_HTTP2);
+                            // close connection to log HTTP1 request in tunnel mode
+                            if (!(hstate->flags & HTP_FLAG_STATE_CLOSED_TC)) {
+                                htp_connp_close(hstate->connp, &ts);
+                                hstate->flags |= HTP_FLAG_STATE_CLOSED_TC;
+                            }
+                            // TODO mimic HTTP1 request into HTTP2
+
+                            // During HTTP2 upgrade, we may consume the HTTP1 part of the data
+                            // and we need to parser the remaining part with HTTP2
+                            if (consumed > 0 && consumed < input_len) {
+                                SCReturnStruct(
+                                        APP_LAYER_INCOMPLETE(consumed, input_len - consumed));
+                            }
+                            SCReturnStruct(APP_LAYER_OK);
+                        }
+                    }
+                }
                 break;
             default:
                 break;

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -288,6 +288,9 @@ void HTPConfigure(void);
 void HtpConfigCreateBackup(void);
 void HtpConfigRestoreBackup(void);
 
+void *HtpGetTxForH2(void *);
+void HtpFreeTxFromH2(void *);
+
 #endif	/* __APP_LAYER_HTP_H__ */
 
 /**

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -247,7 +247,6 @@ typedef struct HtpState_ {
     Flow *f;                /**< Needed to retrieve the original flow when using HTPLib callbacks */
     uint64_t transaction_cnt;
     uint64_t store_tx_id;
-    htp_tx_t *upgrade_tx;
     FileContainer *files_ts;
     FileContainer *files_tc;
     const struct HTPCfgRec_ *cfg;
@@ -290,7 +289,6 @@ void HtpConfigCreateBackup(void);
 void HtpConfigRestoreBackup(void);
 
 void *HtpGetTxForH2(void *);
-void HtpFreeTxFromH2(void *);
 
 #endif	/* __APP_LAYER_HTP_H__ */
 

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -247,6 +247,7 @@ typedef struct HtpState_ {
     Flow *f;                /**< Needed to retrieve the original flow when using HTPLib callbacks */
     uint64_t transaction_cnt;
     uint64_t store_tx_id;
+    htp_tx_t *upgrade_tx;
     FileContainer *files_ts;
     FileContainer *files_tc;
     const struct HTPCfgRec_ *cfg;

--- a/src/app-layer-http2.c
+++ b/src/app-layer-http2.c
@@ -72,7 +72,7 @@ void RegisterHTTP2Parsers(void)
 
 void HTTP2MimicHttp1Request(void *h1, void *h2s)
 {
-    if (h2s == NULL) {
+    if (h2s == NULL || h1 == NULL) {
         return;
     }
     htp_tx_t *h1tx = (htp_tx_t *)h1;

--- a/src/app-layer-http2.c
+++ b/src/app-layer-http2.c
@@ -76,9 +76,7 @@ void HTTP2MimicHttp1Request(void *h1, void *h2s)
         return;
     }
     htp_tx_t *h1tx = (htp_tx_t *)h1;
-    void *tmp = malloc(bstr_len(h1tx->request_method));
-    memcpy(tmp, bstr_ptr(h1tx->request_method), bstr_len(h1tx->request_method));
-    rs_http2_tx_set_method(h2s, tmp, bstr_len(h1tx->request_method));
+    rs_http2_tx_set_method(h2s, bstr_ptr(h1tx->request_method), bstr_len(h1tx->request_method));
     rs_http2_tx_set_uri(h2s, bstr_ptr(h1tx->request_uri), bstr_len(h1tx->request_uri));
     size_t nbheaders = htp_table_size(h1tx->request_headers);
     for (size_t i = 0; i < nbheaders; i++) {

--- a/src/app-layer-http2.c
+++ b/src/app-layer-http2.c
@@ -69,3 +69,23 @@ void RegisterHTTP2Parsers(void)
     //TODOask HTTP2ParserRegisterTests();
 #endif
 }
+
+void HTTP2MimicHttp1Request(void *h1, void *h2s)
+{
+    if (h2s == NULL) {
+        return;
+    }
+    htp_tx_t *h1tx = (htp_tx_t *)h1;
+    void *tmp = malloc(bstr_len(h1tx->request_method));
+    memcpy(tmp, bstr_ptr(h1tx->request_method), bstr_len(h1tx->request_method));
+    rs_http2_tx_set_method(h2s, tmp, bstr_len(h1tx->request_method));
+    rs_http2_tx_set_uri(h2s, bstr_ptr(h1tx->request_uri), bstr_len(h1tx->request_uri));
+    size_t nbheaders = htp_table_size(h1tx->request_headers);
+    for (size_t i = 0; i < nbheaders; i++) {
+        htp_header_t *h = htp_table_get_index(h1tx->request_headers, i, NULL);
+        if (h != NULL) {
+            rs_http2_tx_add_header(h2s, bstr_ptr(h->name), bstr_len(h->name), bstr_ptr(h->value),
+                    bstr_len(h->value));
+        }
+    }
+}

--- a/src/app-layer-http2.h
+++ b/src/app-layer-http2.h
@@ -26,4 +26,6 @@
 
 void RegisterHTTP2Parsers(void);
 
+void HTTP2MimicHttp1Request(void *, void *);
+
 #endif /* __APP_LAYER_HTTP2_H__ */

--- a/src/app-layer-http2.h
+++ b/src/app-layer-http2.h
@@ -26,6 +26,6 @@
 
 void RegisterHTTP2Parsers(void);
 
-void HTTP2MimicHttp1Request(void *, void *);
+void HTTP2MimicHttp1Request(const Flow *);
 
 #endif /* __APP_LAYER_HTTP2_H__ */

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1445,12 +1445,12 @@ void AppLayerParserSetStreamDepthFlag(uint8_t ipproto, AppProto alproto, void *s
 
 /***** Cleanup *****/
 
-void AppLayerParserStateCleanup(const Flow *f, void *alstate,
-                                AppLayerParserState *pstate)
+void AppLayerParserStateProtoCleanup(
+        uint8_t protomap, AppProto alproto, void *alstate, AppLayerParserState *pstate)
 {
     SCEnter();
 
-    AppLayerParserProtoCtx *ctx = &alp_ctx.ctxs[f->protomap][f->alproto];
+    AppLayerParserProtoCtx *ctx = &alp_ctx.ctxs[protomap][alproto];
 
     if (ctx->StateFree != NULL && alstate != NULL)
         ctx->StateFree(alstate);
@@ -1460,6 +1460,11 @@ void AppLayerParserStateCleanup(const Flow *f, void *alstate,
         AppLayerParserStateFree(pstate);
 
     SCReturn;
+}
+
+void AppLayerParserStateCleanup(const Flow *f, void *alstate, AppLayerParserState *pstate)
+{
+    AppLayerParserStateProtoCleanup(f->protomap, f->alproto, alstate, pstate);
 }
 
 static void ValidateParserProtoDump(AppProto alproto, uint8_t ipproto)

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -258,6 +258,8 @@ int AppLayerParserIsEnabled(AppProto alproto);
 
 /***** Cleanup *****/
 
+void AppLayerParserStateProtoCleanup(
+        uint8_t protomap, AppProto alproto, void *alstate, AppLayerParserState *pstate);
 void AppLayerParserStateCleanup(const Flow *f, void *alstate, AppLayerParserState *pstate);
 
 void AppLayerParserRegisterProtocolParsers(void);

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -31,6 +31,8 @@
 #include "app-layer-protos.h"
 #include "app-layer-expectation.h"
 #include "app-layer-ftp.h"
+#include "app-layer-htp.h"
+#include "app-layer-http2.h"
 #include "app-layer-detect-proto.h"
 #include "stream-tcp-reassemble.h"
 #include "stream-tcp-private.h"
@@ -630,13 +632,25 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         }
     } else if (alproto != ALPROTO_UNKNOWN && FlowChangeProto(f)) {
         f->alproto_orig = f->alproto;
+        void *tx = NULL;
+        if (f->alproto_orig == ALPROTO_HTTP && f->alproto_expect == ALPROTO_HTTP2) {
+            // get tx and remove it from HTTP
+            tx = HtpGetTxForH2(f->alstate);
+        }
         SCLogDebug("protocol change, old %s", AppProtoToString(f->alproto_orig));
         AppLayerProtoDetectReset(f);
         /* rerun protocol detection */
         if (TCPProtoDetect(tv, ra_ctx, app_tctx, p, f, ssn, stream,
                            data, data_len, flags) != 0) {
             SCLogDebug("proto detect failure");
+            if (tx != NULL) {
+                HtpFreeTxFromH2(tx);
+            }
             goto failure;
+        }
+        if (f->alproto_orig == ALPROTO_HTTP && f->alproto_expect == ALPROTO_HTTP2 && tx != NULL) {
+            HTTP2MimicHttp1Request(tx, f->alstate);
+            HtpFreeTxFromH2(tx);
         }
         SCLogDebug("protocol change, old %s, new %s",
                 AppProtoToString(f->alproto_orig), AppProtoToString(f->alproto));

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -632,26 +632,22 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         }
     } else if (alproto != ALPROTO_UNKNOWN && FlowChangeProto(f)) {
         f->alproto_orig = f->alproto;
-        void *tx = NULL;
-        if (f->alproto_orig == ALPROTO_HTTP && f->alproto_expect == ALPROTO_HTTP2) {
-            // get tx and remove it from HTTP
-            tx = HtpGetTxForH2(f->alstate);
-        }
         SCLogDebug("protocol change, old %s", AppProtoToString(f->alproto_orig));
+        void *alstate_orig = f->alstate;
+        AppLayerParserState *alparser = f->alparser;
+        // we delay AppLayerParserStateCleanup because we may need previous parser state
         AppLayerProtoDetectReset(f);
         /* rerun protocol detection */
         if (TCPProtoDetect(tv, ra_ctx, app_tctx, p, f, ssn, stream,
                            data, data_len, flags) != 0) {
             SCLogDebug("proto detect failure");
-            if (tx != NULL) {
-                HtpFreeTxFromH2(tx);
-            }
+            AppLayerParserStateProtoCleanup(f->protomap, f->alproto_orig, alstate_orig, alparser);
             goto failure;
         }
-        if (f->alproto_orig == ALPROTO_HTTP && f->alproto_expect == ALPROTO_HTTP2 && tx != NULL) {
-            HTTP2MimicHttp1Request(tx, f->alstate);
-            HtpFreeTxFromH2(tx);
+        if (f->alproto_orig == ALPROTO_HTTP && f->alproto_expect == ALPROTO_HTTP2) {
+            HTTP2MimicHttp1Request(HtpGetTxForH2(alstate_orig), f->alstate);
         }
+        AppLayerParserStateProtoCleanup(f->protomap, f->alproto_orig, alstate_orig, alparser);
         SCLogDebug("protocol change, old %s, new %s",
                 AppProtoToString(f->alproto_orig), AppProtoToString(f->alproto));
 

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -137,6 +137,9 @@ static inline void AppLayerProfilingStore(AppLayerThreadCtx *app_tctx, Packet *p
 
 void AppLayerRegisterGlobalCounters(void);
 
+//FIXME Dummy global to remove
+void *alstate_orig;
+
 /***** Unittests *****/
 
 #ifdef UNITTESTS


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3866

Describe changes:
- Adds mechanism to change protocol from HTTP1 to HTTP2

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

suricata-verify-pr: 320

Makes https://github.com/OISF/suricata-verify/pull/320 pass

Modifies #5354 by 
- having `HTTP2MimicHttp1Request` called from `rs_http2_parse_tc` in the case `FlowChangeProto`
- delaying the reset of `FlowUnsetChangeProtoFlag` after `TCPProtoDetect
- FIXME having a global variable so that `HTTP2MimicHttp1Request` can access the previous HTTP1 state

⚠️  This is not good enough as it is not thread safe
Hence this is a draft PR and the previous PR is not closed