### PR TITLE
pgsql: fix defect found by coverity

### DIFF
--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -24,7 +24,7 @@ use crate::pgsql::parser::*;
 use crate::pgsql::pgsql::*;
 use std;
 
-pub const PGSQL_LOG_PASSWORDS: u32 = BIT_U32!(1);
+pub const PGSQL_LOG_PASSWORDS: u32 = BIT_U32!(0);
 
 fn log_pgsql(tx: &PgsqlTransaction, flags: u32, js: &mut JsonBuilder) -> Result<(), JsonError> {
     js.set_uint("tx_id", tx.tx_id)?;

--- a/src/output-json-pgsql.c
+++ b/src/output-json-pgsql.c
@@ -47,7 +47,7 @@
 #include "output-json-pgsql.h"
 #include "rust.h"
 
-#define PGSQL_LOG_PASSWORDS BIT_U32(1)
+#define PGSQL_LOG_PASSWORDS BIT_U32(0)
 
 typedef struct OutputPgsqlCtx_ {
     uint32_t flags;
@@ -103,10 +103,10 @@ static void JsonPgsqlLogParseConfig(ConfNode *conf, OutputPgsqlCtx *pgsqllog_ctx
         if (ConfValIsTrue(query)) {
             pgsqllog_ctx->flags |= PGSQL_LOG_PASSWORDS;
         } else {
-            pgsqllog_ctx->flags &= !PGSQL_LOG_PASSWORDS;
+            pgsqllog_ctx->flags &= ~PGSQL_LOG_PASSWORDS;
         }
     } else {
-        pgsqllog_ctx->flags &= !PGSQL_LOG_PASSWORDS;
+        pgsqllog_ctx->flags &= ~PGSQL_LOG_PASSWORDS;
     }
 }
 


### PR DESCRIPTION
Pgsql was using bitwise operations to assign password output config to
its context flags, but mixing that with logic negation of the default
value, resulting in the expressions having a constant value as result.

Link to redmine ticket:
https://redmine.openinfosecfoundation.org/issues/5007

Describe changes:
- use bitwise operator, instead of logical
- also change the default value in the code to be 0, to better reflect that the actual default is `disabled`

suricata-verify-pr: 656
https://github.com/OISF/suricata-verify/pull/656