### PR TITLE
Http range file v7

### DIFF
--- a/rules/http-events.rules
+++ b/rules/http-events.rules
@@ -83,4 +83,6 @@ alert http any any -> any any (msg:"SURICATA HTTP compression bomb"; flow:establ
 
 alert http any any -> any any (msg:"SURICATA HTTP too many warnings"; flow:established; app-layer-event:http.too_many_warnings; flowint:http.anomaly.count,+,1; classtype:protocol-command-decode; sid:2221050; rev:1;)
 
-# next sid 2221051
+alert http any any -> any any (msg:"SURICATA HTTP invalid Range header value"; flow:established; app-layer-event:http.range_invalid; flowint:http.anomaly.count,+,1; classtype:protocol-command-decode; sid:2221051; rev:1;)
+
+# next sid 2221052

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -59,6 +59,7 @@ app-layer-ssl.c app-layer-ssl.h \
 app-layer-sip.c app-layer-sip.h \
 conf.c conf.h \
 conf-yaml-loader.c conf-yaml-loader.h \
+containers.c containers.h \
 counters.c counters.h \
 datasets.c datasets.h datasets-reputation.h \
 datasets-string.c datasets-string.h \

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -27,6 +27,7 @@
 #include "suricata.h"
 #include "suricata-common.h"
 #include "debug.h"
+#include "util-validate.h"
 #include "decode.h"
 #include "threads.h"
 
@@ -114,6 +115,8 @@ int HTPFileOpen(HtpState *s, const uint8_t *filename, uint16_t filename_len,
 
         sbcfg = &s->cfg->response.sbcfg;
 
+        // we shall not open a new file if there is a current one
+        DEBUG_VALIDATE_BUG_ON(s->file_range_container != NULL);
     } else {
         if (s->files_ts == NULL) {
             s->files_ts = FileContainerAlloc();
@@ -225,34 +228,90 @@ int HTPParseContentRange(bstr * rawvalue, HtpContentRange *range)
  *  \retval -2 error parsing
  *  \retval -3 error negative end in range
  */
-int HTPFileSetRange(HtpState *s, bstr *rawvalue)
+int HTPFileOpenWithRange(HtpState *s,const uint8_t *filename, uint16_t filename_len,
+                         const uint8_t *data, uint32_t data_len,
+                         uint64_t txid, bstr *rawvalue, HtpTxUserData *htud)
 {
     SCEnter();
+    uint16_t flags;
 
     if (s == NULL) {
         SCReturnInt(-1);
     }
 
-    FileContainer * files = s->files_tc;
-    if (files == NULL) {
-        SCLogDebug("no files in state");
-        SCReturnInt(-1);
-    }
-
     HtpContentRange crparsed;
     if (HTPParseContentRange(rawvalue, &crparsed) != 0) {
-        SCLogDebug("parsing range failed");
-        SCReturnInt(-2);
+        AppLayerDecoderEventsSetEventRaw(&htud->decoder_events, HTTP_DECODER_EVENT_RANGE_INVALID);
+        s->events++;
+
+        SCLogDebug("parsing range failed, going back to normal file");
+        return HTPFileOpen(s, filename, (uint32_t)filename_len,
+                           data, data_len,
+                           txid, STREAM_TOCLIENT);
     }
-    if (crparsed.end <= 0) {
-        SCLogDebug("negative end in range");
-        SCReturnInt(-3);
+    /* crparsed.end <= 0 means a range with only size
+     * this is the answer to an unsatisfied range with the whole file
+     * crparsed.size <= 0 means an unknown size, so we do not know
+     * when to close it...
+     */
+    if (crparsed.end <= 0 || crparsed.size <= 0) {
+        SCLogDebug("range without all information");
+        return HTPFileOpen(s, filename, (uint32_t)filename_len,
+                           data, data_len,
+                           txid, STREAM_TOCLIENT);
     }
-    int retval = FileSetRange(files, crparsed.start, crparsed.end);
-    if (retval == -1) {
+
+    flags = FileFlowToFlags(s->f, STREAM_TOCLIENT);
+    if ((s->flags & HTP_FLAG_STORE_FILES_TS) ||
+        ((s->flags & HTP_FLAG_STORE_FILES_TX_TS) && txid == s->store_tx_id)) {
+        flags |= FILE_STORE;
+        flags &= ~FILE_NOSTORE;
+    } else if (!(flags & FILE_STORE) && (s->f->file_flags & FLOWFILE_NO_STORE_TC)) {
+        flags |= FILE_NOSTORE;
+    }
+
+    FileContainer * files = s->files_tc;
+    if (files == NULL) {
+        s->files_tc = FileContainerAlloc();
+        if (s->files_tc == NULL) {
+            SCReturnInt(-1);
+        }
+        files = s->files_tc;
+    }
+
+    if (FileOpenFileWithId(files, &s->cfg->response.sbcfg, s->file_track_id++,
+                                                      filename, filename_len,
+                                                      data, data_len, flags) != 0) {
+        SCReturnInt(-1);
+    }
+    FileSetTx(files->tail, txid);
+
+    if (FileSetRange(files, crparsed.start, crparsed.end, crparsed.size) < 0) {
         SCLogDebug("set range failed");
     }
-    SCReturnInt(retval);
+    s->file_range_container = ContainerUrlRangeGet(filename, filename_len, &s->f->lastts);
+    if (s->file_range_container == NULL) {
+        // probably reached memcap
+        return HTPFileOpen(s, filename, (uint32_t)filename_len,
+                           data, data_len,
+                           txid, STREAM_TOCLIENT);
+    }
+    if (s->file_range_container->files->tail == NULL) {
+        if (FileOpenFileWithId(s->file_range_container->files, &s->cfg->response.sbcfg, 0,
+                                                              filename, filename_len,
+                                                              NULL, 0, flags) != 0) {
+            SCLogDebug("open file for range failed");
+            SCReturnInt(-1);
+        }
+    }
+    if (ContainerUrlRangeSetRange(s->file_range_container, crparsed.start, crparsed.end, crparsed.size) < 0) {
+        SCLogDebug("Set range failed");
+    }
+    if (ContainerUrlRangeAppendData(s->file_range_container, data, data_len) < 0) {
+        SCLogDebug("Failed to append data");
+    }
+
+    SCReturnInt(0);
 }
 
 /**
@@ -292,6 +351,11 @@ int HTPFileStoreChunk(HtpState *s, const uint8_t *data, uint32_t data_len,
         goto end;
     }
 
+    if (s->file_range_container != NULL) {
+        if (ContainerUrlRangeAppendData(s->file_range_container, data, data_len) < 0) {
+            SCLogDebug("Failed to append data");
+        }
+    }
     result = FileAppendData(files, data, data_len);
     if (result == -1) {
         SCLogDebug("appending data failed");
@@ -349,6 +413,16 @@ int HTPFileClose(HtpState *s, const uint8_t *data, uint32_t data_len,
         retval = -1;
     } else if (result == -2) {
         retval = -2;
+    }
+    if (s->file_range_container != NULL) {
+        if (ContainerUrlRangeAppendData(s->file_range_container, data, data_len) < 0) {
+            SCLogDebug("Failed to append data");
+        }
+        File * ranged = ContainerUrlRangeClose(s->file_range_container, flags);
+        if (ranged) {
+            FileContainerAdd(files, ranged);
+        }
+        s->file_range_container = NULL;
     }
 
 end:

--- a/src/app-layer-htp-file.h
+++ b/src/app-layer-htp-file.h
@@ -33,7 +33,7 @@ typedef struct HtpContentRange_ {
 
 int HTPFileOpen(HtpState *, const uint8_t *, uint16_t, const uint8_t *, uint32_t, uint64_t, uint8_t);
 int HTPParseContentRange(bstr * rawvalue, HtpContentRange *range);
-int HTPFileSetRange(HtpState *, bstr *rawvalue);
+int HTPFileOpenWithRange(HtpState *, const uint8_t *, uint16_t, const uint8_t *, uint32_t, uint64_t, bstr *rawvalue, HtpTxUserData *htud);
 int HTPFileStoreChunk(HtpState *, const uint8_t *, uint32_t, uint8_t);
 int HTPFileClose(HtpState *, const uint8_t *, uint32_t, uint8_t, uint8_t);
 

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -194,6 +194,9 @@ SCEnumCharMap http_decoder_event_table[ ] = {
     { "COMPRESSION_BOMB",
         HTTP_DECODER_EVENT_COMPRESSION_BOMB},
 
+    { "RANGE_INVALID",
+        HTTP_DECODER_EVENT_RANGE_INVALID},
+
     /* suricata warnings/errors */
     { "MULTIPART_GENERIC_ERROR",
         HTTP_DECODER_EVENT_MULTIPART_GENERIC_ERROR},
@@ -1749,8 +1752,19 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
         }
 
         if (filename != NULL) {
-            result = HTPFileOpen(hstate, filename, (uint32_t)filename_len,
-                    data, data_len, HtpGetActiveResponseTxID(hstate), STREAM_TOCLIENT);
+            //set range if present
+            htp_header_t *h_content_range = htp_table_get_c(tx->response_headers,
+                                                            "content-range");
+            if (h_content_range != NULL) {
+                result = HTPFileOpenWithRange(hstate, filename, (uint32_t)filename_len,
+                                              data, data_len,
+                                              HtpGetActiveResponseTxID(hstate),
+                                              h_content_range->value, htud);
+            } else {
+                result = HTPFileOpen(hstate, filename, (uint32_t)filename_len,
+                                     data, data_len,
+                                     HtpGetActiveResponseTxID(hstate), STREAM_TOCLIENT);
+            }
             SCLogDebug("result %d", result);
             if (result == -1) {
                 goto end;
@@ -1760,11 +1774,6 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
                 FlagDetectStateNewFile(htud, STREAM_TOCLIENT);
                 htud->tcflags |= HTP_FILENAME_SET;
                 htud->tcflags &= ~HTP_DONTSTORE;
-            }
-            //set range if present
-            htp_header_t *h_content_range = htp_table_get_c(tx->response_headers, "content-range");
-            if (h_content_range != NULL) {
-                HTPFileSetRange(hstate, h_content_range->value);
             }
         }
     }

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -38,6 +38,7 @@
 #include "app-layer-htp-mem.h"
 #include "detect-engine-state.h"
 #include "util-streaming-buffer.h"
+#include "containers.h"
 #include "rust.h"
 
 #include <htp/htp.h>
@@ -129,6 +130,8 @@ enum {
 
     HTTP_DECODER_EVENT_LZMA_MEMLIMIT_REACHED,
     HTTP_DECODER_EVENT_COMPRESSION_BOMB,
+
+    HTTP_DECODER_EVENT_RANGE_INVALID,
 
     /* suricata errors/warnings */
     HTTP_DECODER_EVENT_MULTIPART_GENERIC_ERROR,
@@ -255,6 +258,7 @@ typedef struct HtpState_ {
     uint16_t events;
     uint16_t htp_messages_offset; /**< offset into conn->messages list */
     uint32_t file_track_id;             /**< used to assign file track ids to files */
+    ContainerUrlRange *file_range_container;             /**< used to assign track ids to range file */
     uint64_t last_request_data_stamp;
     uint64_t last_response_data_stamp;
 } HtpState;

--- a/src/containers.c
+++ b/src/containers.c
@@ -1,0 +1,304 @@
+/* Copyright (C) 2021 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Philippe Antoine <p.antoine@catenacyber.fr>
+ */
+
+#include "suricata-common.h"
+#include "containers.h"
+#include "util-misc.h" //ParseSizeStringU64
+#include "util-thash.h" //HashTable
+#include "util-memcmp.h" //SCBufferCmp
+#include "util-hash-string.h" //StringHashDjb2
+#include "util-validate.h" //DEBUG_VALIDATE_BUG_ON
+
+typedef struct ContainerList {
+    THashTableContext* ht;
+    uint32_t timeout;
+} ContainerList;
+
+//globals
+ContainerList ContainerUrlRangeList;
+
+#define CONTAINER_URLRANGE_HASH_SIZE 256
+
+static int ContainerUrlRangeSet(void *dst, void *src)
+{
+    ContainerUrlRange *src_s = src;
+    ContainerUrlRange *dst_s = dst;
+    dst_s->len = src_s->len;
+    dst_s->key = SCMalloc(dst_s->len);
+    BUG_ON(dst_s->key == NULL);
+    memcpy(dst_s->key, src_s->key, dst_s->len);
+    dst_s->files = FileContainerAlloc();
+    dst_s->ranges = NULL;
+    dst_s->current = NULL;
+    dst_s->toskip = 0;
+    dst_s->flags = 0;
+    dst_s->totalsize = 0;
+
+    return 0;
+}
+
+static bool ContainerUrlRangeCompare(void *a, void *b)
+{
+    const ContainerUrlRange *as = a;
+    const ContainerUrlRange *bs = b;
+    if (SCBufferCmp(as->key, as->len, bs->key, bs->len) == 0) {
+        return true;
+    }
+    return false;
+}
+
+static uint32_t ContainerUrlRangeHash(void *s)
+{
+    ContainerUrlRange *cur = s;
+    uint32_t h = StringHashDjb2(cur->key, cur->len);
+    return h;
+}
+
+static void RangeContainerFree(ContainerUrlRange *c) {
+    RangeContainer * range = c->ranges;
+    while (range) {
+        RangeContainer * next = range->next;
+        SCFree(range->buffer);
+        (void) SC_ATOMIC_SUB(ContainerUrlRangeList.ht->memuse, range->buflen);
+        SCFree(range);
+        range = next;
+    }
+}
+
+// base data stays in hash
+static void ContainerUrlRangeFree(void *s)
+{
+    ContainerUrlRange *cu = s;
+    SCFree(cu->key);
+    FileContainerFree(cu->files);
+    RangeContainerFree(cu);
+}
+
+static bool ContainerValueRangeTimeout(ContainerUrlRange *cu, struct timeval *ts) {
+    return (ts->tv_sec > cu->expire);
+}
+
+static void ContainerUrlRangeUpdate(ContainerUrlRange *cu, uint32_t expire) {
+    cu->expire = expire;
+}
+
+void ContainersInit(void) {
+    SCLogDebug("containers start");
+    const char *str = NULL;
+    uint64_t memcap = 0;
+    uint32_t timeout = 0;
+    if (ConfGetValue("containers.memcap", &str) == 1) {
+        if (ParseSizeStringU64(str, &memcap) < 0) {
+            SCLogWarning(SC_ERR_INVALID_VALUE,
+                         "memcap value cannot be deduced: %s,"
+                         " resetting to default",
+                         str);
+            memcap = 0;
+        }
+    }
+    if (ConfGetValue("containers.timeout", &str) == 1) {
+        if (ParseSizeStringU32(str, &timeout) < 0) {
+            SCLogWarning(SC_ERR_INVALID_VALUE,
+                         "timeout value cannot be deduced: %s,"
+                         " resetting to default",
+                         str);
+            timeout = 0;
+        }
+    }
+
+    ContainerUrlRangeList.ht = THashInit("containers.urlrange",
+                                        sizeof(ContainerUrlRange), ContainerUrlRangeSet, ContainerUrlRangeFree, ContainerUrlRangeHash,
+                                        ContainerUrlRangeCompare,
+                                        false, memcap, CONTAINER_URLRANGE_HASH_SIZE);
+    ContainerUrlRangeList.timeout = timeout;
+
+    SCLogDebug("containers started");
+}
+
+void ContainersDestroy(void) {
+    THashShutdown(ContainerUrlRangeList.ht);
+}
+
+uint32_t ContainersTimeoutHash(struct timeval *ts) {
+    uint32_t cnt = 0;
+
+    for (size_t i = 0; i < ContainerUrlRangeList.ht->config.hash_size; i++) {
+        THashHashRow *hb = &ContainerUrlRangeList.ht->array[i];
+
+        if (HRLOCK_TRYLOCK(hb) != 0)
+            continue;
+        /* hash bucket is now locked */
+        THashData *h = hb->head;
+        while (h) {
+            THashData *n = h->next;
+            if (ContainerValueRangeTimeout(h->data, ts)) {
+                /* remove from the hash */
+                if (h->prev != NULL)
+                    h->prev->next = h->next;
+                if (h->next != NULL)
+                    h->next->prev = h->prev;
+                if (hb->head == h)
+                    hb->head = h->next;
+                if (hb->tail == h)
+                    hb->tail = h->prev;
+                h->next = NULL;
+                h->prev = NULL;
+                ContainerUrlRange *c = h->data;
+                FileCloseFile(c->files, NULL, 0, FILE_TRUNCATED);
+                //TODOask can we log it somehow ?
+                RangeContainerFree(c);
+                THashDataMoveToSpare(ContainerUrlRangeList.ht, h->data);
+            }
+            h = n;
+        }
+        HRLOCK_UNLOCK(hb);
+    }
+
+    return cnt;
+}
+
+void * ContainerUrlRangeGet(const uint8_t * key, size_t keylen, struct timeval *ts) {
+    ContainerUrlRange lookup;
+    // cast so as not to have const in the structure
+    lookup.key = (uint8_t *) key;
+    lookup.len = keylen;
+    struct THashDataGetResult res = THashGetFromHash(ContainerUrlRangeList.ht, &lookup);
+    if (res.data) {
+        //nothing more to do if (res.is_new)
+        ContainerUrlRangeUpdate(res.data->data, ts->tv_sec + ContainerUrlRangeList.timeout);
+        THashDecrUsecnt(res.data);
+        THashDataUnlock(res.data);
+        return res.data->data;
+    }
+    return NULL;
+}
+
+int ContainerUrlRangeSetRange(ContainerUrlRange *c, uint64_t start, uint64_t end, uint64_t total) {
+    if (total > c->totalsize) {
+        //TODOask add checks about totalsize remaining the same
+        c->totalsize = total;
+    }
+    if (start == c->files->tail->size) {
+        // easy case : append to current file
+        return 0;
+    } else if (start < c->files->tail->size) {
+        //skip first overlap
+        c->toskip = c->files->tail->size - start;
+        return 0;
+    }
+    // else {
+    // insert range in ordered linked list, if we have enough memcap
+    uint64_t buflen = end-start+1;
+    if (!(THASH_CHECK_MEMCAP(ContainerUrlRangeList.ht, buflen))) {
+        //TODOask release memory for others RangeContainerFree(c);
+        // skips this range
+        c->toskip = buflen;
+        return -1;
+    }
+    (void) SC_ATOMIC_ADD(ContainerUrlRangeList.ht->memuse, buflen);
+    RangeContainer * range = SCCalloc(1, sizeof(RangeContainer));
+    range->buffer = SCMalloc(buflen);
+    range->buflen = buflen;
+    range->start = start;
+
+    if (c->ranges == NULL || range->start < c->ranges->start) {
+        range->next = c->ranges;
+        c->ranges = range;
+    } else {
+        RangeContainer * next = c->ranges;
+        while (next->next != NULL && range->start >= next->next->start) {
+            next = next->next;
+        }
+        //TODOask merge contiguous ie if (range->start == next->start + next->buflen) {
+        range->next = next->next;
+        next->next = range;
+    }
+    c->current = range;
+    return 0;
+}
+
+int ContainerUrlRangeAppendData(ContainerUrlRange *c, const uint8_t * data, size_t len) {
+    if (c->current) {
+        if (c->current->offset + len <= c->current->buflen) {
+            memcpy(c->current->buffer + c->current->offset, data, len);
+            c->current->offset += len;
+        } else {
+            memcpy(c->current->buffer + c->current->offset, data, c->current->buflen - c->current->offset);
+            c->current->offset = c->current->buflen;
+        }
+        return 0;
+    } else if (c->toskip > 0) {
+        if (c->toskip >= len) {
+            c->toskip -= len;
+            return 0;
+        } // else
+        int r = FileAppendData(c->files, data + c->toskip, len - c->toskip);
+        c->toskip = 0;
+        return r;
+    } //else {
+    return FileAppendData(c->files, data, len);
+}
+
+File * ContainerUrlRangeClose(ContainerUrlRange *c, uint16_t flags) {
+    if (c->toskip > 0) {
+        // was only an overlapping range
+        c->toskip = 0;
+        return NULL;
+    } else if (c->current) {
+        // a stored range
+        c->current = NULL;
+        return NULL;
+    } //else {
+    File *f = c->files->tail;
+
+    // just finished appending to a file, have we reached a saved range ?
+    RangeContainer * range = c->ranges;
+    while (range && f->size >= range->start) {
+        if (f->size == range->start) {
+            FileAppendData(c->files, range->buffer, range->offset);
+        } else {
+            // in case of overlap, only add the extra data (if any)
+            uint64_t overlap = f->size + 1 - range->start;
+            if (overlap > range->offset) {
+                FileAppendData(c->files, range->buffer + overlap, range->offset - overlap);
+            }
+        }
+        RangeContainer * next = range->next;
+        SCFree(range->buffer);
+        (void) SC_ATOMIC_SUB(ContainerUrlRangeList.ht->memuse, range->buflen);
+        SCFree(range);
+        range = next;
+        c->ranges = range;
+    }
+
+    if (f->size + 1 >= c->totalsize) {
+        FileCloseFile(c->files, NULL, 0, c->flags | flags);
+        // move ownership to caller
+        DEBUG_VALIDATE_BUG_ON(c->files->head != c->files->tail);
+        c->files->head = NULL;
+        c->files->tail = NULL;
+        THashRemoveFromHash(ContainerUrlRangeList.ht, c);
+        return f;
+    }
+    return NULL;
+}

--- a/src/containers.h
+++ b/src/containers.h
@@ -1,0 +1,54 @@
+/* Copyright (C) 2021 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef __CONTAINERS_H__
+#define __CONTAINERS_H__
+
+
+void ContainersInit(void);
+void ContainersDestroy(void);
+uint32_t ContainersTimeoutHash(struct timeval *ts);
+
+
+void * ContainerUrlRangeGet(const uint8_t * key, size_t keylen, struct timeval *ts);
+
+typedef struct RangeContainer {
+    struct RangeContainer *next;
+    uint8_t * buffer;
+    uint64_t buflen;
+    uint64_t start;
+    uint64_t offset;
+} RangeContainer;
+
+typedef struct ContainerUrlRange {
+    uint8_t *key;
+    uint32_t len;
+    uint32_t expire;
+    uint64_t totalsize;
+    uint64_t toskip;
+    uint16_t flags;
+    FileContainer *files;
+    RangeContainer *ranges;
+    RangeContainer *current;
+} ContainerUrlRange;
+
+int ContainerUrlRangeSetRange(ContainerUrlRange *c, uint64_t start, uint64_t end, uint64_t total);
+int ContainerUrlRangeAppendData(ContainerUrlRange *c, const uint8_t * data, size_t len);
+File * ContainerUrlRangeClose(ContainerUrlRange *c, uint16_t flags);
+
+
+#endif /* __CONTAINERS_H__ */

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -66,6 +66,7 @@
 #include "host-timeout.h"
 #include "defrag-timeout.h"
 #include "ippair-timeout.h"
+#include "containers.h"
 
 #include "output-flow.h"
 #include "util-validate.h"
@@ -987,6 +988,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
             //uint32_t hosts_pruned =
             HostTimeoutHash(&ts);
             IPPairTimeoutHash(&ts);
+            ContainersTimeoutHash(&ts);
             other_last_sec = (uint32_t)ts.tv_sec;
         }
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -68,6 +68,7 @@
 #include "conf.h"
 #include "conf-yaml-loader.h"
 
+#include "containers.h"
 #include "datasets.h"
 
 #include "stream-tcp.h"
@@ -339,6 +340,7 @@ static void GlobalsDestroy(SCInstance *suri)
     AppLayerDeSetup();
     DatasetsSave();
     DatasetsDestroy();
+    ContainersDestroy();
     TagDestroyCtx();
 
     LiveDeviceListClean();
@@ -1998,6 +2000,7 @@ void PreRunInit(const int runmode)
 {
     /* Initialize Datasets to be able to use them with unix socket */
     DatasetsInit();
+    ContainersInit();
     if (runmode == RUNMODE_UNIX_SOCKET)
         return;
 

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -809,7 +809,7 @@ void FileSetInspectSizes(File *file, const uint32_t win, const uint32_t min)
  *  \retval  0 ok
  *  \retval -1 error
  */
-int FileSetRange(FileContainer *ffc, uint64_t start, uint64_t end)
+int FileSetRange(FileContainer *ffc, uint64_t start, uint64_t end, uint64_t totalsize)
 {
     SCEnter();
 
@@ -818,6 +818,7 @@ int FileSetRange(FileContainer *ffc, uint64_t start, uint64_t end)
     }
     ffc->tail->start = start;
     ffc->tail->end = end;
+    ffc->tail->totalsize = totalsize;
     SCReturnInt(0);
 }
 

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -98,6 +98,7 @@ typedef struct File_ {
     uint32_t inspect_min_size;
     uint64_t start;
     uint64_t end;
+    uint64_t totalsize;
 
     uint32_t *sid; /* signature id of a rule that triggered the filestore event */
     uint32_t sid_cnt;
@@ -183,11 +184,12 @@ void FileSetInspectSizes(File *file, const uint32_t win, const uint32_t min);
  *  \param ffc the container
  *  \param start start offset
  *  \param end end offset
+ *  \param total total size of file
  *
  *  \retval 0 ok
  *  \retval -1 error
  */
-int FileSetRange(FileContainer *, uint64_t start, uint64_t end);
+int FileSetRange(FileContainer *, uint64_t start, uint64_t end, uint64_t total);
 
 /**
  *  \brief Tag a file for storing

--- a/src/util-hash-string.c
+++ b/src/util-hash-string.c
@@ -19,17 +19,20 @@
 #include "util-hash-string.h"
 
 /* djb2 string hashing */
-uint32_t StringHashFunc(HashTable *ht, void *data, uint16_t datalen)
+uint32_t StringHashDjb2(uint8_t *data, uint32_t datalen)
 {
     uint32_t hash = 5381;
-    int c;
-
-    while ((c = *(char *)data++))
+    for (uint32_t i = 0; i < datalen; i++) {
+        uint32_t c = data[i];
         hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
-
-    hash = hash % ht->array_size;
-
+    }
     return hash;
+}
+
+/* djb2 string hashing */
+uint32_t StringHashFunc(HashTable *ht, void *data, uint16_t datalen)
+{
+    return StringHashDjb2(data, datalen) % ht->array_size;
 }
 
 char StringHashCompareFunc(void *data1, uint16_t datalen1,

--- a/src/util-hash-string.h
+++ b/src/util-hash-string.h
@@ -18,6 +18,7 @@
 #ifndef __UTIL_HASH_STRING_H__
 #define __UTIL_HASH_STRING_H__
 
+uint32_t StringHashDjb2(uint8_t *data, uint32_t datalen);
 uint32_t StringHashFunc(HashTable *ht, void *data, uint16_t datalen);
 char StringHashCompareFunc(void *data1, uint16_t datalen1,
                            void *data2, uint16_t datalen2);

--- a/src/util-memcmp.h
+++ b/src/util-memcmp.h
@@ -377,5 +377,15 @@ static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t len)
 
 #endif /* SIMD */
 
+static inline int SCBufferCmp(const void *s1, size_t len1, const void *s2, size_t len2)
+{
+    if (len1 == len2) {
+        return SCMemcmp(s1, s2, len1);
+    } else if (len1 < len2) {
+        return -1;
+    }
+    return 1;
+}
+
 #endif /* __UTIL_MEMCMP_H__ */
 

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -37,7 +37,7 @@
 static THashData *THashGetUsed(THashTableContext *ctx);
 static void THashDataEnqueue (THashDataQueue *q, THashData *h);
 
-static void THashDataMoveToSpare(THashTableContext *ctx, THashData *h)
+void THashDataMoveToSpare(THashTableContext *ctx, THashData *h)
 {
     THashDataEnqueue(&ctx->spare_q, h);
     (void) SC_ATOMIC_SUB(ctx->counter, 1);

--- a/src/util-thash.h
+++ b/src/util-thash.h
@@ -214,5 +214,6 @@ void THashCleanup(THashTableContext *ctx);
 int THashWalk(THashTableContext *, THashFormatFunc, THashOutputFunc, void *);
 int THashRemoveFromHash (THashTableContext *ctx, void *data);
 void THashConsolidateMemcap(THashTableContext *ctx);
+void THashDataMoveToSpare(THashTableContext *ctx, THashData *h);
 
 #endif /* __THASH_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -978,6 +978,12 @@ asn1-max-frames: 256
 #     hashsize: 2048
 
 ##############################################################################
+# Containers default settings
+# containers:
+#   urlrange:
+#     memcap: 100mb
+#     timeout: 60
+
 ##
 ## Advanced settings below
 ##


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1576

Describe changes:
- Uses a generic container (a thread-safe hash table whose key is the url/filename) to store file parts with HTTP Range header
- handles reassembly of these parts, while enforcing a global memcap

I bet there is a lot to say about this... comments to follow in the code

suricata-verify-pr: 443