### PR TITLE
rust: fix rust build errors and warnings for rustc 1.24.1

### DIFF
--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -426,7 +426,7 @@ pub unsafe extern "C" fn rs_dhcp_register_parser() {
         get_tx_iterator: Some(rs_dhcp_state_get_tx_iterator),
         set_tx_detect_flags: None,
         get_tx_detect_flags: None,
-        flags              : crate::core::APP_LAYER_PARSER_OPT_UNIDIR_TXS,
+        flags              : core::APP_LAYER_PARSER_OPT_UNIDIR_TXS,
     };
 
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -687,7 +687,7 @@ pub unsafe extern "C" fn rs_register_ikev2_parser() {
         get_tx_iterator   : None,
         get_tx_detect_flags: None,
         set_tx_detect_flags: None,
-        flags              : crate::core::APP_LAYER_PARSER_OPT_UNIDIR_TXS,
+        flags              : core::APP_LAYER_PARSER_OPT_UNIDIR_TXS,
     };
 
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -647,7 +647,7 @@ pub unsafe extern "C" fn rs_register_krb5_parser() {
         get_tx_iterator   : None,
         get_tx_detect_flags: Some(rs_krb5_tx_detect_flags_get),
         set_tx_detect_flags: Some(rs_krb5_tx_detect_flags_set),
-        flags              : crate::core::APP_LAYER_PARSER_OPT_UNIDIR_TXS,
+        flags              : core::APP_LAYER_PARSER_OPT_UNIDIR_TXS,
     };
     // register UDP parser
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -15,7 +15,6 @@
  * 02110-1301, USA.
  */
 
-#![allow(ellipsis_inclusive_range_patterns)] // TODO: Remove when MSRV is higher than 1.24
 #![cfg_attr(feature = "strict", deny(warnings))]
 
 extern crate libc;

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -399,7 +399,7 @@ pub unsafe extern "C" fn rs_register_ntp_parser() {
         get_tx_iterator   : None,
         get_tx_detect_flags: None,
         set_tx_detect_flags: None,
-        flags              : crate::core::APP_LAYER_PARSER_OPT_UNIDIR_TXS,
+        flags              : core::APP_LAYER_PARSER_OPT_UNIDIR_TXS,
     };
 
     let ip_proto_str = CString::new("udp").unwrap();


### PR DESCRIPTION
- Builds for suricata fail with rustc 1.24.1 due to usage of `crate`
to specify the absolute path for the app-layer-parser with the errors:
    ```
    error[E0433]: `crate` can only be used in absolute paths
    error: `crate` in paths is experimental
    ```
   Modify relevant files to use relative paths instead.

- The build also gives the warning:
    ``` 
    warning: unknown lint: `ellipsis_inclusive_range_patterns`
    ```
   The builtin lint warning had been added to fix a deprecation warning
   for the `...` range patterns. However, as rustc 1.24.1 is no more
    supported as MSRV, the warning is unnecessary.

   Remove the lint "ellipsis_inclusive_range_patterns" for a cleaner build.

Fixes Bug ~#4064~
References :
- https://travis-ci.com/github/OISF/suricata/jobs/396870085
- https://github.com/OISF/suricata/commit/882237cead8b39120da1ac4db726b923f2a705aa

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4064

Describe changes:
- Remove crate from absolute path, and therefore, use relative path for the app-layer-parser.
- Remove the lint, `ellipsis_inclusive_range_patterns`.

Changes from v1 -> v2 :
   - Add a separate commit to remove build warning for unknown lint.
