### PR TITLE
Protocol detection 2757 v5

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -564,7 +564,11 @@ again_midstream:
     } else {
         /* first try the destination port */
         pp_port_dp = AppLayerProtoDetectGetProbingParsers(alpd_ctx.ctx_pp, ipproto, dp);
-        alproto_masks = &f->probing_parser_toclient_alproto_masks;
+        if (dir == idir) {
+            // do not update alproto_masks to let a chance to second packet
+            // for instance when sending a junk packet to a DNS server
+            alproto_masks = &f->probing_parser_toclient_alproto_masks;
+        }
         if (pp_port_dp != NULL) {
             SCLogDebug("toclient - Probing parser found for destination port %"PRIu16, dp);
 

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -634,8 +634,9 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
 
     /* if we don't know the proto yet and we have received a stream
      * initializer message, we run proto detection.
-     * We receive 2 stream init msgs (one for each direction) but we
-     * only run the proto detection once. */
+     * We receive 2 stream init msgs (one for each direction), we
+     * only run the proto detection for both and emit an event
+     * in the case protocols mismatch. */
     if (alproto == ALPROTO_UNKNOWN && (flags & STREAM_START)) {
         DEBUG_VALIDATE_BUG_ON(FlowChangeProto(f));
         /* run protocol detection */
@@ -734,6 +735,8 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
 int AppLayerHandleUdp(ThreadVars *tv, AppLayerThreadCtx *tctx, Packet *p, Flow *f)
 {
     SCEnter();
+    AppProto *alproto;
+    AppProto *alproto_otherdir;
 
     if (f->alproto == ALPROTO_FAILED) {
         SCReturnInt(0);
@@ -743,27 +746,70 @@ int AppLayerHandleUdp(ThreadVars *tv, AppLayerThreadCtx *tctx, Packet *p, Flow *
     uint8_t flags = 0;
     if (p->flowflags & FLOW_PKT_TOSERVER) {
         flags |= STREAM_TOSERVER;
+        alproto = &f->alproto_ts;
+        alproto_otherdir = &f->alproto_tc;
     } else {
         flags |= STREAM_TOCLIENT;
+        alproto = &f->alproto_tc;
+        alproto_otherdir = &f->alproto_ts;
     }
 
     AppLayerProfilingReset(tctx);
 
     /* if the protocol is still unknown, run detection */
-    if (f->alproto == ALPROTO_UNKNOWN) {
+    if (*alproto == ALPROTO_UNKNOWN) {
         SCLogDebug("Detecting AL proto on udp mesg (len %" PRIu32 ")",
                    p->payload_len);
 
         bool reverse_flow = false;
         PACKET_PROFILING_APP_PD_START(tctx);
-        f->alproto = AppLayerProtoDetectGetProto(tctx->alpd_tctx,
+        *alproto = AppLayerProtoDetectGetProto(tctx->alpd_tctx,
                                   f, p->payload, p->payload_len,
                                   IPPROTO_UDP, flags, &reverse_flow);
         PACKET_PROFILING_APP_PD_END(tctx);
 
-        if (f->alproto != ALPROTO_UNKNOWN) {
-            AppLayerIncFlowCounter(tv, f);
-
+        switch (*alproto) {
+            case ALPROTO_UNKNOWN:
+                if (*alproto_otherdir != ALPROTO_UNKNOWN) {
+                    // Use recognized side
+                    f->alproto = *alproto_otherdir;
+                    // do not keep ALPROTO_UNKNOWN for this side so as not to loop
+                    *alproto = *alproto_otherdir;
+                    AppLayerIncFlowCounter(tv, f);
+                    if (*alproto_otherdir == ALPROTO_FAILED) {
+                        SCLogDebug("ALPROTO_UNKNOWN flow %p", f);
+                    }
+                } else {
+                    // First side of protocol is unknown
+                    *alproto = ALPROTO_FAILED;
+                }
+                break;
+            case ALPROTO_FAILED:
+                if (*alproto_otherdir != ALPROTO_UNKNOWN) {
+                    // Use recognized side
+                    f->alproto = *alproto_otherdir;
+                    AppLayerIncFlowCounter(tv, f);
+                    if (*alproto_otherdir == ALPROTO_FAILED) {
+                        SCLogDebug("ALPROTO_UNKNOWN flow %p", f);
+                    }
+                }
+                // else wait for second side of protocol
+                break;
+            default:
+                f->alproto = *alproto;
+                if (*alproto_otherdir == ALPROTO_FAILED) {
+                    AppLayerIncFlowCounter(tv, f);
+                } else if (*alproto_otherdir != ALPROTO_UNKNOWN) {
+                    if (*alproto_otherdir != *alproto) {
+                        AppLayerDecoderEventsSetEventRaw(&p->app_layer_events,
+                                                         APPLAYER_MISMATCH_PROTOCOL_BOTH_DIRECTIONS);
+                    } else {
+                        AppLayerIncFlowCounter(tv, f);
+                    }
+                }
+        }
+        // parse the data if we recognized one protocol
+        if (f->alproto != ALPROTO_UNKNOWN && f->alproto != ALPROTO_FAILED) {
             if (reverse_flow) {
                 SCLogDebug("reversing flow after proto detect told us so");
                 PacketSwap(p);
@@ -775,10 +821,6 @@ int AppLayerHandleUdp(ThreadVars *tv, AppLayerThreadCtx *tctx, Packet *p, Flow *
             r = AppLayerParserParse(tv, tctx->alp_tctx, f, f->alproto,
                                     flags, p->payload, p->payload_len);
             PACKET_PROFILING_APP_END(tctx, f->alproto);
-        } else {
-            f->alproto = ALPROTO_FAILED;
-            AppLayerIncFlowCounter(tv, f);
-            SCLogDebug("ALPROTO_UNKNOWN flow %p", f);
         }
         PACKET_PROFILING_APP_STORE(tctx, p);
         /* we do only inspection in one direction, so flag both


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2757

Describe changes:
- Use both directions for protocol detection over UDP (as is done with TCP)
- Changes `AppLayerProtoDetectPPGetProto` so that first packet does not bit mask away a protocol for both directions when config option midstream is activated 

The main goal was the first one (use both directions for UDP)
And then I came across this unwanted behavior from `AppLayerProtoDetectPPGetProto` :
When the first packet is no valid DNS but on port 53 (for instance a junk request), second packet (error response from server) does not get checked for DNS as first packet bit masked away DNS for both directions (ie `probing_parser_toclient_alproto_masks` and `probing_parser_toserver_alproto_masks`)

There are other open PRs regarding
https://redmine.openinfosecfoundation.org/issues/2757
such as "Support when multiple protocols have patterns matching (such as USER for FTP and IRC)"

Modifies #4681
- do not check forever if one side says `ALPROTO_UNKNOWN` and the other one says `ALPROTO_DCERPC`
- call `AppLayerParserParse` if the current side failed protocol detection, but the other side gave us previously the protocol to parse

suricata-verify-pr: 415