### PR TITLE
libsuricata - baby steps - v1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *.lo
+*.la
 *.in
 *.[ch]e
 *.log

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -22,6 +22,7 @@ use crate::core::{DetectEngineState,Flow,AppLayerEventType,AppLayerDecoderEvents
 use crate::filecontainer::FileContainer;
 use crate::applayer;
 use std::os::raw::{c_void,c_char,c_int};
+use crate::core::SC;
 
 #[repr(C)]
 #[derive(Debug,PartialEq)]
@@ -289,7 +290,11 @@ pub type TruncateFn = unsafe extern "C" fn (*mut c_void, u8);
 // Defined in app-layer-register.h
 extern {
     pub fn AppLayerRegisterProtocolDetection(parser: *const RustParser, enable_default: c_int) -> AppProto;
-    pub fn AppLayerRegisterParser(parser: *const RustParser, alproto: AppProto) -> c_int;
+}
+
+#[allow(non_snake_case)]
+pub unsafe fn AppLayerRegisterParser(parser: *const RustParser, alproto: AppProto) -> c_int {
+    (SC.unwrap().AppLayerRegisterParser)(parser, alproto)
 }
 
 // Defined in app-layer-detect-proto.h

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -141,6 +141,8 @@ pub struct SuricataContext {
     pub FileContainerRecycle: SCFileContainerRecycle,
     pub FilePrune: SCFilePrune,
     pub FileSetTx: SCFileSetTx,
+
+    pub AppLayerRegisterParser: extern fn(parser: *const crate::applayer::RustParser, alproto: AppProto) -> std::os::raw::c_int,
 }
 
 #[allow(non_snake_case)]

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -585,17 +585,24 @@ EXTRA_DIST = tests
 # set the include path found by configure
 AM_CPPFLAGS = $(all_includes)
 
-suricata_SOURCES = main.c $(COMMON_SOURCES)
+noinst_LTLIBRARIES = libsuricatac.la
+libsuricatac_la_SOURCES = $(COMMON_SOURCES)
+
+suricata_SOURCES = main.c
 
 # the library search path.
 suricata_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
-suricata_LDADD = $(HTP_LDADD) $(RUST_LDADD)
-suricata_DEPENDENCIES = $(RUST_SURICATA_LIB)
+suricata_LDADD = libsuricatac.la $(HTP_LDADD) $(RUST_LDADD)
+suricata_DEPENDENCIES = libsuricatac.la
 
 if BUILD_FUZZTARGETS
-nodist_fuzz_applayerprotodetectgetproto_SOURCES = tests/fuzz/fuzz_applayerprotodetectgetproto.c $(COMMON_SOURCES)
-fuzz_applayerprotodetectgetproto_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
-fuzz_applayerprotodetectgetproto_LDADD = $(RUST_SURICATA_LIB) $(HTP_LDADD) $(RUST_LDADD)
+
+LDFLAGS_FUZZ = $(all_libraries) $(SECLDFLAGS)
+LDADD_FUZZ = libsuricatac.la $(HTP_LDADD) $(RUST_LDADD)
+
+nodist_fuzz_applayerprotodetectgetproto_SOURCES = tests/fuzz/fuzz_applayerprotodetectgetproto.c
+fuzz_applayerprotodetectgetproto_LDFLAGS = $(LDFLAGS_FUZZ)
+fuzz_applayerprotodetectgetproto_LDADD = $(LDADD_FUZZ)
 if HAS_FUZZLDFLAGS
     fuzz_applayerprotodetectgetproto_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else
@@ -604,9 +611,9 @@ endif
 # force usage of CXX for linker
 nodist_EXTRA_fuzz_applayerprotodetectgetproto_SOURCES = force-cxx-linking.cxx
 
-nodist_fuzz_applayerparserparse_SOURCES = tests/fuzz/fuzz_applayerparserparse.c $(COMMON_SOURCES)
-fuzz_applayerparserparse_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
-fuzz_applayerparserparse_LDADD = $(RUST_SURICATA_LIB) $(HTP_LDADD) $(RUST_LDADD)
+nodist_fuzz_applayerparserparse_SOURCES = tests/fuzz/fuzz_applayerparserparse.c
+fuzz_applayerparserparse_LDFLAGS = $(LDFLAGS_FUZZ)
+fuzz_applayerparserparse_LDADD = $(LDADD_FUZZ)
 if HAS_FUZZLDFLAGS
     fuzz_applayerparserparse_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else
@@ -615,9 +622,9 @@ endif
 # force usage of CXX for linker
 nodist_EXTRA_fuzz_applayerparserparse_SOURCES = force-cxx-linking.cxx
 
-nodist_fuzz_siginit_SOURCES = tests/fuzz/fuzz_siginit.c $(COMMON_SOURCES)
-fuzz_siginit_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
-fuzz_siginit_LDADD = $(RUST_SURICATA_LIB) $(HTP_LDADD) $(RUST_LDADD)
+nodist_fuzz_siginit_SOURCES = tests/fuzz/fuzz_siginit.c
+fuzz_siginit_LDFLAGS = $(LDFLAGS_FUZZ)
+fuzz_siginit_LDADD = $(LDADD_FUZZ)
 if HAS_FUZZLDFLAGS
     fuzz_siginit_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else
@@ -626,9 +633,9 @@ endif
 # force usage of CXX for linker
 nodist_EXTRA_fuzz_siginit_SOURCES = force-cxx-linking.cxx
 
-nodist_fuzz_confyamlloadstring_SOURCES = tests/fuzz/fuzz_confyamlloadstring.c $(COMMON_SOURCES)
-fuzz_confyamlloadstring_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
-fuzz_confyamlloadstring_LDADD = $(RUST_SURICATA_LIB) $(HTP_LDADD) $(RUST_LDADD)
+nodist_fuzz_confyamlloadstring_SOURCES = tests/fuzz/fuzz_confyamlloadstring.c
+fuzz_confyamlloadstring_LDFLAGS = $(LDFLAGS_FUZZ)
+fuzz_confyamlloadstring_LDADD = $(LDADD_FUZZ)
 if HAS_FUZZLDFLAGS
     fuzz_confyamlloadstring_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else
@@ -637,9 +644,9 @@ endif
 # force usage of CXX for linker
 nodist_EXTRA_fuzz_confyamlloadstring_SOURCES = force-cxx-linking.cxx
 
-nodist_fuzz_decodepcapfile_SOURCES = tests/fuzz/fuzz_decodepcapfile.c $(COMMON_SOURCES)
-fuzz_decodepcapfile_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
-fuzz_decodepcapfile_LDADD = $(RUST_SURICATA_LIB) $(HTP_LDADD) $(RUST_LDADD)
+nodist_fuzz_decodepcapfile_SOURCES = tests/fuzz/fuzz_decodepcapfile.c
+fuzz_decodepcapfile_LDFLAGS = $(LDFLAGS_FUZZ)
+fuzz_decodepcapfile_LDADD = $(LDADD_FUZZ)
 if HAS_FUZZLDFLAGS
     fuzz_decodepcapfile_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else
@@ -648,9 +655,9 @@ endif
 # force usage of CXX for linker
 nodist_EXTRA_fuzz_decodepcapfile_SOURCES = force-cxx-linking.cxx
 
-nodist_fuzz_sigpcap_SOURCES = tests/fuzz/fuzz_sigpcap.c $(COMMON_SOURCES)
-fuzz_sigpcap_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
-fuzz_sigpcap_LDADD = $(RUST_SURICATA_LIB) $(HTP_LDADD) $(RUST_LDADD)
+nodist_fuzz_sigpcap_SOURCES = tests/fuzz/fuzz_sigpcap.c
+fuzz_sigpcap_LDFLAGS = $(LDFLAGS_FUZZ)
+fuzz_sigpcap_LDADD = $(LDADD_FUZZ)
 if HAS_FUZZLDFLAGS
     fuzz_sigpcap_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else
@@ -659,9 +666,9 @@ endif
 # force usage of CXX for linker
 nodist_EXTRA_fuzz_sigpcap_SOURCES = force-cxx-linking.cxx
 
-nodist_fuzz_mimedecparseline_SOURCES = tests/fuzz/fuzz_mimedecparseline.c $(COMMON_SOURCES)
-fuzz_mimedecparseline_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
-fuzz_mimedecparseline_LDADD = $(RUST_SURICATA_LIB) $(HTP_LDADD) $(RUST_LDADD)
+nodist_fuzz_mimedecparseline_SOURCES = tests/fuzz/fuzz_mimedecparseline.c
+fuzz_mimedecparseline_LDFLAGS = $(LDFLAGS_FUZZ)
+fuzz_mimedecparseline_LDADD = $(LDADD_FUZZ)
 if HAS_FUZZLDFLAGS
     fuzz_mimedecparseline_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else

--- a/src/rust-context.h
+++ b/src/rust-context.h
@@ -25,6 +25,8 @@
 #include "app-layer-snmp.h" //SNMPState, SNMPTransaction
 #include "app-layer-tftp.h" //TFTPState, TFTPTransaction
 
+struct AppLayerParser;
+
 typedef struct SuricataContext_ {
     SCError (*SCLogMessage)(const SCLogLevel, const char *, const unsigned int,
             const char *, const SCError, const char *message);
@@ -45,6 +47,8 @@ typedef struct SuricataContext_ {
     void (*FileContainerRecycle)(FileContainer *ffc);
     void (*FilePrune)(FileContainer *ffc);
     void (*FileSetTx)(FileContainer *, uint64_t);
+
+    int (*AppLayerRegisterParser)(const struct AppLayerParser *p, AppProto alproto);
 
 } SuricataContext;
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -113,6 +113,7 @@
 
 #include "app-layer.h"
 #include "app-layer-parser.h"
+#include "app-layer-register.h"
 #include "app-layer-htp.h"
 #include "app-layer-ssl.h"
 #include "app-layer-ssh.h"
@@ -2668,6 +2669,8 @@ int InitGlobal(void) {
     suricata_context.FileContainerRecycle = FileContainerRecycle;
     suricata_context.FilePrune = FilePrune;
     suricata_context.FileSetTx = FileContainerSetTx;
+
+    suricata_context.AppLayerRegisterParser = AppLayerRegisterParser;
 
     rs_init(&suricata_context);
 


### PR DESCRIPTION
This PR moves one C method called by Rust into the "rust context" of C function pointers prevent a circular reference that prevented us from using autotools/libtool convenience wrappers. Then we make use of this convenience library for Suricata and all the fuzz applications, which is how we should have done this in the first place.

This is a precursor to upcoming lib work, but want to see this simple step pass all QA.