### PR TITLE
log: Log output errors

### DIFF
--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -528,8 +528,14 @@ char *strptime(const char * __restrict, const char * __restrict, struct tm * __r
 
 #ifndef HAVE_FWRITE_UNLOCKED
 #define SCFwriteUnlocked    fwrite
+#define SCFflushUnlocked    fflush
+#define SCClearErrUnlocked  clearerr
+#define SCFerrorUnlocked    ferror
 #else
 #define SCFwriteUnlocked    fwrite_unlocked
+#define SCFflushUnlocked    fflush_unlocked
+#define SCClearErrUnlocked  clearerr_unlocked
+#define SCFerrorUnlocked    ferror_unlocked
 #endif
 extern int coverage_unittests;
 extern int g_ut_modules;

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -375,6 +375,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_WARN_FILESTORE_CONFIG);
         CASE_CODE (SC_WARN_PATH_READ_ERROR);
         CASE_CODE (SC_ERR_PLUGIN);
+        CASE_CODE (SC_ERR_LOG_OUTPUT);
 
         CASE_CODE (SC_ERR_MAX);
     }

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -365,6 +365,7 @@ typedef enum {
     SC_WARN_PATH_READ_ERROR,
     SC_ERR_HTTP2_LOG_GENERIC,
     SC_ERR_PLUGIN,
+    SC_ERR_LOG_OUTPUT,
 
     SC_ERR_MAX
 } SCError;

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -209,9 +209,9 @@ static int SCLogFileWriteNoLock(const char *buffer, int buffer_len, LogFileCtx *
     }
 
     if (log_ctx->fp) {
-        clearerr(log_ctx->fp);
+        SCClearErrUnlocked(log_ctx->fp);
         ret = SCFwriteUnlocked(buffer, buffer_len, 1, log_ctx->fp);
-        fflush(log_ctx->fp);
+        SCFflushUnlocked(log_ctx->fp);
     }
 
     return ret;

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -148,6 +148,8 @@ typedef struct LogFileCtx_ {
     /* Socket types may need to drop events to keep from blocking
      * Suricata. */
     uint64_t dropped;
+
+    uint64_t output_errors;
 } LogFileCtx;
 
 /* Min time (msecs) before trying to reconnect a Unix domain socket */


### PR DESCRIPTION
Continuation of #5289

This PR causes Suricata to no longer fail silently when writing log messages.

Errors while writing log output will be logged once to provide visibility to operational issues that prevented the log output from being written successfully.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3482](https://redmine.openinfosecfoundation.org/issues/3842)

Describe changes:
-Address review comments.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
