### PR TITLE
Next/20210409/v5

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -1066,11 +1066,6 @@ pub extern "C" fn rs_dns_apply_tx_config(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_dns_init(proto: AppProto) {
-    ALPROTO_DNS = proto;
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn rs_dns_udp_register_parser() {
     let default_port = std::ffi::CString::new("[53]").unwrap();
     let parser = RustParser{

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -227,19 +227,6 @@ pub extern "C" fn rs_http2_tx_get_next_window(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_parse_settingsid(
-    str: *const std::os::raw::c_char,
-) -> std::os::raw::c_int {
-    let ft_name: &CStr = CStr::from_ptr(str); //unsafe
-    if let Ok(s) = ft_name.to_str() {
-        if let Ok(x) = parser::HTTP2SettingsId::from_str(s) {
-            return x as i32;
-        }
-    }
-    return -1;
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn rs_http2_detect_settingsctx_parse(
     str: *const std::os::raw::c_char,
 ) -> *mut std::os::raw::c_void {

--- a/src/app-layer-expectation.c
+++ b/src/app-layer-expectation.c
@@ -324,7 +324,7 @@ AppProto AppLayerExpectationHandle(Flow *f, uint8_t flags)
             alproto = exp->alproto;
             f->alproto_ts = alproto;
             f->alproto_tc = alproto;
-            void *fdata = FlowGetStorageById(f, g_expectation_id);
+            void *fdata = FlowGetStorageById(f, g_expectation_data_id);
             if (fdata) {
                 /* We already have an expectation so let's clean this one */
                 ExpectationDataFree(exp->data);

--- a/src/app-layer-expectation.c
+++ b/src/app-layer-expectation.c
@@ -64,7 +64,7 @@
 #include "queue.h"
 
 static int g_ippair_expectation_id = -1;
-static int g_flow_expectation_id = -1;
+static FlowStorageId g_flow_expectation_id = { .id = -1 };
 
 SC_ATOMIC_DECLARE(uint32_t, expectation_count);
 

--- a/src/app-layer-expectation.c
+++ b/src/app-layer-expectation.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2020 Open Information Security Foundation
+/* Copyright (C) 2017-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -38,7 +38,7 @@
  * AppLayerExpectationGetDataId():
  *
  * ```
- * data = (char *)FlowGetStorageById(f, AppLayerExpectationGetDataId());
+ * data = (char *)FlowGetStorageById(f, AppLayerExpectationGetFlowId());
  * ```
  * This storage can be used to store information that are only available in the
  * parent connection and could be useful in the parent connection. For instance
@@ -63,8 +63,8 @@
 #include "util-print.h"
 #include "queue.h"
 
-static int g_expectation_id = -1;
-static int g_expectation_data_id = -1;
+static int g_ippair_expectation_id = -1;
+static int g_flow_expectation_id = -1;
 
 SC_ATOMIC_DECLARE(uint32_t, expectation_count);
 
@@ -146,8 +146,10 @@ uint64_t ExpectationGetCounter(void)
 
 void AppLayerExpectationSetup(void)
 {
-    g_expectation_id = IPPairStorageRegister("expectation", sizeof(void *), NULL, ExpectationListFree);
-    g_expectation_data_id = FlowStorageRegister("expectation", sizeof(void *), NULL, ExpectationDataFree);
+    g_ippair_expectation_id =
+            IPPairStorageRegister("expectation", sizeof(void *), NULL, ExpectationListFree);
+    g_flow_expectation_id =
+            FlowStorageRegister("expectation", sizeof(void *), NULL, ExpectationDataFree);
     SC_ATOMIC_INIT(expectation_count);
 }
 
@@ -177,7 +179,7 @@ static ExpectationList *AppLayerExpectationLookup(Flow *f, IPPair **ipp)
         return NULL;
     }
 
-    return IPPairGetStorageById(*ipp, g_expectation_id);
+    return IPPairGetStorageById(*ipp, g_ippair_expectation_id);
 }
 
 
@@ -190,7 +192,7 @@ static ExpectationList *AppLayerExpectationRemove(IPPair *ipp,
     SC_ATOMIC_SUB(expectation_count, 1);
     exp_list->length--;
     if (exp_list->length == 0) {
-        IPPairSetStorageById(ipp, g_expectation_id, NULL);
+        IPPairSetStorageById(ipp, g_ippair_expectation_id, NULL);
         ExpectationListFree(exp_list);
         exp_list = NULL;
     }
@@ -240,7 +242,7 @@ int AppLayerExpectationCreate(Flow *f, int direction, Port src, Port dst,
     if (ipp == NULL)
         goto error;
 
-    exp_list = IPPairGetStorageById(ipp, g_expectation_id);
+    exp_list = IPPairGetStorageById(ipp, g_ippair_expectation_id);
     if (exp_list) {
         CIRCLEQ_INSERT_HEAD(&exp_list->list, exp, entries);
         /* In case there is already EXPECTATION_MAX_LEVEL expectations waiting to be fullfill,
@@ -262,7 +264,7 @@ int AppLayerExpectationCreate(Flow *f, int direction, Port src, Port dst,
         exp_list->length = 0;
         CIRCLEQ_INIT(&exp_list->list);
         CIRCLEQ_INSERT_HEAD(&exp_list->list, exp, entries);
-        IPPairSetStorageById(ipp, g_expectation_id, exp_list);
+        IPPairSetStorageById(ipp, g_ippair_expectation_id, exp_list);
     }
 
     exp_list->length += 1;
@@ -284,9 +286,9 @@ error:
  *
  * \return expectation data identifier
  */
-int AppLayerExpectationGetDataId(void)
+FlowStorageId AppLayerExpectationGetFlowId(void)
 {
-    return g_expectation_data_id;
+    return g_flow_expectation_id;
 }
 
 /**
@@ -324,13 +326,13 @@ AppProto AppLayerExpectationHandle(Flow *f, uint8_t flags)
             alproto = exp->alproto;
             f->alproto_ts = alproto;
             f->alproto_tc = alproto;
-            void *fdata = FlowGetStorageById(f, g_expectation_data_id);
+            void *fdata = FlowGetStorageById(f, g_flow_expectation_id);
             if (fdata) {
                 /* We already have an expectation so let's clean this one */
                 ExpectationDataFree(exp->data);
             } else {
                 /* Transfer ownership of Expectation data to the Flow */
-                if (FlowSetStorageById(f, g_expectation_data_id, exp->data) != 0) {
+                if (FlowSetStorageById(f, g_flow_expectation_id, exp->data) != 0) {
                     SCLogDebug("Unable to set flow storage");
                 }
             }

--- a/src/app-layer-expectation.h
+++ b/src/app-layer-expectation.h
@@ -28,7 +28,7 @@ void AppLayerExpectationSetup(void);
 int AppLayerExpectationCreate(Flow *f, int direction, Port src, Port dst,
                               AppProto alproto, void *data);
 AppProto AppLayerExpectationHandle(Flow *f, uint8_t flags);
-int AppLayerExpectationGetDataId(void);
+int AppLayerExpectationGetFlowId(void);
 
 void AppLayerExpectationClean(Flow *f);
 

--- a/src/app-layer-expectation.h
+++ b/src/app-layer-expectation.h
@@ -24,11 +24,13 @@
 #ifndef __APP_LAYER_EXPECTATION__H__
 #define __APP_LAYER_EXPECTATION__H__
 
+#include "flow-storage.h"
+
 void AppLayerExpectationSetup(void);
 int AppLayerExpectationCreate(Flow *f, int direction, Port src, Port dst,
                               AppProto alproto, void *data);
 AppProto AppLayerExpectationHandle(Flow *f, uint8_t flags);
-int AppLayerExpectationGetFlowId(void);
+FlowStorageId AppLayerExpectationGetFlowId(void);
 
 void AppLayerExpectationClean(Flow *f);
 

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1054,14 +1054,15 @@ static AppLayerResult FTPDataParse(Flow *f, FtpDataState *ftpdata_state,
     /* we depend on detection engine for file pruning */
     flags |= FILE_USE_DETECT;
     if (ftpdata_state->files == NULL) {
-        struct FtpTransferCmd *data = (struct FtpTransferCmd *)FlowGetStorageById(f, AppLayerExpectationGetDataId());
+        struct FtpTransferCmd *data =
+                (struct FtpTransferCmd *)FlowGetStorageById(f, AppLayerExpectationGetFlowId());
         if (data == NULL) {
             SCReturnStruct(APP_LAYER_ERROR);
         }
 
         ftpdata_state->files = FileContainerAlloc();
         if (ftpdata_state->files == NULL) {
-            FlowFreeStorageById(f, AppLayerExpectationGetDataId());
+            FlowFreeStorageById(f, AppLayerExpectationGetFlowId());
             SCReturnStruct(APP_LAYER_ERROR);
         }
 
@@ -1091,7 +1092,7 @@ static AppLayerResult FTPDataParse(Flow *f, FtpDataState *ftpdata_state,
             SCLogDebug("Can't open file");
             ret = -1;
         }
-        FlowFreeStorageById(f, AppLayerExpectationGetDataId());
+        FlowFreeStorageById(f, AppLayerExpectationGetFlowId());
     } else {
         if (input_len != 0) {
             ret = FileAppendData(ftpdata_state->files, input, input_len);

--- a/src/detect-engine-tag.c
+++ b/src/detect-engine-tag.c
@@ -46,7 +46,7 @@ SC_ATOMIC_DECLARE(unsigned int, num_tags);  /**< Atomic counter, to know if we
                                                  have tagged hosts/sessions,
                                                  to avoid locking */
 static int host_tag_id = -1;                /**< Host storage id for tags */
-static int flow_tag_id = -1;                /**< Flow storage id for tags */
+static FlowStorageId flow_tag_id = { .id = -1 }; /**< Flow storage id for tags */
 
 void TagInitCtx(void)
 {
@@ -57,7 +57,7 @@ void TagInitCtx(void)
         FatalError(SC_ERR_FATAL, "Can't initiate host storage for tag");
     }
     flow_tag_id = FlowStorageRegister("tag", sizeof(void *), NULL, DetectTagDataListFree);
-    if (flow_tag_id == -1) {
+    if (flow_tag_id.id == -1) {
         FatalError(SC_ERR_FATAL, "Can't initiate flow storage for tag");
     }
 }

--- a/src/flow-storage.c
+++ b/src/flow-storage.c
@@ -36,24 +36,24 @@ unsigned int FlowStorageSize(void)
     return StorageGetSize(STORAGE_FLOW);
 }
 
-void *FlowGetStorageById(Flow *f, int id)
+void *FlowGetStorageById(Flow *f, FlowStorageId id)
 {
-    return StorageGetById((Storage *)((void *)f + sizeof(Flow)), STORAGE_FLOW, id);
+    return StorageGetById((Storage *)((void *)f + sizeof(Flow)), STORAGE_FLOW, id.id);
 }
 
-int FlowSetStorageById(Flow *f, int id, void *ptr)
+int FlowSetStorageById(Flow *f, FlowStorageId id, void *ptr)
 {
-    return StorageSetById((Storage *)((void *)f + sizeof(Flow)), STORAGE_FLOW, id, ptr);
+    return StorageSetById((Storage *)((void *)f + sizeof(Flow)), STORAGE_FLOW, id.id, ptr);
 }
 
-void *FlowAllocStorageById(Flow *f, int id)
+void *FlowAllocStorageById(Flow *f, FlowStorageId id)
 {
-    return StorageAllocByIdPrealloc((Storage *)((void *)f + sizeof(Flow)), STORAGE_FLOW, id);
+    return StorageAllocByIdPrealloc((Storage *)((void *)f + sizeof(Flow)), STORAGE_FLOW, id.id);
 }
 
-void FlowFreeStorageById(Flow *f, int id)
+void FlowFreeStorageById(Flow *f, FlowStorageId id)
 {
-    StorageFreeById((Storage *)((void *)f + sizeof(Flow)), STORAGE_FLOW, id);
+    StorageFreeById((Storage *)((void *)f + sizeof(Flow)), STORAGE_FLOW, id.id);
 }
 
 void FlowFreeStorage(Flow *f)
@@ -62,8 +62,12 @@ void FlowFreeStorage(Flow *f)
         StorageFreeAll((Storage *)((void *)f + sizeof(Flow)), STORAGE_FLOW);
 }
 
-int FlowStorageRegister(const char *name, const unsigned int size, void *(*Alloc)(unsigned int), void (*Free)(void *)) {
-    return StorageRegister(STORAGE_FLOW, name, size, Alloc, Free);
+FlowStorageId FlowStorageRegister(const char *name, const unsigned int size,
+        void *(*Alloc)(unsigned int), void (*Free)(void *))
+{
+    int id = StorageRegister(STORAGE_FLOW, name, size, Alloc, Free);
+    FlowStorageId fsi = { .id = id };
+    return fsi;
 }
 
 #ifdef UNITTESTS
@@ -85,14 +89,15 @@ static int FlowStorageTest01(void)
 
     StorageInit();
 
-    int id1 = FlowStorageRegister("test", 8, StorageTestAlloc, StorageTestFree);
-    if (id1 < 0)
+    FlowStorageId id1 = FlowStorageRegister("test", 8, StorageTestAlloc, StorageTestFree);
+    if (id1.id < 0)
         goto error;
-    int id2 = FlowStorageRegister("variable", 24, StorageTestAlloc, StorageTestFree);
-    if (id2 < 0)
+    FlowStorageId id2 = FlowStorageRegister("variable", 24, StorageTestAlloc, StorageTestFree);
+    if (id2.id < 0)
         goto error;
-    int id3 = FlowStorageRegister("store", sizeof(void *), StorageTestAlloc, StorageTestFree);
-    if (id3 < 0)
+    FlowStorageId id3 =
+            FlowStorageRegister("store", sizeof(void *), StorageTestAlloc, StorageTestFree);
+    if (id3.id < 0)
         goto error;
 
     if (StorageFinalize() < 0)
@@ -165,8 +170,8 @@ static int FlowStorageTest02(void)
 
     StorageInit();
 
-    int id1 = FlowStorageRegister("test", sizeof(void *), NULL, StorageTestFree);
-    if (id1 < 0)
+    FlowStorageId id1 = FlowStorageRegister("test", sizeof(void *), NULL, StorageTestFree);
+    if (id1.id < 0)
         goto error;
 
     if (StorageFinalize() < 0)
@@ -216,14 +221,14 @@ static int FlowStorageTest03(void)
 
     StorageInit();
 
-    int id1 = FlowStorageRegister("test1", sizeof(void *), NULL, StorageTestFree);
-    if (id1 < 0)
+    FlowStorageId id1 = FlowStorageRegister("test1", sizeof(void *), NULL, StorageTestFree);
+    if (id1.id < 0)
         goto error;
-    int id2 = FlowStorageRegister("test2", sizeof(void *), NULL, StorageTestFree);
-    if (id2 < 0)
+    FlowStorageId id2 = FlowStorageRegister("test2", sizeof(void *), NULL, StorageTestFree);
+    if (id2.id < 0)
         goto error;
-    int id3 = FlowStorageRegister("test3", 32, StorageTestAlloc, StorageTestFree);
-    if (id3 < 0)
+    FlowStorageId id3 = FlowStorageRegister("test3", 32, StorageTestAlloc, StorageTestFree);
+    if (id3.id < 0)
         goto error;
 
     if (StorageFinalize() < 0)

--- a/src/flow-storage.h
+++ b/src/flow-storage.h
@@ -29,17 +29,22 @@
 #include "util-storage.h"
 #include "flow.h"
 
+typedef struct FlowStorageId {
+    int id;
+} FlowStorageId;
+
 unsigned int FlowStorageSize(void);
 
-void *FlowGetStorageById(Flow *h, int id);
-int FlowSetStorageById(Flow *h, int id, void *ptr);
-void *FlowAllocStorageById(Flow *h, int id);
+void *FlowGetStorageById(Flow *h, FlowStorageId id);
+int FlowSetStorageById(Flow *h, FlowStorageId id, void *ptr);
+void *FlowAllocStorageById(Flow *h, FlowStorageId id);
 
-void FlowFreeStorageById(Flow *h, int id);
+void FlowFreeStorageById(Flow *h, FlowStorageId id);
 void FlowFreeStorage(Flow *h);
 
 void RegisterFlowStorageTests(void);
 
-int FlowStorageRegister(const char *name, const unsigned int size, void *(*Alloc)(unsigned int), void (*Free)(void *));
+FlowStorageId FlowStorageRegister(const char *name, const unsigned int size,
+        void *(*Alloc)(unsigned int), void (*Free)(void *));
 
 #endif /* __FLOW_STORAGE_H__ */

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -215,9 +215,9 @@ void FlowInit(Flow *f, const Packet *p)
     SCReturn;
 }
 
-int g_bypass_info_id = -1;
+FlowStorageId g_bypass_info_id = { .id = -1 };
 
-int GetFlowBypassInfoID(void)
+FlowStorageId GetFlowBypassInfoID(void)
 {
     return g_bypass_info_id;
 }

--- a/src/flow.h
+++ b/src/flow.h
@@ -24,6 +24,9 @@
 #ifndef __FLOW_H__
 #define __FLOW_H__
 
+/* forward declaration for macset include */
+typedef struct FlowStorageId FlowStorageId;
+
 #include "decode.h"
 #include "util-var.h"
 #include "util-atomic.h"
@@ -579,7 +582,7 @@ int FlowSetMemcap(uint64_t size);
 uint64_t FlowGetMemcap(void);
 uint64_t FlowGetMemuse(void);
 
-int GetFlowBypassInfoID(void);
+FlowStorageId GetFlowBypassInfoID(void);
 void RegisterFlowBypassInfo(void);
 
 void FlowGetLastTimeAsParts(Flow *flow, uint64_t *secs, uint64_t *usecs);

--- a/src/tests/fuzz/confyaml.c
+++ b/src/tests/fuzz/confyaml.c
@@ -8,6 +8,7 @@ pcap-file:\n\
 stream:\n\
 \n\
   checksum-validation: no\n\
+  midstream: true\n\
 outputs:\n\
   - fast:\n\
       enabled: yes\n\

--- a/src/util-macset.c
+++ b/src/util-macset.c
@@ -56,7 +56,7 @@ struct MacSet_ {
         last[2];
 };
 
-int g_macset_storage_id = -1;
+FlowStorageId g_macset_storage_id = { .id = -1 };
 
 void MacSetRegisterFlowStorage(void)
 {
@@ -83,7 +83,7 @@ void MacSetRegisterFlowStorage(void)
 
 bool MacSetFlowStorageEnabled(void)
 {
-    return (g_macset_storage_id != -1);
+    return (g_macset_storage_id.id != -1);
 }
 
 
@@ -110,7 +110,7 @@ MacSet *MacSetInit(int size)
     return ms;
 }
 
-int MacSetGetFlowStorageID(void)
+FlowStorageId MacSetGetFlowStorageID(void)
 {
     return g_macset_storage_id;
 }

--- a/src/util-macset.h
+++ b/src/util-macset.h
@@ -41,7 +41,7 @@ int     MacSetSize(const MacSet*);
 void    MacSetReset(MacSet*);
 void    MacSetFree(MacSet*);
 void    MacSetRegisterFlowStorage(void);
-int     MacSetGetFlowStorageID(void);
+FlowStorageId MacSetGetFlowStorageID(void);
 bool    MacSetFlowStorageEnabled(void);
 void    MacSetRegisterTests(void);
 


### PR DESCRIPTION
#6040 with formatting fixes

#5821 #6029

b4e510a proposes to use specific types for the flow storage id's. This would have to be implemented as well for the other storage api users.
