### PR TITLE
log: Log output errors

### DIFF
--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -528,8 +528,14 @@ char *strptime(const char * __restrict, const char * __restrict, struct tm * __r
 
 #ifndef HAVE_FWRITE_UNLOCKED
 #define SCFwriteUnlocked    fwrite
+#define SCFflushUnlocked    fflush
+#define SCClearErrUnlocked  clearerr
+#define SCFerrorUnlocked    ferror
 #else
 #define SCFwriteUnlocked    fwrite_unlocked
+#define SCFflushUnlocked    fflush_unlocked
+#define SCClearErrUnlocked  clearerr_unlocked
+#define SCFerrorUnlocked    ferror_unlocked
 #endif
 extern int coverage_unittests;
 extern int g_ut_modules;

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -375,6 +375,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_WARN_FILESTORE_CONFIG);
         CASE_CODE (SC_WARN_PATH_READ_ERROR);
         CASE_CODE (SC_ERR_PLUGIN);
+        CASE_CODE(SC_ERR_LOG_OUTPUT);
 
         CASE_CODE (SC_ERR_MAX);
     }

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -176,9 +176,9 @@ typedef enum {
     SC_ERR_LIBNET_BUILD_FAILED,
     SC_ERR_LIBNET_WRITE_FAILED,
     SC_ERR_LIBNET_NOT_ENABLED,
-    SC_ERR_UNIFIED_LOG_FILE_HEADER,  /**< Error to indicate the unified file
-                                          header writing function has been
-                                          failed */
+    SC_ERR_UNIFIED_LOG_FILE_HEADER, /**< Error to indicate the unified file
+                                         header writing function has been
+                                         failed */
     SC_ERR_REFERENCE_UNKNOWN,       /**< unknown reference key (cve, url, etc) */
     SC_ERR_PIDFILE_SNPRINTF,
     SC_ERR_PIDFILE_OPEN,
@@ -199,13 +199,13 @@ typedef enum {
     SC_ERR_ERF_DAG_STREAM_READ_FAILED,
     SC_WARN_ERF_DAG_REC_LEN_CHANGED,
     SC_ERR_DAG_REQUIRED,
-    SC_ERR_DAG_NOSUPPORT,           /**< no ERF/DAG support compiled in */
+    SC_ERR_DAG_NOSUPPORT, /**< no ERF/DAG support compiled in */
     SC_ERR_FATAL,
     SC_ERR_DCERPC,
-    SC_ERR_DETECT_PREPARE,          /**< preparing the detection engine failed */
+    SC_ERR_DETECT_PREPARE, /**< preparing the detection engine failed */
     SC_ERR_AHO_CORASICK,
     SC_ERR_REFERENCE_CONFIG,
-    SC_ERR_DUPLICATE_SIG,       /**< Error to indicate that signature is duplicate */
+    SC_ERR_DUPLICATE_SIG, /**< Error to indicate that signature is duplicate */
     SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL,
     SC_ERR_PCAP_MULTI_DEV_NO_SUPPORT,
     SC_ERR_HTTP_METHOD_NEEDS_PRECEEDING_CONTENT,
@@ -230,7 +230,7 @@ typedef enum {
     SC_ERR_SIZE_PARSE,
     SC_ERR_RAWBYTES_BUFFER,
     SC_ERR_SOCKET,
-    SC_ERR_PCAP_TRANSLATE,          /* failed to translate ip to dev */
+    SC_ERR_PCAP_TRANSLATE, /* failed to translate ip to dev */
     SC_WARN_OUTDATED_LIBHTP,
     SC_WARN_DEPRECATED,
     SC_WARN_PROFILE,
@@ -302,9 +302,9 @@ typedef enum {
     SC_ERR_INVALID_RULE_ARGUMENT, /**< Generic error code for invalid
                                    * rule argument. */
     SC_ERR_MT_NO_MAPPING,
-    SC_ERR_STATS_LOG_NEGATED, /** When totals and threads are both NO in yaml **/
+    SC_ERR_STATS_LOG_NEGATED,      /** When totals and threads are both NO in yaml **/
     SC_ERR_JSON_STATS_LOG_NEGATED, /** When totals and threads are both NO in yaml **/
-    SC_ERR_DEPRECATED_CONF, /**< Deprecated configuration parameter. */
+    SC_ERR_DEPRECATED_CONF,        /**< Deprecated configuration parameter. */
     SC_WARN_FASTER_CAPTURE_AVAILABLE,
     SC_WARN_POOR_RULE,
     SC_ERR_ALERT_PAYLOAD_BUFFER,
@@ -365,6 +365,7 @@ typedef enum {
     SC_WARN_PATH_READ_ERROR,
     SC_ERR_HTTP2_LOG_GENERIC,
     SC_ERR_PLUGIN,
+    SC_ERR_LOG_OUTPUT,
 
     SC_ERR_MAX
 } SCError;

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -209,9 +209,9 @@ static int SCLogFileWriteNoLock(const char *buffer, int buffer_len, LogFileCtx *
     }
 
     if (log_ctx->fp) {
-        clearerr(log_ctx->fp);
+        SCClearErrUnlocked(log_ctx->fp);
         ret = SCFwriteUnlocked(buffer, buffer_len, 1, log_ctx->fp);
-        fflush(log_ctx->fp);
+        SCFflushUnlocked(log_ctx->fp);
     }
 
     return ret;

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -210,8 +210,17 @@ static int SCLogFileWriteNoLock(const char *buffer, int buffer_len, LogFileCtx *
 
     if (log_ctx->fp) {
         SCClearErrUnlocked(log_ctx->fp);
-        ret = SCFwriteUnlocked(buffer, buffer_len, 1, log_ctx->fp);
-        SCFflushUnlocked(log_ctx->fp);
+        if (1 != SCFwriteUnlocked(buffer, buffer_len, 1, log_ctx->fp)) {
+            /* Only the first error is logged */
+            if (!log_ctx->output_errors) {
+                SCLogError(SC_ERR_LOG_OUTPUT, "%s error while writing to %s",
+                        SCFerrorUnlocked(log_ctx->fp) ? strerror(errno) : "unknown error",
+                        log_ctx->filename);
+            }
+            log_ctx->output_errors++;
+        } else {
+            SCFflushUnlocked(log_ctx->fp);
+        }
     }
 
     return ret;
@@ -250,8 +259,17 @@ static int SCLogFileWrite(const char *buffer, int buffer_len, LogFileCtx *log_ct
 
         if (log_ctx->fp) {
             clearerr(log_ctx->fp);
-            ret = fwrite(buffer, buffer_len, 1, log_ctx->fp);
-            fflush(log_ctx->fp);
+            if (1 != fwrite(buffer, buffer_len, 1, log_ctx->fp)) {
+                /* Only the first error is logged */
+                if (!log_ctx->output_errors) {
+                    SCLogError(SC_ERR_LOG_OUTPUT, "%s error while writing to %s",
+                            ferror(log_ctx->fp) ? strerror(errno) : "unknown error",
+                            log_ctx->filename);
+                }
+                log_ctx->output_errors++;
+            } else {
+                fflush(log_ctx->fp);
+            }
         }
     }
 
@@ -285,6 +303,11 @@ static void SCLogFileCloseNoLock(LogFileCtx *log_ctx)
 {
     if (log_ctx->fp)
         fclose(log_ctx->fp);
+
+    if (log_ctx->output_errors) {
+        SCLogError(SC_ERR_LOG_OUTPUT, "There were %" PRIu64 " output errors to %s",
+                log_ctx->output_errors, log_ctx->filename);
+    }
 }
 
 static void SCLogFileClose(LogFileCtx *log_ctx)

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -148,6 +148,8 @@ typedef struct LogFileCtx_ {
     /* Socket types may need to drop events to keep from blocking
      * Suricata. */
     uint64_t dropped;
+
+    uint64_t output_errors;
 } LogFileCtx;
 
 /* Min time (msecs) before trying to reconnect a Unix domain socket */


### PR DESCRIPTION
Continuation of #5371

This PR causes Suricata to no longer fail silently when writing log messages.

Errors while writing log output will be logged once to provide visibility to operational issues that prevented the log output from being written successfully.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3482](https://redmine.openinfosecfoundation.org/issues/3842)

Describe changes:
- Addressed formatting issues.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
