### PR TITLE
Additional dataset operation

### DIFF
--- a/doc/userguide/rules/datasets.rst
+++ b/doc/userguide/rules/datasets.rst
@@ -169,6 +169,15 @@ type
 data
   Data to remove in serialized form (base64 for string, hex notation for md5/sha256)
 
+dataset-dump
+~~~~~~~~~~~~
+
+Unix socket command to trigger a dump of datasets to disk.
+
+Syntax::
+
+    dataset-dump
+
 File formats
 ------------
 

--- a/doc/userguide/rules/datasets.rst
+++ b/doc/userguide/rules/datasets.rst
@@ -184,6 +184,26 @@ set name
 type
   Data type: string, md5, sha256
 
+dataset-exist
+~~~~~~~~~~~~~
+
+Unix Socket command to test if data is in a set. 
+
+Syntax::
+
+    dataset-exist <set name> <set type> <data>
+
+set name
+  Name of an already defined dataset
+type
+  Data type: string, md5, sha256
+data
+  Data to test in serialized form (base64 for string, hex notation for md5/sha256)
+
+Example testing if 'google.com' is in the set 'myset'::
+
+    dataset-exist myset string Z29vZ2xlLmNvbQ==
+
 dataset-dump
 ~~~~~~~~~~~~
 

--- a/doc/userguide/rules/datasets.rst
+++ b/doc/userguide/rules/datasets.rst
@@ -169,6 +169,21 @@ type
 data
   Data to remove in serialized form (base64 for string, hex notation for md5/sha256)
 
+dataset-remove
+~~~~~~~~~~~~~~
+
+Unix Socket command to remove all data from a set. On success, the removal becomes
+active instantly.
+
+Syntax::
+
+    dataset-clear <set name> <set type>
+
+set name
+  Name of an already defined dataset
+type
+  Data type: string, md5, sha256
+
 dataset-dump
 ~~~~~~~~~~~~
 

--- a/python/suricata/sc/specs.py
+++ b/python/suricata/sc/specs.py
@@ -194,4 +194,14 @@ argsd = {
             "required": 1,
         },
     ],
+    "dataset-clear": [
+        {
+            "name": "setname",
+            "required": 1,
+        },
+        {
+            "name": "settype",
+            "required": 1,
+        }
+    ],
     }

--- a/python/suricata/sc/specs.py
+++ b/python/suricata/sc/specs.py
@@ -204,4 +204,18 @@ argsd = {
             "required": 1,
         }
     ],
+    "dataset-exist": [
+        {
+            "name": "setname",
+            "required": 1,
+        },
+        {
+            "name": "settype",
+            "required": 1,
+        },
+        {
+            "name": "datavalue",
+            "required": 1,
+        },
+    ],
     }

--- a/python/suricata/sc/suricatasc.py
+++ b/python/suricata/sc/suricatasc.py
@@ -107,6 +107,7 @@ class SuricataSC:
                 "memcap-show",
                 "dataset-add",
                 "dataset-remove",
+                "dataset-clear",
                 ]
         self.cmd_list = self.basic_commands + self.fn_commands
         self.sck_path = sck_path

--- a/python/suricata/sc/suricatasc.py
+++ b/python/suricata/sc/suricatasc.py
@@ -108,6 +108,7 @@ class SuricataSC:
                 "dataset-add",
                 "dataset-remove",
                 "dataset-clear",
+                "dataset-exist",
                 ]
         self.cmd_list = self.basic_commands + self.fn_commands
         self.sck_path = sck_path

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -1175,6 +1175,48 @@ int DatasetAddSerialized(Dataset *set, const char *string)
     return -1;
 }
 
+/** \brief add serialized data to set
+ *  \retval int 1 added
+ *  \retval int 0 already in hash
+ *  \retval int -1 API error (not added)
+ *  \retval int -2 DATA error
+ */
+int DatasetLookupSerialized(Dataset *set, const char *string)
+{
+    if (set == NULL)
+        return -1;
+
+    switch (set->type) {
+        case DATASET_TYPE_STRING: {
+            // coverity[alloc_strlen : FALSE]
+            uint8_t decoded[strlen(string)];
+            uint32_t len = DecodeBase64(decoded, (const uint8_t *)string, strlen(string), 1);
+            if (len == 0) {
+                return -2;
+            }
+
+            return DatasetLookup(set, decoded, len);
+        }
+        case DATASET_TYPE_MD5: {
+            if (strlen(string) != 32)
+                return -2;
+            uint8_t hash[16];
+            if (HexToRaw((const uint8_t *)string, 32, hash, sizeof(hash)) < 0)
+                return -2;
+            return DatasetLookup(set, hash, 16);
+        }
+        case DATASET_TYPE_SHA256: {
+            if (strlen(string) != 64)
+                return -2;
+            uint8_t hash[32];
+            if (HexToRaw((const uint8_t *)string, 64, hash, sizeof(hash)) < 0)
+                return -2;
+            return DatasetLookup(set, hash, 32);
+        }
+    }
+    return -1;
+}
+
 /**
  *  \retval 1 data was removed from the hash
  *  \retval 0 data not removed (busy)

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -1133,13 +1133,10 @@ static int DatasetAddwRep(Dataset *set, const uint8_t *data, const uint32_t data
     return -1;
 }
 
-/** \brief add serialized data to set
- *  \retval int 1 added
- *  \retval int 0 already in hash
- *  \retval int -1 API error (not added)
- *  \retval int -2 DATA error
- */
-int DatasetAddSerialized(Dataset *set, const char *string)
+typedef int (*DatasetOpFunc)(Dataset *set, const uint8_t *data, const uint32_t data_len);
+
+static int DatasetOpSerialized(Dataset *set, const char *string, DatasetOpFunc DatasetOpString,
+        DatasetOpFunc DatasetOpMd5, DatasetOpFunc DatasetOpSha256)
 {
     if (set == NULL)
         return -1;
@@ -1153,7 +1150,7 @@ int DatasetAddSerialized(Dataset *set, const char *string)
                 return -2;
             }
 
-            return DatasetAddString(set, decoded, len);
+            return DatasetOpString(set, decoded, len);
         }
         case DATASET_TYPE_MD5: {
             if (strlen(string) != 32)
@@ -1161,7 +1158,7 @@ int DatasetAddSerialized(Dataset *set, const char *string)
             uint8_t hash[16];
             if (HexToRaw((const uint8_t *)string, 32, hash, sizeof(hash)) < 0)
                 return -2;
-            return DatasetAddMd5(set, hash, 16);
+            return DatasetOpMd5(set, hash, 16);
         }
         case DATASET_TYPE_SHA256: {
             if (strlen(string) != 64)
@@ -1169,10 +1166,20 @@ int DatasetAddSerialized(Dataset *set, const char *string)
             uint8_t hash[32];
             if (HexToRaw((const uint8_t *)string, 64, hash, sizeof(hash)) < 0)
                 return -2;
-            return DatasetAddSha256(set, hash, 32);
+            return DatasetOpSha256(set, hash, 32);
         }
     }
-    return -1;
+}
+
+/** \brief add serialized data to set
+ *  \retval int 1 added
+ *  \retval int 0 already in hash
+ *  \retval int -1 API error (not added)
+ *  \retval int -2 DATA error
+ */
+int DatasetAddSerialized(Dataset *set, const char *string)
+{
+    return DatasetOpSerialized(set, string, DatasetAddString, DatasetAddMd5, DatasetAddSha256);
 }
 
 /** \brief add serialized data to set
@@ -1183,38 +1190,8 @@ int DatasetAddSerialized(Dataset *set, const char *string)
  */
 int DatasetLookupSerialized(Dataset *set, const char *string)
 {
-    if (set == NULL)
-        return -1;
-
-    switch (set->type) {
-        case DATASET_TYPE_STRING: {
-            // coverity[alloc_strlen : FALSE]
-            uint8_t decoded[strlen(string)];
-            uint32_t len = DecodeBase64(decoded, (const uint8_t *)string, strlen(string), 1);
-            if (len == 0) {
-                return -2;
-            }
-
-            return DatasetLookup(set, decoded, len);
-        }
-        case DATASET_TYPE_MD5: {
-            if (strlen(string) != 32)
-                return -2;
-            uint8_t hash[16];
-            if (HexToRaw((const uint8_t *)string, 32, hash, sizeof(hash)) < 0)
-                return -2;
-            return DatasetLookup(set, hash, 16);
-        }
-        case DATASET_TYPE_SHA256: {
-            if (strlen(string) != 64)
-                return -2;
-            uint8_t hash[32];
-            if (HexToRaw((const uint8_t *)string, 64, hash, sizeof(hash)) < 0)
-                return -2;
-            return DatasetLookup(set, hash, 32);
-        }
-    }
-    return -1;
+    return DatasetOpSerialized(
+            set, string, DatasetLookupString, DatasetLookupMd5, DatasetLookupSha256);
 }
 
 /**
@@ -1265,36 +1242,6 @@ static int DatasetRemoveSha256(Dataset *set, const uint8_t *data, const uint32_t
  *  \retval int -2 DATA error */
 int DatasetRemoveSerialized(Dataset *set, const char *string)
 {
-    if (set == NULL)
-        return -1;
-
-    switch (set->type) {
-        case DATASET_TYPE_STRING: {
-            // coverity[alloc_strlen : FALSE]
-            uint8_t decoded[strlen(string)];
-            uint32_t len = DecodeBase64(decoded, (const uint8_t *)string, strlen(string), 1);
-            if (len == 0) {
-                return -2;
-            }
-
-            return DatasetRemoveString(set, decoded, len);
-        }
-        case DATASET_TYPE_MD5: {
-            if (strlen(string) != 32)
-                return -2;
-            uint8_t hash[16];
-            if (HexToRaw((const uint8_t *)string, 32, hash, sizeof(hash)) < 0)
-                return -2;
-            return DatasetRemoveMd5(set, hash, 16);
-        }
-        case DATASET_TYPE_SHA256: {
-            if (strlen(string) != 64)
-                return -2;
-            uint8_t hash[32];
-            if (HexToRaw((const uint8_t *)string, 64, hash, sizeof(hash)) < 0)
-                return -2;
-            return DatasetRemoveSha256(set, hash, 32);
-        }
-    }
-    return -1;
+    return DatasetOpSerialized(
+            set, string, DatasetRemoveString, DatasetRemoveMd5, DatasetRemoveSha256);
 }

--- a/src/datasets.h
+++ b/src/datasets.h
@@ -60,5 +60,6 @@ DataRepResultType DatasetLookupwRep(Dataset *set, const uint8_t *data, const uin
 
 int DatasetAddSerialized(Dataset *set, const char *string);
 int DatasetRemoveSerialized(Dataset *set, const char *string);
+int DatasetLookupSerialized(Dataset *set, const char *string);
 
 #endif /* __DATASETS_H__ */

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -744,6 +744,15 @@ TmEcode UnixSocketDatasetRemove(json_t *cmd, json_t* answer, void *data)
     }
 }
 
+TmEcode UnixSocketDatasetDump(json_t *cmd, json_t *answer, void *data)
+{
+    SCEnter();
+    SCLogDebug("Going to dump datasets");
+    DatasetsSave();
+    json_object_set_new(answer, "message", json_string("datasets dump done"));
+    SCReturnInt(TM_ECODE_OK);
+}
+
 /**
  * \brief Command to add a tenant handler
  *

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -753,6 +753,42 @@ TmEcode UnixSocketDatasetDump(json_t *cmd, json_t *answer, void *data)
     SCReturnInt(TM_ECODE_OK);
 }
 
+TmEcode UnixSocketDatasetClear(json_t *cmd, json_t *answer, void *data)
+{
+    /* 1 get dataset name */
+    json_t *narg = json_object_get(cmd, "setname");
+    if (!json_is_string(narg)) {
+        json_object_set_new(answer, "message", json_string("setname is not a string"));
+        return TM_ECODE_FAILED;
+    }
+    const char *set_name = json_string_value(narg);
+
+    /* 2 get the data type */
+    json_t *targ = json_object_get(cmd, "settype");
+    if (!json_is_string(targ)) {
+        json_object_set_new(answer, "message", json_string("settype is not a string"));
+        return TM_ECODE_FAILED;
+    }
+    const char *type = json_string_value(targ);
+
+    enum DatasetTypes t = DatasetGetTypeFromString(type);
+    if (t == DATASET_TYPE_NOTSET) {
+        json_object_set_new(answer, "message", json_string("unknown settype"));
+        return TM_ECODE_FAILED;
+    }
+
+    Dataset *set = DatasetFind(set_name, t);
+    if (set == NULL) {
+        json_object_set_new(answer, "message", json_string("set not found or wrong type"));
+        return TM_ECODE_FAILED;
+    }
+
+    THashCleanup(set->hash);
+
+    json_object_set_new(answer, "message", json_string("dataset cleared"));
+    return TM_ECODE_OK;
+}
+
 /**
  * \brief Command to add a tenant handler
  *

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -789,6 +789,55 @@ TmEcode UnixSocketDatasetClear(json_t *cmd, json_t *answer, void *data)
     return TM_ECODE_OK;
 }
 
+TmEcode UnixSocketDatasetExist(json_t *cmd, json_t *answer, void *data)
+{
+    /* 1 get dataset name */
+    json_t *narg = json_object_get(cmd, "setname");
+    if (!json_is_string(narg)) {
+        json_object_set_new(answer, "message", json_string("setname is not a string"));
+        return TM_ECODE_FAILED;
+    }
+    const char *set_name = json_string_value(narg);
+
+    /* 2 get the data type */
+    json_t *targ = json_object_get(cmd, "settype");
+    if (!json_is_string(targ)) {
+        json_object_set_new(answer, "message", json_string("settype is not a string"));
+        return TM_ECODE_FAILED;
+    }
+    const char *type = json_string_value(targ);
+
+    /* 3 get value */
+    json_t *varg = json_object_get(cmd, "datavalue");
+    if (!json_is_string(varg)) {
+        json_object_set_new(answer, "message", json_string("datavalue is not string"));
+        return TM_ECODE_FAILED;
+    }
+    const char *value = json_string_value(varg);
+
+    SCLogDebug("dataset-exist: %s type %s value %s", set_name, type, value);
+
+    enum DatasetTypes t = DatasetGetTypeFromString(type);
+    if (t == DATASET_TYPE_NOTSET) {
+        json_object_set_new(answer, "message", json_string("unknown settype"));
+        return TM_ECODE_FAILED;
+    }
+
+    Dataset *set = DatasetFind(set_name, t);
+    if (set == NULL) {
+        json_object_set_new(answer, "message", json_string("set not found or wrong type"));
+        return TM_ECODE_FAILED;
+    }
+
+    if (DatasetLookupSerialized(set, value) > 0) {
+        json_object_set_new(answer, "message", json_string("item found in set"));
+        return TM_ECODE_OK;
+    } else {
+        json_object_set_new(answer, "message", json_string("item not found in set"));
+        return TM_ECODE_FAILED;
+    }
+}
+
 /**
  * \brief Command to add a tenant handler
  *

--- a/src/runmode-unix-socket.h
+++ b/src/runmode-unix-socket.h
@@ -34,6 +34,7 @@ TmEcode UnixSocketPcapFile(TmEcode tm, struct timespec *last_processed);
 TmEcode UnixSocketDatasetAdd(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketDatasetRemove(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketDatasetDump(json_t *cmd, json_t *answer, void *data);
+TmEcode UnixSocketDatasetClear(json_t *cmd, json_t *answer, void *data);
 TmEcode UnixSocketRegisterTenantHandler(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketUnregisterTenantHandler(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketRegisterTenant(json_t *cmd, json_t* answer, void *data);

--- a/src/runmode-unix-socket.h
+++ b/src/runmode-unix-socket.h
@@ -33,6 +33,7 @@ TmEcode UnixSocketPcapFile(TmEcode tm, struct timespec *last_processed);
 #ifdef BUILD_UNIX_SOCKET
 TmEcode UnixSocketDatasetAdd(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketDatasetRemove(json_t *cmd, json_t* answer, void *data);
+TmEcode UnixSocketDatasetDump(json_t *cmd, json_t *answer, void *data);
 TmEcode UnixSocketRegisterTenantHandler(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketUnregisterTenantHandler(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketRegisterTenant(json_t *cmd, json_t* answer, void *data);

--- a/src/runmode-unix-socket.h
+++ b/src/runmode-unix-socket.h
@@ -35,6 +35,7 @@ TmEcode UnixSocketDatasetAdd(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketDatasetRemove(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketDatasetDump(json_t *cmd, json_t *answer, void *data);
 TmEcode UnixSocketDatasetClear(json_t *cmd, json_t *answer, void *data);
+TmEcode UnixSocketDatasetExist(json_t *cmd, json_t *answer, void *data);
 TmEcode UnixSocketRegisterTenantHandler(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketUnregisterTenantHandler(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketRegisterTenant(json_t *cmd, json_t* answer, void *data);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -1083,6 +1083,7 @@ int UnixManagerInit(void)
 
     UnixManagerRegisterCommand("dataset-add", UnixSocketDatasetAdd, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("dataset-remove", UnixSocketDatasetRemove, &command, UNIX_CMD_TAKE_ARGS);
+    UnixManagerRegisterCommand("dataset-dump", UnixSocketDatasetDump, NULL, 0);
 
     return 0;
 }

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -1084,6 +1084,8 @@ int UnixManagerInit(void)
     UnixManagerRegisterCommand("dataset-add", UnixSocketDatasetAdd, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("dataset-remove", UnixSocketDatasetRemove, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("dataset-dump", UnixSocketDatasetDump, NULL, 0);
+    UnixManagerRegisterCommand(
+            "dataset-clear", UnixSocketDatasetClear, &command, UNIX_CMD_TAKE_ARGS);
 
     return 0;
 }

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -1086,6 +1086,8 @@ int UnixManagerInit(void)
     UnixManagerRegisterCommand("dataset-dump", UnixSocketDatasetDump, NULL, 0);
     UnixManagerRegisterCommand(
             "dataset-clear", UnixSocketDatasetClear, &command, UNIX_CMD_TAKE_ARGS);
+    UnixManagerRegisterCommand(
+            "dataset-exist", UnixSocketDatasetExist, &command, UNIX_CMD_TAKE_ARGS);
 
     return 0;
 }


### PR DESCRIPTION
This patchset contains the work done on #5708 but also adds some new commands.

As a result the following commands are added to unix socket:
- datataset-clear to delete all entries in a set
- dataset-dump to trigger a dump on disk
- dataset-check to verify if a entry is in a set

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4269

Describe changes:
- Add new unix socket commands
- Document new commands

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
