### PR TITLE
scripts/setup-app-layer: fix Makefile.am patch

### DIFF
--- a/scripts/setup-app-layer.py
+++ b/scripts/setup-app-layer.py
@@ -90,7 +90,7 @@ def patch_makefile_am(protoname):
     output = io.StringIO()
     with open("src/Makefile.am") as infile:
         for line in infile:
-            if line.startswith("app-layer-template.c"):
+            if line.startswith("	app-layer-template.c"):
                 output.write(line.replace("template", protoname.lower()))
             output.write(line)
     open("src/Makefile.am", "w").write(output.getvalue())
@@ -277,7 +277,7 @@ def logger_patch_makefile_am(protoname):
     output = io.StringIO()
     with open(filename) as infile:
         for line in infile:
-            if line.startswith("output-json-template.c"):
+            if line.startswith("	output-json-template.c"):
                 output.write(line.replace("template", protoname.lower()))
             output.write(line)
     open(filename, "w").write(output.getvalue())
@@ -545,7 +545,7 @@ The following files have been created and linked into the build:
 
     if parser or logger:
         print("""
-Suricata should now build cleanly. Try running "make".
+Suricata should now build cleanly. Try running "./configure" and "make".
 """)
 
 if __name__ == "__main__":


### PR DESCRIPTION
adjust lines for patching /src/Makefile.am, as currently generated
Makefile wasn't building Suricata.
Add suggestion to run "./configure" before running "make"

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
there isn't one. Should I create in this case?

Describe changes:
- after a recent change in the Makefile.am file, setup-app-layer patches to this file stopped working, as an indent was inserted in the line it should recognize. To fix this, added that space where the script looks for the pattern to be replaced.
- also added the suggestion to run `./configure` before make, so a new suricata.yaml file will be generated, too.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
