### PR TITLE
Pcap conditional v2.1.0

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -403,6 +403,16 @@ By default all packets are logged except:
 - TCP streams beyond stream.reassembly.depth
 - encrypted streams after the key exchange
 
+It is possible to do conditional pcap logging by using the `conditional`
+option in the pcap-log section. By default the variable is set to `all`
+so all packet are logged. If the variable is set to `alerts` then only
+the flow with alerts will be logged. If the variable is set to `tag`
+then only packets tagged by signature using the `tag` keyword will
+be logged to the pcap file. Please note that if `alert` or `tag` is
+used, then in the case of TCP session, Suricata will use available
+information from the streaming engine to log data that have triggered
+the alert.
+
 ::
 
   - pcap-log:
@@ -414,6 +424,7 @@ By default all packets are logged except:
 
       mode: sguil # "normal" (default) or sguil.
       sguil_base_dir: /nsm_data/
+      conditional: alerts
 
 Verbose Alerts Log (alert-debug.log)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -109,6 +109,13 @@ the signature.
        "port": 80
      },
 
+Pcap Field
+~~~~~~~~~~
+
+If pcap log capture is active, a `capture_file` key will be added to the event
+with value being the full path of the pcap file where the corresponding packets
+have been extracted.
+
 Event type: Anomaly
 -------------------
 

--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -136,7 +136,8 @@ static void AlertDebugLogPktVars(AlertDebugLogThread *aft, const Packet *p)
 
 /** \todo doc
  * assume we have aft lock */
-static int AlertDebugPrintStreamSegmentCallback(const Packet *p, void *data, const uint8_t *buf, uint32_t buflen)
+static int AlertDebugPrintStreamSegmentCallback(
+        const Packet *p, TcpSegment *seg, void *data, const uint8_t *buf, uint32_t buflen)
 {
     AlertDebugLogThread *aft = (AlertDebugLogThread *)data;
 
@@ -291,9 +292,9 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
             /* IDS mode reverse the data */
             /** \todo improve the order selection policy */
             if (p->flowflags & FLOW_PKT_TOSERVER) {
-                flag = FLOW_PKT_TOCLIENT;
+                flag = STREAM_DUMP_TOCLIENT;
             } else {
-                flag = FLOW_PKT_TOSERVER;
+                flag = STREAM_DUMP_TOSERVER;
             }
             ret = StreamSegmentForEach((const Packet *)p, flag,
                                  AlertDebugPrintStreamSegmentCallback,

--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -466,7 +466,7 @@ error:
     return result;
 }
 
-static int AlertDebugLogCondition(ThreadVars *tv, const Packet *p)
+static int AlertDebugLogCondition(ThreadVars *tv, void *thread_data, const Packet *p)
 {
     return (p->alerts.cnt ? TRUE : FALSE);
 }

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -69,7 +69,7 @@ TmEcode AlertFastLogThreadDeinit(ThreadVars *, void *);
 void AlertFastLogRegisterTests(void);
 static void AlertFastLogDeInitCtx(OutputCtx *);
 
-int AlertFastLogCondition(ThreadVars *tv, const Packet *p);
+int AlertFastLogCondition(ThreadVars *tv, void *thread_data, const Packet *p);
 int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p);
 
 void AlertFastLogRegister(void)
@@ -85,7 +85,7 @@ typedef struct AlertFastLogThread_ {
     LogFileCtx* file_ctx;
 } AlertFastLogThread;
 
-int AlertFastLogCondition(ThreadVars *tv, const Packet *p)
+int AlertFastLogCondition(ThreadVars *tv, void *thread_data, const Packet *p)
 {
     return (p->alerts.cnt ? TRUE : FALSE);
 }

--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -1178,7 +1178,7 @@ static OutputInitResult AlertPreludeInitCtx(ConfNode *conf)
     SCReturnCT(result, "OutputInitResult");
 }
 
-static int AlertPreludeCondition(ThreadVars *tv, const Packet *p)
+static int AlertPreludeCondition(ThreadVars *tv, void* thread_data, const Packet *p)
 {
     if (p->alerts.cnt == 0)
         return FALSE;

--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -1000,7 +1000,8 @@ static int EventToReference(const PacketAlert *pa, const Packet *p, idmef_classi
     SCReturnInt(0);
 }
 
-static int PreludePrintStreamSegmentCallback(const Packet *p, void *data, const uint8_t *buf, uint32_t buflen)
+static int PreludePrintStreamSegmentCallback(
+        const Packet *p, TcpSegment *seg, void *data, const uint8_t *buf, uint32_t buflen)
 {
     int ret;
 
@@ -1271,9 +1272,9 @@ static int AlertPreludeLogger(ThreadVars *tv, void *thread_data, const Packet *p
     if (PKT_IS_TCP(p) && (pa->flags & PACKET_ALERT_FLAG_STATE_MATCH)) {
         uint8_t flag;
         if (p->flowflags & FLOW_PKT_TOSERVER) {
-            flag = FLOW_PKT_TOCLIENT;
+            flag = STREAM_DUMP_TOCLIENT;
         } else {
-            flag = FLOW_PKT_TOSERVER;
+            flag = STREAM_DUMP_TOSERVER;
         }
         ret = StreamSegmentForEach(p, flag,
                                    PreludePrintStreamSegmentCallback,

--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -1178,7 +1178,7 @@ static OutputInitResult AlertPreludeInitCtx(ConfNode *conf)
     SCReturnCT(result, "OutputInitResult");
 }
 
-static int AlertPreludeCondition(ThreadVars *tv, void* thread_data, const Packet *p)
+static int AlertPreludeCondition(ThreadVars *tv, void *thread_data, const Packet *p)
 {
     if (p->alerts.cnt == 0)
         return FALSE;

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -370,7 +370,7 @@ static TmEcode AlertSyslogDecoderEvent(ThreadVars *tv, const Packet *p, void *da
     return TM_ECODE_OK;
 }
 
-static int AlertSyslogCondition(ThreadVars *tv, const Packet *p)
+static int AlertSyslogCondition(ThreadVars *tv, void *thread_data, const Packet *p)
 {
     return (p->alerts.cnt > 0 ? TRUE : FALSE);
 }

--- a/src/decode.h
+++ b/src/decode.h
@@ -1154,6 +1154,8 @@ void DecodeUnregisterCounters(void);
 /** Packet is part of stream in known bad condition (loss, wrong thread),
  *  so flag it for not setting stream events */
 #define PKT_STREAM_NO_EVENTS            (1<<28)
+/** We had no alert on flow before this packet */
+#define PKT_FIRST_ALERTS (1 << 29)
 
 /** \brief return 1 if the packet is a pseudo packet */
 #define PKT_IS_PSEUDOPKT(p) \

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -325,7 +325,10 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
 
     /* Set flag on flow to indicate that it has alerts */
     if (p->flow != NULL && p->alerts.cnt > 0) {
-        FlowSetHasAlertsFlag(p->flow);
+        if (!FlowHasAlerts(p->flow)) {
+            FlowSetHasAlertsFlag(p->flow);
+            p->flags |= PKT_FIRST_ALERTS;
+        }
     }
 
 }

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -14,7 +14,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
  * 02110-1301, USA.
  */
-
 
 /**
  * \file

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -26,7 +26,9 @@
  */
 
 #include "suricata-common.h"
+#include "util-buffer.h"
 #include "util-fmemopen.h"
+#include "stream-tcp-util.h"
 
 #ifdef HAVE_LIBLZ4
 #include <lz4frame.h>
@@ -186,6 +188,7 @@ typedef struct PcapLogData_ {
 
 typedef struct PcapLogThreadData_ {
     PcapLogData *pcap_log;
+    MemBuffer *buf;
 } PcapLogThreadData;
 
 /* Pattern for extracting timestamp from pcap log files. */
@@ -513,6 +516,49 @@ static inline int PcapWrite(
     return TM_ECODE_OK;
 }
 
+struct PcapLogCallbackContext {
+    PcapLogData *pl;
+    PcapLogCompressionData *connp;
+    MemBuffer *buf;
+};
+
+static int PcapLogSegmentCallback(
+        const Packet *p, TcpSegment *seg, void *data, const uint8_t *buf, uint32_t buflen)
+{
+    struct PcapLogCallbackContext *pctx = (struct PcapLogCallbackContext *)data;
+
+    if (seg->pcap_hdr_storage->pktlen) {
+        pctx->pl->h->ts.tv_sec = seg->pcap_hdr_storage->ts.tv_sec;
+        pctx->pl->h->ts.tv_usec = seg->pcap_hdr_storage->ts.tv_usec;
+        pctx->pl->h->len = seg->pcap_hdr_storage->pktlen + buflen;
+        pctx->pl->h->caplen = seg->pcap_hdr_storage->pktlen + buflen;
+        MemBufferReset(pctx->buf);
+        MemBufferWriteRaw(pctx->buf, seg->pcap_hdr_storage->pkt_hdr, seg->pcap_hdr_storage->pktlen);
+        MemBufferWriteRaw(pctx->buf, buf, buflen);
+
+        PcapWrite(pctx->pl, pctx->connp, (uint8_t *)pctx->buf->buffer,
+                seg->pcap_hdr_storage->pktlen + buflen);
+    }
+    return 1;
+}
+
+static void PcapLogDumpSegments(
+        PcapLogThreadData *td, PcapLogCompressionData *connp, const Packet *p)
+{
+    uint8_t flag;
+    /*  check which side is packet */
+    if (p->flowflags & FLOW_PKT_TOSERVER) {
+        flag = STREAM_DUMP_TOCLIENT;
+    } else {
+        flag = STREAM_DUMP_TOSERVER;
+    }
+    flag |= STREAM_DUMP_HEADERS;
+
+    /* Loop on segment from this side */
+    struct PcapLogCallbackContext data = { td->pcap_log, connp, td->buf };
+    StreamSegmentForEach(p, flag, PcapLogSegmentCallback, (void *)&data);
+}
+
 /**
  * \brief Pcap logging main function
  *
@@ -607,6 +653,19 @@ static int PcapLog (ThreadVars *t, void *thread_data, const Packet *p)
     }
 
     PCAPLOG_PROFILE_START;
+
+    /* if we are using alerted logging and if packet is first one with alert in flow
+     * then we need to dump in the pcap the stream acked by the packet */
+    if ((p->flags & PKT_FIRST_ALERTS) && (td->pcap_log->conditional == LOGMODE_COND_ALERTS)) {
+        if (PKT_IS_TCP(p)) {
+            /* dump fake packets for all segments we have on acked by packet */
+#ifdef HAVE_LIBLZ4
+            PcapLogDumpSegments(td, connp, p);
+#else
+            PcapLogDumpSegments(td, NULL, p);
+#endif
+        }
+    }
 
 #ifdef HAVE_LIBLZ4
     ret = PcapWrite(pl, comp, GET_PKT_DATA(p), len);
@@ -978,6 +1037,12 @@ static TmEcode PcapLogDataInit(ThreadVars *t, const void *initdata, void **data)
 
     *data = (void *)td;
 
+    if (IsTcpSessionDumpingEnabled()) {
+        td->buf = MemBufferCreateNew(65537);
+    } else {
+        td->buf = NULL;
+    }
+
     if (pl->max_files && (pl->mode == LOGMODE_MULTI || pl->threads == 1)) {
 #ifdef INIT_RING_BUFFER
         if (PcapLogInitRingBuffer(td->pcap_log) == TM_ECODE_FAILED) {
@@ -1087,6 +1152,9 @@ static TmEcode PcapLogDataDeinit(ThreadVars *t, void *thread_data)
     if (pl != g_pcap_data) {
         PcapLogDataFree(pl);
     }
+
+    if (td->buf)
+        MemBufferFree(td->buf);
 
     SCFree(td);
     return TM_ECODE_OK;
@@ -1453,6 +1521,7 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
         if (s_conditional != NULL) {
             if (strcasecmp(s_conditional, "alerts") == 0) {
                 pl->conditional = LOGMODE_COND_ALERTS;
+                EnableTcpSessionDumping();
             } else if (strcasecmp(s_conditional, "all") != 0) {
                 SCLogError(SC_ERR_INVALID_ARGUMENT,
                         "log-pcap: invalid conditional \"%s\". Valid options: \"all\", "

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -290,7 +290,7 @@ static int PcapLogCloseFile(ThreadVars *t, PcapLogData *pl)
         if (comp->format == PCAP_LOG_COMPRESSION_FORMAT_LZ4) {
             /* pcap_dump_close did not write any data because we call
              * pcap_dump_flush() after every write when writing
-	     * compressed output. */
+             * compressed output. */
             uint64_t bytes_written = LZ4F_compressEnd(comp->lz4f_context,
                     comp->buffer, comp->buffer_size, NULL);
             if (LZ4F_isError(bytes_written)) {

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -75,6 +75,9 @@
 #define LOGMODE_SGUIL                   1
 #define LOGMODE_MULTI                   2
 
+#define LOGMODE_COND_ALL                0
+#define LOGMODE_COND_ALERTS             1
+
 #define RING_BUFFER_MODE_DISABLED       0
 #define RING_BUFFER_MODE_ENABLED        1
 
@@ -155,6 +158,7 @@ typedef struct PcapLogData_ {
     uint64_t profile_data_size; /**< track in bytes how many bytes we wrote */
     uint32_t file_cnt;          /**< count of pcap files we currently have */
     uint32_t max_files;         /**< maximum files to use in ring buffer mode */
+    int conditional;            /**< log all packets or just packets and flows with alerts */
 
     PcapLogProfileData profile_lock;
     PcapLogProfileData profile_write;
@@ -200,7 +204,7 @@ static TmEcode PcapLogDataDeinit(ThreadVars *, void *);
 static void PcapLogFileDeInitCtx(OutputCtx *);
 static OutputInitResult PcapLogInitCtx(ConfNode *);
 static void PcapLogProfilingDump(PcapLogData *);
-static int PcapLogCondition(ThreadVars *, const Packet *);
+static int PcapLogCondition(ThreadVars *, void *, const Packet *);
 
 void PcapLogRegister(void)
 {
@@ -220,13 +224,25 @@ void PcapLogRegister(void)
     (prof).total += (UtilCpuGetTicks() - pcaplog_profile_ticks); \
     (prof).cnt++
 
-static int PcapLogCondition(ThreadVars *tv, const Packet *p)
+
+static int PcapLogCondition(ThreadVars *tv, void *thread_data, const Packet *p)
 {
+    PcapLogThreadData *ptd = (PcapLogThreadData *)thread_data;
+
     if (p->flags & PKT_PSEUDO_STREAM_END) {
         return FALSE;
     }
     if (IS_TUNNEL_PKT(p) && !IS_TUNNEL_ROOT_PKT(p)) {
         return FALSE;
+    }
+    /* Log alerted flow */
+    if (ptd->pcap_log->conditional == LOGMODE_COND_ALERTS) {
+        if (p->alerts.cnt ||
+                (p->flow && FlowHasAlerts(p->flow))) {
+            return TRUE; 
+        } else {
+            return FALSE;
+        }
     }
     return TRUE;
 }
@@ -630,6 +646,7 @@ static PcapLogData *PcapLogDataCopy(const PcapLogData *pl)
     copy->timestamp_format = pl->timestamp_format;
     copy->use_stream_depth = pl->use_stream_depth;
     copy->size_limit = pl->size_limit;
+    copy->conditional = pl->conditional;
 
     const PcapLogCompressionData *comp = &pl->compression;
     PcapLogCompressionData *copy_comp = &copy->compression;
@@ -1194,6 +1211,7 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
     pl->timestamp_format = TS_FORMAT_SEC;
     pl->use_stream_depth = USE_STREAM_DEPTH_DISABLED;
     pl->honor_pass_rules = HONOR_PASS_RULES_DISABLED;
+    pl->conditional = LOGMODE_COND_ALL;
 
     TAILQ_INIT(&pl->pcap_file_list);
 
@@ -1418,6 +1436,23 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
 
         SCLogInfo("Selected pcap-log compression method: %s",
                 compression_str ? compression_str : "none");
+
+        const char *s_conditional = NULL;
+        s_conditional = ConfNodeLookupChildValue(conf, "conditional");
+        if (s_conditional != NULL) {
+            if (strcasecmp(s_conditional, "alerts") == 0) {
+                pl->conditional = LOGMODE_COND_ALERTS;
+            } else if (strcasecmp(s_conditional, "all") != 0) {
+                SCLogError(SC_ERR_INVALID_ARGUMENT,
+                    "log-pcap: invalid conditional \"%s\". Valid options: \"all\", "
+                    "or \"alerts\" mode ", s_conditional);
+                exit(EXIT_FAILURE);
+            }
+        }
+
+        SCLogInfo("Selected pcap-log conditional logging: %s",
+                s_conditional ? s_conditional : "all");
+
     }
 
     if (filename) {

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -79,6 +79,7 @@
 
 #define LOGMODE_COND_ALL    0
 #define LOGMODE_COND_ALERTS 1
+#define LOGMODE_COND_TAG    2
 
 #define RING_BUFFER_MODE_DISABLED       0
 #define RING_BUFFER_MODE_ENABLED        1
@@ -234,13 +235,23 @@ static int PcapLogCondition(ThreadVars *tv, void *thread_data, const Packet *p)
     if (p->flags & PKT_PSEUDO_STREAM_END) {
         return FALSE;
     }
-    /* Log alerted flow */
-    if (ptd->pcap_log->conditional == LOGMODE_COND_ALERTS) {
-        if (p->alerts.cnt || (p->flow && FlowHasAlerts(p->flow))) {
-            return TRUE;
-        } else {
-            return FALSE;
-        }
+
+    /* Log alerted flow or tagged flow */
+    switch (ptd->pcap_log->conditional) {
+        case LOGMODE_COND_ALERTS:
+            if (p->alerts.cnt || (p->flow && FlowHasAlerts(p->flow))) {
+                return TRUE;
+            } else {
+                return FALSE;
+            }
+            break;
+        case LOGMODE_COND_TAG:
+            if (p->flags & PKT_HAS_TAG) {
+                return TRUE;
+            } else {
+                return FALSE;
+            }
+            break;
     }
 
     if (IS_TUNNEL_PKT(p) && !IS_TUNNEL_ROOT_PKT(p)) {
@@ -670,7 +681,7 @@ static int PcapLog (ThreadVars *t, void *thread_data, const Packet *p)
 
     /* if we are using alerted logging and if packet is first one with alert in flow
      * then we need to dump in the pcap the stream acked by the packet */
-    if ((p->flags & PKT_FIRST_ALERTS) && (td->pcap_log->conditional == LOGMODE_COND_ALERTS)) {
+    if ((p->flags & PKT_FIRST_ALERTS) && (td->pcap_log->conditional != LOGMODE_COND_ALL)) {
         if (PKT_IS_TCP(p)) {
             /* dump fake packets for all segments we have on acked by packet */
 #ifdef HAVE_LIBLZ4
@@ -1543,6 +1554,9 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
         if (s_conditional != NULL) {
             if (strcasecmp(s_conditional, "alerts") == 0) {
                 pl->conditional = LOGMODE_COND_ALERTS;
+                EnableTcpSessionDumping();
+            } else if (strcasecmp(s_conditional, "tag") == 0) {
+                pl->conditional = LOGMODE_COND_TAG;
                 EnableTcpSessionDumping();
             } else if (strcasecmp(s_conditional, "all") != 0) {
                 SCLogError(SC_ERR_INVALID_ARGUMENT,

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -234,9 +234,6 @@ static int PcapLogCondition(ThreadVars *tv, void *thread_data, const Packet *p)
     if (p->flags & PKT_PSEUDO_STREAM_END) {
         return FALSE;
     }
-    if (IS_TUNNEL_PKT(p) && !IS_TUNNEL_ROOT_PKT(p)) {
-        return FALSE;
-    }
     /* Log alerted flow */
     if (ptd->pcap_log->conditional == LOGMODE_COND_ALERTS) {
         if (p->alerts.cnt || (p->flow && FlowHasAlerts(p->flow))) {
@@ -244,6 +241,10 @@ static int PcapLogCondition(ThreadVars *tv, void *thread_data, const Packet *p)
         } else {
             return FALSE;
         }
+    }
+
+    if (IS_TUNNEL_PKT(p) && !IS_TUNNEL_ROOT_PKT(p)) {
+        return FALSE;
     }
     return TRUE;
 }
@@ -399,12 +400,18 @@ static int PcapLogRotateFile(ThreadVars *t, PcapLogData *pl)
 static int PcapLogOpenHandles(PcapLogData *pl, const Packet *p)
 {
     PCAPLOG_PROFILE_START;
+    const Packet *real_p;
 
-    SCLogDebug("Setting pcap-log link type to %u", p->datalink);
+    if (IS_TUNNEL_PKT(p)) {
+        real_p = p->root;
+    } else {
+        real_p = p;
+    }
+
+    SCLogDebug("Setting pcap-log link type to %u", real_p->datalink);
 
     if (pl->pcap_dead_handle == NULL) {
-        if ((pl->pcap_dead_handle = pcap_open_dead(p->datalink,
-                PCAP_SNAPLEN)) == NULL) {
+        if ((pl->pcap_dead_handle = pcap_open_dead(real_p->datalink, PCAP_SNAPLEN)) == NULL) {
             SCLogDebug("Error opening dead pcap handle");
             return TM_ECODE_FAILED;
         }
@@ -574,6 +581,7 @@ static int PcapLog (ThreadVars *t, void *thread_data, const Packet *p)
     size_t len;
     int rotate = 0;
     int ret = 0;
+    Packet *rp;
 
     PcapLogThreadData *td = (PcapLogThreadData *)thread_data;
     PcapLogData *pl = td->pcap_log;
@@ -581,7 +589,6 @@ static int PcapLog (ThreadVars *t, void *thread_data, const Packet *p)
     if ((p->flags & PKT_PSEUDO_STREAM_END) ||
         ((p->flags & PKT_STREAM_NOPCAPLOG) &&
          (pl->use_stream_depth == USE_STREAM_DEPTH_ENABLED)) ||
-        (IS_TUNNEL_PKT(p) && !IS_TUNNEL_ROOT_PKT(p)) ||
         (pl->honor_pass_rules && (p->flags & PKT_NOPACKET_INSPECTION)))
     {
         return TM_ECODE_OK;
@@ -592,9 +599,16 @@ static int PcapLog (ThreadVars *t, void *thread_data, const Packet *p)
     pl->pkt_cnt++;
     pl->h->ts.tv_sec = p->ts.tv_sec;
     pl->h->ts.tv_usec = p->ts.tv_usec;
-    pl->h->caplen = GET_PKT_LEN(p);
-    pl->h->len = GET_PKT_LEN(p);
-    len = sizeof(*pl->h) + GET_PKT_LEN(p);
+    if (IS_TUNNEL_PKT(p)) {
+        rp = p->root;
+        pl->h->caplen = GET_PKT_LEN(rp);
+        pl->h->len = GET_PKT_LEN(rp);
+        len = sizeof(*pl->h) + GET_PKT_LEN(rp);
+    } else {
+        pl->h->caplen = GET_PKT_LEN(p);
+        pl->h->len = GET_PKT_LEN(p);
+        len = sizeof(*pl->h) + GET_PKT_LEN(p);
+    }
 
     if (pl->filename == NULL) {
         ret = PcapLogOpenFileCtx(pl);
@@ -660,18 +674,26 @@ static int PcapLog (ThreadVars *t, void *thread_data, const Packet *p)
         if (PKT_IS_TCP(p)) {
             /* dump fake packets for all segments we have on acked by packet */
 #ifdef HAVE_LIBLZ4
-            PcapLogDumpSegments(td, connp, p);
+            PcapLogDumpSegments(td, comp, p);
 #else
             PcapLogDumpSegments(td, NULL, p);
 #endif
         }
     }
 
+    if (IS_TUNNEL_PKT(p)) {
 #ifdef HAVE_LIBLZ4
-    ret = PcapWrite(pl, comp, GET_PKT_DATA(p), len);
+        ret = PcapWrite(pl, comp, GET_PKT_DATA(rp), len);
 #else
-    ret = PcapWrite(pl, NULL, GET_PKT_DATA(p), len);
+        ret = PcapWrite(pl, NULL, GET_PKT_DATA(rp), len);
 #endif
+    } else {
+#ifdef HAVE_LIBLZ4
+        ret = PcapWrite(pl, comp, GET_PKT_DATA(p), len);
+#else
+        ret = PcapWrite(pl, NULL, GET_PKT_DATA(p), len);
+#endif
+    }
     if (ret != TM_ECODE_OK)
         return ret;
 

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -895,8 +895,8 @@ static TmEcode PcapLogInitRingBuffer(PcapLogData *pl)
             }
             switch (part[1]) {
                 case 'i':
-                    SCLogError(SC_ERR_INVALID_ARGUMENT,
-                        "Thread ID not allowed inring buffer mode.");
+                    SCLogError(
+                            SC_ERR_INVALID_ARGUMENT, "Thread ID not allowed in ring buffer mode.");
                     return TM_ECODE_FAILED;
                 case 'n': {
                     char tmp[PATH_MAX];

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -110,6 +110,8 @@ typedef struct PcapFileName_ {
     TAILQ_ENTRY(PcapFileName_) next; /**< Pointer to next Pcap File for tailq. */
 } PcapFileName;
 
+thread_local char *current_pcap_file = NULL;
+
 typedef struct PcapLogProfileData_ {
     uint64_t total;
     uint64_t cnt;
@@ -1085,6 +1087,16 @@ static TmEcode PcapLogDataInit(ThreadVars *t, const void *initdata, void **data)
 #endif /* INIT_RING_BUFFER */
     }
 
+    if (pl->mode == LOGMODE_MULTI) {
+        PcapLogOpenFileCtx(td->pcap_log);
+    } else {
+        if (pl->filename == NULL) {
+            PcapLogOpenFileCtx(pl);
+        } else {
+            current_pcap_file = pl->filename;
+        }
+    }
+
     return TM_ECODE_OK;
 }
 
@@ -1838,12 +1850,21 @@ static int PcapLogOpenFileCtx(PcapLogData *pl)
     SCLogDebug("Opening pcap file log %s", pf->filename);
     TAILQ_INSERT_TAIL(&pl->pcap_file_list, pf, next);
 
+    current_pcap_file = pf->filename;
     PCAPLOG_PROFILE_END(pl->profile_open);
     return 0;
 
 error:
     PcapFileNameFree(pf);
     return -1;
+}
+
+char *PcapLogGetFilename(void)
+{
+    if (current_pcap_file != NULL) {
+        return current_pcap_file;
+    }
+    return NULL;
 }
 
 static int profiling_pcaplog_enabled = 0;

--- a/src/log-pcap.h
+++ b/src/log-pcap.h
@@ -30,5 +30,6 @@
 
 void PcapLogRegister(void);
 void PcapLogProfileSetup(void);
+char *PcapLogGetFilename(void);
 
 #endif /* __LOG_PCAP_H__ */

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -121,7 +121,8 @@ typedef struct JsonAlertLogThread_ {
 
 /* Callback function to pack payload contents from a stream into a buffer
  * so we can report them in JSON output. */
-static int AlertJsonDumpStreamSegmentCallback(const Packet *p, void *data, const uint8_t *buf, uint32_t buflen)
+static int AlertJsonDumpStreamSegmentCallback(
+        const Packet *p, TcpSegment *seg, void *data, const uint8_t *buf, uint32_t buflen)
 {
     MemBuffer *payload = (MemBuffer *)data;
     MemBufferWriteRaw(payload, buf, buflen);
@@ -663,9 +664,9 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                 MemBufferReset(payload);
 
                 if (p->flowflags & FLOW_PKT_TOSERVER) {
-                    flag = FLOW_PKT_TOCLIENT;
+                    flag = STREAM_DUMP_TOCLIENT;
                 } else {
-                    flag = FLOW_PKT_TOSERVER;
+                    flag = STREAM_DUMP_TOSERVER;
                 }
 
                 StreamSegmentForEach((const Packet *)p, flag,

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -53,6 +53,7 @@
 #include "util-classification-config.h"
 #include "util-syslog.h"
 #include "util-logopenfile.h"
+#include "log-pcap.h"
 
 #include "output.h"
 #include "output-json.h"
@@ -703,6 +704,11 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
         /* base64-encoded full packet */
         if (json_output_ctx->flags & LOG_JSON_PACKET) {
             EvePacket(p, jb, 0);
+        }
+
+        char *pcap_filename = PcapLogGetFilename();
+        if (pcap_filename != NULL) {
+            jb_set_string(jb, "capture_file", pcap_filename);
         }
 
         if (have_xff_ip && xff_cfg->flags & XFF_EXTRADATA) {

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -773,7 +773,7 @@ static int JsonAlertLogger(ThreadVars *tv, void *thread_data, const Packet *p)
     return 0;
 }
 
-static int JsonAlertLogCondition(ThreadVars *tv, const Packet *p)
+static int JsonAlertLogCondition(ThreadVars *tv, void *thread_data, const Packet *p)
 {
     if (p->alerts.cnt || (p->flags & PKT_HAS_TAG)) {
         return TRUE;

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -292,7 +292,7 @@ static int JsonAnomalyLogger(ThreadVars *tv, void *thread_data, const Packet *p)
     return AnomalyJson(tv, aft, p);
 }
 
-static int JsonAnomalyLogCondition(ThreadVars *tv, const Packet *p)
+static int JsonAnomalyLogCondition(ThreadVars *tv, void *thread_data, const Packet *p)
 {
     return p->events.cnt > 0 ||
            (p->app_layer_events && p->app_layer_events->cnt > 0) ||

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -341,7 +341,7 @@ static int JsonDropLogger(ThreadVars *tv, void *thread_data, const Packet *p)
  *
  * \retval bool TRUE or FALSE
  */
-static int JsonDropLogCondition(ThreadVars *tv, const Packet *p)
+static int JsonDropLogCondition(ThreadVars *tv, void *data, const Packet *p)
 {
     if (!EngineModeIsIPS()) {
         SCLogDebug("engine is not running in inline mode, so returning");

--- a/src/output-json-metadata.c
+++ b/src/output-json-metadata.c
@@ -96,7 +96,7 @@ static int JsonMetadataLogger(ThreadVars *tv, void *thread_data, const Packet *p
     return MetadataJson(tv, aft, p);
 }
 
-static int JsonMetadataLogCondition(ThreadVars *tv, const Packet *p)
+static int JsonMetadataLogCondition(ThreadVars *tv, void *data, const Packet *p)
 {
     if (p->pktvar) {
         return TRUE;

--- a/src/output-packet.c
+++ b/src/output-packet.c
@@ -111,7 +111,7 @@ static TmEcode OutputPacketLog(ThreadVars *tv, Packet *p, void *thread_data)
     while (logger && store) {
         DEBUG_VALIDATE_BUG_ON(logger->LogFunc == NULL || logger->ConditionFunc == NULL);
 
-        if ((logger->ConditionFunc(tv, (const Packet *)p)) == TRUE) {
+        if ((logger->ConditionFunc(tv, store->thread_data, (const Packet *)p)) == TRUE) {
             PACKET_PROFILING_LOGGER_START(p, logger->logger_id);
             logger->LogFunc(tv, store->thread_data, (const Packet *)p);
             PACKET_PROFILING_LOGGER_END(p, logger->logger_id);

--- a/src/output-packet.h
+++ b/src/output-packet.h
@@ -35,7 +35,7 @@ typedef int (*PacketLogger)(ThreadVars *, void *thread_data, const Packet *);
 /** packet logger condition function pointer type,
  *  must return true for packets that should be logged
  */
-typedef int (*PacketLogCondition)(ThreadVars *, const Packet *);
+typedef int (*PacketLogCondition)(ThreadVars *, void *thread_data, const Packet *);
 
 int OutputRegisterPacketLogger(LoggerId logger_id, const char *name,
     PacketLogger LogFunc, PacketLogCondition ConditionFunc, OutputCtx *,

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -548,6 +548,56 @@ static int DoHandleData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
 }
 
 /**
+ * \brief Adds the following information to the TcpSegment from the current
+ *  packet being processed: time values, packet length, and the
+ *  header data of the packet. This information is added to the TcpSegment so
+ *  that it can be used in pcap capturing (log-pcap-stream) to dump the tcp
+ *  session at the beginning of the pcap capture.
+ * \param seg TcpSegment where information is being stored.
+ * \param p Packet being processed.
+ * \param tv Thread-specific variables.
+ * \param ra_ctx TcpReassembly thread-specific variables
+ */
+static void StreamTcpSegmentAddPacketData(
+        TcpSegment *seg, Packet *p, ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx)
+{
+    if (seg->pcap_hdr_storage == NULL || seg->pcap_hdr_storage->pkt_hdr == NULL) {
+        return;
+    }
+
+    /* FIXME we need to address pseudo packet */
+
+    if (GET_PKT_DATA(p) != NULL && GET_PKT_LEN(p) > p->payload_len) {
+        seg->pcap_hdr_storage->ts.tv_sec = p->ts.tv_sec;
+        seg->pcap_hdr_storage->ts.tv_usec = p->ts.tv_usec;
+        seg->pcap_hdr_storage->pktlen = GET_PKT_LEN(p) - p->payload_len;
+        /*
+         * pkt_hdr members are initially allocated 64 bytes of memory. Thus,
+         * need to check that this is sufficient and allocate more memory if
+         * not.
+         */
+        if (GET_PKT_LEN(p) - p->payload_len > seg->pcap_hdr_storage->alloclen) {
+            uint8_t *tmp_pkt_hdr =
+                    SCRealloc(seg->pcap_hdr_storage->pkt_hdr, GET_PKT_LEN(p) - p->payload_len);
+            if (tmp_pkt_hdr == NULL) {
+                SCLogDebug("Failed to realloc");
+                goto hdr_clean;
+            } else {
+                seg->pcap_hdr_storage->pkt_hdr = tmp_pkt_hdr;
+                seg->pcap_hdr_storage->alloclen = GET_PKT_LEN(p) - p->payload_len;
+            }
+        }
+        memcpy(seg->pcap_hdr_storage->pkt_hdr, GET_PKT_DATA(p),
+                (size_t)GET_PKT_LEN(p) - p->payload_len);
+    } else {
+    hdr_clean:
+        seg->pcap_hdr_storage->ts.tv_sec = 0;
+        seg->pcap_hdr_storage->ts.tv_usec = 0;
+        seg->pcap_hdr_storage->pktlen = 0;
+    }
+}
+
+/**
  *  \retval -1 segment not inserted
  *
  *  \param seg segment, this function takes total ownership
@@ -569,6 +619,9 @@ int StreamTcpReassembleInsertSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
         StatsIncr(tv, ra_ctx->counter_tcp_reass_list_fail);
         StreamTcpSegmentReturntoPool(seg);
         SCReturnInt(-1);
+    }
+    if (IsTcpSessionDumpingEnabled()) {
+        StreamTcpSegmentAddPacketData(seg, p, tv, ra_ctx);
     }
 
     if (likely(r == 0)) {

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -561,24 +561,30 @@ static int DoHandleData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
 static void StreamTcpSegmentAddPacketData(
         TcpSegment *seg, Packet *p, ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx)
 {
+    Packet *rp = p;
     if (seg->pcap_hdr_storage == NULL || seg->pcap_hdr_storage->pkt_hdr == NULL) {
         return;
     }
 
-    /* FIXME we need to address pseudo packet */
+    if (IS_TUNNEL_PKT(p)) {
+        if (p->root == NULL) {
+            return;
+        }
+        rp = p->root;
+    }
 
-    if (GET_PKT_DATA(p) != NULL && GET_PKT_LEN(p) > p->payload_len) {
-        seg->pcap_hdr_storage->ts.tv_sec = p->ts.tv_sec;
-        seg->pcap_hdr_storage->ts.tv_usec = p->ts.tv_usec;
-        seg->pcap_hdr_storage->pktlen = GET_PKT_LEN(p) - p->payload_len;
+    if (GET_PKT_DATA(rp) != NULL && GET_PKT_LEN(rp) > p->payload_len) {
+        seg->pcap_hdr_storage->ts.tv_sec = rp->ts.tv_sec;
+        seg->pcap_hdr_storage->ts.tv_usec = rp->ts.tv_usec;
+        seg->pcap_hdr_storage->pktlen = GET_PKT_LEN(rp) - p->payload_len;
         /*
          * pkt_hdr members are initially allocated 64 bytes of memory. Thus,
          * need to check that this is sufficient and allocate more memory if
          * not.
          */
-        if (GET_PKT_LEN(p) - p->payload_len > seg->pcap_hdr_storage->alloclen) {
+        if (GET_PKT_LEN(rp) - p->payload_len > seg->pcap_hdr_storage->alloclen) {
             uint8_t *tmp_pkt_hdr =
-                    SCRealloc(seg->pcap_hdr_storage->pkt_hdr, GET_PKT_LEN(p) - p->payload_len);
+                    SCRealloc(seg->pcap_hdr_storage->pkt_hdr, GET_PKT_LEN(rp) - p->payload_len);
             if (tmp_pkt_hdr == NULL) {
                 SCLogDebug("Failed to realloc");
                 goto hdr_clean;
@@ -587,8 +593,8 @@ static void StreamTcpSegmentAddPacketData(
                 seg->pcap_hdr_storage->alloclen = GET_PKT_LEN(p) - p->payload_len;
             }
         }
-        memcpy(seg->pcap_hdr_storage->pkt_hdr, GET_PKT_DATA(p),
-                (size_t)GET_PKT_LEN(p) - p->payload_len);
+        memcpy(seg->pcap_hdr_storage->pkt_hdr, GET_PKT_DATA(rp),
+                (size_t)GET_PKT_LEN(rp) - p->payload_len);
     } else {
     hdr_clean:
         seg->pcap_hdr_storage->ts.tv_sec = 0;

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -583,8 +583,8 @@ static void StreamTcpSegmentAddPacketData(
          * not.
          */
         if (GET_PKT_LEN(rp) - p->payload_len > seg->pcap_hdr_storage->alloclen) {
-            uint8_t *tmp_pkt_hdr =
-                    SCRealloc(seg->pcap_hdr_storage->pkt_hdr, GET_PKT_LEN(rp) - p->payload_len);
+            uint8_t *tmp_pkt_hdr = StreamTcpReassembleRealloc(seg->pcap_hdr_storage->pkt_hdr,
+                    seg->pcap_hdr_storage->alloclen, GET_PKT_LEN(rp) - p->payload_len);
             if (tmp_pkt_hdr == NULL) {
                 SCLogDebug("Failed to realloc");
                 goto hdr_clean;

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -58,12 +58,27 @@ int TcpSackCompare(struct StreamTcpSackRecord *a, struct StreamTcpSackRecord *b)
 RB_HEAD(TCPSACK, StreamTcpSackRecord);
 RB_PROTOTYPE(TCPSACK, StreamTcpSackRecord, rb, TcpSackCompare);
 
+#define TCPSEG_PKT_HDR_DEFAULT_SIZE 64
+
+/*
+ * Struct to add the additional information required to use TcpSegments to dump
+ * a packet capture to file with the stream-pcap-log output option. This is only
+ * used if the session-dump option is enabled.
+ */
+typedef struct TcpSegmentPcapHdrStorage_ {
+    struct timeval ts;
+    uint32_t pktlen;
+    uint32_t alloclen;
+    uint8_t *pkt_hdr;
+} TcpSegmentPcapHdrStorage;
+
 typedef struct TcpSegment {
     PoolThreadReserved res;
     uint16_t payload_len;       /**< actual size of the payload */
     uint32_t seq;
     RB_ENTRY(TcpSegment) __attribute__((__packed__)) rb;
     StreamingBufferSegment sbseg;
+    TcpSegmentPcapHdrStorage *pcap_hdr_storage;
 } __attribute__((__packed__)) TcpSegment;
 
 /** \brief compare function for the Segment tree

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -223,7 +223,7 @@ static void *ReassembleCalloc(size_t n, size_t size)
 /*
     void *(*Realloc)(void *ptr, size_t orig_size, size_t size);
 */
-static void *ReassembleRealloc(void *optr, size_t orig_size, size_t size)
+void *StreamTcpReassembleRealloc(void *optr, size_t orig_size, size_t size)
 {
     if (size > orig_size) {
         if (StreamTcpReassembleCheckMemcap(size - orig_size) == 0)
@@ -441,7 +441,7 @@ static int StreamTcpReassemblyConfig(char quiet)
     stream_config.sbcnf.buf_size = 2048;
     stream_config.sbcnf.Malloc = ReassembleMalloc;
     stream_config.sbcnf.Calloc = ReassembleCalloc;
-    stream_config.sbcnf.Realloc = ReassembleRealloc;
+    stream_config.sbcnf.Realloc = StreamTcpReassembleRealloc;
     stream_config.sbcnf.Free = ReassembleFree;
 
     return 0;

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -130,6 +130,9 @@ int StreamTcpCheckStreamContents(uint8_t *, uint16_t , TcpStream *);
 bool StreamReassembleRawHasDataReady(TcpSession *ssn, Packet *p);
 void StreamTcpReassemblySetMinInspectDepth(TcpSession *ssn, int direction, uint32_t depth);
 
+int IsTcpSessionDumpingEnabled(void);
+void EnableTcpSessionDumping(void);
+
 static inline bool STREAM_LASTACK_GT_BASESEQ(const TcpStream *stream)
 {
     /* last ack not yet initialized */

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -85,6 +85,7 @@ void StreamTcpReassembleInitMemuse(void);
 int StreamTcpReassembleHandleSegment(ThreadVars *, TcpReassemblyThreadCtx *, TcpSession *, TcpStream *, Packet *, PacketQueueNoLock *);
 int StreamTcpReassembleInit(char);
 void StreamTcpReassembleFree(char);
+void *StreamTcpReassembleRealloc(void *optr, size_t orig_size, size_t size);
 void StreamTcpReassembleRegisterTests(void);
 TcpReassemblyThreadCtx *StreamTcpReassembleInitThreadCtx(ThreadVars *tv);
 void StreamTcpReassembleFreeThreadCtx(TcpReassemblyThreadCtx *);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6235,7 +6235,7 @@ int StreamTcpSegmentForEach(const Packet *p, uint8_t flag, StreamSegmentCallback
         return 0;
     }
 
-    if (flag & FLOW_PKT_TOSERVER) {
+    if (flag & STREAM_DUMP_TOSERVER) {
         stream = &(ssn->server);
     } else {
         stream = &(ssn->client);
@@ -6252,7 +6252,7 @@ int StreamTcpSegmentForEach(const Packet *p, uint8_t flag, StreamSegmentCallback
         uint32_t seg_datalen;
         StreamingBufferSegmentGetData(&stream->sb, &seg->sbseg, &seg_data, &seg_datalen);
 
-        ret = CallbackFunc(p, data, seg_data, seg_datalen);
+        ret = CallbackFunc(p, seg, data, seg_data, seg_datalen);
         if (ret != 1) {
             SCLogDebug("Callback function has failed");
             return -1;

--- a/src/stream.h
+++ b/src/stream.h
@@ -25,6 +25,7 @@
 #define __STREAM_H__
 
 #include "flow.h"
+#include "stream-tcp-private.h"
 
 #define STREAM_START        BIT_U8(0)
 #define STREAM_EOF          BIT_U8(1)
@@ -35,7 +36,12 @@
 #define STREAM_MIDSTREAM    BIT_U8(6)
 #define STREAM_FLUSH        BIT_U8(7)
 
-typedef int (*StreamSegmentCallback)(const Packet *, void *, const uint8_t *, uint32_t);
+#define STREAM_DUMP_TOCLIENT BIT_U8(1)
+#define STREAM_DUMP_TOSERVER BIT_U8(2)
+#define STREAM_DUMP_HEADERS  BIT_U8(3)
+
+typedef int (*StreamSegmentCallback)(
+        const Packet *, TcpSegment *, void *, const uint8_t *, uint32_t);
 int StreamSegmentForEach(const Packet *p, uint8_t flag,
                          StreamSegmentCallback CallbackFunc,
                          void *data);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -390,7 +390,8 @@ outputs:
       #ts-format: usec # sec or usec second format (default) is filename.sec usec is filename.sec.usec
       use-stream-depth: no #If set to "yes" packets seen after reaching stream inspection depth are ignored. "no" logs all packets
       honor-pass-rules: no # If set to "yes", flows in which a pass rule matched will stop being logged.
-      # Use "all" to log all packets or use "alerts" to log only alerted packets and flows
+      # Use "all" to log all packets or use "alerts" to log only alerted packets and flows or "tag"
+      # to log only flow tagged via the "tag" keyword
       #conditional: all
 
   # a full alert log containing much information for signature writers

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -390,6 +390,8 @@ outputs:
       #ts-format: usec # sec or usec second format (default) is filename.sec usec is filename.sec.usec
       use-stream-depth: no #If set to "yes" packets seen after reaching stream inspection depth are ignored. "no" logs all packets
       honor-pass-rules: no # If set to "yes", flows in which a pass rule matched will stop being logged.
+      # Use "all" to log all packets or use "alerts" to log only alerted packets and flows
+      #conditional: all
 
   # a full alert log containing much information for signature writers
   # or for investigating suspected false positives.


### PR DESCRIPTION
Update of #5825. It adds a new key named `capture_file` in alert that contains the full path to the pcap file where the corresponding packets have been stored. This allows the user to retrieve the data for an alert by looking in this file with a filter on the packet tuple. If ever, exchange continue on other pcap it is enough to do the same on subsequent pcap (on same thread in multi mode). This should address a remark done on #5825 by @scottfgjordan.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Rebase to latest master
- Add `capture_file` key in alert
