### PR TITLE
util/mime: fix integer warnings

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -296,6 +296,9 @@ static void SMTPConfigure(void) {
             TAILQ_FOREACH (scheme, &extract_urls_schemes->head, next) {
                 /* new_val_len: scheme value from config e.g. 'http' + '://' + null terminator */
                 size_t new_val_len = strlen(scheme->val) + 3 + 1;
+                if (new_val_len > UINT16_MAX) {
+                    FatalError(SC_ERR_FATAL, "Too long value for extract-urls-schemes");
+                }
                 char *new_val = SCMalloc(new_val_len);
                 if (unlikely(new_val == NULL)) {
                     FatalError(SC_ERR_FATAL, "SCMalloc failure.");

--- a/src/util-decode-mime.h
+++ b/src/util-decode-mime.h
@@ -86,7 +86,8 @@ typedef enum MimeDecRetCode {
     MIME_DEC_ERR_DATA = -1,
     MIME_DEC_ERR_MEM = -2,
     MIME_DEC_ERR_PARSE = -3,
-    MIME_DEC_ERR_STATE = -4,    /**< parser in error state */
+    MIME_DEC_ERR_STATE = -4, /**< parser in error state */
+    MIME_DEC_ERR_OVERFLOW = -5,
 } MimeDecRetCode;
 
 /**
@@ -160,7 +161,7 @@ typedef struct MimeDecEntity {
 typedef struct MimeDecStackNode {
     MimeDecEntity *data;  /**< Pointer to the entity data structure */
     uint8_t *bdef;  /**< Copy of boundary definition for child entity */
-    uint32_t bdef_len;  /**< Boundary length for child entity */
+    uint16_t bdef_len;  /**< Boundary length for child entity */
     bool is_encap;      /**< Flag indicating entity is encapsulated in message */
     struct MimeDecStackNode *next;  /**< Pointer to next item on the stack */
 } MimeDecStackNode;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4516

Describe changes:
- Fix integer warnings `-Wimplicit-int-conversion` in util-decode-mime.c

It does not fix the `tolower` stuff taken care of by #7073 

Part of #7006 modified : `FindBuffer` now takes an `uint16`
The only problematic part is about `extract_urls_schemes` which uses `strlen` on strings coming from configuration.
This length is now checked when reading the configuration in `SMTPConfigure`
The other uses of  `FindBuffer` use fixed strings (whose length fits in a u8) or strings whose length is checked cf `BOUNDARY_BUF`
