### PR TITLE
detect: apply transforms to http body

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -51,7 +51,7 @@ jobs:
 
               sv_repo=$(echo "${body}" | awk '/^suricata-verify-repo/ { print $2 }')
               sv_branch=$(echo "${body}" | awk '/^suricata-verify-branch/ { print $2 }')
-              sv_pr=$(echo "${body}" | awk '/^suricata-verify-pr/ { print $2 }')
+              sv_pr=$(echo "${body}" | awk '/^suricata-verify-pr/ { print $2 }' | tr -dc '0-9')
           fi
           echo "libhtp_repo=${libhtp_repo:-${DEFAULT_LIBHTP_REPO}}" >> $GITHUB_ENV
           echo "libhtp_branch=${libhtp_branch:-${DEFAULT_LIBHTP_BRANCH}}" >> $GITHUB_ENV

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -258,6 +258,7 @@ static InspectionBuffer *HttpClientBodyGetDataCallback(DetectEngineThreadCtx *de
     StreamingBufferGetDataAtOffset(body->sb,
             &data, &data_len, offset);
     InspectionBufferSetup(buffer, data, data_len);
+    InspectionBufferApplyTransforms(buffer, transforms);
     buffer->inspect_offset = offset;
 
     /* move inspected tracker to end of the data. HtpBodyPrune will consider


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2689

Describe changes:
- Support transforms for HTTP body

suricata-verify-pr: 362

https://github.com/OISF/suricata-verify/pull/362
Not sure if it is related to #5550 or what was the blocker there
