### PR TITLE
Fuzz conf protodetect 4125 v1

### DIFF
--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -356,15 +356,7 @@ static uint16_t ENIPProbingParser(Flow *f, uint8_t direction,
     uint32_t option;
     uint16_t nbitems;
 
-    int ret = ByteExtractUint16(
-            &enip_len, BYTE_LITTLE_ENDIAN, sizeof(uint16_t), (const uint8_t *)(input + 2));
-    if (ret < 0) {
-        return ALPROTO_FAILED;
-    }
-    if (enip_len < sizeof(ENIPEncapHdr)) {
-        return ALPROTO_FAILED;
-    }
-    ret = ByteExtractUint32(
+    int ret = ByteExtractUint32(
             &status, BYTE_LITTLE_ENDIAN, sizeof(uint32_t), (const uint8_t *)(input + 8));
     if (ret < 0) {
         return ALPROTO_FAILED;
@@ -388,6 +380,11 @@ static uint16_t ENIPProbingParser(Flow *f, uint8_t direction,
     }
     ret = ByteExtractUint32(
             &option, BYTE_LITTLE_ENDIAN, sizeof(uint32_t), (const uint8_t *)(input + 20));
+    if (ret < 0) {
+        return ALPROTO_FAILED;
+    }
+    ret = ByteExtractUint16(
+            &enip_len, BYTE_LITTLE_ENDIAN, sizeof(uint16_t), (const uint8_t *)(input + 2));
     if (ret < 0) {
         return ALPROTO_FAILED;
     }

--- a/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
+++ b/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
@@ -10,12 +10,15 @@
 #include "flow-util.h"
 #include "app-layer-parser.h"
 #include "util-unittest-helper.h"
+#include "conf-yaml-loader.h"
 
 
 #define HEADER_LEN 6
 
 //rule of thumb constant, so as not to timeout target
 #define PROTO_DETECT_MAX_LEN 1024
+
+#include "confyaml.c"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 
@@ -37,6 +40,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         //global init
         InitGlobal();
         run_mode = RUNMODE_UNITTEST;
+        if (ConfYamlLoadString(configNoChecksum, strlen(configNoChecksum)) != 0) {
+            abort();
+        }
         MpmTableSetup();
         SpmTableSetup();
         AppLayerProtoDetectSetup();
@@ -60,14 +66,15 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     }
     alproto = AppLayerProtoDetectGetProto(
             alpd_tctx, f, data + HEADER_LEN, size - HEADER_LEN, f->proto, flags, &reverse);
-    if (alproto != ALPROTO_UNKNOWN && alproto != ALPROTO_FAILED && f->proto == IPPROTO_TCP &&
-            (data[0] & STREAM_MIDSTREAM) == 0) {
+    if (alproto != ALPROTO_UNKNOWN && alproto != ALPROTO_FAILED && f->proto == IPPROTO_TCP) {
         /* If we find a valid protocol at the start of a stream :
          * check that with smaller input
          * we find the same protocol or ALPROTO_UNKNOWN.
          * Otherwise, we have evasion with TCP splitting
          */
         for (size_t i = 0; i < size-HEADER_LEN && i < PROTO_DETECT_MAX_LEN; i++) {
+            // reset detection at each try cf probing_parser_toserver_alproto_masks
+            AppLayerProtoDetectReset(f);
             alproto2 = AppLayerProtoDetectGetProto(
                     alpd_tctx, f, data + HEADER_LEN, i, f->proto, flags, &reverse);
             if (alproto2 != ALPROTO_UNKNOWN && alproto2 != alproto) {

--- a/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
+++ b/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
@@ -12,7 +12,6 @@
 #include "util-unittest-helper.h"
 #include "conf-yaml-loader.h"
 
-
 #define HEADER_LEN 6
 
 //rule of thumb constant, so as not to timeout target


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4125

Describe changes:
- Improves fuzz target for protocol detection
- Fixes bug in ENIP probing parser