### PR TITLE
detect/content: Consider distance in validation 

### DIFF
--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -213,13 +213,11 @@ DetectContentData *DetectContentParse(SpmGlobalThreadCtx *spm_global_thread_ctx,
         return NULL;
     }
 
-    cd = SCMalloc(sizeof(DetectContentData) + len);
+    cd = SCCalloc(1, sizeof(DetectContentData) + len);
     if (unlikely(cd == NULL)) {
         SCFree(content);
         exit(EXIT_FAILURE);
     }
-
-    memset(cd, 0, sizeof(DetectContentData) + len);
 
     cd->content = (uint8_t *)cd + sizeof(DetectContentData);
     memcpy(cd->content, content, len);

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2019 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -385,6 +385,30 @@ void DetectContentFree(DetectEngineCtx *de_ctx, void *ptr)
     SCReturn;
 }
 
+void SigParseRequiredContentSize(const Signature *s, int list, int *len, int *offset)
+{
+    SigMatch *sm = s->init_data->smlists[list];
+    int max_offset = 0, total_len = 0;
+    for (; sm != NULL; sm = sm->next) {
+        if (sm->type != DETECT_CONTENT || sm->ctx == NULL) {
+            continue;
+        }
+
+        DetectContentData *cd = (DetectContentData *)sm->ctx;
+        if (cd->flags & DETECT_CONTENT_NEGATED && cd->content_len == cd->within) {
+            SCLogDebug("negated ... within: %d", cd->within);
+            continue;
+        }
+        SCLogDebug("content_len %d; distance: %d, offset: %d, depth: %d", cd->content_len,
+                cd->distance, cd->offset, cd->depth);
+        total_len += cd->content_len + cd->distance;
+        max_offset = MAX(max_offset, cd->offset);
+    }
+
+    *len = total_len;
+    *offset = max_offset;
+}
+
 /**
  *  \retval 1 valid
  *  \retval 0 invalid
@@ -402,25 +426,17 @@ bool DetectContentPMATCHValidateCallback(const Signature *s)
 
     uint32_t max_right_edge = (uint32_t)max_right_edge_i;
 
-    const SigMatch *sm = s->init_data->smlists[DETECT_SM_LIST_PMATCH];
-    for ( ; sm != NULL; sm = sm->next) {
-        if (sm->type != DETECT_CONTENT)
-            continue;
-        const DetectContentData *cd = (const DetectContentData *)sm->ctx;
-        uint32_t right_edge = cd->content_len + cd->offset;
-        if (cd->content_len > max_right_edge) {
+    int min_dsize_required = SigParseMaxRequiredDsize(s);
+    if (min_dsize_required >= 0) {
+        SCLogDebug("min_dsize %d; max_right_edge %d", min_dsize_required, max_right_edge);
+        if ((uint32_t)min_dsize_required > max_right_edge) {
             SCLogError(SC_ERR_INVALID_SIGNATURE,
-                    "signature can't match as content length %u is bigger than dsize %u.",
-                    cd->content_len, max_right_edge);
-            return false;
-        }
-        if (right_edge > max_right_edge) {
-            SCLogError(SC_ERR_INVALID_SIGNATURE,
-                    "signature can't match as content length %u with offset %u (=%u) is bigger than dsize %u.",
-                    cd->content_len, cd->offset, right_edge, max_right_edge);
+                    "signature can't match as required content length %d exceeds dsize value %d",
+                    min_dsize_required, max_right_edge);
             return false;
         }
     }
+
     return true;
 }
 
@@ -2611,7 +2627,7 @@ static int SigTest42TestNegatedContent(void)
 /**
  * \test A negative test that checks that the content string doesn't contain
  *       the negated content within the specified depth, and also after the
- *       specified offset. Since the content is there, the match fails. 
+ *       specified offset. Since the content is there, the match fails.
  *
  *       Match is at offset:23, depth:34
  */

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -1330,7 +1330,7 @@ static int DetectContentParseTest09(void)
 }
 
 /**
- * \test Test cases where if within specified is < content lenggth we invalidate
+ * \test Test cases where if within specified is < content length we invalidate
  *       the sig.
  */
 static int DetectContentParseTest17(void)

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -387,20 +387,31 @@ void SigParseRequiredContentSize(const Signature *s, int list, int *len, int *of
 {
     SigMatch *sm = s->init_data->smlists[list];
     int max_offset = 0, total_len = 0;
+    bool first = true;
     for (; sm != NULL; sm = sm->next) {
         if (sm->type != DETECT_CONTENT || sm->ctx == NULL) {
             continue;
         }
 
         DetectContentData *cd = (DetectContentData *)sm->ctx;
-        if (cd->flags & DETECT_CONTENT_NEGATED && cd->content_len == cd->within) {
-            SCLogDebug("negated ... within: %d", cd->within);
-            continue;
+        SCLogDebug("content_len %d; negated: %s; distance: %d, offset: %d, depth: %d",
+                cd->content_len, cd->flags & DETECT_CONTENT_NEGATED ? "yes" : "no", cd->distance,
+                cd->offset, cd->depth);
+
+        /* Only count negated content bound with within/distance */
+        if (!first) {
+            /* only count content with relative modifiers */
+            if (!((cd->flags & DETECT_CONTENT_DISTANCE) || (cd->flags & DETECT_CONTENT_WITHIN)))
+                continue;
+
+            /* ignore negated content if len == within */
+            if (cd->flags & DETECT_CONTENT_NEGATED && cd->within == cd->content_len) {
+                continue;
+            }
         }
-        SCLogDebug("content_len %d; distance: %d, offset: %d, depth: %d", cd->content_len,
-                cd->distance, cd->offset, cd->depth);
         total_len += cd->content_len + cd->distance;
         max_offset = MAX(max_offset, cd->offset);
+        first = false;
     }
 
     *len = total_len;

--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -124,5 +124,6 @@ bool DetectContentPMATCHValidateCallback(const Signature *s);
 void DetectContentPropagateLimits(Signature *s);
 
 void DetectContentPatternPrettyPrint(const DetectContentData *cd, char *str, size_t str_len);
+void SigParseRequiredContentSize(const Signature *s, int list, int *len, int *offset);
 
 #endif /* __DETECT_CONTENT_H__ */

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -444,6 +444,47 @@ void SigParseSetDsizePair(Signature *s)
 
         SCLogDebug("low %u, high %u, mode %u", low, high, dd->mode);
     }
+}
+
+/**
+ *  \brief Determine the required dsize for the signature
+ *  \param s signature to get dsize value from
+ *
+ *  Note that negated content does not contribute to the maximum
+ *  required dsize value.
+ *
+ * \retval -1 Signature doesn't have a dsize keyword
+ * \retval >= 0 Dsize value required to not exclude content matches
+ */
+int SigParseMaxRequiredDsize(const Signature *s)
+{
+    SCEnter();
+
+    if (!(s->flags & SIG_FLAG_DSIZE)) {
+        SCReturnInt(-1);
+    }
+
+    int dsize = SigParseGetMaxDsize(s);
+    if (dsize < 0) {
+        /* nothing to do */
+        SCReturnInt(-1);
+    }
+
+    int total_length, offset;
+    SigParseRequiredContentSize(s, DETECT_SM_LIST_PMATCH, &total_length, &offset);
+    SCLogDebug("len: %d; offset: %d", total_length, offset);
+
+    if (total_length > dsize) {
+        SCLogDebug("required_dsize: %d exceeds dsize: %d", total_length, dsize);
+        return total_length;
+    }
+
+    if ((total_length + offset) > dsize) {
+        SCLogDebug("length + offset: %d exceeds dsize: %d", total_length + offset, dsize);
+        return total_length + offset;
+    }
+
+    SCReturnInt(-1);
 }
 
 /**

--- a/src/detect-dsize.h
+++ b/src/detect-dsize.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -39,6 +39,7 @@ typedef struct DetectDsizeData_ {
 /* prototypes */
 void DetectDsizeRegister (void);
 
+int SigParseMaxRequiredDsize(const Signature *s);
 int SigParseGetMaxDsize(const Signature *s);
 void SigParseSetDsizePair(Signature *s);
 void SigParseApplyDsizeToContent(Signature *s);

--- a/src/tests/detect-bsize.c
+++ b/src/tests/detect-bsize.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2020 Open Information Security Foundation
+/* Copyright (C) 2017-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -116,41 +116,42 @@ static int DetectBsizeTest04(void)
 
 static int DetectBsizeSigTest01(void)
 {
-#if 0
     TEST_OK("alert http any any -> any any (http_request_line; bsize:10; sid:1;)");
     TEST_OK("alert http any any -> any any (file_data; bsize:>1000; sid:2;)");
-
-    TEST_FAIL("alert tcp any any -> any any (content:\"abc\"; bsize:10; sid:3;)");
-    TEST_FAIL("alert http any any -> any any (content:\"GET\"; http_method; bsize:10; sid:4;)");
-    TEST_FAIL("alert http any any -> any any (http_request_line; content:\"GET\"; bsize:<10>; sid:5;)");
 
     /* bsize validation with buffer */
     TEST_OK("alert http any any -> any any (http.uri; content:\"/index.php\"; bsize:>1024; "
             "sid:6;)");
-    TEST_OK("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"g\"; bsize:1; "
-            "sid:7;)");
-    TEST_OK("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"g\"; bsize:4; "
-            "sid:8;)");
     TEST_OK("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:<20; "
             " sid:9;)");
     TEST_OK("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:15<>25; "
             "sid:10;)");
+    TEST_OK("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:10<>15; "
+            "sid:13;)");
+
+    TEST_FAIL("alert tcp any any -> any any (content:\"abc\"; bsize:10; sid:3;)");
+    TEST_FAIL("alert http any any -> any any (content:\"GET\"; http_method; bsize:10; sid:4;)");
+    TEST_FAIL("alert http any any -> any any (http_request_line; content:\"GET\"; bsize:<10>; "
+              "sid:5;)");
+
     TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:2; "
               "sid:11;)");
     TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:<13; "
               "sid:12;)");
-    TEST_OK("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:10<>15; "
-              "sid:13;)");
+    TEST_FAIL(
+            "alert http any any -> any any (http.uri; content:\"abcdef\"; content: \"g\"; bsize:1; "
+            "sid:7;)");
+    TEST_FAIL(
+            "alert http any any -> any any (http.uri; content:\"abcdef\"; content: \"g\"; bsize:4; "
+            "sid:8;)");
     TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefghi123456\"; offset:12; "
               "bsize:3; sid:14;)");
     TEST_FAIL("alert http any any -> any any (http.uri; content:\"abc\"; offset:3; depth:3; "
               "bsize:3; sid:15;)");
-    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"gh\"; "
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdef\"; content: \"gh\"; "
               "bsize:1; sid:16;)");
     TEST_FAIL("alert http any any -> any any (http.uri; content:\"abc\"; offset:3; bsize:3; "
               "sid:17;)");
-
-#endif
     TEST_FAIL("alert http any any -> any any (http.uri; content:\"abc\"; offset:65535; bsize:3; "
               "sid:18;)");
     PASS;

--- a/src/tests/detect-bsize.c
+++ b/src/tests/detect-bsize.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -17,13 +17,14 @@
 
 #include "../util-unittest.h"
 
-#define TEST_OK(str, m, lo, hi) {                       \
-    DetectBsizeData *bsz = DetectBsizeParse((str));     \
-    FAIL_IF_NULL(bsz);                                  \
-    FAIL_IF_NOT(bsz->mode == (m));                      \
-    DetectBsizeFree(NULL, bsz);                         \
-    SCLogDebug("str %s OK", (str));                     \
-}
+#define TEST_OK(str, m, lo, hi)                                                                    \
+    {                                                                                              \
+        DetectBsizeData *bsz = DetectBsizeParse((str));                                            \
+        FAIL_IF_NULL(bsz);                                                                         \
+        FAIL_IF_NOT(bsz->mode == (m));                                                             \
+        DetectBsizeFree(NULL, bsz);                                                                \
+        SCLogDebug("str %s OK", (str));                                                            \
+    }
 #define TEST_FAIL(str) {                                \
     DetectBsizeData *bsz = DetectBsizeParse((str));     \
     FAIL_IF_NOT_NULL(bsz);                              \
@@ -93,32 +94,65 @@ static int DetectBsizeTest04(void)
 #undef TEST_OK
 #undef TEST_FAIL
 
-#define TEST_OK(rule)                                                                       \
-{                                                                                           \
-    DetectEngineCtx *de_ctx = DetectEngineCtxInit();                                        \
-    FAIL_IF_NULL(de_ctx);                                                                   \
-    Signature *s = DetectEngineAppendSig(de_ctx, (rule));                                   \
-    FAIL_IF_NULL(s);                                                                        \
-    DetectEngineCtxFree(de_ctx);                                                            \
-}
+#define TEST_OK(rule)                                                                              \
+    {                                                                                              \
+        DetectEngineCtx *de_ctx = DetectEngineCtxInit();                                           \
+        FAIL_IF_NULL(de_ctx);                                                                      \
+        SCLogNotice("rule: %s", rule);                                                             \
+        Signature *s = DetectEngineAppendSig(de_ctx, (rule));                                      \
+        FAIL_IF_NULL(s);                                                                           \
+        DetectEngineCtxFree(de_ctx);                                                               \
+    }
 
-#define TEST_FAIL(rule)                                                                     \
-{                                                                                           \
-    DetectEngineCtx *de_ctx = DetectEngineCtxInit();                                        \
-    FAIL_IF_NULL(de_ctx);                                                                   \
-    Signature *s = DetectEngineAppendSig(de_ctx, (rule));                                   \
-    FAIL_IF_NOT_NULL(s);                                                                    \
-    DetectEngineCtxFree(de_ctx);                                                            \
-}
+#define TEST_FAIL(rule)                                                                            \
+    {                                                                                              \
+        DetectEngineCtx *de_ctx = DetectEngineCtxInit();                                           \
+        FAIL_IF_NULL(de_ctx);                                                                      \
+        SCLogNotice("rule: %s", rule);                                                             \
+        Signature *s = DetectEngineAppendSig(de_ctx, (rule));                                      \
+        FAIL_IF_NOT_NULL(s);                                                                       \
+        DetectEngineCtxFree(de_ctx);                                                               \
+    }
 
 static int DetectBsizeSigTest01(void)
 {
+#if 0
     TEST_OK("alert http any any -> any any (http_request_line; bsize:10; sid:1;)");
     TEST_OK("alert http any any -> any any (file_data; bsize:>1000; sid:2;)");
 
     TEST_FAIL("alert tcp any any -> any any (content:\"abc\"; bsize:10; sid:3;)");
     TEST_FAIL("alert http any any -> any any (content:\"GET\"; http_method; bsize:10; sid:4;)");
     TEST_FAIL("alert http any any -> any any (http_request_line; content:\"GET\"; bsize:<10>; sid:5;)");
+
+    /* bsize validation with buffer */
+    TEST_OK("alert http any any -> any any (http.uri; content:\"/index.php\"; bsize:>1024; "
+            "sid:6;)");
+    TEST_OK("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"g\"; bsize:1; "
+            "sid:7;)");
+    TEST_OK("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"g\"; bsize:4; "
+            "sid:8;)");
+    TEST_OK("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:<20; "
+            " sid:9;)");
+    TEST_OK("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:15<>25; "
+            "sid:10;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:2; "
+              "sid:11;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:<13; "
+              "sid:12;)");
+    TEST_OK("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:10<>15; "
+              "sid:13;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefghi123456\"; offset:12; "
+              "bsize:3; sid:14;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abc\"; offset:3; depth:3; "
+              "bsize:3; sid:15;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"gh\"; "
+              "bsize:1; sid:16;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abc\"; offset:3; bsize:3; "
+              "sid:17;)");
+
+#endif
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abc\"; offset:65535; bsize:3; "
+              "sid:18;)");
     PASS;
 }
 


### PR DESCRIPTION
Continuation of #6954

This commit modifies the validation callback to include the distance
during validation.

Values of distance that cause the right edge to be exceeded are
considered an error and the signature will be rejected.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [2982](https://redmine.openinfosecfoundation.org/issues/2982)

Describe changes:
- fixups

Updates:
- clang-format

suricata-verify-pr: 716
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
