### PR TITLE
ci: updates github ci add-path mechanism

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -54,7 +54,8 @@ jobs:
                 software-properties-common \
                 zlib1g \
                 zlib1g-dev
-      - run: echo "::add-path::$HOME/.cargo/bin:/usr/lib/ccache"
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: echo "/usr/lib/ccache" >> $GITHUB_PATH
       - name: Install cbindgen
         run: cargo install cbindgen
       - run: echo $PATH

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -63,7 +63,7 @@ jobs:
           apt-get install -y clang-format-9
       - name: Install cbindgen
         run: cargo install --force --debug --version 0.14.1 cbindgen
-      - run: echo "::add-path::$HOME/.cargo/bin"
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       # Checking out the branch is not as simple as "checking out".
       #
       # In case master has any new commits since we branched off, github will


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Updates Github CI mechanisms to add a directory to the path
