### PR TITLE
http2: enable by default

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -286,10 +286,8 @@ outputs:
         - ssh
         - mqtt:
             # passwords: yes           # enable output of passwords
-        # HTTP2 logging. HTTP2 support is currently experimental and
-        # disabled by default. To enable, uncomment the following line
-        # and be sure to enable http2 in the app-layer section.
-        #- http2
+        # HTTP2 logging. HTTP2 support is now enabled by default
+        - http2
         - stats:
             totals: yes       # stats for all threads merged together
             threads: no       # per thread stats
@@ -758,9 +756,9 @@ app-layer:
     ssh:
       enabled: yes
       #hassh: yes
-    # HTTP2: Experimental HTTP 2 support. Disabled by default.
+    # HTTP2: Now enabled by default.
     http2:
-      enabled: no
+      enabled: yes
     smtp:
       enabled: yes
       raw-extraction: no


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4721

Describe changes:
- Enables HTTP2 by default

It looks too simple. Did I miss something ?