### PR TITLE
Ftp data alert json 4860 v2

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -46,6 +46,7 @@ Logging changes
 - IKEv2 Eve logging changed, the event_type has become ``ike``. The fields ``errors`` and ``notify`` have moved to
   ``ike.ikev2.errors`` and ``ike.ikev2.notify``.
 - FTP DATA metadata for alerts are now logged in ``ftp_data`` instead of root.
+- HTTP ``xff`` field is now logged in ``http.xff`` for alerts instead of in the root.
 
 Other changes
 ~~~~~~~~~~~~~

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -45,6 +45,7 @@ Logging changes
 ~~~~~~~~~~~~~~~
 - IKEv2 Eve logging changed, the event_type has become ``ike``. The fields ``errors`` and ``notify`` have moved to
   ``ike.ikev2.errors`` and ``ike.ikev2.notify``.
+- FTP DATA metadata for alerts are now logged in ``ftp_data`` instead of root.
 
 Other changes
 ~~~~~~~~~~~~~

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -519,7 +519,10 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
             }
             break;
         case ALPROTO_FTPDATA:
+            jb_get_mark(jb, &mark);
+            jb_open_object(jb, "ftp_data");
             EveFTPDataAddMetadata(p->flow, jb);
+            jb_close(jb);
             break;
         case ALPROTO_DNP3:
             AlertJsonDnp3(p->flow, tx_id, jb);

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -441,8 +441,8 @@ static void AlertAddPayload(AlertJsonOutputCtx *json_output_ctx, JsonBuilder *js
     }
 }
 
-static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
-        const uint64_t tx_id, const uint16_t option_flags)
+static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb, const uint64_t tx_id,
+        const uint16_t option_flags, const char *xff_buffer)
 {
     const AppProto proto = FlowGetAppProtocol(p->flow);
     JsonBuilderMark mark = { 0, 0, 0 };
@@ -457,6 +457,9 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
                 if (option_flags & LOG_JSON_HTTP_BODY_BASE64) {
                     EveHttpLogJSONBodyBase64(jb, p->flow, tx_id);
                 }
+            }
+            if (xff_buffer[0]) {
+                jb_set_string(jb, "xff", xff_buffer);
             }
             jb_close(jb);
             break;
@@ -610,6 +613,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
             json_output_ctx->xff_cfg : json_output_ctx->parent_xff_cfg;;
         int have_xff_ip = 0;
         char xff_buffer[XFF_MAXLEN];
+        xff_buffer[0] = 0;
         if ((xff_cfg != NULL) && !(xff_cfg->flags & XFF_DISABLED) && p->flow != NULL) {
             if (FlowGetAppProtocol(p->flow) == ALPROTO_HTTP1) {
                 if (pa->flags & PACKET_ALERT_FLAG_TX) {
@@ -631,6 +635,10 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                  * logged below. */
                 have_xff_ip = false;
             }
+            if (have_xff_ip && !(xff_cfg->flags & XFF_EXTRADATA)) {
+                // reset xff_buffer so as not to log it
+                xff_buffer[0] = 0;
+            }
         }
 
         JsonBuilder *jb =
@@ -649,7 +657,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 
         if (p->flow != NULL) {
             if (json_output_ctx->flags & LOG_JSON_APP_LAYER) {
-                AlertAddAppLayer(p, jb, pa->tx_id, json_output_ctx->flags);
+                AlertAddAppLayer(p, jb, pa->tx_id, json_output_ctx->flags, xff_buffer);
             }
             /* including fileinfo data is configured by the metadata setting */
             if (json_output_ctx->flags & LOG_JSON_RULE_METADATA) {
@@ -716,10 +724,6 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
         /* base64-encoded full packet */
         if (json_output_ctx->flags & LOG_JSON_PACKET) {
             EvePacket(p, jb, 0);
-        }
-
-        if (have_xff_ip && xff_cfg->flags & XFF_EXTRADATA) {
-            jb_set_string(jb, "xff", xff_buffer);
         }
 
         OutputJsonBuilderBuffer(jb, aft->ctx);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4860
but also https://redmine.openinfosecfoundation.org/issues/1369

Describe changes:
- move some app-layer specific fields out of root object (into the app-layer specific object)
  - ftp-data : command and filename (for alert metadata)
  - http : xff (for alert metadata as well)

suricata-verify-pr: 590

Replaces #6658 with upgrade guide additions