### PR TITLE
fix krb5_msg_type: Unable to detect AS-REQ, TGS-REQ and KRB-ERROR v2

### DIFF
--- a/doc/userguide/rules/kerberos-keywords.rst
+++ b/doc/userguide/rules/kerberos-keywords.rst
@@ -4,25 +4,31 @@ Kerberos Keywords
 krb5_msg_type
 -------------
 
-Kerberos message type (integer).
-
-Values are defined in RFC4120. Common values are
+This keyword allows to match the Kerberos messages by its type (integer).
+It is possible to specify the following values defined in RFC4120:
 
 * 10 (AS-REQ)
 * 11 (AS-REP)
 * 12 (TGS-REQ)
 * 13 (TGS-REP)
-* 14 (AP-REQ)
-* 15 (AP-REP)
 * 30 (ERROR)
 
 Syntax::
 
  krb5_msg_type:<number>
 
-Signature example::
+Signature examples::
 
  alert krb5 any any -> any any (msg:"Kerberos 5 AS-REQ message"; krb5_msg_type:10; sid:3; rev:1;)
+ alert krb5 any any -> any any (msg:"Kerberos 5 AS-REP message"; krb5_msg_type:11; sid:4; rev:1;)
+ alert krb5 any any -> any any (msg:"Kerberos 5 TGS-REQ message"; krb5_msg_type:12; sid:5; rev:1;)
+ alert krb5 any any -> any any (msg:"Kerberos 5 TGS-REP message"; krb5_msg_type:13; sid:6; rev:1;)
+ alert krb5 any any -> any any (msg:"Kerberos 5 ERROR message"; krb5_msg_type:30; sid:7; rev:1;)
+
+
+.. note:: AP-REQ and AP-REP are not currently supported since those messages
+          are embedded in other application protocols.
+
 
 krb5_cname
 ----------

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -117,6 +117,16 @@ impl KRB5State {
                 if hdr.class != BerClass::Application { return 0; }
                 match hdr.tag.0 {
                     10 => {
+                        let req = krb5_parser::parse_as_req(i);
+                        if let Ok((_,kdc_req)) = req {
+                            let mut tx = self.new_tx();
+                            tx.msg_type = MessageType::KRB_AS_REQ;
+                            tx.cname = kdc_req.req_body.cname;
+                            tx.realm = Some(kdc_req.req_body.realm);
+                            tx.sname = kdc_req.req_body.sname;
+                            tx.etype = None;
+                            self.transactions.push(tx);
+                        };
                         self.req_id = 10;
                     },
                     11 => {

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -138,6 +138,8 @@ impl KRB5State {
                             let mut tx = self.new_tx();
                             tx.msg_type = MessageType::KRB_AS_REP;
                             if self.req_id > 0 {
+                                // set request type only if previous message
+                                // was a request
                                 tx.req_type = Some(MessageType(self.req_id.into()));
                             }
                             tx.cname = Some(kdc_rep.cname);
@@ -170,6 +172,8 @@ impl KRB5State {
                             let mut tx = self.new_tx();
                             tx.msg_type = MessageType::KRB_TGS_REP;
                             if self.req_id > 0 {
+                                // set request type only if previous message
+                                // was a request
                                 tx.req_type = Some(MessageType(self.req_id.into()));
                             }
                             tx.cname = Some(kdc_rep.cname);
@@ -194,6 +198,8 @@ impl KRB5State {
                         if let Ok((_,error)) = res {
                             let mut tx = self.new_tx();
                             if self.req_id > 0 {
+                                // set request type only if previous message
+                                // was a request
                                 tx.req_type = Some(MessageType(self.req_id.into()));
                             }
                             tx.msg_type = MessageType::KRB_ERROR;

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -184,7 +184,7 @@ impl KRB5State {
                         let res = krb5_parser::parse_krb_error(i);
                         if let Ok((_,error)) = res {
                             let mut tx = self.new_tx();
-                            tx.msg_type = MessageType(self.req_id as u32);
+                            tx.msg_type = MessageType::KRB_ERROR;
                             tx.cname = error.cname;
                             tx.realm = error.crealm;
                             tx.sname = Some(error.sname);

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -74,6 +74,9 @@ pub struct KRB5Transaction {
     /// Error code, if request has failed
     pub error_code: Option<ErrorCode>,
 
+    /// Message type of request. For using in responses.
+    pub req_type: Option<MessageType>,
+
     /// The internal transaction id
     id: u64,
 
@@ -134,6 +137,9 @@ impl KRB5State {
                         if let Ok((_,kdc_rep)) = res {
                             let mut tx = self.new_tx();
                             tx.msg_type = MessageType::KRB_AS_REP;
+                            if self.req_id > 0 {
+                                tx.req_type = Some(MessageType(self.req_id.into()));
+                            }
                             tx.cname = Some(kdc_rep.cname);
                             tx.realm = Some(kdc_rep.crealm);
                             tx.sname = Some(kdc_rep.ticket.sname);
@@ -163,6 +169,9 @@ impl KRB5State {
                         if let Ok((_,kdc_rep)) = res {
                             let mut tx = self.new_tx();
                             tx.msg_type = MessageType::KRB_TGS_REP;
+                            if self.req_id > 0 {
+                                tx.req_type = Some(MessageType(self.req_id.into()));
+                            }
                             tx.cname = Some(kdc_rep.cname);
                             tx.realm = Some(kdc_rep.crealm);
                             tx.sname = Some(kdc_rep.ticket.sname);
@@ -184,6 +193,9 @@ impl KRB5State {
                         let res = krb5_parser::parse_krb_error(i);
                         if let Ok((_,error)) = res {
                             let mut tx = self.new_tx();
+                            if self.req_id > 0 {
+                                tx.req_type = Some(MessageType(self.req_id.into()));
+                            }
                             tx.msg_type = MessageType::KRB_ERROR;
                             tx.cname = error.cname;
                             tx.realm = error.crealm;
@@ -250,6 +262,7 @@ impl KRB5Transaction {
             sname: None,
             etype: None,
             error_code: None,
+            req_type: None,
             id: id,
             tx_data: applayer::AppLayerTxData::new(),
         }

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -146,6 +146,16 @@ impl KRB5State {
                         self.req_id = 0;
                     },
                     12 => {
+                        let req = krb5_parser::parse_tgs_req(i);
+                        if let Ok((_,kdc_req)) = req {
+                            let mut tx = self.new_tx();
+                            tx.msg_type = MessageType::KRB_TGS_REQ;
+                            tx.cname = kdc_req.req_body.cname;
+                            tx.realm = Some(kdc_req.req_body.realm);
+                            tx.sname = kdc_req.req_body.sname;
+                            tx.etype = None;
+                            self.transactions.push(tx);
+                        };
                         self.req_id = 12;
                     },
                     13 => {

--- a/rust/src/krb/log.rs
+++ b/rust/src/krb/log.rs
@@ -28,6 +28,9 @@ fn krb5_log_response(jsb: &mut JsonBuilder, tx: &mut KRB5Transaction) -> Result<
             if let Some(req_type) = tx.req_type {
                 jsb.set_string("failed_request", &format!("{:?}", req_type))?;
             } else {
+                // In case we capture the response but not the request
+                // we can't know the failed request type, since it could be
+                // AS-REQ or TGS-REQ
                 jsb.set_string("failed_request", "UNKNOWN")?;
             }
             jsb.set_string("error_code", &format!("{:?}", c))?;

--- a/rust/src/krb/log.rs
+++ b/rust/src/krb/log.rs
@@ -24,8 +24,12 @@ fn krb5_log_response(jsb: &mut JsonBuilder, tx: &mut KRB5Transaction) -> Result<
 {
     match tx.error_code {
         Some(c) => {
-            jsb.set_string("msg_type", "KRB_ERROR")?;
-            jsb.set_string("failed_request", &format!("{:?}", tx.msg_type))?;
+            jsb.set_string("msg_type", &format!("{:?}", tx.msg_type))?;
+            if let Some(req_type) = tx.req_type {
+                jsb.set_string("failed_request", &format!("{:?}", req_type))?;
+            } else {
+                jsb.set_string("failed_request", "UNKNOWN")?;
+            }
             jsb.set_string("error_code", &format!("{:?}", c))?;
         },
         None    => { jsb.set_string("msg_type", &format!("{:?}", tx.msg_type))?; },


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4529

Previous PR: https://github.com/OISF/suricata/pull/6508
Related SV test: https://github.com/OISF/suricata-verify/pull/572

The problem is that the krb5_msg_type doesn't trigger properly for:
- AS-REQ (krb5_msg_type: 10): This rule matches the KRB-ERROR message that follows an AS-REQ, which is not the expected behaviour. 
- TGS-REQ (krb5_msg_type: 12): Same behaviour as AS-REQ.
-  KRB-ERROR (krb5_msg_type: 30) It's not triggered at all.

To solve the problem the following actions were taken in `KRB5State.parse`:
- Add transaction when parsing AS-REQ message
- Add transaction when parsing TGS-REQ message
- Change the message type of KRB-ERROR to MessageType::KRB_ERROR

suricata-verify-pr: 572