### PR TITLE
log: Coverity REVERSE_INULL warnings

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1104,8 +1104,7 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
     json_ctx->file_ctx = LogFileNewCtx();
     if (unlikely(json_ctx->file_ctx == NULL)) {
         SCLogDebug("AlertJsonInitCtx: Could not create new LogFileCtx");
-        SCFree(json_ctx);
-        return result;
+        goto error_exit;
     }
 
     if (sensor_name) {
@@ -1243,11 +1242,16 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
 
 error_exit:
     if (json_ctx->file_ctx) {
+        if (json_ctx->file_ctx->prefix) {
+            SCFree(json_ctx->file_ctx->prefix);
+        }
+        if (json_ctx->file_ctx->sensor_name) {
+            SCFree(json_ctx->file_ctx->sensor_name);
+        }
         LogFileFreeCtx(json_ctx->file_ctx);
     }
-    if (json_ctx) {
-        SCFree(json_ctx);
-    }
+    SCFree(json_ctx);
+
     if (output_ctx) {
         SCFree(output_ctx);
     }


### PR DESCRIPTION
Continuation of #6399 

This commit addresses Coverity reported "REVERSE_INULL" warnings.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4699](https://redmine.openinfosecfoundation.org/issues/4699)

Updates:
- Rebase

Describe changes:
- Restructure `error_exit` logic to eliminate NULL derefs
- On error, ensure `sensor_name` and `prefix` memory is released

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
