### PR TITLE
doc/userguide: include man page even when not including pdf - v1

### DIFF
--- a/doc/userguide/Makefile.am
+++ b/doc/userguide/Makefile.am
@@ -31,14 +31,14 @@ EXTRA_DIST = \
 	what-is-suricata.rst
 
 if HAVE_SURICATA_MAN
-man1_MANS = suricata.1
+dist_man1_MANS = suricata.1
 endif
 
 if HAVE_SPHINXBUILD
-man1_MANS = suricata.1
+dist_man1_MANS = suricata.1
 
 if HAVE_PDFLATEX
-EXTRA_DIST += $(man1_MANS) userguide.pdf
+EXTRA_DIST += userguide.pdf
 endif
 
 SPHINX_BUILD = sphinx-build -q


### PR DESCRIPTION
Fix a mistake in Makefile.am where the man page was only being added to the
distribution if the PDF was also created. It should be included even if the PDF
cannot be included.
