### PR TITLE
output/log: Ensure files are closed on shutdown

### DIFF
--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -576,7 +576,6 @@ SCConfLogOpenGeneric(ConfNode *conf,
     } else {
         SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY, "Invalid entry for "
                    "%s.filetype.  Expected \"regular\" (default), \"unix_stream\", "
-                   "\"pcie\" "
                    "or \"unix_dgram\"",
                    conf->name);
     }

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -1,5 +1,5 @@
 /* vi: set et ts=4: */
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -304,6 +304,7 @@ static char *SCLogFilenameFromPattern(const char *pattern)
 
 static void SCLogFileCloseNoLock(LogFileCtx *log_ctx)
 {
+    SCLogDebug("Closing %s", log_ctx->filename);
     if (log_ctx->fp)
         fclose(log_ctx->fp);
 
@@ -821,6 +822,7 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
         for(int i = 0; i < lf_ctx->threads->slot_count; i++) {
             if (lf_ctx->threads->lf_slots[i]) {
                 OutputUnregisterFileRotationFlag(&lf_ctx->threads->lf_slots[i]->rotation_flag);
+                lf_ctx->threads->lf_slots[i]->Close(lf_ctx->threads->lf_slots[i]);
                 SCFree(lf_ctx->threads->lf_slots[i]->filename);
                 SCFree(lf_ctx->threads->lf_slots[i]);
             }

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -33,10 +33,6 @@
 
 #include "suricata-plugin.h"
 
-typedef struct {
-    uint16_t fileno;
-} PcieFile;
-
 enum LogFileType { LOGFILE_TYPE_FILE,
                    LOGFILE_TYPE_SYSLOG,
                    LOGFILE_TYPE_UNIX_DGRAM,
@@ -60,7 +56,6 @@ typedef struct LogThreadedFileCtx_ {
 typedef struct LogFileCtx_ {
     union {
         FILE *fp;
-        PcieFile *pcie_fp;
         LogThreadedFileCtx *threads;
         void *plugin_data;
 #ifdef HAVE_LIBHIREDIS


### PR DESCRIPTION
This PR ensures that eve output file pointers are closed on shutdown when using threaded mode.

Describe changes:
- Close file on shutdown when logging in threaded mode
- Remove Tilera logging vestiges

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
