### PR TITLE
tcp: remove debug asserts about large windows

### DIFF
--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -741,7 +741,6 @@ static inline uint64_t GetLeftEdge(TcpSession *ssn, TcpStream *stream)
         if (STREAM_LASTACK_GT_BASESEQ(stream)) {
             /* get window of data that is acked */
             const uint32_t delta = stream->last_ack - stream->base_seq;
-            DEBUG_VALIDATE_BUG_ON(delta > 10000000ULL && delta > stream->window);
             /* get max absolute offset */
             last_ack_abs += delta;
         }

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -986,7 +986,6 @@ static inline bool CheckGap(TcpSession *ssn, TcpStream *stream, Packet *p)
     if (STREAM_LASTACK_GT_BASESEQ(stream)) {
         /* get window of data that is acked */
         const uint32_t delta = stream->last_ack - stream->base_seq;
-        DEBUG_VALIDATE_BUG_ON(delta > 10000000ULL && delta > stream->window);
         /* get max absolute offset */
         last_ack_abs += delta;
 
@@ -1577,7 +1576,6 @@ static int StreamReassembleRawInline(TcpSession *ssn, const Packet *p,
         uint64_t last_ack_abs = STREAM_BASE_OFFSET(stream);
         if (STREAM_LASTACK_GT_BASESEQ(stream)) {
             uint32_t delta = stream->last_ack - stream->base_seq;
-            DEBUG_VALIDATE_BUG_ON(delta > 10000000ULL && delta > stream->window);
             /* get max absolute offset */
             last_ack_abs += delta;
         }
@@ -1674,7 +1672,6 @@ static int StreamReassembleRawDo(TcpSession *ssn, TcpStream *stream,
     if (STREAM_LASTACK_GT_BASESEQ(stream)) {
         SCLogDebug("last_ack %u, base_seq %u", stream->last_ack, stream->base_seq);
         uint32_t delta = stream->last_ack - stream->base_seq;
-        DEBUG_VALIDATE_BUG_ON(delta > 10000000ULL && delta > stream->window);
         /* get max absolute offset */
         last_ack_abs += delta;
         SCLogDebug("last_ack_abs %"PRIu64, last_ack_abs);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4246

Describe changes:
- remove all debug asserts about large windows

Completes commit 00d7c9034be7470177c01e8805831c258b016d0e
