### PR TITLE
detect: only apply ConfigApplyTx with app-layers

### DIFF
--- a/src/detect-config.c
+++ b/src/detect-config.c
@@ -288,6 +288,10 @@ static int DetectConfigSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
         fd->scope = CONFIG_SCOPE_TX;
     }
 
+    if (fd->scope == CONFIG_SCOPE_TX) {
+        s->flags |= SIG_FLAG_APPLAYER;
+    }
+
     sm->ctx = (SigMatchCtx*)fd;
     SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
 

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -33,6 +33,7 @@
 #include "detect-dsize.h"
 #include "detect-tcp-flags.h"
 #include "detect-flow.h"
+#include "detect-config.h"
 #include "detect-flowbits.h"
 
 #include "util-profiling.h"
@@ -560,6 +561,13 @@ static int SignatureCreateMask(Signature *s)
             case DETECT_ENGINE_EVENT:
                 s->mask |= SIG_MASK_REQUIRE_ENGINE_EVENT;
                 break;
+            case DETECT_CONFIG: {
+                DetectConfigData *fd = (DetectConfigData *)sm->ctx;
+                if (fd->scope == CONFIG_SCOPE_FLOW) {
+                    s->mask |= SIG_MASK_REQUIRE_FLOW;
+                }
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4972

Describe changes:
- detect: only apply ConfigApplyTx when relevant (like with app-layer)

Replaces #7063 with adding a case for `DETECT_CONFIG` in `SignatureCreateMask` to set `SIG_MASK_REQUIRE_FLOW