### PR TITLE
rust - vendoring fixups - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2305,21 +2305,6 @@ fi
     AC_SUBST(rust_vendor_comment)
     AM_CONDITIONAL([HAVE_RUST_VENDOR], [test "x$have_rust_vendor" = "xyes"])
 
-    # With Rust/Cargo 1.37 and greater, cargo-vendor is built-in.
-    AC_MSG_CHECKING(for cargo vendor support)
-    AS_VERSION_COMPARE([$cargo_version], [1.37.0],
-        [have_cargo_vendor="no"],
-        [have_cargo_vendor="yes"],
-        [have_cargo_vendor="yes"])
-    AC_MSG_RESULT($have_cargo_vendor)
-
-    # If Rust is older than 1.37, check for cargo-vendor as an
-    # external sub-command.
-    if test "x$have_cargo_vendor" != "xyes"; then
-        AC_CHECK_PROG(have_cargo_vendor_bin, cargo-vendor, yes, no)
-        have_cargo_vendor=$have_cargo_vendor_bin
-    fi
-
     have_rust_headers="no"
     AC_MSG_CHECKING(for $srcdir/rust/dist/rust-bindings.h)
     if test -f "$srcdir/rust/dist/rust-bindings.h"; then
@@ -2368,7 +2353,6 @@ fi
 
     AM_CONDITIONAL([HAVE_RUST_HEADERS], [test "x$have_rust_headers" = "xyes"])
     AM_CONDITIONAL([HAVE_CBINDGEN], [test "x$CBINDGEN" != "xno"])
-    AM_CONDITIONAL([HAVE_CARGO_VENDOR], [test "x$have_cargo_vendor" != "xno"])
 
     AC_ARG_ENABLE(rust_strict,
            AS_HELP_STRING([--enable-rust-strict], [Rust warnings as errors]),[enable_rust_strict=$enableval],[enable_rust_strict=no])
@@ -2589,7 +2573,6 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   Rust compiler version:                   ${rust_compiler_version}
   Cargo path:                              ${CARGO}
   Cargo version:                           ${cargo_version_output}
-  Cargo vendor:                            ${have_cargo_vendor}
 
   Python support:                          ${enable_python}
   Python path:                             ${python_path}

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -1,11 +1,8 @@
 EXTRA_DIST =	src derive \
 		.cargo/config.in \
 		cbindgen.toml \
-		dist/rust-bindings.h
-
-if HAVE_CARGO_VENDOR
-EXTRA_DIST +=	vendor
-endif
+		dist/rust-bindings.h \
+		vendor
 
 if !DEBUG
 RELEASE = --release
@@ -79,12 +76,8 @@ check:
 		CARGO_TARGET_DIR="$(abs_top_builddir)/rust/target" \
 		$(CARGO) test --all $(RELEASE) --features "$(RUST_FEATURES)"
 
-if HAVE_CARGO_VENDOR
 vendor:
 	CARGO_HOME="$(CARGO_HOME)" @rustup_home@ $(CARGO) vendor > /dev/null
-else
-vendor:
-endif
 
 if HAVE_CBINDGEN
 gen/rust-bindings.h: $(RUST_SURICATA_LIB)

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -71,7 +71,7 @@ endif
 distclean-local:
 	rm -f Cargo.lock
 
-maintainerclean-local:
+maintainer-clean-local:
 	rm -rf vendor gen
 
 check:


### PR DESCRIPTION
- Fix maintainer-clean target. The name of the target was wrong in the Makefile so never being executed. This cleaned up vendor sources on `make maintainer-clean`.
- No longer do a configure check for `cargo vendor`. Our MSRV has it built in.
