### PR TITLE
detect: runs pkt checks every time

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -1084,15 +1084,15 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
             TRACE_SID_TXS(s->id, tx, "DetectRunInspectRuleHeader() no match");
             return false;
         }
-        if (DetectEnginePktInspectionRun(tv, det_ctx, s, f, p, NULL) == false) {
-            TRACE_SID_TXS(s->id, tx, "DetectEnginePktInspectionRun no match");
-            return false;
-        }
         /* stream mpm and negated mpm sigs can end up here with wrong proto */
         if (!(AppProtoEquals(s->alproto, f->alproto) || s->alproto == ALPROTO_UNKNOWN)) {
             TRACE_SID_TXS(s->id, tx, "alproto mismatch");
             return false;
         }
+    }
+    if (DetectEnginePktInspectionRun(tv, det_ctx, s, f, p, NULL) == false) {
+        TRACE_SID_TXS(s->id, tx, "DetectEnginePktInspectionRun no match");
+        return false;
     }
 
     const DetectEngineAppInspectionEngine *engine = s->app_inspect;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2836

Describe changes:
- Run `DetectEnginePktInspectionRun` for every `DetectRunTxInspectRule`

suricata-verify-pr: 493

Analyzing what happens on suricata-verify test 
(maybe as the flow bit is not set at the start of the transaction), we run `DetectRunStoreStateTx` at packet 5
At packet 6, we skip `DetectEnginePktInspectionRun` but we do not have any file yet, so we do not trigger sid 3
At packet 7 we set the flow bit Sith the signature sid 1
We do not trigger sid 3 at packet 7 because `stored_flags == NULL` (packet in opposite direction) in `DetectRunTxInspectRule` and so we call `DetectEnginePktInspectionRun` which says no match as the flow bit is set
And we do trigger sid 3 at packet 8 because `stored_flags!=NULL` (because we called `DetectRunStoreStateTx` at packet 5), so we do not call `DetectEnginePktInspectionRun` to check the flow bit, so we just check the filemagic which says match

Interestingly, the bug does not happen for the flow bit isset because we do `s->flags |= SIG_FLAG_REQUIRE_FLOWVAR` for this case and this flag is checked by `DetectRunInspectRuleHeader`


Feedback welcome here

PS : This was the oldest S-V PR