### PR TITLE
Doc: Fix typo in documentation of rule keyword flow.

### DIFF
--- a/doc/userguide/rules/flow-keywords.rst
+++ b/doc/userguide/rules/flow-keywords.rst
@@ -58,7 +58,7 @@ flow
 
 The flow keyword can be used to match on direction of the flow, so to/from
 client or to/from server. It can also match if the flow is established or not.
-The flow keyword can also be use to say the signature has to match on stream
+The flow keyword can also be used to say the signature has to match on stream
 only (only_stream) or on packet only (no_stream).
 
 So with the flow keyword you can match on:


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
  Not applicable, since this is just a minor typo fix.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: Not applicable, since this is just a minor typo fix.

Describe changes:
- Fix small typo in documentation of the rule keyword "flow"

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
