### PR TITLE
track TCP flags in first packet in each direction

### DIFF
--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -308,9 +308,15 @@ static void EveFlowLogJSON(JsonFlowLogThread *aft, JsonBuilder *jb, Flow *f)
                 ssn ? ssn->client.tcp_flags : 0);
         jb_set_string(jb, "tcp_flags_ts", hexflags);
 
+        snprintf(hexflags, sizeof(hexflags), "%02x", ssn ? ssn->client.tcp_init_flags : 0);
+        jb_set_string(jb, "tcp_init_flags_ts", hexflags);
+
         snprintf(hexflags, sizeof(hexflags), "%02x",
                 ssn ? ssn->server.tcp_flags : 0);
         jb_set_string(jb, "tcp_flags_tc", hexflags);
+
+        snprintf(hexflags, sizeof(hexflags), "%02x", ssn ? ssn->server.tcp_init_flags : 0);
+        jb_set_string(jb, "tcp_init_flags_tc", hexflags);
 
         EveTcpFlags(ssn ? ssn->tcp_packet_flags : 0, jb);
 

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -96,7 +96,8 @@ typedef struct TcpStream_ {
     /* coccinelle: TcpStream:flags:STREAMTCP_STREAM_FLAG_ */
     uint16_t wscale:4;              /**< wscale setting in this direction, 4 bits as max val is 15 */
     uint8_t os_policy;              /**< target based OS policy used for reassembly and handling packets*/
-    uint8_t tcp_flags;              /**< TCP flags seen */
+    uint8_t tcp_init_flags;         /**< TCP flags seen in first packet */
+    uint8_t tcp_flags;              /**< union of TCP flags seen in all packets */
 
     uint32_t isn;                   /**< initial sequence number */
     uint32_t next_seq;              /**< next expected sequence number */


### PR DESCRIPTION
Suricata saves the TCP flags which it sees inside
`struct TcpStream_::tcp_flags` but this contains a union of
all flags seen.  It can be beneficial to know the flags
used solely in the first packet seen (in each direction).

This change stores the initial flags seen in each direction,
even if the first packet seen is a FIN or a RST (if midstream
is configured)

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-

suricata-verify-pr: 432
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
