### PR TITLE
Rust warnings v1

### DIFF
--- a/rust/src/kerberos.rs
+++ b/rust/src/kerberos.rs
@@ -62,12 +62,12 @@ fn parse_kerberos5_request_do(blob: &[u8]) -> IResult<&[u8], ApReq, SecBlobError
     )?;
     do_parse!(
         blob,
-        base_o: parse_der_oid >>
-        tok_id: le_u16 >>
+        _base_o: parse_der_oid >>
+        _tok_id: le_u16 >>
         ap_req: parse_ap_req >>
         ({
-            SCLogDebug!("parse_kerberos5_request: base_o {:?}", base_o.as_oid());
-            SCLogDebug!("parse_kerberos5_request: tok_id {}", tok_id);
+            SCLogDebug!("parse_kerberos5_request: base_o {:?}", _base_o.as_oid());
+            SCLogDebug!("parse_kerberos5_request: tok_id {}", _tok_id);
             ap_req
         })
     )

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,9 +4,9 @@ if BUILD_FUZZTARGETS
     fuzz_applayerparserparse fuzz_siginit \
     fuzz_confyamlloadstring fuzz_decodepcapfile \
     fuzz_sigpcap fuzz_mimedecparseline
-endif
 if HAS_FUZZPCAP
     bin_PROGRAMS += fuzz_sigpcap_aware
+endif
 endif
 
 noinst_HEADERS = \


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- fixes rust compiler warnings
- do not build fuzz_sigpcap_aware if we did not run configure with `--enable-fuzztargets`