### PR TITLE
github-ci: trim \r from pull request body before parsing - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -40,7 +40,7 @@ jobs:
           PR_HREF: ${{ github.event.pull_request._links.self.href }}
         run: |
           if test "${PR_HREF}"; then
-              body=$(curl -s "${PR_HREF}" | jq -r .body)
+              body=$(curl -s "${PR_HREF}" | jq -r .body | tr -d '\r')
               libhtp_repo=$(echo "${body}" | awk '/^libhtp-repo/ { print $2 }')
               libhtp_branch=$(echo "${body}" | awk '/^libhtp-branch/ { print $2 }')
               libhtp_pr=$(echo "${body}" | awk '/^libhtp-pr/ { print $2 }')


### PR DESCRIPTION
Allows variables like suricata-verify-pr to work again.
