### PR TITLE
dcerpc: use null for default ports

### DIFF
--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -1378,10 +1378,9 @@ pub const PARSER_NAME: &'static [u8] = b"dcerpc\0";
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_dcerpc_register_parser() {
-    let default_port = CString::new("[0:65355]").unwrap();
     let parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
-        default_port: default_port.as_ptr(),
+        default_port: b"\0".as_ptr() as *const std::os::raw::c_char,
         ipproto: IPPROTO_TCP,
         probe_ts: None,
         probe_tc: None,

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -345,10 +345,9 @@ fn register_pattern_probe() -> i8 {
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_dcerpc_udp_register_parser() {
-    let default_port = CString::new("[0:65535]").unwrap();
     let parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
-        default_port: default_port.as_ptr(),
+        default_port: b"\0".as_ptr() as *const std::os::raw::c_char,
         ipproto: core::IPPROTO_UDP,
         probe_ts: None,
         probe_tc: None,


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4475
