### PR TITLE
detect/bsize: Validate against content buffer when available

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -267,17 +267,42 @@ You can also use the negation (!) before isdataat.
 bsize
 -----
 
-With the bsize keyword, you can match on the length of the buffer. This adds precision to the content match, previously this could have been done with isdataat.
+With the ``bsize`` keyword, you can match on the length of the buffer. This adds
+precision to the content match, previously this could have been done with ``isdataat``.
+
+An optional operator can be specified; if no operator is present, the operator will
+default to '='. When a relational operator is used, e.g., '<', '>' or '<>' (range),
+the bsize value will be compared using the relational operator. Ranges are inclusive.
+
+If one or more ``content`` keywords precedes ``bsize``, each occurrence of ``content``
+will be inspected and an error will be raised if the content length and the bsize
+value prevent a match.
 
 Format::
 
   bsize:<number>;
+  bsize:=<number>;
+  bsize:<<number>;
+  bsize:><number>;
+  bsize:<lo-number><><hi-number>;
 
-Example of bsize in a rule:
+Examples of ``bsize`` in a rule:
 
 .. container:: example-rule
 
    alert dns any any -> any any (msg:"test bsize rule"; dns.query; content:"google.com"; bsize:10; sid:123; rev:1;)
+
+.. container:: example-rule
+
+   alert dns any any -> any any (msg:"test bsize rule"; dns.query; content:"short"; bsize:<10; sid:124; rev:1;)
+
+.. container:: example-rule
+
+   alert dns any any -> any any (msg:"test bsize rule"; dns.query; content:"longer string"; bsize:>10; sid:125; rev:1;)
+
+.. container:: example-rule
+
+   alert dns any any -> any any (msg:"test bsize rule"; dns.query; content:"middle"; bsize:6<>15; sid:126; rev:1;)
 
 dsize
 -----

--- a/src/detect-bsize.c
+++ b/src/detect-bsize.c
@@ -38,7 +38,7 @@
 
 /*prototypes*/
 static int DetectBsizeSetup (DetectEngineCtx *, Signature *, const char *);
-static void DetectBsizeFree (DetectEngineCtx *, void *);
+static void DetectBsizeFree(DetectEngineCtx *, void *);
 #ifdef UNITTESTS
 static void DetectBsizeRegisterTests (void);
 #endif
@@ -64,6 +64,8 @@ void DetectBsizeRegister(void)
 #define DETECT_BSIZE_GT 1
 #define DETECT_BSIZE_RA 2
 #define DETECT_BSIZE_EQ 3
+
+const char *bsize_mode_strings[] = { "<", ">", "<>", "=" };
 
 typedef struct DetectBsizeData {
     uint8_t mode;
@@ -266,6 +268,72 @@ static DetectBsizeData *DetectBsizeParse (const char *str)
     return bsz;
 }
 
+static inline bool DetectCheckValue(const DetectBsizeData *bsz, uint64_t value)
+{
+    bool possible = false;
+    switch (bsz->mode) {
+        case DETECT_BSIZE_GT:
+            possible = true;
+            break;
+
+        case DETECT_BSIZE_EQ:
+        case DETECT_BSIZE_RA:
+        case DETECT_BSIZE_LT:
+            possible = value <= bsz->lo;
+            break;
+    }
+    return possible;
+}
+
+static bool DetectBsizeCheckContent(const SigMatch *sm, const DetectBsizeData *bsz)
+{
+    bool possible = true;
+    int32_t bytes_required = -1;
+
+    /* Check bsize value against all preceding content keywords */
+    for (; sm != NULL; sm = sm->next) {
+        if (sm->type != DETECT_CONTENT || sm->ctx == NULL)
+            continue;
+
+        const DetectContentData *cd = (DetectContentData *)sm->ctx;
+
+        SCLogDebug("Content %.*s, content-len %" PRIu16 " offset: %" PRIu16 " depth: %" PRIu16,
+                cd->content_len, cd->content, cd->content_len, cd->offset, cd->depth);
+
+        bytes_required = cd->content_len;
+        if (cd->flags & DETECT_CONTENT_OFFSET) {
+            bytes_required = cd->content_len + cd->offset;
+        }
+
+        /* Validate bsize value against content length (and offset, if avail) */
+        if (DetectCheckValue(bsz, bytes_required)) {
+            /* no match possible, continue checking */
+            possible = true;
+            continue;
+        }
+        possible = false;
+
+        /* Validate bsize value against depth */
+        if (cd->flags & DETECT_CONTENT_DEPTH) {
+            bytes_required = cd->depth;
+            if (DetectCheckValue(bsz, bytes_required)) {
+                possible = true;
+                continue;
+            }
+            possible = false;
+        }
+    }
+
+    if (!possible) {
+        BUG_ON(bytes_required == -1);
+        SCLogError(SC_ERR_INVALID_SIGNATURE,
+                "bsize match impossible: bsize value: %" PRIu64 ", content len: %" PRIi32, bsz->lo,
+                bytes_required);
+    }
+
+    return possible;
+}
+
 /**
  * \brief this function is used to parse bsize data into the current signature
  *
@@ -291,6 +359,15 @@ static int DetectBsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
     DetectBsizeData *bsz = DetectBsizeParse(sizestr);
     if (bsz == NULL)
         goto error;
+
+    SigMatch *prev_pm = DetectGetLastSMFromLists(s, DETECT_CONTENT, -1);
+    if (prev_pm != NULL) {
+        list = SigMatchListSMBelongsTo(s, prev_pm);
+        if (list < 0 || !DetectBsizeCheckContent(s->init_data->smlists[list], bsz)) {
+            goto error;
+        }
+    }
+
     sm = SigMatchAlloc();
     if (sm == NULL)
         goto error;

--- a/src/tests/detect-bsize.c
+++ b/src/tests/detect-bsize.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -17,13 +17,14 @@
 
 #include "../util-unittest.h"
 
-#define TEST_OK(str, m, lo, hi) {                       \
-    DetectBsizeData *bsz = DetectBsizeParse((str));     \
-    FAIL_IF_NULL(bsz);                                  \
-    FAIL_IF_NOT(bsz->mode == (m));                      \
-    DetectBsizeFree(NULL, bsz);                         \
-    SCLogDebug("str %s OK", (str));                     \
-}
+#define TEST_OK(str, m, lo, hi)                                                                    \
+    {                                                                                              \
+        DetectBsizeData *bsz = DetectBsizeParse((str));                                            \
+        FAIL_IF_NULL(bsz);                                                                         \
+        FAIL_IF_NOT(bsz->mode == (m));                                                             \
+        DetectBsizeFree(NULL, bsz);                                                                \
+        SCLogDebug("str %s OK", (str));                                                            \
+    }
 #define TEST_FAIL(str) {                                \
     DetectBsizeData *bsz = DetectBsizeParse((str));     \
     FAIL_IF_NOT_NULL(bsz);                              \
@@ -119,6 +120,33 @@ static int DetectBsizeSigTest01(void)
     TEST_FAIL("alert tcp any any -> any any (content:\"abc\"; bsize:10; sid:3;)");
     TEST_FAIL("alert http any any -> any any (content:\"GET\"; http_method; bsize:10; sid:4;)");
     TEST_FAIL("alert http any any -> any any (http_request_line; content:\"GET\"; bsize:<10>; sid:5;)");
+
+    /* bsize validation with buffer */
+    TEST_OK("alert http any any -> any any (http.uri; content:\"/index.php\"; bsize:>1024; "
+            "sid:6;)");
+    TEST_OK("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"g\"; bsize:1; "
+            "sid:7;)");
+    TEST_OK("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"g\"; bsize:4; "
+            "sid:8;)");
+    TEST_OK("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:<20; "
+            " sid:9;)");
+    TEST_OK("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:15<>25; "
+            "sid:10;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:2; "
+              "sid:11;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:<13; "
+              "sid:12;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:10<>15; "
+              "sid:13;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefghi123456\"; offset:12; "
+              "bsize:3; sid:14;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abc\"; offset:3; depth:3; "
+              "bsize:3; sid:15;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"gh\"; "
+              "bsize:1; sid:16;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abc\"; offset:3; bsize:3; "
+              "sid:17;)");
+
     PASS;
 }
 


### PR DESCRIPTION
Continuation of #5576

This PR adds additional validation when using the `bsize` keyword. If a one or more `content` keywords immediately precedes `bsize`, then the `bsize` value is checked against each to see if a match is possible using the operation (`=, <, >, <>`) and the value.

An error is raised if `bsize` value prevents a match, e.g., the content length exceeds the `bsize` value. The `bsize` operation and values are used to do the evaluation.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3682](https://redmine.openinfosecfoundation.org/issues/3682)

Describe changes:
- Correct issue found by fuzzing.

suricata-verify-pr: 238
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
