### PR TITLE
dns eve v1 logging memory leak - v1

### DIFF
--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -116,7 +116,8 @@ outputs:
             # Default: all
             #answer-types: [a, aaaa, cname, mx, ns, ptr, txt]
         - dns:
-            # Version 1 (deprecated) DNS logger.
+            # Version 1 DNS logger.
+            # Deprecated: Will be removed by May 2022.
             version: 1
 
             enabled: no

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -381,6 +381,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
                 break;
             }
             jb_set_object(jb, "dns", answer);
+            jb_free(answer);
 
             MemBufferReset(td->buffer);
             OutputJsonBuilderBuffer(jb, td->file_ctx, &td->buffer);
@@ -401,6 +402,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
                 break;
             }
             jb_set_object(jb, "dns", answer);
+            jb_free(answer);
 
             MemBufferReset(td->buffer);
             OutputJsonBuilderBuffer(jb, td->file_ctx, &td->buffer);

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -270,6 +270,8 @@ typedef struct LogDnsLogThread_ {
     MemBuffer *buffer;
 } LogDnsLogThread;
 
+static bool v1_deprecation_warned = false;
+
 JsonBuilder *JsonDNSLogQuery(void *txptr, uint64_t tx_id)
 {
     JsonBuilder *queryjb = jb_new_array();
@@ -564,6 +566,12 @@ static DnsVersion JsonDnsParseVersion(ConfNode *conf)
     } else {
         SCLogConfig("eve-log dns version not set, defaulting to version %u",
                 version);
+    }
+
+    if (!v1_deprecation_warned && version == DNS_VERSION_1) {
+        SCLogWarning(SC_WARN_DEPRECATED, "DNS EVE v1 style logs have been "
+                "deprecated and will be removed by May 2022");
+        v1_deprecation_warned = true;
     }
 
     return version;


### PR DESCRIPTION
First commit is to fix a memory leak in V1 DNS eve logging.

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/4086

The following 2 commits are just deprecation notices for v1 style logging.

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/4137
