### PR TITLE
detect: logs an error if a protocol is disabled

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1507,6 +1507,11 @@ int DetectSignatureSetAppProto(Signature *s, AppProto alproto)
         }
     }
 
+    if (AppLayerProtoDetectGetProtoName(alproto) == NULL && alproto != ALPROTO_HTTP) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT, "disabled alproto %s, rule can never match",
+                AppProtoToString(alproto));
+        return -1;
+    }
     s->alproto = alproto;
     s->flags |= SIG_FLAG_APPLAYER;
     return 0;


### PR DESCRIPTION
Link to redmine ticket:
https://redmine.openinfosecfoundation.org/issues/4125

Describe changes:

- detect: logs an error if a protocol is disabled

That is because I spent too much time debugging why I did not get any alerts with my signature

> If I have a signature with alproto ENIP, and enip is disabled in suricata.yaml, why can I still load the rule without error or warnings ?

```
alert ip any any -> any any (enip_command: 112; sid:2; )
alert ip any any -> any any (dnp3_func: 1; sid:3; )
```

I think we have a warning if the signature's protocol is specified such as `alert enip any any -> any any (enip_command: 112; sid:2; )`

Replaces #6717 with only commit left to be merged rebased
Discussion is going https://github.com/OISF/suricata/pull/6717#discussion_r786583625