### PR TITLE
ci: rebase specified s-v pr

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -97,11 +97,12 @@ jobs:
           tar zcf suricata-update.tar.gz suricata-update
       - name: Fetching suricata-verify
         run: |
-          git clone --depth 1 ${sv_repo} -b ${sv_branch} suricata-verify
+          git clone ${sv_repo} -b ${sv_branch} suricata-verify
           if [[ "${sv_pr}" != "" ]]; then
               cd suricata-verify
               git fetch origin pull/${sv_pr}/head:prep
               git checkout prep
+              git rebase ${DEFAULT_SV_BRANCH}
               cd ..
           fi
           tar zcf suricata-verify.tar.gz suricata-verify


### PR DESCRIPTION
Link to redmine ticket:
None

Describe changes:
- ci : rebase suricata verify PR when specified

Just for testing
suricata-verify-pr: 476

Modifies #6255 by removing `depth` argument in `git clone` of suricata-verify