### PR TITLE
config/threshold: Slow startup when threshold.config contains many suppress addrs

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -121,7 +121,7 @@ static void DetectAddressHeadFree(DetectAddressHead *gh)
  * \retval ag Pointer to the new instance of DetectAddress that contains the
  *            copied address.
  */
-static DetectAddress *DetectAddressCopy(DetectAddress *orig)
+DetectAddress *DetectAddressCopy(DetectAddress *orig)
 {
     DetectAddress *ag = DetectAddressInit();
     if (ag == NULL)
@@ -829,7 +829,7 @@ static int DetectAddressParse2(const DetectEngineCtx *de_ctx,
                     }
                     DetectAddressHeadCleanup(&tmp_ghn);
 
-                    SCLogDebug("merged succesfully");
+                    SCLogDebug("merged successfully");
 
                     /* insert the IPv4 addresses into the negated list */
                     for (tmp_ad = tmp_gh.ipv4_head; tmp_ad; tmp_ad = tmp_ad->next) {
@@ -1504,7 +1504,7 @@ void DetectAddressHeadCleanup(DetectAddressHead *gh)
  *        explanations on what these functions do.
  *
  * \param de_ctx Pointer to the DetectEngineCtx.
- * \param a      Pointer the the first address to be cut.
+ * \param a      Pointer to the first address to be cut.
  * \param b      Pointer to the second address to be cut.
  * \param c      Pointer to a pointer to a third DetectAddressData, in case the
  *               ranges from a and b, demand a third address range.

--- a/src/detect-engine-address.h
+++ b/src/detect-engine-address.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -28,6 +28,7 @@
 
 DetectAddress *DetectAddressInit(void);
 void DetectAddressFree(DetectAddress *);
+DetectAddress *DetectAddressCopy(DetectAddress *);
 int DetectAddressParse(const DetectEngineCtx *, DetectAddressHead *, const char *);
 void DetectAddressHeadCleanup(DetectAddressHead *);
 

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -284,6 +284,53 @@ static void DetectThresholdFree(DetectEngineCtx *de_ctx, void *de_ptr)
         DetectAddressHeadCleanup(&de->addrs);
         SCFree(de);
     }
+}
+
+/**
+ * \brief Make a deep-copy of an extant DetectTHresholdData object.
+ *
+ * \param de pointer to DetectThresholdData
+ */
+DetectThresholdData *DetectThresholdDataCopy(DetectThresholdData *de)
+{
+    DetectThresholdData *new_de = SCCalloc(1, sizeof(DetectThresholdData));
+    if (unlikely(new_de == NULL))
+        return NULL;
+
+    *new_de = *de;
+    new_de->addrs.ipv4_head = NULL;
+    new_de->addrs.ipv6_head = NULL;
+
+    for (DetectAddress *last = NULL, *tmp_ad = de->addrs.ipv4_head; tmp_ad; tmp_ad = tmp_ad->next) {
+        DetectAddress *n_addr = DetectAddressCopy(tmp_ad);
+        if (n_addr == NULL)
+            goto error;
+        if (last == NULL) {
+            new_de->addrs.ipv4_head = n_addr;
+        } else {
+            last->next = n_addr;
+            n_addr->prev = last;
+        }
+        last = n_addr;
+    }
+    for (DetectAddress *last = NULL, *tmp_ad = de->addrs.ipv6_head; tmp_ad; tmp_ad = tmp_ad->next) {
+        DetectAddress *n_addr = DetectAddressCopy(tmp_ad);
+        if (n_addr == NULL)
+            goto error;
+        if (last == NULL) {
+            new_de->addrs.ipv6_head = n_addr;
+        } else {
+            last->next = n_addr;
+            n_addr->prev = last;
+        }
+        last = n_addr;
+    }
+
+    return new_de;
+
+error:
+    DetectThresholdFree(NULL, new_de);
+    return NULL;
 }
 
 /*

--- a/src/detect-threshold.h
+++ b/src/detect-threshold.h
@@ -85,5 +85,6 @@ typedef struct DetectThresholdEntry_ {
  */
 
 void DetectThresholdRegister(void);
+DetectThresholdData *DetectThresholdDataCopy(DetectThresholdData *);
 
 #endif /*__DETECT_THRESHOLD_H__ */

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -385,8 +385,8 @@ static int SetupSuppressRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid,
         }
     } else if (id > 0 && gid == 0) {
         SCLogError(SC_ERR_INVALID_VALUE, "Can't use a event config that has "
-                   "sid > 0 and gid == 0. Please fix this "
-                   "in your threshold.conf file");
+                                         "sid > 0 and gid == 0. Please fix this "
+                                         "in your threshold.config file");
         goto error;
     } else {
         s = SigFindSignatureBySidGid(de_ctx, id, gid);

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -306,6 +306,25 @@ static int SetupSuppressRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid,
 
     BUG_ON(parsed_type != TYPE_SUPPRESS);
 
+    DetectThresholdData *orig_de = NULL;
+    if (parsed_track != TRACK_RULE) {
+        orig_de = SCCalloc(1, sizeof(DetectThresholdData));
+        if (unlikely(orig_de == NULL))
+            goto error;
+
+        orig_de->type = TYPE_SUPPRESS;
+        orig_de->track = parsed_track;
+        orig_de->count = parsed_count;
+        orig_de->seconds = parsed_seconds;
+        orig_de->new_action = parsed_new_action;
+        orig_de->timeout = parsed_timeout;
+        if (DetectAddressParse((const DetectEngineCtx *)de_ctx, &orig_de->addrs, (char *)th_ip) <
+                0) {
+            SCLogError(SC_ERR_INVALID_IP_NETBLOCK, "failed to parse %s", th_ip);
+            goto error;
+        }
+    }
+
     /* Install it */
     if (id == 0 && gid == 0) {
         if (parsed_track == TRACK_RULE) {
@@ -320,24 +339,9 @@ static int SetupSuppressRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid,
                 continue;
             }
 
-            de = SCMalloc(sizeof(DetectThresholdData));
+            de = DetectThresholdDataCopy(orig_de);
             if (unlikely(de == NULL))
                 goto error;
-            memset(de,0,sizeof(DetectThresholdData));
-
-            de->type = TYPE_SUPPRESS;
-            de->track = parsed_track;
-            de->count = parsed_count;
-            de->seconds = parsed_seconds;
-            de->new_action = parsed_new_action;
-            de->timeout = parsed_timeout;
-
-            if (parsed_track != TRACK_RULE) {
-                if (DetectAddressParse((const DetectEngineCtx *)de_ctx, &de->addrs, (char *)th_ip) < 0) {
-                    SCLogError(SC_ERR_INVALID_IP_NETBLOCK, "failed to parse %s", th_ip);
-                    goto error;
-                }
-            }
 
             sm = SigMatchAlloc();
             if (sm == NULL) {
@@ -364,25 +368,9 @@ static int SetupSuppressRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid,
                 continue;
             }
 
-            de = SCMalloc(sizeof(DetectThresholdData));
+            de = DetectThresholdDataCopy(orig_de);
             if (unlikely(de == NULL))
                 goto error;
-
-            memset(de,0,sizeof(DetectThresholdData));
-
-            de->type = TYPE_SUPPRESS;
-            de->track = parsed_track;
-            de->count = parsed_count;
-            de->seconds = parsed_seconds;
-            de->new_action = parsed_new_action;
-            de->timeout = parsed_timeout;
-
-            if (parsed_track != TRACK_RULE) {
-                if (DetectAddressParse((const DetectEngineCtx *)de_ctx, &de->addrs, (char *)th_ip) < 0) {
-                    SCLogError(SC_ERR_INVALID_IP_NETBLOCK, "failed to parse %s", th_ip);
-                    goto error;
-                }
-            }
 
             sm = SigMatchAlloc();
             if (sm == NULL) {
@@ -411,22 +399,9 @@ static int SetupSuppressRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid,
                 goto end;
             }
 
-            de = SCMalloc(sizeof(DetectThresholdData));
+            de = DetectThresholdDataCopy(orig_de);
             if (unlikely(de == NULL))
                 goto error;
-            memset(de,0,sizeof(DetectThresholdData));
-
-            de->type = TYPE_SUPPRESS;
-            de->track = parsed_track;
-            de->count = parsed_count;
-            de->seconds = parsed_seconds;
-            de->new_action = parsed_new_action;
-            de->timeout = parsed_timeout;
-
-            if (DetectAddressParse((const DetectEngineCtx *)de_ctx, &de->addrs, (char *)th_ip) < 0) {
-                SCLogError(SC_ERR_INVALID_IP_NETBLOCK, "failed to parse %s", th_ip);
-                goto error;
-            }
 
             sm = SigMatchAlloc();
             if (sm == NULL) {
@@ -442,8 +417,16 @@ static int SetupSuppressRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid,
     }
 
 end:
+    if (orig_de != NULL) {
+        DetectAddressHeadCleanup(&orig_de->addrs);
+        SCFree(orig_de);
+    }
     return 0;
 error:
+    if (orig_de != NULL) {
+        DetectAddressHeadCleanup(&orig_de->addrs);
+        SCFree(orig_de);
+    }
     if (de != NULL) {
         DetectAddressHeadCleanup(&de->addrs);
         SCFree(de);


### PR DESCRIPTION
Continuation of #6005 
This PR improves Suricata's startup time when `threshold.config` contains many suppress addresses.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4407](https://redmine.openinfosecfoundation.org/issues/4407)

Describe changes:
- clang-format fixups
- suricata-verify test case added for code coverage.

suricata-verify-pr: 484
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
