### PR TITLE
output/json: Eliminate dangling XFF reference

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -585,9 +585,9 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                 }
                 else if (xff_cfg->flags & XFF_OVERWRITE) {
                     if (p->flowflags & FLOW_PKT_TOCLIENT) {
-                        json_object_set(js, "dest_ip", json_string(buffer));
+                        json_object_set_new(js, "dest_ip", json_string(buffer));
                     } else {
-                        json_object_set(js, "src_ip", json_string(buffer));
+                        json_object_set_new(js, "src_ip", json_string(buffer));
                     }
                 }
             }

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -234,9 +234,9 @@ json_t *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
             }
             else if (xff_cfg->flags & XFF_OVERWRITE) {
                 if (p->flowflags & FLOW_PKT_TOCLIENT) {
-                    json_object_set(js, "dest_ip", json_string(buffer));
+                    json_object_set_new(js, "dest_ip", json_string(buffer));
                 } else {
-                    json_object_set(js, "src_ip", json_string(buffer));
+                    json_object_set_new(js, "src_ip", json_string(buffer));
                 }
             }
         }

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -545,9 +545,9 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
             }
             else if (xff_cfg->flags & XFF_OVERWRITE) {
                 if (p->flowflags & FLOW_PKT_TOCLIENT) {
-                    json_object_set(js, "dest_ip", json_string(buffer));
+                    json_object_set_new(js, "dest_ip", json_string(buffer));
                 } else {
-                    json_object_set(js, "src_ip", json_string(buffer));
+                    json_object_set_new(js, "src_ip", json_string(buffer));
                 }
             }
         }


### PR DESCRIPTION
This commit eliminates a dangling reference caused by the use of
json_object_set. This function adds a reference to the final parameter
-- in this case the object returned by json_string() whereas
json_object_set_new doesn't add the additional reference to the
final parameter.

Describe changes:
- Use `json_object_set_new` instead of `json_object_new`.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
