### PR TITLE
decode/tcp: Improved handling of TFO options

### DIFF
--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -154,11 +154,8 @@ static void DecodeTCPOptions(Packet *p, const uint8_t *pkt, uint16_t pktlen)
                     break;
                 case TCP_OPT_TFO:
                     SCLogDebug("TFO option, len %u", olen);
-                    if ((olen != 2) &&
-                           (olen < TCP_OPT_TFO_MIN_LEN ||
-                            olen > TCP_OPT_TFO_MAX_LEN ||
-                            !((olen - 2) % 8 == 0)))
-                    {
+                    if ((olen != 2) && (olen < TCP_OPT_TFO_MIN_LEN || olen > TCP_OPT_TFO_MAX_LEN ||
+                                               !(((olen - 2) & 0x1) == 0))) {
                         ENGINE_SET_EVENT(p,TCP_OPT_INVALID_LEN);
                     } else {
                         if (p->tcpvars.tfo.type != 0) {

--- a/src/decode-tcp.h
+++ b/src/decode-tcp.h
@@ -62,7 +62,7 @@
 #define TCP_OPT_SACK_MIN_LEN                 10 /* hdr 2, 1 pair 8 = 10 */
 #define TCP_OPT_SACK_MAX_LEN                 34 /* hdr 2, 4 pair 32= 34 */
 #define TCP_OPT_TFO_MIN_LEN                  6  /* kind, len, 6 */
-#define TCP_OPT_TFO_MAX_LEN                  20 /* kind, len, 18 */
+#define TCP_OPT_TFO_MAX_LEN                  18 /* kind, len, 18 */
 
 /** Max valid wscale value. */
 #define TCP_WSCALE_MAX                       14


### PR DESCRIPTION
Continuation of #5702 

This commit improves handling of TCP fast open options
- Option length must be in [6, 18]
- Option length must be an even value

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4238](https://redmine.openinfosecfoundation.org/issues/4238)

Describe changes:
- clang-format updates

suricata-verify-pr: 390
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
