### PR TITLE
Bug 4577: fix minor warnings wrt ConfGetBool unchecked calls - v1

### DIFF
--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -137,7 +137,7 @@ uint64_t StreamTcpReassembleMemuseGlobalCounter(void)
 
 /**
  * \brief  Function to Check the reassembly memory usage counter against the
- *         allowed max memory usgae for TCP segments.
+ *         allowed max memory usage for TCP segments.
  *
  * \param  size Size of the TCP segment and its payload length memory allocated
  * \retval 1 if in bounds
@@ -456,7 +456,7 @@ TcpReassemblyThreadCtx *StreamTcpReassembleInitThreadCtx(ThreadVars *tv)
                 PoolThreadSize(segment_thread_pool),
                 ra_ctx->segment_thread_pool_id);
     } else {
-        /* grow segment_thread_pool until we have a element for our thread id */
+        /* grow segment_thread_pool until we have an element for our thread id */
         ra_ctx->segment_thread_pool_id = PoolThreadExpand(segment_thread_pool);
         SCLogDebug("pool size %d, thread segment_thread_pool_id %d",
                 PoolThreadSize(segment_thread_pool),

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -378,7 +378,7 @@ static int StreamTcpReassemblyConfig(bool quiet)
     stream_config.prealloc_segments = segment_prealloc;
 
     int overlap_diff_data = 0;
-    ConfGetBool("stream.reassembly.check-overlap-different-data", &overlap_diff_data);
+    (void)ConfGetBool("stream.reassembly.check-overlap-different-data", &overlap_diff_data);
     if (overlap_diff_data) {
         StreamTcpReassembleConfigEnableOverlapCheck();
     }

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2016 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -555,7 +555,7 @@ void StreamTcpInitConfig(bool quiet)
     int randomize = 0;
     if ((ConfGetBool("stream.reassembly.randomize-chunk-size", &randomize)) == 0) {
         /* randomize by default if value not set
-         * In ut mode we disable, to get predictible test results */
+         * In ut mode we disable, to get predictable test results */
         if (!(RunmodeIsUnittests()))
             randomize = 1;
     }
@@ -898,7 +898,7 @@ static int StreamTcpPacketIsRetransmission(TcpStream *stream, Packet *p)
  *          packets while the session state is None which means a newly
  *          initialized structure, or a fully closed session.
  *
- *  \param  tv      Thread Variable containig  input/output queue, cpu affinity
+ *  \param  tv      Thread Variable containing  input/output queue, cpu affinity
  *  \param  p       Packet which has to be handled in this TCP state.
  *  \param  stt     Strean Thread module registered to handle the stream handling
  *
@@ -1408,7 +1408,7 @@ static inline bool StateSynSentValidateTimestamp(TcpSession *ssn, Packet *p)
  *          SYN, SYN/ACK, RST packets and correspondingly changes the connection
  *          state.
  *
- *  \param  tv      Thread Variable containig  input/output queue, cpu affinity
+ *  \param  tv      Thread Variable containing  input/output queue, cpu affinity
  *  \param  p       Packet which has to be handled in this TCP state.
  *  \param  stt     Strean Thread module registered to handle the stream handling
  */
@@ -1649,8 +1649,8 @@ static int StreamTcpPacketStateSynSent(ThreadVars *tv, Packet *p,
 
     } else if (p->tcph->th_flags & TH_ACK) {
         /* Handle the asynchronous stream, when we receive a  SYN packet
-           and now istead of receving a SYN/ACK we receive a ACK from the
-           same host, which sent the SYN, this suggests the ASNYC streams.*/
+           and now instead of receiving a SYN/ACK we receive a ACK from the
+           same host, which sent the SYN, this suggests the ASYNC streams.*/
         if (stream_config.async_oneside == FALSE)
             return 0;
 
@@ -1726,7 +1726,7 @@ static int StreamTcpPacketStateSynSent(ThreadVars *tv, Packet *p,
  *          SYN, SYN/ACK, ACK, FIN, RST packets and correspondingly changes
  *          the connection state.
  *
- *  \param  tv      Thread Variable containig  input/output queue, cpu affinity
+ *  \param  tv      Thread Variable containing  input/output queue, cpu affinity
  *  \param  p       Packet which has to be handled in this TCP state.
  *  \param  stt     Strean Thread module registered to handle the stream handling
  *
@@ -2156,7 +2156,7 @@ static int StreamTcpPacketStateSynRecv(ThreadVars *tv, Packet *p,
  *
  *  Timestamp has already been checked at this point.
  *
- *  \param  tv      Thread Variable containig  input/output queue, cpu affinity etc.
+ *  \param  tv      Thread Variable containing  input/output queue, cpu affinity etc.
  *  \param  ssn     Pointer to the current TCP session
  *  \param  p       Packet which has to be handled in this TCP state.
  *  \param  stt     Strean Thread module registered to handle the stream handling
@@ -2343,7 +2343,7 @@ static int HandleEstablishedPacketToServer(ThreadVars *tv, TcpSession *ssn, Pack
  *
  *  Timestamp has already been checked at this point.
  *
- *  \param  tv      Thread Variable containig  input/output queue, cpu affinity etc.
+ *  \param  tv      Thread Variable containing  input/output queue, cpu affinity etc.
  *  \param  ssn     Pointer to the current TCP session
  *  \param  p       Packet which has to be handled in this TCP state.
  *  \param  stt     Strean Thread module registered to handle the stream handling
@@ -2576,7 +2576,7 @@ static bool StreamTcpPacketIsOutdatedAck(TcpSession *ssn, Packet *p)
  *          state. The function handles the data inside packets and call
  *          StreamTcpReassembleHandleSegment(tv, ) to handle the reassembling.
  *
- *  \param  tv      Thread Variable containig  input/output queue, cpu affinity etc.
+ *  \param  tv      Thread Variable containing  input/output queue, cpu affinity etc.
  *  \param  p       Packet which has to be handled in this TCP state.
  *  \param  stt     Strean Thread module registered to handle the stream handling
  */
@@ -2780,7 +2780,7 @@ static int StreamTcpPacketStateEstablished(ThreadVars *tv, Packet *p,
  *  \brief  Function to handle the FIN packets for states TCP_SYN_RECV and
  *          TCP_ESTABLISHED and changes to another TCP state as required.
  *
- *  \param  tv      Thread Variable containig  input/output queue, cpu affinity
+ *  \param  tv      Thread Variable containing  input/output queue, cpu affinity
  *  \param  p       Packet which has to be handled in this TCP state.
  *  \param  stt     Strean Thread module registered to handle the stream handling
  *
@@ -2897,7 +2897,7 @@ static int StreamTcpHandleFin(ThreadVars *tv, StreamTcpThread *stt,
  *          ACK, FIN, RST packets and correspondingly changes the connection
  *          state.
  *
- *  \param  tv      Thread Variable containig  input/output queue, cpu affinity
+ *  \param  tv      Thread Variable containing  input/output queue, cpu affinity
  *  \param  p       Packet which has to be handled in this TCP state.
  *  \param  stt     Strean Thread module registered to handle the stream handling
  *
@@ -3342,7 +3342,7 @@ static int StreamTcpPacketStateFinWait1(ThreadVars *tv, Packet *p,
  *          ACK, RST, FIN packets and correspondingly changes the connection
  *          state.
  *
- *  \param  tv      Thread Variable containig  input/output queue, cpu affinity
+ *  \param  tv      Thread Variable containing  input/output queue, cpu affinity
  *  \param  p       Packet which has to be handled in this TCP state.
  *  \param  stt     Strean Thread module registered to handle the stream handling
  */
@@ -3645,7 +3645,7 @@ static int StreamTcpPacketStateFinWait2(ThreadVars *tv, Packet *p,
  *          the connection goes to TCP_TIME_WAIT state. The state has been
  *          reached as both end application has been closed.
  *
- *  \param  tv      Thread Variable containig  input/output queue, cpu affinity
+ *  \param  tv      Thread Variable containing  input/output queue, cpu affinity
  *  \param  p       Packet which has to be handled in this TCP state.
  *  \param  stt     Strean Thread module registered to handle the stream handling
  */
@@ -3809,7 +3809,7 @@ static int StreamTcpPacketStateClosing(ThreadVars *tv, Packet *p,
  *          packet from server the connection goes to TCP_LAST_ACK state.
  *          The state is possible only for server host.
  *
- *  \param  tv      Thread Variable containig  input/output queue, cpu affinity
+ *  \param  tv      Thread Variable containing  input/output queue, cpu affinity
  *  \param  p       Packet which has to be handled in this TCP state.
  *  \param  stt     Strean Thread module registered to handle the stream handling
  */
@@ -4112,7 +4112,7 @@ static int StreamTcpPacketStateCloseWait(ThreadVars *tv, Packet *p,
  *          the connection goes to TCP_CLOSED state and stream memory is
  *          returned back to pool. The state is possible only for server host.
  *
- *  \param  tv      Thread Variable containig  input/output queue, cpu affinity
+ *  \param  tv      Thread Variable containing  input/output queue, cpu affinity
  *  \param  p       Packet which has to be handled in this TCP state.
  *  \param  stt     Strean Thread module registered to handle the stream handling
  */
@@ -4237,7 +4237,7 @@ static int StreamTcpPacketStateLastAck(ThreadVars *tv, Packet *p,
  *          the connection goes to TCP_CLOSED state and stream memory is
  *          returned back to pool.
  *
- *  \param  tv      Thread Variable containig  input/output queue, cpu affinity
+ *  \param  tv      Thread Variable containing  input/output queue, cpu affinity
  *  \param  p       Packet which has to be handled in this TCP state.
  *  \param  stt     Strean Thread module registered to handle the stream handling
  */
@@ -5633,7 +5633,7 @@ static int StreamTcpValidateTimestamp (TcpSession *ssn, Packet *p)
         }
 
         if (receiver_stream->os_policy == OS_POLICY_HPUX11) {
-            /* HPUX11 igoners the timestamp of out of order packets */
+            /* HPUX11 ignores the timestamp of out of order packets */
             if (!SEQ_EQ(sender_stream->next_seq, TCP_GET_SEQ(p)))
                 check_ts = 0;
         }
@@ -5648,7 +5648,7 @@ static int StreamTcpValidateTimestamp (TcpSession *ssn, Packet *p)
                     /* Old Linux and windows allowed packet with 0 timestamp. */
                     break;
                 default:
-                    /* other OS simply drop the pakcet with 0 timestamp, when
+                    /* other OS simply drop the packet with 0 timestamp, when
                      * 3whs has valid timestamp*/
                     goto invalid;
             }
@@ -5777,7 +5777,7 @@ static int StreamTcpHandleTimestamp (TcpSession *ssn, Packet *p)
         }
 
         if (receiver_stream->os_policy == OS_POLICY_HPUX11) {
-            /*HPUX11 igoners the timestamp of out of order packets*/
+            /*HPUX11 ignores the timestamp of out of order packets*/
             if (!SEQ_EQ(sender_stream->next_seq, TCP_GET_SEQ(p)))
                 check_ts = 0;
         }
@@ -5792,7 +5792,7 @@ static int StreamTcpHandleTimestamp (TcpSession *ssn, Packet *p)
                     /* Old Linux and windows allowed packet with 0 timestamp. */
                     break;
                 default:
-                    /* other OS simply drop the pakcet with 0 timestamp, when
+                    /* other OS simply drop the packet with 0 timestamp, when
                      * 3whs has valid timestamp*/
                     goto invalid;
             }
@@ -6059,7 +6059,7 @@ Packet *StreamTcpPseudoSetup(Packet *parent, uint8_t *pkt, uint32_t len)
     else
         p->root = parent;
 
-    /* copy packet and set lenght, proto */
+    /* copy packet and set length, proto */
     p->proto = parent->proto;
     p->datalink = parent->datalink;
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -419,14 +419,14 @@ void StreamTcpInitConfig(bool quiet)
     }
 
     int imidstream;
-    ConfGetBool("stream.midstream", &imidstream);
+    (void)ConfGetBool("stream.midstream", &imidstream);
     stream_config.midstream = imidstream != 0;
 
     if (!quiet) {
         SCLogConfig("stream \"midstream\" session pickups: %s", stream_config.midstream ? "enabled" : "disabled");
     }
 
-    ConfGetBool("stream.async-oneside", &stream_config.async_oneside);
+    (void)ConfGetBool("stream.async-oneside", &stream_config.async_oneside);
 
     if (!quiet) {
         SCLogConfig("stream \"async-oneside\": %s", stream_config.async_oneside ? "enabled" : "disabled");

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -537,17 +537,17 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
 /** \brief Fatal error IF we're starting up, and configured to consider
  *         errors to be fatal errors */
 #if !defined(__clang_analyzer__)
-#define FatalErrorOnInit(x, ...) do {                                       \
-    SC_ATOMIC_EXTERN(unsigned int, engine_stage);                           \
-    int init_errors_fatal = 0;                                              \
-    ConfGetBool("engine.init-failure-fatal", &init_errors_fatal);           \
-    if (init_errors_fatal && (SC_ATOMIC_GET(engine_stage) == SURICATA_INIT))\
-    {                                                                       \
-        SCLogError(x, __VA_ARGS__);                                         \
-        exit(EXIT_FAILURE);                                                 \
-    }                                                                       \
-    SCLogWarning(x, __VA_ARGS__);                                           \
-} while(0)
+#define FatalErrorOnInit(x, ...)                                                                   \
+    do {                                                                                           \
+        SC_ATOMIC_EXTERN(unsigned int, engine_stage);                                              \
+        int init_errors_fatal = 0;                                                                 \
+        (void)ConfGetBool("engine.init-failure-fatal", &init_errors_fatal);                        \
+        if (init_errors_fatal && (SC_ATOMIC_GET(engine_stage) == SURICATA_INIT)) {                 \
+            SCLogError(x, __VA_ARGS__);                                                            \
+            exit(EXIT_FAILURE);                                                                    \
+        }                                                                                          \
+        SCLogWarning(x, __VA_ARGS__);                                                              \
+    } while (0)
 /* make it simpler for scan-build */
 #else
 #define FatalErrorOnInit(x, ...) FatalError(x, __VA_ARGS__)

--- a/src/util-napatech.c
+++ b/src/util-napatech.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -467,10 +467,10 @@ static uint32_t UpdateStreamStats(ThreadVars *tv,
 /**
  * \brief Statistics processing loop
  *
- * Instantiated on the stats thread.  Periodically retrieives
+ * Instantiated on the stats thread. Periodically retrieves
  * statistics from the Napatech card and updates the packet counters
  *
- * \param arg Pointer that is caste into a TheardVars structure
+ * \param arg Pointer that is cast into a TheardVars structure
  */
 static void *NapatechStatsLoop(void *arg)
 {

--- a/src/util-napatech.c
+++ b/src/util-napatech.c
@@ -878,7 +878,7 @@ int NapatechGetStreamConfig(NapatechStreamConfig stream_config[])
         }
 
     } else {
-        ConfGetBool("threading.set-cpu-affinity", &set_cpu_affinity);
+        (void)ConfGetBool("threading.set-cpu-affinity", &set_cpu_affinity);
         if (NapatechIsAutoConfigEnabled() && (set_cpu_affinity == 1)) {
             start = 0;
             end = CountWorkerThreads() - 1;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4577?issue_count=10&issue_position=1&next_issue_id=4566

Describe changes. For the 4 files:
- Cast unchecked calls to `void` as that seemed like a valid alternative for the cases left unchecked
- fix typos
- update copyright years
- fix formatting (clang)