### PR TITLE
mqtt: enable in config and remove misleading comment

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -722,9 +722,8 @@ app-layer:
       enabled: yes
       detection-ports:
         dp: 5900, 5901, 5902, 5903, 5904, 5905, 5906, 5907, 5908, 5909
-    # MQTT, disabled by default.
     mqtt:
-      # enabled: no
+      enabled: yes
       # max-msg-length: 1mb
     krb5:
       enabled: yes


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Enable MQTT in config explicitly (to make it clear to the user whether it's intended to be on or off) 
- Remove misleading comment about MQTT being disabled by default.

This implements my suggested alternative to #6229 