### PR TITLE
rust: msrv, library naming - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2239,10 +2239,6 @@ fi
     AC_MSG_RESULT(yes)
 
     RUST_FEATURES=""
-    AS_VERSION_COMPARE([$rustc_version], [1.38.0],
-        [],
-	[RUST_FEATURES="$RUST_FEATURES function-macro"],
-	[RUST_FEATURES="$RUST_FEATURES function-macro"])
 
     rust_vendor_comment="# "
     have_rust_vendor="no"

--- a/configure.ac
+++ b/configure.ac
@@ -2223,7 +2223,7 @@ fi
     cargo_version_output=$($CARGO --version)
     cargo_version=$(echo "$cargo_version_output" | sed 's/^.*[[^0-9]]\([[0-9]]*\.[[0-9]]*\.[[0-9]]*\).*$/\1/')
 
-    MIN_RUSTC_VERSION="1.34.2"
+    MIN_RUSTC_VERSION="1.41.1"
     AC_MSG_CHECKING(for Rust version $MIN_RUSTC_VERSION or newer)
     AS_VERSION_COMPARE([$rustc_version], [$MIN_RUSTC_VERSION],
         [

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -20,7 +20,6 @@ lua_int8 = ["lua"]
 strict = []
 debug = []
 debug-validate = []
-function-macro = []
 
 [dependencies]
 nom = "~5.1.2"

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -9,7 +9,7 @@ members = [".", "./derive"]
 [lib]
 crate-type = ["staticlib", "rlib"]
 path = "@e_rustdir@/src/lib.rs"
-name = "suricata_rust"
+name = "suricata"
 
 [profile.release]
 debug = true

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -45,8 +45,12 @@ else
 		$(CARGO) build $(RELEASE) $(NIGHTLY_ARGS) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)
 endif
-	if test -e $(RUST_SURICATA_LIBDIR)/suricata_rust.lib; then \
-		cp $(RUST_SURICATA_LIBDIR)/suricata_rust.lib \
+	if test -e $(RUST_SURICATA_LIBDIR)/suricata.lib; then \
+		cp -a $(RUST_SURICATA_LIBDIR)/suricata.lib \
+			$(RUST_SURICATA_LIBDIR)/${RUST_SURICATA_LIBNAME}; \
+	fi
+	if test -e $(RUST_SURICATA_LIBDIR)/libsuricata.a; then \
+		cp -a $(RUST_SURICATA_LIBDIR)/libsuricata.a \
 			$(RUST_SURICATA_LIBDIR)/${RUST_SURICATA_LIBNAME}; \
 	fi
 	$(MAKE) gen/rust-bindings.h

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -25,6 +25,10 @@ use std::os::raw::{c_void,c_char,c_int};
 use crate::core::SC;
 use std::ffi::CStr;
 
+// Make the AppLayerEvent derive macro available to users importing
+// AppLayerEvent from this module.
+pub use suricata_derive::AppLayerEvent;
+
 #[repr(C)]
 #[derive(Default, Debug,PartialEq)]
 pub struct AppLayerTxConfig {

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -84,7 +84,6 @@ pub fn sclog(level: Level, file: &str, line: u32, function: &str,
 // This macro has been borrowed from https://github.com/popzxc/stdext-rs, which
 // is released under the MIT license as there is currently no macro in Rust
 // to provide the function name.
-#[cfg(feature = "function-macro")]
 #[macro_export(local_inner_macros)]
 macro_rules!function {
     () => {{
@@ -96,14 +95,6 @@ macro_rules!function {
          let name = type_name_of(__f);
          &name[..name.len() - 5]
     }}
-}
-
-// Rust versions less than 1.38 can not use the above macro, so keep the old
-// macro around for a while.
-#[cfg(not(feature = "function-macro"))]
-#[macro_export(local_inner_macros)]
-macro_rules!function {
-    () => {{ "<rust>" }}
 }
 
 #[macro_export]


### PR DESCRIPTION
First update MSRV to 1.41.1 as done in 6.0.x.

Second, updating Rust library naming to provide a better experience for users
of the Rust library (including plugin users). Also updates the AppLayerEvent
derive macro to work internally for Suricata as well as library users.
