### PR TITLE
Iponly radix issues/v7

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -4343,23 +4343,18 @@ static int AddressTestAddressGroupSetup48(void)
 
 static int AddressTestCutIPv401(void)
 {
-    DetectAddress *a, *b, *c;
-    a = DetectAddressParseSingle("1.2.3.0/255.255.255.0");
-    b = DetectAddressParseSingle("1.2.2.0-1.2.3.4");
+    DetectAddress *c;
+    DetectAddress *a = DetectAddressParseSingle("1.2.3.0/255.255.255.0");
+    FAIL_IF_NULL(a);
+    DetectAddress *b = DetectAddressParseSingle("1.2.2.0-1.2.3.4");
+    FAIL_IF_NULL(b);
 
-    if (DetectAddressCut(NULL, a, b, &c) == -1)
-        goto error;
+    FAIL_IF(DetectAddressCut(NULL, a, b, &c) == -1);
 
     DetectAddressFree(a);
     DetectAddressFree(b);
     DetectAddressFree(c);
-    return 1;
-
-error:
-    DetectAddressFree(a);
-    DetectAddressFree(b);
-    DetectAddressFree(c);
-    return 0;
+    PASS;
 }
 
 static int AddressTestCutIPv402(void)

--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -456,6 +456,13 @@ static int DetectAddressParseString(DetectAddress *dd, const char *str)
                     goto error;
 
                 netmask = in.s_addr;
+
+                /* validate netmask */
+                int cidr = CIDRFromMask(netmask);
+                if (cidr < 0) {
+                    SCLogNotice("cidr %d for netmask %08x/%s", cidr, netmask, mask);
+                    goto error;
+                }
             }
 
             r = inet_pton(AF_INET, ip, &in);

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -98,6 +98,50 @@ static uint8_t IPOnlyCIDRItemCompare(IPOnlyCIDRItem *head,
 static IPOnlyCIDRItem *IPOnlyCIDRItemInsert(IPOnlyCIDRItem *head,
                                             IPOnlyCIDRItem *item);
 
+static int InsertRange(
+        IPOnlyCIDRItem **pdd, IPOnlyCIDRItem *dd, const uint32_t first_in, const uint32_t last_in)
+{
+    DEBUG_VALIDATE_BUG_ON(dd == NULL);
+    DEBUG_VALIDATE_BUG_ON(pdd == NULL);
+
+    uint32_t first = first_in;
+    uint32_t last = last_in;
+
+    dd->netmask = 32;
+    /* Find the maximum netmask starting from current address first
+     * and not crossing last.
+     * To extend the mask, we need to start from a power of 2.
+     * And we need to pay attention to unsigned overflow back to 0.0.0.0
+     */
+    while (dd->netmask > 0 && (first & (1UL << (32 - dd->netmask))) == 0 &&
+            first + (1UL << (32 - (dd->netmask - 1))) - 1 <= last) {
+        dd->netmask--;
+    }
+    dd->ip[0] = htonl(first);
+    first += 1UL << (32 - dd->netmask);
+    // case whatever-255.255.255.255 looping to 0.0.0.0/0
+    while (first <= last && first != 0) {
+        IPOnlyCIDRItem *new = IPOnlyCIDRItemNew();
+        if (new == NULL)
+            goto error;
+        new->negated = dd->negated;
+        new->family = dd->family;
+        new->netmask = 32;
+        while (new->netmask > 0 && (first & (1UL << (32 - new->netmask))) == 0 &&
+                first + (1UL << (32 - (new->netmask - 1))) - 1 <= last) {
+            new->netmask--;
+        }
+        new->ip[0] = htonl(first);
+        first += 1UL << (32 - new->netmask);
+        dd = IPOnlyCIDRItemInsert(dd, new);
+    }
+    // update head of list
+    *pdd = dd;
+    return 0;
+error:
+    return -1;
+}
+
 /**
  * \internal
  * \brief Parses an ipv4/ipv6 address string and updates the result into the
@@ -202,7 +246,7 @@ static int IPOnlyCIDRItemParseSingle(IPOnlyCIDRItem **pdd, const char *str)
 
             dd->ip[0] = in.s_addr & netmask;
 
-        } else if ((ip2 = strchr(ip, '-')) != NULL)  {
+        } else if ((ip2 = strchr(ip, '-')) != NULL) {
             /* 1.2.3.4-1.2.3.6 range format */
             ip[ip2 - ip] = '\0';
             ip2++;
@@ -224,39 +268,7 @@ static int IPOnlyCIDRItemParseSingle(IPOnlyCIDRItem **pdd, const char *str)
                 goto error;
 
             SCLogDebug("Creating CIDR range for [%s - %s]", ip, ip2);
-            dd->netmask = 32;
-            /* Find the maximum netmask starting from current address first
-             * and not crossing last.
-             * To extend the mask, we need to start from a power of 2.
-             * And we need to pay attention to unsigned overflow back to 0.0.0.0
-             */
-            while (dd->netmask > 0 &&
-                   (first & (1UL << (32-dd->netmask))) == 0 &&
-                   first + (1UL << (32-(dd->netmask-1))) - 1 <= last) {
-                dd->netmask--;
-            }
-            dd->ip[0] = htonl(first);
-            first += 1UL << (32-dd->netmask);
-            //case whatever-255.255.255.255 looping to 0.0.0.0/0
-            while ( first <= last && first != 0 ) {
-                IPOnlyCIDRItem *new = IPOnlyCIDRItemNew();
-                if (new == NULL)
-                    goto error;
-                new->negated = dd->negated;
-                new->family= dd->family;
-                new->netmask = 32;
-                while (new->netmask > 0 &&
-                       (first & (1UL << (32-new->netmask))) == 0 &&
-                       first + (1UL << (32-(new->netmask-1))) - 1 <= last) {
-                    new->netmask--;
-                }
-                new->ip[0] = htonl(first);
-                first += 1UL << (32-new->netmask);
-                dd = IPOnlyCIDRItemInsert(dd, new);
-            }
-            //update head of list
-            *pdd = dd;
-
+            return InsertRange(pdd, dd, first, last);
         } else {
             /* 1.2.3.4 format */
             r = inet_pton(AF_INET, ip, &in);

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -228,16 +228,11 @@ static int IPOnlyCIDRItemParseSingle(IPOnlyCIDRItem **pdd, const char *str)
                 if (r <= 0)
                     goto error;
 
-                netmask = in.s_addr;
-                if (netmask != 0) {
-                    uint32_t m = netmask;
-                    /* Extract cidr netmask */
-                    while ((0x01 & m) == 0) {
-                        dd->netmask++;
-                        m = m >> 1;
-                    }
-                    dd->netmask = 32 - dd->netmask;
-                }
+                int cidr = CIDRFromMask(in.s_addr);
+                if (cidr < 0)
+                    goto error;
+
+                dd->netmask = (uint8_t)cidr;
             }
 
             r = inet_pton(AF_INET, ip, &in);

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -2419,6 +2419,33 @@ static int IPOnlyTestBug5066v5(void)
     PASS;
 }
 
+static int IPOnlyTestBug5168v1(void)
+{
+    IPOnlyCIDRItem *x = IPOnlyCIDRItemNew();
+    FAIL_IF_NULL(x);
+
+    FAIL_IF(IPOnlyCIDRItemParseSingle(&x, "1.2.3.64/0.0.0.0") != 0);
+
+    char ip[16];
+    PrintInet(AF_INET, (const void *)&x->ip[0], ip, sizeof(ip));
+    SCLogDebug("ip %s netmask %d", ip, x->netmask);
+
+    FAIL_IF_NOT(strcmp(ip, "0.0.0.0") == 0);
+    FAIL_IF_NOT(x->netmask == 0);
+
+    IPOnlyCIDRListFree(x);
+    PASS;
+}
+
+static int IPOnlyTestBug5168v2(void)
+{
+    IPOnlyCIDRItem *x = IPOnlyCIDRItemNew();
+    FAIL_IF_NULL(x);
+    FAIL_IF(IPOnlyCIDRItemParseSingle(&x, "0.0.0.5/0.0.0.5") != -1);
+    IPOnlyCIDRListFree(x);
+    PASS;
+}
+
 #endif /* UNITTESTS */
 
 void IPOnlyRegisterTests(void)
@@ -2461,6 +2488,9 @@ void IPOnlyRegisterTests(void)
     UtRegisterTest("IPOnlyTestBug5066v3", IPOnlyTestBug5066v3);
     UtRegisterTest("IPOnlyTestBug5066v4", IPOnlyTestBug5066v4);
     UtRegisterTest("IPOnlyTestBug5066v5", IPOnlyTestBug5066v5);
+
+    UtRegisterTest("IPOnlyTestBug5168v1", IPOnlyTestBug5168v1);
+    UtRegisterTest("IPOnlyTestBug5168v2", IPOnlyTestBug5168v2);
 #endif
 
     return;

--- a/src/util-cidr.c
+++ b/src/util-cidr.c
@@ -26,6 +26,32 @@
 #include "suricata-common.h"
 #include "util-cidr.h"
 
+/** \brief turn 32 bit mask into CIDR
+ *  \retval cidr cidr value or -1 if the netmask can't be expressed as cidr
+ */
+int CIDRFromMask(uint32_t netmask)
+{
+    if (netmask == 0) {
+        return 0;
+    }
+    int lead_1 = 0;
+    bool seen_0 = false;
+    for (int i = 0; i < 32; i++) {
+        if (!seen_0) {
+            if ((netmask & BIT_U32(i)) != 0) {
+                lead_1++;
+            } else {
+                seen_0 = true;
+            }
+        } else {
+            if ((netmask & BIT_U32(i)) != 0) {
+                return -1;
+            }
+        }
+    }
+    return lead_1;
+}
+
 uint32_t CIDRGet(int cidr)
 {
     if (cidr <= 0 || cidr > 32)

--- a/src/util-cidr.h
+++ b/src/util-cidr.h
@@ -24,6 +24,7 @@
 #ifndef __UTIL_NETMASK_H__
 #define __UTIL_NETMASK_H__
 
+int CIDRFromMask(uint32_t netmask);
 uint32_t CIDRGet(int);
 void CIDRGetIPv6(int cidr, struct in6_addr *in6);
 


### PR DESCRIPTION
Addressing `0.0.0.5/0.0.0.5` style netmask, that are not handled correctly in IPOnly due to our Radix tree requiring CIDR compatible netmasks.

Fix requires all netmasks to be expressible as CIDR as well, so this tightens the parser for rule address input.

https://redmine.openinfosecfoundation.org/issues/5168