### PR TITLE
http: enables request decompression

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2381,6 +2381,8 @@ static void HTPConfigSetDefaultsPhase1(HTPCfgRec *cfg_prec)
 
     /* don't convert + to space by default */
     htp_config_set_plusspace_decode(cfg_prec->cfg, HTP_DECODER_URLENCODED, 0);
+    // enables request decompression
+    htp_config_set_request_decompression(cfg_prec->cfg, 1);
 #ifdef HAVE_HTP_CONFIG_SET_LZMA_LAYERS
     // disable by default
     htp_config_set_lzma_layers(cfg_prec->cfg, HTP_CONFIG_DEFAULT_LZMA_LAYERS);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2510

Describe changes:
- Enables HTTP request decompression

suricata-verify-pr: 416
libhtp-pr: 318

References
https://github.com/OISF/libhtp/pull/318
https://github.com/OISF/suricata-verify/pull/329

Big change is in libhtp.
We enable it in Suricata 7 and keep old behavior in previous Suricata versions

