### PR TITLE
Datasets parsing/v1

### DIFF
--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -39,9 +39,6 @@
 #include "util-print.h"
 #include "util-misc.h"
 
-#define PARSE_REGEX         "([a-z]+)(?:,\\s*([\\-_A-z0-9\\s\\.]+)){1,4}"
-static DetectParseRegex parse_regex;
-
 int DetectDatasetMatch (ThreadVars *, DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectDatasetSetup (DetectEngineCtx *, Signature *, const char *);
@@ -54,8 +51,6 @@ void DetectDatasetRegister (void)
     sigmatch_table[DETECT_DATASET].url = "/rules/dataset-keywords.html#dataset";
     sigmatch_table[DETECT_DATASET].Setup = DetectDatasetSetup;
     sigmatch_table[DETECT_DATASET].Free  = DetectDatasetFree;
-
-    DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
 }
 
 /*

--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -129,13 +129,13 @@ static int DetectDatasetParse(const char *str, char *cmd, int cmd_len, char *nam
         }
 
         if (!cmd_set) {
-            if (val) {
+            if (val && strlen(val) != 0) {
                 return -1;
             }
             strlcpy(cmd, key, cmd_len);
             cmd_set = true;
         } else if (!name_set) {
-            if (val) {
+            if (val && strlen(val) != 0) {
                 return -1;
             }
             strlcpy(name, key, name_len);


### PR DESCRIPTION
If there is a space following a keyword that does not expect a value,
the rule fails to load due to improper value evaluation.
e.g. Space after `set` command
```
alert http any any -> any any (http.user_agent; dataset:set  ,ua-seen,type string,save datasets.csv; sid:1;)
```

gives error
```
[ERRCODE: SC_ERR_UNKNOWN_VALUE(129)] - dataset action "" is not supported.
```

Fix this by handling values correctly for such cases.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/5019

suricata-verify-pr: 801