### PR TITLE
flow: provide flags accessor function - v1

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -222,6 +222,7 @@ pub enum Flow {}
 /// Extern functions operating on Flow.
 extern {
     pub fn FlowGetLastTimeAsParts(flow: &Flow, secs: *mut u64, usecs: *mut u64);
+    pub fn FlowGetFlags(flow: &Flow) -> u32;
 }
 
 /// Rust implementation of Flow.
@@ -236,5 +237,10 @@ impl Flow {
             FlowGetLastTimeAsParts(self, &mut secs, &mut usecs);
             std::time::Duration::new(secs, usecs as u32 * 1000)
         }
+    }
+
+    /// Return the flow flags.
+    pub fn get_flags(&self) -> u32 {
+        unsafe { FlowGetFlags(self) }
     }
 }

--- a/src/flow.c
+++ b/src/flow.c
@@ -1171,6 +1171,17 @@ void FlowGetLastTimeAsParts(Flow *flow, uint64_t *secs, uint64_t *usecs)
     *usecs = (uint64_t)flow->lastts.tv_usec;
 }
 
+/**
+ * \brief Get flow flags.
+ *
+ * A function to get the flow flags useful when the caller only has an
+ * opaque pointer to the flow structure.
+ */
+uint32_t FlowGetFlags(Flow *flow)
+{
+    return flow->flags;
+}
+
 /************************************Unittests*******************************/
 
 #ifdef UNITTESTS

--- a/src/flow.h
+++ b/src/flow.h
@@ -586,6 +586,7 @@ FlowStorageId GetFlowBypassInfoID(void);
 void RegisterFlowBypassInfo(void);
 
 void FlowGetLastTimeAsParts(Flow *flow, uint64_t *secs, uint64_t *usecs);
+uint32_t FlowGetFlags(Flow *flow);
 
 /** ----- Inline functions ----- */
 


### PR DESCRIPTION
Add an accessor function for flow flags. To be used by Rust where the flow struct is an opaque data type.