### PR TITLE
6.0.x/ish/backports/v1 - dns - freebsd - v1

### DIFF
--- a/src/app-layer-expectation.c
+++ b/src/app-layer-expectation.c
@@ -52,6 +52,7 @@
  * \author Eric Leblond <eric@regit.org>
  */
 
+#include "queue.h"
 #include "suricata-common.h"
 #include "debug.h"
 
@@ -61,7 +62,6 @@
 #include "app-layer-expectation.h"
 
 #include "util-print.h"
-#include "queue.h"
 
 static int g_expectation_id = -1;
 static int g_expectation_data_id = -1;

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -946,7 +946,7 @@ void AppLayerParserTransactionsCleanup(Flow *f)
                 if (!(detect_flags_ts & APP_LAYER_TX_INSPECTED_FLAG)) {
                     SCLogDebug("%p/%"PRIu64" skipping: TS inspect not done: ts:%"PRIx64,
                             tx, i, detect_flags_ts);
-                    tx_skipped = skipped = true;
+                    tx_skipped = true;
                 } else {
                     inspected = true;
                 }
@@ -956,7 +956,7 @@ void AppLayerParserTransactionsCleanup(Flow *f)
                 if (!(detect_flags_tc & APP_LAYER_TX_INSPECTED_FLAG)) {
                     SCLogDebug("%p/%"PRIu64" skipping: TC inspect not done: tc:%"PRIx64,
                             tx, i, detect_flags_tc);
-                    tx_skipped = skipped = true;
+                    tx_skipped = true;
                 } else {
                     inspected = true;
                 }
@@ -967,6 +967,7 @@ void AppLayerParserTransactionsCleanup(Flow *f)
         // been inspected.
         if (!is_unidir && tx_skipped) {
             SCLogDebug("%p/%" PRIu64 " !is_unidir && tx_skipped", tx, i);
+            skipped = true;
             goto next;
         }
 
@@ -976,6 +977,7 @@ void AppLayerParserTransactionsCleanup(Flow *f)
         // tx inspected flag checked.
         if (is_unidir && tx_skipped && !inspected) {
             SCLogDebug("%p/%" PRIu64 " is_unidir && tx_skipped && !inspected", tx, i);
+            skipped = true;
             goto next;
         }
 


### PR DESCRIPTION
Backports the following fixes to 6.0.x:
- DNS fix. Does not remove flood detection, just the transaction handling fix. https://redmine.openinfosecfoundation.org/issues/4441
- FreeBSD build issue. https://redmine.openinfosecfoundation.org/issues/4443