### PR TITLE
ebpf: avoid need of 32 bit header

### DIFF
--- a/ebpf/xdp_lb.c
+++ b/ebpf/xdp_lb.c
@@ -23,6 +23,9 @@
 #include <linux/if_ether.h>
 #include <linux/if_packet.h>
 #include <linux/if_vlan.h>
+/* Workaround to avoid the need of 32bit headers */
+#define _LINUX_IF_H
+#define IFNAMSIZ 16
 #include <linux/if_tunnel.h>
 #include <linux/ip.h>
 #include <linux/ipv6.h>


### PR DESCRIPTION
Compilation of xdp_lb.c was failing in some case with the following
error:

/usr/include/x86_64-linux-gnu/gnu/stubs.h:7:11: fatal error: 'gnu/stubs-32.h' file not found

This patch add some define to be able to skip recursive inclusion of
header files leading to the problem.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Add some define to allow build without stubs-32.h