### PR TITLE
eve cleanup - v2

### DIFF
--- a/src/detect-engine-profile.c
+++ b/src/detect-engine-profile.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2020 Open Information Security Foundation
+/* Copyright (C) 2016-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -38,7 +38,7 @@ SCMutex g_rule_dump_write_m = SCMUTEX_INITIALIZER;
 void RulesDumpMatchArray(const DetectEngineThreadCtx *det_ctx,
         const SigGroupHead *sgh, const Packet *p)
 {
-    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "inspectedrules", NULL);
+    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "inspectedrules", NULL, NULL);
     if (js == NULL)
         return;
 

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2020 Open Information Security Foundation
+/* Copyright (C) 2018-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -168,8 +168,8 @@ static void OutputFilestoreFinalizeFiles(ThreadVars *tv,
             WARN_ONCE(SC_ERR_SPRINTF,
                 "Failed to write file info record. Output filename truncated.");
         } else {
-            JsonBuilder *js_fileinfo = JsonBuildFileInfoRecord(p, ff, true, dir,
-                    ctx->xff_cfg);
+            JsonBuilder *js_fileinfo =
+                    JsonBuildFileInfoRecord(p, ff, true, dir, ctx->xff_cfg, NULL);
             if (likely(js_fileinfo != NULL)) {
                 jb_close(js_fileinfo);
                 FILE *out = fopen(js_metadata_filename, "w");

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -172,9 +172,8 @@ static int AnomalyAppLayerDecoderEventJson(JsonAnomalyLogThread *aft,
 
         JsonBuilder *js;
         if (tx_id != TX_ID_UNUSED) {
-            js = CreateEveHeaderWithTxId(p, LOG_DIR_PACKET,
-                                          ANOMALY_EVENT_TYPE, NULL, tx_id);
-            EveAddCommonOptions(&aft->json_output_ctx->eve_ctx->cfg, p, p->flow, js);
+            js = CreateEveHeaderWithTxId(p, LOG_DIR_PACKET, ANOMALY_EVENT_TYPE, NULL, tx_id,
+                    aft->json_output_ctx->eve_ctx);
         } else {
             js = CreateEveHeader(
                     p, LOG_DIR_PACKET, ANOMALY_EVENT_TYPE, NULL, aft->json_output_ctx->eve_ctx);

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019-2020 Open Information Security Foundation
+/* Copyright (C) 2019-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -72,9 +72,8 @@
 #define TX_ID_UNUSED UINT64_MAX
 
 typedef struct AnomalyJsonOutputCtx_ {
-    LogFileCtx* file_ctx;
     uint16_t flags;
-    OutputJsonCommonSettings cfg;
+    OutputJsonCtx *eve_ctx;
 } AnomalyJsonOutputCtx;
 
 typedef struct JsonAnomalyLogThread_ {
@@ -108,7 +107,6 @@ static void OutputAnomalyLoggerDisable(void)
 static int AnomalyDecodeEventJson(ThreadVars *tv, JsonAnomalyLogThread *aft,
                                   const Packet *p)
 {
-    const bool is_ip_pkt = PKT_IS_IPV4(p) || PKT_IS_IPV6(p);
     const uint16_t log_type = aft->json_output_ctx->flags;
     const bool log_stream = log_type & LOG_JSON_STREAM_TYPE;
     const bool log_decode = log_type & LOG_JSON_DECODE_TYPE;
@@ -123,13 +121,10 @@ static int AnomalyDecodeEventJson(ThreadVars *tv, JsonAnomalyLogThread *aft,
 
         MemBufferReset(aft->json_buffer);
 
-        JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, ANOMALY_EVENT_TYPE, NULL);
+        JsonBuilder *js = CreateEveHeader(
+                p, LOG_DIR_PACKET, ANOMALY_EVENT_TYPE, NULL, aft->json_output_ctx->eve_ctx);
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
-        }
-
-        if (is_ip_pkt) {
-            EveAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js);
         }
 
         jb_open_object(js, ANOMALY_EVENT_TYPE);
@@ -179,14 +174,15 @@ static int AnomalyAppLayerDecoderEventJson(JsonAnomalyLogThread *aft,
         if (tx_id != TX_ID_UNUSED) {
             js = CreateEveHeaderWithTxId(p, LOG_DIR_PACKET,
                                           ANOMALY_EVENT_TYPE, NULL, tx_id);
+            EveAddCommonOptions(&aft->json_output_ctx->eve_ctx->cfg, p, p->flow, js);
         } else {
-            js = CreateEveHeader(p, LOG_DIR_PACKET, ANOMALY_EVENT_TYPE, NULL);
+            js = CreateEveHeader(
+                    p, LOG_DIR_PACKET, ANOMALY_EVENT_TYPE, NULL, aft->json_output_ctx->eve_ctx);
         }
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
         }
 
-        EveAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js);
 
         jb_open_object(js, ANOMALY_EVENT_TYPE);
 
@@ -319,7 +315,7 @@ static TmEcode JsonAnomalyLogThreadInit(ThreadVars *t, const void *initdata, voi
     /** Use the Output Context (file pointer and mutex) */
     AnomalyJsonOutputCtx *json_output_ctx = ((OutputCtx *)initdata)->data;
 
-    aft->file_ctx = LogFileEnsureExists(json_output_ctx->file_ctx, t->id);
+    aft->file_ctx = LogFileEnsureExists(json_output_ctx->eve_ctx->file_ctx, t->id);
     if (!aft->file_ctx) {
         goto error_exit;
     }
@@ -431,9 +427,8 @@ static OutputInitResult JsonAnomalyLogInitCtxHelper(ConfNode *conf, OutputCtx *p
         goto error;
     }
 
-    json_output_ctx->file_ctx = ajt->file_ctx;
     JsonAnomalyLogConf(json_output_ctx, conf);
-    json_output_ctx->cfg = ajt->cfg;
+    json_output_ctx->eve_ctx = ajt;
 
     output_ctx->data = json_output_ctx;
     output_ctx->DeInit = JsonAnomalyLogDeInitCtxSubHelper;

--- a/src/output-json-dcerpc.c
+++ b/src/output-json-dcerpc.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2020 Open Information Security Foundation
+/* Copyright (C) 2017-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -46,7 +46,7 @@ static int JsonDCERPCLogger(ThreadVars *tv, void *thread_data,
 {
     OutputJsonThreadCtx *thread = thread_data;
 
-    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "dcerpc", NULL);
+    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "dcerpc", NULL, thread->ctx);
     if (unlikely(jb == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-email-common.h
+++ b/src/output-json-email-common.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -25,10 +25,9 @@
 #define __OUTPUT_JSON_EMAIL_COMMON_H__
 
 typedef struct OutputJsonEmailCtx_ {
-    LogFileCtx *file_ctx;
     uint32_t flags; /** Store mode */
     uint64_t fields;/** Store fields */
-    OutputJsonCommonSettings cfg;
+    OutputJsonCtx *eve_ctx;
 } OutputJsonEmailCtx;
 
 typedef struct JsonEmailLogThread_ {

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -70,10 +70,10 @@
 #include "stream-tcp-reassemble.h"
 
 typedef struct OutputFileCtx_ {
-    LogFileCtx *file_ctx;
     uint32_t file_cnt;
     HttpXFFCfg *xff_cfg;
     HttpXFFCfg *parent_xff_cfg;
+    OutputJsonCtx *eve_ctx;
 } OutputFileCtx;
 
 typedef struct JsonFileLogThread_ {
@@ -82,8 +82,8 @@ typedef struct JsonFileLogThread_ {
     MemBuffer *buffer;
 } JsonFileLogThread;
 
-JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
-        const bool stored, uint8_t dir, HttpXFFCfg *xff_cfg)
+JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff, const bool stored,
+        uint8_t dir, HttpXFFCfg *xff_cfg, OutputJsonCtx *eve_ctx)
 {
     enum OutputJsonLogDirection fdir = LOG_DIR_FLOW;
 
@@ -119,7 +119,7 @@ JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
         }
     }
 
-    JsonBuilder *js = CreateEveHeader(p, fdir, "fileinfo", &addr);
+    JsonBuilder *js = CreateEveHeader(p, fdir, "fileinfo", &addr, eve_ctx);
     if (unlikely(js == NULL))
         return NULL;
 
@@ -202,13 +202,13 @@ JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
  *  \internal
  *  \brief Write meta data on a single line json record
  */
-static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p,
-                                const File *ff, uint32_t dir)
+static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const File *ff,
+        uint32_t dir, OutputJsonCtx *eve_ctx)
 {
     HttpXFFCfg *xff_cfg = aft->filelog_ctx->xff_cfg != NULL ?
         aft->filelog_ctx->xff_cfg : aft->filelog_ctx->parent_xff_cfg;;
-    JsonBuilder *js = JsonBuildFileInfoRecord(p, ff,
-            ff->flags & FILE_STORED ? true : false, dir, xff_cfg);
+    JsonBuilder *js = JsonBuildFileInfoRecord(
+            p, ff, ff->flags & FILE_STORED ? true : false, dir, xff_cfg, eve_ctx);
     if (unlikely(js == NULL)) {
         return;
     }
@@ -228,7 +228,7 @@ static int JsonFileLogger(ThreadVars *tv, void *thread_data, const Packet *p,
 
     SCLogDebug("ff %p", ff);
 
-    FileWriteJsonRecord(aft, p, ff, dir);
+    FileWriteJsonRecord(aft, p, ff, dir, aft->filelog_ctx->eve_ctx);
     return 0;
 }
 
@@ -252,7 +252,7 @@ static TmEcode JsonFileLogThreadInit(ThreadVars *t, const void *initdata, void *
 
     /* Use the Ouptut Context (file pointer and mutex) */
     aft->filelog_ctx = ((OutputCtx *)initdata)->data;
-    aft->file_ctx = LogFileEnsureExists(aft->filelog_ctx->file_ctx, t->id);
+    aft->file_ctx = LogFileEnsureExists(aft->filelog_ctx->eve_ctx->file_ctx, t->id);
     if (!aft->file_ctx) {
         goto error_exit;
     }
@@ -312,8 +312,6 @@ static OutputInitResult OutputFileLogInitSub(ConfNode *conf, OutputCtx *parent_c
         return result;
     }
 
-    output_file_ctx->file_ctx = ojc->file_ctx;
-
     if (conf) {
         const char *force_filestore = ConfNodeLookupChildValue(conf, "force-filestore");
         if (force_filestore != NULL && ConfValIsTrue(force_filestore)) {
@@ -339,6 +337,7 @@ static OutputInitResult OutputFileLogInitSub(ConfNode *conf, OutputCtx *parent_c
         output_file_ctx->parent_xff_cfg = ojc->xff_cfg;
     }
 
+    output_file_ctx->eve_ctx = ojc;
     output_ctx->data = output_file_ctx;
     output_ctx->DeInit = OutputFileLogDeinitSub;
 

--- a/src/output-json-file.h
+++ b/src/output-json-file.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -26,8 +26,10 @@
 
 #include "app-layer-htp-xff.h"
 
+typedef struct OutputJsonCtx_ OutputJsonCtx;
+
 void JsonFileLogRegister(void);
-JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
-        const bool stored, uint8_t dir, HttpXFFCfg *xff_cfg);
+JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff, const bool stored,
+        uint8_t dir, HttpXFFCfg *xff_cfg, OutputJsonCtx *eve_ctx);
 
 #endif /* __OUTPUT_JSON_FILE_H__ */

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -51,19 +51,6 @@
 #include "stream-tcp-private.h"
 #include "flow-storage.h"
 
-typedef struct LogJsonFileCtx_ {
-    LogFileCtx *file_ctx;
-    uint32_t flags; /** Store mode */
-    OutputJsonCommonSettings cfg;
-} LogJsonFileCtx;
-
-typedef struct JsonFlowLogThread_ {
-    LogJsonFileCtx *flowlog_ctx;
-    /** LogFileCtx has the pointer to the file and a mutex to allow multithreading */
-    LogFileCtx *file_ctx;
-    MemBuffer *buffer;
-} JsonFlowLogThread;
-
 static JsonBuilder *CreateEveHeaderFromFlow(const Flow *f)
 {
     char timebuf[64];
@@ -227,10 +214,8 @@ void EveAddFlow(Flow *f, JsonBuilder *js)
 }
 
 /* Eve format logging */
-static void EveFlowLogJSON(JsonFlowLogThread *aft, JsonBuilder *jb, Flow *f)
+static void EveFlowLogJSON(OutputJsonThreadCtx *aft, JsonBuilder *jb, Flow *f)
 {
-    LogJsonFileCtx *flow_ctx = aft->flowlog_ctx;
-
     EveAddAppProto(f, jb);
     jb_open_object(jb, "flow");
     EveAddFlow(f, jb);
@@ -291,7 +276,7 @@ static void EveFlowLogJSON(JsonFlowLogThread *aft, JsonBuilder *jb, Flow *f)
     /* Close flow. */
     jb_close(jb);
 
-    EveAddCommonOptions(&flow_ctx->cfg, NULL, f, jb);
+    EveAddCommonOptions(&aft->ctx->cfg, NULL, f, jb);
 
     /* TCP */
     if (f->proto == IPPROTO_TCP) {
@@ -328,112 +313,27 @@ static void EveFlowLogJSON(JsonFlowLogThread *aft, JsonBuilder *jb, Flow *f)
 static int JsonFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
 {
     SCEnter();
-    JsonFlowLogThread *jhl = (JsonFlowLogThread *)thread_data;
+    OutputJsonThreadCtx *thread = thread_data;
 
     /* reset */
-    MemBufferReset(jhl->buffer);
+    MemBufferReset(thread->buffer);
 
     JsonBuilder *jb = CreateEveHeaderFromFlow(f);
     if (unlikely(jb == NULL)) {
         SCReturnInt(TM_ECODE_OK);
     }
 
-    EveFlowLogJSON(jhl, jb, f);
+    EveFlowLogJSON(thread, jb, f);
 
-    OutputJsonBuilderBuffer(jb, jhl->file_ctx, &jhl->buffer);
+    OutputJsonBuilderBuffer(jb, thread->file_ctx, &thread->buffer);
     jb_free(jb);
 
     SCReturnInt(TM_ECODE_OK);
 }
 
-static void OutputFlowLogDeinitSub(OutputCtx *output_ctx)
-{
-    LogJsonFileCtx *flow_ctx = output_ctx->data;
-    SCFree(flow_ctx);
-    SCFree(output_ctx);
-}
-
-static OutputInitResult OutputFlowLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
-{
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ojc = parent_ctx->data;
-
-    LogJsonFileCtx *flow_ctx = SCMalloc(sizeof(LogJsonFileCtx));
-    if (unlikely(flow_ctx == NULL))
-        return result;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
-    if (unlikely(output_ctx == NULL)) {
-        SCFree(flow_ctx);
-        return result;
-    }
-
-    flow_ctx->file_ctx = ojc->file_ctx;
-    flow_ctx->cfg = ojc->cfg;
-
-    output_ctx->data = flow_ctx;
-    output_ctx->DeInit = OutputFlowLogDeinitSub;
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
-}
-
-static TmEcode JsonFlowLogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    JsonFlowLogThread *aft = SCCalloc(1, sizeof(JsonFlowLogThread));
-    if (unlikely(aft == NULL))
-        return TM_ECODE_FAILED;
-
-    if(initdata == NULL)
-    {
-        SCLogDebug("Error getting context for EveLogFlow.  \"initdata\" argument NULL");
-        goto error_exit;
-    }
-
-    /* Use the Outptut Context (file pointer and mutex) */
-    aft->flowlog_ctx = ((OutputCtx *)initdata)->data; //TODO
-
-    aft->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (aft->buffer == NULL) {
-        goto error_exit;
-    }
-
-    aft->file_ctx = LogFileEnsureExists(aft->flowlog_ctx->file_ctx, t->id);
-    if (!aft->file_ctx) {
-        goto error_exit;
-    }
-
-    *data = (void *)aft;
-    return TM_ECODE_OK;
-
-error_exit:
-    if (aft->buffer != NULL) {
-        MemBufferFree(aft->buffer);
-    }
-    SCFree(aft);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonFlowLogThreadDeinit(ThreadVars *t, void *data)
-{
-    JsonFlowLogThread *aft = (JsonFlowLogThread *)data;
-    if (aft == NULL) {
-        return TM_ECODE_OK;
-    }
-
-    MemBufferFree(aft->buffer);
-    /* clear memory */
-    memset(aft, 0, sizeof(JsonFlowLogThread));
-
-    SCFree(aft);
-    return TM_ECODE_OK;
-}
-
 void JsonFlowLogRegister (void)
 {
     /* register as child of eve-log */
-    OutputRegisterFlowSubModule(LOGGER_JSON_FLOW, "eve-log", "JsonFlowLog",
-        "eve-log.flow", OutputFlowLogInitSub, JsonFlowLogger,
-        JsonFlowLogThreadInit, JsonFlowLogThreadDeinit, NULL);
+    OutputRegisterFlowSubModule(LOGGER_JSON_FLOW, "eve-log", "JsonFlowLog", "eve-log.flow",
+            OutputJsonLogInitSub, JsonFlowLogger, JsonLogThreadInit, JsonLogThreadDeinit, NULL);
 }

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -48,16 +48,6 @@
 #include "app-layer-ftp.h"
 #include "output-json-ftp.h"
 
-typedef struct LogFTPFileCtx_ {
-    OutputJsonCtx *eve_ctx;
-} LogFTPFileCtx;
-
-typedef struct LogFTPLogThread_ {
-    LogFileCtx *file_ctx;
-    LogFTPFileCtx *ftplog_ctx;
-    MemBuffer          *buffer;
-} LogFTPLogThread;
-
 static void EveFTPLogCommand(Flow *f, FTPTransaction *tx, JsonBuilder *jb)
 {
     /* Preallocate array objects to simplify failure case */
@@ -149,6 +139,7 @@ static int JsonFTPLogger(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *vtx, uint64_t tx_id)
 {
     SCEnter();
+    OutputJsonThreadCtx *thread = thread_data;
 
     const char *event_type;
     if (f->alproto == ALPROTO_FTPDATA) {
@@ -157,11 +148,9 @@ static int JsonFTPLogger(ThreadVars *tv, void *thread_data,
         event_type = "ftp";
     }
     FTPTransaction *tx = vtx;
-    LogFTPLogThread *thread = thread_data;
-    LogFTPFileCtx *ftp_ctx = thread->ftplog_ctx;
 
-    JsonBuilder *jb = CreateEveHeaderWithTxId(
-            p, LOG_DIR_FLOW, event_type, NULL, tx_id, thread->ftplog_ctx->eve_ctx);
+    JsonBuilder *jb =
+            CreateEveHeaderWithTxId(p, LOG_DIR_FLOW, event_type, NULL, tx_id, thread->ctx);
     if (likely(jb)) {
         jb_open_object(jb, event_type);
         if (f->alproto == ALPROTO_FTPDATA) {
@@ -186,107 +175,23 @@ fail:
     return TM_ECODE_FAILED;
 }
 
-static void OutputFTPLogDeInitCtxSub(OutputCtx *output_ctx)
-{
-    LogFTPFileCtx *ftplog_ctx = (LogFTPFileCtx *)output_ctx->data;
-    SCFree(ftplog_ctx);
-    SCFree(output_ctx);
-}
-
-
 static OutputInitResult OutputFTPLogInitSub(ConfNode *conf,
     OutputCtx *parent_ctx)
 {
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ajt = parent_ctx->data;
-
-    LogFTPFileCtx *ftplog_ctx = SCCalloc(1, sizeof(*ftplog_ctx));
-    if (unlikely(ftplog_ctx == NULL)) {
-        return result;
-    }
-    ftplog_ctx->eve_ctx = ajt;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
-    if (unlikely(output_ctx == NULL)) {
-        SCFree(ftplog_ctx);
-        return result;
-    }
-    output_ctx->data = ftplog_ctx;
-    output_ctx->DeInit = OutputFTPLogDeInitCtxSub;
-
-    SCLogDebug("FTP log sub-module initialized.");
-
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_FTP);
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_FTPDATA);
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
-}
-
-static TmEcode JsonFTPLogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    LogFTPLogThread *thread = SCCalloc(1, sizeof(*thread));
-    if (unlikely(thread == NULL)) {
-        return TM_ECODE_FAILED;
-    }
-
-    if (initdata == NULL) {
-        SCLogDebug("Error getting context for EveLogFTP.  \"initdata\" is NULL.");
-        goto error_exit;
-    }
-
-    thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (unlikely(thread->buffer == NULL)) {
-        goto error_exit;
-    }
-
-    thread->ftplog_ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->ftplog_ctx->eve_ctx->file_ctx, t->id);
-    if (!thread->file_ctx) {
-        goto error_exit;
-    }
-
-    *data = (void *)thread;
-
-    return TM_ECODE_OK;
-
-error_exit:
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonFTPLogThreadDeinit(ThreadVars *t, void *data)
-{
-    LogFTPLogThread *thread = (LogFTPLogThread *)data;
-    if (thread == NULL) {
-        return TM_ECODE_OK;
-    }
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    /* clear memory */
-    memset(thread, 0, sizeof(LogFTPLogThread));
-    SCFree(thread);
-    return TM_ECODE_OK;
+    return OutputJsonLogInitSub(conf, parent_ctx);
 }
 
 void JsonFTPLogRegister(void)
 {
     /* Register as an eve sub-module. */
-    OutputRegisterTxSubModule(LOGGER_JSON_FTP, "eve-log", "JsonFTPLog",
-                              "eve-log.ftp", OutputFTPLogInitSub,
-                              ALPROTO_FTP, JsonFTPLogger,
-                              JsonFTPLogThreadInit, JsonFTPLogThreadDeinit,
-                              NULL);
-    OutputRegisterTxSubModule(LOGGER_JSON_FTP, "eve-log", "JsonFTPLog",
-                              "eve-log.ftp", OutputFTPLogInitSub,
-                              ALPROTO_FTPDATA, JsonFTPLogger,
-                              JsonFTPLogThreadInit, JsonFTPLogThreadDeinit,
-                              NULL);
+    OutputRegisterTxSubModule(LOGGER_JSON_FTP, "eve-log", "JsonFTPLog", "eve-log.ftp",
+            OutputFTPLogInitSub, ALPROTO_FTP, JsonFTPLogger, JsonLogThreadInit, JsonLogThreadDeinit,
+            NULL);
+    OutputRegisterTxSubModule(LOGGER_JSON_FTP, "eve-log", "JsonFTPLog", "eve-log.ftp",
+            OutputFTPLogInitSub, ALPROTO_FTPDATA, JsonFTPLogger, JsonLogThreadInit,
+            JsonLogThreadDeinit, NULL);
 
     SCLogDebug("FTP JSON logger registered.");
 }

--- a/src/output-json-http2.c
+++ b/src/output-json-http2.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -54,8 +54,7 @@
 #define MODULE_NAME "LogHttp2Log"
 
 typedef struct OutputHttp2Ctx_ {
-    LogFileCtx *file_ctx;
-    OutputJsonCommonSettings cfg;
+    OutputJsonCtx *eve_ctx;
 } OutputHttp2Ctx;
 
 
@@ -82,17 +81,15 @@ static int JsonHttp2Logger(ThreadVars *tv, void *thread_data, const Packet *p,
                          Flow *f, void *state, void *txptr, uint64_t tx_id)
 {
     JsonHttp2LogThread *aft = (JsonHttp2LogThread *)thread_data;
-    OutputHttp2Ctx *http2_ctx = aft->http2log_ctx;
 
     if (unlikely(state == NULL)) {
         return 0;
     }
 
-    JsonBuilder *js = CreateEveHeaderWithTxId(p, LOG_DIR_FLOW, "http", NULL, tx_id);
+    JsonBuilder *js = CreateEveHeaderWithTxId(
+            p, LOG_DIR_FLOW, "http", NULL, tx_id, aft->http2log_ctx->eve_ctx);
     if (unlikely(js == NULL))
         return 0;
-
-    EveAddCommonOptions(&http2_ctx->cfg, p, f, js);
 
     /* reset */
     MemBufferReset(aft->buffer);
@@ -122,7 +119,7 @@ static TmEcode JsonHttp2LogThreadInit(ThreadVars *t, const void *initdata, void 
 
     /* Use the Output Context (file pointer and mutex) */
     aft->http2log_ctx = ((OutputCtx *)initdata)->data;
-    aft->file_ctx = LogFileEnsureExists(aft->http2log_ctx->file_ctx, t->id);
+    aft->file_ctx = LogFileEnsureExists(aft->http2log_ctx->eve_ctx->file_ctx, t->id);
     if (!aft->file_ctx) {
         goto error_exit;
     }
@@ -158,55 +155,6 @@ static TmEcode JsonHttp2LogThreadDeinit(ThreadVars *t, void *data)
     return TM_ECODE_OK;
 }
 
-static void OutputHttp2LogDeinit(OutputCtx *output_ctx)
-{
-    OutputHttp2Ctx *http2_ctx = output_ctx->data;
-    LogFileCtx *logfile_ctx = http2_ctx->file_ctx;
-    LogFileFreeCtx(logfile_ctx);
-    SCFree(http2_ctx);
-    SCFree(output_ctx);
-}
-
-#define DEFAULT_LOG_FILENAME "http2.json"
-static OutputInitResult OutputHttp2LogInit(ConfNode *conf)
-{
-    OutputInitResult result = { NULL, false };
-    LogFileCtx *file_ctx = LogFileNewCtx();
-    if(file_ctx == NULL) {
-        SCLogError(SC_ERR_HTTP2_LOG_GENERIC, "couldn't create new file_ctx");
-        return result;
-    }
-
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
-        LogFileFreeCtx(file_ctx);
-        return result;
-    }
-
-    OutputHttp2Ctx *http2_ctx = SCMalloc(sizeof(OutputHttp2Ctx));
-    if (unlikely(http2_ctx == NULL)) {
-        LogFileFreeCtx(file_ctx);
-        return result;
-    }
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
-    if (unlikely(output_ctx == NULL)) {
-        LogFileFreeCtx(file_ctx);
-        SCFree(http2_ctx);
-        return result;
-    }
-
-    http2_ctx->file_ctx = file_ctx;
-
-    output_ctx->data = http2_ctx;
-    output_ctx->DeInit = OutputHttp2LogDeinit;
-
-    AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_HTTP2);
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
-}
-
 static void OutputHttp2LogDeinitSub(OutputCtx *output_ctx)
 {
     OutputHttp2Ctx *http2_ctx = output_ctx->data;
@@ -229,8 +177,7 @@ static OutputInitResult OutputHttp2LogInitSub(ConfNode *conf, OutputCtx *parent_
         return result;
     }
 
-    http2_ctx->file_ctx = ojc->file_ctx;
-    http2_ctx->cfg = ojc->cfg;
+    http2_ctx->eve_ctx = ojc;
 
     output_ctx->data = http2_ctx;
     output_ctx->DeInit = OutputHttp2LogDeinitSub;
@@ -244,13 +191,6 @@ static OutputInitResult OutputHttp2LogInitSub(ConfNode *conf, OutputCtx *parent_
 
 void JsonHttp2LogRegister (void)
 {
-    /* register as separate module */
-    OutputRegisterTxModuleWithProgress(LOGGER_JSON_HTTP2,
-        MODULE_NAME, "http2-json-log",
-        OutputHttp2LogInit, ALPROTO_HTTP2, JsonHttp2Logger,
-        HTTP2StateClosed, HTTP2StateClosed,
-        JsonHttp2LogThreadInit, JsonHttp2LogThreadDeinit, NULL);
-
     /* also register as child of eve-log */
     OutputRegisterTxSubModuleWithProgress(LOGGER_JSON_HTTP2,
         "eve-log", MODULE_NAME, "eve-log.http2",

--- a/src/output-json-ike.c
+++ b/src/output-json-ike.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2020 Open Information Security Foundation
+/* Copyright (C) 2018-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -54,9 +54,8 @@
 #define LOG_IKE_EXTENDED (1 << 0)
 
 typedef struct LogIKEFileCtx_ {
-    LogFileCtx *file_ctx;
     uint32_t flags;
-    OutputJsonCommonSettings cfg;
+    OutputJsonCtx *eve_ctx;
 } LogIKEFileCtx;
 
 typedef struct LogIKELogThread_ {
@@ -82,11 +81,11 @@ static int JsonIKELogger(ThreadVars *tv, void *thread_data, const Packet *p, Flo
         void *tx, uint64_t tx_id)
 {
     LogIKELogThread *thread = thread_data;
-    JsonBuilder *jb = CreateEveHeader((Packet *)p, LOG_DIR_PACKET, "ike", NULL);
+    JsonBuilder *jb =
+            CreateEveHeader((Packet *)p, LOG_DIR_PACKET, "ike", NULL, thread->ikelog_ctx->eve_ctx);
     if (unlikely(jb == NULL)) {
         return TM_ECODE_FAILED;
     }
-    EveAddCommonOptions(&thread->ikelog_ctx->cfg, p, f, jb);
 
     LogIKEFileCtx *ike_ctx = thread->ikelog_ctx;
     if (!rs_ike_logger_log(state, tx, ike_ctx->flags, jb)) {
@@ -120,8 +119,7 @@ static OutputInitResult OutputIKELogInitSub(ConfNode *conf, OutputCtx *parent_ct
     if (unlikely(ikelog_ctx == NULL)) {
         return result;
     }
-    ikelog_ctx->file_ctx = ajt->file_ctx;
-    ikelog_ctx->cfg = ajt->cfg;
+    ikelog_ctx->eve_ctx = ajt;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {
@@ -165,7 +163,7 @@ static TmEcode JsonIKELogThreadInit(ThreadVars *t, const void *initdata, void **
     }
 
     thread->ikelog_ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->ikelog_ctx->file_ctx, t->id);
+    thread->file_ctx = LogFileEnsureExists(thread->ikelog_ctx->eve_ctx->file_ctx, t->id);
     if (!thread->file_ctx) {
         goto error_exit;
     }

--- a/src/output-json-krb5.c
+++ b/src/output-json-krb5.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2020 Open Information Security Foundation
+/* Copyright (C) 2018-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -49,29 +49,16 @@
 
 #include "rust.h"
 
-typedef struct LogKRB5FileCtx_ {
-    LogFileCtx *file_ctx;
-    OutputJsonCommonSettings cfg;
-} LogKRB5FileCtx;
-
-typedef struct LogKRB5LogThread_ {
-    LogFileCtx *file_ctx;
-    LogKRB5FileCtx *krb5log_ctx;
-    MemBuffer          *buffer;
-} LogKRB5LogThread;
-
 static int JsonKRB5Logger(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
 {
     KRB5Transaction *krb5tx = tx;
-    LogKRB5LogThread *thread = thread_data;
+    OutputJsonThreadCtx *thread = thread_data;
 
-    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "krb5", NULL);
+    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "krb5", NULL, thread->ctx);
     if (unlikely(jb == NULL)) {
         return TM_ECODE_FAILED;
     }
-
-    EveAddCommonOptions(&thread->krb5log_ctx->cfg, p, f, jb);
 
     jb_open_object(jb, "krb5");
     if (!rs_krb5_log_json_response(jb, state, krb5tx)) {
@@ -90,98 +77,20 @@ error:
     return TM_ECODE_FAILED;
 }
 
-static void OutputKRB5LogDeInitCtxSub(OutputCtx *output_ctx)
-{
-    LogKRB5FileCtx *krb5log_ctx = (LogKRB5FileCtx *)output_ctx->data;
-    SCFree(krb5log_ctx);
-    SCFree(output_ctx);
-}
-
 static OutputInitResult OutputKRB5LogInitSub(ConfNode *conf,
     OutputCtx *parent_ctx)
 {
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ajt = parent_ctx->data;
-
-    LogKRB5FileCtx *krb5log_ctx = SCCalloc(1, sizeof(*krb5log_ctx));
-    if (unlikely(krb5log_ctx == NULL)) {
-        return result;
-    }
-    krb5log_ctx->file_ctx = ajt->file_ctx;
-    krb5log_ctx->cfg = ajt->cfg;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
-    if (unlikely(output_ctx == NULL)) {
-        SCFree(krb5log_ctx);
-        return result;
-    }
-    output_ctx->data = krb5log_ctx;
-    output_ctx->DeInit = OutputKRB5LogDeInitCtxSub;
-
-    SCLogDebug("KRB5 log sub-module initialized.");
-
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_KRB5);
     AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_KRB5);
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
-}
-
-static TmEcode JsonKRB5LogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    LogKRB5LogThread *thread = SCCalloc(1, sizeof(*thread));
-    if (unlikely(thread == NULL)) {
-        return TM_ECODE_FAILED;
-    }
-
-    if (initdata == NULL) {
-        SCLogDebug("Error getting context for EveLogKRB5.  \"initdata\" is NULL.");
-        goto error_exit;
-    }
-
-    thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (unlikely(thread->buffer == NULL)) {
-        goto error_exit;
-    }
-
-    thread->krb5log_ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->krb5log_ctx->file_ctx, t->id);
-    if (!thread->file_ctx) {
-        goto error_exit;
-    }
-    *data = (void *)thread;
-
-    return TM_ECODE_OK;
-
-error_exit:
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonKRB5LogThreadDeinit(ThreadVars *t, void *data)
-{
-    LogKRB5LogThread *thread = (LogKRB5LogThread *)data;
-    if (thread == NULL) {
-        return TM_ECODE_OK;
-    }
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_OK;
+    return OutputJsonLogInitSub(conf, parent_ctx);
 }
 
 void JsonKRB5LogRegister(void)
 {
     /* Register as an eve sub-module. */
-    OutputRegisterTxSubModule(LOGGER_JSON_KRB5, "eve-log", "JsonKRB5Log",
-        "eve-log.krb5", OutputKRB5LogInitSub, ALPROTO_KRB5,
-        JsonKRB5Logger, JsonKRB5LogThreadInit,
-        JsonKRB5LogThreadDeinit, NULL);
+    OutputRegisterTxSubModule(LOGGER_JSON_KRB5, "eve-log", "JsonKRB5Log", "eve-log.krb5",
+            OutputKRB5LogInitSub, ALPROTO_KRB5, JsonKRB5Logger, JsonLogThreadInit,
+            JsonLogThreadDeinit, NULL);
 
     SCLogDebug("KRB5 JSON logger registered.");
 }

--- a/src/output-json-metadata.c
+++ b/src/output-json-metadata.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013-2020 Open Information Security Foundation
+/* Copyright (C) 2013-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -65,26 +65,18 @@
 
 #define MODULE_NAME "JsonMetadataLog"
 
-typedef struct MetadataJsonOutputCtx_ {
-    LogFileCtx* file_ctx;
-    OutputJsonCommonSettings cfg;
-} MetadataJsonOutputCtx;
-
-typedef struct JsonMetadataLogThread_ {
-    /** LogFileCtx has the pointer to the file and a mutex to allow multithreading */
-    LogFileCtx* file_ctx;
-    MemBuffer *json_buffer;
-    MetadataJsonOutputCtx* json_output_ctx;
-} JsonMetadataLogThread;
-
-static int MetadataJson(ThreadVars *tv, JsonMetadataLogThread *aft, const Packet *p)
+static int MetadataJson(ThreadVars *tv, OutputJsonThreadCtx *aft, const Packet *p)
 {
-    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "metadata", NULL);
+    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "metadata", NULL, aft->ctx);
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 
-    EveAddCommonOptions(&aft->json_output_ctx->cfg, p, p->flow, js);
-    OutputJsonBuilderBuffer(js, aft->file_ctx, &aft->json_buffer);
+    /* If metadata is not enabled for eve, explicitly log it here as this is
+     * what logging metadata is about. */
+    if (!aft->ctx->cfg.include_metadata) {
+        EveAddMetadata(p, p->flow, js);
+    }
+    OutputJsonBuilderBuffer(js, aft->file_ctx, &aft->buffer);
 
     jb_free(js);
     return TM_ECODE_OK;
@@ -92,7 +84,7 @@ static int MetadataJson(ThreadVars *tv, JsonMetadataLogThread *aft, const Packet
 
 static int JsonMetadataLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 {
-    JsonMetadataLogThread *aft = thread_data;
+    OutputJsonThreadCtx *aft = thread_data;
 
     return MetadataJson(tv, aft, p);
 }
@@ -105,123 +97,14 @@ static int JsonMetadataLogCondition(ThreadVars *tv, const Packet *p)
     return FALSE;
 }
 
-static TmEcode JsonMetadataLogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    JsonMetadataLogThread *aft = SCCalloc(1, sizeof(JsonMetadataLogThread));
-    if (unlikely(aft == NULL))
-        return TM_ECODE_FAILED;
-
-    if(initdata == NULL) {
-        SCLogDebug("Error getting context for EveLogMetadata.  \"initdata\" argument NULL");
-        goto error_exit;
-    }
-
-    aft->json_buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (aft->json_buffer == NULL) {
-        goto error_exit;
-    }
-
-    /** Use the Output Context (file pointer and mutex) */
-    MetadataJsonOutputCtx *json_output_ctx = ((OutputCtx *)initdata)->data;
-    aft->file_ctx = LogFileEnsureExists(json_output_ctx->file_ctx, t->id);
-    if (!aft->file_ctx) {
-        goto error_exit;
-    }
-    aft->json_output_ctx = json_output_ctx;
-
-    *data = (void *)aft;
-    return TM_ECODE_OK;
-
-error_exit:
-    if (aft->json_buffer != NULL) {
-        MemBufferFree(aft->json_buffer);
-    }
-    SCFree(aft);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonMetadataLogThreadDeinit(ThreadVars *t, void *data)
-{
-    JsonMetadataLogThread *aft = (JsonMetadataLogThread *)data;
-    if (aft == NULL) {
-        return TM_ECODE_OK;
-    }
-
-    MemBufferFree(aft->json_buffer);
-
-    /* clear memory */
-    memset(aft, 0, sizeof(JsonMetadataLogThread));
-
-    SCFree(aft);
-    return TM_ECODE_OK;
-}
-
-static void JsonMetadataLogDeInitCtxSub(OutputCtx *output_ctx)
-{
-    SCLogDebug("cleaning up sub output_ctx %p", output_ctx);
-
-    MetadataJsonOutputCtx *json_output_ctx = (MetadataJsonOutputCtx *) output_ctx->data;
-
-    if (json_output_ctx != NULL) {
-        SCFree(json_output_ctx);
-    }
-    SCFree(output_ctx);
-}
-
-/**
- * \brief Create a new LogFileCtx for "fast" output style.
- * \param conf The configuration node for this output.
- * \return A LogFileCtx pointer on success, NULL on failure.
- */
-static OutputInitResult JsonMetadataLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
-{
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ajt = parent_ctx->data;
-    MetadataJsonOutputCtx *json_output_ctx = NULL;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
-    if (unlikely(output_ctx == NULL))
-        return result;
-
-    json_output_ctx = SCMalloc(sizeof(MetadataJsonOutputCtx));
-    if (unlikely(json_output_ctx == NULL)) {
-        goto error;
-    }
-    memset(json_output_ctx, 0, sizeof(MetadataJsonOutputCtx));
-
-    json_output_ctx->file_ctx = ajt->file_ctx;
-    json_output_ctx->cfg = ajt->cfg;
-    /* override config setting as this logger is about metadata */
-    json_output_ctx->cfg.include_metadata = true;
-
-    output_ctx->data = json_output_ctx;
-    output_ctx->DeInit = JsonMetadataLogDeInitCtxSub;
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
-
-error:
-    if (json_output_ctx != NULL) {
-        SCFree(json_output_ctx);
-    }
-    if (output_ctx != NULL) {
-        SCFree(output_ctx);
-    }
-
-    return result;
-}
-
 void JsonMetadataLogRegister (void)
 {
-    OutputRegisterPacketSubModule(LOGGER_JSON_METADATA, "eve-log", MODULE_NAME,
-        "eve-log.metadata", JsonMetadataLogInitCtxSub, JsonMetadataLogger,
-        JsonMetadataLogCondition, JsonMetadataLogThreadInit,
-        JsonMetadataLogThreadDeinit, NULL);
+    OutputRegisterPacketSubModule(LOGGER_JSON_METADATA, "eve-log", MODULE_NAME, "eve-log.metadata",
+            OutputJsonLogInitSub, JsonMetadataLogger, JsonMetadataLogCondition, JsonLogThreadInit,
+            JsonLogThreadDeinit, NULL);
 
     /* Kept for compatibility. */
-    OutputRegisterPacketSubModule(LOGGER_JSON_METADATA, "eve-log", MODULE_NAME,
-        "eve-log.vars", JsonMetadataLogInitCtxSub, JsonMetadataLogger,
-        JsonMetadataLogCondition, JsonMetadataLogThreadInit,
-        JsonMetadataLogThreadDeinit, NULL);
+    OutputRegisterPacketSubModule(LOGGER_JSON_METADATA, "eve-log", MODULE_NAME, "eve-log.vars",
+            OutputJsonLogInitSub, JsonMetadataLogger, JsonMetadataLogCondition, JsonLogThreadInit,
+            JsonLogThreadDeinit, NULL);
 }

--- a/src/output-json-mqtt.c
+++ b/src/output-json-mqtt.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -50,8 +50,8 @@
 #define MQTT_DEFAULTS (MQTT_LOG_PASSWORDS)
 
 typedef struct LogMQTTFileCtx_ {
-    LogFileCtx *file_ctx;
     uint32_t    flags;
+    OutputJsonCtx *eve_ctx;
 } LogMQTTFileCtx;
 
 typedef struct LogMQTTLogThread_ {
@@ -86,7 +86,7 @@ static int JsonMQTTLogger(ThreadVars *tv, void *thread_data,
         dir = LOG_DIR_FLOW_TOSERVER;
     }
 
-    JsonBuilder *js = CreateEveHeader(p, dir, "mqtt", NULL);
+    JsonBuilder *js = CreateEveHeader(p, dir, "mqtt", NULL, thread->mqttlog_ctx->eve_ctx);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }
@@ -95,7 +95,7 @@ static int JsonMQTTLogger(ThreadVars *tv, void *thread_data,
         goto error;
 
     MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(js, thread->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(js, thread->mqttlog_ctx->eve_ctx->file_ctx, &thread->buffer);
     jb_free(js);
 
     return TM_ECODE_OK;
@@ -136,7 +136,7 @@ static OutputInitResult OutputMQTTLogInitSub(ConfNode *conf,
     if (unlikely(mqttlog_ctx == NULL)) {
         return result;
     }
-    mqttlog_ctx->file_ctx = ajt->file_ctx;
+    mqttlog_ctx->eve_ctx = ajt;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {
@@ -175,7 +175,7 @@ static TmEcode JsonMQTTLogThreadInit(ThreadVars *t, const void *initdata, void *
     }
 
     thread->mqttlog_ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->mqttlog_ctx->file_ctx, t->id);
+    thread->file_ctx = LogFileEnsureExists(thread->mqttlog_ctx->eve_ctx->file_ctx, t->id);
 
     *data = (void *)thread;
 

--- a/src/output-json-mqtt.c
+++ b/src/output-json-mqtt.c
@@ -58,6 +58,7 @@ typedef struct LogMQTTLogThread_ {
     LogMQTTFileCtx *mqttlog_ctx;
     uint32_t        count;
     MemBuffer      *buffer;
+    LogFileCtx *file_ctx;
 } LogMQTTLogThread;
 
 bool JsonMQTTAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
@@ -94,7 +95,7 @@ static int JsonMQTTLogger(ThreadVars *tv, void *thread_data,
         goto error;
 
     MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(js, thread->mqttlog_ctx->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(js, thread->file_ctx, &thread->buffer);
     jb_free(js);
 
     return TM_ECODE_OK;
@@ -174,6 +175,8 @@ static TmEcode JsonMQTTLogThreadInit(ThreadVars *t, const void *initdata, void *
     }
 
     thread->mqttlog_ctx = ((OutputCtx *)initdata)->data;
+    thread->file_ctx = LogFileEnsureExists(thread->mqttlog_ctx->file_ctx, t->id);
+
     *data = (void *)thread;
 
     return TM_ECODE_OK;

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -49,19 +49,6 @@
 
 #include "stream-tcp-private.h"
 
-typedef struct LogJsonFileCtx_ {
-    LogFileCtx *file_ctx;
-    OutputJsonCommonSettings cfg;
-} LogJsonFileCtx;
-
-typedef struct JsonNetFlowLogThread_ {
-    LogFileCtx *file_ctx;
-    LogJsonFileCtx *flowlog_ctx;
-    /** LogFileCtx has the pointer to the file and a mutex to allow multithreading */
-
-    MemBuffer *buffer;
-} JsonNetFlowLogThread;
-
 static JsonBuilder *CreateEveHeaderFromNetFlow(const Flow *f, int dir)
 {
     char timebuf[64];
@@ -187,7 +174,7 @@ static JsonBuilder *CreateEveHeaderFromNetFlow(const Flow *f, int dir)
 }
 
 /* JSON format logging */
-static void NetFlowLogEveToServer(JsonNetFlowLogThread *aft, JsonBuilder *js, Flow *f)
+static void NetFlowLogEveToServer(JsonBuilder *js, Flow *f)
 {
     jb_set_string(js, "app_proto",
             AppProtoToString(f->alproto_ts ? f->alproto_ts : f->alproto));
@@ -231,7 +218,7 @@ static void NetFlowLogEveToServer(JsonNetFlowLogThread *aft, JsonBuilder *js, Fl
     }
 }
 
-static void NetFlowLogEveToClient(JsonNetFlowLogThread *aft, JsonBuilder *js, Flow *f)
+static void NetFlowLogEveToClient(JsonBuilder *js, Flow *f)
 {
     jb_set_string(js, "app_proto",
             AppProtoToString(f->alproto_tc ? f->alproto_tc : f->alproto));
@@ -281,16 +268,15 @@ static void NetFlowLogEveToClient(JsonNetFlowLogThread *aft, JsonBuilder *js, Fl
 static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
 {
     SCEnter();
-    JsonNetFlowLogThread *jhl = (JsonNetFlowLogThread *)thread_data;
-    LogJsonFileCtx *netflow_ctx = jhl->flowlog_ctx;
+    OutputJsonThreadCtx *jhl = thread_data;
 
     /* reset */
     MemBufferReset(jhl->buffer);
     JsonBuilder *jb = CreateEveHeaderFromNetFlow(f, 0);
     if (unlikely(jb == NULL))
         return TM_ECODE_OK;
-    NetFlowLogEveToServer(jhl, jb, f);
-    EveAddCommonOptions(&netflow_ctx->cfg, NULL, f, jb);
+    NetFlowLogEveToServer(jb, f);
+    EveAddCommonOptions(&jhl->ctx->cfg, NULL, f, jb);
     OutputJsonBuilderBuffer(jb, jhl->file_ctx, &jhl->buffer);
     jb_free(jb);
 
@@ -301,101 +287,17 @@ static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
         jb = CreateEveHeaderFromNetFlow(f, 1);
         if (unlikely(jb == NULL))
             return TM_ECODE_OK;
-        NetFlowLogEveToClient(jhl, jb, f);
-        EveAddCommonOptions(&netflow_ctx->cfg, NULL, f, jb);
+        NetFlowLogEveToClient(jb, f);
+        EveAddCommonOptions(&jhl->ctx->cfg, NULL, f, jb);
         OutputJsonBuilderBuffer(jb, jhl->file_ctx, &jhl->buffer);
         jb_free(jb);
     }
     SCReturnInt(TM_ECODE_OK);
 }
 
-static void OutputNetFlowLogDeinitSub(OutputCtx *output_ctx)
-{
-    LogJsonFileCtx *flow_ctx = output_ctx->data;
-    SCFree(flow_ctx);
-    SCFree(output_ctx);
-}
-
-static OutputInitResult OutputNetFlowLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
-{
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ojc = parent_ctx->data;
-
-    LogJsonFileCtx *flow_ctx = SCMalloc(sizeof(LogJsonFileCtx));
-    if (unlikely(flow_ctx == NULL))
-        return result;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
-    if (unlikely(output_ctx == NULL)) {
-        SCFree(flow_ctx);
-        return result;
-    }
-
-    flow_ctx->file_ctx = ojc->file_ctx;
-    flow_ctx->cfg = ojc->cfg;
-
-    output_ctx->data = flow_ctx;
-    output_ctx->DeInit = OutputNetFlowLogDeinitSub;
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
-}
-
-static TmEcode JsonNetFlowLogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    JsonNetFlowLogThread *aft = SCCalloc(1, sizeof(JsonNetFlowLogThread));
-    if (unlikely(aft == NULL))
-        return TM_ECODE_FAILED;
-
-    if(initdata == NULL) {
-        SCLogDebug("Error getting context for EveLogNetflow.  \"initdata\" argument NULL");
-        goto error_exit;
-    }
-
-    /* Use the Ouptut Context (file pointer and mutex) */
-    aft->flowlog_ctx = ((OutputCtx *)initdata)->data; //TODO
-
-    aft->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (aft->buffer == NULL) {
-        goto error_exit;
-    }
-
-    aft->file_ctx = LogFileEnsureExists(aft->flowlog_ctx->file_ctx, t->id);
-    if (!aft->file_ctx) {
-        goto error_exit;
-    }
-
-    *data = (void *)aft;
-    return TM_ECODE_OK;
-
-error_exit:
-    if (aft->buffer != NULL) {
-        MemBufferFree(aft->buffer);
-    }
-    SCFree(aft);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonNetFlowLogThreadDeinit(ThreadVars *t, void *data)
-{
-    JsonNetFlowLogThread *aft = (JsonNetFlowLogThread *)data;
-    if (aft == NULL) {
-        return TM_ECODE_OK;
-    }
-
-    MemBufferFree(aft->buffer);
-    /* clear memory */
-    memset(aft, 0, sizeof(JsonNetFlowLogThread));
-
-    SCFree(aft);
-    return TM_ECODE_OK;
-}
-
 void JsonNetFlowLogRegister(void)
 {
     /* register as child of eve-log */
-    OutputRegisterFlowSubModule(LOGGER_JSON_NETFLOW, "eve-log", "JsonNetFlowLog",
-        "eve-log.netflow", OutputNetFlowLogInitSub, JsonNetFlowLogger,
-        JsonNetFlowLogThreadInit, JsonNetFlowLogThreadDeinit, NULL);
+    OutputRegisterFlowSubModule(LOGGER_JSON_NETFLOW, "eve-log", "JsonNetFlowLog", "eve-log.netflow",
+            OutputJsonLogInitSub, JsonNetFlowLogger, JsonLogThreadInit, JsonLogThreadDeinit, NULL);
 }

--- a/src/output-json-nfs.c
+++ b/src/output-json-nfs.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020 Open Information Security Foundation
+/* Copyright (C) 2015-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -81,11 +81,10 @@ static int JsonNFSLogger(ThreadVars *tv, void *thread_data,
     if (rs_nfs_tx_logging_is_filtered(state, nfstx))
         return TM_ECODE_OK;
 
-    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "nfs", NULL);
+    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "nfs", NULL, thread->ctx);
     if (unlikely(jb == NULL)) {
         return TM_ECODE_OK;
     }
-    EveAddCommonOptions(&thread->ctx->cfg, p, f, jb);
 
     jb_open_object(jb, "rpc");
     rs_rpc_log_json_response(tx, jb);

--- a/src/output-json-rdp.c
+++ b/src/output-json-rdp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019-2020 Open Information Security Foundation
+/* Copyright (C) 2019-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -43,28 +43,15 @@
 #include "output-json-rdp.h"
 #include "rust.h"
 
-typedef struct LogRdpFileCtx_ {
-    LogFileCtx *file_ctx;
-    uint32_t    flags;
-    OutputJsonCommonSettings cfg;
-} LogRdpFileCtx;
-
-typedef struct LogRdpLogThread_ {
-    LogRdpFileCtx *rdplog_ctx;
-    LogFileCtx *file_ctx;
-    MemBuffer       *buffer;
-} LogRdpLogThread;
-
 static int JsonRdpLogger(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
 {
-    LogRdpLogThread *thread = thread_data;
+    OutputJsonThreadCtx *thread = thread_data;
 
-    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "rdp", NULL);
+    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "rdp", NULL, thread->ctx);
     if (unlikely(js == NULL)) {
         return TM_ECODE_OK;
     }
-    EveAddCommonOptions(&thread->rdplog_ctx->cfg, p, f, js);
     if (!rs_rdp_to_json(tx, js)) {
         jb_free(js);
         return TM_ECODE_FAILED;
@@ -76,105 +63,19 @@ static int JsonRdpLogger(ThreadVars *tv, void *thread_data,
     return TM_ECODE_OK;
 }
 
-static void OutputRdpLogDeInitCtxSub(OutputCtx *output_ctx)
-{
-    LogRdpFileCtx *rdplog_ctx = (LogRdpFileCtx *)output_ctx->data;
-    SCFree(rdplog_ctx);
-    SCFree(output_ctx);
-}
-
 static OutputInitResult OutputRdpLogInitSub(ConfNode *conf,
     OutputCtx *parent_ctx)
 {
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ajt = parent_ctx->data;
-
-    LogRdpFileCtx *rdplog_ctx = SCCalloc(1, sizeof(*rdplog_ctx));
-    if (unlikely(rdplog_ctx == NULL)) {
-        return result;
-    }
-    rdplog_ctx->file_ctx = ajt->file_ctx;
-    rdplog_ctx->cfg = ajt->cfg;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
-    if (unlikely(output_ctx == NULL)) {
-        SCFree(rdplog_ctx);
-        return result;
-    }
-    output_ctx->data = rdplog_ctx;
-    output_ctx->DeInit = OutputRdpLogDeInitCtxSub;
-
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_RDP);
-
-    SCLogDebug("rdp log sub-module initialized.");
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
-}
-
-static TmEcode JsonRdpLogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    if (initdata == NULL) {
-        SCLogDebug("Error getting context for EveLogRdp. \"initdata\" is NULL.");
-        return TM_ECODE_FAILED;
-    }
-
-    LogRdpLogThread *thread = SCCalloc(1, sizeof(*thread));
-    if (unlikely(thread == NULL)) {
-        return TM_ECODE_FAILED;
-    }
-
-    thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (unlikely(thread->buffer == NULL)) {
-        goto error_exit;
-    }
-
-    thread->rdplog_ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->rdplog_ctx->file_ctx, t->id);
-    if (!thread->file_ctx) {
-        goto error_exit;
-    }
-
-    *data = (void *)thread;
-    return TM_ECODE_OK;
-
-error_exit:
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonRdpLogThreadDeinit(ThreadVars *t, void *data)
-{
-    LogRdpLogThread *thread = (LogRdpLogThread *)data;
-    if (thread == NULL) {
-        return TM_ECODE_OK;
-    }
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_OK;
+    return OutputJsonLogInitSub(conf, parent_ctx);
 }
 
 void JsonRdpLogRegister(void)
 {
     /* Register as an eve sub-module. */
-    OutputRegisterTxSubModule(
-        LOGGER_JSON_RDP,
-        "eve-log",
-        "JsonRdpLog",
-        "eve-log.rdp",
-        OutputRdpLogInitSub,
-        ALPROTO_RDP,
-        JsonRdpLogger,
-        JsonRdpLogThreadInit,
-        JsonRdpLogThreadDeinit,
-        NULL
-    );
+    OutputRegisterTxSubModule(LOGGER_JSON_RDP, "eve-log", "JsonRdpLog", "eve-log.rdp",
+            OutputRdpLogInitSub, ALPROTO_RDP, JsonRdpLogger, JsonLogThreadInit, JsonLogThreadDeinit,
+            NULL);
 
     SCLogDebug("rdp json logger registered.");
 }

--- a/src/output-json-smb.c
+++ b/src/output-json-smb.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2020 Open Information Security Foundation
+/* Copyright (C) 2017-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -64,7 +64,7 @@ static int JsonSMBLogger(ThreadVars *tv, void *thread_data,
 {
     OutputJsonThreadCtx *thread = thread_data;
 
-    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "smb", NULL);
+    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "smb", NULL, thread->ctx);
     if (unlikely(jb == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -76,10 +76,10 @@ static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     SCEnter();
     JsonEmailLogThread *jhl = (JsonEmailLogThread *)thread_data;
 
-    JsonBuilder *jb = CreateEveHeaderWithTxId(p, LOG_DIR_FLOW, "smtp", NULL, tx_id);
+    JsonBuilder *jb = CreateEveHeaderWithTxId(
+            p, LOG_DIR_FLOW, "smtp", NULL, tx_id, jhl->emaillog_ctx->eve_ctx);
     if (unlikely(jb == NULL))
         return TM_ECODE_OK;
-    EveAddCommonOptions(&jhl->emaillog_ctx->cfg, p, f, jb);
 
     /* reset */
     MemBufferReset(jhl->buffer);
@@ -137,8 +137,7 @@ static OutputInitResult OutputSmtpLogInitSub(ConfNode *conf, OutputCtx *parent_c
         return result;
     }
 
-    email_ctx->file_ctx = ojc->file_ctx;
-    email_ctx->cfg = ojc->cfg;
+    email_ctx->eve_ctx = ojc;
 
     OutputEmailInitConf(conf, email_ctx);
 
@@ -172,7 +171,7 @@ static TmEcode JsonSmtpLogThreadInit(ThreadVars *t, const void *initdata, void *
         goto error_exit;
     }
 
-    aft->file_ctx = LogFileEnsureExists(aft->emaillog_ctx->file_ctx, t->id);
+    aft->file_ctx = LogFileEnsureExists(aft->emaillog_ctx->eve_ctx->file_ctx, t->id);
     if (!aft->file_ctx) {
         goto error_exit;
     }

--- a/src/output-json-snmp.c
+++ b/src/output-json-snmp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2020 Open Information Security Foundation
+/* Copyright (C) 2018-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -49,29 +49,16 @@
 
 #include "rust.h"
 
-typedef struct LogSNMPFileCtx_ {
-    LogFileCtx *file_ctx;
-    OutputJsonCommonSettings cfg;
-} LogSNMPFileCtx;
-
-typedef struct LogSNMPLogThread_ {
-    LogFileCtx *file_ctx;
-    LogSNMPFileCtx *snmplog_ctx;
-    MemBuffer          *buffer;
-} LogSNMPLogThread;
-
 static int JsonSNMPLogger(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
 {
     SNMPTransaction *snmptx = tx;
-    LogSNMPLogThread *thread = thread_data;
+    OutputJsonThreadCtx *thread = thread_data;
 
-    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "snmp", NULL);
+    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "snmp", NULL, thread->ctx);
     if (unlikely(jb == NULL)) {
         return TM_ECODE_FAILED;
     }
-
-    EveAddCommonOptions(&thread->snmplog_ctx->cfg, p, f, jb);
 
     jb_open_object(jb, "snmp");
     if (!rs_snmp_log_json_response(jb, state, snmptx)) {
@@ -90,98 +77,19 @@ error:
     return TM_ECODE_FAILED;
 }
 
-static void OutputSNMPLogDeInitCtxSub(OutputCtx *output_ctx)
-{
-    LogSNMPFileCtx *snmplog_ctx = (LogSNMPFileCtx *)output_ctx->data;
-    SCFree(snmplog_ctx);
-    SCFree(output_ctx);
-}
-
 static OutputInitResult OutputSNMPLogInitSub(ConfNode *conf,
     OutputCtx *parent_ctx)
 {
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ajt = parent_ctx->data;
-
-    LogSNMPFileCtx *snmplog_ctx = SCCalloc(1, sizeof(*snmplog_ctx));
-    if (unlikely(snmplog_ctx == NULL)) {
-        return result;
-    }
-    snmplog_ctx->file_ctx = ajt->file_ctx;
-    snmplog_ctx->cfg = ajt->cfg;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
-    if (unlikely(output_ctx == NULL)) {
-        SCFree(snmplog_ctx);
-        return result;
-    }
-    output_ctx->data = snmplog_ctx;
-    output_ctx->DeInit = OutputSNMPLogDeInitCtxSub;
-
-    SCLogDebug("SNMP log sub-module initialized.");
-
     AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_SNMP);
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
-}
-
-static TmEcode JsonSNMPLogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    LogSNMPLogThread *thread = SCCalloc(1, sizeof(*thread));
-    if (unlikely(thread == NULL)) {
-        return TM_ECODE_FAILED;
-    }
-
-    if (initdata == NULL) {
-        SCLogDebug("Error getting context for EveLogSNMP.  \"initdata\" is NULL.");
-        goto error_exit;
-    }
-
-    thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (unlikely(thread->buffer == NULL)) {
-        goto error_exit;
-    }
-
-    thread->snmplog_ctx = ((OutputCtx *)initdata)->data;
-
-    thread->file_ctx = LogFileEnsureExists(thread->snmplog_ctx->file_ctx, t->id);
-    if (!thread->file_ctx) {
-        goto error_exit;
-    }
-
-    *data = (void *)thread;
-    return TM_ECODE_OK;
-
-error_exit:
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonSNMPLogThreadDeinit(ThreadVars *t, void *data)
-{
-    LogSNMPLogThread *thread = (LogSNMPLogThread *)data;
-    if (thread == NULL) {
-        return TM_ECODE_OK;
-    }
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_OK;
+    return OutputJsonLogInitSub(conf, parent_ctx);
 }
 
 void JsonSNMPLogRegister(void)
 {
     /* Register as an eve sub-module. */
-    OutputRegisterTxSubModule(LOGGER_JSON_SNMP, "eve-log", "JsonSNMPLog",
-        "eve-log.snmp", OutputSNMPLogInitSub, ALPROTO_SNMP,
-        JsonSNMPLogger, JsonSNMPLogThreadInit,
-        JsonSNMPLogThreadDeinit, NULL);
+    OutputRegisterTxSubModule(LOGGER_JSON_SNMP, "eve-log", "JsonSNMPLog", "eve-log.snmp",
+            OutputSNMPLogInitSub, ALPROTO_SNMP, JsonSNMPLogger, JsonLogThreadInit,
+            JsonLogThreadDeinit, NULL);
 
     SCLogDebug("SNMP JSON logger registered.");
 }

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -62,11 +62,9 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         return 0;
     }
 
-    JsonBuilder *js = CreateEveHeaderWithTxId(p, LOG_DIR_FLOW, "ssh", NULL, tx_id);
+    JsonBuilder *js = CreateEveHeaderWithTxId(p, LOG_DIR_FLOW, "ssh", NULL, tx_id, thread->ctx);
     if (unlikely(js == NULL))
         return 0;
-
-    EveAddCommonOptions(&thread->ctx->cfg, p, f, js);
 
     /* reset */
     MemBufferReset(thread->buffer);

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014-2020 Open Information Security Foundation
+/* Copyright (C) 2014-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -53,24 +53,10 @@
 
 #define MODULE_NAME "LogSshLog"
 
-typedef struct OutputSshCtx_ {
-    LogFileCtx *file_ctx;
-    OutputJsonCommonSettings cfg;
-} OutputSshCtx;
-
-
-typedef struct JsonSshLogThread_ {
-    OutputSshCtx *sshlog_ctx;
-    LogFileCtx *file_ctx;
-    MemBuffer *buffer;
-} JsonSshLogThread;
-
-
 static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
                          Flow *f, void *state, void *txptr, uint64_t tx_id)
 {
-    JsonSshLogThread *aft = (JsonSshLogThread *)thread_data;
-    OutputSshCtx *ssh_ctx = aft->sshlog_ctx;
+    OutputJsonThreadCtx *thread = thread_data;
 
     if (unlikely(state == NULL)) {
         return 0;
@@ -80,113 +66,33 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
     if (unlikely(js == NULL))
         return 0;
 
-    EveAddCommonOptions(&ssh_ctx->cfg, p, f, js);
+    EveAddCommonOptions(&thread->ctx->cfg, p, f, js);
 
     /* reset */
-    MemBufferReset(aft->buffer);
+    MemBufferReset(thread->buffer);
 
     jb_open_object(js, "ssh");
     if (!rs_ssh_log_json(txptr, js)) {
         goto end;
     }
     jb_close(js);
-    OutputJsonBuilderBuffer(js, aft->file_ctx, &aft->buffer);
+    OutputJsonBuilderBuffer(js, thread->file_ctx, &thread->buffer);
 
 end:
     jb_free(js);
     return 0;
 }
 
-static TmEcode JsonSshLogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    if (initdata == NULL) {
-        SCLogDebug("Error getting context for EveLogSSH.  \"initdata\" argument NULL");
-        return TM_ECODE_FAILED;
-    }
-
-    JsonSshLogThread *aft = SCCalloc(1, sizeof(JsonSshLogThread));
-    if (unlikely(aft == NULL))
-        return TM_ECODE_FAILED;
-
-    /* Use the Output Context (file pointer and mutex) */
-    aft->sshlog_ctx = ((OutputCtx *)initdata)->data;
-
-    aft->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (aft->buffer == NULL) {
-        goto error_exit;
-    }
-
-    aft->file_ctx = LogFileEnsureExists(aft->sshlog_ctx->file_ctx, t->id);
-    if (!aft->file_ctx) {
-        goto error_exit;
-    }
-
-    *data = (void *)aft;
-    return TM_ECODE_OK;
-
-error_exit:
-    if (aft->buffer != NULL) {
-        MemBufferFree(aft->buffer);
-    }
-    SCFree(aft);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonSshLogThreadDeinit(ThreadVars *t, void *data)
-{
-    JsonSshLogThread *aft = (JsonSshLogThread *)data;
-    if (aft == NULL) {
-        return TM_ECODE_OK;
-    }
-
-    MemBufferFree(aft->buffer);
-    /* clear memory */
-    memset(aft, 0, sizeof(JsonSshLogThread));
-
-    SCFree(aft);
-    return TM_ECODE_OK;
-}
-
-static void OutputSshLogDeinitSub(OutputCtx *output_ctx)
-{
-    OutputSshCtx *ssh_ctx = output_ctx->data;
-    SCFree(ssh_ctx);
-    SCFree(output_ctx);
-}
-
 static OutputInitResult OutputSshLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ojc = parent_ctx->data;
-
-    OutputSshCtx *ssh_ctx = SCMalloc(sizeof(OutputSshCtx));
-    if (unlikely(ssh_ctx == NULL))
-        return result;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
-    if (unlikely(output_ctx == NULL)) {
-        SCFree(ssh_ctx);
-        return result;
-    }
-
-    ssh_ctx->file_ctx = ojc->file_ctx;
-    ssh_ctx->cfg = ojc->cfg;
-
-    output_ctx->data = ssh_ctx;
-    output_ctx->DeInit = OutputSshLogDeinitSub;
-
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_SSH);
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
+    return OutputJsonLogInitSub(conf, parent_ctx);
 }
 
 void JsonSshLogRegister (void)
 {
     /* register as child of eve-log */
-    OutputRegisterTxSubModuleWithCondition(LOGGER_JSON_SSH,
-        "eve-log", "JsonSshLog", "eve-log.ssh",
-        OutputSshLogInitSub, ALPROTO_SSH, JsonSshLogger,
-        SSHTxLogCondition, JsonSshLogThreadInit, JsonSshLogThreadDeinit, NULL);
+    OutputRegisterTxSubModuleWithCondition(LOGGER_JSON_SSH, "eve-log", "JsonSshLog", "eve-log.ssh",
+            OutputSshLogInitSub, ALPROTO_SSH, JsonSshLogger, SSHTxLogCondition, JsonLogThreadInit,
+            JsonLogThreadDeinit, NULL);
 }

--- a/src/output-json-tftp.c
+++ b/src/output-json-tftp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -50,24 +50,12 @@
 
 #include "rust.h"
 
-typedef struct LogTFTPFileCtx_ {
-    LogFileCtx *file_ctx;
-    uint32_t    flags;
-    OutputJsonCommonSettings cfg;
-} LogTFTPFileCtx;
-
-typedef struct LogTFTPLogThread_ {
-    LogFileCtx *file_ctx;
-    LogTFTPFileCtx *tftplog_ctx;
-    MemBuffer          *buffer;
-} LogTFTPLogThread;
-
 static int JsonTFTPLogger(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
 {
-    LogTFTPLogThread *thread = thread_data;
+    OutputJsonThreadCtx *thread = thread_data;
 
-    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "tftp", NULL);
+    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "tftp", NULL, thread->ctx);
     if (unlikely(jb == NULL)) {
         return TM_ECODE_FAILED;
     }
@@ -78,7 +66,6 @@ static int JsonTFTPLogger(ThreadVars *tv, void *thread_data,
     }
     jb_close(jb);
 
-    EveAddCommonOptions(&thread->tftplog_ctx->cfg, p, f, jb);
     MemBufferReset(thread->buffer);
     OutputJsonBuilderBuffer(jb, thread->file_ctx, &thread->buffer);
 
@@ -90,98 +77,19 @@ error:
     return TM_ECODE_FAILED;
 }
 
-static void OutputTFTPLogDeInitCtxSub(OutputCtx *output_ctx)
-{
-    LogTFTPFileCtx *tftplog_ctx = (LogTFTPFileCtx *)output_ctx->data;
-    SCFree(tftplog_ctx);
-    SCFree(output_ctx);
-}
-
 static OutputInitResult OutputTFTPLogInitSub(ConfNode *conf,
     OutputCtx *parent_ctx)
 {
-    OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ajt = parent_ctx->data;
-
-    LogTFTPFileCtx *tftplog_ctx = SCCalloc(1, sizeof(*tftplog_ctx));
-    if (unlikely(tftplog_ctx == NULL)) {
-        return result;
-    }
-    tftplog_ctx->file_ctx = ajt->file_ctx;
-    tftplog_ctx->cfg = ajt->cfg;
-
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
-    if (unlikely(output_ctx == NULL)) {
-        SCFree(tftplog_ctx);
-        return result;
-    }
-    output_ctx->data = tftplog_ctx;
-    output_ctx->DeInit = OutputTFTPLogDeInitCtxSub;
-
-    SCLogDebug("TFTP log sub-module initialized.");
-
     AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_TFTP);
-
-    result.ctx = output_ctx;
-    result.ok = true;
-    return result;
-}
-
-static TmEcode JsonTFTPLogThreadInit(ThreadVars *t, const void *initdata, void **data)
-{
-    LogTFTPLogThread *thread = SCCalloc(1, sizeof(*thread));
-    if (unlikely(thread == NULL)) {
-        return TM_ECODE_FAILED;
-    }
-
-    if (initdata == NULL) {
-        SCLogDebug("Error getting context for EveLogTFTP.  \"initdata\" is NULL.");
-        goto error_exit;
-    }
-
-    thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (unlikely(thread->buffer == NULL)) {
-        goto error_exit;
-    }
-
-    thread->tftplog_ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->tftplog_ctx->file_ctx, t->id);
-    if (!thread->file_ctx) {
-        goto error_exit;
-    }
-    *data = (void *)thread;
-
-    return TM_ECODE_OK;
-
-error_exit:
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_FAILED;
-}
-
-static TmEcode JsonTFTPLogThreadDeinit(ThreadVars *t, void *data)
-{
-    LogTFTPLogThread *thread = (LogTFTPLogThread *)data;
-    if (thread == NULL) {
-        return TM_ECODE_OK;
-    }
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
-    return TM_ECODE_OK;
+    return OutputJsonLogInitSub(conf, parent_ctx);
 }
 
 void JsonTFTPLogRegister(void)
 {
     /* Register as an eve sub-module. */
-    OutputRegisterTxSubModule(LOGGER_JSON_TFTP, "eve-log", "JsonTFTPLog",
-                              "eve-log.tftp", OutputTFTPLogInitSub,
-                              ALPROTO_TFTP, JsonTFTPLogger,
-                              JsonTFTPLogThreadInit, JsonTFTPLogThreadDeinit,
-                              NULL);
+    OutputRegisterTxSubModule(LOGGER_JSON_TFTP, "eve-log", "JsonTFTPLog", "eve-log.tftp",
+            OutputTFTPLogInitSub, ALPROTO_TFTP, JsonTFTPLogger, JsonLogThreadInit,
+            JsonLogThreadDeinit, NULL);
 
     SCLogDebug("TFTP JSON logger registered.");
 }

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -98,10 +98,9 @@ TlsFields tls_fields[] = {
 };
 
 typedef struct OutputTlsCtx_ {
-    LogFileCtx *file_ctx;
     uint32_t flags;  /** Store mode */
     uint64_t fields; /** Store fields */
-    OutputJsonCommonSettings cfg;
+    OutputJsonCtx *eve_ctx;
 } OutputTlsCtx;
 
 
@@ -414,12 +413,10 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         return 0;
     }
 
-    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_FLOW, "tls", NULL);
+    JsonBuilder *js = CreateEveHeader(p, LOG_DIR_FLOW, "tls", NULL, aft->tlslog_ctx->eve_ctx);
     if (unlikely(js == NULL)) {
         return 0;
     }
-
-    EveAddCommonOptions(&tls_ctx->cfg, p, f, js);
 
     jb_open_object(js, "tls");
 
@@ -475,7 +472,7 @@ static TmEcode JsonTlsLogThreadInit(ThreadVars *t, const void *initdata, void **
     /* use the Output Context (file pointer and mutex) */
     aft->tlslog_ctx = ((OutputCtx *)initdata)->data;
 
-    aft->file_ctx = LogFileEnsureExists(aft->tlslog_ctx->file_ctx, t->id);
+    aft->file_ctx = LogFileEnsureExists(aft->tlslog_ctx->eve_ctx->file_ctx, t->id);
     if (!aft->file_ctx) {
         goto error_exit;
     }
@@ -586,8 +583,7 @@ static OutputInitResult OutputTlsLogInitSub(ConfNode *conf, OutputCtx *parent_ct
         return result;
     }
 
-    tls_ctx->file_ctx = ojc->file_ctx;
-    tls_ctx->cfg = ojc->cfg;
+    tls_ctx->eve_ctx = ojc;
 
     if ((tls_ctx->fields & LOG_TLS_FIELD_CERTIFICATE) &&
             (tls_ctx->fields & LOG_TLS_FIELD_CHAIN)) {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -398,7 +398,7 @@ static void EveAddFlowVars(const Flow *f, JsonBuilder *js_root, JsonBuilder **js
     }
 }
 
-static void EveAddMetadata(const Packet *p, const Flow *f, JsonBuilder *js)
+void EveAddMetadata(const Packet *p, const Flow *f, JsonBuilder *js)
 {
     if ((p && p->pktvar) || (f && f->flowvar)) {
         JsonBuilder *js_vars = jb_new_object();
@@ -836,7 +836,7 @@ int CreateJSONEther(JsonBuilder *js, const Packet *p, const Flow *f)
 }
 
 JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
-        const char *event_type, JsonAddrInfo *addr)
+        const char *event_type, JsonAddrInfo *addr, OutputJsonCtx *eve_ctx)
 {
     char timebuf[64];
     const Flow *f = (const Flow *)p->flow;
@@ -909,13 +909,17 @@ JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
             break;
     }
 
+    if (eve_ctx != NULL) {
+        EveAddCommonOptions(&eve_ctx->cfg, p, f, js);
+    }
+
     return js;
 }
 
 JsonBuilder *CreateEveHeaderWithTxId(const Packet *p, enum OutputJsonLogDirection dir,
                                  const char *event_type, JsonAddrInfo *addr, uint64_t tx_id)
 {
-    JsonBuilder *js = CreateEveHeader(p, dir, event_type, addr);
+    JsonBuilder *js = CreateEveHeader(p, dir, event_type, addr, NULL);
     if (unlikely(js == NULL))
         return NULL;
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -917,9 +917,9 @@ JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
 }
 
 JsonBuilder *CreateEveHeaderWithTxId(const Packet *p, enum OutputJsonLogDirection dir,
-                                 const char *event_type, JsonAddrInfo *addr, uint64_t tx_id)
+        const char *event_type, JsonAddrInfo *addr, uint64_t tx_id, OutputJsonCtx *eve_ctx)
 {
-    JsonBuilder *js = CreateEveHeader(p, dir, event_type, addr, NULL);
+    JsonBuilder *js = CreateEveHeader(p, dir, event_type, addr, eve_ctx);
     if (unlikely(js == NULL))
         return NULL;
 

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -101,7 +101,7 @@ void EvePacket(const Packet *p, JsonBuilder *js, unsigned long max_length);
 JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
         const char *event_type, JsonAddrInfo *addr, OutputJsonCtx *eve_ctx);
 JsonBuilder *CreateEveHeaderWithTxId(const Packet *p, enum OutputJsonLogDirection dir,
-        const char *event_type, JsonAddrInfo *addr, uint64_t tx_id);
+        const char *event_type, JsonAddrInfo *addr, uint64_t tx_id, OutputJsonCtx *eve_ctx);
 int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer);
 int OutputJsonBuilderBuffer(JsonBuilder *js, LogFileCtx *file_ctx, MemBuffer **buffer);
 OutputInitResult OutputJsonInitCtx(ConfNode *);

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -68,26 +68,6 @@ typedef struct OutputJSONMemBufferWrapper_ {
     size_t expand_by;   /**< expand by this size */
 } OutputJSONMemBufferWrapper;
 
-int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
-
-void CreateEveFlowId(JsonBuilder *js, const Flow *f);
-void EveFileInfo(JsonBuilder *js, const File *file, const bool stored);
-void EveTcpFlags(uint8_t flags, JsonBuilder *js);
-void EvePacket(const Packet *p, JsonBuilder *js, unsigned long max_length);
-JsonBuilder *CreateEveHeader(const Packet *p,
-        enum OutputJsonLogDirection dir, const char *event_type,
-        JsonAddrInfo *addr);
-JsonBuilder *CreateEveHeaderWithTxId(const Packet *p,
-        enum OutputJsonLogDirection dir, const char *event_type, JsonAddrInfo *addr,
-        uint64_t tx_id);
-int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer);
-int OutputJsonBuilderBuffer(JsonBuilder *js, LogFileCtx *file_ctx, MemBuffer **buffer);
-OutputInitResult OutputJsonInitCtx(ConfNode *);
-
-OutputInitResult OutputJsonLogInitSub(ConfNode *conf, OutputCtx *parent_ctx);
-TmEcode JsonLogThreadInit(ThreadVars *t, const void *initdata, void **data);
-TmEcode JsonLogThreadDeinit(ThreadVars *t, void *data);
-
 typedef struct OutputJsonCommonSettings_ {
     bool include_metadata;
     bool include_community_id;
@@ -114,7 +94,26 @@ typedef struct OutputJsonThreadCtx_ {
 
 json_t *SCJsonString(const char *val);
 
+void CreateEveFlowId(JsonBuilder *js, const Flow *f);
+void EveFileInfo(JsonBuilder *js, const File *file, const bool stored);
+void EveTcpFlags(uint8_t flags, JsonBuilder *js);
+void EvePacket(const Packet *p, JsonBuilder *js, unsigned long max_length);
+JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
+        const char *event_type, JsonAddrInfo *addr, OutputJsonCtx *eve_ctx);
+JsonBuilder *CreateEveHeaderWithTxId(const Packet *p, enum OutputJsonLogDirection dir,
+        const char *event_type, JsonAddrInfo *addr, uint64_t tx_id);
+int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer);
+int OutputJsonBuilderBuffer(JsonBuilder *js, LogFileCtx *file_ctx, MemBuffer **buffer);
+OutputInitResult OutputJsonInitCtx(ConfNode *);
+
+OutputInitResult OutputJsonLogInitSub(ConfNode *conf, OutputCtx *parent_ctx);
+TmEcode JsonLogThreadInit(ThreadVars *t, const void *initdata, void **data);
+TmEcode JsonLogThreadDeinit(ThreadVars *t, void *data);
+
 void EveAddCommonOptions(const OutputJsonCommonSettings *cfg,
         const Packet *p, const Flow *f, JsonBuilder *js);
+void EveAddMetadata(const Packet *p, const Flow *f, JsonBuilder *js);
+
+int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
 
 #endif /* __OUTPUT_JSON_H__ */


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/6001

Changes from last PR:
- Cleanup loggers that used CreateEveHeaderWithTxId.

I think the next step is create a configuration callback so each eve sub-logger can parse its config, but still use the generic initialization code for file handling.  And perhaps something similar around the buffer reset, and JSON rendering.

suricata-verify-pr: 483
