### PR TITLE
rust: remove transmute; make fn's unsafe - v8

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -238,7 +238,7 @@ pub struct RustParser {
 /// UNSAFE !
 #[macro_export]
 macro_rules! build_slice {
-    ($buf:ident, $len:expr) => ( unsafe{ std::slice::from_raw_parts($buf, $len) } );
+    ($buf:ident, $len:expr) => ( std::slice::from_raw_parts($buf, $len) );
 }
 
 /// Cast pointer to a variable, as a mutable reference to an object
@@ -246,32 +246,33 @@ macro_rules! build_slice {
 /// UNSAFE !
 #[macro_export]
 macro_rules! cast_pointer {
-    ($ptr:ident, $ty:ty) => ( unsafe{ &mut *($ptr as *mut $ty) } );
+    ($ptr:ident, $ty:ty) => ( &mut *($ptr as *mut $ty) );
 }
 
-pub type ParseFn      = extern "C" fn (flow: *const Flow,
+pub type ParseFn      = unsafe extern "C" fn (flow: *const Flow,
                                        state: *mut c_void,
                                        pstate: *mut c_void,
                                        input: *const u8,
                                        input_len: u32,
                                        data: *const c_void,
                                        flags: u8) -> AppLayerResult;
-pub type ProbeFn      = extern "C" fn (flow: *const Flow, flags: u8, input:*const u8, input_len: u32, rdir: *mut u8) -> AppProto;
+pub type ProbeFn      = unsafe extern "C" fn (flow: *const Flow, flags: u8, input:*const u8, input_len: u32, rdir: *mut u8) -> AppProto;
 pub type StateAllocFn = extern "C" fn (*mut c_void, AppProto) -> *mut c_void;
-pub type StateFreeFn  = extern "C" fn (*mut c_void);
-pub type StateTxFreeFn  = extern "C" fn (*mut c_void, u64);
-pub type StateGetTxFn            = extern "C" fn (*mut c_void, u64) -> *mut c_void;
-pub type StateGetTxCntFn         = extern "C" fn (*mut c_void) -> u64;
-pub type StateGetProgressFn = extern "C" fn (*mut c_void, u8) -> c_int;
-pub type GetDetectStateFn   = extern "C" fn (*mut c_void) -> *mut DetectEngineState;
-pub type SetDetectStateFn   = extern "C" fn (*mut c_void, &mut DetectEngineState) -> c_int;
-pub type GetEventInfoFn     = extern "C" fn (*const c_char, *mut c_int, *mut AppLayerEventType) -> c_int;
-pub type GetEventInfoByIdFn = extern "C" fn (c_int, *mut *const c_char, *mut AppLayerEventType) -> i8;
-pub type GetEventsFn        = extern "C" fn (*mut c_void) -> *mut AppLayerDecoderEvents;
+pub type StateFreeFn  = unsafe extern "C" fn (*mut c_void);
+pub type StateTxFreeFn  = unsafe extern "C" fn (*mut c_void, u64);
+pub type StateGetTxFn            = unsafe extern "C" fn (*mut c_void, u64) -> *mut c_void;
+pub type StateGetTxCntFn         = unsafe extern "C" fn (*mut c_void) -> u64;
+pub type StateGetProgressFn = unsafe extern "C" fn (*mut c_void, u8) -> c_int;
+pub type GetDetectStateFn   = unsafe extern "C" fn (*mut c_void) -> *mut DetectEngineState;
+pub type SetDetectStateFn   = unsafe extern "C" fn (*mut c_void, &mut DetectEngineState) -> c_int;
+pub type GetEventInfoFn     = unsafe extern "C" fn (*const c_char, *mut c_int, *mut AppLayerEventType) -> c_int;
+pub type GetEventInfoByIdFn = unsafe extern "C" fn (c_int, *mut *const c_char, *mut AppLayerEventType) -> i8;
+pub type GetEventsFn        = unsafe extern "C" fn (*mut c_void) -> *mut AppLayerDecoderEvents;
 pub type LocalStorageNewFn  = extern "C" fn () -> *mut c_void;
 pub type LocalStorageFreeFn = extern "C" fn (*mut c_void);
-pub type GetFilesFn         = extern "C" fn (*mut c_void, u8) -> *mut FileContainer;
-pub type GetTxIteratorFn    = extern "C" fn (ipproto: u8, alproto: AppProto,
+pub type GetFilesFn         = unsafe 
+extern "C" fn (*mut c_void, u8) -> *mut FileContainer;
+pub type GetTxIteratorFn    = unsafe extern "C" fn (ipproto: u8, alproto: AppProto,
                                              state: *mut c_void,
                                              min_tx_id: u64,
                                              max_tx_id: u64,
@@ -320,7 +321,7 @@ pub const APP_LAYER_PARSER_BYPASS_READY : u8 = BIT_U8!(4);
 pub const APP_LAYER_PARSER_OPT_ACCEPT_GAPS: u32 = BIT_U32!(0);
 pub const APP_LAYER_PARSER_OPT_UNIDIR_TXS: u32 = BIT_U32!(1);
 
-pub type AppLayerGetTxIteratorFn = extern "C" fn (ipproto: u8,
+pub type AppLayerGetTxIteratorFn = unsafe extern "C" fn (ipproto: u8,
                                                   alproto: AppProto,
                                                   alstate: *mut c_void,
                                                   min_tx_id: u64,
@@ -384,7 +385,7 @@ impl LoggerFlags {
 macro_rules!export_tx_get_detect_state {
     ($name:ident, $type:ty) => (
         #[no_mangle]
-        pub extern "C" fn $name(tx: *mut std::os::raw::c_void)
+        pub unsafe extern "C" fn $name(tx: *mut std::os::raw::c_void)
             -> *mut core::DetectEngineState
         {
             let tx = cast_pointer!(tx, $type);
@@ -405,7 +406,7 @@ macro_rules!export_tx_get_detect_state {
 macro_rules!export_tx_set_detect_state {
     ($name:ident, $type:ty) => (
         #[no_mangle]
-        pub extern "C" fn $name(tx: *mut std::os::raw::c_void,
+        pub unsafe extern "C" fn $name(tx: *mut std::os::raw::c_void,
                 de_state: &mut core::DetectEngineState) -> std::os::raw::c_int
         {
             let tx = cast_pointer!(tx, $type);

--- a/rust/src/applayertemplate/logger.rs
+++ b/rust/src/applayertemplate/logger.rs
@@ -30,7 +30,7 @@ fn log_template(tx: &TemplateTransaction, js: &mut JsonBuilder) -> Result<(), Js
 }
 
 #[no_mangle]
-pub extern "C" fn rs_template_logger_log(tx: *mut std::os::raw::c_void, js: &mut JsonBuilder) -> bool {
+pub unsafe extern "C" fn rs_template_logger_log(tx: *mut std::os::raw::c_void, js: &mut JsonBuilder) -> bool {
     let tx = cast_pointer!(tx, TemplateTransaction);
     log_template(tx, js).is_ok()
 }

--- a/rust/src/asn1/mod.rs
+++ b/rust/src/asn1/mod.rs
@@ -211,7 +211,7 @@ fn asn1_decode<'a>(
 /// input must be a valid buffer of at least input_len bytes
 /// pointer must be freed using `rs_asn1_free`
 #[no_mangle]
-pub extern "C" fn rs_asn1_decode(
+pub unsafe extern "C" fn rs_asn1_decode(
     input: *const u8, input_len: u16, buffer_offset: u32, ad_ptr: *const DetectAsn1Data,
 ) -> *mut Asn1<'static> {
     if input.is_null() || input_len == 0 || ad_ptr.is_null() {
@@ -220,7 +220,7 @@ pub extern "C" fn rs_asn1_decode(
 
     let slice = build_slice!(input, input_len as usize);
 
-    let ad = unsafe { &*ad_ptr };
+    let ad = &*ad_ptr ;
 
     let res = asn1_decode(slice, buffer_offset, ad);
 

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -15,7 +15,6 @@
  * 02110-1301, USA.
  */
 
-use std::mem::transmute;
 use crate::applayer::*;
 use crate::core::{self, *};
 use crate::dcerpc::parser;
@@ -1193,12 +1192,12 @@ pub extern "C" fn rs_dcerpc_parse_response(
 pub extern "C" fn rs_dcerpc_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: core::AppProto) -> *mut std::os::raw::c_void {
     let state = DCERPCState::new();
     let boxed = Box::new(state);
-    return unsafe { transmute(boxed)};
+    return Box::into_raw(boxed) as *mut _;
 }
 
 #[no_mangle]
 pub extern "C" fn rs_dcerpc_state_free(state: *mut std::os::raw::c_void) {
-    let _state: Box<DCERPCState> = unsafe { transmute(state) };
+    std::mem::drop(unsafe { Box::from_raw(state as *mut DCERPCState)} );
 }
 
 #[no_mangle]
@@ -1258,7 +1257,7 @@ pub extern "C" fn rs_dcerpc_get_tx(
 ) -> *mut std::os::raw::c_void {
     let dce_state = cast_pointer!(vtx, DCERPCState);
     match dce_state.get_tx(tx_id) {
-        Some(tx) => unsafe { transmute(tx) },
+        Some(tx) => tx as *const _ as *mut _,
         None => std::ptr::null_mut(),
     }
 }

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -15,8 +15,6 @@
  * 02110-1301, USA.
  */
 
-use std::mem::transmute;
-
 use crate::applayer::*;
 use crate::core;
 use crate::dcerpc::dcerpc::{
@@ -221,14 +219,14 @@ pub extern "C" fn rs_dcerpc_udp_parse(
 
 #[no_mangle]
 pub extern "C" fn rs_dcerpc_udp_state_free(state: *mut std::os::raw::c_void) {
-    let _drop: Box<DCERPCUDPState> = unsafe { transmute(state) };
+    std::mem::drop(unsafe { Box::from_raw(state as *mut DCERPCUDPState) });
 }
 
 #[no_mangle]
 pub extern "C" fn rs_dcerpc_udp_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: core::AppProto) -> *mut std::os::raw::c_void {
     let state = DCERPCUDPState::new();
     let boxed = Box::new(state);
-    return unsafe { transmute(boxed) };
+    return Box::into_raw(boxed) as *mut _;
 }
 
 #[no_mangle]
@@ -276,7 +274,7 @@ pub extern "C" fn rs_dcerpc_udp_get_tx(
     let dce_state = cast_pointer!(state, DCERPCUDPState);
     match dce_state.get_tx(tx_id) {
         Some(tx) => {
-            return unsafe{ transmute(tx) };
+            return tx as *const _ as *mut _;
         },
         None => {
             return std::ptr::null_mut();

--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -281,7 +281,7 @@ pub unsafe extern "C" fn rs_dcerpc_iface_parse(carg: *const c_char) -> *mut c_vo
     };
 
     match parse_iface_data(&arg) {
-        Ok(detect) => std::mem::transmute(Box::new(detect)),
+        Ok(detect) => Box::into_raw(Box::new(detect)) as *mut _,
         Err(_) => std::ptr::null_mut(),
     }
 }
@@ -289,7 +289,7 @@ pub unsafe extern "C" fn rs_dcerpc_iface_parse(carg: *const c_char) -> *mut c_vo
 #[no_mangle]
 pub unsafe extern "C" fn rs_dcerpc_iface_free(ptr: *mut c_void) {
     if ptr != std::ptr::null_mut() {
-        let _: Box<DCEIfaceData> = std::mem::transmute(ptr);
+        std::mem::drop(Box::from_raw(ptr as *mut DCEIfaceData));
     }
 }
 
@@ -328,7 +328,7 @@ pub unsafe extern "C" fn rs_dcerpc_opnum_parse(carg: *const c_char) -> *mut c_vo
     };
 
     match parse_opnum_data(&arg) {
-        Ok(detect) => std::mem::transmute(Box::new(detect)),
+        Ok(detect) => Box::into_raw(Box::new(detect)) as *mut _,
         Err(_) => std::ptr::null_mut(),
     }
 }
@@ -336,7 +336,7 @@ pub unsafe extern "C" fn rs_dcerpc_opnum_parse(carg: *const c_char) -> *mut c_vo
 #[no_mangle]
 pub unsafe extern "C" fn rs_dcerpc_opnum_free(ptr: *mut c_void) {
     if ptr != std::ptr::null_mut() {
-        let _: Box<DCEOpnumData> = std::mem::transmute(ptr);
+        std::mem::drop(Box::from_raw(ptr as *mut DCEOpnumData));
     }
 }
 

--- a/rust/src/dhcp/logger.rs
+++ b/rust/src/dhcp/logger.rs
@@ -259,12 +259,12 @@ fn format_addr_hex(input: &Vec<u8>) -> String {
 pub extern "C" fn rs_dhcp_logger_new(conf: *const c_void) -> *mut std::os::raw::c_void {
     let conf = ConfNode::wrap(conf);
     let boxed = Box::new(DHCPLogger::new(conf));
-    return unsafe{std::mem::transmute(boxed)};
+    return Box::into_raw(boxed) as *mut _;
 }
 
 #[no_mangle]
 pub extern "C" fn rs_dhcp_logger_free(logger: *mut std::os::raw::c_void) {
-    let _: Box<DHCPLogger> = unsafe{std::mem::transmute(logger)};
+    std::mem::drop(unsafe { Box::from_raw(logger as *mut DHCPLogger) });
 }
 
 #[no_mangle]

--- a/rust/src/dhcp/logger.rs
+++ b/rust/src/dhcp/logger.rs
@@ -263,12 +263,12 @@ pub extern "C" fn rs_dhcp_logger_new(conf: *const c_void) -> *mut std::os::raw::
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dhcp_logger_free(logger: *mut std::os::raw::c_void) {
-    std::mem::drop(unsafe { Box::from_raw(logger as *mut DHCPLogger) });
+pub unsafe extern "C" fn rs_dhcp_logger_free(logger: *mut std::os::raw::c_void) {
+    std::mem::drop(Box::from_raw(logger as *mut DHCPLogger));
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dhcp_logger_log(logger: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_dhcp_logger_log(logger: *mut std::os::raw::c_void,
                                      tx: *mut std::os::raw::c_void,
                                      js: &mut JsonBuilder) -> bool {
     let logger = cast_pointer!(logger, DHCPLogger);
@@ -277,7 +277,7 @@ pub extern "C" fn rs_dhcp_logger_log(logger: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dhcp_logger_do_log(logger: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_dhcp_logger_do_log(logger: *mut std::os::raw::c_void,
                                         tx: *mut std::os::raw::c_void)
                                         -> bool {
     let logger = cast_pointer!(logger, DHCPLogger);

--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -108,7 +108,7 @@ pub unsafe extern "C" fn rs_detect_dns_opcode_parse(carg: *const c_char) -> *mut
     };
 
     match parse_opcode(&arg) {
-        Ok(detect) => std::mem::transmute(Box::new(detect)),
+        Ok(detect) => Box::into_raw(Box::new(detect)) as *mut _,
         Err(_) => std::ptr::null_mut(),
     }
 }
@@ -116,7 +116,7 @@ pub unsafe extern "C" fn rs_detect_dns_opcode_parse(carg: *const c_char) -> *mut
 #[no_mangle]
 pub unsafe extern "C" fn rs_dns_detect_opcode_free(ptr: *mut c_void) {
     if ptr != std::ptr::null_mut() {
-        let _: Box<DetectDnsOpcode> = std::mem::transmute(ptr);
+        std::mem::drop(Box::from_raw(ptr as *mut DetectDnsOpcode));
     }
 }
 

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -155,23 +155,21 @@ impl DNSEvent {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_state_get_event_info_by_id(
+pub unsafe extern "C" fn rs_dns_state_get_event_info_by_id(
     event_id: std::os::raw::c_int,
     event_name: *mut *const std::os::raw::c_char,
     event_type: *mut core::AppLayerEventType,
 ) -> i8 {
     if let Some(e) = DNSEvent::from_id(event_id as u32) {
-        unsafe {
-            *event_name = e.to_cstring().as_ptr() as *const std::os::raw::c_char;
-            *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
-        }
+        *event_name = e.to_cstring().as_ptr() as *const std::os::raw::c_char;
+        *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
         return 0;
     }
     return -1;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_state_get_event_info(
+pub unsafe extern "C" fn rs_dns_state_get_event_info(
     event_name: *const std::os::raw::c_char,
     event_id: *mut std::os::raw::c_int,
     event_type: *mut core::AppLayerEventType
@@ -180,13 +178,11 @@ pub extern "C" fn rs_dns_state_get_event_info(
         return -1;
     }
 
-    let event_name = unsafe { std::ffi::CStr::from_ptr(event_name) };
+    let event_name = std::ffi::CStr::from_ptr(event_name);
     if let Ok(event_name) = event_name.to_str() {
         if let Some(event) = DNSEvent::from_string(event_name) {
-            unsafe {
-                *event_id = event as std::os::raw::c_int;
-                *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
-            }
+            *event_id = event as std::os::raw::c_int;
+            *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
         } else {
             // Unknown event...
             return -1;
@@ -739,7 +735,7 @@ pub extern "C" fn rs_dns_state_free(state: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_state_tx_free(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_dns_state_tx_free(state: *mut std::os::raw::c_void,
                                        tx_id: u64)
 {
     let state = cast_pointer!(state, DNSState);
@@ -748,7 +744,7 @@ pub extern "C" fn rs_dns_state_tx_free(state: *mut std::os::raw::c_void,
 
 /// C binding parse a DNS request. Returns 1 on success, -1 on failure.
 #[no_mangle]
-pub extern "C" fn rs_dns_parse_request(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_dns_parse_request(_flow: *const core::Flow,
                                         state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        input: *const u8,
@@ -757,7 +753,7 @@ pub extern "C" fn rs_dns_parse_request(_flow: *const core::Flow,
                                        _flags: u8)
                                        -> AppLayerResult {
     let state = cast_pointer!(state, DNSState);
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+    let buf = std::slice::from_raw_parts(input, input_len as usize);
     if state.parse_request(buf) {
         AppLayerResult::ok()
     } else {
@@ -766,7 +762,7 @@ pub extern "C" fn rs_dns_parse_request(_flow: *const core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_parse_response(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_dns_parse_response(_flow: *const core::Flow,
                                         state: *mut std::os::raw::c_void,
                                         _pstate: *mut std::os::raw::c_void,
                                         input: *const u8,
@@ -775,7 +771,7 @@ pub extern "C" fn rs_dns_parse_response(_flow: *const core::Flow,
                                         _flags: u8)
                                         -> AppLayerResult {
     let state = cast_pointer!(state, DNSState);
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+    let buf = std::slice::from_raw_parts(input, input_len as usize);
     if state.parse_response(buf) {
         AppLayerResult::ok()
     } else {
@@ -785,7 +781,7 @@ pub extern "C" fn rs_dns_parse_response(_flow: *const core::Flow,
 
 /// C binding parse a DNS request. Returns 1 on success, -1 on failure.
 #[no_mangle]
-pub extern "C" fn rs_dns_parse_request_tcp(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_dns_parse_request_tcp(_flow: *const core::Flow,
                                            state: *mut std::os::raw::c_void,
                                            _pstate: *mut std::os::raw::c_void,
                                            input: *const u8,
@@ -796,8 +792,7 @@ pub extern "C" fn rs_dns_parse_request_tcp(_flow: *const core::Flow,
     let state = cast_pointer!(state, DNSState);
     if input_len > 0 {
         if input != std::ptr::null_mut() {
-            let buf = unsafe{
-                std::slice::from_raw_parts(input, input_len as usize)};
+            let buf = std::slice::from_raw_parts(input, input_len as usize);
             return state.parse_request_tcp(buf);
         }
         state.request_gap(input_len);
@@ -806,7 +801,7 @@ pub extern "C" fn rs_dns_parse_request_tcp(_flow: *const core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_parse_response_tcp(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_dns_parse_response_tcp(_flow: *const core::Flow,
                                             state: *mut std::os::raw::c_void,
                                             _pstate: *mut std::os::raw::c_void,
                                             input: *const u8,
@@ -817,8 +812,7 @@ pub extern "C" fn rs_dns_parse_response_tcp(_flow: *const core::Flow,
     let state = cast_pointer!(state, DNSState);
     if input_len > 0 {
         if input != std::ptr::null_mut() {
-            let buf = unsafe{
-                std::slice::from_raw_parts(input, input_len as usize)};
+            let buf = std::slice::from_raw_parts(input, input_len as usize);
             return state.parse_response_tcp(buf);
         }
         state.response_gap(input_len);
@@ -838,7 +832,7 @@ pub extern "C" fn rs_dns_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_state_get_tx_count(state: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_dns_state_get_tx_count(state: *mut std::os::raw::c_void)
                                             -> u64
 {
     let state = cast_pointer!(state, DNSState);
@@ -847,7 +841,7 @@ pub extern "C" fn rs_dns_state_get_tx_count(state: *mut std::os::raw::c_void)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_state_get_tx(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_dns_state_get_tx(state: *mut std::os::raw::c_void,
                                       tx_id: u64)
                                       -> *mut std::os::raw::c_void
 {
@@ -873,7 +867,7 @@ pub extern "C" fn rs_dns_tx_is_response(tx: &mut DNSTransaction) -> bool {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_state_set_tx_detect_state(
+pub unsafe extern "C" fn rs_dns_state_set_tx_detect_state(
     tx: *mut std::os::raw::c_void,
     de_state: &mut core::DetectEngineState) -> std::os::raw::c_int
 {
@@ -883,7 +877,7 @@ pub extern "C" fn rs_dns_state_set_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_state_get_tx_detect_state(
+pub unsafe extern "C" fn rs_dns_state_get_tx_detect_state(
     tx: *mut std::os::raw::c_void)
     -> *mut core::DetectEngineState
 {
@@ -899,7 +893,7 @@ pub extern "C" fn rs_dns_state_get_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_state_get_events(tx: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_dns_state_get_events(tx: *mut std::os::raw::c_void)
                                           -> *mut core::AppLayerDecoderEvents
 {
     let tx = cast_pointer!(tx, DNSTransaction);
@@ -907,7 +901,7 @@ pub extern "C" fn rs_dns_state_get_events(tx: *mut std::os::raw::c_void)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_state_get_tx_data(
+pub unsafe extern "C" fn rs_dns_state_get_tx_data(
     tx: *mut std::os::raw::c_void)
     -> *mut AppLayerTxData
 {
@@ -916,7 +910,7 @@ pub extern "C" fn rs_dns_state_get_tx_data(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_tx_get_query_name(tx: &mut DNSTransaction,
+pub unsafe extern "C" fn rs_dns_tx_get_query_name(tx: &mut DNSTransaction,
                                        i: u32,
                                        buf: *mut *const u8,
                                        len: *mut u32)
@@ -926,10 +920,8 @@ pub extern "C" fn rs_dns_tx_get_query_name(tx: &mut DNSTransaction,
         if (i as usize) < request.queries.len() {
             let query = &request.queries[i as usize];
             if query.name.len() > 0 {
-                unsafe {
-                    *len = query.name.len() as u32;
-                    *buf = query.name.as_ptr();
-                }
+                *len = query.name.len() as u32;
+                *buf = query.name.as_ptr();
                 return 1;
             }
         }
@@ -957,7 +949,7 @@ pub extern "C" fn rs_dns_tx_get_response_flags(tx: &mut DNSTransaction)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_tx_get_query_rrtype(tx: &mut DNSTransaction,
+pub unsafe extern "C" fn rs_dns_tx_get_query_rrtype(tx: &mut DNSTransaction,
                                          i: u16,
                                          rrtype: *mut u16)
                                          -> u8
@@ -966,9 +958,7 @@ pub extern "C" fn rs_dns_tx_get_query_rrtype(tx: &mut DNSTransaction,
         if (i as usize) < request.queries.len() {
             let query = &request.queries[i as usize];
             if query.name.len() > 0 {
-                unsafe {
-                    *rrtype = query.rrtype;
-                }
+                *rrtype = query.rrtype;
                 return 1;
             }
         }
@@ -977,7 +967,7 @@ pub extern "C" fn rs_dns_tx_get_query_rrtype(tx: &mut DNSTransaction,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_probe(
+pub unsafe extern "C" fn rs_dns_probe(
     _flow: *const core::Flow,
     _dir: u8,
     input: *const u8,
@@ -987,9 +977,7 @@ pub extern "C" fn rs_dns_probe(
     if len == 0 || len < std::mem::size_of::<DNSHeader>() as u32 {
         return core::ALPROTO_UNKNOWN;
     }
-    let slice: &[u8] = unsafe {
-        std::slice::from_raw_parts(input as *mut u8, len as usize)
-    };
+    let slice: &[u8] = std::slice::from_raw_parts(input as *mut u8, len as usize);
     let (is_dns, is_request, _) = probe(slice, slice.len());
     if is_dns {
         let dir = if is_request {
@@ -997,16 +985,14 @@ pub extern "C" fn rs_dns_probe(
         } else {
             core::STREAM_TOCLIENT
         };
-        unsafe {
-            *rdir = dir;
-            return ALPROTO_DNS;
-        }
+        *rdir = dir;
+        return ALPROTO_DNS;
     }
     return 0;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_probe_tcp(
+pub unsafe extern "C" fn rs_dns_probe_tcp(
     _flow: *const core::Flow,
     direction: u8,
     input: *const u8,
@@ -1016,9 +1002,7 @@ pub extern "C" fn rs_dns_probe_tcp(
     if len == 0 || len < std::mem::size_of::<DNSHeader>() as u32 + 2 {
         return core::ALPROTO_UNKNOWN;
     }
-    let slice: &[u8] = unsafe {
-        std::slice::from_raw_parts(input as *mut u8, len as usize)
-    };
+    let slice: &[u8] = std::slice::from_raw_parts(input as *mut u8, len as usize);
     //is_incomplete is checked by caller
     let (is_dns, is_request, _) = probe_tcp(slice);
     if is_dns {
@@ -1028,15 +1012,15 @@ pub extern "C" fn rs_dns_probe_tcp(
             core::STREAM_TOCLIENT
         };
         if direction & (core::STREAM_TOSERVER|core::STREAM_TOCLIENT) != dir {
-            unsafe { *rdir = dir };
+            *rdir = dir;
         }
-        return unsafe { ALPROTO_DNS };
+        return ALPROTO_DNS;
     }
     return 0;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_apply_tx_config(
+pub unsafe extern "C" fn rs_dns_apply_tx_config(
     _state: *mut std::os::raw::c_void, _tx: *mut std::os::raw::c_void,
     _mode: std::os::raw::c_int, config: AppLayerTxConfig
 ) {

--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -76,7 +76,7 @@ named!(pub ftp_pasv_response<u16>,
 
 
 #[no_mangle]
-pub extern "C" fn rs_ftp_active_port(input: *const u8, len: u32) -> u16 {
+pub unsafe extern "C" fn rs_ftp_active_port(input: *const u8, len: u32) -> u16 {
     let buf = build_slice!(input, len as usize);
     match ftp_active_port(buf) {
         Ok((_, dport)) => {
@@ -94,8 +94,8 @@ pub extern "C" fn rs_ftp_active_port(input: *const u8, len: u32) -> u16 {
 
 
 #[no_mangle]
-pub extern "C" fn rs_ftp_pasv_response(input: *const u8, len: u32) -> u16 {
-    let buf = unsafe{std::slice::from_raw_parts(input, len as usize)};
+pub unsafe extern "C" fn rs_ftp_pasv_response(input: *const u8, len: u32) -> u16 {
+    let buf = std::slice::from_raw_parts(input, len as usize);
     match ftp_pasv_response(buf) {
         Ok((_, dport)) => {
             return dport;
@@ -140,7 +140,7 @@ named!(pub ftp_active_eprt<u16>,
 );
 
 #[no_mangle]
-pub extern "C" fn rs_ftp_active_eprt(input: *const u8, len: u32) -> u16 {
+pub unsafe extern "C" fn rs_ftp_active_eprt(input: *const u8, len: u32) -> u16 {
     let buf = build_slice!(input, len as usize);
     match ftp_active_eprt(buf) {
         Ok((_, dport)) => {
@@ -157,8 +157,8 @@ pub extern "C" fn rs_ftp_active_eprt(input: *const u8, len: u32) -> u16 {
     return 0;
 }
 #[no_mangle]
-pub extern "C" fn rs_ftp_epsv_response(input: *const u8, len: u32) -> u16 {
-    let buf = unsafe{std::slice::from_raw_parts(input, len as usize)};
+pub unsafe extern "C" fn rs_ftp_epsv_response(input: *const u8, len: u32) -> u16 {
+    let buf = std::slice::from_raw_parts(input, len as usize);
     match ftp_epsv_response(buf) {
         Ok((_, dport)) => {
             return dport;

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -21,7 +21,6 @@ use super::http2::{
 use super::parser;
 use crate::core::STREAM_TOSERVER;
 use std::ffi::CStr;
-use std::mem::transmute;
 use std::str::FromStr;
 
 fn http2_tx_has_frametype(
@@ -234,7 +233,7 @@ pub unsafe extern "C" fn rs_http2_detect_settingsctx_parse(
     if let Ok(s) = ft_name.to_str() {
         if let Ok((_, ctx)) = parser::http2_parse_settingsctx(s) {
             let boxed = Box::new(ctx);
-            return transmute(boxed); //unsafe
+            return Box::into_raw(boxed) as *mut _;
         }
     }
     return std::ptr::null_mut();
@@ -243,7 +242,7 @@ pub unsafe extern "C" fn rs_http2_detect_settingsctx_parse(
 #[no_mangle]
 pub unsafe extern "C" fn rs_http2_detect_settingsctx_free(ctx: *mut std::os::raw::c_void) {
     // Just unbox...
-    let _ctx: Box<parser::DetectHTTP2settingsSigCtx> = transmute(ctx);
+    std::mem::drop(Box::from_raw(ctx as *mut parser::DetectHTTP2settingsSigCtx));
 }
 
 fn http2_detect_settings_match(
@@ -329,7 +328,7 @@ pub unsafe extern "C" fn rs_detect_u64_parse(
     if let Ok(s) = ft_name.to_str() {
         if let Ok((_, ctx)) = parser::detect_parse_u64(s) {
             let boxed = Box::new(ctx);
-            return transmute(boxed); //unsafe
+            return Box::into_raw(boxed) as *mut _;
         }
     }
     return std::ptr::null_mut();
@@ -338,7 +337,7 @@ pub unsafe extern "C" fn rs_detect_u64_parse(
 #[no_mangle]
 pub unsafe extern "C" fn rs_detect_u64_free(ctx: *mut std::os::raw::c_void) {
     // Just unbox...
-    let _ctx: Box<parser::DetectU64Data> = transmute(ctx);
+    std::mem::drop(Box::from_raw(ctx as *mut parser::DetectU64Data));
 }
 
 fn http2_detect_sizeupdate_match(

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -43,7 +43,7 @@ fn http2_tx_has_frametype(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_http2_tx_has_frametype(
+pub unsafe extern "C" fn rs_http2_tx_has_frametype(
     tx: *mut std::os::raw::c_void, direction: u8, value: u8,
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, HTTP2Transaction);
@@ -103,7 +103,7 @@ fn http2_tx_has_errorcode(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_http2_tx_has_errorcode(
+pub unsafe extern "C" fn rs_http2_tx_has_errorcode(
     tx: *mut std::os::raw::c_void, direction: u8, code: u32,
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, HTTP2Transaction);
@@ -176,7 +176,7 @@ fn http2_tx_get_next_priority(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_http2_tx_get_next_priority(
+pub unsafe extern "C" fn rs_http2_tx_get_next_priority(
     tx: *mut std::os::raw::c_void, direction: u8, nb: u32,
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, HTTP2Transaction);
@@ -218,7 +218,7 @@ fn http2_tx_get_next_window(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_http2_tx_get_next_window(
+pub unsafe extern "C" fn rs_http2_tx_get_next_window(
     tx: *mut std::os::raw::c_void, direction: u8, nb: u32,
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, HTTP2Transaction);
@@ -312,7 +312,7 @@ fn http2_detect_settingsctx_match(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_http2_detect_settingsctx_match(
+pub unsafe extern "C" fn rs_http2_detect_settingsctx_match(
     ctx: *const std::os::raw::c_void, tx: *mut std::os::raw::c_void, direction: u8,
 ) -> std::os::raw::c_int {
     let ctx = cast_pointer!(ctx, parser::DetectHTTP2settingsSigCtx);
@@ -413,7 +413,7 @@ fn http2_detect_sizeupdatectx_match(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_http2_detect_sizeupdatectx_match(
+pub unsafe extern "C" fn rs_http2_detect_sizeupdatectx_match(
     ctx: *const std::os::raw::c_void, tx: *mut std::os::raw::c_void, direction: u8,
 ) -> std::os::raw::c_int {
     let ctx = cast_pointer!(ctx, parser::DetectU64Data);
@@ -704,7 +704,7 @@ fn http2_tx_set_header(state: &mut HTTP2State, name: &[u8], input: &[u8]) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_http2_tx_set_method(
+pub unsafe extern "C" fn rs_http2_tx_set_method(
     state: &mut HTTP2State, buffer: *const u8, buffer_len: u32,
 ) {
     let slice = build_slice!(buffer, buffer_len as usize);
@@ -712,7 +712,7 @@ pub extern "C" fn rs_http2_tx_set_method(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_http2_tx_set_uri(state: &mut HTTP2State, buffer: *const u8, buffer_len: u32) {
+pub unsafe extern "C" fn rs_http2_tx_set_uri(state: &mut HTTP2State, buffer: *const u8, buffer_len: u32) {
     let slice = build_slice!(buffer, buffer_len as usize);
     http2_tx_set_header(state, ":path".as_bytes(), slice)
 }
@@ -853,7 +853,7 @@ fn http2_tx_set_settings(state: &mut HTTP2State, input: &[u8]) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_http2_tx_add_header(
+pub unsafe extern "C" fn rs_http2_tx_add_header(
     state: &mut HTTP2State, name: *const u8, name_len: u32, value: *const u8, value_len: u32,
 ) {
     let slice_name = build_slice!(name, name_len as usize);

--- a/rust/src/http2/logger.rs
+++ b/rust/src/http2/logger.rs
@@ -268,7 +268,7 @@ fn log_http2(tx: &HTTP2Transaction, js: &mut JsonBuilder) -> Result<bool, JsonEr
 }
 
 #[no_mangle]
-pub extern "C" fn rs_http2_log_json(tx: *mut std::os::raw::c_void, js: &mut JsonBuilder) -> bool {
+pub unsafe extern "C" fn rs_http2_log_json(tx: *mut std::os::raw::c_void, js: &mut JsonBuilder) -> bool {
     let tx = cast_pointer!(tx, HTTP2Transaction);
     if let Ok(x) = log_http2(tx, js) {
         return x;

--- a/rust/src/ike/ike.rs
+++ b/rust/src/ike/ike.rs
@@ -322,21 +322,21 @@ export_tx_set_detect_state!(rs_ike_tx_set_detect_state, IKETransaction);
 
 /// C entry point for a probing parser.
 #[no_mangle]
-pub extern "C" fn rs_ike_probing_parser(
+pub unsafe extern "C" fn rs_ike_probing_parser(
     _flow: *const Flow, direction: u8, input: *const u8, input_len: u32, rdir: *mut u8,
 ) -> AppProto {
     if input_len < 28 {
         // at least the ISAKMP_HEADER must be there, not ALPROTO_UNKNOWN because over UDP
-        return unsafe { ALPROTO_FAILED };
+        return ALPROTO_FAILED;
     }
 
     if input != std::ptr::null_mut() {
         let slice = build_slice!(input, input_len as usize);
         if probe(slice, direction, rdir) {
-            return unsafe { ALPROTO_IKE };
+            return ALPROTO_IKE ;
         }
     }
-    return unsafe { ALPROTO_FAILED };
+    return ALPROTO_FAILED;
 }
 
 #[no_mangle]
@@ -349,19 +349,19 @@ pub extern "C" fn rs_ike_state_new(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_state_free(state: *mut std::os::raw::c_void) {
+pub unsafe extern "C" fn rs_ike_state_free(state: *mut std::os::raw::c_void) {
     // Just unbox...
-    std::mem::drop(unsafe { Box::from_raw(state as *mut IKEState) });
+    std::mem::drop(Box::from_raw(state as *mut IKEState));
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_state_tx_free(state: *mut std::os::raw::c_void, tx_id: u64) {
+pub unsafe extern "C" fn rs_ike_state_tx_free(state: *mut std::os::raw::c_void, tx_id: u64) {
     let state = cast_pointer!(state, IKEState);
     state.free_tx(tx_id);
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_parse_request(
+pub unsafe extern "C" fn rs_ike_parse_request(
     _flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     input: *const u8, input_len: u32, _data: *const std::os::raw::c_void, _flags: u8,
 ) -> AppLayerResult {
@@ -372,7 +372,7 @@ pub extern "C" fn rs_ike_parse_request(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_parse_response(
+pub unsafe extern "C" fn rs_ike_parse_response(
     _flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     input: *const u8, input_len: u32, _data: *const std::os::raw::c_void, _flags: u8,
 ) -> AppLayerResult {
@@ -382,7 +382,7 @@ pub extern "C" fn rs_ike_parse_response(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_state_get_tx(
+pub unsafe extern "C" fn rs_ike_state_get_tx(
     state: *mut std::os::raw::c_void, tx_id: u64,
 ) -> *mut std::os::raw::c_void {
     let state = cast_pointer!(state, IKEState);
@@ -397,7 +397,7 @@ pub extern "C" fn rs_ike_state_get_tx(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_state_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
+pub unsafe extern "C" fn rs_ike_state_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
     let state = cast_pointer!(state, IKEState);
     return state.tx_id;
 }
@@ -416,7 +416,7 @@ pub extern "C" fn rs_ike_tx_get_alstate_progress(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_tx_get_logged(
+pub unsafe extern "C" fn rs_ike_tx_get_logged(
     _state: *mut std::os::raw::c_void, tx: *mut std::os::raw::c_void,
 ) -> u32 {
     let tx = cast_pointer!(tx, IKETransaction);
@@ -424,7 +424,7 @@ pub extern "C" fn rs_ike_tx_get_logged(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_tx_set_logged(
+pub unsafe extern "C" fn rs_ike_tx_set_logged(
     _state: *mut std::os::raw::c_void, tx: *mut std::os::raw::c_void, logged: u32,
 ) {
     let tx = cast_pointer!(tx, IKETransaction);
@@ -432,7 +432,7 @@ pub extern "C" fn rs_ike_tx_set_logged(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_state_get_events(
+pub unsafe extern "C" fn rs_ike_state_get_events(
     tx: *mut std::os::raw::c_void,
 ) -> *mut core::AppLayerDecoderEvents {
     let tx = cast_pointer!(tx, IKETransaction);
@@ -440,7 +440,7 @@ pub extern "C" fn rs_ike_state_get_events(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_state_get_event_info_by_id(
+pub unsafe extern "C" fn rs_ike_state_get_event_info_by_id(
     event_id: std::os::raw::c_int, event_name: *mut *const std::os::raw::c_char,
     event_type: *mut core::AppLayerEventType,
 ) -> i8 {
@@ -459,10 +459,8 @@ pub extern "C" fn rs_ike_state_get_event_info_by_id(
             IkeEvent::PayloadExtraData => "payload_extra_data\0",
             IkeEvent::MultipleServerProposal => "multiple_server_proposal\0",
         };
-        unsafe {
-            *event_name = estr.as_ptr() as *const std::os::raw::c_char;
-            *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
-        };
+        *event_name = estr.as_ptr() as *const std::os::raw::c_char;
+        *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
         0
     } else {
         -1
@@ -470,14 +468,14 @@ pub extern "C" fn rs_ike_state_get_event_info_by_id(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_state_get_event_info(
+pub unsafe extern "C" fn rs_ike_state_get_event_info(
     event_name: *const std::os::raw::c_char, event_id: *mut std::os::raw::c_int,
     event_type: *mut core::AppLayerEventType,
 ) -> std::os::raw::c_int {
     if event_name == std::ptr::null() {
         return -1;
     }
-    let c_event_name: &CStr = unsafe { CStr::from_ptr(event_name) };
+    let c_event_name: &CStr = CStr::from_ptr(event_name);
     let event = match c_event_name.to_str() {
         Ok(s) => {
             match s {
@@ -498,17 +496,15 @@ pub extern "C" fn rs_ike_state_get_event_info(
         }
         Err(_) => -1, // UTF-8 conversion failed
     };
-    unsafe {
-        *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
-        *event_id = event as std::os::raw::c_int;
-    };
+    *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
+    *event_id = event as std::os::raw::c_int;
     0
 }
 
 static mut ALPROTO_IKE : AppProto = ALPROTO_UNKNOWN;
 
 #[no_mangle]
-pub extern "C" fn rs_ike_state_get_tx_iterator(
+pub unsafe extern "C" fn rs_ike_state_get_tx_iterator(
     _ipproto: u8, _alproto: AppProto, state: *mut std::os::raw::c_void, min_tx_id: u64,
     _max_tx_id: u64, istate: &mut u64,
 ) -> applayer::AppLayerGetTxIterTuple {

--- a/rust/src/ike/logger.rs
+++ b/rust/src/ike/logger.rs
@@ -224,7 +224,7 @@ fn log_ikev2(tx: &IKETransaction, jb: &mut JsonBuilder) -> Result<(), JsonError>
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_logger_log(
+pub unsafe extern "C" fn rs_ike_logger_log(
     state: &mut IKEState, tx: *mut std::os::raw::c_void, flags: u32, js: &mut JsonBuilder,
 ) -> bool {
     let tx = cast_pointer!(tx, IKETransaction);

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -276,15 +276,14 @@ pub fn test_weak_encryption(alg:EncryptionType) -> bool {
 pub extern "C" fn rs_krb5_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = KRB5State::new();
     let boxed = Box::new(state);
-    return unsafe{std::mem::transmute(boxed)};
+    return Box::into_raw(boxed) as *mut _;
 }
 
 /// Params:
 /// - state: *mut KRB5State as void pointer
 #[no_mangle]
 pub extern "C" fn rs_krb5_state_free(state: *mut std::os::raw::c_void) {
-    // Just unbox...
-    let mut state: Box<KRB5State> = unsafe{std::mem::transmute(state)};
+    let mut state: Box<KRB5State> = unsafe{Box::from_raw(state as _)};
     state.free();
 }
 
@@ -295,7 +294,7 @@ pub extern "C" fn rs_krb5_state_get_tx(state: *mut std::os::raw::c_void,
 {
     let state = cast_pointer!(state,KRB5State);
     match state.get_tx_by_id(tx_id) {
-        Some(tx) => unsafe{std::mem::transmute(tx)},
+        Some(tx) => tx as *const _ as *mut _,
         None     => std::ptr::null_mut(),
     }
 }

--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -67,15 +67,13 @@ pub extern "C" fn rs_mqtt_tx_has_type(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_mqtt_cstr_message_code(
+pub unsafe extern "C" fn rs_mqtt_cstr_message_code(
     str: *const std::os::raw::c_char,
 ) -> std::os::raw::c_int {
-    unsafe {
-        let msgtype: &CStr = CStr::from_ptr(str);
-        if let Ok(s) = msgtype.to_str() {
-            if let Ok(x) = MQTTTypeCode::from_str(s) {
-                return x as i32;
-            }
+    let msgtype: &CStr = CStr::from_ptr(str);
+    if let Ok(s) = msgtype.to_str() {
+        if let Ok(x) = MQTTTypeCode::from_str(s) {
+            return x as i32;
         }
     }
     return -1;
@@ -145,7 +143,7 @@ pub extern "C" fn rs_mqtt_tx_has_connect_flags(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_mqtt_tx_get_connect_clientid(
+pub unsafe extern "C" fn rs_mqtt_tx_get_connect_clientid(
     tx: &MQTTTransaction,
     buffer: *mut *const u8,
     buffer_len: *mut u32,
@@ -154,24 +152,20 @@ pub extern "C" fn rs_mqtt_tx_get_connect_clientid(
         if let MQTTOperation::CONNECT(ref cv) = msg.op {
             let p = &cv.client_id;
             if p.len() > 0 {
-                unsafe {
-                    *buffer = p.as_ptr();
-                    *buffer_len = p.len() as u32;
-                }
+                *buffer = p.as_ptr();
+                *buffer_len = p.len() as u32;
                 return 1;
             }
         }
     }
 
-    unsafe {
-        *buffer = ptr::null();
-        *buffer_len = 0;
-    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
     return 0;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_mqtt_tx_get_connect_username(
+pub unsafe extern "C" fn rs_mqtt_tx_get_connect_username(
     tx: &MQTTTransaction,
     buffer: *mut *const u8,
     buffer_len: *mut u32,
@@ -180,26 +174,22 @@ pub extern "C" fn rs_mqtt_tx_get_connect_username(
         if let MQTTOperation::CONNECT(ref cv) = msg.op {
             if let Some(p) = &cv.username {
                 if p.len() > 0 {
-                    unsafe {
-                        *buffer = p.as_ptr();
-                        *buffer_len = p.len() as u32;
-                    }
+                    *buffer = p.as_ptr();
+                    *buffer_len = p.len() as u32;
                     return 1;
                 }
             }
         }
     }
 
-    unsafe {
-        *buffer = ptr::null();
-        *buffer_len = 0;
-    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
 
     return 0;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_mqtt_tx_get_connect_password(
+pub unsafe extern "C" fn rs_mqtt_tx_get_connect_password(
     tx: &MQTTTransaction,
     buffer: *mut *const u8,
     buffer_len: *mut u32,
@@ -208,25 +198,21 @@ pub extern "C" fn rs_mqtt_tx_get_connect_password(
         if let MQTTOperation::CONNECT(ref cv) = msg.op {
             if let Some(p) = &cv.password {
                 if p.len() > 0 {
-                    unsafe {
-                        *buffer = p.as_ptr();
-                        *buffer_len = p.len() as u32;
-                    }
+                    *buffer = p.as_ptr();
+                    *buffer_len = p.len() as u32;
                     return 1;
                 }
             }
         }
     }
 
-    unsafe {
-        *buffer = ptr::null();
-        *buffer_len = 0;
-    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
     return 0;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_mqtt_tx_get_connect_willtopic(
+pub unsafe extern "C" fn rs_mqtt_tx_get_connect_willtopic(
     tx: &MQTTTransaction,
     buffer: *mut *const u8,
     buffer_len: *mut u32,
@@ -235,26 +221,22 @@ pub extern "C" fn rs_mqtt_tx_get_connect_willtopic(
         if let MQTTOperation::CONNECT(ref cv) = msg.op {
             if let Some(p) = &cv.will_topic {
                 if p.len() > 0 {
-                    unsafe {
-                        *buffer = p.as_ptr();
-                        *buffer_len = p.len() as u32;
-                    }
+                    *buffer = p.as_ptr();
+                    *buffer_len = p.len() as u32;
                     return 1;
                 }
             }
         }
     }
 
-    unsafe {
-        *buffer = ptr::null();
-        *buffer_len = 0;
-    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
 
     return 0;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_mqtt_tx_get_connect_willmessage(
+pub unsafe extern "C" fn rs_mqtt_tx_get_connect_willmessage(
     tx: &MQTTTransaction,
     buffer: *mut *const u8,
     buffer_len: *mut u32,
@@ -263,34 +245,28 @@ pub extern "C" fn rs_mqtt_tx_get_connect_willmessage(
         if let MQTTOperation::CONNECT(ref cv) = msg.op {
             if let Some(p) = &cv.will_message {
                 if p.len() > 0 {
-                    unsafe {
-                        *buffer = p.as_ptr();
-                        *buffer_len = p.len() as u32;
-                    }
+                    *buffer = p.as_ptr();
+                    *buffer_len = p.len() as u32;
                     return 1;
                 }
             }
         }
     }
 
-    unsafe {
-        *buffer = ptr::null();
-        *buffer_len = 0;
-    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
 
     return 0;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_mqtt_tx_get_connack_sessionpresent(
+pub unsafe extern "C" fn rs_mqtt_tx_get_connack_sessionpresent(
     tx: &MQTTTransaction,
     session_present: *mut bool,
 ) -> u8 {
     for msg in tx.msg.iter() {
         if let MQTTOperation::CONNACK(ref ca) = msg.op {
-            unsafe {
-                *session_present = ca.session_present;
-            }
+            *session_present = ca.session_present;
             return 1;
         }
     }
@@ -298,7 +274,7 @@ pub extern "C" fn rs_mqtt_tx_get_connack_sessionpresent(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_mqtt_tx_get_publish_topic(
+pub unsafe extern "C" fn rs_mqtt_tx_get_publish_topic(
     tx: &MQTTTransaction,
     buffer: *mut *const u8,
     buffer_len: *mut u32,
@@ -307,25 +283,21 @@ pub extern "C" fn rs_mqtt_tx_get_publish_topic(
         if let MQTTOperation::PUBLISH(ref pubv) = msg.op {
             let p = &pubv.topic;
             if p.len() > 0 {
-                unsafe {
-                    *buffer = p.as_ptr();
-                    *buffer_len = p.len() as u32;
-                }
+                *buffer = p.as_ptr();
+                *buffer_len = p.len() as u32;
                 return 1;
             }
         }
     }
 
-    unsafe {
-        *buffer = ptr::null();
-        *buffer_len = 0;
-    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
 
     return 0;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_mqtt_tx_get_publish_message(
+pub unsafe extern "C" fn rs_mqtt_tx_get_publish_message(
     tx: &MQTTTransaction,
     buffer: *mut *const u8,
     buffer_len: *mut u32,
@@ -334,25 +306,21 @@ pub extern "C" fn rs_mqtt_tx_get_publish_message(
         if let MQTTOperation::PUBLISH(ref pubv) = msg.op {
             let p = &pubv.message;
             if p.len() > 0 {
-                unsafe {
-                    *buffer = p.as_ptr();
-                    *buffer_len = p.len() as u32;
-                }
+                *buffer = p.as_ptr();
+                *buffer_len = p.len() as u32;
                 return 1;
             }
         }
     }
 
-    unsafe {
-        *buffer = ptr::null();
-        *buffer_len = 0;
-    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
 
     return 0;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_mqtt_tx_get_subscribe_topic(tx: &MQTTTransaction,
+pub unsafe extern "C" fn rs_mqtt_tx_get_subscribe_topic(tx: &MQTTTransaction,
     i: u32,
     buf: *mut *const u8,
     len: *mut u32)
@@ -364,10 +332,8 @@ pub extern "C" fn rs_mqtt_tx_get_subscribe_topic(tx: &MQTTTransaction,
             if (i as usize) < subv.topics.len() + offset {
                 let topic = &subv.topics[(i as usize) - offset];
                 if topic.topic_name.len() > 0 {
-                    unsafe {
-                        *len = topic.topic_name.len() as u32;
-                        *buf = topic.topic_name.as_ptr();
-                    }
+                    *len = topic.topic_name.len() as u32;
+                    *buf = topic.topic_name.as_ptr();
                     return 1;
                 }
             } else {
@@ -376,16 +342,14 @@ pub extern "C" fn rs_mqtt_tx_get_subscribe_topic(tx: &MQTTTransaction,
         }
     }
 
-    unsafe {
-        *buf = ptr::null();
-        *len = 0;
-    }
+    *buf = ptr::null();
+    *len = 0;
 
     return 0;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_mqtt_tx_get_unsubscribe_topic(tx: &MQTTTransaction,
+pub unsafe extern "C" fn rs_mqtt_tx_get_unsubscribe_topic(tx: &MQTTTransaction,
     i: u32,
     buf: *mut *const u8,
     len: *mut u32)
@@ -397,10 +361,8 @@ pub extern "C" fn rs_mqtt_tx_get_unsubscribe_topic(tx: &MQTTTransaction,
             if (i as usize) < unsubv.topics.len() + offset {
                 let topic = &unsubv.topics[(i as usize) - offset];
                 if topic.len() > 0 {
-                    unsafe {
-                        *len = topic.len() as u32;
-                        *buf = topic.as_ptr();
-                    }
+                    *len = topic.len() as u32;
+                    *buf = topic.as_ptr();
                     return 1;
                 }
             } else {
@@ -409,16 +371,14 @@ pub extern "C" fn rs_mqtt_tx_get_unsubscribe_topic(tx: &MQTTTransaction,
         }
     }
 
-    unsafe {
-        *buf = ptr::null();
-        *len = 0;
-    }
+    *buf = ptr::null();
+    *len = 0;
 
     return 0;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_mqtt_tx_get_reason_code(
+pub unsafe extern "C" fn rs_mqtt_tx_get_reason_code(
     tx: &MQTTTransaction,
     result: *mut u8,
 ) -> u8 {
@@ -429,29 +389,21 @@ pub extern "C" fn rs_mqtt_tx_get_reason_code(
             | MQTTOperation::PUBREC(ref v)
             | MQTTOperation::PUBCOMP(ref v) => {
                 if let Some(rcode) = v.reason_code {
-                    unsafe {
-                        *result = rcode;
-                    }
+                    *result = rcode;
                     return 1;
                 }
             }
             MQTTOperation::AUTH(ref v) => {
-                unsafe {
-                    *result = v.reason_code;
-                }
+                *result = v.reason_code;
                 return 1;
             }
             MQTTOperation::CONNACK(ref v) => {
-                unsafe {
-                    *result = v.return_code;
-                }
+                *result = v.return_code;
                 return 1;
             }
             MQTTOperation::DISCONNECT(ref v) => {
                 if let Some(rcode) = v.reason_code {
-                    unsafe {
-                        *result = rcode;
-                    }
+                    *result = rcode;
                     return 1;
                 }
             }
@@ -520,23 +472,23 @@ mod test {
         });
         let mut s: *const u8 = std::ptr::null_mut();
         let mut slen: u32 = 0;
-        let mut r = rs_mqtt_tx_get_unsubscribe_topic(&t, 0, &mut s, &mut slen);
+        let mut r = unsafe{rs_mqtt_tx_get_unsubscribe_topic(&t, 0, &mut s, &mut slen)};
         assert_eq!(r, 1);
-        let mut topic = String::from_utf8_lossy(build_slice!(s, slen as usize));
+        let mut topic = String::from_utf8_lossy(unsafe{build_slice!(s, slen as usize)});
         assert_eq!(topic, "foo");
-        r = rs_mqtt_tx_get_unsubscribe_topic(&t, 1, &mut s, &mut slen);
+        r = unsafe{rs_mqtt_tx_get_unsubscribe_topic(&t, 1, &mut s, &mut slen)};
         assert_eq!(r, 1);
-        topic = String::from_utf8_lossy(build_slice!(s, slen as usize));
+        topic = String::from_utf8_lossy(unsafe{build_slice!(s, slen as usize)});
         assert_eq!(topic, "baar");
-        r = rs_mqtt_tx_get_unsubscribe_topic(&t, 2, &mut s, &mut slen);
+        r = unsafe{rs_mqtt_tx_get_unsubscribe_topic(&t, 2, &mut s, &mut slen)};
         assert_eq!(r, 1);
-        topic = String::from_utf8_lossy(build_slice!(s, slen as usize));
+        topic = String::from_utf8_lossy(unsafe{build_slice!(s, slen as usize)});
         assert_eq!(topic, "fieee");
-        r = rs_mqtt_tx_get_unsubscribe_topic(&t, 3, &mut s, &mut slen);
+        r = unsafe{rs_mqtt_tx_get_unsubscribe_topic(&t, 3, &mut s, &mut slen)};
         assert_eq!(r, 1);
-        topic = String::from_utf8_lossy(build_slice!(s, slen as usize));
+        topic = String::from_utf8_lossy(unsafe{build_slice!(s, slen as usize)});
         assert_eq!(topic, "baaaaz");
-        r = rs_mqtt_tx_get_unsubscribe_topic(&t, 4, &mut s, &mut slen);
+        r = unsafe{rs_mqtt_tx_get_unsubscribe_topic(&t, 4, &mut s, &mut slen)};
         assert_eq!(r, 0);
     }
 
@@ -588,23 +540,23 @@ mod test {
         });
         let mut s: *const u8 = std::ptr::null_mut();
         let mut slen: u32 = 0;
-        let mut r = rs_mqtt_tx_get_subscribe_topic(&t, 0, &mut s, &mut slen);
+        let mut r = unsafe{rs_mqtt_tx_get_subscribe_topic(&t, 0, &mut s, &mut slen)};
         assert_eq!(r, 1);
-        let mut topic = String::from_utf8_lossy(build_slice!(s, slen as usize));
+        let mut topic = String::from_utf8_lossy(unsafe{build_slice!(s, slen as usize)});
         assert_eq!(topic, "foo");
-        r = rs_mqtt_tx_get_subscribe_topic(&t, 1, &mut s, &mut slen);
+        r = unsafe{rs_mqtt_tx_get_subscribe_topic(&t, 1, &mut s, &mut slen)};
         assert_eq!(r, 1);
-        topic = String::from_utf8_lossy(build_slice!(s, slen as usize));
+        topic = String::from_utf8_lossy(unsafe{build_slice!(s, slen as usize)});
         assert_eq!(topic, "baar");
-        r = rs_mqtt_tx_get_subscribe_topic(&t, 2, &mut s, &mut slen);
+        r = unsafe{rs_mqtt_tx_get_subscribe_topic(&t, 2, &mut s, &mut slen)};
         assert_eq!(r, 1);
-        topic = String::from_utf8_lossy(build_slice!(s, slen as usize));
+        topic = String::from_utf8_lossy(unsafe{build_slice!(s, slen as usize)});
         assert_eq!(topic, "fieee");
-        r = rs_mqtt_tx_get_subscribe_topic(&t, 3, &mut s, &mut slen);
+        r = unsafe{rs_mqtt_tx_get_subscribe_topic(&t, 3, &mut s, &mut slen)};
         assert_eq!(r, 1);
-        topic = String::from_utf8_lossy(build_slice!(s, slen as usize));
+        topic = String::from_utf8_lossy(unsafe{build_slice!(s, slen as usize)});
         assert_eq!(topic, "baaaaz");
-        r = rs_mqtt_tx_get_subscribe_topic(&t, 4, &mut s, &mut slen);
+        r = unsafe{rs_mqtt_tx_get_subscribe_topic(&t, 4, &mut s, &mut slen)};
         assert_eq!(r, 0);
     }
 }

--- a/rust/src/mqtt/logger.rs
+++ b/rust/src/mqtt/logger.rs
@@ -297,7 +297,7 @@ fn log_mqtt(tx: &MQTTTransaction, flags: u32, js: &mut JsonBuilder) -> Result<()
 }
 
 #[no_mangle]
-pub extern "C" fn rs_mqtt_logger_log(_state: &mut MQTTState, tx: *mut std::os::raw::c_void, flags: u32, js: &mut JsonBuilder) -> bool {
+pub unsafe extern "C" fn rs_mqtt_logger_log(_state: &mut MQTTState, tx: *mut std::os::raw::c_void, flags: u32, js: &mut JsonBuilder) -> bool {
     let tx = cast_pointer!(tx, MQTTTransaction);
     log_mqtt(tx, flags, js).is_ok()
 }

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -1390,7 +1390,7 @@ pub extern "C" fn rs_nfs_state_free(state: *mut std::os::raw::c_void) {
 
 /// C binding parse a NFS TCP request. Returns 1 on success, -1 on failure.
 #[no_mangle]
-pub extern "C" fn rs_nfs_parse_request(flow: *const Flow,
+pub unsafe extern "C" fn rs_nfs_parse_request(flow: *const Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        input: *const u8,
@@ -1401,13 +1401,13 @@ pub extern "C" fn rs_nfs_parse_request(flow: *const Flow,
 {
     let state = cast_pointer!(state, NFSState);
     let flow = cast_pointer!(flow, Flow);
-    let file_flags = unsafe { FileFlowToFlags(flow, STREAM_TOSERVER) };
+    let file_flags = FileFlowToFlags(flow, STREAM_TOSERVER);
     rs_nfs_setfileflags(STREAM_TOSERVER, state, file_flags);
 
     if input.is_null() == true && input_len > 0 {
         return rs_nfs_parse_request_tcp_gap(state, input_len);
     }
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+    let buf = std::slice::from_raw_parts(input, input_len as usize);
     SCLogDebug!("parsing {} bytes of request data", input_len);
 
     state.update_ts(flow.get_last_time().as_secs());
@@ -1424,7 +1424,7 @@ pub extern "C" fn rs_nfs_parse_request_tcp_gap(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_parse_response(flow: *const Flow,
+pub unsafe extern "C" fn rs_nfs_parse_response(flow: *const Flow,
                                         state: *mut std::os::raw::c_void,
                                         _pstate: *mut std::os::raw::c_void,
                                         input: *const u8,
@@ -1435,14 +1435,14 @@ pub extern "C" fn rs_nfs_parse_response(flow: *const Flow,
 {
     let state = cast_pointer!(state, NFSState);
     let flow = cast_pointer!(flow, Flow);
-    let file_flags = unsafe { FileFlowToFlags(flow, STREAM_TOCLIENT) };
+    let file_flags = FileFlowToFlags(flow, STREAM_TOCLIENT);
     rs_nfs_setfileflags(STREAM_TOCLIENT, state, file_flags);
 
     if input.is_null() == true && input_len > 0 {
         return rs_nfs_parse_response_tcp_gap(state, input_len);
     }
     SCLogDebug!("parsing {} bytes of response data", input_len);
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+    let buf = std::slice::from_raw_parts(input, input_len as usize);
 
     state.update_ts(flow.get_last_time().as_secs());
     state.parse_tcp_data_tc(buf)
@@ -1459,7 +1459,7 @@ pub extern "C" fn rs_nfs_parse_response_tcp_gap(
 
 /// C binding to parse an NFS/UDP request. Returns 1 on success, -1 on failure.
 #[no_mangle]
-pub extern "C" fn rs_nfs_parse_request_udp(f: *const Flow,
+pub unsafe extern "C" fn rs_nfs_parse_request_udp(f: *const Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        input: *const u8,
@@ -1468,16 +1468,16 @@ pub extern "C" fn rs_nfs_parse_request_udp(f: *const Flow,
                                        _flags: u8) -> AppLayerResult
 {
     let state = cast_pointer!(state, NFSState);
-    let file_flags = unsafe { FileFlowToFlags(f, STREAM_TOSERVER) };
+    let file_flags = FileFlowToFlags(f, STREAM_TOSERVER);
     rs_nfs_setfileflags(STREAM_TOSERVER, state, file_flags);
 
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+    let buf = std::slice::from_raw_parts(input, input_len as usize);
     SCLogDebug!("parsing {} bytes of request data", input_len);
     state.parse_udp_ts(buf)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_parse_response_udp(f: *const Flow,
+pub unsafe extern "C" fn rs_nfs_parse_response_udp(f: *const Flow,
                                         state: *mut std::os::raw::c_void,
                                         _pstate: *mut std::os::raw::c_void,
                                         input: *const u8,
@@ -1486,15 +1486,15 @@ pub extern "C" fn rs_nfs_parse_response_udp(f: *const Flow,
                                         _flags: u8) -> AppLayerResult
 {
     let state = cast_pointer!(state, NFSState);
-    let file_flags = unsafe { FileFlowToFlags(f, STREAM_TOCLIENT) };
+    let file_flags = FileFlowToFlags(f, STREAM_TOCLIENT);
     rs_nfs_setfileflags(STREAM_TOCLIENT, state, file_flags);
     SCLogDebug!("parsing {} bytes of response data", input_len);
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+    let buf = std::slice::from_raw_parts(input, input_len as usize);
     state.parse_udp_tc(buf)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_get_tx_count(state: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_nfs_state_get_tx_count(state: *mut std::os::raw::c_void)
                                             -> u64
 {
     let state = cast_pointer!(state, NFSState);
@@ -1503,7 +1503,7 @@ pub extern "C" fn rs_nfs_state_get_tx_count(state: *mut std::os::raw::c_void)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_get_tx(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_nfs_state_get_tx(state: *mut std::os::raw::c_void,
                                       tx_id: u64)
                                       -> *mut std::os::raw::c_void
 {
@@ -1520,7 +1520,7 @@ pub extern "C" fn rs_nfs_state_get_tx(state: *mut std::os::raw::c_void,
 
 // for use with the C API call StateGetTxIterator
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_get_tx_iterator(
+pub unsafe extern "C" fn rs_nfs_state_get_tx_iterator(
                                       _ipproto: u8,
                                       _alproto: AppProto,
                                       state: *mut std::os::raw::c_void,
@@ -1543,7 +1543,7 @@ pub extern "C" fn rs_nfs_state_get_tx_iterator(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_tx_free(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_nfs_state_tx_free(state: *mut std::os::raw::c_void,
                                        tx_id: u64)
 {
     let state = cast_pointer!(state, NFSState);
@@ -1551,7 +1551,7 @@ pub extern "C" fn rs_nfs_state_tx_free(state: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_tx_get_alstate_progress(tx: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_nfs_tx_get_alstate_progress(tx: *mut std::os::raw::c_void,
                                                   direction: u8)
                                                   -> std::os::raw::c_int
 {
@@ -1569,7 +1569,7 @@ pub extern "C" fn rs_nfs_tx_get_alstate_progress(tx: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_get_tx_data(
+pub unsafe extern "C" fn rs_nfs_get_tx_data(
     tx: *mut std::os::raw::c_void)
     -> *mut AppLayerTxData
 {
@@ -1578,7 +1578,7 @@ pub extern "C" fn rs_nfs_get_tx_data(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_set_tx_detect_state(
+pub unsafe extern "C" fn rs_nfs_state_set_tx_detect_state(
     tx: *mut std::os::raw::c_void,
     de_state: &mut DetectEngineState) -> i32
 {
@@ -1588,7 +1588,7 @@ pub extern "C" fn rs_nfs_state_set_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_get_tx_detect_state(
+pub unsafe extern "C" fn rs_nfs_state_get_tx_detect_state(
     tx: *mut std::os::raw::c_void)
     -> *mut DetectEngineState
 {
@@ -1606,7 +1606,7 @@ pub extern "C" fn rs_nfs_state_get_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_get_events(tx: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_nfs_state_get_events(tx: *mut std::os::raw::c_void)
                                           -> *mut AppLayerDecoderEvents
 {
     let tx = cast_pointer!(tx, NFSTransaction);
@@ -1614,7 +1614,7 @@ pub extern "C" fn rs_nfs_state_get_events(tx: *mut std::os::raw::c_void)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_get_event_info_by_id(event_id: std::os::raw::c_int,
+pub unsafe extern "C" fn rs_nfs_state_get_event_info_by_id(event_id: std::os::raw::c_int,
                                               event_name: *mut *const std::os::raw::c_char,
                                               event_type: *mut AppLayerEventType)
                                               -> i8
@@ -1625,10 +1625,8 @@ pub extern "C" fn rs_nfs_state_get_event_info_by_id(event_id: std::os::raw::c_in
             NFSEvent::NonExistingVersion => { "non_existing_version\0" },
             NFSEvent::UnsupportedVersion => { "unsupported_version\0" },
         };
-        unsafe{
-            *event_name = estr.as_ptr() as *const std::os::raw::c_char;
-            *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
-        };
+        *event_name = estr.as_ptr() as *const std::os::raw::c_char;
+        *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
         0
     } else {
         -1
@@ -1637,7 +1635,7 @@ pub extern "C" fn rs_nfs_state_get_event_info_by_id(event_id: std::os::raw::c_in
 
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_state_get_event_info(event_name: *const std::os::raw::c_char,
+pub unsafe extern "C" fn rs_nfs_state_get_event_info(event_name: *const std::os::raw::c_char,
                                               event_id: *mut std::os::raw::c_int,
                                               event_type: *mut AppLayerEventType)
                                               -> std::os::raw::c_int
@@ -1645,7 +1643,7 @@ pub extern "C" fn rs_nfs_state_get_event_info(event_name: *const std::os::raw::c
     if event_name == std::ptr::null() {
         return -1;
     }
-    let c_event_name: &CStr = unsafe { CStr::from_ptr(event_name) };
+    let c_event_name: &CStr = CStr::from_ptr(event_name);
     let event = match c_event_name.to_str() {
         Ok(s) => {
             match s {
@@ -1655,10 +1653,8 @@ pub extern "C" fn rs_nfs_state_get_event_info(event_name: *const std::os::raw::c
         },
         Err(_) => -1, // UTF-8 conversion failed
     };
-    unsafe{
-        *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
-        *event_id = event as std::os::raw::c_int;
-    };
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+    *event_id = event as std::os::raw::c_int;
     0
 }
 
@@ -1666,15 +1662,13 @@ pub extern "C" fn rs_nfs_state_get_event_info(event_name: *const std::os::raw::c
 /// otherwise get procs from the 'file_additional_procs'.
 /// Keep calling until 0 is returned.
 #[no_mangle]
-pub extern "C" fn rs_nfs_tx_get_procedures(tx: &mut NFSTransaction,
+pub unsafe extern "C" fn rs_nfs_tx_get_procedures(tx: &mut NFSTransaction,
                                            i: u16,
                                            procedure: *mut u32)
                                            -> u8
 {
     if i == 0 {
-        unsafe {
-            *procedure = tx.procedure as u32;
-        }
+        *procedure = tx.procedure as u32;
         return 1;
     }
 
@@ -1688,9 +1682,7 @@ pub extern "C" fn rs_nfs_tx_get_procedures(tx: &mut NFSTransaction,
         let idx = i as usize - 1;
         if idx < tdf.file_additional_procs.len() {
             let p = tdf.file_additional_procs[idx];
-            unsafe {
-                *procedure = p as u32;
-            }
+            *procedure = p as u32;
             return 1;
         }
     }
@@ -1698,20 +1690,16 @@ pub extern "C" fn rs_nfs_tx_get_procedures(tx: &mut NFSTransaction,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_tx_get_version(tx: &mut NFSTransaction,
+pub unsafe extern "C" fn rs_nfs_tx_get_version(tx: &mut NFSTransaction,
                                         version: *mut u32)
 {
-    unsafe {
-        *version = tx.nfs_version as u32;
-    }
+    *version = tx.nfs_version as u32;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_init(context: &'static mut SuricataFileContext)
+pub unsafe extern "C" fn rs_nfs_init(context: &'static mut SuricataFileContext)
 {
-    unsafe {
-        SURICATA_NFS_FILE_CONFIG = Some(context);
-    }
+    SURICATA_NFS_FILE_CONFIG = Some(context);
 }
 
 fn nfs_probe_dir(i: &[u8], rdir: *mut u8) -> i8 {
@@ -1826,7 +1814,7 @@ pub fn nfs_probe_udp(i: &[u8], direction: u8) -> i32 {
 
 /// MIDSTREAM
 #[no_mangle]
-pub extern "C" fn rs_nfs_probe_ms(
+pub unsafe extern "C" fn rs_nfs_probe_ms(
         _flow: *const Flow,
         direction: u8, input: *const u8,
         len: u32, rdir: *mut u8) -> AppProto
@@ -1845,25 +1833,25 @@ pub extern "C" fn rs_nfs_probe_ms(
                 1 => {
                     SCLogDebug!("nfs_probe success: dir {:02x} adir {:02x}", direction, adirection);
                     if (direction & (STREAM_TOSERVER|STREAM_TOCLIENT)) != adirection {
-                        unsafe { *rdir = adirection; }
+                        *rdir = adirection;
                     }
-                    unsafe { ALPROTO_NFS }
+                    ALPROTO_NFS
                 },
                 0 => { ALPROTO_UNKNOWN },
-                _ => { unsafe { ALPROTO_FAILED } },
+                _ => { ALPROTO_FAILED },
             }
         },
         0 => {
             ALPROTO_UNKNOWN
         },
         _ => {
-            unsafe { ALPROTO_FAILED }
+            ALPROTO_FAILED
         }
     }
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_probe(_f: *const Flow,
+pub unsafe extern "C" fn rs_nfs_probe(_f: *const Flow,
                                direction: u8,
                                input: *const u8,
                                len: u32,
@@ -1873,15 +1861,15 @@ pub extern "C" fn rs_nfs_probe(_f: *const Flow,
     let slice: &[u8] = build_slice!(input, len as usize);
     SCLogDebug!("rs_nfs_probe: running probe");
     match nfs_probe(slice, direction) {
-        1 => { unsafe { ALPROTO_NFS } },
-        -1 => { unsafe { ALPROTO_FAILED } },
+        1 => { ALPROTO_NFS },
+        -1 => { ALPROTO_FAILED },
         _ => { ALPROTO_UNKNOWN },
     }
 }
 
 /// TOSERVER probe function
 #[no_mangle]
-pub extern "C" fn rs_nfs_probe_udp_ts(_f: *const Flow,
+pub unsafe extern "C" fn rs_nfs_probe_udp_ts(_f: *const Flow,
                                _direction: u8,
                                input: *const u8,
                                len: u32,
@@ -1890,15 +1878,15 @@ pub extern "C" fn rs_nfs_probe_udp_ts(_f: *const Flow,
 {
     let slice: &[u8] = build_slice!(input, len as usize);
     match nfs_probe_udp(slice, STREAM_TOSERVER) {
-        1 => { unsafe { ALPROTO_NFS } },
-        -1 => { unsafe { ALPROTO_FAILED } },
+        1 => { ALPROTO_NFS },
+        -1 => { ALPROTO_FAILED },
         _ => { ALPROTO_UNKNOWN },
     }
 }
 
 /// TOCLIENT probe function
 #[no_mangle]
-pub extern "C" fn rs_nfs_probe_udp_tc(_f: *const Flow,
+pub unsafe extern "C" fn rs_nfs_probe_udp_tc(_f: *const Flow,
                                _direction: u8,
                                input: *const u8,
                                len: u32,
@@ -1907,22 +1895,22 @@ pub extern "C" fn rs_nfs_probe_udp_tc(_f: *const Flow,
 {
     let slice: &[u8] = build_slice!(input, len as usize);
     match nfs_probe_udp(slice, STREAM_TOCLIENT) {
-        1 => { unsafe { ALPROTO_NFS } },
-        -1 => { unsafe { ALPROTO_FAILED } },
+        1 => { ALPROTO_NFS },
+        -1 => { ALPROTO_FAILED },
         _ => { ALPROTO_UNKNOWN },
     }
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_getfiles(ptr: *mut std::ffi::c_void, direction: u8) -> * mut FileContainer {
+pub unsafe extern "C" fn rs_nfs_getfiles(ptr: *mut std::ffi::c_void, direction: u8) -> * mut FileContainer {
     if ptr.is_null() { panic!("NULL ptr"); };
     let parser = cast_pointer!(ptr, NFSState);
     parser.getfiles(direction)
 }
 #[no_mangle]
-pub extern "C" fn rs_nfs_setfileflags(direction: u8, ptr: *mut NFSState, flags: u16) {
+pub unsafe extern "C" fn rs_nfs_setfileflags(direction: u8, ptr: *mut NFSState, flags: u16) {
     if ptr.is_null() { panic!("NULL ptr"); };
-    let parser = unsafe { &mut *ptr };
+    let parser = &mut *ptr;
     SCLogDebug!("direction {} flags {}", direction, flags);
     parser.setfileflags(direction, flags)
 }

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -178,15 +178,14 @@ impl Drop for NTPTransaction {
 pub extern "C" fn rs_ntp_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = NTPState::new();
     let boxed = Box::new(state);
-    return unsafe{std::mem::transmute(boxed)};
+    return Box::into_raw(boxed) as *mut _;
 }
 
 /// Params:
 /// - state: *mut NTPState as void pointer
 #[no_mangle]
 pub extern "C" fn rs_ntp_state_free(state: *mut std::os::raw::c_void) {
-    // Just unbox...
-    let mut ntp_state: Box<NTPState> = unsafe{std::mem::transmute(state)};
+    let mut ntp_state = unsafe{ Box::from_raw(state as *mut NTPState) };
     ntp_state.free();
 }
 
@@ -229,7 +228,7 @@ pub extern "C" fn rs_ntp_state_get_tx(state: *mut std::os::raw::c_void,
 {
     let state = cast_pointer!(state,NTPState);
     match state.get_tx_by_id(tx_id) {
-        Some(tx) => unsafe{std::mem::transmute(tx)},
+        Some(tx) => tx as *const _ as *mut _,
         None     => std::ptr::null_mut(),
     }
 }

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -190,7 +190,7 @@ pub extern "C" fn rs_ntp_state_free(state: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_parse_request(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_ntp_parse_request(_flow: *const core::Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        input: *const u8,
@@ -206,7 +206,7 @@ pub extern "C" fn rs_ntp_parse_request(_flow: *const core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_parse_response(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_ntp_parse_response(_flow: *const core::Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        input: *const u8,
@@ -222,7 +222,7 @@ pub extern "C" fn rs_ntp_parse_response(_flow: *const core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_state_get_tx(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_ntp_state_get_tx(state: *mut std::os::raw::c_void,
                                       tx_id: u64)
                                       -> *mut std::os::raw::c_void
 {
@@ -234,7 +234,7 @@ pub extern "C" fn rs_ntp_state_get_tx(state: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_state_get_tx_count(state: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_ntp_state_get_tx_count(state: *mut std::os::raw::c_void)
                                             -> u64
 {
     let state = cast_pointer!(state,NTPState);
@@ -242,7 +242,7 @@ pub extern "C" fn rs_ntp_state_get_tx_count(state: *mut std::os::raw::c_void)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_state_tx_free(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_ntp_state_tx_free(state: *mut std::os::raw::c_void,
                                        tx_id: u64)
 {
     let state = cast_pointer!(state,NTPState);
@@ -258,7 +258,7 @@ pub extern "C" fn rs_ntp_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_state_set_tx_detect_state(
+pub unsafe extern "C" fn rs_ntp_state_set_tx_detect_state(
     tx: *mut std::os::raw::c_void,
     de_state: &mut core::DetectEngineState) -> std::os::raw::c_int
 {
@@ -268,7 +268,7 @@ pub extern "C" fn rs_ntp_state_set_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_state_get_tx_detect_state(
+pub unsafe extern "C" fn rs_ntp_state_get_tx_detect_state(
     tx: *mut std::os::raw::c_void)
     -> *mut core::DetectEngineState
 {
@@ -280,7 +280,7 @@ pub extern "C" fn rs_ntp_state_get_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_state_get_event_info_by_id(event_id: std::os::raw::c_int,
+pub unsafe extern "C" fn rs_ntp_state_get_event_info_by_id(event_id: std::os::raw::c_int,
                                                     event_name: *mut *const std::os::raw::c_char,
                                                     event_type: *mut core::AppLayerEventType)
                                                     -> i8
@@ -292,10 +292,8 @@ pub extern "C" fn rs_ntp_state_get_event_info_by_id(event_id: std::os::raw::c_in
             NTPEvent::NotRequest          => { "not_request\0" },
             NTPEvent::NotResponse         => { "not_response\0" },
         };
-        unsafe{
-            *event_name = estr.as_ptr() as *const std::os::raw::c_char;
-            *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
-        };
+        *event_name = estr.as_ptr() as *const std::os::raw::c_char;
+        *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
         0
     } else {
         -1
@@ -303,7 +301,7 @@ pub extern "C" fn rs_ntp_state_get_event_info_by_id(event_id: std::os::raw::c_in
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_state_get_events(tx: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_ntp_state_get_events(tx: *mut std::os::raw::c_void)
                                           -> *mut core::AppLayerDecoderEvents
 {
     let tx = cast_pointer!(tx, NTPTransaction);
@@ -311,13 +309,13 @@ pub extern "C" fn rs_ntp_state_get_events(tx: *mut std::os::raw::c_void)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ntp_state_get_event_info(event_name: *const std::os::raw::c_char,
+pub unsafe extern "C" fn rs_ntp_state_get_event_info(event_name: *const std::os::raw::c_char,
                                               event_id: *mut std::os::raw::c_int,
                                               event_type: *mut core::AppLayerEventType)
                                               -> std::os::raw::c_int
 {
     if event_name == std::ptr::null() { return -1; }
-    let c_event_name: &CStr = unsafe { CStr::from_ptr(event_name) };
+    let c_event_name: &CStr = CStr::from_ptr(event_name);
     let event = match c_event_name.to_str() {
         Ok(s) => {
             match s {
@@ -327,10 +325,8 @@ pub extern "C" fn rs_ntp_state_get_event_info(event_name: *const std::os::raw::c
         },
         Err(_) => -1, // UTF-8 conversion failed
     };
-    unsafe{
-        *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
-        *event_id = event as std::os::raw::c_int;
-    };
+    *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
+    *event_id = event as std::os::raw::c_int;
     0
 }
 

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -79,7 +79,7 @@ impl Drop for RdpTransaction {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rdp_state_get_tx(
+pub unsafe extern "C" fn rs_rdp_state_get_tx(
     state: *mut std::os::raw::c_void, tx_id: u64,
 ) -> *mut std::os::raw::c_void {
     let state = cast_pointer!(state, RdpState);
@@ -94,7 +94,7 @@ pub extern "C" fn rs_rdp_state_get_tx(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rdp_state_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
+pub unsafe extern "C" fn rs_rdp_state_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
     let state = cast_pointer!(state, RdpState);
     return state.next_id;
 }
@@ -384,7 +384,7 @@ pub extern "C" fn rs_rdp_state_free(state: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rdp_state_tx_free(state: *mut std::os::raw::c_void, tx_id: u64) {
+pub unsafe extern "C" fn rs_rdp_state_tx_free(state: *mut std::os::raw::c_void, tx_id: u64) {
     let state = cast_pointer!(state, RdpState);
     state.free_tx(tx_id);
 }
@@ -407,7 +407,7 @@ fn probe_rdp(input: &[u8]) -> bool {
 
 /// probe for T.123 message, whether to client or to server
 #[no_mangle]
-pub extern "C" fn rs_rdp_probe_ts_tc(
+pub unsafe extern "C" fn rs_rdp_probe_ts_tc(
     _flow: *const Flow, _direction: u8, input: *const u8, input_len: u32, _rdir: *mut u8,
 ) -> AppProto {
     if input != std::ptr::null_mut() {
@@ -418,7 +418,7 @@ pub extern "C" fn rs_rdp_probe_ts_tc(
         // https://wiki.wireshark.org/SampleCaptures?action=AttachFile&do=view&target=rdp-ssl.pcap.gz
         // but this callback will not be exercised, so `probe_tls_handshake` not needed here.
         if probe_rdp(slice) {
-            return unsafe { ALPROTO_RDP };
+            return ALPROTO_RDP;
         }
     }
     return ALPROTO_UNKNOWN;
@@ -434,7 +434,7 @@ fn probe_tls_handshake(input: &[u8]) -> bool {
 //
 
 #[no_mangle]
-pub extern "C" fn rs_rdp_parse_ts(
+pub unsafe extern "C" fn rs_rdp_parse_ts(
     _flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     input: *const u8, input_len: u32, _data: *const std::os::raw::c_void, _flags: u8,
 ) -> AppLayerResult {
@@ -445,7 +445,7 @@ pub extern "C" fn rs_rdp_parse_ts(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rdp_parse_tc(
+pub unsafe extern "C" fn rs_rdp_parse_tc(
     _flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     input: *const u8, input_len: u32, _data: *const std::os::raw::c_void, _flags: u8,
 ) -> AppLayerResult {

--- a/rust/src/rfb/logger.rs
+++ b/rust/src/rfb/logger.rs
@@ -113,7 +113,7 @@ fn log_rfb(tx: &RFBTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rfb_logger_log(_state: &mut RFBState,
+pub unsafe extern "C" fn rs_rfb_logger_log(_state: &mut RFBState,
                                     tx: *mut std::os::raw::c_void,
                                     js: &mut JsonBuilder) -> bool {
     let tx = cast_pointer!(tx, RFBTransaction);

--- a/rust/src/rfb/rfb.rs
+++ b/rust/src/rfb/rfb.rs
@@ -530,7 +530,7 @@ pub extern "C" fn rs_rfb_state_free(state: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rfb_state_tx_free(
+pub unsafe extern "C" fn rs_rfb_state_tx_free(
     state: *mut std::os::raw::c_void,
     tx_id: u64,
 ) {
@@ -539,7 +539,7 @@ pub extern "C" fn rs_rfb_state_tx_free(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rfb_parse_request(
+pub unsafe extern "C" fn rs_rfb_parse_request(
     _flow: *const Flow,
     state: *mut std::os::raw::c_void,
     _pstate: *mut std::os::raw::c_void,
@@ -554,7 +554,7 @@ pub extern "C" fn rs_rfb_parse_request(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rfb_parse_response(
+pub unsafe extern "C" fn rs_rfb_parse_response(
     _flow: *const Flow,
     state: *mut std::os::raw::c_void,
     _pstate: *mut std::os::raw::c_void,
@@ -569,7 +569,7 @@ pub extern "C" fn rs_rfb_parse_response(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rfb_state_get_tx(
+pub unsafe extern "C" fn rs_rfb_state_get_tx(
     state: *mut std::os::raw::c_void,
     tx_id: u64,
 ) -> *mut std::os::raw::c_void {
@@ -585,7 +585,7 @@ pub extern "C" fn rs_rfb_state_get_tx(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rfb_state_get_tx_count(
+pub unsafe extern "C" fn rs_rfb_state_get_tx_count(
     state: *mut std::os::raw::c_void,
 ) -> u64 {
     let state = cast_pointer!(state, RFBState);
@@ -593,7 +593,7 @@ pub extern "C" fn rs_rfb_state_get_tx_count(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rfb_tx_get_alstate_progress(
+pub unsafe extern "C" fn rs_rfb_tx_get_alstate_progress(
     tx: *mut std::os::raw::c_void,
     _direction: u8,
 ) -> std::os::raw::c_int {
@@ -605,7 +605,7 @@ pub extern "C" fn rs_rfb_tx_get_alstate_progress(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rfb_state_get_events(
+pub unsafe extern "C" fn rs_rfb_state_get_events(
     tx: *mut std::os::raw::c_void
 ) -> *mut core::AppLayerDecoderEvents {
     let tx = cast_pointer!(tx, RFBTransaction);
@@ -629,7 +629,7 @@ pub extern "C" fn rs_rfb_state_get_event_info_by_id(_event_id: std::os::raw::c_i
     return -1;
 }
 #[no_mangle]
-pub extern "C" fn rs_rfb_state_get_tx_iterator(
+pub unsafe extern "C" fn rs_rfb_state_get_tx_iterator(
     _ipproto: u8,
     _alproto: AppProto,
     state: *mut std::os::raw::c_void,

--- a/rust/src/rfb/rfb.rs
+++ b/rust/src/rfb/rfb.rs
@@ -19,7 +19,6 @@
 
 use std;
 use std::ffi::CString;
-use std::mem::transmute;
 use crate::core::{self, ALPROTO_UNKNOWN, AppProto, Flow, IPPROTO_TCP};
 use crate::applayer;
 use crate::applayer::*;
@@ -521,13 +520,13 @@ export_tx_set_detect_state!(
 pub extern "C" fn rs_rfb_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = RFBState::new();
     let boxed = Box::new(state);
-    return unsafe { transmute(boxed) };
+    return Box::into_raw(boxed) as *mut _;
 }
 
 #[no_mangle]
 pub extern "C" fn rs_rfb_state_free(state: *mut std::os::raw::c_void) {
     // Just unbox...
-    let _drop: Box<RFBState> = unsafe { transmute(state) };
+    std::mem::drop(unsafe { Box::from_raw(state as *mut RFBState) });
 }
 
 #[no_mangle]
@@ -577,7 +576,7 @@ pub extern "C" fn rs_rfb_state_get_tx(
     let state = cast_pointer!(state, RFBState);
     match state.get_tx(tx_id) {
         Some(tx) => {
-            return unsafe { transmute(tx) };
+            return tx as *const _ as *mut _;
         }
         None => {
             return std::ptr::null_mut();
@@ -641,7 +640,7 @@ pub extern "C" fn rs_rfb_state_get_tx_iterator(
     let state = cast_pointer!(state, RFBState);
     match state.tx_iterator(min_tx_id, istate) {
         Some((tx, out_tx_id, has_next)) => {
-            let c_tx = unsafe { transmute(tx) };
+            let c_tx = tx as *const _ as *mut _;
             let ires = applayer::AppLayerGetTxIterTuple::with_values(
                 c_tx,
                 out_tx_id,

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -182,7 +182,7 @@ pub extern "C" fn rs_sip_state_free(state: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_state_get_tx(
+pub unsafe extern "C" fn rs_sip_state_get_tx(
     state: *mut std::os::raw::c_void,
     tx_id: u64,
 ) -> *mut std::os::raw::c_void {
@@ -194,13 +194,13 @@ pub extern "C" fn rs_sip_state_get_tx(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_state_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
+pub unsafe extern "C" fn rs_sip_state_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
     let state = cast_pointer!(state, SIPState);
     state.tx_id
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_state_tx_free(state: *mut std::os::raw::c_void, tx_id: u64) {
+pub unsafe extern "C" fn rs_sip_state_tx_free(state: *mut std::os::raw::c_void, tx_id: u64) {
     let state = cast_pointer!(state, SIPState);
     state.free_tx(tx_id);
 }
@@ -214,7 +214,7 @@ pub extern "C" fn rs_sip_tx_get_alstate_progress(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_state_set_tx_detect_state(
+pub unsafe extern "C" fn rs_sip_state_set_tx_detect_state(
     tx: *mut std::os::raw::c_void,
     de_state: &mut core::DetectEngineState,
 ) -> std::os::raw::c_int {
@@ -224,7 +224,7 @@ pub extern "C" fn rs_sip_state_set_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_state_get_tx_detect_state(
+pub unsafe extern "C" fn rs_sip_state_get_tx_detect_state(
     tx: *mut std::os::raw::c_void,
 ) -> *mut core::DetectEngineState {
     let tx = cast_pointer!(tx, SIPTransaction);
@@ -235,7 +235,7 @@ pub extern "C" fn rs_sip_state_get_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_state_get_events(
+pub unsafe extern "C" fn rs_sip_state_get_events(
     tx: *mut std::os::raw::c_void,
 ) -> *mut core::AppLayerDecoderEvents {
     let tx = cast_pointer!(tx, SIPTransaction);
@@ -243,7 +243,7 @@ pub extern "C" fn rs_sip_state_get_events(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_state_get_event_info(
+pub unsafe extern "C" fn rs_sip_state_get_event_info(
     event_name: *const std::os::raw::c_char,
     event_id: *mut std::os::raw::c_int,
     event_type: *mut core::AppLayerEventType,
@@ -251,7 +251,7 @@ pub extern "C" fn rs_sip_state_get_event_info(
     if event_name == std::ptr::null() {
         return -1;
     }
-    let c_event_name: &CStr = unsafe { CStr::from_ptr(event_name) };
+    let c_event_name: &CStr = CStr::from_ptr(event_name);
     let event = match c_event_name.to_str() {
         Ok(s) => {
             match s {
@@ -262,15 +262,13 @@ pub extern "C" fn rs_sip_state_get_event_info(
         }
         Err(_) => -1, // UTF-8 conversion failed
     };
-    unsafe {
-        *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
-        *event_id = event as std::os::raw::c_int;
-    };
+    *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
+    *event_id = event as std::os::raw::c_int;
     0
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_state_get_event_info_by_id(
+pub unsafe extern "C" fn rs_sip_state_get_event_info_by_id(
     event_id: std::os::raw::c_int,
     event_name: *mut *const std::os::raw::c_char,
     event_type: *mut core::AppLayerEventType,
@@ -280,10 +278,8 @@ pub extern "C" fn rs_sip_state_get_event_info_by_id(
             SIPEvent::IncompleteData => "incomplete_data\0",
             SIPEvent::InvalidData => "invalid_data\0",
         };
-        unsafe {
-            *event_name = estr.as_ptr() as *const std::os::raw::c_char;
-            *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
-        };
+        *event_name = estr.as_ptr() as *const std::os::raw::c_char;
+        *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
         0
     } else {
         -1
@@ -293,7 +289,7 @@ pub extern "C" fn rs_sip_state_get_event_info_by_id(
 static mut ALPROTO_SIP: AppProto = ALPROTO_UNKNOWN;
 
 #[no_mangle]
-pub extern "C" fn rs_sip_probing_parser_ts(
+pub unsafe extern "C" fn rs_sip_probing_parser_ts(
     _flow: *const Flow,
     _direction: u8,
     input: *const u8,
@@ -302,13 +298,13 @@ pub extern "C" fn rs_sip_probing_parser_ts(
 ) -> AppProto {
     let buf = build_slice!(input, input_len as usize);
     if sip_parse_request(buf).is_ok() {
-        return unsafe { ALPROTO_SIP };
+        return ALPROTO_SIP;
     }
     return ALPROTO_UNKNOWN;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_probing_parser_tc(
+pub unsafe extern "C" fn rs_sip_probing_parser_tc(
     _flow: *const Flow,
     _direction: u8,
     input: *const u8,
@@ -317,13 +313,13 @@ pub extern "C" fn rs_sip_probing_parser_tc(
 ) -> AppProto {
     let buf = build_slice!(input, input_len as usize);
     if sip_parse_response(buf).is_ok() {
-        return unsafe { ALPROTO_SIP };
+        return ALPROTO_SIP;
     }
     return ALPROTO_UNKNOWN;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_parse_request(
+pub unsafe extern "C" fn rs_sip_parse_request(
     _flow: *const core::Flow,
     state: *mut std::os::raw::c_void,
     _pstate: *mut std::os::raw::c_void,
@@ -338,7 +334,7 @@ pub extern "C" fn rs_sip_parse_request(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_parse_response(
+pub unsafe extern "C" fn rs_sip_parse_response(
     _flow: *const core::Flow,
     state: *mut std::os::raw::c_void,
     _pstate: *mut std::os::raw::c_void,

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -172,12 +172,12 @@ impl Drop for SIPTransaction {
 pub extern "C" fn rs_sip_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = SIPState::new();
     let boxed = Box::new(state);
-    return unsafe { std::mem::transmute(boxed) };
+    return Box::into_raw(boxed) as *mut _;
 }
 
 #[no_mangle]
 pub extern "C" fn rs_sip_state_free(state: *mut std::os::raw::c_void) {
-    let mut state: Box<SIPState> = unsafe { std::mem::transmute(state) };
+    let mut state = unsafe { Box::from_raw(state as *mut SIPState) };
     state.free();
 }
 
@@ -188,7 +188,7 @@ pub extern "C" fn rs_sip_state_get_tx(
 ) -> *mut std::os::raw::c_void {
     let state = cast_pointer!(state, SIPState);
     match state.get_tx_by_id(tx_id) {
-        Some(tx) => unsafe { std::mem::transmute(tx) },
+        Some(tx) => tx as *const _ as *mut _,
         None => std::ptr::null_mut(),
     }
 }

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -21,7 +21,7 @@ use crate::smb::smb::*;
 use crate::dcerpc::detect::{DCEIfaceData, DCEOpnumData, DETECT_DCE_OPNUM_RANGE_UNINITIALIZED};
 
 #[no_mangle]
-pub extern "C" fn rs_smb_tx_get_share(tx: &mut SMBTransaction,
+pub unsafe extern "C" fn rs_smb_tx_get_share(tx: &mut SMBTransaction,
                                             buffer: *mut *const u8,
                                             buffer_len: *mut u32)
                                             -> u8
@@ -30,26 +30,22 @@ pub extern "C" fn rs_smb_tx_get_share(tx: &mut SMBTransaction,
         Some(SMBTransactionTypeData::TREECONNECT(ref x)) => {
             SCLogDebug!("is_pipe {}", x.is_pipe);
             if !x.is_pipe {
-                unsafe {
-                    *buffer = x.share_name.as_ptr();
-                    *buffer_len = x.share_name.len() as u32;
-                    return 1;
-                }
+                *buffer = x.share_name.as_ptr();
+                *buffer_len = x.share_name.len() as u32;
+                return 1;
             }
         }
         _ => {
         }
     }
 
-    unsafe {
-        *buffer = ptr::null();
-        *buffer_len = 0;
-    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
     return 0;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_tx_get_named_pipe(tx: &mut SMBTransaction,
+pub unsafe extern "C" fn rs_smb_tx_get_named_pipe(tx: &mut SMBTransaction,
                                             buffer: *mut *const u8,
                                             buffer_len: *mut u32)
                                             -> u8
@@ -58,26 +54,22 @@ pub extern "C" fn rs_smb_tx_get_named_pipe(tx: &mut SMBTransaction,
         Some(SMBTransactionTypeData::TREECONNECT(ref x)) => {
             SCLogDebug!("is_pipe {}", x.is_pipe);
             if x.is_pipe {
-                unsafe {
-                    *buffer = x.share_name.as_ptr();
-                    *buffer_len = x.share_name.len() as u32;
-                    return 1;
-                }
+                *buffer = x.share_name.as_ptr();
+                *buffer_len = x.share_name.len() as u32;
+                return 1;
             }
         }
         _ => {
         }
     }
 
-    unsafe {
-        *buffer = ptr::null();
-        *buffer_len = 0;
-    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
     return 0;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_tx_get_stub_data(tx: &mut SMBTransaction,
+pub unsafe extern "C" fn rs_smb_tx_get_stub_data(tx: &mut SMBTransaction,
                                             direction: u8,
                                             buffer: *mut *const u8,
                                             buffer_len: *mut u32)
@@ -91,21 +83,17 @@ pub extern "C" fn rs_smb_tx_get_stub_data(tx: &mut SMBTransaction,
                 &x.stub_data_tc
             };
             if vref.len() > 0 {
-                unsafe {
-                    *buffer = vref.as_ptr();
-                    *buffer_len = vref.len() as u32;
-                    return 1;
-                }
+                *buffer = vref.as_ptr();
+                *buffer_len = vref.len() as u32;
+                return 1;
             }
         }
         _ => {
         }
     }
 
-    unsafe {
-        *buffer = ptr::null();
-        *buffer_len = 0;
-    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
     return 0;
 }
 

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -190,16 +190,16 @@ impl SMBState {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_getfiles(ptr: *mut std::ffi::c_void, direction: u8) -> * mut FileContainer {
+pub unsafe extern "C" fn rs_smb_getfiles(ptr: *mut std::ffi::c_void, direction: u8) -> * mut FileContainer {
     if ptr.is_null() { panic!("NULL ptr"); };
     let parser = cast_pointer!(ptr, SMBState);
     parser.getfiles(direction)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_setfileflags(direction: u8, ptr: *mut SMBState, flags: u16) {
+pub unsafe extern "C" fn rs_smb_setfileflags(direction: u8, ptr: *mut SMBState, flags: u16) {
     if ptr.is_null() { panic!("NULL ptr"); };
-    let parser = unsafe { &mut *ptr };
+    let parser = &mut *ptr;
     SCLogDebug!("direction {} flags {}", direction, flags);
     parser.setfileflags(direction, flags)
 }

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -26,7 +26,6 @@
 // written by Victor Julien
 
 use std;
-use std::mem::transmute;
 use std::str;
 use std::ffi::{self, CStr, CString};
 
@@ -1798,16 +1797,15 @@ pub extern "C" fn rs_smb_state_new(_orig_state: *mut std::os::raw::c_void, _orig
     let state = SMBState::new();
     let boxed = Box::new(state);
     SCLogDebug!("allocating state");
-    return unsafe{transmute(boxed)};
+    return Box::into_raw(boxed) as *mut _;
 }
 
 /// Params:
 /// - state: *mut SMBState as void pointer
 #[no_mangle]
 pub extern "C" fn rs_smb_state_free(state: *mut std::os::raw::c_void) {
-    // Just unbox...
     SCLogDebug!("freeing state");
-    let mut smb_state: Box<SMBState> = unsafe{transmute(state)};
+    let mut smb_state = unsafe { Box::from_raw(state as *mut SMBState) };
     smb_state.free();
 }
 
@@ -2021,7 +2019,7 @@ pub extern "C" fn rs_smb_state_get_tx(state: *mut ffi::c_void,
     let state = cast_pointer!(state, SMBState);
     match state.get_tx_by_id(tx_id) {
         Some(tx) => {
-            return unsafe{transmute(tx)};
+            return tx as *const _ as *mut _;
         }
         None => {
             return std::ptr::null_mut();
@@ -2043,7 +2041,7 @@ pub extern "C" fn rs_smb_state_get_tx_iterator(
     let state = cast_pointer!(state, SMBState);
     match state.get_tx_iterator(min_tx_id, istate) {
         Some((tx, out_tx_id, has_next)) => {
-            let c_tx = unsafe { transmute(tx) };
+            let c_tx = tx as *const _ as *mut _;
             let ires = applayer::AppLayerGetTxIterTuple::with_values(c_tx, out_tx_id, has_next);
             return ires;
         }

--- a/rust/src/snmp/detect.rs
+++ b/rust/src/snmp/detect.rs
@@ -20,43 +20,37 @@
 use crate::snmp::snmp::SNMPTransaction;
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_tx_get_version(tx: &mut SNMPTransaction,
+pub unsafe extern "C" fn rs_snmp_tx_get_version(tx: &mut SNMPTransaction,
                                          version: *mut u32)
 {
     debug_assert!(tx.version != 0, "SNMP version is 0");
-    unsafe {
-        *version = tx.version as u32;
-    }
+    *version = tx.version as u32;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_tx_get_community(tx: &mut SNMPTransaction,
+pub unsafe extern "C" fn rs_snmp_tx_get_community(tx: &mut SNMPTransaction,
                                            buf: *mut *const u8,
                                            len: *mut u32)
 {
     match tx.community {
         Some(ref c) => {
-            unsafe {
-                *buf = (&c).as_ptr();
-                *len = c.len() as u32;
-            }
+            *buf = (&c).as_ptr();
+            *len = c.len() as u32;
         },
         None        => ()
     }
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_tx_get_pdu_type(tx: &mut SNMPTransaction,
+pub unsafe extern "C" fn rs_snmp_tx_get_pdu_type(tx: &mut SNMPTransaction,
                                           pdu_type: *mut u32)
 {
-    unsafe {
-        match tx.info {
-            Some(ref info) => {
-                *pdu_type = info.pdu_type.0 as u32;
-            },
-            None           => {
-                *pdu_type = 0xffffffff;
-            }
+    match tx.info {
+        Some(ref info) => {
+            *pdu_type = info.pdu_type.0 as u32;
+        },
+        None           => {
+            *pdu_type = 0xffffffff;
         }
     }
 }

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -311,7 +311,7 @@ pub extern "C" fn rs_snmp_state_free(state: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_parse_request(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_snmp_parse_request(_flow: *const core::Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        input: *const u8,
@@ -324,7 +324,7 @@ pub extern "C" fn rs_snmp_parse_request(_flow: *const core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_parse_response(_flow: *const core::Flow,
+pub unsafe extern "C" fn rs_snmp_parse_response(_flow: *const core::Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        input: *const u8,
@@ -337,7 +337,7 @@ pub extern "C" fn rs_snmp_parse_response(_flow: *const core::Flow,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_state_get_tx(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_snmp_state_get_tx(state: *mut std::os::raw::c_void,
                                       tx_id: u64)
                                       -> *mut std::os::raw::c_void
 {
@@ -349,7 +349,7 @@ pub extern "C" fn rs_snmp_state_get_tx(state: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_state_get_tx_count(state: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_snmp_state_get_tx_count(state: *mut std::os::raw::c_void)
                                             -> u64
 {
     let state = cast_pointer!(state,SNMPState);
@@ -357,7 +357,7 @@ pub extern "C" fn rs_snmp_state_get_tx_count(state: *mut std::os::raw::c_void)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_state_tx_free(state: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_snmp_state_tx_free(state: *mut std::os::raw::c_void,
                                        tx_id: u64)
 {
     let state = cast_pointer!(state,SNMPState);
@@ -373,7 +373,7 @@ pub extern "C" fn rs_snmp_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_state_set_tx_detect_state(
+pub unsafe extern "C" fn rs_snmp_state_set_tx_detect_state(
     tx: *mut std::os::raw::c_void,
     de_state: &mut core::DetectEngineState) -> std::os::raw::c_int
 {
@@ -383,7 +383,7 @@ pub extern "C" fn rs_snmp_state_set_tx_detect_state(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_state_get_tx_detect_state(
+pub unsafe extern "C" fn rs_snmp_state_get_tx_detect_state(
     tx: *mut std::os::raw::c_void)
     -> *mut core::DetectEngineState
 {
@@ -396,7 +396,7 @@ pub extern "C" fn rs_snmp_state_get_tx_detect_state(
 
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_state_get_events(tx: *mut std::os::raw::c_void)
+pub unsafe extern "C" fn rs_snmp_state_get_events(tx: *mut std::os::raw::c_void)
                                            -> *mut core::AppLayerDecoderEvents
 {
     let tx = cast_pointer!(tx, SNMPTransaction);
@@ -404,7 +404,7 @@ pub extern "C" fn rs_snmp_state_get_events(tx: *mut std::os::raw::c_void)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_state_get_event_info_by_id(event_id: std::os::raw::c_int,
+pub unsafe extern "C" fn rs_snmp_state_get_event_info_by_id(event_id: std::os::raw::c_int,
                                                      event_name: *mut *const std::os::raw::c_char,
                                                      event_type: *mut core::AppLayerEventType)
                                                      -> i8
@@ -415,10 +415,8 @@ pub extern "C" fn rs_snmp_state_get_event_info_by_id(event_id: std::os::raw::c_i
             SNMPEvent::UnknownSecurityModel  => { "unknown_security_model\0" },
             SNMPEvent::VersionMismatch       => { "version_mismatch\0" },
         };
-        unsafe{
-            *event_name = estr.as_ptr() as *const std::os::raw::c_char;
-            *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
-        };
+        *event_name = estr.as_ptr() as *const std::os::raw::c_char;
+        *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
         0
     } else {
         -1
@@ -426,13 +424,13 @@ pub extern "C" fn rs_snmp_state_get_event_info_by_id(event_id: std::os::raw::c_i
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_state_get_event_info(event_name: *const std::os::raw::c_char,
+pub unsafe extern "C" fn rs_snmp_state_get_event_info(event_name: *const std::os::raw::c_char,
                                               event_id: *mut std::os::raw::c_int,
                                               event_type: *mut core::AppLayerEventType)
                                               -> std::os::raw::c_int
 {
     if event_name == std::ptr::null() { return -1; }
-    let c_event_name: &CStr = unsafe { CStr::from_ptr(event_name) };
+    let c_event_name: &CStr = CStr::from_ptr(event_name);
     let event = match c_event_name.to_str() {
         Ok(s) => {
             match s {
@@ -444,10 +442,8 @@ pub extern "C" fn rs_snmp_state_get_event_info(event_name: *const std::os::raw::
         },
         Err(_) => -1, // UTF-8 conversion failed
     };
-    unsafe{
-        *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
-        *event_id = event as std::os::raw::c_int;
-    };
+    *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
+    *event_id = event as std::os::raw::c_int;
     0
 }
 
@@ -473,7 +469,7 @@ pub extern "C" fn rs_snmp_state_get_tx_iterator(
 
 // for use with the C API call StateGetTxIterator
 #[no_mangle]
-pub extern "C" fn rs_snmp_get_tx_iterator(_ipproto: u8,
+pub unsafe extern "C" fn rs_snmp_get_tx_iterator(_ipproto: u8,
                                           _alproto: AppProto,
                                           alstate: *mut std::os::raw::c_void,
                                           min_tx_id: u64,
@@ -524,18 +520,18 @@ fn parse_pdu_enveloppe_version(i:&[u8]) -> IResult<&[u8],u32> {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_probing_parser(_flow: *const Flow,
+pub unsafe extern "C" fn rs_snmp_probing_parser(_flow: *const Flow,
                                          _direction: u8,
                                          input:*const u8,
                                          input_len: u32,
                                          _rdir: *mut u8) -> AppProto {
     let slice = build_slice!(input,input_len as usize);
-    let alproto = unsafe{ ALPROTO_SNMP };
-    if slice.len() < 4 { return unsafe{ALPROTO_FAILED}; }
+    let alproto = ALPROTO_SNMP;
+    if slice.len() < 4 { return ALPROTO_FAILED; }
     match parse_pdu_enveloppe_version(slice) {
         Ok((_,_))                    => alproto,
         Err(nom::Err::Incomplete(_)) => ALPROTO_UNKNOWN,
-        _                            => unsafe{ALPROTO_FAILED},
+        _                            => ALPROTO_FAILED,
     }
 }
 

--- a/rust/src/ssh/detect.rs
+++ b/rust/src/ssh/detect.rs
@@ -20,7 +20,7 @@ use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use std::ptr;
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_tx_get_protocol(
+pub unsafe extern "C" fn rs_ssh_tx_get_protocol(
     tx: *mut std::os::raw::c_void, buffer: *mut *const u8, buffer_len: *mut u32, direction: u8,
 ) -> u8 {
     let tx = cast_pointer!(tx, SSHTransaction);
@@ -28,35 +28,29 @@ pub extern "C" fn rs_ssh_tx_get_protocol(
         STREAM_TOSERVER => {
             let m = &tx.cli_hdr.protover;
             if m.len() > 0 {
-                unsafe {
-                    *buffer = m.as_ptr();
-                    *buffer_len = m.len() as u32;
-                }
+                *buffer = m.as_ptr();
+                *buffer_len = m.len() as u32;
                 return 1;
             }
         }
         STREAM_TOCLIENT => {
             let m = &tx.srv_hdr.protover;
             if m.len() > 0 {
-                unsafe {
-                    *buffer = m.as_ptr();
-                    *buffer_len = m.len() as u32;
-                }
+                *buffer = m.as_ptr();
+                *buffer_len = m.len() as u32;
                 return 1;
             }
         }
         _ => {}
     }
-    unsafe {
-        *buffer = ptr::null();
-        *buffer_len = 0;
-    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
 
     return 0;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_tx_get_software(
+pub unsafe extern "C" fn rs_ssh_tx_get_software(
     tx: *mut std::os::raw::c_void, buffer: *mut *const u8, buffer_len: *mut u32, direction: u8,
 ) -> u8 {
     let tx = cast_pointer!(tx, SSHTransaction);
@@ -64,35 +58,29 @@ pub extern "C" fn rs_ssh_tx_get_software(
         STREAM_TOSERVER => {
             let m = &tx.cli_hdr.swver;
             if m.len() > 0 {
-                unsafe {
-                    *buffer = m.as_ptr();
-                    *buffer_len = m.len() as u32;
-                }
+                *buffer = m.as_ptr();
+                *buffer_len = m.len() as u32;
                 return 1;
             }
         }
         STREAM_TOCLIENT => {
             let m = &tx.srv_hdr.swver;
             if m.len() > 0 {
-                unsafe {
-                    *buffer = m.as_ptr();
-                    *buffer_len = m.len() as u32;
-                }
+                *buffer = m.as_ptr();
+                *buffer_len = m.len() as u32;
                 return 1;
             }
         }
         _ => {}
     }
-    unsafe {
-        *buffer = ptr::null();
-        *buffer_len = 0;
-    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
 
     return 0;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_tx_get_hassh(
+pub unsafe extern "C" fn rs_ssh_tx_get_hassh(
     tx: *mut std::os::raw::c_void,
     buffer: *mut *const u8,
     buffer_len: *mut u32,
@@ -103,35 +91,29 @@ pub extern "C" fn rs_ssh_tx_get_hassh(
         STREAM_TOSERVER => {
             let m = &tx.cli_hdr.hassh;
             if m.len() > 0 {
-                unsafe {
-                    *buffer = m.as_ptr();
-                    *buffer_len = m.len() as u32;
-                }
+                *buffer = m.as_ptr();
+                *buffer_len = m.len() as u32;
                 return 1;
             }
         }
         STREAM_TOCLIENT => {
             let m = &tx.srv_hdr.hassh;
             if m.len() > 0 {
-                unsafe {
-                    *buffer = m.as_ptr();
-                    *buffer_len = m.len() as u32;
-                }
+                *buffer = m.as_ptr();
+                *buffer_len = m.len() as u32;
                 return 1;
             }
         }
         _ => {}
     }
-    unsafe {
-        *buffer = ptr::null();
-        *buffer_len = 0;
-    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
 
     return 0;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_tx_get_hassh_string(
+pub unsafe extern "C" fn rs_ssh_tx_get_hassh_string(
     tx: *mut std::os::raw::c_void,
     buffer: *mut *const u8,
     buffer_len: *mut u32,
@@ -142,29 +124,23 @@ pub extern "C" fn rs_ssh_tx_get_hassh_string(
         STREAM_TOSERVER => {
             let m = &tx.cli_hdr.hassh_string;
             if m.len() > 0 {
-                unsafe {
-                    *buffer = m.as_ptr();
-                    *buffer_len = m.len() as u32;
-                }
+                *buffer = m.as_ptr();
+                *buffer_len = m.len() as u32;
                 return 1;
             }
         }
         STREAM_TOCLIENT => {
             let m = &tx.srv_hdr.hassh_string;
             if m.len() > 0 {
-                unsafe {
-                    *buffer = m.as_ptr();
-                    *buffer_len = m.len() as u32;
-                }
+                *buffer = m.as_ptr();
+                *buffer_len = m.len() as u32;
                 return 1;
             }
         }
         _ => {}
     }
-    unsafe {
-        *buffer = ptr::null();
-        *buffer_len = 0;
-    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
 
     return 0;
 }

--- a/rust/src/ssh/logger.rs
+++ b/rust/src/ssh/logger.rs
@@ -62,7 +62,7 @@ fn log_ssh(tx: &SSHTransaction, js: &mut JsonBuilder) -> Result<bool, JsonError>
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_log_json(tx: *mut std::os::raw::c_void, js: &mut JsonBuilder) -> bool {
+pub unsafe extern "C" fn rs_ssh_log_json(tx: *mut std::os::raw::c_void, js: &mut JsonBuilder) -> bool {
     let tx = cast_pointer!(tx, SSHTransaction);
     if let Ok(x) = log_ssh(tx, js) {
         return x;

--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -369,7 +369,7 @@ export_tx_set_detect_state!(rs_ssh_tx_set_detect_state, SSHTransaction);
 export_tx_data_get!(rs_ssh_get_tx_data, SSHTransaction);
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_state_get_events(
+pub unsafe extern "C" fn rs_ssh_state_get_events(
     tx: *mut std::os::raw::c_void,
 ) -> *mut core::AppLayerDecoderEvents {
     let tx = cast_pointer!(tx, SSHTransaction);
@@ -377,14 +377,14 @@ pub extern "C" fn rs_ssh_state_get_events(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_state_get_event_info(
+pub unsafe extern "C" fn rs_ssh_state_get_event_info(
     event_name: *const std::os::raw::c_char, event_id: *mut std::os::raw::c_int,
     event_type: *mut core::AppLayerEventType,
 ) -> std::os::raw::c_int {
     if event_name == std::ptr::null() {
         return -1;
     }
-    let c_event_name: &CStr = unsafe { CStr::from_ptr(event_name) };
+    let c_event_name: &CStr = CStr::from_ptr(event_name);
     let event = match c_event_name.to_str() {
         Ok(s) => {
             match s {
@@ -397,15 +397,13 @@ pub extern "C" fn rs_ssh_state_get_event_info(
         }
         Err(_) => -1, // UTF-8 conversion failed
     };
-    unsafe {
-        *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
-        *event_id = event as std::os::raw::c_int;
-    };
+    *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
+    *event_id = event as std::os::raw::c_int;
     0
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_state_get_event_info_by_id(
+pub unsafe extern "C" fn rs_ssh_state_get_event_info_by_id(
     event_id: std::os::raw::c_int, event_name: *mut *const std::os::raw::c_char,
     event_type: *mut core::AppLayerEventType,
 ) -> i8 {
@@ -416,10 +414,8 @@ pub extern "C" fn rs_ssh_state_get_event_info_by_id(
             SSHEvent::InvalidRecord => "invalid_record\0",
             SSHEvent::LongKexRecord => "long_kex_record\0",
         };
-        unsafe {
-            *event_name = estr.as_ptr() as *const std::os::raw::c_char;
-            *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
-        };
+        *event_name = estr.as_ptr() as *const std::os::raw::c_char;
+        *event_type = core::APP_LAYER_EVENT_TYPE_TRANSACTION;
         0
     } else {
         -1
@@ -434,8 +430,8 @@ pub extern "C" fn rs_ssh_state_new(_orig_state: *mut std::os::raw::c_void, _orig
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_state_free(state: *mut std::os::raw::c_void) {
-    std::mem::drop(unsafe { Box::from_raw(state as *mut SSHState) });
+pub unsafe extern "C" fn rs_ssh_state_free(state: *mut std::os::raw::c_void) {
+    std::mem::drop(Box::from_raw(state as *mut SSHState));
 }
 
 #[no_mangle]
@@ -444,7 +440,7 @@ pub extern "C" fn rs_ssh_state_tx_free(_state: *mut std::os::raw::c_void, _tx_id
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_parse_request(
+pub unsafe extern "C" fn rs_ssh_parse_request(
     _flow: *const Flow, state: *mut std::os::raw::c_void, pstate: *mut std::os::raw::c_void,
     input: *const u8, input_len: u32, _data: *const std::os::raw::c_void, _flags: u8,
 ) -> AppLayerResult {
@@ -459,7 +455,7 @@ pub extern "C" fn rs_ssh_parse_request(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_parse_response(
+pub unsafe extern "C" fn rs_ssh_parse_response(
     _flow: *const Flow, state: *mut std::os::raw::c_void, pstate: *mut std::os::raw::c_void,
     input: *const u8, input_len: u32, _data: *const std::os::raw::c_void, _flags: u8,
 ) -> AppLayerResult {
@@ -474,7 +470,7 @@ pub extern "C" fn rs_ssh_parse_response(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_state_get_tx(
+pub unsafe extern "C" fn rs_ssh_state_get_tx(
     state: *mut std::os::raw::c_void, _tx_id: u64,
 ) -> *mut std::os::raw::c_void {
     let state = cast_pointer!(state, SSHState);
@@ -487,7 +483,7 @@ pub extern "C" fn rs_ssh_state_get_tx_count(_state: *mut std::os::raw::c_void) -
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_tx_get_flags(
+pub unsafe extern "C" fn rs_ssh_tx_get_flags(
     tx: *mut std::os::raw::c_void, direction: u8,
 ) -> SSHConnectionState {
     let tx = cast_pointer!(tx, SSHTransaction);
@@ -499,7 +495,7 @@ pub extern "C" fn rs_ssh_tx_get_flags(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_tx_get_alstate_progress(
+pub unsafe extern "C" fn rs_ssh_tx_get_alstate_progress(
     tx: *mut std::os::raw::c_void, direction: u8,
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, SSHTransaction);
@@ -588,7 +584,7 @@ pub extern "C" fn rs_ssh_hassh_is_enabled() -> bool {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ssh_tx_get_log_condition( tx: *mut std::os::raw::c_void) -> bool {
+pub unsafe extern "C" fn rs_ssh_tx_get_log_condition( tx: *mut std::os::raw::c_void) -> bool {
     let tx = cast_pointer!(tx, SSHTransaction);
     
     if rs_ssh_hassh_is_enabled() {

--- a/rust/src/tftp/tftp.rs
+++ b/rust/src/tftp/tftp.rs
@@ -21,7 +21,6 @@ extern crate nom;
 
 use std::str;
 use std;
-use std::mem::transmute;
 use nom::*;
 
 use crate::applayer::AppLayerTxData;
@@ -89,12 +88,12 @@ impl TFTPTransaction {
 pub extern "C" fn rs_tftp_state_alloc() -> *mut std::os::raw::c_void {
     let state = TFTPState { transactions : Vec::new(), tx_id: 0, };
     let boxed = Box::new(state);
-    return unsafe{transmute(boxed)};
+    return Box::into_raw(boxed) as *mut _;
 }
 
 #[no_mangle]
 pub extern "C" fn rs_tftp_state_free(state: *mut std::os::raw::c_void) {
-    let _state : Box<TFTPState> = unsafe{transmute(state)};
+    std::mem::drop(unsafe { Box::from_raw(state as *mut TFTPState) });
 }
 
 #[no_mangle]
@@ -107,7 +106,7 @@ pub extern "C" fn rs_tftp_state_tx_free(state: &mut TFTPState,
 pub extern "C" fn rs_tftp_get_tx(state: &mut TFTPState,
                                     tx_id: u64) -> *mut std::os::raw::c_void {
     match state.get_tx_by_id(tx_id) {
-        Some(tx) => unsafe{std::mem::transmute(tx)},
+        Some(tx) => tx as *const _ as *mut _,
         None     => std::ptr::null_mut(),
     }
 }

--- a/rust/src/tftp/tftp.rs
+++ b/rust/src/tftp/tftp.rs
@@ -153,10 +153,10 @@ fn parse_tftp_request(input: &[u8]) -> Option<TFTPTransaction> {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_request(state: &mut TFTPState,
+pub unsafe extern "C" fn rs_tftp_request(state: &mut TFTPState,
                                   input: *const u8,
                                   len: u32) -> i64 {
-    let buf = unsafe{std::slice::from_raw_parts(input, len as usize)};
+    let buf = std::slice::from_raw_parts(input, len as usize);
     match parse_tftp_request(buf) {
         Some(mut tx) => {
             state.tx_id += 1;
@@ -171,7 +171,7 @@ pub extern "C" fn rs_tftp_request(state: &mut TFTPState,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_get_tx_data(
+pub unsafe extern "C" fn rs_tftp_get_tx_data(
     tx: *mut std::os::raw::c_void)
     -> *mut AppLayerTxData
 {

--- a/rust/src/x509/mod.rs
+++ b/rust/src/x509/mod.rs
@@ -66,7 +66,7 @@ pub unsafe extern "C" fn rs_x509_decode(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_x509_get_subject(ptr: *const X509) -> *mut c_char {
+pub unsafe extern "C" fn rs_x509_get_subject(ptr: *const X509) -> *mut c_char {
     if ptr.is_null() {
         return std::ptr::null_mut();
     }
@@ -76,7 +76,7 @@ pub extern "C" fn rs_x509_get_subject(ptr: *const X509) -> *mut c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_x509_get_issuer(ptr: *const X509) -> *mut c_char {
+pub unsafe extern "C" fn rs_x509_get_issuer(ptr: *const X509) -> *mut c_char {
     if ptr.is_null() {
         return std::ptr::null_mut();
     }
@@ -86,7 +86,7 @@ pub extern "C" fn rs_x509_get_issuer(ptr: *const X509) -> *mut c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_x509_get_serial(ptr: *const X509) -> *mut c_char {
+pub unsafe extern "C" fn rs_x509_get_serial(ptr: *const X509) -> *mut c_char {
     if ptr.is_null() {
         return std::ptr::null_mut();
     }


### PR DESCRIPTION
Previous PR: #6280

The first commits remove all usages of transmute. Every usage of
it in our code can be replaced by a cast, or Box::into_raw and
Box::from_raw.

Next, mark all functions that dereference a raw pointer as unsafe,
this means most extern "C" functions that take a pointer from C.

Reference: https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

And some discussion in PR #4666.
