### PR TITLE
6.0.x - rustdoc fix; msrv ci

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -27,6 +27,8 @@ env:
   # could cause some steps to fail.
   RUST_VERSION_KNOWN: "1.49.0"
 
+  # The minimum version of Rust supported.
+  RUST_VERSION_MIN: 1.34.2
 jobs:
 
   prepare-deps:
@@ -939,12 +941,12 @@ jobs:
       - run: AFL_HARDEN=1 ac_cv_func_realloc_0_nonnull=yes ac_cv_func_malloc_0_nonnull=yes CFLAGS="-fsanitize=address -fno-omit-frame-pointer" CXXFLAGS=$CFLAGS CC=afl-clang-fast CXX=afl-clang-fast++ ./configure --enable-fuzztargets --disable-shared
       - run: AFL_HARDEN=1 make -j2
 
-  # An Ubuntu 16.04 build using the tarball generated in the CentOS 8
-  # build above.
-  ubuntu-16-04:
-    name: Ubuntu 16.04
+  # An Ubuntu 20.04 build using the tarball generated in the CentOS 8
+  # build above also testing the minimum supported Rust version.
+  ubuntu-20-04-msrv:
+    name: Ubuntu 20.04 (MSRV)
     runs-on: ubuntu-latest
-    container: ubuntu:16.04
+    container: ubuntu:20.04
     needs: centos-8
     steps:
       - name: Install dependencies
@@ -971,11 +973,12 @@ jobs:
                 libyaml-0-2 \
                 libyaml-dev \
                 make \
+                python3-distutils \
                 python3-yaml \
                 zlib1g \
                 zlib1g-dev
       - name: Install Rust
-        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.34.2 -y
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain ${RUST_VERSION_MIN} -y
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Download suricata.tar.gz
         uses: actions/download-artifact@v2

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -57,8 +57,8 @@ pub const DHCP_TYPE_NAK: u8 = 6;
 pub const DHCP_TYPE_RELEASE: u8 = 7;
 pub const DHCP_TYPE_INFORM: u8 = 8;
 
-/// DHCP parameter types.
-/// https://www.iana.org/assignments/bootp-dhcp-parameters/bootp-dhcp-parameters.txt
+// DHCP parameter types.
+// https://www.iana.org/assignments/bootp-dhcp-parameters/bootp-dhcp-parameters.txt
 pub const DHCP_PARAM_SUBNET_MASK: u8 = 1;
 pub const DHCP_PARAM_ROUTER: u8 = 3;
 pub const DHCP_PARAM_DNS_SERVER: u8 = 6;


### PR DESCRIPTION
- Update Ubuntu 16.04 to 20.04 and clarify that its an MSRV test.
- Pull in fix for rustdoc from master.