### PR TITLE
log-pcap: fix segfault on lz4 compressed pcaps

### DIFF
--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -412,10 +412,9 @@ static int PcapLogOpenHandles(PcapLogData *pl, const Packet *p)
             }
             comp->file = fopen(pl->filename, "w");
             if (comp->file == NULL) {
-                /*              took this out so that it won't print twice, but still would function
-                   same SCLogError(SC_ERR_OPENING_FILE, "Error opening file for compressed output:
-                   %s", strerror(errno));
-                */
+                /* Removed error log so that it won't print twice,
+                 * but still would function the same.
+                 */
                 return TM_ECODE_FAILED;
             }
             uint64_t bytes_written = LZ4F_compressBegin(comp->lz4f_context,


### PR DESCRIPTION
Moved a file existence check to fix segfault if Suricata tries to write to an lz4 compressed .pcap file if you don't have permission to write to it.  Also removed the previous code that would log this elsewhere, so you don't get double log entries.

https://redmine.openinfosecfoundation.org/issues/5022