### PR TITLE
dcerpc-udp: fixed several dcerpc-udp related issues

### DIFF
--- a/rust/src/dcerpc/log.rs
+++ b/rust/src/dcerpc/log.rs
@@ -29,7 +29,7 @@ fn log_dcerpc_header(
                 jsb.open_object("req")?;
                 jsb.set_uint("opnum", tx.opnum as u64)?;
                 jsb.set_uint("frag_cnt", tx.frag_cnt_ts as u64)?;
-                jsb.set_uint("stub_data_size", tx.stub_data_buffer_len_ts as u64)?;
+                jsb.set_uint("stub_data_size", tx.stub_data_buffer_ts.len() as u64)?;
                 jsb.close()?;
             }
             DCERPC_TYPE_BIND => match &state.bind {
@@ -61,7 +61,7 @@ fn log_dcerpc_header(
             DCERPC_TYPE_RESPONSE => {
                 jsb.open_object("res")?;
                 jsb.set_uint("frag_cnt", tx.frag_cnt_tc as u64)?;
-                jsb.set_uint("stub_data_size", tx.stub_data_buffer_len_tc as u64)?;
+                jsb.set_uint("stub_data_size", tx.stub_data_buffer_tc.len() as u64)?;
                 jsb.close()?;
             }
             _ => {} // replicating behavior from smb


### PR DESCRIPTION
- proper flag definitions for connectionless dcerpc are used
- proper pairing of messages into transaction by activity uid and sequence number is implemented
- removed unnecessary (wrong) code that came from C implementation

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
DCERPC UDP is a connectionless version. However original implementation wrongly uses TCP flag bit definitions. The fix defines proper connectionless flags and uses them to identify fragmentation, etc. 

Original implementation wrongly pairs messages in a transaction by serial number. DCERPC UDP messages must be paired by activity uid and sequence number.

Removed unnecessary code that came from C implementation

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
