### PR TITLE
dns: parse SRV records - v2

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -422,6 +422,14 @@ More complex DNS record types may log additional fields for resource data:
   * "algo": Algorithm number (ex: 1 for RSA, 2 for DSS)
   * "type": Fingerprint type (ex: 1 for SHA-1)
 
+* "srv": section containing fields for the SRV (location of services) record type
+
+  * "target": Domain name of the target host (ex: ``foo.bar.baz``)
+  * "priority": Target priority (ex: 20)
+  * "weight": Weight for target selection (ex: 1)
+  * "port": Port on this target host of this service (ex: 5060)
+  * "raw": Raw resource data bytes (e.g. for DNS tunneling detection)
+
 One can control which RR types are logged by using the "types" field in the
 suricata.yaml file. If this field is not specified, all RR types are logged.
 More than 50 values can be specified with this field as shown below:

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -259,6 +259,20 @@ pub struct DNSRDataSSHFP {
     pub fingerprint: Vec<u8>,
 }
 
+#[derive(Debug,PartialEq)]
+pub struct DNSRDataSRV {
+    /// Priority
+    pub priority: u16,
+    /// Weight
+    pub weight: u16,
+    /// Port
+    pub port: u16,
+    /// Target
+    pub target: Vec<u8>,
+    /// Raw value (for tunneling detection etc.)
+    pub raw: Vec<u8>,
+}
+
 /// Represents RData of various formats
 #[derive(Debug,PartialEq)]
 pub enum DNSRData {
@@ -275,6 +289,7 @@ pub enum DNSRData {
     NULL(Vec<u8>),
     // RData has several fields
     SOA(DNSRDataSOA),
+    SRV(DNSRDataSRV),
     SSHFP(DNSRDataSSHFP),
     // RData for remaining types is sometimes ignored
     Unknown(Vec<u8>),

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -199,6 +199,11 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
                     lua.pushstring(&String::from_utf8_lossy(&sshfp.fingerprint));
                     lua.settable(-3);
                 },
+                DNSRData::SRV(ref srv) => {
+                    lua.pushstring("addr");
+                    lua.pushstring(&String::from_utf8_lossy(&srv.target));
+                    lua.settable(-3);
+                },
             }
             lua.settable(-3);
         }

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -347,13 +347,9 @@ fn dns_parse_rdata_txt<'a>(input: &'a [u8])
     )
 }
 
-fn dns_parse_rdata_null<'a>(input: &'a [u8])
-                            -> IResult<&'a [u8], DNSRData> {
-    do_parse!(
-        input,
-        data: take!(input.len()) >>
-            (DNSRData::NULL(data.to_vec()))
-    )
+
+fn dns_parse_rdata_null<'a>(input: &'a [u8]) -> IResult<&'a [u8], DNSRData> {
+    rest(input).map(|(input, data)| (input, DNSRData::NULL(data.to_vec())))
 }
 
 fn dns_parse_rdata_sshfp<'a>(input: &'a [u8])

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -319,6 +319,24 @@ fn dns_parse_rdata_mx<'a>(input: &'a [u8], message: &'a [u8])
     )
 }
 
+fn dns_parse_rdata_srv<'a>(input: &'a [u8], message: &'a [u8])
+                             -> IResult<&'a [u8], DNSRData> {
+    do_parse!(
+        input,
+        priority: be_u16 >>
+        weight: be_u16 >>
+        port: be_u16 >>
+        target: call!(dns_parse_name, message) >>
+            (DNSRData::SRV(DNSRDataSRV{
+                priority,
+                weight,
+                port,
+                target,
+                raw: input.to_vec()
+            }))
+    )
+}
+
 fn dns_parse_rdata_txt<'a>(input: &'a [u8])
                            -> IResult<&'a [u8], DNSRData> {
     do_parse!(
@@ -372,6 +390,7 @@ pub fn dns_parse_rdata<'a>(input: &'a [u8], message: &'a [u8], rrtype: u16)
         DNS_RECORD_TYPE_TXT => dns_parse_rdata_txt(input),
         DNS_RECORD_TYPE_NULL => dns_parse_rdata_null(input),
         DNS_RECORD_TYPE_SSHFP => dns_parse_rdata_sshfp(input),
+        DNS_RECORD_TYPE_SRV => dns_parse_rdata_srv(input, message),
         _ => dns_parse_rdata_unknown(input),
     }
 }


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/5525

Describe changes (to previous PR):
- Remove `NS` and `NULL` handling.
- Restructure commits.
- Use `NS` parsing function using `rest()`.
