### PR TITLE
Integer overflow 4516 v7

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -465,7 +465,7 @@ jobs:
           chmod 755 $HOME/.cargo/bin/cbindgen
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: ./autogen.sh
-      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis
+      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer  -Wimplicit-int-float-conversion" ./configure --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis
         env:
           LDFLAGS: "-fsanitize=address"
           ac_cv_func_realloc_0_nonnull: "yes"

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -72,11 +72,10 @@ typedef struct AppLayerProtoDetectProbingParserElement_ {
     uint16_t port;
     /* \todo calculate at runtime and get rid of this var */
     uint32_t alproto_mask;
-    /* \todo check if we can reduce the bottom 2 vars to uint16_t */
     /* the min length of data that has to be supplied to invoke the parser */
-    uint32_t min_depth;
+    uint16_t min_depth;
     /* the max length of data after which this parser won't be invoked */
-    uint32_t max_depth;
+    uint16_t max_depth;
 
     /* the to_server probing parser function */
     ProbingParserFPtr ProbingParserTs;
@@ -194,7 +193,7 @@ static void AppLayerProtoDetectPEGetIpprotos(AppProto alproto,
  *  \param searchlen pattern matching portion of buffer */
 static AppProto AppLayerProtoDetectPMMatchSignature(const AppLayerProtoDetectPMSignature *s,
         AppLayerProtoDetectThreadCtx *tctx, Flow *f, uint8_t flags, const uint8_t *buf,
-        uint16_t buflen, uint16_t searchlen, bool *rflow)
+        uint32_t buflen, uint16_t searchlen, bool *rflow)
 {
     SCEnter();
 
@@ -267,11 +266,12 @@ static AppProto AppLayerProtoDetectPMMatchSignature(const AppLayerProtoDetectPMS
  */
 static inline int PMGetProtoInspect(AppLayerProtoDetectThreadCtx *tctx,
         AppLayerProtoDetectPMCtx *pm_ctx, MpmThreadCtx *mpm_tctx, Flow *f, const uint8_t *buf,
-        uint16_t buflen, uint8_t flags, AppProto *pm_results, bool *rflow)
+        uint32_t buflen, uint8_t flags, AppProto *pm_results, bool *rflow)
 {
     int pm_matches = 0;
 
-    uint16_t searchlen = MIN(buflen, pm_ctx->mpm_ctx.maxdepth);
+    // maxdepth is u16, so minimum is u16
+    uint16_t searchlen = (uint16_t)MIN(buflen, pm_ctx->mpm_ctx.maxdepth);
     SCLogDebug("searchlen %u buflen %u", searchlen, buflen);
 
     /* do the mpm search */
@@ -319,7 +319,7 @@ static inline int PMGetProtoInspect(AppLayerProtoDetectThreadCtx *tctx,
  *  \param direction direction for the patterns
  *  \param pm_results[out] AppProto array of size ALPROTO_MAX */
 static AppProto AppLayerProtoDetectPMGetProto(AppLayerProtoDetectThreadCtx *tctx, Flow *f,
-        const uint8_t *buf, uint16_t buflen, uint8_t flags, AppProto *pm_results, bool *rflow)
+        const uint8_t *buf, uint32_t buflen, uint8_t flags, AppProto *pm_results, bool *rflow)
 {
     SCEnter();
 
@@ -1276,7 +1276,7 @@ static void AppLayerProtoDetectPMGetIpprotos(AppProto alproto,
 {
     SCEnter();
 
-    for (int i = 0; i < FLOW_PROTO_DEFAULT; i++) {
+    for (uint8_t i = 0; i < FLOW_PROTO_DEFAULT; i++) {
         uint8_t ipproto = FlowGetReverseProtoMapping(i);
         for (int j = 0; j < 2; j++) {
             AppLayerProtoDetectPMCtx *pm_ctx = &alpd_ctx.ctx_ipp[i].ctx_pm[j];
@@ -1308,7 +1308,7 @@ static int AppLayerProtoDetectPMSetContentIDs(AppLayerProtoDetectPMCtx *ctx)
     /* array hash buffer */
     uint8_t *ahb = NULL;
     uint8_t *content = NULL;
-    uint8_t content_len = 0;
+    uint16_t content_len = 0;
     PatIntId max_id = 0;
     TempContainer *struct_offset = NULL;
     uint8_t *content_offset = NULL;
@@ -1688,7 +1688,7 @@ void AppLayerProtoDetectPPRegister(uint8_t ipproto,
     DetectPortParse(NULL,&head, portstr);
     DetectPort *temp_dp = head;
     while (temp_dp != NULL) {
-        uint32_t port = temp_dp->port;
+        uint16_t port = temp_dp->port;
         if (port == 0 && temp_dp->port2 != 0)
             port++;
         for ( ; port <= temp_dp->port2; port++) {

--- a/src/app-layer-dnp3-objects.c
+++ b/src/app-layer-dnp3-objects.c
@@ -7153,10 +7153,10 @@ static int DNP3DecodeObjectG70V4(const uint8_t **buf, uint32_t *len,
         if (!DNP3ReadUint8(buf, len, &object->status_code)) {
             goto error;
         }
-        if (prefix - (offset - *len) >= 255) {
+        if (prefix - (offset - *len) >= 255 || prefix < (offset - *len)) {
             goto error;
         }
-        object->optional_text_len = prefix - (offset - *len);
+        object->optional_text_len = (uint8_t)(prefix - (offset - *len));
         if (object->optional_text_len > 0) {
             if (*len < object->optional_text_len) {
                 /* Not enough data. */
@@ -7220,10 +7220,10 @@ static int DNP3DecodeObjectG70V5(const uint8_t **buf, uint32_t *len,
         if (!DNP3ReadUint32(buf, len, &object->block_number)) {
             goto error;
         }
-        if (prefix - (offset - *len) >= 255) {
+        if (prefix - (offset - *len) >= 255 || prefix < (offset - *len)) {
             goto error;
         }
-        object->file_data_len = prefix - (offset - *len);
+        object->file_data_len = (uint8_t)(prefix - (offset - *len));
         if (object->file_data_len > 0) {
             if (*len < object->file_data_len) {
                 /* Not enough data. */
@@ -7290,10 +7290,10 @@ static int DNP3DecodeObjectG70V6(const uint8_t **buf, uint32_t *len,
         if (!DNP3ReadUint8(buf, len, &object->status_code)) {
             goto error;
         }
-        if (prefix - (offset - *len) >= 255) {
+        if (prefix - (offset - *len) >= 255 || prefix < (offset - *len)) {
             goto error;
         }
-        object->optional_text_len = prefix - (offset - *len);
+        object->optional_text_len = (uint8_t)(prefix - (offset - *len));
         if (object->optional_text_len > 0) {
             if (*len < object->optional_text_len) {
                 /* Not enough data. */
@@ -7422,10 +7422,10 @@ static int DNP3DecodeObjectG70V8(const uint8_t **buf, uint32_t *len,
 
         offset = *len;
 
-        if (prefix - (offset - *len) >= 65535) {
+        if (prefix - (offset - *len) >= 65535 || prefix < (offset - *len)) {
             goto error;
         }
-        object->file_specification_len = prefix - (offset - *len);
+        object->file_specification_len = (uint16_t)(prefix - (offset - *len));
         if (object->file_specification_len > 0) {
             if (*len < object->file_specification_len) {
                 /* Not enough data. */
@@ -7764,7 +7764,10 @@ static int DNP3DecodeObjectG120V1(const uint8_t **buf, uint32_t *len,
         if (!DNP3ReadUint8(buf, len, &object->reason)) {
             goto error;
         }
-        object->challenge_data_len = prefix - (offset - *len);
+        if (prefix < (offset - *len)) {
+            goto error;
+        }
+        object->challenge_data_len = (uint16_t)(prefix - (offset - *len));
         if (object->challenge_data_len > 0) {
             if (*len < object->challenge_data_len) {
                 /* Not enough data. */
@@ -7834,7 +7837,10 @@ static int DNP3DecodeObjectG120V2(const uint8_t **buf, uint32_t *len,
         if (!DNP3ReadUint16(buf, len, &object->usr)) {
             goto error;
         }
-        object->mac_value_len = prefix - (offset - *len);
+        if (prefix < (offset - *len)) {
+            goto error;
+        }
+        object->mac_value_len = (uint16_t)(prefix - (offset - *len));
         if (object->mac_value_len > 0) {
             if (*len < object->mac_value_len) {
                 /* Not enough data. */
@@ -8018,7 +8024,10 @@ static int DNP3DecodeObjectG120V5(const uint8_t **buf, uint32_t *len,
             *buf += object->challenge_data_len;
             *len -= object->challenge_data_len;
         }
-        object->mac_value_len = prefix - (offset - *len);
+        if (prefix < (offset - *len)) {
+            goto error;
+        }
+        object->mac_value_len = (uint16_t)(prefix - (offset - *len));
         if (object->mac_value_len > 0) {
             if (*len < object->mac_value_len) {
                 /* Not enough data. */
@@ -8091,7 +8100,10 @@ static int DNP3DecodeObjectG120V6(const uint8_t **buf, uint32_t *len,
         if (!DNP3ReadUint16(buf, len, &object->usr)) {
             goto error;
         }
-        object->wrapped_key_data_len = prefix - (offset - *len);
+        if (prefix < (offset - *len)) {
+            goto error;
+        }
+        object->wrapped_key_data_len = (uint16_t)(prefix - (offset - *len));
         if (object->wrapped_key_data_len > 0) {
             if (*len < object->wrapped_key_data_len) {
                 /* Not enough data. */
@@ -8170,10 +8182,10 @@ static int DNP3DecodeObjectG120V7(const uint8_t **buf, uint32_t *len,
         if (!DNP3ReadUint48(buf, len, &object->time_of_error)) {
             goto error;
         }
-        if (prefix - (offset - *len) >= 65535) {
+        if (prefix - (offset - *len) >= 65535 || prefix < (offset - *len)) {
             goto error;
         }
-        object->error_text_len = prefix - (offset - *len);
+        object->error_text_len = (uint16_t)(prefix - (offset - *len));
         if (object->error_text_len > 0) {
             if (*len < object->error_text_len) {
                 /* Not enough data. */
@@ -8237,7 +8249,10 @@ static int DNP3DecodeObjectG120V8(const uint8_t **buf, uint32_t *len,
         if (!DNP3ReadUint8(buf, len, &object->certificate_type)) {
             goto error;
         }
-        object->certificate_len = prefix - (offset - *len);
+        if (prefix < (offset - *len)) {
+            goto error;
+        }
+        object->certificate_len = (uint16_t)(prefix - (offset - *len));
         if (object->certificate_len > 0) {
             if (*len < object->certificate_len) {
                 /* Not enough data. */
@@ -8297,7 +8312,10 @@ static int DNP3DecodeObjectG120V9(const uint8_t **buf, uint32_t *len,
 
         offset = *len;
 
-        object->mac_value_len = prefix - (offset - *len);
+        if (prefix < (offset - *len)) {
+            goto error;
+        }
+        object->mac_value_len = (uint16_t)(prefix - (offset - *len));
         if (object->mac_value_len > 0) {
             if (*len < object->mac_value_len) {
                 /* Not enough data. */
@@ -8688,7 +8706,10 @@ static int DNP3DecodeObjectG120V14(const uint8_t **buf, uint32_t *len,
 
         offset = *len;
 
-        object->digital_signature_len = prefix - (offset - *len);
+        if (prefix < (offset - *len)) {
+            goto error;
+        }
+        object->digital_signature_len = (uint16_t)(prefix - (offset - *len));
         if (object->digital_signature_len > 0) {
             if (*len < object->digital_signature_len) {
                 /* Not enough data. */
@@ -8752,7 +8773,10 @@ static int DNP3DecodeObjectG120V15(const uint8_t **buf, uint32_t *len,
 
         offset = *len;
 
-        object->mac_len = prefix - (offset - *len);
+        if (prefix < (offset - *len)) {
+            goto error;
+        }
+        object->mac_len = (uint16_t)(prefix - (offset - *len));
         if (object->mac_len > 0) {
             if (*len < object->mac_len) {
                 /* Not enough data. */

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -97,9 +97,6 @@ SCEnumCharMap dnp3_decoder_event_table[] = {
     {NULL, -1},
 };
 
-/* Some DNP3 servers start with a banner. */
-static const char banner[] = "DNP3";
-
 /* Calculate the next transport sequence number. */
 #define NEXT_TH_SEQNO(current) ((current + 1) % DNP3_MAX_TRAN_SEQNO)
 
@@ -251,6 +248,9 @@ static int DNP3CheckStartBytes(const DNP3LinkHeader *header)
         header->start_byte1 == DNP3_START_BYTE1;
 }
 
+/* Some DNP3 servers start with a banner. */
+#define DNP3_BANNER "DNP3"
+
 /**
  * \brief Check if a frame contains a banner.
  *
@@ -261,7 +261,7 @@ static int DNP3CheckStartBytes(const DNP3LinkHeader *header)
  */
 static int DNP3ContainsBanner(const uint8_t *input, uint32_t len)
 {
-    return BasicSearch(input, len, (uint8_t *)banner, strlen(banner)) != NULL;
+    return BasicSearch(input, len, (uint8_t *)DNP3_BANNER, strlen(DNP3_BANNER)) != NULL;
 }
 
 /**

--- a/src/app-layer-enip-common.h
+++ b/src/app-layer-enip-common.h
@@ -120,8 +120,8 @@ typedef struct ENIPEncapAddresItem_
 {
     uint16_t type;
     uint16_t length;
-    uint16_t conn_id;
-    uint16_t sequence_num;
+    uint32_t conn_id;
+    uint32_t sequence_num;
 } ENIPEncapAddresItem;
 
 /**
@@ -182,7 +182,7 @@ typedef struct CIPServiceEntry_
         } request;
         struct
         {
-            uint8_t status;
+            uint16_t status;
         } response;
     };
 
@@ -195,7 +195,7 @@ typedef struct CIPServiceEntry_
 typedef struct ENIPTransaction_
 {
     struct ENIPState_ *enip;
-    uint16_t tx_num;                            /**< internal: id */
+    uint64_t tx_num;                            /**< internal: id */
     uint16_t tx_id;                             /**< transaction id */
     uint16_t service_count;
 

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -93,7 +93,7 @@ static void *ENIPGetTx(void *alstate, uint64_t tx_id)
 
 static uint64_t ENIPGetTxCnt(void *alstate)
 {
-    return ((uint64_t) ((ENIPState *) alstate)->transaction_max);
+    return ((ENIPState *)alstate)->transaction_max;
 }
 
 static AppLayerDecoderEvents *ENIPGetEvents(void *tx)

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2404,14 +2404,12 @@ static void HTPConfigSetDefaultsPhase2(const char *name, HTPCfgRec *cfg_prec)
         int rdrange = cfg_prec->randomize_range;
 
         long int r = RandomGetWrap();
-        cfg_prec->request.inspect_min_size +=
-            (int) (cfg_prec->request.inspect_min_size *
-                   (r * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
+        cfg_prec->request.inspect_min_size += (int)(cfg_prec->request.inspect_min_size *
+                                                    ((double)r / RAND_MAX - 0.5) * rdrange / 100);
 
         r = RandomGetWrap();
-        cfg_prec->request.inspect_window +=
-            (int) (cfg_prec->request.inspect_window *
-                   (r * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
+        cfg_prec->request.inspect_window += (int)(cfg_prec->request.inspect_window *
+                                                  ((double)r / RAND_MAX - 0.5) * rdrange / 100);
         SCLogConfig("'%s' server has 'request-body-minimal-inspect-size' set to"
                   " %d and 'request-body-inspect-window' set to %d after"
                   " randomization.",
@@ -2421,14 +2419,12 @@ static void HTPConfigSetDefaultsPhase2(const char *name, HTPCfgRec *cfg_prec)
 
 
         r = RandomGetWrap();
-        cfg_prec->response.inspect_min_size +=
-            (int) (cfg_prec->response.inspect_min_size *
-                   (r * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
+        cfg_prec->response.inspect_min_size += (int)(cfg_prec->response.inspect_min_size *
+                                                     ((double)r / RAND_MAX - 0.5) * rdrange / 100);
 
         r = RandomGetWrap();
-        cfg_prec->response.inspect_window +=
-            (int) (cfg_prec->response.inspect_window *
-                   (r * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
+        cfg_prec->response.inspect_window += (int)(cfg_prec->response.inspect_window *
+                                                   ((double)r / RAND_MAX - 0.5) * rdrange / 100);
 
         SCLogConfig("'%s' server has 'response-body-minimal-inspect-size' set to"
                   " %d and 'response-body-inspect-window' set to %d after"

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -303,7 +303,7 @@ static int TCPProtoDetect(ThreadVars *tv,
 {
     AppProto *alproto;
     AppProto *alproto_otherdir;
-    int direction = (flags & STREAM_TOSERVER) ? 0 : 1;
+    bool direction = !(flags & STREAM_TOSERVER);
 
     if (flags & STREAM_TOSERVER) {
         alproto = &f->alproto_ts;
@@ -370,7 +370,7 @@ static int TCPProtoDetect(ThreadVars *tv,
             } else {
                 *stream = &ssn->client;
             }
-            direction = 1 - direction;
+            direction = !direction;
         }
 
         /* account flow if we have both sides */
@@ -602,7 +602,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         goto end;
     }
 
-    const int direction = (flags & STREAM_TOSERVER) ? 0 : 1;
+    const bool direction = !(flags & STREAM_TOSERVER);
 
     if (flags & STREAM_TOSERVER) {
         alproto = f->alproto_ts;

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -400,8 +400,6 @@ TmEcode ReceivePcapFileThreadDeinit(ThreadVars *tv, void *data)
     SCReturnInt(TM_ECODE_OK);
 }
 
-static double prev_signaled_ts = 0;
-
 static TmEcode DecodePcapFile(ThreadVars *tv, Packet *p, void *data)
 {
     SCEnter();
@@ -411,14 +409,6 @@ static TmEcode DecodePcapFile(ThreadVars *tv, Packet *p, void *data)
 
     /* update counters */
     DecodeUpdatePacketCounters(tv, dtv, p);
-
-    double curr_ts = p->ts.tv_sec + p->ts.tv_usec / 1000.0;
-    if (curr_ts < prev_signaled_ts || (curr_ts - prev_signaled_ts) > 60.0) {
-        prev_signaled_ts = curr_ts;
-#if 0
-        FlowWakeupFlowManagerThread();
-#endif
-    }
 
     DecoderFunc decoder;
     if(ValidateLinkType(p->datalink, &decoder) == TM_ECODE_OK) {

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5973,8 +5973,7 @@ invalid:
  * \param ssn TCP Session
  * \param direction direction to set the flag in: 0 toserver, 1 toclient
  */
-void StreamTcpUpdateAppLayerProgress(TcpSession *ssn, char direction,
-        const uint32_t progress)
+void StreamTcpUpdateAppLayerProgress(TcpSession *ssn, bool direction, const uint32_t progress)
 {
     if (direction) {
         ssn->server.app_progress_rel += progress;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -597,8 +597,8 @@ void StreamTcpInitConfig(bool quiet)
     if (randomize) {
         long int r = RandomGetWrap();
         stream_config.reassembly_toserver_chunk_size +=
-            (int) (stream_config.reassembly_toserver_chunk_size *
-                   (r * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
+                (int)(stream_config.reassembly_toserver_chunk_size * ((double)r / RAND_MAX - 0.5) *
+                        rdrange / 100);
     }
     const char *temp_stream_reassembly_toclient_chunk_size_str;
     if (ConfGetValue("stream.reassembly.toclient-chunk-size",
@@ -619,8 +619,8 @@ void StreamTcpInitConfig(bool quiet)
     if (randomize) {
         long int r = RandomGetWrap();
         stream_config.reassembly_toclient_chunk_size +=
-            (int) (stream_config.reassembly_toclient_chunk_size *
-                   (r * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
+                (int)(stream_config.reassembly_toclient_chunk_size * ((double)r / RAND_MAX - 0.5) *
+                        rdrange / 100);
     }
     if (!quiet) {
         SCLogConfig("stream.reassembly \"toserver-chunk-size\": %"PRIu16,

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -195,8 +195,7 @@ int StreamTcpInlineMode(void);
 
 int TcpSessionPacketSsnReuse(const Packet *p, const Flow *f, const void *tcp_ssn);
 
-void StreamTcpUpdateAppLayerProgress(TcpSession *ssn, char direction,
-        const uint32_t progress);
+void StreamTcpUpdateAppLayerProgress(TcpSession *ssn, bool direction, const uint32_t progress);
 
 #endif /* __STREAM_TCP_H__ */
 

--- a/src/util-clock.h
+++ b/src/util-clock.h
@@ -33,7 +33,8 @@
 
 #define CLOCK_END           clo2 = clock()
 
-#define CLOCK_PRINT_SEC     printf("Seconds spent: %.4fs\n", ((clo2 - clo1)/(double)CLOCKS_PER_SEC))
+#define CLOCK_PRINT_SEC                                                                            \
+    printf("Seconds spent: %.4fs\n", ((double)(clo2 - clo1) / (double)CLOCKS_PER_SEC))
 
 #define GET_CLOCK_END_SECS  ((clo1 - clo2)/(double)CLOCKS_PER_SEC)
 

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -351,11 +351,10 @@ int LiveDeviceListClean()
 
     TAILQ_FOREACH_SAFE(pd, &live_devices, next, tpd) {
         if (live_devices_stats) {
-            SCLogNotice("Stats for '%s':  pkts: %" PRIu64", drop: %" PRIu64 " (%.2f%%), invalid chksum: %" PRIu64,
-                    pd->dev,
-                    SC_ATOMIC_GET(pd->pkts),
-                    SC_ATOMIC_GET(pd->drop),
-                    100 * (SC_ATOMIC_GET(pd->drop) * 1.0) / SC_ATOMIC_GET(pd->pkts),
+            SCLogNotice("Stats for '%s':  pkts: %" PRIu64 ", drop: %" PRIu64
+                        " (%.2f%%), invalid chksum: %" PRIu64,
+                    pd->dev, SC_ATOMIC_GET(pd->pkts), SC_ATOMIC_GET(pd->drop),
+                    100 * ((double)SC_ATOMIC_GET(pd->drop)) / (double)SC_ATOMIC_GET(pd->pkts),
                     SC_ATOMIC_GET(pd->invalid_checksums));
         }
 

--- a/src/util-pool.c
+++ b/src/util-pool.c
@@ -372,7 +372,12 @@ void PoolReturn(Pool *p, void *data)
 
 void PoolPrintSaturation(Pool *p)
 {
-    SCLogDebug("pool %p is using %"PRIu32" out of %"PRIu32" items (%02.1f%%), max %"PRIu32" (%02.1f%%): pool struct memory %"PRIu64".", p, p->outstanding, p->max_buckets, (float)(p->outstanding/(float)(p->max_buckets))*100, p->max_outstanding, (float)(p->max_outstanding/(float)(p->max_buckets))*100, (uint64_t)(p->max_buckets * sizeof(PoolBucket)));
+    SCLogDebug("pool %p is using %" PRIu32 " out of %" PRIu32 " items (%02.1f%%), max %" PRIu32
+               " (%02.1f%%): pool struct memory %" PRIu64 ".",
+            p, p->outstanding, p->max_buckets,
+            (float)(p->outstanding) / (float)(p->max_buckets) * 100, p->max_outstanding,
+            (float)(p->max_outstanding) / (float)(p->max_buckets) * 100,
+            (uint64_t)(p->max_buckets * sizeof(PoolBucket)));
 }
 
 /*


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4516

Describe changes:
- Avoids some warnings about integers

Obviously not complete yet... But still mergeable ?

Replaces #6636 with
- CI only using builds that support new warning flags (ie Fedora with latest clang)

libhtp-pr: 339

I also discovered a style issue : removing explicit useless casts such as
```
uint64_t t = 0;
uint64_t x = 1;
x = (uint64_t) t;
```
Is there some automated tool to do this ? 
(and remove the `#if 0` as well ?)