### PR TITLE
log/eve: Rename fileinfo alert object to files

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -556,7 +556,7 @@ static void AlertAddFiles(const Packet *p, JsonBuilder *jb, const uint64_t tx_id
             if (tx_id == file->txid) {
                 if (!isopen) {
                     isopen = true;
-                    jb_open_array(jb, "fileinfo");
+                    jb_open_array(jb, "files");
                 }
                 jb_start_object(jb);
                 EveFileInfo(jb, file, file->flags & FILE_STORED);


### PR DESCRIPTION
This commit changes the name of the "fileinfo" array in the alert object
to "files" to better support legacy use of "fileinfo" in reporting and
elsewhere.

The "fileinfo" event type is not an array while the alert "fileinfo"
member was.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3927](https://redmine.openinfosecfoundation.org/issues/3927)

Describe changes:
- Rename "fileinfo" object in alerts to "files"


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
