### PR TITLE
netmap: allow specifying a library directory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1337,12 +1337,19 @@
     AC_ARG_WITH(netmap_includes,
             [  --with-netmap-includes=DIR netmap include directory],
             [with_netmap_includes="$withval"],[with_netmap_includes=no])
+    AC_ARG_WITH(netmap_libraries,
+            [  --with-netmap-libraries=DIR netmap library directory],
+            [with_netmap_libraries="$withval"],[with_netmap_libraries=no])
 
     AS_IF([test "x$enable_netmap" = "xyes"], [
         AC_DEFINE([HAVE_NETMAP],[1],(NETMAP support enabled))
 
         if test "$with_netmap_includes" != "no"; then
             CPPFLAGS="${CPPFLAGS} -I${with_netmap_includes}"
+        fi
+
+        if test "$with_netmap_libraries" != "no"; then
+            LDFLAGS="${LDFLAGS} -L${with_netmap_libraries}"
         fi
 
         AC_CHECK_HEADER(net/netmap_user.h,,[AC_MSG_ERROR(net/netmap_user.h not found ...)],)


### PR DESCRIPTION
Based on #6646

`configure` accepts specification of non-standard library locations when using netmap. Use `--with-netmap-libraries=DIR`.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4482](https://redmine.openinfosecfoundation.org/issues/4882)

Describe changes:
- Added `--with-netmap-libraries`

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
