### PR TITLE
rust: fix (match_single_binding) clippy warning v2

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -51,7 +51,6 @@
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::enum_variant_names)]
 #![allow(clippy::if_same_then_else)]
-#![allow(clippy::match_single_binding)]
 #![allow(clippy::match_like_matches_macro)]
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::mixed_case_hex_literals)]

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -883,9 +883,8 @@ pub fn smb1_trans_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
                 let mut frankenfid = pipe.fid.to_vec();
                 frankenfid.extend_from_slice(&u32_as_bytes(r.ssn_id));
 
-                let (_filename, is_dcerpc) = match state.get_service_for_guid(&frankenfid) {
-                    (n, x) => (n, x),
-                };
+                let (n, x) = state.get_service_for_guid(&frankenfid);
+                let (_filename, is_dcerpc) = (n, x);
                 SCLogDebug!("smb1_trans_request_record: name {} is_dcerpc {}",
                         _filename, is_dcerpc);
                 pipe_dcerpc = is_dcerpc;
@@ -924,9 +923,8 @@ pub fn smb1_trans_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
             let mut frankenfid = fid.to_vec();
             frankenfid.extend_from_slice(&u32_as_bytes(r.ssn_id));
 
-            let (_filename, is_dcerpc) = match state.get_service_for_guid(&frankenfid) {
-                (n, x) => (n, x),
-            };
+            let (n, x) = state.get_service_for_guid(&frankenfid);
+            let (_filename, is_dcerpc) = (n, x);
             SCLogDebug!("smb1_trans_response_record: name {} is_dcerpc {}",
                     _filename, is_dcerpc);
 

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -168,9 +168,8 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     _ => { (Vec::new(), false) },
                 };
                 let mut is_dcerpc = if is_pipe || (share_name.len() == 0 && !is_pipe) {
-                    match state.get_service_for_guid(&file_guid) {
-                        (_, x) => x,
-                    }
+                    let (_, x) = state.get_service_for_guid(&file_guid);
+                    x
                 } else {
                     false
                 };
@@ -280,9 +279,8 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     _ => { (Vec::new(), false) },
                 };
                 let mut is_dcerpc = if is_pipe || (share_name.len() == 0 && !is_pipe) {
-                    match state.get_service_for_guid(wr.guid) {
-                        (_, x) => x,
-                    }
+                    let (_, x) = state.get_service_for_guid(wr.guid);
+                    x
                 } else {
                     false
                 };

--- a/rust/src/smb/smb2_ioctl.rs
+++ b/rust/src/smb/smb2_ioctl.rs
@@ -62,9 +62,9 @@ pub fn smb2_ioctl_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
     match parse_smb2_request_ioctl(r.data) {
         Ok((_, rd)) => {
             SCLogDebug!("IOCTL request data: {:?}", rd);
-            let is_dcerpc = rd.is_pipe && match state.get_service_for_guid(rd.guid) {
-                (_, x) => x,
-            };
+
+            let (_,x) = state.get_service_for_guid(rd.guid);
+            let is_dcerpc = rd.is_pipe && x;
             if is_dcerpc {
                 SCLogDebug!("IOCTL request data is_pipe. Calling smb_write_dcerpc_record");
                 let vercmd = SMBVerCmdStat::new2(SMB2_COMMAND_IOCTL);
@@ -90,9 +90,8 @@ pub fn smb2_ioctl_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
         Ok((_, rd)) => {
             SCLogDebug!("IOCTL response data: {:?}", rd);
 
-            let is_dcerpc = rd.is_pipe && match state.get_service_for_guid(rd.guid) {
-                (_, x) => x,
-            };
+            let (_, x) = state.get_service_for_guid(rd.guid);
+            let is_dcerpc = rd.is_pipe && x;
             if is_dcerpc {
                 SCLogDebug!("IOCTL response data is_pipe. Calling smb_read_dcerpc_record");
                 let vercmd = SMBVerCmdStat::new2_with_ntstatus(SMB2_COMMAND_IOCTL, r.nt_status);


### PR DESCRIPTION
`match` is better used with binding to multiple variables,
for binding to a single value, `let` statement is recommended.
Fixes clippy warning: `match_single_binding`

Fixes: #4616

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4616

Ticket: #4616
Prev-PR: #6496 

Describe changes:

- Fix match_single_binding warning
- Remove #[allow(clippy::match_single_binding)] from rust/src/lib.rs
