### PR TITLE
[WIP] decoder: implement IEEE802.1BR

### DIFF
--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -146,6 +146,7 @@ enum {
     VLAN_HEADER_TOO_MANY_LAYERS,
 
     IEEE8021AH_HEADER_TOO_SMALL,
+    IEEE8021BR_HEADER_TOO_SMALL,
 
     /* RAW EVENTS */
     IPRAW_INVALID_IPV, /**< invalid ip version in ip raw */

--- a/src/decode-ieee8021br.c
+++ b/src/decode-ieee8021br.c
@@ -1,0 +1,93 @@
+/* Copyright (C) 2015-2018 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \ingroup decode
+ *
+ * @{
+ */
+
+
+/**
+ * \file
+ *
+ * \author XXX Sumera Priyadarsini <sylphrenadin@gmail.com>
+ *
+ * Decodes IEEE802.1BR 
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+#include "decode.h"
+#include "decode-events.h"
+#include "decode-ieee8021br.h"
+
+#define IEEE8021BR_HEADER_LEN sizeof(Ieee8021brHdr)
+/**
+ * \brief Function to decode IEEE8021BR packets
+ * \param tv thread vars
+ * \param dtv decoder thread vars
+ * \param p packet
+ * \param pkt raw packet data
+ * \param len length in bytes of pkt array
+ * \retval TM_ECODE_OK or TM_ECODE_FAILED on serious error
+ */
+
+int DecodeIEEE8021BR(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+                   const uint8_t *pkt, uint32_t len)
+{
+    StatsIncr(tv, dtv->counter_ieee8021br);
+
+    if (len < IEEE8021BR_HEADER_LEN) {
+        ENGINE_SET_INVALID_EVENT(p, IEEE8021BR_HEADER_TOO_SMALL);
+        return TM_ECODE_FAILED;
+    }
+
+    const Ieee8021brHdr *hdr = (const Ieee8021brHdr *)pkt;
+
+    const uint16_t next_proto = SCNtohs(hdr->pad1);
+
+    DecodeNetworkLayer(tv, dtv, next_proto, pkt + IEEE8021BR_HEADER_LEN,
+            len - IEEE8021BR_HEADER_LEN);
+
+    /* lets assume we have UDP encapsulated
+    if (hdr->proto == 17) {
+        /* we need to pass on the pkt and it's length minus the current
+         * header */
+        size_t hdr_len = sizeof(Ieee8021brHdr);
+        /* in this example it's clear that hdr_len can't be bigger than
+         * 'len', but in more complex cases checking that we can't underflow
+         * len is very important
+        if (hdr_len >= len) {
+            ENGINE_SET_EVENT(p,IEEE8021BR_MALFORMED_HDRLEN);
+            return TM_ECODE_FAILED;
+        }
+         */
+
+        /* invoke the next decoder on the remainder of the data 
+        return DecodeUDP(tv, dtv, p, (uint8_t *)pkt + hdr_len, len - hdr_len);
+    } else {
+        //ENGINE_SET_EVENT(p,IEEE8021BR_UNSUPPORTED_PROTOCOL);
+        return TM_ECODE_FAILED;
+    }*/
+
+    return TM_ECODE_OK;
+}
+
+/**
+ * @}
+ */

--- a/src/decode-ieee8021br.h
+++ b/src/decode-ieee8021br.h
@@ -1,0 +1,40 @@
+/* Copyright (C) 2015-2018 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author XXX
+ *
+ */
+
+#ifndef __DECODE_IEEE8021BR_H__
+#define __DECODE_IEEE8021BR_H__
+
+#include "decode.h"
+#include "threadvars.h"
+
+/* Header layout. Keep things like alignment and endianess in
+ * mind while constructing this. */
+
+typedef struct Ieee8021brHdr_ {
+    uint8_t proto;
+    uint8_t pad0;
+    uint16_t pad1;
+} __attribute__((__packed__)) Ieee8021brHdr;
+
+#endif /* __DECODE_IEEE8021BR_H__ */

--- a/src/decode.c
+++ b/src/decode.c
@@ -507,6 +507,7 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_vlan_qinq = StatsRegisterCounter("decoder.vlan_qinq", tv);
     dtv->counter_vxlan = StatsRegisterCounter("decoder.vxlan", tv);
     dtv->counter_ieee8021ah = StatsRegisterCounter("decoder.ieee8021ah", tv);
+    dtv->counter_ieee8021br = StatsRegisterCounter("decoder.ieee8021br", tv);
     dtv->counter_teredo = StatsRegisterCounter("decoder.teredo", tv);
     dtv->counter_ipv4inipv6 = StatsRegisterCounter("decoder.ipv4_in_ipv6", tv);
     dtv->counter_ipv6inipv6 = StatsRegisterCounter("decoder.ipv6_in_ipv6", tv);

--- a/src/decode.h
+++ b/src/decode.h
@@ -662,6 +662,7 @@ typedef struct DecodeThreadVars_
     uint16_t counter_vlan_qinq;
     uint16_t counter_vxlan;
     uint16_t counter_ieee8021ah;
+    uint16_t counter_ieee8021br;
     uint16_t counter_pppoe;
     uint16_t counter_teredo;
     uint16_t counter_mpls;
@@ -1245,6 +1246,9 @@ static inline bool DecodeNetworkLayer(ThreadVars *tv, DecodeThreadVars *dtv,
             break;
         case ETHERNET_TYPE_8021AH:
             DecodeIEEE8021ah(tv, dtv, p, data, len);
+            break;
+        case ETHERNET_TYPE_8021BR:
+            DecodeIEEE8021br(tv, dtv, p, data, len);
             break;
         case ETHERNET_TYPE_ARP:
             break;


### PR DESCRIPTION
Add packet decoder for 802.1BR E-tag.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3953?tab=history

Describe changes:
- Add decoder file, and header file to implement decode functionality.
- Update `decode.c` and `decode.h` to initiate and register counter.
- Update `decode-events.c` to add events for incompatible header.
