### PR TITLE
datasets: free old data when reusing a hash container

### DIFF
--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -753,6 +753,9 @@ static THashData *THashGetUsed(THashTableContext *ctx)
         h->prev = NULL;
         HRLOCK_UNLOCK(hb);
 
+        if (h->data != NULL) {
+            ctx->config.DataFree(h->data);
+        }
         SCMutexUnlock(&h->m);
 
         (void) SC_ATOMIC_ADD(ctx->prune_idx, (ctx->config.hash_size - cnt));


### PR DESCRIPTION
(cherry picked from commit 017c038bcba9ebe279e470cc48e1f440dfa0ef7d)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4878](https://redmine.openinfosecfoundation.org/issues/4878)

Describe changes:
- Cherry-pick fix from issue 3879

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
