### PR TITLE
log: Add module and subsystem identifiers to log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: false
 language: c
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -208,3 +208,9 @@ before_install:
 
     cargo install --force --debug --version 0.14.1 cbindgen
   - ./qa/travis-libhtp.sh
+
+after_failure:
+    - echo == Start of after failure logs ==
+    - find . -name config.log | xargs cat
+    - sleep 10
+    - echo == End of after failure logs ==

--- a/configure.ac
+++ b/configure.ac
@@ -2597,6 +2597,9 @@ if test "${enable_ebpf}" = "yes" || test "${enable_nfqueue}" = "yes" || test "${
   AC_DEFINE([CAPTURE_OFFLOAD], [1],[Building flow capture bypass code])
 fi
 
+# Add diagnostic filename
+CPPFLAGS="${CPPFLAGS} -D__SCFILENAME__=\\\"\$(*F)\\\""
+
 AC_SUBST(CFLAGS)
 AC_SUBST(LDFLAGS)
 AC_SUBST(CPPFLAGS)

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -75,6 +75,7 @@ pub type SCLogMessageFunc =
                   filename: *const std::os::raw::c_char,
                   line: std::os::raw::c_uint,
                   function: *const std::os::raw::c_char,
+                  subsystem: *const std::os::raw::c_char,
                   code: std::os::raw::c_int,
                   message: *const std::os::raw::c_char) -> std::os::raw::c_int;
 

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -71,10 +71,12 @@ pub fn sclog(level: Level, file: &str, line: u32, function: &str,
          code: i32, message: &str)
 {
     let filename = basename(file);
+    let noext = &filename[0..filename.len() - 3];
     sc_log_message(level,
                    filename,
                    line,
                    function,
+                   noext,
                    code,
                    message);
 }
@@ -178,6 +180,7 @@ pub fn sc_log_message(level: Level,
                       filename: &str,
                       line: std::os::raw::c_uint,
                       function: &str,
+                      module: &str,
                       code: std::os::raw::c_int,
                       message: &str) -> std::os::raw::c_int
 {
@@ -188,6 +191,7 @@ pub fn sc_log_message(level: Level,
                 to_safe_cstring(filename).as_ptr(),
                 line,
                 to_safe_cstring(function).as_ptr(),
+                to_safe_cstring(module).as_ptr(),
                 code,
                 to_safe_cstring(message).as_ptr());
         }

--- a/src/counters.c
+++ b/src/counters.c
@@ -370,6 +370,7 @@ static void *StatsMgmtThread(void *arg)
     if (SCSetThreadName(tv_local->name) < 0) {
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
+    SCSetSubsystem(tv_local->name);
 
     if (tv_local->thread_setup_flags != 0)
         TmThreadSetupOptions(tv_local);
@@ -382,6 +383,7 @@ static void *StatsMgmtThread(void *arg)
         SCLogError(SC_ERR_STATS_NOT_INIT, "Stats API not init"
                    "StatsInitCounterApi() has to be called first");
         TmThreadsSetFlag(tv_local, THV_CLOSED | THV_RUNNING_DONE);
+        SCClearSubsystem();
         return NULL;
     }
 
@@ -392,6 +394,7 @@ static void *StatsMgmtThread(void *arg)
         SCLogError(SC_ERR_THREAD_INIT, "Stats API "
                    "ThreadInit failed");
         TmThreadsSetFlag(tv_local, THV_CLOSED | THV_RUNNING_DONE);
+        SCClearSubsystem();
         return NULL;
     }
     SCLogDebug("stats_thread_data %p", &stats_thread_data);
@@ -434,6 +437,7 @@ static void *StatsMgmtThread(void *arg)
     }
 
     TmThreadsSetFlag(tv_local, THV_CLOSED);
+    SCClearSubsystem();
     return NULL;
 }
 
@@ -453,6 +457,7 @@ static void *StatsWakeupThread(void *arg)
     if (SCSetThreadName(tv_local->name) < 0) {
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
+    SCSetSubsystem(tv_local->name);
 
     if (tv_local->thread_setup_flags != 0)
         TmThreadSetupOptions(tv_local);
@@ -465,6 +470,7 @@ static void *StatsWakeupThread(void *arg)
         SCLogError(SC_ERR_STATS_NOT_INIT, "Stats API not init"
                    "StatsInitCounterApi() has to be called first");
         TmThreadsSetFlag(tv_local, THV_CLOSED | THV_RUNNING_DONE);
+        SCClearSubsystem();
         return NULL;
     }
 
@@ -531,6 +537,7 @@ static void *StatsWakeupThread(void *arg)
     TmThreadsSetFlag(tv_local, THV_RUNNING_DONE);
     TmThreadWaitForFlag(tv_local, THV_DEINIT);
     TmThreadsSetFlag(tv_local, THV_CLOSED);
+    SCClearSubsystem();
     return NULL;
 }
 

--- a/src/rust-context.h
+++ b/src/rust-context.h
@@ -28,7 +28,7 @@
 struct AppLayerParser;
 
 typedef struct SuricataContext_ {
-    SCError (*SCLogMessage)(const SCLogLevel, const char *, const unsigned int,
+    SCError (*SCLogMessage)(const SCLogLevel, const char *, const unsigned int, const char *,
             const char *, const SCError, const char *message);
     void (*DetectEngineStateFree)(DetectEngineState *);
     void (*AppLayerDecoderEventsSetEventRaw)(AppLayerDecoderEvents **,

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2678,7 +2678,10 @@ int InitGlobal(void) {
 
     (void)SCSetThreadName("Suricata-Main");
 
-    /* Ignore SIGUSR2 as early as possble. We redeclare interest
+    /* Set subsystem name - TLS for main thread */
+    SCSetSubsystem("Suricata-main");
+
+    /* Ignore SIGUSR2 as early as possible. We redeclare interest
      * once we're done launching threads. The goal is to either die
      * completely or handle any and all SIGUSR2s correctly.
      */
@@ -2686,6 +2689,7 @@ int InitGlobal(void) {
     UtilSignalHandlerSetup(SIGUSR2, SIG_IGN);
     if (UtilSignalBlock(SIGUSR2)) {
         SCLogError(SC_ERR_INITIALIZATION, "SIGUSR2 initialization error");
+        SCClearSubsystem();
         return EXIT_FAILURE;
     }
 #endif
@@ -2710,22 +2714,27 @@ int SuricataMain(int argc, char **argv)
 #ifdef OS_WIN32
     /* service initialization */
     if (WindowsInitService(argc, argv) != 0) {
+        SCClearSubsystem();
         exit(EXIT_FAILURE);
     }
 #endif /* OS_WIN32 */
 
     if (ParseCommandLine(argc, argv, &suricata) != TM_ECODE_OK) {
+        SCClearSubsystem();
         exit(EXIT_FAILURE);
     }
 
     if (FinalizeRunMode(&suricata, argv) != TM_ECODE_OK) {
+        SCClearSubsystem();
         exit(EXIT_FAILURE);
     }
 
     switch (StartInternalRunMode(&suricata, argc, argv)) {
         case TM_ECODE_DONE:
+            SCClearSubsystem();
             exit(EXIT_SUCCESS);
         case TM_ECODE_FAILED:
+            SCClearSubsystem();
             exit(EXIT_FAILURE);
     }
 
@@ -2734,11 +2743,13 @@ int SuricataMain(int argc, char **argv)
 
     /* Load yaml configuration file if provided. */
     if (LoadYamlConfig(&suricata) != TM_ECODE_OK) {
+        SCClearSubsystem();
         exit(EXIT_FAILURE);
     }
 
     if (suricata.run_mode == RUNMODE_DUMP_CONFIG) {
         ConfDump();
+        SCClearSubsystem();
         exit(EXIT_SUCCESS);
     }
 
@@ -2759,10 +2770,12 @@ int SuricataMain(int argc, char **argv)
     UtilCpuPrintSummary();
 
     if (ParseInterfacesList(suricata.aux_run_mode, suricata.pcap_dev) != TM_ECODE_OK) {
+        SCClearSubsystem();
         exit(EXIT_FAILURE);
     }
 
     if (PostConfLoadedSetup(&suricata) != TM_ECODE_OK) {
+        SCClearSubsystem();
         exit(EXIT_FAILURE);
     }
 
@@ -2793,6 +2806,7 @@ int SuricataMain(int argc, char **argv)
 
     /* Wait till all the threads have been initialized */
     if (TmThreadWaitOnThreadInit() == TM_ECODE_FAILED) {
+        SCClearSubsystem();
         FatalError(SC_ERR_FATAL, "Engine initialization failed, "
                    "aborting...");
     }
@@ -2819,5 +2833,6 @@ int SuricataMain(int argc, char **argv)
 out:
     GlobalsDestroy(&suricata);
 
+    SCClearSubsystem();
     exit(EXIT_SUCCESS);
 }

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -233,6 +233,8 @@ static void *TmThreadsSlotPktAcqLoop(void *td)
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
 
+    SCSetSubsystem(tv->name);
+
     if (tv->thread_setup_flags != 0)
         TmThreadSetupOptions(tv);
 
@@ -248,6 +250,7 @@ static void *TmThreadsSlotPktAcqLoop(void *td)
                                  " tmqh_out=%p",
                    s, s ? s->PktAcqLoop : NULL, tv->tmqh_in, tv->tmqh_out);
         TmThreadsSetFlag(tv, THV_CLOSED | THV_RUNNING_DONE);
+        SCClearSubsystem();
         pthread_exit((void *) -1);
         return NULL;
     }
@@ -351,11 +354,13 @@ static void *TmThreadsSlotPktAcqLoop(void *td)
     tv->stream_pq = NULL;
     SCLogDebug("%s ending", tv->name);
     TmThreadsSetFlag(tv, THV_CLOSED);
+    SCClearSubsystem();
     pthread_exit((void *) 0);
     return NULL;
 
 error:
     tv->stream_pq = NULL;
+    SCClearSubsystem();
     pthread_exit((void *) -1);
     return NULL;
 }
@@ -375,6 +380,8 @@ static void *TmThreadsSlotVar(void *td)
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
 
+    SCSetSubsystem(tv->name);
+
     if (tv->thread_setup_flags != 0)
         TmThreadSetupOptions(tv);
 
@@ -384,6 +391,7 @@ static void *TmThreadsSlotVar(void *td)
     /* check if we are setup properly */
     if (s == NULL || tv->tmqh_in == NULL || tv->tmqh_out == NULL) {
         TmThreadsSetFlag(tv, THV_CLOSED | THV_RUNNING_DONE);
+        SCClearSubsystem();
         pthread_exit((void *) -1);
         return NULL;
     }
@@ -493,11 +501,13 @@ static void *TmThreadsSlotVar(void *td)
     SCLogDebug("%s ending", tv->name);
     tv->stream_pq = NULL;
     TmThreadsSetFlag(tv, THV_CLOSED);
+    SCClearSubsystem();
     pthread_exit((void *) 0);
     return NULL;
 
 error:
     tv->stream_pq = NULL;
+    SCClearSubsystem();
     pthread_exit((void *) -1);
     return NULL;
 }
@@ -515,6 +525,8 @@ static void *TmThreadsManagement(void *td)
         SCLogWarning(SC_ERR_THREAD_INIT, "Unable to set thread name");
     }
 
+    SCSetSubsystem(tv->name);
+
     if (tv->thread_setup_flags != 0)
         TmThreadSetupOptions(tv);
 
@@ -528,6 +540,7 @@ static void *TmThreadsManagement(void *td)
         r = s->SlotThreadInit(tv, s->slot_initdata, &slot_data);
         if (r != TM_ECODE_OK) {
             TmThreadsSetFlag(tv, THV_CLOSED | THV_RUNNING_DONE);
+            SCClearSubsystem();
             pthread_exit((void *) -1);
             return NULL;
         }
@@ -559,12 +572,14 @@ static void *TmThreadsManagement(void *td)
         r = s->SlotThreadDeinit(tv, SC_ATOMIC_GET(s->slot_data));
         if (r != TM_ECODE_OK) {
             TmThreadsSetFlag(tv, THV_CLOSED);
+            SCClearSubsystem();
             pthread_exit((void *) -1);
             return NULL;
         }
     }
 
     TmThreadsSetFlag(tv, THV_CLOSED);
+    SCClearSubsystem();
     pthread_exit((void *) 0);
     return NULL;
 }
@@ -1659,6 +1674,7 @@ static void TmThreadFree(ThreadVars *tv)
     }
 
     TmThreadsUnregisterThread(tv->id);
+
     SCFree(tv);
 }
 

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -440,17 +440,8 @@ static SCError SCLogMessageGetBuffer(struct timeval *tval, int color, SCLogOPTyp
 
             case SC_LOG_FMT_TM:
                 temp_fmt[0] = '\0';
-/* disabled to prevent dead lock:
- * log or alloc (which calls log on error) can call TmThreadsGetCallingThread
- * which will lock tv_root_lock. This can happen while we already hold this
- * lock. */
-#if 0
-                ThreadVars *tv = TmThreadsGetCallingThread();
-                cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - *msg),
-                              "%s%s", substr, ((tv != NULL)? tv->name: "UNKNOWN TM"));
-#endif
-                cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer),
-                              "%s%s", substr, "N/A");
+                cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer), "%s%s", substr,
+                        _sc_subsystem == NULL ? "N/A" : _sc_subsystem);
                 if (cw < 0)
                     return SC_ERR_SPRINTF;
                 temp += cw;

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -801,11 +801,10 @@ static inline SCLogOPIfaceCtx *SCLogAllocLogOPIfaceCtx(void)
 {
     SCLogOPIfaceCtx *iface_ctx = NULL;
 
-    if ( (iface_ctx = SCMalloc(sizeof(SCLogOPIfaceCtx))) == NULL) {
+    if ((iface_ctx = SCCalloc(1, sizeof(SCLogOPIfaceCtx))) == NULL) {
         FatalError(SC_ERR_FATAL,
                    "Fatal error encountered in SCLogallocLogOPIfaceCtx. Exiting...");
     }
-    memset(iface_ctx, 0, sizeof(SCLogOPIfaceCtx));
 
     return iface_ctx;
 }
@@ -1245,11 +1244,8 @@ SCLogInitData *SCLogAllocLogInitData(void)
 {
     SCLogInitData *sc_lid = NULL;
 
-    /* not using SCMalloc here because if it fails we can't log */
-    if ( (sc_lid = SCMalloc(sizeof(SCLogInitData))) == NULL)
+    if ((sc_lid = SCCalloc(1, sizeof(SCLogInitData))) == NULL)
         return NULL;
-
-    memset(sc_lid, 0, sizeof(SCLogInitData));
 
     return sc_lid;
 }
@@ -1402,11 +1398,10 @@ void SCLogInitLogModule(SCLogInitData *sc_lid)
 #endif /* OS_WIN32 */
 
     /* sc_log_config is a global variable */
-    if ( (sc_log_config = SCMalloc(sizeof(SCLogConfig))) == NULL) {
+    if ((sc_log_config = SCCalloc(1, sizeof(SCLogConfig))) == NULL) {
         FatalError(SC_ERR_FATAL,
                    "Fatal error encountered in SCLogInitLogModule. Exiting...");
     }
-    memset(sc_log_config, 0, sizeof(SCLogConfig));
 
     SCLogSetLogLevel(sc_lid, sc_log_config);
     SCLogSetLogFormat(sc_lid, sc_log_config);

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -189,7 +189,7 @@ static inline void SCLogPrintToStream(FILE *fd, char *msg)
 }
 
 /**
- * \brief Output function that logs a character string throught the syslog iface
+ * \brief Output function that logs a character string through the syslog iface
  *
  * \param syslog_log_level Holds the syslog_log_level that the message should be
  *                         logged as
@@ -349,11 +349,14 @@ static const char *SCTransformModule(const char *module_name, int *dn_len)
  *
  * \retval SC_OK on success; else an error code
  */
-static SCError SCLogMessageGetBuffer(struct timeval *tval, int color, SCLogOPType type,
-        char *buffer, size_t buffer_size, const char *log_format,
-
-        const SCLogLevel log_level, const char *file, const unsigned int line, const char *function,
-        const char *module, const SCError error_code, const char *message)
+static SCError SCLogMessageGetBuffer(
+        struct timeval *tval, int color, SCLogOPType type,
+                     char *buffer, size_t buffer_size,
+                     const char *log_format,
+                     const SCLogLevel log_level, const char *file,
+                     const unsigned int line, const char *function,
+                     const char *module, const SCError error_code,
+                     const char *message)
 {
     if (type == SC_LOG_OP_TYPE_JSON)
         return SCLogMessageJSON(tval, buffer, buffer_size, log_level, file, line, function, module,
@@ -1232,7 +1235,7 @@ static inline void SCLogSetOPFilter(SCLogInitData *sc_lid, SCLogConfig *sc_lc)
 
 /**
  * \brief Returns a pointer to a new SCLogInitData.  This is a public interface
- *        intended to be used after the logging paramters are read from the
+ *        intended to be used after the logging parameters are read from the
  *        conf file
  *
  * \retval sc_lid Pointer to the newly created SCLogInitData

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -214,36 +214,34 @@ static int SCLogMessageJSON(struct timeval *tval, char *buffer, size_t buffer_si
         SCLogLevel log_level, const char *file, unsigned line, const char *function,
         const char *module, SCError error_code, const char *message)
 {
-    json_t *js = json_object();
+    JsonBuilder *js = jb_new_object();
     if (unlikely(js == NULL))
-        goto error;
-    json_t *ejs = json_object();
-    if (unlikely(ejs == NULL))
         goto error;
 
     char timebuf[64];
     CreateIsoTimeString(tval, timebuf, sizeof(timebuf));
-    json_object_set_new(js, "timestamp", json_string(timebuf));
+    jb_set_string(js, "timestamp", timebuf);
 
     const char *s = SCMapEnumValueToName(log_level, sc_log_level_map);
     if (s != NULL) {
-        json_object_set_new(js, "log_level", json_string(s));
+        jb_set_string(js, "log_level", s);
     } else {
-        json_object_set_new(js, "log_level", json_string("INVALID"));
+        JB_SET_STRING(js, "log_level", "INVALID");
     }
 
-    json_object_set_new(js, "event_type", json_string("engine"));
+    JB_SET_STRING(js, "event_type", "engine");
+    jb_open_object(js, "engine");
 
     if (error_code > 0) {
-        json_object_set_new(ejs, "error_code", json_integer(error_code));
-        json_object_set_new(ejs, "error", json_string(SCErrorToString(error_code)));
+        jb_set_uint(js, "error_code", error_code);
+        jb_set_string(js, "error", SCErrorToString(error_code));
     }
 
     if (message)
-        json_object_set_new(ejs, "message", json_string(message));
+        jb_set_string(js, "message", message);
 
     if (_sc_subsystem) {
-        json_object_set_new(ejs, "subsystem", json_string(_sc_subsystem));
+        jb_set_string(js, "subsystem", _sc_subsystem);
     }
 
     if (module) {
@@ -251,33 +249,27 @@ static int SCLogMessageJSON(struct timeval *tval, char *buffer, size_t buffer_si
         int dn_len = 0;
         const char *dn_name;
         dn_name = SCTransformModule(module, &dn_len);
-        json_object_set_new(ejs, "module", json_string(dn_name));
+        jb_set_string(js, "module", dn_name);
     }
 
     if (log_level >= SC_LOG_DEBUG) {
         if (function)
-            json_object_set_new(ejs, "function", json_string(function));
+            jb_set_string(js, "function", function);
 
         if (file)
-            json_object_set_new(ejs, "file", json_string(file));
+            jb_set_string(js, "file", file);
 
         if (line > 0)
-            json_object_set_new(ejs, "line", json_integer(line));
+            jb_set_uint(js, "line", line);
     }
 
-    json_object_set_new(js, "engine", ejs);
+    jb_close(js);
+    memcpy(buffer, jb_ptr(js), MIN(buffer_size, jb_len(js)));
 
-    char *js_s = json_dumps(js,
-            JSON_PRESERVE_ORDER|JSON_COMPACT|JSON_ENSURE_ASCII|
-            JSON_ESCAPE_SLASH);
-    snprintf(buffer, buffer_size, "%s", js_s);
-    free(js_s);
-
-    json_object_del(js, "engine");
-    json_object_clear(js);
-    json_decref(js);
+    jb_free(js);
 
     return 0;
+
 error:
     return -1;
 }

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -324,7 +324,7 @@ static const char *SCTransformModule(const char *module_name, int *dn_len)
 
     char *last;
     char *w = (char *)module_name;
-    while (w && (w = index(w, '-')) != NULL && seg_cnt < max_segs) {
+    while (w && (w = strchr(w, '-')) != NULL && seg_cnt < max_segs) {
         seg_cnt++;
         last = w;
         w++; /* skip past '-' */

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -72,12 +72,20 @@ SCEnumCharMap sc_log_op_iface_map[ ] = {
     { NULL,             -1 }
 };
 
+/* TLS values to track thread name (length) */
+__thread const char *_sc_subsystem;
+
 #if defined (OS_WIN32)
 /**
  * \brief Used for synchronous output on WIN32
  */
 static SCMutex sc_log_stream_lock;
 #endif /* OS_WIN32 */
+
+/**
+ * \brief Transform the module name into display module name for logging
+ */
+static const char *SCTransformModule(const char *module_name, int *dn_len);
 
 /**
  * \brief Holds the config state for the logging module
@@ -203,9 +211,8 @@ static inline void SCLogPrintToSyslog(int syslog_log_level, const char *msg)
 /**
  */
 static int SCLogMessageJSON(struct timeval *tval, char *buffer, size_t buffer_size,
-        SCLogLevel log_level, const char *file,
-        unsigned line, const char *function, SCError error_code,
-        const char *message)
+        SCLogLevel log_level, const char *file, unsigned line, const char *function,
+        const char *module, SCError error_code, const char *message)
 {
     json_t *js = json_object();
     if (unlikely(js == NULL))
@@ -235,6 +242,18 @@ static int SCLogMessageJSON(struct timeval *tval, char *buffer, size_t buffer_si
     if (message)
         json_object_set_new(ejs, "message", json_string(message));
 
+    if (_sc_subsystem) {
+        json_object_set_new(ejs, "subsystem", json_string(_sc_subsystem));
+    }
+
+    if (module) {
+        /* Determine how much of module name to display */
+        int dn_len = 0;
+        const char *dn_name;
+        dn_name = SCTransformModule(module, &dn_len);
+        json_object_set_new(ejs, "module", json_string(dn_name));
+    }
+
     if (log_level >= SC_LOG_DEBUG) {
         if (function)
             json_object_set_new(ejs, "function", json_string(function));
@@ -263,6 +282,62 @@ error:
     return -1;
 }
 
+/*
+ * \brief Return a display name for the given module name for logging.
+ *
+ * The transformation is dependent upon the source code module names
+ * that use the dash character to separate incremental refinements of
+ * the subsystem.
+ *
+ * The transformation uses the local constant "max_segs" to determine
+ * how many segments to display; the transformed name will never consist
+ * of more than this many segments.
+ *
+ * E.g., "detect-http-content-len" ==> "detect-http" when the max is 2
+ *
+ * \param module_name The source code module name to be transformed.
+ * \param dn_len The number of characters in the display name to print.
+ *
+ * \retval Pointer to the display name
+ */
+static const char *SCTransformModule(const char *module_name, int *dn_len)
+{
+    /*
+     * special case for source code module names beginning with
+     * 	tm-*
+     *	util-*
+     *	source-*
+     */
+    if (strncmp("tm-", module_name, 3) == 0) {
+        *dn_len = strlen(module_name) - 3;
+        return module_name + 3;
+    } else if (strncmp("util-", module_name, 5) == 0) {
+        *dn_len = strlen(module_name) - 5;
+        return module_name + 5;
+    } else if (strncmp("source-", module_name, 7) == 0) {
+        *dn_len = strlen(module_name) - 7;
+        return module_name + 7;
+    }
+
+    const int max_segs = 2; /* The maximum segment count to display */
+    int seg_cnt = 0;
+
+    char *last;
+    char *w = (char *)module_name;
+    while (w && (w = index(w, '-')) != NULL && seg_cnt < max_segs) {
+        seg_cnt++;
+        last = w;
+        w++; /* skip past '-' */
+    }
+
+    if (seg_cnt < max_segs)
+        *dn_len = strlen(module_name);
+    else
+        *dn_len = last - module_name;
+
+    return module_name;
+}
+
 /**
  * \brief Adds the global log_format to the outgoing buffer
  *
@@ -274,17 +349,15 @@ error:
  *
  * \retval SC_OK on success; else an error code
  */
-static SCError SCLogMessageGetBuffer(
-        struct timeval *tval, int color, SCLogOPType type,
-                     char *buffer, size_t buffer_size,
-                     const char *log_format,
+static SCError SCLogMessageGetBuffer(struct timeval *tval, int color, SCLogOPType type,
+        char *buffer, size_t buffer_size, const char *log_format,
 
-                     const SCLogLevel log_level, const char *file,
-                     const unsigned int line, const char *function,
-                     const SCError error_code, const char *message)
+        const SCLogLevel log_level, const char *file, const unsigned int line, const char *function,
+        const char *module, const SCError error_code, const char *message)
 {
     if (type == SC_LOG_OP_TYPE_JSON)
-        return SCLogMessageJSON(tval, buffer, buffer_size, log_level, file, line, function, error_code, message);
+        return SCLogMessageJSON(tval, buffer, buffer_size, log_level, file, line, function, module,
+                error_code, message);
 
     char *temp = buffer;
     const char *s = NULL;
@@ -438,6 +511,28 @@ static SCError SCLogMessageGetBuffer(
                 substr++;
                 break;
 
+            case SC_LOG_FMT_SUBSYSTEM:
+                temp_fmt[0] = '\0';
+
+                /* Determine how much of module name to display */
+                int dn_len = 0;
+                const char *dn_name;
+                if (module) {
+                    dn_name = SCTransformModule(module, &dn_len);
+                }
+
+                cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer), "%s%s%s%s%.*s%s",
+                        substr, green, _sc_subsystem == NULL ? "" : _sc_subsystem,
+                        _sc_subsystem == NULL ? "" : ":", dn_len, module == NULL ? "" : dn_name,
+                        reset);
+                if (cw < 0)
+                    return SC_ERR_SPRINTF;
+                temp += cw;
+                temp_fmt++;
+                substr = temp_fmt;
+                substr++;
+                break;
+
             case SC_LOG_FMT_FUNCTION:
                 temp_fmt[0] = '\0';
                 cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer),
@@ -450,6 +545,24 @@ static SCError SCLogMessageGetBuffer(
                 substr++;
                 break;
 
+            case SC_LOG_FMT_ERRCODE:
+                temp_fmt[0] = '\0';
+                if (SC_OK != error_code) {
+                    cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer),
+                            "%s[%sERRCODE%s: %s%s%s(%s%d%s)] - ", substr, yellow, reset, red,
+                            SCErrorToString(error_code), reset, yellow, error_code, reset);
+                    if (cw < 0)
+                        return SC_ERR_SPRINTF;
+                } else {
+                    cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer), "%s", substr);
+                    if (cw < 0)
+                        return SC_ERR_SPRINTF;
+                }
+                temp += cw;
+                temp_fmt++;
+                substr = temp_fmt;
+                substr++;
+                break;
         }
         temp_fmt++;
 	}
@@ -463,18 +576,6 @@ static SCError SCLogMessageGetBuffer(
     temp += cw;
     if ((temp - buffer) > SC_LOG_MAX_LOG_MSG_LEN) {
         return SC_OK;
-    }
-
-    if (error_code != SC_OK) {
-        cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer),
-                "[%sERRCODE%s: %s%s%s(%s%d%s)] - ", yellow, reset, red, SCErrorToString(error_code), reset, yellow, error_code, reset);
-        if (cw < 0) {
-            return SC_ERR_SPRINTF;
-        }
-        temp += cw;
-        if ((temp - buffer) > SC_LOG_MAX_LOG_MSG_LEN) {
-            return SC_OK;
-        }
     }
 
     const char *hi = "";
@@ -538,9 +639,8 @@ static int SCLogReopen(SCLogOPIfaceCtx *op_iface_ctx)
  *
  * \retval SC_OK on success; else an error code
  */
-SCError SCLogMessage(const SCLogLevel log_level, const char *file,
-                     const unsigned int line, const char *function,
-                     const SCError error_code, const char *message)
+SCError SCLogMessage(const SCLogLevel log_level, const char *file, const unsigned int line,
+        const char *function, const char *module, const SCError error_code, const char *message)
 {
     char buffer[SC_LOG_MAX_LOG_MSG_LEN] = "";
     SCLogOPIfaceCtx *op_iface_ctx = NULL;
@@ -565,22 +665,18 @@ SCError SCLogMessage(const SCLogLevel log_level, const char *file,
         switch (op_iface_ctx->iface) {
             case SC_LOG_OP_IFACE_CONSOLE:
                 if (SCLogMessageGetBuffer(&tval, op_iface_ctx->use_color, op_iface_ctx->type,
-                                          buffer, sizeof(buffer),
-                                          op_iface_ctx->log_format ?
-                                              op_iface_ctx->log_format : sc_log_config->log_format,
-                                          log_level, file, line, function,
-                                          error_code, message) == 0)
-                {
+                            buffer, sizeof(buffer),
+                            op_iface_ctx->log_format ? op_iface_ctx->log_format
+                                                     : sc_log_config->log_format,
+                            log_level, file, line, function, module, error_code, message) == 0) {
                     SCLogPrintToStream((log_level == SC_LOG_ERROR)? stderr: stdout, buffer);
                 }
                 break;
             case SC_LOG_OP_IFACE_FILE:
                 if (SCLogMessageGetBuffer(&tval, 0, op_iface_ctx->type, buffer, sizeof(buffer),
-                                          op_iface_ctx->log_format ?
-                                              op_iface_ctx->log_format : sc_log_config->log_format,
-                                          log_level, file, line, function,
-                                          error_code, message) == 0)
-                {
+                            op_iface_ctx->log_format ? op_iface_ctx->log_format
+                                                     : sc_log_config->log_format,
+                            log_level, file, line, function, module, error_code, message) == 0) {
                     int r = 0;
                     SCMutexLock(&op_iface_ctx->fp_mutex);
                     if (op_iface_ctx->rotation_flag) {
@@ -599,11 +695,9 @@ SCError SCLogMessage(const SCLogLevel log_level, const char *file,
                 break;
             case SC_LOG_OP_IFACE_SYSLOG:
                 if (SCLogMessageGetBuffer(&tval, 0, op_iface_ctx->type, buffer, sizeof(buffer),
-                                          op_iface_ctx->log_format ?
-                                              op_iface_ctx->log_format : sc_log_config->log_format,
-                                          log_level, file, line, function,
-                                          error_code, message) == 0)
-                {
+                            op_iface_ctx->log_format ? op_iface_ctx->log_format
+                                                     : sc_log_config->log_format,
+                            log_level, file, line, function, module, error_code, message) == 0) {
                     SCLogPrintToSyslog(SCLogMapLogLevelToSyslogLevel(log_level), buffer);
                 }
                 break;
@@ -615,7 +709,7 @@ SCError SCLogMessage(const SCLogLevel log_level, const char *file,
     return SC_OK;
 }
 
-void SCLog(int x, const char *file, const char *func, const int line,
+void SCLog(int x, const char *file, const char *func, const int line, const char *module,
         const char *fmt, ...)
 {
     if (sc_log_global_log_level >= x &&
@@ -630,11 +724,11 @@ void SCLog(int x, const char *file, const char *func, const int line,
         va_start(ap, fmt);
         vsnprintf(msg, sizeof(msg), fmt, ap);
         va_end(ap);
-        SCLogMessage(x, file, line, func, SC_OK, msg);
+        SCLogMessage(x, file, line, func, module, SC_OK, msg);
     }
 }
 
-void SCLogErr(int x, const char *file, const char *func, const int line,
+void SCLogErr(int x, const char *file, const char *func, const int line, const char *module,
         const int err, const char *fmt, ...)
 {
     if (sc_log_global_log_level >= x &&
@@ -649,7 +743,7 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
         va_start(ap, fmt);
         vsnprintf(msg, sizeof(msg), fmt, ap);
         va_end(ap);
-        SCLogMessage(x, file, line, func, err, msg);
+        SCLogMessage(x, file, line, func, module, err, msg);
     }
 }
 

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -341,14 +341,10 @@ static const char *SCTransformModule(const char *module_name, int *dn_len)
  *
  * \retval SC_OK on success; else an error code
  */
-static SCError SCLogMessageGetBuffer(
-        struct timeval *tval, int color, SCLogOPType type,
-                     char *buffer, size_t buffer_size,
-                     const char *log_format,
-                     const SCLogLevel log_level, const char *file,
-                     const unsigned int line, const char *function,
-                     const char *module, const SCError error_code,
-                     const char *message)
+static SCError SCLogMessageGetBuffer(struct timeval *tval, int color, SCLogOPType type,
+        char *buffer, size_t buffer_size, const char *log_format, const SCLogLevel log_level,
+        const char *file, const unsigned int line, const char *function, const char *module,
+        const SCError error_code, const char *message)
 {
     if (type == SC_LOG_OP_TYPE_JSON)
         return SCLogMessageJSON(tval, buffer, buffer_size, log_level, file, line, function, module,

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -79,8 +79,12 @@ typedef enum {
 } SCLogOPType;
 
 /* The default log_format, if it is not supplied by the user */
-#define SC_LOG_DEF_LOG_FORMAT_REL "%t - <%d> - "
-#define SC_LOG_DEF_LOG_FORMAT_DEV "[%i] %t - (%f:%l) <%d> (%n) -- "
+#define SC_LOG_DEF_LOG_FORMAT_REL "%t [%S] - <%d> - "
+#ifdef DEBUG
+#define SC_LOG_DEF_LOG_FORMAT_DEV "[%i] %t [%S] - (%f:%l) <%d> (%n) -- %E"
+#else
+#define SC_LOG_DEF_LOG_FORMAT_DEV "[%i] %t [%S] - <%d> -- %E"
+#endif
 
 /* The maximum length of the log message */
 #define SC_LOG_MAX_LOG_MSG_LEN 2048
@@ -194,9 +198,32 @@ typedef struct SCLogConfig_ {
 #define SC_LOG_FMT_FILE_NAME        'f' /* File name */
 #define SC_LOG_FMT_LINE             'l' /* Line number */
 #define SC_LOG_FMT_FUNCTION         'n' /* Function */
+#define SC_LOG_FMT_SUBSYSTEM        'S' /* Subsystem name */
+#define SC_LOG_FMT_ERRCODE          'E' /* Error code */
 
 /* The log format prefix for the format specifiers */
 #define SC_LOG_FMT_PREFIX           '%'
+
+/* Module and thread tagging */
+/* The module name, usually the containing source-module name */
+static const char *_sc_module __attribute__((unused)) = __SCFILENAME__;
+
+#define _SC_SUBSYSTEM_NAME_LEN 16
+/* The subsystem name, usually the thread's name */
+#define SCClearSubsystem()                                                                         \
+    do {                                                                                           \
+        extern __thread const char *_sc_subsystem;                                                 \
+        if (_sc_subsystem != NULL)                                                                 \
+            free((void *)_sc_subsystem);                                                           \
+        _sc_subsystem = NULL;                                                                      \
+    } while (0)
+
+#define SCSetSubsystem(subsystem_name)                                                             \
+    do {                                                                                           \
+        extern __thread const char *_sc_subsystem;                                                 \
+        size_t sn_len = strnlen(subsystem_name, _SC_SUBSYSTEM_NAME_LEN);                           \
+        _sc_subsystem = SCStrndup(subsystem_name, sn_len);                                         \
+    } while (0)
 
 extern SCLogLevel sc_log_global_log_level;
 
@@ -204,35 +231,33 @@ extern int sc_log_module_initialized;
 
 extern int sc_log_module_cleaned;
 
-void SCLog(int x, const char *file, const char *func, const int line,
-        const char *fmt, ...) ATTR_FMT_PRINTF(5,6);
-void SCLogErr(int x, const char *file, const char *func, const int line,
-        const int err, const char *fmt, ...) ATTR_FMT_PRINTF(6,7);
+void SCLog(int x, const char *file, const char *func, const int line, const char *module,
+        const char *fmt, ...) ATTR_FMT_PRINTF(6, 7);
+void SCLogErr(int x, const char *file, const char *func, const int line, const char *module,
+        const int err, const char *fmt, ...) ATTR_FMT_PRINTF(7, 8);
 
 /**
  * \brief Macro used to log INFORMATIONAL messages.
  *
  * \retval ... Takes as argument(s), a printf style format message
  */
-#define SCLogInfo(...) SCLog(SC_LOG_INFO, \
-        __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
-#define SCLogInfoRaw(file, func, line, ...) SCLog(SC_LOG_INFO, \
-        (file), (func), (line), __VA_ARGS__)
+#define SCLogInfo(...) SCLog(SC_LOG_INFO, __FILE__, __FUNCTION__, __LINE__, _sc_module, __VA_ARGS__)
+#define SCLogInfoRaw(file, func, line, ...)                                                        \
+    SCLog(SC_LOG_INFO, (file), (func), (line), _sc_module, __VA_ARGS__)
 
-#define SCLogConfig(...) SCLog(SC_LOG_CONFIG, \
-        __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
-#define SCLogPerf(...) SCLog(SC_LOG_PERF, \
-        __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+#define SCLogConfig(...)                                                                           \
+    SCLog(SC_LOG_CONFIG, __FILE__, __FUNCTION__, __LINE__, _sc_module, __VA_ARGS__)
+#define SCLogPerf(...) SCLog(SC_LOG_PERF, __FILE__, __FUNCTION__, __LINE__, _sc_module, __VA_ARGS__)
 
 /**
  * \brief Macro used to log NOTICE messages.
  *
  * \retval ... Takes as argument(s), a printf style format message
  */
-#define SCLogNotice(...) SCLog(SC_LOG_NOTICE, \
-        __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
-#define SCLogNoticeRaw(file, func, line, ... ) SCLog(SC_LOG_NOTICE, \
-        (file), (func), (line), __VA_ARGS__)
+#define SCLogNotice(...)                                                                           \
+    SCLog(SC_LOG_NOTICE, __FILE__, __FUNCTION__, __LINE__, _sc_module, __VA_ARGS__)
+#define SCLogNoticeRaw(file, func, line, ...)                                                      \
+    SCLog(SC_LOG_NOTICE, (file), (func), (line), _sc_module, __VA_ARGS__)
 
 /**
  * \brief Macro used to log WARNING messages.
@@ -241,11 +266,10 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
  *                  warning message
  * \retval ...      Takes as argument(s), a printf style format message
  */
-#define SCLogWarning(err_code, ...) SCLogErr(SC_LOG_WARNING, \
-        __FILE__, __FUNCTION__, __LINE__, \
-        err_code, __VA_ARGS__)
-#define SCLogWarningRaw(err_code, file, func, line, ...) \
-    SCLogErr(SC_LOG_WARNING, (file), (func), (line), err_code, __VA_ARGS__)
+#define SCLogWarning(err_code, ...)                                                                \
+    SCLogErr(SC_LOG_WARNING, __FILE__, __FUNCTION__, __LINE__, _sc_module, err_code, __VA_ARGS__)
+#define SCLogWarningRaw(err_code, file, func, line, ...)                                           \
+    SCLogErr(SC_LOG_WARNING, (file), (func), (line), _sc_module, err_code, __VA_ARGS__)
 
 /**
  * \brief Macro used to log ERROR messages.
@@ -254,11 +278,10 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
  *                  error message
  * \retval ...      Takes as argument(s), a printf style format message
  */
-#define SCLogError(err_code, ...) SCLogErr(SC_LOG_ERROR, \
-        __FILE__, __FUNCTION__, __LINE__, \
-        err_code, __VA_ARGS__)
-#define SCLogErrorRaw(err_code, file, func, line, ...) SCLogErr(SC_LOG_ERROR, \
-        (file), (func), (line), err_code, __VA_ARGS__)
+#define SCLogError(err_code, ...)                                                                  \
+    SCLogErr(SC_LOG_ERROR, __FILE__, __FUNCTION__, __LINE__, _sc_module, err_code, __VA_ARGS__)
+#define SCLogErrorRaw(err_code, file, func, line, ...)                                             \
+    SCLogErr(SC_LOG_ERROR, (file), (func), (line), _sc_module, err_code, __VA_ARGS__)
 
 /**
  * \brief Macro used to log CRITICAL messages.
@@ -267,9 +290,8 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
  *                  critical message
  * \retval ...      Takes as argument(s), a printf style format message
  */
-#define SCLogCritical(err_code, ...) SCLogErr(SC_LOG_CRITICAL, \
-        __FILE__, __FUNCTION__, __LINE__, \
-        err_code, __VA_ARGS__)
+#define SCLogCritical(err_code, ...)                                                               \
+    SCLogErr(SC_LOG_CRITICAL, __FILE__, __FUNCTION__, __LINE__, _sc_module, err_code, __VA_ARGS__)
 /**
  * \brief Macro used to log ALERT messages.
  *
@@ -277,9 +299,8 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
  *                  alert message
  * \retval ...      Takes as argument(s), a printf style format message
  */
-#define SCLogAlert(err_code, ...) SCLogErr(SC_LOG_ALERT, \
-        __FILE__, __FUNCTION__, __LINE__, \
-        err_code, __VA_ARGS__)
+#define SCLogAlert(err_code, ...)                                                                  \
+    SCLogErr(SC_LOG_ALERT, __FILE__, __FUNCTION__, __LINE__, _sc_module, err_code, __VA_ARGS__)
 /**
  * \brief Macro used to log EMERGENCY messages.
  *
@@ -287,10 +308,8 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
  *                  emergency message
  * \retval ...      Takes as argument(s), a printf style format message
  */
-#define SCLogEmerg(err_code, ...) SCLogErr(SC_LOG_EMERGENCY, \
-        __FILE__, __FUNCTION__, __LINE__, \
-        err_code, __VA_ARGS__)
-
+#define SCLogEmerg(err_code, ...)                                                                  \
+    SCLogErr(SC_LOG_EMERGENCY, __FILE__, __FUNCTION__, __LINE__, _sc_module, err_code, __VA_ARGS__)
 
 /* Avoid the overhead of using the debugging subsystem, in production mode */
 #ifndef DEBUG
@@ -329,7 +348,8 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
  *
  * \retval ... Takes as argument(s), a printf style format message
  */
-#define SCLogDebug(...)       SCLog(SC_LOG_DEBUG, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+#define SCLogDebug(...)                                                                            \
+    SCLog(SC_LOG_DEBUG, __FILE__, __FUNCTION__, __LINE__, _sc_module, __VA_ARGS__)
 
 /**
  * \brief Macro used to log debug messages on function entry.  Comes under the
@@ -347,10 +367,9 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
                                   }                                             \
                               } while(0)
 
-
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that don't return
@@ -366,7 +385,7 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns an
@@ -384,7 +403,7 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns an
@@ -402,7 +421,7 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns a
@@ -420,7 +439,7 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns a var
@@ -438,7 +457,7 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns a
@@ -457,10 +476,9 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
                                  return x;                                   \
                               } while(0)
 
-
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns a var
@@ -481,7 +499,7 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
 
 /**
  * \brief Macro used to log debug messages on function exit.  Comes under the
- *        debugging sybsystem, and hence will be enabled only in the presence
+ *        debugging subsystem, and hence will be enabled only in the presence
  *        of the DEBUG macro.  Apart from logging function_exit logs, it also
  *        processes the FD filters, if any FD filters are registered.  This
  *        function_exit macro should be used for functions that returns a
@@ -564,8 +582,8 @@ void SCLogInitLogModule(SCLogInitData *);
 
 void SCLogDeInitLogModule(void);
 
-SCError SCLogMessage(const SCLogLevel, const char *, const unsigned int,
-                     const char *, const SCError, const char *message);
+SCError SCLogMessage(const SCLogLevel, const char *, const unsigned int, const char *, const char *,
+        const SCError, const char *message);
 
 SCLogOPBuffer *SCLogAllocLogOPBuffer(void);
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -543,7 +543,7 @@ logging:
   # output section.  You can leave this out to get the default.
   #
   # This value is overridden by the SC_LOG_FORMAT env var.
-  #default-log-format: "[%i] %t - (%f:%l) <%d> (%n) -- "
+  #default-log-format: "[%i] %t [%S] - (%f:%l) <%d> (%n) -- "
 
   # A regex to filter output.  Can be overridden in an output section.
   # Defaults to empty (no filter).

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -542,7 +542,7 @@ logging:
   # something reasonable if not provided.  Can be overridden in an
   # output section.  You can leave this out to get the default.
   #
-  # This value is overridden by the SC_LOG_FORMAT env var.
+  # This console log format value can be  overridden by the SC_LOG_FORMAT env var.
   #default-log-format: "[%i] %t [%S] - (%f:%l) <%d> (%n) -- "
 
   # A regex to filter output.  Can be overridden in an output section.


### PR DESCRIPTION
Continuation of #6022

This changeset provides subsystem and module identifiers in the log when
the log format string contains `"%S"`. By convention, the log format
surrounds `"%S"` with brackets.

The subsystem name is generally the same as the thread name. The module
name is derived from the source code module name and usually consists of
the first one or 2 segments of the name using the dash character as the
segment delimiter.

Issue 2497: [redmine](https://redmine.openinfosecfoundation.org/issues/2497)

@jasonish suggested formatting changes -- those have been incorporated into this PR. See below for example output for non-debug and debug modes.

Updates:
1. Clang-format fixups

Describe changes:
This PR adds a subsystem and module identifier to SCLog messages when the log format includes `%S`. Subsystem and module identifiers are intrinsic properties of threads and source code modules (respectively).

New threads are assigned a subsystem identifier when the thread is created; the identifier is a Thread-Local-Storage variable declared in util-debug.c; values are assigned to it as threads are created using SCSetSubsystem (a macro defined in util-debug.h).

Module identifiers are derived from the source code module emitting the log message. A new CPP define `__SCFILENAME__` is assigned to `_sc_module` (`util-debug.h`) at compile time. Rust source module names are determined dynamically during the calls to the log function.

Subsystem and module identifiers are added to log messages when the format contains `%S`. The generated log message will substitute a tag built from

- The subsystem identifier. This corresponds to the calling thread which may be the Suricata main thread, or a subordinate thread for a task-specific function, e.g., `RX#01`.
- (Optional) The module identifier will be included if set (not all source modules will set one but most source modules have been modified to set one.)
The constructed tag is of the form `subsystem-id[:module-identifier]` (the brackets surrounding the module-identifier indicate the module-identifier is optional and are not included in the output; output formatting is strictly controlled by the log format in effect).

Also, two travis related changes are included in this PR
1. Update Travis to use Xenial (16.04) rather than Trusty (14.04)
1. Update to display config.log when Travis build errors occur.

Example output
Non-debug mode
```
[2182243] 5/4/2021 -- 08:32:51 [Suricata-main:suricata] - <Notice> -- This is Suricata version 7.0.0-dev running in USER mode
[2182243] 5/4/2021 -- 08:32:51 [Suricata-main:cpu] - <Info> -- CPUs/cores online: 16
[2182243] 5/4/2021 -- 08:32:52 [Suricata-main:coredump-config] - <Info> -- Could not set core dump size to unlimited; it's set to the hard limit.
[2182243] 5/4/2021 -- 08:32:52 [Suricata-main:logopenfile] - <Info> -- fast output device (regular) initialized: fast.log
[2182243] 5/4/2021 -- 08:32:52 [Suricata-main:logopenfile] - <Info> -- eve-log output device (regular) initialized: eve.json
[2182243] 5/4/2021 -- 08:32:52 [Suricata-main:logopenfile] - <Info> -- stats output device (regular) initialized: stats.log
[2182243] 5/4/2021 -- 08:32:52 [Suricata-main:classification-config] - <Info> -- Added "43" classification types from the classification file
[2182243] 5/4/2021 -- 08:32:52 [Suricata-main:reference-config] - <Info> -- Added "19" reference types from the reference.config file
[2182243] 5/4/2021 -- 08:32:56 [Suricata-main:detect-parse] - <Error> -- [ERRCODE: SC_ERR_INVALID_SIGNATURE(39)] - unexpected option to http_header_names keyword: 'http_header_names'
[2182243] 5/4/2021 -- 08:32:56 [Suricata-main:detect-engine] - <Error> -- [ERRCODE: SC_ERR_INVALID_SIGNATURE(39)] - error parsing signature "alert http $HOME_NET any -> $EXTERNAL_NET any (msg:"ET MALWARE Win32/Adware.Adposhel.A Checkin M6"; flow:established,to_server; content:"GET"; http_method; urilen:>200; content:"/q/?q="; http_uri; depth:6; fast_pattern; pcre:"/^[a-zA-Z0-9_-]+/UR"; content:"User-Agent|3a 20|"; http_user_agent; depth:12; http_header_names: content:!"Referer"; content:!"Accept"; metadata: former_category ADWARE_PUP; classtype:trojan-activity; sid:2029055; rev:2; metadata:affected_product Windows_XP_Vista_7_8_10_Server_32_64_Bit, attack_target Client_Endpoint, deployment Perimeter, signature_severity Major, created_at 2019_11_26, performance_impact Low, updated_at 2019_11_26;)" from file /home/jlucovsky/et.rules at line 19714
[2182243] 5/4/2021 -- 08:33:13 [Suricata-main:detect-engine] - <Info> -- 1 rule files processed. 19187 rules successfully loaded, 1 rules failed
[2182243] 5/4/2021 -- 08:33:13 [Suricata-main:threshold-config] - <Warning> -- [ERRCODE: SC_ERR_FOPEN(44)] - Error opening file: "/usr/local/etc/suricata//threshold.config": Permission denied
[2182243] 5/4/2021 -- 08:33:13 [Suricata-main:detect-engine] - <Info> -- 19190 signatures processed. 1094 are IP-only rules, 3860 are inspecting packet payload, 14179 inspect application layer, 0 are decoder event only
[2182716] 5/4/2021 -- 08:33:53 [RX#01:pcap-file] - <Info> -- Argument /home/jlucovsky/pcap/ was a directory
[2182243] 5/4/2021 -- 08:33:53 [Suricata-main:threads] - <Notice> -- Threads created -> RX: 1 W: 16 FM: 1 FR: 1   Engine started.
[2182716] 5/4/2021 -- 08:33:53 [RX#01:pcap-file] - <Info> -- Starting directory run for /home/jlucovsky/pcap/
```

Debug mode
```
[2102717] 5/4/2021 -- 08:18:43 [Suricata-main:suricata] - (suricata.c:1062) <Notice> (LogVersion) -- This is Suricata version 7.0.0-dev running in USER mode
[2102717] 5/4/2021 -- 08:18:43 [Suricata-main:cpu] - (util-cpu.c:178) <Info> (UtilCpuPrintSummary) -- CPUs/cores online: 16
[2102717] 5/4/2021 -- 08:18:43 [Suricata-main:coredump-config] - (util-coredump-config.c:166) <Info> (CoredumpLoadConfig) -- Could not set core dump size to unlimited; it's set to the hard limit.
[2102717] 5/4/2021 -- 08:18:43 [Suricata-main:logopenfile] - (util-logopenfile.c:596) <Info> (SCConfLogOpenGeneric) -- fast output device (regular) initialized: fast.log
[2102717] 5/4/2021 -- 08:18:43 [Suricata-main:logopenfile] - (util-logopenfile.c:596) <Info> (SCConfLogOpenGeneric) -- eve-log output device (regular) initialized: eve.json
[2102717] 5/4/2021 -- 08:18:43 [Suricata-main:logopenfile] - (util-logopenfile.c:596) <Info> (SCConfLogOpenGeneric) -- stats output device (regular) initialized: stats.log
[2102717] 5/4/2021 -- 08:18:43 [Suricata-main:classification-config] - (util-classification-config.c:363) <Info> (SCClassConfParseFile) -- Added "43" classification types from the classification file
[2102717] 5/4/2021 -- 08:18:43 [Suricata-main:reference-config] - (util-reference-config.c:339) <Info> (SCRConfParseFile) -- Added "19" reference types from the reference.config file
[2102717] 5/4/2021 -- 08:18:47 [Suricata-main:detect-parse] - (detect-parse.c:714) <Error> (SigParseOptions) -- [ERRCODE: SC_ERR_INVALID_SIGNATURE(39)] - unexpected option to http_header_names keyword: 'http_header_names'
[2102717] 5/4/2021 -- 08:18:47 [Suricata-main:detect-engine] - (detect-engine-loader.c:184) <Error> (DetectLoadSigFile) -- [ERRCODE: SC_ERR_INVALID_SIGNATURE(39)] - error parsing signature "alert http $HOME_NET any -> $EXTERNAL_NET any (msg:"ET MALWARE Win32/Adware.Adposhel.A Checkin M6"; flow:established,to_server; content:"GET"; http_method; urilen:>200; content:"/q/?q="; http_uri; depth:6; fast_pattern; pcre:"/^[a-zA-Z0-9_-]+/UR"; content:"User-Agent|3a 20|"; http_user_agent; depth:12; http_header_names: content:!"Referer"; content:!"Accept"; metadata: former_category ADWARE_PUP; classtype:trojan-activity; sid:2029055; rev:2; metadata:affected_product Windows_XP_Vista_7_8_10_Server_32_64_Bit, attack_target Client_Endpoint, deployment Perimeter, signature_severity Major, created_at 2019_11_26, performance_impact Low, updated_at 2019_11_26;)" from file /home/jlucovsky/et.rules at line 19714
[2102717] 5/4/2021 -- 08:19:05 [Suricata-main:detect-engine] - (detect-engine-loader.c:354) <Info> (SigLoadSignatures) -- 1 rule files processed. 19187 rules successfully loaded, 1 rules failed
[2102717] 5/4/2021 -- 08:19:05 [Suricata-main:threshold-config] - (util-threshold-config.c:250) <Warning> (SCThresholdConfInitContext) -- [ERRCODE: SC_ERR_FOPEN(44)] - Error opening file: "/usr/local/etc/suricata//threshold.config": Permission denied
[2102717] 5/4/2021 -- 08:19:06 [Suricata-main:detect-engine] - (detect-engine-build.c:1416) <Info> (SigAddressPrepareStage1) -- 19190 signatures processed. 1094 are IP-only rules, 3860 are inspecting packet payload, 14179 inspect application layer, 0 are decoder event only
[2103193] 5/4/2021 -- 08:19:45 [RX#01:pcap-file] - (source-pcap-file.c:276) <Info> (ReceivePcapFileThreadInit) -- Argument /home/jlucovsky/pcap/ was a directory
[2102717] 5/4/2021 -- 08:19:46 [Suricata-main:threads] - (tm-threads.c:2020) <Notice> (TmThreadWaitOnThreadInit) -- Threads created -> RX: 1 W: 16 FM: 1 FR: 1   Engine started.
[2103193] 5/4/2021 -- 08:19:46 [RX#01:pcap-file] - (source-pcap-file.c:177) <Info> (ReceivePcapFileLoop) -- Starting directory run for /home/jlucovsky/pcap/
```

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
