### PR TITLE
app-layer: disable by default if not in configuration

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -323,6 +323,7 @@ extern {
                                                      offset: u16, direction: u8, ppfn: ProbeFn,
                                                      pp_min_depth: u16, pp_max_depth: u16) -> c_int;
     pub fn AppLayerProtoDetectConfProtoDetectionEnabled(ipproto: *const c_char, proto: *const c_char) -> c_int;
+    pub fn AppLayerProtoDetectConfProtoDetectionEnabledDefault(ipproto: *const c_char, proto: *const c_char, default: bool) -> c_int;
 }
 
 // Defined in app-layer-parser.h

--- a/rust/src/modbus/modbus.rs
+++ b/rust/src/modbus/modbus.rs
@@ -443,7 +443,7 @@ pub unsafe extern "C" fn rs_modbus_register_parser() {
     };
 
     let ip_proto_str = CString::new("tcp").unwrap();
-    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+    if AppLayerProtoDetectConfProtoDetectionEnabledDefault(ip_proto_str.as_ptr(), parser.name, false) != 0 {
         let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
         ALPROTO_MODBUS = alproto;
         if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1984,8 +1984,8 @@ void AppLayerProtoDetectReset(Flow *f)
     f->alproto_tc = ALPROTO_UNKNOWN;
 }
 
-int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto,
-                                                 const char *alproto)
+int AppLayerProtoDetectConfProtoDetectionEnabledDefault(
+        const char *ipproto, const char *alproto, bool default_enabled)
 {
     SCEnter();
 
@@ -2021,7 +2021,11 @@ int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto,
         node = ConfGetNode(param);
         if (node == NULL) {
             SCLogDebug("Entry for %s not found.", param);
-            goto enabled;
+            if (default_enabled) {
+                goto enabled;
+            } else {
+                goto disabled;
+            }
         }
     }
 
@@ -2043,6 +2047,11 @@ int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto,
     enabled = 0;
  enabled:
     SCReturnInt(enabled);
+}
+
+int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto, const char *alproto)
+{
+    return AppLayerProtoDetectConfProtoDetectionEnabledDefault(ipproto, alproto, true);
 }
 
 AppLayerProtoDetectThreadCtx *AppLayerProtoDetectGetCtxThread(void)

--- a/src/app-layer-detect-proto.h
+++ b/src/app-layer-detect-proto.h
@@ -163,6 +163,19 @@ int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto,
                                                  const char *alproto);
 
 /**
+ * \brief Given a protocol name, checks if proto detection is enabled in
+ *        the conf file.
+ *
+ * \param alproto Name of the app layer protocol.
+ * \param default_enabled enable by default if not in the configuration file
+ *
+ * \retval 1 If enabled.
+ * \retval 0 If disabled.
+ */
+int AppLayerProtoDetectConfProtoDetectionEnabledDefault(
+        const char *ipproto, const char *alproto, bool default_enabled);
+
+/**
  * \brief Inits and returns an app layer protocol detection thread context.
 
  * \param ctx Pointer to the app layer protocol detection context.

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -1587,8 +1587,7 @@ void RegisterDNP3Parsers(void)
 
     const char *proto_name = "dnp3";
 
-    if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name))
-    {
+    if (AppLayerProtoDetectConfProtoDetectionEnabledDefault("tcp", proto_name, false)) {
         AppLayerProtoDetectRegisterProtocol(ALPROTO_DNP3, proto_name);
 
         if (RunmodeIsUnittests()) {
@@ -1604,8 +1603,7 @@ void RegisterDNP3Parsers(void)
             }
         }
 
-    }
-    else {
+    } else {
         SCLogConfig("Protocol detection and parser disabled for DNP3.");
         SCReturn;
     }

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -465,8 +465,7 @@ void RegisterENIPUDPParsers(void)
     SCEnter();
     const char *proto_name = "enip";
 
-    if (AppLayerProtoDetectConfProtoDetectionEnabled("udp", proto_name))
-    {
+    if (AppLayerProtoDetectConfProtoDetectionEnabledDefault("udp", proto_name, false)) {
         AppLayerProtoDetectRegisterProtocol(ALPROTO_ENIP, proto_name);
 
         if (RunmodeIsUnittests())
@@ -496,8 +495,7 @@ void RegisterENIPUDPParsers(void)
             }
         }
 
-    } else
-    {
+    } else {
         SCLogConfig("Protocol detection and parser disabled for %s protocol.",
                 proto_name);
         return;
@@ -555,8 +553,7 @@ void RegisterENIPTCPParsers(void)
     SCEnter();
     const char *proto_name = "enip";
 
-    if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name))
-    {
+    if (AppLayerProtoDetectConfProtoDetectionEnabledDefault("tcp", proto_name, false)) {
         AppLayerProtoDetectRegisterProtocol(ALPROTO_ENIP, proto_name);
 
         if (RunmodeIsUnittests())
@@ -577,8 +574,7 @@ void RegisterENIPTCPParsers(void)
             }
         }
 
-    } else
-    {
+    } else {
         SCLogDebug("Protocol detection and parser disabled for %s protocol.",
                 proto_name);
         return;

--- a/src/app-layer-http2.c
+++ b/src/app-layer-http2.c
@@ -57,7 +57,7 @@ void RegisterHTTP2Parsers(void)
 {
     const char *proto_name = "http2";
 
-    if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name)) {
+    if (AppLayerProtoDetectConfProtoDetectionEnabledDefault("tcp", proto_name, false)) {
         AppLayerProtoDetectRegisterProtocol(ALPROTO_HTTP2, proto_name);
         if (HTTP2RegisterPatternsForProtocolDetection() < 0)
             return;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4739

Describe changes:
- Truly disables by default some protocols

That means disable them when they are not in the configuration file 