### PR TITLE
Misc fixes 20210105

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -487,7 +487,7 @@
           [
             AS_IF([test "$CLANG" != no],
                   [
-                    llc_candidates=$($CLANG --version | \
+                    llc_candidates=$($CLANG --version | sed -e 's/.*clang version/clang version/' | \
                       awk '/^clang version/ {
                              split($3, v, ".");
                              printf("llc-%s.%s llc-%s llc", v[[1]], v[[2]], v[[1]])

--- a/doc/userguide/rules/datasets.rst
+++ b/doc/userguide/rules/datasets.rst
@@ -169,6 +169,15 @@ type
 data
   Data to remove in serialized form (base64 for string, hex notation for md5/sha256)
 
+dataset-dump
+~~~~~~~~~~~~
+
+Unix socket command to trigger a dump of datasets to disk.
+
+Syntax::
+
+    dataset-dump
+
 File formats
 ------------
 

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -744,6 +744,15 @@ TmEcode UnixSocketDatasetRemove(json_t *cmd, json_t* answer, void *data)
     }
 }
 
+TmEcode UnixSocketDatasetDump(json_t *cmd, json_t *answer, void *data)
+{
+    SCEnter();
+    SCLogDebug("Going to dump datasets");
+    DatasetsSave();
+    json_object_set_new(answer, "message", json_string("datasets dump done"));
+    SCReturnInt(TM_ECODE_OK);
+}
+
 /**
  * \brief Command to add a tenant handler
  *

--- a/src/runmode-unix-socket.h
+++ b/src/runmode-unix-socket.h
@@ -33,6 +33,7 @@ TmEcode UnixSocketPcapFile(TmEcode tm, struct timespec *last_processed);
 #ifdef BUILD_UNIX_SOCKET
 TmEcode UnixSocketDatasetAdd(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketDatasetRemove(json_t *cmd, json_t* answer, void *data);
+TmEcode UnixSocketDatasetDump(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketRegisterTenantHandler(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketUnregisterTenantHandler(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketRegisterTenant(json_t *cmd, json_t* answer, void *data);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -1083,6 +1083,7 @@ int UnixManagerInit(void)
 
     UnixManagerRegisterCommand("dataset-add", UnixSocketDatasetAdd, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("dataset-remove", UnixSocketDatasetRemove, &command, UNIX_CMD_TAKE_ARGS);
+    UnixManagerRegisterCommand("dataset-dump", UnixSocketDatasetDump, NULL, 0);
 
     return 0;
 }


### PR DESCRIPTION
This patchset fixes llc version detection on at least some recent Debian and add a dataset-dump command to unix socket.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- fix auto detection of llc version (ebpf)
- add a dataset-dump command to unix socket commands
