### PR TITLE
scripts/setup-app-layer: fix rust generation - v1

### DIFF
--- a/scripts/setup-app-layer.py
+++ b/scripts/setup-app-layer.py
@@ -71,7 +71,7 @@ def copy_app_layer_templates(proto, rust):
             ("rust/src/applayertemplate/mod.rs",
              "rust/src/applayer%s/mod.rs" % (lower)),
             ("rust/src/applayertemplate/template.rs",
-             "rust/src/applayer%s/gopher.rs" % (lower)),
+             "rust/src/applayer%s/%s.rs" % (lower, lower)),
             ("rust/src/applayertemplate/parser.rs",
              "rust/src/applayer%s/parser.rs" % (lower)),
         )


### PR DESCRIPTION
Fix Rust app-layer generation. Main parser file was being named
gopher.rs instead of the name of the protocol.
