### PR TITLE
Next/50x/20201201/v2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -293,7 +293,6 @@
             WINDOWS_PATH="yes"
             PCAP_LIB_NAME="wpcap"
             AC_DEFINE([HAVE_NON_POSIX_MKDIR], [1], [mkdir is not POSIX compliant: single arg])
-            RUST_SURICATA_LIBNAME="suricata.lib"
             RUST_LDADD=" -lws2_32 -liphlpapi -lwbemuuid -lOle32 -lOleAut32 -lUuid -luserenv -lshell32 -ladvapi32 -lgcc_eh"
             ;;
         *-*-cygwin)
@@ -2406,10 +2405,11 @@ fi
     fi
 
     if test "x$enable_debug" = "xyes"; then
-      RUST_SURICATA_LIB="../rust/target/${RUST_SURICATA_LIB_XC_DIR}debug/${RUST_SURICATA_LIBNAME}"
+      RUST_SURICATA_LIBDIR="../rust/target/${RUST_SURICATA_LIB_XC_DIR}debug"
     else
-      RUST_SURICATA_LIB="../rust/target/${RUST_SURICATA_LIB_XC_DIR}release/${RUST_SURICATA_LIBNAME}"
+      RUST_SURICATA_LIBDIR="../rust/target/${RUST_SURICATA_LIB_XC_DIR}release"
     fi
+    RUST_SURICATA_LIB="${RUST_SURICATA_LIBDIR}/${RUST_SURICATA_LIBNAME}"
 
     RUST_LDADD="${RUST_SURICATA_LIB} ${RUST_LDADD}"
     CFLAGS="${CFLAGS} -I\${srcdir}/../rust/gen/c-headers"
@@ -2592,6 +2592,8 @@ AC_SUBST(CONFIGURE_SYSCONDIR)
 AC_SUBST(CONFIGURE_LOCALSTATEDIR)
 AC_SUBST(CONFIGURE_DATAROOTDIR)
 AC_SUBST(PACKAGE_VERSION)
+AC_SUBST(RUST_FEATURES)
+AC_SUBST(RUST_SURICATA_LIBDIR)
 
 AC_CONFIG_FILES(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config)
 AC_CONFIG_FILES(qa/Makefile qa/coccinelle/Makefile)

--- a/configure.ac
+++ b/configure.ac
@@ -290,12 +290,11 @@
             ;;
         *-*-mingw32*|*-*-msys)
             CFLAGS="${CFLAGS} -DOS_WIN32"
-            LDFLAGS="${LDFLAGS} -lws2_32 -liphlpapi -lwbemuuid -lOle32 -lOleAut32 -lUuid"
             WINDOWS_PATH="yes"
             PCAP_LIB_NAME="wpcap"
             AC_DEFINE([HAVE_NON_POSIX_MKDIR], [1], [mkdir is not POSIX compliant: single arg])
             RUST_SURICATA_LIBNAME="suricata.lib"
-            RUST_LDADD="-luserenv -lshell32 -ladvapi32 -lgcc_eh"
+            RUST_LDADD=" -lws2_32 -liphlpapi -lwbemuuid -lOle32 -lOleAut32 -lUuid -luserenv -lshell32 -ladvapi32 -lgcc_eh"
             ;;
         *-*-cygwin)
             LUA_LIB_NAME="lua"

--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -170,6 +170,12 @@ characters %20 in a uri. This means matching on the uri.raw. The
 uri.raw and the normalized uri are separate buffers. So, the uri.raw
 inspects the uri.raw buffer and can not inspect the normalized buffer.
 
+.. note:: uri.raw never has any spaces in it.
+          With this request line ``GET /uid=0(root) gid=0(root) HTTP/1.1``,
+          the ``http.uri.raw`` will match ``/uid=0(root)``
+          and ``http.protocol`` will match ``gid=0(root) HTTP/1.1``
+          Reference: `https://redmine.openinfosecfoundation.org/issues/2881 <https://redmine.openinfosecfoundation.org/issues/2881>`_
+
 Example of the URI in a HTTP request:
 
 .. image:: http-keywords/uri1.png

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -39,6 +39,10 @@ else
 		$(CARGO) build $(RELEASE) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)
 endif
+	if test -e $(RUST_SURICATA_LIBDIR)/suricata.lib; then \
+		cp $(RUST_SURICATA_LIBDIR)/suricata.lib \
+			$(RUST_SURICATA_LIBDIR)/libsuricata.a; \
+	fi
 
 clean-local:
 	-rm -rf target gen


### PR DESCRIPTION
Backport of #5614 
#5623

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
Passed