### PR TITLE
pthreads: set minimum stack size

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -739,6 +739,11 @@
 
     AC_CHECK_FUNCS([pthread_spin_unlock])
 
+    AS_IF([test "x$enable_debug" = "xyes"], [
+        # Debug only function used for diagnostic display
+        AC_CHECK_FUNCS([pthread_getattr_np])
+    ])
+
   # libjansson
     AC_ARG_WITH(libjansson_includes,
             [  --with-libjansson-includes=DIR  libjansson include directory],

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -730,6 +730,16 @@ waited for a detection thread. The remaining detection thread can
 become active.
 
 
+You can alter the per-thread stack-size if the default provided by
+your build system is too small. The default value is provided by
+your build system; we suggest setting the value to 8MB if the default
+value is too small.
+
+::
+
+  stack-size: 8MB
+
+
 In the option 'cpu affinity' you can set which CPU's/cores work on which
 thread. In this option there are several sets of threads. The management-,
 receive-, worker- and verdict-set. These are fixed names and can not be

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -58,6 +58,7 @@
 
 int debuglog_enabled = 0;
 int threading_set_cpu_affinity = FALSE;
+uint64_t threading_set_stack_size = 0;
 
 /* Runmode Global Thread Names */
 const char *thread_name_autofp = "RX";
@@ -945,4 +946,20 @@ void RunModeInitialize(void)
     }
 
     SCLogDebug("threading.detect-thread-ratio %f", threading_detect_ratio);
+
+    /*
+     * Check if there's a configuration setting for the per-thread stack size
+     * in case the default per-thread stack size is to be adjusted
+     */
+    const char *ss = NULL;
+    if ((ConfGetValue("threading.stack-size", &ss)) == 1) {
+        if (ss != NULL) {
+            if (ParseSizeStringU64(ss, &threading_set_stack_size) < 0) {
+                FatalError(SC_ERR_INVALID_ARGUMENT,
+                        "Failed to initialize thread_stack_size output, invalid limit: %s", ss);
+            }
+        }
+    }
+
+    SCLogDebug("threading.stack-size %" PRIu64, threading_set_stack_size);
 }

--- a/src/runmodes.h
+++ b/src/runmodes.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -115,6 +115,7 @@ int RunModeNeedsBypassManager(void);
 
 extern int threading_set_cpu_affinity;
 extern float threading_detect_ratio;
+extern uint64_t threading_set_stack_size;
 
 extern int debuglog_enabled;
 

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1721,7 +1721,7 @@ TmEcode TmThreadSpawn(ThreadVars *tv)
 {
     pthread_attr_t attr;
     if (tv->tm_func == NULL) {
-        printf("ERROR: no thread function set\n");
+        FatalError(SC_ERR_TM_THREADS_ERROR, "ERROR: no thread function set\n");
         return TM_ECODE_FAILED;
     }
 
@@ -1730,11 +1730,36 @@ TmEcode TmThreadSpawn(ThreadVars *tv)
 
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 
+    if (threading_set_stack_size) {
+        /* Adjust thread stack size if configured */
+        SCLogDebug("Setting per-thread stack size to %" PRIu64, threading_set_stack_size);
+        if (pthread_attr_setstacksize(&attr, (size_t)threading_set_stack_size)) {
+            FatalError(SC_ERR_TM_THREADS_ERROR,
+                    "Unable to increase stack size to %" PRIu64 " in thread attributes\n",
+                    threading_set_stack_size);
+        }
+    }
+
     int rc = pthread_create(&tv->t, &attr, tv->tm_func, (void *)tv);
     if (rc) {
-        printf("ERROR; return code from pthread_create() is %" PRId32 "\n", rc);
-        return TM_ECODE_FAILED;
+        FatalError(SC_ERR_THREAD_CREATE,
+                "Unable to create thread with pthread_create() is %" PRId32 "\n", rc);
     }
+
+#if DEBUG && HAVE_PTHREAD_GETATTR_NP
+    if (threading_set_stack_size) {
+        if (pthread_getattr_np(tv->t, &attr) == 0) {
+            size_t stack_size;
+            void *stack_addr;
+            pthread_attr_getstack(&attr, &stack_addr, &stack_size);
+            SCLogDebug("stack: %p;  size %" PRIu64, stack_addr, (uint64_t)stack_size);
+        } else {
+            SCLogDebug("ERROR: unable to retrieve current stack-size for display; return code from "
+                       "pthread_getattr_np() is %" PRId32 "\n",
+                    rc);
+        }
+    }
+#endif
 
     TmThreadWaitForFlag(tv, THV_INIT_DONE | THV_RUNNING_DONE);
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1587,6 +1587,14 @@ threading:
   # thread will always be created.
   #
   detect-thread-ratio: 1.0
+  #
+  # By default, the per-thread stack size is left to its default setting. If
+  # the default thread stack size is too small, use the following configuration
+  # setting to change the size. Note that if any thread's stack size cannot be
+  # set to this value, a fatal error occurs.
+  #
+  # Generally, the per-thread stack-size should not exceed 8MB.
+  #stack-size: 8mb
 
 # Luajit has a strange memory requirement, its 'states' need to be in the
 # first 2G of the process' memory.


### PR DESCRIPTION
Continuation of #6995

This PR exposes a configuration setting for the per-thread stack size. Some runtime environments, like MUSL, have a small stack size for each thread. This setting allows the stack size to be increased when needed.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4550](https://redmine.openinfosecfoundation.org/issues/4550)

Describe changes:
- Add config setting for per-thread stack size: `threading.stack-size`
- Fetch configuration setting during runmode setup
- Apply per-thread stack setting (if configured)
- Document configuration setting for per-thread stack size

Updates
- clang-format fixup
- debug print config probe

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
