### PR TITLE
dpdk: adjust setting of MTU to the new DPDK API (21.11)

### DIFF
--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -848,13 +848,48 @@ static void DumpRSSFlags(const uint64_t requested, const uint64_t actual)
     SCLogConfig("ETH_RSS_L4_DST_ONLY %sset", (actual & ETH_RSS_L4_DST_ONLY) ? "" : "NOT ");
 }
 
+static int DeviceValidateMTU(const DPDKIfaceConfig *iconf, const struct rte_eth_dev_info *dev_info)
+{
+    if (iconf->mtu > dev_info->max_mtu || iconf->mtu < dev_info->min_mtu) {
+        SCLogError(SC_ERR_DPDK_INIT,
+                "Loaded MTU of \"%s\" is out of bounds. "
+                "Min MTU: %" PRIu16 " Max MTU: %" PRIu16,
+                iconf->iface, dev_info->min_mtu, dev_info->max_mtu);
+        SCReturnInt(-ERANGE);
+    }
+
+#if RTE_VER_YEAR < 21 || RTE_VER_YEAR == 21 && RTE_VER_MONTH < 11
+    // check if jumbo frames are set and are available
+    if (iconf->mtu > RTE_ETHER_MAX_LEN &&
+            !(dev_info->rx_offload_capa & DEV_RX_OFFLOAD_JUMBO_FRAME)) {
+        SCLogError(SC_ERR_DPDK_CONF,
+                "Jumbo frames not supported, set MTU of \"%s\" to 1500B",
+                iconf->iface);
+        SCReturnInt(-EINVAL);
+    }
+#endif
+
+    SCReturnInt(0);
+}
+
+static void DeviceSetMTU(struct rte_eth_conf *port_conf, uint16_t mtu)
+{
+#if RTE_VER_YEAR > 21 || RTE_VER_YEAR == 21 && RTE_VER_MONTH == 11
+    port_conf->rxmode.mtu = mtu;
+#else
+    port_conf->rxmode.max_rx_pkt_len = mtu;
+    if (mtu > RTE_ETHER_MAX_LEN) {
+        port_conf->rxmode.offloads |= DEV_RX_OFFLOAD_JUMBO_FRAME;
+    }
+#endif
+}
+
 static void DeviceInitPortConf(const DPDKIfaceConfig *iconf,
         const struct rte_eth_dev_info *dev_info, struct rte_eth_conf *port_conf)
 {
     *port_conf = (struct rte_eth_conf){
             .rxmode = {
                     .mq_mode = ETH_MQ_RX_NONE,
-                    .max_rx_pkt_len = iconf->mtu,
                     .offloads = 0, // turn every offload off to prevent any packet modification
             },
             .txmode = {
@@ -912,9 +947,7 @@ static void DeviceInitPortConf(const DPDKIfaceConfig *iconf,
         }
     }
 
-    if (iconf->mtu > RTE_ETHER_MAX_LEN) {
-        port_conf->rxmode.offloads |= DEV_RX_OFFLOAD_JUMBO_FRAME;
-    }
+    DeviceSetMTU(port_conf, iconf->mtu);
 
     if (dev_info->tx_offload_capa & DEV_TX_OFFLOAD_MBUF_FAST_FREE) {
         port_conf->txmode.offloads |= DEV_TX_OFFLOAD_MBUF_FAST_FREE;
@@ -1120,23 +1153,9 @@ static int DeviceConfigure(DPDKIfaceConfig *iconf)
         SCReturnInt(-ERANGE);
     }
 
-    if (iconf->mtu > dev_info.max_mtu || iconf->mtu < dev_info.min_mtu) {
-        SCLogError(SC_ERR_DPDK_INIT,
-                "Loaded MTU of \"%s\" is out of bounds. "
-                "Min MTU: %" PRIu16 " Max MTU: %" PRIu16,
-                iconf->iface, dev_info.min_mtu, dev_info.max_mtu);
-        SCReturnInt(-ERANGE);
-    }
-
-    // check if jumbo frames are set and are available
-    if (iconf->mtu > RTE_ETHER_MAX_LEN &&
-            !(dev_info.rx_offload_capa & DEV_RX_OFFLOAD_JUMBO_FRAME)) {
-        SCLogError(SC_ERR_DPDK_CONF,
-                "Jumbo frames not supported, "
-                "set MTU of \"%s\" to 1500B",
-                iconf->iface);
-        SCReturnInt(-EINVAL);
-    }
+    retval = DeviceValidateMTU(iconf, &dev_info);
+    if (retval != 0)
+        return retval;
 
     DeviceInitPortConf(iconf, &dev_info, &port_conf);
     if (port_conf.rxmode.offloads & DEV_RX_OFFLOAD_CHECKSUM) {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5009) ticket:

Describe changes:
- from DPDK 21.11 the structure `struct rte_eth_rxmode` has changed and attribute `max_rx_pkt_len` was renamed to `mtu`
- from DPDK 21.11 the flag `DEV_RX_OFFLOAD_JUMBO_FRAME` was removed 
- this [patch](https://patches.dpdk.org/project/dpdk/patch/20210709172923.3369846-4-ferruh.yigit@intel.com/) brings the change to the DPDK API
