### PR TITLE
Doc: Fix typos in documentation of suricata.yaml.

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -149,9 +149,9 @@ Splitting configuration in multiple files
 -----------------------------------------
 
 Some users might have a need or a wish to split their suricata.yaml
-file in to separate files, this is available vis the 'include' and
+file in to separate files, this is available via the 'include' and
 '!include' keyword. The first example is of taking the contents of the
-outputs section and storing them in outputs.yaml
+outputs section and storing them in outputs.yaml.
 
 ::
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
  Not applicable, since this is just a minor typo fix.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: Not applicable, since this is just a minor typo fix.

Describe changes:
- Fix small typos in documentation of splitting suricata.yaml in to multiple files ([10.1.7](https://suricata.readthedocs.io/en/latest/configuration/suricata-yaml.html#splitting-configuration-in-multiple-files)).

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:

Thanks for merging :)