### PR TITLE
Datasets memcap/v1

### DIFF
--- a/src/datasets.c
+++ b/src/datasets.c
@@ -177,7 +177,7 @@ static int DatasetLoadMd5(Dataset *set)
         /* straight black/white list */
         if (strlen(line) == 33) {
             line[strlen(line) - 1] = '\0';
-            SCLogDebug("line: '%s'", line);
+            //SCLogDebug("line: '%s'", line);
 
             uint8_t hash[16];
             if (HexToRaw((const uint8_t *)line, 32, hash, sizeof(hash)) < 0)
@@ -246,7 +246,7 @@ static int DatasetLoadSha256(Dataset *set)
         /* straight black/white list */
         if (strlen(line) == 65) {
             line[strlen(line) - 1] = '\0';
-            SCLogDebug("line: '%s'", line);
+//            SCLogDebug("line: '%s'", line);
 
             uint8_t hash[32];
             if (HexToRaw((const uint8_t *)line, 64, hash, sizeof(hash)) < 0)
@@ -314,7 +314,7 @@ static int DatasetLoadString(Dataset *set)
         char *r = strchr(line, ',');
         if (r == NULL) {
             line[strlen(line) - 1] = '\0';
-            SCLogDebug("line: '%s'", line);
+//            SCLogDebug("line: '%s'", line);
 
             // coverity[alloc_strlen : FALSE]
             uint8_t decoded[strlen(line)];
@@ -329,7 +329,7 @@ static int DatasetLoadString(Dataset *set)
             cnt++;
         } else {
             line[strlen(line) - 1] = '\0';
-            SCLogDebug("line: '%s'", line);
+//            SCLogDebug("line: '%s'", line);
 
             *r = '\0';
 
@@ -419,6 +419,7 @@ Dataset *DatasetFind(const char *name, enum DatasetTypes type)
 Dataset *DatasetGet(const char *name, enum DatasetTypes type,
         const char *save, const char *load)
 {
+    SCLogDebug("Datasetget now");
     if (strlen(name) > DATASET_NAME_MAX_LEN) {
         return NULL;
     }
@@ -490,15 +491,16 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type,
     switch (type) {
         case DATASET_TYPE_MD5:
             set->hash = THashInit(cnf_name, sizeof(Md5Type), Md5StrSet,
-                    Md5StrFree, Md5StrHash, Md5StrCompare);
+                    Md5StrFree, Md5StrHash, Md5StrCompare, load != NULL ? 1 : 0);
             if (set->hash == NULL)
                 goto out_err;
             if (DatasetLoadMd5(set) < 0)
                 goto out_err;
             break;
         case DATASET_TYPE_STRING:
+            SCLogDebug("%d", load!=NULL?1:0);
             set->hash = THashInit(cnf_name, sizeof(StringType), StringSet,
-                    StringFree, StringHash, StringCompare);
+                    StringFree, StringHash, StringCompare, load != NULL ? 1 : 0);
             if (set->hash == NULL)
                 goto out_err;
             if (DatasetLoadString(set) < 0)
@@ -506,7 +508,7 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type,
             break;
         case DATASET_TYPE_SHA256:
             set->hash = THashInit(cnf_name, sizeof(Sha256Type), Sha256StrSet,
-                    Sha256StrFree, Sha256StrHash, Sha256StrCompare);
+                    Sha256StrFree, Sha256StrHash, Sha256StrCompare, load != NULL ? 1 : 0);
             if (set->hash == NULL)
                 goto out_err;
             if (DatasetLoadSha256(set) < 0)

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -357,6 +357,8 @@ static int DatasetLoadString(Dataset *set)
         }
     }
 
+    // TODO figure out how to reset memcap after load is finished, a reset function? a macro?
+
     fclose(fp);
     SCLogConfig("dataset: %s loaded %u records", set->name, cnt);
     return 0;
@@ -644,12 +646,16 @@ int DatasetsInit(void)
             }
 
             ConfNode *set_memcap = ConfNodeLookupChild(iter, "memcap");
-            if (StringParseUint64(&memcap, 10, 0, set_memcap->val) < 0) {
-                FatalError(SC_ERR_FATAL, "memcap value cannot be deduced: %s", set_memcap->val);
+            if (set_memcap) {
+                if (StringParseUint64(&memcap, 10, 0, set_memcap->val) < 0) {
+                    FatalError(SC_ERR_FATAL, "memcap value cannot be deduced: %s", set_memcap->val);
+                }
             }
             ConfNode *set_hashsize = ConfNodeLookupChild(iter, "hashsize");
-            if (StringParseUint32(&hashsize, 10, 0, set_hashsize->val) < 0) {
-                FatalError(SC_ERR_FATAL, "hashsize value cannot be deduced: %s", set_hashsize->val);
+            if (set_hashsize) {
+                if (StringParseUint32(&hashsize, 10, 0, set_hashsize->val) < 0) {
+                    FatalError(SC_ERR_FATAL, "hashsize value cannot be deduced: %s", set_hashsize->val);
+                }
             }
             char conf_str[1024];
             snprintf(conf_str, sizeof(conf_str), "datasets.%d.%s", list_pos, set_name);

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -417,7 +417,7 @@ Dataset *DatasetFind(const char *name, enum DatasetTypes type)
 }
 
 Dataset *DatasetGet(const char *name, enum DatasetTypes type,
-        const char *save, const char *load)
+        const char *save, const char *load, uint64_t memcap, uint32_t hashsize)
 {
     SCLogDebug("Datasetget now");
     if (strlen(name) > DATASET_NAME_MAX_LEN) {
@@ -491,7 +491,8 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type,
     switch (type) {
         case DATASET_TYPE_MD5:
             set->hash = THashInit(cnf_name, sizeof(Md5Type), Md5StrSet,
-                    Md5StrFree, Md5StrHash, Md5StrCompare, load != NULL ? 1 : 0);
+                    Md5StrFree, Md5StrHash, Md5StrCompare, load != NULL ? 1 : 0,
+                    memcap, hashsize);
             if (set->hash == NULL)
                 goto out_err;
             if (DatasetLoadMd5(set) < 0)
@@ -500,7 +501,8 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type,
         case DATASET_TYPE_STRING:
             SCLogDebug("%d", load!=NULL?1:0);
             set->hash = THashInit(cnf_name, sizeof(StringType), StringSet,
-                    StringFree, StringHash, StringCompare, load != NULL ? 1 : 0);
+                    StringFree, StringHash, StringCompare, load != NULL ? 1 : 0,
+                    memcap, hashsize);
             if (set->hash == NULL)
                 goto out_err;
             if (DatasetLoadString(set) < 0)
@@ -508,7 +510,8 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type,
             break;
         case DATASET_TYPE_SHA256:
             set->hash = THashInit(cnf_name, sizeof(Sha256Type), Sha256StrSet,
-                    Sha256StrFree, Sha256StrHash, Sha256StrCompare, load != NULL ? 1 : 0);
+                    Sha256StrFree, Sha256StrHash, Sha256StrCompare, load != NULL ? 1 : 0,
+                    memcap, hashsize);
             if (set->hash == NULL)
                 goto out_err;
             if (DatasetLoadSha256(set) < 0)
@@ -611,6 +614,8 @@ int DatasetsInit(void)
 
             char save[PATH_MAX] = "";
             char load[PATH_MAX] = "";
+            uint64_t memcap = 0;
+            uint32_t hashsize = 0;
 
             const char *set_name = iter->name;
             if (strlen(set_name) > DATASET_NAME_MAX_LEN) {
@@ -638,13 +643,21 @@ int DatasetsInit(void)
                 }
             }
 
+            ConfNode *set_memcap = ConfNodeLookupChild(iter, "memcap");
+            if (StringParseUint64(&memcap, 10, 0, set_memcap->val) < 0) {
+                FatalError(SC_ERR_FATAL, "memcap value cannot be deduced: %s", set_memcap->val);
+            }
+            ConfNode *set_hashsize = ConfNodeLookupChild(iter, "hashsize");
+            if (StringParseUint32(&hashsize, 10, 0, set_hashsize->val) < 0) {
+                FatalError(SC_ERR_FATAL, "hashsize value cannot be deduced: %s", set_hashsize->val);
+            }
             char conf_str[1024];
             snprintf(conf_str, sizeof(conf_str), "datasets.%d.%s", list_pos, set_name);
 
             SCLogDebug("(%d) set %s type %s. Conf %s", n, set_name, set_type->val, conf_str);
 
             if (strcmp(set_type->val, "md5") == 0) {
-                Dataset *dset = DatasetGet(set_name, DATASET_TYPE_MD5, save, load);
+                Dataset *dset = DatasetGet(set_name, DATASET_TYPE_MD5, save, load, memcap, hashsize);
                 if (dset == NULL)
                     FatalError(SC_ERR_FATAL, "failed to setup dataset for %s", set_name);
                 SCLogDebug("dataset %s: id %d type %s", set_name, n, set_type->val);
@@ -652,7 +665,7 @@ int DatasetsInit(void)
                 n++;
 
             } else if (strcmp(set_type->val, "sha256") == 0) {
-                Dataset *dset = DatasetGet(set_name, DATASET_TYPE_SHA256, save, load);
+                Dataset *dset = DatasetGet(set_name, DATASET_TYPE_SHA256, save, load, memcap, hashsize);
                 if (dset == NULL)
                     FatalError(SC_ERR_FATAL, "failed to setup dataset for %s", set_name);
                 SCLogDebug("dataset %s: id %d type %s", set_name, n, set_type->val);
@@ -660,7 +673,7 @@ int DatasetsInit(void)
                 n++;
 
             } else if (strcmp(set_type->val, "string") == 0) {
-                Dataset *dset = DatasetGet(set_name, DATASET_TYPE_STRING, save, load);
+                Dataset *dset = DatasetGet(set_name, DATASET_TYPE_STRING, save, load, memcap, hashsize);
                 if (dset == NULL)
                     FatalError(SC_ERR_FATAL, "failed to setup dataset for %s", set_name);
                 SCLogDebug("dataset %s: id %d type %s", set_name, n, set_type->val);

--- a/src/datasets.h
+++ b/src/datasets.h
@@ -52,7 +52,7 @@ typedef struct Dataset {
 enum DatasetTypes DatasetGetTypeFromString(const char *s);
 Dataset *DatasetFind(const char *name, enum DatasetTypes type);
 Dataset *DatasetGet(const char *name, enum DatasetTypes type,
-        const char *save, const char *load);
+        const char *save, const char *load, uint64_t memcap, uint32_t hashsize);
 int DatasetAdd(Dataset *set, const uint8_t *data, const uint32_t data_len);
 int DatasetLookup(Dataset *set, const uint8_t *data, const uint32_t data_len);
 DataRepResultType DatasetLookupwRep(Dataset *set, const uint8_t *data, const uint32_t data_len,

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -294,7 +294,8 @@ THashTableContext* THashInit(const char *cnf_prefix, size_t data_size,
     int (*DataSet)(void *, void *),
      void (*DataFree)(void *),
      uint32_t (*DataHash)(void *),
-     bool (*DataCompare)(void *, void *))
+     bool (*DataCompare)(void *, void *),
+     bool reset_memcap)
 {
     THashTableContext *ctx = SCCalloc(1, sizeof(*ctx));
     BUG_ON(!ctx);
@@ -308,7 +309,7 @@ THashTableContext* THashInit(const char *cnf_prefix, size_t data_size,
     /* set defaults */
     ctx->config.hash_rand = (uint32_t)RandomGet();
     ctx->config.hash_size = THASH_DEFAULT_HASHSIZE;
-    ctx->config.memcap = THASH_DEFAULT_MEMCAP;
+    ctx->config.memcap = reset_memcap ? UINT64_MAX : THASH_DEFAULT_MEMCAP;
     ctx->config.prealloc = THASH_DEFAULT_PREALLOC;
 
     SC_ATOMIC_INIT(ctx->counter);
@@ -467,6 +468,7 @@ static THashData *THashDataGetNew(THashTableContext *ctx, void *data)
     h = THashDataDequeue(&ctx->spare_q);
     if (h == NULL) {
         /* If we reached the max memcap, we get used data */
+//        SCLogDebug("memcap: %ld", ctx->config.memcap);
         if (!(THASH_CHECK_MEMCAP(ctx, THASH_DATA_SIZE(ctx)))) {
             h = THashGetUsed(ctx);
             if (h == NULL) {

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -291,11 +291,13 @@ static void THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
 }
 
 THashTableContext* THashInit(const char *cnf_prefix, size_t data_size,
-    int (*DataSet)(void *, void *),
+     int (*DataSet)(void *, void *),
      void (*DataFree)(void *),
      uint32_t (*DataHash)(void *),
      bool (*DataCompare)(void *, void *),
-     bool reset_memcap)
+     bool reset_memcap,
+     uint64_t memcap,
+     uint32_t hashsize)
 {
     THashTableContext *ctx = SCCalloc(1, sizeof(*ctx));
     BUG_ON(!ctx);
@@ -308,8 +310,14 @@ THashTableContext* THashInit(const char *cnf_prefix, size_t data_size,
 
     /* set defaults */
     ctx->config.hash_rand = (uint32_t)RandomGet();
-    ctx->config.hash_size = THASH_DEFAULT_HASHSIZE;
-    ctx->config.memcap = reset_memcap ? UINT64_MAX : THASH_DEFAULT_MEMCAP;
+    ctx->config.hash_size = hashsize > 0 ? hashsize : THASH_DEFAULT_HASHSIZE;
+    /* Reset memcap in case of loading from file to the highest possible value
+     unless defined by the rule keyword */
+    if (memcap > 0) {
+        ctx->config.memcap = memcap;
+    } else {
+        ctx->config.memcap = reset_memcap ? UINT64_MAX : THASH_DEFAULT_MEMCAP;
+    }
     ctx->config.prealloc = THASH_DEFAULT_PREALLOC;
 
     SC_ATOMIC_INIT(ctx->counter);

--- a/src/util-thash.h
+++ b/src/util-thash.h
@@ -190,7 +190,9 @@ THashTableContext* THashInit(const char *cnf_prefix, size_t data_size,
     void (*DataFree)(void *),
     uint32_t (*DataHash)(void *),
     bool (*DataCompare)(void *, void *),
-    bool reset_memcap);
+    bool reset_memcap,
+    uint64_t memcap,
+    uint32_t hashsize);
 
 void THashShutdown(THashTableContext *ctx);
 

--- a/src/util-thash.h
+++ b/src/util-thash.h
@@ -189,7 +189,8 @@ THashTableContext* THashInit(const char *cnf_prefix, size_t data_size,
     int (*DataSet)(void *dst, void *src),
     void (*DataFree)(void *),
     uint32_t (*DataHash)(void *),
-    bool (*DataCompare)(void *, void *));
+    bool (*DataCompare)(void *, void *),
+    bool reset_memcap);
 
 void THashShutdown(THashTableContext *ctx);
 


### PR DESCRIPTION
Allow memcap and hashsize to be set via rules or via yaml. In case of `load`, set the memcap to highest possible value unless defined.