### PR TITLE
datasets: initialize after dropping privileges - v6

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2000,8 +2000,6 @@ static int InitSignalHandler(SCInstance *suri)
  * Will be run once per pcap in unix-socket mode */
 void PreRunInit(const int runmode)
 {
-    /* Initialize Datasets to be able to use them with unix socket */
-    DatasetsInit();
     HttpRangeContainersInit();
     if (runmode == RUNMODE_UNIX_SOCKET)
         return;
@@ -2029,6 +2027,7 @@ void PreRunPostPrivsDropInit(const int runmode)
 {
     StatsSetupPostConfigPreOutput();
     RunModeInitializeOutputs();
+    DatasetsInit();
 
     if (runmode == RUNMODE_UNIX_SOCKET) {
         /* As the above did some necessary startup initialization, it


### PR DESCRIPTION
Alternate fix to https://redmine.openinfosecfoundation.org/issues/4239.

While testing I noticed that datasets defined within a rule didn't have the issue in the bug, just datasets defined in the `suricata.yaml` so I thought I'd try just moving where the datasets are initialized. This appears to fix the issue, and I tested that it still works with unix socket.

Ticket: https://redmine.openinfosecfoundation.org/issues/4239
Eric's PR: https://github.com/OISF/suricata/pull/6678