### PR TITLE
Draft: Plugins, refactors, public API

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -392,7 +392,7 @@ jobs:
       - run: test ! -e /usr/local/lib/libsuricata_c.a
       - run: test ! -e /usr/local/include/suricata
       - run: make install-headers
-      - run: test -e /usr/local/include/suricata/suricata.h
+      - run: test -e /usr/local/include/suricata/suricata-plugin.h
       - run: make install-library
       - run: test -e /usr/local/lib/libsuricata_c.a
       - run: test -e /usr/local/lib/libsuricata_rust.a
@@ -838,7 +838,7 @@ jobs:
       - run: test ! -e /usr/local/lib/libsuricata_c.a
       - run: test ! -e /usr/local/include/suricata
       - run: make install-headers
-      - run: test -e /usr/local/include/suricata/suricata.h
+      - run: test -e /usr/local/include/suricata/suricata-plugin.h
       - run: make install-library
       - run: test -e /usr/local/lib/libsuricata_c.a
       - run: test -e /usr/local/lib/libsuricata_rust.a

--- a/libsuricata-config.in
+++ b/libsuricata-config.in
@@ -56,7 +56,7 @@ fi
 output=""
 
 if [ "$show_cflags" = "yes" ]; then
-    output="${output} -DHAVE_CONFIG_H -I$includedir/suricata"
+    output="${output} -I$includedir"
 fi
 
 if [ "$show_libs" = "yes" ]; then

--- a/output-eve-syslog.c
+++ b/output-eve-syslog.c
@@ -1,0 +1,114 @@
+/* vi: set et ts=4: */
+/* Copyright (C) 2021 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Mike Pomraning <mpomraning@qualys.com>
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ *
+ * File-like output for logging:  syslog
+ */
+
+#ifndef OS_WIN32
+#include "suricata-plugin.h" /* errno.h, string.h, etc. */
+#include "conf.h"            /* ConfNode, etc. */
+#include "output.h"          /* DEFAULT_LOG_* */
+#include "output-eve-syslog.h"
+#include "util-syslog.h"
+
+#define DEFAULT_ALERT_SYSLOG_FACILITY_STR "local0"
+#define DEFAULT_ALERT_SYSLOG_FACILITY     LOG_LOCAL0
+#define DEFAULT_ALERT_SYSLOG_LEVEL        LOG_INFO
+
+#define OUTPUT_NAME "syslog"
+
+typedef struct Context_ {
+    int alert_syslog_level;
+} Context;
+
+static int SyslogInit(ConfNode *conf, bool threaded, void **init_data)
+{
+    Context *context = SCCalloc(1, sizeof(Context));
+    if (context == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate context for %s", OUTPUT_NAME);
+        return -1;
+    }
+    const char *facility_s = ConfNodeLookupChildValue(conf, "facility");
+    if (facility_s == NULL) {
+        facility_s = DEFAULT_ALERT_SYSLOG_FACILITY_STR;
+    }
+
+    int facility = SCMapEnumNameToValue(facility_s, SCSyslogGetFacilityMap());
+    if (facility == -1) {
+        SCLogWarning(SC_ERR_INVALID_ARGUMENT,
+                "Invalid syslog facility: \"%s\","
+                " now using \"%s\" as syslog facility",
+                facility_s, DEFAULT_ALERT_SYSLOG_FACILITY_STR);
+        facility = DEFAULT_ALERT_SYSLOG_FACILITY;
+    }
+
+    const char *level_s = ConfNodeLookupChildValue(conf, "level");
+    if (level_s != NULL) {
+        int level = SCMapEnumNameToValue(level_s, SCSyslogGetLogLevelMap());
+        if (level != -1) {
+            context->alert_syslog_level = level;
+        }
+    }
+
+    const char *ident = ConfNodeLookupChildValue(conf, "identity");
+    /* if null we just pass that to openlog, which will then
+     * figure it out by itself. */
+
+    openlog(ident, LOG_PID | LOG_NDELAY, facility);
+    SCLogNotice("Syslog: facility %s, level %s, ident %s", facility_s, level_s, ident);
+    *init_data = context;
+    return 0;
+}
+
+static int SyslogWrite(const char *buffer, int buffer_len, void *init_data, void *thread_data)
+{
+    Context *context = init_data;
+    syslog(context->alert_syslog_level, "%s", (const char *)buffer);
+
+    return 0;
+}
+
+static void SyslogDeInit(void *init_data)
+{
+    if (init_data) {
+        closelog();
+        SCFree(init_data);
+    }
+}
+
+void SyslogInitialize(void)
+{
+    SCPluginFileType *plugin_data = SCCalloc(1, sizeof(SCPluginFileType));
+
+    if (plugin_data == NULL) {
+        FatalError(SC_ERR_MEM_ALLOC, "Unable to allocate memory for eve output %s", OUTPUT_NAME);
+    }
+
+    plugin_data->internal = true;
+    plugin_data->name = OUTPUT_NAME;
+    plugin_data->Init = SyslogInit;
+    plugin_data->Deinit = SyslogDeInit;
+    plugin_data->Write = SyslogWrite;
+}
+#endif /* !OS_WIN32 */

--- a/output-eve-syslog.c
+++ b/output-eve-syslog.c
@@ -105,7 +105,6 @@ void SyslogInitialize(void)
         FatalError(SC_ERR_MEM_ALLOC, "Unable to allocate memory for eve output %s", OUTPUT_NAME);
     }
 
-    plugin_data->internal = true;
     plugin_data->name = OUTPUT_NAME;
     plugin_data->Init = SyslogInit;
     plugin_data->Deinit = SyslogDeInit;

--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -2,3 +2,6 @@
 # we expect the default formatting rules to be used.
 
 fn_args_layout = "compressed"
+
+# Disable conversion of 'extern {' to 'extern "C" {'
+force_explicit_abi = false

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -22,10 +22,11 @@ use std::os::raw::c_void;
 use std::ptr;
 use std::str;
 
-extern "C" {
+extern {
     fn ConfGet(key: *const c_char, res: *mut *const c_char) -> i8;
     fn ConfGetChildValue(conf: *const c_void, key: *const c_char, vptr: *mut *const c_char) -> i8;
     fn ConfGetChildValueBool(conf: *const c_void, key: *const c_char, vptr: *mut c_int) -> i8;
+    fn ConfNodeLookupChild(node: *const c_void, name: *const c_char) -> *const c_void;
 }
 
 // Return the string value of a configuration value.
@@ -109,5 +110,22 @@ impl ConfNode {
             return true;
         }
         return false;
+    }
+
+    // Get a child node of this node by name.
+    //
+    // Wrapper around ConfNodeLookupChild.
+    //
+    // Returns None if the child is not found.
+    pub fn get_child(&self, name: &str) -> Option<ConfNode> {
+        unsafe {
+            let name = CString::new(name).unwrap();
+            let child = ConfNodeLookupChild(self.conf, name.as_ptr());
+            if child != std::ptr::null() {
+                Some(ConfNode { conf: child })
+            } else {
+                None
+            }
+        }
     }
 }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,6 +10,7 @@ if HAS_FUZZPCAP
 endif
 
 HEADERS_PUBLIC = \
+	output-json-filetypes.h \
 	suricata-plugin.h
 
 HEADERS_PRIVATE = \
@@ -970,6 +971,7 @@ libsuricata_c_a_SOURCES = \
 	output-json-drop.c \
 	output-json-email-common.c \
 	output-json-file.c \
+	output-json-filetypes.c \
 	output-json-flow.c \
 	output-json-ftp.c \
 	output-json-http2.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -411,6 +411,7 @@ noinst_HEADERS = \
 	output-json-template-rust.h \
 	output-json-tftp.h \
 	output-json-tls.h \
+	output-eve-syslog.h \
 	output-lua.h \
 	output-packet.h \
 	output-stats.h \
@@ -986,6 +987,7 @@ libsuricata_c_a_SOURCES = \
 	output-json-template-rust.c \
 	output-json-tftp.c \
 	output-json-tls.c \
+	output-eve-syslog.c \
 	output-lua.c \
 	output-packet.c \
 	output-stats.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,7 +9,10 @@ if HAS_FUZZPCAP
     bin_PROGRAMS += fuzz_sigpcap_aware
 endif
 
-noinst_HEADERS = \
+HEADERS_PUBLIC = \
+	suricata-plugin.h
+
+HEADERS_PRIVATE = \
 	action-globals.h \
 	alert-debuglog.h \
 	alert-fastlog.h \
@@ -466,7 +469,6 @@ noinst_HEADERS = \
 	stream-tcp-util.h \
 	suricata-common.h \
 	suricata.h \
-	suricata-plugin.h \
 	threads-debug.h \
 	threads.h \
 	threads-profile.h \
@@ -592,6 +594,10 @@ noinst_HEADERS = \
 	win32-service.h \
 	win32-syscall.h \
 	win32-syslog.h
+
+noinst_HEADERS = \
+	$(HEADERS_PUBLIC) \
+	$(HEADERS_PRIVATE)
 
 libsuricata_c_a_SOURCES = \
 	alert-debuglog.c \
@@ -1215,9 +1221,12 @@ EXTRA_DIST = \
 	tests/stream-tcp.c
 
 install-headers:
-	mkdir -p $(DESTDIR)${includedir}/suricata
-	for header in $(noinst_HEADERS); do \
+	mkdir -p $(DESTDIR)${includedir}/suricata/private
+	for header in $(HEADERS_PUBLIC); do \
 		$(INSTALL_DATA) $$header "$(DESTDIR)${includedir}/suricata"; \
+	done
+	for header in $(HEADERS_PRIVATE); do \
+		$(INSTALL_DATA) $$header "$(DESTDIR)${includedir}/suricata/private"; \
 	done
 
 # set the include path found by configure

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -52,9 +52,6 @@
 
 #ifndef OS_WIN32
 
-#define DEFAULT_ALERT_SYSLOG_FACILITY_STR       "local0"
-#define DEFAULT_ALERT_SYSLOG_FACILITY           LOG_LOCAL0
-#define DEFAULT_ALERT_SYSLOG_LEVEL              LOG_ERR
 #define MODULE_NAME                             "AlertSyslog"
 
 static int alert_syslog_level = DEFAULT_ALERT_SYSLOG_LEVEL;

--- a/src/output-eve-syslog.c
+++ b/src/output-eve-syslog.c
@@ -104,7 +104,6 @@ void SyslogInitialize(void)
         FatalError(SC_ERR_MEM_ALLOC, "Unable to allocate memory for eve file type %s", OUTPUT_NAME);
     }
 
-    file_type->internal = true;
     file_type->name = OUTPUT_NAME;
     file_type->Init = SyslogInit;
     file_type->Deinit = SyslogDeInit;

--- a/src/output-eve-syslog.c
+++ b/src/output-eve-syslog.c
@@ -98,7 +98,7 @@ static void SyslogDeInit(void *init_data)
 
 void SyslogInitialize(void)
 {
-    SCPluginFileType *plugin_data = SCCalloc(1, sizeof(SCPluginFileType));
+    SCEveFileType *plugin_data = SCCalloc(1, sizeof(SCEveFileType));
 
     if (plugin_data == NULL) {
         FatalError(SC_ERR_MEM_ALLOC, "Unable to allocate memory for eve output %s", OUTPUT_NAME);

--- a/src/output-eve-syslog.c
+++ b/src/output-eve-syslog.c
@@ -109,5 +109,8 @@ void SyslogInitialize(void)
     plugin_data->Init = SyslogInit;
     plugin_data->Deinit = SyslogDeInit;
     plugin_data->Write = SyslogWrite;
+    if (!SCRegisterEveFileType(plugin_data)) {
+        FatalError(SC_ERR_PLUGIN, "Failed to register EVE output: %s", OUTPUT_NAME);
+    }
 }
 #endif /* !OS_WIN32 */

--- a/src/output-eve-syslog.c
+++ b/src/output-eve-syslog.c
@@ -44,6 +44,10 @@ typedef struct Context_ {
 
 static int SyslogInit(ConfNode *conf, bool threaded, void **init_data)
 {
+    if (threaded) {
+        FatalError(SC_ERR_FATAL, "Syslog file type does not support threaded output");
+    }
+
     Context *context = SCCalloc(1, sizeof(Context));
     if (context == NULL) {
         SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate context for %s", OUTPUT_NAME);

--- a/src/output-eve-syslog.c
+++ b/src/output-eve-syslog.c
@@ -30,10 +30,6 @@
 #include "output-eve-syslog.h"
 #include "util-syslog.h"
 
-#define DEFAULT_ALERT_SYSLOG_FACILITY_STR "local0"
-#define DEFAULT_ALERT_SYSLOG_FACILITY     LOG_LOCAL0
-#define DEFAULT_ALERT_SYSLOG_LEVEL        LOG_INFO
-
 #ifdef OS_WIN32
 void SyslogInitialize(void)
 {
@@ -113,8 +109,5 @@ void SyslogInitialize(void)
     plugin_data->Init = SyslogInit;
     plugin_data->Deinit = SyslogDeInit;
     plugin_data->Write = SyslogWrite;
-    if (!SCRegisterEveFileType(plugin_data)) {
-        FatalError(SC_ERR_PLUGIN, "Failed to register EVE output: %s", OUTPUT_NAME);
-    }
 }
 #endif /* !OS_WIN32 */

--- a/src/output-eve-syslog.c
+++ b/src/output-eve-syslog.c
@@ -22,7 +22,7 @@
  * \author Mike Pomraning <mpomraning@qualys.com>
  * \author Jeff Lucovsky <jeff@lucovsky.org>
  *
- * File-like output for logging:  syslog
+ * File-like output for logging: syslog
  */
 
 #include "suricata-common.h" /* errno.h, string.h, etc. */
@@ -98,19 +98,19 @@ static void SyslogDeInit(void *init_data)
 
 void SyslogInitialize(void)
 {
-    SCEveFileType *plugin_data = SCCalloc(1, sizeof(SCEveFileType));
+    SCEveFileType *file_type = SCCalloc(1, sizeof(SCEveFileType));
 
-    if (plugin_data == NULL) {
-        FatalError(SC_ERR_MEM_ALLOC, "Unable to allocate memory for eve output %s", OUTPUT_NAME);
+    if (file_type == NULL) {
+        FatalError(SC_ERR_MEM_ALLOC, "Unable to allocate memory for eve file type %s", OUTPUT_NAME);
     }
 
-    plugin_data->internal = true;
-    plugin_data->name = OUTPUT_NAME;
-    plugin_data->Init = SyslogInit;
-    plugin_data->Deinit = SyslogDeInit;
-    plugin_data->Write = SyslogWrite;
-    if (!SCRegisterEveFileType(plugin_data)) {
-        FatalError(SC_ERR_PLUGIN, "Failed to register EVE output: %s", OUTPUT_NAME);
+    file_type->internal = true;
+    file_type->name = OUTPUT_NAME;
+    file_type->Init = SyslogInit;
+    file_type->Deinit = SyslogDeInit;
+    file_type->Write = SyslogWrite;
+    if (!SCRegisterEveFileType(file_type)) {
+        FatalError(SC_ERR_LOG_OUTPUT, "Failed to register EVE file type: %s", OUTPUT_NAME);
     }
 }
 #endif /* !OS_WIN32 */

--- a/src/output-eve-syslog.c
+++ b/src/output-eve-syslog.c
@@ -1,0 +1,120 @@
+/* vi: set et ts=4: */
+/* Copyright (C) 2021 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Mike Pomraning <mpomraning@qualys.com>
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ *
+ * File-like output for logging:  syslog
+ */
+
+#include "suricata-common.h" /* errno.h, string.h, etc. */
+#include "output.h"          /* DEFAULT_LOG_* */
+#include "output-eve-syslog.h"
+#include "util-syslog.h"
+
+#define DEFAULT_ALERT_SYSLOG_FACILITY_STR "local0"
+#define DEFAULT_ALERT_SYSLOG_FACILITY     LOG_LOCAL0
+#define DEFAULT_ALERT_SYSLOG_LEVEL        LOG_INFO
+
+#ifdef OS_WIN32
+void SyslogInitialize(void)
+{
+}
+#else /* !OS_WIN32 */
+#define OUTPUT_NAME "syslog"
+
+typedef struct Context_ {
+    int alert_syslog_level;
+} Context;
+
+static int SyslogInit(ConfNode *conf, bool threaded, void **init_data)
+{
+    Context *context = SCCalloc(1, sizeof(Context));
+    if (context == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate context for %s", OUTPUT_NAME);
+        return -1;
+    }
+    const char *facility_s = ConfNodeLookupChildValue(conf, "facility");
+    if (facility_s == NULL) {
+        facility_s = DEFAULT_ALERT_SYSLOG_FACILITY_STR;
+    }
+
+    int facility = SCMapEnumNameToValue(facility_s, SCSyslogGetFacilityMap());
+    if (facility == -1) {
+        SCLogWarning(SC_ERR_INVALID_ARGUMENT,
+                "Invalid syslog facility: \"%s\","
+                " now using \"%s\" as syslog facility",
+                facility_s, DEFAULT_ALERT_SYSLOG_FACILITY_STR);
+        facility = DEFAULT_ALERT_SYSLOG_FACILITY;
+    }
+
+    const char *level_s = ConfNodeLookupChildValue(conf, "level");
+    if (level_s != NULL) {
+        int level = SCMapEnumNameToValue(level_s, SCSyslogGetLogLevelMap());
+        if (level != -1) {
+            context->alert_syslog_level = level;
+        }
+    }
+
+    const char *ident = ConfNodeLookupChildValue(conf, "identity");
+    /* if null we just pass that to openlog, which will then
+     * figure it out by itself. */
+
+    openlog(ident, LOG_PID | LOG_NDELAY, facility);
+    SCLogNotice("Syslog: facility %s, level %s, ident %s", facility_s, level_s, ident);
+    *init_data = context;
+    return 0;
+}
+
+static int SyslogWrite(const char *buffer, int buffer_len, void *init_data, void *thread_data)
+{
+    Context *context = init_data;
+    syslog(context->alert_syslog_level, "%s", (const char *)buffer);
+
+    return 0;
+}
+
+static void SyslogDeInit(void *init_data)
+{
+    if (init_data) {
+        closelog();
+        SCFree(init_data);
+    }
+}
+
+void SyslogInitialize(void)
+{
+    SCPluginFileType *plugin_data = SCCalloc(1, sizeof(SCPluginFileType));
+
+    if (plugin_data == NULL) {
+        FatalError(SC_ERR_MEM_ALLOC, "Unable to allocate memory for eve output %s", OUTPUT_NAME);
+    }
+
+    plugin_data->internal = true;
+    plugin_data->name = OUTPUT_NAME;
+    plugin_data->Init = SyslogInit;
+    plugin_data->Deinit = SyslogDeInit;
+    plugin_data->Write = SyslogWrite;
+    if (!SCRegisterEveFileType(plugin_data)) {
+        FatalError(SC_ERR_PLUGIN, "Failed to register EVE output: %s", OUTPUT_NAME);
+    }
+}
+#endif /* !OS_WIN32 */

--- a/src/output-eve-syslog.c
+++ b/src/output-eve-syslog.c
@@ -28,6 +28,7 @@
 #include "suricata-common.h" /* errno.h, string.h, etc. */
 #include "output.h"          /* DEFAULT_LOG_* */
 #include "output-eve-syslog.h"
+#include "output-json-filetypes.h"
 #include "util-syslog.h"
 
 #ifdef OS_WIN32

--- a/src/output-eve-syslog.h
+++ b/src/output-eve-syslog.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,17 +15,15 @@
  * 02110-1301, USA.
  */
 
-#ifndef __UTIL_PLUGIN_H__
-#define __UTIL_PLUGIN_H__
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff@lucovsky.org>
+ */
 
-#include "suricata-plugin.h"
-#include "output-eve-syslog.h"
+#ifndef __OUTPUT_EVE_SYSLOG_H__
+#define __OUTPUT_EVE_SYSLOG_H__
 
-void SCInternalLoad(void);
-void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_args);
-SCPluginFileType *SCPluginFindFileType(const char *name);
-SCCapturePlugin *SCPluginFindCaptureByName(const char *name);
+void SyslogInitialize(void);
 
-bool RegisterPlugin(SCPlugin *, void *);
-
-#endif /* __UTIL_PLUGIN_H__ */
+#endif /* __OUTPUT_EVE_SYSLOG_H__ */

--- a/src/output-json-filetypes.c
+++ b/src/output-json-filetypes.c
@@ -1,0 +1,98 @@
+/* Copyright (C) 2021 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+#include "output-json-filetypes.h"
+
+typedef struct EveFileType_ {
+    SCEveFileType *file_type;
+    TAILQ_ENTRY(EveFileType_) entries;
+} EveFileType;
+
+static TAILQ_HEAD(, EveFileType_) output_types = TAILQ_HEAD_INITIALIZER(output_types);
+
+static bool IsBuiltinTypeName(const char *name)
+{
+    const char *builtin[] = {
+        "regular",
+        "unix_dgram",
+        "unix_stream",
+        "redis",
+        NULL,
+    };
+    for (int i = 0;; i++) {
+        if (builtin[i] == NULL) {
+            break;
+        }
+        if (strcmp(builtin[i], name) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * \brief Register an Eve file type.
+ *
+ * \retval true if registered successfully, false if the file type name
+ *      conflicts with a built-in or previously registered
+ *      file type.
+ */
+bool SCRegisterEveFileType(SCEveFileType *file_type)
+{
+    /* First check that the name doesn't conflict with a built-in filetype. */
+    if (IsBuiltinTypeName(file_type->name)) {
+        SCLogError(SC_ERR_LOG_OUTPUT, "Eve file type name conflicts with built-in type: %s",
+                file_type->name);
+        return false;
+    }
+
+    /* Now check against previously registered file types. */
+    EveFileType *existing = NULL;
+    TAILQ_FOREACH (existing, &output_types, entries) {
+        if (strcmp(existing->file_type->name, file_type->name) == 0) {
+            SCLogError(SC_ERR_LOG_OUTPUT,
+                    "Eve file type name conflicts with previously registered type: %s",
+                    existing->file_type->name);
+            return false;
+        }
+    }
+
+    /* Wrap and register. */
+    EveFileType *new = SCCalloc(1, sizeof(*new));
+    if (new == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate memory for eve file type: %s",
+                file_type->name);
+        return false;
+    }
+    new->file_type = file_type;
+
+    SCLogDebug("Registering EVE file type plugin %s", file_type->name);
+    TAILQ_INSERT_TAIL(&output_types, new, entries);
+    return true;
+}
+
+SCEveFileType *SCEveFindFileType(const char *name)
+{
+    EveFileType *file_type = NULL;
+    TAILQ_FOREACH (file_type, &output_types, entries) {
+        if (strcmp(name, file_type->file_type->name) == 0) {
+            return file_type->file_type;
+        }
+    }
+    return NULL;
+}

--- a/src/output-json-filetypes.h
+++ b/src/output-json-filetypes.h
@@ -34,16 +34,26 @@ typedef struct SCEveFileType_ {
     /* The name of the output, used to specify the output in the filetype section
      * of the eve-log configuration. */
     const char *name;
-    /* Init Called on first access */
+
+    /* Init - Called on first access. A return value < 0 indicates error and the
+     * output will not be enabled at runtime. */
     int (*Init)(ConfNode *conf, bool threaded, void **init_data);
-    /* Write - Called on each write to the object */
+
+    /* Write - Called on each write to the object. A return value < 0 indicates
+     * error but this value is not used at this time. */
     int (*Write)(const char *buffer, int buffer_len, void *init_data, void *thread_data);
+
     /* Close - Called on final close */
     void (*Deinit)(void *init_data);
-    /* ThreadInit - Called for each thread using file object*/
+
+    /* ThreadInit - Called for each thread using file object. A return value < 0
+     * indicates error, however this value is not used at this time. The module
+     * should be able to internally handle this error and write calls that will be
+     * made. */
     int (*ThreadInit)(void *init_data, int thread_id, void **thread_data);
+
     /* ThreadDeinit - Called for each thread using file object */
-    int (*ThreadDeinit)(void *init_data, void *thread_data);
+    void (*ThreadDeinit)(void *init_data, void *thread_data);
 } SCEveFileType;
 
 bool SCRegisterEveFileType(SCEveFileType *file_type);

--- a/src/output-json-filetypes.h
+++ b/src/output-json-filetypes.h
@@ -1,0 +1,52 @@
+/* Copyright (C) 2021 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef __SC_OUTPUT_JSON_FILETYPES_H__
+#define __SC_OUTPUT_JSON_FILETYPES_H__
+
+#include <stdbool.h>
+
+/**
+ * Forward declaration of ConfNode as the configuration API is still private at
+ * this time. Users can include <suricata/private/conf.h> if they need to access
+ * this data type now.
+ */
+typedef struct ConfNode_ ConfNode;
+
+/**
+ * Struct defining an Eve file type.
+ */
+typedef struct SCEveFileType_ {
+    /* The name of the output, used to specify the output in the filetype section
+     * of the eve-log configuration. */
+    const char *name;
+    /* Init Called on first access */
+    int (*Init)(ConfNode *conf, bool threaded, void **init_data);
+    /* Write - Called on each write to the object */
+    int (*Write)(const char *buffer, int buffer_len, void *init_data, void *thread_data);
+    /* Close - Called on final close */
+    void (*Deinit)(void *init_data);
+    /* ThreadInit - Called for each thread using file object*/
+    int (*ThreadInit)(void *init_data, int thread_id, void **thread_data);
+    /* ThreadDeinit - Called for each thread using file object */
+    int (*ThreadDeinit)(void *init_data, void *thread_data);
+} SCEveFileType;
+
+bool SCRegisterEveFileType(SCEveFileType *file_type);
+SCEveFileType *SCEveFindFileType(const char *name);
+
+#endif /* ! __SC_OUTOUT_JSON_FILETYPES_H__ */

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -91,6 +91,10 @@ void OutputJsonRegister (void)
 
     traffic_id_prefix_len = strlen(TRAFFIC_ID_PREFIX);
     traffic_label_prefix_len = strlen(TRAFFIC_LABEL_PREFIX);
+
+    // Register output file types that use the new eve filetype registration
+    // API.
+    SyslogInitialize();
 }
 
 json_t *SCJsonString(const char *val)

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1133,7 +1133,7 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
         enum LogFileType log_filetype = FileTypeFromConf(output_s);
         if (log_filetype == LOGFILE_TYPE_NOTSET) {
 #ifdef HAVE_PLUGINS
-            SCPluginFileType *plugin = SCPluginFindFileType(output_s);
+            SCEveFileType *plugin = SCPluginFindFileType(output_s);
             if (plugin != NULL) {
                 log_filetype = LOGFILE_TYPE_PLUGIN;
                 json_ctx->plugin = plugin;

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -48,6 +48,7 @@
 
 #include "output.h"
 #include "output-json.h"
+#include "output-json-filetypes.h"
 
 #include "util-byte.h"
 #include "util-privs.h"
@@ -1134,14 +1135,13 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
 
         enum LogFileType log_filetype = FileTypeFromConf(output_s);
         if (log_filetype == LOGFILE_TYPE_NOTSET) {
-#ifdef HAVE_PLUGINS
-            SCEveFileType *plugin = SCPluginFindFileType(output_s);
+            SCEveFileType *plugin = SCEveFindFileType(output_s);
             if (plugin != NULL) {
                 log_filetype = LOGFILE_TYPE_PLUGIN;
                 json_ctx->plugin = plugin;
-            } else
-#endif
+            } else {
                 FatalError(SC_ERR_INVALID_ARGUMENT, "Invalid JSON output option: %s", output_s);
+            }
         }
 
         const char *prefix = ConfNodeLookupChildValue(conf, "prefix");

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -71,9 +71,6 @@
 #include "suricata-plugin.h"
 
 #define DEFAULT_LOG_FILENAME "eve.json"
-#define DEFAULT_ALERT_SYSLOG_FACILITY_STR       "local0"
-#define DEFAULT_ALERT_SYSLOG_FACILITY           LOG_LOCAL0
-#define DEFAULT_ALERT_SYSLOG_LEVEL              LOG_INFO
 #define MODULE_NAME "OutputJSON"
 
 #define MAX_JSON_SIZE 2048

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1062,10 +1062,8 @@ static int LogFileTypePrepare(
                 return -1;
             }
         }
-        ConfNode *plugin_conf = ConfNodeLookupChild(conf, json_ctx->plugin->name);
         void *init_data = NULL;
-        if (json_ctx->plugin->Init(json_ctx->plugin->internal ? conf : plugin_conf,
-                    json_ctx->file_ctx->threaded, &init_data) < 0) {
+        if (json_ctx->plugin->Init(conf, json_ctx->file_ctx->threaded, &init_data) < 0) {
             return -1;
         }
         json_ctx->file_ctx->plugin.plugin = json_ctx->plugin;

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1002,6 +1002,78 @@ int OutputJsonBuilderBuffer(JsonBuilder *js, OutputJsonThreadCtx *ctx)
     return 0;
 }
 
+static inline enum LogFileType FileTypeFromConf(const char *typestr)
+{
+    enum LogFileType log_filetype = LOGFILE_TYPE_NOTSET;
+
+    if (typestr == NULL) {
+        log_filetype = LOGFILE_TYPE_FILE;
+    } else if (strcmp(typestr, "file") == 0 || strcmp(typestr, "regular") == 0) {
+        log_filetype = LOGFILE_TYPE_FILE;
+    } else if (strcmp(typestr, "unix_dgram") == 0) {
+        log_filetype = LOGFILE_TYPE_UNIX_DGRAM;
+    } else if (strcmp(typestr, "unix_stream") == 0) {
+        log_filetype = LOGFILE_TYPE_UNIX_STREAM;
+    } else if (strcmp(typestr, "redis") == 0) {
+#ifdef HAVE_LIBHIREDIS
+        log_filetype = LOGFILE_TYPE_REDIS;
+#else
+        FatalError(SC_ERR_FATAL, "redis JSON output option is not compiled");
+#endif
+    }
+    SCLogDebug("type %s, file type value %d", typestr, log_filetype);
+    return log_filetype;
+}
+
+static int LogFileTypePrepare(
+        OutputJsonCtx *json_ctx, enum LogFileType log_filetype, ConfNode *conf)
+{
+
+    if (log_filetype == LOGFILE_TYPE_FILE || log_filetype == LOGFILE_TYPE_UNIX_DGRAM ||
+            log_filetype == LOGFILE_TYPE_UNIX_STREAM) {
+        if (SCConfLogOpenGeneric(conf, json_ctx->file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
+            return -1;
+        }
+        OutputRegisterFileRotationFlag(&json_ctx->file_ctx->rotation_flag);
+    }
+#ifdef HAVE_LIBHIREDIS
+    else if (log_filetype == LOGFILE_TYPE_REDIS) {
+        SCLogRedisInit();
+        ConfNode *redis_node = ConfNodeLookupChild(conf, "redis");
+        if (!json_ctx->file_ctx->sensor_name) {
+            char hostname[1024];
+            gethostname(hostname, 1023);
+            json_ctx->file_ctx->sensor_name = SCStrdup(hostname);
+        }
+        if (json_ctx->file_ctx->sensor_name == NULL) {
+            return -1;
+        }
+
+        if (SCConfLogOpenRedis(redis_node, json_ctx->file_ctx) < 0) {
+            return -1;
+        }
+    }
+#endif
+    else if (log_filetype == LOGFILE_TYPE_PLUGIN) {
+        if (json_ctx->file_ctx->threaded) {
+            /* Prepare for threaded log output. */
+            if (!SCLogOpenThreadedFile(NULL, NULL, json_ctx->file_ctx, 1)) {
+                return -1;
+            }
+        }
+        ConfNode *plugin_conf = ConfNodeLookupChild(conf, json_ctx->plugin->name);
+        void *init_data = NULL;
+        if (json_ctx->plugin->Init(json_ctx->plugin->internal ? conf : plugin_conf,
+                    json_ctx->file_ctx->threaded, &init_data) < 0) {
+            return -1;
+        }
+        json_ctx->file_ctx->plugin.plugin = json_ctx->plugin;
+        json_ctx->file_ctx->plugin.init_data = init_data;
+    }
+
+    return 0;
+}
+
 /**
  * \brief Create a new LogFileCtx for "fast" output style.
  * \param conf The configuration node for this output.
@@ -1010,6 +1082,7 @@ int OutputJsonBuilderBuffer(JsonBuilder *js, OutputJsonThreadCtx *ctx)
 OutputInitResult OutputJsonInitCtx(ConfNode *conf)
 {
     OutputInitResult result = { NULL, false };
+    OutputCtx *output_ctx = NULL;
 
     OutputJsonCtx *json_ctx = SCCalloc(1, sizeof(OutputJsonCtx));
     if (unlikely(json_ctx == NULL)) {
@@ -1038,20 +1111,16 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
 
     if (sensor_name) {
         json_ctx->file_ctx->sensor_name = SCStrdup(sensor_name);
-        if (json_ctx->file_ctx->sensor_name  == NULL) {
-            LogFileFreeCtx(json_ctx->file_ctx);
-            SCFree(json_ctx);
-            return result;
+        if (json_ctx->file_ctx->sensor_name == NULL) {
+            goto error_exit;
         }
     } else {
         json_ctx->file_ctx->sensor_name = NULL;
     }
 
-    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
+    output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {
-        LogFileFreeCtx(json_ctx->file_ctx);
-        SCFree(json_ctx);
-        return result;
+        goto error_exit;
     }
 
     output_ctx->data = json_ctx;
@@ -1059,45 +1128,21 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
 
     if (conf) {
         const char *output_s = ConfNodeLookupChildValue(conf, "filetype");
-
         // Backwards compatibility
         if (output_s == NULL) {
             output_s = ConfNodeLookupChildValue(conf, "type");
         }
 
-        if (output_s != NULL) {
-            if (strcmp(output_s, "file") == 0 ||
-                strcmp(output_s, "regular") == 0) {
-                json_ctx->json_out = LOGFILE_TYPE_FILE;
-            } else if (strcmp(output_s, "syslog") == 0) {
-                json_ctx->json_out = LOGFILE_TYPE_SYSLOG;
-            } else if (strcmp(output_s, "unix_dgram") == 0) {
-                json_ctx->json_out = LOGFILE_TYPE_UNIX_DGRAM;
-            } else if (strcmp(output_s, "unix_stream") == 0) {
-                json_ctx->json_out = LOGFILE_TYPE_UNIX_STREAM;
-            } else if (strcmp(output_s, "redis") == 0) {
-#ifdef HAVE_LIBHIREDIS
-                SCLogRedisInit();
-                json_ctx->json_out = LOGFILE_TYPE_REDIS;
-#else
-                           FatalError(SC_ERR_FATAL,
-                                      "redis JSON output option is not compiled");
-#endif
-            } else {
+        enum LogFileType log_filetype = FileTypeFromConf(output_s);
+        if (log_filetype == LOGFILE_TYPE_NOTSET) {
 #ifdef HAVE_PLUGINS
-                SCPluginFileType *plugin = SCPluginFindFileType(output_s);
-                if (plugin == NULL) {
-                    FatalError(SC_ERR_INVALID_ARGUMENT,
-                            "Invalid JSON output option: %s", output_s);
-                } else {
-                    json_ctx->json_out = LOGFILE_TYPE_PLUGIN;
-                    json_ctx->plugin = plugin;
-                }
-#else
-                FatalError(SC_ERR_INVALID_ARGUMENT,
-                        "Invalid JSON output option: %s", output_s);
+            SCPluginFileType *plugin = SCPluginFindFileType(output_s);
+            if (plugin != NULL) {
+                log_filetype = LOGFILE_TYPE_PLUGIN;
+                json_ctx->plugin = plugin;
+            } else
 #endif
-            }
+                FatalError(SC_ERR_INVALID_ARGUMENT, "Invalid JSON output option: %s", output_s);
         }
 
         const char *prefix = ConfNodeLookupChildValue(conf, "prefix");
@@ -1121,115 +1166,17 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
         } else {
             json_ctx->file_ctx->threaded = false;
         }
-
-        if (json_ctx->json_out == LOGFILE_TYPE_FILE ||
-            json_ctx->json_out == LOGFILE_TYPE_UNIX_DGRAM ||
-            json_ctx->json_out == LOGFILE_TYPE_UNIX_STREAM)
-        {
-
-            if (SCConfLogOpenGeneric(conf, json_ctx->file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
-                LogFileFreeCtx(json_ctx->file_ctx);
-                SCFree(json_ctx);
-                SCFree(output_ctx);
-                return result;
-            }
-            OutputRegisterFileRotationFlag(&json_ctx->file_ctx->rotation_flag);
-
+        if (LogFileTypePrepare(json_ctx, log_filetype, conf) < 0) {
+            goto error_exit;
         }
-#ifndef OS_WIN32
-	else if (json_ctx->json_out == LOGFILE_TYPE_SYSLOG) {
-            const char *facility_s = ConfNodeLookupChildValue(conf, "facility");
-            if (facility_s == NULL) {
-                facility_s = DEFAULT_ALERT_SYSLOG_FACILITY_STR;
-            }
-
-            int facility = SCMapEnumNameToValue(facility_s, SCSyslogGetFacilityMap());
-            if (facility == -1) {
-                SCLogWarning(SC_ERR_INVALID_ARGUMENT, "Invalid syslog facility: \"%s\","
-                        " now using \"%s\" as syslog facility", facility_s,
-                        DEFAULT_ALERT_SYSLOG_FACILITY_STR);
-                facility = DEFAULT_ALERT_SYSLOG_FACILITY;
-            }
-
-            const char *level_s = ConfNodeLookupChildValue(conf, "level");
-            if (level_s != NULL) {
-                int level = SCMapEnumNameToValue(level_s, SCSyslogGetLogLevelMap());
-                if (level != -1) {
-                    json_ctx->file_ctx->syslog_setup.alert_syslog_level = level;
-                }
-            }
-
-            const char *ident = ConfNodeLookupChildValue(conf, "identity");
-            /* if null we just pass that to openlog, which will then
-             * figure it out by itself. */
-
-            openlog(ident, LOG_PID|LOG_NDELAY, facility);
-        }
-#endif
-#ifdef HAVE_LIBHIREDIS
-        else if (json_ctx->json_out == LOGFILE_TYPE_REDIS) {
-            ConfNode *redis_node = ConfNodeLookupChild(conf, "redis");
-            if (!json_ctx->file_ctx->sensor_name) {
-                char hostname[1024];
-                gethostname(hostname, 1023);
-                json_ctx->file_ctx->sensor_name = SCStrdup(hostname);
-            }
-            if (json_ctx->file_ctx->sensor_name  == NULL) {
-                LogFileFreeCtx(json_ctx->file_ctx);
-                SCFree(json_ctx);
-                SCFree(output_ctx);
-                return result;
-            }
-
-            if (SCConfLogOpenRedis(redis_node, json_ctx->file_ctx) < 0) {
-                LogFileFreeCtx(json_ctx->file_ctx);
-                SCFree(json_ctx);
-                SCFree(output_ctx);
-                return result;
-            }
-        }
-#endif
-#ifdef HAVE_PLUGINS
-        else if (json_ctx->json_out == LOGFILE_TYPE_PLUGIN) {
-            if (json_ctx->file_ctx->threaded) {
-                /* Prepare for storing per-thread data */
-                if (!SCLogOpenThreadedFile(NULL, NULL, json_ctx->file_ctx, 1)) {
-                    SCFree(json_ctx);
-                    SCFree(output_ctx);
-                    return result;
-                }
-            }
-
-            void *init_data = NULL;
-            if (json_ctx->plugin->Init(conf, json_ctx->file_ctx->threaded, &init_data) < 0) {
-                LogFileFreeCtx(json_ctx->file_ctx);
-                SCFree(json_ctx);
-                SCFree(output_ctx);
-                return result;
-            }
-
-            /* Now that initialization completed successfully, if threaded, make sure
-             * that ThreadInit and ThreadDeInit exist
-             */
-            if (json_ctx->file_ctx->threaded) {
-                if (!json_ctx->plugin->ThreadInit || !json_ctx->plugin->ThreadDeinit) {
-                    FatalError(SC_ERR_LOG_OUTPUT, "Output logger must supply ThreadInit and "
-                                                  "ThreadDeinit functions for threaded mode");
-                }
-            }
-
-            json_ctx->file_ctx->plugin.plugin = json_ctx->plugin;
-            json_ctx->file_ctx->plugin.init_data = init_data;
-        }
-#endif
 
         const char *sensor_id_s = ConfNodeLookupChildValue(conf, "sensor-id");
         if (sensor_id_s != NULL) {
             if (StringParseUint64((uint64_t *)&sensor_id, 10, 0, sensor_id_s) < 0) {
-                SCLogError(SC_ERR_INVALID_ARGUMENT,
-                           "Failed to initialize JSON output, "
-                           "invalid sensor-id: %s", sensor_id_s);
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_INVALID_ARGUMENT,
+                        "Failed to initialize JSON output, "
+                        "invalid sensor-id: %s",
+                        sensor_id_s);
             }
         }
 
@@ -1264,10 +1211,10 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
             if (StringParseUint16(&json_ctx->cfg.community_id_seed,
                         10, 0, cid_seed) < 0)
             {
-                SCLogError(SC_ERR_INVALID_ARGUMENT,
-                           "Failed to initialize JSON output, "
-                           "invalid community-id-seed: %s", cid_seed);
-                exit(EXIT_FAILURE);
+                FatalError(SC_ERR_INVALID_ARGUMENT,
+                        "Failed to initialize JSON output, "
+                        "invalid community-id-seed: %s",
+                        cid_seed);
             }
         }
 
@@ -1286,14 +1233,25 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
                 (RunmodeGetCurrent() == RUNMODE_PCAP_FILE ||
                  RunmodeGetCurrent() == RUNMODE_UNIX_SOCKET);
         }
-
-        json_ctx->file_ctx->type = json_ctx->json_out;
+        json_ctx->file_ctx->type = log_filetype;
     }
 
     SCLogDebug("returning output_ctx %p", output_ctx);
 
     result.ctx = output_ctx;
     result.ok = true;
+    return result;
+
+error_exit:
+    if (json_ctx->file_ctx) {
+        LogFileFreeCtx(json_ctx->file_ctx);
+    }
+    if (json_ctx) {
+        SCFree(json_ctx);
+    }
+    if (output_ctx) {
+        SCFree(output_ctx);
+    }
     return result;
 }
 

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -83,7 +83,7 @@ typedef struct OutputJsonCtx_ {
     enum LogFileType json_out;
     OutputJsonCommonSettings cfg;
     HttpXFFCfg *xff_cfg;
-    SCPluginFileType *plugin;
+    SCEveFileType *plugin;
 } OutputJsonCtx;
 
 typedef struct OutputJsonThreadCtx_ {

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -493,6 +493,7 @@ typedef enum {
 #ifndef SURICATA_PLUGIN
 #include <htp/htp.h>
 #endif
+#include "queue.h"
 #include "threads.h"
 #include "tm-threads-common.h"
 #include "util-debug.h"

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -21,7 +21,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include "conf.h"
+/**
+ * Forward declaration of ConfNode as we don't have a public header for
+ * the configuration API yet. Plugins can still use it by pulling the
+ * private header. */
+typedef struct ConfNode_ ConfNode;
 
 /**
  * The size of the data chunk inside each packet structure a plugin

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -40,6 +40,8 @@ typedef struct SCPlugin_ {
     void (*Init)(void);
 } SCPlugin;
 
+typedef SCPlugin *(*SCPluginRegisterFunc)(void);
+
 /**
  * Structure used to define a file type plugin.
  *
@@ -64,7 +66,7 @@ typedef struct SCPluginFileType_ {
     TAILQ_ENTRY(SCPluginFileType_) entries;
 } SCPluginFileType;
 
-bool SCPluginRegisterFileType(SCPluginFileType *);
+bool SCPluginRegisterEveFileType(SCPluginFileType *);
 bool SCRegisterEveFileType(SCPluginFileType *);
 
 typedef struct SCCapturePlugin_ {

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -45,29 +45,6 @@ typedef struct SCPlugin_ {
 
 typedef SCPlugin *(*SCPluginRegisterFunc)(void);
 
-/**
- * Structure used to define an Eve output file type plugin.
- */
-typedef struct SCEveFileType_ {
-    /* The name of the output, used to specify the output in the filetype section
-     * of the eve-log configuration. */
-    const char *name;
-    /* Init Called on first access */
-    int (*Init)(ConfNode *conf, bool threaded, void **init_data);
-    /* Write - Called on each write to the object */
-    int (*Write)(const char *buffer, int buffer_len, void *init_data, void *thread_data);
-    /* Close - Called on final close */
-    void (*Deinit)(void *init_data);
-    /* ThreadInit - Called for each thread using file object*/
-    int (*ThreadInit)(void *init_data, int thread_id, void **thread_data);
-    /* ThreadDeinit - Called for each thread using file object */
-    int (*ThreadDeinit)(void *init_data, void *thread_data);
-    TAILQ_ENTRY(SCEveFileType_) entries;
-} SCEveFileType;
-
-bool SCPluginRegisterEveFileType(SCEveFileType *);
-bool SCRegisterEveFileType(SCEveFileType *);
-
 typedef struct SCCapturePlugin_ {
     char *name;
     void (*Init)(const char *args, int plugin_slot, int receive_slot, int decode_slot);

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -36,7 +36,6 @@ typedef struct SCPlugin_ {
     const char *name;
     const char *license;
     const char *author;
-    const bool internal;
     void (*Init)(void);
 } SCPlugin;
 
@@ -49,7 +48,6 @@ typedef struct SCEveFileType_ {
     /* The name of the output, used to specify the output in the filetype section
      * of the eve-log configuration. */
     const char *name;
-    bool internal;
     /* Init Called on first access */
     int (*Init)(ConfNode *conf, bool threaded, void **init_data);
     /* Write - Called on each write to the object */

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -43,14 +43,11 @@ typedef struct SCPlugin_ {
 typedef SCPlugin *(*SCPluginRegisterFunc)(void);
 
 /**
- * Structure used to define a file type plugin.
- *
- * Currently only used by the Eve output type.
- *
- * name -- The plugin name. This name is used to identify the plugin: eve-log.filetype and in the
- * plugins: section
+ * Structure used to define an Eve output file type plugin.
  */
-typedef struct SCPluginFileType_ {
+typedef struct SCEveFileType_ {
+    /* The name of the output, used to specify the output in the filetype section
+     * of the eve-log configuration. */
     const char *name;
     bool internal;
     /* Init Called on first access */
@@ -63,11 +60,11 @@ typedef struct SCPluginFileType_ {
     int (*ThreadInit)(void *init_data, int thread_id, void **thread_data);
     /* ThreadDeinit - Called for each thread using file object */
     int (*ThreadDeinit)(void *init_data, void *thread_data);
-    TAILQ_ENTRY(SCPluginFileType_) entries;
-} SCPluginFileType;
+    TAILQ_ENTRY(SCEveFileType_) entries;
+} SCEveFileType;
 
-bool SCPluginRegisterEveFileType(SCPluginFileType *);
-bool SCRegisterEveFileType(SCPluginFileType *);
+bool SCPluginRegisterEveFileType(SCEveFileType *);
+bool SCRegisterEveFileType(SCEveFileType *);
 
 typedef struct SCCapturePlugin_ {
     char *name;

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -36,6 +36,7 @@ typedef struct SCPlugin_ {
     const char *name;
     const char *license;
     const char *author;
+    const bool internal;
     void (*Init)(void);
 } SCPlugin;
 
@@ -48,7 +49,8 @@ typedef struct SCPlugin_ {
  * plugins: section
  */
 typedef struct SCPluginFileType_ {
-    char *name;
+    const char *name;
+    bool internal;
     /* Init Called on first access */
     int (*Init)(ConfNode *conf, bool threaded, void **init_data);
     /* Write - Called on each write to the object */

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -63,6 +63,7 @@ typedef struct SCPluginFileType_ {
 } SCPluginFileType;
 
 bool SCPluginRegisterFileType(SCPluginFileType *);
+bool SCRegisterEveFileType(SCPluginFileType *);
 
 typedef struct SCCapturePlugin_ {
     char *name;

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2553,7 +2553,6 @@ int PostConfLoadedSetup(SCInstance *suri)
     FeatureTrackingRegister(); /* must occur prior to output mod registration */
     RegisterAllModules();
 #ifdef HAVE_PLUGINS
-    SCInternalLoad();
     SCPluginsLoad(suri->capture_plugin_name, suri->capture_plugin_args);
 #endif
     AppLayerHtpNeedFileInspection();

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2553,6 +2553,7 @@ int PostConfLoadedSetup(SCInstance *suri)
     FeatureTrackingRegister(); /* must occur prior to output mod registration */
     RegisterAllModules();
 #ifdef HAVE_PLUGINS
+    SCInternalLoad();
     SCPluginsLoad(suri->capture_plugin_name, suri->capture_plugin_args);
 #endif
     AppLayerHtpNeedFileInspection();

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -834,7 +834,7 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
             if (lf_ctx->type != LOGFILE_TYPE_PLUGIN) {
                 OutputUnregisterFileRotationFlag(&this_ctx->rotation_flag);
                 this_ctx->Close(this_ctx);
-            } else {
+            } else if (lf_ctx->plugin.plugin->ThreadDeinit) {
                 lf_ctx->plugin.plugin->ThreadDeinit(
                         this_ctx->plugin.init_data, this_ctx->plugin.thread_data);
             }
@@ -859,7 +859,7 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
         SCMutexDestroy(&lf_ctx->fp_mutex);
     }
 
-    if (lf_ctx->type == LOGFILE_TYPE_PLUGIN) {
+    if (lf_ctx->type == LOGFILE_TYPE_PLUGIN && lf_ctx->plugin.plugin->Deinit) {
         lf_ctx->plugin.plugin->Deinit(lf_ctx->plugin.init_data);
     }
 

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -886,13 +886,8 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
 
 int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer)
 {
-    if (file_ctx->type == LOGFILE_TYPE_SYSLOG) {
-        syslog(file_ctx->syslog_setup.alert_syslog_level, "%s",
-                (const char *)MEMBUFFER_BUFFER(buffer));
-    } else if (file_ctx->type == LOGFILE_TYPE_FILE ||
-               file_ctx->type == LOGFILE_TYPE_UNIX_DGRAM ||
-               file_ctx->type == LOGFILE_TYPE_UNIX_STREAM)
-    {
+    if (file_ctx->type == LOGFILE_TYPE_FILE || file_ctx->type == LOGFILE_TYPE_UNIX_DGRAM ||
+            file_ctx->type == LOGFILE_TYPE_UNIX_STREAM) {
         /* append \n for files only */
         MemBufferWriteString(buffer, "\n");
         file_ctx->Write((const char *)MEMBUFFER_BUFFER(buffer),

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -35,7 +35,6 @@
 
 enum LogFileType {
     LOGFILE_TYPE_FILE,
-    LOGFILE_TYPE_SYSLOG,
     LOGFILE_TYPE_UNIX_DGRAM,
     LOGFILE_TYPE_UNIX_STREAM,
     LOGFILE_TYPE_REDIS,
@@ -73,7 +72,6 @@ typedef struct LogFileCtx_ {
     LogThreadedFileCtx *threads;
 
     union {
-        SyslogSetup syslog_setup;
 #ifdef HAVE_LIBHIREDIS
         RedisSetup redis_setup;
 #endif

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -55,7 +55,7 @@ typedef struct LogThreadedFileCtx_ {
 } LogThreadedFileCtx;
 
 typedef struct LogFilePluginCtx_ {
-    SCPluginFileType *plugin;
+    SCEveFileType *plugin;
     void *init_data;
     void *thread_data;
 } LogFilePluginCtx;

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -31,7 +31,7 @@
 #include "util-log-redis.h"
 #endif /* HAVE_LIBHIREDIS */
 
-#include "suricata-plugin.h"
+#include "output-json-filetypes.h"
 
 enum LogFileType {
     LOGFILE_TYPE_FILE,

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -33,12 +33,15 @@
 
 #include "suricata-plugin.h"
 
-enum LogFileType { LOGFILE_TYPE_FILE,
-                   LOGFILE_TYPE_SYSLOG,
-                   LOGFILE_TYPE_UNIX_DGRAM,
-                   LOGFILE_TYPE_UNIX_STREAM,
-                   LOGFILE_TYPE_REDIS,
-                   LOGFILE_TYPE_PLUGIN };
+enum LogFileType {
+    LOGFILE_TYPE_FILE,
+    LOGFILE_TYPE_SYSLOG,
+    LOGFILE_TYPE_UNIX_DGRAM,
+    LOGFILE_TYPE_UNIX_STREAM,
+    LOGFILE_TYPE_REDIS,
+    LOGFILE_TYPE_PLUGIN,
+    LOGFILE_TYPE_NOTSET
+};
 
 typedef struct SyslogSetup_ {
     int alert_syslog_level;

--- a/src/util-plugin.c
+++ b/src/util-plugin.c
@@ -38,8 +38,7 @@ typedef struct PluginListNode_ {
  */
 static TAILQ_HEAD(, PluginListNode_) plugins = TAILQ_HEAD_INITIALIZER(plugins);
 
-static TAILQ_HEAD(, SCPluginFileType_) output_types =
-    TAILQ_HEAD_INITIALIZER(output_types);
+static TAILQ_HEAD(, SCEveFileType_) output_types = TAILQ_HEAD_INITIALIZER(output_types);
 
 static TAILQ_HEAD(, SCCapturePlugin_) capture_plugins = TAILQ_HEAD_INITIALIZER(capture_plugins);
 
@@ -142,9 +141,9 @@ void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_a
     }
 }
 
-bool SCRegisterEveFileType(SCPluginFileType *plugin)
+bool SCRegisterEveFileType(SCEveFileType *plugin)
 {
-    SCPluginFileType *existing = NULL;
+    SCEveFileType *existing = NULL;
     TAILQ_FOREACH (existing, &output_types, entries) {
         if (strcmp(existing->name, plugin->name) == 0) {
             SCLogNotice("EVE file type plugin name conflicts with previously "
@@ -167,7 +166,7 @@ bool SCRegisterEveFileType(SCPluginFileType *plugin)
  *      plugin file type.
  *
  */
-bool SCPluginRegisterEveFileType(SCPluginFileType *plugin)
+bool SCPluginRegisterEveFileType(SCEveFileType *plugin)
 {
     const char *builtin[] = {
         "regular",
@@ -191,9 +190,9 @@ bool SCPluginRegisterEveFileType(SCPluginFileType *plugin)
     return SCRegisterEveFileType(plugin);
 }
 
-SCPluginFileType *SCPluginFindFileType(const char *name)
+SCEveFileType *SCPluginFindFileType(const char *name)
 {
-    SCPluginFileType *plugin = NULL;
+    SCEveFileType *plugin = NULL;
     TAILQ_FOREACH(plugin, &output_types, entries) {
         if (strcmp(name, plugin->name) == 0) {
             return plugin;

--- a/src/util-plugin.c
+++ b/src/util-plugin.c
@@ -86,14 +86,6 @@ static void InitPlugin(char *path)
     }
 }
 
-/**
- * \brief Load internal plugins
- */
-void SCInternalLoad(void)
-{
-    SyslogInitialize();
-}
-
 void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_args)
 {
     ConfNode *conf = ConfGetNode("plugins");

--- a/src/util-plugin.c
+++ b/src/util-plugin.c
@@ -17,13 +17,12 @@
 
 #include "suricata-common.h"
 #include "suricata-plugin.h"
+#include "output-eve-syslog.h"
 #include "util-plugin.h"
 
 #ifdef HAVE_PLUGINS
 
 #include <dlfcn.h>
-
-typedef SCPlugin *(*SCPluginRegisterFunc)(void);
 
 typedef struct PluginListNode_ {
     SCPlugin *plugin;
@@ -167,9 +166,8 @@ bool SCRegisterEveFileType(SCPluginFileType *plugin)
  *      conflicts with a built-in or previously registered
  *      plugin file type.
  *
- * TODO: As this is Eve specific, perhaps Eve should be in the filename.
  */
-bool SCPluginRegisterFileType(SCPluginFileType *plugin)
+bool SCPluginRegisterEveFileType(SCPluginFileType *plugin)
 {
     const char *builtin[] = {
         "regular",
@@ -190,18 +188,7 @@ bool SCPluginRegisterFileType(SCPluginFileType *plugin)
         }
     }
 
-    SCPluginFileType *existing = NULL;
-    TAILQ_FOREACH(existing, &output_types, entries) {
-        if (strcmp(existing->name, plugin->name) == 0) {
-            SCLogNotice("Eve filetype plugin name conflicts with previously "
-                    "registered plugin: %s", plugin->name);
-            return false;
-        }
-    }
-
-    SCLogNotice("Registering JSON file type plugin %s", plugin->name);
-    TAILQ_INSERT_TAIL(&output_types, plugin, entries);
-    return true;
+    return SCRegisterEveFileType(plugin);
 }
 
 SCPluginFileType *SCPluginFindFileType(const char *name)

--- a/src/util-plugin.c
+++ b/src/util-plugin.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -93,6 +93,7 @@ static void InitPlugin(char *path)
  */
 void SCInternalLoad(void)
 {
+    SyslogInitialize();
 }
 
 void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_args)

--- a/src/util-plugin.c
+++ b/src/util-plugin.c
@@ -85,6 +85,13 @@ static void InitPlugin(char *path)
     }
 }
 
+/**
+ * \brief Load internal plugins
+ */
+void SCInternalLoad(void)
+{
+}
+
 void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_args)
 {
     ConfNode *conf = ConfGetNode("plugins");

--- a/src/util-plugin.h
+++ b/src/util-plugin.h
@@ -22,7 +22,6 @@
 #include "output-eve-syslog.h"
 
 void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_args);
-SCEveFileType *SCPluginFindFileType(const char *name);
 SCCapturePlugin *SCPluginFindCaptureByName(const char *name);
 
 bool RegisterPlugin(SCPlugin *, void *);

--- a/src/util-plugin.h
+++ b/src/util-plugin.h
@@ -23,7 +23,7 @@
 
 void SCInternalLoad(void);
 void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_args);
-SCPluginFileType *SCPluginFindFileType(const char *name);
+SCEveFileType *SCPluginFindFileType(const char *name);
 SCCapturePlugin *SCPluginFindCaptureByName(const char *name);
 
 bool RegisterPlugin(SCPlugin *, void *);

--- a/src/util-plugin.h
+++ b/src/util-plugin.h
@@ -21,7 +21,6 @@
 #include "suricata-plugin.h"
 #include "output-eve-syslog.h"
 
-void SCInternalLoad(void);
 void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_args);
 SCEveFileType *SCPluginFindFileType(const char *name);
 SCCapturePlugin *SCPluginFindCaptureByName(const char *name);

--- a/src/util-plugin.h
+++ b/src/util-plugin.h
@@ -20,6 +20,7 @@
 
 #include "suricata-plugin.h"
 
+void SCInternalLoad(void);
 void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_args);
 SCPluginFileType *SCPluginFindFileType(const char *name);
 SCCapturePlugin *SCPluginFindCaptureByName(const char *name);

--- a/src/util-plugin.h
+++ b/src/util-plugin.h
@@ -25,4 +25,6 @@ void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_a
 SCPluginFileType *SCPluginFindFileType(const char *name);
 SCCapturePlugin *SCPluginFindCaptureByName(const char *name);
 
+bool RegisterPlugin(SCPlugin *, void *);
+
 #endif /* __UTIL_PLUGIN_H__ */

--- a/src/util-syslog.h
+++ b/src/util-syslog.h
@@ -28,4 +28,10 @@
 SCEnumCharMap *SCSyslogGetFacilityMap(void);
 SCEnumCharMap *SCSyslogGetLogLevelMap(void);
 
+#ifndef OS_WIN32
+#define DEFAULT_ALERT_SYSLOG_FACILITY_STR "local0"
+#define DEFAULT_ALERT_SYSLOG_FACILITY     LOG_LOCAL0
+#define DEFAULT_ALERT_SYSLOG_LEVEL        LOG_ERR
+#endif
+
 #endif	/* UTIL_SYSLOG_H */


### PR DESCRIPTION
Builds on Jeff's PR https://github.com/OISF/suricata/pull/6133 to use the plugin API for registering eve filetypes internally. First we  that idea and just make it feel less like a plugin, as its internal. Then refactor a bit to expose that new internal API for registering filetypes as a plugin. Probably how it should have been done in the first place. Also includes some minor fixups to that PR.

Also includes some include file cleanup with an attempt to seprate some public/private API.  Headers that are designed to be public will be installed in `/usr/include/suricata`, while all other headers will be installed in `/usr/include/suricata/private`. The idea here is not to prevent access to private API, but just make it clear to users, and to us, which APIs we've exposed as public and that will need extra documentation when we break.

For example, the eve filetype template plugin now looks like:
```
/* Required by suricata-plugin.h at this time. Will be fixed. */
#include <suricata/private/queue.h>

#include <suricata/suricata-plugin.h>
#include <suricata/output-json-filetypes.h>
#include <suricata/private/util-debug.h>
```

Here the plugin interface and registering new JSON/EVE filetypes is public interface. Obvious SCLog* make good candidates for public interfaces.  Queue.h might, but its just waiting on a refactor of the capture plugin interface to remove it as a requirement from being included.

This header idea was taken from some documentation I saw on Qt projects that do similar, even though many C projects just install all headers.  But I think the separation is good as it makes it clear what we need to be careful of changing. I don't plan on this settings APIs in stone, but more a queue that a changelog entry is required on change. Also its bad to expose HAVE_CONFIG_H in public headers, as a user of our library may have their own and this can lead to undesirable side affects.

I have a companion plugin to this work which is a Redis output plugin written in Rust: https://github.com/jasonish/eve-redis-plugin/blob/main/src/ffi.rs
