### PR TITLE
filestore: use Rust to provde md5/sha1/sha256 support - v0

### DIFF
--- a/doc/userguide/rules/ja3-keywords.rst
+++ b/doc/userguide/rules/ja3-keywords.rst
@@ -5,8 +5,6 @@ Suricata comes with a JA3 integration (https://github.com/salesforce/ja3). JA3 i
 
 JA3 must be enabled in the Suricata config file (set 'app-layer.protocols.tls.ja3-fingerprints' to 'yes').
 
-JA3 also requires Suricata to be built with LibNSS support.
-
 ja3.hash
 --------
 

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -41,6 +41,8 @@ tls-parser = "0.9"
 x509-parser = "0.6.5"
 libc = "0.2.67"
 sha2 = "0.9.2"
+digest = "0.9.0"
+sha-1 = "0.9.2"
 
 [dev-dependencies]
 test-case = "1.0"

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -40,6 +40,7 @@ snmp-parser = "0.6"
 tls-parser = "0.9"
 x509-parser = "0.6.5"
 libc = "0.2.67"
+sha2 = "0.9.2"
 
 [dev-dependencies]
 test-case = "1.0"

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -29,7 +29,6 @@ num = "0.2"
 num-derive = "0.2"
 num-traits = "0.2"
 widestring = "0.4"
-md5 = "0.7.0"
 
 der-parser = "4.0"
 kerberos-parser = "0.5"
@@ -43,7 +42,7 @@ libc = "0.2.67"
 sha2 = "0.9.2"
 digest = "0.9.0"
 sha-1 = "0.9.2"
-md5c = { package = "md-5", version = "0.9.1" }
+md-5 = "0.9.1"
 
 [dev-dependencies]
 test-case = "1.0"

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -43,6 +43,7 @@ libc = "0.2.67"
 sha2 = "0.9.2"
 digest = "0.9.0"
 sha-1 = "0.9.2"
+md5c = { package = "md-5", version = "0.9.1" }
 
 [dev-dependencies]
 test-case = "1.0"

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -43,7 +43,7 @@ include_version = true
 
 # A list of headers to #include (with quotes)
 # default: []
-includes = ["rust.h"]
+includes = []
 
 # The desired length of a line to use when formatting lines
 # default: 100

--- a/rust/src/ffi/hashing.rs
+++ b/rust/src/ffi/hashing.rs
@@ -16,7 +16,7 @@
  */
 
 use digest::Digest;
-use md5c::Md5;
+use md5::Md5;
 use sha1::Sha1;
 use sha2::Sha256;
 

--- a/rust/src/ffi/hashing.rs
+++ b/rust/src/ffi/hashing.rs
@@ -132,6 +132,14 @@ pub unsafe extern "C" fn SCMd5Free(hasher: &mut SCMd5) {
     let _: Box<SCMd5> = Box::from_raw(hasher);
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn SCMd5HashBuffer(buf: *const u8, buf_len: u32, out: *mut u8, len: u32) {
+    let data = std::slice::from_raw_parts(buf, buf_len as usize);
+    let output = std::slice::from_raw_parts_mut(out, len as usize);
+    let hash = Md5::new().chain(data).finalize();
+    output.copy_from_slice(&hash);
+}
+
 // Functions that are generic over Digest. For the most part the C bindings are
 // just wrappers around these.
 

--- a/rust/src/ffi/hashing.rs
+++ b/rust/src/ffi/hashing.rs
@@ -16,6 +16,7 @@
  */
 
 use digest::Digest;
+use md5c::Md5;
 use sha1::Sha1;
 use sha2::Sha256;
 
@@ -101,6 +102,34 @@ pub unsafe extern "C" fn SCSha1Finalize(hasher: &mut SCSha1, out: *mut u8, len: 
 pub unsafe extern "C" fn SCSha1Free(hasher: &mut SCSha1) {
     // Drop.
     let _: Box<SCSha1> = Box::from_raw(hasher);
+}
+
+// Start of MD5 C bindins.
+
+pub struct SCMd5(Md5);
+
+#[no_mangle]
+pub extern "C" fn SCMd5New() -> *mut SCMd5 {
+    let hasher = Box::new(SCMd5(Md5::new()));
+    Box::into_raw(hasher)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCMd5Update(hasher: &mut SCMd5, bytes: *const u8, len: u32) {
+    update(&mut hasher.0, bytes, len);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCMd5Finalize(hasher: &mut SCMd5, out: *mut u8, len: u32) {
+    let hasher: Box<SCMd5> = Box::from_raw(hasher);
+    finalize(hasher.0, out, len);
+}
+
+/// Free an unfinalized Sha1 context.
+#[no_mangle]
+pub unsafe extern "C" fn SCMd5Free(hasher: &mut SCMd5) {
+    // Drop.
+    let _: Box<SCMd5> = Box::from_raw(hasher);
 }
 
 // Functions that are generic over Digest. For the most part the C bindings are

--- a/rust/src/ffi/hashing.rs
+++ b/rust/src/ffi/hashing.rs
@@ -17,6 +17,8 @@
 
 use sha2::{Digest, Sha256};
 
+pub const SC_SHA256_LEN: usize = 32;
+
 // Wrap the Rust Sha256 in a new type named SCSha256 to give this type
 // the "SC" prefix. The one drawback is we must access the actual context
 // with .0.
@@ -39,6 +41,7 @@ pub unsafe extern "C" fn SCSha256Finalize(hasher: &mut SCSha256, out: *mut u8, l
     let hasher: Box<SCSha256> = Box::from_raw(hasher);
     let result = hasher.0.finalize();
     let output = std::slice::from_raw_parts_mut(out, len as usize);
+    // This will panic if the sizes differ.
     output.copy_from_slice(&result);
 }
 
@@ -59,7 +62,11 @@ pub unsafe extern "C" fn SCSha256FinalizeToHex(hasher: &mut SCSha256, out: *mut 
     let result = hasher.0.finalize();
     let hex = format!("{:x}", &result);
     let output = std::slice::from_raw_parts_mut(out, len as usize);
+
+    // This will panic if the sizes differ.
     output[0..len as usize - 1].copy_from_slice(&hex.as_bytes());
+
+    // Terminate the string.
     output[output.len() - 1] = 0;
 }
 

--- a/rust/src/ffi/hashing.rs
+++ b/rust/src/ffi/hashing.rs
@@ -1,0 +1,71 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use sha2::{Digest, Sha256};
+
+// Wrap the Rust Sha256 in a new type named SCSha256 to give this type
+// the "SC" prefix. The one drawback is we must access the actual context
+// with .0.
+pub struct SCSha256(Sha256);
+
+#[no_mangle]
+pub extern "C" fn SCSha256New() -> *mut SCSha256 {
+    let hasher = Box::new(SCSha256(Sha256::new()));
+    Box::into_raw(hasher)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCSha256Update(hasher: &mut SCSha256, bytes: *const u8, len: u32) {
+    let data = std::slice::from_raw_parts(bytes, len as usize);
+    hasher.0.update(data);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCSha256Finalize(hasher: &mut SCSha256, out: *mut u8, len: u32) {
+    let hasher: Box<SCSha256> = Box::from_raw(hasher);
+    let result = hasher.0.finalize();
+    let output = std::slice::from_raw_parts_mut(out, len as usize);
+    output.copy_from_slice(&result);
+}
+
+/// C function to finalize the Sha256 hasher to a hex string.
+///
+/// Notes:
+/// - The output pointer is of type *mut u8 as I'm not sure how to perform the copy
+///   from the hex string to C string efficiently. I believe the code is still correct
+///   but C function signature isn't ideal bing *uint8_t instead of *char.
+/// - There is probably room for optimization here, by iterating the result and writing
+///   the output directly to the output buffer.
+///
+/// But even given the notes, this appears to be faster than the equivalent that we
+/// did in C using NSS.
+#[no_mangle]
+pub unsafe extern "C" fn SCSha256FinalizeToHex(hasher: &mut SCSha256, out: *mut u8, len: u32) {
+    let hasher: Box<SCSha256> = Box::from_raw(hasher);
+    let result = hasher.0.finalize();
+    let hex = format!("{:x}", &result);
+    let output = std::slice::from_raw_parts_mut(out, len as usize);
+    output[0..len as usize - 1].copy_from_slice(&hex.as_bytes());
+    output[output.len() - 1] = 0;
+}
+
+/// Free an unfinalized Sha256 context.
+#[no_mangle]
+pub unsafe extern "C" fn SCSha256Free(hasher: &mut SCSha256) {
+    // Drop.
+    let _: Box<SCSha256> = Box::from_raw(hasher);
+}

--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -1,0 +1,18 @@
+/* Copyright (C) 2020 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+pub mod hashing;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -84,3 +84,4 @@ pub mod ssh;
 pub mod http2;
 pub mod plugin;
 pub mod util;
+pub mod ffi;

--- a/rust/src/ssh/parser.rs
+++ b/rust/src/ssh/parser.rs
@@ -17,6 +17,8 @@
 
 use nom::combinator::rest;
 use nom::number::streaming::{be_u32, be_u8};
+use md5c::Md5;
+use digest::Digest;
 use std::fmt;
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
@@ -151,8 +153,6 @@ pub struct SshPacketKeyExchange<'a> {
     pub reserved: u32,
 }
 
-use md5::compute;
-
 const SSH_HASSH_STRING_DELIMITER_SLICE: [u8; 1] = [b';'];
 
 impl<'a> SshPacketKeyExchange<'a> {
@@ -172,7 +172,7 @@ impl<'a> SshPacketKeyExchange<'a> {
         hassh_string.reserve_exact(slices.iter().fold(0, |acc, x| acc + x.len()));
         // copying slices to hassh string
         slices.iter().for_each(|&x| hassh_string.extend_from_slice(x)); 
-        hassh.extend(format!("{:x?}", compute(&hassh_string)).as_bytes());
+        hassh.extend(format!("{:x}", Md5::new().chain(&hassh_string).finalize()).as_bytes());
     }
 }
 

--- a/rust/src/ssh/parser.rs
+++ b/rust/src/ssh/parser.rs
@@ -17,7 +17,7 @@
 
 use nom::combinator::rest;
 use nom::number::streaming::{be_u32, be_u8};
-use md5c::Md5;
+use md5::Md5;
 use digest::Digest;
 use std::fmt;
 

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -54,6 +54,10 @@
 #include "flow-private.h"
 #include "util-validate.h"
 
+#ifdef HAVE_NSS
+#include <sechash.h>
+#endif
+
 SCEnumCharMap tls_decoder_event_table[ ] = {
     /* TLS protocol messages */
     { "INVALID_SSLV2_HEADER",        TLS_DECODER_EVENT_INVALID_SSLV2_HEADER },

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -3026,18 +3026,9 @@ void RegisterSSLParsers(void)
         }
         SC_ATOMIC_SET(ssl_config.enable_ja3, enable_ja3);
 
-#ifndef HAVE_NSS
-        if (SC_ATOMIC_GET(ssl_config.enable_ja3)) {
-            SCLogWarning(SC_WARN_NO_JA3_SUPPORT,
-                         "no MD5 calculation support built in (LibNSS), disabling JA3");
-            SC_ATOMIC_SET(ssl_config.enable_ja3, 0);
-        }
-#else
         if (RunmodeIsUnittests()) {
             SC_ATOMIC_SET(ssl_config.enable_ja3, 1);
         }
-#endif
-
     } else {
         SCLogConfig("Parsed disabled for %s protocol. Protocol detection"
                   "still on.", proto_name);
@@ -3057,7 +3048,6 @@ void RegisterSSLParsers(void)
  */
 void SSLEnableJA3(void)
 {
-#ifdef HAVE_NSS
     if (ssl_config.disable_ja3) {
         return;
     }
@@ -3065,16 +3055,13 @@ void SSLEnableJA3(void)
         return;
     }
     SC_ATOMIC_SET(ssl_config.enable_ja3, 1);
-#endif
 }
 
 bool SSLJA3IsEnabled(void)
 {
-#ifdef HAVE_NSS
     if (SC_ATOMIC_GET(ssl_config.enable_ja3)) {
         return true;
     }
-#endif
     return false;
 }
 

--- a/src/detect-file-hash-common.c
+++ b/src/detect-file-hash-common.c
@@ -32,8 +32,6 @@
 
 #include "app-layer-htp.h"
 
-#ifdef HAVE_NSS
-
 /**
  * \brief Read the bytes of a hash from an hexadecimal string
  *
@@ -379,5 +377,3 @@ void DetectFileHashFree(DetectEngineCtx *de_ctx, void *ptr)
         SCFree(filehash);
     }
 }
-
-#endif /* HAVE_NSS */

--- a/src/detect-filemd5.c
+++ b/src/detect-filemd5.c
@@ -31,29 +31,6 @@
 
 #include "detect-filemd5.h"
 
-#ifndef HAVE_NSS
-
-static int DetectFileMd5SetupNoSupport (DetectEngineCtx *a, Signature *b, const char *c)
-{
-    SCLogError(SC_ERR_NO_MD5_SUPPORT, "no MD5 calculation support built in, needed for filemd5 keyword");
-    return -1;
-}
-
-/**
- * \brief Registration function for keyword: filemd5
- */
-void DetectFileMd5Register(void)
-{
-    sigmatch_table[DETECT_FILEMD5].name = "filemd5";
-    sigmatch_table[DETECT_FILEMD5].Setup = DetectFileMd5SetupNoSupport;
-    sigmatch_table[DETECT_FILEMD5].flags = SIGMATCH_NOT_BUILT;
-
-    SCLogDebug("registering filemd5 rule option");
-    return;
-}
-
-#else /* HAVE_NSS */
-
 static int g_file_match_list_id = 0;
 
 static int DetectFileMd5Setup (DetectEngineCtx *, Signature *, const char *);
@@ -159,6 +136,3 @@ void DetectFileMd5RegisterTests(void)
     UtRegisterTest("MD5MatchTest01", MD5MatchTest01);
 }
 #endif
-
-#endif /* HAVE_NSS */
-

--- a/src/detect-filesha1.c
+++ b/src/detect-filesha1.c
@@ -32,29 +32,6 @@
 
 #include "detect-filesha1.h"
 
-#ifndef HAVE_NSS
-
-static int DetectFileSha1SetupNoSupport (DetectEngineCtx *a, Signature *b, const char *c)
-{
-    SCLogError(SC_ERR_NO_SHA1_SUPPORT, "no SHA-1 calculation support built in, needed for filesha1 keyword");
-    return -1;
-}
-
-/**
- * \brief Registration function for keyword: filesha1
- */
-void DetectFileSha1Register(void)
-{
-    sigmatch_table[DETECT_FILESHA1].name = "filesha1";
-    sigmatch_table[DETECT_FILESHA1].Setup = DetectFileSha1SetupNoSupport;
-    sigmatch_table[DETECT_FILESHA1].flags = SIGMATCH_NOT_BUILT;
-
-    SCLogDebug("registering filesha1 rule option");
-    return;
-}
-
-#else /* HAVE_NSS */
-
 static int DetectFileSha1Setup (DetectEngineCtx *, Signature *, const char *);
 #ifdef UNITTESTS
 static void DetectFileSha1RegisterTests(void);
@@ -145,4 +122,3 @@ static void DetectFileSha1RegisterTests(void)
     UtRegisterTest("SHA1MatchTest01", SHA1MatchTest01);
 }
 #endif
-#endif /* HAVE_NSS */

--- a/src/detect-filesha256.c
+++ b/src/detect-filesha256.c
@@ -32,29 +32,6 @@
 
 #include "detect-filesha256.h"
 
-#ifndef HAVE_NSS
-
-static int DetectFileSha256SetupNoSupport (DetectEngineCtx *a, Signature *b, const char *c)
-{
-    SCLogError(SC_ERR_NO_SHA256_SUPPORT, "no SHA-256 calculation support built in, needed for filesha256 keyword");
-    return -1;
-}
-
-/**
- * \brief Registration function for keyword: filesha256
- */
-void DetectFileSha256Register(void)
-{
-    sigmatch_table[DETECT_FILESHA256].name = "filesha256";
-    sigmatch_table[DETECT_FILESHA256].Setup = DetectFileSha256SetupNoSupport;
-    sigmatch_table[DETECT_FILESHA256].flags = SIGMATCH_NOT_BUILT;
-
-    SCLogDebug("registering filesha256 rule option");
-    return;
-}
-
-#else /* HAVE_NSS */
-
 static int DetectFileSha256Setup (DetectEngineCtx *, Signature *, const char *);
 #ifdef UNITTESTS
 static void DetectFileSha256RegisterTests(void);
@@ -160,4 +137,3 @@ void DetectFileSha256RegisterTests(void)
     UtRegisterTest("SHA256MatchTest01", SHA256MatchTest01);
 }
 #endif
-#endif /* HAVE_NSS */

--- a/src/detect-mqtt-connack-sessionpresent.c
+++ b/src/detect-mqtt-connack-sessionpresent.c
@@ -30,7 +30,7 @@
 #include "detect-mqtt-connack-sessionpresent.h"
 #include "util-unittest.h"
 
-#include "rust-bindings.h"
+#include "rust.h"
 
 #define PARSE_REGEX "^true|false|yes|no$"
 static DetectParseRegex parse_regex;

--- a/src/detect-mqtt-connect-flags.c
+++ b/src/detect-mqtt-connect-flags.c
@@ -30,7 +30,7 @@
 #include "detect-mqtt-connect-flags.h"
 #include "util-unittest.h"
 
-#include "rust-bindings.h"
+#include "rust.h"
 
 #define PARSE_REGEX "(?: *,?!?(?:username|password|will|will_retain|clean_session))+"
 static DetectParseRegex parse_regex;

--- a/src/detect-mqtt-flags.c
+++ b/src/detect-mqtt-flags.c
@@ -30,7 +30,7 @@
 #include "detect-mqtt-flags.h"
 #include "util-unittest.h"
 
-#include "rust-bindings.h"
+#include "rust.h"
 
 #define PARSE_REGEX "(?: *,?!?(?:retain|dup))+"
 static DetectParseRegex parse_regex;

--- a/src/detect-mqtt-protocol-version.c
+++ b/src/detect-mqtt-protocol-version.c
@@ -32,7 +32,7 @@
 #include "util-byte.h"
 #include "util-unittest.h"
 
-#include "rust-bindings.h"
+#include "rust.h"
 
 static int mqtt_protocol_version_id = 0;
 

--- a/src/detect-mqtt-qos.c
+++ b/src/detect-mqtt-qos.c
@@ -31,7 +31,7 @@
 #include "util-byte.h"
 #include "util-unittest.h"
 
-#include "rust-bindings.h"
+#include "rust.h"
 
 static int mqtt_qos_id = 0;
 

--- a/src/detect-mqtt-reason-code.c
+++ b/src/detect-mqtt-reason-code.c
@@ -31,7 +31,7 @@
 #include "util-byte.h"
 #include "util-unittest.h"
 
-#include "rust-bindings.h"
+#include "rust.h"
 
 #define PARSE_REGEX "^\\s*\\d+\\s*$"
 static DetectParseRegex parse_regex;

--- a/src/detect-mqtt-type.c
+++ b/src/detect-mqtt-type.c
@@ -30,7 +30,7 @@
 #include "detect-mqtt-type.h"
 #include "util-unittest.h"
 
-#include "rust-bindings.h"
+#include "rust.h"
 
 static int mqtt_type_id = 0;
 

--- a/src/detect-rfb-secresult.c
+++ b/src/detect-rfb-secresult.c
@@ -30,7 +30,7 @@
 #include "detect-rfb-secresult.h"
 #include "util-unittest.h"
 
-#include "rust-bindings.h"
+#include "rust.h"
 
 #define PARSE_REGEX "\\S[A-z]"
 static DetectParseRegex parse_regex;

--- a/src/detect-transform-md5.c
+++ b/src/detect-transform-md5.c
@@ -34,6 +34,10 @@
 #include "util-unittest.h"
 #include "util-print.h"
 
+#ifdef HAVE_NSS
+#include <sechash.h>
+#endif
+
 static int DetectTransformToMd5Setup (DetectEngineCtx *, Signature *, const char *);
 #ifdef HAVE_NSS
 #ifdef UNITTESTS

--- a/src/detect-transform-sha1.c
+++ b/src/detect-transform-sha1.c
@@ -34,6 +34,10 @@
 #include "util-unittest.h"
 #include "util-print.h"
 
+#ifdef HAVE_NSS
+#include <sechash.h>
+#endif
+
 static int DetectTransformToSha1Setup (DetectEngineCtx *, Signature *, const char *);
 #ifdef HAVE_NSS
 #ifdef UNITTESTS

--- a/src/detect-transform-sha256.c
+++ b/src/detect-transform-sha256.c
@@ -34,6 +34,10 @@
 #include "util-unittest.h"
 #include "util-print.h"
 
+#ifdef HAVE_NSS
+#include <sechash.h>
+#endif
+
 static int DetectTransformToSha256Setup (DetectEngineCtx *, Signature *, const char *);
 #ifdef HAVE_NSS
 #ifdef UNITTESTS

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -32,13 +32,11 @@
 #include "util-print.h"
 #include "util-misc.h"
 
-#ifdef HAVE_NSS
-
 #define MODULE_NAME "OutputFilestore"
 
 /* Create a filestore specific PATH_MAX that is less than the system
  * PATH_MAX to prevent newer gcc truncation warnings with snprint. */
-#define SHA256_STRING_LEN (SHA256_LENGTH * 2)
+#define SHA256_STRING_LEN    (SC_SHA256_LEN * 2)
 #define LEAF_DIR_MAX_LEN 4
 #define FILESTORE_PREFIX_MAX (PATH_MAX - SHA256_STRING_LEN - LEAF_DIR_MAX_LEN)
 
@@ -129,7 +127,7 @@ static void OutputFilestoreFinalizeFiles(ThreadVars *tv,
         const Packet *p, File *ff, uint8_t dir) {
     /* Stringify the SHA256 which will be used in the final
      * filename. */
-    char sha256string[(SHA256_LENGTH * 2) + 1];
+    char sha256string[(SC_SHA256_LEN * 2) + 1];
     PrintHexString(sha256string, sizeof(sha256string), ff->sha256,
             sizeof(ff->sha256));
 
@@ -535,11 +533,8 @@ static OutputInitResult OutputFilestoreLogInitCtx(ConfNode *conf)
     SCReturnCT(result, "OutputInitResult");
 }
 
-#endif /* HAVE_NSS */
-
 void OutputFilestoreRegister(void)
 {
-#ifdef HAVE_NSS
     OutputRegisterFiledataModule(LOGGER_FILE_STORE, MODULE_NAME, "file-store",
             OutputFilestoreLogInitCtx, OutputFilestoreLogger,
             OutputFilestoreLogThreadInit, OutputFilestoreLogThreadDeinit,
@@ -547,5 +542,4 @@ void OutputFilestoreRegister(void)
 
     SC_ATOMIC_INIT(filestore_open_file_cnt);
     SC_ATOMIC_SET(filestore_open_file_cnt, 0);
-#endif
 }

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -156,7 +156,6 @@ void EveFileInfo(JsonBuilder *jb, const File *ff, const bool stored)
     switch (ff->state) {
         case FILE_STATE_CLOSED:
             JB_SET_STRING(jb, "state", "CLOSED");
-#ifdef HAVE_NSS
             if (ff->flags & FILE_MD5) {
                 size_t x;
                 int i;
@@ -175,7 +174,6 @@ void EveFileInfo(JsonBuilder *jb, const File *ff, const bool stored)
                 }
                 jb_set_string(jb, "sha1", str);
             }
-#endif
             break;
         case FILE_STATE_TRUNCATED:
             JB_SET_STRING(jb, "state", "TRUNCATED");
@@ -188,7 +186,6 @@ void EveFileInfo(JsonBuilder *jb, const File *ff, const bool stored)
             break;
     }
 
-#ifdef HAVE_NSS
     if (ff->flags & FILE_SHA256) {
         size_t x;
         int i;
@@ -198,7 +195,6 @@ void EveFileInfo(JsonBuilder *jb, const File *ff, const bool stored)
         }
         jb_set_string(jb, "sha256", str);
     }
-#endif
 
     if (stored) {
         JB_SET_TRUE(jb, "stored");

--- a/src/tests/detect-tls-ja3-hash.c
+++ b/src/tests/detect-tls-ja3-hash.c
@@ -22,15 +22,6 @@
  *
  */
 
-#ifndef HAVE_NSS
-
-static void DetectTlsJa3HashRegisterTests(void)
-{
-    /* Don't register any tests */
-}
-
-#else /* HAVE_NSS */
-
 /**
  * \test Test matching on a simple client hello packet
  */
@@ -224,5 +215,3 @@ static void DetectTlsJa3HashRegisterTests(void)
     UtRegisterTest("DetectTlsJa3HashTest01", DetectTlsJa3HashTest01);
     UtRegisterTest("DetectTlsJa3HashTest02", DetectTlsJa3HashTest02);
 }
-
-#endif /* HAVE_NSS */

--- a/src/tests/detect-tls-ja3-string.c
+++ b/src/tests/detect-tls-ja3-string.c
@@ -22,15 +22,6 @@
  *
  */
 
-#ifndef HAVE_NSS
-
-static void DetectTlsJa3StringRegisterTests(void)
-{
-    /* Don't register any tests */
-}
-
-#else /* HAVE_NSS */
-
 /**
  * \test Test matching on a simple client hello packet
  */
@@ -127,5 +118,3 @@ static void DetectTlsJa3StringRegisterTests(void)
 {
     UtRegisterTest("DetectTlsJa3StringTest01", DetectTlsJa3StringTest01);
 }
-
-#endif /* HAVE_NSS */

--- a/src/tests/detect-tls-ja3s-hash.c
+++ b/src/tests/detect-tls-ja3s-hash.c
@@ -22,15 +22,6 @@
  *
  */
 
-#ifndef HAVE_NSS
-
-static void DetectTlsJa3SHashRegisterTests(void)
-{
-    /* Don't register any tests */
-}
-
-#else /* HAVE_NSS */
-
 /**
  * \test Test matching on a JA3S hash from a ServerHello record
  */
@@ -173,5 +164,3 @@ void DetectTlsJa3SHashRegisterTests(void)
 {
     UtRegisterTest("DetectTlsJa3SHashTest01", DetectTlsJa3SHashTest01);
 }
-
-#endif /* HAVE_NSS */

--- a/src/tests/detect-tls-ja3s-string.c
+++ b/src/tests/detect-tls-ja3s-string.c
@@ -15,15 +15,6 @@
  * 02110-1301, USA.
  */
 
-#ifndef HAVE_NSS
-
-static void DetectTlsJa3SStringRegisterTests(void)
-{
-    /* Don't register any tests */
-}
-
-#else /* HAVE_NSS */
-
 /**
  * \test Test matching on a simple client hello packet
  */
@@ -166,5 +157,3 @@ static void DetectTlsJa3SStringRegisterTests(void)
 {
     UtRegisterTest("DetectTlsJa3SStringTest01", DetectTlsJa3SStringTest01);
 }
-
-#endif /* HAVE_NSS */

--- a/src/util-decode-mime.h
+++ b/src/util-decode-mime.h
@@ -25,6 +25,10 @@
 #ifndef MIME_DECODE_H_
 #define MIME_DECODE_H_
 
+#ifdef HAVE_NSS
+#include <sechash.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -33,6 +33,13 @@
 
 #include "util-streaming-buffer.h"
 
+/* Hack: Pulling rust.h to get the SCSha256 causes all sorts of problems with
+ *   header include orders, which is something we'll have to resolve as we provide
+ *   more functionality via Rust. But this lets me continue with replacing nss
+ *   without fighting the headers at this time. */
+typedef struct SCSha256 SCSha256;
+#define SC_SHA256_LEN 32
+
 #define FILE_TRUNCATED  BIT_U16(0)
 #define FILE_NOMAGIC    BIT_U16(1)
 #define FILE_NOMD5      BIT_U16(2)
@@ -80,8 +87,8 @@ typedef struct File_ {
     uint8_t md5[MD5_LENGTH];
     HASHContext *sha1_ctx;
     uint8_t sha1[SHA1_LENGTH];
-    HASHContext *sha256_ctx;
-    uint8_t sha256[SHA256_LENGTH];
+    SCSha256 *sha256_ctx;
+    uint8_t sha256[SC_SHA256_LEN];
 #endif
     uint64_t content_inspected;     /**< used in pruning if FILE_USE_DETECT
                                      *   flag is set */

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -25,10 +25,6 @@
 #ifndef __UTIL_FILE_H__
 #define __UTIL_FILE_H__
 
-#ifdef HAVE_NSS
-#include <sechash.h>
-#endif
-
 #include "conf.h"
 
 #include "util-streaming-buffer.h"
@@ -88,14 +84,12 @@ typedef struct File_ {
     char *magic;
 #endif
     struct File_ *next;
-#ifdef HAVE_NSS
     SCMd5 *md5_ctx;
     uint8_t md5[SC_MD5_LEN];
     SCSha1 *sha1_ctx;
     uint8_t sha1[SC_SHA1_LEN];
     SCSha256 *sha256_ctx;
     uint8_t sha256[SC_SHA256_LEN];
-#endif
     uint64_t content_inspected;     /**< used in pruning if FILE_USE_DETECT
                                      *   flag is set */
     uint64_t content_stored;

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -40,6 +40,9 @@
 typedef struct SCSha256 SCSha256;
 #define SC_SHA256_LEN 32
 
+typedef struct SCSha1 SCSha1;
+#define SC_SHA1_LEN 20
+
 #define FILE_TRUNCATED  BIT_U16(0)
 #define FILE_NOMAGIC    BIT_U16(1)
 #define FILE_NOMD5      BIT_U16(2)
@@ -85,8 +88,8 @@ typedef struct File_ {
 #ifdef HAVE_NSS
     HASHContext *md5_ctx;
     uint8_t md5[MD5_LENGTH];
-    HASHContext *sha1_ctx;
-    uint8_t sha1[SHA1_LENGTH];
+    SCSha1 *sha1_ctx;
+    uint8_t sha1[SC_SHA1_LEN];
     SCSha256 *sha256_ctx;
     uint8_t sha256[SC_SHA256_LEN];
 #endif

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -43,6 +43,9 @@ typedef struct SCSha256 SCSha256;
 typedef struct SCSha1 SCSha1;
 #define SC_SHA1_LEN 20
 
+typedef struct SCMd5 SCMd5;
+#define SC_MD5_LEN 16
+
 #define FILE_TRUNCATED  BIT_U16(0)
 #define FILE_NOMAGIC    BIT_U16(1)
 #define FILE_NOMD5      BIT_U16(2)
@@ -86,8 +89,8 @@ typedef struct File_ {
 #endif
     struct File_ *next;
 #ifdef HAVE_NSS
-    HASHContext *md5_ctx;
-    uint8_t md5[MD5_LENGTH];
+    SCMd5 *md5_ctx;
+    uint8_t md5[SC_MD5_LEN];
     SCSha1 *sha1_ctx;
     uint8_t sha1[SC_SHA1_LEN];
     SCSha256 *sha256_ctx;

--- a/src/util-ja3.c
+++ b/src/util-ja3.c
@@ -28,10 +28,6 @@
 #include "util-validate.h"
 #include "util-ja3.h"
 
-#ifdef HAVE_NSS
-#include <sechash.h>
-#endif
-
 #define MD5_STRING_LENGTH 33
 
 /**
@@ -220,8 +216,6 @@ int Ja3BufferAddValue(JA3Buffer **buffer, uint32_t value)
  */
 char *Ja3GenerateHash(JA3Buffer *buffer)
 {
-
-#ifdef HAVE_NSS
     if (buffer == NULL) {
         SCLogError(SC_ERR_INVALID_ARGUMENT, "Buffer should not be NULL");
         return NULL;
@@ -239,19 +233,15 @@ char *Ja3GenerateHash(JA3Buffer *buffer)
         return NULL;
     }
 
-    unsigned char md5[MD5_LENGTH];
-    HASH_HashBuf(HASH_AlgMD5, md5, (unsigned char *)buffer->data, buffer->used);
+    unsigned char md5[SC_MD5_LEN];
+    SCMd5HashBuffer((unsigned char *)buffer->data, buffer->used, md5, sizeof(md5));
 
     int i, x;
-    for (i = 0, x = 0; x < MD5_LENGTH; x++) {
+    for (i = 0, x = 0; x < SC_MD5_LEN; x++) {
         i += snprintf(ja3_hash + i, MD5_STRING_LENGTH - i, "%02x", md5[x]);
     }
 
     return ja3_hash;
-#else
-    return NULL;
-#endif /* HAVE_NSS */
-
 }
 
 /**
@@ -274,17 +264,6 @@ int Ja3IsDisabled(const char *type)
         }
         return 1;
     }
-
-#ifndef HAVE_NSS
-    else {
-        if (strcmp(type, "rule") != 0) {
-            SCLogWarning(SC_WARN_NO_JA3_SUPPORT,
-                    "no MD5 calculation support built in (LibNSS), skipping %s",
-                    type);
-        }
-        return 1;
-    }
-#endif /* HAVE_NSS */
 
     return 0;
 }

--- a/src/util-ja3.c
+++ b/src/util-ja3.c
@@ -28,6 +28,10 @@
 #include "util-validate.h"
 #include "util-ja3.h"
 
+#ifdef HAVE_NSS
+#include <sechash.h>
+#endif
+
 #define MD5_STRING_LENGTH 33
 
 /**


### PR DESCRIPTION
This is a draft to show how we can provide sha1/sha256/md5 support
with Rust. This support uses crates from the RustCrypto project
that provide pure Rust implementations for many hash algorithms.

Some simple testing with sha256 showed that it was about 10%
faster than libnss.

This PR only touches that filestore and related detect. But it
should be trivial update all sha1/sha256/md5 use to these functions.

I added the RustCrypto md5 crate as md5c as it conflicts with an
md5 crate we already use. My plan is to replace the one we already
use with the one from the RustCrypto project, as all hashes from
that project use the same Digest trait allowing us to reduce some
code.

Testing with a Suricata with no NSS support, all Suricata-Verify
filestore tests pass.

TODO:
- Suricata-Verify will need some tweaks as it will require NSS on 6.0
  and less. But many tests will no longer require NSS on 7.0+.
- Replace all md5/sha1/sha256 usage in C with these Rust functions.

Issues;
- The RustCrypto project has a MSRV (minimum support Rust version) of 1.41 at this time. They appear to test this, document it, and stick to their MSRV per minor version.

Update:
- Enable JA3 without NSS support.