### PR TITLE
ips: Add stats for additional capture methods

### DIFF
--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -154,6 +154,8 @@ typedef struct AFPPacketVars_
     int v6_map_fd;
     unsigned int nr_cpus;
 #endif
+
+    void *aftv;
 } AFPPacketVars;
 
 #ifdef HAVE_PACKET_EBPF


### PR DESCRIPTION
This PR adds IPS stats (blocked/accepted/dropped/rejected) to:
- Netmap
- AF-PACKET
- IPFW
- 
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4756](https://redmine.openinfosecfoundation.org/issues/4756)

Describe changes:
-  Adds a `CaptureStats` struct to each capture source's per-thread variable
- Invokes `CaptureStatsUpdate` with each packet to record status
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
