### PR TITLE
datasets: fix dataset load path construction - v1

### DIFF
--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -264,7 +264,7 @@ static int SetupLoadPath(const DetectEngineCtx *de_ctx,
     if (snprintf(path, sizeof(path), "%s/%s", dir, load) >= (int)sizeof(path)) // TODO windows path
         return -1;
 
-    if (SCPathExists(load)) {
+    if (SCPathExists(path)) {
         done = true;
         strlcpy(load, path, load_size);
         SCLogDebug("using path '%s' (HAVE_LIBGEN_H)", load);


### PR DESCRIPTION
Test full constructed filename for existence instead of just
the base filename when loading a dataset.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/3916

# Just set to test Python path change on a CI run.
suricata-verify-pr: 327

Prscript:
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/854
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/496
