### PR TITLE
counters: only print alerts if stats are enabled

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -838,6 +838,9 @@ TmEcode StatsOutputCounterSocket(json_t *cmd,
 
 static void StatsLogSummary(void)
 {
+    if (!stats_enabled) {
+        return;
+    }
     uint64_t alerts = 0;
     SCMutexLock(&stats_table_mutex);
     if (stats_table.start_time != 0) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4537