### PR TITLE
log/diag: Support diagnostic stacktraces on SIGSEGV/SIGABRT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1786,6 +1786,13 @@
     ;;
     esac
 
+    AC_CHECK_LIB(unwind,unw_backtrace,,LIBUNW="no")
+    if test "$LIBUNW" = "no"; then
+        echo
+        echo "   libunwind library and development headers not found"
+        echo "   stacktrace on unexpected termination due to signal not possible"
+        echo
+    fi;
 
     AC_ARG_ENABLE(ebpf,
 	        AS_HELP_STRING([--enable-ebpf],[Enable eBPF support]),

--- a/configure.ac
+++ b/configure.ac
@@ -1786,13 +1786,17 @@
     ;;
     esac
 
-    AC_CHECK_LIB(unwind,unw_backtrace,,LIBUNW="no")
-    if test "$LIBUNW" = "no"; then
-        echo
-        echo "   libunwind library and development headers not found"
-        echo "   stacktrace on unexpected termination due to signal not possible"
-        echo
-    fi;
+    AC_ARG_ENABLE(unwind,
+            AS_HELP_STRING([--enable-unwind], [Enable unwind support]),[enable_unwind=$enableval],[enable_unwind=no])
+    AS_IF([test "x$enable_unwind" = "xyes"], [
+        AC_CHECK_LIB(unwind,unw_backtrace,,LIBUNW="no")
+        if test "$LIBUNW" = "no"; then
+            echo
+            echo "   libunwind library and development headers not found"
+            echo "   stacktrace on unexpected termination due to signal not possible"
+            echo
+        fi;
+        ])
 
     AC_ARG_ENABLE(ebpf,
 	        AS_HELP_STRING([--enable-ebpf],[Enable eBPF support]),

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2236,6 +2236,21 @@ inspected for possible presence of Teredo.
 Advanced Options
 ----------------
 
+stacktrace
+~~~~~~~~~~
+Display diagnostic stacktraces when a signal unexpectedly terminates Suricata, e.g., such as
+SIGSEGV or SIGABRT. Requires the ``libunwind`` library to be available. The default value is
+to display the diagnostic message if a signal unexpectedly terminates Suricata -- e.g.,
+``SIGABRT`` or ``SIGSEGV`` occurs while Suricata is running.
+
+::
+
+    logging:
+        # Requires libunwind to be available when Suricata is configured and built.
+        # If a signal unexpectedly terminates Suricata, displays a brief diagnostic
+        # message with the offending stacktrace if enabled.
+        #stacktrace-on-signal: on
+
 luajit
 ~~~~~~
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -292,6 +292,53 @@ static void SignalHandlerSigterm(/*@unused@*/ int sig)
 {
     sigterm_count = 1;
 }
+#ifndef OS_WIN32
+#if HAVE_LIBUNWIND
+#define UNW_LOCAL_ONLY
+#include <libunwind.h>
+static void SignalHandlerUnexpected(int sig_num, siginfo_t *info, void *context)
+{
+    char msg[SC_LOG_MAX_LOG_MSG_LEN];
+    unw_cursor_t cursor;
+    int r;
+    if ((r = unw_init_local(&cursor, (unw_context_t *)(context)) != 0)) {
+        fprintf(stderr, "unable to obtain stack trace: unw_init_local: %s\n", unw_strerror(r));
+        goto terminate;
+    }
+
+    char *temp = msg;
+    int cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - msg), "stacktrace:sig %d:", sig_num);
+    temp += cw;
+    r = 1;
+    while (r > 0) {
+        if (unw_is_signal_frame(&cursor) == 0) {
+            unw_word_t off;
+            char name[256];
+            if (unw_get_proc_name(&cursor, name, sizeof(name), &off) == UNW_ENOMEM) {
+                cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - msg), "[unknown]:");
+            } else {
+                cw = snprintf(
+                        temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - msg), "%s+0x%08" PRIx64, name, off);
+            }
+            temp += cw;
+        }
+
+        r = unw_step(&cursor);
+        if (r > 0) {
+            cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - msg), ";");
+            temp += cw;
+        }
+    }
+    SCLogError(SC_ERR_SIGNAL, "%s", msg);
+
+terminate:
+    // Terminate with SIGABRT ... but first, restore that signal's default handling
+    signal(SIGABRT, SIG_DFL);
+    abort();
+}
+#undef UNW_LOCAL_ONLY
+#endif /* HAVE_LIBUNWIND */
+#endif /* !OS_WIN32 */
 #endif
 
 #ifndef OS_WIN32
@@ -1964,6 +2011,22 @@ static int InitSignalHandler(SCInstance *suri)
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     UtilSignalHandlerSetup(SIGINT, SignalHandlerSigint);
     UtilSignalHandlerSetup(SIGTERM, SignalHandlerSigterm);
+#if HAVE_LIBUNWIND
+    int enabled;
+    if (ConfGetBool("logging.stacktrace-on-signal", &enabled) == 0) {
+        enabled = 1;
+    }
+
+    if (enabled) {
+        SCLogInfo("Preparing unexpected signal handling");
+        struct sigaction stacktrace_action;
+        memset(&stacktrace_action, 0, sizeof(stacktrace_action));
+        stacktrace_action.sa_sigaction = SignalHandlerUnexpected;
+        stacktrace_action.sa_flags = SA_SIGINFO;
+        sigaction(SIGSEGV, &stacktrace_action, NULL);
+        sigaction(SIGABRT, &stacktrace_action, NULL);
+    }
+#endif /* HAVE_LIBUNWIND */
 #endif
 #ifndef OS_WIN32
     UtilSignalHandlerSetup(SIGHUP, SignalHandlerSigHup);

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -377,6 +377,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_ERR_PLUGIN);
         CASE_CODE(SC_ERR_LOG_OUTPUT);
         CASE_CODE(SC_ERR_RULE_INVALID_UTF8);
+        CASE_CODE(SC_ERR_SIGNAL);
 
         CASE_CODE (SC_ERR_MAX);
     }

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -367,6 +367,7 @@ typedef enum {
     SC_ERR_PLUGIN,
     SC_ERR_LOG_OUTPUT,
     SC_ERR_RULE_INVALID_UTF8,
+    SC_ERR_SIGNAL,
 
     SC_ERR_MAX
 } SCError;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -551,6 +551,11 @@ logging:
   # This value is overridden by the SC_LOG_OP_FILTER env var.
   default-output-filter:
 
+  # Requires libunwind to be available when Suricata is configured and built.
+  # If a signal unexpectedly terminates Suricata, displays a brief diagnostic
+  # message with the offending stacktrace if enabled.
+  #stacktrace-on-signal: on
+
   # Define your logging outputs.  If none are defined, or they are all
   # disabled you will get the default: console output.
   outputs:


### PR DESCRIPTION
Continuation of #6862

This PR adds stack trace logging when Suricata stops due to SIGABRT or SIGSEGV.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4973](https://redmine.openinfosecfoundation.org/issues/4973)

Describe changes:
- Cherry-pick commits for issue [4526](https://redmine.openinfosecfoundation.org/issues/4526)

Updates
- Rebase

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
