### PR TITLE
http: delete obsolete range log

### DIFF
--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -358,7 +358,6 @@ void HTPFileCloseHandleRange(FileContainer *files, const uint16_t flags, HttpRan
             /* HtpState owns the constructed file now */
             FileContainerAdd(files, ranged);
         }
-        SCLogDebug("c->container->files->tail %p", c->container->files->tail);
         THashDataUnlock(c->container->hdata);
     }
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4719

Describe changes:
- Remove one obsolete logging line

Commit d776d72711800168cda5d62a7cc4669abda379be
has been transfering ownership of file container

So, we cannot log it

Commit d776d72711800168cda5d62a7cc4669abda379be should have included this change, but I forgot to check app-layer-htp-file.c for references to the range's files container, and only checked app-layer-htp-range.c