### PR TITLE
dnp3: set byte order when logging dnp3 src and dst - v1

### DIFF
--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -152,8 +152,8 @@ void JsonDNP3LogRequest(JsonBuilder *js, DNP3Transaction *dnp3tx)
     JsonDNP3LogLinkControl(js, dnp3tx->request_lh.control);
     jb_close(js);
 
-    jb_set_uint(js, "src", dnp3tx->request_lh.src);
-    jb_set_uint(js, "dst", dnp3tx->request_lh.dst);
+    jb_set_uint(js, "src", DNP3_SWAP16(dnp3tx->request_lh.src));
+    jb_set_uint(js, "dst", DNP3_SWAP16(dnp3tx->request_lh.dst));
 
     jb_open_object(js, "application");
 


### PR DESCRIPTION
DNP3 uses little endian on the wire, for the most part this
is handled as the messages are deserialize. However, the link
header is a cast over raw data, so swap these bytes as they
are being logged.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/4173

