### PR TITLE
detect/iprep: convert to fail/pass api

### DIFF
--- a/src/detect-iprep.c
+++ b/src/detect-iprep.c
@@ -445,17 +445,14 @@ static int DetectIPRepTest01(void)
 {
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;
-    Signature *sig = NULL;
     FILE *fd = NULL;
-    int result = 0, r = 0;
     Packet *p = UTHBuildPacket((uint8_t *)"lalala", 6, IPPROTO_TCP);
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
 
     HostInitConfig(HOST_QUIET);
     memset(&th_v, 0, sizeof(th_v));
 
-    if (de_ctx == NULL || p == NULL)
-        goto end;
+    FAIL_IF(de_ctx == NULL || p == NULL);
 
     p->src.addr_data32[0] = UTHSetIPv4Address("10.0.0.1");
     de_ctx->flags |= DE_QUIET;
@@ -464,21 +461,17 @@ static int DetectIPRepTest01(void)
     SRepResetVersion();
 
     fd = DetectIPRepGenerateCategoriesDummy();
-    r = SRepLoadCatFileFromFD(fd);
-    if (r < 0) {
-        goto end;
-    }
+    int r = SRepLoadCatFileFromFD(fd);
+    FAIL_IF(r < 0);
 
     fd = DetectIPRepGenerateNetworksDummy();
     r = SRepLoadFileFromFD(de_ctx->srepCIDR_ctx, fd);
-    if (r < 0) {
-        goto end;
-    }
+    FAIL_IF(r < 0);
 
-    sig = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:any,BadHosts,>,1; sid:1;rev:1;)");
-    if (sig == NULL) {
-        goto end;
-    }
+    Signature *sig =
+            DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"IPREP High value "
+                                          "badhost\"; iprep:any,BadHosts,>,1; sid:1;rev:1;)");
+    FAIL_IF_NULL(sig);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
@@ -486,38 +479,29 @@ static int DetectIPRepTest01(void)
     p->alerts.cnt = 0;
     p->action = 0;
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    if (p->alerts.cnt != 1 || PACKET_TEST_ACTION(p, ACTION_DROP)) {
-        goto end;
-    }
+    FAIL_IF(p->alerts.cnt != 1 || PACKET_TEST_ACTION(p, ACTION_DROP));
 
-    result = 1;
-end:
     UTHFreePacket(p);
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
 
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
 
     HostShutdown();
-    return result;
+    PASS;
 }
 
 static int DetectIPRepTest02(void)
 {
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;
-    Signature *sig = NULL;
     FILE *fd = NULL;
-    int result = 0, r = 0;
     Packet *p = UTHBuildPacket((uint8_t *)"lalala", 6, IPPROTO_TCP);
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
 
     HostInitConfig(HOST_QUIET);
     memset(&th_v, 0, sizeof(th_v));
 
-    if (de_ctx == NULL || p == NULL)
-        goto end;
+    FAIL_IF(de_ctx == NULL || p == NULL);
 
     p->src.addr_data32[0] = UTHSetIPv4Address("10.0.0.1");
     de_ctx->flags |= DE_QUIET;
@@ -526,21 +510,17 @@ static int DetectIPRepTest02(void)
     SRepResetVersion();
 
     fd = DetectIPRepGenerateCategoriesDummy();
-    r = SRepLoadCatFileFromFD(fd);
-    if (r < 0) {
-        goto end;
-    }
+    int r = SRepLoadCatFileFromFD(fd);
+    FAIL_IF(r < 0);
 
     fd = DetectIPRepGenerateNetworksDummy();
     r = SRepLoadFileFromFD(de_ctx->srepCIDR_ctx, fd);
-    if (r < 0) {
-        goto end;
-    }
+    FAIL_IF(r < 0);
 
-    sig = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:src,BadHosts,>,1; sid:1; rev:1;)");
-    if (sig == NULL) {
-        goto end;
-    }
+    Signature *sig =
+            DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"IPREP High value "
+                                          "badhost\"; iprep:src,BadHosts,>,1; sid:1; rev:1;)");
+    FAIL_IF_NULL(sig);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
@@ -548,38 +528,29 @@ static int DetectIPRepTest02(void)
     p->alerts.cnt = 0;
     p->action = 0;
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    if (p->alerts.cnt != 1 || PACKET_TEST_ACTION(p, ACTION_DROP)) {
-        goto end;
-    }
+    FAIL_IF(p->alerts.cnt != 1 || PACKET_TEST_ACTION(p, ACTION_DROP));
 
-    result = 1;
-end:
     UTHFreePacket(p);
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
 
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
 
     HostShutdown();
-    return result;
+    PASS;
 }
 
 static int DetectIPRepTest03(void)
 {
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;
-    Signature *sig = NULL;
     FILE *fd = NULL;
-    int result = 0, r = 0;
     Packet *p = UTHBuildPacket((uint8_t *)"lalala", 6, IPPROTO_TCP);
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
 
     HostInitConfig(HOST_QUIET);
     memset(&th_v, 0, sizeof(th_v));
 
-    if (de_ctx == NULL || p == NULL)
-        goto end;
+    FAIL_IF(de_ctx == NULL || p == NULL);
 
     p->dst.addr_data32[0] = UTHSetIPv4Address("10.0.0.2");
     de_ctx->flags |= DE_QUIET;
@@ -588,21 +559,17 @@ static int DetectIPRepTest03(void)
     SRepResetVersion();
 
     fd = DetectIPRepGenerateCategoriesDummy();
-    r = SRepLoadCatFileFromFD(fd);
-    if (r < 0) {
-        goto end;
-    }
+    int r = SRepLoadCatFileFromFD(fd);
+    FAIL_IF(r < 0);
 
     fd = DetectIPRepGenerateNetworksDummy();
     r = SRepLoadFileFromFD(de_ctx->srepCIDR_ctx, fd);
-    if (r < 0) {
-        goto end;
-    }
+    FAIL_IF(r < 0);
 
-    sig = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:dst,BadHosts,>,1; sid:1; rev:1;)");
-    if (sig == NULL) {
-        goto end;
-    }
+    Signature *sig =
+            DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"IPREP High value "
+                                          "badhost\"; iprep:dst,BadHosts,>,1; sid:1; rev:1;)");
+    FAIL_IF_NULL(sig);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
@@ -610,38 +577,29 @@ static int DetectIPRepTest03(void)
     p->alerts.cnt = 0;
     p->action = 0;
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    if (p->alerts.cnt != 1 || PACKET_TEST_ACTION(p, ACTION_DROP)) {
-        goto end;
-    }
+    FAIL_IF(p->alerts.cnt != 1 || PACKET_TEST_ACTION(p, ACTION_DROP));
 
-    result = 1;
-end:
     UTHFreePacket(p);
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
 
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
 
     HostShutdown();
-    return result;
+    PASS;
 }
 
 static int DetectIPRepTest04(void)
 {
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;
-    Signature *sig = NULL;
     FILE *fd = NULL;
-    int result = 0, r = 0;
     Packet *p = UTHBuildPacket((uint8_t *)"lalala", 6, IPPROTO_TCP);
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
 
     HostInitConfig(HOST_QUIET);
     memset(&th_v, 0, sizeof(th_v));
 
-    if (de_ctx == NULL || p == NULL)
-        goto end;
+    FAIL_IF(de_ctx == NULL || p == NULL);
 
     p->src.addr_data32[0] = UTHSetIPv4Address("10.0.0.1");
     p->dst.addr_data32[0] = UTHSetIPv4Address("10.0.0.2");
@@ -651,21 +609,17 @@ static int DetectIPRepTest04(void)
     SRepResetVersion();
 
     fd = DetectIPRepGenerateCategoriesDummy();
-    r = SRepLoadCatFileFromFD(fd);
-    if (r < 0) {
-        goto end;
-    }
+    int r = SRepLoadCatFileFromFD(fd);
+    FAIL_IF(r < 0);
 
     fd = DetectIPRepGenerateNetworksDummy();
     r = SRepLoadFileFromFD(de_ctx->srepCIDR_ctx, fd);
-    if (r < 0) {
-        goto end;
-    }
+    FAIL_IF(r < 0);
 
-    sig = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:both,BadHosts,>,1; sid:1; rev:1;)");
-    if (sig == NULL) {
-        goto end;
-    }
+    Signature *sig =
+            DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"IPREP High value "
+                                          "badhost\"; iprep:both,BadHosts,>,1; sid:1; rev:1;)");
+    FAIL_IF_NULL(sig);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
@@ -673,21 +627,15 @@ static int DetectIPRepTest04(void)
     p->alerts.cnt = 0;
     p->action = 0;
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    if (p->alerts.cnt != 1 || PACKET_TEST_ACTION(p, ACTION_DROP)) {
-        goto end;
-    }
+    FAIL_IF(p->alerts.cnt != 1 || PACKET_TEST_ACTION(p, ACTION_DROP));
 
-    result = 1;
-end:
     UTHFreePacket(p);
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
 
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
 
     HostShutdown();
-    return result;
+    PASS;
 }
 
 static int DetectIPRepTest05(void)
@@ -943,17 +891,14 @@ static int DetectIPRepTest09(void)
 {
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;
-    Signature *sig = NULL;
     FILE *fd = NULL;
-    int result = 0, r = 0;
     Packet *p = UTHBuildPacket((uint8_t *)"lalala", 6, IPPROTO_TCP);
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
 
     HostInitConfig(HOST_QUIET);
     memset(&th_v, 0, sizeof(th_v));
 
-    if (de_ctx == NULL || p == NULL)
-        goto end;
+    FAIL_IF(de_ctx == NULL || p == NULL);
 
     p->src.addr_data32[0] = UTHSetIPv4Address("192.168.0.1");
     p->dst.addr_data32[0] = UTHSetIPv4Address("192.168.0.2");
@@ -963,21 +908,16 @@ static int DetectIPRepTest09(void)
     SRepResetVersion();
 
     fd = DetectIPRepGenerateCategoriesDummy2();
-    r = SRepLoadCatFileFromFD(fd);
-    if (r < 0) {
-        goto end;
-    }
+    int r = SRepLoadCatFileFromFD(fd);
+    FAIL_IF(r < 0);
 
     fd = DetectIPRepGenerateNetworksDummy2();
     r = SRepLoadFileFromFD(de_ctx->srepCIDR_ctx, fd);
-    if (r < 0) {
-        goto end;
-    }
+    FAIL_IF(r < 0);
 
-    sig = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"test\"; iprep:src,BadHosts,>,9; sid:1; rev:1;)");
-    if (sig == NULL) {
-        goto end;
-    }
+    Signature *sig = DetectEngineAppendSig(de_ctx,
+            "alert tcp any any -> any any (msg:\"test\"; iprep:src,BadHosts,>,9; sid:1; rev:1;)");
+    FAIL_IF_NULL(sig);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
@@ -985,21 +925,15 @@ static int DetectIPRepTest09(void)
     p->alerts.cnt = 0;
     p->action = 0;
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    if (p->alerts.cnt != 1 || PACKET_TEST_ACTION(p, ACTION_DROP)) {
-        goto end;
-    }
+    FAIL_IF(p->alerts.cnt != 1 || PACKET_TEST_ACTION(p, ACTION_DROP));
 
-    result = 1;
-end:
     UTHFreePacket(p);
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
 
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
 
     HostShutdown();
-    return result;
+    PASS;
 }
 
 /**


### PR DESCRIPTION
Issue 4048. WIP.
Convert unittests to FAIL/PASS API.
Replace SigInit with DetectEngineAppendSig.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4048

Describe changes:
- Convert unittests to FAIL/PASS API.
- Replace SigInit with DetectEngineAppendSig.

Submitting this as a draft because I'm not sure about how to proceed with methods:
- DetectIPrepTest05
- DetectIPrepTest06
- DetectIPrepTest07
- DetectIPrepTest08

So far, all tests I've seen followed a "return 1" logic for passing, as to say: "int result" would control the checks, and by the end, if no checks had failed, it would be 1, and that would be returned, so same as using PASS at the end of the method.

But for those four mentioned above, it seems that the method returns true if result is 0:
return result == 0

Does that mean that for these tests the logic is that they pass if the checks fail?

I have considered using
PASS_IF(result == 0)

at the end of the methods instead, but I am not confident this is enough to keep things as they should be, if I kept using the FAIL_IF macros in the body of those...

Thanks in advance...

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
