### PR TITLE
detect: debug validation for list ids overflows

### DIFF
--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -115,6 +115,7 @@ void DetectAppLayerMpmRegister2(const char *name,
     am->name = name;
     snprintf(am->pname, sizeof(am->pname), "%s", am->name);
     am->direction = direction;
+    DEBUG_VALIDATE_BUG_ON(sm_list < 0 || sm_list > INT16_MAX);
     am->sm_list = sm_list;
     am->sm_list_base = sm_list;
     am->priority = priority;
@@ -155,6 +156,7 @@ void DetectAppLayerMpmRegisterByParentId(DetectEngineCtx *de_ctx,
             BUG_ON(am == NULL);
             am->name = t->name;
             am->direction = t->direction;
+            DEBUG_VALIDATE_BUG_ON(id < 0 || id > INT16_MAX);
             am->sm_list = id; // use new id
             am->sm_list_base = t->sm_list;
             am->type = DETECT_BUFFER_MPM_TYPE_APP;
@@ -314,6 +316,7 @@ void DetectPktMpmRegister(const char *name,
     BUG_ON(am == NULL);
     am->name = name;
     snprintf(am->pname, sizeof(am->pname), "%s", am->name);
+    DEBUG_VALIDATE_BUG_ON(sm_list < 0 || sm_list > INT16_MAX);
     am->sm_list = sm_list;
     am->priority = priority;
     am->type = DETECT_BUFFER_MPM_TYPE_PKT;
@@ -351,6 +354,7 @@ void DetectPktMpmRegisterByParentId(DetectEngineCtx *de_ctx,
             BUG_ON(am == NULL);
             am->name = t->name;
             snprintf(am->pname, sizeof(am->pname), "%s#%d", am->name, id);
+            DEBUG_VALIDATE_BUG_ON(id < 0 || id > INT16_MAX);
             am->sm_list = id; // use new id
             am->sm_list_base = t->sm_list;
             am->type = DETECT_BUFFER_MPM_TYPE_PKT;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4403

Describe changes:
- Adds debug validation for list id integer overflow

https://github.com/OISF/suricata/pull/5932/commits/975062cf401f79c00abf728d923c65aabd143af2#diff-99eda33658bd0778da7bf89acbb4e7bbdb9ce82b0ab93486e1643691925f4091L600 has changed `sm_list` from `int` to `int16_t`
But there are no checks against integer overflow on this shorter integer