### PR TITLE
nfs4: add missing parsers v2

### DIFF
--- a/rust/src/nfs/nfs4_records.rs
+++ b/rust/src/nfs/nfs4_records.rs
@@ -61,6 +61,7 @@ pub enum Nfs4RequestContent<'a> {
     ExchangeId(Nfs4RequestExchangeId<'a>),
     Sequence(Nfs4RequestSequence<'a>),
     CreateSession(Nfs4RequestCreateSession<'a>),
+    ReclaimComplete(u32),
 }
 
 #[derive(Debug,PartialEq)]
@@ -418,6 +419,10 @@ fn nfs4_req_commit(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
     Ok((i, Nfs4RequestContent::Commit))
 }
 
+fn nfs4_req_reclaim_complete(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+    map(verify(be_u32, |&v| v <= 1), Nfs4RequestContent::ReclaimComplete) (i)
+}
+
 #[derive(Debug,PartialEq)]
 pub struct Nfs4RequestExchangeId<'a> {
     pub client_string: &'a[u8],
@@ -488,6 +493,7 @@ fn parse_request_compound_command(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent
         NFSPROC4_SEQUENCE => nfs4_req_sequence(i)?,
         NFSPROC4_EXCHANGE_ID => nfs4_req_exchangeid(i)?,
         NFSPROC4_CREATE_SESSION => nfs4_req_create_session(i)?,
+        NFSPROC4_RECLAIM_COMPLETE => nfs4_req_reclaim_complete(i)?,
         _ => { return Err(Err::Error(make_error(i, ErrorKind::Switch))); }
     };
     Ok((i, cmd_data))
@@ -537,6 +543,7 @@ pub enum Nfs4ResponseContent<'a> {
     ExchangeId(u32, Option<Nfs4ResponseExchangeId<'a>>),
     Sequence(u32, Option<Nfs4ResponseSequence<'a>>),
     CreateSession(u32, Option<Nfs4ResponseCreateSession<'a>>),
+    ReclaimComplete(u32),
 }
 
 #[derive(Debug, PartialEq)]
@@ -592,6 +599,10 @@ fn nfs4_parse_res_exchangeid(i: &[u8]) -> IResult<&[u8], Nfs4ResponseExchangeId>
         nii_domain,
         nii_name,
     }))
+}
+
+fn nfs4_res_reclaim_complete(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+    map(be_u32, Nfs4ResponseContent::ReclaimComplete) (i)
 }
 
 fn nfs4_res_exchangeid(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
@@ -946,6 +957,7 @@ fn nfs4_res_compound_command(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
         NFSPROC4_SEQUENCE => nfs4_res_sequence(i)?,
         NFSPROC4_RENEW => nfs4_res_renew(i)?,
         NFSPROC4_CREATE_SESSION => nfs4_res_create_session(i)?,
+        NFSPROC4_RECLAIM_COMPLETE => nfs4_res_reclaim_complete(i)?,
         _ => { return Err(Err::Error(make_error(i, ErrorKind::Switch))); }
     };
     Ok((i, cmd_data))

--- a/rust/src/nfs/nfs4_records.rs
+++ b/rust/src/nfs/nfs4_records.rs
@@ -65,6 +65,7 @@ pub enum Nfs4RequestContent<'a> {
     CreateSession(Nfs4RequestCreateSession<'a>),
     ReclaimComplete(u32),
     SecInfoNoName(u32),
+    LayoutGet(Nfs4RequestLayoutGet<'a>),
 }
 
 #[derive(Debug,PartialEq)]
@@ -429,6 +430,32 @@ fn nfs4_req_reclaim_complete(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
     map(verify(be_u32, |&v| v <= 1), Nfs4RequestContent::ReclaimComplete) (i)
 }
 
+#[derive(Debug, PartialEq)]
+pub struct Nfs4RequestLayoutGet<'a> {
+    pub layout_type: u32,
+    pub length: u64,
+    pub min_length: u64,
+    pub stateid: Nfs4StateId<'a>,
+}
+
+fn nfs4_req_layoutget(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+    let (i, _layout_available) = verify(be_u32, |&v| v <= 1)(i)?;
+    let (i, layout_type) = be_u32(i)?;
+    let (i, _iq_mode) = be_u32(i)?;
+    let (i, _offset) = be_u64(i)?;
+    let (i, length) = be_u64(i)?;
+    let (i, min_length) = be_u64(i)?;
+    let (i, stateid) = nfs4_parse_stateid(i)?;
+    let (i, _maxcount) = be_u32(i)?;
+    let req = Nfs4RequestContent::LayoutGet(Nfs4RequestLayoutGet {
+        layout_type,
+        length,
+        min_length,
+        stateid,
+    });
+    Ok((i, req))
+}
+
 #[derive(Debug,PartialEq)]
 pub struct Nfs4RequestExchangeId<'a> {
     pub client_string: &'a[u8],
@@ -501,6 +528,7 @@ fn parse_request_compound_command(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent
         NFSPROC4_CREATE_SESSION => nfs4_req_create_session(i)?,
         NFSPROC4_RECLAIM_COMPLETE => nfs4_req_reclaim_complete(i)?,
         NFSPROC4_SECINFO_NO_NAME => nfs4_req_secinfo_no_name(i)?,
+        NFSPROC4_LAYOUTGET => nfs4_req_layoutget(i)?,
         _ => { return Err(Err::Error(make_error(i, ErrorKind::Switch))); }
     };
     Ok((i, cmd_data))
@@ -552,6 +580,7 @@ pub enum Nfs4ResponseContent<'a> {
     CreateSession(u32, Option<Nfs4ResponseCreateSession<'a>>),
     ReclaimComplete(u32),
     SecInfoNoName(u32),
+    LayoutGet(u32, Option<Nfs4ResponseLayoutGet<'a>>),
 }
 
 #[derive(Debug, PartialEq)]
@@ -747,6 +776,46 @@ fn nfs4_res_open(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
     Ok((i, Nfs4ResponseContent::Open(status, open_data)))
 }
 
+/*https://datatracker.ietf.org/doc/html/rfc5661#section-13.1*/
+// in case of multiple file handles, return handles in a vector
+#[derive(Debug, PartialEq)]
+pub struct Nfs4ResponseLayoutGet<'a> {
+    pub stateid: Nfs4StateId<'a>,
+    pub length: u64,
+    pub layout_type: u32,
+    pub device_id: &'a[u8],
+    pub file_handles: Vec<Nfs4Handle<'a>>,
+}
+
+fn nfs4_parse_res_layoutget(i: &[u8]) -> IResult<&[u8], Nfs4ResponseLayoutGet> {
+    let (i, _return_on_close) =  verify(be_u32, |&v| v <= 1)(i)?;
+    let (i, stateid) = nfs4_parse_stateid(i)?;
+    let (i, _layout_seg) = be_u32(i)?;
+    let (i, _offset) = be_u64(i)?;
+    let (i, length) = be_u64(i)?;
+    let (i, _lo_mode) = be_u32(i)?;
+    let (i, layout_type) = be_u32(i)?;
+    let (i, _) = be_u32(i)?;
+    let (i, device_id) = take(16_usize)(i)?;
+    let (i, _nfl_util) = be_u32(i)?;
+    let (i, _strip_index) = be_u32(i)?;
+    let (i, _offset) = be_u64(i)?;
+    let (i, fh_handles) = be_u32(i)?;
+    let (i, file_handles) = count(nfs4_parse_handle, fh_handles as usize)(i)?;
+    Ok((i, Nfs4ResponseLayoutGet {
+        stateid,
+        length,
+        layout_type,
+        device_id,
+        file_handles,
+    }))
+}
+
+fn nfs4_res_layoutget(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+    let (i, status) = be_u32(i)?;
+    let (i, lyg_data) = cond(status == 0, nfs4_parse_res_layoutget)(i)?;
+    Ok((i, Nfs4ResponseContent::LayoutGet( status, lyg_data )))
+}
 
 // #[derive(Debug, PartialEq)]
 // pub struct Nfs4FlavorRpcSecGss<'a> {
@@ -995,6 +1064,7 @@ fn nfs4_res_compound_command(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
         NFSPROC4_CREATE_SESSION => nfs4_res_create_session(i)?,
         NFSPROC4_RECLAIM_COMPLETE => nfs4_res_reclaim_complete(i)?,
         NFSPROC4_SECINFO_NO_NAME => nfs4_res_secinfo_no_name(i)?,
+        NFSPROC4_LAYOUTGET => nfs4_res_layoutget(i)?,
         _ => { return Err(Err::Error(make_error(i, ErrorKind::Switch))); }
     };
     Ok((i, cmd_data))
@@ -1331,6 +1401,33 @@ mod tests {
                 assert_eq!(create_ssn.client_id, &buf[4..12]);
                 assert_eq!(create_ssn.seqid, 1);
                 assert_eq!(create_ssn.machine_name, b"netapp-26");
+            }
+            _ => { panic!("Failure"); }
+        }
+    }
+
+    #[test]
+    fn test_nfs4_request_layoutget() {
+        let buf: &[u8] = &[
+            0x00, 0x00, 0x00, 0x32, /*opcode*/
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // layoutget
+            0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x02, 0x82, 0x14, 0xe0, 0x5b, 0x00, 0x89, 0xd9,
+            0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00,
+        ];
+
+        let (_, stateid_buf) = nfs4_parse_stateid(&buf[40..56]).unwrap();
+        assert_eq!(stateid_buf.seqid, 0);
+
+        let (_, request) = nfs4_req_layoutget(&buf[4..]).unwrap();
+        match request {
+            Nfs4RequestContent::LayoutGet( lyg_data ) => {
+                assert_eq!(lyg_data.layout_type, 1);
+                assert_eq!(lyg_data.min_length, 4096);
+                assert_eq!(lyg_data.stateid, stateid_buf);
             }
             _ => { panic!("Failure"); }
         }
@@ -1704,4 +1801,46 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_nfs4_response_layoutget() {
+        let buf: &[u8] = &[
+            0x00, 0x00, 0x00, 0x32, /*opcode*/
+            0x00, 0x00, 0x00, 0x00, /*status*/
+        // layoutget
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x03, 0x82, 0x14, 0xe0, 0x5b, 0x00, 0x89, 0xd9,
+            0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x58, 0x01, 0x01, 0x00, 0x00,
+            0x00, 0xf2, 0xfa, 0x80, 0x00, 0x00, 0x00, 0x00,
+            0x20, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x30, 0x01, 0x03, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x84, 0x72, 0x00, 0x00, 0x23, 0xa6, 0xc0, 0x12,
+            0x00, 0xf2, 0xfa, 0x80, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00,
+            0x00, 0xf2, 0xfa, 0x80, 0x00, 0x00, 0x00, 0x00,
+            0x20, 0x00, 0x00, 0x00,
+        ];
+
+        let (_, stateid) = nfs4_parse_stateid(&buf[12..28]).unwrap();
+
+        let (_, lyg_data) = nfs4_parse_res_layoutget(&buf[8..]).unwrap();
+        assert_eq!(lyg_data.stateid, stateid);
+        assert_eq!(lyg_data.layout_type, 1);
+        assert_eq!(lyg_data.device_id, &buf[60..76]);
+
+        let (_, response) = nfs4_res_layoutget(&buf[4..]).unwrap();
+        match response {
+            Nfs4ResponseContent::LayoutGet( status, lyg ) => {
+                assert_eq!(status, 0);
+                assert_eq!(lyg, Some(lyg_data));
+            }
+            _ => { panic!("Failure"); }
+        }
+    }
 }

--- a/rust/src/nfs/nfs4_records.rs
+++ b/rust/src/nfs/nfs4_records.rs
@@ -25,6 +25,11 @@ use nom7::{Err, IResult};
 
 use crate::nfs::types::*;
 
+/*https://datatracker.ietf.org/doc/html/rfc7530 - section 16.16 File Delegation Types */
+const OPEN_DELEGATE_NONE:    u32 = 0;
+const OPEN_DELEGATE_READ:    u32 = 1;
+const OPEN_DELEGATE_WRITE:   u32 = 2;
+
 // Maximum number of operations per compound
 // Linux defines NFSD_MAX_OPS_PER_COMPOUND to 16 (tested in Linux 5.15.1).
 const NFSD_MAX_OPS_PER_COMPOUND: usize = 64;
@@ -550,8 +555,35 @@ fn nfs4_res_read(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
 pub struct Nfs4ResponseOpen<'a> {
     pub stateid: Nfs4StateId<'a>,
     pub result_flags: u32,
-    pub delegation_type: u32,
-    pub delegate_read: Option<Nfs4ResponseOpenDelegateRead<'a>>,
+    pub delegate: Nfs4ResponseFileDelegation<'a>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Nfs4ResponseFileDelegation<'a> {
+    DelegateRead(Nfs4ResponseOpenDelegateRead<'a>),
+    DelegateWrite(Nfs4ResponseOpenDelegateWrite<'a>),
+    DelegateNone(u32),
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Nfs4ResponseOpenDelegateWrite<'a> {
+    pub stateid: Nfs4StateId<'a>,
+    pub who: &'a[u8],
+}
+
+fn nfs4_res_open_ok_delegate_write(i: &[u8]) -> IResult<&[u8], Nfs4ResponseFileDelegation> {
+    let (i, stateid) = nfs4_parse_stateid(i)?;
+    let (i, _recall) = be_u32(i)?;
+    let (i, _space_limit) = be_u32(i)?;
+    let (i, _filesize) = be_u32(i)?;
+    let (i, _access_type) = be_u32(i)?;
+    let (i, _ace_flags) = be_u32(i)?;
+    let (i, _ace_mask) = be_u32(i)?;
+    let (i, who) = nfs4_parse_nfsstring(i)?;
+    Ok((i, Nfs4ResponseFileDelegation::DelegateWrite(Nfs4ResponseOpenDelegateWrite {
+        stateid, 
+        who, 
+    })))
 }
 
 #[derive(Debug,PartialEq)]
@@ -559,7 +591,7 @@ pub struct Nfs4ResponseOpenDelegateRead<'a> {
     pub stateid: Nfs4StateId<'a>,
 }
 
-fn nfs4_res_open_ok_delegate_read(i: &[u8]) -> IResult<&[u8], Nfs4ResponseOpenDelegateRead> {
+fn nfs4_res_open_ok_delegate_read(i: &[u8]) -> IResult<&[u8], Nfs4ResponseFileDelegation> {
     let (i, stateid) = nfs4_parse_stateid(i)?;
     let (i, _recall) = be_u32(i)?;
     let (i, _ace_type) = be_u32(i)?;
@@ -567,7 +599,20 @@ fn nfs4_res_open_ok_delegate_read(i: &[u8]) -> IResult<&[u8], Nfs4ResponseOpenDe
     let (i, _ace_mask) = be_u32(i)?;
     let (i, who_len) = be_u32(i)?;
     let (i, _who) = take(who_len as usize)(i)?;
-    Ok((i, Nfs4ResponseOpenDelegateRead { stateid }))
+    Ok((i, Nfs4ResponseFileDelegation::DelegateRead(Nfs4ResponseOpenDelegateRead {
+        stateid,
+    })))
+}
+
+fn nfs4_parse_file_delegation(i: &[u8]) -> IResult<&[u8], Nfs4ResponseFileDelegation> {
+    let (i, delegation_type) = be_u32(i)?;
+    let (i, file_delegation) = match delegation_type {
+        OPEN_DELEGATE_READ => nfs4_res_open_ok_delegate_read(i)?,
+        OPEN_DELEGATE_WRITE => nfs4_res_open_ok_delegate_write(i)?,
+        OPEN_DELEGATE_NONE => (i, Nfs4ResponseFileDelegation::DelegateNone(OPEN_DELEGATE_NONE)),
+        _ => { return Err(Err::Error(make_error(i, ErrorKind::Switch))); }
+    };
+    Ok((i, file_delegation))
 }
 
 fn nfs4_res_open_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseOpen> {
@@ -575,13 +620,11 @@ fn nfs4_res_open_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseOpen> {
     let (i, _change_info) = take(20_usize)(i)?;
     let (i, result_flags) = be_u32(i)?;
     let (i, _attrs) = nfs4_parse_attrbits(i)?;
-    let (i, delegation_type) = be_u32(i)?;
-    let (i, delegate_read) = cond(delegation_type == 1, nfs4_res_open_ok_delegate_read)(i)?;
+    let (i, delegate) = nfs4_parse_file_delegation(i)?;
     let resp = Nfs4ResponseOpen {
         stateid,
         result_flags,
-        delegation_type,
-        delegate_read
+        delegate,
     };
     Ok((i, resp))
 }
@@ -1185,29 +1228,31 @@ mod tests {
             0x5b, 0x00, 0x88, 0xd9, 0x04, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x01, 0x16, 0xf8, 0x2f, 0xd5, /*_change_info*/
             0xdb, 0xb7, 0xfe, 0x38, 0x16, 0xf8, 0x2f, 0xdf,
-            0x21, 0xa8, 0x2a, 0x48,
-            0x00, 0x00, 0x00, 0x04, /*result_flags*/
-            0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x10, /*_attrs*/
+            0x21, 0xa8, 0x2a, 0x48, 0x00, 0x00, 0x00, 0x04,
+            0x00, 0x00, 0x00, 0x03,
+            0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x02, /*_attrs*/
+            0x00, 0x00, 0x00, 0x00,
+        // delegate_write
             0x00, 0x00, 0x00, 0x02, /*delegation_type*/
-        // delegate_read
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
             0x00, 0x00, 0x00, 0x01, 0x02, 0x82, 0x14, 0xe0,
             0x5b, 0x00, 0x89, 0xd9, 0x04, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
         ];
 
         let stateid_buf = &buf[8..24];
         let (_, res_stateid) = nfs4_parse_stateid(stateid_buf).unwrap();
 
+        let delegate_buf = &buf[64..];
+        let (_, delegate) = nfs4_parse_file_delegation(delegate_buf).unwrap();
+
         let open_data_buf = &buf[8..];
         let (_, res_open_data) = nfs4_res_open_ok(open_data_buf).unwrap();
         assert_eq!(res_open_data.stateid, res_stateid);
         assert_eq!(res_open_data.result_flags, 4);
-        assert_eq!(res_open_data.delegation_type, 2);
-        assert_eq!(res_open_data.delegate_read, None);
+        assert_eq!(res_open_data.delegate, delegate);
 
         let (_, response) = nfs4_res_open(&buf[4..]).unwrap();
         match response {

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -273,11 +273,10 @@ pub const NFSPROC4_SETCLIENTID_CONFIRM: u32 = 36;
 pub const NFSPROC4_VERIFY:              u32 = 37;
 pub const NFSPROC4_WRITE:               u32 = 38;
 pub const NFSPROC4_RELEASE_LOCKOWNER:   u32 = 39;
+pub const NFSPROC4_EXCHANGE_ID:         u32 = 42;
 pub const NFSPROC4_CREATE_SESSION:      u32 = 43;
 pub const NFSPROC4_SEQUENCE:            u32 = 53;
-
-
-pub const NFSPROC4_EXCHANGE_ID:         u32 = 42;
+pub const NFSPROC4_RECLAIM_COMPLETE:    u32 = 58;
 
 pub const NFSPROC4_ILLEGAL:             u32 = 10044;
 

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -275,6 +275,7 @@ pub const NFSPROC4_WRITE:               u32 = 38;
 pub const NFSPROC4_RELEASE_LOCKOWNER:   u32 = 39;
 pub const NFSPROC4_EXCHANGE_ID:         u32 = 42;
 pub const NFSPROC4_CREATE_SESSION:      u32 = 43;
+pub const NFSPROC4_SECINFO_NO_NAME:     u32 = 52;
 pub const NFSPROC4_SEQUENCE:            u32 = 53;
 pub const NFSPROC4_RECLAIM_COMPLETE:    u32 = 58;
 

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -273,6 +273,7 @@ pub const NFSPROC4_SETCLIENTID_CONFIRM: u32 = 36;
 pub const NFSPROC4_VERIFY:              u32 = 37;
 pub const NFSPROC4_WRITE:               u32 = 38;
 pub const NFSPROC4_RELEASE_LOCKOWNER:   u32 = 39;
+pub const NFSPROC4_CREATE_SESSION:      u32 = 43;
 pub const NFSPROC4_SEQUENCE:            u32 = 53;
 
 

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -281,6 +281,7 @@ pub const NFSPROC4_LAYOUTGET:           u32 = 50;
 pub const NFSPROC4_LAYOUTRETURN:        u32 = 51;
 pub const NFSPROC4_SECINFO_NO_NAME:     u32 = 52;
 pub const NFSPROC4_SEQUENCE:            u32 = 53;
+pub const NFSPROC4_DESTROY_CLIENTID:    u32 = 57;
 pub const NFSPROC4_RECLAIM_COMPLETE:    u32 = 58;
 
 pub const NFSPROC4_ILLEGAL:             u32 = 10044;

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -275,6 +275,7 @@ pub const NFSPROC4_WRITE:               u32 = 38;
 pub const NFSPROC4_RELEASE_LOCKOWNER:   u32 = 39;
 pub const NFSPROC4_EXCHANGE_ID:         u32 = 42;
 pub const NFSPROC4_CREATE_SESSION:      u32 = 43;
+pub const NFSPROC4_LAYOUTGET:           u32 = 50;
 pub const NFSPROC4_SECINFO_NO_NAME:     u32 = 52;
 pub const NFSPROC4_SEQUENCE:            u32 = 53;
 pub const NFSPROC4_RECLAIM_COMPLETE:    u32 = 58;

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -275,6 +275,7 @@ pub const NFSPROC4_WRITE:               u32 = 38;
 pub const NFSPROC4_RELEASE_LOCKOWNER:   u32 = 39;
 pub const NFSPROC4_EXCHANGE_ID:         u32 = 42;
 pub const NFSPROC4_CREATE_SESSION:      u32 = 43;
+pub const NFSPROC4_GETDEVINFO:          u32 = 47;
 pub const NFSPROC4_LAYOUTGET:           u32 = 50;
 pub const NFSPROC4_SECINFO_NO_NAME:     u32 = 52;
 pub const NFSPROC4_SEQUENCE:            u32 = 53;

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -275,6 +275,7 @@ pub const NFSPROC4_WRITE:               u32 = 38;
 pub const NFSPROC4_RELEASE_LOCKOWNER:   u32 = 39;
 pub const NFSPROC4_EXCHANGE_ID:         u32 = 42;
 pub const NFSPROC4_CREATE_SESSION:      u32 = 43;
+pub const NFSPROC4_DESTROY_SESSION:     u32 = 44;
 pub const NFSPROC4_GETDEVINFO:          u32 = 47;
 pub const NFSPROC4_LAYOUTGET:           u32 = 50;
 pub const NFSPROC4_LAYOUTRETURN:        u32 = 51;

--- a/rust/src/nfs/types.rs
+++ b/rust/src/nfs/types.rs
@@ -277,6 +277,7 @@ pub const NFSPROC4_EXCHANGE_ID:         u32 = 42;
 pub const NFSPROC4_CREATE_SESSION:      u32 = 43;
 pub const NFSPROC4_GETDEVINFO:          u32 = 47;
 pub const NFSPROC4_LAYOUTGET:           u32 = 50;
+pub const NFSPROC4_LAYOUTRETURN:        u32 = 51;
 pub const NFSPROC4_SECINFO_NO_NAME:     u32 = 52;
 pub const NFSPROC4_SEQUENCE:            u32 = 53;
 pub const NFSPROC4_RECLAIM_COMPLETE:    u32 = 58;


### PR DESCRIPTION
Previous PR #7046 
Changes from Previous PR:
- Cleanups
- Verify Boolean fields if needed.

Redmine Ticket: [#5174](https://redmine.openinfosecfoundation.org/issues/5175?next_issue_id=5174)

An NFS4 compound record is parsed as a whole --
if an operation in a compound record is missing a parser, the parsing will fail.

A couple of NFS4 compound records were logged as `MalformedData` due to missing op parsers
Add missing parsers and their respective unittests if needed.

suricata-verfiy-pr: 779