### PR TITLE
ike: do not keep server transforms in state

### DIFF
--- a/rust/src/ike/detect.rs
+++ b/rust/src/ike/detect.rs
@@ -166,39 +166,37 @@ pub extern "C" fn rs_ike_state_get_sa_attribute(
                 }
             }
         } else if tx.ike_version == 2 {
-            'outer2: for server_transform in tx.hdr.ikev2_transforms.iter() {
-                for attr in server_transform {
-                    match attr {
-                        IkeV2Transform::Encryption(e) => {
-                            if sa == "alg_enc" {
-                                ret_val = e.0 as u32;
-                                ret_code = 1;
-                                break 'outer2;
-                            }
+            for attr in tx.hdr.ikev2_transforms.iter() {
+                match attr {
+                    IkeV2Transform::Encryption(e) => {
+                        if sa == "alg_enc" {
+                            ret_val = e.0 as u32;
+                            ret_code = 1;
+                            break;
                         }
-                        IkeV2Transform::Auth(e) => {
-                            if sa == "alg_auth" {
-                                ret_val = e.0 as u32;
-                                ret_code = 1;
-                                break 'outer2;
-                            }
-                        }
-                        IkeV2Transform::PRF(ref e) => {
-                            if sa == "alg_prf" {
-                                ret_val = e.0 as u32;
-                                ret_code = 1;
-                                break 'outer2;
-                            }
-                        }
-                        IkeV2Transform::DH(ref e) => {
-                            if sa == "alg_dh" {
-                                ret_val = e.0 as u32;
-                                ret_code = 1;
-                                break 'outer2;
-                            }
-                        }
-                        _ => (),
                     }
+                    IkeV2Transform::Auth(e) => {
+                        if sa == "alg_auth" {
+                            ret_val = e.0 as u32;
+                            ret_code = 1;
+                            break;
+                        }
+                    }
+                    IkeV2Transform::PRF(ref e) => {
+                        if sa == "alg_prf" {
+                            ret_val = e.0 as u32;
+                            ret_code = 1;
+                            break;
+                        }
+                    }
+                    IkeV2Transform::DH(ref e) => {
+                        if sa == "alg_dh" {
+                            ret_val = e.0 as u32;
+                            ret_code = 1;
+                            break;
+                        }
+                    }
+                    _ => (),
                 }
             }
         }

--- a/rust/src/ike/ike.rs
+++ b/rust/src/ike/ike.rs
@@ -57,7 +57,7 @@ pub struct IkeHeaderWrapper {
     pub msg_id: u32,
     pub flags: u8,
     pub ikev1_transforms: Vec<Vec<SaAttribute>>,
-    pub ikev2_transforms: Vec<Vec<IkeV2Transform>>,
+    pub ikev2_transforms: Vec<IkeV2Transform>,
     pub ikev1_header: IkeV1Header,
     pub ikev2_header: IkeV2Header,
 }
@@ -135,6 +135,12 @@ impl IKETransaction {
         if let Some(state) = self.de_state {
             core::sc_detect_engine_state_free(state);
         }
+    }
+
+    /// Set an event.
+    pub fn set_event(&mut self, event: IkeEvent) {
+        let ev = event as u8;
+        core::sc_app_layer_decoder_events_set_event_raw(&mut self.events, ev);
     }
 }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4534

Describe changes:
- ike :  only the tx with the transforms will match with `ike.chosen_sa_attribute`

use transaction when available instead of resorting to state to get last transaction