### PR TITLE
Http2 files v6

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -723,7 +723,7 @@ jobs:
           chmod 755 $HOME/.cargo/bin/cbindgen
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: ./autogen.sh
-      - run: CFLAGS="$DEFAULT_CFLAGS -DNDEBUG" ./configure --enable-unittests
+      - run: CFLAGS="$DEFAULT_CFLAGS -DNDEBUG" ./configure --enable-unittests --enable-http2-decompression
       - run: make -j2
       - run: make check
       - run: make dist

--- a/configure.ac
+++ b/configure.ac
@@ -521,6 +521,14 @@
     ])
     AM_CONDITIONAL([DEBUG_VALIDATION], [test "x$enable_debug_validation" = "xyes"])
 
+  # enable http2 decompression
+    AC_ARG_ENABLE(http2-decompression,
+           AS_HELP_STRING([--enable-http2-decompression], [Enable http2 decompression]),[enable_http2_decompression=$enableval],[enable_http2_decompression=no])
+    AS_IF([test "x$enable_http2_decompression" = "xyes"], [
+        AC_DEFINE([HTTP2_DECOMPRESSION],[1],[Enable http2 decompression])
+    ])
+    AM_CONDITIONAL([HTTP2_DECOMPRESSION], [test "x$enable_http2_decompression" = "xyes"])
+
   # profiling support
     AC_ARG_ENABLE(profiling,
            AS_HELP_STRING([--enable-profiling], [Enable performance profiling]),[enable_profiling=$enableval],[enable_profiling=no])
@@ -2716,6 +2724,7 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   Hyperscan support:                       ${enable_hyperscan}
   Libnet support:                          ${enable_libnet}
   liblz4 support:                          ${enable_liblz4}
+  HTTP2 decompression:                     ${enable_http2_decompression}
 
   Rust support:                            ${enable_rust}
   Rust strict mode:                        ${enable_rust_strict}

--- a/rules/http2-events.rules
+++ b/rules/http2-events.rules
@@ -14,3 +14,4 @@ alert http2 any any -> any any (msg:"SURICATA HTTP2 header frame with extra data
 alert http2 any any -> any any (msg:"SURICATA HTTP2 too long frame data"; flow:established; app-layer-event:http2.long_frame_data; classtype:protocol-command-decode; sid:2290006; rev:1;)
 alert http2 any any -> any any (msg:"SURICATA HTTP2 stream identifier reuse"; flow:established; app-layer-event:http2.stream_id_reuse; classtype:protocol-command-decode; sid:2290007; rev:1;)
 alert http2 any any -> any any (msg:"SURICATA HTTP2 invalid HTTP1 settings during upgrade"; flow:established; app-layer-event:http2.invalid_http1_settings; classtype:protocol-command-decode; sid:2290008; rev:1;)
+alert http2 any any -> any any (msg:"SURICATA HTTP2 failed decompression"; flow:established; app-layer-event:http2.failed_decompression; classtype:protocol-command-decode; sid:2290009; rev:1;)

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -17,6 +17,7 @@ strict = []
 debug = []
 debug-validate = []
 function-macro = []
+decompression = ["flate2", "brotli"]
 
 [dependencies]
 nom = "= 5.1.1"
@@ -43,6 +44,9 @@ sha2 = "0.9.2"
 digest = "0.9.0"
 sha-1 = "0.9.2"
 md-5 = "0.9.1"
+
+flate2 = { version = "1.0", optional = true }
+brotli = { version = "3.3.0", optional = true }
 
 [dev-dependencies]
 test-case = "1.0"

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -27,6 +27,10 @@ if DEBUG_VALIDATION
 RUST_FEATURES +=	debug-validate
 endif
 
+if HTTP2_DECOMPRESSION
+RUST_FEATURES +=	decompression
+endif
+
 if RUST_CROSS_COMPILE 
 RUST_TARGET = --target $(host_triplet)
 endif

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -48,6 +48,10 @@ pub static mut ALPROTO_FAILED : AppProto = 0; // updated during init
 pub const IPPROTO_TCP : i32 = 6;
 pub const IPPROTO_UDP : i32 = 17;
 
+macro_rules!BIT_U16 {
+    ($x:expr) => (1 << $x);
+}
+
 macro_rules!BIT_U32 {
     ($x:expr) => (1 << $x);
 }

--- a/rust/src/filecontainer.rs
+++ b/rust/src/filecontainer.rs
@@ -24,7 +24,7 @@ use crate::core::*;
 extern {
     pub fn FileFlowToFlags(flow: *const Flow, flags: u8) -> u16;
 }
-pub const FILE_USE_DETECT:    u16 = 0x2000;
+pub const FILE_USE_DETECT:    u16 = BIT_U16!(13);
 
 
 // Generic file structure, so it can be used by different protocols

--- a/rust/src/http2/decompression.rs
+++ b/rust/src/http2/decompression.rs
@@ -1,0 +1,216 @@
+/* Copyright (C) 2021 Open Information Security Foundation
+*
+* You can copy, redistribute or modify this Program under the terms of
+* the GNU General Public License version 2 as published by the Free
+* Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* version 2 along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+* 02110-1301, USA.
+*/
+
+use crate::core::STREAM_TOCLIENT;
+use brotli;
+use flate2::read::GzDecoder;
+use std;
+use std::io;
+use std::io::{Cursor, Read, Write};
+
+pub const HTTP2_DECOMPRESSION_CHUNK_SIZE: usize = 0x1000; // 4096
+
+#[repr(u8)]
+#[derive(Copy, Clone, PartialOrd, PartialEq, Debug)]
+pub enum HTTP2ContentEncoding {
+    HTTP2ContentEncodingUnknown = 0,
+    HTTP2ContentEncodingGzip = 1,
+    HTTP2ContentEncodingBr = 2,
+    HTTP2ContentEncodingUnrecognized = 3,
+}
+
+//a cursor turning EOF into blocking errors
+pub struct HTTP2cursor {
+    pub cursor: Cursor<Vec<u8>>,
+}
+
+impl HTTP2cursor {
+    pub fn new() -> HTTP2cursor {
+        HTTP2cursor {
+            cursor: Cursor::new(Vec::new()),
+        }
+    }
+
+    #[cfg(feature = "debug-validate")]
+    pub fn position(&self) -> u64 {
+        return self.cursor.position();
+    }
+
+    pub fn set_position(&mut self, pos: u64) {
+        return self.cursor.set_position(pos);
+    }
+}
+
+// we need to implement this as flate2 and brotli crates
+// will read from this object
+impl Read for HTTP2cursor {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        //use the cursor, except it turns eof into blocking error
+        let r = self.cursor.read(buf);
+        match r {
+            Err(ref err) => {
+                if err.kind() == io::ErrorKind::UnexpectedEof {
+                    return Err(io::ErrorKind::WouldBlock.into());
+                }
+            }
+            Ok(0) => {
+                //regular EOF turned into blocking error
+                return Err(io::ErrorKind::WouldBlock.into());
+            }
+            Ok(_n) => {}
+        }
+        return r;
+    }
+}
+
+pub enum HTTP2Decompresser {
+    UNASSIGNED,
+    GZIP(GzDecoder<HTTP2cursor>),
+    BROTLI(brotli::Decompressor<HTTP2cursor>),
+}
+
+struct HTTP2DecoderHalf {
+    encoding: HTTP2ContentEncoding,
+    decoder: HTTP2Decompresser,
+}
+
+pub trait GetMutCursor {
+    fn get_mut(&mut self) -> &mut HTTP2cursor;
+}
+
+impl GetMutCursor for GzDecoder<HTTP2cursor> {
+    fn get_mut(&mut self) -> &mut HTTP2cursor {
+        return self.get_mut();
+    }
+}
+
+impl GetMutCursor for brotli::Decompressor<HTTP2cursor> {
+    fn get_mut(&mut self) -> &mut HTTP2cursor {
+        return self.get_mut();
+    }
+}
+
+fn http2_decompress<'a>(
+    decoder: &mut (impl Read + GetMutCursor), input: &'a [u8], output: &'a mut Vec<u8>,
+) -> io::Result<&'a [u8]> {
+    match decoder.get_mut().cursor.write_all(input) {
+        Ok(()) => {}
+        Err(e) => {
+            return Err(e);
+        }
+    }
+    let mut offset = 0;
+    decoder.get_mut().set_position(0);
+    output.resize(HTTP2_DECOMPRESSION_CHUNK_SIZE, 0);
+    loop {
+        match decoder.read(&mut output[offset..]) {
+            Ok(0) => {
+                break;
+            }
+            Ok(n) => {
+                offset += n;
+                if offset == output.len() {
+                    output.resize(output.len() + HTTP2_DECOMPRESSION_CHUNK_SIZE, 0);
+                }
+            }
+            Err(e) => {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    break;
+                }
+                return Err(e);
+            }
+        }
+    }
+    //checks all input was consumed
+    debug_validate_bug_on!(decoder.get_mut().position() < (input.len() as u64));
+    decoder.get_mut().set_position(0);
+    return Ok(&output[..offset]);
+}
+
+impl HTTP2DecoderHalf {
+    pub fn new() -> HTTP2DecoderHalf {
+        HTTP2DecoderHalf {
+            encoding: HTTP2ContentEncoding::HTTP2ContentEncodingUnknown,
+            decoder: HTTP2Decompresser::UNASSIGNED,
+        }
+    }
+
+    pub fn http2_encoding_fromvec(&mut self, input: &Vec<u8>) {
+        //use first encoding...
+        if self.encoding == HTTP2ContentEncoding::HTTP2ContentEncodingUnknown {
+            if *input == "gzip".as_bytes().to_vec() {
+                self.encoding = HTTP2ContentEncoding::HTTP2ContentEncodingGzip;
+                self.decoder = HTTP2Decompresser::GZIP(GzDecoder::new(HTTP2cursor::new()));
+            } else if *input == "br".as_bytes().to_vec() {
+                self.encoding = HTTP2ContentEncoding::HTTP2ContentEncodingBr;
+                self.decoder = HTTP2Decompresser::BROTLI(brotli::Decompressor::new(
+                    HTTP2cursor::new(),
+                    HTTP2_DECOMPRESSION_CHUNK_SIZE,
+                ));
+            } else {
+                self.encoding = HTTP2ContentEncoding::HTTP2ContentEncodingUnrecognized;
+            }
+        }
+    }
+
+    pub fn decompress<'a>(
+        &'a mut self, input: &'a [u8], output: &'a mut Vec<u8>,
+    ) -> io::Result<&'a [u8]> {
+        match self.decoder {
+            HTTP2Decompresser::GZIP(ref mut gzip_decoder) => {
+                return http2_decompress(gzip_decoder, input, output);
+            }
+            HTTP2Decompresser::BROTLI(ref mut br_decoder) => {
+                return http2_decompress(br_decoder, input, output);
+            }
+            _ => {}
+        }
+        return Ok(input);
+    }
+}
+
+pub struct HTTP2Decoder {
+    decoder_tc: HTTP2DecoderHalf,
+    decoder_ts: HTTP2DecoderHalf,
+}
+
+impl HTTP2Decoder {
+    pub fn new() -> HTTP2Decoder {
+        HTTP2Decoder {
+            decoder_tc: HTTP2DecoderHalf::new(),
+            decoder_ts: HTTP2DecoderHalf::new(),
+        }
+    }
+
+    pub fn http2_encoding_fromvec(&mut self, input: &Vec<u8>, dir: u8) {
+        if dir == STREAM_TOCLIENT {
+            self.decoder_tc.http2_encoding_fromvec(input);
+        } else {
+            self.decoder_ts.http2_encoding_fromvec(input);
+        }
+    }
+
+    pub fn decompress<'a>(
+        &'a mut self, input: &'a [u8], output: &'a mut Vec<u8>, dir: u8,
+    ) -> io::Result<&'a [u8]> {
+        if dir == STREAM_TOCLIENT {
+            return self.decoder_tc.decompress(input, output);
+        } else {
+            return self.decoder_ts.decompress(input, output);
+        }
+    }
+}

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -784,7 +784,7 @@ impl HTTP2State {
                                     );
                                 }
                             }
-                            None => panic!("BUG"),
+                            None => panic!("no SURICATA_HTTP2_FILE_CONFIG"),
                         }
                     }
                     input = &rem[hlsafe..];

--- a/rust/src/http2/mod.rs
+++ b/rust/src/http2/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+#[cfg(feature = "decompression")]
+mod decompression;
 pub mod detect;
 pub mod http2;
 mod huffman;

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -268,7 +268,7 @@ pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContai
         Some(sfcm) => {
             ft.new_chunk(sfcm, files, flags, &name, data, chunk_offset,
                     chunk_size, fill_bytes, is_last, xid); }
-        None => panic!("BUG"),
+        None => panic!("no SURICATA_NFS_FILE_CONFIG"),
     }
 }
 

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -56,7 +56,7 @@ pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContai
         Some(sfcm) => {
             ft.new_chunk(sfcm, files, flags, &name, data, chunk_offset,
                     chunk_size, fill_bytes, is_last, xid); }
-        None => panic!("BUG"),
+        None => panic!("no SURICATA_SMB_FILE_CONFIG"),
     }
 }
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -694,6 +694,9 @@ static void PrintBuildInfo(void)
 #endif
     /* For compatibility, just say we have HAVE_NSS. */
     strlcat(features, "HAVE_NSS ", sizeof(features));
+#ifdef HTTP2_DECOMPRESSION
+    strlcat(features, "HTTP2_DECOMPRESSION ", sizeof(features));
+#endif
 #ifdef HAVE_LUA
     strlcat(features, "HAVE_LUA ", sizeof(features));
 #endif

--- a/src/tests/fuzz/oss-fuzz-configure.sh
+++ b/src/tests/fuzz/oss-fuzz-configure.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-./configure --disable-shared --enable-fuzztargets --disable-gccmarch-native --enable-debug-validation
+./configure --disable-shared --enable-fuzztargets --disable-gccmarch-native --enable-debug-validation --enable-http2-decompression
+


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4116

Describe changes:
- Files decompression for HTTP2


suricata-verify-pr: 398

Makes https://github.com/OISF/suricata-verify/pull/398 pass (includes a framework change to have feature selection by check and not only by whole test)

Modifies #5775 with rightly fixed conflict, and commits squashed so that each one compiles
