### PR TITLE
dceprc: signature rust check with is_char_boundary

### DIFF
--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -60,7 +60,7 @@ pub struct DCEOpnumData {
 }
 
 fn extract_op_version(opver: &str) -> Result<(u8, u16), ()> {
-    if opver.len() < 1 {
+    if !opver.is_char_boundary(1){
         return Err(());
     }
     let (op, version) = opver.split_at(1);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3921

Describe changes:
- signature rust check with `is_char_boundary` before calling `splita_at` which may panic

