### PR TITLE
app-layer/template: don't always enable if unittests built

### DIFF
--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -471,19 +471,11 @@ void RegisterTemplateParsers(void)
 {
     const char *proto_name = "template";
 
-    /* TEMPLATE_START_REMOVE */
-#ifndef UNITTESTS
-    /* Ensure template registration for unittests */
-    if (ConfGetNode("app-layer.protocols.template") == NULL) {
-        return;
-    }
-#endif
-    /* TEMPLATE_END_REMOVE */
     /* Check if Template TCP detection is enabled. If it does not exist in
-     * the configuration file then it will be enabled by default. */
-    if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name)) {
+     * the configuration file then it will be disabled by default. */
+    if (AppLayerProtoDetectConfProtoDetectionEnabledDefault("tcp", proto_name, false)) {
 
-        SCLogNotice("Template TCP protocol detection enabled.");
+        SCLogDebug("Template TCP protocol detection enabled.");
 
         AppLayerProtoDetectRegisterProtocol(ALPROTO_TEMPLATE, proto_name);
 
@@ -500,9 +492,9 @@ void RegisterTemplateParsers(void)
             if (!AppLayerProtoDetectPPParseConfPorts("tcp", IPPROTO_TCP,
                     proto_name, ALPROTO_TEMPLATE, 0, TEMPLATE_MIN_FRAME_LEN,
                     TemplateProbingParserTs, TemplateProbingParserTc)) {
-                SCLogNotice("No template app-layer configuration, enabling echo"
-                    " detection TCP detection on port %s.",
-                    TEMPLATE_DEFAULT_PORT);
+                SCLogDebug("No template app-layer configuration, enabling echo"
+                           " detection TCP detection on port %s.",
+                        TEMPLATE_DEFAULT_PORT);
                 AppLayerProtoDetectPPRegister(IPPROTO_TCP,
                     TEMPLATE_DEFAULT_PORT, ALPROTO_TEMPLATE, 0,
                     TEMPLATE_MIN_FRAME_LEN, STREAM_TOSERVER,
@@ -514,7 +506,7 @@ void RegisterTemplateParsers(void)
     }
 
     else {
-        SCLogNotice("Protocol detector and parser disabled for Template.");
+        SCLogDebug("Protocol detector and parser disabled for Template.");
         return;
     }
 
@@ -570,7 +562,7 @@ void RegisterTemplateParsers(void)
             APP_LAYER_PARSER_OPT_ACCEPT_GAPS);
     }
     else {
-        SCLogNotice("Template protocol parsing disabled.");
+        SCLogDebug("Template protocol parsing disabled.");
     }
 
 #ifdef UNITTESTS

--- a/src/detect-template-buffer.c
+++ b/src/detect-template-buffer.c
@@ -53,12 +53,14 @@ static int g_template_buffer_id = 0;
 void DetectTemplateBufferRegister(void)
 {
     /* TEMPLATE_START_REMOVE */
-#ifndef UNITTESTS
-    /* Ensure registration when running unittests */
-    if (ConfGetNode("app-layer.protocols.template") == NULL) {
-        return;
+    /* Prevent registration of this buffer unless explicitly enabled or when
+     * running unittests. This will be removed during code generation from this
+     * template. */
+    if (!RunmodeIsUnittests()) {
+        if (ConfGetNode("app-layer.protocols.template") == NULL) {
+            return;
+        }
     }
-#endif
     /* TEMPLATE_END_REMOVE */
     sigmatch_table[DETECT_AL_TEMPLATE_BUFFER].name = "template_buffer";
     sigmatch_table[DETECT_AL_TEMPLATE_BUFFER].desc =
@@ -90,7 +92,8 @@ void DetectTemplateBufferRegister(void)
 
     g_template_buffer_id = DetectBufferTypeGetByName("template_buffer");
 
-    SCLogNotice("Template application layer detect registered.");
+    /* NOTE: You may want to change this to SCLogNotice during development. */
+    SCLogDebug("Template application layer detect registered.");
 }
 
 static int DetectTemplateBufferSetup(DetectEngineCtx *de_ctx, Signature *s,


### PR DESCRIPTION
314ec77f88325a4e8989e898991b9af493cad3dc had the unintended side affect
of enabling the template parser and detection buffer if unittests were
enabled.

Fix this by using the new `Default` method for registering parsers.
However, the buffer still needs an explicit configuration check.

Also convert Notice debug messages to Debug to reduce output when in
unittest mode.  If we feel stronly this should still be Notice in the
template, that is a conversion we can make in the generation script when
generating a new parser.
