### PR TITLE
Batch backports to 5.0.x

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -956,12 +956,13 @@ jobs:
           nspr \
           pcre \
           pkg-config \
+          python \
           rust \
           xz
       - name: Install cbindgen
         run: cargo install --force --debug --version 0.14.1 cbindgen
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - run: pip install PyYAML
+      - run: pip3 install PyYAML
       - uses: actions/checkout@v1
       - name: Downloading prep archive
         uses: actions/download-artifact@v2
@@ -975,4 +976,4 @@ jobs:
       - run: make check
       - run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -840,7 +840,7 @@ jobs:
                 libtool \
                 m4 \
                 make \
-                python-yaml \
+                python3-yaml \
                 pkg-config \
                 rustc \
                 sudo \
@@ -865,7 +865,7 @@ jobs:
       - run: make check
       - run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py
 
   debian-9:
     name: Debian 9
@@ -903,7 +903,7 @@ jobs:
                 libtool \
                 m4 \
                 make \
-                python-yaml \
+                python3-yaml \
                 pkg-config \
                 sudo \
                 zlib1g \
@@ -926,7 +926,7 @@ jobs:
       - run: make check
       - run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py
 
   macos-latest:
     name: MacOS Latest

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -705,7 +705,7 @@ static int DatasetLookupString(Dataset *set, const uint8_t *data, const uint32_t
     StringType lookup = { .ptr = (uint8_t *)data, .len = data_len, .rep.value = 0 };
     THashData *rdata = THashLookupFromHash(set->hash, &lookup);
     if (rdata) {
-        THashDataUnlock(rdata);
+        DatasetUnlockData(rdata);
         return 1;
     }
     return 0;

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -170,9 +170,10 @@ void DetectFastPatternRegister(void)
     sigmatch_table[DETECT_FAST_PATTERN].Match = NULL;
     sigmatch_table[DETECT_FAST_PATTERN].Setup = DetectFastPatternSetup;
     sigmatch_table[DETECT_FAST_PATTERN].Free  = NULL;
+#ifdef UNITTESTS
     sigmatch_table[DETECT_FAST_PATTERN].RegisterTests = DetectFastPatternRegisterTests;
-
-    sigmatch_table[DETECT_FAST_PATTERN].flags |= SIGMATCH_NOOPT;
+#endif
+    sigmatch_table[DETECT_FAST_PATTERN].flags |= SIGMATCH_OPTIONAL_OPT;
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
@@ -185,7 +186,7 @@ void DetectFastPatternRegister(void)
  *
  * \param de_ctx   Pointer to the Detection Engine Context.
  * \param s        Pointer to the Signature to which the current keyword belongs.
- * \param null_str Should hold an empty string always.
+ * \param arg      May hold an argument
  *
  * \retval  0 On success.
  * \retval -1 On failure.

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -704,8 +704,14 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
 
     if (!(st->flags & (SIGMATCH_NOOPT|SIGMATCH_OPTIONAL_OPT))) {
         if (optvalue == NULL || strlen(optvalue) == 0) {
-            SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid formatting or malformed option to %s keyword: \'%s\'",
-                    optname, optstr);
+            SCLogError(SC_ERR_INVALID_SIGNATURE,
+                    "invalid formatting or malformed option to %s keyword: '%s'", optname, optstr);
+            goto error;
+        }
+    } else if (st->flags & SIGMATCH_NOOPT) {
+        if (optvalue && strlen(optvalue)) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "unexpected option to %s keyword: '%s'", optname,
+                    optstr);
             goto error;
         }
     }

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -545,7 +545,7 @@ static DnsVersion JsonDnsParseVersion(ConfNode *conf)
 
 static void JsonDnsLogInitFilters(LogDnsFileCtx *dnslog_ctx, ConfNode *conf)
 {
-    dnslog_ctx->flags = ~0UL;
+    dnslog_ctx->flags = ~0ULL;
 
     if (conf) {
         if (dnslog_ctx->version == DNS_VERSION_1) {

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -435,9 +435,6 @@ static int SRepLoadFile(SRepCIDRTree *cidr_ctx, char *filename)
 int SRepLoadFileFromFD(SRepCIDRTree *cidr_ctx, FILE *fp)
 {
     char line[8192] = "";
-    Address a;
-    memset(&a, 0x00, sizeof(a));
-    a.family = AF_INET;
 
     while(fgets(line, (int)sizeof(line), fp) != NULL) {
         size_t len = strlen(line);
@@ -458,6 +455,10 @@ int SRepLoadFileFromFD(SRepCIDRTree *cidr_ctx, FILE *fp)
         if (line[len - 1] == '\n' || line[len - 1] == '\r') {
             line[len - 1] = '\0';
         }
+
+        Address a;
+        memset(&a, 0x00, sizeof(a));
+        a.family = AF_INET;
 
         uint8_t cat = 0, value = 0;
         int r = SRepSplitLine(cidr_ctx, line, &a, &cat, &value);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2775,8 +2775,10 @@ static int PostConfLoadedSetup(SCInstance *suri)
 
     StorageInit();
 #ifdef HAVE_PACKET_EBPF
-    EBPFRegisterExtension();
-    LiveDevRegisterExtension();
+    if (suri->run_mode == RUNMODE_AFP_DEV) {
+        EBPFRegisterExtension();
+        LiveDevRegisterExtension();
+    }
 #endif
     RegisterFlowBypassInfo();
     AppLayerSetup();

--- a/src/tests/detect-parse.c
+++ b/src/tests/detect-parse.c
@@ -38,6 +38,23 @@ static int DetectParseTest01 (void)
     PASS;
 }
 
+/**
+ * \test DetectParseTestNoOpt  is a regression test to make sure that we reject
+ * any signature where a NOOPT rule option is given a value. This can hide rule
+ * errors which make other options disappear, eg: foo: bar: baz; where "foo" is
+ * the NOOPT option, we will end up with a signature which is missing "bar".
+ */
+
+static int DetectParseTestNoOpt(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF(DetectEngineAppendSig(de_ctx,
+                    "alert http any any -> any any (msg:\"sid 1 version 0\"; "
+                    "content:\"dummy1\"; endswith: reference: ref; sid:1;)") != NULL);
+    DetectEngineCtxFree(de_ctx);
+
+    PASS;
+}
 
 /**
  * \brief this function registers unit tests for DetectParse
@@ -45,4 +62,5 @@ static int DetectParseTest01 (void)
 void DetectParseRegisterTests(void)
 {
     UtRegisterTest("DetectParseTest01", DetectParseTest01);
+    UtRegisterTest("DetectParseTestNoOpt", DetectParseTestNoOpt);
 }


### PR DESCRIPTION
Continuation of #5861

Batch backports to 5.0.x

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) tickets:
- [4295](https://redmine.openinfosecfoundation.org/issues/4295)
- [4305](https://redmine.openinfosecfoundation.org/issues/4305)
- [4328](https://redmine.openinfosecfoundation.org/issues/4328)
- [4291](https://redmine.openinfosecfoundation.org/issues/4291)
- [4289](https://redmine.openinfosecfoundation.org/issues/4289)

Describe changes:
- Added additional backport issues

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
