### PR TITLE
range: prevents memory leak of file from HTTP2

### DIFF
--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -183,6 +183,7 @@ impl HTTP2Transaction {
                         0,
                     );
                     (c.HttpRangeFreeBlock)(self.file_range);
+                    self.file_range = std::ptr::null_mut();
                 }
             }
         }
@@ -426,6 +427,26 @@ impl HTTP2State {
     }
 
     pub fn free(&mut self) {
+        // this should be in HTTP2Transaction::free
+        // but we need state's file container cf https://redmine.openinfosecfoundation.org/issues/4444
+        for tx in &mut self.transactions {
+            if !tx.file_range.is_null() {
+                match unsafe { SC } {
+                    None => panic!("BUG no suricata_config"),
+                    Some(c) => {
+                        (c.HTPFileCloseHandleRange)(
+                            &mut self.files.files_tc,
+                            0,
+                            tx.file_range,
+                            std::ptr::null_mut(),
+                            0,
+                        );
+                        (c.HttpRangeFreeBlock)(tx.file_range);
+                        tx.file_range = std::ptr::null_mut();
+                    }
+                }
+            }
+        }
         self.transactions.clear();
     }
 
@@ -445,7 +466,7 @@ impl HTTP2State {
         let mut found = false;
         let mut index = 0;
         for i in 0..len {
-            let tx = &self.transactions[i];
+            let tx = &mut self.transactions[i];
             if tx.tx_id == tx_id + 1 {
                 found = true;
                 index = i;
@@ -463,6 +484,7 @@ impl HTTP2State {
                                 0,
                             );
                             (c.HttpRangeFreeBlock)(tx.file_range);
+                            tx.file_range = std::ptr::null_mut();
                         }
                     }
                 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4811

Describe changes:
- avoid a memory leak with range from HTTP2

Completes #6585 and replaces #6637 with a fix not failing CIFuzz