### PR TITLE
Http2 pcapfixes v5

### DIFF
--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -58,6 +58,8 @@ const HTTP2_FRAME_GOAWAY_LEN: usize = 4;
 const HTTP2_FRAME_RSTSTREAM_LEN: usize = 4;
 const HTTP2_FRAME_PRIORITY_LEN: usize = 1;
 const HTTP2_FRAME_WINDOWUPDATE_LEN: usize = 4;
+//TODO make this configurable
+pub const HTTP2_MAX_TABLESIZE: u32 = 0x10000; // 65536
 
 #[repr(u8)]
 #[derive(Copy, Clone, PartialOrd, PartialEq, Debug)]
@@ -271,12 +273,30 @@ impl HTTP2Event {
     }
 }
 
+pub struct HTTP2DynTable {
+    pub table: Vec<parser::HTTP2FrameHeaderBlock>,
+    pub current_size: usize,
+    pub max_size: usize,
+    pub overflow: u8,
+}
+
+impl HTTP2DynTable {
+    pub fn new() -> Self {
+        Self {
+            table: Vec::with_capacity(64),
+            current_size: 0,
+            max_size: 4096, //default value
+            overflow: 0,
+        }
+    }
+}
+
 pub struct HTTP2State {
     tx_id: u64,
     request_frame_size: u32,
     response_frame_size: u32,
-    dynamic_headers_ts: Vec<parser::HTTP2FrameHeaderBlock>,
-    dynamic_headers_tc: Vec<parser::HTTP2FrameHeaderBlock>,
+    dynamic_headers_ts: HTTP2DynTable,
+    dynamic_headers_tc: HTTP2DynTable,
     transactions: Vec<HTTP2Transaction>,
     progress: HTTP2ConnectionState,
     pub files: HTTP2Files,
@@ -291,8 +311,8 @@ impl HTTP2State {
             // the headers are encoded on one byte
             // with a fixed number of static headers, and
             // a variable number of dynamic headers
-            dynamic_headers_ts: Vec::with_capacity(256 - parser::HTTP2_STATIC_HEADERS_NUMBER),
-            dynamic_headers_tc: Vec::with_capacity(256 - parser::HTTP2_STATIC_HEADERS_NUMBER),
+            dynamic_headers_ts: HTTP2DynTable::new(),
+            dynamic_headers_tc: HTTP2DynTable::new(),
             transactions: Vec::new(),
             progress: HTTP2ConnectionState::Http2StateInit,
             files: HTTP2Files::new(),
@@ -444,6 +464,21 @@ impl HTTP2State {
             Some(parser::HTTP2FrameType::SETTINGS) => {
                 match parser::http2_parse_frame_settings(input) {
                     Ok((_, set)) => {
+                        for i in 0..set.len() {
+                            if set[i].id == parser::HTTP2SettingsId::SETTINGSHEADERTABLESIZE {
+                                self.dynamic_headers_ts.max_size = set[i].value as usize;
+                                self.dynamic_headers_tc.max_size = set[i].value as usize;
+                                if set[i].value > HTTP2_MAX_TABLESIZE {
+                                    //mark potential overflow
+                                    self.dynamic_headers_ts.overflow = 1;
+                                    self.dynamic_headers_tc.overflow = 1;
+                                } else {
+//reset in case peer set a lower value, to be tested
+                                    self.dynamic_headers_ts.overflow = 0;
+                                    self.dynamic_headers_tc.overflow = 0;
+                                }
+                            }
+                        }
                         //we could set an event on remaining data
                         return HTTP2FrameTypeData::SETTINGS(set);
                     }

--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -16,6 +16,7 @@
  */
 
 use super::huffman;
+use crate::http2::http2::{HTTP2DynTable, HTTP2_MAX_TABLESIZE};
 use nom::character::complete::digit1;
 use nom::combinator::rest;
 use nom::error::ErrorKind;
@@ -209,9 +210,7 @@ named!(pub http2_parse_headers_priority<HTTP2FrameHeadersPriority>,
 
 pub const HTTP2_STATIC_HEADERS_NUMBER: usize = 61;
 
-fn http2_frame_header_static(
-    n: u64, dyn_headers: &Vec<HTTP2FrameHeaderBlock>,
-) -> Option<HTTP2FrameHeaderBlock> {
+fn http2_frame_header_static(n: u64, dyn_headers: &HTTP2DynTable) -> Option<HTTP2FrameHeaderBlock> {
     let (name, value) = match n {
         1 => (":authority", ""),
         2 => (":method", "GET"),
@@ -292,7 +291,7 @@ fn http2_frame_header_static(
                 error: HTTP2HeaderDecodeStatus::HTTP2HeaderDecodeIndex0,
                 sizeupdate: 0,
             });
-        } else if dyn_headers.len() + HTTP2_STATIC_HEADERS_NUMBER < n as usize {
+        } else if dyn_headers.table.len() + HTTP2_STATIC_HEADERS_NUMBER < n as usize {
             return Some(HTTP2FrameHeaderBlock {
                 name: Vec::new(),
                 value: Vec::new(),
@@ -300,10 +299,10 @@ fn http2_frame_header_static(
                 sizeupdate: 0,
             });
         } else {
-            let indyn = dyn_headers.len() - (n as usize - HTTP2_STATIC_HEADERS_NUMBER);
+            let indyn = dyn_headers.table.len() - (n as usize - HTTP2_STATIC_HEADERS_NUMBER);
             let headcopy = HTTP2FrameHeaderBlock {
-                name: dyn_headers[indyn].name.to_vec(),
-                value: dyn_headers[indyn].value.to_vec(),
+                name: dyn_headers.table[indyn].name.to_vec(),
+                value: dyn_headers.table[indyn].value.to_vec(),
                 error: HTTP2HeaderDecodeStatus::HTTP2HeaderDecodeSuccess,
                 sizeupdate: 0,
             };
@@ -338,7 +337,7 @@ pub struct HTTP2FrameHeaderBlock {
 }
 
 fn http2_parse_headers_block_indexed<'a>(
-    input: &'a [u8], dyn_headers: &Vec<HTTP2FrameHeaderBlock>,
+    input: &'a [u8], dyn_headers: &HTTP2DynTable,
 ) -> IResult<&'a [u8], HTTP2FrameHeaderBlock> {
     fn parser(input: &[u8]) -> IResult<&[u8], (u8, u8)> {
         bits!(
@@ -379,7 +378,7 @@ fn http2_parse_headers_block_string(input: &[u8]) -> IResult<&[u8], Vec<u8>> {
 }
 
 fn http2_parse_headers_block_literal_common<'a>(
-    input: &'a [u8], index: u64, dyn_headers: &Vec<HTTP2FrameHeaderBlock>,
+    input: &'a [u8], index: u64, dyn_headers: &HTTP2DynTable,
 ) -> IResult<&'a [u8], HTTP2FrameHeaderBlock> {
     let (i3, name, error) = if index == 0 {
         match http2_parse_headers_block_string(input) {
@@ -413,7 +412,7 @@ fn http2_parse_headers_block_literal_common<'a>(
 }
 
 fn http2_parse_headers_block_literal_incindex<'a>(
-    input: &'a [u8], dyn_headers: &mut Vec<HTTP2FrameHeaderBlock>,
+    input: &'a [u8], dyn_headers: &mut HTTP2DynTable,
 ) -> IResult<&'a [u8], HTTP2FrameHeaderBlock> {
     fn parser(input: &[u8]) -> IResult<&[u8], (u8, u8)> {
         bits!(
@@ -438,16 +437,27 @@ fn http2_parse_headers_block_literal_incindex<'a>(
                 error: head.error,
                 sizeupdate: 0,
             };
-            dyn_headers.push(headcopy);
-            let mut dynsize = 0;
-            //we may spend less CPU by storing in memory
-            for i in 0..dyn_headers.len() {
-                dynsize += 32 + dyn_headers[i].name.len() + dyn_headers[i].value.len();
-            }
-            //TODO keep track of settings + updates instead of magic default value
-            while dynsize > 4096 {
-                dynsize -= 32 + dyn_headers[0].name.len() + dyn_headers[0].value.len();
-                dyn_headers.remove(0);
+            if head.error == HTTP2HeaderDecodeStatus::HTTP2HeaderDecodeSuccess {
+                dyn_headers.current_size += 32 + headcopy.name.len() + headcopy.value.len();
+                //in case of overflow, best effort is to keep first headers
+                if dyn_headers.overflow > 0 {
+                    if dyn_headers.overflow == 1 {
+                        if dyn_headers.current_size <= (HTTP2_MAX_TABLESIZE as usize) {
+                            //overflow had not yet happened
+                            dyn_headers.table.push(headcopy);
+                        } else if dyn_headers.current_size > dyn_headers.max_size {
+                            //overflow happens, we cannot replace evicted headers
+                            dyn_headers.overflow = 2;
+                        }
+                    }
+                } else {
+                    dyn_headers.table.push(headcopy);
+                }
+                while dyn_headers.current_size > dyn_headers.max_size && dyn_headers.table.len() > 0 {
+                    dyn_headers.current_size -=
+                        32 + dyn_headers.table[0].name.len() + dyn_headers.table[0].value.len();
+                    dyn_headers.table.remove(0);
+                }
             }
             return Ok((r, head));
         }
@@ -458,7 +468,7 @@ fn http2_parse_headers_block_literal_incindex<'a>(
 }
 
 fn http2_parse_headers_block_literal_noindex<'a>(
-    input: &'a [u8], dyn_headers: &Vec<HTTP2FrameHeaderBlock>,
+    input: &'a [u8], dyn_headers: &HTTP2DynTable,
 ) -> IResult<&'a [u8], HTTP2FrameHeaderBlock> {
     fn parser(input: &[u8]) -> IResult<&[u8], (u8, u8)> {
         bits!(
@@ -479,7 +489,7 @@ fn http2_parse_headers_block_literal_noindex<'a>(
 }
 
 fn http2_parse_headers_block_literal_neverindex<'a>(
-    input: &'a [u8], dyn_headers: &Vec<HTTP2FrameHeaderBlock>,
+    input: &'a [u8], dyn_headers: &HTTP2DynTable,
 ) -> IResult<&'a [u8], HTTP2FrameHeaderBlock> {
     fn parser(input: &[u8]) -> IResult<&[u8], (u8, u8)> {
         bits!(
@@ -521,7 +531,9 @@ fn http2_parse_var_uint(input: &[u8], value: u64, max: u64) -> IResult<&[u8], u6
     return Ok((i3, varval));
 }
 
-fn http2_parse_headers_block_dynamic_size(input: &[u8]) -> IResult<&[u8], HTTP2FrameHeaderBlock> {
+fn http2_parse_headers_block_dynamic_size<'a>(
+    input: &'a [u8], dyn_headers: &mut HTTP2DynTable,
+) -> IResult<&'a [u8], HTTP2FrameHeaderBlock> {
     fn parser(input: &[u8]) -> IResult<&[u8], (u8, u8)> {
         bits!(
             input,
@@ -544,6 +556,15 @@ fn http2_parse_headers_block_dynamic_size(input: &[u8]) -> IResult<&[u8], HTTP2F
             },
         ));
     }
+    if (maxsize2 as usize) < dyn_headers.max_size {
+        dyn_headers.max_size = maxsize2 as usize;
+        //may evict entries
+        while dyn_headers.current_size > dyn_headers.max_size {
+            dyn_headers.current_size -=
+                32 + dyn_headers.table[0].name.len() + dyn_headers.table[0].value.len();
+            dyn_headers.table.remove(0);
+        }
+    }
     return Ok((
         i3,
         HTTP2FrameHeaderBlock {
@@ -556,7 +577,7 @@ fn http2_parse_headers_block_dynamic_size(input: &[u8]) -> IResult<&[u8], HTTP2F
 }
 
 fn http2_parse_headers_block<'a>(
-    input: &'a [u8], dyn_headers: &mut Vec<HTTP2FrameHeaderBlock>,
+    input: &'a [u8], dyn_headers: &mut HTTP2DynTable,
 ) -> IResult<&'a [u8], HTTP2FrameHeaderBlock> {
     //caller garantees o have at least one byte
     if input[0] & 0x80 != 0 {
@@ -564,7 +585,7 @@ fn http2_parse_headers_block<'a>(
     } else if input[0] & 0x40 != 0 {
         return http2_parse_headers_block_literal_incindex(input, dyn_headers);
     } else if input[0] & 0x20 != 0 {
-        return http2_parse_headers_block_dynamic_size(input);
+        return http2_parse_headers_block_dynamic_size(input, dyn_headers);
     } else if input[0] & 0x10 != 0 {
         return http2_parse_headers_block_literal_neverindex(input, dyn_headers);
     } else {
@@ -586,7 +607,7 @@ const HTTP2_FLAG_HEADER_PADDED: u8 = 0x8;
 const HTTP2_FLAG_HEADER_PRIORITY: u8 = 0x20;
 
 pub fn http2_parse_frame_headers<'a>(
-    input: &'a [u8], flags: u8, dyn_headers: &mut Vec<HTTP2FrameHeaderBlock>,
+    input: &'a [u8], flags: u8, dyn_headers: &mut HTTP2DynTable,
 ) -> IResult<&'a [u8], HTTP2FrameHeaders> {
     let (i2, padlength) = cond!(input, flags & HTTP2_FLAG_HEADER_PADDED != 0, be_u8)?;
     let (mut i3, priority) = cond!(
@@ -630,7 +651,7 @@ pub struct HTTP2FramePushPromise {
 }
 
 pub fn http2_parse_frame_push_promise<'a>(
-    input: &'a [u8], flags: u8, dyn_headers: &mut Vec<HTTP2FrameHeaderBlock>,
+    input: &'a [u8], flags: u8, dyn_headers: &mut HTTP2DynTable,
 ) -> IResult<&'a [u8], HTTP2FramePushPromise> {
     let (i2, padlength) = cond!(input, flags & HTTP2_FLAG_HEADER_PADDED != 0, be_u8)?;
     let (mut i3, stream_id) = bits!(i2, tuple!(take_bits!(1u8), take_bits!(31u32)))?;
@@ -668,7 +689,7 @@ pub struct HTTP2FrameContinuation {
 }
 
 pub fn http2_parse_frame_continuation<'a>(
-    input: &'a [u8], dyn_headers: &mut Vec<HTTP2FrameHeaderBlock>,
+    input: &'a [u8], dyn_headers: &mut HTTP2DynTable,
 ) -> IResult<&'a [u8], HTTP2FrameContinuation> {
     let mut i3 = input;
     let mut blocks = Vec::new();
@@ -897,8 +918,7 @@ mod tests {
     #[test]
     fn test_http2_parse_header() {
         let buf0: &[u8] = &[0x82];
-        let mut dynh: Vec<HTTP2FrameHeaderBlock> =
-            Vec::with_capacity(255 - HTTP2_STATIC_HEADERS_NUMBER);
+        let mut dynh: HTTP2DynTable::new();
         let r0 = http2_parse_headers_block(buf0, &mut dynh);
         match r0 {
             Ok((remainder, hd)) => {

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -398,6 +398,36 @@ static AppProto AppLayerProtoDetectPMGetProto(
     SCReturnUInt(0);
 }
 
+static AppLayerProtoDetectProbingParserElement *AppLayerProtoDetectGetProbingParser(
+        AppLayerProtoDetectProbingParser *pp, uint8_t ipproto, AppProto alproto)
+{
+    AppLayerProtoDetectProbingParserElement *pp_elem = NULL;
+    AppLayerProtoDetectProbingParserPort *pp_port = NULL;
+
+    while (pp != NULL) {
+        if (pp->ipproto == ipproto)
+            break;
+        pp = pp->next;
+    }
+    if (pp == NULL)
+        return NULL;
+
+    pp_port = pp->port;
+    while (pp_port != NULL) {
+        if (pp_port->dp != NULL && pp_port->dp->alproto == alproto) {
+            pp_elem = pp_port->dp;
+            break;
+        }
+        if (pp_port->sp != NULL && pp_port->sp->alproto == alproto) {
+            pp_elem = pp_port->sp;
+            break;
+        }
+        pp_port = pp_port->next;
+    }
+
+    SCReturnPtr(pp_elem, "AppLayerProtoDetectProbingParserElement *");
+}
+
 static AppLayerProtoDetectProbingParserPort *AppLayerProtoDetectGetProbingParsers(AppLayerProtoDetectProbingParser *pp,
                                                                                   uint8_t ipproto,
                                                                                   uint16_t port)
@@ -491,6 +521,7 @@ static AppProto AppLayerProtoDetectPPGetProto(Flow *f,
 {
     const AppLayerProtoDetectProbingParserPort *pp_port_dp = NULL;
     const AppLayerProtoDetectProbingParserPort *pp_port_sp = NULL;
+    const AppLayerProtoDetectProbingParserElement *pe0 = NULL;
     const AppLayerProtoDetectProbingParserElement *pe1 = NULL;
     const AppLayerProtoDetectProbingParserElement *pe2 = NULL;
     AppProto alproto = ALPROTO_UNKNOWN;
@@ -552,7 +583,13 @@ again_midstream:
         }
     }
 
-    if (pe1 == NULL && pe2 == NULL) {
+    if (dir == STREAM_TOSERVER && f->alproto_tc != ALPROTO_UNKNOWN) {
+        pe0 = AppLayerProtoDetectGetProbingParser(alpd_ctx.ctx_pp, ipproto, f->alproto_tc);
+    } else if (dir == STREAM_TOCLIENT && f->alproto_ts != ALPROTO_UNKNOWN) {
+        pe0 = AppLayerProtoDetectGetProbingParser(alpd_ctx.ctx_pp, ipproto, f->alproto_ts);
+    }
+
+    if (pe1 == NULL && pe2 == NULL && pe0 == NULL) {
         SCLogDebug("%s - No probing parsers found for either port",
                 (dir == STREAM_TOSERVER) ? "toserver":"toclient");
         if (dir == idir)
@@ -562,6 +599,9 @@ again_midstream:
 
     /* run the parser(s): always call with original direction */
     uint8_t rdir = 0;
+    alproto = PPGetProto(pe0, f, idir, buf, buflen, alproto_masks, &rdir);
+    if (AppProtoIsValid(alproto))
+        goto end;
     alproto = PPGetProto(pe1, f, idir, buf, buflen, alproto_masks, &rdir);
     if (AppProtoIsValid(alproto))
         goto end;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3955 
https://redmine.openinfosecfoundation.org/issues/3956
https://redmine.openinfosecfoundation.org/issues/3972
https://redmine.openinfosecfoundation.org/issues/3989

Describe changes:
- Runs probing parser for protocol found by pattern on other direction
- Rerun probing parser for protocol found by pattern on other direction if probing parser failed in the first try
- HTTP2 : Uses variable integers to read headers length 
- HTTP2 : better handle transaction state and adds exceptions to stream id reuse event as authorized per RFC
- HTTP2 : keep track of dynamic headers table size

Modifies #5455 by adding the commit fixing the tracking of dynamic headers table size https://redmine.openinfosecfoundation.org/issues/3989

suricata-verify-pr: 332