### PR TITLE
unittests: Register missing UT module

### DIFF
--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -472,9 +472,12 @@ void RegisterTemplateParsers(void)
     const char *proto_name = "template";
 
     /* TEMPLATE_START_REMOVE */
+#ifndef UNITTESTS
+    /* Ensure template registration for unittests */
     if (ConfGetNode("app-layer.protocols.template") == NULL) {
         return;
     }
+#endif
     /* TEMPLATE_END_REMOVE */
     /* Check if Template TCP detection is enabled. If it does not exist in
      * the configuration file then it will be enabled by default. */

--- a/src/detect-engine-enip.c
+++ b/src/detect-engine-enip.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015 Open Information Security Foundation
+/* Copyright (C) 2015-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -291,13 +291,13 @@ int DetectEngineInspectENIP(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 
-static uint8_t listIdentity[] = {/* List ID */    0x00, 0x63,
+static uint8_t listIdentity[] = {/* List ID */    0x63, 0x00,
                                  /* Length */     0x00, 0x00,
                                  /* Session */    0x00, 0x00, 0x00, 0x00,
                                  /* Status */     0x00, 0x00, 0x00, 0x00,
                                  /*  Delay*/      0x00,
                                  /* Context */    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                 /* Quantity of coils */ 0x00, 0x00, 0x00, 0x00,};
+                                 /* Quantity of coils */ 0x00, 0x00, 0x00, 0x00, 0x00,};
 
 /** \test Test code function. */
 static int DetectEngineInspectENIPTest01(void)
@@ -336,7 +336,7 @@ static int DetectEngineInspectENIPTest01(void)
     de_ctx->flags |= DE_QUIET;
     s = de_ctx->sig_list = SigInit(de_ctx, "alert enip any any -> any any "
             "(msg:\"Testing enip command\"; "
-            "enipcommand:99 ; sid:1;)");
+            "enip_command:99 ; sid:1;)");
     FAIL_IF_NULL(s);
 
     SigGroupBuild(de_ctx);

--- a/src/detect-template-buffer.c
+++ b/src/detect-template-buffer.c
@@ -53,9 +53,12 @@ static int g_template_buffer_id = 0;
 void DetectTemplateBufferRegister(void)
 {
     /* TEMPLATE_START_REMOVE */
+#ifndef UNITTESTS
+    /* Ensure registration when running unittests */
     if (ConfGetNode("app-layer.protocols.template") == NULL) {
         return;
     }
+#endif
     /* TEMPLATE_END_REMOVE */
     sigmatch_table[DETECT_AL_TEMPLATE_BUFFER].name = "template_buffer";
     sigmatch_table[DETECT_AL_TEMPLATE_BUFFER].desc =

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -37,6 +37,7 @@
 #include "detect-engine-dcepayload.h"
 #include "detect-engine-state.h"
 #include "detect-engine-tag.h"
+#include "detect-engine-enip.h"
 #include "detect-fast-pattern.h"
 #include "flow.h"
 #include "flow-timeout.h"
@@ -181,6 +182,7 @@ static void RegisterUnittests(void)
 #endif
     DeStateRegisterTests();
     MemcmpRegisterTests();
+    DetectEngineInspectENIPRegisterTests();
     DetectEngineRegisterTests();
     SCLogRegisterTests();
     MagicRegisterTests();


### PR DESCRIPTION
Continuation of #6089 

This commit adds three UT registrations that were discovered missing during code coverage.

Describe changes:
- Register UT functions for ENIP, template-buffer and rust-template-buffer.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
