### PR TITLE
app-layer: factor out some common code between parsers - v8.1

### DIFF
--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -259,15 +259,6 @@ fn probe(input: &[u8]) -> nom::IResult<&[u8], ()> {
 
 // C exports.
 
-export_tx_get_detect_state!(
-    rs_template_tx_get_detect_state,
-    TemplateTransaction
-);
-export_tx_set_detect_state!(
-    rs_template_tx_set_detect_state,
-    TemplateTransaction
-);
-
 /// C entry point for a probing parser.
 #[no_mangle]
 pub unsafe extern "C" fn rs_template_probing_parser(
@@ -483,8 +474,6 @@ pub unsafe extern "C" fn rs_template_register_parser() {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_template_tx_get_alstate_progress,
-        get_de_state: rs_template_tx_get_detect_state,
-        set_de_state: rs_template_tx_set_detect_state,
         get_events: Some(rs_template_state_get_events),
         get_eventinfo: Some(TemplateEvent::get_event_info),
         get_eventinfo_byid : Some(TemplateEvent::get_event_info_by_id),

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -239,26 +239,6 @@ pub unsafe extern "C" fn rs_dcerpc_udp_state_transaction_free(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_dcerpc_udp_get_tx_detect_state(
-    vtx: *mut std::os::raw::c_void,
-) -> *mut core::DetectEngineState {
-    let dce_state = cast_pointer!(vtx, DCERPCTransaction);
-    match dce_state.de_state {
-        Some(ds) => ds,
-        None => std::ptr::null_mut(),
-    }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_dcerpc_udp_set_tx_detect_state(
-    vtx: *mut std::os::raw::c_void, de_state: &mut core::DetectEngineState,
-) -> std::os::raw::c_int {
-    let dce_state = cast_pointer!(vtx, DCERPCTransaction);
-    dce_state.de_state = Some(de_state);
-    0
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn rs_dcerpc_udp_get_tx_data(
     tx: *mut std::os::raw::c_void)
     -> *mut AppLayerTxData
@@ -359,8 +339,6 @@ pub unsafe extern "C" fn rs_dcerpc_udp_register_parser() {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_dcerpc_get_alstate_progress,
-        get_de_state: rs_dcerpc_udp_get_tx_detect_state,
-        set_de_state: rs_dcerpc_udp_set_tx_detect_state,
         get_events: None,
         get_eventinfo: None,
         get_eventinfo_byid: None,

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -56,8 +56,8 @@ pub const DHCP_TYPE_NAK: u8 = 6;
 pub const DHCP_TYPE_RELEASE: u8 = 7;
 pub const DHCP_TYPE_INFORM: u8 = 8;
 
-/// DHCP parameter types.
-/// https://www.iana.org/assignments/bootp-dhcp-parameters/bootp-dhcp-parameters.txt
+// DHCP parameter types.
+// https://www.iana.org/assignments/bootp-dhcp-parameters/bootp-dhcp-parameters.txt
 pub const DHCP_PARAM_SUBNET_MASK: u8 = 1;
 pub const DHCP_PARAM_ROUTER: u8 = 3;
 pub const DHCP_PARAM_DNS_SERVER: u8 = 6;

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -109,6 +109,12 @@ impl DHCPTransaction {
 
 }
 
+impl Transaction for DHCPTransaction {
+    fn id(&self) -> u64 {
+        self.tx_id
+    }
+}
+
 impl Drop for DHCPTransaction {
     fn drop(&mut self) {
         self.free();
@@ -127,6 +133,12 @@ pub struct DHCPState {
     transactions: Vec<DHCPTransaction>,
 
     events: u16,
+}
+
+impl State<DHCPTransaction> for DHCPState {
+    fn get_transactions(&self) -> &[DHCPTransaction] {
+        &self.transactions
+    }
 }
 
 impl DHCPState {
@@ -188,25 +200,6 @@ impl DHCPState {
                 &mut tx.events, event as u8);
             self.events += 1;
         }
-    }
-
-    fn get_tx_iterator(&mut self, min_tx_id: u64, state: &mut u64) ->
-        Option<(&DHCPTransaction, u64, bool)>
-    {
-        let mut index = *state as usize;
-        let len = self.transactions.len();
-
-        while index < len {
-            let tx = &self.transactions[index];
-            if tx.tx_id < min_tx_id + 1 {
-                index += 1;
-                continue;
-            }
-            *state = index as u64;
-            return Some((tx, tx.tx_id - 1, (len - index) > 1));
-        }
-        
-        return None;
     }
 }
 
@@ -304,30 +297,6 @@ pub unsafe extern "C" fn rs_dhcp_state_get_events(tx: *mut std::os::raw::c_void)
     return tx.events;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_dhcp_state_get_tx_iterator(
-    _ipproto: u8,
-    _alproto: AppProto,
-    state: *mut std::os::raw::c_void,
-    min_tx_id: u64,
-    _max_tx_id: u64,
-    istate: &mut u64)
-    -> applayer::AppLayerGetTxIterTuple
-{
-    let state = cast_pointer!(state, DHCPState);
-    match state.get_tx_iterator(min_tx_id, istate) {
-        Some((tx, out_tx_id, has_next)) => {
-            let c_tx = tx as *const _ as *mut _;
-            let ires = applayer::AppLayerGetTxIterTuple::with_values(
-                c_tx, out_tx_id, has_next);
-            return ires;
-        }
-        None => {
-            return applayer::AppLayerGetTxIterTuple::not_found();
-        }
-    }
-}
-
 export_tx_data_get!(rs_dhcp_get_tx_data, DHCPTransaction);
 
 const PARSER_NAME: &'static [u8] = b"dhcp\0";
@@ -362,7 +331,7 @@ pub unsafe extern "C" fn rs_dhcp_register_parser() {
         localstorage_new   : None,
         localstorage_free  : None,
         get_files          : None,
-        get_tx_iterator    : Some(rs_dhcp_state_get_tx_iterator),
+        get_tx_iterator    : Some(applayer::state_get_tx_iterator::<DHCPState, DHCPTransaction>),
         get_tx_data        : rs_dhcp_get_tx_data,
         apply_tx_config    : None,
         flags              : APP_LAYER_PARSER_OPT_UNIDIR_TXS,

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -236,6 +236,12 @@ pub struct DNSTransaction {
     pub tx_data: AppLayerTxData,
 }
 
+impl Transaction for DNSTransaction {
+    fn id(&self) -> u64 {
+        self.id
+    }
+}
+
 impl DNSTransaction {
 
     pub fn new() -> Self {
@@ -334,6 +340,12 @@ pub struct DNSState {
     config: Option<ConfigTracker>,
 
     gap: bool,
+}
+
+impl State<DNSTransaction> for DNSState {
+    fn get_transactions(&self) -> &[DNSTransaction] {
+        &self.transactions
+    }
 }
 
 impl DNSState {
@@ -991,7 +1003,7 @@ pub unsafe extern "C" fn rs_dns_udp_register_parser() {
         localstorage_new: None,
         localstorage_free: None,
         get_files: None,
-        get_tx_iterator: None,
+        get_tx_iterator: Some(crate::applayer::state_get_tx_iterator::<DNSState, DNSTransaction>),
         get_de_state: rs_dns_state_get_tx_detect_state,
         set_de_state: rs_dns_state_set_tx_detect_state,
         get_tx_data: rs_dns_state_get_tx_data,
@@ -1037,7 +1049,7 @@ pub unsafe extern "C" fn rs_dns_tcp_register_parser() {
         localstorage_new: None,
         localstorage_free: None,
         get_files: None,
-        get_tx_iterator: None,
+        get_tx_iterator: Some(crate::applayer::state_get_tx_iterator::<DNSState, DNSTransaction>),
         get_de_state: rs_dns_state_get_tx_detect_state,
         set_de_state: rs_dns_state_set_tx_detect_state,
         get_tx_data: rs_dns_state_get_tx_data,

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -134,7 +134,6 @@ pub struct HTTP2Transaction {
     decoder: decompression::HTTP2Decoder,
     pub file_range: *mut HttpRangeContainerBlock,
 
-    de_state: Option<*mut core::DetectEngineState>,
     events: *mut core::AppLayerDecoderEvents,
     tx_data: AppLayerTxData,
     pub ft_tc: FileTransferTracker,
@@ -162,7 +161,6 @@ impl HTTP2Transaction {
             frames_ts: Vec::new(),
             decoder: decompression::HTTP2Decoder::new(),
             file_range: std::ptr::null_mut(),
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: AppLayerTxData::new(),
             ft_tc: FileTransferTracker::new(),
@@ -174,9 +172,6 @@ impl HTTP2Transaction {
     pub fn free(&mut self) {
         if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-        if let Some(state) = self.de_state {
-            core::sc_detect_engine_state_free(state);
         }
         if !self.file_range.is_null() {
             match unsafe { SC } {
@@ -991,9 +986,6 @@ impl HTTP2State {
 
 // C exports.
 
-export_tx_get_detect_state!(rs_http2_tx_get_detect_state, HTTP2Transaction);
-export_tx_set_detect_state!(rs_http2_tx_set_detect_state, HTTP2Transaction);
-
 export_tx_data_get!(rs_http2_get_tx_data, HTTP2Transaction);
 
 /// C entry point for a probing parser.
@@ -1168,8 +1160,6 @@ pub unsafe extern "C" fn rs_http2_register_parser() {
         tx_comp_st_ts: HTTP2TransactionState::HTTP2StateClosed as i32,
         tx_comp_st_tc: HTTP2TransactionState::HTTP2StateClosed as i32,
         tx_get_progress: rs_http2_tx_get_alstate_progress,
-        get_de_state: rs_http2_tx_get_detect_state,
-        set_de_state: rs_http2_tx_set_detect_state,
         get_events: Some(rs_http2_state_get_events),
         get_eventinfo: Some(HTTP2Event::get_event_info),
         get_eventinfo_byid: Some(HTTP2Event::get_event_info_by_id),

--- a/rust/src/ike/ike.rs
+++ b/rust/src/ike/ike.rs
@@ -107,7 +107,6 @@ pub struct IKETransaction {
     pub errors: u32,
 
     logged: LoggerFlags,
-    de_state: Option<*mut core::DetectEngineState>,
     events: *mut core::AppLayerDecoderEvents,
     tx_data: applayer::AppLayerTxData,
 }
@@ -127,7 +126,6 @@ impl IKETransaction {
             payload_types: Default::default(),
             notify_types: vec![],
             logged: LoggerFlags::new(),
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: applayer::AppLayerTxData::new(),
             errors: 0,
@@ -137,9 +135,6 @@ impl IKETransaction {
     pub fn free(&mut self) {
         if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-        if let Some(state) = self.de_state {
-            core::sc_detect_engine_state_free(state);
         }
     }
 
@@ -295,8 +290,6 @@ fn probe(input: &[u8], direction: u8, rdir: *mut u8) -> bool {
 }
 
 // C exports.
-export_tx_get_detect_state!(rs_ike_tx_get_detect_state, IKETransaction);
-export_tx_set_detect_state!(rs_ike_tx_set_detect_state, IKETransaction);
 
 /// C entry point for a probing parser.
 #[no_mangle]
@@ -446,8 +439,6 @@ pub unsafe extern "C" fn rs_ike_register_parser() {
         tx_comp_st_ts      : 1,
         tx_comp_st_tc      : 1,
         tx_get_progress    : rs_ike_tx_get_alstate_progress,
-        get_de_state       : rs_ike_tx_get_detect_state,
-        set_de_state       : rs_ike_tx_set_detect_state,
         get_events         : Some(rs_ike_state_get_events),
         get_eventinfo      : Some(IkeEvent::get_event_info),
         get_eventinfo_byid : Some(IkeEvent::get_event_info_by_id),

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -51,6 +51,12 @@ pub struct KRB5State {
     tx_id: u64,
 }
 
+impl State<KRB5Transaction> for KRB5State {
+    fn get_transactions(&self) -> &[KRB5Transaction] {
+        &self.transactions
+    }
+}
+
 pub struct KRB5Transaction {
     /// The message type: AS-REQ, AS-REP, etc.
     pub msg_type: MessageType,
@@ -78,6 +84,12 @@ pub struct KRB5Transaction {
     events: *mut core::AppLayerDecoderEvents,
 
     tx_data: applayer::AppLayerTxData,
+}
+
+impl Transaction for KRB5Transaction {
+    fn id(&self) -> u64 {
+        self.id
+    }
 }
 
 pub fn to_hex_string(bytes: &[u8]) -> String {
@@ -590,7 +602,7 @@ pub unsafe extern "C" fn rs_register_krb5_parser() {
         localstorage_new   : None,
         localstorage_free  : None,
         get_files          : None,
-        get_tx_iterator    : None,
+        get_tx_iterator    : Some(applayer::state_get_tx_iterator::<KRB5State, KRB5Transaction>),
         get_tx_data        : rs_krb5_get_tx_data,
         apply_tx_config    : None,
         flags              : APP_LAYER_PARSER_OPT_UNIDIR_TXS,

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -179,7 +179,6 @@ pub struct NFSTransaction {
     /// attempt failed.
     pub type_data: Option<NFSTransactionTypeData>,
 
-    pub de_state: Option<*mut DetectEngineState>,
     pub events: *mut AppLayerDecoderEvents,
 
     pub tx_data: AppLayerTxData,
@@ -208,7 +207,6 @@ impl NFSTransaction {
             file_tx_direction: 0,
             file_handle:Vec::new(),
             type_data: None,
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: AppLayerTxData::new(),
         }
@@ -219,12 +217,6 @@ impl NFSTransaction {
         debug_validate_bug_on!(self.tx_data.files_logged > 1);
         if !self.events.is_null() {
             sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-        match self.de_state {
-            Some(state) => {
-                sc_detect_engine_state_free(state);
-            }
-            _ => {}
         }
     }
 }
@@ -1550,34 +1542,6 @@ pub unsafe extern "C" fn rs_nfs_get_tx_data(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_nfs_state_set_tx_detect_state(
-    tx: *mut std::os::raw::c_void,
-    de_state: &mut DetectEngineState) -> i32
-{
-    let tx = cast_pointer!(tx, NFSTransaction);
-    tx.de_state = Some(de_state);
-    0
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_nfs_state_get_tx_detect_state(
-    tx: *mut std::os::raw::c_void)
-    -> *mut DetectEngineState
-{
-    let tx = cast_pointer!(tx, NFSTransaction);
-    match tx.de_state {
-        Some(ds) => {
-            SCLogDebug!("{}: getting de_state", tx.id);
-            return ds;
-        },
-        None => {
-            SCLogDebug!("{}: getting de_state: have none", tx.id);
-            return std::ptr::null_mut();
-        }
-    }
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn rs_nfs_state_get_events(tx: *mut std::os::raw::c_void)
                                           -> *mut AppLayerDecoderEvents
 {
@@ -1911,8 +1875,6 @@ pub unsafe extern "C" fn rs_nfs_register_parser() {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_nfs_tx_get_alstate_progress,
-        get_de_state: rs_nfs_state_get_tx_detect_state,
-        set_de_state: rs_nfs_state_set_tx_detect_state,
         get_events: Some(rs_nfs_state_get_events),
         get_eventinfo: Some(rs_nfs_state_get_event_info),
         get_eventinfo_byid : Some(rs_nfs_state_get_event_info_by_id),
@@ -1990,8 +1952,6 @@ pub unsafe extern "C" fn rs_nfs_udp_register_parser() {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_nfs_tx_get_alstate_progress,
-        get_de_state: rs_nfs_state_get_tx_detect_state,
-        set_de_state: rs_nfs_state_set_tx_detect_state,
         get_events: Some(rs_nfs_state_get_events),
         get_eventinfo: Some(rs_nfs_state_get_event_info),
         get_eventinfo_byid : None,

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -54,9 +54,6 @@ pub struct NTPTransaction {
     /// The internal transaction id
     id: u64,
 
-    /// The detection engine state, if present
-    de_state: Option<*mut core::DetectEngineState>,
-
     /// The events associated with this transaction
     events: *mut core::AppLayerDecoderEvents,
 
@@ -152,7 +149,6 @@ impl NTPTransaction {
         NTPTransaction {
             xid: 0,
             id: id,
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: applayer::AppLayerTxData::new(),
         }
@@ -161,9 +157,6 @@ impl NTPTransaction {
     fn free(&mut self) {
         if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-        if let Some(de_state) = self.de_state {
-            core::sc_detect_engine_state_free(de_state);
         }
     }
 }
@@ -259,28 +252,6 @@ pub extern "C" fn rs_ntp_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void,
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_ntp_state_set_tx_detect_state(
-    tx: *mut std::os::raw::c_void,
-    de_state: &mut core::DetectEngineState) -> std::os::raw::c_int
-{
-    let tx = cast_pointer!(tx,NTPTransaction);
-    tx.de_state = Some(de_state);
-    0
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_ntp_state_get_tx_detect_state(
-    tx: *mut std::os::raw::c_void)
-    -> *mut core::DetectEngineState
-{
-    let tx = cast_pointer!(tx,NTPTransaction);
-    match tx.de_state {
-        Some(ds) => ds,
-        None => std::ptr::null_mut(),
-    }
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn rs_ntp_state_get_events(tx: *mut std::os::raw::c_void)
                                           -> *mut core::AppLayerDecoderEvents
 {
@@ -340,8 +311,6 @@ pub unsafe extern "C" fn rs_register_ntp_parser() {
         tx_comp_st_ts      : 1,
         tx_comp_st_tc      : 1,
         tx_get_progress    : rs_ntp_tx_get_alstate_progress,
-        get_de_state       : rs_ntp_state_get_tx_detect_state,
-        set_de_state       : rs_ntp_state_set_tx_detect_state,
         get_events         : Some(rs_ntp_state_get_events),
         get_eventinfo      : Some(NTPEvent::get_event_info),
         get_eventinfo_byid : Some(NTPEvent::get_event_info_by_id),

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -63,7 +63,11 @@ pub struct NTPTransaction {
     tx_data: applayer::AppLayerTxData,
 }
 
-
+impl Transaction for NTPTransaction {
+    fn id(&self) -> u64 {
+        self.id
+    }
+}
 
 impl NTPState {
     pub fn new() -> NTPState {
@@ -72,6 +76,12 @@ impl NTPState {
             events: 0,
             tx_id: 0,
         }
+    }
+}
+
+impl State<NTPTransaction> for NTPState {
+    fn get_transactions(&self) -> &[NTPTransaction] {
+        &self.transactions
     }
 }
 
@@ -338,7 +348,7 @@ pub unsafe extern "C" fn rs_register_ntp_parser() {
         localstorage_new   : None,
         localstorage_free  : None,
         get_files          : None,
-        get_tx_iterator    : None,
+        get_tx_iterator    : Some(applayer::state_get_tx_iterator::<NTPState, NTPTransaction>),
         get_tx_data        : rs_ntp_get_tx_data,
         apply_tx_config    : None,
         flags              : APP_LAYER_PARSER_OPT_UNIDIR_TXS,

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -155,8 +155,8 @@ impl RdpState {
     }
 
     fn new_tx(&mut self, item: RdpTransactionItem) -> RdpTransaction {
-        let tx = RdpTransaction::new(self.next_id, item);
         self.next_id += 1;
+        let tx = RdpTransaction::new(self.next_id, item);
         return tx;
     }
 
@@ -602,8 +602,8 @@ mod tests {
         state.transactions.push(tx0);
         state.transactions.push(tx1);
         assert_eq!(2, state.transactions.len());
-        assert_eq!(0, state.transactions[0].id);
-        assert_eq!(1, state.transactions[1].id);
+        assert_eq!(1, state.transactions[0].id);
+        assert_eq!(2, state.transactions[1].id);
         assert_eq!(false, state.tls_parsing);
         assert_eq!(false, state.bypass_parsing);
     }
@@ -626,7 +626,7 @@ mod tests {
         state.transactions.push(tx0);
         state.transactions.push(tx1);
         state.transactions.push(tx2);
-        assert_eq!(Some(&state.transactions[1]), state.get_tx(1));
+        assert_eq!(Some(&state.transactions[1]), state.get_tx(2));
     }
 
     #[test]
@@ -650,8 +650,8 @@ mod tests {
         state.free_tx(1);
         assert_eq!(3, state.next_id);
         assert_eq!(2, state.transactions.len());
-        assert_eq!(0, state.transactions[0].id);
-        assert_eq!(2, state.transactions[1].id);
+        assert_eq!(2, state.transactions[0].id);
+        assert_eq!(3, state.transactions[1].id);
         assert_eq!(None, state.get_tx(1));
     }
 }

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -20,7 +20,7 @@
 //! RDP application layer
 
 use crate::applayer::{self, *};
-use crate::core::{self, AppProto, DetectEngineState, Flow, ALPROTO_UNKNOWN, IPPROTO_TCP};
+use crate::core::{AppProto, Flow, ALPROTO_UNKNOWN, IPPROTO_TCP};
 use crate::rdp::parser::*;
 use nom;
 use std;
@@ -51,7 +51,6 @@ pub struct RdpTransaction {
     pub id: u64,
     pub item: RdpTransactionItem,
     // managed by macros `export_tx_get_detect_state!` and `export_tx_set_detect_state!`
-    de_state: Option<*mut DetectEngineState>,
     tx_data: AppLayerTxData,
 }
 
@@ -66,21 +65,8 @@ impl RdpTransaction {
         Self {
             id,
             item,
-            de_state: None,
             tx_data: AppLayerTxData::new(),
         }
-    }
-
-    fn free(&mut self) {
-        if let Some(de_state) = self.de_state {
-            core::sc_detect_engine_state_free(de_state);
-        }
-    }
-}
-
-impl Drop for RdpTransaction {
-    fn drop(&mut self) {
-        self.free();
     }
 }
 
@@ -402,13 +388,6 @@ pub unsafe extern "C" fn rs_rdp_state_tx_free(state: *mut std::os::raw::c_void, 
 }
 
 //
-// detection state
-//
-
-export_tx_get_detect_state!(rs_rdp_tx_get_detect_state, RdpTransaction);
-export_tx_set_detect_state!(rs_rdp_tx_set_detect_state, RdpTransaction);
-
-//
 // probe
 //
 
@@ -496,8 +475,6 @@ pub unsafe extern "C" fn rs_rdp_register_parser() {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_rdp_tx_get_progress,
-        get_de_state: rs_rdp_tx_get_detect_state,
-        set_de_state: rs_rdp_tx_set_detect_state,
         get_events: None,
         get_eventinfo: None,
         get_eventinfo_byid: None,

--- a/rust/src/rfb/rfb.rs
+++ b/rust/src/rfb/rfb.rs
@@ -44,7 +44,6 @@ pub struct RFBTransaction {
     pub tc_failure_reason: Option<parser::FailureReason>,
     pub tc_server_init: Option<parser::ServerInit>,
 
-    de_state: Option<*mut core::DetectEngineState>,
     events: *mut core::AppLayerDecoderEvents,
     tx_data: applayer::AppLayerTxData,
 }
@@ -74,7 +73,6 @@ impl RFBTransaction {
             tc_failure_reason: None,
             tc_server_init: None,
 
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: applayer::AppLayerTxData::new(),
         }
@@ -83,9 +81,6 @@ impl RFBTransaction {
     pub fn free(&mut self) {
         if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-        if let Some(state) = self.de_state {
-            core::sc_detect_engine_state_free(state);
         }
     }
 }
@@ -498,15 +493,6 @@ impl RFBState {
 
 // C exports.
 
-export_tx_get_detect_state!(
-    rs_rfb_tx_get_detect_state,
-    RFBTransaction
-);
-export_tx_set_detect_state!(
-    rs_rfb_tx_set_detect_state,
-    RFBTransaction
-);
-
 #[no_mangle]
 pub extern "C" fn rs_rfb_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = RFBState::new();
@@ -628,8 +614,6 @@ pub unsafe extern "C" fn rs_rfb_register_parser() {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_rfb_tx_get_alstate_progress,
-        get_de_state: rs_rfb_tx_get_detect_state,
-        set_de_state: rs_rfb_tx_set_detect_state,
         get_events: Some(rs_rfb_state_get_events),
         get_eventinfo: None,
         get_eventinfo_byid: None,

--- a/rust/src/rfb/rfb.rs
+++ b/rust/src/rfb/rfb.rs
@@ -49,6 +49,12 @@ pub struct RFBTransaction {
     tx_data: applayer::AppLayerTxData,
 }
 
+impl Transaction for RFBTransaction {
+    fn id(&self) -> u64 {
+        self.tx_id
+    }
+}
+
 impl RFBTransaction {
     pub fn new() -> RFBTransaction {
         RFBTransaction {
@@ -94,6 +100,12 @@ pub struct RFBState {
     tx_id: u64,
     transactions: Vec<RFBTransaction>,
     state: parser::RFBGlobalState
+}
+
+impl State<RFBTransaction> for RFBState {
+    fn get_transactions(&self) -> &[RFBTransaction] {
+        &self.transactions
+    }
 }
 
 impl RFBState {
@@ -482,27 +494,6 @@ impl RFBState {
             }
         }
     }
-
-    fn tx_iterator(
-        &mut self,
-        min_tx_id: u64,
-        state: &mut u64,
-    ) -> Option<(&RFBTransaction, u64, bool)> {
-        let mut index = *state as usize;
-        let len = self.transactions.len();
-
-        while index < len {
-            let tx = &self.transactions[index];
-            if tx.tx_id < min_tx_id + 1 {
-                index += 1;
-                continue;
-            }
-            *state = index as u64;
-            return Some((tx, tx.tx_id - 1, (len - index) > 1));
-        }
-
-        return None;
-    }
 }
 
 // C exports.
@@ -612,32 +603,6 @@ pub unsafe extern "C" fn rs_rfb_state_get_events(
     return tx.events;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_rfb_state_get_tx_iterator(
-    _ipproto: u8,
-    _alproto: AppProto,
-    state: *mut std::os::raw::c_void,
-    min_tx_id: u64,
-    _max_tx_id: u64,
-    istate: &mut u64,
-) -> applayer::AppLayerGetTxIterTuple {
-    let state = cast_pointer!(state, RFBState);
-    match state.tx_iterator(min_tx_id, istate) {
-        Some((tx, out_tx_id, has_next)) => {
-            let c_tx = tx as *const _ as *mut _;
-            let ires = applayer::AppLayerGetTxIterTuple::with_values(
-                c_tx,
-                out_tx_id,
-                has_next,
-            );
-            return ires;
-        }
-        None => {
-            return applayer::AppLayerGetTxIterTuple::not_found();
-        }
-    }
-}
-
 // Parser name as a C style string.
 const PARSER_NAME: &'static [u8] = b"rfb\0";
 
@@ -671,7 +636,7 @@ pub unsafe extern "C" fn rs_rfb_register_parser() {
         localstorage_new: None,
         localstorage_free: None,
         get_files: None,
-        get_tx_iterator: Some(rs_rfb_state_get_tx_iterator),
+        get_tx_iterator: Some(applayer::state_get_tx_iterator::<RFBState, RFBTransaction>),
         get_tx_data: rs_rfb_get_tx_data,
         apply_tx_config: None,
         flags: 0,

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -36,6 +36,12 @@ pub struct SIPState {
     tx_id: u64,
 }
 
+impl State<SIPTransaction> for SIPState {
+    fn get_transactions(&self) -> &[SIPTransaction] {
+        &self.transactions
+    }
+}
+
 pub struct SIPTransaction {
     id: u64,
     pub request: Option<Request>,
@@ -45,6 +51,12 @@ pub struct SIPTransaction {
     de_state: Option<*mut core::DetectEngineState>,
     events: *mut core::AppLayerDecoderEvents,
     tx_data: applayer::AppLayerTxData,
+}
+
+impl Transaction for SIPTransaction {
+    fn id(&self) -> u64 {
+        self.id
+    }
 }
 
 impl SIPState {
@@ -326,7 +338,7 @@ pub unsafe extern "C" fn rs_sip_register_parser() {
         localstorage_new: None,
         localstorage_free: None,
         get_files: None,
-        get_tx_iterator: None,
+        get_tx_iterator: Some(applayer::state_get_tx_iterator::<SIPState, SIPTransaction>),        
         get_tx_data: rs_sip_get_tx_data,
         apply_tx_config: None,
         flags: APP_LAYER_PARSER_OPT_UNIDIR_TXS,

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -19,7 +19,7 @@
 
 use crate::applayer::{self, *};
 use crate::core;
-use crate::core::{sc_detect_engine_state_free, AppProto, Flow, ALPROTO_UNKNOWN};
+use crate::core::{AppProto, Flow, ALPROTO_UNKNOWN};
 use crate::sip::parser::*;
 use nom7::Err;
 use std;
@@ -48,7 +48,6 @@ pub struct SIPTransaction {
     pub response: Option<Response>,
     pub request_line: Option<String>,
     pub response_line: Option<String>,
-    de_state: Option<*mut core::DetectEngineState>,
     events: *mut core::AppLayerDecoderEvents,
     tx_data: applayer::AppLayerTxData,
 }
@@ -147,7 +146,6 @@ impl SIPTransaction {
     pub fn new(id: u64) -> SIPTransaction {
         SIPTransaction {
             id,
-            de_state: None,
             request: None,
             response: None,
             request_line: None,
@@ -162,9 +160,6 @@ impl Drop for SIPTransaction {
     fn drop(&mut self) {
         if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-        if let Some(state) = self.de_state {
-            sc_detect_engine_state_free(state);
         }
     }
 }
@@ -212,27 +207,6 @@ pub extern "C" fn rs_sip_tx_get_alstate_progress(
     _direction: u8,
 ) -> std::os::raw::c_int {
     1
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_sip_state_set_tx_detect_state(
-    tx: *mut std::os::raw::c_void,
-    de_state: &mut core::DetectEngineState,
-) -> std::os::raw::c_int {
-    let tx = cast_pointer!(tx, SIPTransaction);
-    tx.de_state = Some(de_state);
-    0
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_sip_state_get_tx_detect_state(
-    tx: *mut std::os::raw::c_void,
-) -> *mut core::DetectEngineState {
-    let tx = cast_pointer!(tx, SIPTransaction);
-    match tx.de_state {
-        Some(ds) => ds,
-        None => std::ptr::null_mut(),
-    }
 }
 
 #[no_mangle]
@@ -330,8 +304,6 @@ pub unsafe extern "C" fn rs_sip_register_parser() {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_sip_tx_get_alstate_progress,
-        get_de_state: rs_sip_state_get_tx_detect_state,
-        set_de_state: rs_sip_state_set_tx_detect_state,
         get_events: Some(rs_sip_state_get_events),
         get_eventinfo: Some(SIPEvent::get_event_info),
         get_eventinfo_byid: Some(SIPEvent::get_event_info_by_id),

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -541,6 +541,12 @@ pub struct SMBTransaction {
     pub tx_data: AppLayerTxData,
 }
 
+impl Transaction for SMBTransaction {
+    fn id(&self) -> u64 {
+        self.id
+    }
+}
+
 impl SMBTransaction {
     pub fn new() -> Self {
         return Self {
@@ -772,6 +778,12 @@ pub struct SMBState<> {
     ts: u64,
 }
 
+impl State<SMBTransaction> for SMBState {
+    fn get_transactions(&self) -> &[SMBTransaction] {
+        &self.transactions
+    }
+}
+
 impl SMBState {
     /// Allocation function for a new TLS parser instance
     pub fn new() -> Self {
@@ -837,31 +849,6 @@ impl SMBState {
                     tx_id, tx_id+1, index, self.transactions.len(), self.tx_id);
             self.transactions.remove(index);
         }
-    }
-
-    // for use with the C API call StateGetTxIterator
-    pub fn get_tx_iterator(&mut self, min_tx_id: u64, state: &mut u64) ->
-        Option<(&SMBTransaction, u64, bool)>
-    {
-        let mut index = *state as usize;
-        let len = self.transactions.len();
-
-        // find tx that is >= min_tx_id
-        while index < len {
-            let tx = &self.transactions[index];
-            if tx.id < min_tx_id + 1 {
-                index += 1;
-                continue;
-            }
-            // store current index in the state and not the next
-            // as transactions might be freed between now and the
-            // next time we are called.
-            *state = index as u64;
-            //SCLogDebug!("returning tx_id {} has_next? {} (len {} index {}), tx {:?}",
-            //        tx.id - 1, (len - index) > 1, len, index, tx);
-            return Some((tx, tx.id - 1, (len - index) > 1));
-        }
-        return None;
     }
 
     pub fn get_tx_by_id(&mut self, tx_id: u64) -> Option<&SMBTransaction> {
@@ -2030,30 +2017,6 @@ pub unsafe extern "C" fn rs_smb_state_get_tx(state: *mut ffi::c_void,
     }
 }
 
-// for use with the C API call StateGetTxIterator
-#[no_mangle]
-pub unsafe extern "C" fn rs_smb_state_get_tx_iterator(
-                                               _ipproto: u8,
-                                               _alproto: AppProto,
-                                               state: *mut std::os::raw::c_void,
-                                               min_tx_id: u64,
-                                               _max_tx_id: u64,
-                                               istate: &mut u64,
-                                               ) -> applayer::AppLayerGetTxIterTuple
-{
-    let state = cast_pointer!(state, SMBState);
-    match state.get_tx_iterator(min_tx_id, istate) {
-        Some((tx, out_tx_id, has_next)) => {
-            let c_tx = tx as *const _ as *mut _;
-            let ires = applayer::AppLayerGetTxIterTuple::with_values(c_tx, out_tx_id, has_next);
-            return ires;
-        }
-        None => {
-            return applayer::AppLayerGetTxIterTuple::not_found();
-        }
-    }
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn rs_smb_state_tx_free(state: *mut ffi::c_void,
                                        tx_id: u64)
@@ -2243,7 +2206,7 @@ pub unsafe extern "C" fn rs_smb_register_parser() {
         localstorage_new: None,
         localstorage_free: None,
         get_files: Some(rs_smb_getfiles),
-        get_tx_iterator: Some(rs_smb_state_get_tx_iterator),
+        get_tx_iterator: Some(applayer::state_get_tx_iterator::<SMBState, SMBTransaction>),
         get_tx_data: rs_smb_get_tx_data,
         apply_tx_config: None,
         flags: APP_LAYER_PARSER_OPT_ACCEPT_GAPS,

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -87,7 +87,11 @@ pub struct SNMPTransaction<'a> {
     tx_data: applayer::AppLayerTxData,
 }
 
-
+impl<'a> Transaction for SNMPTransaction<'a> {
+    fn id(&self) -> u64 {
+        self.id
+    }
+}
 
 impl<'a> SNMPState<'a> {
     pub fn new() -> SNMPState<'a> {
@@ -107,6 +111,12 @@ impl<'a> Default for SNMPPduInfo<'a> {
             trap_type: None,
             vars: Vec::new()
         }
+    }
+}
+
+impl<'a> State<SNMPTransaction<'a>> for SNMPState<'a> {
+    fn get_transactions(&self) -> &[SNMPTransaction<'a>] {
+        &self.transactions
     }
 }
 
@@ -226,28 +236,6 @@ impl<'a> SNMPState<'a> {
     /// Set an event on a specific transaction.
     fn set_event_tx(&self, tx: &mut SNMPTransaction, event: SNMPEvent) {
         core::sc_app_layer_decoder_events_set_event_raw(&mut tx.events, event as u8);
-    }
-
-    // for use with the C API call StateGetTxIterator
-    pub fn get_tx_iterator(&mut self, min_tx_id: u64, state: &mut u64) ->
-        Option<(&SNMPTransaction, u64, bool)>
-    {
-        let mut index = *state as usize;
-        let len = self.transactions.len();
-
-        // find tx that is >= min_tx_id
-        while index < len {
-            let tx = &self.transactions[index];
-            if tx.id < min_tx_id + 1 {
-                index += 1;
-                continue;
-            }
-            *state = index as u64 + 1;
-            //SCLogDebug!("returning tx_id {} has_next? {} (len {} index {}), tx {:?}",
-            //        tx.id - 1, (len - index) > 1, len, index, tx);
-            return Some((tx, tx.id - 1, (len - index) > 1));
-        }
-        return None;
     }
 }
 
@@ -396,50 +384,6 @@ pub unsafe extern "C" fn rs_snmp_state_get_events(tx: *mut std::os::raw::c_void)
     return tx.events;
 }
 
-// for use with the C API call StateGetTxIterator
-#[no_mangle]
-pub extern "C" fn rs_snmp_state_get_tx_iterator(
-                                      state: &mut SNMPState,
-                                      min_tx_id: u64,
-                                      istate: &mut u64)
-                                      -> applayer::AppLayerGetTxIterTuple
-{
-    match state.get_tx_iterator(min_tx_id, istate) {
-        Some((tx, out_tx_id, has_next)) => {
-            let c_tx = tx as *const _ as *mut _;
-            let ires = applayer::AppLayerGetTxIterTuple::with_values(c_tx, out_tx_id, has_next);
-            return ires;
-        }
-        None => {
-            return applayer::AppLayerGetTxIterTuple::not_found();
-        }
-    }
-}
-
-// for use with the C API call StateGetTxIterator
-#[no_mangle]
-pub unsafe extern "C" fn rs_snmp_get_tx_iterator(_ipproto: u8,
-                                          _alproto: AppProto,
-                                          alstate: *mut std::os::raw::c_void,
-                                          min_tx_id: u64,
-                                          _max_tx_id: u64,
-                                          istate: &mut u64) -> applayer::AppLayerGetTxIterTuple
-{
-    let state = cast_pointer!(alstate,SNMPState);
-    match state.get_tx_iterator(min_tx_id, istate) {
-        Some((tx, out_tx_id, has_next)) => {
-            let c_tx = tx as *const _ as *mut _;
-            let ires = applayer::AppLayerGetTxIterTuple::with_values(c_tx, out_tx_id, has_next);
-            return ires;
-        }
-        None => {
-            return applayer::AppLayerGetTxIterTuple::not_found();
-        }
-    }
-}
-
-
-
 static mut ALPROTO_SNMP : AppProto = ALPROTO_UNKNOWN;
 
 // Read PDU sequence and extract version, if similar to SNMP definition
@@ -517,7 +461,7 @@ pub unsafe extern "C" fn rs_register_snmp_parser() {
         localstorage_new   : None,
         localstorage_free  : None,
         get_files          : None,
-        get_tx_iterator    : None,
+        get_tx_iterator    : Some(applayer::state_get_tx_iterator::<SNMPState, SNMPTransaction>),
         get_tx_data        : rs_snmp_get_tx_data,
         apply_tx_config    : None,
         flags              : APP_LAYER_PARSER_OPT_UNIDIR_TXS,
@@ -532,7 +476,6 @@ pub unsafe extern "C" fn rs_register_snmp_parser() {
         if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
             let _ = AppLayerRegisterParser(&parser, alproto);
         }
-        AppLayerParserRegisterGetTxIterator(core::IPPROTO_UDP as u8, alproto, rs_snmp_get_tx_iterator);
         // port 162
         let default_port_traps = CString::new("162").unwrap();
         parser.default_port = default_port_traps.as_ptr();

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -78,9 +78,6 @@ pub struct SNMPTransaction<'a> {
     /// The internal transaction id
     id: u64,
 
-    /// The detection engine state, if present
-    de_state: Option<*mut core::DetectEngineState>,
-
     /// The events associated with this transaction
     events: *mut core::AppLayerDecoderEvents,
 
@@ -248,7 +245,6 @@ impl<'a> SNMPTransaction<'a> {
             usm: None,
             encrypted: false,
             id: id,
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: applayer::AppLayerTxData::new(),
         }
@@ -257,9 +253,6 @@ impl<'a> SNMPTransaction<'a> {
     fn free(&mut self) {
         if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-        if let Some(de_state) = self.de_state {
-            core::sc_detect_engine_state_free(de_state);
         }
     }
 }
@@ -354,29 +347,6 @@ pub extern "C" fn rs_snmp_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_snmp_state_set_tx_detect_state(
-    tx: *mut std::os::raw::c_void,
-    de_state: &mut core::DetectEngineState) -> std::os::raw::c_int
-{
-    let tx = cast_pointer!(tx,SNMPTransaction);
-    tx.de_state = Some(de_state);
-    0
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_snmp_state_get_tx_detect_state(
-    tx: *mut std::os::raw::c_void)
-    -> *mut core::DetectEngineState
-{
-    let tx = cast_pointer!(tx,SNMPTransaction);
-    match tx.de_state {
-        Some(ds) => ds,
-        None => std::ptr::null_mut(),
-    }
-}
-
-
-#[no_mangle]
 pub unsafe extern "C" fn rs_snmp_state_get_events(tx: *mut std::os::raw::c_void)
                                            -> *mut core::AppLayerDecoderEvents
 {
@@ -453,8 +423,6 @@ pub unsafe extern "C" fn rs_register_snmp_parser() {
         tx_comp_st_ts      : 1,
         tx_comp_st_tc      : 1,
         tx_get_progress    : rs_snmp_tx_get_alstate_progress,
-        get_de_state       : rs_snmp_state_get_tx_detect_state,
-        set_de_state       : rs_snmp_state_set_tx_detect_state,
         get_events         : Some(rs_snmp_state_get_events),
         get_eventinfo      : Some(SNMPEvent::get_event_info),
         get_eventinfo_byid : Some(SNMPEvent::get_event_info_by_id),

--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -83,7 +83,6 @@ pub struct SSHTransaction {
     pub srv_hdr: SshHeader,
     pub cli_hdr: SshHeader,
 
-    de_state: Option<*mut core::DetectEngineState>,
     events: *mut core::AppLayerDecoderEvents,
     tx_data: AppLayerTxData,
 }
@@ -93,7 +92,6 @@ impl SSHTransaction {
         SSHTransaction {
             srv_hdr: SshHeader::new(),
             cli_hdr: SshHeader::new(),
-            de_state: None,
             events: std::ptr::null_mut(),
             tx_data: AppLayerTxData::new(),
         }
@@ -102,9 +100,6 @@ impl SSHTransaction {
     pub fn free(&mut self) {
         if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-        if let Some(state) = self.de_state {
-            core::sc_detect_engine_state_free(state);
         }
     }
 }
@@ -352,9 +347,6 @@ impl SSHState {
 
 // C exports.
 
-export_tx_get_detect_state!(rs_ssh_tx_get_detect_state, SSHTransaction);
-export_tx_set_detect_state!(rs_ssh_tx_set_detect_state, SSHTransaction);
-
 export_tx_data_get!(rs_ssh_get_tx_data, SSHTransaction);
 
 #[no_mangle]
@@ -486,8 +478,6 @@ pub unsafe extern "C" fn rs_ssh_register_parser() {
         tx_comp_st_ts: SSHConnectionState::SshStateFinished as i32,
         tx_comp_st_tc: SSHConnectionState::SshStateFinished as i32,
         tx_get_progress: rs_ssh_tx_get_alstate_progress,
-        get_de_state: rs_ssh_tx_get_detect_state,
-        set_de_state: rs_ssh_tx_set_detect_state,
         get_events: Some(rs_ssh_state_get_events),
         get_eventinfo: Some(SSHEvent::get_event_info),
         get_eventinfo_byid: Some(SSHEvent::get_event_info_by_id),

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -1392,8 +1392,8 @@ static void DNP3TxFree(DNP3Transaction *tx)
 
     AppLayerDecoderEventsFreeEvents(&tx->decoder_events);
 
-    if (tx->de_state != NULL) {
-        DetectEngineStateFree(tx->de_state);
+    if (tx->tx_data.de_state != NULL) {
+        DetectEngineStateFree(tx->tx_data.de_state);
     }
 
     DNP3TxFreeObjectList(&tx->request_objects);
@@ -1535,25 +1535,6 @@ static int DNP3StateGetEventInfoById(int event_id, const char **event_name,
     return 0;
 }
 
-/**
- * \brief App-layer support.
- */
-static DetectEngineState *DNP3GetTxDetectState(void *vtx)
-{
-    DNP3Transaction *tx = vtx;
-    return tx->de_state;
-}
-
-/**
- * \brief App-layer support.
- */
-static int DNP3SetTxDetectState(void *vtx, DetectEngineState *s)
-{
-    DNP3Transaction *tx = vtx;
-    tx->de_state = s;
-    return 0;
-}
-
 static AppLayerTxData *DNP3GetTxData(void *vtx)
 {
     DNP3Transaction *tx = (DNP3Transaction *)vtx;
@@ -1622,8 +1603,6 @@ void RegisterDNP3Parsers(void)
 
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_DNP3,
             DNP3GetEvents);
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_DNP3,
-            DNP3GetTxDetectState, DNP3SetTxDetectState);
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_DNP3, DNP3GetTx);
         AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_DNP3, DNP3GetTxCnt);

--- a/src/app-layer-dnp3.h
+++ b/src/app-layer-dnp3.h
@@ -245,7 +245,6 @@ typedef struct DNP3Transaction_ {
 
     AppLayerDecoderEvents *decoder_events; /**< Per transcation
                                             * decoder events. */
-    DetectEngineState *de_state;
 
     TAILQ_ENTRY(DNP3Transaction_) next;
 } DNP3Transaction;

--- a/src/app-layer-enip-common.h
+++ b/src/app-layer-enip-common.h
@@ -209,7 +209,6 @@ typedef struct ENIPTransaction_
     AppLayerDecoderEvents *decoder_events;      /**< per tx events */
 
     TAILQ_ENTRY(ENIPTransaction_) next;
-    DetectEngineState *de_state;
     AppLayerTxData tx_data;
 } ENIPTransaction;
 

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -66,19 +66,6 @@ static int ENIPGetAlstateProgress(void *tx, uint8_t direction)
     return 1;
 }
 
-static DetectEngineState *ENIPGetTxDetectState(void *vtx)
-{
-    ENIPTransaction *tx = (ENIPTransaction *)vtx;
-    return tx->de_state;
-}
-
-static int ENIPSetTxDetectState(void *vtx, DetectEngineState *s)
-{
-    ENIPTransaction *tx = (ENIPTransaction *)vtx;
-    tx->de_state = s;
-    return 0;
-}
-
 static AppLayerTxData *ENIPGetTxData(void *vtx)
 {
     ENIPTransaction *tx = (ENIPTransaction *)vtx;
@@ -196,9 +183,8 @@ static void ENIPTransactionFree(ENIPTransaction *tx, ENIPState *state)
 
     AppLayerDecoderEventsFreeEvents(&tx->decoder_events);
 
-    if (tx->de_state != NULL)
-    {
-        DetectEngineStateFree(tx->de_state);
+    if (tx->tx_data.de_state != NULL) {
+        DetectEngineStateFree(tx->tx_data.de_state);
 
         state->tx_with_detect_state_cnt--;
     }
@@ -513,9 +499,6 @@ void RegisterENIPUDPParsers(void)
 
         AppLayerParserRegisterGetEventsFunc(IPPROTO_UDP, ALPROTO_ENIP, ENIPGetEvents);
 
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_ENIP,
-                ENIPGetTxDetectState, ENIPSetTxDetectState);
-
         AppLayerParserRegisterGetTx(IPPROTO_UDP, ALPROTO_ENIP, ENIPGetTx);
         AppLayerParserRegisterTxDataFunc(IPPROTO_UDP, ALPROTO_ENIP, ENIPGetTxData);
         AppLayerParserRegisterGetTxCnt(IPPROTO_UDP, ALPROTO_ENIP, ENIPGetTxCnt);
@@ -590,9 +573,6 @@ void RegisterENIPTCPParsers(void)
                 ENIPStateAlloc, ENIPStateFree);
 
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_ENIP, ENIPGetEvents);
-
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_ENIP,
-                ENIPGetTxDetectState, ENIPSetTxDetectState);
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_ENIP, ENIPGetTx);
         AppLayerParserRegisterTxDataFunc(IPPROTO_TCP, ALPROTO_ENIP, ENIPGetTxData);

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -326,8 +326,8 @@ static void FTPTransactionFree(FTPTransaction *tx)
 {
     SCEnter();
 
-    if (tx->de_state != NULL) {
-        DetectEngineStateFree(tx->de_state);
+    if (tx->tx_data.de_state != NULL) {
+        DetectEngineStateFree(tx->tx_data.de_state);
     }
 
     if (tx->request) {
@@ -884,13 +884,6 @@ static void FTPStateFree(void *s)
 #endif
 }
 
-static int FTPSetTxDetectState(void *vtx, DetectEngineState *de_state)
-{
-    FTPTransaction *tx = (FTPTransaction *)vtx;
-    tx->de_state = de_state;
-    return 0;
-}
-
 /**
  * \brief This function returns the oldest open transaction; if none
  * are open, then the oldest transaction is returned
@@ -941,13 +934,6 @@ static void *FTPGetTx(void *state, uint64_t tx_id)
     }
     return NULL;
 }
-
-static DetectEngineState *FTPGetTxDetectState(void *vtx)
-{
-    FTPTransaction *tx = (FTPTransaction *)vtx;
-    return tx->de_state;
-}
-
 
 static AppLayerTxData *FTPGetTxData(void *vtx)
 {
@@ -1175,8 +1161,8 @@ static void FTPDataStateFree(void *s)
 {
     FtpDataState *fstate = (FtpDataState *) s;
 
-    if (fstate->de_state != NULL) {
-        DetectEngineStateFree(fstate->de_state);
+    if (fstate->tx_data.de_state != NULL) {
+        DetectEngineStateFree(fstate->tx_data.de_state);
     }
     if (fstate->file_name != NULL) {
         FTPFree(fstate->file_name, fstate->file_len + 1);
@@ -1191,19 +1177,6 @@ static void FTPDataStateFree(void *s)
     ftpdata_state_memuse-=sizeof(FtpDataState);
     SCMutexUnlock(&ftpdata_state_mem_lock);
 #endif
-}
-
-static int FTPDataSetTxDetectState(void *vtx, DetectEngineState *de_state)
-{
-    FtpDataState *ftp_state = (FtpDataState *)vtx;
-    ftp_state->de_state = de_state;
-    return 0;
-}
-
-static DetectEngineState *FTPDataGetTxDetectState(void *vtx)
-{
-    FtpDataState *ftp_state = (FtpDataState *)vtx;
-    return ftp_state->de_state;
 }
 
 static AppLayerTxData *FTPDataGetTxData(void *vtx)
@@ -1303,9 +1276,6 @@ void RegisterFTPParsers(void)
 
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_FTP, FTPStateTransactionFree);
 
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_FTP,
-                FTPGetTxDetectState, FTPSetTxDetectState);
-
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_FTP, FTPGetTx);
         AppLayerParserRegisterTxDataFunc(IPPROTO_TCP, ALPROTO_FTP, FTPGetTxData);
 
@@ -1326,8 +1296,6 @@ void RegisterFTPParsers(void)
         AppLayerParserRegisterStateFuncs(IPPROTO_TCP, ALPROTO_FTPDATA, FTPDataStateAlloc, FTPDataStateFree);
         AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_TCP, ALPROTO_FTPDATA, STREAM_TOSERVER | STREAM_TOCLIENT);
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_FTPDATA, FTPDataStateTransactionFree);
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_FTPDATA,
-                FTPDataGetTxDetectState, FTPDataSetTxDetectState);
 
         AppLayerParserRegisterGetFilesFunc(IPPROTO_TCP, ALPROTO_FTPDATA, FTPDataStateGetFiles);
 

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -153,8 +153,6 @@ typedef struct FTPTransaction_  {
     /* Handle multiple responses */
     TAILQ_HEAD(, FTPString_) response_list;
 
-    DetectEngineState *de_state;
-
     TAILQ_ENTRY(FTPTransaction_) next;
 } FTPTransaction;
 
@@ -201,7 +199,6 @@ typedef struct FtpDataState_ {
     uint8_t *input;
     uint8_t *file_name;
     FileContainer *files;
-    DetectEngineState *de_state;
     int32_t input_len;
     int16_t file_len;
     FtpRequestCommand command;

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -241,7 +241,6 @@ typedef struct HtpTxUserData_ {
 
     uint8_t request_body_type;
 
-    DetectEngineState *de_state;
     AppLayerTxData tx_data;
 } HtpTxUserData;
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1389,14 +1389,6 @@ int AppLayerParserIsEnabled(AppProto alproto)
     return 0;
 }
 
-int AppLayerParserProtocolIsTxEventAware(uint8_t ipproto, AppProto alproto)
-{
-    SCEnter();
-    int ipproto_map = FlowGetProtoMapping(ipproto);
-    int r = (alp_ctx.ctxs[ipproto_map][alproto].StateGetEvents == NULL) ? 0 : 1;
-    SCReturnInt(r);
-}
-
 int AppLayerParserProtocolHasLogger(uint8_t ipproto, AppProto alproto)
 {
     SCEnter();

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1144,23 +1144,6 @@ int AppLayerParserSupportsFiles(uint8_t ipproto, AppProto alproto)
     return FALSE;
 }
 
-DetectEngineState *AppLayerParserGetTxDetectState(uint8_t ipproto, AppProto alproto, void *tx)
-{
-    SCEnter();
-    AppLayerTxData *d = AppLayerParserGetTxData(ipproto, alproto, tx);
-    DetectEngineState *s = d->de_state;
-    SCReturnPtr(s, "DetectEngineState");
-}
-
-int AppLayerParserSetTxDetectState(const Flow *f,
-                                   void *tx, DetectEngineState *s)
-{
-    SCEnter();
-    AppLayerTxData *d = alp_ctx.ctxs[f->protomap][f->alproto].GetTxData(tx);
-    d->de_state = s;
-    SCReturnInt(0);
-}
-
 AppLayerTxData *AppLayerParserGetTxData(uint8_t ipproto, AppProto alproto, void *tx)
 {
     SCEnter();

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -263,7 +263,6 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *tctx, Flow *f, 
                    uint8_t flags, const uint8_t *input, uint32_t input_len);
 void AppLayerParserSetEOF(AppLayerParserState *pstate);
 bool AppLayerParserHasDecoderEvents(AppLayerParserState *pstate);
-int AppLayerParserProtocolIsTxEventAware(uint8_t ipproto, AppProto alproto);
 int AppLayerParserProtocolHasLogger(uint8_t ipproto, AppProto alproto);
 LoggerId AppLayerParserProtocolGetLoggerBits(uint8_t ipproto, AppProto alproto);
 void AppLayerParserTriggerRawStreamReassembly(Flow *f, int direction);

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -252,9 +252,6 @@ uint64_t AppLayerParserGetTransactionActive(const Flow *f, AppLayerParserState *
 uint8_t AppLayerParserGetFirstDataDir(uint8_t ipproto, AppProto alproto);
 
 int AppLayerParserSupportsFiles(uint8_t ipproto, AppProto alproto);
-int AppLayerParserHasTxDetectState(uint8_t ipproto, AppProto alproto, void *alstate);
-DetectEngineState *AppLayerParserGetTxDetectState(uint8_t ipproto, AppProto alproto, void *tx);
-int AppLayerParserSetTxDetectState(const Flow *f, void *tx, DetectEngineState *s);
 
 AppLayerTxData *AppLayerParserGetTxData(uint8_t ipproto, AppProto alproto, void *tx);
 void AppLayerParserApplyTxConfig(uint8_t ipproto, AppProto alproto,

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -204,9 +204,6 @@ void AppLayerParserRegisterGetEventInfo(uint8_t ipproto, AppProto alproto,
 void AppLayerParserRegisterGetEventInfoById(uint8_t ipproto, AppProto alproto,
     int (*StateGetEventInfoById)(int event_id, const char **event_name,
                                  AppLayerEventType *event_type));
-void AppLayerParserRegisterDetectStateFuncs(uint8_t ipproto, AppProto alproto,
-        DetectEngineState *(*GetTxDetectState)(void *tx),
-        int (*SetTxDetectState)(void *tx, DetectEngineState *));
 void AppLayerParserRegisterGetStreamDepth(uint8_t ipproto,
                                           AppProto alproto,
                                           uint32_t (*GetStreamDepth)(void));

--- a/src/app-layer-register.c
+++ b/src/app-layer-register.c
@@ -137,10 +137,6 @@ int AppLayerRegisterParser(const struct AppLayerParser *p, AppProto alproto)
     AppLayerParserRegisterGetTx(p->ip_proto, alproto,
         p->StateGetTx);
 
-    /* What is this being registered for? */
-    AppLayerParserRegisterDetectStateFuncs(p->ip_proto, alproto,
-        p->GetTxDetectState, p->SetTxDetectState);
-
     if (p->StateGetEventInfo) {
         AppLayerParserRegisterGetEventInfo(p->ip_proto, alproto,
                 p->StateGetEventInfo);

--- a/src/app-layer-register.h
+++ b/src/app-layer-register.h
@@ -49,9 +49,6 @@ typedef struct AppLayerParser {
     const int complete_tc;
     int (*StateGetProgress)(void *alstate, uint8_t direction);
 
-    DetectEngineState *(*GetTxDetectState)(void *tx);
-    int (*SetTxDetectState)(void *tx, DetectEngineState *);
-
     AppLayerDecoderEvents *(*StateGetEvents)(void *);
     int (*StateGetEventInfo)(const char *event_name,
                              int *event_id, AppLayerEventType *event_type);

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -374,12 +374,12 @@ static SMTPTransaction *SMTPTransactionCreate(void)
 
 static void FlagDetectStateNewFile(SMTPTransaction *tx)
 {
-    if (tx && tx->de_state) {
+    if (tx && tx->tx_data.de_state) {
         SCLogDebug("DETECT_ENGINE_STATE_FLAG_FILE_NEW set");
-        tx->de_state->dir_state[0].flags |= DETECT_ENGINE_STATE_FLAG_FILE_NEW;
+        tx->tx_data.de_state->dir_state[0].flags |= DETECT_ENGINE_STATE_FLAG_FILE_NEW;
     } else if (tx == NULL) {
         SCLogDebug("DETECT_ENGINE_STATE_FLAG_FILE_NEW NOT set, no TX");
-    } else if (tx->de_state == NULL) {
+    } else if (tx->tx_data.de_state == NULL) {
         SCLogDebug("DETECT_ENGINE_STATE_FLAG_FILE_NEW NOT set, no TX DESTATE");
     }
 }
@@ -1533,8 +1533,8 @@ static void SMTPTransactionFree(SMTPTransaction *tx, SMTPState *state)
     if (tx->decoder_events != NULL)
         AppLayerDecoderEventsFreeEvents(&tx->decoder_events);
 
-    if (tx->de_state != NULL)
-        DetectEngineStateFree(tx->de_state);
+    if (tx->tx_data.de_state != NULL)
+        DetectEngineStateFree(tx->tx_data.de_state);
 
     if (tx->mail_from)
         SCFree(tx->mail_from);
@@ -1762,19 +1762,6 @@ static AppLayerDecoderEvents *SMTPGetEvents(void *tx)
     return ((SMTPTransaction *)tx)->decoder_events;
 }
 
-static DetectEngineState *SMTPGetTxDetectState(void *vtx)
-{
-    SMTPTransaction *tx = (SMTPTransaction *)vtx;
-    return tx->de_state;
-}
-
-static int SMTPSetTxDetectState(void *vtx, DetectEngineState *s)
-{
-    SMTPTransaction *tx = (SMTPTransaction *)vtx;
-    tx->de_state = s;
-    return 0;
-}
-
 static AppLayerTxData *SMTPGetTxData(void *vtx)
 {
     SMTPTransaction *tx = (SMTPTransaction *)vtx;
@@ -1809,8 +1796,6 @@ void RegisterSMTPParsers(void)
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetEventInfo);
         AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetEventInfoById);
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_SMTP, SMTPGetEvents);
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_SMTP,
-                                               SMTPGetTxDetectState, SMTPSetTxDetectState);
 
         AppLayerParserRegisterLocalStorageFunc(IPPROTO_TCP, ALPROTO_SMTP, SMTPLocalStorageAlloc,
                                                SMTPLocalStorageFree);

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -80,7 +80,6 @@ typedef struct SMTPTransaction_ {
     MimeDecParseState *mime_state;
 
     AppLayerDecoderEvents *decoder_events;          /**< per tx events */
-    DetectEngineState *de_state;
 
     /* MAIL FROM parameters */
     uint8_t *mail_from;

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -251,19 +251,6 @@ static AppLayerDecoderEvents *SSLGetEvents(void *tx)
     return ssl_state->decoder_events;
 }
 
-static int SSLSetTxDetectState(void *vtx, DetectEngineState *de_state)
-{
-    SSLState *ssl_state = (SSLState *)vtx;
-    ssl_state->de_state = de_state;
-    return 0;
-}
-
-static DetectEngineState *SSLGetTxDetectState(void *vtx)
-{
-    SSLState *ssl_state = (SSLState *)vtx;
-    return ssl_state->de_state;
-}
-
 static void *SSLGetTx(void *state, uint64_t tx_id)
 {
     SSLState *ssl_state = (SSLState *)state;
@@ -2693,8 +2680,8 @@ static void SSLStateFree(void *p)
 
     AppLayerDecoderEventsFreeEvents(&ssl_state->decoder_events);
 
-    if (ssl_state->de_state != NULL) {
-        DetectEngineStateFree(ssl_state->de_state);
+    if (ssl_state->tx_data.de_state != NULL) {
+        DetectEngineStateFree(ssl_state->tx_data.de_state);
     }
 
     /* Free certificate chain */
@@ -2967,9 +2954,6 @@ void RegisterSSLParsers(void)
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_TLS, SSLStateTransactionFree);
 
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_TLS, SSLGetEvents);
-
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_TLS,
-                                               SSLGetTxDetectState, SSLSetTxDetectState);
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_TLS, SSLGetTx);
         AppLayerParserRegisterTxDataFunc(IPPROTO_TCP, ALPROTO_TLS, SSLGetTxData);

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -250,7 +250,6 @@ typedef struct SSLState_ {
     SSLStateConnp client_connp;
     SSLStateConnp server_connp;
 
-    DetectEngineState *de_state;
     AppLayerDecoderEvents *decoder_events;
 } SSLState;
 

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -447,26 +447,6 @@ static AppLayerTxData *TemplateGetTxData(void *vtx)
     return &tx->tx_data;
 }
 
-/**
- * \brief retrieve the detection engine per tx state
- */
-static DetectEngineState *TemplateGetTxDetectState(void *vtx)
-{
-    TemplateTransaction *tx = vtx;
-    return tx->de_state;
-}
-
-/**
- * \brief get the detection engine per tx state
- */
-static int TemplateSetTxDetectState(void *vtx,
-    DetectEngineState *s)
-{
-    TemplateTransaction *tx = vtx;
-    tx->de_state = s;
-    return 0;
-}
-
 void RegisterTemplateParsers(void)
 {
     const char *proto_name = "template";
@@ -552,10 +532,6 @@ void RegisterTemplateParsers(void)
             TemplateGetTx);
         AppLayerParserRegisterTxDataFunc(IPPROTO_TCP, ALPROTO_TEMPLATE,
             TemplateGetTxData);
-
-        /* What is this being registered for? */
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_TEMPLATE,
-            TemplateGetTxDetectState, TemplateSetTxDetectState);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_TEMPLATE,
             TemplateStateGetEventInfo);

--- a/src/app-layer-template.h
+++ b/src/app-layer-template.h
@@ -51,8 +51,6 @@ typedef struct TemplateTransaction
     uint8_t response_done; /*<< Flag to be set when the response is
                             * seen. */
 
-    DetectEngineState *de_state;
-
     AppLayerTxData tx_data;
 
     TAILQ_ENTRY(TemplateTransaction) next;

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -159,17 +159,6 @@ static int TFTPGetStateProgress(void *tx, uint8_t direction)
     return 1;
 }
 
-static DetectEngineState *TFTPGetTxDetectState(void *vtx)
-{
-    return NULL;
-}
-
-static int TFTPSetTxDetectState(void *vtx,
-    DetectEngineState *s)
-{
-    return 0;
-}
-
 void RegisterTFTPParsers(void)
 {
     const char *proto_name = "tftp";
@@ -241,11 +230,6 @@ void RegisterTFTPParsers(void)
                                                    TFTPGetStateProgress);
         AppLayerParserRegisterGetTx(IPPROTO_UDP, ALPROTO_TFTP,
                                     TFTPGetTx);
-
-        /* What is this being registered for? */
-        AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_TFTP,
-                                               TFTPGetTxDetectState,
-                                               TFTPSetTxDetectState);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_UDP, ALPROTO_TFTP,
                                            TFTPStateGetEventInfo);

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -222,19 +222,20 @@ void DetectRunStoreStateTx(
         uint32_t inspect_flags, uint8_t flow_flags,
         const uint16_t file_no_match)
 {
-    DetectEngineState *destate = AppLayerParserGetTxDetectState(f->proto, f->alproto, tx);
-    if (destate == NULL) {
-        destate = DetectEngineStateAlloc();
-        if (destate == NULL)
+    AppLayerTxData *tx_data = AppLayerParserGetTxData(f->proto, f->alproto, tx);
+    BUG_ON(tx_data == NULL);
+    if (tx_data == NULL) {
+        SCLogDebug("No TX data for %" PRIu64, tx_id);
+        return;
+    }
+    if (tx_data->de_state == NULL) {
+        tx_data->de_state = DetectEngineStateAlloc();
+        if (tx_data->de_state == NULL)
             return;
-        if (AppLayerParserSetTxDetectState(f, tx, destate) < 0) {
-            DetectEngineStateFree(destate);
-            return;
-        }
         SCLogDebug("destate created for %"PRIu64, tx_id);
     }
-    DeStateSignatureAppend(destate, s, inspect_flags, flow_flags);
-    StoreStateTxHandleFiles(sgh, f, destate, flow_flags, tx_id, file_no_match);
+    DeStateSignatureAppend(tx_data->de_state, s, inspect_flags, flow_flags);
+    StoreStateTxHandleFiles(sgh, f, tx_data->de_state, flow_flags, tx_id, file_no_match);
 
     SCLogDebug("Stored for TX %"PRIu64, tx_id);
 }
@@ -296,8 +297,11 @@ void DetectEngineStateResetTxs(Flow *f)
     for ( ; inspect_tx_id < total_txs; inspect_tx_id++) {
         void *inspect_tx = AppLayerParserGetTx(f->proto, f->alproto, alstate, inspect_tx_id);
         if (inspect_tx != NULL) {
-            DetectEngineState *tx_de_state = AppLayerParserGetTxDetectState(f->proto, f->alproto, inspect_tx);
-            ResetTxState(tx_de_state);
+            AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, f->alproto, inspect_tx);
+            BUG_ON(txd == NULL);
+            if (txd) {
+                ResetTxState(txd->de_state);
+            }
         }
     }
 }
@@ -625,7 +629,9 @@ static int DeStateSigTest02(void)
     void *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, f.alstate, 0);
     FAIL_IF_NULL(tx);
 
-    DetectEngineState *tx_de_state = AppLayerParserGetTxDetectState(IPPROTO_TCP, ALPROTO_HTTP1, tx);
+    AppLayerTxData *tx_data = AppLayerParserGetTxData(IPPROTO_TCP, ALPROTO_HTTP1, tx);
+    FAIL_IF_NULL(tx_data);
+    DetectEngineState *tx_de_state = tx_data->de_state;
     FAIL_IF_NULL(tx_de_state);
     FAIL_IF(tx_de_state->dir_state[0].cnt != 1);
     /* http_header(mpm): 5, uri: 3, method: 6, cookie: 7 */

--- a/src/detect.c
+++ b/src/detect.c
@@ -1235,7 +1235,7 @@ static DetectTransaction GetDetectTx(const uint8_t ipproto, const AppProto alpro
 
     const int tx_progress = AppLayerParserGetStateProgress(ipproto, alproto, tx_ptr, flow_flags);
     const int dir_int = (flow_flags & STREAM_TOSERVER) ? 0 : 1;
-    DetectEngineState *tx_de_state = AppLayerParserGetTxDetectState(ipproto, alproto, tx_ptr);
+    DetectEngineState *tx_de_state = txd->de_state;
     DetectEngineStateDirection *tx_dir_state = tx_de_state ? &tx_de_state->dir_state[dir_int] : NULL;
     uint64_t prefilter_flags = detect_flags & APP_LAYER_TX_PREFILTER_MASK;
     DEBUG_VALIDATE_BUG_ON(prefilter_flags & APP_LAYER_TX_RESERVED_FLAGS);

--- a/src/output-json-modbus.c
+++ b/src/output-json-modbus.c
@@ -132,6 +132,7 @@ static TmEcode JsonModbusLogThreadDeinit(ThreadVars *t, void *data)
     if (thread == NULL) {
         return TM_ECODE_OK;
     }
+    FreeEveThreadCtx(thread->ctx);
     SCFree(thread);
     return TM_ECODE_OK;
 }


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/6593

Changes from last PR:
- Address comments.
- Fix a memory leak.

This PR creates a generic TX iterator that can be used by most parsers provided the transaction and state implement the `State` and `Transaction` traits and follow convention for transaction management.

It also pulls the `de_state` into the `AppLayerTxData` reducing the number of C bindings and common boilerplate between parsers.
