### PR TITLE
rust(lint): use is_null() for null pointer checks

### DIFF
--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -48,7 +48,7 @@ pub fn conf_get(key: &str) -> Option<&str> {
         }
     }
 
-    if vptr == ptr::null() {
+    if vptr.is_null() {
         return None;
     }
 
@@ -103,7 +103,7 @@ impl ConfNode {
             }
         }
 
-        if vptr == ptr::null() {
+        if vptr.is_null() {
             return None;
         }
 


### PR DESCRIPTION
Based on Lint warning "cmp_null", use the method .is_null()
instead of comparing to ptr::null() or ptr::null_mut().

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/) ticket:
https://redmine.openinfosecfoundation.org/issues/4595
Ticket: #4595


Describe changes:
- Remove comparison with ptr::null() or ptr::null_mut() in null pointer checks
- Use .is_null() method instead

