### PR TITLE
fuzz: adds MSAN to CIFuzz

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -6,7 +6,7 @@ jobs:
    strategy:
      fail-fast: false
      matrix:
-       sanitizer: [address, undefined]
+       sanitizer: [address, undefined, memory]
    steps:
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4125

Describe changes:
- Adds memory sanitizer to CIFuzz

cf https://github.com/google/oss-fuzz/issues/4614
cc @jonathanmetzman

Let's see if CI works 