### PR TITLE
fuzz: rightly uses PacketFreeOrRelease in target

### DIFF
--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -155,13 +155,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             }
             Packet *extra_p = PacketDequeueNoLock(&tv.decode_pq);
             while (extra_p != NULL) {
-                PacketFree(extra_p);
+                PacketFreeOrRelease(extra_p);
                 extra_p = PacketDequeueNoLock(&tv.decode_pq);
             }
             tmm_modules[TMM_FLOWWORKER].Func(&tv, p, fwd);
             extra_p = PacketDequeueNoLock(&tv.decode_pq);
             while (extra_p != NULL) {
-                PacketFree(extra_p);
+                PacketFreeOrRelease(extra_p);
                 extra_p = PacketDequeueNoLock(&tv.decode_pq);
             }
         }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4125
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29932

Describe changes:
- fuzz: rightly uses PacketFreeOrRelease in target

instead of `PacketFree` because packets may belong to the pool which will get empty forever