### PR TITLE
plugin/syslog: Make syslog an internal plugin

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -413,6 +413,7 @@ noinst_HEADERS = \
 	output-json-template-rust.h \
 	output-json-tftp.h \
 	output-json-tls.h \
+	output-eve-syslog.h \
 	output-lua.h \
 	output-packet.h \
 	output-stats.h \
@@ -990,6 +991,7 @@ libsuricata_c_a_SOURCES = \
 	output-json-template-rust.c \
 	output-json-tftp.c \
 	output-json-tls.c \
+	output-eve-syslog.c \
 	output-lua.c \
 	output-packet.c \
 	output-stats.c \

--- a/src/output-eve-syslog.c
+++ b/src/output-eve-syslog.c
@@ -1,0 +1,117 @@
+/* vi: set et ts=4: */
+/* Copyright (C) 2021 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Mike Pomraning <mpomraning@qualys.com>
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ *
+ * File-like output for logging:  syslog
+ */
+
+#ifndef OS_WIN32
+#include "suricata-plugin.h" /* errno.h, string.h, etc. */
+#include "conf.h"            /* ConfNode, etc. */
+#include "output.h"          /* DEFAULT_LOG_* */
+#include "output-eve-syslog.h"
+#include "util-syslog.h"
+
+#define DEFAULT_ALERT_SYSLOG_FACILITY_STR "local0"
+#define DEFAULT_ALERT_SYSLOG_FACILITY     LOG_LOCAL0
+#define DEFAULT_ALERT_SYSLOG_LEVEL        LOG_INFO
+
+#define OUTPUT_NAME "syslog"
+
+typedef struct Context_ {
+    int alert_syslog_level;
+} Context;
+
+static int SyslogInit(ConfNode *conf, bool threaded, void **init_data)
+{
+    Context *context = SCCalloc(1, sizeof(Context));
+    if (context == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate context for %s", OUTPUT_NAME);
+        return -1;
+    }
+    const char *facility_s = ConfNodeLookupChildValue(conf, "facility");
+    if (facility_s == NULL) {
+        facility_s = DEFAULT_ALERT_SYSLOG_FACILITY_STR;
+    }
+
+    int facility = SCMapEnumNameToValue(facility_s, SCSyslogGetFacilityMap());
+    if (facility == -1) {
+        SCLogWarning(SC_ERR_INVALID_ARGUMENT,
+                "Invalid syslog facility: \"%s\","
+                " now using \"%s\" as syslog facility",
+                facility_s, DEFAULT_ALERT_SYSLOG_FACILITY_STR);
+        facility = DEFAULT_ALERT_SYSLOG_FACILITY;
+    }
+
+    const char *level_s = ConfNodeLookupChildValue(conf, "level");
+    if (level_s != NULL) {
+        int level = SCMapEnumNameToValue(level_s, SCSyslogGetLogLevelMap());
+        if (level != -1) {
+            context->alert_syslog_level = level;
+        }
+    }
+
+    const char *ident = ConfNodeLookupChildValue(conf, "identity");
+    /* if null we just pass that to openlog, which will then
+     * figure it out by itself. */
+
+    openlog(ident, LOG_PID | LOG_NDELAY, facility);
+    SCLogNotice("Syslog: facility %s, level %s, ident %s", facility_s, level_s, ident);
+    *init_data = context;
+    return 0;
+}
+
+static int SyslogWrite(const char *buffer, int buffer_len, void *init_data, void *thread_data)
+{
+    Context *context = init_data;
+    syslog(context->alert_syslog_level, "%s", (const char *)buffer);
+
+    return 0;
+}
+
+static void SyslogDeInit(void *init_data)
+{
+    if (init_data) {
+        closelog();
+        SCFree(init_data);
+    }
+}
+
+void SyslogInitialize(void)
+{
+    SCPluginFileType *plugin_data = SCCalloc(1, sizeof(SCPluginFileType));
+
+    if (plugin_data == NULL) {
+        FatalError(SC_ERR_MEM_ALLOC, "Unable to allocate memory for eve output %s", OUTPUT_NAME);
+    }
+
+    plugin_data->internal = true;
+    plugin_data->name = OUTPUT_NAME;
+    plugin_data->Init = SyslogInit;
+    plugin_data->Deinit = SyslogDeInit;
+    plugin_data->Write = SyslogWrite;
+    if (!SCRegisterEveFileType(plugin_data)) {
+        FatalError(SC_ERR_PLUGIN, "Failed to register EVE output: %s", OUTPUT_NAME);
+    }
+}
+#endif /* !OS_WIN32 */

--- a/src/output-eve-syslog.h
+++ b/src/output-eve-syslog.h
@@ -1,0 +1,32 @@
+/* Copyright (C) 2021 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ */
+
+#ifndef __OUTPUT_SYSLOG_PLUGIN_H__
+#define __OUTPUT_SYSLOG_PLUGIN_H__
+
+#ifndef OS_WIN32
+void SyslogInitialize(void);
+SCPlugin *SyslogRegister(void);
+#endif /* !OS_WIN32 */
+
+#endif /* __OUTPUT_SYSLOG_PLUGIN_H__ */

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1002,6 +1002,117 @@ int OutputJsonBuilderBuffer(JsonBuilder *js, OutputJsonThreadCtx *ctx)
     return 0;
 }
 
+static inline enum LogFileType FileTypeFromConf(const char *typestr)
+{
+    enum LogFileType log_filetype = LOGFILE_TYPE_NOTSET;
+
+    if (typestr == NULL) {
+        log_filetype = LOGFILE_TYPE_FILE;
+    } else if (strcmp(typestr, "file") == 0 || strcmp(typestr, "regular") == 0) {
+        log_filetype = LOGFILE_TYPE_FILE;
+    } else if (strcmp(typestr, "syslog") == 0) {
+        log_filetype = LOGFILE_TYPE_SYSLOG;
+    } else if (strcmp(typestr, "unix_dgram") == 0) {
+        log_filetype = LOGFILE_TYPE_UNIX_DGRAM;
+    } else if (strcmp(typestr, "unix_stream") == 0) {
+        log_filetype = LOGFILE_TYPE_UNIX_STREAM;
+    } else if (strcmp(typestr, "redis") == 0) {
+#ifdef HAVE_LIBHIREDIS
+        log_filetype = LOGFILE_TYPE_REDIS;
+#else
+        FatalError(SC_ERR_FATAL, "redis JSON output option is not compiled");
+#endif
+    }
+    SCLogNotice("type %s, file type value %d", typestr, log_filetype);
+    return log_filetype;
+}
+
+static int LogFileTypePrepare(
+        OutputJsonCtx *json_ctx, enum LogFileType log_filetype, ConfNode *conf)
+{
+
+    if (log_filetype == LOGFILE_TYPE_FILE || log_filetype == LOGFILE_TYPE_UNIX_DGRAM ||
+            log_filetype == LOGFILE_TYPE_UNIX_STREAM) {
+        if (log_filetype == LOGFILE_TYPE_FILE) {
+            /* Threaded file output */
+            const ConfNode *threaded = ConfNodeLookupChild(conf, "threaded");
+            if (threaded && threaded->val && ConfValIsTrue(threaded->val)) {
+                SCLogConfig("Enabling threaded eve logging.");
+                json_ctx->file_ctx->threaded = true;
+            } else {
+                json_ctx->file_ctx->threaded = false;
+            }
+        }
+
+        if (SCConfLogOpenGeneric(conf, json_ctx->file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
+            return -1;
+        }
+        OutputRegisterFileRotationFlag(&json_ctx->file_ctx->rotation_flag);
+
+    }
+#ifndef OS_WIN32
+    else if (log_filetype == LOGFILE_TYPE_SYSLOG) {
+        const char *facility_s = ConfNodeLookupChildValue(conf, "facility");
+        if (facility_s == NULL) {
+            facility_s = DEFAULT_ALERT_SYSLOG_FACILITY_STR;
+        }
+
+        int facility = SCMapEnumNameToValue(facility_s, SCSyslogGetFacilityMap());
+        if (facility == -1) {
+            SCLogWarning(SC_ERR_INVALID_ARGUMENT,
+                    "Invalid syslog facility: \"%s\","
+                    " now using \"%s\" as syslog facility",
+                    facility_s, DEFAULT_ALERT_SYSLOG_FACILITY_STR);
+            facility = DEFAULT_ALERT_SYSLOG_FACILITY;
+        }
+
+        const char *level_s = ConfNodeLookupChildValue(conf, "level");
+        if (level_s != NULL) {
+            int level = SCMapEnumNameToValue(level_s, SCSyslogGetLogLevelMap());
+            if (level != -1) {
+                json_ctx->file_ctx->syslog_setup.alert_syslog_level = level;
+            }
+        }
+
+        const char *ident = ConfNodeLookupChildValue(conf, "identity");
+        /* if null we just pass that to openlog, which will then
+         * figure it out by itself. */
+
+        openlog(ident, LOG_PID | LOG_NDELAY, facility);
+    }
+#endif
+#ifdef HAVE_LIBHIREDIS
+    else if (log_filetype == LOGFILE_TYPE_REDIS) {
+        SCLogRedisInit();
+        ConfNode *redis_node = ConfNodeLookupChild(conf, "redis");
+        if (!json_ctx->file_ctx->sensor_name) {
+            char hostname[1024];
+            gethostname(hostname, 1023);
+            json_ctx->file_ctx->sensor_name = SCStrdup(hostname);
+        }
+        if (json_ctx->file_ctx->sensor_name == NULL) {
+            return -1;
+        }
+
+        if (SCConfLogOpenRedis(redis_node, json_ctx->file_ctx) < 0) {
+            return -1;
+        }
+    }
+#endif
+    else if (log_filetype == LOGFILE_TYPE_PLUGIN) {
+        ConfNode *plugin_conf = ConfNodeLookupChild(conf, json_ctx->plugin->name);
+        void *init_data = NULL;
+        if (json_ctx->plugin->Init(json_ctx->plugin->internal ? conf : plugin_conf,
+                    json_ctx->file_ctx->threaded, &init_data) < 0) {
+            return -1;
+        }
+        json_ctx->file_ctx->plugin.plugin = json_ctx->plugin;
+        json_ctx->file_ctx->plugin.init_data = init_data;
+    }
+
+    return 0;
+}
+
 /**
  * \brief Create a new LogFileCtx for "fast" output style.
  * \param conf The configuration node for this output.
@@ -1010,6 +1121,7 @@ int OutputJsonBuilderBuffer(JsonBuilder *js, OutputJsonThreadCtx *ctx)
 OutputInitResult OutputJsonInitCtx(ConfNode *conf)
 {
     OutputInitResult result = { NULL, false };
+    OutputCtx *output_ctx = NULL;
 
     OutputJsonCtx *json_ctx = SCCalloc(1, sizeof(OutputJsonCtx));
     if (unlikely(json_ctx == NULL)) {
@@ -1038,20 +1150,16 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
 
     if (sensor_name) {
         json_ctx->file_ctx->sensor_name = SCStrdup(sensor_name);
-        if (json_ctx->file_ctx->sensor_name  == NULL) {
-            LogFileFreeCtx(json_ctx->file_ctx);
-            SCFree(json_ctx);
-            return result;
+        if (json_ctx->file_ctx->sensor_name == NULL) {
+            goto error_exit;
         }
     } else {
         json_ctx->file_ctx->sensor_name = NULL;
     }
 
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
+    output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {
-        LogFileFreeCtx(json_ctx->file_ctx);
-        SCFree(json_ctx);
-        return result;
+        goto error_exit;
     }
 
     output_ctx->data = json_ctx;
@@ -1059,45 +1167,21 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
 
     if (conf) {
         const char *output_s = ConfNodeLookupChildValue(conf, "filetype");
-
         // Backwards compatibility
         if (output_s == NULL) {
             output_s = ConfNodeLookupChildValue(conf, "type");
         }
 
-        if (output_s != NULL) {
-            if (strcmp(output_s, "file") == 0 ||
-                strcmp(output_s, "regular") == 0) {
-                json_ctx->json_out = LOGFILE_TYPE_FILE;
-            } else if (strcmp(output_s, "syslog") == 0) {
-                json_ctx->json_out = LOGFILE_TYPE_SYSLOG;
-            } else if (strcmp(output_s, "unix_dgram") == 0) {
-                json_ctx->json_out = LOGFILE_TYPE_UNIX_DGRAM;
-            } else if (strcmp(output_s, "unix_stream") == 0) {
-                json_ctx->json_out = LOGFILE_TYPE_UNIX_STREAM;
-            } else if (strcmp(output_s, "redis") == 0) {
-#ifdef HAVE_LIBHIREDIS
-                SCLogRedisInit();
-                json_ctx->json_out = LOGFILE_TYPE_REDIS;
-#else
-                           FatalError(SC_ERR_FATAL,
-                                      "redis JSON output option is not compiled");
-#endif
-            } else {
+        enum LogFileType log_filetype = FileTypeFromConf(output_s);
+        if (log_filetype == LOGFILE_TYPE_NOTSET) {
 #ifdef HAVE_PLUGINS
-                SCPluginFileType *plugin = SCPluginFindFileType(output_s);
-                if (plugin == NULL) {
-                    FatalError(SC_ERR_INVALID_ARGUMENT,
-                            "Invalid JSON output option: %s", output_s);
-                } else {
-                    json_ctx->json_out = LOGFILE_TYPE_PLUGIN;
-                    json_ctx->plugin = plugin;
-                }
-#else
-                FatalError(SC_ERR_INVALID_ARGUMENT,
-                        "Invalid JSON output option: %s", output_s);
+            SCPluginFileType *plugin = SCPluginFindFileType(output_s);
+            if (plugin != NULL) {
+                log_filetype = LOGFILE_TYPE_PLUGIN;
+                json_ctx->plugin = plugin;
+            } else
 #endif
-            }
+                FatalError(SC_ERR_INVALID_ARGUMENT, "Invalid JSON output option: %s", output_s);
         }
 
         const char *prefix = ConfNodeLookupChildValue(conf, "prefix");
@@ -1121,115 +1205,17 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
         } else {
             json_ctx->file_ctx->threaded = false;
         }
-
-        if (json_ctx->json_out == LOGFILE_TYPE_FILE ||
-            json_ctx->json_out == LOGFILE_TYPE_UNIX_DGRAM ||
-            json_ctx->json_out == LOGFILE_TYPE_UNIX_STREAM)
-        {
-
-            if (SCConfLogOpenGeneric(conf, json_ctx->file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
-                LogFileFreeCtx(json_ctx->file_ctx);
-                SCFree(json_ctx);
-                SCFree(output_ctx);
-                return result;
-            }
-            OutputRegisterFileRotationFlag(&json_ctx->file_ctx->rotation_flag);
-
+        if (LogFileTypePrepare(json_ctx, log_filetype, conf) < 0) {
+            goto error_exit;
         }
-#ifndef OS_WIN32
-	else if (json_ctx->json_out == LOGFILE_TYPE_SYSLOG) {
-            const char *facility_s = ConfNodeLookupChildValue(conf, "facility");
-            if (facility_s == NULL) {
-                facility_s = DEFAULT_ALERT_SYSLOG_FACILITY_STR;
-            }
-
-            int facility = SCMapEnumNameToValue(facility_s, SCSyslogGetFacilityMap());
-            if (facility == -1) {
-                SCLogWarning(SC_ERR_INVALID_ARGUMENT, "Invalid syslog facility: \"%s\","
-                        " now using \"%s\" as syslog facility", facility_s,
-                        DEFAULT_ALERT_SYSLOG_FACILITY_STR);
-                facility = DEFAULT_ALERT_SYSLOG_FACILITY;
-            }
-
-            const char *level_s = ConfNodeLookupChildValue(conf, "level");
-            if (level_s != NULL) {
-                int level = SCMapEnumNameToValue(level_s, SCSyslogGetLogLevelMap());
-                if (level != -1) {
-                    json_ctx->file_ctx->syslog_setup.alert_syslog_level = level;
-                }
-            }
-
-            const char *ident = ConfNodeLookupChildValue(conf, "identity");
-            /* if null we just pass that to openlog, which will then
-             * figure it out by itself. */
-
-            openlog(ident, LOG_PID|LOG_NDELAY, facility);
-        }
-#endif
-#ifdef HAVE_LIBHIREDIS
-        else if (json_ctx->json_out == LOGFILE_TYPE_REDIS) {
-            ConfNode *redis_node = ConfNodeLookupChild(conf, "redis");
-            if (!json_ctx->file_ctx->sensor_name) {
-                char hostname[1024];
-                gethostname(hostname, 1023);
-                json_ctx->file_ctx->sensor_name = SCStrdup(hostname);
-            }
-            if (json_ctx->file_ctx->sensor_name  == NULL) {
-                LogFileFreeCtx(json_ctx->file_ctx);
-                SCFree(json_ctx);
-                SCFree(output_ctx);
-                return result;
-            }
-
-            if (SCConfLogOpenRedis(redis_node, json_ctx->file_ctx) < 0) {
-                LogFileFreeCtx(json_ctx->file_ctx);
-                SCFree(json_ctx);
-                SCFree(output_ctx);
-                return result;
-            }
-        }
-#endif
-#ifdef HAVE_PLUGINS
-        else if (json_ctx->json_out == LOGFILE_TYPE_PLUGIN) {
-            if (json_ctx->file_ctx->threaded) {
-                /* Prepare for storing per-thread data */
-                if (!SCLogOpenThreadedFile(NULL, NULL, json_ctx->file_ctx, 1)) {
-                    SCFree(json_ctx);
-                    SCFree(output_ctx);
-                    return result;
-                }
-            }
-
-            void *init_data = NULL;
-            if (json_ctx->plugin->Init(conf, json_ctx->file_ctx->threaded, &init_data) < 0) {
-                LogFileFreeCtx(json_ctx->file_ctx);
-                SCFree(json_ctx);
-                SCFree(output_ctx);
-                return result;
-            }
-
-            /* Now that initialization completed successfully, if threaded, make sure
-             * that ThreadInit and ThreadDeInit exist
-             */
-            if (json_ctx->file_ctx->threaded) {
-                if (!json_ctx->plugin->ThreadInit || !json_ctx->plugin->ThreadDeinit) {
-                    FatalError(SC_ERR_LOG_OUTPUT, "Output logger must supply ThreadInit and "
-                                                  "ThreadDeinit functions for threaded mode");
-                }
-            }
-
-            json_ctx->file_ctx->plugin.plugin = json_ctx->plugin;
-            json_ctx->file_ctx->plugin.init_data = init_data;
-        }
-#endif
 
         const char *sensor_id_s = ConfNodeLookupChildValue(conf, "sensor-id");
         if (sensor_id_s != NULL) {
             if (StringParseUint64((uint64_t *)&sensor_id, 10, 0, sensor_id_s) < 0) {
-                SCLogError(SC_ERR_INVALID_ARGUMENT,
-                           "Failed to initialize JSON output, "
-                           "invalid sensor-id: %s", sensor_id_s);
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_INVALID_ARGUMENT,
+                        "Failed to initialize JSON output, "
+                        "invalid sensor-id: %s",
+                        sensor_id_s);
             }
         }
 
@@ -1264,10 +1250,10 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
             if (StringParseUint16(&json_ctx->cfg.community_id_seed,
                         10, 0, cid_seed) < 0)
             {
-                SCLogError(SC_ERR_INVALID_ARGUMENT,
-                           "Failed to initialize JSON output, "
-                           "invalid community-id-seed: %s", cid_seed);
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_INVALID_ARGUMENT,
+                        "Failed to initialize JSON output, "
+                        "invalid community-id-seed: %s",
+                        cid_seed);
             }
         }
 
@@ -1286,14 +1272,25 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
                 (RunmodeGetCurrent() == RUNMODE_PCAP_FILE ||
                  RunmodeGetCurrent() == RUNMODE_UNIX_SOCKET);
         }
-
-        json_ctx->file_ctx->type = json_ctx->json_out;
+        json_ctx->file_ctx->type = log_filetype;
     }
 
     SCLogDebug("returning output_ctx %p", output_ctx);
 
     result.ctx = output_ctx;
     result.ok = true;
+    return result;
+
+error_exit:
+    if (json_ctx->file_ctx) {
+        LogFileFreeCtx(json_ctx->file_ctx);
+    }
+    if (json_ctx) {
+        SCFree(json_ctx);
+    }
+    if (output_ctx) {
+        SCFree(output_ctx);
+    }
     return result;
 }
 

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -38,8 +38,11 @@ typedef struct SCPlugin_ {
     const char *name;
     const char *license;
     const char *author;
+    const bool internal;
     void (*Init)(void);
 } SCPlugin;
+
+typedef SCPlugin *(*SCPluginRegisterFunc)(void);
 
 /**
  * Structure used to define a file type plugin.
@@ -50,7 +53,8 @@ typedef struct SCPlugin_ {
  * plugins: section
  */
 typedef struct SCPluginFileType_ {
-    char *name;
+    const char *name;
+    bool internal;
     /* Init Called on first access */
     int (*Init)(ConfNode *conf, bool threaded, void **init_data);
     /* Write - Called on each write to the object */
@@ -64,7 +68,8 @@ typedef struct SCPluginFileType_ {
     TAILQ_ENTRY(SCPluginFileType_) entries;
 } SCPluginFileType;
 
-bool SCPluginRegisterFileType(SCPluginFileType *);
+bool SCPluginRegisterEveFileType(SCPluginFileType *);
+bool SCRegisterEveFileType(SCPluginFileType *);
 
 typedef struct SCCapturePlugin_ {
     char *name;

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2556,6 +2556,7 @@ int PostConfLoadedSetup(SCInstance *suri)
     FeatureTrackingRegister(); /* must occur prior to output mod registration */
     RegisterAllModules();
 #ifdef HAVE_PLUGINS
+    SCInternalLoad();
     SCPluginsLoad(suri->capture_plugin_name, suri->capture_plugin_args);
 #endif
     AppLayerHtpNeedFileInspection();

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -886,13 +886,8 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
 
 int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer)
 {
-    if (file_ctx->type == LOGFILE_TYPE_SYSLOG) {
-        syslog(file_ctx->syslog_setup.alert_syslog_level, "%s",
-                (const char *)MEMBUFFER_BUFFER(buffer));
-    } else if (file_ctx->type == LOGFILE_TYPE_FILE ||
-               file_ctx->type == LOGFILE_TYPE_UNIX_DGRAM ||
-               file_ctx->type == LOGFILE_TYPE_UNIX_STREAM)
-    {
+    if (file_ctx->type == LOGFILE_TYPE_FILE || file_ctx->type == LOGFILE_TYPE_UNIX_DGRAM ||
+            file_ctx->type == LOGFILE_TYPE_UNIX_STREAM) {
         /* append \n for files only */
         MemBufferWriteString(buffer, "\n");
         file_ctx->Write((const char *)MEMBUFFER_BUFFER(buffer),

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -35,7 +35,6 @@
 
 enum LogFileType {
     LOGFILE_TYPE_FILE,
-    LOGFILE_TYPE_SYSLOG,
     LOGFILE_TYPE_UNIX_DGRAM,
     LOGFILE_TYPE_UNIX_STREAM,
     LOGFILE_TYPE_REDIS,
@@ -73,7 +72,6 @@ typedef struct LogFileCtx_ {
     LogThreadedFileCtx *threads;
 
     union {
-        SyslogSetup syslog_setup;
 #ifdef HAVE_LIBHIREDIS
         RedisSetup redis_setup;
 #endif

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -33,12 +33,15 @@
 
 #include "suricata-plugin.h"
 
-enum LogFileType { LOGFILE_TYPE_FILE,
-                   LOGFILE_TYPE_SYSLOG,
-                   LOGFILE_TYPE_UNIX_DGRAM,
-                   LOGFILE_TYPE_UNIX_STREAM,
-                   LOGFILE_TYPE_REDIS,
-                   LOGFILE_TYPE_PLUGIN };
+enum LogFileType {
+    LOGFILE_TYPE_FILE,
+    LOGFILE_TYPE_SYSLOG,
+    LOGFILE_TYPE_UNIX_DGRAM,
+    LOGFILE_TYPE_UNIX_STREAM,
+    LOGFILE_TYPE_REDIS,
+    LOGFILE_TYPE_PLUGIN,
+    LOGFILE_TYPE_NOTSET
+};
 
 typedef struct SyslogSetup_ {
     int alert_syslog_level;

--- a/src/util-plugin.h
+++ b/src/util-plugin.h
@@ -20,8 +20,11 @@
 
 #include "suricata-plugin.h"
 
+void SCInternalLoad(void);
 void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_args);
 SCPluginFileType *SCPluginFindFileType(const char *name);
 SCCapturePlugin *SCPluginFindCaptureByName(const char *name);
+
+bool RegisterPlugin(SCPlugin *, void *);
 
 #endif /* __UTIL_PLUGIN_H__ */


### PR DESCRIPTION
Conversion from draft pr.

This PR changes the syslog output type into a plugin -- an internal plugin -- to take advantage of the EVE output plugin framework. 

Describe changes:
- Refactor internal output file type handling code
- Move syslog output code into an internal plugin

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
