### PR TITLE
Rust overflows v3

### DIFF
--- a/rules/http2-events.rules
+++ b/rules/http2-events.rules
@@ -16,3 +16,4 @@ alert http2 any any -> any any (msg:"SURICATA HTTP2 stream identifier reuse"; fl
 alert http2 any any -> any any (msg:"SURICATA HTTP2 invalid HTTP1 settings during upgrade"; flow:established; app-layer-event:http2.invalid_http1_settings; classtype:protocol-command-decode; sid:2290008; rev:1;)
 alert http2 any any -> any any (msg:"SURICATA HTTP2 failed decompression"; flow:established; app-layer-event:http2.failed_decompression; classtype:protocol-command-decode; sid:2290009; rev:1;)
 alert http2 any any -> any any (msg:"SURICATA HTTP2 invalid range header"; flow:established; app-layer-event:http2.invalid_range; classtype:protocol-command-decode; sid:2290010; rev:1;)
+alert http2 any any -> any any (msg:"SURICATA HTTP2 variable-length integer overflow"; flow:established; app-layer-event:http2.header_integer_overflow; classtype:protocol-command-decode; sid:2290011; rev:1;)

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -295,6 +295,10 @@ impl Flow {
             let mut secs: u64 = 0;
             let mut usecs: u64 = 0;
             FlowGetLastTimeAsParts(self, &mut secs, &mut usecs);
+            if usecs > 999999 {
+                // if microseconds are inconsistent, reset them to 0
+                usecs = 0;
+            }
             std::time::Duration::new(secs, usecs as u32 * 1000)
         }
     }

--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -530,11 +530,11 @@ fn http2_parse_var_uint(input: &[u8], value: u64, max: u64) -> IResult<&[u8], u6
     for i in 0..varia.len() {
         varval += ((varia[i] & 0x7F) as u64) << (7 * i);
     }
-    varval += (finalv as u64) << (7 * varia.len());
-    if varval < max {
-        // this has overflown u64
+    if (finalv as u64) << (7 * varia.len()) > u64::MAX - varval {
+        // this would overflow u64
         return Ok((i3, 0));
     }
+    varval += (finalv as u64) << (7 * varia.len());
     return Ok((i3, varval));
 }
 

--- a/rust/src/mqtt/parser.rs
+++ b/rust/src/mqtt/parser.rs
@@ -22,6 +22,7 @@ use crate::mqtt::mqtt_message::*;
 use crate::mqtt::mqtt_property::*;
 use nom7::bits::streaming::take as take_bits;
 use nom7::bytes::streaming::take_while_m_n;
+use nom7::bytes::complete::take;
 use nom7::combinator::{complete, cond, verify};
 use nom7::multi::{length_data, many0, many1};
 use nom7::number::streaming::*;
@@ -105,26 +106,24 @@ fn parse_properties(input: &[u8], precond: bool) -> IResult<&[u8], Option<Vec<MQ
     }
     // parse properties length
     match parse_mqtt_variable_integer(input) {
-        Ok((rem, mut proplen)) => {
+        Ok((rem, proplen)) => {
             if proplen == 0 {
                 // no properties
                 return Ok((rem, None));
             }
             // parse properties
             let mut props = Vec::<MQTTProperty>::new();
-            let mut newrem = rem;
-            while proplen > 0 {
+            let (rem, mut newrem) = take(proplen as usize)(rem)?;
+            while newrem.len() > 0 {
                 match parse_property(newrem) {
-                    Ok((rem, val)) => {
+                    Ok((rem2, val)) => {
                         props.push(val);
-                        let curparselen = (newrem.len() - rem.len()) as u32;
-                        proplen -= curparselen;
-                        newrem = rem;
+                        newrem = rem2;
                     }
                     Err(e) => return Err(e),
                 }
             }
-            return Ok((newrem, Some(props)));
+            return Ok((rem, Some(props)));
         }
         Err(e) => return Err(e),
     }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- http2 : checks unsigned overflow before it happens
- MQTT : use appropriate size for buffer when parsing properties
- NFS : fixes unsigned underflow
- Adds a consistency check about timestamp microseconds

Modifies #6864 :
- removing PGSQL commit to be handled in https://redmine.openinfosecfoundation.org/issues/5016
- adding NFS commit
- MQTT : more idiomatic nom (still more work to do to avoid endless buffering with more `complete`, not as part of this PR)
- HTTP2 : sets an app-layer event in case of integer overflow

For NFS, should we do this ?
```
diff --git a/rust/src/nfs/nfs3_records.rs b/rust/src/nfs/nfs3_records.rs
index 66c02cf07..d1d1b31da 100644
--- a/rust/src/nfs/nfs3_records.rs
+++ b/rust/src/nfs/nfs3_records.rs
@@ -344,8 +344,8 @@ pub fn parse_nfs3_request_write(i: &[u8]) -> IResult<&[u8], Nfs3RequestWrite> {
     let (i, count) = be_u32(i)?;
     let (i, stable) = be_u32(i)?;
     let (i, file_len) = be_u32(i)?;
-    let (i, file_data) = take(file_len as usize)(i)?;
-    let (i, _file_padding) = cond(file_len % 4 !=0, take(4 - (file_len % 4)))(i)?;
+    let (i, file_data) = take(count as usize)(i)?;
+    let (i, _file_padding) = cond(count % 4 !=0, take(4 - (count % 4)))(i)?;
     let req = Nfs3RequestWrite {
         handle,
         offset,
```

cf https://datatracker.ietf.org/doc/html/rfc1813#section-3.3.7