### PR TITLE
detect/pcre: Capture count validation check 

### DIFF
--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -3552,6 +3552,11 @@ static int DetectPcreParseCaptureTest(void)
     s = DetectEngineAppendSig(de_ctx, "alert http any any -> any any "
             "(content:\"Server: \"; http_header; pcre:\"/([a-z]+)([0-9]+)\\r\\n/HR, flow:somecapture, pkt:anothercap\"; content:\"xyz\"; http_header; sid:3;)");
     FAIL_IF(s == NULL);
+    s = DetectEngineAppendSig(de_ctx,
+            "alert http any any -> any any "
+            "(content:\"Server: \"; http_header; pcre:\"/([a-z]+)\\r\\n/HR, flow:somecapture, "
+            "pkt:anothercap\"; content:\"xyz\"; http_header; sid:3;)");
+    FAIL_IF_NOT_NULL(s);
 
     SigGroupBuild(de_ctx);
 

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -723,7 +723,7 @@ static int DetectPcreParseCapture(const char *regexstr, DetectEngineCtx *de_ctx,
     {
         char *ptr = NULL;
         while ((name_array[name_idx] = strtok_r(name_idx == 0 ? capture_names : NULL, " ,", &ptr))){
-            if (name_idx > capture_cnt) {
+            if (name_idx > (capture_cnt - 1)) {
                 SCLogError(SC_ERR_VAR_LIMIT, "more pkt/flow "
                         "var capture names than capturing substrings");
                 return -1;


### PR DESCRIPTION
Continuation of #5826 
This PR fixes the validation check between the capture count in the PCRE and the number of variables to extract.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4261](https://redmine.openinfosecfoundation.org/issues/4261)

Describe changes:
- `clang-format` fixups
- 
#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
