### PR TITLE
fix: closing bracket was at wrong place

### DIFF
--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -174,9 +174,9 @@ static int TmThreadTimeoutLoop(ThreadVars *tv, TmSlot *s)
                 Packet *p = PacketDequeue(tv->stream_pq);
                 SCMutexUnlock(&tv->stream_pq->mutex_q);
                 if (likely(p)) {
-                    if ((r = TmThreadsSlotProcessPkt(tv, fw_slot, p) != TM_ECODE_OK)) {
-                        if (r == TM_ECODE_FAILED)
-                            break;
+                    r = TmThreadsSlotProcessPkt(tv, fw_slot, p);
+                    if (r == TM_ECODE_FAILED) {
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
This bug was found by svace static code analyzer

warn: OP_PRECEDENCE_ASSIGN_CMP
msg: Logic operator precedence in assignment can produce an unexpected result