### PR TITLE
Adding missing deps to Debian recommended

### DIFF
--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -97,7 +97,7 @@ Recommended::
                     libnet1-dev libyaml-0-2 libyaml-dev pkg-config zlib1g zlib1g-dev \
                     libcap-ng-dev libcap-ng0 make libmagic-dev         \
                     libnss3-dev libgeoip-dev liblua5.1-dev libhiredis-dev libevent-dev \
-                    python-yaml rustc cargo
+                    python-yaml rustc cargo libjansson libjansson-dev
 
 Extra for iptables/nftables IPS integration::
 


### PR DESCRIPTION
Added missing `libjansson libjansson-dev` dependencies in the Debian recommended section. These were already listed for minimal.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [DW] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [DW] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [DW] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
