### PR TITLE
pcre: fixes a memory leak on alloc error

### DIFF
--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -266,8 +266,9 @@ int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
                         capture_len = (capture_len < 0xffff) ? (uint16_t)capture_len : 0xffff;
                         uint8_t *str_ptr2 = SCMalloc(capture_len);
                         if (unlikely(str_ptr2 == NULL)) {
-                            pcre2_substring_free((PCRE2_UCHAR8 *)pcre2_str_ptr);
-                            continue;
+                            SCFree(str_ptr);
+                            pcre2_substring_free((PCRE2_UCHAR8 *)pcre2_str_ptr2);
+                            break;
                         }
                         memcpy(str_ptr2, pcre2_str_ptr2, capture_len);
                         pcre2_substring_free((PCRE2_UCHAR8 *)pcre2_str_ptr2);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4724

Describe changes:
- pcre: fixes a memory leak on alloc error


There were in fact 2 errors 
- forgot to free `str_ptr`
- freed `pcre2_str_ptr` (which was already freed) instead of `pcre2_str_ptr2`