### PR TITLE
loopback: decodes IPv6 from all OSes

### DIFF
--- a/src/decode-null.c
+++ b/src/decode-null.c
@@ -45,6 +45,13 @@
 
 #define HDR_SIZE 4
 
+#define AF_INET6_BSD     24
+#define AF_INET6_FREEBSD 28
+#define AF_INET6_DARWIN  30
+#define AF_INET6_LINUX   10
+#define AF_INET6_SOLARIS 26
+#define AF_INET6_WINSOCK 23
+
 int DecodeNull(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         const uint8_t *pkt, uint32_t len, PacketQueue *pq)
 {
@@ -68,7 +75,12 @@ int DecodeNull(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             SCLogDebug("IPV4 Packet");
             DecodeIPV4(tv, dtv, p, GET_PKT_DATA(p)+HDR_SIZE, GET_PKT_LEN(p)-HDR_SIZE, pq);
             break;
-        case AF_INET6:
+        case AF_INET6_BSD:
+        case AF_INET6_FREEBSD:
+        case AF_INET6_DARWIN:
+        case AF_INET6_LINUX:
+        case AF_INET6_SOLARIS:
+        case AF_INET6_WINSOCK:
             SCLogDebug("IPV6 Packet");
             DecodeIPV6(tv, dtv, p, GET_PKT_DATA(p)+HDR_SIZE, GET_PKT_LEN(p)-HDR_SIZE, pq);
             break;


### PR DESCRIPTION
As does wireshark

(cherry picked from commit 27b4f165b17499cc765ccb770f1cf994992e10f6)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4794](https://redmine.openinfosecfoundation.org/issues/4794)

Describe changes:
- [4794](https://redmine.openinfosecfoundation.org/issues/4794) cherry-pick


#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
