### PR TITLE
Range already closed 5132 v1

### DIFF
--- a/rust/src/http2/range.rs
+++ b/rust/src/http2/range.rs
@@ -77,7 +77,7 @@ fn http2_parse_content_range<'a>(input: &'a [u8]) -> IResult<&'a [u8], HTTPConte
 
 pub fn http2_parse_check_content_range<'a>(input: &'a [u8]) -> IResult<&'a [u8], HTTPContentRange> {
     let (rem, v) = http2_parse_content_range(input)?;
-    if v.start > v.end {
+    if v.start > v.end || (v.end > 0 && v.size > 0 && v.end > v.size - 1) {
         return Err(Err::Error(make_error(rem, ErrorKind::Verify)));
     }
     return Ok((rem, v));

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -196,7 +196,7 @@ static int HTPParseAndCheckContentRange(
     } else if (range->end == range->size - 1 && range->start == 0) {
         SCLogDebug("range without all information");
         return -3;
-    } else if (range->start > range->end) {
+    } else if (range->start > range->end || range->end > range->size - 1) {
         AppLayerDecoderEventsSetEventRaw(&htud->tx_data.events, HTTP_DECODER_EVENT_RANGE_INVALID);
         s->events++;
         SCLogDebug("invalid range");

--- a/src/app-layer-htp-range.c
+++ b/src/app-layer-htp-range.c
@@ -493,11 +493,17 @@ File *HttpRangeClose(HttpRangeContainerBlock *c, uint16_t flags)
                 (void)SC_ATOMIC_SUB(ContainerUrlRangeList.ht->memuse, c->current->buflen);
                 SCFree(c->current->buffer);
                 SCFree(c->current);
+                c->current = NULL;
+                return NULL;
             }
             SCLogDebug("inserted range fragment");
             c->current = NULL;
             if (c->container->files == NULL) {
                 // we have to wait for the flow owning the file
+                return NULL;
+            }
+            if (c->container->files->tail == NULL) {
+                // file has already been closed meanwhile
                 return NULL;
             }
             // keep on going, maybe this out of order chunk


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5132

Describe changes:
- Adds a validity check for parsed ranges
- Adds a check when closing an out of order range (it can only be meaningful if the file did not get closed meanwhile)