### PR TITLE
draft: Fix/dpdk-counters-v1 Suricata counters are not correctly set

### DIFF
--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -267,28 +267,36 @@ static inline void DPDKDumpCounters(DPDKThreadVars *ptv)
     int retval = rte_eth_stats_get(ptv->port_id, &eth_stats);
     if (unlikely(retval != 0)) {
         SCLogError(SC_ERR_STAT, "Failed to get stats for port id %d: %s", ptv->port_id,
-                strerror(-retval));
+                rte_strerror(-retval));
         return;
     }
-
-    uint64_t th_pkts = StatsGetLocalCounterValue(ptv->tv, ptv->capture_dpdk_packets);
-    StatsAddUI64(ptv->tv, ptv->capture_dpdk_packets, ptv->pkts - th_pkts);
-    SC_ATOMIC_ADD(ptv->livedev->pkts, ptv->pkts - th_pkts);
 
     /* Some NICs (e.g. Intel) do not support queue statistics and the drops can be fetched only on
      * the port level. Therefore setting it to the first worker to have at least continuous update
      * on the dropped packets. */
     if (ptv->queue_id == 0) {
-        StatsSetUI64(ptv->tv, ptv->capture_dpdk_rx_errs,
-                eth_stats.imissed + eth_stats.ierrors + eth_stats.rx_nombuf + ptv->pkts);
-        StatsSetUI64(ptv->tv, ptv->capture_dpdk_imissed, eth_stats.imissed);
-        StatsSetUI64(ptv->tv, ptv->capture_dpdk_rx_no_mbufs, eth_stats.rx_nombuf);
-        StatsSetUI64(ptv->tv, ptv->capture_dpdk_ierrors, eth_stats.ierrors);
-        StatsSetUI64(ptv->tv, ptv->capture_dpdk_tx_errs, eth_stats.oerrors);
-        SC_ATOMIC_SET(ptv->livedev->drop, eth_stats.imissed + eth_stats.ierrors +
-                                                  eth_stats.rx_nombuf + eth_stats.oerrors +
-                                                  ptv->pkts);
+        StatsAddUI64(ptv->tv, ptv->capture_dpdk_packets,
+                ptv->pkts + eth_stats.imissed + eth_stats.ierrors + eth_stats.rx_nombuf);
+        SC_ATOMIC_ADD(ptv->livedev->pkts,
+                ptv->pkts + eth_stats.imissed + eth_stats.ierrors + eth_stats.rx_nombuf);
+        StatsAddUI64(ptv->tv, ptv->capture_dpdk_rx_errs,
+                eth_stats.imissed + eth_stats.ierrors + eth_stats.rx_nombuf);
+        StatsAddUI64(ptv->tv, ptv->capture_dpdk_imissed, eth_stats.imissed);
+        StatsAddUI64(ptv->tv, ptv->capture_dpdk_rx_no_mbufs, eth_stats.rx_nombuf);
+        StatsAddUI64(ptv->tv, ptv->capture_dpdk_ierrors, eth_stats.ierrors);
+        StatsAddUI64(ptv->tv, ptv->capture_dpdk_tx_errs, eth_stats.oerrors);
+        SC_ATOMIC_ADD(ptv->livedev->drop,
+                eth_stats.imissed + eth_stats.ierrors + eth_stats.rx_nombuf + eth_stats.oerrors);
+
+        retval = rte_eth_stats_reset(ptv->port_id); // reset the dropped counters on the NIC
+        if (retval < 0)
+            SCLogError(SC_ERR_STAT, "Failed to reset stats for port id %d: %s", ptv->port_id,
+                    rte_strerror(-retval));
+    } else {
+        StatsAddUI64(ptv->tv, ptv->capture_dpdk_packets, ptv->pkts);
+        SC_ATOMIC_ADD(ptv->livedev->pkts, ptv->pkts);
     }
+    ptv->pkts = 0; // reset the thread's counter
 }
 
 static void DPDKReleasePacket(Packet *p)

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -505,38 +505,8 @@ fail:
  */
 static void ReceiveDPDKThreadExitStats(ThreadVars *tv, void *data)
 {
-    SCEnter();
-    int retval;
     DPDKThreadVars *ptv = (DPDKThreadVars *)data;
-
-    if (ptv->queue_id == 0) {
-        struct rte_eth_stats eth_stats;
-        char port_name[RTE_ETH_NAME_MAX_LEN];
-
-        retval = rte_eth_dev_get_name_by_port(ptv->port_id, port_name);
-        if (unlikely(retval != 0)) {
-            SCLogError(SC_ERR_STAT, "Failed to convert port id %d to the interface name: %s",
-                    ptv->port_id, strerror(-retval));
-            SCReturn;
-        }
-        retval = rte_eth_stats_get(ptv->port_id, &eth_stats);
-        if (unlikely(retval != 0)) {
-            SCLogError(SC_ERR_STAT, "Failed to get stats for interface %s: %s", port_name,
-                    strerror(-retval));
-            SCReturn;
-        }
-        SCLogPerf("Total RX stats of %s: packets %" PRIu64 " bytes: %" PRIu64 " missed: %" PRIu64
-                  " errors: %" PRIu64 " nombufs: %" PRIu64,
-                port_name, eth_stats.ipackets, eth_stats.ibytes, eth_stats.imissed,
-                eth_stats.ierrors, eth_stats.rx_nombuf);
-        if (ptv->copy_mode == DPDK_COPY_MODE_TAP || ptv->copy_mode == DPDK_COPY_MODE_IPS)
-            SCLogPerf("Total TX stats of %s: packets %" PRIu64 " bytes: %" PRIu64
-                      " errors: %" PRIu64,
-                    port_name, eth_stats.opackets, eth_stats.obytes, eth_stats.oerrors);
-    }
-
     DPDKDumpCounters(ptv);
-    SCLogPerf("(%s) received packets %" PRIu64, tv->name, ptv->pkts);
 }
 
 /**


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)


This PR does not have a Redmine ticket, rather addresses an issue found by @amaan-fmad in https://github.com/OISF/suricata/pull/6652/files#r765566286. I have revisited Suricata counters again and thought that resetting the helper counter in the thread (pkts) and drop counters on the NIC (e.g. `imissed`, `no_mbufs`) is probably the cleanest solution to get continuous increments. 

Describe changes:
- refactor the way counters are set
- since we are resetting the counters on the NIC, the final performance report at the very end of Suricata does not output correct stats (prints zeroed stats)
