### PR TITLE
detect-gid: convert unittests to FAIL/PASS APIs

### DIFF
--- a/src/detect-gid.c
+++ b/src/detect-gid.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -99,77 +99,50 @@ static int DetectGidSetup (DetectEngineCtx *de_ctx, Signature *s, const char *ra
 #ifdef UNITTESTS
 /**
  * \test GidTestParse01 is a test for a  valid gid value
- *
- *  \retval 1 on succces
- *  \retval 0 on failure
  */
 static int GidTestParse01 (void)
 {
-    int result = 0;
-    Signature *s = NULL;
-
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
+    FAIL_IF_NULL(de_ctx);
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 any -> any any (sid:1; gid:1;)");
-    if (s == NULL || s->gid != 1)
-        goto end;
+    Signature *s =
+            DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 any -> any any (sid:1; gid:1;)");
 
-    result = 1;
-end:
-    if (de_ctx != NULL)
-        DetectEngineCtxFree(de_ctx);
-    return result;
+    FAIL_IF_NULL(s);
+    FAIL_IF(s->gid != 1);
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
 }
 
 /**
  * \test GidTestParse02 is a test for an invalid gid value
- *
- *  \retval 1 on succces
- *  \retval 0 on failure
  */
 static int GidTestParse02 (void)
 {
-    int result = 0;
-
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
+    FAIL_IF_NULL(de_ctx);
 
-    if (DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 any -> any any (sid:1; gid:a;)") != NULL)
-        goto end;
+    FAIL_IF_NOT_NULL(
+            DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 any -> any any (sid:1; gid:a;)"));
 
-    result = 1;
-end:
-    if (de_ctx != NULL)
-        DetectEngineCtxFree(de_ctx);
-    return result;
+    DetectEngineCtxFree(de_ctx);
+    PASS;
 }
 
 /**
  * \test Test a gid consisting of a single quote.
- *
- * \retval 1 on succces
- * \retval 0 on failure
  */
 static int GidTestParse03 (void)
 {
-    int result = 0;
-
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
+    FAIL_IF_NULL(de_ctx);
 
-    if (DetectEngineAppendSig(de_ctx,
-            "alert tcp any any -> any any (content:\"ABC\"; gid:\";)") != NULL)
-        goto end;
+    FAIL_IF_NOT_NULL(DetectEngineAppendSig(
+            de_ctx, "alert tcp any any -> any any (content:\"ABC\"; gid:\";)"));
 
-    result = 1;
-end:
-    if (de_ctx != NULL)
-        DetectEngineCtxFree(de_ctx);
-    return result;
+    DetectEngineCtxFree(de_ctx);
+    PASS;
 }
 
 /**


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to redmine ticket:
https://redmine.openinfosecfoundation.org/issues/4041

Ticket: #4041

Describe changes:

- Update detect-gid unit tests to use FAIL/PASS APIs
- Update Copyright Year