### PR TITLE
fix bug on ValidateParserProto

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1580,9 +1580,6 @@ static void ValidateParserProto(AppProto alproto, uint8_t ipproto)
     if (!(BOTH_SET(ctx->GetTxDetectState, ctx->SetTxDetectState))) {
         goto bad;
     }
-    if (!(BOTH_SET_OR_BOTH_UNSET(ctx->GetTxDetectState, ctx->SetTxDetectState))) {
-        goto bad;
-    }
     if (ctx->GetTxData == NULL) {
         goto bad;
     }


### PR DESCRIPTION
on line 1580, we have checked both GetTxDetectState and SetTxDetectState are not NULL, so check them again if they're both NULL is unnecessary

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- delete lines on ValidateParserProto in app-layer-parser.c

#suricata-verify-pr: no
#suricata-verify-repo: no
#suricata-verify-branch: no
#suricata-update-pr: no
#suricata-update-repo: no
#suricata-update-branch: no
#libhtp-pr: no
#libhtp-repo: no
#libhtp-branch: no
