### PR TITLE
Detect uricontent 4911/v6: remove unittests 

### DIFF
--- a/src/detect-uricontent.c
+++ b/src/detect-uricontent.c
@@ -232,200 +232,155 @@ static int DetectUriSigTest01(void)
  */
 static int DetectUriSigTest02(void)
 {
-    int result = 0;
     Signature *s = NULL;
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL) {
-        goto end;
-    }
+    FAIL_IF_NULL(de_ctx);
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"foo\"; sid:1;)");
-    if (s == NULL ||
-        s->sm_lists[g_http_uri_buffer_id] == NULL ||
-        s->sm_lists[DETECT_SM_LIST_PMATCH] != NULL ||
-        s->sm_lists[DETECT_SM_LIST_MATCH] != NULL)
-    {
-        printf("sig 1 failed to parse: ");
-        goto end;
-    }
+    s = SigInit(de_ctx, "alert tcp any any -> any any (msg:"
+                        "\" Test uricontent\"; "
+                        "uricontent:\"foo\"; sid:1;)");
+    FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";sid:1;)");
-    if (s == NULL ||
-        s->sm_lists[g_http_uri_buffer_id] == NULL ||
-        s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
-        s->sm_lists[DETECT_SM_LIST_MATCH] != NULL)
-    {
-        printf("sig 2 failed to parse: ");
-        goto end;
-    }
+    s = SigInit(de_ctx, "alert tcp any any -> any any (msg:"
+                        "\" Test uricontent and content\"; "
+                        "uricontent:\"foo\"; content:\"bar\";sid:1;)");
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; sid:1;)");
-    if (s == NULL ||
-        s->sm_lists[g_http_uri_buffer_id] == NULL ||
-        s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
-        ((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15 ||
-        ((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5 ||
-        s->sm_lists[DETECT_SM_LIST_MATCH] != NULL)
-    {
-        printf("sig 3 failed to parse: ");
-        goto end;
-    }
+    FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "content:\"foo\"; uricontent:\"bar\";"
-                                   " depth:10; offset: 5; sid:1;)");
-    if (s == NULL ||
-        s->sm_lists[g_http_uri_buffer_id] == NULL ||
-        s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
-        ((DetectContentData *)s->sm_lists[g_http_uri_buffer_id]->ctx)->depth != 15 ||
-        ((DetectContentData *)s->sm_lists[g_http_uri_buffer_id]->ctx)->offset != 5 ||
-        s->sm_lists[DETECT_SM_LIST_MATCH] != NULL)
-    {
-        printf("sig 4 failed to parse: ");
-        goto end;
-    }
+    s = SigInit(de_ctx, "alert tcp any any -> any any (msg:"
+                        "\" Test uricontent and content\"; "
+                        "uricontent:\"foo\"; content:\"bar\";"
+                        " depth:10; offset: 5; sid:1;)");
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; within:3; sid:1;)");
-    if (s != NULL) {
-        printf("sig 5 failed to parse: ");
-        goto end;
-    }
+    FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+    FAIL_IF(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15);
+    FAIL_IF(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; distance:3; sid:1;)");
-    if (s != NULL) {
-        printf("sig 6 failed to parse: ");
-        goto end;
-    }
+    s = SigInit(de_ctx, "alert tcp any any -> any any (msg:"
+                        "\" Test uricontent and content\"; "
+                        "content:\"foo\"; uricontent:\"bar\";"
+                        " depth:10; offset: 5; sid:1;)");
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; content:"
-                                   "\"two_contents\"; within:30; sid:1;)");
-    if (s == NULL) {
-        goto end;
-    } else if (s->sm_lists[g_http_uri_buffer_id] == NULL ||
-            s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15 ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5 ||
-            ((DetectContentData*) s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx)->within != 30 ||
-            s->sm_lists[DETECT_SM_LIST_MATCH] != NULL)
-    {
-        printf("sig 7 failed to parse: ");
-        DetectContentPrint((DetectContentData*) s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx);
-        goto end;
-    }
+    FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+    FAIL_IF(((DetectContentData *)s->sm_lists[g_http_uri_buffer_id]->ctx)->depth != 15);
+    FAIL_IF(((DetectContentData *)s->sm_lists[g_http_uri_buffer_id]->ctx)->offset != 5);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; uricontent:"
-                                   "\"two_uricontents\"; within:30; sid:1;)");
-    if (s == NULL) {
-        goto end;
-    } else if (s->sm_lists[g_http_uri_buffer_id] == NULL ||
-            s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15 ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5 ||
-            ((DetectContentData*) s->sm_lists_tail[g_http_uri_buffer_id]->ctx)->within != 30 ||
-            s->sm_lists[DETECT_SM_LIST_MATCH] != NULL)
-    {
-        printf("sig 8 failed to parse: ");
-        DetectUricontentPrint((DetectContentData*) s->sm_lists_tail[g_http_uri_buffer_id]->ctx);
-        goto end;
-    }
+    s = SigInit(de_ctx, "alert tcp any any -> any any (msg:"
+                        "\" Test uricontent and content\"; "
+                        "uricontent:\"foo\"; content:\"bar\";"
+                        " depth:10; offset: 5; within:3; sid:1;)");
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; content:"
-                                   "\"two_contents\"; distance:30; sid:1;)");
-    if (s == NULL) {
-        goto end;
-    } else if (
-            s->sm_lists[g_http_uri_buffer_id] == NULL ||
-            s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15 ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5 ||
-            ((DetectContentData*) s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx)->distance != 30 ||
-            s->sm_lists[DETECT_SM_LIST_MATCH] != NULL)
-    {
-        printf("sig 9 failed to parse: ");
-        DetectContentPrint((DetectContentData*) s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx);
-        goto end;
-    }
+    FAIL_IF_NOT_NULL(s);
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; uricontent:"
-                                   "\"two_uricontents\"; distance:30; sid:1;)");
-    if (s == NULL) {
-        goto end;
-    } else if (
-            s->sm_lists[g_http_uri_buffer_id] == NULL ||
-            s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15 ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5 ||
-            ((DetectContentData*) s->sm_lists_tail[g_http_uri_buffer_id]->ctx)->distance != 30 ||
-            s->sm_lists[DETECT_SM_LIST_MATCH] != NULL)
-    {
-        printf("sig 10 failed to parse: ");
-        DetectUricontentPrint((DetectContentData*) s->sm_lists_tail[g_http_uri_buffer_id]->ctx);
-        goto end;
-    }
+    s = SigInit(de_ctx, "alert tcp any any -> any any (msg:"
+                        "\" Test uricontent and content\"; "
+                        "uricontent:\"foo\"; content:\"bar\";"
+                        " depth:10; offset: 5; distance:3; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; uricontent:"
-                                   "\"two_uricontents\"; distance:30; "
-                                   "within:60; content:\"two_contents\";"
-                                   " within:70; distance:45; sid:1;)");
-    if (s == NULL) {
-        printf("sig 10 failed to parse: ");
-        goto end;
-    }
+    s = SigInit(de_ctx, "alert tcp any any -> any any (msg:"
+                        "\" Test uricontent and content\"; "
+                        "uricontent:\"foo\"; content:\"bar\";"
+                        " depth:10; offset: 5; content:"
+                        "\"two_contents\"; within:30; sid:1;)");
 
-    if (s->sm_lists[g_http_uri_buffer_id] == NULL || s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL) {
-        printf("umatch %p or pmatch %p: ", s->sm_lists[g_http_uri_buffer_id], s->sm_lists[DETECT_SM_LIST_PMATCH]);
-        goto end;
-    }
+    FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+    FAIL_IF(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15);
+    FAIL_IF(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5);
+    FAIL_IF(((DetectContentData *)s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx)->within != 30);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
 
-    if (    ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15 ||
-            ((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5 ||
-            ((DetectContentData*) s->sm_lists_tail[g_http_uri_buffer_id]->ctx)->distance != 30 ||
-            ((DetectContentData*) s->sm_lists_tail[g_http_uri_buffer_id]->ctx)->within != 60 ||
-            ((DetectContentData*) s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx)->distance != 45 ||
-            ((DetectContentData*) s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx)->within != 70 ||
-            s->sm_lists[DETECT_SM_LIST_MATCH] != NULL) {
-        printf("sig 10 failed to parse, content not setup properly: ");
-        DetectContentPrint((DetectContentData*) s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx);
-        DetectUricontentPrint((DetectContentData*) s->sm_lists_tail[g_http_uri_buffer_id]->ctx);
-        DetectContentPrint((DetectContentData*) s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx);
-        goto end;
-    }
+    DetectContentPrint((DetectContentData *)s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx);
 
-    result = 1;
-end:
-    if (de_ctx != NULL)
-        DetectEngineCtxFree(de_ctx);
-    return result;
+    s = SigInit(de_ctx, "alert tcp any any -> any any (msg:"
+                        "\" Test uricontent and content\"; "
+                        "uricontent:\"foo\"; content:\"bar\";"
+                        " depth:10; offset: 5; uricontent:"
+                        "\"two_uricontents\"; within:30; sid:1;)");
+
+    FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+    FAIL_IF(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15);
+    FAIL_IF(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5);
+    FAIL_IF(((DetectContentData *)s->sm_lists_tail[g_http_uri_buffer_id]->ctx)->within != 30);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
+
+    DetectUricontentPrint((DetectContentData *)s->sm_lists_tail[g_http_uri_buffer_id]->ctx);
+
+    s = SigInit(de_ctx, "alert tcp any any -> any any (msg:"
+                        "\" Test uricontent and content\"; "
+                        "uricontent:\"foo\"; content:\"bar\";"
+                        " depth:10; offset: 5; content:"
+                        "\"two_contents\"; distance:30; sid:1;)");
+
+    FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+    FAIL_IF(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15);
+    FAIL_IF(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5);
+    FAIL_IF(((DetectContentData *)s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx)->distance != 30);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
+
+    DetectContentPrint((DetectContentData *)s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx);
+
+    s = SigInit(de_ctx, "alert tcp any any -> any any (msg:"
+                        "\" Test uricontent and content\"; "
+                        "uricontent:\"foo\"; content:\"bar\";"
+                        " depth:10; offset: 5; uricontent:"
+                        "\"two_uricontents\"; distance:30; sid:1;)");
+
+    FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+    FAIL_IF(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15);
+    FAIL_IF(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5);
+    FAIL_IF(((DetectContentData *)s->sm_lists_tail[g_http_uri_buffer_id]->ctx)->distance != 30);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
+
+    DetectUricontentPrint((DetectContentData *)s->sm_lists_tail[g_http_uri_buffer_id]->ctx);
+
+    s = SigInit(de_ctx, "alert tcp any any -> any any (msg:"
+                        "\" Test uricontent and content\"; "
+                        "uricontent:\"foo\"; content:\"bar\";"
+                        " depth:10; offset: 5; uricontent:"
+                        "\"two_uricontents\"; distance:30; "
+                        "within:60; content:\"two_contents\";"
+                        " within:70; distance:45; sid:1;)");
+    FAIL_IF_NULL(s);
+
+    FAIL_IF_NULL(s->sm_lists[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists[DETECT_SM_LIST_PMATCH]);
+
+    FAIL_IF(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->depth != 15);
+    FAIL_IF(((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx)->offset != 5);
+    FAIL_IF(((DetectContentData *)s->sm_lists_tail[g_http_uri_buffer_id]->ctx)->distance != 30);
+    FAIL_IF(((DetectContentData *)s->sm_lists_tail[g_http_uri_buffer_id]->ctx)->within != 60);
+    FAIL_IF(((DetectContentData *)s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx)->distance != 45);
+    FAIL_IF(((DetectContentData *)s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx)->within != 70);
+    FAIL_IF_NOT_NULL(s->sm_lists[DETECT_SM_LIST_MATCH]);
+
+    DetectContentPrint((DetectContentData *)s->sm_lists[DETECT_SM_LIST_PMATCH]->ctx);
+    DetectUricontentPrint((DetectContentData *)s->sm_lists_tail[g_http_uri_buffer_id]->ctx);
+    DetectContentPrint((DetectContentData *)s->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx);
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
 }
 
 
@@ -434,28 +389,16 @@ end:
  */
 static int DetectUriSigTest03(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"\"; sid:238012;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"\"; sid:238012;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -463,28 +406,16 @@ static int DetectUriSigTest03(void)
  */
 static int DetectUriSigTest04(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"; sid:238012;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"; sid:238012;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -492,28 +423,16 @@ static int DetectUriSigTest04(void)
  */
 static int DetectUriSigTest05(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"boo; sid:238012;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"boo; sid:238012;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -521,28 +440,16 @@ static int DetectUriSigTest05(void)
  */
 static int DetectUriSigTest06(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:boo\"; sid:238012;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:boo\"; sid:238012;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -550,38 +457,25 @@ static int DetectUriSigTest06(void)
  */
 static int DetectUriSigTest07(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
     DetectContentData *ud = 0;
     Signature *s = NULL;
-    int result = 0;
 
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx,
-                                   "alert udp any any -> any any "
-                                   "(msg:\"test\"; uricontent:    !\"boo\"; sid:238012;)");
-    if (de_ctx->sig_list == NULL) {
-        printf("de_ctx->sig_list == NULL: ");
-        goto end;
-    }
+    s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                      "(msg:\"test\"; uricontent:    !\"boo\"; sid:238012;)");
+    FAIL_IF_NULL(s);
 
-    if (s->sm_lists_tail[g_http_uri_buffer_id] == NULL || s->sm_lists_tail[g_http_uri_buffer_id]->ctx == NULL) {
-        printf("de_ctx->pmatch_tail == NULL && de_ctx->pmatch_tail->ctx == NULL: ");
-        goto end;
-    }
+    FAIL_IF_NULL(s->sm_lists_tail[g_http_uri_buffer_id]);
+    FAIL_IF_NULL(s->sm_lists_tail[g_http_uri_buffer_id]->ctx);
 
     ud = (DetectContentData *)s->sm_lists_tail[g_http_uri_buffer_id]->ctx;
-    result = (strncmp("boo", (char *)ud->content, ud->content_len) == 0);
+    FAIL_IF_NOT(strncmp("boo", (char *)ud->content, ud->content_len) == 0);
 
-end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 
@@ -590,28 +484,16 @@ end:
  */
 static int DetectUriContentParseTest08(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|\"; sid:1;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"|\"; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -619,28 +501,16 @@ static int DetectUriContentParseTest08(void)
  */
 static int DetectUriContentParseTest09(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af\"; sid:1;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"|af\"; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -648,28 +518,16 @@ static int DetectUriContentParseTest09(void)
  */
 static int DetectUriContentParseTest10(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"af|\"; sid:1;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"af|\"; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -677,28 +535,16 @@ static int DetectUriContentParseTest10(void)
  */
 static int DetectUriContentParseTest11(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af|\"; sid:1;)");
-    if (de_ctx->sig_list == NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"|af|\"; sid:1;)");
+    FAIL_IF_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -706,28 +552,16 @@ static int DetectUriContentParseTest11(void)
  */
 static int DetectUriContentParseTest12(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"aast|\"; sid:1;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"aast|\"; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -735,28 +569,16 @@ static int DetectUriContentParseTest12(void)
  */
 static int DetectUriContentParseTest13(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"aast|af\"; sid:1;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"aast|af\"; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -764,28 +586,16 @@ static int DetectUriContentParseTest13(void)
  */
 static int DetectUriContentParseTest14(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"aast|af|\"; sid:1;)");
-    if (de_ctx->sig_list == NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"aast|af|\"; sid:1;)");
+    FAIL_IF_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -793,28 +603,16 @@ static int DetectUriContentParseTest14(void)
  */
 static int DetectUriContentParseTest15(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af|asdf\"; sid:1;)");
-    if (de_ctx->sig_list == NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"|af|asdf\"; sid:1;)");
+    FAIL_IF_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -822,28 +620,16 @@ static int DetectUriContentParseTest15(void)
  */
 static int DetectUriContentParseTest16(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af|af|\"; sid:1;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"|af|af|\"; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -851,28 +637,17 @@ static int DetectUriContentParseTest16(void)
  */
 static int DetectUriContentParseTest17(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af|af|af\"; sid:1;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s =
+            DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                          "(msg:\"test\"; uricontent:\"|af|af|af\"; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -880,28 +655,17 @@ static int DetectUriContentParseTest17(void)
  */
 static int DetectUriContentParseTest18(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af|af|af|\"; sid:1;)");
-    if (de_ctx->sig_list == NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s =
+            DetectEngineAppendSig(de_ctx, "alert udp any any -> any any "
+                                          "(msg:\"test\"; uricontent:\"|af|af|af|\"; sid:1;)");
+    FAIL_IF_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -909,28 +673,16 @@ static int DetectUriContentParseTest18(void)
  */
 static int DetectUriContentParseTest19(void)
 {
-    DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
-
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"\"; sid:1;)");
-    if (de_ctx->sig_list != NULL) {
-        result = 0;
-        goto end;
-    }
 
- end:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
+                                                 "(msg:\"test\"; uricontent:\"\"; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 static int DetectUricontentIsdataatParseTest(void)


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to redmine ticket: https://redmine.openinfosecfoundation.org/issues/4911

Describe changes:
- remove unittests that have been converted to Suricata-Verify
- update detect-uricontent unittests to use FAIL/PASS APIs
- cleanup unittests
- update Copyright Year

Previous PR: #6898

suricata-verify-pr: 659