### PR TITLE
applayer/frame: remove output from GetFrame funcs - v1

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -194,7 +194,6 @@ static int HTTPGetFrameIdByName(const char *frame_name)
 {
     int id = SCMapEnumNameToValue(frame_name, http_frame_table);
     if (id < 0) {
-        SCLogError(SC_ERR_INVALID_ENUM_MAP, "unknown frame type \"%s\"", frame_name);
         return -1;
     }
     return id;

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2769,7 +2769,6 @@ static int SSLStateGetFrameIdByName(const char *frame_name)
 {
     int id = SCMapEnumNameToValue(frame_name, tls_frame_table);
     if (id < 0) {
-        SCLogError(SC_ERR_INVALID_ENUM_MAP, "unknown frame type \"%s\"", frame_name);
         return -1;
     }
     return id;


### PR DESCRIPTION
As these functions can be probed, having output there results in
misleading output messages.

