### PR TITLE
rust/dns: Ensure JSON object doesn't get leaked

### DIFF
--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -478,7 +478,7 @@ fn dns_log_json_answer(response: &DNSResponse, flags: u64) -> Json
     js.set_string("rcode", &dns_rcode_string(header.flags));
 
     if response.answers.len() > 0 {
-        let js_answers = Json::array();
+        let js_answers = if flags & LOG_FORMAT_DETAILED != 0 { Some(Json::array()) } else { None };
 
         // For grouped answers we use a HashMap keyed by the rrtype.
         let mut answer_types = HashMap::new();
@@ -526,12 +526,13 @@ fn dns_log_json_answer(response: &DNSResponse, flags: u64) -> Json
                 }
             }
 
-            if flags & LOG_FORMAT_DETAILED != 0 {
+            if let Some(js_answers) = &js_answers {
                 js_answers.array_append(dns_log_json_answer_detail(answer));
             }
         }
 
-        if flags & LOG_FORMAT_DETAILED != 0 {
+
+        if let Some(js_answers) = js_answers {
             js.set("answers", js_answers);
         }
 


### PR DESCRIPTION
Ensure js_answers isn't leaked when detailed logging is not in use. This
commit changes how js_answers allocation is performed. Previously, it
was allocated regardless of whether detailed logging was enabled. Now,
it's only allocated if detailed logging is enabled.

Ticket: #4901

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4901](https://redmine.openinfosecfoundation.org/issues/4901)

Describe changes:
- Allocate js_answers iff detailed logging is configured


#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
