### PR TITLE
Fuzzing and rust coverage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2624,7 +2624,7 @@ fi
     AC_ARG_ENABLE(fuzztargets,
         AS_HELP_STRING([--enable-fuzztargets], [Enable fuzz targets]),[enable_fuzztargets=$enableval],[enable_fuzztargets=no])
     AM_CONDITIONAL([BUILD_FUZZTARGETS], [test "x$enable_fuzztargets" = "xyes"])
-    AM_CONDITIONAL([RUST_BUILD_STD], [test "x$enable_fuzztargets" = "xyes" && echo "$rust_compiler_version" | grep -q nightly])
+    AM_CONDITIONAL([RUST_BUILD_STD], [test "x$enable_fuzztargets" = "xyes" && echo "$rust_compiler_version" | grep -q nightly && echo "$RUSTFLAGS" | grep -v -q coverage])
     AC_PROG_CXX
     AS_IF([test "x$enable_fuzztargets" = "xyes"], [
         AS_IF([test "x$CARGO_BUILD_TARGET" = "x" && echo "$rust_compiler_version" | grep -q nightly], [

--- a/src/tests/fuzz/onefile.c
+++ b/src/tests/fuzz/onefile.c
@@ -1,25 +1,17 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <dirent.h>
+#include <unistd.h>
 #include "autoconf.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 
-int main(int argc, char** argv)
-{
-    FILE * fp;
+static int runOneFile(const char *fname) {
+    //opens the file, get its size, and reads it into a buffer
     uint8_t *data;
     size_t size;
-
-    if (argc != 2) {
-        return 1;
-    }
-#ifdef AFLFUZZ_PERSISTANT_MODE
-    while (__AFL_LOOP(1000)) {
-#endif /* AFLFUZZ_PERSISTANT_MODE */
-
-    //opens the file, get its size, and reads it into a buffer
-    fp = fopen(argv[1], "rb");
+    FILE *fp = fopen(fname, "rb");
     if (fp == NULL) {
         return 2;
     }
@@ -51,6 +43,48 @@ int main(int argc, char** argv)
     LLVMFuzzerTestOneInput(data, size);
     free(data);
     fclose(fp);
+    return 0;
+}
+
+int main(int argc, char** argv)
+{
+    DIR *d;
+    struct dirent *dir;
+    int r;
+
+    if (argc != 2) {
+        return 1;
+    }
+#ifdef AFLFUZZ_PERSISTANT_MODE
+    while (__AFL_LOOP(1000)) {
+#endif /* AFLFUZZ_PERSISTANT_MODE */
+
+    d = opendir(argv[1]);
+    if (d == NULL) {
+        //run one file
+        r = runOneFile(argv[1]);
+        if (r != 0) {
+            return r;
+        }
+    } else {
+        //run every file in one directory
+        if (chdir(argv[1]) != 0) {
+            closedir(d);
+            printf("Invalid directory\n");
+            return 2;
+        }
+        while((dir = readdir(d)) != NULL) {
+            if (dir->d_type != DT_REG) {
+                continue;
+            }
+            printf("Running file %s ", dir->d_name);
+            r = runOneFile(dir->d_name);
+            if (r != 0) {
+                return r;
+            }
+        }
+        closedir(d);
+    }
 #ifdef AFLFUZZ_PERSISTANT_MODE
     }
 #endif /* AFLFUZZ_PERSISTANT_MODE */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4125

Describe changes:
- do not rebuild rust std when instrumenting for coverage (as both seem incompatible)
- fuzz driver accepts directories as well as single files now

TL;DR
To get coverage report including rust with oss-fuzz, we will also need rustc changes, and oss-fuzz changes
To get this manually is possible, cf below

To get coverage, I compile with
```
export RUSTFLAGS="$RUSTFLAGS -Zinstrument-coverage"
export CFLAGS="-g -O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fprofile-instr-generate -fcoverage-mapping -pthread -fsanitize=fuzzer-no-link"
export CXXFLAGS="-g -O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fprofile-instr-generate -fcoverage-mapping -pthread -fsanitize=fuzzer-no-link -stdlib=libc++"
```

I also run in rust subdirectory
```
abspath=`cargo metadata | jq -r '.workspace_root'`
export RUSTFLAGS="$RUSTFLAGS --remap-path-prefix src=$abspath/src"
```
to get the absolute file paths for suricata's crate, so that llvm-cov can generate a nice report

You need some fresh rust nightly compiler and llvm 10
For LLVM 11 and 12, rust compiler is not ready yet cf https://github.com/rust-lang/rust/pull/79365