### PR TITLE
tx: fix unidirection transaction cleanup (dns tx fix) - v4

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -951,7 +951,7 @@ void AppLayerParserTransactionsCleanup(Flow *f)
                 if (!(detect_flags_ts & APP_LAYER_TX_INSPECTED_FLAG)) {
                     SCLogDebug("%p/%"PRIu64" skipping: TS inspect not done: ts:%"PRIx64,
                             tx, i, detect_flags_ts);
-                    tx_skipped = skipped = true;
+                    tx_skipped = true;
                 } else {
                     inspected = true;
                 }
@@ -961,7 +961,7 @@ void AppLayerParserTransactionsCleanup(Flow *f)
                 if (!(detect_flags_tc & APP_LAYER_TX_INSPECTED_FLAG)) {
                     SCLogDebug("%p/%"PRIu64" skipping: TC inspect not done: tc:%"PRIx64,
                             tx, i, detect_flags_tc);
-                    tx_skipped = skipped = true;
+                    tx_skipped = true;
                 } else {
                     inspected = true;
                 }
@@ -972,6 +972,7 @@ void AppLayerParserTransactionsCleanup(Flow *f)
         // been inspected.
         if (!is_unidir && tx_skipped) {
             SCLogDebug("%p/%" PRIu64 " !is_unidir && tx_skipped", tx, i);
+            skipped = true;
             goto next;
         }
 
@@ -981,6 +982,7 @@ void AppLayerParserTransactionsCleanup(Flow *f)
         // tx inspected flag checked.
         if (is_unidir && tx_skipped && !inspected) {
             SCLogDebug("%p/%" PRIu64 " is_unidir && tx_skipped && !inspected", tx, i);
+            skipped = true;
             goto next;
         }
 


### PR DESCRIPTION
Fir commit fixes unidirection transaction handling. We only want to mark a TX as skipped if skipped in both the TS and TC side if unidirectional.  If one side is seen, then its complete.  Instead it has been marked as skipped, so the starting TX ID on cleanup is never incremented, resulting in a larger number of iterations as the transaction grow on a session.

This was easily seen with DNS when multiple transactions occurred on the same flow before the flow timed out. In many cases this would not be noticed, but is really notiecable when there are devices present that blast DNS requests over the same session.

Note: You must have some rules enabled to hit this case, it doesn't appear to show up if you have no rules enabled.

The second commit just removes the DNS flood protection which appears is not needed, as it only kicks in when it should not kick in.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/4437