### PR TITLE
config/threshold: Slow startup when threshold.config contains many suppress addrs

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -121,7 +121,7 @@ static void DetectAddressHeadFree(DetectAddressHead *gh)
  * \retval ag Pointer to the new instance of DetectAddress that contains the
  *            copied address.
  */
-static DetectAddress *DetectAddressCopy(DetectAddress *orig)
+DetectAddress *DetectAddressCopy(DetectAddress *orig)
 {
     DetectAddress *ag = DetectAddressInit();
     if (ag == NULL)
@@ -829,7 +829,7 @@ static int DetectAddressParse2(const DetectEngineCtx *de_ctx,
                     }
                     DetectAddressHeadCleanup(&tmp_ghn);
 
-                    SCLogDebug("merged succesfully");
+                    SCLogDebug("merged successfully");
 
                     /* insert the IPv4 addresses into the negated list */
                     for (tmp_ad = tmp_gh.ipv4_head; tmp_ad; tmp_ad = tmp_ad->next) {
@@ -1504,7 +1504,7 @@ void DetectAddressHeadCleanup(DetectAddressHead *gh)
  *        explanations on what these functions do.
  *
  * \param de_ctx Pointer to the DetectEngineCtx.
- * \param a      Pointer the the first address to be cut.
+ * \param a      Pointer to the first address to be cut.
  * \param b      Pointer to the second address to be cut.
  * \param c      Pointer to a pointer to a third DetectAddressData, in case the
  *               ranges from a and b, demand a third address range.

--- a/src/detect-engine-address.h
+++ b/src/detect-engine-address.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -28,6 +28,7 @@
 
 DetectAddress *DetectAddressInit(void);
 void DetectAddressFree(DetectAddress *);
+DetectAddress *DetectAddressCopy(DetectAddress *);
 int DetectAddressParse(const DetectEngineCtx *, DetectAddressHead *, const char *);
 void DetectAddressHeadCleanup(DetectAddressHead *);
 

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -284,6 +284,53 @@ static void DetectThresholdFree(DetectEngineCtx *de_ctx, void *de_ptr)
         DetectAddressHeadCleanup(&de->addrs);
         SCFree(de);
     }
+}
+
+/**
+ * \brief Make a deep-copy of an extant DetectTHresholdData object.
+ *
+ * \param de pointer to DetectThresholdData
+ */
+DetectThresholdData *DetectThresholdDataCopy(DetectThresholdData *de)
+{
+    DetectThresholdData *new_de = SCCalloc(1, sizeof(DetectThresholdData));
+    if (unlikely(new_de == NULL))
+        return NULL;
+
+    *new_de = *de;
+    new_de->addrs.ipv4_head = NULL;
+    new_de->addrs.ipv6_head = NULL;
+
+    for (DetectAddress *last = NULL, *tmp_ad = de->addrs.ipv4_head; tmp_ad; tmp_ad = tmp_ad->next) {
+        DetectAddress *n_addr = DetectAddressCopy(tmp_ad);
+        if (n_addr == NULL)
+            goto error;
+        if (last == NULL) {
+            new_de->addrs.ipv4_head = n_addr;
+        } else {
+            last->next = n_addr;
+            n_addr->prev = last;
+        }
+        last = n_addr;
+    }
+    for (DetectAddress *last = NULL, *tmp_ad = de->addrs.ipv6_head; tmp_ad; tmp_ad = tmp_ad->next) {
+        DetectAddress *n_addr = DetectAddressCopy(tmp_ad);
+        if (n_addr == NULL)
+            goto error;
+        if (last == NULL) {
+            new_de->addrs.ipv6_head = n_addr;
+        } else {
+            last->next = n_addr;
+            n_addr->prev = last;
+        }
+        last = n_addr;
+    }
+
+    return new_de;
+
+error:
+    DetectThresholdFree(NULL, new_de);
+    return NULL;
 }
 
 /*

--- a/src/detect-threshold.h
+++ b/src/detect-threshold.h
@@ -85,5 +85,6 @@ typedef struct DetectThresholdEntry_ {
  */
 
 void DetectThresholdRegister(void);
+DetectThresholdData *DetectThresholdDataCopy(DetectThresholdData *);
 
 #endif /*__DETECT_THRESHOLD_H__ */

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -374,8 +374,8 @@ static int SetupSuppressRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid,
         }
     } else if (id > 0 && gid == 0) {
         SCLogError(SC_ERR_INVALID_VALUE, "Can't use a event config that has "
-                   "sid > 0 and gid == 0. Please fix this "
-                   "in your threshold.conf file");
+                                         "sid > 0 and gid == 0. Please fix this "
+                                         "in your threshold.config file");
         goto error;
     } else {
         s = SigFindSignatureBySidGid(de_ctx, id, gid);
@@ -1300,7 +1300,7 @@ static FILE *SCThresholdConfGenerateValidDummyFD11(void)
 /**
  * \test Check if the threshold file is loaded and well parsed
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest01(void)
@@ -1333,7 +1333,7 @@ static int SCThresholdConfTest01(void)
 /**
  * \test Check if the threshold file is loaded and well parsed
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest02(void)
@@ -1366,7 +1366,7 @@ static int SCThresholdConfTest02(void)
 /**
  * \test Check if the threshold file is loaded and well parsed
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest03(void)
@@ -1399,7 +1399,7 @@ static int SCThresholdConfTest03(void)
 /**
  * \test Check if the threshold file is loaded and well parsed
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest04(void)
@@ -1428,7 +1428,7 @@ static int SCThresholdConfTest04(void)
 /**
  * \test Check if the threshold file is loaded and well parsed
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest05(void)
@@ -1483,7 +1483,7 @@ static int SCThresholdConfTest05(void)
 /**
  * \test Check if the threshold file is loaded and well parsed
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest06(void)
@@ -1516,7 +1516,7 @@ static int SCThresholdConfTest06(void)
 /**
  * \test Check if the rate_filter rules are loaded and well parsed
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest07(void)
@@ -1550,7 +1550,7 @@ static int SCThresholdConfTest07(void)
  * \test Check if the rate_filter rules are loaded and well parsed
  *       with multilines
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest08(void)
@@ -1583,7 +1583,7 @@ static int SCThresholdConfTest08(void)
 /**
  * \test Check if the rate_filter rules work
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest09(void)
@@ -1671,7 +1671,7 @@ static int SCThresholdConfTest09(void)
 /**
  * \test Check if the rate_filter rules work with track by_rule
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest10(void)
@@ -1765,7 +1765,7 @@ static int SCThresholdConfTest10(void)
 /**
  * \test Check if the rate_filter rules work
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest11(void)
@@ -1874,7 +1874,7 @@ static int SCThresholdConfTest11(void)
 /**
  * \test Check if the rate_filter rules work
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest12(void)
@@ -1983,7 +1983,7 @@ static int SCThresholdConfTest12(void)
 /**
  * \test Check if the threshold file is loaded and well parsed
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest13(void)
@@ -2016,7 +2016,7 @@ static int SCThresholdConfTest13(void)
 /**
  * \test Check if the suppress rules work
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest14(void)
@@ -2081,7 +2081,7 @@ static int SCThresholdConfTest14(void)
 /**
  * \test Check if the suppress rules work
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest15(void)
@@ -2133,7 +2133,7 @@ static int SCThresholdConfTest15(void)
 /**
  * \test Check if the suppress rules work
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest16(void)
@@ -2184,7 +2184,7 @@ static int SCThresholdConfTest16(void)
 /**
  * \test Check if the suppress rules work - ip only rule
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest17(void)
@@ -2255,7 +2255,7 @@ static FILE *SCThresholdConfGenerateInvalidDummyFD12(void)
 /**
  * \test Check if the suppress rule parsing handles errors correctly
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest18(void)
@@ -2307,7 +2307,7 @@ static FILE *SCThresholdConfGenerateInvalidDummyFD13(void)
 /**
  * \test Check if the suppress rule parsing handles errors correctly
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest19(void)
@@ -2357,7 +2357,7 @@ static FILE *SCThresholdConfGenerateValidDummyFD20(void)
 /**
  * \test Check if the threshold file is loaded and well parsed
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest20(void)
@@ -2403,7 +2403,7 @@ static int SCThresholdConfTest20(void)
  * \test Check if the threshold file is loaded and well parsed, and applied
  *       correctly to a rule with thresholding
  *
- *  \retval 1 on succces
+ *  \retval 1 on success
  *  \retval 0 on failure
  */
 static int SCThresholdConfTest21(void)
@@ -2463,11 +2463,11 @@ static FILE *SCThresholdConfGenerateValidDummyFD22(void)
 }
 
 /**
-* \test Check if the rate_filter rules work with track by_both
-*
-*  \retval 1 on succces
-*  \retval 0 on failure
-*/
+ * \test Check if the rate_filter rules work with track by_both
+ *
+ *  \retval 1 on success
+ *  \retval 0 on failure
+ */
 static int SCThresholdConfTest22(void)
 {
     ThreadVars th_v;
@@ -2603,12 +2603,12 @@ static FILE *SCThresholdConfGenerateValidDummyFD23(void)
 }
 
 /**
-* \test Check if the rate_filter by_both work when similar packets
-*       going in opposite direction
-*
-*  \retval 1 on succces
-*  \retval 0 on failure
-*/
+ * \test Check if the rate_filter by_both work when similar packets
+ *       going in opposite direction
+ *
+ *  \retval 1 on success
+ *  \retval 0 on failure
+ */
 static int SCThresholdConfTest23(void)
 {
     ThreadVars th_v;


### PR DESCRIPTION
This PR improves Suricata's startup time when `threshold.config` contains many suppress addresses.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4407](https://redmine.openinfosecfoundation.org/issues/4407)

Describe changes:
- Move loop-invariant for address parsing out of the loop. Create a master copy and copy to individual sigs as needed.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
