### PR TITLE
Flow manager adaptive/v20

### DIFF
--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -77,11 +77,19 @@ struct AppLayerThreadCtx_ {
 typedef struct AppLayerCounterNames_ {
     char name[MAX_COUNTER_SIZE];
     char tx_name[MAX_COUNTER_SIZE];
+    char gap_error[MAX_COUNTER_SIZE];
+    char parser_error[MAX_COUNTER_SIZE];
+    char internal_error[MAX_COUNTER_SIZE];
+    char alloc_error[MAX_COUNTER_SIZE];
 } AppLayerCounterNames;
 
 typedef struct AppLayerCounters_ {
     uint16_t counter_id;
     uint16_t counter_tx_id;
+    uint16_t gap_error_id;
+    uint16_t parser_error_id;
+    uint16_t internal_error_id;
+    uint16_t alloc_error_id;
 } AppLayerCounters;
 
 /* counter names. Only used at init. */
@@ -117,6 +125,38 @@ void AppLayerIncTxCounter(ThreadVars *tv, Flow *f, uint64_t step)
     const uint16_t id = applayer_counters[f->protomap][f->alproto].counter_tx_id;
     if (likely(tv && id > 0)) {
         StatsAddUI64(tv, id, step);
+    }
+}
+
+void AppLayerIncGapErrorCounter(ThreadVars *tv, Flow *f)
+{
+    const uint16_t id = applayer_counters[f->protomap][f->alproto].gap_error_id;
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
+    }
+}
+
+void AppLayerIncAllocErrorCounter(ThreadVars *tv, Flow *f)
+{
+    const uint16_t id = applayer_counters[f->protomap][f->alproto].alloc_error_id;
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
+    }
+}
+
+void AppLayerIncParserErrorCounter(ThreadVars *tv, Flow *f)
+{
+    const uint16_t id = applayer_counters[f->protomap][f->alproto].parser_error_id;
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
+    }
+}
+
+void AppLayerIncInternalErrorCounter(ThreadVars *tv, Flow *f)
+{
+    const uint16_t id = applayer_counters[f->protomap][f->alproto].internal_error_id;
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
     }
 }
 
@@ -942,6 +982,7 @@ void AppLayerSetupCounters()
     AppProto alproto;
     AppProto alprotos[ALPROTO_MAX];
     const char *str = "app_layer.flow.";
+    const char *estr = "app_layer.error.";
 
     AppLayerProtoDetectSupportedAppProtocols(alprotos);
 
@@ -964,6 +1005,21 @@ void AppLayerSetupCounters()
                     snprintf(applayer_counter_names[ipproto_map][alproto].tx_name,
                             sizeof(applayer_counter_names[ipproto_map][alproto].tx_name),
                             "%s%s%s", tx_str, alproto_str, ipproto_suffix);
+
+                    if (ipproto == IPPROTO_TCP) {
+                        snprintf(applayer_counter_names[ipproto_map][alproto].gap_error,
+                                sizeof(applayer_counter_names[ipproto_map][alproto].gap_error),
+                                "%s%s%s.gap", estr, alproto_str, ipproto_suffix);
+                    }
+                    snprintf(applayer_counter_names[ipproto_map][alproto].alloc_error,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].alloc_error),
+                            "%s%s%s.alloc", estr, alproto_str, ipproto_suffix);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].parser_error,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].parser_error),
+                            "%s%s%s.parser", estr, alproto_str, ipproto_suffix);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].internal_error,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].internal_error),
+                            "%s%s%s.internal", estr, alproto_str, ipproto_suffix);
                 } else {
                     snprintf(applayer_counter_names[ipproto_map][alproto].name,
                             sizeof(applayer_counter_names[ipproto_map][alproto].name),
@@ -971,11 +1027,31 @@ void AppLayerSetupCounters()
                     snprintf(applayer_counter_names[ipproto_map][alproto].tx_name,
                             sizeof(applayer_counter_names[ipproto_map][alproto].tx_name),
                             "%s%s", tx_str, alproto_str);
+
+                    if (ipproto == IPPROTO_TCP) {
+                        snprintf(applayer_counter_names[ipproto_map][alproto].gap_error,
+                                sizeof(applayer_counter_names[ipproto_map][alproto].gap_error),
+                                "%s%s.gap", estr, alproto_str);
+                    }
+                    snprintf(applayer_counter_names[ipproto_map][alproto].alloc_error,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].alloc_error),
+                            "%s%s.alloc", estr, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].parser_error,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].parser_error),
+                            "%s%s.parser", estr, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].internal_error,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].internal_error),
+                            "%s%s.internal", estr, alproto_str);
                 }
             } else if (alproto == ALPROTO_FAILED) {
                 snprintf(applayer_counter_names[ipproto_map][alproto].name,
                         sizeof(applayer_counter_names[ipproto_map][alproto].name),
                         "%s%s%s", str, "failed", ipproto_suffix);
+                if (ipproto == IPPROTO_TCP) {
+                    snprintf(applayer_counter_names[ipproto_map][alproto].gap_error,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].gap_error),
+                            "%sfailed%s.gap", estr, ipproto_suffix);
+                }
             }
         }
     }
@@ -1000,9 +1076,25 @@ void AppLayerRegisterThreadCounters(ThreadVars *tv)
 
                 applayer_counters[ipproto_map][alproto].counter_tx_id =
                     StatsRegisterCounter(applayer_counter_names[ipproto_map][alproto].tx_name, tv);
+
+                if (ipproto == IPPROTO_TCP) {
+                    applayer_counters[ipproto_map][alproto].gap_error_id = StatsRegisterCounter(
+                            applayer_counter_names[ipproto_map][alproto].gap_error, tv);
+                }
+                applayer_counters[ipproto_map][alproto].alloc_error_id = StatsRegisterCounter(
+                        applayer_counter_names[ipproto_map][alproto].alloc_error, tv);
+                applayer_counters[ipproto_map][alproto].parser_error_id = StatsRegisterCounter(
+                        applayer_counter_names[ipproto_map][alproto].parser_error, tv);
+                applayer_counters[ipproto_map][alproto].internal_error_id = StatsRegisterCounter(
+                        applayer_counter_names[ipproto_map][alproto].internal_error, tv);
             } else if (alproto == ALPROTO_FAILED) {
                 applayer_counters[ipproto_map][alproto].counter_id =
                     StatsRegisterCounter(applayer_counter_names[ipproto_map][alproto].name, tv);
+
+                if (ipproto == IPPROTO_TCP) {
+                    applayer_counters[ipproto_map][alproto].gap_error_id = StatsRegisterCounter(
+                            applayer_counter_names[ipproto_map][alproto].gap_error, tv);
+                }
             }
         }
     }

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -146,6 +146,10 @@ void AppLayerUnittestsRegister(void);
 #endif
 
 void AppLayerIncTxCounter(ThreadVars *tv, Flow *f, uint64_t step);
+void AppLayerIncGapErrorCounter(ThreadVars *tv, Flow *f);
+void AppLayerIncAllocErrorCounter(ThreadVars *tv, Flow *f);
+void AppLayerIncParserErrorCounter(ThreadVars *tv, Flow *f);
+void AppLayerIncInternalErrorCounter(ThreadVars *tv, Flow *f);
 
 static inline uint8_t StreamSliceGetFlags(const StreamSlice *stream_slice)
 {

--- a/src/counters.c
+++ b/src/counters.c
@@ -182,6 +182,27 @@ void StatsIncr(ThreadVars *tv, uint16_t id)
 }
 
 /**
+ * \brief Decrements the local counter
+ *
+ * \param id  Index of the counter in the counter array
+ * \param pca Counter array that holds the local counters for this TM
+ */
+void StatsDecr(ThreadVars *tv, uint16_t id)
+{
+    StatsPrivateThreadContext *pca = &tv->perf_private_ctx;
+#if defined (UNITTESTS) || defined (FUZZ)
+    if (pca->initialized == 0)
+        return;
+#endif
+#ifdef DEBUG
+    BUG_ON ((id < 1) || (id > pca->size));
+#endif
+    pca->head[id].value--;
+    pca->head[id].updates++;
+    return;
+}
+
+/**
  * \brief Sets a value of type double to the local counter
  *
  * \param id  Index of the local counter in the counter array
@@ -200,7 +221,7 @@ void StatsSetUI64(ThreadVars *tv, uint16_t id, uint64_t x)
 #endif
 
     if ((pca->head[id].pc->type == STATS_TYPE_MAXIMUM) &&
-            (x > pca->head[id].value)) {
+            ((int64_t)x > pca->head[id].value)) {
         pca->head[id].value = x;
     } else if (pca->head[id].pc->type == STATS_TYPE_NORMAL) {
         pca->head[id].value = x;
@@ -672,7 +693,7 @@ static int StatsOutput(ThreadVars *tv)
      *  especially needed for the average counters */
     struct CountersMergeTable {
         int type;
-        uint64_t value;
+        int64_t value;
         uint64_t updates;
     } merge_table[max_id];
     memset(&merge_table, 0x00,

--- a/src/counters.h
+++ b/src/counters.h
@@ -41,7 +41,7 @@ typedef struct StatsCounter_ {
     uint16_t gid;
 
     /* counter value(s): copies from the 'private' counter */
-    uint64_t value;     /**< sum of updates/increments, or 'set' value */
+    int64_t value;      /**< sum of updates/increments, or 'set' value */
     uint64_t updates;   /**< number of updates (for avg) */
 
     /* when using type STATS_TYPE_Q_FUNC this function is called once
@@ -84,7 +84,7 @@ typedef struct StatsLocalCounter_ {
     uint16_t id;
 
     /* total value of the adds/increments, or exact value in case of 'set' */
-    uint64_t value;
+    int64_t value;
 
     /* no of times the local counter has been updated */
     uint64_t updates;
@@ -124,6 +124,7 @@ uint16_t StatsRegisterGlobalCounter(const char *cname, uint64_t (*Func)(void));
 void StatsAddUI64(struct ThreadVars_ *, uint16_t, uint64_t);
 void StatsSetUI64(struct ThreadVars_ *, uint16_t, uint64_t);
 void StatsIncr(struct ThreadVars_ *, uint16_t);
+void StatsDecr(struct ThreadVars_ *, uint16_t);
 
 /* utility functions */
 int StatsUpdateCounterArray(StatsPrivateThreadContext *, StatsPublicThreadContext *);

--- a/src/decode.c
+++ b/src/decode.c
@@ -532,6 +532,9 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_nsh = StatsRegisterMaxCounter("decoder.nsh", tv);
     dtv->counter_flow_memcap = StatsRegisterCounter("flow.memcap", tv);
 
+    dtv->counter_tcp_active_sessions = StatsRegisterCounter("tcp.active_sessions", tv);
+    dtv->counter_flow_total = StatsRegisterCounter("flow.total", tv);
+    dtv->counter_flow_active = StatsRegisterCounter("flow.active", tv);
     dtv->counter_flow_tcp = StatsRegisterCounter("flow.tcp", tv);
     dtv->counter_flow_udp = StatsRegisterCounter("flow.udp", tv);
     dtv->counter_flow_icmp4 = StatsRegisterCounter("flow.icmpv4", tv);

--- a/src/decode.h
+++ b/src/decode.h
@@ -699,6 +699,9 @@ typedef struct DecodeThreadVars_
 
     uint16_t counter_flow_memcap;
 
+    uint16_t counter_tcp_active_sessions;
+    uint16_t counter_flow_total;
+    uint16_t counter_flow_active;
     uint16_t counter_flow_tcp;
     uint16_t counter_flow_udp;
     uint16_t counter_flow_icmp4;

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -485,6 +485,8 @@ static inline void FlowUpdateCounter(ThreadVars *tv, DecodeThreadVars *dtv,
 #ifdef UNITTESTS
     if (tv && dtv) {
 #endif
+        StatsIncr(tv, dtv->counter_flow_total);
+        StatsIncr(tv, dtv->counter_flow_active);
         switch (proto){
             case IPPROTO_UDP:
                 StatsIncr(tv, dtv->counter_flow_udp);

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -580,6 +580,7 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, const Packet *p)
             if (!(SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY)) {
                 SC_ATOMIC_OR(flow_flags, FLOW_EMERGENCY);
                 FlowTimeoutsEmergency();
+                FlowWakeupFlowManagerThread();
             }
 
             f = FlowGetUsedFlow(tv, fls->dtv, &p->ts);

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -597,8 +597,6 @@ typedef struct FlowQueueTimeoutCounters {
     uint32_t flows_timeout;
 } FlowQueueTimeoutCounters;
 
-extern int g_detect_disabled;
-
 typedef struct FlowCounters_ {
     uint16_t flow_mgr_full_pass;
     uint16_t flow_mgr_cnt_clo;

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -678,6 +678,31 @@ static void FlowCountersInit(ThreadVars *t, FlowCounters *fc)
     fc->memcap_pressure_max = StatsRegisterMaxCounter("memcap_pressure_max", t);
 }
 
+static void FlowCountersUpdate(
+        ThreadVars *th_v, const FlowManagerThreadData *ftd, const FlowTimeoutCounters *counters)
+{
+    StatsAddUI64(th_v, ftd->cnt.flow_mgr_cnt_clo, (uint64_t)counters->clo);
+    StatsAddUI64(th_v, ftd->cnt.flow_mgr_cnt_new, (uint64_t)counters->new);
+    StatsAddUI64(th_v, ftd->cnt.flow_mgr_cnt_est, (uint64_t)counters->est);
+    StatsAddUI64(th_v, ftd->cnt.flow_mgr_cnt_byp, (uint64_t)counters->byp);
+
+    StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_checked, (uint64_t)counters->flows_checked);
+    StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_notimeout, (uint64_t)counters->flows_notimeout);
+
+    StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_timeout, (uint64_t)counters->flows_timeout);
+    StatsAddUI64(
+            th_v, ftd->cnt.flow_mgr_flows_timeout_inuse, (uint64_t)counters->flows_timeout_inuse);
+    StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_aside, (uint64_t)counters->flows_aside);
+    StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_aside_needs_work,
+            (uint64_t)counters->flows_aside_needs_work);
+
+    StatsAddUI64(th_v, ftd->cnt.flow_bypassed_cnt_clo, (uint64_t)counters->bypassed_count);
+    StatsAddUI64(th_v, ftd->cnt.flow_bypassed_pkts, (uint64_t)counters->bypassed_pkts);
+    StatsAddUI64(th_v, ftd->cnt.flow_bypassed_bytes, (uint64_t)counters->bypassed_bytes);
+
+    StatsSetUI64(th_v, ftd->cnt.flow_mgr_rows_maxlen, (uint64_t)counters->rows_maxlen);
+}
+
 static TmEcode FlowManagerThreadInit(ThreadVars *t, const void *initdata, void **data)
 {
     FlowManagerThreadData *ftd = SCCalloc(1, sizeof(FlowManagerThreadData));
@@ -869,24 +894,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
             const uint32_t spare_pool_len = FlowSpareGetPoolSize();
             StatsSetUI64(th_v, ftd->cnt.flow_mgr_spare, (uint64_t)spare_pool_len);
 
-            StatsAddUI64(th_v, ftd->cnt.flow_mgr_cnt_clo, (uint64_t)counters.clo);
-            StatsAddUI64(th_v, ftd->cnt.flow_mgr_cnt_new, (uint64_t)counters.new);
-            StatsAddUI64(th_v, ftd->cnt.flow_mgr_cnt_est, (uint64_t)counters.est);
-            StatsAddUI64(th_v, ftd->cnt.flow_mgr_cnt_byp, (uint64_t)counters.byp);
-
-            StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_checked, (uint64_t)counters.flows_checked);
-            StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_notimeout, (uint64_t)counters.flows_notimeout);
-
-            StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_timeout, (uint64_t)counters.flows_timeout);
-            StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_timeout_inuse, (uint64_t)counters.flows_timeout_inuse);
-            StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_aside, (uint64_t)counters.flows_aside);
-            StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_aside_needs_work, (uint64_t)counters.flows_aside_needs_work);
-
-            StatsAddUI64(th_v, ftd->cnt.flow_bypassed_cnt_clo, (uint64_t)counters.bypassed_count);
-            StatsAddUI64(th_v, ftd->cnt.flow_bypassed_pkts, (uint64_t)counters.bypassed_pkts);
-            StatsAddUI64(th_v, ftd->cnt.flow_bypassed_bytes, (uint64_t)counters.bypassed_bytes);
-
-            StatsSetUI64(th_v, ftd->cnt.flow_mgr_rows_maxlen, (uint64_t)counters.rows_maxlen);
+            FlowCountersUpdate(th_v, ftd, &counters);
 
             if (emerg == true) {
                 SCLogDebug("flow_sparse_q.len = %" PRIu32 " prealloc: %" PRIu32

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -782,30 +782,30 @@ static void GetWorkUnitSizing(const uint32_t pass_in_sec, const uint32_t rows, c
 static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
 {
     FlowManagerThreadData *ftd = thread_data;
-    struct timeval ts;
+    const uint32_t rows = ftd->max - ftd->min;
+    const uint32_t min_timeout = FlowTimeoutsMin();
+    const uint32_t pass_in_sec = min_timeout ? min_timeout * 8 : 60;
+    const bool time_is_live = TimeModeIsLive();
+
+    uint32_t emerg_over_cnt = 0;
+    uint64_t next_run_ms = 0;
+    uint32_t pos = 0;
+    uint32_t rows_per_wu = 0;
+    uint64_t sleep_per_wu = 0;
     bool emerg = false;
     bool prev_emerg = false;
     uint32_t other_last_sec = 0; /**< last sec stamp when defrag etc ran */
+    struct timeval ts;
     memset(&ts, 0, sizeof(ts));
-    const uint32_t min_timeout = FlowTimeoutsMin();
-    const uint32_t pass_in_sec = min_timeout ? min_timeout * 8 : 60;
 
     /* don't start our activities until time is setup */
     while (!TimeModeIsReady()) {
         if (suricata_ctl_flags != 0)
             return TM_ECODE_OK;
     }
-    const bool time_is_live = TimeModeIsLive();
 
     SCLogDebug("FM %s/%d starting. min_timeout %us. Full hash pass in %us", th_v->name,
             ftd->instance, min_timeout, pass_in_sec);
-
-    uint32_t emerg_over_cnt = 0;
-    uint64_t next_run_ms = 0;
-    const uint32_t rows = ftd->max - ftd->min;
-    uint32_t pos = 0;
-    uint32_t rows_per_wu = 0;
-    uint64_t sleep_per_wu = 0;
 
     uint32_t mp = MemcapsGetPressure() * 100;
     if (ftd->instance == 0) {
@@ -866,6 +866,9 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
                 }
             }
 
+            const uint32_t spare_pool_len = FlowSpareGetPoolSize();
+            StatsSetUI64(th_v, ftd->cnt.flow_mgr_spare, (uint64_t)spare_pool_len);
+
             StatsAddUI64(th_v, ftd->cnt.flow_mgr_cnt_clo, (uint64_t)counters.clo);
             StatsAddUI64(th_v, ftd->cnt.flow_mgr_cnt_new, (uint64_t)counters.new);
             StatsAddUI64(th_v, ftd->cnt.flow_mgr_cnt_est, (uint64_t)counters.est);
@@ -885,17 +888,15 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
 
             StatsSetUI64(th_v, ftd->cnt.flow_mgr_rows_maxlen, (uint64_t)counters.rows_maxlen);
 
-            uint32_t len = FlowSpareGetPoolSize();
-            StatsSetUI64(th_v, ftd->cnt.flow_mgr_spare, (uint64_t)len);
-
             if (emerg == true) {
-                SCLogDebug("flow_sparse_q.len = %"PRIu32" prealloc: %"PRIu32
-                        "flow_spare_q status: %"PRIu32"%% flows at the queue",
-                        len, flow_config.prealloc, len * 100 / flow_config.prealloc);
+                SCLogDebug("flow_sparse_q.len = %" PRIu32 " prealloc: %" PRIu32
+                           "flow_spare_q status: %" PRIu32 "%% flows at the queue",
+                        spare_pool_len, flow_config.prealloc,
+                        spare_pool_len * 100 / flow_config.prealloc);
 
                 /* only if we have pruned this "emergency_recovery" percentage
                  * of flows, we will unset the emergency bit */
-                if (len * 100 / flow_config.prealloc > flow_config.emergency_recovery) {
+                if (spare_pool_len * 100 / flow_config.prealloc > flow_config.emergency_recovery) {
                     emerg_over_cnt++;
                 } else {
                     emerg_over_cnt = 0;
@@ -913,7 +914,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
                                 "ts.tv_usec:%" PRIuMAX ") flow_spare_q status(): %" PRIu32
                                 "%% flows at the queue",
                             (uintmax_t)ts.tv_sec, (uintmax_t)ts.tv_usec,
-                            len * 100 / flow_config.prealloc);
+                            spare_pool_len * 100 / flow_config.prealloc);
 
                     StatsIncr(th_v, ftd->cnt.flow_emerg_mode_over);
                 }

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -93,6 +93,8 @@ SC_ATOMIC_EXTERN(unsigned int, flow_flags);
 
 SCCtrlCondT flow_manager_ctrl_cond;
 SCCtrlMutex flow_manager_ctrl_mutex;
+SCCtrlCondT flow_recycler_ctrl_cond;
+SCCtrlMutex flow_recycler_ctrl_mutex;
 
 void FlowTimeoutsInit(void)
 {
@@ -305,11 +307,13 @@ static uint32_t ProcessAsideQueue(FlowManagerTimeoutThread *td, FlowTimeoutCount
         FlowQueuePrivateAppendFlow(&recycle, f);
         if (recycle.len == 100) {
             FlowQueueAppendPrivate(&flow_recycle_q, &recycle);
+            FlowWakeupFlowRecyclerThread();
         }
         cnt++;
     }
     if (recycle.len) {
         FlowQueueAppendPrivate(&flow_recycle_q, &recycle);
+        FlowWakeupFlowRecyclerThread();
     }
     return cnt;
 }
@@ -591,9 +595,11 @@ static uint32_t FlowCleanupHash(void)
         FBLOCK_UNLOCK(fb);
         if (local_queue.len >= 25) {
             FlowQueueAppendPrivate(&flow_recycle_q, &local_queue);
+            FlowWakeupFlowRecyclerThread();
         }
     }
     FlowQueueAppendPrivate(&flow_recycle_q, &local_queue);
+    FlowWakeupFlowRecyclerThread();
 
     return cnt;
 }
@@ -1058,6 +1064,7 @@ static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
 {
     FlowRecyclerThreadData *ftd = (FlowRecyclerThreadData *)thread_data;
     BUG_ON(ftd == NULL);
+    const bool time_is_live = TimeModeIsLive();
     uint64_t recycled_cnt = 0;
     struct timeval ts;
     memset(&ts, 0, sizeof(ts));
@@ -1090,7 +1097,30 @@ static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
             break;
         }
 
-        usleep(250);
+        const bool emerg = (SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY);
+        if (emerg || !time_is_live) {
+            usleep(250);
+        } else {
+            struct timeval cond_tv;
+            gettimeofday(&cond_tv, NULL);
+            cond_tv.tv_sec += 1;
+            struct timespec cond_time = FROM_TIMEVAL(cond_tv);
+            SCCtrlMutexLock(&flow_recycler_ctrl_mutex);
+            while (1) {
+                int rc = SCCtrlCondTimedwait(
+                        &flow_recycler_ctrl_cond, &flow_recycler_ctrl_mutex, &cond_time);
+                if (rc == ETIMEDOUT || rc < 0) {
+                    break;
+                }
+                if (SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY) {
+                    break;
+                }
+                if (SC_ATOMIC_GET(flow_recycle_q.non_empty) == true) {
+                    break;
+                }
+            }
+            SCCtrlMutexUnlock(&flow_recycler_ctrl_mutex);
+        }
 
         SCLogDebug("woke up...");
 
@@ -1125,6 +1155,9 @@ void FlowRecyclerThreadSpawn()
                 "invalid flow.recyclers setting %"PRIdMAX, setting);
     }
     flowrec_number = (uint32_t)setting;
+
+    SCCtrlCondInit(&flow_recycler_ctrl_cond, NULL);
+    SCCtrlMutexInit(&flow_recycler_ctrl_mutex, NULL);
 
     SCLogConfig("using %u flow recycler threads", flowrec_number);
 
@@ -1167,6 +1200,7 @@ void FlowDisableFlowRecyclerThread(void)
 
     /* make sure all flows are processed */
     do {
+        FlowWakeupFlowRecyclerThread();
         usleep(10);
     } while (FlowRecyclerReadyToShutdown() == false);
 
@@ -1200,6 +1234,7 @@ again:
         {
             if (!TmThreadsCheckFlag(tv, THV_RUNNING_DONE)) {
                 SCMutexUnlock(&tv_root_lock);
+                FlowWakeupFlowRecyclerThread();
                 /* sleep outside lock */
                 SleepMsec(1);
                 goto again;

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -737,8 +737,6 @@ static uint32_t FlowTimeoutsMin(void)
     return m;
 }
 
-//#define FM_PROFILE
-
 static void GetWorkUnitSizing(const uint32_t pass_in_sec, const uint32_t rows, const uint32_t mp,
         const bool emergency, uint64_t *wu_sleep, uint32_t *wu_rows)
 {
@@ -785,18 +783,10 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
 {
     FlowManagerThreadData *ftd = thread_data;
     struct timeval ts;
-    uint32_t established_cnt = 0, new_cnt = 0, closing_cnt = 0;
     bool emerg = false;
     bool prev_emerg = false;
     uint32_t other_last_sec = 0; /**< last sec stamp when defrag etc ran */
-/* VJ leaving disabled for now, as hosts are only used by tags and the numbers
- * are really low. Might confuse ppl
-    uint16_t flow_mgr_host_prune = StatsRegisterCounter("hosts.pruned", th_v);
-    uint16_t flow_mgr_host_active = StatsRegisterCounter("hosts.active", th_v);
-    uint16_t flow_mgr_host_spare = StatsRegisterCounter("hosts.spare", th_v);
-*/
     memset(&ts, 0, sizeof(ts));
-
     const uint32_t min_timeout = FlowTimeoutsMin();
     const uint32_t pass_in_sec = min_timeout ? min_timeout * 8 : 60;
 
@@ -809,21 +799,6 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
 
     SCLogDebug("FM %s/%d starting. min_timeout %us. Full hash pass in %us", th_v->name,
             ftd->instance, min_timeout, pass_in_sec);
-
-#ifdef FM_PROFILE
-    struct timeval endts;
-    struct timeval active;
-    struct timeval paused;
-    struct timeval sleeping;
-    memset(&endts, 0, sizeof(endts));
-    memset(&active, 0, sizeof(active));
-    memset(&paused, 0, sizeof(paused));
-    memset(&sleeping, 0, sizeof(sleeping));
-#endif
-
-    struct timeval startts;
-    memset(&startts, 0, sizeof(startts));
-    gettimeofday(&startts, NULL);
 
     uint32_t emerg_over_cnt = 0;
     uint64_t next_run_ms = 0;
@@ -843,32 +818,13 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
     {
         if (TmThreadsCheckFlag(th_v, THV_PAUSE)) {
             TmThreadsSetFlag(th_v, THV_PAUSED);
-#ifdef FM_PROFILE
-            struct timeval pause_startts;
-            memset(&pause_startts, 0, sizeof(pause_startts));
-            gettimeofday(&pause_startts, NULL);
-#endif
             TmThreadTestThreadUnPaused(th_v);
-#ifdef FM_PROFILE
-            struct timeval pause_endts;
-            memset(&pause_endts, 0, sizeof(pause_endts));
-            gettimeofday(&pause_endts, NULL);
-            struct timeval pause_time;
-            memset(&pause_time, 0, sizeof(pause_time));
-            timersub(&pause_endts, &pause_startts, &pause_time);
-            timeradd(&paused, &pause_time, &paused);
-#endif
             TmThreadsUnsetFlag(th_v, THV_PAUSED);
         }
 
         if (SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY) {
             emerg = true;
         }
-#ifdef FM_PROFILE
-        struct timeval run_startts;
-        memset(&run_startts, 0, sizeof(run_startts));
-        gettimeofday(&run_startts, NULL);
-#endif
         /* Get the time */
         memset(&ts, 0, sizeof(ts));
         TimeGet(&ts);
@@ -910,13 +866,6 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
                 }
             }
 
-            /*
-               StatsAddUI64(th_v, flow_mgr_host_prune, (uint64_t)hosts_pruned);
-               uint32_t hosts_active = HostGetActiveCount();
-               StatsSetUI64(th_v, flow_mgr_host_active, (uint64_t)hosts_active);
-               uint32_t hosts_spare = HostGetSpareCount();
-               StatsSetUI64(th_v, flow_mgr_host_spare, (uint64_t)hosts_spare);
-             */
             StatsAddUI64(th_v, ftd->cnt.flow_mgr_cnt_clo, (uint64_t)counters.clo);
             StatsAddUI64(th_v, ftd->cnt.flow_mgr_cnt_new, (uint64_t)counters.new);
             StatsAddUI64(th_v, ftd->cnt.flow_mgr_cnt_est, (uint64_t)counters.est);
@@ -926,7 +875,6 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
             StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_notimeout, (uint64_t)counters.flows_notimeout);
 
             StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_timeout, (uint64_t)counters.flows_timeout);
-            //StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_removed, (uint64_t)counters.flows_removed);
             StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_timeout_inuse, (uint64_t)counters.flows_timeout_inuse);
             StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_aside, (uint64_t)counters.flows_aside);
             StatsAddUI64(th_v, ftd->cnt.flow_mgr_flows_aside_needs_work, (uint64_t)counters.flows_aside_needs_work);
@@ -936,10 +884,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
             StatsAddUI64(th_v, ftd->cnt.flow_bypassed_bytes, (uint64_t)counters.bypassed_bytes);
 
             StatsSetUI64(th_v, ftd->cnt.flow_mgr_rows_maxlen, (uint64_t)counters.rows_maxlen);
-            // TODO AVG MAXLEN
-            // TODO LOOKUP STEPS MAXLEN and AVG LEN
-            /* Don't fear, FlowManagerThread is here...
-             * clear emergency bit if we have at least xx flows pruned. */
+
             uint32_t len = FlowSpareGetPoolSize();
             StatsSetUI64(th_v, ftd->cnt.flow_mgr_spare, (uint64_t)len);
 
@@ -987,7 +932,6 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         if (other_last_sec == 0 || other_last_sec < (uint32_t)ts.tv_sec) {
             if (ftd->instance == 0) {
                 DefragTimeoutHash(&ts);
-                // uint32_t hosts_pruned =
                 HostTimeoutHash(&ts);
                 IPPairTimeoutHash(&ts);
                 HttpRangeContainersTimeoutHash(&ts);
@@ -995,26 +939,10 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
             }
         }
 
-#ifdef FM_PROFILE
-        struct timeval run_endts;
-        memset(&run_endts, 0, sizeof(run_endts));
-        gettimeofday(&run_endts, NULL);
-        struct timeval run_time;
-        memset(&run_time, 0, sizeof(run_time));
-        timersub(&run_endts, &run_startts, &run_time);
-        timeradd(&active, &run_time, &active);
-#endif
-
         if (TmThreadsCheckFlag(th_v, THV_KILL)) {
             StatsSyncCounters(th_v);
             break;
         }
-
-#ifdef FM_PROFILE
-        struct timeval sleep_startts;
-        memset(&sleep_startts, 0, sizeof(sleep_startts));
-        gettimeofday(&sleep_startts, NULL);
-#endif
 
         if (emerg || !time_is_live) {
             usleep(250);
@@ -1040,35 +968,10 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
             SCCtrlMutexUnlock(&flow_manager_ctrl_mutex);
         }
 
-#ifdef FM_PROFILE
-        struct timeval sleep_endts;
-        memset(&sleep_endts, 0, sizeof(sleep_endts));
-        gettimeofday(&sleep_endts, NULL);
-
-        struct timeval sleep_time;
-        memset(&sleep_time, 0, sizeof(sleep_time));
-        timersub(&sleep_endts, &sleep_startts, &sleep_time);
-        timeradd(&sleeping, &sleep_time, &sleeping);
-#endif
         SCLogDebug("woke up... %s", SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY ? "emergency":"");
 
         StatsSyncCountersIfSignalled(th_v);
     }
-    SCLogPerf("%" PRIu32 " new flows, %" PRIu32 " established flows were "
-              "timed out, %"PRIu32" flows in closed state", new_cnt,
-              established_cnt, closing_cnt);
-
-#ifdef FM_PROFILE
-    gettimeofday(&endts, NULL);
-    struct timeval total_run_time;
-    timersub(&endts, &startts, &total_run_time);
-
-    SCLogNotice("FM: active %u.%us out of %u.%us; sleeping %u.%us, paused %u.%us",
-            (uint32_t)active.tv_sec, (uint32_t)active.tv_usec,
-            (uint32_t)total_run_time.tv_sec, (uint32_t)total_run_time.tv_usec,
-            (uint32_t)sleeping.tv_sec, (uint32_t)sleeping.tv_usec,
-            (uint32_t)paused.tv_sec, (uint32_t)paused.tv_usec);
-#endif
     return TM_ECODE_OK;
 }
 
@@ -1152,49 +1055,14 @@ static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
     memset(&ts, 0, sizeof(ts));
     uint32_t fr_passes = 0;
 
-#ifdef FM_PROFILE
-    struct timeval endts;
-    struct timeval active;
-    struct timeval paused;
-    struct timeval sleeping;
-    memset(&endts, 0, sizeof(endts));
-    memset(&active, 0, sizeof(active));
-    memset(&paused, 0, sizeof(paused));
-    memset(&sleeping, 0, sizeof(sleeping));
-#endif
-    struct timeval startts;
-    memset(&startts, 0, sizeof(startts));
-    gettimeofday(&startts, NULL);
-
     while (1)
     {
         if (TmThreadsCheckFlag(th_v, THV_PAUSE)) {
             TmThreadsSetFlag(th_v, THV_PAUSED);
-#ifdef FM_PROFILE
-            struct timeval pause_startts;
-            memset(&pause_startts, 0, sizeof(pause_startts));
-            gettimeofday(&pause_startts, NULL);
-#endif
             TmThreadTestThreadUnPaused(th_v);
-
-#ifdef FM_PROFILE
-            struct timeval pause_endts;
-            memset(&pause_endts, 0, sizeof(pause_endts));
-            gettimeofday(&pause_endts, NULL);
-
-            struct timeval pause_time;
-            memset(&pause_time, 0, sizeof(pause_time));
-            timersub(&pause_endts, &pause_startts, &pause_time);
-            timeradd(&paused, &pause_time, &paused);
-#endif
             TmThreadsUnsetFlag(th_v, THV_PAUSED);
         }
         fr_passes++;
-#ifdef FM_PROFILE
-        struct timeval run_startts;
-        memset(&run_startts, 0, sizeof(run_startts));
-        gettimeofday(&run_startts, NULL);
-#endif
         SC_ATOMIC_ADD(flowrec_busy,1);
         FlowQueuePrivate list = FlowQueueExtractPrivate(&flow_recycle_q);
 
@@ -1212,55 +1080,17 @@ static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
         }
         SC_ATOMIC_SUB(flowrec_busy,1);
 
-#ifdef FM_PROFILE
-        struct timeval run_endts;
-        memset(&run_endts, 0, sizeof(run_endts));
-        gettimeofday(&run_endts, NULL);
-
-        struct timeval run_time;
-        memset(&run_time, 0, sizeof(run_time));
-        timersub(&run_endts, &run_startts, &run_time);
-        timeradd(&active, &run_time, &active);
-#endif
-
         if (bail) {
             break;
         }
 
-#ifdef FM_PROFILE
-        struct timeval sleep_startts;
-        memset(&sleep_startts, 0, sizeof(sleep_startts));
-        gettimeofday(&sleep_startts, NULL);
-#endif
         usleep(250);
-#ifdef FM_PROFILE
-        struct timeval sleep_endts;
-        memset(&sleep_endts, 0, sizeof(sleep_endts));
-        gettimeofday(&sleep_endts, NULL);
-        struct timeval sleep_time;
-        memset(&sleep_time, 0, sizeof(sleep_time));
-        timersub(&sleep_endts, &sleep_startts, &sleep_time);
-        timeradd(&sleeping, &sleep_time, &sleeping);
-#endif
 
         SCLogDebug("woke up...");
 
         StatsSyncCountersIfSignalled(th_v);
     }
     StatsSyncCounters(th_v);
-#ifdef FM_PROFILE
-    gettimeofday(&endts, NULL);
-    struct timeval total_run_time;
-    timersub(&endts, &startts, &total_run_time);
-    SCLogNotice("FR: active %u.%us out of %u.%us; sleeping %u.%us, paused %u.%us",
-            (uint32_t)active.tv_sec, (uint32_t)active.tv_usec,
-            (uint32_t)total_run_time.tv_sec, (uint32_t)total_run_time.tv_usec,
-            (uint32_t)sleeping.tv_sec, (uint32_t)sleeping.tv_usec,
-            (uint32_t)paused.tv_sec, (uint32_t)paused.tv_usec);
-
-    SCLogNotice("FR passes %u passes/s %u", fr_passes,
-            (uint32_t)fr_passes/((uint32_t)active.tv_sec?(uint32_t)active.tv_sec:1));
-#endif
     SCLogPerf("%"PRIu64" flows processed", recycled_cnt);
     return TM_ECODE_OK;
 }

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -1056,13 +1056,11 @@ static TmEcode FlowRecyclerThreadDeinit(ThreadVars *t, void *data)
  */
 static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
 {
-    struct timeval ts;
-    uint64_t recycled_cnt = 0;
     FlowRecyclerThreadData *ftd = (FlowRecyclerThreadData *)thread_data;
     BUG_ON(ftd == NULL);
-
+    uint64_t recycled_cnt = 0;
+    struct timeval ts;
     memset(&ts, 0, sizeof(ts));
-    uint32_t fr_passes = 0;
 
     while (1)
     {
@@ -1071,7 +1069,6 @@ static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
             TmThreadTestThreadUnPaused(th_v);
             TmThreadsUnsetFlag(th_v, THV_PAUSED);
         }
-        fr_passes++;
         SC_ATOMIC_ADD(flowrec_busy,1);
         FlowQueuePrivate list = FlowQueueExtractPrivate(&flow_recycle_q);
 

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -622,6 +622,8 @@ typedef struct FlowQueueTimeoutCounters {
 
 typedef struct FlowCounters_ {
     uint16_t flow_mgr_full_pass;
+    uint16_t flow_mgr_rows_sec;
+
     uint16_t flow_mgr_cnt_clo;
     uint16_t flow_mgr_cnt_new;
     uint16_t flow_mgr_cnt_est;
@@ -660,6 +662,8 @@ typedef struct FlowManagerThreadData_ {
 static void FlowCountersInit(ThreadVars *t, FlowCounters *fc)
 {
     fc->flow_mgr_full_pass = StatsRegisterCounter("flow.mgr.full_hash_pass", t);
+    fc->flow_mgr_rows_sec = StatsRegisterCounter("flow.mgr.rows_per_sec", t);
+
     fc->flow_mgr_cnt_clo = StatsRegisterCounter("flow.mgr.closed_pruned", t);
     fc->flow_mgr_cnt_new = StatsRegisterCounter("flow.mgr.new_pruned", t);
     fc->flow_mgr_cnt_est = StatsRegisterCounter("flow.mgr.est_pruned", t);
@@ -769,7 +773,7 @@ static uint32_t FlowTimeoutsMin(void)
 }
 
 static void GetWorkUnitSizing(const uint32_t pass_in_sec, const uint32_t rows, const uint32_t mp,
-        const bool emergency, uint64_t *wu_sleep, uint32_t *wu_rows)
+        const bool emergency, uint64_t *wu_sleep, uint32_t *wu_rows, uint32_t *rows_sec)
 {
     if (emergency) {
         *wu_rows = rows;
@@ -778,30 +782,26 @@ static void GetWorkUnitSizing(const uint32_t pass_in_sec, const uint32_t rows, c
     }
 
     uint32_t full_pass_in_ms = pass_in_sec * 1000;
-    float perc = MIN((((float)(100 - mp) / (float)100)), 1);
+    const float perc = MIN((((float)(100 - mp) / (float)100)), 1.0);
     full_pass_in_ms *= perc;
     full_pass_in_ms = MAX(full_pass_in_ms, 333);
 
     uint32_t work_unit_ms = 999 * perc;
     work_unit_ms = MAX(work_unit_ms, 250);
 
-    uint32_t wus_per_full_pass = full_pass_in_ms / work_unit_ms;
+    const uint32_t wus_per_full_pass = full_pass_in_ms / work_unit_ms;
 
-    uint32_t rows_per_wu = MAX(1, rows / wus_per_full_pass);
-    uint32_t rows_process_cost = rows_per_wu / 1000; // est 1usec per row
+    const uint32_t rows_per_wu = MAX(1, rows / wus_per_full_pass);
+    const uint32_t rows_process_cost = rows_per_wu / 1000; // est 1usec per row
 
     int32_t sleep_per_wu = work_unit_ms - rows_process_cost;
     sleep_per_wu = MAX(sleep_per_wu, 10);
-#if 0
-    float passes_sec = 1000.0/(float)full_pass_in_ms;
-    SCLogNotice("full_pass_in_ms %u perc %f rows %u "
-            "wus_per_full_pass %u rows_per_wu %u work_unit_ms %u sleep_per_wu %u => passes/s %f rows/s %u",
-            full_pass_in_ms, perc, rows,
-            wus_per_full_pass, rows_per_wu, work_unit_ms, (uint32_t)sleep_per_wu,
-            passes_sec, (uint32_t)((float)rows * passes_sec));
-#endif
+
+    const float passes_sec = 1000.0 / (float)full_pass_in_ms;
+
     *wu_sleep = sleep_per_wu;
     *wu_rows = rows_per_wu;
+    *rows_sec = (uint32_t)((float)rows * passes_sec);
 }
 
 /** \brief Thread that manages the flow table and times out flows.
@@ -821,6 +821,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
     uint32_t emerg_over_cnt = 0;
     uint64_t next_run_ms = 0;
     uint32_t pos = 0;
+    uint32_t rows_sec = 0;
     uint32_t rows_per_wu = 0;
     uint64_t sleep_per_wu = 0;
     bool emerg = false;
@@ -843,7 +844,8 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         StatsSetUI64(th_v, ftd->cnt.memcap_pressure, mp);
         StatsSetUI64(th_v, ftd->cnt.memcap_pressure_max, mp);
     }
-    GetWorkUnitSizing(pass_in_sec, rows, mp, emerg, &sleep_per_wu, &rows_per_wu);
+    GetWorkUnitSizing(pass_in_sec, rows, mp, emerg, &sleep_per_wu, &rows_per_wu, &rows_sec);
+    StatsSetUI64(th_v, ftd->cnt.flow_mgr_rows_sec, rows_sec);
 
     while (1)
     {
@@ -935,12 +937,16 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
             }
 
             /* update work units */
+            const uint32_t pmp = mp;
             mp = MemcapsGetPressure() * 100;
             if (ftd->instance == 0) {
                 StatsSetUI64(th_v, ftd->cnt.memcap_pressure, mp);
                 StatsSetUI64(th_v, ftd->cnt.memcap_pressure_max, mp);
             }
-            GetWorkUnitSizing(pass_in_sec, rows, mp, emerg, &sleep_per_wu, &rows_per_wu);
+            GetWorkUnitSizing(pass_in_sec, rows, mp, emerg, &sleep_per_wu, &rows_per_wu, &rows_sec);
+            if (pmp != mp) {
+                StatsSetUI64(th_v, ftd->cnt.flow_mgr_rows_sec, rows_sec);
+            }
 
             next_run_ms = ts_ms + sleep_per_wu;
         }

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2021 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -90,6 +90,9 @@ static uint32_t flowrec_number = 1;
 SC_ATOMIC_DECLARE(uint32_t, flowrec_cnt);
 SC_ATOMIC_DECLARE(uint32_t, flowrec_busy);
 SC_ATOMIC_EXTERN(unsigned int, flow_flags);
+
+SCCtrlCondT flow_manager_ctrl_cond;
+SCCtrlMutex flow_manager_ctrl_mutex;
 
 void FlowTimeoutsInit(void)
 {
@@ -802,6 +805,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         if (suricata_ctl_flags != 0)
             return TM_ECODE_OK;
     }
+    const bool time_is_live = TimeModeIsLive();
 
     SCLogDebug("FM %s/%d starting. min_timeout %us. Full hash pass in %us", th_v->name,
             ftd->instance, min_timeout, pass_in_sec);
@@ -869,7 +873,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         memset(&ts, 0, sizeof(ts));
         TimeGet(&ts);
         SCLogDebug("ts %" PRIdMAX "", (intmax_t)ts.tv_sec);
-        const uint64_t ts_ms = ts.tv_sec * 1000 + ts.tv_usec / 1000;
+        uint64_t ts_ms = ts.tv_sec * 1000 + ts.tv_usec / 1000;
         const bool emerge_p = (emerg && !prev_emerg);
         if (emerge_p) {
             next_run_ms = 0;
@@ -1011,7 +1015,30 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         memset(&sleep_startts, 0, sizeof(sleep_startts));
         gettimeofday(&sleep_startts, NULL);
 #endif
-        usleep(250);
+
+        if (emerg || !time_is_live) {
+            usleep(250);
+        } else {
+            struct timeval cond_tv;
+            gettimeofday(&cond_tv, NULL);
+            struct timeval add_tv;
+            add_tv.tv_sec = 0;
+            add_tv.tv_usec = (sleep_per_wu * 1000);
+            timeradd(&cond_tv, &add_tv, &cond_tv);
+
+            struct timespec cond_time = FROM_TIMEVAL(cond_tv);
+            SCCtrlMutexLock(&flow_manager_ctrl_mutex);
+            while (1) {
+                int rc = SCCtrlCondTimedwait(
+                        &flow_manager_ctrl_cond, &flow_manager_ctrl_mutex, &cond_time);
+                if (rc == ETIMEDOUT || rc < 0)
+                    break;
+                if (SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY) {
+                    break;
+                }
+            }
+            SCCtrlMutexUnlock(&flow_manager_ctrl_mutex);
+        }
 
 #ifdef FM_PROFILE
         struct timeval sleep_endts;
@@ -1056,6 +1083,9 @@ void FlowManagerThreadSpawn()
                 "invalid flow.managers setting %"PRIdMAX, setting);
     }
     flowmgr_number = (uint32_t)setting;
+
+    SCCtrlCondInit(&flow_manager_ctrl_cond, NULL);
+    SCCtrlMutexInit(&flow_manager_ctrl_mutex, NULL);
 
     SCLogConfig("using %u flow manager threads", flowmgr_number);
     StatsRegisterGlobalCounter("flow.memuse", FlowGetMemuse);

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -71,6 +71,8 @@
 #include "output-flow.h"
 #include "util-validate.h"
 
+#include "runmode-unix-socket.h"
+
 /* Run mode selected at suricata.c */
 extern int run_mode;
 
@@ -486,22 +488,34 @@ static uint32_t FlowTimeoutHash(FlowManagerTimeoutThread *td,
     return cnt;
 }
 
-static uint32_t FlowTimeoutHashInChunks(FlowManagerTimeoutThread *td,
-        struct timeval *ts,
-        const uint32_t hash_min, const uint32_t hash_max,
-        FlowTimeoutCounters *counters, uint32_t iter, const uint32_t chunks)
+/** \internal
+ *  \brief handle timeout for a slice of hash rows
+ *  If we wrap around we call FlowTimeoutHash twice */
+static uint32_t FlowTimeoutHashInChunks(FlowManagerTimeoutThread *td, struct timeval *ts,
+        const uint32_t hash_min, const uint32_t hash_max, FlowTimeoutCounters *counters,
+        const uint32_t rows, uint32_t *pos)
 {
-    const uint32_t rows = hash_max - hash_min;
-    const uint32_t chunk_size = rows / chunks;
+    uint32_t start = 0;
+    uint32_t end = 0;
+    uint32_t cnt = 0;
+    uint32_t rows_left = rows;
 
-    const uint32_t min = iter * chunk_size + hash_min;
-    uint32_t max = min + chunk_size;
-    /* we start at beginning of hash at next iteration so let's check
-     * hash till the end */
-    if (iter + 1 == chunks) {
-        max = hash_max;
+again:
+    start = hash_min + (*pos);
+    if (start >= hash_max) {
+        start = hash_min;
     }
-    const uint32_t cnt = FlowTimeoutHash(td, ts, min, max, counters);
+    end = start + rows_left;
+    if (end > hash_max) {
+        end = hash_max;
+    }
+    *pos = (end == hash_max) ? hash_min : end;
+    rows_left = rows_left - (end - start);
+
+    cnt += FlowTimeoutHash(td, ts, start, end, counters);
+    if (rows_left) {
+        goto again;
+    }
     return cnt;
 }
 
@@ -619,6 +633,9 @@ typedef struct FlowCounters_ {
     uint16_t flow_bypassed_cnt_clo;
     uint16_t flow_bypassed_pkts;
     uint16_t flow_bypassed_bytes;
+
+    uint16_t memcap_pressure;
+    uint16_t memcap_pressure_max;
 } FlowCounters;
 
 typedef struct FlowManagerThreadData_ {
@@ -653,6 +670,9 @@ static void FlowCountersInit(ThreadVars *t, FlowCounters *fc)
     fc->flow_bypassed_cnt_clo = StatsRegisterCounter("flow_bypassed.closed", t);
     fc->flow_bypassed_pkts = StatsRegisterCounter("flow_bypassed.pkts", t);
     fc->flow_bypassed_bytes = StatsRegisterCounter("flow_bypassed.bytes", t);
+
+    fc->memcap_pressure = StatsRegisterCounter("memcap_pressure", t);
+    fc->memcap_pressure_max = StatsRegisterMaxCounter("memcap_pressure_max", t);
 }
 
 static TmEcode FlowManagerThreadInit(ThreadVars *t, const void *initdata, void **data)
@@ -716,6 +736,42 @@ static uint32_t FlowTimeoutsMin(void)
 
 //#define FM_PROFILE
 
+static void GetWorkUnitSizing(const uint32_t pass_in_sec, const uint32_t rows, const uint32_t mp,
+        const bool emergency, uint64_t *wu_sleep, uint32_t *wu_rows)
+{
+    if (emergency) {
+        *wu_rows = rows;
+        *wu_sleep = 250;
+        return;
+    }
+
+    uint32_t full_pass_in_ms = pass_in_sec * 1000;
+    float perc = MIN((((float)(100 - mp) / (float)100)), 1);
+    full_pass_in_ms *= perc;
+    full_pass_in_ms = MAX(full_pass_in_ms, 333);
+
+    uint32_t work_unit_ms = 999 * perc;
+    work_unit_ms = MAX(work_unit_ms, 250);
+
+    uint32_t wus_per_full_pass = full_pass_in_ms / work_unit_ms;
+
+    uint32_t rows_per_wu = MAX(1, rows / wus_per_full_pass);
+    uint32_t rows_process_cost = rows_per_wu / 1000; // est 1usec per row
+
+    int32_t sleep_per_wu = work_unit_ms - rows_process_cost;
+    sleep_per_wu = MAX(sleep_per_wu, 10);
+#if 0
+    float passes_sec = 1000.0/(float)full_pass_in_ms;
+    SCLogNotice("full_pass_in_ms %u perc %f rows %u "
+            "wus_per_full_pass %u rows_per_wu %u work_unit_ms %u sleep_per_wu %u => passes/s %f rows/s %u",
+            full_pass_in_ms, perc, rows,
+            wus_per_full_pass, rows_per_wu, work_unit_ms, (uint32_t)sleep_per_wu,
+            passes_sec, (uint32_t)((float)rows * passes_sec));
+#endif
+    *wu_sleep = sleep_per_wu;
+    *wu_rows = rows_per_wu;
+}
+
 /** \brief Thread that manages the flow table and times out flows.
  *
  *  \param td ThreadVars casted to void ptr
@@ -730,7 +786,6 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
     bool emerg = false;
     bool prev_emerg = false;
     uint32_t other_last_sec = 0; /**< last sec stamp when defrag etc ran */
-    uint32_t flow_last_sec = 0;
 /* VJ leaving disabled for now, as hosts are only used by tags and the numbers
  * are really low. Might confuse ppl
     uint16_t flow_mgr_host_prune = StatsRegisterCounter("hosts.pruned", th_v);
@@ -738,12 +793,6 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
     uint16_t flow_mgr_host_spare = StatsRegisterCounter("hosts.spare", th_v);
 */
     memset(&ts, 0, sizeof(ts));
-    uint32_t hash_passes = 0;
-#ifdef FM_PROFILE
-    uint32_t hash_row_checks = 0;
-    uint32_t hash_passes_chunks = 0;
-#endif
-    uint32_t hash_full_passes = 0;
 
     const uint32_t min_timeout = FlowTimeoutsMin();
     const uint32_t pass_in_sec = min_timeout ? min_timeout * 8 : 60;
@@ -772,9 +821,19 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
     memset(&startts, 0, sizeof(startts));
     gettimeofday(&startts, NULL);
 
-    uint32_t hash_pass_iter = 0;
     uint32_t emerg_over_cnt = 0;
     uint64_t next_run_ms = 0;
+    const uint32_t rows = ftd->max - ftd->min;
+    uint32_t pos = 0;
+    uint32_t rows_per_wu = 0;
+    uint64_t sleep_per_wu = 0;
+
+    uint32_t mp = MemcapsGetPressure() * 100;
+    if (ftd->instance == 0) {
+        StatsSetUI64(th_v, ftd->cnt.memcap_pressure, mp);
+        StatsSetUI64(th_v, ftd->cnt.memcap_pressure_max, mp);
+    }
+    GetWorkUnitSizing(pass_in_sec, rows, mp, emerg, &sleep_per_wu, &rows_per_wu);
 
     while (1)
     {
@@ -811,7 +870,6 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         TimeGet(&ts);
         SCLogDebug("ts %" PRIdMAX "", (intmax_t)ts.tv_sec);
         const uint64_t ts_ms = ts.tv_sec * 1000 + ts.tv_usec / 1000;
-        const uint32_t rt = (uint32_t)ts.tv_sec;
         const bool emerge_p = (emerg && !prev_emerg);
         if (emerge_p) {
             next_run_ms = 0;
@@ -828,7 +886,6 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
                     FlowSparePoolUpdate(sq_len);
                 }
             }
-            const uint32_t secs_passed = rt - flow_last_sec;
 
             /* try to time out flows */
             FlowTimeoutCounters counters = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
@@ -836,34 +893,18 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
             if (emerg) {
                 /* in emergency mode, do a full pass of the hash table */
                 FlowTimeoutHash(&ftd->timeout, &ts, ftd->min, ftd->max, &counters);
-                hash_passes++;
-                hash_full_passes++;
-                hash_passes++;
-#ifdef FM_PROFILE
-                hash_passes_chunks += 1;
-                hash_row_checks += counters.rows_checked;
-#endif
                 StatsIncr(th_v, ftd->cnt.flow_mgr_full_pass);
             } else {
-                /* non-emergency mode: scan part of the hash */
-                const uint32_t chunks = MIN(secs_passed, pass_in_sec);
-                for (uint32_t i = 0; i < chunks; i++) {
-                    FlowTimeoutHashInChunks(&ftd->timeout, &ts, ftd->min, ftd->max,
-                            &counters, hash_pass_iter, pass_in_sec);
-                    hash_pass_iter++;
-                    if (hash_pass_iter == pass_in_sec) {
-                        hash_pass_iter = 0;
-                        hash_full_passes++;
-                        StatsIncr(th_v, ftd->cnt.flow_mgr_full_pass);
-                    }
+                SCLogDebug("hash %u:%u slice starting at %u with %u rows", ftd->min, ftd->max, pos,
+                        rows_per_wu);
+
+                const uint32_t ppos = pos;
+                FlowTimeoutHashInChunks(
+                        &ftd->timeout, &ts, ftd->min, ftd->max, &counters, rows_per_wu, &pos);
+                if (ppos > pos) {
+                    StatsIncr(th_v, ftd->cnt.flow_mgr_full_pass);
                 }
-                hash_passes++;
-#ifdef FM_PROFILE
-                hash_row_checks += counters.rows_checked;
-                hash_passes_chunks += chunks;
-#endif
             }
-            flow_last_sec = rt;
 
             /*
                StatsAddUI64(th_v, flow_mgr_host_prune, (uint64_t)hosts_pruned);
@@ -897,54 +938,58 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
              * clear emergency bit if we have at least xx flows pruned. */
             uint32_t len = FlowSpareGetPoolSize();
             StatsSetUI64(th_v, ftd->cnt.flow_mgr_spare, (uint64_t)len);
+
             if (emerg == true) {
                 SCLogDebug("flow_sparse_q.len = %"PRIu32" prealloc: %"PRIu32
                         "flow_spare_q status: %"PRIu32"%% flows at the queue",
                         len, flow_config.prealloc, len * 100 / flow_config.prealloc);
 
-            /* only if we have pruned this "emergency_recovery" percentage
-             * of flows, we will unset the emergency bit */
-            if (len * 100 / flow_config.prealloc > flow_config.emergency_recovery) {
-                emerg_over_cnt++;
-            } else {
-                emerg_over_cnt = 0;
+                /* only if we have pruned this "emergency_recovery" percentage
+                 * of flows, we will unset the emergency bit */
+                if (len * 100 / flow_config.prealloc > flow_config.emergency_recovery) {
+                    emerg_over_cnt++;
+                } else {
+                    emerg_over_cnt = 0;
+                }
+
+                if (emerg_over_cnt >= 30) {
+                    SC_ATOMIC_AND(flow_flags, ~FLOW_EMERGENCY);
+                    FlowTimeoutsReset();
+
+                    emerg = false;
+                    prev_emerg = false;
+                    emerg_over_cnt = 0;
+                    SCLogNotice("Flow emergency mode over, back to normal... unsetting"
+                                " FLOW_EMERGENCY bit (ts.tv_sec: %" PRIuMAX ", "
+                                "ts.tv_usec:%" PRIuMAX ") flow_spare_q status(): %" PRIu32
+                                "%% flows at the queue",
+                            (uintmax_t)ts.tv_sec, (uintmax_t)ts.tv_usec,
+                            len * 100 / flow_config.prealloc);
+
+                    StatsIncr(th_v, ftd->cnt.flow_emerg_mode_over);
+                }
             }
 
-            if (emerg_over_cnt >= 30) {
-                SC_ATOMIC_AND(flow_flags, ~FLOW_EMERGENCY);
-                FlowTimeoutsReset();
+            /* update work units */
+            mp = MemcapsGetPressure() * 100;
+            if (ftd->instance == 0) {
+                StatsSetUI64(th_v, ftd->cnt.memcap_pressure, mp);
+                StatsSetUI64(th_v, ftd->cnt.memcap_pressure_max, mp);
+            }
+            GetWorkUnitSizing(pass_in_sec, rows, mp, emerg, &sleep_per_wu, &rows_per_wu);
 
-                emerg = false;
-                prev_emerg = false;
-                emerg_over_cnt = 0;
-                hash_pass_iter = 0;
-                SCLogNotice("Flow emergency mode over, back to normal... unsetting"
-                          " FLOW_EMERGENCY bit (ts.tv_sec: %"PRIuMAX", "
-                          "ts.tv_usec:%"PRIuMAX") flow_spare_q status(): %"PRIu32
-                          "%% flows at the queue", (uintmax_t)ts.tv_sec,
-                          (uintmax_t)ts.tv_usec, len * 100 / flow_config.prealloc);
-
-                StatsIncr(th_v, ftd->cnt.flow_emerg_mode_over);
+            next_run_ms = ts_ms + sleep_per_wu;
+        }
+        if (other_last_sec == 0 || other_last_sec < (uint32_t)ts.tv_sec) {
+            if (ftd->instance == 0) {
+                DefragTimeoutHash(&ts);
+                // uint32_t hosts_pruned =
+                HostTimeoutHash(&ts);
+                IPPairTimeoutHash(&ts);
+                HttpRangeContainersTimeoutHash(&ts);
+                other_last_sec = (uint32_t)ts.tv_sec;
             }
         }
-        next_run_ms = ts_ms + 667;
-        if (emerg)
-            next_run_ms = ts_ms + 250;
-        }
-        if (flow_last_sec == 0) {
-            flow_last_sec = rt;
-        }
-
-        if (ftd->instance == 0 &&
-                (other_last_sec == 0 || other_last_sec < (uint32_t)ts.tv_sec)) {
-            DefragTimeoutHash(&ts);
-            //uint32_t hosts_pruned =
-            HostTimeoutHash(&ts);
-            IPPairTimeoutHash(&ts);
-            HttpRangeContainersTimeoutHash(&ts);
-            other_last_sec = (uint32_t)ts.tv_sec;
-        }
-
 
 #ifdef FM_PROFILE
         struct timeval run_endts;
@@ -987,11 +1032,6 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
               established_cnt, closing_cnt);
 
 #ifdef FM_PROFILE
-    SCLogNotice("hash passes %u avg chunks %u full %u rows %u (rows/s %u)",
-            hash_passes, hash_passes_chunks / (hash_passes ? hash_passes : 1),
-            hash_full_passes, hash_row_checks,
-            hash_row_checks / ((uint32_t)active.tv_sec?(uint32_t)active.tv_sec:1));
-
     gettimeofday(&endts, NULL);
     struct timeval total_run_time;
     timersub(&endts, &startts, &total_run_time);

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -604,17 +604,6 @@ static uint32_t FlowCleanupHash(void)
     return cnt;
 }
 
-static void Recycler(ThreadVars *tv, void *output_thread_data, Flow *f)
-{
-    FLOWLOCK_WRLOCK(f);
-
-    (void)OutputFlowLog(tv, output_thread_data, f);
-
-    FlowClearMemory (f, f->protomap);
-    FLOWLOCK_UNLOCK(f);
-    FlowSparePoolReturnFlow(f);
-}
-
 typedef struct FlowQueueTimeoutCounters {
     uint32_t flows_removed;
     uint32_t flows_timeout;
@@ -1034,6 +1023,14 @@ void FlowManagerThreadSpawn()
 
 typedef struct FlowRecyclerThreadData_ {
     void *output_thread_data;
+
+    uint16_t counter_flows;
+    uint16_t counter_queue_avg;
+    uint16_t counter_queue_max;
+
+    uint16_t counter_flow_active;
+    uint16_t counter_tcp_active_sessions;
+    FlowEndCounters fec;
 } FlowRecyclerThreadData;
 
 static TmEcode FlowRecyclerThreadInit(ThreadVars *t, const void *initdata, void **data)
@@ -1048,6 +1045,15 @@ static TmEcode FlowRecyclerThreadInit(ThreadVars *t, const void *initdata, void 
     }
     SCLogDebug("output_thread_data %p", ftd->output_thread_data);
 
+    ftd->counter_flows = StatsRegisterCounter("flow.recycler.recycled", t);
+    ftd->counter_queue_avg = StatsRegisterAvgCounter("flow.recycler.queue_avg", t);
+    ftd->counter_queue_max = StatsRegisterMaxCounter("flow.recycler.queue_max", t);
+
+    ftd->counter_flow_active = StatsRegisterCounter("flow.active", t);
+    ftd->counter_tcp_active_sessions = StatsRegisterCounter("tcp.active_sessions", t);
+
+    FlowEndCountersRegister(t, &ftd->fec);
+
     *data = ftd;
     return TM_ECODE_OK;
 }
@@ -1060,6 +1066,23 @@ static TmEcode FlowRecyclerThreadDeinit(ThreadVars *t, void *data)
 
     SCFree(data);
     return TM_ECODE_OK;
+}
+
+static void Recycler(ThreadVars *tv, FlowRecyclerThreadData *ftd, Flow *f)
+{
+    FLOWLOCK_WRLOCK(f);
+
+    (void)OutputFlowLog(tv, ftd->output_thread_data, f);
+
+    FlowEndCountersUpdate(tv, &ftd->fec, f);
+    if (f->proto == IPPROTO_TCP && f->protoctx != NULL) {
+        StatsDecr(tv, ftd->counter_tcp_active_sessions);
+    }
+    StatsDecr(tv, ftd->counter_flow_active);
+
+    FlowClearMemory (f, f->protomap);
+    FLOWLOCK_UNLOCK(f);
+    FlowSparePoolReturnFlow(f);
 }
 
 /** \brief Thread that manages timed out flows.
@@ -1085,6 +1108,9 @@ static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
         SC_ATOMIC_ADD(flowrec_busy,1);
         FlowQueuePrivate list = FlowQueueExtractPrivate(&flow_recycle_q);
 
+        StatsAddUI64(th_v, ftd->counter_queue_avg, list.len);
+        StatsSetUI64(th_v, ftd->counter_queue_max, list.len);
+
         const int bail = (TmThreadsCheckFlag(th_v, THV_KILL));
 
         /* Get the time */
@@ -1094,8 +1120,9 @@ static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
 
         Flow *f;
         while ((f = FlowQueuePrivateGetFromTop(&list)) != NULL) {
-            Recycler(th_v, ftd->output_thread_data, f);
+            Recycler(th_v, ftd, f);
             recycled_cnt++;
+            StatsIncr(th_v, ftd->counter_flows);
         }
         SC_ATOMIC_SUB(flowrec_busy,1);
 

--- a/src/flow-manager.h
+++ b/src/flow-manager.h
@@ -28,6 +28,9 @@
 extern SCCtrlCondT flow_manager_ctrl_cond;
 extern SCCtrlMutex flow_manager_ctrl_mutex;
 #define FlowWakeupFlowManagerThread() SCCtrlCondSignal(&flow_manager_ctrl_cond)
+extern SCCtrlCondT flow_recycler_ctrl_cond;
+extern SCCtrlMutex flow_recycler_ctrl_mutex;
+#define FlowWakeupFlowRecyclerThread() SCCtrlCondSignal(&flow_recycler_ctrl_cond)
 
 #define FlowTimeoutsReset() FlowTimeoutsInit()
 void FlowTimeoutsInit(void);

--- a/src/flow-manager.h
+++ b/src/flow-manager.h
@@ -24,6 +24,11 @@
 #ifndef __FLOW_MANAGER_H__
 #define __FLOW_MANAGER_H__
 
+/** flow manager scheduling condition */
+extern SCCtrlCondT flow_manager_ctrl_cond;
+extern SCCtrlMutex flow_manager_ctrl_mutex;
+#define FlowWakeupFlowManagerThread() SCCtrlCondSignal(&flow_manager_ctrl_cond)
+
 #define FlowTimeoutsReset() FlowTimeoutsInit()
 void FlowTimeoutsInit(void);
 void FlowTimeoutsEmergency(void);

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -306,4 +306,5 @@ void FlowEndCountersRegister(ThreadVars *t, FlowEndCounters *fec)
 
         fec->flow_tcp_state[i] = StatsRegisterCounter(name, t);
     }
+    fec->flow_tcp_liberal = StatsRegisterCounter("flow.end.tcp_liberal", t);
 }

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -240,3 +240,70 @@ void RegisterFlowBypassInfo(void)
     g_bypass_info_id = FlowStorageRegister("bypass_counters", sizeof(void *),
                                               NULL, FlowBypassFree);
 }
+
+void FlowEndCountersRegister(ThreadVars *t, FlowEndCounters *fec)
+{
+    for (int i = 0; i < FLOW_STATE_SIZE; i++) {
+        const char *name = NULL;
+        if (i == FLOW_STATE_NEW) {
+            name = "flow.end.state.new";
+        } else if (i == FLOW_STATE_ESTABLISHED) {
+            name = "flow.end.state.established";
+        } else if (i == FLOW_STATE_CLOSED) {
+            name = "flow.end.state.closed";
+        } else if (i == FLOW_STATE_LOCAL_BYPASSED) {
+            name = "flow.end.state.local_bypassed";
+#ifdef CAPTURE_OFFLOAD
+        } else if (i == FLOW_STATE_CAPTURE_BYPASSED) {
+            name = "flow.end.state.capture_bypassed";
+#endif
+        }
+        if (name) {
+            fec->flow_state[i] = StatsRegisterCounter(name, t);
+        }
+    }
+
+    for (enum TcpState i = TCP_NONE; i <= TCP_CLOSED; i++) {
+        const char *name;
+        switch (i) {
+            case TCP_NONE:
+                name = "flow.end.tcp_state.none";
+                break;
+            case TCP_LISTEN:
+                name = "flow.end.tcp_state.listen";
+                break;
+            case TCP_SYN_SENT:
+                name = "flow.end.tcp_state.syn_sent";
+                break;
+            case TCP_SYN_RECV:
+                name = "flow.end.tcp_state.syn_recv";
+                break;
+            case TCP_ESTABLISHED:
+                name = "flow.end.tcp_state.established";
+                break;
+            case TCP_FIN_WAIT1:
+                name = "flow.end.tcp_state.fin_wait1";
+                break;
+            case TCP_FIN_WAIT2:
+                name = "flow.end.tcp_state.fin_wait2";
+                break;
+            case TCP_TIME_WAIT:
+                name = "flow.end.tcp_state.time_wait";
+                break;
+            case TCP_LAST_ACK:
+                name = "flow.end.tcp_state.last_ack";
+                break;
+            case TCP_CLOSE_WAIT:
+                name = "flow.end.tcp_state.close_wait";
+                break;
+            case TCP_CLOSING:
+                name = "flow.end.tcp_state.closing";
+                break;
+            case TCP_CLOSED:
+                name = "flow.end.tcp_state.closed";
+                break;
+        }
+
+        fec->flow_tcp_state[i] = StatsRegisterCounter(name, t);
+    }
+}

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -157,6 +157,7 @@ uint8_t FlowGetReverseProtoMapping(uint8_t rproto);
 typedef struct FlowEndCounters_ {
     uint16_t flow_state[FLOW_STATE_SIZE];
     uint16_t flow_tcp_state[TCP_CLOSED + 1];
+    uint16_t flow_tcp_liberal;
 } FlowEndCounters;
 
 static inline void FlowEndCountersUpdate(ThreadVars *tv, FlowEndCounters *fec, Flow *f)
@@ -164,6 +165,9 @@ static inline void FlowEndCountersUpdate(ThreadVars *tv, FlowEndCounters *fec, F
     if (f->proto == IPPROTO_TCP && f->protoctx != NULL) {
         TcpSession *ssn = f->protoctx;
         StatsIncr(tv, fec->flow_tcp_state[ssn->state]);
+        if (ssn->lossy_be_liberal) {
+            StatsIncr(tv, fec->flow_tcp_liberal);
+        }
     }
     StatsIncr(tv, fec->flow_state[f->flow_state]);
 }

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -83,6 +83,7 @@ typedef struct FlowWorkerThreadData_ {
         uint16_t flows_aside_needs_work;
         uint16_t flows_aside_pkt_inject;
     } cnt;
+    FlowEndCounters fec;
 
 } FlowWorkerThreadData;
 
@@ -189,6 +190,12 @@ static void CheckWorkQueue(ThreadVars *tv, FlowWorkerThreadData *fw,
         if (fw->output_thread_flow != NULL)
             (void)OutputFlowLog(tv, fw->output_thread_flow, f);
 
+        FlowEndCountersUpdate(tv, &fw->fec, f);
+        if (f->proto == IPPROTO_TCP && f->protoctx != NULL) {
+            StatsDecr(tv, fw->dtv->counter_tcp_active_sessions);
+        }
+        StatsDecr(tv, fw->dtv->counter_flow_active);
+
         FlowClearMemory (f, f->protomap);
         FLOWLOCK_UNLOCK(f);
         if (fw->fls.spare_queue.len >= 200) { // TODO match to API? 200 = 2 * block size
@@ -288,6 +295,7 @@ static TmEcode FlowWorkerThreadInit(ThreadVars *tv, const void *initdata, void *
 
     DecodeRegisterPerfCounters(fw->dtv, tv);
     AppLayerRegisterThreadCounters(tv);
+    FlowEndCountersRegister(tv, &fw->fec);
 
     /* setup pq for stream end pkts */
     memset(&fw->pq, 0, sizeof(PacketQueueNoLock));

--- a/src/flow.h
+++ b/src/flow.h
@@ -514,6 +514,11 @@ enum FlowState {
     FLOW_STATE_CAPTURE_BYPASSED,
 #endif
 };
+#ifdef CAPTURE_OFFLOAD
+#define FLOW_STATE_SIZE 5
+#else
+#define FLOW_STATE_SIZE 4
+#endif
 
 typedef struct FlowProtoTimeout_ {
     uint32_t new_timeout;

--- a/src/log-stats.c
+++ b/src/log-stats.c
@@ -142,7 +142,7 @@ static int LogStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *s
                     continue;
 
                 char line[256];
-                size_t len = snprintf(line, sizeof(line), "%-45s | %-25s | %-" PRIu64 "\n",
+                size_t len = snprintf(line, sizeof(line), "%-45s | %-25s | %-" PRIi64 "\n",
                         st->tstats[u].name, st->tstats[u].tm_name, st->tstats[u].value);
 
                 /* since we can have many threads, the buffer might not be big enough.

--- a/src/output-stats.h
+++ b/src/output-stats.h
@@ -29,8 +29,8 @@
 typedef struct StatsRecord_ {
     const char *name;
     const char *tm_name;
-    uint64_t value;         /**< total value */
-    uint64_t pvalue;        /**< prev value (may be higher for memuse counters) */
+    int64_t value;          /**< total value */
+    int64_t pvalue;         /**< prev value (may be higher for memuse counters) */
 } StatsRecord;
 
 typedef struct StatsTable_ {

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -82,8 +82,6 @@ const char *RunModeUnixSocketGetDefaultMode(void)
     return "autofp";
 }
 
-#ifdef BUILD_UNIX_SOCKET
-
 #define MEMCAPS_MAX 7
 static MemcapCommand memcaps[MEMCAPS_MAX] = {
     {
@@ -129,6 +127,24 @@ static MemcapCommand memcaps[MEMCAPS_MAX] = {
         HostGetMemuse
     },
 };
+
+float MemcapsGetPressure(void)
+{
+    float percent = 0.0;
+    for (int i = 0; i < 4; i++) { // only flow, streams, http
+        uint64_t memcap = memcaps[i].GetFunc();
+        if (memcap) {
+            uint64_t memuse = memcaps[i].GetMemuseFunc();
+            float p = (float)((double)memuse / (double)memcap);
+            // SCLogNotice("%s: memuse %"PRIu64", memcap %"PRIu64" => %f%%",
+            //    memcaps[i].name, memuse, memcap, (p * 100));
+            percent = MAX(p, percent);
+        }
+    }
+    return percent;
+}
+
+#ifdef BUILD_UNIX_SOCKET
 
 static int RunModeUnixSocketMaster(void);
 static int unix_manager_pcap_task_running = 0;

--- a/src/runmode-unix-socket.h
+++ b/src/runmode-unix-socket.h
@@ -30,6 +30,8 @@ int RunModeUnixSocketIsActive(void);
 
 TmEcode UnixSocketPcapFile(TmEcode tm, struct timespec *last_processed);
 
+float MemcapsGetPressure(void);
+
 #ifdef BUILD_UNIX_SOCKET
 TmEcode UnixSocketDatasetAdd(json_t *cmd, json_t* answer, void *data);
 TmEcode UnixSocketDatasetRemove(json_t *cmd, json_t* answer, void *data);

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -590,6 +590,9 @@ int StreamTcpReassembleInsertSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
             StatsIncr(tv, ra_ctx->counter_tcp_reass_data_normal_fail);
             StreamTcpRemoveSegmentFromStream(stream, seg);
             StreamTcpSegmentReturntoPool(seg);
+            if (res == -1) {
+                SCReturnInt(-ENOMEM);
+            }
             SCReturnInt(-1);
         }
 

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -268,6 +268,7 @@ typedef struct TcpSession_ {
     /* coccinelle: TcpSession:flags:STREAMTCP_FLAG */
     uint16_t flags;
     uint32_t reassembly_depth;      /**< reassembly depth for the stream */
+    bool lossy_be_liberal;
     TcpStream server;
     TcpStream client;
     TcpStateQueue *queue;                   /**< list of SYN/ACK candidates */

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -681,6 +681,7 @@ int StreamTcpReassembleHandleSegmentHandleData(ThreadVars *tv, TcpReassemblyThre
     if (seg == NULL) {
         SCLogDebug("segment_pool is empty");
         StreamTcpSetEvent(p, STREAM_REASSEMBLY_NO_SEGMENT);
+        ssn->lossy_be_liberal = true;
         SCReturnInt(-1);
     }
 
@@ -699,7 +700,11 @@ int StreamTcpReassembleHandleSegmentHandleData(ThreadVars *tv, TcpReassemblyThre
                 APPLAYER_PROTO_DETECTION_SKIPPED);
     }
 
-    if (StreamTcpReassembleInsertSegment(tv, ra_ctx, stream, seg, p, TCP_GET_SEQ(p), p->payload, p->payload_len) != 0) {
+    int r = StreamTcpReassembleInsertSegment(tv, ra_ctx, stream, seg, p, TCP_GET_SEQ(p), p->payload, p->payload_len);
+    if (r < 0) {
+        if (r == -ENOMEM) {
+            ssn->lossy_be_liberal = true;
+        }
         SCLogDebug("StreamTcpReassembleInsertSegment failed");
         SCReturnInt(-1);
     }
@@ -1137,6 +1142,7 @@ static int ReassembleUpdateAppLayer (ThreadVars *tv,
 
             StreamTcpSetEvent(p, STREAM_REASSEMBLY_SEQ_GAP);
             StatsIncr(tv, ra_ctx->counter_tcp_reass_gap);
+            ssn->lossy_be_liberal = true;
 
             /* AppLayerHandleTCPData has likely updated progress. */
             const bool no_progress_update = (app_progress == STREAM_APP_PROGRESS(*stream));

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -86,14 +86,6 @@
 #define STREAMTCP_DEFAULT_TOCLIENT_CHUNK_SIZE   2560
 #define STREAMTCP_DEFAULT_MAX_SYNACK_QUEUED     5
 
-#define STREAMTCP_NEW_TIMEOUT                   60
-#define STREAMTCP_EST_TIMEOUT                   3600
-#define STREAMTCP_CLOSED_TIMEOUT                120
-
-#define STREAMTCP_EMERG_NEW_TIMEOUT             10
-#define STREAMTCP_EMERG_EST_TIMEOUT             300
-#define STREAMTCP_EMERG_CLOSED_TIMEOUT          20
-
 static int StreamTcpHandleFin(ThreadVars *tv, StreamTcpThread *, TcpSession *, Packet *, PacketQueueNoLock *);
 void StreamTcpReturnStreamSegments (TcpStream *);
 void StreamTcpInitConfig(bool);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -923,6 +923,7 @@ static int StreamTcpPacketStateNone(ThreadVars *tv, Packet *p,
                 return -1;
             }
             StatsIncr(tv, stt->counter_tcp_sessions);
+            StatsIncr(tv, stt->counter_tcp_active_sessions);
             StatsIncr(tv, stt->counter_tcp_midstream_pickups);
         }
 
@@ -1016,6 +1017,7 @@ static int StreamTcpPacketStateNone(ThreadVars *tv, Packet *p,
             }
 
             StatsIncr(tv, stt->counter_tcp_sessions);
+            StatsIncr(tv, stt->counter_tcp_active_sessions);
         }
 
         /* set the state */
@@ -1082,6 +1084,7 @@ static int StreamTcpPacketStateNone(ThreadVars *tv, Packet *p,
                 return -1;
             }
             StatsIncr(tv, stt->counter_tcp_sessions);
+            StatsIncr(tv, stt->counter_tcp_active_sessions);
             StatsIncr(tv, stt->counter_tcp_midstream_pickups);
         }
         /* set the state */
@@ -5317,6 +5320,7 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
 
     *data = (void *)stt;
 
+    stt->counter_tcp_active_sessions = StatsRegisterCounter("tcp.active_sessions", tv);
     stt->counter_tcp_sessions = StatsRegisterCounter("tcp.sessions", tv);
     stt->counter_tcp_ssn_memcap = StatsRegisterCounter("tcp.ssn_memcap_drop", tv);
     stt->counter_tcp_pseudo = StatsRegisterCounter("tcp.pseudo", tv);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5416,6 +5416,10 @@ static int StreamTcpValidateRst(TcpSession *ssn, Packet *p)
 {
     uint8_t os_policy;
 
+    if (ssn->lossy_be_liberal) {
+        SCReturnInt(1);
+    }
+
     if (ssn->flags & STREAMTCP_FLAG_TIMESTAMP) {
         if (!StreamTcpValidateTimestamp(ssn, p)) {
             SCReturnInt(0);

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -75,6 +75,7 @@ typedef struct StreamTcpThread_ {
      *  receiving (valid) RST packets */
     PacketQueueNoLock pseudo_queue;
 
+    uint16_t counter_tcp_active_sessions;
     uint16_t counter_tcp_sessions;
     /** sessions not picked up because memcap was reached */
     uint16_t counter_tcp_ssn_memcap;

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -713,6 +713,12 @@ LogFileCtx *LogFileEnsureExists(LogFileCtx *parent_ctx, int thread_id)
 static bool LogFileThreadedName(
         const char *original_name, char *threaded_name, size_t len, uint32_t unique_id)
 {
+    /* allow "threaded" /dev/null output for QA purposes. */
+    if (strcmp(original_name, "/dev/null") == 0) {
+        strlcpy(threaded_name, original_name, len);
+        return true;
+    }
+
     const char *base = SCBasename(original_name);
     if (!base) {
         FatalError(SC_ERR_FATAL,

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -44,6 +44,18 @@ void TimeGet(struct timeval *);
     (((tv_first).tv_sec < (tv_second).tv_sec) || \
      ((tv_first).tv_sec == (tv_second).tv_sec && (tv_first).tv_usec < (tv_second).tv_usec))
 
+#ifndef timeradd
+#define timeradd(a, b, r)                                                                          \
+    do {                                                                                           \
+        (r)->tv_sec = (a)->tv_sec + (b)->tv_sec;                                                   \
+        (r)->tv_usec = (a)->tv_usec + (b)->tv_usec;                                                \
+        if ((r)->tv_usec >= 1000000) {                                                             \
+            (r)->tv_sec++;                                                                         \
+            (r)->tv_usec -= 1000000;                                                               \
+        }                                                                                          \
+    } while (0)
+#endif
+
 #ifdef UNITTESTS
 void TimeSet(struct timeval *);
 void TimeSetToCurrentTime(void);


### PR DESCRIPTION
#6596 rebased, adding
- lots more counters
- "liberal mode" for TCP if we know we missed packets. This will make us accept RSTs more liberally.