### PR TITLE
Warn clang14 v1

### DIFF
--- a/rust/src/filetracker.rs
+++ b/rust/src/filetracker.rs
@@ -51,7 +51,6 @@ impl FileChunk {
 #[derive(Debug)]
 #[derive(Default)]
 pub struct FileTransferTracker {
-    file_size: u64,
     pub tracked: u64,
     cur_ooo: u64,   // how many bytes do we have queued from ooo chunks
     track_id: u32,

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -78,13 +78,6 @@ impl State {
     }
 }
 
-#[derive(Debug, Clone)]
-struct Mark {
-    position: usize,
-    state_index: usize,
-    state: State,
-}
-
 /// A "mark" or saved state for a JsonBuilder object.
 ///
 /// The name is full, and the types are u64 as this object is used

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1469,7 +1469,7 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
     }
     if (rule_flow == 0 && rule_flags == 0
         && !(s->proto.flags & DETECT_PROTO_ANY) && DetectProtoContainsProto(&s->proto, IPPROTO_TCP)
-        && (rule_content || rule_content_http || rule_pcre || rule_pcre_http || rule_flowbits)) {
+        && (rule_content || rule_content_http || rule_pcre || rule_pcre_http || rule_flowbits || rule_flowint)) {
         rule_warning += 1;
         warn_tcp_no_flow = 1;
     }
@@ -1536,7 +1536,7 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
         if (rule_ipv6_only) fprintf(rule_engine_analysis_FD, "    Rule is IPv6 only.\n");
         if (rule_ipv4_only) fprintf(rule_engine_analysis_FD, "    Rule is IPv4 only.\n");
         if (packet_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on packets.\n");
-        if (!rule_flow_nostream && stream_buf && (rule_flow || rule_flowbits || rule_content || rule_pcre)) {
+        if (!rule_flow_nostream && stream_buf && (rule_flow || rule_flowbits || rule_flowint || rule_content || rule_pcre)) {
             fprintf(rule_engine_analysis_FD, "    Rule matches on reassembled stream.\n");
         }
         for(size_t i = 0; i < ARRAY_SIZE(analyzer_items); i++) {

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1467,9 +1467,10 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
     if (rule_content == 1) {
          //todo: warning if content is weak, separate warning for pcre + weak content
     }
-    if (rule_flow == 0 && rule_flags == 0
-        && !(s->proto.flags & DETECT_PROTO_ANY) && DetectProtoContainsProto(&s->proto, IPPROTO_TCP)
-        && (rule_content || rule_content_http || rule_pcre || rule_pcre_http || rule_flowbits || rule_flowint)) {
+    if (rule_flow == 0 && rule_flags == 0 && !(s->proto.flags & DETECT_PROTO_ANY) &&
+            DetectProtoContainsProto(&s->proto, IPPROTO_TCP) &&
+            (rule_content || rule_content_http || rule_pcre || rule_pcre_http || rule_flowbits ||
+                    rule_flowint)) {
         rule_warning += 1;
         warn_tcp_no_flow = 1;
     }
@@ -1536,7 +1537,8 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
         if (rule_ipv6_only) fprintf(rule_engine_analysis_FD, "    Rule is IPv6 only.\n");
         if (rule_ipv4_only) fprintf(rule_engine_analysis_FD, "    Rule is IPv4 only.\n");
         if (packet_buf) fprintf(rule_engine_analysis_FD, "    Rule matches on packets.\n");
-        if (!rule_flow_nostream && stream_buf && (rule_flow || rule_flowbits || rule_flowint || rule_content || rule_pcre)) {
+        if (!rule_flow_nostream && stream_buf &&
+                (rule_flow || rule_flowbits || rule_flowint || rule_content || rule_pcre)) {
             fprintf(rule_engine_analysis_FD, "    Rule matches on reassembled stream.\n");
         }
         for(size_t i = 0; i < ARRAY_SIZE(analyzer_items); i++) {

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -629,7 +629,6 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
     uint32_t payload_no_mpm_cnt = 0;
     uint32_t syn_cnt = 0;
 
-    uint32_t mpms_total = 0;
     uint32_t mpms_min = 0;
     uint32_t mpms_max = 0;
 
@@ -741,7 +740,6 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
             }
 
             uint32_t w = PatternStrength(cd->content, cd->content_len);
-            mpms_total += w;
             if (mpms_min == 0)
                 mpms_min = w;
             if (w < mpms_min)

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -806,8 +806,10 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
 */
     memset(&ts, 0, sizeof(ts));
     uint32_t hash_passes = 0;
+#ifdef FM_PROFILE
     uint32_t hash_row_checks = 0;
     uint32_t hash_passes_chunks = 0;
+#endif
     uint32_t hash_full_passes = 0;
 
     const uint32_t min_timeout = FlowTimeoutsMin();
@@ -903,9 +905,11 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
                 FlowTimeoutHash(&ftd->timeout, &ts, ftd->min, ftd->max, &counters);
                 hash_passes++;
                 hash_full_passes++;
-                hash_passes_chunks += 1;
                 hash_passes++;
+#ifdef FM_PROFILE
+                hash_passes_chunks += 1;
                 hash_row_checks += counters.rows_checked;
+#endif
                 StatsIncr(th_v, ftd->cnt.flow_mgr_full_pass);
             } else {
                 /* non-emergency mode: scan part of the hash */
@@ -921,8 +925,10 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
                     }
                 }
                 hash_passes++;
+#ifdef FM_PROFILE
                 hash_row_checks += counters.rows_checked;
                 hash_passes_chunks += chunks;
+#endif
             }
             flow_last_sec = rt;
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None, should I create one ?

Describe changes:
- Fixes the latest warnings on rust nightly + clang 14
- One functional change to fix one of the warnings is to treat `rule_flowint` as `rule_flowbits` in detect-engine-analyzer.c

Warnings are 
```
warning: field is never read: `position`
  --> /src/suricata/rust/src/jsonbuilder.rs:83:5
   |
83 |     position: usize,
   |     ^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: field is never read: `state_index`
  --> /src/suricata/rust/src/jsonbuilder.rs:84:5
   |
84 |     state_index: usize,
   |     ^^^^^^^^^^^^^^^^^^

warning: field is never read: `state`
  --> /src/suricata/rust/src/jsonbuilder.rs:85:5
   |
85 |     state: State,
   |     ^^^^^^^^^^^^

warning: field is never read: `file_size`
  --> /src/suricata/rust/src/filetracker.rs:54:5
   |
54 |     file_size: u64,
   |     ^^^^^^^^^^^^^^

```

and
```
detect-engine-build.c:632:14: warning: variable 'mpms_total' set but not used [-Wunused-but-set-variable]
    uint32_t mpms_total = 0;
             ^
detect-engine-analyzer.c:1319:14: warning: variable 'rule_flowint' set but not used [-Wunused-but-set-variable]
    uint32_t rule_flowint = 0;

flow-manager.c:809:14: warning: variable 'hash_row_checks' set but not used [-Wunused-but-set-variable]
    uint32_t hash_row_checks = 0;
             ^
flow-manager.c:810:14: warning: variable 'hash_passes_chunks' set but not used [-Wunused-but-set-variable]
    uint32_t hash_passes_chunks = 0;
             ^
```