### PR TITLE
doc: escape dot in pcre

### DIFF
--- a/doc/userguide/rules/tls-keywords.rst
+++ b/doc/userguide/rules/tls-keywords.rst
@@ -11,7 +11,7 @@ Match TLS/SSL certificate Subject field.
 Examples::
 
   tls.cert_subject; content:"CN=*.googleusercontent.com"; isdataat:!1,relative;
-  tls.cert_subject; content:"google.com"; nocase; pcre:"/google.com$/";
+  tls.cert_subject; content:"google.com"; nocase; pcre:"/google\.com$/";
 
 ``tls.cert_subject`` is a 'sticky buffer'.
 


### PR DESCRIPTION
- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Escape a dot in a regular expression to match `.com` TLD

@catenacyber 