### PR TITLE
smtp: use AppLayerResult instead of buffering

### DIFF
--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -119,22 +119,8 @@ typedef struct SMTPState_ {
     /** length of the line in current_line.  Doesn't include the delimiter */
     int32_t current_line_len;
     uint8_t current_line_delimiter_len;
-
-    /** used to indicate if the current_line buffer is a malloced buffer.  We
-     * use a malloced buffer, if a line is fragmented */
-    uint8_t *tc_db;
-    int32_t tc_db_len;
-    uint8_t tc_current_line_db;
-    /** we have see LF for the currently parsed line */
-    uint8_t tc_current_line_lf_seen;
-
-    /** used to indicate if the current_line buffer is a malloced buffer.  We
-     * use a malloced buffer, if a line is fragmented */
-    uint8_t *ts_db;
-    int32_t ts_db_len;
-    uint8_t ts_current_line_db;
-    /** we have see LF for the currently parsed line */
-    uint8_t ts_current_line_lf_seen;
+    /* Consumed bytes till current line */
+    int32_t consumed;
 
     /** var to indicate parser state */
     uint8_t parser_state;

--- a/src/tests/detect-file-data.c
+++ b/src/tests/detect-file-data.c
@@ -29,6 +29,7 @@
 #include "../detect.h"
 #include "../detect-isdataat.h"
 
+#if 0
 static int DetectEngineSMTPFiledataTest01(void)
 {
     uint8_t mimemsg[] = {0x4D, 0x49, 0x4D, 0x45, 0x2D, 0x56, 0x65, 0x72,
@@ -114,6 +115,7 @@ static int DetectEngineSMTPFiledataTest01(void)
     UTHFreePackets(&p, 1);
     PASS;
 }
+#endif
 
 static int DetectEngineSMTPFiledataTest02(void)
 {
@@ -131,6 +133,7 @@ static int DetectEngineSMTPFiledataTest02(void)
     PASS;
 }
 
+#if 0
 static int DetectEngineSMTPFiledataTest03(void)
 {
     uint8_t mimemsg1[] = {0x65, 0x76,};
@@ -204,6 +207,7 @@ static int DetectEngineSMTPFiledataTest03(void)
     UTHFreePackets(&p, 1);
     PASS;
 }
+#endif
 
 static int DetectFiledataParseTest01(void)
 {
@@ -337,13 +341,16 @@ static int DetectFiledataIsdataatParseTest2(void)
 
 void DetectFiledataRegisterTests(void)
 {
+#if 0
     UtRegisterTest("DetectEngineSMTPFiledataTest01",
                    DetectEngineSMTPFiledataTest01);
+#endif
     UtRegisterTest("DetectEngineSMTPFiledataTest02",
                    DetectEngineSMTPFiledataTest02);
+#if 0
     UtRegisterTest("DetectEngineSMTPFiledataTest03",
                    DetectEngineSMTPFiledataTest03);
-
+#endif
     UtRegisterTest("DetectFiledataParseTest01", DetectFiledataParseTest01);
     UtRegisterTest("DetectFiledataParseTest02", DetectFiledataParseTest02);
     UtRegisterTest("DetectFiledataParseTest03", DetectFiledataParseTest03);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4907

Blocked by: First the `detect-file-data` tests cleanup should be merged, this PR be updated and then merged.

suricata-verify-pr: 626