### PR TITLE
Task 4053, convert unit tests to FAIL/PASS API

### DIFF
--- a/src/detect-msg.c
+++ b/src/detect-msg.c
@@ -125,89 +125,66 @@ error:
 #ifdef UNITTESTS
 static int DetectMsgParseTest01(void)
 {
-    int result = 0;
     Signature *sig = NULL;
     const char *teststringparsed = "flow stateless to_server";
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
+    FAIL_IF_NULL(de_ctx);
 
     FILE *fd = SCClassConfGenerateValidDummyClassConfigFD01();
     SCClassConfLoadClassficationConfigFile(de_ctx, fd);
 
     sig = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"flow stateless to_server\"; flow:stateless,to_server; content:\"flowstatelesscheck\"; classtype:bad-unknown; sid: 40000002; rev: 1;)");
-    if(sig == NULL)
-        goto end;
+    FAIL_IF_NULL(sig);
 
-    if (strcmp(sig->msg, teststringparsed) != 0) {
-        printf("got \"%s\", expected: \"%s\": ", sig->msg, teststringparsed);
-        goto end;
-    }
+    FAIL_IF(strcmp(sig->msg, teststringparsed) != 0);
 
-    result = 1;
-end:
     if (sig != NULL)
         SigFree(de_ctx, sig);
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
-    return result;
+
+    PASS;
 }
 
 static int DetectMsgParseTest02(void)
 {
-    int result = 0;
     Signature *sig = NULL;
     const char *teststringparsed = "msg escape tests wxy'\"\\;:";
-    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
+    FAIL_IF_NULL(de_ctx);
 
     sig = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"msg escape tests \\w\\x\\y\\'\\\"\\\\;\\:\"; flow:to_server,established; content:\"blah\"; uricontent:\"/blah/\"; sid: 100;)");
-    if(sig == NULL)
-        goto end;
+    FAIL_IF_NULL(sig);
 
-    if (strcmp(sig->msg, teststringparsed) != 0) {
-        printf("got \"%s\", expected: \"%s\": ",sig->msg, teststringparsed);
-        goto end;
-    }
+    FAIL_IF(strcmp(sig->msg, teststringparsed) != 0);
 
-    result = 1;
-end:
     if (sig != NULL)
         SigFree(de_ctx, sig);
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
-    return result;
+    PASS;
 }
 
 static int DetectMsgParseTest03(void)
 {
-    int result = 0;
     Signature *sig = NULL;
     const char *teststringparsed = "flow stateless to_server";
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
+
+    FAIL_IF_NULL(de_ctx);
 
     FILE *fd = SCClassConfGenerateValidDummyClassConfigFD01();
     SCClassConfLoadClassficationConfigFile(de_ctx, fd);
 
     sig = SigInit(de_ctx, "alert tcp any any -> any any (msg: \"flow stateless to_server\"; flow:stateless,to_server; content:\"flowstatelesscheck\"; classtype:bad-unknown; sid: 40000002; rev: 1;)");
-    if(sig == NULL)
-        goto end;
+    FAIL_IF_NULL(sig);
 
-    if (strcmp(sig->msg, teststringparsed) != 0) {
-        printf("got \"%s\", expected: \"%s\": ", sig->msg, teststringparsed);
-        goto end;
-    }
+    FAIL_IF(strcmp(sig->msg, teststringparsed) != 0);
 
-    result = 1;
-end:
     if (sig != NULL)
         SigFree(de_ctx, sig);
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
-    return result;
+    PASS;
 }
 
 /**


### PR DESCRIPTION
src/detect-msg.c - Converted statements like "if()... go to end" to the new FAIL/PASS style.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4053

Describe changes:
- in src/detect-msg.c converted the applicable pieces of code to be compatible with the FAIL/PASS API, deleting variables when and if they would be no longer needed after the change.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
