### PR TITLE
fuzz: improves sigpcap target with PacketPoolInit

### DIFF
--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -79,7 +79,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         tmm_modules[TMM_FLOWWORKER].ThreadInit(&tv, NULL, &fwd);
         StatsSetupPrivate(&tv);
 
-        PacketPoolInitEmpty();
+        PacketPoolInit();
         initialized = 1;
     }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4125

Describe changes:
- Fixes sigpcap fuzz target using `PacketPoolInit` instead of `PacketPoolInitEmpty`

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28390