### PR TITLE
http2: document HTTP1 keywords enabling

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1387,6 +1387,13 @@ the app-layer event ``http.compression_bomb`` is set
 (this event can also set from other conditions).
 This can happen on slow configurations (hardware, ASAN, etc...)
 
+HTTP2
+-----
+
+HTTP keywords can be enabled to match on HTTP1 traffic.
+To do so, you should set ``app-layer.protocols.http2.http1-rules``.
+In this case, you cannot have HTTP1-only rules.
+
 Configure SMB (Rust)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -766,6 +766,8 @@ app-layer:
     # HTTP2: Experimental HTTP 2 support. Disabled by default.
     http2:
       enabled: no
+      # use http keywords on HTTP2 traffic
+      http1-rules: no
     smtp:
       enabled: yes
       raw-extraction: no


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4552

Describe changes:
- document `app-layer.protocols.http2.http1-rules` to enable HTTP keywords on HTTP2 traffic (version 6 only)