### PR TITLE
dataset: fix dataset string lookup

### DIFF
--- a/src/datasets.c
+++ b/src/datasets.c
@@ -832,7 +832,7 @@ static int DatasetLookupString(Dataset *set, const uint8_t *data, const uint32_t
     StringType lookup = { .ptr = (uint8_t *)data, .len = data_len, .rep.value = 0 };
     THashData *rdata = THashLookupFromHash(set->hash, &lookup);
     if (rdata) {
-        THashDataUnlock(rdata);
+        DatasetUnlockData(rdata);
         return 1;
     }
     return 0;


### PR DESCRIPTION
The data was unlocked but the use_cnt was not decreased resulting
in the data entry not being removable.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4271

Describe changes:
- Fix the DatasetLookupString function.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
