### PR TITLE
log/eve: Threaded filename change: eve.N.json

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -27,8 +27,8 @@ Output types::
 
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
-      # Enable for multi-threaded eve.json output; output files are suffixed
-      # with an identifier, e.g., eve.json.9.. Default: off
+      # Enable for multi-threaded eve.json output; output files are amended
+      # with an identifier, e.g., eve.9.json. Default: off
       #threaded: off
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
@@ -309,7 +309,10 @@ Threaded file output
 ~~~~~~~~~~~~~~~~~~~~
 
 By default, all output is written to the named filename in the outputs section. The ``threaded`` option enables
-each output thread to write to individual files prefixed with the configured ``filenmae``.
+each output thread to write to individual files. In this case, the ``filename`` will include a unique identifier.
+
+With ``threaded`` enabled, the output will be split among many files -- and
+the aggregate of each file's contents must be treated together.
 
 ::
 
@@ -319,10 +322,8 @@ each output thread to write to individual files prefixed with the configured ``f
          threaded: on
 
 This example will cause each Suricata thread to write to its own "eve.json" file. Filenames are constructed
-by adding a suffix with the thread id. For example, the thread with id 7 would write to `eve.json.7`.
+by adding a unique identifier to the filename.  For example, ``eve.7.json``.
 
-With ``threaded`` enabled, the output will be split among many files -- each having the same prefix and a unique suffix -- and
-the aggregate of each file's contents must be treated together.
 
 Rotate log file
 ~~~~~~~~~~~~~~~

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -4,8 +4,8 @@ outputs:
       enabled: yes
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
-      # Enable for multi-threaded eve.json output; output files are suffixed
-      # with an identifier, e.g., eve.json.9.
+      # Enable for multi-threaded eve.json output; output files are amended
+      # with an identifier, e.g., eve.9.json
       #threaded: false
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -44,8 +44,8 @@
 static bool LogFileNewThreadedCtx(LogFileCtx *parent_ctx, const char *log_path, const char *append, int i);
 static bool SCLogOpenThreadedFileFp(const char *log_path, const char *append, LogFileCtx *parent_ctx, int slot_count);
 
-// Threaded eve.json suffixes
-static SC_ATOMIC_DECL_AND_INIT_WITH_VAL(uint32_t, eve_file_suffix, 1);
+// Threaded eve.json identifier
+static SC_ATOMIC_DECL_AND_INIT_WITH_VAL(uint32_t, eve_file_id, 1);
 
 #ifdef BUILD_WITH_UNIXSOCKET
 /** \brief connect to the indicated local stream socket, logging any errors
@@ -708,6 +708,50 @@ LogFileCtx *LogFileEnsureExists(LogFileCtx *parent_ctx, int thread_id)
     return parent_ctx->threads->lf_slots[thread_id];
 }
 
+/** \brief LogFileThreadedName() Create file name for threaded EVE storage
+ *
+ */
+static bool LogFileThreadedName(
+        const char *original_name, char *threaded_name, size_t len, uint32_t unique_id)
+{
+    const char *base = SCBasename(original_name);
+    if (!base) {
+        FatalError(SC_ERR_FATAL,
+                "Invalid filename for threaded mode \"%s\"; "
+                "no basename found.",
+                original_name);
+    }
+
+    /* Check if basename has an extension */
+    char *dot = strrchr(base, '.');
+    if (dot) {
+        char *tname = SCStrdup(original_name);
+        if (!tname) {
+            return false;
+        }
+
+        /* Fetch extension location from original, not base
+         * for update
+         */
+        dot = strrchr(original_name, '.');
+        int dotpos = dot - original_name;
+        tname[dotpos] = '\0';
+        char *ext = tname + dotpos + 1;
+        if (strlen(tname) && strlen(ext)) {
+            snprintf(threaded_name, len, "%s.%d.%s", tname, unique_id, ext);
+        } else {
+            FatalError(SC_ERR_FATAL,
+                    "Invalid filename for threaded mode \"%s\"; "
+                    "filenames must include an extension, e.g: \"name.ext\"",
+                    original_name);
+        }
+        SCFree(tname);
+    } else {
+        snprintf(threaded_name, len, "%s.%d", original_name, unique_id);
+    }
+    return true;
+}
+
 /** \brief LogFileNewThreadedCtx() Create file context for threaded output
  * \param parent_ctx
  * \param log_path
@@ -724,7 +768,10 @@ static bool LogFileNewThreadedCtx(LogFileCtx *parent_ctx, const char *log_path, 
 
     *thread = *parent_ctx;
     char fname[NAME_MAX];
-    snprintf(fname, sizeof(fname), "%s.%d", log_path, SC_ATOMIC_ADD(eve_file_suffix, 1));
+    if (!LogFileThreadedName(log_path, fname, sizeof(fname), SC_ATOMIC_ADD(eve_file_id, 1))) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Unable to create threaded filename for log");
+        return false;
+    }
     SCLogDebug("Thread open -- using name %s [replaces %s]", fname, log_path);
     thread->fp = SCLogOpenFileFp(fname, append, thread->filemode);
     if (thread->fp == NULL) {
@@ -748,7 +795,7 @@ static bool LogFileNewThreadedCtx(LogFileCtx *parent_ctx, const char *log_path, 
     return true;
 
 error:
-    SC_ATOMIC_SUB(eve_file_suffix, 1);
+    SC_ATOMIC_SUB(eve_file_id, 1);
     if (thread->fp) {
         thread->Close(thread);
     }

--- a/src/util-path.c
+++ b/src/util-path.c
@@ -28,6 +28,12 @@
 #include "util-debug.h"
 #include "util-path.h"
 
+#ifdef OS_WIN32
+#define DIRECTORY_SEPARATOR '\\'
+#else
+#define DIRECTORY_SEPARATOR '/'
+#endif
+
 /**
  *  \brief Check if a path is absolute
  *
@@ -81,11 +87,6 @@ int PathIsRelative(const char *path)
 TmEcode PathJoin (char *out_buf, uint16_t buf_len, const char *const dir, const char *const fname)
 {
     SCEnter();
-#ifdef OS_WIN32
-#define DIRECTORY_SEPARATOR '\\'
-#else
-#define DIRECTORY_SEPARATOR '/'
-#endif
     uint16_t max_path_len = MAX(buf_len, PATH_MAX);
     int bytes_written = snprintf(out_buf, max_path_len, "%s%c%s", dir, DIRECTORY_SEPARATOR, fname);
     if (bytes_written <= 0) {
@@ -224,4 +225,25 @@ char *SCRealPath(const char *path, char *resolved_path)
 #else
     return realpath(path, resolved_path);
 #endif
+}
+
+/*
+ * \brief Return the basename of the provided path.
+ * \param path The path on which to compute the basename
+ *
+ * \retval the basename of the path or NULL if the path lacks a non-leaf
+ */
+const char *SCBasename(const char *path)
+{
+    if (!path || strlen(path) == 0)
+        return NULL;
+
+    char *final = strrchr(path, DIRECTORY_SEPARATOR);
+    if (!final)
+        return path;
+
+    if (*(final + 1) == '\0')
+        return NULL;
+
+    return final + 1;
 }

--- a/src/util-path.h
+++ b/src/util-path.h
@@ -40,5 +40,6 @@ bool SCPathExists(const char *path);
 bool SCIsRegularDirectory(const struct dirent *const dir_entry);
 bool SCIsRegularFile(const struct dirent *const dir_entry);
 char *SCRealPath(const char *path, char *resolved_path);
+const char *SCBasename(const char *path);
 
 #endif /* __UTIL_PATH_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -85,8 +85,8 @@ outputs:
       enabled: @e_enable_evelog@
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
-      # Enable for multi-threaded eve.json output; output files are suffixed
-      # with an identifier, e.g., eve.json.9.
+      # Enable for multi-threaded eve.json output; output files are amended with
+      # with an identifier, e.g., eve.9.json
       #threaded: false
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above


### PR DESCRIPTION
Continuation of #5454

This commit changes the name of the file used with threaded eve logging
to better support log rotation

Instead of using "eve.json.N" and creating potential issues with log
rotation (which also uses a ".N" suffix), the eve logs will be named
"eve.N.json" when threaded.

Describe changes:
- Remove extra `SCLogNotice` calls

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
