### PR TITLE
filestore: fix global counter init in unix socket mode - v2

### DIFF
--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -525,9 +525,6 @@ static OutputInitResult OutputFilestoreLogInitCtx(ConfNode *conf)
         }
     }
 
-    StatsRegisterGlobalCounter("file_store.open_files",
-            OutputFilestoreOpenFilesCounter);
-
     result.ctx = output_ctx;
     result.ok = true;
     SCReturnCT(result, "OutputInitResult");
@@ -542,4 +539,9 @@ void OutputFilestoreRegister(void)
 
     SC_ATOMIC_INIT(filestore_open_file_cnt);
     SC_ATOMIC_SET(filestore_open_file_cnt, 0);
+}
+
+void OutputFilestoreRegisterGlobalCounters(void)
+{
+    StatsRegisterGlobalCounter("file_store.open_files", OutputFilestoreOpenFilesCounter);
 }

--- a/src/output-filestore.h
+++ b/src/output-filestore.h
@@ -20,5 +20,6 @@
 
 void OutputFilestoreRegister(void);
 void OutputFilestoreInitConfig(void);
+void OutputFilestoreRegisterGlobalCounters(void);
 
 #endif /* __OUTPUT_FILESTORE_H__ */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -125,6 +125,8 @@
 #include "app-layer-smb.h"
 #include "app-layer-dcerpc.h"
 
+#include "output-filestore.h"
+
 #include "util-ebpf.h"
 #include "util-radix-tree.h"
 #include "util-host-os-info.h"
@@ -2015,6 +2017,7 @@ void PreRunInit(const int runmode)
     StreamTcpInitConfig(STREAM_VERBOSE);
     AppLayerParserPostStreamSetup();
     AppLayerRegisterGlobalCounters();
+    OutputFilestoreRegisterGlobalCounters();
 }
 
 /* tasks we need to run before packets start flowing,


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/5671

Changes from last PR:
- Update for master and removal of HAVE_NSS: just remove the HAVE_NSS guard.

Move initialization of filestore global counter to PreRunInit,
so they get registered during program initialization, or as
required in unix-socket mode, initialized for each file run.

Fixes Redmine issue:
https://redmine.openinfosecfoundation.org/issues/4216
