### PR TITLE
build-info: add info about fuzztargets - v2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2592,6 +2592,7 @@ Development settings:
   Unit tests enabled:                      ${enable_unittests}
   Debug output enabled:                    ${enable_debug}
   Debug validation enabled:                ${enable_debug_validation}
+  Fuzz targets enabled:                    ${enable_fuzztargets}
 
 Generic build parameters:
   Installation prefix:                     ${prefix}


### PR DESCRIPTION
We were missing that information from the Development information. It is something useful to know, so it makes sense that we have it there, alongside with other configure enabled options...

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
none

Previous PR:
https://github.com/OISF/suricata/pull/7030

Describe changes:
- cleanup extra line added by mistake