### PR TITLE
Pcre2 3194 v21

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -209,6 +209,7 @@ jobs:
                 make \
                 nss-devel \
                 pcre-devel \
+                pcre2-devel \
                 pkgconfig \
                 python3-devel \
                 python3-sphinx \
@@ -284,6 +285,7 @@ jobs:
                 make \
                 nss-devel \
                 pcre-devel \
+                pcre2-devel \
                 pkgconfig \
                 python36-PyYAML \
                 rust \
@@ -360,6 +362,7 @@ jobs:
                 make \
                 nss-softokn-devel \
                 pcre-devel \
+                pcre2-devel \
                 pkgconfig \
                 python3-yaml \
                 sudo \
@@ -446,6 +449,7 @@ jobs:
                 make \
                 nss-softokn-devel \
                 pcre-devel \
+                pcre2-devel \
                 pkgconfig \
                 python3-yaml \
                 sudo \
@@ -518,6 +522,7 @@ jobs:
                 make \
                 nss-softokn-devel \
                 pcre-devel \
+                pcre2-devel \
                 pkgconfig \
                 python3-yaml \
                 sudo \
@@ -556,6 +561,7 @@ jobs:
           apt -y install \
                 libpcre3 \
                 libpcre3-dev \
+                libpcre2-dev \
                 build-essential \
                 autoconf \
                 automake \
@@ -633,6 +639,7 @@ jobs:
           apt -y install \
                 libpcre3 \
                 libpcre3-dev \
+                libpcre2-dev \
                 build-essential \
                 autoconf \
                 automake \
@@ -706,6 +713,7 @@ jobs:
           apt -y install \
                 libpcre3 \
                 libpcre3-dev \
+                libpcre2-dev \
                 build-essential \
                 autoconf \
                 automake \
@@ -807,6 +815,7 @@ jobs:
                 libpython2.7 \
                 libpcre3 \
                 libpcre3-dev \
+                libpcre2-dev \
                 make \
                 parallel \
                 python3-yaml \
@@ -882,6 +891,7 @@ jobs:
                 libpython2.7 \
                 libpcre3 \
                 libpcre3-dev \
+                libpcre2-dev \
                 make \
                 python3-yaml \
                 software-properties-common \
@@ -922,6 +932,7 @@ jobs:
           apt -y install \
                 libpcre3 \
                 libpcre3-dev \
+                libpcre2-dev \
                 build-essential \
                 autoconf \
                 automake \
@@ -994,6 +1005,7 @@ jobs:
           apt -y install \
                 libpcre3 \
                 libpcre3-dev \
+                libpcre2-dev \
                 build-essential \
                 autoconf \
                 automake \
@@ -1091,6 +1103,7 @@ jobs:
                 afl-clang \
                 libpcre3 \
                 libpcre3-dev \
+                libpcre2-dev \
                 build-essential \
                 autoconf \
                 automake \
@@ -1160,6 +1173,7 @@ jobs:
                 libnfnetlink0 \
                 libpcre3 \
                 libpcre3-dev \
+                libpcre2-dev \
                 libpcap-dev \
                 libyaml-0-2 \
                 libyaml-dev \
@@ -1213,6 +1227,7 @@ jobs:
                 libpcre3 \
                 libpcre3-dbg \
                 libpcre3-dev \
+                libpcre2-dev \
                 libpcap-dev   \
                 libnet1-dev \
                 libyaml-0-2 \
@@ -1279,6 +1294,7 @@ jobs:
                 libpcre3 \
                 libpcre3-dbg \
                 libpcre3-dev \
+                libpcre2-dev \
                 libpcap-dev   \
                 libnet1-dev \
                 libyaml-0-2 \
@@ -1383,7 +1399,7 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          install: git mingw-w64-x86_64-toolchain automake1.16 automake-wrapper autoconf libtool libyaml-devel pcre-devel jansson-devel make mingw-w64-x86_64-libyaml mingw-w64-x86_64-pcre mingw-w64-x86_64-rust mingw-w64-x86_64-jansson unzip p7zip python-setuptools mingw-w64-x86_64-python-yaml mingw-w64-x86_64-jq mingw-w64-x86_64-libxml2
+          install: git mingw-w64-x86_64-toolchain automake1.16 automake-wrapper autoconf libtool libyaml-devel pcre-devel pcre2-devel jansson-devel make mingw-w64-x86_64-libyaml mingw-w64-x86_64-pcre mingw-w64-x86_64-pcre2 mingw-w64-x86_64-rust mingw-w64-x86_64-jansson unzip p7zip python-setuptools mingw-w64-x86_64-python-yaml mingw-w64-x86_64-jq mingw-w64-x86_64-libxml2
       # hack: install our own cbindgen system wide as we can't get the
       # preinstalled one to be picked up by configure
       - name: cbindgen

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -21,6 +21,7 @@ jobs:
           apt -y install \
                 libpcre3 \
                 libpcre3-dev \
+                libpcre2-dev \
                 build-essential \
                 autoconf \
                 automake \

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -31,6 +31,7 @@ jobs:
           apt -y install \
                 libpcre3 \
                 libpcre3-dev \
+                libpcre2-dev \
                 build-essential \
                 autoconf \
                 automake \

--- a/configure.ac
+++ b/configure.ac
@@ -608,35 +608,6 @@
         LIBS="${TMPLIBS} -lz"
     fi
 
-  #libpcre
-    AC_ARG_WITH(libpcre_includes,
-            [  --with-libpcre-includes=DIR  libpcre include directory],
-            [with_libpcre_includes="$withval"],[with_libpcre_includes="no"])
-    AC_ARG_WITH(libpcre_libraries,
-            [  --with-libpcre-libraries=DIR    libpcre library directory],
-            [with_libpcre_libraries="$withval"],[with_libpcre_libraries="no"])
-
-    if test "$with_libpcre_includes" != "no"; then
-        CPPFLAGS="${CPPFLAGS} -I${with_libpcre_includes}"
-    fi
-    AC_CHECK_HEADER(pcre.h,,[AC_MSG_ERROR(pcre.h not found ...)])
-
-    if test "$with_libpcre_libraries" != "no"; then
-        LDFLAGS="${LDFLAGS} -L${with_libpcre_libraries}"
-    fi
-    PCRE=""
-    AC_CHECK_LIB(pcre, pcre_get_substring,,PCRE="no")
-    if test "$PCRE" = "no"; then
-        echo
-        echo "   ERROR!  pcre library not found, go get it"
-        echo "   from www.pcre.org. Or from packages:"
-        echo "   Debian/Ubuntu: apt install libpcre3-dev"
-        echo "   Fedora: dnf install pcre-devel"
-        echo "   CentOS/RHEL: yum install pcre-devel"
-        echo
-        exit 1
-    fi
-
     PCRE2=""
     AC_CHECK_LIB(pcre2-8, pcre2_compile_8,,PCRE2="no")
     if test "$PCRE2" = "no"; then
@@ -664,45 +635,6 @@
     else
         AC_MSG_RESULT(no)
     fi
-
-    # libpcre 8.35 (especially on debian) has a known issue that results in segfaults
-    # see https://redmine.openinfosecfoundation.org/issues/1693
-    if test "$with_libpcre_libraries" = "no"; then
-        PKG_CHECK_MODULES(LIBPCREVERSION, [libpcre = 8.35],[libpcre_buggy_found="yes"],[libprce_buggy_found="no"])
-        if test "$libpcre_buggy_found" = "yes"; then
-            echo
-            echo "   Warning! vulnerable libpcre version 8.35 found"
-            echo "   This version has a known issue that could result in segfaults"
-            echo "   please upgrade to a newer version of pcre which you can get from"
-            echo "   www.pcre.org. For more information, see issue #1693"
-            echo
-            echo "   Continuing for now with JIT disabled..."
-            echo
-        fi
-    fi
-
-    # To prevent duping the lib link we reset LIBS after this check. Setting action-if-found to NULL doesn't seem to work
-    # see: http://blog.flameeyes.eu/2008/04/29/i-consider-ac_check_lib-harmful
-    PCRE=""
-    TMPLIBS="${LIBS}"
-    AC_CHECK_LIB(pcre, pcre_dfa_exec,, PCRE="no")
-    if test "$PCRE" = "no"; then
-        echo
-        echo "   ERROR!  pcre library was found but version was < 6.0"
-        echo "   please upgrade to a newer version of pcre which you can get from"
-        echo "   www.pcre.org."
-        echo
-        exit 1
-    fi
-    LIBS="${TMPLIBS}"
-
-    TMPCFLAGS="${CFLAGS}"
-    CFLAGS="-O0 -g -Werror -Wall"
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ #include <pcre.h> ]],
-        [[ pcre_extra *extra = NULL; pcre_free_study(extra); ]])],
-        [ AC_DEFINE([HAVE_PCRE_FREE_STUDY], [1], [Pcre pcre_free_study supported])],[:]
-    )
-    CFLAGS="${TMPCFLAGS}"
 
   # libhs
     enable_hyperscan="no"
@@ -2616,7 +2548,7 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   libjansson support:                      ${enable_jansson}
   hiredis support:                         ${enable_hiredis}
   hiredis async with libevent:             ${enable_hiredis_async}
-  PCRE jit:                                ${pcre_jit_available}
+  PCRE jit:                                ${pcre2_jit_available}
   LUA support:                             ${enable_lua}
   libluajit:                               ${enable_luajit}
   GeoIP2 support:                          ${enable_geoip}

--- a/configure.ac
+++ b/configure.ac
@@ -637,6 +637,34 @@
         exit 1
     fi
 
+    PCRE2=""
+    AC_CHECK_LIB(pcre2-8, pcre2_compile_8,,PCRE2="no")
+    if test "$PCRE2" = "no"; then
+        echo
+        echo "   ERROR!  pcre2 library not found, go get it"
+        echo "   from www.pcre.org. Or from packages:"
+        echo "   Debian/Ubuntu: apt install libpcre2-dev"
+        echo "   Fedora: dnf install pcre2-devel"
+        echo "   CentOS/RHEL: yum install pcre2-devel"
+        echo
+        exit 1
+    fi
+
+    AC_DEFINE([PCRE2_CODE_UNIT_WIDTH], [8], [Pcre code unit width is 8 bits])
+    AC_MSG_CHECKING(for PCRE2 JIT support)
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ #include <pcre2.h> ]],
+        [[
+        int jit = 0;
+        pcre2_config(PCRE2_CONFIG_JIT, &jit);
+        ]])],[ pcre2_jit_available=yes ],[ pcre2_jit_available=no ]
+        )
+    if test "x$pcre2_jit_available" = "xyes"; then
+        AC_MSG_RESULT(yes)
+        AC_DEFINE([PCRE2_HAVE_JIT], [1], [Pcre2 with JIT compiler support enabled])
+    else
+        AC_MSG_RESULT(no)
+    fi
+
     # libpcre 8.35 (especially on debian) has a known issue that results in segfaults
     # see https://redmine.openinfosecfoundation.org/issues/1693
     if test "$with_libpcre_libraries" = "no"; then
@@ -668,20 +696,6 @@
     fi
     LIBS="${TMPLIBS}"
 
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ #include <pcre.h> ]],
-        [[ int eo = 0; eo |= PCRE_EXTRA_MATCH_LIMIT_RECURSION; ]])],
-        [ pcre_match_limit_recursion_available=yes ],[:]
-    )
-    if test "$pcre_match_limit_recursion_available" != "yes"; then
-        echo
-        echo "   Warning! pcre extra opt PCRE_EXTRA_MATCH_LIMIT_RECURSION not found"
-        echo "   This could lead to potential DoS please upgrade to pcre >= 6.5"
-        echo "   from www.pcre.org."
-        echo "   Continuing for now...."
-        echo
-        AC_DEFINE([NO_PCRE_MATCH_RLIMIT],[1],[Pcre PCRE_EXTRA_MATCH_LIMIT_RECURSION not available])
-    fi
-
     TMPCFLAGS="${CFLAGS}"
     CFLAGS="-O0 -g -Werror -Wall"
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ #include <pcre.h> ]],
@@ -689,104 +703,6 @@
         [ AC_DEFINE([HAVE_PCRE_FREE_STUDY], [1], [Pcre pcre_free_study supported])],[:]
     )
     CFLAGS="${TMPCFLAGS}"
-
-    #enable support for PCRE-jit available since pcre-8.20
-    AC_MSG_CHECKING(for PCRE JIT support)
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ #include <pcre.h> ]],
-        [[
-        int jit = 0;
-        pcre_config(PCRE_CONFIG_JIT, &jit);
-        ]])],[ pcre_jit_available=yes ],[ pcre_jit_available=no ]
-        )
-
-    case $host in
-        *powerpc64*)
-            PKG_CHECK_MODULES(LIBPCREVERSION, [libpcre = 8.39],[libpcre_ppc64_buggy_found1="yes"],[libprce_ppc64_buggy_found1="no"])
-            PKG_CHECK_MODULES(LIBPCREVERSION, [libpcre = 8.40],[libpcre_ppc64_buggy_found2="yes"],[libprce_ppc64_buggy_found2="no"])
-
-            if test "$libprce_ppc64_buggy_found1" = "yes" || test "$libprce_ppc64_buggy_found2"; then
-                # on powerpc64, both gcc and clang lead to SIGILL in
-                # unittests when jit is enabled.
-                pcre_jit_available="no, pcre 8.39/8.40 jit disabled for powerpc64"
-            fi
-            # hack: use libatomic
-            LIBS="${LIBS} -latomic"
-        ;;
-        *)
-            # bug 1693, libpcre 8.35 is broken and debian jessie is still using that
-            if test "$libpcre_buggy_found" = "yes"; then
-                pcre_jit_available="no, libpcre 8.35 blacklisted"
-            fi
-        ;;
-    esac
-
-    if test "x$pcre_jit_available" = "xyes"; then
-       AC_MSG_RESULT(yes)
-       AC_DEFINE([PCRE_HAVE_JIT], [1], [Pcre with JIT compiler support enabled])
-
-       AC_MSG_CHECKING(for PCRE JIT support usability)
-       AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ #include <pcre.h> ]],
-           [[
-           const char *error;
-           int err_offset;
-           pcre *re = pcre_compile("(a|b|c|d)",0, &error, &err_offset,NULL);
-           pcre_extra *extra = pcre_study(re, PCRE_STUDY_JIT_COMPILE, &error);
-           if (extra == NULL)
-               exit(EXIT_FAILURE);
-           int jit = 0;
-           int ret = pcre_fullinfo(re, extra, PCRE_INFO_JIT, &jit);
-           if (ret != 0 || jit != 1)
-               exit(EXIT_FAILURE);
-           exit(EXIT_SUCCESS);
-           ]])],[ pcre_jit_works=yes ],[:]
-       )
-       if test "x$pcre_jit_works" != "xyes"; then
-           AC_MSG_RESULT(no)
-           echo
-           echo "   PCRE JIT support detection worked but testing it failed"
-           echo "   something odd is going on, please file a bug report."
-           echo
-           exit 1
-       else
-           AC_MSG_RESULT(yes)
-       fi
-    else
-        AC_MSG_RESULT(no)
-    fi
-
-    if test "x$pcre_jit_works" = "xyes"; then
-
-       AC_MSG_CHECKING(for PCRE JIT exec availability)
-       AC_LINK_IFELSE(
-           [AC_LANG_PROGRAM(
-               [
-                  #include <pcre.h>
-                  #include <string.h>
-               ],
-               [
-                   const char *error;
-                   int err_offset;
-                   pcre *re = pcre_compile("(a|b|c|d)", 0, &error, &err_offset,NULL);
-                   pcre_extra *study = pcre_study(re, PCRE_STUDY_JIT_COMPILE, &error);
-                   if (study == NULL)
-                       exit(EXIT_FAILURE);
-                   pcre_jit_stack *stack = pcre_jit_stack_alloc(32*1024,40*1024);
-                   if (stack == 0)
-                       exit(EXIT_FAILURE);
-                   int ret = pcre_jit_exec(re, study, "apple", 5, 0, 0, NULL, 0, stack);
-                   exit(ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
-               ])],
-           [pcre_jit_exec_available="yes" ],
-           [pcre_jit_exec_available="no" ])
-       if test "x$pcre_jit_exec_available" != "xyes"; then
-           AC_MSG_RESULT(no)
-       else
-           AC_MSG_RESULT(yes)
-           AC_DEFINE([PCRE_HAVE_JIT_EXEC], [1], [PCRE with JIT compiler support enabled supporting pcre_jit_exec])
-       fi
-    else
-        AC_MSG_RESULT(no)
-    fi
 
   # libhs
     enable_hyperscan="no"

--- a/doc/INSTALL.PF_RING
+++ b/doc/INSTALL.PF_RING
@@ -8,7 +8,7 @@ apt-get install dkms
 apt-get install subversion flex bison
 
 #Install the debs needed for suricata.
-apt-get install libpcre3-dev libpcap-dev libyaml-dev zlib1g-dev libcap-ng-dev libnet1-dev
+apt-get install libpcap-dev libyaml-dev zlib1g-dev libcap-ng-dev libnet1-dev libpcre2-dev
 
 #In the exmple we will build from the GIT repo so we will need some extra packages
 apt-get install git-core automake autoconf libtool

--- a/doc/INSTALL.WINDOWS
+++ b/doc/INSTALL.WINDOWS
@@ -75,7 +75,7 @@ the following packages to c:\mingw (use newer versions if you like):
     - unpack to /msys/1.0
     - don't forget to edit your ~/.gitconfig to at least give youreself a name :-)
 
-5. Get libpcre
+5. Get libpcre2
 
     http://www.pcre.org/
 
@@ -117,7 +117,7 @@ the following packages to c:\mingw (use newer versions if you like):
     make
 
 If everything goes well, you'll end up with suricata.exe in src/.lib. To test it
-you will need libpcre-0.dll, libz-1.dll, and pthreadGC2.dll which you already have somewhere
+you will need libpcre2-0.dll, libz-1.dll, and pthreadGC2.dll which you already have somewhere
 under c:/mingw or c:/msys. To prepare the runtime environment:
 
     - copy the executable and the DLLs to a dedicated directory

--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -63,7 +63,7 @@ Dependencies
 
 For Suricata's compilation you'll need the following libraries and their development headers installed::
 
-  libjansson, libpcap, libpcre, libmagic, zlib, libyaml
+  libjansson, libpcap, libpcre2, libmagic, zlib, libyaml
 
 The following tools are required::
 
@@ -87,17 +87,17 @@ Ubuntu/Debian
 
 Minimal::
 
-    apt-get install libpcre3 libpcre3-dbg libpcre3-dev build-essential libpcap-dev   \
+    apt-get install build-essential libpcap-dev   \
                     libyaml-0-2 libyaml-dev pkg-config zlib1g zlib1g-dev \
-                    make libmagic-dev libjansson libjansson-dev
+                    make libmagic-dev libjansson libjansson-dev libpcre2-dev
 
 Recommended::
 
-    apt-get install libpcre3 libpcre3-dbg libpcre3-dev build-essential libpcap-dev   \
+    apt-get install build-essential libpcap-dev   \
                     libnet1-dev libyaml-0-2 libyaml-dev pkg-config zlib1g zlib1g-dev \
                     libcap-ng-dev libcap-ng0 make libmagic-dev         \
                     libgeoip-dev liblua5.1-dev libhiredis-dev libevent-dev \
-                    python-yaml rustc cargo
+                    python-yaml rustc cargo libpcre2-dev
 
 Extra for iptables/nftables IPS integration::
 

--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -757,3 +757,22 @@ Suricata has its own specific pcre modifiers. These are:
   relative to the previous match so both matches have to be in the
   HTTP-Host buffer.
 
+.. _pcre-update-v1-to-v2:
+
+Changes from PCRE1 to PCRE2
+===========================
+
+The upgrade from PCRE1 to PCRE2 changes the behavior for some
+PCRE expressions.
+
+- ``\I`` is a valid pcre in PCRE1, with a useless escape, so
+  equivalent to ``I``, but it is no longer the case in PCRE2.
+  There are other characters than I exhibiting this pattern
+- ``[\d-a]`` is a valid pcre in PCRE1, with either a digit,
+  a dash or the character ``a``, but the dash must now be escaped
+  with PCRE2 as ``[\d\-a]`` to get the same behavior
+- ``pcre2_substring_copy_bynumber`` now returns an error
+  ``PCRE2_ERROR_UNSET`` instead of ``pcre_copy_substring`` returning
+  no error and giving an empty string. If the behavior of some use
+  case is no longer the expected one, please let us know.
+

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -35,6 +35,7 @@ Upgrading 6.0 to 7.0
 
 Major changes
 ~~~~~~~~~~~~~
+- Upgrade of PCRE1 to PCRE2. See :ref:`pcre-update-v1-to-v2` for more details.
 
 Removals
 ~~~~~~~~

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -214,13 +214,11 @@ int DetectByteExtractDoMatch(DetectEngineThreadCtx *det_ctx, const SigMatchData 
 static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_ctx, const char *arg)
 {
     DetectByteExtractData *bed = NULL;
-#undef MAX_SUBSTRINGS
-#define MAX_SUBSTRINGS 100
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     int i = 0;
 
-    ret = DetectParsePcreExec(&parse_regex, arg,  0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, arg, 0, 0);
     if (ret < 3 || ret > 19) {
         SCLogError(SC_ERR_PCRE_PARSE, "parse error, ret %" PRId32
                    ", string \"%s\"", ret, arg);
@@ -236,11 +234,12 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
 
     /* no of bytes to extract */
     char nbytes_str[64] = "";
-    res = pcre_copy_substring((char *)arg, ov,
-                             MAX_SUBSTRINGS, 1, nbytes_str, sizeof(nbytes_str));
+    pcre2len = sizeof(nbytes_str);
+    res = pcre2_substring_copy_bynumber(
+            parse_regex.match, 1, (PCRE2_UCHAR8 *)nbytes_str, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                   "for arg 1 for byte_extract");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
+                                              "for arg 1 for byte_extract");
         goto error;
     }
     if (StringParseUint8(&bed->nbytes, 10, 0,
@@ -252,11 +251,12 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
 
     /* offset */
     char offset_str[64] = "";
-    res = pcre_copy_substring((char *)arg, ov,
-                             MAX_SUBSTRINGS, 2, offset_str, sizeof(offset_str));
+    pcre2len = sizeof(offset_str);
+    res = pcre2_substring_copy_bynumber(
+            parse_regex.match, 2, (PCRE2_UCHAR8 *)offset_str, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                   "for arg 2 for byte_extract");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
+                                              "for arg 2 for byte_extract");
         goto error;
     }
     int32_t offset;
@@ -268,11 +268,12 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
 
     /* var name */
     char varname_str[256] = "";
-    res = pcre_copy_substring((char *)arg, ov,
-                             MAX_SUBSTRINGS, 3, varname_str, sizeof(varname_str));
+    pcre2len = sizeof(varname_str);
+    res = pcre2_substring_copy_bynumber(
+            parse_regex.match, 3, (PCRE2_UCHAR8 *)varname_str, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                   "for arg 3 for byte_extract");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
+                                              "for arg 3 for byte_extract");
         goto error;
     }
     bed->name = SCStrdup(varname_str);
@@ -282,11 +283,14 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
     /* check out other optional args */
     for (i = 4; i < ret; i++) {
         char opt_str[64] = "";
-        res = pcre_copy_substring((char *)arg, ov,
-                                 MAX_SUBSTRINGS, i, opt_str, sizeof(opt_str));
+        pcre2len = sizeof(opt_str);
+        res = pcre2_substring_copy_bynumber(
+                parse_regex.match, i, (PCRE2_UCHAR8 *)opt_str, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                       "for arg %d for byte_extract", i);
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING,
+                    "pcre2_substring_copy_bynumber failed "
+                    "for arg %d for byte_extract",
+                    i);
             goto error;
         }
 
@@ -307,11 +311,14 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
             i++;
 
             char multiplier_str[16] = "";
-            res = pcre_copy_substring((char *)arg, ov,
-                                     MAX_SUBSTRINGS, i, multiplier_str, sizeof(multiplier_str));
+            pcre2len = sizeof(multiplier_str);
+            res = pcre2_substring_copy_bynumber(
+                    parse_regex.match, i, (PCRE2_UCHAR8 *)multiplier_str, &pcre2len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                           "for arg %d for byte_extract", i);
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING,
+                        "pcre2_substring_copy_bynumber failed "
+                        "for arg %d for byte_extract",
+                        i);
                 goto error;
             }
             int32_t multiplier;
@@ -410,11 +417,14 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
             i++;
 
             char align_str[16] = "";
-            res = pcre_copy_substring((char *)arg, ov,
-                                     MAX_SUBSTRINGS, i, align_str, sizeof(align_str));
+            pcre2len = sizeof(align_str);
+            res = pcre2_substring_copy_bynumber(
+                    parse_regex.match, i, (PCRE2_UCHAR8 *)align_str, &pcre2len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                           "for arg %d in byte_extract", i);
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING,
+                        "pcre2_substring_copy_bynumber failed "
+                        "for arg %d in byte_extract",
+                        i);
                 goto error;
             }
             if (StringParseUint8(&bed->align_value, 10, 0,

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -284,13 +284,12 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
     for (i = 4; i < ret; i++) {
         char opt_str[64] = "";
         pcre2len = sizeof(opt_str);
-        res = pcre2_substring_copy_bynumber(
-                parse_regex.match, i, (PCRE2_UCHAR8 *)opt_str, &pcre2len);
+        res = SC_pcre2_substring_copy(parse_regex.match, i, (PCRE2_UCHAR8 *)opt_str, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING,
                     "pcre2_substring_copy_bynumber failed "
-                    "for arg %d for byte_extract",
-                    i);
+                    "for arg %d for byte_extract with %d",
+                    i, res);
             goto error;
         }
 

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -284,7 +284,7 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
     for (i = 4; i < ret; i++) {
         char opt_str[64] = "";
         pcre2len = sizeof(opt_str);
-        res = SC_pcre2_substring_copy(parse_regex.match, i, (PCRE2_UCHAR8 *)opt_str, &pcre2len);
+        res = SC_Pcre2SubstringCopy(parse_regex.match, i, (PCRE2_UCHAR8 *)opt_str, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING,
                     "pcre2_substring_copy_bynumber failed "

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -259,12 +259,10 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
 {
     DetectByteMathData *bmd = NULL;
     int ret, res;
-#undef MAX_SUBSTRINGS
-#define MAX_SUBSTRINGS 100
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     char tmp_str[128] = "";
 
-    ret = DetectParsePcreExec(&parse_regex, arg, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, arg, 0, 0);
     if (ret < MIN_GROUP || ret > MAX_GROUP) {
         SCLogError(SC_ERR_PCRE_PARSE, "byte_math parse error; invalid value: ret %" PRId32
                    ", string \"%s\"", ret, arg);
@@ -276,11 +274,14 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
         goto error;
 
     /* no of bytes to extract */
-    res = pcre_copy_substring((char *)arg, ov,
-                             MAX_SUBSTRINGS, BYTES_VAL, tmp_str, sizeof(tmp_str));
+    pcre2len = sizeof(tmp_str);
+    res = pcre2_substring_copy_bynumber(
+            parse_regex.match, BYTES_VAL, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                   "for \"nbytes\" value: \"%s\"", tmp_str);
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING,
+                "pcre2_substring_copy_bynumber failed "
+                "for \"nbytes\" value: \"%s\"",
+                tmp_str);
         goto error;
     }
 
@@ -294,11 +295,14 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
     }
 
     /* offset */
-    res = pcre_copy_substring((char *)arg, ov,
-                             MAX_SUBSTRINGS, OFFSET_VAL, tmp_str, sizeof(tmp_str));
+    pcre2len = sizeof(tmp_str);
+    res = pcre2_substring_copy_bynumber(
+            parse_regex.match, OFFSET_VAL, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                   "for \"offset\" value: \"%s\"", tmp_str);
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING,
+                "pcre2_substring_copy_bynumber failed "
+                "for \"offset\" value: \"%s\"",
+                tmp_str);
         goto error;
     }
 
@@ -310,11 +314,14 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
     }
 
     /* operator */
-    res = pcre_copy_substring((char *)arg, ov,
-                             MAX_SUBSTRINGS, OPER_VAL, tmp_str, sizeof(tmp_str));
+    pcre2len = sizeof(tmp_str);
+    res = pcre2_substring_copy_bynumber(
+            parse_regex.match, OPER_VAL, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                   "for \"operator\" value of byte_math: \"%s\"", tmp_str);
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING,
+                "pcre2_substring_copy_bynumber failed "
+                "for \"operator\" value of byte_math: \"%s\"",
+                tmp_str);
         goto error;
     }
 
@@ -333,11 +340,14 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
     }
 
     /* rvalue */
-    res = pcre_copy_substring((char *)arg, ov, MAX_SUBSTRINGS,
-                              RVALUE_VAL, tmp_str, sizeof(tmp_str));
+    pcre2len = sizeof(tmp_str);
+    res = pcre2_substring_copy_bynumber(
+            parse_regex.match, RVALUE_VAL, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                   "for \"rvalue\" to byte_math: \"%s\"", tmp_str);
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING,
+                "pcre2_substring_copy_bynumber failed "
+                "for \"rvalue\" to byte_math: \"%s\"",
+                tmp_str);
         goto error;
     }
 
@@ -361,11 +371,12 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
     }
 
     /* result */
-    res = pcre_copy_substring((char *)arg, ov, MAX_SUBSTRINGS,
-                              RESULT_VAL, tmp_str, sizeof(tmp_str));
+    pcre2len = sizeof(tmp_str);
+    res = pcre2_substring_copy_bynumber(
+            parse_regex.match, RESULT_VAL, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                   "for \"result\" to byte_math");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
+                                              "for \"result\" to byte_math");
         goto error;
     }
     if (!isalpha(*tmp_str)) {
@@ -387,12 +398,13 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
      */
 
     if (ret > RELATIVE_KW) {
-        res = pcre_copy_substring((char *)arg, ov, MAX_SUBSTRINGS,
-                                  RELATIVE_KW, tmp_str, sizeof(tmp_str));
+        pcre2len = sizeof(tmp_str);
+        res = pcre2_substring_copy_bynumber(
+                parse_regex.match, RELATIVE_KW, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
 
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                       "for byte_math \"relative\" arg");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
+                                                  "for byte_math \"relative\" arg");
             goto error;
         }
 
@@ -402,11 +414,12 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
     }
 
     if (ret > ENDIAN_VAL) {
-        res = pcre_copy_substring((char *)arg, ov, MAX_SUBSTRINGS,
-                                  ENDIAN_KW, tmp_str, sizeof(tmp_str));
+        pcre2len = sizeof(tmp_str);
+        res = pcre2_substring_copy_bynumber(
+                parse_regex.match, ENDIAN_KW, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                       "for byte_math \"endian\" arg");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
+                                                  "for byte_math \"endian\" arg");
             goto error;
         }
 
@@ -414,11 +427,12 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
             bmd->flags |= DETECT_BYTEMATH_FLAG_ENDIAN;
         }
 
-        res = pcre_copy_substring((char *)arg, ov, MAX_SUBSTRINGS,
-                                 ENDIAN_VAL, tmp_str, sizeof(tmp_str));
+        pcre2len = sizeof(tmp_str);
+        res = pcre2_substring_copy_bynumber(
+                parse_regex.match, ENDIAN_VAL, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                       "for byte_math \"endian\" value");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
+                                                  "for byte_math \"endian\" value");
             goto error;
         }
 
@@ -430,11 +444,12 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
     }
 
     if (ret > STRING_VAL) {
-        res = pcre_copy_substring((char *)arg, ov, MAX_SUBSTRINGS,
-                                  STRING_KW, tmp_str, sizeof(tmp_str));
+        pcre2len = sizeof(tmp_str);
+        res = pcre2_substring_copy_bynumber(
+                parse_regex.match, STRING_KW, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                       "for byte_math \"string\" arg");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
+                                                  "for byte_math \"string\" arg");
             goto error;
         }
 
@@ -442,11 +457,12 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
             bmd->flags |= DETECT_BYTEMATH_FLAG_STRING;
         }
 
-        res = pcre_copy_substring((char *)arg, ov, MAX_SUBSTRINGS,
-                                  STRING_VAL, tmp_str, sizeof(tmp_str));
+        pcre2len = sizeof(tmp_str);
+        res = pcre2_substring_copy_bynumber(
+                parse_regex.match, STRING_VAL, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                       "for byte_math \"string\" value");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
+                                                  "for byte_math \"string\" value");
             goto error;
         }
 
@@ -461,11 +477,12 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
     }
 
     if (ret > DCE_KW) {
-        res = pcre_copy_substring((char *)arg, ov, MAX_SUBSTRINGS,
-                                  DCE_KW, tmp_str, sizeof(tmp_str));
+        pcre2len = sizeof(tmp_str);
+        res = pcre2_substring_copy_bynumber(
+                parse_regex.match, DCE_KW, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                       "for byte_math \"dce\" arg");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
+                                                  "for byte_math \"dce\" arg");
             goto error;
         }
 
@@ -476,11 +493,12 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
     }
 
     if (ret > BITMASK_VAL) {
-        res = pcre_copy_substring((char *)arg, ov, MAX_SUBSTRINGS,
-                                  BITMASK_KW, tmp_str, sizeof(tmp_str));
+        pcre2len = sizeof(tmp_str);
+        res = pcre2_substring_copy_bynumber(
+                parse_regex.match, BITMASK_KW, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                       "for byte_math \"bitmask\" arg");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
+                                                  "for byte_math \"bitmask\" arg");
             goto error;
         }
 
@@ -489,11 +507,14 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
         }
 
         /* bitmask value*/
-        res = pcre_copy_substring((char *)arg, ov, MAX_SUBSTRINGS,
-                                  BITMASK_VAL, tmp_str, sizeof(tmp_str));
+        pcre2len = sizeof(tmp_str);
+        res = pcre2_substring_copy_bynumber(
+                parse_regex.match, BITMASK_VAL, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed "
-                   "for bitmask value: \"%s\"", tmp_str);
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING,
+                    "pcre2_substring_copy_bynumber failed "
+                    "for bitmask value: \"%s\"",
+                    tmp_str);
             goto error;
         }
 

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -399,7 +399,7 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
 
     if (ret > RELATIVE_KW) {
         pcre2len = sizeof(tmp_str);
-        res = pcre2_substring_copy_bynumber(
+        res = SC_pcre2_substring_copy(
                 parse_regex.match, RELATIVE_KW, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
 
         if (res < 0) {
@@ -415,7 +415,7 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
 
     if (ret > ENDIAN_VAL) {
         pcre2len = sizeof(tmp_str);
-        res = pcre2_substring_copy_bynumber(
+        res = SC_pcre2_substring_copy(
                 parse_regex.match, ENDIAN_KW, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
@@ -428,7 +428,7 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
         }
 
         pcre2len = sizeof(tmp_str);
-        res = pcre2_substring_copy_bynumber(
+        res = SC_pcre2_substring_copy(
                 parse_regex.match, ENDIAN_VAL, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
@@ -445,7 +445,7 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
 
     if (ret > STRING_VAL) {
         pcre2len = sizeof(tmp_str);
-        res = pcre2_substring_copy_bynumber(
+        res = SC_pcre2_substring_copy(
                 parse_regex.match, STRING_KW, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
@@ -458,7 +458,7 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
         }
 
         pcre2len = sizeof(tmp_str);
-        res = pcre2_substring_copy_bynumber(
+        res = SC_pcre2_substring_copy(
                 parse_regex.match, STRING_VAL, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
@@ -478,7 +478,7 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
 
     if (ret > DCE_KW) {
         pcre2len = sizeof(tmp_str);
-        res = pcre2_substring_copy_bynumber(
+        res = SC_pcre2_substring_copy(
                 parse_regex.match, DCE_KW, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -399,7 +399,7 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
 
     if (ret > RELATIVE_KW) {
         pcre2len = sizeof(tmp_str);
-        res = SC_pcre2_substring_copy(
+        res = SC_Pcre2SubstringCopy(
                 parse_regex.match, RELATIVE_KW, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
 
         if (res < 0) {
@@ -415,7 +415,7 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
 
     if (ret > ENDIAN_VAL) {
         pcre2len = sizeof(tmp_str);
-        res = SC_pcre2_substring_copy(
+        res = SC_Pcre2SubstringCopy(
                 parse_regex.match, ENDIAN_KW, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
@@ -428,7 +428,7 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
         }
 
         pcre2len = sizeof(tmp_str);
-        res = SC_pcre2_substring_copy(
+        res = SC_Pcre2SubstringCopy(
                 parse_regex.match, ENDIAN_VAL, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
@@ -445,7 +445,7 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
 
     if (ret > STRING_VAL) {
         pcre2len = sizeof(tmp_str);
-        res = SC_pcre2_substring_copy(
+        res = SC_Pcre2SubstringCopy(
                 parse_regex.match, STRING_KW, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
@@ -458,7 +458,7 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
         }
 
         pcre2len = sizeof(tmp_str);
-        res = SC_pcre2_substring_copy(
+        res = SC_Pcre2SubstringCopy(
                 parse_regex.match, STRING_VAL, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
@@ -478,8 +478,7 @@ static DetectByteMathData *DetectByteMathParse(DetectEngineCtx *de_ctx, const ch
 
     if (ret > DCE_KW) {
         pcre2len = sizeof(tmp_str);
-        res = SC_pcre2_substring_copy(
-                parse_regex.match, DCE_KW, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
+        res = SC_Pcre2SubstringCopy(parse_regex.match, DCE_KW, (PCRE2_UCHAR8 *)tmp_str, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed "
                                                   "for byte_math \"dce\" arg");

--- a/src/detect-classtype.c
+++ b/src/detect-classtype.c
@@ -69,20 +69,21 @@ void DetectClasstypeRegister(void)
  */
 static int DetectClasstypeParseRawString(const char *rawstr, char *out, size_t outsize)
 {
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
 
     const size_t esize = CLASSTYPE_NAME_MAX_LEN + 8;
     char e[esize];
 
-    int ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    int ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret < 0) {
         SCLogError(SC_ERR_PCRE_MATCH, "Invalid Classtype in Signature");
         return -1;
     }
 
-    ret = pcre_copy_substring((char *)rawstr, ov, 30, 1, e, esize);
+    pcre2len = esize;
+    ret = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)e, &pcre2len);
     if (ret < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         return -1;
     }
 

--- a/src/detect-config.c
+++ b/src/detect-config.c
@@ -167,9 +167,8 @@ static int DetectConfigSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
 
     DetectConfigData *fd = NULL;
     SigMatch *sm = NULL;
-#define MAX_SUBSTRINGS 30
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
 #if 0
     /* filestore and bypass keywords can't work together */
     if (s->flags & SIG_FLAG_BYPASS) {
@@ -195,14 +194,15 @@ static int DetectConfigSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     char scopeval[32];
     SCLogDebug("str %s", str);
 
-    ret = DetectParsePcreExec(&parse_regex,  str, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, str, 0, 0);
     if (ret != 7) {
         SCLogError(SC_ERR_INVALID_RULE_ARGUMENT, "config is rather picky at this time");
         goto error;
     }
-    res = pcre_copy_substring((char *)str, ov, MAX_SUBSTRINGS, 1, subsys, sizeof(subsys));
+    pcre2len = sizeof(subsys);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)subsys, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 
@@ -212,9 +212,10 @@ static int DetectConfigSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     }
     SCLogDebug("subsys %s", subsys);
 
-    res = pcre_copy_substring((char *)str, ov, MAX_SUBSTRINGS, 2, state, sizeof(state));
+    pcre2len = sizeof(state);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 *)state, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 
@@ -224,9 +225,10 @@ static int DetectConfigSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     }
     SCLogDebug("state %s", state);
 
-    res = pcre_copy_substring((char *)str, ov, MAX_SUBSTRINGS, 3, type, sizeof(type));
+    pcre2len = sizeof(type);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 3, (PCRE2_UCHAR8 *)type, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 
@@ -236,9 +238,10 @@ static int DetectConfigSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     }
     SCLogDebug("type %s", type);
 
-    res = pcre_copy_substring((char *)str, ov, MAX_SUBSTRINGS, 4, typeval, sizeof(typeval));
+    pcre2len = sizeof(typeval);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 4, (PCRE2_UCHAR8 *)typeval, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 
@@ -248,9 +251,10 @@ static int DetectConfigSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     }
     SCLogDebug("typeval %s", typeval);
 
-    res = pcre_copy_substring((char *)str, ov, MAX_SUBSTRINGS, 5, scope, sizeof(scope));
+    pcre2len = sizeof(scope);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 5, (PCRE2_UCHAR8 *)scope, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 
@@ -260,9 +264,10 @@ static int DetectConfigSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     }
     SCLogDebug("scope %s", scope);
 
-    res = pcre_copy_substring((char *)str, ov, MAX_SUBSTRINGS, 6, scopeval, sizeof(scopeval));
+    pcre2len = sizeof(scopeval);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 6, (PCRE2_UCHAR8 *)scopeval, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -156,7 +156,7 @@ static DetectDsizeData *DetectDsizeParse (const char *rawstr)
     }
 
     pcre2len = sizeof(mode);
-    res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
+    res = SC_Pcre2SubstringCopy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed with %d", res);
         goto error;

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -156,9 +156,9 @@ static DetectDsizeData *DetectDsizeParse (const char *rawstr)
     }
 
     pcre2len = sizeof(mode);
-    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
+    res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed with %d", res);
         goto error;
     }
     SCLogDebug("mode \"%s\"", mode);

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -143,44 +143,49 @@ static DetectDsizeData *DetectDsizeParse (const char *rawstr)
 {
     DetectDsizeData *dd = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     char mode[2] = "";
     char value1[6] = "";
     char value2[6] = "";
     char range[3] = "";
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret < 3 || ret > 5) {
         SCLogError(SC_ERR_PCRE_MATCH,"Parse error %s", rawstr);
         goto error;
     }
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 1, mode, sizeof(mode));
+    pcre2len = sizeof(mode);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING,"pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
     SCLogDebug("mode \"%s\"", mode);
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 2, value1, sizeof(value1));
+    pcre2len = sizeof(value1);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 *)value1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING,"pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
     SCLogDebug("value1 \"%s\"", value1);
 
     if (ret > 3) {
-        res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 3, range, sizeof(range));
+        pcre2len = sizeof(range);
+        res = pcre2_substring_copy_bynumber(parse_regex.match, 3, (PCRE2_UCHAR8 *)range, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING,"pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;
         }
         SCLogDebug("range \"%s\"", range);
 
         if (ret > 4) {
-            res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 4, value2, sizeof(value2));
+            pcre2len = sizeof(value2);
+            res = pcre2_substring_copy_bynumber(
+                    parse_regex.match, 4, (PCRE2_UCHAR8 *)value2, &pcre2len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING,"pcre_copy_substring failed");
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                 goto error;
             }
             SCLogDebug("value2 \"%s\"", value2);

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -433,7 +433,7 @@ int PerCentEncodingSetup ()
 #define DETECT_PERCENT_ENCODING_REGEX "%[0-9|a-f|A-F]{2}"
     int en;
     PCRE2_SIZE eo = 0;
-    int opts = 0;    //PCRE_NEWLINE_ANY??
+    int opts = 0; // PCRE2_NEWLINE_ANY??
 
     percent_re = pcre2_compile((PCRE2_SPTR8)DETECT_PERCENT_ENCODING_REGEX, PCRE2_ZERO_TERMINATED,
             opts, &en, &eo, NULL);

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -38,7 +38,6 @@
 #include "detect-tcp-flags.h"
 #include "feature.h"
 #include "util-print.h"
-#include <pcre2.h>
 
 static int rule_warnings_only = 0;
 static FILE *rule_engine_analysis_FD = NULL;

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -123,9 +123,9 @@ static DetectEngineEventData *DetectEngineEventParse (const char *rawstr)
     int i;
     DetectEngineEventData *de = NULL;
     int ret = 0, res = 0, found = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret < 1) {
         SCLogError(SC_ERR_PCRE_MATCH, "pcre_exec parse error, ret %" PRId32
                 ", string %s", ret, rawstr);
@@ -133,11 +133,11 @@ static DetectEngineEventData *DetectEngineEventParse (const char *rawstr)
     }
 
     char copy_str[128] = "";
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 0,
-            copy_str, sizeof(copy_str));
+    pcre2len = sizeof(copy_str);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 0, (PCRE2_UCHAR8 *)copy_str, &pcre2len);
 
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 

--- a/src/detect-engine-uint.c
+++ b/src/detect-engine-uint.c
@@ -96,33 +96,37 @@ DetectU32Data *DetectU32Parse (const char *u32str)
     char arg3[16] = "";
 
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
 
-    ret = DetectParsePcreExec(&uint_pcre, u32str, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&uint_pcre, u32str, 0, 0);
     if (ret < 2 || ret > 4) {
         SCLogError(SC_ERR_PCRE_MATCH, "parse error, ret %" PRId32 "", ret);
         return NULL;
     }
 
-    res = pcre_copy_substring((char *) u32str, ov, MAX_SUBSTRINGS, 1, arg1, sizeof(arg1));
+    pcre2len = sizeof(arg1);
+    res = pcre2_substring_copy_bynumber(uint_pcre.match, 1, (PCRE2_UCHAR8 *)arg1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         return NULL;
     }
     SCLogDebug("Arg1 \"%s\"", arg1);
 
     if (ret >= 3) {
-        res = pcre_copy_substring((char *) u32str, ov, MAX_SUBSTRINGS, 2, arg2, sizeof(arg2));
+        pcre2len = sizeof(arg2);
+        res = pcre2_substring_copy_bynumber(uint_pcre.match, 2, (PCRE2_UCHAR8 *)arg2, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             return NULL;
         }
         SCLogDebug("Arg2 \"%s\"", arg2);
 
         if (ret >= 4) {
-            res = pcre_copy_substring((char *) u32str, ov, MAX_SUBSTRINGS, 3, arg3, sizeof(arg3));
+            pcre2len = sizeof(arg3);
+            res = pcre2_substring_copy_bynumber(
+                    uint_pcre.match, 3, (PCRE2_UCHAR8 *)arg3, &pcre2len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+                SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                 return NULL;
             }
             SCLogDebug("Arg3 \"%s\"", arg3);
@@ -308,33 +312,37 @@ DetectU8Data *DetectU8Parse (const char *u8str)
     char arg3[16] = "";
 
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
 
-    ret = DetectParsePcreExec(&uint_pcre, u8str, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&uint_pcre, u8str, 0, 0);
     if (ret < 2 || ret > 4) {
         SCLogError(SC_ERR_PCRE_MATCH, "parse error, ret %" PRId32 "", ret);
         return NULL;
     }
 
-    res = pcre_copy_substring((char *) u8str, ov, MAX_SUBSTRINGS, 1, arg1, sizeof(arg1));
+    pcre2len = sizeof(arg1);
+    res = pcre2_substring_copy_bynumber(uint_pcre.match, 1, (PCRE2_UCHAR8 *)arg1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         return NULL;
     }
     SCLogDebug("Arg1 \"%s\"", arg1);
 
     if (ret >= 3) {
-        res = pcre_copy_substring((char *) u8str, ov, MAX_SUBSTRINGS, 2, arg2, sizeof(arg2));
+        pcre2len = sizeof(arg2);
+        res = pcre2_substring_copy_bynumber(uint_pcre.match, 2, (PCRE2_UCHAR8 *)arg2, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             return NULL;
         }
         SCLogDebug("Arg2 \"%s\"", arg2);
 
         if (ret >= 4) {
-            res = pcre_copy_substring((char *) u8str, ov, MAX_SUBSTRINGS, 3, arg3, sizeof(arg3));
+            pcre2len = sizeof(arg3);
+            res = pcre2_substring_copy_bynumber(
+                    uint_pcre.match, 3, (PCRE2_UCHAR8 *)arg3, &pcre2len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+                SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                 return NULL;
             }
             SCLogDebug("Arg3 \"%s\"", arg3);

--- a/src/detect-filesize.c
+++ b/src/detect-filesize.c
@@ -158,7 +158,7 @@ static DetectFilesizeData *DetectFilesizeParse (const char *str)
 
     SCLogDebug("ret %d", ret);
 
-    res = pcre2_substring_get_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+    res = SC_pcre2_substring_get(parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;
@@ -201,15 +201,15 @@ static DetectFilesizeData *DetectFilesizeParse (const char *str)
     goto error;
     memset(fsd, 0, sizeof(DetectFilesizeData));
 
-    if (arg1[0] == '<')
+    if (arg1 != NULL && arg1[0] == '<')
         fsd->mode = DETECT_FILESIZE_LT;
-    else if (arg1[0] == '>')
+    else if (arg1 != NULL && arg1[0] == '>')
         fsd->mode = DETECT_FILESIZE_GT;
     else
         fsd->mode = DETECT_FILESIZE_EQ;
 
     if (arg3 != NULL && strcmp("<>", arg3) == 0) {
-        if (strlen(arg1) != 0) {
+        if (arg1 != NULL && strlen(arg1) != 0) {
             SCLogError(SC_ERR_INVALID_ARGUMENT,"Range specified but mode also set");
             goto error;
         }

--- a/src/detect-filesize.c
+++ b/src/detect-filesize.c
@@ -158,7 +158,7 @@ static DetectFilesizeData *DetectFilesizeParse (const char *str)
 
     SCLogDebug("ret %d", ret);
 
-    res = SC_pcre2_substring_get(parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+    res = SC_Pcre2SubstringGet(parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;

--- a/src/detect-filesize.c
+++ b/src/detect-filesize.c
@@ -147,9 +147,9 @@ static DetectFilesizeData *DetectFilesizeParse (const char *str)
     char *arg3 = NULL;
     char *arg4 = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2_len;
 
-    ret = DetectParsePcreExec(&parse_regex, str, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, str, 0, 0);
     if (ret < 3 || ret > 5) {
         SCLogError(SC_ERR_PCRE_PARSE, "filesize option pcre parse error: \"%s\"", str);
         goto error;
@@ -158,35 +158,37 @@ static DetectFilesizeData *DetectFilesizeParse (const char *str)
 
     SCLogDebug("ret %d", ret);
 
-    res = pcre_get_substring((char *)str, ov, MAX_SUBSTRINGS, 1, &str_ptr);
+    res = pcre2_substring_get_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;
     }
     arg1 = (char *) str_ptr;
     SCLogDebug("Arg1 \"%s\"", arg1);
 
-    res = pcre_get_substring((char *)str, ov, MAX_SUBSTRINGS, 2, &str_ptr);
+    res = pcre2_substring_get_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;
     }
     arg2 = (char *) str_ptr;
     SCLogDebug("Arg2 \"%s\"", arg2);
 
     if (ret > 3) {
-        res = pcre_get_substring((char *)str, ov, MAX_SUBSTRINGS, 3, &str_ptr);
+        res = pcre2_substring_get_bynumber(
+                parse_regex.match, 3, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;
         }
         arg3 = (char *) str_ptr;
         SCLogDebug("Arg3 \"%s\"", arg3);
 
         if (ret > 4) {
-            res = pcre_get_substring((char *)str, ov, MAX_SUBSTRINGS, 4, &str_ptr);
+            res = pcre2_substring_get_bynumber(
+                    parse_regex.match, 4, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
                 goto error;
             }
             arg4 = (char *) str_ptr;
@@ -240,25 +242,25 @@ static DetectFilesizeData *DetectFilesizeParse (const char *str)
         }
     }
 
-    pcre_free_substring(arg1);
-    pcre_free_substring(arg2);
+    pcre2_substring_free((PCRE2_UCHAR *)arg1);
+    pcre2_substring_free((PCRE2_UCHAR *)arg2);
     if (arg3 != NULL)
-        pcre_free_substring(arg3);
+        pcre2_substring_free((PCRE2_UCHAR *)arg3);
     if (arg4 != NULL)
-        pcre_free_substring(arg4);
+        pcre2_substring_free((PCRE2_UCHAR *)arg4);
     return fsd;
 
 error:
     if (fsd)
         SCFree(fsd);
     if (arg1 != NULL)
-        SCFree(arg1);
+        pcre2_substring_free((PCRE2_UCHAR *)arg1);
     if (arg2 != NULL)
-        SCFree(arg2);
+        pcre2_substring_free((PCRE2_UCHAR *)arg2);
     if (arg3 != NULL)
-        SCFree(arg3);
+        pcre2_substring_free((PCRE2_UCHAR *)arg3);
     if (arg4 != NULL)
-        SCFree(arg4);
+        pcre2_substring_free((PCRE2_UCHAR *)arg4);
     return NULL;
 }
 

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -349,7 +349,7 @@ static int DetectFilestoreSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
     SigMatch *sm = NULL;
     char *args[3] = {NULL,NULL,NULL};
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
 
     /* filestore and bypass keywords can't work together */
     if (s->flags & SIG_FLAG_BYPASS) {
@@ -370,32 +370,38 @@ static int DetectFilestoreSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
         char str_2[32];
         SCLogDebug("str %s", str);
 
-        ret = DetectParsePcreExec(&parse_regex, str, 0, 0, ov, MAX_SUBSTRINGS);
+        ret = DetectParsePcreExec(&parse_regex, str, 0, 0);
         if (ret < 1 || ret > 4) {
             SCLogError(SC_ERR_PCRE_MATCH, "parse error, ret %" PRId32 ", string %s", ret, str);
             goto error;
         }
 
         if (ret > 1) {
-            res = pcre_copy_substring((char *)str, ov, MAX_SUBSTRINGS, 1, str_0, sizeof(str_0));
+            pcre2len = sizeof(str_0);
+            res = pcre2_substring_copy_bynumber(
+                    parse_regex.match, 1, (PCRE2_UCHAR8 *)str_0, &pcre2len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+                SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                 goto error;
             }
             args[0] = (char *)str_0;
 
             if (ret > 2) {
-                res = pcre_copy_substring((char *)str, ov, MAX_SUBSTRINGS, 2, str_1, sizeof(str_1));
+                pcre2len = sizeof(str_1);
+                res = pcre2_substring_copy_bynumber(
+                        parse_regex.match, 2, (PCRE2_UCHAR8 *)str_1, &pcre2len);
                 if (res < 0) {
-                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                     goto error;
                 }
                 args[1] = (char *)str_1;
             }
             if (ret > 3) {
-                res = pcre_copy_substring((char *)str, ov, MAX_SUBSTRINGS, 3, str_2, sizeof(str_2));
+                pcre2len = sizeof(str_2);
+                res = pcre2_substring_copy_bynumber(
+                        parse_regex.match, 3, (PCRE2_UCHAR8 *)str_2, &pcre2len);
                 if (res < 0) {
-                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                     goto error;
                 }
                 args[2] = (char *)str_2;

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -174,35 +174,40 @@ static DetectFlowData *DetectFlowParse (DetectEngineCtx *de_ctx, const char *flo
     DetectFlowData *fd = NULL;
     char *args[3] = {NULL,NULL,NULL};
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     char str1[16] = "", str2[16] = "", str3[16] = "";
 
-    ret = DetectParsePcreExec(&parse_regex, flowstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, flowstr, 0, 0);
     if (ret < 1 || ret > 4) {
         SCLogError(SC_ERR_PCRE_MATCH, "parse error, ret %" PRId32 ", string %s", ret, flowstr);
         goto error;
     }
 
     if (ret > 1) {
-        res = pcre_copy_substring((char *)flowstr, ov, MAX_SUBSTRINGS, 1, str1, sizeof(str1));
+        pcre2len = sizeof(str1);
+        res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)str1, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;
         }
         args[0] = (char *)str1;
 
         if (ret > 2) {
-            res = pcre_copy_substring((char *)flowstr, ov, MAX_SUBSTRINGS, 2, str2, sizeof(str2));
+            pcre2len = sizeof(str2);
+            res = pcre2_substring_copy_bynumber(
+                    parse_regex.match, 2, (PCRE2_UCHAR8 *)str2, &pcre2len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                 goto error;
             }
             args[1] = (char *)str2;
         }
         if (ret > 3) {
-            res = pcre_copy_substring((char *)flowstr, ov, MAX_SUBSTRINGS, 3, str3, sizeof(str3));
+            pcre2len = sizeof(str3);
+            res = pcre2_substring_copy_bynumber(
+                    parse_regex.match, 3, (PCRE2_UCHAR8 *)str3, &pcre2len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                 goto error;
             }
             args[2] = (char *)str3;

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -185,7 +185,7 @@ static DetectFlowData *DetectFlowParse (DetectEngineCtx *de_ctx, const char *flo
 
     if (ret > 1) {
         pcre2len = sizeof(str1);
-        res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)str1, &pcre2len);
+        res = SC_Pcre2SubstringCopy(parse_regex.match, 1, (PCRE2_UCHAR8 *)str1, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -185,7 +185,7 @@ static DetectFlowData *DetectFlowParse (DetectEngineCtx *de_ctx, const char *flo
 
     if (ret > 1) {
         pcre2len = sizeof(str1);
-        res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)str1, &pcre2len);
+        res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)str1, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -215,28 +215,28 @@ int DetectFlowbitMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
 static int DetectFlowbitParse(const char *str, char *cmd, int cmd_len, char *name,
     int name_len)
 {
-    const int max_substrings = 30;
     int count, rc;
-    int ov[max_substrings];
+    size_t pcre2len;
 
-    count = DetectParsePcreExec(&parse_regex, str, 0, 0, ov, max_substrings);
+    count = DetectParsePcreExec(&parse_regex, str, 0, 0);
     if (count != 2 && count != 3) {
         SCLogError(SC_ERR_PCRE_MATCH,
             "\"%s\" is not a valid setting for flowbits.", str);
         return 0;
     }
 
-    rc = pcre_copy_substring((char *)str, ov, max_substrings, 1, cmd, cmd_len);
+    pcre2len = cmd_len;
+    rc = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)cmd, &pcre2len);
     if (rc < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         return 0;
     }
 
     if (count == 3) {
-        rc = pcre_copy_substring((char *)str, ov, max_substrings, 2, name,
-            name_len);
+        pcre2len = name_len;
+        rc = pcre2_substring_copy_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 *)name, &pcre2len);
         if (rc < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             return 0;
         }
 

--- a/src/detect-flowvar.c
+++ b/src/detect-flowvar.c
@@ -116,28 +116,30 @@ static int DetectFlowvarSetup (DetectEngineCtx *de_ctx, Signature *s, const char
     DetectFlowvarData *fd = NULL;
     SigMatch *sm = NULL;
     char varname[64], varcontent[64];
-#define MAX_SUBSTRINGS 30
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     uint8_t *content = NULL;
     uint16_t contentlen = 0;
     uint32_t contentflags = s->init_data->negated ? DETECT_CONTENT_NEGATED : 0;
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret != 3) {
         SCLogError(SC_ERR_PCRE_MATCH, "\"%s\" is not a valid setting for flowvar.", rawstr);
         return -1;
     }
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 1, varname, sizeof(varname));
+    pcre2len = sizeof(varname);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)varname, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         return -1;
     }
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 2, varcontent, sizeof(varcontent));
+    pcre2len = sizeof(varcontent);
+    res = pcre2_substring_copy_bynumber(
+            parse_regex.match, 2, (PCRE2_UCHAR8 *)varcontent, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         return -1;
     }
 

--- a/src/detect-fragbits.c
+++ b/src/detect-fragbits.c
@@ -183,8 +183,7 @@ static DetectFragBitsData *DetectFragBitsParse (const char *rawstr)
     }
 
     for (i = 0; i < (ret - 1); i++) {
-        res = SC_pcre2_substring_get(
-                parse_regex.match, i + 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+        res = SC_Pcre2SubstringGet(parse_regex.match, i + 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed %d", res);
             goto error;

--- a/src/detect-fragbits.c
+++ b/src/detect-fragbits.c
@@ -183,10 +183,10 @@ static DetectFragBitsData *DetectFragBitsParse (const char *rawstr)
     }
 
     for (i = 0; i < (ret - 1); i++) {
-        res = pcre2_substring_get_bynumber(
+        res = SC_pcre2_substring_get(
                 parse_regex.match, i + 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed %d", res);
             goto error;
         }
 

--- a/src/detect-fragoffset.c
+++ b/src/detect-fragoffset.c
@@ -144,21 +144,22 @@ static DetectFragOffsetData *DetectFragOffsetParse (DetectEngineCtx *de_ctx, con
     DetectFragOffsetData *fragoff = NULL;
     char *substr[3] = {NULL, NULL, NULL};
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2_len;
     int i;
     const char *str_ptr;
     char *mode = NULL;
 
-    ret = DetectParsePcreExec(&parse_regex, fragoffsetstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, fragoffsetstr, 0, 0);
     if (ret < 1 || ret > 4) {
         SCLogError(SC_ERR_PCRE_MATCH,"Parse error %s", fragoffsetstr);
         goto error;
     }
 
     for (i = 1; i < ret; i++) {
-        res = pcre_get_substring((char *)fragoffsetstr, ov, MAX_SUBSTRINGS, i, &str_ptr);
+        res = pcre2_substring_get_bynumber(
+                parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING,"pcre_get_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;
         }
         substr[i-1] = (char *)str_ptr;
@@ -195,14 +196,16 @@ static DetectFragOffsetData *DetectFragOffsetParse (DetectEngineCtx *de_ctx, con
     }
 
     for (i = 0; i < 3; i++) {
-        if (substr[i] != NULL) SCFree(substr[i]);
+        if (substr[i] != NULL)
+            pcre2_substring_free((PCRE2_UCHAR8 *)substr[i]);
     }
 
     return fragoff;
 
 error:
     for (i = 0; i < 3; i++) {
-        if (substr[i] != NULL) SCFree(substr[i]);
+        if (substr[i] != NULL)
+            pcre2_substring_free((PCRE2_UCHAR8 *)substr[i]);
     }
     if (fragoff != NULL) DetectFragOffsetFree(de_ctx, fragoff);
     return NULL;

--- a/src/detect-fragoffset.c
+++ b/src/detect-fragoffset.c
@@ -156,8 +156,7 @@ static DetectFragOffsetData *DetectFragOffsetParse (DetectEngineCtx *de_ctx, con
     }
 
     for (i = 1; i < ret; i++) {
-        res = pcre2_substring_get_bynumber(
-                parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+        res = SC_pcre2_substring_get(parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;

--- a/src/detect-fragoffset.c
+++ b/src/detect-fragoffset.c
@@ -156,7 +156,7 @@ static DetectFragOffsetData *DetectFragOffsetParse (DetectEngineCtx *de_ctx, con
     }
 
     for (i = 1; i < ret; i++) {
-        res = SC_pcre2_substring_get(parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+        res = SC_Pcre2SubstringGet(parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;

--- a/src/detect-ftpdata.c
+++ b/src/detect-ftpdata.c
@@ -141,17 +141,18 @@ static DetectFtpdataData *DetectFtpdataParse(const char *ftpcommandstr)
 {
     DetectFtpdataData *ftpcommandd = NULL;
     char arg1[5] = "";
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
 
-    int ret = DetectParsePcreExec(&parse_regex, ftpcommandstr, 0, 0, ov, MAX_SUBSTRINGS);
+    int ret = DetectParsePcreExec(&parse_regex, ftpcommandstr, 0, 0);
     if (ret != 2) {
         SCLogError(SC_ERR_PCRE_MATCH, "parse error, ret %" PRId32 "", ret);
         goto error;
     }
 
-    int res = pcre_copy_substring((char *) ftpcommandstr, ov, MAX_SUBSTRINGS, 1, arg1, sizeof(arg1));
+    pcre2len = sizeof(arg1);
+    int res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)arg1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
     SCLogDebug("Arg1 \"%s\"", arg1);

--- a/src/detect-hostbits.c
+++ b/src/detect-hostbits.c
@@ -282,36 +282,36 @@ static int DetectHostbitMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
 static int DetectHostbitParse(const char *str, char *cmd, int cmd_len,
     char *name, int name_len, char *dir, int dir_len)
 {
-    const int max_substrings = 30;
     int count, rc;
-    int ov[max_substrings];
+    size_t pcre2len;
 
-    count = DetectParsePcreExec(&parse_regex, str, 0, 0, ov, max_substrings);
+    count = DetectParsePcreExec(&parse_regex, str, 0, 0);
     if (count != 2 && count != 3 && count != 4) {
         SCLogError(SC_ERR_PCRE_MATCH,
             "\"%s\" is not a valid setting for hostbits.", str);
         return 0;
     }
 
-    rc = pcre_copy_substring((char *)str, ov, max_substrings, 1, cmd, cmd_len);
+    pcre2len = cmd_len;
+    rc = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)cmd, &pcre2len);
     if (rc < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         return 0;
     }
 
     if (count >= 3) {
-        rc = pcre_copy_substring((char *)str, ov, max_substrings, 2, name,
-            name_len);
+        pcre2len = name_len;
+        rc = pcre2_substring_copy_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 *)name, &pcre2len);
         if (rc < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             return 0;
         }
         if (count >= 4) {
-            rc = pcre_copy_substring((char *)str, ov, max_substrings, 3, dir,
-                dir_len);
+            pcre2len = dir_len;
+            rc = pcre2_substring_copy_bynumber(
+                    parse_regex.match, 3, (PCRE2_UCHAR8 *)dir, &pcre2len);
             if (rc < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING,
-                    "pcre_copy_substring failed");
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                 return 0;
             }
         }

--- a/src/detect-icmp-id.c
+++ b/src/detect-icmp-id.c
@@ -172,7 +172,7 @@ static DetectIcmpIdData *DetectIcmpIdParse (DetectEngineCtx *de_ctx, const char 
     int i;
     const char *str_ptr;
     for (i = 1; i < ret; i++) {
-        res = SC_pcre2_substring_get(parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+        res = SC_Pcre2SubstringGet(parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;

--- a/src/detect-icmp-id.c
+++ b/src/detect-icmp-id.c
@@ -172,8 +172,7 @@ static DetectIcmpIdData *DetectIcmpIdParse (DetectEngineCtx *de_ctx, const char 
     int i;
     const char *str_ptr;
     for (i = 1; i < ret; i++) {
-        res = pcre2_substring_get_bynumber(
-                parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+        res = SC_pcre2_substring_get(parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;

--- a/src/detect-icmp-seq.c
+++ b/src/detect-icmp-seq.c
@@ -163,20 +163,21 @@ static DetectIcmpSeqData *DetectIcmpSeqParse (DetectEngineCtx *de_ctx, const cha
     DetectIcmpSeqData *iseq = NULL;
     char *substr[3] = {NULL, NULL, NULL};
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2_len;
     int i;
     const char *str_ptr;
 
-    ret = DetectParsePcreExec(&parse_regex, icmpseqstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, icmpseqstr, 0, 0);
     if (ret < 1 || ret > 4) {
         SCLogError(SC_ERR_PCRE_MATCH,"Parse error %s", icmpseqstr);
         goto error;
     }
 
     for (i = 1; i < ret; i++) {
-        res = pcre_get_substring((char *)icmpseqstr, ov, MAX_SUBSTRINGS, i, &str_ptr);
+        res = pcre2_substring_get_bynumber(
+                parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING,"pcre_get_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;
         }
         substr[i-1] = (char *)str_ptr;
@@ -209,14 +210,16 @@ static DetectIcmpSeqData *DetectIcmpSeqParse (DetectEngineCtx *de_ctx, const cha
     iseq->seq = htons(seq);
 
     for (i = 0; i < 3; i++) {
-        if (substr[i] != NULL) SCFree(substr[i]);
+        if (substr[i] != NULL)
+            pcre2_substring_free((PCRE2_UCHAR8 *)substr[i]);
     }
 
     return iseq;
 
 error:
     for (i = 0; i < 3; i++) {
-        if (substr[i] != NULL) SCFree(substr[i]);
+        if (substr[i] != NULL)
+            pcre2_substring_free((PCRE2_UCHAR8 *)substr[i]);
     }
     if (iseq != NULL) DetectIcmpSeqFree(de_ctx, iseq);
     return NULL;

--- a/src/detect-icmp-seq.c
+++ b/src/detect-icmp-seq.c
@@ -174,7 +174,7 @@ static DetectIcmpSeqData *DetectIcmpSeqParse (DetectEngineCtx *de_ctx, const cha
     }
 
     for (i = 1; i < ret; i++) {
-        res = SC_pcre2_substring_get(parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+        res = SC_Pcre2SubstringGet(parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;

--- a/src/detect-icmp-seq.c
+++ b/src/detect-icmp-seq.c
@@ -174,8 +174,7 @@ static DetectIcmpSeqData *DetectIcmpSeqParse (DetectEngineCtx *de_ctx, const cha
     }
 
     for (i = 1; i < ret; i++) {
-        res = pcre2_substring_get_bynumber(
-                parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+        res = SC_pcre2_substring_get(parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;

--- a/src/detect-icode.c
+++ b/src/detect-icode.c
@@ -163,8 +163,7 @@ static DetectICodeData *DetectICodeParse(DetectEngineCtx *de_ctx, const char *ic
     int i;
     const char *str_ptr;
     for (i = 1; i < ret; i++) {
-        res = pcre2_substring_get_bynumber(
-                parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+        res = SC_pcre2_substring_get(parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;

--- a/src/detect-icode.c
+++ b/src/detect-icode.c
@@ -163,7 +163,7 @@ static DetectICodeData *DetectICodeParse(DetectEngineCtx *de_ctx, const char *ic
     int i;
     const char *str_ptr;
     for (i = 1; i < ret; i++) {
-        res = SC_pcre2_substring_get(parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+        res = SC_Pcre2SubstringGet(parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;

--- a/src/detect-id.c
+++ b/src/detect-id.c
@@ -125,9 +125,9 @@ static DetectIdData *DetectIdParse (const char *idstr)
     uint32_t temp;
     DetectIdData *id_d = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
 
-    ret = DetectParsePcreExec(&parse_regex, idstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, idstr, 0, 0);
 
     if (ret < 1 || ret > 3) {
         SCLogError(SC_ERR_INVALID_VALUE, "invalid id option '%s'. The id option "
@@ -138,10 +138,10 @@ static DetectIdData *DetectIdParse (const char *idstr)
 
     char copy_str[128] = "";
     char *tmp_str;
-    res = pcre_copy_substring((char *)idstr, ov, MAX_SUBSTRINGS, 1,
-            copy_str, sizeof(copy_str));
+    pcre2len = sizeof(copy_str);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)copy_str, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         return NULL;
     }
     tmp_str = copy_str;

--- a/src/detect-ike-chosen-sa.c
+++ b/src/detect-ike-chosen-sa.c
@@ -143,11 +143,11 @@ static DetectIkeChosenSaData *DetectIkeChosenSaParse(const char *rawstr)
      */
     DetectIkeChosenSaData *dd = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     char attribute[100];
     char value[100];
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret < 3 || ret > 5) {
         SCLogError(SC_ERR_PCRE_MATCH,
                 "pcre match for ike.chosen_sa_attribute failed, should be: <sa_attribute>=<type>, "
@@ -156,15 +156,17 @@ static DetectIkeChosenSaData *DetectIkeChosenSaParse(const char *rawstr)
         goto error;
     }
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 1, attribute, sizeof(attribute));
+    pcre2len = sizeof(attribute);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)attribute, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 2, value, sizeof(value));
+    pcre2len = sizeof(value);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 *)value, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -130,9 +130,8 @@ static DetectIpOptsData *DetectIpOptsParse (const char *rawstr)
     int i;
     DetectIpOptsData *de = NULL;
     int ret = 0, found = 0;
-    int ov[MAX_SUBSTRINGS];
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret < 1) {
         SCLogError(SC_ERR_PCRE_MATCH, "pcre_exec parse error, ret %" PRId32 ", string %s", ret, rawstr);
         goto error;

--- a/src/detect-iprep.c
+++ b/src/detect-iprep.c
@@ -246,39 +246,39 @@ int DetectIPRepSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
     char *cmd_str = NULL, *name = NULL, *op_str = NULL, *value = NULL;
     uint8_t cmd = 0;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2_len;
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret != 5) {
         SCLogError(SC_ERR_PCRE_MATCH, "\"%s\" is not a valid setting for iprep", rawstr);
         return -1;
     }
 
     const char *str_ptr;
-    res = pcre_get_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 1, &str_ptr);
+    res = pcre2_substring_get_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         return -1;
     }
     cmd_str = (char *)str_ptr;
 
-    res = pcre_get_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 2, &str_ptr);
+    res = pcre2_substring_get_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;
     }
     name = (char *)str_ptr;
 
-    res = pcre_get_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 3, &str_ptr);
+    res = pcre2_substring_get_bynumber(parse_regex.match, 3, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;
     }
     op_str = (char *)str_ptr;
 
-    res = pcre_get_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 4, &str_ptr);
+    res = pcre2_substring_get_bynumber(parse_regex.match, 4, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;
     }
     value = (char *)str_ptr;
@@ -340,13 +340,13 @@ int DetectIPRepSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
     cd->val = val;
     SCLogDebug("cmd %u, cat %u, op %u, val %u", cd->cmd, cd->cat, cd->op, cd->val);
 
-    pcre_free_substring(name);
+    pcre2_substring_free((PCRE2_UCHAR *)name);
     name = NULL;
-    pcre_free_substring(cmd_str);
+    pcre2_substring_free((PCRE2_UCHAR *)cmd_str);
     cmd_str = NULL;
-    pcre_free_substring(op_str);
+    pcre2_substring_free((PCRE2_UCHAR *)op_str);
     op_str = NULL;
-    pcre_free_substring(value);
+    pcre2_substring_free((PCRE2_UCHAR *)value);
     value = NULL;
 
     /* Okay so far so good, lets get this into a SigMatch
@@ -364,13 +364,13 @@ int DetectIPRepSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 
 error:
     if (name != NULL)
-        pcre_free_substring(name);
+        pcre2_substring_free((PCRE2_UCHAR *)name);
     if (cmd_str != NULL)
-        pcre_free_substring(cmd_str);
+        pcre2_substring_free((PCRE2_UCHAR *)cmd_str);
     if (op_str != NULL)
-        pcre_free_substring(op_str);
+        pcre2_substring_free((PCRE2_UCHAR *)op_str);
     if (value != NULL)
-        pcre_free_substring(value);
+        pcre2_substring_free((PCRE2_UCHAR *)value);
     if (cd != NULL)
         SCFree(cd);
     if (sm != NULL)

--- a/src/detect-itype.c
+++ b/src/detect-itype.c
@@ -163,8 +163,7 @@ static DetectITypeData *DetectITypeParse(DetectEngineCtx *de_ctx, const char *it
     int i;
     const char *str_ptr;
     for (i = 1; i < ret; i++) {
-        res = pcre2_substring_get_bynumber(
-                parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+        res = SC_pcre2_substring_get(parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;

--- a/src/detect-itype.c
+++ b/src/detect-itype.c
@@ -163,7 +163,7 @@ static DetectITypeData *DetectITypeParse(DetectEngineCtx *de_ctx, const char *it
     int i;
     const char *str_ptr;
     for (i = 1; i < ret; i++) {
-        res = SC_pcre2_substring_get(parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+        res = SC_Pcre2SubstringGet(parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;

--- a/src/detect-itype.c
+++ b/src/detect-itype.c
@@ -152,9 +152,9 @@ static DetectITypeData *DetectITypeParse(DetectEngineCtx *de_ctx, const char *it
     DetectITypeData *itd = NULL;
     char *args[3] = {NULL, NULL, NULL};
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2_len;
 
-    ret = DetectParsePcreExec(&parse_regex, itypestr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, itypestr, 0, 0);
     if (ret < 1 || ret > 4) {
         SCLogError(SC_ERR_PCRE_MATCH, "pcre_exec parse error, ret %" PRId32 ", string %s", ret, itypestr);
         goto error;
@@ -163,9 +163,10 @@ static DetectITypeData *DetectITypeParse(DetectEngineCtx *de_ctx, const char *it
     int i;
     const char *str_ptr;
     for (i = 1; i < ret; i++) {
-        res = pcre_get_substring((char *)itypestr, ov, MAX_SUBSTRINGS, i, &str_ptr);
+        res = pcre2_substring_get_bynumber(
+                parse_regex.match, i, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;
         }
         args[i-1] = (char *)str_ptr;
@@ -243,14 +244,14 @@ static DetectITypeData *DetectITypeParse(DetectEngineCtx *de_ctx, const char *it
 
     for (i = 0; i < (ret-1); i++) {
         if (args[i] != NULL)
-            SCFree(args[i]);
+            pcre2_substring_free((PCRE2_UCHAR8 *)args[i]);
     }
     return itd;
 
 error:
     for (i = 0; i < (ret-1) && i < 3; i++) {
         if (args[i] != NULL)
-            SCFree(args[i]);
+            pcre2_substring_free((PCRE2_UCHAR8 *)args[i]);
     }
     if (itd != NULL)
         DetectITypeFree(de_ctx, itd);

--- a/src/detect-krb5-errcode.c
+++ b/src/detect-krb5-errcode.c
@@ -139,17 +139,18 @@ static DetectKrb5ErrCodeData *DetectKrb5ErrCodeParse (const char *krb5str)
     DetectKrb5ErrCodeData *krb5d = NULL;
     char arg1[4] = "";
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
 
-    ret = DetectParsePcreExec(&parse_regex, krb5str, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, krb5str, 0, 0);
     if (ret != 2) {
         SCLogError(SC_ERR_PCRE_MATCH, "parse error, ret %" PRId32 "", ret);
         goto error;
     }
 
-    res = pcre_copy_substring((char *) krb5str, ov, MAX_SUBSTRINGS, 1, arg1, sizeof(arg1));
+    pcre2len = sizeof(arg1);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)arg1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 

--- a/src/detect-krb5-msgtype.c
+++ b/src/detect-krb5-msgtype.c
@@ -136,17 +136,18 @@ static DetectKrb5MsgTypeData *DetectKrb5MsgTypeParse (const char *krb5str)
     DetectKrb5MsgTypeData *krb5d = NULL;
     char arg1[4] = "";
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
 
-    ret = DetectParsePcreExec(&parse_regex, krb5str, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, krb5str, 0, 0);
     if (ret != 2) {
         SCLogError(SC_ERR_PCRE_MATCH, "parse error, ret %" PRId32 "", ret);
         goto error;
     }
 
-    res = pcre_copy_substring((char *) krb5str, ov, MAX_SUBSTRINGS, 1, arg1, sizeof(arg1));
+    pcre2len = sizeof(arg1);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)arg1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 

--- a/src/detect-mqtt-connect-flags.c
+++ b/src/detect-mqtt-connect-flags.c
@@ -130,9 +130,8 @@ static DetectMQTTConnectFlagsData *DetectMQTTConnectFlagsParse(const char *rawst
 {
     DetectMQTTConnectFlagsData *de = NULL;
     int ret = 0;
-    int ov[MAX_SUBSTRINGS];
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret < 1) {
         SCLogError(SC_ERR_PCRE_MATCH, "invalid flag definition: %s", rawstr);
         return NULL;

--- a/src/detect-mqtt-flags.c
+++ b/src/detect-mqtt-flags.c
@@ -125,9 +125,8 @@ static DetectMQTTFlagsData *DetectMQTTFlagsParse(const char *rawstr)
 {
     DetectMQTTFlagsData *de = NULL;
     int ret = 0;
-    int ov[MAX_SUBSTRINGS];
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret < 1) {
         SCLogError(SC_ERR_PCRE_MATCH, "invalid flag definition: %s", rawstr);
         return NULL;

--- a/src/detect-nfs-procedure.c
+++ b/src/detect-nfs-procedure.c
@@ -218,7 +218,7 @@ static DetectNfsProcedureData *DetectNfsProcedureParse (const char *rawstr)
     }
 
     pcre2len = sizeof(mode);
-    res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
+    res = SC_Pcre2SubstringCopy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;

--- a/src/detect-nfs-procedure.c
+++ b/src/detect-nfs-procedure.c
@@ -205,49 +205,49 @@ static DetectNfsProcedureData *DetectNfsProcedureParse (const char *rawstr)
 {
     DetectNfsProcedureData *dd = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     char mode[2] = "";
     char value1[20] = "";
     char value2[20] = "";
     char range[3] = "";
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret < 3 || ret > 5) {
         SCLogError(SC_ERR_PCRE_MATCH, "Parse error %s", rawstr);
         goto error;
     }
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 1, mode,
-                              sizeof(mode));
+    pcre2len = sizeof(mode);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
     SCLogDebug("mode \"%s\"", mode);
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 2, value1,
-                              sizeof(value1));
+    pcre2len = sizeof(value1);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 *)value1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
     SCLogDebug("value1 \"%s\"", value1);
 
     if (ret > 3) {
-        res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 3,
-                                  range, sizeof(range));
+        pcre2len = sizeof(range);
+        res = pcre2_substring_copy_bynumber(parse_regex.match, 3, (PCRE2_UCHAR8 *)range, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;
         }
         SCLogDebug("range \"%s\"", range);
 
         if (ret > 4) {
-            res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 4,
-                                      value2, sizeof(value2));
+            pcre2len = sizeof(value2);
+            res = pcre2_substring_copy_bynumber(
+                    parse_regex.match, 4, (PCRE2_UCHAR8 *)value2, &pcre2len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING,
-                           "pcre_copy_substring failed");
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                 goto error;
             }
             SCLogDebug("value2 \"%s\"", value2);

--- a/src/detect-nfs-procedure.c
+++ b/src/detect-nfs-procedure.c
@@ -218,7 +218,7 @@ static DetectNfsProcedureData *DetectNfsProcedureParse (const char *rawstr)
     }
 
     pcre2len = sizeof(mode);
-    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
+    res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;

--- a/src/detect-nfs-version.c
+++ b/src/detect-nfs-version.c
@@ -196,49 +196,49 @@ static DetectNfsVersionData *DetectNfsVersionParse (const char *rawstr)
 {
     DetectNfsVersionData *dd = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     char mode[2] = "";
     char value1[20] = "";
     char value2[20] = "";
     char range[3] = "";
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret < 3 || ret > 5) {
         SCLogError(SC_ERR_PCRE_MATCH, "Parse error %s", rawstr);
         goto error;
     }
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 1, mode,
-                              sizeof(mode));
+    pcre2len = sizeof(mode);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
     SCLogDebug("mode \"%s\"", mode);
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 2, value1,
-                              sizeof(value1));
+    pcre2len = sizeof(value1);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 *)value1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
     SCLogDebug("value1 \"%s\"", value1);
 
     if (ret > 3) {
-        res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 3,
-                                  range, sizeof(range));
+        pcre2len = sizeof(range);
+        res = pcre2_substring_copy_bynumber(parse_regex.match, 3, (PCRE2_UCHAR8 *)range, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;
         }
         SCLogDebug("range \"%s\"", range);
 
         if (ret > 4) {
-            res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 4,
-                                      value2, sizeof(value2));
+            pcre2len = sizeof(value2);
+            res = pcre2_substring_copy_bynumber(
+                    parse_regex.match, 4, (PCRE2_UCHAR8 *)value2, &pcre2len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING,
-                           "pcre_copy_substring failed");
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                 goto error;
             }
             SCLogDebug("value2 \"%s\"", value2);

--- a/src/detect-nfs-version.c
+++ b/src/detect-nfs-version.c
@@ -209,7 +209,7 @@ static DetectNfsVersionData *DetectNfsVersionParse (const char *rawstr)
     }
 
     pcre2len = sizeof(mode);
-    res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
+    res = SC_Pcre2SubstringCopy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;

--- a/src/detect-nfs-version.c
+++ b/src/detect-nfs-version.c
@@ -209,7 +209,7 @@ static DetectNfsVersionData *DetectNfsVersionParse (const char *rawstr)
     }
 
     pcre2len = sizeof(mode);
-    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
+    res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2560,6 +2560,30 @@ DetectParseRegex2 *DetectSetupPCRE2(const char *parse_str, int opts)
     return detect_parse;
 }
 
+int SC_pcre2_substring_copy(
+        pcre2_match_data *match_data, uint32_t number, PCRE2_UCHAR *buffer, PCRE2_SIZE *bufflen)
+{
+    int r = pcre2_substring_copy_bynumber(match_data, number, buffer, bufflen);
+    if (r == PCRE2_ERROR_UNSET) {
+        buffer[0] = 0;
+        *bufflen = 0;
+        return 0;
+    }
+    return r;
+}
+
+int SC_pcre2_substring_get(
+        pcre2_match_data *match_data, uint32_t number, PCRE2_UCHAR **bufferptr, PCRE2_SIZE *bufflen)
+{
+    int r = pcre2_substring_get_bynumber(match_data, number, bufferptr, bufflen);
+    if (r == PCRE2_ERROR_UNSET) {
+        *bufferptr = NULL;
+        *bufflen = 0;
+        return 0;
+    }
+    return r;
+}
+
 void DetectSetupParseRegexes(const char *parse_str, DetectParseRegex *detect_parse)
 {
     if (!DetectSetupParseRegexesOpts(parse_str, detect_parse, 0)) {

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2431,30 +2431,21 @@ error:
 }
 
 static DetectParseRegex *g_detect_parse_regex_list = NULL;
-int DetectParsePcreExecLen(DetectParseRegex *parse_regex, const char *str,
-                   int str_len,
-                   int start_offset, int options,
-                   int *ovector, int ovector_size)
-{
-    return pcre_exec(parse_regex->regex, parse_regex->study, str, str_len,
-                     start_offset, options, ovector, ovector_size);
-}
 
-int DetectParsePcreExec(DetectParseRegex *parse_regex, const char *str,
-                   int start_offset, int options,
-                   int *ovector, int ovector_size)
+int DetectParsePcreExec(
+        DetectParseRegex *parse_regex, const char *str, int start_offset, int options)
 {
-    return pcre_exec(parse_regex->regex, parse_regex->study, str, strlen(str),
-                     start_offset, options, ovector, ovector_size);
+    return pcre2_match(parse_regex->regex, (PCRE2_SPTR8)str, strlen(str), options, start_offset,
+            parse_regex->match, NULL);
 }
 
 void DetectParseFreeRegex(DetectParseRegex *r)
 {
     if (r->regex) {
-        pcre_free(r->regex);
+        pcre2_code_free(r->regex);
     }
-    if (r->study) {
-        pcre_free_study(r->study);
+    if (r->match) {
+        pcre2_match_data_free(r->match);
     }
 }
 
@@ -2505,29 +2496,28 @@ void DetectParseRegexAddToFreeList(DetectParseRegex *detect_parse)
         FatalError(SC_ERR_MEM_ALLOC, "failed to alloc memory for pcre free list");
     }
     r->regex = detect_parse->regex;
-    r->study = detect_parse->study;
+    r->match = detect_parse->match;
     r->next = g_detect_parse_regex_list;
     g_detect_parse_regex_list = r;
 }
 
 bool DetectSetupParseRegexesOpts(const char *parse_str, DetectParseRegex *detect_parse, int opts)
 {
-    const char *eb = NULL;
-    int eo;
+    int en;
+    PCRE2_SIZE eo;
 
-    detect_parse->regex = pcre_compile(parse_str, opts, &eb, &eo, NULL);
+    detect_parse->regex =
+            pcre2_compile((PCRE2_SPTR8)parse_str, PCRE2_ZERO_TERMINATED, opts, &en, &eo, NULL);
     if (detect_parse->regex == NULL) {
-        SCLogError(SC_ERR_PCRE_COMPILE, "pcre compile of \"%s\" failed at "
-                "offset %" PRId32 ": %s", parse_str, eo, eb);
+        PCRE2_UCHAR errbuffer[256];
+        pcre2_get_error_message(en, errbuffer, sizeof(errbuffer));
+        SCLogError(SC_ERR_PCRE_COMPILE,
+                "pcre compile of \"%s\" failed at "
+                "offset %d: %s",
+                parse_str, en, errbuffer);
         return false;
     }
-
-    detect_parse->study = pcre_study(detect_parse->regex, 0 , &eb);
-    if (eb != NULL) {
-        SCLogError(SC_ERR_PCRE_STUDY, "pcre study failed: %s", eb);
-        return false;
-    }
-
+    detect_parse->match = pcre2_match_data_create_from_pattern(detect_parse->regex, NULL);
 
     DetectParseRegexAddToFreeList(detect_parse);
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2531,7 +2531,7 @@ DetectParseRegex *DetectSetupPCRE2(const char *parse_str, int opts)
     return detect_parse;
 }
 
-int SC_pcre2_substring_copy(
+int SC_Pcre2SubstringCopy(
         pcre2_match_data *match_data, uint32_t number, PCRE2_UCHAR *buffer, PCRE2_SIZE *bufflen)
 {
     int r = pcre2_substring_copy_bynumber(match_data, number, buffer, bufflen);
@@ -2543,7 +2543,7 @@ int SC_pcre2_substring_copy(
     return r;
 }
 
-int SC_pcre2_substring_get(
+int SC_Pcre2SubstringGet(
         pcre2_match_data *match_data, uint32_t number, PCRE2_UCHAR **bufferptr, PCRE2_SIZE *bufflen)
 {
     int r = pcre2_substring_get_bynumber(match_data, number, bufferptr, bufflen);

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -45,6 +45,15 @@ typedef struct DetectParseRegex_ {
     struct DetectParseRegex_ *next;
 } DetectParseRegex;
 
+#include <pcre2.h>
+
+typedef struct DetectParseRegex2 {
+    pcre2_code *regex;
+    pcre2_match_context *context;
+    pcre2_match_data *match;
+    struct DetectParseRegex2 *next;
+} DetectParseRegex2;
+
 /* prototypes */
 Signature *SigAlloc(void);
 void SigFree(DetectEngineCtx *de_ctx, Signature *s);
@@ -85,6 +94,8 @@ int WARN_UNUSED DetectSignatureSetAppProto(Signature *s, AppProto alproto);
 
 /* parse regex setup and free util funcs */
 
+void DetectParseFreePCRE2(DetectParseRegex2 *r);
+DetectParseRegex2 *DetectSetupPCRE2(const char *parse_str, int opts);
 bool DetectSetupParseRegexesOpts(const char *parse_str, DetectParseRegex *parse_regex, int opts);
 void DetectSetupParseRegexes(const char *parse_str, DetectParseRegex *parse_regex);
 void DetectParseRegexAddToFreeList(DetectParseRegex *parse_regex);

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -42,9 +42,6 @@ enum {
 typedef struct DetectParseRegex_ {
     pcre *regex;
     pcre_extra *study;
-#ifdef PCRE_HAVE_JIT_EXEC
-    pcre_jit_stack *jit_stack;
-#endif
     struct DetectParseRegex_ *next;
 } DetectParseRegex;
 

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -39,18 +39,12 @@ enum {
     SIG_DIREC_DST
 };
 
-typedef struct DetectParseRegex_ {
-    pcre2_code *regex;
-    pcre2_match_data *match;
-    struct DetectParseRegex_ *next;
-} DetectParseRegex;
-
-typedef struct DetectParseRegex2 {
+typedef struct DetectParseRegex {
     pcre2_code *regex;
     pcre2_match_context *context;
     pcre2_match_data *match;
-    struct DetectParseRegex2 *next;
-} DetectParseRegex2;
+    struct DetectParseRegex *next;
+} DetectParseRegex;
 
 /* prototypes */
 Signature *SigAlloc(void);
@@ -92,8 +86,7 @@ int WARN_UNUSED DetectSignatureSetAppProto(Signature *s, AppProto alproto);
 
 /* parse regex setup and free util funcs */
 
-void DetectParseFreePCRE2(DetectParseRegex2 *r);
-DetectParseRegex2 *DetectSetupPCRE2(const char *parse_str, int opts);
+DetectParseRegex *DetectSetupPCRE2(const char *parse_str, int opts);
 bool DetectSetupParseRegexesOpts(const char *parse_str, DetectParseRegex *parse_regex, int opts);
 void DetectSetupParseRegexes(const char *parse_str, DetectParseRegex *parse_regex);
 void DetectParseRegexAddToFreeList(DetectParseRegex *parse_regex);

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -96,9 +96,9 @@ void DetectParseFreeRegex(DetectParseRegex *r);
 /* parse regex exec */
 int DetectParsePcreExec(
         DetectParseRegex *parse_regex, const char *str, int start_offset, int options);
-int SC_pcre2_substring_copy(
+int SC_Pcre2SubstringCopy(
         pcre2_match_data *match_data, uint32_t number, PCRE2_UCHAR *buffer, PCRE2_SIZE *bufflen);
-int SC_pcre2_substring_get(pcre2_match_data *match_data, uint32_t number, PCRE2_UCHAR **bufferptr,
+int SC_Pcre2SubstringGet(pcre2_match_data *match_data, uint32_t number, PCRE2_UCHAR **bufferptr,
         PCRE2_SIZE *bufflen);
 
 #endif /* __DETECT_PARSE_H__ */

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -45,8 +45,6 @@ typedef struct DetectParseRegex_ {
     struct DetectParseRegex_ *next;
 } DetectParseRegex;
 
-#include <pcre2.h>
-
 typedef struct DetectParseRegex2 {
     pcre2_code *regex;
     pcre2_match_context *context;

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -40,8 +40,8 @@ enum {
 };
 
 typedef struct DetectParseRegex_ {
-    pcre *regex;
-    pcre_extra *study;
+    pcre2_code *regex;
+    pcre2_match_data *match;
     struct DetectParseRegex_ *next;
 } DetectParseRegex;
 
@@ -103,15 +103,8 @@ void DetectParseFreeRegexes(void);
 void DetectParseFreeRegex(DetectParseRegex *r);
 
 /* parse regex exec */
-int DetectParsePcreExec(DetectParseRegex *parse_regex, const char *str,
-                   int start_offset, int options,
-                   int *ovector, int ovector_size);
-int DetectParsePcreExecLen(DetectParseRegex *parse_regex, const char *str,
-                   int str_len, int start_offset, int options,
-                   int *ovector, int ovector_size);
-
-/* typical size of ovector */
-#define MAX_SUBSTRINGS 30
+int DetectParsePcreExec(
+        DetectParseRegex *parse_regex, const char *str, int start_offset, int options);
 
 #endif /* __DETECT_PARSE_H__ */
 

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -105,6 +105,10 @@ void DetectParseFreeRegex(DetectParseRegex *r);
 /* parse regex exec */
 int DetectParsePcreExec(
         DetectParseRegex *parse_regex, const char *str, int start_offset, int options);
+int SC_pcre2_substring_copy(
+        pcre2_match_data *match_data, uint32_t number, PCRE2_UCHAR *buffer, PCRE2_SIZE *bufflen);
+int SC_pcre2_substring_get(pcre2_match_data *match_data, uint32_t number, PCRE2_UCHAR **bufferptr,
+        PCRE2_SIZE *bufflen);
 
 #endif /* __DETECT_PARSE_H__ */
 

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -24,7 +24,6 @@
  */
 
 #include "suricata-common.h"
-#include "pcre.h"
 #include "debug.h"
 #include "decode.h"
 #include "detect.h"

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -74,36 +74,20 @@ static int pcre_match_limit_recursion = 0;
 static DetectParseRegex parse_regex;
 static DetectParseRegex parse_capture_regex;
 
-#ifdef PCRE_HAVE_JIT
-static int pcre_use_jit = 1;
+#ifdef PCRE2_HAVE_JIT
+static int pcre2_use_jit = 1;
 #endif
 
-#ifdef PCRE_HAVE_JIT_EXEC
-#define PCRE_JIT_MIN_STACK 32*1024
-#define PCRE_JIT_MAX_STACK 512*1024
-
-#endif
+// TODOpcre2 pcre2_jit_stack_create ?
 
 /* \brief Helper function for using pcre_exec with/without JIT
  */
-static inline int DetectPcreExec(DetectEngineThreadCtx *det_ctx, DetectPcreData *pd, DetectParseRegex *regex,
-        const char *str, const size_t strlen, int start_offset, int options,  int *ovector, int ovector_size)
+static inline int DetectPcreExec(DetectEngineThreadCtx *det_ctx, DetectPcreData *pd,
+        const char *str, const size_t strlen, int start_offset, int options)
 {
-#ifdef PCRE_HAVE_JIT_EXEC
-    if (pd->thread_ctx_jit_stack_id != -1) {
-        pcre_jit_stack *jit_stack = (pcre_jit_stack *)
-            DetectThreadCtxGetKeywordThreadCtx(det_ctx, pd->thread_ctx_jit_stack_id);
-        if (jit_stack) {
-            SCLogDebug("Using jit_stack %p", jit_stack);
-            return pcre_jit_exec(regex->regex, regex->study, str, strlen,
-                                start_offset, options, ovector, ovector_size,
-                                jit_stack);
-        }
-    }
-#endif
     /* Fallback if registration during setup failed */
-    return pcre_exec(regex->regex, regex->study, str, strlen,
-                     start_offset, options, ovector, ovector_size);
+    return pcre2_match(pd->parse_regex.regex, (PCRE2_SPTR8)str, strlen, start_offset, options,
+            pd->parse_regex.match, NULL);
 }
 
 static int DetectPcreSetup (DetectEngineCtx *, Signature *, const char *);
@@ -163,10 +147,10 @@ void DetectPcreRegister (void)
         FatalError(SC_ERR_PCRE_COMPILE, "pcre compile and study failed");
     }
 
-#ifdef PCRE_HAVE_JIT
+#ifdef PCRE2_HAVE_JIT
     if (PageSupportsRWX() == 0) {
-        SCLogConfig("PCRE won't use JIT as OS doesn't allow RWX pages");
-        pcre_use_jit = 0;
+        SCLogConfig("PCRE2 won't use JIT as OS doesn't allow RWX pages");
+        pcre2_use_jit = 0;
     }
 #endif
 
@@ -193,10 +177,9 @@ int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
 {
     SCEnter();
     int ret = 0;
-    int ov[MAX_SUBSTRINGS];
     const uint8_t *ptr = NULL;
     uint16_t len = 0;
-    uint16_t capture_len = 0;
+    PCRE2_SIZE capture_len = 0;
 
     DetectPcreData *pe = (DetectPcreData *)smd->ctx;
 
@@ -214,10 +197,10 @@ int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
     }
 
     /* run the actual pcre detection */
-    ret = DetectPcreExec(det_ctx, pe, &pe->parse_regex, (char *) ptr, len, start_offset, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectPcreExec(det_ctx, pe, (char *)ptr, len, start_offset, 0);
     SCLogDebug("ret %d (negating %s)", ret, (pe->flags & DETECT_PCRE_NEGATE) ? "set" : "not set");
 
-    if (ret == PCRE_ERROR_NOMATCH) {
+    if (ret == PCRE2_ERROR_NOMATCH) {
         if (pe->flags & DETECT_PCRE_NEGATE) {
             /* regex didn't match with negate option means we
              * consider it a match */
@@ -241,28 +224,47 @@ int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
                 uint8_t x;
                 for (x = 0; x < pe->idx; x++) {
                     SCLogDebug("capturing %u", x);
-                    const char *str_ptr = NULL;
-                    ret = pcre_get_substring((char *)ptr, ov, MAX_SUBSTRINGS, x+1, &str_ptr);
-                    if (unlikely(ret == 0)) {
-                        pcre_free_substring(str_ptr);
+                    const char *pcre2_str_ptr = NULL;
+                    ret = pcre2_substring_get_bynumber(pe->parse_regex.match, x + 1,
+                            (PCRE2_UCHAR8 **)&pcre2_str_ptr, &capture_len);
+                    if (unlikely(ret != 0)) {
+                        pcre2_substring_free((PCRE2_UCHAR8 *)pcre2_str_ptr);
                         continue;
                     }
+                    /* store max 64k. Errors are ignored */
+                    capture_len = (capture_len < 0xffff) ? (uint16_t)capture_len : 0xffff;
+                    uint8_t *str_ptr = SCMalloc(capture_len);
+                    if (unlikely(str_ptr == NULL)) {
+                        pcre2_substring_free((PCRE2_UCHAR8 *)pcre2_str_ptr);
+                        continue;
+                    }
+                    memcpy(str_ptr, pcre2_str_ptr, capture_len);
+                    pcre2_substring_free((PCRE2_UCHAR8 *)pcre2_str_ptr);
 
                     SCLogDebug("data %p/%u, type %u id %u p %p",
                             str_ptr, ret, pe->captypes[x], pe->capids[x], p);
 
                     if (pe->captypes[x] == VAR_TYPE_PKT_VAR_KV) {
                         /* get the value, as first capture is the key */
-                        const char *str_ptr2 = NULL;
-                        int ret2 = pcre_get_substring((char *)ptr, ov, MAX_SUBSTRINGS, x+2, &str_ptr2);
-                        if (unlikely(ret2 == 0)) {
-                            pcre_free_substring(str_ptr);
-                            pcre_free_substring(str_ptr2);
+                        const char *pcre2_str_ptr2 = NULL;
+                        /* key length is limited to 256 chars */
+                        uint16_t key_len = (capture_len < 0xff) ? (uint16_t)capture_len : 0xff;
+                        int ret2 = pcre2_substring_get_bynumber(pe->parse_regex.match, x + 2,
+                                (PCRE2_UCHAR8 **)&pcre2_str_ptr2, &capture_len);
+
+                        if (unlikely(ret2 != 0)) {
+                            SCFree(str_ptr);
+                            pcre2_substring_free((PCRE2_UCHAR8 *)pcre2_str_ptr2);
                             break;
                         }
-                        /* key length is limited to 256 chars */
-                        uint16_t key_len = (ret < 0xff) ? (uint16_t)ret : 0xff;
-                        capture_len = (ret2 < 0xffff) ? (uint16_t)ret2 : 0xffff;
+                        capture_len = (capture_len < 0xffff) ? (uint16_t)capture_len : 0xffff;
+                        uint8_t *str_ptr2 = SCMalloc(capture_len);
+                        if (unlikely(str_ptr2 == NULL)) {
+                            pcre2_substring_free((PCRE2_UCHAR8 *)pcre2_str_ptr);
+                            continue;
+                        }
+                        memcpy(str_ptr2, pcre2_str_ptr2, capture_len);
+                        pcre2_substring_free((PCRE2_UCHAR8 *)pcre2_str_ptr2);
 
                         (void)DetectVarStoreMatchKeyValue(det_ctx,
                                 (uint8_t *)str_ptr, key_len,
@@ -270,15 +272,11 @@ int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
                                 DETECT_VAR_TYPE_PKT_POSTMATCH);
 
                     } else if (pe->captypes[x] == VAR_TYPE_PKT_VAR) {
-                        /* store max 64k. Errors are ignored */
-                        capture_len = (ret < 0xffff) ? (uint16_t)ret : 0xffff;
                         (void)DetectVarStoreMatch(det_ctx, pe->capids[x],
                                 (uint8_t *)str_ptr, capture_len,
                                 DETECT_VAR_TYPE_PKT_POSTMATCH);
 
                     } else if (pe->captypes[x] == VAR_TYPE_FLOW_VAR && f != NULL) {
-                        /* store max 64k. Errors are ignored */
-                        capture_len = (ret < 0xffff) ? (uint16_t)ret : 0xffff;
                         (void)DetectVarStoreMatch(det_ctx, pe->capids[x],
                                 (uint8_t *)str_ptr, capture_len,
                                 DETECT_VAR_TYPE_FLOW_POSTMATCH);
@@ -286,6 +284,7 @@ int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
                 }
             }
 
+            PCRE2_SIZE *ov = pcre2_get_ovector_pointer(pe->parse_regex.match);
             /* update offset for pcre RELATIVE */
             det_ctx->buffer_offset = (ptr + ov[1]) - payload;
             det_ctx->pcre_match_start_offset = (ptr + ov[0] + 1) - payload;
@@ -346,9 +345,8 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx,
         const char *regexstr, int *sm_list, char *capture_names,
         size_t capture_names_size, bool negate, AppProto *alproto)
 {
-    int ec;
-    const char *eb;
-    int eo;
+    int en;
+    PCRE2_SIZE eo2;
     int opts = 0;
     DetectPcreData *pd = NULL;
     char *op = NULL;
@@ -436,27 +434,27 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx,
 
             switch (*op) {
                 case 'A':
-                    opts |= PCRE_ANCHORED;
+                    opts |= PCRE2_ANCHORED;
                     break;
                 case 'E':
-                    opts |= PCRE_DOLLAR_ENDONLY;
+                    opts |= PCRE2_DOLLAR_ENDONLY;
                     break;
                 case 'G':
-                    opts |= PCRE_UNGREEDY;
+                    opts |= PCRE2_UNGREEDY;
                     break;
 
                 case 'i':
-                    opts |= PCRE_CASELESS;
+                    opts |= PCRE2_CASELESS;
                     pd->flags |= DETECT_PCRE_CASELESS;
                     break;
                 case 'm':
-                    opts |= PCRE_MULTILINE;
+                    opts |= PCRE2_MULTILINE;
                     break;
                 case 's':
-                    opts |= PCRE_DOTALL;
+                    opts |= PCRE2_DOTALL;
                     break;
                 case 'x':
-                    opts |= PCRE_EXTENDED;
+                    opts |= PCRE2_EXTENDED;
                     break;
 
                 case 'O':
@@ -627,70 +625,57 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx,
      * PCRE will let us know.
      */
     if (capture_names == NULL || strlen(capture_names) == 0)
-        opts |= PCRE_NO_AUTO_CAPTURE;
+        opts |= PCRE2_NO_AUTO_CAPTURE;
 
-    pd->parse_regex.regex = pcre_compile2(re, opts, &ec, &eb, &eo, NULL);
-    if (pd->parse_regex.regex == NULL && ec == 15) { // reference to non-existent subpattern
-        opts &= ~PCRE_NO_AUTO_CAPTURE;
-        pd->parse_regex.regex = pcre_compile(re, opts, &eb, &eo, NULL);
+    pd->parse_regex.regex =
+            pcre2_compile((PCRE2_SPTR8)re, PCRE2_ZERO_TERMINATED, opts, &en, &eo2, NULL);
+    if (pd->parse_regex.regex == NULL && en == 115) { // reference to non-existent subpattern
+        opts &= ~PCRE2_NO_AUTO_CAPTURE;
+        pd->parse_regex.regex =
+                pcre2_compile((PCRE2_SPTR8)re, PCRE2_ZERO_TERMINATED, opts, &en, &eo2, NULL);
     }
-
     if (pd->parse_regex.regex == NULL)  {
-        SCLogError(SC_ERR_PCRE_COMPILE, "pcre compile of \"%s\" failed "
-                "at offset %" PRId32 ": %s", regexstr, eo, eb);
+        PCRE2_UCHAR errbuffer[256];
+        pcre2_get_error_message(en, errbuffer, sizeof(errbuffer));
+        SCLogError(SC_ERR_PCRE_COMPILE,
+                "pcre2 compile of \"%s\" failed at "
+                "offset %d: %s",
+                regexstr, (int)eo2, errbuffer);
         goto error;
     }
 
-    int options = 0;
-#ifdef PCRE_HAVE_JIT
-    if (pcre_use_jit)
-        options |= PCRE_STUDY_JIT_COMPILE;
-#endif
-    pd->parse_regex.study = pcre_study(pd->parse_regex.regex, options, &eb);
-    if(eb != NULL)  {
-        SCLogError(SC_ERR_PCRE_STUDY, "pcre study failed : %s", eb);
+#ifdef PCRE2_HAVE_JIT
+    if (pcre2_use_jit) {
+        ret = pcre2_jit_compile(pd->parse_regex.regex, PCRE2_JIT_COMPLETE);
+        if (ret != 0) {
+            /* warning, so we won't print the sig after this. Adding
+             * file and line to the message so the admin can figure
+             * out what sig this is about */
+            SCLogDebug("PCRE2 JIT compiler does not support: %s. "
+                       "Falling back to regular PCRE2 handling (%s:%d)",
+                    regexstr, de_ctx->rule_file, de_ctx->rule_line);
+        }
+    }
+#endif /*PCRE2_HAVE_JIT*/
+
+    pd->parse_regex.context = pcre2_match_context_create(NULL);
+    if (pd->parse_regex.context == NULL) {
+        SCLogError(SC_ERR_PCRE_COMPILE, "pcre2 could not create match context");
         goto error;
     }
+    pd->parse_regex.match = pcre2_match_data_create_from_pattern(pd->parse_regex.regex, NULL);
 
-#ifdef PCRE_HAVE_JIT
-    int jit = 0;
-    ret = pcre_fullinfo(pd->parse_regex.regex, pd->parse_regex.study, PCRE_INFO_JIT, &jit);
-    if (ret != 0 || jit != 1) {
-        /* warning, so we won't print the sig after this. Adding
-         * file and line to the message so the admin can figure
-         * out what sig this is about */
-        SCLogDebug("PCRE JIT compiler does not support: %s. "
-                "Falling back to regular PCRE handling (%s:%d)",
-                regexstr, de_ctx->rule_file, de_ctx->rule_line);
-    }
-
-#endif /*PCRE_HAVE_JIT*/
-
-    if (pd->parse_regex.study == NULL)
-        pd->parse_regex.study = (pcre_extra *) SCCalloc(1,sizeof(pcre_extra));
-
-    if (pd->parse_regex.study) {
-        if(pd->flags & DETECT_PCRE_MATCH_LIMIT) {
-            if(pcre_match_limit >= -1)    {
-                pd->parse_regex.study->match_limit = pcre_match_limit;
-                pd->parse_regex.study->flags |= PCRE_EXTRA_MATCH_LIMIT;
-            }
-#ifndef NO_PCRE_MATCH_RLIMIT
-            if(pcre_match_limit_recursion >= -1)    {
-                pd->parse_regex.study->match_limit_recursion = pcre_match_limit_recursion;
-                pd->parse_regex.study->flags |= PCRE_EXTRA_MATCH_LIMIT_RECURSION;
-            }
-#endif /* NO_PCRE_MATCH_RLIMIT */
-        } else {
-            pd->parse_regex.study->match_limit = SC_MATCH_LIMIT_DEFAULT;
-            pd->parse_regex.study->flags |= PCRE_EXTRA_MATCH_LIMIT;
-#ifndef NO_PCRE_MATCH_RLIMIT
-            pd->parse_regex.study->match_limit_recursion = SC_MATCH_LIMIT_RECURSION_DEFAULT;
-            pd->parse_regex.study->flags |= PCRE_EXTRA_MATCH_LIMIT_RECURSION;
-#endif /* NO_PCRE_MATCH_RLIMIT */
+    if (pd->flags & DETECT_PCRE_MATCH_LIMIT) {
+        if (pcre_match_limit >= -1) {
+            pcre2_set_match_limit(pd->parse_regex.context, pcre_match_limit);
+        }
+        if (pcre_match_limit_recursion >= -1) {
+            // pcre2_set_depth_limit unsupported on ubuntu 16.04
+            pcre2_set_recursion_limit(pd->parse_regex.context, pcre_match_limit_recursion);
         }
     } else {
-        goto error;
+        pcre2_set_match_limit(pd->parse_regex.context, SC_MATCH_LIMIT_DEFAULT);
+        pcre2_set_recursion_limit(pd->parse_regex.context, PCRE_EXTRA_MATCH_LIMIT_RECURSION);
     }
     return pd;
 
@@ -717,7 +702,7 @@ static int DetectPcreParseCapture(const char *regexstr, DetectEngineCtx *de_ctx,
 
     SCLogDebug("regexstr %s, pd %p", regexstr, pd);
 
-    ret = pcre_fullinfo(pd->parse_regex.regex, pd->parse_regex.study, PCRE_INFO_CAPTURECOUNT, &capture_cnt);
+    ret = pcre2_pattern_info(pd->parse_regex.regex, PCRE2_INFO_CAPTURECOUNT, &capture_cnt);
     SCLogDebug("ret %d capture_cnt %d", ret, capture_cnt);
     if (ret == 0 && capture_cnt && strlen(capture_names) > 0)
     {
@@ -835,27 +820,6 @@ error:
     return -1;
 }
 
-#ifdef PCRE_HAVE_JIT_EXEC
-static void *DetectPcreThreadInit(void *data /*@unused@*/)
-{
-    pcre_jit_stack *jit_stack = pcre_jit_stack_alloc(PCRE_JIT_MIN_STACK, PCRE_JIT_MAX_STACK);
-
-    if (jit_stack == NULL) {
-        SCLogWarning(SC_WARN_PCRE_JITSTACK, "Unable to allocate PCRE JIT stack; will continue without JIT stack");
-    }
-    SCLogDebug("Using jit_stack %p", jit_stack);
-
-    return (void *)jit_stack;
-}
-
-static void DetectPcreThreadFree(void *ctx)
-{
-    SCLogDebug("freeing jit_stack %p", ctx);
-    if (ctx != NULL)
-        pcre_jit_stack_free((pcre_jit_stack *)ctx);
-}
-
-#endif
 static int DetectPcreSetup (DetectEngineCtx *de_ctx, Signature *s, const char *regexstr)
 {
     SCEnter();
@@ -872,14 +836,6 @@ static int DetectPcreSetup (DetectEngineCtx *de_ctx, Signature *s, const char *r
         goto error;
     if (DetectPcreParseCapture(regexstr, de_ctx, pd, capture_names) < 0)
         goto error;
-
-#ifdef PCRE_HAVE_JIT_EXEC
-    /* Deliberately silent on failures. Not having a context id means
-     * JIT will be bypassed */
-    pd->thread_ctx_jit_stack_id = DetectRegisterThreadCtxFuncs(de_ctx, "pcre",
-            DetectPcreThreadInit, (void *)pd,
-            DetectPcreThreadFree, 1);
-#endif
 
     int sm_list = -1;
     if (s->init_data->list != DETECT_SM_LIST_NOTSET) {
@@ -967,7 +923,9 @@ static void DetectPcreFree(DetectEngineCtx *de_ctx, void *ptr)
         return;
 
     DetectPcreData *pd = (DetectPcreData *)ptr;
-    DetectParseFreeRegex(&pd->parse_regex);
+    pcre2_code_free(pd->parse_regex.regex);
+    pcre2_match_context_free(pd->parse_regex.context);
+    pcre2_match_data_free(pd->parse_regex.match);
     SCFree(pd);
 
     return;

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -410,7 +410,7 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx,
 
     res = pcre2_substring_copy_bynumber(parse_regex->match, 1, (PCRE2_UCHAR8 *)re, &slen);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         return NULL;
     }
 
@@ -419,7 +419,7 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx,
         res = pcre2_substring_copy_bynumber(
                 parse_regex->match, 2, (PCRE2_UCHAR8 *)op_str, &copylen);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             return NULL;
         }
         op = op_str;
@@ -781,14 +781,14 @@ static int DetectPcreParseCapture(const char *regexstr, DetectEngineCtx *de_ctx,
         res = pcre2_substring_copy_bynumber(
                 parse_capture_regex->match, 1, (PCRE2_UCHAR8 *)type_str, &copylen);
         if (res != 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;
         }
         cap_buffer_len = strlen(regexstr) + 1;
         res = pcre2_substring_copy_bynumber(
                 parse_capture_regex->match, 2, (PCRE2_UCHAR8 *)capture_str, &cap_buffer_len);
         if (res != 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;
         }
         if (strlen(capture_str) == 0 || strlen(type_str) == 0) {

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -71,8 +71,8 @@
 static int pcre_match_limit = 0;
 static int pcre_match_limit_recursion = 0;
 
-static DetectParseRegex2 *parse_regex;
-static DetectParseRegex2 *parse_capture_regex;
+static DetectParseRegex *parse_regex;
+static DetectParseRegex *parse_capture_regex;
 
 #ifdef PCRE2_HAVE_JIT
 static int pcre2_use_jit = 1;
@@ -931,7 +931,7 @@ static void DetectPcreFree(DetectEngineCtx *de_ctx, void *ptr)
         return;
 
     DetectPcreData *pd = (DetectPcreData *)ptr;
-    DetectParseFreePCRE2(&pd->parse_regex);
+    DetectParseFreeRegex(&pd->parse_regex);
     SCFree(pd);
 
     return;

--- a/src/detect-pcre.h
+++ b/src/detect-pcre.h
@@ -38,7 +38,7 @@
 
 typedef struct DetectPcreData_ {
     /* pcre options */
-    DetectParseRegex2 parse_regex;
+    DetectParseRegex parse_regex;
 
     int opts;
     uint16_t flags;

--- a/src/detect-pcre.h
+++ b/src/detect-pcre.h
@@ -36,14 +36,19 @@
 
 #define DETECT_PCRE_CAPTURE_MAX         8
 
+#include <pcre2.h>
+
+typedef struct DetectParseRegex2 {
+    pcre2_code *regex;
+    pcre2_match_context *context;
+    pcre2_match_data *match;
+    // struct DetectParseRegex2 *next;
+} DetectParseRegex2;
+
 typedef struct DetectPcreData_ {
     /* pcre options */
-    DetectParseRegex parse_regex;
+    DetectParseRegex2 parse_regex;
 
-#ifdef PCRE_HAVE_JIT_EXEC
-    /* JIT stack thread context id */
-    int thread_ctx_jit_stack_id;
-#endif
     int opts;
     uint16_t flags;
     uint8_t idx;

--- a/src/detect-pcre.h
+++ b/src/detect-pcre.h
@@ -36,15 +36,6 @@
 
 #define DETECT_PCRE_CAPTURE_MAX         8
 
-#include <pcre2.h>
-
-typedef struct DetectParseRegex2 {
-    pcre2_code *regex;
-    pcre2_match_context *context;
-    pcre2_match_data *match;
-    // struct DetectParseRegex2 *next;
-} DetectParseRegex2;
-
 typedef struct DetectPcreData_ {
     /* pcre options */
     DetectParseRegex2 parse_regex;

--- a/src/detect-priority.c
+++ b/src/detect-priority.c
@@ -63,18 +63,19 @@ static int DetectPrioritySetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     char copy_str[128] = "";
 
     int ret = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, 30);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret < 0) {
         SCLogError(SC_ERR_PCRE_MATCH, "Invalid Priority in Signature "
                      "- %s", rawstr);
         return -1;
     }
 
-    ret = pcre_copy_substring((char *)rawstr, ov, 30, 1, copy_str, sizeof(copy_str));
+    pcre2len = sizeof(copy_str);
+    ret = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)copy_str, &pcre2len);
     if (ret < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         return -1;
     }
 

--- a/src/detect-reference.c
+++ b/src/detect-reference.c
@@ -96,11 +96,11 @@ static DetectReference *DetectReferenceParse(const char *rawstr, DetectEngineCtx
     SCEnter();
 
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     char key[REFERENCE_SYSTEM_NAME_MAX] = "";
     char content[REFERENCE_CONTENT_NAME_MAX] = "";
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret < 2) {
         SCLogError(SC_ERR_INVALID_SIGNATURE, "Unable to parse \"reference\" "
                    "keyword argument - \"%s\".   Invalid argument.", rawstr);
@@ -112,15 +112,17 @@ static DetectReference *DetectReferenceParse(const char *rawstr, DetectEngineCtx
         return NULL;
     }
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 1, key, sizeof(key));
+    pcre2len = sizeof(key);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)key, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 2, content, sizeof(content));
+    pcre2len = sizeof(content);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 *)content, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 

--- a/src/detect-rfb-secresult.c
+++ b/src/detect-rfb-secresult.c
@@ -170,11 +170,9 @@ static DetectRfbSecresultData *DetectRfbSecresultParse (const char *rawstr)
 {
     int i;
     DetectRfbSecresultData *de = NULL;
-#define MAX_SUBSTRINGS 30
     int ret = 0, found = 0;
-    int ov[MAX_SUBSTRINGS];
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret < 1) {
         SCLogError(SC_ERR_PCRE_MATCH, "pcre_exec parse error, ret %" PRId32 ", string %s", ret, rawstr);
         goto error;

--- a/src/detect-rfb-sectype.c
+++ b/src/detect-rfb-sectype.c
@@ -174,7 +174,7 @@ static DetectRfbSectypeData *DetectRfbSectypeParse (const char *rawstr)
     }
 
     pcre2len = sizeof(mode);
-    res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
+    res = SC_Pcre2SubstringCopy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;

--- a/src/detect-rfb-sectype.c
+++ b/src/detect-rfb-sectype.c
@@ -174,7 +174,7 @@ static DetectRfbSectypeData *DetectRfbSectypeParse (const char *rawstr)
     }
 
     pcre2len = sizeof(mode);
-    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
+    res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;

--- a/src/detect-rfb-sectype.c
+++ b/src/detect-rfb-sectype.c
@@ -162,29 +162,28 @@ static int DetectRfbSectypeMatch (DetectEngineThreadCtx *det_ctx,
 static DetectRfbSectypeData *DetectRfbSectypeParse (const char *rawstr)
 {
     DetectRfbSectypeData *dd = NULL;
-#define MAX_SUBSTRINGS 30
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     char mode[2] = "";
     char value1[20] = "";
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret < 3 || ret > 5) {
         SCLogError(SC_ERR_PCRE_MATCH, "Parse error %s", rawstr);
         goto error;
     }
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 1, mode,
-                              sizeof(mode));
+    pcre2len = sizeof(mode);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 2, value1,
-                              sizeof(value1));
+    pcre2len = sizeof(value1);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 *)value1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 

--- a/src/detect-snmp-pdu_type.c
+++ b/src/detect-snmp-pdu_type.c
@@ -135,20 +135,20 @@ static DetectSNMPPduTypeData *DetectSNMPPduTypeParse (const char *rawstr)
 {
     DetectSNMPPduTypeData *dd = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     char value1[20] = "";
     char *endptr = NULL;
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret != 2) {
         SCLogError(SC_ERR_PCRE_MATCH, "Parse error %s", rawstr);
         goto error;
     }
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 1, value1,
-                              sizeof(value1));
+    pcre2len = sizeof(value1);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)value1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 

--- a/src/detect-snmp-version.c
+++ b/src/detect-snmp-version.c
@@ -188,7 +188,7 @@ static DetectSNMPVersionData *DetectSNMPVersionParse (const char *rawstr)
     }
 
     pcre2len = sizeof(mode);
-    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
+    res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;

--- a/src/detect-snmp-version.c
+++ b/src/detect-snmp-version.c
@@ -176,28 +176,28 @@ static DetectSNMPVersionData *DetectSNMPVersionParse (const char *rawstr)
 {
     DetectSNMPVersionData *dd = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     char mode[2] = "";
     char value1[20] = "";
     char *endptr = NULL;
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret < 3 || ret > 5) {
         SCLogError(SC_ERR_PCRE_MATCH, "Parse error %s", rawstr);
         goto error;
     }
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 1, mode,
-                              sizeof(mode));
+    pcre2len = sizeof(mode);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 2, value1,
-                              sizeof(value1));
+    pcre2len = sizeof(value1);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 *)value1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 

--- a/src/detect-snmp-version.c
+++ b/src/detect-snmp-version.c
@@ -188,7 +188,7 @@ static DetectSNMPVersionData *DetectSNMPVersionParse (const char *rawstr)
     }
 
     pcre2len = sizeof(mode);
-    res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
+    res = SC_Pcre2SubstringCopy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;

--- a/src/detect-ssl-state.c
+++ b/src/detect-ssl-state.c
@@ -154,31 +154,32 @@ static int DetectSslStateMatch(DetectEngineThreadCtx *det_ctx,
 static DetectSslStateData *DetectSslStateParse(const char *arg)
 {
     int ret = 0, res = 0;
-    int ov1[MAX_SUBSTRINGS];
-    int ov2[MAX_SUBSTRINGS];
+    size_t pcre2len;
     char str1[64];
     char str2[64];
     int negate = 0;
     uint32_t flags = 0, mask = 0;
     DetectSslStateData *ssd = NULL;
 
-    ret = DetectParsePcreExec(&parse_regex1, arg, 0, 0, ov1, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex1, arg, 0, 0);
     if (ret < 1) {
         SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid arg \"%s\" supplied to "
                    "ssl_state keyword.", arg);
         goto error;
     }
 
-    res = pcre_copy_substring((char *)arg, ov1, MAX_SUBSTRINGS, 1, str1, sizeof(str1));
+    pcre2len = sizeof(str1);
+    res = pcre2_substring_copy_bynumber(parse_regex1.match, 1, (PCRE2_UCHAR8 *)str1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
     negate = !strcmp("!", str1);
 
-    res = pcre_copy_substring((char *)arg, ov1, MAX_SUBSTRINGS, 2, str1, sizeof(str1));
+    pcre2len = sizeof(str1);
+    res = pcre2_substring_copy_bynumber(parse_regex1.match, 2, (PCRE2_UCHAR8 *)str1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 
@@ -208,29 +209,32 @@ static DetectSslStateData *DetectSslStateParse(const char *arg)
         goto error;
     }
 
-    res = pcre_copy_substring((char *)arg, ov1, MAX_SUBSTRINGS, 3, str1, sizeof(str1));
+    pcre2len = sizeof(str1);
+    res = pcre2_substring_copy_bynumber(parse_regex1.match, 3, (PCRE2_UCHAR8 *)str1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
     while (res > 0) {
-        ret = DetectParsePcreExec(&parse_regex2, str1,  0, 0, ov2, MAX_SUBSTRINGS);
+        ret = DetectParsePcreExec(&parse_regex2, str1, 0, 0);
         if (ret < 1) {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid arg \"%s\" supplied to "
                        "ssl_state keyword.", arg);
             goto error;
         }
 
-        res = pcre_copy_substring((char *)str1, ov2, MAX_SUBSTRINGS, 1, str2, sizeof(str2));
+        pcre2len = sizeof(str2);
+        res = pcre2_substring_copy_bynumber(parse_regex2.match, 1, (PCRE2_UCHAR8 *)str2, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;
         }
         negate = !strcmp("!", str2);
 
-        res = pcre_copy_substring((char *)str1, ov2, MAX_SUBSTRINGS, 2, str2, sizeof(str2));
+        pcre2len = sizeof(str2);
+        res = pcre2_substring_copy_bynumber(parse_regex2.match, 2, (PCRE2_UCHAR8 *)str2, &pcre2len);
         if (res <= 0) {
-            SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;
         }
         if (strcmp("client_hello", str2) == 0) {
@@ -259,9 +263,10 @@ static DetectSslStateData *DetectSslStateParse(const char *arg)
             goto error;
         }
 
-        res = pcre_copy_substring((char *)str1, ov2, MAX_SUBSTRINGS, 3, str2, sizeof(str2));
+        pcre2len = sizeof(str2);
+        res = pcre2_substring_copy_bynumber(parse_regex2.match, 3, (PCRE2_UCHAR8 *)str2, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;
         }
 

--- a/src/detect-ssl-state.c
+++ b/src/detect-ssl-state.c
@@ -215,7 +215,7 @@ static DetectSslStateData *DetectSslStateParse(const char *arg)
         SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
-    while (res > 0) {
+    while (res >= 0 && strlen(str1) > 0) {
         ret = DetectParsePcreExec(&parse_regex2, str1, 0, 0);
         if (ret < 1) {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid arg \"%s\" supplied to "
@@ -233,7 +233,7 @@ static DetectSslStateData *DetectSslStateParse(const char *arg)
 
         pcre2len = sizeof(str2);
         res = pcre2_substring_copy_bynumber(parse_regex2.match, 2, (PCRE2_UCHAR8 *)str2, &pcre2len);
-        if (res <= 0) {
+        if (res < 0) {
             SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;
         }

--- a/src/detect-target.c
+++ b/src/detect-target.c
@@ -82,19 +82,19 @@ void DetectTargetRegister(void) {
 static int DetectTargetParse(Signature *s, const char *targetstr)
 {
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     char value[10];
 
-    ret = DetectParsePcreExec(&parse_regex, targetstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, targetstr, 0, 0);
     if (ret < 1) {
         SCLogError(SC_ERR_PCRE_MATCH, "pcre_exec parse error, ret %" PRId32 ", string %s", ret, targetstr);
         return -1;
     }
 
-    res = pcre_copy_substring(targetstr, ov, MAX_SUBSTRINGS, 1,
-                              value, sizeof(value));
+    pcre2len = sizeof(value);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)value, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         return -1;
     }
 

--- a/src/detect-tcp-flags.c
+++ b/src/detect-tcp-flags.c
@@ -189,7 +189,7 @@ static DetectFlagsData *DetectFlagsParse (const char *rawstr)
     }
 
     pcre2len = sizeof(arg1);
-    res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)arg1, &pcre2len);
+    res = SC_Pcre2SubstringCopy(parse_regex.match, 1, (PCRE2_UCHAR8 *)arg1, &pcre2len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         SCReturnPtr(NULL, "DetectFlagsData");
@@ -204,7 +204,7 @@ static DetectFlagsData *DetectFlagsParse (const char *rawstr)
     }
     if (ret >= 3) {
         pcre2len = sizeof(arg3);
-        res = SC_pcre2_substring_copy(parse_regex.match, 3, (PCRE2_UCHAR8 *)arg3, &pcre2len);
+        res = SC_Pcre2SubstringCopy(parse_regex.match, 3, (PCRE2_UCHAR8 *)arg3, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             SCReturnPtr(NULL, "DetectFlagsData");

--- a/src/detect-tcp-flags.c
+++ b/src/detect-tcp-flags.c
@@ -189,7 +189,7 @@ static DetectFlagsData *DetectFlagsParse (const char *rawstr)
     }
 
     pcre2len = sizeof(arg1);
-    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)arg1, &pcre2len);
+    res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)arg1, &pcre2len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         SCReturnPtr(NULL, "DetectFlagsData");
@@ -204,7 +204,7 @@ static DetectFlagsData *DetectFlagsParse (const char *rawstr)
     }
     if (ret >= 3) {
         pcre2len = sizeof(arg3);
-        res = pcre2_substring_copy_bynumber(parse_regex.match, 3, (PCRE2_UCHAR8 *)arg3, &pcre2len);
+        res = SC_pcre2_substring_copy(parse_regex.match, 3, (PCRE2_UCHAR8 *)arg3, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             SCReturnPtr(NULL, "DetectFlagsData");

--- a/src/detect-tcp-flags.c
+++ b/src/detect-tcp-flags.c
@@ -174,36 +174,39 @@ static DetectFlagsData *DetectFlagsParse (const char *rawstr)
     SCEnter();
 
     int ret = 0, found = 0, ignore = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     char *ptr;
 
     char arg1[16] = "";
     char arg2[16] = "";
     char arg3[16] = "";
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     SCLogDebug("input '%s', pcre said %d", rawstr, ret);
     if (ret < 3) {
         SCLogError(SC_ERR_PCRE_MATCH, "pcre match failed");
         SCReturnPtr(NULL, "DetectFlagsData");
     }
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 1, arg1, sizeof(arg1));
+    pcre2len = sizeof(arg1);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)arg1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         SCReturnPtr(NULL, "DetectFlagsData");
     }
     if (ret >= 2) {
-        res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 2, arg2, sizeof(arg2));
+        pcre2len = sizeof(arg2);
+        res = pcre2_substring_copy_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 *)arg2, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             SCReturnPtr(NULL, "DetectFlagsData");
         }
     }
     if (ret >= 3) {
-        res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 3, arg3, sizeof(arg3));
+        pcre2len = sizeof(arg3);
+        res = pcre2_substring_copy_bynumber(parse_regex.match, 3, (PCRE2_UCHAR8 *)arg3, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             SCReturnPtr(NULL, "DetectFlagsData");
         }
     }

--- a/src/detect-tcp-window.c
+++ b/src/detect-tcp-window.c
@@ -127,8 +127,7 @@ static DetectWindowData *DetectWindowParse(DetectEngineCtx *de_ctx, const char *
     if (ret > 1) {
         char copy_str[128] = "";
         pcre2len = sizeof(copy_str);
-        res = pcre2_substring_copy_bynumber(
-                parse_regex.match, 1, (PCRE2_UCHAR8 *)copy_str, &pcre2len);
+        res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)copy_str, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;

--- a/src/detect-tcp-window.c
+++ b/src/detect-tcp-window.c
@@ -127,7 +127,7 @@ static DetectWindowData *DetectWindowParse(DetectEngineCtx *de_ctx, const char *
     if (ret > 1) {
         char copy_str[128] = "";
         pcre2len = sizeof(copy_str);
-        res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)copy_str, &pcre2len);
+        res = SC_Pcre2SubstringCopy(parse_regex.match, 1, (PCRE2_UCHAR8 *)copy_str, &pcre2len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;

--- a/src/detect-tcp-window.c
+++ b/src/detect-tcp-window.c
@@ -112,9 +112,9 @@ static DetectWindowData *DetectWindowParse(DetectEngineCtx *de_ctx, const char *
 {
     DetectWindowData *wd = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
 
-    ret = DetectParsePcreExec(&parse_regex, windowstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, windowstr, 0, 0);
     if (ret < 1 || ret > 3) {
         SCLogError(SC_ERR_PCRE_MATCH, "pcre_exec parse error, ret %" PRId32 ", string %s", ret, windowstr);
         goto error;
@@ -126,10 +126,11 @@ static DetectWindowData *DetectWindowParse(DetectEngineCtx *de_ctx, const char *
 
     if (ret > 1) {
         char copy_str[128] = "";
-        res = pcre_copy_substring((char *)windowstr, ov, MAX_SUBSTRINGS, 1,
-                copy_str, sizeof(copy_str));
+        pcre2len = sizeof(copy_str);
+        res = pcre2_substring_copy_bynumber(
+                parse_regex.match, 1, (PCRE2_UCHAR8 *)copy_str, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;
         }
 
@@ -140,10 +141,11 @@ static DetectWindowData *DetectWindowParse(DetectEngineCtx *de_ctx, const char *
             wd->negated = 0;
 
         if (ret > 2) {
-            res = pcre_copy_substring((char *)windowstr, ov, MAX_SUBSTRINGS, 2,
-                    copy_str, sizeof(copy_str));
+            pcre2len = sizeof(copy_str);
+            res = pcre2_substring_copy_bynumber(
+                    parse_regex.match, 2, (PCRE2_UCHAR8 *)copy_str, &pcre2len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                 goto error;
             }
 

--- a/src/detect-tcpmss.c
+++ b/src/detect-tcpmss.c
@@ -128,36 +128,38 @@ static DetectTcpmssData *DetectTcpmssParse (const char *tcpmssstr)
     char *arg2 = NULL;
     char *arg3 = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2_len;
 
-    ret = DetectParsePcreExec(&parse_regex, tcpmssstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, tcpmssstr, 0, 0);
     if (ret < 2 || ret > 4) {
         SCLogError(SC_ERR_PCRE_MATCH, "parse error, ret %" PRId32 "", ret);
         goto error;
     }
     const char *str_ptr;
 
-    res = pcre_get_substring((char *) tcpmssstr, ov, MAX_SUBSTRINGS, 1, &str_ptr);
+    res = pcre2_substring_get_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;
     }
     arg1 = (char *) str_ptr;
     SCLogDebug("Arg1 \"%s\"", arg1);
 
     if (ret >= 3) {
-        res = pcre_get_substring((char *) tcpmssstr, ov, MAX_SUBSTRINGS, 2, &str_ptr);
+        res = pcre2_substring_get_bynumber(
+                parse_regex.match, 2, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;
         }
         arg2 = (char *) str_ptr;
         SCLogDebug("Arg2 \"%s\"", arg2);
 
         if (ret >= 4) {
-            res = pcre_get_substring((char *) tcpmssstr, ov, MAX_SUBSTRINGS, 3, &str_ptr);
+            res = pcre2_substring_get_bynumber(
+                    parse_regex.match, 3, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
                 goto error;
             }
             arg3 = (char *) str_ptr;
@@ -250,20 +252,20 @@ static DetectTcpmssData *DetectTcpmssParse (const char *tcpmssstr)
         }
     }
 
-    SCFree(arg1);
-    SCFree(arg2);
-    SCFree(arg3);
+    pcre2_substring_free((PCRE2_UCHAR8 *)arg1);
+    pcre2_substring_free((PCRE2_UCHAR8 *)arg2);
+    pcre2_substring_free((PCRE2_UCHAR8 *)arg3);
     return tcpmssd;
 
 error:
     if (tcpmssd)
         SCFree(tcpmssd);
     if (arg1)
-        SCFree(arg1);
+        pcre2_substring_free((PCRE2_UCHAR8 *)arg1);
     if (arg2)
-        SCFree(arg2);
+        pcre2_substring_free((PCRE2_UCHAR8 *)arg2);
     if (arg3)
-        SCFree(arg3);
+        pcre2_substring_free((PCRE2_UCHAR8 *)arg3);
     return NULL;
 }
 

--- a/src/detect-template.c
+++ b/src/detect-template.c
@@ -129,24 +129,26 @@ static DetectTemplateData *DetectTemplateParse (const char *templatestr)
 {
     char arg1[4] = "";
     char arg2[4] = "";
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
 
-    int ret = DetectParsePcreExec(&parse_regex, templatestr, 0, 0, ov, MAX_SUBSTRINGS);
+    int ret = DetectParsePcreExec(&parse_regex, templatestr, 0, 0);
     if (ret != 3) {
         SCLogError(SC_ERR_PCRE_MATCH, "parse error, ret %" PRId32 "", ret);
         return NULL;
     }
 
-    ret = pcre_copy_substring((char *) templatestr, ov, MAX_SUBSTRINGS, 1, arg1, sizeof(arg1));
+    pcre2len = sizeof(arg1);
+    ret = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)arg1, &pcre2len);
     if (ret < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         return NULL;
     }
     SCLogDebug("Arg1 \"%s\"", arg1);
 
-    ret = pcre_copy_substring((char *) templatestr, ov, MAX_SUBSTRINGS, 2, arg2, sizeof(arg2));
+    pcre2len = sizeof(arg2);
+    ret = pcre2_substring_copy_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 *)arg2, &pcre2len);
     if (ret < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         return NULL;
     }
     SCLogDebug("Arg2 \"%s\"", arg2);

--- a/src/detect-template2.c
+++ b/src/detect-template2.c
@@ -135,36 +135,38 @@ static DetectTemplate2Data *DetectTemplate2Parse (const char *template2str)
     char *arg2 = NULL;
     char *arg3 = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2_len;
 
-    ret = DetectParsePcreExec(&parse_regex, template2str, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, template2str, 0, 0);
     if (ret < 2 || ret > 4) {
         SCLogError(SC_ERR_PCRE_MATCH, "parse error, ret %" PRId32 "", ret);
         goto error;
     }
     const char *str_ptr;
 
-    res = pcre_get_substring((char *) template2str, ov, MAX_SUBSTRINGS, 1, &str_ptr);
+    res = pcre2_substring_get_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;
     }
     arg1 = (char *) str_ptr;
     SCLogDebug("Arg1 \"%s\"", arg1);
 
     if (ret >= 3) {
-        res = pcre_get_substring((char *) template2str, ov, MAX_SUBSTRINGS, 2, &str_ptr);
+        res = pcre2_substring_get_bynumber(
+                parse_regex.match, 2, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;
         }
         arg2 = (char *) str_ptr;
         SCLogDebug("Arg2 \"%s\"", arg2);
 
         if (ret >= 4) {
-            res = pcre_get_substring((char *) template2str, ov, MAX_SUBSTRINGS, 3, &str_ptr);
+            res = pcre2_substring_get_bynumber(
+                    parse_regex.match, 3, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
                 goto error;
             }
             arg3 = (char *) str_ptr;
@@ -263,20 +265,20 @@ static DetectTemplate2Data *DetectTemplate2Parse (const char *template2str)
         }
     }
 
-    SCFree(arg1);
-    SCFree(arg2);
-    SCFree(arg3);
+    pcre2_substring_free((PCRE2_UCHAR8 *)arg1);
+    pcre2_substring_free((PCRE2_UCHAR8 *)arg2);
+    pcre2_substring_free((PCRE2_UCHAR8 *)arg3);
     return template2d;
 
 error:
     if (template2d)
         SCFree(template2d);
     if (arg1)
-        SCFree(arg1);
+        pcre2_substring_free((PCRE2_UCHAR8 *)arg1);
     if (arg2)
-        SCFree(arg2);
+        pcre2_substring_free((PCRE2_UCHAR8 *)arg2);
     if (arg3)
-        SCFree(arg3);
+        pcre2_substring_free((PCRE2_UCHAR8 *)arg3);
     return NULL;
 }
 

--- a/src/detect-tls-cert-validity.c
+++ b/src/detect-tls-cert-validity.c
@@ -319,7 +319,7 @@ static DetectTlsValidityData *DetectTlsValidityParse (const char *rawstr)
     }
 
     pcre2len = sizeof(mode);
-    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
+    res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;

--- a/src/detect-tls-cert-validity.c
+++ b/src/detect-tls-cert-validity.c
@@ -306,49 +306,49 @@ static DetectTlsValidityData *DetectTlsValidityParse (const char *rawstr)
 {
     DetectTlsValidityData *dd = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     char mode[2] = "";
     char value1[20] = "";
     char value2[20] = "";
     char range[3] = "";
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret < 3 || ret > 5) {
         SCLogError(SC_ERR_PCRE_MATCH, "Parse error %s", rawstr);
         goto error;
     }
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 1, mode,
-                              sizeof(mode));
+    pcre2len = sizeof(mode);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
     SCLogDebug("mode \"%s\"", mode);
 
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 2, value1,
-                              sizeof(value1));
+    pcre2len = sizeof(value1);
+    res = pcre2_substring_copy_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 *)value1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
     SCLogDebug("value1 \"%s\"", value1);
 
     if (ret > 3) {
-        res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 3,
-                                  range, sizeof(range));
+        pcre2len = sizeof(range);
+        res = pcre2_substring_copy_bynumber(parse_regex.match, 3, (PCRE2_UCHAR8 *)range, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;
         }
         SCLogDebug("range \"%s\"", range);
 
         if (ret > 4) {
-            res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 4,
-                                      value2, sizeof(value2));
+            pcre2len = sizeof(value2);
+            res = pcre2_substring_copy_bynumber(
+                    parse_regex.match, 4, (PCRE2_UCHAR8 *)value2, &pcre2len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING,
-                           "pcre_copy_substring failed");
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                 goto error;
             }
             SCLogDebug("value2 \"%s\"", value2);

--- a/src/detect-tls-cert-validity.c
+++ b/src/detect-tls-cert-validity.c
@@ -319,7 +319,7 @@ static DetectTlsValidityData *DetectTlsValidityParse (const char *rawstr)
     }
 
     pcre2len = sizeof(mode);
-    res = SC_pcre2_substring_copy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
+    res = SC_Pcre2SubstringCopy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;

--- a/src/detect-tls-version.c
+++ b/src/detect-tls-version.c
@@ -152,9 +152,9 @@ static DetectTlsVersionData *DetectTlsVersionParse (DetectEngineCtx *de_ctx, con
     uint16_t temp;
     DetectTlsVersionData *tls = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
 
-    ret = DetectParsePcreExec(&parse_regex, str, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, str, 0, 0);
     if (ret < 1 || ret > 3) {
         SCLogError(SC_ERR_PCRE_MATCH, "invalid tls.version option");
         goto error;
@@ -163,9 +163,11 @@ static DetectTlsVersionData *DetectTlsVersionParse (DetectEngineCtx *de_ctx, con
     if (ret > 1) {
         char ver_ptr[64];
         char *tmp_str;
-        res = pcre_copy_substring((char *)str, ov, MAX_SUBSTRINGS, 1, ver_ptr, sizeof(ver_ptr));
+        pcre2len = sizeof(ver_ptr);
+        res = pcre2_substring_copy_bynumber(
+                parse_regex.match, 1, (PCRE2_UCHAR8 *)ver_ptr, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             goto error;
         }
 

--- a/src/detect-tls.c
+++ b/src/detect-tls.c
@@ -223,13 +223,13 @@ static DetectTlsData *DetectTlsSubjectParse (DetectEngineCtx *de_ctx, const char
 {
     DetectTlsData *tls = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2_len;
     const char *str_ptr;
     char *orig = NULL;
     char *tmp_str;
     uint32_t flag = 0;
 
-    ret = DetectParsePcreExec(&subject_parse_regex, str, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&subject_parse_regex, str, 0, 0);
     if (ret != 2) {
         SCLogError(SC_ERR_PCRE_MATCH, "invalid tls.subject option");
         goto error;
@@ -238,9 +238,10 @@ static DetectTlsData *DetectTlsSubjectParse (DetectEngineCtx *de_ctx, const char
     if (negate)
         flag = DETECT_CONTENT_NEGATED;
 
-    res = pcre_get_substring((char *)str, ov, MAX_SUBSTRINGS, 1, &str_ptr);
+    res = pcre2_substring_get_bynumber(
+            subject_parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;
     }
 
@@ -255,7 +256,7 @@ static DetectTlsData *DetectTlsSubjectParse (DetectEngineCtx *de_ctx, const char
     if (unlikely(orig == NULL)) {
         goto error;
     }
-    pcre_free_substring(str_ptr);
+    pcre2_substring_free((PCRE2_UCHAR *)str_ptr);
 
     tmp_str=orig;
 
@@ -414,13 +415,13 @@ static DetectTlsData *DetectTlsIssuerDNParse(DetectEngineCtx *de_ctx, const char
 {
     DetectTlsData *tls = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2_len;
     const char *str_ptr;
     char *orig = NULL;
     char *tmp_str;
     uint32_t flag = 0;
 
-    ret = DetectParsePcreExec(&issuerdn_parse_regex, str, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&issuerdn_parse_regex, str, 0, 0);
     if (ret != 2) {
         SCLogError(SC_ERR_PCRE_MATCH, "invalid tls.issuerdn option");
         goto error;
@@ -429,9 +430,10 @@ static DetectTlsData *DetectTlsIssuerDNParse(DetectEngineCtx *de_ctx, const char
     if (negate)
         flag = DETECT_CONTENT_NEGATED;
 
-    res = pcre_get_substring((char *)str, ov, MAX_SUBSTRINGS, 1, &str_ptr);
+    res = pcre2_substring_get_bynumber(
+            issuerdn_parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;
     }
 
@@ -446,7 +448,7 @@ static DetectTlsData *DetectTlsIssuerDNParse(DetectEngineCtx *de_ctx, const char
     if (unlikely(orig == NULL)) {
         goto error;
     }
-    pcre_free_substring(str_ptr);
+    pcre2_substring_free((PCRE2_UCHAR *)str_ptr);
 
     tmp_str=orig;
 
@@ -546,13 +548,13 @@ static DetectTlsData *DetectTlsFingerprintParse (DetectEngineCtx *de_ctx, const 
 {
     DetectTlsData *tls = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2_len;
     const char *str_ptr;
     char *orig;
     char *tmp_str;
     uint32_t flag = 0;
 
-    ret = DetectParsePcreExec(&fingerprint_parse_regex, str, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&fingerprint_parse_regex, str, 0, 0);
     if (ret != 2) {
         SCLogError(SC_ERR_PCRE_MATCH, "invalid tls.fingerprint option");
         goto error;
@@ -561,9 +563,10 @@ static DetectTlsData *DetectTlsFingerprintParse (DetectEngineCtx *de_ctx, const 
     if (negate)
         flag = DETECT_CONTENT_NEGATED;
 
-    res = pcre_get_substring((char *)str, ov, MAX_SUBSTRINGS, 1, &str_ptr);
+    res = pcre2_substring_get_bynumber(
+            fingerprint_parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;
     }
 
@@ -578,7 +581,7 @@ static DetectTlsData *DetectTlsFingerprintParse (DetectEngineCtx *de_ctx, const 
     if (unlikely(orig == NULL)) {
         goto error;
     }
-    pcre_free_substring(str_ptr);
+    pcre2_substring_free((PCRE2_UCHAR *)str_ptr);
 
     tmp_str=orig;
 

--- a/src/detect-tos.c
+++ b/src/detect-tos.c
@@ -112,9 +112,9 @@ static DetectTosData *DetectTosParse(const char *arg, bool negate)
 {
     DetectTosData *tosd = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
 
-    ret = DetectParsePcreExec(&parse_regex, arg, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, arg, 0, 0);
     if (ret != 2) {
         SCLogError(SC_ERR_PCRE_MATCH, "invalid tos option - %s. "
                    "The tos option value must be in the range "
@@ -124,10 +124,11 @@ static DetectTosData *DetectTosParse(const char *arg, bool negate)
 
     /* For TOS value */
     char tosbytes_str[64] = "";
-    res = pcre_copy_substring((char *)arg, ov, MAX_SUBSTRINGS, 1,
-                             tosbytes_str, sizeof(tosbytes_str));
+    pcre2len = sizeof(tosbytes_str);
+    res = pcre2_substring_copy_bynumber(
+            parse_regex.match, 1, (PCRE2_UCHAR8 *)tosbytes_str, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 

--- a/src/detect-transform-pcrexform.c
+++ b/src/detect-transform-pcrexform.c
@@ -25,7 +25,6 @@
 
 #include "suricata-common.h"
 
-#include <pcre2.h>
 #include "detect.h"
 #include "detect-engine.h"
 #include "detect-parse.h"

--- a/src/detect-ttl.c
+++ b/src/detect-ttl.c
@@ -133,36 +133,40 @@ static int DetectTtlMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
 
 static DetectTtlData *DetectTtlParse (const char *ttlstr)
 {
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     char arg1[6] = "";
     char arg2[6] = "";
     char arg3[6] = "";
 
-    int ret = DetectParsePcreExec(&parse_regex, ttlstr, 0, 0, ov, MAX_SUBSTRINGS);
+    int ret = DetectParsePcreExec(&parse_regex, ttlstr, 0, 0);
     if (ret < 2 || ret > 4) {
         SCLogError(SC_ERR_PCRE_MATCH, "parse error, ret %" PRId32 "", ret);
         return NULL;
     }
 
-    int res = pcre_copy_substring((char *) ttlstr, ov, MAX_SUBSTRINGS, 1, arg1, sizeof(arg1));
+    pcre2len = sizeof(arg1);
+    int res = pcre2_substring_copy_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 *)arg1, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         return NULL;
     }
     SCLogDebug("arg1 \"%s\"", arg1);
 
     if (ret >= 3) {
-        res = pcre_copy_substring((char *) ttlstr, ov, MAX_SUBSTRINGS, 2, arg2, sizeof(arg2));
+        pcre2len = sizeof(arg2);
+        res = pcre2_substring_copy_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 *)arg2, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             return NULL;
         }
         SCLogDebug("arg2 \"%s\"", arg2);
 
         if (ret >= 4) {
-            res = pcre_copy_substring((char *) ttlstr, ov, MAX_SUBSTRINGS, 3, arg3, sizeof(arg3));
+            pcre2len = sizeof(arg3);
+            res = pcre2_substring_copy_bynumber(
+                    parse_regex.match, 3, (PCRE2_UCHAR8 *)arg3, &pcre2len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                 return NULL;
             }
             SCLogDebug("arg3 \"%s\"", arg3);

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -108,7 +108,7 @@ static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
 
     SCLogDebug("ret %d", ret);
 
-    res = SC_pcre2_substring_get(parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+    res = SC_Pcre2SubstringGet(parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;
@@ -125,7 +125,7 @@ static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
     SCLogDebug("Arg2 \"%s\"", arg2);
 
     if (ret > 3) {
-        res = SC_pcre2_substring_get(parse_regex.match, 3, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+        res = SC_Pcre2SubstringGet(parse_regex.match, 3, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;
@@ -134,8 +134,7 @@ static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
         SCLogDebug("Arg3 \"%s\"", arg3);
 
         if (ret > 4) {
-            res = SC_pcre2_substring_get(
-                    parse_regex.match, 4, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+            res = SC_Pcre2SubstringGet(parse_regex.match, 4, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
             if (res < 0) {
                 SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
                 goto error;

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -108,7 +108,7 @@ static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
 
     SCLogDebug("ret %d", ret);
 
-    res = pcre2_substring_get_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+    res = SC_pcre2_substring_get(parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;
@@ -125,8 +125,7 @@ static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
     SCLogDebug("Arg2 \"%s\"", arg2);
 
     if (ret > 3) {
-        res = pcre2_substring_get_bynumber(
-                parse_regex.match, 3, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
+        res = SC_pcre2_substring_get(parse_regex.match, 3, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;
@@ -135,7 +134,7 @@ static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
         SCLogDebug("Arg3 \"%s\"", arg3);
 
         if (ret > 4) {
-            res = pcre2_substring_get_bynumber(
+            res = SC_pcre2_substring_get(
                     parse_regex.match, 4, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
             if (res < 0) {
                 SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
@@ -161,15 +160,15 @@ static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
         goto error;
     memset(urilend, 0, sizeof(DetectUrilenData));
 
-    if (arg1[0] == '<')
+    if (arg1 != NULL && arg1[0] == '<')
         urilend->mode = DETECT_URILEN_LT;
-    else if (arg1[0] == '>')
+    else if (arg1 != NULL && arg1[0] == '>')
         urilend->mode = DETECT_URILEN_GT;
     else
         urilend->mode = DETECT_URILEN_EQ;
 
     if (arg3 != NULL && strcmp("<>", arg3) == 0) {
-        if (strlen(arg1) != 0) {
+        if (arg1 != NULL && strlen(arg1) != 0) {
             SCLogError(SC_ERR_INVALID_ARGUMENT,"Range specified but mode also set");
             goto error;
         }

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -97,9 +97,9 @@ static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
     char *arg4 = NULL;
     char *arg5 = NULL;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2_len;
 
-    ret = DetectParsePcreExec(&parse_regex, urilenstr, 0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, urilenstr, 0, 0);
     if (ret < 3 || ret > 6) {
         SCLogError(SC_ERR_PCRE_PARSE, "urilen option pcre parse error: \"%s\"", urilenstr);
         goto error;
@@ -108,44 +108,47 @@ static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
 
     SCLogDebug("ret %d", ret);
 
-    res = pcre_get_substring((char *)urilenstr, ov, MAX_SUBSTRINGS, 1, &str_ptr);
+    res = pcre2_substring_get_bynumber(parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;
     }
     arg1 = (char *) str_ptr;
     SCLogDebug("Arg1 \"%s\"", arg1);
 
-    res = pcre_get_substring((char *)urilenstr, ov, MAX_SUBSTRINGS, 2, &str_ptr);
+    res = pcre2_substring_get_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;
     }
     arg2 = (char *) str_ptr;
     SCLogDebug("Arg2 \"%s\"", arg2);
 
     if (ret > 3) {
-        res = pcre_get_substring((char *)urilenstr, ov, MAX_SUBSTRINGS, 3, &str_ptr);
+        res = pcre2_substring_get_bynumber(
+                parse_regex.match, 3, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
             goto error;
         }
         arg3 = (char *) str_ptr;
         SCLogDebug("Arg3 \"%s\"", arg3);
 
         if (ret > 4) {
-            res = pcre_get_substring((char *)urilenstr, ov, MAX_SUBSTRINGS, 4, &str_ptr);
+            res = pcre2_substring_get_bynumber(
+                    parse_regex.match, 4, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
                 goto error;
             }
             arg4 = (char *) str_ptr;
             SCLogDebug("Arg4 \"%s\"", arg4);
         }
         if (ret > 5) {
-            res = pcre_get_substring((char *)urilenstr, ov, MAX_SUBSTRINGS, 5, &str_ptr);
+            res = pcre2_substring_get_bynumber(
+                    parse_regex.match, 5, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
                 goto error;
             }
             arg5 = (char *) str_ptr;
@@ -206,29 +209,29 @@ static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
         }
     }
 
-    pcre_free_substring(arg1);
-    pcre_free_substring(arg2);
+    pcre2_substring_free((PCRE2_UCHAR *)arg1);
+    pcre2_substring_free((PCRE2_UCHAR *)arg2);
     if (arg3 != NULL)
-        pcre_free_substring(arg3);
+        pcre2_substring_free((PCRE2_UCHAR *)arg3);
     if (arg4 != NULL)
-        pcre_free_substring(arg4);
+        pcre2_substring_free((PCRE2_UCHAR *)arg4);
     if (arg5 != NULL)
-        pcre_free_substring(arg5);
+        pcre2_substring_free((PCRE2_UCHAR *)arg5);
     return urilend;
 
 error:
     if (urilend)
         SCFree(urilend);
     if (arg1 != NULL)
-        pcre_free_substring(arg1);
+        pcre2_substring_free((PCRE2_UCHAR *)arg1);
     if (arg2 != NULL)
-        pcre_free_substring(arg2);
+        pcre2_substring_free((PCRE2_UCHAR *)arg2);
     if (arg3 != NULL)
-        pcre_free_substring(arg3);
+        pcre2_substring_free((PCRE2_UCHAR *)arg3);
     if (arg4 != NULL)
-        pcre_free_substring(arg4);
+        pcre2_substring_free((PCRE2_UCHAR *)arg4);
     if (arg5 != NULL)
-        pcre_free_substring(arg5);
+        pcre2_substring_free((PCRE2_UCHAR *)arg5);
     return NULL;
 }
 

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -197,34 +197,40 @@ static int DetectXbitParse(DetectEngineCtx *de_ctx,
     uint8_t fb_cmd = 0;
     uint8_t hb_dir = 0;
     int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
+    size_t pcre2len;
     char fb_cmd_str[16] = "", fb_name[256] = "";
     char hb_dir_str[16] = "";
     enum VarTypes var_type = VAR_TYPE_NOT_SET;
     uint32_t expire = DETECT_XBITS_EXPIRE_DEFAULT;
 
-    ret = DetectParsePcreExec(&parse_regex, rawstr,  0, 0, ov, MAX_SUBSTRINGS);
+    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret != 2 && ret != 3 && ret != 4 && ret != 5) {
         SCLogError(SC_ERR_PCRE_MATCH, "\"%s\" is not a valid setting for xbits.", rawstr);
         return -1;
     }
     SCLogDebug("ret %d, %s", ret, rawstr);
-    res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 1, fb_cmd_str, sizeof(fb_cmd_str));
+    pcre2len = sizeof(fb_cmd_str);
+    res = pcre2_substring_copy_bynumber(
+            parse_regex.match, 1, (PCRE2_UCHAR8 *)fb_cmd_str, &pcre2len);
     if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         return -1;
     }
 
     if (ret >= 3) {
-        res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 2, fb_name, sizeof(fb_name));
+        pcre2len = sizeof(fb_name);
+        res = pcre2_substring_copy_bynumber(
+                parse_regex.match, 2, (PCRE2_UCHAR8 *)fb_name, &pcre2len);
         if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
             return -1;
         }
         if (ret >= 4) {
-            res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 3, hb_dir_str, sizeof(hb_dir_str));
+            pcre2len = sizeof(hb_dir_str);
+            res = pcre2_substring_copy_bynumber(
+                    parse_regex.match, 3, (PCRE2_UCHAR8 *)hb_dir_str, &pcre2len);
             if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                 return -1;
             }
             SCLogDebug("hb_dir_str %s", hb_dir_str);
@@ -246,9 +252,11 @@ static int DetectXbitParse(DetectEngineCtx *de_ctx,
 
             if (ret >= 5) {
                 char expire_str[16] = "";
-                res = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 4, expire_str, sizeof(expire_str));
+                pcre2len = sizeof(expire_str);
+                res = pcre2_substring_copy_bynumber(
+                        parse_regex.match, 4, (PCRE2_UCHAR8 *)expire_str, &pcre2len);
                 if (res < 0) {
-                    SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
+                    SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                     return -1;
                 }
                 SCLogDebug("expire_str %s", expire_str);

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -58,7 +58,6 @@
 #include "util-misc.h"
 #include "util-cpu.h"
 #include "util-atomic.h"
-#include <pcre2.h>
 
 #include "source-pcap.h"
 

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -58,6 +58,7 @@
 #include "util-misc.h"
 #include "util-cpu.h"
 #include "util-atomic.h"
+#include <pcre2.h>
 
 #include "source-pcap.h"
 
@@ -186,8 +187,8 @@ typedef struct PcapLogThreadData_ {
 
 /* Pattern for extracting timestamp from pcap log files. */
 static const char timestamp_pattern[] = ".*?(\\d+)(\\.(\\d+))?";
-static pcre *pcre_timestamp_code = NULL;
-static pcre_extra *pcre_timestamp_extra = NULL;
+static pcre2_code *pcre_timestamp_code = NULL;
+static pcre2_match_data *pcre_timestamp_match = NULL;
 
 /* global pcap data for when we're using multi mode. At exit we'll
  * merge counters into this one and then report counters. */
@@ -717,13 +718,11 @@ static PcapLogData *PcapLogDataCopy(const PcapLogData *pl)
 static int PcapLogGetTimeOfFile(const char *filename, uint64_t *secs,
     uint32_t *usecs)
 {
-    int pcre_ovecsize = 4 * 3;
-    int pcre_ovec[pcre_ovecsize];
     char buf[PATH_MAX];
+    size_t copylen;
 
-    int n = pcre_exec(pcre_timestamp_code, pcre_timestamp_extra,
-        filename, strlen(filename), 0, 0, pcre_ovec,
-        pcre_ovecsize);
+    int n = pcre2_match(pcre_timestamp_code, (PCRE2_SPTR8)filename, strlen(filename), 0, 0,
+            pcre_timestamp_match, NULL);
     if (n != 2 && n != 4) {
         /* No match. */
         return 0;
@@ -731,8 +730,9 @@ static int PcapLogGetTimeOfFile(const char *filename, uint64_t *secs,
 
     if (n >= 2) {
         /* Extract seconds. */
-        if (pcre_copy_substring(filename, pcre_ovec, pcre_ovecsize,
-                1, buf, sizeof(buf)) < 0) {
+        copylen = sizeof(buf);
+        if (pcre2_substring_copy_bynumber(pcre_timestamp_match, 1, (PCRE2_UCHAR8 *)buf, &copylen) <
+                0) {
             return 0;
         }
         if (StringParseUint64(secs, 10, 0, buf) < 0) {
@@ -741,8 +741,9 @@ static int PcapLogGetTimeOfFile(const char *filename, uint64_t *secs,
     }
     if (n == 4) {
         /* Extract microseconds. */
-        if (pcre_copy_substring(filename, pcre_ovec, pcre_ovecsize,
-                3, buf, sizeof(buf)) < 0) {
+        copylen = sizeof(buf);
+        if (pcre2_substring_copy_bynumber(pcre_timestamp_match, 3, (PCRE2_UCHAR8 *)buf, &copylen) <
+                0) {
             return 0;
         }
         if (StringParseUint32(usecs, 10, 0, buf) < 0) {
@@ -1172,8 +1173,8 @@ error:
 static OutputInitResult PcapLogInitCtx(ConfNode *conf)
 {
     OutputInitResult result = { NULL, false };
-    const char *pcre_errbuf;
-    int pcre_erroffset;
+    int en;
+    PCRE2_SIZE eo = 0;
 
     PcapLogData *pl = SCMalloc(sizeof(PcapLogData));
     if (unlikely(pl == NULL)) {
@@ -1200,17 +1201,15 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
     SCMutexInit(&pl->plog_lock, NULL);
 
     /* Initialize PCREs. */
-    pcre_timestamp_code = pcre_compile(timestamp_pattern, 0, &pcre_errbuf,
-        &pcre_erroffset, NULL);
+    pcre_timestamp_code =
+            pcre2_compile((PCRE2_SPTR8)timestamp_pattern, PCRE2_ZERO_TERMINATED, 0, &en, &eo, NULL);
     if (pcre_timestamp_code == NULL) {
-        FatalError(SC_ERR_PCRE_COMPILE,
-            "Failed to compile \"%s\" at offset %"PRIu32": %s",
-            timestamp_pattern, pcre_erroffset, pcre_errbuf);
+        PCRE2_UCHAR errbuffer[256];
+        pcre2_get_error_message(en, errbuffer, sizeof(errbuffer));
+        FatalError(SC_ERR_PCRE_COMPILE, "Failed to compile \"%s\" at offset %d: %s",
+                timestamp_pattern, (int)eo, errbuffer);
     }
-    pcre_timestamp_extra = pcre_study(pcre_timestamp_code, 0, &pcre_errbuf);
-    if (pcre_errbuf != NULL) {
-        FatalError(SC_ERR_PCRE_STUDY, "Fail to study pcre: %s", pcre_errbuf);
-    }
+    pcre_timestamp_match = pcre2_match_data_create_from_pattern(pcre_timestamp_code, NULL);
 
     /* conf params */
 
@@ -1523,6 +1522,10 @@ static void PcapLogFileDeInitCtx(OutputCtx *output_ctx)
     }
     PcapLogDataFree(pl);
     SCFree(output_ctx);
+
+    pcre2_code_free(pcre_timestamp_code);
+    pcre2_match_data_free(pcre_timestamp_match);
+
     return;
 }
 

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -138,7 +138,6 @@ typedef unsigned short u_short
 typedef unsigned char u_char
 #endif
 
-#include <pcre.h>
 #include <pcre2.h>
 
 #ifdef HAVE_SYSLOG_H
@@ -363,10 +362,6 @@ typedef unsigned char u_char
 
 #if !defined(__LITTLE_ENDIAN) && !defined(__BIG_ENDIAN)
     #error "byte order: can't figure out big or little"
-#endif
-
-#ifndef HAVE_PCRE_FREE_STUDY
-#define pcre_free_study pcre_free
 #endif
 
 #ifndef MIN

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -139,6 +139,7 @@ typedef unsigned char u_char
 #endif
 
 #include <pcre.h>
+#include <pcre2.h>
 
 #ifdef HAVE_SYSLOG_H
 #include <syslog.h>

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -694,7 +694,7 @@ static void PrintBuildInfo(void)
 #ifdef HAVE_HTP_URI_NORMALIZE_HOOK
     strlcat(features, "HAVE_HTP_URI_NORMALIZE_HOOK ", sizeof(features));
 #endif
-#ifdef PCRE_HAVE_JIT
+#ifdef PCRE2_HAVE_JIT
     strlcat(features, "PCRE_JIT ", sizeof(features));
 #endif
     /* For compatibility, just say we have HAVE_NSS. */

--- a/src/tests/detect-transform-pcrexform.c
+++ b/src/tests/detect-transform-pcrexform.c
@@ -58,10 +58,29 @@ static int DetectTransformPcrexformParseTest02 (void)
 }
 
 /**
+ * \test signature with a pcrexform value without substring capture
+ */
+
+static int DetectTransformPcrexformParseTest03(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    Signature *sig = DetectEngineAppendSig(de_ctx,
+            "alert http any any -> any any (msg:\"HTTP with pcrexform\"; http.request_line; "
+            "pcrexform:\"No-match\"; content:\"/no-match.jpg\"; sid:1;)");
+    FAIL_IF_NOT_NULL(sig);
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+/**
  * \brief this function registers unit tests for DetectTransformPcrexform
  */
 void DetectTransformPcrexformRegisterTests(void)
 {
     UtRegisterTest("DetectTransformPcrexformParseTest01", DetectTransformPcrexformParseTest01);
     UtRegisterTest("DetectTransformPcrexformParseTest02", DetectTransformPcrexformParseTest02);
+    UtRegisterTest("DetectTransformPcrexformParseTest03", DetectTransformPcrexformParseTest03);
 }

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -35,6 +35,7 @@
 #include "util-debug.h"
 #include "util-fmemopen.h"
 #include "util-byte.h"
+#include <pcre2.h>
 
 /* Regex to parse the classtype argument from a Signature.  The first substring
  * holds the classtype name, the second substring holds the classtype the
@@ -48,8 +49,8 @@
 #define SC_CLASS_CONF_DEF_CONF_FILEPATH CONFIG_DIR "/classification.config"
 #endif
 
-static pcre *regex = NULL;
-static pcre_extra *regex_study = NULL;
+static pcre2_code *regex = NULL;
+static pcre2_match_data *regex_match = NULL;
 
 uint32_t SCClassConfClasstypeHashFunc(HashTable *ht, void *data, uint16_t datalen);
 char SCClassConfClasstypeHashCompareFunc(void *data1, uint16_t datalen1,
@@ -63,36 +64,34 @@ static void SCClassConfDeAllocClasstype(SCClassConfClasstype *ct);
 
 void SCClassConfInit(void)
 {
-    const char *eb = NULL;
-    int eo;
+    int en;
+    PCRE2_SIZE eo;
     int opts = 0;
 
-    regex = pcre_compile(DETECT_CLASSCONFIG_REGEX, opts, &eb, &eo, NULL);
+    regex = pcre2_compile(
+            (PCRE2_SPTR8)DETECT_CLASSCONFIG_REGEX, PCRE2_ZERO_TERMINATED, opts, &en, &eo, NULL);
     if (regex == NULL) {
-        SCLogDebug("Compile of \"%s\" failed at offset %" PRId32 ": %s",
-                   DETECT_CLASSCONFIG_REGEX, eo, eb);
+        PCRE2_UCHAR errbuffer[256];
+        pcre2_get_error_message(en, errbuffer, sizeof(errbuffer));
+        SCLogWarning(SC_ERR_PCRE_COMPILE,
+                "pcre2 compile of \"%s\" failed at "
+                "offset %d: %s",
+                DETECT_CLASSCONFIG_REGEX, (int)eo, errbuffer);
         return;
     }
-
-    regex_study = pcre_study(regex, 0, &eb);
-    if (eb != NULL) {
-        pcre_free(regex);
-        regex = NULL;
-        SCLogDebug("pcre study failed: %s", eb);
-        return;
-    }
+    regex_match = pcre2_match_data_create_from_pattern(regex, NULL);
     return;
 }
 
 void SCClassConfDeinit(void)
 {
     if (regex != NULL) {
-        pcre_free(regex);
+        pcre2_code_free(regex);
         regex = NULL;
     }
-    if (regex_study != NULL) {
-        pcre_free(regex_study);
-        regex_study = NULL;
+    if (regex_match != NULL) {
+        pcre2_match_data_free(regex_match);
+        regex_match = NULL;
     }
 }
 
@@ -251,35 +250,36 @@ int SCClassConfAddClasstype(DetectEngineCtx *de_ctx, char *rawstr, uint16_t inde
     SCClassConfClasstype *ct_new = NULL;
     SCClassConfClasstype *ct_lookup = NULL;
 
-#define MAX_SUBSTRINGS 30
     int ret = 0;
-    int ov[MAX_SUBSTRINGS];
 
-    ret = pcre_exec(regex, regex_study, rawstr, strlen(rawstr), 0, 0, ov, 30);
+    ret = pcre2_match(regex, (PCRE2_SPTR8)rawstr, strlen(rawstr), 0, 0, regex_match, NULL);
     if (ret < 0) {
         SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid Classtype in "
                    "classification.config file");
         goto error;
     }
 
+    size_t copylen = sizeof(ct_name);
     /* retrieve the classtype name */
-    ret = pcre_copy_substring((char *)rawstr, ov, 30, 1, ct_name, sizeof(ct_name));
+    ret = pcre2_substring_copy_bynumber(regex_match, 1, (PCRE2_UCHAR8 *)ct_name, &copylen);
     if (ret < 0) {
-        SCLogInfo("pcre_copy_substring() failed");
+        SCLogInfo("pcre2_substring_copy_bynumber() failed");
         goto error;
     }
 
     /* retrieve the classtype description */
-    ret = pcre_copy_substring((char *)rawstr, ov, 30, 2, ct_desc, sizeof(ct_desc));
+    copylen = sizeof(ct_desc);
+    ret = pcre2_substring_copy_bynumber(regex_match, 2, (PCRE2_UCHAR8 *)ct_desc, &copylen);
     if (ret < 0) {
-        SCLogInfo("pcre_copy_substring() failed");
+        SCLogInfo("pcre2_substring_copy_bynumber() failed");
         goto error;
     }
 
     /* retrieve the classtype priority */
-    ret = pcre_copy_substring((char *)rawstr, ov, 30, 3, ct_priority_str, sizeof(ct_priority_str));
+    copylen = sizeof(ct_priority_str);
+    ret = pcre2_substring_copy_bynumber(regex_match, 3, (PCRE2_UCHAR8 *)ct_priority_str, &copylen);
     if (ret < 0) {
-        SCLogInfo("pcre_copy_substring() failed");
+        SCLogInfo("pcre2_substring_copy_bynumber() failed");
         goto error;
     }
     if (StringParseUint32(&ct_priority, 10, 0, (const char *)ct_priority_str) < 0) {

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -35,7 +35,6 @@
 #include "util-debug.h"
 #include "util-fmemopen.h"
 #include "util-byte.h"
-#include <pcre2.h>
 
 /* Regex to parse the classtype argument from a Signature.  The first substring
  * holds the classtype name, the second substring holds the classtype the

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -31,6 +31,7 @@
 #include "util-error.h"
 #include "util-debug-filters.h"
 #include "util-atomic.h"
+#include <pcre2.h>
 
 /**
  * \brief ENV vars that can be used to set the properties for the logging module
@@ -176,8 +177,8 @@ typedef struct SCLogConfig_ {
 
     char *op_filter;
     /* compiled pcre filter expression */
-    pcre *op_filter_regex;
-    pcre_extra *op_filter_regex_study;
+    pcre2_code *op_filter_regex;
+    pcre2_match_data *op_filter_regex_match;
 
     /* op ifaces used */
     SCLogOPIfaceCtx *op_ifaces;

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -31,7 +31,6 @@
 #include "util-error.h"
 #include "util-debug-filters.h"
 #include "util-atomic.h"
-#include <pcre2.h>
 
 /**
  * \brief ENV vars that can be used to set the properties for the logging module

--- a/src/util-host-info.c
+++ b/src/util-host-info.c
@@ -27,6 +27,7 @@
 #include "suricata-common.h"
 #include "util-host-info.h"
 #include "util-byte.h"
+#include <pcre2.h>
 
 #ifndef OS_WIN32
 #include <sys/utsname.h>
@@ -36,16 +37,14 @@
 int SCKernelVersionIsAtLeast(int major, int minor)
 {
     struct utsname kuname;
-    pcre *version_regex;
-    pcre_extra *version_regex_study;
-    const char *eb;
+    pcre2_code *version_regex;
+    pcre2_match_data *version_regex_match;
+    int en;
     int opts = 0;
-    int eo;
-#define MAX_SUBSTRINGS 3 * 6
-    int ov[MAX_SUBSTRINGS];
+    PCRE2_SIZE eo;
     int ret;
     int kmajor, kminor;
-    const char **list;
+    PCRE2_UCHAR **list;
 
     /* get local version */
     if (uname(&kuname) != 0) {
@@ -56,20 +55,21 @@ int SCKernelVersionIsAtLeast(int major, int minor)
 
     SCLogDebug("Kernel release is '%s'", kuname.release);
 
-    version_regex = pcre_compile(VERSION_REGEX, opts, &eb, &eo, NULL);
+    version_regex =
+            pcre2_compile((PCRE2_SPTR8)VERSION_REGEX, PCRE2_ZERO_TERMINATED, opts, &en, &eo, NULL);
     if (version_regex == NULL) {
-        SCLogError(SC_ERR_PCRE_COMPILE, "pcre compile of \"%s\" failed at offset %" PRId32 ": %s", VERSION_REGEX, eo, eb);
+        PCRE2_UCHAR errbuffer[256];
+        pcre2_get_error_message(en, errbuffer, sizeof(errbuffer));
+        SCLogError(SC_ERR_PCRE_COMPILE,
+                "pcre2 compile of \"%s\" failed at "
+                "offset %d: %s",
+                VERSION_REGEX, (int)eo, errbuffer);
         goto error;
     }
+    version_regex_match = pcre2_match_data_create_from_pattern(version_regex, NULL);
 
-    version_regex_study = pcre_study(version_regex, 0, &eb);
-    if (eb != NULL) {
-        SCLogError(SC_ERR_PCRE_STUDY, "pcre study failed: %s", eb);
-        goto error;
-    }
-
-    ret = pcre_exec(version_regex, version_regex_study, kuname.release,
-                    strlen(kuname.release), 0, 0, ov, MAX_SUBSTRINGS);
+    ret = pcre2_match(version_regex, (PCRE2_SPTR8)kuname.release, strlen(kuname.release), 0, 0,
+            version_regex_match, NULL);
 
     if (ret < 0) {
         SCLogError(SC_ERR_PCRE_MATCH, "Version did not cut");
@@ -81,7 +81,7 @@ int SCKernelVersionIsAtLeast(int major, int minor)
         goto error;
     }
 
-    pcre_get_substring_list(kuname.release, ov, ret, &list);
+    pcre2_substring_list_get(version_regex_match, &list, NULL);
 
     bool err = false;
     if (StringParseInt32(&kmajor, 10, 0, (const char *)list[1]) < 0) {
@@ -93,9 +93,9 @@ int SCKernelVersionIsAtLeast(int major, int minor)
         err = true;
     }
 
-    pcre_free_substring_list(list);
-    pcre_free_study(version_regex_study);
-    pcre_free(version_regex);
+    pcre2_substring_list_free((PCRE2_SPTR *)list);
+    pcre2_match_data_free(version_regex_match);
+    pcre2_code_free(version_regex);
 
     if (err)
         goto error;

--- a/src/util-host-info.c
+++ b/src/util-host-info.c
@@ -27,7 +27,6 @@
 #include "suricata-common.h"
 #include "util-host-info.h"
 #include "util-byte.h"
-#include <pcre2.h>
 
 #ifndef OS_WIN32
 #include <sys/utsname.h>

--- a/src/util-misc.c
+++ b/src/util-misc.c
@@ -27,7 +27,6 @@
 #include "util-debug.h"
 #include "util-unittest.h"
 #include "util-misc.h"
-#include <pcre2.h>
 
 #define PARSE_REGEX "^\\s*(\\d+(?:.\\d+)?)\\s*([a-zA-Z]{2})?\\s*$"
 static pcre2_code *parse_regex = NULL;

--- a/src/util-reference-config.c
+++ b/src/util-reference-config.c
@@ -25,7 +25,6 @@
 #include "detect.h"
 #include "detect-engine.h"
 #include "util-hash.h"
-#include <pcre2.h>
 
 #include "util-reference-config.h"
 #include "conf.h"

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -87,104 +87,108 @@ static FILE *g_ut_threshold_fp = NULL;
 #define THRESHOLD_CONF_DEF_CONF_FILEPATH CONFIG_DIR "/threshold.config"
 #endif
 
-static pcre *regex_base = NULL;
-static pcre_extra *regex_base_study = NULL;
+static pcre2_code *regex_base = NULL;
+static pcre2_match_data *regex_base_match = NULL;
 
-static pcre *regex_threshold = NULL;
-static pcre_extra *regex_threshold_study = NULL;
+static pcre2_code *regex_threshold = NULL;
+static pcre2_match_data *regex_threshold_match = NULL;
 
-static pcre *regex_rate = NULL;
-static pcre_extra *regex_rate_study = NULL;
+static pcre2_code *regex_rate = NULL;
+static pcre2_match_data *regex_rate_match = NULL;
 
-static pcre *regex_suppress = NULL;
-static pcre_extra *regex_suppress_study = NULL;
+static pcre2_code *regex_suppress = NULL;
+static pcre2_match_data *regex_suppress_match = NULL;
 
 static void SCThresholdConfDeInitContext(DetectEngineCtx *de_ctx, FILE *fd);
 
 void SCThresholdConfGlobalInit(void)
 {
-    const char *eb = NULL;
-    int eo;
+    int en;
+    PCRE2_SIZE eo;
     int opts = 0;
+    PCRE2_UCHAR errbuffer[256];
 
-    regex_base = pcre_compile(DETECT_BASE_REGEX, opts, &eb, &eo, NULL);
+    regex_base = pcre2_compile(
+            (PCRE2_SPTR8)DETECT_BASE_REGEX, PCRE2_ZERO_TERMINATED, opts, &en, &eo, NULL);
     if (regex_base == NULL) {
-        FatalError(SC_ERR_PCRE_COMPILE, "Compile of \"%s\" failed at offset %" PRId32 ": %s",DETECT_BASE_REGEX, eo, eb);
+        pcre2_get_error_message(en, errbuffer, sizeof(errbuffer));
+        FatalError(SC_ERR_PCRE_COMPILE,
+                "pcre2 compile of \"%s\" failed at "
+                "offset %d: %s",
+                DETECT_BASE_REGEX, (int)eo, errbuffer);
     }
+    regex_base_match = pcre2_match_data_create_from_pattern(regex_base, NULL);
 
-    regex_base_study = pcre_study(regex_base, 0, &eb);
-    if (eb != NULL) {
-        FatalError(SC_ERR_PCRE_STUDY, "pcre study failed: %s", eb);
-    }
-
-    regex_threshold = pcre_compile(DETECT_THRESHOLD_REGEX, opts, &eb, &eo, NULL);
+    regex_threshold = pcre2_compile(
+            (PCRE2_SPTR8)DETECT_THRESHOLD_REGEX, PCRE2_ZERO_TERMINATED, opts, &en, &eo, NULL);
     if (regex_threshold == NULL) {
-        FatalError(SC_ERR_PCRE_COMPILE, "Compile of \"%s\" failed at offset %" PRId32 ": %s",DETECT_THRESHOLD_REGEX, eo, eb);
+        pcre2_get_error_message(en, errbuffer, sizeof(errbuffer));
+        FatalError(SC_ERR_PCRE_COMPILE,
+                "pcre2 compile of \"%s\" failed at "
+                "offset %d: %s",
+                DETECT_THRESHOLD_REGEX, (int)eo, errbuffer);
     }
+    regex_threshold_match = pcre2_match_data_create_from_pattern(regex_threshold, NULL);
 
-    regex_threshold_study = pcre_study(regex_threshold, 0, &eb);
-    if (eb != NULL) {
-        FatalError(SC_ERR_PCRE_STUDY, "pcre study failed: %s", eb);
-    }
-
-    regex_rate = pcre_compile(DETECT_RATE_REGEX, opts, &eb, &eo, NULL);
+    regex_rate = pcre2_compile(
+            (PCRE2_SPTR8)DETECT_RATE_REGEX, PCRE2_ZERO_TERMINATED, opts, &en, &eo, NULL);
     if (regex_rate == NULL) {
-        FatalError(SC_ERR_PCRE_COMPILE, "Compile of \"%s\" failed at offset %" PRId32 ": %s",DETECT_RATE_REGEX, eo, eb);
+        pcre2_get_error_message(en, errbuffer, sizeof(errbuffer));
+        FatalError(SC_ERR_PCRE_COMPILE,
+                "pcre2 compile of \"%s\" failed at "
+                "offset %d: %s",
+                DETECT_RATE_REGEX, (int)eo, errbuffer);
     }
+    regex_rate_match = pcre2_match_data_create_from_pattern(regex_rate, NULL);
 
-    regex_rate_study = pcre_study(regex_rate, 0, &eb);
-    if (eb != NULL) {
-        FatalError(SC_ERR_PCRE_STUDY, "pcre study failed: %s", eb);
-    }
-
-    regex_suppress = pcre_compile(DETECT_SUPPRESS_REGEX, opts, &eb, &eo, NULL);
+    regex_suppress = pcre2_compile(
+            (PCRE2_SPTR8)DETECT_SUPPRESS_REGEX, PCRE2_ZERO_TERMINATED, opts, &en, &eo, NULL);
     if (regex_suppress == NULL) {
-        FatalError(SC_ERR_PCRE_COMPILE, "Compile of \"%s\" failed at offset %" PRId32 ": %s",DETECT_SUPPRESS_REGEX, eo, eb);
+        pcre2_get_error_message(en, errbuffer, sizeof(errbuffer));
+        FatalError(SC_ERR_PCRE_COMPILE,
+                "pcre2 compile of \"%s\" failed at "
+                "offset %d: %s",
+                DETECT_SUPPRESS_REGEX, (int)eo, errbuffer);
     }
-
-    regex_suppress_study = pcre_study(regex_suppress, 0, &eb);
-    if (eb != NULL) {
-        FatalError(SC_ERR_PCRE_STUDY, "pcre study failed: %s", eb);
-    }
-
+    regex_suppress_match = pcre2_match_data_create_from_pattern(regex_suppress, NULL);
 }
 
 void SCThresholdConfGlobalFree(void)
 {
     if (regex_base != NULL) {
-        pcre_free(regex_base);
+        pcre2_code_free(regex_base);
         regex_base = NULL;
     }
-    if (regex_base_study != NULL) {
-        pcre_free(regex_base_study);
-        regex_base_study = NULL;
+    if (regex_base_match != NULL) {
+        pcre2_match_data_free(regex_base_match);
+        regex_base_match = NULL;
     }
 
     if (regex_threshold != NULL) {
-        pcre_free(regex_threshold);
+        pcre2_code_free(regex_threshold);
         regex_threshold = NULL;
     }
-    if (regex_threshold_study != NULL) {
-        pcre_free(regex_threshold_study);
-        regex_threshold_study = NULL;
+    if (regex_threshold_match != NULL) {
+        pcre2_match_data_free(regex_threshold_match);
+        regex_threshold_match = NULL;
     }
 
     if (regex_rate != NULL) {
-        pcre_free(regex_rate);
+        pcre2_code_free(regex_rate);
         regex_rate = NULL;
     }
-    if (regex_rate_study != NULL) {
-        pcre_free(regex_rate_study);
-        regex_rate_study = NULL;
+    if (regex_rate_match != NULL) {
+        pcre2_match_data_free(regex_rate_match);
+        regex_rate_match = NULL;
     }
 
     if (regex_suppress != NULL) {
-        pcre_free(regex_suppress);
+        pcre2_code_free(regex_suppress);
         regex_suppress = NULL;
     }
-    if (regex_suppress_study != NULL) {
-        pcre_free(regex_suppress_study);
-        regex_suppress_study = NULL;
+    if (regex_suppress_match != NULL) {
+        pcre2_match_data_free(regex_suppress_match);
+        regex_suppress_match = NULL;
     }
 }
 
@@ -648,43 +652,49 @@ static int ParseThresholdRule(DetectEngineCtx *de_ctx, char *rawstr,
     uint32_t parsed_timeout = 0;
 
     int ret = 0;
-    int ov[MAX_SUBSTRINGS];
     uint32_t id = 0, gid = 0;
     ThresholdRuleType rule_type;
 
     if (de_ctx == NULL)
         return -1;
 
-    ret = pcre_exec(regex_base, regex_base_study, rawstr, strlen(rawstr), 0, 0, ov, MAX_SUBSTRINGS);
+    ret = pcre2_match(
+            regex_base, (PCRE2_SPTR8)rawstr, strlen(rawstr), 0, 0, regex_base_match, NULL);
     if (ret < 4) {
-        SCLogError(SC_ERR_PCRE_MATCH, "pcre_exec parse error, ret %" PRId32 ", string %s", ret, rawstr);
+        SCLogError(SC_ERR_PCRE_MATCH, "pcre2_match parse error, ret %" PRId32 ", string %s", ret,
+                rawstr);
         goto error;
     }
 
     /* retrieve the classtype name */
-    ret = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 1, th_rule_type, sizeof(th_rule_type));
+    size_t copylen = sizeof(th_rule_type);
+    ret = pcre2_substring_copy_bynumber(
+            regex_base_match, 1, (PCRE2_UCHAR8 *)th_rule_type, &copylen);
     if (ret < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 
     /* retrieve the classtype name */
-    ret = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 2, th_gid, sizeof(th_gid));
+    copylen = sizeof(th_gid);
+    ret = pcre2_substring_copy_bynumber(regex_base_match, 2, (PCRE2_UCHAR8 *)th_gid, &copylen);
     if (ret < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 
-    ret = pcre_copy_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 3, th_sid, sizeof(th_sid));
+    copylen = sizeof(th_sid);
+    ret = pcre2_substring_copy_bynumber(regex_base_match, 3, (PCRE2_UCHAR8 *)th_sid, &copylen);
     if (ret < 0) {
-        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+        SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
         goto error;
     }
 
     /* Use "get" for heap allocation */
-    ret = pcre_get_substring((char *)rawstr, ov, MAX_SUBSTRINGS, 4, &rule_extend);
+    ret = pcre2_substring_get_bynumber(
+            regex_base_match, 4, (PCRE2_UCHAR8 **)&rule_extend, &copylen);
     if (ret < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
         goto error;
     }
 
@@ -707,37 +717,44 @@ static int ParseThresholdRule(DetectEngineCtx *de_ctx, char *rawstr,
         case THRESHOLD_TYPE_EVENT_FILTER:
         case THRESHOLD_TYPE_THRESHOLD:
             if (strlen(rule_extend) > 0) {
-                ret = pcre_exec(regex_threshold, regex_threshold_study,
-                        rule_extend, strlen(rule_extend),
-                        0, 0, ov, MAX_SUBSTRINGS);
+                ret = pcre2_match(regex_threshold, (PCRE2_SPTR8)rule_extend, strlen(rule_extend), 0,
+                        0, regex_threshold_match, NULL);
                 if (ret < 4) {
                     SCLogError(SC_ERR_PCRE_MATCH,
-                            "pcre_exec parse error, ret %" PRId32 ", string %s",
-                            ret, rule_extend);
+                            "pcre2_match parse error, ret %" PRId32 ", string %s", ret,
+                            rule_extend);
                     goto error;
                 }
 
-                ret = pcre_copy_substring((char *)rule_extend, ov, MAX_SUBSTRINGS, 1, th_type, sizeof(th_type));
+                copylen = sizeof(th_type);
+                ret = pcre2_substring_copy_bynumber(
+                        regex_threshold_match, 1, (PCRE2_UCHAR8 *)th_type, &copylen);
                 if (ret < 0) {
-                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                     goto error;
                 }
 
-                ret = pcre_copy_substring((char *)rule_extend, ov, MAX_SUBSTRINGS, 2, th_track, sizeof(th_track));
+                copylen = sizeof(th_track);
+                ret = pcre2_substring_copy_bynumber(
+                        regex_threshold_match, 2, (PCRE2_UCHAR8 *)th_track, &copylen);
                 if (ret < 0) {
-                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                     goto error;
                 }
 
-                ret = pcre_copy_substring((char *)rule_extend, ov, MAX_SUBSTRINGS, 3, th_count, sizeof(th_count));
+                copylen = sizeof(th_count);
+                ret = pcre2_substring_copy_bynumber(
+                        regex_threshold_match, 3, (PCRE2_UCHAR8 *)th_count, &copylen);
                 if (ret < 0) {
-                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                     goto error;
                 }
 
-                ret = pcre_copy_substring((char *)rule_extend, ov, MAX_SUBSTRINGS, 4, th_seconds, sizeof(th_seconds));
+                copylen = sizeof(th_seconds);
+                ret = pcre2_substring_copy_bynumber(
+                        regex_threshold_match, 4, (PCRE2_UCHAR8 *)th_seconds, &copylen);
                 if (ret < 0) {
-                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                     goto error;
                 }
 
@@ -758,25 +775,27 @@ static int ParseThresholdRule(DetectEngineCtx *de_ctx, char *rawstr,
             break;
         case THRESHOLD_TYPE_SUPPRESS:
             if (strlen(rule_extend) > 0) {
-                ret = pcre_exec(regex_suppress, regex_suppress_study,
-                        rule_extend, strlen(rule_extend),
-                        0, 0, ov, MAX_SUBSTRINGS);
+                ret = pcre2_match(regex_suppress, (PCRE2_SPTR8)rule_extend, strlen(rule_extend), 0,
+                        0, regex_suppress_match, NULL);
                 if (ret < 2) {
                     SCLogError(SC_ERR_PCRE_MATCH,
-                            "pcre_exec parse error, ret %" PRId32 ", string %s",
-                            ret, rule_extend);
+                            "pcre2_match parse error, ret %" PRId32 ", string %s", ret,
+                            rule_extend);
                     goto error;
                 }
                 /* retrieve the track mode */
-                ret = pcre_copy_substring((char *)rule_extend, ov, MAX_SUBSTRINGS, 1, th_track, sizeof(th_track));
+                copylen = sizeof(th_seconds);
+                ret = pcre2_substring_copy_bynumber(
+                        regex_suppress_match, 1, (PCRE2_UCHAR8 *)th_track, &copylen);
                 if (ret < 0) {
-                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                     goto error;
                 }
                 /* retrieve the IP; use "get" for heap allocation */
-                ret = pcre_get_substring((char *)rule_extend, ov, MAX_SUBSTRINGS, 2, &th_ip);
+                ret = pcre2_substring_get_bynumber(
+                        regex_suppress_match, 2, (PCRE2_UCHAR8 **)&th_ip, &copylen);
                 if (ret < 0) {
-                    SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+                    SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
                     goto error;
                 }
             } else {
@@ -786,43 +805,52 @@ static int ParseThresholdRule(DetectEngineCtx *de_ctx, char *rawstr,
             break;
         case THRESHOLD_TYPE_RATE:
             if (strlen(rule_extend) > 0) {
-                ret = pcre_exec(regex_rate, regex_rate_study,
-                        rule_extend, strlen(rule_extend),
-                        0, 0, ov, MAX_SUBSTRINGS);
+                ret = pcre2_match(regex_rate, (PCRE2_SPTR8)rule_extend, strlen(rule_extend), 0, 0,
+                        regex_rate_match, NULL);
                 if (ret < 5) {
                     SCLogError(SC_ERR_PCRE_MATCH,
-                            "pcre_exec parse error, ret %" PRId32 ", string %s",
-                            ret, rule_extend);
+                            "pcre2_match parse error, ret %" PRId32 ", string %s", ret,
+                            rule_extend);
                     goto error;
                 }
 
-                ret = pcre_copy_substring((char *)rule_extend, ov, MAX_SUBSTRINGS, 1, th_track, sizeof(th_track));
+                copylen = sizeof(th_track);
+                ret = pcre2_substring_copy_bynumber(
+                        regex_rate_match, 1, (PCRE2_UCHAR8 *)th_track, &copylen);
                 if (ret < 0) {
-                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                     goto error;
                 }
 
-                ret = pcre_copy_substring((char *)rule_extend, ov, MAX_SUBSTRINGS, 2, th_count, sizeof(th_count));
+                copylen = sizeof(th_count);
+                ret = pcre2_substring_copy_bynumber(
+                        regex_rate_match, 2, (PCRE2_UCHAR8 *)th_count, &copylen);
                 if (ret < 0) {
-                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                     goto error;
                 }
 
-                ret = pcre_copy_substring((char *)rule_extend, ov, MAX_SUBSTRINGS, 3, th_seconds, sizeof(th_seconds));
+                copylen = sizeof(th_seconds);
+                ret = pcre2_substring_copy_bynumber(
+                        regex_rate_match, 3, (PCRE2_UCHAR8 *)th_seconds, &copylen);
                 if (ret < 0) {
-                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                     goto error;
                 }
 
-                ret = pcre_copy_substring((char *)rule_extend, ov, MAX_SUBSTRINGS, 4, th_new_action, sizeof(th_new_action));
+                copylen = sizeof(th_new_action);
+                ret = pcre2_substring_copy_bynumber(
+                        regex_rate_match, 4, (PCRE2_UCHAR8 *)th_new_action, &copylen);
                 if (ret < 0) {
-                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                     goto error;
                 }
 
-                ret = pcre_copy_substring((char *)rule_extend, ov, MAX_SUBSTRINGS, 5, th_timeout, sizeof(th_timeout));
+                copylen = sizeof(th_timeout);
+                ret = pcre2_substring_copy_bynumber(
+                        regex_rate_match, 5, (PCRE2_UCHAR8 *)th_timeout, &copylen);
                 if (ret < 0) {
-                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre_copy_substring failed");
+                    SCLogError(SC_ERR_PCRE_COPY_SUBSTRING, "pcre2_substring_copy_bynumber failed");
                     goto error;
                 }
 
@@ -926,18 +954,16 @@ static int ParseThresholdRule(DetectEngineCtx *de_ctx, char *rawstr,
     *ret_th_ip = NULL;
     if (th_ip != NULL) {
         *ret_th_ip = (char *)th_ip;
-    } else {
-        SCFree((char *)th_ip);
     }
-    SCFree((char *)rule_extend);
+    pcre2_substring_free((PCRE2_UCHAR8 *)rule_extend);
     return 0;
 
 error:
     if (rule_extend != NULL) {
-        SCFree((char *)rule_extend);
+        pcre2_substring_free((PCRE2_UCHAR8 *)rule_extend);
     }
     if (th_ip != NULL) {
-        SCFree((char *)th_ip);
+        pcre2_substring_free((PCRE2_UCHAR8 *)th_ip);
     }
     return -1;
 }
@@ -983,11 +1009,11 @@ static int SCThresholdConfAddThresholdtype(char *rawstr, DetectEngineCtx *de_ctx
         goto error;
     }
 
-    SCFree(th_ip);
+    pcre2_substring_free((PCRE2_UCHAR8 *)th_ip);
     return 0;
 error:
     if (th_ip != NULL)
-        SCFree(th_ip);
+        pcre2_substring_free((PCRE2_UCHAR8 *)th_ip);
     return -1;
 }
 

--- a/src/util-unittest.c
+++ b/src/util-unittest.c
@@ -38,7 +38,6 @@
 #include "util-debug.h"
 #include "util-time.h"
 #include "conf.h"
-#include <pcre2.h>
 
 #include "stream-tcp.h"
 #include "stream-tcp-reassemble.h"


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3194
https://redmine.openinfosecfoundation.org/issues/4446

Describe changes:
- migrate all pcre1 code to pcre2
- qa : remove some obsolete files
- pcrexform : checks that we have exactly one substring capture in a signature

suricata-verify-pr: 502

https://github.com/OISF/suricata-verify/pull/502

Replaces https://github.com/OISF/suricata/pull/6413 with latest rebase and removing commit suppressing drmemory file which will keep obsolete pcre1 references
