### PR TITLE
Iface preack

### DIFF
--- a/doc/userguide/rules/dcerpc-keywords.rst
+++ b/doc/userguide/rules/dcerpc-keywords.rst
@@ -16,14 +16,23 @@ The format of the keyword::
   dcerpc.iface:<uuid>;
   dcerpc.iface:<uuid>,[>,<,!,=]<iface_version>;
   dcerpc.iface:<uuid>,any_frag;
-  dcerpc.iface:<uuid>,[>,<,!,=]<iface_version>,any_frag;
+  dcerpc.iface:<uuid>,preack;
+  dcerpc.iface:<uuid>,[>,<,!,=]<iface_version>,any_frag,preack;
+
+The `preack` option only works on DCERPC over SMB traffic, where some machines
+will submit requests before receiving the bind_ack response. If you want that
+your request match after the bind is issue without waiting for the bind_ack,
+then you can use `preack`. Keep in mind that if the next bind_ack rejects the
+bind context you want to match, it will stop matching.
 
 Examples::
 
   dcerpc.iface:367abb81-9844-35f1-ad32-98f038001003;
   dcerpc.iface:367abb81-9844-35f1-ad32-98f038001003,!10;
   dcerpc.iface:367abb81-9844-35f1-ad32-98f038001003,any_frag;
+  dcerpc.iface:367abb81-9844-35f1-ad32-98f038001003,preack;
   dcerpc.iface:367abb81-9844-35f1-ad32-98f038001003,>1,any_frag;
+  dcerpc.iface:367abb81-9844-35f1-ad32-98f038001003,>1,any_frag,preack;
 
 ET Open rule example:
 

--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -159,35 +159,17 @@ fn parse_iface_data(arg: &str) -> Result<DCEIfaceData, ()> {
         }
     };
 
-    match split_args.len() {
-        1 => {}
-        2 => match split_args[1] {
-            "any_frag" => {
-                any_frag = 1;
-            }
-            _ => {
-                op_version = match extract_op_version(split_args[1]) {
-                    Ok((op, ver)) => (op, ver),
-                    _ => {
-                        return Err(());
-                    }
-                };
-            }
-        },
-        3 => {
-            op_version = match extract_op_version(split_args[1]) {
+    for i in 1..split_args.len() {
+        let arg = split_args[i];
+        if arg == "any_frag" {
+            any_frag = 1
+        } else {
+            op_version = match extract_op_version(arg) {
                 Ok((op, ver)) => (op, ver),
                 _ => {
                     return Err(());
                 }
             };
-            if split_args[2] != "any_frag" {
-                return Err(());
-            }
-            any_frag = 1;
-        }
-        _ => {
-            return Err(());
         }
     }
 

--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -162,16 +162,18 @@ fn parse_iface_data(arg: &str) -> Result<DCEIfaceData, ()> {
     };
 
     for i in 1..split_args.len() {
-        let arg = split_args[i];
-        if arg == "any_frag" {
-            any_frag = 1
-        } else {
-            op_version = match extract_op_version(arg) {
-                Ok((op, ver)) => (op, ver),
-                _ => {
-                    return Err(());
-                }
-            };
+        let arg = split_args[i].trim();
+        match arg {
+            "any_frag" => any_frag = 1,
+            "preack" => preack = true,
+            _ => {
+                op_version = match extract_op_version(arg) {
+                    Ok((op, ver)) => (op, ver),
+                    _ => {
+                        return Err(());
+                    }
+                };
+            }
         }
     }
 

--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -37,6 +37,7 @@ pub struct DCEIfaceData {
     pub op: u8,
     pub version: u16,
     pub any_frag: u8,
+    pub preack: bool,
 }
 
 #[derive(Debug)]
@@ -152,6 +153,7 @@ fn parse_iface_data(arg: &str) -> Result<DCEIfaceData, ()> {
     let split_args: Vec<&str> = arg.split(',').collect();
     let mut op_version = (0, 0);
     let mut any_frag: u8 = 0;
+    let mut preack = false;
     let if_uuid = match Uuid::parse_str(split_args[0]) {
         Ok(res) => res.as_bytes().to_vec(),
         _ => {
@@ -178,6 +180,7 @@ fn parse_iface_data(arg: &str) -> Result<DCEIfaceData, ()> {
         op: op_version.0,
         version: op_version.1,
         any_frag: any_frag,
+        preack
     })
 }
 
@@ -370,6 +373,7 @@ mod test {
             op: 3,
             version: 10,
             any_frag: 0,
+            preack: false,
         };
         let version = 10;
         assert_eq!(true, match_iface_version(version, &iface_data));
@@ -451,6 +455,19 @@ mod test {
         let arg = "12345678-1234-1234-1234-123456789ABC,>65535,any_frag";
         let iface_data = parse_iface_data(arg);
         assert_eq!(iface_data.is_err(), true);
+    }
+
+    #[test]
+    fn test_parse_iface_data_preack() {
+        let expected_uuid = String::from("12345678-1234-1234-1234-123456789ABC").to_lowercase();
+        let arg = "12345678-1234-1234-1234-123456789ABC, preack";
+        let iface_data = parse_iface_data(arg).unwrap();
+
+        let uuid = Uuid::from_slice(iface_data.if_uuid.as_slice());
+        let uuid = uuid.map(|uuid| uuid.to_hyphenated().to_string()).unwrap();
+        assert_eq!(expected_uuid, uuid);
+        assert_eq!(iface_data.preack, true);
+
     }
 
     #[test]

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -193,8 +193,8 @@ pub extern "C" fn rs_smb_tx_get_dce_iface(state: &mut SMBState,
     for i in ifaces {
         SCLogDebug!("stored UUID {:?} acked {} ack_result {}", i, i.acked, i.ack_result);
 
-        if i.acked && i.ack_result == 0 && i.uuid == if_uuid {
-            if match_version(if_op as u8, if_version as u16, i.ver) {
+        if (dce_data.preack && !i.acked) || (i.acked && i.ack_result == 0) {
+             if i.uuid == if_uuid && match_version(if_op as u8, if_version as u16, i.ver) {
                 return 1;
             }
         }


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5067

Describe changes:
- Create new preack option for dcerpc.iface
- Allow dcerpc over smb requests to match without required bind_ack when preack enabled (if after that, a bind_ack is received rejecting the context, then the rule will stop matching next packets)
- Add preack option to documentation

As described in the related ticket, some Windows OS when using dcerpc over smb, sent request just after the bind, without waiting for the bind_ack. So in case the user wants to match that requests, I introduce a new option in the dcerpc.iface, this way the previous behaviour without the flag remains unaltered.

Also a few changes were made in the processing of the dcerpc.iface options, that now are allowed to include spaces. (`<uuid>,any_frag` and `<uuid>, any_frag` are both valid)

suricata-verify-pr: 729
