### PR TITLE
protocol detection: midstream - set done flag only if parsers for bot…

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -534,6 +534,7 @@ static AppProto AppLayerProtoDetectPPGetProto(Flow *f,
     uint8_t dir = idir;
     uint16_t dp = f->protodetect_dp ? f->protodetect_dp : FLOW_GET_DP(f);
     uint16_t sp = FLOW_GET_SP(f);
+    bool probe_is_found = false;
 
 again_midstream:
     if (idir != dir) {
@@ -596,9 +597,9 @@ again_midstream:
     if (pe1 == NULL && pe2 == NULL && pe0 == NULL) {
         SCLogDebug("%s - No probing parsers found for either port",
                 (dir == STREAM_TOSERVER) ? "toserver":"toclient");
-        if (dir == idir)
-            FLOW_SET_PP_DONE(f, dir);
         goto noparsers;
+    } else {
+        probe_is_found = true;
     }
 
     /* run the parser(s): always call with original direction */
@@ -634,8 +635,8 @@ again_midstream:
         }
     }
 
- noparsers:
-    if (stream_config.midstream == true && idir == dir) {
+noparsers:
+    if (stream_config.midstream && idir == dir) {
         if (idir == STREAM_TOSERVER) {
             dir = STREAM_TOCLIENT;
         } else {
@@ -644,6 +645,8 @@ again_midstream:
         SCLogDebug("no match + midstream, retry the other direction %s",
                 (dir == STREAM_TOSERVER) ? "toserver" : "toclient");
         goto again_midstream;
+    } else if (!probe_is_found) {
+        FLOW_SET_PP_DONE(f, idir);
     }
 
  end:

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -55,7 +55,7 @@ typedef struct TcpStreamCnf_ {
 
     uint32_t prealloc_sessions; /**< ssns to prealloc per stream thread */
     uint32_t prealloc_segments; /**< segments to prealloc per stream thread */
-    int midstream;
+    bool midstream;
     int async_oneside;
     uint32_t reassembly_depth;  /**< Depth until when we reassemble the stream */
 

--- a/src/tests/stream-tcp.c
+++ b/src/tests/stream-tcp.c
@@ -214,7 +214,7 @@ static int StreamTcpTest03(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    if (stream_config.midstream != TRUE) {
+    if (!stream_config.midstream) {
         ret = 1;
         goto end;
     }
@@ -281,7 +281,7 @@ static int StreamTcpTest04(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    if (stream_config.midstream != TRUE) {
+    if (!stream_config.midstream) {
         ret = 1;
         goto end;
     }
@@ -379,7 +379,7 @@ static int StreamTcpTest05(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    if (stream_config.midstream != TRUE) {
+    if (!stream_config.midstream) {
         ret = 1;
         goto end;
     }
@@ -1226,7 +1226,7 @@ static int StreamTcpTest14(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    if (stream_config.midstream != TRUE) {
+    if (!stream_config.midstream) {
         ret = 1;
         goto end;
     }
@@ -1616,7 +1616,7 @@ static int StreamTcpTest15(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    if (stream_config.midstream != TRUE) {
+    if (!stream_config.midstream) {
         ret = 1;
         goto end;
     }
@@ -1778,7 +1778,7 @@ static int StreamTcpTest16(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    if (stream_config.midstream != TRUE) {
+    if (!stream_config.midstream) {
         ret = 1;
         goto end;
     }
@@ -1941,7 +1941,7 @@ static int StreamTcpTest17(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    if (stream_config.midstream != TRUE) {
+    if (!stream_config.midstream) {
         ret = 1;
         goto end;
     }


### PR DESCRIPTION
…h directions are not found

  in a case of midstream parsers from other direction are tried if nothing is found for the initial one.
  done flag must be set if nothing is found in both directions.
  otherwise processing of incomplete data is terminated at the very first try.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Currently, done flag is set when parsers for initial directions are not found. It prevents further protocol detection on a flow that starts from the server message and this message is split between TCP segments. Normally probing parser returns incomplete and detection is retried until the max depth of probing parser is reached. But in the case of midstream, the direction is immediately marked as done so detection is terminated.

The fix allows detection from midstream to continue the same way as for normally started flow.

The test is already prepared in suricata-verify with the same branch name midstream-detect

suricata-verify-pr: 438
#suricata-verify-repo:
#suricata-verify-branch: midstream-detect
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
