### PR TITLE
smtp: log transaction even if no email present

### DIFF
--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -85,9 +85,8 @@ static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     EveSmtpDataLogger(f, state, tx, tx_id, jb);
     jb_close(jb);
 
-    if (EveEmailLogJson(jhl, jb, p, f, state, tx, tx_id) == TM_ECODE_OK) {
-        OutputJsonBuilderBuffer(jb, jhl->ctx);
-    }
+    EveEmailLogJson(jhl, jb, p, f, state, tx, tx_id);
+    OutputJsonBuilderBuffer(jb, jhl->ctx);
 
     jb_free(jb);
 


### PR DESCRIPTION
The SMTP transaction logger was not writing the log if the email
portion of the logger failed, such as in the case of STARTTLS
where this is no email decoded.

Ticket https://redmine.openinfosecfoundation.org/issues/4817

suricata-verify-pr: 581