### PR TITLE
Ticket 4523: Fix ownership of application log file - v2

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1483,13 +1483,13 @@ jobs:
       - run: tar xf prep/suricata-update.tar.gz
       - name: Npcap DLL
         run: |
-          curl -s -O https://nmap.org/npcap/dist/npcap-1.00.exe
+          curl -sL -O https://nmap.org/npcap/dist/npcap-1.00.exe
           7z -y x -o/npcap-bin npcap-1.00.exe
           # hack: place dlls in cwd
           cp /npcap-bin/*.dll .
       - name: Npcap SDK
         run: |
-          curl -s -O https://nmap.org/npcap/dist/npcap-sdk-1.06.zip
+          curl -sL -O https://nmap.org/npcap/dist/npcap-sdk-1.06.zip
           unzip npcap-sdk-1.06.zip -d /npcap
           cp /npcap/Lib/x64/* /usr/lib/
       - run: tar xf prep/suricata-verify.tar.gz

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1075,9 +1075,9 @@ static void SCInstanceInit(SCInstance *suri, const char *progname)
     suri->group_name = NULL;
     suri->do_setuid = FALSE;
     suri->do_setgid = FALSE;
+#endif /* OS_WIN32 */
     suri->userid = 0;
     suri->groupid = 0;
-#endif /* OS_WIN32 */
     suri->delayed_detect = 0;
     suri->daemon = 0;
     suri->offline = 0;
@@ -2887,7 +2887,7 @@ int SuricataMain(int argc, char **argv)
 
     /* Since our config is now loaded we can finish configurating the
      * logging module. */
-    SCLogLoadConfig(suricata.daemon, suricata.verbose);
+    SCLogLoadConfig(suricata.daemon, suricata.verbose, suricata.userid, suricata.groupid);
 
     LogVersion(&suricata);
     UtilCpuPrintSummary();

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2046,34 +2046,10 @@ static int MayDaemonize(SCInstance *suri)
     return TM_ECODE_OK;
 }
 
-static int InitSignalHandler(SCInstance *suri)
+/* Initialize the user and group Suricata is to run as. */
+static int InitRunAs(SCInstance *suri)
 {
-    /* registering signals we use */
-#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    UtilSignalHandlerSetup(SIGINT, SignalHandlerSigint);
-    UtilSignalHandlerSetup(SIGTERM, SignalHandlerSigterm);
-#if HAVE_LIBUNWIND
-    int enabled;
-    if (ConfGetBool("logging.stacktrace-on-signal", &enabled) == 0) {
-        enabled = 1;
-    }
-
-    if (enabled) {
-        SCLogInfo("Preparing unexpected signal handling");
-        struct sigaction stacktrace_action;
-        memset(&stacktrace_action, 0, sizeof(stacktrace_action));
-        stacktrace_action.sa_sigaction = SignalHandlerUnexpected;
-        stacktrace_action.sa_flags = SA_SIGINFO;
-        sigaction(SIGSEGV, &stacktrace_action, NULL);
-        sigaction(SIGABRT, &stacktrace_action, NULL);
-    }
-#endif /* HAVE_LIBUNWIND */
-#endif
 #ifndef OS_WIN32
-    UtilSignalHandlerSetup(SIGHUP, SignalHandlerSigHup);
-    UtilSignalHandlerSetup(SIGPIPE, SIG_IGN);
-    UtilSignalHandlerSetup(SIGSYS, SIG_IGN);
-
     /* Try to get user/group to run suricata as if
        command line as not decide of that */
     if (suri->do_setuid == FALSE && suri->do_setgid == FALSE) {
@@ -2105,6 +2081,37 @@ static int InitSignalHandler(SCInstance *suri)
 
         sc_set_caps = TRUE;
     }
+#endif
+    return TM_ECODE_OK;
+}
+
+static int InitSignalHandler(SCInstance *suri)
+{
+    /* registering signals we use */
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    UtilSignalHandlerSetup(SIGINT, SignalHandlerSigint);
+    UtilSignalHandlerSetup(SIGTERM, SignalHandlerSigterm);
+#if HAVE_LIBUNWIND
+    int enabled;
+    if (ConfGetBool("logging.stacktrace-on-signal", &enabled) == 0) {
+        enabled = 1;
+    }
+
+    if (enabled) {
+        SCLogInfo("Preparing unexpected signal handling");
+        struct sigaction stacktrace_action;
+        memset(&stacktrace_action, 0, sizeof(stacktrace_action));
+        stacktrace_action.sa_sigaction = SignalHandlerUnexpected;
+        stacktrace_action.sa_flags = SA_SIGINFO;
+        sigaction(SIGSEGV, &stacktrace_action, NULL);
+        sigaction(SIGABRT, &stacktrace_action, NULL);
+    }
+#endif /* HAVE_LIBUNWIND */
+#endif
+#ifndef OS_WIN32
+    UtilSignalHandlerSetup(SIGHUP, SignalHandlerSigHup);
+    UtilSignalHandlerSetup(SIGPIPE, SIG_IGN);
+    UtilSignalHandlerSetup(SIGSYS, SIG_IGN);
 #endif /* OS_WIN32 */
 
     return TM_ECODE_OK;
@@ -2876,6 +2883,7 @@ int SuricataMain(int argc, char **argv)
     SCLogDebug("vlan tracking is %s", vlan_tracking == 1 ? "enabled" : "disabled");
 
     SetupUserMode(&suricata);
+    InitRunAs(&suricata);
 
     /* Since our config is now loaded we can finish configurating the
      * logging module. */

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -137,9 +137,9 @@ typedef struct SCInstance_ {
     const char *group_name;
     uint8_t do_setuid;
     uint8_t do_setgid;
+#endif /* OS_WIN32 */
     uint32_t userid;
     uint32_t groupid;
-#endif /* OS_WIN32 */
 
     bool system;
     bool set_logdir;

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -573,7 +573,7 @@ int SCLogDebugEnabled(void);
 
 void SCLogRegisterTests(void);
 
-void SCLogLoadConfig(int daemon, int verbose);
+void SCLogLoadConfig(int daemon, int verbose, uint32_t userid, uint32_t groupid);
 
 SCLogLevel SCLogGetLogLevel(void);
 

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -386,6 +386,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE(SC_ERR_DPDK_CONF);
         CASE_CODE(SC_WARN_DPDK_CONF);
         CASE_CODE(SC_ERR_SIGNAL);
+        CASE_CODE(SC_WARN_CHOWN);
 
         CASE_CODE (SC_ERR_MAX);
     }

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -376,6 +376,7 @@ typedef enum {
     SC_ERR_DPDK_CONF,
     SC_WARN_DPDK_CONF,
     SC_ERR_SIGNAL,
+    SC_WARN_CHOWN,
 
     SC_ERR_MAX
 } SCError;

--- a/src/util-running-modes.c
+++ b/src/util-running-modes.c
@@ -31,7 +31,7 @@
 
 int ListKeywords(const char *keyword_info)
 {
-    SCLogLoadConfig(0, 0);
+    SCLogLoadConfig(0, 0, 0, 0);
     MpmTableSetup();
     SpmTableSetup();
     AppLayerSetup();
@@ -42,7 +42,7 @@ int ListKeywords(const char *keyword_info)
 int ListAppLayerProtocols(const char *conf_filename)
 {
     if (ConfYamlLoadFile(conf_filename) != -1)
-        SCLogLoadConfig(0, 0);
+        SCLogLoadConfig(0, 0, 0, 0);
     MpmTableSetup();
     SpmTableSetup();
     AppLayerSetup();


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/4523

Allows the application log file `suricata.log` to be rotated when using privilege de-escalation.