### PR TITLE
detect/mark: convert unittests to use PASS/FAIL API

### DIFF
--- a/src/detect-mark.c
+++ b/src/detect-mark.c
@@ -253,8 +253,6 @@ static int DetectMarkPacket(DetectEngineThreadCtx *det_ctx, Packet *p,
 /**
  * \test MarkTestParse01 is a test for a valid mark value
  *
- *  \retval 1 on succces
- *  \retval 0 on failure
  */
 static int MarkTestParse01 (void)
 {
@@ -262,19 +260,15 @@ static int MarkTestParse01 (void)
 
     data = DetectMarkParse("1/1");
 
-    if (data == NULL) {
-        return 0;
-    }
+    FAIL_IF_NULL(data);
 
     DetectMarkDataFree(NULL, data);
-    return 1;
+    PASS;
 }
 
 /**
  * \test MarkTestParse02 is a test for an invalid mark value
  *
- *  \retval 1 on succces
- *  \retval 0 on failure
  */
 static int MarkTestParse02 (void)
 {
@@ -282,19 +276,15 @@ static int MarkTestParse02 (void)
 
     data = DetectMarkParse("4");
 
-    if (data == NULL) {
-        return 1;
-    }
+    PASS_IF(data == NULL);
 
     DetectMarkDataFree(NULL, data);
-    return 0;
+    FAIL;
 }
 
 /**
  * \test MarkTestParse03 is a test for a valid mark value
  *
- *  \retval 1 on succces
- *  \retval 0 on failure
  */
 static int MarkTestParse03 (void)
 {
@@ -302,19 +292,15 @@ static int MarkTestParse03 (void)
 
     data = DetectMarkParse("0x10/0xff");
 
-    if (data == NULL) {
-        return 0;
-    }
+    FAIL_IF_NULL(data);
 
     DetectMarkDataFree(NULL, data);
-    return 1;
+    PASS;
 }
 
 /**
  * \test MarkTestParse04 is a test for a invalid mark value
  *
- *  \retval 1 on succces
- *  \retval 0 on failure
  */
 static int MarkTestParse04 (void)
 {
@@ -322,12 +308,10 @@ static int MarkTestParse04 (void)
 
     data = DetectMarkParse("0x1g/0xff");
 
-    if (data == NULL) {
-        return 1;
-    }
+    PASS_IF(data == NULL);
 
     DetectMarkDataFree(NULL, data);
-    return 0;
+    FAIL;
 }
 
 /**


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4052

Describe changes:
- Removed initial test methods in detect-mark.c
- Used FAIL or PASS macros described in util-unittest.h


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
