### PR TITLE
mqtt: raise event on parse error

### DIFF
--- a/rules/mqtt-events.rules
+++ b/rules/mqtt-events.rules
@@ -14,3 +14,4 @@ alert mqtt any any -> any any (msg:"SURICATA MQTT invalid QOS level"; app-layer-
 alert mqtt any any -> any any (msg:"SURICATA MQTT missing message ID"; app-layer-event:mqtt.missing_msg_id; classtype:protocol-command-decode; sid:2229007; rev:1;)
 alert mqtt any any -> any any (msg:"SURICATA MQTT unassigned message type (0 or >15)"; app-layer-event:mqtt.unassigned_msg_type; classtype:protocol-command-decode; sid:2229008; rev:1;)
 alert mqtt any any -> any any (msg:"SURICATA MQTT too many transactions"; app-layer-event:mqtt.too_many_transactions; classtype:protocol-command-decode; sid:2229009; rev:1;)
+alert mqtt any any -> any any (msg:"SURICATA MQTT parse error"; app-layer-event:mqtt.parse_error; classtype:protocol-command-decode; sid:2229010; rev:1;)

--- a/rust/src/mqtt/parser.rs
+++ b/rust/src/mqtt/parser.rs
@@ -92,7 +92,7 @@ pub fn parse_mqtt_string_pair(i: &[u8]) -> IResult<&[u8], (String, String)> {
 // MESSAGE COMPONENTS
 
 #[inline]
-pub fn parse_property(i: &[u8]) -> IResult<&[u8], MQTTProperty> {
+fn parse_property(i: &[u8]) -> IResult<&[u8], MQTTProperty> {
     let (i, identifier) = parse_mqtt_variable_integer(i)?;
     let (i, value) = parse_qualified_property(i, identifier)?;
     Ok((i, value))
@@ -187,7 +187,7 @@ fn parse_connect_variable_flags(i: &[u8]) -> IResult<&[u8], (u8, u8, u8, u8, u8,
 }
 
 #[inline]
-pub fn parse_connect(i: &[u8]) -> IResult<&[u8], MQTTConnectData> {
+fn parse_connect(i: &[u8]) -> IResult<&[u8], MQTTConnectData> {
     let (i, protocol_string) = parse_mqtt_string(i)?;
     let (i, protocol_version) = be_u8(i)?;
     let (i, flags) = parse_connect_variable_flags(i)?;
@@ -222,7 +222,7 @@ pub fn parse_connect(i: &[u8]) -> IResult<&[u8], MQTTConnectData> {
     ))
 }
 
-pub fn parse_connack(protocol_version: u8) -> impl Fn(&[u8]) -> IResult<&[u8], MQTTConnackData>
+fn parse_connack(protocol_version: u8) -> impl Fn(&[u8]) -> IResult<&[u8], MQTTConnackData>
 where
 {
     move |i: &[u8]| {
@@ -324,7 +324,7 @@ fn parse_msgidonly(protocol_version: u8) -> impl Fn(&[u8]) -> IResult<&[u8], MQT
 }
 
 #[inline]
-pub fn parse_msgidonly_v3(i: &[u8]) -> IResult<&[u8], MQTTMessageIdOnly> {
+fn parse_msgidonly_v3(i: &[u8]) -> IResult<&[u8], MQTTMessageIdOnly> {
     let (i, message_id) = be_u16(i)?;
     Ok((
         i,
@@ -337,7 +337,7 @@ pub fn parse_msgidonly_v3(i: &[u8]) -> IResult<&[u8], MQTTMessageIdOnly> {
 }
 
 #[inline]
-pub fn parse_subscribe_topic(i: &[u8]) -> IResult<&[u8], MQTTSubscribeTopicData> {
+fn parse_subscribe_topic(i: &[u8]) -> IResult<&[u8], MQTTSubscribeTopicData> {
     let (i, topic_name) = parse_mqtt_string(i)?;
     let (i, qos) = be_u8(i)?;
     Ok((i, MQTTSubscribeTopicData { topic_name, qos }))
@@ -362,7 +362,7 @@ where {
     }
 }
 
-pub fn parse_suback(protocol_version: u8) -> impl Fn(&[u8]) -> IResult<&[u8], MQTTSubackData>
+fn parse_suback(protocol_version: u8) -> impl Fn(&[u8]) -> IResult<&[u8], MQTTSubackData>
 where {
     move |i: &[u8]| {
         let (i, message_id) = be_u16(i)?;
@@ -378,7 +378,7 @@ where {
     }
 }
 
-pub fn parse_unsubscribe(
+fn parse_unsubscribe(
     protocol_version: u8,
 ) -> impl Fn(&[u8]) -> IResult<&[u8], MQTTUnsubscribeData>
 where {
@@ -397,7 +397,7 @@ where {
     }
 }
 
-pub fn parse_unsuback(protocol_version: u8) -> impl Fn(&[u8]) -> IResult<&[u8], MQTTUnsubackData>
+fn parse_unsuback(protocol_version: u8) -> impl Fn(&[u8]) -> IResult<&[u8], MQTTUnsubackData>
 where {
     move |i: &[u8]| {
         let (i, message_id) = be_u16(i)?;
@@ -474,7 +474,7 @@ where {
 }
 
 #[inline]
-pub fn parse_auth(i: &[u8]) -> IResult<&[u8], MQTTAuthData> {
+fn parse_auth(i: &[u8]) -> IResult<&[u8], MQTTAuthData> {
     let (i, reason_code) = be_u8(i)?;
     let (i, properties) = parse_properties(i, true)?;
     Ok((


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5018

Describe changes:
- Remove `pub` property from some parser functions.
- Always require `complete` parsing of all messages. This basically addresses any case where crafted internal buffer lengths exceed the total length given in the `remaining_length` header entry. Also see https://github.com/OISF/suricata/pull/6851#discussion_r803741210 for a discussion of this potential issue.
- Raise Suricata app-layer event `parse_error`  in case of  any parse error.

#suricata-verify-pr: 737
