### PR TITLE
docs - add docutils.conf to disable smart quotes

### DIFF
--- a/doc/devguide/docutils.conf
+++ b/doc/devguide/docutils.conf
@@ -1,0 +1,2 @@
+[parsers]
+smart_quotes: false

--- a/doc/userguide/docutils.conf
+++ b/doc/userguide/docutils.conf
@@ -1,0 +1,2 @@
+[parsers]
+smart_quotes: false


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Disable use of stupid Unicode smart quotes in readthedocs

fixes examples such as https://suricata.readthedocs.io/en/latest/rules/dns-keywords.html#dns-query 

![image](https://user-images.githubusercontent.com/5124946/109797709-ceac6b00-7be7-11eb-8564-192d010a69c9.png)
-----

Regards,

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
