### PR TITLE
config: fix null dereference in MacSetRegisterFlowStorage

### DIFF
--- a/src/util-macset.c
+++ b/src/util-macset.c
@@ -66,7 +66,7 @@ void MacSetRegisterFlowStorage(void)
        has the ethernet setting enabled */
     if (root != NULL) {
         TAILQ_FOREACH(node, &root->head, next) {
-            if (strcmp(node->val, "eve-log") == 0) {
+            if (node->val && strcmp(node->val, "eve-log") == 0) {
                 const char *enabled = ConfNodeLookupChildValue(node->head.tqh_first, "enabled");
                 if (enabled != NULL && ConfValIsTrue(enabled)) {
                     const char *ethernet = ConfNodeLookupChildValue(node->head.tqh_first, "ethernet");


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4525

Describe changes:
- fix null dereference in `MacSetRegisterFlowStorage`
