### PR TITLE
Next/50x/backports/v2

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -101,6 +101,30 @@ jobs:
           name: prep
           path: .
 
+  prepare-cbindgen:
+    name: Prepare cbindgen
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache ~/.cargo
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo
+          key: cbindgen
+      - name: Installing Rust
+        run: |
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          rustup target add x86_64-unknown-linux-musl
+      - name: Buliding static cbindgen for Linux
+        run: |
+          cargo install --target x86_64-unknown-linux-musl --debug cbindgen
+          cp $HOME/.cargo/bin/cbindgen .
+      - name: Uploading prep archive
+        uses: actions/upload-artifact@v2
+        with:
+          name: prep
+          path: .
+
   centos-8:
     name: CentOS 8
     runs-on: ubuntu-latest
@@ -801,7 +825,7 @@ jobs:
     name: Debian 10
     runs-on: ubuntu-latest
     container: debian:10
-    needs: prep
+    needs: [prep, prepare-cbindgen]
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
@@ -849,8 +873,6 @@ jobs:
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $RUST_VERSION_KNOWN -y
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - name: Install cbindgen
-        run: cargo install --force --debug --version 0.14.1 cbindgen
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -859,6 +881,11 @@ jobs:
           path: prep
       - run: tar xf prep/libhtp.tar.gz
       - run: tar xf prep/suricata-update.tar.gz
+      - name: Setup cbindgen
+        run: |
+          mkdir -p $HOME/.cargo/bin
+          cp prep/cbindgen $HOME/.cargo/bin
+          chmod 755 $HOME/.cargo/bin/cbindgen
       - run: ./autogen.sh
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-unittests --enable-fuzztargets
       - run: make -j2
@@ -871,7 +898,7 @@ jobs:
     name: Debian 9
     runs-on: ubuntu-latest
     container: debian:9
-    needs: prep
+    needs: [prep, prepare-cbindgen]
     steps:
       - run: |
           apt update
@@ -911,8 +938,6 @@ jobs:
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $RUST_VERSION_KNOWN -y
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - name: Install cbindgen
-        run: cargo install --force --debug --version 0.14.1 cbindgen
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
@@ -920,6 +945,11 @@ jobs:
           path: prep
       - run: tar xf prep/libhtp.tar.gz
       - run: tar xf prep/suricata-update.tar.gz
+      - name: Setup cbindgen
+        run: |
+          mkdir -p $HOME/.cargo/bin
+          cp prep/cbindgen $HOME/.cargo/bin
+          chmod 755 $HOME/.cargo/bin/cbindgen
       - run: ./autogen.sh
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-unittests
       - run: make -j2

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -358,7 +358,7 @@ jobs:
       - name: Extracting suricata-verify
         run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: python3 ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py --quiet
 
   fedora-32-no-jansson:
     name: Fedora 32 (no jansson)
@@ -490,7 +490,7 @@ jobs:
       - name: Extracting suricata-verify
         run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: python3 ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py --quiet
 
   ubuntu-20-04:
     name: Ubuntu 20.04 (no nss, no nspr)
@@ -551,7 +551,7 @@ jobs:
       - name: Extracting suricata-verify
         run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: python3 ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py --quiet
 
   ubuntu-20-04-ndebug:
     name: Ubuntu 20.04 (-DNDEBUG)
@@ -614,7 +614,7 @@ jobs:
       - name: Extracting suricata-verify
         run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: python3 ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py --quiet
 
   ubuntu-18-04-debug-validation:
     name: Ubuntu 18.04 (Debug Validation)
@@ -683,7 +683,7 @@ jobs:
       - name: Extracting suricata-verify
         run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: python3 ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py --quiet
 
   ubuntu-18-04:
     name: Ubuntu 18.04 (Cocci)
@@ -757,7 +757,7 @@ jobs:
       - name: Extracting suricata-verify
         run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: python3 ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py --quiet
 
   # An Ubuntu 16.04 build using the tarball generated in the CentOS 8
   # build above.
@@ -892,7 +892,7 @@ jobs:
       - run: make check
       - run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: python3 ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py --quiet
 
   debian-9:
     name: Debian 9
@@ -956,7 +956,7 @@ jobs:
       - run: make check
       - run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: python3 ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py --quiet
 
   macos-latest:
     name: MacOS Latest
@@ -1006,4 +1006,4 @@ jobs:
       - run: make check
       - run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: python3 ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py --quiet

--- a/rules/decoder-events.rules
+++ b/rules/decoder-events.rules
@@ -104,6 +104,7 @@ alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv4 Packet size too large";
 alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv4 Fragmentation overlap"; decode-event:ipv4.frag_overlap; classtype:protocol-command-decode; sid:2200070; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv6 Packet size too large"; decode-event:ipv6.frag_pkt_too_large; classtype:protocol-command-decode; sid:2200071; rev:3;)
 alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv6 Fragmentation overlap"; decode-event:ipv6.frag_overlap; classtype:protocol-command-decode; sid:2200072; rev:2;)
+alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv6 Fragment invalid length"; decode-event:ipv6.frag_invalid_length; classtype:protocol-command-decode; sid:2200119; rev:1;)
 
 # checksum rules
 alert ip any any -> any any (msg:"SURICATA IPv4 invalid checksum"; ipv4-csum:invalid; classtype:protocol-command-decode; sid:2200073; rev:2;)
@@ -145,4 +146,4 @@ alert pkthdr any any -> any any (msg:"SURICATA DCE packet too small"; decode-eve
 
 alert pkthdr any any -> any any (msg:"SURICATA packet with too many layers"; decode-event:too_many_layers; classtype:protocol-command-decode; sid:2200116; rev:1;)
 
-# next sid is 2200117
+# next sid is 2200120

--- a/src/decode-events.c
+++ b/src/decode-events.c
@@ -153,10 +153,26 @@ const struct DecodeEvents_ DEvents[] = {
     { "decoder.sctp.pkt_too_small", SCTP_PKT_TOO_SMALL, },
 
     /* Fragmentation reasembly events. */
-    { "decoder.ipv4.frag_pkt_too_large", IPV4_FRAG_PKT_TOO_LARGE, },
-    { "decoder.ipv6.frag_pkt_too_large", IPV6_FRAG_PKT_TOO_LARGE, },
-    { "decoder.ipv4.frag_overlap", IPV4_FRAG_OVERLAP, },
-    { "decoder.ipv6.frag_overlap", IPV6_FRAG_OVERLAP, },
+    {
+            "decoder.ipv4.frag_pkt_too_large",
+            IPV4_FRAG_PKT_TOO_LARGE,
+    },
+    {
+            "decoder.ipv6.frag_pkt_too_large",
+            IPV6_FRAG_PKT_TOO_LARGE,
+    },
+    {
+            "decoder.ipv4.frag_overlap",
+            IPV4_FRAG_OVERLAP,
+    },
+    {
+            "decoder.ipv6.frag_overlap",
+            IPV6_FRAG_OVERLAP,
+    },
+    {
+            "decoder.ipv6.frag_invalid_length",
+            IPV6_FRAG_INVALID_LENGTH,
+    },
     /* Fragment ignored due to internal error */
     { "decoder.ipv4.frag_ignored", IPV4_FRAG_IGNORED, },
     { "decoder.ipv6.frag_ignored", IPV6_FRAG_IGNORED, },

--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -162,6 +162,7 @@ enum {
     IPV6_FRAG_PKT_TOO_LARGE,
     IPV4_FRAG_OVERLAP,
     IPV6_FRAG_OVERLAP,
+    IPV6_FRAG_INVALID_LENGTH,
 
     /* Fragment ignored due to internal error */
     IPV4_FRAG_IGNORED,

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -459,6 +459,12 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                     plen -= hdrextlen;
                     break;
                 }
+                if (p->ip6eh.fh_more_frags_set != 0 && plen % 8 != 0) {
+                    // cf https://datatracker.ietf.org/doc/html/rfc2460#section-4.5
+                    // each, except possibly the last ("rightmost") one,
+                    // being an integer multiple of 8 octets long.
+                    ENGINE_SET_EVENT(p, IPV6_FRAG_INVALID_LENGTH);
+                }
 
                 /* the rest is parsed upon reassembly */
                 p->flags |= PKT_IS_FRAGMENT;


### PR DESCRIPTION
#6370 

plus a new envvar `SC_MAX_CPUS`, which can be used to limit the number of CPUs suri considers for autofp. The idea is that in CI we can easily limit the number of threads created for all tests at once. I wanted to avoid having to backport https://github.com/OISF/suricata/commit/7d3f39939eb1ec4939bef847dd83a4f88eea3d82 into 5.0.x