### PR TITLE
5.0.x: dns: use transaction iterator - v1

### DIFF
--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -23,6 +23,7 @@
 
 #include "suricata-common.h"
 #include "app-layer-dns-common.h"
+#include "rust-dns-dns-gen.h"
 
 SCEnumCharMap dns_decoder_event_table[ ] = {
     { "UNSOLLICITED_RESPONSE",      DNS_DECODER_EVENT_UNSOLLICITED_RESPONSE, },
@@ -328,3 +329,12 @@ void DNSCreateRcodeString(uint8_t rcode, char *str, size_t str_size)
             snprintf(str, str_size, "%04x/%u", rcode, rcode);
     }
 }
+
+AppLayerGetTxIterTuple RustDNSGetTxIterator(
+    const uint8_t ipproto, const AppProto alproto,
+    void *alstate, uint64_t min_tx_id, uint64_t max_tx_id,
+    AppLayerGetTxIterState *istate)
+{
+    return rs_dns_state_get_tx_iterator(alstate, min_tx_id, (uint64_t *)istate);
+}
+

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -143,5 +143,9 @@ void DNSAppLayerRegisterGetEventInfoById(uint8_t ipproto, AppProto alproto);
 
 void DNSCreateTypeString(uint16_t type, char *str, size_t str_size);
 void DNSCreateRcodeString(uint8_t rcode, char *str, size_t str_size);
+AppLayerGetTxIterTuple RustDNSGetTxIterator(
+    const uint8_t ipproto, const AppProto alproto,
+    void *alstate, uint64_t min_tx_id, uint64_t max_tx_id,
+    AppLayerGetTxIterState *istate);
 
 #endif /* __APP_LAYER_DNS_COMMON_H__ */

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -169,6 +169,9 @@ void RegisterDNSTCPParsers(void)
         DNSAppLayerRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_DNS);
         DNSAppLayerRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_DNS);
 
+        AppLayerParserRegisterGetTxIterator(IPPROTO_TCP, ALPROTO_DNS,
+                RustDNSGetTxIterator);
+
         /* This parser accepts gaps. */
         AppLayerParserRegisterOptionFlags(IPPROTO_TCP, ALPROTO_DNS,
                 APP_LAYER_PARSER_OPT_ACCEPT_GAPS);

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -180,6 +180,9 @@ void RegisterDNSUDPParsers(void)
         AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_DNS,
                 rs_dns_state_progress_completion_status);
 
+        AppLayerParserRegisterGetTxIterator(IPPROTO_UDP, ALPROTO_DNS,
+                RustDNSGetTxIterator);
+
         DNSAppLayerRegisterGetEventInfo(IPPROTO_UDP, ALPROTO_DNS);
         DNSAppLayerRegisterGetEventInfoById(IPPROTO_UDP, ALPROTO_DNS);
 


### PR DESCRIPTION
Certain DNS patterns (long lived session with many request) can
stress the transaction handling and this shows up in the DNS
parser due to its unidirectional nature.
    
The get_tx is often called by Suricata's transaction handling
before previous transactions are cleaned up, requiring some
looping. Use an interator here in attempt to reduce the looping.
    
Redmine issue:
https://redmine.openinfosecfoundation.org/issues/4474