### PR TITLE
proto: Remove dependency on /etc/protocols

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -30,6 +30,20 @@ by the ones Suricata supplies.
 Major updates include new features, new default settings and often also
 remove features.
 
+Upgrading 6.0 to 7.0
+--------------------
+
+Major changes
+~~~~~~~~~~~~~
+
+Removals
+~~~~~~~~
+
+Logging changes
+~~~~~~~~~~~~~~~
+- Protocol values and their names are built-in to Suricata instead of using the system's ``/etc/protocols`` file. Some names and casing may have changed
+  in the values ``proto`` in ``eve.json`` log entries and other logs containing protocol names and values.
+
 Upgrading 5.0 to 6.0
 --------------------
 - SIP now enabled by default

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -126,7 +126,7 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)
     char alert_buffer[MAX_FASTLOG_BUFFER_SIZE];
 
     char proto[16] = "";
-    char *protoptr;
+    const char *protoptr;
     if (SCProtoNameValid(IP_GET_IPPROTO(p))) {
         protoptr = known_proto[IP_GET_IPPROTO(p)];
     } else {

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -210,7 +210,7 @@ static TmEcode AlertSyslogIPv4(ThreadVars *tv, const Packet *p, void *data)
         return TM_ECODE_OK;
 
     char proto[16] = "";
-    char *protoptr;
+    const char *protoptr;
     if (SCProtoNameValid(IPV4_GET_IPPROTO(p))) {
         protoptr = known_proto[IPV4_GET_IPPROTO(p)];
     } else {
@@ -268,7 +268,7 @@ static TmEcode AlertSyslogIPv6(ThreadVars *tv, const Packet *p, void *data)
         return TM_ECODE_OK;
 
     char proto[16] = "";
-    char *protoptr;
+    const char *protoptr;
     if (SCProtoNameValid(IPV6_GET_L4PROTO(p))) {
         protoptr = known_proto[IPV6_GET_L4PROTO(p)];
     } else {

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013 Open Information Security Foundation
+/* Copyright (C) 2013-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -239,8 +239,6 @@ void RunUnittests(int list_unittests, const char *regex_arg)
     TmqhSetup();
 
     CIDRInit();
-
-    SCProtoNameInit();
 
     TagInitCtx();
     SCReferenceConfInit();

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -346,7 +346,6 @@ static void GlobalsDestroy(SCInstance *suri)
     OutputDeregisterAll();
     FeatureTrackingRelease();
     TimeDeinit();
-    SCProtoNameDeInit();
     if (!suri->disabled_detect) {
         SCReferenceConfDeinit();
         SCClassConfDeinit();
@@ -2532,7 +2531,6 @@ int PostConfLoadedSetup(SCInstance *suri)
     TmqhSetup();
 
     CIDRInit();
-    SCProtoNameInit();
 
     TagInitCtx();
     PacketAlertTagInit();

--- a/src/util-proto-name.c
+++ b/src/util-proto-name.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -20,85 +20,170 @@
  *
  * \author Gurvinder Singh <gurvindersinghdahiya@gmail.com>
  *
- * File to provide the protocol names based on protocol numbers defined in the
- * specified protocol file.
+ * File to provide the protocol names based on protocol numbers defined by the
+ * IANA
  */
 
 #include "suricata-common.h"
 #include "util-proto-name.h"
-#include "util-byte.h"
 
 /** Lookup array to hold the information related to known protocol
- *  in /etc/protocols */
-char *known_proto[256];
-static int init_once = 0;
-
-static void SetDefault(const uint8_t proto, const char *string)
-{
-    if (known_proto[proto] == NULL) {
-        known_proto[proto] = SCStrdup(string);
-        if (unlikely(known_proto[proto] == NULL)) {
-            FatalError(SC_ERR_MEM_ALLOC, "failed to alloc protocol name");
-        }
-    }
-}
-
-/**
- *  \brief  Function to load the protocol names from the specified protocol
- *          file.
+ *  values
  */
-void SCProtoNameInit()
-{
-    BUG_ON(init_once);
-    init_once++;
-    memset(known_proto, 0x00, sizeof(known_proto));
 
-    /* Load the known protocols name from the /etc/protocols file */
-    FILE *fp = fopen(PROTO_FILE,"r");
-    if (fp != NULL) {
-        char line[200];
-        char *ptr = NULL;
-
-        while(fgets(line, sizeof(line), fp) != NULL) {
-            if (line[0] == '#')
-                continue;
-
-            char *name = strtok_r(line," \t", &ptr);
-            if (name == NULL)
-                continue;
-
-            char *proto_ch = strtok_r(NULL," \t", &ptr);
-            if (proto_ch == NULL)
-                continue;
-
-            uint8_t proto;
-            if (StringParseUint8(&proto, 10, 0, (const char *)proto_ch) < 0)
-                continue;
-
-            char *cname = strtok_r(NULL, " \t", &ptr);
-
-            if (known_proto[proto] != NULL) {
-                SCFree(known_proto[proto]);
-            }
-
-            if (cname != NULL) {
-                known_proto[proto] = SCStrdup(cname);
-            } else {
-                known_proto[proto] = SCStrdup(name);
-            }
-            if (unlikely(known_proto[proto] == NULL)) {
-                SCLogError(SC_ERR_MEM_ALLOC, "Failed proto name allocation");
-                continue;
-            }
-            int proto_len = strlen(known_proto[proto]);
-            if (proto_len > 0 && known_proto[proto][proto_len - 1] == '\n')
-                known_proto[proto][proto_len - 1] = '\0';
-        }
-        fclose(fp);
-    }
-
-    SetDefault(IPPROTO_SCTP, "SCTP");
-}
+const char *known_proto[256] = {
+    "HOPOPT",   /* 0x00: 0 - IPv6 Hop-by-Hop Option	RFC 8200 */
+    "ICMP",     /* 0x01: 1 - Internet Control Message Protocol	RFC 792 */
+    "IGMP",     /* 0x02: 2 - Internet Group Management Protocol	RFC 1112 */
+    "GGP",      /* 0x03: 3 - Gateway-to-Gateway Protocol	RFC 823 */
+    "IP-in-IP", /* 0x04: 4 - IP in IP (encapsulation)	RFC 2003 */
+    "ST",       /* 0x05: 5 - Internet Stream Protocol	RFC 1190, RFC 1819 */
+    "TCP",      /* 0x06: 6 - Transmission Control Protocol	RFC 793 */
+    "CBT",      /* 0x07: 7 - Core-based trees	RFC 2189 */
+    "EGP",      /* 0x08: 8 - Exterior Gateway Protocol	RFC 888 */
+    "IGP", /* 0x09: 9 - Interior Gateway Protocol (any private interior gateway, for example Cisco's
+              IGRP) */
+    "BBN-RCC-MON", /* 0x0A: 10 - BBN RCC Monitoring */
+    "NVP-II",      /* 0x0B: 11 - Network Voice Protocol	RFC 741 */
+    "PUP",         /* 0x0C: 12 - Xerox PUP */
+    "ARGUS",       /* 0x0D: 13 - ARGUS */
+    "EMCON",       /* 0x0E: 14 - EMCON */
+    "XNET",        /* 0x0F: 15 - Cross Net Debugger	IEN 158[2] */
+    "CHAOS",       /* 0x10: 16 - Chaos */
+    "UDP",         /* 0x11: 17 - User Datagram Protocol	RFC 768 */
+    "MUX",         /* 0x12: 18 - Multiplexing	IEN 90[3] */
+    "DCN-MEAS",    /* 0x13: 19 - DCN Measurement Subsystems */
+    "HMP",         /* 0x14: 20 - Host Monitoring Protocol	RFC 869 */
+    "PRM",         /* 0x15: 21 - Packet Radio Measurement */
+    "XNS-IDP",     /* 0x16: 22 - XEROX NS IDP */
+    "TRUNK-1",     /* 0x17: 23 - Trunk-1 */
+    "TRUNK-2",     /* 0x18: 24 - Trunk-2 */
+    "LEAF-1",      /* 0x19: 25 - Leaf-1 */
+    "LEAF-2",      /* 0x1A: 26 - Leaf-2 */
+    "RDP",         /* 0x1B: 27 - Reliable Data Protocol	RFC 908 */
+    "IRTP",        /* 0x1C: 28 - Internet Reliable Transaction Protocol	RFC 938 */
+    "ISO-TP4",     /* 0x1D: 29 - ISO Transport Protocol Class 4	RFC 905 */
+    "NETBLT",      /* 0x1E: 30 - Bulk Data Transfer Protocol	RFC 998 */
+    "MFE-NSP",     /* 0x1F: 31 - MFE Network Services Protocol */
+    "MERIT-INP",   /* 0x20: 32 - MERIT Internodal Protocol */
+    "DCCP",        /* 0x21: 33 - Datagram Congestion Control Protocol	RFC 4340 */
+    "3PC",         /* 0x22: 34 - Third Party Connect Protocol */
+    "IDPR",        /* 0x23: 35 - Inter-Domain Policy Routing Protocol	RFC 1479 */
+    "XTP",         /* 0x24: 36 - Xpress Transport Protocol */
+    "DDP",         /* 0x25: 37 - Datagram Delivery Protocol */
+    "IDPR-CMTP",   /* 0x26: 38 - IDPR Control Message Transport Protocol */
+    "TP++",        /* 0x27: 39 - TP++ Transport Protocol */
+    "IL",          /* 0x28: 40 - IL Transport Protocol */
+    "IPv6",        /* 0x29: 41 - IPv6 Encapsulation	RFC 2473 */
+    "SDRP",        /* 0x2A: 42 - Source Demand Routing Protocol	RFC 1940 */
+    "IPv6-Route",  /* 0x2B: 43 - Routing Header for IPv6	RFC 8200 */
+    "IPv6-Frag",   /* 0x2C: 44 - Fragment Header for IPv6	RFC 8200 */
+    "IDRP",        /* 0x2D: 45 - Inter-Domain Routing Protocol */
+    "RSVP",        /* 0x2E: 46 - Resource Reservation Protocol	RFC 2205 */
+    "GRE",         /* 0x2F: 47 - Generic Routing Encapsulation	RFC 2784, RFC 2890 */
+    "DSR",         /* 0x30: 48 - Dynamic Source Routing Protocol	RFC 4728 */
+    "BNA",         /* 0x31: 49 - Burroughs Network Architecture */
+    "ESP",         /* 0x32: 50 - Encapsulating Security Payload	RFC 4303 */
+    "AH",          /* 0x33: 51 - Authentication Header	RFC 4302 */
+    "I-NLSP",      /* 0x34: 52 - Integrated Net Layer Security Protocol	TUBA */
+    "SwIPe",       /* 0x35: 53 - SwIPe	RFC 5237 */
+    "NARP",        /* 0x36: 54 - NBMA Address Resolution Protocol	RFC 1735 */
+    "MOBILE",      /* 0x37: 55 - IP Mobility (Min Encap)	RFC 2004 */
+    "TLSP",      /* 0x38: 56 - Transport Layer Security Protocol (using Kryptonet key management) */
+    "SKIP",      /* 0x39: 57 - Simple Key-Management for Internet Protocol	RFC 2356 */
+    "IPv6-ICMP", /* 0x3A: 58 - ICMP for IPv6	RFC 4443, RFC 4884 */
+    "IPv6-NoNxt",  /* 0x3B: 59 - No Next Header for IPv6	RFC 8200 */
+    "IPv6-Opts",   /* 0x3C: 60 - Destination Options for IPv6	RFC 8200 */
+    "Any",         /* 0x3D: 61 - host internal protocol */
+    "CFTP",        /* 0x3E: 62 - CFTP */
+    "Any",         /* 0x3F: 63 - local network */
+    "SAT-EXPAK",   /* 0x40: 64 - SATNET and Backroom EXPAK */
+    "KRYPTOLAN",   /* 0x41: 65 - Kryptolan */
+    "RVD",         /* 0x42: 66 - MIT Remote Virtual Disk Protocol */
+    "IPPC",        /* 0x43: 67 - Internet Pluribus Packet Core */
+    "Any",         /* 0x44: 68 - distributed file system */
+    "SAT-MON",     /* 0x45: 69 - SATNET Monitoring */
+    "VISA",        /* 0x46: 70 - VISA Protocol */
+    "IPCU",        /* 0x47: 71 - Internet Packet Core Utility */
+    "CPNX",        /* 0x48: 72 - Computer Protocol Network Executive */
+    "CPHB",        /* 0x49: 73 - Computer Protocol Heart Beat */
+    "WSN",         /* 0x4A: 74 - Wang Span Network */
+    "PVP",         /* 0x4B: 75 - Packet Video Protocol */
+    "BR-SAT-MON",  /* 0x4C: 76 - Backroom SATNET Monitoring */
+    "SUN-ND",      /* 0x4D: 77 - SUN ND PROTOCOL-Temporary */
+    "WB-MON",      /* 0x4E: 78 - WIDEBAND Monitoring */
+    "WB-EXPAK",    /* 0x4F: 79 - WIDEBAND EXPAK */
+    "ISO-IP",      /* 0x50: 80 - International Organization for Standardization Internet Protocol */
+    "VMTP",        /* 0x51: 81 - Versatile Message Transaction Protocol	RFC 1045 */
+    "SECURE-VMTP", /* 0x52: 82 - Secure Versatile Message Transaction Protocol	RFC 1045 */
+    "VINES",       /* 0x53: 83 - VINES */
+    "TTP",         /* 0x54: 84 - TTP */
+    "NSFNET-IGP",  /* 0x55: 85 - NSFNET-IGP */
+    "DGP",         /* 0x56: 86 - Dissimilar Gateway Protocol */
+    "TCF",         /* 0x57: 87 - TCF */
+    "EIGRP",       /* 0x58: 88 - EIGRP	Informational RFC 7868 */
+    "OSPF",        /* 0x59: 89 - Open Shortest Path First	RFC 2328 */
+    "Sprite-RPC",  /* 0x5A: 90 - Sprite RPC Protocol */
+    "LARP",        /* 0x5B: 91 - Locus Address Resolution Protocol */
+    "MTP",         /* 0x5C: 92 - Multicast Transport Protocol */
+    "AX.25",       /* 0x5D: 93 - AX.25 */
+    "OS",          /* 0x5E: 94 - KA9Q NOS compatible IP over IP tunneling */
+    "MICP",        /* 0x5F: 95 - Mobile Internetworking Control Protocol */
+    "SCC-SP",      /* 0x60: 96 - Semaphore Communications Sec. Pro */
+    "ETHERIP",     /* 0x61: 97 - Ethernet-within-IP Encapsulation	RFC 3378 */
+    "ENCAP",       /* 0x62: 98 - Encapsulation Header	RFC 1241 */
+    "Any",         /* 0x63: 99 - private encryption scheme */
+    "GMTP",        /* 0x64: 100 - GMTP */
+    "IFMP",        /* 0x65: 101 - Ipsilon Flow Management Protocol */
+    "PNNI",        /* 0x66: 102 - PNNI over IP */
+    "PIM",         /* 0x67: 103 - Protocol Independent Multicast */
+    "ARIS",        /* 0x68: 104 - IBM's ARIS (Aggregate Route IP Switching) Protocol */
+    "SCPS",        /* 0x69: 105 - SCPS (Space Communications Protocol Standards)	SCPS-TP[4] */
+    "QNX",         /* 0x6A: 106 - QNX */
+    "A/N",         /* 0x6B: 107 - Active Networks */
+    "IPComp",      /* 0x6C: 108 - IP Payload Compression Protocol	RFC 3173 */
+    "SNP",         /* 0x6D: 109 - Sitara Networks Protocol */
+    "Compaq-Peer", /* 0x6E: 110 - Compaq Peer Protocol */
+    "IPX-in-IP",   /* 0x6F: 111 - IPX in IP */
+    "VRRP",  /* 0x70: 112 - Virtual Router Redundancy Protocol, Common Address Redundancy Protocol
+                (not IANA assigned)	VRRP:RFC 3768 */
+    "PGM",   /* 0x71: 113 - PGM Reliable Transport Protocol	RFC 3208 */
+    "Any",   /* 0x72: 114 - 0-hop protocol */
+    "L2TP",  /* 0x73: 115 - Layer Two Tunneling Protocol Version 3	RFC 3931 */
+    "DDX",   /* 0x74: 116 - D-II Data Exchange (DDX) */
+    "IATP",  /* 0x75: 117 - Interactive Agent Transfer Protocol */
+    "STP",   /* 0x76: 118 - Schedule Transfer Protocol */
+    "SRP",   /* 0x77: 119 - SpectraLink Radio Protocol */
+    "UTI",   /* 0x78: 120 - Universal Transport Interface Protocol */
+    "SMP",   /* 0x79: 121 - Simple Message Protocol */
+    "SM",    /* 0x7A: 122 - Simple Multicast Protocol	draft-perlman-simple-multicast-03 */
+    "PTP",   /* 0x7B: 123 - Performance Transparency Protocol */
+    "IS-IS", /* 0x7C: 124 - over IPv4	Intermediate System to Intermediate System (IS-IS) Protocol
+                over IPv4	RFC 1142 and RFC 1195 */
+    "FIRE",  /* 0x7D: 125 - Flexible Intra-AS Routing Environment */
+    "CRTP",  /* 0x7E: 126 - Combat Radio Transport Protocol */
+    "CRUDP", /* 0x7F: 127 - Combat Radio User Datagram */
+    "SSCOPMCE", /* 0x80: 128 - Service-Specific Connection-Oriented Protocol in a Multilink and
+                   Connectionless Environment	ITU-T Q.2111 (1999) */
+    "IPLT",     /* 0x81: 129 -  */
+    "SPS",      /* 0x82: 130 - Secure Packet Shield */
+    "PIPE",     /* 0x83: 131 - Private IP Encapsulation within IP	Expired I-D
+                   draft-petri-mobileip-pipe-00.txt */
+    "SCTP",     /* 0x84: 132 - Stream Control Transmission Protocol	RFC 4960 */
+    "FC",       /* 0x85: 133 - Fibre Channel */
+    "RSVP-E2E-IGNORE", /* 0x86: 134 - Reservation Protocol (RSVP) End-to-End Ignore	RFC 3175 */
+    "Mobility",        /* 0x87: 135 - Header	Mobility Extension Header for IPv6	RFC 6275 */
+    "UDPLite",         /* 0x88: 136 - Lightweight User Datagram Protocol	RFC 3828 */
+    "MPLS-in-IP",      /* 0x89: 137 - Multiprotocol Label Switching Encapsulated in IP	RFC 4023,
+                          RFC      5332 */
+    "manet",           /* 0x8A: 138 - MANET Protocols	RFC 5498 */
+    "HIP",             /* 0x8B: 139 - Host Identity Protocol	RFC 5201 */
+    "Shim6",           /* 0x8C: 140 - Site Multihoming by IPv6 Intermediation	RFC 5533 */
+    "WESP",            /* 0x8D: 141 - Wrapped Encapsulating Security Payload	RFC 5840 */
+    "ROHC",            /* 0x8E: 142 - Robust Header Compression	RFC 5856 */
+    "Ethernet" /* 0x8F: 143 - IPv6 Segment Routing (TEMPORARY - registered 2020-01-31, expires
+                  2021-01-31) */
+};
 
 /**
  * \brief   Function to check if the received protocol number is valid and do
@@ -110,17 +195,4 @@ void SCProtoNameInit()
 bool SCProtoNameValid(uint16_t proto)
 {
     return (proto <= 255 && known_proto[proto] != NULL);
-}
-
-/**
- *  \brief  Function to clears the memory used in storing the protocol names.
- */
-void SCProtoNameDeInit()
-{
-    int cnt;
-    /* clears the memory of loaded protocol names */
-    for (cnt = 0; cnt < 255; cnt++) {
-        if (known_proto[cnt] != NULL)
-            SCFree(known_proto[cnt]);
-    }
 }

--- a/src/util-proto-name.h
+++ b/src/util-proto-name.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -24,19 +24,12 @@
 #ifndef __UTIL_PROTO_NAME_H__
 #define	__UTIL_PROTO_NAME_H__
 
-#ifndef OS_WIN32
-#define PROTO_FILE    "/etc/protocols"
-#else
-#define PROTO_FILE    "C:\\Windows\\system32\\drivers\\etc\\protocol"
-#endif /* OS_WIN32 */
-
 /** Lookup array to hold the information related to known protocol
- *  in /etc/protocols */
-extern char *known_proto[256];
+ *  values
+ */
+extern const char *known_proto[256];
 
 bool SCProtoNameValid(uint16_t);
-void SCProtoNameInit(void);
-void SCProtoNameDeInit(void);
 
 #endif	/* __UTIL_PROTO_NAME_H__ */
 


### PR DESCRIPTION
Continuation of #6112

This commit eliminates the dependency on /etc/protocols and equivalent
on other platforms by using a static table of IANA assigned protocol
values (names, description).

Describe changes:
- Upgrade guide -- move note to logging section

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
