### PR TITLE
MQTT: improve handling of many topics

### DIFF
--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -353,7 +353,7 @@ pub extern "C" fn rs_mqtt_tx_get_publish_message(
 
 #[no_mangle]
 pub extern "C" fn rs_mqtt_tx_get_subscribe_topic(tx: &MQTTTransaction,
-    i: u16,
+    i: u32,
     buf: *mut *const u8,
     len: *mut u32)
     -> u8
@@ -386,7 +386,7 @@ pub extern "C" fn rs_mqtt_tx_get_subscribe_topic(tx: &MQTTTransaction,
 
 #[no_mangle]
 pub extern "C" fn rs_mqtt_tx_get_unsubscribe_topic(tx: &MQTTTransaction,
-    i: u16,
+    i: u32,
     buf: *mut *const u8,
     len: *mut u32)
     -> u8

--- a/src/detect-mqtt-subscribe-topic.c
+++ b/src/detect-mqtt-subscribe-topic.c
@@ -78,7 +78,7 @@ static InspectionBuffer *MQTTSubscribeTopicGetData(DetectEngineThreadCtx *det_ct
 
     const uint8_t *data;
     uint32_t data_len;
-    if (rs_mqtt_tx_get_subscribe_topic(cbdata->txv, (uint16_t)cbdata->local_id,
+    if (rs_mqtt_tx_get_subscribe_topic(cbdata->txv, (uint32_t)cbdata->local_id,
                 &data, &data_len) == 0) {
         return NULL;
     }

--- a/src/detect-mqtt-subscribe-topic.c
+++ b/src/detect-mqtt-subscribe-topic.c
@@ -80,8 +80,8 @@ static InspectionBuffer *MQTTSubscribeTopicGetData(DetectEngineThreadCtx *det_ct
 
     const uint8_t *data;
     uint32_t data_len;
-    if (rs_mqtt_tx_get_subscribe_topic(cbdata->txv, (uint32_t)cbdata->local_id,
-                &data, &data_len) == 0) {
+    if (rs_mqtt_tx_get_subscribe_topic(cbdata->txv, (uint32_t)cbdata->local_id, &data, &data_len) ==
+            0) {
         return NULL;
     }
     buffer->inspect = data;
@@ -104,7 +104,7 @@ static int DetectEngineInspectMQTTSubscribeTopic(
         transforms = engine->v2.transforms;
     }
 
-    while((subscribe_topic_match_limit == 0) || local_id < subscribe_topic_match_limit) {
+    while ((subscribe_topic_match_limit == 0) || local_id < subscribe_topic_match_limit) {
         struct MQTTSubscribeTopicGetDataArgs cbdata = { local_id, txv, };
         InspectionBuffer *buffer = MQTTSubscribeTopicGetData(det_ctx,
             transforms, f, &cbdata, engine->sm_list, false);
@@ -155,7 +155,7 @@ static void PrefilterTxMQTTSubscribeTopic(DetectEngineThreadCtx *det_ctx,
     const int list_id = ctx->list_id;
 
     int local_id = 0;
-    while((subscribe_topic_match_limit == 0) || local_id < subscribe_topic_match_limit) {
+    while ((subscribe_topic_match_limit == 0) || local_id < subscribe_topic_match_limit) {
         struct MQTTSubscribeTopicGetDataArgs cbdata = { local_id, txv };
         InspectionBuffer *buffer = MQTTSubscribeTopicGetData(det_ctx, ctx->transforms,
                 f, &cbdata, list_id, true);
@@ -208,7 +208,8 @@ void DetectMQTTSubscribeTopicRegister (void)
     intmax_t val = 0;
     if (ConfGetInt("mqtt.subscribe-topic-match-limit", &val)) {
         subscribe_topic_match_limit = val;
-        SCLogDebug("Using MQTT SUBSCRIBE topic match-limit setting of: %i", subscribe_topic_match_limit);
+        SCLogDebug("Using MQTT SUBSCRIBE topic match-limit setting of: %i",
+                subscribe_topic_match_limit);
     }
     if (subscribe_topic_match_limit == 0) {
         SCLogDebug("Using unrestricted MQTT SUBSCRIBE topic matching");

--- a/src/detect-mqtt-subscribe-topic.c
+++ b/src/detect-mqtt-subscribe-topic.c
@@ -82,7 +82,7 @@ static InspectionBuffer *MQTTSubscribeTopicGetData(DetectEngineThreadCtx *det_ct
                 &data, &data_len) == 0) {
         return NULL;
     }
-
+    buffer->inspect = data;
     InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
     InspectionBufferApplyTransforms(buffer, transforms);
 

--- a/src/detect-mqtt-subscribe-topic.c
+++ b/src/detect-mqtt-subscribe-topic.c
@@ -58,6 +58,8 @@ static int DetectMQTTSubscribeTopicSetup(DetectEngineCtx *, Signature *, const c
 
 static int g_mqtt_subscribe_topic_buffer_id = 0;
 
+static int subscribe_topic_match_limit = 0;
+
 struct MQTTSubscribeTopicGetDataArgs {
     int local_id;
     void *txv;
@@ -102,7 +104,7 @@ static int DetectEngineInspectMQTTSubscribeTopic(
         transforms = engine->v2.transforms;
     }
 
-    while(1) {
+    while((subscribe_topic_match_limit == 0) || local_id < subscribe_topic_match_limit) {
         struct MQTTSubscribeTopicGetDataArgs cbdata = { local_id, txv, };
         InspectionBuffer *buffer = MQTTSubscribeTopicGetData(det_ctx,
             transforms, f, &cbdata, engine->sm_list, false);
@@ -153,7 +155,7 @@ static void PrefilterTxMQTTSubscribeTopic(DetectEngineThreadCtx *det_ctx,
     const int list_id = ctx->list_id;
 
     int local_id = 0;
-    while(1) {
+    while((subscribe_topic_match_limit == 0) || local_id < subscribe_topic_match_limit) {
         struct MQTTSubscribeTopicGetDataArgs cbdata = { local_id, txv };
         InspectionBuffer *buffer = MQTTSubscribeTopicGetData(det_ctx, ctx->transforms,
                 f, &cbdata, list_id, true);
@@ -203,6 +205,14 @@ void DetectMQTTSubscribeTopicRegister (void)
     sigmatch_table[DETECT_AL_MQTT_SUBSCRIBE_TOPIC].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_AL_MQTT_SUBSCRIBE_TOPIC].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
+    intmax_t val = 0;
+    if (ConfGetInt("mqtt.subscribe-topic-match-limit", &val)) {
+        subscribe_topic_match_limit = val;
+        SCLogDebug("Using MQTT SUBSCRIBE topic match-limit setting of: %i", subscribe_topic_match_limit);
+    }
+    if (subscribe_topic_match_limit == 0) {
+        SCLogDebug("Using unrestricted MQTT SUBSCRIBE topic matching");
+    }
 
     DetectAppLayerMpmRegister2("mqtt.subscribe.topic", SIG_FLAG_TOSERVER, 1,
             PrefilterMpmMQTTSubscribeTopicRegister, NULL,

--- a/src/detect-mqtt-unsubscribe-topic.c
+++ b/src/detect-mqtt-unsubscribe-topic.c
@@ -82,7 +82,7 @@ static InspectionBuffer *MQTTUnsubscribeTopicGetData(DetectEngineThreadCtx *det_
                 &data, &data_len) == 0) {
         return NULL;
     }
-
+    buffer->inspect = data;
     InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
     InspectionBufferApplyTransforms(buffer, transforms);
 

--- a/src/detect-mqtt-unsubscribe-topic.c
+++ b/src/detect-mqtt-unsubscribe-topic.c
@@ -80,8 +80,8 @@ static InspectionBuffer *MQTTUnsubscribeTopicGetData(DetectEngineThreadCtx *det_
 
     const uint8_t *data;
     uint32_t data_len;
-    if (rs_mqtt_tx_get_unsubscribe_topic(cbdata->txv, (uint32_t)cbdata->local_id,
-                &data, &data_len) == 0) {
+    if (rs_mqtt_tx_get_unsubscribe_topic(
+                cbdata->txv, (uint32_t)cbdata->local_id, &data, &data_len) == 0) {
         return NULL;
     }
     buffer->inspect = data;
@@ -104,7 +104,7 @@ static int DetectEngineInspectMQTTUnsubscribeTopic(
         transforms = engine->v2.transforms;
     }
 
-    while((unsubscribe_topic_match_limit == 0) || local_id < unsubscribe_topic_match_limit) {
+    while ((unsubscribe_topic_match_limit == 0) || local_id < unsubscribe_topic_match_limit) {
         struct MQTTUnsubscribeTopicGetDataArgs cbdata = { local_id, txv, };
         InspectionBuffer *buffer = MQTTUnsubscribeTopicGetData(det_ctx,
             transforms, f, &cbdata, engine->sm_list, false);
@@ -155,7 +155,7 @@ static void PrefilterTxMQTTUnsubscribeTopic(DetectEngineThreadCtx *det_ctx,
     const int list_id = ctx->list_id;
 
     int local_id = 0;
-    while((unsubscribe_topic_match_limit == 0) || local_id < unsubscribe_topic_match_limit) {
+    while ((unsubscribe_topic_match_limit == 0) || local_id < unsubscribe_topic_match_limit) {
         struct MQTTUnsubscribeTopicGetDataArgs cbdata = { local_id, txv };
         InspectionBuffer *buffer = MQTTUnsubscribeTopicGetData(det_ctx, ctx->transforms,
                 f, &cbdata, list_id, true);
@@ -208,7 +208,8 @@ void DetectMQTTUnsubscribeTopicRegister (void)
     intmax_t val = 0;
     if (ConfGetInt("mqtt.unsubscribe-topic-match-limit", &val)) {
         unsubscribe_topic_match_limit = val;
-        SCLogDebug("Using MQTT UNSUBSCRIBE topic match-limit setting of: %i", unsubscribe_topic_match_limit);
+        SCLogDebug("Using MQTT UNSUBSCRIBE topic match-limit setting of: %i",
+                unsubscribe_topic_match_limit);
     }
     if (unsubscribe_topic_match_limit == 0) {
         SCLogDebug("Using unrestricted MQTT UNSUBSCRIBE topic matching");

--- a/src/detect-mqtt-unsubscribe-topic.c
+++ b/src/detect-mqtt-unsubscribe-topic.c
@@ -78,7 +78,7 @@ static InspectionBuffer *MQTTUnsubscribeTopicGetData(DetectEngineThreadCtx *det_
 
     const uint8_t *data;
     uint32_t data_len;
-    if (rs_mqtt_tx_get_unsubscribe_topic(cbdata->txv, (uint16_t)cbdata->local_id,
+    if (rs_mqtt_tx_get_unsubscribe_topic(cbdata->txv, (uint32_t)cbdata->local_id,
                 &data, &data_len) == 0) {
         return NULL;
     }

--- a/src/detect-mqtt-unsubscribe-topic.c
+++ b/src/detect-mqtt-unsubscribe-topic.c
@@ -58,6 +58,8 @@ static int DetectMQTTUnsubscribeTopicSetup(DetectEngineCtx *, Signature *, const
 
 static int g_mqtt_unsubscribe_topic_buffer_id = 0;
 
+static int unsubscribe_topic_match_limit = 0;
+
 struct MQTTUnsubscribeTopicGetDataArgs {
     int local_id;
     void *txv;
@@ -102,7 +104,7 @@ static int DetectEngineInspectMQTTUnsubscribeTopic(
         transforms = engine->v2.transforms;
     }
 
-    while(1) {
+    while((unsubscribe_topic_match_limit == 0) || local_id < unsubscribe_topic_match_limit) {
         struct MQTTUnsubscribeTopicGetDataArgs cbdata = { local_id, txv, };
         InspectionBuffer *buffer = MQTTUnsubscribeTopicGetData(det_ctx,
             transforms, f, &cbdata, engine->sm_list, false);
@@ -153,7 +155,7 @@ static void PrefilterTxMQTTUnsubscribeTopic(DetectEngineThreadCtx *det_ctx,
     const int list_id = ctx->list_id;
 
     int local_id = 0;
-    while(1) {
+    while((unsubscribe_topic_match_limit == 0) || local_id < unsubscribe_topic_match_limit) {
         struct MQTTUnsubscribeTopicGetDataArgs cbdata = { local_id, txv };
         InspectionBuffer *buffer = MQTTUnsubscribeTopicGetData(det_ctx, ctx->transforms,
                 f, &cbdata, list_id, true);
@@ -203,6 +205,14 @@ void DetectMQTTUnsubscribeTopicRegister (void)
     sigmatch_table[DETECT_AL_MQTT_UNSUBSCRIBE_TOPIC].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_AL_MQTT_UNSUBSCRIBE_TOPIC].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
+    intmax_t val = 0;
+    if (ConfGetInt("mqtt.unsubscribe-topic-match-limit", &val)) {
+        unsubscribe_topic_match_limit = val;
+        SCLogDebug("Using MQTT UNSUBSCRIBE topic match-limit setting of: %i", unsubscribe_topic_match_limit);
+    }
+    if (unsubscribe_topic_match_limit == 0) {
+        SCLogDebug("Using unrestricted MQTT UNSUBSCRIBE topic matching");
+    }
 
     DetectAppLayerMpmRegister2("mqtt.unsubscribe.topic", SIG_FLAG_TOSERVER, 1,
             PrefilterMpmMQTTUnsubscribeTopicRegister, NULL,

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1115,6 +1115,11 @@ pcre:
   match-limit: 3500
   match-limit-recursion: 1500
 
+# MQTT topic detection depth
+mqtt:
+  subscribe-topic-match-limit: 100
+  unsubscribe-topic-match-limit: 100
+
 ##
 ## Advanced Traffic Tracking and Reconstruction Settings
 ##


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Make sure 32-bit unsigned values are used for multi-topic matching (see discussion here: https://github.com/OISF/suricata/pull/5622#discussion_r538529290). This helps avoiding an infinite loop introduced by allowing a too small variable to overflow.
- Make sure that `inspect` values in inspection buffers are initialized (thanks @catenacyber)
- Add a new config option set `mqtt.(un)subscribe-topic-match-limit` to limit the amount of topics matched in detection. This can be used to limit performance impacts when seeing lots of small topic subscriptions/unsubscriptions which might be malicious. Not sure if this is needed. To be discussed!