### PR TITLE
Dev/nom7 simplify bits annotation v0.1

### DIFF
--- a/rust/src/mqtt/parser.rs
+++ b/rust/src/mqtt/parser.rs
@@ -17,12 +17,12 @@
 
 // written by Sascha Steinbiss <sascha@steinbiss.name>
 
+use crate::common::nom7::bits;
 use crate::mqtt::mqtt_message::*;
 use crate::mqtt::mqtt_property::*;
-use nom7::bits::{bits, streaming::take as take_bits};
+use nom7::bits::streaming::take as take_bits;
 use nom7::bytes::streaming::take_while_m_n;
 use nom7::combinator::{complete, cond, verify};
-use nom7::error::Error;
 use nom7::multi::{length_data, many0, many1};
 use nom7::number::streaming::*;
 use nom7::sequence::tuple;
@@ -132,7 +132,7 @@ fn parse_properties(input: &[u8], precond: bool) -> IResult<&[u8], Option<Vec<MQ
 
 #[inline]
 fn parse_fixed_header_flags(i: &[u8]) -> IResult<&[u8], (u8, u8, u8, u8)> {
-    bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((
+    bits(tuple((
         take_bits(4u8),
         take_bits(1u8),
         take_bits(2u8),
@@ -176,7 +176,7 @@ pub fn parse_fixed_header(i: &[u8]) -> IResult<&[u8], FixedHeader> {
 
 #[inline]
 fn parse_connect_variable_flags(i: &[u8]) -> IResult<&[u8], (u8, u8, u8, u8, u8, u8, u8)> {
-    bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((
+    bits(tuple((
         take_bits(1u8),
         take_bits(1u8),
         take_bits(1u8),

--- a/rust/src/nfs/rpc_records.rs
+++ b/rust/src/nfs/rpc_records.rs
@@ -17,10 +17,10 @@
 
 //! Nom parsers for RPCv2
 
-use nom7::bits::{bits, streaming::take as take_bits};
+use crate::common::nom7::bits;
+use nom7::bits::streaming::take as take_bits;
 use nom7::bytes::streaming::take;
 use nom7::combinator::cond;
-use nom7::error::Error;
 use nom7::multi::length_data;
 use nom7::number::streaming::be_u32;
 use nom7::sequence::tuple;
@@ -121,7 +121,7 @@ pub struct RpcPacketHeader {
 }
 
 fn parse_bits(i: &[u8]) -> IResult<&[u8], (u8, u32)> {
-    bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((
+    bits(tuple((
         take_bits(1u8),   // is_last
         take_bits(31u32), // len
     )))(i)

--- a/rust/src/smb/dcerpc_records.rs
+++ b/rust/src/smb/dcerpc_records.rs
@@ -15,11 +15,11 @@
  * 02110-1301, USA.
  */
 
+use crate::common::nom7::bits;
 use crate::smb::error::SmbError;
-use nom7::bits::{bits, streaming::take as take_bits};
+use nom7::bits::streaming::take as take_bits;
 use nom7::bytes::streaming::take;
 use nom7::combinator::{cond, rest};
-use nom7::error::Error;
 use nom7::multi::count;
 use nom7::number::Endianness;
 use nom7::number::streaming::{be_u16, le_u8, le_u16, le_u32, u16, u32};
@@ -204,7 +204,7 @@ pub struct DceRpcRecord<'a> {
 }
 
 fn parse_dcerpc_flags1(i:&[u8]) -> IResult<&[u8],(u8,u8,u8)> {
-    bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((
+    bits(tuple((
         take_bits(6u8),
         take_bits(1u8),   // last (1)
         take_bits(1u8),
@@ -212,7 +212,7 @@ fn parse_dcerpc_flags1(i:&[u8]) -> IResult<&[u8],(u8,u8,u8)> {
 }
 
 fn parse_dcerpc_flags2(i:&[u8]) -> IResult<&[u8],(u32,u32,u32)> {
-    bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((
+    bits(tuple((
        take_bits(3u32),
        take_bits(1u32),     // endianess
        take_bits(28u32),

--- a/rust/src/smb/ntlmssp_records.rs
+++ b/rust/src/smb/ntlmssp_records.rs
@@ -15,12 +15,11 @@
  * 02110-1301, USA.
  */
 
-use crate::common::nom7::take_until_and_consume;
+use crate::common::nom7::{bits, take_until_and_consume};
 use std::fmt;
-use nom7::bits::{bits, streaming::take as take_bits};
+use nom7::bits::streaming::take as take_bits;
 use nom7::bytes::streaming::take;
 use nom7::combinator::{cond, rest};
-use nom7::error::Error;
 use nom7::number::streaming::{le_u8, le_u16, le_u32};
 use nom7::sequence::tuple;
 use nom7::IResult;
@@ -65,7 +64,7 @@ pub struct NTLMSSPAuthRecord<'a> {
 }
 
 fn parse_ntlm_auth_nego_flags(i:&[u8]) -> IResult<&[u8],(u8,u8,u32)> {
-    bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((
+    bits(tuple((
         take_bits(6u8),
         take_bits(1u8),
         take_bits(25u32),

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -15,12 +15,13 @@
  * 02110-1301, USA.
  */
 
+use crate::common::nom7::bits;
 use crate::smb::smb::*;
 use crate::smb::nbss_records::NBSS_MSGTYPE_SESSION_MESSAGE;
-use nom7::bits::{bits, streaming::take as take_bits};
+use nom7::bits::streaming::take as take_bits;
 use nom7::bytes::streaming::{tag, take};
 use nom7::combinator::{cond, map_parser, rest};
-use nom7::error::{make_error, Error, ErrorKind};
+use nom7::error::{make_error, ErrorKind};
 use nom7::multi::count;
 use nom7::number::streaming::{le_u8, le_u16, le_u32, le_u64};
 use nom7::sequence::tuple;
@@ -71,7 +72,7 @@ impl<'a> Smb2Record<'a> {
 }
 
 fn parse_smb2_request_flags(i:&[u8]) -> IResult<&[u8],(u8,u8,u8,u32,u8,u8,u8,u8)> {
-    bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((
+    bits(tuple((
         take_bits(2u8),      // reserved / unused
         take_bits(1u8),      // replay op
         take_bits(1u8),      // dfs op


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
This is an attempt to fix the problem raised in https://github.com/OISF/suricata/pull/6771#discussion_r783425750

After some tests, I think I have found a nice way to remove the need for annotations in the `bits` combinator.
4d6aa6d53297ef21901a6ba62387b5e15f148852 adds a `bits` combinator to the `common::nom7` module, which is a proxy to the nom combinator with some types made explicit, but still generic.

It can then be used in the rest of the code, and the annotations can be removed,

Note: it is still possible to use the nom combinator if needed, the choice simply depends on the namespace use in the `use` statement.