### PR TITLE
suricatasc: Handle incomplete/empty recv values

### DIFF
--- a/python/suricata/sc/suricatasc.py
+++ b/python/suricata/sc/suricatasc.py
@@ -118,9 +118,14 @@ class SuricataSC:
         data = ""
         while True:
             if sys.version < '3':
-                data += self.socket.recv(INC_SIZE)
+                received = self.socket.recv(INC_SIZE)
             else:
-                data += self.socket.recv(INC_SIZE).decode('iso-8859-1')
+                received = self.socket.recv(INC_SIZE).decode('iso-8859-1')
+
+            if not received:
+                break
+
+            data += received
             if data.endswith('\n'):
                 cmdret = json.loads(data)
                 break


### PR DESCRIPTION
Continuation of #6768 

Issue: 4947

Improve handling of values returned by recv. Sometimes, recv returns an
empty string if suricata terminates asynchronously.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4947](https://redmine.openinfosecfoundation.org/issues/4947)

Describe changes:
- Handle empty strings returned by recv (or a return value of None)

Updates:
- Improve python formatting

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
