### PR TITLE
log/eve: Threaded filename change: eve.N.json

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -27,8 +27,8 @@ Output types::
 
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
-      # Enable for multi-threaded eve.json output; output files are suffixed
-      # with an identifier, e.g., eve.json.9.. Default: off
+      # Enable for multi-threaded eve.json output; output files are amended
+      # with an identifier, e.g., eve.9.json. Default: off
       #threaded: off
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
@@ -309,7 +309,10 @@ Threaded file output
 ~~~~~~~~~~~~~~~~~~~~
 
 By default, all output is written to the named filename in the outputs section. The ``threaded`` option enables
-each output thread to write to individual files prefixed with the configured ``filenmae``.
+each output thread to write to individual files. In this case, the ``filename`` will include a unique identifier.
+
+With ``threaded`` enabled, the output will be split among many files -- and
+the aggregate of each file's contents must be treated together.
 
 ::
 
@@ -319,10 +322,8 @@ each output thread to write to individual files prefixed with the configured ``f
          threaded: on
 
 This example will cause each Suricata thread to write to its own "eve.json" file. Filenames are constructed
-by adding a suffix with the thread id. For example, the thread with id 7 would write to `eve.json.7`.
+by adding a unique identifier to the filename.  For example, ``eve.7.json``.
 
-With ``threaded`` enabled, the output will be split among many files -- each having the same prefix and a unique suffix -- and
-the aggregate of each file's contents must be treated together.
 
 Rotate log file
 ~~~~~~~~~~~~~~~

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -4,8 +4,8 @@ outputs:
       enabled: yes
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
-      # Enable for multi-threaded eve.json output; output files are suffixed
-      # with an identifier, e.g., eve.json.9.
+      # Enable for multi-threaded eve.json output; output files are amended
+      # with an identifier, e.g., eve.9.json
       #threaded: false
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above

--- a/doc/userguide/rules/transforms.rst.save
+++ b/doc/userguide/rules/transforms.rst.save
@@ -1,0 +1,97 @@
+Transformations
+===============
+
+Transformation keywords turn the data at a sticky buffer into something else.
+
+Example::
+
+    alert http any any -> any any (file_data; strip_whitespace; \
+        content:"window.navigate("; sid:1;)
+
+This example will match on traffic even if there are one or more spaces between
+the ``navigate`` and ``(``.
+
+The transforms can be chained. They are processed in the order in which they
+appear in a rule. Each transforms output acts as input for the next one.
+
+Example::
+
+    alert http any any -> any any (http_request_line; compress_whitespace; to_sha256; \
+        content:"|54A9 7A8A B09C 1B81 3725 2214 51D3 F997 F015 9DD7 049E E5AD CED3 945A FC79 7401|"; sid:1;)
+
+.. note:: not all sticky buffers support transformations yet
+
+domain
+------
+
+Takes the buffer, and returns the domain, if any and passes it on.
+
+Example::
+
+    alert http any any -> any any (dns.query; domain; \
+        content:"update.microsoft.com"; sid:1;)
+
+strip_whitespace
+----------------
+
+Strips all whitespace as considered by the ``isspace()`` call in C.
+
+Example::
+
+    alert http any any -> any any (file_data; strip_whitespace; \
+        content:"window.navigate("; sid:1;)
+
+compress_whitespace
+-------------------
+
+Compresses all consecutive whitespace into a single space.
+
+tld
+---
+
+Takes the buffer, and returns the top level domain, if any and passes it on.
+
+Example::
+
+    alert dns any any -> any any (dns.query; tld; \
+        content:"com"; sid:1;)
+
+to_md5
+------
+
+Takes the buffer, calculates the MD5 hash and passes the raw hash value
+on.
+
+Example::
+
+    alert http any any -> any any (http_request_line; to_md5; \
+        content:"|54 A9 7A 8A B0 9C 1B 81 37 25 22 14 51 D3 F9 97|"; sid:1;)
+
+.. note:: depends on libnss being compiled into Suricata
+
+to_sha1
+---------
+
+Takes the buffer, calculates the SHA-1 hash and passes the raw hash value
+on.
+
+Example::
+
+    alert http any any -> any any (http_request_line; to_sha1; \
+        content:"|54A9 7A8A B09C 1B81 3725 2214 51D3 F997 F015 9DD7|"; sid:1;)
+
+.. note:: depends on libnss being compiled into Suricata
+
+to_sha256
+---------
+
+Takes the buffer, calculates the SHA-256 hash and passes the raw hash value
+on.
+
+Example::
+
+    alert http any any -> any any (http_request_line; to_sha256; \
+        content:"|54A9 7A8A B09C 1B81 3725 2214 51D3 F997 F015 9DD7 049E E5AD CED3 945A FC79 7401|"; sid:1;)
+
+.. note:: depends on libnss being compiled into Suricata
+

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -44,8 +44,8 @@
 static bool LogFileNewThreadedCtx(LogFileCtx *parent_ctx, const char *log_path, const char *append, int i);
 static bool SCLogOpenThreadedFileFp(const char *log_path, const char *append, LogFileCtx *parent_ctx, int slot_count);
 
-// Threaded eve.json suffixes
-static SC_ATOMIC_DECL_AND_INIT_WITH_VAL(uint32_t, eve_file_suffix, 1);
+// Threaded eve.json identifier
+static SC_ATOMIC_DECL_AND_INIT_WITH_VAL(uint32_t, eve_file_id, 1);
 
 #ifdef BUILD_WITH_UNIXSOCKET
 /** \brief connect to the indicated local stream socket, logging any errors
@@ -708,6 +708,37 @@ LogFileCtx *LogFileEnsureExists(LogFileCtx *parent_ctx, int thread_id)
     return parent_ctx->threads->lf_slots[thread_id];
 }
 
+/** \brief LogFileThreadedName() Create file name for threaded EVE storage
+ *
+ */
+static bool LogFileThreadedName(
+        const char *original_name, char *threaded_name, size_t len, uint32_t unique_id)
+{
+    char *dot = strrchr(original_name, '.');
+    if (dot) {
+        char *tname = SCStrdup(original_name);
+        if (!tname) {
+            return false;
+        }
+
+        int dotpos = dot - original_name;
+        tname[dotpos] = '\0';
+        char *ext = tname + dotpos + 1;
+        if (strlen(tname) && strlen(ext)) {
+            snprintf(threaded_name, len, "%s.%d.%s", tname, unique_id, ext);
+        } else {
+            FatalError(SC_ERR_FATAL,
+                    "Invalid filename for threaded mode \"%s\"; "
+                    "filenames must include an extension, e.g: \"name.ext\"",
+                    original_name);
+        }
+        SCFree(tname);
+    } else {
+        snprintf(threaded_name, len, "%s.%d", original_name, unique_id);
+    }
+    return true;
+}
+
 /** \brief LogFileNewThreadedCtx() Create file context for threaded output
  * \param parent_ctx
  * \param log_path
@@ -724,8 +755,11 @@ static bool LogFileNewThreadedCtx(LogFileCtx *parent_ctx, const char *log_path, 
 
     *thread = *parent_ctx;
     char fname[NAME_MAX];
-    snprintf(fname, sizeof(fname), "%s.%d", log_path, SC_ATOMIC_ADD(eve_file_suffix, 1));
-    SCLogDebug("Thread open -- using name %s [replaces %s]", fname, log_path);
+    if (!LogFileThreadedName(log_path, fname, sizeof(fname), SC_ATOMIC_ADD(eve_file_id, 1))) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Unable to create threaded filename for log");
+        return false;
+    }
+    SCLogNotice("Thread open -- using name %s [replaces %s]", fname, log_path);
     thread->fp = SCLogOpenFileFp(fname, append, thread->filemode);
     if (thread->fp == NULL) {
         goto error;
@@ -748,7 +782,7 @@ static bool LogFileNewThreadedCtx(LogFileCtx *parent_ctx, const char *log_path, 
     return true;
 
 error:
-    SC_ATOMIC_SUB(eve_file_suffix, 1);
+    SC_ATOMIC_SUB(eve_file_id, 1);
     if (thread->fp) {
         thread->Close(thread);
     }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -85,8 +85,8 @@ outputs:
       enabled: @e_enable_evelog@
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
-      # Enable for multi-threaded eve.json output; output files are suffixed
-      # with an identifier, e.g., eve.json.9.
+      # Enable for multi-threaded eve.json output; output files are amended with
+      # with an identifier, e.g., eve.9.json
       #threaded: false
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above


### PR DESCRIPTION
Continuation of #5444

This commit changes the name of the file used with threaded eve logging
to better support log rotation

Instead of using "eve.json.N" and creating potential issues with log
rotation (which also uses a ".N" suffix), the eve logs will be named
"eve.N.json" when threaded.

Describe changes:
- Updates documentation and yaml configuration template
- Improved handling of filenames without extensions.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
