### PR TITLE
readthedocs: add configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ test.sh
 !/suricata-update/Makefile.am
 /libsuricata-config
 !/libsuricata-config.in
+!/.readthedocs.yaml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+# Required by Read The Docs
+version: 2
+
+python:
+  version: "3.8"
+
+  # Use an empty install section to avoid RTD from picking up a non-python
+  # requirements.txt file.
+  install: []


### PR DESCRIPTION
Fix ReadTheDocs builds.  We added a requirements.txt but not for Python. This instructs ReadTheDocs to not pickup the requirements.txt file (we could point it elsewhere if needed).

The alternative would be to rename requirements.txt, but I'm a little annoyed that a language picked such a generic term and always expects a file of that name to be a "python" requirements file ;)
