### PR TITLE
Fixed threshold rule to match description

### DIFF
--- a/threshold.config
+++ b/threshold.config
@@ -20,10 +20,10 @@
 # https://suricata.readthedocs.io/en/latest/configuration/global-thresholds.html#global-thresholds-vs-rule-thresholds
 
 # Limit to 10 alerts every 10 seconds for each source host
-#threshold gen_id 0, sig_id 0, type threshold, track by_src, count 10, seconds 10
+#threshold gen_id 0, sig_id 0, type limit, track by_src, count 10, seconds 10
 
-# Limit to 1 alert every 10 seconds for signature with sid 2404000
-#threshold gen_id 1, sig_id 2404000, type threshold, track by_dst, count 1, seconds 10
+# Limit to 1 alert every 10 seconds for signature with sid 2404000 per destination host
+#threshold gen_id 1, sig_id 2404000, type limit, track by_dst, count 1, seconds 10
 
 # Avoid to alert on f-secure update
 # Example taken from https://blog.inliniac.net/2012/03/07/f-secure-av-updates-and-suricata-ips/


### PR DESCRIPTION
Describe changes:
- Fixed threshold.conf rule examples to match description, based on documentation (https://suricata.readthedocs.io/en/suricata-6.0.3/rules/thresholding.html)
