### PR TITLE
Http2 keywords 4067 v7

### DIFF
--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -540,6 +540,18 @@ pub unsafe extern "C" fn rs_http2_tx_get_useragent(
     return 0;
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn rs_http2_tx_get_status(
+    tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> u8 {
+    if let Ok(value) = http2_frames_get_header_value(&tx.frames_tc, ":status") {
+        *buffer = value.as_ptr(); //unsafe
+        *buffer_len = value.len() as u32;
+        return 1;
+    }
+    return 0;
+}
+
 fn http2_escape_header(hd: &parser::HTTP2FrameHeaders, i: u32) -> Vec<u8> {
     //minimum size + 2 for escapes
     let normalsize = hd.blocks[i as usize].value.len() + 2 + hd.blocks[i as usize].name.len() + 2;

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -528,6 +528,18 @@ pub unsafe extern "C" fn rs_http2_tx_get_uri(
     return 0;
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn rs_http2_tx_get_useragent(
+    tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> u8 {
+    if let Ok(value) = http2_frames_get_header_value(&tx.frames_ts, "user-agent") {
+        *buffer = value.as_ptr(); //unsafe
+        *buffer_len = value.len() as u32;
+        return 1;
+    }
+    return 0;
+}
+
 fn http2_escape_header(hd: &parser::HTTP2FrameHeaders, i: u32) -> Vec<u8> {
     //minimum size + 2 for escapes
     let normalsize = hd.blocks[i as usize].value.len() + 2 + hd.blocks[i as usize].name.len() + 2;

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -71,6 +71,9 @@ static int g_http_stat_msg_buffer_id = 0;
 static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms, Flow *_f,
         const uint8_t _flow_flags, void *txv, const int list_id);
+static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
+        const int list_id);
 static int DetectHttpStatMsgSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str);
 
 /**
@@ -103,6 +106,12 @@ void DetectHttpStatMsgRegister (void)
     DetectAppLayerMpmRegister2("http_stat_msg", SIG_FLAG_TOCLIENT, 3,
             PrefilterGenericMpmRegister, GetData, ALPROTO_HTTP,
             HTP_RESPONSE_LINE);
+
+    DetectAppLayerInspectEngineRegister2("http_stat_msg", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetData2);
+
+    DetectAppLayerMpmRegister2("http_stat_msg", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
+            GetData2, ALPROTO_HTTP2, HTTP2StateDataServer);
 
     DetectBufferTypeSetDescriptionByName("http_stat_msg",
             "http response status message");
@@ -164,6 +173,29 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(tx->response_message);
 
         InspectionBufferSetup(buffer, data, data_len);
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+
+    return buffer;
+}
+
+static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
+        const int list_id)
+{
+    SCEnter();
+
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        uint32_t b_len = 0;
+        const uint8_t *b = NULL;
+
+        if (rs_http2_tx_get_status(txv, &b, &b_len) != 1)
+            return NULL;
+        if (b == NULL || b_len == 0)
+            return NULL;
+
+        InspectionBufferSetup(buffer, b, b_len);
         InspectionBufferApplyTransforms(buffer, transforms);
     }
 

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -69,6 +69,9 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms,
         Flow *_f, const uint8_t _flow_flags,
         void *txv, const int list_id);
+static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
+        const int list_id);
 
 /**
  * \brief Registers the keyword handlers for the "http_user_agent" keyword.
@@ -176,6 +179,29 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(h->value);
 
         InspectionBufferSetup(buffer, data, data_len);
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+
+    return buffer;
+}
+
+static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
+        const int list_id)
+{
+    SCEnter();
+
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        uint32_t b_len = 0;
+        const uint8_t *b = NULL;
+
+        if (rs_http2_tx_get_useragent(txv, &b, &b_len) != 1)
+            return NULL;
+        if (b == NULL || b_len == 0)
+            return NULL;
+
+        InspectionBufferSetup(buffer, b, b_len);
         InspectionBufferApplyTransforms(buffer, transforms);
     }
 

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -103,6 +103,12 @@ void DetectHttpUARegister(void)
             PrefilterGenericMpmRegister, GetData, ALPROTO_HTTP,
             HTP_REQUEST_HEADERS);
 
+    DetectAppLayerInspectEngineRegister2("http_user_agent", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2StateDataClient, DetectEngineInspectBufferGeneric, GetData2);
+
+    DetectAppLayerMpmRegister2("http_user_agent", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
+            GetData2, ALPROTO_HTTP2, HTTP2StateDataClient);
+
     DetectBufferTypeSetDescriptionByName("http_user_agent",
             "http user agent");
 

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -68,6 +68,9 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms,
         Flow *_f, const uint8_t _flow_flags,
         void *txv, const int list_id);
+static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
+        const int list_id);
 static int DetectHttpUriSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str);
 static int DetectHttpRawUriSetup(DetectEngineCtx *, Signature *, const char *);
 static void DetectHttpRawUriSetupCallback(const DetectEngineCtx *de_ctx,
@@ -113,6 +116,12 @@ void DetectHttpUriRegister (void)
     DetectAppLayerMpmRegister2("http_uri", SIG_FLAG_TOSERVER, 2,
             PrefilterGenericMpmRegister, GetData, ALPROTO_HTTP,
             HTP_REQUEST_LINE);
+
+    DetectAppLayerInspectEngineRegister2("http_uri", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2StateDataClient, DetectEngineInspectBufferGeneric, GetData2);
+
+    DetectAppLayerMpmRegister2("http_uri", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
+            GetData2, ALPROTO_HTTP2, HTTP2StateDataClient);
 
     DetectBufferTypeSetDescriptionByName("http_uri",
             "http request uri");
@@ -229,6 +238,29 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(tx_ud->request_uri_normalized);
 
         InspectionBufferSetup(buffer, data, data_len);
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+
+    return buffer;
+}
+
+static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
+        const int list_id)
+{
+    SCEnter();
+
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        uint32_t b_len = 0;
+        const uint8_t *b = NULL;
+
+        if (rs_http2_tx_get_uri(txv, &b, &b_len) != 1)
+            return NULL;
+        if (b == NULL || b_len == 0)
+            return NULL;
+
+        InspectionBufferSetup(buffer, b, b_len);
         InspectionBufferApplyTransforms(buffer, transforms);
     }
 

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -157,6 +157,13 @@ void DetectHttpUriRegister (void)
             PrefilterGenericMpmRegister, GetRawData, ALPROTO_HTTP,
             HTP_REQUEST_LINE);
 
+    // no difference between raw and decoded uri for HTTP2
+    DetectAppLayerInspectEngineRegister2("http_raw_uri", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2StateDataClient, DetectEngineInspectBufferGeneric, GetData2);
+
+    DetectAppLayerMpmRegister2("http_raw_uri", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
+            GetData2, ALPROTO_HTTP2, HTTP2StateDataClient);
+
     DetectBufferTypeSetDescriptionByName("http_raw_uri",
             "raw http uri");
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1491,14 +1491,18 @@ int DetectSignatureSetAppProto(Signature *s, AppProto alproto)
         return -1;
     }
 
-    if (s->alproto != ALPROTO_UNKNOWN && s->alproto != alproto) {
+    if (s->alproto != ALPROTO_UNKNOWN && s->alproto != alproto &&
+        // allow to keep HTTP2 with HTTP1 keywords
+        !(s->alproto == ALPROTO_HTTP2 && alproto == ALPROTO_HTTP)) {
         SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS,
             "can't set rule app proto to %s: already set to %s",
             AppProtoToString(alproto), AppProtoToString(s->alproto));
         return -1;
     }
 
-    s->alproto = alproto;
+    if (!(s->alproto == ALPROTO_HTTP2 && alproto == ALPROTO_HTTP)) {
+        s->alproto = alproto;
+    }
     s->flags |= SIG_FLAG_APPLAYER;
     return 0;
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4067

Describe changes:
- Accepts HTTP1 keyword for HTTP2 signatures (hack to `DetectSignatureSetAppProto`)
- `http.uri` keyword now matches on HTTP2 traffic (as well as `http.uri.raw`)
- `http.user_agent` keyword now matches on HTTP2 traffic
- `http.stat_msg` keyword now matches on HTTP2 traffic

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

suricata-verify-pr: 384

Does _not_ make S-V test in https://github.com/OISF/suricata-verify/pull/384 pass because :
- `alert http1` is not valid for signatures
- Neither `alert http` nor  `alert tcp` not ` `alert ip` work for HTTP2 traffic


Modifies #5669 by 
- replacing signature protocol logic with hack to accept only `alert http2 any any -> any any (http.uri; content:"foo")`