### PR TITLE
suricata: indicate that Suricata is ready for packets.

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1519,6 +1519,9 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
     fds.fd = ptv->socket;
     fds.events = POLLIN;
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
     while (1) {
         /* Start by checking the state of our interface */
         if (unlikely(ptv->afp_state == AFP_STATE_DOWN)) {

--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -335,6 +335,8 @@ ReceiveErfDagLoop(ThreadVars *tv, void *data, void *slot)
 
     dtv->slot = s->slot_next;
 
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (1) {
         if (suricata_ctl_flags & SURICATA_STOP) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/source-erf-file.c
+++ b/src/source-erf-file.c
@@ -115,6 +115,8 @@ TmEcode ReceiveErfFileLoop(ThreadVars *tv, void *data, void *slot)
 
     etv->slot = ((TmSlot *)slot)->slot_next;
 
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (1) {
         if (suricata_ctl_flags & SURICATA_STOP) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -237,6 +237,8 @@ TmEcode ReceiveIPFWLoop(ThreadVars *tv, void *data, void *slot)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     SCLogInfo("Thread '%s' will run on port %d (item %d)",
               tv->name, nq->port_num, ptv->ipfw_index);
     while (1) {

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -905,6 +905,8 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
     TmSlot *s = (TmSlot *) slot;
     ntv->slot = s->slot_next;
 
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (!(suricata_ctl_flags & SURICATA_STOP)) {
         /* make sure we have at least one packet in the packet pool, to prevent
          * us from alloc'ing packets at line rate */

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -608,6 +608,8 @@ static TmEcode ReceiveNetmapLoop(ThreadVars *tv, void *data, void *slot)
     fds.fd = ntv->ifsrc->nmd->fd;
     fds.events = POLLIN;
 
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     for(;;) {
         if (unlikely(suricata_ctl_flags != 0)) {
             break;

--- a/src/source-nflog.c
+++ b/src/source-nflog.c
@@ -427,6 +427,8 @@ TmEcode ReceiveNFLOGLoop(ThreadVars *tv, void *data, void *slot)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (1) {
         if (suricata_ctl_flags != 0)
             break;

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -1005,6 +1005,8 @@ TmEcode ReceiveNFQLoop(ThreadVars *tv, void *data, void *slot)
 
     ntv->slot = ((TmSlot *) slot)->slot_next;
 
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while(1) {
         if (unlikely(suricata_ctl_flags != 0)) {
             NFQDestroyQueue(nq);

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -169,6 +169,8 @@ TmEcode ReceivePcapFileLoop(ThreadVars *tv, void *data, void *slot)
     ptv->shared.slot = s->slot_next;
     ptv->shared.cb_result = TM_ECODE_OK;
 
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     if(ptv->is_directory == 0) {
         SCLogInfo("Starting file run for %s", ptv->behavior.file->filename);
         status = PcapFileDispatch(ptv->behavior.file);

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -310,6 +310,8 @@ static TmEcode ReceivePcapLoop(ThreadVars *tv, void *data, void *slot)
     ptv->slot = s->slot_next;
     ptv->cb_result = TM_ECODE_OK;
 
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (1) {
         if (suricata_ctl_flags & SURICATA_STOP) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -360,6 +360,9 @@ TmEcode ReceivePfringLoop(ThreadVars *tv, void *data, void *slot)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
     while(1) {
         if (suricata_ctl_flags & SURICATA_STOP) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/source-windivert.c
+++ b/src/source-windivert.c
@@ -410,6 +410,8 @@ TmEcode ReceiveWinDivertLoop(ThreadVars *tv, void *data, void *slot)
     WinDivertThreadVars *wd_tv = (WinDivertThreadVars *)data;
     wd_tv->slot = ((TmSlot *)slot)->slot_next;
 
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (true) {
         if (suricata_ctl_flags & SURICATA_STOP) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -232,6 +232,10 @@ uint16_t g_vlan_mask = 0xffff;
  * support */
 bool g_disable_hashing = false;
 
+/* What for worker threads to indicate they're running before indicating that
+ * Suricata has started */
+bool g_sync_workers = false;
+
 /** Suricata instance */
 SCInstance suricata;
 
@@ -631,6 +635,8 @@ static void PrintUsage(const char *progname)
     printf("\t--reject-dev <dev>                   : send reject packets from this interface\n");
 #endif
     printf("\t--set name=value                     : set a configuration value\n");
+    printf("\t--sync-workers                       : wait for all workers to start before logging "
+           "that Suricata has started\n");
     printf("\n");
     printf("\nTo run the engine with default configuration on "
             "interface eth0 with signature file \"signatures.rules\", run the "
@@ -1240,6 +1246,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #ifdef HAVE_NFLOG
         {"nflog", optional_argument, 0, 0},
 #endif
+	{"sync-workers", optional_argument, 0, 0},
         {NULL, 0, NULL, 0}
     };
     // clang-format on
@@ -1606,6 +1613,8 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 if (suri->strict_rule_parsing_string == NULL) {
                     FatalError(SC_ERR_MEM_ALLOC, "failed to duplicate 'strict' string");
                 }
+            } else if (strcmp((long_opts[option_index]).name, "sync-workers") == 0) {
+                g_sync_workers = true;
             }
             break;
         case 'c':
@@ -2615,6 +2624,7 @@ int PostConfLoadedSetup(SCInstance *suri)
 
 static void SuricataMainLoop(SCInstance *suri)
 {
+    SCLogNotice("Suricata Main Loop Started");
     while(1) {
         if (sigterm_count || sigint_count) {
             suricata_ctl_flags |= SURICATA_STOP;
@@ -2800,8 +2810,12 @@ int SuricataMain(int argc, char **argv)
     SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);
     PacketPoolPostRunmodes();
 
-    /* Un-pause all the paused threads */
+    /* Un-pause all the paused threads, and wait for them to start */
     TmThreadContinueThreads();
+    if (g_sync_workers) {
+        TmThreadEnsureUnpaused();
+        TmThreadEnsureRunning();
+    }
 
     PostRunStartedDetectSetup(&suricata);
 

--- a/src/threadvars.h
+++ b/src/threadvars.h
@@ -54,6 +54,7 @@ struct TmSlot_;
  *  rule reloads even if no packets are read by the capture method. */
 #define THV_CAPTURE_INJECT_PKT  BIT_U32(11)
 #define THV_DEAD                BIT_U32(12) /**< thread has been joined with pthread_join() */
+#define THV_RUNNING             BIT_U32(13) /**< thread is running */
 
 /** \brief Per thread variable structure */
 typedef struct ThreadVars_ {

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -437,6 +437,7 @@ static void *TmThreadsSlotVar(void *td)
 
     s = (TmSlot *)tv->tm_slots;
 
+    TmThreadsSetFlag(tv, THV_RUNNING);
     while (run) {
         if (TmThreadsCheckFlag(tv, THV_PAUSE)) {
             TmThreadsSetFlag(tv, THV_PAUSED);
@@ -1839,6 +1840,64 @@ void TmThreadContinueThreads()
         }
     }
     SCMutexUnlock(&tv_root_lock);
+    return;
+}
+
+void TmThreadEnsureUnpaused()
+{
+    ThreadVars *tv = NULL;
+    int i = 0;
+    int paused_threads = 0;
+
+    SCMutexLock(&tv_root_lock);
+
+    do {
+        paused_threads = 0;
+        for (i = 0; i < TVT_MAX; i++) {
+            tv = tv_root[i];
+            while (tv != NULL) {
+                if (TmThreadsCheckFlag(tv, THV_PAUSED)) {
+                    paused_threads++;
+                }
+                tv = tv->next;
+            }
+        }
+        if (paused_threads) {
+            SCLogDebug("%u threads paused; waiting 100us for them to unpause", paused_threads);
+            SleepUsec(100);
+        }
+    } while (paused_threads != 0);
+
+    SCMutexUnlock(&tv_root_lock);
+
+    return;
+}
+
+void TmThreadEnsureRunning()
+{
+    ThreadVars *tv = NULL;
+    int non_running_threads = 0;
+
+    SCMutexLock(&tv_root_lock);
+
+    do {
+        non_running_threads = 0;
+        tv = tv_root[TVT_PPT];
+        while (tv != NULL) {
+            if (!TmThreadsCheckFlag(tv, THV_RUNNING)) {
+                non_running_threads++;
+            }
+            tv = tv->next;
+        }
+        if (non_running_threads) {
+            SCLogDebug(
+                    "%u threads not running; waiting 100us for them to run", non_running_threads);
+            SleepUsec(100);
+        }
+    } while (non_running_threads != 0);
+
+    SCMutexUnlock(&tv_root_lock);
+
     return;
 }
 

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -109,6 +109,8 @@ void TmThreadInitMC(ThreadVars *);
 void TmThreadTestThreadUnPaused(ThreadVars *);
 void TmThreadContinue(ThreadVars *);
 void TmThreadContinueThreads(void);
+void TmThreadEnsureUnpaused(void);
+void TmThreadEnsureRunning(void);
 void TmThreadPause(ThreadVars *);
 void TmThreadPauseThreads(void);
 void TmThreadCheckThreadState(void);

--- a/src/tmqh-flow.c
+++ b/src/tmqh-flow.c
@@ -32,6 +32,7 @@
 #include "decode.h"
 #include "threads.h"
 #include "threadvars.h"
+#include "tm-threads.h"
 #include "tmqh-flow.h"
 
 #include "tm-queuehandlers.h"

--- a/src/tmqh-simple.c
+++ b/src/tmqh-simple.c
@@ -28,6 +28,7 @@
 #include "decode.h"
 #include "threads.h"
 #include "threadvars.h"
+#include "tm-threads.h"
 
 #include "tm-queuehandlers.h"
 #include "tmqh-simple.h"


### PR DESCRIPTION
Depending on the configuration used, the time it takes for
Suricata to initialize and have worker threads ready to
process packets can vary dramatically.

In order to facility quicker end-to-end/integration
tests, having an indication for when this state has
been reached would be beneficial.

This change first waits for workers to unpause, and then
waits for them to actively enter their packet polling loops
before outputting an log string which test frameworks
can use to determine that Suricata is ready to process packets.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Previous PR: https://github.com/OISF/suricata/pull/5800

Describe changes:
-
-
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:

