### PR TITLE
counters: only print alerts if stats are enabled

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -851,7 +851,9 @@ static void StatsLogSummary(void)
         }
     }
     SCMutexUnlock(&stats_table_mutex);
-    SCLogInfo("Alerts: %"PRIu64, alerts);
+    if (stats_enabled) {
+        SCLogInfo("Alerts: %"PRIu64, alerts);
+    }
 }
 
 /**


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4537