### PR TITLE
rust/frames: derive direction from StreamSlice - v1

### DIFF
--- a/rust/src/frames.rs
+++ b/rust/src/frames.rs
@@ -17,6 +17,7 @@
 
 use crate::applayer::StreamSlice;
 use crate::core::Flow;
+use crate::core::STREAM_TOSERVER;
 
 #[repr(C)]
 struct CFrame {
@@ -37,19 +38,22 @@ extern {
 
 pub struct Frame {
     pub id: i64,
+    direction: i32,
 }
 
 impl std::fmt::Debug for Frame {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "frame: {}", self.id)
+        write!(f, "frame: {}, direction: {}", self.id, self.direction)
     }
 }
 
 impl Frame {
     pub fn new(
         flow: *const Flow, stream_slice: &StreamSlice, frame_start: &[u8], frame_len: i64,
-        dir: i32, frame_type: u8,
+        frame_type: u8,
     ) -> Option<Self> {
+        // Derive the direction from the stream slice, 0 for to server, 1 for to client.
+        let direction = if stream_slice.flags() & STREAM_TOSERVER != 0 { 0 } else { 1 };
         let offset = frame_start.as_ptr() as usize - stream_slice.as_slice().as_ptr() as usize;
         SCLogDebug!("offset {} stream_slice.len() {} frame_start.len() {}", offset, stream_slice.len(), frame_start.len());
         let frame = unsafe {
@@ -58,47 +62,33 @@ impl Frame {
                 stream_slice,
                 offset as u32,
                 frame_len,
-                dir,
+                direction,
                 frame_type,
             )
         };
         let id = unsafe { AppLayerFrameGetId(frame) };
         if id > 0 {
-            Some(Self { id })
+            Some(Self { id, direction })
         } else {
             None
         }
     }
 
-    pub fn new_ts(
-        flow: *const Flow, stream_slice: &StreamSlice, frame_start: &[u8], frame_len: i64,
-        frame_type: u8,
-    ) -> Option<Self> {
-        Self::new(flow, stream_slice, frame_start, frame_len, 0, frame_type)
-    }
-
-    pub fn new_tc(
-        flow: *const Flow, stream_slice: &StreamSlice, frame_start: &[u8], frame_len: i64,
-        frame_type: u8,
-    ) -> Option<Self> {
-        Self::new(flow, stream_slice, frame_start, frame_len, 1, frame_type)
-    }
-
-    pub fn set_len(&self, flow: *const Flow, dir: i32, len: i64) {
+    pub fn set_len(&self, flow: *const Flow, len: i64) {
         unsafe {
-            AppLayerFrameSetLengthById(flow, dir, self.id, len);
+            AppLayerFrameSetLengthById(flow, self.direction, self.id, len);
         };
     }
 
-    pub fn set_tx(&self, flow: *const Flow, dir: i32, tx_id: u64) {
+    pub fn set_tx(&self, flow: *const Flow, tx_id: u64) {
         unsafe {
-            AppLayerFrameSetTxIdById(flow, dir, self.id, tx_id);
+            AppLayerFrameSetTxIdById(flow, self.direction, self.id, tx_id);
         };
     }
 
-    pub fn add_event(&self, flow: *const Flow, dir: i32, event: u8) {
+    pub fn add_event(&self, flow: *const Flow, event: u8) {
         unsafe {
-            AppLayerFrameAddEventById(flow, dir, self.id, event);
+            AppLayerFrameAddEventById(flow, self.direction, self.id, event);
         };
     }
 }

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -112,7 +112,7 @@ impl SIPState {
     // app-layer-frame-documentation tag start: parse_request
     fn parse_request(&mut self, flow: *const core::Flow, stream_slice: StreamSlice) -> bool {
         let input = stream_slice.as_slice();
-        let _pdu = Frame::new_ts(
+        let _pdu = Frame::new(
             flow,
             &stream_slice,
             input,
@@ -146,7 +146,7 @@ impl SIPState {
 
     fn parse_response(&mut self, flow: *const core::Flow, stream_slice: StreamSlice) -> bool {
         let input = stream_slice.as_slice();
-        let _pdu = Frame::new_tc(flow, &stream_slice, input, input.len() as i64, SIPFrameType::Pdu as u8);
+        let _pdu = Frame::new(flow, &stream_slice, input, input.len() as i64, SIPFrameType::Pdu as u8);
         SCLogDebug!("tc: pdu {:?}", _pdu);
 
         match sip_parse_response(input) {
@@ -188,7 +188,7 @@ impl SIPTransaction {
 // app-layer-frame-documentation tag start: function to add frames
 fn sip_frames_ts(flow: *const core::Flow, stream_slice: &StreamSlice, r: &Request) {
     let oi = stream_slice.as_slice();
-    let _f = Frame::new_ts(
+    let _f = Frame::new(
         flow,
         stream_slice,
         oi,
@@ -197,7 +197,7 @@ fn sip_frames_ts(flow: *const core::Flow, stream_slice: &StreamSlice, r: &Reques
     );
     SCLogDebug!("ts: request_line {:?}", _f);
     let hi = &oi[r.request_line_len as usize..];
-    let _f = Frame::new_ts(
+    let _f = Frame::new(
         flow,
         stream_slice,
         hi,
@@ -207,7 +207,7 @@ fn sip_frames_ts(flow: *const core::Flow, stream_slice: &StreamSlice, r: &Reques
     SCLogDebug!("ts: request_headers {:?}", _f);
     if r.body_len > 0 {
         let bi = &oi[r.body_offset as usize..];
-        let _f = Frame::new_ts(
+        let _f = Frame::new(
             flow,
             stream_slice,
             bi,
@@ -221,14 +221,14 @@ fn sip_frames_ts(flow: *const core::Flow, stream_slice: &StreamSlice, r: &Reques
 
 fn sip_frames_tc(flow: *const core::Flow, stream_slice: &StreamSlice, r: &Response) {
     let oi = stream_slice.as_slice();
-    let _f = Frame::new_tc(flow, stream_slice, oi, r.response_line_len as i64, SIPFrameType::ResponseLine as u8);
+    let _f = Frame::new(flow, stream_slice, oi, r.response_line_len as i64, SIPFrameType::ResponseLine as u8);
     let hi = &oi[r.response_line_len as usize ..];
     SCLogDebug!("tc: response_line {:?}", _f);
-    let _f = Frame::new_tc(flow, stream_slice, hi, r.headers_len as i64, SIPFrameType::ResponseHeaders as u8);
+    let _f = Frame::new(flow, stream_slice, hi, r.headers_len as i64, SIPFrameType::ResponseHeaders as u8);
     SCLogDebug!("tc: response_headers {:?}", _f);
     if r.body_len > 0 {
         let bi = &oi[r.body_offset as usize ..];
-        let _f = Frame::new_tc(flow, stream_slice, bi, r.body_len as i64, SIPFrameType::ResponseBody as u8);
+        let _f = Frame::new(flow, stream_slice, bi, r.body_len as i64, SIPFrameType::ResponseBody as u8);
         SCLogDebug!("tc: response_body {:?}", _f);
     }
 }

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1236,53 +1236,53 @@ impl SMBState {
     }
 
     fn add_nbss_ts_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) -> (Option<Frame>, Option<Frame>, Option<Frame>) {
-        let nbss_pdu = Frame::new_ts(flow, stream_slice, input, nbss_len + 4, SMBFrameType::NBSSPdu as u8);
+        let nbss_pdu = Frame::new(flow, stream_slice, input, nbss_len + 4, SMBFrameType::NBSSPdu as u8);
         SCLogDebug!("NBSS PDU frame {:?}", nbss_pdu);
-        let nbss_hdr_frame = Frame::new_ts(flow, stream_slice, input, 4 as i64, SMBFrameType::NBSSHdr as u8);
+        let nbss_hdr_frame = Frame::new(flow, stream_slice, input, 4 as i64, SMBFrameType::NBSSHdr as u8);
         SCLogDebug!("NBSS HDR frame {:?}", nbss_hdr_frame);
-        let nbss_data_frame = Frame::new_ts(flow, stream_slice, &input[4..], nbss_len, SMBFrameType::NBSSData as u8);
+        let nbss_data_frame = Frame::new(flow, stream_slice, &input[4..], nbss_len, SMBFrameType::NBSSData as u8);
         SCLogDebug!("NBSS DATA frame {:?}", nbss_data_frame);
         (nbss_pdu, nbss_hdr_frame, nbss_data_frame)
     }
 
     fn add_smb1_ts_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) -> Option<Frame> {
-        let smb_pdu = Frame::new_ts(flow, stream_slice, input, nbss_len, SMBFrameType::SMB1Pdu as u8);
+        let smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB1Pdu as u8);
         SCLogDebug!("SMB PDU frame {:?}", smb_pdu);
         smb_pdu
     }
     fn add_smb1_ts_hdr_data_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) {
-        let _smb1_hdr = Frame::new_ts(flow, stream_slice, input, 32 as i64, SMBFrameType::SMB1Hdr as u8);
+        let _smb1_hdr = Frame::new(flow, stream_slice, input, 32 as i64, SMBFrameType::SMB1Hdr as u8);
         SCLogDebug!("SMBv1 HDR frame {:?}", _smb1_hdr);
         if input.len() > 32 {
-            let _smb1_data = Frame::new_ts(flow, stream_slice, &input[32..], (nbss_len - 32) as i64, SMBFrameType::SMB1Data as u8);
+            let _smb1_data = Frame::new(flow, stream_slice, &input[32..], (nbss_len - 32) as i64, SMBFrameType::SMB1Data as u8);
             SCLogDebug!("SMBv1 DATA frame {:?}", _smb1_data);
         }
     }
 
     fn add_smb2_ts_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) -> Option<Frame> {
-        let smb_pdu = Frame::new_ts(flow, stream_slice, input, nbss_len, SMBFrameType::SMB2Pdu as u8);
+        let smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB2Pdu as u8);
         SCLogDebug!("SMBv2 PDU frame {:?}", smb_pdu);
         smb_pdu
     }
     fn add_smb2_ts_hdr_data_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64, hdr_len: i64) {
-        let _smb2_hdr = Frame::new_ts(flow, stream_slice, input, hdr_len, SMBFrameType::SMB2Hdr as u8);
+        let _smb2_hdr = Frame::new(flow, stream_slice, input, hdr_len, SMBFrameType::SMB2Hdr as u8);
         SCLogDebug!("SMBv2 HDR frame {:?}", _smb2_hdr);
         if input.len() > hdr_len as usize {
-            let _smb2_data = Frame::new_ts(flow, stream_slice, &input[hdr_len as usize..], nbss_len - hdr_len, SMBFrameType::SMB2Data as u8);
+            let _smb2_data = Frame::new(flow, stream_slice, &input[hdr_len as usize..], nbss_len - hdr_len, SMBFrameType::SMB2Data as u8);
             SCLogDebug!("SMBv2 DATA frame {:?}", _smb2_data);
         }
     }
 
     fn add_smb3_ts_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) -> Option<Frame> {
-        let smb_pdu = Frame::new_ts(flow, stream_slice, input, nbss_len, SMBFrameType::SMB3Pdu as u8);
+        let smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB3Pdu as u8);
         SCLogDebug!("SMBv3 PDU frame {:?}", smb_pdu);
         smb_pdu
     }
     fn add_smb3_ts_hdr_data_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) {
-        let _smb3_hdr = Frame::new_ts(flow, stream_slice, input, 52 as i64, SMBFrameType::SMB3Hdr as u8);
+        let _smb3_hdr = Frame::new(flow, stream_slice, input, 52 as i64, SMBFrameType::SMB3Hdr as u8);
         SCLogDebug!("SMBv3 HDR frame {:?}", _smb3_hdr);
         if input.len() > 52 {
-            let _smb3_data = Frame::new_ts(flow, stream_slice, &input[52..], (nbss_len - 52) as i64, SMBFrameType::SMB3Data as u8);
+            let _smb3_data = Frame::new(flow, stream_slice, &input[52..], (nbss_len - 52) as i64, SMBFrameType::SMB3Data as u8);
             SCLogDebug!("SMBv3 DATA frame {:?}", _smb3_data);
         }
     }
@@ -1459,7 +1459,7 @@ impl SMBState {
                                         },
                                         _ => {
                                             if let Some(frame) = nbss_data_frame {
-                                                frame.add_event(flow, 0, SMBEvent::MalformedData as u8);
+                                                frame.add_event(flow, SMBEvent::MalformedData as u8);
                                             }
                                             self.set_event(SMBEvent::MalformedData);
                                             return AppLayerResult::err();
@@ -1480,7 +1480,7 @@ impl SMBState {
                                             },
                                             _ => {
                                                 if let Some(frame) = nbss_data_frame {
-                                                    frame.add_event(flow, 0, SMBEvent::MalformedData as u8);
+                                                    frame.add_event(flow, SMBEvent::MalformedData as u8);
                                                 }
                                                 self.set_event(SMBEvent::MalformedData);
                                                 return AppLayerResult::err();
@@ -1501,7 +1501,7 @@ impl SMBState {
                                             },
                                             _ => {
                                                 if let Some(frame) = nbss_data_frame {
-                                                    frame.add_event(flow, 0, SMBEvent::MalformedData as u8);
+                                                    frame.add_event(flow, SMBEvent::MalformedData as u8);
                                                 }
                                                 self.set_event(SMBEvent::MalformedData);
                                                 return AppLayerResult::err();
@@ -1562,51 +1562,51 @@ impl SMBState {
     }
 
     fn add_nbss_tc_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) -> (Option<Frame>, Option<Frame>, Option<Frame>) {
-        let nbss_pdu = Frame::new_tc(flow, stream_slice, input, nbss_len + 4, SMBFrameType::NBSSPdu as u8);
+        let nbss_pdu = Frame::new(flow, stream_slice, input, nbss_len + 4, SMBFrameType::NBSSPdu as u8);
         SCLogDebug!("NBSS PDU frame {:?}", nbss_pdu);
-        let nbss_hdr_frame = Frame::new_tc(flow, stream_slice, input, 4 as i64, SMBFrameType::NBSSHdr as u8);
+        let nbss_hdr_frame = Frame::new(flow, stream_slice, input, 4 as i64, SMBFrameType::NBSSHdr as u8);
         SCLogDebug!("NBSS HDR frame {:?}", nbss_hdr_frame);
-        let nbss_data_frame = Frame::new_tc(flow, stream_slice, &input[4..], nbss_len, SMBFrameType::NBSSData as u8);
+        let nbss_data_frame = Frame::new(flow, stream_slice, &input[4..], nbss_len, SMBFrameType::NBSSData as u8);
         SCLogDebug!("NBSS DATA frame {:?}", nbss_data_frame);
         (nbss_pdu, nbss_hdr_frame, nbss_data_frame)
     }
 
     fn add_smb1_tc_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) {
-        let _smb_pdu = Frame::new_tc(flow, stream_slice, input, nbss_len, SMBFrameType::SMB1Pdu as u8);
+        let _smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB1Pdu as u8);
         SCLogDebug!("SMB PDU frame {:?}", _smb_pdu);
     }
     fn add_smb1_tc_hdr_data_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) {
-        let _smb1_hdr = Frame::new_tc(flow, stream_slice, input, SMB1_HEADER_SIZE as i64, SMBFrameType::SMB1Hdr as u8);
+        let _smb1_hdr = Frame::new(flow, stream_slice, input, SMB1_HEADER_SIZE as i64, SMBFrameType::SMB1Hdr as u8);
         SCLogDebug!("SMBv1 HDR frame {:?}", _smb1_hdr);
         if input.len() > SMB1_HEADER_SIZE {
-            let _smb1_data = Frame::new_tc(flow, stream_slice, &input[SMB1_HEADER_SIZE..], (nbss_len - SMB1_HEADER_SIZE as i64) as i64,
+            let _smb1_data = Frame::new(flow, stream_slice, &input[SMB1_HEADER_SIZE..], (nbss_len - SMB1_HEADER_SIZE as i64) as i64,
                     SMBFrameType::SMB1Data as u8);
             SCLogDebug!("SMBv1 DATA frame {:?}", _smb1_data);
         }
     }
 
     fn add_smb2_tc_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) {
-        let _smb_pdu = Frame::new_tc(flow, stream_slice, input, nbss_len, SMBFrameType::SMB2Pdu as u8);
+        let _smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB2Pdu as u8);
         SCLogDebug!("SMBv2 PDU frame {:?}", _smb_pdu);
     }
     fn add_smb2_tc_hdr_data_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64, hdr_len: i64) {
-        let _smb2_hdr = Frame::new_tc(flow, stream_slice, input, hdr_len, SMBFrameType::SMB2Hdr as u8);
+        let _smb2_hdr = Frame::new(flow, stream_slice, input, hdr_len, SMBFrameType::SMB2Hdr as u8);
         SCLogDebug!("SMBv2 HDR frame {:?}", _smb2_hdr);
         if input.len() > hdr_len as usize {
-            let _smb2_data = Frame::new_tc(flow, stream_slice, &input[hdr_len as usize ..], nbss_len - hdr_len, SMBFrameType::SMB2Data as u8);
+            let _smb2_data = Frame::new(flow, stream_slice, &input[hdr_len as usize ..], nbss_len - hdr_len, SMBFrameType::SMB2Data as u8);
             SCLogDebug!("SMBv2 DATA frame {:?}", _smb2_data);
         }
     }
 
     fn add_smb3_tc_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) {
-        let _smb_pdu = Frame::new_tc(flow, stream_slice, input, nbss_len, SMBFrameType::SMB3Pdu as u8);
+        let _smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB3Pdu as u8);
         SCLogDebug!("SMBv3 PDU frame {:?}", _smb_pdu);
     }
     fn add_smb3_tc_hdr_data_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) {
-        let _smb3_hdr = Frame::new_tc(flow, stream_slice, input, 52 as i64, SMBFrameType::SMB3Hdr as u8);
+        let _smb3_hdr = Frame::new(flow, stream_slice, input, 52 as i64, SMBFrameType::SMB3Hdr as u8);
         SCLogDebug!("SMBv3 HDR frame {:?}", _smb3_hdr);
         if input.len() > 52 {
-            let _smb3_data = Frame::new_tc(flow, stream_slice, &input[52..], (nbss_len - 52) as i64, SMBFrameType::SMB3Data as u8);
+            let _smb3_data = Frame::new(flow, stream_slice, &input[52..], (nbss_len - 52) as i64, SMBFrameType::SMB3Data as u8);
             SCLogDebug!("SMBv3 DATA frame {:?}", _smb3_data);
         }
     }

--- a/rust/src/telnet/telnet.rs
+++ b/rust/src/telnet/telnet.rs
@@ -166,7 +166,7 @@ impl TelnetState {
         let mut start = input;
         while start.len() > 0 {
             if self.request_frame.is_none() {
-                self.request_frame = Frame::new_ts(
+                self.request_frame = Frame::new(
                     flow,
                     stream_slice,
                     start,
@@ -177,7 +177,7 @@ impl TelnetState {
             if self.request_specific_frame.is_none() {
                 if let Ok((_, is_ctl)) = parser::peek_message_is_ctl(start) {
                     let f = if is_ctl {
-                        Frame::new_ts(
+                        Frame::new(
                             flow,
                             stream_slice,
                             start,
@@ -185,7 +185,7 @@ impl TelnetState {
                             TelnetFrameType::Ctl as u8,
                         )
                     } else {
-                        Frame::new_ts(
+                        Frame::new(
                             flow,
                             stream_slice,
                             start,
@@ -207,12 +207,12 @@ impl TelnetState {
                     start = rem;
 
                     if let Some(frame) = &self.request_frame {
-                        frame.set_len(flow, 0, consumed as i64);
+                        frame.set_len(flow, consumed as i64);
                         // app-layer-frame-documentation tag end: update frame_len
                         self.request_frame = None;
                     }
                     if let Some(frame) = &self.request_specific_frame {
-                        frame.set_len(flow, 0, consumed as i64);
+                        frame.set_len(flow, consumed as i64);
                         self.request_specific_frame = None;
                     }
 
@@ -274,14 +274,14 @@ impl TelnetState {
         let mut start = input;
         while start.len() > 0 {
             if self.response_frame.is_none() {
-                self.response_frame = Frame::new_tc(flow, stream_slice, start, -1 as i64, TelnetFrameType::Pdu as u8);
+                self.response_frame = Frame::new(flow, stream_slice, start, -1 as i64, TelnetFrameType::Pdu as u8);
             }
             if self.response_specific_frame.is_none() {
                 if let Ok((_, is_ctl)) = parser::peek_message_is_ctl(start) {
                     self.response_specific_frame = if is_ctl {
-                        Frame::new_tc(flow, stream_slice, start, -1 as i64, TelnetFrameType::Ctl as u8)
+                        Frame::new(flow, stream_slice, start, -1 as i64, TelnetFrameType::Ctl as u8)
                     } else {
-                        Frame::new_tc(flow, stream_slice, start, -1 as i64, TelnetFrameType::Data as u8)
+                        Frame::new(flow, stream_slice, start, -1 as i64, TelnetFrameType::Data as u8)
                     };
                 }
             }
@@ -298,11 +298,11 @@ impl TelnetState {
                     start = rem;
 
                     if let Some(frame) = &self.response_frame {
-                        frame.set_len(flow, 1, consumed as i64);
+                        frame.set_len(flow, consumed as i64);
                         self.response_frame = None;
                     }
                     if let Some(frame) = &self.response_specific_frame {
-                        frame.set_len(flow, 1, consumed as i64);
+                        frame.set_len(flow, consumed as i64);
                         self.response_specific_frame = None;
                     }
 


### PR DESCRIPTION
On the Rust side, a Frame requires a StreamSlice to be created. We can
derive the direction and retain the direction from the StreamSlice
removing the need for callers to provide the direction when operating on
the frame.

Am I missing a reason why this might not be a good idea or work in all cases?