### PR TITLE
App maxtx 4530 v2

### DIFF
--- a/rust/src/kerberos.rs
+++ b/rust/src/kerberos.rs
@@ -62,12 +62,12 @@ fn parse_kerberos5_request_do(blob: &[u8]) -> IResult<&[u8], ApReq, SecBlobError
     )?;
     do_parse!(
         blob,
-        base_o: parse_der_oid >>
-        tok_id: le_u16 >>
+        _base_o: parse_der_oid >>
+        _tok_id: le_u16 >>
         ap_req: parse_ap_req >>
         ({
-            SCLogDebug!("parse_kerberos5_request: base_o {:?}", base_o.as_oid());
-            SCLogDebug!("parse_kerberos5_request: tok_id {}", tok_id);
+            SCLogDebug!("parse_kerberos5_request: base_o {:?}", _base_o.as_oid());
+            SCLogDebug!("parse_kerberos5_request: tok_id {}", _tok_id);
             ap_req
         })
     )

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -227,7 +227,7 @@ int AppLayerParserSetup(void)
 }
 
 // default value is 4096
-uint32_t g_alparser_tx_max = 0x1000;
+uint32_t g_alparser_tx_max = 0x100;
 
 void AppLayerParserPostStreamSetup(void)
 {
@@ -894,7 +894,6 @@ FileContainer *AppLayerParserGetFiles(const Flow *f, const uint8_t direction)
 #define IS_DISRUPTED(flags) ((flags) & (STREAM_DEPTH | STREAM_GAP))
 
 extern int g_detect_disabled;
-extern uint32_t g_alparser_tx_max;
 
 void AppLayerParserUpdateDisrupt(uint64_t id, Flow *f, uint8_t *flags)
 {

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -164,6 +164,11 @@ struct AppLayerParserState_ {
 
     uint64_t min_id;
 
+    /* There are incomplete transactions which should get removed
+     * between min_id and purge_before_tx_id
+     */
+    uint64_t purge_before_tx_id;
+
     /* Used to store decoder events. */
     AppLayerDecoderEvents *decoder_events;
 };
@@ -221,6 +226,9 @@ int AppLayerParserSetup(void)
     SCReturnInt(0);
 }
 
+// default value is 4096
+uint32_t g_alparser_tx_max = 0x1000;
+
 void AppLayerParserPostStreamSetup(void)
 {
     AppProto alproto = 0;
@@ -234,6 +242,16 @@ void AppLayerParserPostStreamSetup(void)
                 alp_ctx.ctxs[flow_proto][alproto].stream_depth =
                     stream_config.reassembly_depth;
             }
+        }
+    }
+
+    const char *conf_val;
+    uint32_t configval;
+    if ((ConfGet("app-layer.max_tx", &conf_val)) == 1) {
+        if (StringParseUint32(&configval, 10, strlen(conf_val), conf_val) > 0) {
+            g_alparser_tx_max = configval;
+        } else {
+            SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for app-layer.max_tx");
         }
     }
 }
@@ -876,6 +894,19 @@ FileContainer *AppLayerParserGetFiles(const Flow *f, const uint8_t direction)
 #define IS_DISRUPTED(flags) ((flags) & (STREAM_DEPTH | STREAM_GAP))
 
 extern int g_detect_disabled;
+extern uint32_t g_alparser_tx_max;
+
+void AppLayerParserUpdateDisrupt(uint64_t id, Flow *f, uint8_t *flags)
+{
+    AppLayerParserState *const alparser = f->alparser;
+    // fake STREAM_DEPTH to fake disruption
+    if (id < alparser->purge_before_tx_id) {
+        *flags |= STREAM_DEPTH;
+    } else {
+        *flags &= ~STREAM_DEPTH;
+    }
+}
+
 /**
  * \brief remove obsolete (inspected and logged) transactions
  */
@@ -902,8 +933,8 @@ void AppLayerParserTransactionsCleanup(Flow *f)
     const LoggerId logger_expectation = AppLayerParserProtocolGetLoggerBits(ipproto, alproto);
     const int tx_end_state_ts = AppLayerParserGetStateProgressCompletionStatus(alproto, STREAM_TOSERVER);
     const int tx_end_state_tc = AppLayerParserGetStateProgressCompletionStatus(alproto, STREAM_TOCLIENT);
-    const uint8_t ts_disrupt_flags = FlowGetDisruptionFlags(f, STREAM_TOSERVER);
-    const uint8_t tc_disrupt_flags = FlowGetDisruptionFlags(f, STREAM_TOCLIENT);
+    uint8_t ts_disrupt_flags = FlowGetDisruptionFlags(f, STREAM_TOSERVER);
+    uint8_t tc_disrupt_flags = FlowGetDisruptionFlags(f, STREAM_TOCLIENT);
 
     AppLayerGetTxIteratorFunc IterFunc = AppLayerGetTxIterator(ipproto, alproto);
     AppLayerGetTxIterState state;
@@ -914,6 +945,7 @@ void AppLayerParserTransactionsCleanup(Flow *f)
     bool skipped = false;
     const bool is_unidir =
             AppLayerParserGetOptionFlags(f->protomap, f->alproto) & APP_LAYER_PARSER_OPT_UNIDIR_TXS;
+    uint64_t nbtx = 0;
 
     while (1) {
         AppLayerGetTxIterTuple ires = IterFunc(ipproto, alproto, alstate, i, total_txs, &state);
@@ -923,9 +955,11 @@ void AppLayerParserTransactionsCleanup(Flow *f)
         bool tx_skipped = false;
         void *tx = ires.tx_ptr;
         i = ires.tx_id; // actual tx id for the tx the IterFunc returned
+        nbtx++;
 
         SCLogDebug("%p/%"PRIu64" checking", tx, i);
 
+        AppLayerParserUpdateDisrupt(i, f, &tc_disrupt_flags);
         const int tx_progress_tc =
                 AppLayerParserGetStateProgress(ipproto, alproto, tx, tc_disrupt_flags);
         if (tx_progress_tc < tx_end_state_tc) {
@@ -933,6 +967,7 @@ void AppLayerParserTransactionsCleanup(Flow *f)
             skipped = true;
             goto next;
         }
+        AppLayerParserUpdateDisrupt(i, f, &ts_disrupt_flags);
         const int tx_progress_ts =
                 AppLayerParserGetStateProgress(ipproto, alproto, tx, ts_disrupt_flags);
         if (tx_progress_ts < tx_end_state_ts) {
@@ -996,6 +1031,7 @@ void AppLayerParserTransactionsCleanup(Flow *f)
 
         /* if we are here, the tx can be freed. */
         p->StateTransactionFree(alstate, i);
+        nbtx--;
         SCLogDebug("%p/%"PRIu64" freed", tx, i);
 
         /* if we didn't skip any tx so far, up the minimum */
@@ -1018,6 +1054,18 @@ next:
             break;
         }
         i++;
+    }
+    memset(&state, 0, sizeof(state));
+    alparser->purge_before_tx_id = new_min;
+    while (g_alparser_tx_max > 0 && nbtx > g_alparser_tx_max) {
+        AppLayerGetTxIterTuple ires = IterFunc(
+                ipproto, alproto, alstate, alparser->purge_before_tx_id, total_txs, &state);
+        if (ires.tx_ptr == NULL) {
+            alparser->purge_before_tx_id++;
+            continue;
+        }
+        alparser->purge_before_tx_id = ires.tx_id + 1;
+        nbtx--;
     }
 
     /* see if we need to bring all trackers up to date. */

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -274,6 +274,9 @@ void AppLayerParserStateFree(AppLayerParserState *pstate);
 
 void AppLayerParserTransactionsCleanup(Flow *f);
 
+// fake a disruption if tx id is before purge_before_tx_id
+void AppLayerParserUpdateDisrupt(uint64_t id, Flow *f, uint8_t *flags);
+
 #ifdef DEBUG
 void AppLayerParserStatePrintDetails(AppLayerParserState *pstate);
 #endif

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -192,8 +192,8 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
     const bool last_pseudo = (p->flowflags & FLOW_PKT_LAST_PSEUDO) != 0;
     const bool ts_eof = AppLayerParserStateIssetFlag(f->alparser, APP_LAYER_PARSER_EOF_TS) != 0;
     const bool tc_eof = AppLayerParserStateIssetFlag(f->alparser, APP_LAYER_PARSER_EOF_TC) != 0;
-    const uint8_t ts_disrupt_flags = FlowGetDisruptionFlags(f, STREAM_TOSERVER);
-    const uint8_t tc_disrupt_flags = FlowGetDisruptionFlags(f, STREAM_TOCLIENT);
+    uint8_t ts_disrupt_flags = FlowGetDisruptionFlags(f, STREAM_TOSERVER);
+    uint8_t tc_disrupt_flags = FlowGetDisruptionFlags(f, STREAM_TOCLIENT);
     const uint64_t total_txs = AppLayerParserGetTxCnt(f, alstate);
     uint64_t tx_id = AppLayerParserGetTransactionLogId(f->alparser);
     uint64_t max_id = tx_id;
@@ -239,6 +239,8 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
             goto next_tx;
         }
 
+        AppLayerParserUpdateDisrupt(tx_id, f, &ts_disrupt_flags);
+        AppLayerParserUpdateDisrupt(tx_id, f, &tc_disrupt_flags);
         const int tx_progress_ts =
                 AppLayerParserGetStateProgress(p->proto, alproto, tx, ts_disrupt_flags);
         const int tx_progress_tc =

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -117,6 +117,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         f->alproto = data[0];
     }
 
+    FLOWLOCK_WRLOCK(f);
     /*
      * We want to fuzz multiple calls to AppLayerParserParse
      * because some parts of the code are only reached after
@@ -158,6 +159,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
                 alsize = 0;
                 break;
             }
+
+            AppLayerParserTransactionsCleanup(f);
         }
         alsize -= alnext - albuffer + 4;
         albuffer = alnext + 4;
@@ -186,6 +189,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         free(isolatedBuffer);
     }
 
+    FLOWLOCK_UNLOCK(f);
     FlowFree(f);
 
     return 0;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4530

Describe changes:
- limits the number of active transactions per flow

Default value is 4096 and configurable.

This is to avoid DOS by quadratic complexity for protocols looping over the whole list of transactions looking for a
specific transation with an identifier, so that a new PDU gets processed within that transaction.

These protocols include HTTP2, MQTT, Modbus (tx id is only u16), SMB ?..

These maxed-out transactions should get logged even if they are incomplete

I do not find elegant that `AppLayerParserUpdateDisrupt` sets a fake STREAM_DEPTH
Do you see a better way ?
Casting u8 to a u16 and adding a new flag ?