### PR TITLE
tools: bash from env (version 3)

### DIFF
--- a/scripts/check-setup.sh
+++ b/scripts/check-setup.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Script to clang-format suricata C code changes
 #

--- a/scripts/setup-decoder.sh
+++ b/scripts/setup-decoder.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Script to setup a new decoder.
 # Written by Victor Julien <victor@inliniac.net>

--- a/scripts/setup-simple-detect.sh
+++ b/scripts/setup-simple-detect.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Script to setup a new 'simple' detect module.
 # Written by Victor Julien <victor@inliniac.net>

--- a/scripts/setup-simple-detect2.sh
+++ b/scripts/setup-simple-detect2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Script to setup a new 'simple' detect module.
 # Written by Victor Julien <victor@inliniac.net>


### PR DESCRIPTION
Use of hardcoded bash prevents users from using an upgraded bash which may
live in a different location. This behavior is often seen on OSX systems.

Utilize env to find the preferred bash to call for scripts.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Utilize env to find bash
-
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
