### PR TITLE
reference: Enable validation checking in test mode

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2059,7 +2059,8 @@ static DetectEngineCtx *DetectEngineCtxInitReal(enum DetectEngineType type, cons
     (void)SRepInit(de_ctx);
 
     SCClassConfLoadClassficationConfigFile(de_ctx, NULL);
-    SCRConfLoadReferenceConfigFile(de_ctx, NULL);
+    if (SCRConfLoadReferenceConfigFile(de_ctx, NULL) < 0)
+        goto error;
 
     if (ActionInitConfig() < 0) {
         goto error;

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2472,7 +2472,7 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
     }
     if (DetectPortParse(de_ctx, &de_ctx->udp_whitelist, ports) != 0) {
         SCLogWarning(SC_ERR_INVALID_YAML_CONF_ENTRY, "'%s' is not a valid value "
-                "forr detect.grouping.udp-whitelist", ports);
+                "for detect.grouping.udp-whitelist", ports);
     }
     for (x = de_ctx->udp_whitelist; x != NULL;  x = x->next) {
         if (x->port != x->port2) {

--- a/src/util-reference-config.c
+++ b/src/util-reference-config.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2019 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -319,7 +319,7 @@ static int SCRConfIsLineBlankOrComment(char *line)
  *
  * \param de_ctx Pointer to the Detection Engine Context.
  */
-static void SCRConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
+static int SCRConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
 {
     char line[1024];
     uint8_t i = 1;
@@ -328,7 +328,10 @@ static void SCRConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
         if (SCRConfIsLineBlankOrComment(line))
             continue;
 
-        SCRConfAddReference(de_ctx, line);
+        if (SCRConfAddReference(de_ctx, line) != 0)
+            if (RunmodeGetCurrent() == RUNMODE_CONF_TEST) {
+                return -1;
+            }
         i++;
     }
 
@@ -336,7 +339,7 @@ static void SCRConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
     SCLogInfo("Added \"%d\" reference types from the reference.config file",
               de_ctx->reference_conf_ht->count);
 #endif /* UNITTESTS */
-    return;
+    return 0;
 }
 
 /**
@@ -501,10 +504,10 @@ int SCRConfLoadReferenceConfigFile(DetectEngineCtx *de_ctx, FILE *fd)
         return -1;
     }
 
-    SCRConfParseFile(de_ctx, fd);
+    int rc = SCRConfParseFile(de_ctx, fd);
     SCRConfDeInitLocalResources(de_ctx, fd);
 
-    return 0;
+    return rc;
 }
 
 /**


### PR DESCRIPTION
This PR modifies suricata to fail in test mode iff `reference.config` is improperly formatted. In non-test mode, an improperly formatted `reference.config` file will not stop suricata and a log message will be displayed.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4659](https://redmine.openinfosecfoundation.org/issues/4659)

Describe changes:
- Raise an error if reference.config parsing fails in test mode.

suricata-verify-pr: 628
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
