### PR TITLE
Minor updates to lessen Suricata output

### DIFF
--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -124,8 +124,6 @@ pub fn ftp_epsv_response(i: &[u8]) -> IResult<&[u8], u16> {
     let (i, port) = getu16(i)?;
     let (i, _) = tag("|)")(i)?;
     let (i, _) = opt(complete(tag(".")))(i)?;
-    use nom7::HexDisplay;
-    eprintln!("ftp_epsv_response:\n{}", i.to_hex(16));
     Ok((i, port))
 }
 

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -77,9 +77,9 @@ static AppLayerDecoderEvents *TFTPGetEvents(void *tx)
 }
 
 /**
- * \brief Probe the input to see if it looks like echo.
+ * \brief Probe the input to see if it looks like tftp.
  *
- * \retval ALPROTO_TFTP if it looks like echo, otherwise
+ * \retval ALPROTO_TFTP if it looks like tftp, otherwise
  *     ALPROTO_UNKNOWN.
  */
 static AppProto TFTPProbingParser(Flow *f, uint8_t direction,
@@ -100,7 +100,7 @@ static AppLayerResult TFTPParseRequest(Flow *f, void *state,
     AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len,
     void *local_data, const uint8_t flags)
 {
-    SCLogDebug("Parsing echo request: len=%"PRIu32, input_len);
+    SCLogDebug("Parsing tftp request: len=%" PRIu32, input_len);
 
     /* Likely connection closed, we can just return here. */
     if ((input == NULL || input_len == 0) &&
@@ -144,7 +144,7 @@ static void *TFTPGetTx(void *state, uint64_t tx_id)
 /**
  * \brief Return the state of a transaction in a given direction.
  *
- * In the case of the echo protocol, the existence of a transaction
+ * In the case of the tftp protocol, the existence of a transaction
  * means that the request is done. However, some protocols that may
  * need multiple chunks of data to complete the request may need more
  * than just the existence of a transaction for the request to be
@@ -183,7 +183,7 @@ void RegisterTFTPParsers(void)
         AppLayerProtoDetectRegisterProtocol(ALPROTO_TFTP, proto_name);
 
         if (RunmodeIsUnittests()) {
-            SCLogDebug("Unittest mode, registeringd default configuration.");
+            SCLogDebug("Unittest mode, registering default configuration.");
             AppLayerProtoDetectPPRegister(IPPROTO_UDP, TFTP_DEFAULT_PORT,
                                           ALPROTO_TFTP, 0, TFTP_MIN_FRAME_LEN,
                                           STREAM_TOSERVER, TFTPProbingParser,
@@ -193,9 +193,9 @@ void RegisterTFTPParsers(void)
                                                      proto_name, ALPROTO_TFTP,
                                                      0, TFTP_MIN_FRAME_LEN,
                                                      TFTPProbingParser, TFTPProbingParser)) {
-                SCLogDebug("No echo app-layer configuration, enabling echo"
+                SCLogDebug("No tftp app-layer configuration, enabling tftp"
                            " detection UDP detection on port %s.",
-                           TFTP_DEFAULT_PORT);
+                        TFTP_DEFAULT_PORT);
                 AppLayerProtoDetectPPRegister(IPPROTO_UDP,
                                               TFTP_DEFAULT_PORT, ALPROTO_TFTP,
                                               0, TFTP_MIN_FRAME_LEN,
@@ -204,7 +204,7 @@ void RegisterTFTPParsers(void)
             }
         }
     } else {
-        SCLogDebug("Protocol detecter and parser disabled for TFTP.");
+        SCLogDebug("Protocol detector and parser disabled for TFTP.");
         return;
     }
 


### PR DESCRIPTION
Continuation of #6594 
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- TFTP: Change references to `tftp` (was `echo`)
- FTP `EPSV` parser: remove diagnostic log message
- clang-format fixups

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
