### PR TITLE
nfs/ Implement Frames v1

### DIFF
--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -26,6 +26,7 @@ use nom7::{Err, Needed};
 
 use crate::applayer;
 use crate::applayer::*;
+use crate::frames::*;
 use crate::core::*;
 use crate::conf::*;
 use crate::filetracker::*;
@@ -85,6 +86,19 @@ static mut ALPROTO_NFS: AppProto = ALPROTO_UNKNOWN;
  * Transaction lookup.
  */
 
+#[derive(AppLayerFrameType)]
+pub enum NFSFrameType {
+    RPCPdu,
+    RPCHdr,
+    RPCData,
+    NFSPdu,
+    NFSStatus,
+    NFS4Pdu,
+    NFS4Tag,
+    NFS4Ops,
+    NFS4Status,
+}
+
 #[repr(u32)]
 pub enum NFSEvent {
     MalformedData = 0,
@@ -102,7 +116,6 @@ impl NFSEvent {
         }
     }
 }
-
 
 #[derive(Debug)]
 pub enum NFSTransactionTypeData {
@@ -438,6 +451,113 @@ impl NFSState {
         }
     }
 
+    fn add_rpc_udp_ts_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], rpc_udp_len: i64) -> (Option<Frame>, Option<Frame>, Option<Frame>) {
+        let rpc_udp_ts_pdu = Frame::new_ts(flow, stream_slice, input, rpc_udp_len, NFSFrameType::RPCPdu as u8);
+        let rpc_udp_ts_hdr = Frame::new_ts(flow, stream_slice, input, 8, NFSFrameType::RPCHdr as u8);
+        let rpc_udp_ts_data = Frame::new_ts(flow, stream_slice, &input[8..], rpc_udp_len - 8, NFSFrameType::RPCData as u8);
+        SCLogDebug!("RPC UDP To Server Frames:\n{:?}\n{:?}\n{:?}", rpc_udp_ts_pdu, rpc_udp_ts_hdr, rpc_udp_ts_data);
+
+        // SCLogNotice!("rpc_udp_ts_pdu: {:?}\nrpc_udp_ts_pdu len: {:?}", input, input.len());
+        // SCLogNotice!("rpc_udp_ts_hdr: {:?}", &input[..8]);
+        // SCLogNotice!("rpc_udp_ts_data: {:?}", &input[8..]);
+
+        (rpc_udp_ts_pdu, rpc_udp_ts_hdr, rpc_udp_ts_data)
+    }
+
+    fn add_rpc_tcp_ts_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], rpc_tcp_len: i64) -> (Option<Frame>, Option<Frame>, Option<Frame>) {
+        let rpc_tcp_pdu = Frame::new_ts(flow, stream_slice, input, rpc_tcp_len, NFSFrameType::RPCPdu as u8);
+        let rpc_tcp_hdr = Frame::new_ts(flow, stream_slice, input, 12, NFSFrameType::RPCHdr as u8);
+        let rpc_tcp_data = Frame::new_ts(flow, stream_slice, &input[12..], rpc_tcp_len - 12, NFSFrameType::RPCData as u8);
+        SCLogNotice!("RPC TCP ts Frames\n{:?}\n{:?}\n{:?}", rpc_tcp_pdu, rpc_tcp_hdr, rpc_tcp_data);
+        SCLogNotice!("rpc_request_pdu: {:?}\nRPC Request Pdu Len {:?}", input, input.len());
+        SCLogNotice!("rpc_request_hdr: {:?}", &input[..12]);
+        SCLogNotice!("rpc_request_data: {:?}\nRPC Request Data Buffer len {:?}", &input[12..], input.len() - 12);
+        (rpc_tcp_pdu, rpc_tcp_hdr, rpc_tcp_data)
+    }
+
+    // should we add a NULL record check?
+    fn add_nfs_ts_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nfs_req_len: i64) -> Option<Frame> {
+        let nfs_ts_pdu = Frame::new_ts(flow, stream_slice, input, nfs_req_len, NFSFrameType::NFSPdu as u8);
+        SCLogNotice!("NFS Request Frame {:?}", nfs_ts_pdu);
+        SCLogNotice!("NFS Request Buffer {:?}\nNFS Request Buffer len {:?}", input, input.len());
+        nfs_ts_pdu
+    }
+
+    fn add_nfs4_ts_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nfs4_req_len: i64) -> Option<Frame> {
+        let nfs4_ts_pdu = Frame::new_ts(flow, stream_slice, input, nfs4_req_len, NFSFrameType::NFS4Pdu as u8);
+        SCLogDebug!("NFS4 Request Frame: {:?}", nfs4_ts_pdu);
+        SCLogNotice!("NFS4 Request Buffer: {:?}\nNFS4 Request Buffer len {:?}", input, input.len());
+        nfs4_ts_pdu
+    }
+
+    fn add_nfs4_ts_tag_ops_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nfs4_req_len: i64) {
+        if nfs4_req_len > 0 {
+            let _nfs4_ts_tag = Frame::new_ts(flow, stream_slice, input, 8, NFSFrameType::NFS4Tag as u8);
+            let _nfs4_ts_ops = Frame::new_ts(flow, stream_slice, &input[8..], nfs4_req_len - 8, NFSFrameType::NFS4Ops as u8);
+            SCLogDebug!("NFS4 Tag Frame {:?}\n NFS4 Ops Frame {:?}", nfs4_ts_tag, nfs4_ts_ops);
+            // SCLogNotice!("NFS4 Tag Buffer {:?}", &input[..8]);
+            // SCLogNotice!("NFS4 Ops Buffer {:?}\nNFS4 Ops Buffer len {:?}", &input[8..], &input[8..].len());
+        }
+    }
+
+    fn add_rpc_udp_tc_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], rpc_udp_len: i64) -> (Option<Frame>, Option<Frame>, Option<Frame>) {
+        let rpc_udp_tc_pdu = Frame::new_ts(flow, stream_slice, input, rpc_udp_len, NFSFrameType::RPCPdu as u8);
+        let rpc_udp_tc_hdr = Frame::new_ts(flow, stream_slice, input, 8, NFSFrameType::RPCHdr as u8);
+        let rpc_udp_tc_data = Frame::new_ts(flow, stream_slice, &input[8..], rpc_udp_len - 8, NFSFrameType::RPCData as u8);
+        // SCLogNotice!("rpc_udp_tc_pdu: {:?}\nrpc_udp_tc_pdu len: {:?}", input, input.len());
+        // SCLogNotice!("rpc_udp_tc_hdr: {:?}", &input[..8]);
+        // SCLogNotice!("rpc_udp_tc_data: {:?}", &input[8..]);
+        SCLogDebug!("RPC UDP To Client Frames:\n{:?}\n{:?}\n{:?}", rpc_udp_tc_pdu, rpc_udp_tc_hdr, rpc_udp_tc_data);
+        (rpc_udp_tc_pdu, rpc_udp_tc_hdr, rpc_udp_tc_data)
+    }
+
+    fn add_rpc_tcp_tc_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], rpc_tcp_len: i64) -> (Option<Frame>, Option<Frame>, Option<Frame>) {
+        let rpc_tcp_tc_pdu = Frame::new_tc(flow, stream_slice, input, rpc_tcp_len, NFSFrameType::RPCPdu as u8);
+        let rpc_tcp_tc_hdr = Frame::new_tc(flow, stream_slice, input, 12, NFSFrameType::RPCHdr as u8);
+        let rpc_tcp_tc_data = Frame::new_tc(flow, stream_slice, &input[12..], rpc_tcp_len - 12, NFSFrameType::RPCData as u8);
+        SCLogDebug!("RPC TCP To Client Frames\n{:?}\n{:?}\n{:?}", rpc_tcp_tc_pdu, rpc_tcp_tc_hdr, rpc_tcp_tc_data);
+        // SCLogNotice!("rpc_response_pdu {:?}\nRPC Response Pdu Len {:?}", input, input.len());
+        // SCLogNotice!("rpc_response_hdr {:?}", &input[..12]);
+        // SCLogNotice!("rpc_response_data {:?}\nRPC Response Data Buffer len {:?}", &input[12..], input.len() - 12);
+        (rpc_tcp_tc_pdu, rpc_tcp_tc_hdr, rpc_tcp_tc_data)
+    }
+
+    fn add_nfs_tc_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nfs_res_len: i64) -> Option<Frame> {
+        let nfs_tc_pdu = Frame::new_tc(flow, stream_slice, input, nfs_res_len, NFSFrameType::NFSPdu as u8);
+        if nfs_res_len > 0 {
+            let _nfs_tc_status = Frame::new_tc(flow, stream_slice, input, 4, NFSFrameType::NFSStatus as u8);
+            SCLogDebug!("NFS Response Status {:?}", nfs_tc_status);
+            // SCLogNotice!("NFS Response Status {:?}", &input[..4]);
+        }
+        SCLogDebug!("NFS Response Frame {:?}", nfs_tc_pdu);
+        // SCLogNotice!("NFS Response Buffer {:?}\nNFS Response Buffer len {:?}", input, input.len());
+        nfs_tc_pdu
+    }
+
+    fn add_nfs4_tc_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nfs4_res_len: i64) -> Option<Frame> {
+        let nfs4_tc_pdu = Frame::new_tc(flow, stream_slice, input, nfs4_res_len, NFSFrameType::NFS4Pdu as u8);
+        if nfs4_res_len > 0 {
+            let _nfs4_tc_status = Frame::new_tc(flow, stream_slice, input, 4, NFSFrameType::NFS4Status as u8);
+            SCLogDebug!("NFS4 Response Status {:?}", nfs4_tc_status);
+            // SCLogNotice!("NFS4 Response Status {:?}", &input[..4]);
+        }
+        // SCLogNotice!("NFS4 Response Pdu Buffer {:?}\nNFS4 Response Buffer len {:?}", input, input.len());
+        nfs4_tc_pdu
+    }
+
+    fn add_nfs4_tc_tag_ops_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nfs4_req_len: i64) {
+        if nfs4_req_len > 0 {
+            let _nfs4_tc_status = Frame::new_tc(flow, stream_slice, input, 4, NFSFrameType::NFS4Status as u8);
+            let _nfs4_tc_tag = Frame::new_tc(flow, stream_slice, &input[4..], 8, NFSFrameType::NFS4Tag as u8);
+            let _nfs4_tc_ops = Frame::new_tc(flow, stream_slice, &input[12..], nfs4_req_len - 12, NFSFrameType::NFS4Ops as u8);
+            SCLogDebug!("NFS4 Status Frame {:?}", nfs4_tc_status);
+            SCLogDebug!("NFS4 Tag Frame {:?}", nfs4_tc_tag);
+            SCLogDebug!("NFS4 Ops Frame {:?}", nfs4_tc_ops);
+            // SCLogNotice!("NFS4 Status Buffer {:?}", &input[..4]);
+            // SCLogNotice!("NFS4 Tag Buffer {:?}", &input[..8]);
+            // SCLogNotice!("NFS4 Ops Buffer {:?}\nNFS4 Ops Buffer len {:?}", &input[8..], &input[8..].len());
+        }
+    }
     fn post_gap_housekeeping_for_files(&mut self)
     {
         let mut post_gap_txs = false;
@@ -531,18 +651,22 @@ impl NFSState {
     }
 
     /// complete request record
-    fn process_request_record<'b>(&mut self, r: &RpcPacket<'b>) {
+    fn process_request_record<'b>(&mut self, flow: *const Flow, stream_slice: &StreamSlice, r: &RpcPacket<'b>) {
         SCLogDebug!("REQUEST {} procedure {} ({}) blob size {}",
                 r.hdr.xid, r.procedure, self.requestmap.len(), r.prog_data.len());
 
         match r.progver {
             4 => {
+                self.add_nfs4_ts_pdu_frame(flow, stream_slice, r.prog_data, r.prog_data.len() as i64);
+                self.add_nfs4_ts_tag_ops_frame(flow, stream_slice, r.prog_data, r.prog_data.len() as i64);
                 self.process_request_record_v4(r)
             },
             3 => {
+                self.add_nfs_ts_frame(flow, stream_slice, r.prog_data, r.prog_data.len() as i64);
                 self.process_request_record_v3(r)
             },
             2 => {
+                self.add_nfs_ts_frame(flow, stream_slice, r.prog_data, r.prog_data.len() as i64); // no pcap to back this
                 self.process_request_record_v2(r)
             },
             _ => { },
@@ -666,7 +790,7 @@ impl NFSState {
         return self.process_write_record(r, w);
     }
 
-    fn process_reply_record<'b>(&mut self, r: &RpcReplyPacket<'b>) -> u32 {
+    fn process_reply_record<'b>(&mut self, flow: *const Flow, stream_slice: &StreamSlice, r: &RpcReplyPacket<'b>) -> u32 {
         let mut xidmap;
         match self.requestmap.remove(&r.hdr.xid) {
             Some(p) => { xidmap = p; },
@@ -689,16 +813,20 @@ impl NFSState {
         match xidmap.progver {
             2 => {
                 SCLogDebug!("NFSv2 reply record");
+                self.add_nfs_tc_frames(flow, stream_slice, r.prog_data, r.prog_data.len() as i64);
                 self.process_reply_record_v2(r, &xidmap);
                 return 0;
             },
             3 => {
                 SCLogDebug!("NFSv3 reply record");
+                self.add_nfs_tc_frames(flow, stream_slice, r.prog_data, r.prog_data.len() as i64);
                 self.process_reply_record_v3(r, &mut xidmap);
                 return 0;
             },
             4 => {
                 SCLogDebug!("NFSv4 reply record");
+                self.add_nfs4_tc_frames(flow, stream_slice, r.prog_data, r.prog_data.len() as i64);
+                self.add_nfs4_tc_tag_ops_frame(flow, stream_slice, r.prog_data, r.prog_data.len() as i64);
                 self.process_reply_record_v4(r, &mut xidmap);
                 return 0;
             },
@@ -985,8 +1113,8 @@ impl NFSState {
     }
 
     /// Parsing function, handling TCP chunks fragmentation
-    pub fn parse_tcp_data_ts<'b>(&mut self, i: &'b[u8]) -> AppLayerResult {
-        let mut cur_i = i;
+    pub fn parse_tcp_data_ts<'b>(&mut self, flow: *const Flow, stream_slice: &StreamSlice) -> AppLayerResult {
+        let mut cur_i = stream_slice.as_slice();
         // take care of in progress file chunk transfers
         // and skip buffer beyond it
         let consumed = self.filetracker_update(Direction::ToServer, cur_i, 0);
@@ -1014,7 +1142,7 @@ impl NFSState {
                     0 => {
                         SCLogDebug!("incomplete, queue and retry with the next block (input {}). Looped {} times.",
                                 cur_i.len(), _cnt);
-                        return AppLayerResult::incomplete((i.len() - cur_i.len()) as u32, (cur_i.len() + 1) as u32);
+                        return AppLayerResult::incomplete(stream_slice.len() - cur_i.len() as u32, (cur_i.len() + 1) as u32);
                     },
                     -1 => {
                         cur_i = &cur_i[1..];
@@ -1050,6 +1178,7 @@ impl NFSState {
 
                                 // lets try to parse the RPC record. Might fail with Incomplete.
                                 match parse_rpc(cur_i) {
+// should we set an event here???
                                     Ok((remaining, ref rpc_record)) => {
                                         match parse_nfs3_request_write(rpc_record.prog_data) {
                                             Ok((_, ref nfs_request_write)) => {
@@ -1083,15 +1212,17 @@ impl NFSState {
                         // but lower than the record size
                         let n1 = cmp::max(cur_i.len(), 1024);
                         let n2 = cmp::min(n1, rec_size);
-                        return AppLayerResult::incomplete((i.len() - cur_i.len()) as u32, n2 as u32);
+                        return AppLayerResult::incomplete(stream_slice.len() - cur_i.len() as u32, n2 as u32);
                     }
 
                     // we have the full records size worth of data,
                     // let's parse it
                     match parse_rpc(&cur_i[..rec_size]) {
                         Ok((_, ref rpc_record)) => {
+                            self.add_rpc_tcp_ts_frames(flow, stream_slice, cur_i, cur_i.len() as i64);
+
                             cur_i = &cur_i[rec_size..];
-                            self.process_request_record(rpc_record);
+                            self.process_request_record(flow, stream_slice, rpc_record);
                         },
                         Err(Err::Incomplete(_)) => {
                             cur_i = &cur_i[rec_size..]; // progress input past parsed record
@@ -1116,7 +1247,7 @@ impl NFSState {
                         // looks for.
                         let n = usize::from(n);
                         let need = if n > 28 { n } else { 28 };
-                        return AppLayerResult::incomplete((i.len() - cur_i.len()) as u32, need as u32);
+                        return AppLayerResult::incomplete(stream_slice.len() - cur_i.len() as u32, need as u32);
                     }
                     return AppLayerResult::err();
                 },
@@ -1139,8 +1270,8 @@ impl NFSState {
     }
 
     /// Parsing function, handling TCP chunks fragmentation
-    pub fn parse_tcp_data_tc<'b>(&mut self, i: &'b[u8]) -> AppLayerResult {
-        let mut cur_i = i;
+    pub fn parse_tcp_data_tc<'b>(&mut self, flow: *const Flow, stream_slice: &StreamSlice) -> AppLayerResult {
+        let mut cur_i = stream_slice.as_slice();
         // take care of in progress file chunk transfers
         // and skip buffer beyond it
         let consumed = self.filetracker_update(Direction::ToClient, cur_i, 0);
@@ -1168,7 +1299,7 @@ impl NFSState {
                     0 => {
                         SCLogDebug!("incomplete, queue and retry with the next block (input {}). Looped {} times.",
                                 cur_i.len(), _cnt);
-                        return AppLayerResult::incomplete((i.len() - cur_i.len()) as u32, (cur_i.len() + 1) as u32);
+                        return AppLayerResult::incomplete(stream_slice.len() - cur_i.len() as u32, (cur_i.len() + 1) as u32);
                     },
                     -1 => {
                         cur_i = &cur_i[1..];
@@ -1237,14 +1368,16 @@ impl NFSState {
                         // but lower than the record size
                         let n1 = cmp::max(cur_i.len(), 1024);
                         let n2 = cmp::min(n1, rec_size);
-                        return AppLayerResult::incomplete((i.len() - cur_i.len()) as u32, n2 as u32);
+                        return AppLayerResult::incomplete(stream_slice.len() - cur_i.len() as u32, n2 as u32);
                     }
 
                     // we have the full data of the record, lets parse
                     match parse_rpc_reply(&cur_i[..rec_size]) {
                         Ok((_, ref rpc_record)) => {
+                            self.add_rpc_tcp_tc_frames(flow, stream_slice, cur_i, cur_i.len() as i64);
+
                             cur_i = &cur_i[rec_size..]; // progress input past parsed record
-                            self.process_reply_record(rpc_record);
+                            self.process_reply_record(flow, stream_slice, rpc_record);
                         },
                         Err(Err::Incomplete(_)) => {
                             cur_i = &cur_i[rec_size..]; // progress input past parsed record
@@ -1269,7 +1402,7 @@ impl NFSState {
                         // looks for.
                         let n = usize::from(n);
                         let need = if n > 12 { n } else { 12 };
-                        return AppLayerResult::incomplete((i.len() - cur_i.len()) as u32, need as u32);
+                        return AppLayerResult::incomplete(stream_slice.len() - cur_i.len() as u32, need as u32);
                     }
                     return AppLayerResult::err();
                 },
@@ -1289,7 +1422,8 @@ impl NFSState {
         AppLayerResult::ok()
     }
     /// Parsing function
-    pub fn parse_udp_ts<'b>(&mut self, input: &'b[u8]) -> AppLayerResult {
+    pub fn parse_udp_ts<'b>(&mut self, flow: *const Flow, stream_slice: &StreamSlice) -> AppLayerResult {
+        let input = stream_slice.as_slice();
         SCLogDebug!("parse_udp_ts ({})", input.len());
         if input.len() > 0 {
             match parse_rpc_udp_request(input) {
@@ -1297,10 +1431,14 @@ impl NFSState {
                     self.is_udp = true;
                     match rpc_record.progver {
                         3 => {
-                            self.process_request_record(rpc_record);
-                        },
+                            self.process_request_record(flow, stream_slice, rpc_record);
+                            self.add_rpc_udp_ts_frames(flow, stream_slice, input, input.len() as i64);
+                            self.add_nfs_ts_frame(flow, stream_slice, rpc_record.prog_data, rpc_record.prog_data.len() as i64);
+                                                    },
                         2 => {
                             self.process_request_record_v2(rpc_record);
+                            self.add_rpc_udp_ts_frames(flow, stream_slice, input, input.len() as i64);
+                            self.add_nfs_ts_frame(flow, stream_slice, rpc_record.prog_data, rpc_record.prog_data.len() as i64);
                         },
                         _ => { },
                     }
@@ -1317,13 +1455,16 @@ impl NFSState {
     }
 
     /// Parsing function
-    pub fn parse_udp_tc<'b>(&mut self, input: &'b[u8]) -> AppLayerResult {
+    pub fn parse_udp_tc<'b>(&mut self, flow: *const Flow, stream_slice: &StreamSlice) -> AppLayerResult {
+        let input = stream_slice.as_slice();
         SCLogDebug!("parse_udp_tc ({})", input.len());
         if input.len() > 0 {
             match parse_rpc_udp_reply(input) {
                 Ok((_, ref rpc_record)) => {
                     self.is_udp = true;
-                    self.process_reply_record(rpc_record);
+                    self.process_reply_record(flow, stream_slice, rpc_record);
+                    self.add_rpc_udp_tc_frames(flow, stream_slice, input, input.len() as i64);
+                    self.add_nfs_tc_frames(flow, stream_slice, rpc_record.prog_data, rpc_record.prog_data.len() as i64);
                 },
                 Err(Err::Incomplete(_)) => {
                 },
@@ -1392,7 +1533,7 @@ pub unsafe extern "C" fn rs_nfs_parse_request(flow: *const Flow,
     SCLogDebug!("parsing {} bytes of request data", stream_slice.len());
 
     state.update_ts(flow.get_last_time().as_secs());
-    state.parse_tcp_data_ts(stream_slice.as_slice())
+    state.parse_tcp_data_ts(flow, &stream_slice)
 }
 
 #[no_mangle]
@@ -1423,7 +1564,7 @@ pub unsafe extern "C" fn rs_nfs_parse_response(flow: *const Flow,
     SCLogDebug!("parsing {} bytes of response data", stream_slice.len());
 
     state.update_ts(flow.get_last_time().as_secs());
-    state.parse_tcp_data_tc(stream_slice.as_slice())
+    state.parse_tcp_data_tc(flow, &stream_slice)
 }
 
 #[no_mangle]
@@ -1449,7 +1590,7 @@ pub unsafe extern "C" fn rs_nfs_parse_request_udp(f: *const Flow,
     rs_nfs_setfileflags(Direction::ToServer.into(), state, file_flags);
 
     SCLogDebug!("parsing {} bytes of request data", stream_slice.len());
-    state.parse_udp_ts(stream_slice.as_slice())
+    state.parse_udp_ts(f, &stream_slice)
 }
 
 #[no_mangle]
@@ -1464,7 +1605,7 @@ pub unsafe extern "C" fn rs_nfs_parse_response_udp(f: *const Flow,
     let file_flags = FileFlowToFlags(f, Direction::ToClient.into());
     rs_nfs_setfileflags(Direction::ToClient.into(), state, file_flags);
     SCLogDebug!("parsing {} bytes of response data", stream_slice.len());
-    state.parse_udp_tc(stream_slice.as_slice())
+    state.parse_udp_tc(f, &stream_slice)
 }
 
 #[no_mangle]
@@ -1863,8 +2004,8 @@ pub unsafe extern "C" fn rs_nfs_register_parser() {
         apply_tx_config: None,
         flags: APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
         truncate: None,
-        get_frame_id_by_name: None,
-        get_frame_name_by_id: None,
+        get_frame_id_by_name: Some(NFSFrameType::ffi_id_from_name),
+        get_frame_name_by_id: Some(NFSFrameType::ffi_name_from_id),
     };
 
     let ip_proto_str = CString::new("tcp").unwrap();
@@ -1941,8 +2082,8 @@ pub unsafe extern "C" fn rs_nfs_udp_register_parser() {
         apply_tx_config: None,
         flags: APP_LAYER_PARSER_OPT_UNIDIR_TXS,
         truncate: None,
-        get_frame_id_by_name: None,
-        get_frame_name_by_id: None,
+        get_frame_id_by_name: Some(NFSFrameType::ffi_id_from_name),
+        get_frame_name_by_id: Some(NFSFrameType::ffi_name_from_id),
     };
 
     let ip_proto_str = CString::new("udp").unwrap();


### PR DESCRIPTION
Feature #4872
Redmine Ticket: https://redmine.openinfosecfoundation.org/issues/4872

Frames:
```
RPCPdu
RPCHdr
RPCData
NFSPdu
NFSStatus 
NFS4Pdu
NFS4Tag
NFS4Ops
NFS4Status
```

- `NFS*` Frames are generic over `NFS2` | `NFS3`
- `NFS4Tag` for `NFS4` Header information
- `NFS*Status` For all `NFS` Responses. _might not be needed, I'll wait confirmation on that_
- `RPC*` Frames are generic for Traffic over `TCP` | `UDP`
- `SCLogNotice` are left for reviewing offsets.
