### PR TITLE
detect: only apply ConfigApplyTx with app-layers

### DIFF
--- a/src/detect-config.c
+++ b/src/detect-config.c
@@ -288,6 +288,10 @@ static int DetectConfigSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
         fd->scope = CONFIG_SCOPE_TX;
     }
 
+    if (fd->scope == CONFIG_SCOPE_TX) {
+        s->flags |= SIG_FLAG_APPLAYER;
+    }
+
     sm->ctx = (SigMatchCtx*)fd;
     SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4972

Describe changes:
- detect: only apply ConfigApplyTx with app-layers

> If the scope is flow it should require a flow to be present.

How do we do that ?
I do not see `SIG_FLAG_FLOW`