### PR TITLE
af-packet: use configured cluster-id when checking for fanout - v2

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -272,7 +272,7 @@ typedef struct AFPThreadVars_
 
     int down_count;
 
-    int cluster_id;
+    uint16_t cluster_id;
     int cluster_type;
 
     int threads;
@@ -1977,7 +1977,7 @@ mmap_err:
 /** \brief test if we can use FANOUT. Older kernels like those in
  *         CentOS6 have HAVE_PACKET_FANOUT defined but fail to work
  */
-int AFPIsFanoutSupported(int cluster_id)
+int AFPIsFanoutSupported(uint16_t cluster_id)
 {
 #ifdef HAVE_PACKET_FANOUT
     int fd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
@@ -1985,8 +1985,7 @@ int AFPIsFanoutSupported(int cluster_id)
         return 0;
 
     uint32_t mode = PACKET_FANOUT_HASH | PACKET_FANOUT_FLAG_DEFRAG;
-    uint16_t id = 1;
-    uint32_t option = (mode << 16) | (id & 0xffff);
+    uint32_t option = (mode << 16) | cluster_id;
     int r = setsockopt(fd, SOL_PACKET, PACKET_FANOUT,(void *)&option, sizeof(option));
     close(fd);
 

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -186,7 +186,6 @@ TmEcode AFPPeersListCheck(void);
 void AFPPeersListClean(void);
 int AFPGetLinkType(const char *ifname);
 
-int AFPIsFanoutSupported(int cluster_id);
-
+int AFPIsFanoutSupported(uint16_t cluster_id);
 
 #endif /* __SOURCE_AFP_H__ */


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/5494

Changes from previous PR:
- Fix comments with respect to datatypes.

When testing for fanout support a cluster-id of 1 was always being
used instead of the configured cluster-id. This limited fanout
support to only one Suricata instance.

Instead of hardcoding an ID of 1, use the configured cluster-id.

Also make cluster_id a uint16_t instead of an int in AFPThreadVars.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/3419
