### PR TITLE
Keyword/smb cmd

### DIFF
--- a/doc/userguide/rules/index.rst
+++ b/doc/userguide/rules/index.rst
@@ -26,6 +26,7 @@ Suricata Rules
    snmp-keywords
    base64-keywords
    sip-keywords
+   smb-keywords
    rfb-keywords
    mqtt-keywords
    ike-keywords

--- a/doc/userguide/rules/smb-keywords.rst
+++ b/doc/userguide/rules/smb-keywords.rst
@@ -1,0 +1,148 @@
+SMB Keywords
+==============
+
+SMB keywords used in both SMB1 and SMB2 protocols.
+
+smb.cmd
+---------
+
+Used to match SMB command. Decimal, Hexadecimal or command names values are admitted.
+
+
+The following signature are equivalent::
+
+  alert smb any any -> any any (msg: "Smb command rule"; smb.cmd: 10; sid: 1;)
+  alert smb any any -> any any (msg: "Smb command rule"; smb.cmd: 0xa; sid: 1;)
+  alert smb any any -> any any (msg: "Smb command rule"; smb.cmd: lock; sid: 1;)
+
+
+You can also specify several commands separated by comma::
+
+  alert smb any any -> any any (msg: "Smb command rule"; smb.cmd: 10,create,0x4; sid: 1;)
+
+
+Commands will match with both versions of SMB, so very careful using this rule.
+For example, the following rule::
+
+  alert smb any any -> any any (msg: "Smb command rule"; smb.cmd: 1; sid: 1;)
+
+
+It will match with the ``SMB2 Session Setup`` and ``SMB1 Delete Directory`` commands.
+
+Moreover, some commands names are shared by both SMB1 and SMB2, so they will match both.
+That can be useful in certain situations but lead to false positives in others, be aware.
+For example this rule::
+
+  alert smb any any -> any any (msg: "Smb command rule"; smb.cmd: create; sid: 1;)
+
+It will match with SMB2 0x05 and SMB1 0x03 commands codes.
+
+SMB2 command names:
+
+================== ========================
+SMB2 Command Name  Code
+================== ========================
+negotiate          0x00
+session_setup      0x01
+logoff             0x02
+tree_connect       0x03
+tree_disconnect    0x04
+create             0x05
+close              0x06
+flush              0x07
+read               0x08
+write              0x09
+lock               0x0A
+ioctl              0x0B
+cancel             0x0C
+echo               0x0D
+query_directory    0x0E
+change_notify      0x0F
+query_info         0x10
+set_info           0x11
+oplock_break       0x12
+================== ========================
+
+
+SMB1 command names:
+
+======================= ========================
+SMB1 Command Name       Code
+======================= ========================
+create_directory        0x00
+delete_directory        0x01
+open                    0x02
+create                  0x03
+close                   0x04
+flush                   0x05
+delete                  0x06
+rename                  0x07
+query_information       0x08
+set_information         0x09
+read                    0x0A
+write                   0x0B
+lock_byte_range         0x0C
+unlock_byte_range       0x0D
+create_temporary        0x0E
+create_new              0x0F
+check_directory         0x10
+process_exit            0x11
+seek                    0x12
+lock_and_read           0x13
+write_and_unlock        0x14
+read_raw                0x1A
+read_mpx                0x1B
+read_mpx_secondary      0x1C
+write_raw               0x1D
+write_mpx               0x1E
+write_mpx_secondary     0x1F
+write_complete          0x20
+query_server            0x21
+set_information2        0x22
+query_information2      0x23
+locking_andx            0x24
+transaction             0x25
+transaction_secondary   0x26
+ioctl                   0x27
+ioctl_secondary         0x28
+copy                    0x29
+move                    0x2A
+echo                    0x2B
+write_and_close         0x2C
+open_andx               0x2D
+read_andx               0x2E
+write_andx              0x2F
+new_file_size           0x30
+close_and_tree_disc     0x31
+transaction2            0x32
+transaction2_secondary  0x33
+find_close2             0x34
+find_notify_close       0x35
+tree_connect            0x70
+tree_disconnect         0x71
+negotiate               0x72
+session_setup_andx      0x73
+logoff_andx             0x74
+tree_connect_andx       0x75
+security_package_andx   0x7E
+query_information_disk  0x80
+search                  0x81
+find                    0x82
+find_unique             0x83
+find_close              0x84
+nt_transact             0xA0
+nt_transact_secondary   0xA1
+nt_create_andx          0xA2
+nt_cancel               0xA4
+nt_rename               0xA5
+open_print_file         0xC0
+write_print_file        0xC1
+close_print_file        0xC2
+get_print_queue         0xC3
+read_bulk               0xD8
+write_bulk              0xD9
+write_bulk_data         0xDA
+invalid                 0xFE
+no_andx_command         0xFF
+======================= ========================
+

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -256,6 +256,7 @@ pub unsafe extern "C" fn rs_smb_cmd_free(ptr: *mut c_void) {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct SmbCmdData (HashMap<u8, HashSet<u16>>);
 
 impl SmbCmdData {
@@ -428,4 +429,32 @@ fn gen_smb1_command_names() -> HashMap<&'static str, u16> {
     cmd_names1.insert("no_andx_command", 0xFFu16);
 
     return cmd_names1;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_cmd_data() {
+        let option = "5,negotiate,0x8";
+
+        let cmd_names1 = gen_smb1_command_names();
+        let cmd_names2 = gen_smb2_command_names();
+
+        let mut cmd_codes1 = HashSet::new();
+        cmd_codes1.insert(5);
+        cmd_codes1.insert(*cmd_names1.get("negotiate").unwrap());
+        cmd_codes1.insert(0x8);
+
+        let mut cmd_codes2 = HashSet::new();
+        cmd_codes2.insert(5);
+        cmd_codes2.insert(*cmd_names2.get("negotiate").unwrap());
+        cmd_codes2.insert(0x8);
+
+        assert_eq!(
+            SmbCmdData::new(cmd_codes1, cmd_codes2),
+            parse_cmd_data(option).unwrap(),
+        );
+    }
 }

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -20,6 +20,9 @@ use crate::core::*;
 use crate::smb::smb::*;
 use crate::dcerpc::detect::{DCEIfaceData, DCEOpnumData, DETECT_DCE_OPNUM_RANGE_UNINITIALIZED};
 use crate::dcerpc::dcerpc::DCERPC_TYPE_REQUEST;
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_void};
+use std::collections::{HashMap, HashSet};
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_smb_tx_get_share(tx: &mut SMBTransaction,
@@ -200,4 +203,229 @@ pub extern "C" fn rs_smb_tx_get_dce_iface(state: &mut SMBState,
         }
     }
     return 0;
+}
+
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_smb_cmd_match(
+    tx: &mut SMBTransaction, cmd_data: &mut SmbCmdData,
+) -> u8 {
+
+    let version = tx.vercmd.get_version();
+    let cmd;
+    if version == 1 {
+        cmd = tx.vercmd.get_smb1_cmd().1 as u16;
+    } else {
+        cmd = tx.vercmd.get_smb2_cmd().1;
+    }
+
+    SCLogDebug!("rs_smb_cmd_match: version {} cmd {}", version, cmd);
+
+    if let Some(set) = cmd_data.0.get(&version) {
+        if set.contains(&cmd) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_smb_cmd_parse(carg: *const c_char) -> *mut c_void {
+    if carg.is_null() {
+        return std::ptr::null_mut();
+    }
+    let arg = match CStr::from_ptr(carg).to_str() {
+        Ok(arg) => arg,
+        _ => {
+            return std::ptr::null_mut();
+        }
+    };
+
+    match parse_cmd_data(arg) {
+        Ok(detect) => Box::into_raw(Box::new(detect)) as *mut _,
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_smb_cmd_free(ptr: *mut c_void) {
+    if ptr != std::ptr::null_mut() {
+        std::mem::drop(Box::from_raw(ptr as *mut SmbCmdData));
+    }
+}
+
+pub struct SmbCmdData (HashMap<u8, HashSet<u16>>);
+
+impl SmbCmdData {
+
+    fn new(cmd_codes1: HashSet<u16>, cmd_codes2: HashSet<u16>) -> Self {
+
+        let mut cmd_data = HashMap::new();
+        cmd_data.insert(1, cmd_codes1);
+        cmd_data.insert(2, cmd_codes2);
+
+        return Self(cmd_data);
+    }
+
+}
+
+fn str_to_u16(v: &str) -> Result<u16, ()> {
+    let size;
+    if v.starts_with("0x") {
+        let no_prefix = v.trim_start_matches("0x");
+        size = u16::from_str_radix(&no_prefix, 16);
+    } else {
+        size = u16::from_str_radix(&v, 10);
+    }
+
+    return size.map_err(|_| ());
+}
+
+
+fn parse_cmd_data(arg: &str) -> Result<SmbCmdData, ()> {
+
+    let cmd_names1 = gen_smb1_command_names();
+    let cmd_names2 = gen_smb2_command_names();
+
+
+    let split_args: Vec<&str> = arg.split(',').collect();
+
+    let mut cmd_codes1 = HashSet::new();
+    let mut cmd_codes2 = HashSet::new();
+
+    for cmd in split_args.iter() {
+
+        match str_to_u16(cmd) {
+            Ok(cmd_code) =>  {
+                cmd_codes1.insert(cmd_code);
+                cmd_codes2.insert(cmd_code);
+            }
+            Err(_) => {
+                let mut in_any = false;
+                if let Some(cmd_code) = cmd_names1.get(cmd) {
+                    cmd_codes1.insert(*cmd_code);
+                    in_any = true;
+                }
+
+                if let Some(cmd_code) = cmd_names2.get(cmd) {
+                    cmd_codes2.insert(*cmd_code);
+                    in_any = true;
+                }
+
+                if !in_any {
+                    return Err(());
+                }
+            }
+        }
+
+    }
+    return Ok(SmbCmdData::new(cmd_codes1, cmd_codes2));
+}
+
+fn gen_smb2_command_names() -> HashMap<&'static str, u16> {
+    let mut cmd_names2 = HashMap::new();
+    cmd_names2.insert("negotiate", 0u16);
+    cmd_names2.insert("session_setup", 1u16);
+    cmd_names2.insert("logoff", 2u16);
+    cmd_names2.insert("tree_connect", 3u16);
+    cmd_names2.insert("tree_disconnect", 4u16);
+    cmd_names2.insert("create", 5u16);
+    cmd_names2.insert("close", 6u16);
+    cmd_names2.insert("flush", 7u16);
+    cmd_names2.insert("read", 8u16);
+    cmd_names2.insert("write", 9u16);
+    cmd_names2.insert("lock", 0xau16);
+    cmd_names2.insert("ioctl", 0xbu16);
+    cmd_names2.insert("cancel", 0xcu16);
+    cmd_names2.insert("echo", 0xdu16);
+    cmd_names2.insert("query_directory", 0xeu16);
+    cmd_names2.insert("change_notify", 0xfu16);
+    cmd_names2.insert("query_info", 0x10u16);
+    cmd_names2.insert("set_info", 0x11u16);
+    cmd_names2.insert("oplock_break", 0x12u16);
+
+    return cmd_names2;
+}
+
+fn gen_smb1_command_names() -> HashMap<&'static str, u16> {
+    let mut cmd_names1 = HashMap::new();
+    cmd_names1.insert("create_directory", 0x00u16);
+    cmd_names1.insert("delete_directory", 0x01u16);
+    cmd_names1.insert("open", 0x02u16);
+    cmd_names1.insert("create", 0x03u16);
+    cmd_names1.insert("close", 0x04u16);
+    cmd_names1.insert("flush", 0x05u16);
+    cmd_names1.insert("delete", 0x06u16);
+    cmd_names1.insert("rename", 0x07u16);
+    cmd_names1.insert("query_information", 0x08u16);
+    cmd_names1.insert("set_information", 0x09u16);
+    cmd_names1.insert("read", 0x0Au16);
+    cmd_names1.insert("write", 0x0Bu16);
+    cmd_names1.insert("lock_byte_range", 0x0Cu16);
+    cmd_names1.insert("unlock_byte_range", 0x0Du16);
+    cmd_names1.insert("create_temporary", 0x0Eu16);
+    cmd_names1.insert("create_new", 0x0Fu16);
+    cmd_names1.insert("check_directory", 0x10u16);
+    cmd_names1.insert("process_exit", 0x11u16);
+    cmd_names1.insert("seek", 0x12u16);
+    cmd_names1.insert("lock_and_read", 0x13u16);
+    cmd_names1.insert("write_and_unlock", 0x14u16);
+    cmd_names1.insert("read_raw", 0x1Au16);
+    cmd_names1.insert("read_mpx", 0x1Bu16);
+    cmd_names1.insert("read_mpx_secondary", 0x1Cu16);
+    cmd_names1.insert("write_raw", 0x1Du16);
+    cmd_names1.insert("write_mpx", 0x1Eu16);
+    cmd_names1.insert("write_mpx_secondary", 0x1Fu16);
+    cmd_names1.insert("write_complete", 0x20u16);
+    cmd_names1.insert("query_server", 0x21u16);
+    cmd_names1.insert("set_information2", 0x22u16);
+    cmd_names1.insert("query_information2", 0x23u16);
+    cmd_names1.insert("locking_andx", 0x24u16);
+    cmd_names1.insert("transaction", 0x25u16);
+    cmd_names1.insert("transaction_secondary", 0x26u16);
+    cmd_names1.insert("ioctl", 0x27u16);
+    cmd_names1.insert("ioctl_secondary", 0x28u16);
+    cmd_names1.insert("copy", 0x29u16);
+    cmd_names1.insert("move", 0x2Au16);
+    cmd_names1.insert("echo", 0x2Bu16);
+    cmd_names1.insert("write_and_close", 0x2Cu16);
+    cmd_names1.insert("open_andx", 0x2Du16);
+    cmd_names1.insert("read_andx", 0x2Eu16);
+    cmd_names1.insert("write_andx", 0x2Fu16);
+    cmd_names1.insert("new_file_size", 0x30u16);
+    cmd_names1.insert("close_and_tree_disc", 0x31u16);
+    cmd_names1.insert("transaction2", 0x32u16);
+    cmd_names1.insert("transaction2_secondary", 0x33u16);
+    cmd_names1.insert("find_close2", 0x34u16);
+    cmd_names1.insert("find_notify_close", 0x35u16);
+    cmd_names1.insert("tree_connect", 0x70u16);
+    cmd_names1.insert("tree_disconnect", 0x71u16);
+    cmd_names1.insert("negotiate", 0x72u16);
+    cmd_names1.insert("session_setup_andx", 0x73u16);
+    cmd_names1.insert("logoff_andx", 0x74u16);
+    cmd_names1.insert("tree_connect_andx", 0x75u16);
+    cmd_names1.insert("security_package_andx", 0x7Eu16);
+    cmd_names1.insert("query_information_disk", 0x80u16);
+    cmd_names1.insert("search", 0x81u16);
+    cmd_names1.insert("find", 0x82u16);
+    cmd_names1.insert("find_unique", 0x83u16);
+    cmd_names1.insert("find_close", 0x84u16);
+    cmd_names1.insert("nt_transact", 0xA0u16);
+    cmd_names1.insert("nt_transact_secondary", 0xA1u16);
+    cmd_names1.insert("nt_create_andx", 0xA2u16);
+    cmd_names1.insert("nt_cancel", 0xA4u16);
+    cmd_names1.insert("nt_rename", 0xA5u16);
+    cmd_names1.insert("open_print_file", 0xC0u16);
+    cmd_names1.insert("write_print_file", 0xC1u16);
+    cmd_names1.insert("close_print_file", 0xC2u16);
+    cmd_names1.insert("get_print_queue", 0xC3u16);
+    cmd_names1.insert("read_bulk", 0xD8u16);
+    cmd_names1.insert("write_bulk", 0xD9u16);
+    cmd_names1.insert("write_bulk_data", 0xDAu16);
+    cmd_names1.insert("invalid", 0xFEu16);
+    cmd_names1.insert("no_andx_command", 0xFFu16);
+
+    return cmd_names1;
 }

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -297,6 +297,7 @@ fn parse_cmd_data(arg: &str) -> Result<SmbCmdData, ()> {
     let mut cmd_codes2 = HashSet::new();
 
     for cmd in split_args.iter() {
+        let cmd = cmd.trim();
 
         match str_to_u16(cmd) {
             Ok(cmd_code) =>  {
@@ -437,7 +438,7 @@ mod tests {
 
     #[test]
     fn test_parse_cmd_data() {
-        let option = "5,negotiate,0x8";
+        let option = "5,negotiate, 0x8";
 
         let cmd_names1 = gen_smb1_command_names();
         let cmd_names2 = gen_smb2_command_names();

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -293,6 +293,7 @@ noinst_HEADERS = \
 	detect-sip-stat-msg.h \
 	detect-sip-uri.h \
 	detect-smb-share.h \
+  detect-smb-cmd.h \
 	detect-snmp-community.h \
 	detect-snmp-pdu_type.h \
 	detect-snmp-version.h \
@@ -886,6 +887,7 @@ libsuricata_c_a_SOURCES = \
 	detect-sip-stat-msg.c \
 	detect-sip-uri.c \
 	detect-smb-share.c \
+  detect-smb-cmd.c \
 	detect-snmp-community.c \
 	detect-snmp-pdu_type.c \
 	detect-snmp-version.c \

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -74,6 +74,7 @@
 #include "detect-config.h"
 
 #include "detect-smb-share.h"
+#include "detect-smb-cmd.h"
 
 #include "detect-base64-decode.h"
 #include "detect-base64-data.h"
@@ -581,6 +582,7 @@ void SigTableSetup(void)
     DetectDceStubDataRegister();
     DetectSmbNamedPipeRegister();
     DetectSmbShareRegister();
+    DetectSmbCmdRegister();
     DetectTlsRegister();
     DetectTlsValidityRegister();
     DetectTlsVersionRegister();

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -189,6 +189,7 @@ enum DetectKeywordId {
     DETECT_DCE_STUB_DATA,
     DETECT_SMB_NAMED_PIPE,
     DETECT_SMB_SHARE,
+    DETECT_SMB_CMD,
 
     DETECT_ASN1,
 

--- a/src/detect-smb-cmd.c
+++ b/src/detect-smb-cmd.c
@@ -1,0 +1,128 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+
+#include "detect.h"
+#include "detect-parse.h"
+
+#include "detect-engine.h"
+#include "detect-engine-mpm.h"
+#include "detect-engine-state.h"
+#include "detect-engine-prefilter.h"
+#include "detect-engine-content-inspection.h"
+
+#include "detect-smb-cmd.h"
+#include "rust.h"
+
+#define PARSE_REGEX "^\\s*([0-9]{1,5}(\\s*-\\s*[0-9]{1,5}\\s*)?)(,\\s*[0-9]{1,5}(\\s*-\\s*[0-9]{1,5})?\\s*)*$"
+static DetectParseRegex parse_regex;
+
+static int g_smb_cmd_list_id = 0;
+
+static void DetectSmbCmdFree(DetectEngineCtx *de_ctx, void *ptr)
+{
+    SCEnter();
+
+    SCLogDebug("smb_cmd: DetectSmbCmdFree");
+
+    if (ptr != NULL) {
+        rs_smb_cmd_free(ptr);
+    }
+    SCReturn;
+}
+
+static int DetectSmbCmdSetup(
+    DetectEngineCtx *de_ctx,
+    Signature *s,
+    const char *arg)
+{
+    SCLogDebug("smb_cmd: DetectSmbCmdSetup");
+
+    if (DetectSignatureSetAppProto(s, ALPROTO_SMB) < 0)
+        return -1;
+
+    if (arg == NULL) {
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "Error parsing smb_cmd option in "
+                   "signature, it needs a value");
+        return -1;
+    }
+
+    void *dod = rs_smb_cmd_parse(arg);
+    if (dod == NULL) {
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "Error parsing smb_cmd option in "
+                   "signature");
+        return -1;
+    }
+
+    SigMatch *sm = SigMatchAlloc();
+    if (sm == NULL) {
+        DetectSmbCmdFree(de_ctx, dod);
+        return -1;
+    }
+
+    sm->type = DETECT_SMB_CMD;
+    sm->ctx = (void *)dod;
+
+    SigMatchAppendSMToList(s, sm, g_smb_cmd_list_id);
+    return 0;
+}
+
+static int DetectSmbCmdMatchRust(DetectEngineThreadCtx *det_ctx,
+        Flow *f, uint8_t flags, void *state, void *txv,
+        const Signature *s, const SigMatchCtx *m)
+{
+    SCEnter();
+
+    SCLogDebug("smb_cmd: DetectSmbCmdMatchRust");
+
+    if (rs_smb_cmd_match(txv, (void *)m) != 1)
+        SCReturnInt(0);
+
+    SCReturnInt(1);
+}
+
+static int DetectEngineInspectSmbCmd(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
+        uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+{
+    return DetectEngineInspectGenericList(
+            de_ctx, det_ctx, s, engine->smd, f, flags, alstate, txv, tx_id);
+}
+
+void DetectSmbCmdRegister(void)
+{
+    sigmatch_table[DETECT_SMB_CMD].name = "smb.cmd";
+    sigmatch_table[DETECT_SMB_CMD].alias = "smb_cmd";
+    sigmatch_table[DETECT_SMB_CMD].desc = "Match SMB message type";
+    sigmatch_table[DETECT_SMB_CMD].Setup = DetectSmbCmdSetup;
+    sigmatch_table[DETECT_SMB_CMD].Match = NULL;
+    sigmatch_table[DETECT_SMB_CMD].AppLayerTxMatch = DetectSmbCmdMatchRust;
+    sigmatch_table[DETECT_SMB_CMD].Free  = DetectSmbCmdFree;
+
+    DetectAppLayerInspectEngineRegister2("smb_cmd", ALPROTO_SMB, SIG_FLAG_TOSERVER, 0,
+            DetectEngineInspectSmbCmd, NULL);
+
+    DetectAppLayerInspectEngineRegister2("smb_cmd", ALPROTO_SMB, SIG_FLAG_TOCLIENT, 0,
+            DetectEngineInspectSmbCmd, NULL);
+
+    /* set up the PCRE for keyword parsing */
+    DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
+
+    g_smb_cmd_list_id = DetectBufferTypeRegister("smb_cmd");
+
+}

--- a/src/detect-smb-cmd.h
+++ b/src/detect-smb-cmd.h
@@ -1,0 +1,25 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef __DETECT_SMB_CMD_H__
+#define __DETECT_SMB_CMD_H__
+
+void DetectSmbCmdRegister(void);
+
+#endif /* __DETECT_SMB_CMD_H__ */
+
+


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: 
https://redmine.openinfosecfoundation.org/issues/5069

Describe changes:
- New keyword smb.cmd added, which allows to match the command value in smb message header. It works for smb1 and smb2.
- Documentation for the keyword added (created SMB keyword documentation)

Example of rule `alert smb any any -> any any (msg: "Smb command rule"; smb.cmd: 10; sid: 1;)` . More examples in documentation.

suricata-verify-pr: 733
