### PR TITLE
Pcre threadsafe 4720 v3

### DIFF
--- a/src/detect-pcre.h
+++ b/src/detect-pcre.h
@@ -45,6 +45,7 @@ typedef struct DetectPcreData_ {
     uint8_t idx;
     uint8_t captypes[DETECT_PCRE_CAPTURE_MAX];
     uint32_t capids[DETECT_PCRE_CAPTURE_MAX];
+    int thread_ctx_id;
 } DetectPcreData;
 
 /* prototypes */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4720

Describe changes:
- Creates a `pcre2_match_data` for each thread to be used in of `DetectPcrePayloadMatch`
- Creates a `pcre2_match_data` for each call to pcerexform Transform (as we do not have access to `DetectEngineThreadCtx` in transforms)

Replaces #6427 with fixing compilation and formatting check