### PR TITLE
Fuzz improve fixes v3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2626,7 +2626,7 @@ fi
     AC_ARG_ENABLE(fuzztargets,
         AS_HELP_STRING([--enable-fuzztargets], [Enable fuzz targets]),[enable_fuzztargets=$enableval],[enable_fuzztargets=no])
     AM_CONDITIONAL([BUILD_FUZZTARGETS], [test "x$enable_fuzztargets" = "xyes"])
-    AM_CONDITIONAL([RUST_BUILD_STD], [test "x$enable_fuzztargets" = "xyes" && echo "$rust_compiler_version" | grep -q nightly])
+    AM_CONDITIONAL([RUST_BUILD_STD], [test "x$enable_fuzztargets" = "xyes" && echo "$rust_compiler_version" | grep -q nightly && echo "$RUSTFLAGS" | grep -v -q coverage])
     AC_PROG_CXX
     AS_IF([test "x$enable_fuzztargets" = "xyes"], [
         AS_IF([test "x$CARGO_BUILD_TARGET" = "x" && echo "$rust_compiler_version" | grep -q nightly], [

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -1767,6 +1767,7 @@ static int DNP3CheckUserDataCRCsTest(void)
     };
     FAIL_IF(!DNP3CheckUserDataCRCs(data_valid, sizeof(data_valid)));
 
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     /* Multi-block data with one non-crc byte altered. */
     uint8_t data_invalid[] = {
         0xff, 0xc9, 0x05, 0x0c,
@@ -1791,7 +1792,6 @@ static int DNP3CheckUserDataCRCsTest(void)
         0x01, /* Invalid byte. */
         0xff, 0xff, /* CRC. */
     };
-#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     FAIL_IF(DNP3CheckUserDataCRCs(data_invalid, sizeof(data_invalid)));
 
     /* 1 byte - need at least 3. */

--- a/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
+++ b/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
@@ -64,7 +64,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         for (size_t i = 0; i < size-HEADER_LEN && i < PROTO_DETECT_MAX_LEN; i++) {
             alproto2 = AppLayerProtoDetectGetProto(alpd_tctx, f, data+HEADER_LEN, i, f->proto, data[0], &reverse);
             if (alproto2 != ALPROTO_UNKNOWN && alproto2 != alproto) {
-                printf("Assertion failure : With input length %"PRIuMAX", found %s instead of %s\n", (uintmax_t) i, AppProtoToString(alproto2), AppProtoToString(alproto));
+                printf("Failed with input length %" PRIuMAX " versus %" PRIuMAX
+                       ", found %s instead of %s\n",
+                        (uintmax_t)i, (uintmax_t)size - HEADER_LEN, AppProtoToString(alproto2),
+                        AppProtoToString(alproto));
+                printf("Assertion failure: %s-%s\n", AppProtoToString(alproto2),
+                        AppProtoToString(alproto));
+                fflush(stdout);
                 abort();
             }
         }

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -143,22 +143,23 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     p->ts.tv_usec = header->ts.tv_usec;
     p->datalink = pcap_datalink(pkts);
     while (r > 0) {
-        PacketCopyData(p, pkt, header->caplen);
-        //DecodePcapFile
-        TmEcode ecode = tmm_modules[TMM_DECODEPCAPFILE].Func(&tv, p, dtv);
-        if (ecode == TM_ECODE_FAILED) {
-            break;
-        }
-        Packet *extra_p = PacketDequeueNoLock(&tv.decode_pq);
-        while (extra_p != NULL) {
-            PacketFree(extra_p);
+        if (PacketCopyData(p, pkt, header->caplen) == 0) {
+            // DecodePcapFile
+            TmEcode ecode = tmm_modules[TMM_DECODEPCAPFILE].Func(&tv, p, dtv);
+            if (ecode == TM_ECODE_FAILED) {
+                break;
+            }
+            Packet *extra_p = PacketDequeueNoLock(&tv.decode_pq);
+            while (extra_p != NULL) {
+                PacketFree(extra_p);
+                extra_p = PacketDequeueNoLock(&tv.decode_pq);
+            }
+            tmm_modules[TMM_FLOWWORKER].Func(&tv, p, fwd);
             extra_p = PacketDequeueNoLock(&tv.decode_pq);
-        }
-        tmm_modules[TMM_FLOWWORKER].Func(&tv, p, fwd);
-        extra_p = PacketDequeueNoLock(&tv.decode_pq);
-        while (extra_p != NULL) {
-            PacketFree(extra_p);
-            extra_p = PacketDequeueNoLock(&tv.decode_pq);
+            while (extra_p != NULL) {
+                PacketFree(extra_p);
+                extra_p = PacketDequeueNoLock(&tv.decode_pq);
+            }
         }
         r = pcap_next_ex(pkts, &header, &pkt);
         PACKET_RECYCLE(p);

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -308,16 +308,16 @@ THashTableContext *THashInit(const char *cnf_prefix, size_t data_size,
     ctx->config.hash_size = hashsize > 0 ? hashsize : THASH_DEFAULT_HASHSIZE;
     /* Reset memcap in case of loading from file to the highest possible value
      unless defined by the rule keyword */
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    // limit memcap size to default when fuzzing
+    ctx->config.memcap = THASH_DEFAULT_MEMCAP;
+#else
     if (memcap > 0) {
         ctx->config.memcap = memcap;
     } else {
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-        // limit hash size to default when fuzzing
-        ctx->config.memcap = THASH_DEFAULT_MEMCAP;
-#else
         ctx->config.memcap = reset_memcap ? UINT64_MAX : THASH_DEFAULT_MEMCAP;
-#endif
     }
+#endif
     ctx->config.prealloc = THASH_DEFAULT_PREALLOC;
 
     SC_ATOMIC_INIT(ctx->counter);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4125

Describe changes:
- improves detect proto fuzz target (to be matched as an assert by oss-fuzz)
- fix one warning when compiling with unit tests and `DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION`
- limit memcap for datasets when fuzzing to avoid OOMs
- check PacketCopyData return value in fuzz sigpcap target
- rust : do not compile with coverage and build-std

Modifies #5615 with cocci check fix