### PR TITLE
Draft changes for issue 4145 -- file handling registration unification.

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -93,10 +93,11 @@ typedef struct AppLayerParserFileKeywordHandlerNode_ {
     DetectAppLayerParserKeywordEntry *keyword_list;
     int keyword_list_size;
     const char *keyword;
-    //void (*callback)(const char **, AppProto);
+    // void (*callback)(const char **, AppProto);
     TAILQ_ENTRY(AppLayerParserFileKeywordHandlerNode_) entries;
 } AppLayerParserFileKeywordHandlerNode;
-static TAILQ_HEAD(, AppLayerParserFileKeywordHandlerNode_) keyword_handler_node_list = TAILQ_HEAD_INITIALIZER(keyword_handler_node_list);
+static TAILQ_HEAD(, AppLayerParserFileKeywordHandlerNode_)
+        keyword_handler_node_list = TAILQ_HEAD_INITIALIZER(keyword_handler_node_list);
 
 /**
  * \brief App layer protocol parser context.
@@ -1159,46 +1160,37 @@ int AppLayerParserSupportsTxDetectState(uint8_t ipproto, AppProto alproto)
     return FALSE;
 }
 
-void AppLayerParserRegisterFileKeywordEntry(const char *name, DetectAppLayerParserKeywordEntry *entry)
+void AppLayerParserRegisterFileKeywordEntry(
+        const char *name, DetectAppLayerParserKeywordEntry *entry)
 {
-	SCLogNotice("Registering %s %s (%s%s)",
-            name,
-            AppProtoToString(entry->alproto),
+    SCLogNotice("Registering %s %s (%s%s)", name, AppProtoToString(entry->alproto),
             entry->directions & SIG_FLAG_TOSERVER ? "server " : "",
-            entry->directions & SIG_FLAG_TOCLIENT ? "client" : ""
-            );
-     if (entry->directions & SIG_FLAG_TOSERVER) {
-        DetectAppLayerInspectEngineRegister2(name,
-            entry->alproto, SIG_FLAG_TOSERVER, entry->inspect.progress,
-            entry->inspect.Callback, entry->inspect.Getdata);
+            entry->directions & SIG_FLAG_TOCLIENT ? "client" : "");
+    if (entry->directions & SIG_FLAG_TOSERVER) {
+        DetectAppLayerInspectEngineRegister2(name, entry->alproto, SIG_FLAG_TOSERVER,
+                entry->inspect.progress, entry->inspect.Callback, entry->inspect.Getdata);
     }
     if (entry->directions & SIG_FLAG_TOCLIENT) {
-        DetectAppLayerInspectEngineRegister2(name,
-                entry->alproto, SIG_FLAG_TOCLIENT, entry->inspect.progress,
-                entry->inspect.Callback, entry->inspect.Getdata);
+        DetectAppLayerInspectEngineRegister2(name, entry->alproto, SIG_FLAG_TOCLIENT,
+                entry->inspect.progress, entry->inspect.Callback, entry->inspect.Getdata);
     }
 
     if (entry->mpm.PrefilterRegister) {
         if (entry->directions & SIG_FLAG_TOSERVER) {
-            DetectAppLayerMpmRegister2(name,
-                    SIG_FLAG_TOSERVER, entry->mpm.priority,
-                    entry->mpm.PrefilterRegister,
-                    entry->mpm.Getdata,
-                    entry->alproto,
+            DetectAppLayerMpmRegister2(name, SIG_FLAG_TOSERVER, entry->mpm.priority,
+                    entry->mpm.PrefilterRegister, entry->mpm.Getdata, entry->alproto,
                     entry->mpm.tx_min_progress);
         }
         if (entry->directions & SIG_FLAG_TOCLIENT) {
-            DetectAppLayerMpmRegister2(name,
-                    SIG_FLAG_TOCLIENT, entry->mpm.priority,
-                    entry->mpm.PrefilterRegister,
-                    entry->mpm.Getdata,
-                    entry->alproto,
+            DetectAppLayerMpmRegister2(name, SIG_FLAG_TOCLIENT, entry->mpm.priority,
+                    entry->mpm.PrefilterRegister, entry->mpm.Getdata, entry->alproto,
                     entry->mpm.tx_min_progress);
         }
     }
 }
 
-void AppLayerParserRegisterFileKeywordHandler(const char *keyword, DetectAppLayerParserKeywordEntry *keyword_list, size_t keyword_list_len )
+void AppLayerParserRegisterFileKeywordHandler(const char *keyword,
+        DetectAppLayerParserKeywordEntry *keyword_list, size_t keyword_list_len)
 {
     AppLayerParserFileKeywordHandlerNode *node = SCCalloc(1, sizeof(*node));
     if (node == NULL) {
@@ -1212,7 +1204,7 @@ void AppLayerParserRegisterFileKeywordHandler(const char *keyword, DetectAppLaye
         return;
     }
 
-    node->keyword_list_size = (int) keyword_list_len;
+    node->keyword_list_size = (int)keyword_list_len;
     node->keyword_list = keyword_list;
     TAILQ_INSERT_TAIL(&keyword_handler_node_list, node, entries);
 }
@@ -1221,17 +1213,18 @@ void AppLayerParserRegisterFileHandlers(void)
 {
     for (int ipproto = IPPROTO_IP; ipproto < IPPROTO_MAX; ipproto++) {
         for (AppProto alproto = 0; alproto < ALPROTO_MAX; alproto++) {
-            if (!AppLayerParserSupportsFiles((uint8_t) ipproto, alproto)) {
+            if (!AppLayerParserSupportsFiles((uint8_t)ipproto, alproto)) {
                 continue;
             }
             AppLayerParserFileKeywordHandlerNode *node = NULL;
-            TAILQ_FOREACH(node, &keyword_handler_node_list, entries) {
+            TAILQ_FOREACH (node, &keyword_handler_node_list, entries) {
                 for (int i = 0; i < node->keyword_list_size; i++) {
                     DetectAppLayerParserKeywordEntry entry = node->keyword_list[i];
                     if (entry.alproto != alproto) {
                         continue;
                     }
-                    SCLogNotice("FILES: ip proto: %d application layer proto %s", ipproto, AppProtoToString(alproto));
+                    SCLogNotice("FILES: ip proto: %d application layer proto %s", ipproto,
+                            AppProtoToString(alproto));
                     AppLayerParserRegisterFileKeywordEntry(node->keyword, &entry);
                 }
             }

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -124,7 +124,7 @@ typedef struct AppLayerGetTxIterState {
 
 typedef struct DetectAppLayerParserRegisterKeywordEntry_ {
     AppProto alproto;
-    uint32_t    directions;
+    uint32_t directions;
     struct {
         int progress;
         InspectEngineFuncPtr2 Callback;
@@ -133,8 +133,7 @@ typedef struct DetectAppLayerParserRegisterKeywordEntry_ {
     /* MPM */
     struct {
         int priority;
-        int (*PrefilterRegister)(DetectEngineCtx *de_ctx,
-                SigGroupHead *sgh, MpmCtx *mpm_ctx,
+        int (*PrefilterRegister)(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmCtx *mpm_ctx,
                 const DetectBufferMpmRegistery *mpm_reg, int list_id);
         InspectionBufferGetDataPtr Getdata;
         int tx_min_progress;
@@ -213,7 +212,8 @@ void AppLayerParserRegisterTxDataFunc(uint8_t ipproto, AppProto alproto,
 void AppLayerParserRegisterApplyTxConfigFunc(uint8_t ipproto, AppProto alproto,
         bool (*ApplyTxConfig)(void *state, void *tx, int mode, AppLayerTxConfig));
 
-void AppLayerParserRegisterFileKeywordHandler(const char *, DetectAppLayerParserKeywordEntry *, size_t);
+void AppLayerParserRegisterFileKeywordHandler(
+        const char *, DetectAppLayerParserKeywordEntry *, size_t);
 
 /***** Get and transaction functions *****/
 

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -122,6 +122,27 @@ typedef struct AppLayerGetTxIterState {
     } un;
 } AppLayerGetTxIterState;
 
+typedef struct DetectAppLayerParserRegisterKeywordEntry_ {
+    AppProto alproto;
+    uint32_t    directions;
+    struct {
+        int progress;
+        InspectEngineFuncPtr2 Callback;
+        InspectionBufferGetDataPtr Getdata;
+    } inspect;
+    /* MPM */
+    struct {
+        int priority;
+        int (*PrefilterRegister)(DetectEngineCtx *de_ctx,
+                SigGroupHead *sgh, MpmCtx *mpm_ctx,
+                const DetectBufferMpmRegistery *mpm_reg, int list_id);
+        InspectionBufferGetDataPtr Getdata;
+        int tx_min_progress;
+    } mpm;
+} DetectAppLayerParserKeywordEntry;
+
+void AppLayerParserRegisterFileKeywordEntry(const char *, DetectAppLayerParserKeywordEntry *);
+
 /** \brief tx iterator prototype */
 typedef AppLayerGetTxIterTuple (*AppLayerGetTxIteratorFunc)
        (const uint8_t ipproto, const AppProto alproto,
@@ -192,6 +213,8 @@ void AppLayerParserRegisterTxDataFunc(uint8_t ipproto, AppProto alproto,
 void AppLayerParserRegisterApplyTxConfigFunc(uint8_t ipproto, AppProto alproto,
         bool (*ApplyTxConfig)(void *state, void *tx, int mode, AppLayerTxConfig));
 
+void AppLayerParserRegisterFileKeywordHandler(const char *, DetectAppLayerParserKeywordEntry *, size_t);
+
 /***** Get and transaction functions *****/
 
 uint32_t AppLayerParserGetOptionFlags(uint8_t protomap, AppProto alproto);
@@ -228,6 +251,7 @@ uint64_t AppLayerParserGetTransactionActive(const Flow *f, AppLayerParserState *
 
 uint8_t AppLayerParserGetFirstDataDir(uint8_t ipproto, AppProto alproto);
 
+void AppLayerParserRegisterFileHandlers(void);
 int AppLayerParserSupportsFiles(uint8_t ipproto, AppProto alproto);
 int AppLayerParserHasTxDetectState(uint8_t ipproto, AppProto alproto, void *alstate);
 DetectEngineState *AppLayerParserGetTxDetectState(uint8_t ipproto, AppProto alproto, void *tx);

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -657,6 +657,7 @@ void SigTableSetup(void)
     DetectTransformPcrexformRegister();
     DetectTransformUrlDecodeRegister();
 
+    AppLayerParserRegisterFileHandlers();
     /* close keyword registration */
     DetectBufferTypeCloseRegistration();
 }

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -74,6 +74,124 @@ static int DetectEngineInspectFilename(
         const Signature *s,
         Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
+DetectAppLayerParserKeywordEntry filename_list[] = {
+        {
+            .alproto = ALPROTO_HTTP, .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
+            .inspect =  {
+                .Callback = DetectEngineInspectFilename
+            },
+            .mpm =  {
+                .priority = 2,
+                .PrefilterRegister = PrefilterMpmFilenameRegister
+            }
+        },
+        {
+            .alproto = ALPROTO_SMTP, .directions = SIG_FLAG_TOSERVER,
+            .inspect =  {
+                .Callback = DetectEngineInspectFilename
+            },
+            .mpm =  {
+                .priority = 2,
+                .PrefilterRegister = PrefilterMpmFilenameRegister
+            }
+        },
+        {
+            .alproto = ALPROTO_FTP, .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
+            .inspect =  {
+                .Callback = DetectEngineInspectFilename
+            },
+            .mpm =  {
+                .priority = 2,
+                .PrefilterRegister = PrefilterMpmFilenameRegister
+            }
+        },
+        {
+            .alproto = ALPROTO_FTPDATA, .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
+            .inspect =  {
+                .Callback = DetectEngineInspectFilename
+            },
+            .mpm =  {
+                .priority = 2,
+                .PrefilterRegister = PrefilterMpmFilenameRegister
+            }
+        },
+        {
+            .alproto = ALPROTO_SMB, .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
+            .inspect =  {
+                .Callback = DetectEngineInspectFilename
+            },
+            .mpm =  {
+                .priority = 2,
+                .PrefilterRegister = PrefilterMpmFilenameRegister
+            }
+        },
+        {
+            .alproto = ALPROTO_NFS, .directions = SIG_FLAG_TOCLIENT,
+            .inspect =  {
+                .Callback = DetectEngineInspectFilename
+            },
+            .mpm =  {
+                .priority = 2,
+                .PrefilterRegister = PrefilterMpmFilenameRegister
+            }
+        }
+};
+
+DetectAppLayerParserKeywordEntry files_list[] = {
+	{
+		.alproto= ALPROTO_HTTP, .directions = SIG_FLAG_TOSERVER,
+		.inspect = {
+			.progress = HTP_REQUEST_BODY,
+			.Callback = DetectFileInspectGeneric
+		}
+	},
+	{
+		.alproto = ALPROTO_HTTP, .directions = SIG_FLAG_TOCLIENT,
+		.inspect =  {
+			.progress = HTP_RESPONSE_BODY,
+			.Callback = DetectFileInspectGeneric
+		}
+	},
+	{
+		.alproto = ALPROTO_HTTP2, .directions = SIG_FLAG_TOSERVER,
+		.inspect =  {
+			.progress = HTTP2StateDataClient,
+			.Callback = DetectFileInspectGeneric
+		}
+	},
+	{
+		.alproto = ALPROTO_HTTP2, .directions = SIG_FLAG_TOCLIENT,
+		.inspect =  {
+			.progress = HTTP2StateDataServer,
+			.Callback = DetectFileInspectGeneric
+		}
+	},
+	{
+		.alproto = ALPROTO_NFS, .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
+		.inspect =  {
+			.Callback = DetectFileInspectGeneric
+		}
+	},
+	{
+		.alproto = ALPROTO_SMB, .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
+		.inspect =  {
+			.Callback = DetectFileInspectGeneric
+		}
+	},
+	{
+		.alproto = ALPROTO_SMTP, .directions = SIG_FLAG_TOSERVER,
+		.inspect =  {
+			.Callback = DetectFileInspectGeneric
+		}
+	},
+	{
+		.alproto = ALPROTO_FTPDATA, .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
+		.inspect =  {
+			.Callback = DetectFileInspectGeneric
+		}
+	}
+};
+
 /**
  * \brief Registration function for keyword: filename
  */
@@ -155,6 +273,10 @@ void DetectFilenameRegister(void)
     DetectBufferTypeSetDescriptionByName("file.name",
             "http user agent");
 
+    AppLayerParserRegisterFileKeywordHandler("files", files_list, ARRAY_SIZE(files_list));
+    AppLayerParserRegisterFileKeywordHandler("file.name", filename_list, ARRAY_SIZE(filename_list));
+
+    g_file_match_list_id = DetectBufferTypeGetByName("files");
     g_file_name_buffer_id = DetectBufferTypeGetByName("file.name");
 	SCLogDebug("registering filename rule option");
     return;

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -75,121 +75,57 @@ static int DetectEngineInspectFilename(
         Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
 DetectAppLayerParserKeywordEntry filename_list[] = {
-        {
-            .alproto = ALPROTO_HTTP, .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
-            .inspect =  {
-                .Callback = DetectEngineInspectFilename
-            },
-            .mpm =  {
-                .priority = 2,
-                .PrefilterRegister = PrefilterMpmFilenameRegister
-            }
-        },
-        {
-            .alproto = ALPROTO_SMTP, .directions = SIG_FLAG_TOSERVER,
-            .inspect =  {
-                .Callback = DetectEngineInspectFilename
-            },
-            .mpm =  {
-                .priority = 2,
-                .PrefilterRegister = PrefilterMpmFilenameRegister
-            }
-        },
-        {
-            .alproto = ALPROTO_FTP, .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
-            .inspect =  {
-                .Callback = DetectEngineInspectFilename
-            },
-            .mpm =  {
-                .priority = 2,
-                .PrefilterRegister = PrefilterMpmFilenameRegister
-            }
-        },
-        {
-            .alproto = ALPROTO_FTPDATA, .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
-            .inspect =  {
-                .Callback = DetectEngineInspectFilename
-            },
-            .mpm =  {
-                .priority = 2,
-                .PrefilterRegister = PrefilterMpmFilenameRegister
-            }
-        },
-        {
-            .alproto = ALPROTO_SMB, .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
-            .inspect =  {
-                .Callback = DetectEngineInspectFilename
-            },
-            .mpm =  {
-                .priority = 2,
-                .PrefilterRegister = PrefilterMpmFilenameRegister
-            }
-        },
-        {
-            .alproto = ALPROTO_NFS, .directions = SIG_FLAG_TOCLIENT,
-            .inspect =  {
-                .Callback = DetectEngineInspectFilename
-            },
-            .mpm =  {
-                .priority = 2,
-                .PrefilterRegister = PrefilterMpmFilenameRegister
-            }
-        }
+    { .alproto = ALPROTO_HTTP,
+            .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
+            .inspect = { .Callback = DetectEngineInspectFilename },
+            .mpm = { .priority = 2, .PrefilterRegister = PrefilterMpmFilenameRegister } },
+    { .alproto = ALPROTO_SMTP,
+            .directions = SIG_FLAG_TOSERVER,
+            .inspect = { .Callback = DetectEngineInspectFilename },
+            .mpm = { .priority = 2, .PrefilterRegister = PrefilterMpmFilenameRegister } },
+    { .alproto = ALPROTO_FTP,
+            .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
+            .inspect = { .Callback = DetectEngineInspectFilename },
+            .mpm = { .priority = 2, .PrefilterRegister = PrefilterMpmFilenameRegister } },
+    { .alproto = ALPROTO_FTPDATA,
+            .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
+            .inspect = { .Callback = DetectEngineInspectFilename },
+            .mpm = { .priority = 2, .PrefilterRegister = PrefilterMpmFilenameRegister } },
+    { .alproto = ALPROTO_SMB,
+            .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
+            .inspect = { .Callback = DetectEngineInspectFilename },
+            .mpm = { .priority = 2, .PrefilterRegister = PrefilterMpmFilenameRegister } },
+    { .alproto = ALPROTO_NFS,
+            .directions = SIG_FLAG_TOCLIENT,
+            .inspect = { .Callback = DetectEngineInspectFilename },
+            .mpm = { .priority = 2, .PrefilterRegister = PrefilterMpmFilenameRegister } }
 };
 
 DetectAppLayerParserKeywordEntry files_list[] = {
-	{
-		.alproto= ALPROTO_HTTP, .directions = SIG_FLAG_TOSERVER,
-		.inspect = {
-			.progress = HTP_REQUEST_BODY,
-			.Callback = DetectFileInspectGeneric
-		}
-	},
-	{
-		.alproto = ALPROTO_HTTP, .directions = SIG_FLAG_TOCLIENT,
-		.inspect =  {
-			.progress = HTP_RESPONSE_BODY,
-			.Callback = DetectFileInspectGeneric
-		}
-	},
-	{
-		.alproto = ALPROTO_HTTP2, .directions = SIG_FLAG_TOSERVER,
-		.inspect =  {
-			.progress = HTTP2StateDataClient,
-			.Callback = DetectFileInspectGeneric
-		}
-	},
-	{
-		.alproto = ALPROTO_HTTP2, .directions = SIG_FLAG_TOCLIENT,
-		.inspect =  {
-			.progress = HTTP2StateDataServer,
-			.Callback = DetectFileInspectGeneric
-		}
-	},
-	{
-		.alproto = ALPROTO_NFS, .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
-		.inspect =  {
-			.Callback = DetectFileInspectGeneric
-		}
-	},
-	{
-		.alproto = ALPROTO_SMB, .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
-		.inspect =  {
-			.Callback = DetectFileInspectGeneric
-		}
-	},
-	{
-		.alproto = ALPROTO_SMTP, .directions = SIG_FLAG_TOSERVER,
-		.inspect =  {
-			.Callback = DetectFileInspectGeneric
-		}
-	},
-	{
-		.alproto = ALPROTO_FTPDATA, .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
-		.inspect =  {
-			.Callback = DetectFileInspectGeneric
-		}
-	}
+    { .alproto = ALPROTO_HTTP,
+            .directions = SIG_FLAG_TOSERVER,
+            .inspect = { .progress = HTP_REQUEST_BODY, .Callback = DetectFileInspectGeneric } },
+    { .alproto = ALPROTO_HTTP,
+            .directions = SIG_FLAG_TOCLIENT,
+            .inspect = { .progress = HTP_RESPONSE_BODY, .Callback = DetectFileInspectGeneric } },
+    { .alproto = ALPROTO_HTTP2,
+            .directions = SIG_FLAG_TOSERVER,
+            .inspect = { .progress = HTTP2StateDataClient, .Callback = DetectFileInspectGeneric } },
+    { .alproto = ALPROTO_HTTP2,
+            .directions = SIG_FLAG_TOCLIENT,
+            .inspect = { .progress = HTTP2StateDataServer, .Callback = DetectFileInspectGeneric } },
+    { .alproto = ALPROTO_NFS,
+            .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
+            .inspect = { .Callback = DetectFileInspectGeneric } },
+    { .alproto = ALPROTO_SMB,
+            .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
+            .inspect = { .Callback = DetectFileInspectGeneric } },
+    { .alproto = ALPROTO_SMTP,
+            .directions = SIG_FLAG_TOSERVER,
+            .inspect = { .Callback = DetectFileInspectGeneric } },
+    { .alproto = ALPROTO_FTPDATA,
+            .directions = SIG_FLAG_TOCLIENT | SIG_FLAG_TOSERVER,
+            .inspect = { .Callback = DetectFileInspectGeneric } }
 };
 
 /**


### PR DESCRIPTION
[draft] This commit presents a different way to register file keyword handler
specific. For this draft, the changes have been made for "file",
"filename", and "file_data" only.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4145](https://redmine.openinfosecfoundation.org/issues/4145)

Describe changes:
- Register keyword specifics with the app layer parser
- Use these to register for inspection and mpm handling
- Changes limited to `file`, `filename`, and `file_data`

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
