### PR TITLE
Fuzz msan v3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -475,6 +475,7 @@
     AC_ARG_ENABLE(fuzztargets,
         AS_HELP_STRING([--enable-fuzztargets], [Enable fuzz targets]),[enable_fuzztargets=$enableval],[enable_fuzztargets=no])
     AM_CONDITIONAL([BUILD_FUZZTARGETS], [test "x$enable_fuzztargets" = "xyes"])
+    AM_CONDITIONAL([RUST_BUILD_STD], [test "x$enable_fuzztargets" = "xyes" && echo $rust_compiler_version | grep -q nightly])
     AC_PROG_CXX
     AS_IF([test "x$enable_fuzztargets" = "xyes"], [
         AC_DEFINE([FUZZ], [1], [Fuzz targets are enabled])

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -7,8 +7,12 @@ if HAVE_CARGO_VENDOR
 EXTRA_DIST +=	vendor
 endif
 
+if RUST_BUILD_STD
+RELEASE = -Z build-std
+else
 if !DEBUG
 RELEASE = --release
+endif
 endif
 
 if HAVE_LUA

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2463,7 +2463,7 @@ void DetectParseRegexAddToFreeList(DetectParseRegex *detect_parse)
 
 bool DetectSetupParseRegexesOpts(const char *parse_str, DetectParseRegex *detect_parse, int opts)
 {
-    const char *eb;
+    const char *eb = NULL;
     int eo;
 
     detect_parse->regex = pcre_compile(parse_str, opts, &eb, &eo, NULL);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Enables MSAN by recompiling rust std library with fuzz targets
- Fixes a use of uninitialized value

Cf google/oss-fuzz#3469 (comment)

Follows https://github.com/OISF/suricata/pull/5409 with checking rust compiler is nightly