### PR TITLE
detect/mark:Fix unittest into FAIL/PASS API

### DIFF
--- a/src/detect-mark.c
+++ b/src/detect-mark.c
@@ -253,8 +253,9 @@ static int DetectMarkPacket(DetectEngineThreadCtx *det_ctx, Packet *p,
 /**
  * \test MarkTestParse01 is a test for a valid mark value
  *
- *  \retval 1 on succces
- *  \retval 0 on failure
+ * \FAIL/PASS API
+ *  \PASS macro returns 1
+ *  \FAIL macro returns 0
  */
 static int MarkTestParse01 (void)
 {
@@ -262,19 +263,18 @@ static int MarkTestParse01 (void)
 
     data = DetectMarkParse("1/1");
 
-    if (data == NULL) {
-        return 0;
-    }
+    FAIL_IF_NULL(data);
 
     DetectMarkDataFree(NULL, data);
-    return 1;
+    PASS;
 }
 
 /**
  * \test MarkTestParse02 is a test for an invalid mark value
  *
- *  \retval 1 on succces
- *  \retval 0 on failure
+ * \FAIL/PASS API
+ *  \PASS macro returns 1
+ *  \FAIL macro returns 0
  */
 static int MarkTestParse02 (void)
 {
@@ -282,19 +282,18 @@ static int MarkTestParse02 (void)
 
     data = DetectMarkParse("4");
 
-    if (data == NULL) {
-        return 1;
-    }
+    PASS_IF_NULL(data);
 
     DetectMarkDataFree(NULL, data);
-    return 0;
+    FAIL;
 }
 
 /**
  * \test MarkTestParse03 is a test for a valid mark value
  *
- *  \retval 1 on succces
- *  \retval 0 on failure
+ * \FAIL/PASS API
+ *  \PASS macro returns 1
+ *  \FAIL macro returns 0
  */
 static int MarkTestParse03 (void)
 {
@@ -302,19 +301,18 @@ static int MarkTestParse03 (void)
 
     data = DetectMarkParse("0x10/0xff");
 
-    if (data == NULL) {
-        return 0;
-    }
+    FAIL_IF_NULL(data);
 
     DetectMarkDataFree(NULL, data);
-    return 1;
+    PASS;
 }
 
 /**
  * \test MarkTestParse04 is a test for a invalid mark value
  *
- *  \retval 1 on succces
- *  \retval 0 on failure
+ * \FAIL/PASS API
+ *  \PASS macro returns 1
+ *  \FAIL macro returns 0
  */
 static int MarkTestParse04 (void)
 {
@@ -322,12 +320,10 @@ static int MarkTestParse04 (void)
 
     data = DetectMarkParse("0x1g/0xff");
 
-    if (data == NULL) {
-        return 1;
-    }
+    PASS_IF_NULL(data);
 
     DetectMarkDataFree(NULL, data);
-    return 0;
+    FAIL;
 }
 
 /**


### PR DESCRIPTION

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ .] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ .] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ .] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4052

Describe changes:
- Removed initial test methods in detect-mark.c
- Used FAIL or PASS macros described in util-unittest.h
- FAIL/PASS macros determine conditionals for return value(0 or 1 respectively)

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
