### PR TITLE
detect: fix inspection order with stateful rules

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -1009,8 +1009,13 @@ static int RuleMatchCandidateTxArrayExpand(DetectEngineThreadCtx *det_ctx, const
     return 1;
 }
 
-
-/* TODO maybe let one with flags win if equal? */
+/** \internal
+ *  \brief sort helper for sorting match candidates by id: ascending
+ *
+ *  The id field is set from Signature::num, so we sort the candidates to match the signature
+ *  sort order (ascending).
+ *
+ *  \todo maybe let one with flags win if equal? */
 static int
 DetectRunTxSortHelper(const void *a, const void *b)
 {
@@ -1019,7 +1024,7 @@ DetectRunTxSortHelper(const void *a, const void *b)
     if (s1->id == s0->id)
         return 0;
     else
-        return s0->id > s1->id ? -1 : 1;
+        return s0->id > s1->id ? 1 : -1;
 }
 
 #if 0


### PR DESCRIPTION
When stateful detection rules, for which detection has already started
for a previous packet, are added to the candidates array, the array
is sorted to mantain the correct inspection order. However, due to a
trivial error in the sort helper the array was sorted in descending
instead of ascending order.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
