### PR TITLE
rust: fix inherent to string

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -64,7 +64,6 @@
 #![allow(clippy::branches_sharing_code)]
 #![allow(clippy::while_let_loop)]
 #![allow(clippy::redundant_pattern_matching)]
-#![allow(clippy::inherent_to_string)]
 #![allow(clippy::field_reassign_with_default)]
 #![allow(clippy::collapsible_match)]
 

--- a/rust/src/smb/ntlmssp_records.rs
+++ b/rust/src/smb/ntlmssp_records.rs
@@ -15,6 +15,7 @@
  * 02110-1301, USA.
  */
 
+use std::fmt;
 use nom::IResult;
 use nom::combinator::rest;
 use nom::number::streaming::{le_u8, le_u16, le_u32};
@@ -27,9 +28,9 @@ pub struct NTLMSSPVersion {
     pub ver_ntlm_rev: u8,
 }
 
-impl NTLMSSPVersion {
-    pub fn to_string(&self) -> String {
-        format!("{}.{} build {} rev {}",
+impl fmt::Display for NTLMSSPVersion {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}.{} build {} rev {}",
                 self.ver_major, self.ver_minor,
                 self.ver_build, self.ver_ntlm_rev)
     }


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to redmine ticket:
https://redmine.openinfosecfoundation.org/issues/4618

Ticket: #4618
Prev-PR: #6516 

Describe changes:

- ntlmssp_records:-Add fix to inherent_to_string warning
- Remove #!allow(clippy::inherent_to_string) clippy lint from rust/src/lib.rs