### PR TITLE
app-layer/pd: only consider actual available data

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,4 @@
+extraction:
+  cpp:
+    after_prepare:
+      - git clone --depth 1 https://github.com/OISF/libhtp.git

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -205,11 +205,9 @@ static void TCPProtoDetectCheckBailConditions(ThreadVars *tv,
         return;
     }
 
-    const uint64_t size_ts = STREAM_HAS_SEEN_DATA(&ssn->client) ?
-        STREAM_RIGHT_EDGE(&ssn->client) : 0;
-    const uint64_t size_tc = STREAM_HAS_SEEN_DATA(&ssn->server) ?
-        STREAM_RIGHT_EDGE(&ssn->server) : 0;
-    SCLogDebug("size_ts %"PRIu64", size_tc %"PRIu64, size_ts, size_tc);
+    const uint32_t size_ts = StreamDataAvailableForProtoDetect(&ssn->client);
+    const uint32_t size_tc = StreamDataAvailableForProtoDetect(&ssn->server);
+    SCLogDebug("size_ts %" PRIu32 ", size_tc %" PRIu32, size_ts, size_tc);
 
     DEBUG_VALIDATE_BUG_ON(size_ts > 1000000UL);
     DEBUG_VALIDATE_BUG_ON(size_tc > 1000000UL);

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -587,6 +587,31 @@ static uint32_t StreamTcpReassembleCheckDepth(TcpSession *ssn, TcpStream *stream
     SCReturnUInt(0);
 }
 
+uint32_t StreamDataAvailableForProtoDetect(TcpStream *stream)
+{
+    if (RB_EMPTY(&stream->sb.sbb_tree)) {
+        if (stream->sb.stream_offset != 0)
+            return 0;
+
+        return stream->sb.buf_offset;
+    } else {
+        DEBUG_VALIDATE_BUG_ON(stream->sb.head == NULL);
+
+        if (stream->sb.head->offset != 0)
+            return 0;
+
+        // sums all lengths of different TCP segments
+        // so as to bail out in case of missing data
+        uint32_t r = 0;
+        StreamingBufferBlock *sbb = NULL;
+        RB_FOREACH(sbb, SBB, &stream->sb.sbb_tree)
+        {
+            r += sbb->len;
+        }
+        return r;
+    }
+}
+
 /**
  *  \brief Insert a packets TCP data into the stream reassembly engine.
  *

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -140,5 +140,7 @@ static inline bool STREAM_LASTACK_GT_BASESEQ(const TcpStream *stream)
     return false;
 }
 
+uint32_t StreamDataAvailableForProtoDetect(TcpStream *stream);
+
 #endif /* __STREAM_TCP_REASSEMBLE_H__ */
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4171

Describe changes:
- Use function `StreamDataAvailableForProtoDetect` instead of `STREAM_RIGHT_EDGE` to bail out of protocol detection

Replaces #6072 (and #6069) by iterating over the whole red and black tree (which should not be that fulll ?) to get the total length of received tcp segments (and not only the first one)

suricata-verify-pr: 488
cf OISF/suricata-verify#488