### PR TITLE
doc/copyright: Update copyright dates for dev/user guide

### DIFF
--- a/doc/devguide/conf.py
+++ b/doc/devguide/conf.py
@@ -14,6 +14,7 @@ import os
 import shlex
 import re
 import subprocess
+import datetime
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
@@ -48,7 +49,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Suricata'
-copyright = u'2020, OISF'
+current_year = datetime.datetime.now().date().year
+copyright = u'{}, OISF'.format(current_year)
 author = u'OISF'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -16,6 +16,7 @@ import sys
 import os
 import shlex
 import re
+import datetime
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
@@ -49,8 +50,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
+# Ensure copyright has current year
 project = u'Suricata'
-copyright = u'2016-2019, OISF'
+copyright = u'2016-{}, OISF'.format(year = datetime.datetime.now().date().year)
 author = u'OISF'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -52,7 +52,8 @@ master_doc = 'index'
 # General information about the project.
 # Ensure copyright has current year
 project = u'Suricata'
-copyright = u'2016-{}, OISF'.format(year = datetime.datetime.now().date().year)
+end_year = datetime.datetime.now().date().year
+copyright = u'2016-{}, OISF'.format(end_year)
 author = u'OISF'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
This PR updates the document tools to use the current year as the range end (user guide) or single date (dev guide).

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5046](https://redmine.openinfosecfoundation.org/issues/5046)

Describe changes:
- Dynamically determine year

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
