### PR TITLE
Draft: Eve cleanup - round 1

### DIFF
--- a/src/detect-engine-profile.c
+++ b/src/detect-engine-profile.c
@@ -38,7 +38,7 @@ SCMutex g_rule_dump_write_m = SCMUTEX_INITIALIZER;
 void RulesDumpMatchArray(const DetectEngineThreadCtx *det_ctx,
         const SigGroupHead *sgh, const Packet *p)
 {
-    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "inspectedrules", NULL);
+    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "inspectedrules", NULL, NULL);
     if (js == NULL)
         return;
 

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -168,8 +168,8 @@ static void OutputFilestoreFinalizeFiles(ThreadVars *tv,
             WARN_ONCE(SC_ERR_SPRINTF,
                 "Failed to write file info record. Output filename truncated.");
         } else {
-            JsonBuilder *js_fileinfo = JsonBuildFileInfoRecord(p, ff, true, dir,
-                    ctx->xff_cfg);
+            JsonBuilder *js_fileinfo =
+                    JsonBuildFileInfoRecord(p, ff, true, dir, ctx->xff_cfg, NULL);
             if (likely(js_fileinfo != NULL)) {
                 jb_close(js_fileinfo);
                 FILE *out = fopen(js_metadata_filename, "w");

--- a/src/output-json-dcerpc.c
+++ b/src/output-json-dcerpc.c
@@ -46,7 +46,7 @@ static int JsonDCERPCLogger(ThreadVars *tv, void *thread_data,
 {
     OutputJsonThreadCtx *thread = thread_data;
 
-    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "dcerpc", NULL);
+    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "dcerpc", NULL, thread->ctx);
     if (unlikely(jb == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -47,10 +47,9 @@
 
 
 typedef struct LogDHCPFileCtx_ {
-    LogFileCtx *file_ctx;
     uint32_t    flags;
     void       *rs_logger;
-    OutputJsonCommonSettings cfg;
+    OutputJsonCtx *eve_ctx;
 } LogDHCPFileCtx;
 
 typedef struct LogDHCPLogThread_ {
@@ -69,12 +68,10 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_OK;
     }
 
-    JsonBuilder *js = CreateEveHeader((Packet *)p, 0, "dhcp", NULL);
+    JsonBuilder *js = CreateEveHeader((Packet *)p, 0, "dhcp", NULL, ctx->eve_ctx);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }
-
-    EveAddCommonOptions(&thread->dhcplog_ctx->cfg, p, f, js);
 
     rs_dhcp_logger_log(ctx->rs_logger, tx, js);
 
@@ -97,14 +94,12 @@ static OutputInitResult OutputDHCPLogInitSub(ConfNode *conf,
     OutputCtx *parent_ctx)
 {
     OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ajt = parent_ctx->data;
 
     LogDHCPFileCtx *dhcplog_ctx = SCCalloc(1, sizeof(*dhcplog_ctx));
     if (unlikely(dhcplog_ctx == NULL)) {
         return result;
     }
-    dhcplog_ctx->file_ctx = ajt->file_ctx;
-    dhcplog_ctx->cfg = ajt->cfg;
+    dhcplog_ctx->eve_ctx = parent_ctx->data;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {
@@ -142,7 +137,7 @@ static TmEcode JsonDHCPLogThreadInit(ThreadVars *t, const void *initdata, void *
     }
 
     thread->dhcplog_ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->dhcplog_ctx->file_ctx, t->id);
+    thread->file_ctx = LogFileEnsureExists(thread->dhcplog_ctx->eve_ctx->file_ctx, t->id);
     if (!thread->file_ctx) {
         goto error_exit;
     }

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -260,7 +260,7 @@ typedef struct LogDnsFileCtx_ {
     LogFileCtx *file_ctx;
     uint64_t flags; /** Store mode */
     DnsVersion version;
-    OutputJsonCommonSettings cfg;
+    OutputJsonCtx *eve_ctx;
 } LogDnsFileCtx;
 
 typedef struct LogDnsLogThread_ {
@@ -319,11 +319,10 @@ static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
     }
 
     for (uint16_t i = 0; i < 0xffff; i++) {
-        JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "dns", NULL);
+        JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "dns", NULL, dnslog_ctx->eve_ctx);
         if (unlikely(jb == NULL)) {
             return TM_ECODE_OK;
         }
-        EveAddCommonOptions(&dnslog_ctx->cfg, p, f, jb);
 
         jb_open_object(jb, "dns");
         if (!rs_dns_log_json_query(txptr, i, td->dnslog_ctx->flags, jb)) {
@@ -354,11 +353,10 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
 
     if (td->dnslog_ctx->version == DNS_VERSION_2) {
         if (rs_dns_do_log_answer(txptr, td->dnslog_ctx->flags)) {
-            JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "dns", NULL);
+            JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "dns", NULL, dnslog_ctx->eve_ctx);
             if (unlikely(jb == NULL)) {
                 return TM_ECODE_OK;
             }
-            EveAddCommonOptions(&dnslog_ctx->cfg, p, f, jb);
 
             jb_open_object(jb, "dns");
             rs_dns_log_json_answer(txptr, td->dnslog_ctx->flags, jb);
@@ -370,11 +368,10 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
     } else {
         /* Log answers. */
         for (uint16_t i = 0; i < UINT16_MAX; i++) {
-            JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "dns", NULL);
+            JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "dns", NULL, dnslog_ctx->eve_ctx);
             if (unlikely(jb == NULL)) {
                 return TM_ECODE_OK;
             }
-            EveAddCommonOptions(&dnslog_ctx->cfg, p, f, jb);
 
             JsonBuilder *answer = rs_dns_log_json_answer_v1(txptr, i,
                     td->dnslog_ctx->flags);
@@ -391,11 +388,10 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
         }
         /* Log authorities. */
         for (uint16_t i = 0; i < UINT16_MAX; i++) {
-            JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "dns", NULL);
+            JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "dns", NULL, dnslog_ctx->eve_ctx);
             if (unlikely(jb == NULL)) {
                 return TM_ECODE_OK;
             }
-            EveAddCommonOptions(&dnslog_ctx->cfg, p, f, jb);
 
             JsonBuilder *answer = rs_dns_log_json_authority_v1(txptr, i,
                     td->dnslog_ctx->flags);
@@ -627,7 +623,7 @@ static OutputInitResult JsonDnsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_c
     memset(dnslog_ctx, 0x00, sizeof(LogDnsFileCtx));
 
     dnslog_ctx->file_ctx = ojc->file_ctx;
-    dnslog_ctx->cfg = ojc->cfg;
+    dnslog_ctx->eve_ctx = ojc;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -64,6 +64,7 @@ typedef struct JsonDropOutputCtx_ {
     LogFileCtx *file_ctx;
     uint8_t flags;
     OutputJsonCommonSettings cfg;
+    OutputJsonCtx *eve_ctx;
 } JsonDropOutputCtx;
 
 typedef struct JsonDropLogThread_ {
@@ -91,7 +92,7 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
     JsonAddrInfo addr = json_addr_info_zero;
     JsonAddrInfoInit(p, LOG_DIR_PACKET, &addr);
 
-    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "drop", &addr);
+    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "drop", &addr, drop_ctx->eve_ctx);
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 

--- a/src/output-json-file.h
+++ b/src/output-json-file.h
@@ -26,8 +26,10 @@
 
 #include "app-layer-htp-xff.h"
 
+typedef struct OutputJsonCtx_ OutputJsonCtx;
+
 void JsonFileLogRegister(void);
-JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
-        const bool stored, uint8_t dir, HttpXFFCfg *xff_cfg);
+JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff, const bool stored,
+        uint8_t dir, HttpXFFCfg *xff_cfg, OutputJsonCtx *eve_ctx);
 
 #endif /* __OUTPUT_JSON_FILE_H__ */

--- a/src/output-json-krb5.c
+++ b/src/output-json-krb5.c
@@ -49,29 +49,16 @@
 
 #include "rust.h"
 
-typedef struct LogKRB5FileCtx_ {
-    LogFileCtx *file_ctx;
-    OutputJsonCommonSettings cfg;
-} LogKRB5FileCtx;
-
-typedef struct LogKRB5LogThread_ {
-    LogFileCtx *file_ctx;
-    LogKRB5FileCtx *krb5log_ctx;
-    MemBuffer          *buffer;
-} LogKRB5LogThread;
-
 static int JsonKRB5Logger(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
 {
     KRB5Transaction *krb5tx = tx;
-    LogKRB5LogThread *thread = thread_data;
+    OutputJsonThreadCtx *thread = thread_data;
 
-    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "krb5", NULL);
+    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "krb5", NULL, thread->ctx);
     if (unlikely(jb == NULL)) {
         return TM_ECODE_FAILED;
     }
-
-    EveAddCommonOptions(&thread->krb5log_ctx->cfg, p, f, jb);
 
     jb_open_object(jb, "krb5");
     if (!rs_krb5_log_json_response(jb, state, krb5tx)) {
@@ -90,98 +77,20 @@ error:
     return TM_ECODE_FAILED;
 }
 
-static void OutputKRB5LogDeInitCtxSub(OutputCtx *output_ctx)
-{
-    LogKRB5FileCtx *krb5log_ctx = (LogKRB5FileCtx *)output_ctx->data;
-    SCFree(krb5log_ctx);
-    SCFree(output_ctx);
-}
-
 static OutputInitResult OutputKRB5LogInitSub(ConfNode *conf,
     OutputCtx *parent_ctx)
 {
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ajt = parent_ctx->data;
-
-    LogKRB5FileCtx *krb5log_ctx = SCCalloc(1, sizeof(*krb5log_ctx));
-    if (unlikely(krb5log_ctx == NULL)) {
-        return result;
-    }
-    krb5log_ctx->file_ctx = ajt->file_ctx;
-    krb5log_ctx->cfg = ajt->cfg;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
-    if (unlikely(output_ctx == NULL)) {
-        SCFree(krb5log_ctx);
-        return result;
-    }
-    output_ctx->data = krb5log_ctx;
-    output_ctx->DeInit = OutputKRB5LogDeInitCtxSub;
-
-    SCLogDebug("KRB5 log sub-module initialized.");
-
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_KRB5);
     AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_KRB5);
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
-}
-
-static TmEcode JsonKRB5LogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    LogKRB5LogThread *thread = SCCalloc(1, sizeof(*thread));
-    if (unlikely(thread == NULL)) {
-        return TM_ECODE_FAILED;
-    }
-
-    if (initdata == NULL) {
-        SCLogDebug("Error getting context for EveLogKRB5.  \"initdata\" is NULL.");
-        goto error_exit;
-    }
-
-    thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (unlikely(thread->buffer == NULL)) {
-        goto error_exit;
-    }
-
-    thread->krb5log_ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->krb5log_ctx->file_ctx, t->id);
-    if (!thread->file_ctx) {
-        goto error_exit;
-    }
-    *data = (void *)thread;
-
-    return TM_ECODE_OK;
-
-error_exit:
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonKRB5LogThreadDeinit(ThreadVars *t, void *data)
-{
-    LogKRB5LogThread *thread = (LogKRB5LogThread *)data;
-    if (thread == NULL) {
-        return TM_ECODE_OK;
-    }
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_OK;
+    return OutputJsonLogInitSub(conf, parent_ctx);
 }
 
 void JsonKRB5LogRegister(void)
 {
     /* Register as an eve sub-module. */
-    OutputRegisterTxSubModule(LOGGER_JSON_KRB5, "eve-log", "JsonKRB5Log",
-        "eve-log.krb5", OutputKRB5LogInitSub, ALPROTO_KRB5,
-        JsonKRB5Logger, JsonKRB5LogThreadInit,
-        JsonKRB5LogThreadDeinit, NULL);
+    OutputRegisterTxSubModule(LOGGER_JSON_KRB5, "eve-log", "JsonKRB5Log", "eve-log.krb5",
+            OutputKRB5LogInitSub, ALPROTO_KRB5, JsonKRB5Logger, JsonLogThreadInit,
+            JsonLogThreadDeinit, NULL);
 
     SCLogDebug("KRB5 JSON logger registered.");
 }

--- a/src/output-json-metadata.c
+++ b/src/output-json-metadata.c
@@ -65,26 +65,18 @@
 
 #define MODULE_NAME "JsonMetadataLog"
 
-typedef struct MetadataJsonOutputCtx_ {
-    LogFileCtx* file_ctx;
-    OutputJsonCommonSettings cfg;
-} MetadataJsonOutputCtx;
-
-typedef struct JsonMetadataLogThread_ {
-    /** LogFileCtx has the pointer to the file and a mutex to allow multithreading */
-    LogFileCtx* file_ctx;
-    MemBuffer *json_buffer;
-    MetadataJsonOutputCtx* json_output_ctx;
-} JsonMetadataLogThread;
-
-static int MetadataJson(ThreadVars *tv, JsonMetadataLogThread *aft, const Packet *p)
+static int MetadataJson(ThreadVars *tv, OutputJsonThreadCtx *aft, const Packet *p)
 {
-    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "metadata", NULL);
+    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "metadata", NULL, aft->ctx);
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 
-    EveAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js);
-    OutputJsonBuilderBuffer(js, aft->file_ctx, &aft->json_buffer);
+    /* If metadata is not enabled for eve, explicitly log it here as this is
+     * what logging metadata is about. */
+    if (!aft->ctx->cfg.include_metadata) {
+        EveAddMetadata(p, p->flow, js);
+    }
+    OutputJsonBuilderBuffer(js, aft->file_ctx, &aft->buffer);
 
     jb_free(js);
     return TM_ECODE_OK;
@@ -92,7 +84,7 @@ static int MetadataJson(ThreadVars *tv, JsonMetadataLogThread *aft, const Packet
 
 static int JsonMetadataLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 {
-    JsonMetadataLogThread *aft = thread_data;
+    OutputJsonThreadCtx *aft = thread_data;
 
     return MetadataJson(tv, aft, p);
 }
@@ -105,123 +97,14 @@ static int JsonMetadataLogCondition(ThreadVars *tv, const Packet *p)
     return FALSE;
 }
 
-static TmEcode JsonMetadataLogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    JsonMetadataLogThread *aft = SCCalloc(1, sizeof(JsonMetadataLogThread));
-    if (unlikely(aft == NULL))
-        return TM_ECODE_FAILED;
-
-    if(initdata == NULL) {
-        SCLogDebug("Error getting context for EveLogMetadata.  \"initdata\" argument NULL");
-        goto error_exit;
-    }
-
-    aft->json_buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (aft->json_buffer == NULL) {
-        goto error_exit;
-    }
-
-    /** Use the Output Context (file pointer and mutex) */
-    MetadataJsonOutputCtx *json_output_ctx = ((OutputCtx *)initdata)->data;
-    aft->file_ctx = LogFileEnsureExists(json_output_ctx->file_ctx, t->id);
-    if (!aft->file_ctx) {
-        goto error_exit;
-    }
-    aft->json_output_ctx = json_output_ctx;
-
-    *data = (void *)aft;
-    return TM_ECODE_OK;
-
-error_exit:
-    if (aft->json_buffer != NULL) {
-        MemBufferFree(aft->json_buffer);
-    }
-    SCFree(aft);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonMetadataLogThreadDeinit(ThreadVars *t, void *data)
-{
-    JsonMetadataLogThread *aft = (JsonMetadataLogThread *)data;
-    if (aft == NULL) {
-        return TM_ECODE_OK;
-    }
-
-    MemBufferFree(aft->json_buffer);
-
-    /* clear memory */
-    memset(aft, 0, sizeof(JsonMetadataLogThread));
-
-    SCFree(aft);
-    return TM_ECODE_OK;
-}
-
-static void JsonMetadataLogDeInitCtxSub(OutputCtx *output_ctx)
-{
-    SCLogDebug("cleaning up sub output_ctx %p", output_ctx);
-
-    MetadataJsonOutputCtx *json_output_ctx = (MetadataJsonOutputCtx *) output_ctx->data;
-
-    if (json_output_ctx != NULL) {
-        SCFree(json_output_ctx);
-    }
-    SCFree(output_ctx);
-}
-
-/**
- * \brief Create a new LogFileCtx for "fast" output style.
- * \param conf The configuration node for this output.
- * \return A LogFileCtx pointer on success, NULL on failure.
- */
-static OutputInitResult JsonMetadataLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
-{
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ajt = parent_ctx->data;
-    MetadataJsonOutputCtx *json_output_ctx = NULL;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
-    if (unlikely(output_ctx == NULL))
-        return result;
-
-    json_output_ctx = SCMalloc(sizeof(MetadataJsonOutputCtx));
-    if (unlikely(json_output_ctx == NULL)) {
-        goto error;
-    }
-    memset(json_output_ctx, 0, sizeof(MetadataJsonOutputCtx));
-
-    json_output_ctx->file_ctx = ajt->file_ctx;
-    json_output_ctx->cfg = ajt->cfg;
-    /* override config setting as this logger is about metadata */
-    json_output_ctx->cfg.include_metadata = true;
-
-    output_ctx->data = json_output_ctx;
-    output_ctx->DeInit = JsonMetadataLogDeInitCtxSub;
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
-
-error:
-    if (json_output_ctx != NULL) {
-        SCFree(json_output_ctx);
-    }
-    if (output_ctx != NULL) {
-        SCFree(output_ctx);
-    }
-
-    return result;
-}
-
 void JsonMetadataLogRegister (void)
 {
-    OutputRegisterPacketSubModule(LOGGER_JSON_METADATA, "eve-log", MODULE_NAME,
-        "eve-log.metadata", JsonMetadataLogInitCtxSub, JsonMetadataLogger,
-        JsonMetadataLogCondition, JsonMetadataLogThreadInit,
-        JsonMetadataLogThreadDeinit, NULL);
+    OutputRegisterPacketSubModule(LOGGER_JSON_METADATA, "eve-log", MODULE_NAME, "eve-log.metadata",
+            OutputJsonLogInitSub, JsonMetadataLogger, JsonMetadataLogCondition, JsonLogThreadInit,
+            JsonLogThreadDeinit, NULL);
 
     /* Kept for compatibility. */
-    OutputRegisterPacketSubModule(LOGGER_JSON_METADATA, "eve-log", MODULE_NAME,
-        "eve-log.vars", JsonMetadataLogInitCtxSub, JsonMetadataLogger,
-        JsonMetadataLogCondition, JsonMetadataLogThreadInit,
-        JsonMetadataLogThreadDeinit, NULL);
+    OutputRegisterPacketSubModule(LOGGER_JSON_METADATA, "eve-log", MODULE_NAME, "eve-log.vars",
+            OutputJsonLogInitSub, JsonMetadataLogger, JsonMetadataLogCondition, JsonLogThreadInit,
+            JsonLogThreadDeinit, NULL);
 }

--- a/src/output-json-mqtt.c
+++ b/src/output-json-mqtt.c
@@ -58,6 +58,7 @@ typedef struct LogMQTTLogThread_ {
     LogMQTTFileCtx *mqttlog_ctx;
     uint32_t        count;
     MemBuffer      *buffer;
+    LogFileCtx *file_ctx;
 } LogMQTTLogThread;
 
 bool JsonMQTTAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
@@ -94,7 +95,7 @@ static int JsonMQTTLogger(ThreadVars *tv, void *thread_data,
         goto error;
 
     MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(js, thread->mqttlog_ctx->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(js, thread->file_ctx, &thread->buffer);
     jb_free(js);
 
     return TM_ECODE_OK;
@@ -174,6 +175,8 @@ static TmEcode JsonMQTTLogThreadInit(ThreadVars *t, const void *initdata, void *
     }
 
     thread->mqttlog_ctx = ((OutputCtx *)initdata)->data;
+    thread->file_ctx = LogFileEnsureExists(thread->mqttlog_ctx->file_ctx, t->id);
+
     *data = (void *)thread;
 
     return TM_ECODE_OK;

--- a/src/output-json-nfs.c
+++ b/src/output-json-nfs.c
@@ -81,11 +81,10 @@ static int JsonNFSLogger(ThreadVars *tv, void *thread_data,
     if (rs_nfs_tx_logging_is_filtered(state, nfstx))
         return TM_ECODE_OK;
 
-    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "nfs", NULL);
+    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "nfs", NULL, thread->ctx);
     if (unlikely(jb == NULL)) {
         return TM_ECODE_OK;
     }
-    EveAddCommonOptions(&thread->ctx->cfg, p, f, jb);
 
     jb_open_object(jb, "rpc");
     rs_rpc_log_json_response(tx, jb);

--- a/src/output-json-rdp.c
+++ b/src/output-json-rdp.c
@@ -43,28 +43,15 @@
 #include "output-json-rdp.h"
 #include "rust.h"
 
-typedef struct LogRdpFileCtx_ {
-    LogFileCtx *file_ctx;
-    uint32_t    flags;
-    OutputJsonCommonSettings cfg;
-} LogRdpFileCtx;
-
-typedef struct LogRdpLogThread_ {
-    LogRdpFileCtx *rdplog_ctx;
-    LogFileCtx *file_ctx;
-    MemBuffer       *buffer;
-} LogRdpLogThread;
-
 static int JsonRdpLogger(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
 {
-    LogRdpLogThread *thread = thread_data;
+    OutputJsonThreadCtx *thread = thread_data;
 
-    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "rdp", NULL);
+    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "rdp", NULL, thread->ctx);
     if (unlikely(js == NULL)) {
         return TM_ECODE_OK;
     }
-    EveAddCommonOptions(&thread->rdplog_ctx->cfg, p, f, js);
     if (!rs_rdp_to_json(tx, js)) {
         jb_free(js);
         return TM_ECODE_FAILED;
@@ -76,105 +63,19 @@ static int JsonRdpLogger(ThreadVars *tv, void *thread_data,
     return TM_ECODE_OK;
 }
 
-static void OutputRdpLogDeInitCtxSub(OutputCtx *output_ctx)
-{
-    LogRdpFileCtx *rdplog_ctx = (LogRdpFileCtx *)output_ctx->data;
-    SCFree(rdplog_ctx);
-    SCFree(output_ctx);
-}
-
 static OutputInitResult OutputRdpLogInitSub(ConfNode *conf,
     OutputCtx *parent_ctx)
 {
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ajt = parent_ctx->data;
-
-    LogRdpFileCtx *rdplog_ctx = SCCalloc(1, sizeof(*rdplog_ctx));
-    if (unlikely(rdplog_ctx == NULL)) {
-        return result;
-    }
-    rdplog_ctx->file_ctx = ajt->file_ctx;
-    rdplog_ctx->cfg = ajt->cfg;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
-    if (unlikely(output_ctx == NULL)) {
-        SCFree(rdplog_ctx);
-        return result;
-    }
-    output_ctx->data = rdplog_ctx;
-    output_ctx->DeInit = OutputRdpLogDeInitCtxSub;
-
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_RDP);
-
-    SCLogDebug("rdp log sub-module initialized.");
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
-}
-
-static TmEcode JsonRdpLogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    if (initdata == NULL) {
-        SCLogDebug("Error getting context for EveLogRdp. \"initdata\" is NULL.");
-        return TM_ECODE_FAILED;
-    }
-
-    LogRdpLogThread *thread = SCCalloc(1, sizeof(*thread));
-    if (unlikely(thread == NULL)) {
-        return TM_ECODE_FAILED;
-    }
-
-    thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (unlikely(thread->buffer == NULL)) {
-        goto error_exit;
-    }
-
-    thread->rdplog_ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->rdplog_ctx->file_ctx, t->id);
-    if (!thread->file_ctx) {
-        goto error_exit;
-    }
-
-    *data = (void *)thread;
-    return TM_ECODE_OK;
-
-error_exit:
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonRdpLogThreadDeinit(ThreadVars *t, void *data)
-{
-    LogRdpLogThread *thread = (LogRdpLogThread *)data;
-    if (thread == NULL) {
-        return TM_ECODE_OK;
-    }
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_OK;
+    return OutputJsonLogInitSub(conf, parent_ctx);
 }
 
 void JsonRdpLogRegister(void)
 {
     /* Register as an eve sub-module. */
-    OutputRegisterTxSubModule(
-        LOGGER_JSON_RDP,
-        "eve-log",
-        "JsonRdpLog",
-        "eve-log.rdp",
-        OutputRdpLogInitSub,
-        ALPROTO_RDP,
-        JsonRdpLogger,
-        JsonRdpLogThreadInit,
-        JsonRdpLogThreadDeinit,
-        NULL
-    );
+    OutputRegisterTxSubModule(LOGGER_JSON_RDP, "eve-log", "JsonRdpLog", "eve-log.rdp",
+            OutputRdpLogInitSub, ALPROTO_RDP, JsonRdpLogger, JsonLogThreadInit, JsonLogThreadDeinit,
+            NULL);
 
     SCLogDebug("rdp json logger registered.");
 }

--- a/src/output-json-rfb.c
+++ b/src/output-json-rfb.c
@@ -46,17 +46,6 @@
 
 #include "rust-bindings.h"
 
-typedef struct LogRFBFileCtx_ {
-    LogFileCtx *file_ctx;
-    uint32_t    flags;
-} LogRFBFileCtx;
-
-typedef struct LogRFBLogThread_ {
-    LogRFBFileCtx *rfblog_ctx;
-    LogFileCtx *file_ctx;
-    MemBuffer          *buffer;
-} LogRFBLogThread;
-
 bool JsonRFBAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
 {
     RFBState *state = FlowGetAppState(f);
@@ -73,9 +62,9 @@ bool JsonRFBAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
 static int JsonRFBLogger(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
 {
-    LogRFBLogThread *thread = thread_data;
+    OutputJsonThreadCtx *thread = thread_data;
 
-    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_FLOW, "rfb", NULL);
+    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_FLOW, "rfb", NULL, thread->ctx);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }
@@ -95,92 +84,17 @@ error:
     return TM_ECODE_FAILED;
 }
 
-static void OutputRFBLogDeInitCtxSub(OutputCtx *output_ctx)
-{
-    LogRFBFileCtx *rfblog_ctx = (LogRFBFileCtx *)output_ctx->data;
-    SCFree(rfblog_ctx);
-    SCFree(output_ctx);
-}
-
 static OutputInitResult OutputRFBLogInitSub(ConfNode *conf,
     OutputCtx *parent_ctx)
 {
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ajt = parent_ctx->data;
-
-    LogRFBFileCtx *rfblog_ctx = SCCalloc(1, sizeof(*rfblog_ctx));
-    if (unlikely(rfblog_ctx == NULL)) {
-        return result;
-    }
-    rfblog_ctx->file_ctx = ajt->file_ctx;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
-    if (unlikely(output_ctx == NULL)) {
-        SCFree(rfblog_ctx);
-        return result;
-    }
-    output_ctx->data = rfblog_ctx;
-    output_ctx->DeInit = OutputRFBLogDeInitCtxSub;
-
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_RFB);
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
-}
-
-static TmEcode JsonRFBLogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    if (initdata == NULL) {
-        SCLogDebug("Error getting context for EveLogRFB.  \"initdata\" is NULL.");
-        return TM_ECODE_FAILED;
-    }
-
-    LogRFBLogThread *thread = SCCalloc(1, sizeof(*thread));
-    if (unlikely(thread == NULL)) {
-        return TM_ECODE_FAILED;
-    }
-
-    thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (unlikely(thread->buffer == NULL)) {
-        goto error_exit;
-    }
-
-    thread->rfblog_ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->rfblog_ctx->file_ctx, t->id);
-    if (!thread->file_ctx) {
-        goto error_exit;
-    }
-    *data = (void *)thread;
-
-    return TM_ECODE_OK;
-
-error_exit:
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonRFBLogThreadDeinit(ThreadVars *t, void *data)
-{
-    LogRFBLogThread *thread = (LogRFBLogThread *)data;
-    if (thread == NULL) {
-        return TM_ECODE_OK;
-    }
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_OK;
+    return OutputJsonLogInitSub(conf, parent_ctx);
 }
 
 void JsonRFBLogRegister(void)
 {
     /* Register as an eve sub-module. */
-    OutputRegisterTxSubModule(LOGGER_JSON_RFB, "eve-log",
-        "JsonRFBLog", "eve-log.rfb",
-        OutputRFBLogInitSub, ALPROTO_RFB, JsonRFBLogger,
-        JsonRFBLogThreadInit, JsonRFBLogThreadDeinit, NULL);
+    OutputRegisterTxSubModule(LOGGER_JSON_RFB, "eve-log", "JsonRFBLog", "eve-log.rfb",
+            OutputRFBLogInitSub, ALPROTO_RFB, JsonRFBLogger, JsonLogThreadInit, JsonLogThreadDeinit,
+            NULL);
 }

--- a/src/output-json-sip.c
+++ b/src/output-json-sip.c
@@ -49,17 +49,6 @@
 
 #include "rust.h"
 
-typedef struct LogSIPFileCtx_ {
-    LogFileCtx *file_ctx;
-    OutputJsonCommonSettings cfg;
-} LogSIPFileCtx;
-
-typedef struct LogSIPLogThread_ {
-    LogFileCtx *file_ctx;
-    LogSIPFileCtx *siplog_ctx;
-    MemBuffer          *buffer;
-} LogSIPLogThread;
-
 void JsonSIPAddMetadata(JsonBuilder *js, const Flow *f, uint64_t tx_id)
 {
     SIPState *state = FlowGetAppState(f);
@@ -75,13 +64,12 @@ static int JsonSIPLogger(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
 {
     SIPTransaction *siptx = tx;
-    LogSIPLogThread *thread = thread_data;
+    OutputJsonThreadCtx *thread = thread_data;
 
-    JsonBuilder *js = CreateEveHeader((Packet *)p, LOG_DIR_PACKET, "sip", NULL);
+    JsonBuilder *js = CreateEveHeader((Packet *)p, LOG_DIR_PACKET, "sip", NULL, thread->ctx);
     if (unlikely(js == NULL)) {
         return TM_ECODE_OK;
     }
-    EveAddCommonOptions(&thread->siplog_ctx->cfg, p, f, js);
 
     if (!rs_sip_log_json(siptx, js)) {
         goto error;
@@ -98,100 +86,19 @@ error:
     return TM_ECODE_FAILED;
 }
 
-static void OutputSIPLogDeInitCtxSub(OutputCtx *output_ctx)
-{
-    LogSIPFileCtx *siplog_ctx = (LogSIPFileCtx *)output_ctx->data;
-    SCFree(siplog_ctx);
-    SCFree(output_ctx);
-}
-
 static OutputInitResult OutputSIPLogInitSub(ConfNode *conf,
     OutputCtx *parent_ctx)
 {
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ajt = parent_ctx->data;
-
-    LogSIPFileCtx *siplog_ctx = SCCalloc(1, sizeof(*siplog_ctx));
-    if (unlikely(siplog_ctx == NULL)) {
-        return result;
-    }
-    siplog_ctx->file_ctx = ajt->file_ctx;
-    siplog_ctx->cfg = ajt->cfg;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
-    if (unlikely(output_ctx == NULL)) {
-        SCFree(siplog_ctx);
-        return result;
-    }
-    output_ctx->data = siplog_ctx;
-    output_ctx->DeInit = OutputSIPLogDeInitCtxSub;
-
-    SCLogDebug("SIP log sub-module initialized.");
-
     AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_SIP);
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
-}
-
-#define OUTPUT_BUFFER_SIZE 65535
-
-static TmEcode JsonSIPLogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    LogSIPLogThread *thread = SCCalloc(1, sizeof(*thread));
-    if (unlikely(thread == NULL)) {
-        return TM_ECODE_FAILED;
-    }
-
-    if (initdata == NULL) {
-        SCLogDebug("Error getting context for EveLogSIP.  \"initdata\" is NULL.");
-        goto error_exit;
-    }
-
-    thread->buffer = MemBufferCreateNew(OUTPUT_BUFFER_SIZE);
-    if (unlikely(thread->buffer == NULL)) {
-        goto error_exit;
-    }
-
-    thread->siplog_ctx = ((OutputCtx *)initdata)->data;
-
-    thread->file_ctx = LogFileEnsureExists(thread->siplog_ctx->file_ctx, t->id);
-    if (!thread->file_ctx) {
-        goto error_exit;
-    }
-    *data = (void *)thread;
-
-    return TM_ECODE_OK;
-
-error_exit:
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonSIPLogThreadDeinit(ThreadVars *t, void *data)
-{
-    LogSIPLogThread *thread = (LogSIPLogThread *)data;
-    if (thread == NULL) {
-        return TM_ECODE_OK;
-    }
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_OK;
+    return OutputJsonLogInitSub(conf, parent_ctx);
 }
 
 void JsonSIPLogRegister(void)
 {
     /* Register as an eve sub-module. */
-    OutputRegisterTxSubModule(LOGGER_JSON_SIP, "eve-log", "JsonSIPLog",
-        "eve-log.sip", OutputSIPLogInitSub, ALPROTO_SIP,
-        JsonSIPLogger, JsonSIPLogThreadInit,
-        JsonSIPLogThreadDeinit, NULL);
+    OutputRegisterTxSubModule(LOGGER_JSON_SIP, "eve-log", "JsonSIPLog", "eve-log.sip",
+            OutputSIPLogInitSub, ALPROTO_SIP, JsonSIPLogger, JsonLogThreadInit, JsonLogThreadDeinit,
+            NULL);
 
     SCLogDebug("SIP JSON logger registered.");
 }

--- a/src/output-json-smb.c
+++ b/src/output-json-smb.c
@@ -64,7 +64,7 @@ static int JsonSMBLogger(ThreadVars *tv, void *thread_data,
 {
     OutputJsonThreadCtx *thread = thread_data;
 
-    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "smb", NULL);
+    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "smb", NULL, thread->ctx);
     if (unlikely(jb == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-snmp.c
+++ b/src/output-json-snmp.c
@@ -49,29 +49,16 @@
 
 #include "rust.h"
 
-typedef struct LogSNMPFileCtx_ {
-    LogFileCtx *file_ctx;
-    OutputJsonCommonSettings cfg;
-} LogSNMPFileCtx;
-
-typedef struct LogSNMPLogThread_ {
-    LogFileCtx *file_ctx;
-    LogSNMPFileCtx *snmplog_ctx;
-    MemBuffer          *buffer;
-} LogSNMPLogThread;
-
 static int JsonSNMPLogger(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
 {
     SNMPTransaction *snmptx = tx;
-    LogSNMPLogThread *thread = thread_data;
+    OutputJsonThreadCtx *thread = thread_data;
 
-    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "snmp", NULL);
+    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "snmp", NULL, thread->ctx);
     if (unlikely(jb == NULL)) {
         return TM_ECODE_FAILED;
     }
-
-    EveAddCommonOptions(&thread->snmplog_ctx->cfg, p, f, jb);
 
     jb_open_object(jb, "snmp");
     if (!rs_snmp_log_json_response(jb, state, snmptx)) {
@@ -90,98 +77,19 @@ error:
     return TM_ECODE_FAILED;
 }
 
-static void OutputSNMPLogDeInitCtxSub(OutputCtx *output_ctx)
-{
-    LogSNMPFileCtx *snmplog_ctx = (LogSNMPFileCtx *)output_ctx->data;
-    SCFree(snmplog_ctx);
-    SCFree(output_ctx);
-}
-
 static OutputInitResult OutputSNMPLogInitSub(ConfNode *conf,
     OutputCtx *parent_ctx)
 {
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ajt = parent_ctx->data;
-
-    LogSNMPFileCtx *snmplog_ctx = SCCalloc(1, sizeof(*snmplog_ctx));
-    if (unlikely(snmplog_ctx == NULL)) {
-        return result;
-    }
-    snmplog_ctx->file_ctx = ajt->file_ctx;
-    snmplog_ctx->cfg = ajt->cfg;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
-    if (unlikely(output_ctx == NULL)) {
-        SCFree(snmplog_ctx);
-        return result;
-    }
-    output_ctx->data = snmplog_ctx;
-    output_ctx->DeInit = OutputSNMPLogDeInitCtxSub;
-
-    SCLogDebug("SNMP log sub-module initialized.");
-
     AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_SNMP);
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
-}
-
-static TmEcode JsonSNMPLogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    LogSNMPLogThread *thread = SCCalloc(1, sizeof(*thread));
-    if (unlikely(thread == NULL)) {
-        return TM_ECODE_FAILED;
-    }
-
-    if (initdata == NULL) {
-        SCLogDebug("Error getting context for EveLogSNMP.  \"initdata\" is NULL.");
-        goto error_exit;
-    }
-
-    thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (unlikely(thread->buffer == NULL)) {
-        goto error_exit;
-    }
-
-    thread->snmplog_ctx = ((OutputCtx *)initdata)->data;
-
-    thread->file_ctx = LogFileEnsureExists(thread->snmplog_ctx->file_ctx, t->id);
-    if (!thread->file_ctx) {
-        goto error_exit;
-    }
-
-    *data = (void *)thread;
-    return TM_ECODE_OK;
-
-error_exit:
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonSNMPLogThreadDeinit(ThreadVars *t, void *data)
-{
-    LogSNMPLogThread *thread = (LogSNMPLogThread *)data;
-    if (thread == NULL) {
-        return TM_ECODE_OK;
-    }
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_OK;
+    return OutputJsonLogInitSub(conf, parent_ctx);
 }
 
 void JsonSNMPLogRegister(void)
 {
     /* Register as an eve sub-module. */
-    OutputRegisterTxSubModule(LOGGER_JSON_SNMP, "eve-log", "JsonSNMPLog",
-        "eve-log.snmp", OutputSNMPLogInitSub, ALPROTO_SNMP,
-        JsonSNMPLogger, JsonSNMPLogThreadInit,
-        JsonSNMPLogThreadDeinit, NULL);
+    OutputRegisterTxSubModule(LOGGER_JSON_SNMP, "eve-log", "JsonSNMPLog", "eve-log.snmp",
+            OutputSNMPLogInitSub, ALPROTO_SNMP, JsonSNMPLogger, JsonLogThreadInit,
+            JsonLogThreadDeinit, NULL);
 
     SCLogDebug("SNMP JSON logger registered.");
 }

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -53,24 +53,10 @@
 
 #define MODULE_NAME "LogSshLog"
 
-typedef struct OutputSshCtx_ {
-    LogFileCtx *file_ctx;
-    OutputJsonCommonSettings cfg;
-} OutputSshCtx;
-
-
-typedef struct JsonSshLogThread_ {
-    OutputSshCtx *sshlog_ctx;
-    LogFileCtx *file_ctx;
-    MemBuffer *buffer;
-} JsonSshLogThread;
-
-
 static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
                          Flow *f, void *state, void *txptr, uint64_t tx_id)
 {
-    JsonSshLogThread *aft = (JsonSshLogThread *)thread_data;
-    OutputSshCtx *ssh_ctx = aft->sshlog_ctx;
+    OutputJsonThreadCtx *thread = thread_data;
 
     if (unlikely(state == NULL)) {
         return 0;
@@ -80,113 +66,33 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
     if (unlikely(js == NULL))
         return 0;
 
-    EveAddCommonOptions(&ssh_ctx->cfg, p, f, js);
+    EveAddCommonOptions(&thread->ctx->cfg, p, f, js);
 
     /* reset */
-    MemBufferReset(aft->buffer);
+    MemBufferReset(thread->buffer);
 
     jb_open_object(js, "ssh");
     if (!rs_ssh_log_json(txptr, js)) {
         goto end;
     }
     jb_close(js);
-    OutputJsonBuilderBuffer(js, aft->file_ctx, &aft->buffer);
+    OutputJsonBuilderBuffer(js, thread->file_ctx, &thread->buffer);
 
 end:
     jb_free(js);
     return 0;
 }
 
-static TmEcode JsonSshLogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    if (initdata == NULL) {
-        SCLogDebug("Error getting context for EveLogSSH.  \"initdata\" argument NULL");
-        return TM_ECODE_FAILED;
-    }
-
-    JsonSshLogThread *aft = SCCalloc(1, sizeof(JsonSshLogThread));
-    if (unlikely(aft == NULL))
-        return TM_ECODE_FAILED;
-
-    /* Use the Output Context (file pointer and mutex) */
-    aft->sshlog_ctx = ((OutputCtx *)initdata)->data;
-
-    aft->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (aft->buffer == NULL) {
-        goto error_exit;
-    }
-
-    aft->file_ctx = LogFileEnsureExists(aft->sshlog_ctx->file_ctx, t->id);
-    if (!aft->file_ctx) {
-        goto error_exit;
-    }
-
-    *data = (void *)aft;
-    return TM_ECODE_OK;
-
-error_exit:
-    if (aft->buffer != NULL) {
-        MemBufferFree(aft->buffer);
-    }
-    SCFree(aft);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonSshLogThreadDeinit(ThreadVars *t, void *data)
-{
-    JsonSshLogThread *aft = (JsonSshLogThread *)data;
-    if (aft == NULL) {
-        return TM_ECODE_OK;
-    }
-
-    MemBufferFree(aft->buffer);
-    /* clear memory */
-    memset(aft, 0, sizeof(JsonSshLogThread));
-
-    SCFree(aft);
-    return TM_ECODE_OK;
-}
-
-static void OutputSshLogDeinitSub(OutputCtx *output_ctx)
-{
-    OutputSshCtx *ssh_ctx = output_ctx->data;
-    SCFree(ssh_ctx);
-    SCFree(output_ctx);
-}
-
 static OutputInitResult OutputSshLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ojc = parent_ctx->data;
-
-    OutputSshCtx *ssh_ctx = SCMalloc(sizeof(OutputSshCtx));
-    if (unlikely(ssh_ctx == NULL))
-        return result;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
-    if (unlikely(output_ctx == NULL)) {
-        SCFree(ssh_ctx);
-        return result;
-    }
-
-    ssh_ctx->file_ctx = ojc->file_ctx;
-    ssh_ctx->cfg = ojc->cfg;
-
-    output_ctx->data = ssh_ctx;
-    output_ctx->DeInit = OutputSshLogDeinitSub;
-
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_SSH);
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
+    return OutputJsonLogInitSub(conf, parent_ctx);
 }
 
 void JsonSshLogRegister (void)
 {
     /* register as child of eve-log */
-    OutputRegisterTxSubModuleWithCondition(LOGGER_JSON_SSH,
-        "eve-log", "JsonSshLog", "eve-log.ssh",
-        OutputSshLogInitSub, ALPROTO_SSH, JsonSshLogger,
-        SSHTxLogCondition, JsonSshLogThreadInit, JsonSshLogThreadDeinit, NULL);
+    OutputRegisterTxSubModuleWithCondition(LOGGER_JSON_SSH, "eve-log", "JsonSshLog", "eve-log.ssh",
+            OutputSshLogInitSub, ALPROTO_SSH, JsonSshLogger, SSHTxLogCondition, JsonLogThreadInit,
+            JsonLogThreadDeinit, NULL);
 }

--- a/src/output-json-template-rust.c
+++ b/src/output-json-template-rust.c
@@ -55,8 +55,8 @@
 #include "rust.h"
 
 typedef struct LogTemplateFileCtx_ {
-    LogFileCtx *file_ctx;
     uint32_t    flags;
+    OutputJsonCtx *eve_ctx;
 } LogTemplateFileCtx;
 
 typedef struct LogTemplateLogThread_ {
@@ -71,7 +71,8 @@ static int JsonTemplateLogger(ThreadVars *tv, void *thread_data,
     SCLogNotice("JsonTemplateLogger");
     LogTemplateLogThread *thread = thread_data;
 
-    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "template-rust", NULL);
+    JsonBuilder *js = CreateEveHeader(
+            p, LOG_DIR_PACKET, "template-rust", NULL, thread->templatelog_ctx->eve_ctx);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }
@@ -110,7 +111,7 @@ static OutputInitResult OutputTemplateLogInitSub(ConfNode *conf,
     if (unlikely(templatelog_ctx == NULL)) {
         return result;
     }
-    templatelog_ctx->file_ctx = ajt->file_ctx;
+    templatelog_ctx->eve_ctx = ajt;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {
@@ -147,7 +148,7 @@ static TmEcode JsonTemplateLogThreadInit(ThreadVars *t, const void *initdata, vo
     }
 
     thread->templatelog_ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->templatelog_ctx->file_ctx, t->id);
+    thread->file_ctx = LogFileEnsureExists(thread->templatelog_ctx->eve_ctx->file_ctx, t->id);
     if (!thread->file_ctx) {
         goto error_exit;
     }

--- a/src/output-json-template.c
+++ b/src/output-json-template.c
@@ -54,8 +54,8 @@
 #include "output-json-template.h"
 
 typedef struct LogTemplateFileCtx_ {
-    LogFileCtx *file_ctx;
     uint32_t    flags;
+    OutputJsonCtx *eve_ctx;
 } LogTemplateFileCtx;
 
 typedef struct LogTemplateLogThread_ {
@@ -72,7 +72,8 @@ static int JsonTemplateLogger(ThreadVars *tv, void *thread_data,
 
     SCLogNotice("Logging template transaction %"PRIu64".", templatetx->tx_id);
 
-    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "template", NULL);
+    JsonBuilder *js =
+            CreateEveHeader(p, LOG_DIR_PACKET, "template", NULL, thread->templatelog_ctx->eve_ctx);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }
@@ -118,7 +119,7 @@ static OutputInitResult OutputTemplateLogInitSub(ConfNode *conf,
     if (unlikely(templatelog_ctx == NULL)) {
         return result;
     }
-    templatelog_ctx->file_ctx = ajt->file_ctx;
+    templatelog_ctx->eve_ctx = ajt;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {
@@ -155,7 +156,7 @@ static TmEcode JsonTemplateLogThreadInit(ThreadVars *t, const void *initdata, vo
     }
 
     thread->templatelog_ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->templatelog_ctx->file_ctx, t->id);
+    thread->file_ctx = LogFileEnsureExists(thread->templatelog_ctx->eve_ctx->file_ctx, t->id);
     if (!thread->file_ctx) {
         goto error_exit;
     }

--- a/src/output-json-tftp.c
+++ b/src/output-json-tftp.c
@@ -50,24 +50,12 @@
 
 #include "rust.h"
 
-typedef struct LogTFTPFileCtx_ {
-    LogFileCtx *file_ctx;
-    uint32_t    flags;
-    OutputJsonCommonSettings cfg;
-} LogTFTPFileCtx;
-
-typedef struct LogTFTPLogThread_ {
-    LogFileCtx *file_ctx;
-    LogTFTPFileCtx *tftplog_ctx;
-    MemBuffer          *buffer;
-} LogTFTPLogThread;
-
 static int JsonTFTPLogger(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
 {
-    LogTFTPLogThread *thread = thread_data;
+    OutputJsonThreadCtx *thread = thread_data;
 
-    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "tftp", NULL);
+    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "tftp", NULL, thread->ctx);
     if (unlikely(jb == NULL)) {
         return TM_ECODE_FAILED;
     }
@@ -78,7 +66,6 @@ static int JsonTFTPLogger(ThreadVars *tv, void *thread_data,
     }
     jb_close(jb);
 
-    EveAddCommonOptions(&thread->tftplog_ctx->cfg, p, f, jb);
     MemBufferReset(thread->buffer);
     OutputJsonBuilderBuffer(jb, thread->file_ctx, &thread->buffer);
 
@@ -90,98 +77,19 @@ error:
     return TM_ECODE_FAILED;
 }
 
-static void OutputTFTPLogDeInitCtxSub(OutputCtx *output_ctx)
-{
-    LogTFTPFileCtx *tftplog_ctx = (LogTFTPFileCtx *)output_ctx->data;
-    SCFree(tftplog_ctx);
-    SCFree(output_ctx);
-}
-
 static OutputInitResult OutputTFTPLogInitSub(ConfNode *conf,
     OutputCtx *parent_ctx)
 {
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ajt = parent_ctx->data;
-
-    LogTFTPFileCtx *tftplog_ctx = SCCalloc(1, sizeof(*tftplog_ctx));
-    if (unlikely(tftplog_ctx == NULL)) {
-        return result;
-    }
-    tftplog_ctx->file_ctx = ajt->file_ctx;
-    tftplog_ctx->cfg = ajt->cfg;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
-    if (unlikely(output_ctx == NULL)) {
-        SCFree(tftplog_ctx);
-        return result;
-    }
-    output_ctx->data = tftplog_ctx;
-    output_ctx->DeInit = OutputTFTPLogDeInitCtxSub;
-
-    SCLogDebug("TFTP log sub-module initialized.");
-
     AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_TFTP);
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
-}
-
-static TmEcode JsonTFTPLogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    LogTFTPLogThread *thread = SCCalloc(1, sizeof(*thread));
-    if (unlikely(thread == NULL)) {
-        return TM_ECODE_FAILED;
-    }
-
-    if (initdata == NULL) {
-        SCLogDebug("Error getting context for EveLogTFTP.  \"initdata\" is NULL.");
-        goto error_exit;
-    }
-
-    thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (unlikely(thread->buffer == NULL)) {
-        goto error_exit;
-    }
-
-    thread->tftplog_ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->tftplog_ctx->file_ctx, t->id);
-    if (!thread->file_ctx) {
-        goto error_exit;
-    }
-    *data = (void *)thread;
-
-    return TM_ECODE_OK;
-
-error_exit:
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonTFTPLogThreadDeinit(ThreadVars *t, void *data)
-{
-    LogTFTPLogThread *thread = (LogTFTPLogThread *)data;
-    if (thread == NULL) {
-        return TM_ECODE_OK;
-    }
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_OK;
+    return OutputJsonLogInitSub(conf, parent_ctx);
 }
 
 void JsonTFTPLogRegister(void)
 {
     /* Register as an eve sub-module. */
-    OutputRegisterTxSubModule(LOGGER_JSON_TFTP, "eve-log", "JsonTFTPLog",
-                              "eve-log.tftp", OutputTFTPLogInitSub,
-                              ALPROTO_TFTP, JsonTFTPLogger,
-                              JsonTFTPLogThreadInit, JsonTFTPLogThreadDeinit,
-                              NULL);
+    OutputRegisterTxSubModule(LOGGER_JSON_TFTP, "eve-log", "JsonTFTPLog", "eve-log.tftp",
+            OutputTFTPLogInitSub, ALPROTO_TFTP, JsonTFTPLogger, JsonLogThreadInit,
+            JsonLogThreadDeinit, NULL);
 
     SCLogDebug("TFTP JSON logger registered.");
 }

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -398,7 +398,7 @@ static void EveAddFlowVars(const Flow *f, JsonBuilder *js_root, JsonBuilder **js
     }
 }
 
-static void EveAddMetadata(const Packet *p, const Flow *f, JsonBuilder *js)
+void EveAddMetadata(const Packet *p, const Flow *f, JsonBuilder *js)
 {
     if ((p && p->pktvar) || (f && f->flowvar)) {
         JsonBuilder *js_vars = jb_new_object();
@@ -836,7 +836,7 @@ int CreateJSONEther(JsonBuilder *js, const Packet *p, const Flow *f)
 }
 
 JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
-        const char *event_type, JsonAddrInfo *addr)
+        const char *event_type, JsonAddrInfo *addr, OutputJsonCtx *eve_ctx)
 {
     char timebuf[64];
     const Flow *f = (const Flow *)p->flow;
@@ -909,13 +909,17 @@ JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
             break;
     }
 
+    if (eve_ctx != NULL) {
+        EveAddCommonOptions(&eve_ctx->cfg, p, f, js);
+    }
+
     return js;
 }
 
 JsonBuilder *CreateEveHeaderWithTxId(const Packet *p, enum OutputJsonLogDirection dir,
                                  const char *event_type, JsonAddrInfo *addr, uint64_t tx_id)
 {
-    JsonBuilder *js = CreateEveHeader(p, dir, event_type, addr);
+    JsonBuilder *js = CreateEveHeader(p, dir, event_type, addr, NULL);
     if (unlikely(js == NULL))
         return NULL;
 

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -68,26 +68,6 @@ typedef struct OutputJSONMemBufferWrapper_ {
     size_t expand_by;   /**< expand by this size */
 } OutputJSONMemBufferWrapper;
 
-int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
-
-void CreateEveFlowId(JsonBuilder *js, const Flow *f);
-void EveFileInfo(JsonBuilder *js, const File *file, const bool stored);
-void EveTcpFlags(uint8_t flags, JsonBuilder *js);
-void EvePacket(const Packet *p, JsonBuilder *js, unsigned long max_length);
-JsonBuilder *CreateEveHeader(const Packet *p,
-        enum OutputJsonLogDirection dir, const char *event_type,
-        JsonAddrInfo *addr);
-JsonBuilder *CreateEveHeaderWithTxId(const Packet *p,
-        enum OutputJsonLogDirection dir, const char *event_type, JsonAddrInfo *addr,
-        uint64_t tx_id);
-int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer);
-int OutputJsonBuilderBuffer(JsonBuilder *js, LogFileCtx *file_ctx, MemBuffer **buffer);
-OutputInitResult OutputJsonInitCtx(ConfNode *);
-
-OutputInitResult OutputJsonLogInitSub(ConfNode *conf, OutputCtx *parent_ctx);
-TmEcode JsonLogThreadInit(ThreadVars *t, const void *initdata, void **data);
-TmEcode JsonLogThreadDeinit(ThreadVars *t, void *data);
-
 typedef struct OutputJsonCommonSettings_ {
     bool include_metadata;
     bool include_community_id;
@@ -114,7 +94,26 @@ typedef struct OutputJsonThreadCtx_ {
 
 json_t *SCJsonString(const char *val);
 
+void CreateEveFlowId(JsonBuilder *js, const Flow *f);
+void EveFileInfo(JsonBuilder *js, const File *file, const bool stored);
+void EveTcpFlags(uint8_t flags, JsonBuilder *js);
+void EvePacket(const Packet *p, JsonBuilder *js, unsigned long max_length);
+JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
+        const char *event_type, JsonAddrInfo *addr, OutputJsonCtx *eve_ctx);
+JsonBuilder *CreateEveHeaderWithTxId(const Packet *p, enum OutputJsonLogDirection dir,
+        const char *event_type, JsonAddrInfo *addr, uint64_t tx_id);
+int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer);
+int OutputJsonBuilderBuffer(JsonBuilder *js, LogFileCtx *file_ctx, MemBuffer **buffer);
+OutputInitResult OutputJsonInitCtx(ConfNode *);
+
+OutputInitResult OutputJsonLogInitSub(ConfNode *conf, OutputCtx *parent_ctx);
+TmEcode JsonLogThreadInit(ThreadVars *t, const void *initdata, void **data);
+TmEcode JsonLogThreadDeinit(ThreadVars *t, void *data);
+
 void EveAddCommonOptions(const OutputJsonCommonSettings *cfg,
         const Packet *p, const Flow *f, JsonBuilder *js);
+void EveAddMetadata(const Packet *p, const Flow *f, JsonBuilder *js);
+
+int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
 
 #endif /* __OUTPUT_JSON_H__ */


### PR DESCRIPTION
The first change was to have CreateEveHeader add the common options
as this was left out in a few loggers. While update all the loggers
that use CreateEveHeader, remove redundant code, in particular
from loggers that don't need to use their own context but
can use the generic one.

The idea is to make loggers much easier to register, which will ease registration from Rust, and parser plugins.