### PR TITLE
Backports 5.0.x backports

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -158,7 +158,7 @@ jobs:
     steps:
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.33.0 -y
-      - run: echo "::add-path::/github/home/.cargo/bin"
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Install system dependencies
         run: |
           yum -y install epel-release
@@ -356,7 +356,7 @@ jobs:
                 zlib1g-dev
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.33.0 -y
-      - run: echo "::add-path::/github/home/.cargo/bin"
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Download suricata.tar.gz
         uses: actions/download-artifact@v1
         with:
@@ -489,7 +489,7 @@ jobs:
                 zlib1g-dev
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.33.0 -y
-      - run: echo "::add-path::/github/home/.cargo/bin"
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v1
       - name: Bundling libhtp
         run: git clone https://github.com/OISF/libhtp -b 0.5.x

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -54,7 +54,7 @@ jobs:
                 software-properties-common \
                 zlib1g \
                 zlib1g-dev
-      - run: echo "::add-path::$HOME/.cargo/bin:/usr/lib/ccache"
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Install cbindgen
         run: cargo install cbindgen
       - run: echo $PATH

--- a/doc/userguide/rules/header-keywords.rst
+++ b/doc/userguide/rules/header-keywords.rst
@@ -635,3 +635,9 @@ Example of icmp_seq in a rule:
 .. container:: example-rule
 
     alert icmp $EXTERNAL_NET any -> $HOME_NET any (msg:"GPL SCAN Broadscan Smurf Scanner"; dsize:4; icmp_id:0; :example-rule-emphasis:`icmp_seq:0;` itype:8; classtype:attempted-recon; sid:2100478; rev:4;)
+
+icmpv4.hdr
+^^^^^^^^^^
+
+Sitcky buffer to match on the whole ICMPv4 header.
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -204,6 +204,7 @@ detect-http-ua.c detect-http-ua.h \
 detect-http-uri.c detect-http-uri.h \
 detect-icmp-id.c detect-icmp-id.h \
 detect-icmp-seq.c detect-icmp-seq.h \
+detect-icmpv4hdr.c detect-icmpv4hdr.h \
 detect-icode.c detect-icode.h \
 detect-id.c detect-id.h \
 detect-ipopts.c detect-ipopts.h \

--- a/src/decode-icmpv4.h
+++ b/src/decode-icmpv4.h
@@ -186,6 +186,9 @@ typedef struct ICMPV4Vars_
     uint16_t  id;
     uint16_t  seq;
 
+    /** Actual header length **/
+    uint32_t hlen;
+
     /** Pointers to the embedded packet headers */
     IPV4Hdr *emb_ipv4h;
     TCPHdr *emb_tcph;
@@ -202,6 +205,23 @@ typedef struct ICMPV4Vars_
     uint16_t emb_sport;
     uint16_t emb_dport;
 } ICMPV4Vars;
+
+/* ICMPV4 Router Advertisement - fixed components */
+/* actual size determined by address count and size */
+typedef struct ICMPV4RtrAdvert_ {
+    /** Number of advertised addresses **/
+    uint8_t naddr;
+
+    /** Size of each advertised address **/
+    uint8_t addr_sz;
+} __attribute__((__packed__)) ICMPV4RtrAdvert;
+
+/* ICMPV4 TImestamp messages */
+typedef struct ICMPV4Timestamp_ {
+    uint32_t orig_ts;
+    uint32_t rx_ts;
+    uint32_t tx_ts;
+} __attribute__((__packed__)) ICMPV4Timestamp;
 
 #define CLEAR_ICMPV4_PACKET(p) do { \
     (p)->level4_comp_csum = -1;     \
@@ -238,6 +258,8 @@ typedef struct ICMPV4Vars_
 #define ICMPV4_GET_EMB_UDP(p)      (p)->icmpv4vars.emb_udph
 /** macro for icmpv4 embedded "icmpv4h" header access */
 #define ICMPV4_GET_EMB_ICMPV4H(p)  (p)->icmpv4vars.emb_icmpv4h
+/** macro for icmpv4 header length */
+#define ICMPV4_GET_HLEN_ICMPV4H(p) (p)->icmpv4vars.hlen
 
 /** macro for checking if a ICMP DEST UNREACH packet is valid for use
  *  in other parts of the engine, such as the flow engine. 

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -140,6 +140,7 @@
 #include "detect-icode.h"
 #include "detect-icmp-id.h"
 #include "detect-icmp-seq.h"
+#include "detect-icmpv4hdr.h"
 #include "detect-dce-iface.h"
 #include "detect-dce-opnum.h"
 #include "detect-dce-stub-data.h"
@@ -512,6 +513,7 @@ void SigTableSetup(void)
     DetectICodeRegister();
     DetectIcmpIdRegister();
     DetectIcmpSeqRegister();
+    DetectIcmpv4HdrRegister();
     DetectDceIfaceRegister();
     DetectDceOpnumRegister();
     DetectDceStubDataRegister();

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -46,6 +46,7 @@ enum DetectKeywordId {
     DETECT_ICODE,
     DETECT_ICMP_ID,
     DETECT_ICMP_SEQ,
+    DETECT_ICMPV4HDR,
     DETECT_DSIZE,
 
     DETECT_FLOW,

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -415,13 +415,10 @@ static int DetectFilemagicSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
     if (filemagic == NULL)
         return -1;
 
-    if (g_magic_thread_ctx_id == -1) {
-        g_magic_thread_ctx_id = DetectRegisterThreadCtxFuncs(de_ctx, "filemagic",
-                DetectFilemagicThreadInit, (void *)filemagic,
-                DetectFilemagicThreadFree, 1);
-        if (g_magic_thread_ctx_id == -1)
-            goto error;
-    }
+    g_magic_thread_ctx_id = DetectRegisterThreadCtxFuncs(de_ctx, "filemagic",
+            DetectFilemagicThreadInit, (void *)filemagic, DetectFilemagicThreadFree, 1);
+    if (g_magic_thread_ctx_id == -1)
+        goto error;
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */

--- a/src/detect-icmpv4hdr.c
+++ b/src/detect-icmpv4hdr.c
@@ -1,0 +1,124 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ *
+ */
+
+#include "suricata-common.h"
+
+#include "detect.h"
+#include "detect-engine.h"
+#include "detect-engine-mpm.h"
+#include "detect-icmpv4hdr.h"
+
+/* prototypes */
+static int DetectIcmpv4HdrSetup(DetectEngineCtx *, Signature *, const char *);
+#ifdef UNITTESTS
+void DetectIcmpv4HdrRegisterTests(void);
+#endif
+
+static int g_icmpv4hdr_buffer_id = 0;
+
+static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Packet *p, const int list_id);
+
+/**
+ * \brief Registration function for icmpv4.hdr: keyword
+ */
+void DetectIcmpv4HdrRegister(void)
+{
+    sigmatch_table[DETECT_ICMPV4HDR].name = "icmpv4.hdr";
+    sigmatch_table[DETECT_ICMPV4HDR].desc = "sticky buffer to match on the ICMP v4 header";
+    sigmatch_table[DETECT_ICMPV4HDR].url = "/rules/header-keywords.html#icmpv4-hdr";
+    sigmatch_table[DETECT_ICMPV4HDR].Setup = DetectIcmpv4HdrSetup;
+    sigmatch_table[DETECT_ICMPV4HDR].flags |= SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
+#ifdef UNITTESTS
+    sigmatch_table[DETECT_ICMPV4HDR].RegisterTests = DetectIcmpv4HdrRegisterTests;
+#endif
+
+    g_icmpv4hdr_buffer_id = DetectBufferTypeRegister("icmpv4.hdr");
+    BUG_ON(g_icmpv4hdr_buffer_id < 0);
+
+    DetectBufferTypeSupportsPacket("icmpv4.hdr");
+
+    DetectPktMpmRegister("icmpv4.hdr", 2, PrefilterGenericMpmPktRegister, GetData);
+
+    DetectPktInspectEngineRegister("icmpv4.hdr", GetData, DetectEngineInspectPktBufferGeneric);
+
+    return;
+}
+
+/**
+ * \brief setup icmpv4.hdr sticky buffer
+ *
+ * \param de_ctx pointer to the Detection Engine Context
+ * \param s pointer to the Current Signature
+ * \param _unused unused
+ *
+ * \retval 0 on Success
+ * \retval -1 on Failure
+ */
+static int DetectIcmpv4HdrSetup(DetectEngineCtx *de_ctx, Signature *s, const char *_unused)
+{
+    if (!(DetectProtoContainsProto(&s->proto, IPPROTO_ICMP)))
+        return -1;
+
+    s->proto.flags |= DETECT_PROTO_IPV4;
+    s->flags |= SIG_FLAG_REQUIRE_PACKET;
+
+    if (DetectBufferSetActiveList(s, g_icmpv4hdr_buffer_id) < 0)
+        return -1;
+
+    return 0;
+}
+
+static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Packet *p, const int list_id)
+{
+    SCEnter();
+
+    if (p->icmpv4h == NULL) {
+        SCReturnPtr(NULL, "InspectionBuffer");
+    }
+
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        uint16_t hlen = ICMPV4_GET_HLEN_ICMPV4H(p);
+        if (((uint8_t *)p->icmpv4h + (ptrdiff_t)hlen) >
+                ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p))) {
+            SCLogDebug("data out of range: %p > %p", ((uint8_t *)p->icmpv4h + (ptrdiff_t)hlen),
+                    ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p)));
+            SCReturnPtr(NULL, "InspectionBuffer");
+        }
+
+        const uint32_t data_len = hlen;
+        const uint8_t *data = (const uint8_t *)p->icmpv4h;
+
+        InspectionBufferSetup(buffer, data, data_len);
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+
+    SCReturnPtr(buffer, "InspectionBuffer");
+}
+
+#ifdef UNITTESTS
+#include "tests/detect-icmpv4hdr.c"
+#endif

--- a/src/detect-icmpv4hdr.h
+++ b/src/detect-icmpv4hdr.h
@@ -1,0 +1,29 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ */
+
+#ifndef _DETECT_ICMPV4HDR_H
+#define _DETECT_ICMPV4HDR_H
+
+void DetectIcmpv4HdrRegister(void);
+
+#endif /* _DETECT_ICMPV4HDR_H */

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -447,13 +447,10 @@ TmEcode NapatechPacketLoopZC(ThreadVars *tv, void *data, void *slot)
                       NT_NET_GET_PKT_WIRE_LENGTH(packet_buffer)))) {
 
             TmqhOutputPacketpool(ntv->tv, p);
-            NT_NetRxRelease(ntv->rx_stream, packet_buffer);
             SCReturnInt(TM_ECODE_FAILED);
         }
 
         if (unlikely(TmThreadsSlotProcessPkt(ntv->tv, ntv->slot, p) != TM_ECODE_OK)) {
-            TmqhOutputPacketpool(ntv->tv, p);
-            NT_NetRxRelease(ntv->rx_stream, packet_buffer);
             SCReturnInt(TM_ECODE_FAILED);
         }
 

--- a/src/tests/detect-icmpv4hdr.c
+++ b/src/tests/detect-icmpv4hdr.c
@@ -1,0 +1,45 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "../suricata-common.h"
+
+#include "../detect.h"
+#include "../detect-parse.h"
+
+#include "../detect-icmpv4hdr.h"
+
+#include "../util-unittest.h"
+
+static int DetectIcmpv4HdrParseTest01(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    FAIL_IF_NULL(DetectEngineAppendSig(
+            de_ctx, "alert icmp any any -> any any (icmpv4.hdr; content:\"A\"; sid:1; rev:1;)"));
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+/**
+ * \brief this function registers unit tests for DetectIcmpv4Hdr
+ */
+void DetectIcmpv4HdrRegisterTests(void)
+{
+    UtRegisterTest("DetectIcmpv4HdrParseTest01", DetectIcmpv4HdrParseTest01);
+}


### PR DESCRIPTION
Continuation of #5605 

Batch backports to 5.0.x
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Replaced deprecated `add-path` from CI
- [4129](https://redmine.openinfosecfoundation.org/issues/4129)
- [4133](https://redmine.openinfosecfoundation.org/issues/4133)
- [4168](https://redmine.openinfosecfoundation.org/issues/4168)

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
