### PR TITLE
App maxtx 4530 v6

### DIFF
--- a/rules/http2-events.rules
+++ b/rules/http2-events.rules
@@ -16,3 +16,4 @@ alert http2 any any -> any any (msg:"SURICATA HTTP2 stream identifier reuse"; fl
 alert http2 any any -> any any (msg:"SURICATA HTTP2 invalid HTTP1 settings during upgrade"; flow:established; app-layer-event:http2.invalid_http1_settings; classtype:protocol-command-decode; sid:2290008; rev:1;)
 alert http2 any any -> any any (msg:"SURICATA HTTP2 failed decompression"; flow:established; app-layer-event:http2.failed_decompression; classtype:protocol-command-decode; sid:2290009; rev:1;)
 alert http2 any any -> any any (msg:"SURICATA HTTP2 invalid range header"; flow:established; app-layer-event:http2.invalid_range; classtype:protocol-command-decode; sid:2290010; rev:1;)
+alert http2 any any -> any any (msg:"SURICATA HTTP2 too many streams"; flow:established; app-layer-event:http2.too_many_streams; classtype:protocol-command-decode; sid:2290011; rev:1;)

--- a/rules/mqtt-events.rules
+++ b/rules/mqtt-events.rules
@@ -13,3 +13,4 @@ alert mqtt any any -> any any (msg:"SURICATA MQTT message seen before CONNECT/CO
 alert mqtt any any -> any any (msg:"SURICATA MQTT invalid QOS level"; app-layer-event:mqtt.invalid_qos_level; classtype:protocol-command-decode; sid:2229006; rev:1;)
 alert mqtt any any -> any any (msg:"SURICATA MQTT missing message ID"; app-layer-event:mqtt.missing_msg_id; classtype:protocol-command-decode; sid:2229007; rev:1;)
 alert mqtt any any -> any any (msg:"SURICATA MQTT unassigned message type (0 or >15)"; app-layer-event:mqtt.unassigned_msg_type; classtype:protocol-command-decode; sid:2229008; rev:1;)
+alert mqtt any any -> any any (msg:"SURICATA MQTT too many transactions"; app-layer-event:mqtt.too_many_transactions; classtype:protocol-command-decode; sid:2229009; rev:1;)

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -58,8 +58,9 @@ const HTTP2_FRAME_GOAWAY_LEN: usize = 4;
 const HTTP2_FRAME_RSTSTREAM_LEN: usize = 4;
 const HTTP2_FRAME_PRIORITY_LEN: usize = 5;
 const HTTP2_FRAME_WINDOWUPDATE_LEN: usize = 4;
-//TODO make this configurable
+//TODO make these configurable
 pub const HTTP2_MAX_TABLESIZE: u32 = 0x10000; // 65536
+pub const HTTP2_MAX_STREAMS: usize = 0x1000; // 4096
 
 #[repr(u8)]
 #[derive(Copy, Clone, PartialOrd, PartialEq, Debug)]
@@ -110,6 +111,8 @@ pub enum HTTP2TransactionState {
     HTTP2StateClosed = 7,
     //not a RFC-defined state, used for stream 0 frames appyling to the global connection
     HTTP2StateGlobal = 8,
+    //not a RFC-defined state, dropping this old tx because we have too many
+    HTTP2StateTodrop = 9,
 }
 
 #[derive(Debug)]
@@ -366,6 +369,7 @@ pub enum HTTP2Event {
     InvalidHTTP1Settings,
     FailedDecompression,
     InvalidRange,
+    TooManyStreams,
 }
 
 pub struct HTTP2DynTable {
@@ -570,6 +574,18 @@ impl HTTP2State {
             tx.tx_id = self.tx_id;
             tx.stream_id = sid;
             tx.state = HTTP2TransactionState::HTTP2StateOpen;
+            // do not use SETTINGS_MAX_CONCURRENT_STREAMS as it can grow too much
+            if self.transactions.len() > HTTP2_MAX_STREAMS {
+                // set at least one another transaction to the drop state
+                for tx_old in &mut self.transactions {
+                    if tx_old.state != HTTP2TransactionState::HTTP2StateTodrop {
+                        // use a distinct state, even if we do not log it
+                        tx_old.set_event(HTTP2Event::TooManyStreams);
+                        tx_old.state = HTTP2TransactionState::HTTP2StateTodrop;
+                        break;
+                    }
+                }
+            }
             self.transactions.push(tx);
             return self.transactions.last_mut().unwrap();
         }

--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -446,7 +446,7 @@ fn http2_parse_headers_block_literal_incindex<'a>(
                 //in case of overflow, best effort is to keep first headers
                 if dyn_headers.overflow > 0 {
                     if dyn_headers.overflow == 1 {
-                        if dyn_headers.current_size <= (HTTP2_MAX_TABLESIZE as usize) {
+                        if dyn_headers.current_size <= (unsafe { HTTP2_MAX_TABLESIZE } as usize) {
                             //overflow had not yet happened
                             dyn_headers.table.push(headcopy);
                         } else if dyn_headers.current_size > dyn_headers.max_size {

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -59,6 +59,9 @@ int LLVMFuzzerInitialize(int *argc, char ***argv)
     return 0;
 }
 
+// arbitrary value
+#define ALPROTO_MAXTX 4096
+
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     Flow * f;
@@ -166,6 +169,27 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             }
 
             AppLayerParserTransactionsCleanup(f);
+
+            const uint64_t total_txs = AppLayerParserGetTxCnt(f, f->alstate);
+            uint64_t min = 0;
+            AppLayerGetTxIterState state;
+            memset(&state, 0, sizeof(state));
+            uint64_t nbtx = 0;
+            AppLayerGetTxIteratorFunc IterFunc = AppLayerGetTxIterator(f->proto, f->alproto);
+            while (1) {
+                AppLayerGetTxIterTuple ires =
+                        IterFunc(f->proto, f->alproto, f->alstate, min, total_txs, &state);
+                if (ires.tx_ptr == NULL)
+                    break;
+                min = ires.tx_id;
+                if (nbtx > ALPROTO_MAXTX) {
+                    printf("Too many open transactions for protocol %s\n",
+                            AppProtoToString(f->alproto));
+                    printf("Assertion failure: %s\n", AppProtoToString(f->alproto));
+                    fflush(stdout);
+                    abort();
+                }
+            }
         }
         alsize -= alnext - albuffer + 4;
         albuffer = alnext + 4;

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -117,6 +117,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         f->alproto = data[0];
     }
 
+    FLOWLOCK_WRLOCK(f);
     /*
      * We want to fuzz multiple calls to AppLayerParserParse
      * because some parts of the code are only reached after
@@ -163,6 +164,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
                 alsize = 0;
                 break;
             }
+
+            AppLayerParserTransactionsCleanup(f);
         }
         alsize -= alnext - albuffer + 4;
         albuffer = alnext + 4;
@@ -191,6 +194,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         free(isolatedBuffer);
     }
 
+    FLOWLOCK_UNLOCK(f);
     FlowFree(f);
 
     return 0;

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -170,24 +170,27 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
             AppLayerParserTransactionsCleanup(f);
 
-            const uint64_t total_txs = AppLayerParserGetTxCnt(f, f->alstate);
-            uint64_t min = 0;
-            AppLayerGetTxIterState state;
-            memset(&state, 0, sizeof(state));
-            uint64_t nbtx = 0;
-            AppLayerGetTxIteratorFunc IterFunc = AppLayerGetTxIterator(f->proto, f->alproto);
-            while (1) {
-                AppLayerGetTxIterTuple ires =
-                        IterFunc(f->proto, f->alproto, f->alstate, min, total_txs, &state);
-                if (ires.tx_ptr == NULL)
-                    break;
-                min = ires.tx_id;
-                if (nbtx > ALPROTO_MAXTX) {
-                    printf("Too many open transactions for protocol %s\n",
-                            AppProtoToString(f->alproto));
-                    printf("Assertion failure: %s\n", AppProtoToString(f->alproto));
-                    fflush(stdout);
-                    abort();
+            if (f->alstate && f->alparser) {
+                // check if we have too many open transactions
+                const uint64_t total_txs = AppLayerParserGetTxCnt(f, f->alstate);
+                uint64_t min = 0;
+                AppLayerGetTxIterState state;
+                memset(&state, 0, sizeof(state));
+                uint64_t nbtx = 0;
+                AppLayerGetTxIteratorFunc IterFunc = AppLayerGetTxIterator(f->proto, f->alproto);
+                while (1) {
+                    AppLayerGetTxIterTuple ires =
+                            IterFunc(f->proto, f->alproto, f->alstate, min, total_txs, &state);
+                    if (ires.tx_ptr == NULL)
+                        break;
+                    min = ires.tx_id;
+                    if (nbtx > ALPROTO_MAXTX) {
+                        printf("Too many open transactions for protocol %s\n",
+                                AppProtoToString(f->alproto));
+                        printf("Assertion failure: %s\n", AppProtoToString(f->alproto));
+                        fflush(stdout);
+                        abort();
+                    }
                 }
             }
         }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -819,6 +819,10 @@ app-layer:
       #hassh: yes
     http2:
       enabled: yes
+      # Maximum number of live HTTP2 streams in a flow
+      #max-streams: 4096
+      # Maximum headers table size
+      #max-table-size: 65536
     smtp:
       enabled: yes
       raw-extraction: no


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4530

Describe changes:
- limits the number of active transactions per flow for HTTP2 and MQTT
- fixes MQTT transaction completion

This is to avoid DOS by quadratic complexity for protocols looping over the whole list of transactions looking for a
specific transation with an identifier, so that a new PDU gets processed within that transaction.

There may be other protocols with this problem (like Modbus)

Replaces #6661 with 
- adding an assertion in the fuzz target to find which protocols can assign too many transactions
- making the maxtx configurable for HTTP2
- making on the way the maximum headers table size of HTTP2 configurable as well