### PR TITLE
Ossfuzz corp v7

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,7 +1,7 @@
 codecov:
   require_ci_to_pass: yes
   notify:
-    after_n_builds: 2
+    after_n_builds: 3
 
 coverage:
   precision: 2

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -666,6 +666,82 @@ jobs:
         with:
           flags: unittests
 
+  ubuntu-20-04-cov-fuzz:
+    name: Ubuntu 20.04 (fuzz corpus coverage)
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
+    needs: [prepare-deps, prepare-cbindgen]
+    steps:
+      - name: Install dependencies
+        run: |
+          apt update
+          apt -y install \
+                libpcre3 \
+                libpcre3-dev \
+                build-essential \
+                autoconf \
+                automake \
+                llvm-10 \
+                clang-10 \
+                git \
+                jq \
+                libc++-dev \
+                libc++abi-dev \
+                libtool \
+                libpcap-dev \
+                libnet1-dev \
+                libyaml-0-2 \
+                libyaml-dev \
+                libcap-ng-dev \
+                libcap-ng0 \
+                libmagic-dev \
+                libnetfilter-queue-dev \
+                libnetfilter-queue1 \
+                libnfnetlink-dev \
+                libnfnetlink0 \
+                libhiredis-dev \
+                liblua5.1-dev \
+                libjansson-dev \
+                libevent-dev \
+                libevent-pthreads-2.1-7 \
+                libjansson-dev \
+                libpython2.7 \
+                make \
+                parallel \
+                python3-yaml \
+                rustc \
+                software-properties-common \
+                zlib1g \
+                zlib1g-dev \
+                exuberant-ctags \
+                unzip \
+                curl \
+                wget
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/libhtp.tar.gz
+      - name: Setup cbindgen
+        run: |
+          mkdir -p $HOME/.cargo/bin
+          cp prep/cbindgen $HOME/.cargo/bin
+          chmod 755 $HOME/.cargo/bin/cbindgen
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: ./autogen.sh
+      - run: LIB_FUZZING_ENGINE="fail_to_onefile_driver" CC=clang-10 CXX=clang++-10 CFLAGS="-fprofile-arcs -ftest-coverage -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -fPIC -Wno-unused-parameter -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1" CXXFLAGS="-fprofile-arcs -ftest-coverage -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -stdlib=libc++" ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes ./configure --with-gnu-ld --enable-fuzztargets --disable-shared --enable-gccprotect
+      - run: make -j2
+      - run: ./qa/run-ossfuzz-corpus.sh
+      - name: Gcov
+        run: |
+          cd src
+          llvm-cov-10 gcov -p *.c
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          flags: fuzzcorpus
+
   ubuntu-20-04-ndebug:
     name: Ubuntu 20.04 (-DNDEBUG)
     runs-on: ubuntu-latest

--- a/qa/run-ossfuzz-corpus.sh
+++ b/qa/run-ossfuzz-corpus.sh
@@ -1,0 +1,13 @@
+#/bin/sh
+ls src/fuzz_* | while read ftarget
+do
+    target=$(basename $ftarget)
+    echo "target $target"
+    #download public corpus
+    rm -f public.zip
+    wget --quiet "https://storage.googleapis.com/suricata-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/suricata_$target/public.zip"
+    rm -rf corpus_$target
+    unzip -q public.zip -d corpus_$target
+    #run target on corpus.
+    ./src/$target corpus_$target
+done

--- a/src/decode-chdlc.c
+++ b/src/decode-chdlc.c
@@ -51,6 +51,7 @@ int DecodeCHDLC(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     if (unlikely(len > CHDLC_HEADER_LEN + USHRT_MAX)) {
         return TM_ECODE_FAILED;
     }
+    PACKET_INCREASE_CHECK_LAYERS(p);
 
     CHDLCHdr *hdr = (CHDLCHdr *)pkt;
     if (unlikely(hdr == NULL))

--- a/src/decode-erspan.c
+++ b/src/decode-erspan.c
@@ -80,6 +80,7 @@ int DecodeERSPAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
         ENGINE_SET_EVENT(p,ERSPAN_HEADER_TOO_SMALL);
         return TM_ECODE_FAILED;
     }
+    PACKET_INCREASE_CHECK_LAYERS(p);
 
     const ErspanHdr *ehdr = (const ErspanHdr *)pkt;
     uint16_t version = SCNtohs(ehdr->ver_vlan) >> 12;

--- a/src/decode-esp.c
+++ b/src/decode-esp.c
@@ -65,6 +65,7 @@ int DecodeESP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *p
         CLEAR_ESP_PACKET(p);
         return TM_ECODE_FAILED;
     }
+    PACKET_INCREASE_CHECK_LAYERS(p);
 
     SCLogDebug("ESP spi: %" PRIu32 " sequence: %" PRIu32, ESP_GET_SPI(p), ESP_GET_SEQUENCE(p));
 

--- a/src/decode-ethernet.c
+++ b/src/decode-ethernet.c
@@ -38,6 +38,8 @@
 #include "util-unittest.h"
 #include "util-debug.h"
 
+#define MAX_ETH_OFFSET 256
+
 int DecodeEthernet(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                    const uint8_t *pkt, uint32_t len)
 {
@@ -48,6 +50,7 @@ int DecodeEthernet(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         return TM_ECODE_FAILED;
     }
 
+    PACKET_INCREASE_CHECK_LAYERS(p);
     p->ethh = (EthernetHdr *)pkt;
     if (unlikely(p->ethh == NULL))
         return TM_ECODE_FAILED;

--- a/src/decode-geneve.c
+++ b/src/decode-geneve.c
@@ -194,6 +194,7 @@ int DecodeGeneve(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
 
     if (unlikely(len < GENEVE_MIN_HEADER_LEN))
         return TM_ECODE_FAILED;
+    PACKET_INCREASE_CHECK_LAYERS(p);
 
     /* Specific Geneve header field validation */
     geneve_hdr_len = GENEVE_TOTAL_HEADER_LEN(geneve_hdr);

--- a/src/decode-gre.c
+++ b/src/decode-gre.c
@@ -54,6 +54,7 @@ int DecodeGRE(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *p
         ENGINE_SET_INVALID_EVENT(p, GRE_PKT_TOO_SMALL);
         return TM_ECODE_FAILED;
     }
+    PACKET_INCREASE_CHECK_LAYERS(p);
 
     p->greh = (GREHdr *)pkt;
     if(p->greh == NULL)

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -527,6 +527,7 @@ int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         CLEAR_IPV4_PACKET((p));
         return TM_ECODE_FAILED;
     }
+    PACKET_INCREASE_CHECK_LAYERS(p);
     p->proto = IPV4_GET_IPPROTO(p);
 
     /* If a fragment, pass off for re-assembly. */

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -571,6 +571,7 @@ int DecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *
         CLEAR_IPV6_PACKET(p);
         return TM_ECODE_FAILED;
     }
+    PACKET_INCREASE_CHECK_LAYERS(p);
 
 #ifdef DEBUG
     if (SCLogDebugEnabled()) { /* only convert the addresses if debug is really enabled */

--- a/src/decode-mpls.c
+++ b/src/decode-mpls.c
@@ -58,6 +58,7 @@ int DecodeMPLS(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             ENGINE_SET_INVALID_EVENT(p, MPLS_HEADER_TOO_SMALL);
             return TM_ECODE_FAILED;
         }
+        PACKET_INCREASE_CHECK_LAYERS(p);
         memcpy(&shim, pkt, sizeof(shim));
         pkt += MPLS_HEADER_LEN;
         len -= MPLS_HEADER_LEN;

--- a/src/decode-nsh.c
+++ b/src/decode-nsh.c
@@ -51,6 +51,7 @@ int DecodeNSH(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *p
         ENGINE_SET_INVALID_EVENT(p, NSH_HEADER_TOO_SMALL);
         return TM_ECODE_FAILED;
     }
+    PACKET_INCREASE_CHECK_LAYERS(p);
 
     /* Sanity check the header version */
     const NshHdr *hdr = (const NshHdr *)pkt;

--- a/src/decode-ppp.c
+++ b/src/decode-ppp.c
@@ -49,6 +49,7 @@ int DecodePPP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         ENGINE_SET_INVALID_EVENT(p, PPP_PKT_TOO_SMALL);
         return TM_ECODE_FAILED;
     }
+    PACKET_INCREASE_CHECK_LAYERS(p);
 
     p->ppph = (PPPHdr *)pkt;
     if (unlikely(p->ppph == NULL))

--- a/src/decode-sll.c
+++ b/src/decode-sll.c
@@ -45,6 +45,7 @@ int DecodeSll(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         ENGINE_SET_INVALID_EVENT(p, SLL_PKT_TOO_SMALL);
         return TM_ECODE_FAILED;
     }
+    PACKET_INCREASE_CHECK_LAYERS(p);
 
     SllHdr *sllh = (SllHdr *)pkt;
     if (unlikely(sllh == NULL))

--- a/src/decode-template.c
+++ b/src/decode-template.c
@@ -62,6 +62,7 @@ int DecodeTEMPLATE(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         //ENGINE_SET_EVENT(p,TEMPLATE_HEADER_TOO_SMALL);
         return TM_ECODE_FAILED;
     }
+    PACKET_INCREASE_CHECK_LAYERS(p);
 
     /* Now we can access the header */
     const TemplateHdr *hdr = (const TemplateHdr *)pkt;

--- a/src/decode-vlan.c
+++ b/src/decode-vlan.c
@@ -70,6 +70,7 @@ int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         ENGINE_SET_INVALID_EVENT(p, VLAN_HEADER_TOO_SMALL);
         return TM_ECODE_FAILED;
     }
+    PACKET_INCREASE_CHECK_LAYERS(p);
     if (p->vlan_idx >= 2) {
         ENGINE_SET_EVENT(p,VLAN_HEADER_TOO_MANY_LAYERS);
         return TM_ECODE_FAILED;

--- a/src/decode-vxlan.c
+++ b/src/decode-vxlan.c
@@ -136,6 +136,7 @@ int DecodeVXLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 
     if (len < (VXLAN_HEADER_LEN + sizeof(EthernetHdr)))
         return TM_ECODE_FAILED;
+    PACKET_INCREASE_CHECK_LAYERS(p);
 
     const VXLANHeader *vxlanh = (const VXLANHeader *)pkt;
     if ((vxlanh->flags[0] & 0x08) == 0 || vxlanh->res != 0)

--- a/src/decode.c
+++ b/src/decode.c
@@ -73,7 +73,9 @@ extern bool stats_decoder_events;
 extern const char *stats_decoder_events_prefix;
 extern bool stats_stream_events;
 
-int DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+static int DecodeTunnel(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t, enum DecodeTunnelProto) WARN_UNUSED;
+
+static int DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         const uint8_t *pkt, uint32_t len, enum DecodeTunnelProto proto)
 {
     switch (proto) {

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -262,7 +262,7 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
 #undef MAX_SUBSTRINGS
 #define MAX_SUBSTRINGS 100
     int ov[MAX_SUBSTRINGS];
-    char tmp_str[128];
+    char tmp_str[128] = "";
 
     ret = DetectParsePcreExec(&parse_regex, arg, 0, 0, ov, MAX_SUBSTRINGS);
     if (ret < MIN_GROUP || ret > MAX_GROUP) {

--- a/src/tests/fuzz/onefile.c
+++ b/src/tests/fuzz/onefile.c
@@ -1,25 +1,19 @@
+#define _DEFAULT_SOURCE 1 // for DT_REG
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <dirent.h>
+#include <unistd.h>
 #include "autoconf.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 
-int main(int argc, char** argv)
+static int runOneFile(const char *fname)
 {
-    FILE * fp;
+    // opens the file, get its size, and reads it into a buffer
     uint8_t *data;
     size_t size;
-
-    if (argc != 2) {
-        return 1;
-    }
-#ifdef AFLFUZZ_PERSISTANT_MODE
-    while (__AFL_LOOP(1000)) {
-#endif /* AFLFUZZ_PERSISTANT_MODE */
-
-    //opens the file, get its size, and reads it into a buffer
-    fp = fopen(argv[1], "rb");
+    FILE *fp = fopen(fname, "rb");
     if (fp == NULL) {
         return 2;
     }
@@ -51,10 +45,50 @@ int main(int argc, char** argv)
     LLVMFuzzerTestOneInput(data, size);
     free(data);
     fclose(fp);
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    DIR *d;
+    struct dirent *dir;
+    int r;
+
+    if (argc != 2) {
+        return 1;
+    }
+#ifdef AFLFUZZ_PERSISTANT_MODE
+    while (__AFL_LOOP(1000)) {
+#endif /* AFLFUZZ_PERSISTANT_MODE */
+
+        d = opendir(argv[1]);
+        if (d == NULL) {
+            // run one file
+            r = runOneFile(argv[1]);
+            if (r != 0) {
+                return r;
+            }
+        } else {
+            // run every file in one directory
+            if (chdir(argv[1]) != 0) {
+                closedir(d);
+                printf("Invalid directory\n");
+                return 2;
+            }
+            while ((dir = readdir(d)) != NULL) {
+                if (dir->d_type != DT_REG) {
+                    continue;
+                }
+                r = runOneFile(dir->d_name);
+                if (r != 0) {
+                    return r;
+                }
+            }
+            closedir(d);
+        }
 #ifdef AFLFUZZ_PERSISTANT_MODE
     }
 #endif /* AFLFUZZ_PERSISTANT_MODE */
 
     return 0;
 }
-

--- a/src/tests/fuzz/onefile.c
+++ b/src/tests/fuzz/onefile.c
@@ -1,10 +1,4 @@
-#define _DEFAULT_SOURCE 1 // for DT_REG
-#include <stdint.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <dirent.h>
-#include <unistd.h>
-#include "autoconf.h"
+#include "suricata-common.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4125

Describe changes:
- Runs CI on public corpuses of fuzz targets for coverage and ASAN bugs
- simple fuzz driver can run on flat directories (not only files)
- fix bug of uninitialized memory in `bytemath` keyword parsing
- fix bug by avoiding over recursion between `DecodeEthernet` and `DecodeMPLS`

Modifies #5811 by counting the total number of layers so that too much recursion can't happen anywhere (and adding a field to the structure Packet to do so)
