### PR TITLE
ippair/storage: use dedicated 'id' type

### DIFF
--- a/src/app-layer-expectation.c
+++ b/src/app-layer-expectation.c
@@ -63,7 +63,7 @@
 #include "util-print.h"
 #include "queue.h"
 
-static int g_ippair_expectation_id = -1;
+static IPPairStorageId g_ippair_expectation_id = { .id = -1 };
 static FlowStorageId g_flow_expectation_id = { .id = -1 };
 
 SC_ATOMIC_DECLARE(uint32_t, expectation_count);

--- a/src/app-layer-expectation.h
+++ b/src/app-layer-expectation.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2015 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -70,7 +70,7 @@
 #include "tm-threads.h"
 
 static int host_threshold_id = -1; /**< host storage id for thresholds */
-static int ippair_threshold_id = -1; /**< ip pair storage id for thresholds */
+static IPPairStorageId ippair_threshold_id = { .id = -1 }; /**< ip pair storage id for thresholds */
 
 int ThresholdHostStorageId(void)
 {
@@ -85,7 +85,7 @@ void ThresholdInit(void)
                    "Can't initiate host storage for thresholding");
     }
     ippair_threshold_id = IPPairStorageRegister("threshold", sizeof(void *), NULL, ThresholdListFree);
-    if (ippair_threshold_id == -1) {
+    if (ippair_threshold_id.id == -1) {
         FatalError(SC_ERR_FATAL,
                    "Can't initiate IP pair storage for thresholding");
     }

--- a/src/ippair-bit.c
+++ b/src/ippair-bit.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Open Information Security Foundation
+/* Copyright (C) 2014-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -38,7 +38,7 @@
 #include "util-unittest.h"
 #include "ippair-storage.h"
 
-static int ippair_bit_id = -1;                /**< IPPair storage id for bits */
+static IPPairStorageId ippair_bit_id = { .id = -1 }; /**< IPPair storage id for bits */
 
 static void XBitFreeAll(void *store)
 {
@@ -49,7 +49,7 @@ static void XBitFreeAll(void *store)
 void IPPairBitInitCtx(void)
 {
     ippair_bit_id = IPPairStorageRegister("bit", sizeof(void *), NULL, XBitFreeAll);
-    if (ippair_bit_id == -1) {
+    if (ippair_bit_id.id == -1) {
         FatalError(SC_ERR_FATAL, "Can't initiate ippair storage for bits");
     }
 }

--- a/src/ippair-storage.c
+++ b/src/ippair-storage.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -32,24 +32,24 @@ unsigned int IPPairStorageSize(void)
     return StorageGetSize(STORAGE_IPPAIR);
 }
 
-void *IPPairGetStorageById(IPPair *h, int id)
+void *IPPairGetStorageById(IPPair *h, IPPairStorageId id)
 {
-    return StorageGetById((Storage *)((void *)h + sizeof(IPPair)), STORAGE_IPPAIR, id);
+    return StorageGetById((Storage *)((void *)h + sizeof(IPPair)), STORAGE_IPPAIR, id.id);
 }
 
-int IPPairSetStorageById(IPPair *h, int id, void *ptr)
+int IPPairSetStorageById(IPPair *h, IPPairStorageId id, void *ptr)
 {
-    return StorageSetById((Storage *)((void *)h + sizeof(IPPair)), STORAGE_IPPAIR, id, ptr);
+    return StorageSetById((Storage *)((void *)h + sizeof(IPPair)), STORAGE_IPPAIR, id.id, ptr);
 }
 
-void *IPPairAllocStorageById(IPPair *h, int id)
+void *IPPairAllocStorageById(IPPair *h, IPPairStorageId id)
 {
-    return StorageAllocByIdPrealloc((Storage *)((void *)h + sizeof(IPPair)), STORAGE_IPPAIR, id);
+    return StorageAllocByIdPrealloc((Storage *)((void *)h + sizeof(IPPair)), STORAGE_IPPAIR, id.id);
 }
 
-void IPPairFreeStorageById(IPPair *h, int id)
+void IPPairFreeStorageById(IPPair *h, IPPairStorageId id)
 {
-    StorageFreeById((Storage *)((void *)h + sizeof(IPPair)), STORAGE_IPPAIR, id);
+    StorageFreeById((Storage *)((void *)h + sizeof(IPPair)), STORAGE_IPPAIR, id.id);
 }
 
 void IPPairFreeStorage(IPPair *h)
@@ -58,8 +58,13 @@ void IPPairFreeStorage(IPPair *h)
         StorageFreeAll((Storage *)((void *)h + sizeof(IPPair)), STORAGE_IPPAIR);
 }
 
-int IPPairStorageRegister(const char *name, const unsigned int size, void *(*Alloc)(unsigned int), void (*Free)(void *)) {
-    return StorageRegister(STORAGE_IPPAIR, name, size, Alloc, Free);
+IPPairStorageId IPPairStorageRegister(const char *name, const unsigned int size,
+        void *(*Alloc)(unsigned int), void (*Free)(void *))
+{
+    // return StorageRegister(STORAGE_IPPAIR, name, size, Alloc, Free);
+    int id = StorageRegister(STORAGE_IPPAIR, name, size, Alloc, Free);
+    IPPairStorageId ippsi = { .id = id };
+    return ippsi;
 }
 
 #ifdef UNITTESTS
@@ -79,14 +84,15 @@ static int IPPairStorageTest01(void)
 {
     StorageInit();
 
-    int id1 = IPPairStorageRegister("test", 8, StorageTestAlloc, StorageTestFree);
-    if (id1 < 0)
+    IPPairStorageId id1 = IPPairStorageRegister("test", 8, StorageTestAlloc, StorageTestFree);
+    if (id1.id < 0)
         goto error;
-    int id2 = IPPairStorageRegister("variable", 24, StorageTestAlloc, StorageTestFree);
-    if (id2 < 0)
+    IPPairStorageId id2 = IPPairStorageRegister("variable", 24, StorageTestAlloc, StorageTestFree);
+    if (id2.id < 0)
         goto error;
-    int id3 = IPPairStorageRegister("store", sizeof(void *), StorageTestAlloc, StorageTestFree);
-    if (id3 < 0)
+    IPPairStorageId id3 =
+            IPPairStorageRegister("store", sizeof(void *), StorageTestAlloc, StorageTestFree);
+    if (id3.id < 0)
         goto error;
 
     if (StorageFinalize() < 0)
@@ -161,8 +167,8 @@ static int IPPairStorageTest02(void)
 {
     StorageInit();
 
-    int id1 = IPPairStorageRegister("test", sizeof(void *), NULL, StorageTestFree);
-    if (id1 < 0)
+    IPPairStorageId id1 = IPPairStorageRegister("test", sizeof(void *), NULL, StorageTestFree);
+    if (id1.id < 0)
         goto error;
 
     if (StorageFinalize() < 0)
@@ -214,14 +220,14 @@ static int IPPairStorageTest03(void)
 {
     StorageInit();
 
-    int id1 = IPPairStorageRegister("test1", sizeof(void *), NULL, StorageTestFree);
-    if (id1 < 0)
+    IPPairStorageId id1 = IPPairStorageRegister("test1", sizeof(void *), NULL, StorageTestFree);
+    if (id1.id < 0)
         goto error;
-    int id2 = IPPairStorageRegister("test2", sizeof(void *), NULL, StorageTestFree);
-    if (id2 < 0)
+    IPPairStorageId id2 = IPPairStorageRegister("test2", sizeof(void *), NULL, StorageTestFree);
+    if (id2.id < 0)
         goto error;
-    int id3 = IPPairStorageRegister("test3", 32, StorageTestAlloc, StorageTestFree);
-    if (id3 < 0)
+    IPPairStorageId id3 = IPPairStorageRegister("test3", 32, StorageTestAlloc, StorageTestFree);
+    if (id3.id < 0)
         goto error;
 
     if (StorageFinalize() < 0)

--- a/src/ippair-storage.h
+++ b/src/ippair-storage.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -29,17 +29,22 @@
 #include "util-storage.h"
 #include "ippair.h"
 
+typedef struct IPPairStorageId {
+    int id;
+} IPPairStorageId;
+
 unsigned int IPPairStorageSize(void);
 
-void *IPPairGetStorageById(IPPair *h, int id);
-int IPPairSetStorageById(IPPair *h, int id, void *ptr);
-void *IPPairAllocStorageById(IPPair *h, int id);
+void *IPPairGetStorageById(IPPair *h, IPPairStorageId id);
+int IPPairSetStorageById(IPPair *h, IPPairStorageId id, void *ptr);
+void *IPPairAllocStorageById(IPPair *h, IPPairStorageId id);
 
-void IPPairFreeStorageById(IPPair *h, int id);
+void IPPairFreeStorageById(IPPair *h, IPPairStorageId id);
 void IPPairFreeStorage(IPPair *h);
 
 void RegisterIPPairStorageTests(void);
 
-int IPPairStorageRegister(const char *name, const unsigned int size, void *(*Alloc)(unsigned int), void (*Free)(void *));
+IPPairStorageId IPPairStorageRegister(const char *name, const unsigned int size,
+        void *(*Alloc)(unsigned int), void (*Free)(void *));
 
 #endif /* __IPPAIR_STORAGE_H__ */


### PR DESCRIPTION

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4427

Describe changes:
- Wrap the id in a new IPPairStorageId struct, to avoid id
confusion with other storage API calls.
- Formatting fixes by clang.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
