### PR TITLE
src/detect: fix non-existent sid bug (Bug 4491) - v2

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-sid.c
+++ b/src/detect-sid.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -60,7 +60,7 @@ static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, const char *si
         goto error;
     }
     if (id >= UINT_MAX) {
-        SCLogError(SC_ERR_INVALID_NUMERIC_VALUE, "sid value to high, max %u", UINT_MAX);
+        SCLogError(SC_ERR_INVALID_NUMERIC_VALUE, "sid value too high, max %u", UINT_MAX);
         goto error;
     }
     if (id == 0) {

--- a/src/detect-sid.c
+++ b/src/detect-sid.c
@@ -119,6 +119,22 @@ static int SidTestParse03(void)
     PASS;
 }
 
+static int SidTestParse04(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    FAIL_IF_NOT_NULL(DetectEngineAppendSig(
+            de_ctx, "alert tcp any any -> any any (content:\"ABC\"; sid: 0;)"));
+
+    /* Let's also make sure that Suricata fails a rule which doesn't have a sid at all */
+    FAIL_IF_NOT_NULL(
+            DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"ABC\";)"));
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
 /**
  * \brief Register DetectSid unit tests.
  */
@@ -127,5 +143,6 @@ static void DetectSidRegisterTests(void)
     UtRegisterTest("SidTestParse01", SidTestParse01);
     UtRegisterTest("SidTestParse02", SidTestParse02);
     UtRegisterTest("SidTestParse03", SidTestParse03);
+    UtRegisterTest("SidTestParse04", SidTestParse04);
 }
 #endif /* UNITTESTS */


### PR DESCRIPTION
Before, if Suricata parsed a rule without a 'sid' option, instead of
failing that rule, the rule was parsed and attributed a sid 0.
Changes to:
src/detect-parse:
- add logic to filter out rules without sid;
- change unittest which didn't have a sid, but used to pass.

src/detect-sid: 
- add unittest for rules without sid or with sid: 0
- fix typo

-- update copyright year
-- Incorporate changes suggested by Jeff

Previous PR https://github.com/OISF/suricata/pull/6204

Link to redmine ticket:
https://redmine.openinfosecfoundation.org/issues/4491

suricata-verify-pr: 510
OISF/suricata-verify#510