### PR TITLE
reference: Enable validation checking in test mode

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2364,7 +2364,8 @@ static DetectEngineCtx *DetectEngineCtxInitReal(enum DetectEngineType type, cons
     (void)SRepInit(de_ctx);
 
     SCClassConfLoadClassficationConfigFile(de_ctx, NULL);
-    SCRConfLoadReferenceConfigFile(de_ctx, NULL);
+    if (SCRConfLoadReferenceConfigFile(de_ctx, NULL) < 0)
+        goto error;
 
     if (ActionInitConfig() < 0) {
         goto error;

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2776,8 +2776,10 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
 
     }
     if (DetectPortParse(de_ctx, &de_ctx->udp_whitelist, ports) != 0) {
-        SCLogWarning(SC_ERR_INVALID_YAML_CONF_ENTRY, "'%s' is not a valid value "
-                "forr detect.grouping.udp-whitelist", ports);
+        SCLogWarning(SC_ERR_INVALID_YAML_CONF_ENTRY,
+                "'%s' is not a valid value "
+                "for detect.grouping.udp-whitelist",
+                ports);
     }
     for (x = de_ctx->udp_whitelist; x != NULL;  x = x->next) {
         if (x->port != x->port2) {

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2364,8 +2364,11 @@ static DetectEngineCtx *DetectEngineCtxInitReal(enum DetectEngineType type, cons
     (void)SRepInit(de_ctx);
 
     SCClassConfLoadClassficationConfigFile(de_ctx, NULL);
-    if (SCRConfLoadReferenceConfigFile(de_ctx, NULL) < 0)
-        goto error;
+
+    if (SCRConfLoadReferenceConfigFile(de_ctx, NULL) < 0) {
+        if (RunmodeGetCurrent() == RUNMODE_CONF_TEST)
+            goto error;
+    }
 
     if (ActionInitConfig() < 0) {
         goto error;

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1717,7 +1717,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             suri->conf_filename = optarg;
             break;
         case 'T':
-            SCLogInfo("Running suricata under test mode");
+            SCLogNotice("Running suricata under test mode");
             conf_test = 1;
             if (ConfSetFinal("engine.init-failure-fatal", "1") != 1) {
                 fprintf(stderr, "ERROR: Failed to set engine init-failure-fatal.\n");

--- a/src/util-reference-config.c
+++ b/src/util-reference-config.c
@@ -502,7 +502,8 @@ int SCRConfLoadReferenceConfigFile(DetectEngineCtx *de_ctx, FILE *fd)
     if (fd == NULL) {
 #ifdef UNITTESTS
         if (RunmodeIsUnittests() && fd == NULL) {
-            return -1;
+            /* Silently fail */
+            return 0;
         }
 #endif
         SCLogError(SC_ERR_OPENING_FILE, "please check the \"reference-config-file\" "

--- a/src/util-reference-config.c
+++ b/src/util-reference-config.c
@@ -333,7 +333,6 @@ static bool SCRConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
 
         if (SCRConfAddReference(de_ctx, line) != 0) {
             if (is_conf_test_mode) {
-                SCLogNotice("current runmode = runmode_conf_test; returning false\n");
                 return false;
             }
         }
@@ -516,7 +515,7 @@ int SCRConfLoadReferenceConfigFile(DetectEngineCtx *de_ctx, FILE *fd)
 }
 
 /**
- * \brief Gets the refernce config from the corresponding hash table stored
+ * \brief Gets the reference config from the corresponding hash table stored
  *        in the Detection Engine Context's reference conf ht, given the
  *        reference name.
  *

--- a/src/util-reference-config.c
+++ b/src/util-reference-config.c
@@ -120,10 +120,15 @@ static FILE *SCRConfInitContextAndLocalResources(DetectEngineCtx *de_ctx, FILE *
      * reference strings */
     if (fd == NULL) {
         const char *filename = SCRConfGetConfFilename(de_ctx);
+#if 1
+        SCLogNotice("using reference config = %s", filename);
+#endif
         if ((fd = fopen(filename, "r")) == NULL) {
 #ifdef UNITTESTS
-            if (RunmodeIsUnittests())
+            if (RunmodeIsUnittests()) {
+                printf("fopen of %s failed\n", filename);
                 return NULL; // silently fail
+            }
 #endif
             SCLogError(SC_ERR_FOPEN, "Error opening file: \"%s\": %s", filename,
                        strerror(errno));
@@ -131,6 +136,7 @@ static FILE *SCRConfInitContextAndLocalResources(DetectEngineCtx *de_ctx, FILE *
         }
     }
 
+    printf("fd is non-null: %p\n", fd);
     return fd;
 }
 

--- a/src/util-reference-config.c
+++ b/src/util-reference-config.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2019 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -319,7 +319,7 @@ static int SCRConfIsLineBlankOrComment(char *line)
  *
  * \param de_ctx Pointer to the Detection Engine Context.
  */
-static void SCRConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
+static int SCRConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
 {
     char line[1024];
     uint8_t i = 1;
@@ -328,7 +328,10 @@ static void SCRConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
         if (SCRConfIsLineBlankOrComment(line))
             continue;
 
-        SCRConfAddReference(de_ctx, line);
+        if (SCRConfAddReference(de_ctx, line) != 0)
+            if (RunmodeGetCurrent() == RUNMODE_CONF_TEST) {
+                return -1;
+            }
         i++;
     }
 
@@ -336,7 +339,7 @@ static void SCRConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
     SCLogInfo("Added \"%d\" reference types from the reference.config file",
               de_ctx->reference_conf_ht->count);
 #endif /* UNITTESTS */
-    return;
+    return 0;
 }
 
 /**
@@ -501,10 +504,10 @@ int SCRConfLoadReferenceConfigFile(DetectEngineCtx *de_ctx, FILE *fd)
         return -1;
     }
 
-    SCRConfParseFile(de_ctx, fd);
+    int rc = SCRConfParseFile(de_ctx, fd);
     SCRConfDeInitLocalResources(de_ctx, fd);
 
-    return 0;
+    return rc;
 }
 
 /**

--- a/src/util-reference-config.c
+++ b/src/util-reference-config.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -319,7 +319,7 @@ static int SCRConfIsLineBlankOrComment(char *line)
  *
  * \param de_ctx Pointer to the Detection Engine Context.
  */
-static int SCRConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
+static bool SCRConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
 {
     char line[1024];
     uint8_t i = 1;
@@ -330,7 +330,7 @@ static int SCRConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
 
         if (SCRConfAddReference(de_ctx, line) != 0)
             if (RunmodeGetCurrent() == RUNMODE_CONF_TEST) {
-                return -1;
+                return false;
             }
         i++;
     }
@@ -339,7 +339,7 @@ static int SCRConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
     SCLogInfo("Added \"%d\" reference types from the reference.config file",
               de_ctx->reference_conf_ht->count);
 #endif /* UNITTESTS */
-    return 0;
+    return true;
 }
 
 /**
@@ -504,10 +504,10 @@ int SCRConfLoadReferenceConfigFile(DetectEngineCtx *de_ctx, FILE *fd)
         return -1;
     }
 
-    int rc = SCRConfParseFile(de_ctx, fd);
+    bool rc = SCRConfParseFile(de_ctx, fd);
     SCRConfDeInitLocalResources(de_ctx, fd);
 
-    return rc;
+    return rc ? 0 : -1;
 }
 
 /**


### PR DESCRIPTION
Continuation of #6767

This PR modifies suricata to fail in test mode iff `reference.config` is improperly formatted. In non-test mode, an improperly formatted `reference.config` file will not stop suricata and a log message will be displayed.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4659](https://redmine.openinfosecfoundation.org/issues/4659)

Describe changes:
- Raise an error if reference.config parsing fails in test mode.

Updates:
- Update s-v pr

suricata-verify-pr: 679
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
