### PR TITLE
profiling: fix profiling with sample rate

### DIFF
--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -1243,6 +1243,8 @@ int SCProfileRuleStart(Packet *p)
         return 1;
     }
 #endif
+    if (p->flags & PKT_PROFILE)
+        return 1;
     return 0;
 }
 


### PR DESCRIPTION
Rules profiling was returning invalid results when used with sample
rate. The problem was that the sample condition was run twice in the
packet flow. As a result, the second pass was not initializing the
variable storing the initial CPU ticks and the resulting performance
counters were reporting invalid values.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4836

Describe changes:
- fix rules profiling when a sample rate is used
