### PR TITLE
Detect uricontent 4911/v4: remove unittests

### DIFF
--- a/src/detect-uricontent.c
+++ b/src/detect-uricontent.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -201,563 +201,11 @@ static void DetectUricontentPrint(DetectContentData *cd)
     SCLogDebug("-----------");
 }
 
-/** \test Test case where path traversal has been sent as a path string in the
- *        HTTP URL and normalized path string is checked */
-static int HTTPUriTest01(void)
-{
-    int result = 0;
-    Flow f;
-    uint8_t httpbuf1[] = "GET /../../images.gif HTTP/1.1\r\nHost: www.ExA"
-                         "mPlE.cOM\r\n\r\n";
-    uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
-    TcpSession ssn;
-    int r = 0;
-    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
-    memset(&f, 0, sizeof(f));
-    memset(&ssn, 0, sizeof(ssn));
-
-    FLOW_INITIALIZE(&f);
-    f.protoctx = (void *)&ssn;
-    f.proto = IPPROTO_TCP;
-    f.alproto = ALPROTO_HTTP1;
-    f.flags |= FLOW_IPV4;
-
-    StreamTcpInitConfig(true);
-
-    FLOWLOCK_WRLOCK(&f);
-    r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP1,
-            STREAM_TOSERVER | STREAM_START | STREAM_EOF, httpbuf1, httplen1);
-    if (r != 0) {
-        printf("AppLayerParse failed: r(%d) != 0: ", r);
-        goto end;
-    }
-
-    HtpState *htp_state = f.alstate;
-    if (htp_state == NULL) {
-        printf("no http state: ");
-        goto end;
-    }
-
-    htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, htp_state, 0);
-
-    if (tx->request_method_number != HTP_M_GET ||
-        tx->request_protocol_number != HTP_PROTOCOL_1_1)
-    {
-        goto end;
-    }
-
-    if ((tx->request_hostname == NULL) ||
-            (bstr_cmp_c(tx->request_hostname, "www.example.com") != 0))
-    {
-        goto end;
-    }
-
-    if ((tx->parsed_uri->path == NULL) ||
-            (bstr_cmp_c(tx->parsed_uri->path, "/images.gif") != 0))
-    {
-        goto end;
-    }
-
-    result = 1;
-end:
-    if (alp_tctx != NULL)
-        AppLayerParserThreadCtxFree(alp_tctx);
-    StreamTcpFreeConfig(true);
-    FLOWLOCK_UNLOCK(&f);
-    FLOW_DESTROY(&f);
-    return result;
-}
-
-/** \test Test case where path traversal has been sent in special characters in
- *        HEX encoding in the HTTP URL and normalized path string is checked */
-static int HTTPUriTest02(void)
-{
-    int result = 0;
-    Flow f;
-    HtpState *htp_state = NULL;
-    uint8_t httpbuf1[] = "GET /%2e%2e/images.gif HTTP/1.1\r\nHost: www.ExA"
-                         "mPlE.cOM\r\n\r\n";
-    uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
-    TcpSession ssn;
-    int r = 0;
-    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
-
-    memset(&f, 0, sizeof(f));
-    memset(&ssn, 0, sizeof(ssn));
-
-    FLOW_INITIALIZE(&f);
-    f.protoctx = (void *)&ssn;
-    f.proto = IPPROTO_TCP;
-    f.alproto = ALPROTO_HTTP1;
-    f.flags |= FLOW_IPV4;
-
-    StreamTcpInitConfig(true);
-
-    FLOWLOCK_WRLOCK(&f);
-    r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP1,
-            STREAM_TOSERVER | STREAM_START | STREAM_EOF, httpbuf1, httplen1);
-    if (r != 0) {
-        printf("AppLayerParse failed: r(%d) != 0: ", r);
-        goto end;
-    }
-
-    htp_state = f.alstate;
-    if (htp_state == NULL) {
-        printf("no http state: ");
-        goto end;
-    }
-
-    htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, htp_state, 0);
-
-    if (tx->request_method_number != HTP_M_GET ||
-        tx->request_protocol_number != HTP_PROTOCOL_1_1)
-    {
-        goto end;
-    }
-
-    if ((tx->request_hostname == NULL) ||
-            (bstr_cmp_c(tx->request_hostname, "www.example.com") != 0))
-    {
-        goto end;
-    }
-
-    if ((tx->parsed_uri->path == NULL) ||
-            (bstr_cmp_c(tx->parsed_uri->path, "/images.gif") != 0))
-    {
-        goto end;
-    }
-
-    result = 1;
-end:
-    if (alp_tctx != NULL)
-        AppLayerParserThreadCtxFree(alp_tctx);
-    StreamTcpFreeConfig(true);
-    FLOWLOCK_UNLOCK(&f);
-    FLOW_DESTROY(&f);
-    return result;
-}
-
-/** \test Test case where NULL character has been sent in HEX encoding in the
- *        HTTP URL and normalized path string is checked */
-static int HTTPUriTest03(void)
-{
-    int result = 0;
-    Flow f;
-    HtpState *htp_state = NULL;
-    uint8_t httpbuf1[] = "GET%00 /images.gif HTTP/1.1\r\nHost: www.ExA"
-                         "mPlE.cOM\r\n\r\n";
-    uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
-    TcpSession ssn;
-    int r = 0;
-    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
-
-    memset(&f, 0, sizeof(f));
-    memset(&ssn, 0, sizeof(ssn));
-
-    FLOW_INITIALIZE(&f);
-    f.protoctx = (void *)&ssn;
-    f.proto = IPPROTO_TCP;
-    f.alproto = ALPROTO_HTTP1;
-    f.flags |= FLOW_IPV4;
-
-    StreamTcpInitConfig(true);
-
-    FLOWLOCK_WRLOCK(&f);
-    r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP1,
-            STREAM_TOSERVER | STREAM_START | STREAM_EOF, httpbuf1, httplen1);
-    if (r != 0) {
-        printf("AppLayerParse failed: r(%d) != 0: ", r);
-        goto end;
-    }
-
-    htp_state = f.alstate;
-    if (htp_state == NULL) {
-        printf("no http state: ");
-        goto end;
-    }
-
-    htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, htp_state, 0);
-
-    if (tx->request_method_number != HTP_M_UNKNOWN ||
-        tx->request_protocol_number != HTP_PROTOCOL_1_1)
-    {
-        goto end;
-    }
-
-    if ((tx->request_hostname == NULL) ||
-            (bstr_cmp_c(tx->request_hostname, "www.example.com") != 0))
-    {
-        goto end;
-    }
-
-    if ((tx->parsed_uri->path == NULL) ||
-            (bstr_cmp_c(tx->parsed_uri->path, "/images.gif") != 0))
-    {
-        goto end;
-    }
-
-    result = 1;
-end:
-    if (alp_tctx != NULL)
-        AppLayerParserThreadCtxFree(alp_tctx);
-    StreamTcpFreeConfig(true);
-    FLOWLOCK_UNLOCK(&f);
-    FLOW_DESTROY(&f);
-    return result;
-}
-
-
-/** \test Test case where self referencing directories request has been sent
- *        in the HTTP URL and normalized path string is checked */
-static int HTTPUriTest04(void)
-{
-    int result = 0;
-    Flow f;
-    HtpState *htp_state = NULL;
-    uint8_t httpbuf1[] = "GET /./././images.gif HTTP/1.1\r\nHost: www.ExA"
-                         "mPlE.cOM\r\n\r\n";
-    uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
-    TcpSession ssn;
-    int r = 0;
-    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
-
-    memset(&f, 0, sizeof(f));
-    memset(&ssn, 0, sizeof(ssn));
-
-    FLOW_INITIALIZE(&f);
-    f.protoctx = (void *)&ssn;
-    f.proto = IPPROTO_TCP;
-    f.alproto = ALPROTO_HTTP1;
-    f.flags |= FLOW_IPV4;
-
-    StreamTcpInitConfig(true);
-
-    FLOWLOCK_WRLOCK(&f);
-    r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP1,
-            STREAM_TOSERVER | STREAM_START | STREAM_EOF, httpbuf1, httplen1);
-    if (r != 0) {
-        printf("AppLayerParse failed: r(%d) != 0: ", r);
-        goto end;
-    }
-
-    htp_state = f.alstate;
-    if (htp_state == NULL) {
-        printf("no http state: ");
-        goto end;
-    }
-
-    htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, htp_state, 0);
-
-    if (tx->request_method_number != HTP_M_GET ||
-        tx->request_protocol_number != HTP_PROTOCOL_1_1)
-    {
-        goto end;
-    }
-
-    if ((tx->request_hostname == NULL) ||
-            (bstr_cmp_c(tx->request_hostname, "www.example.com") != 0))
-    {
-        goto end;
-    }
-
-    if ((tx->parsed_uri->path == NULL) ||
-           (bstr_cmp_c(tx->parsed_uri->path, "/images.gif") != 0))
-    {
-        goto end;
-    }
-
-    result = 1;
-end:
-    if (alp_tctx != NULL)
-        AppLayerParserThreadCtxFree(alp_tctx);
-    StreamTcpFreeConfig(true);
-    FLOWLOCK_UNLOCK(&f);
-    FLOW_DESTROY(&f);
-    return result;
-}
-
-/**
- * \test Checks if a uricontent is registered in a Signature
- */
-static int DetectUriSigTest01(void)
-{
-    ThreadVars th_v;
-    Signature *s = NULL;
-
-    memset(&th_v, 0, sizeof(th_v));
-
-    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    FAIL_IF_NULL(de_ctx);
-    de_ctx->flags |= DE_QUIET;
-
-    s = DetectEngineAppendSig(de_ctx,"alert http any any -> any any (msg:"
-            "\" Test uricontent\"; content:\"me\"; uricontent:\"me\"; sid:1;)");
-    FAIL_IF_NULL(s);
-
-    BUG_ON(s->sm_lists[g_http_uri_buffer_id] == NULL);
-    FAIL_IF_NOT(de_ctx->sig_list->sm_lists[g_http_uri_buffer_id]->type == DETECT_CONTENT);
-
-    DetectEngineCtxFree(de_ctx);
-    PASS;
-}
-
-/** \test Check the signature working to alert when http_cookie is matched . */
-static int DetectUriSigTest02(void)
-{
-    int result = 0;
-    Flow f;
-    uint8_t httpbuf1[] = "POST /one HTTP/1.0\r\nUser-Agent: Mozilla/1.0\r\nCookie:"
-                         " hellocatch\r\n\r\n";
-    uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
-    TcpSession ssn;
-    Packet *p = NULL;
-    Signature *s = NULL;
-    ThreadVars th_v;
-    DetectEngineThreadCtx *det_ctx = NULL;
-    HtpState *http_state = NULL;
-    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
-
-    memset(&th_v, 0, sizeof(th_v));
-    memset(&f, 0, sizeof(f));
-    memset(&ssn, 0, sizeof(ssn));
-
-    p = UTHBuildPacket(httpbuf1, httplen1, IPPROTO_TCP);
-
-    FLOW_INITIALIZE(&f);
-    f.protoctx = (void *)&ssn;
-    f.proto = IPPROTO_TCP;
-    f.flags |= FLOW_IPV4;
-
-    p->flow = &f;
-    p->flowflags |= FLOW_PKT_TOSERVER;
-    p->flowflags |= FLOW_PKT_ESTABLISHED;
-    p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP1;
-
-    StreamTcpInitConfig(true);
-
-    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL) {
-        goto end;
-    }
-    de_ctx->flags |= DE_QUIET;
-
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"foo\"; sid:1;)");
-    if (s == NULL) {
-        goto end;
-    }
-
-    s = s->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"one\"; sid:2;)");
-    if (s == NULL) {
-        goto end;
-    }
-
-    s = s->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"oisf\"; sid:3;)");
-    if (s == NULL) {
-        goto end;
-    }
-
-
-    SigGroupBuild(de_ctx);
-    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
-
-    FLOWLOCK_WRLOCK(&f);
-    int r = AppLayerParserParse(
-            NULL, alp_tctx, &f, ALPROTO_HTTP1, STREAM_TOSERVER, httpbuf1, httplen1);
-    if (r != 0) {
-        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
-        FLOWLOCK_UNLOCK(&f);
-        goto end;
-    }
-    FLOWLOCK_UNLOCK(&f);
-
-    http_state = f.alstate;
-    if (http_state == NULL) {
-        printf("no http state: ");
-        goto end;
-    }
-
-    /* do detect */
-    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-
-    if ((PacketAlertCheck(p, 1))) {
-        printf("sig: 1 alerted, but it should not\n");
-        goto end;
-    } else if (!PacketAlertCheck(p, 2)) {
-        printf("sig: 2 did not alerted, but it should\n");
-        goto end;
-    }  else if ((PacketAlertCheck(p, 3))) {
-        printf("sig: 3 alerted, but it should not\n");
-        goto end;
-    }
-
-    result = 1;
-end:
-    if (alp_tctx != NULL)
-        AppLayerParserThreadCtxFree(alp_tctx);
-    //if (http_state != NULL) HTPStateFree(http_state);
-    if (de_ctx != NULL) SigCleanSignatures(de_ctx);
-    if (de_ctx != NULL) SigGroupCleanup(de_ctx);
-    if (det_ctx != NULL) DetectEngineThreadCtxDeinit(&th_v, det_ctx);
-    if (de_ctx != NULL) DetectEngineCtxFree(de_ctx);
-
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
-    UTHFreePackets(&p, 1);
-    return result;
-}
-
-/** \test Check the working of search once per packet only in applayer
- *        match */
-static int DetectUriSigTest03(void)
-{
-    int result = 0;
-    Flow f;
-    HtpState *http_state = NULL;
-    uint8_t httpbuf1[] = "POST /one HTTP/1.0\r\nUser-Agent: Mozilla/1.0\r\nCookie:"
-                         " hellocatch\r\n\r\n";
-    uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
-    uint8_t httpbuf2[] = "POST /oneself HTTP/1.0\r\nUser-Agent: Mozilla/1.0\r\nCookie:"
-                         " hellocatch\r\n\r\n";
-    uint32_t httplen2 = sizeof(httpbuf2) - 1; /* minus the \0 */
-    TcpSession ssn;
-    Packet *p = NULL;
-    Signature *s = NULL;
-    ThreadVars th_v;
-    DetectEngineThreadCtx *det_ctx = NULL;
-    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
-
-    memset(&th_v, 0, sizeof(th_v));
-    memset(&f, 0, sizeof(f));
-    memset(&ssn, 0, sizeof(ssn));
-
-    p = UTHBuildPacket(httpbuf1, httplen1, IPPROTO_TCP);
-
-    FLOW_INITIALIZE(&f);
-    f.protoctx = (void *)&ssn;
-    f.proto = IPPROTO_TCP;
-    f.flags |= FLOW_IPV4;
-
-    p->flow = &f;
-    p->flowflags |= FLOW_PKT_TOSERVER;
-    p->flowflags |= FLOW_PKT_ESTABLISHED;
-    p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP1;
-
-    StreamTcpInitConfig(true);
-
-    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL) {
-        goto end;
-    }
-    de_ctx->flags |= DE_QUIET;
-
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"foo\"; sid:1;)");
-    if (s == NULL) {
-        goto end;
-    }
-
-   s = s->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"one\"; sid:2;)");
-    if (s == NULL) {
-        goto end;
-    }
-
-    s = s->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"self\"; sid:3;)");
-    if (s == NULL) {
-        goto end;
-    }
-
-
-    SigGroupBuild(de_ctx);
-    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
-
-    FLOWLOCK_WRLOCK(&f);
-    int r = AppLayerParserParse(
-            NULL, alp_tctx, &f, ALPROTO_HTTP1, STREAM_TOSERVER, httpbuf1, httplen1);
-    if (r != 0) {
-        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
-        FLOWLOCK_UNLOCK(&f);
-        goto end;
-    }
-    FLOWLOCK_UNLOCK(&f);
-
-    /* do detect */
-    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-
-    if ((PacketAlertCheck(p, 1))) {
-        printf("sig 1 alerted, but it should not: ");
-        goto end;
-    } else if (!PacketAlertCheck(p, 2)) {
-        printf("sig 2 did not alert, but it should: ");
-        goto end;
-    } else if ((PacketAlertCheck(p, 3))) {
-        printf("sig 3 alerted, but it should not: ");
-        goto end;
-    }
-
-
-    FLOWLOCK_WRLOCK(&f);
-    r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP1, STREAM_TOSERVER, httpbuf2, httplen2);
-    if (r != 0) {
-        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
-    FLOWLOCK_UNLOCK(&f);
-        goto end;
-    }
-    FLOWLOCK_UNLOCK(&f);
-
-    http_state = f.alstate;
-    if (http_state == NULL) {
-        printf("no http state: ");
-        goto end;
-    }
-
-    /* do detect */
-    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-
-    if ((PacketAlertCheck(p, 1))) {
-        printf("sig 1 alerted, but it should not (chunk 2): ");
-        goto end;
-    } else if (!PacketAlertCheck(p, 2)) {
-        printf("sig 2 alerted, but it should not (chunk 2): ");
-        goto end;
-    } else if (!(PacketAlertCheck(p, 3))) {
-        printf("sig 3 did not alert, but it should (chunk 2): ");
-        goto end;
-    }
-
-    result = 1;
-
-end:
-    if (alp_tctx != NULL)
-        AppLayerParserThreadCtxFree(alp_tctx);
-    if (de_ctx != NULL) SigGroupCleanup(de_ctx);
-    if (de_ctx != NULL) SigCleanSignatures(de_ctx);
-    if (det_ctx != NULL) DetectEngineThreadCtxDeinit(&th_v, det_ctx);
-    if (de_ctx != NULL) DetectEngineCtxFree(de_ctx);
-
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
-    UTHFreePackets(&p, 1);
-    return result;
-}
-
 /**
  * \test Check that modifiers of content apply only to content keywords
  *       and the same for uricontent modifiers
  */
-static int DetectUriSigTest04(void)
+static int DetectUriSigTest01(void)
 {
     int result = 0;
     Signature *s = NULL;
@@ -955,267 +403,10 @@ end:
     return result;
 }
 
-/** \test Check the modifiers for uricontent and content
- *        match
- */
-static int DetectUriSigTest05(void)
-{
-    HtpState *http_state = NULL;
-    uint8_t httpbuf1[] = "POST /one/two/three HTTP/1.0\r\nUser-Agent: Mozilla/1.0\r\nCookie:"
-                         " hellocatch\r\n\r\n";
-    uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
-    Packet *p = NULL;
-    Signature *s = NULL;
-    ThreadVars th_v;
-    DetectEngineThreadCtx *det_ctx = NULL;
-    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
-
-    memset(&th_v, 0, sizeof(th_v));
-    StreamTcpInitConfig(true);
-
-    p = UTHBuildPacket(httpbuf1, httplen1, IPPROTO_TCP);
-    FAIL_IF_NULL(p);
-    p->tcph->th_seq = htonl(1000);
-    Flow *f = UTHBuildFlow(AF_INET, "192.168.1.5", "192.168.1.1", 41424, 80);
-    FAIL_IF_NULL(f);
-    f->proto = IPPROTO_TCP;
-
-    UTHAddSessionToFlow(f, 1000, 1000);
-    UTHAddStreamToFlow(f, 0, httpbuf1, httplen1);
-
-    p->flow = f;
-    p->flowflags |= FLOW_PKT_TOSERVER;
-    p->flowflags |= FLOW_PKT_ESTABLISHED;
-    p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f->alproto = ALPROTO_HTTP1;
-
-    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    FAIL_IF_NULL(de_ctx);
-    de_ctx->flags |= DE_QUIET;
-
-    s = DetectEngineAppendSig(de_ctx,"alert tcp any any -> any any (msg:"
-            "\" Test uricontent\"; uricontent:\"foo\"; sid:1;)");
-    FAIL_IF_NULL(s);
-
-    s = DetectEngineAppendSig(de_ctx,"alert tcp any any -> any any (msg:"
-            "\" Test uricontent\"; uricontent:\"one\"; content:\"two\"; sid:2;)");
-    FAIL_IF_NULL(s);
-
-    s = DetectEngineAppendSig(de_ctx,"alert tcp any any -> any any (msg:"
-            "\" Test uricontent\"; uricontent:\"one\"; offset:1; depth:10; "
-            "uricontent:\"two\"; distance:1; within: 4; uricontent:\"three\"; "
-            "distance:1; within: 6; sid:3;)");
-    FAIL_IF_NULL(s);
-
-    SigGroupBuild(de_ctx);
-    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
-
-    int r = AppLayerParserParse(
-            NULL, alp_tctx, f, ALPROTO_HTTP1, STREAM_TOSERVER, httpbuf1, httplen1);
-    FAIL_IF(r != 0);
-    http_state = f->alstate;
-    FAIL_IF_NULL(http_state);
-
-    /* do detect */
-    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-
-    FAIL_IF((PacketAlertCheck(p, 1)));
-    FAIL_IF(!PacketAlertCheck(p, 2));
-    FAIL_IF(!(PacketAlertCheck(p, 3)));
-
-    AppLayerParserThreadCtxFree(alp_tctx);
-    DetectEngineThreadCtxDeinit(&th_v, det_ctx);
-    DetectEngineCtxFree(de_ctx);
-
-    UTHRemoveSessionFromFlow(f);
-    UTHFreeFlow(f);
-    UTHFreePackets(&p, 1);
-    StreamTcpFreeConfig(true);
-    PASS;
-}
-
-/** \test Check the modifiers for uricontent and content
- *        match
- */
-static int DetectUriSigTest06(void)
-{
-    HtpState *http_state = NULL;
-    uint8_t httpbuf1[] = "POST /one/two/three HTTP/1.0\r\nUser-Agent: Mozilla/1.0\r\nCookie:"
-                         " hellocatch\r\n\r\n";
-    uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
-    Packet *p = NULL;
-    Signature *s = NULL;
-    ThreadVars th_v;
-    DetectEngineThreadCtx *det_ctx = NULL;
-    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
-
-    memset(&th_v, 0, sizeof(th_v));
-    StreamTcpInitConfig(true);
-
-    p = UTHBuildPacket(httpbuf1, httplen1, IPPROTO_TCP);
-    FAIL_IF_NULL(p);
-    p->tcph->th_seq = htonl(1000);
-    Flow *f = UTHBuildFlow(AF_INET, "192.168.1.5", "192.168.1.1", 41424, 80);
-    FAIL_IF_NULL(f);
-    f->proto = IPPROTO_TCP;
-
-    UTHAddSessionToFlow(f, 1000, 1000);
-    UTHAddStreamToFlow(f, 0, httpbuf1, httplen1);
-
-    p->flow = f;
-    p->flowflags |= FLOW_PKT_TOSERVER;
-    p->flowflags |= FLOW_PKT_ESTABLISHED;
-    p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f->alproto = ALPROTO_HTTP1;
-
-    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    FAIL_IF_NULL(de_ctx);
-    de_ctx->flags |= DE_QUIET;
-
-    s = DetectEngineAppendSig(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"foo\"; content:\"bar\"; sid:1;)");
-    FAIL_IF_NULL(s);
-
-    s = DetectEngineAppendSig(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"one\"; offset:1; depth:10; "
-                                   "content:\"one\"; offset:1; depth:10; "
-                                   "uricontent:\"two\"; distance:1; within: 4; "
-                                   "content:\"two\"; distance:1; within: 4; "
-                                   "uricontent:\"three\"; distance:1; within: 6; "
-                                   "content:\"/three\"; distance:0; within: 7; "
-                                   "sid:2;)");
-    FAIL_IF_NULL(s);
-
-    s = DetectEngineAppendSig(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"one\"; offset:1; depth:10; "
-                                   "uricontent:\"two\"; distance:1; within: 4; "
-                                   "uricontent:\"three\"; distance:1; within: 6; "
-                                   "sid:3;)");
-    FAIL_IF_NULL(s);
-
-    SigGroupBuild(de_ctx);
-    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
-
-    int r = AppLayerParserParse(
-            NULL, alp_tctx, f, ALPROTO_HTTP1, STREAM_TOSERVER, httpbuf1, httplen1);
-    FAIL_IF(r != 0);
-    http_state = f->alstate;
-    FAIL_IF_NULL(http_state);
-
-    /* do detect */
-    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-
-    FAIL_IF((PacketAlertCheck(p, 1)));
-    FAIL_IF(!PacketAlertCheck(p, 2));
-    FAIL_IF(!(PacketAlertCheck(p, 3)));
-
-    AppLayerParserThreadCtxFree(alp_tctx);
-    DetectEngineThreadCtxDeinit(&th_v, det_ctx);
-    DetectEngineCtxFree(de_ctx);
-
-    UTHRemoveSessionFromFlow(f);
-    UTHFreeFlow(f);
-    UTHFreePackets(&p, 1);
-    StreamTcpFreeConfig(true);
-    PASS;
-}
-
-/** \test Check the modifiers for uricontent and content
- *        match
- */
-static int DetectUriSigTest07(void)
-{
-    HtpState *http_state = NULL;
-    uint8_t httpbuf1[] = "POST /one/two/three HTTP/1.0\r\nUser-Agent: Mozilla/1.0\r\nCookie:"
-                         " hellocatch\r\n\r\n";
-    uint32_t httplen1 = sizeof(httpbuf1) - 1; /* minus the \0 */
-    Packet *p = NULL;
-    Signature *s = NULL;
-    ThreadVars th_v;
-    DetectEngineThreadCtx *det_ctx = NULL;
-    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
-
-    memset(&th_v, 0, sizeof(th_v));
-    StreamTcpInitConfig(true);
-
-    p = UTHBuildPacket(httpbuf1, httplen1, IPPROTO_TCP);
-    FAIL_IF_NULL(p);
-    p->tcph->th_seq = htonl(1000);
-    Flow *f = UTHBuildFlow(AF_INET, "192.168.1.5", "192.168.1.1", 41424, 80);
-    FAIL_IF_NULL(f);
-    f->proto = IPPROTO_TCP;
-
-    UTHAddSessionToFlow(f, 1000, 1000);
-    UTHAddStreamToFlow(f, 0, httpbuf1, httplen1);
-
-    p->flow = f;
-    p->flowflags |= FLOW_PKT_TOSERVER;
-    p->flowflags |= FLOW_PKT_ESTABLISHED;
-    p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f->alproto = ALPROTO_HTTP1;
-
-    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    FAIL_IF_NULL(de_ctx);
-    de_ctx->flags |= DE_QUIET;
-
-    s = DetectEngineAppendSig(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"foo\"; content:\"bar\"; sid:1;)");
-    FAIL_IF_NULL(s);
-
-    s = DetectEngineAppendSig(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"one\"; offset:1; depth:10; "
-                                   "content:\"one\"; offset:1; depth:10; "
-                                   "uricontent:\"two\"; distance:3; within: 4; "
-                                   "content:\"two\"; distance:1; within: 4; "
-                                   "uricontent:\"three\"; distance:1; within: 6; "
-                                   "content:\"/three\"; distance:0; within: 7; "
-                                   "sid:2;)");
-    FAIL_IF_NULL(s);
-
-    s = DetectEngineAppendSig(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"one\"; offset:1; depth:10; "
-                                   "uricontent:\"two\"; distance:1; within: 4; "
-                                   "uricontent:\"six\"; distance:1; within: 6; "
-                                   "sid:3;)");
-    FAIL_IF_NULL(s);
-
-    SigGroupBuild(de_ctx);
-    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
-
-    int r = AppLayerParserParse(
-            NULL, alp_tctx, f, ALPROTO_HTTP1, STREAM_TOSERVER, httpbuf1, httplen1);
-    FAIL_IF(r != 0);
-    http_state = f->alstate;
-    FAIL_IF_NULL(http_state);
-
-    /* do detect */
-    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-
-    FAIL_IF((PacketAlertCheck(p, 1)));
-    FAIL_IF((PacketAlertCheck(p, 2)));
-    FAIL_IF((PacketAlertCheck(p, 3)));
-
-    AppLayerParserThreadCtxFree(alp_tctx);
-    DetectEngineThreadCtxDeinit(&th_v, det_ctx);
-    DetectEngineCtxFree(de_ctx);
-
-    UTHRemoveSessionFromFlow(f);
-    UTHFreeFlow(f);
-    UTHFreePackets(&p, 1);
-    StreamTcpFreeConfig(true);
-    PASS;
-}
-
 /**
  * \test Test content for dce sig.
  */
-static int DetectUriSigTest08(void)
+static int DetectUriSigTest02(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -1244,7 +435,7 @@ static int DetectUriSigTest08(void)
 /**
  * \test Test content for dce sig.
  */
-static int DetectUriSigTest09(void)
+static int DetectUriSigTest03(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -1273,7 +464,7 @@ static int DetectUriSigTest09(void)
 /**
  * \test Test content for dce sig.
  */
-static int DetectUriSigTest10(void)
+static int DetectUriSigTest04(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -1302,7 +493,7 @@ static int DetectUriSigTest10(void)
 /**
  * \test Test content for dce sig.
  */
-static int DetectUriSigTest11(void)
+static int DetectUriSigTest05(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -1331,7 +522,7 @@ static int DetectUriSigTest11(void)
 /**
  * \test Parsing test
  */
-static int DetectUriSigTest12(void)
+static int DetectUriSigTest06(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     DetectContentData *ud = 0;
@@ -1371,7 +562,7 @@ end:
 /**
  * \test Parsing test
  */
-static int DetectUriContentParseTest13(void)
+static int DetectUriContentParseTest01(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -1400,7 +591,7 @@ static int DetectUriContentParseTest13(void)
 /**
  * \test Parsing test
  */
-static int DetectUriContentParseTest14(void)
+static int DetectUriContentParseTest02(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -1429,7 +620,7 @@ static int DetectUriContentParseTest14(void)
 /**
  * \test Parsing test
  */
-static int DetectUriContentParseTest15(void)
+static int DetectUriContentParseTest03(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -1458,7 +649,7 @@ static int DetectUriContentParseTest15(void)
 /**
  * \test Parsing test
  */
-static int DetectUriContentParseTest16(void)
+static int DetectUriContentParseTest04(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -1487,7 +678,7 @@ static int DetectUriContentParseTest16(void)
 /**
  * \test Parsing test
  */
-static int DetectUriContentParseTest17(void)
+static int DetectUriContentParseTest05(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -1516,7 +707,7 @@ static int DetectUriContentParseTest17(void)
 /**
  * \test Parsing test
  */
-static int DetectUriContentParseTest18(void)
+static int DetectUriContentParseTest06(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -1545,7 +736,7 @@ static int DetectUriContentParseTest18(void)
 /**
  * \test Parsing test
  */
-static int DetectUriContentParseTest19(void)
+static int DetectUriContentParseTest07(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -1574,7 +765,7 @@ static int DetectUriContentParseTest19(void)
 /**
  * \test Parsing test
  */
-static int DetectUriContentParseTest20(void)
+static int DetectUriContentParseTest08(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -1603,7 +794,7 @@ static int DetectUriContentParseTest20(void)
 /**
  * \test Parsing test
  */
-static int DetectUriContentParseTest21(void)
+static int DetectUriContentParseTest09(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -1632,7 +823,7 @@ static int DetectUriContentParseTest21(void)
 /**
  * \test Parsing test
  */
-static int DetectUriContentParseTest22(void)
+static int DetectUriContentParseTest10(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -1661,7 +852,7 @@ static int DetectUriContentParseTest22(void)
 /**
  * \test Parsing test
  */
-static int DetectUriContentParseTest23(void)
+static int DetectUriContentParseTest11(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -1690,7 +881,7 @@ static int DetectUriContentParseTest23(void)
 /**
  * \test Parsing test
  */
-static int DetectUriContentParseTest24(void)
+static int DetectUriContentParseTest12(void)
 {
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -1743,36 +934,25 @@ static int DetectUricontentIsdataatParseTest(void)
 
 static void DetectUricontentRegisterTests(void)
 {
-    UtRegisterTest("HTTPUriTest01", HTTPUriTest01);
-    UtRegisterTest("HTTPUriTest02", HTTPUriTest02);
-    UtRegisterTest("HTTPUriTest03", HTTPUriTest03);
-    UtRegisterTest("HTTPUriTest04", HTTPUriTest04);
-
-    UtRegisterTest("DetectUriSigTest01", DetectUriSigTest01);
+    UtRegisterTest("DetectUriSigTest04 - Modifiers", DetectUriSigTest01);
     UtRegisterTest("DetectUriSigTest02", DetectUriSigTest02);
     UtRegisterTest("DetectUriSigTest03", DetectUriSigTest03);
-    UtRegisterTest("DetectUriSigTest04 - Modifiers", DetectUriSigTest04);
-    UtRegisterTest("DetectUriSigTest05 - Inspection", DetectUriSigTest05);
-    UtRegisterTest("DetectUriSigTest06 - Inspection", DetectUriSigTest06);
-    UtRegisterTest("DetectUriSigTest07 - Inspection", DetectUriSigTest07);
-    UtRegisterTest("DetectUriSigTest08", DetectUriSigTest08);
-    UtRegisterTest("DetectUriSigTest09", DetectUriSigTest09);
-    UtRegisterTest("DetectUriSigTest10", DetectUriSigTest10);
-    UtRegisterTest("DetectUriSigTest11", DetectUriSigTest11);
-    UtRegisterTest("DetectUriSigTest12", DetectUriSigTest12);
+    UtRegisterTest("DetectUriSigTest04", DetectUriSigTest04);
+    UtRegisterTest("DetectUriSigTest05", DetectUriSigTest05);
+    UtRegisterTest("DetectUriSigTest06", DetectUriSigTest06);
 
-    UtRegisterTest("DetectUriContentParseTest13", DetectUriContentParseTest13);
-    UtRegisterTest("DetectUriContentParseTest14", DetectUriContentParseTest14);
-    UtRegisterTest("DetectUriContentParseTest15", DetectUriContentParseTest15);
-    UtRegisterTest("DetectUriContentParseTest16", DetectUriContentParseTest16);
-    UtRegisterTest("DetectUriContentParseTest17", DetectUriContentParseTest17);
-    UtRegisterTest("DetectUriContentParseTest18", DetectUriContentParseTest18);
-    UtRegisterTest("DetectUriContentParseTest19", DetectUriContentParseTest19);
-    UtRegisterTest("DetectUriContentParseTest20", DetectUriContentParseTest20);
-    UtRegisterTest("DetectUriContentParseTest21", DetectUriContentParseTest21);
-    UtRegisterTest("DetectUriContentParseTest22", DetectUriContentParseTest22);
-    UtRegisterTest("DetectUriContentParseTest23", DetectUriContentParseTest23);
-    UtRegisterTest("DetectUriContentParseTest24", DetectUriContentParseTest24);
+    UtRegisterTest("DetectUriContentParseTest01", DetectUriContentParseTest01);
+    UtRegisterTest("DetectUriContentParseTest02", DetectUriContentParseTest02);
+    UtRegisterTest("DetectUriContentParseTest03", DetectUriContentParseTest03);
+    UtRegisterTest("DetectUriContentParseTest04", DetectUriContentParseTest04);
+    UtRegisterTest("DetectUriContentParseTest05", DetectUriContentParseTest05);
+    UtRegisterTest("DetectUriContentParseTest06", DetectUriContentParseTest06);
+    UtRegisterTest("DetectUriContentParseTest07", DetectUriContentParseTest07);
+    UtRegisterTest("DetectUriContentParseTest08", DetectUriContentParseTest08);
+    UtRegisterTest("DetectUriContentParseTest09", DetectUriContentParseTest09);
+    UtRegisterTest("DetectUriContentParseTest10", DetectUriContentParseTest10);
+    UtRegisterTest("DetectUriContentParseTest11", DetectUriContentParseTest11);
+    UtRegisterTest("DetectUriContentParseTest12", DetectUriContentParseTest12);
 
     UtRegisterTest("DetectUricontentIsdataatParseTest",
             DetectUricontentIsdataatParseTest);

--- a/src/detect-uricontent.c
+++ b/src/detect-uricontent.c
@@ -207,200 +207,157 @@ static void DetectUricontentPrint(DetectContentData *cd)
  */
 static int DetectUriSigTest01(void)
 {
-    int result = 0;
     Signature *s = NULL;
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL) {
-        goto end;
-    }
+    FAIL_IF_NULL(de_ctx);
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"foo\"; sid:1;)");
-    if (s == NULL ||
-        s->sm_lists[g_http_uri_buffer_id] == NULL ||
-        s->sm_lists[DETECT_SM_LIST_PMATCH] != NULL ||
-        s->sm_lists[DETECT_SM_LIST_MATCH] != NULL)
-    {
-        printf("sig 1 failed to parse: ");
-        goto end;
-    }
+    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:"
+                                      "\" Test uricontent\"; "
+                                      "uricontent:\"foo\"; sid:1;)");
+    FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";sid:1;)");
-    if (s == NULL ||
-        s->sm_lists[g_http_uri_buffer_id] == NULL ||
-        s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
-        s->sm_lists[DETECT_SM_LIST_MATCH] != NULL)
-    {
-        printf("sig 2 failed to parse: ");
-        goto end;
-    }
+    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:"
+                                      "\" Test uricontent and content\"; "
+                                      "uricontent:\"foo\"; content:\"bar\";sid:1;)");
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; sid:1;)");
-    if (s == NULL ||
-        s->sm_lists[g_http_uri_buffer_id] == NULL ||
-        s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
-        ((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15 ||
-        ((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5 ||
-        s->sm_lists[DETECT_SM_LIST_MATCH] != NULL)
-    {
-        printf("sig 3 failed to parse: ");
-        goto end;
-    }
+    FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "content:\"foo\"; uricontent:\"bar\";"
-                                   " depth:10; offset: 5; sid:1;)");
-    if (s == NULL ||
-        s->sm_lists[g_http_uri_buffer_id] == NULL ||
-        s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
-        ((DetectContentData *)s->sm_lists[g_http_uri_buffer_id]->ctx)->depth != 15 ||
-        ((DetectContentData *)s->sm_lists[g_http_uri_buffer_id]->ctx)->offset != 5 ||
-        s->sm_lists[DETECT_SM_LIST_MATCH] != NULL)
-    {
-        printf("sig 4 failed to parse: ");
-        goto end;
-    }
+    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:"
+                                      "\" Test uricontent and content\"; "
+                                      "uricontent:\"foo\"; content:\"bar\";"
+                                      " depth:10; offset: 5; sid:1;)");
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; within:3; sid:1;)");
-    if (s != NULL) {
-        printf("sig 5 failed to parse: ");
-        goto end;
-    }
+    FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; distance:3; sid:1;)");
-    if (s != NULL) {
-        printf("sig 6 failed to parse: ");
-        goto end;
-    }
+    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:"
+                                      "\" Test uricontent and content\"; "
+                                      "content:\"foo\"; uricontent:\"bar\";"
+                                      " depth:10; offset: 5; sid:1;)");
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; content:"
-                                   "\"two_contents\"; within:30; sid:1;)");
-    if (s == NULL) {
-        goto end;
-    } else if (s->sm_lists[g_http_uri_buffer_id] == NULL ||
-            s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15 ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5 ||
-            ((DetectContentData*) s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx)->within != 30 ||
-            s->sm_lists[DETECT_SM_LIST_MATCH] != NULL)
-    {
-        printf("sig 7 failed to parse: ");
-        DetectContentPrint((DetectContentData*) s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx);
-        goto end;
-    }
+    FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists[g_http_uri_buffer_id]->ctx)->depth != 15);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists[g_http_uri_buffer_id]->ctx)->offset != 5);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; uricontent:"
-                                   "\"two_uricontents\"; within:30; sid:1;)");
-    if (s == NULL) {
-        goto end;
-    } else if (s->sm_lists[g_http_uri_buffer_id] == NULL ||
-            s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15 ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5 ||
-            ((DetectContentData*) s->sm_lists_tail[g_http_uri_buffer_id]->ctx)->within != 30 ||
-            s->sm_lists[DETECT_SM_LIST_MATCH] != NULL)
-    {
-        printf("sig 8 failed to parse: ");
-        DetectUricontentPrint((DetectContentData*) s->sm_lists_tail[g_http_uri_buffer_id]->ctx);
-        goto end;
-    }
+    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:"
+                                      "\" Test uricontent and content\"; "
+                                      "uricontent:\"foo\"; content:\"bar\";"
+                                      " depth:10; offset: 5; within:3; sid:1;)");
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; content:"
-                                   "\"two_contents\"; distance:30; sid:1;)");
-    if (s == NULL) {
-        goto end;
-    } else if (
-            s->sm_lists[g_http_uri_buffer_id] == NULL ||
-            s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15 ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5 ||
-            ((DetectContentData*) s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx)->distance != 30 ||
-            s->sm_lists[DETECT_SM_LIST_MATCH] != NULL)
-    {
-        printf("sig 9 failed to parse: ");
-        DetectContentPrint((DetectContentData*) s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx);
-        goto end;
-    }
+    FAIL_IF_NOT_NULL(s);
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; uricontent:"
-                                   "\"two_uricontents\"; distance:30; sid:1;)");
-    if (s == NULL) {
-        goto end;
-    } else if (
-            s->sm_lists[g_http_uri_buffer_id] == NULL ||
-            s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15 ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5 ||
-            ((DetectContentData*) s->sm_lists_tail[g_http_uri_buffer_id]->ctx)->distance != 30 ||
-            s->sm_lists[DETECT_SM_LIST_MATCH] != NULL)
-    {
-        printf("sig 10 failed to parse: ");
-        DetectUricontentPrint((DetectContentData*) s->sm_lists_tail[g_http_uri_buffer_id]->ctx);
-        goto end;
-    }
+    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:"
+                                      "\" Test uricontent and content\"; "
+                                      "uricontent:\"foo\"; content:\"bar\";"
+                                      " depth:10; offset: 5; distance:3; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; uricontent:"
-                                   "\"two_uricontents\"; distance:30; "
-                                   "within:60; content:\"two_contents\";"
-                                   " within:70; distance:45; sid:1;)");
-    if (s == NULL) {
-        printf("sig 10 failed to parse: ");
-        goto end;
-    }
+    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:"
+                                      "\" Test uricontent and content\"; "
+                                      "uricontent:\"foo\"; content:\"bar\";"
+                                      " depth:10; offset: 5; content:"
+                                      "\"two_contents\"; within:30; sid:1;)");
 
-    if (s->sm_lists[g_http_uri_buffer_id] == NULL || s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL) {
-        printf("umatch %p or pmatch %p: ", s->sm_lists[g_http_uri_buffer_id], s->sm_lists[DETECT_SM_LIST_PMATCH]);
-        goto end;
-    }
+    FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx)->within != 30);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
 
-    if (    ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15 ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5 ||
-            ((DetectContentData*) s->sm_lists_tail[g_http_uri_buffer_id]->ctx)->distance != 30 ||
-            ((DetectContentData*) s->sm_lists_tail[g_http_uri_buffer_id]->ctx)->within != 60 ||
-            ((DetectContentData*) s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx)->distance != 45 ||
-            ((DetectContentData*) s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx)->within != 70 ||
-            s->sm_lists[DETECT_SM_LIST_MATCH] != NULL) {
-        printf("sig 10 failed to parse, content not setup properly: ");
-        DetectContentPrint((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx);
-        DetectUricontentPrint((DetectContentData*) s->sm_lists_tail[g_http_uri_buffer_id]->ctx);
-        DetectContentPrint((DetectContentData*) s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx);
-        goto end;
-    }
+    DetectContentPrint((DetectContentData *)s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx);
 
-    result = 1;
-end:
-    if (de_ctx != NULL)
-        DetectEngineCtxFree(de_ctx);
-    return result;
+    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:"
+                                      "\" Test uricontent and content\"; "
+                                      "uricontent:\"foo\"; content:\"bar\";"
+                                      " depth:10; offset: 5; uricontent:"
+                                      "\"two_uricontents\"; within:30; sid:1;)");
+
+    FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists_tail[g_http_uri_buffer_id]->ctx)->within != 30);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
+
+    DetectUricontentPrint((DetectContentData *)s->sm_lists_tail[g_http_uri_buffer_id]->ctx);
+
+    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:"
+                                      "\" Test uricontent and content\"; "
+                                      "uricontent:\"foo\"; content:\"bar\";"
+                                      " depth:10; offset: 5; content:"
+                                      "\"two_contents\"; distance:30; sid:1;)");
+
+    FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5);
+    FAIL_IF_NOT(
+            ((DetectContentData *)s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx)->distance != 30);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
+
+    DetectContentPrint((DetectContentData *)s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx);
+
+    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:"
+                                      "\" Test uricontent and content\"; "
+                                      "uricontent:\"foo\"; content:\"bar\";"
+                                      " depth:10; offset: 5; uricontent:"
+                                      "\"two_uricontents\"; distance:30; sid:1;)");
+
+    FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists_tail[g_http_uri_buffer_id]->ctx)->distance != 30);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
+
+    DetectUricontentPrint((DetectContentData *)s->sm_lists_tail[g_http_uri_buffer_id]->ctx);
+
+    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:"
+                                      "\" Test uricontent and content\"; "
+                                      "uricontent:\"foo\"; content:\"bar\";"
+                                      " depth:10; offset: 5; uricontent:"
+                                      "\"two_uricontents\"; distance:30; "
+                                      "within:60; content:\"two_contents\";"
+                                      " within:70; distance:45; sid:1;)");
+    FAIL_IF_NULL(s);
+
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists_tail[g_http_uri_buffer_id]->ctx)->distance != 30);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists_tail[g_http_uri_buffer_id]->ctx)->within != 60);
+    FAIL_IF_NOT(
+            ((DetectContentData *)s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx)->distance != 45);
+    FAIL_IF_NOT(((DetectContentData *)s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx)->within != 70);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
+
+    DetectContentPrint((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx);
+    DetectUricontentPrint((DetectContentData *)s->sm_lists_tail[g_http_uri_buffer_id]->ctx);
+    DetectContentPrint((DetectContentData *)s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx);
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
 }
 
 /**
@@ -408,28 +365,16 @@ end:
  */
 static int DetectUriSigTest02(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"\"; sid:238012;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"\"; sid:238012;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -437,28 +382,16 @@ static int DetectUriSigTest02(void)
  */
 static int DetectUriSigTest03(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"; sid:238012;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"; sid:238012;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -466,28 +399,16 @@ static int DetectUriSigTest03(void)
  */
 static int DetectUriSigTest04(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"boo; sid:238012;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"boo; sid:238012;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -495,28 +416,16 @@ static int DetectUriSigTest04(void)
  */
 static int DetectUriSigTest05(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:boo\"; sid:238012;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:boo\"; sid:238012;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -524,38 +433,25 @@ static int DetectUriSigTest05(void)
  */
 static int DetectUriSigTest06(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
     DetectContentData *ud = 0;
     Signature *s = NULL;
-    int result = 0;
 
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx,
-                                   "alert udp any any -> any any "
-                                   "(msg:\"test\"; uricontent:    !\"boo\"; sid:238012;)");
-    if (de_ctx->sig_list == NULL) {
-        printf("de_ctx->sig_list == NULL: ");
-        goto end;
-    }
+    s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                      "(msg:\"test\"; uricontent:    !\"boo\"; sid:238012;)");
+    FAIL_IF_NULL(s);
 
-    if (s->sm_lists_tail[g_http_uri_buffer_id] == NULL || s->sm_lists_tail[g_http_uri_buffer_id]->ctx == NULL) {
-        printf("de_ctx->pmatch_tail == NULL && de_ctx->pmatch_tail->ctx == NULL: ");
-        goto end;
-    }
+    FAIL_IF_NULL(s->sm_lists_tail[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists_tail[g_http_uri_buffer_id]->ctx);
 
     ud = (DetectContentData *)s->sm_lists_tail[g_http_uri_buffer_id]->ctx;
-    result = (strncmp("boo", (char *)ud->content, ud->content_len) == 0);
+    FAIL_IF_NOT(strncmp("boo", (char *)ud->content, ud->content_len) == 0);
 
-end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 
@@ -564,28 +460,16 @@ end:
  */
 static int DetectUriContentParseTest01(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|\"; sid:1;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"|\"; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -593,28 +477,16 @@ static int DetectUriContentParseTest01(void)
  */
 static int DetectUriContentParseTest02(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af\"; sid:1;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"|af\"; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -622,28 +494,16 @@ static int DetectUriContentParseTest02(void)
  */
 static int DetectUriContentParseTest03(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"af|\"; sid:1;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"af|\"; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -651,28 +511,16 @@ static int DetectUriContentParseTest03(void)
  */
 static int DetectUriContentParseTest04(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af|\"; sid:1;)");
-    if (de_ctx->sig_list == NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"|af|\"; sid:1;)");
+    FAIL_IF_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -680,28 +528,16 @@ static int DetectUriContentParseTest04(void)
  */
 static int DetectUriContentParseTest05(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"aast|\"; sid:1;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"aast|\"; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -709,28 +545,16 @@ static int DetectUriContentParseTest05(void)
  */
 static int DetectUriContentParseTest06(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"aast|af\"; sid:1;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"aast|af\"; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -738,28 +562,16 @@ static int DetectUriContentParseTest06(void)
  */
 static int DetectUriContentParseTest07(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"aast|af|\"; sid:1;)");
-    if (de_ctx->sig_list == NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"aast|af|\"; sid:1;)");
+    FAIL_IF_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -767,28 +579,16 @@ static int DetectUriContentParseTest07(void)
  */
 static int DetectUriContentParseTest08(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af|asdf\"; sid:1;)");
-    if (de_ctx->sig_list == NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"|af|asdf\"; sid:1;)");
+    FAIL_IF_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -796,28 +596,16 @@ static int DetectUriContentParseTest08(void)
  */
 static int DetectUriContentParseTest09(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af|af|\"; sid:1;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"|af|af|\"; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -825,28 +613,17 @@ static int DetectUriContentParseTest09(void)
  */
 static int DetectUriContentParseTest10(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af|af|af\"; sid:1;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s =
+            DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                          "(msg:\"test\"; uricontent:\"|af|af|af\"; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -854,28 +631,17 @@ static int DetectUriContentParseTest10(void)
  */
 static int DetectUriContentParseTest11(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af|af|af|\"; sid:1;)");
-    if (de_ctx->sig_list == NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s =
+            DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                          "(msg:\"test\"; uricontent:\"|af|af|af|\"; sid:1;)");
+    FAIL_IF_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -883,28 +649,16 @@ static int DetectUriContentParseTest11(void)
  */
 static int DetectUriContentParseTest12(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"\"; sid:1;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"\"; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 static int DetectUricontentIsdataatParseTest(void)


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to redmine ticket: https://redmine.openinfosecfoundation.org/issues/4911

Describe changes:
- remove unittests that have been converted to Suricata-Verify
- Update detect-uricontent unittests to use FAIL/PASS APIs
- Cleanup unittests
- Update Copyright Year

Previous PR: #6850

suricata-verify-pr: 659