### PR TITLE
decode: add icmpv4.hdr keyword

### DIFF
--- a/doc/userguide/rules/header-keywords.rst
+++ b/doc/userguide/rules/header-keywords.rst
@@ -643,6 +643,11 @@ Example of icmp_seq in a rule:
 
     alert icmp $EXTERNAL_NET any -> $HOME_NET any (msg:"GPL SCAN Broadscan Smurf Scanner"; dsize:4; icmp_id:0; :example-rule-emphasis:`icmp_seq:0;` itype:8; classtype:attempted-recon; sid:2100478; rev:4;)
 
+icmpv4.hdr
+^^^^^^^^^^
+
+Sitcky buffer to match on the whole ICMPv4 header.
+
 icmpv6.hdr
 ^^^^^^^^^^
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -213,6 +213,7 @@ detect-http-uri.c detect-http-uri.h \
 detect-http2.c detect-http2.h \
 detect-icmp-id.c detect-icmp-id.h \
 detect-icmp-seq.c detect-icmp-seq.h \
+detect-icmpv4hdr.c detect-icmpv4hdr.h \
 detect-icmpv6hdr.c detect-icmpv6hdr.h \
 detect-icmpv6-mtu.c detect-icmpv6-mtu.h \
 detect-icode.c detect-icode.h \

--- a/src/decode-icmpv4.c
+++ b/src/decode-icmpv4.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -168,8 +168,6 @@ int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
     p->proto = IPPROTO_ICMP;
     p->icmp_s.type = p->icmpv4h->type;
     p->icmp_s.code = p->icmpv4h->code;
-    p->payload = (uint8_t *)pkt + ICMPV4_HEADER_LEN;
-    p->payload_len = len - ICMPV4_HEADER_LEN;
 
     int ctype = ICMPv4GetCounterpart(p->icmp_s.type);
     if (ctype != -1) {
@@ -177,6 +175,7 @@ int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
     }
 
     ICMPV4ExtHdr* icmp4eh = (ICMPV4ExtHdr*) p->icmpv4h;
+    p->icmpv4vars.hlen = ICMPV4_HEADER_LEN;
 
     switch (p->icmpv4h->type)
     {
@@ -270,6 +269,12 @@ int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
             if (p->icmpv4h->code!=0) {
                 ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_CODE);
             }
+
+            if (len < (sizeof(ICMPV4Timestamp) + ICMPV4_HEADER_LEN)) {
+                ENGINE_SET_EVENT(p, ICMPV4_IPV4_TRUNC_PKT);
+            } else {
+                p->icmpv4vars.hlen += sizeof(ICMPV4Timestamp);
+            }
             break;
 
         case ICMP_TIMESTAMPREPLY:
@@ -277,6 +282,12 @@ int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
             p->icmpv4vars.seq=icmp4eh->seq;
             if (p->icmpv4h->code!=0) {
                 ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_CODE);
+            }
+
+            if (len < (sizeof(ICMPV4Timestamp) + ICMPV4_HEADER_LEN)) {
+                ENGINE_SET_EVENT(p, ICMPV4_IPV4_TRUNC_PKT);
+            } else {
+                p->icmpv4vars.hlen += sizeof(ICMPV4Timestamp);
             }
             break;
 
@@ -295,6 +306,18 @@ int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
                 ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_CODE);
             }
             break;
+
+        case ICMP_ROUTERADVERT: {
+            /* pkt points to beginning of icmp message */
+            ICMPV4RtrAdvert *icmpv4_router_advert = (ICMPV4RtrAdvert *)(pkt + sizeof(ICMPV4Hdr));
+            uint32_t advert_len = icmpv4_router_advert->naddr *
+                             (icmpv4_router_advert->addr_sz * sizeof(uint32_t));
+            if (len < (advert_len + ICMPV4_HEADER_LEN)) {
+                ENGINE_SET_EVENT(p, ICMPV4_IPV4_TRUNC_PKT);
+            } else {
+                p->icmpv4vars.hlen += advert_len;
+            }
+        } break;
 
         case ICMP_ADDRESS:
             p->icmpv4vars.id=icmp4eh->id;
@@ -316,6 +339,9 @@ int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
             ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_TYPE);
 
     }
+
+    p->payload = (uint8_t *)pkt + p->icmpv4vars.hlen;
+    p->payload_len = len - p->icmpv4vars.hlen;
 
     FlowSetupPacket(p);
     return TM_ECODE_OK;

--- a/src/decode-icmpv4.h
+++ b/src/decode-icmpv4.h
@@ -186,6 +186,9 @@ typedef struct ICMPV4Vars_
     uint16_t  id;
     uint16_t  seq;
 
+    /** Actual header length **/
+    uint32_t hlen;
+
     /** Pointers to the embedded packet headers */
     IPV4Hdr *emb_ipv4h;
     TCPHdr *emb_tcph;
@@ -202,6 +205,23 @@ typedef struct ICMPV4Vars_
     uint16_t emb_sport;
     uint16_t emb_dport;
 } ICMPV4Vars;
+
+/* ICMPV4 Router Advertisement - fixed components */
+/* actual size determined by address count and size */
+typedef struct ICMPV4RtrAdvert_ {
+    /** Number of advertised addresses **/
+    uint8_t naddr;
+
+    /** Size of each advertised address **/
+    uint8_t addr_sz;
+} __attribute__((__packed__)) ICMPV4RtrAdvert;
+
+/* ICMPV4 TImestamp messages */
+typedef struct ICMPV4Timestamp_ {
+    uint32_t orig_ts;
+    uint32_t rx_ts;
+    uint32_t tx_ts;
+} __attribute__((__packed__)) ICMPV4Timestamp;
 
 #define CLEAR_ICMPV4_PACKET(p) do { \
     (p)->level4_comp_csum = -1;     \
@@ -238,6 +258,8 @@ typedef struct ICMPV4Vars_
 #define ICMPV4_GET_EMB_UDP(p)      (p)->icmpv4vars.emb_udph
 /** macro for icmpv4 embedded "icmpv4h" header access */
 #define ICMPV4_GET_EMB_ICMPV4H(p)  (p)->icmpv4vars.emb_icmpv4h
+/** macro for icmpv4 header length */
+#define ICMPV4_GET_HLEN_ICMPV4H(p) (p)->icmpv4vars.hlen
 
 /** macro for checking if a ICMP DEST UNREACH packet is valid for use
  *  in other parts of the engine, such as the flow engine. 

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -143,6 +143,7 @@
 #include "detect-icode.h"
 #include "detect-icmp-id.h"
 #include "detect-icmp-seq.h"
+#include "detect-icmpv4hdr.h"
 #include "detect-dce-iface.h"
 #include "detect-dce-opnum.h"
 #include "detect-dce-stub-data.h"
@@ -546,6 +547,7 @@ void SigTableSetup(void)
     DetectICodeRegister();
     DetectIcmpIdRegister();
     DetectIcmpSeqRegister();
+    DetectIcmpv4HdrRegister();
     DetectDceIfaceRegister();
     DetectDceOpnumRegister();
     DetectDceStubDataRegister();

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -46,6 +46,7 @@ enum DetectKeywordId {
     DETECT_ICODE,
     DETECT_ICMP_ID,
     DETECT_ICMP_SEQ,
+    DETECT_ICMPV4HDR,
     DETECT_DSIZE,
 
     DETECT_FLOW,

--- a/src/detect-icmpv4hdr.c
+++ b/src/detect-icmpv4hdr.c
@@ -1,0 +1,124 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ *
+ */
+
+#include "suricata-common.h"
+
+#include "detect.h"
+#include "detect-engine.h"
+#include "detect-engine-mpm.h"
+#include "detect-icmpv4hdr.h"
+
+/* prototypes */
+static int DetectIcmpv4HdrSetup(DetectEngineCtx *, Signature *, const char *);
+#ifdef UNITTESTS
+void DetectIcmpv4HdrRegisterTests(void);
+#endif
+
+static int g_icmpv4hdr_buffer_id = 0;
+
+static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Packet *p, const int list_id);
+
+/**
+ * \brief Registration function for icmpv4.hdr: keyword
+ */
+void DetectIcmpv4HdrRegister(void)
+{
+    sigmatch_table[DETECT_ICMPV4HDR].name = "icmpv4.hdr";
+    sigmatch_table[DETECT_ICMPV4HDR].desc = "sticky buffer to match on the ICMP v4 header";
+    sigmatch_table[DETECT_ICMPV4HDR].url = "/rules/header-keywords.html#icmpv4-hdr";
+    sigmatch_table[DETECT_ICMPV4HDR].Setup = DetectIcmpv4HdrSetup;
+    sigmatch_table[DETECT_ICMPV4HDR].flags |= SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
+#ifdef UNITTESTS
+    sigmatch_table[DETECT_ICMPV4HDR].RegisterTests = DetectIcmpv4HdrRegisterTests;
+#endif
+
+    g_icmpv4hdr_buffer_id = DetectBufferTypeRegister("icmpv4.hdr");
+    BUG_ON(g_icmpv4hdr_buffer_id < 0);
+
+    DetectBufferTypeSupportsPacket("icmpv4.hdr");
+
+    DetectPktMpmRegister("icmpv4.hdr", 2, PrefilterGenericMpmPktRegister, GetData);
+
+    DetectPktInspectEngineRegister("icmpv4.hdr", GetData, DetectEngineInspectPktBufferGeneric);
+
+    return;
+}
+
+/**
+ * \brief setup icmpv4.hdr sticky buffer
+ *
+ * \param de_ctx pointer to the Detection Engine Context
+ * \param s pointer to the Current Signature
+ * \param _unused unused
+ *
+ * \retval 0 on Success
+ * \retval -1 on Failure
+ */
+static int DetectIcmpv4HdrSetup(DetectEngineCtx *de_ctx, Signature *s, const char *_unused)
+{
+    if (!(DetectProtoContainsProto(&s->proto, IPPROTO_ICMP)))
+        return -1;
+
+    s->proto.flags |= DETECT_PROTO_IPV4;
+    s->flags |= SIG_FLAG_REQUIRE_PACKET;
+
+    if (DetectBufferSetActiveList(s, g_icmpv4hdr_buffer_id) < 0)
+        return -1;
+
+    return 0;
+}
+
+static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Packet *p, const int list_id)
+{
+    SCEnter();
+
+    if (p->icmpv4h == NULL) {
+        SCReturnPtr(NULL, "InspectionBuffer");
+    }
+
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        uint16_t hlen = ICMPV4_GET_HLEN_ICMPV4H(p);
+        if (((uint8_t *)p->icmpv4h + (ptrdiff_t)hlen) >
+                ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p))) {
+            SCLogDebug("data out of range: %p > %p", ((uint8_t *)p->icmpv4h + (ptrdiff_t)hlen),
+                    ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p)));
+            SCReturnPtr(NULL, "InspectionBuffer");
+        }
+
+        const uint32_t data_len = hlen;
+        const uint8_t *data = (const uint8_t *)p->icmpv4h;
+
+        InspectionBufferSetup(buffer, data, data_len);
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+
+    SCReturnPtr(buffer, "InspectionBuffer");
+}
+
+#ifdef UNITTESTS
+#include "tests/detect-icmpv4hdr.c"
+#endif

--- a/src/detect-icmpv4hdr.h
+++ b/src/detect-icmpv4hdr.h
@@ -1,0 +1,29 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ */
+
+#ifndef _DETECT_ICMPV4HDR_H
+#define _DETECT_ICMPV4HDR_H
+
+void DetectIcmpv4HdrRegister(void);
+
+#endif /* _DETECT_ICMPV4HDR_H */

--- a/src/tests/detect-icmpv4hdr.c
+++ b/src/tests/detect-icmpv4hdr.c
@@ -1,0 +1,45 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "../suricata-common.h"
+
+#include "../detect.h"
+#include "../detect-parse.h"
+
+#include "../detect-icmpv4hdr.h"
+
+#include "../util-unittest.h"
+
+static int DetectIcmpv4HdrParseTest01(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    FAIL_IF_NULL(DetectEngineAppendSig(
+            de_ctx, "alert icmp any any -> any any (icmpv4.hdr; content:\"A\"; sid:1; rev:1;)"));
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+/**
+ * \brief this function registers unit tests for DetectIcmpv4Hdr
+ */
+void DetectIcmpv4HdrRegisterTests(void)
+{
+    UtRegisterTest("DetectIcmpv4HdrParseTest01", DetectIcmpv4HdrParseTest01);
+}


### PR DESCRIPTION
Continuation of #5546

This PR adds a keyword for the ICMPv4 header -- `icmpv4.hdr`. 

This sticky buffer returns ICMPv4 header bytes; the size of the header is determined by the ICMP message type. Some messages, like router advertisements, are variable lengths.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4090](https://redmine.openinfosecfoundation.org/issues/4090)

Describe changes:
- Addresses review comments

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

suricata-verify-pr: 357
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
