### PR TITLE
unittests: Register missing UT modules

### DIFF
--- a/src/detect-template-buffer.c
+++ b/src/detect-template-buffer.c
@@ -53,9 +53,11 @@ static int g_template_buffer_id = 0;
 void DetectTemplateBufferRegister(void)
 {
     /* TEMPLATE_START_REMOVE */
+#ifndef UNITTESTS
     if (ConfGetNode("app-layer.protocols.template") == NULL) {
         return;
     }
+#endif
     /* TEMPLATE_END_REMOVE */
     sigmatch_table[DETECT_AL_TEMPLATE_BUFFER].name = "template_buffer";
     sigmatch_table[DETECT_AL_TEMPLATE_BUFFER].desc =

--- a/src/detect-template-rust-buffer.c
+++ b/src/detect-template-rust-buffer.c
@@ -54,9 +54,11 @@ static int g_template_rust_id = 0;
 void DetectTemplateRustBufferRegister(void)
 {
     /* TEMPLATE_START_REMOVE */
+#ifndef UNITTESTS
     if (ConfGetNode("app-layer.protocols.template-rust") == NULL) {
         return;
     }
+#endif
     /* TEMPLATE_END_REMOVE */
     sigmatch_table[DETECT_AL_TEMPLATE_RUST_BUFFER].name =
         "template_rust_buffer";

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -38,6 +38,7 @@
 #include "detect-engine-state.h"
 #include "detect-engine-tag.h"
 #include "detect-engine-modbus.h"
+#include "detect-engine-enip.h"
 #include "detect-fast-pattern.h"
 #include "flow.h"
 #include "flow-timeout.h"
@@ -184,6 +185,7 @@ static void RegisterUnittests(void)
     DeStateRegisterTests();
     MemcmpRegisterTests();
     DetectEngineInspectModbusRegisterTests();
+    DetectEngineInspectENIPRegisterTests();
     DetectEngineRegisterTests();
     SCLogRegisterTests();
     MagicRegisterTests();


### PR DESCRIPTION
This commit adds three UT registrations that were discovered missing
during code coverage.

Describe changes:
- Register UT functions for ENIP, template-buffer and rust-template-buffer.
-
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
