### PR TITLE
dns: log rdata for NULL record type

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -271,6 +271,7 @@ pub enum DNSRData {
     MX(Vec<u8>),
     // RData is text
     TXT(Vec<u8>),
+    NULL(Vec<u8>),
     // RData has several fields
     SOA(DNSRDataSOA),
     SSHFP(DNSRDataSSHFP),

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -444,6 +444,7 @@ fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Result<JsonBuilder, Js
         DNSRData::CNAME(bytes) |
         DNSRData::MX(bytes) |
         DNSRData::TXT(bytes) |
+        DNSRData::NULL(bytes) |
         DNSRData::PTR(bytes) => {
             jsa.set_string_from_bytes("rdata", &bytes)?;
         }
@@ -515,6 +516,7 @@ fn dns_log_json_answer(js: &mut JsonBuilder, response: &DNSResponse, flags: u64)
                     DNSRData::CNAME(bytes) |
                     DNSRData::MX(bytes) |
                     DNSRData::TXT(bytes) |
+                    DNSRData::NULL(bytes) |
                     DNSRData::PTR(bytes) => {
                         if !answer_types.contains_key(&type_string) {
                             answer_types.insert(type_string.to_string(),
@@ -687,6 +689,7 @@ fn dns_log_json_answer_v1(header: &DNSHeader, answer: &DNSAnswerEntry)
         DNSRData::CNAME(bytes) |
         DNSRData::MX(bytes) |
         DNSRData::TXT(bytes) |
+        DNSRData::NULL(bytes) |
         DNSRData::PTR(bytes) => {
             js.set_string_from_bytes("rdata", &bytes)?;
         }

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -177,6 +177,7 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
                 DNSRData::CNAME(ref bytes) |
                 DNSRData::MX(ref bytes) |
                 DNSRData::TXT(ref bytes) |
+                DNSRData::NULL(ref bytes) |
                 DNSRData::PTR(ref bytes) |
                 DNSRData::Unknown(ref bytes) => {
                     if bytes.len() > 0 {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
- [3663](https://redmine.openinfosecfoundation.org/issues/3663)

Describe changes:
- Logs the rdata for a NULL record type as a printable string.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- I don't have the docker build set up locally anymore.

Suricata-verify PR:
- [#337](https://github.com/OISF/suricata-verify/pull/337)
