### PR TITLE
nfs4: add missing parsers v1

### DIFF
--- a/rust/src/nfs/nfs4_records.rs
+++ b/rust/src/nfs/nfs4_records.rs
@@ -67,6 +67,7 @@ pub enum Nfs4RequestContent<'a> {
     SecInfoNoName(u32),
     LayoutGet(Nfs4RequestLayoutGet<'a>),
     GetDevInfo(Nfs4RequestGetDevInfo<'a>),
+    LayoutReturn(Nfs4RequestLayoutReturn<'a>),
 }
 
 #[derive(Debug,PartialEq)]
@@ -134,6 +135,34 @@ fn nfs4_parse_nfsstring(i: &[u8]) -> IResult<&[u8], &[u8]> {
     let (i, data) = take(len as usize)(i)?;
     let (i, _fill_bytes) = cond(len % 4 != 0, take(4 - (len % 4)))(i)?;
     Ok((i, data))
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Nfs4RequestLayoutReturn<'a> {
+    pub layout_type: u32,
+    pub return_type: u32,
+    pub length: u64,
+    pub stateid: Nfs4StateId<'a>,
+    pub lrf_data: &'a[u8],
+}
+
+fn nfs4_req_layoutreturn(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+    let (i, _reclaim) = be_u32(i)?;
+    let (i, layout_type) = be_u32(i)?;
+    let (i, _iq_mode) = be_u32(i)?;
+    let (i, return_type) = be_u32(i)?;
+    let (i, _offset) = be_u64(i)?;
+    let (i, length) = be_u64(i)?;
+    let (i, stateid) = nfs4_parse_stateid(i)?;
+    let (i, lrf_data) = nfs4_parse_nfsstring(i)?;
+    let req = Nfs4RequestContent::LayoutReturn(Nfs4RequestLayoutReturn {
+        layout_type,
+        return_type,
+        length,
+        stateid,
+        lrf_data,
+    });
+    Ok((i, req))
 }
 
 #[derive(Debug, PartialEq)]
@@ -554,6 +583,7 @@ fn parse_request_compound_command(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent
         NFSPROC4_SECINFO_NO_NAME => nfs4_req_secinfo_no_name(i)?,
         NFSPROC4_LAYOUTGET => nfs4_req_layoutget(i)?,
         NFSPROC4_GETDEVINFO => nfs4_req_getdevinfo(i)?,
+        NFSPROC4_LAYOUTRETURN => nfs4_req_layoutreturn(i)?,
         _ => { return Err(Err::Error(make_error(i, ErrorKind::Switch))); }
     };
     Ok((i, cmd_data))
@@ -607,6 +637,14 @@ pub enum Nfs4ResponseContent<'a> {
     SecInfoNoName(u32),
     LayoutGet(u32, Option<Nfs4ResponseLayoutGet<'a>>),
     GetDevInfo(u32, Option<Nfs4ResponseGetDevInfo<'a>>),
+    LayoutReturn(u32),
+}
+
+// might need improvment with a stateid_present = yes case
+fn nfs4_res_layoutreturn(i:&[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+    let (i, status) = be_u32(i)?;
+    let (i, _stateid_present) = be_u32(i)?;
+    Ok((i, Nfs4ResponseContent::LayoutReturn(status)))
 }
 
 #[derive(Debug, PartialEq)]
@@ -1122,6 +1160,7 @@ fn nfs4_res_compound_command(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
         NFSPROC4_SECINFO_NO_NAME => nfs4_res_secinfo_no_name(i)?,
         NFSPROC4_LAYOUTGET => nfs4_res_layoutget(i)?,
         NFSPROC4_GETDEVINFO => nfs4_res_getdevinfo(i)?,
+        NFSPROC4_LAYOUTRETURN => nfs4_res_layoutreturn(i)?,
         _ => { return Err(Err::Error(make_error(i, ErrorKind::Switch))); }
     };
     Ok((i, cmd_data))
@@ -1507,6 +1546,33 @@ mod tests {
                 assert_eq!(getdevifo.layout_type, 1);
                 assert_eq!(getdevifo.maxcount, 81440);
                 assert_eq!(getdevifo.notify_mask, 6);
+            }
+            _ => { panic!("Failure"); }
+        }
+    }
+
+    #[test]
+    fn test_nfs4_request_layoutreturn() {
+        let buf: &[u8] = &[
+            0x00, 0x00, 0x00, 0x33, /*opcode*/
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // layoutreturn
+            0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0x00, 0x00, 0x00, 0x01, 0x03, 0x82, 0x14, 0xe0,
+            0x5b, 0x00, 0x89, 0xd9, 0x04, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ];
+
+        let (_, stateid_buf) = nfs4_parse_stateid(&buf[36..52]).unwrap();
+        assert_eq!(stateid_buf.seqid, 1);
+
+        let (_, request) = nfs4_req_layoutreturn(&buf[4..]).unwrap();
+        match request {
+            Nfs4RequestContent::LayoutReturn( layoutreturn ) => {
+                assert_eq!(layoutreturn.layout_type, 1);
+                assert_eq!(layoutreturn.return_type, 1);
+                assert_eq!(layoutreturn.stateid, stateid_buf);
             }
             _ => { panic!("Failure"); }
         }

--- a/rust/src/nfs/nfs4_records.rs
+++ b/rust/src/nfs/nfs4_records.rs
@@ -69,6 +69,7 @@ pub enum Nfs4RequestContent<'a> {
     GetDevInfo(Nfs4RequestGetDevInfo<'a>),
     LayoutReturn(Nfs4RequestLayoutReturn<'a>),
     DestroySession(&'a[u8]),
+    DestroyClientID(&'a[u8]),
 }
 
 #[derive(Debug,PartialEq)]
@@ -489,6 +490,11 @@ fn nfs4_req_reclaim_complete(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
     map(be_u32, Nfs4RequestContent::ReclaimComplete) (i)
 }
 
+fn nfs4_req_destroy_clientid(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+    let (i, client_id) = take(8_usize)(i)?;
+    Ok((i, Nfs4RequestContent::DestroyClientID(client_id)))
+}
+
 #[derive(Debug, PartialEq)]
 pub struct Nfs4RequestLayoutGet<'a> {
     pub layout_type: u32,
@@ -591,6 +597,7 @@ fn parse_request_compound_command(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent
         NFSPROC4_GETDEVINFO => nfs4_req_getdevinfo(i)?,
         NFSPROC4_LAYOUTRETURN => nfs4_req_layoutreturn(i)?,
         NFSPROC4_DESTROY_SESSION => nfs4_req_destroy_session(i)?,
+        NFSPROC4_DESTROY_CLIENTID => nfs4_req_destroy_clientid(i)?,
         _ => { return Err(Err::Error(make_error(i, ErrorKind::Switch))); }
     };
     Ok((i, cmd_data))
@@ -646,6 +653,7 @@ pub enum Nfs4ResponseContent<'a> {
     GetDevInfo(u32, Option<Nfs4ResponseGetDevInfo<'a>>),
     LayoutReturn(u32),
     DestroySession(u32),
+    DestroyClientID(u32),
 }
 
 // might need improvment with a stateid_present = yes case
@@ -1140,6 +1148,10 @@ fn nfs4_res_destroy_session(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
     map(be_u32, Nfs4ResponseContent::DestroySession) (i)
 }
 
+fn nfs4_res_destroy_clientid(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+    map(be_u32, Nfs4ResponseContent::DestroyClientID) (i)
+}
+
 fn nfs4_res_compound_command(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
     let (i, cmd) = be_u32(i)?;
     let (i, cmd_data) = match cmd {
@@ -1174,6 +1186,7 @@ fn nfs4_res_compound_command(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
         NFSPROC4_GETDEVINFO => nfs4_res_getdevinfo(i)?,
         NFSPROC4_LAYOUTRETURN => nfs4_res_layoutreturn(i)?,
         NFSPROC4_DESTROY_SESSION => nfs4_res_destroy_session(i)?,
+        NFSPROC4_DESTROY_CLIENTID => nfs4_res_destroy_clientid(i)?,
         _ => { return Err(Err::Error(make_error(i, ErrorKind::Switch))); }
     };
     Ok((i, cmd_data))
@@ -2046,7 +2059,5 @@ mod tests {
             }
             _ => { panic!("Failure"); }
         }
-
-
     }
 }

--- a/rust/src/nfs/nfs4_records.rs
+++ b/rust/src/nfs/nfs4_records.rs
@@ -17,7 +17,7 @@
 
 //! Nom parsers for NFSv4 records
 use nom7::bytes::streaming::{tag, take};
-use nom7::combinator::{complete, cond, map, peek};
+use nom7::combinator::{complete, cond, map, peek, rest};
 use nom7::error::{make_error, ErrorKind};
 use nom7::multi::{count, many_till};
 use nom7::number::streaming::{be_u32, be_u64};
@@ -60,6 +60,7 @@ pub enum Nfs4RequestContent<'a> {
     SetClientIdConfirm,
     ExchangeId(Nfs4RequestExchangeId<'a>),
     Sequence(Nfs4RequestSequence<'a>),
+    CreateSession(Nfs4RequestCreateSession<'a>),
 }
 
 #[derive(Debug,PartialEq)]
@@ -127,6 +128,34 @@ fn nfs4_parse_nfsstring(i: &[u8]) -> IResult<&[u8], &[u8]> {
     let (i, data) = take(len as usize)(i)?;
     let (i, _fill_bytes) = cond(len % 4 != 0, take(4 - (len % 4)))(i)?;
     Ok((i, data))
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Nfs4RequestCreateSession<'a> {
+    pub client_id: &'a[u8],
+    pub seqid: u32,
+    pub machine_name: &'a[u8],
+}
+
+fn nfs4_req_create_session(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+    let (i, client_id) = take(8_usize)(i)?;
+    let (i, seqid) = be_u32(i)?;
+    let (i, _flags) = be_u32(i)?;
+    let (i, _fore_chan_attrs) = take(28_usize)(i)?;
+    let (i, _back_chan_attrs) = take(28_usize)(i)?;
+    let (i, _cb_program) = be_u32(i)?;
+    let (i, _) = be_u32(i)?;
+    let (i, _flavor) = be_u32(i)?;
+    let (i, _stamp) = be_u32(i)?;
+    let (i, machine_name) = nfs4_parse_nfsstring(i)?;
+    let (i, _) = rest(i)?;
+
+    let req = Nfs4RequestContent::CreateSession(Nfs4RequestCreateSession {
+        client_id,
+        seqid,
+        machine_name,
+    });
+    Ok((i, req))
 }
 
 fn nfs4_req_putfh(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
@@ -458,6 +487,7 @@ fn parse_request_compound_command(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent
         NFSPROC4_SETCLIENTID_CONFIRM => nfs4_req_setclientid_confirm(i)?,
         NFSPROC4_SEQUENCE => nfs4_req_sequence(i)?,
         NFSPROC4_EXCHANGE_ID => nfs4_req_exchangeid(i)?,
+        NFSPROC4_CREATE_SESSION => nfs4_req_create_session(i)?,
         _ => { return Err(Err::Error(make_error(i, ErrorKind::Switch))); }
     };
     Ok((i, cmd_data))
@@ -506,6 +536,31 @@ pub enum Nfs4ResponseContent<'a> {
     Commit(u32),
     ExchangeId(u32, Option<Nfs4ResponseExchangeId<'a>>),
     Sequence(u32, Option<Nfs4ResponseSequence<'a>>),
+    CreateSession(u32, Option<Nfs4ResponseCreateSession<'a>>),
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Nfs4ResponseCreateSession<'a> {
+    pub ssn_id: &'a[u8],
+    pub seq_id: u32,
+}
+
+fn nfs4_parse_res_create_session(i: &[u8]) -> IResult<&[u8], Nfs4ResponseCreateSession> {
+    let (i, ssn_id) = take(16_usize)(i)?;
+    let (i, seq_id) = be_u32(i)?;
+    let (i, _flags) = be_u32(i)?;
+    let (i, _fore_chan_attrs) = take(28_usize)(i)?;
+    let (i, _back_chan_attrs) = take(28_usize)(i)?;
+    Ok((i, Nfs4ResponseCreateSession {
+        ssn_id,
+        seq_id
+    }))
+}
+
+fn nfs4_res_create_session(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+    let (i, status) = be_u32(i)?;
+    let (i, create_ssn_data) = cond(status == 0, nfs4_parse_res_create_session)(i)?;
+    Ok((i, Nfs4ResponseContent::CreateSession( status, create_ssn_data )))
 }
 
 #[derive(Debug, PartialEq)]
@@ -890,6 +945,7 @@ fn nfs4_res_compound_command(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
         NFSPROC4_EXCHANGE_ID => nfs4_res_exchangeid(i)?,
         NFSPROC4_SEQUENCE => nfs4_res_sequence(i)?,
         NFSPROC4_RENEW => nfs4_res_renew(i)?,
+        NFSPROC4_CREATE_SESSION => nfs4_res_create_session(i)?,
         _ => { return Err(Err::Error(make_error(i, ErrorKind::Switch))); }
     };
     Ok((i, cmd_data))
@@ -1196,6 +1252,38 @@ mod tests {
                 assert_eq!(putfh_handle.len, handle_buf.len);
             }
             _ => { panic!("Failure, {:?}", result); }
+        }
+    }
+
+    #[test]
+    fn test_nfs4_request_create_session() {
+        let buf: &[u8] = &[
+            0x00, 0x00, 0x00, 0x2b, /*opcode*/
+            0xe0, 0x14, 0x82, 0x00, 0x00, 0x00, 0x02, 0xd2, // create_session
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x03,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x04, 0x14,
+            0x00, 0x10, 0x03, 0x88, 0x00, 0x00, 0x0d, 0x64,
+            0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x40,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x10, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+            0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x01, 0x0c, 0x09, 0x5e, 0x92,
+            0x00, 0x00, 0x00, 0x09, 0x6e, 0x65, 0x74, 0x61,
+            0x70, 0x70, 0x2d, 0x32, 0x36, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ];
+
+        let (_, request) = nfs4_req_create_session(&buf[4..]).unwrap();
+        match request {
+            Nfs4RequestContent::CreateSession( create_ssn ) => {
+                assert_eq!(create_ssn.client_id, &buf[4..12]);
+                assert_eq!(create_ssn.seqid, 1);
+                assert_eq!(create_ssn.machine_name, b"netapp-26");
+            }
+            _ => { panic!("Failure"); }
         }
     }
 
@@ -1537,5 +1625,34 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_nfs4_response_create_session() {
+        let buf: &[u8] = &[
+            0x00, 0x00, 0x00, 0x2b, /*opcode*/
+            0x00, 0x00, 0x00, 0x00, /*status*/
+        // create_session
+            0x00, 0x00, 0x02, 0xd2, 0xe0, 0x14, 0x82, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x02,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x03,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x18, 0x00,
+            0x00, 0x01, 0x40, 0x00, 0x00, 0x00, 0x02, 0x80,
+            0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x40,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x10, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        let (_, create_ssn) = nfs4_parse_res_create_session(&buf[8..]).unwrap();
+
+        let (_, response) = nfs4_res_create_session(&buf[4..]).unwrap();
+        match response {
+            Nfs4ResponseContent::CreateSession( status, create_ssn_data) => {
+                assert_eq!(status, 0);
+                assert_eq!(create_ssn_data, Some(create_ssn));
+            }
+            _ => { panic!("Failure"); }
+        }
+    }
 
 }

--- a/rust/src/nfs/nfs4_records.rs
+++ b/rust/src/nfs/nfs4_records.rs
@@ -25,6 +25,11 @@ use nom7::{Err, IResult};
 
 use crate::nfs::types::*;
 
+/*https://datatracker.ietf.org/doc/html/rfc7530 - section 16.16 File Delegation Types */
+const OPEN_DELEGATE_NONE:    u32 = 0;
+const OPEN_DELEGATE_READ:    u32 = 1;
+const OPEN_DELEGATE_WRITE:   u32 = 2;
+
 // Maximum number of operations per compound
 // Linux defines NFSD_MAX_OPS_PER_COMPOUND to 16 (tested in Linux 5.15.1).
 const NFSD_MAX_OPS_PER_COMPOUND: usize = 64;
@@ -550,8 +555,35 @@ fn nfs4_res_read(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
 pub struct Nfs4ResponseOpen<'a> {
     pub stateid: Nfs4StateId<'a>,
     pub result_flags: u32,
-    pub delegation_type: u32,
-    pub delegate_read: Option<Nfs4ResponseOpenDelegateRead<'a>>,
+    pub delegate: Nfs4ResponseFileDelegation<'a>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Nfs4ResponseFileDelegation<'a> {
+    DelegateRead(Nfs4ResponseOpenDelegateRead<'a>),
+    DelegateWrite(Nfs4ResponseOpenDelegateWrite<'a>),
+    DelegateNone(u32),
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Nfs4ResponseOpenDelegateWrite<'a> {
+    pub stateid: Nfs4StateId<'a>,
+    pub who: &'a[u8],
+}
+
+fn nfs4_res_open_ok_delegate_write(i: &[u8]) -> IResult<&[u8], Nfs4ResponseFileDelegation> {
+    let (i, stateid) = nfs4_parse_stateid(i)?;
+    let (i, _recall) = be_u32(i)?;
+    let (i, _space_limit) = be_u32(i)?;
+    let (i, _filesize) = be_u32(i)?;
+    let (i, _access_type) = be_u32(i)?;
+    let (i, _ace_flags) = be_u32(i)?;
+    let (i, _ace_mask) = be_u32(i)?;
+    let (i, who) = nfs4_parse_nfsstring(i)?;
+    Ok((i, Nfs4ResponseFileDelegation::DelegateWrite(Nfs4ResponseOpenDelegateWrite {
+        stateid, 
+        who, 
+    })))
 }
 
 #[derive(Debug,PartialEq)]
@@ -559,7 +591,7 @@ pub struct Nfs4ResponseOpenDelegateRead<'a> {
     pub stateid: Nfs4StateId<'a>,
 }
 
-fn nfs4_res_open_ok_delegate_read(i: &[u8]) -> IResult<&[u8], Nfs4ResponseOpenDelegateRead> {
+fn nfs4_res_open_ok_delegate_read(i: &[u8]) -> IResult<&[u8], Nfs4ResponseFileDelegation> {
     let (i, stateid) = nfs4_parse_stateid(i)?;
     let (i, _recall) = be_u32(i)?;
     let (i, _ace_type) = be_u32(i)?;
@@ -567,7 +599,20 @@ fn nfs4_res_open_ok_delegate_read(i: &[u8]) -> IResult<&[u8], Nfs4ResponseOpenDe
     let (i, _ace_mask) = be_u32(i)?;
     let (i, who_len) = be_u32(i)?;
     let (i, _who) = take(who_len as usize)(i)?;
-    Ok((i, Nfs4ResponseOpenDelegateRead { stateid }))
+    Ok((i, Nfs4ResponseFileDelegation::DelegateRead(Nfs4ResponseOpenDelegateRead {
+        stateid,
+    })))
+}
+
+fn nfs4_parse_file_delegation(i: &[u8]) -> IResult<&[u8], Nfs4ResponseFileDelegation> {
+    let (i, delegation_type) = be_u32(i)?;
+    let (i, file_delegation) = match delegation_type {
+        OPEN_DELEGATE_READ => nfs4_res_open_ok_delegate_read(i)?,
+        OPEN_DELEGATE_WRITE => nfs4_res_open_ok_delegate_write(i)?,
+        OPEN_DELEGATE_NONE => (i, Nfs4ResponseFileDelegation::DelegateNone(OPEN_DELEGATE_NONE)),
+        _ => { return Err(Err::Error(make_error(i, ErrorKind::Switch))); }
+    };
+    Ok((i, file_delegation))
 }
 
 fn nfs4_res_open_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseOpen> {
@@ -575,13 +620,11 @@ fn nfs4_res_open_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseOpen> {
     let (i, _change_info) = take(20_usize)(i)?;
     let (i, result_flags) = be_u32(i)?;
     let (i, _attrs) = nfs4_parse_attrbits(i)?;
-    let (i, delegation_type) = be_u32(i)?;
-    let (i, delegate_read) = cond(delegation_type == 1, nfs4_res_open_ok_delegate_read)(i)?;
+    let (i, delegate) = nfs4_parse_file_delegation(i)?;
     let resp = Nfs4ResponseOpen {
         stateid,
         result_flags,
-        delegation_type,
-        delegate_read
+        delegate,
     };
     Ok((i, resp))
 }
@@ -1185,29 +1228,31 @@ mod tests {
             0x5b, 0x00, 0x88, 0xd9, 0x04, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x01, 0x16, 0xf8, 0x2f, 0xd5, /*_change_info*/
             0xdb, 0xb7, 0xfe, 0x38, 0x16, 0xf8, 0x2f, 0xdf,
-            0x21, 0xa8, 0x2a, 0x48,
-            0x00, 0x00, 0x00, 0x04, /*result_flags*/
-            0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x10, /*_attrs*/
+            0x21, 0xa8, 0x2a, 0x48, 0x00, 0x00, 0x00, 0x04,
+            0x00, 0x00, 0x00, 0x03,
+            0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x02, /*_attrs*/
+            0x00, 0x00, 0x00, 0x00,
+        // delegate_write
             0x00, 0x00, 0x00, 0x02, /*delegation_type*/
-        // delegate_read
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
             0x00, 0x00, 0x00, 0x01, 0x02, 0x82, 0x14, 0xe0,
             0x5b, 0x00, 0x89, 0xd9, 0x04, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
         ];
 
         let stateid_buf = &buf[8..24];
         let (_, res_stateid) = nfs4_parse_stateid(stateid_buf).unwrap();
 
+        let delegate_buf = &buf[64..];
+        let (_, delegate) = nfs4_parse_file_delegation(delegate_buf).unwrap();
+
         let open_data_buf = &buf[8..];
         let (_, res_open_data) = nfs4_res_open_ok(open_data_buf).unwrap();
         assert_eq!(res_open_data.stateid, res_stateid);
         assert_eq!(res_open_data.result_flags, 4);
-        assert_eq!(res_open_data.delegation_type, 2);
-        assert_eq!(res_open_data.delegate_read, None);
+        assert_eq!(res_open_data.delegate, delegate);
 
         let (_, response) = nfs4_res_open(&buf[4..]).unwrap();
         match response {

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -273,11 +273,10 @@ pub const NFSPROC4_SETCLIENTID_CONFIRM: u32 = 36;
 pub const NFSPROC4_VERIFY:              u32 = 37;
 pub const NFSPROC4_WRITE:               u32 = 38;
 pub const NFSPROC4_RELEASE_LOCKOWNER:   u32 = 39;
+pub const NFSPROC4_EXCHANGE_ID:         u32 = 42;
 pub const NFSPROC4_CREATE_SESSION:      u32 = 43;
 pub const NFSPROC4_SEQUENCE:            u32 = 53;
-
-
-pub const NFSPROC4_EXCHANGE_ID:         u32 = 42;
+pub const NFSPROC4_RECLAIM_COMPLETE:    u32 = 58;
 
 pub const NFSPROC4_ILLEGAL:             u32 = 10044;
 

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -275,6 +275,7 @@ pub const NFSPROC4_WRITE:               u32 = 38;
 pub const NFSPROC4_RELEASE_LOCKOWNER:   u32 = 39;
 pub const NFSPROC4_EXCHANGE_ID:         u32 = 42;
 pub const NFSPROC4_CREATE_SESSION:      u32 = 43;
+pub const NFSPROC4_SECINFO_NO_NAME:     u32 = 52;
 pub const NFSPROC4_SEQUENCE:            u32 = 53;
 pub const NFSPROC4_RECLAIM_COMPLETE:    u32 = 58;
 

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -273,6 +273,7 @@ pub const NFSPROC4_SETCLIENTID_CONFIRM: u32 = 36;
 pub const NFSPROC4_VERIFY:              u32 = 37;
 pub const NFSPROC4_WRITE:               u32 = 38;
 pub const NFSPROC4_RELEASE_LOCKOWNER:   u32 = 39;
+pub const NFSPROC4_CREATE_SESSION:      u32 = 43;
 pub const NFSPROC4_SEQUENCE:            u32 = 53;
 
 

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -281,6 +281,7 @@ pub const NFSPROC4_LAYOUTGET:           u32 = 50;
 pub const NFSPROC4_LAYOUTRETURN:        u32 = 51;
 pub const NFSPROC4_SECINFO_NO_NAME:     u32 = 52;
 pub const NFSPROC4_SEQUENCE:            u32 = 53;
+pub const NFSPROC4_DESTROY_CLIENTID:    u32 = 57;
 pub const NFSPROC4_RECLAIM_COMPLETE:    u32 = 58;
 
 pub const NFSPROC4_ILLEGAL:             u32 = 10044;

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -275,6 +275,7 @@ pub const NFSPROC4_WRITE:               u32 = 38;
 pub const NFSPROC4_RELEASE_LOCKOWNER:   u32 = 39;
 pub const NFSPROC4_EXCHANGE_ID:         u32 = 42;
 pub const NFSPROC4_CREATE_SESSION:      u32 = 43;
+pub const NFSPROC4_LAYOUTGET:           u32 = 50;
 pub const NFSPROC4_SECINFO_NO_NAME:     u32 = 52;
 pub const NFSPROC4_SEQUENCE:            u32 = 53;
 pub const NFSPROC4_RECLAIM_COMPLETE:    u32 = 58;

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -275,6 +275,7 @@ pub const NFSPROC4_WRITE:               u32 = 38;
 pub const NFSPROC4_RELEASE_LOCKOWNER:   u32 = 39;
 pub const NFSPROC4_EXCHANGE_ID:         u32 = 42;
 pub const NFSPROC4_CREATE_SESSION:      u32 = 43;
+pub const NFSPROC4_GETDEVINFO:          u32 = 47;
 pub const NFSPROC4_LAYOUTGET:           u32 = 50;
 pub const NFSPROC4_SECINFO_NO_NAME:     u32 = 52;
 pub const NFSPROC4_SEQUENCE:            u32 = 53;

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -275,6 +275,7 @@ pub const NFSPROC4_WRITE:               u32 = 38;
 pub const NFSPROC4_RELEASE_LOCKOWNER:   u32 = 39;
 pub const NFSPROC4_EXCHANGE_ID:         u32 = 42;
 pub const NFSPROC4_CREATE_SESSION:      u32 = 43;
+pub const NFSPROC4_DESTROY_SESSION:     u32 = 44;
 pub const NFSPROC4_GETDEVINFO:          u32 = 47;
 pub const NFSPROC4_LAYOUTGET:           u32 = 50;
 pub const NFSPROC4_LAYOUTRETURN:        u32 = 51;

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -277,6 +277,7 @@ pub const NFSPROC4_EXCHANGE_ID:         u32 = 42;
 pub const NFSPROC4_CREATE_SESSION:      u32 = 43;
 pub const NFSPROC4_GETDEVINFO:          u32 = 47;
 pub const NFSPROC4_LAYOUTGET:           u32 = 50;
+pub const NFSPROC4_LAYOUTRETURN:        u32 = 51;
 pub const NFSPROC4_SECINFO_NO_NAME:     u32 = 52;
 pub const NFSPROC4_SEQUENCE:            u32 = 53;
 pub const NFSPROC4_RECLAIM_COMPLETE:    u32 = 58;


### PR DESCRIPTION
An `NFS4` compound record is parsed as a whole -- 
if an operation in a compound record is missing a parser, the parsing will fail.

A couple of `NFS4` compound records were logged as `MalformedData` due to missing op parsers
Add missing parsers and their respective unittests if needed.