### PR TITLE
unix-socket: reset to ready state on startup - v2

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2027,8 +2027,14 @@ void PreRunPostPrivsDropInit(const int runmode)
     StatsSetupPostConfigPreOutput();
     RunModeInitializeOutputs();
 
-    if (runmode == RUNMODE_UNIX_SOCKET)
+    if (runmode == RUNMODE_UNIX_SOCKET) {
+        /* As the above did some necessary startup initialization, it
+         * also setup some outputs where only one is allowed, so
+         * deinitialize to the state that unix-mode does after every
+         * pcap. */
+        PostRunDeinit(RUNMODE_PCAP_FILE, NULL);
         return;
+    }
 
     StatsSetupPostConfigPostOutput();
 }


### PR DESCRIPTION
Rebase of https://github.com/OISF/suricata/pull/5928.
Changes: None, just commit message

Tested to confirm that it also fixes new issue:
https://redmine.openinfosecfoundation.org/issues/4434

Note: This initializes all files in the default-log-directory as mentioned in ticket 4434. I think that is best solved as another issue, which is less important than what we are fixing here.

As part of commit ea15282f47c6ff781533e3a063f9c903dd6f1afb,
some initialization was moved to happen even in unix socket mode,
however, this initialization does setup some loggers that can only have
one instance enabled (anomaly, drop, file-store).

This will cause these loggers to error out on the first pcap, but work
on subsequent runs of the pcap as some deinitialization is done after
each pcap.

This fix just runs the post pcap-file deinitialization routine to
reset some of the initialization done on startup, like is done after
running each pcap in unix socket mode.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/4225

Additionally this prevents alerts from being logged two times
on the first run of a pcap through the unix socket:

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/4434
