### PR TITLE
App layer error close txs 4318 v2

### DIFF
--- a/src/flow.c
+++ b/src/flow.c
@@ -1131,7 +1131,8 @@ uint8_t FlowGetDisruptionFlags(const Flow *f, uint8_t flags)
     TcpSession *ssn = f->protoctx;
     TcpStream *stream = flags & STREAM_TOSERVER ? &ssn->client : &ssn->server;
 
-    if (stream->flags & STREAMTCP_STREAM_FLAG_DEPTH_REACHED) {
+    if ((stream->flags & STREAMTCP_STREAM_FLAG_DEPTH_REACHED) ||
+            (ssn->flags & STREAMTCP_FLAG_APP_LAYER_DISABLED)) {
         newflags |= STREAM_DEPTH;
     }
     /* todo: handle pass case (also for UDP!) */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4318

Describe changes:
- app-layer: clean and "close" all txs if protocol reaches error state

The best way I see to test this is SMB
But I am not sure how to get multiple live transactions over SMB

Then to get an error, simply have a NBSS message with length 4, and just `\xFFSMB` so the SMB parser will fail decode the SMB1 header (not sure it should put the whole parser in an error state by the way, as we could go on with the next NBSS message)

Modifies #6472 by checking `STREAMTCP_FLAG_APP_LAYER_DISABLED` against `ssn->flags` instead of `stream->flags`
Is there a way (other than rust) to prevent this kind of mistake ?