### PR TITLE
Http2 deflate 4556 v2

### DIFF
--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -712,7 +712,9 @@ pub unsafe extern "C" fn rs_http2_tx_set_method(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_set_uri(state: &mut HTTP2State, buffer: *const u8, buffer_len: u32) {
+pub unsafe extern "C" fn rs_http2_tx_set_uri(
+    state: &mut HTTP2State, buffer: *const u8, buffer_len: u32,
+) {
     let slice = build_slice!(buffer, buffer_len as usize);
     http2_tx_set_header(state, ":path".as_bytes(), slice)
 }

--- a/rust/src/http2/logger.rs
+++ b/rust/src/http2/logger.rs
@@ -268,7 +268,9 @@ fn log_http2(tx: &HTTP2Transaction, js: &mut JsonBuilder) -> Result<bool, JsonEr
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_log_json(tx: *mut std::os::raw::c_void, js: &mut JsonBuilder) -> bool {
+pub unsafe extern "C" fn rs_http2_log_json(
+    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
+) -> bool {
     let tx = cast_pointer!(tx, HTTP2Transaction);
     if let Ok(x) = log_http2(tx, js) {
         return x;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4556

Describe changes:
- Support for deflate decompression over HTTP2

suricata-verify-pr: 515

https://github.com/OISF/suricata-verify/pull/515

Modifies #6253 by
- rustfmt again all HTTP2 (@ct0br0 could we have a Github formatting CI check that if one rust file is ok for rusrtfmt in master, a PR should keep it ok ?)
- Better position for call to `incr_files_opened` so that a small file that gets opened, written and close right away is still accounted for