### PR TITLE
Datasets memcap/v3

### DIFF
--- a/doc/userguide/rules/datasets.rst
+++ b/doc/userguide/rules/datasets.rst
@@ -39,6 +39,30 @@ Rules to go with the above:
 
     alert http any any -> any any (msg: "http user-agent test"; http.user_agent; dataset:set,ua-seen; sid:234; rev:1;)
 
+It is also possible to optionally define global default memcap and hashsize.
+
+Example::
+
+    datasets:
+      defaults:
+        memcap: 100mb
+        hashsize: 2048
+      ua-seen:
+        type: string
+        load: ua-seen.lst
+
+or define memcap and hashsize per dataset.
+
+Example::
+
+    datasets:
+      ua-seen:
+        type: string
+        load: ua-seen.lst
+        memcap: 10mb
+        hashsize: 1024
+
+
 Rule keywords
 -------------
 
@@ -52,7 +76,7 @@ Syntax::
     dataset:<cmd>,<name>,<options>;
 
     dataset:<set|isset|isnotset>,<name> \
-        [, type <string|md5|sha256>, save <file name>, load <file name>, state <file name>];
+        [, type <string|md5|sha256>, save <file name>, load <file name>, state <file name>, memcap <size>, hashsize <size>];
 
 type <type>
   the data type: string, md5, sha256
@@ -63,6 +87,10 @@ state
 save <file name>
   advanced option to set the file name for saving the in-memory data
   when Suricata exits.
+memcap <size>
+  maximum memory limit for the respective dataset
+hashsize <size>
+  allowed size of the hash for the respective dataset
 
 .. note:: 'load' and 'state' or 'save' and 'state' cannot be mixed.
 
@@ -74,11 +102,11 @@ Data Reputation allows matching data against a reputation list.
 Syntax::
 
     datarep:<name>,<operator>,<value>, \
-        [, load <file name>, type <string|md5|sha256>];
+        [, load <file name>, type <string|md5|sha256>, memcap <size>, hashsize <size>];
 
 Example rules could look like::
 
-    alert dns any any -> any any (dns.query; to_md5; datarep:dns_md5, >, 200, load dns_md5.rep, type md5; sid:1;)
+    alert dns any any -> any any (dns.query; to_md5; datarep:dns_md5, >, 200, load dns_md5.rep, type md5, memcap 100mb, hashsize 2048; sid:1;)
     alert dns any any -> any any (dns.query; to_sha256; datarep:dns_sha256, >, 200, load dns_sha256.rep, type sha256; sid:2;)
     alert dns any any -> any any (dns.query; datarep:dns_string, >, 200, load dns_string.rep, type string; sid:3;)
 

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -421,8 +421,8 @@ Dataset *DatasetFind(const char *name, enum DatasetTypes type)
     return set;
 }
 
-Dataset *DatasetGet(const char *name, enum DatasetTypes type,
-        const char *save, const char *load, uint64_t memcap, uint32_t hashsize)
+Dataset *DatasetGet(const char *name, enum DatasetTypes type, const char *save, const char *load,
+        uint64_t memcap, uint32_t hashsize)
 {
     uint64_t default_memcap = 0;
     uint32_t default_hashsize = 0;
@@ -497,9 +497,8 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type,
     GetDefaultMemcap(&default_memcap, &default_hashsize);
     switch (type) {
         case DATASET_TYPE_MD5:
-            set->hash = THashInit(cnf_name, sizeof(Md5Type), Md5StrSet,
-                    Md5StrFree, Md5StrHash, Md5StrCompare, load != NULL ? 1 : 0,
-                    memcap > 0 ? memcap : default_memcap,
+            set->hash = THashInit(cnf_name, sizeof(Md5Type), Md5StrSet, Md5StrFree, Md5StrHash,
+                    Md5StrCompare, load != NULL ? 1 : 0, memcap > 0 ? memcap : default_memcap,
                     hashsize > 0 ? hashsize : default_hashsize);
             if (set->hash == NULL)
                 goto out_err;
@@ -507,9 +506,8 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type,
                 goto out_err;
             break;
         case DATASET_TYPE_STRING:
-            set->hash = THashInit(cnf_name, sizeof(StringType), StringSet,
-                    StringFree, StringHash, StringCompare, load != NULL ? 1 : 0,
-                    memcap > 0 ? memcap : default_memcap,
+            set->hash = THashInit(cnf_name, sizeof(StringType), StringSet, StringFree, StringHash,
+                    StringCompare, load != NULL ? 1 : 0, memcap > 0 ? memcap : default_memcap,
                     hashsize > 0 ? hashsize : default_hashsize);
             if (set->hash == NULL)
                 goto out_err;
@@ -517,8 +515,8 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type,
                 goto out_err;
             break;
         case DATASET_TYPE_SHA256:
-            set->hash = THashInit(cnf_name, sizeof(Sha256Type), Sha256StrSet,
-                    Sha256StrFree, Sha256StrHash, Sha256StrCompare, load != NULL ? 1 : 0,
+            set->hash = THashInit(cnf_name, sizeof(Sha256Type), Sha256StrSet, Sha256StrFree,
+                    Sha256StrHash, Sha256StrCompare, load != NULL ? 1 : 0,
                     memcap > 0 ? memcap : default_memcap,
                     hashsize > 0 ? hashsize : default_hashsize);
             if (set->hash == NULL)
@@ -679,7 +677,8 @@ int DatasetsInit(void)
             ConfNode *set_hashsize = ConfNodeLookupChild(iter, "hashsize");
             if (set_hashsize) {
                 if (ParseSizeStringU32(set_hashsize->val, &hashsize) < 0) {
-                    FatalError(SC_ERR_FATAL, "hashsize value cannot be deduced: %s", set_hashsize->val);
+                    FatalError(SC_ERR_FATAL, "hashsize value cannot be deduced: %s",
+                            set_hashsize->val);
                 }
             }
             char conf_str[1024];
@@ -688,8 +687,8 @@ int DatasetsInit(void)
             SCLogDebug("(%d) set %s type %s. Conf %s", n, set_name, set_type->val, conf_str);
 
             if (strcmp(set_type->val, "md5") == 0) {
-                Dataset *dset = DatasetGet(set_name, DATASET_TYPE_MD5,
-                        save, load, memcap > 0 ? memcap : default_memcap,
+                Dataset *dset = DatasetGet(set_name, DATASET_TYPE_MD5, save, load,
+                        memcap > 0 ? memcap : default_memcap,
                         hashsize > 0 ? hashsize : default_hashsize);
                 if (dset == NULL)
                     FatalError(SC_ERR_FATAL, "failed to setup dataset for %s", set_name);
@@ -698,8 +697,8 @@ int DatasetsInit(void)
                 n++;
 
             } else if (strcmp(set_type->val, "sha256") == 0) {
-                Dataset *dset = DatasetGet(set_name, DATASET_TYPE_SHA256,
-                        save, load, memcap > 0 ? memcap : default_memcap,
+                Dataset *dset = DatasetGet(set_name, DATASET_TYPE_SHA256, save, load,
+                        memcap > 0 ? memcap : default_memcap,
                         hashsize > 0 ? hashsize : default_hashsize);
                 if (dset == NULL)
                     FatalError(SC_ERR_FATAL, "failed to setup dataset for %s", set_name);
@@ -708,8 +707,8 @@ int DatasetsInit(void)
                 n++;
 
             } else if (strcmp(set_type->val, "string") == 0) {
-                Dataset *dset = DatasetGet(set_name, DATASET_TYPE_STRING,
-                        save, load, memcap > 0 ? memcap : default_memcap,
+                Dataset *dset = DatasetGet(set_name, DATASET_TYPE_STRING, save, load,
+                        memcap > 0 ? memcap : default_memcap,
                         hashsize > 0 ? hashsize : default_hashsize);
                 if (dset == NULL)
                     FatalError(SC_ERR_FATAL, "failed to setup dataset for %s", set_name);

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -490,7 +490,7 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type,
     switch (type) {
         case DATASET_TYPE_MD5:
             set->hash = THashInit(cnf_name, sizeof(Md5Type), Md5StrSet,
-                    Md5StrFree, Md5StrHash, Md5StrCompare);
+                    Md5StrFree, Md5StrHash, Md5StrCompare, load != NULL ? 1 : 0);
             if (set->hash == NULL)
                 goto out_err;
             if (DatasetLoadMd5(set) < 0)
@@ -498,7 +498,7 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type,
             break;
         case DATASET_TYPE_STRING:
             set->hash = THashInit(cnf_name, sizeof(StringType), StringSet,
-                    StringFree, StringHash, StringCompare);
+                    StringFree, StringHash, StringCompare, load != NULL ? 1 : 0);
             if (set->hash == NULL)
                 goto out_err;
             if (DatasetLoadString(set) < 0)
@@ -506,7 +506,7 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type,
             break;
         case DATASET_TYPE_SHA256:
             set->hash = THashInit(cnf_name, sizeof(Sha256Type), Sha256StrSet,
-                    Sha256StrFree, Sha256StrHash, Sha256StrCompare);
+                    Sha256StrFree, Sha256StrHash, Sha256StrCompare, load != NULL ? 1 : 0);
             if (set->hash == NULL)
                 goto out_err;
             if (DatasetLoadSha256(set) < 0)

--- a/src/datasets.h
+++ b/src/datasets.h
@@ -51,8 +51,8 @@ typedef struct Dataset {
 
 enum DatasetTypes DatasetGetTypeFromString(const char *s);
 Dataset *DatasetFind(const char *name, enum DatasetTypes type);
-Dataset *DatasetGet(const char *name, enum DatasetTypes type,
-        const char *save, const char *load, uint64_t memcap, uint32_t hashsize);
+Dataset *DatasetGet(const char *name, enum DatasetTypes type, const char *save, const char *load,
+        uint64_t memcap, uint32_t hashsize);
 int DatasetAdd(Dataset *set, const uint8_t *data, const uint32_t data_len);
 int DatasetLookup(Dataset *set, const uint8_t *data, const uint32_t data_len);
 DataRepResultType DatasetLookupwRep(Dataset *set, const uint8_t *data, const uint32_t data_len,

--- a/src/datasets.h
+++ b/src/datasets.h
@@ -52,7 +52,7 @@ typedef struct Dataset {
 enum DatasetTypes DatasetGetTypeFromString(const char *s);
 Dataset *DatasetFind(const char *name, enum DatasetTypes type);
 Dataset *DatasetGet(const char *name, enum DatasetTypes type,
-        const char *save, const char *load);
+        const char *save, const char *load, uint64_t memcap, uint32_t hashsize);
 int DatasetAdd(Dataset *set, const uint8_t *data, const uint32_t data_len);
 int DatasetLookup(Dataset *set, const uint8_t *data, const uint32_t data_len);
 DataRepResultType DatasetLookupwRep(Dataset *set, const uint8_t *data, const uint32_t data_len,

--- a/src/detect-datarep.c
+++ b/src/detect-datarep.c
@@ -92,12 +92,8 @@ int DetectDatarepBufferMatch(DetectEngineThreadCtx *det_ctx,
     return 0;
 }
 
-static int DetectDatarepParse(const char *str,
-        char *cmd, int cmd_len,
-        char *name, int name_len,
-        enum DatasetTypes *type,
-        char *load, size_t load_size,
-        uint16_t *rep_value,
+static int DetectDatarepParse(const char *str, char *cmd, int cmd_len, char *name, int name_len,
+        enum DatasetTypes *type, char *load, size_t load_size, uint16_t *rep_value,
         uint64_t *memcap, uint32_t *hashsize)
 {
     bool cmd_set = false;
@@ -309,8 +305,8 @@ static int DetectDatarepSetup (DetectEngineCtx *de_ctx, Signature *s, const char
         SCReturnInt(-1);
     }
 
-    if (!DetectDatarepParse(rawstr, cmd_str, sizeof(cmd_str), name,
-            sizeof(name), &type, load, sizeof(load), &value, &memcap, &hashsize)) {
+    if (!DetectDatarepParse(rawstr, cmd_str, sizeof(cmd_str), name, sizeof(name), &type, load,
+                sizeof(load), &value, &memcap, &hashsize)) {
         return -1;
     }
 

--- a/src/detect-datarep.c
+++ b/src/detect-datarep.c
@@ -38,6 +38,7 @@
 #include "util-byte.h"
 #include "util-debug.h"
 #include "util-print.h"
+#include "util-misc.h"
 
 #define PARSE_REGEX         "([a-z]+)(?:,\\s*([\\-_A-z0-9\\s\\.]+)){1,4}"
 static DetectParseRegex parse_regex;
@@ -96,7 +97,8 @@ static int DetectDatarepParse(const char *str,
         char *name, int name_len,
         enum DatasetTypes *type,
         char *load, size_t load_size,
-        uint16_t *rep_value)
+        uint16_t *rep_value,
+        uint64_t *memcap, uint32_t *hashsize)
 {
     bool cmd_set = false;
     bool name_set = false;
@@ -168,6 +170,18 @@ static int DetectDatarepParse(const char *str,
             } else if (strcmp(key, "load") == 0) {
                 SCLogDebug("load %s", val);
                 strlcpy(load, val, load_size);
+            }
+            if (strcmp(key, "memcap") == 0) {
+                if (ParseSizeStringU64(val, memcap) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid value for memcap: %s", val);
+                    return -1;
+                }
+            }
+            if (strcmp(key, "hashsize") == 0) {
+                if (ParseSizeStringU32(val, hashsize) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid value for hashsize: %s", val);
+                    return -1;
+                }
             }
         }
 
@@ -279,6 +293,8 @@ static int DetectDatarepSetup (DetectEngineCtx *de_ctx, Signature *s, const char
     enum DatasetTypes type = DATASET_TYPE_NOTSET;
     char load[PATH_MAX];
     uint16_t value = 0;
+    uint64_t memcap = 0;
+    uint32_t hashsize = 0;
 
     if (DetectBufferGetActiveList(de_ctx, s) == -1) {
         SCLogError(SC_ERR_INVALID_SIGNATURE,
@@ -294,7 +310,7 @@ static int DetectDatarepSetup (DetectEngineCtx *de_ctx, Signature *s, const char
     }
 
     if (!DetectDatarepParse(rawstr, cmd_str, sizeof(cmd_str), name,
-            sizeof(name), &type, load, sizeof(load), &value)) {
+            sizeof(name), &type, load, sizeof(load), &value, &memcap, &hashsize)) {
         return -1;
     }
 
@@ -316,7 +332,7 @@ static int DetectDatarepSetup (DetectEngineCtx *de_ctx, Signature *s, const char
         return -1;
     }
 
-    Dataset *set = DatasetGet(name, type, /* no save */ NULL, load);
+    Dataset *set = DatasetGet(name, type, /* no save */ NULL, load, memcap, hashsize);
     if (set == NULL) {
         SCLogError(SC_ERR_UNKNOWN_VALUE,
                 "failed to set up datarep set '%s'.", name);

--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -100,12 +100,8 @@ int DetectDatasetBufferMatch(DetectEngineThreadCtx *det_ctx,
     return 0;
 }
 
-static int DetectDatasetParse(const char *str,
-        char *cmd, int cmd_len,
-        char *name, int name_len,
-        enum DatasetTypes *type,
-        char *load, size_t load_size,
-        char *save, size_t save_size,
+static int DetectDatasetParse(const char *str, char *cmd, int cmd_len, char *name, int name_len,
+        enum DatasetTypes *type, char *load, size_t load_size, char *save, size_t save_size,
         uint64_t *memcap, uint32_t *hashsize)
 {
     bool cmd_set = false;
@@ -348,9 +344,8 @@ int DetectDatasetSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawst
         SCReturnInt(-1);
     }
 
-    if (!DetectDatasetParse(rawstr, cmd_str, sizeof(cmd_str), name,
-            sizeof(name), &type, load, sizeof(load), save, sizeof(save),
-            &memcap, &hashsize)) {
+    if (!DetectDatasetParse(rawstr, cmd_str, sizeof(cmd_str), name, sizeof(name), &type, load,
+                sizeof(load), save, sizeof(save), &memcap, &hashsize)) {
         return -1;
     }
 

--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -37,6 +37,7 @@
 
 #include "util-debug.h"
 #include "util-print.h"
+#include "util-misc.h"
 
 #define PARSE_REGEX         "([a-z]+)(?:,\\s*([\\-_A-z0-9\\s\\.]+)){1,4}"
 static DetectParseRegex parse_regex;
@@ -104,7 +105,8 @@ static int DetectDatasetParse(const char *str,
         char *name, int name_len,
         enum DatasetTypes *type,
         char *load, size_t load_size,
-        char *save, size_t save_size)
+        char *save, size_t save_size,
+        uint64_t *memcap, uint32_t *hashsize)
 {
     bool cmd_set = false;
     bool name_set = false;
@@ -194,6 +196,18 @@ static int DetectDatasetParse(const char *str,
                 strlcpy(load, val, load_size);
                 strlcpy(save, val, save_size);
                 state_set = true;
+            }
+            if (strcmp(key, "memcap") == 0) {
+                if (ParseSizeStringU64(val, memcap) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid value for memcap: %s", val);
+                    return -1;
+                }
+            }
+            if (strcmp(key, "hashsize") == 0) {
+                if (ParseSizeStringU32(val, hashsize) < 0) {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid value for hashsize: %s", val);
+                    return -1;
+                }
             }
         }
 
@@ -314,6 +328,8 @@ int DetectDatasetSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawst
     DetectDatasetData *cd = NULL;
     SigMatch *sm = NULL;
     uint8_t cmd = 0;
+    uint64_t memcap = 0;
+    uint32_t hashsize = 0;
     char cmd_str[16] = "", name[DATASET_NAME_MAX_LEN + 1] = "";
     enum DatasetTypes type = DATASET_TYPE_NOTSET;
     char load[PATH_MAX] = "";
@@ -333,7 +349,8 @@ int DetectDatasetSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawst
     }
 
     if (!DetectDatasetParse(rawstr, cmd_str, sizeof(cmd_str), name,
-            sizeof(name), &type, load, sizeof(load), save, sizeof(save))) {
+            sizeof(name), &type, load, sizeof(load), save, sizeof(save),
+            &memcap, &hashsize)) {
         return -1;
     }
 
@@ -371,7 +388,7 @@ int DetectDatasetSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawst
     }
 
     SCLogDebug("name '%s' load '%s' save '%s'", name, load, save);
-    Dataset *set = DatasetGet(name, type, save, load);
+    Dataset *set = DatasetGet(name, type, save, load, memcap, hashsize);
     if (set == NULL) {
         SCLogError(SC_ERR_INVALID_SIGNATURE,
                 "failed to set up dataset '%s'.", name);

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -294,7 +294,8 @@ THashTableContext* THashInit(const char *cnf_prefix, size_t data_size,
     int (*DataSet)(void *, void *),
      void (*DataFree)(void *),
      uint32_t (*DataHash)(void *),
-     bool (*DataCompare)(void *, void *))
+     bool (*DataCompare)(void *, void *),
+     bool reset_memcap)
 {
     THashTableContext *ctx = SCCalloc(1, sizeof(*ctx));
     BUG_ON(!ctx);
@@ -308,7 +309,7 @@ THashTableContext* THashInit(const char *cnf_prefix, size_t data_size,
     /* set defaults */
     ctx->config.hash_rand = (uint32_t)RandomGet();
     ctx->config.hash_size = THASH_DEFAULT_HASHSIZE;
-    ctx->config.memcap = THASH_DEFAULT_MEMCAP;
+    ctx->config.memcap = reset_memcap ? UINT64_MAX : THASH_DEFAULT_MEMCAP;
     ctx->config.prealloc = THASH_DEFAULT_PREALLOC;
 
     SC_ATOMIC_INIT(ctx->counter);

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -291,11 +291,13 @@ static void THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
 }
 
 THashTableContext* THashInit(const char *cnf_prefix, size_t data_size,
-    int (*DataSet)(void *, void *),
+     int (*DataSet)(void *, void *),
      void (*DataFree)(void *),
      uint32_t (*DataHash)(void *),
      bool (*DataCompare)(void *, void *),
-     bool reset_memcap)
+     bool reset_memcap,
+     uint64_t memcap,
+     uint32_t hashsize)
 {
     THashTableContext *ctx = SCCalloc(1, sizeof(*ctx));
     BUG_ON(!ctx);
@@ -308,8 +310,14 @@ THashTableContext* THashInit(const char *cnf_prefix, size_t data_size,
 
     /* set defaults */
     ctx->config.hash_rand = (uint32_t)RandomGet();
-    ctx->config.hash_size = THASH_DEFAULT_HASHSIZE;
-    ctx->config.memcap = reset_memcap ? UINT64_MAX : THASH_DEFAULT_MEMCAP;
+    ctx->config.hash_size = hashsize > 0 ? hashsize : THASH_DEFAULT_HASHSIZE;
+    /* Reset memcap in case of loading from file to the highest possible value
+     unless defined by the rule keyword */
+    if (memcap > 0) {
+        ctx->config.memcap = memcap;
+    } else {
+        ctx->config.memcap = reset_memcap ? UINT64_MAX : THASH_DEFAULT_MEMCAP;
+    }
     ctx->config.prealloc = THASH_DEFAULT_PREALLOC;
 
     SC_ATOMIC_INIT(ctx->counter);
@@ -319,6 +327,14 @@ THashTableContext* THashInit(const char *cnf_prefix, size_t data_size,
 
     THashInitConfig(ctx, cnf_prefix);
     return ctx;
+}
+
+/* \brief Set memcap to current memuse
+ * */
+void THashConsolidateMemcap(THashTableContext *ctx)
+{
+    ctx->config.memcap = MAX(SC_ATOMIC_GET(ctx->memuse), THASH_DEFAULT_MEMCAP);
+    SCLogDebug("memcap after load set to: %lu", ctx->config.memcap);
 }
 
 /** \brief shutdown the flow engine

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -290,14 +290,9 @@ static void THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
     return;
 }
 
-THashTableContext* THashInit(const char *cnf_prefix, size_t data_size,
-     int (*DataSet)(void *, void *),
-     void (*DataFree)(void *),
-     uint32_t (*DataHash)(void *),
-     bool (*DataCompare)(void *, void *),
-     bool reset_memcap,
-     uint64_t memcap,
-     uint32_t hashsize)
+THashTableContext *THashInit(const char *cnf_prefix, size_t data_size,
+        int (*DataSet)(void *, void *), void (*DataFree)(void *), uint32_t (*DataHash)(void *),
+        bool (*DataCompare)(void *, void *), bool reset_memcap, uint64_t memcap, uint32_t hashsize)
 {
     THashTableContext *ctx = SCCalloc(1, sizeof(*ctx));
     BUG_ON(!ctx);

--- a/src/util-thash.h
+++ b/src/util-thash.h
@@ -190,7 +190,9 @@ THashTableContext* THashInit(const char *cnf_prefix, size_t data_size,
     void (*DataFree)(void *),
     uint32_t (*DataHash)(void *),
     bool (*DataCompare)(void *, void *),
-    bool reset_memcap);
+    bool reset_memcap,
+    uint64_t memcap,
+    uint32_t hashsize);
 
 void THashShutdown(THashTableContext *ctx);
 
@@ -215,5 +217,6 @@ THashDataQueue *THashDataQueueNew(void);
 void THashCleanup(THashTableContext *ctx);
 int THashWalk(THashTableContext *, THashFormatFunc, THashOutputFunc, void *);
 int THashRemoveFromHash (THashTableContext *ctx, void *data);
+void THashConsolidateMemcap(THashTableContext *ctx);
 
 #endif /* __THASH_H__ */

--- a/src/util-thash.h
+++ b/src/util-thash.h
@@ -189,7 +189,8 @@ THashTableContext* THashInit(const char *cnf_prefix, size_t data_size,
     int (*DataSet)(void *dst, void *src),
     void (*DataFree)(void *),
     uint32_t (*DataHash)(void *),
-    bool (*DataCompare)(void *, void *));
+    bool (*DataCompare)(void *, void *),
+    bool reset_memcap);
 
 void THashShutdown(THashTableContext *ctx);
 

--- a/src/util-thash.h
+++ b/src/util-thash.h
@@ -185,14 +185,10 @@ typedef struct THashTableContext_ {
         }                                             \
     } while (0)
 
-THashTableContext* THashInit(const char *cnf_prefix, size_t data_size,
-    int (*DataSet)(void *dst, void *src),
-    void (*DataFree)(void *),
-    uint32_t (*DataHash)(void *),
-    bool (*DataCompare)(void *, void *),
-    bool reset_memcap,
-    uint64_t memcap,
-    uint32_t hashsize);
+THashTableContext *THashInit(const char *cnf_prefix, size_t data_size,
+        int (*DataSet)(void *dst, void *src), void (*DataFree)(void *),
+        uint32_t (*DataHash)(void *), bool (*DataCompare)(void *, void *), bool reset_memcap,
+        uint64_t memcap, uint32_t hashsize);
 
 void THashShutdown(THashTableContext *ctx);
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -969,6 +969,13 @@ app-layer:
 # Limit for the maximum number of asn1 frames to decode (default 256)
 asn1-max-frames: 256
 
+# Datasets default settings
+# datasets:
+#   # Default fallback memcap and hashsize values for datasets in case these
+#   # were not explicitly defined.
+#   defaults:
+#     memcap: 100mb
+#     hashsize: 2048
 
 ##############################################################################
 ##


### PR DESCRIPTION
It is now possible to set `memcap` and `hashsize` via `suricata.yaml` and rules.

Rule example:
```
alert http any any -> any any (http.user_agent; dataset:isset,ua-seen,type string,load datasets.csv,memcap 100mb,hashsize 2048; sid:1;)
```

`suricata.yaml` example:
```
datasets:
  defaults:
    memcap: 100mb
    hashsize: 2048
  ua-seen:
    type: string
    load: datasets.csv
    memcap: 20mb
    hashsize: 2048
```