### PR TITLE
devguide/transaction documentation v6

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1024,6 +1024,7 @@ jobs:
       - name: Install packages for generating documentation
         run: |
           DEBIAN_FRONTEND=noninteractive apt -y install \
+                mscgen \
                 sphinx-doc \
                 sphinx-common \
                 texlive-latex-base \

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1031,6 +1031,7 @@ jobs:
                 texlive-fonts-recommended \
                 texlive-fonts-extra \
                 texlive-latex-extra
+      - run:  pip install sphinxcontrib-mscgen
       - name: Install Coccinelle
         run: |
           add-apt-repository -y ppa:npalix/coccinelle

--- a/doc/devguide/Makefile.am
+++ b/doc/devguide/Makefile.am
@@ -7,6 +7,7 @@ EXTRA_DIST = \
 	extending/index.rst \
 	extending/app-layer/index.rst \
 	extending/app-layer/parser.rst \
+	extending/app-layer/transactions.rst \
 	extending/capture/index.rst \
 	extending/output/index.rst \
 	internals/engines/index.rst \

--- a/doc/devguide/conf.py
+++ b/doc/devguide/conf.py
@@ -13,6 +13,7 @@ import sys
 import os
 import shlex
 import re
+import sphinxcontrib
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
@@ -29,7 +30,7 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ['sphinxcontrib.mscgen']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/devguide/conf.py
+++ b/doc/devguide/conf.py
@@ -13,7 +13,7 @@ import sys
 import os
 import shlex
 import re
-import sphinxcontrib
+import sphinxcontrib.mscgen
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 

--- a/doc/devguide/extending/app-layer/index.rst
+++ b/doc/devguide/extending/app-layer/index.rst
@@ -5,3 +5,4 @@ App-Layer
    :maxdepth: 2
 
    parser.rst
+   transactions.rst

--- a/doc/devguide/extending/app-layer/transactions.rst
+++ b/doc/devguide/extending/app-layer/transactions.rst
@@ -66,7 +66,7 @@ _`Progress Tracking`
 
 As a rule of thumb, transactions will follow a request-response model: if a transaction has had a request and a response, it is complete.
 
-But if a protocol has situations where a request or response won’t expect or generate a message from its counter-part,
+But if a protocol has situations where a request or response won’t expect or generate a message from its counterpart,
 it is also possible to have uni-directional transactions. In such cases, transaction is set to complete at the moment of
 creation.
 
@@ -86,7 +86,7 @@ In Summary - Transactions and State
 
 - Initial state value: ``0``
 - Simpler scenarios: state is simply an int.  ``1`` represents transaction completion, per direction.
-- Complex Transaction State in Suricata: ``enum`` (Rust: ``i32``). Completion is indicated by the highest enum value (some examples are: SSH, HTTP, DNS, SBM).
+- Complex Transaction State in Suricata: ``enum`` (Rust: ``i32``). Completion is indicated by the highest enum value (some examples are: SSH, HTTP, DNS, SMB).
 
 _`Examples`
 ===========

--- a/doc/devguide/extending/app-layer/transactions.rst
+++ b/doc/devguide/extending/app-layer/transactions.rst
@@ -231,19 +231,19 @@ An HTTP2 transaction is an example of a bidirectional transaction, in Suricata:
 .. mscgen::
 
     msc {
-    
+
         # Chart options
         arcgradient = "10", hscale = "1.2";
-    
-        # Entitties
+
+        # Entities
         a [ label = "Client" ], b [ label = "Server" ];
-    
+
         # Message flow
         a =>> b [ label = "Request" ];
         b =>> a [ label = "Response" ];
         |||;
-        --- [ label = "Transaction completed" ];
-    
+        --- [ label = "Transaction Completed" ];
+
         # Reference: https://tools.ietf.org/html/rfc7540#section-8.1
     }
 
@@ -258,10 +258,10 @@ completed:
     msc {
         # Chart Options
         arcgradient = "10", hscale = "1.2";
-    
+
         # Entitties
         a [ label = "Client" ], b [ label = "Server"];
-    
+
         # Message Flow
         a =>> b [ label = "ClientHello"];
         b =>> a [ label = "ServerHello"];
@@ -271,7 +271,7 @@ completed:
         a =>> b [ label = "ClientKeyExchange"];
         a =>> b [ label = "Finished" ];
         b =>> a [ label = "Finished" ];
-    
+
         --- [ label = "Transaction Completed" ];
     }
 

--- a/doc/devguide/extending/app-layer/transactions.rst
+++ b/doc/devguide/extending/app-layer/transactions.rst
@@ -84,9 +84,9 @@ The engine interacts with transactions state using a set of callbacks the parser
 In Summary - Transactions and State
 -----------------------------------
 
-| Initial state value: ``0``
-| Simpler scenarios: state is simply an int.  ``1`` represents transaction completion, per direction.
-| Complex Transaction State in Suricata: ``enum`` (Rust: ``i32``). Completion is indicated by the highest enum value (some examples are: SSH, HTTP, DNS, SBM).
+- Initial state value: ``0``
+- Simpler scenarios: state is simply an int.  ``1`` represents transaction completion, per direction.
+- Complex Transaction State in Suricata: ``enum`` (Rust: ``i32``). Completion is indicated by the highest enum value (some examples are: SSH, HTTP, DNS, SBM).
 
 _`Examples`
 ===========

--- a/doc/devguide/extending/app-layer/transactions.rst
+++ b/doc/devguide/extending/app-layer/transactions.rst
@@ -13,22 +13,23 @@ Table of Contents
 _`General Concepts`
 ===================
 
-Transactions are abstractions that help detecting and logging in Suricata. They’ll also help during the detection phase,
+Transactions are abstractions that help detecting and logging in Suricata. They also help during the detection phase,
 when dealing with protocols that can have large PDUs, like TCP, in controlling state for partial rule matching, in case of rules that mention more than one field.
 
-Transactions are implemented and stored in the per-flow state. The engine interacts with it using a set of callbacks the parser registers.
+Transactions are implemented and stored in the per-flow state. The engine interacts with them using a set of callbacks the parser registers.
 
 _`How the engine uses transactions`
 ===================================
 
 Logging
-~~~~~~~~
+~~~~~~~
 
-Suricata controls when logging should happen based on transaction completeness. For simpler protocols, that will most
-likely happen once per transaction, by the time of its completion. In other cases, like with HTTP, this may happen also at intermediary states.
+Suricata controls when logging should happen based on transaction completeness. For simpler protocols, such as ``dns``
+or ``ntp``, that will most
+likely happen once per transaction, by the time of its completion. In other cases, like with HTTP, this may happen at intermediary states.
 
 In ``OutputTxLog``, the engine will compare current state with the value defined for the logging to happen, per flow
-direction (``logger->tc_log_progress``, ``logger->ts_log_progress``). If state is lesser than that value, the engine skips to
+direction (``logger->tc_log_progress``, ``logger->ts_log_progress``). If state is less than that value, the engine skips to
 the next logger. Code snippet from: suricata/src/output-tx.c:
 
 .. code-block:: c
@@ -65,9 +66,9 @@ the next logger. Code snippet from: suricata/src/output-tx.c:
     }
 
 Rule Matching
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
-Transactions progress is also used for certain keywords to know what is the minimum state before we can expect a match: until that, Suricata won't even try to look for the patterns.
+Transaction progress is also used for certain keywords to know what is the minimum state before we can expect a match: until that, Suricata won't even try to look for the patterns.
 
 As seen in ```DetectAppLayerMpmRegister2`` that has ``int progress`` as parameter, and ``DetectAppLayerInspectEngineRegister2``, which expects ``int tx_min_progress``, for instance. In the code snippet,
 ``HTTP2StateDataClient``, ``HTTP2StateDataServer`` and ``0`` are the values passed to the functions.
@@ -117,7 +118,7 @@ progresses. A state will start at 0. The higher its value, the closer the transa
 The engine interacts with transactions state using a set of callbacks the parser registers. State is defined per flow direction (``STREAM_TOSERVER`` / ``STREAM_TOCLIENT``).
 
 In Summary - Transactions and State
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Initial state value: ``0``
 - Simpler scenarios: state is simply an int.  ``1`` represents transaction completion, per direction.
@@ -127,7 +128,7 @@ _`Examples`
 ===========
 
 Enums
-~~~~~~
+~~~~~
 
 Code snippet from: rust/src/ssh/ssh.rs:
 
@@ -152,7 +153,7 @@ From src/app-layer-ftp.h:
 
 
 API Callbacks
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 In Rust, this is done via the RustParser struct. As seen in rust/src/applayer.rs:
 
@@ -215,8 +216,8 @@ _`Common words and abbreviations`
 - al, applayer: application layer
 - alproto: application layer protocol
 - alstate: application layer state
-- engine: refers to Suricata core
-- flow: a bidirectional flow of packets with the same 5 tuple elements (protocol, source ip, destination ip, source port, destination port. Vlans can be added as well)
+- engine: refers to Suricata core detection logic
+- flow: a bidirectional flow of packets with the same 5-tuple elements (protocol, source ip, destination ip, source port, destination port. Vlans can be added as well)
 - PDU: Protocol Data Unit
 - rs: rust
 - tc: to client

--- a/doc/devguide/extending/app-layer/transactions.rst
+++ b/doc/devguide/extending/app-layer/transactions.rst
@@ -1,0 +1,189 @@
+************
+Transactions
+************
+
+Table of Contents
+=================
+- `General Concepts`_
+- `How the engine uses transactions`_
+- `Progress Tracking`_
+- `Examples`_
+- `Common words and abbreviations`_
+
+_`General Concepts`
+===================
+
+Transactions are abstractions that help detecting and logging in Suricata. They’ll also help during the detection phase,
+when dealing with protocols that can have large PDUs, like TCP, in controlling state for partial rule matching, in case of rules that mention more than one field.
+
+Transactions are implemented and stored in the per-flow state. The engine interacts with it using a set of callbacks the parser registers.
+
+_`How the engine uses transactions`
+===================================
+
+Suricata controls when logging should happen based on transaction completeness. For simpler protocols, that will most
+likely happen once per transaction, by the time of its completion. In other cases, like with HTTP, this may happen also at intermediary states.
+
+In ``OutputTxLog``, the engine will compare current state with the value defined for the logging to happen, per flow
+direction (``logger->tc_log_progress``, ``logger->ts_log_progress``). If state is lesser than that value, the engine skips to
+the next logger. Code snippet from: suricata/src/output-tx.c:
+
+.. code-block:: c
+
+    static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
+    {
+        .
+        .
+        .
+            if ((ts_eof && tc_eof) || last_pseudo) {
+                SCLogDebug("EOF, so log now");
+            } else {
+                if (logger->LogCondition) {
+                    int r = logger->LogCondition(tv, p, alstate, tx, tx_id);
+                    if (r == FALSE) {
+                        SCLogDebug("conditions not met, not logging");
+                        goto next_logger;
+                    }
+                } else {
+                    if (tx_progress_tc < logger->tc_log_progress) {
+                        SCLogDebug("progress not far enough, not logging");
+                        goto next_logger;
+                    }
+
+                    if (tx_progress_ts < logger->ts_log_progress) {
+                        SCLogDebug("progress not far enough, not logging");
+                        goto next_logger;
+                    }
+                }
+             }
+        .
+        .
+        .
+    }
+
+_`Progress Tracking`
+====================
+
+As a rule of thumb, transactions will follow a request-response model: if a transaction has had a request and a response, it is complete.
+
+But if a protocol has situations where a request or response won’t expect or generate a message from its counter-part,
+it is also possible to have uni-directional transactions. In such cases, transaction is set to complete at the moment of
+creation.
+
+For example, DNS responses may be considered as completed transactions, because they also contain the request data, so
+all information needed for logging and detection can be found in the response.
+
+In addition, for file transfer protocols, or similar ones where there may be several messages before the file exchange
+is completed (NFS, SMB), it is possible to create a level of abstraction to handle such complexity. This could be achieved by adding phases to the protocol implemented model (e.g., protocol negotiation phase (SMB), request parsed (HTTP), and so on).
+
+This is controlled by implementing states. In Suricata, those will be enums that are incremented as the parsing
+progresses. A state will start at 0. The higher its value, the closer the transaction would be to completion.
+
+The engine interacts with transactions state using a set of callbacks the parser registers. State is defined per flow direction (``STREAM_TOSERVER`` / ``STREAM_TOCLIENT``).
+
+In Summary - Transactions and State
+-----------------------------------
+
+| Initial state value: ``0``
+| Simpler scenarios: state is simply an int.  ``1`` represents transaction completion, per direction.
+| Complex Transaction State in Suricata: ``enum`` (Rust: ``i32``). Completion is indicated by the highest enum value (some examples are: SSH, HTTP, DNS, SBM).
+
+_`Examples`
+===========
+
+Enums
+-----
+
+Code snippet from: rust/src/ssh/ssh.rs:
+
+.. code-block:: rust
+
+    pub enum SSHConnectionState {
+        SshStateInProgress = 0,
+        SshStateBannerWaitEol = 1,
+        SshStateBannerDone = 2,
+        SshStateFinished = 3,
+    }
+
+From src/app-layer-ftp.h:
+
+.. code-block:: c
+
+    enum {
+        FTP_STATE_IN_PROGRESS,
+        FTP_STATE_PORT_DONE,
+        FTP_STATE_FINISHED,
+    };
+
+
+API Callbacks
+-------------
+
+In Rust, this is done via the RustParser struct. As seen in rust/src/applayer.rs:
+
+.. code-block:: rust
+
+    /// Rust parser declaration
+    pub struct RustParser {
+            .
+            .
+            .
+        /// Progress values at which the tx is considered complete in a direction
+        pub tx_comp_st_ts:      c_int,
+        pub tx_comp_st_tc:      c_int,
+        .
+        .
+        .
+    }
+
+In C, the callback API is:
+
+.. code-block:: c
+
+    void AppLayerParserRegisterStateProgressCompletionStatus(
+        AppProto alproto, const int ts, const int tc)
+
+Simple scenario described, in Rust:
+
+.. code-block:: rust
+
+    rust/src/dhcp/dhcp.rs:
+
+    tx_comp_st_ts: 1
+    tx_comp_st_tc: 1
+
+For SSH, this looks like this:
+
+.. code-block:: rust
+
+    rust/src/ssh/ssh.rs:
+
+    tx_comp_st_ts: SSHConnectionState::SshStateFinished as i32,
+    tx_comp_st_tc: SSHConnectionState::SshStateFinished as i32,
+
+In C, callback usage would be as follows:
+
+.. code-block:: c
+
+    src/app-layer-dcerpc.c:
+
+    AppLayerParserRegisterStateProgressCompletionStatus(ALPROTO_DCERPC, 1, 1);
+
+    src/app-layer-ftp.c:
+
+    AppLayerParserRegisterStateProgressCompletionStatus(
+        ALPROTO_FTP, FTP_STATE_FINISHED, FTP_STATE_FINISHED);
+
+_`Common words and abbreviations`
+=================================
+
+- al, applayer: application layer
+- alproto: application layer protocol
+- alstate: application layer state
+- engine: refers to Suricata core
+- flow: a bidirectional flow of packets with the same 5 tuple elements (protocol, source ip, destination ip, source port, destination port. Vlans can be added as well)
+- PDU: Protocol Data Unit
+- rs: rust
+- tc: to client
+- ts: to server
+- tx: transaction

--- a/doc/devguide/extending/app-layer/transactions.rst
+++ b/doc/devguide/extending/app-layer/transactions.rst
@@ -2,13 +2,7 @@
 Transactions
 ************
 
-Table of Contents
-=================
-- `General Concepts`_
-- `How the engine uses transactions`_
-- `Progress Tracking`_
-- `Examples`_
-- `Common words and abbreviations`_
+.. contents:: Table of Contents
 
 _`General Concepts`
 ===================
@@ -209,6 +203,77 @@ In C, callback usage would be as follows:
 
     AppLayerParserRegisterStateProgressCompletionStatus(
         ALPROTO_FTP, FTP_STATE_FINISHED, FTP_STATE_FINISHED);
+
+Sequence Diagrams
+~~~~~~~~~~~~~~~~~
+
+A DNS transaction in Suricata can be considered unidirectional:
+
+..
+    MSC Sequence Diagram Example: DNS Query Transaction
+
+.. mscgen::
+
+    msc {
+        arcgradient = "10", hscale = "1.2";
+
+        a [ label = "Client" ], b [ label = "Server" ];
+
+        a =>> b [ label = "DNS Request" ];
+        --- [ label = "Transaction Completed" ];
+    }
+
+An HTTP2 transaction is an example of a bidirectional transaction, in Suricata:
+
+..
+    MSC Sequence Diagram Example: HTTP2 Transaction
+
+.. mscgen::
+
+    msc {
+    
+        # Chart options
+        arcgradient = "10", hscale = "1.2";
+    
+        # Entitties
+        a [ label = "Client" ], b [ label = "Server" ];
+    
+        # Message flow
+        a =>> b [ label = "Request" ];
+        b =>> a [ label = "Response" ];
+        |||;
+        --- [ label = "Transaction completed" ];
+    
+        # Reference: https://tools.ietf.org/html/rfc7540#section-8.1
+    }
+
+A TLS Handshake is a more complex example, where several messages are exchanged before the transaction is considered
+completed:
+
+..
+    MSC Sequence Diagram Example: TLS Handshake Transaction
+
+.. mscgen::
+
+    msc {
+        # Chart Options
+        arcgradient = "10", hscale = "1.2";
+    
+        # Entitties
+        a [ label = "Client" ], b [ label = "Server"];
+    
+        # Message Flow
+        a =>> b [ label = "ClientHello"];
+        b =>> a [ label = "ServerHello"];
+        b =>> a [ label = "ServerCertificate"];
+        b =>> a [ label = "ServerHello Done"];
+        a =>> b [ label = "ClientCertificate"];
+        a =>> b [ label = "ClientKeyExchange"];
+        a =>> b [ label = "Finished" ];
+        b =>> a [ label = "Finished" ];
+    
+        --- [ label = "Transaction Completed" ];
+    }
 
 _`Common words and abbreviations`
 =================================


### PR DESCRIPTION
Describe changes:

- add SequenceDiagrams for TLS, HTTP2 and DNS transactions, generated by mscgen
- refine grammar and some wordings
- add examples for simpler protocols
- use native markup for `table of contents`

Link to Redmine issue: https://redmine.openinfosecfoundation.org/issues/4396

Previous PR: https://github.com/OISF/suricata/pull/6162