### PR TITLE
Dnp3 intraoverflow 4558 v2

### DIFF
--- a/scripts/dnp3-gen/dnp3-gen.py
+++ b/scripts/dnp3-gen/dnp3-gen.py
@@ -171,7 +171,7 @@ void OutputJsonDNP3SetItem(JsonBuilder *js, DNP3Object *object,
 {% elif field.type in ["flt32", "flt64"] %}
             jb_set_float(js, "{{field.name}}", data->{{field.name}});
 {% elif field.type == "bytearray" %}
-            unsigned long {{field.name}}_b64_len = data->{{field.len_field}} * 2;
+            unsigned long {{field.name}}_b64_len = BASE64_BUFFER_SIZE(data->{{field.len_field}});
             uint8_t {{field.name}}_b64[{{field.name}}_b64_len];
             Base64Encode(data->{{field.name}}, data->{{field.len_field}},
                 {{field.name}}_b64, &{{field.name}}_b64_len);

--- a/scripts/dnp3-gen/dnp3-gen.py
+++ b/scripts/dnp3-gen/dnp3-gen.py
@@ -518,6 +518,9 @@ static int DNP3DecodeObjectG{{object.group}}V{{object.variation}}(const uint8_t 
         }
 {% elif field.type == "chararray" %}
 {% if field.len_from_prefix %}
+        if (prefix - (offset - *len) >= {{field.size}}) {
+            goto error;
+        }
         object->{{field.len_field}} = prefix - (offset - *len);
 {% endif %}
         if (object->{{field.len_field}} > 0) {

--- a/src/app-layer-dnp3-objects.c
+++ b/src/app-layer-dnp3-objects.c
@@ -7153,6 +7153,9 @@ static int DNP3DecodeObjectG70V4(const uint8_t **buf, uint32_t *len,
         if (!DNP3ReadUint8(buf, len, &object->status_code)) {
             goto error;
         }
+        if (prefix - (offset - *len) >= 255) {
+            goto error;
+        }
         object->optional_text_len = prefix - (offset - *len);
         if (object->optional_text_len > 0) {
             if (*len < object->optional_text_len) {
@@ -7215,6 +7218,9 @@ static int DNP3DecodeObjectG70V5(const uint8_t **buf, uint32_t *len,
             goto error;
         }
         if (!DNP3ReadUint32(buf, len, &object->block_number)) {
+            goto error;
+        }
+        if (prefix - (offset - *len) >= 255) {
             goto error;
         }
         object->file_data_len = prefix - (offset - *len);
@@ -7282,6 +7288,9 @@ static int DNP3DecodeObjectG70V6(const uint8_t **buf, uint32_t *len,
             goto error;
         }
         if (!DNP3ReadUint8(buf, len, &object->status_code)) {
+            goto error;
+        }
+        if (prefix - (offset - *len) >= 255) {
             goto error;
         }
         object->optional_text_len = prefix - (offset - *len);
@@ -7413,6 +7422,9 @@ static int DNP3DecodeObjectG70V8(const uint8_t **buf, uint32_t *len,
 
         offset = *len;
 
+        if (prefix - (offset - *len) >= 65535) {
+            goto error;
+        }
         object->file_specification_len = prefix - (offset - *len);
         if (object->file_specification_len > 0) {
             if (*len < object->file_specification_len) {
@@ -8156,6 +8168,9 @@ static int DNP3DecodeObjectG120V7(const uint8_t **buf, uint32_t *len,
             goto error;
         }
         if (!DNP3ReadUint48(buf, len, &object->time_of_error)) {
+            goto error;
+        }
+        if (prefix - (offset - *len) >= 65535) {
             goto error;
         }
         object->error_text_len = prefix - (offset - *len);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4558

Describe changes:
- adds a bound check in DNP3 parsing (for prefix chararray)
- use base64 macro in gen script (as was already done in generated C code)