### PR TITLE
Range logfix 4719 v2

### DIFF
--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -224,7 +224,7 @@ impl HTTP2Transaction {
                     match range::http2_parse_content_range(&value) {
                         Ok((_, v)) => {
                             range::http2_range_open(self, &v, flow, sfcm, flags, decompressed);
-                            if over {
+                            if over && self.file_range != std::ptr::null_mut() {
                                 range::http2_range_close(self, files, flags, &[])
                             }
                         }

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -358,7 +358,6 @@ void HTPFileCloseHandleRange(FileContainer *files, const uint16_t flags, HttpRan
             /* HtpState owns the constructed file now */
             FileContainerAdd(files, ranged);
         }
-        SCLogDebug("c->container->files->tail %p", c->container->files->tail);
         THashDataUnlock(c->container->hdata);
     }
 }

--- a/src/app-layer-htp-range.c
+++ b/src/app-layer-htp-range.c
@@ -421,11 +421,12 @@ int HttpRangeAppendData(HttpRangeContainerBlock *c, const uint8_t *data, uint32_
         SCLogDebug("update files (FileAppendData)");
         return FileAppendData(c->files, data, len);
     }
-    // If we are not in the previous cases, only one case remains
-    DEBUG_VALIDATE_BUG_ON(c->current == NULL);
-    // So we have a current allocated buffer to copy to
-    // in the case of an unordered range being handled
+    // Maybe we were in the skipping case,
+    // but we get more data than expected and had set c->toskip = 0
+    // so we need to check for last case with something to do
     if (c->current) {
+        // So we have a current allocated buffer to copy to
+        // in the case of an unordered range being handled
         SCLogDebug("update current: adding %u bytes to block %p", len, c);
         // GAP "data"
         if (data == NULL) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4719

Describe changes:
- Remove one obsolete logging line
- Adds one check before calling `http2_range_close`

Commit 3ed38d2 has been transfering ownership of file container
So, we cannot log it

Commit 3ed38d2 should have included this change, but I forgot to check app-layer-htp-file.c for references to the range's files container, and only checked app-layer-htp-range.c

