### PR TITLE
Multi-threaded EVE support for output plugins 

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1109,20 +1109,19 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
             json_ctx->file_ctx->prefix_len = strlen(prefix);
         }
 
+        /* Threaded file output */
+        const ConfNode *threaded = ConfNodeLookupChild(conf, "threaded");
+        if (threaded && threaded->val && ConfValIsTrue(threaded->val)) {
+            SCLogConfig("Threaded EVE logging configured");
+            json_ctx->file_ctx->threaded = true;
+        } else {
+            json_ctx->file_ctx->threaded = false;
+        }
+
         if (json_ctx->json_out == LOGFILE_TYPE_FILE ||
             json_ctx->json_out == LOGFILE_TYPE_UNIX_DGRAM ||
             json_ctx->json_out == LOGFILE_TYPE_UNIX_STREAM)
         {
-            if (json_ctx->json_out == LOGFILE_TYPE_FILE) {
-                /* Threaded file output */
-                const ConfNode *threaded = ConfNodeLookupChild(conf, "threaded");
-                if (threaded && threaded->val && ConfValIsTrue(threaded->val)) {
-                    SCLogConfig("Enabling threaded eve logging.");
-                    json_ctx->file_ctx->threaded = true;
-                } else {
-                    json_ctx->file_ctx->threaded = false;
-                }
-            }
 
             if (SCConfLogOpenGeneric(conf, json_ctx->file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
                 LogFileFreeCtx(json_ctx->file_ctx);
@@ -1179,6 +1178,7 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
             }
 
             if (SCConfLogOpenRedis(redis_node, json_ctx->file_ctx) < 0) {
+                SCFree(json_ctx->file_ctx->sensor_name);
                 LogFileFreeCtx(json_ctx->file_ctx);
                 SCFree(json_ctx);
                 SCFree(output_ctx);
@@ -1186,20 +1186,43 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
             }
         }
 #endif
+#ifdef HAVE_PLUGINS
         else if (json_ctx->json_out == LOGFILE_TYPE_PLUGIN) {
-            ConfNode *plugin_conf = ConfNodeLookupChild(conf,
-                json_ctx->plugin->name);
-            void *plugin_data = NULL;
-            if (json_ctx->plugin->Init(plugin_conf, false, &plugin_data) < 0) {
+            void *init_data = NULL;
+            const char *append = ConfNodeLookupChildValue(conf, "append");
+            if (append == NULL) {
+                append = DEFAULT_LOG_MODE_APPEND;
+            }
+            if (json_ctx->file_ctx->threaded) {
+                if (!SCLogOpenThreadedFile(
+                            ConfigGetLogDirectory(), append, json_ctx->file_ctx, 1)) {
+                    SCFree(json_ctx);
+                    SCFree(output_ctx);
+                    return result;
+                }
+            }
+
+            if (json_ctx->plugin->Init(conf, json_ctx->file_ctx->threaded, &init_data) < 0) {
                 LogFileFreeCtx(json_ctx->file_ctx);
                 SCFree(json_ctx);
                 SCFree(output_ctx);
                 return result;
-            } else {
-                json_ctx->file_ctx->plugin = json_ctx->plugin;
-                json_ctx->file_ctx->plugin_data = plugin_data;
             }
+
+            /* Now that initialization completed successfully, if threaded, make sure
+             * that ThreadInit and ThreadDeInit exist
+             */
+            if (json_ctx->file_ctx->threaded) {
+                if (!json_ctx->plugin->ThreadInit || !json_ctx->plugin->ThreadDeinit) {
+                    FatalError(SC_ERR_LOG_OUTPUT, "Output logger must supply ThreadInit and "
+                                                  "ThreadDeinit functions for threaded mode");
+                }
+            }
+
+            json_ctx->file_ctx->plugin.plugin = json_ctx->plugin;
+            json_ctx->file_ctx->plugin.init_data = init_data;
         }
+#endif
 
         const char *sensor_id_s = ConfNodeLookupChildValue(conf, "sensor-id");
         if (sensor_id_s != NULL) {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1190,7 +1190,7 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
             ConfNode *plugin_conf = ConfNodeLookupChild(conf,
                 json_ctx->plugin->name);
             void *plugin_data = NULL;
-            if (json_ctx->plugin->Open(plugin_conf, &plugin_data) < 0) {
+            if (json_ctx->plugin->Init(plugin_conf, false, &plugin_data) < 0) {
                 LogFileFreeCtx(json_ctx->file_ctx);
                 SCFree(json_ctx);
                 SCFree(output_ctx);

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -45,12 +45,22 @@ typedef struct SCPlugin_ {
  * Structure used to define a file type plugin.
  *
  * Currently only used by the Eve output type.
+ *
+ * name -- The plugin name. This name is used to identify the plugin: eve-log.filetype and in the
+ * plugins: section
  */
 typedef struct SCPluginFileType_ {
     char *name;
-    int (*Open)(ConfNode *conf, void **data);
-    int (*Write)(const char *buffer, int buffer_len, void *ctx);
-    void (*Close)(void *ctx);
+    /* Init Called on first access */
+    int (*Init)(ConfNode *conf, bool threaded, void **init_data);
+    /* Write - Called on each write to the object */
+    int (*Write)(const char *buffer, int buffer_len, void *init_data, void *thread_data);
+    /* Close - Called on final close */
+    void (*Deinit)(void *init_data);
+    /* ThreadInit - Called for each thread using file object*/
+    int (*ThreadInit)(void *init_data, int thread_id, void **thread_data);
+    /* ThreadDeinit - Called for each thread using file object */
+    int (*ThreadDeinit)(void *init_data, void *thread_data);
     TAILQ_ENTRY(SCPluginFileType_) entries;
 } SCPluginFileType;
 
@@ -59,6 +69,8 @@ bool SCPluginRegisterFileType(SCPluginFileType *);
 typedef struct SCCapturePlugin_ {
     char *name;
     void (*Init)(const char *args, int plugin_slot, int receive_slot, int decode_slot);
+    int (*ThreadInit)(void *ctx, int thread_id, void **thread_ctx);
+    int (*ThreadDeinit)(void *ctx, void *thread_ctx);
     const char *(*GetDefaultMode)(void);
     TAILQ_ENTRY(SCCapturePlugin_) entries;
 } SCCapturePlugin;

--- a/src/util-log-redis.c
+++ b/src/util-log-redis.c
@@ -1,5 +1,5 @@
 /* vi: set et ts=4: */
-/* Copyright (C) 2007-2016 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -53,7 +53,7 @@ void SCLogRedisInit()
 #endif /* HAVE_LIBEVENT_PTHREADS */
 }
 
-/** \brief SCLogRedisContextAlloc() - Allocates and initalizes redis context
+/** \brief SCLogRedisContextAlloc() - Allocates and initializes redis context
  */
 static SCLogRedisContext *SCLogRedisContextAlloc(void)
 {
@@ -430,7 +430,7 @@ static int SCLogRedisWriteSync(LogFileCtx *file_ctx, const char *string)
  * \param log_ctx Log file context allocated by caller
  * \param string buffer with data to write
  * \param string_len data length
- * \retval 0 on sucess;
+ * \retval 0 on success;
  * \retval -1 on failure;
  */
 int LogFileWriteRedis(void *lf_ctx, const char *string, size_t string_len)
@@ -460,6 +460,10 @@ int LogFileWriteRedis(void *lf_ctx, const char *string, size_t string_len)
  */
 int SCConfLogOpenRedis(ConfNode *redis_node, void *lf_ctx)
 {
+    if (lf_ctx->threaded) {
+        FatalError(SC_ERR_FATAL, "redis does not support threaded output");
+    }
+
     LogFileCtx *log_ctx = lf_ctx;
 
     const char *redis_port = NULL;

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -831,8 +831,8 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
         SCFree(lf_ctx->threads);
     } else {
         if (lf_ctx->type == LOGFILE_TYPE_PLUGIN) {
-            if (lf_ctx->plugin->Close != NULL) {
-                lf_ctx->plugin->Close(lf_ctx->plugin_data);
+            if (lf_ctx->plugin->Deinit != NULL) {
+                lf_ctx->plugin->Deinit(lf_ctx->plugin_data);
             }
         } else if (lf_ctx->fp != NULL) {
             lf_ctx->Close(lf_ctx);
@@ -889,7 +889,7 @@ int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer)
 #endif
     else if (file_ctx->type == LOGFILE_TYPE_PLUGIN) {
         file_ctx->plugin->Write((const char *)MEMBUFFER_BUFFER(buffer),
-                        MEMBUFFER_OFFSET(buffer), file_ctx->plugin_data);
+                        MEMBUFFER_OFFSET(buffer), file_ctx->plugin_data, NULL);
     }
 
     return 0;

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -52,16 +52,22 @@ typedef struct LogThreadedFileCtx_ {
     char *append;
 } LogThreadedFileCtx;
 
+typedef struct LogFilePluginCtx_ {
+    SCPluginFileType *plugin;
+    void *init_data;
+    void *thread_data;
+} LogFilePluginCtx;
+
 /** Global structure for Output Context */
 typedef struct LogFileCtx_ {
     union {
         FILE *fp;
-        LogThreadedFileCtx *threads;
         void *plugin_data;
 #ifdef HAVE_LIBHIREDIS
         void *redis;
 #endif
     };
+    LogThreadedFileCtx *threads;
 
     union {
         SyslogSetup syslog_setup;
@@ -73,7 +79,7 @@ typedef struct LogFileCtx_ {
     int (*Write)(const char *buffer, int buffer_len, struct LogFileCtx_ *fp);
     void (*Close)(struct LogFileCtx_ *fp);
 
-    SCPluginFileType *plugin;
+    LogFilePluginCtx plugin;
 
     /** It will be locked if the log/alert
      * record cannot be written to the file in one call */
@@ -162,5 +168,7 @@ int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer);
 LogFileCtx *LogFileEnsureExists(LogFileCtx *lf_ctx, int thread_id);
 int SCConfLogOpenGeneric(ConfNode *conf, LogFileCtx *, const char *, int);
 int SCConfLogReopen(LogFileCtx *);
+bool SCLogOpenThreadedFile(
+        const char *log_path, const char *append, LogFileCtx *parent_ctx, int slot_count);
 
 #endif /* __UTIL_LOGOPENFILE_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -71,6 +71,10 @@ stats:
   # Add stream events as stats.
   #stream-events: false
 
+# Plugins -- Experimental -- specify the filename for each plugin shared object
+plugins:
+#   - /path/to/plugin.so
+
 # Configure the type of alert (and other) logging you would like.
 outputs:
   # a line based alerts log similar to Snort's fast.log


### PR DESCRIPTION
Continuation of #6064


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4126](https://redmine.openinfosecfoundation.org/issues/4126)

Describe changes:
These changes build upon the experimental file output plugin support by
adding calls when a thread attaches and detaches from an output context:
- Address review comments
- Remove unneeded per-thread de-initialization call from each output file.
- clang-format fix

I've modified @jasonish's output plugin with a multi-threaded variant: https://github.com/jlucovsky/suricata-example-plugins/tree/output/1/eve-file-type

Configure Suricata to use this plugin by adding the following to `suricata.yaml`

```
plugins:
    - /path/to/plugin.so
```

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
