### PR TITLE
Detect analyze/v25

### DIFF
--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -123,4 +123,6 @@ void DetectContentFree(DetectEngineCtx *, void *);
 bool DetectContentPMATCHValidateCallback(const Signature *s);
 void DetectContentPropagateLimits(Signature *s);
 
+void DetectContentPatternPrettyPrint(const DetectContentData *cd, char *str, size_t str_len);
+
 #endif /* __DETECT_CONTENT_H__ */

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -463,6 +463,7 @@ void SigParseApplyDsizeToContent(Signature *s)
             }
 
             if (cd->depth == 0 || cd->depth >= dsize) {
+                cd->flags |= DETECT_CONTENT_DEPTH;
                 cd->depth = (uint16_t)dsize;
                 SCLogDebug("updated %u, content %u to have depth %u "
                         "because of dsize.", s->id, cd->id, cd->depth);

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -610,7 +610,10 @@ static bool LooksLikeHTTPUA(const uint8_t *buf, uint16_t len)
 
 static void DumpContent(JsonBuilder *js, const DetectContentData *cd)
 {
-    jb_set_string_from_bytes(js, "pattern", cd->content, cd->content_len);
+    char pattern_str[1024] = "";
+    DetectContentPatternPrettyPrint(cd, pattern_str, sizeof(pattern_str));
+
+    jb_set_string(js, "pattern", pattern_str);
     jb_set_uint(js, "length", cd->content_len);
     jb_set_bool(js, "nocase", cd->flags & DETECT_CONTENT_NOCASE);
     jb_set_bool(js, "negated", cd->flags & DETECT_CONTENT_NEGATED);

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -677,10 +677,14 @@ static void DumpMatches(RuleAnalyzer *ctx, JsonBuilder *js, const SigMatchData *
     jb_close(js);
 }
 
+static void EngineAnalysisRulePatterns(const DetectEngineCtx *de_ctx, const Signature *s);
+
 SCMutex g_rules_analyzer_write_m = SCMUTEX_INITIALIZER;
 void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
 {
     SCEnter();
+
+    EngineAnalysisRulePatterns(de_ctx, s);
 
     RuleAnalyzer ctx = { NULL, NULL, NULL };
 
@@ -953,6 +957,328 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
     }
     SCMutexUnlock(&g_rules_analyzer_write_m);
     jb_free(ctx.js);
+    SCReturn;
+}
+
+struct PatternItem {
+    const DetectContentData *cd;
+    int sm_list;
+    uint32_t cnt;
+    uint32_t mpm;
+};
+
+static inline uint32_t ContentFlagsForHash(const DetectContentData *cd)
+{
+    return cd->flags & (DETECT_CONTENT_NOCASE | DETECT_CONTENT_OFFSET | DETECT_CONTENT_DEPTH |
+                               DETECT_CONTENT_NEGATED | DETECT_CONTENT_ENDS_WITH);
+}
+
+/** \internal
+ *  \brief The hash function for Pattern
+ *
+ *  \param ht      Pointer to the hash table.
+ *  \param data    Pointer to the Pattern.
+ *  \param datalen Not used in our case.
+ *
+ *  \retval hash The generated hash value.
+ */
+static uint32_t PatternHashFunc(HashListTable *ht, void *data, uint16_t datalen)
+{
+    struct PatternItem *p = (struct PatternItem *)data;
+    uint32_t hash = p->sm_list + ContentFlagsForHash(p->cd);
+
+    for (uint32_t b = 0; b < p->cd->content_len; b++)
+        hash += p->cd->content[b];
+
+    return hash % ht->array_size;
+}
+
+/**
+ * \brief The Compare function for Pattern
+ *
+ * \param data1 Pointer to the first Pattern.
+ * \param len1  Not used.
+ * \param data2 Pointer to the second Pattern.
+ * \param len2  Not used.
+ *
+ * \retval 1 If the 2 Patterns sent as args match.
+ * \retval 0 If the 2 Patterns sent as args do not match.
+ */
+static char PatternCompareFunc(void *data1, uint16_t len1, void *data2, uint16_t len2)
+{
+    const struct PatternItem *p1 = (struct PatternItem *)data1;
+    const struct PatternItem *p2 = (struct PatternItem *)data2;
+
+    if (p1->sm_list != p2->sm_list)
+        return 0;
+
+    if (ContentFlagsForHash(p1->cd) != ContentFlagsForHash(p2->cd))
+        return 0;
+
+    if (p1->cd->content_len != p2->cd->content_len)
+        return 0;
+
+    if (memcmp(p1->cd->content, p2->cd->content, p1->cd->content_len) != 0) {
+        return 0;
+    }
+
+    return 1;
+}
+
+static void PatternFreeFunc(void *ptr)
+{
+    SCFree(ptr);
+}
+
+/**
+ * \brief Initializes the Pattern mpm hash table to be used by the detection
+ *        engine context.
+ *
+ * \param de_ctx Pointer to the detection engine context.
+ *
+ * \retval  0 On success.
+ * \retval -1 On failure.
+ */
+static int PatternInit(DetectEngineCtx *de_ctx)
+{
+    de_ctx->pattern_hash_table =
+            HashListTableInit(4096, PatternHashFunc, PatternCompareFunc, PatternFreeFunc);
+    if (de_ctx->pattern_hash_table == NULL)
+        goto error;
+
+    return 0;
+
+error:
+    return -1;
+}
+
+static inline bool NeedsAsHex(uint8_t c)
+{
+    if (!isprint(c))
+        return true;
+
+    switch (c) {
+        case '/':
+        case ';':
+        case ':':
+        case '\\':
+        case ' ':
+        case '|':
+        case '"':
+        case '`':
+        case '\'':
+            return true;
+    }
+    return false;
+}
+
+static void PatternPrettyPrint(const DetectContentData *cd, char *str, size_t str_len)
+{
+    bool hex = false;
+    for (uint16_t i = 0; i < cd->content_len; i++) {
+        if (NeedsAsHex(cd->content[i])) {
+            char hex_str[4];
+            snprintf(hex_str, sizeof(hex_str), "%s%02X", !hex ? "|" : " ", cd->content[i]);
+            strlcat(str, hex_str, str_len);
+            hex = true;
+        } else {
+            char p_str[3];
+            snprintf(p_str, sizeof(p_str), "%s%c", hex ? "|" : "", cd->content[i]);
+            strlcat(str, p_str, str_len);
+            hex = false;
+        }
+    }
+    if (hex) {
+        strlcat(str, "|", str_len);
+    }
+}
+
+void DumpPatterns(DetectEngineCtx *de_ctx)
+{
+    if (de_ctx->buffer_type_map_elements == 0 || de_ctx->pattern_hash_table == NULL)
+        return;
+
+    JsonBuilder *root_jb = jb_new_object();
+    JsonBuilder *arrays[de_ctx->buffer_type_map_elements];
+    memset(&arrays, 0, sizeof(JsonBuilder *) * de_ctx->buffer_type_map_elements);
+
+    jb_open_array(root_jb, "buffers");
+
+    for (HashListTableBucket *htb = HashListTableGetListHead(de_ctx->pattern_hash_table);
+            htb != NULL; htb = HashListTableGetListNext(htb)) {
+        char str[1024] = "";
+        struct PatternItem *p = HashListTableGetListData(htb);
+        PatternPrettyPrint(p->cd, str, sizeof(str));
+
+        JsonBuilder *jb = arrays[p->sm_list];
+        if (arrays[p->sm_list] == NULL) {
+            jb = arrays[p->sm_list] = jb_new_object();
+            const char *name;
+            if (p->sm_list < DETECT_SM_LIST_DYNAMIC_START)
+                name = DetectListToHumanString(p->sm_list);
+            else
+                name = DetectBufferTypeGetNameById(de_ctx, p->sm_list);
+            jb_set_string(jb, "name", name);
+            jb_set_uint(jb, "list_id", p->sm_list);
+
+            jb_open_array(jb, "patterns");
+        }
+
+        jb_start_object(jb);
+        jb_set_string(jb, "pattern", str);
+        jb_set_uint(jb, "patlen", p->cd->content_len);
+        jb_set_uint(jb, "cnt", p->cnt);
+        jb_set_uint(jb, "mpm", p->mpm);
+        jb_open_object(jb, "flags");
+        jb_set_bool(jb, "nocase", p->cd->flags & DETECT_CONTENT_NOCASE);
+        jb_set_bool(jb, "negated", p->cd->flags & DETECT_CONTENT_NEGATED);
+        jb_set_bool(jb, "depth", p->cd->flags & DETECT_CONTENT_DEPTH);
+        jb_set_bool(jb, "offset", p->cd->flags & DETECT_CONTENT_OFFSET);
+        jb_set_bool(jb, "endswith", p->cd->flags & DETECT_CONTENT_ENDS_WITH);
+        jb_close(jb);
+        jb_close(jb);
+    }
+
+    for (uint32_t i = 0; i < de_ctx->buffer_type_map_elements; i++) {
+        JsonBuilder *jb = arrays[i];
+        if (jb == NULL)
+            continue;
+
+        jb_close(jb); // array
+        jb_close(jb); // object
+
+        jb_append_object(root_jb, jb);
+        jb_free(jb);
+    }
+    jb_close(root_jb);
+    jb_close(root_jb);
+
+    const char *filename = "patterns.json";
+    const char *log_dir = ConfigGetLogDirectory();
+    char json_path[PATH_MAX] = "";
+    snprintf(json_path, sizeof(json_path), "%s/%s", log_dir, filename);
+
+    SCMutexLock(&g_rules_analyzer_write_m);
+    FILE *fp = fopen(json_path, "a");
+    if (fp != NULL) {
+        fwrite(jb_ptr(root_jb), jb_len(root_jb), 1, fp);
+        fprintf(fp, "\n");
+        fclose(fp);
+    }
+    SCMutexUnlock(&g_rules_analyzer_write_m);
+    jb_free(root_jb);
+
+    HashListTableFree(de_ctx->pattern_hash_table);
+    de_ctx->pattern_hash_table = NULL;
+}
+
+static void EngineAnalysisRulePatterns(const DetectEngineCtx *de_ctx, const Signature *s)
+{
+    SCEnter();
+
+    if (de_ctx->pattern_hash_table == NULL)
+        PatternInit((DetectEngineCtx *)de_ctx); // TODO hack const
+
+    if (s->sm_arrays[DETECT_SM_LIST_PMATCH]) {
+        SigMatchData *smd = s->sm_arrays[DETECT_SM_LIST_PMATCH];
+        do {
+            switch (smd->type) {
+                case DETECT_CONTENT: {
+                    const DetectContentData *cd = (const DetectContentData *)smd->ctx;
+                    struct PatternItem lookup = {
+                        .cd = cd, .sm_list = DETECT_SM_LIST_PMATCH, .cnt = 0, .mpm = 0
+                    };
+                    struct PatternItem *res =
+                            HashListTableLookup(de_ctx->pattern_hash_table, &lookup, 0);
+                    if (res) {
+                        res->cnt++;
+                        res->mpm += ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                    } else {
+                        struct PatternItem *add = SCCalloc(1, sizeof(*add));
+                        add->cd = cd;
+                        add->sm_list = DETECT_SM_LIST_PMATCH;
+                        add->cnt = 1;
+                        add->mpm = ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                        HashListTableAdd(de_ctx->pattern_hash_table, (void *)add, 0);
+                    }
+                    break;
+                }
+            }
+            if (smd->is_last)
+                break;
+            smd++;
+        } while (1);
+    }
+
+    const DetectEngineAppInspectionEngine *app = s->app_inspect;
+    for (; app != NULL; app = app->next) {
+        SigMatchData *smd = app->smd;
+        do {
+            switch (smd->type) {
+                case DETECT_CONTENT: {
+                    const DetectContentData *cd = (const DetectContentData *)smd->ctx;
+
+                    struct PatternItem lookup = {
+                        .cd = cd, .sm_list = app->sm_list, .cnt = 0, .mpm = 0
+                    };
+                    struct PatternItem *res =
+                            HashListTableLookup(de_ctx->pattern_hash_table, &lookup, 0);
+                    if (res) {
+                        res->cnt++;
+                        res->mpm += ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                    } else {
+                        struct PatternItem *add = SCCalloc(1, sizeof(*add));
+                        add->cd = cd;
+                        add->sm_list = app->sm_list;
+                        add->cnt = 1;
+                        add->mpm = ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                        HashListTableAdd(de_ctx->pattern_hash_table, (void *)add, 0);
+                    }
+                    break;
+                }
+            }
+            if (smd->is_last)
+                break;
+            smd++;
+        } while (1);
+    }
+    const DetectEnginePktInspectionEngine *pkt = s->pkt_inspect;
+    for (; pkt != NULL; pkt = pkt->next) {
+        SigMatchData *smd = pkt->smd;
+        do {
+            if (smd == NULL) {
+                BUG_ON(!(pkt->sm_list < DETECT_SM_LIST_DYNAMIC_START));
+                smd = s->sm_arrays[pkt->sm_list];
+            }
+            switch (smd->type) {
+                case DETECT_CONTENT: {
+                    const DetectContentData *cd = (const DetectContentData *)smd->ctx;
+
+                    struct PatternItem lookup = {
+                        .cd = cd, .sm_list = pkt->sm_list, .cnt = 0, .mpm = 0
+                    };
+                    struct PatternItem *res =
+                            HashListTableLookup(de_ctx->pattern_hash_table, &lookup, 0);
+                    if (res) {
+                        res->cnt++;
+                        res->mpm += ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                    } else {
+                        struct PatternItem *add = SCCalloc(1, sizeof(*add));
+                        add->cd = cd;
+                        add->sm_list = pkt->sm_list;
+                        add->cnt = 1;
+                        add->mpm = ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                        HashListTableAdd(de_ctx->pattern_hash_table, (void *)add, 0);
+                    }
+                    break;
+                }
+            }
+            if (smd->is_last)
+                break;
+            smd++;
+        } while (1);
+    }
+
     SCReturn;
 }
 

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1052,47 +1052,6 @@ error:
     return -1;
 }
 
-static inline bool NeedsAsHex(uint8_t c)
-{
-    if (!isprint(c))
-        return true;
-
-    switch (c) {
-        case '/':
-        case ';':
-        case ':':
-        case '\\':
-        case ' ':
-        case '|':
-        case '"':
-        case '`':
-        case '\'':
-            return true;
-    }
-    return false;
-}
-
-static void PatternPrettyPrint(const DetectContentData *cd, char *str, size_t str_len)
-{
-    bool hex = false;
-    for (uint16_t i = 0; i < cd->content_len; i++) {
-        if (NeedsAsHex(cd->content[i])) {
-            char hex_str[4];
-            snprintf(hex_str, sizeof(hex_str), "%s%02X", !hex ? "|" : " ", cd->content[i]);
-            strlcat(str, hex_str, str_len);
-            hex = true;
-        } else {
-            char p_str[3];
-            snprintf(p_str, sizeof(p_str), "%s%c", hex ? "|" : "", cd->content[i]);
-            strlcat(str, p_str, str_len);
-            hex = false;
-        }
-    }
-    if (hex) {
-        strlcat(str, "|", str_len);
-    }
-}
-
 void DumpPatterns(DetectEngineCtx *de_ctx)
 {
     if (de_ctx->buffer_type_map_elements == 0 || de_ctx->pattern_hash_table == NULL)
@@ -1108,7 +1067,7 @@ void DumpPatterns(DetectEngineCtx *de_ctx)
             htb != NULL; htb = HashListTableGetListNext(htb)) {
         char str[1024] = "";
         struct PatternItem *p = HashListTableGetListData(htb);
-        PatternPrettyPrint(p->cd, str, sizeof(str));
+        DetectContentPatternPrettyPrint(p->cd, str, sizeof(str));
 
         JsonBuilder *jb = arrays[p->sm_list];
         if (arrays[p->sm_list] == NULL) {

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -911,6 +911,18 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
             smd++;
         } while (1);
         jb_close(ctx.js);
+    } else if (s->init_data->prefilter_sm) {
+        jb_open_object(ctx.js, "prefilter");
+        int prefilter_list = SigMatchListSMBelongsTo(s, s->init_data->prefilter_sm);
+        const char *name;
+        if (prefilter_list < DETECT_SM_LIST_DYNAMIC_START)
+            name = DetectListToHumanString(prefilter_list);
+        else
+            name = DetectBufferTypeGetNameById(de_ctx, prefilter_list);
+        jb_set_string(ctx.js, "buffer", name);
+        const char *mname = sigmatch_table[s->init_data->prefilter_sm->type].name;
+        jb_set_string(ctx.js, "name", mname);
+        jb_close(ctx.js);
     }
 
     if (ctx.js_warnings) {

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -624,6 +624,8 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
     uint32_t prefilter_cnt = 0;
     uint32_t mpm_cnt = 0;
     uint32_t nonmpm_cnt = 0;
+    uint32_t mpm_depth_cnt = 0;
+    uint32_t mpm_endswith_cnt = 0;
     uint32_t negmpm_cnt = 0;
     uint32_t any5_cnt = 0;
     uint32_t payload_no_mpm_cnt = 0;
@@ -765,6 +767,12 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
                 SCLogDebug("SGH %p MPM Pattern on %s, is negated. Rule %u", sgh, DetectListToString(mpm_list), s->id);
                 negmpm_cnt++;
             }
+            if (cd->flags & DETECT_CONTENT_ENDS_WITH) {
+                mpm_endswith_cnt++;
+            }
+            if (cd->flags & DETECT_CONTENT_DEPTH) {
+                mpm_depth_cnt++;
+            }
         }
 
         if (RuleInspectsPayloadHasNoMpm(s)) {
@@ -791,6 +799,8 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
     json_t *types = json_object();
     json_object_set_new(types, "mpm", json_integer(mpm_cnt));
     json_object_set_new(types, "non_mpm", json_integer(nonmpm_cnt));
+    json_object_set_new(types, "mpm_depth", json_integer(mpm_depth_cnt));
+    json_object_set_new(types, "mpm_endswith", json_integer(mpm_endswith_cnt));
     json_object_set_new(types, "negated_mpm", json_integer(negmpm_cnt));
     json_object_set_new(types, "payload_but_no_mpm", json_integer(payload_no_mpm_cnt));
     json_object_set_new(types, "prefilter", json_integer(prefilter_cnt));

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1912,7 +1912,7 @@ static int SigMatchPrepare(DetectEngineCtx *de_ctx)
         s->init_data = NULL;
     }
 
-
+    DumpPatterns(de_ctx);
     SCReturnInt(0);
 }
 

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -919,8 +919,26 @@ static void RulesDumpGrouping(const DetectEngineCtx *de_ctx,
             json_object_set_new(tcp, "toclient", tc_array);
 
             json_object_set_new(js, name, tcp);
-        }
+        } else if (p == IPPROTO_ICMP || p == IPPROTO_ICMPV6) {
+            const char *name = (p == IPPROTO_ICMP) ? "icmpv4" : "icmpv6";
+            json_t *o = json_object();
+            json_t *ts = json_object();
+            json_t *tc = json_object();
 
+            if (de_ctx->flow_gh[1].sgh[p]) {
+                json_t *group_ts = RulesGroupPrintSghStats(
+                        de_ctx, de_ctx->flow_gh[1].sgh[p], add_rules, add_mpm_stats);
+                json_object_set_new(ts, "rulegroup", group_ts);
+                json_object_set_new(o, "toserver", ts);
+            }
+            if (de_ctx->flow_gh[0].sgh[p]) {
+                json_t *group_tc = RulesGroupPrintSghStats(
+                        de_ctx, de_ctx->flow_gh[0].sgh[p], add_rules, add_mpm_stats);
+                json_object_set_new(tc, "rulegroup", group_tc);
+                json_object_set_new(o, "toclient", tc);
+            }
+            json_object_set_new(js, name, o);
+        }
     }
 
     const char *filename = "rule_group.json";

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -661,8 +661,8 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
 
     const Signature *s;
     uint32_t x;
-    for (x = 0; x < sgh->sig_cnt; x++) {
-        s = sgh->match_array[x];
+    for (x = 0; x < sgh->init->sig_cnt; x++) {
+        s = sgh->init->match_array[x];
         if (s == NULL)
             continue;
 
@@ -794,7 +794,7 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
     json_object_set_new(js, "rules", js_array);
 
     json_t *stats = json_object();
-    json_object_set_new(stats, "total", json_integer(sgh->sig_cnt));
+    json_object_set_new(stats, "total", json_integer(sgh->init->sig_cnt));
 
     json_t *types = json_object();
     json_object_set_new(types, "mpm", json_integer(mpm_cnt));
@@ -928,16 +928,15 @@ static void RulesDumpGrouping(const DetectEngineCtx *de_ctx,
         } else if (p == IPPROTO_ICMP || p == IPPROTO_ICMPV6) {
             const char *name = (p == IPPROTO_ICMP) ? "icmpv4" : "icmpv6";
             json_t *o = json_object();
-            json_t *ts = json_object();
-            json_t *tc = json_object();
-
             if (de_ctx->flow_gh[1].sgh[p]) {
+                json_t *ts = json_object();
                 json_t *group_ts = RulesGroupPrintSghStats(
                         de_ctx, de_ctx->flow_gh[1].sgh[p], add_rules, add_mpm_stats);
                 json_object_set_new(ts, "rulegroup", group_ts);
                 json_object_set_new(o, "toserver", ts);
             }
             if (de_ctx->flow_gh[0].sgh[p]) {
+                json_t *tc = json_object();
                 json_t *group_tc = RulesGroupPrintSghStats(
                         de_ctx, de_ctx->flow_gh[0].sgh[p], add_rules, add_mpm_stats);
                 json_object_set_new(tc, "rulegroup", group_tc);
@@ -1480,32 +1479,32 @@ static int PortGroupWhitelist(const DetectPort *a)
 int CreateGroupedPortListCmpCnt(DetectPort *a, DetectPort *b)
 {
     if (PortGroupWhitelist(a) && !PortGroupWhitelist(b)) {
-        SCLogDebug("%u:%u (cnt %u, wl %d) wins against %u:%u (cnt %u, wl %d)",
-                a->port, a->port2, a->sh->sig_cnt, PortGroupWhitelist(a),
-                b->port, b->port2, b->sh->sig_cnt, PortGroupWhitelist(b));
+        SCLogDebug("%u:%u (cnt %u, wl %d) wins against %u:%u (cnt %u, wl %d)", a->port, a->port2,
+                a->sh->init->sig_cnt, PortGroupWhitelist(a), b->port, b->port2,
+                b->sh->init->sig_cnt, PortGroupWhitelist(b));
         return 1;
     } else if (!PortGroupWhitelist(a) && PortGroupWhitelist(b)) {
-        SCLogDebug("%u:%u (cnt %u, wl %d) loses against %u:%u (cnt %u, wl %d)",
-                a->port, a->port2, a->sh->sig_cnt, PortGroupWhitelist(a),
-                b->port, b->port2, b->sh->sig_cnt, PortGroupWhitelist(b));
+        SCLogDebug("%u:%u (cnt %u, wl %d) loses against %u:%u (cnt %u, wl %d)", a->port, a->port2,
+                a->sh->init->sig_cnt, PortGroupWhitelist(a), b->port, b->port2,
+                b->sh->init->sig_cnt, PortGroupWhitelist(b));
         return 0;
     } else if (PortGroupWhitelist(a) > PortGroupWhitelist(b)) {
-        SCLogDebug("%u:%u (cnt %u, wl %d) wins against %u:%u (cnt %u, wl %d)",
-                a->port, a->port2, a->sh->sig_cnt, PortGroupWhitelist(a),
-                b->port, b->port2, b->sh->sig_cnt, PortGroupWhitelist(b));
+        SCLogDebug("%u:%u (cnt %u, wl %d) wins against %u:%u (cnt %u, wl %d)", a->port, a->port2,
+                a->sh->init->sig_cnt, PortGroupWhitelist(a), b->port, b->port2,
+                b->sh->init->sig_cnt, PortGroupWhitelist(b));
         return 1;
     } else if (PortGroupWhitelist(a) == PortGroupWhitelist(b)) {
-        if (a->sh->sig_cnt > b->sh->sig_cnt) {
-            SCLogDebug("%u:%u (cnt %u, wl %d) wins against %u:%u (cnt %u, wl %d)",
-                    a->port, a->port2, a->sh->sig_cnt, PortGroupWhitelist(a),
-                    b->port, b->port2, b->sh->sig_cnt, PortGroupWhitelist(b));
+        if (a->sh->init->sig_cnt > b->sh->init->sig_cnt) {
+            SCLogDebug("%u:%u (cnt %u, wl %d) wins against %u:%u (cnt %u, wl %d)", a->port,
+                    a->port2, a->sh->init->sig_cnt, PortGroupWhitelist(a), b->port, b->port2,
+                    b->sh->init->sig_cnt, PortGroupWhitelist(b));
             return 1;
         }
     }
 
-    SCLogDebug("%u:%u (cnt %u, wl %d) loses against %u:%u (cnt %u, wl %d)",
-            a->port, a->port2, a->sh->sig_cnt, PortGroupWhitelist(a),
-            b->port, b->port2, b->sh->sig_cnt, PortGroupWhitelist(b));
+    SCLogDebug("%u:%u (cnt %u, wl %d) loses against %u:%u (cnt %u, wl %d)", a->port, a->port2,
+            a->sh->init->sig_cnt, PortGroupWhitelist(a), b->port, b->port2, b->sh->init->sig_cnt,
+            PortGroupWhitelist(b));
     return 0;
 }
 
@@ -1821,9 +1820,6 @@ int SigAddressPrepareStage4(DetectEngineCtx *de_ctx)
 
         SigGroupHeadBuildNonPrefilterArray(de_ctx, sgh);
 
-        SigGroupHeadInitDataFree(sgh->init);
-        sgh->init = NULL;
-
         sgh->id = idx;
         cnt++;
     }
@@ -1836,10 +1832,6 @@ int SigAddressPrepareStage4(DetectEngineCtx *de_ctx)
          * signature not decode event only. */
     }
 
-    /* cleanup the hashes now since we won't need them
-     * after the initialization phase. */
-    SigGroupHeadHashFree(de_ctx);
-
     int dump_grouping = 0;
     (void)ConfGetBool("detect.profiling.grouping.dump-to-disk", &dump_grouping);
 
@@ -1851,6 +1843,17 @@ int SigAddressPrepareStage4(DetectEngineCtx *de_ctx)
 
         RulesDumpGrouping(de_ctx, add_rules, add_mpm_stats);
     }
+
+    for (uint32_t idx = 0; idx < de_ctx->sgh_array_cnt; idx++) {
+        SigGroupHead *sgh = de_ctx->sgh_array[idx];
+        if (sgh == NULL)
+            continue;
+        SigGroupHeadInitDataFree(sgh->init);
+        sgh->init = NULL;
+    }
+    /* cleanup the hashes now since we won't need them
+     * after the initialization phase. */
+    SigGroupHeadHashFree(de_ctx);
 
 #ifdef PROFILING
     SCProfilingSghInitCounters(de_ctx);

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -713,9 +713,7 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
             uint32_t size = cd->content_len < 256 ? cd->content_len : 255;
 
             mpm_sizes[mpm_list][size]++;
-            if (s->alproto != ALPROTO_UNKNOWN) {
-                alproto_mpm_bufs[s->alproto][mpm_list]++;
-            }
+            alproto_mpm_bufs[s->alproto][mpm_list]++;
 
             if (mpm_list == DETECT_SM_LIST_PMATCH) {
                 if (size == 1) {
@@ -774,9 +772,7 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
             payload_no_mpm_cnt++;
         }
 
-        if (s->alproto != ALPROTO_UNKNOWN) {
-            alstats[s->alproto]++;
-        }
+        alstats[s->alproto]++;
 
         if (add_rules) {
             json_t *js_sig = json_object();
@@ -802,8 +798,7 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
     json_object_set_new(types, "any5", json_integer(any5_cnt));
     json_object_set_new(stats, "types", types);
 
-    int i;
-    for (i = 0; i < ALPROTO_MAX; i++) {
+    for (int i = 0; i < ALPROTO_MAX; i++) {
         if (alstats[i] > 0) {
             json_t *app = json_object();
             json_object_set_new(app, "total", json_integer(alstats[i]));
@@ -821,14 +816,15 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
                 json_object_set_new(app, name, json_integer(alproto_mpm_bufs[i][y]));
             }
 
-            json_object_set_new(stats, AppProtoToString(i), app);
+            const char *proto_name = (i == ALPROTO_UNKNOWN) ? "payload" : AppProtoToString(i);
+            json_object_set_new(stats, proto_name, app);
         }
     }
 
     if (add_mpm_stats) {
         json_t *mpm_js = json_object();
 
-        for (i = 0; i < max_buffer_type_id; i++) {
+        for (int i = 0; i < max_buffer_type_id; i++) {
             if (mpm_stats[i].cnt > 0) {
 
                 json_t *mpm_sizes_array = json_array();

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -621,6 +621,7 @@ static int RuleMpmIsNegated(const Signature *s)
 static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigGroupHead *sgh,
         const int add_rules, const int add_mpm_stats)
 {
+    uint32_t prefilter_cnt = 0;
     uint32_t mpm_cnt = 0;
     uint32_t nonmpm_cnt = 0;
     uint32_t negmpm_cnt = 0;
@@ -683,6 +684,7 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
             any5_cnt++;
         }
 
+        prefilter_cnt += (s->init_data->prefilter_sm != 0);
         if (s->init_data->mpm_sm == NULL) {
             nonmpm_cnt++;
 
@@ -795,6 +797,7 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
     json_object_set_new(types, "non_mpm", json_integer(nonmpm_cnt));
     json_object_set_new(types, "negated_mpm", json_integer(negmpm_cnt));
     json_object_set_new(types, "payload_but_no_mpm", json_integer(payload_no_mpm_cnt));
+    json_object_set_new(types, "prefilter", json_integer(prefilter_cnt));
     json_object_set_new(types, "syn", json_integer(syn_cnt));
     json_object_set_new(types, "any5", json_integer(any5_cnt));
     json_object_set_new(stats, "types", types);

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -618,8 +618,8 @@ static int RuleMpmIsNegated(const Signature *s)
     return (cd->flags & DETECT_CONTENT_NEGATED);
 }
 
-static json_t *RulesGroupPrintSghStats(const SigGroupHead *sgh,
-                                const int add_rules, const int add_mpm_stats)
+static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigGroupHead *sgh,
+        const int add_rules, const int add_mpm_stats)
 {
     uint32_t mpm_cnt = 0;
     uint32_t nonmpm_cnt = 0;
@@ -808,8 +808,14 @@ static json_t *RulesGroupPrintSghStats(const SigGroupHead *sgh,
             for (int y = 0; y < max_buffer_type_id; y++) {
                 if (alproto_mpm_bufs[i][y] == 0)
                     continue;
-                json_object_set_new(
-                        app, DetectListToHumanString(y), json_integer(alproto_mpm_bufs[i][y]));
+
+                const char *name;
+                if (y < DETECT_SM_LIST_DYNAMIC_START)
+                    name = DetectListToHumanString(y);
+                else
+                    name = DetectBufferTypeGetNameById(de_ctx, y);
+
+                json_object_set_new(app, name, json_integer(alproto_mpm_bufs[i][y]));
             }
 
             json_object_set_new(stats, AppProtoToString(i), app);
@@ -841,7 +847,13 @@ static json_t *RulesGroupPrintSghStats(const SigGroupHead *sgh,
 
                 json_object_set_new(buf, "sizes", mpm_sizes_array);
 
-                json_object_set_new(mpm_js, DetectListToHumanString(i), buf);
+                const char *name;
+                if (i < DETECT_SM_LIST_DYNAMIC_START)
+                    name = DetectListToHumanString(i);
+                else
+                    name = DetectBufferTypeGetNameById(de_ctx, i);
+
+                json_object_set_new(mpm_js, name, buf);
             }
         }
 
@@ -877,8 +889,8 @@ static void RulesDumpGrouping(const DetectEngineCtx *de_ctx,
                 json_object_set_new(port, "port", json_integer(list->port));
                 json_object_set_new(port, "port2", json_integer(list->port2));
 
-                json_t *tcp_ts = RulesGroupPrintSghStats(list->sh,
-                        add_rules, add_mpm_stats);
+                json_t *tcp_ts =
+                        RulesGroupPrintSghStats(de_ctx, list->sh, add_rules, add_mpm_stats);
                 json_object_set_new(port, "rulegroup", tcp_ts);
                 json_array_append_new(ts_array, port);
 
@@ -894,8 +906,8 @@ static void RulesDumpGrouping(const DetectEngineCtx *de_ctx,
                 json_object_set_new(port, "port", json_integer(list->port));
                 json_object_set_new(port, "port2", json_integer(list->port2));
 
-                json_t *tcp_tc = RulesGroupPrintSghStats(list->sh,
-                        add_rules, add_mpm_stats);
+                json_t *tcp_tc =
+                        RulesGroupPrintSghStats(de_ctx, list->sh, add_rules, add_mpm_stats);
                 json_object_set_new(port, "rulegroup", tcp_tc);
                 json_array_append_new(tc_array, port);
 

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -1344,8 +1344,8 @@ MpmStore *MpmStorePrepareBuffer(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
             break;
     }
 
-    for (sig = 0; sig < sgh->sig_cnt; sig++) {
-        s = sgh->match_array[sig];
+    for (sig = 0; sig < sgh->init->sig_cnt; sig++) {
+        s = sgh->init->match_array[sig];
         if (s == NULL)
             continue;
 
@@ -1436,8 +1436,8 @@ static MpmStore *MpmStorePrepareBufferAppLayer(DetectEngineCtx *de_ctx,
             am->direction == SIG_FLAG_TOSERVER ? "toserver" : "toclient",
             am->sm_list);
 
-    for (sig = 0; sig < sgh->sig_cnt; sig++) {
-        s = sgh->match_array[sig];
+    for (sig = 0; sig < sgh->init->sig_cnt; sig++) {
+        s = sgh->init->match_array[sig];
         if (s == NULL)
             continue;
 
@@ -1513,8 +1513,8 @@ static MpmStore *MpmStorePrepareBufferPkt(DetectEngineCtx *de_ctx,
     SCLogDebug("handling %s for list %d", am->name,
             am->sm_list);
 
-    for (sig = 0; sig < sgh->sig_cnt; sig++) {
-        s = sgh->match_array[sig];
+    for (sig = 0; sig < sgh->init->sig_cnt; sig++) {
+        s = sgh->init->match_array[sig];
         if (s == NULL)
             continue;
 
@@ -1576,8 +1576,8 @@ static void SetRawReassemblyFlag(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
     const Signature *s = NULL;
     uint32_t sig;
 
-    for (sig = 0; sig < sgh->sig_cnt; sig++) {
-        s = sgh->match_array[sig];
+    for (sig = 0; sig < sgh->init->sig_cnt; sig++) {
+        s = sgh->init->match_array[sig];
         if (s == NULL)
             continue;
 

--- a/src/detect-engine-prefilter-common.c
+++ b/src/detect-engine-prefilter-common.c
@@ -118,8 +118,8 @@ SetupEngineForPacketHeader(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
         return -1;
     }
 
-    for (sig = 0; sig < sgh->sig_cnt; sig++) {
-        s = sgh->match_array[sig];
+    for (sig = 0; sig < sgh->init->sig_cnt; sig++) {
+        s = sgh->init->match_array[sig];
         if (s == NULL)
             continue;
         if (s->init_data->prefilter_sm == NULL || s->init_data->prefilter_sm->type != sm_type)
@@ -230,8 +230,8 @@ SetupEngineForPacketHeaderPrefilterPacketU8HashCtx(DetectEngineCtx *de_ctx,
         return 0;
     }
 
-    for (sig = 0; sig < sgh->sig_cnt; sig++) {
-        s = sgh->match_array[sig];
+    for (sig = 0; sig < sgh->init->sig_cnt; sig++) {
+        s = sgh->init->match_array[sig];
         if (s == NULL)
             continue;
         if (s->init_data->prefilter_sm == NULL || s->init_data->prefilter_sm->type != sm_type)
@@ -357,8 +357,8 @@ static int PrefilterSetupPacketHeaderCommon(DetectEngineCtx *de_ctx,
     if (hash_table == NULL)
         return -1;
 
-    for (sig = 0; sig < sgh->sig_cnt; sig++) {
-        s = sgh->match_array[sig];
+    for (sig = 0; sig < sgh->init->sig_cnt; sig++) {
+        s = sgh->init->match_array[sig];
         if (s == NULL)
             continue;
         if (s->init_data->prefilter_sm == NULL || s->init_data->prefilter_sm->type != sm_type)

--- a/src/detect-engine-profile.c
+++ b/src/detect-engine-profile.c
@@ -35,6 +35,50 @@
 #ifdef PROFILING
 SCMutex g_rule_dump_write_m = SCMUTEX_INITIALIZER;
 
+void RulesDumpTxMatchArray(const DetectEngineThreadCtx *det_ctx, const SigGroupHead *sgh,
+        const Packet *p, const uint64_t tx_id, const uint32_t rule_cnt,
+        const uint32_t pkt_prefilter_cnt)
+{
+    JsonBuilder *js = CreateEveHeaderWithTxId(p, LOG_DIR_PACKET, "inspectedrules", NULL, tx_id);
+    if (js == NULL)
+        return;
+
+    jb_set_string(js, "app_proto", AppProtoToString(p->flow->alproto));
+
+    jb_open_object(js, "inspectedrules");
+    jb_set_string(js, "inspect_type", "tx");
+    jb_set_uint(js, "rule_group_id", sgh->id);
+    jb_set_uint(js, "rule_cnt", rule_cnt);
+    jb_set_uint(js, "pkt_rule_cnt", pkt_prefilter_cnt);
+    jb_set_uint(js, "non_pf_rule_cnt", det_ctx->non_pf_store_cnt);
+
+    jb_open_array(js, "rules");
+    for (uint32_t x = 0; x < rule_cnt; x++) {
+        SigIntId iid = det_ctx->tx_candidates[x].id;
+        const Signature *s = det_ctx->de_ctx->sig_array[iid];
+        if (s == NULL)
+            continue;
+        jb_append_uint(js, s->id);
+    }
+    jb_close(js); // close array
+    jb_close(js); // close inspectedrules object
+    jb_close(js); // final close
+
+    const char *filename = "packet_inspected_rules.json";
+    const char *log_dir = ConfigGetLogDirectory();
+    char log_path[PATH_MAX] = "";
+    snprintf(log_path, sizeof(log_path), "%s/%s", log_dir, filename);
+
+    SCMutexLock(&g_rule_dump_write_m);
+    FILE *fp = fopen(log_path, "a");
+    if (fp != NULL) {
+        fwrite(jb_ptr(js), jb_len(js), 1, fp);
+        fclose(fp);
+    }
+    SCMutexUnlock(&g_rule_dump_write_m);
+    jb_free(js);
+}
+
 void RulesDumpMatchArray(const DetectEngineThreadCtx *det_ctx,
         const SigGroupHead *sgh, const Packet *p)
 {
@@ -42,9 +86,15 @@ void RulesDumpMatchArray(const DetectEngineThreadCtx *det_ctx,
     if (js == NULL)
         return;
 
+    if (p->flow) {
+        jb_set_string(js, "app_proto", AppProtoToString(p->flow->alproto));
+    }
+
     jb_open_object(js, "inspectedrules");
+    jb_set_string(js, "inspect_type", "packet");
     jb_set_uint(js, "rule_group_id", sgh->id);
     jb_set_uint(js, "rule_cnt", det_ctx->match_array_cnt);
+    jb_set_uint(js, "non_pf_rule_cnt", det_ctx->non_pf_store_cnt);
 
     jb_open_array(js, "rules");
     for (uint32_t x = 0; x < det_ctx->match_array_cnt; x++) {

--- a/src/detect-engine-profile.h
+++ b/src/detect-engine-profile.h
@@ -24,6 +24,9 @@
 #ifndef _DETECT_ENGINE_PROFILE_H
 #define	_DETECT_ENGINE_PROFILE_H
 
+void RulesDumpTxMatchArray(const DetectEngineThreadCtx *det_ctx, const SigGroupHead *sgh,
+        const Packet *p, const uint64_t tx_id, const uint32_t rule_cnt,
+        const uint32_t pkt_prefilter_cnt);
 void RulesDumpMatchArray(const DetectEngineThreadCtx *det_ctx,
         const SigGroupHead *sgh, const Packet *p);
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -1419,7 +1419,10 @@ static void DetectRunTx(ThreadVars *tv,
                         tx.tx_ptr, tx.tx_id, array_idx - old);
             }
         }
-
+#ifdef PROFILING
+        if (array_idx >= de_ctx->profile_match_logging_threshold)
+            RulesDumpTxMatchArray(det_ctx, scratch->sgh, p, tx.tx_id, array_idx, x);
+#endif
         det_ctx->tx_id = tx.tx_id;
         det_ctx->tx_id_set = 1;
         det_ctx->p = p;

--- a/src/detect.h
+++ b/src/detect.h
@@ -1333,6 +1333,12 @@ typedef struct SigGroupHeadInitData_ {
     PrefilterEngineList *payload_engines;
     PrefilterEngineList *tx_engines;
 
+    /** number of sigs in this group */
+    SigIntId sig_cnt;
+
+    /** Array with sig ptrs... size is sig_cnt * sizeof(Signature *) */
+    Signature **match_array;
+
     /* port ptr */
     struct DetectPort_ *port;
 } SigGroupHeadInitData;
@@ -1341,9 +1347,6 @@ typedef struct SigGroupHeadInitData_ {
 typedef struct SigGroupHead_ {
     uint32_t flags;
     /* coccinelle: SigGroupHead:flags:SIG_GROUP_HEAD_ */
-
-    /* number of sigs in this head */
-    SigIntId sig_cnt;
 
     /* non prefilter list excluding SYN rules */
     uint32_t non_pf_other_store_cnt;
@@ -1361,9 +1364,6 @@ typedef struct SigGroupHead_ {
     PrefilterEngine *pkt_engines;
     PrefilterEngine *payload_engines;
     PrefilterEngine *tx_engines;
-
-    /** Array with sig ptrs... size is sig_cnt * sizeof(Signature *) */
-    Signature **match_array;
 
     /* ptr to our init data we only use at... init :) */
     SigGroupHeadInitData *init;

--- a/src/detect.h
+++ b/src/detect.h
@@ -796,6 +796,7 @@ typedef struct DetectEngineCtx_ {
     HashListTable *sgh_hash_table;
 
     HashListTable *mpm_hash_table;
+    HashListTable *pattern_hash_table;
 
     /* hash table used to cull out duplicate sigs */
     HashListTable *dup_sig_hash_table;
@@ -1499,6 +1500,8 @@ void DetectEngineSetEvent(DetectEngineThreadCtx *det_ctx, uint8_t e);
 AppLayerDecoderEvents *DetectEngineGetEvents(DetectEngineThreadCtx *det_ctx);
 int DetectEngineGetEventInfo(const char *event_name, int *event_id,
                              AppLayerEventType *event_type);
+
+void DumpPatterns(DetectEngineCtx *de_ctx);
 
 #include "detect-engine-build.h"
 #include "detect-engine-register.h"

--- a/src/util-mpm.h
+++ b/src/util-mpm.h
@@ -112,12 +112,13 @@ typedef struct MpmCtx_ {
  * we should supply this as the key */
 #define MPM_CTX_FACTORY_UNIQUE_CONTEXT -1
 
-typedef struct MpmCtxFactoryItem_ {
+typedef struct MpmCtxFactoryItem {
     const char *name;
     MpmCtx *mpm_ctx_ts;
     MpmCtx *mpm_ctx_tc;
     int32_t id;
     int32_t sm_list;
+    struct MpmCtxFactoryItem *next;
 } MpmCtxFactoryItem;
 
 typedef struct MpmCtxFactoryContainer_ {


### PR DESCRIPTION
Continuation of #5848. Output much more detail about the rule internals in `--engine-analysis`. Adds a `patterns.json` that dumps info about patterns in use.