### PR TITLE
smb: fix flag parsing; set event when records in wrong direction - v3

### DIFF
--- a/rules/smb-events.rules
+++ b/rules/smb-events.rules
@@ -16,3 +16,5 @@ alert smb any any -> any any (msg:"SURICATA SMB malformed NTLMSSP record"; flow:
 alert smb any any -> any any (msg:"SURICATA SMB malformed request dialects"; flow:to_server; app-layer-event:smb.negotiate_malformed_dialects; classtype:protocol-command-decode; sid:2225005; rev:1;)
 
 alert smb any any -> any any (msg:"SURICATA SMB file overlap"; app-layer-event:smb.file_overlap; classtype:protocol-command-decode; sid:2225006; rev:1;)
+alert smb any any -> any any (msg:"SURICATA SMB wrong direction"; app-layer-event:smb.response_to_server; classtype:protocol-command-decode; sid:2225007; rev:1;)
+alert smb any any -> any any (msg:"SURICATA SMB wrong direction"; app-layer-event:smb.request_to_client; classtype:protocol-command-decode; sid:2225008; rev:1;)

--- a/rust/src/smb/events.rs
+++ b/rust/src/smb/events.rs
@@ -27,6 +27,10 @@ pub enum SMBEvent {
     DuplicateNegotiate,
     NegotiateMalformedDialects,
     FileOverlap,
+    /// A request was seen in the to client direction.
+    RequestToClient,
+    /// A response was seen in the to server direction,
+    ResponseToServer,
 }
 
 impl SMBTransaction {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1453,9 +1453,18 @@ impl SMBState {
                                     SCLogDebug!("SMBv1 record");
                                     match parse_smb_record(nbss_hdr.data) {
                                         Ok((_, ref smb_record)) => {
-                                            self.add_smb1_ts_pdu_frame(flow, stream_slice, nbss_hdr.data, nbss_hdr.length as i64);
+                                            let pdu_frame = self.add_smb1_ts_pdu_frame(flow, stream_slice, nbss_hdr.data, nbss_hdr.length as i64);
                                             self.add_smb1_ts_hdr_data_frames(flow, stream_slice, nbss_hdr.data, nbss_hdr.length as i64);
-                                            smb1_request_record(self, smb_record);
+                                            if smb_record.is_request() {
+                                                smb1_request_record(self, smb_record);
+                                            } else {
+                                                // If we recevied a response when expecting a request, set an event
+                                                // on the PDU frame instead of handling the response.
+                                                SCLogDebug!("SMB1 reply seen from client to server");
+                                                if let Some(frame) = pdu_frame {
+                                                    frame.add_event(flow, 0, SMBEvent::ResponseToServer as u8);
+                                                }
+                                            }
                                         },
                                         _ => {
                                             if let Some(frame) = nbss_data_frame {
@@ -1472,10 +1481,19 @@ impl SMBState {
                                         match parse_smb2_request_record(nbss_data) {
                                             Ok((nbss_data_rem, ref smb_record)) => {
                                                 let record_len = (nbss_data.len() - nbss_data_rem.len()) as i64;
-                                                self.add_smb2_ts_pdu_frame(flow, stream_slice, nbss_data, record_len);
+                                                let pdu_frame = self.add_smb2_ts_pdu_frame(flow, stream_slice, nbss_data, record_len);
                                                 self.add_smb2_ts_hdr_data_frames(flow, stream_slice, nbss_data, record_len, smb_record.header_len as i64);
                                                 SCLogDebug!("nbss_data_rem {}", nbss_data_rem.len());
-                                                smb2_request_record(self, smb_record);
+                                                if smb_record.direction == 0 {
+                                                    smb2_request_record(self, smb_record);
+                                                } else {
+                                                    // If we recevied a response when expecting a request, set an event
+                                                    // on the PDU frame instead of handling the response.
+                                                    SCLogDebug!("SMB2 reply seen from client to server");
+                                                    if let Some(frame) = pdu_frame {
+                                                        frame.add_event(flow, 0, SMBEvent::ResponseToServer as u8);
+                                                    }
+                                                }
                                                 nbss_data = nbss_data_rem;
                                             },
                                             _ => {
@@ -1571,9 +1589,10 @@ impl SMBState {
         (nbss_pdu, nbss_hdr_frame, nbss_data_frame)
     }
 
-    fn add_smb1_tc_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) {
-        let _smb_pdu = Frame::new_tc(flow, stream_slice, input, nbss_len, SMBFrameType::SMB1Pdu as u8);
-        SCLogDebug!("SMB PDU frame {:?}", _smb_pdu);
+    fn add_smb1_tc_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) -> Option<Frame> {
+        let smb_pdu = Frame::new_tc(flow, stream_slice, input, nbss_len, SMBFrameType::SMB1Pdu as u8);
+        SCLogDebug!("SMB PDU frame {:?}", smb_pdu);
+        smb_pdu
     }
     fn add_smb1_tc_hdr_data_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) {
         let _smb1_hdr = Frame::new_tc(flow, stream_slice, input, SMB1_HEADER_SIZE as i64, SMBFrameType::SMB1Hdr as u8);
@@ -1585,9 +1604,10 @@ impl SMBState {
         }
     }
 
-    fn add_smb2_tc_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) {
-        let _smb_pdu = Frame::new_tc(flow, stream_slice, input, nbss_len, SMBFrameType::SMB2Pdu as u8);
-        SCLogDebug!("SMBv2 PDU frame {:?}", _smb_pdu);
+    fn add_smb2_tc_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) -> Option<Frame> {
+        let smb_pdu = Frame::new_tc(flow, stream_slice, input, nbss_len, SMBFrameType::SMB2Pdu as u8);
+        SCLogDebug!("SMBv2 PDU frame {:?}", smb_pdu);
+        smb_pdu
     }
     fn add_smb2_tc_hdr_data_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64, hdr_len: i64) {
         let _smb2_hdr = Frame::new_tc(flow, stream_slice, input, hdr_len, SMBFrameType::SMB2Hdr as u8);
@@ -1764,9 +1784,16 @@ impl SMBState {
                                     SCLogDebug!("SMBv1 record");
                                     match parse_smb_record(nbss_hdr.data) {
                                         Ok((_, ref smb_record)) => {
-                                            self.add_smb1_tc_pdu_frame(flow, stream_slice, nbss_hdr.data, nbss_hdr.length as i64);
+                                            let pdu_frame = self.add_smb1_tc_pdu_frame(flow, stream_slice, nbss_hdr.data, nbss_hdr.length as i64);
                                             self.add_smb1_tc_hdr_data_frames(flow, stream_slice, nbss_hdr.data, nbss_hdr.length as i64);
-                                            smb1_response_record(self, smb_record);
+                                            if smb_record.is_reply() {
+                                                smb1_response_record(self, smb_record);
+                                            } else {
+                                                SCLogDebug!("SMB1 request seen from server to client");
+                                                if let Some(frame) = pdu_frame {
+                                                    frame.add_event(flow, 1, SMBEvent::RequestToClient as u8);
+                                                }
+                                            }
                                         },
                                         _ => {
                                             self.set_event(SMBEvent::MalformedData);
@@ -1780,9 +1807,16 @@ impl SMBState {
                                         match parse_smb2_response_record(nbss_data) {
                                             Ok((nbss_data_rem, ref smb_record)) => {
                                                 let record_len = (nbss_data.len() - nbss_data_rem.len()) as i64;
-                                                self.add_smb2_tc_pdu_frame(flow, stream_slice, nbss_data, record_len);
+                                                let pdu_frame = self.add_smb2_tc_pdu_frame(flow, stream_slice, nbss_data, record_len);
                                                 self.add_smb2_tc_hdr_data_frames(flow, stream_slice, nbss_data, record_len, smb_record.header_len as i64);
-                                                smb2_response_record(self, smb_record);
+                                                if smb_record.direction == 1 {
+                                                    smb2_response_record(self, smb_record);
+                                                } else {
+                                                    SCLogDebug!("SMB2 request seen from server to client");
+                                                    if let Some(frame) = pdu_frame {
+                                                        frame.add_event(flow, 1, SMBEvent::RequestToClient as u8);
+                                                    }
+                                                }
                                                 nbss_data = nbss_data_rem;
                                             },
                                             _ => {

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -27,6 +27,8 @@ use nom7::IResult;
 
 pub const SMB1_HEADER_SIZE: usize = 32;
 
+pub const SMB1_FLAGS_REPLY: u8 = 0x80;
+
 fn smb_get_unicode_string_with_offset(i: &[u8], offset: usize) -> IResult<&[u8], Vec<u8>, SmbError>
 {
     let (i, _) = cond(offset % 2 == 1, take(1_usize))(i)?;
@@ -814,6 +816,16 @@ impl<'a> SmbRecord<'a> {
     }
     pub fn is_dos_error(&self) -> bool {
         self.flags2 & 0x4000_u16 != 0
+    }
+
+    /// Return true if record is a request.
+    pub fn is_request(&self) -> bool {
+        self.flags & SMB1_FLAGS_REPLY == 0
+    }
+
+    /// Return true if record is a reply.
+    pub fn is_reply(&self) -> bool {
+        self.flags & SMB1_FLAGS_REPLY != 0
     }
 }
 


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/7053

Changes from last PR:
- Methods `.is_request()` and `.is_reply()` instead of using 0 and 1 for direction.
- Some debug logging.
- Rules for wrong direction

Ticket: https://redmine.openinfosecfoundation.org/issues/4945

suricata-verify-pr: 768