### PR TITLE
log: Ensure threaded eve honors SIGHUP

### DIFF
--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -736,8 +736,10 @@ static bool LogFileNewThreadedCtx(LogFileCtx *parent_ctx, const char *log_path, 
     thread->threaded = false;
     thread->parent = parent_ctx;
     thread->id = thread_id;
+    thread->is_regular = true;
     thread->Write = SCLogFileWriteNoLock;
     thread->Close = SCLogFileCloseNoLock;
+    OutputRegisterFileRotationFlag(&thread->rotation_flag);
 
     parent_ctx->threads->lf_slots[thread_id] = thread;
     return true;


### PR DESCRIPTION
This commit ensures that all logging contexts register for the file
rotation mechanism (SIGHUP and configured).

Describe changes:
- Register file rotation flag when creating context
- Set `is_regular` correctly

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/3915

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
