### PR TITLE
http2: adds check about dynamic headers table size

### DIFF
--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -564,7 +564,9 @@ fn http2_parse_headers_block_dynamic_size<'a>(
     if (maxsize2 as usize) < dyn_headers.max_size {
         //dyn_headers.max_size is updated later with all headers
         //may evict entries
-        while dyn_headers.current_size > (maxsize2 as usize) {
+        while dyn_headers.current_size > (maxsize2 as usize) && dyn_headers.table.len() > 0 {
+            // we check dyn_headers.table as we may be in best effort
+            // because the previous maxsize was too big for us to retain all the headers
             dyn_headers.current_size -=
                 32 + dyn_headers.table[0].name.len() + dyn_headers.table[0].value.len();
             dyn_headers.table.remove(0);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4400

Describe changes:
- adds check about dynamic headers table size