### PR TITLE
mime: postpone md5 calculation to parse complete - v1

### DIFF
--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -2094,13 +2094,6 @@ static int ProcessBodyComplete(MimeDecParseState *state)
         }
     }
 
-#ifdef HAVE_NSS
-    if (state->md5_ctx) {
-        unsigned int len = 0;
-        HASH_End(state->md5_ctx, state->md5, &len, sizeof(state->md5));
-    }
-#endif
-
     /* Invoke pre-processor and callback with remaining data */
     ret = ProcessDecodedDataChunk(state->data_chunk, state->data_chunk_len, state);
     if (ret != MIME_DEC_OK) {
@@ -2546,6 +2539,13 @@ int MimeDecParseComplete(MimeDecParseState *state)
         SCLogDebug("Error: ProcessBodyComplete() function failed");
         return ret;
     }
+
+#ifdef HAVE_NSS
+    if (state->md5_ctx) {
+        unsigned int len = 0;
+        HASH_End(state->md5_ctx, state->md5, &len, sizeof(state->md5));
+    }
+#endif
 
     if (state->stack->top == NULL) {
         state->msg->anomaly_flags |= ANOM_MALFORMED_MSG;


### PR DESCRIPTION
Instead of calculating the MD5 at the end of every part, only
compute it when parsing is complete.

With libnss, the hash never updates after the first HASH_End, so
the md5 of only the first part of the body is logged, rather than
the md5 of all the parts.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/4245

suricata-verify-pr: 391
