### PR TITLE
rust: fix (match_single_binding) clippy warning v5

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -51,7 +51,6 @@
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::enum_variant_names)]
 #![allow(clippy::if_same_then_else)]
-#![allow(clippy::match_single_binding)]
 #![allow(clippy::match_like_matches_macro)]
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::mixed_case_hex_literals)]

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -883,9 +883,8 @@ pub fn smb1_trans_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
                 let mut frankenfid = pipe.fid.to_vec();
                 frankenfid.extend_from_slice(&u32_as_bytes(r.ssn_id));
 
-                let (_filename, is_dcerpc) = match state.get_service_for_guid(&frankenfid) {
-                    (n, x) => (n, x),
-                };
+                let (_filename, is_dcerpc) = state.get_service_for_guid(&frankenfid);
+
                 SCLogDebug!("smb1_trans_request_record: name {} is_dcerpc {}",
                         _filename, is_dcerpc);
                 pipe_dcerpc = is_dcerpc;
@@ -924,9 +923,8 @@ pub fn smb1_trans_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
             let mut frankenfid = fid.to_vec();
             frankenfid.extend_from_slice(&u32_as_bytes(r.ssn_id));
 
-            let (_filename, is_dcerpc) = match state.get_service_for_guid(&frankenfid) {
-                (n, x) => (n, x),
-            };
+            let (_filename, is_dcerpc) = state.get_service_for_guid(&frankenfid);
+
             SCLogDebug!("smb1_trans_response_record: name {} is_dcerpc {}",
                     _filename, is_dcerpc);
 

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -168,9 +168,7 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     _ => { (Vec::new(), false) },
                 };
                 let mut is_dcerpc = if is_pipe || (share_name.len() == 0 && !is_pipe) {
-                    match state.get_service_for_guid(&file_guid) {
-                        (_, x) => x,
-                    }
+                    state.get_service_for_guid(&file_guid).1
                 } else {
                     false
                 };
@@ -280,9 +278,7 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     _ => { (Vec::new(), false) },
                 };
                 let mut is_dcerpc = if is_pipe || (share_name.len() == 0 && !is_pipe) {
-                    match state.get_service_for_guid(wr.guid) {
-                        (_, x) => x,
-                    }
+                    state.get_service_for_guid(wr.guid).1
                 } else {
                     false
                 };

--- a/rust/src/smb/smb2_ioctl.rs
+++ b/rust/src/smb/smb2_ioctl.rs
@@ -62,8 +62,10 @@ pub fn smb2_ioctl_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
     match parse_smb2_request_ioctl(r.data) {
         Ok((_, rd)) => {
             SCLogDebug!("IOCTL request data: {:?}", rd);
-            let is_dcerpc = rd.is_pipe && match state.get_service_for_guid(rd.guid) {
-                (_, x) => x,
+            let is_dcerpc = if rd.is_pipe {
+                state.get_service_for_guid(rd.guid).1
+            } else {
+                false
             };
             if is_dcerpc {
                 SCLogDebug!("IOCTL request data is_pipe. Calling smb_write_dcerpc_record");
@@ -90,8 +92,10 @@ pub fn smb2_ioctl_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
         Ok((_, rd)) => {
             SCLogDebug!("IOCTL response data: {:?}", rd);
 
-            let is_dcerpc = rd.is_pipe && match state.get_service_for_guid(rd.guid) {
-                (_, x) => x,
+            let is_dcerpc = if rd.is_pipe {
+                state.get_service_for_guid(rd.guid).1
+            } else {
+                false
             };
             if is_dcerpc {
                 SCLogDebug!("IOCTL response data is_pipe. Calling smb_read_dcerpc_record");


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4616

Ticket: #4616
Prev-PR: #6521 

Describe changes:

- Use `let` for binding to single value
- Restrict `get_service_for_guid()` execution to condition `rd.is_pipe == true`
- Remove clippy lint `#![allow(clippy::match_single_binding)]` from `lib.rs`
