### PR TITLE
dns: z bit transactions and logging - v1

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -436,6 +436,7 @@ Outline of fields seen in the different kinds of DNS events:
 * "tc": Indicating in case of DNS answer flag, Truncation flag (ex: true if set)
 * "rd": Indicating in case of DNS answer flag, Recursion Desired flag (ex: true if set)
 * "ra": Indicating in case of DNS answer flag, Recursion Available flag (ex: true if set)
+* "z": Indicating in case of DNS answer flag, Reserved bit  (ex: true if set)
 * "rcode": (ex: NOERROR)
 * "rrname": Resource Record Name (ex: a domain name)
 * "rrtype": Resource Record Type (ex: A, AAAA, NS, PTR)

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -393,15 +393,17 @@ impl DNSState {
                     return false;
                 }
 
-                if request.header.flags & 0x0040 != 0 {
-                    SCLogDebug!("Z-flag set on DNS response");
-                    self.set_event(DNSEvent::ZFlagSet);
-                    return false;
-                }
+                let z_flag = request.header.flags & 0x0040 != 0;
 
                 let mut tx = self.new_tx();
                 tx.request = Some(request);
                 self.transactions.push(tx);
+
+                if z_flag {
+                    SCLogDebug!("Z-flag set on DNS response");
+                    self.set_event(DNSEvent::ZFlagSet);
+                }
+
                 return true;
             }
             Err(Err::Incomplete(_)) => {
@@ -430,11 +432,7 @@ impl DNSState {
                     self.set_event(DNSEvent::NotResponse);
                 }
 
-                if response.header.flags & 0x0040 != 0 {
-                    SCLogDebug!("Z-flag set on DNS response");
-                    self.set_event(DNSEvent::ZFlagSet);
-                    return false;
-                }
+                let z_flag = response.header.flags & 0x0040 != 0;
 
                 let mut tx = self.new_tx();
                 if let Some(ref mut config) = &mut self.config {
@@ -444,6 +442,12 @@ impl DNSState {
                 }
                 tx.response = Some(response);
                 self.transactions.push(tx);
+
+                if z_flag {
+                    SCLogDebug!("Z-flag set on DNS response");
+                    self.set_event(DNSEvent::ZFlagSet);
+                }
+
                 return true;
             }
             Err(Err::Incomplete(_)) => {

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -629,6 +629,9 @@ fn dns_log_query(tx: &mut DNSTransaction,
                 jb.set_string_from_bytes("rrname", &query.name)?;
                 jb.set_string("rrtype", &dns_rrtype_string(query.rrtype))?;
                 jb.set_uint("tx_id", tx.id - 1)?;
+                if request.header.flags & 0x0040 != 0 {
+                    jb.set_bool("z", true)?;
+                }
                 return Ok(true);
             }
         }

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -503,6 +503,9 @@ fn dns_log_json_answer(js: &mut JsonBuilder, response: &DNSResponse, flags: u64)
     if header.flags & 0x0080 != 0 {
         js.set_bool("ra", true)?;
     }
+    if header.flags & 0x0040 != 0 {
+        js.set_bool("z", true)?;
+    }
 
     for query in &response.queries {
         js.set_string_from_bytes("rrname", &query.name)?;
@@ -704,6 +707,9 @@ fn dns_log_json_answer_v1(header: &DNSHeader, answer: &DNSAnswerEntry)
     }
     if header.flags & 0x0080 != 0 {
         js.set_bool("ra", true)?;
+    }
+    if header.flags & 0x0040 != 0 {
+        js.set_bool("z", true)?;
     }
     js.set_string("rcode", &dns_rcode_string(header.flags))?;
     js.set_string_from_bytes("rrname", &answer.name)?;

--- a/src/detect-dns-query.c
+++ b/src/detect-dns-query.c
@@ -829,8 +829,8 @@ static int DetectDnsQueryTest05(void)
     FLOWLOCK_WRLOCK(&f);
     r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_DNS, STREAM_TOCLIENT,
                             buf2, sizeof(buf2));
-    if (r != -1) {
-        printf("toserver client 1 returned %" PRId32 ", expected -1\n", r);
+    if (r != 0) {
+        printf("toserver client 1 returned %" PRId32 ", expected 0\n", r);
         FLOWLOCK_UNLOCK(&f);
         FAIL;
     }


### PR DESCRIPTION
- Create DNS transaction even if z flag is set.
- Log z flag.

Ticket: 4515 4924

Pulls in PR: https://github.com/OISF/suricata/pull/6187

suricata-verify-pr:617