### PR TITLE
fix: smb dce_iface doesn't match rpc requests/responses

### DIFF
--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -180,6 +180,7 @@ pub fn smb_write_dcerpc_record<'b>(state: &mut SMBState,
         data: &'b [u8]) -> bool
 {
     let mut bind_ifaces : Option<Vec<DCERPCIface>> = None;
+    let mut is_bind = false;
 
     SCLogDebug!("called for {} bytes of data", data.len());
     match parse_dcerpc_record(data) {
@@ -259,6 +260,7 @@ pub fn smb_write_dcerpc_record<'b>(state: &mut SMBState,
                     };
                     match brec {
                         Ok((_, bindr)) => {
+                            is_bind = true;
                             SCLogDebug!("SMB DCERPC {:?} BIND {:?}", dcer, bindr);
 
                             if bindr.ifaces.len() > 0 {
@@ -304,7 +306,13 @@ pub fn smb_write_dcerpc_record<'b>(state: &mut SMBState,
         },
     }
 
-    state.dcerpc_ifaces = bind_ifaces; // TODO store per ssn
+    if is_bind {
+        // We have to write here the interfaces
+        // rather than in the BIND block
+        // due to borrow issues with the tx mutable reference
+        // that is part of the state
+        state.dcerpc_ifaces = bind_ifaces; // TODO store per ssn
+    }
     return true;
 }
 

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -19,6 +19,7 @@ use std::ptr;
 use crate::core::*;
 use crate::smb::smb::*;
 use crate::dcerpc::detect::{DCEIfaceData, DCEOpnumData, DETECT_DCE_OPNUM_RANGE_UNINITIALIZED};
+use crate::dcerpc::dcerpc::DCERPC_TYPE_REQUEST;
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_smb_tx_get_share(tx: &mut SMBTransaction,
@@ -172,7 +173,9 @@ pub extern "C" fn rs_smb_tx_get_dce_iface(state: &mut SMBState,
     let if_op = dce_data.op;
     let if_version = dce_data.version;
     let is_dcerpc_request = match tx.type_data {
-        Some(SMBTransactionTypeData::DCERPC(ref x)) => { x.req_cmd == 1 },
+        Some(SMBTransactionTypeData::DCERPC(ref x)) => {
+            x.req_cmd == DCERPC_TYPE_REQUEST
+        },
         _ => { false },
     };
     if !is_dcerpc_request {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4767](https://redmine.openinfosecfoundation.org/issues/4767)

The bug:
The smb dce_iface keyword must match for all those dcerpc requests and responses sent in the context of the given interface. They are not matching due to two problems:
- In `rs_smb_tx_get_dce_iface` the `x.req_cmd` is erroneously compared with 1. https://github.com/OISF/suricata/blob/master/rust/src/smb/detect.rs#L175
- In `smb_write_dcerpc_record`, the current bind interfaces are deleted by any non bind message. https://github.com/OISF/suricata/blob/master/rust/src/smb/dcerpc.rs#L307

Related SV test: https://github.com/OISF/suricata-verify/pull/569

Describe changes:
- compare `x.req_cmd` with the  DCERPC_TYPE_REQUEST constant
- protect the `state.dcerpc_ifaces ` from arbitrary writings