### PR TITLE
log: rename http.xff to http.xff_header

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -46,6 +46,7 @@ Logging changes
 - IKEv2 Eve logging changed, the event_type has become ``ike``. The fields ``errors`` and ``notify`` have moved to
   ``ike.ikev2.errors`` and ``ike.ikev2.notify``.
 - FTP DATA metadata for alerts are now logged in ``ftp_data`` instead of root.
+- HTTP xff header is now logged as ``http.xff_header`` instead of ``http.xff`` while the root object ``.xff`` remains the same
 
 Other changes
 ~~~~~~~~~~~~~

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -229,7 +229,7 @@ static void EveHttpLogJSONBasic(JsonBuilder *js, htp_tx_t *tx)
         /* x-forwarded-for */
         htp_header_t *h_x_forwarded_for = htp_table_get_c(tx->request_headers, "x-forwarded-for");
         if (h_x_forwarded_for != NULL) {
-            jb_set_string_from_bytes(js, "xff", bstr_ptr(h_x_forwarded_for->value),
+            jb_set_string_from_bytes(js, "xff_header", bstr_ptr(h_x_forwarded_for->value),
                     bstr_len(h_x_forwarded_for->value));
         }
     }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4860
but also https://redmine.openinfosecfoundation.org/issues/1369

Describe changes:
- http : rename http.xff to `http.xff_header` as it does not have the same meaning as `.xff`

suricata-verify-pr: 756
https://github.com/OISF/suricata-verify/pull/756

Replaces #6904 with renaming `http.xff` to `http.xff_header`