### PR TITLE
detect/lua: Add utility functions with "SC" prefix

### DIFF
--- a/doc/userguide/lua/lua-functions.rst
+++ b/doc/userguide/lua/lua-functions.rst
@@ -879,39 +879,39 @@ index so in our case we need to use 0.
 ::
 
  function match(args)
-     a = ScFlowintGet(0);
+     a = SCFlowintGet(0);
      if a then
-         ScFlowintSet(0, a + 1)
+         SCFlowintSet(0, a + 1)
      else
-         ScFlowintSet(0, 1)
+         SCFlowintSet(0, 1)
      end 
 
-ScFlowintGet
+SCFlowintGet
 ~~~~~~~~~~~~
 
 Get the Flowint at index given by the parameter.
 
-ScFlowintSet
+SCFlowintSet
 ~~~~~~~~~~~~
 
 Set the Flowint at index given by the first parameter. The second parameter is the value.
 
-ScFlowintIncr
+SCFlowintIncr
 ~~~~~~~~~~~~~
 
 Increment Flowint at index given by the first parameter.
 
-ScFlowintDecr
+SCFlowintDecr
 ~~~~~~~~~~~~~
 
 Decrement Flowint at index given by the first parameter.
 
-ScFlowvarGet
+SCFlowvarGet
 ~~~~~~~~~~~~
 
 Get the Flowvar at index given by the parameter.
 
-ScFlowvarSet
+SCFlowvarSet
 ~~~~~~~~~~~~
 
 Set a Flowvar. First parameter is the index, second is the data
@@ -929,13 +929,13 @@ You can use it to set string
  end
  
  function match(args)
-     a = ScFlowvarGet(0);
+     a = SCFlowvarGet(0);
      if a then
          a = tostring(tonumber(a)+1)
-         ScFlowvarSet(0, a, #a)
+         SCFlowvarSet(0, a, #a)
      else
          a = tostring(1)
-         ScFlowvarSet(0, a, #a)
+         SCFlowvarSet(0, a, #a)
      end 
 
 Misc

--- a/src/detect-lua-extensions.c
+++ b/src/detect-lua-extensions.c
@@ -77,7 +77,7 @@
 static const char luaext_key_ld[] = "suricata:luadata";
 
 /* hack to please scan-build. Even though LuaCallbackError *always*
- * returns 2, scan-build doesn't accept it and and generates false
+ * returns 2, scan-build doesn't accept it and generates false
  * positives */
 #define LUA_ERROR(msg)                  \
     LuaCallbackError(luastate, (msg));  \

--- a/src/detect-lua-extensions.c
+++ b/src/detect-lua-extensions.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -516,20 +516,38 @@ int LuaRegisterExtensions(lua_State *lua_state)
     lua_pushcfunction(lua_state, LuaGetFlowvar);
     lua_setglobal(lua_state, "ScFlowvarGet");
 
+    lua_pushcfunction(lua_state, LuaGetFlowvar);
+    lua_setglobal(lua_state, "SCFlowvarGet");
+
     lua_pushcfunction(lua_state, LuaSetFlowvar);
     lua_setglobal(lua_state, "ScFlowvarSet");
+
+    lua_pushcfunction(lua_state, LuaSetFlowvar);
+    lua_setglobal(lua_state, "SCFlowvarSet");
 
     lua_pushcfunction(lua_state, LuaGetFlowint);
     lua_setglobal(lua_state, "ScFlowintGet");
 
+    lua_pushcfunction(lua_state, LuaGetFlowint);
+    lua_setglobal(lua_state, "SCFlowintGet");
+
     lua_pushcfunction(lua_state, LuaSetFlowint);
     lua_setglobal(lua_state, "ScFlowintSet");
+
+    lua_pushcfunction(lua_state, LuaSetFlowint);
+    lua_setglobal(lua_state, "SCFlowintSet");
 
     lua_pushcfunction(lua_state, LuaIncrFlowint);
     lua_setglobal(lua_state, "ScFlowintIncr");
 
+    lua_pushcfunction(lua_state, LuaIncrFlowint);
+    lua_setglobal(lua_state, "SCFlowintIncr");
+
     lua_pushcfunction(lua_state, LuaDecrFlowint);
     lua_setglobal(lua_state, "ScFlowintDecr");
+
+    lua_pushcfunction(lua_state, LuaDecrFlowint);
+    lua_setglobal(lua_state, "SCFlowintDecr");
 
     LuaRegisterFunctions(lua_state);
     LuaRegisterHttpFunctions(lua_state);

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -1313,45 +1313,203 @@ end:
     return result;
 }
 
+static int LuaMatchTest01a(void)
+{
+    const char script[] = "function init (args)\n"
+                          "   local needs = {}\n"
+                          "   needs[\"http.request_headers\"] = tostring(true)\n"
+                          "   needs[\"flowvar\"] = {\"cnt\"}\n"
+                          "   return needs\n"
+                          "end\n"
+                          "\n"
+                          "function match(args)\n"
+                          "   a = SCFlowvarGet(0)\n"
+                          "   if a then\n"
+                          "       a = tostring(tonumber(a)+1)\n"
+                          "       print (a)\n"
+                          "       SCFlowvarSet(0, a, #a)\n"
+                          "   else\n"
+                          "       a = tostring(1)\n"
+                          "       print (a)\n"
+                          "       SCFlowvarSet(0, a, #a)\n"
+                          "   end\n"
+                          "   \n"
+                          "   print (\"pre check: \" .. (a))\n"
+                          "   if tonumber(a) == 2 then\n"
+                          "       print \"match\"\n"
+                          "       return 1\n"
+                          "   end\n"
+                          "   return 0\n"
+                          "end\n"
+                          "return 0\n";
+    char sig[] = "alert http any any -> any any (flow:to_server; lua:unittest; sid:1;)";
+    int result = 0;
+    uint8_t httpbuf1[] = "POST / HTTP/1.1\r\n"
+                         "Host: www.emergingthreats.net\r\n\r\n";
+    uint8_t httpbuf2[] = "POST / HTTP/1.1\r\n"
+                         "Host: www.openinfosecfoundation.org\r\n\r\n";
+    uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
+    uint32_t httplen2 = sizeof(httpbuf2) - 1; /* minus the \0 */
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    Flow f;
+    Signature *s = NULL;
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx;
+
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    ut_script = script;
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+    f.alproto = ALPROTO_HTTP;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOSERVER;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
+
+    StreamTcpInitConfig(TRUE);
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL) {
+        goto end;
+    }
+    de_ctx->flags |= DE_QUIET;
+
+    s = DetectEngineAppendSig(de_ctx, sig);
+    if (s == NULL) {
+        printf("sig parse failed: ");
+        goto end;
+    }
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    FLOWLOCK_WRLOCK(&f);
+    int r = AppLayerParserParse(
+            NULL, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, httpbuf1, httplen1);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        FLOWLOCK_UNLOCK(&f);
+        goto end;
+    }
+    FLOWLOCK_UNLOCK(&f);
+    HtpState *http_state = f.alstate;
+    if (http_state == NULL) {
+        printf("no http state: ");
+        goto end;
+    }
+
+    /* do detect for p1 */
+    SCLogDebug("inspecting p1");
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    if ((PacketAlertCheck(p1, 1))) {
+        printf("sid 1 didn't match on p1 but should have: ");
+        goto end;
+    }
+
+    FLOWLOCK_WRLOCK(&f);
+    r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, httpbuf2, httplen2);
+    if (r != 0) {
+        printf("toserver chunk 2 returned %" PRId32 ", expected 0: ", r);
+        FLOWLOCK_UNLOCK(&f);
+        goto end;
+    }
+    FLOWLOCK_UNLOCK(&f);
+    /* do detect for p2 */
+    SCLogDebug("inspecting p2");
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    if (!(PacketAlertCheck(p2, 1))) {
+        printf("sid 1 didn't match on p2 but should have: ");
+        goto end;
+    }
+
+    FlowVar *fv = FlowVarGet(&f, 1);
+    if (fv == NULL) {
+        printf("no flowvar: ");
+        goto end;
+    }
+
+    if (fv->data.fv_str.value_len != 1) {
+        printf("%u != %u: ", fv->data.fv_str.value_len, 1);
+        goto end;
+    }
+
+    if (memcmp(fv->data.fv_str.value, "2", 1) != 0) {
+        PrintRawDataFp(stdout, fv->data.fv_str.value, fv->data.fv_str.value_len);
+
+        printf("buffer mismatch: ");
+        goto end;
+    }
+
+    result = 1;
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    return result;
+}
+
 /** \test payload buffer */
 static int LuaMatchTest02(void)
 {
-    const char script[] =
-        "function init (args)\n"
-        "   local needs = {}\n"
-        "   needs[\"payload\"] = tostring(true)\n"
-        "   needs[\"flowvar\"] = {\"cnt\"}\n"
-        "   return needs\n"
-        "end\n"
-        "\n"
-        "function match(args)\n"
-        "   a = ScFlowvarGet(0)\n"
-        "   if a then\n"
-        "       a = tostring(tonumber(a)+1)\n"
-        "       print (a)\n"
-        "       ScFlowvarSet(0, a, #a)\n"
-        "   else\n"
-        "       a = tostring(1)\n"
-        "       print (a)\n"
-        "       ScFlowvarSet(0, a, #a)\n"
-        "   end\n"
-        "   \n"
-        "   print (\"pre check: \" .. (a))\n"
-        "   if tonumber(a) == 2 then\n"
-        "       print \"match\"\n"
-        "       return 1\n"
-        "   end\n"
-        "   return 0\n"
-        "end\n"
-        "return 0\n";
+    const char script[] = "function init (args)\n"
+                          "   local needs = {}\n"
+                          "   needs[\"payload\"] = tostring(true)\n"
+                          "   needs[\"flowvar\"] = {\"cnt\"}\n"
+                          "   return needs\n"
+                          "end\n"
+                          "\n"
+                          "function match(args)\n"
+                          "   a = ScFlowvarGet(0)\n"
+                          "   if a then\n"
+                          "       a = tostring(tonumber(a)+1)\n"
+                          "       print (a)\n"
+                          "       ScFlowvarSet(0, a, #a)\n"
+                          "   else\n"
+                          "       a = tostring(1)\n"
+                          "       print (a)\n"
+                          "       ScFlowvarSet(0, a, #a)\n"
+                          "   end\n"
+                          "   \n"
+                          "   print (\"pre check: \" .. (a))\n"
+                          "   if tonumber(a) == 2 then\n"
+                          "       print \"match\"\n"
+                          "       return 1\n"
+                          "   end\n"
+                          "   return 0\n"
+                          "end\n"
+                          "return 0\n";
     char sig[] = "alert tcp any any -> any any (flow:to_server; lua:unittest; sid:1;)";
     int result = 0;
-    uint8_t httpbuf1[] =
-        "POST / HTTP/1.1\r\n"
-        "Host: www.emergingthreats.net\r\n\r\n";
-    uint8_t httpbuf2[] =
-        "POST / HTTP/1.1\r\n"
-        "Host: www.openinfosecfoundation.org\r\n\r\n";
+    uint8_t httpbuf1[] = "POST / HTTP/1.1\r\n"
+                         "Host: www.emergingthreats.net\r\n\r\n";
+    uint8_t httpbuf2[] = "POST / HTTP/1.1\r\n"
+                         "Host: www.openinfosecfoundation.org\r\n\r\n";
     uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
     uint32_t httplen2 = sizeof(httpbuf2) - 1; /* minus the \0 */
     TcpSession ssn;
@@ -1380,11 +1538,144 @@ static int LuaMatchTest02(void)
     p1->flow = &f;
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
-    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p2->flow = &f;
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
-    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
+
+    StreamTcpInitConfig(TRUE);
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL) {
+        goto end;
+    }
+    de_ctx->flags |= DE_QUIET;
+
+    s = DetectEngineAppendSig(de_ctx, sig);
+    if (s == NULL) {
+        printf("sig parse failed: ");
+        goto end;
+    }
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    /* do detect for p1 */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    if ((PacketAlertCheck(p1, 1))) {
+        printf("sid 1 didn't match on p1 but should have: ");
+        goto end;
+    }
+
+    /* do detect for p2 */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    if (!(PacketAlertCheck(p2, 1))) {
+        printf("sid 1 didn't match on p2 but should have: ");
+        goto end;
+    }
+
+    FlowVar *fv = FlowVarGet(&f, 1);
+    if (fv == NULL) {
+        printf("no flowvar: ");
+        goto end;
+    }
+
+    if (fv->data.fv_str.value_len != 1) {
+        printf("%u != %u: ", fv->data.fv_str.value_len, 1);
+        goto end;
+    }
+
+    if (memcmp(fv->data.fv_str.value, "2", 1) != 0) {
+        PrintRawDataFp(stdout, fv->data.fv_str.value, fv->data.fv_str.value_len);
+
+        printf("buffer mismatch: ");
+        goto end;
+    }
+
+    result = 1;
+end:
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    return result;
+}
+
+/** \test payload buffer */
+static int LuaMatchTest02a(void)
+{
+    const char script[] = "function init (args)\n"
+                          "   local needs = {}\n"
+                          "   needs[\"payload\"] = tostring(true)\n"
+                          "   needs[\"flowvar\"] = {\"cnt\"}\n"
+                          "   return needs\n"
+                          "end\n"
+                          "\n"
+                          "function match(args)\n"
+                          "   a = SCFlowvarGet(0)\n"
+                          "   if a then\n"
+                          "       a = tostring(tonumber(a)+1)\n"
+                          "       print (a)\n"
+                          "       SCFlowvarSet(0, a, #a)\n"
+                          "   else\n"
+                          "       a = tostring(1)\n"
+                          "       print (a)\n"
+                          "       SCFlowvarSet(0, a, #a)\n"
+                          "   end\n"
+                          "   \n"
+                          "   print (\"pre check: \" .. (a))\n"
+                          "   if tonumber(a) == 2 then\n"
+                          "       print \"match\"\n"
+                          "       return 1\n"
+                          "   end\n"
+                          "   return 0\n"
+                          "end\n"
+                          "return 0\n";
+    char sig[] = "alert tcp any any -> any any (flow:to_server; lua:unittest; sid:1;)";
+    int result = 0;
+    uint8_t httpbuf1[] = "POST / HTTP/1.1\r\n"
+                         "Host: www.emergingthreats.net\r\n\r\n";
+    uint8_t httpbuf2[] = "POST / HTTP/1.1\r\n"
+                         "Host: www.openinfosecfoundation.org\r\n\r\n";
+    uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
+    uint32_t httplen2 = sizeof(httpbuf2) - 1; /* minus the \0 */
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    Flow f;
+    Signature *s = NULL;
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx;
+
+    ut_script = script;
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(httpbuf1, httplen1, IPPROTO_TCP);
+    p2 = UTHBuildPacket(httpbuf2, httplen2, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+    f.alproto = ALPROTO_HTTP;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOSERVER;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
 
     StreamTcpInitConfig(TRUE);
 
@@ -1452,42 +1743,39 @@ end:
 /** \test packet buffer */
 static int LuaMatchTest03(void)
 {
-    const char script[] =
-        "function init (args)\n"
-        "   local needs = {}\n"
-        "   needs[\"packet\"] = tostring(true)\n"
-        "   needs[\"flowvar\"] = {\"cnt\"}\n"
-        "   return needs\n"
-        "end\n"
-        "\n"
-        "function match(args)\n"
-        "   a = ScFlowvarGet(0)\n"
-        "   if a then\n"
-        "       a = tostring(tonumber(a)+1)\n"
-        "       print (a)\n"
-        "       ScFlowvarSet(0, a, #a)\n"
-        "   else\n"
-        "       a = tostring(1)\n"
-        "       print (a)\n"
-        "       ScFlowvarSet(0, a, #a)\n"
-        "   end\n"
-        "   \n"
-        "   print (\"pre check: \" .. (a))\n"
-        "   if tonumber(a) == 2 then\n"
-        "       print \"match\"\n"
-        "       return 1\n"
-        "   end\n"
-        "   return 0\n"
-        "end\n"
-        "return 0\n";
+    const char script[] = "function init (args)\n"
+                          "   local needs = {}\n"
+                          "   needs[\"packet\"] = tostring(true)\n"
+                          "   needs[\"flowvar\"] = {\"cnt\"}\n"
+                          "   return needs\n"
+                          "end\n"
+                          "\n"
+                          "function match(args)\n"
+                          "   a = ScFlowvarGet(0)\n"
+                          "   if a then\n"
+                          "       a = tostring(tonumber(a)+1)\n"
+                          "       print (a)\n"
+                          "       ScFlowvarSet(0, a, #a)\n"
+                          "   else\n"
+                          "       a = tostring(1)\n"
+                          "       print (a)\n"
+                          "       ScFlowvarSet(0, a, #a)\n"
+                          "   end\n"
+                          "   \n"
+                          "   print (\"pre check: \" .. (a))\n"
+                          "   if tonumber(a) == 2 then\n"
+                          "       print \"match\"\n"
+                          "       return 1\n"
+                          "   end\n"
+                          "   return 0\n"
+                          "end\n"
+                          "return 0\n";
     char sig[] = "alert tcp any any -> any any (flow:to_server; lua:unittest; sid:1;)";
     int result = 0;
-    uint8_t httpbuf1[] =
-        "POST / HTTP/1.1\r\n"
-        "Host: www.emergingthreats.net\r\n\r\n";
-    uint8_t httpbuf2[] =
-        "POST / HTTP/1.1\r\n"
-        "Host: www.openinfosecfoundation.org\r\n\r\n";
+    uint8_t httpbuf1[] = "POST / HTTP/1.1\r\n"
+                         "Host: www.emergingthreats.net\r\n\r\n";
+    uint8_t httpbuf2[] = "POST / HTTP/1.1\r\n"
+                         "Host: www.openinfosecfoundation.org\r\n\r\n";
     uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
     uint32_t httplen2 = sizeof(httpbuf2) - 1; /* minus the \0 */
     TcpSession ssn;
@@ -1516,11 +1804,144 @@ static int LuaMatchTest03(void)
     p1->flow = &f;
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
-    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p2->flow = &f;
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
-    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
+
+    StreamTcpInitConfig(TRUE);
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL) {
+        goto end;
+    }
+    de_ctx->flags |= DE_QUIET;
+
+    s = DetectEngineAppendSig(de_ctx, sig);
+    if (s == NULL) {
+        printf("sig parse failed: ");
+        goto end;
+    }
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    /* do detect for p1 */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    if ((PacketAlertCheck(p1, 1))) {
+        printf("sid 1 didn't match on p1 but should have: ");
+        goto end;
+    }
+
+    /* do detect for p2 */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    if (!(PacketAlertCheck(p2, 1))) {
+        printf("sid 1 didn't match on p2 but should have: ");
+        goto end;
+    }
+
+    FlowVar *fv = FlowVarGet(&f, 1);
+    if (fv == NULL) {
+        printf("no flowvar: ");
+        goto end;
+    }
+
+    if (fv->data.fv_str.value_len != 1) {
+        printf("%u != %u: ", fv->data.fv_str.value_len, 1);
+        goto end;
+    }
+
+    if (memcmp(fv->data.fv_str.value, "2", 1) != 0) {
+        PrintRawDataFp(stdout, fv->data.fv_str.value, fv->data.fv_str.value_len);
+
+        printf("buffer mismatch: ");
+        goto end;
+    }
+
+    result = 1;
+end:
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    return result;
+}
+
+/** \test packet buffer */
+static int LuaMatchTest03a(void)
+{
+    const char script[] = "function init (args)\n"
+                          "   local needs = {}\n"
+                          "   needs[\"packet\"] = tostring(true)\n"
+                          "   needs[\"flowvar\"] = {\"cnt\"}\n"
+                          "   return needs\n"
+                          "end\n"
+                          "\n"
+                          "function match(args)\n"
+                          "   a = SCFlowvarGet(0)\n"
+                          "   if a then\n"
+                          "       a = tostring(tonumber(a)+1)\n"
+                          "       print (a)\n"
+                          "       SCFlowvarSet(0, a, #a)\n"
+                          "   else\n"
+                          "       a = tostring(1)\n"
+                          "       print (a)\n"
+                          "       SCFlowvarSet(0, a, #a)\n"
+                          "   end\n"
+                          "   \n"
+                          "   print (\"pre check: \" .. (a))\n"
+                          "   if tonumber(a) == 2 then\n"
+                          "       print \"match\"\n"
+                          "       return 1\n"
+                          "   end\n"
+                          "   return 0\n"
+                          "end\n"
+                          "return 0\n";
+    char sig[] = "alert tcp any any -> any any (flow:to_server; lua:unittest; sid:1;)";
+    int result = 0;
+    uint8_t httpbuf1[] = "POST / HTTP/1.1\r\n"
+                         "Host: www.emergingthreats.net\r\n\r\n";
+    uint8_t httpbuf2[] = "POST / HTTP/1.1\r\n"
+                         "Host: www.openinfosecfoundation.org\r\n\r\n";
+    uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
+    uint32_t httplen2 = sizeof(httpbuf2) - 1; /* minus the \0 */
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    Flow f;
+    Signature *s = NULL;
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx;
+
+    ut_script = script;
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(httpbuf1, httplen1, IPPROTO_TCP);
+    p2 = UTHBuildPacket(httpbuf2, httplen2, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+    f.alproto = ALPROTO_HTTP;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOSERVER;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
 
     StreamTcpInitConfig(TRUE);
 
@@ -1588,31 +2009,183 @@ end:
 /** \test http buffer, flowints */
 static int LuaMatchTest04(void)
 {
-    const char script[] =
-        "function init (args)\n"
-        "   local needs = {}\n"
-        "   needs[\"http.request_headers\"] = tostring(true)\n"
-        "   needs[\"flowint\"] = {\"cnt\"}\n"
-        "   return needs\n"
-        "end\n"
-        "\n"
-        "function match(args)\n"
-        "   print \"inspecting\""
-        "   a = ScFlowintGet(0)\n"
-        "   if a then\n"
-        "       ScFlowintSet(0, a + 1)\n"
-        "   else\n"
-        "       ScFlowintSet(0, 1)\n"
-        "   end\n"
-        "   \n"
-        "   a = ScFlowintGet(0)\n"
-        "   if a == 2 then\n"
-        "       print \"match\"\n"
-        "       return 1\n"
-        "   end\n"
-        "   return 0\n"
-        "end\n"
-        "return 0\n";
+    const char script[] = "function init (args)\n"
+                          "   local needs = {}\n"
+                          "   needs[\"http.request_headers\"] = tostring(true)\n"
+                          "   needs[\"flowint\"] = {\"cnt\"}\n"
+                          "   return needs\n"
+                          "end\n"
+                          "\n"
+                          "function match(args)\n"
+                          "   print \"inspecting\""
+                          "   a = ScFlowintGet(0)\n"
+                          "   if a then\n"
+                          "       ScFlowintSet(0, a + 1)\n"
+                          "   else\n"
+                          "       ScFlowintSet(0, 1)\n"
+                          "   end\n"
+                          "   \n"
+                          "   a = ScFlowintGet(0)\n"
+                          "   if a == 2 then\n"
+                          "       print \"match\"\n"
+                          "       return 1\n"
+                          "   end\n"
+                          "   return 0\n"
+                          "end\n"
+                          "return 0\n";
+    char sig[] = "alert http any any -> any any (flow:to_server; lua:unittest; sid:1;)";
+    int result = 0;
+    uint8_t httpbuf1[] = "POST / HTTP/1.1\r\n"
+                         "Host: www.emergingthreats.net\r\n\r\n";
+    uint8_t httpbuf2[] = "POST / HTTP/1.1\r\n"
+                         "Host: www.openinfosecfoundation.org\r\n\r\n";
+    uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
+    uint32_t httplen2 = sizeof(httpbuf2) - 1; /* minus the \0 */
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    Flow f;
+    Signature *s = NULL;
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx;
+
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    ut_script = script;
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+    f.alproto = ALPROTO_HTTP;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
+
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOSERVER;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
+
+    StreamTcpInitConfig(TRUE);
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL) {
+        goto end;
+    }
+    de_ctx->flags |= DE_QUIET;
+
+    s = DetectEngineAppendSig(de_ctx, sig);
+    if (s == NULL) {
+        printf("sig parse failed: ");
+        goto end;
+    }
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    FLOWLOCK_WRLOCK(&f);
+    int r = AppLayerParserParse(
+            NULL, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, httpbuf1, httplen1);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        FLOWLOCK_UNLOCK(&f);
+        goto end;
+    }
+    FLOWLOCK_UNLOCK(&f);
+    HtpState *http_state = f.alstate;
+    if (http_state == NULL) {
+        printf("no http state: ");
+        goto end;
+    }
+
+    /* do detect for p1 */
+    SCLogInfo("p1");
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    if (PacketAlertCheck(p1, 1)) {
+        printf("sid 1 matched on p1 but should not have: ");
+        goto end;
+    }
+
+    FLOWLOCK_WRLOCK(&f);
+    r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, httpbuf2, httplen2);
+    if (r != 0) {
+        printf("toserver chunk 2 returned %" PRId32 ", expected 0: ", r);
+        FLOWLOCK_UNLOCK(&f);
+        goto end;
+    }
+    FLOWLOCK_UNLOCK(&f);
+    /* do detect for p2 */
+    SCLogInfo("p2");
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    if (!(PacketAlertCheck(p2, 1))) {
+        printf("sid 1 didn't match on p2 but should have: ");
+        goto end;
+    }
+
+    FlowVar *fv = FlowVarGet(&f, 1);
+    if (fv == NULL) {
+        printf("no flowvar: ");
+        goto end;
+    }
+
+    if (fv->data.fv_int.value != 2) {
+        printf("%u != %u: ", fv->data.fv_int.value, 2);
+        goto end;
+    }
+
+    result = 1;
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    return result;
+}
+
+/** \test http buffer, flowints */
+static int LuaMatchTest04a(void)
+{
+    const char script[] = "function init (args)\n"
+                          "   local needs = {}\n"
+                          "   needs[\"http.request_headers\"] = tostring(true)\n"
+                          "   needs[\"flowint\"] = {\"cnt\"}\n"
+                          "   return needs\n"
+                          "end\n"
+                          "\n"
+                          "function match(args)\n"
+                          "   print \"inspecting\""
+                          "   a = SCFlowintGet(0)\n"
+                          "   if a then\n"
+                          "       SCFlowintSet(0, a + 1)\n"
+                          "   else\n"
+                          "       SCFlowintSet(0, 1)\n"
+                          "   end\n"
+                          "   \n"
+                          "   a = SCFlowintGet(0)\n"
+                          "   if a == 2 then\n"
+                          "       print \"match\"\n"
+                          "       return 1\n"
+                          "   end\n"
+                          "   return 0\n"
+                          "end\n"
+                          "return 0\n";
     char sig[] = "alert http any any -> any any (flow:to_server; lua:unittest; sid:1;)";
     int result = 0;
     uint8_t httpbuf1[] =
@@ -1676,8 +2249,8 @@ static int LuaMatchTest04(void)
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
     FLOWLOCK_WRLOCK(&f);
-    int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
-                                STREAM_TOSERVER, httpbuf1, httplen1);
+    int r = AppLayerParserParse(
+            NULL, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, httpbuf1, httplen1);
     if (r != 0) {
         printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
         FLOWLOCK_UNLOCK(&f);
@@ -1700,8 +2273,7 @@ static int LuaMatchTest04(void)
     }
 
     FLOWLOCK_WRLOCK(&f);
-    r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
-                            STREAM_TOSERVER, httpbuf2, httplen2);
+    r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, httpbuf2, httplen2);
     if (r != 0) {
         printf("toserver chunk 2 returned %" PRId32 ", expected 0: ", r);
         FLOWLOCK_UNLOCK(&f);
@@ -1745,24 +2317,171 @@ end:
 /** \test http buffer, flowints */
 static int LuaMatchTest05(void)
 {
-    const char script[] =
-        "function init (args)\n"
-        "   local needs = {}\n"
-        "   needs[\"http.request_headers\"] = tostring(true)\n"
-        "   needs[\"flowint\"] = {\"cnt\"}\n"
-        "   return needs\n"
-        "end\n"
-        "\n"
-        "function match(args)\n"
-        "   print \"inspecting\""
-        "   a = ScFlowintIncr(0)\n"
-        "   if a == 2 then\n"
-        "       print \"match\"\n"
-        "       return 1\n"
-        "   end\n"
-        "   return 0\n"
-        "end\n"
-        "return 0\n";
+    const char script[] = "function init (args)\n"
+                          "   local needs = {}\n"
+                          "   needs[\"http.request_headers\"] = tostring(true)\n"
+                          "   needs[\"flowint\"] = {\"cnt\"}\n"
+                          "   return needs\n"
+                          "end\n"
+                          "\n"
+                          "function match(args)\n"
+                          "   print \"inspecting\""
+                          "   a = ScFlowintIncr(0)\n"
+                          "   if a == 2 then\n"
+                          "       print \"match\"\n"
+                          "       return 1\n"
+                          "   end\n"
+                          "   return 0\n"
+                          "end\n"
+                          "return 0\n";
+    char sig[] = "alert http any any -> any any (flow:to_server; lua:unittest; sid:1;)";
+    int result = 0;
+    uint8_t httpbuf1[] =
+        "POST / HTTP/1.1\r\n"
+        "Host: www.emergingthreats.net\r\n\r\n";
+    uint8_t httpbuf2[] =
+        "POST / HTTP/1.1\r\n"
+        "Host: www.openinfosecfoundation.org\r\n\r\n";
+    uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
+    uint32_t httplen2 = sizeof(httpbuf2) - 1; /* minus the \0 */
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    Flow f;
+    Signature *s = NULL;
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx;
+
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    ut_script = script;
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+    f.alproto = ALPROTO_HTTP;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOSERVER;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+
+    StreamTcpInitConfig(TRUE);
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL) {
+        goto end;
+    }
+    de_ctx->flags |= DE_QUIET;
+
+    s = DetectEngineAppendSig(de_ctx, sig);
+    if (s == NULL) {
+        printf("sig parse failed: ");
+        goto end;
+    }
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    FLOWLOCK_WRLOCK(&f);
+    int r = AppLayerParserParse(
+            NULL, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, httpbuf1, httplen1);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        FLOWLOCK_UNLOCK(&f);
+        goto end;
+    }
+    FLOWLOCK_UNLOCK(&f);
+    HtpState *http_state = f.alstate;
+    if (http_state == NULL) {
+        printf("no http state: ");
+        goto end;
+    }
+
+    /* do detect for p1 */
+    SCLogInfo("p1");
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    if (PacketAlertCheck(p1, 1)) {
+        printf("sid 1 matched on p1 but should not have: ");
+        goto end;
+    }
+
+    FLOWLOCK_WRLOCK(&f);
+    r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, httpbuf2, httplen2);
+    if (r != 0) {
+        printf("toserver chunk 2 returned %" PRId32 ", expected 0: ", r);
+        FLOWLOCK_UNLOCK(&f);
+        goto end;
+    }
+    FLOWLOCK_UNLOCK(&f);
+    /* do detect for p2 */
+    SCLogInfo("p2");
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    if (!(PacketAlertCheck(p2, 1))) {
+        printf("sid 1 didn't match on p2 but should have: ");
+        goto end;
+    }
+
+    FlowVar *fv = FlowVarGet(&f, 1);
+    if (fv == NULL) {
+        printf("no flowvar: ");
+        goto end;
+    }
+
+    if (fv->data.fv_int.value != 2) {
+        printf("%u != %u: ", fv->data.fv_int.value, 2);
+        goto end;
+    }
+
+    result = 1;
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    return result;
+}
+
+/** \test http buffer, flowints */
+static int LuaMatchTest05a(void)
+{
+    const char script[] = "function init (args)\n"
+                          "   local needs = {}\n"
+                          "   needs[\"http.request_headers\"] = tostring(true)\n"
+                          "   needs[\"flowint\"] = {\"cnt\"}\n"
+                          "   return needs\n"
+                          "end\n"
+                          "\n"
+                          "function match(args)\n"
+                          "   print \"inspecting\""
+                          "   a = SCFlowintIncr(0)\n"
+                          "   if a == 2 then\n"
+                          "       print \"match\"\n"
+                          "       return 1\n"
+                          "   end\n"
+                          "   return 0\n"
+                          "end\n"
+                          "return 0\n";
     char sig[] = "alert http any any -> any any (flow:to_server; lua:unittest; sid:1;)";
     int result = 0;
     uint8_t httpbuf1[] =
@@ -1895,29 +2614,182 @@ end:
 /** \test http buffer, flowints */
 static int LuaMatchTest06(void)
 {
-    const char script[] =
-        "function init (args)\n"
-        "   local needs = {}\n"
-        "   needs[\"http.request_headers\"] = tostring(true)\n"
-        "   needs[\"flowint\"] = {\"cnt\"}\n"
-        "   return needs\n"
-        "end\n"
-        "\n"
-        "function match(args)\n"
-        "   print \"inspecting\""
-        "   a = ScFlowintGet(0)\n"
-        "   if a == nil then\n"
-        "       print \"new var set to 2\""
-        "       ScFlowintSet(0, 2)\n"
-        "   end\n"
-        "   a = ScFlowintDecr(0)\n"
-        "   if a == 0 then\n"
-        "       print \"match\"\n"
-        "       return 1\n"
-        "   end\n"
-        "   return 0\n"
-        "end\n"
-        "return 0\n";
+    const char script[] = "function init (args)\n"
+                          "   local needs = {}\n"
+                          "   needs[\"http.request_headers\"] = tostring(true)\n"
+                          "   needs[\"flowint\"] = {\"cnt\"}\n"
+                          "   return needs\n"
+                          "end\n"
+                          "\n"
+                          "function match(args)\n"
+                          "   print \"inspecting\""
+                          "   a = ScFlowintGet(0)\n"
+                          "   if a == nil then\n"
+                          "       print \"new var set to 2\""
+                          "       ScFlowintSet(0, 2)\n"
+                          "   end\n"
+                          "   a = ScFlowintDecr(0)\n"
+                          "   if a == 0 then\n"
+                          "       print \"match\"\n"
+                          "       return 1\n"
+                          "   end\n"
+                          "   return 0\n"
+                          "end\n"
+                          "return 0\n";
+    char sig[] = "alert http any any -> any any (flow:to_server; lua:unittest; sid:1;)";
+    int result = 0;
+    uint8_t httpbuf1[] =
+        "POST / HTTP/1.1\r\n"
+        "Host: www.emergingthreats.net\r\n\r\n";
+    uint8_t httpbuf2[] =
+        "POST / HTTP/1.1\r\n"
+        "Host: www.openinfosecfoundation.org\r\n\r\n";
+    uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
+    uint32_t httplen2 = sizeof(httpbuf2) - 1; /* minus the \0 */
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    Flow f;
+    Signature *s = NULL;
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx;
+
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    ut_script = script;
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+    f.alproto = ALPROTO_HTTP;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOSERVER;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+
+    StreamTcpInitConfig(TRUE);
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL) {
+        goto end;
+    }
+    de_ctx->flags |= DE_QUIET;
+
+    s = DetectEngineAppendSig(de_ctx, sig);
+    if (s == NULL) {
+        printf("sig parse failed: ");
+        goto end;
+    }
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    FLOWLOCK_WRLOCK(&f);
+    int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
+                                STREAM_TOSERVER, httpbuf1, httplen1);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        FLOWLOCK_UNLOCK(&f);
+        goto end;
+    }
+    FLOWLOCK_UNLOCK(&f);
+    HtpState *http_state = f.alstate;
+    if (http_state == NULL) {
+        printf("no http state: ");
+        goto end;
+    }
+
+    /* do detect for p1 */
+    SCLogInfo("p1");
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    if (PacketAlertCheck(p1, 1)) {
+        printf("sid 1 matched on p1 but should not have: ");
+        goto end;
+    }
+
+    FLOWLOCK_WRLOCK(&f);
+    r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
+                            STREAM_TOSERVER, httpbuf2, httplen2);
+    if (r != 0) {
+        printf("toserver chunk 2 returned %" PRId32 ", expected 0: ", r);
+        FLOWLOCK_UNLOCK(&f);
+        goto end;
+    }
+    FLOWLOCK_UNLOCK(&f);
+    /* do detect for p2 */
+    SCLogInfo("p2");
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    if (!(PacketAlertCheck(p2, 1))) {
+        printf("sid 1 didn't match on p2 but should have: ");
+        goto end;
+    }
+
+    FlowVar *fv = FlowVarGet(&f, 1);
+    if (fv == NULL) {
+        printf("no flowvar: ");
+        goto end;
+    }
+
+    if (fv->data.fv_int.value != 0) {
+        printf("%u != %u: ", fv->data.fv_int.value, 0);
+        goto end;
+    }
+
+    result = 1;
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    return result;
+}
+
+/** \test http buffer, flowints */
+static int LuaMatchTest06a(void)
+{
+    const char script[] = "function init (args)\n"
+                          "   local needs = {}\n"
+                          "   needs[\"http.request_headers\"] = tostring(true)\n"
+                          "   needs[\"flowint\"] = {\"cnt\"}\n"
+                          "   return needs\n"
+                          "end\n"
+                          "\n"
+                          "function match(args)\n"
+                          "   print \"inspecting\""
+                          "   a = SCFlowintGet(0)\n"
+                          "   if a == nil then\n"
+                          "       print \"new var set to 2\""
+                          "       SCFlowintSet(0, 2)\n"
+                          "   end\n"
+                          "   a = SCFlowintDecr(0)\n"
+                          "   if a == 0 then\n"
+                          "       print \"match\"\n"
+                          "       return 1\n"
+                          "   end\n"
+                          "   return 0\n"
+                          "end\n"
+                          "return 0\n";
     char sig[] = "alert http any any -> any any (flow:to_server; lua:unittest; sid:1;)";
     int result = 0;
     uint8_t httpbuf1[] =
@@ -2050,11 +2922,17 @@ end:
 void DetectLuaRegisterTests(void)
 {
     UtRegisterTest("LuaMatchTest01", LuaMatchTest01);
+    UtRegisterTest("LuaMatchTest01a", LuaMatchTest01a);
     UtRegisterTest("LuaMatchTest02", LuaMatchTest02);
+    UtRegisterTest("LuaMatchTest02a", LuaMatchTest02a);
     UtRegisterTest("LuaMatchTest03", LuaMatchTest03);
+    UtRegisterTest("LuaMatchTest03a", LuaMatchTest03a);
     UtRegisterTest("LuaMatchTest04", LuaMatchTest04);
+    UtRegisterTest("LuaMatchTest04a", LuaMatchTest04a);
     UtRegisterTest("LuaMatchTest05", LuaMatchTest05);
+    UtRegisterTest("LuaMatchTest05a", LuaMatchTest05a);
     UtRegisterTest("LuaMatchTest06", LuaMatchTest06);
+    UtRegisterTest("LuaMatchTest06a", LuaMatchTest06a);
 }
 #endif
 #endif /* HAVE_LUAJIT */


### PR DESCRIPTION
This MR adds functions available to Lua with "SC" casing for the 6 functions currently prefixed with "Sc". The latter API functions are retained for compatibility; the documentation only describes the API functions using "SC".

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4253](https://redmine.openinfosecfoundation.org/issues/4253)

Describe changes:
- Add API interfaces with "SC" prefix for the 6 functions available to Lua that use "SC"
- Update documentation with new API casing
- Add test cases using new API casing

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
