### PR TITLE
Backport to 6.0.x: config: fix null dereference in MacSetRegisterFlowStorage

### DIFF
--- a/src/util-macset.c
+++ b/src/util-macset.c
@@ -66,7 +66,7 @@ void MacSetRegisterFlowStorage(void)
        has the ethernet setting enabled */
     if (root != NULL) {
         TAILQ_FOREACH(node, &root->head, next) {
-            if (strcmp(node->val, "eve-log") == 0) {
+            if (node->val && strcmp(node->val, "eve-log") == 0) {
                 const char *enabled = ConfNodeLookupChildValue(node->head.tqh_first, "enabled");
                 if (enabled != NULL && ConfValIsTrue(enabled)) {
                     const char *ethernet = ConfNodeLookupChildValue(node->head.tqh_first, "ethernet");


### PR DESCRIPTION
Crash happens with
--set outputs.eve-json.types.files.force-magic=yes

(cherry picked from commit 8bf653054025e6297f05ec211a0baa44cf795704)


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4531](https://redmine.openinfosecfoundation.org/issues/4531)

Describe changes:
- Cherry-pick fix for [4525](https://redmine.openinfosecfoundation.org/issues/4525)
-
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
