### PR TITLE
rules: fix flow drop for ip-only sig with noalert

### DIFF
--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -1115,14 +1115,15 @@ void IPOnlyMatchPacket(ThreadVars *tv,
                             }
                         }
                     }
+
+                    /* IP-only drops should be applied to the flow */
+                    const uint8_t alert_flags =
+                            ((s->action & ACTION_DROP)) ? PACKET_ALERT_FLAG_DROP_FLOW : 0;
                     if (!(s->flags & SIG_FLAG_NOALERT)) {
-                        if (s->action & ACTION_DROP)
-                            PacketAlertAppend(det_ctx, s, p, 0, PACKET_ALERT_FLAG_DROP_FLOW);
-                        else
-                            PacketAlertAppend(det_ctx, s, p, 0, 0);
+                        PacketAlertAppend(det_ctx, s, p, 0, alert_flags);
                     } else {
                         /* apply actions for noalert/rule suppressed as well */
-                        DetectSignatureApplyActions(p, s, 0);
+                        DetectSignatureApplyActions(p, s, alert_flags);
                     }
                 }
             }

--- a/src/detect.c
+++ b/src/detect.c
@@ -1547,6 +1547,9 @@ void DetectSignatureApplyActions(Packet *p,
             p->alerts.drop.action = s->action;
             p->alerts.drop.s = (Signature *)s;
         }
+        if ((p->flow != NULL) && (alert_flags & PACKET_ALERT_FLAG_DROP_FLOW)) {
+            p->flow->flags |= FLOW_ACTION_DROP;
+        }
     } else if (s->action & ACTION_PASS) {
         /* if an stream/app-layer match we enforce the pass for the flow */
         if ((p->flow != NULL) &&


### PR DESCRIPTION
A simple drop rules like drop tcp any any -> any any (noalert; sid:1; rev:1;)
fails to drop packets beyond the first in each direction of the flow.

The cause is that the rule is just evaluated once per flow direction, by the
"IP-only" detection path. In this case the 'noalert' presence causes the drop
not to be applied to the flow.

Bug: #4663

suricata-verify-pr: 528
