### PR TITLE
qa: use time on fuzz targets being run on corpus

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -741,6 +741,7 @@ jobs:
                 exuberant-ctags \
                 unzip \
                 curl \
+                time \
                 wget
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2

--- a/qa/run-ossfuzz-corpus.sh
+++ b/qa/run-ossfuzz-corpus.sh
@@ -9,5 +9,5 @@ do
     rm -rf corpus_$target
     unzip -q public.zip -d corpus_$target
     #run target on corpus.
-    ./src/$target corpus_$target
+    /usr/bin/time -v ./src/$target corpus_$target
 done


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- 

We use to get for build ubuntu-20-04-cov-fuzz, aka Ubuntu 20.04 (fuzz corpus coverage)
```
Run ./qa/run-ossfuzz-corpus.sh
target fuzz_applayerparserparse
target fuzz_applayerprotodetectgetproto
target fuzz_confyamlloadstring
target fuzz_decodepcapfile
target fuzz_mimedecparseline
target fuzz_siginit
target fuzz_sigpcap
Killed
Error: Process completed with exit code 137.
```

It does not look reproducible, and `time` or printing the file name of the input being run seem to prevent these crashes