### PR TITLE
app-layer/pd: only consider actual available data

### DIFF
--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -205,11 +205,9 @@ static void TCPProtoDetectCheckBailConditions(ThreadVars *tv,
         return;
     }
 
-    const uint64_t size_ts = STREAM_HAS_SEEN_DATA(&ssn->client) ?
-        STREAM_RIGHT_EDGE(&ssn->client) : 0;
-    const uint64_t size_tc = STREAM_HAS_SEEN_DATA(&ssn->server) ?
-        STREAM_RIGHT_EDGE(&ssn->server) : 0;
-    SCLogDebug("size_ts %"PRIu64", size_tc %"PRIu64, size_ts, size_tc);
+    const uint32_t size_ts = ssn->client.data_protodetect_seen;
+    const uint32_t size_tc = ssn->server.data_protodetect_seen;
+    SCLogDebug("size_ts %" PRIu32 ", size_tc %" PRIu32, size_ts, size_tc);
 
     DEBUG_VALIDATE_BUG_ON(size_ts > 1000000UL);
     DEBUG_VALIDATE_BUG_ON(size_tc > 1000000UL);
@@ -358,6 +356,9 @@ static int TCPProtoDetect(ThreadVars *tv,
         } else {
             f->alproto = *alproto;
         }
+        // Now the union is no more for protocol detection, but for data_required
+        ssn->client.data_protodetect_seen = 0;
+        ssn->server.data_protodetect_seen = 0;
 
         StreamTcpSetStreamFlagAppProtoDetectionCompleted(*stream);
         TcpSessionSetReassemblyDepth(ssn,

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -624,6 +624,9 @@ int StreamTcpReassembleInsertSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
         }
     }
 
+    if (!(StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(stream))) {
+        stream->data_protodetect_seen += pkt_datalen;
+    }
     SCReturnInt(0);
 }
 

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -117,7 +117,11 @@ typedef struct TcpStream_ {
 
     uint32_t min_inspect_depth;     /**< min inspect size set by the app layer, to make sure enough data
                                      *   remains available for inspection together with app layer buffers */
-    uint32_t data_required;         /**< data required from STREAM_APP_PROGRESS before calling app-layer again */
+    union {
+        uint32_t data_required; /**< data required from STREAM_APP_PROGRESS before calling app-layer
+                                   again */
+        uint32_t data_protodetect_seen; /**< data seen for protocol detection */
+    };
 
     StreamingBuffer sb;
     struct TCPSEG seg_tree;         /**< red black tree of TCP segments. Data is stored in TcpStream::sb */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4171

Describe changes:
- Adds a field `data_protodetect_seen` to structure `TcpStream` to count data for protocol detection bailout
- Places this field in an union so as not to consume more memory
- Uses flag `STREAMTCP_STREAM_FLAG_APPPROTO_DETECTION_COMPLETED` to know which field to use in the union (ie do not use `data_required` as long as we did not complete protocol detection)
- Updates this field `data_protodetect_seen` in `StreamTcpReassembleInsertSegment` (so long as we did not finish protocol detection)
- Resets this union on protocol detection success (does not seem needed in case of protocol detection failure)

Replaces #6164 by not using flow bytes count but a field in the tcp stream, and the difficult trick is to place it in an union so as not to consume more memory

suricata-verify-pr: 488
cf OISF/suricata-verify#488