### PR TITLE
util/thash: fix memcap consolidate function

### DIFF
--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -336,7 +336,7 @@ THashTableContext *THashInit(const char *cnf_prefix, size_t data_size,
  * */
 void THashConsolidateMemcap(THashTableContext *ctx)
 {
-    ctx->config.memcap = MAX(SC_ATOMIC_GET(ctx->memuse), THASH_DEFAULT_MEMCAP);
+    ctx->config.memcap = MAX(SC_ATOMIC_GET(ctx->memuse), ctx->config.memcap);
     SCLogDebug("memcap after load set to: %" PRIu64, ctx->config.memcap);
 }
 


### PR DESCRIPTION
The function THashConsolidateMemcap is used to allow to load a dataset even when the memcap is not set. But the implementation was in fact resetting the memcap value to the max of memory usage after loading and default memcap. As a result, the function was resetting memcap to the default memcap even if a huge memcap was set in the dataset definition. In the case of dataset where we add to the set it was leading to memcap limit hitting despite the settings of memcap by the user.

This patch udpates the code to set the final memcap value to the max of memory usage after loading and set memcap.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4275

Describe changes:
- Fix THashConsolidateMemcap function