### PR TITLE
Protodetect multiple v6

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -41,6 +41,7 @@
 #include "util-pool.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
+#include "util-validate.h"
 
 #include "flow.h"
 #include "flow-util.h"
@@ -1551,6 +1552,7 @@ AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx,
         uint16_t pm_matches = AppLayerProtoDetectPMGetProto(tctx, f,
                 buf, buflen, direction, pm_results, reverse_flow);
         if (pm_matches > 0) {
+            DEBUG_VALIDATE_BUG_ON(pm_matches > 1);
             alproto = pm_results[0];
 
             // rerun probing parser for other direction if it is unknown

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -329,8 +329,10 @@ static AppProto AppLayerProtoDetectPMGetProto(
     MpmThreadCtx *mpm_tctx;
     int m = -1;
 
-    if (f->protomap >= FLOW_PROTO_DEFAULT)
-        return ALPROTO_FAILED;
+    if (f->protomap >= FLOW_PROTO_DEFAULT) {
+        pm_results[0] = ALPROTO_FAILED;
+        SCReturnUInt(1);
+    }
 
     if (direction & STREAM_TOSERVER) {
         pm_ctx = &alpd_ctx.ctx_ipp[f->protomap].ctx_pm[0];


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2757

Describe changes:
- Adds debug validation when multiple patterns are found for protocol detection
- Fixes failure case returned value in `AppLayerProtoDetectPMGetProto`

Modifies #5232 with adding a commit to fix failure case of `AppLayerProtoDetectPMGetProto`