### PR TITLE
Detect prefilter setupu8 4335 v5

### DIFF
--- a/src/detect-engine-uint.c
+++ b/src/detect-engine-uint.c
@@ -65,6 +65,32 @@ int DetectU32Match(const uint32_t parg, const DetectU32Data *du32)
     return 0;
 }
 
+static int DetectU32Validate(DetectU32Data *du32) {
+    switch (du32->mode) {
+        case DETECT_UINT_LT:
+            if (du32->arg1 == 0) {
+                return 1;
+            }
+            break;
+        case DETECT_UINT_GT:
+            if (du32->arg1 == UINT32_MAX) {
+                return 1;
+            }
+            break;
+        case DETECT_UINT_RA:
+            if (du32->arg1 >= du32->arg2) {
+                return 1;
+            }
+            // we need at least one value that can match parg > du32->arg1 && parg < du32->arg2
+            if (du32->arg1 + 1 >= du32->arg2) {
+                return 1;
+            }
+            break;
+        default:
+            break;
+    }
+    return 0;
+}
 
 /**
  * \brief This function is used to parse u32 options passed via some u32 keyword
@@ -189,6 +215,10 @@ DetectU32Data *DetectU32Parse (const char *u32str)
             return NULL;
         }
     }
+    if (DetectU32Validate(&u32da)) {
+        SCLogError(SC_ERR_INVALID_VALUE, "Impossible value for uint32 condition");
+        return NULL;
+    }
     u32d = SCCalloc(1, sizeof (DetectU32Data));
     if (unlikely(u32d == NULL))
         return NULL;
@@ -256,6 +286,33 @@ int DetectU8Match(const uint8_t parg, const DetectU8Data *du8)
             return 0;
         default:
             BUG_ON("unknown mode");
+    }
+    return 0;
+}
+
+static int DetectU8Validate(DetectU8Data *du8) {
+    switch (du8->mode) {
+        case DETECT_UINT_LT:
+            if (du8->arg1 == 0) {
+                return 1;
+            }
+            break;
+        case DETECT_UINT_GT:
+            if (du8->arg1 == UINT8_MAX) {
+                return 1;
+            }
+            break;
+        case DETECT_UINT_RA:
+            if (du8->arg1 >= du8->arg2) {
+                return 1;
+            }
+            // we need at least one value that can match parg > du8->arg1 && parg < du8->arg2
+            if (du8->arg1 + 1 >= du8->arg2) {
+                return 1;
+            }
+            break;
+        default:
+            break;
     }
     return 0;
 }
@@ -372,6 +429,10 @@ DetectU8Data *DetectU8Parse (const char *u8str)
             SCLogError(SC_ERR_BYTE_EXTRACT_FAILED, "ByteExtractStringUint8 failed");
             return NULL;
         }
+    }
+    if (DetectU8Validate(&u8da)) {
+        SCLogError(SC_ERR_INVALID_VALUE, "Impossible value for uint8 condition");
+        return NULL;
     }
     u8d = SCCalloc(1, sizeof (DetectU8Data));
     if (unlikely(u8d == NULL))

--- a/src/detect-engine-uint.c
+++ b/src/detect-engine-uint.c
@@ -150,24 +150,33 @@ DetectU32Data *DetectU32Parse (const char *u32str)
         switch(arg2[0]) {
             case '<':
             case '>':
-                if (strlen(arg3) == 0)
-                    return NULL;
+                if (strlen(arg2) == 1) {
+                    if (strlen(arg3) == 0)
+                        return NULL;
 
-                if (ByteExtractStringUint32(&u32da.arg1, 10, strlen(arg3), arg3) < 0) {
-                    SCLogError(SC_ERR_BYTE_EXTRACT_FAILED, "ByteExtractStringUint32 failed");
+                    if (ByteExtractStringUint32(&u32da.arg1, 10, strlen(arg3), arg3) < 0) {
+                        SCLogError(SC_ERR_BYTE_EXTRACT_FAILED, "ByteExtractStringUint32 failed");
+                        return NULL;
+                    }
+
+                    SCLogDebug("u32 is %"PRIu32"",u32da.arg1);
+                    if (strlen(arg1) > 0)
+                        return NULL;
+
+                    if (arg2[0] == '<') {
+                        u32da.mode = DETECT_UINT_LT;
+                    } else { // arg2[0] == '>'
+                        u32da.mode = DETECT_UINT_GT;
+                    }
+                    break;
+                } else if (strlen(arg2) == 2) {
+                    if (arg2[0] != '<' || arg2[1] != '>') {
+                        return NULL;
+                    }
+                } else {
                     return NULL;
                 }
-
-                SCLogDebug("u32 is %"PRIu32"",u32da.arg1);
-                if (strlen(arg1) > 0)
-                    return NULL;
-
-                if (arg2[0] == '<') {
-                    u32da.mode = DETECT_UINT_LT;
-                } else { // arg2[0] == '>'
-                    u32da.mode = DETECT_UINT_GT;
-                }
-                break;
+                //fall through
             case '-':
                 if (strlen(arg1)== 0)
                     return NULL;
@@ -375,21 +384,30 @@ DetectU8Data *DetectU8Parse (const char *u8str)
         switch(arg2[0]) {
             case '<':
             case '>':
-                if (StringParseUint8(&u8da.arg1, 10, strlen(arg3), arg3) < 0) {
-                    SCLogError(SC_ERR_BYTE_EXTRACT_FAILED, "ByteExtractStringUint8 failed");
+                if (strlen(arg2) == 1) {
+                    if (StringParseUint8(&u8da.arg1, 10, strlen(arg3), arg3) < 0) {
+                        SCLogError(SC_ERR_BYTE_EXTRACT_FAILED, "ByteExtractStringUint8 failed");
+                        return NULL;
+                    }
+
+                    SCLogDebug("u8 is %"PRIu8"",u8da.arg1);
+                    if (strlen(arg1) > 0)
+                        return NULL;
+
+                    if (arg2[0] == '<') {
+                        u8da.mode = DETECT_UINT_LT;
+                    } else { // arg2[0] == '>'
+                        u8da.mode = DETECT_UINT_GT;
+                    }
+                    break;
+                } else if (strlen(arg2) == 2) {
+                    if (arg2[0] != '<' || arg2[1] != '>') {
+                        return NULL;
+                    }
+                } else {
                     return NULL;
                 }
-
-                SCLogDebug("u8 is %"PRIu8"",u8da.arg1);
-                if (strlen(arg1) > 0)
-                    return NULL;
-
-                if (arg2[0] == '<') {
-                    u8da.mode = DETECT_UINT_LT;
-                } else { // arg2[0] == '>'
-                    u8da.mode = DETECT_UINT_GT;
-                }
-                break;
+                //fallthrough
             case '-':
                 u8da.mode = DETECT_UINT_RA;
                 if (StringParseUint8(&u8da.arg1, 10, strlen(arg1), arg1) < 0) {

--- a/src/detect-engine-uint.c
+++ b/src/detect-engine-uint.c
@@ -194,9 +194,11 @@ DetectU32Data *DetectU32Parse (const char *u32str)
                 }
 
                 SCLogDebug("u32 is %"PRIu32" to %"PRIu32"", u32da.arg1, u32da.arg2);
-                if (u32da.arg1 >= u32da.arg2) {
-                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid u32 range. ");
-                    return NULL;
+                if (u32da.arg1 > u32da.arg2) {
+                    uint32_t temp = u32da.arg1;
+                    u32da.arg1 = u32da.arg2;
+                    u32da.arg2 = temp;
+                    SCLogWarning(SC_WARN_POOR_RULE, "Reversed u32 range. ");
                 }
                 break;
             default:
@@ -420,9 +422,11 @@ DetectU8Data *DetectU8Parse (const char *u8str)
                 }
 
                 SCLogDebug("u8 is %"PRIu8" to %"PRIu8"", u8da.arg1, u8da.arg2);
-                if (u8da.arg1 >= u8da.arg2) {
-                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid u8 range. ");
-                    return NULL;
+                if (u8da.arg1 > u8da.arg2) {
+                    uint8_t temp = u8da.arg1;
+                    u8da.arg1 = u8da.arg2;
+                    u8da.arg2 = temp;
+                    SCLogWarning(SC_WARN_POOR_RULE, "Reversed u8 range. ");
                 }
                 break;
             default:

--- a/src/detect-engine-uint.h
+++ b/src/detect-engine-uint.h
@@ -27,10 +27,10 @@
 #include "detect-engine-prefilter-common.h"
 
 typedef enum {
-    DETECT_UINT_LT,
-    DETECT_UINT_EQ,
-    DETECT_UINT_GT,
-    DETECT_UINT_RA,
+    DETECT_UINT_LT = PREFILTER_U8HASH_MODE_LT,
+    DETECT_UINT_EQ = PREFILTER_U8HASH_MODE_EQ,
+    DETECT_UINT_GT = PREFILTER_U8HASH_MODE_GT,
+    DETECT_UINT_RA = PREFILTER_U8HASH_MODE_RA,
 } DetectUintMode;
 
 typedef struct DetectU32Data_ {

--- a/src/detect-icode.c
+++ b/src/detect-icode.c
@@ -352,6 +352,21 @@ static int DetectICodeParseTest08(void)
 }
 
 /**
+ * \test DetectICodeParseTest09 is a test for setting a valid icode value
+ *       with "<<" operator
+ */
+static int DetectICodeParseTest09(void)
+{
+    DetectU8Data *icd = NULL;
+    icd = DetectU8Parse("8<<20");
+    if (icd == NULL)
+        return 1;
+    DetectICodeFree(NULL, icd);
+    return 0;
+
+}
+
+/**
  * \test DetectICodeMatchTest01 is a test for checking the working of icode
  *       keyword by creating 5 rules and matching a crafted packet against
  *       them. 4 out of 5 rules shall trigger.
@@ -451,6 +466,7 @@ void DetectICodeRegisterTests(void)
     UtRegisterTest("DetectICodeParseTest06", DetectICodeParseTest06);
     UtRegisterTest("DetectICodeParseTest07", DetectICodeParseTest07);
     UtRegisterTest("DetectICodeParseTest08", DetectICodeParseTest08);
+    UtRegisterTest("DetectICodeParseTest09", DetectICodeParseTest09);
     UtRegisterTest("DetectICodeMatchTest01", DetectICodeMatchTest01);
 }
 #endif /* UNITTESTS */

--- a/src/detect-icode.c
+++ b/src/detect-icode.c
@@ -30,6 +30,7 @@
 #include "detect.h"
 #include "detect-parse.h"
 #include "detect-engine-prefilter-common.h"
+#include "detect-engine-uint.h"
 
 #include "detect-icode.h"
 
@@ -41,9 +42,6 @@
 /**
  *\brief Regex for parsing our icode options
  */
-#define PARSE_REGEX "^\\s*(<|>)?\\s*([0-9]+)\\s*(?:<>\\s*([0-9]+))?\\s*$"
-
-static DetectParseRegex parse_regex;
 
 static int DetectICodeMatch(DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
@@ -72,40 +70,8 @@ void DetectICodeRegister (void)
 #endif
     sigmatch_table[DETECT_ICODE].SupportsPrefilter = PrefilterICodeIsPrefilterable;
     sigmatch_table[DETECT_ICODE].SetupPrefilter = PrefilterSetupICode;
-
-    DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
 }
 
-#define DETECT_ICODE_EQ   PREFILTER_U8HASH_MODE_EQ   /**< "equal" operator */
-#define DETECT_ICODE_LT   PREFILTER_U8HASH_MODE_LT   /**< "less than" operator */
-#define DETECT_ICODE_GT   PREFILTER_U8HASH_MODE_GT   /**< "greater than" operator */
-#define DETECT_ICODE_RN   PREFILTER_U8HASH_MODE_RA   /**< "range" operator */
-
-typedef struct DetectICodeData_ {
-    uint8_t code1;
-    uint8_t code2;
-
-    uint8_t mode;
-} DetectICodeData;
-
-static inline int ICodeMatch(const uint8_t pcode, const uint8_t mode,
-                             const uint8_t dcode1, const uint8_t dcode2)
-{
-    switch (mode) {
-        case DETECT_ICODE_EQ:
-            return (pcode == dcode1) ? 1 : 0;
-
-        case DETECT_ICODE_LT:
-            return (pcode < dcode1) ? 1 : 0;
-
-        case DETECT_ICODE_GT:
-            return (pcode > dcode1) ? 1 : 0;
-
-        case DETECT_ICODE_RN:
-            return (pcode > dcode1 && pcode < dcode2) ? 1 : 0;
-    }
-    return 0;
-}
 
 /**
  * \brief This function is used to match icode rule option set on a packet with those passed via icode:
@@ -113,7 +79,7 @@ static inline int ICodeMatch(const uint8_t pcode, const uint8_t mode,
  * \param t pointer to thread vars
  * \param det_ctx pointer to the pattern matcher thread
  * \param p pointer to the current packet
- * \param m pointer to the sigmatch that we will cast into DetectICodeData
+ * \param ctx pointer to the sigmatch that we will cast into DetectU8Data
  *
  * \retval 0 no match
  * \retval 1 match
@@ -134,110 +100,8 @@ static int DetectICodeMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
         return 0;
     }
 
-    const DetectICodeData *icd = (const DetectICodeData *)ctx;
-    return ICodeMatch(picode, icd->mode, icd->code1, icd->code2);
-}
-
-/**
- * \brief This function is used to parse icode options passed via icode: keyword
- *
- * \param de_ctx Pointer to the detection engine context
- * \param icodestr Pointer to the user provided icode options
- *
- * \retval icd pointer to DetectICodeData on success
- * \retval NULL on failure
- */
-static DetectICodeData *DetectICodeParse(DetectEngineCtx *de_ctx, const char *icodestr)
-{
-    DetectICodeData *icd = NULL;
-    char *args[3] = {NULL, NULL, NULL};
-    int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
-
-    ret = DetectParsePcreExec(&parse_regex, icodestr, 0, 0, ov, MAX_SUBSTRINGS);
-    if (ret < 1 || ret > 4) {
-        SCLogError(SC_ERR_PCRE_MATCH, "pcre_exec parse error, ret %" PRId32 ", string %s", ret, icodestr);
-        goto error;
-    }
-
-    int i;
-    const char *str_ptr;
-    for (i = 1; i < ret; i++) {
-        res = pcre_get_substring((char *)icodestr, ov, MAX_SUBSTRINGS, i, &str_ptr);
-        if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
-            goto error;
-        }
-        args[i-1] = (char *)str_ptr;
-    }
-
-    icd = SCMalloc(sizeof(DetectICodeData));
-    if (unlikely(icd == NULL))
-        goto error;
-    icd->code1 = 0;
-    icd->code2 = 0;
-    icd->mode = 0;
-
-    /* we have either "<" or ">" */
-    if (args[0] != NULL && strlen(args[0]) != 0) {
-        /* we have a third part ("<> y"), therefore it's invalid */
-        if (args[2] != NULL) {
-            SCLogError(SC_ERR_INVALID_VALUE, "icode: invalid value");
-            goto error;
-        }
-        /* we have only a comparison ("<", ">") */
-        if (StringParseUint8(&icd->code1, 10, 0, args[1]) < 0) {
-            SCLogError(SC_ERR_INVALID_ARGUMENT, "specified icmp code %s is not "
-                                        "valid", args[1]);
-            goto error;
-        }
-        if ((strcmp(args[0], ">")) == 0) icd->mode = DETECT_ICODE_GT;
-        else icd->mode = DETECT_ICODE_LT;
-    } else { /* no "<", ">" */
-        /* we have a range ("<>") */
-        if (args[2] != NULL) {
-            icd->mode = (uint8_t) DETECT_ICODE_RN;
-            if (StringParseUint8(&icd->code1, 10, 0, args[1]) < 0) {
-                SCLogError(SC_ERR_INVALID_ARGUMENT, "specified icmp code %s is not "
-                                            "valid", args[1]);
-                goto error;
-            }
-            if (StringParseUint8(&icd->code2, 10, 0, args[2]) < 0) {
-                SCLogError(SC_ERR_INVALID_ARGUMENT, "specified icmp code %s is not "
-                                            "valid", args[2]);
-                goto error;
-            }
-            /* we check that the first given value in the range is less than
-               the second, otherwise we swap them */
-            if (icd->code1 > icd->code2) {
-                uint8_t temp = icd->code1;
-                icd->code1 = icd->code2;
-                icd->code2 = temp;
-            }
-        } else { /* we have an equality */
-            icd->mode = DETECT_ICODE_EQ;
-            if (StringParseUint8(&icd->code1, 10, 0, args[1]) < 0) {
-                SCLogError(SC_ERR_INVALID_ARGUMENT, "specified icmp code %s is not "
-                                                    "valid", args[1]);
-                goto error;
-            }
-        }
-    }
-
-    for (i = 0; i < (ret-1); i++) {
-        if (args[i] != NULL)
-            SCFree(args[i]);
-    }
-    return icd;
-
-error:
-    for (i = 0; i < (ret-1) && i < 3; i++) {
-        if (args[i] != NULL)
-            SCFree(args[i]);
-    }
-    if (icd != NULL)
-        DetectICodeFree(de_ctx, icd);
-    return NULL;
+    const DetectU8Data *icd = (const DetectU8Data *)ctx;
+    return DetectU8Match(picode, icd);
 }
 
 /**
@@ -253,10 +117,10 @@ error:
 static int DetectICodeSetup(DetectEngineCtx *de_ctx, Signature *s, const char *icodestr)
 {
 
-    DetectICodeData *icd = NULL;
+    DetectU8Data *icd = NULL;
     SigMatch *sm = NULL;
 
-    icd = DetectICodeParse(NULL, icodestr);
+    icd = DetectU8Parse(icodestr);
     if (icd == NULL) goto error;
 
     sm = SigMatchAlloc();
@@ -271,20 +135,19 @@ static int DetectICodeSetup(DetectEngineCtx *de_ctx, Signature *s, const char *i
     return 0;
 
 error:
-    if (icd != NULL) DetectICodeFree(de_ctx, icd);
+    if (icd != NULL) SCFree(icd);
     if (sm != NULL) SCFree(sm);
     return -1;
 }
 
 /**
- * \brief this function will free memory associated with DetectICodeData
+ * \brief this function will free memory associated with DetectU8Data
  *
- * \param ptr pointer to DetectICodeData
+ * \param ptr pointer to DetectU8Data
  */
 void DetectICodeFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    DetectICodeData *icd = (DetectICodeData *)ptr;
-    SCFree(icd);
+    SCFree(ptr);
 }
 
 /* prefilter code */
@@ -316,19 +179,19 @@ static void PrefilterPacketICodeMatch(DetectEngineThreadCtx *det_ctx,
 static void
 PrefilterPacketICodeSet(PrefilterPacketHeaderValue *v, void *smctx)
 {
-    const DetectICodeData *a = smctx;
+    const DetectU8Data *a = smctx;
     v->u8[0] = a->mode;
-    v->u8[1] = a->code1;
-    v->u8[2] = a->code2;
+    v->u8[1] = a->arg1;
+    v->u8[2] = a->arg2;
 }
 
 static bool
 PrefilterPacketICodeCompare(PrefilterPacketHeaderValue v, void *smctx)
 {
-    const DetectICodeData *a = smctx;
+    const DetectU8Data *a = smctx;
     if (v.u8[0] == a->mode &&
-        v.u8[1] == a->code1 &&
-        v.u8[2] == a->code2)
+        v.u8[1] == a->arg1 &&
+        v.u8[2] == a->arg2)
         return TRUE;
     return FALSE;
 }
@@ -362,11 +225,11 @@ static bool PrefilterICodeIsPrefilterable(const Signature *s)
  */
 static int DetectICodeParseTest01(void)
 {
-    DetectICodeData *icd = NULL;
+    DetectU8Data *icd = NULL;
     int result = 0;
-    icd = DetectICodeParse(NULL, "8");
+    icd = DetectU8Parse("8");
     if (icd != NULL) {
-        if (icd->code1 == 8 && icd->mode == DETECT_ICODE_EQ)
+        if (icd->arg1 == 8 && icd->mode == DETECT_UINT_EQ)
             result = 1;
         DetectICodeFree(NULL, icd);
     }
@@ -379,11 +242,11 @@ static int DetectICodeParseTest01(void)
  */
 static int DetectICodeParseTest02(void)
 {
-    DetectICodeData *icd = NULL;
+    DetectU8Data *icd = NULL;
     int result = 0;
-    icd = DetectICodeParse(NULL, ">8");
+    icd = DetectU8Parse(">8");
     if (icd != NULL) {
-        if (icd->code1 == 8 && icd->mode == DETECT_ICODE_GT)
+        if (icd->arg1 == 8 && icd->mode == DETECT_UINT_GT)
             result = 1;
         DetectICodeFree(NULL, icd);
     }
@@ -396,11 +259,11 @@ static int DetectICodeParseTest02(void)
  */
 static int DetectICodeParseTest03(void)
 {
-    DetectICodeData *icd = NULL;
+    DetectU8Data *icd = NULL;
     int result = 0;
-    icd = DetectICodeParse(NULL, "<8");
+    icd = DetectU8Parse("<8");
     if (icd != NULL) {
-        if (icd->code1 == 8 && icd->mode == DETECT_ICODE_LT)
+        if (icd->arg1 == 8 && icd->mode == DETECT_UINT_LT)
             result = 1;
         DetectICodeFree(NULL, icd);
     }
@@ -413,11 +276,11 @@ static int DetectICodeParseTest03(void)
  */
 static int DetectICodeParseTest04(void)
 {
-    DetectICodeData *icd = NULL;
+    DetectU8Data *icd = NULL;
     int result = 0;
-    icd = DetectICodeParse(NULL, "8<>20");
+    icd = DetectU8Parse("8<>20");
     if (icd != NULL) {
-        if (icd->code1 == 8 && icd->code2 == 20 && icd->mode == DETECT_ICODE_RN)
+        if (icd->arg1 == 8 && icd->arg2 == 20 && icd->mode == DETECT_UINT_RA)
             result = 1;
         DetectICodeFree(NULL, icd);
     }
@@ -430,11 +293,11 @@ static int DetectICodeParseTest04(void)
  */
 static int DetectICodeParseTest05(void)
 {
-    DetectICodeData *icd = NULL;
+    DetectU8Data *icd = NULL;
     int result = 0;
-    icd = DetectICodeParse(NULL, "  8 ");
+    icd = DetectU8Parse("  8 ");
     if (icd != NULL) {
-        if (icd->code1 == 8 && icd->mode == DETECT_ICODE_EQ)
+        if (icd->arg1 == 8 && icd->mode == DETECT_UINT_EQ)
             result = 1;
         DetectICodeFree(NULL, icd);
     }
@@ -447,11 +310,11 @@ static int DetectICodeParseTest05(void)
  */
 static int DetectICodeParseTest06(void)
 {
-    DetectICodeData *icd = NULL;
+    DetectU8Data *icd = NULL;
     int result = 0;
-    icd = DetectICodeParse(NULL, "  >  8 ");
+    icd = DetectU8Parse("  >  8 ");
     if (icd != NULL) {
-        if (icd->code1 == 8 && icd->mode == DETECT_ICODE_GT)
+        if (icd->arg1 == 8 && icd->mode == DETECT_UINT_GT)
             result = 1;
         DetectICodeFree(NULL, icd);
     }
@@ -464,11 +327,11 @@ static int DetectICodeParseTest06(void)
  */
 static int DetectICodeParseTest07(void)
 {
-    DetectICodeData *icd = NULL;
+    DetectU8Data *icd = NULL;
     int result = 0;
-    icd = DetectICodeParse(NULL, "  8  <>  20 ");
+    icd = DetectU8Parse("  8  <>  20 ");
     if (icd != NULL) {
-        if (icd->code1 == 8 && icd->code2 == 20 && icd->mode == DETECT_ICODE_RN)
+        if (icd->arg1 == 8 && icd->arg2 == 20 && icd->mode == DETECT_UINT_RA)
             result = 1;
         DetectICodeFree(NULL, icd);
     }
@@ -480,8 +343,8 @@ static int DetectICodeParseTest07(void)
  */
 static int DetectICodeParseTest08(void)
 {
-    DetectICodeData *icd = NULL;
-    icd = DetectICodeParse(NULL, "> 8 <> 20");
+    DetectU8Data *icd = NULL;
+    icd = DetectU8Parse("> 8 <> 20");
     if (icd == NULL)
         return 1;
     DetectICodeFree(NULL, icd);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4112
https://redmine.openinfosecfoundation.org/issues/4335

Describe changes:
- Adds error for impossible rules such as >255 for uint8 fields
- converts icode to use the generic (many more keywords to do)
  * allows <> syntax for uint ranges to support existing syntax
  * corrects reverted ranges and issues a warning (so 20<>8 becomes 8<>20 ) to support existing syntax

Modifies #5920 by getting CI to pass with //fallthrough comment and using the new test