### PR TITLE
lgtm: adds build instructions to get lgtm to work

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,9 @@
+extraction:
+  cpp:
+    prepare:
+      packages:
+        - cargo 
+    after_prepare:
+      - git clone --depth 1 https://github.com/OISF/libhtp.git
+      - cargo install cbindgen
+      - export PATH=/opt/work/.cargo/bin:$PATH


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- LGTM is a statis analysis tool

It did not manage to build suricata as it installed an old cbindgen and did not clone libhtp

See https://lgtm.com/projects/g/OISF/suricata/?mode=list