### PR TITLE
Minor update in Quickstart

### DIFF
--- a/doc/userguide/quickstart.rst
+++ b/doc/userguide/quickstart.rst
@@ -129,8 +129,8 @@ can be triggered quite easy. Before we trigger it, start ``tail`` to see updates
 
 Rule trigger::
 
-    sudo tail -f /var/log/suricata/fast.log
     curl http://testmyids.com/
+    sudo tail -f /var/log/suricata/fast.log
 
 The following output should now be seen in the log::
 


### PR DESCRIPTION
The curl command to trigger the IDS should be executed before the tail command on the log, so that the logs can show the details of the attack as given in the next line.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [*] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [*] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [*] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- The curl command to trigger the IDS should be executed before the tail command on the log, so that the logs can show the details of the attack as given in the next line.
-
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
