### PR TITLE
Http2 keywords 4067 v1

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -2090,9 +2090,14 @@ void AppLayerProtoDetectSupportedIpprotos(AppProto alproto, uint8_t *ipprotos)
 {
     SCEnter();
 
+    if (alproto == ALPROTO_HTTP_ANY) {
+        AppLayerProtoDetectSupportedIpprotos(ALPROTO_HTTP, ipprotos);
+        AppLayerProtoDetectSupportedIpprotos(ALPROTO_HTTP2, ipprotos);
+    } else {
     AppLayerProtoDetectPMGetIpprotos(alproto, ipprotos);
     AppLayerProtoDetectPPGetIpprotos(alproto, ipprotos);
     AppLayerProtoDetectPEGetIpprotos(alproto, ipprotos);
+    }
 
     SCReturn;
 }

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -2107,12 +2107,11 @@ AppProto AppLayerProtoDetectGetProtoByName(const char *alproto_name)
     SCEnter();
 
     AppProto a;
+    AppProto b = StringToAppProto(alproto_name);
     for (a = 0; a < ALPROTO_MAX; a++) {
-        if (alpd_ctx.alproto_names[a] != NULL &&
-            strlen(alpd_ctx.alproto_names[a]) == strlen(alproto_name) &&
-            (SCMemcmp(alpd_ctx.alproto_names[a], alproto_name, strlen(alproto_name)) == 0))
+        if (alpd_ctx.alproto_names[a] != NULL && AppProtoEquals(b, a))
         {
-            SCReturnCT(a, "AppProto");
+            SCReturnCT(b, "AppProto");
         }
     }
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1122,6 +1122,10 @@ uint64_t AppLayerParserGetTransactionActive(const Flow *f,
 
 int AppLayerParserSupportsFiles(uint8_t ipproto, AppProto alproto)
 {
+    if (alproto == ALPROTO_HTTP_ANY) {
+        return AppLayerParserSupportsFiles(ipproto, ALPROTO_HTTP) ||
+               AppLayerParserSupportsFiles(ipproto, ALPROTO_HTTP2);
+    }
     if (alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].StateGetFiles != NULL)
         return TRUE;
     return FALSE;

--- a/src/app-layer-protos.c
+++ b/src/app-layer-protos.c
@@ -120,6 +120,9 @@ const char *AppProtoToString(AppProto alproto)
         case ALPROTO_HTTP2:
             proto_name = "http2";
             break;
+        case ALPROTO_HTTP_ANY:
+            proto_name = "http_any";
+            break;
         case ALPROTO_FAILED:
             proto_name = "failed";
             break;
@@ -138,7 +141,8 @@ AppProto StringToAppProto(const char *proto_name)
 {
     if (proto_name == NULL) return ALPROTO_UNKNOWN;
 
-    if (strcmp(proto_name,"http")==0) return ALPROTO_HTTP;
+    if (strcmp(proto_name,"http")==0) return ALPROTO_HTTP_ANY;
+    if (strcmp(proto_name,"http1")==0) return ALPROTO_HTTP;
     if (strcmp(proto_name,"ftp")==0) return ALPROTO_FTP;
     if (strcmp(proto_name,"smtp")==0) return ALPROTO_SMTP;
     if (strcmp(proto_name,"tls")==0) return ALPROTO_TLS;

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -57,6 +57,7 @@ enum AppProtoEnum {
     ALPROTO_TEMPLATE_RUST,
     ALPROTO_RDP,
     ALPROTO_HTTP2,
+    ALPROTO_HTTP_ANY, // HTTP but any version 1 or 2, used in signatures
 
     /* used by the probing parser when alproto detection fails
      * permanently for that particular stream */
@@ -75,6 +76,16 @@ typedef uint16_t AppProto;
 static inline bool AppProtoIsValid(AppProto a)
 {
     return ((a > ALPROTO_UNKNOWN && a < ALPROTO_FAILED));
+}
+
+static inline bool AppProtoEquals(AppProto sigproto, AppProto alproto)
+{
+    switch (sigproto) {
+        case ALPROTO_HTTP_ANY:
+            return (alproto == ALPROTO_HTTP) || (alproto == ALPROTO_HTTP2) ||
+                   (alproto == ALPROTO_HTTP_ANY);
+    }
+    return (sigproto == alproto);
 }
 
 /**

--- a/src/detect-app-layer-protocol.c
+++ b/src/detect-app-layer-protocol.c
@@ -136,7 +136,7 @@ static int DetectAppLayerProtocolSetup(DetectEngineCtx *de_ctx,
     DetectAppLayerProtocolData *data = NULL;
     SigMatch *sm = NULL;
 
-    if (s->alproto != ALPROTO_UNKNOWN) {
+    if (s->alolproto != ALPROTO_UNKNOWN) {
         SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS, "Either we already "
                    "have the rule match on an app layer protocol set through "
                    "other keywords that match on this protocol, or have "

--- a/src/detect-dce-iface.c
+++ b/src/detect-dce-iface.c
@@ -160,8 +160,8 @@ static int DetectDceIfaceSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 {
     SCEnter();
 
-    if (s->alproto != ALPROTO_UNKNOWN && s->alproto != ALPROTO_DCERPC &&
-        s->alproto != ALPROTO_SMB) {
+    if (s->alolproto != ALPROTO_UNKNOWN && s->alolproto != ALPROTO_DCERPC &&
+        s->alolproto != ALPROTO_SMB) {
         SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS, "rule contains conflicting keywords.");
         return -1;
     }

--- a/src/detect-dce-opnum.c
+++ b/src/detect-dce-opnum.c
@@ -132,8 +132,8 @@ static int DetectDceOpnumSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         return -1;
     }
 
-    if (s->alproto != ALPROTO_UNKNOWN && s->alproto != ALPROTO_DCERPC &&
-        s->alproto != ALPROTO_SMB) {
+    if (s->alolproto != ALPROTO_UNKNOWN && s->alolproto != ALPROTO_DCERPC &&
+        s->alolproto != ALPROTO_SMB) {
         SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS, "rule contains conflicting keywords.");
         return -1;
     }

--- a/src/detect-dce-stub-data.c
+++ b/src/detect-dce-stub-data.c
@@ -171,8 +171,8 @@ void DetectDceStubDataRegister(void)
 
 static int DetectDceStubDataSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
 {
-    if (s->alproto != ALPROTO_UNKNOWN && s->alproto != ALPROTO_DCERPC &&
-        s->alproto != ALPROTO_SMB) {
+    if (s->alolproto != ALPROTO_UNKNOWN && s->alolproto != ALPROTO_DCERPC &&
+        s->alolproto != ALPROTO_SMB) {
         SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS, "rule contains conflicting keywords.");
         return -1;
     }

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -687,7 +687,7 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
     jb_set_uint(ctx.js, "rev", s->rev);
     jb_set_string(ctx.js, "msg", s->msg);
 
-    const char *alproto = AppProtoToString(s->alproto);
+    const char *alproto = AppProtoToString(s->alolproto);
     jb_set_string(ctx.js, "app_proto", alproto);
 
     jb_open_array(ctx.js, "requirements");
@@ -1098,7 +1098,7 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
         rule_warning += 1;
         warn_pcre_http_content = 1;
     }
-    else if (s->alproto == ALPROTO_HTTP && rule_pcre > 0 && rule_pcre_http == 0) {
+    else if (s->alolproto == ALPROTO_HTTP && rule_pcre > 0 && rule_pcre_http == 0) {
         rule_warning += 1;
         warn_pcre_http = 1;
     }
@@ -1107,7 +1107,7 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
         rule_warning += 1;
         warn_content_http_content = 1;
     }
-    if (s->alproto == ALPROTO_HTTP && rule_content > 0 && rule_content_http == 0) {
+    if (s->alolproto == ALPROTO_HTTP && rule_content > 0 && rule_content_http == 0) {
         rule_warning += 1;
         warn_content_http = 1;
     }
@@ -1151,11 +1151,11 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
         rule_warning += 1;
         warn_offset_depth_pkt_stream = 1;
     }
-    if (rule_content_offset_depth > 0 && !stream_buf && packet_buf && s->alproto != ALPROTO_UNKNOWN) {
+    if (rule_content_offset_depth > 0 && !stream_buf && packet_buf && s->alolproto != ALPROTO_UNKNOWN) {
         rule_warning += 1;
         warn_offset_depth_alproto = 1;
     }
-    if (s->init_data->mpm_sm != NULL && s->alproto == ALPROTO_HTTP &&
+    if (s->init_data->mpm_sm != NULL && s->alolproto == ALPROTO_HTTP &&
         SigMatchListSMBelongsTo(s, s->init_data->mpm_sm) == DETECT_SM_LIST_PMATCH) {
         rule_warning += 1;
         warn_non_alproto_fp_for_alproto_sig = 1;
@@ -1192,8 +1192,8 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
                  fprintf(rule_engine_analysis_FD, "    Rule matches on %s buffer.\n", ai->display_name);
             }
         }
-        if (s->alproto != ALPROTO_UNKNOWN) {
-            fprintf(rule_engine_analysis_FD, "    App layer protocol is %s.\n", AppProtoToString(s->alproto));
+        if (s->alolproto != ALPROTO_UNKNOWN) {
+            fprintf(rule_engine_analysis_FD, "    App layer protocol is %s.\n", AppProtoToString(s->alolproto));
         }
         if (rule_content || rule_content_http || rule_pcre || rule_pcre_http) {
             fprintf(rule_engine_analysis_FD, "    Rule contains %d content options, %d http content options, %d pcre options, and %d pcre options with http modifiers.\n", rule_content, rule_content_http, rule_pcre, rule_pcre_http);
@@ -1273,7 +1273,7 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
                     "app layer protocol - %d.  This can lead to FNs if we "
                     "have a offset/depth content match on a packet payload "
                     "before we can detect the app layer protocol for the "
-                    "flow.\n", s->alproto);
+                    "flow.\n", s->alolproto);
         }
         if (warn_non_alproto_fp_for_alproto_sig) {
             fprintf(rule_engine_analysis_FD, "    Warning: Rule app layer "

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -186,7 +186,7 @@ int SignatureIsFilesizeInspecting(const Signature *s)
  */
 int SignatureIsIPOnly(DetectEngineCtx *de_ctx, const Signature *s)
 {
-    if (s->alproto != ALPROTO_UNKNOWN)
+    if (s->alolproto != ALPROTO_UNKNOWN)
         return 0;
 
     if (s->init_data->smlists[DETECT_SM_LIST_PMATCH] != NULL)
@@ -252,7 +252,7 @@ iponly:
  */
 static int SignatureIsPDOnly(const DetectEngineCtx *de_ctx, const Signature *s)
 {
-    if (s->alproto != ALPROTO_UNKNOWN)
+    if (s->alolproto != ALPROTO_UNKNOWN)
         return 0;
 
     if (s->init_data->smlists[DETECT_SM_LIST_PMATCH] != NULL)
@@ -336,7 +336,7 @@ static int SignatureIsInspectingPayload(DetectEngineCtx *de_ctx, const Signature
  */
 static int SignatureIsDEOnly(DetectEngineCtx *de_ctx, const Signature *s)
 {
-    if (s->alproto != ALPROTO_UNKNOWN) {
+    if (s->alolproto != ALPROTO_UNKNOWN) {
         SCReturnInt(0);
     }
 
@@ -710,8 +710,8 @@ static json_t *RulesGroupPrintSghStats(const SigGroupHead *sgh,
             uint32_t size = cd->content_len < 256 ? cd->content_len : 255;
 
             mpm_sizes[mpm_list][size]++;
-            if (s->alproto != ALPROTO_UNKNOWN) {
-                alproto_mpm_bufs[s->alproto][mpm_list]++;
+            if (s->alolproto != ALPROTO_UNKNOWN) {
+                alproto_mpm_bufs[s->alolproto][mpm_list]++;
             }
 
             if (mpm_list == DETECT_SM_LIST_PMATCH) {
@@ -771,8 +771,8 @@ static json_t *RulesGroupPrintSghStats(const SigGroupHead *sgh,
             payload_no_mpm_cnt++;
         }
 
-        if (s->alproto != ALPROTO_UNKNOWN) {
-            alstats[s->alproto]++;
+        if (s->alolproto != ALPROTO_UNKNOWN) {
+            alstats[s->alolproto]++;
         }
 
         if (add_rules) {

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -710,6 +710,7 @@ static json_t *RulesGroupPrintSghStats(const SigGroupHead *sgh,
             uint32_t size = cd->content_len < 256 ? cd->content_len : 255;
 
             mpm_sizes[mpm_list][size]++;
+            // && s->alolproto != ALPROTO_HTTP_ANY
             if (s->alolproto != ALPROTO_UNKNOWN) {
                 alproto_mpm_bufs[s->alolproto][mpm_list]++;
             }

--- a/src/detect-engine-prefilter-common.c
+++ b/src/detect-engine-prefilter-common.c
@@ -80,9 +80,9 @@ static void GetExtraMatch(const Signature *s, uint16_t *type, uint16_t *value)
     {
         *type = PREFILTER_EXTRA_MATCH_SRCPORT;
         *value = s->sp->port;
-    } else if (s->alproto != ALPROTO_UNKNOWN) {
+    } else if (s->alolproto != ALPROTO_UNKNOWN) {
         *type = PREFILTER_EXTRA_MATCH_ALPROTO;
-        *value = s->alproto;
+        *value = s->alolproto;
     } else if (s->dp != NULL && s->dp->next == NULL && s->dp->port == s->dp->port2 &&
         !(s->dp->flags & PORT_FLAG_NOT))
     {

--- a/src/detect-engine-prefilter-common.h
+++ b/src/detect-engine-prefilter-common.h
@@ -79,7 +79,7 @@ PrefilterPacketHeaderExtraMatch(const PrefilterPacketHeaderCtx *ctx,
         case PREFILTER_EXTRA_MATCH_UNUSED:
             break;
         case PREFILTER_EXTRA_MATCH_ALPROTO:
-            if (p->flow == NULL || p->flow->alproto != ctx->value)
+            if (p->flow == NULL || !AppProtoEquals(ctx->value, p->flow->alproto))
                 return FALSE;
             break;
         case PREFILTER_EXTRA_MATCH_SRCPORT:

--- a/src/detect-engine-siggroup.c
+++ b/src/detect-engine-siggroup.c
@@ -699,7 +699,7 @@ int SigGroupHeadBuildNonPrefilterArray(DetectEngineCtx *de_ctx, SigGroupHead *sg
                 BUG_ON(sgh->non_pf_other_store_array == NULL);
                 sgh->non_pf_other_store_array[sgh->non_pf_other_store_cnt].id = s->num;
                 sgh->non_pf_other_store_array[sgh->non_pf_other_store_cnt].mask = s->mask;
-                sgh->non_pf_other_store_array[sgh->non_pf_other_store_cnt].alproto = s->alolproto;
+                sgh->non_pf_other_store_array[sgh->non_pf_other_store_cnt].alolproto = s->alolproto;
                 sgh->non_pf_other_store_cnt++;
             }
 
@@ -707,7 +707,7 @@ int SigGroupHeadBuildNonPrefilterArray(DetectEngineCtx *de_ctx, SigGroupHead *sg
             BUG_ON(sgh->non_pf_syn_store_array == NULL);
             sgh->non_pf_syn_store_array[sgh->non_pf_syn_store_cnt].id = s->num;
             sgh->non_pf_syn_store_array[sgh->non_pf_syn_store_cnt].mask = s->mask;
-            sgh->non_pf_syn_store_array[sgh->non_pf_syn_store_cnt].alproto = s->alolproto;
+            sgh->non_pf_syn_store_array[sgh->non_pf_syn_store_cnt].alolproto = s->alolproto;
             sgh->non_pf_syn_store_cnt++;
         }
     }

--- a/src/detect-engine-siggroup.c
+++ b/src/detect-engine-siggroup.c
@@ -699,7 +699,7 @@ int SigGroupHeadBuildNonPrefilterArray(DetectEngineCtx *de_ctx, SigGroupHead *sg
                 BUG_ON(sgh->non_pf_other_store_array == NULL);
                 sgh->non_pf_other_store_array[sgh->non_pf_other_store_cnt].id = s->num;
                 sgh->non_pf_other_store_array[sgh->non_pf_other_store_cnt].mask = s->mask;
-                sgh->non_pf_other_store_array[sgh->non_pf_other_store_cnt].alproto = s->alproto;
+                sgh->non_pf_other_store_array[sgh->non_pf_other_store_cnt].alproto = s->alolproto;
                 sgh->non_pf_other_store_cnt++;
             }
 
@@ -707,7 +707,7 @@ int SigGroupHeadBuildNonPrefilterArray(DetectEngineCtx *de_ctx, SigGroupHead *sg
             BUG_ON(sgh->non_pf_syn_store_array == NULL);
             sgh->non_pf_syn_store_array[sgh->non_pf_syn_store_cnt].id = s->num;
             sgh->non_pf_syn_store_array[sgh->non_pf_syn_store_cnt].mask = s->mask;
-            sgh->non_pf_syn_store_array[sgh->non_pf_syn_store_cnt].alproto = s->alproto;
+            sgh->non_pf_syn_store_array[sgh->non_pf_syn_store_cnt].alproto = s->alolproto;
             sgh->non_pf_syn_store_cnt++;
         }
     }

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -543,7 +543,7 @@ int DetectEngineAppInspectionEngine2Signature(DetectEngineCtx *de_ctx, Signature
 
         if (t->alproto == ALPROTO_UNKNOWN) {
             /* special case, inspect engine applies to all protocols */
-        } else if (s->alproto != ALPROTO_UNKNOWN && s->alproto != t->alproto)
+        } else if (s->alolproto != ALPROTO_UNKNOWN && s->alolproto != t->alproto)
             goto next;
 
         if (s->flags & SIG_FLAG_TOSERVER && !(s->flags & SIG_FLAG_TOCLIENT)) {

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -543,7 +543,7 @@ int DetectEngineAppInspectionEngine2Signature(DetectEngineCtx *de_ctx, Signature
 
         if (t->alproto == ALPROTO_UNKNOWN) {
             /* special case, inspect engine applies to all protocols */
-        } else if (s->alolproto != ALPROTO_UNKNOWN && s->alolproto != t->alproto)
+        } else if (s->alolproto != ALPROTO_UNKNOWN && !AppProtoEquals(s->alolproto, t->alproto))
             goto next;
 
         if (s->flags & SIG_FLAG_TOSERVER && !(s->flags & SIG_FLAG_TOCLIENT)) {

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -250,21 +250,21 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     SCEnter();
 
     if (!DetectProtoContainsProto(&s->proto, IPPROTO_TCP) ||
-        (s->alproto != ALPROTO_UNKNOWN && s->alproto != ALPROTO_HTTP &&
-        s->alproto != ALPROTO_SMTP && s->alproto != ALPROTO_SMB &&
-        s->alproto != ALPROTO_HTTP2)) {
+        (s->alolproto != ALPROTO_UNKNOWN && s->alolproto != ALPROTO_HTTP &&
+        s->alolproto != ALPROTO_SMTP && s->alolproto != ALPROTO_SMB &&
+        s->alolproto != ALPROTO_HTTP2)) {
         SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS, "rule contains conflicting keywords.");
         return -1;
     }
 
-    if (s->alproto == ALPROTO_HTTP && (s->init_data->init_flags & SIG_FLAG_INIT_FLOW) &&
+    if (s->alolproto == ALPROTO_HTTP && (s->init_data->init_flags & SIG_FLAG_INIT_FLOW) &&
         (s->flags & SIG_FLAG_TOSERVER) && !(s->flags & SIG_FLAG_TOCLIENT)) {
         SCLogError(SC_ERR_INVALID_SIGNATURE, "Can't use file_data with "
                 "flow:to_server or flow:from_client with http.");
         return -1;
     }
 
-    if (s->alproto == ALPROTO_SMTP && (s->init_data->init_flags & SIG_FLAG_INIT_FLOW) &&
+    if (s->alolproto == ALPROTO_SMTP && (s->init_data->init_flags & SIG_FLAG_INIT_FLOW) &&
         !(s->flags & SIG_FLAG_TOSERVER) && (s->flags & SIG_FLAG_TOCLIENT)) {
         SCLogError(SC_ERR_INVALID_SIGNATURE, "Can't use file_data with "
                 "flow:to_client or flow:from_server with smtp.");
@@ -282,7 +282,7 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
 static void DetectFiledataSetupCallback(const DetectEngineCtx *de_ctx,
                                         Signature *s)
 {
-    if (s->alproto == ALPROTO_HTTP || s->alproto == ALPROTO_UNKNOWN) {
+    if (s->alolproto == ALPROTO_HTTP || s->alolproto == ALPROTO_UNKNOWN) {
         AppLayerHtpEnableResponseBodyCallback();
     }
 

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -252,7 +252,7 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     if (!DetectProtoContainsProto(&s->proto, IPPROTO_TCP) ||
         (s->alolproto != ALPROTO_UNKNOWN && s->alolproto != ALPROTO_HTTP &&
         s->alolproto != ALPROTO_SMTP && s->alolproto != ALPROTO_SMB &&
-        s->alolproto != ALPROTO_HTTP2)) {
+         s->alolproto != ALPROTO_HTTP2 && s->alolproto != ALPROTO_HTTP_ANY)) {
         SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS, "rule contains conflicting keywords.");
         return -1;
     }
@@ -282,7 +282,8 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
 static void DetectFiledataSetupCallback(const DetectEngineCtx *de_ctx,
                                         Signature *s)
 {
-    if (s->alolproto == ALPROTO_HTTP || s->alolproto == ALPROTO_UNKNOWN) {
+    if (s->alolproto == ALPROTO_HTTP || s->alolproto == ALPROTO_UNKNOWN ||
+        s->alolproto == ALPROTO_HTTP_ANY) {
         AppLayerHtpEnableResponseBodyCallback();
     }
 

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -455,7 +455,7 @@ static int DetectFilestoreSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
         sm->ctx = (SigMatchCtx*)NULL;
     }
 
-    if (s->alolproto == ALPROTO_HTTP) {
+    if (s->alolproto == ALPROTO_HTTP || s->alolproto == ALPROTO_HTTP_ANY) {
         AppLayerHtpNeedFileInspection();
     }
 

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -455,7 +455,7 @@ static int DetectFilestoreSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
         sm->ctx = (SigMatchCtx*)NULL;
     }
 
-    if (s->alproto == ALPROTO_HTTP) {
+    if (s->alolproto == ALPROTO_HTTP) {
         AppLayerHtpNeedFileInspection();
     }
 

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -68,6 +68,10 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms,
         Flow *_f, const uint8_t _flow_flags,
         void *txv, const int list_id);
+static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms,
+        Flow *_f, const uint8_t _flow_flags,
+        void *txv, const int list_id);
 static int DetectHttpUriSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str);
 static int DetectHttpRawUriSetup(DetectEngineCtx *, Signature *, const char *);
 static void DetectHttpRawUriSetupCallback(const DetectEngineCtx *de_ctx,
@@ -113,6 +117,14 @@ void DetectHttpUriRegister (void)
     DetectAppLayerMpmRegister2("http_uri", SIG_FLAG_TOSERVER, 2,
             PrefilterGenericMpmRegister, GetData, ALPROTO_HTTP,
             HTP_REQUEST_LINE);
+
+    DetectAppLayerInspectEngineRegister2("http_uri", ALPROTO_HTTP2,
+            SIG_FLAG_TOSERVER, HTTP2StateDataClient,
+            DetectEngineInspectBufferGeneric, GetData2);
+
+    DetectAppLayerMpmRegister2("http_uri", SIG_FLAG_TOSERVER, 2,
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2,
+            HTTP2StateDataClient);
 
     DetectBufferTypeSetDescriptionByName("http_uri",
             "http request uri");
@@ -204,7 +216,7 @@ static int DetectHttpUriSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const
 {
     if (DetectBufferSetActiveList(s, g_http_uri_buffer_id) < 0)
         return -1;
-    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP) < 0)
+    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP_ANY) < 0)
         return -1;
     return 0;
 }
@@ -229,6 +241,29 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(tx_ud->request_uri_normalized);
 
         InspectionBufferSetup(buffer, data, data_len);
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+
+    return buffer;
+}
+
+static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *_f,
+        const uint8_t _flow_flags, void *txv, const int list_id)
+{
+    SCEnter();
+
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        uint32_t b_len = 0;
+        const uint8_t *b = NULL;
+
+        if (rs_http2_tx_get_uri(txv, &b, &b_len) != 1)
+            return NULL;
+        if (b == NULL || b_len == 0)
+            return NULL;
+
+        InspectionBufferSetup(buffer, b, b_len);
         InspectionBufferApplyTransforms(buffer, transforms);
     }
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1486,10 +1486,14 @@ int DetectSignatureSetAppProto(Signature *s, AppProto alproto)
     }
 
     if (s->alolproto != ALPROTO_UNKNOWN && !AppProtoEquals(s->alolproto, alproto)) {
+        if (AppProtoEquals(alproto, s->alolproto)) {
+            alproto = s->alolproto;
+        } else {
         SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS,
             "can't set rule app proto to %s: already set to %s",
             AppProtoToString(alproto), AppProtoToString(s->alolproto));
         return -1;
+        }
     }
 
     s->alolproto = alproto;

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -904,8 +904,8 @@ static int DetectPcreSetup (DetectEngineCtx *de_ctx, Signature *s, const char *r
                 if (alproto != ALPROTO_UNKNOWN) {
                     /* see if the proto doesn't conflict
                      * with what we already have. */
-                    if (s->alproto != ALPROTO_UNKNOWN &&
-                            alproto != s->alproto) {
+                    if (s->alolproto != ALPROTO_UNKNOWN &&
+                            alproto != s->alolproto) {
                         goto error;
                     }
                     if (DetectSignatureSetAppProto(s, alproto) < 0)

--- a/src/detect.c
+++ b/src/detect.c
@@ -777,7 +777,7 @@ static inline void DetectRulePacketRules(
 
         /* if the sig has alproto and the session as well they should match */
         if (likely(sflags & SIG_FLAG_APPLAYER)) {
-            if (s->alolproto != ALPROTO_UNKNOWN && s->alolproto != scratch->alproto) {
+            if (s->alolproto != ALPROTO_UNKNOWN && !AppProtoEquals(s->alolproto, scratch->alproto)) {
                 if (s->alolproto == ALPROTO_DCERPC) {
                     if (scratch->alproto != ALPROTO_SMB) {
                         SCLogDebug("DCERPC sig, alproto not SMB");
@@ -1091,7 +1091,7 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
             return false;
         }
         /* stream mpm and negated mpm sigs can end up here with wrong proto */
-        if (!(f->alproto == s->alolproto || s->alolproto == ALPROTO_UNKNOWN)) {
+        if (!(AppProtoEquals(s->alolproto, f->alproto) || s->alolproto == ALPROTO_UNKNOWN)) {
             TRACE_SID_TXS(s->id, tx, "alproto mismatch");
             return false;
         }

--- a/src/detect.c
+++ b/src/detect.c
@@ -360,8 +360,8 @@ DetectPrefilterBuildNonPrefilterList(DetectEngineThreadCtx *det_ctx,
         /* only if the mask matches this rule can possibly match,
          * so build the non_mpm array only for match candidates */
         const SignatureMask rule_mask = det_ctx->non_pf_store_ptr[x].mask;
-        const uint8_t rule_alproto = det_ctx->non_pf_store_ptr[x].alproto;
-        if ((rule_mask & mask) == rule_mask && (rule_alproto == 0 || rule_alproto == alproto)) {
+        const uint8_t rule_alproto = det_ctx->non_pf_store_ptr[x].alolproto;
+        if ((rule_mask & mask) == rule_mask && (rule_alproto == 0 || AppProtoEquals(rule_alproto, alproto))) {
             det_ctx->non_pf_id_array[det_ctx->non_pf_id_cnt++] = det_ctx->non_pf_store_ptr[x].id;
         }
     }

--- a/src/detect.c
+++ b/src/detect.c
@@ -777,8 +777,8 @@ static inline void DetectRulePacketRules(
 
         /* if the sig has alproto and the session as well they should match */
         if (likely(sflags & SIG_FLAG_APPLAYER)) {
-            if (s->alproto != ALPROTO_UNKNOWN && s->alproto != scratch->alproto) {
-                if (s->alproto == ALPROTO_DCERPC) {
+            if (s->alolproto != ALPROTO_UNKNOWN && s->alolproto != scratch->alproto) {
+                if (s->alolproto == ALPROTO_DCERPC) {
                     if (scratch->alproto != ALPROTO_SMB) {
                         SCLogDebug("DCERPC sig, alproto not SMB");
                         goto next;
@@ -1091,7 +1091,7 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
             return false;
         }
         /* stream mpm and negated mpm sigs can end up here with wrong proto */
-        if (!(f->alproto == s->alproto || s->alproto == ALPROTO_UNKNOWN)) {
+        if (!(f->alproto == s->alolproto || s->alolproto == ALPROTO_UNKNOWN)) {
             TRACE_SID_TXS(s->id, tx, "alproto mismatch");
             return false;
         }

--- a/src/detect.h
+++ b/src/detect.h
@@ -264,6 +264,7 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_INIT_PRIO_EXPLICT          BIT_U32(8)  /**< priority is explicitly set by the priority keyword */
 #define SIG_FLAG_INIT_FILEDATA              BIT_U32(9)  /**< signature has filedata keyword */
 #define SIG_FLAG_INIT_DCERPC                BIT_U32(10) /**< signature has DCERPC keyword */
+#define SIG_FLAG_INIT_HTTP                  BIT_U32(11) /**< signature has HTTP keyword */
 
 /* signature mask flags */
 /** \note: additions should be added to the rule analyzer as well */
@@ -529,7 +530,7 @@ typedef struct Signature_ {
     uint32_t flags;
     /* coccinelle: Signature:flags:SIG_FLAG_ */
 
-    AppProto alproto;
+    AppProto alolproto;
 
     uint16_t dsize_low;
     uint16_t dsize_high;

--- a/src/detect.h
+++ b/src/detect.h
@@ -264,7 +264,6 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_INIT_PRIO_EXPLICT          BIT_U32(8)  /**< priority is explicitly set by the priority keyword */
 #define SIG_FLAG_INIT_FILEDATA              BIT_U32(9)  /**< signature has filedata keyword */
 #define SIG_FLAG_INIT_DCERPC                BIT_U32(10) /**< signature has DCERPC keyword */
-#define SIG_FLAG_INIT_HTTP                  BIT_U32(11) /**< signature has HTTP keyword */
 
 /* signature mask flags */
 /** \note: additions should be added to the rule analyzer as well */
@@ -988,7 +987,7 @@ typedef struct HttpReassembledBody_ {
 typedef struct SignatureNonPrefilterStore_ {
     SigIntId id;
     SignatureMask mask;
-    uint8_t alproto;
+    uint8_t alolproto;
 } SignatureNonPrefilterStore;
 
 /** array of TX inspect rule candidates */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4067

Describe changes:
- Adds `ALPROTO_HTTP_ANY` for signatures to match on both HTTP1 and HTTP2
- `http.uri` keyword now matches on HTTP2 traffic

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

suricata-verify-pr: 377

TL;DR
Is this the good way to go ?

The big change is in this `ALPROTO_HTTP_ANY`
It comes from writing the rules, cf S-V test in https://github.com/OISF/suricata-verify/pull/377
I think it is good to allow these rules
```
# match on any HTTP version
alert http any any -> any any (http.uri; content:"/doc/manual/html/index.html"; sid:10;)
# match on HTTP 1 only
alert http1 any any -> any any (http.uri; content:"/doc/manual/html/index.html"; sid:11;)
# match on HTTP 2 only
alert http2 any any -> any any (http.uri; content:"/doc/manual/html/index.html"; sid:12;)
# match on whatever
alert ip any any -> any any (http.uri; content:"/doc/manual/html/index.html"; sid:13;)
```

As a consequence, the `Signature` structure shall contain this detailed information  about the app-layer protocol
That meant either
- adding a new (fake) protocol to `AppProtoEnum`
- adding a new field to `struct Signature_` to complete `AppProto alproto`
- merging HTTP2 and HTTP1 all in `ALPROTO_HTTP`

The last solution does not feel good to me, as it makes sense to have 2 different `ALPROTO_` related to the flow as they are 2 completely different protocols/encoding even if they offer the same functionalities
Adding a field meant to consume more memory
So I went with the first solution.
I renamed the `struct Signature_` field to `alolproto` to see where it gets used, as this is a Signature protocol, which may correspond to multiple Flow protocol. That is : a Flow has only one protocol. A Signature may have multiple protocols
I created a function `AppProtoEquals` that says if a Signature protocol matches a Flow protocol
I added `ALPROTO_HTTP_ANY`
Then, this was just inspecting every use of `alolproto` and translating it to its new meaning


What remains to be done :
- get validation about design first
- squash commits
- rename `alolproto` to `sig_alproto`. Thoughts about a better name ?
- CI (clang-format)
- document how to add new keywords and do it