### PR TITLE
app-layer: fix integer warnings

### DIFF
--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -77,6 +77,7 @@ include = [
     "SIPState",
     "ModbusState",
     "CMark",
+    "Direction",
 ]
 
 # A list of items to not include in the generated bindings

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -303,7 +303,7 @@ static int TCPProtoDetect(ThreadVars *tv,
 {
     AppProto *alproto;
     AppProto *alproto_otherdir;
-    int direction = (flags & STREAM_TOSERVER) ? 0 : 1;
+    Direction direction = (flags & STREAM_TOSERVER) ? ToServer : ToClient;
 
     if (flags & STREAM_TOSERVER) {
         alproto = &f->alproto_ts;
@@ -370,7 +370,8 @@ static int TCPProtoDetect(ThreadVars *tv,
             } else {
                 *stream = &ssn->client;
             }
-            direction = 1 - direction;
+            // switch direction
+            direction = (direction == ToClient) ? ToServer : ToClient;
         }
 
         /* account flow if we have both sides */
@@ -602,7 +603,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         goto end;
     }
 
-    const int direction = (flags & STREAM_TOSERVER) ? 0 : 1;
+    const Direction direction = (flags & STREAM_TOSERVER) ? ToServer : ToClient;
 
     if (flags & STREAM_TOSERVER) {
         alproto = f->alproto_ts;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5973,10 +5973,9 @@ invalid:
  * \param ssn TCP Session
  * \param direction direction to set the flag in: 0 toserver, 1 toclient
  */
-void StreamTcpUpdateAppLayerProgress(TcpSession *ssn, char direction,
-        const uint32_t progress)
+void StreamTcpUpdateAppLayerProgress(TcpSession *ssn, Direction direction, const uint32_t progress)
 {
-    if (direction) {
+    if (direction == ToServer) {
         ssn->server.app_progress_rel += progress;
     } else {
         ssn->client.app_progress_rel += progress;

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -29,6 +29,8 @@
 
 #include "stream.h"
 #include "stream-tcp-reassemble.h"
+#include "rust.h"
+#include "rust-bindings.h"
 
 #define STREAM_VERBOSE false
 /* Flag to indicate that the checksum validation for the stream engine
@@ -195,8 +197,7 @@ int StreamTcpInlineMode(void);
 
 int TcpSessionPacketSsnReuse(const Packet *p, const Flow *f, const void *tcp_ssn);
 
-void StreamTcpUpdateAppLayerProgress(TcpSession *ssn, char direction,
-        const uint32_t progress);
+void StreamTcpUpdateAppLayerProgress(TcpSession *ssn, Direction direction, const uint32_t progress);
 
 #endif /* __STREAM_TCP_H__ */
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4516

Describe changes:
- Avoids some warnings about integers : for direction argument of `StreamTcpUpdateAppLayerProgress`

DRAFT : do not merge

@victorjulien you said :

> I would like this to be solved in a different way, more like how its now done on the Rust side: with a direction enum

But C enums are not as good as Rust enums.
So, I am not sure this is a good idea.

For instance, keeping `direction = 1 - direction;` in this patch (with direction being an enum `Direction`) does not produce warnings on my setup !

See commit https://github.com/OISF/suricata/pull/6638/commits/53aac7fd0dd4b8283f151bc223d351cd38ffda32 for the alternative