### PR TITLE
App maxtx 4530 v3

### DIFF
--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -274,6 +274,9 @@ void AppLayerParserStateFree(AppLayerParserState *pstate);
 
 void AppLayerParserTransactionsCleanup(Flow *f);
 
+// fake a disruption if tx id is before purge_before_tx_id
+void AppLayerParserUpdateDisrupt(uint64_t id, Flow *f, uint8_t *flags);
+
 #ifdef DEBUG
 void AppLayerParserStatePrintDetails(AppLayerParserState *pstate);
 #endif

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -192,8 +192,8 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
     const bool last_pseudo = (p->flowflags & FLOW_PKT_LAST_PSEUDO) != 0;
     const bool ts_eof = AppLayerParserStateIssetFlag(f->alparser, APP_LAYER_PARSER_EOF_TS) != 0;
     const bool tc_eof = AppLayerParserStateIssetFlag(f->alparser, APP_LAYER_PARSER_EOF_TC) != 0;
-    const uint8_t ts_disrupt_flags = FlowGetDisruptionFlags(f, STREAM_TOSERVER);
-    const uint8_t tc_disrupt_flags = FlowGetDisruptionFlags(f, STREAM_TOCLIENT);
+    uint8_t ts_disrupt_flags = FlowGetDisruptionFlags(f, STREAM_TOSERVER);
+    uint8_t tc_disrupt_flags = FlowGetDisruptionFlags(f, STREAM_TOCLIENT);
     const uint64_t total_txs = AppLayerParserGetTxCnt(f, alstate);
     uint64_t tx_id = AppLayerParserGetTransactionLogId(f->alparser);
     uint64_t max_id = tx_id;
@@ -239,6 +239,8 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
             goto next_tx;
         }
 
+        AppLayerParserUpdateDisrupt(tx_id, f, &ts_disrupt_flags);
+        AppLayerParserUpdateDisrupt(tx_id, f, &tc_disrupt_flags);
         const int tx_progress_ts =
                 AppLayerParserGetStateProgress(p->proto, alproto, tx, ts_disrupt_flags);
         const int tx_progress_tc =

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -117,6 +117,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         f->alproto = data[0];
     }
 
+    FLOWLOCK_WRLOCK(f);
     /*
      * We want to fuzz multiple calls to AppLayerParserParse
      * because some parts of the code are only reached after
@@ -158,6 +159,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
                 alsize = 0;
                 break;
             }
+
+            AppLayerParserTransactionsCleanup(f);
         }
         alsize -= alnext - albuffer + 4;
         albuffer = alnext + 4;
@@ -186,6 +189,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         free(isolatedBuffer);
     }
 
+    FLOWLOCK_UNLOCK(f);
     FlowFree(f);
 
     return 0;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4530

Describe changes:
- limits the number of active transactions per flow

Default value is 4096 and configurable.

This is to avoid DOS by quadratic complexity for protocols looping over the whole list of transactions looking for a
specific transation with an identifier, so that a new PDU gets processed within that transaction.

These protocols include HTTP2, MQTT, Modbus (tx id is only u16), SMB ?..

These maxed-out transactions should get logged even if they are incomplete

I do not find elegant that `AppLayerParserUpdateDisrupt` sets a fake STREAM_DEPTH
Do you see a better way ?
Casting u8 to a u16 and adding a new flag ?

Replaces #6230 with better decimal readability