### PR TITLE
output:Fix possible segmentfault

### DIFF
--- a/src/util-log-redis.c
+++ b/src/util-log-redis.c
@@ -210,6 +210,7 @@ static int SCConfLogReopenAsyncRedis(LogFileCtx *log_ctx)
 
     if (ctx->ev_base != NULL) {
         event_base_free(ctx->ev_base);
+        ctx->ev_base = NULL;
     }
 
     if (ctx->async == NULL) {


### PR DESCRIPTION
This trivial fix is to avoid segmentfault when reopening redis
ticket: https://redmine.openinfosecfoundation.org/issues/4586