### PR TITLE
fuzz: adds fuzzing status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Suricata
 ========
 
+[![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/suricata.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:suricata)
+
 Introduction
 ------------
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- adds fuzzing status badge in README

I am not sure wether such badges are welcome, but I will know with this PR ;-)