### PR TITLE
Improve midstream pickup of TCP flows at SYN/ACK stage

### DIFF
--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -348,7 +348,9 @@ int FlowForceReassemblyNeedReassembly(Flow *f)
  */
 void FlowForceReassemblyForFlow(Flow *f)
 {
-    const int thread_id = (int)f->thread_id[0];
+    /* if we only saw server->client traffic, then thread_id[TO_SERVER]
+     * will be 0, so choose thread_id[TO_CLIENT] */
+    const int thread_id = (int)(f->thread_id[0] != 0 ? f->thread_id[0] : f->thread_id[1]);
     TmThreadsInjectFlowById(f, thread_id);
 }
 

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -26,6 +26,7 @@
 #include "suricata-common.h"
 #include "threads.h"
 
+#include "stream-tcp.h"
 #include "flow.h"
 #include "flow-private.h"
 #include "flow-util.h"
@@ -152,27 +153,28 @@ void FlowInit(Flow *f, const Packet *p)
     f->vlan_idx = p->vlan_idx;
     f->livedev = p->livedev;
 
-    if (PKT_IS_IPV4(p)) {
-        FLOW_SET_IPV4_SRC_ADDR_FROM_PACKET(p, &f->src);
-        FLOW_SET_IPV4_DST_ADDR_FROM_PACKET(p, &f->dst);
-        f->min_ttl_toserver = f->max_ttl_toserver = IPV4_GET_IPTTL((p));
-        f->flags |= FLOW_IPV4;
-    } else if (PKT_IS_IPV6(p)) {
-        FLOW_SET_IPV6_SRC_ADDR_FROM_PACKET(p, &f->src);
-        FLOW_SET_IPV6_DST_ADDR_FROM_PACKET(p, &f->dst);
-        f->min_ttl_toserver = f->max_ttl_toserver = IPV6_GET_HLIM((p));
-        f->flags |= FLOW_IPV6;
-    }
-#ifdef DEBUG
-    /* XXX handle default */
-    else {
-        printf("FIXME: %s:%s:%" PRId32 "\n", __FILE__, __FUNCTION__, __LINE__);
-    }
-#endif
+    int pkt_is_from_client = 1;
 
     if (p->tcph != NULL) { /* XXX MACRO */
-        SET_TCP_SRC_PORT(p,&f->sp);
-        SET_TCP_DST_PORT(p,&f->dp);
+        /* If the first packet to be seen by suricata is a TCP SYNACK then it's from
+         * the server rather than the client, and the flow direction should be set
+         * accordingly. But only do this if midstream flow pickup or async flows are
+         * enabled in config, as these are required for the TCP session state to be
+         * tracked.
+         */
+        if (stream_config.midstream == TRUE || stream_config.async_oneside == TRUE) {
+            if ((p->tcph->th_flags & (TH_SYN | TH_ACK)) == (TH_SYN | TH_ACK)) {
+                pkt_is_from_client = 0;
+            }
+        }
+
+        if (likely(pkt_is_from_client)) {
+            SET_TCP_SRC_PORT(p, &f->sp);
+            SET_TCP_DST_PORT(p, &f->dp);
+        } else {
+            SET_TCP_SRC_PORT(p, &f->dp);
+            SET_TCP_DST_PORT(p, &f->sp);
+        }
     } else if (p->udph != NULL) { /* XXX MACRO */
         SET_UDP_SRC_PORT(p,&f->sp);
         SET_UDP_DST_PORT(p,&f->dp);
@@ -195,6 +197,37 @@ void FlowInit(Flow *f, const Packet *p)
         printf("FIXME: %s:%s:%" PRId32 "\n", __FILE__, __FUNCTION__, __LINE__);
     }
 #endif
+
+    if (PKT_IS_IPV4(p)) {
+        if (likely(pkt_is_from_client)) {
+            FLOW_SET_IPV4_SRC_ADDR_FROM_PACKET(p, &f->src);
+            FLOW_SET_IPV4_DST_ADDR_FROM_PACKET(p, &f->dst);
+            f->min_ttl_toserver = f->max_ttl_toserver = IPV4_GET_IPTTL((p));
+        } else {
+            FLOW_SET_IPV4_SRC_ADDR_FROM_PACKET(p, &f->dst);
+            FLOW_SET_IPV4_DST_ADDR_FROM_PACKET(p, &f->src);
+            f->min_ttl_toclient = f->max_ttl_toclient = IPV4_GET_IPTTL((p));
+        }
+        f->flags |= FLOW_IPV4;
+    } else if (PKT_IS_IPV6(p)) {
+        if (likely(pkt_is_from_client)) {
+            FLOW_SET_IPV6_SRC_ADDR_FROM_PACKET(p, &f->src);
+            FLOW_SET_IPV6_DST_ADDR_FROM_PACKET(p, &f->dst);
+            f->min_ttl_toserver = f->max_ttl_toserver = IPV6_GET_HLIM((p));
+        } else {
+            FLOW_SET_IPV6_SRC_ADDR_FROM_PACKET(p, &f->dst);
+            FLOW_SET_IPV6_DST_ADDR_FROM_PACKET(p, &f->src);
+            f->min_ttl_toclient = f->max_ttl_toclient = IPV6_GET_HLIM((p));
+        }
+        f->flags |= FLOW_IPV6;
+    }
+#ifdef DEBUG
+    /* XXX handle default */
+    else {
+        printf("FIXME: %s:%s:%" PRId32 "\n", __FILE__, __FUNCTION__, __LINE__);
+    }
+#endif
+
     COPY_TIMESTAMP(&p->ts, &f->startts);
 
     f->protomap = FlowGetProtoMapping(f->proto);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -933,11 +933,6 @@ static int StreamTcpPacketStateNone(ThreadVars *tv, Packet *p,
             StatsIncr(tv, stt->counter_tcp_midstream_pickups);
         }
 
-        /* reverse packet and flow */
-        SCLogDebug("reversing flow and packet");
-        PacketSwap(p);
-        FlowSwap(p->flow);
-
         /* set the state */
         StreamTcpPacketSetState(p, ssn, TCP_SYN_RECV);
         SCLogDebug("ssn %p: =~ midstream picked ssn state is now "


### PR DESCRIPTION
If midstream pickup is enabled for suricata, the first packet seen for
a flow is assumed to come from the client endpoint. This approach has a
50% chance of being correct. If the first packet to be seen for a TCP
flow is a SYN/ACK then it must have been sent by the server endpoint,
not the client. This change leverages that fact to improve the chances
of flows that are picked up midstream having the correct cardinality.

The FlowInit method now checks to see if the first packet is a TCP
SYN/ACK and, if it is, sets the source and destination addresses for
the flow accordingly. This subsequently means that the
PacketSwap/FlowSwap methods are no longer required, which in turn
*should* slightly reduce the computational overhead for affected flows.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ ] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Previous PR:
https://github.com/OISF/suricata/pull/5802

Describe changes:
-
-
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
