### PR TITLE
mqtt: fix transaction completion

### DIFF
--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -627,13 +627,14 @@ pub unsafe extern "C" fn rs_mqtt_tx_get_alstate_progress(
     direction: u8,
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, MQTTTransaction);
-    if tx.complete {
-        if direction == Direction::ToServer.into() {
-            if tx.toserver {
+    match direction.into() {
+        Direction::ToServer => {
+            if tx.complete || tx.toclient {
                 return 1;
             }
-        } else if direction == Direction::ToClient.into() {
-            if tx.toclient {
+        }
+        Direction::ToClient => {
+            if tx.complete || tx.toserver {
                 return 1;
             }
         }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4862

Describe changes:
- Fixes `rs_mqtt_tx_get_alstate_progress` so that transaction can get cleaned by `AppLayerParserTransactionsCleanup`

Before this fix, there is always one direction where the transactions are not considered complete because their state is 0

suricata-verify-pr: 593