### PR TITLE
proflite: new light weigth packet profiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -538,6 +538,13 @@
     esac
     ])
 
+  # profiling support, lite
+    AC_ARG_ENABLE(profiling-lite,
+           AS_HELP_STRING([--enable-profiling-lite], [Enable performance profiling (lite)]),[enable_profiling_lite=$enableval],[enable_profiling_lite=no])
+    AS_IF([test "x$enable_profiling_lite" = "xyes"], [
+        AC_DEFINE([PROFILING_LITE],[1],[Enable performance profiling lite])
+    ])
+
   # profiling support, locking
     AC_ARG_ENABLE(profiling-locks,
            AS_HELP_STRING([--enable-profiling-locks], [Enable performance profiling for locks]),[enable_profiling_locks=$enableval],[enable_profiling_locks=no])
@@ -2750,6 +2757,7 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   Install suricata-update:                 ${install_suricata_update}${install_suricata_update_reason}
 
   Profiling enabled:                       ${enable_profiling}
+  Profiling (lite) enabled:                ${enable_profiling_lite}
   Profiling locks enabled:                 ${enable_profiling_locks}
 
   Plugin support (experimental):           ${plugin_support}

--- a/python/suricata/sc/specs.py
+++ b/python/suricata/sc/specs.py
@@ -194,4 +194,28 @@ argsd = {
             "required": 1,
         },
     ],
+    "profile-feature-enable": [
+        {
+            "name": "setting",
+            "required": 1,
+        },
+    ],
+    "profile-feature-disable": [
+        {
+            "name": "setting",
+            "required": 1,
+        },
+    ],
+    "profile-tracepoint-entry": [
+        {
+            "name": "setting",
+            "required": 1,
+        },
+    ],
+    "profile-tracepoint-exit": [
+        {
+            "name": "setting",
+            "required": 1,
+        },
+    ],
     }

--- a/python/suricata/sc/suricatasc.py
+++ b/python/suricata/sc/suricatasc.py
@@ -107,6 +107,10 @@ class SuricataSC:
                 "memcap-show",
                 "dataset-add",
                 "dataset-remove",
+                "profile-feature-enable",
+                "profile-feature-disable",
+                "profile-tracepoint-entry",
+                "profile-tracepoint-exit",
                 ]
         self.cmd_list = self.basic_commands + self.fn_commands
         self.sck_path = sck_path

--- a/src/decode.h
+++ b/src/decode.h
@@ -618,6 +618,10 @@ typedef struct Packet_
 #ifdef PROFILING
     PktProfiling *profile;
 #endif
+#ifdef PROFILING_LITE
+    AppProto proflite_alproto;
+    struct timeval proflite_startts;
+#endif
 #ifdef HAVE_NAPATECH
     NapatechPacketVars ntpv;
 #endif

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -127,6 +127,7 @@ void DetectFiledataRegister(void)
             DetectEngineInspectFiledata, NULL);
     DetectBufferTypeRegisterSetupCallback("file_data",
             DetectFiledataSetupCallback);
+
     DetectAppLayerInspectEngineRegister2("file_data",
             ALPROTO_SMB, SIG_FLAG_TOSERVER, 0,
             DetectEngineInspectFiledata, NULL);

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -360,9 +360,11 @@ static void FlowPruneFiles(Packet *p)
 static inline void FlowWorkerStreamTCPUpdate(ThreadVars *tv, FlowWorkerThreadData *fw,
         Packet *p, void *detect_thread)
 {
+    PACKET_PROFLITE_TRACEPOINT(tv, p, PROFLITE_TP_FLOWWORKER_APPLAYER_START);
     FLOWWORKER_PROFILING_START(p, PROFILE_FLOWWORKER_STREAM);
     StreamTcp(tv, p, fw->stream_thread, &fw->pq);
     FLOWWORKER_PROFILING_END(p, PROFILE_FLOWWORKER_STREAM);
+    PACKET_PROFLITE_TRACEPOINT(tv, p, PROFLITE_TP_FLOWWORKER_APPLAYER_END);
 
     if (FlowChangeProto(p->flow)) {
         StreamTcpDetectLogFlush(tv, fw->stream_thread, p->flow, p, &fw->pq);
@@ -469,6 +471,8 @@ static inline void FlowWorkerProcessLocalFlows(ThreadVars *tv,
 
 static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
 {
+    PACKET_PROFLITE_TRACEPOINT(tv, p, PROFLITE_TP_FLOWWORKER_ENTER);
+
     FlowWorkerThreadData *fw = data;
     void *detect_thread = SC_ATOMIC_GET(fw->detect_thread);
 
@@ -491,6 +495,7 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
             DEBUG_ASSERT_FLOW_LOCKED(p->flow);
             if (FlowUpdate(tv, fw, p) == TM_ECODE_DONE) {
                 FLOWLOCK_UNLOCK(p->flow);
+                PACKET_PROFLITE_TRACEPOINT(tv, p, PROFLITE_TP_FLOWWORKER_EXIT);
                 return TM_ECODE_OK;
             }
         }
@@ -525,9 +530,11 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
 
     /* handle the app layer part of the UDP packet payload */
     } else if (p->flow && p->proto == IPPROTO_UDP) {
+        PACKET_PROFLITE_TRACEPOINT(tv, p, PROFLITE_TP_FLOWWORKER_APPLAYER_START);
         FLOWWORKER_PROFILING_START(p, PROFILE_FLOWWORKER_APPLAYERUDP);
         AppLayerHandleUdp(tv, fw->stream_thread->ra_ctx->app_tctx, p, p->flow);
         FLOWWORKER_PROFILING_END(p, PROFILE_FLOWWORKER_APPLAYERUDP);
+        PACKET_PROFLITE_TRACEPOINT(tv, p, PROFLITE_TP_FLOWWORKER_APPLAYER_END);
     }
 
     PacketUpdateEngineEventCounters(tv, fw->dtv, p);
@@ -536,13 +543,17 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
     DEBUG_ASSERT_FLOW_LOCKED(p->flow);
     SCLogDebug("packet %"PRIu64" calling Detect", p->pcap_cnt);
     if (detect_thread != NULL) {
+        PACKET_PROFLITE_TRACEPOINT(tv, p, PROFLITE_TP_FLOWWORKER_DETECT_START);
         FLOWWORKER_PROFILING_START(p, PROFILE_FLOWWORKER_DETECT);
         Detect(tv, p, detect_thread);
         FLOWWORKER_PROFILING_END(p, PROFILE_FLOWWORKER_DETECT);
+        PACKET_PROFLITE_TRACEPOINT(tv, p, PROFLITE_TP_FLOWWORKER_DETECT_END);
     }
 
     // Outputs.
+    PACKET_PROFLITE_TRACEPOINT(tv, p, PROFLITE_TP_FLOWWORKER_OUTPUT_START);
     OutputLoggerLog(tv, p, fw->output_thread);
+    PACKET_PROFLITE_TRACEPOINT(tv, p, PROFLITE_TP_FLOWWORKER_OUTPUT_END);
 
     /* Prune any stored files. */
     FlowPruneFiles(p);
@@ -561,10 +572,16 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
         /* run tx cleanup last */
         AppLayerParserTransactionsCleanup(p->flow);
 
+#ifdef PROFILING_LITE
+        if (p->flags & PKT_PROFILE)
+            p->proflite_alproto = p->flow->alproto;
+#endif
         Flow *f = p->flow;
         FlowDeReference(&p->flow);
         FLOWLOCK_UNLOCK(f);
     }
+
+    PACKET_PROFLITE_TRACEPOINT(tv, p, PROFLITE_TP_FLOWWORKER_PRE_INJECT);
 
     /* take injected flows and process them */
     FlowWorkerProcessInjectedFlows(tv, fw, p, detect_thread);
@@ -572,6 +589,7 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
     /* process local work queue */
     FlowWorkerProcessLocalFlows(tv, fw, p, detect_thread);
 
+    PACKET_PROFLITE_TRACEPOINT(tv, p, PROFLITE_TP_FLOWWORKER_EXIT);
     return TM_ECODE_OK;
 }
 

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -1523,6 +1523,97 @@ TmEcode UnixSocketShowAllMemcap(json_t *cmd, json_t *answer, void *data)
     json_object_set_new(answer, "message", jmemcaps);
     SCReturnInt(TM_ECODE_OK);
 }
+
+#ifdef PROFILING_LITE
+void ProfliteEnable(const char *setting);
+void ProfliteDisable(const char *setting);
+void ProfliteSetTpEntry(const char *setting);
+void ProfliteSetTpExit(const char *setting);
+
+static void HandleProfile(const char *setting, bool enable)
+{
+    if (enable)
+        ProfliteEnable(setting);
+    else
+        ProfliteDisable(setting);
+}
+#endif
+
+TmEcode UnixSocketProfileEnable(json_t *cmd, json_t *answer, void *data)
+{
+#ifndef PROFILING_LITE
+    json_object_set_new(answer, "message",
+            json_string("profiling not compiled it: recompile with --enable-profiling-lite"));
+    return TM_ECODE_FAILED;
+#else
+    json_t *narg = json_object_get(cmd, "setting");
+    if (!json_is_string(narg)) {
+        json_object_set_new(answer, "message", json_string("setting is not a string"));
+        return TM_ECODE_FAILED;
+    }
+    const char *setting = json_string_value(narg);
+    HandleProfile(setting, true);
+    SCLogNotice("enabled %s", setting);
+    SCReturnInt(TM_ECODE_OK);
+#endif
+}
+
+TmEcode UnixSocketProfileDisable(json_t *cmd, json_t *answer, void *data)
+{
+#ifndef PROFILING_LITE
+    json_object_set_new(answer, "message",
+            json_string("profiling not compiled it: recompile with --enable-profiling-lite"));
+    return TM_ECODE_FAILED;
+#else
+    json_t *narg = json_object_get(cmd, "setting");
+    if (!json_is_string(narg)) {
+        json_object_set_new(answer, "message", json_string("setting is not a string"));
+        return TM_ECODE_FAILED;
+    }
+    const char *setting = json_string_value(narg);
+    HandleProfile(setting, false);
+    SCLogNotice("disabled %s", setting);
+    SCReturnInt(TM_ECODE_OK);
+#endif
+}
+
+TmEcode UnixSocketProfileTpEntry(json_t *cmd, json_t *answer, void *data)
+{
+#ifndef PROFILING_LITE
+    json_object_set_new(answer, "message",
+            json_string("profiling not compiled it: recompile with --enable-profiling-lite"));
+    return TM_ECODE_FAILED;
+#else
+    json_t *narg = json_object_get(cmd, "setting");
+    if (!json_is_string(narg)) {
+        json_object_set_new(answer, "message", json_string("setting is not a string"));
+        return TM_ECODE_FAILED;
+    }
+    const char *setting = json_string_value(narg);
+    ProfliteSetTpEntry(setting);
+    SCLogNotice("set entry tracepoint %s", setting);
+    SCReturnInt(TM_ECODE_OK);
+#endif
+}
+
+TmEcode UnixSocketProfileTpExit(json_t *cmd, json_t *answer, void *data)
+{
+#ifndef PROFILING_LITE
+    json_object_set_new(answer, "message",
+            json_string("profiling not compiled it: recompile with --enable-profiling-lite"));
+    return TM_ECODE_FAILED;
+#else
+    json_t *narg = json_object_get(cmd, "setting");
+    if (!json_is_string(narg)) {
+        json_object_set_new(answer, "message", json_string("setting is not a string"));
+        return TM_ECODE_FAILED;
+    }
+    const char *setting = json_string_value(narg);
+    ProfliteSetTpExit(setting);
+    SCLogNotice("set exit tracepoint %s", setting);
+    SCReturnInt(TM_ECODE_OK);
+#endif
+}
 #endif /* BUILD_UNIX_SOCKET */
 
 #ifdef BUILD_UNIX_SOCKET

--- a/src/runmode-unix-socket.h
+++ b/src/runmode-unix-socket.h
@@ -44,6 +44,10 @@ TmEcode UnixSocketHostbitList(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketSetMemcap(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketShowMemcap(json_t *cmd, json_t *answer, void *data);
 TmEcode UnixSocketShowAllMemcap(json_t *cmd, json_t *answer, void *data);
+TmEcode UnixSocketProfileEnable(json_t *cmd, json_t *answer, void *data);
+TmEcode UnixSocketProfileDisable(json_t *cmd, json_t *answer, void *data);
+TmEcode UnixSocketProfileTpEntry(json_t *cmd, json_t *answer, void *data);
+TmEcode UnixSocketProfileTpExit(json_t *cmd, json_t *answer, void *data);
 #endif
 
 #endif /* __RUNMODE_UNIX_SOCKET_H__ */

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -197,6 +197,8 @@ typedef unsigned char u_char
 #include <netdb.h>
 #endif
 
+#include <math.h>
+
 #if __CYGWIN__
 #if !defined _X86_ && !defined __x86_64
 #define _X86_

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2010,6 +2010,8 @@ void PreRunInit(const int runmode)
     SCProfilingPrefilterGlobalInit();
     SCProfilingSghsGlobalInit();
     SCProfilingInit();
+#elif defined(PROFILING_LITE)
+    ProfliteRegisterCounterNames();
 #endif /* PROFILING */
     DefragInit();
     FlowInitConfig(FLOW_QUIET);

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -240,6 +240,9 @@ static void *TmThreadsSlotPktAcqLoop(void *td)
     SCDropCaps(tv);
 
     PacketPoolInit();
+#ifdef PROFILING_LITE
+    ProfliteRegisterCounters(tv);
+#endif
 
     /* check if we are setup properly */
     if (s == NULL || s->PktAcqLoop == NULL || tv->tmqh_in == NULL || tv->tmqh_out == NULL) {
@@ -348,6 +351,9 @@ static void *TmThreadsSlotPktAcqLoop(void *td)
         }
     }
 
+#ifdef PROFILING_LITE
+    ProfliteDump();
+#endif
     tv->stream_pq = NULL;
     SCLogDebug("%s ending", tv->name);
     TmThreadsSetFlag(tv, THV_CLOSED);
@@ -370,6 +376,9 @@ static void *TmThreadsSlotVar(void *td)
 
     PacketPoolInit();//Empty();
 
+#ifdef PROFILING_LITE
+    ProfliteRegisterCounters(tv);
+#endif
     /* Set the thread name */
     if (SCSetThreadName(tv->name) < 0) {
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
@@ -490,6 +499,9 @@ static void *TmThreadsSlotVar(void *td)
         }
     }
 
+#ifdef PROFILING_LITE
+    ProfliteDump();
+#endif
     SCLogDebug("%s ending", tv->name);
     tv->stream_pq = NULL;
     TmThreadsSetFlag(tv, THV_CLOSED);

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -408,7 +408,7 @@ void TmqhOutputPacketpool(ThreadVars *t, Packet *p)
                  * when we handle them */
                 SET_TUNNEL_PKT_VERDICTED(p);
 
-                PACKET_PROFILING_END(p);
+                PACKET_PROFILING_END(t, p);
                 SCMutexUnlock(m);
                 SCReturn;
             }
@@ -459,7 +459,7 @@ void TmqhOutputPacketpool(ThreadVars *t, Packet *p)
         p->root = NULL;
     }
 
-    PACKET_PROFILING_END(p);
+    PACKET_PROFILING_END(t, p);
 
     PACKET_RELEASE_REFS(p);
     p->ReleasePacket(p);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -1084,6 +1084,14 @@ int UnixManagerInit(void)
     UnixManagerRegisterCommand("dataset-add", UnixSocketDatasetAdd, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("dataset-remove", UnixSocketDatasetRemove, &command, UNIX_CMD_TAKE_ARGS);
 
+    UnixManagerRegisterCommand(
+            "profile-feature-enable", UnixSocketProfileEnable, &command, UNIX_CMD_TAKE_ARGS);
+    UnixManagerRegisterCommand(
+            "profile-feature-disable", UnixSocketProfileDisable, &command, UNIX_CMD_TAKE_ARGS);
+    UnixManagerRegisterCommand(
+            "profile-tracepoint-entry", UnixSocketProfileTpEntry, &command, UNIX_CMD_TAKE_ARGS);
+    UnixManagerRegisterCommand(
+            "profile-tracepoint-exit", UnixSocketProfileTpExit, &command, UNIX_CMD_TAKE_ARGS);
     return 0;
 }
 

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1245,7 +1245,497 @@ int SCProfileRuleStart(Packet *p)
 #endif
     return 0;
 }
+#endif
 
+#if defined(PROFILING_LITE)
+thread_local uint64_t proflite_features = 0;
+thread_local uint64_t proflite_tracepoints = 0;
+
+static enum ProfliteTracepoint SettingToTp(const char *setting)
+{
+    if (strcmp(setting, "packetpool_get") == 0) {
+        return PROFLITE_TP_PP_GET;
+    } else if (strcmp(setting, "packetpool_return") == 0) {
+        return PROFLITE_TP_PP_RETURN;
+    } else if (strcmp(setting, "flowworker_enter") == 0) {
+        return PROFLITE_TP_FLOWWORKER_ENTER;
+    } else if (strcmp(setting, "flowworker_pre_inject") == 0) {
+        return PROFLITE_TP_FLOWWORKER_PRE_INJECT;
+    } else if (strcmp(setting, "flowworker_applayer_enter") == 0) {
+        return PROFLITE_TP_FLOWWORKER_APPLAYER_START;
+    } else if (strcmp(setting, "flowworker_applayer_end") == 0) {
+        return PROFLITE_TP_FLOWWORKER_APPLAYER_END;
+    } else if (strcmp(setting, "flowworker_detect_enter") == 0) {
+        return PROFLITE_TP_FLOWWORKER_DETECT_START;
+    } else if (strcmp(setting, "flowworker_detect_end") == 0) {
+        return PROFLITE_TP_FLOWWORKER_DETECT_END;
+    } else if (strcmp(setting, "flowworker_output_start") == 0) {
+        return PROFLITE_TP_FLOWWORKER_OUTPUT_START;
+    } else if (strcmp(setting, "flowworker_output_end") == 0) {
+        return PROFLITE_TP_FLOWWORKER_OUTPUT_END;
+    } else if (strcmp(setting, "flowworker_exit") == 0) {
+        return PROFLITE_TP_FLOWWORKER_EXIT;
+    }
+    return PROFLITE_TP_DISABLED;
+}
+
+void ProfliteSetTpEntry(const char *setting)
+{
+    const enum ProfliteTracepoint tp = SettingToTp(setting);
+    SC_ATOMIC_SET(proflite_tp_entry, tp);
+    SCLogNotice("entry point set to \"%s\" Tp now %u", setting, SC_ATOMIC_GET(proflite_tp_entry));
+}
+void ProfliteSetTpExit(const char *setting)
+{
+    const enum ProfliteTracepoint tp = SettingToTp(setting);
+    if (tp > SC_ATOMIC_GET(proflite_tp_entry)) {
+        SC_ATOMIC_SET(proflite_tp_exit, tp);
+        SCLogNotice("exit point set to \"%s\" Tp now %u", setting, SC_ATOMIC_GET(proflite_tp_exit));
+    } else {
+        SCLogNotice("tracepoint should be > entry (TODO error handle)");
+    }
+}
+
+void ProfliteEnable(const char *setting)
+{
+    if (strcmp(setting, "all") == 0) {
+        SC_ATOMIC_OR(proflite_features, PROFLITE_ALL_BIT);
+    } else if (strcmp(setting, "tcp") == 0) {
+        SC_ATOMIC_OR(proflite_features, PROFLITE_TCP_BIT);
+    } else if (strcmp(setting, "app_http") == 0) {
+        SC_ATOMIC_OR(proflite_features, PROFLITE_ALPROTO_HTTP_BIT);
+    } else if (strcmp(setting, "only_app_http") == 0) {
+        SC_ATOMIC_SET(proflite_features, PROFLITE_ALPROTO_HTTP_BIT);
+    } else if (strcmp(setting, "app_dns") == 0) {
+        SC_ATOMIC_OR(proflite_features, PROFLITE_ALPROTO_DNS_BIT);
+    } else if (strcmp(setting, "only_app_dns") == 0) {
+        SC_ATOMIC_SET(proflite_features, PROFLITE_ALPROTO_DNS_BIT);
+    } else if (strcmp(setting, "app_ftp") == 0) {
+        SC_ATOMIC_OR(proflite_features, PROFLITE_ALPROTO_FTP_BIT);
+    } else if (strcmp(setting, "only_app_ftp") == 0) {
+        SC_ATOMIC_SET(proflite_features, PROFLITE_ALPROTO_FTP_BIT);
+    } else if (strcmp(setting, "app_dcerpc") == 0) {
+        SC_ATOMIC_OR(proflite_features, PROFLITE_ALPROTO_DCERPC_BIT);
+    } else if (strcmp(setting, "only_app_dcerpc") == 0) {
+        SC_ATOMIC_SET(proflite_features, PROFLITE_ALPROTO_DCERPC_BIT);
+    } else if (strcmp(setting, "any") == 0) {
+        SC_ATOMIC_SET(proflite_features, UINT64_MAX);
+    } else {
+        SCLogNotice("unknown setting %s", setting);
+        return;
+    }
+    SCLogNotice("enabled \"%s\". Flags now %" PRIx64, setting, SC_ATOMIC_GET(proflite_features));
+}
+
+void ProfliteDisable(const char *setting)
+{
+#if 0
+    if (strcmp(setting, "global") == 0) {
+        SC_ATOMIC_AND(proflite_flags, ~PROFLITE_ENABLED_BIT);
+    } else if (strcmp(setting, "app_http") == 0) {
+        SC_ATOMIC_AND(proflite_flags, ~PROFLITE_ALPROTO_HTTP_BIT);
+    } else {
+        abort();
+    }
+    SCLogNotice("disabled \"%s\". Flags now %"PRIx64, setting, SC_ATOMIC_GET(proflite_flags));
+#endif
+}
+
+enum ProfileLiteTracker {
+    PLT_ALL,
+    PLT_ALL_PSEUDO,
+    PLT_ALL_PAYLOAD,
+    PLT_ALL_NOPAYLOAD,
+    PLT_ALL_ALERT,
+    PLT_ALL_NOALERT,
+    PLT_TCP_ALL,
+    PLT_TCP_SYN,
+    PLT_TCP_RST,
+    PLT_TCP_FIN,
+    PLT_TCP_OTHER,
+    PLT_UDP,
+    PLT_ICMP4,
+    PLT_ICMP6,
+    PLT_OTHERIP,
+    PLT_OTHER,
+    PLT_ALPROTO_HTTP,
+    PLT_ALPROTO_HTTP2,
+    PLT_ALPROTO_SMB,
+    PLT_ALPROTO_NFS,
+    PLT_ALPROTO_DNS,
+    PLT_ALPROTO_DCERPC,
+    PLT_ALPROTO_SMTP,
+    PLT_ALPROTO_FTP,
+    PLT_ALPROTO_FTPDATA,
+    PLT_ALPROTO_TLS,
+    PLT_ALPROTO_SSH,
+    PLT_ALPROTO_DHCP,
+    PLT_ALPROTO_SNMP,
+    PLT_ALPROTO_TFTP,
+    PLT_ALPROTO_OTHER,
+    PLT_ALPROTO_NONE,
+    PLT_SIZE,
+};
+static const char *PltToString(enum ProfileLiteTracker t)
+{
+    switch (t) {
+        case PLT_ALL:
+            return "all";
+        case PLT_ALL_PSEUDO:
+            return "all_pseudo";
+        case PLT_ALL_PAYLOAD:
+            return "all_payload";
+        case PLT_ALL_NOPAYLOAD:
+            return "all_nopayload";
+        case PLT_ALL_ALERT:
+            return "all_alert";
+        case PLT_ALL_NOALERT:
+            return "all_noalert";
+        case PLT_TCP_ALL:
+            return "tcp_all";
+        case PLT_TCP_SYN:
+            return "tcp_syn";
+        case PLT_TCP_FIN:
+            return "tcp_fin";
+        case PLT_TCP_RST:
+            return "tcp_rst";
+        case PLT_TCP_OTHER:
+            return "tcp_other";
+        case PLT_UDP:
+            return "udp";
+        case PLT_ICMP4:
+            return "icmp4";
+        case PLT_ICMP6:
+            return "icmp6";
+        case PLT_OTHERIP:
+            return "other_ip";
+        case PLT_OTHER:
+            return "other";
+        case PLT_ALPROTO_HTTP:
+            return "app_http";
+        case PLT_ALPROTO_HTTP2:
+            return "app_http2";
+        case PLT_ALPROTO_SMTP:
+            return "app_http2";
+        case PLT_ALPROTO_SMB:
+            return "app_smb";
+        case PLT_ALPROTO_NFS:
+            return "app_nfs";
+        case PLT_ALPROTO_DNS:
+            return "app_dns";
+        case PLT_ALPROTO_DCERPC:
+            return "app_dcerpc";
+        case PLT_ALPROTO_FTP:
+            return "app_ftp";
+        case PLT_ALPROTO_FTPDATA:
+            return "app_ftpdata";
+        case PLT_ALPROTO_TLS:
+            return "app_tls";
+        case PLT_ALPROTO_SSH:
+            return "app_ssh";
+        case PLT_ALPROTO_SNMP:
+            return "app_snmp";
+        case PLT_ALPROTO_DHCP:
+            return "app_dhcp";
+        case PLT_ALPROTO_TFTP:
+            return "app_tftp";
+        case PLT_ALPROTO_OTHER:
+            return "app_other";
+        case PLT_ALPROTO_NONE:
+            return "app_none";
+        case PLT_SIZE:
+            return "ERROR";
+    }
+}
+
+struct ProfileLiteCounters {
+    uint16_t cnt;
+    uint16_t stdev;
+    uint16_t avg;
+    uint16_t max;
+    uint16_t gt_1stdev;
+    uint16_t gt_2stdev;
+    uint16_t gt_3stdev;
+};
+
+struct ProfileLiteCounterNames {
+    char cnt[256];
+    char stdev[256];
+    char avg[256];
+    char max[256];
+    char gt_1stdev[256];
+    char gt_2stdev[256];
+    char gt_3stdev[256];
+};
+
+thread_local struct ProfileLiteCounters profile_lite_counters[PLT_SIZE];
+struct ProfileLiteCounterNames profile_lite_names[PLT_SIZE];
+
+void ProfliteRegisterCounterNames(void)
+{
+    for (enum ProfileLiteTracker t = 0; t < PLT_SIZE; t++) {
+        struct ProfileLiteCounterNames *n = &profile_lite_names[t];
+
+        snprintf(n->cnt, sizeof(n->cnt), "profile.%s.cnt", PltToString(t));
+        snprintf(n->max, sizeof(n->max), "profile.%s.max", PltToString(t));
+        snprintf(n->stdev, sizeof(n->stdev), "profile.%s.stdev", PltToString(t));
+        snprintf(n->avg, sizeof(n->avg), "profile.%s.avg", PltToString(t));
+        snprintf(n->gt_1stdev, sizeof(n->gt_1stdev), "profile.%s.1_2_stdev", PltToString(t));
+        snprintf(n->gt_2stdev, sizeof(n->gt_2stdev), "profile.%s.2_3_stdev", PltToString(t));
+        snprintf(n->gt_3stdev, sizeof(n->gt_3stdev), "profile.%s.3_stdev", PltToString(t));
+    }
+}
+
+void ProfliteRegisterCounters(ThreadVars *tv)
+{
+    for (enum ProfileLiteTracker t = 0; t < PLT_SIZE; t++) {
+        struct ProfileLiteCounters *c = &profile_lite_counters[t];
+        const struct ProfileLiteCounterNames *n = &profile_lite_names[t];
+
+        c->cnt = StatsRegisterCounter(n->cnt, tv);
+        c->max = StatsRegisterMaxCounter(n->max, tv);
+        c->stdev = StatsRegisterCounter(n->stdev, tv);
+        c->avg = StatsRegisterAvgCounter(n->avg, tv);
+
+        c->gt_1stdev = StatsRegisterCounter(n->gt_1stdev, tv);
+        c->gt_2stdev = StatsRegisterCounter(n->gt_2stdev, tv);
+        c->gt_3stdev = StatsRegisterCounter(n->gt_3stdev, tv);
+    }
+}
+
+struct ProfLiteStats {
+    uint64_t tot;
+    uint64_t cnt;
+    uint64_t sd_cum; /**< stdev cumulative */
+};
+
+thread_local struct ProfLiteStats proflite_stats[PLT_SIZE] = { 0 };
+
+static inline void Update(ThreadVars *tv, enum ProfileLiteTracker t, uint64_t usecs)
+{
+    struct ProfLiteStats *s = &proflite_stats[t];
+    const struct ProfileLiteCounters *c = &profile_lite_counters[t];
+
+    if (s->cnt > 1000) {
+        const int64_t old_avg = s->tot / s->cnt;
+        s->tot += usecs;
+        s->cnt++;
+        const int64_t new_avg = s->tot / s->cnt;
+        const int64_t sd_sum_add = (usecs - old_avg) * (usecs - new_avg);
+        s->sd_cum += sd_sum_add;
+        double stdev = sqrt(s->sd_cum / (s->cnt - 1));
+        if (usecs > new_avg + (stdev * 3)) {
+            StatsIncr(tv, c->gt_3stdev);
+        } else if (usecs > new_avg + (stdev * 2)) {
+            StatsIncr(tv, c->gt_2stdev);
+        } else if (usecs > new_avg + stdev) {
+            StatsIncr(tv, c->gt_1stdev);
+        }
+        StatsSetUI64(tv, c->stdev, (uint64_t)stdev);
+        StatsAddUI64(tv, c->avg, usecs);
+        StatsIncr(tv, c->cnt);
+        StatsSetUI64(tv, c->max, usecs);
+    } else {
+        s->tot += usecs;
+        s->cnt++;
+    }
+}
+
+void ProfliteAddPacket(ThreadVars *tv, Packet *p, const uint64_t flags)
+{
+    struct timeval endts;
+    gettimeofday(&endts, NULL);
+
+    if (unlikely(timercmp(&p->proflite_startts, &endts, >))) {
+        memset(&p->proflite_startts, 0, sizeof(p->proflite_startts));
+        return;
+    }
+    struct timeval e;
+    timersub(&endts, &p->proflite_startts, &e);
+    memset(&p->proflite_startts, 0, sizeof(p->proflite_startts));
+
+    uint64_t usecs = (e.tv_sec * (uint64_t)1000000) + (e.tv_usec);
+    if (flags & PROFLITE_ALL_BIT) {
+        Update(tv, PLT_ALL, usecs);
+
+        if (PKT_IS_PSEUDOPKT(p)) {
+            Update(tv, PLT_ALL_PSEUDO, usecs);
+        }
+
+        if (p->payload_len) {
+            Update(tv, PLT_ALL_PAYLOAD, usecs);
+        } else {
+            Update(tv, PLT_ALL_NOPAYLOAD, usecs);
+        }
+        if (flags & PROFLITE_ALERT_BIT) {
+            if (p->alerts.cnt) {
+                Update(tv, PLT_ALL_ALERT, usecs);
+            } else {
+                Update(tv, PLT_ALL_NOALERT, usecs);
+            }
+        }
+    }
+    if (p->ip4h || p->ip6h) {
+        switch (p->proto) {
+            case IPPROTO_TCP: {
+                if (flags & PROFLITE_TCP_BIT) {
+                    Update(tv, PLT_TCP_ALL, usecs);
+
+                    if (p->tcph && p->tcph->th_flags & TH_SYN) {
+                        Update(tv, PLT_TCP_SYN, usecs);
+                    } else if (p->tcph && p->tcph->th_flags & TH_FIN) {
+                        Update(tv, PLT_TCP_FIN, usecs);
+                    } else if (p->tcph && p->tcph->th_flags & TH_RST) {
+                        Update(tv, PLT_TCP_RST, usecs);
+                    } else {
+                        Update(tv, PLT_TCP_OTHER, usecs);
+                    }
+                }
+
+                const AppProto alproto = p->flow ? p->flow->alproto : p->proflite_alproto;
+                switch (alproto) {
+                    case ALPROTO_HTTP1:
+                        if (flags & PROFLITE_ALPROTO_HTTP_BIT) {
+                            Update(tv, PLT_ALPROTO_HTTP, usecs);
+                        }
+                        break;
+                    case ALPROTO_SMB:
+                        if (flags & PROFLITE_ALPROTO_SMB_BIT) {
+                            Update(tv, PLT_ALPROTO_SMB, usecs);
+                        }
+                        break;
+                    case ALPROTO_NFS:
+                        if (flags & PROFLITE_ALPROTO_NFS_BIT) {
+                            Update(tv, PLT_ALPROTO_NFS, usecs);
+                        }
+                        break;
+                    case ALPROTO_SMTP:
+                        if (flags & PROFLITE_ALPROTO_SMTP_BIT) {
+                            Update(tv, PLT_ALPROTO_SMTP, usecs);
+                        }
+                        break;
+                    case ALPROTO_DNS:
+                        if (flags & PROFLITE_ALPROTO_DNS_BIT) {
+                            Update(tv, PLT_ALPROTO_DNS, usecs);
+                        }
+                        break;
+                    case ALPROTO_SSH:
+                        if (flags & PROFLITE_ALPROTO_SSH_BIT) {
+                            Update(tv, PLT_ALPROTO_SSH, usecs);
+                        }
+                        break;
+                    case ALPROTO_DCERPC:
+                        if (flags & PROFLITE_ALPROTO_DCERPC_BIT) {
+                            Update(tv, PLT_ALPROTO_DCERPC, usecs);
+                        }
+                        break;
+                    case ALPROTO_FTP:
+                        if (flags & PROFLITE_ALPROTO_FTP_BIT) {
+                            Update(tv, PLT_ALPROTO_FTP, usecs);
+                        }
+                        break;
+                    case ALPROTO_FTPDATA:
+                        if (flags & PROFLITE_ALPROTO_FTPDATA_BIT) {
+                            Update(tv, PLT_ALPROTO_FTPDATA, usecs);
+                        }
+                        break;
+                    case ALPROTO_TLS:
+                        if (flags & PROFLITE_ALPROTO_TLS_BIT) {
+                            Update(tv, PLT_ALPROTO_TLS, usecs);
+                        }
+                        break;
+                    case ALPROTO_HTTP2:
+                        if (flags & PROFLITE_ALPROTO_HTTP2_BIT) {
+                            Update(tv, PLT_ALPROTO_HTTP2, usecs);
+                        }
+                        break;
+                    case ALPROTO_UNKNOWN:
+                    case ALPROTO_FAILED:
+                        if (flags & PROFLITE_ALPROTO_NONE_BIT) {
+                            Update(tv, PLT_ALPROTO_NONE, usecs);
+                        }
+                        break;
+                    default:
+                        if (flags & PROFLITE_ALPROTO_OTHER_BIT) {
+                            Update(tv, PLT_ALPROTO_OTHER, usecs);
+                        }
+                        break;
+                }
+                break;
+            }
+            case IPPROTO_UDP: {
+                if (flags & PROFLITE_UDP_BIT) {
+                    Update(tv, PLT_UDP, usecs);
+                }
+
+                const AppProto alproto = p->flow ? p->flow->alproto : p->proflite_alproto;
+                if (alproto == ALPROTO_DNS) {
+                    if (flags & PROFLITE_ALPROTO_DNS_BIT) {
+                        Update(tv, PLT_ALPROTO_DNS, usecs);
+                    }
+                } else if (alproto == ALPROTO_SNMP) {
+                    if (flags & PROFLITE_ALPROTO_SNMP_BIT) {
+                        Update(tv, PLT_ALPROTO_SNMP, usecs);
+                    }
+                } else if (alproto == ALPROTO_DHCP) {
+                    if (flags & PROFLITE_ALPROTO_DHCP_BIT) {
+                        Update(tv, PLT_ALPROTO_DHCP, usecs);
+                    }
+                } else if (alproto == ALPROTO_TFTP) {
+                    if (flags & PROFLITE_ALPROTO_TFTP_BIT) {
+                        Update(tv, PLT_ALPROTO_TFTP, usecs);
+                    }
+                } else if (alproto == ALPROTO_UNKNOWN || alproto == ALPROTO_FAILED) {
+                    if (flags & PROFLITE_ALPROTO_NONE_BIT) {
+                        Update(tv, PLT_ALPROTO_NONE, usecs);
+                    }
+                } else {
+                    if (flags & PROFLITE_ALPROTO_OTHER_BIT) {
+                        Update(tv, PLT_ALPROTO_OTHER, usecs);
+                    }
+                }
+                break;
+            }
+            case IPPROTO_ICMP:
+                if (flags & PROFLITE_ICMP4_BIT) {
+                    Update(tv, PLT_ICMP4, usecs);
+                }
+                break;
+            case IPPROTO_ICMPV6:
+                if (flags & PROFLITE_ICMP6_BIT) {
+                    Update(tv, PLT_ICMP6, usecs);
+                }
+                break;
+            default:
+                if (flags & PROFLITE_OTHERIP_BIT) {
+                    Update(tv, PLT_OTHERIP, usecs);
+                }
+                break;
+        }
+    } else {
+        if (flags & PROFLITE_OTHER_BIT) {
+            Update(tv, PLT_OTHER, usecs);
+        }
+    }
+}
+
+void ProfliteDump(void)
+{
+    for (int idx = 0; idx < PLT_SIZE; idx++) {
+        const struct ProfLiteStats *s = &proflite_stats[idx];
+        if (s->cnt > 1000) {
+            int64_t avg = s->tot / s->cnt;
+            double stdev = sqrt(s->sd_cum / (s->cnt - 1));
+
+            const char *str = PltToString(idx);
+            SCLogNotice(
+                    "(%s): avg %" PRIi64 ", stdev %0.1f, cnt %" PRIu64, str, avg, stdev, s->cnt);
+        }
+    }
+}
+#endif /* PROFILING_LITE */
+
+#if defined(PROFILING)
 #define CASE_CODE(E)  case E: return #E
 
 /**


### PR DESCRIPTION
Rebased #5728

Can be enabled/disabled over unix-socket.

There are several tracepoints that can be selected:

    suricatasc -c "profile-tracepoint-entry packetpool_get"
    suricatasc -c "profile-tracepoint-exit packetpool_return"

The tracepoints are:

    packetpool_get, packetpool_return,
    flowworker_enter, flowworker_exit,
    flowworker_pre_inject (as flowworker_exit but excludes flow
                           house keeping tasks)
    flowworker_applayer_enter, flowworker_applayer_end,
    flowworker_detect_enter, flowworker_detect_end,
    flowworker_output_start, flowworker_output_end,

By selecting packetpool_get as entry and packetpool_return as exit the
entire lifetime of a packet is accounted.

Features can be enabled by:

    suricatasc -c "profile-feature-enable any"
    suricatasc -c "profile-feature-enable only_http"

Features:

    all - special counters for all packets
    tcp - tcp packets with break out per SYN/FIN/RST flags
    app_http / only_app_http
    app_dns / only_app_dns
    app_ftp / only_app_ftp
    app_dcerpc / only_app_dcerpc
    any - enable all counters
