### PR TITLE
fuzz: fixes a leak in applayerparse target

### DIFF
--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -148,6 +148,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             memcpy(isolatedBuffer, albuffer, alnext - albuffer);
             (void) AppLayerParserParse(NULL, alp_tctx, f, f->alproto, flags, isolatedBuffer, alnext - albuffer);
             free(isolatedBuffer);
+            if (FlowChangeProto(f)) {
+                // exits if a protocol change is requested
+                alsize = 0;
+                break;
+            }
             flags &= ~(STREAM_START);
             if (f->alparser &&
                    (((flags & STREAM_TOSERVER) != 0 &&


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4125
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=39014


Describe changes:
- Ends processing by fuzz_applayerparser_parse when a protocol change is requested
