### PR TITLE
detect/http-client-body: Improved support for shared bufs

### DIFF
--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -227,12 +227,11 @@ static int DetectEngineInspectBufferHttpBody(DetectEngineCtx *de_ctx,
     int r = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f, (uint8_t *)data,
             data_len, offset, ci_flags, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
 
-    /* move inspected tracker to end of the data. HtpBodyPrune will consider
+    /* Set to move inspected tracker to end of the data. HtpBodyPrune will consider
      * the window sizes when freeing data */
-    htp_tx_t *tx = txv;
-    HtpBody *body = GetResponseBody(tx);
-    body->body_inspected = body->content_len_so_far;
-    SCLogDebug("body->body_inspected now: %" PRIu64, body->body_inspected);
+    HtpBody *body = GetResponseBody(txv);
+    det_ctx->http_body_progress_updated = true;
+    det_ctx->http_body_progress = body->content_len_so_far;
 
     if (r == 1) {
         return DETECT_ENGINE_INSPECT_SIG_MATCH;

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -314,22 +314,20 @@ static int DetectEngineInspectBufferHttpRequest(DetectEngineCtx *de_ctx,
     int r = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f, (uint8_t *)data,
             data_len, offset, ci_flags, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
 
-    /* move inspected tracker to end of the data. HtpBodyPrune will consider
+    /* Set to move inspected tracker to end of the data. HtpBodyPrune will consider
      * the window sizes when freeing data */
+
+    HtpBody *body = GetRequestBody(txv);
+    det_ctx->http_body_progress_updated = true;
+    det_ctx->http_body_progress = body->content_len_so_far;
 
     if (r == 1) {
         return DETECT_ENGINE_INSPECT_SIG_MATCH;
     }
 
-    if (flags & STREAM_TOSERVER) {
-        if (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP, txv, flags) >
-                HTP_REQUEST_BODY)
-            return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH;
-    } else {
-        if (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP, txv, flags) >
-                HTP_RESPONSE_BODY)
-            return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH;
-    }
+    if (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP, txv, flags) > HTP_REQUEST_BODY)
+        return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH;
+
     return DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
 }
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2017 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -32,6 +32,7 @@
 #include "stream-tcp.h"
 #include "app-layer.h"
 #include "app-layer-parser.h"
+#include "app-layer-htp.h"
 
 #include "detect.h"
 #include "detect-engine.h"
@@ -941,6 +942,32 @@ static inline void DetectRunPostRules(
     PACKET_PROFILING_DETECT_END(p, PROF_DETECT_ALERT);
 }
 
+static inline HtpBody *GetBody(const uint8_t flow_flags, void *tx)
+{
+    htp_tx_t *htx = tx;
+    HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(htx);
+    if (htud == NULL) {
+        SCLogDebug("no htud");
+        return NULL;
+    }
+
+    return flow_flags & STREAM_TOSERVER ? &htud->request_body : &htud->response_body;
+}
+
+static void DetectRunTxCleanup(
+        DetectEngineThreadCtx *det_ctx, const AppProto alproto, const uint8_t flow_flags, void *tx)
+{
+    if (alproto == ALPROTO_HTTP && det_ctx->http_body_progress_updated) {
+        HtpBody *body = GetBody(flow_flags, tx);
+        if (body) {
+            body->body_inspected = det_ctx->http_body_progress;
+            det_ctx->http_body_progress_updated = false;
+            SCLogDebug("body->inspected = %" PRIu64 " body->content_len_so_far = %" PRIu64,
+                    body->body_inspected, body->content_len_so_far);
+        }
+    }
+}
+
 static void DetectRunCleanup(DetectEngineThreadCtx *det_ctx,
         Packet *p, Flow * const pflow)
 {
@@ -1523,6 +1550,10 @@ static void DetectRunTx(ThreadVars *tv,
 
             StoreDetectFlags(&tx, flow_flags, ipproto, alproto, new_detect_flags);
         }
+        if (new_detect_flags & APP_LAYER_TX_INSPECTED_FLAG) {
+            DetectRunTxCleanup(det_ctx, alproto, flow_flags, tx.tx_ptr);
+        }
+
 next:
         InspectionBufferClean(det_ctx);
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1133,6 +1133,10 @@ typedef struct DetectEngineThreadCtx_ {
 
     AppLayerDecoderEvents *decoder_events;
     uint16_t events;
+
+    /** signal when HTTP body progress should be updated */
+    bool http_body_progress_updated;
+    uint64_t http_body_progress;
 
 #ifdef DEBUG
     uint64_t pkt_stream_add_cnt;


### PR DESCRIPTION
Continuation of #5778

This commit improves support for shared buffer usage, i.e., when
multiple rules share the HTTP client body and apply different
combinations of transforms and fast_patterns (or none).

Redmine issue: [4199](https://redmine.openinfosecfoundation.org/issues/4199)

Describe changes:
- Incorporate review comments.

suricata-verify-pr: 420
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
