### PR TITLE
Feat/frames/v92

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -20,7 +20,7 @@ jobs:
     name: Formatting Check (clang 9)
     runs-on: ubuntu-20.04
     container: ubuntu:20.04
-    continue-on-error: true
+    continue-on-error: false
     steps:
 
       # Cache Rust stuff.

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -39,6 +39,10 @@ pub struct StreamSlice {
 }
 
 impl StreamSlice {
+    pub fn new(input: *const u8, input_len: u32, flags: u8, offset: u64) -> Self {
+        Self { input, input_len, flags, offset }
+    }
+
     pub fn is_gap(&self) -> bool {
         self.input.is_null() && self.input_len > 0
     }

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -271,7 +271,7 @@ const PARSER_NAME: &'static [u8] = b"sip\0";
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_sip_register_parser() {
-    let default_port = CString::new("5060").unwrap();
+    let default_port = CString::new("[5060,5061]").unwrap();
     let parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
         default_port: default_port.as_ptr(),

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -197,7 +197,7 @@ FramesContainer *AppLayerFramesGetContainer(Flow *f)
 FramesContainer *AppLayerFramesSetupContainer(Flow *f)
 {
 #ifdef UNITTESTS
-    if (f == NULL || f->alparser == NULL || f->protoctx == NULL)
+    if (f == NULL || f->alparser == NULL || (f->proto == IPPROTO_TCP && f->protoctx == NULL))
         return NULL;
 #endif
     DEBUG_VALIDATE_BUG_ON(f == NULL || f->alparser == NULL);

--- a/src/detect-frame.c
+++ b/src/detect-frame.c
@@ -47,8 +47,6 @@
 #include "util-spm.h"
 #include "util-print.h"
 
-static int DetectFrameSetup(DetectEngineCtx *, Signature *, const char *);
-
 /**
  * \brief this function setup the sticky buffer used in the rule
  *
@@ -59,7 +57,7 @@ static int DetectFrameSetup(DetectEngineCtx *, Signature *, const char *);
  * \retval 0  On success
  * \retval -1 On failure
  */
-static int DetectFrameSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)
+int DetectFrameSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
     char value[256] = "";
     strlcpy(value, str, sizeof(value));

--- a/src/detect-frame.h
+++ b/src/detect-frame.h
@@ -25,4 +25,6 @@
 /* Prototypes */
 void DetectFrameRegister(void);
 
+int DetectFrameSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str);
+
 #endif /* __DETECT_FRAME_H__ */

--- a/src/detect.c
+++ b/src/detect.c
@@ -145,6 +145,8 @@ static void DetectRun(ThreadVars *th_v,
                 DetectRunFrames(th_v, de_ctx, det_ctx, p, pflow, &scratch);
                 // PACKET_PROFILING_DETECT_END(p, PROF_DETECT_TX);
             }
+        } else if (p->proto == IPPROTO_UDP) {
+            DetectRunFrames(th_v, de_ctx, det_ctx, p, pflow, &scratch);
         }
 
         PACKET_PROFILING_DETECT_START(p, PROF_DETECT_TX);

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -574,6 +574,8 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
             StreamTcpPruneSession(p->flow, p->flowflags & FLOW_PKT_TOSERVER ?
                     STREAM_TOSERVER : STREAM_TOCLIENT);
             FLOWWORKER_PROFILING_END(p, PROFILE_FLOWWORKER_TCPPRUNE);
+        } else if (p->proto == IPPROTO_UDP) {
+            FramesPrune(p->flow, p);
         }
 
         /* run tx cleanup last */

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -592,27 +592,37 @@ static void AlertAddFiles(const Packet *p, JsonBuilder *jb, const uint64_t tx_id
 
 static void AlertAddFrame(const Packet *p, JsonBuilder *jb, const int64_t frame_id)
 {
-    if (p->flow == NULL || p->flow->protoctx == NULL)
+    if (p->flow == NULL || (p->proto == IPPROTO_TCP && p->flow->protoctx == NULL))
         return;
 
     FramesContainer *frames_container = AppLayerFramesGetContainer(p->flow);
     if (frames_container == NULL)
         return;
 
-    Frames *frames;
-    TcpSession *ssn = p->flow->protoctx;
-    TcpStream *stream;
-    if (PKT_IS_TOSERVER(p)) {
-        stream = &ssn->client;
-        frames = &frames_container->toserver;
-    } else {
-        stream = &ssn->server;
-        frames = &frames_container->toclient;
+    Frames *frames = NULL;
+    TcpStream *stream = NULL;
+    if (p->proto == IPPROTO_TCP) {
+        TcpSession *ssn = p->flow->protoctx;
+        if (PKT_IS_TOSERVER(p)) {
+            stream = &ssn->client;
+            frames = &frames_container->toserver;
+        } else {
+            stream = &ssn->server;
+            frames = &frames_container->toclient;
+        }
+    } else if (p->proto == IPPROTO_UDP) {
+        if (PKT_IS_TOSERVER(p)) {
+            frames = &frames_container->toserver;
+        } else {
+            frames = &frames_container->toclient;
+        }
     }
 
-    Frame *frame = FrameGetById(frames, frame_id);
-    if (frame != NULL) {
-        FrameJsonLogOneFrame(frame, p->flow, stream, p, jb);
+    if (frames) {
+        Frame *frame = FrameGetById(frames, frame_id);
+        if (frame != NULL) {
+            FrameJsonLogOneFrame(frame, p->flow, stream, p, jb);
+        }
     }
 }
 

--- a/src/output-json-frame.c
+++ b/src/output-json-frame.c
@@ -126,7 +126,7 @@ static void PayloadAsHex(const uint8_t *data, uint32_t data_len, char *str, size
 }
 #endif
 
-static void FrameAddPayload(JsonBuilder *js, const TcpStream *stream, const Frame *frame)
+static void FrameAddPayloadTCP(JsonBuilder *js, const TcpStream *stream, const Frame *frame)
 {
     uint32_t sb_data_len = 0;
     const uint8_t *data = NULL;
@@ -178,43 +178,121 @@ static void FrameAddPayload(JsonBuilder *js, const TcpStream *stream, const Fram
 #endif
 }
 
+static void FrameAddPayloadUDP(JsonBuilder *js, const Packet *p, const Frame *frame)
+{
+    DEBUG_VALIDATE_BUG_ON(frame->rel_offset >= p->payload_len);
+    if (frame->rel_offset >= p->payload_len)
+        return;
+
+    int frame_len = frame->len != -1 ? frame->len : p->payload_len - frame->rel_offset;
+
+    if (frame->rel_offset + frame_len > p->payload_len) {
+        frame_len = p->payload_len - frame->rel_offset;
+        JB_SET_FALSE(js, "complete");
+    } else {
+        JB_SET_TRUE(js, "complete");
+    }
+    const uint8_t *data = p->payload + frame->rel_offset;
+    const uint32_t data_len = frame_len;
+
+    const uint32_t log_data_len = MIN(data_len, 256);
+    jb_set_base64(js, "payload", data, log_data_len);
+
+    uint8_t printable_buf[log_data_len + 1];
+    uint32_t o = 0;
+    PrintStringsToBuffer(printable_buf, &o, log_data_len + 1, data, log_data_len);
+    printable_buf[log_data_len] = '\0';
+    jb_set_string(js, "payload_printable", (char *)printable_buf);
+#if 0
+    char pretty_buf[data_len * 4 + 1];
+    pretty_buf[0] = '\0';
+    PayloadAsHex(data, data_len, pretty_buf, data_len * 4 + 1);
+    jb_set_string(js, "payload_hex", pretty_buf);
+#endif
+}
+
 // TODO separate between stream_offset and frame_offset
 void FrameJsonLogOneFrame(const Frame *frame, const Flow *f, const TcpStream *stream,
         const Packet *p, JsonBuilder *jb)
 {
-    int64_t abs_offset = frame->rel_offset + (int64_t)STREAM_BASE_OFFSET(stream);
-
     jb_open_object(jb, "frame");
     jb_set_string(jb, "type", AppLayerParserGetFrameNameById(f->proto, f->alproto, frame->type));
     jb_set_uint(jb, "id", frame->id);
-    jb_set_uint(jb, "stream_offset", (uint64_t)abs_offset);
+    jb_set_string(jb, "direction", PKT_IS_TOSERVER(p) ? "toserver" : "toclient");
 
-    if (frame->len < 0) {
-        uint64_t usable = StreamTcpGetUsable(stream, true);
-        uint64_t len = usable - abs_offset;
-        jb_set_uint(jb, "length", len);
+    if (f->proto == IPPROTO_TCP) {
+        int64_t abs_offset = frame->rel_offset + (int64_t)STREAM_BASE_OFFSET(stream);
+        jb_set_uint(jb, "stream_offset", (uint64_t)abs_offset);
+
+        if (f->proto == IPPROTO_TCP && frame->len < 0) {
+            uint64_t usable = StreamTcpGetUsable(stream, true);
+            uint64_t len = usable - abs_offset;
+            jb_set_uint(jb, "length", len);
+        } else {
+            jb_set_uint(jb, "length", frame->len);
+        }
+        FrameAddPayloadTCP(jb, stream, frame);
     } else {
         jb_set_uint(jb, "length", frame->len);
+        FrameAddPayloadUDP(jb, p, frame);
     }
-    jb_set_string(jb, "direction", PKT_IS_TOSERVER(p) ? "toserver" : "toclient");
     if (frame->flags & FRAME_FLAG_TX_ID_SET) {
         jb_set_uint(jb, "tx_id", frame->tx_id);
     }
-    FrameAddPayload(jb, stream, frame);
     jb_close(jb);
+}
+
+static int FrameJsonUdp(
+        JsonFrameLogThread *aft, const Packet *p, Flow *f, FramesContainer *frames_container)
+{
+    FrameJsonOutputCtx *json_output_ctx = aft->json_output_ctx;
+
+    Frames *frames;
+    if (PKT_IS_TOSERVER(p)) {
+        frames = &frames_container->toserver;
+    } else {
+        frames = &frames_container->toclient;
+    }
+
+    for (uint32_t idx = 0; idx < frames->cnt; idx++) {
+        Frame *frame = FrameGetByIndex(frames, idx);
+        if (frame == NULL || frame->flags & FRAME_FLAG_LOGGED)
+            continue;
+
+        /* First initialize the address info (5-tuple). */
+        JsonAddrInfo addr = json_addr_info_zero;
+        JsonAddrInfoInit(p, LOG_DIR_PACKET, &addr);
+
+        JsonBuilder *jb =
+                CreateEveHeader(p, LOG_DIR_PACKET, "frame", &addr, json_output_ctx->eve_ctx);
+        if (unlikely(jb == NULL))
+            return TM_ECODE_OK;
+
+        jb_set_string(jb, "app_proto", AppProtoToString(f->alproto));
+        FrameJsonLogOneFrame(frame, p->flow, NULL, p, jb);
+        OutputJsonBuilderBuffer(jb, aft->ctx);
+        jb_free(jb);
+        frame->flags |= FRAME_FLAG_LOGGED;
+    }
+    return TM_ECODE_OK;
 }
 
 static int FrameJson(ThreadVars *tv, JsonFrameLogThread *aft, const Packet *p)
 {
     FrameJsonOutputCtx *json_output_ctx = aft->json_output_ctx;
 
-    BUG_ON(p->proto != IPPROTO_TCP);
     BUG_ON(p->flow == NULL);
-    BUG_ON(p->flow->protoctx == NULL);
 
     FramesContainer *frames_container = AppLayerFramesGetContainer(p->flow);
     if (frames_container == NULL)
         return TM_ECODE_OK;
+
+    if (p->proto == IPPROTO_UDP) {
+        return FrameJsonUdp(aft, p, p->flow, frames_container);
+    }
+
+    BUG_ON(p->proto != IPPROTO_TCP);
+    BUG_ON(p->flow->protoctx == NULL);
 
     /* TODO can we set these EOF flags once per packet? We have them in detect, tx, file, filedata,
      * etc */
@@ -288,7 +366,7 @@ static int JsonFrameLogCondition(ThreadVars *tv, const Packet *p)
     if (p->flow == NULL || p->flow->alproto == ALPROTO_UNKNOWN)
         return FALSE;
 
-    if (p->proto == IPPROTO_TCP && p->flow->alparser != NULL) {
+    if ((p->proto == IPPROTO_TCP || p->proto == IPPROTO_UDP) && p->flow->alparser != NULL) {
         FramesContainer *frames_container = AppLayerFramesGetContainer(p->flow);
         if (frames_container == NULL)
             return FALSE;


### PR DESCRIPTION
UDP frames
SIP/UDP frames implementation

For discussion: https://github.com/OISF/suricata/commit/1851eb4535f6993b3bb111b1c405525c52437483

This allows to use frames directly in rules, so instead of:
```
alert udp ... (frames:sip.request_line; content:"REGISTER"; ...)
alert sip ... (frames:request_line; content:"REGISTER"; ...)
```
one can do
```
alert sip ... (request_line; content:"REGISTER"; ...)
```

suricata-verify-pr: 701

replaces #6913: rebase, formatting check update