### PR TITLE
Fixes 20210127

### DIFF
--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -215,12 +215,16 @@ static void JsonTlsLogJa3String(JsonBuilder *js, SSLState *ssl_state)
 
 static void JsonTlsLogJa3(JsonBuilder *js, SSLState *ssl_state)
 {
-    jb_open_object(js, "ja3");
+    if ((ssl_state->client_connp.ja3_hash != NULL) ||
+            ((ssl_state->client_connp.ja3_str != NULL) &&
+                    ssl_state->client_connp.ja3_str->data != NULL)) {
+        jb_open_object(js, "ja3");
 
-    JsonTlsLogJa3Hash(js, ssl_state);
-    JsonTlsLogJa3String(js, ssl_state);
+        JsonTlsLogJa3Hash(js, ssl_state);
+        JsonTlsLogJa3String(js, ssl_state);
 
-    jb_close(js);
+        jb_close(js);
+    }
 }
 
 static void JsonTlsLogJa3SHash(JsonBuilder *js, SSLState *ssl_state)
@@ -242,12 +246,16 @@ static void JsonTlsLogJa3SString(JsonBuilder *js, SSLState *ssl_state)
 
 static void JsonTlsLogJa3S(JsonBuilder *js, SSLState *ssl_state)
 {
-    jb_open_object(js, "ja3s");
+    if ((ssl_state->server_connp.ja3_hash != NULL) ||
+            ((ssl_state->server_connp.ja3_str != NULL) &&
+                    ssl_state->server_connp.ja3_str->data != NULL)) {
+        jb_open_object(js, "ja3s");
 
-    JsonTlsLogJa3SHash(js, ssl_state);
-    JsonTlsLogJa3SString(js, ssl_state);
+        JsonTlsLogJa3SHash(js, ssl_state);
+        JsonTlsLogJa3SString(js, ssl_state);
 
-    jb_close(js);
+        jb_close(js);
+    }
 }
 
 static void JsonTlsLogCertificate(JsonBuilder *js, SSLState *ssl_state)

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1840,12 +1840,6 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         return TM_ECODE_FAILED;
     }
 
-    if ((suri->run_mode == RUNMODE_UNIX_SOCKET) && suri->set_logdir) {
-        SCLogError(SC_ERR_INITIALIZATION,
-                "can't use -l and unix socket runmode at the same time");
-        return TM_ECODE_FAILED;
-    }
-
     /* save the runmode from the commandline (if any) */
     suri->aux_run_mode = suri->run_mode;
 


### PR DESCRIPTION
2 small improvements on logging and unix socket mode.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- unix-socket mode and -l are compatible so allow it
- Only output ja3 and ja3s if present