### PR TITLE
Rust overflows v2

### DIFF
--- a/rules/http2-events.rules
+++ b/rules/http2-events.rules
@@ -16,3 +16,4 @@ alert http2 any any -> any any (msg:"SURICATA HTTP2 stream identifier reuse"; fl
 alert http2 any any -> any any (msg:"SURICATA HTTP2 invalid HTTP1 settings during upgrade"; flow:established; app-layer-event:http2.invalid_http1_settings; classtype:protocol-command-decode; sid:2290008; rev:1;)
 alert http2 any any -> any any (msg:"SURICATA HTTP2 failed decompression"; flow:established; app-layer-event:http2.failed_decompression; classtype:protocol-command-decode; sid:2290009; rev:1;)
 alert http2 any any -> any any (msg:"SURICATA HTTP2 invalid range header"; flow:established; app-layer-event:http2.invalid_range; classtype:protocol-command-decode; sid:2290010; rev:1;)
+alert http2 any any -> any any (msg:"SURICATA HTTP2 variable-length integer overflow"; flow:established; app-layer-event:http2.header_integer_overflow; classtype:protocol-command-decode; sid:2290011; rev:1;)

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -295,6 +295,10 @@ impl Flow {
             let mut secs: u64 = 0;
             let mut usecs: u64 = 0;
             FlowGetLastTimeAsParts(self, &mut secs, &mut usecs);
+            if usecs > 999999 {
+                // if microseconds are inconsistent, reset them to 0
+                usecs = 0;
+            }
             std::time::Duration::new(secs, usecs as u32 * 1000)
         }
     }

--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -530,11 +530,11 @@ fn http2_parse_var_uint(input: &[u8], value: u64, max: u64) -> IResult<&[u8], u6
     for i in 0..varia.len() {
         varval += ((varia[i] & 0x7F) as u64) << (7 * i);
     }
-    varval += (finalv as u64) << (7 * varia.len());
-    if varval < max {
-        // this has overflown u64
+    if (finalv as u64) << (7 * varia.len()) > u64::MAX - varval {
+        // this would overflow u64
         return Ok((i3, 0));
     }
+    varval += (finalv as u64) << (7 * varia.len());
     return Ok((i3, varval));
 }
 

--- a/rust/src/mqtt/parser.rs
+++ b/rust/src/mqtt/parser.rs
@@ -22,6 +22,7 @@ use crate::mqtt::mqtt_message::*;
 use crate::mqtt::mqtt_property::*;
 use nom7::bits::streaming::take as take_bits;
 use nom7::bytes::streaming::take_while_m_n;
+use nom7::bytes::complete::take;
 use nom7::combinator::{complete, cond, verify};
 use nom7::multi::{length_data, many0, many1};
 use nom7::number::streaming::*;
@@ -105,26 +106,24 @@ fn parse_properties(input: &[u8], precond: bool) -> IResult<&[u8], Option<Vec<MQ
     }
     // parse properties length
     match parse_mqtt_variable_integer(input) {
-        Ok((rem, mut proplen)) => {
+        Ok((rem, proplen)) => {
             if proplen == 0 {
                 // no properties
                 return Ok((rem, None));
             }
             // parse properties
             let mut props = Vec::<MQTTProperty>::new();
-            let mut newrem = rem;
-            while proplen > 0 {
+            let (rem, mut newrem) = take(proplen as usize)(rem)?;
+            while newrem.len() > 0 {
                 match parse_property(newrem) {
-                    Ok((rem, val)) => {
+                    Ok((rem2, val)) => {
                         props.push(val);
-                        let curparselen = (newrem.len() - rem.len()) as u32;
-                        proplen -= curparselen;
-                        newrem = rem;
+                        newrem = rem2;
                     }
                     Err(e) => return Err(e),
                 }
             }
-            return Ok((newrem, Some(props)));
+            return Ok((rem, Some(props)));
         }
         Err(e) => return Err(e),
     }

--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -28,7 +28,7 @@ use nom7::error::{make_error, ErrorKind};
 use nom7::multi::{many1, many_m_n, many_till};
 use nom7::number::streaming::{be_i16, be_i32};
 use nom7::number::streaming::{be_u16, be_u32, be_u8};
-use nom7::sequence::{terminated, tuple};
+use nom7::sequence::terminated;
 use nom7::{Err, IResult};
 
 pub const PGSQL_LENGTH_FIELD: u32 = 4;
@@ -1064,11 +1064,12 @@ fn parse_notification_response(i: &[u8]) -> IResult<&[u8], PgsqlBEMessage> {
 }
 
 pub fn pgsql_parse_response(i: &[u8]) -> IResult<&[u8], PgsqlBEMessage> {
-    let (i, pseudo_header) = peek(tuple((be_u8, be_u32)))(i)?;
+    let (i, pseudo_header0) = be_u8(i)?;
+    let (i, pseudo_header1) = peek(be_u32)(i)?;
     let (i, message) = map_parser(
-        take(pseudo_header.1 + 1),
+        take(pseudo_header1),
         |b| {
-            match pseudo_header.0 {
+            match pseudo_header0 {
                 b'E' => pgsql_parse_error_response(b),
                 b'K' => parse_backend_key_data_message(b),
                 b'N' => pgsql_parse_notice_response(b),


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- http2 : checks unsigned overflow before it happens
- MQTT : use appropriate size for buffer when parsing properties
- PGSQL : fixes unsigned overflow
- Adds a consistency check about timestamp microseconds

cc @satta for the mqtt commit
cc @jufajardini for the PGSQL commit

Modifies #6851 :
- adds PGSQL and timestamp microseconds commits
- MQTT : more idiomatic nom (still more work to do to avoid endless buffering with more `complete`, not as part of this PR)
- HTTP2 : sets an app-layer event in case of integer overflow