### PR TITLE
protodetect: improve midstream handling

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -531,6 +531,7 @@ static AppProto AppLayerProtoDetectPPGetProto(Flow *f,
     uint8_t dir = idir;
     uint16_t dp = f->protodetect_dp ? f->protodetect_dp : FLOW_GET_DP(f);
     uint16_t sp = FLOW_GET_SP(f);
+    bool probe_is_found = false;
 
 again_midstream:
     if (idir != dir) {
@@ -593,9 +594,9 @@ again_midstream:
     if (pe1 == NULL && pe2 == NULL && pe0 == NULL) {
         SCLogDebug("%s - No probing parsers found for either port",
                 (dir == STREAM_TOSERVER) ? "toserver":"toclient");
-        if (dir == idir)
-            FLOW_SET_PP_DONE(f, dir);
         goto noparsers;
+    } else {
+        probe_is_found = true;
     }
 
     /* run the parser(s): always call with original direction */
@@ -631,8 +632,8 @@ again_midstream:
         }
     }
 
- noparsers:
-    if (stream_config.midstream == true && idir == dir) {
+noparsers:
+    if (stream_config.midstream && idir == dir) {
         if (idir == STREAM_TOSERVER) {
             dir = STREAM_TOCLIENT;
         } else {
@@ -641,6 +642,8 @@ again_midstream:
         SCLogDebug("no match + midstream, retry the other direction %s",
                 (dir == STREAM_TOSERVER) ? "toserver" : "toclient");
         goto again_midstream;
+    } else if (!probe_is_found) {
+        FLOW_SET_PP_DONE(f, idir);
     }
 
  end:


### PR DESCRIPTION
Set "done flag" only if parsers for both directions are not found in a
case of midstream parsers from other direction are tried if nothing is found
for the initial one. "done flag" must be set if nothing is found in both
directions. Otherwise processing of incomplete data is terminated at the very
first try.

(cherry picked from commit 5285163d8f31dc89a4ab96b0842099f9792e29be)

suricata-verify-pr: 451