### PR TITLE
fuzz: makes target sigpcap more reproducible

### DIFF
--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -61,6 +61,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         if (ConfYamlLoadString(configNoChecksum, strlen(configNoChecksum)) != 0) {
             abort();
         }
+        //do not load rules before reproducible DetectEngineReload
+        remove("/tmp/fuzz.rules");
         surifuzz.sig_file = strdup("/tmp/fuzz.rules");
         surifuzz.sig_file_exclusive = 1;
         //loads rules after init


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4125
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29886

Describe changes:
- Improves `fuzz_sigpcap` target by making it more reproducible