### PR TITLE
modbus: do not claim to handle gaps

### DIFF
--- a/rust/src/modbus/modbus.rs
+++ b/rust/src/modbus/modbus.rs
@@ -534,7 +534,7 @@ pub unsafe extern "C" fn rs_modbus_register_parser() {
         set_de_state: rs_modbus_state_set_tx_detect_state,
         get_tx_data: rs_modbus_state_get_tx_data,
         apply_tx_config: None,
-        flags: APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
+        flags: 0,
         truncate: None,
     };
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4533

Describe changes:
- modbus parser does not handle gaps

cc @cccs-sadugas 