### PR TITLE
detect/ip_proto: Use built-in protcol mapping table.

### DIFF
--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -38,6 +38,7 @@
 #include "detect-engine-address.h"
 
 #include "util-byte.h"
+#include "util-proto-name.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 
@@ -121,18 +122,21 @@ static DetectIPProtoData *DetectIPProtoParse(const char *optstr)
 
     /* Protocol name/number */
     if (!isdigit((unsigned char)*(args[1]))) {
-        struct protoent *pent = getprotobyname(args[1]);
-        if (pent == NULL) {
-            SCLogError(SC_ERR_INVALID_VALUE, "Malformed protocol name: %s",
-                       str_ptr);
+        int proto = SCGetProtoByName(args[1]);
+        if (-1 == proto) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Malformed protocol name: \"%s\"", str_ptr);
             goto error;
         }
-        data->proto = (uint8_t)pent->p_proto;
+        data->proto = (uint8_t)proto;
     }
     else {
         if (StringParseUint8(&data->proto, 10, 0, args[1]) <= 0) {
             SCLogError(SC_ERR_INVALID_VALUE, "Malformed protocol number: %s",
                        str_ptr);
+            goto error;
+        }
+        if (!SCProtoNameValid((uint16_t)data->proto)) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Unknown protocol number: %d", data->proto);
             goto error;
         }
     }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -306,6 +306,9 @@ static void SignalHandlerUnexpected(int sig_num, siginfo_t *info, void *context)
 {
     char msg[SC_LOG_MAX_LOG_MSG_LEN];
     unw_cursor_t cursor;
+    /* Restore defaults for signals to avoid loops */
+    signal(SIGABRT, SIG_DFL);
+    signal(SIGSEGV, SIG_DFL);
     int r;
     if ((r = unw_init_local(&cursor, (unw_context_t *)(context)) != 0)) {
         fprintf(stderr, "unable to obtain stack trace: unw_init_local: %s\n", unw_strerror(r));
@@ -338,9 +341,8 @@ static void SignalHandlerUnexpected(int sig_num, siginfo_t *info, void *context)
     SCLogError(SC_ERR_SIGNAL, "%s", msg);
 
 terminate:
-    // Terminate with SIGABRT ... but first, restore that signal's default handling
-    signal(SIGABRT, SIG_DFL);
-    abort();
+    // Propagate signal to watchers, if any
+    kill(0, sig_num);
 }
 #undef UNW_LOCAL_ONLY
 #endif /* HAVE_LIBUNWIND */

--- a/src/util-proto-name.c
+++ b/src/util-proto-name.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -195,4 +195,23 @@ const char *known_proto[256] = {
 bool SCProtoNameValid(uint16_t proto)
 {
     return (proto <= 255 && known_proto[proto] != NULL);
+}
+
+/**
+ * \brief   Function to return the protocol number for a named protocol.
+ *
+ * \param proto Protocol name.
+ * \retval ret On success returns the protocol number; else -1
+ */
+int SCGetProtoByName(char *protoname)
+{
+    if (protoname) {
+        for (int i = 0; i <= 255; i++) {
+            if (known_proto[i] &&
+                    0 == strncasecmp(known_proto[i], protoname, strlen(known_proto[i]))) {
+                return i;
+            }
+        }
+    }
+    return -1;
 }

--- a/src/util-proto-name.h
+++ b/src/util-proto-name.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -30,6 +30,7 @@
 extern const char *known_proto[256];
 
 bool SCProtoNameValid(uint16_t);
+int SCGetProtoByName(char *protoname);
 
 #endif	/* __UTIL_PROTO_NAME_H__ */
 


### PR DESCRIPTION
This PR modifies the detect keyword `ip_proto` to use the built-in protocol table instead of using the underlying system's.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5072](https://redmine.openinfosecfoundation.org/issues/5072)

Describe changes:
- Add utility function to validate protocol name


suricata-verify-pr: 738
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
