### PR TITLE
rust: bump bitflags dependency version

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -21,7 +21,7 @@ function-macro = []
 
 [dependencies]
 nom = "~5.1.2"
-bitflags = "~1.0.4"
+bitflags = "~1.2.1"
 byteorder = "~1.4.2"
 uuid = "~0.8.2"
 crc = "~1.8.1"


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=32569

Will fix build failure with rust nightly, including oss-fuzz

Describe changes:
- bump bitflags dependency version

So that lexical-core, needed by nom, and using bitflags
is used with version 0.7.5 instead of version 0.7.0
which fixed the fact that BITS is now a reserved keyword
in nightly version


Is there a tool to do so automatically for every dependency ? (checking compilation is ok)