### PR TITLE
rust: fix warnings found by nightly compiler

### DIFF
--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -35,7 +35,8 @@ pub fn conf_get(key: &str) -> Option<&str> {
     let mut vptr: *const c_char = ptr::null_mut();
 
     unsafe {
-        if ConfGet(CString::new(key).unwrap().as_ptr(), &mut vptr) != 1 {
+        let s = CString::new(key).unwrap();
+        if ConfGet(s.as_ptr(), &mut vptr) != 1 {
             SCLogDebug!("Failed to find value for key {}", key);
             return None;
         }
@@ -88,8 +89,9 @@ impl ConfNode {
         let mut vptr: *const c_char = ptr::null_mut();
 
         unsafe {
+            let s = CString::new(key).unwrap();
             if ConfGetChildValue(self.conf,
-                                 CString::new(key).unwrap().as_ptr(),
+                                 s.as_ptr(),
                                  &mut vptr) != 1 {
                 return None;
             }
@@ -110,8 +112,9 @@ impl ConfNode {
         let mut vptr: c_int = 0;
 
         unsafe {
+            let s = CString::new(key).unwrap();
             if ConfGetChildValueBool(self.conf,
-                                     CString::new(key).unwrap().as_ptr(),
+                                     s.as_ptr(),
                                      &mut vptr) != 1 {
                 return false;
             }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Fixes a warning found by rust nightly compiler

My compiler is `rustc 1.50.0-nightly (603ab5bd6 2020-11-15)`

The full warning text is
```
warning: getting the inner pointer of a temporary `CString`
  --> src/conf.rs:38:47
   |
38 |         if ConfGet(CString::new(key).unwrap().as_ptr(), &mut vptr) != 1 {
   |                    -------------------------- ^^^^^^ this pointer will be invalid
   |                    |
   |                    this `CString` is deallocated at the end of the statement, bind it to a variable to extend its lifetime
   |
   = note: `#[warn(temporary_cstring_as_ptr)]` on by default
   = note: pointers do not have a lifetime; when calling `as_ptr` the `CString` will be deallocated at the end of the statement because nothing is referencing it as far as the type system is concerned
   = help: for more information, see https://doc.rust-lang.org/reference/destructors.html
```