### PR TITLE
output/alert: don't call basic logging twice

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -134,7 +134,6 @@ static void AlertJsonTls(const Flow *f, JsonBuilder *js)
     if (ssl_state) {
         jb_open_object(js, "tls");
 
-        JsonTlsLogJSONBasic(js, ssl_state);
         JsonTlsLogJSONExtended(js, ssl_state);
 
         jb_close(js);


### PR DESCRIPTION
Issue: 4106

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4106

Describe changes:
- Fix duplicate logging of TLS basic fields
