### PR TITLE
ebpf: Enable vlan use-for-tracking in ebpf keys

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2402,8 +2402,8 @@ static int AFPBypassCallback(Packet *p)
         keys[0]->dst = htonl(GET_IPV4_DST_ADDR_U32(p));
         keys[0]->port16[0] = GET_TCP_SRC_PORT(p);
         keys[0]->port16[1] = GET_TCP_DST_PORT(p);
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[0]->vlan1 = p->vlan_id[1] & g_vlan_mask;
 
         if (IPV4_GET_IPPROTO(p) == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
@@ -2427,8 +2427,8 @@ static int AFPBypassCallback(Packet *p)
         keys[1]->dst = htonl(GET_IPV4_SRC_ADDR_U32(p));
         keys[1]->port16[0] = GET_TCP_DST_PORT(p);
         keys[1]->port16[1] = GET_TCP_SRC_PORT(p);
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[1]->vlan1 = p->vlan_id[1] & g_vlan_mask;
 
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[1],
@@ -2462,8 +2462,8 @@ static int AFPBypassCallback(Packet *p)
         }
         keys[0]->port16[0] = GET_TCP_SRC_PORT(p);
         keys[0]->port16[1] = GET_TCP_DST_PORT(p);
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[0]->vlan1 = p->vlan_id[1] & g_vlan_mask;
 
         if (IPV6_GET_NH(p) == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
@@ -2489,8 +2489,8 @@ static int AFPBypassCallback(Packet *p)
         }
         keys[1]->port16[0] = GET_TCP_DST_PORT(p);
         keys[1]->port16[1] = GET_TCP_SRC_PORT(p);
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[1]->vlan1 = p->vlan_id[1] & g_vlan_mask;
 
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[1],
@@ -2558,8 +2558,8 @@ static int AFPXDPBypassCallback(Packet *p)
          * (as in eBPF filter) so we need to pass from host to network order */
         keys[0]->port16[0] = htons(p->sp);
         keys[0]->port16[1] = htons(p->dp);
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[0]->vlan1 = p->vlan_id[1] & g_vlan_mask;
         if (IPV4_GET_IPPROTO(p) == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
         } else {
@@ -2582,8 +2582,8 @@ static int AFPXDPBypassCallback(Packet *p)
         keys[1]->dst = p->src.addr_data32[0];
         keys[1]->port16[0] = htons(p->dp);
         keys[1]->port16[1] = htons(p->sp);
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[1]->vlan1 = p->vlan_id[1] & g_vlan_mask;
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {
@@ -2615,8 +2615,8 @@ static int AFPXDPBypassCallback(Packet *p)
         }
         keys[0]->port16[0] = htons(GET_TCP_SRC_PORT(p));
         keys[0]->port16[1] = htons(GET_TCP_DST_PORT(p));
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[0]->vlan1 = p->vlan_id[1] & g_vlan_mask;
         if (IPV6_GET_NH(p) == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
         } else {
@@ -2641,8 +2641,8 @@ static int AFPXDPBypassCallback(Packet *p)
         }
         keys[1]->port16[0] = htons(GET_TCP_DST_PORT(p));
         keys[1]->port16[1] = htons(GET_TCP_SRC_PORT(p));
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[1]->vlan1 = p->vlan_id[1] & g_vlan_mask;
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/4214) ticket:

Describe changes:
- Ensure that vlan tags is not used in ebpf keys when vlan use-for-tracking is disabled in suricata.yaml.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
