### PR TITLE
Dev/nom7 smb v0.1

### DIFF
--- a/rust/src/common.rs
+++ b/rust/src/common.rs
@@ -1,6 +1,23 @@
 use std::ffi::CString;
 use std::os::raw::c_char;
 
+pub mod nom7 {
+    use nom7::bytes::streaming::{tag, take_until};
+    use nom7::error::ParseError;
+    use nom7::IResult;
+
+    pub fn take_until_and_consume<'a, E: ParseError<&'a [u8]>>(t: &'a [u8])
+         -> impl Fn(&'a [u8]) -> IResult<&'a [u8], &'a [u8], E>
+    {
+        move |i: &'a [u8]| {
+            let t = t.clone();
+            let (i, res) = take_until(t)(i)?;
+            let (i, _) = tag(t)(i)?;
+            Ok((i, res))
+        }
+    }
+}
+
 #[macro_export]
 macro_rules! take_until_and_consume (
  ( $i:expr, $needle:expr ) => (

--- a/rust/src/smb/dcerpc_records.rs
+++ b/rust/src/smb/dcerpc_records.rs
@@ -16,11 +16,15 @@
  */
 
 use crate::smb::error::SmbError;
-use nom;
-use nom::IResult;
-use nom::combinator::rest;
-use nom::number::Endianness;
-use nom::number::streaming::{be_u16, le_u8, le_u16, le_u32};
+use nom7::bits::{bits, streaming::take as take_bits};
+use nom7::bytes::streaming::take;
+use nom7::combinator::{cond, rest};
+use nom7::error::Error;
+use nom7::multi::count;
+use nom7::number::Endianness;
+use nom7::number::streaming::{be_u16, le_u8, le_u16, le_u32, u16, u32};
+use nom7::sequence::tuple;
+use nom7::IResult;
 
 #[derive(Debug,PartialEq)]
 pub struct DceRpcResponseRecord<'a> {
@@ -30,7 +34,7 @@ pub struct DceRpcResponseRecord<'a> {
 /// parse a packet type 'response' DCERPC record. Implemented
 /// as function to be able to pass the fraglen in.
 pub fn parse_dcerpc_response_record(i:&[u8], frag_len: u16 )
-    -> IResult<&[u8], DceRpcResponseRecord, SmbError>
+    -> nom::IResult<&[u8], DceRpcResponseRecord, SmbError>
 {
     if frag_len < 24 {
         return Err(nom::Err::Error(SmbError::RecordTooSmall));
@@ -53,8 +57,9 @@ pub struct DceRpcRequestRecord<'a> {
 /// parse a packet type 'request' DCERPC record. Implemented
 /// as function to be able to pass the fraglen in.
 pub fn parse_dcerpc_request_record(i:&[u8], frag_len: u16, little: bool)
-    -> IResult<&[u8], DceRpcRequestRecord, SmbError>
+    -> nom::IResult<&[u8], DceRpcRequestRecord, SmbError>
 {
+    use nom::number::Endianness;
     if frag_len < 24 {
         return Err(nom::Err::Error(SmbError::RecordTooSmall));
     }
@@ -77,37 +82,37 @@ pub struct DceRpcBindIface<'a> {
     pub ver_min: u16,
 }
 
-named!(pub parse_dcerpc_bind_iface<DceRpcBindIface>,
-    do_parse!(
-            _ctx_id: le_u16
-        >>  _num_trans_items: le_u8
-        >>  take!(1) // reserved
-        >>  interface: take!(16)
-        >>  ver: le_u16
-        >>  ver_min: le_u16
-        >>  take!(20)
-        >> (DceRpcBindIface {
-                iface:interface,
-                ver:ver,
-                ver_min:ver_min,
-            })
-));
+pub fn parse_dcerpc_bind_iface(i: &[u8]) -> IResult<&[u8], DceRpcBindIface> {
+    let (i, _ctx_id) = le_u16(i)?;
+    let (i, _num_trans_items) = le_u8(i)?;
+    let (i, _) = take(1_usize)(i)?; // reserved
+    let (i, interface) = take(16_usize)(i)?;
+    let (i, ver) = le_u16(i)?;
+    let (i, ver_min) = le_u16(i)?;
+    let (i, _) = take(20_usize)(i)?;
+    let res = DceRpcBindIface {
+        iface:interface,
+        ver,
+        ver_min,
+    };
+    Ok((i, res))
+}
 
-named!(pub parse_dcerpc_bind_iface_big<DceRpcBindIface>,
-    do_parse!(
-            _ctx_id: le_u16
-        >>  _num_trans_items: le_u8
-        >>  take!(1) // reserved
-        >>  interface: take!(16)
-        >>  ver_min: be_u16
-        >>  ver: be_u16
-        >>  take!(20)
-        >> (DceRpcBindIface {
-                iface:interface,
-                ver:ver,
-                ver_min:ver_min,
-            })
-));
+pub fn parse_dcerpc_bind_iface_big(i: &[u8]) -> IResult<&[u8], DceRpcBindIface> {
+    let (i, _ctx_id) = le_u16(i)?;
+    let (i, _num_trans_items) = le_u8(i)?;
+    let (i, _) = take(1_usize)(i)?; // reserved
+    let (i, interface) = take(16_usize)(i)?;
+    let (i, ver_min) = be_u16(i)?;
+    let (i, ver) = be_u16(i)?;
+    let (i, _) = take(20_usize)(i)?;
+    let res = DceRpcBindIface {
+        iface:interface,
+        ver,
+        ver_min,
+    };
+    Ok((i, res))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct DceRpcBindRecord<'a> {
@@ -115,33 +120,33 @@ pub struct DceRpcBindRecord<'a> {
     pub ifaces: Vec<DceRpcBindIface<'a>>,
 }
 
-named!(pub parse_dcerpc_bind_record<DceRpcBindRecord>,
-    do_parse!(
-            _max_xmit_frag: le_u16
-        >>  _max_recv_frag: le_u16
-        >>  _assoc_group: take!(4)
-        >>  num_ctx_items: le_u8
-        >>  take!(3) // reserved
-        >>  ifaces: count!(parse_dcerpc_bind_iface, num_ctx_items as usize)
-        >> (DceRpcBindRecord {
-                num_ctx_items:num_ctx_items,
-                ifaces:ifaces,
-           })
-));
+pub fn parse_dcerpc_bind_record(i: &[u8]) -> IResult<&[u8], DceRpcBindRecord> {
+    let (i, _max_xmit_frag) = le_u16(i)?;
+    let (i, _max_recv_frag) = le_u16(i)?;
+    let (i, _assoc_group) = take(4_usize)(i)?;
+    let (i, num_ctx_items) = le_u8(i)?;
+    let (i, _) = take(3_usize)(i)?; // reserved
+    let (i, ifaces) = count(parse_dcerpc_bind_iface, num_ctx_items as usize)(i)?;
+    let record = DceRpcBindRecord {
+        num_ctx_items,
+        ifaces,
+    };
+    Ok((i, record))
+}
 
-named!(pub parse_dcerpc_bind_record_big<DceRpcBindRecord>,
-    do_parse!(
-            _max_xmit_frag: be_u16
-        >>  _max_recv_frag: be_u16
-        >>  _assoc_group: take!(4)
-        >>  num_ctx_items: le_u8
-        >>  take!(3) // reserved
-        >>  ifaces: count!(parse_dcerpc_bind_iface_big, num_ctx_items as usize)
-        >> (DceRpcBindRecord {
-                num_ctx_items:num_ctx_items,
-                ifaces:ifaces,
-           })
-));
+pub fn parse_dcerpc_bind_record_big(i: &[u8]) -> IResult<&[u8], DceRpcBindRecord> {
+    let (i, _max_xmit_frag) = be_u16(i)?;
+    let (i, _max_recv_frag) = be_u16(i)?;
+    let (i, _assoc_group) = take(4_usize)(i)?;
+    let (i, num_ctx_items) = le_u8(i)?;
+    let (i, _) = take(3_usize)(i)?; // reserved
+    let (i, ifaces) = count(parse_dcerpc_bind_iface_big, num_ctx_items as usize)(i)?;
+    let record = DceRpcBindRecord {
+        num_ctx_items,
+        ifaces,
+    };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct DceRpcBindAckResult<'a> {
@@ -151,19 +156,19 @@ pub struct DceRpcBindAckResult<'a> {
     pub syntax_version: u32,
 }
 
-named!(pub parse_dcerpc_bindack_result<DceRpcBindAckResult>,
-    do_parse!(
-            ack_result: le_u16
-        >>  ack_reason: le_u16
-        >>  transfer_syntax: take!(16)
-        >>  syntax_version: le_u32
-        >> (DceRpcBindAckResult {
-                ack_result:ack_result,
-                ack_reason:ack_reason,
-                transfer_syntax:transfer_syntax,
-                syntax_version:syntax_version,
-            })
-));
+pub fn parse_dcerpc_bindack_result(i: &[u8]) -> IResult<&[u8], DceRpcBindAckResult> {
+    let (i, ack_result) = le_u16(i)?;
+    let (i, ack_reason) = le_u16(i)?;
+    let (i, transfer_syntax) = take(16_usize)(i)?;
+    let (i, syntax_version) = le_u32(i)?;
+    let res = DceRpcBindAckResult {
+        ack_result,
+        ack_reason,
+        transfer_syntax,
+        syntax_version,
+    };
+    Ok((i, res))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct DceRpcBindAckRecord<'a> {
@@ -171,22 +176,22 @@ pub struct DceRpcBindAckRecord<'a> {
     pub results: Vec<DceRpcBindAckResult<'a>>,
 }
 
-named!(pub parse_dcerpc_bindack_record<DceRpcBindAckRecord>,
-    do_parse!(
-            _max_xmit_frag: le_u16
-        >>  _max_recv_frag: le_u16
-        >>  _assoc_group: take!(4)
-        >>  sec_addr_len: le_u16
-        >>  take!(sec_addr_len)
-        >>  cond!((sec_addr_len+2) % 4 != 0, take!(4 - (sec_addr_len+2) % 4))
-        >>  num_results: le_u8
-        >>  take!(3) // padding
-        >>  results: count!(parse_dcerpc_bindack_result, num_results as usize)
-        >> (DceRpcBindAckRecord {
-                num_results:num_results,
-                results:results,
-           })
-));
+pub fn parse_dcerpc_bindack_record(i: &[u8]) -> IResult<&[u8], DceRpcBindAckRecord> {
+    let (i, _max_xmit_frag) = le_u16(i)?;
+    let (i, _max_recv_frag) = le_u16(i)?;
+    let (i, _assoc_group) = take(4_usize)(i)?;
+    let (i, sec_addr_len) = le_u16(i)?;
+    let (i, _) = take(sec_addr_len)(i)?;
+    let (i, _) = cond((sec_addr_len+2) % 4 != 0, take(4 - (sec_addr_len+2) % 4))(i)?;
+    let (i, num_results) = le_u8(i)?;
+    let (i, _) = take(3_usize)(i)?; // padding
+    let (i, results) = count(parse_dcerpc_bindack_result, num_results as usize)(i)?;
+    let record = DceRpcBindAckRecord {
+        num_results,
+        results,
+    };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct DceRpcRecord<'a> {
@@ -207,42 +212,42 @@ pub struct DceRpcRecord<'a> {
 }
 
 fn parse_dcerpc_flags1(i:&[u8]) -> IResult<&[u8],(u8,u8,u8)> {
-    bits!(i,
-        tuple!(
-            take_bits!(6u8),
-            take_bits!(1u8),   // last (1)
-            take_bits!(1u8)))  // first (2)
+    bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((
+        take_bits(6u8),
+        take_bits(1u8),   // last (1)
+        take_bits(1u8),
+    )))(i)
 }
 
 fn parse_dcerpc_flags2(i:&[u8]) -> IResult<&[u8],(u32,u32,u32)> {
-    bits!(i,
-        tuple!(
-            take_bits!(3u32),
-            take_bits!(1u32),     // endianess
-            take_bits!(28u32)))
+    bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((
+       take_bits(3u32),
+       take_bits(1u32),     // endianess
+       take_bits(28u32),
+    )))(i)
 }
 
-named!(pub parse_dcerpc_record<DceRpcRecord>,
-    do_parse!(
-            version_major: le_u8
-        >>  version_minor: le_u8
-        >>  packet_type: le_u8
-        >>  packet_flags: parse_dcerpc_flags1
-        >>  data_rep: parse_dcerpc_flags2
-        >>  endian: value!(if data_rep.1 == 0 { Endianness::Big } else { Endianness::Little })
-        >>  frag_len: u16!(endian)
-        >>  _auth: u16!(endian)
-        >>  call_id: u32!(endian)
-        >>  data:rest
-        >> (DceRpcRecord {
-                version_major:version_major,
-                version_minor:version_minor,
-                packet_type:packet_type,
-                first_frag:packet_flags.2==1,
-                last_frag:packet_flags.1==1,
-                frag_len: frag_len,
-                little_endian:data_rep.1==1,
-                call_id:call_id,
-                data:data,
-           })
-));
+pub fn parse_dcerpc_record(i: &[u8]) -> IResult<&[u8], DceRpcRecord> {
+    let (i, version_major) = le_u8(i)?;
+    let (i, version_minor) = le_u8(i)?;
+    let (i, packet_type) = le_u8(i)?;
+    let (i, packet_flags) = parse_dcerpc_flags1(i)?;
+    let (i, data_rep) = parse_dcerpc_flags2(i)?;
+    let endian = if data_rep.1 == 0 { Endianness::Big } else { Endianness::Little };
+    let (i, frag_len) = u16(endian)(i)?;
+    let (i, _auth) = u16(endian)(i)?;
+    let (i, call_id) = u32(endian)(i)?;
+    let (i, data) = rest(i)?;
+    let record = DceRpcRecord {
+        version_major,
+        version_minor,
+        packet_type,
+        first_frag: packet_flags.2 == 1,
+        last_frag: packet_flags.1 == 1,
+        frag_len,
+        little_endian: data_rep.1 == 1,
+        call_id,
+        data,
+    };
+    Ok((i, record))
+}

--- a/rust/src/smb/error.rs
+++ b/rust/src/smb/error.rs
@@ -16,7 +16,7 @@
  */
 
 // Author: Pierre Chifflier <chifflier@wzdftpd.net>
-use nom::error::{ErrorKind, ParseError};
+use nom7::error::{ErrorKind, ParseError};
 
 #[derive(Debug)]
 pub enum SmbError {

--- a/rust/src/smb/ntlmssp_records.rs
+++ b/rust/src/smb/ntlmssp_records.rs
@@ -15,10 +15,15 @@
  * 02110-1301, USA.
  */
 
+use crate::common::nom7::take_until_and_consume;
 use std::fmt;
-use nom::IResult;
-use nom::combinator::rest;
-use nom::number::streaming::{le_u8, le_u16, le_u32};
+use nom7::bits::{bits, streaming::take as take_bits};
+use nom7::bytes::streaming::take;
+use nom7::combinator::{cond, rest};
+use nom7::error::Error;
+use nom7::number::streaming::{le_u8, le_u16, le_u32};
+use nom7::sequence::tuple;
+use nom7::IResult;
 
 #[derive(Debug,PartialEq)]
 pub struct NTLMSSPVersion {
@@ -36,20 +41,20 @@ impl fmt::Display for NTLMSSPVersion {
     }
 }
 
-named!(parse_ntlm_auth_version<NTLMSSPVersion>,
-    do_parse!(
-            ver_major: le_u8
-         >> ver_minor: le_u8
-         >> ver_build: le_u16
-         >> take!(3)
-         >> ver_ntlm_rev: le_u8
-         >> ( NTLMSSPVersion {
-                ver_major: ver_major,
-                ver_minor: ver_minor,
-                ver_build: ver_build,
-                ver_ntlm_rev: ver_ntlm_rev,
-             })
-));
+fn parse_ntlm_auth_version(i: &[u8]) -> IResult<&[u8], NTLMSSPVersion> {
+    let (i, ver_major) = le_u8(i)?;
+    let (i, ver_minor) = le_u8(i)?;
+    let (i, ver_build) = le_u16(i)?;
+    let (i, _) = take(3_usize)(i)?;
+    let (i, ver_ntlm_rev) = le_u8(i)?;
+    let version = NTLMSSPVersion {
+        ver_major,
+        ver_minor,
+        ver_build,
+        ver_ntlm_rev,
+    };
+    Ok((i, version))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct NTLMSSPAuthRecord<'a> {
@@ -60,56 +65,60 @@ pub struct NTLMSSPAuthRecord<'a> {
 }
 
 fn parse_ntlm_auth_nego_flags(i:&[u8]) -> IResult<&[u8],(u8,u8,u32)> {
-    bits!(i, tuple!(take_bits!(6u8),take_bits!(1u8),take_bits!(25u32)))
+    bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((
+        take_bits(6u8),
+        take_bits(1u8),
+        take_bits(25u32),
+    )))(i)
 }
 
-named!(pub parse_ntlm_auth_record<NTLMSSPAuthRecord>,
-    do_parse!(
-            _lm_blob_len: le_u16
-         >> _lm_blob_maxlen: le_u16
-         >> _lm_blob_offset: le_u32
+pub fn parse_ntlm_auth_record(i: &[u8]) -> IResult<&[u8], NTLMSSPAuthRecord> {
+    let (i, _lm_blob_len) = le_u16(i)?;
+    let (i, _lm_blob_maxlen) = le_u16(i)?;
+    let (i, _lm_blob_offset) = le_u32(i)?;
 
-         >> _ntlmresp_blob_len: le_u16
-         >> _ntlmresp_blob_maxlen: le_u16
-         >> _ntlmresp_blob_offset: le_u32
+    let (i, _ntlmresp_blob_len) = le_u16(i)?;
+    let (i, _ntlmresp_blob_maxlen) = le_u16(i)?;
+    let (i, _ntlmresp_blob_offset) = le_u32(i)?;
 
-         >> domain_blob_len: le_u16
-         >> _domain_blob_maxlen: le_u16
-         >> domain_blob_offset: le_u32
+    let (i, domain_blob_len) = le_u16(i)?;
+    let (i, _domain_blob_maxlen) = le_u16(i)?;
+    let (i, domain_blob_offset) = le_u32(i)?;
 
-         >> user_blob_len: le_u16
-         >> _user_blob_maxlen: le_u16
-         >> _user_blob_offset: le_u32
+    let (i, user_blob_len) = le_u16(i)?;
+    let (i, _user_blob_maxlen) = le_u16(i)?;
+    let (i, _user_blob_offset) = le_u32(i)?;
 
-         >> host_blob_len: le_u16
-         >> _host_blob_maxlen: le_u16
-         >> _host_blob_offset: le_u32
+    let (i, host_blob_len) = le_u16(i)?;
+    let (i, _host_blob_maxlen) = le_u16(i)?;
+    let (i, _host_blob_offset) = le_u32(i)?;
 
-         >> _ssnkey_blob_len: le_u16
-         >> _ssnkey_blob_maxlen: le_u16
-         >> _ssnkey_blob_offset: le_u32
+    let (i, _ssnkey_blob_len) = le_u16(i)?;
+    let (i, _ssnkey_blob_maxlen) = le_u16(i)?;
+    let (i, _ssnkey_blob_offset) = le_u32(i)?;
 
-         >> nego_flags: parse_ntlm_auth_nego_flags
-         >> version: cond!(nego_flags.1==1, parse_ntlm_auth_version)
+    let (i, nego_flags) = parse_ntlm_auth_nego_flags(i)?;
+    let (i, version) = cond(nego_flags.1==1, parse_ntlm_auth_version)(i)?;
 
-         // subtrack 12 as idenfier (8) and type (4) are cut before we are called
-         // subtract 60 for the len/offset/maxlen fields above
-         >> cond!(nego_flags.1==1, take!(domain_blob_offset - (12 + 60)))
-         // or 52 if we have no version
-         >> cond!(nego_flags.1==0, take!(domain_blob_offset - (12 + 52)))
+    // subtrack 12 as idenfier (8) and type (4) are cut before we are called
+    // subtract 60 for the len/offset/maxlen fields above
+    let (i, _) = cond(nego_flags.1==1, |b| take(domain_blob_offset - (12 + 60))(b))(i)?;
+    // or 52 if we have no version
+    let (i, _) = cond(nego_flags.1==0, |b| take(domain_blob_offset - (12 + 52))(b))(i)?;
 
-         >> domain_blob: take!(domain_blob_len)
-         >> user_blob: take!(user_blob_len)
-         >> host_blob: take!(host_blob_len)
+    let (i, domain_blob) = take(domain_blob_len)(i)?;
+    let (i, user_blob) = take(user_blob_len)(i)?;
+    let (i, host_blob) = take(host_blob_len)(i)?;
 
-         >> ( NTLMSSPAuthRecord {
-                domain: domain_blob,
-                user: user_blob,
-                host: host_blob,
+    let record = NTLMSSPAuthRecord {
+        domain: domain_blob,
+        user: user_blob,
+        host: host_blob,
 
-                version: version,
-            })
-));
+        version,
+    };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct NTLMSSPRecord<'a> {
@@ -117,14 +126,10 @@ pub struct NTLMSSPRecord<'a> {
     pub data: &'a[u8],
 }
 
-named!(pub parse_ntlmssp<NTLMSSPRecord>,
-    do_parse!(
-            take_until!("NTLMSSP\x00")
-        >>  tag!("NTLMSSP\x00")
-        >>  msg_type: le_u32
-        >>  data: rest
-        >>  (NTLMSSPRecord {
-                msg_type:msg_type,
-                data:data,
-            })
-));
+pub fn parse_ntlmssp(i: &[u8]) -> IResult<&[u8], NTLMSSPRecord> {
+    let (i, _) = take_until_and_consume(b"NTLMSSP\x00")(i)?;
+    let (i, msg_type) = le_u32(i)?;
+    let (i, data) = rest(i)?;
+    let record = NTLMSSPRecord { msg_type, data };
+    Ok((i, record))
+}

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -31,7 +31,6 @@ use std::ffi::{self, CString};
 
 use std::collections::HashMap;
 
-use nom;
 use nom7::{Err, Needed};
 
 use crate::core::*;
@@ -1649,7 +1648,7 @@ impl SMBState {
                                     }
                                 }
                             },
-                            Err(nom::Err::Incomplete(_)) => {
+                            Err(Err::Incomplete(_)) => {
                                 // not enough data to contain basic SMB hdr
                                 // TODO event: empty NBSS_MSGTYPE_SESSION_MESSAGE
                             },

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -32,6 +32,7 @@ use std::ffi::{self, CString};
 use std::collections::HashMap;
 
 use nom;
+use nom7::{Err, Needed};
 
 use crate::core::*;
 use crate::applayer;
@@ -1420,8 +1421,9 @@ impl SMBState {
                     }
                     cur_i = rem;
                 },
-                Err(nom::Err::Incomplete(needed)) => {
-                    if let nom::Needed::Size(n) = needed {
+                Err(Err::Incomplete(needed)) => {
+                    if let Needed::Size(n) = needed {
+                        let n = usize::from(n) + cur_i.len();
                         // 512 is the minimum for parse_tcp_data_ts_partial
                         if n >= 512 && cur_i.len() < 512 {
                             let total_consumed = i.len() - cur_i.len();
@@ -1433,7 +1435,7 @@ impl SMBState {
                             let total_consumed = i.len() - cur_i.len();
                             SCLogDebug!("setting consumed {} need {} needed {:?} total input {}",
                                     total_consumed, n, needed, i.len());
-                            let need = n + 4; // Incomplete returns size of data minus NBSS header
+                            let need = n;
                             return AppLayerResult::incomplete(total_consumed as u32, need as u32);
                         }
                         // tracking a write record, which we don't need to
@@ -1661,9 +1663,10 @@ impl SMBState {
                     }
                     cur_i = rem;
                 },
-                Err(nom::Err::Incomplete(needed)) => {
+                Err(Err::Incomplete(needed)) => {
                     SCLogDebug!("INCOMPLETE have {} needed {:?}", cur_i.len(), needed);
-                    if let nom::Needed::Size(n) = needed {
+                    if let Needed::Size(n) = needed {
+                        let n = usize::from(n) + cur_i.len();
                         // 512 is the minimum for parse_tcp_data_tc_partial
                         if n >= 512 && cur_i.len() < 512 {
                             let total_consumed = i.len() - cur_i.len();
@@ -1675,7 +1678,7 @@ impl SMBState {
                             let total_consumed = i.len() - cur_i.len();
                             SCLogDebug!("setting consumed {} need {} needed {:?} total input {}",
                                     total_consumed, n, needed, i.len());
-                            let need = n + 4; // Incomplete returns size of data minus NBSS header
+                            let need = n;
                             return AppLayerResult::incomplete(total_consumed as u32, need as u32);
                         }
                         // tracking a read record, which we don't need to

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -19,8 +19,6 @@
  * - check all parsers for calls on non-SUCCESS status
  */
 
-use nom;
-
 use crate::core::*;
 
 use crate::smb::smb::*;
@@ -30,6 +28,8 @@ use crate::smb::files::*;
 
 use crate::smb::smb1_records::*;
 use crate::smb::smb1_session::*;
+
+use nom7::Err;
 
 // https://msdn.microsoft.com/en-us/library/ee441741.aspx
 pub const SMB1_COMMAND_CREATE_DIRECTORY:        u8 = 0x00;
@@ -251,13 +251,13 @@ fn smb1_request_record_one<'b>(state: &mut SMBState, r: &SmbRecord<'b>, command:
                                             true
 
                                         },
-                                        Err(nom::Err::Incomplete(_n)) => {
+                                        Err(Err::Incomplete(_n)) => {
                                             SCLogDebug!("TRANS2 SET_FILE_INFO DATA DISPOSITION INCOMPLETE {:?}", _n);
                                             events.push(SMBEvent::MalformedData);
                                             false
                                         },
-                                        Err(nom::Err::Error(_e)) |
-                                        Err(nom::Err::Failure(_e)) => {
+                                        Err(Err::Error(_e)) |
+                                        Err(Err::Failure(_e)) => {
                                             SCLogDebug!("TRANS2 SET_FILE_INFO DATA DISPOSITION ERROR {:?}", _e);
                                             events.push(SMBEvent::MalformedData);
                                             false
@@ -279,13 +279,13 @@ fn smb1_request_record_one<'b>(state: &mut SMBState, r: &SmbRecord<'b>, command:
                                             tx.vercmd.set_smb1_cmd(SMB1_COMMAND_TRANS2);
                                             true
                                         },
-                                        Err(nom::Err::Incomplete(_n)) => {
+                                        Err(Err::Incomplete(_n)) => {
                                             SCLogDebug!("TRANS2 SET_PATH_INFO DATA RENAME INCOMPLETE {:?}", _n);
                                             events.push(SMBEvent::MalformedData);
                                             false
                                         },
-                                        Err(nom::Err::Error(_e)) |
-                                        Err(nom::Err::Failure(_e)) => {
+                                        Err(Err::Error(_e)) |
+                                        Err(Err::Failure(_e)) => {
                                             SCLogDebug!("TRANS2 SET_PATH_INFO DATA RENAME ERROR {:?}", _e);
                                             events.push(SMBEvent::MalformedData);
                                             false
@@ -295,13 +295,13 @@ fn smb1_request_record_one<'b>(state: &mut SMBState, r: &SmbRecord<'b>, command:
                                     false
                                 }
                             },
-                            Err(nom::Err::Incomplete(_n)) => {
+                            Err(Err::Incomplete(_n)) => {
                                 SCLogDebug!("TRANS2 SET_PATH_INFO PARAMS INCOMPLETE {:?}", _n);
                                 events.push(SMBEvent::MalformedData);
                                 false
                             },
-                            Err(nom::Err::Error(_e)) |
-                            Err(nom::Err::Failure(_e)) => {
+                            Err(Err::Error(_e)) |
+                            Err(Err::Failure(_e)) => {
                                 SCLogDebug!("TRANS2 SET_PATH_INFO PARAMS ERROR {:?}", _e);
                                 events.push(SMBEvent::MalformedData);
                                 false
@@ -334,13 +334,13 @@ fn smb1_request_record_one<'b>(state: &mut SMBState, r: &SmbRecord<'b>, command:
                                             true
 
                                         },
-                                        Err(nom::Err::Incomplete(_n)) => {
+                                        Err(Err::Incomplete(_n)) => {
                                             SCLogDebug!("TRANS2 SET_FILE_INFO DATA DISPOSITION INCOMPLETE {:?}", _n);
                                             events.push(SMBEvent::MalformedData);
                                             false
                                         },
-                                        Err(nom::Err::Error(_e)) |
-                                        Err(nom::Err::Failure(_e)) => {
+                                        Err(Err::Error(_e)) |
+                                        Err(Err::Failure(_e)) => {
                                             SCLogDebug!("TRANS2 SET_FILE_INFO DATA DISPOSITION ERROR {:?}", _e);
                                             events.push(SMBEvent::MalformedData);
                                             false
@@ -367,13 +367,13 @@ fn smb1_request_record_one<'b>(state: &mut SMBState, r: &SmbRecord<'b>, command:
                                             tx.vercmd.set_smb1_cmd(SMB1_COMMAND_TRANS2);
                                             true
                                         },
-                                        Err(nom::Err::Incomplete(_n)) => {
+                                        Err(Err::Incomplete(_n)) => {
                                             SCLogDebug!("TRANS2 SET_FILE_INFO DATA RENAME INCOMPLETE {:?}", _n);
                                             events.push(SMBEvent::MalformedData);
                                             false
                                         },
-                                        Err(nom::Err::Error(_e)) |
-                                        Err(nom::Err::Failure(_e)) => {
+                                        Err(Err::Error(_e)) |
+                                        Err(Err::Failure(_e)) => {
                                             SCLogDebug!("TRANS2 SET_FILE_INFO DATA RENAME ERROR {:?}", _e);
                                             events.push(SMBEvent::MalformedData);
                                             false
@@ -383,13 +383,13 @@ fn smb1_request_record_one<'b>(state: &mut SMBState, r: &SmbRecord<'b>, command:
                                     false
                                 }
                             },
-                            Err(nom::Err::Incomplete(_n)) => {
+                            Err(Err::Incomplete(_n)) => {
                                 SCLogDebug!("TRANS2 SET_FILE_INFO PARAMS INCOMPLETE {:?}", _n);
                                 events.push(SMBEvent::MalformedData);
                                 false
                             },
-                            Err(nom::Err::Error(_e)) |
-                            Err(nom::Err::Failure(_e)) => {
+                            Err(Err::Error(_e)) |
+                            Err(Err::Failure(_e)) => {
                                 SCLogDebug!("TRANS2 SET_FILE_INFO PARAMS ERROR {:?}", _e);
                                 events.push(SMBEvent::MalformedData);
                                 false
@@ -399,13 +399,13 @@ fn smb1_request_record_one<'b>(state: &mut SMBState, r: &SmbRecord<'b>, command:
                         false
                     }
                 },
-                Err(nom::Err::Incomplete(_n)) => {
+                Err(Err::Incomplete(_n)) => {
                     SCLogDebug!("TRANS2 INCOMPLETE {:?}", _n);
                     events.push(SMBEvent::MalformedData);
                     false
                 },
-                Err(nom::Err::Error(_e)) |
-                Err(nom::Err::Failure(_e)) => {
+                Err(Err::Error(_e)) |
+                Err(Err::Failure(_e)) => {
                     SCLogDebug!("TRANS2 ERROR {:?}", _e);
                     events.push(SMBEvent::MalformedData);
                     false

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -15,7 +15,7 @@
  * 02110-1301, USA.
  */
 
-use nom;
+use nom7::Err;
 
 use crate::core::*;
 
@@ -392,13 +392,13 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         _ => false,
                     }
                 },
-                Err(nom::Err::Incomplete(_n)) => {
+                Err(Err::Incomplete(_n)) => {
                     SCLogDebug!("SMB2_COMMAND_SET_INFO: {:?}", _n);
                     events.push(SMBEvent::MalformedData);
                     false
                 },
-                Err(nom::Err::Error(_e)) |
-                Err(nom::Err::Failure(_e)) => {
+                Err(Err::Error(_e)) |
+                Err(Err::Failure(_e)) => {
                     SCLogDebug!("SMB2_COMMAND_SET_INFO: {:?}", _e);
                     events.push(SMBEvent::MalformedData);
                     false

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -15,40 +15,41 @@
  * 02110-1301, USA.
  */
 
-use nom;
-use nom::IResult;
-use nom::combinator::rest;
-use nom::number::streaming::{le_u8, le_u16, le_u32, le_u64};
 use crate::smb::smb::*;
 use crate::smb::nbss_records::NBSS_MSGTYPE_SESSION_MESSAGE;
+use nom7::bits::{bits, streaming::take as take_bits};
+use nom7::bytes::streaming::{tag, take};
+use nom7::combinator::{cond, map_parser, rest};
+use nom7::error::{make_error, Error, ErrorKind};
+use nom7::multi::count;
+use nom7::number::streaming::{le_u8, le_u16, le_u32, le_u64};
+use nom7::sequence::tuple;
+use nom7::{Err, IResult, Needed};
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2SecBlobRecord<'a> {
     pub data: &'a[u8],
 }
 
-named!(pub parse_smb2_sec_blob<Smb2SecBlobRecord>,
-    do_parse!(
-         data: rest
-         >> ( Smb2SecBlobRecord {
-                data: data,
-            })
-));
+pub fn parse_smb2_sec_blob(i: &[u8]) -> IResult<&[u8], Smb2SecBlobRecord> {
+    let (i, data) = rest(i)?;
+    Ok((i, Smb2SecBlobRecord { data }))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2RecordDir<> {
     pub request: bool,
 }
 
-named!(pub parse_smb2_record_direction<Smb2RecordDir>,
-    do_parse!(
-            _server_component: tag!(b"\xfeSMB")
-        >>  _skip: take!(12)
-        >>  flags: le_u8
-        >> (Smb2RecordDir {
-                request: flags & 0x01 == 0,
-           })
-));
+pub fn parse_smb2_record_direction(i: &[u8]) -> IResult<&[u8], Smb2RecordDir> {
+    let (i, _server_component) = tag(b"\xfeSMB")(i)?;
+    let (i, _skip) = take(12_usize)(i)?;
+    let (i, flags) = le_u8(i)?;
+    let record = Smb2RecordDir {
+        request: flags & 0x01 == 0,
+    };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2Record<'a> {
@@ -69,49 +70,50 @@ impl<'a> Smb2Record<'a> {
 }
 
 fn parse_smb2_request_flags(i:&[u8]) -> IResult<&[u8],(u8,u8,u8,u32,u8,u8,u8,u8)> {
-    bits!(i,
-        tuple!(
-            take_bits!(2u8),      // reserved / unused
-            take_bits!(1u8),      // replay op
-            take_bits!(1u8),      // dfs op
-            take_bits!(24u32),    // reserved / unused
-            take_bits!(1u8),      // signing
-            take_bits!(1u8),      // chained
-            take_bits!(1u8),      // async
-            take_bits!(1u8)       // response
-        ))
+    bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((
+        take_bits(2u8),      // reserved / unused
+        take_bits(1u8),      // replay op
+        take_bits(1u8),      // dfs op
+        take_bits(24u32),    // reserved / unused
+        take_bits(1u8),      // signing
+        take_bits(1u8),      // chained
+        take_bits(1u8),      // async
+        take_bits(1u8)       // response
+    )))(i)
 }
 
-named!(pub parse_smb2_request_record<Smb2Record>,
-    do_parse!(
-            _server_component: tag!(b"\xfeSMB")
-        >>  hlen: le_u16
-        >>  _credit_charge: le_u16
-        >>  _channel_seq: le_u16
-        >>  _reserved: take!(2)
-        >>  command: le_u16
-        >>  _credits_requested: le_u16
-        >>  flags: parse_smb2_request_flags
-        >> chain_offset: le_u32
-        >> message_id: le_u64
-        >> _process_id: le_u32
-        >> tree_id: le_u32
-        >> session_id: le_u64
-        >> _signature: take!(16)
-        // there is probably a cleaner way to do this
-        >> data_c: cond!(chain_offset > hlen as u32, take!(chain_offset - hlen as u32))
-        >> data_r: cond!(chain_offset <= hlen as u32, rest)
-        >> (Smb2Record {
-                direction: flags.7,
-                nt_status: 0,
-                command:command,
-                message_id: message_id,
-                tree_id: tree_id,
-                async_id: 0,
-                session_id: session_id,
-                data: if data_c != None { data_c.unwrap() } else { data_r.unwrap() }
-           })
-));
+pub fn parse_smb2_request_record(i: &[u8]) -> IResult<&[u8], Smb2Record> {
+    let (i, _server_component) = tag(b"\xfeSMB")(i)?;
+    let (i, hlen) = le_u16(i)?;
+    let (i, _credit_charge) = le_u16(i)?;
+    let (i, _channel_seq) = le_u16(i)?;
+    let (i, _reserved) = take(2_usize)(i)?;
+    let (i, command) = le_u16(i)?;
+    let (i, _credits_requested) = le_u16(i)?;
+    let (i, flags) = parse_smb2_request_flags(i)?;
+    let (i, chain_offset) = le_u32(i)?;
+    let (i, message_id) = le_u64(i)?;
+    let (i, _process_id) = le_u32(i)?;
+    let (i, tree_id) = le_u32(i)?;
+    let (i, session_id) = le_u64(i)?;
+    let (i, _signature) = take(16_usize)(i)?;
+    let (i, data) = if chain_offset > hlen as u32 {
+        take(chain_offset - hlen as u32)(i)?
+    } else {
+        rest(i)?
+    };
+    let record = Smb2Record {
+        direction: flags.7,
+        nt_status: 0,
+        command,
+        message_id,
+        tree_id,
+        async_id: 0,
+        session_id,
+        data,
+    };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2NegotiateProtocolRequestRecord<'a> {
@@ -119,23 +121,23 @@ pub struct Smb2NegotiateProtocolRequestRecord<'a> {
     pub client_guid: &'a[u8],
 }
 
-named!(pub parse_smb2_request_negotiate_protocol<Smb2NegotiateProtocolRequestRecord>,
-    do_parse!(
-            _struct_size: take!(2)
-        >>  dialects_count: le_u16
-        >>  _sec_mode: le_u16
-        >>  _reserved1: le_u16
-        >>  _capabilities: le_u32
-        >>  client_guid: take!(16)
-        >>  _ctx_offset: le_u32
-        >>  _ctx_cnt: le_u16
-        >>  _reserved2: le_u16
-        >>  dia_vec: count!(le_u16, dialects_count as usize)
-        >>  (Smb2NegotiateProtocolRequestRecord {
-                dialects_vec: dia_vec,
-                client_guid: client_guid,
-            })
-));
+pub fn parse_smb2_request_negotiate_protocol(i: &[u8]) -> IResult<&[u8], Smb2NegotiateProtocolRequestRecord> {
+    let (i, _struct_size) = take(2_usize)(i)?;
+    let (i, dialects_count) = le_u16(i)?;
+    let (i, _sec_mode) = le_u16(i)?;
+    let (i, _reserved1) = le_u16(i)?;
+    let (i, _capabilities) = le_u32(i)?;
+    let (i, client_guid) = take(16_usize)(i)?;
+    let (i, _ctx_offset) = le_u32(i)?;
+    let (i, _ctx_cnt) = le_u16(i)?;
+    let (i, _reserved2) = le_u16(i)?;
+    let (i, dia_vec) = count(le_u16, dialects_count as usize)(i)?;
+    let record = Smb2NegotiateProtocolRequestRecord {
+        dialects_vec: dia_vec,
+        client_guid,
+    };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2NegotiateProtocolResponseRecord<'a> {
@@ -143,28 +145,28 @@ pub struct Smb2NegotiateProtocolResponseRecord<'a> {
     pub server_guid: &'a[u8],
 }
 
-named!(pub parse_smb2_response_negotiate_protocol<Smb2NegotiateProtocolResponseRecord>,
-    do_parse!(
-            _struct_size: take!(2)
-        >>  _skip1: take!(2)
-        >>  dialect: le_u16
-        >>  _ctx_cnt: le_u16
-        >>  server_guid: take!(16)
-        >>  (Smb2NegotiateProtocolResponseRecord {
-                dialect,
-                server_guid
-            })
-));
+pub fn parse_smb2_response_negotiate_protocol(i: &[u8]) -> IResult<&[u8], Smb2NegotiateProtocolResponseRecord> {
+    let (i, _struct_size) = take(2_usize)(i)?;
+    let (i, _skip1) = take(2_usize)(i)?;
+    let (i, dialect) = le_u16(i)?;
+    let (i, _ctx_cnt) = le_u16(i)?;
+    let (i, server_guid) = take(16_usize)(i)?;
+    let record = Smb2NegotiateProtocolResponseRecord {
+        dialect,
+        server_guid
+    };
+    Ok((i, record))
+}
 
-named!(pub parse_smb2_response_negotiate_protocol_error<Smb2NegotiateProtocolResponseRecord>,
-    do_parse!(
-            _struct_size: take!(2)
-        >>  _skip1: take!(2)
-        >>  (Smb2NegotiateProtocolResponseRecord {
-                dialect: 0,
-                server_guid: &[],
-            })
-));
+pub fn parse_smb2_response_negotiate_protocol_error(i: &[u8]) -> IResult<&[u8], Smb2NegotiateProtocolResponseRecord> {
+    let (i, _struct_size) = take(2_usize)(i)?;
+    let (i, _skip1) = take(2_usize)(i)?;
+    let record = Smb2NegotiateProtocolResponseRecord {
+        dialect: 0,
+        server_guid: &[],
+    };
+    Ok((i, record))
+}
 
 
 #[derive(Debug,PartialEq)]
@@ -172,55 +174,49 @@ pub struct Smb2SessionSetupRequestRecord<'a> {
     pub data: &'a[u8],
 }
 
-named!(pub parse_smb2_request_session_setup<Smb2SessionSetupRequestRecord>,
-    do_parse!(
-            _struct_size: take!(2)
-        >>  _flags: le_u8
-        >>  _security_mode: le_u8
-        >>  _capabilities: le_u32
-        >>  _channel: le_u32
-        >>  _sec_offset: le_u16
-        >>  _sec_len: le_u16
-        >>  _prev_ssn_id: take!(8)
-        >>  data: rest
-        >>  (Smb2SessionSetupRequestRecord {
-                data:data,
-            })
-));
-
+pub fn parse_smb2_request_session_setup(i: &[u8]) -> IResult<&[u8], Smb2SessionSetupRequestRecord> {
+    let (i, _struct_size) = take(2_usize)(i)?;
+    let (i, _flags) = le_u8(i)?;
+    let (i, _security_mode) = le_u8(i)?;
+    let (i, _capabilities) = le_u32(i)?;
+    let (i, _channel) = le_u32(i)?;
+    let (i, _sec_offset) = le_u16(i)?;
+    let (i, _sec_len) = le_u16(i)?;
+    let (i, _prev_ssn_id) = take(8_usize)(i)?;
+    let (i, data) = rest(i)?;
+    let record = Smb2SessionSetupRequestRecord { data };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2TreeConnectRequestRecord<'a> {
     pub share_name: &'a[u8],
 }
 
-named!(pub parse_smb2_request_tree_connect<Smb2TreeConnectRequestRecord>,
-    do_parse!(
-            _struct_size: take!(2)
-        >>  _offset_length: take!(4)
-        >>  data: rest
-        >>  (Smb2TreeConnectRequestRecord {
-                share_name:data,
-            })
-));
+pub fn parse_smb2_request_tree_connect(i: &[u8]) -> IResult<&[u8], Smb2TreeConnectRequestRecord> {
+    let (i, _struct_size) = take(2_usize)(i)?;
+    let (i, _offset_length) = take(4_usize)(i)?;
+    let (i, data) = rest(i)?;
+    let record = Smb2TreeConnectRequestRecord {
+        share_name:data,
+    };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2TreeConnectResponseRecord<> {
     pub share_type: u8,
 }
 
-named!(pub parse_smb2_response_tree_connect<Smb2TreeConnectResponseRecord>,
-    do_parse!(
-            _struct_size: take!(2)
-        >>  share_type: le_u8
-        >>  _share_flags: le_u32
-        >>  _share_caps: le_u32
-        >>  _access_mask: le_u32
-        >>  (Smb2TreeConnectResponseRecord {
-                share_type
-            })
-));
-
+pub fn parse_smb2_response_tree_connect(i: &[u8]) -> IResult<&[u8], Smb2TreeConnectResponseRecord> {
+    let (i, _struct_size) = take(2_usize)(i)?;
+    let (i, share_type) = le_u8(i)?;
+    let (i, _share_flags) = le_u32(i)?;
+    let (i, _share_caps) = le_u32(i)?;
+    let (i, _access_mask) = le_u32(i)?;
+    let record = Smb2TreeConnectResponseRecord { share_type };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2CreateRequestRecord<'a> {
@@ -229,22 +225,22 @@ pub struct Smb2CreateRequestRecord<'a> {
     pub data: &'a[u8],
 }
 
-named!(pub parse_smb2_request_create<Smb2CreateRequestRecord>,
-    do_parse!(
-            _skip1: take!(36)
-        >>  disposition: le_u32
-        >>  create_options: le_u32
-        >>  _file_name_offset: le_u16
-        >>  file_name_length: le_u16
-        >>  _skip2: take!(8)
-        >>  data: take!(file_name_length)
-        >>  _skip3: rest
-        >>  (Smb2CreateRequestRecord {
-                disposition,
-                create_options,
-                data
-            })
-));
+pub fn parse_smb2_request_create(i: &[u8]) -> IResult<&[u8], Smb2CreateRequestRecord> {
+    let (i, _skip1) = take(36_usize)(i)?;
+    let (i, disposition) = le_u32(i)?;
+    let (i, create_options) = le_u32(i)?;
+    let (i, _file_name_offset) = le_u16(i)?;
+    let (i, file_name_length) = le_u16(i)?;
+    let (i, _skip2) = take(8_usize)(i)?;
+    let (i, data) = take(file_name_length)(i)?;
+    let (i, _skip3) = rest(i)?;
+    let record = Smb2CreateRequestRecord {
+        disposition,
+        create_options,
+        data
+    };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2IOCtlRequestRecord<'a> {
@@ -254,26 +250,26 @@ pub struct Smb2IOCtlRequestRecord<'a> {
     pub data: &'a[u8],
 }
 
-named!(pub parse_smb2_request_ioctl<Smb2IOCtlRequestRecord>,
-    do_parse!(
-            _skip: take!(2)  // structure size
-        >>  take!(2)        // reserved
-        >>  func: le_u32
-        >>  guid: take!(16)
-        >>  _indata_offset: le_u32
-        >>  indata_len: le_u32
-        >>  take!(4)
-        >>  _outdata_offset: le_u32
-        >>  _outdata_len: le_u32
-        >>  take!(12)
-        >>  data: take!(indata_len)
-        >>  (Smb2IOCtlRequestRecord {
-                is_pipe: (func == 0x0011c017),
-                function: func,
-                guid:guid,
-                data:data,
-            })
-));
+pub fn parse_smb2_request_ioctl(i: &[u8]) -> IResult<&[u8], Smb2IOCtlRequestRecord> {
+    let (i, _skip) = take(2_usize)  (i)?;// structure size
+    let (i, _) = take(2_usize)        (i)?;// reserved
+    let (i, func) = le_u32(i)?;
+    let (i, guid) = take(16_usize)(i)?;
+    let (i, _indata_offset) = le_u32(i)?;
+    let (i, indata_len) = le_u32(i)?;
+    let (i, _) = take(4_usize)(i)?;
+    let (i, _outdata_offset) = le_u32(i)?;
+    let (i, _outdata_len) = le_u32(i)?;
+    let (i, _) = take(12_usize)(i)?;
+    let (i, data) = take(indata_len)(i)?;
+    let record = Smb2IOCtlRequestRecord {
+        is_pipe: (func == 0x0011c017),
+        function: func,
+        guid,
+        data,
+    };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2IOCtlResponseRecord<'a> {
@@ -286,73 +282,69 @@ pub struct Smb2IOCtlResponseRecord<'a> {
     pub outdata_offset: u32,
 }
 
-named!(pub parse_smb2_response_ioctl<Smb2IOCtlResponseRecord>,
-    do_parse!(
-            _skip: take!(2)  // structure size
-        >>  take!(2)        // reserved
-        >>  func: le_u32
-        >>  guid: take!(16)
-        >>  indata_offset: le_u32
-        >>  indata_len: le_u32
-        >>  outdata_offset: le_u32
-        >>  outdata_len: le_u32
-        >>  take!(8)
-        >>  take!(indata_len)
-        >>  data: take!(outdata_len)
-        >>  (Smb2IOCtlResponseRecord {
-                is_pipe: (func == 0x0011c017),
-                guid:guid,
-                data:data,
-                indata_len:indata_len,
-                outdata_len:outdata_len,
-                indata_offset:indata_offset,
-                outdata_offset:outdata_offset,
-            })
-));
+pub fn parse_smb2_response_ioctl(i: &[u8]) -> IResult<&[u8], Smb2IOCtlResponseRecord> {
+    let (i, _skip) = take(2_usize)(i)?; // structure size
+    let (i, _) = take(2_usize)(i)?; // reserved
+    let (i, func) = le_u32(i)?;
+    let (i, guid) = take(16_usize)(i)?;
+    let (i, indata_offset) = le_u32(i)?;
+    let (i, indata_len) = le_u32(i)?;
+    let (i, outdata_offset) = le_u32(i)?;
+    let (i, outdata_len) = le_u32(i)?;
+    let (i, _) = take(8_usize)(i)?;
+    let (i, _) = take(indata_len)(i)?;
+    let (i, data) = take(outdata_len)(i)?;
+    let record = Smb2IOCtlResponseRecord {
+        is_pipe: (func == 0x0011c017),
+        guid,
+        data,
+        indata_len,
+        outdata_len,
+        indata_offset,
+        outdata_offset,
+    };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2CloseRequestRecord<'a> {
     pub guid: &'a[u8],
 }
 
-named!(pub parse_smb2_request_close<Smb2CloseRequestRecord>,
-    do_parse!(
-            _skip: take!(8)
-        >>  guid: take!(16)
-        >>  (Smb2CloseRequestRecord {
-                guid
-            })
-));
+pub fn parse_smb2_request_close(i: &[u8]) -> IResult<&[u8], Smb2CloseRequestRecord> {
+    let (i, _skip) = take(8_usize)(i)?;
+    let (i, guid) = take(16_usize)(i)?;
+    let record = Smb2CloseRequestRecord { guid };
+    Ok((i, record))
+}
 
 #[derive(Debug)]
 pub struct Smb2SetInfoRequestRenameRecord<'a> {
     pub name: &'a[u8],
 }
 
-named!(pub parse_smb2_request_setinfo_rename<Smb2SetInfoRequestData>,
-    do_parse!(
-            _replace: le_u8
-        >>  _reserved: take!(7)
-        >>  _root_handle: take!(8)
-        >>  name_len: le_u32
-        >>  name: take!(name_len)
-        >> (Smb2SetInfoRequestData::RENAME(Smb2SetInfoRequestRenameRecord {
-                name
-            }))
-));
+pub fn parse_smb2_request_setinfo_rename(i: &[u8]) -> IResult<&[u8], Smb2SetInfoRequestData> {
+    let (i, _replace) = le_u8(i)?;
+    let (i, _reserved) = take(7_usize)(i)?;
+    let (i, _root_handle) = take(8_usize)(i)?;
+    let (i, name_len) = le_u32(i)?;
+    let (i, name) = take(name_len)(i)?;
+    let record = Smb2SetInfoRequestData::RENAME(Smb2SetInfoRequestRenameRecord { name });
+    Ok((i, record))
+}
 
 #[derive(Debug)]
 pub struct Smb2SetInfoRequestDispoRecord {
     pub delete: bool,
 }
 
-named!(pub parse_smb2_request_setinfo_disposition<&[u8], Smb2SetInfoRequestData>,
-    do_parse!(
-        info: le_u8 >>
-        (Smb2SetInfoRequestData::DISPOSITION(Smb2SetInfoRequestDispoRecord {
-                delete: info & 1 != 0,
-            }))
-));
+pub fn parse_smb2_request_setinfo_disposition(i: &[u8]) -> IResult<&[u8], Smb2SetInfoRequestData> {
+    let (i, info) = le_u8(i)?;
+    let record = Smb2SetInfoRequestData::DISPOSITION(Smb2SetInfoRequestDispoRecord {
+        delete: info & 1 != 0,
+    });
+    Ok((i, record))
+}
 
 #[derive(Debug)]
 pub enum Smb2SetInfoRequestData<'a> {
@@ -387,24 +379,27 @@ fn parse_smb2_request_setinfo_data(
     return Ok((i, Smb2SetInfoRequestData::UNHANDLED));
 }
 
-named!(pub parse_smb2_request_setinfo<Smb2SetInfoRequestRecord>,
-    do_parse!(
-            _struct_size: le_u16
-        >>  class: le_u8
-        >>  infolvl: le_u8
-        >>  setinfo_size: le_u32
-        >>  _setinfo_offset: le_u16
-        >>  _reserved: take!(2)
-        >>  _additional_info: le_u32
-        >>  guid: take!(16)
-        >>  data: flat_map!(take!(setinfo_size), call!(parse_smb2_request_setinfo_data, class, infolvl))
-        >> (Smb2SetInfoRequestRecord {
-                guid: guid,
-                class: class,
-                infolvl: infolvl,
-                data: data,
-            })
-));
+pub fn parse_smb2_request_setinfo(i: &[u8]) -> IResult<&[u8], Smb2SetInfoRequestRecord> {
+    let (i, _struct_size) = le_u16(i)?;
+    let (i, class) = le_u8(i)?;
+    let (i, infolvl) = le_u8(i)?;
+    let (i, setinfo_size) = le_u32(i)?;
+    let (i, _setinfo_offset) = le_u16(i)?;
+    let (i, _reserved) = take(2_usize)(i)?;
+    let (i, _additional_info) = le_u32(i)?;
+    let (i, guid) = take(16_usize)(i)?;
+    let (i, data) = map_parser(
+        take(setinfo_size),
+        |b| parse_smb2_request_setinfo_data(b, class, infolvl)
+    )(i)?;
+    let record = Smb2SetInfoRequestRecord {
+        guid,
+        class,
+        infolvl,
+        data,
+    };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2WriteRequestRecord<'a> {
@@ -415,24 +410,24 @@ pub struct Smb2WriteRequestRecord<'a> {
 }
 
 // can be called on incomplete records
-named!(pub parse_smb2_request_write<Smb2WriteRequestRecord>,
-    do_parse!(
-            _skip1: take!(4)
-        >>  wr_len: le_u32
-        >>  wr_offset: le_u64
-        >>  guid: take!(16)
-        >>  _channel: le_u32
-        >>  _remaining_bytes: le_u32
-        >>  _write_flags: le_u32
-        >>  _skip2: take!(4)
-        >>  data: call!(parse_smb2_data, wr_len)
-        >>  (Smb2WriteRequestRecord {
-                wr_len:wr_len,
-                wr_offset:wr_offset,
-                guid:guid,
-                data:data,
-            })
-));
+pub fn parse_smb2_request_write(i: &[u8]) -> IResult<&[u8], Smb2WriteRequestRecord> {
+    let (i, _skip1) = take(4_usize)(i)?;
+    let (i, wr_len) = le_u32(i)?;
+    let (i, wr_offset) = le_u64(i)?;
+    let (i, guid) = take(16_usize)(i)?;
+    let (i, _channel) = le_u32(i)?;
+    let (i, _remaining_bytes) = le_u32(i)?;
+    let (i, _write_flags) = le_u32(i)?;
+    let (i, _skip2) = take(4_usize)(i)?;
+    let (i, data) = parse_smb2_data(i, wr_len)?;
+    let record = Smb2WriteRequestRecord {
+        wr_len,
+        wr_offset,
+        guid,
+        data,
+    };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2ReadRequestRecord<'a> {
@@ -441,22 +436,22 @@ pub struct Smb2ReadRequestRecord<'a> {
     pub guid: &'a[u8],
 }
 
-named!(pub parse_smb2_request_read<Smb2ReadRequestRecord>,
-    do_parse!(
-            _skip1: take!(4)
-        >>  rd_len: le_u32
-        >>  rd_offset: le_u64
-        >>  guid: take!(16)
-        >>  _min_count: le_u32
-        >>  _channel: le_u32
-        >>  _remaining_bytes: le_u32
-        >>  _skip2: take!(4)
-        >>  (Smb2ReadRequestRecord {
-                rd_len:rd_len,
-                rd_offset:rd_offset,
-                guid:guid,
-            })
-));
+pub fn parse_smb2_request_read(i: &[u8]) -> IResult<&[u8], Smb2ReadRequestRecord> {
+    let (i, _skip1) = take(4_usize)(i)?;
+    let (i, rd_len) = le_u32(i)?;
+    let (i, rd_offset) = le_u64(i)?;
+    let (i, guid) = take(16_usize)(i)?;
+    let (i, _min_count) = le_u32(i)?;
+    let (i, _channel) = le_u32(i)?;
+    let (i, _remaining_bytes) = le_u32(i)?;
+    let (i, _skip2) = take(4_usize)(i)?;
+    let record = Smb2ReadRequestRecord {
+        rd_len,
+        rd_offset,
+        guid,
+    };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2ReadResponseRecord<'a> {
@@ -473,24 +468,24 @@ fn parse_smb2_data<'a>(i: &'a[u8], len: u32)
     if len as usize > i.len() {
         rest(i)
     } else {
-        take!(i, len)
+        take(len)(i)
     }
 }
 
 // can be called on incomplete records
-named!(pub parse_smb2_response_read<Smb2ReadResponseRecord>,
-    do_parse!(
-            _struct_size: le_u16
-        >>  _data_offset: le_u16
-        >>  rd_len: le_u32
-        >>  _rd_rem: le_u32
-        >>  _padding: take!(4)
-        >>  data: call!(parse_smb2_data, rd_len)
-        >>  (Smb2ReadResponseRecord {
-                len : rd_len,
-                data : data,
-            })
-));
+pub fn parse_smb2_response_read(i: &[u8]) -> IResult<&[u8], Smb2ReadResponseRecord> {
+    let (i, _struct_size) = le_u16(i)?;
+    let (i, _data_offset) = le_u16(i)?;
+    let (i, rd_len) = le_u32(i)?;
+    let (i, _rd_rem) = le_u32(i)?;
+    let (i, _padding) = take(4_usize)(i)?;
+    let (i, data) = parse_smb2_data(i, rd_len)?;
+    let record = Smb2ReadResponseRecord {
+        len: rd_len,
+        data,
+    };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2CreateResponseRecord<'a> {
@@ -502,77 +497,77 @@ pub struct Smb2CreateResponseRecord<'a> {
     pub size: u64,
 }
 
-named!(pub parse_smb2_response_create<Smb2CreateResponseRecord>,
-    do_parse!(
-            _ssize: le_u16
-        >>  _oplock: le_u8
-        >>  _resp_flags: le_u8
-        >>  _create_action: le_u32
-        >>  create_ts: le_u64
-        >>  last_access_ts: le_u64
-        >>  last_write_ts: le_u64
-        >>  last_change_ts: le_u64
-        >>  _alloc_size: le_u64
-        >>  eof: le_u64
-        >>  _attrs: le_u32
-        >>  _padding: take!(4)
-        >>  guid: take!(16)
-        >>  _skip2: take!(8)
-        >>  (Smb2CreateResponseRecord {
-                guid : guid,
-                create_ts: SMBFiletime::new(create_ts),
-                last_access_ts: SMBFiletime::new(last_access_ts),
-                last_write_ts: SMBFiletime::new(last_write_ts),
-                last_change_ts: SMBFiletime::new(last_change_ts),
-                size: eof,
-            })
-));
+pub fn parse_smb2_response_create(i: &[u8]) -> IResult<&[u8], Smb2CreateResponseRecord> {
+    let (i, _ssize) = le_u16(i)?;
+    let (i, _oplock) = le_u8(i)?;
+    let (i, _resp_flags) = le_u8(i)?;
+    let (i, _create_action) = le_u32(i)?;
+    let (i, create_ts) = le_u64(i)?;
+    let (i, last_access_ts) = le_u64(i)?;
+    let (i, last_write_ts) = le_u64(i)?;
+    let (i, last_change_ts) = le_u64(i)?;
+    let (i, _alloc_size) = le_u64(i)?;
+    let (i, eof) = le_u64(i)?;
+    let (i, _attrs) = le_u32(i)?;
+    let (i, _padding) = take(4_usize)(i)?;
+    let (i, guid) = take(16_usize)(i)?;
+    let (i, _skip2) = take(8_usize)(i)?;
+    let record = Smb2CreateResponseRecord {
+        guid,
+        create_ts: SMBFiletime::new(create_ts),
+        last_access_ts: SMBFiletime::new(last_access_ts),
+        last_write_ts: SMBFiletime::new(last_write_ts),
+        last_change_ts: SMBFiletime::new(last_change_ts),
+        size: eof,
+    };
+    Ok((i, record))
+}
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2WriteResponseRecord<> {
     pub wr_cnt: u32,
 }
 
-named!(pub parse_smb2_response_write<Smb2WriteResponseRecord>,
-    do_parse!(
-            _skip1: take!(4)
-        >>  wr_cnt: le_u32
-        >>  _skip2: take!(6)
-        >>  (Smb2WriteResponseRecord {
-                wr_cnt : wr_cnt,
-            })
-));
+pub fn parse_smb2_response_write(i: &[u8]) -> IResult<&[u8], Smb2WriteResponseRecord> {
+    let (i, _skip1) = take(4_usize)(i)?;
+    let (i, wr_cnt) = le_u32(i)?;
+    let (i, _skip2) = take(6_usize)(i)?;
+    let record = Smb2WriteResponseRecord { wr_cnt };
+    Ok((i, record))
+}
 
-named!(pub parse_smb2_response_record<Smb2Record>,
-    do_parse!(
-            tag!(b"\xfeSMB")
-        >>  hlen: le_u16
-        >>  _credit_charge: le_u16
-        >>  nt_status: le_u32
-        >>  command: le_u16
-        >>  _credit_granted: le_u16
-        >>  flags: parse_smb2_request_flags
-        >> chain_offset: le_u32
-        >> message_id: le_u64
-        >> _process_id: cond!(flags.6==0, le_u32)
-        >> tree_id: cond!(flags.6==0, le_u32)
-        >> async_id: cond!(flags.6==1, le_u64)
-        >> session_id: le_u64
-        >> _signature: take!(16)
-        // there is probably a cleaner way to do this
-        >> data_c: cond!(chain_offset > hlen as u32, take!(chain_offset - hlen as u32))
-        >> data_r: cond!(chain_offset <= hlen as u32, rest)
-        >> (Smb2Record {
-                direction: flags.7,
-                nt_status: nt_status,
-                message_id: message_id,
-                tree_id: tree_id.unwrap_or(0),
-                async_id: async_id.unwrap_or(0),
-                session_id: session_id,
-                command:command,
-                data: data_c.or(data_r).unwrap()
-           })
-));
+pub fn parse_smb2_response_record(i: &[u8]) -> IResult<&[u8], Smb2Record> {
+    let (i, _) = tag(b"\xfeSMB")(i)?;
+    let (i, hlen) = le_u16(i)?;
+    let (i, _credit_charge) = le_u16(i)?;
+    let (i, nt_status) = le_u32(i)?;
+    let (i, command) = le_u16(i)?;
+    let (i, _credit_granted) = le_u16(i)?;
+    let (i, flags) = parse_smb2_request_flags(i)?;
+    let (i, chain_offset) = le_u32(i)?;
+    let (i, message_id) = le_u64(i)?;
+    let (i, _process_id) = cond(flags.6 == 0, le_u32)(i)?;
+    let (i, tree_id) = cond(flags.6 == 0, le_u32)(i)?;
+    let (i, async_id) = cond(flags.6 == 1, le_u64)(i)?;
+    let (i, session_id) = le_u64(i)?;
+    let (i, _signature) = take(16_usize)(i)?;
+    let (i, data) = if chain_offset > hlen as u32 {
+        take(chain_offset - hlen as u32)(i)?
+    } else {
+        rest(i)?
+    };
+    let record = Smb2Record {
+        direction: flags.7,
+        nt_status,
+        message_id,
+        tree_id: tree_id.unwrap_or(0),
+        async_id: async_id.unwrap_or(0),
+        session_id,
+        command,
+        data,
+    };
+    Ok((i, record))
+}
 
 fn smb_basic_search(d: &[u8]) -> usize {
     let needle = b"SMB";
@@ -588,12 +583,12 @@ fn smb_basic_search(d: &[u8]) -> usize {
     return 0;
 }
 
-pub fn search_smb_record<'a>(i: &'a [u8]) -> nom::IResult<&'a [u8], &'a [u8]> {
+pub fn search_smb_record<'a>(i: &'a [u8]) -> IResult<&'a [u8], &'a [u8]> {
     let mut d = i;
     while d.len() >= 4 {
         let index = smb_basic_search(d);
         if index == 0 {
-            return Err(nom::Err::Error((d, nom::error::ErrorKind::Eof)));
+            return Err(Err::Error(make_error(d, ErrorKind::Eof)));
         }
         if d[index - 1] == 0xfe || d[index - 1] == 0xff || d[index - 1] == 0xfd {
             // if we have enough data, check nbss
@@ -603,5 +598,5 @@ pub fn search_smb_record<'a>(i: &'a [u8]) -> nom::IResult<&'a [u8], &'a [u8]> {
         }
         d = &d[index + 3..];
     }
-    Err(nom::Err::Incomplete(nom::Needed::Size(4 as usize - d.len())))
+    Err(Err::Incomplete(Needed::new(4 as usize - d.len())))
 }

--- a/rust/src/smb/smb3.rs
+++ b/rust/src/smb/smb3.rs
@@ -15,7 +15,9 @@
  * 02110-1301, USA.
  */
 
-use nom::number::streaming::{le_u16, le_u32, le_u64};
+use nom7::bytes::streaming::{tag, take};
+use nom7::number::streaming::{le_u16, le_u32, le_u64};
+use nom7::IResult;
 
 #[derive(Debug,PartialEq)]
 pub struct Smb3TransformRecord<'a> {
@@ -24,19 +26,19 @@ pub struct Smb3TransformRecord<'a> {
     pub enc_data: &'a[u8],
 }
 
-named!(pub parse_smb3_transform_record<Smb3TransformRecord>,
-    do_parse!(
-            tag!(b"\xfdSMB")
-        >>  _signature: take!(16)
-        >>  _nonce: take!(16)
-        >>  msg_size: le_u32
-        >>  _reserved: le_u16
-        >>  enc_algo: le_u16
-        >>  session_id: le_u64
-        >>  enc_data: take!(msg_size)
-        >> ( Smb3TransformRecord {
-                session_id,
-                enc_algo,
-                enc_data,
-            })
-));
+pub fn parse_smb3_transform_record(i: &[u8]) -> IResult<&[u8], Smb3TransformRecord> {
+    let (i, _) = tag(b"\xfdSMB")(i)?;
+    let (i, _signature) = take(16_usize)(i)?;
+    let (i, _nonce) = take(16_usize)(i)?;
+    let (i, msg_size) = le_u32(i)?;
+    let (i, _reserved) = le_u16(i)?;
+    let (i, enc_algo) = le_u16(i)?;
+    let (i, session_id) = le_u64(i)?;
+    let (i, enc_data) = take(msg_size)(i)?;
+    let record = Smb3TransformRecord {
+        session_id,
+        enc_algo,
+        enc_data,
+    };
+    Ok((i, record))
+}

--- a/rust/src/smb/smb_records.rs
+++ b/rust/src/smb/smb_records.rs
@@ -15,9 +15,9 @@
  * 02110-1301, USA.
  */
 
+use crate::common::nom7::take_until_and_consume;
 use crate::smb::error::SmbError;
-use nom;
-use nom::IResult;
+use nom7::{Err, IResult};
 
 /// parse a UTF16 string that is null terminated. Normally by 2 null
 /// bytes, but at the end of the data it can also be a single null.
@@ -42,13 +42,12 @@ pub fn smb_get_unicode_string(blob: &[u8]) -> IResult<&[u8], Vec<u8>, SmbError>
         name.push(c[0]);
         c = &c[2..];
     }
-    Err(nom::Err::Error(SmbError::BadEncoding))
+    Err(Err::Error(SmbError::BadEncoding))
 }
 
 // parse an ASCII string that is null terminated
-named!(pub smb_get_ascii_string<&[u8], Vec<u8>, SmbError>,
-    do_parse!(
-            s: take_until_and_consume!("\x00")
-        >> ( s.to_vec() )
-));
+pub fn smb_get_ascii_string(i: &[u8]) -> IResult<&[u8], Vec<u8>, SmbError> {
+    let (i, s) = take_until_and_consume(b"\x00")(i)?;
+    Ok((i, s.to_vec()))
+}
 


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4165

Describe changes:
- Followup work from #6589 
- Rewrite SMB 2/3/4 parsers to nom 7
- As previously, no rustfmt, only affected files are changed
- All parsers but a tiny number are updated. Some dependencies (like x509-parser, RDP parsing etc.) are breaking CI on ubuntu 16.04 when upgraded, this needs to be investigated separately.
- This PR includes all changes that can be done on SMB without changing version requirements or dependencies
