### PR TITLE
detect-id: convert unittests to FAIL/PASS APIs

### DIFF
--- a/src/detect-id.c
+++ b/src/detect-id.c
@@ -364,10 +364,6 @@ static int DetectIdTestMatch01(void)
     /* UDP IP id = 91011 */
     p[2]->ip4h->ip_id = htons(5101);
 
-    sigs[0]= "alert ip any any -> any any (msg:\"Testing id 1\"; id:1234; sid:1;)";
-    sigs[1]= "alert ip any any -> any any (msg:\"Testing id 2\"; id:5678; sid:2;)";
-    sigs[2]= "alert ip any any -> any any (msg:\"Testing id 3\"; id:5101; sid:3;)";
-
     UTHFreePackets(p, 3);
 
     PASS;

--- a/src/detect-id.c
+++ b/src/detect-id.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -283,14 +283,14 @@ static bool PrefilterIdIsPrefilterable(const Signature *s)
  */
 static int DetectIdTestParse01 (void)
 {
-    DetectIdData *id_d = NULL;
-    id_d = DetectIdParse(" 35402 ");
-    if (id_d != NULL &&id_d->id==35402) {
-        DetectIdFree(NULL, id_d);
-        return 1;
-    }
+    DetectIdData *id_d = DetectIdParse(" 35402 ");
 
-    return 0;
+    FAIL_IF_NULL(id_d);
+    FAIL_IF_NOT(id_d->id == 35402);
+
+    DetectIdFree(NULL, id_d);
+
+    PASS;
 }
 
 /**
@@ -300,14 +300,11 @@ static int DetectIdTestParse01 (void)
  */
 static int DetectIdTestParse02 (void)
 {
-    DetectIdData *id_d = NULL;
-    id_d = DetectIdParse("65537");
-    if (id_d == NULL) {
-        DetectIdFree(NULL, id_d);
-        return 1;
-    }
+    DetectIdData *id_d = DetectIdParse("65537");
 
-    return 0;
+    FAIL_IF_NOT_NULL(id_d);
+
+    PASS;
 }
 
 /**
@@ -317,14 +314,11 @@ static int DetectIdTestParse02 (void)
  */
 static int DetectIdTestParse03 (void)
 {
-    DetectIdData *id_d = NULL;
-    id_d = DetectIdParse("12what?");
-    if (id_d == NULL) {
-        DetectIdFree(NULL, id_d);
-        return 1;
-    }
+    DetectIdData *id_d = DetectIdParse("12what?");
 
-    return 0;
+    FAIL_IF_NOT_NULL(id_d);
+
+    PASS;
 }
 
 /**
@@ -333,15 +327,15 @@ static int DetectIdTestParse03 (void)
  */
 static int DetectIdTestParse04 (void)
 {
-    DetectIdData *id_d = NULL;
     /* yep, look if we trim blank spaces correctly and ignore "'s */
-    id_d = DetectIdParse(" \"35402\" ");
-    if (id_d != NULL &&id_d->id==35402) {
-        DetectIdFree(NULL, id_d);
-        return 1;
-    }
+    DetectIdData *id_d = DetectIdParse(" \"35402\" ");
 
-    return 0;
+    FAIL_IF_NULL(id_d);
+    FAIL_IF_NOT(id_d->id == 35402);
+
+    DetectIdFree(NULL, id_d);
+
+    PASS;
 }
 
 /**
@@ -350,7 +344,6 @@ static int DetectIdTestParse04 (void)
  */
 static int DetectIdTestMatch01(void)
 {
-    int result = 0;
     uint8_t *buf = (uint8_t *)"Hi all!";
     uint16_t buflen = strlen((char *)buf);
     Packet *p[3];
@@ -358,8 +351,9 @@ static int DetectIdTestMatch01(void)
     p[1] = UTHBuildPacket((uint8_t *)buf, buflen, IPPROTO_UDP);
     p[2] = UTHBuildPacket((uint8_t *)buf, buflen, IPPROTO_ICMP);
 
-    if (p[0] == NULL || p[1] == NULL ||p[2] == NULL)
-        goto end;
+    FAIL_IF_NULL(p[0]);
+    FAIL_IF_NULL(p[1]);
+    FAIL_IF_NULL(p[2]);
 
     /* TCP IP id = 1234 */
     p[0]->ip4h->ip_id = htons(1234);
@@ -385,11 +379,9 @@ static int DetectIdTestMatch01(void)
                               /* packet 2 should not match */
                               {0, 0, 1} };
 
-    result = UTHGenericTest(p, 3, sigs, sid, (uint32_t *) results, 3);
-
     UTHFreePackets(p, 3);
-end:
-    return result;
+
+    PASS;
 }
 
 /**

--- a/src/detect-id.c
+++ b/src/detect-id.c
@@ -368,7 +368,6 @@ static int DetectIdTestMatch01(void)
     sigs[1]= "alert ip any any -> any any (msg:\"Testing id 2\"; id:5678; sid:2;)";
     sigs[2]= "alert ip any any -> any any (msg:\"Testing id 3\"; id:5101; sid:3;)";
 
-
     UTHFreePackets(p, 3);
 
     PASS;

--- a/src/detect-id.c
+++ b/src/detect-id.c
@@ -364,20 +364,10 @@ static int DetectIdTestMatch01(void)
     /* UDP IP id = 91011 */
     p[2]->ip4h->ip_id = htons(5101);
 
-    const char *sigs[3];
     sigs[0]= "alert ip any any -> any any (msg:\"Testing id 1\"; id:1234; sid:1;)";
     sigs[1]= "alert ip any any -> any any (msg:\"Testing id 2\"; id:5678; sid:2;)";
     sigs[2]= "alert ip any any -> any any (msg:\"Testing id 3\"; id:5101; sid:3;)";
 
-    uint32_t sid[3] = {1, 2, 3};
-
-    uint32_t results[3][3] = {
-                              /* packet 0 match sid 1 but should not match sid 2 */
-                              {1, 0, 0},
-                              /* packet 1 should not match */
-                              {0, 1, 0},
-                              /* packet 2 should not match */
-                              {0, 0, 1} };
 
     UTHFreePackets(p, 3);
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to redmine ticket:
https://redmine.openinfosecfoundation.org/issues/4046

Ticket: #4046

Previous PR: #6618

Describe changes:

- Update detect-id unit tests to use FAIL/PASS APIs
- Update Copyright Year