### PR TITLE
Batch backports to 5.0.x

### DIFF
--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -711,7 +711,7 @@ static int DetectPcreParseCapture(const char *regexstr, DetectEngineCtx *de_ctx,
     {
         char *ptr = NULL;
         while ((name_array[name_idx] = strtok_r(name_idx == 0 ? capture_names : NULL, " ,", &ptr))){
-            if (name_idx > capture_cnt) {
+            if (name_idx > (capture_cnt - 1)) {
                 SCLogError(SC_ERR_VAR_LIMIT, "more pkt/flow "
                         "var capture names than capturing substrings");
                 return -1;

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -743,7 +743,6 @@ static inline uint64_t GetLeftEdge(TcpSession *ssn, TcpStream *stream)
         if (STREAM_LASTACK_GT_BASESEQ(stream)) {
             /* get window of data that is acked */
             const uint32_t delta = stream->last_ack - stream->base_seq;
-            DEBUG_VALIDATE_BUG_ON(delta > 10000000ULL && delta > stream->window);
             /* get max absolute offset */
             last_ack_abs += delta;
         }

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -950,7 +950,6 @@ static inline bool CheckGap(TcpSession *ssn, TcpStream *stream, Packet *p)
     if (STREAM_LASTACK_GT_BASESEQ(stream)) {
         /* get window of data that is acked */
         const uint32_t delta = stream->last_ack - stream->base_seq;
-        DEBUG_VALIDATE_BUG_ON(delta > 10000000ULL && delta > stream->window);
         /* get max absolute offset */
         last_ack_abs += delta;
 
@@ -1063,7 +1062,6 @@ static int ReassembleUpdateAppLayer (ThreadVars *tv,
             if (STREAM_LASTACK_GT_BASESEQ(*stream)) {
                 /* get window of data that is acked */
                 uint32_t delta = (*stream)->last_ack - (*stream)->base_seq;
-                DEBUG_VALIDATE_BUG_ON(delta > 10000000ULL && delta > (*stream)->window);
                 /* get max absolute offset */
                 last_ack_abs += delta;
             }
@@ -1483,7 +1481,6 @@ static int StreamReassembleRawInline(TcpSession *ssn, const Packet *p,
         uint64_t last_ack_abs = STREAM_BASE_OFFSET(stream);
         if (STREAM_LASTACK_GT_BASESEQ(stream)) {
             uint32_t delta = stream->last_ack - stream->base_seq;
-            DEBUG_VALIDATE_BUG_ON(delta > 10000000ULL && delta > stream->window);
             /* get max absolute offset */
             last_ack_abs += delta;
         }
@@ -1580,7 +1577,6 @@ static int StreamReassembleRawDo(TcpSession *ssn, TcpStream *stream,
     if (STREAM_LASTACK_GT_BASESEQ(stream)) {
         SCLogDebug("last_ack %u, base_seq %u", stream->last_ack, stream->base_seq);
         uint32_t delta = stream->last_ack - stream->base_seq;
-        DEBUG_VALIDATE_BUG_ON(delta > 10000000ULL && delta > stream->window);
         /* get max absolute offset */
         last_ack_abs += delta;
         SCLogDebug("last_ack_abs %"PRIu64, last_ack_abs);


### PR DESCRIPTION
Continuation of #5887 

Batch backports to 5.0.x

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) tickets:
- [4287](https://redmine.openinfosecfoundation.org/issues/4287)
- [4341](https://redmine.openinfosecfoundation.org/issues/4341)


Describe changes:
- Adds 7264f58f2cbf266ba44efd32c5031b692b57967d [issue 4341]

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
