### PR TITLE
app-layer: reduce boilerplate code - v3

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -514,6 +514,14 @@ pub unsafe fn get_event_info_by_id<T: AppLayerEvent>(
 /// in order to define some generic helper functions.
 pub trait Transaction {
     fn id(&self) -> u64;
+
+    /// Get the app-layer decoder events from the transaction.
+    ///
+    /// A default implementation is provided for app-layer implememtations
+    /// that do not have decoder events.
+    fn get_events(&self) -> *mut AppLayerDecoderEvents {
+        std::ptr::null_mut()
+    }
 }
 
 pub trait State<Tx: Transaction> {
@@ -546,4 +554,9 @@ pub unsafe extern "C" fn state_get_tx_iterator<S: State<Tx>, Tx: Transaction>(
 ) -> AppLayerGetTxIterTuple {
     let state = cast_pointer!(state, S);
     state.get_transaction_iterator(min_tx_id, istate)
+}
+
+pub unsafe extern "C" fn tx_get_events<Tx: Transaction>(tx: *mut c_void) -> *mut AppLayerDecoderEvents {
+    let tx = cast_pointer!(tx, Tx);
+    tx.get_events()
 }

--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -268,15 +268,6 @@ fn probe(input: &[u8]) -> nom::IResult<&[u8], ()> {
 
 // C exports.
 
-export_tx_get_detect_state!(
-    rs_template_tx_get_detect_state,
-    TemplateTransaction
-);
-export_tx_set_detect_state!(
-    rs_template_tx_set_detect_state,
-    TemplateTransaction
-);
-
 /// C entry point for a probing parser.
 #[no_mangle]
 pub unsafe extern "C" fn rs_template_probing_parser(
@@ -518,8 +509,6 @@ pub unsafe extern "C" fn rs_template_register_parser() {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_template_tx_get_alstate_progress,
-        get_de_state: rs_template_tx_get_detect_state,
-        set_de_state: rs_template_tx_set_detect_state,
         get_events: Some(rs_template_state_get_events),
         get_eventinfo: Some(TemplateEvent::get_event_info),
         get_eventinfo_byid : Some(TemplateEvent::get_event_info_by_id),

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -239,26 +239,6 @@ pub unsafe extern "C" fn rs_dcerpc_udp_state_transaction_free(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_dcerpc_udp_get_tx_detect_state(
-    vtx: *mut std::os::raw::c_void,
-) -> *mut core::DetectEngineState {
-    let dce_state = cast_pointer!(vtx, DCERPCTransaction);
-    match dce_state.de_state {
-        Some(ds) => ds,
-        None => std::ptr::null_mut(),
-    }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_dcerpc_udp_set_tx_detect_state(
-    vtx: *mut std::os::raw::c_void, de_state: &mut core::DetectEngineState,
-) -> std::os::raw::c_int {
-    let dce_state = cast_pointer!(vtx, DCERPCTransaction);
-    dce_state.de_state = Some(de_state);
-    0
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn rs_dcerpc_udp_get_tx_data(
     tx: *mut std::os::raw::c_void)
     -> *mut AppLayerTxData
@@ -359,8 +339,6 @@ pub unsafe extern "C" fn rs_dcerpc_udp_register_parser() {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_dcerpc_get_alstate_progress,
-        get_de_state: rs_dcerpc_udp_get_tx_detect_state,
-        set_de_state: rs_dcerpc_udp_set_tx_detect_state,
         get_events: None,
         get_eventinfo: None,
         get_eventinfo_byid: None,

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -18,7 +18,7 @@
 use crate::applayer::{self, *};
 use crate::core;
 use crate::core::{ALPROTO_UNKNOWN, AppProto, Flow, IPPROTO_UDP};
-use crate::core::{sc_detect_engine_state_free, sc_app_layer_decoder_events_free_events};
+use crate::core::sc_app_layer_decoder_events_free_events;
 use crate::dhcp::parser::*;
 use std;
 use std::ffi::CString;
@@ -79,7 +79,6 @@ pub enum DHCPEvent {
 pub struct DHCPTransaction {
     tx_id: u64,
     pub message: DHCPMessage,
-    de_state: Option<*mut core::DetectEngineState>,
     events: *mut core::AppLayerDecoderEvents,
     tx_data: applayer::AppLayerTxData,
 }
@@ -89,7 +88,6 @@ impl DHCPTransaction {
         DHCPTransaction {
             tx_id: id,
             message: message,
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: applayer::AppLayerTxData::new(),
         }
@@ -98,12 +96,6 @@ impl DHCPTransaction {
     pub fn free(&mut self) {
         if !self.events.is_null() {
             sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-        match self.de_state {
-            Some(state) => {
-                sc_detect_engine_state_free(state);
-            }
-            _ => {}
         }
     }
 
@@ -114,9 +106,6 @@ impl Drop for DHCPTransaction {
         self.free();
     }
 }
-
-export_tx_get_detect_state!(rs_dhcp_tx_get_detect_state, DHCPTransaction);
-export_tx_set_detect_state!(rs_dhcp_tx_set_detect_state, DHCPTransaction);
 
 #[derive(Default)]
 pub struct DHCPState {
@@ -354,8 +343,6 @@ pub unsafe extern "C" fn rs_dhcp_register_parser() {
         tx_comp_st_ts      : 1,
         tx_comp_st_tc      : 1,
         tx_get_progress    : rs_dhcp_tx_get_alstate_progress,
-        get_de_state       : rs_dhcp_tx_get_detect_state,
-        set_de_state       : rs_dhcp_tx_set_detect_state,
         get_events         : Some(rs_dhcp_state_get_events),
         get_eventinfo      : Some(DHCPEvent::get_event_info),
         get_eventinfo_byid : Some(DHCPEvent::get_event_info_by_id),

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -236,6 +236,12 @@ pub struct DNSTransaction {
     pub tx_data: AppLayerTxData,
 }
 
+impl Transaction for DNSTransaction {
+    fn id(&self) -> u64 {
+        self.id
+    }
+}
+
 impl DNSTransaction {
 
     pub fn new() -> Self {
@@ -334,6 +340,12 @@ pub struct DNSState {
     config: Option<ConfigTracker>,
 
     gap: bool,
+}
+
+impl State<DNSTransaction> for DNSState {
+    fn get_transactions(&self) -> &[DNSTransaction] {
+        &self.transactions
+    }
 }
 
 impl DNSState {
@@ -991,7 +1003,7 @@ pub unsafe extern "C" fn rs_dns_udp_register_parser() {
         localstorage_new: None,
         localstorage_free: None,
         get_files: None,
-        get_tx_iterator: None,
+        get_tx_iterator: Some(crate::applayer::state_get_tx_iterator::<DNSState, DNSTransaction>),
         get_de_state: rs_dns_state_get_tx_detect_state,
         set_de_state: rs_dns_state_set_tx_detect_state,
         get_tx_data: rs_dns_state_get_tx_data,
@@ -1037,7 +1049,7 @@ pub unsafe extern "C" fn rs_dns_tcp_register_parser() {
         localstorage_new: None,
         localstorage_free: None,
         get_files: None,
-        get_tx_iterator: None,
+        get_tx_iterator: Some(crate::applayer::state_get_tx_iterator::<DNSState, DNSTransaction>),
         get_de_state: rs_dns_state_get_tx_detect_state,
         set_de_state: rs_dns_state_set_tx_detect_state,
         get_tx_data: rs_dns_state_get_tx_data,

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -231,7 +231,6 @@ pub struct DNSTransaction {
     pub id: u64,
     pub request: Option<DNSRequest>,
     pub response: Option<DNSResponse>,
-    pub de_state: Option<*mut core::DetectEngineState>,
     pub events: *mut core::AppLayerDecoderEvents,
     pub tx_data: AppLayerTxData,
 }
@@ -253,7 +252,6 @@ impl DNSTransaction {
             id: 0,
             request: None,
             response: None,
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: AppLayerTxData::new(),
         }
@@ -262,12 +260,6 @@ impl DNSTransaction {
     pub fn free(&mut self) {
         if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-        match self.de_state {
-            Some(state) => {
-                core::sc_detect_engine_state_free(state);
-            }
-            None => { },
         }
     }
 
@@ -811,32 +803,6 @@ pub extern "C" fn rs_dns_tx_is_response(tx: &mut DNSTransaction) -> bool {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_dns_state_set_tx_detect_state(
-    tx: *mut std::os::raw::c_void,
-    de_state: &mut core::DetectEngineState) -> std::os::raw::c_int
-{
-    let tx = cast_pointer!(tx, DNSTransaction);
-    tx.de_state = Some(de_state);
-    return 0;
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_dns_state_get_tx_detect_state(
-    tx: *mut std::os::raw::c_void)
-    -> *mut core::DetectEngineState
-{
-    let tx = cast_pointer!(tx, DNSTransaction);
-    match tx.de_state {
-        Some(ds) => {
-            return ds;
-        },
-        None => {
-            return std::ptr::null_mut();
-        }
-    }
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn rs_dns_state_get_tx_data(
     tx: *mut std::os::raw::c_void)
     -> *mut AppLayerTxData
@@ -1000,8 +966,6 @@ pub unsafe extern "C" fn rs_dns_udp_register_parser() {
         localstorage_free: None,
         get_files: None,
         get_tx_iterator: Some(crate::applayer::state_get_tx_iterator::<DNSState, DNSTransaction>),
-        get_de_state: rs_dns_state_get_tx_detect_state,
-        set_de_state: rs_dns_state_set_tx_detect_state,
         get_tx_data: rs_dns_state_get_tx_data,
         apply_tx_config: Some(rs_dns_apply_tx_config),
         flags: APP_LAYER_PARSER_OPT_UNIDIR_TXS,
@@ -1046,8 +1010,6 @@ pub unsafe extern "C" fn rs_dns_tcp_register_parser() {
         localstorage_free: None,
         get_files: None,
         get_tx_iterator: Some(crate::applayer::state_get_tx_iterator::<DNSState, DNSTransaction>),
-        get_de_state: rs_dns_state_get_tx_detect_state,
-        set_de_state: rs_dns_state_set_tx_detect_state,
         get_tx_data: rs_dns_state_get_tx_data,
         apply_tx_config: Some(rs_dns_apply_tx_config),
         flags: APP_LAYER_PARSER_OPT_ACCEPT_GAPS | APP_LAYER_PARSER_OPT_UNIDIR_TXS,

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -134,7 +134,6 @@ pub struct HTTP2Transaction {
     decoder: decompression::HTTP2Decoder,
     pub file_range: *mut HttpRangeContainerBlock,
 
-    de_state: Option<*mut core::DetectEngineState>,
     events: *mut core::AppLayerDecoderEvents,
     tx_data: AppLayerTxData,
     pub ft_tc: FileTransferTracker,
@@ -156,7 +155,6 @@ impl HTTP2Transaction {
             frames_ts: Vec::new(),
             decoder: decompression::HTTP2Decoder::new(),
             file_range: std::ptr::null_mut(),
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: AppLayerTxData::new(),
             ft_tc: FileTransferTracker::new(),
@@ -168,9 +166,6 @@ impl HTTP2Transaction {
     pub fn free(&mut self) {
         if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-        if let Some(state) = self.de_state {
-            core::sc_detect_engine_state_free(state);
         }
         if !self.file_range.is_null() {
             match unsafe { SC } {
@@ -998,9 +993,6 @@ impl HTTP2State {
 
 // C exports.
 
-export_tx_get_detect_state!(rs_http2_tx_get_detect_state, HTTP2Transaction);
-export_tx_set_detect_state!(rs_http2_tx_set_detect_state, HTTP2Transaction);
-
 export_tx_data_get!(rs_http2_get_tx_data, HTTP2Transaction);
 
 /// C entry point for a probing parser.
@@ -1193,8 +1185,6 @@ pub unsafe extern "C" fn rs_http2_register_parser() {
         tx_comp_st_ts: HTTP2TransactionState::HTTP2StateClosed as i32,
         tx_comp_st_tc: HTTP2TransactionState::HTTP2StateClosed as i32,
         tx_get_progress: rs_http2_tx_get_alstate_progress,
-        get_de_state: rs_http2_tx_get_detect_state,
-        set_de_state: rs_http2_tx_set_detect_state,
         get_events: Some(rs_http2_state_get_events),
         get_eventinfo: Some(HTTP2Event::get_event_info),
         get_eventinfo_byid: Some(HTTP2Event::get_event_info_by_id),

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -28,7 +28,7 @@ use kerberos_parser::krb5_parser;
 use kerberos_parser::krb5::{EncryptionType,ErrorCode,MessageType,PrincipalName,Realm};
 use crate::applayer::{self, *};
 use crate::core;
-use crate::core::{AppProto,Flow,ALPROTO_FAILED,ALPROTO_UNKNOWN,STREAM_TOCLIENT,STREAM_TOSERVER,sc_detect_engine_state_free};
+use crate::core::{AppProto,Flow,ALPROTO_FAILED,ALPROTO_UNKNOWN,STREAM_TOCLIENT,STREAM_TOSERVER};
 
 #[derive(AppLayerEvent)]
 pub enum KRB5Event {
@@ -70,9 +70,6 @@ pub struct KRB5Transaction {
 
     /// The internal transaction id
     id: u64,
-
-    /// The detection engine state, if present
-    de_state: Option<*mut core::DetectEngineState>,
 
     /// The events associated with this transaction
     events: *mut core::AppLayerDecoderEvents,
@@ -226,7 +223,6 @@ impl KRB5Transaction {
             etype: None,
             error_code: None,
             id: id,
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: applayer::AppLayerTxData::new(),
         }
@@ -237,9 +233,6 @@ impl Drop for KRB5Transaction {
     fn drop(&mut self) {
         if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-        if let Some(state) = self.de_state {
-            sc_detect_engine_state_free(state);
         }
     }
 }
@@ -311,28 +304,6 @@ pub extern "C" fn rs_krb5_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void
                                                  -> std::os::raw::c_int
 {
     1
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_state_set_tx_detect_state(
-    tx: *mut std::os::raw::c_void,
-    de_state: &mut core::DetectEngineState) -> std::os::raw::c_int
-{
-    let tx = cast_pointer!(tx,KRB5Transaction);
-    tx.de_state = Some(de_state);
-    0
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_state_get_tx_detect_state(
-    tx: *mut std::os::raw::c_void)
-    -> *mut core::DetectEngineState
-{
-    let tx = cast_pointer!(tx,KRB5Transaction);
-    match tx.de_state {
-        Some(ds) => ds,
-        None => std::ptr::null_mut(),
-    }
 }
 
 #[no_mangle]
@@ -582,8 +553,6 @@ pub unsafe extern "C" fn rs_register_krb5_parser() {
         tx_comp_st_ts      : 1,
         tx_comp_st_tc      : 1,
         tx_get_progress    : rs_krb5_tx_get_alstate_progress,
-        get_de_state       : rs_krb5_state_get_tx_detect_state,
-        set_de_state       : rs_krb5_state_set_tx_detect_state,
         get_events         : Some(rs_krb5_state_get_events),
         get_eventinfo      : Some(KRB5Event::get_event_info),
         get_eventinfo_byid : Some(KRB5Event::get_event_info_by_id),

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -60,7 +60,6 @@ pub struct MQTTTransaction {
     toserver: bool,
 
     logged: LoggerFlags,
-    de_state: Option<*mut core::DetectEngineState>,
     events: *mut core::AppLayerDecoderEvents,
     tx_data: applayer::AppLayerTxData,
 }
@@ -75,7 +74,6 @@ impl MQTTTransaction {
             msg: Vec::new(),
             toclient: false,
             toserver: false,
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: applayer::AppLayerTxData::new(),
         };
@@ -86,9 +84,6 @@ impl MQTTTransaction {
     pub fn free(&mut self) {
         if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-        if let Some(state) = self.de_state {
-            core::sc_detect_engine_state_free(state);
         }
     }
 }
@@ -545,9 +540,6 @@ impl MQTTState {
 
 // C exports.
 
-export_tx_get_detect_state!(rs_mqtt_tx_get_detect_state, MQTTTransaction);
-export_tx_set_detect_state!(rs_mqtt_tx_set_detect_state, MQTTTransaction);
-
 #[no_mangle]
 pub unsafe extern "C" fn rs_mqtt_probing_parser(
     _flow: *const Flow,
@@ -750,8 +742,6 @@ pub unsafe extern "C" fn rs_mqtt_register_parser(cfg_max_msg_len: u32) {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_mqtt_tx_get_alstate_progress,
-        get_de_state: rs_mqtt_tx_get_detect_state,
-        set_de_state: rs_mqtt_tx_set_detect_state,
         get_events: Some(rs_mqtt_state_get_events),
         get_eventinfo: Some(MQTTEvent::get_event_info),
         get_eventinfo_byid: Some(MQTTEvent::get_event_info_by_id),

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -179,7 +179,6 @@ pub struct NFSTransaction {
     /// attempt failed.
     pub type_data: Option<NFSTransactionTypeData>,
 
-    pub de_state: Option<*mut DetectEngineState>,
     pub events: *mut AppLayerDecoderEvents,
 
     pub tx_data: AppLayerTxData,
@@ -208,7 +207,6 @@ impl NFSTransaction {
             file_tx_direction: 0,
             file_handle:Vec::new(),
             type_data: None,
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: AppLayerTxData::new(),
         }
@@ -219,12 +217,6 @@ impl NFSTransaction {
         debug_validate_bug_on!(self.tx_data.files_logged > 1);
         if !self.events.is_null() {
             sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-        match self.de_state {
-            Some(state) => {
-                sc_detect_engine_state_free(state);
-            }
-            _ => {}
         }
     }
 }
@@ -1587,34 +1579,6 @@ pub unsafe extern "C" fn rs_nfs_get_tx_data(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_nfs_state_set_tx_detect_state(
-    tx: *mut std::os::raw::c_void,
-    de_state: &mut DetectEngineState) -> i32
-{
-    let tx = cast_pointer!(tx, NFSTransaction);
-    tx.de_state = Some(de_state);
-    0
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_nfs_state_get_tx_detect_state(
-    tx: *mut std::os::raw::c_void)
-    -> *mut DetectEngineState
-{
-    let tx = cast_pointer!(tx, NFSTransaction);
-    match tx.de_state {
-        Some(ds) => {
-            SCLogDebug!("{}: getting de_state", tx.id);
-            return ds;
-        },
-        None => {
-            SCLogDebug!("{}: getting de_state: have none", tx.id);
-            return std::ptr::null_mut();
-        }
-    }
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn rs_nfs_state_get_events(tx: *mut std::os::raw::c_void)
                                           -> *mut AppLayerDecoderEvents
 {
@@ -1948,8 +1912,6 @@ pub unsafe extern "C" fn rs_nfs_register_parser() {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_nfs_tx_get_alstate_progress,
-        get_de_state: rs_nfs_state_get_tx_detect_state,
-        set_de_state: rs_nfs_state_set_tx_detect_state,
         get_events: Some(rs_nfs_state_get_events),
         get_eventinfo: Some(rs_nfs_state_get_event_info),
         get_eventinfo_byid : Some(rs_nfs_state_get_event_info_by_id),
@@ -2027,8 +1989,6 @@ pub unsafe extern "C" fn rs_nfs_udp_register_parser() {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_nfs_tx_get_alstate_progress,
-        get_de_state: rs_nfs_state_get_tx_detect_state,
-        set_de_state: rs_nfs_state_set_tx_detect_state,
         get_events: Some(rs_nfs_state_get_events),
         get_eventinfo: Some(rs_nfs_state_get_event_info),
         get_eventinfo_byid : None,

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -54,9 +54,6 @@ pub struct NTPTransaction {
     /// The internal transaction id
     id: u64,
 
-    /// The detection engine state, if present
-    de_state: Option<*mut core::DetectEngineState>,
-
     /// The events associated with this transaction
     events: *mut core::AppLayerDecoderEvents,
 
@@ -142,7 +139,6 @@ impl NTPTransaction {
         NTPTransaction {
             xid: 0,
             id: id,
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: applayer::AppLayerTxData::new(),
         }
@@ -246,28 +242,6 @@ pub extern "C" fn rs_ntp_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_ntp_state_set_tx_detect_state(
-    tx: *mut std::os::raw::c_void,
-    de_state: &mut core::DetectEngineState) -> std::os::raw::c_int
-{
-    let tx = cast_pointer!(tx,NTPTransaction);
-    tx.de_state = Some(de_state);
-    0
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_ntp_state_get_tx_detect_state(
-    tx: *mut std::os::raw::c_void)
-    -> *mut core::DetectEngineState
-{
-    let tx = cast_pointer!(tx,NTPTransaction);
-    match tx.de_state {
-        Some(ds) => ds,
-        None => std::ptr::null_mut(),
-    }
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn rs_ntp_state_get_events(tx: *mut std::os::raw::c_void)
                                           -> *mut core::AppLayerDecoderEvents
 {
@@ -327,8 +301,6 @@ pub unsafe extern "C" fn rs_register_ntp_parser() {
         tx_comp_st_ts      : 1,
         tx_comp_st_tc      : 1,
         tx_get_progress    : rs_ntp_tx_get_alstate_progress,
-        get_de_state       : rs_ntp_state_get_tx_detect_state,
-        set_de_state       : rs_ntp_state_set_tx_detect_state,
         get_events         : Some(rs_ntp_state_get_events),
         get_eventinfo      : Some(NTPEvent::get_event_info),
         get_eventinfo_byid : Some(NTPEvent::get_event_info_by_id),

--- a/rust/src/rfb/rfb.rs
+++ b/rust/src/rfb/rfb.rs
@@ -44,7 +44,6 @@ pub struct RFBTransaction {
     pub tc_failure_reason: Option<parser::FailureReason>,
     pub tc_server_init: Option<parser::ServerInit>,
 
-    de_state: Option<*mut core::DetectEngineState>,
     events: *mut core::AppLayerDecoderEvents,
     tx_data: applayer::AppLayerTxData,
 }
@@ -68,7 +67,6 @@ impl RFBTransaction {
             tc_failure_reason: None,
             tc_server_init: None,
 
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: applayer::AppLayerTxData::new(),
         }
@@ -77,9 +75,6 @@ impl RFBTransaction {
     pub fn free(&mut self) {
         if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-        if let Some(state) = self.de_state {
-            core::sc_detect_engine_state_free(state);
         }
     }
 }
@@ -507,15 +502,6 @@ impl RFBState {
 
 // C exports.
 
-export_tx_get_detect_state!(
-    rs_rfb_tx_get_detect_state,
-    RFBTransaction
-);
-export_tx_set_detect_state!(
-    rs_rfb_tx_set_detect_state,
-    RFBTransaction
-);
-
 #[no_mangle]
 pub extern "C" fn rs_rfb_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = RFBState::new();
@@ -663,8 +649,6 @@ pub unsafe extern "C" fn rs_rfb_register_parser() {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_rfb_tx_get_alstate_progress,
-        get_de_state: rs_rfb_tx_get_detect_state,
-        set_de_state: rs_rfb_tx_set_detect_state,
         get_events: Some(rs_rfb_state_get_events),
         get_eventinfo: None,
         get_eventinfo_byid: None,

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -541,6 +541,12 @@ pub struct SMBTransaction {
     pub tx_data: AppLayerTxData,
 }
 
+impl Transaction for SMBTransaction {
+    fn id(&self) -> u64 {
+        self.id
+    }
+}
+
 impl SMBTransaction {
     pub fn new() -> Self {
         return Self {
@@ -772,6 +778,12 @@ pub struct SMBState<> {
     ts: u64,
 }
 
+impl State<SMBTransaction> for SMBState {
+    fn get_transactions(&self) -> &[SMBTransaction] {
+        &self.transactions
+    }
+}
+
 impl SMBState {
     /// Allocation function for a new TLS parser instance
     pub fn new() -> Self {
@@ -837,31 +849,6 @@ impl SMBState {
                     tx_id, tx_id+1, index, self.transactions.len(), self.tx_id);
             self.transactions.remove(index);
         }
-    }
-
-    // for use with the C API call StateGetTxIterator
-    pub fn get_tx_iterator(&mut self, min_tx_id: u64, state: &mut u64) ->
-        Option<(&SMBTransaction, u64, bool)>
-    {
-        let mut index = *state as usize;
-        let len = self.transactions.len();
-
-        // find tx that is >= min_tx_id
-        while index < len {
-            let tx = &self.transactions[index];
-            if tx.id < min_tx_id + 1 {
-                index += 1;
-                continue;
-            }
-            // store current index in the state and not the next
-            // as transactions might be freed between now and the
-            // next time we are called.
-            *state = index as u64;
-            //SCLogDebug!("returning tx_id {} has_next? {} (len {} index {}), tx {:?}",
-            //        tx.id - 1, (len - index) > 1, len, index, tx);
-            return Some((tx, tx.id - 1, (len - index) > 1));
-        }
-        return None;
     }
 
     pub fn get_tx_by_id(&mut self, tx_id: u64) -> Option<&SMBTransaction> {
@@ -2030,30 +2017,6 @@ pub unsafe extern "C" fn rs_smb_state_get_tx(state: *mut ffi::c_void,
     }
 }
 
-// for use with the C API call StateGetTxIterator
-#[no_mangle]
-pub unsafe extern "C" fn rs_smb_state_get_tx_iterator(
-                                               _ipproto: u8,
-                                               _alproto: AppProto,
-                                               state: *mut std::os::raw::c_void,
-                                               min_tx_id: u64,
-                                               _max_tx_id: u64,
-                                               istate: &mut u64,
-                                               ) -> applayer::AppLayerGetTxIterTuple
-{
-    let state = cast_pointer!(state, SMBState);
-    match state.get_tx_iterator(min_tx_id, istate) {
-        Some((tx, out_tx_id, has_next)) => {
-            let c_tx = tx as *const _ as *mut _;
-            let ires = applayer::AppLayerGetTxIterTuple::with_values(c_tx, out_tx_id, has_next);
-            return ires;
-        }
-        None => {
-            return applayer::AppLayerGetTxIterTuple::not_found();
-        }
-    }
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn rs_smb_state_tx_free(state: *mut ffi::c_void,
                                        tx_id: u64)
@@ -2243,7 +2206,7 @@ pub unsafe extern "C" fn rs_smb_register_parser() {
         localstorage_new: None,
         localstorage_free: None,
         get_files: Some(rs_smb_getfiles),
-        get_tx_iterator: Some(rs_smb_state_get_tx_iterator),
+        get_tx_iterator: Some(applayer::state_get_tx_iterator::<SMBState, SMBTransaction>),
         get_tx_data: rs_smb_get_tx_data,
         apply_tx_config: None,
         flags: APP_LAYER_PARSER_OPT_ACCEPT_GAPS,

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -78,9 +78,6 @@ pub struct SNMPTransaction<'a> {
     /// The internal transaction id
     id: u64,
 
-    /// The detection engine state, if present
-    de_state: Option<*mut core::DetectEngineState>,
-
     /// The events associated with this transaction
     events: *mut core::AppLayerDecoderEvents,
 
@@ -260,7 +257,6 @@ impl<'a> SNMPTransaction<'a> {
             usm: None,
             encrypted: false,
             id: id,
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: applayer::AppLayerTxData::new(),
         }
@@ -361,29 +357,6 @@ pub extern "C" fn rs_snmp_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void
 {
     1
 }
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_snmp_state_set_tx_detect_state(
-    tx: *mut std::os::raw::c_void,
-    de_state: &mut core::DetectEngineState) -> std::os::raw::c_int
-{
-    let tx = cast_pointer!(tx,SNMPTransaction);
-    tx.de_state = Some(de_state);
-    0
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_snmp_state_get_tx_detect_state(
-    tx: *mut std::os::raw::c_void)
-    -> *mut core::DetectEngineState
-{
-    let tx = cast_pointer!(tx,SNMPTransaction);
-    match tx.de_state {
-        Some(ds) => ds,
-        None => std::ptr::null_mut(),
-    }
-}
-
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_snmp_state_get_events(tx: *mut std::os::raw::c_void)
@@ -506,8 +479,6 @@ pub unsafe extern "C" fn rs_register_snmp_parser() {
         tx_comp_st_ts      : 1,
         tx_comp_st_tc      : 1,
         tx_get_progress    : rs_snmp_tx_get_alstate_progress,
-        get_de_state       : rs_snmp_state_get_tx_detect_state,
-        set_de_state       : rs_snmp_state_set_tx_detect_state,
         get_events         : Some(rs_snmp_state_get_events),
         get_eventinfo      : Some(SNMPEvent::get_event_info),
         get_eventinfo_byid : Some(SNMPEvent::get_event_info_by_id),

--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -83,7 +83,6 @@ pub struct SSHTransaction {
     pub srv_hdr: SshHeader,
     pub cli_hdr: SshHeader,
 
-    de_state: Option<*mut core::DetectEngineState>,
     events: *mut core::AppLayerDecoderEvents,
     tx_data: AppLayerTxData,
 }
@@ -93,7 +92,6 @@ impl SSHTransaction {
         SSHTransaction {
             srv_hdr: SshHeader::new(),
             cli_hdr: SshHeader::new(),
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: AppLayerTxData::new(),
         }
@@ -102,9 +100,6 @@ impl SSHTransaction {
     pub fn free(&mut self) {
         if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-        if let Some(state) = self.de_state {
-            core::sc_detect_engine_state_free(state);
         }
     }
 }
@@ -352,9 +347,6 @@ impl SSHState {
 
 // C exports.
 
-export_tx_get_detect_state!(rs_ssh_tx_get_detect_state, SSHTransaction);
-export_tx_set_detect_state!(rs_ssh_tx_set_detect_state, SSHTransaction);
-
 export_tx_data_get!(rs_ssh_get_tx_data, SSHTransaction);
 
 #[no_mangle]
@@ -486,8 +478,6 @@ pub unsafe extern "C" fn rs_ssh_register_parser() {
         tx_comp_st_ts: SSHConnectionState::SshStateFinished as i32,
         tx_comp_st_tc: SSHConnectionState::SshStateFinished as i32,
         tx_get_progress: rs_ssh_tx_get_alstate_progress,
-        get_de_state: rs_ssh_tx_get_detect_state,
-        set_de_state: rs_ssh_tx_set_detect_state,
         get_events: Some(rs_ssh_state_get_events),
         get_eventinfo: Some(SSHEvent::get_event_info),
         get_eventinfo_byid: Some(SSHEvent::get_event_info_by_id),

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -1535,25 +1535,6 @@ static int DNP3StateGetEventInfoById(int event_id, const char **event_name,
     return 0;
 }
 
-/**
- * \brief App-layer support.
- */
-static DetectEngineState *DNP3GetTxDetectState(void *vtx)
-{
-    DNP3Transaction *tx = vtx;
-    return tx->de_state;
-}
-
-/**
- * \brief App-layer support.
- */
-static int DNP3SetTxDetectState(void *vtx, DetectEngineState *s)
-{
-    DNP3Transaction *tx = vtx;
-    tx->de_state = s;
-    return 0;
-}
-
 static AppLayerTxData *DNP3GetTxData(void *vtx)
 {
     DNP3Transaction *tx = (DNP3Transaction *)vtx;
@@ -1622,8 +1603,6 @@ void RegisterDNP3Parsers(void)
 
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_DNP3,
             DNP3GetEvents);
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_DNP3,
-            DNP3GetTxDetectState, DNP3SetTxDetectState);
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_DNP3, DNP3GetTx);
         AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_DNP3, DNP3GetTxCnt);

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -66,19 +66,6 @@ static int ENIPGetAlstateProgress(void *tx, uint8_t direction)
     return 1;
 }
 
-static DetectEngineState *ENIPGetTxDetectState(void *vtx)
-{
-    ENIPTransaction *tx = (ENIPTransaction *)vtx;
-    return tx->de_state;
-}
-
-static int ENIPSetTxDetectState(void *vtx, DetectEngineState *s)
-{
-    ENIPTransaction *tx = (ENIPTransaction *)vtx;
-    tx->de_state = s;
-    return 0;
-}
-
 static AppLayerTxData *ENIPGetTxData(void *vtx)
 {
     ENIPTransaction *tx = (ENIPTransaction *)vtx;
@@ -513,9 +500,6 @@ void RegisterENIPUDPParsers(void)
 
         AppLayerParserRegisterGetEventsFunc(IPPROTO_UDP, ALPROTO_ENIP, ENIPGetEvents);
 
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_ENIP,
-                ENIPGetTxDetectState, ENIPSetTxDetectState);
-
         AppLayerParserRegisterGetTx(IPPROTO_UDP, ALPROTO_ENIP, ENIPGetTx);
         AppLayerParserRegisterTxDataFunc(IPPROTO_UDP, ALPROTO_ENIP, ENIPGetTxData);
         AppLayerParserRegisterGetTxCnt(IPPROTO_UDP, ALPROTO_ENIP, ENIPGetTxCnt);
@@ -590,9 +574,6 @@ void RegisterENIPTCPParsers(void)
                 ENIPStateAlloc, ENIPStateFree);
 
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_ENIP, ENIPGetEvents);
-
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_ENIP,
-                ENIPGetTxDetectState, ENIPSetTxDetectState);
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_ENIP, ENIPGetTx);
         AppLayerParserRegisterTxDataFunc(IPPROTO_TCP, ALPROTO_ENIP, ENIPGetTxData);

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -884,13 +884,6 @@ static void FTPStateFree(void *s)
 #endif
 }
 
-static int FTPSetTxDetectState(void *vtx, DetectEngineState *de_state)
-{
-    FTPTransaction *tx = (FTPTransaction *)vtx;
-    tx->de_state = de_state;
-    return 0;
-}
-
 /**
  * \brief This function returns the oldest open transaction; if none
  * are open, then the oldest transaction is returned
@@ -941,13 +934,6 @@ static void *FTPGetTx(void *state, uint64_t tx_id)
     }
     return NULL;
 }
-
-static DetectEngineState *FTPGetTxDetectState(void *vtx)
-{
-    FTPTransaction *tx = (FTPTransaction *)vtx;
-    return tx->de_state;
-}
-
 
 static AppLayerTxData *FTPGetTxData(void *vtx)
 {
@@ -1193,19 +1179,6 @@ static void FTPDataStateFree(void *s)
 #endif
 }
 
-static int FTPDataSetTxDetectState(void *vtx, DetectEngineState *de_state)
-{
-    FtpDataState *ftp_state = (FtpDataState *)vtx;
-    ftp_state->de_state = de_state;
-    return 0;
-}
-
-static DetectEngineState *FTPDataGetTxDetectState(void *vtx)
-{
-    FtpDataState *ftp_state = (FtpDataState *)vtx;
-    return ftp_state->de_state;
-}
-
 static AppLayerTxData *FTPDataGetTxData(void *vtx)
 {
     FtpDataState *ftp_state = (FtpDataState *)vtx;
@@ -1303,9 +1276,6 @@ void RegisterFTPParsers(void)
 
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_FTP, FTPStateTransactionFree);
 
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_FTP,
-                FTPGetTxDetectState, FTPSetTxDetectState);
-
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_FTP, FTPGetTx);
         AppLayerParserRegisterTxDataFunc(IPPROTO_TCP, ALPROTO_FTP, FTPGetTxData);
 
@@ -1326,8 +1296,6 @@ void RegisterFTPParsers(void)
         AppLayerParserRegisterStateFuncs(IPPROTO_TCP, ALPROTO_FTPDATA, FTPDataStateAlloc, FTPDataStateFree);
         AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_TCP, ALPROTO_FTPDATA, STREAM_TOSERVER | STREAM_TOCLIENT);
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_FTPDATA, FTPDataStateTransactionFree);
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_FTPDATA,
-                FTPDataGetTxDetectState, FTPDataSetTxDetectState);
 
         AppLayerParserRegisterGetFilesFunc(IPPROTO_TCP, ALPROTO_FTPDATA, FTPDataStateGetFiles);
 

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -241,7 +241,6 @@ typedef struct HtpTxUserData_ {
 
     uint8_t request_body_type;
 
-    DetectEngineState *de_state;
     AppLayerTxData tx_data;
 } HtpTxUserData;
 

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -204,9 +204,6 @@ void AppLayerParserRegisterGetEventInfo(uint8_t ipproto, AppProto alproto,
 void AppLayerParserRegisterGetEventInfoById(uint8_t ipproto, AppProto alproto,
     int (*StateGetEventInfoById)(int event_id, const char **event_name,
                                  AppLayerEventType *event_type));
-void AppLayerParserRegisterDetectStateFuncs(uint8_t ipproto, AppProto alproto,
-        DetectEngineState *(*GetTxDetectState)(void *tx),
-        int (*SetTxDetectState)(void *tx, DetectEngineState *));
 void AppLayerParserRegisterGetStreamDepth(uint8_t ipproto,
                                           AppProto alproto,
                                           uint32_t (*GetStreamDepth)(void));

--- a/src/app-layer-register.c
+++ b/src/app-layer-register.c
@@ -137,10 +137,6 @@ int AppLayerRegisterParser(const struct AppLayerParser *p, AppProto alproto)
     AppLayerParserRegisterGetTx(p->ip_proto, alproto,
         p->StateGetTx);
 
-    /* What is this being registered for? */
-    AppLayerParserRegisterDetectStateFuncs(p->ip_proto, alproto,
-        p->GetTxDetectState, p->SetTxDetectState);
-
     if (p->StateGetEventInfo) {
         AppLayerParserRegisterGetEventInfo(p->ip_proto, alproto,
                 p->StateGetEventInfo);

--- a/src/app-layer-register.h
+++ b/src/app-layer-register.h
@@ -49,9 +49,6 @@ typedef struct AppLayerParser {
     const int complete_tc;
     int (*StateGetProgress)(void *alstate, uint8_t direction);
 
-    DetectEngineState *(*GetTxDetectState)(void *tx);
-    int (*SetTxDetectState)(void *tx, DetectEngineState *);
-
     AppLayerDecoderEvents *(*StateGetEvents)(void *);
     int (*StateGetEventInfo)(const char *event_name,
                              int *event_id, AppLayerEventType *event_type);

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1761,19 +1761,6 @@ static AppLayerDecoderEvents *SMTPGetEvents(void *tx)
     return ((SMTPTransaction *)tx)->decoder_events;
 }
 
-static DetectEngineState *SMTPGetTxDetectState(void *vtx)
-{
-    SMTPTransaction *tx = (SMTPTransaction *)vtx;
-    return tx->de_state;
-}
-
-static int SMTPSetTxDetectState(void *vtx, DetectEngineState *s)
-{
-    SMTPTransaction *tx = (SMTPTransaction *)vtx;
-    tx->de_state = s;
-    return 0;
-}
-
 static AppLayerTxData *SMTPGetTxData(void *vtx)
 {
     SMTPTransaction *tx = (SMTPTransaction *)vtx;
@@ -1808,8 +1795,6 @@ void RegisterSMTPParsers(void)
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetEventInfo);
         AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetEventInfoById);
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_SMTP, SMTPGetEvents);
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_SMTP,
-                                               SMTPGetTxDetectState, SMTPSetTxDetectState);
 
         AppLayerParserRegisterLocalStorageFunc(IPPROTO_TCP, ALPROTO_SMTP, SMTPLocalStorageAlloc,
                                                SMTPLocalStorageFree);

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -251,19 +251,6 @@ static AppLayerDecoderEvents *SSLGetEvents(void *tx)
     return ssl_state->decoder_events;
 }
 
-static int SSLSetTxDetectState(void *vtx, DetectEngineState *de_state)
-{
-    SSLState *ssl_state = (SSLState *)vtx;
-    ssl_state->de_state = de_state;
-    return 0;
-}
-
-static DetectEngineState *SSLGetTxDetectState(void *vtx)
-{
-    SSLState *ssl_state = (SSLState *)vtx;
-    return ssl_state->de_state;
-}
-
 static void *SSLGetTx(void *state, uint64_t tx_id)
 {
     SSLState *ssl_state = (SSLState *)state;
@@ -2967,9 +2954,6 @@ void RegisterSSLParsers(void)
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_TLS, SSLStateTransactionFree);
 
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_TLS, SSLGetEvents);
-
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_TLS,
-                                               SSLGetTxDetectState, SSLSetTxDetectState);
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_TLS, SSLGetTx);
         AppLayerParserRegisterTxDataFunc(IPPROTO_TCP, ALPROTO_TLS, SSLGetTxData);

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -447,26 +447,6 @@ static AppLayerTxData *TemplateGetTxData(void *vtx)
     return &tx->tx_data;
 }
 
-/**
- * \brief retrieve the detection engine per tx state
- */
-static DetectEngineState *TemplateGetTxDetectState(void *vtx)
-{
-    TemplateTransaction *tx = vtx;
-    return tx->de_state;
-}
-
-/**
- * \brief get the detection engine per tx state
- */
-static int TemplateSetTxDetectState(void *vtx,
-    DetectEngineState *s)
-{
-    TemplateTransaction *tx = vtx;
-    tx->de_state = s;
-    return 0;
-}
-
 void RegisterTemplateParsers(void)
 {
     const char *proto_name = "template";
@@ -552,10 +532,6 @@ void RegisterTemplateParsers(void)
             TemplateGetTx);
         AppLayerParserRegisterTxDataFunc(IPPROTO_TCP, ALPROTO_TEMPLATE,
             TemplateGetTxData);
-
-        /* What is this being registered for? */
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_TEMPLATE,
-            TemplateGetTxDetectState, TemplateSetTxDetectState);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_TEMPLATE,
             TemplateStateGetEventInfo);

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -159,17 +159,6 @@ static int TFTPGetStateProgress(void *tx, uint8_t direction)
     return 1;
 }
 
-static DetectEngineState *TFTPGetTxDetectState(void *vtx)
-{
-    return NULL;
-}
-
-static int TFTPSetTxDetectState(void *vtx,
-    DetectEngineState *s)
-{
-    return 0;
-}
-
 void RegisterTFTPParsers(void)
 {
     const char *proto_name = "tftp";
@@ -241,11 +230,6 @@ void RegisterTFTPParsers(void)
                                                    TFTPGetStateProgress);
         AppLayerParserRegisterGetTx(IPPROTO_UDP, ALPROTO_TFTP,
                                     TFTPGetTx);
-
-        /* What is this being registered for? */
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_TFTP,
-                                               TFTPGetTxDetectState,
-                                               TFTPSetTxDetectState);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_UDP, ALPROTO_TFTP,
                                            TFTPStateGetEventInfo);


### PR DESCRIPTION
Builds on https://github.com/OISF/suricata/pull/6519.  While looking at making a generic function for `DetectEngineState`, it appeared that we could just include that state is the `AppLayerTxData` which allows for the removal of all boilerplate for `DetectEngineState`. This was easy because both fields are required by the app-layer API (at least in Rust).

I have this little feeling that there was a reason we couldn't put `DetectEngineState` in this common data structure, but all tests are passing.