### PR TITLE
doc: http.uri.raw has no spaces

### DIFF
--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -190,6 +190,12 @@ characters %20 in a uri. This means matching on the uri.raw. The
 uri.raw and the normalized uri are separate buffers. So, the uri.raw
 inspects the uri.raw buffer and can not inspect the normalized buffer.
 
+.. note:: uri.raw never has any spaces in it.
+          In case of a request line ``GET /uid=0(root) gid=0(root) HTTP/1.1``,
+          the http.uri.raw will match ``/uid=0(root)``
+          and http.protocol will match ``gid=0(root) HTTP/1.1``
+          `https://redmine.openinfosecfoundation.org/issues/2881 <https://redmine.openinfosecfoundation.org/issues/2881>`_
+
 Example of the URI in a HTTP request:
 
 .. image:: http-keywords/uri1.png


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2881

Describe changes:
- Document that http.uri.raw has no spaces as they are parsed in the protocol field

Not sure how to test the appearance of such a documentation PR