### PR TITLE
Research/bug 3703 file bug/v9

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2020 Open Information Security Foundation
+/* Copyright (C) 2017-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -58,6 +58,10 @@ pub struct AppLayerTxData {
     /// logger flags for tx logging api
     logged: LoggerFlags,
 
+    /// track file open/logs so we can know how long to keep the tx
+    pub files_opened: u32,
+    pub files_logged: u32,
+
     /// detection engine flags for use by detection engine
     detect_flags_ts: u64,
     detect_flags_tc: u64,
@@ -68,9 +72,17 @@ impl AppLayerTxData {
         Self {
             config: AppLayerTxConfig::new(),
             logged: LoggerFlags::new(),
+            files_opened: 0,
+            files_logged: 0,
             detect_flags_ts: 0,
             detect_flags_tc: 0,
         }
+    }
+    pub fn init_files_opened(&mut self) {
+        self.files_opened = 1;
+    }
+    pub fn incr_files_opened(&mut self) {
+        self.files_opened += 1;
     }
 }
 

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -61,6 +61,7 @@ pub struct AppLayerTxData {
     /// track file open/logs so we can know how long to keep the tx
     pub files_opened: u32,
     pub files_logged: u32,
+    pub files_stored: u32,
 
     /// detection engine flags for use by detection engine
     detect_flags_ts: u64,
@@ -74,6 +75,7 @@ impl AppLayerTxData {
             logged: LoggerFlags::new(),
             files_opened: 0,
             files_logged: 0,
+            files_stored: 0,
             detect_flags_ts: 0,
             detect_flags_tc: 0,
         }

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -157,6 +157,8 @@ impl HTTP2Transaction {
     }
 
     pub fn free(&mut self) {
+        debug_validate_bug_on!(self.tx_data.files_opened > 1);
+        debug_validate_bug_on!(self.tx_data.files_logged > 1);
         if self.events != std::ptr::null_mut() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
         }

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -809,6 +809,7 @@ impl HTTP2State {
                                     let mut tx_same = &mut self.transactions[index - 1];
                                     tx_same.ft.tx_id = tx_same.tx_id - 1;
                                     let (files, flags) = self.files.get(dir);
+                                    tx_same.tx_data.init_files_opened(); // TODO do we have a place for doing this once?
                                     match tx_same.decompress(
                                         &rem[..hlsafe],
                                         dir,

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -591,6 +591,7 @@ impl NFSState {
         if let Some(NFSTransactionTypeData::FILE(ref mut d)) = tx.type_data {
             d.file_tracker.tx_id = tx.id - 1;
         }
+        tx.tx_data.init_files_opened();
         SCLogDebug!("new_file_tx: TX FILE created: ID {} NAME {}",
                 tx.id, String::from_utf8_lossy(file_name));
         self.transactions.push(tx);

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -215,6 +215,8 @@ impl NFSTransaction {
     }
 
     pub fn free(&mut self) {
+        debug_validate_bug_on!(self.tx_data.files_opened > 1);
+        debug_validate_bug_on!(self.tx_data.files_logged > 1);
         if self.events != std::ptr::null_mut() {
             sc_app_layer_decoder_events_free_events(&mut self.events);
         }

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -126,6 +126,7 @@ impl NFSState {
                         tdf.file_last_xid = r.hdr.xid;
                         tx.is_last = true;
                         tx.request_done = true;
+                        tx.is_file_closed = true;
                     }
                 }
             } else {

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -75,6 +75,7 @@ impl SMBState {
             },
             _ => { },
         }
+        tx.tx_data.init_files_opened();
         SCLogDebug!("SMB: new_file_tx: TX FILE created: ID {} NAME {}",
                 tx.id, String::from_utf8_lossy(file_name));
         self.transactions.push(tx);

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -591,6 +591,8 @@ impl SMBTransaction {
     }
 
     pub fn free(&mut self) {
+        debug_validate_bug_on!(self.tx_data.files_opened > 1);
+        debug_validate_bug_on!(self.tx_data.files_logged > 1);
         if self.events != std::ptr::null_mut() {
             sc_app_layer_decoder_events_free_events(&mut self.events);
         }

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1092,6 +1092,7 @@ static AppLayerResult FTPDataParse(Flow *f, FtpDataState *ftpdata_state,
             ret = -1;
         }
         FlowFreeStorageById(f, AppLayerExpectationGetDataId());
+        ftpdata_state->tx_data.files_opened = 1;
     } else {
         if (input_len != 0) {
             ret = FileAppendData(ftpdata_state->files, input, input_len);

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -76,7 +76,8 @@
  *  \retval -1 error
  *  \retval -2 not handling files on this flow
  */
-int HTPFileOpen(HtpState *s, const uint8_t *filename, uint16_t filename_len,
+int HTPFileOpen(HtpState *s, HtpTxUserData *tx,
+        const uint8_t *filename, uint16_t filename_len,
         const uint8_t *data, uint32_t data_len,
         uint64_t txid, uint8_t direction)
 {
@@ -145,6 +146,7 @@ int HTPFileOpen(HtpState *s, const uint8_t *filename, uint16_t filename_len,
     }
 
     FileSetTx(files->tail, txid);
+    tx->tx_data.files_opened++;
 
 end:
     SCReturnInt(retval);

--- a/src/app-layer-htp-file.h
+++ b/src/app-layer-htp-file.h
@@ -31,7 +31,7 @@ typedef struct HtpContentRange_ {
     int64_t size;
 } HtpContentRange;
 
-int HTPFileOpen(HtpState *, const uint8_t *, uint16_t, const uint8_t *, uint32_t, uint64_t, uint8_t);
+int HTPFileOpen(HtpState *, HtpTxUserData *, const uint8_t *, uint16_t, const uint8_t *, uint32_t, uint64_t, uint8_t);
 int HTPParseContentRange(bstr * rawvalue, HtpContentRange *range);
 int HTPFileSetRange(HtpState *, bstr *rawvalue);
 int HTPFileStoreChunk(HtpState *, const uint8_t *, uint32_t, uint8_t);

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1536,7 +1536,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                 printf("FILEDATA END: \n");
 #endif
 
-                result = HTPFileOpen(hstate, filename, filename_len,
+                result = HTPFileOpen(hstate, htud, filename, filename_len,
                             filedata, filedata_len, HtpGetActiveRequestTxID(hstate),
                             STREAM_TOSERVER);
                 if (result == -1) {
@@ -1589,7 +1589,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                         filedata = NULL;
                         filedata_len = 0;
                     }
-                    result = HTPFileOpen(hstate, filename, filename_len,
+                    result = HTPFileOpen(hstate, htud, filename, filename_len,
                             filedata, filedata_len, HtpGetActiveRequestTxID(hstate),
                             STREAM_TOSERVER);
                     if (result == -1) {
@@ -1605,7 +1605,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                     filedata_len = header_next - filedata - 2;
                     SCLogDebug("filedata_len %u", filedata_len);
 
-                    result = HTPFileOpen(hstate, filename, filename_len,
+                    result = HTPFileOpen(hstate, htud, filename, filename_len,
                             filedata, filedata_len, HtpGetActiveRequestTxID(hstate),
                             STREAM_TOSERVER);
                     if (result == -1) {
@@ -1678,7 +1678,7 @@ static int HtpRequestBodyHandlePOSTorPUT(HtpState *hstate, HtpTxUserData *htud,
         }
 
         if (filename != NULL) {
-            result = HTPFileOpen(hstate, filename, (uint32_t)filename_len, data, data_len,
+            result = HTPFileOpen(hstate, htud, filename, (uint32_t)filename_len, data, data_len,
                     HtpGetActiveRequestTxID(hstate), STREAM_TOSERVER);
             if (result == -1) {
                 goto end;
@@ -1749,7 +1749,7 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
         }
 
         if (filename != NULL) {
-            result = HTPFileOpen(hstate, filename, (uint32_t)filename_len,
+            result = HTPFileOpen(hstate, htud, filename, (uint32_t)filename_len,
                     data, data_len, HtpGetActiveResponseTxID(hstate), STREAM_TOCLIENT);
             SCLogDebug("result %d", result);
             if (result == -1) {

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -879,6 +879,7 @@ FileContainer *AppLayerParserGetFiles(const Flow *f, const uint8_t direction)
 
 extern int g_detect_disabled;
 extern bool g_file_logger_enabled;
+extern bool g_filedata_logger_enabled;
 
 /**
  * \brief remove obsolete (inspected and logged) transactions
@@ -998,8 +999,12 @@ void AppLayerParserTransactionsCleanup(Flow *f)
 
         /* if file logging is enabled, we keep a tx active while some of the files aren't
          * logged yet. */
-        if (txd && txd->files_opened && g_file_logger_enabled) {
-            if (txd->files_opened != txd->files_logged) {
+        if (txd && txd->files_opened) {
+            if (g_file_logger_enabled && txd->files_opened != txd->files_logged) {
+                skipped = true;
+                goto next;
+            }
+            if (g_filedata_logger_enabled && txd->files_opened != txd->files_stored) {
                 skipped = true;
                 goto next;
             }

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -878,6 +878,8 @@ FileContainer *AppLayerParserGetFiles(const Flow *f, const uint8_t direction)
 #define IS_DISRUPTED(flags) ((flags) & (STREAM_DEPTH | STREAM_GAP))
 
 extern int g_detect_disabled;
+extern bool g_file_logger_enabled;
+
 /**
  * \brief remove obsolete (inspected and logged) transactions
  */
@@ -989,6 +991,15 @@ void AppLayerParserTransactionsCleanup(Flow *f)
             if (tx_logged != logger_expectation) {
                 SCLogDebug("%p/%"PRIu64" skipping: logging not done: want:%"PRIx32", have:%"PRIx32,
                         tx, i, logger_expectation, tx_logged);
+                skipped = true;
+                goto next;
+            }
+        }
+
+        /* if file logging is enabled, we keep a tx active while some of the files aren't
+         * logged yet. */
+        if (txd && txd->files_opened && g_file_logger_enabled) {
+            if (txd->files_opened != txd->files_logged) {
                 skipped = true;
                 goto next;
             }

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -397,6 +397,7 @@ static void SMTPNewFile(SMTPTransaction *tx, File *file)
 #endif
     FlagDetectStateNewFile(tx);
     FileSetTx(file, tx->tx_id);
+    tx->tx_data.files_opened++;
 
     /* set inspect sizes used in file pruning logic.
      * TODO consider moving this to the file.data code that

--- a/src/output-file.c
+++ b/src/output-file.c
@@ -168,18 +168,23 @@ static TmEcode OutputFileLog(ThreadVars *tv, Packet *p, void *thread_data)
         SCReturnInt(TM_ECODE_OK);
     }
 
-    const bool file_close_ts = ((p->flags & PKT_PSEUDO_STREAM_END) &&
-            (p->flowflags & FLOW_PKT_TOSERVER));
-    const bool file_close_tc = ((p->flags & PKT_PSEUDO_STREAM_END) &&
-            (p->flowflags & FLOW_PKT_TOCLIENT));
-    const bool file_trunc = StreamTcpReassembleDepthReached(p);
-
-    FileContainer *ffc_ts = AppLayerParserGetFiles(f, STREAM_TOSERVER);
-    FileContainer *ffc_tc = AppLayerParserGetFiles(f, STREAM_TOCLIENT);
-
-    OutputFileLogFfc(tv, op_thread_data, p, ffc_ts, file_close_ts, file_trunc, STREAM_TOSERVER);
-    OutputFileLogFfc(tv, op_thread_data, p, ffc_tc, file_close_tc, file_trunc, STREAM_TOCLIENT);
-
+    if (p->proto == IPPROTO_TCP) {
+        const bool file_trunc = StreamTcpReassembleDepthReached(p);
+        if (p->flowflags & FLOW_PKT_TOSERVER) {
+            const bool file_close_ts = ((p->flags & PKT_PSEUDO_STREAM_END));
+            FileContainer *ffc_ts = AppLayerParserGetFiles(f, STREAM_TOSERVER);
+            OutputFileLogFfc(tv, op_thread_data, p, ffc_ts, file_close_ts, file_trunc, STREAM_TOSERVER);
+        } else {
+            const bool file_close_tc = ((p->flags & PKT_PSEUDO_STREAM_END));
+            FileContainer *ffc_tc = AppLayerParserGetFiles(f, STREAM_TOCLIENT);
+            OutputFileLogFfc(tv, op_thread_data, p, ffc_tc, file_close_tc, file_trunc, STREAM_TOCLIENT);
+        }
+    } else if (p->proto == IPPROTO_UDP) {
+        FileContainer *ffc_ts = AppLayerParserGetFiles(f, STREAM_TOSERVER);
+        OutputFileLogFfc(tv, op_thread_data, p, ffc_ts, false, false, STREAM_TOSERVER);
+        FileContainer *ffc_tc = AppLayerParserGetFiles(f, STREAM_TOCLIENT);
+        OutputFileLogFfc(tv, op_thread_data, p, ffc_tc, false, false, STREAM_TOCLIENT);
+    }
     return TM_ECODE_OK;
 }
 

--- a/src/output-filedata.c
+++ b/src/output-filedata.c
@@ -225,18 +225,18 @@ static TmEcode OutputFiledataLog(ThreadVars *tv, Packet *p, void *thread_data)
         SCReturnInt(TM_ECODE_OK);
     }
 
-    const bool file_close_ts = ((p->flags & PKT_PSEUDO_STREAM_END) &&
-            (p->flowflags & FLOW_PKT_TOSERVER));
-    const bool file_close_tc = ((p->flags & PKT_PSEUDO_STREAM_END) &&
-            (p->flowflags & FLOW_PKT_TOCLIENT));
     const bool file_trunc = StreamTcpReassembleDepthReached(p);
-
-    FileContainer *ffc_ts = AppLayerParserGetFiles(f, STREAM_TOSERVER);
-    FileContainer *ffc_tc = AppLayerParserGetFiles(f, STREAM_TOCLIENT);
-    SCLogDebug("ffc_ts %p", ffc_ts);
-    OutputFiledataLogFfc(tv, op_thread_data, p, ffc_ts, STREAM_TOSERVER, file_close_ts, file_trunc, STREAM_TOSERVER);
-    SCLogDebug("ffc_tc %p", ffc_tc);
-    OutputFiledataLogFfc(tv, op_thread_data, p, ffc_tc, STREAM_TOCLIENT, file_close_tc, file_trunc, STREAM_TOCLIENT);
+    if (p->flowflags & FLOW_PKT_TOSERVER) {
+        const bool file_close_ts = ((p->flags & PKT_PSEUDO_STREAM_END));
+        FileContainer *ffc_ts = AppLayerParserGetFiles(f, STREAM_TOSERVER);
+        SCLogDebug("ffc_ts %p", ffc_ts);
+        OutputFiledataLogFfc(tv, op_thread_data, p, ffc_ts, STREAM_TOSERVER, file_close_ts, file_trunc, STREAM_TOSERVER);
+    } else {
+        const bool file_close_tc = ((p->flags & PKT_PSEUDO_STREAM_END));
+        FileContainer *ffc_tc = AppLayerParserGetFiles(f, STREAM_TOCLIENT);
+        SCLogDebug("ffc_tc %p", ffc_tc);
+        OutputFiledataLogFfc(tv, op_thread_data, p, ffc_tc, STREAM_TOCLIENT, file_close_tc, file_trunc, STREAM_TOCLIENT);
+    }
 
     return TM_ECODE_OK;
 }


### PR DESCRIPTION
Address issue 3703 by logging files/filedata in the packet direction only. This leads to missing metadata in file records as txs are cleared before the files are logged. So address this by creating file accouning per tx.

suricata-verify-pr: 481
