### PR TITLE
Prelude: Fix #3763 and #4065 (Redmine tickets)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1192,7 +1192,7 @@
     CFLAGS="${CFLAGS} -Wno-error=unused-result"
 
     AS_IF([test "x$enable_prelude" = "xyes"], [
-        AM_PATH_LIBPRELUDE(0.9.9, , AC_MSG_ERROR(Cannot find libprelude: Is libprelude-config in the path?), no)
+        AM_LIBPRELUDE(4.0.0, , AC_MSG_ERROR(Cannot find libprelude: Is libprelude-config in the path?), no)
         if test "x${LIBPRELUDE_CFLAGS}" != "x"; then
             CPPFLAGS="${CPPFLAGS} ${LIBPRELUDE_CFLAGS}"
         fi

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
     AC_INIT([suricata],[7.0.0-dev])
     m4_ifndef([AM_SILENT_RULES], [m4_define([AM_SILENT_RULES],[])])AM_SILENT_RULES([yes])
-    AC_CONFIG_HEADERS([src/autoconf.h])
+    AC_CONFIG_HEADERS([src/config.h])
     AC_CONFIG_SRCDIR([src/suricata.c])
     AC_CONFIG_MACRO_DIR(m4)
     AM_INIT_AUTOMAKE([tar-ustar subdir-objects])

--- a/m4/libprelude.m4
+++ b/m4/libprelude.m4
@@ -1,71 +1,50 @@
 dnl Autoconf macros for libprelude
 dnl $id$
 
+# Modified for LIBPRELUDE -- Thomas Andrejak
 # Modified for LIBPRELUDE -- Yoann Vandoorselaere
 # Modified for LIBGNUTLS -- nmav
 # Configure paths for LIBGCRYPT
 # Shamelessly stolen from the one of XDELTA by Owen Taylor
 # Werner Koch   99-12-09
 
-dnl AM_PATH_LIBPRELUDE([MINIMUM-VERSION, [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND ]]], THREAD_SUPPORT)
+dnl AM_LIBPRELUDE([MINIMUM-VERSION, [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND ]]], THREAD_SUPPORT)
 dnl Test for libprelude, and define LIBPRELUDE_PREFIX, LIBPRELUDE_CFLAGS, LIBPRELUDE_PTHREAD_CFLAGS,
 dnl LIBPRELUDE_LDFLAGS, and LIBPRELUDE_LIBS
 dnl
-AC_DEFUN([AM_PATH_LIBPRELUDE],
+AC_DEFUN([AM_LIBPRELUDE],
 [dnl
-dnl Get the cflags and libraries from the libprelude-config script
+dnl Get the cflags and libraries from the pkg-config file
 dnl
-AC_ARG_WITH(libprelude-prefix, AC_HELP_STRING(--with-libprelude-prefix=PFX,
-            Prefix where libprelude is installed (optional)),
-            libprelude_config_prefix="$withval", libprelude_config_prefix="")
-
-  if test x$libprelude_config_prefix != x ; then
-     if test x${LIBPRELUDE_CONFIG+set} != xset ; then
-        LIBPRELUDE_CONFIG=$libprelude_config_prefix/bin/libprelude-config
-     fi
-  fi
-
-  AC_PATH_PROG(LIBPRELUDE_CONFIG, libprelude-config, no)
-  if test "$LIBPRELUDE_CONFIG" != "no"; then
-	if $($LIBPRELUDE_CONFIG --thread > /dev/null 2>&1); then
-		LIBPRELUDE_PTHREAD_CFLAGS=`$LIBPRELUDE_CONFIG --thread --cflags`
-
-		if test x$4 = xtrue || test x$4 = xyes; then
-			libprelude_config_args="--thread"
-		else
-			libprelude_config_args="--no-thread"
-		fi
-	else
-		LIBPRELUDE_PTHREAD_CFLAGS=`$LIBPRELUDE_CONFIG --pthread-cflags`
-	fi
-  fi
-
-  min_libprelude_version=ifelse([$1], ,0.1.0,$1)
-  AC_MSG_CHECKING(for libprelude - version >= $min_libprelude_version)
+AC_ARG_ENABLE(libprelude, AC_HELP_STRING(--enable-libprelude, Define whether LibPrelude is required), libprelude_required="yes", enable_libprelude="yes")
+if test x$enable_libprelude = xyes; then
   no_libprelude=""
-  if test "$LIBPRELUDE_CONFIG" = "no" ; then
-    no_libprelude=yes
+  min_libprelude_version=ifelse([$1], ,0.1.0,$1)
+  PKG_CHECK_MODULES([LIBPRELUDE], [libprelude >= $min_libprelude_version],
+     [AC_CHECK_HEADER(libprelude/prelude.h, enable_libprelude=yes, enable_libprelude=no)],
+     [enable_libprelude=no])
+  if test "x$enable_libprelude" = xno ; then
+    no_libprelude="no"
+    ifelse([$3], , :, [$3])
   else
-    LIBPRELUDE_CFLAGS=`$LIBPRELUDE_CONFIG $libprelude_config_args --cflags`
-    LIBPRELUDE_LDFLAGS=`$LIBPRELUDE_CONFIG $libprelude_config_args --ldflags`
-    LIBPRELUDE_LIBS=`$LIBPRELUDE_CONFIG $libprelude_config_args --libs`
-    LIBPRELUDE_PREFIX=`$LIBPRELUDE_CONFIG $libprelude_config_args --prefix`
-    LIBPRELUDE_CONFIG_PREFIX=`$LIBPRELUDE_CONFIG $libprelude_config_args --config-prefix`
-    libprelude_config_version=`$LIBPRELUDE_CONFIG $libprelude_config_args --version`
+    AC_MSG_CHECKING(libprelude $min_libprelude_version usability)
+  
+    LIBPRELUDE_PREFIX=`pkg-config libprelude --variable=prefix`
+    LIBPRELUDE_CONFIG_PREFIX=`pkg-config libprelude --variable=configprefix`
+    libprelude_config_version=`pkg-config libprelude --modversion`
 
-
-      ac_save_CFLAGS="$CFLAGS"
-      ac_save_LDFLAGS="$LDFLAGS"
-      ac_save_LIBS="$LIBS"
-      CFLAGS="$CFLAGS $LIBPRELUDE_CFLAGS"
-      LDFLAGS="$LDFLAGS $LIBPRELUDE_LDFLAGS"
-      LIBS="$LIBS $LIBPRELUDE_LIBS"
+    ac_save_CFLAGS="$CFLAGS"
+    ac_save_LDFLAGS="$LDFLAGS"
+    ac_save_LIBS="$LIBS"
+    CFLAGS="$CFLAGS $LIBPRELUDE_CFLAGS"
+    LDFLAGS="$LDFLAGS $LIBPRELUDE_LDFLAGS"
+    LIBS="$LIBS $LIBPRELUDE_LIBS"
 dnl
 dnl Now check if the installed libprelude is sufficiently new. Also sanity
 dnl checks the results of libprelude-config to some extent
 dnl
-      rm -f conf.libpreludetest
-      AC_TRY_RUN([
+     rm -f conf.libpreludetest
+     AC_TRY_RUN([
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -78,16 +57,10 @@ main ()
 
     if( strcmp( prelude_check_version(NULL), "$libprelude_config_version" ) )
     {
-      printf("\n*** 'libprelude-config --version' returned %s, but LIBPRELUDE (%s)\n",
+      printf("\n*** 'pkg-config libprelude --modversion' returned %s, but LIBPRELUDE (%s)\n",
              "$libprelude_config_version", prelude_check_version(NULL) );
-      printf("*** was found! If libprelude-config was correct, then it is best\n");
-      printf("*** to remove the old version of LIBPRELUDE. You may also be able to fix the error\n");
-      printf("*** by modifying your LD_LIBRARY_PATH enviroment variable, or by editing\n");
-      printf("*** /etc/ld.so.conf. Make sure you have run ldconfig if that is\n");
-      printf("*** required on your system.\n");
-      printf("*** If libprelude-config was wrong, set the environment variable LIBPRELUDE_CONFIG\n");
-      printf("*** to point to the correct copy of libprelude-config, and remove the file config.cache\n");
-      printf("*** before re-running configure\n");
+      printf("*** was found! If pkg-config was correct, then it is best\n");
+      printf("*** to remove the old version of LIBPRELUDE.\n");
     }
     else if ( strcmp(prelude_check_version(NULL), LIBPRELUDE_VERSION ) ) {
         printf("\n*** LIBPRELUDE header file (version %s) does not match\n", LIBPRELUDE_VERSION);
@@ -101,43 +74,28 @@ main ()
                 prelude_check_version(NULL) );
         printf("*** You need a version of LIBPRELUDE newer than %s. The latest version of\n",
                "$min_libprelude_version" );
-        printf("*** LIBPRELUDE is always available from http://www.prelude-siem.com/index.php/en/community/download\n");
+        printf("*** LIBPRELUDE is always available from https://www.prelude-siem.org/project/prelude/files\n");
         printf("*** \n");
         printf("*** If you have already installed a sufficiently new version, this error\n");
-        printf("*** probably means that the wrong copy of the libprelude-config shell script is\n");
-        printf("*** being found. The easiest way to fix this is to remove the old version\n");
-        printf("*** of LIBPRELUDE, but you can also set the LIBPRELUDE_CONFIG environment to point to the\n");
-        printf("*** correct copy of libprelude-config. (In this case, you will have to\n");
-        printf("*** modify your LD_LIBRARY_PATH enviroment variable, or edit /etc/ld.so.conf\n");
-        printf("*** so that the correct libraries are found at run-time))\n");
+        printf("*** probably means that the wrong copy of the libprelude pkg-config file is\n");
+        printf("*** being found.\n");
       }
     }
     return 1;
 }
 ],, no_libprelude=yes,[echo $ac_n "cross compiling; assumed OK... $ac_c"])
-       CFLAGS="$ac_save_CFLAGS"
-       LIBS="$ac_save_LIBS"
-       LDFLAGS="$ac_save_LDFLAGS"
-  fi
+    CFLAGS="$ac_save_CFLAGS"
+    LIBS="$ac_save_LIBS"
+    LDFLAGS="$ac_save_LDFLAGS"
 
-  if test "x$no_libprelude" = x ; then
-     AC_MSG_RESULT(yes)
-     ifelse([$2], , :, [$2])
-  else
-     if test -f conf.libpreludetest ; then
-        :
-     else
-        AC_MSG_RESULT(no)
-     fi
-     if test "$LIBPRELUDE_CONFIG" = "no" ; then
-       echo "*** The libprelude-config script installed by LIBPRELUDE could not be found"
-       echo "*** If LIBPRELUDE was installed in PREFIX, make sure PREFIX/bin is in"
-       echo "*** your path, or set the LIBPRELUDE_CONFIG environment variable to the"
-       echo "*** full path to libprelude-config."
-     else
+    if test "x$no_libprelude" = x ; then
+       AC_MSG_RESULT(yes)
+       ifelse([$2], , :, [$2])
+    else
        if test -f conf.libpreludetest ; then
         :
        else
+          AC_MSG_RESULT(no)
           echo "*** Could not run libprelude test program, checking why..."
           CFLAGS="$CFLAGS $LIBPRELUDE_CFLAGS"
           LDFLAGS="$LDFLAGS $LIBPRELUDE_LDFLAGS"
@@ -162,28 +120,32 @@ main ()
           echo "*** exact error that occured. This usually means LIBPRELUDE was incorrectly installed"
           echo "*** or that you have moved LIBPRELUDE since it was installed. In the latter case, you"
           echo "*** may want to edit the libprelude-config script: $LIBPRELUDE_CONFIG" ])
-          CFLAGS="$ac_save_CFLAGS"
-          LDFLAGS="$ac_save_LDFLAGS"
-          LIBS="$ac_save_LIBS"
+           CFLAGS="$ac_save_CFLAGS"
+           LDFLAGS="$ac_save_LDFLAGS"
+           LIBS="$ac_save_LIBS"
        fi
-     fi
-     LIBPRELUDE_CFLAGS=""
-     LIBPRELUDE_LDFLAGS=""
-     LIBPRELUDE_LIBS=""
-     ifelse([$3], , :, [$3])
+       LIBPRELUDE_CFLAGS=""
+       LIBPRELUDE_LDFLAGS=""
+       LIBPRELUDE_LIBS=""
+       ifelse([$3], , :, [$3])
+    fi
+    rm -f conf.libpreludetest
+    AC_SUBST(LIBPRELUDE_CFLAGS)
+    AC_SUBST(LIBPRELUDE_PTHREAD_CFLAGS)
+    AC_SUBST(LIBPRELUDE_LDFLAGS)
+    AC_SUBST(LIBPRELUDE_LIBS)
+    AC_SUBST(LIBPRELUDE_PREFIX)
+    AC_SUBST(LIBPRELUDE_CONFIG_PREFIX)
   fi
-  rm -f conf.libpreludetest
-  AC_SUBST(LIBPRELUDE_CFLAGS)
-  AC_SUBST(LIBPRELUDE_PTHREAD_CFLAGS)
-  AC_SUBST(LIBPRELUDE_LDFLAGS)
-  AC_SUBST(LIBPRELUDE_LIBS)
-  AC_SUBST(LIBPRELUDE_PREFIX)
-  AC_SUBST(LIBPRELUDE_CONFIG_PREFIX)
 
   m4_ifdef([LT_INIT],
            [AC_DEFINE([PRELUDE_APPLICATION_USE_LIBTOOL2], [], [Define whether application use libtool >= 2.0])],
            [])
 
+  if test x$enable_libprelude = xno && test x$libprelude_required = xyes; then
+     AC_MSG_ERROR([Could not find libprelude library])
+  fi
+fi
 ])
 
 dnl *-*wedit:notab*-*  Please keep this as the last line.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,7 +53,7 @@ noinst_HEADERS = \
 	app-layer-template.h \
 	app-layer-template-rust.h \
 	app-layer-tftp.h \
-	autoconf.h \
+	config.h \
 	build-info.h \
 	conf.h \
 	conf-yaml-loader.h \

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -37,7 +37,7 @@
 #define __USE_GNU
 
 #if HAVE_CONFIG_H
-#include <autoconf.h>
+#include <config.h>
 #endif
 
 #ifndef CLS

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -18,7 +18,7 @@
 #ifndef __SURICATA_PLUGIN_H__
 #define __SURICATA_PLUGIN_H__
 
-#include "autoconf.h"
+#include "config.h"
 
 #include <stdint.h>
 #include <stdbool.h>

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -54,7 +54,7 @@
 #include <bpf/libbpf.h>
 #include <bpf/bpf.h>
 #include <net/if.h>
-#include "autoconf.h"
+#include "config.h"
 
 #define BPF_MAP_MAX_COUNT 16
 


### PR DESCRIPTION
Describe changes:
- #4065 : Fix missing file config.h
      Since 900f1522b444e8391250683d48855ceb3d23f225 , HAVE_CONFIG_H is defined but config.h is not available.
- #3763 : Update from libjansson to JsonBuilder when getting information from output-json-http for example.
      JsonBuilder does not provides functions to access JSON data. Loading it with libjansson and access data.
- Update m4/libprelude.m4 to detect libprelude through pkg-config because libprelude-config is deprecated