### PR TITLE
(draft) windows: allow libpcap - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1456,8 +1456,8 @@ jobs:
       - name: Running suricata-verify
         run: python3 ./suricata-verify/run.py -q
 
-  windows-msys2-mingw64:
-    name: Windows MSYS2 MINGW64
+  windows-msys2-mingw64-npcap:
+    name: Windows MSYS2 MINGW64 (NPcap)
     runs-on: windows-latest
     needs: [prepare-deps]
     defaults:
@@ -1504,3 +1504,40 @@ jobs:
           ./src/suricata -u -l /tmp/
           # need cwd in path due to npcap dlls (see above)
           PATH="$PATH:$(pwd)" python3 ./suricata-verify/run.py -q
+
+  windows-msys2-mingw64-libpcap:
+    name: Windows MSYS2 MINGW64 (libpcap)
+    runs-on: windows-latest
+    needs: [prepare-deps]
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: git mingw-w64-x86_64-toolchain automake1.16 automake-wrapper autoconf libtool libyaml-devel pcre2-devel jansson-devel make mingw-w64-x86_64-libyaml mingw-w64-x86_64-pcre2 mingw-w64-x86_64-rust mingw-w64-x86_64-jansson unzip p7zip python-setuptools mingw-w64-x86_64-python-yaml mingw-w64-x86_64-jq mingw-w64-x86_64-libxml2 libpcap-devel mingw-w64-x86_64-libpcap
+      # hack: install our own cbindgen system wide as we can't get the
+      # preinstalled one to be picked up by configure
+      - name: cbindgen
+        run: cargo install --root /usr --force --debug --version 0.14.1 cbindgen
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/libhtp.tar.gz
+      - run: tar xf prep/suricata-update.tar.gz
+      - run: tar xf prep/suricata-verify.tar.gz
+      - name: Build
+        run: |
+          ./autogen.sh
+          CFLAGS="-ggdb -Werror" ./configure --enable-unittests --enable-gccprotect --disable-gccmarch-native --disable-shared --with-libpcap-includes=/npcap/Include --with-libpcap-libraries=/npcap/Lib/x64
+          make -j3
+      - name: Run
+        run: |
+          ./src/suricata --build-info
+          ./src/suricata -u -l /tmp/
+          python3 ./suricata-verify/run.py -q

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1483,13 +1483,13 @@ jobs:
       - run: tar xf prep/suricata-update.tar.gz
       - name: Npcap DLL
         run: |
-          curl -s -O https://nmap.org/npcap/dist/npcap-1.00.exe
+          curl -sL -O https://nmap.org/npcap/dist/npcap-1.00.exe
           7z -y x -o/npcap-bin npcap-1.00.exe
           # hack: place dlls in cwd
           cp /npcap-bin/*.dll .
       - name: Npcap SDK
         run: |
-          curl -s -O https://nmap.org/npcap/dist/npcap-sdk-1.06.zip
+          curl -sL -O https://nmap.org/npcap/dist/npcap-sdk-1.06.zip
           unzip npcap-sdk-1.06.zip -d /npcap
           cp /npcap/Lib/x64/* /usr/lib/
       - run: tar xf prep/suricata-verify.tar.gz

--- a/configure.ac
+++ b/configure.ac
@@ -1191,23 +1191,15 @@
         exit 1
     fi
 
-    # pcap_activate and pcap_create only exists in libpcap >= 1.0
-    LIBPCAPVTEST=""
-    #To prevent duping the lib link we reset LIBS after this check. Setting action-if-found to NULL doesn't seem to work
-    #see: http://blog.flameeyes.eu/2008/04/29/i-consider-ac_check_lib-harmful
-    TMPLIBS="${LIBS}"
-    AC_CHECK_LIB(${PCAP_LIB_NAME}, pcap_activate,, LPCAPVTEST="no")
-    if test "$LPCAPVTEST" = "no"; then
-        echo
-        echo "   ERROR!  libpcap library too old, need at least 1+, "
-        echo "   go get it from http://www.tcpdump.org or your distribution:"
-        echo
-        echo "   Ubuntu: apt-get install libpcap-dev"
-        echo "   Fedora: dnf install libpcap-devel"
-        echo "   CentOS/RHEL: yum install libpcap-devel"
-        echo
-        exit 1
-    fi
+    AC_CHECK_LIB(${PCAP_LIB_NAME}, pcap_activate,
+        [AC_DEFINE([HAVE_PCAP_ACTIVATE], [1], [libpcap has pcap_activate])],
+        [
+            echo ""
+            echo "   Warning: libpcap does not have pcap_activate. Suricata will"
+            echo "       not be able to use libpcap for live capture."
+            echo ""
+        ])
+
     AC_PATH_PROG(HAVE_PCAP_CONFIG, pcap-config, "no")
     if test "$HAVE_PCAP_CONFIG" = "no" -o "$cross_compiling" = "yes"; then
         AC_MSG_RESULT(no pcap-config is use)
@@ -1215,18 +1207,10 @@
         PCAP_CFLAGS="$(pcap-config --defines) $(pcap-config --cflags)"
         AC_SUBST(PCAP_CFLAGS)
     fi
-    LIBS="${TMPLIBS}"
 
-    #Appears as if pcap_set_buffer_size is linux only?
-    LIBPCAPSBUFF=""
-    #To prevent duping the lib link we reset LIBS after this check. Setting action-if-found to NULL doesn't seem to work
-    #see: http://blog.flameeyes.eu/2008/04/29/i-consider-ac_check_lib-harmful
-    TMPLIBS="${LIBS}"
-    AC_CHECK_LIB(${PCAP_LIB_NAME}, pcap_set_buffer_size,, LPCAPSBUFF="no")
-    if test "$LPCAPSBUFF" != "no"; then
-        AC_DEFINE([HAVE_PCAP_SET_BUFF],[1],(libpcap has pcap_set_buffer_size function))
-    fi
-    LIBS="${TMPLIBS}"
+    # Appears as if pcap_set_buffer_size is linux only?
+    AC_CHECK_LIB(${PCAP_LIB_NAME}, pcap_set_buffer_size,
+        [AC_DEFINE([HAVE_PCAP_SET_BUFF],[1],[libpcap has pcap_set_buffer_size function])])
 
   # libpfring
     # libpfring (currently only supported for libpcap enabled pfring)

--- a/configure.ac
+++ b/configure.ac
@@ -309,6 +309,7 @@
             CFLAGS="${CFLAGS} -DOS_WIN32"
             WINDOWS_PATH="yes"
             PCAP_LIB_NAME="wpcap"
+            TRY_WPCAP="yes"
             AC_DEFINE([HAVE_NON_POSIX_MKDIR], [1], [mkdir is not POSIX compliant: single arg])
             RUST_LDADD=" -lws2_32 -liphlpapi -lwbemuuid -lOle32 -lOleAut32 -lUuid -luserenv -lshell32 -ladvapi32 -lgcc_eh -lbcrypt"
             ;;
@@ -316,6 +317,7 @@
             LUA_LIB_NAME="lua"
             WINDOWS_PATH="yes"
             PCAP_LIB_NAME="wpcap"
+            TRY_WPCAP="yes"
             ;;
         *-*-solaris*)
             AC_MSG_WARN([support for Solaris/Illumos/SunOS is experimental])
@@ -1176,20 +1178,35 @@
                 #define _DEFAULT_SOURCE 1
             ]])
 
-    LIBPCAP=""
-    PKG_CHECK_MODULES([PCAP],libpcap,[CPPFLAGS="${CPPFLAGS} ${PCAP_CFLAGS}" LIBS="${LIBS} ${PCAP_LIBS}"],[:])
-    AC_CHECK_LIB(${PCAP_LIB_NAME}, pcap_open_dead,, LIBPCAP="no")
-    if test "$LIBPCAP" = "no"; then
-        echo
-        echo "   ERROR!  libpcap library not found, go get it"
-        echo "   from http://www.tcpdump.org or your distribution:"
-        echo
-        echo "   Ubuntu: apt-get install libpcap-dev"
-        echo "   Fedora: dnf install libpcap-devel"
-        echo "   CentOS/RHEL: yum install libpcap-devel"
-        echo
-        exit 1
+    have_wpcap=""
+    if test "$TRY_WPCAP" = "yes"; then
+        AC_CHECK_LIB(wpcap, pcap_activate, [], have_wpcap="no")
+        if test "$have_wpcap" = "no"; then
+            echo ""
+            echo "    Warning: NPCap was not found. Live capture will not be available."
+            echo ""
+        else
+            PCAP_LIB_NAME="wpcap"
+            have_wpcap="yes"
+        fi
     fi
+
+    if test "$have_wpcap" != "yes"; then
+        AC_CHECK_LIB(pcap, pcap_open_dead, [], [
+            echo
+            echo "   ERROR!  libpcap library not found, go get it"
+            echo "   from http://www.tcpdump.org or your distribution:"
+            echo
+            echo "   Ubuntu: apt-get install libpcap-dev"
+            echo "   Fedora: dnf install libpcap-devel"
+            echo "   CentOS/RHEL: yum install libpcap-devel"
+            echo
+            exit 1
+        ])
+        PCAP_LIB_NAME="pcap"
+    fi
+
+    PKG_CHECK_MODULES([PCAP],libpcap,[CPPFLAGS="${CPPFLAGS} ${PCAP_CFLAGS}" LIBS="${LIBS} ${PCAP_LIBS}"],[:])
 
     AC_CHECK_LIB(${PCAP_LIB_NAME}, pcap_activate,
         [AC_DEFINE([HAVE_PCAP_ACTIVATE], [1], [libpcap has pcap_activate])],

--- a/configure.ac
+++ b/configure.ac
@@ -1178,7 +1178,7 @@
 
     LIBPCAP=""
     PKG_CHECK_MODULES([PCAP],libpcap,[CPPFLAGS="${CPPFLAGS} ${PCAP_CFLAGS}" LIBS="${LIBS} ${PCAP_LIBS}"],[:])
-    AC_CHECK_LIB(${PCAP_LIB_NAME}, pcap_open_live,, LIBPCAP="no")
+    AC_CHECK_LIB(${PCAP_LIB_NAME}, pcap_open_dead,, LIBPCAP="no")
     if test "$LIBPCAP" = "no"; then
         echo
         echo "   ERROR!  libpcap library not found, go get it"

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -386,6 +386,7 @@ static TmEcode ReceivePcapBreakLoop(ThreadVars *tv, void *data)
 static TmEcode ReceivePcapThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
     SCEnter();
+#ifdef HAVE_PCAP_ACTIVATE
     PcapIfaceConfig *pcapconfig = (PcapIfaceConfig *)initdata;
 
     if (initdata == NULL) {
@@ -552,6 +553,10 @@ static TmEcode ReceivePcapThreadInit(ThreadVars *tv, const void *initdata, void 
 
     *data = (void *)ptv;
     SCReturnInt(TM_ECODE_OK);
+#else
+    FatalError(SC_ERR_FATAL, "Live capture not available");
+    SCReturnInt(TM_ECODE_FAILED);
+#endif
 }
 
 /**


### PR DESCRIPTION
Allow the Windows build to succeed with libpcap from msys2. This won't allow
for live capture, is useful for reading capture files, or in the future,
libsuricata.

Known issue: If you attempt to listen on a live interface, Suricata will
segfault.  I need to detect that its not available earlier in the startup
sequence.
