### PR TITLE
Detect rfb secresult fail/pass 4055 v1

### DIFF
--- a/src/detect-rfb-secresult.c
+++ b/src/detect-rfb-secresult.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -268,14 +268,13 @@ void DetectRfbSecresultFree(DetectEngineCtx *de_ctx, void *de_ptr)
  */
 static int RfbSecresultTestParse01 (void)
 {
-    DetectRfbSecresultData *de = NULL;
-    de = DetectRfbSecresultParse("fail");
-    if (de) {
-        DetectRfbSecresultFree(NULL, de);
-        return 1;
-    }
+    DetectRfbSecresultData *de = DetectRfbSecresultParse("fail");
 
-    return 0;
+    FAIL_IF_NULL(de);
+
+    DetectRfbSecresultFree(NULL, de);
+
+    PASS;
 }
 
 /**
@@ -286,14 +285,13 @@ static int RfbSecresultTestParse01 (void)
  */
 static int RfbSecresultTestParse02 (void)
 {
-    DetectRfbSecresultData *de = NULL;
-    de = DetectRfbSecresultParse("invalidopt");
-    if (de) {
-        DetectRfbSecresultFree(NULL, de);
-        return 0;
-    }
+    DetectRfbSecresultData *de = DetectRfbSecresultParse("invalidopt");
 
-    return 1;
+    FAIL_IF_NOT_NULL(de);
+
+    DetectRfbSecresultFree(NULL, de);
+
+    PASS;
 }
 
 /**


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to redmine ticket:
https://redmine.openinfosecfoundation.org/issues/4055

Ticket: #4055

Describe changes:
- Update Detect rfb secresult unittests to use FAIL/PASS APIs
- Update Copyright Year