### PR TITLE
detect: apply transforms to http body

### DIFF
--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -258,6 +258,7 @@ static InspectionBuffer *HttpClientBodyGetDataCallback(DetectEngineThreadCtx *de
     StreamingBufferGetDataAtOffset(body->sb,
             &data, &data_len, offset);
     InspectionBufferSetup(buffer, data, data_len);
+    InspectionBufferApplyTransforms(buffer, transforms);
     buffer->inspect_offset = offset;
 
     /* move inspected tracker to end of the data. HtpBodyPrune will consider


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2689

Describe changes:
- Support transforms for HTTP body

suricata-verify-pr: 362

https://github.com/OISF/suricata-verify/pull/362
Not sure if it is related to #5550 or what was the blocker there

Replaces #5554 with removing dummy commit
