### PR TITLE
dns: add rdata logging for NS rrtype v2

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -269,6 +269,7 @@ pub enum DNSRData {
     CNAME(Vec<u8>),
     PTR(Vec<u8>),
     MX(Vec<u8>),
+    NS(Vec<u8>),
     // RData is text
     TXT(Vec<u8>),
     // RData has several fields

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -443,6 +443,7 @@ fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Result<JsonBuilder, Js
         }
         DNSRData::CNAME(bytes) |
         DNSRData::MX(bytes) |
+        DNSRData::NS(bytes) |
         DNSRData::TXT(bytes) |
         DNSRData::PTR(bytes) => {
             jsa.set_string_from_bytes("rdata", &bytes)?;
@@ -514,6 +515,7 @@ fn dns_log_json_answer(js: &mut JsonBuilder, response: &DNSResponse, flags: u64)
                     }
                     DNSRData::CNAME(bytes) |
                     DNSRData::MX(bytes) |
+                    DNSRData::NS(bytes) |
                     DNSRData::TXT(bytes) |
                     DNSRData::PTR(bytes) => {
                         if !answer_types.contains_key(&type_string) {
@@ -686,6 +688,7 @@ fn dns_log_json_answer_v1(header: &DNSHeader, answer: &DNSAnswerEntry)
         }
         DNSRData::CNAME(bytes) |
         DNSRData::MX(bytes) |
+        DNSRData::NS(bytes) |
         DNSRData::TXT(bytes) |
         DNSRData::PTR(bytes) => {
             js.set_string_from_bytes("rdata", &bytes)?;

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -176,6 +176,7 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
                 },
                 DNSRData::CNAME(ref bytes) |
                 DNSRData::MX(ref bytes) |
+                DNSRData::NS(ref bytes) |
                 DNSRData::TXT(ref bytes) |
                 DNSRData::PTR(ref bytes) |
                 DNSRData::Unknown(ref bytes) => {

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -272,6 +272,12 @@ fn dns_parse_rdata_cname<'a>(input: &'a [u8], message: &'a [u8])
             (input, DNSRData::CNAME(name)))
 }
 
+fn dns_parse_rdata_ns<'a>(input: &'a [u8], message: &'a [u8])
+                             -> IResult<&'a [u8], DNSRData> {
+    dns_parse_name(input, message).map(|(input, name)|
+            (input, DNSRData::NS(name)))
+}
+
 fn dns_parse_rdata_ptr<'a>(input: &'a [u8], message: &'a [u8])
                            -> IResult<&'a [u8], DNSRData> {
     dns_parse_name(input, message).map(|(input, name)|
@@ -353,6 +359,7 @@ pub fn dns_parse_rdata<'a>(input: &'a [u8], message: &'a [u8], rrtype: u16)
         DNS_RECORD_TYPE_PTR => dns_parse_rdata_ptr(input, message),
         DNS_RECORD_TYPE_SOA => dns_parse_rdata_soa(input, message),
         DNS_RECORD_TYPE_MX => dns_parse_rdata_mx(input, message),
+        DNS_RECORD_TYPE_NS => dns_parse_rdata_ns(input, message),
         DNS_RECORD_TYPE_TXT => dns_parse_rdata_txt(input),
         DNS_RECORD_TYPE_SSHFP => dns_parse_rdata_sshfp(input),
         _ => dns_parse_rdata_unknown(input),


### PR DESCRIPTION
- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4063

Describe changes:
- add rdata logging for NS rrtype which used to work (possibly a regression when dns was moved to rust code)
- v2 fixes the missing match for rust/src/dns/lua.rs

