### PR TITLE
Fuzz msan v2

### DIFF
--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -7,8 +7,12 @@ if HAVE_CARGO_VENDOR
 EXTRA_DIST +=	vendor
 endif
 
+if BUILD_FUZZTARGETS
+RELEASE = -Z build-std
+else
 if !DEBUG
 RELEASE = --release
+endif
 endif
 
 if HAVE_LUA

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2463,7 +2463,7 @@ void DetectParseRegexAddToFreeList(DetectParseRegex *detect_parse)
 
 bool DetectSetupParseRegexesOpts(const char *parse_str, DetectParseRegex *detect_parse, int opts)
 {
-    const char *eb;
+    const char *eb = NULL;
     int eo;
 
     detect_parse->regex = pcre_compile(parse_str, opts, &eb, &eo, NULL);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Enables MSAN by recompiling rust std library with fuzz targets
- Fixes a use of uninitialized value

Cf google/oss-fuzz#3469 (comment)

Follows https://github.com/OISF/suricata/pull/5395 with rebasing