### PR TITLE
Enum dir rust/v9

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -19,6 +19,7 @@
 
 use std;
 use crate::filecontainer::*;
+use crate::debug_validate_fail;
 
 /// Opaque C types.
 pub enum DetectEngineState {}
@@ -38,6 +39,42 @@ pub const STREAM_TOCLIENT: u8 = 0x08;
 pub const STREAM_GAP:      u8 = 0x10;
 pub const STREAM_DEPTH:    u8 = 0x20;
 pub const STREAM_MIDSTREAM:u8 = 0x40;
+pub const DIR_BOTH:        u8 = 0b0000_1100;
+const DIR_TOSERVER:        u8 = 0b0000_0100;
+const DIR_TOCLIENT:        u8 = 0b0000_1000;
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum Direction {
+    ToServer = 0x04,
+    ToClient = 0x08,
+}
+
+impl Default for Direction {
+    fn default() -> Self { Direction::ToServer }
+}
+
+impl From<u8> for Direction {
+    fn from(d: u8) -> Self {
+        if d & (DIR_TOSERVER | DIR_TOCLIENT) == (DIR_TOSERVER | DIR_TOCLIENT) {
+            debug_validate_fail!("Both directions are set");
+            Direction::ToServer
+        } else if d & DIR_TOSERVER != 0 {
+            Direction::ToServer
+        } else if d & DIR_TOCLIENT != 0 {
+            Direction::ToClient
+        } else {
+            debug_validate_fail!("Unknown direction!!");
+            Direction::ToServer
+        }
+    }
+}
+
+impl From<Direction> for u8 {
+    fn from(d: Direction) -> u8 {
+        d as u8
+    }
+}
 
 // Application layer protocol identifiers (app-layer-protos.h)
 pub type AppProto = u16;

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -34,8 +34,6 @@ pub const APP_LAYER_EVENT_TYPE_PACKET      : i32 = 2;
 // From stream.h.
 pub const STREAM_START:    u8 = 0x01;
 pub const STREAM_EOF:      u8 = 0x02;
-pub const STREAM_TOSERVER: u8 = 0x04;
-pub const STREAM_TOCLIENT: u8 = 0x08;
 pub const STREAM_GAP:      u8 = 0x10;
 pub const STREAM_DEPTH:    u8 = 0x20;
 pub const STREAM_MIDSTREAM:u8 = 0x40;

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -321,8 +321,8 @@ pub struct DCERPCState {
     pub bytes_consumed: u16,
     pub tx_id: u64,
     pub query_completed: bool,
-    pub data_needed_for_dir: u8,
-    pub prev_dir: u8,
+    pub data_needed_for_dir: Direction,
+    pub prev_dir: Direction,
     pub prev_tx_call_id: u32,
     pub clear_bind_cache: bool,
     pub ts_gap: bool,
@@ -337,8 +337,8 @@ pub struct DCERPCState {
 impl DCERPCState {
     pub fn new() -> Self {
         return Self {
-            data_needed_for_dir: core::STREAM_TOSERVER,
-            prev_dir: core::STREAM_TOSERVER,
+            data_needed_for_dir: Direction::ToServer,
+            prev_dir: Direction::ToServer,
             ..Default::default()
         }
     }
@@ -450,13 +450,13 @@ impl DCERPCState {
         return 0;
     }
 
-    pub fn clean_buffer(&mut self, direction: u8) {
+    pub fn clean_buffer(&mut self, direction: Direction) {
         match direction {
-            core::STREAM_TOSERVER => {
+            Direction::ToServer => {
                 self.buffer_ts.clear();
                 self.ts_gap = false;
             }
-            _ => {
+            Direction::ToClient => {
                 self.buffer_tc.clear();
                 self.tc_gap = false;
             }
@@ -464,23 +464,23 @@ impl DCERPCState {
         self.bytes_consumed = 0;
     }
 
-    pub fn extend_buffer(&mut self, buffer: &[u8], direction: u8) {
+    pub fn extend_buffer(&mut self, buffer: &[u8], direction: Direction) {
         match direction {
-            core::STREAM_TOSERVER => {
+            Direction::ToServer => {
                 self.buffer_ts.extend_from_slice(buffer);
             }
-            _ => {
+            Direction::ToClient => {
                 self.buffer_tc.extend_from_slice(buffer);
             }
         }
         self.data_needed_for_dir = direction;
     }
 
-    pub fn reset_direction(&mut self, direction: u8) {
-        if direction == core::STREAM_TOSERVER {
-            self.data_needed_for_dir = core::STREAM_TOCLIENT;
+    pub fn reset_direction(&mut self, direction: Direction) {
+        if direction == Direction::ToServer {
+            self.data_needed_for_dir = Direction::ToClient;
         } else {
-            self.data_needed_for_dir = core::STREAM_TOSERVER;
+            self.data_needed_for_dir = Direction::ToServer;
         }
     }
 
@@ -513,24 +513,24 @@ impl DCERPCState {
     ///             type: unsigned 32 bit integer
     ///      description: call_id param derived from TCP Header
     /// * `dir`:
-    ///         type: unsigned 8 bit integer
+    ///         type: enum Direction
     ///  description: direction of the flow
     ///
     /// Return value:
     /// Option mutable reference to DCERPCTransaction
-    pub fn get_tx_by_call_id(&mut self, call_id: u32, dir: u8) -> Option<&mut DCERPCTransaction> {
+    pub fn get_tx_by_call_id(&mut self, call_id: u32, dir: Direction) -> Option<&mut DCERPCTransaction> {
         let cmd = self.get_hdr_type().unwrap_or(0);
         for tx in &mut self.transactions {
             let found = tx.call_id == call_id;
             if found {
                 match dir {
-                    core::STREAM_TOSERVER => {
+                    Direction::ToServer => {
                         let resp_cmd = get_resp_type_for_req(cmd);
                         if resp_cmd != tx.resp_cmd {
                             continue;
                         }
                     }
-                    _ => {
+                    Direction::ToClient => {
                         let req_cmd = get_req_type_for_resp(cmd);
                         if req_cmd != tx.req_cmd {
                             continue;
@@ -556,13 +556,13 @@ impl DCERPCState {
         self.prev_tx_call_id = call_id;
     }
 
-    pub fn parse_data_gap(&mut self, direction: u8) -> AppLayerResult {
+    pub fn parse_data_gap(&mut self, direction: Direction) -> AppLayerResult {
         match direction {
-            core::STREAM_TOSERVER => {
+            Direction::ToServer => {
                 self.ts_gap = true;
                 self.ts_ssn_gap = true;
             },
-            _ => {
+            Direction::ToClient => {
                 self.tc_gap = true;
                 self.tc_ssn_gap = true;
             },
@@ -570,9 +570,9 @@ impl DCERPCState {
         AppLayerResult::ok()
     }
 
-    pub fn post_gap_housekeeping(&mut self, dir: u8) {
+    pub fn post_gap_housekeeping(&mut self, dir: Direction) {
         SCLogDebug!("ts ssn gap: {:?}, tc ssn gap: {:?}, dir: {:?}", self.ts_ssn_gap, self.tc_ssn_gap, dir);
-        if self.ts_ssn_gap && dir == core::STREAM_TOSERVER {
+        if self.ts_ssn_gap && dir == Direction::ToServer {
             for tx in &mut self.transactions {
                 if tx.id >= self.tx_id {
                     SCLogDebug!("post_gap_housekeeping: done");
@@ -583,10 +583,10 @@ impl DCERPCState {
                 }
                 tx.req_done = true;
                 if let Some(flow) = self.flow {
-                    sc_app_layer_parser_trigger_raw_stream_reassembly(flow, dir.into());
+                    sc_app_layer_parser_trigger_raw_stream_reassembly(flow, dir as i32);
                 }
             }
-        } else if self.tc_ssn_gap && dir == core::STREAM_TOCLIENT {
+        } else if self.tc_ssn_gap && dir == Direction::ToClient {
             for tx in &mut self.transactions {
                 if tx.id >= self.tx_id {
                     SCLogDebug!("post_gap_housekeeping: done");
@@ -601,7 +601,7 @@ impl DCERPCState {
                 tx.req_done = true;
                 tx.resp_done = true;
                 if let Some(flow) = self.flow {
-                    sc_app_layer_parser_trigger_raw_stream_reassembly(flow, dir.into());
+                    sc_app_layer_parser_trigger_raw_stream_reassembly(flow, dir as i32);
                 }
             }
         }
@@ -716,7 +716,7 @@ impl DCERPCState {
                 tx.req_cmd = self.get_hdr_type().unwrap_or(0);
                 tx.req_done = true;
                 if let Some(flow) = self.flow {
-                    sc_app_layer_parser_trigger_raw_stream_reassembly(flow, core::STREAM_TOSERVER.into());
+                    sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToServer as i32);
                 }
                 tx.frag_cnt_ts = 1;
                 self.transactions.push(tx);
@@ -772,7 +772,7 @@ impl DCERPCState {
         }
     }
 
-    pub fn handle_stub_data(&mut self, input: &[u8], input_len: u16, dir: u8) -> u16 {
+    pub fn handle_stub_data(&mut self, input: &[u8], input_len: u16, dir: Direction) -> u16 {
         let retval;
         let hdrpfcflags = self.get_hdr_pfcflags().unwrap_or(0);
         let padleft = self.padleft;
@@ -801,7 +801,7 @@ impl DCERPCState {
                     tx.req_done = true;
                     tx.frag_cnt_ts = 1;
                     if let Some(flow) = self.flow {
-                        sc_app_layer_parser_trigger_raw_stream_reassembly(flow, core::STREAM_TOSERVER.into());
+                        sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToServer as i32);
                     }
                 }
                 DCERPC_TYPE_RESPONSE => {
@@ -816,7 +816,7 @@ impl DCERPCState {
                     tx.resp_done = true;
                     tx.frag_cnt_tc = 1;
                     if let Some(flow) = self.flow {
-                        sc_app_layer_parser_trigger_raw_stream_reassembly(flow, core::STREAM_TOCLIENT.into());
+                        sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToClient as i32);
                     }
                 }
                 _ => {
@@ -844,13 +844,13 @@ impl DCERPCState {
     ///           type: 16 bit unsigned integer.
     ///    description: bytes consumed *after* parsing header.
     /// * `dir`:
-    ///           type: 8 bit unsigned integer.
+    ///           type: enum Direction.
     ///    description: direction whose stub is supposed to be handled.
     ///
     /// Return value:
     /// * Success: Number of bytes successfully parsed.
     /// * Failure: -1 in case fragment length defined by header mismatches the data.
-    pub fn handle_common_stub(&mut self, input: &[u8], bytes_consumed: u16, dir: u8) -> i32 {
+    pub fn handle_common_stub(&mut self, input: &[u8], bytes_consumed: u16, dir: Direction) -> i32 {
         let fraglen = self.get_hdr_fraglen().unwrap_or(0);
         if fraglen < bytes_consumed as u16 + DCERPC_HDR_LEN {
             return -1;
@@ -866,7 +866,7 @@ impl DCERPCState {
             } else if input_left > 0 {
                 SCLogDebug!(
                     "Error parsing DCERPC {} stub data",
-                    if dir == core::STREAM_TOSERVER {
+                    if dir == Direction::ToServer {
                         "request"
                     } else {
                         "response"
@@ -885,7 +885,7 @@ impl DCERPCState {
             Ok((leftover_input, request)) => {
                 let call_id = self.get_hdr_call_id().unwrap_or(0);
                 let hdr_type = self.get_hdr_type().unwrap_or(0);
-                let mut transaction = self.get_tx_by_call_id(call_id, core::STREAM_TOSERVER);
+                let mut transaction = self.get_tx_by_call_id(call_id, Direction::ToServer);
                 match transaction {
                     Some(ref mut tx) => {
                         tx.req_cmd = hdr_type;
@@ -905,7 +905,7 @@ impl DCERPCState {
                 let parsed = self.handle_common_stub(
                     input,
                     (input.len() - leftover_input.len()) as u16,
-                    core::STREAM_TOSERVER,
+                    Direction::ToServer,
                 );
                 parsed
             }
@@ -922,7 +922,7 @@ impl DCERPCState {
         }
     }
 
-    pub fn handle_input_data(&mut self, input: &[u8], direction: u8) -> AppLayerResult {
+    pub fn handle_input_data(&mut self, input: &[u8], direction: Direction) -> AppLayerResult {
         let mut parsed;
         let retval;
         let mut cur_i = input;
@@ -932,7 +932,7 @@ impl DCERPCState {
         self.query_completed = false;
 
         // Skip the record since this means that its in the middle of a known length record
-        if (self.ts_gap && direction == core::STREAM_TOSERVER) || (self.tc_gap && direction == core::STREAM_TOCLIENT) {
+        if (self.ts_gap && direction == Direction::ToServer) || (self.tc_gap && direction == Direction::ToClient) {
             SCLogDebug!("Trying to catch up after GAP (input {})", cur_i.len());
             match self.search_dcerpc_record(cur_i) {
                 Ok((_, pg)) => {
@@ -940,10 +940,10 @@ impl DCERPCState {
                     let offset = cur_i.len() - pg.len();
                     cur_i = &cur_i[offset..];
                     match direction {
-                        core::STREAM_TOSERVER => {
+                        Direction::ToServer => {
                             self.ts_gap = false;
                         },
-                        _ => {
+                        Direction::ToClient => {
                             self.tc_gap = false;
                         }
                     }
@@ -969,7 +969,7 @@ impl DCERPCState {
         }
 
         let buffer = match direction {
-            core::STREAM_TOSERVER => {
+            Direction::ToServer => {
                 if self.buffer_ts.len() + input_len > 1024 * 1024 {
                     SCLogDebug!("DCERPC TOSERVER stream: Buffer Overflow");
                     return AppLayerResult::err();
@@ -978,7 +978,7 @@ impl DCERPCState {
                 v.extend_from_slice(cur_i);
                 v.as_slice()
             }
-            _ => {
+            Direction::ToClient => {
                 if self.buffer_tc.len() + input_len > 1024 * 1024 {
                     SCLogDebug!("DCERPC TOCLIENT stream: Buffer Overflow");
                     return AppLayerResult::err();
@@ -1037,7 +1037,7 @@ impl DCERPCState {
                     if retval == -1 {
                         return AppLayerResult::err();
                     }
-                    let tx = if let Some(tx) = self.get_tx_by_call_id(current_call_id, core::STREAM_TOCLIENT) {
+                    let tx = if let Some(tx) = self.get_tx_by_call_id(current_call_id, Direction::ToClient) {
                         tx.resp_cmd = x;
                         tx
                     } else {
@@ -1049,7 +1049,7 @@ impl DCERPCState {
                     tx.resp_done = true;
                     tx.frag_cnt_tc = 1;
                     if let Some(flow) = self.flow {
-                        sc_app_layer_parser_trigger_raw_stream_reassembly(flow, core::STREAM_TOCLIENT.into());
+                        sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToClient as i32);
                     }
                     self.handle_bind_cache(current_call_id, false);
                 }
@@ -1063,7 +1063,7 @@ impl DCERPCState {
                     self.handle_bind_cache(current_call_id, false);
                 }
                 DCERPC_TYPE_RESPONSE => {
-                    let transaction = self.get_tx_by_call_id(current_call_id, core::STREAM_TOCLIENT);
+                    let transaction = self.get_tx_by_call_id(current_call_id, Direction::ToClient);
                     match transaction {
                         Some(tx) => {
                             tx.resp_cmd = x;
@@ -1077,7 +1077,7 @@ impl DCERPCState {
                     retval = self.handle_common_stub(
                         &buffer[parsed as usize..],
                         0,
-                        core::STREAM_TOCLIENT,
+                        Direction::ToClient,
                     );
                     if retval < 0 {
                         return AppLayerResult::err();
@@ -1132,7 +1132,7 @@ pub extern "C" fn rs_parse_dcerpc_request_gap(
     state: &mut DCERPCState,
     _input_len: u32,
 ) -> AppLayerResult {
-    state.parse_data_gap(core::STREAM_TOSERVER)
+    state.parse_data_gap(Direction::ToServer)
 }
 
 #[no_mangle]
@@ -1140,7 +1140,7 @@ pub extern "C" fn rs_parse_dcerpc_response_gap(
     state: &mut DCERPCState,
     _input_len: u32,
 ) -> AppLayerResult {
-    state.parse_data_gap(core::STREAM_TOCLIENT)
+    state.parse_data_gap(Direction::ToClient)
 }
 
 #[no_mangle]
@@ -1161,7 +1161,7 @@ pub unsafe extern "C" fn rs_dcerpc_parse_request(
     if input_len > 0 && !input.is_null() {
         let buf = build_slice!(input, input_len as usize);
         state.flow = Some(flow);
-        return state.handle_input_data(buf, core::STREAM_TOSERVER);
+        return state.handle_input_data(buf, Direction::ToServer);
     }
     AppLayerResult::err()
 }
@@ -1183,7 +1183,7 @@ pub unsafe extern "C" fn rs_dcerpc_parse_response(
         if !input.is_null() {
             let buf = build_slice!(input, input_len as usize);
             state.flow = Some(flow);
-            return state.handle_input_data(buf, core::STREAM_TOCLIENT);
+            return state.handle_input_data(buf, Direction::ToClient);
         }
     }
     AppLayerResult::err()
@@ -1211,24 +1211,27 @@ pub unsafe extern "C" fn rs_dcerpc_state_transaction_free(state: *mut std::os::r
 #[no_mangle]
 pub unsafe extern "C" fn rs_dcerpc_state_trunc(state: *mut std::os::raw::c_void, direction: u8) {
     let dce_state = cast_pointer!(state, DCERPCState);
-    if direction & core::STREAM_TOSERVER != 0 {
-        dce_state.ts_ssn_trunc = true;
-        for tx in &mut dce_state.transactions {
-            tx.req_done = true;
-            if let Some(flow) = dce_state.flow {
-                sc_app_layer_parser_trigger_raw_stream_reassembly(flow, core::STREAM_TOSERVER.into());
+    match direction.into() {
+        Direction::ToServer =>  {
+            dce_state.ts_ssn_trunc = true;
+            for tx in &mut dce_state.transactions {
+                tx.req_done = true;
+                if let Some(flow) = dce_state.flow {
+                    sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToServer as i32);
+                }
             }
+            SCLogDebug!("dce_state.ts_ssn_trunc = true; txs {}", dce_state.transactions.len());
         }
-        SCLogDebug!("dce_state.ts_ssn_trunc = true; txs {}", dce_state.transactions.len());
-    } else if direction & core::STREAM_TOCLIENT != 0 {
-        dce_state.tc_ssn_trunc = true;
-        for tx in &mut dce_state.transactions {
-            tx.resp_done = true;
-            if let Some(flow) = dce_state.flow {
-                sc_app_layer_parser_trigger_raw_stream_reassembly(flow, core::STREAM_TOCLIENT.into());
+        Direction::ToClient => {
+            dce_state.tc_ssn_trunc = true;
+            for tx in &mut dce_state.transactions {
+                tx.resp_done = true;
+                if let Some(flow) = dce_state.flow {
+                    sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToClient as i32);
+                }
             }
+            SCLogDebug!("dce_state.tc_ssn_trunc = true; txs {}", dce_state.transactions.len());
         }
-        SCLogDebug!("dce_state.tc_ssn_trunc = true; txs {}", dce_state.transactions.len());
     }
 }
 
@@ -1273,10 +1276,10 @@ pub unsafe extern "C" fn rs_dcerpc_get_tx_cnt(vtx: *mut std::os::raw::c_void) ->
 pub unsafe extern "C" fn rs_dcerpc_get_alstate_progress(tx: *mut std::os::raw::c_void, direction: u8
                                                  )-> std::os::raw::c_int {
     let tx = cast_pointer!(tx, DCERPCTransaction);
-    if direction == core::STREAM_TOSERVER && tx.req_done {
+    if direction == Direction::ToServer.into() && tx.req_done {
         SCLogDebug!("tx {} TOSERVER progress 1 => {:?}", tx.call_id, tx);
         return 1;
-    } else if direction == core::STREAM_TOCLIENT && tx.resp_done {
+    } else if direction == Direction::ToClient.into() && tx.resp_done {
         SCLogDebug!("tx {} TOCLIENT progress 1 => {:?}", tx.call_id, tx);
         return 1;
     }
@@ -1297,13 +1300,13 @@ pub unsafe extern "C" fn rs_dcerpc_get_tx_data(
 pub unsafe extern "C" fn rs_dcerpc_get_stub_data(
     tx: &mut DCERPCTransaction, buf: *mut *const u8, len: *mut u32, endianness: *mut u8, dir: u8,
 ) {
-    match dir {
-        core::STREAM_TOSERVER => {
+    match dir.into() {
+        Direction::ToServer => {
             *len = tx.stub_data_buffer_ts.len() as u32;
             *buf = tx.stub_data_buffer_ts.as_ptr();
             SCLogDebug!("DCERPC Request stub buffer: Setting buffer to: {:?}", *buf);
         }
-        _ => {
+        Direction::ToClient => {
             *len = tx.stub_data_buffer_tc.len() as u32;
             *buf = tx.stub_data_buffer_tc.as_ptr();
             SCLogDebug!("DCERPC Response stub buffer: Setting buffer to: {:?}", *buf);
@@ -1339,12 +1342,12 @@ pub unsafe extern "C" fn rs_dcerpc_probe_tcp(_f: *const core::Flow, direction: u
     let (is_dcerpc, is_request, ) = probe(slice);
     if is_dcerpc {
         let dir = if is_request {
-            core::STREAM_TOSERVER
+            Direction::ToServer
         } else {
-            core::STREAM_TOCLIENT
+            Direction::ToClient
         };
-        if direction & (core::STREAM_TOSERVER|core::STREAM_TOCLIENT) != dir {
-            *rdir = dir;
+        if (direction & DIR_BOTH) != dir as u8 {
+            *rdir = dir as u8;
         }
         return ALPROTO_DCERPC;
     }
@@ -1355,13 +1358,13 @@ fn register_pattern_probe() -> i8 {
     unsafe {
         if AppLayerProtoDetectPMRegisterPatternCSwPP(IPPROTO_TCP as u8, ALPROTO_DCERPC,
                                                      b"|05 00|\0".as_ptr() as *const std::os::raw::c_char, 2, 0,
-                                                     core::STREAM_TOSERVER, rs_dcerpc_probe_tcp, 0, 0) < 0 {
+                                                     Direction::ToServer.into(), rs_dcerpc_probe_tcp, 0, 0) < 0 {
             SCLogDebug!("TOSERVER => AppLayerProtoDetectPMRegisterPatternCSwPP FAILED");
             return -1;
         }
         if AppLayerProtoDetectPMRegisterPatternCSwPP(IPPROTO_TCP as u8, ALPROTO_DCERPC,
                                                      b"|05 00|\0".as_ptr() as *const std::os::raw::c_char, 2, 0,
-                                                     core::STREAM_TOCLIENT, rs_dcerpc_probe_tcp, 0, 0) < 0 {
+                                                     Direction::ToClient.into(), rs_dcerpc_probe_tcp, 0, 0) < 0 {
             SCLogDebug!("TOCLIENT => AppLayerProtoDetectPMRegisterPatternCSwPP FAILED");
             return -1;
         }
@@ -1437,7 +1440,7 @@ pub unsafe extern "C" fn rs_dcerpc_register_parser() {
 #[cfg(test)]
 mod tests {
     use crate::applayer::AppLayerResult;
-    use crate::core;
+    use crate::core::*;
     use crate::dcerpc::dcerpc::DCERPCState;
     use std::cmp;
 
@@ -1864,7 +1867,7 @@ mod tests {
         let mut dcerpc_state = DCERPCState::new();
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(request, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(request, Direction::ToServer)
         );
         if let Some(hdr) = dcerpc_state.header {
             assert_eq!(0, hdr.hdrtype);
@@ -1900,11 +1903,11 @@ mod tests {
         let mut dcerpc_state = DCERPCState::new();
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(bind1, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(bind1, Direction::ToServer)
         );
         assert_eq!(
             AppLayerResult::ok(), // TODO ASK if this is correct?
-            dcerpc_state.handle_input_data(bind2, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(bind2, Direction::ToServer)
         );
     }
 
@@ -1970,11 +1973,11 @@ mod tests {
         let mut dcerpc_state = DCERPCState::new();
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(bind1, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(bind1, Direction::ToServer)
         );
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(bind2, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(bind2, Direction::ToServer)
         );
         if let Some(ref bind) = dcerpc_state.bind {
             assert_eq!(16, bind.numctxitems);
@@ -1994,15 +1997,15 @@ mod tests {
         let mut dcerpc_state = DCERPCState::new();
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(request1, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(request1, Direction::ToServer)
         );
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(request2, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(request2, Direction::ToServer)
         );
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(request3, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(request3, Direction::ToServer)
         );
         let tx = &dcerpc_state.transactions[0];
         assert_eq!(20, tx.stub_data_buffer_ts.len());
@@ -2018,7 +2021,7 @@ mod tests {
         let mut dcerpc_state = DCERPCState::new();
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(request1, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(request1, Direction::ToServer)
         );
     }
 
@@ -2032,7 +2035,7 @@ mod tests {
         let mut dcerpc_state = DCERPCState::new();
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(request1, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(request1, Direction::ToServer)
         );
     }
 
@@ -2052,15 +2055,15 @@ mod tests {
         let mut dcerpc_state = DCERPCState::new();
         assert_eq!(
             AppLayerResult::err(),
-            dcerpc_state.handle_input_data(fault, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(fault, Direction::ToServer)
         );
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(request1, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(request1, Direction::ToServer)
         );
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(request2, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(request2, Direction::ToServer)
         );
         let tx = &dcerpc_state.transactions[0];
         assert_eq!(12, tx.stub_data_buffer_ts.len());
@@ -2082,15 +2085,15 @@ mod tests {
         let mut dcerpc_state = DCERPCState::new();
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(request1, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(request1, Direction::ToServer)
         );
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(request2, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(request2, Direction::ToServer)
         );
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(request3, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(request3, Direction::ToServer)
         );
     }
 
@@ -2107,14 +2110,14 @@ mod tests {
             0x00, 0x00,
         ];
         let mut dcerpc_state = DCERPCState::new();
-        dcerpc_state.data_needed_for_dir = core::STREAM_TOCLIENT;
+        dcerpc_state.data_needed_for_dir = Direction::ToClient;
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(bind_ack1, core::STREAM_TOCLIENT)
+            dcerpc_state.handle_input_data(bind_ack1, Direction::ToClient)
         );
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(bind_ack2, core::STREAM_TOCLIENT)
+            dcerpc_state.handle_input_data(bind_ack2, Direction::ToClient)
         );
     }
 
@@ -2137,7 +2140,7 @@ mod tests {
         ];
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(bindbuf, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(bindbuf, Direction::ToServer)
         );
         if let Some(ref bind) = dcerpc_state.bind {
             let bind_uuid = &bind.uuid_list[0].uuid;
@@ -2171,7 +2174,7 @@ mod tests {
         let mut dcerpc_state = DCERPCState::new();
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(bindbuf, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(bindbuf, Direction::ToServer)
         );
     }
 
@@ -2188,10 +2191,10 @@ mod tests {
             0xFF,
         ];
         let mut dcerpc_state = DCERPCState::new();
-        dcerpc_state.data_needed_for_dir = core::STREAM_TOCLIENT;
+        dcerpc_state.data_needed_for_dir = Direction::ToClient;
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(bind_ack, core::STREAM_TOCLIENT)
+            dcerpc_state.handle_input_data(bind_ack, Direction::ToClient)
         );
     }
 
@@ -2442,11 +2445,11 @@ mod tests {
         ];
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(bind1, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(bind1, Direction::ToServer)
         );
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(bind_ack1, core::STREAM_TOCLIENT)
+            dcerpc_state.handle_input_data(bind_ack1, Direction::ToClient)
         );
         if let Some(ref back) = dcerpc_state.bindack {
             assert_eq!(1, back.accepted_uuid_list.len());
@@ -2455,11 +2458,11 @@ mod tests {
         }
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(bind2, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(bind2, Direction::ToServer)
         );
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(bind_ack2, core::STREAM_TOCLIENT)
+            dcerpc_state.handle_input_data(bind_ack2, Direction::ToClient)
         );
         if let Some(ref back) = dcerpc_state.bindack {
             assert_eq!(1, back.accepted_uuid_list.len());
@@ -2468,15 +2471,15 @@ mod tests {
         }
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(bind3, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(bind3, Direction::ToServer)
         );
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(bind_ack3, core::STREAM_TOCLIENT)
+            dcerpc_state.handle_input_data(bind_ack3, Direction::ToClient)
         );
         if let Some(ref back) = dcerpc_state.bindack {
             assert_eq!(1, back.accepted_uuid_list.len());
-            dcerpc_state.data_needed_for_dir = core::STREAM_TOSERVER;
+            dcerpc_state.data_needed_for_dir = Direction::ToServer;
             assert_eq!(11, back.accepted_uuid_list[0].ctxid);
             assert_eq!(expected_uuid3, back.accepted_uuid_list[0].uuid);
         }
@@ -2525,11 +2528,11 @@ mod tests {
         ];
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(bind, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(bind, Direction::ToServer)
         );
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(bindack, core::STREAM_TOCLIENT)
+            dcerpc_state.handle_input_data(bindack, Direction::ToClient)
         );
         if let Some(ref back) = dcerpc_state.bindack {
             assert_eq!(1, back.accepted_uuid_list.len());
@@ -2538,11 +2541,11 @@ mod tests {
         }
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(alter_context, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(alter_context, Direction::ToServer)
         );
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(alter_context_resp, core::STREAM_TOCLIENT)
+            dcerpc_state.handle_input_data(alter_context_resp, Direction::ToClient)
         );
         if let Some(ref back) = dcerpc_state.bindack {
             assert_eq!(1, back.accepted_uuid_list.len());
@@ -2564,11 +2567,11 @@ mod tests {
         let mut dcerpc_state = DCERPCState::new();
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(request1, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(request1, Direction::ToServer)
         );
         assert_eq!(
             AppLayerResult::ok(),
-            dcerpc_state.handle_input_data(request2, core::STREAM_TOSERVER)
+            dcerpc_state.handle_input_data(request2, Direction::ToServer)
         );
         let tx = &dcerpc_state.transactions[0];
         assert_eq!(2, tx.opnum);

--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -16,7 +16,7 @@
  */
 
 use super::dns::DNSTransaction;
-use crate::core;
+use crate::core::*;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
 
@@ -62,13 +62,13 @@ pub extern "C" fn rs_dns_opcode_match(
     detect: &mut DetectDnsOpcode,
     flags: u8,
 ) -> u8 {
-    let header_flags = if flags & core::STREAM_TOSERVER != 0 {
+    let header_flags = if flags & Direction::ToServer as u8 != 0 {
         if let Some(request) = &tx.request {
             request.header.flags
         } else {
             return 0;
         }
-    } else if flags & core::STREAM_TOCLIENT != 0 {
+    } else if flags & Direction::ToClient as u8 != 0 {
         if let Some(response) = &tx.response {
             response.header.flags
         } else {

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -23,7 +23,7 @@ use std::collections::HashMap;
 use std::collections::VecDeque;
 
 use crate::applayer::*;
-use crate::core::{self, AppProto, ALPROTO_UNKNOWN, IPPROTO_UDP, IPPROTO_TCP};
+use crate::core::{self, *};
 use crate::dns::parser;
 
 use nom::IResult;
@@ -909,11 +909,11 @@ pub unsafe extern "C" fn rs_dns_probe(
     let (is_dns, is_request, _) = probe(slice, slice.len());
     if is_dns {
         let dir = if is_request {
-            core::STREAM_TOSERVER
+            Direction::ToServer
         } else {
-            core::STREAM_TOCLIENT
+            Direction::ToClient
         };
-        *rdir = dir;
+        *rdir = dir as u8;
         return ALPROTO_DNS;
     }
     return 0;
@@ -935,12 +935,12 @@ pub unsafe extern "C" fn rs_dns_probe_tcp(
     let (is_dns, is_request, _) = probe_tcp(slice);
     if is_dns {
         let dir = if is_request {
-            core::STREAM_TOSERVER
+            Direction::ToServer
         } else {
-            core::STREAM_TOCLIENT
+            Direction::ToClient
         };
-        if direction & (core::STREAM_TOSERVER|core::STREAM_TOCLIENT) != dir {
-            *rdir = dir;
+        if (direction & DIR_BOTH) != dir.into() {
+            *rdir = dir as u8;
         }
         return ALPROTO_DNS;
     }

--- a/rust/src/filecontainer.rs
+++ b/rust/src/filecontainer.rs
@@ -37,9 +37,9 @@ pub struct Files {
 }
 
 impl Files {
-    pub fn get(&mut self, direction: u8) -> (&mut FileContainer, u16)
+    pub fn get(&mut self, direction: Direction) -> (&mut FileContainer, u16)
     {
-        if direction == STREAM_TOSERVER {
+        if direction == Direction::ToServer {
             (&mut self.files_ts, self.flags_ts)
         } else {
             (&mut self.files_tc, self.flags_tc)

--- a/rust/src/http2/decompression.rs
+++ b/rust/src/http2/decompression.rs
@@ -15,7 +15,7 @@
 * 02110-1301, USA.
 */
 
-use crate::core::STREAM_TOCLIENT;
+use crate::core::Direction;
 use brotli;
 use flate2::read::{DeflateDecoder, GzDecoder};
 use std;
@@ -240,8 +240,8 @@ impl HTTP2Decoder {
         }
     }
 
-    pub fn http2_encoding_fromvec(&mut self, input: &Vec<u8>, dir: u8) {
-        if dir == STREAM_TOCLIENT {
+    pub fn http2_encoding_fromvec(&mut self, input: &Vec<u8>, dir: Direction) {
+        if dir == Direction::ToClient {
             self.decoder_tc.http2_encoding_fromvec(input);
         } else {
             self.decoder_ts.http2_encoding_fromvec(input);
@@ -249,9 +249,9 @@ impl HTTP2Decoder {
     }
 
     pub fn decompress<'a>(
-        &mut self, input: &'a [u8], output: &'a mut Vec<u8>, dir: u8,
+        &mut self, input: &'a [u8], output: &'a mut Vec<u8>, dir: Direction,
     ) -> io::Result<&'a [u8]> {
-        if dir == STREAM_TOCLIENT {
+        if dir == Direction::ToClient {
             return self.decoder_tc.decompress(input, output);
         } else {
             return self.decoder_ts.decompress(input, output);

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -19,14 +19,14 @@ use super::http2::{
     HTTP2Event, HTTP2Frame, HTTP2FrameTypeData, HTTP2State, HTTP2Transaction, HTTP2TransactionState,
 };
 use super::parser;
-use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
+use crate::core::Direction;
 use std::ffi::CStr;
 use std::str::FromStr;
 
 fn http2_tx_has_frametype(
-    tx: &mut HTTP2Transaction, direction: u8, value: u8,
+    tx: &mut HTTP2Transaction, direction: Direction, value: u8,
 ) -> std::os::raw::c_int {
-    if direction & STREAM_TOSERVER != 0 {
+    if direction == Direction::ToServer {
         for i in 0..tx.frames_ts.len() {
             if tx.frames_ts[i].header.ftype as u8 == value {
                 return 1;
@@ -47,7 +47,7 @@ pub unsafe extern "C" fn rs_http2_tx_has_frametype(
     tx: *mut std::os::raw::c_void, direction: u8, value: u8,
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, HTTP2Transaction);
-    return http2_tx_has_frametype(tx, direction, value);
+    return http2_tx_has_frametype(tx, direction.into(), value);
 }
 
 #[no_mangle]
@@ -64,9 +64,9 @@ pub unsafe extern "C" fn rs_http2_parse_frametype(
 }
 
 fn http2_tx_has_errorcode(
-    tx: &mut HTTP2Transaction, direction: u8, code: u32,
+    tx: &mut HTTP2Transaction, direction: Direction, code: u32,
 ) -> std::os::raw::c_int {
-    if direction & STREAM_TOSERVER != 0 {
+    if direction == Direction::ToServer {
         for i in 0..tx.frames_ts.len() {
             match tx.frames_ts[i].data {
                 HTTP2FrameTypeData::GOAWAY(goaway) => {
@@ -107,7 +107,7 @@ pub unsafe extern "C" fn rs_http2_tx_has_errorcode(
     tx: *mut std::os::raw::c_void, direction: u8, code: u32,
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, HTTP2Transaction);
-    return http2_tx_has_errorcode(tx, direction, code);
+    return http2_tx_has_errorcode(tx, direction.into(), code);
 }
 
 #[no_mangle]
@@ -124,10 +124,10 @@ pub unsafe extern "C" fn rs_http2_parse_errorcode(
 }
 
 fn http2_tx_get_next_priority(
-    tx: &mut HTTP2Transaction, direction: u8, nb: u32,
+    tx: &mut HTTP2Transaction, direction: Direction, nb: u32,
 ) -> std::os::raw::c_int {
     let mut pos = 0 as u32;
-    if direction & STREAM_TOSERVER != 0 {
+    if direction == Direction::ToServer {
         for i in 0..tx.frames_ts.len() {
             match &tx.frames_ts[i].data {
                 HTTP2FrameTypeData::PRIORITY(prio) => {
@@ -180,14 +180,14 @@ pub unsafe extern "C" fn rs_http2_tx_get_next_priority(
     tx: *mut std::os::raw::c_void, direction: u8, nb: u32,
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, HTTP2Transaction);
-    return http2_tx_get_next_priority(tx, direction, nb);
+    return http2_tx_get_next_priority(tx, direction.into(), nb);
 }
 
 fn http2_tx_get_next_window(
-    tx: &mut HTTP2Transaction, direction: u8, nb: u32,
+    tx: &mut HTTP2Transaction, direction: Direction, nb: u32,
 ) -> std::os::raw::c_int {
     let mut pos = 0 as u32;
-    if direction & STREAM_TOSERVER != 0 {
+    if direction == Direction::ToServer {
         for i in 0..tx.frames_ts.len() {
             match tx.frames_ts[i].data {
                 HTTP2FrameTypeData::WINDOWUPDATE(wu) => {
@@ -222,7 +222,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_next_window(
     tx: *mut std::os::raw::c_void, direction: u8, nb: u32,
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, HTTP2Transaction);
-    return http2_tx_get_next_window(tx, direction, nb);
+    return http2_tx_get_next_window(tx, direction.into(), nb);
 }
 
 #[no_mangle]
@@ -283,9 +283,9 @@ fn http2_detect_settings_match(
 }
 
 fn http2_detect_settingsctx_match(
-    ctx: &mut parser::DetectHTTP2settingsSigCtx, tx: &mut HTTP2Transaction, direction: u8,
+    ctx: &mut parser::DetectHTTP2settingsSigCtx, tx: &mut HTTP2Transaction, direction: Direction,
 ) -> std::os::raw::c_int {
-    if direction & STREAM_TOSERVER != 0 {
+    if direction == Direction::ToServer {
         for i in 0..tx.frames_ts.len() {
             match &tx.frames_ts[i].data {
                 HTTP2FrameTypeData::SETTINGS(set) => {
@@ -317,7 +317,7 @@ pub unsafe extern "C" fn rs_http2_detect_settingsctx_match(
 ) -> std::os::raw::c_int {
     let ctx = cast_pointer!(ctx, parser::DetectHTTP2settingsSigCtx);
     let tx = cast_pointer!(tx, HTTP2Transaction);
-    return http2_detect_settingsctx_match(ctx, tx, direction);
+    return http2_detect_settingsctx_match(ctx, tx, direction.into());
 }
 
 #[no_mangle]
@@ -396,9 +396,9 @@ fn http2_header_blocks(frame: &HTTP2Frame) -> Option<&[parser::HTTP2FrameHeaderB
 }
 
 fn http2_detect_sizeupdatectx_match(
-    ctx: &mut parser::DetectU64Data, tx: &mut HTTP2Transaction, direction: u8,
+    ctx: &mut parser::DetectU64Data, tx: &mut HTTP2Transaction, direction: Direction,
 ) -> std::os::raw::c_int {
-    if direction & STREAM_TOSERVER != 0 {
+    if direction == Direction::ToServer {
         for i in 0..tx.frames_ts.len() {
             if let Some(blocks) = http2_header_blocks(&tx.frames_ts[i]) {
                 if http2_detect_sizeupdate_match(blocks, ctx) != 0 {
@@ -424,7 +424,7 @@ pub unsafe extern "C" fn rs_http2_detect_sizeupdatectx_match(
 ) -> std::os::raw::c_int {
     let ctx = cast_pointer!(ctx, parser::DetectU64Data);
     let tx = cast_pointer!(tx, HTTP2Transaction);
-    return http2_detect_sizeupdatectx_match(ctx, tx, direction);
+    return http2_detect_sizeupdatectx_match(ctx, tx, direction.into());
 }
 
 //TODOask better syntax between rs_http2_tx_get_header_name in argument
@@ -434,29 +434,32 @@ pub unsafe extern "C" fn rs_http2_tx_get_header_name(
     tx: &mut HTTP2Transaction, direction: u8, nb: u32, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     let mut pos = 0 as u32;
-    if direction & STREAM_TOSERVER != 0 {
-        for i in 0..tx.frames_ts.len() {
-            if let Some(blocks) = http2_header_blocks(&tx.frames_ts[i]) {
-                if nb < pos + blocks.len() as u32 {
-                    let value = &blocks[(nb - pos) as usize].name;
-                    *buffer = value.as_ptr(); //unsafe
-                    *buffer_len = value.len() as u32;
-                    return 1;
-                } else {
-                    pos = pos + blocks.len() as u32;
+    match direction.into() {
+        Direction::ToServer => {
+            for i in 0..tx.frames_ts.len() {
+                if let Some(blocks) = http2_header_blocks(&tx.frames_ts[i]) {
+                    if nb < pos + blocks.len() as u32 {
+                        let value = &blocks[(nb - pos) as usize].name;
+                        *buffer = value.as_ptr(); //unsafe
+                        *buffer_len = value.len() as u32;
+                        return 1;
+                    } else {
+                        pos = pos + blocks.len() as u32;
+                    }
                 }
             }
         }
-    } else {
-        for i in 0..tx.frames_tc.len() {
-            if let Some(blocks) = http2_header_blocks(&tx.frames_tc[i]) {
-                if nb < pos + blocks.len() as u32 {
-                    let value = &blocks[(nb - pos) as usize].name;
-                    *buffer = value.as_ptr(); //unsafe
-                    *buffer_len = value.len() as u32;
-                    return 1;
-                } else {
-                    pos = pos + blocks.len() as u32;
+        Direction::ToClient => {
+            for i in 0..tx.frames_tc.len() {
+                if let Some(blocks) = http2_header_blocks(&tx.frames_tc[i]) {
+                    if nb < pos + blocks.len() as u32 {
+                        let value = &blocks[(nb - pos) as usize].name;
+                        *buffer = value.as_ptr(); //unsafe
+                        *buffer_len = value.len() as u32;
+                        return 1;
+                    } else {
+                        pos = pos + blocks.len() as u32;
+                    }
                 }
             }
         }
@@ -465,9 +468,9 @@ pub unsafe extern "C" fn rs_http2_tx_get_header_name(
 }
 
 fn http2_frames_get_header_firstvalue<'a>(
-    tx: &'a mut HTTP2Transaction, direction: u8, name: &str,
+    tx: &'a mut HTTP2Transaction, direction: Direction, name: &str,
 ) -> Result<&'a [u8], ()> {
-    let frames = if direction == STREAM_TOSERVER {
+    let frames = if direction == Direction::ToServer {
         &tx.frames_ts
     } else {
         &tx.frames_tc
@@ -487,11 +490,11 @@ fn http2_frames_get_header_firstvalue<'a>(
 // same as http2_frames_get_header_value but returns a new Vec
 // instead of using the transation to store the result slice
 pub fn http2_frames_get_header_value_vec(
-    tx: &HTTP2Transaction, direction: u8, name: &str,
+    tx: &HTTP2Transaction, direction: Direction, name: &str,
 ) -> Result<Vec<u8>, ()> {
     let mut found = 0;
     let mut vec = Vec::new();
-    let frames = if direction == STREAM_TOSERVER {
+    let frames = if direction == Direction::ToServer {
         &tx.frames_ts
     } else {
         &tx.frames_tc
@@ -523,12 +526,12 @@ pub fn http2_frames_get_header_value_vec(
 }
 
 fn http2_frames_get_header_value<'a>(
-    tx: &'a mut HTTP2Transaction, direction: u8, name: &str,
+    tx: &'a mut HTTP2Transaction, direction: Direction, name: &str,
 ) -> Result<&'a [u8], ()> {
     let mut found = 0;
     let mut vec = Vec::new();
     let mut single: Result<&[u8], ()> = Err(());
-    let frames = if direction == STREAM_TOSERVER {
+    let frames = if direction == Direction::ToServer {
         &tx.frames_ts
     } else {
         &tx.frames_tc
@@ -571,7 +574,7 @@ fn http2_frames_get_header_value<'a>(
 pub unsafe extern "C" fn rs_http2_tx_get_uri(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
-    if let Ok(value) = http2_frames_get_header_firstvalue(tx, STREAM_TOSERVER, ":path") {
+    if let Ok(value) = http2_frames_get_header_firstvalue(tx, Direction::ToServer, ":path") {
         *buffer = value.as_ptr(); //unsafe
         *buffer_len = value.len() as u32;
         return 1;
@@ -583,7 +586,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_uri(
 pub unsafe extern "C" fn rs_http2_tx_get_method(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
-    if let Ok(value) = http2_frames_get_header_firstvalue(tx, STREAM_TOSERVER, ":method") {
+    if let Ok(value) = http2_frames_get_header_firstvalue(tx, Direction::ToServer, ":method") {
         *buffer = value.as_ptr(); //unsafe
         *buffer_len = value.len() as u32;
         return 1;
@@ -595,7 +598,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_method(
 pub unsafe extern "C" fn rs_http2_tx_get_host(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
-    if let Ok(value) = http2_frames_get_header_value(tx, STREAM_TOSERVER, ":authority") {
+    if let Ok(value) = http2_frames_get_header_value(tx, Direction::ToServer, ":authority") {
         *buffer = value.as_ptr(); //unsafe
         *buffer_len = value.len() as u32;
         return 1;
@@ -634,7 +637,7 @@ fn http2_normalize_host(value: &[u8]) -> (Option<Vec<u8>>, usize) {
 pub unsafe extern "C" fn rs_http2_tx_get_host_norm(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
-    if let Ok(value) = http2_frames_get_header_value(tx, STREAM_TOSERVER, ":authority") {
+    if let Ok(value) = http2_frames_get_header_value(tx, Direction::ToServer, ":authority") {
         let r = http2_normalize_host(value);
         // r is a tuple with the value and its size
         // this is useful when we only take a substring (before the port)
@@ -663,7 +666,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_host_norm(
 pub unsafe extern "C" fn rs_http2_tx_get_useragent(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
-    if let Ok(value) = http2_frames_get_header_value(tx, STREAM_TOSERVER, "user-agent") {
+    if let Ok(value) = http2_frames_get_header_value(tx, Direction::ToServer, "user-agent") {
         *buffer = value.as_ptr(); //unsafe
         *buffer_len = value.len() as u32;
         return 1;
@@ -675,7 +678,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_useragent(
 pub unsafe extern "C" fn rs_http2_tx_get_status(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
-    if let Ok(value) = http2_frames_get_header_firstvalue(tx, STREAM_TOCLIENT, ":status") {
+    if let Ok(value) = http2_frames_get_header_firstvalue(tx, Direction::ToClient, ":status") {
         *buffer = value.as_ptr(); //unsafe
         *buffer_len = value.len() as u32;
         return 1;
@@ -687,14 +690,14 @@ pub unsafe extern "C" fn rs_http2_tx_get_status(
 pub unsafe extern "C" fn rs_http2_tx_get_cookie(
     tx: &mut HTTP2Transaction, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
-    if direction == STREAM_TOSERVER {
-        if let Ok(value) = http2_frames_get_header_value(tx, STREAM_TOSERVER, "cookie") {
+    if direction == Direction::ToServer.into() {
+        if let Ok(value) = http2_frames_get_header_value(tx, Direction::ToServer, "cookie") {
             *buffer = value.as_ptr(); //unsafe
             *buffer_len = value.len() as u32;
             return 1;
         }
     } else {
-        if let Ok(value) = http2_frames_get_header_value(tx, STREAM_TOCLIENT, "set-cookie") {
+        if let Ok(value) = http2_frames_get_header_value(tx, Direction::ToClient, "set-cookie") {
             *buffer = value.as_ptr(); //unsafe
             *buffer_len = value.len() as u32;
             return 1;
@@ -710,7 +713,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_header_value(
 ) -> u8 {
     let hname: &CStr = CStr::from_ptr(strname); //unsafe
     if let Ok(s) = hname.to_str() {
-        if let Ok(value) = http2_frames_get_header_value(tx, direction, &s.to_lowercase()) {
+        if let Ok(value) = http2_frames_get_header_value(tx, direction.into(), &s.to_lowercase()) {
             *buffer = value.as_ptr(); //unsafe
             *buffer_len = value.len() as u32;
             return 1;
@@ -744,7 +747,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_header_names(
     tx: &mut HTTP2Transaction, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     let mut vec = vec![b'\r', b'\n'];
-    let frames = if direction & STREAM_TOSERVER != 0 {
+    let frames = if direction & Direction::ToServer as u8 != 0 {
         &tx.frames_ts
     } else {
         &tx.frames_tc
@@ -770,9 +773,9 @@ pub unsafe extern "C" fn rs_http2_tx_get_header_names(
     return 0;
 }
 
-fn http2_header_iscookie(direction: u8, hname: &[u8]) -> bool {
+fn http2_header_iscookie(direction: Direction, hname: &[u8]) -> bool {
     if let Ok(s) = std::str::from_utf8(hname) {
-        if direction & STREAM_TOSERVER != 0 {
+        if direction == Direction::ToServer {
             if s.to_lowercase() == "cookie" {
                 return true;
             }
@@ -810,7 +813,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_headers(
     tx: &mut HTTP2Transaction, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     let mut vec = Vec::new();
-    let frames = if direction & STREAM_TOSERVER != 0 {
+    let frames = if direction & Direction::ToServer as u8 != 0 {
         &tx.frames_ts
     } else {
         &tx.frames_tc
@@ -818,7 +821,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_headers(
     for i in 0..frames.len() {
         if let Some(blocks) = http2_header_blocks(&frames[i]) {
             for block in blocks.iter() {
-                if !http2_header_iscookie(direction, &block.name) {
+                if !http2_header_iscookie(direction.into(), &block.name) {
                     // we do not escape linefeeds nor : in headers names
                     vec.extend_from_slice(&block.name);
                     vec.extend_from_slice(&[b':', b' ']);
@@ -844,7 +847,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_headers_raw(
     tx: &mut HTTP2Transaction, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     let mut vec = Vec::new();
-    let frames = if direction & STREAM_TOSERVER != 0 {
+    let frames = if direction & Direction::ToServer as u8 != 0 {
         &tx.frames_ts
     } else {
         &tx.frames_tc
@@ -876,40 +879,42 @@ pub unsafe extern "C" fn rs_http2_tx_get_header(
     tx: &mut HTTP2Transaction, direction: u8, nb: u32, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     let mut pos = 0 as u32;
-    if direction & STREAM_TOSERVER != 0 {
-        for i in 0..tx.frames_ts.len() {
-            if let Some(blocks) = http2_header_blocks(&tx.frames_ts[i]) {
-                if nb < pos + blocks.len() as u32 {
-                    let ehdr = http2_escape_header(&blocks, nb - pos);
-                    tx.escaped.push(ehdr);
-                    let idx = tx.escaped.len() - 1;
-                    let value = &tx.escaped[idx];
-                    *buffer = value.as_ptr(); //unsafe
-                    *buffer_len = value.len() as u32;
-                    return 1;
-                } else {
-                    pos = pos + blocks.len() as u32;
+    match direction.into() {
+        Direction::ToServer => {
+            for i in 0..tx.frames_ts.len() {
+                if let Some(blocks) = http2_header_blocks(&tx.frames_ts[i]) {
+                    if nb < pos + blocks.len() as u32 {
+                        let ehdr = http2_escape_header(&blocks, nb - pos);
+                        tx.escaped.push(ehdr);
+                        let idx = tx.escaped.len() - 1;
+                        let value = &tx.escaped[idx];
+                        *buffer = value.as_ptr(); //unsafe
+                        *buffer_len = value.len() as u32;
+                        return 1;
+                    } else {
+                        pos = pos + blocks.len() as u32;
+                    }
                 }
             }
         }
-    } else {
-        for i in 0..tx.frames_tc.len() {
-            if let Some(blocks) = http2_header_blocks(&tx.frames_tc[i]) {
-                if nb < pos + blocks.len() as u32 {
-                    let ehdr = http2_escape_header(&blocks, nb - pos);
-                    tx.escaped.push(ehdr);
-                    let idx = tx.escaped.len() - 1;
-                    let value = &tx.escaped[idx];
-                    *buffer = value.as_ptr(); //unsafe
-                    *buffer_len = value.len() as u32;
-                    return 1;
-                } else {
-                    pos = pos + blocks.len() as u32;
+        Direction::ToClient => {
+            for i in 0..tx.frames_tc.len() {
+                if let Some(blocks) = http2_header_blocks(&tx.frames_tc[i]) {
+                    if nb < pos + blocks.len() as u32 {
+                        let ehdr = http2_escape_header(&blocks, nb - pos);
+                        tx.escaped.push(ehdr);
+                        let idx = tx.escaped.len() - 1;
+                        let value = &tx.escaped[idx];
+                        *buffer = value.as_ptr(); //unsafe
+                        *buffer_len = value.len() as u32;
+                        return 1;
+                    } else {
+                        pos = pos + blocks.len() as u32;
+                    }
                 }
             }
         }
     }
-
     return 0;
 }
 
@@ -935,7 +940,7 @@ fn http2_tx_set_header(state: &mut HTTP2State, name: &[u8], input: &[u8]) {
         blocks: blocks,
     };
     let txdata = HTTP2FrameTypeData::HEADERS(hs);
-    let tx = state.find_or_create_tx(&head, &txdata, STREAM_TOSERVER);
+    let tx = state.find_or_create_tx(&head, &txdata, Direction::ToServer);
     tx.frames_ts.push(HTTP2Frame {
         header: head,
         data: txdata,
@@ -1078,7 +1083,7 @@ fn http2_tx_set_settings(state: &mut HTTP2State, input: &[u8]) {
             match parser::http2_parse_frame_settings(&dec) {
                 Ok((_, set)) => {
                     let txdata = HTTP2FrameTypeData::SETTINGS(set);
-                    let tx = state.find_or_create_tx(&head, &txdata, STREAM_TOSERVER);
+                    let tx = state.find_or_create_tx(&head, &txdata, Direction::ToServer);
                     tx.frames_ts.push(HTTP2Frame {
                         header: head,
                         data: txdata,
@@ -1202,7 +1207,7 @@ mod tests {
             header: head,
             data: txdata,
         });
-        match http2_frames_get_header_value(&mut tx, STREAM_TOSERVER, "Host") {
+        match http2_frames_get_header_value(&mut tx, Direction::ToServer, "Host") {
             Ok(x) => {
                 assert_eq!(x, "abc.com, efg.net".as_bytes());
             }

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -566,7 +566,7 @@ fn http2_frames_get_header_value<'a>(
         tx.escaped.push(vec);
         let idx = tx.escaped.len() - 1;
         let value = &tx.escaped[idx];
-        return Ok(&value);
+        return Ok(value);
     }
 }
 
@@ -884,7 +884,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_header(
             for i in 0..tx.frames_ts.len() {
                 if let Some(blocks) = http2_header_blocks(&tx.frames_ts[i]) {
                     if nb < pos + blocks.len() as u32 {
-                        let ehdr = http2_escape_header(&blocks, nb - pos);
+                        let ehdr = http2_escape_header(blocks, nb - pos);
                         tx.escaped.push(ehdr);
                         let idx = tx.escaped.len() - 1;
                         let value = &tx.escaped[idx];
@@ -901,7 +901,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_header(
             for i in 0..tx.frames_tc.len() {
                 if let Some(blocks) = http2_header_blocks(&tx.frames_tc[i]) {
                     if nb < pos + blocks.len() as u32 {
-                        let ehdr = http2_escape_header(&blocks, nb - pos);
+                        let ehdr = http2_escape_header(blocks, nb - pos);
                         tx.escaped.push(ehdr);
                         let idx = tx.escaped.len() - 1;
                         let value = &tx.escaped[idx];

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -871,7 +871,7 @@ impl HTTP2State {
                                 let index = self.find_tx_index(sid);
                                 if index > 0 {
                                     let tx_same = &mut self.transactions[index - 1];
-                                    let (files, flags) = self.files.get(dir);
+                                    let (files, flags) = self.files.get(dir.into());
                                     match tx_same.decompress(
                                         &rem[..hlsafe],
                                         dir,

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -21,10 +21,7 @@ use super::parser;
 use super::range;
 
 use crate::applayer::{self, *};
-use crate::core::{
-    self, AppProto, Flow, HttpRangeContainerBlock, SuricataFileContext, ALPROTO_FAILED,
-    ALPROTO_UNKNOWN, IPPROTO_TCP, SC, STREAM_TOCLIENT, STREAM_TOSERVER,
-};
+use crate::core::{self, *};
 use crate::filecontainer::*;
 use crate::filetracker::*;
 use nom;
@@ -195,7 +192,7 @@ impl HTTP2Transaction {
         core::sc_app_layer_decoder_events_set_event_raw(&mut self.events, ev);
     }
 
-    fn handle_headers(&mut self, blocks: &Vec<parser::HTTP2FrameHeaderBlock>, dir: u8) {
+    fn handle_headers(&mut self, blocks: &Vec<parser::HTTP2FrameHeaderBlock>, dir: Direction) {
         for i in 0..blocks.len() {
             if blocks[i].name == "content-encoding".as_bytes().to_vec() {
                 self.decoder.http2_encoding_fromvec(&blocks[i].value, dir);
@@ -204,13 +201,13 @@ impl HTTP2Transaction {
     }
 
     fn decompress<'a>(
-        &'a mut self, input: &'a [u8], dir: u8, sfcm: &'static SuricataFileContext, over: bool,
-        files: &mut FileContainer, flags: u16, flow: *const Flow,
+        &'a mut self, input: &'a [u8], dir: Direction, sfcm: &'static SuricataFileContext,
+        over: bool, files: &mut FileContainer, flags: u16, flow: *const Flow,
     ) -> io::Result<()> {
         let mut output = Vec::with_capacity(decompression::HTTP2_DECOMPRESSION_CHUNK_SIZE);
         let decompressed = self.decoder.decompress(input, &mut output, dir)?;
         let xid: u32 = self.tx_id as u32;
-        if dir == STREAM_TOCLIENT {
+        if dir == Direction::ToClient {
             self.ft_tc.tx_id = self.tx_id - 1;
             if !self.ft_tc.file_open {
                 // we are now sure that new_chunk will open a file
@@ -218,7 +215,7 @@ impl HTTP2Transaction {
                 self.tx_data.incr_files_opened();
                 if let Ok(value) = detect::http2_frames_get_header_value_vec(
                     self,
-                    STREAM_TOCLIENT,
+                    Direction::ToClient,
                     "content-range",
                 ) {
                     match range::http2_parse_check_content_range(&value) {
@@ -276,12 +273,12 @@ impl HTTP2Transaction {
     }
 
     fn handle_frame(
-        &mut self, header: &parser::HTTP2FrameHeader, data: &HTTP2FrameTypeData, dir: u8,
+        &mut self, header: &parser::HTTP2FrameHeader, data: &HTTP2FrameTypeData, dir: Direction,
     ) {
         //handle child_stream_id changes
         match data {
             HTTP2FrameTypeData::PUSHPROMISE(hs) => {
-                if dir == STREAM_TOCLIENT {
+                if dir == Direction::ToClient {
                     //we could set an event if self.child_stream_id != 0
                     if header.flags & parser::HTTP2_FLAG_HEADER_END_HEADERS == 0 {
                         self.child_stream_id = hs.stream_id;
@@ -291,7 +288,7 @@ impl HTTP2Transaction {
                 self.handle_headers(&hs.blocks, dir);
             }
             HTTP2FrameTypeData::CONTINUATION(hs) => {
-                if dir == STREAM_TOCLIENT
+                if dir == Direction::ToClient
                     && header.flags & parser::HTTP2_FLAG_HEADER_END_HEADERS != 0
                 {
                     self.child_stream_id = 0;
@@ -299,7 +296,7 @@ impl HTTP2Transaction {
                 self.handle_headers(&hs.blocks, dir);
             }
             HTTP2FrameTypeData::HEADERS(hs) => {
-                if dir == STREAM_TOCLIENT {
+                if dir == Direction::ToClient {
                     self.child_stream_id = 0;
                 }
                 self.handle_headers(&hs.blocks, dir);
@@ -316,12 +313,12 @@ impl HTTP2Transaction {
                     match self.state {
                         HTTP2TransactionState::HTTP2StateHalfClosedClient
                         | HTTP2TransactionState::HTTP2StateDataServer => {
-                            if dir == STREAM_TOCLIENT {
+                            if dir == Direction::ToClient {
                                 self.state = HTTP2TransactionState::HTTP2StateClosed;
                             }
                         }
                         HTTP2TransactionState::HTTP2StateHalfClosedServer => {
-                            if dir == STREAM_TOSERVER {
+                            if dir == Direction::ToServer {
                                 self.state = HTTP2TransactionState::HTTP2StateClosed;
                             }
                         }
@@ -329,7 +326,7 @@ impl HTTP2Transaction {
                         HTTP2TransactionState::HTTP2StateClosed => {}
                         HTTP2TransactionState::HTTP2StateGlobal => {}
                         _ => {
-                            if dir == STREAM_TOCLIENT {
+                            if dir == Direction::ToClient {
                                 self.state = HTTP2TransactionState::HTTP2StateHalfClosedServer;
                             } else {
                                 self.state = HTTP2TransactionState::HTTP2StateHalfClosedClient;
@@ -338,7 +335,7 @@ impl HTTP2Transaction {
                     }
                 } else if header.ftype == parser::HTTP2FrameType::DATA as u8 {
                     //not end of stream
-                    if dir == STREAM_TOSERVER {
+                    if dir == Direction::ToServer {
                         if self.state < HTTP2TransactionState::HTTP2StateDataClient {
                             self.state = HTTP2TransactionState::HTTP2StateDataClient;
                         }
@@ -498,7 +495,7 @@ impl HTTP2State {
     }
 
     pub fn find_or_create_tx(
-        &mut self, header: &parser::HTTP2FrameHeader, data: &HTTP2FrameTypeData, dir: u8,
+        &mut self, header: &parser::HTTP2FrameHeader, data: &HTTP2FrameTypeData, dir: Direction,
     ) -> &mut HTTP2Transaction {
         if header.stream_id == 0 {
             return self.create_global_tx();
@@ -507,7 +504,7 @@ impl HTTP2State {
             //yes, the right stream_id for Suricata is not the header one
             HTTP2FrameTypeData::PUSHPROMISE(hs) => hs.stream_id,
             HTTP2FrameTypeData::CONTINUATION(_) => {
-                if dir == STREAM_TOCLIENT {
+                if dir == Direction::ToClient {
                     //continuation of a push promise
                     self.find_child_stream_id(header.stream_id)
                 } else {
@@ -539,7 +536,7 @@ impl HTTP2State {
         }
     }
 
-    fn process_headers(&mut self, blocks: &Vec<parser::HTTP2FrameHeaderBlock>, dir: u8) {
+    fn process_headers(&mut self, blocks: &Vec<parser::HTTP2FrameHeaderBlock>, dir: Direction) {
         let (mut update, mut sizeup) = (false, 0);
         for i in 0..blocks.len() {
             if blocks[i].error >= parser::HTTP2HeaderDecodeStatus::HTTP2HeaderDecodeError {
@@ -555,7 +552,7 @@ impl HTTP2State {
         }
         if update {
             //borrow checker forbids to pass directly dyn_headers
-            let dyn_headers = if dir == STREAM_TOCLIENT {
+            let dyn_headers = if dir == Direction::ToClient {
                 &mut self.dynamic_headers_tc
             } else {
                 &mut self.dynamic_headers_ts
@@ -565,7 +562,7 @@ impl HTTP2State {
     }
 
     fn parse_frame_data(
-        &mut self, ftype: u8, input: &[u8], complete: bool, hflags: u8, dir: u8,
+        &mut self, ftype: u8, input: &[u8], complete: bool, hflags: u8, dir: Direction,
     ) -> HTTP2FrameTypeData {
         match num::FromPrimitive::from_u8(ftype) {
             Some(parser::HTTP2FrameType::GOAWAY) => {
@@ -593,7 +590,7 @@ impl HTTP2State {
                         for i in 0..set.len() {
                             if set[i].id == parser::HTTP2SettingsId::SETTINGSHEADERTABLESIZE {
                                 //reverse order as this is what we accept from the other endpoint
-                                let dyn_headers = if dir == STREAM_TOCLIENT {
+                                let dyn_headers = if dir == Direction::ToClient {
                                     &mut self.dynamic_headers_ts
                                 } else {
                                     &mut self.dynamic_headers_tc
@@ -692,7 +689,7 @@ impl HTTP2State {
                 }
             }
             Some(parser::HTTP2FrameType::PUSHPROMISE) => {
-                let dyn_headers = if dir == STREAM_TOCLIENT {
+                let dyn_headers = if dir == Direction::ToClient {
                     &mut self.dynamic_headers_tc
                 } else {
                     &mut self.dynamic_headers_ts
@@ -726,7 +723,7 @@ impl HTTP2State {
                 return HTTP2FrameTypeData::DATA;
             }
             Some(parser::HTTP2FrameType::CONTINUATION) => {
-                let dyn_headers = if dir == STREAM_TOCLIENT {
+                let dyn_headers = if dir == Direction::ToClient {
                     &mut self.dynamic_headers_tc
                 } else {
                     &mut self.dynamic_headers_ts
@@ -757,7 +754,7 @@ impl HTTP2State {
                 }
             }
             Some(parser::HTTP2FrameType::HEADERS) => {
-                let dyn_headers = if dir == STREAM_TOCLIENT {
+                let dyn_headers = if dir == Direction::ToClient {
                     &mut self.dynamic_headers_tc
                 } else {
                     &mut self.dynamic_headers_ts
@@ -803,7 +800,7 @@ impl HTTP2State {
     }
 
     fn parse_frames(
-        &mut self, mut input: &[u8], il: usize, dir: u8, flow: *const Flow,
+        &mut self, mut input: &[u8], il: usize, dir: Direction, flow: *const Flow,
     ) -> AppLayerResult {
         while input.len() > 0 {
             match parser::http2_parse_frame_header(input) {
@@ -853,7 +850,7 @@ impl HTTP2State {
                     let over = head.flags & parser::HTTP2_FLAG_HEADER_EOS != 0;
                     let ftype = head.ftype;
                     let sid = head.stream_id;
-                    if dir == STREAM_TOSERVER {
+                    if dir == Direction::ToServer {
                         tx.frames_ts.push(HTTP2Frame {
                             header: head,
                             data: txdata,
@@ -871,7 +868,7 @@ impl HTTP2State {
                                 let index = self.find_tx_index(sid);
                                 if index > 0 {
                                     let tx_same = &mut self.transactions[index - 1];
-                                    let (files, flags) = self.files.get(dir.into());
+                                    let (files, flags) = self.files.get(dir);
                                     match tx_same.decompress(
                                         &rem[..hlsafe],
                                         dir,
@@ -949,7 +946,7 @@ impl HTTP2State {
         }
 
         //then parse all we can
-        let r = self.parse_frames(input, il, STREAM_TOSERVER, flow);
+        let r = self.parse_frames(input, il, Direction::ToServer, flow);
         if r.status == 1 {
             //adds bytes consumed by banner to incomplete result
             return AppLayerResult::incomplete(r.consumed + magic_consumed as u32, r.needed);
@@ -973,7 +970,7 @@ impl HTTP2State {
             }
         }
         //then parse all we can
-        return self.parse_frames(input, il, STREAM_TOCLIENT, flow);
+        return self.parse_frames(input, il, Direction::ToClient, flow);
     }
 
     fn tx_iterator(
@@ -1078,7 +1075,7 @@ pub unsafe extern "C" fn rs_http2_parse_ts(
     let state = cast_pointer!(state, HTTP2State);
     let buf = build_slice!(input, input_len as usize);
 
-    state.files.flags_ts = FileFlowToFlags(flow, STREAM_TOSERVER);
+    state.files.flags_ts = FileFlowToFlags(flow, Direction::ToServer.into());
     state.files.flags_ts = state.files.flags_ts | FILE_USE_DETECT;
     return state.parse_ts(buf, flow);
 }
@@ -1090,7 +1087,7 @@ pub unsafe extern "C" fn rs_http2_parse_tc(
 ) -> AppLayerResult {
     let state = cast_pointer!(state, HTTP2State);
     let buf = build_slice!(input, input_len as usize);
-    state.files.flags_tc = FileFlowToFlags(flow, STREAM_TOCLIENT);
+    state.files.flags_tc = FileFlowToFlags(flow, Direction::ToClient.into());
     state.files.flags_tc = state.files.flags_tc | FILE_USE_DETECT;
     return state.parse_tc(buf, flow);
 }
@@ -1162,7 +1159,7 @@ pub unsafe extern "C" fn rs_http2_getfiles(
     state: *mut std::os::raw::c_void, direction: u8,
 ) -> *mut FileContainer {
     let state = cast_pointer!(state, HTTP2State);
-    if direction == STREAM_TOCLIENT {
+    if direction == Direction::ToClient.into() {
         &mut state.files.files_tc as *mut FileContainer
     } else {
         &mut state.files.files_ts as *mut FileContainer

--- a/rust/src/http2/range.rs
+++ b/rust/src/http2/range.rs
@@ -17,7 +17,7 @@
 
 use super::detect;
 use crate::core::{
-    Flow, HttpRangeContainerBlock, StreamingBufferConfig, SuricataFileContext, SC, STREAM_TOSERVER,
+    Direction, Flow, HttpRangeContainerBlock, StreamingBufferConfig, SuricataFileContext, SC,
 };
 use crate::filecontainer::FileContainer;
 use crate::http2::http2::HTTP2Transaction;
@@ -105,7 +105,7 @@ pub unsafe extern "C" fn rs_http_parse_content_range(
 }
 
 fn http2_range_key_get(tx: &mut HTTP2Transaction) -> Result<(Vec<u8>, usize), ()> {
-    let hostv = detect::http2_frames_get_header_value_vec(tx, STREAM_TOSERVER, ":authority")?;
+    let hostv = detect::http2_frames_get_header_value_vec(tx, Direction::ToServer, ":authority")?;
     let mut hostv = &hostv[..];
     match hostv.iter().position(|&x| x == b':') {
         Some(p) => {
@@ -113,7 +113,7 @@ fn http2_range_key_get(tx: &mut HTTP2Transaction) -> Result<(Vec<u8>, usize), ()
         }
         None => {}
     }
-    let uriv = detect::http2_frames_get_header_value_vec(tx, STREAM_TOSERVER, ":path")?;
+    let uriv = detect::http2_frames_get_header_value_vec(tx, Direction::ToServer, ":path")?;
     let mut uriv = &uriv[..];
     match uriv.iter().position(|&x| x == b'?') {
         Some(p) => {

--- a/rust/src/ike/ikev1.rs
+++ b/rust/src/ike/ikev1.rs
@@ -19,7 +19,7 @@
 
 use crate::applayer::*;
 use crate::common::to_hex;
-use crate::core::STREAM_TOSERVER;
+use crate::core::Direction;
 use crate::ike::ike::{IKEState, IkeEvent};
 use crate::ike::parser::*;
 use nom;
@@ -72,7 +72,7 @@ pub struct Ikev1Container {
 }
 
 pub fn handle_ikev1(
-    state: &mut IKEState, current: &[u8], isakmp_header: IsakmpHeader, direction: u8,
+    state: &mut IKEState, current: &[u8], isakmp_header: IsakmpHeader, direction: Direction,
 ) -> AppLayerResult {
     let mut tx = state.new_tx();
 
@@ -114,7 +114,7 @@ pub fn handle_ikev1(
                 if payload_types.contains(&(IsakmpPayloadType::SecurityAssociation as u8)) {
                     // clear transforms on a new SA in case there is happening a new key exchange
                     // on the same flow, elsewise properties would be added to the old/other SA
-                    if direction == STREAM_TOSERVER {
+                    if direction == Direction::ToServer {
                         state.ikev1_container.client.reset();
                     } else {
                         state.ikev1_container.server.reset();
@@ -122,7 +122,7 @@ pub fn handle_ikev1(
                 }
 
                 // add transaction values to state values
-                if direction == STREAM_TOSERVER {
+                if direction == Direction::ToServer {
                     state.ikev1_container.client.update(
                         &to_hex(tx.hdr.ikev1_header.key_exchange.as_ref()),
                         &to_hex(tx.hdr.ikev1_header.nonce.as_ref()),

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -27,8 +27,7 @@ use der_parser::ber::BerClass;
 use kerberos_parser::krb5_parser;
 use kerberos_parser::krb5::{EncryptionType,ErrorCode,MessageType,PrincipalName,Realm};
 use crate::applayer::{self, *};
-use crate::core;
-use crate::core::{AppProto,Flow,ALPROTO_FAILED,ALPROTO_UNKNOWN,STREAM_TOCLIENT,STREAM_TOSERVER,sc_detect_engine_state_free};
+use crate::core::{self, *};
 
 #[derive(AppLayerEvent)]
 pub enum KRB5Event {
@@ -104,7 +103,7 @@ impl KRB5State {
     /// Parse a Kerberos request message
     ///
     /// Returns 0 in case of success, or -1 on error
-    fn parse(&mut self, i: &[u8], _direction: u8) -> i32 {
+    fn parse(&mut self, i: &[u8], _direction: Direction) -> i32 {
         match der_read_element_header(i) {
             Ok((_rem,hdr)) => {
                 // Kerberos messages start with an APPLICATION header
@@ -417,7 +416,7 @@ pub unsafe extern "C" fn rs_krb5_parse_request(_flow: *const core::Flow,
                                        _flags: u8) -> AppLayerResult {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,KRB5State);
-    if state.parse(buf, STREAM_TOSERVER) < 0 {
+    if state.parse(buf, Direction::ToServer) < 0 {
         return AppLayerResult::err();
     }
     AppLayerResult::ok()
@@ -433,7 +432,7 @@ pub unsafe extern "C" fn rs_krb5_parse_response(_flow: *const core::Flow,
                                        _flags: u8) -> AppLayerResult {
     let buf = build_slice!(input,input_len as usize);
     let state = cast_pointer!(state,KRB5State);
-    if state.parse(buf, STREAM_TOCLIENT) < 0 {
+    if state.parse(buf, Direction::ToClient) < 0 {
         return AppLayerResult::err();
     }
     AppLayerResult::ok()
@@ -484,7 +483,7 @@ pub unsafe extern "C" fn rs_krb5_parse_request_tcp(_flow: *const core::Flow,
             }
         }
         if cur_i.len() >= state.record_ts {
-            if state.parse(cur_i, STREAM_TOSERVER) < 0 {
+            if state.parse(cur_i, Direction::ToServer) < 0 {
                 return AppLayerResult::err();
             }
             state.record_ts = 0;
@@ -543,7 +542,7 @@ pub unsafe extern "C" fn rs_krb5_parse_response_tcp(_flow: *const core::Flow,
             }
         }
         if cur_i.len() >= state.record_tc {
-            if state.parse(cur_i, STREAM_TOCLIENT) < 0 {
+            if state.parse(cur_i, Direction::ToClient) < 0 {
                 return AppLayerResult::err();
             }
             state.record_tc = 0;

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -21,7 +21,7 @@ use super::mqtt_message::*;
 use super::parser::*;
 use crate::applayer::{self, LoggerFlags};
 use crate::applayer::*;
-use crate::core::{self, AppProto, Flow, ALPROTO_FAILED, ALPROTO_UNKNOWN, IPPROTO_TCP};
+use crate::core::{self, *};
 use nom;
 use std;
 use std::ffi::CString;
@@ -660,11 +660,11 @@ pub unsafe extern "C" fn rs_mqtt_tx_get_alstate_progress(
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, MQTTTransaction);
     if tx.complete {
-        if direction == core::STREAM_TOSERVER {
+        if direction == Direction::ToServer.into() {
             if tx.toserver {
                 return 1;
             }
-        } else if direction == core::STREAM_TOCLIENT {
+        } else if direction == Direction::ToClient.into() {
             if tx.toclient {
                 return 1;
             }

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -474,7 +474,7 @@ impl NFSState {
                     if self.ts > f.post_gap_ts {
                         tx.request_done = true;
                         tx.response_done = true;
-                        let (files, flags) = self.files.get(tx.file_tx_direction);
+                        let (files, flags) = self.files.get(tx.file_tx_direction.into());
                         f.file_tracker.trunc(files, flags);
                     } else {
                         post_gap_txs = true;
@@ -594,7 +594,7 @@ impl NFSState {
                 tx.id, String::from_utf8_lossy(file_name));
         self.transactions.push(tx);
         let tx_ref = self.transactions.last_mut();
-        let (files, flags) = self.files.get(direction);
+        let (files, flags) = self.files.get(direction.into());
         return (tx_ref.unwrap(), files, flags)
     }
 
@@ -608,7 +608,7 @@ impl NFSState {
                 tx.file_handle == fh
             {
                 SCLogDebug!("Found NFS file TX with ID {} XID {:04X}", tx.id, tx.xid);
-                let (files, flags) = self.files.get(direction);
+                let (files, flags) = self.files.get(direction.into());
                 return Some((tx, files, flags));
             }
         }

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -118,7 +118,7 @@ impl NFSState {
             SCLogDebug!("COMMIT, closing shop");
             if let Ok((_, rd)) = parse_nfs3_request_commit(r.prog_data) {
                 let file_handle = rd.handle.value.to_vec();
-                if let Some((tx, files, flags)) = self.get_file_tx_by_handle(&file_handle, STREAM_TOSERVER) {
+                if let Some((tx, files, flags)) = self.get_file_tx_by_handle(&file_handle, Direction::ToServer) {
                     if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
                         tdf.chunk_count += 1;
                         tdf.file_additional_procs.push(NFSPROC3_COMMIT);
@@ -165,12 +165,12 @@ impl NFSState {
 
         } else if r.procedure == NFSPROC3_READ {
 
-            let found = match self.get_file_tx_by_handle(&xidmap.file_handle, STREAM_TOCLIENT) {
+            let found = match self.get_file_tx_by_handle(&xidmap.file_handle, Direction::ToClient) {
                 Some((_, _, _)) => true,
                 None => false,
             };
             if !found {
-                let (tx, _, _) = self.new_file_tx(&xidmap.file_handle, &xidmap.file_name, STREAM_TOCLIENT);
+                let (tx, _, _) = self.new_file_tx(&xidmap.file_handle, &xidmap.file_name, Direction::ToClient);
                 tx.procedure = NFSPROC3_READ;
                 tx.xid = r.hdr.xid;
                 tx.is_first = true;

--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -60,7 +60,7 @@ impl NFSState {
             Vec::new()
         };
 
-        let found = match self.get_file_tx_by_handle(&file_handle, STREAM_TOSERVER) {
+        let found = match self.get_file_tx_by_handle(&file_handle, Direction::ToServer) {
             Some((tx, files, flags)) => {
                 if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
                     filetracker_newchunk(&mut tdf.file_tracker, files, flags,
@@ -78,7 +78,7 @@ impl NFSState {
             None => false,
         };
         if !found {
-            let (tx, files, flags) = self.new_file_tx(&file_handle, &file_name, STREAM_TOSERVER);
+            let (tx, files, flags) = self.new_file_tx(&file_handle, &file_name, Direction::ToServer);
             if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
                 filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                         &file_name, w.data, w.offset,
@@ -110,7 +110,7 @@ impl NFSState {
         SCLogDebug!("COMMIT, closing shop");
 
         let file_handle = fh.to_vec();
-        if let Some((tx, files, flags)) = self.get_file_tx_by_handle(&file_handle, STREAM_TOSERVER) {
+        if let Some((tx, files, flags)) = self.get_file_tx_by_handle(&file_handle, Direction::ToServer) {
             if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
                 tdf.file_tracker.close(files, flags);
                 tdf.file_last_xid = r.hdr.xid;

--- a/rust/src/sip/detect.rs
+++ b/rust/src/sip/detect.rs
@@ -17,7 +17,7 @@
 
 // written by Giuseppe Longo <giuseppe@glongo.it>
 
-use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
+use crate::core::Direction;
 use crate::sip::sip::SIPTransaction;
 use std::ptr;
 
@@ -70,8 +70,8 @@ pub unsafe extern "C" fn rs_sip_tx_get_protocol(
     buffer_len: *mut u32,
     direction: u8,
 ) -> u8 {
-    match direction {
-        STREAM_TOSERVER => {
+    match direction.into() {
+        Direction::ToServer => {
             if let Some(ref r) = tx.request {
                 let v = &r.version;
                 if v.len() > 0 {
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn rs_sip_tx_get_protocol(
                 }
             }
         }
-        STREAM_TOCLIENT => {
+        Direction::ToClient => {
             if let Some(ref r) = tx.response {
                 let v = &r.version;
                 if v.len() > 0 {
@@ -91,7 +91,6 @@ pub unsafe extern "C" fn rs_sip_tx_get_protocol(
                 }
             }
         }
-        _ => {}
     }
 
     *buffer = ptr::null();

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn rs_smb_tx_get_stub_data(tx: &mut SMBTransaction,
 {
     match tx.type_data {
         Some(SMBTransactionTypeData::DCERPC(ref x)) => {
-            let vref = if direction == STREAM_TOSERVER {
+            let vref = if direction == Direction::ToServer as u8 {
                 &x.stub_data_ts
             } else {
                 &x.stub_data_tc

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -77,7 +77,7 @@ impl SMBState {
                 tx.id, String::from_utf8_lossy(file_name));
         self.transactions.push(tx);
         let tx_ref = self.transactions.last_mut();
-        let (files, flags) = self.files.get(direction);
+        let (files, flags) = self.files.get(direction.into());
         return (tx_ref.unwrap(), files, flags)
     }
 
@@ -95,7 +95,7 @@ impl SMBState {
 
             if found {
                 SCLogDebug!("SMB: Found SMB file TX with ID {}", tx.id);
-                let (files, flags) = self.files.get(direction);
+                let (files, flags) = self.files.get(direction.into());
                 return Some((tx, files, flags));
             }
         }

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -25,7 +25,7 @@ use crate::smb::smb::*;
 /// File tracking transaction. Single direction only.
 #[derive(Default, Debug)]
 pub struct SMBTransactionFile {
-    pub direction: u8,
+    pub direction: Direction,
     pub fuid: Vec<u8>,
     pub file_name: Vec<u8>,
     pub share_name: Vec<u8>,
@@ -58,7 +58,7 @@ pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContai
 }
 
 impl SMBState {
-    pub fn new_file_tx(&mut self, fuid: &Vec<u8>, file_name: &Vec<u8>, direction: u8)
+    pub fn new_file_tx(&mut self, fuid: &Vec<u8>, file_name: &Vec<u8>, direction: Direction)
         -> (&mut SMBTransaction, &mut FileContainer, u16)
     {
         let mut tx = self.new_tx();
@@ -77,11 +77,11 @@ impl SMBState {
                 tx.id, String::from_utf8_lossy(file_name));
         self.transactions.push(tx);
         let tx_ref = self.transactions.last_mut();
-        let (files, flags) = self.files.get(direction.into());
+        let (files, flags) = self.files.get(direction);
         return (tx_ref.unwrap(), files, flags)
     }
 
-    pub fn get_file_tx_by_fuid(&mut self, fuid: &Vec<u8>, direction: u8)
+    pub fn get_file_tx_by_fuid(&mut self, fuid: &Vec<u8>, direction: Direction)
         -> Option<(&mut SMBTransaction, &mut FileContainer, u16)>
     {
         let f = fuid.to_vec();
@@ -95,7 +95,7 @@ impl SMBState {
 
             if found {
                 SCLogDebug!("SMB: Found SMB file TX with ID {}", tx.id);
-                let (files, flags) = self.files.get(direction.into());
+                let (files, flags) = self.files.get(direction);
                 return Some((tx, files, flags));
             }
         }
@@ -103,17 +103,17 @@ impl SMBState {
         return None;
     }
 
-    fn getfiles(&mut self, direction: u8) -> * mut FileContainer {
-        //SCLogDebug!("direction: {}", direction);
-        if direction == STREAM_TOCLIENT {
+    fn getfiles(&mut self, direction: Direction) -> * mut FileContainer {
+        //SCLogDebug!("direction: {:?}", direction);
+        if direction == Direction::ToClient {
             &mut self.files.files_tc as *mut FileContainer
         } else {
             &mut self.files.files_ts as *mut FileContainer
         }
     }
-    fn setfileflags(&mut self, direction: u8, flags: u16) {
-        SCLogDebug!("direction: {}, flags: {}", direction, flags);
-        if direction == STREAM_TOCLIENT {
+    fn setfileflags(&mut self, direction: Direction, flags: u16) {
+        SCLogDebug!("direction: {:?}, flags: {}", direction, flags);
+        if direction == Direction::ToClient {
             self.files.flags_tc = flags;
         } else {
             self.files.flags_ts = flags;
@@ -122,8 +122,8 @@ impl SMBState {
 
     // update in progress chunks for file transfers
     // return how much data we consumed
-    pub fn filetracker_update(&mut self, direction: u8, data: &[u8], gap_size: u32) -> u32 {
-        let mut chunk_left = if direction == STREAM_TOSERVER {
+    pub fn filetracker_update(&mut self, direction: Direction, data: &[u8], gap_size: u32) -> u32 {
+        let mut chunk_left = if direction == Direction::ToServer {
             self.file_ts_left
         } else {
             self.file_tc_left
@@ -132,7 +132,7 @@ impl SMBState {
             return 0
         }
         SCLogDebug!("chunk_left {} data {}", chunk_left, data.len());
-        let file_handle = if direction == STREAM_TOSERVER {
+        let file_handle = if direction == Direction::ToServer {
             self.file_ts_guid.to_vec()
         } else {
             self.file_tc_guid.to_vec()
@@ -150,7 +150,7 @@ impl SMBState {
             chunk_left -= data.len() as u32;
         }
 
-        if direction == STREAM_TOSERVER {
+        if direction == Direction::ToServer {
             self.file_ts_left = chunk_left;
         } else {
             self.file_tc_left = chunk_left;
@@ -194,7 +194,7 @@ impl SMBState {
 pub unsafe extern "C" fn rs_smb_getfiles(ptr: *mut std::ffi::c_void, direction: u8) -> * mut FileContainer {
     if ptr.is_null() { panic!("NULL ptr"); };
     let parser = cast_pointer!(ptr, SMBState);
-    parser.getfiles(direction)
+    parser.getfiles(direction.into())
 }
 
 #[no_mangle]
@@ -202,5 +202,5 @@ pub unsafe extern "C" fn rs_smb_setfileflags(direction: u8, ptr: *mut SMBState, 
     if ptr.is_null() { panic!("NULL ptr"); };
     let parser = &mut *ptr;
     SCLogDebug!("direction {} flags {}", direction, flags);
-    parser.setfileflags(direction, flags)
+    parser.setfileflags(direction.into(), flags)
 }

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1131,7 +1131,7 @@ impl SMBState {
                     if self.ts > f.post_gap_ts {
                         tx.request_done = true;
                         tx.response_done = true;
-                        let (files, flags) = self.files.get(f.direction);
+                        let (files, flags) = self.files.get(f.direction.into());
                         f.file_tracker.trunc(files, flags);
                     } else {
                         post_gap_txs = true;

--- a/rust/src/ssh/detect.rs
+++ b/rust/src/ssh/detect.rs
@@ -16,7 +16,7 @@
  */
 
 use super::ssh::SSHTransaction;
-use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
+use crate::core::Direction;
 use std::ptr;
 
 #[no_mangle]
@@ -24,8 +24,8 @@ pub unsafe extern "C" fn rs_ssh_tx_get_protocol(
     tx: *mut std::os::raw::c_void, buffer: *mut *const u8, buffer_len: *mut u32, direction: u8,
 ) -> u8 {
     let tx = cast_pointer!(tx, SSHTransaction);
-    match direction {
-        STREAM_TOSERVER => {
+    match direction.into() {
+        Direction::ToServer => {
             let m = &tx.cli_hdr.protover;
             if m.len() > 0 {
                 *buffer = m.as_ptr();
@@ -33,7 +33,7 @@ pub unsafe extern "C" fn rs_ssh_tx_get_protocol(
                 return 1;
             }
         }
-        STREAM_TOCLIENT => {
+        Direction::ToClient => {
             let m = &tx.srv_hdr.protover;
             if m.len() > 0 {
                 *buffer = m.as_ptr();
@@ -41,7 +41,6 @@ pub unsafe extern "C" fn rs_ssh_tx_get_protocol(
                 return 1;
             }
         }
-        _ => {}
     }
     *buffer = ptr::null();
     *buffer_len = 0;
@@ -54,8 +53,8 @@ pub unsafe extern "C" fn rs_ssh_tx_get_software(
     tx: *mut std::os::raw::c_void, buffer: *mut *const u8, buffer_len: *mut u32, direction: u8,
 ) -> u8 {
     let tx = cast_pointer!(tx, SSHTransaction);
-    match direction {
-        STREAM_TOSERVER => {
+    match direction.into() {
+        Direction::ToServer => {
             let m = &tx.cli_hdr.swver;
             if m.len() > 0 {
                 *buffer = m.as_ptr();
@@ -63,7 +62,7 @@ pub unsafe extern "C" fn rs_ssh_tx_get_software(
                 return 1;
             }
         }
-        STREAM_TOCLIENT => {
+        Direction::ToClient => {
             let m = &tx.srv_hdr.swver;
             if m.len() > 0 {
                 *buffer = m.as_ptr();
@@ -71,7 +70,6 @@ pub unsafe extern "C" fn rs_ssh_tx_get_software(
                 return 1;
             }
         }
-        _ => {}
     }
     *buffer = ptr::null();
     *buffer_len = 0;
@@ -87,8 +85,8 @@ pub unsafe extern "C" fn rs_ssh_tx_get_hassh(
     direction: u8,
 ) -> u8 {
     let tx = cast_pointer!(tx, SSHTransaction);
-    match direction {
-        STREAM_TOSERVER => {
+    match direction.into() {
+        Direction::ToServer => {
             let m = &tx.cli_hdr.hassh;
             if m.len() > 0 {
                 *buffer = m.as_ptr();
@@ -96,7 +94,7 @@ pub unsafe extern "C" fn rs_ssh_tx_get_hassh(
                 return 1;
             }
         }
-        STREAM_TOCLIENT => {
+        Direction::ToClient => {
             let m = &tx.srv_hdr.hassh;
             if m.len() > 0 {
                 *buffer = m.as_ptr();
@@ -104,7 +102,6 @@ pub unsafe extern "C" fn rs_ssh_tx_get_hassh(
                 return 1;
             }
         }
-        _ => {}
     }
     *buffer = ptr::null();
     *buffer_len = 0;
@@ -120,8 +117,8 @@ pub unsafe extern "C" fn rs_ssh_tx_get_hassh_string(
     direction: u8,
 ) -> u8 {
     let tx = cast_pointer!(tx, SSHTransaction);
-    match direction {
-        STREAM_TOSERVER => {
+    match direction.into() {
+        Direction::ToServer => {
             let m = &tx.cli_hdr.hassh_string;
             if m.len() > 0 {
                 *buffer = m.as_ptr();
@@ -129,7 +126,7 @@ pub unsafe extern "C" fn rs_ssh_tx_get_hassh_string(
                 return 1;
             }
         }
-        STREAM_TOCLIENT => {
+        Direction::ToClient => {
             let m = &tx.srv_hdr.hassh_string;
             if m.len() > 0 {
                 *buffer = m.as_ptr();
@@ -137,7 +134,6 @@ pub unsafe extern "C" fn rs_ssh_tx_get_hassh_string(
                 return 1;
             }
         }
-        _ => {}
     }
     *buffer = ptr::null();
     *buffer_len = 0;

--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -17,8 +17,7 @@
 
 use super::parser;
 use crate::applayer::*;
-use crate::core::STREAM_TOSERVER;
-use crate::core::{self, AppProto, Flow, ALPROTO_UNKNOWN, IPPROTO_TCP};
+use crate::core::{self, *};
 use std::ffi::CString;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -429,7 +428,7 @@ pub unsafe extern "C" fn rs_ssh_tx_get_flags(
     tx: *mut std::os::raw::c_void, direction: u8,
 ) -> SSHConnectionState {
     let tx = cast_pointer!(tx, SSHTransaction);
-    if direction == STREAM_TOSERVER {
+    if direction == Direction::ToServer.into() {
         return tx.cli_hdr.flags;
     } else {
         return tx.srv_hdr.flags;
@@ -448,7 +447,7 @@ pub unsafe extern "C" fn rs_ssh_tx_get_alstate_progress(
         return SSHConnectionState::SshStateFinished as i32;
     }
 
-    if direction == STREAM_TOSERVER {
+    if direction == Direction::ToServer.into() {
         if tx.cli_hdr.flags >= SSHConnectionState::SshStateBannerDone {
             return SSHConnectionState::SshStateBannerDone as i32;
         }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3832
https://redmine.openinfosecfoundation.org/issues/4563 (accidental fix and not intended by this series of patches)

suricata-verify-pr: 579

Note: Places with bitwise ops w/ Direction do not use `.into()` construct as Rust complains about not being able to decipher the type and giving a constant a concrete type in a separate line every time it was to be used with bitwise ops did not seem nice to me. It is only done at few places.