### PR TITLE
detect/asn1 Rewrite tests w/out test_case crate

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -41,5 +41,5 @@ tls-parser = "0.9"
 x509-parser = "0.6.5"
 libc = "0.2.67"
 
-[dev-dependencies]
-test-case = "1.0"
+#[dev-dependencies]
+#test-case = "1.0"


### PR DESCRIPTION
[Draft] This is a draft commit showing how usage of the test_case crate can be
removed from asn1.

Created to solicit feedback ... actual pr will be more than 1 commit with proper style.

Describe changes:
- Eliminate use of test_case crate
- Modify asn1 tests to use local macros instead.
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
