### PR TITLE
Warnint util 4516 v3

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1833,7 +1833,7 @@ int AppLayerProtoDetectSetup(void)
     memset(&alpd_ctx, 0, sizeof(alpd_ctx));
 
     uint16_t spm_matcher = SinglePatternMatchDefaultMatcher();
-    uint16_t mpm_matcher = PatternMatchDefaultMatcher();
+    uint8_t mpm_matcher = PatternMatchDefaultMatcher();
 
     alpd_ctx.spm_global_thread_ctx = SpmInitGlobalThreadCtx(spm_matcher);
     if (alpd_ctx.spm_global_thread_ctx == NULL) {

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1193,7 +1193,7 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
     void *alstate = NULL;
     uint64_t p_tx_cnt = 0;
     uint32_t consumed = input_len;
-    const int direction = (flags & STREAM_TOSERVER) ? 0 : 1;
+    const uint8_t direction = (flags & STREAM_TOSERVER) ? 0 : 1;
 
     /* we don't have the parser registered for this protocol */
     if (p->StateAlloc == NULL)

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -303,7 +303,7 @@ static int TCPProtoDetect(ThreadVars *tv,
 {
     AppProto *alproto;
     AppProto *alproto_otherdir;
-    int direction = (flags & STREAM_TOSERVER) ? 0 : 1;
+    uint8_t direction = (flags & STREAM_TOSERVER) ? 0 : 1;
 
     if (flags & STREAM_TOSERVER) {
         alproto = &f->alproto_ts;
@@ -602,7 +602,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         goto end;
     }
 
-    const int direction = (flags & STREAM_TOSERVER) ? 0 : 1;
+    const uint8_t direction = (flags & STREAM_TOSERVER) ? 0 : 1;
 
     if (flags & STREAM_TOSERVER) {
         alproto = f->alproto_ts;

--- a/src/decode-tcp.h
+++ b/src/decode-tcp.h
@@ -109,7 +109,7 @@
 
 #define TCP_GET_OFFSET(p)                    TCP_GET_RAW_OFFSET((p)->tcph)
 #define TCP_GET_X2(p)                        TCP_GET_RAW_X2((p)->tcph)
-#define TCP_GET_HLEN(p)                      (TCP_GET_OFFSET((p)) << 2)
+#define TCP_GET_HLEN(p)                      ((uint8_t)(TCP_GET_OFFSET((p)) << 2))
 #define TCP_GET_SRC_PORT(p)                  TCP_GET_RAW_SRC_PORT((p)->tcph)
 #define TCP_GET_DST_PORT(p)                  TCP_GET_RAW_DST_PORT((p)->tcph)
 #define TCP_GET_SEQ(p)                       TCP_GET_RAW_SEQ((p)->tcph)

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -622,10 +622,10 @@ int SignatureHasStreamContent(const Signature *s)
  *
  *  \retval mpm algo value
  */
-uint16_t PatternMatchDefaultMatcher(void)
+uint8_t PatternMatchDefaultMatcher(void)
 {
     const char *mpm_algo;
-    uint16_t mpm_algo_val = mpm_default_matcher;
+    uint8_t mpm_algo_val = mpm_default_matcher;
 
     /* Get the mpm algo defined in config file by the user */
     if ((ConfGet("mpm-algo", &mpm_algo)) == 1) {

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -41,7 +41,7 @@ int DetectMpmPrepareBuiltinMpms(DetectEngineCtx *de_ctx);
 
 uint32_t PatternStrength(uint8_t *, uint16_t);
 
-uint16_t PatternMatchDefaultMatcher(void);
+uint8_t PatternMatchDefaultMatcher(void);
 uint32_t DnsQueryPatternSearch(DetectEngineThreadCtx *det_ctx, uint8_t *buffer, uint32_t buffer_len, uint8_t flags);
 
 void PatternMatchPrepare(MpmCtx *, uint16_t);

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -300,8 +300,8 @@ int FlowForceReassemblyNeedReassembly(Flow *f)
     }
 
     TcpSession *ssn = (TcpSession *)f->protoctx;
-    int client = StreamNeedsReassembly(ssn, STREAM_TOSERVER);
-    int server = StreamNeedsReassembly(ssn, STREAM_TOCLIENT);
+    uint8_t client = StreamNeedsReassembly(ssn, STREAM_TOSERVER);
+    uint8_t server = StreamNeedsReassembly(ssn, STREAM_TOCLIENT);
 
     /* if state is not fully closed we assume that we haven't fully
      * inspected the app layer state yet */

--- a/src/flow.c
+++ b/src/flow.c
@@ -580,8 +580,7 @@ void FlowInitConfig(bool quiet)
             FatalError(SC_ERR_FATAL, "Invalid value for flow.hash-size: NULL");
         }
 
-        if (StringParseUint32(&configval, 10, strlen(conf_val),
-                                    conf_val) > 0) {
+        if (StringParseUint32(&configval, 10, (uint16_t)strlen(conf_val), conf_val) > 0) {
             flow_config.hash_size = configval;
         }
     }
@@ -591,8 +590,7 @@ void FlowInitConfig(bool quiet)
             FatalError(SC_ERR_FATAL, "Invalid value for flow.prealloc: NULL");
         }
 
-        if (StringParseUint32(&configval, 10, strlen(conf_val),
-                                    conf_val) > 0) {
+        if (StringParseUint32(&configval, 10, (uint16_t)strlen(conf_val), conf_val) > 0) {
             flow_config.prealloc = configval;
         }
     }
@@ -764,54 +762,46 @@ void FlowInitFlowProto(void)
             emergency_bypassed = ConfNodeLookupChildValue(proto,
                 "emergency-bypassed");
 
-            if (new != NULL &&
-                StringParseUint32(&configval, 10, strlen(new), new) > 0) {
+            if (new != NULL && StringParseUint32(&configval, 10, (uint16_t)strlen(new), new) > 0) {
 
-                    flow_timeouts_normal[FLOW_PROTO_DEFAULT].new_timeout = configval;
+                flow_timeouts_normal[FLOW_PROTO_DEFAULT].new_timeout = configval;
             }
-            if (established != NULL &&
-                StringParseUint32(&configval, 10, strlen(established),
-                                        established) > 0) {
+            if (established != NULL && StringParseUint32(&configval, 10,
+                                               (uint16_t)strlen(established), established) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_DEFAULT].est_timeout = configval;
             }
             if (closed != NULL &&
-                StringParseUint32(&configval, 10, strlen(closed),
-                                        closed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(closed), closed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_DEFAULT].closed_timeout = configval;
             }
             if (bypassed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(bypassed),
-                                            bypassed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(bypassed), bypassed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_DEFAULT].bypassed_timeout = configval;
             }
             if (emergency_new != NULL &&
-                StringParseUint32(&configval, 10, strlen(emergency_new),
-                                        emergency_new) > 0) {
+                    StringParseUint32(
+                            &configval, 10, (uint16_t)strlen(emergency_new), emergency_new) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_DEFAULT].new_timeout = configval;
             }
             if (emergency_established != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(emergency_established),
-                                            emergency_established) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_established),
+                            emergency_established) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_DEFAULT].est_timeout= configval;
             }
             if (emergency_closed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(emergency_closed),
-                                            emergency_closed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_closed),
+                            emergency_closed) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_DEFAULT].closed_timeout = configval;
             }
             if (emergency_bypassed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(emergency_bypassed),
-                                            emergency_bypassed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_bypassed),
+                            emergency_bypassed) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_DEFAULT].bypassed_timeout = configval;
             }
@@ -832,54 +822,46 @@ void FlowInitFlowProto(void)
             emergency_bypassed = ConfNodeLookupChildValue(proto,
                 "emergency-bypassed");
 
-            if (new != NULL &&
-                StringParseUint32(&configval, 10, strlen(new), new) > 0) {
+            if (new != NULL && StringParseUint32(&configval, 10, (uint16_t)strlen(new), new) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_TCP].new_timeout = configval;
             }
-            if (established != NULL &&
-                StringParseUint32(&configval, 10, strlen(established),
-                                        established) > 0) {
+            if (established != NULL && StringParseUint32(&configval, 10,
+                                               (uint16_t)strlen(established), established) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_TCP].est_timeout = configval;
             }
             if (closed != NULL &&
-                StringParseUint32(&configval, 10, strlen(closed),
-                                        closed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(closed), closed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_TCP].closed_timeout = configval;
             }
             if (bypassed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(bypassed),
-                                            bypassed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(bypassed), bypassed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_TCP].bypassed_timeout = configval;
             }
             if (emergency_new != NULL &&
-                StringParseUint32(&configval, 10, strlen(emergency_new),
-                                        emergency_new) > 0) {
+                    StringParseUint32(
+                            &configval, 10, (uint16_t)strlen(emergency_new), emergency_new) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_TCP].new_timeout = configval;
             }
             if (emergency_established != NULL &&
-                StringParseUint32(&configval, 10,
-                                        strlen(emergency_established),
-                                        emergency_established) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_established),
+                            emergency_established) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_TCP].est_timeout = configval;
             }
             if (emergency_closed != NULL &&
-                StringParseUint32(&configval, 10,
-                                        strlen(emergency_closed),
-                                        emergency_closed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_closed),
+                            emergency_closed) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_TCP].closed_timeout = configval;
             }
             if (emergency_bypassed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(emergency_bypassed),
-                                            emergency_bypassed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_bypassed),
+                            emergency_bypassed) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_TCP].bypassed_timeout = configval;
             }
@@ -897,41 +879,35 @@ void FlowInitFlowProto(void)
             emergency_bypassed = ConfNodeLookupChildValue(proto,
                 "emergency-bypassed");
 
-            if (new != NULL &&
-                StringParseUint32(&configval, 10, strlen(new), new) > 0) {
+            if (new != NULL && StringParseUint32(&configval, 10, (uint16_t)strlen(new), new) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_UDP].new_timeout = configval;
             }
-            if (established != NULL &&
-                StringParseUint32(&configval, 10, strlen(established),
-                                        established) > 0) {
+            if (established != NULL && StringParseUint32(&configval, 10,
+                                               (uint16_t)strlen(established), established) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_UDP].est_timeout = configval;
             }
             if (bypassed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(bypassed),
-                                            bypassed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(bypassed), bypassed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_UDP].bypassed_timeout = configval;
             }
             if (emergency_new != NULL &&
-                StringParseUint32(&configval, 10, strlen(emergency_new),
-                                        emergency_new) > 0) {
+                    StringParseUint32(
+                            &configval, 10, (uint16_t)strlen(emergency_new), emergency_new) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_UDP].new_timeout = configval;
             }
             if (emergency_established != NULL &&
-                StringParseUint32(&configval, 10,
-                                        strlen(emergency_established),
-                                        emergency_established) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_established),
+                            emergency_established) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_UDP].est_timeout = configval;
             }
             if (emergency_bypassed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(emergency_bypassed),
-                                            emergency_bypassed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_bypassed),
+                            emergency_bypassed) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_UDP].bypassed_timeout = configval;
             }
@@ -949,41 +925,35 @@ void FlowInitFlowProto(void)
             emergency_bypassed = ConfNodeLookupChildValue(proto,
                 "emergency-bypassed");
 
-            if (new != NULL &&
-                StringParseUint32(&configval, 10, strlen(new), new) > 0) {
+            if (new != NULL && StringParseUint32(&configval, 10, (uint16_t)strlen(new), new) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_ICMP].new_timeout = configval;
             }
-            if (established != NULL &&
-                StringParseUint32(&configval, 10, strlen(established),
-                                        established) > 0) {
+            if (established != NULL && StringParseUint32(&configval, 10,
+                                               (uint16_t)strlen(established), established) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_ICMP].est_timeout = configval;
             }
             if (bypassed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(bypassed),
-                                            bypassed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(bypassed), bypassed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_ICMP].bypassed_timeout = configval;
             }
             if (emergency_new != NULL &&
-                StringParseUint32(&configval, 10, strlen(emergency_new),
-                                        emergency_new) > 0) {
+                    StringParseUint32(
+                            &configval, 10, (uint16_t)strlen(emergency_new), emergency_new) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_ICMP].new_timeout = configval;
             }
             if (emergency_established != NULL &&
-                StringParseUint32(&configval, 10,
-                                        strlen(emergency_established),
-                                        emergency_established) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_established),
+                            emergency_established) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_ICMP].est_timeout = configval;
             }
             if (emergency_bypassed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(emergency_bypassed),
-                                            emergency_bypassed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_bypassed),
+                            emergency_bypassed) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_ICMP].bypassed_timeout = configval;
             }
@@ -1139,7 +1109,7 @@ uint8_t FlowGetDisruptionFlags(const Flow *f, uint8_t flags)
     return newflags;
 }
 
-void FlowUpdateState(Flow *f, const enum FlowState s)
+void FlowUpdateState(Flow *f, const FlowStateType s)
 {
     if (s != f->flow_state) {
         /* set the state */

--- a/src/flow.h
+++ b/src/flow.h
@@ -579,7 +579,7 @@ int FlowGetPacketDirection(const Flow *, const Packet *);
 
 void FlowCleanupAppLayer(Flow *);
 
-void FlowUpdateState(Flow *f, enum FlowState s);
+void FlowUpdateState(Flow *f, const FlowStateType s);
 
 int FlowSetMemcap(uint64_t size);
 uint64_t FlowGetMemcap(void);

--- a/src/host.c
+++ b/src/host.c
@@ -34,6 +34,7 @@
 #include "util-random.h"
 #include "util-misc.h"
 #include "util-byte.h"
+#include "util-validate.h"
 
 #include "host-queue.h"
 
@@ -173,8 +174,10 @@ void HostClearMemory(Host *h)
 void HostInitConfig(bool quiet)
 {
     SCLogDebug("initializing host engine...");
-    if (HostStorageSize() > 0)
-        g_host_size = sizeof(Host) + HostStorageSize();
+    if (HostStorageSize() > 0) {
+        DEBUG_VALIDATE_BUG_ON(sizeof(Host) + HostStorageSize() > UINT16_MAX);
+        g_host_size = (uint16_t)(sizeof(Host) + HostStorageSize());
+    }
 
     memset(&host_config,  0, sizeof(host_config));
     //SC_ATOMIC_INIT(flow_flags);
@@ -209,16 +212,14 @@ void HostInitConfig(bool quiet)
     }
     if ((ConfGetValue("host.hash-size", &conf_val)) == 1)
     {
-        if (StringParseUint32(&configval, 10, strlen(conf_val),
-                                    conf_val) > 0) {
+        if (StringParseUint32(&configval, 10, (uint16_t)strlen(conf_val), conf_val) > 0) {
             host_config.hash_size = configval;
         }
     }
 
     if ((ConfGetValue("host.prealloc", &conf_val)) == 1)
     {
-        if (StringParseUint32(&configval, 10, strlen(conf_val),
-                                    conf_val) > 0) {
+        if (StringParseUint32(&configval, 10, (uint16_t)strlen(conf_val), conf_val) > 0) {
             host_config.prealloc = configval;
         } else {
             WarnInvalidConfEntry("host.prealloc", "%"PRIu32, host_config.prealloc);

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -204,7 +204,7 @@ void JsonDNP3LogResponse(JsonBuilder *js, DNP3Transaction *dnp3tx)
     jb_close(js);
 
     jb_open_object(js, "iin");
-    JsonDNP3LogIin(js, dnp3tx->response_iin.iin1 << 8 | dnp3tx->response_iin.iin2);
+    JsonDNP3LogIin(js, (uint16_t)(dnp3tx->response_iin.iin1 << 8 | dnp3tx->response_iin.iin2));
     jb_close(js);
 }
 

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -202,7 +202,7 @@ JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff, const bool
  *  \brief Write meta data on a single line json record
  */
 static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const File *ff,
-        uint32_t dir, OutputJsonCtx *eve_ctx)
+        uint8_t dir, OutputJsonCtx *eve_ctx)
 {
     HttpXFFCfg *xff_cfg = aft->filelog_ctx->xff_cfg != NULL ?
         aft->filelog_ctx->xff_cfg : aft->filelog_ctx->parent_xff_cfg;;

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -76,8 +76,13 @@ static void EveFTPLogCommand(Flow *f, FTPTransaction *tx, JsonBuilder *jb)
         TAILQ_FOREACH(response, &tx->response_list, next) {
             /* handle multiple lines within the response, \r\n delimited */
             uint8_t *where = response->str;
-            uint16_t length = response->len ? response->len -1 : 0;
+            uint16_t length = 0;
             uint16_t pos;
+            if (response->len > 0 && response->len <= UINT16_MAX) {
+                length = (uint16_t)response->len - 1;
+            } else if (response->len > UINT16_MAX) {
+                length = UINT16_MAX;
+            }
             while ((pos = JsonGetNextLineFromBuffer((const char *)where, length)) != UINT16_MAX) {
                 uint16_t offset = 0;
                 /* Try to find a completion code for this line */

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -64,7 +64,7 @@ typedef enum OutputEngineInfo_ {
 
 typedef struct OutputStatsCtx_ {
     LogFileCtx *file_ctx;
-    uint32_t flags; /** Store mode */
+    uint8_t flags; /** Store mode */
 } OutputStatsCtx;
 
 typedef struct JsonStatsLogThread_ {

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -76,7 +76,7 @@ static void SRepCIDRFreeUserData(void *data)
     return;
 }
 
-static void SRepCIDRAddNetblock(SRepCIDRTree *cidr_ctx, char *ip, int cat, int value)
+static void SRepCIDRAddNetblock(SRepCIDRTree *cidr_ctx, char *ip, int cat, uint8_t value)
 {
     SReputation *user_data = NULL;
     if ((user_data = SCMalloc(sizeof(SReputation))) == NULL) {
@@ -304,11 +304,11 @@ static int SRepSplitLine(SRepCIDRTree *cidr_ctx, char *line, Address *ip, uint8_
     if (strcmp(ptrs[0], "ip") == 0)
         return 1;
 
-    int c, v;
-    if (StringParseI32RangeCheck(&c, 10, 0, (const char *)ptrs[1], 0, SREP_MAX_CATS - 1) < 0)
+    uint8_t c, v;
+    if (StringParseU8RangeCheck(&c, 10, 0, (const char *)ptrs[1], 0, SREP_MAX_CATS - 1) < 0)
         return -1;
 
-    if (StringParseI32RangeCheck(&v, 10, 0, (const char *)ptrs[2], 0, SREP_MAX_VAL) < 0)
+    if (StringParseU8RangeCheck(&v, 10, 0, (const char *)ptrs[2], 0, SREP_MAX_VAL) < 0)
         return -1;
 
     if (strchr(ptrs[0], '/') != NULL) {

--- a/src/respond-reject-libnet11.c
+++ b/src/respond-reject-libnet11.c
@@ -80,7 +80,7 @@ typedef struct Libnet11Packet_ {
     struct libnet_in6_addr src6, dst6;
     uint32_t src4, dst4;
     uint16_t sp, dp;
-    size_t len;
+    uint16_t len;
     uint8_t *smac, *dmac;
 } Libnet11Packet;
 
@@ -351,7 +351,7 @@ int RejectSendLibnet11IPv4ICMP(ThreadVars *tv, Packet *p, void *data, enum Rejec
     lpacket.id = 0;
     lpacket.flow = 0;
     lpacket.class = 0;
-    const int iplen = IPV4_GET_IPLEN(p);
+    const uint16_t iplen = IPV4_GET_IPLEN(p);
     if (g_reject_dev_mtu >= ETHERNET_HEADER_LEN + LIBNET_IPV4_H + 8) {
         lpacket.len = MIN(g_reject_dev_mtu - ETHERNET_HEADER_LEN, (LIBNET_IPV4_H + iplen));
     } else {
@@ -493,7 +493,7 @@ int RejectSendLibnet11IPv6ICMP(ThreadVars *tv, Packet *p, void *data, enum Rejec
     lpacket.id = 0;
     lpacket.flow = 0;
     lpacket.class = 0;
-    const int iplen = IPV6_GET_PLEN(p);
+    const uint16_t iplen = IPV6_GET_PLEN(p);
     if (g_reject_dev_mtu >= ETHERNET_HEADER_LEN + IPV6_HEADER_LEN + 8) {
         lpacket.len = IPV6_HEADER_LEN + MIN(g_reject_dev_mtu - ETHERNET_HEADER_LEN, iplen);
     } else {

--- a/src/runmode-erf-file.c
+++ b/src/runmode-erf-file.c
@@ -210,7 +210,7 @@ int RunModeErfFileAutoFp(void)
         TmSlotSetFuncAppend(tv_detect_ncpu, tm_module, NULL);
 
         if (threading_set_cpu_affinity) {
-            TmThreadSetCPUAffinity(tv_detect_ncpu, (int)cpu);
+            TmThreadSetCPUAffinity(tv_detect_ncpu, cpu);
             /* If we have more than one core/cpu, the first Detect thread
              * (at cpu 0) will have less priority (higher 'nice' value)
              * In this case we will set the thread priority to +10 (default is 0)

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -808,7 +808,7 @@ TmEcode UnixSocketRegisterTenantHandler(json_t *cmd, json_t* answer, void *data)
         }
 
         SCLogInfo("VLAN handler: id %u maps to tenant %u", (uint32_t)traffic_id, tenant_id);
-        r = DetectEngineTentantRegisterVlanId(tenant_id, (uint32_t)traffic_id);
+        r = DetectEngineTentantRegisterVlanId(tenant_id, (uint16_t)traffic_id);
     }
     if (r != 0) {
         json_object_set_new(answer, "message", json_string("handler setup failure"));
@@ -889,7 +889,7 @@ TmEcode UnixSocketUnregisterTenantHandler(json_t *cmd, json_t* answer, void *dat
         }
 
         SCLogInfo("VLAN handler: removing mapping of %u to tenant %u", (uint32_t)traffic_id, tenant_id);
-        r = DetectEngineTentantUnregisterVlanId(tenant_id, (uint32_t)traffic_id);
+        r = DetectEngineTentantUnregisterVlanId(tenant_id, (uint16_t)traffic_id);
     }
     if (r != 0) {
         json_object_set_new(answer, "message", json_string("handler unregister failure"));

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -902,7 +902,7 @@ void RunModeInitializeOutputs(void)
     }
 
     /* register the logger bits to the app-layer */
-    int a;
+    AppProto a;
     for (a = 0; a < ALPROTO_MAX; a++) {
         if (logger_bits[a] == 0)
             continue;

--- a/src/stream-tcp-inline.c
+++ b/src/stream-tcp-inline.c
@@ -83,8 +83,8 @@ int StreamTcpInlineSegmentCompare(const TcpStream *stream,
 
         SCLogDebug("seq %u, end %u", seq, end);
 
-        uint16_t pkt_off = seq - pkt_seq;
-        uint16_t seg_off = seq - seg->seq;
+        uint32_t pkt_off = seq - pkt_seq;
+        uint32_t seg_off = seq - seg->seq;
         SCLogDebug("pkt_off %u, seg_off %u", pkt_off, seg_off);
 
         uint32_t range = end - seq;
@@ -138,8 +138,8 @@ void StreamTcpInlineSegmentReplacePacket(const TcpStream *stream,
     uint32_t seq = (SEQ_LT(pseq, tseq)) ? tseq : pseq;
     SCLogDebug("seq %u, end %u", seq, end);
 
-    uint16_t poff = seq - pseq;
-    uint16_t toff = seq - tseq;
+    uint32_t poff = seq - pseq;
+    uint32_t toff = seq - tseq;
     SCLogDebug("poff %u, toff %u", poff, toff);
 
     uint32_t range = end - seq;

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -76,7 +76,7 @@ int TcpSegmentCompare(struct TcpSegment *a, struct TcpSegment *b)
 static inline int InsertSegmentDataCustom(TcpStream *stream, TcpSegment *seg, uint8_t *data, uint16_t data_len)
 {
     uint64_t stream_offset;
-    uint16_t data_offset;
+    uint32_t data_offset;
 
     if (likely(SEQ_GEQ(seg->seq, stream->base_seq))) {
         stream_offset = STREAM_BASE_OFFSET(stream) + (seg->seq - stream->base_seq);
@@ -369,8 +369,8 @@ static int DoHandleDataOverlap(TcpStream *stream, const TcpSegment *list,
      * data, we have to update buf with the list data */
     if (data_is_different && !use_new_data) {
         /* we need to copy list into seg */
-        uint16_t list_offset = 0;
-        uint16_t seg_offset = 0;
+        uint32_t list_offset = 0;
+        uint32_t seg_offset = 0;
         uint32_t list_len;
         uint16_t seg_len = p->payload_len;
         uint32_t list_seq = list->seq;

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -786,7 +786,7 @@ static int StreamTcpReassembleRawCheckLimit(const TcpSession *ssn,
 /**
  *  \brief see what if any work the TCP session still needs
  */
-int StreamNeedsReassembly(const TcpSession *ssn, uint8_t direction)
+uint8_t StreamNeedsReassembly(const TcpSession *ssn, uint8_t direction)
 {
     const TcpStream *stream = NULL;
 #ifdef DEBUG

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -696,7 +696,8 @@ static TcpSession *StreamTcpNewSession (Packet *p, int id)
     TcpSession *ssn = (TcpSession *)p->flow->protoctx;
 
     if (ssn == NULL) {
-        p->flow->protoctx = PoolThreadGetById(ssn_pool, id);
+        DEBUG_VALIDATE_BUG_ON(id < 0 || id > UINT16_MAX);
+        p->flow->protoctx = PoolThreadGetById(ssn_pool, (uint16_t)id);
 #ifdef DEBUG
         SCMutexLock(&ssn_pool_mutex);
         if (p->flow->protoctx != NULL)
@@ -775,7 +776,7 @@ void StreamTcpSetOSPolicy(TcpStream *stream, Packet *p)
            packets */
         ret = SCHInfoGetIPv4HostOSFlavour((uint8_t *)GET_IPV4_DST_ADDR_PTR(p));
         if (ret > 0)
-            stream->os_policy = ret;
+            stream->os_policy = (uint8_t)ret;
         else
             stream->os_policy = OS_POLICY_DEFAULT;
 
@@ -785,7 +786,7 @@ void StreamTcpSetOSPolicy(TcpStream *stream, Packet *p)
            packets */
         ret = SCHInfoGetIPv6HostOSFlavour((uint8_t *)GET_IPV6_DST_ADDR(p));
         if (ret > 0)
-            stream->os_policy = ret;
+            stream->os_policy = (uint8_t)ret;
         else
             stream->os_policy = OS_POLICY_DEFAULT;
     }

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -175,7 +175,7 @@ enum {
 };
 
 TmEcode StreamTcp (ThreadVars *, Packet *, void *, PacketQueueNoLock *);
-int StreamNeedsReassembly(const TcpSession *ssn, uint8_t direction);
+uint8_t StreamNeedsReassembly(const TcpSession *ssn, uint8_t direction);
 TmEcode StreamTcpThreadInit(ThreadVars *, void *, void **);
 TmEcode StreamTcpThreadDeinit(ThreadVars *tv, void *data);
 void StreamTcpRegisterTests (void);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2615,8 +2615,7 @@ int PostConfLoadedSetup(SCInstance *suri)
     const char *custom_umask;
     if (ConfGet("umask", &custom_umask) == 1) {
         uint16_t mask;
-        if (StringParseUint16(&mask, 8, strlen(custom_umask),
-                                    custom_umask) > 0) {
+        if (StringParseUint16(&mask, 8, (uint16_t)strlen(custom_umask), custom_umask) > 0) {
             umask((mode_t)mask);
         }
     }

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -175,7 +175,7 @@ extern uint16_t g_vlan_mask;
 extern bool g_disable_hashing;
 
 #include <ctype.h>
-#define u8_tolower(c) tolower((uint8_t)(c))
+#define u8_tolower(c) ((uint8_t)tolower((uint8_t)(c)))
 #define u8_toupper(c) toupper((uint8_t)(c))
 
 void EngineStop(void);

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -33,7 +33,7 @@ AppLayerParserThreadCtx *alp_tctx = NULL;
 
 const uint8_t separator[] = {0x01, 0xD5, 0xCA, 0x7A};
 SCInstance surifuzz;
-uint64_t forceLayer = 0;
+AppProto forceLayer = 0;
 
 int LLVMFuzzerInitialize(int *argc, char ***argv)
 {
@@ -42,14 +42,14 @@ int LLVMFuzzerInitialize(int *argc, char ***argv)
         AppProto applayer = StringToAppProto(target_suffix + 1);
         if (applayer != ALPROTO_UNKNOWN) {
             forceLayer = applayer;
-            printf("Forcing %s=%" PRIu64 "\n", AppProtoToString(forceLayer), forceLayer);
+            printf("Forcing %s=%" PRIu16 "\n", AppProtoToString(forceLayer), forceLayer);
             return 0;
         }
     }
     // else
     const char *forceLayerStr = getenv("FUZZ_APPLAYER");
     if (forceLayerStr) {
-        if (ByteExtractStringUint64(&forceLayer, 10, 0, forceLayerStr) < 0) {
+        if (ByteExtractStringUint16(&forceLayer, 10, 0, forceLayerStr) < 0) {
             forceLayer = 0;
             printf("Invalid numeric value for FUZZ_APPLAYER environment variable");
         } else {
@@ -105,8 +105,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     f->flags |= FLOW_IPV4;
     f->src.addr_data32[0] = 0x01020304;
     f->dst.addr_data32[0] = 0x05060708;
-    f->sp = (data[2] << 8) | data[3];
-    f->dp = (data[4] << 8) | data[5];
+    f->sp = (uint16_t)((data[2] << 8) | data[3]);
+    f->dp = (uint16_t)((data[4] << 8) | data[5]);
     f->proto = data[1];
     memset(&ssn, 0, sizeof(TcpSession));
     f->protoctx = &ssn;

--- a/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
+++ b/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
@@ -45,7 +45,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         alpd_tctx = AppLayerProtoDetectGetCtxThread();
     }
 
-    f = TestHelperBuildFlow(AF_INET, "1.2.3.4", "5.6.7.8", (data[2] << 8) | data[3], (data[4] << 8) | data[5]);
+    f = TestHelperBuildFlow(AF_INET, "1.2.3.4", "5.6.7.8", (uint16_t)((data[2] << 8) | data[3]),
+            (uint16_t)((data[4] << 8) | data[5]));
     if (f == NULL) {
         return 0;
     }

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -902,7 +902,7 @@ TmEcode TmThreadSetupOptions(ThreadVars *tv)
     if (tv->thread_setup_flags & THREAD_SET_AFFTYPE) {
         ThreadsAffinityType *taf = &thread_affinity[tv->cpu_affinity];
         if (taf->mode_flag == EXCLUSIVE_AFFINITY) {
-            int cpu = AffinityGetNextCPU(taf);
+            uint16_t cpu = AffinityGetNextCPU(taf);
             SetCPUAffinity(cpu);
             /* If CPU is in a set overwrite the default thread prio */
             if (CPU_ISSET(cpu, &taf->lowprio_cpu)) {
@@ -2319,7 +2319,7 @@ uint16_t TmThreadsGetWorkerThreadMax()
         SCLogWarning(SC_ERR_RUNMODE, "limited number of 'worker' threads to 1024. Wanted %d", thread_max);
         thread_max = 1024;
     }
-    return thread_max;
+    return (uint16_t)thread_max;
 }
 
 static inline void ThreadBreakLoop(ThreadVars *tv)

--- a/src/util-action.c
+++ b/src/util-action.c
@@ -432,8 +432,8 @@ action-order:\n\
 static int UtilActionTest08(void)
 {
     int res = 0;
-    uint8_t *buf = (uint8_t *)"Hi all!";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "Hi all!";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p[3];
     p[0] = UTHBuildPacketReal((uint8_t *)buf, buflen, IPPROTO_TCP,
                    "192.168.1.5", "192.168.1.1",
@@ -497,8 +497,8 @@ end:
 static int UtilActionTest09(void)
 {
     int res = 1;
-    uint8_t *buf = (uint8_t *)"Hi all!";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "Hi all!";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p[3];
 
     action_order_sigs[0] = ACTION_DROP;
@@ -573,10 +573,10 @@ end:
 static int UtilActionTest10(void)
 {
     int res = 0;
-    uint8_t *buf = (uint8_t *)"Hi all!";
-    uint16_t buflen = strlen((char *)buf);
-    uint8_t *buf2 = (uint8_t *)"wo!";
-    uint16_t buflen2 = strlen((char *)buf2);
+    uint8_t buf[] = "Hi all!";
+    uint16_t buflen = sizeof(buf) - 1;
+    uint8_t buf2[] = "wo!";
+    uint16_t buflen2 = sizeof(buf2) - 1;
     Packet *p[3];
     p[0] = UTHBuildPacketReal((uint8_t *)buf, buflen, IPPROTO_TCP,
                    "192.168.1.5", "192.168.1.1",
@@ -640,10 +640,10 @@ end:
 static int UtilActionTest11(void)
 {
     int res = 1;
-    uint8_t *buf = (uint8_t *)"Hi all!";
-    uint16_t buflen = strlen((char *)buf);
-    uint8_t *buf2 = (uint8_t *)"Hi all wo!";
-    uint16_t buflen2 = strlen((char *)buf2);
+    uint8_t buf[] = "Hi all!";
+    uint16_t buflen = sizeof(buf) - 1;
+    uint8_t buf2[] = "Hi all wo!";
+    uint16_t buflen2 = sizeof(buf2) - 1;
     Packet *p[3];
 
     action_order_sigs[0] = ACTION_DROP;
@@ -718,8 +718,8 @@ end:
 static int UtilActionTest12(void)
 {
     int res = 0;
-    uint8_t *buf = (uint8_t *)"Hi all!";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "Hi all!";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p[3];
     p[0] = UTHBuildPacketReal((uint8_t *)buf, buflen, IPPROTO_TCP,
                    "192.168.1.5", "192.168.1.1",
@@ -781,8 +781,8 @@ end:
 static int UtilActionTest13(void)
 {
     int res = 1;
-    uint8_t *buf = (uint8_t *)"Hi all!";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "Hi all!";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p[3];
 
     action_order_sigs[0] = ACTION_DROP;
@@ -856,8 +856,8 @@ end:
 static int UtilActionTest14(void)
 {
     int res = 1;
-    uint8_t *buf = (uint8_t *)"Hi all!";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "Hi all!";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p[3];
 
     action_order_sigs[0] = ACTION_DROP;
@@ -930,8 +930,8 @@ end:
 static int UtilActionTest15(void)
 {
     int res = 1;
-    uint8_t *buf = (uint8_t *)"Hi all!";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "Hi all!";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p[3];
 
     p[0] = UTHBuildPacketReal((uint8_t *)buf, buflen, IPPROTO_TCP,
@@ -994,8 +994,8 @@ end:
 static int UtilActionTest16(void)
 {
     int res = 1;
-    uint8_t *buf = (uint8_t *)"Hi all!";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "Hi all!";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p[3];
 
     p[0] = UTHBuildPacketReal((uint8_t *)buf, buflen, IPPROTO_TCP,
@@ -1058,8 +1058,8 @@ end:
 static int UtilActionTest17(void)
 {
     int res = 1;
-    uint8_t *buf = (uint8_t *)"Hi all!";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "Hi all!";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p[3];
 
     p[0] = UTHBuildPacketReal((uint8_t *)buf, buflen, IPPROTO_TCP,
@@ -1122,8 +1122,8 @@ end:
 static int UtilActionTest18(void)
 {
     int res = 1;
-    uint8_t *buf = (uint8_t *)"Hi all!";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "Hi all!";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p[3];
 
     action_order_sigs[0] = ACTION_DROP;
@@ -1197,8 +1197,8 @@ end:
 static int UtilActionTest19(void)
 {
     int res = 1;
-    uint8_t *buf = (uint8_t *)"Hi all!";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "Hi all!";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p[3];
 
     action_order_sigs[0] = ACTION_DROP;
@@ -1272,8 +1272,8 @@ end:
 static int UtilActionTest20(void)
 {
     int res = 1;
-    uint8_t *buf = (uint8_t *)"Hi all!";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "Hi all!";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p[3];
 
     action_order_sigs[0] = ACTION_DROP;
@@ -1341,8 +1341,8 @@ end:
 static int UtilActionTest21(void)
 {
     int res = 1;
-    uint8_t *buf = (uint8_t *)"Hi all!";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "Hi all!";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p[3];
 
     action_order_sigs[0] = ACTION_DROP;
@@ -1416,8 +1416,8 @@ end:
 static int UtilActionTest22(void)
 {
     int res = 1;
-    uint8_t *buf = (uint8_t *)"Hi all!";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "Hi all!";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p[3];
 
     action_order_sigs[0] = ACTION_DROP;
@@ -1491,8 +1491,8 @@ end:
 static int UtilActionTest23(void)
 {
     int res = 1;
-    uint8_t *buf = (uint8_t *)"Hi all!";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "Hi all!";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p[3];
 
     action_order_sigs[0] = ACTION_DROP;

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -294,7 +294,7 @@ void AffinitySetupLoadFromConfig()
  * \brief Return next cpu to use for a given thread family
  * \retval the cpu to used given by its id
  */
-int AffinityGetNextCPU(ThreadsAffinityType *taf)
+uint16_t AffinityGetNextCPU(ThreadsAffinityType *taf)
 {
     uint16_t ncpu = 0;
 #if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -296,7 +296,7 @@ void AffinitySetupLoadFromConfig()
  */
 int AffinityGetNextCPU(ThreadsAffinityType *taf)
 {
-    int ncpu = 0;
+    uint16_t ncpu = 0;
 #if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
     int iter = 0;
     SCMutexLock(&taf->taf_mutex);

--- a/src/util-affinity.h
+++ b/src/util-affinity.h
@@ -85,7 +85,7 @@ extern ThreadsAffinityType thread_affinity[MAX_CPU_SET];
 void AffinitySetupLoadFromConfig(void);
 ThreadsAffinityType * GetAffinityTypeFromName(const char *name);
 
-int AffinityGetNextCPU(ThreadsAffinityType *taf);
+uint16_t AffinityGetNextCPU(ThreadsAffinityType *taf);
 
 void BuildCpusetWithCallback(const char *name, ConfNode *node,
                              void (*Callback)(int i, void * data),

--- a/src/util-base64.c
+++ b/src/util-base64.c
@@ -116,7 +116,7 @@ uint32_t DecodeBase64(uint8_t *dest, const uint8_t *src, uint32_t len,
 
         /* For each alpha-numeric letter in the source array, find the numeric
          * value */
-        b64[bbidx++] = (val > 0 ? val : 0);
+        b64[bbidx++] = (val > 0 ? (uint8_t)val : 0);
 
         /* Decode every 4 base64 bytes into 3 ascii bytes */
         if (bbidx == B64_BLOCK) {

--- a/src/util-byte.c
+++ b/src/util-byte.c
@@ -877,10 +877,10 @@ static int ByteTest06 (void)
 
 static int ByteTest07 (void)
 {
-    const char *str = "1234567890";
+    const char str[] = "1234567890";
     uint64_t val = 1234567890;
     uint64_t i64 = 0xbfbfbfbfbfbfbfbfULL;
-    int ret = ByteExtractStringUint64(&i64, 10, strlen(str), str);
+    int ret = ByteExtractStringUint64(&i64, 10, sizeof(str) - 1, str);
 
     if ((ret == 10) && (i64 == val)) {
         return 1;
@@ -891,10 +891,10 @@ static int ByteTest07 (void)
 
 static int ByteTest08 (void)
 {
-    const char *str = "1234567890";
+    const char str[] = "1234567890";
     uint32_t val = 1234567890;
     uint32_t i32 = 0xbfbfbfbf;
-    int ret = ByteExtractStringUint32(&i32, 10, strlen(str), str);
+    int ret = ByteExtractStringUint32(&i32, 10, sizeof(str) - 1, str);
 
     if ((ret == 10) && (i32 == val)) {
         return 1;
@@ -905,10 +905,10 @@ static int ByteTest08 (void)
 
 static int ByteTest09 (void)
 {
-    const char *str = "12345";
+    const char str[] = "12345";
     uint16_t val = 12345;
     uint16_t i16 = 0xbfbf;
-    int ret = ByteExtractStringUint16(&i16, 10, strlen(str), str);
+    int ret = ByteExtractStringUint16(&i16, 10, sizeof(str) - 1, str);
 
     if ((ret == 5) && (i16 == val)) {
         return 1;
@@ -919,10 +919,10 @@ static int ByteTest09 (void)
 
 static int ByteTest10 (void)
 {
-    const char *str = "123";
+    const char str[] = "123";
     uint8_t val = 123;
     uint8_t i8 = 0xbf;
-    int ret = ByteExtractStringUint8(&i8, 10, strlen(str), str);
+    int ret = ByteExtractStringUint8(&i8, 10, sizeof(str) - 1, str);
 
     if ((ret == 3) && (i8 == val)) {
         return 1;
@@ -933,10 +933,10 @@ static int ByteTest10 (void)
 
 static int ByteTest11 (void)
 {
-    const char *str = "-1234567890";
+    const char str[] = "-1234567890";
     int64_t val = -1234567890;
     int64_t i64 = 0xbfbfbfbfbfbfbfbfULL;
-    int ret = ByteExtractStringInt64(&i64, 10, strlen(str), str);
+    int ret = ByteExtractStringInt64(&i64, 10, sizeof(str) - 1, str);
 
     if ((ret == 11) && (i64 == val)) {
         return 1;
@@ -947,10 +947,10 @@ static int ByteTest11 (void)
 
 static int ByteTest12 (void)
 {
-    const char *str = "-1234567890";
+    const char str[] = "-1234567890";
     int32_t val = -1234567890;
     int32_t i32 = 0xbfbfbfbf;
-    int ret = ByteExtractStringInt32(&i32, 10, strlen(str), str);
+    int ret = ByteExtractStringInt32(&i32, 10, sizeof(str) - 1, str);
 
     if ((ret == 11) && (i32 == val)) {
         return 1;
@@ -961,10 +961,10 @@ static int ByteTest12 (void)
 
 static int ByteTest13 (void)
 {
-    const char *str = "-12345";
+    const char str[] = "-12345";
     int16_t val = -12345;
     int16_t i16 = 0xbfbf;
-    int ret = ByteExtractStringInt16(&i16, 10, strlen(str), str);
+    int ret = ByteExtractStringInt16(&i16, 10, sizeof(str) - 1, str);
 
     if ((ret == 6) && (i16 == val)) {
         return 1;
@@ -975,10 +975,10 @@ static int ByteTest13 (void)
 
 static int ByteTest14 (void)
 {
-    const char *str = "-123";
+    const char str[] = "-123";
     int8_t val = -123;
     int8_t i8 = 0xbf;
-    int ret = ByteExtractStringInt8(&i8, 10, strlen(str), str);
+    int ret = ByteExtractStringInt8(&i8, 10, sizeof(str) - 1, str);
 
     if ((ret == 4) && (i8 == val)) {
         return 1;
@@ -990,11 +990,11 @@ static int ByteTest14 (void)
 /** \test max u32 value */
 static int ByteTest15 (void)
 {
-    const char *str = "4294967295";
+    const char str[] = "4294967295";
     uint32_t val = 4294967295UL;
     uint32_t u32 = 0xffffffff;
 
-    int ret = ByteExtractStringUint32(&u32, 10, strlen(str), str);
+    int ret = ByteExtractStringUint32(&u32, 10, sizeof(str) - 1, str);
     if ((ret == 10) && (u32 == val)) {
         return 1;
     }
@@ -1005,10 +1005,10 @@ static int ByteTest15 (void)
 /** \test max u32 value + 1 */
 static int ByteTest16 (void)
 {
-    const char *str = "4294967296";
+    const char str[] = "4294967296";
     uint32_t u32 = 0;
 
-    int ret = ByteExtractStringUint32(&u32, 10, strlen(str), str);
+    int ret = ByteExtractStringUint32(&u32, 10, sizeof(str) - 1, str);
     if (ret != 0) {
         return 1;
     }

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -220,7 +220,7 @@ static char *SCClassConfStringToLowercase(const char *str)
 
     temp_str = new_str;
     while (*temp_str != '\0') {
-        *temp_str = tolower((unsigned char)*temp_str);
+        *temp_str = (char)tolower(*temp_str);
         temp_str++;
     }
 
@@ -560,7 +560,7 @@ SCClassConfClasstype *SCClassConfGetClasstype(const char *ct_name,
     char name[strlen(ct_name) + 1];
     size_t s;
     for (s = 0; s < strlen(ct_name); s++)
-        name[s] = tolower((unsigned char)ct_name[s]);
+        name[s] = (char)tolower(ct_name[s]);
     name[s] = '\0';
 
     SCClassConfClasstype ct_lookup = {0, 0, name, NULL };

--- a/src/util-cpu.c
+++ b/src/util-cpu.c
@@ -121,7 +121,7 @@ uint16_t UtilCpuGetNumProcessorsOnline(void)
         return UINT16_MAX;
     }
 
-    return nprocs;
+    return (uint16_t)nprocs;
 #elif OS_WIN32
 	return UtilCpuGetNumProcessorsConfigured();
 #else

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -118,7 +118,7 @@ typedef struct SCLogOPIfaceCtx_ {
     SCLogOPIface iface;
 
     int16_t use_color;
-    int16_t type;
+    SCLogOPType type;
 
     /* the output file to be used if the interface is SC_LOG_IFACE_FILE */
     const char *file;

--- a/src/util-decode-mime.h
+++ b/src/util-decode-mime.h
@@ -85,7 +85,8 @@ typedef enum MimeDecRetCode {
     MIME_DEC_ERR_DATA = -1,
     MIME_DEC_ERR_MEM = -2,
     MIME_DEC_ERR_PARSE = -3,
-    MIME_DEC_ERR_STATE = -4,    /**< parser in error state */
+    MIME_DEC_ERR_STATE = -4, /**< parser in error state */
+    MIME_DEC_ERR_OVERFLOW = -5,
 } MimeDecRetCode;
 
 /**

--- a/src/util-fix_checksum.c
+++ b/src/util-fix_checksum.c
@@ -54,7 +54,6 @@ FixChecksum(uint16_t sum, uint16_t old, uint16_t new)
 
     l = sum + old - new;
     l = (l >> 16) + (l & 65535);
-    l = l & 65535;
 
-    return l;
+    return (uint16_t)l;
 }

--- a/src/util-host-os-info.c
+++ b/src/util-host-os-info.c
@@ -126,7 +126,7 @@ int SCHInfoAddHostOSInfo(const char *host_os, const char *host_os_ip_range, int 
     struct in_addr *ipv4_addr = NULL;
     struct in6_addr *ipv6_addr = NULL;
     char *netmask_str = NULL;
-    int netmask_value = 0;
+    uint8_t netmask_value = 0;
     int *user_data = NULL;
     bool recursive = false;
 
@@ -185,7 +185,8 @@ int SCHInfoAddHostOSInfo(const char *host_os, const char *host_os_ip_range, int 
             SCRadixAddKeyIPV4((uint8_t *)ipv4_addr, sc_hinfo_tree,
                               (void *)user_data);
         } else {
-            if (StringParseI32RangeCheck(&netmask_value, 10, 0, (const char *)netmask_str, 0, 32) < 0) {
+            if (StringParseU8RangeCheck(&netmask_value, 10, 0, (const char *)netmask_str, 0, 32) <
+                    0) {
                 SCLogError(SC_ERR_INVALID_IP_NETBLOCK, "Invalid IPV4 Netblock");
                 SCHInfoFreeUserDataOSPolicy(user_data);
                 SCFree(ipv4_addr);
@@ -210,7 +211,8 @@ int SCHInfoAddHostOSInfo(const char *host_os, const char *host_os_ip_range, int 
             SCRadixAddKeyIPV6((uint8_t *)ipv6_addr, sc_hinfo_tree,
                               (void *)user_data);
         } else {
-            if (StringParseI32RangeCheck(&netmask_value, 10, 0, (const char *)netmask_str, 0, 128) < 0) {
+            if (StringParseU8RangeCheck(&netmask_value, 10, 0, (const char *)netmask_str, 0, 128) <
+                    0) {
                 SCLogError(SC_ERR_INVALID_IP_NETBLOCK, "Invalid IPV6 Netblock");
                 SCHInfoFreeUserDataOSPolicy(user_data);
                 SCFree(ipv6_addr);

--- a/src/util-ioctl.c
+++ b/src/util-ioctl.c
@@ -206,7 +206,7 @@ int SetIfaceFlags(const char *ifname, int flags)
     ifr.ifr_flags = flags & 0xffff;
     ifr.ifr_flagshigh = flags >> 16;
 #else
-    ifr.ifr_flags = flags;
+    ifr.ifr_flags = (uint16_t)flags;
 #endif
 
     if (ioctl(fd, SIOCSIFFLAGS, &ifr) == -1) {

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -401,7 +401,7 @@ SCLogOpenFileFp(const char *path, const char *append_setting, uint32_t mode)
                    filename, strerror(errno));
     } else {
         if (mode != 0) {
-            int r = chmod(filename, mode);
+            int r = chmod(filename, (mode_t)mode);
             if (r < 0) {
                 SCLogWarning(SC_WARN_CHMOD, "Could not chmod %s to %o: %s",
                              filename, mode, strerror(errno));
@@ -494,9 +494,7 @@ SCConfLogOpenGeneric(ConfNode *conf,
 
     const char *filemode = ConfNodeLookupChildValue(conf, "filemode");
     uint32_t mode = 0;
-    if (filemode != NULL &&
-            StringParseUint32(&mode, 8, strlen(filemode),
-                                    filemode) > 0) {
+    if (filemode != NULL && StringParseUint32(&mode, 8, (uint16_t)strlen(filemode), filemode) > 0) {
         log_ctx->filemode = mode;
     }
 

--- a/src/util-macset.c
+++ b/src/util-macset.c
@@ -375,14 +375,13 @@ static int MacSetTest02(void)
 static int MacSetTest03(void)
 {
     MacSet *ms = NULL;
-    int i = 0;
     SC_ATOMIC_SET(flow_config.memcap, 10000);
 
     ms = MacSetInit(10);
     FAIL_IF_NULL(ms);
     FAIL_IF_NOT(MacSetSize(ms) == 0);
 
-    for (i = 1; i < 100; i++) {
+    for (uint8_t i = 1; i < 100; i++) {
         MacAddr addr1 = {0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
                 addr2 = {0x1, 0x0, 0x0, 0x0, 0x0, 0x1};
         addr1[5] = i;
@@ -409,14 +408,14 @@ static int MacSetTest04(void)
 static int MacSetTest05(void)
 {
     MacSet *ms = NULL;
-    int ret = 0, i = 0;
+    int ret = 0;
     SC_ATOMIC_SET(flow_config.memcap, 64);
 
     ms = MacSetInit(10);
     FAIL_IF_NULL(ms);
     FAIL_IF_NOT(MacSetSize(ms) == 0);
 
-    for (i = 1; i < 100; i++) {
+    for (uint8_t i = 1; i < 100; i++) {
         MacAddr addr1 = {0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
                 addr2 = {0x1, 0x0, 0x0, 0x0, 0x0, 0x1};
         addr1[5] = i;
@@ -425,7 +424,8 @@ static int MacSetTest05(void)
     }
     FAIL_IF_NOT(MacSetSize(ms) == 2);
 
-    ret = MacSetForEach(ms, CheckTest1Membership, &i);
+    int i2 = 100;
+    ret = MacSetForEach(ms, CheckTest1Membership, &i2);
     FAIL_IF_NOT(ret == 0);
 
     MacSetFree(ms);

--- a/src/util-mpm-ac-bs.c
+++ b/src/util-mpm-ac-bs.c
@@ -59,6 +59,7 @@
 #include "util-unittest-helper.h"
 #include "util-memcmp.h"
 #include "util-memcpy.h"
+#include "util-validate.h"
 
 void SCACBSInitCtx(MpmCtx *);
 void SCACBSInitThreadCtx(MpmCtx *, MpmThreadCtx *);
@@ -495,7 +496,8 @@ static inline void SCACBSCreateDeltaTable(MpmCtx *mpm_ctx)
         memset(&q, 0, sizeof(StateQueue));
 
         for (ascii_code = 0; ascii_code < 256; ascii_code++) {
-            SC_AC_BS_STATE_TYPE_U16 temp_state = ctx->goto_table[0][ascii_code];
+            DEBUG_VALIDATE_BUG_ON(ctx->goto_table[0][ascii_code] > UINT16_MAX);
+            SC_AC_BS_STATE_TYPE_U16 temp_state = (uint16_t)ctx->goto_table[0][ascii_code];
             ctx->state_table_u16[0][ascii_code] = temp_state;
             if (temp_state != 0)
                 SCACBSEnqueue(&q, temp_state);
@@ -508,7 +510,8 @@ static inline void SCACBSCreateDeltaTable(MpmCtx *mpm_ctx)
                 int32_t temp_state = ctx->goto_table[r_state][ascii_code];
                 if (temp_state != SC_AC_BS_FAIL) {
                     SCACBSEnqueue(&q, temp_state);
-                    ctx->state_table_u16[r_state][ascii_code] = temp_state;
+                    DEBUG_VALIDATE_BUG_ON(temp_state > UINT16_MAX);
+                    ctx->state_table_u16[r_state][ascii_code] = (uint16_t)temp_state;
                 } else {
                     ctx->state_table_u16[r_state][ascii_code] =
                         ctx->state_table_u16[ctx->failure_table[r_state]][ascii_code];

--- a/src/util-mpm-ac-bs.c
+++ b/src/util-mpm-ac-bs.c
@@ -1850,8 +1850,8 @@ static int SCACBSTest13(void)
     SCACBSInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzABCD";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzABCD";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACBSPreparePatterns(&mpm_ctx);
@@ -1884,8 +1884,8 @@ static int SCACBSTest14(void)
     SCACBSInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzABCDE";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzABCDE";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACBSPreparePatterns(&mpm_ctx);
@@ -1918,8 +1918,8 @@ static int SCACBSTest15(void)
     SCACBSInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzABCDEF";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzABCDEF";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACBSPreparePatterns(&mpm_ctx);
@@ -1952,8 +1952,8 @@ static int SCACBSTest16(void)
     SCACBSInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzABC";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzABC";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACBSPreparePatterns(&mpm_ctx);
@@ -1986,8 +1986,8 @@ static int SCACBSTest17(void)
     SCACBSInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzAB";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzAB";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACBSPreparePatterns(&mpm_ctx);
@@ -2020,8 +2020,13 @@ static int SCACBSTest18(void)
     SCACBSInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcde""fghij""klmno""pqrst""uvwxy""z";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcde"
+                       "fghij"
+                       "klmno"
+                       "pqrst"
+                       "uvwxy"
+                       "z";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACBSPreparePatterns(&mpm_ctx);
@@ -2054,8 +2059,8 @@ static int SCACBSTest19(void)
     SCACBSInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 */
-    const char *pat = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACBSPreparePatterns(&mpm_ctx);
@@ -2087,8 +2092,14 @@ static int SCACBSTest20(void)
     SCACBSInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 */
-    const char *pat = "AAAAA""AAAAA""AAAAA""AAAAA""AAAAA""AAAAA""AA";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "AAAAA"
+                       "AAAAA"
+                       "AAAAA"
+                       "AAAAA"
+                       "AAAAA"
+                       "AAAAA"
+                       "AA";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACBSPreparePatterns(&mpm_ctx);
@@ -2409,8 +2420,8 @@ static int SCACBSTest29(void)
 
 static int SCACBSTest30(void)
 {
-    uint8_t *buf = (uint8_t *)"onetwothreefourfivesixseveneightnine";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "onetwothreefourfivesixseveneightnine";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p = NULL;
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;

--- a/src/util-mpm-ac-ks.c
+++ b/src/util-mpm-ac-ks.c
@@ -1925,8 +1925,8 @@ static int SCACTileTest13(void)
     SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzABCD";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzABCD";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(&mpm_ctx);
@@ -1959,8 +1959,8 @@ static int SCACTileTest14(void)
     SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzABCDE";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzABCDE";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(&mpm_ctx);
@@ -1993,8 +1993,8 @@ static int SCACTileTest15(void)
     SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzABCDEF";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzABCDEF";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(&mpm_ctx);
@@ -2027,8 +2027,8 @@ static int SCACTileTest16(void)
     SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzABC";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzABC";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(&mpm_ctx);
@@ -2061,8 +2061,8 @@ static int SCACTileTest17(void)
     SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzAB";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzAB";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(&mpm_ctx);
@@ -2095,8 +2095,13 @@ static int SCACTileTest18(void)
     SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcde""fghij""klmno""pqrst""uvwxy""z";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcde"
+                       "fghij"
+                       "klmno"
+                       "pqrst"
+                       "uvwxy"
+                       "z";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(&mpm_ctx);
@@ -2129,8 +2134,8 @@ static int SCACTileTest19(void)
     SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 */
-    const char *pat = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(&mpm_ctx);
@@ -2163,8 +2168,14 @@ static int SCACTileTest20(void)
     SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 */
-    const char *pat = "AAAAA""AAAAA""AAAAA""AAAAA""AAAAA""AAAAA""AA";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "AAAAA"
+                       "AAAAA"
+                       "AAAAA"
+                       "AAAAA"
+                       "AAAAA"
+                       "AAAAA"
+                       "AA";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(&mpm_ctx);
@@ -2450,8 +2461,8 @@ static int SCACTileTest28(void)
 
 static int SCACTileTest29(void)
 {
-    uint8_t *buf = (uint8_t *)"onetwothreefourfivesixseveneightnine";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "onetwothreefourfivesixseveneightnine";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p = NULL;
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;

--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -59,6 +59,7 @@
 #include "util-memcmp.h"
 #include "util-mpm-ac.h"
 #include "util-memcpy.h"
+#include "util-validate.h"
 
 void SCACInitCtx(MpmCtx *);
 void SCACInitThreadCtx(MpmCtx *, MpmThreadCtx *);
@@ -578,7 +579,8 @@ static inline void SCACCreateDeltaTable(MpmCtx *mpm_ctx)
         memset(&q, 0, sizeof(StateQueue));
 
         for (ascii_code = 0; ascii_code < 256; ascii_code++) {
-            SC_AC_STATE_TYPE_U16 temp_state = ctx->goto_table[0][ascii_code];
+            DEBUG_VALIDATE_BUG_ON(ctx->goto_table[0][ascii_code] > UINT16_MAX);
+            SC_AC_STATE_TYPE_U16 temp_state = (uint16_t)ctx->goto_table[0][ascii_code];
             ctx->state_table_u16[0][ascii_code] = temp_state;
             if (temp_state != 0)
                 SCACEnqueue(&q, temp_state);
@@ -591,7 +593,8 @@ static inline void SCACCreateDeltaTable(MpmCtx *mpm_ctx)
                 int32_t temp_state = ctx->goto_table[r_state][ascii_code];
                 if (temp_state != SC_AC_FAIL) {
                     SCACEnqueue(&q, temp_state);
-                    ctx->state_table_u16[r_state][ascii_code] = temp_state;
+                    DEBUG_VALIDATE_BUG_ON(temp_state > UINT16_MAX);
+                    ctx->state_table_u16[r_state][ascii_code] = (uint16_t)temp_state;
                 } else {
                     ctx->state_table_u16[r_state][ascii_code] =
                         ctx->state_table_u16[ctx->failure_table[r_state]][ascii_code];

--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -1696,8 +1696,8 @@ static int SCACTest13(void)
     SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzABCD";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzABCD";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACPreparePatterns(&mpm_ctx);
@@ -1730,8 +1730,8 @@ static int SCACTest14(void)
     SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzABCDE";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzABCDE";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACPreparePatterns(&mpm_ctx);
@@ -1764,8 +1764,8 @@ static int SCACTest15(void)
     SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzABCDEF";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzABCDEF";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACPreparePatterns(&mpm_ctx);
@@ -1798,8 +1798,8 @@ static int SCACTest16(void)
     SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzABC";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzABC";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACPreparePatterns(&mpm_ctx);
@@ -1832,8 +1832,8 @@ static int SCACTest17(void)
     SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzAB";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzAB";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACPreparePatterns(&mpm_ctx);
@@ -1866,8 +1866,13 @@ static int SCACTest18(void)
     SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 match */
-    const char *pat = "abcde""fghij""klmno""pqrst""uvwxy""z";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcde"
+                       "fghij"
+                       "klmno"
+                       "pqrst"
+                       "uvwxy"
+                       "z";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACPreparePatterns(&mpm_ctx);
@@ -1900,8 +1905,8 @@ static int SCACTest19(void)
     SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 */
-    const char *pat = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACPreparePatterns(&mpm_ctx);
@@ -1934,8 +1939,14 @@ static int SCACTest20(void)
     SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     /* 1 */
-    const char *pat = "AAAAA""AAAAA""AAAAA""AAAAA""AAAAA""AAAAA""AA";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "AAAAA"
+                       "AAAAA"
+                       "AAAAA"
+                       "AAAAA"
+                       "AAAAA"
+                       "AAAAA"
+                       "AA";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCACPreparePatterns(&mpm_ctx);
@@ -2221,8 +2232,8 @@ static int SCACTest28(void)
 
 static int SCACTest29(void)
 {
-    uint8_t *buf = (uint8_t *)"onetwothreefourfivesixseveneightnine";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "onetwothreefourfivesixseveneightnine";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p = NULL;
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;

--- a/src/util-mpm-hs.c
+++ b/src/util-mpm-hs.c
@@ -1538,8 +1538,8 @@ static int SCHSTest13(void)
     MpmInitCtx(&mpm_ctx, MPM_HS);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzABCD";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzABCD";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCHSPreparePatterns(&mpm_ctx);
@@ -1572,8 +1572,8 @@ static int SCHSTest14(void)
     MpmInitCtx(&mpm_ctx, MPM_HS);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzABCDE";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzABCDE";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCHSPreparePatterns(&mpm_ctx);
@@ -1606,8 +1606,8 @@ static int SCHSTest15(void)
     MpmInitCtx(&mpm_ctx, MPM_HS);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzABCDEF";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzABCDEF";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCHSPreparePatterns(&mpm_ctx);
@@ -1640,8 +1640,8 @@ static int SCHSTest16(void)
     MpmInitCtx(&mpm_ctx, MPM_HS);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzABC";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzABC";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCHSPreparePatterns(&mpm_ctx);
@@ -1674,8 +1674,8 @@ static int SCHSTest17(void)
     MpmInitCtx(&mpm_ctx, MPM_HS);
 
     /* 1 match */
-    const char *pat = "abcdefghijklmnopqrstuvwxyzAB";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcdefghijklmnopqrstuvwxyzAB";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCHSPreparePatterns(&mpm_ctx);
@@ -1708,13 +1708,13 @@ static int SCHSTest18(void)
     MpmInitCtx(&mpm_ctx, MPM_HS);
 
     /* 1 match */
-    const char *pat = "abcde"
-                "fghij"
-                "klmno"
-                "pqrst"
-                "uvwxy"
-                "z";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "abcde"
+                       "fghij"
+                       "klmno"
+                       "pqrst"
+                       "uvwxy"
+                       "z";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCHSPreparePatterns(&mpm_ctx);
@@ -1752,8 +1752,8 @@ static int SCHSTest19(void)
     MpmInitCtx(&mpm_ctx, MPM_HS);
 
     /* 1 */
-    const char *pat = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCHSPreparePatterns(&mpm_ctx);
@@ -1786,14 +1786,14 @@ static int SCHSTest20(void)
     MpmInitCtx(&mpm_ctx, MPM_HS);
 
     /* 1 */
-    const char *pat = "AAAAA"
-                "AAAAA"
-                "AAAAA"
-                "AAAAA"
-                "AAAAA"
-                "AAAAA"
-                "AA";
-    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, strlen(pat), 0, 0, 0, 0, 0);
+    const char pat[] = "AAAAA"
+                       "AAAAA"
+                       "AAAAA"
+                       "AAAAA"
+                       "AAAAA"
+                       "AAAAA"
+                       "AA";
+    MpmAddPatternCS(&mpm_ctx, (uint8_t *)pat, sizeof(pat) - 1, 0, 0, 0, 0, 0);
     PmqSetup(&pmq);
 
     SCHSPreparePatterns(&mpm_ctx);
@@ -2086,8 +2086,8 @@ static int SCHSTest28(void)
 
 static int SCHSTest29(void)
 {
-    uint8_t *buf = (uint8_t *)"onetwothreefourfivesixseveneightnine";
-    uint16_t buflen = strlen((char *)buf);
+    uint8_t buf[] = "onetwothreefourfivesixseveneightnine";
+    uint16_t buflen = sizeof(buf) - 1;
     Packet *p = NULL;
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;

--- a/src/util-mpm.c
+++ b/src/util-mpm.c
@@ -46,7 +46,7 @@
 #endif
 
 MpmTableElmt mpm_table[MPM_TABLE_SIZE];
-uint16_t mpm_default_matcher;
+uint8_t mpm_default_matcher;
 
 /**
  * \brief Register a new Mpm Context.
@@ -197,7 +197,7 @@ void MpmInitThreadCtx(MpmThreadCtx *mpm_thread_ctx, uint16_t matcher)
     mpm_table[matcher].InitThreadCtx(NULL, mpm_thread_ctx);
 }
 
-void MpmInitCtx (MpmCtx *mpm_ctx, uint16_t matcher)
+void MpmInitCtx(MpmCtx *mpm_ctx, uint8_t matcher)
 {
     mpm_ctx->mpm_type = matcher;
     mpm_table[matcher].InitCtx(mpm_ctx);

--- a/src/util-mpm.h
+++ b/src/util-mpm.h
@@ -170,7 +170,7 @@ typedef struct MpmTableElmt_ {
 } MpmTableElmt;
 
 extern MpmTableElmt mpm_table[MPM_TABLE_SIZE];
-extern uint16_t mpm_default_matcher;
+extern uint8_t mpm_default_matcher;
 
 struct DetectEngineCtx_;
 
@@ -188,7 +188,7 @@ void PmqFree(PrefilterRuleStore *);
 void MpmTableSetup(void);
 void MpmRegisterTests(void);
 
-void MpmInitCtx(MpmCtx *mpm_ctx, uint16_t matcher);
+void MpmInitCtx(MpmCtx *mpm_ctx, uint8_t matcher);
 void MpmInitThreadCtx(MpmThreadCtx *mpm_thread_ctx, uint16_t);
 
 int MpmAddPatternCS(struct MpmCtx_ *mpm_ctx, uint8_t *pat, uint16_t patlen,

--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -2953,7 +2953,7 @@ static int SCRadixTestIPV4NetBlocksAndBestSearch15(void)
 
     tree = SCRadixCreateRadixTree(free, NULL);
 
-    uint32_t i = 0;
+    uint8_t i = 0;
 
     uint32_t *user;
 
@@ -3013,7 +3013,7 @@ static int SCRadixTestIPV4NetBlocksAndBestSearch16(void)
 
     tree = SCRadixCreateRadixTree(free, NULL);
 
-    uint32_t i = 0;
+    uint8_t i = 0;
 
     uint32_t *user;
 
@@ -3073,7 +3073,7 @@ static int SCRadixTestIPV4NetBlocksAndBestSearch17(void)
 
     tree = SCRadixCreateRadixTree(free, NULL);
 
-    uint32_t i = 0;
+    uint8_t i = 0;
 
     uint32_t *user;
 
@@ -3133,7 +3133,7 @@ static int SCRadixTestIPV4NetBlocksAndBestSearch18(void)
 
     tree = SCRadixCreateRadixTree(free, NULL);
 
-    uint32_t i = 0;
+    uint8_t i = 0;
 
     uint32_t *user;
 
@@ -3439,7 +3439,7 @@ static int SCRadixTestIPV6NetBlocksAndBestSearch20(void)
 
     tree = SCRadixCreateRadixTree(free, NULL);
 
-    uint32_t i = 0;
+    uint8_t i = 0;
 
     uint32_t *user;
 
@@ -3499,7 +3499,7 @@ static int SCRadixTestIPV6NetBlocksAndBestSearch21(void)
 
     tree = SCRadixCreateRadixTree(free, NULL);
 
-    uint32_t i = 0;
+    uint8_t i = 0;
 
     uint32_t *user;
 
@@ -3559,7 +3559,7 @@ static int SCRadixTestIPV6NetBlocksAndBestSearch22(void)
 
     tree = SCRadixCreateRadixTree(free, NULL);
 
-    uint32_t i = 0;
+    uint8_t i = 0;
 
     uint32_t *user;
 
@@ -3619,7 +3619,7 @@ static int SCRadixTestIPV6NetBlocksAndBestSearch23(void)
 
     tree = SCRadixCreateRadixTree(free, NULL);
 
-    uint32_t i = 0;
+    uint8_t i = 0;
 
     uint32_t *user;
 

--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -486,8 +486,8 @@ void SCRadixReleaseRadixTree(SCRadixTree *tree)
  *
  * \retval node Pointer to the newly created node
  */
-static SCRadixNode *SCRadixAddKey(uint8_t *key_stream, uint16_t key_bitlen,
-                                  SCRadixTree *tree, void *user, uint8_t netmask)
+static SCRadixNode *SCRadixAddKey(
+        uint8_t *key_stream, uint8_t key_bitlen, SCRadixTree *tree, void *user, uint8_t netmask)
 {
     SCRadixNode *node = NULL;
     SCRadixNode *new_node = NULL;
@@ -499,11 +499,11 @@ static SCRadixNode *SCRadixAddKey(uint8_t *key_stream, uint16_t key_bitlen,
     uint8_t *stream = NULL;
     uint8_t bitlen = 0;
 
-    int check_bit = 0;
-    int differ_bit = 0;
+    uint16_t check_bit = 0;
+    uint16_t differ_bit = 0;
 
-    int i = 0;
-    int j = 0;
+    uint16_t i = 0;
+    uint16_t j = 0;
     int temp = 0;
 
     if (tree == NULL) {
@@ -681,14 +681,14 @@ static SCRadixNode *SCRadixAddKey(uint8_t *key_stream, uint16_t key_bitlen,
 
                 node->netmasks[node->netmask_cnt - 1] = netmask;
 
-                for (i = node->netmask_cnt - 2; i >= 0; i--) {
-                    if (netmask < node->netmasks[i]) {
-                        node->netmasks[i + 1] = netmask;
+                for (i = node->netmask_cnt - 1; i > 0; i--) {
+                    if (netmask < node->netmasks[i - 1]) {
+                        node->netmasks[i] = netmask;
                         break;
                     }
 
-                    node->netmasks[i + 1] = node->netmasks[i];
-                    node->netmasks[i] = netmask;
+                    node->netmasks[i] = node->netmasks[i - 1];
+                    node->netmasks[i - 1] = netmask;
                 }
             }
         } else {
@@ -809,38 +809,18 @@ static SCRadixNode *SCRadixAddKey(uint8_t *key_stream, uint16_t key_bitlen,
 
         node->netmasks[node->netmask_cnt - 1] = netmask;
 
-        for (i = node->netmask_cnt - 2; i >= 0; i--) {
-            if (netmask < node->netmasks[i]) {
-                node->netmasks[i + 1] = netmask;
+        for (i = node->netmask_cnt - 1; i > 0; i--) {
+            if (netmask < node->netmasks[i - 1]) {
+                node->netmasks[i] = netmask;
                 break;
             }
 
-            node->netmasks[i + 1] = node->netmasks[i];
-            node->netmasks[i] = netmask;
+            node->netmasks[i] = node->netmasks[i - 1];
+            node->netmasks[i - 1] = netmask;
         }
     }
 
     return new_node;
-}
-
-/**
- * \brief Adds a new generic key to the Radix tree
- *
- * \param key_stream Data that has to be added to the Radix tree
- * \param key_bitlen The bitlen of the the above stream.  For example if the
- *                   stream is the string "abcd", the bitlen would be 32
- * \param tree       Pointer to the Radix tree
- * \param user       Pointer to the user data that has to be associated with the
- *                   key
- *
- * \retval node Pointer to the newly created node
- */
-SCRadixNode *SCRadixAddKeyGeneric(uint8_t *key_stream, uint16_t key_bitlen,
-                                  SCRadixTree *tree, void *user)
-{
-    SCRadixNode *node = SCRadixAddKey(key_stream, key_bitlen, tree, user, 255);
-
-    return node;
 }
 
 /**
@@ -1398,8 +1378,8 @@ static inline SCRadixNode *SCRadixFindKeyIPNetblock(uint8_t *key_stream, uint8_t
  * \param tree        Pointer to the Radix tree
  * \param exact_match The key to be searched is an ip address
  */
-static SCRadixNode *SCRadixFindKey(uint8_t *key_stream, uint16_t key_bitlen,
-                                   SCRadixTree *tree, int exact_match, void **user_data_result)
+static SCRadixNode *SCRadixFindKey(uint8_t *key_stream, uint8_t key_bitlen, SCRadixTree *tree,
+        int exact_match, void **user_data_result)
 {
     if (tree == NULL || tree->head == NULL)
         return NULL;
@@ -1408,9 +1388,6 @@ static SCRadixNode *SCRadixFindKey(uint8_t *key_stream, uint16_t key_bitlen,
     uint32_t mask = 0;
     int bytes = 0;
     uint8_t tmp_stream[255];
-
-    if (key_bitlen > 255)
-        return NULL;
 
     memset(tmp_stream, 0, 255);
     memcpy(tmp_stream, key_stream, key_bitlen / 8);
@@ -1451,19 +1428,6 @@ static SCRadixNode *SCRadixFindKey(uint8_t *key_stream, uint16_t key_bitlen,
 
     SCRadixNode *ret = SCRadixFindKeyIPNetblock(tmp_stream, key_bitlen, node, user_data_result);
     return ret;
-}
-
-/**
- * \brief Checks if a key is present in the tree
- *
- * \param key_stream Data that has to be found in the Radix tree
- * \param key_bitlen The bitlen of the the above stream.
- * \param tree       Pointer to the Radix tree instance
- */
-SCRadixNode *SCRadixFindKeyGeneric(uint8_t *key_stream, uint16_t key_bitlen,
-                                   SCRadixTree *tree, void **user_data_result)
-{
-    return SCRadixFindKey(key_stream, key_bitlen, tree, 1, user_data_result);
 }
 
 /**

--- a/src/util-radix-tree.h
+++ b/src/util-radix-tree.h
@@ -66,7 +66,7 @@ typedef struct SCRadixNode_ {
     uint16_t pad0;
 
     /* total no of netmasks that are registered under this node */
-    int netmask_cnt;
+    uint16_t netmask_cnt;
     /* holds a list of netmaks that come under this node in the tree */
     uint8_t *netmasks;
 
@@ -101,7 +101,6 @@ void SCRadixChopIPAddressAgainstNetmask(uint8_t *, uint8_t, uint16_t);
 SCRadixTree *SCRadixCreateRadixTree(void (*Free)(void*), void (*PrintData)(void*));
 void SCRadixReleaseRadixTree(SCRadixTree *);
 
-SCRadixNode *SCRadixAddKeyGeneric(uint8_t *, uint16_t, SCRadixTree *, void *);
 SCRadixNode *SCRadixAddKeyIPV4(uint8_t *, SCRadixTree *, void *);
 SCRadixNode *SCRadixAddKeyIPV6(uint8_t *, SCRadixTree *, void *);
 SCRadixNode *SCRadixAddKeyIPV4Netblock(uint8_t *, SCRadixTree *, void *,
@@ -116,8 +115,6 @@ void SCRadixRemoveKeyIPV4Netblock(uint8_t *, SCRadixTree *, uint8_t);
 void SCRadixRemoveKeyIPV4(uint8_t *, SCRadixTree *);
 void SCRadixRemoveKeyIPV6Netblock(uint8_t *, SCRadixTree *, uint8_t);
 void SCRadixRemoveKeyIPV6(uint8_t *, SCRadixTree *);
-
-SCRadixNode *SCRadixFindKeyGeneric(uint8_t *, uint16_t, SCRadixTree *, void **);
 
 SCRadixNode *SCRadixFindKeyIPV4ExactMatch(uint8_t *, SCRadixTree *, void **);
 SCRadixNode *SCRadixFindKeyIPV4Netblock(uint8_t *, SCRadixTree *, uint8_t, void **);

--- a/src/util-reference-config.c
+++ b/src/util-reference-config.c
@@ -210,7 +210,7 @@ static char *SCRConfStringToLowercase(const char *str)
 
     temp_str = new_str;
     while (*temp_str != '\0') {
-        *temp_str = tolower((unsigned char)*temp_str);
+        *temp_str = (char)tolower(*temp_str);
         temp_str++;
     }
 

--- a/src/util-spm-bm.c
+++ b/src/util-spm-bm.c
@@ -38,6 +38,7 @@
 #include "util-debug.h"
 #include "util-error.h"
 #include "util-memcpy.h"
+#include "util-validate.h"
 
 static int PreBmGs(const uint8_t *x, uint16_t m, uint16_t *bmGs);
 static void PreBmBc(const uint8_t *x, uint16_t m, uint16_t *bmBc);
@@ -137,7 +138,7 @@ void BoyerMooreCtxDeInit(BmCtx *bmctx)
  */
 static void PreBmBc(const uint8_t *x, uint16_t m, uint16_t *bmBc)
 {
-    int32_t i;
+    uint16_t i;
 
     for (i = 0; i < 256; ++i) {
         bmBc[i] = m;
@@ -168,7 +169,8 @@ static void BoyerMooreSuffixes(const uint8_t *x, uint16_t m, uint16_t *suff)
             f = i;
             while (g >= 0 && x[g] == x[g + m - 1 - f])
                 --g;
-            suff[i] = f - g;
+            DEBUG_VALIDATE_BUG_ON(f - g < 0 || f - g > UINT16_MAX);
+            suff[i] = (uint16_t)(f - g);
         }
     }
 }
@@ -197,10 +199,10 @@ static int PreBmGs(const uint8_t *x, uint16_t m, uint16_t *bmGs)
         if (i == -1 || suff[i] == i + 1)
             for (; j < m - 1 - i; ++j)
                 if (bmGs[j] == m)
-                    bmGs[j] = m - 1 - i;
+                    bmGs[j] = (uint16_t)(m - 1 - i);
 
     for (i = 0; i <= m - 2; ++i)
-        bmGs[m - 1 - suff[i]] = m - 1 - i;
+        bmGs[m - 1 - suff[i]] = (uint16_t)(m - 1 - i);
     return 0;
 }
 
@@ -214,14 +216,14 @@ static int PreBmGs(const uint8_t *x, uint16_t m, uint16_t *bmGs)
  */
 static void PreBmBcNocase(const uint8_t *x, uint16_t m, uint16_t *bmBc)
 {
-    int32_t i;
+    uint16_t i;
 
     for (i = 0; i < 256; ++i) {
         bmBc[i] = m;
     }
     for (i = 0; i < m - 1; ++i) {
-        bmBc[u8_tolower((unsigned char)x[i])] = m - 1 - i;
-        bmBc[u8_toupper((unsigned char)x[i])] = m - 1 - i;
+        bmBc[u8_tolower(x[i])] = m - 1 - i;
+        bmBc[u8_toupper(x[i])] = m - 1 - i;
     }
 }
 
@@ -243,7 +245,8 @@ static void BoyerMooreSuffixesNocase(const uint8_t *x, uint16_t m,
             while (g >= 0 && u8_tolower(x[g]) == u8_tolower(x[g + m - 1 - f])) {
                 --g;
             }
-            suff[i] = f - g;
+            DEBUG_VALIDATE_BUG_ON(f - g < 0 || f - g > UINT16_MAX);
+            suff[i] = (uint16_t)(f - g);
         }
     }
 }
@@ -258,7 +261,7 @@ static void BoyerMooreSuffixesNocase(const uint8_t *x, uint16_t m,
  */
 static void PreBmGsNocase(const uint8_t *x, uint16_t m, uint16_t *bmGs)
 {
-    int32_t i, j;
+    uint16_t i, j;
     uint16_t suff[m + 1];
 
     BoyerMooreSuffixesNocase(x, m, suff);
@@ -267,11 +270,11 @@ static void PreBmGsNocase(const uint8_t *x, uint16_t m, uint16_t *bmGs)
         bmGs[i] = m;
     }
     j = 0;
-    for (i = m - 1; i >= 0; --i) {
-        if (i == -1 || suff[i] == i + 1) {
-            for (; j < m - 1 - i; ++j) {
+    for (i = m; i > 0; --i) {
+        if (suff[i] == i) {
+            for (; j < m - i; ++j) {
                 if (bmGs[j] == m) {
-                    bmGs[j] = m - 1 - i;
+                    bmGs[j] = m - i;
                 }
             }
         }

--- a/src/util-spm.c
+++ b/src/util-spm.c
@@ -298,7 +298,7 @@ uint8_t *BoyerMooreNocaseSearch(const uint8_t *text, uint32_t textlen,
 static uint8_t *BasicSearchWrapper(uint8_t *text, uint8_t *needle, int times)
 {
     uint32_t textlen = strlen((char *)text);
-    uint16_t needlelen = strlen((char *)needle);
+    uint16_t needlelen = (uint16_t)strlen((char *)needle);
 
     uint8_t *ret = NULL;
     int i = 0;
@@ -318,7 +318,7 @@ static uint8_t *BasicSearchWrapper(uint8_t *text, uint8_t *needle, int times)
 static uint8_t *BasicSearchNocaseWrapper(uint8_t *text, uint8_t *needle, int times)
 {
     uint32_t textlen = strlen((char *)text);
-    uint16_t needlelen = strlen((char *)needle);
+    uint16_t needlelen = (uint16_t)strlen((char *)needle);
 
     uint8_t *ret = NULL;
     int i = 0;
@@ -335,7 +335,7 @@ static uint8_t *BasicSearchNocaseWrapper(uint8_t *text, uint8_t *needle, int tim
 static uint8_t *Bs2bmWrapper(uint8_t *text, uint8_t *needle, int times)
 {
     uint32_t textlen = strlen((char *)text);
-    uint16_t needlelen = strlen((char *)needle);
+    uint16_t needlelen = (uint16_t)strlen((char *)needle);
 
     uint8_t badchars[ALPHABET_SIZE];
     Bs2BmBadchars(needle, needlelen, badchars);
@@ -355,7 +355,7 @@ static uint8_t *Bs2bmWrapper(uint8_t *text, uint8_t *needle, int times)
 static uint8_t *Bs2bmNocaseWrapper(uint8_t *text, uint8_t *needle, int times)
 {
     uint32_t textlen = strlen((char *)text);
-    uint16_t needlelen = strlen((char *)needle);
+    uint16_t needlelen = (uint16_t)strlen((char *)needle);
 
     uint8_t badchars[ALPHABET_SIZE];
     Bs2BmBadchars(needle, needlelen, badchars);
@@ -375,7 +375,7 @@ static uint8_t *Bs2bmNocaseWrapper(uint8_t *text, uint8_t *needle, int times)
 static uint8_t *BoyerMooreWrapper(uint8_t *text, uint8_t *needle, int times)
 {
     uint32_t textlen = strlen((char *)text);
-    uint16_t needlelen = strlen((char *)needle);
+    uint16_t needlelen = (uint16_t)strlen((char *)needle);
 
     BmCtx *bm_ctx = BoyerMooreCtxInit(needle, needlelen);
 
@@ -395,7 +395,7 @@ static uint8_t *BoyerMooreWrapper(uint8_t *text, uint8_t *needle, int times)
 static uint8_t *BoyerMooreNocaseWrapper(uint8_t *text, uint8_t *in_needle, int times)
 {
     uint32_t textlen = strlen((char *)text);
-    uint16_t needlelen = strlen((char *)in_needle);
+    uint16_t needlelen = (uint16_t)strlen((char *)in_needle);
 
     /* Make a copy of in_needle to be able to convert it to lowercase. */
     uint8_t *needle = SCMalloc(needlelen);
@@ -2631,7 +2631,7 @@ static int SpmSearchTest02(void) {
             uint16_t prefix;
             for (prefix = 0; prefix < 32; prefix++) {
                 d.needle = needle;
-                d.needle_len = strlen(needle);
+                d.needle_len = (uint16_t)strlen(needle);
                 uint16_t haystack_len = prefix + d.needle_len;
                 char *haystack = SCMalloc(haystack_len);
                 if (haystack == NULL) {
@@ -2655,7 +2655,7 @@ static int SpmSearchTest02(void) {
                 d.nocase = 1;
                 uint16_t j;
                 for (j = 0; j < haystack_len; j++) {
-                    haystack[j] = toupper(haystack[j]);
+                    haystack[j] = (char)toupper(haystack[j]);
                 }
                 if (SpmTestSearch(&d, matcher) == 0) {
                     printf("  test %" PRIu32 ": fail (case-insensitive)\n", i);

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -231,8 +231,7 @@ static int THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
     GET_VAR(cnf_prefix, "hash-size");
     if ((ConfGet(varname, &conf_val)) == 1)
     {
-        if (StringParseUint32(&configval, 10, strlen(conf_val),
-                                    conf_val) > 0) {
+        if (StringParseUint32(&configval, 10, (uint16_t)strlen(conf_val), conf_val) > 0) {
             ctx->config.hash_size = configval;
         }
     }
@@ -240,8 +239,7 @@ static int THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
     GET_VAR(cnf_prefix, "prealloc");
     if ((ConfGet(varname, &conf_val)) == 1)
     {
-        if (StringParseUint32(&configval, 10, strlen(conf_val),
-                                    conf_val) > 0) {
+        if (StringParseUint32(&configval, 10, (uint16_t)strlen(conf_val), conf_val) > 0) {
             ctx->config.prealloc = configval;
         } else {
             WarnInvalidConfEntry(varname, "%"PRIu32, ctx->config.prealloc);

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -856,7 +856,7 @@ static int ParseThresholdRule(DetectEngineCtx *de_ctx, char *rawstr,
 
                 /* TODO: implement option "apply_to" */
 
-                if (StringParseUint32(&parsed_timeout, 10, strlen(th_timeout), th_timeout) <= 0) {
+                if (StringParseUint32(&parsed_timeout, 10, sizeof(th_timeout), th_timeout) <= 0) {
                     goto error;
                 }
 
@@ -904,7 +904,7 @@ static int ParseThresholdRule(DetectEngineCtx *de_ctx, char *rawstr,
                 goto error;
             }
 
-            if (StringParseUint32(&parsed_count, 10, strlen(th_count), th_count) <= 0) {
+            if (StringParseUint32(&parsed_count, 10, sizeof(th_count), th_count) <= 0) {
                 goto error;
             }
             if (parsed_count == 0) {
@@ -912,7 +912,7 @@ static int ParseThresholdRule(DetectEngineCtx *de_ctx, char *rawstr,
                 goto error;
             }
 
-            if (StringParseUint32(&parsed_seconds, 10, strlen(th_seconds), th_seconds) <= 0) {
+            if (StringParseUint32(&parsed_seconds, 10, sizeof(th_seconds), th_seconds) <= 0) {
                 goto error;
             }
 
@@ -935,11 +935,11 @@ static int ParseThresholdRule(DetectEngineCtx *de_ctx, char *rawstr,
             break;
     }
 
-    if (StringParseUint32(&id, 10, strlen(th_sid), th_sid) <= 0) {
+    if (StringParseUint32(&id, 10, sizeof(th_sid), th_sid) <= 0) {
         goto error;
     }
 
-    if (StringParseUint32(&gid, 10, strlen(th_gid), th_gid) <= 0) {
+    if (StringParseUint32(&gid, 10, sizeof(th_gid), th_gid) <= 0) {
         goto error;
     }
 

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -656,13 +656,13 @@ int UTHCheckPacketMatchResults(Packet *p, uint32_t sids[],
     int i = 0;
     int res = 1;
     for (; i < numsids; i++) {
-        uint16_t r = PacketAlertCheck(p, sids[i]);
+        uint32_t r = PacketAlertCheck(p, sids[i]);
         if (r != results[i]) {
-            SCLogInfo("Sid %"PRIu32" matched %"PRIu16" times, and not %"PRIu32
-                    " as expected", sids[i], r, results[i]);
+            SCLogInfo("Sid %" PRIu32 " matched %" PRIu32 " times, and not %" PRIu32 " as expected",
+                    sids[i], r, results[i]);
             res = 0;
         } else {
-            SCLogInfo("Sid %"PRIu32" matched %"PRIu16" times, as expected", sids[i], r);
+            SCLogInfo("Sid %" PRIu32 " matched %" PRIu32 " times, as expected", sids[i], r);
         }
     }
     return res;

--- a/src/util-var-name.c
+++ b/src/util-var-name.c
@@ -61,7 +61,7 @@ static SCMutex g_varnamestore_staging_m = SCMUTEX_INITIALIZER;
 /** \brief Name2idx mapping structure for flowbits, flowvars and pktvars. */
 typedef struct VariableName_ {
     char *name;
-    uint8_t type; /* flowbit, pktvar, etc */
+    enum VarTypes type; /* flowbit, pktvar, etc */
     uint32_t idx;
 } VariableName;
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4516

Describe changes:
- Fix integer warnings `-Wimplicit-int-conversion` in all files except d*

Extends #6792 : now only d* files remain with warnings...

Thoughts about the commit history ?