### PR TITLE
rust: use .is_null() method with null pointer checks v3

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -479,7 +479,7 @@ pub unsafe fn get_event_info<T: AppLayerEvent>(
     event_id: *mut std::os::raw::c_int,
     event_type: *mut core::AppLayerEventType,
 ) -> std::os::raw::c_int {
-    if event_name == std::ptr::null() {
+    if event_name.is_null() {
         return -1;
     }
 

--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -50,7 +50,7 @@ impl TemplateTransaction {
     }
 
     pub fn free(&mut self) {
-        if self.events != std::ptr::null_mut() {
+        if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
         }
         if let Some(state) = self.de_state {
@@ -287,7 +287,7 @@ pub unsafe extern "C" fn rs_template_probing_parser(
     _rdir: *mut u8
 ) -> AppProto {
     // Need at least 2 bytes.
-    if input_len > 1 && input != std::ptr::null_mut() {
+    if input_len > 1 && !input.is_null() {
         let slice = build_slice!(input, input_len as usize);
         if probe(slice).is_ok() {
             return ALPROTO_TEMPLATE;
@@ -340,7 +340,7 @@ pub unsafe extern "C" fn rs_template_parse_request(
 
     let state = cast_pointer!(state, TemplateState);
 
-    if input == std::ptr::null_mut() && input_len > 0 {
+    if input.is_null() && input_len > 0 {
         // Here we have a gap signaled by the input being null, but a greater
         // than 0 input_len which provides the size of the gap.
         state.on_request_gap(input_len);
@@ -368,7 +368,7 @@ pub unsafe extern "C" fn rs_template_parse_response(
     };
     let state = cast_pointer!(state, TemplateState);
 
-    if input == std::ptr::null_mut() && input_len > 0 {
+    if input.is_null() && input_len > 0 {
         // Here we have a gap signaled by the input being null, but a greater
         // than 0 input_len which provides the size of the gap.
         state.on_response_gap(input_len);

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -48,7 +48,7 @@ pub fn conf_get(key: &str) -> Option<&str> {
         }
     }
 
-    if vptr == ptr::null() {
+    if vptr.is_null() {
         return None;
     }
 
@@ -103,7 +103,7 @@ impl ConfNode {
             }
         }
 
-        if vptr == ptr::null() {
+        if vptr.is_null() {
             return None;
         }
 

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -1158,7 +1158,7 @@ pub unsafe extern "C" fn rs_dcerpc_parse_request(
     if flags & (core::STREAM_START|core::STREAM_MIDSTREAM) == (core::STREAM_START|core::STREAM_MIDSTREAM) {
         state.ts_gap = true;
     }
-    if input_len > 0 && input != std::ptr::null_mut() {
+    if input_len > 0 && !input.is_null() {
         let buf = build_slice!(input, input_len as usize);
         state.flow = Some(flow);
         return state.handle_input_data(buf, core::STREAM_TOSERVER);
@@ -1180,7 +1180,7 @@ pub unsafe extern "C" fn rs_dcerpc_parse_response(
         state.tc_gap = true;
     }
     if input_len > 0 {
-        if input != std::ptr::null_mut() {
+        if !input.is_null() {
             let buf = build_slice!(input, input_len as usize);
             state.flow = Some(flow);
             return state.handle_input_data(buf, core::STREAM_TOCLIENT);

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -210,7 +210,7 @@ pub unsafe extern "C" fn rs_dcerpc_udp_parse(
     input: *const u8, input_len: u32, _data: *const std::os::raw::c_void, _flags: u8,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, DCERPCUDPState);
-    if input_len > 0 && input != std::ptr::null_mut() {
+    if input_len > 0 && !input.is_null() {
         let buf = build_slice!(input, input_len as usize);
         return state.handle_input_data(buf);
     }

--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -288,7 +288,7 @@ pub unsafe extern "C" fn rs_dcerpc_iface_parse(carg: *const c_char) -> *mut c_vo
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_dcerpc_iface_free(ptr: *mut c_void) {
-    if ptr != std::ptr::null_mut() {
+    if !ptr.is_null() {
         std::mem::drop(Box::from_raw(ptr as *mut DCEIfaceData));
     }
 }
@@ -335,7 +335,7 @@ pub unsafe extern "C" fn rs_dcerpc_opnum_parse(carg: *const c_char) -> *mut c_vo
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_dcerpc_opnum_free(ptr: *mut c_void) {
-    if ptr != std::ptr::null_mut() {
+    if !ptr.is_null() {
         std::mem::drop(Box::from_raw(ptr as *mut DCEOpnumData));
     }
 }

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -96,7 +96,7 @@ impl DHCPTransaction {
     }
 
     pub fn free(&mut self) {
-        if self.events != std::ptr::null_mut() {
+        if !self.events.is_null() {
             sc_app_layer_decoder_events_free_events(&mut self.events);
         }
         match self.de_state {

--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -115,7 +115,7 @@ pub unsafe extern "C" fn rs_detect_dns_opcode_parse(carg: *const c_char) -> *mut
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_dns_detect_opcode_free(ptr: *mut c_void) {
-    if ptr != std::ptr::null_mut() {
+    if !ptr.is_null() {
         std::mem::drop(Box::from_raw(ptr as *mut DetectDnsOpcode));
     }
 }

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -250,7 +250,7 @@ impl DNSTransaction {
     }
 
     pub fn free(&mut self) {
-        if self.events != std::ptr::null_mut() {
+        if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
         }
         match self.de_state {
@@ -719,7 +719,7 @@ pub unsafe extern "C" fn rs_dns_parse_request_tcp(_flow: *const core::Flow,
                                            -> AppLayerResult {
     let state = cast_pointer!(state, DNSState);
     if input_len > 0 {
-        if input != std::ptr::null_mut() {
+        if !input.is_null() {
             let buf = std::slice::from_raw_parts(input, input_len as usize);
             return state.parse_request_tcp(buf);
         }
@@ -739,7 +739,7 @@ pub unsafe extern "C" fn rs_dns_parse_response_tcp(_flow: *const core::Flow,
                                             -> AppLayerResult {
     let state = cast_pointer!(state, DNSState);
     if input_len > 0 {
-        if input != std::ptr::null_mut() {
+        if !input.is_null() {
             let buf = std::slice::from_raw_parts(input, input_len as usize);
             return state.parse_response_tcp(buf);
         }

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -166,13 +166,13 @@ impl HTTP2Transaction {
     }
 
     pub fn free(&mut self) {
-        if self.events != std::ptr::null_mut() {
+        if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
         }
         if let Some(state) = self.de_state {
             core::sc_detect_engine_state_free(state);
         }
-        if self.file_range != std::ptr::null_mut() {
+        if !self.file_range.is_null() {
             match unsafe { SC } {
                 None => panic!("BUG no suricata_config"),
                 Some(c) => {
@@ -224,7 +224,7 @@ impl HTTP2Transaction {
                     match range::http2_parse_check_content_range(&value) {
                         Ok((_, v)) => {
                             range::http2_range_open(self, &v, flow, sfcm, flags, decompressed);
-                            if over && self.file_range != std::ptr::null_mut() {
+                            if over && !self.file_range.is_null() {
                                 range::http2_range_close(self, files, flags, &[])
                             }
                         }
@@ -234,7 +234,7 @@ impl HTTP2Transaction {
                     }
                 }
             } else {
-                if self.file_range != std::ptr::null_mut() {
+                if !self.file_range.is_null() {
                     if over {
                         range::http2_range_close(self, files, flags, decompressed)
                     } else {
@@ -1008,7 +1008,7 @@ export_tx_data_get!(rs_http2_get_tx_data, HTTP2Transaction);
 pub unsafe extern "C" fn rs_http2_probing_parser_tc(
     _flow: *const Flow, _direction: u8, input: *const u8, input_len: u32, _rdir: *mut u8,
 ) -> AppProto {
-    if input != std::ptr::null_mut() {
+    if !input.is_null() {
         let slice = build_slice!(input, input_len as usize);
         match parser::http2_parse_frame_header(slice) {
             Ok((_, header)) => {
@@ -1049,7 +1049,7 @@ pub extern "C" fn rs_http2_state_new(
     let state = HTTP2State::new();
     let boxed = Box::new(state);
     let r = Box::into_raw(boxed) as *mut _;
-    if orig_state != std::ptr::null_mut() {
+    if !orig_state.is_null() {
         //we could check ALPROTO_HTTP1 == orig_proto
         unsafe {
             HTTP2MimicHttp1Request(orig_state, r);

--- a/rust/src/ike/ike.rs
+++ b/rust/src/ike/ike.rs
@@ -129,7 +129,7 @@ impl IKETransaction {
     }
 
     pub fn free(&mut self) {
-        if self.events != std::ptr::null_mut() {
+        if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
         }
         if let Some(state) = self.de_state {
@@ -316,7 +316,7 @@ pub unsafe extern "C" fn rs_ike_probing_parser(
         return ALPROTO_FAILED;
     }
 
-    if input != std::ptr::null_mut() {
+    if !input.is_null() {
         let slice = build_slice!(input, input_len as usize);
         if probe(slice, direction, rdir) {
             return ALPROTO_IKE ;

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -630,7 +630,7 @@ pub unsafe extern "C" fn jb_open_array(js: &mut JsonBuilder, key: *const c_char)
 pub unsafe extern "C" fn jb_set_string(
     js: &mut JsonBuilder, key: *const c_char, val: *const c_char,
 ) -> bool {
-    if val == std::ptr::null() {
+    if val.is_null() {
         return false;
     }
     if let Ok(key) = CStr::from_ptr(key).to_str() {
@@ -645,7 +645,7 @@ pub unsafe extern "C" fn jb_set_string(
 pub unsafe extern "C" fn jb_set_string_from_bytes(
     js: &mut JsonBuilder, key: *const c_char, bytes: *const u8, len: u32,
 ) -> bool {
-    if bytes == std::ptr::null() || len == 0 {
+    if bytes.is_null() || len == 0 {
         return false;
     }
     if let Ok(key) = CStr::from_ptr(key).to_str() {
@@ -680,7 +680,7 @@ pub unsafe extern "C" fn jb_set_object(
 
 #[no_mangle]
 pub unsafe extern "C" fn jb_append_string(js: &mut JsonBuilder, val: *const c_char) -> bool {
-    if val == std::ptr::null() {
+    if val.is_null() {
         return false;
     }
     if let Ok(val) = CStr::from_ptr(val).to_str() {
@@ -693,7 +693,7 @@ pub unsafe extern "C" fn jb_append_string(js: &mut JsonBuilder, val: *const c_ch
 pub unsafe extern "C" fn jb_append_string_from_bytes(
     js: &mut JsonBuilder, bytes: *const u8, len: u32,
 ) -> bool {
-    if bytes == std::ptr::null() || len == 0 {
+    if bytes.is_null() || len == 0 {
         return false;
     }
     let val = std::slice::from_raw_parts(bytes, len as usize);

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -235,7 +235,7 @@ impl KRB5Transaction {
 
 impl Drop for KRB5Transaction {
     fn drop(&mut self) {
-        if self.events != std::ptr::null_mut() {
+        if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
         }
         if let Some(state) = self.de_state {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -41,7 +41,6 @@
 #![allow(clippy::for_loops_over_fallibles)]
 #![allow(clippy::needless_lifetimes)]
 #![allow(clippy::single_match)]
-#![allow(clippy::cmp_null)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::ptr_arg)]
 #![allow(clippy::new_without_default)]

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -84,7 +84,7 @@ impl MQTTTransaction {
     }
 
     pub fn free(&mut self) {
-        if self.events != std::ptr::null_mut() {
+        if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
         }
         if let Some(state) = self.de_state {

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -217,7 +217,7 @@ impl NFSTransaction {
     pub fn free(&mut self) {
         debug_validate_bug_on!(self.tx_data.files_opened > 1);
         debug_validate_bug_on!(self.tx_data.files_logged > 1);
-        if self.events != std::ptr::null_mut() {
+        if !self.events.is_null() {
             sc_app_layer_decoder_events_free_events(&mut self.events);
         }
         match self.de_state {

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -1649,7 +1649,7 @@ pub unsafe extern "C" fn rs_nfs_state_get_event_info(event_name: *const std::os:
                                               event_type: *mut AppLayerEventType)
                                               -> std::os::raw::c_int
 {
-    if event_name == std::ptr::null() {
+    if event_name.is_null() {
         return -1;
     }
     let c_event_name: &CStr = CStr::from_ptr(event_name);

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -149,7 +149,7 @@ impl NTPTransaction {
     }
 
     fn free(&mut self) {
-        if self.events != std::ptr::null_mut() {
+        if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
         }
     }

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -410,7 +410,7 @@ fn probe_rdp(input: &[u8]) -> bool {
 pub unsafe extern "C" fn rs_rdp_probe_ts_tc(
     _flow: *const Flow, _direction: u8, input: *const u8, input_len: u32, _rdir: *mut u8,
 ) -> AppProto {
-    if input != std::ptr::null_mut() {
+    if !input.is_null() {
         // probe bytes for `rdp` protocol pattern
         let slice = build_slice!(input, input_len as usize);
 

--- a/rust/src/rfb/rfb.rs
+++ b/rust/src/rfb/rfb.rs
@@ -75,7 +75,7 @@ impl RFBTransaction {
     }
 
     pub fn free(&mut self) {
-        if self.events != std::ptr::null_mut() {
+        if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
         }
         if let Some(state) = self.de_state {

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -149,7 +149,7 @@ impl SIPTransaction {
 
 impl Drop for SIPTransaction {
     fn drop(&mut self) {
-        if self.events != std::ptr::null_mut() {
+        if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
         }
         if let Some(state) = self.de_state {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -568,7 +568,7 @@ impl SMBTransaction {
     pub fn free(&mut self) {
         debug_validate_bug_on!(self.tx_data.files_opened > 1);
         debug_validate_bug_on!(self.tx_data.files_logged > 1);
-        if self.events != std::ptr::null_mut() {
+        if !self.events.is_null() {
             sc_app_layer_decoder_events_free_events(&mut self.events);
         }
         match self.de_state {

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -267,7 +267,7 @@ impl<'a> SNMPTransaction<'a> {
     }
 
     fn free(&mut self) {
-        if self.events != std::ptr::null_mut() {
+        if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
         }
     }

--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -99,7 +99,7 @@ impl SSHTransaction {
     }
 
     pub fn free(&mut self) {
-        if self.events != std::ptr::null_mut() {
+        if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
         }
         if let Some(state) = self.de_state {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4595

Ticket: #4595
Prev-PR: #6522 

Describe changes:

- Use `is_null()` with null pointer checks
- Remove `#![allow(clippy::cmp_null)]` clippy lint from `rust/src/lib.rs`