### PR TITLE
http2: pass data through when decompression fails

### DIFF
--- a/rust/src/http2/decompression.rs
+++ b/rust/src/http2/decompression.rs
@@ -172,10 +172,24 @@ impl HTTP2DecoderHalf {
     ) -> io::Result<&'a [u8]> {
         match self.decoder {
             HTTP2Decompresser::GZIP(ref mut gzip_decoder) => {
-                return http2_decompress(gzip_decoder, input, output);
+                let r = http2_decompress(gzip_decoder, input, output);
+                match r {
+                    Err(_) => {
+                        self.decoder = HTTP2Decompresser::UNASSIGNED;
+                    }
+                    _ => {}
+                }
+                return r;
             }
             HTTP2Decompresser::BROTLI(ref mut br_decoder) => {
-                return http2_decompress(br_decoder, input, output);
+                let r = http2_decompress(br_decoder, input, output);
+                match r {
+                    Err(_) => {
+                        self.decoder = HTTP2Decompresser::UNASSIGNED;
+                    }
+                    _ => {}
+                }
+                return r;
             }
             _ => {}
         }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4277

Describe changes:
- Strop decompression and pass data through in case of a decompression error (as is done for HTTP1)