### PR TITLE
When the incoming data is "229 Entering Extended Passive Mode (|||495…

### DIFF
--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -66,7 +66,7 @@ named!(pub ftp_pasv_response<u16>,
             part1: verify!(getu16, |&v| v <= std::u8::MAX as u16) >>
             tag!(",") >>
             part2: verify!(getu16, |&v| v <= std::u8::MAX as u16) >>
-            alt! (tag!(").") | tag!(")")) >>
+            alt! (tag!(")") | tag!(").")) >>
             (
                 part1 * 256 + part2
             )
@@ -118,7 +118,7 @@ named!(pub ftp_epsv_response<u16>,
             take_until!("|||") >>
             tag!("|||") >>
             port: getu16 >>
-            alt! (tag!("|).") | tag!("|)")) >>
+            alt! (tag!("|)") | tag!("|).")) >>
             (
                 port
             )


### PR DESCRIPTION
…88|)", an Incomplete error will be generated.

The reason for the problem is that "tag!("|).")" is matched first.
Reference link: https://docs.rs/nom/4.0.0/nom/macro.alt.html

(cherry picked from commit e863d1692fe1be8c18b3f6a87f45e9638f821217)

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ ] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
