### PR TITLE
Pcre threadsafe 4720 v2

### DIFF
--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -200,7 +200,8 @@ int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
     }
 
     /* run the actual pcre detection */
-    pcre2_match_data *match = pcre2_match_data_create_from_pattern(pe->parse_regex.regex, NULL);
+    pcre2_match_data *match = (pcre2_match_data *)DetectThreadCtxGetKeywordThreadCtx(det_ctx, pe->thread_ctx_id);
+
     ret = DetectPcreExec(det_ctx, pe, (char *)ptr, len, start_offset, 0, match);
     SCLogDebug("ret %d (negating %s)", ret, (pe->flags & DETECT_PCRE_NEGATE) ? "set" : "not set");
 
@@ -303,7 +304,6 @@ int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
         SCLogDebug("pcre had matching error");
         ret = 0;
     }
-    pcre2_match_data_free(match);
     SCReturnInt(ret);
 }
 
@@ -830,6 +830,21 @@ error:
     return -1;
 }
 
+static void *DetectPcreThreadInit(void *data)
+{
+    DetectPcreData *pd = (DetectPcreData *)data;
+    pcre2_match_data *match = pcre2_match_data_create_from_pattern(pd->parse_regex.regex, NULL);
+    return match;
+}
+
+static void DetectPcreThreadFree(void *ctx)
+{
+    if (ctx != NULL) {
+        pcre2_match_data *match = (pcre2_match_data *)ctx;
+        pcre2_match_data_free(match);
+    }
+}
+
 static int DetectPcreSetup (DetectEngineCtx *de_ctx, Signature *s, const char *regexstr)
 {
     SCEnter();
@@ -845,6 +860,12 @@ static int DetectPcreSetup (DetectEngineCtx *de_ctx, Signature *s, const char *r
     if (pd == NULL)
         goto error;
     if (DetectPcreParseCapture(regexstr, de_ctx, pd, capture_names) < 0)
+        goto error;
+
+    pd->thread_ctx_id = DetectRegisterThreadCtxFuncs(de_ctx, "pcre",
+            DetectPcreThreadInit, (void *)pd,
+            DetectPcreThreadFree, 0);
+    if (pd->thread_ctx_id == -1)
         goto error;
 
     int sm_list = -1;
@@ -934,6 +955,8 @@ static void DetectPcreFree(DetectEngineCtx *de_ctx, void *ptr)
 
     DetectPcreData *pd = (DetectPcreData *)ptr;
     DetectParseFreeRegex(&pd->parse_regex);
+    DetectUnregisterThreadCtxFuncs(de_ctx, NULL, pd, "pcre");
+
     SCFree(pd);
 
     return;

--- a/src/detect-pcre.h
+++ b/src/detect-pcre.h
@@ -45,6 +45,7 @@ typedef struct DetectPcreData_ {
     uint8_t idx;
     uint8_t captypes[DETECT_PCRE_CAPTURE_MAX];
     uint32_t capids[DETECT_PCRE_CAPTURE_MAX];
+    int thread_ctx_id;
 } DetectPcreData;
 
 /* prototypes */

--- a/src/detect-transform-pcrexform.c
+++ b/src/detect-transform-pcrexform.c
@@ -32,7 +32,6 @@
 
 typedef struct DetectTransformPcrexformData {
     pcre2_code *regex;
-    pcre2_match_data *match_data;
 } DetectTransformPcrexformData;
 
 static int DetectTransformPcrexformSetup (DetectEngineCtx *, Signature *, const char *);
@@ -65,7 +64,6 @@ static void DetectTransformPcrexformFree(DetectEngineCtx *de_ctx, void *ptr)
     if (ptr != NULL) {
         DetectTransformPcrexformData *pxd = (DetectTransformPcrexformData *) ptr;
         pcre2_code_free(pxd->regex);
-        pcre2_match_data_free(pxd->match_data);
         SCFree(pxd);
     }
 }
@@ -116,7 +114,6 @@ static int DetectTransformPcrexformSetup (DetectEngineCtx *de_ctx, Signature *s,
         DetectTransformPcrexformFree(de_ctx, pxd);
         SCReturnInt(-1);
     }
-    pxd->match_data = pcre2_match_data_create_from_pattern(pxd->regex, NULL);
 
     int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_PCREXFORM, pxd);
     if (r != 0) {
@@ -132,18 +129,20 @@ static void DetectTransformPcrexform(InspectionBuffer *buffer, void *options)
     const uint32_t input_len = buffer->inspect_len;
     DetectTransformPcrexformData *pxd = options;
 
-    int ret = pcre2_match(pxd->regex, (PCRE2_SPTR8)input, input_len, 0, 0, pxd->match_data, NULL);
+    pcre2_match_data *match = pcre2_match_data_create_from_pattern(pxd->regex, NULL);
+    int ret = pcre2_match(pxd->regex, (PCRE2_SPTR8)input, input_len, 0, 0, match, NULL);
 
     if (ret > 0) {
         const char *str;
         PCRE2_SIZE caplen;
-        ret = pcre2_substring_get_bynumber(pxd->match_data, 0, (PCRE2_UCHAR8 **)&str, &caplen);
+        ret = pcre2_substring_get_bynumber(match, 0, (PCRE2_UCHAR8 **)&str, &caplen);
 
         if (ret >= 0) {
             InspectionBufferCopy(buffer, (uint8_t *)str, (uint32_t)caplen);
             pcre2_substring_free((PCRE2_UCHAR8 *)str);
         }
     }
+    pcre2_match_data_free(pxd->match_data);
 }
 
 #ifdef UNITTESTS


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4720

Describe changes:
- Creates a `pcre2_match_data` for each thread to be used in of `DetectPcrePayloadMatch`
- Creates a `pcre2_match_data` for each call to pcerexform Transform (as we do not have access to `DetectEngineThreadCtx` in transforms)

Replaces #6425 with adding
- commit using thread storage instead of reallocating locally for each call of the function `DetectPcrePayloadMatch`
- commit about pcrexform