### PR TITLE
eve cleanup - another round of eve cleanup - v2

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -712,7 +712,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
             jb_set_string(jb, "xff", xff_buffer);
         }
 
-        OutputJsonBuilderBuffer(jb, aft->ctx->file_ctx, &aft->ctx->buffer);
+        OutputJsonBuilderBuffer(jb, aft->ctx);
         jb_free(jb);
     }
 
@@ -722,7 +722,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                 CreateEveHeader(p, LOG_DIR_PACKET, "packet", NULL, json_output_ctx->eve_ctx);
         if (unlikely(packetjs != NULL)) {
             EvePacket(p, packetjs, 0);
-            OutputJsonBuilderBuffer(packetjs, aft->ctx->file_ctx, &aft->ctx->buffer);
+            OutputJsonBuilderBuffer(packetjs, aft->ctx);
             jb_free(packetjs);
         }
     }
@@ -756,7 +756,7 @@ static int AlertJsonDecoderEvent(ThreadVars *tv, JsonAlertLogThread *aft, const 
 
         AlertJsonHeader(json_output_ctx, p, pa, jb, json_output_ctx->flags, NULL);
 
-        OutputJsonBuilderBuffer(jb, aft->ctx->file_ctx, &aft->ctx->buffer);
+        OutputJsonBuilderBuffer(jb, aft->ctx);
         jb_free(jb);
     }
 

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -145,7 +145,7 @@ static int AnomalyDecodeEventJson(ThreadVars *tv, JsonAnomalyLogThread *aft,
             EvePacket(p, js, GET_PKT_LEN(p) < 32 ? GET_PKT_LEN(p) : 32);
         }
 
-        OutputJsonBuilderBuffer(js, aft->ctx->file_ctx, &aft->ctx->buffer);
+        OutputJsonBuilderBuffer(js, aft->ctx);
         jb_free(js);
     }
 
@@ -203,7 +203,7 @@ static int AnomalyAppLayerDecoderEventJson(JsonAnomalyLogThread *aft,
 
         /* anomaly */
         jb_close(js);
-        OutputJsonBuilderBuffer(js, aft->ctx->file_ctx, &aft->ctx->buffer);
+        OutputJsonBuilderBuffer(js, aft->ctx);
         jb_free(js);
 
         /* Current implementation assumes a single owner for this value */

--- a/src/output-json-common.c
+++ b/src/output-json-common.c
@@ -41,29 +41,59 @@
 #include "app-layer.h"
 #include "app-layer-parser.h"
 
+OutputJsonThreadCtx *CreateEveThreadCtx(ThreadVars *t, OutputJsonCtx *ctx)
+{
+    OutputJsonThreadCtx *thread = SCCalloc(1, sizeof(*thread));
+    if (unlikely(thread == NULL)) {
+        return NULL;
+    }
+
+    thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
+    if (unlikely(thread->buffer == NULL)) {
+        goto error;
+    }
+
+    thread->file_ctx = LogFileEnsureExists(ctx->file_ctx, t->id);
+    if (!thread->file_ctx) {
+        goto error;
+    }
+
+    thread->ctx = ctx;
+
+    return thread;
+
+error:
+    if (thread->buffer) {
+        MemBufferFree(thread->buffer);
+    }
+    SCFree(thread);
+    return NULL;
+}
+
+void FreeEveThreadCtx(OutputJsonThreadCtx *ctx)
+{
+    if (ctx != NULL && ctx->buffer != NULL) {
+        MemBufferFree(ctx->buffer);
+    }
+    if (ctx != NULL) {
+        SCFree(ctx);
+    }
+}
+
 static void OutputJsonLogDeInitCtxSub(OutputCtx *output_ctx)
 {
-    SCFree(output_ctx->data);
     SCFree(output_ctx);
 }
 
 OutputInitResult OutputJsonLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
     OutputInitResult result = { NULL, false };
-    OutputJsonCtx *ajt = parent_ctx->data;
-
-    OutputJsonCtx *log_ctx = SCCalloc(1, sizeof(*log_ctx));
-    if (unlikely(log_ctx == NULL)) {
-        return result;
-    }
-    *log_ctx = *ajt;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {
-        SCFree(log_ctx);
         return result;
     }
-    output_ctx->data = log_ctx;
+    output_ctx->data = parent_ctx->data;
     output_ctx->DeInit = OutputJsonLogDeInitCtxSub;
 
     result.ctx = output_ctx;
@@ -108,12 +138,6 @@ error_exit:
 TmEcode JsonLogThreadDeinit(ThreadVars *t, void *data)
 {
     OutputJsonThreadCtx *thread = (OutputJsonThreadCtx *)data;
-    if (thread == NULL) {
-        return TM_ECODE_OK;
-    }
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
-    SCFree(thread);
+    FreeEveThreadCtx(thread);
     return TM_ECODE_OK;
 }

--- a/src/output-json-common.c
+++ b/src/output-json-common.c
@@ -89,7 +89,6 @@ TmEcode JsonLogThreadInit(ThreadVars *t, const void *initdata, void **data)
     }
 
     thread->ctx = ((OutputCtx *)initdata)->data;
-    LogFileEnsureExists(thread->ctx->file_ctx, t->id);
     thread->file_ctx = LogFileEnsureExists(thread->ctx->file_ctx, t->id);
     if (!thread->file_ctx) {
         goto error_exit;

--- a/src/output-json-dcerpc.c
+++ b/src/output-json-dcerpc.c
@@ -64,7 +64,7 @@ static int JsonDCERPCLogger(ThreadVars *tv, void *thread_data,
     jb_close(jb);
 
     MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(jb, thread->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(jb, thread);
 
     jb_free(jb);
     return TM_ECODE_OK;

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -73,7 +73,7 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
 
     rs_dhcp_logger_log(ctx->rs_logger, tx, js);
 
-    OutputJsonBuilderBuffer(js, thread->thread->file_ctx, &thread->thread->buffer);
+    OutputJsonBuilderBuffer(js, thread->thread);
     jb_free(js);
 
     return TM_ECODE_OK;

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -216,9 +216,6 @@ static int JsonDNP3LoggerToServer(ThreadVars *tv, void *thread_data,
     LogDNP3LogThread *thread = (LogDNP3LogThread *)thread_data;
     DNP3Transaction *tx = vtx;
 
-    MemBuffer *buffer = (MemBuffer *)thread->ctx->buffer;
-
-    MemBufferReset(buffer);
     if (tx->has_request && tx->request_done) {
         JsonBuilder *js =
                 CreateEveHeader(p, LOG_DIR_FLOW, "dnp3", NULL, thread->dnp3log_ctx->eve_ctx);
@@ -229,7 +226,7 @@ static int JsonDNP3LoggerToServer(ThreadVars *tv, void *thread_data,
         jb_open_object(js, "dnp3");
         JsonDNP3LogRequest(js, tx);
         jb_close(js);
-        OutputJsonBuilderBuffer(js, thread->ctx->file_ctx, &buffer);
+        OutputJsonBuilderBuffer(js, thread->ctx);
         jb_free(js);
     }
 
@@ -243,9 +240,6 @@ static int JsonDNP3LoggerToClient(ThreadVars *tv, void *thread_data,
     LogDNP3LogThread *thread = (LogDNP3LogThread *)thread_data;
     DNP3Transaction *tx = vtx;
 
-    MemBuffer *buffer = (MemBuffer *)thread->ctx->buffer;
-
-    MemBufferReset(buffer);
     if (tx->has_response && tx->response_done) {
         JsonBuilder *js =
                 CreateEveHeader(p, LOG_DIR_FLOW, "dnp3", NULL, thread->dnp3log_ctx->eve_ctx);
@@ -256,7 +250,7 @@ static int JsonDNP3LoggerToClient(ThreadVars *tv, void *thread_data,
         jb_open_object(js, "dnp3");
         JsonDNP3LogResponse(js, tx);
         jb_close(js);
-        OutputJsonBuilderBuffer(js, thread->ctx->file_ctx, &buffer);
+        OutputJsonBuilderBuffer(js, thread->ctx);
         jb_free(js);
     }
 

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -328,7 +328,7 @@ static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
         }
         jb_close(jb);
 
-        OutputJsonBuilderBuffer(jb, td->ctx->file_ctx, &td->ctx->buffer);
+        OutputJsonBuilderBuffer(jb, td->ctx);
         jb_free(jb);
     }
 
@@ -357,7 +357,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
             jb_open_object(jb, "dns");
             rs_dns_log_json_answer(txptr, td->dnslog_ctx->flags, jb);
             jb_close(jb);
-            OutputJsonBuilderBuffer(jb, td->ctx->file_ctx, &td->ctx->buffer);
+            OutputJsonBuilderBuffer(jb, td->ctx);
             jb_free(jb);
         }
     } else {
@@ -377,7 +377,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
             jb_set_object(jb, "dns", answer);
             jb_free(answer);
 
-            OutputJsonBuilderBuffer(jb, td->ctx->file_ctx, &td->ctx->buffer);
+            OutputJsonBuilderBuffer(jb, td->ctx);
             jb_free(jb);
         }
         /* Log authorities. */
@@ -396,7 +396,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
             jb_set_object(jb, "dns", answer);
             jb_free(answer);
 
-            OutputJsonBuilderBuffer(jb, td->ctx->file_ctx, &td->ctx->buffer);
+            OutputJsonBuilderBuffer(jb, td->ctx);
             jb_free(jb);
         }
     }

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -168,7 +168,7 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
         }
     }
 
-    OutputJsonBuilderBuffer(js, aft->ctx->file_ctx, &aft->ctx->buffer);
+    OutputJsonBuilderBuffer(js, aft->ctx);
     jb_free(js);
 
     return TM_ECODE_OK;

--- a/src/output-json-email-common.h
+++ b/src/output-json-email-common.h
@@ -31,9 +31,8 @@ typedef struct OutputJsonEmailCtx_ {
 } OutputJsonEmailCtx;
 
 typedef struct JsonEmailLogThread_ {
-    LogFileCtx *file_ctx;
     OutputJsonEmailCtx *emaillog_ctx;
-    MemBuffer *buffer;
+    OutputJsonThreadCtx *ctx;
 } JsonEmailLogThread;
 
 TmEcode EveEmailLogJson(JsonEmailLogThread *aft, JsonBuilder *js, const Packet *p, Flow *f, void *state, void *vtx, uint64_t tx_id);

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -212,7 +212,7 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
         return;
     }
 
-    OutputJsonBuilderBuffer(js, aft->ctx->file_ctx, &aft->ctx->buffer);
+    OutputJsonBuilderBuffer(js, aft->ctx);
     jb_free(js);
 }
 

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -325,7 +325,7 @@ static int JsonFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
 
     EveFlowLogJSON(thread, jb, f);
 
-    OutputJsonBuilderBuffer(jb, thread->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(jb, thread);
     jb_free(jb);
 
     SCReturnInt(TM_ECODE_OK);

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -163,8 +163,7 @@ static int JsonFTPLogger(ThreadVars *tv, void *thread_data,
             goto fail;
         }
 
-        MemBufferReset(thread->buffer);
-        OutputJsonBuilderBuffer(jb, thread->file_ctx, &thread->buffer);
+        OutputJsonBuilderBuffer(jb, thread);
 
         jb_free(jb);
     }

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -512,7 +512,7 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
         }
     }
 
-    OutputJsonBuilderBuffer(js, jhl->ctx->file_ctx, &jhl->ctx->buffer);
+    OutputJsonBuilderBuffer(js, jhl->ctx);
     jb_free(js);
 
     SCReturnInt(TM_ECODE_OK);

--- a/src/output-json-http2.c
+++ b/src/output-json-http2.c
@@ -95,7 +95,7 @@ static int JsonHttp2Logger(ThreadVars *tv, void *thread_data, const Packet *p,
         goto end;
     }
     jb_close(js);
-    OutputJsonBuilderBuffer(js, aft->ctx->file_ctx, &aft->ctx->buffer);
+    OutputJsonBuilderBuffer(js, aft->ctx);
 end:
     jb_free(js);
     return 0;

--- a/src/output-json-ike.c
+++ b/src/output-json-ike.c
@@ -91,7 +91,7 @@ static int JsonIKELogger(ThreadVars *tv, void *thread_data, const Packet *p, Flo
         goto error;
     }
 
-    OutputJsonBuilderBuffer(jb, thread->ctx->file_ctx, &thread->ctx->buffer);
+    OutputJsonBuilderBuffer(jb, thread->ctx);
 
     jb_free(jb);
     return TM_ECODE_OK;

--- a/src/output-json-krb5.c
+++ b/src/output-json-krb5.c
@@ -66,8 +66,7 @@ static int JsonKRB5Logger(ThreadVars *tv, void *thread_data,
     }
     jb_close(jb);
 
-    MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(jb, thread->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(jb, thread);
 
     jb_free(jb);
     return TM_ECODE_OK;

--- a/src/output-json-metadata.c
+++ b/src/output-json-metadata.c
@@ -76,7 +76,7 @@ static int MetadataJson(ThreadVars *tv, OutputJsonThreadCtx *aft, const Packet *
     if (!aft->ctx->cfg.include_metadata) {
         EveAddMetadata(p, p->flow, js);
     }
-    OutputJsonBuilderBuffer(js, aft->file_ctx, &aft->buffer);
+    OutputJsonBuilderBuffer(js, aft);
 
     jb_free(js);
     return TM_ECODE_OK;

--- a/src/output-json-mqtt.c
+++ b/src/output-json-mqtt.c
@@ -93,7 +93,7 @@ static int JsonMQTTLogger(ThreadVars *tv, void *thread_data,
     if (!rs_mqtt_logger_log(state, tx, thread->mqttlog_ctx->flags, js))
         goto error;
 
-    OutputJsonBuilderBuffer(js, thread->ctx->file_ctx, &thread->ctx->buffer);
+    OutputJsonBuilderBuffer(js, thread->ctx);
     jb_free(js);
 
     return TM_ECODE_OK;

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -270,26 +270,22 @@ static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
     SCEnter();
     OutputJsonThreadCtx *jhl = thread_data;
 
-    /* reset */
-    MemBufferReset(jhl->buffer);
     JsonBuilder *jb = CreateEveHeaderFromNetFlow(f, 0);
     if (unlikely(jb == NULL))
         return TM_ECODE_OK;
     NetFlowLogEveToServer(jb, f);
     EveAddCommonOptions(&jhl->ctx->cfg, NULL, f, jb);
-    OutputJsonBuilderBuffer(jb, jhl->file_ctx, &jhl->buffer);
+    OutputJsonBuilderBuffer(jb, jhl);
     jb_free(jb);
 
     /* only log a response record if we actually have seen response packets */
     if (f->tosrcpktcnt) {
-        /* reset */
-        MemBufferReset(jhl->buffer);
         jb = CreateEveHeaderFromNetFlow(f, 1);
         if (unlikely(jb == NULL))
             return TM_ECODE_OK;
         NetFlowLogEveToClient(jb, f);
         EveAddCommonOptions(&jhl->ctx->cfg, NULL, f, jb);
-        OutputJsonBuilderBuffer(jb, jhl->file_ctx, &jhl->buffer);
+        OutputJsonBuilderBuffer(jb, jhl);
         jb_free(jb);
     }
     SCReturnInt(TM_ECODE_OK);

--- a/src/output-json-nfs.c
+++ b/src/output-json-nfs.c
@@ -95,7 +95,7 @@ static int JsonNFSLogger(ThreadVars *tv, void *thread_data,
     jb_close(jb);
 
     MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(jb, thread->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(jb, thread);
     jb_free(jb);
     return TM_ECODE_OK;
 }

--- a/src/output-json-rdp.c
+++ b/src/output-json-rdp.c
@@ -56,8 +56,7 @@ static int JsonRdpLogger(ThreadVars *tv, void *thread_data,
         jb_free(js);
         return TM_ECODE_FAILED;
     }
-    MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(js, thread->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(js, thread);
 
     jb_free(js);
     return TM_ECODE_OK;

--- a/src/output-json-rfb.c
+++ b/src/output-json-rfb.c
@@ -73,8 +73,7 @@ static int JsonRFBLogger(ThreadVars *tv, void *thread_data,
         goto error;
     }
 
-    MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(js, thread->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(js, thread);
     jb_free(js);
 
     return TM_ECODE_OK;

--- a/src/output-json-sip.c
+++ b/src/output-json-sip.c
@@ -75,8 +75,7 @@ static int JsonSIPLogger(ThreadVars *tv, void *thread_data,
         goto error;
     }
 
-    MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(js, thread->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(js, thread);
     jb_free(js);
 
     return TM_ECODE_OK;

--- a/src/output-json-smb.c
+++ b/src/output-json-smb.c
@@ -75,9 +75,7 @@ static int JsonSMBLogger(ThreadVars *tv, void *thread_data,
     }
     jb_close(jb);
 
-    EveAddCommonOptions(&thread->ctx->cfg, p, f, jb);
-    MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(jb, thread->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(jb, thread);
 
     jb_free(jb);
     return TM_ECODE_OK;

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -86,7 +86,7 @@ static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     jb_close(jb);
 
     if (EveEmailLogJson(jhl, jb, p, f, state, tx, tx_id) == TM_ECODE_OK) {
-        OutputJsonBuilderBuffer(jb, jhl->ctx->file_ctx, &jhl->ctx->buffer);
+        OutputJsonBuilderBuffer(jb, jhl->ctx);
     }
 
     jb_free(jb);

--- a/src/output-json-snmp.c
+++ b/src/output-json-snmp.c
@@ -66,8 +66,7 @@ static int JsonSNMPLogger(ThreadVars *tv, void *thread_data,
     }
     jb_close(jb);
 
-    MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(jb, thread->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(jb, thread);
 
     jb_free(jb);
     return TM_ECODE_OK;

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -66,15 +66,12 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
     if (unlikely(js == NULL))
         return 0;
 
-    /* reset */
-    MemBufferReset(thread->buffer);
-
     jb_open_object(js, "ssh");
     if (!rs_ssh_log_json(txptr, js)) {
         goto end;
     }
     jb_close(js);
-    OutputJsonBuilderBuffer(js, thread->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(js, thread);
 
 end:
     jb_free(js);

--- a/src/output-json-template-rust.c
+++ b/src/output-json-template-rust.c
@@ -82,7 +82,7 @@ static int JsonTemplateLogger(ThreadVars *tv, void *thread_data,
     }
     jb_close(js);
 
-    OutputJsonBuilderBuffer(js, thread->ctx->file_ctx, &thread->ctx->buffer);
+    OutputJsonBuilderBuffer(js, thread->ctx);
     jb_free(js);
 
     return TM_ECODE_OK;

--- a/src/output-json-template.c
+++ b/src/output-json-template.c
@@ -59,9 +59,8 @@ typedef struct LogTemplateFileCtx_ {
 } LogTemplateFileCtx;
 
 typedef struct LogTemplateLogThread_ {
-    LogFileCtx *file_ctx;
     LogTemplateFileCtx *templatelog_ctx;
-    MemBuffer          *buffer;
+    OutputJsonThreadCtx *ctx;
 } LogTemplateLogThread;
 
 static int JsonTemplateLogger(ThreadVars *tv, void *thread_data,
@@ -95,8 +94,7 @@ static int JsonTemplateLogger(ThreadVars *tv, void *thread_data,
     /* Close template. */
     jb_close(js);
 
-    MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(js, thread->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(js, thread->ctx->file_ctx, &thread->ctx->buffer);
 
     jb_free(js);
     return TM_ECODE_OK;
@@ -150,14 +148,9 @@ static TmEcode JsonTemplateLogThreadInit(ThreadVars *t, const void *initdata, vo
         goto error_exit;
     }
 
-    thread->buffer = MemBufferCreateNew(JSON_OUTPUT_BUFFER_SIZE);
-    if (unlikely(thread->buffer == NULL)) {
-        goto error_exit;
-    }
-
     thread->templatelog_ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->templatelog_ctx->eve_ctx->file_ctx, t->id);
-    if (!thread->file_ctx) {
+    thread->ctx = CreateEveThreadCtx(t, thread->templatelog_ctx->eve_ctx);
+    if (!thread->ctx) {
         goto error_exit;
     }
     *data = (void *)thread;
@@ -165,9 +158,6 @@ static TmEcode JsonTemplateLogThreadInit(ThreadVars *t, const void *initdata, vo
     return TM_ECODE_OK;
 
 error_exit:
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
     SCFree(thread);
     return TM_ECODE_FAILED;
 }
@@ -178,9 +168,7 @@ static TmEcode JsonTemplateLogThreadDeinit(ThreadVars *t, void *data)
     if (thread == NULL) {
         return TM_ECODE_OK;
     }
-    if (thread->buffer != NULL) {
-        MemBufferFree(thread->buffer);
-    }
+    FreeEveThreadCtx(thread->ctx);
     SCFree(thread);
     return TM_ECODE_OK;
 }

--- a/src/output-json-template.c
+++ b/src/output-json-template.c
@@ -94,7 +94,7 @@ static int JsonTemplateLogger(ThreadVars *tv, void *thread_data,
     /* Close template. */
     jb_close(js);
 
-    OutputJsonBuilderBuffer(js, thread->ctx->file_ctx, &thread->ctx->buffer);
+    OutputJsonBuilderBuffer(js, thread->ctx);
 
     jb_free(js);
     return TM_ECODE_OK;

--- a/src/output-json-tftp.c
+++ b/src/output-json-tftp.c
@@ -66,8 +66,7 @@ static int JsonTFTPLogger(ThreadVars *tv, void *thread_data,
     }
     jb_close(jb);
 
-    MemBufferReset(thread->buffer);
-    OutputJsonBuilderBuffer(jb, thread->file_ctx, &thread->buffer);
+    OutputJsonBuilderBuffer(jb, thread);
 
     jb_free(jb);
     return TM_ECODE_OK;

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -442,7 +442,7 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
     /* Close the tls object. */
     jb_close(js);
 
-    OutputJsonBuilderBuffer(js, aft->ctx->file_ctx, &aft->ctx->buffer);
+    OutputJsonBuilderBuffer(js, aft->ctx);
     jb_free(js);
 
     return 0;

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -983,6 +983,8 @@ int OutputJsonBuilderBuffer(JsonBuilder *js, LogFileCtx *file_ctx, MemBuffer **b
 
     jb_close(js);
 
+    MemBufferReset(*buffer);
+
     if (file_ctx->prefix) {
         MemBufferWriteRaw((*buffer), file_ctx->prefix, file_ctx->prefix_len);
     }

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -971,8 +971,10 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer)
     return 0;
 }
 
-int OutputJsonBuilderBuffer(JsonBuilder *js, LogFileCtx *file_ctx, MemBuffer **buffer)
+int OutputJsonBuilderBuffer(JsonBuilder *js, OutputJsonThreadCtx *ctx)
 {
+    LogFileCtx *file_ctx = ctx->file_ctx;
+    MemBuffer **buffer = &ctx->buffer;
     if (file_ctx->sensor_name) {
         jb_set_string(js, "host", file_ctx->sensor_name);
     }

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -103,7 +103,7 @@ JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
 JsonBuilder *CreateEveHeaderWithTxId(const Packet *p, enum OutputJsonLogDirection dir,
         const char *event_type, JsonAddrInfo *addr, uint64_t tx_id, OutputJsonCtx *eve_ctx);
 int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer);
-int OutputJsonBuilderBuffer(JsonBuilder *js, LogFileCtx *file_ctx, MemBuffer **buffer);
+int OutputJsonBuilderBuffer(JsonBuilder *js, OutputJsonThreadCtx *ctx);
 OutputInitResult OutputJsonInitCtx(ConfNode *);
 
 OutputInitResult OutputJsonLogInitSub(ConfNode *conf, OutputCtx *parent_ctx);

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -116,4 +116,7 @@ void EveAddMetadata(const Packet *p, const Flow *f, JsonBuilder *js);
 
 int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
 
+OutputJsonThreadCtx *CreateEveThreadCtx(ThreadVars *t, OutputJsonCtx *ctx);
+void FreeEveThreadCtx(OutputJsonThreadCtx *ctx);
+
 #endif /* __OUTPUT_JSON_H__ */


### PR DESCRIPTION
The idea here is to remove duplicated code as its too easy to mess this up when creating a new parser, and work under normal operation but fail under others.

Factors out the setup of OutputJsonThreadCtx from the generic threadinit function so loggers that need their own custom threadinit function can just wrap this function.  Finally, as OutputJsonBuilder is always taking the same 2 parameters, from the same context object, just have it take the context object.