### PR TITLE
Avoid spurious logs when suricatasc closes connection

### DIFF
--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -572,9 +572,9 @@ static void UnixCommandRun(UnixCommand * this, UnixClient *client)
         do {
             if (ret <= 0) {
                 if (ret == 0) {
-                    SCLogInfo("Unix socket: lost connection with client");
+                    SCLogDebug("Unix socket: lost connection with client");
                 } else {
-                    SCLogInfo("Unix socket: error on recv() from client: %s",
+                    SCLogError(SC_ERR_SOCKET, "Unix socket: error on recv() from client: %s",
                             strerror(errno));
                 }
                 UnixCommandClose(this, client->fd);


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3685

Describe changes:

Use SCLogDebug for control connection EOF, and SCLogError for an error.

As Chandan Chowdhury described in redmine 3685. This makes the logging consistent with the older `if (client->version <= UNIX_PROTO_V1)` block about 20 lines above, and avoids polluting the logs with `Unix socket: lost connection with client`.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
