### PR TITLE
Multi-threaded EVE support for output plugins

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -842,6 +842,8 @@ static TmEcode JsonAlertLogThreadDeinit(ThreadVars *t, void *data)
 
     MemBufferFree(aft->json_buffer);
     MemBufferFree(aft->payload_buffer);
+
+    LogFileDeInitCtx(aft->json_output_ctx->file_ctx, t->id);
 
     /* clear memory */
     memset(aft, 0, sizeof(JsonAlertLogThread));

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -344,6 +344,8 @@ static TmEcode JsonAnomalyLogThreadDeinit(ThreadVars *t, void *data)
     }
 
     MemBufferFree(aft->json_buffer);
+
+    LogFileDeInitCtx(aft->json_output_ctx->file_ctx, t->id);
 
     /* clear memory */
     memset(aft, 0, sizeof(JsonAnomalyLogThread));

--- a/src/output-json-common.c
+++ b/src/output-json-common.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -89,7 +89,6 @@ TmEcode JsonLogThreadInit(ThreadVars *t, const void *initdata, void **data)
     }
 
     thread->ctx = ((OutputCtx *)initdata)->data;
-    LogFileEnsureExists(thread->ctx->file_ctx, t->id);
     thread->file_ctx = LogFileEnsureExists(thread->ctx->file_ctx, t->id);
     if (!thread->file_ctx) {
         goto error_exit;
@@ -112,6 +111,7 @@ TmEcode JsonLogThreadDeinit(ThreadVars *t, void *data)
     if (thread == NULL) {
         return TM_ECODE_OK;
     }
+    LogFileDeInitCtx(thread->ctx->file_ctx, t->id);
     if (thread->buffer != NULL) {
         MemBufferFree(thread->buffer);
     }

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -164,6 +164,7 @@ static TmEcode JsonDHCPLogThreadDeinit(ThreadVars *t, void *data)
     if (thread == NULL) {
         return TM_ECODE_OK;
     }
+    LogFileDeInitCtx(thread->dhcplog_ctx->file_ctx, t->id);
     if (thread->buffer != NULL) {
         MemBufferFree(thread->buffer);
     }

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -347,6 +347,7 @@ static TmEcode JsonDNP3LogThreadDeinit(ThreadVars *t, void *data)
     if (thread == NULL) {
         return TM_ECODE_OK;
     }
+    LogFileDeInitCtx(thread->dnp3log_ctx->file_ctx, t->id);
     if (thread->buffer != NULL) {
         MemBufferFree(thread->buffer);
     }

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -432,7 +432,7 @@ static TmEcode LogDnsLogThreadInit(ThreadVars *t, const void *initdata, void **d
         goto error_exit;
     }
 
-    /* Use the Ouptut Context (file pointer and mutex) */
+    /* Use the Output Context (file pointer and mutex) */
     aft->dnslog_ctx= ((OutputCtx *)initdata)->data;
     aft->file_ctx = LogFileEnsureExists(aft->dnslog_ctx->file_ctx, t->id);
     if (!aft->file_ctx) {
@@ -456,6 +456,8 @@ static TmEcode LogDnsLogThreadDeinit(ThreadVars *t, void *data)
     if (aft == NULL) {
         return TM_ECODE_OK;
     }
+
+    LogFileDeInitCtx(aft->dnslog_ctx->file_ctx, t->id);
 
     MemBufferFree(aft->buffer);
     /* clear memory */

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -224,6 +224,7 @@ static TmEcode JsonDropLogThreadDeinit(ThreadVars *t, void *data)
     }
 
     MemBufferFree(aft->buffer);
+    LogFileDeInitCtx(aft->drop_ctx->file_ctx, t->id);
 
     /* clear memory */
     memset(aft, 0, sizeof(*aft));

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -275,6 +275,7 @@ static TmEcode JsonFileLogThreadDeinit(ThreadVars *t, void *data)
         return TM_ECODE_OK;
     }
 
+    LogFileDeInitCtx(aft->filelog_ctx->file_ctx, t->id);
     MemBufferFree(aft->buffer);
     /* clear memory */
     memset(aft, 0, sizeof(JsonFileLogThread));

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -422,6 +422,7 @@ static TmEcode JsonFlowLogThreadDeinit(ThreadVars *t, void *data)
         return TM_ECODE_OK;
     }
 
+    LogFileDeInitCtx(aft->flowlog_ctx->file_ctx, t->id);
     MemBufferFree(aft->buffer);
     /* clear memory */
     memset(aft, 0, sizeof(JsonFlowLogThread));

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -267,6 +267,7 @@ static TmEcode JsonFTPLogThreadDeinit(ThreadVars *t, void *data)
     if (thread == NULL) {
         return TM_ECODE_OK;
     }
+    LogFileDeInitCtx(thread->ftplog_ctx->file_ctx, t->id);
     if (thread->buffer != NULL) {
         MemBufferFree(thread->buffer);
     }

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -678,6 +678,8 @@ static TmEcode JsonHttpLogThreadDeinit(ThreadVars *t, void *data)
     if (aft == NULL) {
         return TM_ECODE_OK;
     }
+
+    LogFileDeInitCtx(aft->httplog_ctx->file_ctx, t->id);
 
     MemBufferFree(aft->buffer);
     /* clear memory */

--- a/src/output-json-ike.c
+++ b/src/output-json-ike.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -184,6 +184,7 @@ static TmEcode JsonIKELogThreadDeinit(ThreadVars *t, void *data)
     if (thread == NULL) {
         return TM_ECODE_OK;
     }
+    LogFileDeInitCtx(thread->ikelog_ctx->file_ctx, t->id);
     if (thread->buffer != NULL) {
         MemBufferFree(thread->buffer);
     }

--- a/src/output-json-krb5.c
+++ b/src/output-json-krb5.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -168,6 +168,7 @@ static TmEcode JsonKRB5LogThreadDeinit(ThreadVars *t, void *data)
     if (thread == NULL) {
         return TM_ECODE_OK;
     }
+    LogFileDeInitCtx(thread->krb5log_ctx->file_ctx, t->id);
     if (thread->buffer != NULL) {
         MemBufferFree(thread->buffer);
     }

--- a/src/output-json-metadata.c
+++ b/src/output-json-metadata.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -147,6 +147,7 @@ static TmEcode JsonMetadataLogThreadDeinit(ThreadVars *t, void *data)
         return TM_ECODE_OK;
     }
 
+    LogFileDeInitCtx(aft->json_output_ctx->file_ctx, t->id);
     MemBufferFree(aft->json_buffer);
 
     /* clear memory */

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -384,6 +384,7 @@ static TmEcode JsonNetFlowLogThreadDeinit(ThreadVars *t, void *data)
         return TM_ECODE_OK;
     }
 
+    LogFileDeInitCtx(aft->flowlog_ctx->file_ctx, t->id);
     MemBufferFree(aft->buffer);
     /* clear memory */
     memset(aft, 0, sizeof(JsonNetFlowLogThread));

--- a/src/output-json-rdp.c
+++ b/src/output-json-rdp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -153,6 +153,7 @@ static TmEcode JsonRdpLogThreadDeinit(ThreadVars *t, void *data)
     if (thread == NULL) {
         return TM_ECODE_OK;
     }
+    LogFileDeInitCtx(thread->rdplog_ctx->file_ctx, t->id);
     if (thread->buffer != NULL) {
         MemBufferFree(thread->buffer);
     }

--- a/src/output-json-rfb.c
+++ b/src/output-json-rfb.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -169,6 +169,7 @@ static TmEcode JsonRFBLogThreadDeinit(ThreadVars *t, void *data)
     if (thread == NULL) {
         return TM_ECODE_OK;
     }
+    LogFileDeInitCtx(thread->rfblog_ctx->file_ctx, t->id);
     if (thread->buffer != NULL) {
         MemBufferFree(thread->buffer);
     }

--- a/src/output-json-sip.c
+++ b/src/output-json-sip.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -178,6 +178,7 @@ static TmEcode JsonSIPLogThreadDeinit(ThreadVars *t, void *data)
     if (thread == NULL) {
         return TM_ECODE_OK;
     }
+    LogFileDeInitCtx(thread->siplog_ctx->file_ctx, t->id);
     if (thread->buffer != NULL) {
         MemBufferFree(thread->buffer);
     }

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -194,6 +194,7 @@ static TmEcode JsonSmtpLogThreadDeinit(ThreadVars *t, void *data)
         return TM_ECODE_OK;
     }
 
+    LogFileDeInitCtx(aft->emaillog_ctx->file_ctx, t->id);
     MemBufferFree(aft->buffer);
     /* clear memory */
     memset(aft, 0, sizeof(JsonEmailLogThread));

--- a/src/output-json-snmp.c
+++ b/src/output-json-snmp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -168,6 +168,7 @@ static TmEcode JsonSNMPLogThreadDeinit(ThreadVars *t, void *data)
     if (thread == NULL) {
         return TM_ECODE_OK;
     }
+    LogFileDeInitCtx(thread->snmplog_ctx->file_ctx, t->id);
     if (thread->buffer != NULL) {
         MemBufferFree(thread->buffer);
     }

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -139,6 +139,7 @@ static TmEcode JsonSshLogThreadDeinit(ThreadVars *t, void *data)
         return TM_ECODE_OK;
     }
 
+    LogFileDeInitCtx(aft->sshlog_ctx->file_ctx, t->id);
     MemBufferFree(aft->buffer);
     /* clear memory */
     memset(aft, 0, sizeof(JsonSshLogThread));

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -368,6 +368,7 @@ static TmEcode JsonStatsLogThreadDeinit(ThreadVars *t, void *data)
         return TM_ECODE_OK;
     }
 
+    LogFileDeInitCtx(aft->statslog_ctx->file_ctx, t->id);
     MemBufferFree(aft->buffer);
 
     /* clear memory */

--- a/src/output-json-template-rust.c
+++ b/src/output-json-template-rust.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -169,6 +169,7 @@ static TmEcode JsonTemplateLogThreadDeinit(ThreadVars *t, void *data)
     if (thread == NULL) {
         return TM_ECODE_OK;
     }
+    LogFileDeInitCtx(thread->templatelog_ctx->file_ctx, t->id);
     if (thread->buffer != NULL) {
         MemBufferFree(thread->buffer);
     }

--- a/src/output-json-template.c
+++ b/src/output-json-template.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -177,6 +177,7 @@ static TmEcode JsonTemplateLogThreadDeinit(ThreadVars *t, void *data)
     if (thread == NULL) {
         return TM_ECODE_OK;
     }
+    LogFileDeInitCtx(thread->templatelog_ctx->file_ctx, t->id);
     if (thread->buffer != NULL) {
         MemBufferFree(thread->buffer);
     }

--- a/src/output-json-tftp.c
+++ b/src/output-json-tftp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -167,6 +167,7 @@ static TmEcode JsonTFTPLogThreadDeinit(ThreadVars *t, void *data)
     if (thread == NULL) {
         return TM_ECODE_OK;
     }
+    LogFileDeInitCtx(thread->tftplog_ctx->file_ctx, t->id);
     if (thread->buffer != NULL) {
         MemBufferFree(thread->buffer);
     }

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -497,6 +497,7 @@ static TmEcode JsonTlsLogThreadDeinit(ThreadVars *t, void *data)
         return TM_ECODE_OK;
     }
 
+    LogFileDeInitCtx(aft->tlslog_ctx->file_ctx, t->id);
     MemBufferFree(aft->buffer);
 
     /* clear memory */

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1186,7 +1186,7 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
             ConfNode *plugin_conf = ConfNodeLookupChild(conf,
                 json_ctx->plugin->name);
             void *plugin_data = NULL;
-            if (json_ctx->plugin->Open(plugin_conf, &plugin_data) < 0) {
+            if (json_ctx->plugin->Init(plugin_conf, false, &plugin_data) < 0) {
                 LogFileFreeCtx(json_ctx->file_ctx);
                 SCFree(json_ctx);
                 SCFree(output_ctx);

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -45,12 +45,22 @@ typedef struct SCPlugin_ {
  * Structure used to define a file type plugin.
  *
  * Currently only used by the Eve output type.
+ *
+ * name -- The plugin name. This name is used to identify the plugin: eve-log.filetype and in the
+ * plugins: section
  */
 typedef struct SCPluginFileType_ {
     char *name;
-    int (*Open)(ConfNode *conf, void **data);
-    int (*Write)(const char *buffer, int buffer_len, void *ctx);
-    void (*Close)(void *ctx);
+    /* Init Called on first access */
+    int (*Init)(ConfNode *conf, bool threaded, void **init_data);
+    /* Write - Called on each write to the object */
+    int (*Write)(const char *buffer, int buffer_len, void *init_data, void *thread_data);
+    /* Close - Called on final close */
+    void (*Deinit)(void *init_data);
+    /* ThreadInit - Called for each thread using file object*/
+    int (*ThreadInit)(void *init_data, int thread_id, void **thread_data);
+    /* ThreadDeinit - Called for each thread using file object */
+    int (*ThreadDeinit)(void *init_data, void *thread_data);
     TAILQ_ENTRY(SCPluginFileType_) entries;
 } SCPluginFileType;
 
@@ -59,6 +69,8 @@ bool SCPluginRegisterFileType(SCPluginFileType *);
 typedef struct SCCapturePlugin_ {
     char *name;
     void (*Init)(const char *args, int plugin_slot, int receive_slot, int decode_slot);
+    int (*ThreadInit)(void *ctx, int thread_id, void **thread_ctx);
+    int (*ThreadDeinit)(void *ctx, void *thread_ctx);
     const char *(*GetDefaultMode)(void);
     TAILQ_ENTRY(SCCapturePlugin_) entries;
 } SCCapturePlugin;

--- a/src/util-log-redis.c
+++ b/src/util-log-redis.c
@@ -1,5 +1,5 @@
 /* vi: set et ts=4: */
-/* Copyright (C) 2007-2016 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -53,7 +53,7 @@ void SCLogRedisInit()
 #endif /* HAVE_LIBEVENT_PTHREADS */
 }
 
-/** \brief SCLogRedisContextAlloc() - Allocates and initalizes redis context
+/** \brief SCLogRedisContextAlloc() - Allocates and initializes redis context
  */
 static SCLogRedisContext *SCLogRedisContextAlloc(void)
 {
@@ -430,7 +430,7 @@ static int SCLogRedisWriteSync(LogFileCtx *file_ctx, const char *string)
  * \param log_ctx Log file context allocated by caller
  * \param string buffer with data to write
  * \param string_len data length
- * \retval 0 on sucess;
+ * \retval 0 on success;
  * \retval -1 on failure;
  */
 int LogFileWriteRedis(void *lf_ctx, const char *string, size_t string_len)
@@ -460,6 +460,10 @@ int LogFileWriteRedis(void *lf_ctx, const char *string, size_t string_len)
  */
 int SCConfLogOpenRedis(ConfNode *redis_node, void *lf_ctx)
 {
+    if (lf_ctx->threaded) {
+        FatalError(SC_ERR_FATAL, "redis does not support threaded output");
+    }
+
     LogFileCtx *log_ctx = lf_ctx;
 
     const char *redis_port = NULL;

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -830,8 +830,8 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
         SCFree(lf_ctx->threads);
     } else {
         if (lf_ctx->type == LOGFILE_TYPE_PLUGIN) {
-            if (lf_ctx->plugin->Close != NULL) {
-                lf_ctx->plugin->Close(lf_ctx->plugin_data);
+            if (lf_ctx->plugin->Deinit != NULL) {
+                lf_ctx->plugin->Deinit(lf_ctx->plugin_data);
             }
         } else if (lf_ctx->fp != NULL) {
             lf_ctx->Close(lf_ctx);
@@ -888,7 +888,7 @@ int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer)
 #endif
     else if (file_ctx->type == LOGFILE_TYPE_PLUGIN) {
         file_ctx->plugin->Write((const char *)MEMBUFFER_BUFFER(buffer),
-                        MEMBUFFER_OFFSET(buffer), file_ctx->plugin_data);
+                        MEMBUFFER_OFFSET(buffer), file_ctx->plugin_data, NULL);
     }
 
     return 0;

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -56,17 +56,22 @@ typedef struct LogThreadedFileCtx_ {
     char *append;
 } LogThreadedFileCtx;
 
+typedef struct LogFilePluginCtx_ {
+    SCPluginFileType *plugin;
+    void *init_data;
+    void *thread_data;
+} LogFilePluginCtx;
+
 /** Global structure for Output Context */
 typedef struct LogFileCtx_ {
     union {
         FILE *fp;
         PcieFile *pcie_fp;
-        LogThreadedFileCtx *threads;
-        void *plugin_data;
 #ifdef HAVE_LIBHIREDIS
         void *redis;
 #endif
     };
+    LogThreadedFileCtx *threads;
 
     union {
         SyslogSetup syslog_setup;
@@ -78,7 +83,7 @@ typedef struct LogFileCtx_ {
     int (*Write)(const char *buffer, int buffer_len, struct LogFileCtx_ *fp);
     void (*Close)(struct LogFileCtx_ *fp);
 
-    SCPluginFileType *plugin;
+    LogFilePluginCtx plugin;
 
     /** It will be locked if the log/alert
      * record cannot be written to the file in one call */
@@ -161,11 +166,14 @@ typedef struct LogFileCtx_ {
 #define LOGFILE_ROTATE_INTERVAL 0x04
 
 LogFileCtx *LogFileNewCtx(void);
+void LogFileDeInitCtx(LogFileCtx *, int thread_id);
 int LogFileFreeCtx(LogFileCtx *);
 int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer);
 
 LogFileCtx *LogFileEnsureExists(LogFileCtx *lf_ctx, int thread_id);
 int SCConfLogOpenGeneric(ConfNode *conf, LogFileCtx *, const char *, int);
 int SCConfLogReopen(LogFileCtx *);
+bool SCLogOpenThreadedFile(
+        const char *log_path, const char *append, LogFileCtx *parent_ctx, int slot_count);
 
 #endif /* __UTIL_LOGOPENFILE_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -71,6 +71,10 @@ stats:
   # Add stream events as stats.
   #stream-events: false
 
+# Plugins -- Experimental -- specify the plugin name and filename of the plugin shared object
+plugins:
+#   plugin-name: /path/to/plugin.so
+
 # Configure the type of alert (and other) logging you would like.
 outputs:
   # a line based alerts log similar to Snort's fast.log


### PR DESCRIPTION
This commit includes draft changes to support EVE 

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4126](https://redmine.openinfosecfoundation.org/issues/4126)

Describe changes:
These changes build upon the experimental file output plugin support by
adding calls when a thread attaches and detaches from an output context:
- Thread initialization function returns per-thread context
- Thread deinitialization function uses context to remove resources

I've modified @jasonish's output plugin with a multi-threaded variant: https://github.com/jlucovsky/suricata-example-plugins/tree/output/1/eve-file-type

Configure Suricata to use this plugin by adding the following to `suricata.yaml`

```
plugins:
    threaded-filetype-plugin: /path/to/plugin.so
```

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
