### PR TITLE
detect: only apply ConfigApplyTx with app-layers

### DIFF
--- a/src/detect-config.c
+++ b/src/detect-config.c
@@ -288,6 +288,12 @@ static int DetectConfigSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
         fd->scope = CONFIG_SCOPE_TX;
     }
 
+    if (fd->scope == CONFIG_SCOPE_TX) {
+        s->flags |= SIG_FLAG_APPLAYER;
+    } else if (fd->scope == CONFIG_SCOPE_FLOW) {
+        s->init_data->init_flags |= SIG_FLAG_INIT_FLOW;
+    }
+
     sm->ctx = (SigMatchCtx*)fd;
     SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4972

Describe changes:
- detect: only apply ConfigApplyTx when relevant (like with app-layer)

Replaces #7015 with adding `SIG_MASK_REQUIRE_FLOW` set by 
```
    if (s->init_data->init_flags & SIG_FLAG_INIT_FLOW) {
        s->mask |= SIG_MASK_REQUIRE_FLOW;
        SCLogDebug("sig requires flow");
    }
```
in `SignatureCreateMask`