### PR TITLE
log: Ensure threaded eve honors

### DIFF
--- a/src/util-atomic.h
+++ b/src/util-atomic.h
@@ -79,6 +79,12 @@
     _Atomic(type) (name ## _sc_atomic__) = 0
 
 /**
+ *  \brief wrapper for declaring an atomic variable and initializing it
+ *  to a specific value
+ **/
+#define SC_ATOMIC_DECL_AND_INIT_WITH_VAL(type, name, val) _Atomic(type)(name##_sc_atomic__) = val
+
+/**
  *  \brief wrapper for initializing an atomic variable.
  **/
 #define SC_ATOMIC_INIT(name) \
@@ -290,6 +296,12 @@
  */
 #define SC_ATOMIC_EXTERN(type, name) \
     extern type name ## _sc_atomic__
+
+/**
+ *  \brief wrapper for declaring an atomic variable and initializing it
+ *  to a specific value
+ **/
+#define SC_ATOMIC_DECL_AND_INIT_WITH_VAL(type, name, val) type name##_sc_atomic__ = val
 
 /**
  *  \brief wrapper for declaring an atomic variable and initializing it.


### PR DESCRIPTION
Continuation of #5400

This commit ensures that all logging contexts register for the file
rotation mechanism (SIGHUP and configured) and that the suffixes use for threaded EVE output are continuous.

Describe changes:
-  Add atomic macros when missing stdatomic

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/3915

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
