### PR TITLE
Napatech hba deprecation warning

### DIFF
--- a/doc/userguide/capture-hardware/napatech.rst
+++ b/doc/userguide/capture-hardware/napatech.rst
@@ -423,6 +423,9 @@ These are the Napatech options available in the Suricata configuration file::
     # (-1 = OFF, 1 - 100 = percentage of the host buffer that can be held back)
     # This may be enabled when sharing streams with another application.
     # Otherwise, it should be turned off.
+    #
+    # Note: hba will be deprecated in Suricata 7
+    #
     #hba: -1
 
     # When use_all_streams is set to "yes" the initialization code will query

--- a/src/runmode-napatech.c
+++ b/src/runmode-napatech.c
@@ -206,6 +206,9 @@ static void *NapatechConfigParser(const char *device)
      */
     if (ConfGetInt("napatech.hba", &conf->hba) == 0) {
         conf->hba = -1;
+    } else {
+        SCLogWarning(SC_WARN_COMPATIBILITY,
+                "Napatech Host Buffer Allocation (hba) will be deprecated in Suricata v7.0.");
     }
     return (void *) conf;
 }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1762,12 +1762,6 @@ ipfw:
 
 
 napatech:
-    # The Host Buffer Allowance for all streams
-    # (-1 = OFF, 1 - 100 = percentage of the host buffer that can be held back)
-    # This may be enabled when sharing streams with another application.
-    # Otherwise, it should be turned off.
-    #hba: -1
-
     # When use_all_streams is set to "yes" the initialization code will query
     # the Napatech service for all configured streams and listen on all of them.
     # When set to "no" the streams config array will be used.


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
-  Added warning that Host Buffer Allocation (HBA) is scheduled to be deprecated.
-  Removed HBA from default conf file.
-  Added a comment in the docs indicating that HBA is scheduled to be deprecated.

