### PR TITLE
log: Add module and subsystem identifiers to log

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2598,6 +2598,9 @@ if test "${enable_ebpf}" = "yes" || test "${enable_nfqueue}" = "yes" || test "${
   AC_DEFINE([CAPTURE_OFFLOAD], [1],[Building flow capture bypass code])
 fi
 
+# Add diagnostic filename
+CPPFLAGS="${CPPFLAGS} -D__SCFILENAME__=\\\"\$(*F)\\\""
+
 AC_SUBST(CFLAGS)
 AC_SUBST(LDFLAGS)
 AC_SUBST(CPPFLAGS)

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -82,6 +82,7 @@ pub type SCLogMessageFunc =
                   filename: *const std::os::raw::c_char,
                   line: std::os::raw::c_uint,
                   function: *const std::os::raw::c_char,
+                  subsystem: *const std::os::raw::c_char,
                   code: std::os::raw::c_int,
                   message: *const std::os::raw::c_char) -> std::os::raw::c_int;
 

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -71,10 +71,12 @@ pub fn sclog(level: Level, file: &str, line: u32, function: &str,
          code: i32, message: &str)
 {
     let filename = basename(file);
+    let noext = &filename[0..filename.len() - 3];
     sc_log_message(level,
                    filename,
                    line,
                    function,
+                   noext,
                    code,
                    message);
 }
@@ -177,6 +179,7 @@ pub fn sc_log_message(level: Level,
                       filename: &str,
                       line: std::os::raw::c_uint,
                       function: &str,
+                      module: &str,
                       code: std::os::raw::c_int,
                       message: &str) -> std::os::raw::c_int
 {
@@ -187,6 +190,7 @@ pub fn sc_log_message(level: Level,
                 to_safe_cstring(filename).as_ptr(),
                 line,
                 to_safe_cstring(function).as_ptr(),
+                to_safe_cstring(module).as_ptr(),
                 code,
                 to_safe_cstring(message).as_ptr());
         }

--- a/src/rust-context.h
+++ b/src/rust-context.h
@@ -28,7 +28,7 @@
 struct AppLayerParser;
 
 typedef struct SuricataContext_ {
-    SCError (*SCLogMessage)(const SCLogLevel, const char *, const unsigned int,
+    SCError (*SCLogMessage)(const SCLogLevel, const char *, const unsigned int, const char *,
             const char *, const SCError, const char *message);
     void (*DetectEngineStateFree)(DetectEngineState *);
     void (*AppLayerDecoderEventsSetEventRaw)(AppLayerDecoderEvents **,

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2682,7 +2682,7 @@ int InitGlobal(void) {
 
     (void)SCSetThreadName("Suricata-Main");
 
-    /* Ignore SIGUSR2 as early as possble. We redeclare interest
+    /* Ignore SIGUSR2 as early as possible. We redeclare interest
      * once we're done launching threads. The goal is to either die
      * completely or handle any and all SIGUSR2s correctly.
      */

--- a/src/threads.h
+++ b/src/threads.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -276,15 +276,23 @@ enum {
     pthread_set_name_np(pthread_self(), tname); \
     0; \
 })
+#define SCGetThreadName(tname, tnlen)                                                              \
+    ({                                                                                             \
+        pthread_get_name_np(pthread_self(), tname, tnlen);                                         \
+        0;                                                                                         \
+    })
 #elif defined __OpenBSD__ /* OpenBSD */
 /** \todo Add implementation for OpenBSD */
 #define SCSetThreadName(n) (0)
+#define SCGetThreadName(n, l) (0)
 #elif defined OS_WIN32 /* Windows */
 /** \todo Add implementation for Windows */
 #define SCSetThreadName(n) (0)
+#define SCGetThreadName(n, l) (0)
 #elif defined OS_DARWIN /* Mac OS X */
 /** \todo Add implementation for MacOS */
 #define SCSetThreadName(n) (0)
+#define SCGetThreadName(n, l) (0)
 #elif defined PR_SET_NAME /* PR_SET_NAME */
 /**
  * \brief Set the threads name
@@ -299,6 +307,13 @@ enum {
         SCLogDebug("Error setting thread name \"%s\": %s", tname, strerror(errno)); \
     ret; \
 })
+#define SCGetThreadName(tname, tnlen)                                                              \
+    ({                                                                                             \
+        int ret = 0;                                                                               \
+        if ((ret = prctl(PR_GET_NAME, tname, 0, 0, 0)) < 0)                                        \
+            SCLogDebug("Error getting thread name : %s", strerror(errno));                         \
+        ret;                                                                                       \
+    })
 #else
 #define SCSetThreadName(n) (0)
 #endif

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -451,17 +451,8 @@ static SCError SCLogMessageGetBuffer(struct timeval *tval, int color, SCLogOPTyp
 
             case SC_LOG_FMT_TM:
                 temp_fmt[0] = '\0';
-/* disabled to prevent dead lock:
- * log or alloc (which calls log on error) can call TmThreadsGetCallingThread
- * which will lock tv_root_lock. This can happen while we already hold this
- * lock. */
-#if 0
-                ThreadVars *tv = TmThreadsGetCallingThread();
-                cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - *msg),
-                              "%s%s", substr, ((tv != NULL)? tv->name: "UNKNOWN TM"));
-#endif
-                cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer),
-                              "%s%s", substr, "N/A");
+                cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer), "%s%s", substr,
+                        _sc_subsystem[0] == '\0' ? "N/A" : _sc_subsystem);
                 if (cw < 0)
                     return SC_ERR_SPRINTF;
                 temp += cw;

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -189,7 +189,7 @@ static inline void SCLogPrintToStream(FILE *fd, char *msg)
 }
 
 /**
- * \brief Output function that logs a character string throught the syslog iface
+ * \brief Output function that logs a character string through the syslog iface
  *
  * \param syslog_log_level Holds the syslog_log_level that the message should be
  *                         logged as
@@ -1243,7 +1243,7 @@ static inline void SCLogSetOPFilter(SCLogInitData *sc_lid, SCLogConfig *sc_lc)
 
 /**
  * \brief Returns a pointer to a new SCLogInitData.  This is a public interface
- *        intended to be used after the logging paramters are read from the
+ *        intended to be used after the logging parameters are read from the
  *        conf file
  *
  * \retval sc_lid Pointer to the newly created SCLogInitData

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -72,12 +72,20 @@ SCEnumCharMap sc_log_op_iface_map[ ] = {
     { NULL,             -1 }
 };
 
+/* TLS values to track thread name (length) */
+static thread_local char _sc_subsystem[16];
+
 #if defined (OS_WIN32)
 /**
  * \brief Used for synchronous output on WIN32
  */
 static SCMutex sc_log_stream_lock;
 #endif /* OS_WIN32 */
+
+/**
+ * \brief Transform the module name into display module name for logging
+ */
+static const char *SCTransformModule(const char *module_name, int *dn_len);
 
 /**
  * \brief Holds the config state for the logging module
@@ -203,9 +211,8 @@ static inline void SCLogPrintToSyslog(int syslog_log_level, const char *msg)
 /**
  */
 static int SCLogMessageJSON(struct timeval *tval, char *buffer, size_t buffer_size,
-        SCLogLevel log_level, const char *file,
-        unsigned line, const char *function, SCError error_code,
-        const char *message)
+        SCLogLevel log_level, const char *file, unsigned line, const char *function,
+        const char *module, SCError error_code, const char *message)
 {
     json_t *js = json_object();
     if (unlikely(js == NULL))
@@ -235,6 +242,18 @@ static int SCLogMessageJSON(struct timeval *tval, char *buffer, size_t buffer_si
     if (message)
         json_object_set_new(ejs, "message", json_string(message));
 
+    if (_sc_subsystem) {
+        json_object_set_new(ejs, "subsystem", json_string(_sc_subsystem));
+    }
+
+    if (module) {
+        /* Determine how much of module name to display */
+        int dn_len = 0;
+        const char *dn_name;
+        dn_name = SCTransformModule(module, &dn_len);
+        json_object_set_new(ejs, "module", json_string(dn_name));
+    }
+
     if (log_level >= SC_LOG_DEBUG) {
         if (function)
             json_object_set_new(ejs, "function", json_string(function));
@@ -263,6 +282,68 @@ error:
     return -1;
 }
 
+static const int TranfromMaxSegmentCount = 2; /* The maximum segment count to display */
+/*
+ * \brief Return a display name for the given module name for logging.
+ *
+ * The transformation is dependent upon the source code module names
+ * that use the dash character to separate incremental refinements of
+ * the subsystem.
+ *
+ * The transformation uses the local constant "TranfromMaxSegmentCount" to determine
+ * how many segments to display; the transformed name will never consist
+ * of more than this many segments.
+ *
+ * E.g., "detect-http-content-len" ==> "detect-http" when the max is 2
+ *
+ * \param module_name The source code module name to be transformed.
+ * \param dn_len The number of characters in the display name to print.
+ *
+ * \retval Pointer to the display name
+ */
+static const char *SCTransformModule(const char *module_name, int *dn_len)
+{
+    /*
+     * special case for source code module names beginning with:
+     *    Prefixes skipped
+     *        tm-*
+     *        util-*
+     *        source-*
+     *    No transformation
+     *        app-layer-*
+     */
+    if (strncmp("tm-", module_name, 3) == 0) {
+        *dn_len = strlen(module_name) - 3;
+        return module_name + 3;
+    } else if (strncmp("util-", module_name, 5) == 0) {
+        *dn_len = strlen(module_name) - 5;
+        return module_name + 5;
+    } else if (strncmp("source-", module_name, 7) == 0) {
+        *dn_len = strlen(module_name) - 7;
+        return module_name + 7;
+    } else if (strncmp("app-layer-", module_name, 10) == 0) {
+        *dn_len = strlen(module_name);
+        return module_name;
+    }
+
+    int seg_cnt = 0;
+
+    char *last;
+    char *w = (char *)module_name;
+    while (w && (w = strchr(w, '-')) != NULL && seg_cnt < TranfromMaxSegmentCount) {
+        seg_cnt++;
+        last = w;
+        w++; /* skip past '-' */
+    }
+
+    if (seg_cnt < TranfromMaxSegmentCount)
+        *dn_len = strlen(module_name);
+    else
+        *dn_len = last - module_name;
+
+    return module_name;
+}
+
 /**
  * \brief Adds the global log_format to the outgoing buffer
  *
@@ -274,17 +355,20 @@ error:
  *
  * \retval SC_OK on success; else an error code
  */
-static SCError SCLogMessageGetBuffer(
-        struct timeval *tval, int color, SCLogOPType type,
-                     char *buffer, size_t buffer_size,
-                     const char *log_format,
-
-                     const SCLogLevel log_level, const char *file,
-                     const unsigned int line, const char *function,
-                     const SCError error_code, const char *message)
+static SCError SCLogMessageGetBuffer(struct timeval *tval, int color, SCLogOPType type,
+        char *buffer, size_t buffer_size, const char *log_format, const SCLogLevel log_level,
+        const char *file, const unsigned int line, const char *function, const char *module,
+        const SCError error_code, const char *message)
 {
+    if (_sc_subsystem[0] == '\0') {
+        if (SCGetThreadName(_sc_subsystem, 16) < 0) {
+            memset(_sc_subsystem, 0, 16);
+        }
+    }
+
     if (type == SC_LOG_OP_TYPE_JSON)
-        return SCLogMessageJSON(tval, buffer, buffer_size, log_level, file, line, function, error_code, message);
+        return SCLogMessageJSON(tval, buffer, buffer_size, log_level, file, line, function, module,
+                error_code, message);
 
     char *temp = buffer;
     const char *s = NULL;
@@ -438,6 +522,28 @@ static SCError SCLogMessageGetBuffer(
                 substr++;
                 break;
 
+            case SC_LOG_FMT_SUBSYSTEM:
+                temp_fmt[0] = '\0';
+
+                /* Determine how much of module name to display */
+                int dn_len = 0;
+                const char *dn_name;
+                if (module) {
+                    dn_name = SCTransformModule(module, &dn_len);
+                }
+
+                cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer), "%s%s%s%s%.*s%s",
+                        substr, green, _sc_subsystem[0] == '\0' ? "" : _sc_subsystem,
+                        _sc_subsystem[0] == '\0' ? "" : ":", dn_len, module == NULL ? "" : dn_name,
+                        reset);
+                if (cw < 0)
+                    return SC_ERR_SPRINTF;
+                temp += cw;
+                temp_fmt++;
+                substr = temp_fmt;
+                substr++;
+                break;
+
             case SC_LOG_FMT_FUNCTION:
                 temp_fmt[0] = '\0';
                 cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer),
@@ -450,6 +556,24 @@ static SCError SCLogMessageGetBuffer(
                 substr++;
                 break;
 
+            case SC_LOG_FMT_ERRCODE:
+                temp_fmt[0] = '\0';
+                if (SC_OK != error_code) {
+                    cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer),
+                            "%s[%sERRCODE%s: %s%s%s(%s%d%s)] - ", substr, yellow, reset, red,
+                            SCErrorToString(error_code), reset, yellow, error_code, reset);
+                    if (cw < 0)
+                        return SC_ERR_SPRINTF;
+                } else {
+                    cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer), "%s", substr);
+                    if (cw < 0)
+                        return SC_ERR_SPRINTF;
+                }
+                temp += cw;
+                temp_fmt++;
+                substr = temp_fmt;
+                substr++;
+                break;
         }
         temp_fmt++;
 	}
@@ -463,18 +587,6 @@ static SCError SCLogMessageGetBuffer(
     temp += cw;
     if ((temp - buffer) > SC_LOG_MAX_LOG_MSG_LEN) {
         return SC_OK;
-    }
-
-    if (error_code != SC_OK) {
-        cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer),
-                "[%sERRCODE%s: %s%s%s(%s%d%s)] - ", yellow, reset, red, SCErrorToString(error_code), reset, yellow, error_code, reset);
-        if (cw < 0) {
-            return SC_ERR_SPRINTF;
-        }
-        temp += cw;
-        if ((temp - buffer) > SC_LOG_MAX_LOG_MSG_LEN) {
-            return SC_OK;
-        }
     }
 
     const char *hi = "";
@@ -538,9 +650,8 @@ static int SCLogReopen(SCLogOPIfaceCtx *op_iface_ctx)
  *
  * \retval SC_OK on success; else an error code
  */
-SCError SCLogMessage(const SCLogLevel log_level, const char *file,
-                     const unsigned int line, const char *function,
-                     const SCError error_code, const char *message)
+SCError SCLogMessage(const SCLogLevel log_level, const char *file, const unsigned int line,
+        const char *function, const char *module, const SCError error_code, const char *message)
 {
     char buffer[SC_LOG_MAX_LOG_MSG_LEN] = "";
     SCLogOPIfaceCtx *op_iface_ctx = NULL;
@@ -565,22 +676,18 @@ SCError SCLogMessage(const SCLogLevel log_level, const char *file,
         switch (op_iface_ctx->iface) {
             case SC_LOG_OP_IFACE_CONSOLE:
                 if (SCLogMessageGetBuffer(&tval, op_iface_ctx->use_color, op_iface_ctx->type,
-                                          buffer, sizeof(buffer),
-                                          op_iface_ctx->log_format ?
-                                              op_iface_ctx->log_format : sc_log_config->log_format,
-                                          log_level, file, line, function,
-                                          error_code, message) == 0)
-                {
+                            buffer, sizeof(buffer),
+                            op_iface_ctx->log_format ? op_iface_ctx->log_format
+                                                     : sc_log_config->log_format,
+                            log_level, file, line, function, module, error_code, message) == 0) {
                     SCLogPrintToStream((log_level == SC_LOG_ERROR)? stderr: stdout, buffer);
                 }
                 break;
             case SC_LOG_OP_IFACE_FILE:
                 if (SCLogMessageGetBuffer(&tval, 0, op_iface_ctx->type, buffer, sizeof(buffer),
-                                          op_iface_ctx->log_format ?
-                                              op_iface_ctx->log_format : sc_log_config->log_format,
-                                          log_level, file, line, function,
-                                          error_code, message) == 0)
-                {
+                            op_iface_ctx->log_format ? op_iface_ctx->log_format
+                                                     : sc_log_config->log_format,
+                            log_level, file, line, function, module, error_code, message) == 0) {
                     int r = 0;
                     SCMutexLock(&op_iface_ctx->fp_mutex);
                     if (op_iface_ctx->rotation_flag) {
@@ -599,11 +706,9 @@ SCError SCLogMessage(const SCLogLevel log_level, const char *file,
                 break;
             case SC_LOG_OP_IFACE_SYSLOG:
                 if (SCLogMessageGetBuffer(&tval, 0, op_iface_ctx->type, buffer, sizeof(buffer),
-                                          op_iface_ctx->log_format ?
-                                              op_iface_ctx->log_format : sc_log_config->log_format,
-                                          log_level, file, line, function,
-                                          error_code, message) == 0)
-                {
+                            op_iface_ctx->log_format ? op_iface_ctx->log_format
+                                                     : sc_log_config->log_format,
+                            log_level, file, line, function, module, error_code, message) == 0) {
                     SCLogPrintToSyslog(SCLogMapLogLevelToSyslogLevel(log_level), buffer);
                 }
                 break;
@@ -615,7 +720,7 @@ SCError SCLogMessage(const SCLogLevel log_level, const char *file,
     return SC_OK;
 }
 
-void SCLog(int x, const char *file, const char *func, const int line,
+void SCLog(int x, const char *file, const char *func, const int line, const char *module,
         const char *fmt, ...)
 {
     if (sc_log_global_log_level >= x &&
@@ -630,11 +735,11 @@ void SCLog(int x, const char *file, const char *func, const int line,
         va_start(ap, fmt);
         vsnprintf(msg, sizeof(msg), fmt, ap);
         va_end(ap);
-        SCLogMessage(x, file, line, func, SC_OK, msg);
+        SCLogMessage(x, file, line, func, module, SC_OK, msg);
     }
 }
 
-void SCLogErr(int x, const char *file, const char *func, const int line,
+void SCLogErr(int x, const char *file, const char *func, const int line, const char *module,
         const int err, const char *fmt, ...)
 {
     if (sc_log_global_log_level >= x &&
@@ -649,7 +754,7 @@ void SCLogErr(int x, const char *file, const char *func, const int line,
         va_start(ap, fmt);
         vsnprintf(msg, sizeof(msg), fmt, ap);
         va_end(ap);
-        SCLogMessage(x, file, line, func, err, msg);
+        SCLogMessage(x, file, line, func, module, err, msg);
     }
 }
 

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -809,11 +809,10 @@ static inline SCLogOPIfaceCtx *SCLogAllocLogOPIfaceCtx(void)
 {
     SCLogOPIfaceCtx *iface_ctx = NULL;
 
-    if ( (iface_ctx = SCMalloc(sizeof(SCLogOPIfaceCtx))) == NULL) {
+    if ((iface_ctx = SCCalloc(1, sizeof(SCLogOPIfaceCtx))) == NULL) {
         FatalError(SC_ERR_FATAL,
                    "Fatal error encountered in SCLogallocLogOPIfaceCtx. Exiting...");
     }
-    memset(iface_ctx, 0, sizeof(SCLogOPIfaceCtx));
 
     return iface_ctx;
 }
@@ -1253,11 +1252,8 @@ SCLogInitData *SCLogAllocLogInitData(void)
 {
     SCLogInitData *sc_lid = NULL;
 
-    /* not using SCMalloc here because if it fails we can't log */
-    if ( (sc_lid = SCMalloc(sizeof(SCLogInitData))) == NULL)
+    if ((sc_lid = SCCalloc(1, sizeof(SCLogInitData))) == NULL)
         return NULL;
-
-    memset(sc_lid, 0, sizeof(SCLogInitData));
 
     return sc_lid;
 }
@@ -1410,11 +1406,10 @@ void SCLogInitLogModule(SCLogInitData *sc_lid)
 #endif /* OS_WIN32 */
 
     /* sc_log_config is a global variable */
-    if ( (sc_log_config = SCMalloc(sizeof(SCLogConfig))) == NULL) {
+    if ((sc_log_config = SCCalloc(1, sizeof(SCLogConfig))) == NULL) {
         FatalError(SC_ERR_FATAL,
                    "Fatal error encountered in SCLogInitLogModule. Exiting...");
     }
-    memset(sc_log_config, 0, sizeof(SCLogConfig));
 
     SCLogSetLogLevel(sc_lid, sc_log_config);
     SCLogSetLogFormat(sc_lid, sc_log_config);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -546,7 +546,7 @@ logging:
   # something reasonable if not provided.  Can be overridden in an
   # output section.  You can leave this out to get the default.
   #
-  # This value is overridden by the SC_LOG_FORMAT env var.
+  # This console log format value can be  overridden by the SC_LOG_FORMAT env var.
   #default-log-format: "[%i] %t [%S] - (%f:%l) <%d> (%n) -- "
 
   # A regex to filter output.  Can be overridden in an output section.

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -547,7 +547,7 @@ logging:
   # output section.  You can leave this out to get the default.
   #
   # This value is overridden by the SC_LOG_FORMAT env var.
-  #default-log-format: "[%i] %t - (%f:%l) <%d> (%n) -- "
+  #default-log-format: "[%i] %t [%S] - (%f:%l) <%d> (%n) -- "
 
   # A regex to filter output.  Can be overridden in an output section.
   # Defaults to empty (no filter).


### PR DESCRIPTION
Continuation of #6341 

This changeset provides subsystem and module identifiers in the log when
the log format string contains `"%S"`. By convention, the log format
surrounds `"%S"` with brackets.

The subsystem name is generally the same as the thread name. The module
name is derived from the source code module name and usually consists of
the first one or 2 segments of the name using the dash character as the
segment delimiter.

Issue 2497: [redmine](https://redmine.openinfosecfoundation.org/issues/2497)

@jasonish suggested formatting changes -- those have been incorporated into this PR. See below for example output for non-debug and debug modes.

Updates:
1. clang format update 

Describe changes:
This PR adds a subsystem and module identifier to SCLog messages when the log format includes `%S`. Subsystem and module identifiers are intrinsic properties of threads and source code modules (respectively).

New threads are assigned a subsystem identifier when the thread is created; the identifier is a Thread-Local-Storage variable declared in util-debug.c; values are assigned to it as threads are created using SCSetSubsystem (a macro defined in util-debug.h).

Module identifiers are derived from the source code module emitting the log message. A new CPP define `__SCFILENAME__` is assigned to `_sc_module` (`util-debug.h`) at compile time. Rust source module names are determined dynamically during the calls to the log function.

Subsystem and module identifiers are added to log messages when the format contains `%S`. The generated log message will substitute a tag built from

- The subsystem identifier. This corresponds to the calling thread which may be the Suricata main thread, or a subordinate thread for a task-specific function, e.g., `RX#01`.
- (Optional) The module identifier will be included if set (not all source modules will set one but most source modules have been modified to set one.)
The constructed tag is of the form `subsystem-id[:module-identifier]` (the brackets surrounding the module-identifier indicate the module-identifier is optional and are not included in the output; output formatting is strictly controlled by the log format in effect).

Also, two travis related changes are included in this PR
1. Update Travis to use Xenial (16.04) rather than Trusty (14.04)
1. Update to display config.log when Travis build errors occur.

Example output
Non-debug mode
```
[2182243] 5/4/2021 -- 08:32:51 [Suricata-main:suricata] - <Notice> -- This is Suricata version 7.0.0-dev running in USER mode
[2182243] 5/4/2021 -- 08:32:51 [Suricata-main:cpu] - <Info> -- CPUs/cores online: 16
[2182243] 5/4/2021 -- 08:32:52 [Suricata-main:coredump-config] - <Info> -- Could not set core dump size to unlimited; it's set to the hard limit.
[2182243] 5/4/2021 -- 08:32:52 [Suricata-main:logopenfile] - <Info> -- fast output device (regular) initialized: fast.log
[2182243] 5/4/2021 -- 08:32:52 [Suricata-main:logopenfile] - <Info> -- eve-log output device (regular) initialized: eve.json
[2182243] 5/4/2021 -- 08:32:52 [Suricata-main:logopenfile] - <Info> -- stats output device (regular) initialized: stats.log
[2182243] 5/4/2021 -- 08:32:52 [Suricata-main:classification-config] - <Info> -- Added "43" classification types from the classification file
[2182243] 5/4/2021 -- 08:32:52 [Suricata-main:reference-config] - <Info> -- Added "19" reference types from the reference.config file
[2182243] 5/4/2021 -- 08:32:56 [Suricata-main:detect-parse] - <Error> -- [ERRCODE: SC_ERR_INVALID_SIGNATURE(39)] - unexpected option to http_header_names keyword: 'http_header_names'
[2182243] 5/4/2021 -- 08:32:56 [Suricata-main:detect-engine] - <Error> -- [ERRCODE: SC_ERR_INVALID_SIGNATURE(39)] - error parsing signature "alert http $HOME_NET any -> $EXTERNAL_NET any (msg:"ET MALWARE Win32/Adware.Adposhel.A Checkin M6"; flow:established,to_server; content:"GET"; http_method; urilen:>200; content:"/q/?q="; http_uri; depth:6; fast_pattern; pcre:"/^[a-zA-Z0-9_-]+/UR"; content:"User-Agent|3a 20|"; http_user_agent; depth:12; http_header_names: content:!"Referer"; content:!"Accept"; metadata: former_category ADWARE_PUP; classtype:trojan-activity; sid:2029055; rev:2; metadata:affected_product Windows_XP_Vista_7_8_10_Server_32_64_Bit, attack_target Client_Endpoint, deployment Perimeter, signature_severity Major, created_at 2019_11_26, performance_impact Low, updated_at 2019_11_26;)" from file /home/jlucovsky/et.rules at line 19714
[2182243] 5/4/2021 -- 08:33:13 [Suricata-main:detect-engine] - <Info> -- 1 rule files processed. 19187 rules successfully loaded, 1 rules failed
[2182243] 5/4/2021 -- 08:33:13 [Suricata-main:threshold-config] - <Warning> -- [ERRCODE: SC_ERR_FOPEN(44)] - Error opening file: "/usr/local/etc/suricata//threshold.config": Permission denied
[2182243] 5/4/2021 -- 08:33:13 [Suricata-main:detect-engine] - <Info> -- 19190 signatures processed. 1094 are IP-only rules, 3860 are inspecting packet payload, 14179 inspect application layer, 0 are decoder event only
[2182716] 5/4/2021 -- 08:33:53 [RX#01:pcap-file] - <Info> -- Argument /home/jlucovsky/pcap/ was a directory
[2182243] 5/4/2021 -- 08:33:53 [Suricata-main:threads] - <Notice> -- Threads created -> RX: 1 W: 16 FM: 1 FR: 1   Engine started.
[2182716] 5/4/2021 -- 08:33:53 [RX#01:pcap-file] - <Info> -- Starting directory run for /home/jlucovsky/pcap/
```

Debug mode
```
[2102717] 5/4/2021 -- 08:18:43 [Suricata-main:suricata] - (suricata.c:1062) <Notice> (LogVersion) -- This is Suricata version 7.0.0-dev running in USER mode
[2102717] 5/4/2021 -- 08:18:43 [Suricata-main:cpu] - (util-cpu.c:178) <Info> (UtilCpuPrintSummary) -- CPUs/cores online: 16
[2102717] 5/4/2021 -- 08:18:43 [Suricata-main:coredump-config] - (util-coredump-config.c:166) <Info> (CoredumpLoadConfig) -- Could not set core dump size to unlimited; it's set to the hard limit.
[2102717] 5/4/2021 -- 08:18:43 [Suricata-main:logopenfile] - (util-logopenfile.c:596) <Info> (SCConfLogOpenGeneric) -- fast output device (regular) initialized: fast.log
[2102717] 5/4/2021 -- 08:18:43 [Suricata-main:logopenfile] - (util-logopenfile.c:596) <Info> (SCConfLogOpenGeneric) -- eve-log output device (regular) initialized: eve.json
[2102717] 5/4/2021 -- 08:18:43 [Suricata-main:logopenfile] - (util-logopenfile.c:596) <Info> (SCConfLogOpenGeneric) -- stats output device (regular) initialized: stats.log
[2102717] 5/4/2021 -- 08:18:43 [Suricata-main:classification-config] - (util-classification-config.c:363) <Info> (SCClassConfParseFile) -- Added "43" classification types from the classification file
[2102717] 5/4/2021 -- 08:18:43 [Suricata-main:reference-config] - (util-reference-config.c:339) <Info> (SCRConfParseFile) -- Added "19" reference types from the reference.config file
[2102717] 5/4/2021 -- 08:18:47 [Suricata-main:detect-parse] - (detect-parse.c:714) <Error> (SigParseOptions) -- [ERRCODE: SC_ERR_INVALID_SIGNATURE(39)] - unexpected option to http_header_names keyword: 'http_header_names'
[2102717] 5/4/2021 -- 08:18:47 [Suricata-main:detect-engine] - (detect-engine-loader.c:184) <Error> (DetectLoadSigFile) -- [ERRCODE: SC_ERR_INVALID_SIGNATURE(39)] - error parsing signature "alert http $HOME_NET any -> $EXTERNAL_NET any (msg:"ET MALWARE Win32/Adware.Adposhel.A Checkin M6"; flow:established,to_server; content:"GET"; http_method; urilen:>200; content:"/q/?q="; http_uri; depth:6; fast_pattern; pcre:"/^[a-zA-Z0-9_-]+/UR"; content:"User-Agent|3a 20|"; http_user_agent; depth:12; http_header_names: content:!"Referer"; content:!"Accept"; metadata: former_category ADWARE_PUP; classtype:trojan-activity; sid:2029055; rev:2; metadata:affected_product Windows_XP_Vista_7_8_10_Server_32_64_Bit, attack_target Client_Endpoint, deployment Perimeter, signature_severity Major, created_at 2019_11_26, performance_impact Low, updated_at 2019_11_26;)" from file /home/jlucovsky/et.rules at line 19714
[2102717] 5/4/2021 -- 08:19:05 [Suricata-main:detect-engine] - (detect-engine-loader.c:354) <Info> (SigLoadSignatures) -- 1 rule files processed. 19187 rules successfully loaded, 1 rules failed
[2102717] 5/4/2021 -- 08:19:05 [Suricata-main:threshold-config] - (util-threshold-config.c:250) <Warning> (SCThresholdConfInitContext) -- [ERRCODE: SC_ERR_FOPEN(44)] - Error opening file: "/usr/local/etc/suricata//threshold.config": Permission denied
[2102717] 5/4/2021 -- 08:19:06 [Suricata-main:detect-engine] - (detect-engine-build.c:1416) <Info> (SigAddressPrepareStage1) -- 19190 signatures processed. 1094 are IP-only rules, 3860 are inspecting packet payload, 14179 inspect application layer, 0 are decoder event only
[2103193] 5/4/2021 -- 08:19:45 [RX#01:pcap-file] - (source-pcap-file.c:276) <Info> (ReceivePcapFileThreadInit) -- Argument /home/jlucovsky/pcap/ was a directory
[2102717] 5/4/2021 -- 08:19:46 [Suricata-main:threads] - (tm-threads.c:2020) <Notice> (TmThreadWaitOnThreadInit) -- Threads created -> RX: 1 W: 16 FM: 1 FR: 1   Engine started.
[2103193] 5/4/2021 -- 08:19:46 [RX#01:pcap-file] - (source-pcap-file.c:177) <Info> (ReceivePcapFileLoop) -- Starting directory run for /home/jlucovsky/pcap/
```

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
