### PR TITLE
Update references to Suricata website - v1

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Contribution Agreement
 
 Before accepting your pull requests we need you or your organization to sign our contribution agreement.
 
-We do this to keep the ownership of Suricata in one hand: the Open Information Security Foundation. See https://suricata-ids.org/about/open-source/ and https://suricata-ids.org/about/contribution-agreement/
+We do this to keep the ownership of Suricata in one hand: the Open Information Security Foundation. See https://suricata.io/about/open-source/ and https://suricata.io/about/contribution-agreement/
 
 Contribution Process
 --------------------
@@ -34,5 +34,5 @@ On a high level, the steps are:
 Questions
 ---------
 
-If you have questions about contributing, please contact us via https://suricata-ids.org/support/
+If you have questions about contributing, please contact us via https://suricata.io/support/
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 Make sure these boxes are signed before submitting your Pull Request -- thank you.
 
 - [ ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
-- [ ] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
+- [ ] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
 - [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
 
 Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

--- a/README.md
+++ b/README.md
@@ -115,4 +115,4 @@ A: If you really think it is, we can discuss how to improve it. But don't come t
 
 __Q: do you require signing of a contributor license agreement?__
 
-A: Yes, we do this to keep the ownership of Suricata in one hand: the Open Information Security Foundation. See http://suricata-ids.org/about/open-source/ and http://suricata-ids.org/about/contribution-agreement/
+A: Yes, we do this to keep the ownership of Suricata in one hand: the Open Information Security Foundation. See http://suricata.io/about/open-source/ and http://suricata.io/about/contribution-agreement/

--- a/doc/AUTHORS
+++ b/doc/AUTHORS
@@ -1,5 +1,5 @@
 Team:
-https://suricata-ids.org/about/team/
+https://suricata.io/about/team/
 
 All contributors:
 https://www.ohloh.net/p/suricata-engine/contributors/summary

--- a/doc/NEWS
+++ b/doc/NEWS
@@ -1,1 +1,1 @@
-https://suricata-ids.org/news/
+https://suricata.io/news/

--- a/doc/TODO
+++ b/doc/TODO
@@ -1,3 +1,3 @@
 Plenty, and you're welcome to help!
 
-https://suricata-ids.org/participate/
+https://suricata.io/participate/

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2349,4 +2349,4 @@ States are allocated as follows: for each detect script a state is used per
 detect thread. For each output script, a single state is used. Keep in
 mind that a rule reload temporary doubles the states requirement.
 
-.. _deprecation policy: https://suricata-ids.org/about/deprecation-policy/
+.. _deprecation policy: https://suricata.io/about/deprecation-policy/

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -625,7 +625,7 @@ Pattern matcher settings
 
 The multi-pattern-matcher (MPM) is a part of the detection engine
 within Suricata that searches for multiple patterns at
-once. Often, signatures have one ore more patterns. Of each
+once. Often, signatures have one or more patterns. Of each
 signature, one pattern is used by the multi-pattern-matcher. That way
 Suricata can exclude many signatures from being examined, because a
 signature can only match when all its patterns match.
@@ -1466,7 +1466,7 @@ configuration (console, file, syslog) if not otherwise set.
           line option <cmdline-option-v>`.
 
 The ``default-log-level`` set in the configuration value can be
-overriden by the ``SC_LOG_LEVEL`` environment variable.
+overridden by the ``SC_LOG_LEVEL`` environment variable.
 
 Default Log Format
 ~~~~~~~~~~~~~~~~~~

--- a/doc/userguide/manpages/suricata.rst
+++ b/doc/userguide/manpages/suricata.rst
@@ -84,8 +84,8 @@ NOTES
 
 * Suricata Home Page
 
-    https://suricata-ids.org/
+    https://suricata.io/
 
 * Suricata Support Page
 
-    https://suricata-ids.org/support/
+    https://suricata.io/support/

--- a/doc/userguide/manpages/suricatactl-filestore.rst
+++ b/doc/userguide/manpages/suricatactl-filestore.rst
@@ -60,8 +60,8 @@ NOTES
 
 * Suricata Home Page
 
-    https://suricata-ids.org/
+    https://suricata.io/
 
 * Suricata Support Page
 
-    https://suricata-ids.org/support/
+    https://suricata.io/support/

--- a/doc/userguide/manpages/suricatactl.rst
+++ b/doc/userguide/manpages/suricatactl.rst
@@ -36,8 +36,8 @@ NOTES
 
 * Suricata Home Page
 
-    https://suricata-ids.org/
+    https://suricata.io/
 
 * Suricata Support Page
 
-    https://suricata-ids.org/support/
+    https://suricata.io/support/

--- a/doc/userguide/manpages/suricatasc.rst
+++ b/doc/userguide/manpages/suricatasc.rst
@@ -33,8 +33,8 @@ NOTES
 
 * Suricata Home Page
 
-    https://suricata-ids.org/
+    https://suricata.io/
 
 * Suricata Support Page
 
-    https://suricata-ids.org/support/
+    https://suricata.io/support/

--- a/doc/userguide/performance/analysis.rst
+++ b/doc/userguide/performance/analysis.rst
@@ -118,7 +118,7 @@ https://en.wikipedia.org/wiki/IEEE_802.1ad) most implementations only add
 inner one has different VLAN tags it will still end up in the same queue in
 **cluster_qm** mode. This was observed with the i40e driver up to 2.8.20 and
 the firmare version up to 7.00, feel free to report if newer versions have
-fixed this (see https://suricata-ids.org/support/).
+fixed this (see https://suricata.io/support/).
 
 
 If you want to use **tshark** to get an overview of the traffic direction use
@@ -172,7 +172,7 @@ fair amount of load should still be seen. If the load is still very high and
 drops are seen and the hardware should be capable to deal with such traffic
 loads you should deep dive if there is any specific traffic issue (see above)
 or report the performance issue so it can be investigated (see
-https://suricata-ids.org/support/).
+https://suricata.io/join-our-community/).
 
 Suricata also provides several specific traffic related signatures in the rules
 folder that could be enabled for testing to spot specific traffic issues. Those

--- a/doc/userguide/rules/bypass-keyword.rst
+++ b/doc/userguide/rules/bypass-keyword.rst
@@ -15,5 +15,5 @@ Bypass a flow on matching http traffic.
 
 Example::
 
-  alert http any any -> any any (content:"suricata-ids.org"; \
+  alert http any any -> any any (content:"suricata.io"; \
       http_host; bypass; sid:10001; rev:1;)

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -104,4 +104,4 @@ Removals
 - ``file-log``, the non-EVE JSON file log. Use EVE.files instead.
 - ``drop-log``, the non-EVE JSON drop log.
 
-See https://suricata-ids.org/about/deprecation-policy/
+See https://suricata.io/about/deprecation-policy/

--- a/python/setup.py
+++ b/python/setup.py
@@ -47,7 +47,7 @@ setup(
     version=version,
     author='OISF Developers, Eric Leblond',
     author_email='oisf-devel@lists.openinfosecfoundation.org, eric@regit.org',
-    url='https://www.suricata-ids.org/',
+    url='https://www.suricata.io/',
     packages=[
         "suricata",
         "suricata.config",


### PR DESCRIPTION
Many places were still referencing the old Suricata page. 
Used git grep with replace to update them. Checked that new links work. 
Left old references when they were only documentation examples (for
output or unittests, for instance).

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4915

Describe changes:
- replaced references to suricata-ids.org with suricata.io over several different pages, files and docs.
- fixed typos in userguide page about suricata.yaml