### PR TITLE
rust: Convert to use Default/Self

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -25,7 +25,7 @@ use std::os::raw::{c_void,c_char,c_int};
 use crate::core::SC;
 
 #[repr(C)]
-#[derive(Debug,PartialEq)]
+#[derive(Default, Debug,PartialEq)]
 pub struct AppLayerTxConfig {
     /// config: log flags
     log_flags: u8,
@@ -50,7 +50,7 @@ impl AppLayerTxConfig {
 }
 
 #[repr(C)]
-#[derive(Debug,PartialEq)]
+#[derive(Default, Debug,PartialEq)]
 pub struct AppLayerTxData {
     /// config: log flags
     pub config: AppLayerTxConfig,
@@ -351,7 +351,7 @@ impl AppLayerGetTxIterTuple {
 
 /// LoggerFlags tracks which loggers have already been executed.
 #[repr(C)]
-#[derive(Debug,PartialEq)]
+#[derive(Default, Debug,PartialEq)]
 pub struct LoggerFlags {
     flags: u32,
 }

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -88,7 +88,7 @@ macro_rules!export_tx_data_get {
 }
 
 #[repr(C)]
-#[derive(Debug,PartialEq,Copy,Clone)]
+#[derive(Default,Debug,PartialEq,Copy,Clone)]
 pub struct AppLayerResult {
     pub status: i32,
     pub consumed: u32,
@@ -97,20 +97,15 @@ pub struct AppLayerResult {
 
 impl AppLayerResult {
     /// parser has successfully processed in the input, and has consumed all of it
-    pub fn ok() -> AppLayerResult {
-        return AppLayerResult {
-            status: 0,
-            consumed: 0,
-            needed: 0,
-        };
+    pub fn ok() -> Self {
+        Default::default()
     }
     /// parser has hit an unrecoverable error. Returning this to the API
     /// leads to no further calls to the parser.
-    pub fn err() -> AppLayerResult {
-        return AppLayerResult {
+    pub fn err() -> Self {
+        return Self {
             status: -1,
-            consumed: 0,
-            needed: 0,
+            ..Default::default()
         };
     }
     /// parser needs more data. Through 'consumed' it will indicate how many
@@ -118,8 +113,8 @@ impl AppLayerResult {
     /// how many more bytes it needs before getting called again.
     /// Note: consumed should never be more than the input len
     ///       needed + consumed should be more than the input len
-    pub fn incomplete(consumed: u32, needed: u32) -> AppLayerResult {
-        return AppLayerResult {
+    pub fn incomplete(consumed: u32, needed: u32) -> Self {
+        return Self {
             status: 1,
             consumed: consumed,
             needed: needed,
@@ -358,10 +353,8 @@ pub struct LoggerFlags {
 
 impl LoggerFlags {
 
-    pub fn new() -> LoggerFlags {
-        return LoggerFlags{
-            flags: 0,
-        }
+    pub fn new() -> Self {
+        Default::default()
     }
 
     pub fn get(&self) -> u32 {

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -79,8 +79,8 @@ pub struct ConfNode {
 
 impl ConfNode {
 
-    pub fn wrap(conf: *const c_void) -> ConfNode {
-        return ConfNode{
+    pub fn wrap(conf: *const c_void) -> Self {
+        return Self {
             conf: conf,
         }
     }

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -157,7 +157,7 @@ pub fn get_req_type_for_resp(t: u8) -> u8 {
     }
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct DCERPCTransaction {
     pub id: u64, // internal transaction ID
     pub ctxid: u16,
@@ -184,31 +184,17 @@ pub struct DCERPCTransaction {
 }
 
 impl DCERPCTransaction {
-    pub fn new() -> DCERPCTransaction {
-        return DCERPCTransaction {
-            id: 0,
-            ctxid: 0,
-            opnum: 0,
-            first_request_seen: 0,
-            call_id: 0,
-            frag_cnt_ts: 0,
-            frag_cnt_tc: 0,
-            endianness: 0,
+    pub fn new() -> Self {
+        return Self {
             stub_data_buffer_ts: Vec::new(),
             stub_data_buffer_tc: Vec::new(),
-            stub_data_buffer_reset_ts: false,
-            stub_data_buffer_reset_tc: false,
-            req_done: false,
-            resp_done: false,
-            req_lost: false,
-            resp_lost: false,
             req_cmd: DCERPC_TYPE_REQUEST,
             resp_cmd: DCERPC_TYPE_RESPONSE,
             activityuuid: Vec::new(),
-            seqnum: 0,
             tx_data: AppLayerTxData::new(),
             de_state: None,
-        };
+            ..Default::default()
+        }
     }
 
     pub fn free(&mut self) {
@@ -250,7 +236,7 @@ pub struct DCERPCRequest {
     pub first_request_seen: u8,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct DCERPCUuidEntry {
     pub ctxid: u16,
     pub internal_id: u16,
@@ -262,16 +248,8 @@ pub struct DCERPCUuidEntry {
 }
 
 impl DCERPCUuidEntry {
-    pub fn new() -> DCERPCUuidEntry {
-        return DCERPCUuidEntry {
-            ctxid: 0,
-            internal_id: 0,
-            result: 0,
-            uuid: Vec::new(),
-            version: 0,
-            versionminor: 0,
-            flags: 0,
-        };
+    pub fn new() -> Self {
+        Default::default()
     }
 }
 
@@ -327,7 +305,7 @@ pub struct DCERPCBindAck {
     pub ctxitems: Vec<DCERPCBindAckResult>,
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct DCERPCState {
     pub header: Option<DCERPCHdr>,
     pub bind: Option<DCERPCBind>,
@@ -354,31 +332,12 @@ pub struct DCERPCState {
 }
 
 impl DCERPCState {
-    pub fn new() -> DCERPCState {
-        return DCERPCState {
-            header: None,
-            bind: None,
-            bindack: None,
-            transactions: Vec::new(),
-            buffer_ts: Vec::new(),
-            buffer_tc: Vec::new(),
-            pad: 0,
-            padleft: 0,
-            bytes_consumed: 0,
-            tx_id: 0,
-            query_completed: false,
+    pub fn new() -> Self {
+        return Self {
             data_needed_for_dir: core::STREAM_TOSERVER,
             prev_dir: core::STREAM_TOSERVER,
-            prev_tx_call_id: 0,
-            clear_bind_cache: false,
-            ts_gap: false,
-            tc_gap: false,
-            ts_ssn_gap: false,
-            tc_ssn_gap: false,
-            ts_ssn_trunc: false,
-            tc_ssn_trunc: false,
-            flow: None,
-        };
+            ..Default::default()
+        }
     }
 
     fn create_tx(&mut self, call_id: u32) -> DCERPCTransaction {

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -27,7 +27,7 @@ use crate::dcerpc::parser;
 // Constant DCERPC UDP Header length
 pub const DCERPC_UDP_HDR_LEN: i32 = 80;
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct DCERPCHdrUdp {
     pub rpc_vers: u8,
     pub pkt_type: u8,
@@ -50,18 +50,15 @@ pub struct DCERPCHdrUdp {
     pub serial_lo: u8,
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct DCERPCUDPState {
     pub tx_id: u64,
     pub transactions: Vec<DCERPCTransaction>,
 }
 
 impl DCERPCUDPState {
-    pub fn new() -> DCERPCUDPState {
-        return DCERPCUDPState {
-            tx_id: 0,
-            transactions: Vec::new(),
-        };
+    pub fn new() -> Self {
+        Default::default()
     }
 
     fn create_tx(&mut self,  hdr: &DCERPCHdrUdp) -> DCERPCTransaction {

--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -46,8 +46,8 @@ pub struct DCEOpnumRange {
 }
 
 impl DCEOpnumRange {
-    pub fn new() -> DCEOpnumRange {
-        return DCEOpnumRange {
+    pub fn new() -> Self {
+        return Self {
             range1: DETECT_DCE_OPNUM_RANGE_UNINITIALIZED,
             range2: DETECT_DCE_OPNUM_RANGE_UNINITIALIZED,
         };

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -129,6 +129,7 @@ impl Drop for DHCPTransaction {
 export_tx_get_detect_state!(rs_dhcp_tx_get_detect_state, DHCPTransaction);
 export_tx_set_detect_state!(rs_dhcp_tx_set_detect_state, DHCPTransaction);
 
+#[derive(Default)]
 pub struct DHCPState {
     // Internal transaction ID.
     tx_id: u64,
@@ -140,12 +141,8 @@ pub struct DHCPState {
 }
 
 impl DHCPState {
-    pub fn new() -> DHCPState {
-        return DHCPState {
-            tx_id: 0,
-            transactions: Vec::new(),
-            events: 0,
-        };
+    pub fn new() -> Self {
+        Default::default()
     }
 
     pub fn parse(&mut self, input: &[u8]) -> bool {

--- a/rust/src/dhcp/logger.rs
+++ b/rust/src/dhcp/logger.rs
@@ -30,10 +30,10 @@ pub struct DHCPLogger {
 
 impl DHCPLogger {
     
-    pub fn new(conf: ConfNode) -> DHCPLogger {
-        return DHCPLogger{
+    pub fn new(conf: ConfNode) -> Self {
+        return Self {
             extended: conf.get_child_bool("extended"),
-        };
+        }
     }
 
     fn get_type(&self, tx: &DHCPTransaction) -> Option<u8> {

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -315,8 +315,8 @@ pub struct DNSTransaction {
 
 impl DNSTransaction {
 
-    pub fn new() -> DNSTransaction {
-        return DNSTransaction{
+    pub fn new() -> Self {
+        return Self {
             id: 0,
             request: None,
             response: None,
@@ -398,6 +398,7 @@ impl ConfigTracker {
     }
 }
 
+#[derive(Default)]
 pub struct DNSState {
     // Internal transaction ID.
     pub tx_id: u64,
@@ -414,24 +415,12 @@ pub struct DNSState {
 
 impl DNSState {
 
-    pub fn new() -> DNSState {
-        return DNSState{
-            tx_id: 0,
-            transactions: Vec::new(),
-            events: 0,
-            config: None,
-            gap: false,
-        };
+    pub fn new() -> Self {
+            Default::default()
     }
 
-    pub fn new_tcp() -> DNSState {
-        return DNSState{
-            tx_id: 0,
-            transactions: Vec::new(),
-            events: 0,
-            config: None,
-            gap: false,
-        };
+    pub fn new_tcp() -> Self {
+            Default::default()
     }
 
     pub fn new_tx(&mut self) -> DNSTransaction {

--- a/rust/src/filetracker.rs
+++ b/rust/src/filetracker.rs
@@ -49,6 +49,7 @@ impl FileChunk {
 }
 
 #[derive(Debug)]
+#[derive(Default)]
 pub struct FileTransferTracker {
     file_size: u64,
     pub tracked: u64,
@@ -71,19 +72,8 @@ pub struct FileTransferTracker {
 impl FileTransferTracker {
     pub fn new() -> FileTransferTracker {
         FileTransferTracker {
-            file_size:0,
-            tracked:0,
-            cur_ooo:0,
-            track_id:0,
-            chunk_left:0,
-            tx_id:0,
-            fill_bytes:0,
-            file_open:false,
-            chunk_is_last:false,
-            chunk_is_ooo:false,
-            file_is_truncated:false,
-            cur_ooo_chunk_offset:0,
             chunks:HashMap::new(),
+            ..Default::default()
         }
     }
 

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -107,7 +107,7 @@ pub enum NFSTransactionTypeData {
     FILE(NFSTransactionFile),
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct NFSTransactionFile {
     /// additional procedures part of a single file transfer. Currently
     /// only COMMIT on WRITEs.
@@ -128,13 +128,10 @@ pub struct NFSTransactionFile {
 }
 
 impl NFSTransactionFile {
-    pub fn new() -> NFSTransactionFile {
-        return NFSTransactionFile {
-            file_additional_procs: Vec::new(),
-            chunk_count:0,
-            file_last_xid: 0,
-            post_gap_ts: 0,
+    pub fn new() -> Self {
+        return Self {
             file_tracker: FileTransferTracker::new(),
+            ..Default::default()
         }
     }
 }
@@ -185,8 +182,8 @@ pub struct NFSTransaction {
 }
 
 impl NFSTransaction {
-    pub fn new() -> NFSTransaction {
-        return NFSTransaction{
+    pub fn new() -> Self {
+        return Self {
             id: 0,
             xid: 0,
             procedure: 0,

--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -61,7 +61,7 @@ impl SMBCommonHdr {
     }
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct DCERPCIface {
     pub uuid: Vec<u8>,
     pub ver: u16,
@@ -72,19 +72,17 @@ pub struct DCERPCIface {
 }
 
 impl DCERPCIface {
-    pub fn new(uuid: Vec<u8>, ver: u16, ver_min: u16) -> DCERPCIface {
-        DCERPCIface {
+    pub fn new(uuid: Vec<u8>, ver: u16, ver_min: u16) -> Self {
+        Self {
             uuid: uuid,
             ver:ver,
             ver_min:ver_min,
-            ack_result:0,
-            ack_reason:0,
-            acked:false,
+            ..Default::default()
         }
     }
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct SMBTransactionDCERPC {
     pub opnum: u16,
     pub req_cmd: u8,
@@ -99,32 +97,19 @@ pub struct SMBTransactionDCERPC {
 }
 
 impl SMBTransactionDCERPC {
-    fn new_request(req: u8, call_id: u32) -> SMBTransactionDCERPC {
-        return SMBTransactionDCERPC {
+    fn new_request(req: u8, call_id: u32) -> Self {
+        return Self {
             opnum: 0,
             req_cmd: req,
             req_set: true,
-            res_cmd: 0,
-            res_set: false,
             call_id: call_id,
-            frag_cnt_ts: 0,
-            frag_cnt_tc: 0,
-            stub_data_ts:Vec::new(),
-            stub_data_tc:Vec::new(),
+            ..Default::default()
         }
     }
-    fn new_response(call_id: u32) -> SMBTransactionDCERPC {
-        return SMBTransactionDCERPC {
-            opnum: 0,
-            req_cmd: 0,
-            req_set: false,
-            res_cmd: 0,
-            res_set: false,
+    fn new_response(call_id: u32) -> Self {
+        return Self {
             call_id: call_id,
-            frag_cnt_ts: 0,
-            frag_cnt_tc: 0,
-            stub_data_ts:Vec::new(),
-            stub_data_tc:Vec::new(),
+            ..Default::default()
         }
     }
     pub fn set_result(&mut self, res: u8) {

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -22,7 +22,7 @@ use crate::filecontainer::*;
 use crate::smb::smb::*;
 
 /// File tracking transaction. Single direction only.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct SMBTransactionFile {
     pub direction: u8,
     pub fuid: Vec<u8>,
@@ -35,14 +35,10 @@ pub struct SMBTransactionFile {
 }
 
 impl SMBTransactionFile {
-    pub fn new() -> SMBTransactionFile {
-        return SMBTransactionFile {
-            direction: 0,
-            fuid: Vec::new(),
-            file_name: Vec::new(),
-            share_name: Vec::new(),
+    pub fn new() -> Self {
+        return Self {
             file_tracker: FileTransferTracker::new(),
-            post_gap_ts: 0,
+            ..Default::default()
         }
     }
 }

--- a/rust/src/smb/session.rs
+++ b/rust/src/smb/session.rs
@@ -20,7 +20,7 @@ use crate::smb::smb::*;
 use crate::smb::smb1_session::*;
 use crate::smb::auth::*;
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct SMBTransactionSessionSetup {
     pub request_host: Option<SessionSetupRequest>,
     pub response_host: Option<SessionSetupResponse>,
@@ -29,13 +29,8 @@ pub struct SMBTransactionSessionSetup {
 }
 
 impl SMBTransactionSessionSetup {
-    pub fn new() -> SMBTransactionSessionSetup {
-        return SMBTransactionSessionSetup {
-            request_host: None,
-            response_host: None,
-            ntlmssp: None,
-            krb_ticket: None,
-        }
+    pub fn new() -> Self {
+        return Default::default()
     }
 }
 

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -192,7 +192,7 @@ pub fn ntlmssp_type_string(c: u32) -> String {
     }.to_string()
 }
 
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Default, Eq, PartialEq, Debug, Clone)]
 pub struct SMBVerCmdStat {
     smb_ver: u8,
     smb1_cmd: u8,
@@ -205,60 +205,40 @@ pub struct SMBVerCmdStat {
 }
 
 impl SMBVerCmdStat {
-    pub fn new() -> SMBVerCmdStat {
-        return SMBVerCmdStat {
-            smb_ver: 0,
-            smb1_cmd: 0,
-            smb2_cmd: 0,
-            status_set: false,
-            status_is_dos_error: false,
-            status_error_class: 0,
-            status: 0,
-        }
+    pub fn new() -> Self {
+        Default::default()
     }
-    pub fn new1(cmd: u8) -> SMBVerCmdStat {
-        return SMBVerCmdStat {
+    pub fn new1(cmd: u8) -> Self {
+        return Self {
             smb_ver: 1,
             smb1_cmd: cmd,
-            smb2_cmd: 0,
-            status_set: false,
-            status_is_dos_error: false,
-            status_error_class: 0,
-            status: 0,
+            ..Default::default()
         }
     }
-    pub fn new1_with_ntstatus(cmd: u8, status: u32) -> SMBVerCmdStat {
-        return SMBVerCmdStat {
+    pub fn new1_with_ntstatus(cmd: u8, status: u32) -> Self {
+        return Self {
             smb_ver: 1,
             smb1_cmd: cmd,
-            smb2_cmd: 0,
             status_set: true,
-            status_is_dos_error: false,
-            status_error_class: 0,
             status: status,
+            ..Default::default()
         }
     }
-    pub fn new2(cmd: u16) -> SMBVerCmdStat {
-        return SMBVerCmdStat {
+    pub fn new2(cmd: u16) -> Self {
+        return Self {
             smb_ver: 2,
-            smb1_cmd: 0,
             smb2_cmd: cmd,
-            status_set: false,
-            status_is_dos_error: false,
-            status_error_class: 0,
-            status: 0,
+            ..Default::default()
         }
     }
 
-    pub fn new2_with_ntstatus(cmd: u16, status: u32) -> SMBVerCmdStat {
-        return SMBVerCmdStat {
+    pub fn new2_with_ntstatus(cmd: u16, status: u32) -> Self {
+        return Self {
             smb_ver: 2,
-            smb1_cmd: 0,
             smb2_cmd: cmd,
             status_set: true,
-            status_is_dos_error: false,
-            status_error_class: 0,
             status: status,
+            ..Default::default()
         }
     }
 
@@ -338,8 +318,8 @@ pub struct SMBFiletime {
 }
 
 impl SMBFiletime {
-    pub fn new(raw: u64) -> SMBFiletime {
-        SMBFiletime {
+    pub fn new(raw: u64) -> Self {
+        Self {
             ts: raw,
         }
     }
@@ -380,9 +360,9 @@ pub struct SMBTransactionSetFilePathInfo {
 
 impl SMBTransactionSetFilePathInfo {
     pub fn new(filename: Vec<u8>, fid: Vec<u8>, subcmd: u16, loi: u16, delete_on_close: bool)
-        -> SMBTransactionSetFilePathInfo
+        -> Self
     {
-        return SMBTransactionSetFilePathInfo {
+        return Self {
             filename: filename, fid: fid,
             subcmd: subcmd,
             loi: loi,
@@ -438,8 +418,8 @@ pub struct SMBTransactionRename {
 }
 
 impl SMBTransactionRename {
-    pub fn new(fuid: Vec<u8>, oldname: Vec<u8>, newname: Vec<u8>) -> SMBTransactionRename {
-        return SMBTransactionRename {
+    pub fn new(fuid: Vec<u8>, oldname: Vec<u8>, newname: Vec<u8>) -> Self {
+        return Self {
             fuid: fuid, oldname: oldname, newname: newname,
         }
     }
@@ -463,7 +443,7 @@ impl SMBState {
     }
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct SMBTransactionCreate {
     pub disposition: u32,
     pub delete_on_close: bool,
@@ -480,23 +460,18 @@ pub struct SMBTransactionCreate {
 }
 
 impl SMBTransactionCreate {
-    pub fn new(filename: Vec<u8>, disp: u32, del: bool, dir: bool) -> SMBTransactionCreate {
-        return SMBTransactionCreate {
+    pub fn new(filename: Vec<u8>, disp: u32, del: bool, dir: bool) -> Self {
+        return Self {
             disposition: disp,
             delete_on_close: del,
             directory: dir,
             filename: filename,
-            guid: Vec::new(),
-            create_ts: 0,
-            last_access_ts: 0,
-            last_write_ts: 0,
-            last_change_ts: 0,
-            size: 0,
+            ..Default::default()
         }
     }
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct SMBTransactionNegotiate {
     pub smb_ver: u8,
     pub dialects: Vec<Vec<u8>>,
@@ -508,18 +483,16 @@ pub struct SMBTransactionNegotiate {
 }
 
 impl SMBTransactionNegotiate {
-    pub fn new(smb_ver: u8) -> SMBTransactionNegotiate {
-        return SMBTransactionNegotiate {
+    pub fn new(smb_ver: u8) -> Self {
+        return Self {
             smb_ver: smb_ver,
-            dialects: Vec::new(),
-            dialects2: Vec::new(),
-            client_guid: None,
             server_guid: Vec::with_capacity(16),
+            ..Default::default()
         }
     }
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct SMBTransactionTreeConnect {
     pub is_pipe: bool,
     pub share_type: u8,
@@ -532,14 +505,10 @@ pub struct SMBTransactionTreeConnect {
 }
 
 impl SMBTransactionTreeConnect {
-    pub fn new(share_name: Vec<u8>) -> SMBTransactionTreeConnect {
-        return SMBTransactionTreeConnect {
-            is_pipe:false,
-            share_type: 0,
-            tree_id:0,
+    pub fn new(share_name: Vec<u8>) -> Self {
+        return Self {
             share_name:share_name,
-            req_service: None,
-            res_service: None,
+            ..Default::default()
         }
     }
 }
@@ -567,17 +536,17 @@ pub struct SMBTransaction {
 }
 
 impl SMBTransaction {
-    pub fn new() -> SMBTransaction {
-        return SMBTransaction{
-            id: 0,
-            vercmd: SMBVerCmdStat::new(),
-            hdr: SMBCommonHdr::init(),
-            request_done: false,
-            response_done: false,
-            type_data: None,
-            de_state: None,
-            events: std::ptr::null_mut(),
-            tx_data: AppLayerTxData::new(),
+    pub fn new() -> Self {
+        return Self {
+              id: 0,
+              vercmd: SMBVerCmdStat::new(),
+              hdr: SMBCommonHdr::init(),
+              request_done: false,
+              response_done: false,
+              type_data: None,
+              de_state: None,
+              events: std::ptr::null_mut(),
+              tx_data: AppLayerTxData::new(),
         }
     }
 
@@ -616,8 +585,8 @@ pub struct SMBFileGUIDOffset {
 }
 
 impl SMBFileGUIDOffset {
-    pub fn new(guid: Vec<u8>, offset: u64) -> SMBFileGUIDOffset {
-        SMBFileGUIDOffset {
+    pub fn new(guid: Vec<u8>, offset: u64) -> Self {
+        Self {
             guid:guid,
             offset:offset,
         }
@@ -637,7 +606,7 @@ pub const SMBHDR_TYPE_TRANS_FRAG:  u32 = 8;
 pub const SMBHDR_TYPE_TREE:        u32 = 9;
 pub const SMBHDR_TYPE_DCERPCTX:    u32 = 10;
 
-#[derive(Hash, Eq, PartialEq, Debug)]
+#[derive(Default, Hash, Eq, PartialEq, Debug)]
 pub struct SMBCommonHdr {
     pub ssn_id: u64,
     pub tree_id: u32,
@@ -646,16 +615,11 @@ pub struct SMBCommonHdr {
 }
 
 impl SMBCommonHdr {
-    pub fn init() -> SMBCommonHdr {
-        SMBCommonHdr {
-            rec_type : 0,
-            ssn_id : 0,
-            tree_id : 0,
-            msg_id : 0,
-        }
+    pub fn init() -> Self {
+        Default::default()
     }
-    pub fn new(rec_type: u32, ssn_id: u64, tree_id: u32, msg_id: u64) -> SMBCommonHdr {
-        SMBCommonHdr {
+    pub fn new(rec_type: u32, ssn_id: u64, tree_id: u32, msg_id: u64) -> Self {
+        Self {
             rec_type : rec_type,
             ssn_id : ssn_id,
             tree_id : tree_id,
@@ -712,8 +676,8 @@ pub struct SMBHashKeyHdrGuid {
 }
 
 impl SMBHashKeyHdrGuid {
-    pub fn new(hdr: SMBCommonHdr, guid: Vec<u8>) -> SMBHashKeyHdrGuid {
-        SMBHashKeyHdrGuid {
+    pub fn new(hdr: SMBCommonHdr, guid: Vec<u8>) -> Self {
+        Self {
             hdr: hdr, guid: guid,
         }
     }
@@ -726,8 +690,8 @@ pub struct SMBTree {
 }
 
 impl SMBTree {
-    pub fn new(name: Vec<u8>, is_pipe: bool) -> SMBTree {
-        SMBTree {
+    pub fn new(name: Vec<u8>, is_pipe: bool) -> Self {
+        Self {
             name:name,
             is_pipe:is_pipe,
         }
@@ -802,8 +766,8 @@ pub struct SMBState<> {
 
 impl SMBState {
     /// Allocation function for a new TLS parser instance
-    pub fn new() -> SMBState {
-        SMBState {
+    pub fn new() -> Self {
+        Self {
             ssn2vec_map:HashMap::new(),
             guid2name_map:HashMap::new(),
             ssn2vecoffset_map:HashMap::new(),

--- a/rust/src/smb/smb2_ioctl.rs
+++ b/rust/src/smb/smb2_ioctl.rs
@@ -28,8 +28,8 @@ pub struct SMBTransactionIoctl {
 }
 
 impl SMBTransactionIoctl {
-    pub fn new(func: u32) -> SMBTransactionIoctl {
-        return SMBTransactionIoctl {
+    pub fn new(func: u32) -> Self {
+        return Self {
             func: func,
         }
     }


### PR DESCRIPTION
This PR updates the Rust source modules to use the more "modern" Self/Default constructs.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4497](https://redmine.openinfosecfoundation.org/issues/4497)

Describe changes:
- Modify to use Self/Default constructs within Rust source code modules


#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
