### PR TITLE
detect/http-client-body: Improved support for shared bufs

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2017 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -32,6 +32,7 @@
 #include "stream-tcp.h"
 #include "app-layer.h"
 #include "app-layer-parser.h"
+#include "app-layer-htp.h"
 
 #include "detect.h"
 #include "detect-engine.h"
@@ -941,6 +942,31 @@ static inline void DetectRunPostRules(
     PACKET_PROFILING_DETECT_END(p, PROF_DETECT_ALERT);
 }
 
+static inline HtpBody *GetBody(const uint8_t flow_flags, void *tx)
+{
+    htp_tx_t *htx = tx;
+    HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(htx);
+    if (htud == NULL) {
+        SCLogDebug("no htud");
+        return NULL;
+    }
+
+    return flow_flags & STREAM_TOSERVER ? &htud->request_body : &htud->response_body;
+}
+
+static void DetectRunTxCleanup(
+        DetectEngineThreadCtx *det_ctx, const AppProto alproto, const uint8_t flow_flags, void *tx)
+{
+    if (alproto == ALPROTO_HTTP) {
+        HtpBody *body = GetBody(flow_flags, tx);
+        if (body) {
+            body->body_inspected = body->content_len_so_far;
+            SCLogDebug("body->inspected = %" PRIu64 " body->content_len_so_far = %" PRIu64,
+                    body->body_inspected, body->content_len_so_far);
+        }
+    }
+}
+
 static void DetectRunCleanup(DetectEngineThreadCtx *det_ctx,
         Packet *p, Flow * const pflow)
 {
@@ -1523,6 +1549,10 @@ static void DetectRunTx(ThreadVars *tv,
 
             StoreDetectFlags(&tx, flow_flags, ipproto, alproto, new_detect_flags);
         }
+        if (new_detect_flags & APP_LAYER_TX_INSPECTED_FLAG) {
+            DetectRunTxCleanup(det_ctx, alproto, flow_flags, tx.tx_ptr);
+        }
+
 next:
         InspectionBufferClean(det_ctx);
 


### PR DESCRIPTION
Continuation of #5658 

This commit improves support for shared buffer usage, i.e., when
multiple rules share the HTTP client body and apply different
combinations of transforms and fast_patterns (or none).

Redmine issue: [4199](https://redmine.openinfosecfoundation.org/issues/4199)

Describe changes:
- Adds per-TX cleanup when inspection has completed for that tx.

suricata-verify-pr: 420
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
