### PR TITLE
logrotate: reindent to 4 spaces

### DIFF
--- a/etc/suricata.logrotate.in
+++ b/etc/suricata.logrotate.in
@@ -1,13 +1,13 @@
 # Sample /etc/logrotate.d/suricata configuration file.
 @e_logdir@*.log @e_logdir@*.json {
-        daily
-        missingok
-        rotate 5
-        compress
-        delaycompress
-        minsize 500k
-	sharedscripts
-	postrotate
-	    /bin/kill -HUP `cat @e_rundir@suricata.pid 2> /dev/null` 2> /dev/null || true
-	endscript
+    daily
+    missingok
+    rotate 5
+    compress
+    delaycompress
+    minsize 500k
+    sharedscripts
+    postrotate
+        /bin/kill -HUP `cat @e_rundir@suricata.pid 2> /dev/null` 2> /dev/null || true
+    endscript
 }


### PR DESCRIPTION
4 spaces seems to be the norm on Linux, so reindent from a mix
of 8 spaces and tabs to 4 spaces.

Previous PR: https://github.com/OISF/suricata/pull/5436

Changes from last PR:
- Remove documentation and examples for the eve.json.X naming scheme.  The current examples work fine with the updated eve.X.json scheme.