### PR TITLE
detect-rpc-v1

### DIFF
--- a/src/detect-rpc.c
+++ b/src/detect-rpc.c
@@ -309,15 +309,11 @@ void DetectRpcFree(DetectEngineCtx *de_ctx, void *ptr)
  */
 static int DetectRpcTestParse01 (void)
 {
-    int result = 0;
-    DetectRpcData *rd = NULL;
-    rd = DetectRpcParse(NULL, "123,444,555");
-    if (rd != NULL) {
-        DetectRpcFree(NULL, rd);
-        result = 1;
-    }
+    DetectRpcData *rd = DetectRpcParse(NULL, "123,444,555");
+    FAIL_IF_NULL(rd);
 
-    return result;
+    DetectRpcFree(NULL, rd);
+    PASS;
 }
 
 /**
@@ -325,23 +321,19 @@ static int DetectRpcTestParse01 (void)
  */
 static int DetectRpcTestParse02 (void)
 {
-    int result = 0;
     DetectRpcData *rd = NULL;
     rd = DetectRpcParse(NULL, "111,222,333");
-    if (rd != NULL) {
-        if (rd->flags & DETECT_RPC_CHECK_PROGRAM &&
-            rd->flags & DETECT_RPC_CHECK_VERSION &&
-            rd->flags & DETECT_RPC_CHECK_PROCEDURE &&
-            rd->program == 111 && rd->program_version == 222 &&
-            rd->procedure == 333) {
-            result = 1;
-        } else {
-            SCLogDebug("Error: Flags: %d; program: %u, version: %u, procedure: %u", rd->flags, rd->program, rd->program_version, rd->procedure);
-        }
-        DetectRpcFree(NULL, rd);
-    }
+    FAIL_IF_NULL(rd);
+    FAIL_IF_NOT(rd->flags & DETECT_RPC_CHECK_PROGRAM);
+    FAIL_IF_NOT(rd->flags & DETECT_RPC_CHECK_VERSION);
+    FAIL_IF_NOT(rd->flags & DETECT_RPC_CHECK_PROCEDURE);
+    FAIL_IF_NOT(rd->program == 111);
+    FAIL_IF_NOT(rd->program_version == 222);
+    FAIL_IF_NOT(rd->procedure == 333);
 
-    return result;
+    DetectRpcFree(NULL, rd);
+
+    PASS;
 }
 
 /**
@@ -350,78 +342,68 @@ static int DetectRpcTestParse02 (void)
  */
 static int DetectRpcTestParse03 (void)
 {
-    int result = 1;
     DetectRpcData *rd = NULL;
-    rd = DetectRpcParse(NULL, "111,*,333");
-    if (rd == NULL)
-        return 0;
 
-    if ( !(rd->flags & DETECT_RPC_CHECK_PROGRAM &&
-        !(rd->flags & DETECT_RPC_CHECK_VERSION) &&
-        rd->flags & DETECT_RPC_CHECK_PROCEDURE &&
-        rd->program == 111 && rd->program_version == 0 &&
-        rd->procedure == 333))
-            result = 0;
-    SCLogDebug("rd1 Flags: %d; program: %u, version: %u, procedure: %u", rd->flags, rd->program, rd->program_version, rd->procedure);
+    rd = DetectRpcParse(NULL, "111,*,333");
+    FAIL_IF_NULL(rd);
+
+    FAIL_IF_NOT(rd->flags & DETECT_RPC_CHECK_PROGRAM);
+    FAIL_IF(rd->flags & DETECT_RPC_CHECK_VERSION);
+    FAIL_IF_NOT(rd->flags & DETECT_RPC_CHECK_PROCEDURE);
+    FAIL_IF_NOT(rd->program == 111);
+    FAIL_IF_NOT(rd->program_version == 0);
+    FAIL_IF_NOT(rd->procedure == 333);
 
     DetectRpcFree(NULL, rd);
 
     rd = DetectRpcParse(NULL, "111,222,*");
-    if (rd == NULL)
-        return 0;
+    FAIL_IF_NULL(rd);
 
-    if ( !(rd->flags & DETECT_RPC_CHECK_PROGRAM &&
-        rd->flags & DETECT_RPC_CHECK_VERSION &&
-        !(rd->flags & DETECT_RPC_CHECK_PROCEDURE) &&
-        rd->program == 111 && rd->program_version == 222 &&
-        rd->procedure == 0))
-            result = 0;
-    SCLogDebug("rd2 Flags: %d; program: %u, version: %u, procedure: %u", rd->flags, rd->program, rd->program_version, rd->procedure);
+    FAIL_IF_NOT(rd->flags & DETECT_RPC_CHECK_PROGRAM);
+    FAIL_IF_NOT(rd->flags & DETECT_RPC_CHECK_VERSION);
+    FAIL_IF(rd->flags & DETECT_RPC_CHECK_PROCEDURE);
+    FAIL_IF_NOT(rd->program == 111);
+    FAIL_IF_NOT(rd->program_version == 222);
+    FAIL_IF_NOT(rd->procedure == 0);
 
     DetectRpcFree(NULL, rd);
 
     rd = DetectRpcParse(NULL, "111,*,*");
-    if (rd == NULL)
-        return 0;
+    FAIL_IF_NULL(rd);
 
-    if ( !(rd->flags & DETECT_RPC_CHECK_PROGRAM &&
-        !(rd->flags & DETECT_RPC_CHECK_VERSION) &&
-        !(rd->flags & DETECT_RPC_CHECK_PROCEDURE) &&
-        rd->program == 111 && rd->program_version == 0 &&
-        rd->procedure == 0))
-            result = 0;
-    SCLogDebug("rd2 Flags: %d; program: %u, version: %u, procedure: %u", rd->flags, rd->program, rd->program_version, rd->procedure);
+    FAIL_IF_NOT(rd->flags & DETECT_RPC_CHECK_PROGRAM);
+    FAIL_IF(rd->flags & DETECT_RPC_CHECK_VERSION);
+    FAIL_IF(rd->flags & DETECT_RPC_CHECK_PROCEDURE);
+    FAIL_IF_NOT(rd->program == 111);
+    FAIL_IF_NOT(rd->program_version == 0);
+    FAIL_IF_NOT(rd->procedure == 0);
 
     DetectRpcFree(NULL, rd);
 
     rd = DetectRpcParse(NULL, "111,222");
-    if (rd == NULL)
-        return 0;
+    FAIL_IF_NULL(rd);
 
-    if ( !(rd->flags & DETECT_RPC_CHECK_PROGRAM &&
-        rd->flags & DETECT_RPC_CHECK_VERSION &&
-        !(rd->flags & DETECT_RPC_CHECK_PROCEDURE) &&
-        rd->program == 111 && rd->program_version == 222 &&
-        rd->procedure == 0))
-            result = 0;
-    SCLogDebug("rd2 Flags: %d; program: %u, version: %u, procedure: %u", rd->flags, rd->program, rd->program_version, rd->procedure);
+    FAIL_IF_NOT(rd->flags & DETECT_RPC_CHECK_PROGRAM);
+    FAIL_IF_NOT(rd->flags & DETECT_RPC_CHECK_VERSION);
+    FAIL_IF(rd->flags & DETECT_RPC_CHECK_PROCEDURE);
+    FAIL_IF_NOT(rd->program == 111);
+    FAIL_IF_NOT(rd->program_version == 222);
+    FAIL_IF_NOT(rd->procedure == 0);
 
     DetectRpcFree(NULL, rd);
 
     rd = DetectRpcParse(NULL, "111");
-    if (rd == NULL)
-        return 0;
+    FAIL_IF_NULL(rd);
 
-    if ( !(rd->flags & DETECT_RPC_CHECK_PROGRAM &&
-        !(rd->flags & DETECT_RPC_CHECK_VERSION) &&
-        !(rd->flags & DETECT_RPC_CHECK_PROCEDURE) &&
-        rd->program == 111 && rd->program_version == 0 &&
-        rd->procedure == 0))
-            result = 0;
-    SCLogDebug("rd2 Flags: %d; program: %u, version: %u, procedure: %u", rd->flags, rd->program, rd->program_version, rd->procedure);
+    FAIL_IF_NOT(rd->flags & DETECT_RPC_CHECK_PROGRAM);
+    FAIL_IF(rd->flags & DETECT_RPC_CHECK_VERSION);
+    FAIL_IF(rd->flags & DETECT_RPC_CHECK_PROCEDURE);
+    FAIL_IF_NOT(rd->program == 111);
+    FAIL_IF_NOT(rd->program_version == 0);
+    FAIL_IF_NOT(rd->procedure == 0);
 
     DetectRpcFree(NULL, rd);
-    return result;
+    PASS;
 }
 
 /**
@@ -429,17 +411,13 @@ static int DetectRpcTestParse03 (void)
  */
 static int DetectRpcTestParse04 (void)
 {
-    int result = 0;
     DetectRpcData *rd = NULL;
     rd = DetectRpcParse(NULL, "");
-    if (rd == NULL) {
-        result = 1;
-    } else {
-        SCLogDebug("Error: Flags: %d; program: %u, version: %u, procedure: %u", rd->flags, rd->program, rd->program_version, rd->procedure);
-        DetectRpcFree(NULL, rd);
-    }
 
-    return result;
+    FAIL_IF_NOT_NULL(rd);
+    DetectRpcFree(NULL, rd);
+
+    PASS;
 }
 
 /**
@@ -450,14 +428,11 @@ static int DetectRpcTestParse05 (void)
     int result = 0;
     DetectRpcData *rd = NULL;
     rd = DetectRpcParse(NULL, "111,aaa,*");
-    if (rd == NULL) {
-        result = 1;
-    } else {
-        SCLogDebug("Error: Flags: %d; program: %u, version: %u, procedure: %u", rd->flags, rd->program, rd->program_version, rd->procedure);
-        DetectRpcFree(NULL, rd);
-    }
 
-    return result;
+    FAIL_IF_NOT_NULL(rd);
+    DetectRpcFree(NULL, rd);
+
+    PASS;
 }
 
 /**
@@ -500,68 +475,41 @@ static int DetectRpcTestSig01(void)
     Signature *s = NULL;
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx;
-    int result = 0;
 
     memset(&th_v, 0, sizeof(th_v));
 
     p = UTHBuildPacket(buf, buflen, IPPROTO_UDP);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL) {
-        goto end;
-    }
+    FAIL_IF_NULL(de_ctx);
 
     de_ctx->flags |= DE_QUIET;
 
     s = de_ctx->sig_list = SigInit(de_ctx,"alert udp any any -> any any (msg:\"RPC Get Port Call\"; rpc:100000, 2, 3; sid:1;)");
-    if (s == NULL) {
-        goto end;
-    }
+    FAIL_IF_NULL(s);
 
     s = s->next = SigInit(de_ctx,"alert udp any any -> any any (msg:\"RPC Get Port Call\"; rpc:100000, 2, *; sid:2;)");
-    if (s == NULL) {
-        goto end;
-    }
+    FAIL_IF_NULL(s);
 
     s = s->next = SigInit(de_ctx,"alert udp any any -> any any (msg:\"RPC Get Port Call\"; rpc:100000, *, 3; sid:3;)");
-    if (s == NULL) {
-        goto end;
-    }
+    FAIL_IF_NULL(s);
 
     s = s->next = SigInit(de_ctx,"alert udp any any -> any any (msg:\"RPC Get Port Call\"; rpc:100000, *, *; sid:4;)");
-    if (s == NULL) {
-        goto end;
-    }
+    FAIL_IF_NULL(s);
 
     s = s->next = SigInit(de_ctx,"alert udp any any -> any any (msg:\"RPC Get XXX Call.. no match\"; rpc:123456, *, 3; sid:5;)");
-    if (s == NULL) {
-        goto end;
-    }
+    FAIL_IF_NULL(s);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    if (PacketAlertCheck(p, 1) == 0) {
-        printf("sid 1 didnt alert, but it should have: ");
-        goto cleanup;
-    } else if (PacketAlertCheck(p, 2) == 0) {
-        printf("sid 2 didnt alert, but it should have: ");
-        goto cleanup;
-    } else if (PacketAlertCheck(p, 3) == 0) {
-        printf("sid 3 didnt alert, but it should have: ");
-        goto cleanup;
-    } else if (PacketAlertCheck(p, 4) == 0) {
-        printf("sid 4 didnt alert, but it should have: ");
-        goto cleanup;
-    } else if (PacketAlertCheck(p, 5) > 0) {
-        printf("sid 5 did alert, but should not: ");
-        goto cleanup;
-    }
+    FAIL_IF(PacketAlertCheck(p, 1) == 0);
+    FAIL_IF(PacketAlertCheck(p, 2) == 0);
+    FAIL_IF(PacketAlertCheck(p, 3) == 0);
+    FAIL_IF(PacketAlertCheck(p, 4) == 0);
+    FAIL_IF(PacketAlertCheck(p, 5) > 0);
 
-    result = 1;
-
-cleanup:
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
 
@@ -569,8 +517,8 @@ cleanup:
     DetectEngineCtxFree(de_ctx);
 
     UTHFreePackets(&p, 1);
-end:
-    return result;
+
+    PASS;
 }
 
 /**


### PR DESCRIPTION
- detect-rpc: convert unit tests to new FAIL/PASS API

I was wondering if some of the longer tests (like 3rd and 5th) shouldn't be split into smaller, more concise ones...
Also I am not sure about the debugging messages. I mean, they wouldn't work as they did in the previous code, because there are no checks any more, that's why I deleted them. But... should they go somewhere else, now? That's another reason for me to think that splitting the tests could be a good thing. Would be easier to know what was the matter, when a test failed...

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4056

Describe changes:
- detect-rpc: convert unit tests to new FAIL/PASS API
- detect-rpb: delete debug code from unit tests

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
