### PR TITLE
Http2 keywords 4067 v2

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -2090,9 +2090,15 @@ void AppLayerProtoDetectSupportedIpprotos(AppProto alproto, uint8_t *ipprotos)
 {
     SCEnter();
 
+    // Custom case for only signature-only protocol so far
+    if (alproto == ALPROTO_HTTP_ANY) {
+        AppLayerProtoDetectSupportedIpprotos(ALPROTO_HTTP, ipprotos);
+        AppLayerProtoDetectSupportedIpprotos(ALPROTO_HTTP2, ipprotos);
+    } else {
     AppLayerProtoDetectPMGetIpprotos(alproto, ipprotos);
     AppLayerProtoDetectPPGetIpprotos(alproto, ipprotos);
     AppLayerProtoDetectPEGetIpprotos(alproto, ipprotos);
+    }
 
     SCReturn;
 }
@@ -2102,12 +2108,12 @@ AppProto AppLayerProtoDetectGetProtoByName(const char *alproto_name)
     SCEnter();
 
     AppProto a;
+    AppProto b = StringToAppProto(alproto_name);
     for (a = 0; a < ALPROTO_MAX; a++) {
-        if (alpd_ctx.alproto_names[a] != NULL &&
-            strlen(alpd_ctx.alproto_names[a]) == strlen(alproto_name) &&
-            (SCMemcmp(alpd_ctx.alproto_names[a], alproto_name, strlen(alproto_name)) == 0))
+        if (alpd_ctx.alproto_names[a] != NULL && AppProtoEquals(b, a))
         {
-            SCReturnCT(a, "AppProto");
+            // That means return HTTP_ANY if HTTP1 or HTTP2 is enabled
+            SCReturnCT(b, "AppProto");
         }
     }
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1137,6 +1137,11 @@ uint64_t AppLayerParserGetTransactionActive(const Flow *f,
 
 int AppLayerParserSupportsFiles(uint8_t ipproto, AppProto alproto)
 {
+    // Custom case for only signature-only protocol so far
+    if (alproto == ALPROTO_HTTP_ANY) {
+        return AppLayerParserSupportsFiles(ipproto, ALPROTO_HTTP) ||
+               AppLayerParserSupportsFiles(ipproto, ALPROTO_HTTP2);
+    }
     if (alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].StateGetFiles != NULL)
         return TRUE;
     return FALSE;

--- a/src/app-layer-protos.c
+++ b/src/app-layer-protos.c
@@ -120,6 +120,9 @@ const char *AppProtoToString(AppProto alproto)
         case ALPROTO_HTTP2:
             proto_name = "http2";
             break;
+        case ALPROTO_HTTP_ANY:
+            proto_name = "http_any";
+            break;
         case ALPROTO_FAILED:
             proto_name = "failed";
             break;
@@ -138,7 +141,8 @@ AppProto StringToAppProto(const char *proto_name)
 {
     if (proto_name == NULL) return ALPROTO_UNKNOWN;
 
-    if (strcmp(proto_name,"http")==0) return ALPROTO_HTTP;
+    if (strcmp(proto_name,"http")==0) return ALPROTO_HTTP_ANY;
+    if (strcmp(proto_name,"http1")==0) return ALPROTO_HTTP;
     if (strcmp(proto_name,"ftp")==0) return ALPROTO_FTP;
     if (strcmp(proto_name,"smtp")==0) return ALPROTO_SMTP;
     if (strcmp(proto_name,"tls")==0) return ALPROTO_TLS;

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -58,6 +58,10 @@ enum AppProtoEnum {
     ALPROTO_RDP,
     ALPROTO_HTTP2,
 
+    // signature-only (ie not seen in flow)
+    // HTTP for any version (ALPROTO_HTTP (version 1) or ALPROTO_HTTP2)
+    ALPROTO_HTTP_ANY,
+
     /* used by the probing parser when alproto detection fails
      * permanently for that particular stream */
     ALPROTO_FAILED,
@@ -75,6 +79,17 @@ typedef uint16_t AppProto;
 static inline bool AppProtoIsValid(AppProto a)
 {
     return ((a > ALPROTO_UNKNOWN && a < ALPROTO_FAILED));
+}
+
+// wether a signature AppProto matches a flow (or signature) AppProto
+static inline bool AppProtoEquals(AppProto sigproto, AppProto alproto)
+{
+    switch (sigproto) {
+        case ALPROTO_HTTP_ANY:
+            return (alproto == ALPROTO_HTTP) || (alproto == ALPROTO_HTTP2) ||
+                   (alproto == ALPROTO_HTTP_ANY);
+    }
+    return (sigproto == alproto);
 }
 
 /**

--- a/src/detect-engine-prefilter-common.h
+++ b/src/detect-engine-prefilter-common.h
@@ -79,7 +79,7 @@ PrefilterPacketHeaderExtraMatch(const PrefilterPacketHeaderCtx *ctx,
         case PREFILTER_EXTRA_MATCH_UNUSED:
             break;
         case PREFILTER_EXTRA_MATCH_ALPROTO:
-            if (p->flow == NULL || p->flow->alproto != ctx->value)
+            if (p->flow == NULL || !AppProtoEquals(ctx->value, p->flow->alproto))
                 return FALSE;
             break;
         case PREFILTER_EXTRA_MATCH_SRCPORT:

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -480,7 +480,7 @@ int DetectEngineAppInspectionEngine2Signature(DetectEngineCtx *de_ctx, Signature
 
         if (t->alproto == ALPROTO_UNKNOWN) {
             /* special case, inspect engine applies to all protocols */
-        } else if (s->alproto != ALPROTO_UNKNOWN && s->alproto != t->alproto)
+        } else if (s->alproto != ALPROTO_UNKNOWN && !AppProtoEquals(s->alproto, t->alproto))
             goto next;
 
         if (s->flags & SIG_FLAG_TOSERVER && !(s->flags & SIG_FLAG_TOCLIENT)) {

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -252,7 +252,7 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     if (!DetectProtoContainsProto(&s->proto, IPPROTO_TCP) ||
         (s->alproto != ALPROTO_UNKNOWN && s->alproto != ALPROTO_HTTP &&
         s->alproto != ALPROTO_SMTP && s->alproto != ALPROTO_SMB &&
-        s->alproto != ALPROTO_HTTP2)) {
+         s->alproto != ALPROTO_HTTP2 && s->alproto != ALPROTO_HTTP_ANY)) {
         SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS, "rule contains conflicting keywords.");
         return -1;
     }
@@ -282,7 +282,8 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
 static void DetectFiledataSetupCallback(const DetectEngineCtx *de_ctx,
                                         Signature *s)
 {
-    if (s->alproto == ALPROTO_HTTP || s->alproto == ALPROTO_UNKNOWN) {
+    if (s->alproto == ALPROTO_HTTP || s->alproto == ALPROTO_UNKNOWN ||
+        s->alproto == ALPROTO_HTTP_ANY) {
         AppLayerHtpEnableResponseBodyCallback();
     }
 

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -455,7 +455,7 @@ static int DetectFilestoreSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
         sm->ctx = (SigMatchCtx*)NULL;
     }
 
-    if (s->alproto == ALPROTO_HTTP) {
+    if (s->alproto == ALPROTO_HTTP || s->alproto == ALPROTO_HTTP_ANY) {
         AppLayerHtpNeedFileInspection();
     }
 

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -68,6 +68,10 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms,
         Flow *_f, const uint8_t _flow_flags,
         void *txv, const int list_id);
+static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms,
+        Flow *_f, const uint8_t _flow_flags,
+        void *txv, const int list_id);
 static int DetectHttpUriSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str);
 static int DetectHttpRawUriSetup(DetectEngineCtx *, Signature *, const char *);
 static void DetectHttpRawUriSetupCallback(const DetectEngineCtx *de_ctx,
@@ -113,6 +117,14 @@ void DetectHttpUriRegister (void)
     DetectAppLayerMpmRegister2("http_uri", SIG_FLAG_TOSERVER, 2,
             PrefilterGenericMpmRegister, GetData, ALPROTO_HTTP,
             HTP_REQUEST_LINE);
+
+    DetectAppLayerInspectEngineRegister2("http_uri", ALPROTO_HTTP2,
+            SIG_FLAG_TOSERVER, HTTP2StateDataClient,
+            DetectEngineInspectBufferGeneric, GetData2);
+
+    DetectAppLayerMpmRegister2("http_uri", SIG_FLAG_TOSERVER, 2,
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2,
+            HTTP2StateDataClient);
 
     DetectBufferTypeSetDescriptionByName("http_uri",
             "http request uri");
@@ -204,7 +216,7 @@ static int DetectHttpUriSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const
 {
     if (DetectBufferSetActiveList(s, g_http_uri_buffer_id) < 0)
         return -1;
-    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP) < 0)
+    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP_ANY) < 0)
         return -1;
     return 0;
 }
@@ -229,6 +241,29 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(tx_ud->request_uri_normalized);
 
         InspectionBufferSetup(buffer, data, data_len);
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+
+    return buffer;
+}
+
+static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *_f,
+        const uint8_t _flow_flags, void *txv, const int list_id)
+{
+    SCEnter();
+
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        uint32_t b_len = 0;
+        const uint8_t *b = NULL;
+
+        if (rs_http2_tx_get_uri(txv, &b, &b_len) != 1)
+            return NULL;
+        if (b == NULL || b_len == 0)
+            return NULL;
+
+        InspectionBufferSetup(buffer, b, b_len);
         InspectionBufferApplyTransforms(buffer, transforms);
     }
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -163,7 +163,7 @@ int DetectEngineContentModifierBufferSetup(DetectEngineCtx *de_ctx,
                    sigmatch_table[sm_type].name);
         goto end;
     }
-    if (s->alproto != ALPROTO_UNKNOWN && s->alproto != alproto) {
+    if (s->alproto != ALPROTO_UNKNOWN && !AppProtoEquals(s->alproto, alproto)) {
         SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS, "rule contains conflicting "
                    "alprotos set");
         goto end;
@@ -1485,11 +1485,17 @@ int DetectSignatureSetAppProto(Signature *s, AppProto alproto)
         return -1;
     }
 
-    if (s->alproto != ALPROTO_UNKNOWN && s->alproto != alproto) {
+    if (s->alproto != ALPROTO_UNKNOWN && !AppProtoEquals(s->alproto, alproto)) {
+        if (AppProtoEquals(alproto, s->alproto)) {
+            // happens if alproto = HTTP_ANY and s->alproto = HTTP1
+            // in this case, we must keep the most restrictive HTTP1
+            alproto = s->alproto;
+        } else {
         SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS,
             "can't set rule app proto to %s: already set to %s",
             AppProtoToString(alproto), AppProtoToString(s->alproto));
         return -1;
+        }
     }
 
     s->alproto = alproto;
@@ -1681,7 +1687,7 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
         if (s->init_data->smlists[x]) {
             const DetectEngineAppInspectionEngine *app = de_ctx->app_inspect_engines;
             for ( ; app != NULL; app = app->next) {
-                if (app->sm_list == x && ((s->alproto == app->alproto) || s->alproto == 0)) {
+                if (app->sm_list == x && (AppProtoEquals(s->alproto, app->alproto) || s->alproto == 0)) {
                     SCLogDebug("engine %s dir %d alproto %d",
                             DetectBufferTypeGetNameById(de_ctx, app->sm_list),
                             app->dir, app->alproto);
@@ -1863,7 +1869,7 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
             SCReturnInt(0);
         }
 
-        if (s->alproto == ALPROTO_HTTP) {
+        if (s->alproto == ALPROTO_HTTP || s->alproto == ALPROTO_HTTP_ANY) {
             AppLayerHtpNeedFileInspection();
         }
     }

--- a/src/detect.c
+++ b/src/detect.c
@@ -361,7 +361,7 @@ DetectPrefilterBuildNonPrefilterList(DetectEngineThreadCtx *det_ctx,
          * so build the non_mpm array only for match candidates */
         const SignatureMask rule_mask = det_ctx->non_pf_store_ptr[x].mask;
         const uint8_t rule_alproto = det_ctx->non_pf_store_ptr[x].alproto;
-        if ((rule_mask & mask) == rule_mask && (rule_alproto == 0 || rule_alproto == alproto)) {
+        if ((rule_mask & mask) == rule_mask && (rule_alproto == 0 || AppProtoEquals(rule_alproto, alproto))) {
             det_ctx->non_pf_id_array[det_ctx->non_pf_id_cnt++] = det_ctx->non_pf_store_ptr[x].id;
         }
     }
@@ -777,7 +777,7 @@ static inline void DetectRulePacketRules(
 
         /* if the sig has alproto and the session as well they should match */
         if (likely(sflags & SIG_FLAG_APPLAYER)) {
-            if (s->alproto != ALPROTO_UNKNOWN && s->alproto != scratch->alproto) {
+            if (s->alproto != ALPROTO_UNKNOWN && !AppProtoEquals(s->alproto, scratch->alproto)) {
                 if (s->alproto == ALPROTO_DCERPC) {
                     if (scratch->alproto != ALPROTO_SMB) {
                         SCLogDebug("DCERPC sig, alproto not SMB");
@@ -1091,7 +1091,7 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
             return false;
         }
         /* stream mpm and negated mpm sigs can end up here with wrong proto */
-        if (!(f->alproto == s->alproto || s->alproto == ALPROTO_UNKNOWN)) {
+        if (!(AppProtoEquals(s->alproto, f->alproto) || s->alproto == ALPROTO_UNKNOWN)) {
             TRACE_SID_TXS(s->id, tx, "alproto mismatch");
             return false;
         }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4067

Describe changes:
- Adds signature protocol extending flow protocol (one signature protocol matches multiple flow protocols cf `AppProtoEquals`)
- Adds `ALPROTO_HTTP_ANY` (as such a signature protocol) for signatures to match on both HTTP1 and HTTP2
- `http.uri` keyword now matches on HTTP2 traffic

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

suricata-verify-pr: 377

TL;DR
Is this the good way to go ?

The big change is in this `ALPROTO_HTTP_ANY` (first commit)
It comes from writing the rules, cf S-V test in https://github.com/OISF/suricata-verify/pull/377
I think it is good to allow these rules
```
# match on any HTTP version
alert http any any -> any any (http.uri; content:"/doc/manual/html/index.html"; sid:10;)
# match on HTTP 1 only
alert http1 any any -> any any (http.uri; content:"/doc/manual/html/index.html"; sid:11;)
# match on HTTP 2 only
alert http2 any any -> any any (http.uri; content:"/doc/manual/html/index.html"; sid:12;)
# match on whatever
alert ip any any -> any any (http.uri; content:"/doc/manual/html/index.html"; sid:13;)
```

As a consequence, the `Signature` structure shall contain this detailed information  about the app-layer protocol
That meant either
- adding a new (signature) protocol to `AppProtoEnum`
- adding a new field to `struct Signature_` to complete `AppProto alproto`
- merging HTTP2 and HTTP1 all in `ALPROTO_HTTP`

The last solution does not feel good to me, as it makes sense to have 2 different `ALPROTO_` related to the flow as they are 2 completely different protocols/encoding even if they offer the (almost) same functionalities
Adding a field implied consuming more memory...
So I went with the first solution.

I renamed the `struct Signature_` field to `alolproto` to see where it gets used, as this is a Signature protocol, which may correspond to multiple Flow protocol. That is : a Flow has only one protocol. A Signature may have multiple protocols
I created a function `AppProtoEquals` that says if a Signature protocol matches a Flow protocol
I added `ALPROTO_HTTP_ANY`
Then, this was just inspecting every use of `alolproto` and translating it to its new meaning


What remains to be done :
- get validation about design first
- rename `alproto` to `sig_alproto`. Thoughts about a better name ?
- CI (clang-format)
- document how to translate more keywords to using `ALPROTO_HTTP_ANY` (simple enough) and do it

Modifies #5639 with
- renaming back to `alproto` as requested
- adding more comments
- squashing commits