### PR TITLE
Fuzz target remove v3

### DIFF
--- a/src/tests/fuzz/fuzz_decodepcapfile.c
+++ b/src/tests/fuzz/fuzz_decodepcapfile.c
@@ -74,6 +74,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         tmm_modules[TMM_DECODEPCAPFILE].ThreadInit(tv, NULL, (void **) &dtv);
         (void)SC_ATOMIC_SET(tv->tm_slots->slot_next->slot_data, dtv);
 
+        extern intmax_t max_pending_packets;
+        max_pending_packets = 128;
         PacketPoolInit();
 
         initialized = 1;

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -81,6 +81,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         tmm_modules[TMM_FLOWWORKER].ThreadInit(&tv, NULL, &fwd);
         StatsSetupPrivate(&tv);
 
+        extern intmax_t max_pending_packets;
+        max_pending_packets = 128;
         PacketPoolInit();
         initialized = 1;
     }

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -61,6 +61,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         if (ConfYamlLoadString(configNoChecksum, strlen(configNoChecksum)) != 0) {
             abort();
         }
+        // do not load rules before reproducible DetectEngineReload
+        remove("/tmp/fuzz.rules");
         surifuzz.sig_file = strdup("/tmp/fuzz.rules");
         surifuzz.sig_file_exclusive = 1;
         //loads rules after init


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4125
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29886
and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29932

Describe changes:
- Improves `fuzz_sigpcap` target by making it more reproducible
- Defines `max_pending_packets` for fuzz targets (as in unit tests)

Modifies #5787 with second commit defining `max_pending_packets` for fuzz targets as for unit tests