### PR TITLE
output: Fix possible null deref

### DIFF
--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -328,12 +328,11 @@ bool SCLogOpenThreadedFile(
             SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate threads container");
             return false;
         }
-        if (append) {
-            parent_ctx->threads->append = SCStrdup(append);
-            if (!parent_ctx->threads->append) {
-                SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate threads append setting");
-                goto error_exit;
-            }
+
+        parent_ctx->threads->append = SCStrdup(append == NULL ? DEFAULT_LOG_MODE_APPEND : append);
+        if (!parent_ctx->threads->append) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate threads append setting");
+            goto error_exit;
         }
 
         parent_ctx->threads->slot_count = slot_count;
@@ -344,9 +343,8 @@ bool SCLogOpenThreadedFile(
         }
         SCLogDebug("Allocated %d file context pointers for threaded array",
                     parent_ctx->threads->slot_count);
-        int slot = 1;
-        for (; slot < parent_ctx->threads->slot_count; slot++) {
-            if (!LogFileNewThreadedCtx(parent_ctx, log_path, append, slot)) {
+        for (int slot = 1; slot < parent_ctx->threads->slot_count; slot++) {
+            if (!LogFileNewThreadedCtx(parent_ctx, log_path, parent_ctx->threads->append, slot)) {
                 /* TODO: clear allocated entries [1, slot) */
                 goto error_exit;
             }


### PR DESCRIPTION
This commit corrects an issue uncovered by Coverity. See the redmine
issue for details: https://redmine.openinfosecfoundation.org/issues/4495



Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4495]( https://redmine.openinfosecfoundation.org/issues/4495)

Describe changes:
- Insure `append` is never NULL.
-
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
