### PR TITLE
style: use u8_tolower everywhere

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -1024,7 +1024,7 @@ static uint32_t CountersIdHashFunc(HashTable *ht, void *data, uint16_t datalen)
     int len = strlen(t->string);
 
     for (int i = 0; i < len; i++)
-        hash += tolower((unsigned char)t->string[i]);
+        hash += u8_tolower((unsigned char)t->string[i]);
 
     hash = hash % ht->array_size;
     return hash;

--- a/src/detect-fileext.c
+++ b/src/detect-fileext.c
@@ -154,7 +154,7 @@ static DetectFileextData *DetectFileextParse (DetectEngineCtx *de_ctx, const cha
     }
     uint16_t u;
     for (u = 0; u < fileext->len; u++)
-        fileext->ext[u] = tolower(fileext->ext[u]);
+        fileext->ext[u] = u8_tolower(fileext->ext[u]);
 
     if (negate) {
         fileext->flags |= DETECT_CONTENT_NEGATED;

--- a/src/detect-ssh-hassh-server.c
+++ b/src/detect-ssh-hassh-server.c
@@ -173,7 +173,7 @@ static void DetectSshHasshServerHashSetupCallback(const DetectEngineCtx *de_ctx,
         for (u = 0; u < cd->content_len; u++)
         {
             if (isupper(cd->content[u])) {
-                cd->content[u] = tolower(cd->content[u]);
+                cd->content[u] = u8_tolower(cd->content[u]);
             }
         }
 

--- a/src/detect-ssh-hassh.c
+++ b/src/detect-ssh-hassh.c
@@ -175,7 +175,7 @@ static void DetectSshHasshHashSetupCallback(const DetectEngineCtx *de_ctx,
         for (u = 0; u < cd->content_len; u++)
         {
             if (isupper(cd->content[u])) {
-                cd->content[u] = tolower(cd->content[u]);
+                cd->content[u] = u8_tolower(cd->content[u]);
             }
         }
 

--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -211,7 +211,7 @@ static void DetectTlsFingerprintSetupCallback(const DetectEngineCtx *de_ctx,
         for (u = 0; u < cd->content_len; u++)
         {
             if (isupper(cd->content[u])) {
-                cd->content[u] = tolower(cd->content[u]);
+                cd->content[u] = u8_tolower(cd->content[u]);
                 changed = true;
             }
         }

--- a/src/detect-tls-cert-serial.c
+++ b/src/detect-tls-cert-serial.c
@@ -201,7 +201,7 @@ static void DetectTlsSerialSetupCallback(const DetectEngineCtx *de_ctx,
         for (u = 0; u < cd->content_len; u++)
         {
             if (islower(cd->content[u])) {
-                cd->content[u] = toupper(cd->content[u]);
+                cd->content[u] = u8_toupper(cd->content[u]);
                 changed = true;
             }
         }

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -207,7 +207,7 @@ static void DetectTlsJa3HashSetupCallback(const DetectEngineCtx *de_ctx,
         for (u = 0; u < cd->content_len; u++)
         {
             if (isupper(cd->content[u])) {
-                cd->content[u] = tolower(cd->content[u]);
+                cd->content[u] = u8_tolower(cd->content[u]);
                 changed = true;
             }
         }

--- a/src/detect-tls-ja3s-hash.c
+++ b/src/detect-tls-ja3s-hash.c
@@ -205,7 +205,7 @@ static void DetectTlsJa3SHashSetupCallback(const DetectEngineCtx *de_ctx,
         for (u = 0; u < cd->content_len; u++)
         {
             if (isupper(cd->content[u])) {
-                cd->content[u] = tolower(cd->content[u]);
+                cd->content[u] = u8_tolower(cd->content[u]);
                 changed = true;
             }
         }

--- a/src/feature.c
+++ b/src/feature.c
@@ -43,7 +43,7 @@ static uint32_t FeatureHashFunc(HashListTable *ht, void *data,
     int len = strlen(f->feature);
 
     for (int i = 0; i < len; i++)
-        hash += tolower((unsigned char)f->feature[i]);
+        hash += u8_tolower((unsigned char)f->feature[i]);
 
     return (hash % ht->array_size);
 }

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -220,7 +220,7 @@ static char *SCClassConfStringToLowercase(const char *str)
 
     temp_str = new_str;
     while (*temp_str != '\0') {
-        *temp_str = tolower((unsigned char)*temp_str);
+        *temp_str = u8_tolower((unsigned char)*temp_str);
         temp_str++;
     }
 
@@ -453,7 +453,7 @@ uint32_t SCClassConfClasstypeHashFunc(HashTable *ht, void *data, uint16_t datale
     int len = strlen(ct->classtype);
 
     for (i = 0; i < len; i++)
-        hash += tolower((unsigned char)(ct->classtype)[i]);
+        hash += u8_tolower((unsigned char)(ct->classtype)[i]);
 
     hash = hash % ht->array_size;
 
@@ -560,7 +560,7 @@ SCClassConfClasstype *SCClassConfGetClasstype(const char *ct_name,
     char name[strlen(ct_name) + 1];
     size_t s;
     for (s = 0; s < strlen(ct_name); s++)
-        name[s] = tolower((unsigned char)ct_name[s]);
+        name[s] = u8_tolower((unsigned char)ct_name[s]);
     name[s] = '\0';
 
     SCClassConfClasstype ct_lookup = {0, 0, name, NULL };

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -447,7 +447,7 @@ static MimeDecField * MimeDecFillField(MimeDecEntity *entity, uint8_t *name,
         /* convert to lowercase and store */
         uint32_t u;
         for (u = 0; u < nlen; u++)
-            name[u] = tolower(name[u]);
+            name[u] = u8_tolower(name[u]);
 
         field->name = (uint8_t *)name;
         field->name_len = nlen;
@@ -1065,7 +1065,7 @@ static int FindUrlStrings(const uint8_t *line, uint32_t len,
                     tempUrlLen = 0;
                     for (i = 0; i < tokLen && tok[i] != 0; i++) {
                         /* url is all lowercase */
-                        tempUrl[tempUrlLen] = tolower(tok[i]);
+                        tempUrl[tempUrlLen] = u8_tolower(tok[i]);
                         tempUrlLen++;
                     }
 

--- a/src/util-reference-config.c
+++ b/src/util-reference-config.c
@@ -211,7 +211,7 @@ static char *SCRConfStringToLowercase(const char *str)
 
     temp_str = new_str;
     while (*temp_str != '\0') {
-        *temp_str = tolower((unsigned char)*temp_str);
+        *temp_str = u8_tolower((unsigned char)*temp_str);
         temp_str++;
     }
 
@@ -423,7 +423,7 @@ uint32_t SCRConfReferenceHashFunc(HashTable *ht, void *data, uint16_t datalen)
     int len = strlen(ref->system);
 
     for (i = 0; i < len; i++)
-        hash += tolower((unsigned char)ref->system[i]);
+        hash += u8_tolower((unsigned char)ref->system[i]);
 
     hash = hash % ht->array_size;
 

--- a/src/util-spm.c
+++ b/src/util-spm.c
@@ -2655,7 +2655,7 @@ static int SpmSearchTest02(void) {
                 d.nocase = 1;
                 uint16_t j;
                 for (j = 0; j < haystack_len; j++) {
-                    haystack[j] = toupper(haystack[j]);
+                    haystack[j] = u8_toupper(haystack[j]);
                 }
                 if (SpmTestSearch(&d, matcher) == 0) {
                     printf("  test %" PRIu32 ": fail (case-insensitive)\n", i);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4516

Describe changes:
- Fix integer warnings `-Wimplicit-int-conversion` about uses of `tolower`

(`tolower` takes an integer ans returns an integer, but really we use it for `u8`)

Should be uncontroversial part of #7006
