### PR TITLE
suricata-plugin.h: don't include autoconf.h - v1

### DIFF
--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -18,8 +18,6 @@
 #ifndef __SURICATA_PLUGIN_H__
 #define __SURICATA_PLUGIN_H__
 
-#include "autoconf.h"
-
 #include <stdint.h>
 #include <stdbool.h>
 


### PR DESCRIPTION
It is not required here and just creates double inclusion in some
scenarios.
