### PR TITLE
Fuzz protocols v2

### DIFF
--- a/src/tests/fuzz/confyaml.c
+++ b/src/tests/fuzz/confyaml.c
@@ -8,6 +8,7 @@ pcap-file:\n\
 stream:\n\
 \n\
   checksum-validation: no\n\
+  midstream: true\n\
 outputs:\n\
   - fast:\n\
       enabled: yes\n\


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4125

Describe changes:
- Make fuzz target about app-layer force a protocol based on its name

So that oss-fuzz can have one fuzz target for each protocol, just by copying and using another name
Tested with my oss-fuzz branch suricataproto

Modifies #6007 by adding `stream.midstream = true` especially for fuzz_sigpcap