### PR TITLE
devguide: clarify style guide for getframe funcs - v1

### DIFF
--- a/doc/devguide/extending/app-layer/app-layer-frames.rst
+++ b/doc/devguide/extending/app-layer/app-layer-frames.rst
@@ -190,6 +190,8 @@ Register relevant callbacks (note that the actual functions will also have to be
     :end-before: /* app-layer-frame-documentation tag end: registering relevant callbacks
     :dedent: 8
 
+.. note:: The ``GetFrameIdByName`` functions can be "probed", so they should not generate any output or that could be misleading (for instance, Suricata generating a log message stating that a valid frame type is unknown).
+
 Visual context
 ==============
 


### PR DESCRIPTION
As the GetFrameIdByName can be probed, we must warn developers not to
leave any output in them, or misleading messages could be printed.
(Related to a bug observed in the SSL code).

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/5129