### PR TITLE
fuzz: cleans all flow after one run

### DIFF
--- a/src/flow.c
+++ b/src/flow.c
@@ -646,6 +646,22 @@ void FlowInitConfig(bool quiet)
     return;
 }
 
+void FlowReset(void)
+{
+    // resets the flows (for reuse by fuzzing)
+    for (uint32_t u = 0; u < flow_config.hash_size; u++) {
+        Flow *f = flow_hash[u].head;
+        while (f) {
+            Flow *n = f->next;
+            uint8_t proto_map = FlowGetProtoMapping(f->proto);
+            FlowClearMemory(f, proto_map);
+            FlowFree(f);
+            f = n;
+        }
+        flow_hash[u].head = NULL;
+    }
+}
+
 /** \brief shutdown the flow engine
  *  \warning Not thread safe */
 void FlowShutdown(void)

--- a/src/flow.h
+++ b/src/flow.h
@@ -555,6 +555,7 @@ void FlowSetupPacket(Packet *p);
 void FlowHandlePacket (ThreadVars *, FlowLookupStruct *, Packet *);
 void FlowInitConfig(bool);
 void FlowPrintQueueInfo (void);
+void FlowReset(void);
 void FlowShutdown(void);
 void FlowSetIPOnlyFlag(Flow *, int);
 void FlowSetHasAlertsFlag(Flow *);

--- a/src/tests/fuzz/fuzz_predefpcap_aware.c
+++ b/src/tests/fuzz/fuzz_predefpcap_aware.c
@@ -143,17 +143,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         p->pcap_cnt = pcap_cnt;
     }
     PacketFree(p);
-    for (uint32_t u = 0; u < flow_config.hash_size; u++) {
-        Flow *f = flow_hash[u].head;
-        while (f) {
-            Flow *n = f->next;
-            uint8_t proto_map = FlowGetProtoMapping(f->proto);
-            FlowClearMemory(f, proto_map);
-            FlowFree(f);
-            f = n;
-        }
-        flow_hash[u].head = NULL;
-    }
+    FlowReset();
 
     return 0;
 }

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -22,6 +22,7 @@
 #include "util-unittest-helper.h"
 #include "conf-yaml-loader.h"
 #include "pkt-var.h"
+#include "flow-util.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 
@@ -185,6 +186,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     //close structure
     pcap_close(pkts);
     PacketFree(p);
+    FlowReset();
 
     return 0;
 }

--- a/src/tests/fuzz/fuzz_sigpcap_aware.c
+++ b/src/tests/fuzz/fuzz_sigpcap_aware.c
@@ -22,6 +22,7 @@
 #include "util-unittest-helper.h"
 #include "conf-yaml-loader.h"
 #include "pkt-var.h"
+#include "flow-util.h"
 
 #include <fuzz_pcap.h>
 
@@ -181,6 +182,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         p->pcap_cnt = pcap_cnt;
     }
     PacketFree(p);
+    FlowReset();
 
     return 0;
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=43842

Describe changes:
- improves fuzz targets : cleans all flow after one run, as already done in e2370d6861990e9aba7b551e51cfa04d945f4510, but for all such fuzz targets

Fixes false positive found by oss-fuzz about frames assertion

Modifies #6833 with refactoring code