### PR TITLE
rust: fix warning about unused values in smb tests

### DIFF
--- a/rust/src/smb/nbss_records.rs
+++ b/rust/src/smb/nbss_records.rs
@@ -126,7 +126,7 @@ mod tests {
                 // there should be nothing left
                 assert_eq!(remainder.len(), 0);
             }
-            Err(nom::Err::Error((remainder, err))) => {
+            Err(nom::Err::Error((_remainder, err))) => {
                 panic!("Result should not be an error: {:?}.", err);
             }
             Err(nom::Err::Incomplete(_)) => {
@@ -170,7 +170,7 @@ mod tests {
                 // there should be nothing left
                 assert_eq!(remainder.len(), 0);
             }
-            Err(nom::Err::Error((remainder, err))) => {
+            Err(nom::Err::Error((_remainder, err))) => {
                 panic!("Result should not be an error: {:?}.", err);
             }
             Err(nom::Err::Incomplete(_)) => {
@@ -210,7 +210,7 @@ mod tests {
                 // there should be nothing left
                 assert_eq!(remainder.len(), 0);
             }
-            Err(nom::Err::Error((remainder, err))) => {
+            Err(nom::Err::Error((_remainder, err))) => {
                 panic!("Result should not be an error: {:?}.", err);
             }
             Err(nom::Err::Incomplete(_)) => {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- fix warning about unused values in smb tests
