### PR TITLE
Protodetect enip dns 4388 v4

### DIFF
--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -1742,7 +1742,7 @@ pub fn nfs_probe(i: &[u8], direction: u8) -> i8 {
                    rpc.program == 100003 &&
                    rpc.procedure <= NFSPROC3_COMMIT
                 {
-                    return 1;
+                    return rpc_auth_type_known(rpc.creds_flavor);
                 } else {
                     return -1;
                 }

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -177,6 +177,14 @@ pub fn rpc_auth_type_string(auth_type: u32) -> String {
     }.to_string()
 }
 
+pub fn rpc_auth_type_known(auth_type: u32) -> i8 {
+    // RPCAUTH_GSS is the maximum
+    if auth_type <= RPCAUTH_GSS {
+        return 1;
+    }
+    return -1;
+}
+
 /* http://www.iana.org/assignments/rpc-authentication-numbers/rpc-authentication-numbers.xhtml */
 pub const RPCAUTH_OK:                   u32 = 0;  // success/failed at remote end    [RFC5531]
 pub const RPCAUTH_BADCRED:              u32 = 1;  // bad credential (seal broken)    [RFC5531]


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4388

Describe changes:
- Improves probing parsers for nfs, enip and dns

so as to avoid protocol detection confusion with TCP splitting