### PR TITLE
nfs2: add unittests for nom7 parsers - v1

### DIFF
--- a/rust/src/nfs/nfs2_records.rs
+++ b/rust/src/nfs/nfs2_records.rs
@@ -96,3 +96,211 @@ pub fn parse_nfs2_attribs(i: &[u8]) -> IResult<&[u8], Nfs2Attributes> {
     let attrs = Nfs2Attributes { atype, asize };
     Ok((i, attrs))
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::nfs::nfs2_records::*;
+    use nom7::bytes::streaming::take;
+    use nom7::IResult;
+
+    #[test]
+    fn test_nfs2_handle() {
+
+        // file_handle bytes
+        let buf: &[u8] = &[
+            0x00, 0x10, 0x10, 0x85, 0x00, 0x00, 0x03, 0xe7,
+            0x00, 0x0a, 0x00, 0x00, 0x00, 0x00, 0xb2, 0x5a,
+            0x00, 0x00, 0x00, 0x29, 0x00, 0x0a, 0x00, 0x00,
+            0x00, 0x00, 0xb2, 0x5a, 0x00, 0x00, 0x00, 0x29
+        ];
+
+        let result = parse_nfs2_handle(buf);
+        match result {
+            Ok((r, res)) => {
+                assert_eq!(r.len(), 0);
+                assert_eq!(res.value, buf);
+            }
+            Err(error) => { panic!("Parsing nfs2_handle failed: {:?}", error); }
+        }
+    }
+
+    #[test]
+    fn test_nfs2_request_lookup() {
+
+        // packet_bytes
+        let buf: &[u8] = &[
+
+        // [file_handle]
+            0x00, 0x10, 0x10, 0x85, 0x00, 0x00, 0x03, 0xe7,
+            0x00, 0x0a, 0x00, 0x00, 0x00, 0x00, 0xb2, 0x5a,
+            0x00, 0x00, 0x00, 0x29, 0x00, 0x0a, 0x00, 0x00,
+            0x00, 0x00, 0xb2, 0x5a, 0x00, 0x00, 0x00, 0x29,
+
+        // [name]
+        // name_len
+            0x00, 0x00, 0x00, 0x02,
+
+        // name_contents: (am)
+            0x61, 0x6d,
+
+        // _name_padding
+            0x00, 0x00,
+        ];
+
+        let (_, handle) = parse_nfs2_handle(buf).expect("Parsing nfs2_handle failed!");
+
+        let result = parse_nfs2_request_lookup(buf);
+        match result {
+            Ok((r, request)) => {
+                assert_eq!(r.len(), 0);
+                assert_eq!(request.handle, handle);
+                assert_eq!(request.name_vec, b"am".to_vec());
+            }
+            Err(error) => { panic!("Parsing failed: {:?}", error); }
+        }
+    }
+
+    #[test]
+    fn test_nfs2_request_read() {
+
+        // packet_bytes
+        let buf: &[u8] = &[
+
+        // [file_handle]
+            0x00, 0x10, 0x10, 0x85, 0x00, 0x00, 0x03, 0xe7,
+            0x00, 0x0a, 0x00, 0x00, 0x00, 0x00, 0xb2, 0x5d,
+            0x00, 0x00, 0x00, 0x2a, 0x00, 0x0a, 0x00, 0x00,
+            0x00, 0x00, 0xb2, 0x5a, 0x00, 0x00, 0x00, 0x29,
+
+        // offset
+            0x00, 0x00, 0x00, 0x00,
+        // count
+            0x00, 0x00, 0x20, 0x00,
+        // total count
+            0x00, 0x00, 0x20, 0x00
+        ];
+
+        let (_, handle) = parse_nfs2_handle(buf).expect("Parsing nfs2_handle failed!");
+
+        let result = parse_nfs2_request_read(buf);
+        match result {
+            Ok((r, request)) => {
+                assert_eq!(r.len(), 4);
+                assert_eq!(request.handle, handle);
+                assert_eq!(request.offset, 0);
+            }
+            Err(error) => { panic!("Parsing failed: {:?}", error); }
+        }
+    }
+
+    #[test]
+    fn test_nfs2_reply_read() {
+
+        let buf: &[u8] = &[
+
+        // Status: NFS_OK - (0)
+            0x00, 0x00, 0x00, 0x00,
+
+        // attr_blob
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x81, 0xa4,
+            0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x0b,
+            0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x02, 0x00, 0x10, 0x10, 0x85,
+            0x00, 0x00, 0xb2, 0x5d, 0x38, 0x47, 0x75, 0xea,
+            0x00, 0x0b, 0x71, 0xb0, 0x38, 0x47, 0x71, 0xc4,
+            0x00, 0x08, 0xb2, 0x90, 0x38, 0x47, 0x75, 0xea,
+            0x00, 0x09, 0x00, 0xb0,
+
+        // data_len: (11)
+            0x00, 0x00, 0x00, 0x0b,
+
+        // data_contents: ("the b file")
+            0x74, 0x68, 0x65, 0x20,
+            0x62, 0x20, 0x66, 0x69, 0x6c, 0x65, 0x0a,
+
+        // _data_padding: parsed as part of data_contents
+            0x00,
+        ];
+
+        // since NfsReplyRead { data } is likely partial, parse/extract it here?
+        // then assert against it
+        fn extract_data(input: &[u8]) -> &[u8]  {
+
+            // strip packet_bytes up to data_contents
+            let i: IResult<&[u8], &[u8]> = take(76_usize)(input);
+            match i {
+                Ok((remainder, _input)) => {
+                        remainder
+                }
+                Err(error) => { panic!("extracting data field failed: {:?}", error); }
+            }
+        }
+
+        let expected_data = extract_data(buf);
+
+        let result = parse_nfs2_reply_read(buf);
+        match result {
+            Ok((r, response)) => {
+                assert_eq!(r.len(), 0);
+                assert_eq!(response.status, 0);
+                assert_eq!(response.attr_follows, 1);
+                assert_eq!(response.attr_blob.len(), 68);
+                assert_eq!(response.count, response.data_len);
+                assert_eq!(response.eof, false);
+                assert_eq!(response.data_len, 11);
+
+                // different assertions for data
+                assert_eq!(response.data, "the b file\n\0".as_bytes());
+                assert_eq!(response.data, expected_data);
+                assert_eq!(response.data.len(), 12);
+            }
+            Err(error) => { panic!("Parsing failed: {:?}", error); }
+        }
+    }
+
+    #[test]
+    fn test_nfs2_attributes() {
+
+        // packet_bytes
+        let buf: &[u8] = &[
+
+        // Type: Regular File (1)
+            0x00, 0x00, 0x00, 0x01,
+
+        // Attributes
+        // _blob1
+            0x00, 0x00, 0x81, 0xa4,
+            0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x01,
+
+        // Size: (0)
+            0x00, 0x00, 0x00, 0x00,
+
+        // _blob2
+            0x00, 0x00, 0x40, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x10, 0x10, 0x85,
+            0x00, 0x00, 0xa3, 0xe7,
+            0x38, 0x47, 0x75, 0xea,
+            0x00, 0x08, 0x64, 0x70,
+            0x38, 0x47, 0x75, 0xea,
+            0x00, 0x08, 0x64, 0x70,
+            0x38, 0x47, 0x75, 0xea,
+            0x00, 0x08, 0x64, 0x70,
+        ];
+
+        let result = parse_nfs2_attribs(buf);
+        match result {
+            Ok((r, res)) => {
+                assert_eq!(r.len(), 0);
+                assert_eq!(res.atype, 1);
+                assert_eq!(res.asize, 0);
+            }
+
+            Err(error) => { panic!("failed! {:?}", error); }
+        }
+    }
+}


### PR DESCRIPTION
partially closes task #4714

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [#4714](https://redmine.openinfosecfoundation.org/issues/4714)

Describe changes:
- add unittests to `nfs2_records` nom7 parsers