### PR TITLE
ci: do not use ppa for cocci

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1129,7 +1129,6 @@ jobs:
                 texlive-latex-extra
       - name: Install Coccinelle
         run: |
-          add-apt-repository -y ppa:npalix/coccinelle
           apt -y install coccinelle
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Do not use PPA for cocci