### PR TITLE
smb: check correct buffer for overflow - v1

### DIFF
--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1375,7 +1375,7 @@ impl SMBState {
             0 => i,
             _ => {
                 v = self.tcp_buffer_ts.split_off(0);
-                if self.tcp_buffer_ts.len() + i.len() > 100000 {
+                if v.len() + i.len() > 100000 {
                     self.set_event(SMBEvent::RecordOverflow);
                     return 1;
                 };


### PR DESCRIPTION
Fix an error in the checking of an overflow condition.

The first overflow check is only checking the size of the new data, not
the new data + the size of the buffered data. This is due to the buffer
on the state being emptied into a local variable just before the check.

This results in overflows not being caught, but being caught a few lines
down after the copy resulting in increased CPU usage for data that is
just going to be thrown away.

Ticket https://redmine.openinfosecfoundation.org/issues/4945

This doesn't solve the problem of why we enter an overflow state, but does reduce CPU usage when we do enter the overflow state.