### PR TITLE
app-layer: clean and "close" all txs if protocol reaches error state

### DIFF
--- a/src/flow.c
+++ b/src/flow.c
@@ -1131,7 +1131,7 @@ uint8_t FlowGetDisruptionFlags(const Flow *f, uint8_t flags)
     TcpSession *ssn = f->protoctx;
     TcpStream *stream = flags & STREAM_TOSERVER ? &ssn->client : &ssn->server;
 
-    if (stream->flags & STREAMTCP_STREAM_FLAG_DEPTH_REACHED) {
+    if (stream->flags & (STREAMTCP_STREAM_FLAG_DEPTH_REACHED | STREAMTCP_FLAG_APP_LAYER_DISABLED)) {
         newflags |= STREAM_DEPTH;
     }
     /* todo: handle pass case (also for UDP!) */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4318

Describe changes:
- app-layer: clean and "close" all txs if protocol reaches error state

I do not see any easy way to get a pcap where this code will get used
That means a pcap with an app-layer protocol with 2 or more alive transactions, and then reaching an error state.
The best I see right now is to add a dummy patch for the HTTP2 parser to return `AppLayerResult::err()` in some specific case and then create a pcap with multiple HTTP2 requests/streams, no answers, and then triggering the dummy condition...
But we do not want a dummy patch...