### PR TITLE
rust/app-layer: use generic tx iterator - v2

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -514,6 +514,14 @@ pub unsafe fn get_event_info_by_id<T: AppLayerEvent>(
 /// in order to define some generic helper functions.
 pub trait Transaction {
     fn id(&self) -> u64;
+
+    /// Get the app-layer decoder events from the transaction.
+    ///
+    /// A default implementation is provided for app-layer implememtations
+    /// that do not have decoder events.
+    fn get_events(&self) -> *mut AppLayerDecoderEvents {
+        std::ptr::null_mut()
+    }
 }
 
 pub trait State<Tx: Transaction> {
@@ -546,4 +554,9 @@ pub unsafe extern "C" fn state_get_tx_iterator<S: State<Tx>, Tx: Transaction>(
 ) -> AppLayerGetTxIterTuple {
     let state = cast_pointer!(state, S);
     state.get_transaction_iterator(min_tx_id, istate)
+}
+
+pub unsafe extern "C" fn tx_get_events<Tx: Transaction>(tx: *mut c_void) -> *mut AppLayerDecoderEvents {
+    let tx = cast_pointer!(tx, Tx);
+    tx.get_events()
 }

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -236,6 +236,12 @@ pub struct DNSTransaction {
     pub tx_data: AppLayerTxData,
 }
 
+impl Transaction for DNSTransaction {
+    fn id(&self) -> u64 {
+        self.id
+    }
+}
+
 impl DNSTransaction {
 
     pub fn new() -> Self {
@@ -334,6 +340,12 @@ pub struct DNSState {
     config: Option<ConfigTracker>,
 
     gap: bool,
+}
+
+impl State<DNSTransaction> for DNSState {
+    fn get_transactions(&self) -> &[DNSTransaction] {
+        &self.transactions
+    }
 }
 
 impl DNSState {
@@ -991,7 +1003,7 @@ pub unsafe extern "C" fn rs_dns_udp_register_parser() {
         localstorage_new: None,
         localstorage_free: None,
         get_files: None,
-        get_tx_iterator: None,
+        get_tx_iterator: Some(crate::applayer::state_get_tx_iterator::<DNSState, DNSTransaction>),
         get_de_state: rs_dns_state_get_tx_detect_state,
         set_de_state: rs_dns_state_set_tx_detect_state,
         get_tx_data: rs_dns_state_get_tx_data,
@@ -1037,7 +1049,7 @@ pub unsafe extern "C" fn rs_dns_tcp_register_parser() {
         localstorage_new: None,
         localstorage_free: None,
         get_files: None,
-        get_tx_iterator: None,
+        get_tx_iterator: Some(crate::applayer::state_get_tx_iterator::<DNSState, DNSTransaction>),
         get_de_state: rs_dns_state_get_tx_detect_state,
         set_de_state: rs_dns_state_set_tx_detect_state,
         get_tx_data: rs_dns_state_get_tx_data,

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -541,6 +541,12 @@ pub struct SMBTransaction {
     pub tx_data: AppLayerTxData,
 }
 
+impl Transaction for SMBTransaction {
+    fn id(&self) -> u64 {
+        self.id
+    }
+}
+
 impl SMBTransaction {
     pub fn new() -> Self {
         return Self {
@@ -772,6 +778,12 @@ pub struct SMBState<> {
     ts: u64,
 }
 
+impl State<SMBTransaction> for SMBState {
+    fn get_transactions(&self) -> &[SMBTransaction] {
+        &self.transactions
+    }
+}
+
 impl SMBState {
     /// Allocation function for a new TLS parser instance
     pub fn new() -> Self {
@@ -837,31 +849,6 @@ impl SMBState {
                     tx_id, tx_id+1, index, self.transactions.len(), self.tx_id);
             self.transactions.remove(index);
         }
-    }
-
-    // for use with the C API call StateGetTxIterator
-    pub fn get_tx_iterator(&mut self, min_tx_id: u64, state: &mut u64) ->
-        Option<(&SMBTransaction, u64, bool)>
-    {
-        let mut index = *state as usize;
-        let len = self.transactions.len();
-
-        // find tx that is >= min_tx_id
-        while index < len {
-            let tx = &self.transactions[index];
-            if tx.id < min_tx_id + 1 {
-                index += 1;
-                continue;
-            }
-            // store current index in the state and not the next
-            // as transactions might be freed between now and the
-            // next time we are called.
-            *state = index as u64;
-            //SCLogDebug!("returning tx_id {} has_next? {} (len {} index {}), tx {:?}",
-            //        tx.id - 1, (len - index) > 1, len, index, tx);
-            return Some((tx, tx.id - 1, (len - index) > 1));
-        }
-        return None;
     }
 
     pub fn get_tx_by_id(&mut self, tx_id: u64) -> Option<&SMBTransaction> {
@@ -2030,30 +2017,6 @@ pub unsafe extern "C" fn rs_smb_state_get_tx(state: *mut ffi::c_void,
     }
 }
 
-// for use with the C API call StateGetTxIterator
-#[no_mangle]
-pub unsafe extern "C" fn rs_smb_state_get_tx_iterator(
-                                               _ipproto: u8,
-                                               _alproto: AppProto,
-                                               state: *mut std::os::raw::c_void,
-                                               min_tx_id: u64,
-                                               _max_tx_id: u64,
-                                               istate: &mut u64,
-                                               ) -> applayer::AppLayerGetTxIterTuple
-{
-    let state = cast_pointer!(state, SMBState);
-    match state.get_tx_iterator(min_tx_id, istate) {
-        Some((tx, out_tx_id, has_next)) => {
-            let c_tx = tx as *const _ as *mut _;
-            let ires = applayer::AppLayerGetTxIterTuple::with_values(c_tx, out_tx_id, has_next);
-            return ires;
-        }
-        None => {
-            return applayer::AppLayerGetTxIterTuple::not_found();
-        }
-    }
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn rs_smb_state_tx_free(state: *mut ffi::c_void,
                                        tx_id: u64)
@@ -2243,7 +2206,7 @@ pub unsafe extern "C" fn rs_smb_register_parser() {
         localstorage_new: None,
         localstorage_free: None,
         get_files: Some(rs_smb_getfiles),
-        get_tx_iterator: Some(rs_smb_state_get_tx_iterator),
+        get_tx_iterator: Some(applayer::state_get_tx_iterator::<SMBState, SMBTransaction>),
         get_tx_data: rs_smb_get_tx_data,
         apply_tx_config: None,
         flags: APP_LAYER_PARSER_OPT_ACCEPT_GAPS,


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/6476

Changes from last PR:
- Convert SMB to use generic iterator
- Convert Modbux to use generic iterator

Also show how other FFI functions can be made generic like the getter for app-layer events from a transaction.

Redmine issue: https://redmine.openinfosecfoundation.org/issues/4748
