### PR TITLE
misc: include queue.h before other headers - v1

### DIFF
--- a/src/app-layer-expectation.c
+++ b/src/app-layer-expectation.c
@@ -52,6 +52,7 @@
  * \author Eric Leblond <eric@regit.org>
  */
 
+#include "queue.h"
 #include "suricata-common.h"
 #include "debug.h"
 
@@ -61,7 +62,6 @@
 #include "app-layer-expectation.h"
 
 #include "util-print.h"
-#include "queue.h"
 
 static IPPairStorageId g_ippair_expectation_id = { .id = -1 };
 static FlowStorageId g_flow_expectation_id = { .id = -1 };


### PR DESCRIPTION
At least on FreeBSD, some other include is including "sys/queue.h"
which results in FreeBSDs /usr/include/sys/queue.h being picked
up and setting `__SYS_QUEUE_H__` so our queue.h is not picked up.

But the FreeBSD queue.h does not have the `CIRCLEQ` definitions. To
fix just include our queue.h first, which also sets `__SYS_QUEUE_H__`
preventing the system one from being picked up.

This is a different take on https://github.com/OISF/suricata/pull/5340.