### PR TITLE
Http2 deflate 4556 v3

### DIFF
--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -712,7 +712,9 @@ pub unsafe extern "C" fn rs_http2_tx_set_method(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_set_uri(state: &mut HTTP2State, buffer: *const u8, buffer_len: u32) {
+pub unsafe extern "C" fn rs_http2_tx_set_uri(
+    state: &mut HTTP2State, buffer: *const u8, buffer_len: u32,
+) {
     let slice = build_slice!(buffer, buffer_len as usize);
     http2_tx_set_header(state, ":path".as_bytes(), slice)
 }

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -185,6 +185,12 @@ impl HTTP2Transaction {
         let decompressed = self.decoder.decompress(input, &mut output, dir)?;
         let xid: u32 = self.tx_id as u32;
         if dir == STREAM_TOCLIENT {
+            self.ft_tc.tx_id = self.tx_id - 1;
+            if !self.ft_tc.file_open {
+                // we are now sure that new_chunk will open a file
+                // even if it may close it right afterwards
+                self.tx_data.incr_files_opened();
+            }
             self.ft_tc.new_chunk(
                 sfcm,
                 files,
@@ -198,6 +204,10 @@ impl HTTP2Transaction {
                 &xid,
             );
         } else {
+            self.ft_ts.tx_id = self.tx_id - 1;
+            if !self.ft_ts.file_open {
+                self.tx_data.incr_files_opened();
+            }
             self.ft_ts.new_chunk(
                 sfcm,
                 files,
@@ -806,14 +816,7 @@ impl HTTP2State {
                                 //borrow checker forbids to reuse directly tx
                                 let index = self.find_tx_index(sid);
                                 if index > 0 {
-                                    let mut tx_same = &mut self.transactions[index - 1];
-                                    let is_open = if dir == STREAM_TOCLIENT {
-                                        tx_same.ft_tc.tx_id = tx_same.tx_id - 1;
-                                        tx_same.ft_tc.file_open
-                                    } else {
-                                        tx_same.ft_ts.tx_id = tx_same.tx_id - 1;
-                                        tx_same.ft_ts.file_open
-                                    };
+                                    let tx_same = &mut self.transactions[index - 1];
                                     let (files, flags) = self.files.get(dir);
                                     match tx_same.decompress(
                                         &rem[..hlsafe],
@@ -826,17 +829,7 @@ impl HTTP2State {
                                         Err(_e) => {
                                             self.set_event(HTTP2Event::FailedDecompression);
                                         }
-                                        _ => {
-                                            if dir == STREAM_TOCLIENT {
-                                                if !is_open && tx_same.ft_tc.file_open {
-                                                    tx_same.tx_data.incr_files_opened();
-                                                }
-                                            } else {
-                                                if !is_open && tx_same.ft_ts.file_open {
-                                                    tx_same.tx_data.incr_files_opened();
-                                                }
-                                            }
-                                        }
+                                        _ => {}
                                     }
                                 }
                             }
@@ -977,7 +970,7 @@ pub unsafe extern "C" fn rs_http2_probing_parser_tc(
                 return ALPROTO_UNKNOWN;
             }
             Err(_) => {
-                return ALPROTO_FAILED ;
+                return ALPROTO_FAILED;
             }
         }
     }
@@ -1069,7 +1062,9 @@ pub unsafe extern "C" fn rs_http2_state_get_tx_count(state: *mut std::os::raw::c
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_state(tx: *mut std::os::raw::c_void) -> HTTP2TransactionState {
+pub unsafe extern "C" fn rs_http2_tx_get_state(
+    tx: *mut std::os::raw::c_void,
+) -> HTTP2TransactionState {
     let tx = cast_pointer!(tx, HTTP2Transaction);
     return tx.state;
 }

--- a/rust/src/http2/logger.rs
+++ b/rust/src/http2/logger.rs
@@ -268,7 +268,9 @@ fn log_http2(tx: &HTTP2Transaction, js: &mut JsonBuilder) -> Result<bool, JsonEr
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_log_json(tx: *mut std::os::raw::c_void, js: &mut JsonBuilder) -> bool {
+pub unsafe extern "C" fn rs_http2_log_json(
+    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
+) -> bool {
     let tx = cast_pointer!(tx, HTTP2Transaction);
     if let Ok(x) = log_http2(tx, js) {
         return x;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4556

Describe changes:
- Support for deflate decompression over HTTP2

suricata-verify-pr: 515

https://github.com/OISF/suricata-verify/pull/515

Modifies #6329 by fixing rust strict warning about unused mut