### PR TITLE
MQTT: improve handling of many topics -- v3

### DIFF
--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -353,7 +353,7 @@ pub extern "C" fn rs_mqtt_tx_get_publish_message(
 
 #[no_mangle]
 pub extern "C" fn rs_mqtt_tx_get_subscribe_topic(tx: &MQTTTransaction,
-    i: u16,
+    i: u32,
     buf: *mut *const u8,
     len: *mut u32)
     -> u8
@@ -386,7 +386,7 @@ pub extern "C" fn rs_mqtt_tx_get_subscribe_topic(tx: &MQTTTransaction,
 
 #[no_mangle]
 pub extern "C" fn rs_mqtt_tx_get_unsubscribe_topic(tx: &MQTTTransaction,
-    i: u16,
+    i: u32,
     buf: *mut *const u8,
     len: *mut u32)
     -> u8

--- a/src/detect-mqtt-subscribe-topic.c
+++ b/src/detect-mqtt-subscribe-topic.c
@@ -58,6 +58,8 @@ static int DetectMQTTSubscribeTopicSetup(DetectEngineCtx *, Signature *, const c
 
 static int g_mqtt_subscribe_topic_buffer_id = 0;
 
+static int subscribe_topic_match_limit = 100;
+
 struct MQTTSubscribeTopicGetDataArgs {
     uint32_t local_id;
     void *txv;
@@ -101,7 +103,7 @@ static int DetectEngineInspectMQTTSubscribeTopic(
         transforms = engine->v2.transforms;
     }
 
-    while(1) {
+    while ((subscribe_topic_match_limit == 0) || local_id < subscribe_topic_match_limit) {
         struct MQTTSubscribeTopicGetDataArgs cbdata = { local_id, txv, };
         InspectionBuffer *buffer = MQTTSubscribeTopicGetData(det_ctx,
             transforms, f, &cbdata, engine->sm_list, false);
@@ -152,7 +154,7 @@ static void PrefilterTxMQTTSubscribeTopic(DetectEngineThreadCtx *det_ctx,
     const int list_id = ctx->list_id;
 
     int local_id = 0;
-    while(1) {
+    while ((subscribe_topic_match_limit == 0) || local_id < subscribe_topic_match_limit) {
         struct MQTTSubscribeTopicGetDataArgs cbdata = { local_id, txv };
         InspectionBuffer *buffer = MQTTSubscribeTopicGetData(det_ctx, ctx->transforms,
                 f, &cbdata, list_id, true);
@@ -202,6 +204,16 @@ void DetectMQTTSubscribeTopicRegister (void)
     sigmatch_table[DETECT_AL_MQTT_SUBSCRIBE_TOPIC].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_AL_MQTT_SUBSCRIBE_TOPIC].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
+    intmax_t val = 0;
+    if (ConfGetInt("mqtt.subscribe-topic-match-limit", &val)) {
+        subscribe_topic_match_limit = val;
+    }
+    if (subscribe_topic_match_limit == 0) {
+        SCLogDebug("Using unrestricted MQTT SUBSCRIBE topic matching");
+    } else {
+        SCLogDebug("Using MQTT SUBSCRIBE topic match-limit setting of: %i",
+                subscribe_topic_match_limit);
+    }
 
     DetectAppLayerMpmRegister2("mqtt.subscribe.topic", SIG_FLAG_TOSERVER, 1,
             PrefilterMpmMQTTSubscribeTopicRegister, NULL,

--- a/src/detect-mqtt-subscribe-topic.c
+++ b/src/detect-mqtt-subscribe-topic.c
@@ -59,7 +59,7 @@ static int DetectMQTTSubscribeTopicSetup(DetectEngineCtx *, Signature *, const c
 static int g_mqtt_subscribe_topic_buffer_id = 0;
 
 struct MQTTSubscribeTopicGetDataArgs {
-    int local_id;
+    uint32_t local_id;
     void *txv;
 };
 
@@ -78,8 +78,7 @@ static InspectionBuffer *MQTTSubscribeTopicGetData(DetectEngineThreadCtx *det_ct
 
     const uint8_t *data;
     uint32_t data_len;
-    if (rs_mqtt_tx_get_subscribe_topic(cbdata->txv, (uint16_t)cbdata->local_id,
-                &data, &data_len) == 0) {
+    if (rs_mqtt_tx_get_subscribe_topic(cbdata->txv, cbdata->local_id, &data, &data_len) == 0) {
         return NULL;
     }
 

--- a/src/detect-mqtt-unsubscribe-topic.c
+++ b/src/detect-mqtt-unsubscribe-topic.c
@@ -59,7 +59,7 @@ static int DetectMQTTUnsubscribeTopicSetup(DetectEngineCtx *, Signature *, const
 static int g_mqtt_unsubscribe_topic_buffer_id = 0;
 
 struct MQTTUnsubscribeTopicGetDataArgs {
-    int local_id;
+    uint32_t local_id;
     void *txv;
 };
 
@@ -78,8 +78,7 @@ static InspectionBuffer *MQTTUnsubscribeTopicGetData(DetectEngineThreadCtx *det_
 
     const uint8_t *data;
     uint32_t data_len;
-    if (rs_mqtt_tx_get_unsubscribe_topic(cbdata->txv, (uint16_t)cbdata->local_id,
-                &data, &data_len) == 0) {
+    if (rs_mqtt_tx_get_unsubscribe_topic(cbdata->txv, cbdata->local_id, &data, &data_len) == 0) {
         return NULL;
     }
 

--- a/src/detect-mqtt-unsubscribe-topic.c
+++ b/src/detect-mqtt-unsubscribe-topic.c
@@ -58,6 +58,8 @@ static int DetectMQTTUnsubscribeTopicSetup(DetectEngineCtx *, Signature *, const
 
 static int g_mqtt_unsubscribe_topic_buffer_id = 0;
 
+static int unsubscribe_topic_match_limit = 100;
+
 struct MQTTUnsubscribeTopicGetDataArgs {
     uint32_t local_id;
     void *txv;
@@ -101,7 +103,7 @@ static int DetectEngineInspectMQTTUnsubscribeTopic(
         transforms = engine->v2.transforms;
     }
 
-    while(1) {
+    while ((unsubscribe_topic_match_limit == 0) || local_id < unsubscribe_topic_match_limit) {
         struct MQTTUnsubscribeTopicGetDataArgs cbdata = { local_id, txv, };
         InspectionBuffer *buffer = MQTTUnsubscribeTopicGetData(det_ctx,
             transforms, f, &cbdata, engine->sm_list, false);
@@ -152,7 +154,7 @@ static void PrefilterTxMQTTUnsubscribeTopic(DetectEngineThreadCtx *det_ctx,
     const int list_id = ctx->list_id;
 
     int local_id = 0;
-    while(1) {
+    while ((unsubscribe_topic_match_limit == 0) || local_id < unsubscribe_topic_match_limit) {
         struct MQTTUnsubscribeTopicGetDataArgs cbdata = { local_id, txv };
         InspectionBuffer *buffer = MQTTUnsubscribeTopicGetData(det_ctx, ctx->transforms,
                 f, &cbdata, list_id, true);
@@ -202,6 +204,16 @@ void DetectMQTTUnsubscribeTopicRegister (void)
     sigmatch_table[DETECT_AL_MQTT_UNSUBSCRIBE_TOPIC].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_AL_MQTT_UNSUBSCRIBE_TOPIC].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
+    intmax_t val = 0;
+    if (ConfGetInt("mqtt.unsubscribe-topic-match-limit", &val)) {
+        unsubscribe_topic_match_limit = val;
+    }
+    if (unsubscribe_topic_match_limit == 0) {
+        SCLogDebug("Using unrestricted MQTT UNSUBSCRIBE topic matching");
+    } else {
+        SCLogDebug("Using MQTT UNSUBSCRIBE topic match-limit setting of: %i",
+                unsubscribe_topic_match_limit);
+    }
 
     DetectAppLayerMpmRegister2("mqtt.unsubscribe.topic", SIG_FLAG_TOSERVER, 1,
             PrefilterMpmMQTTUnsubscribeTopicRegister, NULL,

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1115,6 +1115,11 @@ pcre:
   match-limit: 3500
   match-limit-recursion: 1500
 
+# MQTT topic detection depth
+mqtt:
+  subscribe-topic-match-limit: 100
+  unsubscribe-topic-match-limit: 100
+
 ##
 ## Advanced Traffic Tracking and Reconstruction Settings
 ##


### PR DESCRIPTION
Previous PR: #6114 

Describe changes (to previous PR):
- Remove buffer initialization (@victorjulien mentioned he would address it another way)
- Make `local_id` a `uint32_t` to begin with, removing need for casts altogether

