### PR TITLE
detect/rules: Increase array size to remove SEGV 

### DIFF
--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1807,7 +1807,7 @@ int SigAddressPrepareStage4(DetectEngineCtx *de_ctx)
         int add_rules = 0;
         (void)ConfGetBool("detect.profiling.grouping.include-rules", &add_rules);
         int add_mpm_stats = 0;
-        (void)ConfGetBool("detect.profiling.grouping.include-mpm-stats", &add_rules);
+        (void)ConfGetBool("detect.profiling.grouping.include-mpm-stats", &add_mpm_stats);
 
         RulesDumpGrouping(de_ctx, add_rules, add_mpm_stats);
     }

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -807,7 +807,8 @@ static json_t *RulesGroupPrintSghStats(const SigGroupHead *sgh,
             for (int y = 0; y < max_buffer_type_id; y++) {
                 if (alproto_mpm_bufs[i][y] == 0)
                     continue;
-                json_object_set_new(app, DetectListToHumanString(y), json_integer(alproto_mpm_bufs[i][y]));
+                json_object_set_new(
+                        app, DetectListToHumanString(y), json_integer(alproto_mpm_bufs[i][y]));
             }
 
             json_object_set_new(stats, AppProtoToString(i), app);


### PR DESCRIPTION
Continuation of #5429 

This commit changes the size of reporting variables to be dynamic based
on the buffer ids in use instead of a fixed value to address a SEGV when
the fixed value was less than the max buffer/type id in use.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3904](https://redmine.openinfosecfoundation.org/issues/3904)

Describe changes:
- Corrects copy/paste error with `include-mpm-stats` conf variable.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
