### PR TITLE
eve/alert: correctly log if file has been stored

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -576,7 +576,7 @@ static void AlertAddFiles(const Packet *p, JsonBuilder *jb, const uint64_t tx_id
                     jb_open_array(jb, "files");
                 }
                 jb_start_object(jb);
-                EveFileInfo(jb, file, file->flags & FILE_STORED);
+                EveFileInfo(jb, file, file->flags & FILE_STORE);
                 jb_close(jb);
             }
             file = file->next;


### PR DESCRIPTION
At the time of logging the alert, the files that will be stored
are in FILE_STORE stage and not FILE_STORED.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4881

Describe changes:
- correctly log when file has been stored
