### PR TITLE
Next/41x/20201016/v1

### DIFF
--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1156,11 +1156,13 @@ impl SMBState {
     {
         let mut post_gap_txs = false;
         for tx in &mut self.transactions {
-            if let Some(SMBTransactionTypeData::FILE(ref f)) = tx.type_data {
+            if let Some(SMBTransactionTypeData::FILE(ref mut f)) = tx.type_data {
                 if f.post_gap_ts > 0 {
                     if self.ts > f.post_gap_ts {
                         tx.request_done = true;
                         tx.response_done = true;
+                        let (files, flags) = self.files.get(f.direction);
+                        f.file_tracker.trunc(files, flags);
                     } else {
                         post_gap_txs = true;
                     }

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -786,6 +786,7 @@ pub struct SMBState<> {
     /// true as long as we have file txs that are in a post-gap
     /// state. It means we'll do extra house keeping for those.
     check_post_gap_file_txs: bool,
+    post_gap_files_checked: bool,
 
     /// transactions list
     pub transactions: Vec<SMBTransaction>,
@@ -832,6 +833,7 @@ impl SMBState {
             ts_trunc: false,
             tc_trunc: false,
             check_post_gap_file_txs: false,
+            post_gap_files_checked: false,
             transactions: Vec::new(),
             tx_id:0,
             dialect:0,
@@ -932,6 +934,7 @@ impl SMBState {
     fn update_ts(&mut self, ts: u64) {
         if ts != self.ts {
             self.ts = ts;
+            self.post_gap_files_checked = false;
         }
     }
 
@@ -1504,8 +1507,9 @@ impl SMBState {
         };
 
         self.post_gap_housekeeping(STREAM_TOSERVER);
-        if self.check_post_gap_file_txs {
+        if self.check_post_gap_file_txs && !self.post_gap_files_checked {
             self.post_gap_housekeeping_for_files();
+            self.post_gap_files_checked = true;
         }
         0
     }
@@ -1734,8 +1738,9 @@ impl SMBState {
             }
         };
         self.post_gap_housekeeping(STREAM_TOCLIENT);
-        if self.check_post_gap_file_txs {
+        if self.check_post_gap_file_txs && !self.post_gap_files_checked {
             self.post_gap_housekeeping_for_files();
+            self.post_gap_files_checked = true;
         }
         self._debug_tx_stats();
         0

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -929,6 +929,12 @@ impl SMBState {
         return None;
     }
 
+    fn update_ts(&mut self, ts: u64) {
+        if ts != self.ts {
+            self.ts = ts;
+        }
+    }
+
     /* generic TX has no type_data and is only used to
      * track a single cmd request/reply pair. */
 
@@ -1847,7 +1853,7 @@ pub extern "C" fn rs_smb_parse_request_tcp(flow: &mut Flow,
         state.ts_gap = true;
     }
 
-    state.ts = flow.get_last_time().as_secs();
+    state.update_ts(flow.get_last_time().as_secs());
     if state.parse_tcp_data_ts(buf) == 0 {
         return 1;
     } else {
@@ -1886,7 +1892,7 @@ pub extern "C" fn rs_smb_parse_response_tcp(flow: &mut Flow,
         state.tc_gap = true;
     }
 
-    state.ts = flow.get_last_time().as_secs();
+    state.update_ts(flow.get_last_time().as_secs());
     if state.parse_tcp_data_tc(buf) == 0 {
         return 1;
     } else {


### PR DESCRIPTION
SMB performance backports.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
