### PR TITLE
Rust: generic files definition

### DIFF
--- a/rust/src/filecontainer.rs
+++ b/rust/src/filecontainer.rs
@@ -25,6 +25,39 @@ extern {
     pub fn FileFlowToFlags(flow: *const Flow, flags: u8) -> u16;
 }
 
+// Generic file structure, so it can be used by different protocols
+#[derive(Debug)]
+pub struct Files {
+    pub files_ts: FileContainer,
+    pub files_tc: FileContainer,
+    pub flags_ts: u16,
+    pub flags_tc: u16,
+}
+
+impl Files {
+    pub fn new() -> Files {
+        Files {
+            files_ts:FileContainer::default(),
+            files_tc:FileContainer::default(),
+            flags_ts:0,
+            flags_tc:0,
+        }
+    }
+    pub fn free(&mut self) {
+        self.files_ts.free();
+        self.files_tc.free();
+    }
+
+    pub fn get(&mut self, direction: u8) -> (&mut FileContainer, u16)
+    {
+        if direction == STREAM_TOSERVER {
+            (&mut self.files_ts, self.flags_ts)
+        } else {
+            (&mut self.files_tc, self.flags_tc)
+        }
+    }
+}
+
 pub struct File;
 #[repr(C)]
 #[derive(Debug)]

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -259,38 +259,6 @@ impl NFSRequestXidMap {
     }
 }
 
-#[derive(Debug)]
-pub struct NFSFiles {
-    pub files_ts: FileContainer,
-    pub files_tc: FileContainer,
-    pub flags_ts: u16,
-    pub flags_tc: u16,
-}
-
-impl NFSFiles {
-    pub fn new() -> NFSFiles {
-        NFSFiles {
-            files_ts:FileContainer::default(),
-            files_tc:FileContainer::default(),
-            flags_ts:0,
-            flags_tc:0,
-        }
-    }
-    pub fn free(&mut self) {
-        self.files_ts.free();
-        self.files_tc.free();
-    }
-
-    pub fn get(&mut self, direction: u8) -> (&mut FileContainer, u16)
-    {
-        if direction == STREAM_TOSERVER {
-            (&mut self.files_ts, self.flags_ts)
-        } else {
-            (&mut self.files_tc, self.flags_tc)
-        }
-    }
-}
-
 /// little wrapper around the FileTransferTracker::new_chunk method
 pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContainer,
         flags: u16, name: &Vec<u8>, data: &[u8],
@@ -315,7 +283,7 @@ pub struct NFSState {
     /// transactions list
     pub transactions: Vec<NFSTransaction>,
 
-    pub files: NFSFiles,
+    pub files: Files,
 
     /// partial record tracking
     pub ts_chunk_xid: u32,
@@ -358,7 +326,7 @@ impl NFSState {
             requestmap:HashMap::new(),
             namemap:HashMap::new(),
             transactions: Vec::new(),
-            files:NFSFiles::new(),
+            files:Files::new(),
             ts_chunk_xid:0,
             tc_chunk_xid:0,
             ts_chunk_left:0,

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -47,39 +47,6 @@ impl SMBTransactionFile {
     }
 }
 
-/// Wrapper around Suricata's internal file container logic.
-#[derive(Debug)]
-pub struct SMBFiles {
-    pub files_ts: FileContainer,
-    pub files_tc: FileContainer,
-    pub flags_ts: u16,
-    pub flags_tc: u16,
-}
-
-impl SMBFiles {
-    pub fn new() -> SMBFiles {
-        SMBFiles {
-            files_ts:FileContainer::default(),
-            files_tc:FileContainer::default(),
-            flags_ts:0,
-            flags_tc:0,
-        }
-    }
-    pub fn free(&mut self) {
-        self.files_ts.free();
-        self.files_tc.free();
-    }
-
-    pub fn get(&mut self, direction: u8) -> (&mut FileContainer, u16)
-    {
-        if direction == STREAM_TOSERVER {
-            (&mut self.files_ts, self.flags_ts)
-        } else {
-            (&mut self.files_tc, self.flags_tc)
-        }
-    }
-}
-
 /// little wrapper around the FileTransferTracker::new_chunk method
 pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContainer,
         flags: u16, name: &Vec<u8>, data: &[u8],

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -37,6 +37,7 @@ use nom;
 use crate::core::*;
 use crate::applayer;
 use crate::applayer::{AppLayerResult, AppLayerTxData};
+use crate::filecontainer::*;
 
 use crate::smb::nbss_records::*;
 use crate::smb::smb1_records::*;
@@ -755,7 +756,7 @@ pub struct SMBState<> {
     // requests for DCERPC.
     pub ssnguid2vec_map: HashMap<SMBHashKeyHdrGuid, Vec<u8>>,
 
-    pub files: SMBFiles,
+    pub files: Files,
 
     skip_ts: u32,
     skip_tc: u32,
@@ -808,7 +809,7 @@ impl SMBState {
             ssn2vecoffset_map:HashMap::new(),
             ssn2tree_map:HashMap::new(),
             ssnguid2vec_map:HashMap::new(),
-            files: SMBFiles::new(),
+            files: Files::new(),
             skip_ts:0,
             skip_tc:0,
             file_ts_left:0,


### PR DESCRIPTION
Issue: Optimization 3825
- filecontainer: add Files structure, to replace/unify SMBFiles
 and NFSFiles
- smb/files: delete SMBFiles implementation
- smb/smb: replace SMBFiles with Files
- nfs/nfs: delete NFSFiles implementation, replace its former
 declarations with Files' ones

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3825

Link to previous PR:
https://github.com/OISF/suricata/pull/5511

Describe changes:
- filecontainer: add Files structure, to replace/unify SMBFiles  and NFSFiles
- smb/files: delete SMBFiles implementation 
- smb/smb: replace SMBFiles with Files
- nfs/nfs: delete NFSFiles implementation, replace its former declarations with Files' ones
- squash commits to keep things clean


[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
