### PR TITLE
Properly set the ICMP emergency-bypassed value

### DIFF
--- a/src/flow.c
+++ b/src/flow.c
@@ -978,7 +978,7 @@ void FlowInitFlowProto(void)
                                             strlen(emergency_bypassed),
                                             emergency_bypassed) > 0) {
 
-                flow_timeouts_emerg[FLOW_PROTO_UDP].bypassed_timeout = configval;
+                flow_timeouts_emerg[FLOW_PROTO_ICMP].bypassed_timeout = configval;
             }
         }
     }


### PR DESCRIPTION
Currently the ICMP emergency-bypassed value defined in suricata.conf is
overwriting the UDP value rather than correctly setting it for ICMP.
This commit corrects this bug so that the ICMP value can be set as
expected.

This can be verified by setting the ICMP bypassed in suricata.conf to less that the default value, there will be a warning generated like the following, regardless of the value set for ICMP emergency-bypassed:
```plain
WARNING: [ERRCODE: SC_WARN_FLOW_EMERGENCY(160)] - emergency timeout value 50 for 'bypassed' must be below regular value 1
```

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Use the correct protocol when setting ICMP emergency-bypassed timeout

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
