### PR TITLE
log/stack: Propagate original signal

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -306,6 +306,9 @@ static void SignalHandlerUnexpected(int sig_num, siginfo_t *info, void *context)
 {
     char msg[SC_LOG_MAX_LOG_MSG_LEN];
     unw_cursor_t cursor;
+    /* Restore defaults for signals to avoid loops */
+    signal(SIGABRT, SIG_DFL);
+    signal(SIGSEGV, SIG_DFL);
     int r;
     if ((r = unw_init_local(&cursor, (unw_context_t *)(context)) != 0)) {
         fprintf(stderr, "unable to obtain stack trace: unw_init_local: %s\n", unw_strerror(r));
@@ -338,9 +341,8 @@ static void SignalHandlerUnexpected(int sig_num, siginfo_t *info, void *context)
     SCLogError(SC_ERR_SIGNAL, "%s", msg);
 
 terminate:
-    // Terminate with SIGABRT ... but first, restore that signal's default handling
-    signal(SIGABRT, SIG_DFL);
-    abort();
+    // Propagate signal to watchers, if any
+    kill(0, sig_num);
 }
 #undef UNW_LOCAL_ONLY
 #endif /* HAVE_LIBUNWIND */


### PR DESCRIPTION
Issue: 4550

This commit modifies the "stack trace on signal" to propagate the
original signal received instead of always raising SIGABRT.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5070](https://redmine.openinfosecfoundation.org/issues/5070)

Describe changes:
- Restore default signal handling behavior on entry
- Propagate signal received instead of always raising SIGABRT

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
