### PR TITLE
detect: try to get tx_id for packet alerts

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -804,8 +804,14 @@ static inline void DetectRulePacketRules(
 
         if (!(sflags & SIG_FLAG_NOALERT)) {
             /* stateful sigs call PacketAlertAppend from DeStateDetectStartDetection */
-            if (!state_alert)
-                PacketAlertAppend(det_ctx, s, p, 0, alert_flags);
+            if (!state_alert) {
+                uint64_t tx_id = 0;
+                if (pflow && pflow->alparser) {
+                    tx_id = AppLayerParserGetTransactionInspectId(
+                            pflow->alparser, scratch->flow_flags);
+                }
+                PacketAlertAppend(det_ctx, s, p, tx_id, alert_flags);
+            }
         } else {
             /* apply actions even if not alerting */
             DetectSignatureApplyActions(p, s, alert_flags);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3354

Describe changes:
- Try to get a better tx_id for packet alerts, so as to get the right app-layer metadata

Uses `AppLayerParserGetTransactionInspectId` to do so.

I am not sure if there is a better way. For HTTP2, we may have multiple transactions going on at the same moment...

suricata-verify-pr: 495

https://github.com/OISF/suricata-verify/pull/495