### PR TITLE
nbss: add parser tests

### DIFF
--- a/rust/src/smb/nbss_records.rs
+++ b/rust/src/smb/nbss_records.rs
@@ -87,3 +87,139 @@ named!(pub parse_nbss_record_partial<NbssRecord>,
             data:data,
         })
 ));
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_parse_nbss_record() {
+        let buff:&[u8] = &[
+        /* message type */ 0x00,
+        /* length */       0x00, 0x00, 0x55,
+        /* data */         0xff, 0x53, 0x4d, 0x42, 0x72, 0x00, 0x00, 0x00, 0x00,
+                           0x98, 0x53, 0xc8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff,
+                           0xfe, 0x00, 0x00, 0x00, 0x00, 0x11, 0x05, 0x00, 0x03,
+                           0x0a, 0x00, 0x01, 0x00, 0x04, 0x11, 0x00, 0x00, 0x00,
+                           0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xfd, 0xe3,
+                           0x00, 0x80, 0x2a, 0x55, 0xc4, 0x38, 0x89, 0x03, 0xcd,
+                           0x01, 0x2c, 0x01, 0x00, 0x10, 0x00, 0xfe, 0x82, 0xf1,
+                           0x64, 0x0b, 0x66, 0xba, 0x4a, 0xbb, 0x81, 0xe1, 0xea,
+                           0x54, 0xae, 0xb8, 0x66];
+
+        let result = parse_nbss_record(&buff);
+        match result {
+            Ok((remainder, p)) => {
+                assert_eq!(p.message_type, NBSS_MSGTYPE_SESSION_MESSAGE);
+                assert_eq!(p.length, 85);
+                assert_eq!(p.data.len(), 85);
+                assert_ne!(p.message_type, NBSS_MSGTYPE_KEEP_ALIVE);
+
+                // this packet had an acceptable length, we don't need more
+                assert_eq!(p.needs_more(), false);
+
+                // does this really look like smb?
+                assert_eq!(p.is_smb(), true);
+
+                // there should be nothing left
+                assert_eq!(remainder.len(), 0);
+            }
+            Err(nom::Err::Error((remainder, err))) => {
+                panic!("Result should not be an error: {:?}.", err);
+            }
+            Err(nom::Err::Incomplete(_)) => {
+                panic!("Result should not have been incomplete.");
+            }
+            _ => {
+                panic!("Unexpected behavior!");
+            }
+        }   
+
+        // Non-SMB packet scenario
+        let buff_not_smb:&[u8] = &[
+            /* message type */ 0x00,
+            /* length */       0x00, 0x00, 0x55,
+            /* data !SMB */    0xff, 0x52, 0x4e, 0x41, 0x72, 0x00, 0x00, 0x00, 0x00,
+                               0x98, 0x53, 0xc8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff,
+                               0xfe, 0x00, 0x00, 0x00, 0x00, 0x11, 0x05, 0x00, 0x03,
+                               0x0a, 0x00, 0x01, 0x00, 0x04, 0x11, 0x00, 0x00, 0x00,
+                               0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xfd, 0xe3,
+                               0x00, 0x80, 0x2a, 0x55, 0xc4, 0x38, 0x89, 0x03, 0xcd,
+                               0x01, 0x2c, 0x01, 0x00, 0x10, 0x00, 0xfe, 0x82, 0xf1,
+                               0x64, 0x0b, 0x66, 0xba, 0x4a, 0xbb, 0x81, 0xe1, 0xea,
+                               0x54, 0xae, 0xb8, 0x66];
+    
+        let result_not_smb = parse_nbss_record(&buff_not_smb);
+        match result_not_smb {
+            Ok((remainder, p_not_smb)) => {
+                assert_eq!(p_not_smb.message_type, NBSS_MSGTYPE_SESSION_MESSAGE);
+                assert_eq!(p_not_smb.length, 85);
+                assert_eq!(p_not_smb.data.len(), 85);
+                assert_ne!(p_not_smb.message_type, NBSS_MSGTYPE_KEEP_ALIVE);
+
+                // this packet had an acceptable length, we don't need more
+                assert_eq!(p_not_smb.needs_more(), false);
+
+                // this packet doesn't have the SMB keyword
+                // is_smb must be false
+                assert_eq!(p_not_smb.is_smb(), false);
+
+                // there should be nothing left
+                assert_eq!(remainder.len(), 0);
+            }
+            Err(nom::Err::Error((remainder, err))) => {
+                panic!("Result should not be an error: {:?}.", err);
+            }
+            Err(nom::Err::Incomplete(_)) => {
+                panic!("Result should not have been incomplete.");
+            }
+            _ => {
+                panic!("Unexpected behavior!");
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_nbss_record_partial() {
+        let buff:&[u8] = &[ 
+        /* message type */  0x00, 
+        /* length */        0x00, 0x00, 0x29,
+        /* data < lenght*/  0xff, 0x53, 0x4d, 0x42, 0x04, 0x00, 0x00, 0x00, 
+                            0x00, 0x18, 0x43, 0xc8, 0x00, 0x00, 0x00, 0x00,
+                            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+                            0x02, 0x08, 0xbd, 0x20, 0x02, 0x08, 0x06, 0x00,
+                            0x02, 0x40, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00];
+
+        let result = parse_nbss_record_partial(&buff);
+        match result {
+            Ok((remainder, p)) => {
+                assert_eq!(p.message_type, NBSS_MSGTYPE_SESSION_MESSAGE);
+                assert_eq!(p.length, 41);
+                assert_ne!(p.data.len(), 41);
+                assert_ne!(p.message_type, NBSS_MSGTYPE_KEEP_ALIVE);
+
+                // this packet had an acceptable length, we don't need more
+                assert_eq!(p.needs_more(), false);
+
+                // does this really look like smb?
+                assert_eq!(p.is_smb(), true);
+
+                // there should be nothing left
+                assert_eq!(remainder.len(), 0);
+            }
+            Err(nom::Err::Error((remainder, err))) => {
+                panic!("Result should not be an error: {:?}.", err);
+            }
+            Err(nom::Err::Incomplete(_)) => {
+                panic!("Result should not have returned as incomplete.");
+            }
+            _ => {
+                panic!("Unexpected behavior!");
+            }
+        }
+        
+    }
+}


### PR DESCRIPTION
Add tests to parse_nbss_record and parse_nbss_record_partial

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
- There isn't one

Link to previous PR:
- https://github.com/OISF/suricata/pull/5690

Describe changes:
- Add another test scenario where the packet doesn't have 'SMB' 
- Insert space after '//'
- Fix typos

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
