### PR TITLE
http: move xff logging to http object

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -46,6 +46,7 @@ Logging changes
 - IKEv2 Eve logging changed, the event_type has become ``ike``. The fields ``errors`` and ``notify`` have moved to
   ``ike.ikev2.errors`` and ``ike.ikev2.notify``.
 - FTP DATA metadata for alerts are now logged in ``ftp_data`` instead of root.
+- HTTP ``xff`` field is now logged in ``http.xff`` for alerts instead of in the root.
 
 Other changes
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4860
but also https://redmine.openinfosecfoundation.org/issues/1369

Describe changes:
- move some app-layer specific fields out of root object (into the app-layer specific object)
  - http : xff (for alert metadata as well)

suricata-verify-pr: 698
https://github.com/OISF/suricata-verify/pull/698

Replaces #6660 with logging `http.xff` for alerts even without `LOG_JSON_APP_LAYER`