### PR TITLE
ipv6: decoder event on invalid length

### DIFF
--- a/rules/decoder-events.rules
+++ b/rules/decoder-events.rules
@@ -106,6 +106,7 @@ alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv4 Packet size too large";
 alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv4 Fragmentation overlap"; decode-event:ipv4.frag_overlap; classtype:protocol-command-decode; sid:2200070; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv6 Packet size too large"; decode-event:ipv6.frag_pkt_too_large; classtype:protocol-command-decode; sid:2200071; rev:3;)
 alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv6 Fragmentation overlap"; decode-event:ipv6.frag_overlap; classtype:protocol-command-decode; sid:2200072; rev:2;)
+alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv6 Fragment invalid length"; decode-event:ipv6.frag_invalid_length; classtype:protocol-command-decode; sid:2200119; rev:1;)
 
 # checksum rules
 alert ip any any -> any any (msg:"SURICATA IPv4 invalid checksum"; ipv4-csum:invalid; classtype:protocol-command-decode; sid:2200073; rev:2;)
@@ -149,5 +150,5 @@ alert pkthdr any any -> any any (msg:"SURICATA CHDLC packet too small"; decode-e
 
 alert pkthdr any any -> any any (msg:"SURICATA packet with too many layers"; decode-event:too_many_layers; classtype:protocol-command-decode; sid:2200116; rev:1;)
 
-# next sid is 2200119
+# next sid is 2200120
 

--- a/src/decode-events.c
+++ b/src/decode-events.c
@@ -458,6 +458,10 @@ const struct DecodeEvents_ DEvents[] = {
             "decoder.ipv6.frag_overlap",
             IPV6_FRAG_OVERLAP,
     },
+    {
+            "decoder.ipv6.frag_invalid_length",
+            IPV6_FRAG_INVALID_LENGTH,
+    },
     /* Fragment ignored due to internal error */
     {
             "decoder.ipv4.frag_ignored",

--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -169,6 +169,7 @@ enum {
     IPV6_FRAG_PKT_TOO_LARGE,
     IPV4_FRAG_OVERLAP,
     IPV6_FRAG_OVERLAP,
+    IPV6_FRAG_INVALID_LENGTH,
 
     /* Fragment ignored due to internal error */
     IPV4_FRAG_IGNORED,

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -453,6 +453,12 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                     plen -= hdrextlen;
                     break;
                 }
+                if (p->ip6eh.fh_more_frags_set != 0 && plen % 8 != 0) {
+                    // cf https://datatracker.ietf.org/doc/html/rfc2460#section-4.5
+                    // each, except possibly the last ("rightmost") one,
+                    // being an integer multiple of 8 octets long.
+                    ENGINE_SET_EVENT(p, IPV6_FRAG_INVALID_LENGTH);
+                }
 
                 /* the rest is parsed upon reassembly */
                 p->flags |= PKT_IS_FRAGMENT;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3323

Describe changes:
- Adds a decoder event when an IPv6 fragment has an invalid length according to the RFC

suricata-verify-pr: 519
https://github.com/OISF/suricata-verify/pull/519

Modifies #6271 with mode readability