### PR TITLE
dns: log more types - v3

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -422,6 +422,13 @@ More complex DNS record types may log additional fields for resource data:
   * "algo": Algorithm number (ex: 1 for RSA, 2 for DSS)
   * "type": Fingerprint type (ex: 1 for SHA-1)
 
+* "srv": section containing fields for the SRV (location of services) record type
+
+  * "target": Domain name of the target host (ex: ``foo.bar.baz``)
+  * "priority": Target priority (ex: 20)
+  * "weight": Weight for target selection (ex: 1)
+  * "port": Port on this target host of this service (ex: 5060)
+
 One can control which RR types are logged by using the "types" field in the
 suricata.yaml file. If this field is not specified, all RR types are logged.
 More than 50 values can be specified with this field as shown below:

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -269,6 +269,7 @@ pub enum DNSRData {
     CNAME(Vec<u8>),
     PTR(Vec<u8>),
     MX(Vec<u8>),
+    NS(Vec<u8>),
     // RData is text
     TXT(Vec<u8>),
     NULL(Vec<u8>),

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -271,6 +271,7 @@ pub enum DNSRData {
     MX(Vec<u8>),
     // RData is text
     TXT(Vec<u8>),
+    NULL(Vec<u8>),
     // RData has several fields
     SOA(DNSRDataSOA),
     SSHFP(DNSRDataSSHFP),

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -259,6 +259,18 @@ pub struct DNSRDataSSHFP {
     pub fingerprint: Vec<u8>,
 }
 
+#[derive(Debug,PartialEq)]
+pub struct DNSRDataSRV {
+    /// Priority
+    pub priority: u16,
+    /// Weight
+    pub weight: u16,
+    /// Port
+    pub port: u16,
+    /// Target
+    pub target: Vec<u8>,
+}
+
 /// Represents RData of various formats
 #[derive(Debug,PartialEq)]
 pub enum DNSRData {
@@ -275,6 +287,7 @@ pub enum DNSRData {
     NULL(Vec<u8>),
     // RData has several fields
     SOA(DNSRDataSOA),
+    SRV(DNSRDataSRV),
     SSHFP(DNSRDataSSHFP),
     // RData for remaining types is sometimes ignored
     Unknown(Vec<u8>),

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -443,6 +443,7 @@ fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Result<JsonBuilder, Js
         }
         DNSRData::CNAME(bytes) |
         DNSRData::MX(bytes) |
+        DNSRData::NS(bytes) |
         DNSRData::TXT(bytes) |
         DNSRData::NULL(bytes) |
         DNSRData::PTR(bytes) => {
@@ -515,6 +516,7 @@ fn dns_log_json_answer(js: &mut JsonBuilder, response: &DNSResponse, flags: u64)
                     }
                     DNSRData::CNAME(bytes) |
                     DNSRData::MX(bytes) |
+                    DNSRData::NS(bytes) |
                     DNSRData::TXT(bytes) |
                     DNSRData::NULL(bytes) |
                     DNSRData::PTR(bytes) => {
@@ -688,6 +690,7 @@ fn dns_log_json_answer_v1(header: &DNSHeader, answer: &DNSAnswerEntry)
         }
         DNSRData::CNAME(bytes) |
         DNSRData::MX(bytes) |
+        DNSRData::NS(bytes) |
         DNSRData::TXT(bytes) |
         DNSRData::NULL(bytes) |
         DNSRData::PTR(bytes) => {

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -444,6 +444,7 @@ fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Result<JsonBuilder, Js
         DNSRData::CNAME(bytes) |
         DNSRData::MX(bytes) |
         DNSRData::TXT(bytes) |
+        DNSRData::NULL(bytes) |
         DNSRData::PTR(bytes) => {
             jsa.set_string_from_bytes("rdata", &bytes)?;
         }
@@ -515,6 +516,7 @@ fn dns_log_json_answer(js: &mut JsonBuilder, response: &DNSResponse, flags: u64)
                     DNSRData::CNAME(bytes) |
                     DNSRData::MX(bytes) |
                     DNSRData::TXT(bytes) |
+                    DNSRData::NULL(bytes) |
                     DNSRData::PTR(bytes) => {
                         if !answer_types.contains_key(&type_string) {
                             answer_types.insert(type_string.to_string(),
@@ -687,6 +689,7 @@ fn dns_log_json_answer_v1(header: &DNSHeader, answer: &DNSAnswerEntry)
         DNSRData::CNAME(bytes) |
         DNSRData::MX(bytes) |
         DNSRData::TXT(bytes) |
+        DNSRData::NULL(bytes) |
         DNSRData::PTR(bytes) => {
             js.set_string_from_bytes("rdata", &bytes)?;
         }

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -429,6 +429,20 @@ fn dns_log_sshfp(sshfp: &DNSRDataSSHFP) -> Result<JsonBuilder, JsonError>
     return Ok(js);
 }
 
+/// Log SRV section fields.
+fn dns_log_srv(srv: &DNSRDataSRV) -> Result<JsonBuilder, JsonError>
+{
+    let mut js = JsonBuilder::new_object();
+
+    js.set_uint("priority", srv.priority as u64)?;
+    js.set_uint("weight", srv.weight as u64)?;
+    js.set_uint("port", srv.port as u64)?;
+    js.set_string_from_bytes("name", &srv.target)?;
+
+    js.close()?;
+    return Ok(js);
+}
+
 fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Result<JsonBuilder, JsonError>
 {
     let mut jsa = JsonBuilder::new_object();
@@ -454,6 +468,9 @@ fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Result<JsonBuilder, Js
         }
         DNSRData::SSHFP(sshfp) => {
             jsa.set_object("sshfp", &dns_log_sshfp(&sshfp)?)?;
+        }
+        DNSRData::SRV(srv) => {
+            jsa.set_object("srv", &dns_log_srv(&srv)?)?;
         }
         _ => {}
     }
@@ -544,6 +561,15 @@ fn dns_log_json_answer(js: &mut JsonBuilder, response: &DNSResponse, flags: u64)
                         }
                         if let Some(a) = answer_types.get_mut(&type_string) {
                             a.append_object(&dns_log_sshfp(&sshfp)?)?;
+                        }
+                    },
+                    DNSRData::SRV(srv) => {
+                        if !answer_types.contains_key(&type_string) {
+                            answer_types.insert(type_string.to_string(),
+                                                JsonBuilder::new_array());
+                        }
+                        if let Some(a) = answer_types.get_mut(&type_string) {
+                            a.append_object(&dns_log_srv(&srv)?)?;
                         }
                     },
                     _ => {}

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -199,6 +199,11 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
                     lua.pushstring(&String::from_utf8_lossy(&sshfp.fingerprint));
                     lua.settable(-3);
                 },
+                DNSRData::SRV(ref srv) => {
+                    lua.pushstring("addr");
+                    lua.pushstring(&String::from_utf8_lossy(&srv.target));
+                    lua.settable(-3);
+                },
             }
             lua.settable(-3);
         }

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -176,6 +176,7 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
                 },
                 DNSRData::CNAME(ref bytes) |
                 DNSRData::MX(ref bytes) |
+                DNSRData::NS(ref bytes) |
                 DNSRData::TXT(ref bytes) |
                 DNSRData::NULL(ref bytes) |
                 DNSRData::PTR(ref bytes) |

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -177,6 +177,7 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
                 DNSRData::CNAME(ref bytes) |
                 DNSRData::MX(ref bytes) |
                 DNSRData::TXT(ref bytes) |
+                DNSRData::NULL(ref bytes) |
                 DNSRData::PTR(ref bytes) |
                 DNSRData::Unknown(ref bytes) => {
                     if bytes.len() > 0 {

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -272,6 +272,12 @@ fn dns_parse_rdata_cname<'a>(input: &'a [u8], message: &'a [u8])
             (input, DNSRData::CNAME(name)))
 }
 
+fn dns_parse_rdata_ns<'a>(input: &'a [u8], message: &'a [u8])
+                             -> IResult<&'a [u8], DNSRData> {
+    dns_parse_name(input, message).map(|(input, name)|
+            (input, DNSRData::NS(name)))
+}
+
 fn dns_parse_rdata_ptr<'a>(input: &'a [u8], message: &'a [u8])
                            -> IResult<&'a [u8], DNSRData> {
     dns_parse_name(input, message).map(|(input, name)|
@@ -362,6 +368,7 @@ pub fn dns_parse_rdata<'a>(input: &'a [u8], message: &'a [u8], rrtype: u16)
         DNS_RECORD_TYPE_PTR => dns_parse_rdata_ptr(input, message),
         DNS_RECORD_TYPE_SOA => dns_parse_rdata_soa(input, message),
         DNS_RECORD_TYPE_MX => dns_parse_rdata_mx(input, message),
+        DNS_RECORD_TYPE_NS => dns_parse_rdata_ns(input, message),
         DNS_RECORD_TYPE_TXT => dns_parse_rdata_txt(input),
         DNS_RECORD_TYPE_NULL => dns_parse_rdata_null(input),
         DNS_RECORD_TYPE_SSHFP => dns_parse_rdata_sshfp(input),

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -319,6 +319,23 @@ fn dns_parse_rdata_mx<'a>(input: &'a [u8], message: &'a [u8])
     )
 }
 
+fn dns_parse_rdata_srv<'a>(input: &'a [u8], message: &'a [u8])
+                             -> IResult<&'a [u8], DNSRData> {
+    do_parse!(
+        input,
+        priority: be_u16 >>
+        weight: be_u16 >>
+        port: be_u16 >>
+        target: call!(dns_parse_name, message) >>
+            (DNSRData::SRV(DNSRDataSRV{
+                priority,
+                weight,
+                port,
+                target,
+            }))
+    )
+}
+
 fn dns_parse_rdata_txt<'a>(input: &'a [u8])
                            -> IResult<&'a [u8], DNSRData> {
     do_parse!(
@@ -372,6 +389,7 @@ pub fn dns_parse_rdata<'a>(input: &'a [u8], message: &'a [u8], rrtype: u16)
         DNS_RECORD_TYPE_TXT => dns_parse_rdata_txt(input),
         DNS_RECORD_TYPE_NULL => dns_parse_rdata_null(input),
         DNS_RECORD_TYPE_SSHFP => dns_parse_rdata_sshfp(input),
+        DNS_RECORD_TYPE_SRV => dns_parse_rdata_srv(input, message),
         _ => dns_parse_rdata_unknown(input),
     }
 }

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -346,13 +346,9 @@ fn dns_parse_rdata_txt<'a>(input: &'a [u8])
     )
 }
 
-fn dns_parse_rdata_null<'a>(input: &'a [u8])
-                            -> IResult<&'a [u8], DNSRData> {
-    do_parse!(
-        input,
-        data: take!(input.len()) >>
-            (DNSRData::NULL(data.to_vec()))
-    )
+
+fn dns_parse_rdata_null<'a>(input: &'a [u8]) -> IResult<&'a [u8], DNSRData> {
+    rest(input).map(|(input, data)| (input, DNSRData::NULL(data.to_vec())))
 }
 
 fn dns_parse_rdata_sshfp<'a>(input: &'a [u8])

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -800,4 +800,82 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_dns_parse_rdata_srv() {
+    /*  ; <<>> DiG 9.11.5-P4-5.1+deb10u2-Debian <<>> _sip._udp.sip.voice.google.com SRV
+        ;; global options: +cmd
+        ;; Got answer:
+        ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 1524
+        ;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 3
+
+        [...]
+
+        ;; ANSWER SECTION:
+        _sip._udp.sip.voice.google.com.	300 IN	SRV	10 1 5060 sip-anycast-1.voice.google.com.
+        _sip._udp.sip.voice.google.com.	300 IN	SRV	20 1 5060 sip-anycast-2.voice.google.com.
+
+        [...]
+
+        ;; Query time: 72 msec
+        ;; MSG SIZE  rcvd: 191   */
+
+        let pkt: &[u8] = &[
+            0xeb, 0x56, 0x81, 0x80, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00,
+            0x00, 0x01, 0x04, 0x5f, 0x73, 0x69, 0x70, 0x04, 0x5f, 0x75,
+            0x64, 0x70, 0x03, 0x73, 0x69, 0x70, 0x05, 0x76, 0x6f, 0x69,
+            0x63, 0x65, 0x06, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x03,
+            0x63, 0x6f, 0x6d, 0x00, 0x00, 0x21, 0x00, 0x01, 0xc0, 0x0c,
+            0x00, 0x21, 0x00, 0x01, 0x00, 0x00, 0x01, 0x13, 0x00, 0x26,
+            0x00, 0x14, 0x00, 0x01, 0x13, 0xc4, 0x0d, 0x73, 0x69, 0x70,
+            0x2d, 0x61, 0x6e, 0x79, 0x63, 0x61, 0x73, 0x74, 0x2d, 0x32,
+            0x05, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x06, 0x67, 0x6f, 0x6f,
+            0x67, 0x6c, 0x65, 0x03, 0x63, 0x6f, 0x6d, 0x00, 0xc0, 0x0c,
+            0x00, 0x21, 0x00, 0x01, 0x00, 0x00, 0x01, 0x13, 0x00, 0x26,
+            0x00, 0x0a, 0x00, 0x01, 0x13, 0xc4, 0x0d, 0x73, 0x69, 0x70,
+            0x2d, 0x61, 0x6e, 0x79, 0x63, 0x61, 0x73, 0x74, 0x2d, 0x31,
+            0x05, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x06, 0x67, 0x6f, 0x6f,
+            0x67, 0x6c, 0x65, 0x03, 0x63, 0x6f, 0x6d, 0x00
+        ];
+
+        let res = dns_parse_response(pkt);
+        match res {
+            Ok((rem, response)) => {
+
+                // The data should be fully parsed.
+                assert_eq!(rem.len(), 0);
+
+                assert_eq!(response.answers.len(), 2);
+
+                let answer1 = &response.answers[0];
+                match &answer1.data {
+                    DNSRData::SRV(srv) => {
+                        assert_eq!(srv.priority, 20);
+                        assert_eq!(srv.weight, 1);
+                        assert_eq!(srv.port, 5060);
+                        assert_eq!(srv.target,
+                            "sip-anycast-2.voice.google.com".as_bytes().to_vec());
+                    }
+                    _ => {
+                        assert!(false);
+                    }
+                }
+                let answer2 = &response.answers[1];
+                match &answer2.data {
+                    DNSRData::SRV(srv) => {
+                        assert_eq!(srv.priority, 10);
+                        assert_eq!(srv.weight, 1);
+                        assert_eq!(srv.port, 5060);
+                        assert_eq!(srv.target,
+                            "sip-anycast-1.voice.google.com".as_bytes().to_vec());
+                    }
+                    _ => {
+                        assert!(false);
+                    }
+                }
+            },
+            _ => {
+                assert!(false);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Rebase to cleanup CI error.

Combines multiple PRs for logging new DNS types:
- SRV: https://github.com/OISF/suricata/pull/5529
- NS: https://github.com/OISF/suricata/pull/5478
- NULL: https://github.com/OISF/suricata/pull/5446

Raw rdata logging was removed until we know/discuss this a little
more.

suricata-verify-pr: 366