### PR TITLE
Detect: noopt validation

### DIFF
--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -175,7 +175,7 @@ void DetectFastPatternRegister(void)
 #ifdef UNITTESTS
     sigmatch_table[DETECT_FAST_PATTERN].RegisterTests = DetectFastPatternRegisterTests;
 #endif
-    sigmatch_table[DETECT_FAST_PATTERN].flags |= SIGMATCH_NOOPT;
+    sigmatch_table[DETECT_FAST_PATTERN].flags |= SIGMATCH_OPTIONAL_OPT;
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
 }
@@ -188,7 +188,7 @@ void DetectFastPatternRegister(void)
  *
  * \param de_ctx   Pointer to the Detection Engine Context.
  * \param s        Pointer to the Signature to which the current keyword belongs.
- * \param null_str Should hold an empty string always.
+ * \param arg      May hold an argument
  *
  * \retval  0 On success.
  * \retval -1 On failure.

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -704,8 +704,14 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
 
     if (!(st->flags & (SIGMATCH_NOOPT|SIGMATCH_OPTIONAL_OPT))) {
         if (optvalue == NULL || strlen(optvalue) == 0) {
-            SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid formatting or malformed option to %s keyword: \'%s\'",
-                    optname, optstr);
+            SCLogError(SC_ERR_INVALID_SIGNATURE,
+                    "invalid formatting or malformed option to %s keyword: '%s'", optname, optstr);
+            goto error;
+        }
+    } else if (st->flags & SIGMATCH_NOOPT) {
+        if (optvalue && strlen(optvalue)) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "unexpected option to %s keyword: '%s'", optname,
+                    optstr);
             goto error;
         }
     }

--- a/src/tests/detect-parse.c
+++ b/src/tests/detect-parse.c
@@ -38,6 +38,23 @@ static int DetectParseTest01 (void)
     PASS;
 }
 
+/**
+ * \test DetectParseTestNoOpt  is a regression test to make sure that we reject
+ * any signature where a NOOPT rule option is given a value. This can hide rule
+ * errors which make other options disappear, eg: foo: bar: baz; where "foo" is
+ * the NOOPT option, we will end up with a signature which is missing "bar".
+ */
+
+static int DetectParseTestNoOpt(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF(DetectEngineAppendSig(de_ctx,
+                    "alert http any any -> any any (msg:\"sid 1 version 0\"; "
+                    "content:\"dummy1\"; endswith: reference: ref; sid:1;)") != NULL);
+    DetectEngineCtxFree(de_ctx);
+
+    PASS;
+}
 
 /**
  * \brief this function registers unit tests for DetectParse
@@ -45,4 +62,5 @@ static int DetectParseTest01 (void)
 void DetectParseRegisterTests(void)
 {
     UtRegisterTest("DetectParseTest01", DetectParseTest01);
+    UtRegisterTest("DetectParseTestNoOpt", DetectParseTestNoOpt);
 }


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: None.

Describe changes:

Rule parser does not currently validate that NOOPT options actually have options. This allows for a simple typo of ":" for ";" to lead to rule bugs. Two such bugs exist in latest ET-open ruleset. I added a patch to validate this.

While validating the change, discovered that detect-fast-pattern was marked NOOPT when it should be OPT_OPTIONAL.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
