### PR TITLE
ftp: do not set alproto if one was already found

### DIFF
--- a/src/app-layer-expectation.c
+++ b/src/app-layer-expectation.c
@@ -324,8 +324,12 @@ AppProto AppLayerExpectationHandle(Flow *f, uint8_t flags)
         if ((exp->direction & flags) && ((exp->sp == 0) || (exp->sp == f->sp)) &&
                 ((exp->dp == 0) || (exp->dp == f->dp))) {
             alproto = exp->alproto;
-            f->alproto_ts = alproto;
-            f->alproto_tc = alproto;
+            if (f->alproto_ts == ALPROTO_UNKNOWN) {
+                f->alproto_ts = alproto;
+            }
+            if (f->alproto_tc == ALPROTO_UNKNOWN) {
+                f->alproto_tc = alproto;
+            }
             void *fdata = FlowGetStorageById(f, g_flow_expectation_id);
             if (fdata) {
                 /* We already have an expectation so let's clean this one */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4857

Describe changes:
- Fixes segfault caused by using a known protocol detection pattern in a file transferred over FTP-DATA

Does not solve the fact that the flow should have been detected as FTP-DATA in the first place