### PR TITLE
detect-dnp3/v2: remove dnp3_data unittests

### DIFF
--- a/src/detect-dnp3.c
+++ b/src/detect-dnp3.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015 Open Information Security Foundation
+/* Copyright (C) 2015-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -125,7 +125,6 @@ DNP3Mapping DNP3FunctionNameMap[] = {
 static void DetectDNP3FuncRegisterTests(void);
 static void DetectDNP3IndRegisterTests(void);
 static void DetectDNP3ObjRegisterTests(void);
-static void DetectDNP3DataRegisterTests(void);
 #endif
 
 /**
@@ -174,14 +173,6 @@ static InspectionBuffer *GetDNP3Data(DetectEngineThreadCtx *det_ctx,
         InspectionBufferApplyTransforms(buffer, transforms);
     }
     return buffer;
-}
-
-static int DetectEngineInspectDNP3(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
-        uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
-{
-    return DetectEngineInspectGenericList(
-            de_ctx, det_ctx, s, engine->smd, f, flags, alstate, txv, tx_id);
 }
 
 /**
@@ -545,69 +536,11 @@ static void DetectDNP3ObjRegister(void)
     SCReturn;
 }
 
-static int DetectDNP3DataSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)
-{
-    SCEnter();
-    if (DetectSignatureSetAppProto(s, ALPROTO_DNP3) != 0)
-        return -1;
-
-    if (DetectBufferSetActiveList(s, g_dnp3_data_buffer_id) != 0)
-        return -1;
-
-    SCReturnInt(0);
-}
-
-static void DetectDNP3DataRegister(void)
-{
-    SCEnter();
-
-    sigmatch_table[DETECT_AL_DNP3DATA].name          = "dnp3.data";
-    sigmatch_table[DETECT_AL_DNP3DATA].alias         = "dnp3_data";
-    sigmatch_table[DETECT_AL_DNP3DATA].desc          = "make the following content options to match on the re-assembled application buffer";
-    sigmatch_table[DETECT_AL_DNP3DATA].url           = "/rules/dnp3-keywords.html#dnp3-data";
-    sigmatch_table[DETECT_AL_DNP3DATA].Setup         = DetectDNP3DataSetup;
-#ifdef UNITTESTS
-    sigmatch_table[DETECT_AL_DNP3DATA].RegisterTests =
-        DetectDNP3DataRegisterTests;
-#endif
-    sigmatch_table[DETECT_AL_DNP3DATA].flags |= SIGMATCH_NOOPT|SIGMATCH_INFO_STICKY_BUFFER;
-
-    DetectAppLayerInspectEngineRegister2("dnp3_data",
-            ALPROTO_DNP3, SIG_FLAG_TOSERVER, 0,
-            DetectEngineInspectBufferGeneric,
-            GetDNP3Data);
-    DetectAppLayerMpmRegister2("dnp3_data", SIG_FLAG_TOSERVER, 2,
-            PrefilterGenericMpmRegister, GetDNP3Data,
-            ALPROTO_DNP3, 0);
-
-    DetectAppLayerInspectEngineRegister2("dnp3_data",
-            ALPROTO_DNP3, SIG_FLAG_TOCLIENT, 0,
-            DetectEngineInspectBufferGeneric,
-            GetDNP3Data);
-    DetectAppLayerMpmRegister2("dnp3_data", SIG_FLAG_TOCLIENT, 2,
-            PrefilterGenericMpmRegister, GetDNP3Data,
-            ALPROTO_DNP3, 0);
-
-    g_dnp3_data_buffer_id = DetectBufferTypeGetByName("dnp3_data");
-    SCReturn;
-}
-
 void DetectDNP3Register(void)
 {
-    DetectDNP3DataRegister();
-
     DetectDNP3FuncRegister();
     DetectDNP3IndRegister();
     DetectDNP3ObjRegister();
-
-    /* Register the list of func, ind and obj. */
-    DetectAppLayerInspectEngineRegister2(
-            "dnp3", ALPROTO_DNP3, SIG_FLAG_TOSERVER, 0, DetectEngineInspectDNP3, NULL);
-    DetectAppLayerInspectEngineRegister2(
-            "dnp3", ALPROTO_DNP3, SIG_FLAG_TOCLIENT, 0, DetectEngineInspectDNP3, NULL);
-
-    g_dnp3_match_buffer_id = DetectBufferTypeRegister("dnp3");
-
 }
 
 #ifdef UNITTESTS
@@ -763,276 +696,6 @@ static int DetectDNP3ObjParseTest(void)
     PASS;
 }
 
-/**
- * Test request (to server) content match.
- */
-static int DetectDNP3DataTest01(void)
-{
-    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
-    DetectEngineThreadCtx *det_ctx = NULL;
-    DetectEngineCtx *de_ctx = NULL;
-    Flow f;
-    Packet *p;
-    TcpSession tcp;
-    ThreadVars tv;
-
-    uint8_t request[] = {
-        0x05, 0x64, 0x1a, 0xc4, 0x02, 0x00, 0x01, 0x00,
-        0xa5, 0xe9,
-
-        0xff, 0xc9, 0x05, 0x0c, 0x01, 0x28, 0x01, 0x00,
-        0x00, 0x00, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00,
-
-        /* CRC. */
-        0x72, 0xef,
-
-        0x00, 0x00, 0x00, 0x00, 0x00,
-
-        /* CRC. */
-        0xff, 0xff,
-    };
-
-    /* Setup flow. */
-    memset(&f, 0, sizeof(Flow));
-    memset(&tcp, 0, sizeof(TcpSession));
-    memset(&tv, 0, sizeof(ThreadVars));
-    p = UTHBuildPacket(request, sizeof(request), IPPROTO_TCP);
-    FLOW_INITIALIZE(&f);
-    f.alproto = ALPROTO_DNP3;
-    f.protoctx = (void *)&tcp;
-    f.proto = IPPROTO_TCP;
-    f.flags |= FLOW_IPV4;
-    p->flow = &f;
-    p->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    p->flowflags |= FLOW_PKT_TOSERVER | FLOW_PKT_ESTABLISHED;
-    StreamTcpInitConfig(true);
-
-    de_ctx = DetectEngineCtxInit();
-    FAIL_IF(de_ctx == NULL);
-
-    /* Either direction - should match. */
-    Signature *s = DetectEngineAppendSig(de_ctx,
-        "alert dnp3 any any -> any any ("
-        "msg:\"DetectDNP3DataTest01\"; "
-        "dnp3_data; "
-        "content:\"|01 01 01 00 00 00 00 00 00 00|\"; "
-        "sid:1; rev:1;)");
-    FAIL_IF(s == NULL);
-
-    /* To server - should match. */
-    s = DetectEngineAppendSig(de_ctx,
-        "alert dnp3 any any -> any any ("
-        "msg:\"DetectDNP3DataTest01\"; "
-        "flow:established,to_server; "
-        "dnp3_data; "
-        "content:\"|01 01 01 00 00 00 00 00 00 00|\"; "
-        "sid:2; rev:1;)");
-    FAIL_IF(s == NULL);
-
-    /* To client - should not match. */
-    s = DetectEngineAppendSig(de_ctx,
-        "alert dnp3 any any -> any any ("
-        "msg:\"DetectDNP3DataTest01\"; "
-        "flow:established,to_client; "
-        "dnp3_data; "
-        "content:\"|01 01 01 00 00 00 00 00 00 00|\"; "
-        "sid:3; rev:1;)");
-    FAIL_IF(s == NULL);
-
-    /* The content of a CRC - should not match. */
-    s = DetectEngineAppendSig(de_ctx,
-        "alert dnp3 any any -> any any ("
-        "msg:\"DetectDNP3DataTest01\"; "
-        "dnp3_data; "
-        "content:\"|72 ef|\"; "
-        "sid:4; rev:1;)");
-    FAIL_IF(s == NULL);
-
-    SigGroupBuild(de_ctx);
-    DetectEngineThreadCtxInit(&tv, (void *)de_ctx, (void *)&det_ctx);
-
-    SCMutexLock(&f.m);
-    int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_DNP3,
-        STREAM_TOSERVER, request, sizeof(request));
-    SCMutexUnlock(&f.m);
-    FAIL_IF(r);
-
-    FAIL_IF(f.alstate == NULL);
-
-    SigMatchSignatures(&tv, de_ctx, det_ctx, p);
-    FAIL_IF(!PacketAlertCheck(p, 1));
-    FAIL_IF(!PacketAlertCheck(p, 2));
-    FAIL_IF(PacketAlertCheck(p, 3));
-    FAIL_IF(PacketAlertCheck(p, 4));
-
-    if (alp_tctx != NULL)
-        AppLayerParserThreadCtxFree(alp_tctx);
-    if (det_ctx != NULL)
-        DetectEngineThreadCtxDeinit(&tv, det_ctx);
-    if (de_ctx != NULL)
-        SigGroupCleanup(de_ctx);
-    if (de_ctx != NULL)
-        DetectEngineCtxFree(de_ctx);
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
-    UTHFreePacket(p);
-    PASS;
-}
-
-/**
- * Test response (to client) content match.
- */
-static int DetectDNP3DataTest02(void)
-{
-    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
-    DetectEngineThreadCtx *det_ctx = NULL;
-    DetectEngineCtx *de_ctx = NULL;
-    Flow f;
-    Packet *p;
-    TcpSession tcp;
-    ThreadVars tv;
-
-    uint8_t request[] = {
-        /* Link header. */
-        0x05, 0x64, 0x1a, 0xc4, 0x02, 0x00, 0x01, 0x00,
-
-        /* CRC. */
-        0xa5, 0xe9,
-
-        /* Transport header. */
-        0xff,
-
-        /* Application layer. */
-        0xc9, 0x05, 0x0c, 0x01, 0x28, 0x01, 0x00, 0x00,
-        0x00, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00,
-
-        /* CRC. */
-        0x72, 0xef,
-
-        /* Application layer. */
-        0x00, 0x00, 0x00, 0x00, 0x00,
-
-        /* CRC. */
-        0xff, 0xff,
-    };
-
-    uint8_t response[] = {
-        /* Link header. */
-        0x05, 0x64, 0x1c, 0x44, 0x01, 0x00, 0x02, 0x00,
-
-        /* CRC. */
-        0xe2, 0x59,
-
-        /* Transport header. */
-        0xc3,
-
-        /* Application layyer. */
-        0xc9, 0x81, 0x00, 0x00, 0x0c, 0x01, 0x28, 0x01,
-        0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x00,
-
-        /* CRC. */
-        0x7a, 0x65,
-
-        /* Application layer. */
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-
-        /* CRC. */
-        0xff, 0xff
-    };
-
-    /* Setup flow. */
-    memset(&f, 0, sizeof(Flow));
-    memset(&tcp, 0, sizeof(TcpSession));
-    memset(&tv, 0, sizeof(ThreadVars));
-    p = UTHBuildPacket(response, sizeof(response), IPPROTO_TCP);
-    FLOW_INITIALIZE(&f);
-    f.alproto = ALPROTO_DNP3;
-    f.protoctx = (void *)&tcp;
-    f.proto = IPPROTO_TCP;
-    f.flags |= FLOW_IPV4;
-    p->flow = &f;
-    p->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    p->flowflags |= FLOW_PKT_TOCLIENT | FLOW_PKT_ESTABLISHED;
-    StreamTcpInitConfig(true);
-
-    de_ctx = DetectEngineCtxInit();
-    FAIL_IF(de_ctx == NULL);
-
-    /* Either direction - should match. */
-    Signature *s = DetectEngineAppendSig(de_ctx,
-        "alert dnp3 any any -> any any ("
-        "msg:\"DetectDNP3DataTest01\"; "
-        "dnp3_data; "
-        "content:\"|01 01 01 00 00 00 00|\"; "
-        "sid:1; rev:1;)");
-    FAIL_IF(s == NULL);
-
-    /* To server - should not match. */
-    s = DetectEngineAppendSig(de_ctx,
-        "alert dnp3 any any -> any any ("
-        "msg:\"DetectDNP3DataTest01\"; "
-        "flow:established,to_server; "
-        "dnp3_data; "
-        "content:\"|01 01 01 00 00 00 00|\"; "
-        "sid:2; rev:1;)");
-    FAIL_IF(s == NULL);
-
-    /* To client - should match. */
-    s = DetectEngineAppendSig(de_ctx,
-        "alert dnp3 any any -> any any ("
-        "msg:\"DetectDNP3DataTest01\"; "
-        "flow:established,to_client; "
-        "dnp3_data; "
-        "content:\"|01 01 01 00 00 00 00|\"; "
-        "sid:3; rev:1;)");
-    FAIL_IF(s == NULL);
-
-    /* The content of a CRC - should not match. */
-    s = DetectEngineAppendSig(de_ctx,
-        "alert dnp3 any any -> any any ("
-        "msg:\"DetectDNP3DataTest01\"; "
-        "dnp3_data; "
-        "content:\"|7a 65|\"; "
-        "sid:4; rev:1;)");
-    FAIL_IF(s == NULL);
-
-    SigGroupBuild(de_ctx);
-    DetectEngineThreadCtxInit(&tv, (void *)de_ctx, (void *)&det_ctx);
-
-    /* Send through the request, then response. */
-    SCMutexLock(&f.m);
-    int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_DNP3,
-        STREAM_TOSERVER, request, sizeof(request));
-    SCMutexUnlock(&f.m);
-    FAIL_IF(r);
-    FAIL_IF(f.alstate == NULL);
-
-    SCMutexLock(&f.m);
-    r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_DNP3, STREAM_TOCLIENT,
-        response, sizeof(response));
-    SCMutexUnlock(&f.m);
-    FAIL_IF(r);
-
-    SigMatchSignatures(&tv, de_ctx, det_ctx, p);
-    FAIL_IF(!PacketAlertCheck(p, 1));
-    FAIL_IF(PacketAlertCheck(p, 2));
-    FAIL_IF(!PacketAlertCheck(p, 3));
-    FAIL_IF(PacketAlertCheck(p, 4));
-
-    if (alp_tctx != NULL)
-        AppLayerParserThreadCtxFree(alp_tctx);
-    if (det_ctx != NULL)
-        DetectEngineThreadCtxDeinit(&tv, det_ctx);
-    if (de_ctx != NULL)
-        SigGroupCleanup(de_ctx);
-    if (de_ctx != NULL)
-        DetectEngineCtxFree(de_ctx);
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
-    UTHFreePacket(p);
-    PASS;
-}
-
 static void DetectDNP3FuncRegisterTests(void)
 {
     UtRegisterTest("DetectDNP3FuncParseFunctionCodeTest",
@@ -1052,11 +715,5 @@ static void DetectDNP3ObjRegisterTests(void)
 {
     UtRegisterTest("DetectDNP3ObjParseTest", DetectDNP3ObjParseTest);
     UtRegisterTest("DetectDNP3ObjSetupTest", DetectDNP3ObjSetupTest);
-}
-
-void DetectDNP3DataRegisterTests(void)
-{
-    UtRegisterTest("DetectDNP3DataTest01", DetectDNP3DataTest01);
-    UtRegisterTest("DetectDNP3DataTest02", DetectDNP3DataTest02);
 }
 #endif


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to redmine ticket: https://redmine.openinfosecfoundation.org/issues/4911

Describe changes:
- remove unittests that have been converted to Suricata-Verify
- update commit message to be more descriptive
- remove DetectDNP3DataSetup & DetectDNP3Dataregister

Previous PR: #7057 

suricata-verify-pr: 760