### PR TITLE
fix: smb dce_opnum doesn't match rpc requests/responses

### DIFF
--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -111,9 +111,9 @@ pub extern "C" fn rs_smb_tx_match_dce_opnum(tx: &mut SMBTransaction,
                     if range.range2 == DETECT_DCE_OPNUM_RANGE_UNINITIALIZED {
                         if range.range1 == x.opnum as u32 {
                             return 1;
-                        } else if range.range1 <= x.opnum as u32 && range.range2 >= x.opnum as u32 {
-                            return 1;
                         }
+                    } else if range.range1 <= x.opnum as u32 && range.range2 >= x.opnum as u32 {
+                        return 1;
                     }
                 }
             }

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -19,6 +19,7 @@ use std::ptr;
 use crate::core::*;
 use crate::smb::smb::*;
 use crate::dcerpc::detect::{DCEIfaceData, DCEOpnumData, DETECT_DCE_OPNUM_RANGE_UNINITIALIZED};
+use crate::dcerpc::dcerpc::DCERPC_TYPE_REQUEST;
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_smb_tx_get_share(tx: &mut SMBTransaction,
@@ -105,7 +106,7 @@ pub extern "C" fn rs_smb_tx_match_dce_opnum(tx: &mut SMBTransaction,
     SCLogDebug!("rs_smb_tx_get_dce_opnum: start");
     match tx.type_data {
         Some(SMBTransactionTypeData::DCERPC(ref x)) => {
-            if x.req_cmd == 1 { // REQUEST
+            if x.req_cmd == DCERPC_TYPE_REQUEST {
                 for range in dce_data.data.iter() {
                     if range.range2 == DETECT_DCE_OPNUM_RANGE_UNINITIALIZED {
                         if range.range1 == x.opnum as u32 {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/

[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4767

SV test: https://github.com/OISF/suricata-verify/pull/568

The dce_opnum keyword must match dcerpc requests and responses for a given opnum.

Bug 1:
The smb dce_opnum keyword doesn't match the dcerpc requests/responses. This occurs because in the `rs_smb_tx_match_dce_opnum` function, the x.req_cmd is matched against the erroneous code 1.
https://github.com/OISF/suricata/blob/master/rust/src/smb/detect.rs#L108


Bug 2:
After resolving the previous bug, another one was discovered. The smb dce_opnum matches all the opnums that are higher that the indicated opnum. This is due the range comparison if was put in the exact comparison context, and in case the opnum doesn't match exactly, then the range comparison is triggered (the upper limit is always true).
https://github.com/OISF/suricata/blob/master/rust/src/smb/detect.rs#L113

Describe changes:
- To solve bug 1: compare x.req_cmd with the DCERPC_TYPE_REQUEST constant
- To solve bug 2: move the erroneus if to the outer context, as else of option of the if that checks if comparison should be exact or range

