### PR TITLE
detect/file_data: Apply transforms

### DIFF
--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -262,7 +262,7 @@ static InspectionBuffer *HttpServerBodyGetDataCallback(DetectEngineThreadCtx *de
 
     HtpBodyChunk *cur = body->first;
     if (cur == NULL) {
-        SCLogDebug("No http chunks to inspect for this transacation");
+        SCLogDebug("No http chunks to inspect for this transaction");
         return NULL;
     }
 

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2018 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -333,6 +333,8 @@ static InspectionBuffer *HttpServerBodyGetDataCallback(DetectEngineThreadCtx *de
                                        htp_state->cfg->swf_compress_depth);
         }
     }
+
+    InspectionBufferApplyTransforms(buffer, transforms);
 
     /* move inspected tracker to end of the data. HtpBodyPrune will consider
      * the window sizes when freeing data */


### PR DESCRIPTION
Continuation of #4946 

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3691](https://redmine.openinfosecfoundation.org/issues/3691)

Describe changes:
- Adds validator for compress-whitespace transform. Buffers with two or more consecutive spaces are not valid.


suricata-verify-pr: 330
