### PR TITLE
detect/payload: convert unittests to FAIL/PASS APIs v1

### DIFF
--- a/src/detect-engine-payload.c
+++ b/src/detect-engine-payload.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2017 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -373,20 +373,15 @@ static int PayloadTestSig01 (void)
     uint8_t *buf = (uint8_t *)
                     "abcabcd";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (content:\"abc\"; content:\"d\"; distance:0; within:1; sid:1;)";
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
+
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 /** \test Nocase matching */
@@ -395,20 +390,15 @@ static int PayloadTestSig02 (void)
     uint8_t *buf = (uint8_t *)
                     "abcaBcd";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (content:\"abc\"; nocase; content:\"d\"; distance:0; within:1; sid:1;)";
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
+
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 /** \test Negative distance matching */
@@ -417,20 +407,15 @@ static int PayloadTestSig03 (void)
     uint8_t *buf = (uint8_t *)
                     "abcaBcd";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (content:\"aBc\"; nocase; content:\"abca\"; distance:-10; within:4; sid:1;)";
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
+
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 /**
@@ -440,22 +425,17 @@ static int PayloadTestSig04(void)
 {
     uint8_t *buf = (uint8_t *)"now this is is big big string now";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"this\"; content:\"is\"; within:6; content:\"big\"; within:8; "
         "content:\"string\"; within:8; sid:1;)";
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
+
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 /**
@@ -465,22 +445,17 @@ static int PayloadTestSig05(void)
 {
     uint8_t *buf = (uint8_t *)"now this is is is big big big string now";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"this\"; content:\"is\"; within:9; content:\"big\"; within:12; "
         "content:\"string\"; within:8; sid:1;)";
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
+
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 /**
@@ -490,22 +465,17 @@ static int PayloadTestSig06(void)
 {
     uint8_t *buf = (uint8_t *)"this this now is is     big string now";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"now\"; content:\"this\"; content:\"is\"; within:12; content:\"big\"; within:8; "
         "content:\"string\"; within:8; sid:1;)";
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
+
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 /**
@@ -515,22 +485,16 @@ static int PayloadTestSig07(void)
 {
     uint8_t *buf = (uint8_t *)"         thus thus is a big";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"thus\"; offset:8; content:\"is\"; within:6; content:\"big\"; within:8; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 /**
@@ -541,21 +505,16 @@ static int PayloadTestSig08(void)
 {
     uint8_t *buf = (uint8_t *)"we need to fix this and yes fix this now";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"fix\"; content:\"this\"; within:6; content:!\"and\"; distance:0; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) != 1) {
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) != 1);
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 /**
@@ -565,22 +524,16 @@ static int PayloadTestSig09(void)
 {
     uint8_t *buf = (uint8_t *)"this is a super duper nova in super nova now";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "pcre:/super/; content:\"nova\"; within:7; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 /**
@@ -590,22 +543,16 @@ static int PayloadTestSig10(void)
 {
     uint8_t *buf = (uint8_t *)"this is a super duper nova in super nova now";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert udp any any -> any any (msg:\"crash\"; "
         "byte_test:4,>,2,0,relative; sid:11;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 1) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 1);
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 /**
@@ -615,22 +562,16 @@ static int PayloadTestSig11(void)
 {
     uint8_t *buf = (uint8_t *)"this is a super duper nova in super nova now";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert udp any any -> any any (msg:\"crash\"; "
         "byte_jump:1,0,relative; sid:11;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 1) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 1);
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 /**
@@ -640,22 +581,16 @@ static int PayloadTestSig12(void)
 {
     uint8_t *buf = (uint8_t *)"this is a super duper nova in super nova now";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert udp any any -> any any (msg:\"crash\"; "
         "isdataat:10,relative; sid:11;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 1) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 1);
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 /**
@@ -683,75 +618,46 @@ static int PayloadTestSig13(void)
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
     uint16_t mpm_type = mpm_default_matcher;
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"aa\"; content:\"aa\"; distance:0; content:\"aa\"; distance:0; "
         "byte_test:1,>,200,0,relative; sid:1;)";
 
-    struct timeval tv_start, tv_end, tv_diff;
+    DecodeThreadVars dtv;
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx = NULL;
 
-    gettimeofday(&tv_start, NULL);
+    memset(&dtv, 0, sizeof(DecodeThreadVars));
+    memset(&th_v, 0, sizeof(th_v));
 
-    do {
-        DecodeThreadVars dtv;
-        ThreadVars th_v;
-        DetectEngineThreadCtx *det_ctx = NULL;
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
 
-        memset(&dtv, 0, sizeof(DecodeThreadVars));
-        memset(&th_v, 0, sizeof(th_v));
+    de_ctx->inspection_recursion_limit = 3000;
 
-        DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-        if (de_ctx == NULL) {
-            printf("de_ctx == NULL: ");
-            goto end;
-        }
-        de_ctx->inspection_recursion_limit = 3000;
+    de_ctx->flags |= DE_QUIET;
+    de_ctx->mpm_matcher = mpm_type;
 
-        de_ctx->flags |= DE_QUIET;
-        de_ctx->mpm_matcher = mpm_type;
+    de_ctx->sig_list = SigInit(de_ctx, sig);
+    FAIL_IF_NULL(de_ctx->sig_list);
 
-        de_ctx->sig_list = SigInit(de_ctx, sig);
-        if (de_ctx->sig_list == NULL) {
-            printf("signature == NULL: ");
-            goto end;
-        }
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
-        SigGroupBuild(de_ctx);
-        DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
 
-        SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-        if (PacketAlertCheck(p, de_ctx->sig_list->id) != 1) {
-            goto end;
-        }
+    FAIL_IF_NOT(PacketAlertCheck(p, de_ctx->sig_list->id) != 1);
 
-        result = 1;
-    end:
-        SigGroupCleanup(de_ctx);
-        SigCleanSignatures(de_ctx);
+    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    DetectEngineCtxFree(de_ctx);
 
-        if (det_ctx != NULL)
-            DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    UTHFreePacket(p);
 
-        if (de_ctx != NULL)
-            DetectEngineCtxFree(de_ctx);
-    } while (0);
-
-    gettimeofday(&tv_end, NULL);
-
-    tv_diff.tv_sec = tv_end.tv_sec - tv_start.tv_sec;
-    tv_diff.tv_usec = tv_end.tv_usec - tv_start.tv_usec;
-
-    printf("%ld.%06ld\n", (long int)tv_diff.tv_sec, (long int)tv_diff.tv_usec);
-
-    result = 1;
-
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    PASS;
 }
 
 /**
@@ -761,92 +667,66 @@ static int PayloadTestSig14(void)
 {
     uint8_t *buf = (uint8_t *)"User-Agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.1b4) Gecko/20090423 Firefox/3.6 GTB5";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (content:\"User-Agent|3A| Mozilla/5.0 |28|Macintosh|3B| \"; content:\"Firefox/3.\"; distance:0; content:!\"Firefox/3.6.12\"; distance:-10; content:!\"Mozilla/5.0 |28|Macintosh|3B| U|3B| Intel Mac OS X 10.5|3B| en-US|3B| rv|3A|1.9.1b4|29| Gecko/20090423 Firefox/3.6 GTB5\"; sid:1; rev:1;)";
 
     //char sig[] = "alert tcp any any -> any any (content:\"User-Agent: Mozilla/5.0 (Macintosh; \"; content:\"Firefox/3.\"; distance:0; content:!\"Firefox/3.6.12\"; distance:-10; content:!\"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.1b4) Gecko/20090423 Firefox/3.6 GTB5\"; sid:1; rev:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 1) {
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 1);
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 static int PayloadTestSig15(void)
 {
     uint8_t *buf = (uint8_t *)"this is a super duper nova in super nova now";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"nova\"; isdataat:18,relative; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
 
-    result = 1;
+    UTHFreePacket(p);
 
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    PASS;
 }
 
 static int PayloadTestSig16(void)
 {
     uint8_t *buf = (uint8_t *)"this is a super duper nova in super nova now";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"nova\"; isdataat:!20,relative; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
 
-    result = 1;
+    UTHFreePacket(p);
 
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    PASS;
 }
 
 static int PayloadTestSig17(void)
 {
     uint8_t buf[] = { 0xEB, 0x29, 0x25, 0x38, 0x78, 0x25, 0x38, 0x78, 0x25 };
     uint16_t buflen = 9;
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"%\"; depth:4; offset:0; "
         "content:\"%\"; within:2; distance:1; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
 
-    result = 1;
+    UTHFreePacket(p);
 
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    PASS;
 }
 
 static int PayloadTestSig18(void)
@@ -857,25 +737,18 @@ static int PayloadTestSig18(void)
         0x0E, 0x0F,
     };
     uint16_t buflen = sizeof(buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"|01 02 03 04|\"; "
         "byte_extract:1,2,one,string,dec,relative; "
         "content:\"|0C 0D 0E 0F|\"; distance:one; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
 
-    result = 1;
+    UTHFreePacket(p);
 
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    PASS;
 }
 
 static int PayloadTestSig19(void)
@@ -886,25 +759,18 @@ static int PayloadTestSig19(void)
         0x0E, 0x0F,
     };
     uint16_t buflen = sizeof(buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"|01 02 03 04|\"; "
         "byte_extract:1,2,one,string,hex,relative; "
         "content:\"|0C 0D 0E 0F|\"; distance:one; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
 
-    result = 1;
+    UTHFreePacket(p);
 
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    PASS;
 }
 
 static int PayloadTestSig20(void)
@@ -915,25 +781,18 @@ static int PayloadTestSig20(void)
         0x0E, 0x0F,
     };
     uint16_t buflen = sizeof(buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"|01 02 03 04|\"; "
         "byte_extract:1,2,one,string,dec,relative; "
         "content:\"|06 35 07 08|\"; offset:one; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
 
-    result = 1;
+    UTHFreePacket(p);
 
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    PASS;
 }
 
 static int PayloadTestSig21(void)
@@ -944,25 +803,18 @@ static int PayloadTestSig21(void)
         0x0E, 0x0F,
     };
     uint16_t buflen = sizeof(buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"|01 02 03 04|\"; "
         "byte_extract:1,2,one,string,dec,relative; "
         "content:\"|03 04 05 06|\"; depth:one; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
 
-    result = 1;
+    UTHFreePacket(p);
 
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    PASS;
 }
 
 static int PayloadTestSig22(void)
@@ -973,25 +825,18 @@ static int PayloadTestSig22(void)
         0x0E, 0x0F,
     };
     uint16_t buflen = sizeof(buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"|01 02 03 04|\"; "
         "byte_extract:1,2,one,string,dec,relative; "
         "content:\"|09 0A 0B 0C|\"; within:one; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
 
-    result = 1;
+    UTHFreePacket(p);
 
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    PASS;
 }
 
 static int PayloadTestSig23(void)
@@ -1002,8 +847,7 @@ static int PayloadTestSig23(void)
         0x32, 0x0F,
     };
     uint16_t buflen = sizeof(buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"|01 02 03 04|\"; "
@@ -1011,17 +855,11 @@ static int PayloadTestSig23(void)
         "byte_extract:1,3,two,string,dec,relative; "
         "byte_test:1,=,one,two,string,dec,relative; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
 
-    result = 1;
+    UTHFreePacket(p);
 
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    PASS;
 }
 
 static int PayloadTestSig24(void)
@@ -1032,8 +870,7 @@ static int PayloadTestSig24(void)
         0x0E, 0x0F,
     };
     uint16_t buflen = sizeof(buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"|01 02 03 04|\"; "
@@ -1041,17 +878,11 @@ static int PayloadTestSig24(void)
         "byte_jump:1,one,string,dec,relative; "
         "content:\"|0D 0E 0F|\"; distance:0; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
 
-    result = 1;
+    UTHFreePacket(p);
 
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    PASS;
 }
 
 /*
@@ -1065,25 +896,18 @@ static int PayloadTestSig25(void)
         0x0E, 0x0F,
     };
     uint16_t buflen = sizeof(buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"|35 07 08 09|\"; "
         "byte_extract:1,-4,one,string,dec,relative; "
         "content:\"|0C 0D 0E 0F|\"; distance:one; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
 
-    result = 1;
+    UTHFreePacket(p);
 
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    PASS;
 }
 
 /*
@@ -1097,25 +921,18 @@ static int PayloadTestSig26(void)
         0x0E, 0x0F,
     };
     uint16_t buflen = sizeof(buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"|35 07 08 09|\"; "
         "byte_extract:1,-3000,one,string,dec,relative; "
         "content:\"|0C 0D 0E 0F|\"; distance:one; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) != 0) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) != 0);
 
-    result = 1;
+    UTHFreePacket(p);
 
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    PASS;
 }
 
 /*
@@ -1125,23 +942,17 @@ static int PayloadTestSig27(void)
 {
     uint8_t buf[] = "dummypayload";
     uint16_t buflen = sizeof(buf) - 1;
-    int result = 0;
-
     Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (content:\"dummy\"; "
         "depth:5; sid:1;)";
 
     p->flags |= PKT_STREAM_ADD;
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) != 1)
-        goto end;
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) != 1);
 
-    result = 1;
+    UTHFreePacket(p);
 
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    PASS;
 }
 
 /*
@@ -1151,23 +962,17 @@ static int PayloadTestSig28(void)
 {
     uint8_t buf[] = "dummypayload";
     uint16_t buflen = sizeof(buf) - 1;
-    int result = 0;
-
     Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (content:\"payload\"; "
         "offset:4; depth:12; sid:1;)";
 
     p->flags |= PKT_STREAM_ADD;
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) != 1)
-        goto end;
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) != 1);
 
-    result = 1;
+    UTHFreePacket(p);
 
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    PASS;
 }
 
 /**
@@ -1177,22 +982,16 @@ static int PayloadTestSig29(void)
 {
     uint8_t *buf = (uint8_t *)"this is a super dupernova in super nova now";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (msg:\"dummy\"; "
         "pcre:/^.{4}/; content:\"nova\"; within:4; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 1) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 1);
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 static int PayloadTestSig30(void)
@@ -1200,20 +999,15 @@ static int PayloadTestSig30(void)
     uint8_t *buf = (uint8_t *)
                     "xyonexxxxxxtwojunkonetwo";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (content:\"one\"; pcre:\"/^two/R\"; sid:1;)";
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
+
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 static int PayloadTestSig31(void)
@@ -1221,20 +1015,15 @@ static int PayloadTestSig31(void)
     uint8_t *buf = (uint8_t *)
                     "xyonexxxxxxtwojunkonetwo";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = UTHBuildPacket( buf, buflen, IPPROTO_TCP);
-    int result = 0;
+    Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
 
     char sig[] = "alert tcp any any -> any any (content:\"one\"; pcre:\"/(fiv|^two)/R\"; sid:1;)";
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0) {
-        result = 0;
-        goto end;
-    }
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
+
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 /**
@@ -1245,19 +1034,15 @@ static int PayloadTestSig32(void)
     uint8_t *buf = (uint8_t *)"dummy2xxcardmessage";
     uint16_t buflen = strlen((char *)buf);
     Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
-    int result = 0;
 
     char sig[] = "alert tcp any any -> any any (msg:\"crash\"; "
         "content:\"message\"; byte_jump:2,-14,string,dec,relative; content:\"card\"; within:4; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0)
-        goto end;
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 /**
@@ -1268,19 +1053,15 @@ static int PayloadTestSig33(void)
     uint8_t *buf = (uint8_t *)"dummy2xxcardmessage";
     uint16_t buflen = strlen((char *)buf);
     Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
-    int result = 0;
 
     char sig[] = "alert tcp any any -> any any (msg:\"crash\"; "
         "content:\"message\"; byte_test:1,=,2,-14,string,dec,relative; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0)
-        goto end;
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 /**
@@ -1291,19 +1072,15 @@ static int PayloadTestSig34(void)
     uint8_t *buf = (uint8_t *)"dummy2xxcardmessage";
     uint16_t buflen = strlen((char *)buf);
     Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
-    int result = 0;
 
     char sig[] = "alert tcp any any -> any any (msg:\"crash\"; "
         "content:\"message\"; byte_extract:1,-14,boom,string,dec,relative; sid:1;)";
 
-    if (UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0)
-        goto end;
+    FAIL_IF(UTHPacketMatchSigMpm(p, sig, mpm_default_matcher) == 0);
 
-    result = 1;
-end:
-    if (p != NULL)
-        UTHFreePacket(p);
-    return result;
+    UTHFreePacket(p);
+
+    PASS;
 }
 
 #endif /* UNITTESTS */


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [#4026](https://redmine.openinfosecfoundation.org/issues/4026)

Describe changes:
- Convert unittests `PayloadTestSig*` to use `FAIL/PASS` APIs
- Cleanup unittests
- Update Copyright Year
