### PR TITLE
lua: Fix SCRule functions for match scripts v2.0

### DIFF
--- a/src/detect-lua-extensions.c
+++ b/src/detect-lua-extensions.c
@@ -481,8 +481,8 @@ static int LuaDecrFlowint(lua_State *luastate)
 
 }
 
-void LuaExtensionsMatchSetup(lua_State *lua_state, DetectLuaData *ld, DetectEngineThreadCtx *det_ctx,
-        Flow *f, Packet *p, uint8_t flags)
+void LuaExtensionsMatchSetup(lua_State *lua_state, DetectLuaData *ld,
+        DetectEngineThreadCtx *det_ctx, Flow *f, Packet *p, const Signature *s, uint8_t flags)
 {
     SCLogDebug("det_ctx %p, f %p", det_ctx, f);
 
@@ -490,6 +490,8 @@ void LuaExtensionsMatchSetup(lua_State *lua_state, DetectLuaData *ld, DetectEngi
     lua_pushlightuserdata(lua_state, (void *)&luaext_key_ld);
     lua_pushlightuserdata(lua_state, (void *)ld);
     lua_settable(lua_state, LUA_REGISTRYINDEX);
+
+    LuaStateSetSignature(lua_state, s);
 
     LuaStateSetFlow(lua_state, f);
 

--- a/src/detect-lua-extensions.h
+++ b/src/detect-lua-extensions.h
@@ -27,9 +27,8 @@
 #ifdef HAVE_LUA
 int LuaRegisterExtensions(lua_State *);
 
-void LuaExtensionsMatchSetup(lua_State *lua_state,
-        DetectLuaData *, DetectEngineThreadCtx *det_ctx,
-        Flow *f, Packet *p, uint8_t flags);
+void LuaExtensionsMatchSetup(lua_State *lua_state, DetectLuaData *, DetectEngineThreadCtx *det_ctx,
+        Flow *f, Packet *p, const Signature *s, uint8_t flags);
 
 #endif /* HAVE_LUA */
 #endif

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -231,8 +231,7 @@ int DetectLuaMatchBuffer(DetectEngineThreadCtx *det_ctx,
     if (tlua == NULL)
         SCReturnInt(0);
 
-    LuaExtensionsMatchSetup(tlua->luastate, lua, det_ctx,
-            f, /* no packet in the ctx */NULL, 0);
+    LuaExtensionsMatchSetup(tlua->luastate, lua, det_ctx, f, /* no packet in the ctx */ NULL, s, 0);
 
     /* prepare data to pass to script */
     lua_getglobal(tlua->luastate, "match");
@@ -347,8 +346,7 @@ static int DetectLuaMatch (DetectEngineThreadCtx *det_ctx,
 
     LuaStateSetThreadVars(tlua->luastate, det_ctx->tv);
 
-    LuaExtensionsMatchSetup(tlua->luastate, lua, det_ctx,
-            p->flow, p, flags);
+    LuaExtensionsMatchSetup(tlua->luastate, lua, det_ctx, p->flow, p, s, flags);
 
     if ((tlua->flags & DATATYPE_PAYLOAD) && p->payload_len == 0)
         SCReturnInt(0);
@@ -480,8 +478,7 @@ static int DetectLuaAppMatchCommon (DetectEngineThreadCtx *det_ctx,
         SCReturnInt(0);
 
     /* setup extension data for use in lua c functions */
-    LuaExtensionsMatchSetup(tlua->luastate, lua, det_ctx,
-            f, NULL, flags);
+    LuaExtensionsMatchSetup(tlua->luastate, lua, det_ctx, f, NULL, s, flags);
 
     if (tlua->alproto != ALPROTO_UNKNOWN) {
         int alproto = f->alproto;

--- a/src/util-lua.c
+++ b/src/util-lua.c
@@ -97,6 +97,8 @@ const char lua_ext_key_direction[] = "suricata:lua:direction";
 
 /* key for pa (packet alert) pointer */
 const char lua_ext_key_pa[] = "suricata:lua:pkt:alert:ptr";
+/* key for s (signature) pointer */
+const char lua_ext_key_s[] = "suricata:lua:signature:ptr";
 /* key for file pointer */
 const char lua_ext_key_file[] = "suricata:lua:file:ptr";
 /* key for streaming buffer pointer */
@@ -192,6 +194,22 @@ void LuaStateSetPacketAlert(lua_State *luastate, PacketAlert *pa)
 {
     lua_pushlightuserdata(luastate, (void *)&lua_ext_key_pa);
     lua_pushlightuserdata(luastate, (void *)pa);
+    lua_settable(luastate, LUA_REGISTRYINDEX);
+}
+
+/** \brief get signature pointer from the lua state */
+Signature *LuaStateGetSignature(lua_State *luastate)
+{
+    lua_pushlightuserdata(luastate, (void *)&lua_ext_key_s);
+    lua_gettable(luastate, LUA_REGISTRYINDEX);
+    void *s = lua_touserdata(luastate, -1);
+    return (Signature *)s;
+}
+
+void LuaStateSetSignature(lua_State *luastate, const Signature *s)
+{
+    lua_pushlightuserdata(luastate, (void *)&lua_ext_key_s);
+    lua_pushlightuserdata(luastate, (void *)s);
     lua_settable(luastate, LUA_REGISTRYINDEX);
 }
 

--- a/src/util-lua.h
+++ b/src/util-lua.h
@@ -63,6 +63,8 @@ Flow *LuaStateGetFlow(lua_State *luastate);
 
 PacketAlert *LuaStateGetPacketAlert(lua_State *luastate);
 
+Signature *LuaStateGetSignature(lua_State *luastate);
+
 /** \brief get file pointer from the lua state */
 File *LuaStateGetFile(lua_State *luastate);
 
@@ -82,6 +84,8 @@ void LuaStateSetTX(lua_State *luastate, void *tx);
 void LuaStateSetFlow(lua_State *luastate, Flow *f);
 
 void LuaStateSetPacketAlert(lua_State *luastate, PacketAlert *pa);
+
+void LuaStateSetSignature(lua_State *luastate, const Signature *s);
 
 void LuaStateSetFile(lua_State *luastate, File *file);
 


### PR DESCRIPTION

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [#2450](https://redmine.openinfosecfoundation.org/issues/2450)

Describe changes:
- Save Signature structure to lua register so SCRule functions can workin match scripts, where no PacketAlert is present
- Updated approach to ticket incorporating feedback from https://github.com/OISF/suricata/pull/6479
