### PR TITLE
(draft) smb: flags fix; set event when record is in the wrong direction - v2

### DIFF
--- a/rust/src/smb/events.rs
+++ b/rust/src/smb/events.rs
@@ -27,6 +27,10 @@ pub enum SMBEvent {
     DuplicateNegotiate,
     NegotiateMalformedDialects,
     FileOverlap,
+    /// A request was seen in the to client direction.
+    RequestToClient,
+    /// A response was seen in the to server direction,
+    ResponseToServer,
 }
 
 impl SMBTransaction {

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -27,6 +27,8 @@ use nom7::IResult;
 
 pub const SMB1_HEADER_SIZE: usize = 32;
 
+pub const SMB1_FLAGS_REPLY: u8 = 0x80;
+
 fn smb_get_unicode_string_with_offset(i: &[u8], offset: usize) -> IResult<&[u8], Vec<u8>, SmbError>
 {
     let (i, _) = cond(offset % 2 == 1, take(1_usize))(i)?;
@@ -814,6 +816,15 @@ impl<'a> SmbRecord<'a> {
     }
     pub fn is_dos_error(&self) -> bool {
         self.flags2 & 0x4000_u16 != 0
+    }
+
+    /// Returns 0 if a request or 1 if a response.
+    pub fn direction(&self) -> u8 {
+        if self.flags & SMB1_FLAGS_REPLY == 0 {
+            0
+        } else {
+            1
+        }
     }
 }
 


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/7023

Changes from last PR:
- If a record is seen in the wrong direction, set an event on the frame.
- Don't return an err, let the parser continue.

TODO: Add the rules for the alerts.

Ticket: https://redmine.openinfosecfoundation.org/issues/4945
