### PR TITLE
fuzz: better configure check for rust nightly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -475,7 +475,8 @@
     AC_ARG_ENABLE(fuzztargets,
         AS_HELP_STRING([--enable-fuzztargets], [Enable fuzz targets]),[enable_fuzztargets=$enableval],[enable_fuzztargets=no])
     AM_CONDITIONAL([BUILD_FUZZTARGETS], [test "x$enable_fuzztargets" = "xyes"])
-    AM_CONDITIONAL([RUST_BUILD_STD], [test "x$enable_fuzztargets" = "xyes" && echo $rust_compiler_version | grep -q nightly])
+    RUST_IS_NIGHTY=`echo $rust_compiler_version | grep nightly | wc -l`
+    AM_CONDITIONAL([RUST_BUILD_STD], [test "x$enable_fuzztargets" = "xyes" && test "$RUST_IS_NIGHTY" -ge 0])
     AC_PROG_CXX
     AS_IF([test "x$enable_fuzztargets" = "xyes"], [
         AC_DEFINE([FUZZ], [1], [Fuzz targets are enabled])


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Improves configure check for Rust nightly version, in order to build with MSAN if needed

It seems #5411 configure/bash magic was not good enough for oss-fuzz Docker, even if it worked locally on my Mac