### PR TITLE
Support "-r -" to indicate "read pcap from stdin"

### DIFF
--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -237,7 +237,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
 
     DIR *directory = NULL;
     SCLogDebug("checking file or directory %s", (char*)initdata);
-    if(PcapDetermineDirectoryOrFile((char *)initdata, &directory) == TM_ECODE_FAILED) {
+    if(strcmp("-", (char *)initdata) != 0 && PcapDetermineDirectoryOrFile((char *)initdata, &directory) == TM_ECODE_FAILED) {
         CleanupPcapFileThreadVars(ptv);
         SCReturnInt(TM_ECODE_OK);
     }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1752,10 +1752,10 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             }
 #ifdef OS_WIN32
             struct _stat buf;
-            if(_stat(optarg, &buf) != 0) {
+            if(strcmp("-", optarg) != 0 && _stat(optarg, &buf) != 0) {
 #else
             struct stat buf;
-            if (stat(optarg, &buf) != 0) {
+            if (strcmp("-", optarg) != 0 && stat(optarg, &buf) != 0) {
 #endif /* OS_WIN32 */
                 SCLogError(SC_ERR_INITIALIZATION, "ERROR: Pcap file does not exist\n");
                 return TM_ECODE_FAILED;


### PR DESCRIPTION
This commit allows "-" to be passed down to pcap_open_offline as a
file name that means "read from standard input". This is in line with
other pcap-reading tools like tcpdump or zeek.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:         git clone https://github.com/OISF/libhtp -b 0.5.x


Describe changes:
- Support `-r -` to mean "read from stdin".
-
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
