### PR TITLE
Fuzz maxtx v2

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1388,20 +1388,12 @@ Its default value is 4096 bytes, but it can be set to any uint32 by a flow.
 `http2.max-streams` refers to `SETTINGS_MAX_CONCURRENT_STREAMS` from rfc 7540 section 6.5.2.
 Its default value is unlimited.
 
-Configure MQTT
-~~~~~~~~~~~~~~
+Maximum transactions
+~~~~~~~~~~~~~~~~~~~~
 
-MQTT has one parameter that can be customized.
-`mqtt.max-tx` refers to the maximum number of live transactions for each flow.
-The app-layer event `mqtt.too_many_transactions` is triggered when this value is reached.
-The point of this parameter is to find a balance between the completeness of analysis
-and the resource consumption.
-
-Configure FTP
-~~~~~~~~~~~~~
-
-FTP has one parameter that can be customized.
-`ftp.max-tx` refers to the maximum number of live transactions for each flow.
+MQTT, FTP, and NFS have each a `max-tx` parameter that can be customized.
+`max-tx` refers to the maximum number of live transactions for each flow.
+An app-layer event `protocol.too_many_transactions` is triggered when this value is reached.
 The point of this parameter is to find a balance between the completeness of analysis
 and the resource consumption.
 

--- a/rules/nfs-events.rules
+++ b/rules/nfs-events.rules
@@ -6,3 +6,4 @@
 #
 alert nfs any any -> any any (msg:"SURICATA NFS malformed request data"; flow:to_server; app-layer-event:nfs.malformed_data; classtype:protocol-command-decode; sid:2223000; rev:1;)
 alert nfs any any -> any any (msg:"SURICATA NFS malformed response data"; flow:to_client; app-layer-event:nfs.malformed_data; classtype:protocol-command-decode; sid:2223001; rev:1;)
+alert nfs any any -> any any (msg:"SURICATA NFS too many transactions"; app-layer-event:nfs.too_many_transactions; classtype:protocol-command-decode; sid:2223002; rev:1;)

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -293,8 +293,6 @@ pub struct NFSState {
 
     pub nfs_version: u16,
 
-    pub events: u16,
-
     /// tx counter for assigning incrementing id's to tx's
     tx_id: u64,
 
@@ -330,7 +328,6 @@ impl NFSState {
             check_post_gap_file_txs:false,
             post_gap_files_checked:false,
             nfs_version:0,
-            events:0,
             tx_id:0,
             ts: 0,
         }
@@ -402,7 +399,6 @@ impl NFSState {
 
         let tx = &mut self.transactions[len - 1];
         tx.tx_data.set_event(event as u8);
-        self.events += 1;
     }
 
     // TODO maybe not enough users to justify a func

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -59,6 +59,9 @@ int LLVMFuzzerInitialize(int *argc, char ***argv)
     return 0;
 }
 
+// arbitrary value
+#define ALPROTO_MAXTX 4096
+
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     Flow * f;
@@ -166,6 +169,31 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             }
 
             AppLayerParserTransactionsCleanup(f);
+
+            if (f->alstate && f->alparser) {
+                // check if we have too many open transactions
+                const uint64_t total_txs = AppLayerParserGetTxCnt(f, f->alstate);
+                uint64_t min = 0;
+                AppLayerGetTxIterState state;
+                memset(&state, 0, sizeof(state));
+                uint64_t nbtx = 0;
+                AppLayerGetTxIteratorFunc IterFunc = AppLayerGetTxIterator(f->proto, f->alproto);
+                while (1) {
+                    AppLayerGetTxIterTuple ires =
+                            IterFunc(f->proto, f->alproto, f->alstate, min, total_txs, &state);
+                    if (ires.tx_ptr == NULL)
+                        break;
+                    min = ires.tx_id + 1;
+                    nbtx++;
+                    if (nbtx > ALPROTO_MAXTX) {
+                        printf("Too many open transactions for protocol %s\n",
+                                AppProtoToString(f->alproto));
+                        printf("Assertion failure: %s\n", AppProtoToString(f->alproto));
+                        fflush(stdout);
+                        abort();
+                    }
+                }
+            }
         }
         alsize -= alnext - albuffer + 4;
         albuffer = alnext + 4;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -886,6 +886,7 @@ app-layer:
 
     nfs:
       enabled: yes
+      # max-tx: 1024
     tftp:
       enabled: yes
     dns:


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4125

Describe changes:
- fuzz : finds if a flow has too many open/live transactions
- nfs : prevents the creation of too many transaction
 
This is to avoid DOS by quadratic complexity for protocols looping over the whole list of transactions looking for a
specific transation with an identifier, so that a new PDU gets processed within that transaction.

Comes from #6863 and CI should already catch missing protocol

Replaces #6923 with removing unused `events` variable