### PR TITLE
eve/ike: restore common option logging

### DIFF
--- a/src/output-json-ike.c
+++ b/src/output-json-ike.c
@@ -56,6 +56,7 @@
 typedef struct LogIKEFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags;
+    OutputJsonCommonSettings cfg;
 } LogIKEFileCtx;
 
 typedef struct LogIKELogThread_ {
@@ -85,6 +86,7 @@ static int JsonIKELogger(ThreadVars *tv, void *thread_data, const Packet *p, Flo
     if (unlikely(jb == NULL)) {
         return TM_ECODE_FAILED;
     }
+    EveAddCommonOptions(&thread->ikelog_ctx->cfg, p, f, jb);
 
     LogIKEFileCtx *ike_ctx = thread->ikelog_ctx;
     if (!rs_ike_logger_log(state, tx, ike_ctx->flags, jb)) {
@@ -119,6 +121,7 @@ static OutputInitResult OutputIKELogInitSub(ConfNode *conf, OutputCtx *parent_ct
         return result;
     }
     ikelog_ctx->file_ctx = ajt->file_ctx;
+    ikelog_ctx->cfg = ajt->cfg;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {


### PR DESCRIPTION
IKke logging had recently lost common options logging.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Restore common logging
