### PR TITLE
optimization: Eliminate NULL pkt checks

### DIFF
--- a/src/decode-chdlc.c
+++ b/src/decode-chdlc.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -35,12 +35,15 @@
 #include "decode-chdlc.h"
 #include "decode-events.h"
 
+#include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
 
 int DecodeCHDLC(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                    const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     StatsIncr(tv, dtv->counter_chdlc);
 
     if (unlikely(len < CHDLC_HEADER_LEN)) {
@@ -56,8 +59,6 @@ int DecodeCHDLC(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     }
 
     CHDLCHdr *hdr = (CHDLCHdr *)pkt;
-    if (unlikely(hdr == NULL))
-        return TM_ECODE_FAILED;
 
     SCLogDebug("p %p pkt %p ether type %04x", p, pkt, SCNtohs(hdr->protocol));
 

--- a/src/decode-erspan.c
+++ b/src/decode-erspan.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -36,6 +36,7 @@
 #include "decode-events.h"
 #include "decode-erspan.h"
 
+#include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
 
@@ -74,6 +75,8 @@ int DecodeERSPANTypeI(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
  */
 int DecodeERSPAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     StatsIncr(tv, dtv->counter_erspan);
 
     if (len < sizeof(ErspanHdr)) {

--- a/src/decode-esp.c
+++ b/src/decode-esp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -31,8 +31,12 @@
 #include "decode-esp.h"
 #include "flow.h"
 
+#include "util-validate.h"
+
 static int DecodeESPPacket(ThreadVars *tv, Packet *p, const uint8_t *pkt, uint16_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     if (unlikely(len < ESP_HEADER_LEN)) {
         ENGINE_SET_INVALID_EVENT(p, ESP_PKT_TOO_SMALL);
         return -1;
@@ -59,6 +63,8 @@ static int DecodeESPPacket(ThreadVars *tv, Packet *p, const uint8_t *pkt, uint16
  */
 int DecodeESP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint16_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     StatsIncr(tv, dtv->counter_esp);
 
     if (!PacketIncreaseCheckLayers(p)) {

--- a/src/decode-ethernet.c
+++ b/src/decode-ethernet.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -35,12 +35,15 @@
 #include "decode-ethernet.h"
 #include "decode-events.h"
 
+#include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
 
 int DecodeEthernet(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                    const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     StatsIncr(tv, dtv->counter_eth);
 
     if (unlikely(len < ETHERNET_HEADER_LEN)) {
@@ -52,8 +55,6 @@ int DecodeEthernet(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         return TM_ECODE_FAILED;
     }
     p->ethh = (EthernetHdr *)pkt;
-    if (unlikely(p->ethh == NULL))
-        return TM_ECODE_FAILED;
 
     SCLogDebug("p %p pkt %p ether type %04x", p, pkt, SCNtohs(p->ethh->eth_type));
 

--- a/src/decode-geneve.c
+++ b/src/decode-geneve.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -35,6 +35,7 @@
 
 #include "flow.h"
 
+#include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
 
@@ -183,6 +184,8 @@ static inline bool IsHeaderLengthConsistentWithOptions(const GeneveHeader *genev
  */
 int DecodeGeneve(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     const GeneveHeader *geneve_hdr = (const GeneveHeader *)pkt;
 
     uint16_t eth_type, geneve_hdr_len;

--- a/src/decode-gre.c
+++ b/src/decode-gre.c
@@ -36,6 +36,7 @@
 #include "decode-events.h"
 #include "decode-gre.h"
 
+#include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
 
@@ -45,6 +46,8 @@
 
 int DecodeGRE(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     uint32_t header_len = GRE_HDR_LEN;
     GRESreHdr *gsre = NULL;
 
@@ -59,8 +62,6 @@ int DecodeGRE(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *p
     }
 
     p->greh = (GREHdr *)pkt;
-    if(p->greh == NULL)
-        return TM_ECODE_FAILED;
 
     SCLogDebug("p %p pkt %p GRE protocol %04x Len: %d GRE version %x",
         p, pkt, GRE_GET_PROTO(p->greh), len,GRE_GET_VERSION(p->greh));

--- a/src/decode-mpls.c
+++ b/src/decode-mpls.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Open Information Security Foundation
+/* Copyright (C) 2014-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -25,6 +25,8 @@
 
 #include "suricata-common.h"
 #include "decode.h"
+
+#include "util-validate.h"
 #include "util-unittest.h"
 
 #define MPLS_HEADER_LEN         4
@@ -47,6 +49,8 @@
 int DecodeMPLS(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     uint32_t shim;
     int label;
     int event = 0;

--- a/src/decode-nsh.c
+++ b/src/decode-nsh.c
@@ -45,9 +45,11 @@
 
 int DecodeNSH(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     StatsIncr(tv, dtv->counter_nsh);
 
-    /* Check mimimum header size */
+    /* Check minimum header size */
     if (len < sizeof(NshHdr)) {
         ENGINE_SET_INVALID_EVENT(p, NSH_HEADER_TOO_SMALL);
         return TM_ECODE_FAILED;

--- a/src/decode-nsh.c
+++ b/src/decode-nsh.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -35,6 +35,7 @@
 #include "decode-events.h"
 #include "decode-nsh.h"
 
+#include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
 

--- a/src/decode-null.c
+++ b/src/decode-null.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015 Open Information Security Foundation
+/* Copyright (C) 2015-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -36,6 +36,7 @@
 #include "decode-raw.h"
 #include "decode-events.h"
 
+#include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
 
@@ -48,6 +49,8 @@
 int DecodeNull(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     StatsIncr(tv, dtv->counter_null);
 
     if (unlikely(len < HDR_SIZE)) {

--- a/src/decode-ppp.c
+++ b/src/decode-ppp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -37,12 +37,15 @@
 
 #include "flow.h"
 
+#include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
 
 int DecodePPP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     StatsIncr(tv, dtv->counter_ppp);
 
     if (unlikely(len < PPP_HEADER_LEN)) {
@@ -54,8 +57,6 @@ int DecodePPP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     }
 
     p->ppph = (PPPHdr *)pkt;
-    if (unlikely(p->ppph == NULL))
-        return TM_ECODE_FAILED;
 
     SCLogDebug("p %p pkt %p PPP protocol %04x Len: %" PRIu32 "",
         p, pkt, SCNtohs(p->ppph->protocol), len);

--- a/src/decode-pppoe.c
+++ b/src/decode-pppoe.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -41,6 +41,7 @@
 
 #include "flow.h"
 
+#include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
 
@@ -50,6 +51,8 @@
 int DecodePPPOEDiscovery(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     StatsIncr(tv, dtv->counter_pppoe);
 
     if (len < PPPOE_DISCOVERY_HEADER_MIN_LEN) {
@@ -58,8 +61,6 @@ int DecodePPPOEDiscovery(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     }
 
     p->pppoedh = (PPPOEDiscoveryHdr *)pkt;
-    if (p->pppoedh == NULL)
-        return TM_ECODE_FAILED;
 
     /* parse the PPPOE code */
     switch (p->pppoedh->pppoe_code)
@@ -130,6 +131,8 @@ int DecodePPPOEDiscovery(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 int DecodePPPOESession(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     StatsIncr(tv, dtv->counter_pppoe);
 
     if (len < PPPOE_SESSION_HEADER_LEN) {
@@ -138,8 +141,6 @@ int DecodePPPOESession(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     }
 
     p->pppoesh = (PPPOESessionHdr *)pkt;
-    if (p->pppoesh == NULL)
-        return TM_ECODE_FAILED;
 
     SCLogDebug("PPPOE VERSION %" PRIu32 " TYPE %" PRIu32 " CODE %" PRIu32 " SESSIONID %" PRIu32 " LENGTH %" PRIu32 "",
            PPPOE_SESSION_GET_VERSION(p->pppoesh),  PPPOE_SESSION_GET_TYPE(p->pppoesh),  p->pppoesh->pppoe_code,  SCNtohs(p->pppoesh->session_id),  SCNtohs(p->pppoesh->pppoe_length));

--- a/src/decode-raw.c
+++ b/src/decode-raw.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -35,6 +35,7 @@
 #include "decode-raw.h"
 #include "decode-events.h"
 
+#include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
 
@@ -46,6 +47,8 @@
 int DecodeRaw(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     StatsIncr(tv, dtv->counter_raw);
 
     /* If it is ipv4 or ipv6 it should at least be the size of ipv4 */

--- a/src/decode-sctp.c
+++ b/src/decode-sctp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2011 Open Information Security Foundation
+/* Copyright (C) 2011-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -34,6 +34,8 @@
 #include "decode.h"
 #include "decode-sctp.h"
 #include "decode-events.h"
+
+#include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
 #include "util-optimize.h"
@@ -41,6 +43,8 @@
 
 static int DecodeSCTPPacket(ThreadVars *tv, Packet *p, const uint8_t *pkt, uint16_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     if (unlikely(len < SCTP_HEADER_LEN)) {
         ENGINE_SET_INVALID_EVENT(p, SCTP_PKT_TOO_SMALL);
         return -1;

--- a/src/decode-sll.c
+++ b/src/decode-sll.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -34,11 +34,15 @@
 #include "decode.h"
 #include "decode-sll.h"
 #include "decode-events.h"
+
+#include "util-validate.h"
 #include "util-debug.h"
 
 int DecodeSll(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     StatsIncr(tv, dtv->counter_sll);
 
     if (unlikely(len < SLL_HEADER_LEN)) {
@@ -50,8 +54,6 @@ int DecodeSll(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     }
 
     SllHdr *sllh = (SllHdr *)pkt;
-    if (unlikely(sllh == NULL))
-        return TM_ECODE_FAILED;
 
     SCLogDebug("p %p pkt %p sll_protocol %04x", p, pkt, SCNtohs(sllh->sll_protocol));
 

--- a/src/decode-template.c
+++ b/src/decode-template.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2018 Open Information Security Foundation
+/* Copyright (C) 2015-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -36,6 +36,8 @@
 #include "decode-events.h"
 #include "decode-template.h"
 
+#include "util-validate.h"
+
 /**
  * \brief Function to decode TEMPLATE packets
  * \param tv thread vars
@@ -49,6 +51,8 @@
 int DecodeTEMPLATE(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                    const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     /* TODO add counter for your type of packet to DecodeThreadVars,
      * and register it in DecodeRegisterPerfCounters */
     //StatsIncr(tv, dtv->counter_template);

--- a/src/decode-teredo.c
+++ b/src/decode-teredo.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2012-2020 Open Information Security Foundation
+/* Copyright (C) 2012-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -36,6 +36,8 @@
 #include "decode.h"
 #include "decode-ipv6.h"
 #include "decode-teredo.h"
+
+#include "util-validate.h"
 #include "util-debug.h"
 #include "conf.h"
 #include "detect-engine-port.h"
@@ -124,6 +126,8 @@ void DecodeTeredoConfig(void)
 int DecodeTeredo(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         const uint8_t *pkt, uint16_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     if (!g_teredo_enabled)
         return TM_ECODE_FAILED;
 

--- a/src/decode-vlan.c
+++ b/src/decode-vlan.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -37,6 +37,7 @@
 
 #include "flow.h"
 
+#include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
 
@@ -59,6 +60,8 @@
 int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     uint32_t proto;
 
     if (p->vlan_idx == 0)
@@ -79,8 +82,6 @@ int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     }
 
     VLANHdr *vlan_hdr = (VLANHdr *)pkt;
-    if(vlan_hdr == NULL)
-        return TM_ECODE_FAILED;
 
     proto = GET_VLAN_PROTO(vlan_hdr);
 
@@ -120,6 +121,8 @@ typedef struct IEEE8021ahHdr_ {
 int DecodeIEEE8021ah(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     StatsIncr(tv, dtv->counter_ieee8021ah);
 
     if (len < IEEE8021AH_HEADER_LEN) {

--- a/src/decode-vntag.c
+++ b/src/decode-vntag.c
@@ -36,6 +36,7 @@
 
 #include "flow.h"
 
+#include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
 
@@ -52,11 +53,12 @@
  * \param p pointer to the packet struct
  * \param pkt pointer to the raw packet
  * \param len packet len
- * \param pq pointer to the packet queue
  *
  */
 int DecodeVNTag(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint32_t len)
 {
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
     StatsIncr(tv, dtv->counter_vntag);
 
     if (len < VNTAG_HEADER_LEN) {
@@ -69,8 +71,6 @@ int DecodeVNTag(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t 
     }
 
     VNTagHdr *vntag_hdr = (VNTagHdr *)pkt;
-    if (vntag_hdr == NULL)
-        return TM_ECODE_FAILED;
 
     uint16_t proto = GET_VNTAG_PROTO(vntag_hdr);
 

--- a/src/decode-vxlan.c
+++ b/src/decode-vxlan.c
@@ -126,10 +126,7 @@ void DecodeVXLANConfig(void)
 int DecodeVXLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         const uint8_t *pkt, uint32_t len)
 {
-    EthernetHdr *ethh = (EthernetHdr *)(pkt + VXLAN_HEADER_LEN);
-
-    uint16_t eth_type;
-    int decode_tunnel_proto = DECODE_TUNNEL_UNSET;
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
 
     /* Initial packet validation */
     if (unlikely(!g_vxlan_enabled))
@@ -153,8 +150,11 @@ int DecodeVXLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     /* Increment stats counter for VXLAN packets */
     StatsIncr(tv, dtv->counter_vxlan);
 
+    EthernetHdr *ethh = (EthernetHdr *)(pkt + VXLAN_HEADER_LEN);
+    int decode_tunnel_proto = DECODE_TUNNEL_UNSET;
+
     /* Look at encapsulated Ethernet frame to get next protocol  */
-    eth_type = SCNtohs(ethh->eth_type);
+    uint16_t eth_type = SCNtohs(ethh->eth_type);
     SCLogDebug("VXLAN ethertype 0x%04x", eth_type);
 
     switch (eth_type) {

--- a/src/decode-vxlan.c
+++ b/src/decode-vxlan.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Open Information Security Foundation
+/* Copyright (C) 2019-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -35,6 +35,7 @@
 
 #include "flow.h"
 
+#include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
 


### PR DESCRIPTION
This PR eliminates the NULL pkt check performed by each decoder.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4496](https://redmine.openinfosecfoundation.org/issues/4496)

Describe changes:
- Remove NULL pkt checks in decoders
- Re-order variable initialization for VXLAN decoder.
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
