### PR TITLE
[DRAFT] Add base64 encoders to JsonBuilder - v1

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -49,6 +49,7 @@ sha-1 = "~0.9.2"
 md-5 = "~0.9.1"
 regex = "~1.4.2"
 lazy_static = "~1.4.0"
+base64 = "~0.13.0"
 
 [dev-dependencies]
 test-case = "~1.1.0"

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -311,6 +311,30 @@ impl JsonBuilder {
         }
     }
 
+    /// Add a string to an array.
+    pub fn append_base64(&mut self, val: &[u8]) -> Result<&mut Self, JsonError> {
+        match self.current_state() {
+            State::ArrayFirst => {
+                self.buf.push('"');
+                base64::encode_config_buf(val, base64::STANDARD, &mut self.buf);
+                self.buf.push('"');
+                self.set_state(State::ArrayNth);
+                Ok(self)
+            }
+            State::ArrayNth => {
+                self.buf.push(',');
+                self.buf.push('"');
+                base64::encode_config_buf(val, base64::STANDARD, &mut self.buf);
+                self.buf.push('"');
+                Ok(self)
+            }
+            _ => {
+                debug_validate_fail!("invalid state");
+                Err(JsonError::InvalidState)
+            }
+        }
+    }
+
     /// Add an unsigned integer to an array.
     pub fn append_uint(&mut self, val: u64) -> Result<&mut Self, JsonError> {
         match self.current_state() {
@@ -432,6 +456,29 @@ impl JsonBuilder {
             Ok(s) => self.set_string(key, s),
             Err(_) => self.set_string(key, &string_from_bytes(val)),
         }
+    }
+
+    /// Set a key and a string field as the base64 encoded string of the value.
+    pub fn set_base64(&mut self, key: &str, val: &[u8]) -> Result<&mut Self, JsonError> {
+        match self.current_state() {
+            State::ObjectNth => {
+                self.buf.push(',');
+            }
+            State::ObjectFirst => {
+                self.set_state(State::ObjectNth);
+            }
+            _ => {
+                debug_validate_fail!("invalid state");
+                return Err(JsonError::InvalidState);
+            }
+        }
+        self.buf.push('"');
+        self.buf.push_str(key);
+        self.buf.push_str("\":\"");
+        base64::encode_config_buf(val, base64::STANDARD, &mut self.buf);
+        self.buf.push('"');
+
+        Ok(self)
     }
 
     /// Set a key and an unsigned integer type on an object.
@@ -663,6 +710,20 @@ pub unsafe extern "C" fn jb_set_string_from_bytes(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn jb_set_base64(
+    js: &mut JsonBuilder, key: *const c_char, bytes: *const u8, len: u32,
+) -> bool {
+    if bytes == std::ptr::null() || len == 0 {
+        return false;
+    }
+    if let Ok(key) = CStr::from_ptr(key).to_str() {
+        let val = std::slice::from_raw_parts(bytes, len as usize);
+        return js.set_base64(key, val).is_ok();
+    }
+    return false;
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn jb_set_formatted(js: &mut JsonBuilder, formatted: *const c_char) -> bool {
     if let Ok(formatted) = CStr::from_ptr(formatted).to_str() {
         return js.set_formatted(formatted).is_ok();
@@ -705,6 +766,17 @@ pub unsafe extern "C" fn jb_append_string_from_bytes(
     }
     let val = std::slice::from_raw_parts(bytes, len as usize);
     return js.append_string_from_bytes(val).is_ok();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn jb_append_base64(
+    js: &mut JsonBuilder, bytes: *const u8, len: u32,
+) -> bool {
+    if bytes == std::ptr::null() || len == 0 {
+        return false;
+    }
+    let val = std::slice::from_raw_parts(bytes, len as usize);
+    return js.append_base64(val).is_ok();
 }
 
 #[no_mangle]

--- a/scripts/dnp3-gen/dnp3-gen.py
+++ b/scripts/dnp3-gen/dnp3-gen.py
@@ -157,6 +157,7 @@ output_json_dnp3_objects_template = """/* Copyright (C) 2015 Open Information Se
 #include "output-json-dnp3-objects.h"
 #include "output-json.h"
 
+// clang-format off
 void OutputJsonDNP3SetItem(JsonBuilder *js, DNP3Object *object,
     DNP3Point *point)
 {
@@ -171,11 +172,7 @@ void OutputJsonDNP3SetItem(JsonBuilder *js, DNP3Object *object,
 {% elif field.type in ["flt32", "flt64"] %}
             jb_set_float(js, "{{field.name}}", data->{{field.name}});
 {% elif field.type == "bytearray" %}
-            unsigned long {{field.name}}_b64_len = data->{{field.len_field}} * 2;
-            uint8_t {{field.name}}_b64[{{field.name}}_b64_len];
-            Base64Encode(data->{{field.name}}, data->{{field.len_field}},
-                {{field.name}}_b64, &{{field.name}}_b64_len);
-            jb_set_string(js, "data->{{field.name}}", (char *){{field.name}}_b64);
+            jb_set_base64(js, "data->{{field.name}}", data->{{field.name}}, data->{{field.len_field}});
 {% elif field.type == "vstr4" %}
             jb_set_string(js, "data->{{field.name}}", data->{{field.name}});
 {% elif field.type == "chararray" %}
@@ -207,6 +204,7 @@ void OutputJsonDNP3SetItem(JsonBuilder *js, DNP3Object *object,
     }
 
 }
+// clang-format on
 
 """
 

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -423,11 +423,7 @@ static void AlertJsonTunnel(const Packet *p, JsonBuilder *js)
 static void AlertAddPayload(AlertJsonOutputCtx *json_output_ctx, JsonBuilder *js, const Packet *p)
 {
     if (json_output_ctx->flags & LOG_JSON_PAYLOAD_BASE64) {
-        unsigned long len = BASE64_BUFFER_SIZE(p->payload_len);
-        uint8_t encoded[len];
-        if (Base64Encode(p->payload, p->payload_len, encoded, &len) == SC_BASE64_OK) {
-            jb_set_string(js, "payload", (char *)encoded);
-        }
+        jb_set_base64(js, "payload", p->payload, p->payload_len);
     }
 
     if (json_output_ctx->flags & LOG_JSON_PAYLOAD) {
@@ -684,10 +680,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                                     (void *)payload);
                 if (payload->offset) {
                     if (json_output_ctx->flags & LOG_JSON_PAYLOAD_BASE64) {
-                        unsigned long len = BASE64_BUFFER_SIZE(json_output_ctx->payload_buffer_size);
-                        uint8_t encoded[len];
-                        Base64Encode(payload->buffer, payload->offset, encoded, &len);
-                        jb_set_string(jb, "payload", (char *)encoded);
+                        jb_set_base64(jb, "payload", payload->buffer, payload->offset);
                     }
 
                     if (json_output_ctx->flags & LOG_JSON_PAYLOAD) {

--- a/src/output-json-dnp3-objects.c
+++ b/src/output-json-dnp3-objects.c
@@ -31,6 +31,7 @@
 #include "output-json-dnp3-objects.h"
 #include "output-json.h"
 
+// clang-format off
 void OutputJsonDNP3SetItem(JsonBuilder *js, DNP3Object *object,
     DNP3Point *point)
 {
@@ -1502,11 +1503,7 @@ void OutputJsonDNP3SetItem(JsonBuilder *js, DNP3Object *object,
             jb_set_string(js, "data->vendor_code", data->vendor_code);
             jb_set_uint(js, "object_id", data->object_id);
             jb_set_uint(js, "length", data->length);
-            unsigned long data_objects_b64_len = BASE64_BUFFER_SIZE(data->length);
-            uint8_t data_objects_b64[data_objects_b64_len];
-            Base64Encode(data->data_objects, data->length,
-                data_objects_b64, &data_objects_b64_len);
-            jb_set_string(js, "data->data_objects", (char *)data_objects_b64);
+            jb_set_base64(js, "data->data_objects", data->data_objects, data->length);
             break;
         }
         case DNP3_OBJECT_CODE(86, 2): {
@@ -1532,22 +1529,14 @@ void OutputJsonDNP3SetItem(JsonBuilder *js, DNP3Object *object,
             jb_set_uint(js, "usr", data->usr);
             jb_set_uint(js, "mal", data->mal);
             jb_set_uint(js, "reason", data->reason);
-            unsigned long challenge_data_b64_len = BASE64_BUFFER_SIZE(data->challenge_data_len);
-            uint8_t challenge_data_b64[challenge_data_b64_len];
-            Base64Encode(data->challenge_data, data->challenge_data_len,
-                challenge_data_b64, &challenge_data_b64_len);
-            jb_set_string(js, "data->challenge_data", (char *)challenge_data_b64);
+            jb_set_base64(js, "data->challenge_data", data->challenge_data, data->challenge_data_len);
             break;
         }
         case DNP3_OBJECT_CODE(120, 2): {
             DNP3ObjectG120V2 *data = point->data;
             jb_set_uint(js, "csq", data->csq);
             jb_set_uint(js, "usr", data->usr);
-            unsigned long mac_value_b64_len = BASE64_BUFFER_SIZE(data->mac_value_len);
-            uint8_t mac_value_b64[mac_value_b64_len];
-            Base64Encode(data->mac_value, data->mac_value_len,
-                mac_value_b64, &mac_value_b64_len);
-            jb_set_string(js, "data->mac_value", (char *)mac_value_b64);
+            jb_set_base64(js, "data->mac_value", data->mac_value, data->mac_value_len);
             break;
         }
         case DNP3_OBJECT_CODE(120, 3): {
@@ -1569,27 +1558,15 @@ void OutputJsonDNP3SetItem(JsonBuilder *js, DNP3Object *object,
             jb_set_uint(js, "key_status", data->key_status);
             jb_set_uint(js, "mal", data->mal);
             jb_set_uint(js, "challenge_data_len", data->challenge_data_len);
-            unsigned long challenge_data_b64_len = BASE64_BUFFER_SIZE(data->challenge_data_len);
-            uint8_t challenge_data_b64[challenge_data_b64_len];
-            Base64Encode(data->challenge_data, data->challenge_data_len,
-                challenge_data_b64, &challenge_data_b64_len);
-            jb_set_string(js, "data->challenge_data", (char *)challenge_data_b64);
-            unsigned long mac_value_b64_len = BASE64_BUFFER_SIZE(data->mac_value_len);
-            uint8_t mac_value_b64[mac_value_b64_len];
-            Base64Encode(data->mac_value, data->mac_value_len,
-                mac_value_b64, &mac_value_b64_len);
-            jb_set_string(js, "data->mac_value", (char *)mac_value_b64);
+            jb_set_base64(js, "data->challenge_data", data->challenge_data, data->challenge_data_len);
+            jb_set_base64(js, "data->mac_value", data->mac_value, data->mac_value_len);
             break;
         }
         case DNP3_OBJECT_CODE(120, 6): {
             DNP3ObjectG120V6 *data = point->data;
             jb_set_uint(js, "ksq", data->ksq);
             jb_set_uint(js, "usr", data->usr);
-            unsigned long wrapped_key_data_b64_len = BASE64_BUFFER_SIZE(data->wrapped_key_data_len);
-            uint8_t wrapped_key_data_b64[wrapped_key_data_b64_len];
-            Base64Encode(data->wrapped_key_data, data->wrapped_key_data_len,
-                wrapped_key_data_b64, &wrapped_key_data_b64_len);
-            jb_set_string(js, "data->wrapped_key_data", (char *)wrapped_key_data_b64);
+            jb_set_base64(js, "data->wrapped_key_data", data->wrapped_key_data, data->wrapped_key_data_len);
             break;
         }
         case DNP3_OBJECT_CODE(120, 7): {
@@ -1615,20 +1592,12 @@ void OutputJsonDNP3SetItem(JsonBuilder *js, DNP3Object *object,
             DNP3ObjectG120V8 *data = point->data;
             jb_set_uint(js, "key_change_method", data->key_change_method);
             jb_set_uint(js, "certificate_type", data->certificate_type);
-            unsigned long certificate_b64_len = BASE64_BUFFER_SIZE(data->certificate_len);
-            uint8_t certificate_b64[certificate_b64_len];
-            Base64Encode(data->certificate, data->certificate_len,
-                certificate_b64, &certificate_b64_len);
-            jb_set_string(js, "data->certificate", (char *)certificate_b64);
+            jb_set_base64(js, "data->certificate", data->certificate, data->certificate_len);
             break;
         }
         case DNP3_OBJECT_CODE(120, 9): {
             DNP3ObjectG120V9 *data = point->data;
-            unsigned long mac_value_b64_len = BASE64_BUFFER_SIZE(data->mac_value_len);
-            uint8_t mac_value_b64[mac_value_b64_len];
-            Base64Encode(data->mac_value, data->mac_value_len,
-                mac_value_b64, &mac_value_b64_len);
-            jb_set_string(js, "data->mac_value", (char *)mac_value_b64);
+            jb_set_base64(js, "data->mac_value", data->mac_value, data->mac_value_len);
             break;
         }
         case DNP3_OBJECT_CODE(120, 10): {
@@ -1651,16 +1620,8 @@ void OutputJsonDNP3SetItem(JsonBuilder *js, DNP3Object *object,
             } else {
                 jb_set_string(js, "username", "");
             }
-            unsigned long user_public_key_b64_len = BASE64_BUFFER_SIZE(data->user_public_key_len);
-            uint8_t user_public_key_b64[user_public_key_b64_len];
-            Base64Encode(data->user_public_key, data->user_public_key_len,
-                user_public_key_b64, &user_public_key_b64_len);
-            jb_set_string(js, "data->user_public_key", (char *)user_public_key_b64);
-            unsigned long certification_data_b64_len = BASE64_BUFFER_SIZE(data->certification_data_len);
-            uint8_t certification_data_b64[certification_data_b64_len];
-            Base64Encode(data->certification_data, data->certification_data_len,
-                certification_data_b64, &certification_data_b64_len);
-            jb_set_string(js, "data->certification_data", (char *)certification_data_b64);
+            jb_set_base64(js, "data->user_public_key", data->user_public_key, data->user_public_key_len);
+            jb_set_base64(js, "data->certification_data", data->certification_data, data->certification_data_len);
             break;
         }
         case DNP3_OBJECT_CODE(120, 11): {
@@ -1678,11 +1639,7 @@ void OutputJsonDNP3SetItem(JsonBuilder *js, DNP3Object *object,
             } else {
                 jb_set_string(js, "username", "");
             }
-            unsigned long master_challenge_data_b64_len = BASE64_BUFFER_SIZE(data->master_challenge_data_len);
-            uint8_t master_challenge_data_b64[master_challenge_data_b64_len];
-            Base64Encode(data->master_challenge_data, data->master_challenge_data_len,
-                master_challenge_data_b64, &master_challenge_data_b64_len);
-            jb_set_string(js, "data->master_challenge_data", (char *)master_challenge_data_b64);
+            jb_set_base64(js, "data->master_challenge_data", data->master_challenge_data, data->master_challenge_data_len);
             break;
         }
         case DNP3_OBJECT_CODE(120, 12): {
@@ -1690,11 +1647,7 @@ void OutputJsonDNP3SetItem(JsonBuilder *js, DNP3Object *object,
             jb_set_uint(js, "ksq", data->ksq);
             jb_set_uint(js, "user_number", data->user_number);
             jb_set_uint(js, "challenge_data_len", data->challenge_data_len);
-            unsigned long challenge_data_b64_len = BASE64_BUFFER_SIZE(data->challenge_data_len);
-            uint8_t challenge_data_b64[challenge_data_b64_len];
-            Base64Encode(data->challenge_data, data->challenge_data_len,
-                challenge_data_b64, &challenge_data_b64_len);
-            jb_set_string(js, "data->challenge_data", (char *)challenge_data_b64);
+            jb_set_base64(js, "data->challenge_data", data->challenge_data, data->challenge_data_len);
             break;
         }
         case DNP3_OBJECT_CODE(120, 13): {
@@ -1702,29 +1655,17 @@ void OutputJsonDNP3SetItem(JsonBuilder *js, DNP3Object *object,
             jb_set_uint(js, "ksq", data->ksq);
             jb_set_uint(js, "user_number", data->user_number);
             jb_set_uint(js, "encrypted_update_key_len", data->encrypted_update_key_len);
-            unsigned long encrypted_update_key_data_b64_len = BASE64_BUFFER_SIZE(data->encrypted_update_key_len);
-            uint8_t encrypted_update_key_data_b64[encrypted_update_key_data_b64_len];
-            Base64Encode(data->encrypted_update_key_data, data->encrypted_update_key_len,
-                encrypted_update_key_data_b64, &encrypted_update_key_data_b64_len);
-            jb_set_string(js, "data->encrypted_update_key_data", (char *)encrypted_update_key_data_b64);
+            jb_set_base64(js, "data->encrypted_update_key_data", data->encrypted_update_key_data, data->encrypted_update_key_len);
             break;
         }
         case DNP3_OBJECT_CODE(120, 14): {
             DNP3ObjectG120V14 *data = point->data;
-            unsigned long digital_signature_b64_len = BASE64_BUFFER_SIZE(data->digital_signature_len);
-            uint8_t digital_signature_b64[digital_signature_b64_len];
-            Base64Encode(data->digital_signature, data->digital_signature_len,
-                digital_signature_b64, &digital_signature_b64_len);
-            jb_set_string(js, "data->digital_signature", (char *)digital_signature_b64);
+            jb_set_base64(js, "data->digital_signature", data->digital_signature, data->digital_signature_len);
             break;
         }
         case DNP3_OBJECT_CODE(120, 15): {
             DNP3ObjectG120V15 *data = point->data;
-            unsigned long mac_b64_len = BASE64_BUFFER_SIZE(data->mac_len);
-            uint8_t mac_b64[mac_b64_len];
-            Base64Encode(data->mac, data->mac_len,
-                mac_b64, &mac_b64_len);
-            jb_set_string(js, "data->mac", (char *)mac_b64);
+            jb_set_base64(js, "data->mac", data->mac, data->mac_len);
             break;
         }
         case DNP3_OBJECT_CODE(121, 1): {
@@ -1777,3 +1718,4 @@ void OutputJsonDNP3SetItem(JsonBuilder *js, DNP3Object *object,
     }
 
 }
+// clang-format on

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -430,11 +430,7 @@ static void BodyBase64Buffer(JsonBuilder *js, HtpBody *body, const char *key)
             return;
         }
 
-        unsigned long len = BASE64_BUFFER_SIZE(body_data_len);
-        uint8_t encoded[len];
-        if (Base64Encode(body_data, body_data_len, encoded, &len) == SC_BASE64_OK) {
-            jb_set_string(js, key, (char *)encoded);
-        }
+        jb_set_base64(js, key, body_data, body_data_len);
     }
 }
 

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -267,12 +267,7 @@ static void JsonTlsLogCertificate(JsonBuilder *js, SSLState *ssl_state)
         return;
     }
 
-    unsigned long len = BASE64_BUFFER_SIZE(cert->cert_len);
-    uint8_t encoded[len];
-    if (Base64Encode(cert->cert_data, cert->cert_len, encoded, &len) ==
-                     SC_BASE64_OK) {
-        jb_set_string(js, "certificate", (char *)encoded);
-    }
+    jb_set_base64(js, "certificate", cert->cert_data, cert->cert_len);
 }
 
 static void JsonTlsLogChain(JsonBuilder *js, SSLState *ssl_state)
@@ -285,12 +280,7 @@ static void JsonTlsLogChain(JsonBuilder *js, SSLState *ssl_state)
 
     SSLCertsChain *cert;
     TAILQ_FOREACH(cert, &ssl_state->server_connp.certs, next) {
-        unsigned long len = BASE64_BUFFER_SIZE(cert->cert_len);
-        uint8_t encoded[len];
-        if (Base64Encode(cert->cert_data, cert->cert_len, encoded, &len) ==
-                         SC_BASE64_OK) {
-            jb_append_string(js, (char *)encoded);
-        }
+        jb_append_base64(js, cert->cert_data, cert->cert_len);
     }
 
     jb_close(js);

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -450,11 +450,7 @@ void EveAddCommonOptions(const OutputJsonCommonSettings *cfg,
 void EvePacket(const Packet *p, JsonBuilder *js, unsigned long max_length)
 {
     unsigned long max_len = max_length == 0 ? GET_PKT_LEN(p) : max_length;
-    unsigned long len = BASE64_BUFFER_SIZE(max_len);
-    uint8_t encoded_packet[len];
-    if (Base64Encode((unsigned char*) GET_PKT_DATA(p), max_len, encoded_packet, &len) == SC_BASE64_OK) {
-        jb_set_string(js, "packet", (char *)encoded_packet);
-    }
+    jb_set_base64(js, "packet", GET_PKT_DATA(p), max_len);
 
     if (!jb_open_object(js, "packet_info")) {
         return;


### PR DESCRIPTION
Add methods `jb_set_base64` and `jb_append_base64` to JsonBuilder to set/append byte array values as base64. This avoids the intermediate buffer that we currently use, and the Rust base64 encode we use can encode directly to the underlying JsonBuilder buffer (internally it appears to use a 1024 byte intermediate buffer that is flushed to the output string when full).

Finally convert all occurrences of `Base64Encode` directly before using it in JsonBuilder with these new methods.

Would be good to have a performance test done. I haven't done my own micro-benchmarks yet, but may do so soon.