### PR TITLE
detect: remove unused references from signature

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1331,36 +1331,6 @@ static void SigMetadataFree(Signature *s)
     SCReturn;
 }
 
-/**
- * \internal
- * \brief Free Reference list
- *
- * \param s Pointer to the signature
- */
-static void SigRefFree (Signature *s)
-{
-    SCEnter();
-
-    DetectReference *ref = NULL;
-    DetectReference *next_ref = NULL;
-
-    if (s == NULL) {
-        SCReturn;
-    }
-
-    SCLogDebug("s %p, s->references %p", s, s->references);
-
-    for (ref = s->references; ref != NULL;)   {
-        next_ref = ref->next;
-        DetectReferenceFree(ref);
-        ref = next_ref;
-    }
-
-    s->references = NULL;
-
-    SCReturn;
-}
-
 static void SigMatchFreeArrays(DetectEngineCtx *de_ctx, Signature *s, int ctxs)
 {
     if (s != NULL) {
@@ -1453,7 +1423,6 @@ void SigFree(DetectEngineCtx *de_ctx, Signature *s)
         SCFree(s->sig_str);
     }
 
-    SigRefFree(s);
     SigMetadataFree(s);
 
     DetectEngineAppInspectionEngineSignatureFree(de_ctx, s);

--- a/src/detect-reference.c
+++ b/src/detect-reference.c
@@ -184,24 +184,12 @@ static int DetectReferenceSetup(DetectEngineCtx *de_ctx, Signature *s,
 {
     SCEnter();
 
-    DetectReference *sig_refs = NULL;
-
     DetectReference *ref = DetectReferenceParse(rawstr, de_ctx);
     if (ref == NULL)
         SCReturnInt(-1);
 
     SCLogDebug("ref %s %s", ref->key, ref->reference);
-
-    if (s->references == NULL)  {
-        s->references = ref;
-    } else {
-        sig_refs = s->references;
-        while (sig_refs->next != NULL) {
-            sig_refs = sig_refs->next;
-        }
-        sig_refs->next = ref;
-        ref->next = NULL;
-    }
+    DetectReferenceFree(ref);
 
     SCReturnInt(0);
 }
@@ -229,11 +217,6 @@ static int DetectReferenceParseTest01(void)
     Signature *s = DetectEngineAppendSig(de_ctx, "alert icmp any any -> any any "
             "(msg:\"One reference\"; reference:one,001-2010; sid:2;)");
     FAIL_IF_NULL(s);
-    FAIL_IF_NULL(s->references);
-
-    DetectReference *ref = s->references;
-    FAIL_IF (strcmp(ref->key, "http://www.one.com") != 0);
-    FAIL_IF (strcmp(ref->reference, "001-2010") != 0);
 
     DetectEngineCtxFree(de_ctx);
     PASS;
@@ -260,16 +243,6 @@ static int DetectReferenceParseTest02(void)
                                    "reference:one,openinfosecdoundation.txt; "
                                    "reference:two,001-2010; sid:2;)");
     FAIL_IF_NULL(s);
-    FAIL_IF_NULL(s->references);
-    FAIL_IF_NULL(s->references->next);
-
-    DetectReference *ref = s->references;
-    FAIL_IF (strcmp(ref->key, "http://www.one.com") != 0);
-    FAIL_IF (strcmp(ref->reference, "openinfosecdoundation.txt") != 0);
-
-    ref = s->references->next;
-    FAIL_IF (strcmp(ref->key, "http://www.two.com") != 0);
-    FAIL_IF (strcmp(ref->reference, "001-2010") != 0);
 
     DetectEngineCtxFree(de_ctx);
     PASS;

--- a/src/detect.h
+++ b/src/detect.h
@@ -577,8 +577,6 @@ typedef struct Signature_ {
 
     /** classification message */
     char *class_msg;
-    /** Reference */
-    DetectReference *references;
     /** Metadata */
     DetectMetadataHead *metadata;
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
During thinking about https://redmine.openinfosecfoundation.org/issues/3588

Describe changes:
- Remove unused `references` from signature

So as to remove unused code and use less memory...

Am I missing something here ?