### PR TITLE
util/unittest:Add PASS_IF_NULL macro to the FAIL/PASS API

### DIFF
--- a/src/util-unittest.h
+++ b/src/util-unittest.h
@@ -119,6 +119,17 @@ extern int unittests_fatal;
         PASS;              \
     } while (0)
 
+/**
+ * \brief Pass the test if expression evaluates to true.
+ *
+ * Only to be used at the end of a function instead of returning the
+ * result of an expression.
+ */
+#define PASS_IF_NULL(expr)                                                                         \
+    do {                                                                                           \
+        PASS_IF(NULL == expr);                                                                     \
+    } while (0)
+
 #endif /* __UTIL_UNITTEST_H__ */
 
 /**


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4066

Describe changes:
- Added PASS_IF_NULL macro to util-unittest.h
- pass if the value provided to it is NULL.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
