### PR TITLE
Doc: Fix another typo in documentation of suricata.yaml

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1070,7 +1070,7 @@ parsers that do file extraction.
 
 Inspection of reassembled data is done in chunks. The size of these
 chunks is set with ``toserver_chunk_size`` and ``toclient_chunk_size``.
-To avoid making the borders predictable, the sizes van be varied by
+To avoid making the borders predictable, the sizes can be varied by
 adding in a random factor.
 
 ::


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
Not applicable, since this is just a minor typo fix.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: Not applicable, since this is just a minor typo fix.

Describe changes:
- Fix another typo in documentation of suricata.yaml ([10.1.12.3](https://suricata.readthedocs.io/en/latest/configuration/suricata-yaml.html?highlight=van#stream-engine)).

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:

Please tell me if I should accumulate further typos or minor doc fixes and hand them in together.

Thanks for merging :)