### PR TITLE
Detect/pd only/v3

### DIFF
--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -263,25 +263,17 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
             }
 
             if (s->flags & SIG_FLAG_IPONLY) {
-                if (((p->flowflags & FLOW_PKT_TOSERVER) && !(p->flowflags & FLOW_PKT_TOSERVER_IPONLY_SET)) ||
-                    ((p->flowflags & FLOW_PKT_TOCLIENT) && !(p->flowflags & FLOW_PKT_TOCLIENT_IPONLY_SET))) {
-                    SCLogDebug("testing against \"ip-only\" signatures");
-
-                    if (p->flow != NULL) {
-                        /* Update flow flags for iponly */
-                        FlowSetIPOnlyFlag(p->flow, (p->flowflags & FLOW_PKT_TOSERVER) ? 1 : 0);
-
-                        if (s->action & ACTION_DROP)
-                            p->flow->flags |= FLOW_ACTION_DROP;
-                        if (s->action & ACTION_REJECT)
-                            p->flow->flags |= FLOW_ACTION_DROP;
-                        if (s->action & ACTION_REJECT_DST)
-                            p->flow->flags |= FLOW_ACTION_DROP;
-                        if (s->action & ACTION_REJECT_BOTH)
-                            p->flow->flags |= FLOW_ACTION_DROP;
-                        if (s->action & ACTION_PASS) {
-                            FlowSetNoPacketInspectionFlag(p->flow);
-                        }
+                if (p->flow != NULL) {
+                    if (s->action & ACTION_DROP)
+                        p->flow->flags |= FLOW_ACTION_DROP;
+                    if (s->action & ACTION_REJECT)
+                        p->flow->flags |= FLOW_ACTION_DROP;
+                    if (s->action & ACTION_REJECT_DST)
+                        p->flow->flags |= FLOW_ACTION_DROP;
+                    if (s->action & ACTION_REJECT_BOTH)
+                        p->flow->flags |= FLOW_ACTION_DROP;
+                    if (s->action & ACTION_PASS) {
+                        FlowSetNoPacketInspectionFlag(p->flow);
                     }
                 }
             }

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -275,7 +275,8 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
                 }
             }
 
-            if (s->flags & SIG_FLAG_IPONLY) {
+            /* IP-only and PD-only matches should apply to the flow */
+            if (s->flags & (SIG_FLAG_IPONLY | SIG_FLAG_PDONLY)) {
                 if (p->flow != NULL) {
                     RuleActionToFlow(s->action, p->flow);
                 }


### PR DESCRIPTION
Fix dropping on "PD only" sigs. These drops were only applied to a single packet, not to the flow.

Minor cleanups.

suricata-verify-pr: 476