### PR TITLE
src/detect: fix bug where rule w/o sid is accepted

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1243,6 +1243,16 @@ static int SigParse(DetectEngineCtx *de_ctx, Signature *s,
         memset(input, 0x00, buffer_size);
         memcpy(input, parser->opts, strlen(parser->opts)+1);
 
+        /* Make sure that options have a "sid" field at all.
+         * This is necessary because when Suricata doesn't parse "sid",
+         * it won't call the functions to check and validate that
+         * field, and Suri won't consider there's something wrong,
+         * even if sid was missing. */
+        if (strstr(input, "sid:") == NULL) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "No `sid` option found.");
+            SCReturnInt(-1);
+        }
+
         /* loop the option parsing. Each run processes one option
          * and returns the rest of the option string through the
          * output variable. */
@@ -2807,13 +2817,15 @@ static int SigParseTest11(void)
 
     Signature *s = NULL;
 
-    s = DetectEngineAppendSig(de_ctx, "drop tcp any any -> any 80 (msg:\"Snort_Inline is blocking the http link\";) ");
+    s = DetectEngineAppendSig(de_ctx,
+            "drop tcp any any -> any 80 (msg:\"Snort_Inline is blocking the http link\"; sid:1;) ");
     if (s == NULL) {
         printf("sig 1 didn't parse: ");
         goto end;
     }
 
-    s = DetectEngineAppendSig(de_ctx, "drop tcp any any -> any 80 (msg:\"Snort_Inline is blocking the http link\"; sid:1;)            ");
+    s = DetectEngineAppendSig(de_ctx, "drop tcp any any -> any 80 (msg:\"Snort_Inline is blocking "
+                                      "the http link\"; sid:2;)            ");
     if (s == NULL) {
         printf("sig 2 didn't parse: ");
         goto end;

--- a/src/detect-sid.c
+++ b/src/detect-sid.c
@@ -119,6 +119,22 @@ static int SidTestParse03(void)
     PASS;
 }
 
+static int SidTestParse04(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    FAIL_IF_NOT_NULL(DetectEngineAppendSig(
+            de_ctx, "alert tcp any any -> any any (content:\"ABC\"; sid: 0;)"));
+
+    /* Let's also make sure that Suricata fails a rule which doesn't have a sid at all */
+    FAIL_IF_NOT_NULL(
+            DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"ABC\";)"));
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
 /**
  * \brief Register DetectSid unit tests.
  */
@@ -127,5 +143,6 @@ static void DetectSidRegisterTests(void)
     UtRegisterTest("SidTestParse01", SidTestParse01);
     UtRegisterTest("SidTestParse02", SidTestParse02);
     UtRegisterTest("SidTestParse03", SidTestParse03);
+    UtRegisterTest("SidTestParse04", SidTestParse04);
 }
 #endif /* UNITTESTS */


### PR DESCRIPTION
Before, if Suricata parsed a rule without a 'sid' option, instead of
failing that rule, the rule was parsed and attributed a sid 0.
Changes to:
src/detect-parse:
- add logic to filter out rules without sid;
- change unittest which didn't have a sid, but used to pass.
src/detect-sid: add unittest for rules without sid or with sid: 0

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4491

Previous PR https://github.com/OISF/suricata/pull/6203
(same changes, just trying to make CI read the S-V PR...)

suricata-verify-pr: 510
https://github.com/OISF/suricata-verify/pull/510