### PR TITLE
fuzz: target must use the rules it parsed

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -85,9 +85,6 @@
 
 #define DETECT_ENGINE_DEFAULT_INSPECTION_RECURSION_LIMIT 3000
 
-static DetectEngineThreadCtx *DetectEngineThreadCtxInitForReload(
-        ThreadVars *tv, DetectEngineCtx *new_de_ctx, int mt);
-
 static int DetectEngineCtxLoadConf(DetectEngineCtx *);
 
 static DetectEngineMasterCtx g_master_de_ctx = { SCMUTEX_INITIALIZER,
@@ -2835,7 +2832,7 @@ TmEcode DetectEngineThreadCtxInit(ThreadVars *tv, void *initdata, void **data)
  *
  * \retval det_ctx detection engine thread ctx or NULL in case of error
  */
-static DetectEngineThreadCtx *DetectEngineThreadCtxInitForReload(
+DetectEngineThreadCtx *DetectEngineThreadCtxInitForReload(
         ThreadVars *tv, DetectEngineCtx *new_de_ctx, int mt)
 {
     DetectEngineThreadCtx *det_ctx = SCMalloc(sizeof(DetectEngineThreadCtx));

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -166,4 +166,7 @@ int DetectEngineMustParseMetadata(void);
 int WARN_UNUSED DetectBufferSetActiveList(Signature *s, const int list);
 int DetectBufferGetActiveList(DetectEngineCtx *de_ctx, Signature *s);
 
+DetectEngineThreadCtx *DetectEngineThreadCtxInitForReload(
+        ThreadVars *tv, DetectEngineCtx *new_de_ctx, int mt);
+
 #endif /* __DETECT_ENGINE_H__ */

--- a/src/tests/fuzz/fuzz_sigpcap_aware.c
+++ b/src/tests/fuzz/fuzz_sigpcap_aware.c
@@ -138,6 +138,14 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     if (DetectEngineReload(&surifuzz) < 0) {
         return 0;
     }
+    DetectEngineThreadCtx *old_det_ctx = FlowWorkerGetDetectCtxPtr(fwd);
+
+    DetectEngineCtx *de_ctx = DetectEngineGetCurrent();
+    de_ctx->ref_cnt--;
+    DetectEngineThreadCtx *new_det_ctx = DetectEngineThreadCtxInitForReload(&tv, de_ctx, 1);
+    FlowWorkerReplaceDetectCtx(fwd, new_det_ctx);
+
+    DetectEngineThreadCtxDeinit(NULL, old_det_ctx);
 
     // loop over packets
     r = FPC_next(&pkts, &header, &pkt);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4125

Describe changes:
- Make fuzz target cover more code

I noticed this with coverage report of `rs_mqtt_tx_has_type` being not covered

`DetectEngineReloadThreads` does not work for the fuzz targets as there is `no_of_detect_tvs = 0` as we did not register real threads and slots.

So, we force the flow worker module to use the newly detect engine context with all it needs
