### PR TITLE
Flow manager adaptive/v6

### DIFF
--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -964,7 +964,6 @@ void AppLayerSetupCounters()
     AppProto alproto;
     AppProto alprotos[ALPROTO_MAX];
     const char *str = "app_layer.flow.";
-    const char *estr = "app_layer.error.";
 
     AppLayerProtoDetectSupportedAppProtocols(alprotos);
 
@@ -990,16 +989,16 @@ void AppLayerSetupCounters()
 
                     snprintf(applayer_counter_names[ipproto_map][alproto].gap_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].gap_error),
-                            "%s%s%s.gap_errors", estr, alproto_str, ipproto_suffix);
+                            "%s%s%s.gap_errors", str, alproto_str, ipproto_suffix);
                     snprintf(applayer_counter_names[ipproto_map][alproto].alloc_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].alloc_error),
-                            "%s%s%s.alloc_errors", estr, alproto_str, ipproto_suffix);
+                            "%s%s%s.alloc_errors", str, alproto_str, ipproto_suffix);
                     snprintf(applayer_counter_names[ipproto_map][alproto].parser_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].parser_error),
-                            "%s%s%s.parser_errors", estr, alproto_str, ipproto_suffix);
+                            "%s%s%s.parser_errors", str, alproto_str, ipproto_suffix);
                     snprintf(applayer_counter_names[ipproto_map][alproto].internal_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].internal_error),
-                            "%s%s%s.internal_errors", estr, alproto_str, ipproto_suffix);
+                            "%s%s%s.internal_errors", str, alproto_str, ipproto_suffix);
                 } else {
                     snprintf(applayer_counter_names[ipproto_map][alproto].name,
                             sizeof(applayer_counter_names[ipproto_map][alproto].name),
@@ -1010,16 +1009,16 @@ void AppLayerSetupCounters()
 
                     snprintf(applayer_counter_names[ipproto_map][alproto].gap_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].gap_error),
-                            "%s%s.gap_errors", estr, alproto_str);
+                            "%s%s.gap_errors", str, alproto_str);
                     snprintf(applayer_counter_names[ipproto_map][alproto].alloc_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].alloc_error),
-                            "%s%s.alloc_errors", estr, alproto_str);
+                            "%s%s.alloc_errors", str, alproto_str);
                     snprintf(applayer_counter_names[ipproto_map][alproto].parser_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].parser_error),
-                            "%s%s.parser_errors", estr, alproto_str);
+                            "%s%s.parser_errors", str, alproto_str);
                     snprintf(applayer_counter_names[ipproto_map][alproto].internal_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].internal_error),
-                            "%s%s.internal_errors", estr, alproto_str);
+                            "%s%s.internal_errors", str, alproto_str);
                 }
             } else if (alproto == ALPROTO_FAILED) {
                 snprintf(applayer_counter_names[ipproto_map][alproto].name,
@@ -1028,7 +1027,7 @@ void AppLayerSetupCounters()
 
                 snprintf(applayer_counter_names[ipproto_map][alproto].gap_error,
                         sizeof(applayer_counter_names[ipproto_map][alproto].gap_error),
-                        "%sfailed%s.gap_errors", estr, ipproto_suffix);
+                        "%sfailed%s.gap_errors", str, ipproto_suffix);
             }
         }
     }

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -144,5 +144,9 @@ void AppLayerUnittestsRegister(void);
 #endif
 
 void AppLayerIncTxCounter(ThreadVars *tv, Flow *f, uint64_t step);
+void AppLayerIncGapErrorCounter(ThreadVars *tv, Flow *f);
+void AppLayerIncAllocErrorCounter(ThreadVars *tv, Flow *f);
+void AppLayerIncParserErrorCounter(ThreadVars *tv, Flow *f);
+void AppLayerIncInternalErrorCounter(ThreadVars *tv, Flow *f);
 
 #endif

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -580,6 +580,7 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, const Packet *p)
             if (!(SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY)) {
                 SC_ATOMIC_OR(flow_flags, FLOW_EMERGENCY);
                 FlowTimeoutsEmergency();
+                FlowWakeupFlowManagerThread();
             }
 
             f = FlowGetUsedFlow(tv, fls->dtv, &p->ts);

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -118,7 +118,6 @@ typedef struct FlowTimeoutCounters_ {
     uint32_t rows_checked;
     uint32_t rows_skipped;
     uint32_t rows_empty;
-    uint32_t rows_busy;
     uint32_t rows_maxlen;
 
     uint32_t flows_checked;
@@ -267,11 +266,6 @@ static inline int FlowBypassedTimeout(Flow *f, struct timeval *ts,
     return 1;
 }
 
-static inline int FMTryLockBucket(FlowBucket *fb)
-{
-    int r = FBLOCK_TRYLOCK(fb);
-    return r;
-}
 static inline void FMFlowLock(Flow *f)
 {
     FLOWLOCK_WRLOCK(f);
@@ -422,7 +416,6 @@ static uint32_t FlowTimeoutHash(FlowManagerTimeoutThread *td,
     const int emergency = ((SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY));
     const uint32_t rows_checked = hash_max - hash_min;
     uint32_t rows_skipped = 0;
-    uint32_t rows_busy = 0;
     uint32_t rows_empty = 0;
 
 #if __WORDSIZE==64
@@ -446,43 +439,34 @@ static uint32_t FlowTimeoutHash(FlowManagerTimeoutThread *td,
         for (uint32_t i = 0; i < check; i++) {
             FlowBucket *fb = &flow_hash[idx+i];
             if ((check_bits & ((TYPE)1 << (TYPE)i)) != 0 && SC_ATOMIC_GET(fb->next_ts) <= (int32_t)ts->tv_sec) {
-                if (FMTryLockBucket(fb) == 0) {
-                    Flow *evicted = NULL;
-                    if (fb->evicted != NULL || fb->head != NULL) {
-                        /* if evicted is set, we only process that list right now.
-                         * Since its set we've had traffic that touched this row
-                         * very recently, and there is a good chance more of it will
-                         * come in in the near future. So unlock the row asap and leave
-                         * the possible eviction of flows to the packet lookup path. */
-                        if (fb->evicted != NULL) {
-                            /* transfer out of bucket so we can do additional work outside
-                             * of the bucket lock */
-                            evicted = fb->evicted;
-                            fb->evicted = NULL;
-                        } else if (fb->head != NULL) {
-                            int32_t next_ts = 0;
-                            FlowManagerHashRowTimeout(td,
-                                    fb->head, ts, emergency, counters, &next_ts);
-
-                            if (SC_ATOMIC_GET(fb->next_ts) != next_ts)
-                                SC_ATOMIC_SET(fb->next_ts, next_ts);
-                        }
-                        if (fb->evicted == NULL && fb->head == NULL) {
-                            SC_ATOMIC_SET(fb->next_ts, INT_MAX);
-                        } else if (fb->evicted != NULL && fb->head == NULL) {
-                            SC_ATOMIC_SET(fb->next_ts, 0);
-                        }
-                    } else {
-                        SC_ATOMIC_SET(fb->next_ts, INT_MAX);
-                        rows_empty++;
+                FBLOCK_LOCK(fb);
+                Flow *evicted = NULL;
+                if (fb->evicted != NULL || fb->head != NULL) {
+                    if (fb->evicted != NULL) {
+                        /* transfer out of bucket so we can do additional work outside
+                         * of the bucket lock */
+                        evicted = fb->evicted;
+                        fb->evicted = NULL;
                     }
-                    FBLOCK_UNLOCK(fb);
-                    /* processed evicted list */
-                    if (evicted) {
-                        FlowManagerHashRowClearEvictedList(td, evicted, ts, counters);
+                    if (fb->head != NULL) {
+                        int32_t next_ts = 0;
+                        FlowManagerHashRowTimeout(td,
+                                fb->head, ts, emergency, counters, &next_ts);
+
+                        if (SC_ATOMIC_GET(fb->next_ts) != next_ts)
+                            SC_ATOMIC_SET(fb->next_ts, next_ts);
+                    }
+                    if (fb->evicted == NULL && fb->head == NULL) {
+                        SC_ATOMIC_SET(fb->next_ts, INT_MAX);
                     }
                 } else {
-                    rows_busy++;
+                    SC_ATOMIC_SET(fb->next_ts, INT_MAX);
+                    rows_empty++;
+                }
+                FBLOCK_UNLOCK(fb);
+                /* processed evicted list */
+                if (evicted) {
+                    FlowManagerHashRowClearEvictedList(td, evicted, ts, counters);
                 }
             } else {
                 rows_skipped++;
@@ -495,7 +479,6 @@ static uint32_t FlowTimeoutHash(FlowManagerTimeoutThread *td,
 
     counters->rows_checked += rows_checked;
     counters->rows_skipped += rows_skipped;
-    counters->rows_busy += rows_busy;
     counters->rows_empty += rows_empty;
 
     if (td->aside_queue.len) {
@@ -917,7 +900,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
             }
 
             /* try to time out flows */
-            FlowTimeoutCounters counters = { 0, 0, 0, 0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+            FlowTimeoutCounters counters = { 0, 0, 0, 0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 
             if (emerg) {
                 /* in emergency mode, do a full pass of the hash table */

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -71,6 +71,8 @@
 #include "output-flow.h"
 #include "util-validate.h"
 
+#include "runmode-unix-socket.h"
+
 /* Run mode selected at suricata.c */
 extern int run_mode;
 
@@ -504,22 +506,36 @@ static uint32_t FlowTimeoutHash(FlowManagerTimeoutThread *td,
     return cnt;
 }
 
+/** \internal
+ *  \brief handle timeout for a slice of hash rows
+ *  If we wrap around we call FlowTimeoutHash twice */
 static uint32_t FlowTimeoutHashInChunks(FlowManagerTimeoutThread *td,
         struct timeval *ts,
         const uint32_t hash_min, const uint32_t hash_max,
-        FlowTimeoutCounters *counters, uint32_t iter, const uint32_t chunks)
+        FlowTimeoutCounters *counters, const uint32_t rows, uint32_t *pos)
 {
-    const uint32_t rows = hash_max - hash_min;
-    const uint32_t chunk_size = rows / chunks;
+    uint32_t start = 0;
+    uint32_t end = 0;
+    uint32_t cnt = 0;
+    uint32_t rows_left = rows;
 
-    const uint32_t min = iter * chunk_size + hash_min;
-    uint32_t max = min + chunk_size;
-    /* we start at beginning of hash at next iteration so let's check
-     * hash till the end */
-    if (iter + 1 == chunks) {
-        max = hash_max;
+again:
+    start = hash_min + (*pos);
+    if (start >= hash_max) {
+        start = hash_min;
     }
-    const uint32_t cnt = FlowTimeoutHash(td, ts, min, max, counters);
+    end = start + rows_left;
+    if (end > hash_max) {
+        end = hash_max;
+    }
+    *pos = (end == hash_max) ? hash_min : end;
+    rows_left = rows_left - (end - start);
+
+    //SCLogNotice("hash %u:%u slice %u-%u rows %u rows_left %u *pos %u", hash_min, hash_max, start, end, rows, rows_left, *pos);
+    cnt += FlowTimeoutHash(td, ts, start, end, counters);
+    if (rows_left) {
+        goto again;
+    }
     return cnt;
 }
 
@@ -639,6 +655,11 @@ typedef struct FlowCounters_ {
     uint16_t flow_bypassed_cnt_clo;
     uint16_t flow_bypassed_pkts;
     uint16_t flow_bypassed_bytes;
+
+    uint16_t memcap_pressure;
+    uint16_t memcap_pressure_max;
+
+    uint16_t flow_pass_in_sec;
 } FlowCounters;
 
 typedef struct FlowManagerThreadData_ {
@@ -673,6 +694,11 @@ static void FlowCountersInit(ThreadVars *t, FlowCounters *fc)
     fc->flow_bypassed_cnt_clo = StatsRegisterCounter("flow_bypassed.closed", t);
     fc->flow_bypassed_pkts = StatsRegisterCounter("flow_bypassed.pkts", t);
     fc->flow_bypassed_bytes = StatsRegisterCounter("flow_bypassed.bytes", t);
+
+    fc->memcap_pressure = StatsRegisterCounter("memcap_pressure", t);
+    fc->memcap_pressure_max = StatsRegisterMaxCounter("memcap_pressure_max", t);
+
+    fc->flow_pass_in_sec = StatsRegisterCounter("flow.mgr.hash_pass_in_sec", t);
 }
 
 static TmEcode FlowManagerThreadInit(ThreadVars *t, const void *initdata, void **data)
@@ -736,6 +762,43 @@ static uint32_t FlowTimeoutsMin(void)
 
 //#define FM_PROFILE
 
+static void GetWorkUnitSizing(const uint32_t pass_in_sec_base, const uint32_t rows, const uint32_t mp,
+        const bool emergency,
+        uint64_t *wu_sleep, uint32_t *wu_rows)
+{
+    if (emergency) {
+        *wu_rows = rows;
+        *wu_sleep = 250;
+        return;
+    }
+
+    uint32_t full_pass_in_ms = pass_in_sec_base * 1000;
+    float perc = MIN((((float)(100 - mp) / (float)100)),1);
+    full_pass_in_ms *= perc;
+    full_pass_in_ms = MAX(full_pass_in_ms, 333);
+
+    uint32_t work_unit_ms = 999 * perc;
+    work_unit_ms = MAX(work_unit_ms, 250);
+
+    uint32_t wus_per_full_pass = full_pass_in_ms / work_unit_ms;
+
+    uint32_t rows_per_wu = MAX(1, rows / wus_per_full_pass);
+    uint32_t rows_process_cost = rows_per_wu / 1000; // est 1usec per row
+
+    int32_t sleep_per_wu = work_unit_ms - rows_process_cost;
+    sleep_per_wu = MAX(sleep_per_wu, 10);
+#if 0
+    float passes_sec = 1000.0/(float)full_pass_in_ms;
+    SCLogNotice("full_pass_in_ms %u perc %f rows %u "
+            "wus_per_full_pass %u rows_per_wu %u work_unit_ms %u sleep_per_wu %u => passes/s %f rows/s %u",
+            full_pass_in_ms, perc, rows,
+            wus_per_full_pass, rows_per_wu, work_unit_ms, (uint32_t)sleep_per_wu,
+            passes_sec, (uint32_t)((float)rows * passes_sec));
+#endif
+    *wu_sleep = sleep_per_wu;
+    *wu_rows = rows_per_wu;
+}
+
 /** \brief Thread that manages the flow table and times out flows.
  *
  *  \param td ThreadVars casted to void ptr
@@ -750,7 +813,6 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
     bool emerg = false;
     bool prev_emerg = false;
     uint32_t other_last_sec = 0; /**< last sec stamp when defrag etc ran */
-    uint32_t flow_last_sec = 0;
 /* VJ leaving disabled for now, as hosts are only used by tags and the numbers
  * are really low. Might confuse ppl
     uint16_t flow_mgr_host_prune = StatsRegisterCounter("hosts.pruned", th_v);
@@ -758,15 +820,10 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
     uint16_t flow_mgr_host_spare = StatsRegisterCounter("hosts.spare", th_v);
 */
     memset(&ts, 0, sizeof(ts));
-    uint32_t hash_passes = 0;
-#ifdef FM_PROFILE
-    uint32_t hash_row_checks = 0;
-    uint32_t hash_passes_chunks = 0;
-#endif
-    uint32_t hash_full_passes = 0;
 
     const uint32_t min_timeout = FlowTimeoutsMin();
-    const uint32_t pass_in_sec = min_timeout ? min_timeout * 8 : 60;
+    const uint32_t pass_in_sec_base = min_timeout ? min_timeout * 8 : 60;
+    //uint32_t pass_in_sec = pass_in_sec_base;
 
     /* don't start our activities until time is setup */
     while (!TimeModeIsReady()) {
@@ -775,7 +832,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
     }
 
     SCLogDebug("FM %s/%d starting. min_timeout %us. Full hash pass in %us", th_v->name,
-            ftd->instance, min_timeout, pass_in_sec);
+            ftd->instance, min_timeout, pass_in_sec_base);
 
 #ifdef FM_PROFILE
     struct timeval endts;
@@ -792,9 +849,20 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
     memset(&startts, 0, sizeof(startts));
     gettimeofday(&startts, NULL);
 
-    uint32_t hash_pass_iter = 0;
     uint32_t emerg_over_cnt = 0;
     uint64_t next_run_ms = 0;
+    const uint32_t rows = ftd->max - ftd->min;
+    uint32_t pos = 0;
+    uint32_t rows_per_wu = 0;
+    uint64_t sleep_per_wu = 0;
+
+    uint32_t mp = MemcapsGetPressure() * 100;
+    if (ftd->instance == 0) {
+        StatsSetUI64(th_v, ftd->cnt.memcap_pressure, mp);
+        StatsSetUI64(th_v, ftd->cnt.memcap_pressure_max, mp);
+    }
+    GetWorkUnitSizing(pass_in_sec_base, rows, mp, emerg, &sleep_per_wu, &rows_per_wu);
+    SCLogNotice("rows_per_wu %u, sleep_per_wu %"PRIu64", mp %u%%", rows_per_wu, sleep_per_wu, mp);
 
     while (1)
     {
@@ -831,7 +899,6 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         TimeGet(&ts);
         SCLogDebug("ts %" PRIdMAX "", (intmax_t)ts.tv_sec);
         const uint64_t ts_ms = ts.tv_sec * 1000 + ts.tv_usec / 1000;
-        const uint32_t rt = (uint32_t)ts.tv_sec;
         const bool emerge_p = (emerg && !prev_emerg);
         if (emerge_p) {
             next_run_ms = 0;
@@ -848,7 +915,6 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
                     FlowSparePoolUpdate(sq_len);
                 }
             }
-            const uint32_t secs_passed = rt - flow_last_sec;
 
             /* try to time out flows */
             FlowTimeoutCounters counters = { 0, 0, 0, 0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
@@ -856,34 +922,17 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
             if (emerg) {
                 /* in emergency mode, do a full pass of the hash table */
                 FlowTimeoutHash(&ftd->timeout, &ts, ftd->min, ftd->max, &counters);
-                hash_passes++;
-                hash_full_passes++;
-                hash_passes++;
-#ifdef FM_PROFILE
-                hash_passes_chunks += 1;
-                hash_row_checks += counters.rows_checked;
-#endif
                 StatsIncr(th_v, ftd->cnt.flow_mgr_full_pass);
             } else {
-                /* non-emergency mode: scan part of the hash */
-                const uint32_t chunks = MIN(secs_passed, pass_in_sec);
-                for (uint32_t i = 0; i < chunks; i++) {
-                    FlowTimeoutHashInChunks(&ftd->timeout, &ts, ftd->min, ftd->max,
-                            &counters, hash_pass_iter, pass_in_sec);
-                    hash_pass_iter++;
-                    if (hash_pass_iter == pass_in_sec) {
-                        hash_pass_iter = 0;
-                        hash_full_passes++;
-                        StatsIncr(th_v, ftd->cnt.flow_mgr_full_pass);
-                    }
+                SCLogDebug("hash %u:%u slice starting at %u with %u rows", ftd->min, ftd->max, pos, rows_per_wu);
+
+                const uint32_t ppos = pos;
+                FlowTimeoutHashInChunks(&ftd->timeout, &ts, ftd->min, ftd->max,
+                              &counters, rows_per_wu, &pos);
+                if (ppos > pos) {
+                    StatsIncr(th_v, ftd->cnt.flow_mgr_full_pass);
                 }
-                hash_passes++;
-#ifdef FM_PROFILE
-                hash_row_checks += counters.rows_checked;
-                hash_passes_chunks += chunks;
-#endif
             }
-            flow_last_sec = rt;
 
             /*
                StatsAddUI64(th_v, flow_mgr_host_prune, (uint64_t)hosts_pruned);
@@ -917,54 +966,61 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
              * clear emergency bit if we have at least xx flows pruned. */
             uint32_t len = FlowSpareGetPoolSize();
             StatsSetUI64(th_v, ftd->cnt.flow_mgr_spare, (uint64_t)len);
+
             if (emerg == true) {
                 SCLogDebug("flow_sparse_q.len = %"PRIu32" prealloc: %"PRIu32
                         "flow_spare_q status: %"PRIu32"%% flows at the queue",
                         len, flow_config.prealloc, len * 100 / flow_config.prealloc);
 
-            /* only if we have pruned this "emergency_recovery" percentage
-             * of flows, we will unset the emergency bit */
-            if (len * 100 / flow_config.prealloc > flow_config.emergency_recovery) {
-                emerg_over_cnt++;
-            } else {
-                emerg_over_cnt = 0;
+                /* only if we have pruned this "emergency_recovery" percentage
+                 * of flows, we will unset the emergency bit */
+                if (len * 100 / flow_config.prealloc > flow_config.emergency_recovery) {
+                    emerg_over_cnt++;
+                } else {
+                    emerg_over_cnt = 0;
+                }
+
+                if (emerg_over_cnt >= 30) {
+                    SC_ATOMIC_AND(flow_flags, ~FLOW_EMERGENCY);
+                    FlowTimeoutsReset();
+
+                    emerg = false;
+                    prev_emerg = false;
+                    emerg_over_cnt = 0;
+                    SCLogNotice("Flow emergency mode over, back to normal... unsetting"
+                            " FLOW_EMERGENCY bit (ts.tv_sec: %"PRIuMAX", "
+                            "ts.tv_usec:%"PRIuMAX") flow_spare_q status(): %"PRIu32
+                            "%% flows at the queue", (uintmax_t)ts.tv_sec,
+                            (uintmax_t)ts.tv_usec, len * 100 / flow_config.prealloc);
+
+                    StatsIncr(th_v, ftd->cnt.flow_emerg_mode_over);
+                }
             }
 
-            if (emerg_over_cnt >= 30) {
-                SC_ATOMIC_AND(flow_flags, ~FLOW_EMERGENCY);
-                FlowTimeoutsReset();
+            /* update work units */
+            const uint32_t pmp = mp;
+            mp = MemcapsGetPressure() * 100;
+            if (ftd->instance == 0) {
+                StatsSetUI64(th_v, ftd->cnt.memcap_pressure, mp);
+                StatsSetUI64(th_v, ftd->cnt.memcap_pressure_max, mp);
+            }
+            GetWorkUnitSizing(pass_in_sec_base, rows, mp, emerg, &sleep_per_wu, &rows_per_wu);
+            if (pmp != mp) {
+                SCLogNotice("rows_per_wu %u, sleep_per_wu %"PRIu64", mp %u%%", rows_per_wu, sleep_per_wu, mp);
+            }
 
-                emerg = false;
-                prev_emerg = false;
-                emerg_over_cnt = 0;
-                hash_pass_iter = 0;
-                SCLogNotice("Flow emergency mode over, back to normal... unsetting"
-                          " FLOW_EMERGENCY bit (ts.tv_sec: %"PRIuMAX", "
-                          "ts.tv_usec:%"PRIuMAX") flow_spare_q status(): %"PRIu32
-                          "%% flows at the queue", (uintmax_t)ts.tv_sec,
-                          (uintmax_t)ts.tv_usec, len * 100 / flow_config.prealloc);
-
-                StatsIncr(th_v, ftd->cnt.flow_emerg_mode_over);
+            next_run_ms = ts_ms + sleep_per_wu;
+        }
+        if (other_last_sec == 0 || other_last_sec < (uint32_t)ts.tv_sec) {
+            if (ftd->instance == 0) {
+                DefragTimeoutHash(&ts);
+                //uint32_t hosts_pruned =
+                HostTimeoutHash(&ts);
+                IPPairTimeoutHash(&ts);
+                HttpRangeContainersTimeoutHash(&ts);
+                other_last_sec = (uint32_t)ts.tv_sec;
             }
         }
-        next_run_ms = ts_ms + 667;
-        if (emerg)
-            next_run_ms = ts_ms + 250;
-        }
-        if (flow_last_sec == 0) {
-            flow_last_sec = rt;
-        }
-
-        if (ftd->instance == 0 &&
-                (other_last_sec == 0 || other_last_sec < (uint32_t)ts.tv_sec)) {
-            DefragTimeoutHash(&ts);
-            //uint32_t hosts_pruned =
-            HostTimeoutHash(&ts);
-            IPPairTimeoutHash(&ts);
-            HttpRangeContainersTimeoutHash(&ts);
-            other_last_sec = (uint32_t)ts.tv_sec;
-        }
-
 
 #ifdef FM_PROFILE
         struct timeval run_endts;
@@ -1007,11 +1063,6 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
               established_cnt, closing_cnt);
 
 #ifdef FM_PROFILE
-    SCLogNotice("hash passes %u avg chunks %u full %u rows %u (rows/s %u)",
-            hash_passes, hash_passes_chunks / (hash_passes ? hash_passes : 1),
-            hash_full_passes, hash_row_checks,
-            hash_row_checks / ((uint32_t)active.tv_sec?(uint32_t)active.tv_sec:1));
-
     gettimeofday(&endts, NULL);
     struct timeval total_run_time;
     timersub(&endts, &startts, &total_run_time);

--- a/src/flow-manager.h
+++ b/src/flow-manager.h
@@ -24,6 +24,11 @@
 #ifndef __FLOW_MANAGER_H__
 #define __FLOW_MANAGER_H__
 
+/** flow manager scheduling condition */
+extern SCCtrlCondT flow_manager_ctrl_cond;
+extern SCCtrlMutex flow_manager_ctrl_mutex;
+#define FlowWakeupFlowManagerThread() SCCtrlCondSignal(&flow_manager_ctrl_cond)
+
 #define FlowTimeoutsReset() FlowTimeoutsInit()
 void FlowTimeoutsInit(void);
 void FlowTimeoutsEmergency(void);

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -82,8 +82,6 @@ const char *RunModeUnixSocketGetDefaultMode(void)
     return "autofp";
 }
 
-#ifdef BUILD_UNIX_SOCKET
-
 #define MEMCAPS_MAX 7
 static MemcapCommand memcaps[MEMCAPS_MAX] = {
     {
@@ -129,6 +127,24 @@ static MemcapCommand memcaps[MEMCAPS_MAX] = {
         HostGetMemuse
     },
 };
+
+float MemcapsGetPressure(void)
+{
+    float percent = 0.0;
+    for (int i = 0; i < 4; i++) { // only flow, streams, http
+        uint64_t memcap = memcaps[i].GetFunc();
+        if (memcap) {
+            uint64_t memuse = memcaps[i].GetMemuseFunc();
+            float p = (float)((double)memuse / (double)memcap);
+            //SCLogNotice("%s: memuse %"PRIu64", memcap %"PRIu64" => %f%%",
+            //    memcaps[i].name, memuse, memcap, (p * 100));
+            percent = MAX(p, percent);
+        }
+    }
+    return percent;
+}
+
+#ifdef BUILD_UNIX_SOCKET
 
 static int RunModeUnixSocketMaster(void);
 static int unix_manager_pcap_task_running = 0;

--- a/src/runmode-unix-socket.h
+++ b/src/runmode-unix-socket.h
@@ -30,6 +30,8 @@ int RunModeUnixSocketIsActive(void);
 
 TmEcode UnixSocketPcapFile(TmEcode tm, struct timespec *last_processed);
 
+float MemcapsGetPressure(void);
+
 #ifdef BUILD_UNIX_SOCKET
 TmEcode UnixSocketDatasetAdd(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketDatasetRemove(json_t *cmd, json_t* answer, void *data);


### PR DESCRIPTION
Flow manager changes to address https://redmine.openinfosecfoundation.org/issues/4650. The core are the first two commits:

### flow/manager: adaptive hash eviction timing

The flow manager scans the hash table in chunks based on the flow timeout
settings. In the default config this will lead to a full hash pass every
240 seconds. Under pressure, this will lead to a large amount of memory
still in use by flows waiting to be evicted, or evicted flows waiting to
be freed.

This patch implements a new adaptive logic to the timing and amount of
work that is done by the flow manager. It takes the memcap budgets and
calculates the proportion of the memcap budgets in use. It takes the max
in-use percentage, and adapts the flow manager behavior based on that.

The memcaps considered are:
    flow, stream, stream-reassembly and app-layer-http

The percentage in use, is inversely applies to the time the flow manager
takes for a full hash pass. In addition, it is also applied to the chunk
size and the sleep time.

Example: tcp.reassembly_memuse is at 90% of the memcap and normal flow
hash pass is 240s. Hash pass time will be:

    240 * (100 - 90) / 100 = 24s

Chunk size and sleep time will automatically be updated for this.

Adds various counters.

### WIP TODO flow/manager: fix flows lingering w/o giving up resources

Flows have been shown to linger for a long time w/o giving up their resources.
This would lead to higher memory use and memcaps getting reached.

Three main causes have been identified:

Slow passes hash passes. By default the flow manager will scan the flow hash
slowly. It is based on the flow timeout settings, and with the default config
it will take 4 minutes for a full scan to be complete. This leaves a window for
flows that are timed out to linger for minutes longer than expected.

Flow Manager yields under pressure. The per row TryLock causes work to be
delayed more. The Flow manager will use trylock on a hash row and will yield
immediately if the row is busy. This means that it will take a full pass before
the row is revisited again. If the row holds busy flows, this could happen many
times in a row.

Flow Manager favors evicted flows over active flows. The Flow Manager will
only process the evicted flows if they are present. These flows have been
evicted by workers. The active flows on that hash row will have to wait
until the next hash pass. Of course by then there could be more evicted flows.

Combined these factors could lead to flows not being considered for freeing
and logging for a very long time, potentially even indefinitly.

The patch addresses the latter two flow manager issues by no longer using
TryLock. It will now simply wait for the lock to be released and then do
its work on it. Additionally for each row both the evicted list and the
active flow list will be processed.