### PR TITLE
github-ci: enable hiredis on fedora 33 build - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -338,6 +338,7 @@ jobs:
                 gcc \
                 gcc-c++ \
                 git \
+                hiredis-devel \
                 jansson-devel \
                 jq \
                 lua-devel \
@@ -374,7 +375,7 @@ jobs:
           chmod 755 $HOME/.cargo/bin/cbindgen
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: ./autogen.sh
-      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-debug --enable-unittests --disable-shared --enable-rust-strict
+      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis
         env:
           LDFLAGS: "-fsanitize=address"
           ac_cv_func_realloc_0_nonnull: "yes"


### PR DESCRIPTION
Enable Hiredis on a GitHub CI build, so this doesn't happen: https://github.com/OISF/suricata/pull/6073#issuecomment-831774886