### PR TITLE
detect: runs flowbits detection on transactions

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -1174,6 +1174,12 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
             inspect_flags, total_matches, engine);
 
     if (engine == NULL && total_matches) {
+        if (stored_flags) {
+            if (DetectEnginePktInspectionRun(tv, det_ctx, s, f, p, NULL) == false) {
+                TRACE_SID_TXS(s->id, tx, "DetectEnginePktInspectionRun no match");
+                return false;
+            }
+        }
         inspect_flags |= DE_STATE_FLAG_FULL_INSPECT;
         TRACE_SID_TXS(s->id, tx, "MATCH");
         retval = true;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2836

Describe changes:
- Run `DetectEnginePktInspectionRun` for every `DetectRunTxInspectRule`

suricata-verify-pr: 493

https://github.com/OISF/suricata-verify/pull/493

Replaces #6092 

> The issue here seems to be that the flowbit logic isn't run at the expected moment. Can you look into ways to get it to run it at the right time w/o brute forcing it?

Assuming there is a problem in flow bit (and not in filemagic which can be replaced by its sticky buffer version to have no problem), the options are :
- prevent it before calling `DetectRunTxInspectRule` : seems more brute forcing to call a check earlier as it will called even more often
- in `DetectRunTxInspectRule` :
  * using a `DetectEngineAppInspectionEngine` for flow bits : but it would need to be defined for each protocol
  * rerun `DetectEnginePktInspectionRun` if there is a match and we have `stored_flags` defined : chosen option to reduce the performance impact
  * I think it impacts all pkt keywords, not only flow bits, but flowvar and others as well (even if some keywords combinations do not make sense to me)
- prevent it after returning from `DetectRunTxInspectRule` : a match seems definite at this point
