### PR TITLE
Integer overflow 4527 v1

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -642,14 +642,18 @@ static AppLayerResult FTPParseRequest(Flow *f, void *ftp_state,
                      * Min size has been checked in FTPParseRequestCommand
                      * PATH_MAX includes the null
                      */
-                    int file_name_len = MIN(PATH_MAX - 1, state->current_line_len - 5);
+                    uint32_t file_name_len = MIN(PATH_MAX - 1, state->current_line_len - 5);
+                    if (file_name_len > UINT16_MAX) {
+                        // truncate the file name if too long for util-file.h
+                        file_name_len = UINT16_MAX;
+                    }
                     data->file_name = FTPCalloc(file_name_len + 1, sizeof(char));
                     if (data->file_name == NULL) {
                         FtpTransferCmdFree(data);
                         SCReturnStruct(APP_LAYER_ERROR);
                     }
                     data->file_name[file_name_len] = 0;
-                    data->file_len = file_name_len;
+                    data->file_len = (uint16_t)file_name_len;
                     memcpy(data->file_name, state->current_line + 5, file_name_len);
                     data->cmd = state->command;
                     data->flow_id = FlowGetId(f);
@@ -1029,9 +1033,8 @@ static StreamingBufferConfig sbcfg = STREAMING_BUFFER_CONFIG_INITIALIZER;
  * \retval 1 when the command is parsed, 0 otherwise
  */
 static AppLayerResult FTPDataParse(Flow *f, FtpDataState *ftpdata_state,
-        AppLayerParserState *pstate,
-        const uint8_t *input, uint32_t input_len,
-        void *local_data, int direction)
+        AppLayerParserState *pstate, const uint8_t *input, uint32_t input_len, void *local_data,
+        uint8_t direction)
 {
     uint16_t flags = FileFlowToFlags(f, direction);
     int ret = 0;
@@ -1361,7 +1364,7 @@ uint16_t JsonGetNextLineFromBuffer(const char *buffer, const uint16_t len)
     }
 
     char *c = strchr(buffer, '\n');
-    return c == NULL ? len : c - buffer + 1;
+    return c == NULL ? len : (uint16_t)(c - buffer + 1);
 }
 
 void EveFTPDataAddMetadata(const Flow *f, JsonBuilder *jb)

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -127,7 +127,7 @@ typedef struct FtpLineState_ {
 
 typedef struct FTPString_ {
     uint8_t *str;
-    uint16_t len;
+    uint32_t len;
     TAILQ_ENTRY(FTPString_) next;
 } FTPString;
 

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -227,8 +227,7 @@ int HTPFileOpenWithRange(HtpState *s, HtpTxUserData *txud, const uint8_t *filena
     HTTPContentRange crparsed;
     if (HTPParseAndCheckContentRange(rawvalue, &crparsed, s, htud) != 0) {
         // range is invalid, fall back to classic open
-        return HTPFileOpen(
-                s, txud, filename, (uint32_t)filename_len, data, data_len, txid, STREAM_TOCLIENT);
+        return HTPFileOpen(s, txud, filename, filename_len, data, data_len, txid, STREAM_TOCLIENT);
     }
     flags = FileFlowToFlags(s->f, STREAM_TOCLIENT);
     if ((s->flags & HTP_FLAG_STORE_FILES_TS) ||

--- a/src/app-layer-htp-range.c
+++ b/src/app-layer-htp-range.c
@@ -163,7 +163,8 @@ void HttpRangeContainersInit(void)
         }
     }
     if (ConfGetValue("app-layer.protocols.http.byterange.timeout", &str) == 1) {
-        if (StringParseUint32(&timeout, 10, strlen(str), str) <= 0) {
+        size_t slen = strlen(str);
+        if (slen > UINT16_MAX || StringParseUint32(&timeout, 10, (uint16_t)slen, str) <= 0) {
             SCLogWarning(SC_ERR_INVALID_VALUE,
                     "timeout value cannot be deduced: %s,"
                     " resetting to default",

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -524,7 +524,7 @@ static uint32_t AppLayerHtpComputeChunkLength(uint64_t content_len_so_far, uint3
 /* below error messages updated up to libhtp 0.5.7 (git 379632278b38b9a792183694a4febb9e0dbd1e7a) */
 struct {
     const char *msg;
-    int  de;
+    uint8_t de;
 } htp_errors[] = {
     { "GZip decompressor: inflateInit2 failed", HTTP_DECODER_EVENT_GZIP_DECOMPRESSION_FAILED},
     { "Request field invalid: colon missing", HTTP_DECODER_EVENT_REQUEST_FIELD_MISSING_COLON},
@@ -547,7 +547,7 @@ struct {
 
 struct {
     const char *msg;
-    int  de;
+    uint8_t de;
 } htp_warnings[] = {
     { "GZip decompressor:", HTTP_DECODER_EVENT_GZIP_DECOMPRESSION_FAILED},
     { "Request field invalid", HTTP_DECODER_EVENT_REQUEST_HEADER_INVALID},
@@ -594,7 +594,7 @@ struct {
  *
  *  \retval id the id or 0 in case of not found
  */
-static int HTPHandleWarningGetId(const char *msg)
+static uint8_t HTPHandleWarningGetId(const char *msg)
 {
     SCLogDebug("received warning \"%s\"", msg);
     size_t idx;
@@ -618,7 +618,7 @@ static int HTPHandleWarningGetId(const char *msg)
  *
  *  \retval id the id or 0 in case of not found
  */
-static int HTPHandleErrorGetId(const char *msg)
+static uint8_t HTPHandleErrorGetId(const char *msg)
 {
     SCLogDebug("received error \"%s\"", msg);
 
@@ -675,7 +675,7 @@ static void HTPHandleError(HtpState *s, const uint8_t dir)
 
         SCLogDebug("message %s", log->msg);
 
-        int id = HTPHandleErrorGetId(log->msg);
+        uint8_t id = HTPHandleErrorGetId(log->msg);
         if (id == 0) {
             id = HTPHandleWarningGetId(log->msg);
             if (id == 0)
@@ -1255,9 +1255,9 @@ static void HtpRequestBodyMultipartParseHeader(HtpState *hstate,
         ft_len = USHRT_MAX;
 
     *filename = fn;
-    *filename_len = fn_len;
+    *filename_len = (uint16_t)fn_len;
     *filetype = ft;
-    *filetype_len = ft_len;
+    *filetype_len = (uint16_t)ft_len;
 }
 
 /**
@@ -1304,8 +1304,8 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
 {
     int result = 0;
     uint8_t boundary[htud->boundary_len + 4]; /**< size limited to HTP_BOUNDARY_MAX + 4 */
-    uint32_t expected_boundary_len = htud->boundary_len + 2;
-    uint32_t expected_boundary_end_len = htud->boundary_len + 4;
+    uint16_t expected_boundary_len = htud->boundary_len + 2;
+    uint16_t expected_boundary_end_len = htud->boundary_len + 4;
     int tx_progress = 0;
 
 #ifdef PRINT
@@ -1434,7 +1434,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
         /* skip empty records */
         if (expected_boundary_len == header_len) {
             goto next;
-        } else if ((expected_boundary_len + 2) <= header_len) {
+        } else if ((uint32_t)(expected_boundary_len + 2) <= header_len) {
             header_len -= (expected_boundary_len + 2);
             header = (uint8_t *)header_start + (expected_boundary_len + 2); // + for 0d 0a
         }
@@ -1536,7 +1536,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                     SCLogDebug("offset %u", offset);
                     htud->request_body.body_parsed += offset;
 
-                    if (filedata_len >= (expected_boundary_len + 2)) {
+                    if (filedata_len >= (uint32_t)(expected_boundary_len + 2)) {
                         filedata_len -= (expected_boundary_len + 2 - 1);
                         SCLogDebug("opening file with partial data");
                     } else {
@@ -1630,7 +1630,11 @@ static int HtpRequestBodyHandlePOSTorPUT(HtpState *hstate, HtpTxUserData *htud,
         }
 
         if (filename != NULL) {
-            result = HTPFileOpen(hstate, htud, filename, (uint32_t)filename_len, data, data_len,
+            if (filename_len > UINT16_MAX) {
+                // explicitly truncate the file name if too long
+                filename_len = UINT16_MAX;
+            }
+            result = HTPFileOpen(hstate, htud, filename, (uint16_t)filename_len, data, data_len,
                     HtpGetActiveRequestTxID(hstate), STREAM_TOSERVER);
             if (result == -1) {
                 goto end;
@@ -1703,11 +1707,15 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
         if (filename != NULL) {
             // set range if present
             htp_header_t *h_content_range = htp_table_get_c(tx->response_headers, "content-range");
+            if (filename_len > UINT16_MAX) {
+                // explicitly truncate the file name if too long
+                filename_len = UINT16_MAX;
+            }
             if (h_content_range != NULL) {
-                result = HTPFileOpenWithRange(hstate, htud, filename, (uint32_t)filename_len, data,
+                result = HTPFileOpenWithRange(hstate, htud, filename, (uint16_t)filename_len, data,
                         data_len, HtpGetActiveResponseTxID(hstate), h_content_range->value, htud);
             } else {
-                result = HTPFileOpen(hstate, htud, filename, (uint32_t)filename_len, data, data_len,
+                result = HTPFileOpen(hstate, htud, filename, (uint16_t)filename_len, data, data_len,
                         HtpGetActiveResponseTxID(hstate), STREAM_TOCLIENT);
             }
             SCLogDebug("result %d", result);
@@ -3025,7 +3033,7 @@ static int HTPRegisterPatternsForProtocolDetection(void)
              * but the pattern matching should only be one char
             */
             register_result = AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_HTTP1,
-                    method_buffer, strlen(method_buffer) - 3, 0, STREAM_TOSERVER);
+                    method_buffer, (uint16_t)strlen(method_buffer) - 3, 0, STREAM_TOSERVER);
             if (register_result < 0) {
                 return -1;
             }
@@ -3035,7 +3043,8 @@ static int HTPRegisterPatternsForProtocolDetection(void)
     /* Loop through all the http verions patterns that are TO_CLIENT */
     for (versions_pos = 0; versions[versions_pos]; versions_pos++) {
         register_result = AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_HTTP1,
-                versions[versions_pos], strlen(versions[versions_pos]), 0, STREAM_TOCLIENT);
+                versions[versions_pos], (uint16_t)strlen(versions[versions_pos]), 0,
+                STREAM_TOCLIENT);
         if (register_result < 0) {
             return -1;
         }

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -249,7 +249,7 @@ AppLayerParserThreadCtx *AppLayerParserThreadCtxAlloc(void)
     SCEnter();
 
     AppProto alproto = 0;
-    int flow_proto = 0;
+    uint8_t flow_proto = 0;
     AppLayerParserThreadCtx *tctx;
 
     tctx = SCMalloc(sizeof(*tctx));
@@ -275,7 +275,7 @@ void AppLayerParserThreadCtxFree(AppLayerParserThreadCtx *tctx)
     SCEnter();
 
     AppProto alproto = 0;
-    int flow_proto = 0;
+    uint8_t flow_proto = 0;
 
     for (flow_proto = 0; flow_proto < FLOW_PROTO_DEFAULT; flow_proto++) {
         for (alproto = 0; alproto < ALPROTO_MAX; alproto++) {

--- a/src/app-layer-register.h
+++ b/src/app-layer-register.h
@@ -27,7 +27,7 @@
 typedef struct AppLayerParser {
     const char *name;
     const char *default_port;
-    int ip_proto;
+    uint8_t ip_proto;
 
     ProbingParserFPtr ProbeTS;
     ProbingParserFPtr ProbeTC;

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -239,7 +239,7 @@ typedef struct SSLState_ {
     uint32_t flags;
 
     /* there might be a better place to store this*/
-    uint16_t hb_record_len;
+    uint32_t hb_record_len;
 
     uint16_t events;
 

--- a/src/util-mpm.c
+++ b/src/util-mpm.c
@@ -46,7 +46,7 @@
 #endif
 
 MpmTableElmt mpm_table[MPM_TABLE_SIZE];
-int mpm_default_matcher;
+uint16_t mpm_default_matcher;
 
 /**
  * \brief Register a new Mpm Context.

--- a/src/util-mpm.h
+++ b/src/util-mpm.h
@@ -170,7 +170,7 @@ typedef struct MpmTableElmt_ {
 } MpmTableElmt;
 
 extern MpmTableElmt mpm_table[MPM_TABLE_SIZE];
-extern int mpm_default_matcher;
+extern uint16_t mpm_default_matcher;
 
 struct DetectEngineCtx_;
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4527

Describe changes:
- Fix integer warnings in all files beginning with a (like app)

libhtp-pr: 339

There remains one warning about the use of `StreamTcpUpdateAppLayerProgress`
cf discussion in https://github.com/OISF/suricata/pull/6649
