### PR TITLE
range: prevents memory leak of file from HTTP2

### DIFF
--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -363,6 +363,7 @@ void HTPFileCloseHandleRange(FileContainer *files, const uint16_t flags, HttpRan
             /* HtpState owns the constructed file now */
             FileContainerAdd(files, ranged);
         }
+        DEBUG_VALIDATE_BUG_ON(ranged && !files);
         THashDataUnlock(c->container->hdata);
     }
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4811

Describe changes:
- Fixes a memory leak in range requests from HTTP2

https://redmine.openinfosecfoundation.org/issues/4444 will make this fix nicer