### PR TITLE
App maxtx 4530 v10

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1375,6 +1375,36 @@ independent. The ``probing parsers`` will only run on the ``detection-ports``.
 SMB is commonly used to transfer the DCERPC protocol. This traffic is also handled by
 this parser.
 
+Configure HTTP2
+~~~~~~~~~~~~~~~
+
+HTTP2 has 2 parameters that can be customized.
+The point of these 2 parameters is to find a balance between the completeness
+of analysis and the resource consumption.
+
+`http2.max-table-size` refers to `SETTINGS_HEADER_TABLE_SIZE` from rfc 7540 section 6.5.2.
+Its default value is 4096 bytes, but it can be set to any uint32 by a flow.
+
+`http2.max-streams` refers to `SETTINGS_MAX_CONCURRENT_STREAMS` from rfc 7540 section 6.5.2.
+Its default value is unlimited.
+
+Configure MQTT
+~~~~~~~~~~~~~~
+
+MQTT has one parameter that can be customized.
+`mqtt.max-tx` refers to the maximum number of live transactions for each flow.
+The app-layer event `mqtt.too_many_transactions` is triggered when this value is reached.
+The point of this parameter is to find a balance between the completeness of analysis
+and the resource consumption.
+
+Configure FTP
+~~~~~~~~~~~~~
+
+FTP has one parameter that can be customized.
+`ftp.max-tx` refers to the maximum number of live transactions for each flow.
+The point of this parameter is to find a balance between the completeness of analysis
+and the resource consumption.
+
 Engine Logging
 --------------
 

--- a/rules/http2-events.rules
+++ b/rules/http2-events.rules
@@ -16,3 +16,4 @@ alert http2 any any -> any any (msg:"SURICATA HTTP2 stream identifier reuse"; fl
 alert http2 any any -> any any (msg:"SURICATA HTTP2 invalid HTTP1 settings during upgrade"; flow:established; app-layer-event:http2.invalid_http1_settings; classtype:protocol-command-decode; sid:2290008; rev:1;)
 alert http2 any any -> any any (msg:"SURICATA HTTP2 failed decompression"; flow:established; app-layer-event:http2.failed_decompression; classtype:protocol-command-decode; sid:2290009; rev:1;)
 alert http2 any any -> any any (msg:"SURICATA HTTP2 invalid range header"; flow:established; app-layer-event:http2.invalid_range; classtype:protocol-command-decode; sid:2290010; rev:1;)
+alert http2 any any -> any any (msg:"SURICATA HTTP2 too many streams"; flow:established; app-layer-event:http2.too_many_streams; classtype:protocol-command-decode; sid:2290011; rev:1;)

--- a/rules/mqtt-events.rules
+++ b/rules/mqtt-events.rules
@@ -13,3 +13,4 @@ alert mqtt any any -> any any (msg:"SURICATA MQTT message seen before CONNECT/CO
 alert mqtt any any -> any any (msg:"SURICATA MQTT invalid QOS level"; app-layer-event:mqtt.invalid_qos_level; classtype:protocol-command-decode; sid:2229006; rev:1;)
 alert mqtt any any -> any any (msg:"SURICATA MQTT missing message ID"; app-layer-event:mqtt.missing_msg_id; classtype:protocol-command-decode; sid:2229007; rev:1;)
 alert mqtt any any -> any any (msg:"SURICATA MQTT unassigned message type (0 or >15)"; app-layer-event:mqtt.unassigned_msg_type; classtype:protocol-command-decode; sid:2229008; rev:1;)
+alert mqtt any any -> any any (msg:"SURICATA MQTT too many transactions"; app-layer-event:mqtt.too_many_transactions; classtype:protocol-command-decode; sid:2229009; rev:1;)

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -21,6 +21,7 @@ use super::parser;
 use super::range;
 
 use crate::applayer::{self, *};
+use crate::conf::conf_get;
 use crate::core::*;
 use crate::filecontainer::*;
 use crate::filetracker::*;
@@ -58,9 +59,8 @@ const HTTP2_FRAME_GOAWAY_LEN: usize = 4;
 const HTTP2_FRAME_RSTSTREAM_LEN: usize = 4;
 const HTTP2_FRAME_PRIORITY_LEN: usize = 5;
 const HTTP2_FRAME_WINDOWUPDATE_LEN: usize = 4;
-//TODO make these configurable
-pub const HTTP2_MAX_TABLESIZE: u32 = 0x10000; // 65536
-pub const HTTP2_MAX_STREAMS: usize = 0x1000; // 4096
+pub static mut HTTP2_MAX_TABLESIZE: u32 = 65536; // 0x10000
+static mut HTTP2_MAX_STREAMS: usize = 4096; // 0x1000
 
 #[repr(u8)]
 #[derive(Copy, Clone, PartialOrd, PartialEq, Debug)]
@@ -575,7 +575,7 @@ impl HTTP2State {
             tx.stream_id = sid;
             tx.state = HTTP2TransactionState::HTTP2StateOpen;
             // do not use SETTINGS_MAX_CONCURRENT_STREAMS as it can grow too much
-            if self.transactions.len() > HTTP2_MAX_STREAMS {
+            if self.transactions.len() > unsafe { HTTP2_MAX_STREAMS } {
                 // set at least one another transaction to the drop state
                 for tx_old in &mut self.transactions {
                     if tx_old.state != HTTP2TransactionState::HTTP2StateTodrop {
@@ -651,7 +651,7 @@ impl HTTP2State {
                                     &mut self.dynamic_headers_tc
                                 };
                                 dyn_headers.max_size = set[i].value as usize;
-                                if set[i].value > HTTP2_MAX_TABLESIZE {
+                                if set[i].value > unsafe { HTTP2_MAX_TABLESIZE } {
                                     //mark potential overflow
                                     dyn_headers.overflow = 1;
                                 } else {
@@ -1103,8 +1103,7 @@ pub unsafe extern "C" fn rs_http2_state_tx_free(state: *mut std::os::raw::c_void
 #[no_mangle]
 pub unsafe extern "C" fn rs_http2_parse_ts(
     flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
-    stream_slice: StreamSlice,
-    _data: *const std::os::raw::c_void
+    stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, HTTP2State);
     let buf = stream_slice.as_slice();
@@ -1117,8 +1116,7 @@ pub unsafe extern "C" fn rs_http2_parse_ts(
 #[no_mangle]
 pub unsafe extern "C" fn rs_http2_parse_tc(
     flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
-    stream_slice: StreamSlice,
-    _data: *const std::os::raw::c_void
+    stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, HTTP2State);
     let buf = stream_slice.as_slice();
@@ -1220,6 +1218,20 @@ pub unsafe extern "C" fn rs_http2_register_parser() {
         ALPROTO_HTTP2 = alproto;
         if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
             let _ = AppLayerRegisterParser(&parser, alproto);
+        }
+        if let Some(val) = conf_get("app-layer.protocols.http2.max-streams") {
+            if let Ok(v) = val.parse::<usize>() {
+                HTTP2_MAX_STREAMS = v;
+            } else {
+                SCLogError!("Invalid value for http2.max-streams");
+            }
+        }
+        if let Some(val) = conf_get("app-layer.protocols.http2.max-table-size") {
+            if let Ok(v) = val.parse::<u32>() {
+                HTTP2_MAX_TABLESIZE = v;
+            } else {
+                SCLogError!("Invalid value for http2.max-table-size");
+            }
         }
         SCLogDebug!("Rust http2 parser registered.");
     } else {

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -58,8 +58,9 @@ const HTTP2_FRAME_GOAWAY_LEN: usize = 4;
 const HTTP2_FRAME_RSTSTREAM_LEN: usize = 4;
 const HTTP2_FRAME_PRIORITY_LEN: usize = 5;
 const HTTP2_FRAME_WINDOWUPDATE_LEN: usize = 4;
-//TODO make this configurable
+//TODO make these configurable
 pub const HTTP2_MAX_TABLESIZE: u32 = 0x10000; // 65536
+pub const HTTP2_MAX_STREAMS: usize = 0x1000; // 4096
 
 #[repr(u8)]
 #[derive(Copy, Clone, PartialOrd, PartialEq, Debug)]
@@ -110,6 +111,8 @@ pub enum HTTP2TransactionState {
     HTTP2StateClosed = 7,
     //not a RFC-defined state, used for stream 0 frames appyling to the global connection
     HTTP2StateGlobal = 8,
+    //not a RFC-defined state, dropping this old tx because we have too many
+    HTTP2StateTodrop = 9,
 }
 
 #[derive(Debug)]
@@ -366,6 +369,7 @@ pub enum HTTP2Event {
     InvalidHTTP1Settings,
     FailedDecompression,
     InvalidRange,
+    TooManyStreams,
 }
 
 pub struct HTTP2DynTable {
@@ -570,6 +574,18 @@ impl HTTP2State {
             tx.tx_id = self.tx_id;
             tx.stream_id = sid;
             tx.state = HTTP2TransactionState::HTTP2StateOpen;
+            // do not use SETTINGS_MAX_CONCURRENT_STREAMS as it can grow too much
+            if self.transactions.len() > HTTP2_MAX_STREAMS {
+                // set at least one another transaction to the drop state
+                for tx_old in &mut self.transactions {
+                    if tx_old.state != HTTP2TransactionState::HTTP2StateTodrop {
+                        // use a distinct state, even if we do not log it
+                        tx_old.set_event(HTTP2Event::TooManyStreams);
+                        tx_old.state = HTTP2TransactionState::HTTP2StateTodrop;
+                        break;
+                    }
+                }
+            }
             self.transactions.push(tx);
             return self.transactions.last_mut().unwrap();
         }

--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -454,7 +454,7 @@ fn http2_parse_headers_block_literal_incindex<'a>(
                 //in case of overflow, best effort is to keep first headers
                 if dyn_headers.overflow > 0 {
                     if dyn_headers.overflow == 1 {
-                        if dyn_headers.current_size <= (HTTP2_MAX_TABLESIZE as usize) {
+                        if dyn_headers.current_size <= (unsafe { HTTP2_MAX_TABLESIZE } as usize) {
                             //overflow had not yet happened
                             dyn_headers.table.push(headcopy);
                         } else if dyn_headers.current_size > dyn_headers.max_size {

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -21,6 +21,7 @@ use super::mqtt_message::*;
 use super::parser::*;
 use crate::applayer::{self, LoggerFlags};
 use crate::applayer::*;
+use crate::conf::conf_get;
 use crate::core::*;
 use nom7::Err;
 use std;
@@ -35,8 +36,7 @@ const MQTT_CONNECT_PKT_ID: u32 = std::u32::MAX;
 // this value, it will be truncated. Default: 1MB.
 static mut MAX_MSG_LEN: u32 = 1048576;
 
-//TODO make this configurable
-const MQTT_MAX_TX: usize = 1024;
+static mut MQTT_MAX_TX: usize = 1024;
 
 static mut ALPROTO_MQTT: AppProto = ALPROTO_UNKNOWN;
 
@@ -167,7 +167,7 @@ impl MQTTState {
         } else {
             tx.toserver = true;
         }
-        if self.transactions.len() > MQTT_MAX_TX {
+        if self.transactions.len() > unsafe { MQTT_MAX_TX } {
             for tx_old in &mut self.transactions {
                 if !tx_old.complete {
                     tx_old.complete = true;
@@ -717,6 +717,13 @@ pub unsafe extern "C" fn rs_mqtt_register_parser(cfg_max_msg_len: u32) {
         ALPROTO_MQTT = alproto;
         if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
             let _ = AppLayerRegisterParser(&parser, alproto);
+        }
+        if let Some(val) = conf_get("app-layer.protocols.mqtt.max-tx") {
+            if let Ok(v) = val.parse::<usize>() {
+                MQTT_MAX_TX = v;
+            } else {
+                SCLogError!("Invalid value for mqtt.max-tx");
+            }
         }
     } else {
         SCLogDebug!("Protocol detector and parser disabled for MQTT.");

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -877,7 +877,7 @@ static int SMTPProcessReply(SMTPState *state, Flow *f,
             SMTPSetEvent(state, SMTP_DECODER_EVENT_DATA_COMMAND_REJECTED);
         }
     } else if (IsReplyToCommand(state, SMTP_COMMAND_RSET)) {
-        if (reply_code == SMTP_REPLY_250 &&
+        if (reply_code == SMTP_REPLY_250 && state->curr_tx &&
                 !(state->parser_state & SMTP_PARSER_STATE_PARSING_MULTILINE_REPLY)) {
             SMTPTransactionComplete(state);
         }

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -59,6 +59,9 @@ int LLVMFuzzerInitialize(int *argc, char ***argv)
     return 0;
 }
 
+// arbitrary value
+#define ALPROTO_MAXTX 4096
+
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     Flow * f;
@@ -166,6 +169,31 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             }
 
             AppLayerParserTransactionsCleanup(f);
+
+            if (f->alstate && f->alparser) {
+                // check if we have too many open transactions
+                const uint64_t total_txs = AppLayerParserGetTxCnt(f, f->alstate);
+                uint64_t min = 0;
+                AppLayerGetTxIterState state;
+                memset(&state, 0, sizeof(state));
+                uint64_t nbtx = 0;
+                AppLayerGetTxIteratorFunc IterFunc = AppLayerGetTxIterator(f->proto, f->alproto);
+                while (1) {
+                    AppLayerGetTxIterTuple ires =
+                            IterFunc(f->proto, f->alproto, f->alstate, min, total_txs, &state);
+                    if (ires.tx_ptr == NULL)
+                        break;
+                    min = ires.tx_id + 1;
+                    nbtx++;
+                    if (nbtx > ALPROTO_MAXTX) {
+                        printf("Too many open transactions for protocol %s\n",
+                                AppProtoToString(f->alproto));
+                        printf("Assertion failure: %s\n", AppProtoToString(f->alproto));
+                        fflush(stdout);
+                        abort();
+                    }
+                }
+            }
         }
         alsize -= alnext - albuffer + 4;
         albuffer = alnext + 4;

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -117,6 +117,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         f->alproto = data[0];
     }
 
+    FLOWLOCK_WRLOCK(f);
     /*
      * We want to fuzz multiple calls to AppLayerParserParse
      * because some parts of the code are only reached after
@@ -163,6 +164,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
                 alsize = 0;
                 break;
             }
+
+            AppLayerParserTransactionsCleanup(f);
         }
         alsize -= alnext - albuffer + 4;
         albuffer = alnext + 4;
@@ -191,6 +194,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         free(isolatedBuffer);
     }
 
+    FLOWLOCK_UNLOCK(f);
     FlowFree(f);
 
     return 0;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -833,6 +833,10 @@ app-layer:
       #hassh: yes
     http2:
       enabled: yes
+      # Maximum number of live HTTP2 streams in a flow
+      #max-streams: 4096
+      # Maximum headers table size
+      #max-table-size: 65536
     smtp:
       enabled: yes
       raw-extraction: no

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -788,6 +788,8 @@ app-layer:
       # max-msg-length: 1mb
       # subscribe-topic-match-limit: 100
       # unsubscribe-topic-match-limit: 100
+      # Maximum number of live MQTT transactions per flow
+      # max-tx: 4096
     krb5:
       enabled: yes
     snmp:


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4530
https://redmine.openinfosecfoundation.org/issues/4948

Describe changes:
- limits the number of active transactions per flow for HTTP2 and MQTT
- fixes MQTT transaction completion
- SMTP : prevents assertion from being triggered (is this assertion meaningful ?)

This is to avoid DOS by quadratic complexity for protocols looping over the whole list of transactions looking for a
specific transation with an identifier, so that a new PDU gets processed within that transaction.

There may be other protocols with this problem (like Modbus)

Replaces #6788 with 
- fixing the SMTP assertions triggered from https://redmine.openinfosecfoundation.org/issues/4948

