### PR TITLE
lib: callback on tcp data

### DIFF
--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -578,14 +578,13 @@ static int TCPProtoDetect(ThreadVars *tv,
  *  \param stream ptr-to-ptr to stream object. Might change if flow dir is
  *                reversed.
  */
-int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
-                          Packet *p, Flow *f,
-                          TcpSession *ssn, TcpStream **stream,
-                          uint8_t *data, uint32_t data_len,
-                          uint8_t flags)
+static int AppLayerHandleTCPDataSuricata(void *tvp, void *ra_ctxp, Packet *p, Flow *f,
+        TcpSession *ssn, TcpStream **stream, uint8_t *data, uint32_t data_len, uint8_t flags)
 {
     SCEnter();
 
+    ThreadVars *tv = (ThreadVars *)tvp;
+    TcpReassemblyThreadCtx *ra_ctx = (TcpReassemblyThreadCtx *)ra_ctxp;
     DEBUG_ASSERT_FLOW_LOCKED(f);
     DEBUG_VALIDATE_BUG_ON(data_len > (uint32_t)INT_MAX);
 
@@ -840,6 +839,7 @@ int AppLayerSetup(void)
 {
     SCEnter();
 
+    AppLayerHandleTCPData = AppLayerHandleTCPDataSuricata;
     AppLayerProtoDetectSetup();
     AppLayerParserSetup();
 

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -718,6 +718,8 @@ static int AppLayerHandleTCPDataSuricata(void *tvp, void *ra_ctxp, Packet *p, Fl
     SCReturnInt(r);
 }
 
+libsuricata_tcp_cb AppLayerHandleTCPData = AppLayerHandleTCPDataSuricata;
+
 /**
  *  \brief Handle a app layer UDP message
  *
@@ -839,7 +841,6 @@ int AppLayerSetup(void)
 {
     SCEnter();
 
-    AppLayerHandleTCPData = AppLayerHandleTCPDataSuricata;
     AppLayerProtoDetectSetup();
     AppLayerParserSetup();
 

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -38,14 +38,13 @@
 
 /***** L7 layer dispatchers *****/
 
+typedef int (*libsuricata_tcp_cb)(void *tv, void *ra_ctx, Packet *p, Flow *f, TcpSession *ssn,
+        TcpStream **stream, uint8_t *data, uint32_t data_len, uint8_t flags);
+
 /**
  * \brief Handles reassembled tcp stream.
  */
-int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
-                          Packet *p, Flow *f,
-                          TcpSession *ssn, TcpStream **stream,
-                          uint8_t *data, uint32_t data_len,
-                          uint8_t flags);
+libsuricata_tcp_cb AppLayerHandleTCPData;
 
 /**
  * \brief Handles an udp chunk.

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -44,7 +44,7 @@ typedef int (*libsuricata_tcp_cb)(void *tv, void *ra_ctx, Packet *p, Flow *f, Tc
 /**
  * \brief Handles reassembled tcp stream.
  */
-libsuricata_tcp_cb AppLayerHandleTCPData;
+extern libsuricata_tcp_cb AppLayerHandleTCPData;
 
 /**
  * \brief Handles an udp chunk.


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4431

Describe changes:
- Adds a callback on tcp data (ie `AppLayerHandleTCPData`) to be overridden by programs using libsuricata 

Ngrep POC is available at https://github.com/catenacyber/ngrep-libsuricata

Modifies https://github.com/OISF/suricata/pull/6247 by removing the different compile-time options/schemes for Suricata and libsuricata users such as ngrep

The other alternative I see to have some ngrep over libsuricata, benefiting from suricata TCP reassembly, is to have a big architectural change in the tcp reassembly to have sequentially tcp reassembly, then app-layer processing on data supplied by tcp reassembly,
ie to call `AppLayerHandleTCPData` (or `StreamTcpReassembleAppLayer`) directly from `FlowWorker` after `FlowWorkerStreamTCPUpdate`, instead of having `AppLayerHandleTCPData` getting called in a 9-deep functions stack
This alternative is complex, and should also take into account the fact that suricata TCP reassembly depends on app-layer processing (sic !) for the case with a request like `GOT / HTTP/1.1` (not GET) and response like `HTTP/1.1 200 OK` where protocol detection recognizes HTTP1 in the response (and nothing in the request), but then wants to parse the HTTP1-ish request before parsing the response. cf `AppLayerTest05`