### PR TITLE
Rust overflows v1

### DIFF
--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -530,11 +530,11 @@ fn http2_parse_var_uint(input: &[u8], value: u64, max: u64) -> IResult<&[u8], u6
     for i in 0..varia.len() {
         varval += ((varia[i] & 0x7F) as u64) << (7 * i);
     }
-    varval += (finalv as u64) << (7 * varia.len());
-    if varval < max {
-        // this has overflown u64
+    if (finalv as u64) << (7 * varia.len()) > u64::MAX - varval {
+        // this would overflow u64
         return Ok((i3, 0));
     }
+    varval += (finalv as u64) << (7 * varia.len());
     return Ok((i3, varval));
 }
 

--- a/rust/src/mqtt/parser.rs
+++ b/rust/src/mqtt/parser.rs
@@ -106,13 +106,13 @@ fn parse_properties(input: &[u8], precond: bool) -> IResult<&[u8], Option<Vec<MQ
     // parse properties length
     match parse_mqtt_variable_integer(input) {
         Ok((rem, mut proplen)) => {
-            if proplen == 0 {
+            if proplen == 0 || proplen as usize > rem.len() {
                 // no properties
                 return Ok((rem, None));
             }
             // parse properties
             let mut props = Vec::<MQTTProperty>::new();
-            let mut newrem = rem;
+            let mut newrem = &rem[..proplen as usize];
             while proplen > 0 {
                 match parse_property(newrem) {
                     Ok((rem, val)) => {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- http2 : checks unsigned overflow before it happens
- MQTT : use appropriate size for buffer when parsing properties

cc @satta for the mqtt commit

If I understand correctly , mqtt properties are part of a bigger message.
So, they have a length, and we should limit to parse what is within that length, and not what is after (even if it is still in the MQTT message)