### PR TITLE
lib: callback on tcp data

### DIFF
--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -145,4 +145,8 @@ void AppLayerUnittestsRegister(void);
 
 void AppLayerIncTxCounter(ThreadVars *tv, Flow *f, uint64_t step);
 
+#ifdef LIBSURICATA_BUILD
+typedef bool (*libsuricata_tcp_cb)(uint8_t *data, uint32_t data_len, uint8_t flags, Flow *f);
+#endif
+
 #endif


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4431

Describe changes:
- Adds a callback on tcp data (ie `AppLayerHandleTCPData`) to be used in libsuricata 

Built with `export CFLAGS=-DLIBSURICATA_BUILD=1`
Ngrep POC is available at https://github.com/catenacyber/ngrep-libsuricata

The other alternative I see to have some ngrep over libsuricata, benefiting from suricata TCP reassembly, is to have a big architectural change in the tcp reassembly to have sequentially tcp reassembly, then app-layer processing on data supplied by tcp reassembly,
ie to call `AppLayerHandleTCPData` (or `StreamTcpReassembleAppLayer`) directly from `FlowWorker` after `FlowWorkerStreamTCPUpdate`, instead of having `AppLayerHandleTCPData` getting called in a 9-deep functions stack
This alternative is complex, and should also take into account the fact that suricata TCP reassembly depends on app-layer processing (sic !) for the case with a request like `GOT / HTTP/1.1` (not GET) and response like `HTTP/1.1 200 OK` where protocol detection recognizes HTTP1 in the response (and nothing in the request), but then wants to parse the HTTP1-ish request before parsing the response. cf `AppLayerTest05`