### PR TITLE
lua - remove includes out of suricata-common.h - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -315,10 +315,10 @@ jobs:
       - run: tar xf prep/suricata-verify.tar.gz
       - run: python3 ./suricata-verify/run.py -q
 
-  fedora-33:
-    name: Fedora 33 (debug, clang, asan, wshadow, rust-strict)
+  fedora-34:
+    name: Fedora 34 (debug, clang, asan, wshadow, rust-strict)
     runs-on: ubuntu-latest
-    container: fedora:33
+    container: fedora:34
     needs: [prepare-deps, prepare-cbindgen]
     steps:
 
@@ -402,10 +402,10 @@ jobs:
       - run: test -e /usr/local/bin/libsuricata-config
       - run: test ! -e /usr/local/lib/libsuricata.so
 
-  fedora-32:
-    name: Fedora 32 (debug, clang, asan, wshadow, rust-strict)
+  fedora-33:
+    name: Fedora 33 (debug, clang, asan, wshadow, rust-strict)
     runs-on: ubuntu-latest
-    container: fedora:32
+    container: fedora:33
     needs: [prepare-deps, prepare-cbindgen]
     steps:
 
@@ -476,10 +476,10 @@ jobs:
       - name: Running suricata-verify
         run: python3 ./suricata-verify/run.py -q
 
-  fedora-32-no-jansson:
-    name: Fedora 32 (no jansson)
+  fedora-34-no-jansson:
+    name: Fedora 34 (no jansson)
     runs-on: ubuntu-latest
-    container: fedora:32
+    container: fedora:34
     needs: [prepare-deps, prepare-cbindgen]
     steps:
 

--- a/src/detect-lua.h
+++ b/src/detect-lua.h
@@ -26,6 +26,8 @@
 
 #ifdef HAVE_LUA
 
+#include "util-lua.h"
+
 typedef struct DetectLuaThreadData {
     lua_State *luastate;
     uint32_t flags;

--- a/src/rust.h
+++ b/src/rust.h
@@ -18,6 +18,7 @@
 #ifndef __RUST_H__
 #define __RUST_H__
 
+#include "util-lua.h"
 #include "rust-context.h"
 #include "rust-bindings.h"
 

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -503,16 +503,6 @@ typedef enum {
 #include "util-path.h"
 #include "util-conf.h"
 
-#ifdef HAVE_LUA
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-#else
-/* If we don't have Lua, create a typedef for lua_State so the
- * exported Lua functions don't fail the build. */
-typedef void lua_State;
-#endif
-
 #ifndef HAVE_STRLCAT
 size_t strlcat(char *, const char *src, size_t siz);
 #endif

--- a/src/util-lua.h
+++ b/src/util-lua.h
@@ -24,7 +24,17 @@
 #ifndef __UTIL_LUA_H__
 #define __UTIL_LUA_H__
 
-#ifdef HAVE_LUA
+#ifndef HAVE_LUA
+
+/* If we don't have Lua, create a typedef for lua_State so the
+ * exported Lua functions don't fail the build. */
+typedef void lua_State;
+
+#else
+
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
 
 #include "util-luajit.h"
 


### PR DESCRIPTION
Move Lua includes out of suricata-common.h.  This causes problems with
library/plugin users as the plugin neesd to setup the Lua CFLAGS to find the
includes if not by default. Ideally a plugin/application should not need to
know about Lua unless itself is using Lua.

This PR puts the Lua headers into util-lua.h so only code that needs to be Lua
aware will end up pulling in the headers.

Also update the Fedora build versions in CI to Fedora 33 and 34.  I tought
disappearing Fedora 32 (now EOL) was causing CI issues so added this commit,
but turns out it was just an intermitent issue.

