### PR TITLE
[Draft]: Multi-queue netmap support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1581,6 +1581,16 @@
         ])], [have_gtv13_netmap="yes"])
         if test "x$have_gtv13_netmap" = "xyes"; then
             have_netmap_version="> v13"
+            AC_CHECK_HEADER(libnetmap.h,,[AC_MSG_ERROR(libnetmap.h not found ...)],)
+            LIBNETMAP=""
+            AC_SEARCH_LIBS([nmport_open],[netmap],,[LIBNETMAP="no"])
+            if test "$LIBNETMAP" = "no"; then
+                echo
+                echo "   ERROR!  libnetmap library not found!"
+                echo
+                exit 1
+            fi
+            AC_DEFINE([HAVE_NETMAP_V14],[1],(NETMAP API v14 support enabled))
         fi
   ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1580,7 +1580,7 @@
         #endif
         ])], [have_gtv13_netmap="yes"])
         if test "x$have_gtv13_netmap" = "xyes"; then
-            have_netmap_version="> v13"
+            have_netmap_version="v14+"
             AC_CHECK_HEADER(libnetmap.h,,[AC_MSG_ERROR(libnetmap.h not found ...)],)
             LIBNETMAP=""
             AC_SEARCH_LIBS([nmport_open],[netmap],,[LIBNETMAP="no"])

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -286,7 +286,6 @@ static void *ParseNetmapConfig(const char *iface_name)
             if_root = ConfFindDeviceConfig(netmap_node, out_iface);
             ParseNetmapSettings(&aconf->out, out_iface, if_root, if_default);
 
-#ifndef HAVE_NETMAP_V14
             /* if one side of the IPS peering uses a sw_ring, we will default
              * to using a single ring/thread on the other side as well. Only
              * if thread variable is set to 'auto'. So the user can override
@@ -296,7 +295,6 @@ static void *ParseNetmapConfig(const char *iface_name)
             } else if (aconf->in.sw_ring && aconf->out.threads_auto) {
                 aconf->out.threads = aconf->in.threads = 1;
             }
-#endif
         }
     }
 
@@ -304,13 +302,9 @@ static void *ParseNetmapConfig(const char *iface_name)
     SCLogNotice("%s -- %d rings", aconf->iface_name, ring_count);
 
     for (int i = 0; i < ring_count; i++) {
-        char *live_buf = SCCalloc(1, 32);
-        if (live_buf == NULL) {
-            FatalError(SC_ERR_FATAL, "Unable to allocate live device name buffer for ring %d", i);
-        }
-        snprintf(live_buf, 32, "netmap%d", i);
+        char live_buf[32] = {0};
+        snprintf(live_buf, sizeof(live_buf), "netmap%d", i);
         LiveRegisterDevice(live_buf);
-        SCFree(live_buf);
     }
 
     /* netmap needs all offloading to be disabled */

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -487,7 +487,7 @@ int RunModeIdsNetmapWorkers(void)
 int RunModeIdsNetmapAutoFp(void)
 {
     SCEnter();
-    FatalError("Netmap not configured");
+    FatalError(SC_ERR_FATAL,"Netmap not configured");
     SCReturnInt(0);
 }
 
@@ -497,7 +497,7 @@ int RunModeIdsNetmapAutoFp(void)
 int RunModeIdsNetmapSingle(void)
 {
     SCEnter();
-    FatalError("Netmap not configured");
+    FatalError(SC_ERR_FATAL,"Netmap not configured");
     SCReturnInt(0);
 }
 
@@ -510,7 +510,7 @@ int RunModeIdsNetmapSingle(void)
 int RunModeIdsNetmapWorkers(void)
 {
     SCEnter();
-    FatalError("Netmap not configured");
+    FatalError(SC_ERR_FATAL,"Netmap not configured");
     SCReturnInt(0);
 }
 #endif // #ifdef HAVE_NETMAP

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014-2018 Open Information Security Foundation
+/* Copyright (C) 2014-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -22,13 +22,14 @@
 */
 
 /**
-* \file
-*
-* \author Aleksey Katargin <gureedo@gmail.com>
-*
-* Netmap runmode
-*
-*/
+ * \file
+ *
+ * \author Aleksey Katargin <gureedo@gmail.com>
+ * \author Bill Meeks <billmeeks8@gmail.com>
+ *
+ * Netmap runmode
+ *
+ */
 
 #include "suricata-common.h"
 #include "tm-threads.h"
@@ -51,6 +52,10 @@
 #include "util-runmodes.h"
 #include "util-ioctl.h"
 #include "util-byte.h"
+
+#ifdef HAVE_NETMAP
+#include <net/netmap_user.h>
+#endif /* HAVE_NETMAP */
 
 #include "source-netmap.h"
 
@@ -208,10 +213,14 @@ finalize:
 
     ns->ips = (ns->copy_mode != NETMAP_COPY_MODE_NONE);
 
+#ifndef HAVE_NETMAP_V14
     if (ns->sw_ring) {
-        /* just one thread per interface supported */
+        /* just one thread per interface supported with older API */
         ns->threads = 1;
     } else if (ns->threads_auto) {
+#else
+    if (ns->threads_auto && !ns->sw_ring) {
+#endif /* HAVE_NETMAP_V14 */
         /* As NetmapGetRSSCount used to be broken on Linux,
          * fall back to GetIfaceRSSQueuesNum if needed. */
         ns->threads = NetmapGetRSSCount(ns->iface);
@@ -277,6 +286,7 @@ static void *ParseNetmapConfig(const char *iface_name)
             if_root = ConfFindDeviceConfig(netmap_node, out_iface);
             ParseNetmapSettings(&aconf->out, out_iface, if_root, if_default);
 
+#ifndef HAVE_NETMAP_V14
             /* if one side of the IPS peering uses a sw_ring, we will default
              * to using a single ring/thread on the other side as well. Only
              * if thread variable is set to 'auto'. So the user can override
@@ -286,7 +296,21 @@ static void *ParseNetmapConfig(const char *iface_name)
             } else if (aconf->in.sw_ring && aconf->out.threads_auto) {
                 aconf->out.threads = aconf->in.threads = 1;
             }
+#endif
         }
+    }
+
+    int ring_count = NetmapGetRSSCount(aconf->iface_name);
+    SCLogNotice("%s -- %d rings", aconf->iface_name, ring_count);
+
+    for (int i = 0; i < ring_count; i++) {
+        char *live_buf = SCCalloc(1, 32);
+        if (live_buf == NULL) {
+            FatalError(SC_ERR_FATAL, "Unable to allocate live device name buffer for ring %d", i);
+        }
+        snprintf(live_buf, 32, "netmap%d", i);
+        LiveRegisterDevice(live_buf);
+        SCFree(live_buf);
     }
 
     /* netmap needs all offloading to be disabled */
@@ -397,38 +421,48 @@ int NetmapRunModeIsIPS()
     return has_ips;
 }
 
-#endif // #ifdef HAVE_NETMAP
+typedef enum { NETMAP_AUTOFP, NETMAP_WORKERS, NETMAP_SINGLE } NetmapRunMode_t;
 
-int RunModeIdsNetmapAutoFp(void)
+static int NetmapRunModeInit(NetmapRunMode_t runmode)
 {
     SCEnter();
 
-#ifdef HAVE_NETMAP
-    int ret;
-    const char *live_dev = NULL;
-
     RunModeInitialize();
-
     TimeModeSetLive();
 
+    const char *live_dev = NULL;
     (void)ConfGet("netmap.live-interface", &live_dev);
 
-    SCLogDebug("live_dev %s", live_dev);
-
-    ret = RunModeSetLiveCaptureAutoFp(
-                              ParseNetmapConfig,
-                              NetmapConfigGeThreadsCount,
-                              "ReceiveNetmap",
-                              "DecodeNetmap", thread_name_autofp,
-                              live_dev);
+    int ret;
+    switch (runmode) {
+        case NETMAP_AUTOFP:
+            ret = RunModeSetLiveCaptureAutoFp(ParseNetmapConfig, NetmapConfigGeThreadsCount,
+                    "ReceiveNetmap", "DecodeNetmap", thread_name_autofp, live_dev);
+            break;
+        case NETMAP_WORKERS:
+            ret = RunModeSetLiveCaptureWorkers(ParseNetmapConfig, NetmapConfigGeThreadsCount,
+                    "ReceiveNetmap", "DecodeNetmap", thread_name_workers, live_dev);
+            break;
+        case NETMAP_SINGLE:
+            ret = RunModeSetLiveCaptureSingle(ParseNetmapConfig, NetmapConfigGeThreadsCount,
+                    "ReceiveNetmap", "DecodeNetmap", thread_name_single, live_dev);
+            break;
+    }
     if (ret != 0) {
-        FatalError(SC_ERR_FATAL, "Unable to start runmode");
+        FatalError(SC_ERR_FATAL, "Unable to start runmode %s",
+                runmode == NETMAP_AUTOFP ? "autofp"
+                                         : runmode == NETMAP_WORKERS ? "workers" : "single");
     }
 
-    SCLogDebug("RunModeIdsNetmapAutoFp initialised");
-#endif /* HAVE_NETMAP */
+    SCLogNotice("%s initialized",
+            runmode == NETMAP_AUTOFP ? "autofp" : runmode == NETMAP_WORKERS ? "workers" : "single");
 
     SCReturnInt(0);
+}
+
+int RunModeIdsNetmapAutoFp(void)
+{
+    return NetmapRunModeInit(NETMAP_AUTOFP);
 }
 
 /**
@@ -436,30 +470,34 @@ int RunModeIdsNetmapAutoFp(void)
 */
 int RunModeIdsNetmapSingle(void)
 {
+    return NetmapRunModeInit(NETMAP_SINGLE);
+}
+
+/**
+ * \brief Workers version of the netmap processing.
+ *
+ * Start N threads with each thread doing all the work.
+ *
+ */
+int RunModeIdsNetmapWorkers(void)
+{
+    return NetmapRunModeInit(NETMAP_WORKERS);
+}
+#else
+int RunModeIdsNetmapAutoFp(void)
+{
     SCEnter();
+    FatalError("Netmap not configured");
+    SCReturnInt(0);
+}
 
-#ifdef HAVE_NETMAP
-    int ret;
-    const char *live_dev = NULL;
-
-    RunModeInitialize();
-    TimeModeSetLive();
-
-    (void)ConfGet("netmap.live-interface", &live_dev);
-
-    ret = RunModeSetLiveCaptureSingle(
-                                    ParseNetmapConfig,
-                                    NetmapConfigGeThreadsCount,
-                                    "ReceiveNetmap",
-                                    "DecodeNetmap", thread_name_single,
-                                    live_dev);
-    if (ret != 0) {
-        FatalError(SC_ERR_FATAL, "Unable to start runmode");
-    }
-
-    SCLogDebug("RunModeIdsNetmapSingle initialised");
-
-#endif /* HAVE_NETMAP */
+/**
+ * \brief Single thread version of the netmap processing.
+ */
+int RunModeIdsNetmapSingle(void)
+{
+    SCEnter();
+    FatalError("Netmap not configured");
     SCReturnInt(0);
 }
 
@@ -472,31 +510,10 @@ int RunModeIdsNetmapSingle(void)
 int RunModeIdsNetmapWorkers(void)
 {
     SCEnter();
-
-#ifdef HAVE_NETMAP
-    int ret;
-    const char *live_dev = NULL;
-
-    RunModeInitialize();
-    TimeModeSetLive();
-
-    (void)ConfGet("netmap.live-interface", &live_dev);
-
-    ret = RunModeSetLiveCaptureWorkers(
-                                    ParseNetmapConfig,
-                                    NetmapConfigGeThreadsCount,
-                                    "ReceiveNetmap",
-                                    "DecodeNetmap", thread_name_workers,
-                                    live_dev);
-    if (ret != 0) {
-        FatalError(SC_ERR_FATAL, "Unable to start runmode");
-    }
-
-    SCLogDebug("RunModeIdsNetmapWorkers initialised");
-
-#endif /* HAVE_NETMAP */
+    FatalError("Netmap not configured");
     SCReturnInt(0);
 }
+#endif // #ifdef HAVE_NETMAP
 
 /**
 * @}

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2011-2018 Open Information Security Foundation
+/* Copyright (C) 2011-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -22,17 +22,17 @@
 */
 
 /**
-* \file
-*
-* \author Aleksey Katargin <gureedo@gmail.com>
-* \author Victor Julien <victor@inliniac.net>
-*
-* Netmap socket acquisition support
-*
-* Many thanks to Luigi Rizzo for guidance and support.
-*
-*/
-
+ * \file
+ *
+ * \author Aleksey Katargin <gureedo@gmail.com>
+ * \author Victor Julien <victor@inliniac.net>
+ * \author Bill Meeks <billmeeks8@gmail.com>
+ *
+ * Netmap socket acquisition support
+ *
+ * Many thanks to Luigi Rizzo for guidance and support.
+ *
+ */
 
 #include "suricata-common.h"
 #include "suricata.h"
@@ -68,7 +68,12 @@
 #ifdef DEBUG
 #define DEBUG_NETMAP_USER
 #endif
+
+#ifdef HAVE_NETMAP_V14
+#include <libnetmap.h>
+#else
 #include <net/netmap_user.h>
+#endif /* HAVE_NETMAP_V14 */
 
 #endif /* HAVE_NETMAP */
 
@@ -128,13 +133,34 @@ enum {
     NETMAP_FLAG_ZERO_COPY = 1,
 };
 
+#ifndef HAVE_NETMAP_WITH_LIBS
+struct nm_pkthdr { /* first part is the same as pcap_pkthdr */
+    struct timeval ts;
+    uint32_t caplen;
+    uint32_t len;
+    uint64_t flags; /* NM_MORE_PKTS etc */
+#define NM_MORE_PKTS 1
+#if NETMAP_API > 13
+    struct nmport_d *d;
+#else
+    struct nm_desc *d;
+#endif
+    struct netmap_slot *slot;
+    uint8_t *buf;
+};
+#endif
+
 /**
  * \brief Netmap device instance. Each ring for each device gets its own
  *        device.
  */
 typedef struct NetmapDevice_
 {
+#if NETMAP_API > 13
+    struct nmport_d *nmd;
+#else
     struct nm_desc *nmd;
+#endif
     unsigned int ref;
     SC_ATOMIC_DECLARE(unsigned int, threads_run);
     TAILQ_ENTRY(NetmapDevice_) next;
@@ -150,7 +176,7 @@ typedef struct NetmapDevice_
  */
 typedef struct NetmapThreadVars_
 {
-    /* receive inteface */
+    /* receive interface */
     NetmapDevice *ifsrc;
     /* dst interface for IPS mode */
     NetmapDevice *ifdst;
@@ -185,12 +211,13 @@ static SCMutex netmap_devlist_lock = SCMUTEX_INITIALIZER;
  */
 int NetmapGetRSSCount(const char *ifname)
 {
-    struct nmreq nm_req;
+    struct nmreq_port_info_get req;
+    struct nmreq_header hdr;
     int rx_rings = 0;
 
     SCMutexLock(&netmap_devlist_lock);
 
-    /* open netmap */
+    /* open netmap device */
     int fd = open("/dev/netmap", O_RDWR);
     if (fd == -1) {
         SCLogError(SC_ERR_NETMAP_CREATE,
@@ -199,19 +226,25 @@ int NetmapGetRSSCount(const char *ifname)
         goto error_open;
     }
 
-    /* query netmap info */
-    memset(&nm_req, 0, sizeof(nm_req));
-    strlcpy(nm_req.nr_name, ifname, sizeof(nm_req.nr_name));
-    nm_req.nr_version = NETMAP_API;
+    /* query netmap interface info */
+    memset(&req, 0, sizeof(req));
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.nr_version = NETMAP_API;
+    hdr.nr_reqtype = NETMAP_REQ_PORT_INFO_GET;
+    hdr.nr_body = (uintptr_t)&req;
+    strlcpy(hdr.nr_name, ifname, sizeof(hdr.nr_name));
 
-    if (ioctl(fd, NIOCGINFO, &nm_req) != 0) {
-        SCLogError(SC_ERR_NETMAP_CREATE,
-                "Couldn't query netmap for %s, error %s",
+    if (ioctl(fd, NIOCCTRL, &hdr) != 0) {
+        SCLogError(SC_ERR_NETMAP_CREATE, "Couldn't query netmap for info about %s, error %s",
                 ifname, strerror(errno));
         goto error_fd;
     };
 
-    rx_rings = nm_req.nr_rx_rings;
+    SCLogNotice("%s: RX rings: %d TX rings: %d", ifname, req.nr_rx_rings, req.nr_tx_rings);
+    /* return RX rings count if it equals TX rings count */
+    if (req.nr_rx_rings == req.nr_tx_rings) {
+        rx_rings = req.nr_rx_rings;
+    }
 
 error_fd:
     close(fd);
@@ -268,19 +301,20 @@ static int NetmapOpen(NetmapIfaceSettings *ns,
         }
     }
     NetmapDevice *pdev = NULL, *spdev = NULL;
-    pdev = SCMalloc(sizeof(*pdev));
+    pdev = SCCalloc(1, sizeof(*pdev));
     if (unlikely(pdev == NULL)) {
         SCLogError(SC_ERR_MEM_ALLOC, "Memory allocation failed");
         goto error;
     }
-    memset(pdev, 0, sizeof(*pdev));
     SC_ATOMIC_INIT(pdev->threads_run);
 
     SCMutexLock(&netmap_devlist_lock);
 
     const int direction = (read != 1);
     int ring = 0;
-    /* search interface in our already opened list */
+    /* Search for interface in our already opened list. */
+    /* We will find it when opening multiple rings on   */
+    /* the device when it exposes multiple RSS queues.  */
     TAILQ_FOREACH(spdev, &netmap_devlist, next) {
         SCLogDebug("spdev %s", spdev->ifname);
         if (direction == spdev->direction && strcmp(ns->iface, spdev->ifname) == 0) {
@@ -312,27 +346,51 @@ retry:
     snprintf(optstr, sizeof(optstr), "%s%s%s", opt_z, opt_x, direction == 0 ? opt_R : opt_T);
 
     char devname[128];
+
     if (strncmp(ns->iface, "netmap:", 7) == 0) {
         snprintf(devname, sizeof(devname), "%s}%d%s%s",
                 ns->iface, ring, strlen(optstr) ? "/" : "", optstr);
     } else if (strlen(ns->iface) > 5 && strncmp(ns->iface, "vale", 4) == 0 && isdigit(ns->iface[4])) {
         snprintf(devname, sizeof(devname), "%s", ns->iface);
+#if NETMAP_API < 14
     } else if (ns->iface[strlen(ns->iface)-1] == '*' ||
             ns->iface[strlen(ns->iface)-1] == '^') {
         SCLogDebug("device with SW-ring enabled (ns->iface): %s",ns->iface);
-        snprintf(devname, sizeof(devname), "netmap:%s", ns->iface);
+        snprintf(devname, sizeof(devname), "netmap:%s%s%s", ns->iface, strlen(optstr) ? "/" : "",
+                optstr);
         SCLogDebug("device with SW-ring enabled (devname): %s",devname);
-        /* just a single ring, so don't use ring param */
+#endif
     } else if (ring == 0 && ns->threads == 1) {
+        /* just a single thread and ring, so don't use ring param */
         snprintf(devname, sizeof(devname), "netmap:%s%s%s",
                 ns->iface, strlen(optstr) ? "/" : "", optstr);
     } else {
+#if NETMAP_API > 13
+        /* multiple rings, so tell netmap which ring, and for software */
+        /* ring, how many rings to open in the initial open call       */
+        if (ns->sw_ring && ring == 0) {
+            snprintf(devname, sizeof(devname),
+                    "netmap:%s-%d%s%s@conf:host-tx-rings=%d,host-rx-rings=%d", ns->iface, ring,
+                    strlen(optstr) ? "/" : "", optstr, ns->threads, ns->threads);
+            SCLogDebug("device with SW-ring enabled (devname): %s", devname);
+        } else {
+            snprintf(devname, sizeof(devname), "netmap:%s-%d%s%s", ns->iface, ring,
+                    strlen(optstr) ? "/" : "", optstr);
+        }
+#else
+        /* multiple rings, so tell netmap which ring */
         snprintf(devname, sizeof(devname), "netmap:%s-%d%s%s",
                 ns->iface, ring, strlen(optstr) ? "/" : "", optstr);
+#endif
     }
     strlcpy(pdev->ifname, ns->iface, sizeof(pdev->ifname));
 
+#if NETMAP_API > 13
+    pdev->nmd = nmport_open(devname);
+#else
     pdev->nmd = nm_open(devname, NULL, 0, NULL);
+#endif
+
     if (pdev->nmd == NULL) {
         if (errno == EINVAL && opt_z[0] == 'z') {
             SCLogNotice("got '%s' EINVAL: going to retry without 'z'", devname);
@@ -348,13 +406,18 @@ retry:
                 devname, strerror(errno));
         exit(EXIT_FAILURE);
     }
+
+    /* Work around bug in libnetmap library where "cur_{r,t}x_ring" values not initialized */
+    pdev->nmd->cur_rx_ring = pdev->nmd->first_rx_ring;
+    pdev->nmd->cur_tx_ring = pdev->nmd->first_tx_ring;
+
     SCLogDebug("devname %s %s opened", devname, ns->iface);
 
     pdev->direction = direction;
     pdev->ring = ring;
     TAILQ_INSERT_TAIL(&netmap_devlist, pdev, next);
 
-    SCLogNotice("opened %s from %s: %p", devname, ns->iface, pdev->nmd);
+    SCLogNotice("opened %s from %s: fd: %d [nmd %p]", devname, ns->iface, pdev->nmd->fd, pdev->nmd);
     SCMutexUnlock(&netmap_devlist_lock);
     *pdevice = pdev;
 
@@ -378,7 +441,11 @@ static int NetmapClose(NetmapDevice *dev)
         if (pdev == dev) {
             pdev->ref--;
             if (!pdev->ref) {
+#if NETMAP_API > 13
+                nmport_close(pdev->nmd);
+#else
                 nm_close(pdev->nmd);
+#endif
                 SCFree(pdev);
             }
             SCMutexUnlock(&netmap_devlist_lock);
@@ -420,12 +487,11 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, const void *initdata, voi
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    NetmapThreadVars *ntv = SCMalloc(sizeof(*ntv));
+    NetmapThreadVars *ntv = SCCalloc(1, sizeof(*ntv));
     if (unlikely(ntv == NULL)) {
         SCLogError(SC_ERR_MEM_ALLOC, "Memory allocation failed");
         goto error;
     }
-    memset(ntv, 0, sizeof(*ntv));
 
     ntv->tv = tv;
     ntv->checksum_mode = aconf->in.checksum_mode;
@@ -449,13 +515,15 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, const void *initdata, voi
         goto error_ntv;
     }
 
+#if NETMAP_API < 14
     if (unlikely(aconf->in.sw_ring && aconf->in.threads > 1)) {
         SCLogError(SC_ERR_INVALID_VALUE,
-                   "Interface '%s+'. "
-                   "Thread count can't be greater than 1 for SW ring.",
-                   aconf->iface_name);
+                "Interface '%s^'. "
+                "Thread count can't be greater than 1 for SW ring.",
+                aconf->iface_name);
         goto error_src;
     }
+#endif
 
     if (aconf->in.copy_mode != NETMAP_COPY_MODE_NONE) {
         SCLogDebug("IPS: opening out iface %s", aconf->out.iface);
@@ -491,6 +559,8 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, const void *initdata, voi
         }
     }
 
+    SCLogNotice("thread: %s polling on fd: %d", tv->name, ntv->ifsrc->nmd->fd);
+
     *data = (void *)ntv;
     aconf->DerefFunc(aconf);
     SCReturnInt(TM_ECODE_OK);
@@ -521,13 +591,19 @@ static TmEcode NetmapWritePacket(NetmapThreadVars *ntv, Packet *p)
     }
     DEBUG_VALIDATE_BUG_ON(ntv->ifdst == NULL);
 
+    /* attempt to write the packet into the netmap ring buffer(s) */
+#if NETMAP_API > 13
+    if (nmport_inject(ntv->ifdst->nmd, GET_PKT_DATA(p), GET_PKT_LEN(p)) == 0) {
+#else
     if (nm_inject(ntv->ifdst->nmd, GET_PKT_DATA(p), GET_PKT_LEN(p)) == 0) {
+#endif
         SCLogDebug("failed to send %s -> %s",
                 ntv->ifsrc->ifname, ntv->ifdst->ifname);
         ntv->drops++;
+        return TM_ECODE_FAILED;
     }
-    SCLogDebug("sent succesfully: %s(%d)->%s(%d) (%u)",
-		    ntv->ifsrc->ifname, ntv->ifsrc->ring,
+
+    SCLogDebug("sent succesfully: %s(%d)->%s(%d) (%u)", ntv->ifsrc->ifname, ntv->ifsrc->ring,
             ntv->ifdst->ifname, ntv->ifdst->ring, GET_PKT_LEN(p));
 
     ioctl(ntv->ifdst->nmd->fd, NIOCTXSYNC, 0);
@@ -587,10 +663,92 @@ static void NetmapCallback(u_char *user, const struct nm_pkthdr *ph, const u_cha
     p->ReleasePacket = NetmapReleasePacket;
     p->netmap_v.ntv = ntv;
 
+    SCLogInfo("Processing rx'd packet: %p [%u]", GET_PKT_DATA(p), GET_PKT_LEN(p));
     SCLogDebug("pktlen: %" PRIu32 " (pkt %p, pkt data %p)",
             GET_PKT_LEN(p), p, GET_PKT_DATA(p));
 
     (void)TmThreadsSlotProcessPkt(ntv->tv, ntv->slot, p);
+}
+
+/**
+ * \brief Copy netmap rings data into Packet structures.
+ * \param *d nmport_d (or nm_desc) netmap if structure.
+ * \param cnt int count of packets to read (-1 = all).
+ * \param *ntv NetmapThreadVars.
+ */
+#if NETMAP_API > 13
+static TmEcode NetmapReadPackets(struct nmport_d *d, int cnt, NetmapThreadVars *ntv)
+#else
+static TmEcode NetmapReadPackets(struct nm_desc *d, int cnt, NetmapThreadVars *ntv)
+#endif
+{
+    struct nm_pkthdr hdr;
+    int n = d->last_rx_ring - d->first_rx_ring + 1;
+    int c, got = 0, ri = d->cur_rx_ring;
+
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.flags = NM_MORE_PKTS;
+
+    if (cnt == 0)
+        cnt = -1;
+
+    for (c = 0; c < n && cnt != got; c++, ri++) {
+        struct netmap_ring *ring;
+
+        if (ri > d->last_rx_ring)
+            ri = d->first_rx_ring;
+
+        ring = NETMAP_RXRING(d->nifp, ri);
+
+        /* cycle through the non-empty ring slots to fetch their data */
+        for (; !nm_ring_empty(ring) && cnt != got; got++) {
+            u_int idx, i;
+            u_char *oldbuf;
+            struct netmap_slot *slot;
+
+            if (hdr.buf) { /* from previous round */
+                NetmapCallback((u_char *)ntv, &hdr, hdr.buf);
+            }
+
+            i = ring->cur;
+            slot = &ring->slot[i];
+            idx = slot->buf_idx;
+            d->cur_rx_ring = ri;
+            hdr.slot = slot;
+            oldbuf = hdr.buf = (u_char *)NETMAP_BUF(ring, idx);
+            hdr.len = hdr.caplen = slot->len;
+
+            /* loop through the ring slots to get packet data */
+            while (slot->flags & NS_MOREFRAG) {
+                /* packet can be fragmented across multiple slots, */
+                /* so loop until we find the slot with the flag    */
+                /* cleared, signalling the end of the packet data. */
+                u_char *nbuf;
+                u_int oldlen = slot->len;
+                i = nm_ring_next(ring, i);
+                slot = &ring->slot[i];
+                hdr.len += slot->len;
+                nbuf = (u_char *)NETMAP_BUF(ring, slot->buf_idx);
+
+                if (oldbuf != NULL && nbuf - oldbuf == ring->nr_buf_size &&
+                        oldlen == ring->nr_buf_size) {
+                    hdr.caplen += slot->len;
+                    oldbuf = nbuf;
+                } else {
+                    oldbuf = NULL;
+                }
+            }
+
+            hdr.ts = ring->ts;
+            ring->head = ring->cur = nm_ring_next(ring, i);
+        }
+    }
+
+    if (hdr.buf) { /* from previous round */
+        hdr.flags = 0;
+        NetmapCallback((u_char *)ntv, &hdr, hdr.buf);
+    }
+    return got;
 }
 
 /**
@@ -622,15 +780,12 @@ static TmEcode ReceiveNetmapLoop(ThreadVars *tv, void *data, void *slot)
             /* error */
             if (errno != EINTR)
                 SCLogError(SC_ERR_NETMAP_READ,
-                           "Error polling netmap from iface '%s': (%d" PRIu32 ") %s",
-                           ntv->ifsrc->ifname, errno, strerror(errno));
+                        "Error polling netmap from iface '%s': (%d" PRIu32 ") %s",
+                        ntv->ifsrc->ifname, errno, strerror(errno));
             continue;
 
         } else if (r == 0) {
             /* no events, timeout */
-            //SCLogDebug("(%s:%d-%d) Poll timeout", ntv->ifsrc->ifname,
-            //           ntv->src_ring_from, ntv->src_ring_to);
-
             /* sync counters */
             NetmapDumpCounters(ntv);
             StatsSyncCountersIfSignalled(tv);
@@ -642,18 +797,18 @@ static TmEcode ReceiveNetmapLoop(ThreadVars *tv, void *data, void *slot)
 
         if (unlikely(fds.revents & POLL_EVENTS)) {
             if (fds.revents & POLLERR) {
-                //SCLogError(SC_ERR_NETMAP_READ,
-                //        "Error reading data from iface '%s': (%d" PRIu32 ") %s",
-                //        ntv->ifsrc->ifname, errno, strerror(errno));
-            } else if (fds.revents & POLLNVAL) {
                 SCLogError(SC_ERR_NETMAP_READ,
-                        "Invalid polling request");
+                        "Error reading netmap data via polling from iface '%s': (%d" PRIu32 ") %s",
+                        ntv->ifsrc->ifname, errno, strerror(errno));
+            } else if (fds.revents & POLLNVAL) {
+                SCLogError(SC_ERR_NETMAP_READ, "Invalid polling request");
             }
             continue;
         }
 
         if (likely(fds.revents & POLLIN)) {
-            nm_dispatch(ntv->ifsrc->nmd, -1, NetmapCallback, (void *)ntv);
+            /* have data, so copy to Packet vars for processing */
+            NetmapReadPackets(ntv->ifsrc->nmd, -1, ntv);
         }
 
         NetmapDumpCounters(ntv);
@@ -713,7 +868,7 @@ static TmEcode ReceiveNetmapThreadDeinit(ThreadVars *tv, void *data)
 
 /**
  * \brief Prepare netmap decode thread.
- * \param tv Thread local avariables.
+ * \param tv Thread local variables.
  * \param initdata Thread config.
  * \param data Pointer to DecodeThreadVars placed here.
  */

--- a/src/threadvars.h
+++ b/src/threadvars.h
@@ -50,7 +50,7 @@ struct TmSlot_;
 #define THV_FLOW_LOOP           BIT_U32(10) /**< thread is in flow shutdown loop */
 
 /** signal thread's capture method to create a fake packet to force through
- *  the engine. This is to force timely handling of maintenance taks like
+ *  the engine. This is to force timely handling of maintenance tasks like
  *  rule reloads even if no packets are read by the capture method. */
 #define THV_CAPTURE_INJECT_PKT  BIT_U32(11)
 #define THV_DEAD                BIT_U32(12) /**< thread has been joined with pthread_join() */
@@ -80,7 +80,7 @@ typedef struct ThreadVars_ {
     uint8_t tmm_flags;
 
     uint8_t cap_flags; /**< Flags to indicate the capabilities of all the
-                            TmModules resgitered under this thread */
+                            TmModules registered under this thread */
     uint8_t inq_id;
     uint8_t outq_id;
 


### PR DESCRIPTION
This commit extends the groundwork performed by @bmeeks8 towards support of Netmap V14+ and its multi-ring/queue enhancements. @bmeeks8 contributed initial changes to handle Netmap v14 differences.

UPDATE: Does not yet support host mode, e.g, `eth1^`

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- configure changes to detect v14
- Runtime changes to spawn a thread for each ring

These changes have only been used on Linux with the most recent content from  https://github.com/luigirizzo/netmap

These changes are draft quality and should not be used in production environments.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
