### PR TITLE
rust: remove unnecessary nested match

### DIFF
--- a/rust/src/dhcp/logger.rs
+++ b/rust/src/dhcp/logger.rs
@@ -60,15 +60,8 @@ impl DHCPLogger {
     pub fn do_log(&self, tx: &DHCPTransaction) -> bool {
         if !self.extended {
             match self.get_type(tx) {
-                Some(t) => {
-                    match t {
-                        DHCP_TYPE_ACK => {
-                            return true;
-                        }
-                        _ => {}
-                    }
-                }
-                _ => {}
+                Some(DHCP_TYPE_ACK) => return true,
+                        _ => {},
             }
             return false;
         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -66,7 +66,6 @@
 #![allow(clippy::redundant_pattern_matching)]
 #![allow(clippy::inherent_to_string)]
 #![allow(clippy::field_reassign_with_default)]
-#![allow(clippy::collapsible_match)]
 
 #[macro_use]
 extern crate nom;


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to redmine ticket: https://redmine.openinfosecfoundation.org/issues/4605

This commit addresses rust "unnecessary_nested_match" clippy warnings.

Describe changes:

- Logger: Fix unnecessary_nested_match clippy warnings
- Remove #![allow(clippy::collapsible_match)] clippy lint from rust/src/lib.rs

ticket: #4605

Previous PR: #6503 