### PR TITLE
kerberos: fix probing parser tag condition

### DIFF
--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -415,7 +415,7 @@ pub extern "C" fn rs_krb5_probing_parser(_flow: *const Flow,
             // Kerberos messages start with an APPLICATION header
             if hdr.class != BerClass::Application { return unsafe{ALPROTO_FAILED}; }
             // Tag number should be <= 30
-            if hdr.tag.0 >= 30 { return unsafe{ALPROTO_FAILED}; }
+            if hdr.tag.0 > 30 { return unsafe{ALPROTO_FAILED}; }
             // Kerberos messages contain sequences
             if rem.is_empty() || rem[0] != 0x30 { return unsafe{ALPROTO_FAILED}; }
             // Check kerberos version


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2809

Describe changes:
- Fixes kerberos probing parser according to the comment

cc @chifflier for such a big patch

suricata-verify-pr: 475

https://github.com/OISF/suricata-verify/pull/475