### PR TITLE
applayer: fix a leak in protocol change

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1196,7 +1196,7 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
     if (flags & STREAM_GAP) {
         if (!(p->option_flags & APP_LAYER_PARSER_OPT_ACCEPT_GAPS)) {
             SCLogDebug("app-layer parser does not accept gaps");
-            if (f->alstate != NULL) {
+            if (f->alstate != NULL && !FlowChangeProto(f)) {
                 AppLayerParserStreamTruncated(f->proto, alproto, f->alstate,
                         flags);
             }

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -640,6 +640,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         /* rerun protocol detection */
         int rd = TCPProtoDetect(tv, ra_ctx, app_tctx, p, f, ssn, stream, data, data_len, flags);
         if (f->alproto == ALPROTO_UNKNOWN) {
+            DEBUG_VALIDATE_BUG_ON(alstate_orig != f->alstate);
             // not enough data, revert AppLayerProtoDetectReset to rerun detection
             f->alparser = alparser;
             f->alproto = f->alproto_orig;
@@ -648,10 +649,13 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         } else {
             FlowUnsetChangeProtoFlag(f);
             AppLayerParserStateProtoCleanup(f->protomap, f->alproto_orig, alstate_orig, alparser);
+            if (alstate_orig == f->alstate) {
+                // we just freed it
+                f->alstate = NULL;
+            }
         }
         if (rd != 0) {
             SCLogDebug("proto detect failure");
-            f->alstate = NULL;
             goto failure;
         }
         SCLogDebug("protocol change, old %s, new %s",


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3924

Describe changes:
- Fixes memory leak in case of protocol change (and potential use after free)
- Adds debug validation for other cases

Leak happened when 
1. there was a protocol change (for instance from HTTP to TLS with `CONNECT`, but it could be other protocols)
2. Call to `TCPProtoDetect` made these changes
2.1 Its call to `AppLayerProtoDetectGetProto` changed `f->alproto` to `ALPROTO_TLS`
2.2 Its call to `AppLayerParserParse` (parsing the TLS data) returned -1 error 
3. We cleant the previous memory state with `AppLayerParserStateProtoCleanup`
4. We forgot the new TLS state by setting `f->alstate = NULL;`  which got leaked

Fix is to tie together the memory cleaning and setting `f->alstate = NULL;`

Modifies #5445 with fixed git author