### PR TITLE
issue 4216 - filestore: fix global counter init in unix socket mode - v1

### DIFF
--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -527,9 +527,6 @@ static OutputInitResult OutputFilestoreLogInitCtx(ConfNode *conf)
         }
     }
 
-    StatsRegisterGlobalCounter("file_store.open_files",
-            OutputFilestoreOpenFilesCounter);
-
     result.ctx = output_ctx;
     result.ok = true;
     SCReturnCT(result, "OutputInitResult");
@@ -547,5 +544,12 @@ void OutputFilestoreRegister(void)
 
     SC_ATOMIC_INIT(filestore_open_file_cnt);
     SC_ATOMIC_SET(filestore_open_file_cnt, 0);
+#endif
+}
+
+void OutputFilestoreRegisterGlobalCounters(void)
+{
+#ifdef HAVE_NSS
+    StatsRegisterGlobalCounter("file_store.open_files", OutputFilestoreOpenFilesCounter);
 #endif
 }

--- a/src/output-filestore.h
+++ b/src/output-filestore.h
@@ -20,5 +20,6 @@
 
 void OutputFilestoreRegister(void);
 void OutputFilestoreInitConfig(void);
+void OutputFilestoreRegisterGlobalCounters(void);
 
 #endif /* __OUTPUT_FILESTORE_H__ */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -129,6 +129,8 @@
 #include "app-layer-smb.h"
 #include "app-layer-dcerpc.h"
 
+#include "output-filestore.h"
+
 #include "util-ebpf.h"
 #include "util-radix-tree.h"
 #include "util-host-os-info.h"
@@ -2026,6 +2028,7 @@ void PreRunInit(const int runmode)
     StreamTcpInitConfig(STREAM_VERBOSE);
     AppLayerParserPostStreamSetup();
     AppLayerRegisterGlobalCounters();
+    OutputFilestoreRegisterGlobalCounters();
 }
 
 /* tasks we need to run before packets start flowing,


### PR DESCRIPTION
Redmine issue:
https://redmine.openinfosecfoundation.org/issues/4216

Move initialization of filestore global counter to PreRunInit,
so they get registered during program initialization, or as
required in unix-socket mode, initialized for each file run.

Will do 5.0.x backport as well.