### PR TITLE
app-layer: do not try to parse gaps during protocol change

### DIFF
--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -618,6 +618,11 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                 goto failure;
             }
         }
+        if (FlowChangeProto(f)) {
+            FlowUnsetChangeProtoFlag(f);
+            SCLogDebug("Cannot handle gap while changing protocol");
+            goto failure;
+        }
         PACKET_PROFILING_APP_START(app_tctx, f->alproto);
         r = AppLayerParserParse(tv, app_tctx->alp_tctx, f, f->alproto,
                 flags, data, data_len);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3924

Describe changes:
- do not try to parse gaps during protocol change

As this will leak the flow alstate because `AppLayerParserParse` relies on `FlowChangeProto` to know if it should allocate a new alstate