### PR TITLE
Fuzz perf v2

### DIFF
--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -211,6 +211,7 @@ void DetectAppLayerMpmRegisterByParentId(DetectEngineCtx *de_ctx,
 void DetectMpmInitializeAppMpms(DetectEngineCtx *de_ctx)
 {
     const DetectBufferMpmRegistery *list = g_mpm_list[DETECT_BUFFER_MPM_TYPE_APP];
+    DetectBufferMpmRegistery *toadd = de_ctx->app_mpms_list;
     while (list != NULL) {
         DetectBufferMpmRegistery *n = SCCalloc(1, sizeof(*n));
         BUG_ON(n == NULL);
@@ -218,14 +219,12 @@ void DetectMpmInitializeAppMpms(DetectEngineCtx *de_ctx)
         *n = *list;
         n->next = NULL;
 
-        if (de_ctx->app_mpms_list == NULL) {
+        if (toadd == NULL) {
+            toadd = n;
             de_ctx->app_mpms_list = n;
         } else {
-            DetectBufferMpmRegistery *t = de_ctx->app_mpms_list;
-            while (t->next != NULL) {
-                t = t->next;
-            }
-            t->next = n;
+            toadd->next = n;
+            toadd = toadd->next;
         }
 
         /* default to whatever the global setting is */

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -230,6 +230,7 @@ void DetectMpmInitializeAppMpms(DetectEngineCtx *de_ctx)
         /* default to whatever the global setting is */
         int shared = (de_ctx->sgh_mpm_ctx_cnf == ENGINE_SGH_MPM_FACTORY_CONTEXT_SINGLE);
 
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
         /* see if we use a unique or shared mpm ctx for this type */
         int confshared = 0;
         char confstring[256] = "detect.mpm.";
@@ -237,6 +238,7 @@ void DetectMpmInitializeAppMpms(DetectEngineCtx *de_ctx)
         strlcat(confstring, ".shared", sizeof(confstring));
         if (ConfGetBool(confstring, &confshared) == 1)
             shared = confshared;
+#endif
 
         if (shared == 0) {
             if (!(de_ctx->flags & DE_QUIET)) {

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -272,6 +272,7 @@ static void DetectAppLayerInspectEngineCopy(
 static void DetectAppLayerInspectEngineCopyListToDetectCtx(DetectEngineCtx *de_ctx)
 {
     const DetectEngineAppInspectionEngine *t = g_app_inspect_engines;
+    DetectEngineAppInspectionEngine *list = de_ctx->app_inspect_engines;
     while (t) {
         DetectEngineAppInspectionEngine *new_engine = SCCalloc(1, sizeof(DetectEngineAppInspectionEngine));
         if (unlikely(new_engine == NULL)) {
@@ -284,16 +285,12 @@ static void DetectAppLayerInspectEngineCopyListToDetectCtx(DetectEngineCtx *de_c
         new_engine->progress = t->progress;
         new_engine->v2 = t->v2;
 
-        if (de_ctx->app_inspect_engines == NULL) {
+        if (list == NULL) {
             de_ctx->app_inspect_engines = new_engine;
         } else {
-            DetectEngineAppInspectionEngine *list = de_ctx->app_inspect_engines;
-            while (list->next != NULL) {
-                list = list->next;
-            }
-
             list->next = new_engine;
         }
+        list = new_engine;
 
         t = t->next;
     }

--- a/src/tests/fuzz/confyaml.c
+++ b/src/tests/fuzz/confyaml.c
@@ -14,58 +14,9 @@ outputs:\n\
       enabled: yes\n\
       filename: /dev/null\n\
   - eve-log:\n\
-      enabled: yes\n\
+      enabled: no\n\
       filetype: regular\n\
       filename: /dev/null\n\
-      xff:\n\
-        enabled: yes\n\
-        mode: extra-data\n\
-        deployment: reverse\n\
-        header: X-Forwarded-For\n\
-      types:\n\
-        - alert:\n\
-            payload: yes\n\
-            payload-printable: yes\n\
-            packet: yes\n\
-            metadata: yes\n\
-            http-body: yes\n\
-            http-body-printable: yes\n\
-            tagged-packets: yes\n\
-        - anomaly:\n\
-            enabled: yes\n\
-            types:\n\
-              decode: yes\n\
-              stream: yes\n\
-              applayer: yes\n\
-            packethdr: yes\n\
-        - http:\n\
-            extended: yes\n\
-            dump-all-headers: both\n\
-        - dns\n\
-        - tls:\n\
-            extended: yes\n\
-            session-resumption: yes\n\
-        - files\n\
-        - smtp:\n\
-            extended: yes\n\
-        - dnp3\n\
-        - ftp\n\
-        - rdp\n\
-        - nfs\n\
-        - smb\n\
-        - tftp\n\
-        - ike\n\
-        - krb5\n\
-        - snmp\n\
-        - rfb\n\
-        - sip\n\
-        - dhcp:\n\
-            enabled: yes\n\
-            extended: yes\n\
-        - ssh\n\
-        - flow\n\
-        - netflow\n\
-        - metadata\n\
   - http-log:\n\
       enabled: yes\n\
       filename: /dev/null\n\

--- a/src/util-hashlist.c
+++ b/src/util-hashlist.c
@@ -36,6 +36,11 @@ HashListTable* HashListTableInit(uint32_t size, uint32_t (*Hash)(struct HashList
 
     HashListTable *ht = NULL;
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    if (size > 256) {
+        size = MIN(size/4, 1024);
+    }
+#endif
     if (size == 0) {
         goto error;
     }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4125

Describe changes:
- avoid quadratic complexity in `DetectAppLayerInspectEngineCopyListToDetectCtx` and `DetectMpmInitializeAppMpms`
- use smaller hash tables when compiled in unsafe fuzzing mode (faster for reset)
- avoids useless reads of config when compiled for fuzzing
- no eve log for fuzzing

This is a draft PR for discussion :
- The first 2 commits seem good in every case for me.
- The additions of `#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION` make the code more complex even if fuzzing is faster
- The removal of eve log will cover less code, but anomaly logging is expensive while fuzzing...

cf https://github.com/google/oss-fuzz/pull/5995