### PR TITLE
app-layer: include decoder events in app-layer tx data

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -18,7 +18,7 @@
 //! Parser registration functions and common interface
 
 use std;
-use crate::core::{self,DetectEngineState,Flow,AppLayerEventType,AppLayerDecoderEvents,AppProto};
+use crate::core::{self,DetectEngineState,Flow,AppLayerEventType,AppProto};
 use crate::filecontainer::FileContainer;
 use crate::applayer;
 use std::os::raw::{c_void,c_char,c_int};
@@ -69,6 +69,7 @@ pub struct AppLayerTxData {
     detect_flags_tc: u64,
 
     de_state: *mut DetectEngineState,
+    pub events: *mut core::AppLayerDecoderEvents,
 }
 
 impl Default for AppLayerTxData {
@@ -81,6 +82,9 @@ impl Drop for AppLayerTxData {
     fn drop(&mut self) {
         if self.de_state != std::ptr::null_mut() {
             core::sc_detect_engine_state_free(self.de_state);
+        }
+        if self.events != std::ptr::null_mut() {
+            core::sc_app_layer_decoder_events_free_events(&mut self.events);
         }
     }
 }
@@ -96,6 +100,7 @@ impl AppLayerTxData {
             detect_flags_ts: 0,
             detect_flags_tc: 0,
             de_state: std::ptr::null_mut(),
+            events: std::ptr::null_mut(),
         }
     }
     pub fn init_files_opened(&mut self) {
@@ -103,6 +108,10 @@ impl AppLayerTxData {
     }
     pub fn incr_files_opened(&mut self) {
         self.files_opened += 1;
+    }
+
+    pub fn set_event(&mut self, event: u8) {
+        core::sc_app_layer_decoder_events_set_event_raw(&mut self.events, event as u8);
     }
 }
 
@@ -227,8 +236,6 @@ pub struct RustParser {
     /// Function returning the current transaction progress
     pub tx_get_progress:    StateGetProgressFn,
 
-    /// Function to get events
-    pub get_events:         Option<GetEventsFn>,
     /// Function to get an event id from a description
     pub get_eventinfo:      Option<GetEventInfoFn>,
     /// Function to get an event description from an event id
@@ -292,7 +299,6 @@ pub type StateGetTxCntFn         = unsafe extern "C" fn (*mut c_void) -> u64;
 pub type StateGetProgressFn = unsafe extern "C" fn (*mut c_void, u8) -> c_int;
 pub type GetEventInfoFn     = unsafe extern "C" fn (*const c_char, *mut c_int, *mut AppLayerEventType) -> c_int;
 pub type GetEventInfoByIdFn = unsafe extern "C" fn (c_int, *mut *const c_char, *mut AppLayerEventType) -> i8;
-pub type GetEventsFn        = unsafe extern "C" fn (*mut c_void) -> *mut AppLayerDecoderEvents;
 pub type LocalStorageNewFn  = extern "C" fn () -> *mut c_void;
 pub type LocalStorageFreeFn = extern "C" fn (*mut c_void);
 pub type GetFilesFn         = unsafe
@@ -521,3 +527,4 @@ pub unsafe extern "C" fn state_get_tx_iterator<S: State<Tx>, Tx: Transaction>(
     let state = cast_pointer!(state, S);
     state.get_transaction_iterator(min_tx_id, istate)
 }
+

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -1360,7 +1360,6 @@ pub unsafe extern "C" fn rs_dcerpc_register_parser() {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_dcerpc_get_alstate_progress,
-        get_events: None,
         get_eventinfo: None,
         get_eventinfo_byid : None,
         localstorage_new: None,

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -341,7 +341,6 @@ pub unsafe extern "C" fn rs_dcerpc_udp_register_parser() {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_dcerpc_get_alstate_progress,
-        get_events: None,
         get_eventinfo: None,
         get_eventinfo_byid: None,
         localstorage_new: None,

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -475,7 +475,6 @@ pub unsafe extern "C" fn rs_rdp_register_parser() {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_rdp_tx_get_progress,
-        get_events: None,
         get_eventinfo: None,
         get_eventinfo_byid: None,
         localstorage_new: None,

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -48,7 +48,6 @@ pub struct SIPTransaction {
     pub response: Option<Response>,
     pub request_line: Option<String>,
     pub response_line: Option<String>,
-    events: *mut core::AppLayerDecoderEvents,
     tx_data: applayer::AppLayerTxData,
 }
 
@@ -92,8 +91,7 @@ impl SIPState {
 
     fn set_event(&mut self, event: SIPEvent) {
         if let Some(tx) = self.transactions.last_mut() {
-            let ev = event as u8;
-            core::sc_app_layer_decoder_events_set_event_raw(&mut tx.events, ev);
+            tx.tx_data.set_event(event as u8);
         }
     }
 
@@ -150,16 +148,7 @@ impl SIPTransaction {
             response: None,
             request_line: None,
             response_line: None,
-            events: std::ptr::null_mut(),
             tx_data: applayer::AppLayerTxData::new(),
-        }
-    }
-}
-
-impl Drop for SIPTransaction {
-    fn drop(&mut self) {
-        if !self.events.is_null() {
-            core::sc_app_layer_decoder_events_free_events(&mut self.events);
         }
     }
 }
@@ -207,14 +196,6 @@ pub extern "C" fn rs_sip_tx_get_alstate_progress(
     _direction: u8,
 ) -> std::os::raw::c_int {
     1
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_sip_state_get_events(
-    tx: *mut std::os::raw::c_void,
-) -> *mut core::AppLayerDecoderEvents {
-    let tx = cast_pointer!(tx, SIPTransaction);
-    return tx.events;
 }
 
 static mut ALPROTO_SIP: AppProto = ALPROTO_UNKNOWN;
@@ -304,7 +285,6 @@ pub unsafe extern "C" fn rs_sip_register_parser() {
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
         tx_get_progress: rs_sip_tx_get_alstate_progress,
-        get_events: Some(rs_sip_state_get_events),
         get_eventinfo: Some(SIPEvent::get_event_info),
         get_eventinfo_byid: Some(SIPEvent::get_event_info_by_id),
         localstorage_new: None,

--- a/rust/src/smb/events.rs
+++ b/rust/src/smb/events.rs
@@ -15,7 +15,6 @@
  * 02110-1301, USA.
  */
 
-use crate::core::*;
 use crate::smb::smb::*;
 
 #[derive(AppLayerEvent)]
@@ -33,13 +32,13 @@ pub enum SMBEvent {
 impl SMBTransaction {
     /// Set event.
     pub fn set_event(&mut self, e: SMBEvent) {
-        sc_app_layer_decoder_events_set_event_raw(&mut self.events, e as u8);
+        self.tx_data.set_event(e as u8);
     }
 
     /// Set events from vector of events.
     pub fn set_events(&mut self, events: Vec<SMBEvent>) {
         for e in events {
-            sc_app_layer_decoder_events_set_event_raw(&mut self.events, e as u8);
+            self.tx_data.set_event(e as u8);
         }
     }
 }
@@ -54,6 +53,5 @@ impl SMBState {
 
         let tx = &mut self.transactions[len - 1];
         tx.set_event(event);
-        //sc_app_layer_decoder_events_set_event_raw(&mut tx.events, event as u8);
     }
 }

--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -17,7 +17,7 @@
 
 use super::parser;
 use crate::applayer::*;
-use crate::core::{self, *};
+use crate::core::*;
 use nom7::Err;
 use std::ffi::CString;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -82,7 +82,6 @@ pub struct SSHTransaction {
     pub srv_hdr: SshHeader,
     pub cli_hdr: SshHeader,
 
-    events: *mut core::AppLayerDecoderEvents,
     tx_data: AppLayerTxData,
 }
 
@@ -91,21 +90,8 @@ impl SSHTransaction {
         SSHTransaction {
             srv_hdr: SshHeader::new(),
             cli_hdr: SshHeader::new(),
-            events: std::ptr::null_mut(),
             tx_data: AppLayerTxData::new(),
         }
-    }
-
-    pub fn free(&mut self) {
-        if !self.events.is_null() {
-            core::sc_app_layer_decoder_events_free_events(&mut self.events);
-        }
-    }
-}
-
-impl Drop for SSHTransaction {
-    fn drop(&mut self) {
-        self.free();
     }
 }
 
@@ -121,8 +107,7 @@ impl SSHState {
     }
 
     fn set_event(&mut self, event: SSHEvent) {
-        let ev = event as u8;
-        core::sc_app_layer_decoder_events_set_event_raw(&mut self.transaction.events, ev);
+        self.transaction.tx_data.set_event(event as u8);
     }
 
     fn parse_record(
@@ -349,14 +334,6 @@ impl SSHState {
 export_tx_data_get!(rs_ssh_get_tx_data, SSHTransaction);
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_ssh_state_get_events(
-    tx: *mut std::os::raw::c_void,
-) -> *mut core::AppLayerDecoderEvents {
-    let tx = cast_pointer!(tx, SSHTransaction);
-    return tx.events;
-}
-
-#[no_mangle]
 pub extern "C" fn rs_ssh_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = SSHState::new();
     let boxed = Box::new(state);
@@ -477,7 +454,6 @@ pub unsafe extern "C" fn rs_ssh_register_parser() {
         tx_comp_st_ts: SSHConnectionState::SshStateFinished as i32,
         tx_comp_st_tc: SSHConnectionState::SshStateFinished as i32,
         tx_get_progress: rs_ssh_tx_get_alstate_progress,
-        get_events: Some(rs_ssh_state_get_events),
         get_eventinfo: Some(SSHEvent::get_event_info),
         get_eventinfo_byid: Some(SSHEvent::get_event_info_by_id),
         localstorage_new: None,

--- a/src/app-layer-dnp3.h
+++ b/src/app-layer-dnp3.h
@@ -243,9 +243,6 @@ typedef struct DNP3Transaction_ {
                                          * we do not know. */
     DNP3ObjectList         response_objects;
 
-    AppLayerDecoderEvents *decoder_events; /**< Per transcation
-                                            * decoder events. */
-
     TAILQ_ENTRY(DNP3Transaction_) next;
 } DNP3Transaction;
 

--- a/src/app-layer-enip-common.h
+++ b/src/app-layer-enip-common.h
@@ -206,8 +206,6 @@ typedef struct ENIPTransaction_
 
     TAILQ_HEAD(, CIPServiceEntry_) service_list; /**< list for CIP  */
 
-    AppLayerDecoderEvents *decoder_events;      /**< per tx events */
-
     TAILQ_ENTRY(ENIPTransaction_) next;
     AppLayerTxData tx_data;
 } ENIPTransaction;

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -96,11 +96,6 @@ static uint64_t ENIPGetTxCnt(void *alstate)
     return ((uint64_t) ((ENIPState *) alstate)->transaction_max);
 }
 
-static AppLayerDecoderEvents *ENIPGetEvents(void *tx)
-{
-    return ((ENIPTransaction *)tx)->decoder_events;
-}
-
 static int ENIPStateGetEventInfo(const char *event_name, int *event_id, AppLayerEventType *event_type)
 {
     *event_id = SCMapEnumNameToValue(event_name, enip_decoder_event_table);
@@ -181,7 +176,7 @@ static void ENIPTransactionFree(ENIPTransaction *tx, ENIPState *state)
         SCFree(svc);
     }
 
-    AppLayerDecoderEventsFreeEvents(&tx->decoder_events);
+    AppLayerDecoderEventsFreeEvents(&tx->tx_data.events);
 
     if (tx->tx_data.de_state != NULL) {
         DetectEngineStateFree(tx->tx_data.de_state);
@@ -270,12 +265,11 @@ static void ENIPStateTransactionFree(void *state, uint64_t tx_id)
         if (tx == enip_state->curr)
         enip_state->curr = NULL;
 
-        if (tx->decoder_events != NULL)
-        {
-            if (tx->decoder_events->cnt <= enip_state->events)
-            enip_state->events -= tx->decoder_events->cnt;
+        if (tx->tx_data.events != NULL) {
+            if (tx->tx_data.events->cnt <= enip_state->events)
+                enip_state->events -= tx->tx_data.events->cnt;
             else
-            enip_state->events = 0;
+                enip_state->events = 0;
         }
 
         TAILQ_REMOVE(&enip_state->tx_list, tx, next);
@@ -497,8 +491,6 @@ void RegisterENIPUDPParsers(void)
         AppLayerParserRegisterStateFuncs(IPPROTO_UDP, ALPROTO_ENIP,
                 ENIPStateAlloc, ENIPStateFree);
 
-        AppLayerParserRegisterGetEventsFunc(IPPROTO_UDP, ALPROTO_ENIP, ENIPGetEvents);
-
         AppLayerParserRegisterGetTx(IPPROTO_UDP, ALPROTO_ENIP, ENIPGetTx);
         AppLayerParserRegisterTxDataFunc(IPPROTO_UDP, ALPROTO_ENIP, ENIPGetTxData);
         AppLayerParserRegisterGetTxCnt(IPPROTO_UDP, ALPROTO_ENIP, ENIPGetTxCnt);
@@ -571,8 +563,6 @@ void RegisterENIPTCPParsers(void)
                 STREAM_TOCLIENT, ENIPParse);
         AppLayerParserRegisterStateFuncs(IPPROTO_TCP, ALPROTO_ENIP,
                 ENIPStateAlloc, ENIPStateFree);
-
-        AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_ENIP, ENIPGetEvents);
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_ENIP, ENIPGetTx);
         AppLayerParserRegisterTxDataFunc(IPPROTO_TCP, ALPROTO_ENIP, ENIPGetTxData);

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -863,8 +863,6 @@ static void FTPStateFree(void *s)
     if (fstate->line_state[1].db)
         FTPFree(fstate->line_state[1].db, fstate->line_state[1].db_len);
 
-    //AppLayerDecoderEventsFreeEvents(&s->decoder_events);
-
     FTPTransaction *tx = NULL;
     while ((tx = TAILQ_FIRST(&fstate->tx_list))) {
         TAILQ_REMOVE(&fstate->tx_list, tx, next);

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -180,7 +180,7 @@ static int HTPParseAndCheckContentRange(
 {
     int r = HTPParseContentRange(rawvalue, range);
     if (r != 0) {
-        AppLayerDecoderEventsSetEventRaw(&htud->decoder_events, HTTP_DECODER_EVENT_RANGE_INVALID);
+        AppLayerDecoderEventsSetEventRaw(&htud->tx_data.events, HTTP_DECODER_EVENT_RANGE_INVALID);
         s->events++;
         SCLogDebug("parsing range failed, going back to normal file");
         return r;
@@ -197,7 +197,7 @@ static int HTPParseAndCheckContentRange(
         SCLogDebug("range without all information");
         return -3;
     } else if (range->start > range->end) {
-        AppLayerDecoderEventsSetEventRaw(&htud->decoder_events, HTTP_DECODER_EVENT_RANGE_INVALID);
+        AppLayerDecoderEventsSetEventRaw(&htud->tx_data.events, HTTP_DECODER_EVENT_RANGE_INVALID);
         s->events++;
         SCLogDebug("invalid range");
         return -4;

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -228,8 +228,6 @@ typedef struct HtpTxUserData_ {
     uint32_t request_headers_raw_len;
     uint32_t response_headers_raw_len;
 
-    AppLayerDecoderEvents *decoder_events;          /**< per tx events */
-
     /** Holds the boundary identification string if any (used on
      *  multipart/form-data only)
      */

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -177,8 +177,8 @@ void AppLayerParserRegisterLocalStorageFunc(uint8_t ipproto, AppProto proto,
                                  void (*LocalStorageFree)(void *));
 void AppLayerParserRegisterGetFilesFunc(uint8_t ipproto, AppProto alproto,
                              FileContainer *(*StateGetFiles)(void *, uint8_t));
-void AppLayerParserRegisterGetEventsFunc(uint8_t ipproto, AppProto proto,
-    AppLayerDecoderEvents *(*StateGetEvents)(void *) __attribute__((nonnull)));
+// void AppLayerParserRegisterGetEventsFunc(uint8_t ipproto, AppProto proto,
+//     AppLayerDecoderEvents *(*StateGetEvents)(void *) __attribute__((nonnull)));
 void AppLayerParserRegisterLoggerFuncs(uint8_t ipproto, AppProto alproto,
                          LoggerId (*StateGetTxLogged)(void *, void *),
                          void (*StateSetTxLogged)(void *, void *, LoggerId));

--- a/src/app-layer-register.c
+++ b/src/app-layer-register.c
@@ -145,10 +145,6 @@ int AppLayerRegisterParser(const struct AppLayerParser *p, AppProto alproto)
         AppLayerParserRegisterGetEventInfoById(p->ip_proto, alproto,
                 p->StateGetEventInfoById);
     }
-    if (p->StateGetEvents) {
-        AppLayerParserRegisterGetEventsFunc(p->ip_proto, alproto,
-                p->StateGetEvents);
-    }
     if (p->LocalStorageAlloc && p->LocalStorageFree) {
         AppLayerParserRegisterLocalStorageFunc(p->ip_proto, alproto,
                 p->LocalStorageAlloc, p->LocalStorageFree);

--- a/src/app-layer-register.h
+++ b/src/app-layer-register.h
@@ -49,7 +49,6 @@ typedef struct AppLayerParser {
     const int complete_tc;
     int (*StateGetProgress)(void *alstate, uint8_t direction);
 
-    AppLayerDecoderEvents *(*StateGetEvents)(void *);
     int (*StateGetEventInfo)(const char *event_name,
                              int *event_id, AppLayerEventType *event_type);
     int (*StateGetEventInfoById)(int event_id, const char **event_name,

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -79,8 +79,6 @@ typedef struct SMTPTransaction_ {
     /** the mime decoding parser state */
     MimeDecParseState *mime_state;
 
-    AppLayerDecoderEvents *decoder_events;          /**< per tx events */
-
     /* MAIL FROM parameters */
     uint8_t *mail_from;
     uint16_t mail_from_len;

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -240,15 +240,8 @@ void SSLSetEvent(SSLState *ssl_state, uint8_t event)
         return;
     }
 
-    AppLayerDecoderEventsSetEventRaw(&ssl_state->decoder_events, event);
+    AppLayerDecoderEventsSetEventRaw(&ssl_state->tx_data.events, event);
     ssl_state->events++;
-}
-
-static AppLayerDecoderEvents *SSLGetEvents(void *tx)
-{
-    /* for TLS, TX == state, see GetTx */
-    SSLState *ssl_state = (SSLState *)tx;
-    return ssl_state->decoder_events;
 }
 
 static void *SSLGetTx(void *state, uint64_t tx_id)
@@ -2678,7 +2671,7 @@ static void SSLStateFree(void *p)
     if (ssl_state->server_connp.ja3_hash)
         SCFree(ssl_state->server_connp.ja3_hash);
 
-    AppLayerDecoderEventsFreeEvents(&ssl_state->decoder_events);
+    AppLayerDecoderEventsFreeEvents(&ssl_state->tx_data.events);
 
     if (ssl_state->tx_data.de_state != NULL) {
         DetectEngineStateFree(ssl_state->tx_data.de_state);
@@ -2952,8 +2945,6 @@ void RegisterSSLParsers(void)
         AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_TCP, ALPROTO_TLS, STREAM_TOSERVER);
 
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_TLS, SSLStateTransactionFree);
-
-        AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_TLS, SSLGetEvents);
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_TLS, SSLGetTx);
         AppLayerParserRegisterTxDataFunc(IPPROTO_TCP, ALPROTO_TLS, SSLGetTxData);

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -249,8 +249,6 @@ typedef struct SSLState_ {
 
     SSLStateConnp client_connp;
     SSLStateConnp server_connp;
-
-    AppLayerDecoderEvents *decoder_events;
 } SSLState;
 
 void RegisterSSLParsers(void);

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -100,7 +100,7 @@ static void TemplateTxFree(void *txv)
         SCFree(tx->response_buffer);
     }
 
-    AppLayerDecoderEventsFreeEvents(&tx->decoder_events);
+    AppLayerDecoderEventsFreeEvents(&tx->tx_data.events);
 
     SCFree(tx);
 }
@@ -188,11 +188,6 @@ static int TemplateStateGetEventInfoById(int event_id, const char **event_name,
     *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
 
     return 0;
-}
-
-static AppLayerDecoderEvents *TemplateGetEvents(void *tx)
-{
-    return ((TemplateTransaction *)tx)->decoder_events;
 }
 
 /**
@@ -303,8 +298,7 @@ static AppLayerResult TemplateParseRequest(Flow *f, void *statev,
     if ((input_len == 1 && tx->request_buffer[0] == '\n') ||
         (input_len == 2 && tx->request_buffer[0] == '\r')) {
         SCLogNotice("Creating event for empty message.");
-        AppLayerDecoderEventsSetEventRaw(&tx->decoder_events,
-            TEMPLATE_DECODER_EVENT_EMPTY_MESSAGE);
+        AppLayerDecoderEventsSetEventRaw(&tx->tx_data.events, TEMPLATE_DECODER_EVENT_EMPTY_MESSAGE);
     }
 
 end:
@@ -529,8 +523,6 @@ void RegisterTemplateParsers(void)
             TemplateStateGetEventInfo);
         AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_TEMPLATE,
             TemplateStateGetEventInfoById);
-        AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_TEMPLATE,
-            TemplateGetEvents);
 
         /* Leave this is if your parser can handle gaps, otherwise
          * remove. */

--- a/src/app-layer-template.h
+++ b/src/app-layer-template.h
@@ -38,10 +38,6 @@ typedef struct TemplateTransaction
     /** Internal transaction ID. */
     uint64_t tx_id;
 
-    /** Application layer events that occurred
-     *  while parsing this transaction. */
-    AppLayerDecoderEvents *decoder_events;
-
     uint8_t *request_buffer;
     uint32_t request_buffer_len;
 

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -71,11 +71,6 @@ static int TFTPStateGetEventInfo(const char *event_name, int *event_id,
     return -1;
 }
 
-static AppLayerDecoderEvents *TFTPGetEvents(void *tx)
-{
-    return NULL;
-}
-
 /**
  * \brief Probe the input to see if it looks like tftp.
  *
@@ -233,8 +228,6 @@ void RegisterTFTPParsers(void)
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_UDP, ALPROTO_TFTP,
                                            TFTPStateGetEventInfo);
-        AppLayerParserRegisterGetEventsFunc(IPPROTO_UDP, ALPROTO_TFTP,
-                                            TFTPGetEvents);
 
         AppLayerParserRegisterTxDataFunc(IPPROTO_UDP, ALPROTO_TFTP,
                                          rs_tftp_get_tx_data);


### PR DESCRIPTION
As most parsers use an events structure we can include it in the
tx_data structure to reduce some boilerplate/housekeeping code
in app-layer parsers.

