### PR TITLE
Detect generic uint 4112 v1

### DIFF
--- a/rust/src/detect.rs
+++ b/rust/src/detect.rs
@@ -97,6 +97,32 @@ fn detect_parse_u32_start_greater(i: &str) -> IResult<&str, DetectU32Data> {
     ))
 }
 
+pub fn detect_match_u32(x: &DetectU32Data, val: u32) -> bool {
+    match x.mode {
+        DetectUintMode::DetectUintModeEqual => {
+            if val == x.value {
+                return true;
+            }
+        }
+        DetectUintMode::DetectUintModeLt => {
+            if val < x.value {
+                return true;
+            }
+        }
+        DetectUintMode::DetectUintModeGt => {
+            if val > x.value {
+                return true;
+            }
+        }
+        DetectUintMode::DetectUintModeRange => {
+            if val < x.value && val > x.valrange {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 pub fn detect_parse_u32(i: &str) -> IResult<&str, DetectU32Data> {
     let (i, u32) = alt((
         detect_parse_u32_start_lesser,
@@ -183,4 +209,30 @@ pub fn detect_parse_u64(i: &str) -> IResult<&str, DetectU64Data> {
         detect_parse_u64_start_equal,
     ))(i)?;
     Ok((i, u64))
+}
+
+pub fn detect_match_u64(x: &DetectU64Data, val: u64) -> bool {
+    match x.mode {
+        DetectUintMode::DetectUintModeEqual => {
+            if val == x.value {
+                return true;
+            }
+        }
+        DetectUintMode::DetectUintModeLt => {
+            if val < x.value {
+                return true;
+            }
+        }
+        DetectUintMode::DetectUintModeGt => {
+            if val > x.value {
+                return true;
+            }
+        }
+        DetectUintMode::DetectUintModeRange => {
+            if val < x.value && val > x.valrange {
+                return true;
+            }
+        }
+    }
+    return false;
 }

--- a/rust/src/detect.rs
+++ b/rust/src/detect.rs
@@ -1,0 +1,186 @@
+/* Copyright (C) 2022 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use nom7::branch::alt;
+use nom7::bytes::complete::{is_a, tag};
+use nom7::character::complete::digit1;
+use nom7::combinator::{complete, map_opt, opt};
+use nom7::IResult;
+
+#[derive(PartialEq, Debug)]
+pub enum DetectUintMode {
+    DetectUintModeEqual,
+    DetectUintModeLt,
+    DetectUintModeGt,
+    DetectUintModeRange,
+}
+
+pub struct DetectU32Data {
+    pub value: u32,
+    pub valrange: u32,
+    pub mode: DetectUintMode,
+}
+
+fn detect_parse_u32_start_equal(i: &str) -> IResult<&str, DetectU32Data> {
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = opt(tag("="))(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u32>().ok())(i)?;
+    Ok((
+        i,
+        DetectU32Data {
+            value,
+            valrange: 0,
+            mode: DetectUintMode::DetectUintModeEqual,
+        },
+    ))
+}
+
+fn detect_parse_u32_start_interval(i: &str) -> IResult<&str, DetectU32Data> {
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u32>().ok())(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = tag("-")(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, valrange) = map_opt(digit1, |s: &str| s.parse::<u32>().ok())(i)?;
+    Ok((
+        i,
+        DetectU32Data {
+            value,
+            valrange,
+            mode: DetectUintMode::DetectUintModeRange,
+        },
+    ))
+}
+
+fn detect_parse_u32_start_lesser(i: &str) -> IResult<&str, DetectU32Data> {
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = tag("<")(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u32>().ok())(i)?;
+    Ok((
+        i,
+        DetectU32Data {
+            value,
+            valrange: 0,
+            mode: DetectUintMode::DetectUintModeLt,
+        },
+    ))
+}
+
+fn detect_parse_u32_start_greater(i: &str) -> IResult<&str, DetectU32Data> {
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = tag(">")(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u32>().ok())(i)?;
+    Ok((
+        i,
+        DetectU32Data {
+            value,
+            valrange: 0,
+            mode: DetectUintMode::DetectUintModeGt,
+        },
+    ))
+}
+
+pub fn detect_parse_u32(i: &str) -> IResult<&str, DetectU32Data> {
+    let (i, u32) = alt((
+        detect_parse_u32_start_lesser,
+        detect_parse_u32_start_greater,
+        complete(detect_parse_u32_start_interval),
+        detect_parse_u32_start_equal,
+    ))(i)?;
+    Ok((i, u32))
+}
+
+pub struct DetectU64Data {
+    pub value: u64,
+    pub valrange: u64,
+    pub mode: DetectUintMode,
+}
+
+fn detect_parse_u64_start_equal(i: &str) -> IResult<&str, DetectU64Data> {
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = opt(tag("="))(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u64>().ok())(i)?;
+    Ok((
+        i,
+        DetectU64Data {
+            value,
+            valrange: 0,
+            mode: DetectUintMode::DetectUintModeEqual,
+        },
+    ))
+}
+
+fn detect_parse_u64_start_interval(i: &str) -> IResult<&str, DetectU64Data> {
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u64>().ok())(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = tag("-")(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, valrange) = map_opt(digit1, |s: &str| s.parse::<u64>().ok())(i)?;
+    Ok((
+        i,
+        DetectU64Data {
+            value,
+            valrange,
+            mode: DetectUintMode::DetectUintModeRange,
+        },
+    ))
+}
+
+fn detect_parse_u64_start_lesser(i: &str) -> IResult<&str, DetectU64Data> {
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = tag("<")(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u64>().ok())(i)?;
+    Ok((
+        i,
+        DetectU64Data {
+            value,
+            valrange: 0,
+            mode: DetectUintMode::DetectUintModeLt,
+        },
+    ))
+}
+
+fn detect_parse_u64_start_greater(i: &str) -> IResult<&str, DetectU64Data> {
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = tag(">")(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u64>().ok())(i)?;
+    Ok((
+        i,
+        DetectU64Data {
+            value,
+            valrange: 0,
+            mode: DetectUintMode::DetectUintModeGt,
+        },
+    ))
+}
+
+pub fn detect_parse_u64(i: &str) -> IResult<&str, DetectU64Data> {
+    let (i, u64) = alt((
+        detect_parse_u64_start_lesser,
+        detect_parse_u64_start_greater,
+        complete(detect_parse_u64_start_interval),
+        detect_parse_u64_start_equal,
+    ))(i)?;
+    Ok((i, u64))
+}

--- a/rust/src/detect.rs
+++ b/rust/src/detect.rs
@@ -18,7 +18,7 @@
 use nom7::branch::alt;
 use nom7::bytes::complete::{is_a, tag};
 use nom7::character::complete::digit1;
-use nom7::combinator::{complete, map_opt, opt};
+use nom7::combinator::{complete, map_opt, opt, verify};
 use nom7::IResult;
 
 #[derive(PartialEq, Debug)]
@@ -73,7 +73,9 @@ fn detect_parse_u32_start_interval(i: &str) -> IResult<&str, DetectU32Data> {
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = tag("-")(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
-    let (i, valrange) = map_opt(digit1, |s: &str| s.parse::<u32>().ok())(i)?;
+    let (i, valrange) = verify(map_opt(digit1, |s: &str| s.parse::<u32>().ok()), |&x| {
+        x > value && x > value + 1
+    })(i)?;
     Ok((
         i,
         DetectU32Data {
@@ -88,7 +90,7 @@ fn detect_parse_u32_start_lesser(i: &str) -> IResult<&str, DetectU32Data> {
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = tag("<")(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
-    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u32>().ok())(i)?;
+    let (i, value) = verify(map_opt(digit1, |s: &str| s.parse::<u32>().ok()), |&x| x > 0)(i)?;
     Ok((
         i,
         DetectU32Data {
@@ -103,7 +105,9 @@ fn detect_parse_u32_start_greater(i: &str) -> IResult<&str, DetectU32Data> {
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = tag(">")(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
-    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u32>().ok())(i)?;
+    let (i, value) = verify(map_opt(digit1, |s: &str| s.parse::<u32>().ok()), |&x| {
+        x < u32::MAX
+    })(i)?;
     Ok((
         i,
         DetectU32Data {
@@ -137,7 +141,7 @@ pub fn detect_match_u32(x: &DetectU32Data, val: u32) -> bool {
             }
         }
         DetectUintMode::DetectUintModeRange => {
-            if val < x.value && val > x.valrange {
+            if val > x.value && val < x.valrange {
                 return true;
             }
         }
@@ -199,7 +203,9 @@ fn detect_parse_u64_start_interval(i: &str) -> IResult<&str, DetectU64Data> {
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = tag("-")(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
-    let (i, valrange) = map_opt(digit1, |s: &str| s.parse::<u64>().ok())(i)?;
+    let (i, valrange) = verify(map_opt(digit1, |s: &str| s.parse::<u64>().ok()), |&x| {
+        x > value && x > value + 1
+    })(i)?;
     Ok((
         i,
         DetectU64Data {
@@ -214,7 +220,7 @@ fn detect_parse_u64_start_lesser(i: &str) -> IResult<&str, DetectU64Data> {
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = tag("<")(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
-    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u64>().ok())(i)?;
+    let (i, value) = verify(map_opt(digit1, |s: &str| s.parse::<u64>().ok()), |&x| x > 0)(i)?;
     Ok((
         i,
         DetectU64Data {
@@ -229,7 +235,9 @@ fn detect_parse_u64_start_greater(i: &str) -> IResult<&str, DetectU64Data> {
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = tag(">")(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
-    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u64>().ok())(i)?;
+    let (i, value) = verify(map_opt(digit1, |s: &str| s.parse::<u64>().ok()), |&x| {
+        x < u64::MAX
+    })(i)?;
     Ok((
         i,
         DetectU64Data {
@@ -274,7 +282,7 @@ pub fn detect_match_u64(x: &DetectU64Data, val: u64) -> bool {
             }
         }
         DetectUintMode::DetectUintModeRange => {
-            if val < x.value && val > x.valrange {
+            if val > x.value && val < x.valrange {
                 return true;
             }
         }
@@ -325,7 +333,9 @@ fn detect_parse_u16_start_interval(i: &str) -> IResult<&str, DetectU16Data> {
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = tag("-")(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
-    let (i, valrange) = map_opt(digit1, |s: &str| s.parse::<u16>().ok())(i)?;
+    let (i, valrange) = verify(map_opt(digit1, |s: &str| s.parse::<u16>().ok()), |&x| {
+        x > value && x > value + 1
+    })(i)?;
     Ok((
         i,
         DetectU16Data {
@@ -340,7 +350,7 @@ fn detect_parse_u16_start_lesser(i: &str) -> IResult<&str, DetectU16Data> {
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = tag("<")(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
-    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u16>().ok())(i)?;
+    let (i, value) = verify(map_opt(digit1, |s: &str| s.parse::<u16>().ok()), |&x| x > 0)(i)?;
     Ok((
         i,
         DetectU16Data {
@@ -355,7 +365,9 @@ fn detect_parse_u16_start_greater(i: &str) -> IResult<&str, DetectU16Data> {
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = tag(">")(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
-    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u16>().ok())(i)?;
+    let (i, value) = verify(map_opt(digit1, |s: &str| s.parse::<u16>().ok()), |&x| {
+        x < u16::MAX
+    })(i)?;
     Ok((
         i,
         DetectU16Data {
@@ -400,7 +412,7 @@ pub fn detect_match_u16(x: &DetectU16Data, val: u16) -> bool {
             }
         }
         DetectUintMode::DetectUintModeRange => {
-            if val < x.value && val > x.valrange {
+            if val > x.value && val < x.valrange {
                 return true;
             }
         }

--- a/rust/src/detect.rs
+++ b/rust/src/detect.rs
@@ -27,6 +27,7 @@ pub enum DetectUintMode {
     DetectUintModeLt,
     DetectUintModeGt,
     DetectUintModeRange,
+    DetectUintModeNe,
 }
 
 #[derive(Debug)]
@@ -47,6 +48,21 @@ fn detect_parse_u32_start_equal(i: &str) -> IResult<&str, DetectU32Data> {
             value,
             valrange: 0,
             mode: DetectUintMode::DetectUintModeEqual,
+        },
+    ))
+}
+
+fn detect_parse_u32_start_ne(i: &str) -> IResult<&str, DetectU32Data> {
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = opt(tag("!"))(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u32>().ok())(i)?;
+    Ok((
+        i,
+        DetectU32Data {
+            value,
+            valrange: 0,
+            mode: DetectUintMode::DetectUintModeNe,
         },
     ))
 }
@@ -105,6 +121,11 @@ pub fn detect_match_u32(x: &DetectU32Data, val: u32) -> bool {
                 return true;
             }
         }
+        DetectUintMode::DetectUintModeNe => {
+            if val != x.value {
+                return true;
+            }
+        }
         DetectUintMode::DetectUintModeLt => {
             if val < x.value {
                 return true;
@@ -130,6 +151,7 @@ pub fn detect_parse_u32(i: &str) -> IResult<&str, DetectU32Data> {
         detect_parse_u32_start_greater,
         complete(detect_parse_u32_start_interval),
         detect_parse_u32_start_equal,
+        detect_parse_u32_start_ne,
     ))(i)?;
     Ok((i, u32))
 }
@@ -152,6 +174,21 @@ fn detect_parse_u64_start_equal(i: &str) -> IResult<&str, DetectU64Data> {
             value,
             valrange: 0,
             mode: DetectUintMode::DetectUintModeEqual,
+        },
+    ))
+}
+
+fn detect_parse_u64_start_ne(i: &str) -> IResult<&str, DetectU64Data> {
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = opt(tag("!"))(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u64>().ok())(i)?;
+    Ok((
+        i,
+        DetectU64Data {
+            value,
+            valrange: 0,
+            mode: DetectUintMode::DetectUintModeNe,
         },
     ))
 }
@@ -209,6 +246,7 @@ pub fn detect_parse_u64(i: &str) -> IResult<&str, DetectU64Data> {
         detect_parse_u64_start_greater,
         complete(detect_parse_u64_start_interval),
         detect_parse_u64_start_equal,
+        detect_parse_u64_start_ne,
     ))(i)?;
     Ok((i, u64))
 }
@@ -217,6 +255,11 @@ pub fn detect_match_u64(x: &DetectU64Data, val: u64) -> bool {
     match x.mode {
         DetectUintMode::DetectUintModeEqual => {
             if val == x.value {
+                return true;
+            }
+        }
+        DetectUintMode::DetectUintModeNe => {
+            if val != x.value {
                 return true;
             }
         }
@@ -257,6 +300,21 @@ fn detect_parse_u16_start_equal(i: &str) -> IResult<&str, DetectU16Data> {
             value,
             valrange: 0,
             mode: DetectUintMode::DetectUintModeEqual,
+        },
+    ))
+}
+
+fn detect_parse_u16_start_ne(i: &str) -> IResult<&str, DetectU16Data> {
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = opt(tag("!"))(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u16>().ok())(i)?;
+    Ok((
+        i,
+        DetectU16Data {
+            value,
+            valrange: 0,
+            mode: DetectUintMode::DetectUintModeNe,
         },
     ))
 }
@@ -314,6 +372,7 @@ pub fn detect_parse_u16(i: &str) -> IResult<&str, DetectU16Data> {
         detect_parse_u16_start_greater,
         complete(detect_parse_u16_start_interval),
         detect_parse_u16_start_equal,
+        detect_parse_u16_start_ne,
     ))(i)?;
     Ok((i, u16))
 }
@@ -322,6 +381,11 @@ pub fn detect_match_u16(x: &DetectU16Data, val: u16) -> bool {
     match x.mode {
         DetectUintMode::DetectUintModeEqual => {
             if val == x.value {
+                return true;
+            }
+        }
+        DetectUintMode::DetectUintModeNe => {
+            if val != x.value {
                 return true;
             }
         }

--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -749,6 +749,7 @@ pub fn http2_parse_frame_settings(i: &[u8]) -> IResult<&[u8], Vec<HTTP2FrameSett
 mod tests {
 
     use super::*;
+    use crate::detect::DetectUintMode;
 
     #[test]
     fn test_http2_parse_header() {

--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -17,11 +17,11 @@
 
 use super::huffman;
 use crate::common::nom7::bits;
+use crate::detect::{detect_parse_u32, DetectU32Data};
 use crate::http2::http2::{HTTP2DynTable, HTTP2_MAX_TABLESIZE};
 use nom7::bits::streaming::take as take_bits;
 use nom7::branch::alt;
-use nom7::bytes::streaming::{is_a, is_not, tag, take, take_while};
-use nom7::character::complete::digit1;
+use nom7::bytes::streaming::{is_a, is_not, take, take_while};
 use nom7::combinator::{complete, cond, map_opt, opt, rest, verify};
 use nom7::error::{make_error, ErrorKind};
 use nom7::multi::many0;
@@ -715,96 +715,9 @@ impl std::str::FromStr for HTTP2SettingsId {
     }
 }
 
-//TODOask move elsewhere generic with DetectU64Data and such
-#[derive(PartialEq, Debug)]
-pub enum DetectUintMode {
-    DetectUintModeEqual,
-    DetectUintModeLt,
-    DetectUintModeGt,
-    DetectUintModeRange,
-}
-
-pub struct DetectU32Data {
-    pub value: u32,
-    pub valrange: u32,
-    pub mode: DetectUintMode,
-}
-
 pub struct DetectHTTP2settingsSigCtx {
     pub id: HTTP2SettingsId,          //identifier
     pub value: Option<DetectU32Data>, //optional value
-}
-
-fn detect_parse_u32_start_equal(i: &str) -> IResult<&str, DetectU32Data> {
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, _) = opt(tag("="))(i)?;
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u32>().ok())(i)?;
-    Ok((
-        i,
-        DetectU32Data {
-            value,
-            valrange: 0,
-            mode: DetectUintMode::DetectUintModeEqual,
-        },
-    ))
-}
-
-fn detect_parse_u32_start_interval(i: &str) -> IResult<&str, DetectU32Data> {
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u32>().ok())(i)?;
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, _) = tag("-")(i)?;
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, valrange) = map_opt(digit1, |s: &str| s.parse::<u32>().ok())(i)?;
-    Ok((
-        i,
-        DetectU32Data {
-            value,
-            valrange,
-            mode: DetectUintMode::DetectUintModeRange,
-        },
-    ))
-}
-
-fn detect_parse_u32_start_lesser(i: &str) -> IResult<&str, DetectU32Data> {
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, _) = tag("<")(i)?;
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u32>().ok())(i)?;
-    Ok((
-        i,
-        DetectU32Data {
-            value,
-            valrange: 0,
-            mode: DetectUintMode::DetectUintModeLt,
-        },
-    ))
-}
-
-fn detect_parse_u32_start_greater(i: &str) -> IResult<&str, DetectU32Data> {
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, _) = tag(">")(i)?;
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u32>().ok())(i)?;
-    Ok((
-        i,
-        DetectU32Data {
-            value,
-            valrange: 0,
-            mode: DetectUintMode::DetectUintModeGt,
-        },
-    ))
-}
-
-fn detect_parse_u32(i: &str) -> IResult<&str, DetectU32Data> {
-    let (i, u32) = alt((
-        detect_parse_u32_start_lesser,
-        detect_parse_u32_start_greater,
-        complete(detect_parse_u32_start_interval),
-        detect_parse_u32_start_equal,
-    ))(i)?;
-    Ok((i, u32))
 }
 
 pub fn http2_parse_settingsctx(i: &str) -> IResult<&str, DetectHTTP2settingsSigCtx> {
@@ -814,84 +727,6 @@ pub fn http2_parse_settingsctx(i: &str) -> IResult<&str, DetectHTTP2settingsSigC
     })(i)?;
     let (i, value) = opt(complete(detect_parse_u32))(i)?;
     Ok((i, DetectHTTP2settingsSigCtx { id, value }))
-}
-
-pub struct DetectU64Data {
-    pub value: u64,
-    pub valrange: u64,
-    pub mode: DetectUintMode,
-}
-
-fn detect_parse_u64_start_equal(i: &str) -> IResult<&str, DetectU64Data> {
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, _) = opt(tag("="))(i)?;
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u64>().ok())(i)?;
-    Ok((
-        i,
-        DetectU64Data {
-            value,
-            valrange: 0,
-            mode: DetectUintMode::DetectUintModeEqual,
-        },
-    ))
-}
-
-fn detect_parse_u64_start_interval(i: &str) -> IResult<&str, DetectU64Data> {
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u64>().ok())(i)?;
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, _) = tag("-")(i)?;
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, valrange) = map_opt(digit1, |s: &str| s.parse::<u64>().ok())(i)?;
-    Ok((
-        i,
-        DetectU64Data {
-            value,
-            valrange,
-            mode: DetectUintMode::DetectUintModeRange,
-        },
-    ))
-}
-
-fn detect_parse_u64_start_lesser(i: &str) -> IResult<&str, DetectU64Data> {
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, _) = tag("<")(i)?;
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u64>().ok())(i)?;
-    Ok((
-        i,
-        DetectU64Data {
-            value,
-            valrange: 0,
-            mode: DetectUintMode::DetectUintModeLt,
-        },
-    ))
-}
-
-fn detect_parse_u64_start_greater(i: &str) -> IResult<&str, DetectU64Data> {
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, _) = tag(">")(i)?;
-    let (i, _) = opt(is_a(" "))(i)?;
-    let (i, value) = map_opt(digit1, |s: &str| s.parse::<u64>().ok())(i)?;
-    Ok((
-        i,
-        DetectU64Data {
-            value,
-            valrange: 0,
-            mode: DetectUintMode::DetectUintModeGt,
-        },
-    ))
-}
-
-pub fn detect_parse_u64(i: &str) -> IResult<&str, DetectU64Data> {
-    let (i, u64) = alt((
-        detect_parse_u64_start_lesser,
-        detect_parse_u64_start_greater,
-        complete(detect_parse_u64_start_interval),
-        detect_parse_u64_start_equal,
-    ))(i)?;
-    Ok((i, u64))
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -101,6 +101,7 @@ pub mod frames;
 pub mod filecontainer;
 pub mod filetracker;
 pub mod kerberos;
+pub mod detect;
 
 #[cfg(feature = "lua")]
 pub mod lua;

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -20,6 +20,7 @@ use crate::core::*;
 use crate::smb::smb::*;
 use crate::dcerpc::detect::{DCEIfaceData, DCEOpnumData, DETECT_DCE_OPNUM_RANGE_UNINITIALIZED};
 use crate::dcerpc::dcerpc::DCERPC_TYPE_REQUEST;
+use crate::detect::detect_match_u16;
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_smb_tx_get_share(tx: &mut SMBTransaction,
@@ -125,40 +126,6 @@ pub extern "C" fn rs_smb_tx_match_dce_opnum(tx: &mut SMBTransaction,
     return 0;
 }
 
-/* based on:
- * typedef enum DetectDceIfaceOperators_ {
- *    DETECT_DCE_IFACE_OP_NONE = 0,
- *    DETECT_DCE_IFACE_OP_LT,
- *    DETECT_DCE_IFACE_OP_GT,
- *    DETECT_DCE_IFACE_OP_EQ,
- *    DETECT_DCE_IFACE_OP_NE,
- * } DetectDceIfaceOperators;
- */
-#[inline]
-fn match_version(op: u8, them: u16, us: u16) -> bool {
-    let result = match op {
-        0 => { // NONE
-            true
-        },
-        1 => { // LT
-            them < us
-        },
-        2 => { // GT
-            them > us
-        },
-        3 => { // EQ
-            them == us
-        },
-        4 => { // NE
-            them != us
-        },
-        _ => {
-            panic!("called with invalid op {}", op);
-        },
-    };
-    result
-}
-
 /* mimic logic that is/was in the C code:
  * - match on REQUEST (so not on BIND/BINDACK (probably for mixing with
  *                     dce_opnum and dce_stub_data)
@@ -170,8 +137,6 @@ pub extern "C" fn rs_smb_tx_get_dce_iface(state: &mut SMBState,
                                             -> u8
 {
     let if_uuid = dce_data.if_uuid.as_slice();
-    let if_op = dce_data.op;
-    let if_version = dce_data.version;
     let is_dcerpc_request = match tx.type_data {
         Some(SMBTransactionTypeData::DCERPC(ref x)) => {
             x.req_cmd == DCERPC_TYPE_REQUEST
@@ -194,8 +159,10 @@ pub extern "C" fn rs_smb_tx_get_dce_iface(state: &mut SMBState,
         SCLogDebug!("stored UUID {:?} acked {} ack_result {}", i, i.acked, i.ack_result);
 
         if i.acked && i.ack_result == 0 && i.uuid == if_uuid {
-            if match_version(if_op as u8, if_version as u16, i.ver) {
-                return 1;
+            if let Some(x) = &dce_data.du16 {
+                if detect_match_u16(&x, i.ver) {
+                    return 1;
+                }
             }
         }
     }

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -43,12 +43,6 @@
 #include "host.h"
 #include "util-profiling.h"
 
-/**
- *  dsize:[<>!]<0-65535>[<><0-65535>];
- */
-#define PARSE_REGEX "^\\s*(<|>|!)?\\s*([0-9]{1,5})\\s*(?:(<>)\\s*([0-9]{1,5}))?\\s*$"
-static DetectParseRegex parse_regex;
-
 static int DetectDsizeMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectDsizeSetup (DetectEngineCtx *, Signature *s, const char *str);
@@ -76,26 +70,6 @@ void DetectDsizeRegister (void)
 #endif
     sigmatch_table[DETECT_DSIZE].SupportsPrefilter = PrefilterDsizeIsPrefilterable;
     sigmatch_table[DETECT_DSIZE].SetupPrefilter = PrefilterSetupDsize;
-
-    DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
-}
-
-static inline int
-DsizeMatch(const uint16_t psize, const uint8_t mode,
-            const uint16_t dsize, const uint16_t dsize2)
-{
-    if (mode == DETECTDSIZE_EQ && dsize == psize)
-        return 1;
-    else if (mode == DETECTDSIZE_LT && psize < dsize)
-        return 1;
-    else if (mode == DETECTDSIZE_GT && psize > dsize)
-        return 1;
-    else if (mode == DETECTDSIZE_RA && psize > dsize && psize < dsize2)
-        return 1;
-    else if (mode == DETECTDSIZE_NE && dsize != psize)
-        return 1;
-
-    return 0;
 }
 
 /**
@@ -121,134 +95,13 @@ static int DetectDsizeMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
         SCReturnInt(0);
     }
 
-    const DetectDsizeData *dd = (const DetectDsizeData *)ctx;
+    const DetectU16Data *dd = (const DetectU16Data *)ctx;
 
     SCLogDebug("p->payload_len %"PRIu16"", p->payload_len);
 
-    ret = DsizeMatch(p->payload_len, dd->mode, dd->dsize, dd->dsize2);
+    ret = DetectU16Match(p->payload_len, dd);
 
     SCReturnInt(ret);
-}
-
-/**
- * \internal
- * \brief This function is used to parse dsize options passed via dsize: keyword
- *
- * \param rawstr Pointer to the user provided dsize options
- *
- * \retval dd pointer to DetectDsizeData on success
- * \retval NULL on failure
- */
-static DetectDsizeData *DetectDsizeParse (const char *rawstr)
-{
-    DetectDsizeData *dd = NULL;
-    int ret = 0, res = 0;
-    size_t pcre2len;
-    char mode[2] = "";
-    char value1[6] = "";
-    char value2[6] = "";
-    char range[3] = "";
-
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
-    if (ret < 3 || ret > 5) {
-        SCLogError(SC_ERR_PCRE_MATCH,"Parse error %s", rawstr);
-        goto error;
-    }
-
-    pcre2len = sizeof(mode);
-    res = SC_Pcre2SubstringCopy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
-    if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed with %d", res);
-        goto error;
-    }
-    SCLogDebug("mode \"%s\"", mode);
-
-    pcre2len = sizeof(value1);
-    res = pcre2_substring_copy_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 *)value1, &pcre2len);
-    if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
-        goto error;
-    }
-    SCLogDebug("value1 \"%s\"", value1);
-
-    if (ret > 3) {
-        pcre2len = sizeof(range);
-        res = pcre2_substring_copy_bynumber(parse_regex.match, 3, (PCRE2_UCHAR8 *)range, &pcre2len);
-        if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
-            goto error;
-        }
-        SCLogDebug("range \"%s\"", range);
-
-        if (ret > 4) {
-            pcre2len = sizeof(value2);
-            res = pcre2_substring_copy_bynumber(
-                    parse_regex.match, 4, (PCRE2_UCHAR8 *)value2, &pcre2len);
-            if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
-                goto error;
-            }
-            SCLogDebug("value2 \"%s\"", value2);
-        }
-    }
-
-    dd = SCMalloc(sizeof(DetectDsizeData));
-    if (unlikely(dd == NULL))
-        goto error;
-    dd->dsize = 0;
-    dd->dsize2 = 0;
-    dd->mode = 0;
-
-    if (strcmp("<>", range) == 0) {
-        if (strlen(mode) != 0) {
-            SCLogError(SC_ERR_INVALID_ARGUMENT,"Range specified but mode also set");
-            goto error;
-        }
-        dd->mode = DETECTDSIZE_RA;
-    } else if (strlen(mode) > 0) {
-        if (mode[0] == '<')
-            dd->mode = DETECTDSIZE_LT;
-        else if (mode[0] == '>')
-            dd->mode = DETECTDSIZE_GT;
-        else if (mode[0] == '!')
-            dd->mode = DETECTDSIZE_NE;
-        else
-            dd->mode = DETECTDSIZE_EQ;
-    } else {
-        dd->mode = DETECTDSIZE_EQ; // default
-    }
-
-    /** set the first dsize value */
-    if (StringParseUint16(&dd->dsize,10,strlen(value1),value1) <= 0) {
-        SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid size value1:\"%s\"", value1);
-        goto error;
-    }
-
-    /** set the second dsize value if specified */
-    if (strlen(value2) > 0) {
-        if (dd->mode != DETECTDSIZE_RA) {
-            SCLogError(SC_ERR_INVALID_ARGUMENT,"Multiple dsize values specified but mode is not range");
-            goto error;
-        }
-
-        if (StringParseUint16(&dd->dsize2,10,strlen(value2),value2) <= 0) {
-            SCLogError(SC_ERR_INVALID_ARGUMENT,"Invalid size value2:\"%s\"",value2);
-            goto error;
-        }
-
-        if (dd->dsize2 <= dd->dsize) {
-            SCLogError(SC_ERR_INVALID_ARGUMENT,"dsize2:%"PRIu16" <= dsize:%"PRIu16"",dd->dsize2,dd->dsize);
-            goto error;
-        }
-    }
-
-    SCLogDebug("dsize parsed successfully dsize: %"PRIu16" dsize2: %"PRIu16"",dd->dsize,dd->dsize2);
-    return dd;
-
-error:
-    if (dd)
-        SCFree(dd);
-    return NULL;
 }
 
 /**
@@ -264,7 +117,7 @@ error:
  */
 static int DetectDsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
-    DetectDsizeData *dd = NULL;
+    DetectU16Data *dd = NULL;
     SigMatch *sm = NULL;
 
     if (DetectGetLastSMFromLists(s, DETECT_DSIZE, -1)) {
@@ -275,7 +128,7 @@ static int DetectDsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
 
     SCLogDebug("\'%s\'", rawstr);
 
-    dd = DetectDsizeParse(rawstr);
+    dd = DetectU16Parse(rawstr);
     if (dd == NULL) {
         SCLogError(SC_ERR_INVALID_ARGUMENT,"Parsing \'%s\' failed", rawstr);
         goto error;
@@ -295,8 +148,8 @@ static int DetectDsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
 
     SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
 
-    SCLogDebug("dd->dsize %"PRIu16", dd->dsize2 %"PRIu16", dd->mode %"PRIu8"",
-            dd->dsize, dd->dsize2, dd->mode);
+    SCLogDebug("dd->arg1 %" PRIu16 ", dd->arg2 %" PRIu16 ", dd->mode %" PRIu8 "", dd->arg1,
+            dd->arg2, dd->mode);
     /* tell the sig it has a dsize to speed up engine init */
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
     s->flags |= SIG_FLAG_DSIZE;
@@ -313,14 +166,13 @@ error:
 
 /**
  * \internal
- * \brief this function will free memory associated with DetectDsizeData
+ * \brief this function will free memory associated with DetectU16Data
  *
- * \param de pointer to DetectDsizeData
+ * \param de pointer to DetectU16Data
  */
 void DetectDsizeFree(DetectEngineCtx *de_ctx, void *de_ptr)
 {
-    DetectDsizeData *dd = (DetectDsizeData *)de_ptr;
-    if(dd) SCFree(dd);
+    SCFree(de_ptr);
 }
 
 /* prefilter code */
@@ -337,39 +189,21 @@ PrefilterPacketDsizeMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void 
         return;
 
     const uint16_t dsize = p->payload_len;
-    if (DsizeMatch(dsize, ctx->v1.u8[0], ctx->v1.u16[1], ctx->v1.u16[2]))
-    {
+    DetectU16Data du16;
+    du16.mode = ctx->v1.u8[0];
+    du16.arg1 = ctx->v1.u16[1];
+    du16.arg2 = ctx->v1.u16[2];
+
+    if (DetectU16Match(dsize, &du16)) {
         SCLogDebug("packet matches dsize %u", dsize);
         PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
     }
 }
 
-static void
-PrefilterPacketDsizeSet(PrefilterPacketHeaderValue *v, void *smctx)
-{
-    const DetectDsizeData *a = smctx;
-    v->u8[0] = a->mode;
-    v->u16[1] = a->dsize;
-    v->u16[2] = a->dsize2;
-}
-
-static bool
-PrefilterPacketDsizeCompare(PrefilterPacketHeaderValue v, void *smctx)
-{
-    const DetectDsizeData *a = smctx;
-    if (v.u8[0] == a->mode &&
-        v.u16[1] == a->dsize &&
-        v.u16[2] == a->dsize2)
-        return true;
-    return false;
-}
-
 static int PrefilterSetupDsize(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
 {
-    return PrefilterSetupPacketHeader(de_ctx, sgh, DETECT_DSIZE,
-            PrefilterPacketDsizeSet,
-            PrefilterPacketDsizeCompare,
-            PrefilterPacketDsizeMatch);
+    return PrefilterSetupPacketHeader(de_ctx, sgh, DETECT_DSIZE, PrefilterPacketU16Set,
+            PrefilterPacketU16Compare, PrefilterPacketDsizeMatch);
 }
 
 static bool PrefilterDsizeIsPrefilterable(const Signature *s)
@@ -391,16 +225,16 @@ static bool PrefilterDsizeIsPrefilterable(const Signature *s)
 int SigParseGetMaxDsize(const Signature *s)
 {
     if (s->flags & SIG_FLAG_DSIZE && s->init_data->dsize_sm != NULL) {
-        const DetectDsizeData *dd = (const DetectDsizeData *)s->init_data->dsize_sm->ctx;
+        const DetectU16Data *dd = (const DetectU16Data *)s->init_data->dsize_sm->ctx;
 
         switch (dd->mode) {
-            case DETECTDSIZE_LT:
-            case DETECTDSIZE_EQ:
-            case DETECTDSIZE_NE:
-                return dd->dsize;
-            case DETECTDSIZE_RA:
-                return dd->dsize2;
-            case DETECTDSIZE_GT:
+            case DETECT_UINT_LT:
+            case DETECT_UINT_EQ:
+            case DETECT_UINT_NE:
+                return dd->arg1;
+            case DETECT_UINT_RA:
+                return dd->arg2;
+            case DETECT_UINT_GT:
             default:
                 SCReturnInt(-2);
         }
@@ -414,27 +248,35 @@ int SigParseGetMaxDsize(const Signature *s)
 void SigParseSetDsizePair(Signature *s)
 {
     if (s->flags & SIG_FLAG_DSIZE && s->init_data->dsize_sm != NULL) {
-        DetectDsizeData *dd = (DetectDsizeData *)s->init_data->dsize_sm->ctx;
+        DetectU16Data *dd = (DetectU16Data *)s->init_data->dsize_sm->ctx;
 
         uint16_t low = 0;
         uint16_t high = 65535;
 
         switch (dd->mode) {
-            case DETECTDSIZE_LT:
+            case DETECT_UINT_LT:
                 low = 0;
-                high = dd->dsize;
+                high = dd->arg1;
                 break;
-            case DETECTDSIZE_EQ:
-            case DETECTDSIZE_NE:
-                low = dd->dsize;
-                high = dd->dsize;
+            case DETECT_UINT_LTE:
+                low = 0;
+                high = dd->arg1 + 1;
                 break;
-            case DETECTDSIZE_RA:
-                low = dd->dsize;
-                high = dd->dsize2;
+            case DETECT_UINT_EQ:
+            case DETECT_UINT_NE:
+                low = dd->arg1;
+                high = dd->arg1;
                 break;
-            case DETECTDSIZE_GT:
-                low = dd->dsize;
+            case DETECT_UINT_RA:
+                low = dd->arg1;
+                high = dd->arg2;
+                break;
+            case DETECT_UINT_GT:
+                low = dd->arg1;
+                high = 65535;
+                break;
+            case DETECT_UINT_GTE:
+                low = dd->arg1 - 1;
                 high = 65535;
                 break;
         }
@@ -497,10 +339,10 @@ void SigParseApplyDsizeToContent(Signature *s)
  */
 static int DsizeTestParse01(void)
 {
-    DetectDsizeData *dd = DetectDsizeParse("1");
+    DetectU16Data *dd = DetectU16Parse("1");
     FAIL_IF_NULL(dd);
-    FAIL_IF_NOT(dd->dsize == 1);
-    FAIL_IF_NOT(dd->dsize2 == 0);
+    FAIL_IF_NOT(dd->arg1 == 1);
+    FAIL_IF_NOT(dd->arg2 == 0);
 
     DetectDsizeFree(NULL, dd);
     PASS;
@@ -512,10 +354,10 @@ static int DsizeTestParse01(void)
  */
 static int DsizeTestParse02(void)
 {
-    DetectDsizeData *dd = DetectDsizeParse(">10");
+    DetectU16Data *dd = DetectU16Parse(">10");
     FAIL_IF_NULL(dd);
-    FAIL_IF_NOT(dd->dsize == 10);
-    FAIL_IF_NOT(dd->mode == DETECTDSIZE_GT);
+    FAIL_IF_NOT(dd->arg1 == 10);
+    FAIL_IF_NOT(dd->mode == DETECT_UINT_GT);
     DetectDsizeFree(NULL, dd);
     PASS;
 }
@@ -526,10 +368,10 @@ static int DsizeTestParse02(void)
  */
 static int DsizeTestParse03(void)
 {
-    DetectDsizeData *dd = DetectDsizeParse("<100");
+    DetectU16Data *dd = DetectU16Parse("<100");
     FAIL_IF_NULL(dd);
-    FAIL_IF_NOT(dd->dsize == 100);
-    FAIL_IF_NOT(dd->mode == DETECTDSIZE_LT);
+    FAIL_IF_NOT(dd->arg1 == 100);
+    FAIL_IF_NOT(dd->mode == DETECT_UINT_LT);
 
     DetectDsizeFree(NULL, dd);
     PASS;
@@ -541,11 +383,11 @@ static int DsizeTestParse03(void)
  */
 static int DsizeTestParse04(void)
 {
-    DetectDsizeData *dd = DetectDsizeParse("1<>2");
+    DetectU16Data *dd = DetectU16Parse("1<>2");
     FAIL_IF_NULL(dd);
-    FAIL_IF_NOT(dd->dsize == 1);
-    FAIL_IF_NOT(dd->dsize2 == 2);
-    FAIL_IF_NOT(dd->mode == DETECTDSIZE_RA);
+    FAIL_IF_NOT(dd->arg1 == 1);
+    FAIL_IF_NOT(dd->arg2 == 2);
+    FAIL_IF_NOT(dd->mode == DETECT_UINT_RA);
 
     DetectDsizeFree(NULL, dd);
     PASS;
@@ -557,11 +399,11 @@ static int DsizeTestParse04(void)
  */
 static int DsizeTestParse05(void)
 {
-    DetectDsizeData *dd = DetectDsizeParse(" 1 <> 2 ");
+    DetectU16Data *dd = DetectU16Parse(" 1 <> 2 ");
     FAIL_IF_NULL(dd);
-    FAIL_IF_NOT(dd->dsize == 1);
-    FAIL_IF_NOT(dd->dsize2 == 2);
-    FAIL_IF_NOT(dd->mode == DETECTDSIZE_RA);
+    FAIL_IF_NOT(dd->arg1 == 1);
+    FAIL_IF_NOT(dd->arg2 == 2);
+    FAIL_IF_NOT(dd->mode == DETECT_UINT_RA);
 
     DetectDsizeFree(NULL, dd);
     PASS;
@@ -573,10 +415,10 @@ static int DsizeTestParse05(void)
  */
 static int DsizeTestParse06(void)
 {
-    DetectDsizeData *dd = DetectDsizeParse("> 2 ");
+    DetectU16Data *dd = DetectU16Parse("> 2 ");
     FAIL_IF_NULL(dd);
-    FAIL_IF_NOT(dd->dsize == 2);
-    FAIL_IF_NOT(dd->mode == DETECTDSIZE_GT);
+    FAIL_IF_NOT(dd->arg1 == 2);
+    FAIL_IF_NOT(dd->mode == DETECT_UINT_GT);
 
     DetectDsizeFree(NULL, dd);
     PASS;
@@ -588,10 +430,10 @@ static int DsizeTestParse06(void)
  */
 static int DsizeTestParse07(void)
 {
-    DetectDsizeData *dd = DetectDsizeParse("<   12 ");
+    DetectU16Data *dd = DetectU16Parse("<   12 ");
     FAIL_IF_NULL(dd);
-    FAIL_IF_NOT(dd->dsize == 12);
-    FAIL_IF_NOT(dd->mode == DETECTDSIZE_LT);
+    FAIL_IF_NOT(dd->arg1 == 12);
+    FAIL_IF_NOT(dd->mode == DETECT_UINT_LT);
 
     DetectDsizeFree(NULL, dd);
     PASS;
@@ -603,10 +445,10 @@ static int DsizeTestParse07(void)
  */
 static int DsizeTestParse08(void)
 {
-    DetectDsizeData *dd = DetectDsizeParse("   12 ");
+    DetectU16Data *dd = DetectU16Parse("   12 ");
     FAIL_IF_NULL(dd);
-    FAIL_IF_NOT(dd->dsize == 12);
-    FAIL_IF_NOT(dd->mode == DETECTDSIZE_EQ);
+    FAIL_IF_NOT(dd->arg1 == 12);
+    FAIL_IF_NOT(dd->mode == DETECT_UINT_EQ);
 
     DetectDsizeFree(NULL, dd);
     PASS;
@@ -618,7 +460,7 @@ static int DsizeTestParse08(void)
  */
 static int DsizeTestParse09(void)
 {
-    DetectDsizeData *dd = DetectDsizeParse("!1");
+    DetectU16Data *dd = DetectU16Parse("!1");
     FAIL_IF_NULL(dd);
     DetectDsizeFree(NULL, dd);
     PASS;
@@ -630,7 +472,7 @@ static int DsizeTestParse09(void)
  */
 static int DsizeTestParse10(void)
 {
-    DetectDsizeData *dd = DetectDsizeParse("! 1");
+    DetectU16Data *dd = DetectU16Parse("! 1");
     FAIL_IF_NULL(dd);
     DetectDsizeFree(NULL, dd);
     PASS;
@@ -645,7 +487,7 @@ static int DsizeTestParse11(void)
 {
     const char *strings[] = { "A", ">10<>10", "<>10", "1<>", "", " ", "2<>1", "1!", NULL };
     for (int i = 0; strings[i]; i++) {
-        DetectDsizeData *dd = DetectDsizeParse(strings[i]);
+        DetectU16Data *dd = DetectU16Parse(strings[i]);
         FAIL_IF_NOT_NULL(dd);
     }
 
@@ -661,8 +503,11 @@ static int DsizeTestMatch01(void)
     uint16_t psize = 1;
     uint16_t dsizelow = 2;
     uint16_t dsizehigh = 0;
-
-    FAIL_IF_NOT(DsizeMatch(psize, DETECTDSIZE_NE, dsizelow, dsizehigh));
+    DetectU16Data du16;
+    du16.mode = DETECT_UINT_NE;
+    du16.arg1 = dsizelow;
+    du16.arg2 = dsizehigh;
+    FAIL_IF_NOT(DetectU16Match(psize, &du16));
 
     PASS;
 }
@@ -676,8 +521,11 @@ static int DsizeTestMatch02(void)
     uint16_t psize = 1;
     uint16_t dsizelow = 1;
     uint16_t dsizehigh = 0;
-
-    FAIL_IF(DsizeMatch(psize, DETECTDSIZE_NE, dsizelow, dsizehigh));
+    DetectU16Data du16;
+    du16.mode = DETECT_UINT_NE;
+    du16.arg1 = dsizelow;
+    du16.arg2 = dsizehigh;
+    FAIL_IF(DetectU16Match(psize, &du16));
 
     PASS;
 }

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -378,15 +378,15 @@ static int DsizeTestParse03(void)
 }
 
 /**
- * \test this is a test for a valid dsize value 1<>2
+ * \test this is a test for a valid dsize value 1<>3
  *
  */
 static int DsizeTestParse04(void)
 {
-    DetectU16Data *dd = DetectU16Parse("1<>2");
+    DetectU16Data *dd = DetectU16Parse("1<>3");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->arg1 == 1);
-    FAIL_IF_NOT(dd->arg2 == 2);
+    FAIL_IF_NOT(dd->arg2 == 3);
     FAIL_IF_NOT(dd->mode == DETECT_UINT_RA);
 
     DetectDsizeFree(NULL, dd);
@@ -394,15 +394,15 @@ static int DsizeTestParse04(void)
 }
 
 /**
- * \test this is a test for a valid dsize value 1 <> 2
+ * \test this is a test for a valid dsize value 1 <> 3
  *
  */
 static int DsizeTestParse05(void)
 {
-    DetectU16Data *dd = DetectU16Parse(" 1 <> 2 ");
+    DetectU16Data *dd = DetectU16Parse(" 1 <> 3 ");
     FAIL_IF_NULL(dd);
     FAIL_IF_NOT(dd->arg1 == 1);
-    FAIL_IF_NOT(dd->arg2 == 2);
+    FAIL_IF_NOT(dd->arg2 == 3);
     FAIL_IF_NOT(dd->mode == DETECT_UINT_RA);
 
     DetectDsizeFree(NULL, dd);

--- a/src/detect-dsize.h
+++ b/src/detect-dsize.h
@@ -24,17 +24,7 @@
 #ifndef __DETECT_DSIZE_H__
 #define __DETECT_DSIZE_H__
 
-#define DETECTDSIZE_LT 0
-#define DETECTDSIZE_EQ 1
-#define DETECTDSIZE_GT 2
-#define DETECTDSIZE_RA 3
-#define DETECTDSIZE_NE 4
-
-typedef struct DetectDsizeData_ {
-    uint16_t dsize;
-    uint16_t dsize2;
-    uint8_t mode;
-} DetectDsizeData;
+#include "detect-engine-uint.h"
 
 /* prototypes */
 void DetectDsizeRegister (void);
@@ -49,7 +39,7 @@ static inline bool SigDsizePrefilter(const Packet *p, const Signature *s, uint32
 {
     if (unlikely(sflags & SIG_FLAG_DSIZE)) {
         if (likely(p->payload_len < s->dsize_low || p->payload_len > s->dsize_high)) {
-            if (!(s->dsize_mode == DETECTDSIZE_NE)) {
+            if (!(s->dsize_mode == DETECT_UINT_NE)) {
                 SCLogDebug("kicked out as p->payload_len %u, dsize low %u, hi %u", p->payload_len,
                         s->dsize_low, s->dsize_high);
                 return true;

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -533,18 +533,18 @@ static int SignatureCreateMask(Signature *s)
             }
             case DETECT_DSIZE:
             {
-                DetectDsizeData *ds = (DetectDsizeData *)sm->ctx;
+                DetectU16Data *ds = (DetectU16Data *)sm->ctx;
                 /* LT will include 0, so no payload.
                  * if GT is used in the same rule the
                  * flag will be set anyway. */
-                if (ds->mode == DETECTDSIZE_RA || ds->mode == DETECTDSIZE_GT ||
-                        ds->mode == DETECTDSIZE_NE) {
+                if (ds->mode == DETECT_UINT_RA || ds->mode == DETECT_UINT_GT ||
+                        ds->mode == DETECT_UINT_NE) {
 
                     s->mask |= SIG_MASK_REQUIRE_PAYLOAD;
                     SCLogDebug("sig requires payload");
 
-                } else if (ds->mode == DETECTDSIZE_EQ) {
-                    if (ds->dsize > 0) {
+                } else if (ds->mode == DETECT_UINT_EQ) {
+                    if (ds->arg1 > 0) {
                         s->mask |= SIG_MASK_REQUIRE_PAYLOAD;
                         SCLogDebug("sig requires payload");
                     } else {

--- a/src/detect-engine-uint.c
+++ b/src/detect-engine-uint.c
@@ -88,6 +88,16 @@ static int DetectU32Validate(DetectU32Data *du32)
                 return 1;
             }
             break;
+        case DETECT_UINT_LTE:
+            if (du32->arg1 == UINT32_MAX) {
+                return 1;
+            }
+            break;
+        case DETECT_UINT_GTE:
+            if (du32->arg1 == 0) {
+                return 1;
+            }
+            break;
         case DETECT_UINT_GT:
             if (du32->arg1 == UINT32_MAX) {
                 return 1;
@@ -351,6 +361,16 @@ static int DetectU8Validate(DetectU8Data *du8)
                 return 1;
             }
             break;
+        case DETECT_UINT_LTE:
+            if (du8->arg1 == UINT8_MAX) {
+                return 1;
+            }
+            break;
+        case DETECT_UINT_GTE:
+            if (du8->arg1 == 0) {
+                return 1;
+            }
+            break;
         case DETECT_UINT_GT:
             if (du8->arg1 == UINT8_MAX) {
                 return 1;
@@ -569,6 +589,16 @@ static int DetectU16Validate(DetectU16Data *du16)
 {
     switch (du16->mode) {
         case DETECT_UINT_LT:
+            if (du16->arg1 == 0) {
+                return 1;
+            }
+            break;
+        case DETECT_UINT_LTE:
+            if (du16->arg1 == UINT16_MAX) {
+                return 1;
+            }
+            break;
+        case DETECT_UINT_GTE:
             if (du16->arg1 == 0) {
                 return 1;
             }

--- a/src/detect-engine-uint.h
+++ b/src/detect-engine-uint.h
@@ -31,6 +31,7 @@ typedef enum {
     DETECT_UINT_EQ = PREFILTER_U8HASH_MODE_EQ,
     DETECT_UINT_GT = PREFILTER_U8HASH_MODE_GT,
     DETECT_UINT_RA = PREFILTER_U8HASH_MODE_RA,
+    DETECT_UINT_NE,
     DETECT_UINT_LTE,
     DETECT_UINT_GTE,
 } DetectUintMode;
@@ -60,13 +61,15 @@ int DetectU8Match(const uint8_t parg, const DetectU8Data *du8);
 DetectU8Data *DetectU8Parse (const char *u8str);
 
 typedef struct DetectU16Data_ {
-    uint16_t arg1;   /**< first arg value in the signature*/
-    uint16_t arg2;   /**< second arg value in the signature, in case of range
-                          operator*/
-    DetectUintMode mode;    /**< operator used in the signature */
+    uint16_t arg1;       /**< first arg value in the signature*/
+    uint16_t arg2;       /**< second arg value in the signature, in case of range
+                              operator*/
+    DetectUintMode mode; /**< operator used in the signature */
 } DetectU16Data;
 
 int DetectU16Match(const uint16_t parg, const DetectU16Data *du16);
-DetectU16Data *DetectU16Parse (const char *u16str);
+DetectU16Data *DetectU16Parse(const char *u16str);
+void PrefilterPacketU16Set(PrefilterPacketHeaderValue *v, void *smctx);
+bool PrefilterPacketU16Compare(PrefilterPacketHeaderValue v, void *smctx);
 
 #endif /* __DETECT_UTIL_UINT_H */

--- a/src/detect-engine-uint.h
+++ b/src/detect-engine-uint.h
@@ -59,4 +59,14 @@ typedef struct DetectU8Data_ {
 int DetectU8Match(const uint8_t parg, const DetectU8Data *du8);
 DetectU8Data *DetectU8Parse (const char *u8str);
 
+typedef struct DetectU16Data_ {
+    uint16_t arg1;   /**< first arg value in the signature*/
+    uint16_t arg2;   /**< second arg value in the signature, in case of range
+                          operator*/
+    DetectUintMode mode;    /**< operator used in the signature */
+} DetectU16Data;
+
+int DetectU16Match(const uint16_t parg, const DetectU16Data *du16);
+DetectU16Data *DetectU16Parse (const char *u16str);
+
 #endif /* __DETECT_UTIL_UINT_H */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4112

Describe changes:
- Makes use of generic `DetectUint` structure for `dsize` and `dcerpc`

Still TODO:
- remove the C version to use only rust version
- more keywords in C use specific versions