### PR TITLE
5.0.x backport: app-layer: disable by default if not in configuration

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1887,8 +1887,8 @@ void AppLayerProtoDetectReset(Flow *f)
     f->alproto_tc = ALPROTO_UNKNOWN;
 }
 
-int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto,
-                                                 const char *alproto)
+int AppLayerProtoDetectConfProtoDetectionEnabledDefault(
+        const char *ipproto, const char *alproto, bool default_enabled)
 {
     SCEnter();
 
@@ -1931,7 +1931,11 @@ int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto,
         node = ConfGetNode(param);
         if (node == NULL) {
             SCLogDebug("Entry for %s not found.", param);
-            goto enabled;
+            if (default_enabled) {
+                goto enabled;
+            } else {
+                goto disabled;
+            }
         }
     }
 
@@ -1953,6 +1957,11 @@ int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto,
     enabled = 0;
  enabled:
     SCReturnInt(enabled);
+}
+
+int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto, const char *alproto)
+{
+    return AppLayerProtoDetectConfProtoDetectionEnabledDefault(ipproto, alproto, true);
 }
 
 AppLayerProtoDetectThreadCtx *AppLayerProtoDetectGetCtxThread(void)

--- a/src/app-layer-detect-proto.h
+++ b/src/app-layer-detect-proto.h
@@ -165,6 +165,19 @@ int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto,
                                                  const char *alproto);
 
 /**
+ * \brief Given a protocol name, checks if proto detection is enabled in
+ *        the conf file.
+ *
+ * \param alproto Name of the app layer protocol.
+ * \param default_enabled enable by default if not in the configuration file
+ *
+ * \retval 1 If enabled.
+ * \retval 0 If disabled.
+ */
+int AppLayerProtoDetectConfProtoDetectionEnabledDefault(
+        const char *ipproto, const char *alproto, bool default_enabled);
+
+/**
  * \brief Inits and returns an app layer protocol detection thread context.
 
  * \param ctx Pointer to the app layer protocol detection context.

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -1623,8 +1623,7 @@ void RegisterDNP3Parsers(void)
 
     const char *proto_name = "dnp3";
 
-    if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name))
-    {
+    if (AppLayerProtoDetectConfProtoDetectionEnabledDefault("tcp", proto_name, false)) {
         AppLayerProtoDetectRegisterProtocol(ALPROTO_DNP3, proto_name);
 
         if (RunmodeIsUnittests()) {
@@ -1642,8 +1641,7 @@ void RegisterDNP3Parsers(void)
             }
         }
 
-    }
-    else {
+    } else {
         SCLogConfig("Protocol detection and parser disabled for DNP3.");
         SCReturn;
     }

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -441,8 +441,7 @@ void RegisterENIPUDPParsers(void)
     SCEnter();
     const char *proto_name = "enip";
 
-    if (AppLayerProtoDetectConfProtoDetectionEnabled("udp", proto_name))
-    {
+    if (AppLayerProtoDetectConfProtoDetectionEnabledDefault("udp", proto_name, false)) {
         AppLayerProtoDetectRegisterProtocol(ALPROTO_ENIP, proto_name);
 
         if (RunmodeIsUnittests())
@@ -472,8 +471,7 @@ void RegisterENIPUDPParsers(void)
             }
         }
 
-    } else
-    {
+    } else {
         SCLogConfig("Protocol detection and parser disabled for %s protocol.",
                 proto_name);
         return;
@@ -533,8 +531,7 @@ void RegisterENIPTCPParsers(void)
     SCEnter();
     const char *proto_name = "enip";
 
-    if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name))
-    {
+    if (AppLayerProtoDetectConfProtoDetectionEnabledDefault("tcp", proto_name, false)) {
         AppLayerProtoDetectRegisterProtocol(ALPROTO_ENIP, proto_name);
 
         if (RunmodeIsUnittests())
@@ -557,8 +554,7 @@ void RegisterENIPTCPParsers(void)
             }
         }
 
-    } else
-    {
+    } else {
         SCLogDebug("Protocol detection and parser disabled for %s protocol.",
                 proto_name);
         return;


### PR DESCRIPTION
DNP3, ENIP, HTTP2 and Modbus are supposed to be disabled
by default. That means the default configuration does it,
but that also means that, if they are not in suricata.yaml,
the protocol should stay disabled.

(cherry picked from commit ea4a509a54e8292a41a496fc9d2b97096de91f77)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4745](https://redmine.openinfosecfoundation.org/issues/4745)


#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
