### PR TITLE
mqtt: disable by default

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -724,7 +724,7 @@ app-layer:
         dp: 5900, 5901, 5902, 5903, 5904, 5905, 5906, 5907, 5908, 5909
     # MQTT, disabled by default.
     mqtt:
-      # enabled: no
+      enabled: no
       # max-msg-length: 1mb
     krb5:
       enabled: yes


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Effectively disables MQTT by default

#suricata-verify-pr: TODO

cc @satta do we want MQTT enabled or disabled by default ?
It is currently enabled (as the line in suricata.yaml.in is commented out), but the comment states otherwise...