### PR TITLE
Setup app layer & template files: fix typos & bug

### DIFF
--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -335,7 +335,7 @@ pub extern "C" fn rs_template_parse_request(
     };
 
     if eof {
-        // If needed, handled EOF, or pass it into the parser.
+        // If needed, handle EOF, or pass it into the parser.
         return AppLayerResult::ok();
     }
 

--- a/scripts/setup-app-layer.py
+++ b/scripts/setup-app-layer.py
@@ -344,7 +344,7 @@ def detect_patch_makefile_am(protoname, buffername):
             output.write(line)
     open(filename, "w").write(output.getvalue())
 
-def detect_patch_detect_enginer_register_c(protoname, buffername):
+def detect_patch_detect_engine_register_c(protoname, buffername):
     filename = "src/detect-engine-register.c"
     print("Patching %s." % (filename))
     output = io.StringIO()
@@ -364,7 +364,7 @@ def detect_patch_detect_enginer_register_c(protoname, buffername):
             output.write(line)
     open(filename, "w").write(output.getvalue())
 
-def detect_patch_detect_enginer_register_h(protoname, buffername):
+def detect_patch_detect_engine_register_h(protoname, buffername):
     filename = "src/detect-engine-register.h"
     print("Patching %s." % (filename))
     output = io.StringIO()
@@ -392,7 +392,7 @@ name specified on the command line. This is done by copying and
 patching src/app-layer-template.[ch] then linking the new files into
 the build system.
 
-By default both the parser and logger will be generate. To generate
+By default both the parser and logger will be generated. To generate
 just one or the other use the --parser or --logger command line flags.
 
 Examples:
@@ -486,13 +486,13 @@ def main():
             raise SetupError("no app-layer parser exists for %s" % (proto))
         detect_copy_templates(proto, args.buffer, args.rust)
         detect_patch_makefile_am(proto, args.buffer)
-        detect_patch_detect_enginer_register_c(proto, args.buffer)
-        detect_patch_detect_enginer_register_h(proto, args.buffer)
+        detect_patch_detect_engine_register_c(proto, args.buffer)
+        detect_patch_detect_engine_register_h(proto, args.buffer)
 
     if parser:
         if args.rust:
             print("""
-An application detector and parser for the protocol %(proto)s has
+An application detector and parser for the protocol %(proto)s have
 now been setup in the files:
 
     rust/src/applayer%(proto_lower)s/mod.rs
@@ -502,7 +502,7 @@ now been setup in the files:
         })
         else:
             print("""
-An application detector and parser for the protocol %(proto)s has
+An application detector and parser for the protocol %(proto)s have
 now been setup in the files:
 
     src/app-layer-%(proto_lower)s.h

--- a/scripts/setup-app-layer.py
+++ b/scripts/setup-app-layer.py
@@ -90,7 +90,7 @@ def patch_makefile_am(protoname):
     output = io.StringIO()
     with open("src/Makefile.am") as infile:
         for line in infile:
-            if line.startswith("app-layer-template.c"):
+            if line.lstrip().startswith("app-layer-template."):
                 output.write(line.replace("template", protoname.lower()))
             output.write(line)
     open("src/Makefile.am", "w").write(output.getvalue())
@@ -277,7 +277,7 @@ def logger_patch_makefile_am(protoname):
     output = io.StringIO()
     with open(filename) as infile:
         for line in infile:
-            if line.startswith("output-json-template.c"):
+            if line.lstrip().startswith("output-json-template."):
                 output.write(line.replace("template", protoname.lower()))
             output.write(line)
     open(filename, "w").write(output.getvalue())
@@ -337,7 +337,7 @@ def detect_patch_makefile_am(protoname, buffername):
     output = io.StringIO()
     with open(filename) as infile:
         for line in infile:
-            if line.startswith("detect-template-buffer.c"):
+            if line.lstrip().startswith("detect-template-buffer."):
                 new = line.replace("template-buffer", "%s-%s" % (
                     protoname.lower(), buffername.lower()))
                 output.write(new)
@@ -397,8 +397,8 @@ just one or the other use the --parser or --logger command line flags.
 
 Examples:
 
-    %(progname)s DNP3
-    %(progname)s Gopher
+    %(progname)s --logger DNP3
+    %(progname)s --parser Gopher
 
 This script can also setup a detect buffer. This is a separate
 operation that must be done after creating the parser.
@@ -545,7 +545,7 @@ The following files have been created and linked into the build:
 
     if parser or logger:
         print("""
-Suricata should now build cleanly. Try running "make".
+Suricata should now build cleanly. Try running "./configure" and "make".
 """)
 
 if __name__ == "__main__":

--- a/src/app-layer-template-rust.c
+++ b/src/app-layer-template-rust.c
@@ -27,7 +27,7 @@
  * \author FirstName LastName <yourname@domain>
  *
  * TemplateRust application layer detector and parser for learning and
- * templaterust pruposes.
+ * templaterust purposes.
  *
  * This templaterust implements a simple application layer for something
  * like the echo protocol running on port 7.

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -27,7 +27,7 @@
  * \author FirstName LastName <yourname@domain>
  *
  * Template application layer detector and parser for learning and
- * template pruposes.
+ * template purposes.
  *
  * This template implements a simple application layer for something
  * like the echo protocol running on port 7.
@@ -280,7 +280,7 @@ static AppLayerResult TemplateParseRequest(Flow *f, void *statev,
      *
      * But note that if a "protocol data unit" is not received in one
      * chunk of data, and the buffering is done on the transaction, we
-     * may need to look for the transaction that this newly recieved
+     * may need to look for the transaction that this newly received
      * data belongs to.
      */
     TemplateTransaction *tx = TemplateTxAlloc(state);
@@ -416,7 +416,7 @@ static void *TemplateGetTx(void *statev, uint64_t tx_id)
  * considered complete.
  *
  * For the response to be considered done, the response for a request
- * needs to be seen.  The response_done flag is set on response for
+ * needs to be seen. The response_done flag is set on response for
  * checking here.
  */
 static int TemplateGetStateProgress(void *txv, uint8_t direction)
@@ -486,7 +486,7 @@ void RegisterTemplateParsers(void)
 
         if (RunmodeIsUnittests()) {
 
-            SCLogNotice("Unittest mode, registeringd default configuration.");
+            SCLogNotice("Unittest mode, registering default configuration.");
             AppLayerProtoDetectPPRegister(IPPROTO_TCP, TEMPLATE_DEFAULT_PORT,
                 ALPROTO_TEMPLATE, 0, TEMPLATE_MIN_FRAME_LEN, STREAM_TOSERVER,
                 TemplateProbingParserTs, TemplateProbingParserTc);
@@ -511,7 +511,7 @@ void RegisterTemplateParsers(void)
     }
 
     else {
-        SCLogNotice("Protocol detecter and parser disabled for Template.");
+        SCLogNotice("Protocol detector and parser disabled for Template.");
         return;
     }
 
@@ -561,7 +561,7 @@ void RegisterTemplateParsers(void)
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_TEMPLATE,
             TemplateGetEvents);
 
-        /* Leave this is if you parser can handle gaps, otherwise
+        /* Leave this is if your parser can handle gaps, otherwise
          * remove. */
         AppLayerParserRegisterOptionFlags(IPPROTO_TCP, ALPROTO_TEMPLATE,
             APP_LAYER_PARSER_OPT_ACCEPT_GAPS);

--- a/src/app-layer-template.h
+++ b/src/app-layer-template.h
@@ -66,7 +66,7 @@ typedef struct TemplateState {
     TAILQ_HEAD(, TemplateTransaction) tx_list;
 
     /** A count of the number of transactions created. The
-     *  transaction ID for each transaction is allocted
+     *  transaction ID for each transaction is allocated
      *  by incrementing this value. */
     uint64_t transaction_max;
 } TemplateState;

--- a/src/detect-template-buffer.c
+++ b/src/detect-template-buffer.c
@@ -59,7 +59,7 @@ void DetectTemplateBufferRegister(void)
     /* TEMPLATE_END_REMOVE */
     sigmatch_table[DETECT_AL_TEMPLATE_BUFFER].name = "template_buffer";
     sigmatch_table[DETECT_AL_TEMPLATE_BUFFER].desc =
-        "Template content modififier to match on the template buffers";
+            "Template content modifier to match on the template buffers";
     sigmatch_table[DETECT_AL_TEMPLATE_BUFFER].Setup = DetectTemplateBufferSetup;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_AL_TEMPLATE_BUFFER].RegisterTests =

--- a/src/detect-template-rust-buffer.c
+++ b/src/detect-template-rust-buffer.c
@@ -61,7 +61,7 @@ void DetectTemplateRustBufferRegister(void)
     sigmatch_table[DETECT_AL_TEMPLATE_RUST_BUFFER].name =
         "template_rust_buffer";
     sigmatch_table[DETECT_AL_TEMPLATE_RUST_BUFFER].desc =
-        "Template content modififier to match on the template buffers";
+            "Template content modifier to match on the template buffers";
     sigmatch_table[DETECT_AL_TEMPLATE_RUST_BUFFER].Setup =
         DetectTemplateRustBufferSetup;
 #ifdef UNITTESTS

--- a/src/detect-template.h
+++ b/src/detect-template.h
@@ -25,7 +25,7 @@
 #define __DETECT_TEMPLATE_H__
 
 /** Per keyword data. This is set up by the DetectTemplateSetup() function.
- *  Each signature will have an instance of DetectTemplateData per occurence
+ *  Each signature will have an instance of DetectTemplateData per occurrence
  *  of the keyword.
  *  The structure should be considered static/readonly after initialization.
  */

--- a/src/detect-template2.c
+++ b/src/detect-template2.c
@@ -281,7 +281,7 @@ error:
 }
 
 /**
- * \brief this function is used to atemplate2d the parsed template2 data into the current signature
+ * \brief this function is used to add the parsed template2 data into the current signature
  *
  * \param de_ctx pointer to the Detection Engine Context
  * \param s pointer to the Current Signature

--- a/src/tests/detect-template2.c
+++ b/src/tests/detect-template2.c
@@ -80,7 +80,7 @@ static int DetectTemplate2ParseTest03 (void)
 
 /**
  * \test DetectTemplate2ParseTest04 is a test for setting up an valid template2 value with
- *       ">" operator and include spaces arround the given values.
+ *       ">" operator and include spaces around the given values.
  */
 
 static int DetectTemplate2ParseTest04 (void)
@@ -98,7 +98,7 @@ static int DetectTemplate2ParseTest04 (void)
 
 /**
  * \test DetectTemplate2ParseTest05 is a test for setting up an valid template2 values with
- *       "-" operator and include spaces arround the given values.
+ *       "-" operator and include spaces around the given values.
  */
 
 static int DetectTemplate2ParseTest05 (void)
@@ -117,7 +117,7 @@ static int DetectTemplate2ParseTest05 (void)
 
 /**
  * \test DetectTemplate2ParseTest06 is a test for setting up an valid template2 values with
- *       invalid "=" operator and include spaces arround the given values.
+ *       invalid "=" operator and include spaces around the given values.
  */
 
 static int DetectTemplate2ParseTest06 (void)
@@ -129,7 +129,7 @@ static int DetectTemplate2ParseTest06 (void)
 
 /**
  * \test DetectTemplate2ParseTest07 is a test for setting up an valid template2 values with
- *       invalid "<>" operator and include spaces arround the given values.
+ *       invalid "<>" operator and include spaces around the given values.
  */
 
 static int DetectTemplate2ParseTest07 (void)


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
there isn't one.

Previous PR: [5992](https://github.com/OISF/suricata/pull/5992)

Describe changes:
First commit: 
- trim white spaces in pattern matching for Makefile.am patches;
- make sure both .c and .h lines are added to Makefile.am for al-parser, logger and detect;
- Make script arguments example more illustrative;
- add suggestion to run ./configure before make.

Second commit:
- fix typos in *template* files .c, .h, .rs and in the setup-app-layer.py script itself.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
