### PR TITLE
Http2 upgrade v5

### DIFF
--- a/rules/http2-events.rules
+++ b/rules/http2-events.rules
@@ -13,3 +13,4 @@ alert http2 any any -> any any (msg:"SURICATA HTTP2 invalid frame length"; flow:
 alert http2 any any -> any any (msg:"SURICATA HTTP2 header frame with extra data"; flow:established; app-layer-event:http2.extra_header_data; classtype:protocol-command-decode; sid:2290005; rev:1;)
 alert http2 any any -> any any (msg:"SURICATA HTTP2 too long frame data"; flow:established; app-layer-event:http2.long_frame_data; classtype:protocol-command-decode; sid:2290006; rev:1;)
 alert http2 any any -> any any (msg:"SURICATA HTTP2 stream identifier reuse"; flow:established; app-layer-event:http2.stream_id_reuse; classtype:protocol-command-decode; sid:2290007; rev:1;)
+alert http2 any any -> any any (msg:"SURICATA HTTP2 invalid HTTP1 settings during upgrade"; flow:established; app-layer-event:http2.invalid_http1_settings; classtype:protocol-command-decode; sid:2290008; rev:1;)

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -256,7 +256,7 @@ pub type ParseFn      = extern "C" fn (flow: *const Flow,
                                        data: *const c_void,
                                        flags: u8) -> AppLayerResult;
 pub type ProbeFn      = extern "C" fn (flow: *const Flow,direction: u8,input:*const u8, input_len: u32, rdir: *mut u8) -> AppProto;
-pub type StateAllocFn = extern "C" fn () -> *mut c_void;
+pub type StateAllocFn = extern "C" fn (*mut c_void, AppProto) -> *mut c_void;
 pub type StateFreeFn  = extern "C" fn (*mut c_void);
 pub type StateTxFreeFn  = extern "C" fn (*mut c_void, u64);
 pub type StateGetTxFn            = extern "C" fn (*mut c_void, u64) -> *mut c_void;

--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -285,7 +285,7 @@ pub extern "C" fn rs_template_probing_parser(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_template_state_new() -> *mut std::os::raw::c_void {
+pub extern "C" fn rs_template_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = TemplateState::new();
     let boxed = Box::new(state);
     return unsafe { transmute(boxed) };

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -1138,7 +1138,7 @@ pub extern "C" fn rs_dcerpc_parse_response(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_dcerpc_state_new() -> *mut std::os::raw::c_void {
+pub unsafe extern "C" fn rs_dcerpc_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: core::AppProto) -> *mut std::os::raw::c_void {
     let state = DCERPCState::new();
     let boxed = Box::new(state);
     transmute(boxed)

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -309,7 +309,7 @@ pub extern "C" fn rs_dcerpc_udp_state_free(state: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_dcerpc_udp_state_new() -> *mut std::os::raw::c_void {
+pub unsafe extern "C" fn rs_dcerpc_udp_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: core::AppProto) -> *mut std::os::raw::c_void {
     let state = DCERPCUDPState::new();
     let boxed = Box::new(state);
     transmute(boxed)

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -307,7 +307,7 @@ pub extern "C" fn rs_dhcp_state_tx_free(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dhcp_state_new() -> *mut std::os::raw::c_void {
+pub extern "C" fn rs_dhcp_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = DHCPState::new();
     let boxed = Box::new(state);
     return unsafe {

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -668,7 +668,7 @@ pub fn probe_tcp(input: &[u8]) -> (bool, bool, bool) {
 
 /// Returns *mut DNSState
 #[no_mangle]
-pub extern "C" fn rs_dns_state_new() -> *mut std::os::raw::c_void {
+pub extern "C" fn rs_dns_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = DNSState::new();
     let boxed = Box::new(state);
     return unsafe{transmute(boxed)};

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -16,11 +16,10 @@
  */
 
 use super::http2::{
-    HTTP2Frame, HTTP2FrameTypeData, HTTP2State, HTTP2Transaction, HTTP2TransactionState,
+    HTTP2Event, HTTP2Frame, HTTP2FrameTypeData, HTTP2State, HTTP2Transaction, HTTP2TransactionState,
 };
 use super::parser;
 use crate::core::STREAM_TOSERVER;
-use crate::log::*;
 use std::ffi::CStr;
 use std::mem::transmute;
 use std::str::FromStr;
@@ -593,6 +592,141 @@ pub extern "C" fn rs_http2_tx_set_uri(state: &mut HTTP2State, buffer: *const u8,
     http2_tx_set_header(state, ":path".as_bytes(), slice)
 }
 
+#[derive(Debug, PartialEq)]
+pub enum Http2Base64Error {
+    InvalidBase64,
+}
+
+impl std::error::Error for Http2Base64Error {}
+
+impl std::fmt::Display for Http2Base64Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "invalid base64")
+    }
+}
+
+fn http2_base64_map(input: u8) -> Result<u8, Http2Base64Error> {
+    match input {
+        43 => Ok(62),  // +
+        47 => Ok(63),  // /
+        48 => Ok(52),  // 0
+        49 => Ok(53),  // 1
+        50 => Ok(54),  // 2
+        51 => Ok(55),  // 3
+        52 => Ok(56),  // 4
+        53 => Ok(57),  // 5
+        54 => Ok(58),  // 6
+        55 => Ok(59),  // 7
+        56 => Ok(60),  // 8
+        57 => Ok(61),  // 9
+        65 => Ok(0),   // A
+        66 => Ok(1),   // B
+        67 => Ok(2),   // C
+        68 => Ok(3),   // D
+        69 => Ok(4),   // E
+        70 => Ok(5),   // F
+        71 => Ok(6),   // G
+        72 => Ok(7),   // H
+        73 => Ok(8),   // I
+        74 => Ok(9),   // J
+        75 => Ok(10),  // K
+        76 => Ok(11),  // L
+        77 => Ok(12),  // M
+        78 => Ok(13),  // N
+        79 => Ok(14),  // O
+        80 => Ok(15),  // P
+        81 => Ok(16),  // Q
+        82 => Ok(17),  // R
+        83 => Ok(18),  // S
+        84 => Ok(19),  // T
+        85 => Ok(20),  // U
+        86 => Ok(21),  // V
+        87 => Ok(22),  // W
+        88 => Ok(23),  // X
+        89 => Ok(24),  // Y
+        90 => Ok(25),  // Z
+        97 => Ok(26),  // a
+        98 => Ok(27),  // b
+        99 => Ok(28),  // c
+        100 => Ok(29), // d
+        101 => Ok(30), // e
+        102 => Ok(31), // f
+        103 => Ok(32), // g
+        104 => Ok(33), // h
+        105 => Ok(34), // i
+        106 => Ok(35), // j
+        107 => Ok(36), // k
+        108 => Ok(37), // l
+        109 => Ok(38), // m
+        110 => Ok(39), // n
+        111 => Ok(40), // o
+        112 => Ok(41), // p
+        113 => Ok(42), // q
+        114 => Ok(43), // r
+        115 => Ok(44), // s
+        116 => Ok(45), // t
+        117 => Ok(46), // u
+        118 => Ok(47), // v
+        119 => Ok(48), // w
+        120 => Ok(49), // x
+        121 => Ok(50), // y
+        122 => Ok(51), // z
+        _ => Err(Http2Base64Error::InvalidBase64),
+    }
+}
+
+fn http2_decode_base64(input: &[u8]) -> Result<Vec<u8>, Http2Base64Error> {
+    if input.len() % 4 != 0 {
+        return Err(Http2Base64Error::InvalidBase64);
+    }
+    let mut r = vec![0; (input.len() * 3) / 4];
+    for i in 0..input.len() / 4 {
+        let i1 = http2_base64_map(input[4 * i])?;
+        let i2 = http2_base64_map(input[4 * i + 1])?;
+        let i3 = http2_base64_map(input[4 * i + 2])?;
+        let i4 = http2_base64_map(input[4 * i + 3])?;
+        r[3 * i] = (i1 << 2) | (i2 >> 4);
+        r[3 * i + 1] = (i2 << 4) | (i3 >> 2);
+        r[3 * i + 2] = (i3 << 6) | i4;
+    }
+    return Ok(r);
+}
+
+fn http2_tx_set_settings(state: &mut HTTP2State, input: &[u8]) {
+    match http2_decode_base64(input) {
+        Ok(dec) => {
+            if dec.len() % 6 != 0 {
+                state.set_event(HTTP2Event::InvalidHTTP1Settings);
+            }
+
+            let head = parser::HTTP2FrameHeader {
+                length: dec.len() as u32,
+                ftype: parser::HTTP2FrameType::SETTINGS as u8,
+                flags: 0,
+                reserved: 0,
+                stream_id: 0,
+            };
+
+            match parser::http2_parse_frame_settings(&dec) {
+                Ok((_, set)) => {
+                    let txdata = HTTP2FrameTypeData::SETTINGS(set);
+                    let tx = state.find_or_create_tx(&head, &txdata, STREAM_TOSERVER);
+                    tx.frames_ts.push(HTTP2Frame {
+                        header: head,
+                        data: txdata,
+                    });
+                }
+                Err(_) => {
+                    state.set_event(HTTP2Event::InvalidHTTP1Settings);
+                }
+            }
+        }
+        Err(_) => {
+            state.set_event(HTTP2Event::InvalidHTTP1Settings);
+        }
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn rs_http2_tx_add_header(
     state: &mut HTTP2State, name: *const u8, name_len: u32, value: *const u8, value_len: u32,
@@ -600,7 +734,7 @@ pub extern "C" fn rs_http2_tx_add_header(
     let slice_name = build_slice!(name, name_len as usize);
     let slice_value = build_slice!(value, value_len as usize);
     if slice_name == "HTTP2-Settings".as_bytes() {
-        SCLogNotice!("lol seetings TODO");
+        http2_tx_set_settings(state, slice_value)
     } else {
         http2_tx_set_header(state, slice_name, slice_value)
     }

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -15,9 +15,12 @@
  * 02110-1301, USA.
  */
 
-use super::http2::{HTTP2FrameTypeData, HTTP2Transaction};
+use super::http2::{
+    HTTP2Frame, HTTP2FrameTypeData, HTTP2State, HTTP2Transaction, HTTP2TransactionState,
+};
 use super::parser;
 use crate::core::STREAM_TOSERVER;
+use crate::log::*;
 use std::ffi::CStr;
 use std::mem::transmute;
 use std::str::FromStr;
@@ -543,4 +546,62 @@ pub unsafe extern "C" fn rs_http2_tx_get_header(
     }
 
     return 0;
+}
+
+fn http2_tx_set_header(state: &mut HTTP2State, name: &[u8], input: &[u8]) {
+    let head = parser::HTTP2FrameHeader {
+        length: 0,
+        ftype: parser::HTTP2FrameType::HEADERS as u8,
+        flags: 0,
+        reserved: 0,
+        stream_id: 1,
+    };
+    let mut blocks = Vec::new();
+    let b = parser::HTTP2FrameHeaderBlock {
+        name: name.to_vec(),
+        value: input.to_vec(),
+        error: parser::HTTP2HeaderDecodeStatus::HTTP2HeaderDecodeSuccess,
+        sizeupdate: 0,
+    };
+    blocks.push(b);
+    let hs = parser::HTTP2FrameHeaders {
+        padlength: None,
+        priority: None,
+        blocks: blocks,
+    };
+    let txdata = HTTP2FrameTypeData::HEADERS(hs);
+    let tx = state.find_or_create_tx(&head, &txdata, STREAM_TOSERVER);
+    tx.frames_ts.push(HTTP2Frame {
+        header: head,
+        data: txdata,
+    });
+    //we do not expect more data from client
+    tx.state = HTTP2TransactionState::HTTP2StateHalfClosedClient;
+}
+
+#[no_mangle]
+pub extern "C" fn rs_http2_tx_set_method(
+    state: &mut HTTP2State, buffer: *const u8, buffer_len: u32,
+) {
+    let slice = build_slice!(buffer, buffer_len as usize);
+    http2_tx_set_header(state, ":method".as_bytes(), slice)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_http2_tx_set_uri(state: &mut HTTP2State, buffer: *const u8, buffer_len: u32) {
+    let slice = build_slice!(buffer, buffer_len as usize);
+    http2_tx_set_header(state, ":path".as_bytes(), slice)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_http2_tx_add_header(
+    state: &mut HTTP2State, name: *const u8, name_len: u32, value: *const u8, value_len: u32,
+) {
+    let slice_name = build_slice!(name, name_len as usize);
+    let slice_value = build_slice!(value, value_len as usize);
+    if slice_name == "HTTP2-Settings".as_bytes() {
+        SCLogNotice!("lol seetings TODO");
+    } else {
+        http2_tx_set_header(state, slice_name, slice_value)
+    }
 }

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -840,7 +840,6 @@ export_tx_set_detect_state!(rs_http2_tx_set_detect_state, HTTP2Transaction);
 
 export_tx_data_get!(rs_http2_get_tx_data, HTTP2Transaction);
 
-//TODOnext connection upgrade from HTTP1 cf SMTP STARTTLS
 /// C entry point for a probing parser.
 #[no_mangle]
 pub extern "C" fn rs_http2_probing_parser_tc(
@@ -1052,8 +1051,7 @@ const PARSER_NAME: &'static [u8] = b"http2\0";
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_http2_register_parser() {
-    //TODOend default port
-    let default_port = CString::new("[3000]").unwrap();
+    let default_port = CString::new("[80]").unwrap();
     let parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
         default_port: default_port.as_ptr(),

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -118,7 +118,7 @@ pub struct HTTP2Frame {
 pub struct HTTP2Transaction {
     tx_id: u64,
     pub stream_id: u32,
-    state: HTTP2TransactionState,
+    pub state: HTTP2TransactionState,
     child_stream_id: u32,
 
     pub frames_tc: Vec<HTTP2Frame>,
@@ -374,7 +374,7 @@ impl HTTP2State {
         return self.transactions.last_mut().unwrap();
     }
 
-    fn find_or_create_tx(
+    pub fn find_or_create_tx(
         &mut self, header: &parser::HTTP2FrameHeader, data: &HTTP2FrameTypeData, dir: u8,
     ) -> &mut HTTP2Transaction {
         if header.stream_id == 0 {
@@ -869,11 +869,27 @@ pub extern "C" fn rs_http2_probing_parser_tc(
     return ALPROTO_UNKNOWN;
 }
 
+/// Extern functions operating on HTTP2.
+extern "C" {
+    pub fn HTTP2MimicHttp1Request(
+        orig_state: *mut std::os::raw::c_void, new_state: *mut std::os::raw::c_void,
+    );
+}
+
 #[no_mangle]
-pub extern "C" fn rs_http2_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
+pub extern "C" fn rs_http2_state_new(
+    orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto,
+) -> *mut std::os::raw::c_void {
     let state = HTTP2State::new();
     let boxed = Box::new(state);
-    return unsafe { transmute(boxed) };
+    let r = unsafe { transmute(boxed) };
+    if orig_state != std::ptr::null_mut() {
+        //we could check ALPROTO_HTTP == orig_proto
+        unsafe {
+            HTTP2MimicHttp1Request(orig_state, r);
+        }
+    }
+    return r;
 }
 
 #[no_mangle]

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -247,6 +247,7 @@ pub enum HTTP2Event {
     ExtraHeaderData,
     LongFrameData,
     StreamIdReuse,
+    InvalidHTTP1Settings,
 }
 
 impl HTTP2Event {
@@ -260,6 +261,7 @@ impl HTTP2Event {
             5 => Some(HTTP2Event::ExtraHeaderData),
             6 => Some(HTTP2Event::LongFrameData),
             7 => Some(HTTP2Event::StreamIdReuse),
+            8 => Some(HTTP2Event::InvalidHTTP1Settings),
             _ => None,
         }
     }
@@ -298,7 +300,7 @@ impl HTTP2State {
         self.files.free();
     }
 
-    fn set_event(&mut self, event: HTTP2Event) {
+    pub fn set_event(&mut self, event: HTTP2Event) {
         let len = self.transactions.len();
         if len == 0 {
             return;
@@ -995,6 +997,7 @@ pub extern "C" fn rs_http2_state_get_event_info(
                 "extra_header_data" => HTTP2Event::ExtraHeaderData as i32,
                 "long_frame_data" => HTTP2Event::LongFrameData as i32,
                 "stream_id_reuse" => HTTP2Event::StreamIdReuse as i32,
+                "invalid_http1_settings" => HTTP2Event::InvalidHTTP1Settings as i32,
                 _ => -1, // unknown event
             }
         }
@@ -1022,6 +1025,7 @@ pub extern "C" fn rs_http2_state_get_event_info_by_id(
             HTTP2Event::ExtraHeaderData => "extra_header_data\0",
             HTTP2Event::LongFrameData => "long_frame_data\0",
             HTTP2Event::StreamIdReuse => "stream_id_reuse\0",
+            HTTP2Event::InvalidHTTP1Settings => "invalid_http1_settings\0",
         };
         unsafe {
             *event_name = estr.as_ptr() as *const std::os::raw::c_char;

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -870,7 +870,7 @@ pub extern "C" fn rs_http2_probing_parser_tc(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_http2_state_new() -> *mut std::os::raw::c_void {
+pub extern "C" fn rs_http2_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = HTTP2State::new();
     let boxed = Box::new(state);
     return unsafe { transmute(boxed) };

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -447,7 +447,7 @@ impl Drop for IKEV2Transaction {
 
 /// Returns *mut IKEV2State
 #[no_mangle]
-pub extern "C" fn rs_ikev2_state_new() -> *mut std::os::raw::c_void {
+pub extern "C" fn rs_ikev2_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = IKEV2State::new();
     let boxed = Box::new(state);
     return unsafe{std::mem::transmute(boxed)};

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -275,7 +275,7 @@ pub fn test_weak_encryption(alg:EncryptionType) -> bool {
 
 /// Returns *mut KRB5State
 #[no_mangle]
-pub extern "C" fn rs_krb5_state_new() -> *mut std::os::raw::c_void {
+pub extern "C" fn rs_krb5_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = KRB5State::new();
     let boxed = Box::new(state);
     return unsafe{std::mem::transmute(boxed)};

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -579,7 +579,7 @@ pub extern "C" fn rs_mqtt_probing_parser(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_mqtt_state_new() -> *mut std::os::raw::c_void {
+pub extern "C" fn rs_mqtt_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = MQTTState::new();
     let boxed = Box::new(state);
     return unsafe { transmute(boxed) };

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -1409,7 +1409,7 @@ impl NFSState {
 
 /// Returns *mut NFSState
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_new() -> *mut std::os::raw::c_void {
+pub extern "C" fn rs_nfs_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = NFSState::new();
     let boxed = Box::new(state);
     SCLogDebug!("allocating state");

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -177,7 +177,7 @@ impl Drop for NTPTransaction {
 
 /// Returns *mut NTPState
 #[no_mangle]
-pub extern "C" fn rs_ntp_state_new() -> *mut std::os::raw::c_void {
+pub extern "C" fn rs_ntp_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = NTPState::new();
     let boxed = Box::new(state);
     return unsafe{std::mem::transmute(boxed)};

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -365,7 +365,7 @@ impl RdpState {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rdp_state_new() -> *mut std::os::raw::c_void {
+pub extern "C" fn rs_rdp_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = RdpState::new();
     let boxed = Box::new(state);
     return unsafe { std::mem::transmute(boxed) };

--- a/rust/src/rfb/rfb.rs
+++ b/rust/src/rfb/rfb.rs
@@ -519,7 +519,7 @@ export_tx_set_detect_state!(
 );
 
 #[no_mangle]
-pub extern "C" fn rs_rfb_state_new() -> *mut std::os::raw::c_void {
+pub extern "C" fn rs_rfb_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = RFBState::new();
     let boxed = Box::new(state);
     return unsafe { transmute(boxed) };

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -170,7 +170,7 @@ impl Drop for SIPTransaction {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_state_new() -> *mut std::os::raw::c_void {
+pub extern "C" fn rs_sip_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = SIPState::new();
     let boxed = Box::new(state);
     return unsafe { std::mem::transmute(boxed) };

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1825,7 +1825,7 @@ impl SMBState {
 
 /// Returns *mut SMBState
 #[no_mangle]
-pub extern "C" fn rs_smb_state_new() -> *mut std::os::raw::c_void {
+pub extern "C" fn rs_smb_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = SMBState::new();
     let boxed = Box::new(state);
     SCLogDebug!("allocating state");

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -299,7 +299,7 @@ impl<'a> Drop for SNMPTransaction<'a> {
 
 /// Returns *mut SNMPState
 #[no_mangle]
-pub extern "C" fn rs_snmp_state_new() -> *mut std::os::raw::c_void {
+pub extern "C" fn rs_snmp_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = SNMPState::new();
     let boxed = Box::new(state);
     return unsafe{std::mem::transmute(boxed)};

--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -429,7 +429,7 @@ pub extern "C" fn rs_ssh_state_get_event_info_by_id(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_state_new() -> *mut std::os::raw::c_void {
+pub extern "C" fn rs_ssh_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = SSHState::new();
     let boxed = Box::new(state);
     return unsafe { transmute(boxed) };

--- a/src/app-layer-dcerpc-udp.c
+++ b/src/app-layer-dcerpc-udp.c
@@ -57,9 +57,9 @@ static AppLayerResult RustDCERPCUDPParse(Flow *f, void *dcerpc_state,
                                local_data, flags);
 }
 
-static void *RustDCERPCUDPStateNew(void)
+static void *RustDCERPCUDPStateNew(void *state_orig, AppProto proto_orig)
 {
-    return rs_dcerpc_udp_state_new();
+    return rs_dcerpc_udp_state_new(state_orig, proto_orig);
 }
 
 static void RustDCERPCUDPStateFree(void *s)

--- a/src/app-layer-dcerpc.c
+++ b/src/app-layer-dcerpc.c
@@ -81,9 +81,9 @@ static AppLayerResult DCERPCParseResponse(Flow *f, void *dcerpc_state,
     }
 }
 
-static void *RustDCERPCStateNew(void)
+static void *RustDCERPCStateNew(void *state_orig, AppProto proto_orig)
 {
-    return rs_dcerpc_state_new();
+    return rs_dcerpc_state_new(state_orig, proto_orig);
 }
 
 static void DCERPCStateFree(void *s)

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1868,7 +1868,6 @@ void AppLayerRequestProtocolTLSUpgrade(Flow *f)
 
 void AppLayerProtoDetectReset(Flow *f)
 {
-    FlowUnsetChangeProtoFlag(f);
     FLOW_RESET_PM_DONE(f, STREAM_TOSERVER);
     FLOW_RESET_PM_DONE(f, STREAM_TOCLIENT);
     FLOW_RESET_PP_DONE(f, STREAM_TOSERVER);
@@ -1878,8 +1877,8 @@ void AppLayerProtoDetectReset(Flow *f)
     f->probing_parser_toserver_alproto_masks = 0;
     f->probing_parser_toclient_alproto_masks = 0;
 
-    AppLayerParserStateCleanup(f, f->alstate, f->alparser);
-    f->alstate = NULL;
+    // Does not free the structures for the parser
+    // keeps f->alstate for new state creation
     f->alparser = NULL;
     f->alproto    = ALPROTO_UNKNOWN;
     f->alproto_ts = ALPROTO_UNKNOWN;

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -432,7 +432,7 @@ static int DNP3ReassembleApplicationLayer(const uint8_t *input,
  *
  * The DNP3 state object represents a single DNP3 TCP session.
  */
-static void *DNP3StateAlloc(void)
+static void *DNP3StateAlloc(void *orig_state, AppProto proto_orig)
 {
     SCEnter();
     DNP3State *dnp3;
@@ -2510,7 +2510,7 @@ static int DNP3ParserTestParsePDU01(void)
         0xe1, 0xc8, 0x01, 0x01, 0x00, 0x06, 0x77, 0x6e
     };
 
-    DNP3State *dnp3state = DNP3StateAlloc();
+    DNP3State *dnp3state = DNP3StateAlloc(NULL, ALPROTO_UNKNOWN);
     int pdus = DNP3HandleRequestLinkLayer(dnp3state, pkt, sizeof(pkt));
     FAIL_IF(pdus < 1);
     DNP3Transaction *dnp3tx = DNP3GetTx(dnp3state, 0);
@@ -2549,7 +2549,7 @@ static int DNP3ParserDecodeG70V3Test(void)
         0xc4, 0x8b
     };
 
-    DNP3State *dnp3state = DNP3StateAlloc();
+    DNP3State *dnp3state = DNP3StateAlloc(NULL, ALPROTO_UNKNOWN);
     FAIL_IF_NULL(dnp3state);
     int bytes = DNP3HandleRequestLinkLayer(dnp3state, pkt, sizeof(pkt));
     FAIL_IF(bytes != sizeof(pkt));
@@ -2610,7 +2610,7 @@ static int DNP3ParserUnknownEventAlertTest(void)
 
     DNP3FixCrc(pkt + 10, sizeof(pkt) - 10);
 
-    DNP3State *dnp3state = DNP3StateAlloc();
+    DNP3State *dnp3state = DNP3StateAlloc(NULL, ALPROTO_UNKNOWN);
     FAIL_IF_NULL(dnp3state);
     int bytes = DNP3HandleRequestLinkLayer(dnp3state, pkt, sizeof(pkt));
     FAIL_IF(bytes != sizeof(pkt));

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -159,7 +159,7 @@ static int ENIPStateGetEventInfoById(int event_id, const char **event_name,
  *
  *  return state
  */
-static void *ENIPStateAlloc(void)
+static void *ENIPStateAlloc(void *orig_state, AppProto proto_orig)
 {
     SCLogDebug("ENIPStateAlloc");
     void *s = SCMalloc(sizeof(ENIPState));

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -833,7 +833,7 @@ static uint64_t ftp_state_memuse = 0;
 static uint64_t ftp_state_memcnt = 0;
 #endif
 
-static void *FTPStateAlloc(void)
+static void *FTPStateAlloc(void *orig_state, AppProto proto_orig)
 {
     void *s = FTPCalloc(1, sizeof(FtpState));
     if (unlikely(s == NULL))
@@ -1152,7 +1152,7 @@ static uint64_t ftpdata_state_memuse = 0;
 static uint64_t ftpdata_state_memcnt = 0;
 #endif
 
-static void *FTPDataStateAlloc(void)
+static void *FTPDataStateAlloc(void *orig_state, AppProto proto_orig)
 {
     void *s = FTPCalloc(1, sizeof(FtpDataState));
     if (unlikely(s == NULL))

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -340,7 +340,7 @@ static AppLayerDecoderEvents *HTPGetEvents(void *tx)
 /** \brief Function to allocates the HTTP state memory and also creates the HTTP
  *         connection parser to be used by the HTP library
  */
-static void *HTPStateAlloc(void)
+static void *HTPStateAlloc(void *orig_state, AppProto proto_orig)
 {
     SCEnter();
 

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -947,11 +947,44 @@ static AppLayerResult HTPHandleResponseData(Flow *f, void *htp_state,
     DEBUG_VALIDATE_BUG_ON(hstate->connp == NULL);
 
     htp_time_t ts = { f->lastts.tv_sec, f->lastts.tv_usec };
+    htp_tx_t *tx = NULL;
+    size_t consumed = 0;
     if (input_len > 0) {
         const int r = htp_connp_res_data(hstate->connp, &ts, input, input_len);
         switch (r) {
             case HTP_STREAM_ERROR:
                 ret = -1;
+                break;
+            case HTP_STREAM_TUNNEL:
+                tx = htp_connp_get_out_tx(hstate->connp);
+                if (tx != NULL && tx->response_status_number == 101) {
+                    htp_header_t *h =
+                            (htp_header_t *)htp_table_get_c(tx->response_headers, "Upgrade");
+                    if (h != NULL) {
+                        if (bstr_cmp_c(h->value, "h2c") == 0) {
+                            uint16_t dp = 0;
+                            if (tx->request_port_number != -1) {
+                                dp = (uint16_t)tx->request_port_number;
+                            }
+                            consumed = htp_connp_res_data_consumed(hstate->connp);
+                            AppLayerRequestProtocolChange(hstate->f, dp, ALPROTO_HTTP2);
+                            // close connection to log HTTP1 request in tunnel mode
+                            if (!(hstate->flags & HTP_FLAG_STATE_CLOSED_TC)) {
+                                htp_connp_close(hstate->connp, &ts);
+                                hstate->flags |= HTP_FLAG_STATE_CLOSED_TC;
+                            }
+                            // TODO mimic HTTP1 request into HTTP2
+
+                            // During HTTP2 upgrade, we may consume the HTTP1 part of the data
+                            // and we need to parser the remaining part with HTTP2
+                            if (consumed > 0 && consumed < input_len) {
+                                SCReturnStruct(
+                                        APP_LAYER_INCOMPLETE(consumed, input_len - consumed));
+                            }
+                            SCReturnStruct(APP_LAYER_OK);
+                        }
+                    }
+                }
                 break;
             default:
                 break;

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -288,6 +288,8 @@ void HTPConfigure(void);
 void HtpConfigCreateBackup(void);
 void HtpConfigRestoreBackup(void);
 
+void *HtpGetTxForH2(void *);
+
 #endif	/* __APP_LAYER_HTP_H__ */
 
 /**

--- a/src/app-layer-http2.h
+++ b/src/app-layer-http2.h
@@ -26,4 +26,6 @@
 
 void RegisterHTTP2Parsers(void);
 
+void HTTP2MimicHttp1Request(void *, void *);
+
 #endif /* __APP_LAYER_HTTP2_H__ */

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1394,7 +1394,7 @@ static AppLayerResult ModbusParseResponse(Flow      *f,
 /** \internal
  *     \brief Function to allocate the Modbus state memory
  */
-static void *ModbusStateAlloc(void)
+static void *ModbusStateAlloc(void *orig_state, AppProto proto_orig)
 {
     ModbusState *modbus;
 

--- a/src/app-layer-nfs-tcp.c
+++ b/src/app-layer-nfs-tcp.c
@@ -66,9 +66,9 @@ SCEnumCharMap nfs_decoder_event_table[] = {
     { NULL, 0 }
 };
 
-static void *NFSTCPStateAlloc(void)
+static void *NFSTCPStateAlloc(void *orig_state, AppProto proto_orig)
 {
-    return rs_nfs_state_new();
+    return rs_nfs_state_new(orig_state, proto_orig);
 }
 
 static void NFSTCPStateFree(void *state)

--- a/src/app-layer-nfs-udp.c
+++ b/src/app-layer-nfs-udp.c
@@ -63,9 +63,9 @@ SCEnumCharMap nfs_udp_decoder_event_table[] = {
     { NULL, 0 }
 };
 
-static void *NFSStateAlloc(void)
+static void *NFSStateAlloc(void *orig_state, AppProto proto_orig)
 {
-    return rs_nfs_state_new();
+    return rs_nfs_state_new(orig_state, proto_orig);
 }
 
 static void NFSStateFree(void *state)

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -99,7 +99,7 @@ typedef struct AppLayerParserProtoCtx_
     bool logger;
     uint32_t logger_bits;   /**< registered loggers for this proto */
 
-    void *(*StateAlloc)(void);
+    void *(*StateAlloc)(void *, AppProto);
     void (*StateFree)(void *);
     void (*StateTransactionFree)(void *, uint64_t);
     void *(*LocalStorageAlloc)(void);
@@ -396,8 +396,7 @@ uint32_t AppLayerParserGetOptionFlags(uint8_t protomap, AppProto alproto)
 }
 
 void AppLayerParserRegisterStateFuncs(uint8_t ipproto, AppProto alproto,
-                           void *(*StateAlloc)(void),
-                           void (*StateFree)(void *))
+        void *(*StateAlloc)(void *, AppProto), void (*StateFree)(void *))
 {
     SCEnter();
 
@@ -1216,7 +1215,7 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
 
     alstate = f->alstate;
     if (alstate == NULL) {
-        f->alstate = alstate = p->StateAlloc();
+        f->alstate = alstate = p->StateAlloc(alstate, f->alproto_orig);
         if (alstate == NULL)
             goto error;
         SCLogDebug("alloced new app layer state %p (name %s)",
@@ -1674,7 +1673,7 @@ static AppLayerResult TestProtocolParser(Flow *f, void *test_state, AppLayerPars
 
 /** \brief Function to allocates the Test protocol state memory
  */
-static void *TestProtocolStateAlloc(void)
+static void *TestProtocolStateAlloc(void *orig_state, AppProto proto_orig)
 {
     SCEnter();
     void *s = SCMalloc(sizeof(TestState));

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1214,7 +1214,7 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
     SetEOFFlags(pstate, flags);
 
     alstate = f->alstate;
-    if (alstate == NULL) {
+    if (alstate == NULL || FlowChangeProto(f)) {
         f->alstate = alstate = p->StateAlloc(alstate, f->alproto_orig);
         if (alstate == NULL)
             goto error;
@@ -1444,12 +1444,12 @@ void AppLayerParserSetStreamDepthFlag(uint8_t ipproto, AppProto alproto, void *s
 
 /***** Cleanup *****/
 
-void AppLayerParserStateCleanup(const Flow *f, void *alstate,
-                                AppLayerParserState *pstate)
+void AppLayerParserStateProtoCleanup(
+        uint8_t protomap, AppProto alproto, void *alstate, AppLayerParserState *pstate)
 {
     SCEnter();
 
-    AppLayerParserProtoCtx *ctx = &alp_ctx.ctxs[f->protomap][f->alproto];
+    AppLayerParserProtoCtx *ctx = &alp_ctx.ctxs[protomap][alproto];
 
     if (ctx->StateFree != NULL && alstate != NULL)
         ctx->StateFree(alstate);
@@ -1459,6 +1459,11 @@ void AppLayerParserStateCleanup(const Flow *f, void *alstate,
         AppLayerParserStateFree(pstate);
 
     SCReturn;
+}
+
+void AppLayerParserStateCleanup(const Flow *f, void *alstate, AppLayerParserState *pstate)
+{
+    AppLayerParserStateProtoCleanup(f->protomap, f->alproto, alstate, pstate);
 }
 
 static void ValidateParserProtoDump(AppProto alproto, uint8_t ipproto)

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -257,6 +257,8 @@ int AppLayerParserIsEnabled(AppProto alproto);
 
 /***** Cleanup *****/
 
+void AppLayerParserStateProtoCleanup(
+        uint8_t protomap, AppProto alproto, void *alstate, AppLayerParserState *pstate);
 void AppLayerParserStateCleanup(const Flow *f, void *alstate, AppLayerParserState *pstate);
 
 void AppLayerParserRegisterProtocolParsers(void);

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -145,8 +145,7 @@ void AppLayerParserRegisterParserAcceptableDataDirection(uint8_t ipproto,
 void AppLayerParserRegisterOptionFlags(uint8_t ipproto, AppProto alproto,
         uint32_t flags);
 void AppLayerParserRegisterStateFuncs(uint8_t ipproto, AppProto alproto,
-                           void *(*StateAlloc)(void),
-                           void (*StateFree)(void *));
+        void *(*StateAlloc)(void *, AppProto), void (*StateFree)(void *));
 void AppLayerParserRegisterLocalStorageFunc(uint8_t ipproto, AppProto proto,
                                  void *(*LocalStorageAlloc)(void),
                                  void (*LocalStorageFree)(void *));

--- a/src/app-layer-register.h
+++ b/src/app-layer-register.h
@@ -35,7 +35,7 @@ typedef struct AppLayerParser {
     uint16_t min_depth;
     uint16_t max_depth;
 
-    void *(*StateAlloc)(void);
+    void *(*StateAlloc)(void *, AppProto);
     void (*StateFree)(void *);
 
     AppLayerParserFPtr ParseTS;

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1432,7 +1432,7 @@ static AppLayerResult SMTPParseServerRecord(Flow *f, void *alstate,
  * \internal
  * \brief Function to allocate SMTP state memory.
  */
-void *SMTPStateAlloc(void)
+void *SMTPStateAlloc(void *orig_state, AppProto proto_orig)
 {
     SMTPState *smtp_state = SCMalloc(sizeof(SMTPState));
     if (unlikely(smtp_state == NULL))
@@ -5154,7 +5154,7 @@ static int SMTPProcessDataChunkTest02(void){
     memset(&ssn, 0, sizeof(ssn));
     FLOW_INITIALIZE(&f);
     f.protoctx = &ssn;
-    f.alstate = SMTPStateAlloc();
+    f.alstate = SMTPStateAlloc(NULL, ALPROTO_UNKNOWN);
     MimeDecParseState *state = MimeDecInitParser(&f, NULL);
     ((MimeDecEntity *)state->stack->top->data)->ctnt_flags = CTNT_IS_ATTACHMENT;
     state->body_begin = 1;
@@ -5185,7 +5185,7 @@ static int SMTPProcessDataChunkTest03(void){
     Flow f;
     FLOW_INITIALIZE(&f);
     f.protoctx = &ssn;
-    f.alstate = SMTPStateAlloc();
+    f.alstate = SMTPStateAlloc(NULL, ALPROTO_UNKNOWN);
     MimeDecParseState *state = MimeDecInitParser(&f, NULL);
     ((MimeDecEntity *)state->stack->top->data)->ctnt_flags = CTNT_IS_ATTACHMENT;
     int ret;
@@ -5241,7 +5241,7 @@ static int SMTPProcessDataChunkTest04(void){
     Flow f;
     FLOW_INITIALIZE(&f);
     f.protoctx = &ssn;
-    f.alstate = SMTPStateAlloc();
+    f.alstate = SMTPStateAlloc(NULL, ALPROTO_UNKNOWN);
     MimeDecParseState *state = MimeDecInitParser(&f, NULL);
     ((MimeDecEntity *)state->stack->top->data)->ctnt_flags = CTNT_IS_ATTACHMENT;
     int ret = MIME_DEC_OK;
@@ -5281,7 +5281,7 @@ static int SMTPProcessDataChunkTest05(void){
     int ret;
     FLOW_INITIALIZE(&f);
     f.protoctx = &ssn;
-    f.alstate = SMTPStateAlloc();
+    f.alstate = SMTPStateAlloc(NULL, ALPROTO_UNKNOWN);
     FAIL_IF(f.alstate == NULL);
     MimeDecParseState *state = MimeDecInitParser(&f, NULL);
     ((MimeDecEntity *)state->stack->top->data)->ctnt_flags = CTNT_IS_ATTACHMENT;

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -174,7 +174,7 @@ typedef struct SMTPState_ {
 extern SMTPConfig smtp_config;
 
 int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len, MimeDecParseState *state);
-void *SMTPStateAlloc(void);
+void *SMTPStateAlloc(void *orig_state, AppProto proto_orig);
 void RegisterSMTPParsers(void);
 void SMTPParserCleanup(void);
 void SMTPParserRegisterTests(void);

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2634,7 +2634,7 @@ static AppLayerResult SSLParseServerRecord(Flow *f, void *alstate, AppLayerParse
  * \internal
  * \brief Function to allocate the SSL state memory.
  */
-static void *SSLStateAlloc(void)
+static void *SSLStateAlloc(void *orig_state, AppProto proto_orig)
 {
     SSLState *ssl_state = SCMalloc(sizeof(SSLState));
     if (unlikely(ssl_state == NULL))

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -105,7 +105,7 @@ static void TemplateTxFree(void *txv)
     SCFree(tx);
 }
 
-static void *TemplateStateAlloc(void)
+static void *TemplateStateAlloc(void *orig_state, AppProto proto_orig)
 {
     SCLogNotice("Allocating template state.");
     TemplateState *state = SCCalloc(1, sizeof(TemplateState));

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -44,7 +44,7 @@
  * be the size of a header. */
 #define TFTP_MIN_FRAME_LEN 4
 
-static void *TFTPStateAlloc(void)
+static void *TFTPStateAlloc(void *orig_state, AppProto proto_orig)
 {
     return rs_tftp_state_alloc();
 }

--- a/src/tests/detect-file-data.c
+++ b/src/tests/detect-file-data.c
@@ -73,7 +73,7 @@ static int DetectEngineSMTPFiledataTest01(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alstate = SMTPStateAlloc();
+    f.alstate = SMTPStateAlloc(NULL, ALPROTO_UNKNOWN);
 
     MimeDecParseState *state = MimeDecInitParser(&f, NULL);
     ((MimeDecEntity *)state->stack->top->data)->ctnt_flags = CTNT_IS_ATTACHMENT;
@@ -205,7 +205,7 @@ static int DetectEngineSMTPFiledataTest03(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alstate = SMTPStateAlloc();
+    f.alstate = SMTPStateAlloc(NULL, ALPROTO_UNKNOWN);
 
     MimeDecParseState *state = MimeDecInitParser(&f, NULL);
     ((MimeDecEntity *)state->stack->top->data)->ctnt_flags = CTNT_IS_ATTACHMENT;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3866

Describe changes:
- Adds mechanism to change protocol from HTTP1 to HTTP2

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

suricata-verify-pr: 320

Makes https://github.com/OISF/suricata-verify/pull/320 pass

Modifies #5363 by fixing compilation with unit tests to get CI better

The downside compared to #5354 is to have one more test ` FlowChangeProto(f)` to run at (almost) each call of `AppLayerParserParse`
