### PR TITLE
readthedocs: Replace dead link from public-data-sets.rst

### DIFF
--- a/doc/userguide/public-data-sets.rst
+++ b/doc/userguide/public-data-sets.rst
@@ -3,7 +3,7 @@ Public Data Sets
 
 Collections of pcaps for testing and profiling.
 
-DARPA sets: http://www.ll.mit.edu/mission/communications/cyber/CSTcorpora/ideval/data/
+DARPA sets: https://www.ll.mit.edu/r-d/datasets?author=All&rdarea=All&rdgroup=All&keywords=cyber&tag=All&items_per_page=10
 
 MAWI sets (pkt headers only, no payloads): http://mawi.wide.ad.jp/mawi/samplepoint-F/2012/
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- On ll.mit.edu it is not possible to find any dataset in cyber section (or any section that would give plausible data).
- Site mawi.wide.ad.jp is dead