### PR TITLE
unix-socket: reset to ready state on startup - v1

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2024,8 +2024,14 @@ void PreRunPostPrivsDropInit(const int runmode)
     StatsSetupPostConfigPreOutput();
     RunModeInitializeOutputs();
 
-    if (runmode == RUNMODE_UNIX_SOCKET)
+    if (runmode == RUNMODE_UNIX_SOCKET) {
+        /* As the above did some necessary startup initialization, it
+         * also setup some outputs where only one is allowed, so
+         * deinitialize to the state that unix-mode does after every
+         * pcap. */
+        PostRunDeinit(RUNMODE_PCAP_FILE, NULL);
         return;
+    }
 
     StatsSetupPostConfigPostOutput();
 }


### PR DESCRIPTION
As part of commit ea15282f47c6ff781533e3a063f9c903dd6f1afb,
some initialization was moved to happen even in unix socket mode,
however, this initialization does setup some loggers that can only have
one instance enabled (anomaly, drop, file-store).

This will cause these loggers to error out on the first pcap, but work
on subsequent runs of the pcap as some deinitialization is done after
each pcap.

This is a bit of a hack, a better fix would be to detangle the real one
time initialization code like pre-formatting metadata (commit
a8e2399ea9aea93166fb9d5280dda47882b291ef) from the reinitialization of
modules like required for the unix socket.

This fix just runs the post pcap-file deinitialization routine to
reset some of the initialization done on startup, like is done after
running each pcap in unix socket mode.

Related remind issue:
https://redmine.openinfosecfoundation.org/issues/4225
