### PR TITLE
FlowSparePoolUpdate input parameter error

### DIFF
--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -875,7 +875,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
                 const uint32_t spare_perc = sq_len * 100 / flow_config.prealloc;
                 /* see if we still have enough spare flows */
                 if (spare_perc < 90 || spare_perc > 110) {
-                    FlowSparePoolUpdate(sq_len);
+                    FlowSparePoolUpdate(sq_len * 100);
                 }
             }
             const uint32_t secs_passed = rt - flow_last_sec;


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ √] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ √] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-I think it's seem wrong with the method input parameter of FlowSparePoolUpdate in method FlowManager line 873,
  if tfd->instance is zero,then we get the  sq_len and spare_perc:the first one is flow spare pool size,most of the time it equals to flow_config.prealloc /100,the second one it's the percentage of spare flows.
  after this ,wo call FlowSparePoolUpdate，and the input parameter is sq_len(flow spare pool size),but in FlowSparePoolUpdate,it compare with flow_spare_pool_block_size,so I think maybe the input parameter is wrong,It's should be the spare flow numbers,not the spare flow pool size .
  

-
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
