### PR TITLE
GRE: Handling pptp without payload

### DIFF
--- a/src/decode-gre.c
+++ b/src/decode-gre.c
@@ -47,6 +47,7 @@ int DecodeGRE(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *p
 {
     uint32_t header_len = GRE_HDR_LEN;
     GRESreHdr *gsre = NULL;
+    GREPPtPHd *gre_pptp_h = NULL;
 
     StatsIncr(tv, dtv->counter_gre);
 
@@ -175,6 +176,8 @@ int DecodeGRE(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *p
             }
 
             header_len += GRE_KEY_LEN;
+            /* key is set and proto == PPP */
+            gre_pptp_h = (GREPPtPHd *)pkt;
 
             /* Adjust header length based on content */
 
@@ -210,6 +213,9 @@ int DecodeGRE(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *p
 
         case GRE_PROTO_PPP:
         {
+            if (gre_pptp_h && !gre_pptp_h->payload_length)
+                return TM_ECODE_OK;
+
             Packet *tp = PacketTunnelPktSetup(tv, dtv, p, pkt + header_len,
                     len - header_len, DECODE_TUNNEL_PPP);
             if (tp != NULL) {

--- a/src/decode-gre.h
+++ b/src/decode-gre.h
@@ -41,6 +41,13 @@ typedef struct GREHdr_
 
 } __attribute__((__packed__)) GREHdr;
 
+/* Enhanced GRE header - https://tools.ietf.org/html/rfc2637#section-4.1 */
+typedef struct GREPPtPHdr_ {
+    GREHdr greh;             /** base GRE packet header */
+    uint16_t payload_length; /** PPP payload length */
+    uint16_t call_id;        /** PPP peer id */
+} __attribute__((__packed__)) GREPPtPHd;
+
 /* Generic Routing Encapsulation Source Route Entries (SREs).
  * The header is followed by a variable amount of Routing Information.
  */


### PR DESCRIPTION
If one of the ppp peers sends a packet with an acknowledge flag,
the ppp payload will be empty and DecodePPP will return TM_ECODE_FAILED.
To handle this case, the packet_length field in the GRE extended header (https://tools.ietf.org/html/rfc2637#section-4.1) is used.
DecodeGRE no longer tries to parse PPP payload if packet_length is zero.

![Wireshark packet screenshot](https://user-images.githubusercontent.com/3380161/101651193-9b31c880-3a5e-11eb-9bda-7ea4a81f8ad8.jpg)

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
