### PR TITLE
log/anomaly: Move metadata out of anomaly section

### DIFF
--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -128,11 +128,11 @@ static int AnomalyDecodeEventJson(ThreadVars *tv, JsonAnomalyLogThread *aft,
             return TM_ECODE_OK;
         }
 
-        jb_open_object(js, ANOMALY_EVENT_TYPE);
-
         if (is_ip_pkt) {
             EveAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js);
         }
+
+        jb_open_object(js, ANOMALY_EVENT_TYPE);
 
         if (event_code < DECODE_EVENT_MAX) {
             const char *event = DEvents[event_code].event_name;


### PR DESCRIPTION
This commit moves the metadata from the anomaly object where it was
incorrectly located.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3928](https://redmine.openinfosecfoundation.org/issues/3928)

Describe changes:
- Move the `metadata` section out of the `anomaly` section

suricata-verify-pr: 333
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
