### PR TITLE
scripts: bundle script for requirements - v1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+libhtp https://github.com/OISF/libhtp/archive/0.5.x.tar.gz
+suricata-update https://github.com/OISF/suricata-update/archive/master.tar.gz

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -1,0 +1,21 @@
+#! /usr/bin/env bash
+
+while IFS= read -r requirement; do
+    set -- $requirement
+    case "$1" in
+        suricata-update)
+            echo "===> Fetching $1"
+            (cd suricata-update &&
+                 curl -Ls "$2" | tar zxf - --strip-components=1)
+            ;;
+        libhtp)
+            echo "===> Fetching $1"
+            mkdir -p libhtp
+            (cd libhtp &&
+                 curl -Ls "$2" | tar zxf - --strip-components=1)
+            ;;
+        *)
+            echo "error: unknown requirement: $1"
+            ;;
+    esac
+done < ./requirements.txt


### PR DESCRIPTION
Add a bundle.sh script to bundle the requirements of libhtp
and suricata-update. This uses a Python like requirements.txt
file to specify the URL to download for libhtp and suricata-update.

Also testing the unversioned-python/v2 suricata-verify branch...

suricata-verify-repo: https://github.com/jasonish/suricata-verify
suricata-verify-branch: unversioned-python/v2
