### PR TITLE
decode/vntag: Add decoder for 802.1Qbh

### DIFF
--- a/rules/decoder-events.rules
+++ b/rules/decoder-events.rules
@@ -97,6 +97,8 @@ alert pkthdr any any -> any any (msg:"SURICATA VLAN header too small "; decode-e
 alert pkthdr any any -> any any (msg:"SURICATA VLAN unknown type"; decode-event:vlan.unknown_type; classtype:protocol-command-decode; sid:2200067; rev:2;)
 # more than 2 vlan layers in the packet
 alert pkthdr any any -> any any (msg:"SURICATA VLAN too many layers"; decode-event:vlan.too_many_layers; classtype:protocol-command-decode; sid:2200091; rev:2;)
+alert pkthdr any any -> any any (msg:"SURICATA VNTAG header too small"; decode-event:vntag.header_too_small; classtype:protocol-command-decode; sid:2200117; rev:1;)
+alert pkthdr any any -> any any (msg:"SURICATA VNTAG unknown type"; decode-event:vntag.unknown_type; classtype:protocol-command-decode; sid:2200118; rev:1;)
 alert pkthdr any any -> any any (msg:"SURICATA IEEE802.1AH header too small"; decode-event:ieee8021ah.header_too_small; classtype:protocol-command-decode; sid:2200112; rev:1;)
 
 alert pkthdr any any -> any any (msg:"SURICATA IP raw invalid IP version "; decode-event:ipraw.invalid_ip_version; classtype:protocol-command-decode; sid:2200068; rev:2;)
@@ -113,7 +115,6 @@ alert icmp any any -> any any (msg:"SURICATA ICMPv4 invalid checksum"; icmpv4-cs
 alert tcp any any -> any any (msg:"SURICATA TCPv6 invalid checksum"; tcpv6-csum:invalid; classtype:protocol-command-decode; sid:2200077; rev:2;)
 alert udp any any -> any any (msg:"SURICATA UDPv6 invalid checksum"; udpv6-csum:invalid; classtype:protocol-command-decode; sid:2200078; rev:2;)
 alert icmp any any -> any any (msg:"SURICATA ICMPv6 invalid checksum"; icmpv6-csum:invalid; classtype:protocol-command-decode; sid:2200079; rev:2;)
-
 # IPv4 in IPv6 rules
 alert pkthdr any any -> any any (msg:"SURICATA IPv4-in-IPv6 packet too short"; decode-event:ipv6.ipv4_in_ipv6_too_small; classtype:protocol-command-decode; sid:2200082; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA IPv4-in-IPv6 invalid protocol"; decode-event:ipv6.ipv4_in_ipv6_wrong_version; classtype:protocol-command-decode; sid:2200083; rev:2;)
@@ -148,5 +149,5 @@ alert pkthdr any any -> any any (msg:"SURICATA CHDLC packet too small"; decode-e
 
 alert pkthdr any any -> any any (msg:"SURICATA packet with too many layers"; decode-event:too_many_layers; classtype:protocol-command-decode; sid:2200116; rev:1;)
 
-# next sid is 2200117
+# next sid is 2200119
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -92,6 +92,7 @@ noinst_HEADERS = \
 	decode-teredo.h \
 	decode-udp.h \
 	decode-vlan.h \
+	decode-vntag.h \
 	decode-vxlan.h \
 	defrag-config.h \
 	defrag.h \
@@ -669,6 +670,7 @@ libsuricata_c_a_SOURCES = \
 	decode-teredo.c \
 	decode-udp.c \
 	decode-vlan.c \
+	decode-vntag.c \
 	decode-vxlan.c \
 	defrag.c \
 	defrag-config.c \

--- a/src/decode-ethernet.h
+++ b/src/decode-ethernet.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -49,6 +49,7 @@
 #define ETHERNET_TYPE_DCE             0x8903 /* Data center ethernet,
                                               * Cisco Fabric Path */
 #define ETHERNET_TYPE_NSH 0x894F
+#define ETHERNET_TYPE_VNTAG 0x8926 /* 802.1Qbh */
 
 typedef struct EthernetHdr_ {
     uint8_t eth_dst[6];

--- a/src/decode-events.c
+++ b/src/decode-events.c
@@ -403,6 +403,16 @@ const struct DecodeEvents_ DEvents[] = {
             IEEE8021AH_HEADER_TOO_SMALL,
     },
 
+    /* VNTAG EVENTS */
+    {
+            "decoder.vntag.header_too_small",
+            VNTAG_HEADER_TOO_SMALL,
+    },
+    {
+            "decoder.vntag.unknown_type",
+            VNTAG_UNKNOWN_TYPE,
+    },
+
     /* RAW EVENTS */
     {
             "decoder.ipraw.invalid_ip_version",

--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -147,6 +147,10 @@ enum {
 
     IEEE8021AH_HEADER_TOO_SMALL,
 
+    /* VNTAG EVENTS */
+    VNTAG_HEADER_TOO_SMALL, /**< vntag header smaller than minimum size */
+    VNTAG_UNKNOWN_TYPE,     /**< vntag unknown type */
+
     /* RAW EVENTS */
     IPRAW_INVALID_IPV, /**< invalid ip version in ip raw */
 

--- a/src/decode-vntag.c
+++ b/src/decode-vntag.c
@@ -1,0 +1,190 @@
+/* Copyright (C) 2021 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \ingroup decode
+ *
+ * @{
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ *
+ * Decode VNTag 802.1Qbh
+ */
+
+#include "suricata-common.h"
+#include "decode.h"
+#include "decode-vntag.h"
+#include "decode-events.h"
+
+#include "flow.h"
+
+#include "util-unittest.h"
+#include "util-debug.h"
+
+#include "pkt-var.h"
+#include "util-profiling.h"
+#include "host.h"
+
+/**
+ * \internal
+ * \brief this function is used to decode 802.1Qbh packets
+ *
+ * \param tv pointer to the thread vars
+ * \param dtv pointer code thread vars
+ * \param p pointer to the packet struct
+ * \param pkt pointer to the raw packet
+ * \param len packet len
+ * \param pq pointer to the packet queue
+ *
+ */
+int DecodeVNTag(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint32_t len)
+{
+    StatsIncr(tv, dtv->counter_vntag);
+
+    if (len < VNTAG_HEADER_LEN) {
+        ENGINE_SET_INVALID_EVENT(p, VNTAG_HEADER_TOO_SMALL);
+        return TM_ECODE_FAILED;
+    }
+
+    if (!PacketIncreaseCheckLayers(p)) {
+        return TM_ECODE_FAILED;
+    }
+
+    VNTagHdr *vntag_hdr = (VNTagHdr *)pkt;
+    if (vntag_hdr == NULL)
+        return TM_ECODE_FAILED;
+
+    uint16_t proto = GET_VNTAG_PROTO(vntag_hdr);
+
+    SCLogDebug("p %p pkt %p protocol %04x DIR %d PTR %d DEST %d LOOPED: %d VERSION: %d SRC: %d "
+               "Len: %" PRIu32 "",
+            p, pkt, proto, GET_VNTAG_DIR(vntag_hdr), GET_VNTAG_PTR(vntag_hdr),
+            GET_VNTAG_DEST(vntag_hdr), GET_VNTAG_LOOPED(vntag_hdr), GET_VNTAG_VERSION(vntag_hdr),
+            GET_VNTAG_SRC(vntag_hdr), len);
+
+    if (DecodeNetworkLayer(tv, dtv, proto, p, pkt + VNTAG_HEADER_LEN, len - VNTAG_HEADER_LEN) ==
+            false) {
+        ENGINE_SET_INVALID_EVENT(p, VNTAG_UNKNOWN_TYPE);
+        return TM_ECODE_FAILED;
+    }
+    return TM_ECODE_OK;
+}
+
+#ifdef UNITTESTS
+
+/**
+ * \test DecodeVNTagTest01 test if vntag header is too small.
+ *
+ *  \retval 1 on success
+ *  \retval 0 on failure
+ */
+static int DecodeVNTagtest01(void)
+{
+    uint8_t raw_vntag[] = { 0x00, 0x20, 0x08 };
+    Packet *p = PacketGetFromAlloc();
+    if (unlikely(p == NULL))
+        return 0;
+    ThreadVars tv;
+    DecodeThreadVars dtv;
+
+    memset(&tv, 0, sizeof(ThreadVars));
+    memset(&dtv, 0, sizeof(DecodeThreadVars));
+
+    FAIL_IF(TM_ECODE_OK == DecodeVNTag(&tv, &dtv, p, raw_vntag, sizeof(raw_vntag)));
+
+    PASS_IF(ENGINE_ISSET_EVENT(p, VNTAG_HEADER_TOO_SMALL));
+}
+
+/**
+ * \test DecodeVNTagt02 test if vntag header has unknown type.
+ *
+ *  \retval 1 on success
+ *  \retval 0 on failure
+ */
+static int DecodeVNTagtest02(void)
+{
+    uint8_t raw_vntag[] = { 0x00, 0x00, 0x00, 0x00, 0xFF, 0x00, 0x00, 0x0b, 0x08, 0x00, 0x45, 0x00,
+        0x00, 0x64, 0xac, 0xe6, 0x00, 0x00, 0xff, 0xfd, 0x08, 0xb3, 0x01, 0x01, 0x01, 0x01, 0x01,
+        0x01, 0x02, 0x01, 0xe5, 0xa3, 0x95, 0x5c, 0x5d, 0x82, 0x50, 0x24, 0x6f, 0x56, 0xac, 0xf4,
+        0xf9, 0x9b, 0x28, 0x6a, 0x03, 0xb5, 0xab, 0x15, 0xfe, 0x6c, 0xab, 0x98, 0x0c, 0x4e, 0xcc,
+        0xf4, 0xd1, 0x5b, 0x22, 0x0b, 0x81, 0x39, 0x08, 0xb3, 0xcf, 0xc2, 0x6b, 0x90, 0xe1, 0xcc,
+        0xe6, 0x4f, 0x5f, 0xa0, 0xb6, 0xa8, 0x93, 0x38, 0x8a, 0x17, 0xac, 0x6e, 0x3b, 0xbc, 0xad,
+        0x67, 0xad, 0xfc, 0x91, 0xf0, 0x16, 0x9d, 0xe2, 0xe1, 0xdf, 0x4f, 0x8c, 0xcb, 0xd3, 0xdc,
+        0xd9, 0xed, 0x3c, 0x0c, 0x92, 0xad, 0x8b, 0xf0, 0x2c, 0x2d, 0x55, 0x41 };
+
+    Packet *p = PacketGetFromAlloc();
+    FAIL_IF_NULL(p);
+    ThreadVars tv;
+    DecodeThreadVars dtv;
+
+    memset(&tv, 0, sizeof(ThreadVars));
+    memset(&dtv, 0, sizeof(DecodeThreadVars));
+
+    PASS_IF(TM_ECODE_OK != DecodeVNTag(&tv, &dtv, p, raw_vntag, sizeof(raw_vntag)));
+}
+
+/**
+ * \test DecodeVNTagTest03 test a good vntag header.
+ *
+ *  \retval 1 on success
+ *  \retval 0 on failure
+ */
+static int DecodeVNTagtest03(void)
+{
+    uint8_t raw_vntag[] = { 0x00, 0x00, 0x00, 0x00, 0x81, 0x00, 0x00, 0x0b, 0x08, 0x00, 0x45, 0x00,
+        0x00, 0x64, 0xac, 0xe6, 0x00, 0x00, 0xff, 0xfd, 0x08, 0xb3, 0x01, 0x01, 0x01, 0x01, 0x01,
+        0x01, 0x02, 0x01, 0xe5, 0xa3, 0x95, 0x5c, 0x5d, 0x82, 0x50, 0x24, 0x6f, 0x56, 0xac, 0xf4,
+        0xf9, 0x9b, 0x28, 0x6a, 0x03, 0xb5, 0xab, 0x15, 0xfe, 0x6c, 0xab, 0x98, 0x0c, 0x4e, 0xcc,
+        0xf4, 0xd1, 0x5b, 0x22, 0x0b, 0x81, 0x39, 0x08, 0xb3, 0xcf, 0xc2, 0x6b, 0x90, 0xe1, 0xcc,
+        0xe6, 0x4f, 0x5f, 0xa0, 0xb6, 0xa8, 0x93, 0x38, 0x8a, 0x17, 0xac, 0x6e, 0x3b, 0xbc, 0xad,
+        0x67, 0xad, 0xfc, 0x91, 0xf0, 0x16, 0x9d, 0xe2, 0xe1, 0xdf, 0x4f, 0x8c, 0xcb, 0xd3, 0xdc,
+        0xd9, 0xed, 0x3c, 0x0c, 0x92, 0xad, 0x8b, 0xf0, 0x2c, 0x2d, 0x55, 0x41 };
+
+    Packet *p = PacketGetFromAlloc();
+    FAIL_IF_NULL(p);
+
+    ThreadVars tv = { 0 };
+    DecodeThreadVars dtv = { 0 };
+
+    FlowInitConfig(FLOW_QUIET);
+
+    FAIL_IF(TM_ECODE_OK != DecodeVNTag(&tv, &dtv, p, raw_vntag, sizeof(raw_vntag)));
+
+    PACKET_RECYCLE(p);
+    FlowShutdown();
+    SCFree(p);
+
+    PASS;
+}
+#endif /* UNITTESTS */
+
+void DecodeVNTagRegisterTests(void)
+{
+#ifdef UNITTESTS
+    UtRegisterTest("DecodeVNTagtest01", DecodeVNTagtest01);
+    UtRegisterTest("DecodeVNTagtest02", DecodeVNTagtest02);
+    UtRegisterTest("DecodeVNTagtest03", DecodeVNTagtest03);
+#endif /* UNITTESTS */
+}
+
+/**
+ * @}
+ */

--- a/src/decode-vntag.c
+++ b/src/decode-vntag.c
@@ -100,8 +100,8 @@ static int DecodeVNTagtest01(void)
 {
     uint8_t raw_vntag[] = { 0x00, 0x20, 0x08 };
     Packet *p = PacketGetFromAlloc();
-    if (unlikely(p == NULL))
-        return 0;
+    FAIL_IF_NULL(p);
+
     ThreadVars tv;
     DecodeThreadVars dtv;
 

--- a/src/decode-vntag.h
+++ b/src/decode-vntag.h
@@ -1,0 +1,49 @@
+
+/* Copyright (C) 2021 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ */
+
+#ifndef __DECODE_VNTAG_H__
+#define __DECODE_VNTAG_H__
+
+/* https://www.ieee802.org/1/files/public/docs2009/new-pelissier-vntag-seminar-0508.pdf */
+/** VNTag macros to access VNTag direction, dst vif_id, dest, looped, version, src vif_id **/
+#define GET_VNTAG_DIR(vntagh)     ((SCNtohl((vntagh)->tag) & 0x80000000) >> 31)
+#define GET_VNTAG_PTR(vntagh)     ((SCNtohl((vntagh)->tag) & 0x40000000) >> 30)
+#define GET_VNTAG_DEST(vntagh)    ((SCNtohl((vntagh)->tag) & 0x3FFF0000) >> 16)
+#define GET_VNTAG_LOOPED(vntagh)  ((SCNtohl((vntagh)->tag) & 0x00008000) >> 15)
+#define GET_VNTAG_VERSION(vntagh) ((SCNtohl((vntagh)->tag) & 0x00003000) >> 12)
+#define GET_VNTAG_SRC(vntagh)     ((SCNtohl((vntagh)->tag) & 0x00000FFF))
+#define GET_VNTAG_PROTO(vntagh)   ((SCNtohs((vntagh)->protocol)))
+
+/** VNTag header struct */
+typedef struct VNTagHdr_ {
+    uint32_t tag;
+    uint16_t protocol; /**< protocol field */
+} __attribute__((__packed__)) VNTagHdr;
+
+/** VNTag header length */
+#define VNTAG_HEADER_LEN 6
+
+void DecodeVNTagRegisterTests(void);
+
+#endif /* __DECODE_VNTAG_H__ */

--- a/src/decode.c
+++ b/src/decode.c
@@ -514,6 +514,7 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_vlan = StatsRegisterCounter("decoder.vlan", tv);
     dtv->counter_vlan_qinq = StatsRegisterCounter("decoder.vlan_qinq", tv);
     dtv->counter_vxlan = StatsRegisterCounter("decoder.vxlan", tv);
+    dtv->counter_vntag = StatsRegisterCounter("decoder.vntag", tv);
     dtv->counter_ieee8021ah = StatsRegisterCounter("decoder.ieee8021ah", tv);
     dtv->counter_teredo = StatsRegisterCounter("decoder.teredo", tv);
     dtv->counter_ipv4inipv6 = StatsRegisterCounter("decoder.ipv4_in_ipv6", tv);

--- a/src/decode.h
+++ b/src/decode.h
@@ -972,6 +972,7 @@ int DecodeSCTP(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint
 int DecodeESP(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint16_t);
 int DecodeGRE(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeVLAN(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
+int DecodeVNTag(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeIEEE8021ah(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeGeneve(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeVXLAN(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
@@ -1290,6 +1291,9 @@ static inline bool DecodeNetworkLayer(ThreadVars *tv, DecodeThreadVars *dtv,
             } else {
                 DecodeEthernet(tv, dtv, p, data, len);
             }
+            break;
+        case ETHERNET_TYPE_VNTAG:
+            DecodeVNTag(tv, dtv, p, data, len);
             break;
         case ETHERNET_TYPE_NSH:
             DecodeNSH(tv, dtv, p, data, len);

--- a/src/decode.h
+++ b/src/decode.h
@@ -94,6 +94,7 @@ enum PktSrcEnum {
 #include "decode-raw.h"
 #include "decode-null.h"
 #include "decode-vlan.h"
+#include "decode-vntag.h"
 #include "decode-vxlan.h"
 #include "decode-mpls.h"
 #include "decode-nsh.h"

--- a/src/decode.h
+++ b/src/decode.h
@@ -670,6 +670,7 @@ typedef struct DecodeThreadVars_
     uint16_t counter_vlan;
     uint16_t counter_vlan_qinq;
     uint16_t counter_vxlan;
+    uint16_t counter_vntag;
     uint16_t counter_ieee8021ah;
     uint16_t counter_pppoe;
     uint16_t counter_teredo;

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -142,6 +142,7 @@ static void RegisterUnittests(void)
     DecodeCHDLCRegisterTests();
     DecodePPPRegisterTests();
     DecodeVLANRegisterTests();
+    DecodeVNTagRegisterTests();
     DecodeGeneveRegisterTests();
     DecodeVXLANRegisterTests();
     DecodeRawRegisterTests();


### PR DESCRIPTION
Continuation of #6085

This PR adds support for decoding VNTAG packets (https://www.ieee802.org/1/files/public/docs2009/new-pelissier-vntag-seminar-0508.pdf)

Describe changes:
- Address review comments -- use `uint16_t` for local var proto

suricata-verify-pr: 489
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
