### PR TITLE
6.0.x fix: smb dce_opnum doesn't match rpc requests/responses

### DIFF
--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -123,9 +123,9 @@ pub extern "C" fn rs_smb_tx_match_dce_opnum(tx: &mut SMBTransaction,
                     if range.range2 == DETECT_DCE_OPNUM_RANGE_UNINITIALIZED {
                         if range.range1 == x.opnum as u32 {
                             return 1;
-                        } else if range.range1 <= x.opnum as u32 && range.range2 >= x.opnum as u32 {
-                            return 1;
                         }
+                    } else if range.range1 <= x.opnum as u32 && range.range2 >= x.opnum as u32 {
+                        return 1;
                     }
                 }
             }

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -19,6 +19,7 @@ use std::ptr;
 use crate::core::*;
 use crate::smb::smb::*;
 use crate::dcerpc::detect::{DCEIfaceData, DCEOpnumData, DETECT_DCE_OPNUM_RANGE_UNINITIALIZED};
+use crate::dcerpc::dcerpc::DCERPC_TYPE_REQUEST;
 
 #[no_mangle]
 pub extern "C" fn rs_smb_tx_get_share(tx: &mut SMBTransaction,
@@ -117,7 +118,7 @@ pub extern "C" fn rs_smb_tx_match_dce_opnum(tx: &mut SMBTransaction,
     SCLogDebug!("rs_smb_tx_get_dce_opnum: start");
     match tx.type_data {
         Some(SMBTransactionTypeData::DCERPC(ref x)) => {
-            if x.req_cmd == 1 { // REQUEST
+            if x.req_cmd == DCERPC_TYPE_REQUEST {
                 for range in dce_data.data.iter() {
                     if range.range2 == DETECT_DCE_OPNUM_RANGE_UNINITIALIZED {
                         if range.range1 == x.opnum as u32 {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/

[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4925

Backport of fix in https://github.com/OISF/suricata/pull/6510

Describe changes:
- To solve bug 1: compare x.req_cmd with the DCERPC_TYPE_REQUEST constant
- To solve bug 2: move the erroneus if to the outer context, as else of option of the if that checks if comparison should be exact or range

#suricata-verify-pr: https://github.com/OISF/suricata-verify/pull/722