### PR TITLE
Ossfuzz corp v6

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,7 +1,7 @@
 codecov:
   require_ci_to_pass: yes
   notify:
-    after_n_builds: 2
+    after_n_builds: 3
 
 coverage:
   precision: 2

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -666,6 +666,82 @@ jobs:
         with:
           flags: unittests
 
+  ubuntu-20-04-cov-fuzz:
+    name: Ubuntu 20.04 (fuzz corpus coverage)
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
+    needs: [prepare-deps, prepare-cbindgen]
+    steps:
+      - name: Install dependencies
+        run: |
+          apt update
+          apt -y install \
+                libpcre3 \
+                libpcre3-dev \
+                build-essential \
+                autoconf \
+                automake \
+                llvm-10 \
+                clang-10 \
+                git \
+                jq \
+                libc++-dev \
+                libc++abi-dev \
+                libtool \
+                libpcap-dev \
+                libnet1-dev \
+                libyaml-0-2 \
+                libyaml-dev \
+                libcap-ng-dev \
+                libcap-ng0 \
+                libmagic-dev \
+                libnetfilter-queue-dev \
+                libnetfilter-queue1 \
+                libnfnetlink-dev \
+                libnfnetlink0 \
+                libhiredis-dev \
+                liblua5.1-dev \
+                libjansson-dev \
+                libevent-dev \
+                libevent-pthreads-2.1-7 \
+                libjansson-dev \
+                libpython2.7 \
+                make \
+                parallel \
+                python3-yaml \
+                rustc \
+                software-properties-common \
+                zlib1g \
+                zlib1g-dev \
+                exuberant-ctags \
+                unzip \
+                curl \
+                wget
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/libhtp.tar.gz
+      - name: Setup cbindgen
+        run: |
+          mkdir -p $HOME/.cargo/bin
+          cp prep/cbindgen $HOME/.cargo/bin
+          chmod 755 $HOME/.cargo/bin/cbindgen
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: ./autogen.sh
+      - run: LIB_FUZZING_ENGINE="fail_to_onefile_driver" CC=clang-10 CXX=clang++-10 CFLAGS="-fprofile-arcs -ftest-coverage -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -fPIC -Wno-unused-parameter -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1" CXXFLAGS="-fprofile-arcs -ftest-coverage -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -stdlib=libc++" ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes ./configure --with-gnu-ld --enable-fuzztargets --disable-shared --enable-gccprotect
+      - run: make -j2
+      - run: ./qa/run-ossfuzz-corpus.sh
+      - name: Gcov
+        run: |
+          cd src
+          llvm-cov-10 gcov -p *.c
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          flags: fuzzcorpus
+
   ubuntu-20-04-ndebug:
     name: Ubuntu 20.04 (-DNDEBUG)
     runs-on: ubuntu-latest

--- a/qa/run-ossfuzz-corpus.sh
+++ b/qa/run-ossfuzz-corpus.sh
@@ -1,0 +1,13 @@
+#/bin/sh
+ls src/fuzz_* | while read ftarget
+do
+    target=$(basename $ftarget)
+    echo "target $target"
+    #download public corpus
+    rm -f public.zip
+    wget --quiet "https://storage.googleapis.com/suricata-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/suricata_$target/public.zip"
+    rm -rf corpus_$target
+    unzip -q public.zip -d corpus_$target
+    #run target on corpus.
+    ./src/$target corpus_$target
+done

--- a/src/decode-ethernet.c
+++ b/src/decode-ethernet.c
@@ -38,6 +38,8 @@
 #include "util-unittest.h"
 #include "util-debug.h"
 
+#define MAX_ETH_OFFSET 256
+
 int DecodeEthernet(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                    const uint8_t *pkt, uint32_t len)
 {
@@ -48,6 +50,9 @@ int DecodeEthernet(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         return TM_ECODE_FAILED;
     }
 
+    if (unlikely(p->ethh != NULL) && ((uint8_t *)p->ethh) - p->ext_pkt > MAX_ETH_OFFSET) {
+        return TM_ECODE_FAILED;
+    }
     p->ethh = (EthernetHdr *)pkt;
     if (unlikely(p->ethh == NULL))
         return TM_ECODE_FAILED;

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -262,7 +262,7 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
 #undef MAX_SUBSTRINGS
 #define MAX_SUBSTRINGS 100
     int ov[MAX_SUBSTRINGS];
-    char tmp_str[128];
+    char tmp_str[128] = "";
 
     ret = DetectParsePcreExec(&parse_regex, arg, 0, 0, ov, MAX_SUBSTRINGS);
     if (ret < MIN_GROUP || ret > MAX_GROUP) {

--- a/src/tests/fuzz/onefile.c
+++ b/src/tests/fuzz/onefile.c
@@ -1,25 +1,19 @@
+#define _DEFAULT_SOURCE 1 // for DT_REG
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <dirent.h>
+#include <unistd.h>
 #include "autoconf.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 
-int main(int argc, char** argv)
+static int runOneFile(const char *fname)
 {
-    FILE * fp;
+    // opens the file, get its size, and reads it into a buffer
     uint8_t *data;
     size_t size;
-
-    if (argc != 2) {
-        return 1;
-    }
-#ifdef AFLFUZZ_PERSISTANT_MODE
-    while (__AFL_LOOP(1000)) {
-#endif /* AFLFUZZ_PERSISTANT_MODE */
-
-    //opens the file, get its size, and reads it into a buffer
-    fp = fopen(argv[1], "rb");
+    FILE *fp = fopen(fname, "rb");
     if (fp == NULL) {
         return 2;
     }
@@ -51,10 +45,50 @@ int main(int argc, char** argv)
     LLVMFuzzerTestOneInput(data, size);
     free(data);
     fclose(fp);
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    DIR *d;
+    struct dirent *dir;
+    int r;
+
+    if (argc != 2) {
+        return 1;
+    }
+#ifdef AFLFUZZ_PERSISTANT_MODE
+    while (__AFL_LOOP(1000)) {
+#endif /* AFLFUZZ_PERSISTANT_MODE */
+
+        d = opendir(argv[1]);
+        if (d == NULL) {
+            // run one file
+            r = runOneFile(argv[1]);
+            if (r != 0) {
+                return r;
+            }
+        } else {
+            // run every file in one directory
+            if (chdir(argv[1]) != 0) {
+                closedir(d);
+                printf("Invalid directory\n");
+                return 2;
+            }
+            while ((dir = readdir(d)) != NULL) {
+                if (dir->d_type != DT_REG) {
+                    continue;
+                }
+                r = runOneFile(dir->d_name);
+                if (r != 0) {
+                    return r;
+                }
+            }
+            closedir(d);
+        }
 #ifdef AFLFUZZ_PERSISTANT_MODE
     }
 #endif /* AFLFUZZ_PERSISTANT_MODE */
 
     return 0;
 }
-

--- a/src/tests/fuzz/onefile.c
+++ b/src/tests/fuzz/onefile.c
@@ -1,10 +1,4 @@
-#define _DEFAULT_SOURCE 1 // for DT_REG
-#include <stdint.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <dirent.h>
-#include <unistd.h>
-#include "autoconf.h"
+#include "suricata-common.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4125

Describe changes:
- Runs CI on public corpuses of fuzz targets for coverage and ASAN bugs
- simple fuzz driver can run on flat directories (not only files)
- fix bug of uninitialized memory in `bytemath` keyword parsing
- fix bug by avoiding over recursion between `DecodeEthernet` and `DecodeMPLS`
