### PR TITLE
Userguide: clarify lua's `need` key usage differences (Doc#4725) - v1

### DIFF
--- a/doc/userguide/lua/lua-functions.rst
+++ b/doc/userguide/lua/lua-functions.rst
@@ -8,7 +8,7 @@ Differences between `output` and `detect`:
 
 Currently, the ``needs`` key initialization varies, depending on what is the goal of the script: output or detection.
 
-If the script is for detection, the ``needs`` initialization should be as seen in the example below (see :ref:`lua-scripting` for a complete example for a detect script):
+If the script is for detection, the ``needs`` initialization should be as seen in the example below (see :ref:`lua-detection` for a complete example of a detection script):
 
 ::
 

--- a/doc/userguide/lua/lua-functions.rst
+++ b/doc/userguide/lua/lua-functions.rst
@@ -3,6 +3,35 @@
 Lua functions
 =============
 
+Differences between `output` and `detect`:
+------------------------------------------
+
+Currently, the ``needs`` key initialization varies, depending on what is the goal of the script: output or detection.
+
+If the script is for detection, the ``needs`` initialization should be as seen in the example below (see :ref:`lua-scripting` for a complete example for a detect script):
+
+::
+
+  function init (args)
+      local needs = {}
+      needs["packet"] = tostring(true)
+      return needs
+  end
+
+For output logs, follow the pattern below. (The complete script structure can be seen at :ref:`lua-output`:)
+
+::
+
+  function init (args)
+      local needs = {}
+      needs["protocol"] = "http"
+      return needs
+  end
+
+
+Do notice that the functions and protocols available for ``log`` and ``match`` may also vary. DNP3, for instance, is not
+available for logging.
+
 packet
 ------
 
@@ -159,13 +188,23 @@ notation. To avoid that, simply do:
 http
 ----
 
-Init with:
+For output, init with:
 
 ::
 
   function init (args)
       local needs = {}
       needs["protocol"] = "http"
+      return needs
+  end
+
+For detection, use the specific buffer (cf :ref:`lua-detection` for a complete list), as with:
+
+::
+
+  function init (args)
+      local needs = {}
+      needs["http.uri"] = tostring(true)
       return needs
   end
 
@@ -297,6 +336,27 @@ HttpGetResponseHeaders
 DNS
 ---
 
+If your purpose is to create a logging script, initialize the buffer as:
+
+::
+
+  function init (args)
+     local needs = {}
+     needs["protocol"] = "dns"
+     return needs
+  end
+
+If you are going to use the script for rule matching, choose one of the available DNS buffers listed in
+:ref:`lua-detection` and follow the pattern:
+
+::
+
+  function init (args)
+     local needs = {}
+     needs["dns.rrname"] = tostring(true)
+     return needs
+  end
+
 DnsGetQueries
 ~~~~~~~~~~~~~
 
@@ -383,13 +443,23 @@ returns a bool
 TLS
 ---
 
-Initialize with:
+For log output, initialize with:
 
 ::
 
   function init (args)
       local needs = {}
       needs["protocol"] = "tls"
+      return needs
+  end
+
+For detection, initialization is as follows:
+
+::
+
+  function init (args)
+      local needs = {}
+      needs["tls"] = tostring(true)
       return needs
   end
 
@@ -519,13 +589,23 @@ JA3
 
 JA3 must be enabled in the Suricata config file (set 'app-layer.protocols.tls.ja3-fingerprints' to 'yes').
 
-Initialize with:
+For log output, initialize with:
 
 ::
 
   function init (args)
       local needs = {}
       needs["protocol"] = "tls"
+      return needs
+  end
+
+For detection, initialization is as follows:
+
+::
+
+  function init (args)
+      local needs = {}
+      needs["tls"] = tostring(true)
       return needs
   end
 
@@ -566,7 +646,7 @@ Ja3SGetHash
 
 Get the JA3S hash (md5sum of JA3S string) through JA3SGetHash.
 
-Example:
+Examples:
 
 ::
 
@@ -577,12 +657,27 @@ Example:
       end
   end
 
+Or, for detection:
+
+::
+
+  function match (args)
+      hash = Ja3SGetHash()
+      if hash == nil then
+        return 0
+      end
+
+      // matching code
+
+      return 0
+  end
+
 JA3SGetString
 ~~~~~~~~~~~~~
 
 Get the JA3S string through Ja3SGetString.
 
-Example:
+Examples:
 
 ::
 
@@ -593,13 +688,27 @@ Example:
       end
   end
 
+Or, for detection:
+
+::
+
+  function match (args)
+    str = Ja3SGetString()
+    if str == nil then
+      return 0
+    end
+
+    // matching code
+
+    return 0
+  end
+
 SSH
 ---
 
 Initialize with:
 
 ::
-
 
   function init (args)
       local needs = {}
@@ -631,7 +740,6 @@ Get SSH software used by the server through SshGetServerSoftwareVersion.
 Example:
 
 ::
-
 
   function log (args)
       software = SshGetServerSoftwareVersion()

--- a/doc/userguide/lua/lua-usage.rst
+++ b/doc/userguide/lua/lua-usage.rst
@@ -17,4 +17,4 @@ Lua can be used to write arbitrary output. See :ref:`lua-output` for more inform
 Lua detection
 -------------
 
-Lua script can be used as a filter condition in signatures. See :ref:`lua-scripting` for more information.
+Lua script can be used as a filter condition in signatures. See :ref:`lua-detection` for more information.

--- a/doc/userguide/lua/lua-usage.rst
+++ b/doc/userguide/lua/lua-usage.rst
@@ -4,8 +4,10 @@ Lua usage in Suricata
 Lua scripting can be used in two components of Suricata. The first is in
 output and the second one in rules in the detection engine.
 
-Both features are using a list of functions to access to data extracted by
+Both features are using a list of functions to access the data extracted by
 Suricata. You can get the list of functions in the :ref:`lua-functions` page.
+
+.. note:: Currently, there is a difference in the ``needs`` key in the ``init`` function, depending on what is the usage: ``output`` or ``detection``. The list of available functions may also differ.
 
 Lua output
 ----------

--- a/doc/userguide/output/lua-output.rst
+++ b/doc/userguide/output/lua-output.rst
@@ -10,7 +10,7 @@ define four hook functions.
 For lua output scripts suricata offers a wide range of lua functions.
 They all return information on specific engine internals and aspects of the network traffic.
 They are described in the following sections, grouped by the event/traffic type.
-But let's start with a example explaining the four hook functions, and how to make
+But let's start with an example explaining the four hook functions, and how to make
 suricata load a lua output script.
 
 Script structure

--- a/doc/userguide/rules/differences-from-snort.rst
+++ b/doc/userguide/rules/differences-from-snort.rst
@@ -492,7 +492,7 @@ Lua Scripting
    HTTP buffers, etc.
 -  Provides powerful flexibility and capabilities that Snort does
    not have.
--  :doc:`rule-lua-scripting`
+-  More details in: :ref:`lua-detection`
 
 Fast Pattern
 ------------

--- a/doc/userguide/rules/index.rst
+++ b/doc/userguide/rules/index.rst
@@ -36,5 +36,5 @@ Suricata Rules
    ip-reputation-rules
    config
    datasets
-   rule-lua-scripting
+   lua-detection
    differences-from-snort

--- a/doc/userguide/rules/lua-detection.rst
+++ b/doc/userguide/rules/lua-detection.rst
@@ -1,7 +1,7 @@
-.. _lua-scripting:
+.. _lua-detection:
 
-Lua Scripting
-=============
+Lua Scripting for Detection
+===========================
 
 Syntax:
 

--- a/doc/userguide/rules/rule-lua-scripting.rst
+++ b/doc/userguide/rules/rule-lua-scripting.rst
@@ -30,6 +30,14 @@ inspection. Currently the following are available:
 * packet -- entire packet, including headers
 * payload -- packet payload (not stream)
 * buffer -- the current sticky buffer
+* stream
+* dnp3
+* dns.request
+* dns.response
+* dns.rrname
+* ssh
+* smtp
+* tls
 * http.uri
 * http.uri.raw
 * http.request_line

--- a/doc/userguide/rules/rule-lua-scripting.rst
+++ b/doc/userguide/rules/rule-lua-scripting.rst
@@ -16,7 +16,6 @@ The script has 2 parts, an init function and a match function. First, the init.
 Init function
 -------------
 
-
 .. code-block:: lua
 
   function init (args)
@@ -88,3 +87,6 @@ Entire script:
   end
 
   return 0
+
+A comprehensive list of existing lua functions -  with examples - can be found at :ref:`lua-functions` (some of them, however,
+work only for the lua-output functionality). 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4725

Describe changes:
- add explanation about the difference in usage when writing output or detection script
- add some more examples showing how to initialize `need` in case of detection script
- rename _Lua Scripting_ page, in Rules section, to _Lua Scripting for Detection_, for better semantics
- update said page with other existing buffers for detection
- nit: fix typo in _Lua output_ page