### PR TITLE
flow: fix timestamp in pseudo packet setup

### DIFF
--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -246,8 +246,7 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(Packet *p,
                                               (uint16_t *)p->tcph, 20, 0);
     }
 
-    memset(&p->ts, 0, sizeof(struct timeval));
-    TimeGet(&p->ts);
+    p->ts = f->lastts;
 
     if (direction == 0) {
         if (f->alparser && !STREAM_HAS_SEEN_DATA(&ssn->client)) {


### PR DESCRIPTION
When Suricata was creating a pseudo packet for flow cleaning
purpose, it was using the timestamp of first packet of the pcap
file when running in pcap mode.

As a result, the timestamp of events triggered during this
flow cleaning phase were completely wrong. As they did often occurs
before the start of the flow itself.

This patch fix this by using flow lastts as timestamp of the packet.
If this is not exact, this is at least really close to reality.

In the case of live traffic, this is also correct as TimeGet function
will get the time when the callback is run which can differ a lot
from the time of the event (which is before timestamp of last seen
packet).

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5037

Describe changes:
- Use lastts for pseudo packet timestamp