### PR TITLE
rust/derive: pin proc-macro-crate to v1.1.0 - v1

### DIFF
--- a/rust/derive/Cargo.toml.in
+++ b/rust/derive/Cargo.toml.in
@@ -8,6 +8,7 @@ proc-macro = true
 path = "@e_rustdir@/derive/src/lib.rs"
 
 [dependencies]
-proc-macro2 = "1.0"
+proc-macro-crate = "= 1.1.0"
+proc-macro2 = "1.0.36"
 quote = "1.0"
 syn = "1.0"


### PR DESCRIPTION
The just released proc-macro-crate v1.1.2 requires at least Rust 1.53.
Pin to the previous release for now.

The commit in question, https://github.com/bkchr/proc-macro-crate/commit/394f6f6d1564a0f4b3f26bcea8563381731dcecb, increases the minimum Rust version from 1.45 (or maybe even older) to 1.53.