### PR TITLE
Warnint util 4516 v8.1

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1845,7 +1845,7 @@ int AppLayerProtoDetectSetup(void)
     memset(&alpd_ctx, 0, sizeof(alpd_ctx));
 
     uint16_t spm_matcher = SinglePatternMatchDefaultMatcher();
-    uint16_t mpm_matcher = PatternMatchDefaultMatcher();
+    uint8_t mpm_matcher = PatternMatchDefaultMatcher();
 
     alpd_ctx.spm_global_thread_ctx = SpmInitGlobalThreadCtx(spm_matcher);
     if (alpd_ctx.spm_global_thread_ctx == NULL) {

--- a/src/app-layer-frames.c
+++ b/src/app-layer-frames.c
@@ -70,7 +70,7 @@ Frame *FrameGetByIndex(Frames *frames, const uint32_t idx)
         FrameDebug("get_by_idx(s)", frames, frame);
         return frame;
     } else {
-        const uint16_t o = idx - FRAMES_STATIC_CNT;
+        const uint32_t o = idx - FRAMES_STATIC_CNT;
         Frame *frame = &frames->dframes[o];
         FrameDebug("get_by_idx(d)", frames, frame);
         return frame;

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1256,7 +1256,7 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
     void *alstate = NULL;
     uint64_t p_tx_cnt = 0;
     uint32_t consumed = input_len;
-    const int direction = (flags & STREAM_TOSERVER) ? 0 : 1;
+    const uint8_t direction = (flags & STREAM_TOSERVER) ? 0 : 1;
 
     /* we don't have the parser registered for this protocol */
     if (p->StateAlloc == NULL)

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -345,7 +345,7 @@ static int TCPProtoDetect(ThreadVars *tv,
 {
     AppProto *alproto;
     AppProto *alproto_otherdir;
-    int direction = (flags & STREAM_TOSERVER) ? 0 : 1;
+    uint8_t direction = (flags & STREAM_TOSERVER) ? 0 : 1;
 
     if (flags & STREAM_TOSERVER) {
         alproto = &f->alproto_ts;
@@ -645,7 +645,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         goto end;
     }
 
-    const int direction = (flags & STREAM_TOSERVER) ? 0 : 1;
+    const uint8_t direction = (flags & STREAM_TOSERVER) ? 0 : 1;
 
     if (flags & STREAM_TOSERVER) {
         alproto = f->alproto_ts;

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -852,10 +852,10 @@ int SignatureHasStreamContent(const Signature *s)
  *
  *  \retval mpm algo value
  */
-uint16_t PatternMatchDefaultMatcher(void)
+uint8_t PatternMatchDefaultMatcher(void)
 {
     const char *mpm_algo;
-    uint16_t mpm_algo_val = mpm_default_matcher;
+    uint8_t mpm_algo_val = mpm_default_matcher;
 
     /* Get the mpm algo defined in config file by the user */
     if ((ConfGet("mpm-algo", &mpm_algo)) == 1) {

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -43,7 +43,7 @@ int DetectMpmPrepareBuiltinMpms(DetectEngineCtx *de_ctx);
 
 uint32_t PatternStrength(uint8_t *, uint16_t);
 
-uint16_t PatternMatchDefaultMatcher(void);
+uint8_t PatternMatchDefaultMatcher(void);
 uint32_t DnsQueryPatternSearch(DetectEngineThreadCtx *det_ctx, uint8_t *buffer, uint32_t buffer_len, uint8_t flags);
 
 void PatternMatchPrepare(MpmCtx *, uint16_t);

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -300,8 +300,8 @@ int FlowForceReassemblyNeedReassembly(Flow *f)
     }
 
     TcpSession *ssn = (TcpSession *)f->protoctx;
-    int client = StreamNeedsReassembly(ssn, STREAM_TOSERVER);
-    int server = StreamNeedsReassembly(ssn, STREAM_TOCLIENT);
+    uint8_t client = StreamNeedsReassembly(ssn, STREAM_TOSERVER);
+    uint8_t server = StreamNeedsReassembly(ssn, STREAM_TOCLIENT);
 
     /* if state is not fully closed we assume that we haven't fully
      * inspected the app layer state yet */

--- a/src/flow.c
+++ b/src/flow.c
@@ -580,8 +580,7 @@ void FlowInitConfig(bool quiet)
             FatalError(SC_ERR_FATAL, "Invalid value for flow.hash-size: NULL");
         }
 
-        if (StringParseUint32(&configval, 10, strlen(conf_val),
-                                    conf_val) > 0) {
+        if (StringParseUint32(&configval, 10, (uint16_t)strlen(conf_val), conf_val) > 0) {
             flow_config.hash_size = configval;
         }
     }
@@ -591,8 +590,7 @@ void FlowInitConfig(bool quiet)
             FatalError(SC_ERR_FATAL, "Invalid value for flow.prealloc: NULL");
         }
 
-        if (StringParseUint32(&configval, 10, strlen(conf_val),
-                                    conf_val) > 0) {
+        if (StringParseUint32(&configval, 10, (uint16_t)strlen(conf_val), conf_val) > 0) {
             flow_config.prealloc = configval;
         }
     }
@@ -780,54 +778,46 @@ void FlowInitFlowProto(void)
             emergency_bypassed = ConfNodeLookupChildValue(proto,
                 "emergency-bypassed");
 
-            if (new != NULL &&
-                StringParseUint32(&configval, 10, strlen(new), new) > 0) {
+            if (new != NULL && StringParseUint32(&configval, 10, (uint16_t)strlen(new), new) > 0) {
 
-                    flow_timeouts_normal[FLOW_PROTO_DEFAULT].new_timeout = configval;
+                flow_timeouts_normal[FLOW_PROTO_DEFAULT].new_timeout = configval;
             }
-            if (established != NULL &&
-                StringParseUint32(&configval, 10, strlen(established),
-                                        established) > 0) {
+            if (established != NULL && StringParseUint32(&configval, 10,
+                                               (uint16_t)strlen(established), established) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_DEFAULT].est_timeout = configval;
             }
             if (closed != NULL &&
-                StringParseUint32(&configval, 10, strlen(closed),
-                                        closed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(closed), closed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_DEFAULT].closed_timeout = configval;
             }
             if (bypassed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(bypassed),
-                                            bypassed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(bypassed), bypassed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_DEFAULT].bypassed_timeout = configval;
             }
             if (emergency_new != NULL &&
-                StringParseUint32(&configval, 10, strlen(emergency_new),
-                                        emergency_new) > 0) {
+                    StringParseUint32(
+                            &configval, 10, (uint16_t)strlen(emergency_new), emergency_new) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_DEFAULT].new_timeout = configval;
             }
             if (emergency_established != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(emergency_established),
-                                            emergency_established) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_established),
+                            emergency_established) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_DEFAULT].est_timeout= configval;
             }
             if (emergency_closed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(emergency_closed),
-                                            emergency_closed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_closed),
+                            emergency_closed) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_DEFAULT].closed_timeout = configval;
             }
             if (emergency_bypassed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(emergency_bypassed),
-                                            emergency_bypassed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_bypassed),
+                            emergency_bypassed) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_DEFAULT].bypassed_timeout = configval;
             }
@@ -848,54 +838,46 @@ void FlowInitFlowProto(void)
             emergency_bypassed = ConfNodeLookupChildValue(proto,
                 "emergency-bypassed");
 
-            if (new != NULL &&
-                StringParseUint32(&configval, 10, strlen(new), new) > 0) {
+            if (new != NULL && StringParseUint32(&configval, 10, (uint16_t)strlen(new), new) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_TCP].new_timeout = configval;
             }
-            if (established != NULL &&
-                StringParseUint32(&configval, 10, strlen(established),
-                                        established) > 0) {
+            if (established != NULL && StringParseUint32(&configval, 10,
+                                               (uint16_t)strlen(established), established) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_TCP].est_timeout = configval;
             }
             if (closed != NULL &&
-                StringParseUint32(&configval, 10, strlen(closed),
-                                        closed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(closed), closed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_TCP].closed_timeout = configval;
             }
             if (bypassed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(bypassed),
-                                            bypassed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(bypassed), bypassed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_TCP].bypassed_timeout = configval;
             }
             if (emergency_new != NULL &&
-                StringParseUint32(&configval, 10, strlen(emergency_new),
-                                        emergency_new) > 0) {
+                    StringParseUint32(
+                            &configval, 10, (uint16_t)strlen(emergency_new), emergency_new) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_TCP].new_timeout = configval;
             }
             if (emergency_established != NULL &&
-                StringParseUint32(&configval, 10,
-                                        strlen(emergency_established),
-                                        emergency_established) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_established),
+                            emergency_established) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_TCP].est_timeout = configval;
             }
             if (emergency_closed != NULL &&
-                StringParseUint32(&configval, 10,
-                                        strlen(emergency_closed),
-                                        emergency_closed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_closed),
+                            emergency_closed) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_TCP].closed_timeout = configval;
             }
             if (emergency_bypassed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(emergency_bypassed),
-                                            emergency_bypassed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_bypassed),
+                            emergency_bypassed) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_TCP].bypassed_timeout = configval;
             }
@@ -913,41 +895,35 @@ void FlowInitFlowProto(void)
             emergency_bypassed = ConfNodeLookupChildValue(proto,
                 "emergency-bypassed");
 
-            if (new != NULL &&
-                StringParseUint32(&configval, 10, strlen(new), new) > 0) {
+            if (new != NULL && StringParseUint32(&configval, 10, (uint16_t)strlen(new), new) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_UDP].new_timeout = configval;
             }
-            if (established != NULL &&
-                StringParseUint32(&configval, 10, strlen(established),
-                                        established) > 0) {
+            if (established != NULL && StringParseUint32(&configval, 10,
+                                               (uint16_t)strlen(established), established) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_UDP].est_timeout = configval;
             }
             if (bypassed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(bypassed),
-                                            bypassed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(bypassed), bypassed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_UDP].bypassed_timeout = configval;
             }
             if (emergency_new != NULL &&
-                StringParseUint32(&configval, 10, strlen(emergency_new),
-                                        emergency_new) > 0) {
+                    StringParseUint32(
+                            &configval, 10, (uint16_t)strlen(emergency_new), emergency_new) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_UDP].new_timeout = configval;
             }
             if (emergency_established != NULL &&
-                StringParseUint32(&configval, 10,
-                                        strlen(emergency_established),
-                                        emergency_established) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_established),
+                            emergency_established) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_UDP].est_timeout = configval;
             }
             if (emergency_bypassed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(emergency_bypassed),
-                                            emergency_bypassed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_bypassed),
+                            emergency_bypassed) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_UDP].bypassed_timeout = configval;
             }
@@ -965,41 +941,35 @@ void FlowInitFlowProto(void)
             emergency_bypassed = ConfNodeLookupChildValue(proto,
                 "emergency-bypassed");
 
-            if (new != NULL &&
-                StringParseUint32(&configval, 10, strlen(new), new) > 0) {
+            if (new != NULL && StringParseUint32(&configval, 10, (uint16_t)strlen(new), new) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_ICMP].new_timeout = configval;
             }
-            if (established != NULL &&
-                StringParseUint32(&configval, 10, strlen(established),
-                                        established) > 0) {
+            if (established != NULL && StringParseUint32(&configval, 10,
+                                               (uint16_t)strlen(established), established) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_ICMP].est_timeout = configval;
             }
             if (bypassed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(bypassed),
-                                            bypassed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(bypassed), bypassed) > 0) {
 
                 flow_timeouts_normal[FLOW_PROTO_ICMP].bypassed_timeout = configval;
             }
             if (emergency_new != NULL &&
-                StringParseUint32(&configval, 10, strlen(emergency_new),
-                                        emergency_new) > 0) {
+                    StringParseUint32(
+                            &configval, 10, (uint16_t)strlen(emergency_new), emergency_new) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_ICMP].new_timeout = configval;
             }
             if (emergency_established != NULL &&
-                StringParseUint32(&configval, 10,
-                                        strlen(emergency_established),
-                                        emergency_established) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_established),
+                            emergency_established) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_ICMP].est_timeout = configval;
             }
             if (emergency_bypassed != NULL &&
-                    StringParseUint32(&configval, 10,
-                                            strlen(emergency_bypassed),
-                                            emergency_bypassed) > 0) {
+                    StringParseUint32(&configval, 10, (uint16_t)strlen(emergency_bypassed),
+                            emergency_bypassed) > 0) {
 
                 flow_timeouts_emerg[FLOW_PROTO_ICMP].bypassed_timeout = configval;
             }
@@ -1159,7 +1129,8 @@ void FlowUpdateState(Flow *f, const enum FlowState s)
 {
     if (s != f->flow_state) {
         /* set the state */
-        f->flow_state = s;
+        // Explicit cast from the enum type to the compact version
+        f->flow_state = (FlowStateType)s;
 
         /* update timeout policy and value */
         const uint32_t timeout_policy = FlowGetTimeoutPolicy(f);

--- a/src/flow.h
+++ b/src/flow.h
@@ -580,7 +580,7 @@ int FlowGetPacketDirection(const Flow *, const Packet *);
 
 void FlowCleanupAppLayer(Flow *);
 
-void FlowUpdateState(Flow *f, enum FlowState s);
+void FlowUpdateState(Flow *f, const enum FlowState s);
 
 int FlowSetMemcap(uint64_t size);
 uint64_t FlowGetMemcap(void);

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -204,7 +204,7 @@ void JsonDNP3LogResponse(JsonBuilder *js, DNP3Transaction *dnp3tx)
     jb_close(js);
 
     jb_open_object(js, "iin");
-    JsonDNP3LogIin(js, dnp3tx->response_iin.iin1 << 8 | dnp3tx->response_iin.iin2);
+    JsonDNP3LogIin(js, (uint16_t)(dnp3tx->response_iin.iin1 << 8 | dnp3tx->response_iin.iin2));
     jb_close(js);
 }
 

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -202,7 +202,7 @@ JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff, const bool
  *  \brief Write meta data on a single line json record
  */
 static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const File *ff,
-        uint32_t dir, OutputJsonCtx *eve_ctx)
+        uint8_t dir, OutputJsonCtx *eve_ctx)
 {
     HttpXFFCfg *xff_cfg = aft->filelog_ctx->xff_cfg != NULL ?
         aft->filelog_ctx->xff_cfg : aft->filelog_ctx->parent_xff_cfg;;

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -76,8 +76,13 @@ static void EveFTPLogCommand(Flow *f, FTPTransaction *tx, JsonBuilder *jb)
         TAILQ_FOREACH(response, &tx->response_list, next) {
             /* handle multiple lines within the response, \r\n delimited */
             uint8_t *where = response->str;
-            uint16_t length = response->len ? response->len -1 : 0;
+            uint16_t length = 0;
             uint16_t pos;
+            if (response->len > 0 && response->len <= UINT16_MAX) {
+                length = (uint16_t)response->len - 1;
+            } else if (response->len > UINT16_MAX) {
+                length = UINT16_MAX;
+            }
             while ((pos = JsonGetNextLineFromBuffer((const char *)where, length)) != UINT16_MAX) {
                 uint16_t offset = 0;
                 /* Try to find a completion code for this line */

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -64,7 +64,7 @@ typedef enum OutputEngineInfo_ {
 
 typedef struct OutputStatsCtx_ {
     LogFileCtx *file_ctx;
-    uint32_t flags; /** Store mode */
+    uint8_t flags; /** Store mode */
 } OutputStatsCtx;
 
 typedef struct JsonStatsLogThread_ {

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -801,7 +801,7 @@ static int StreamTcpReassembleRawCheckLimit(const TcpSession *ssn,
 /**
  *  \brief see what if any work the TCP session still needs
  */
-int StreamNeedsReassembly(const TcpSession *ssn, uint8_t direction)
+uint8_t StreamNeedsReassembly(const TcpSession *ssn, uint8_t direction)
 {
     const TcpStream *stream = NULL;
 #ifdef DEBUG

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -175,7 +175,7 @@ enum {
 };
 
 TmEcode StreamTcp (ThreadVars *, Packet *, void *, PacketQueueNoLock *);
-int StreamNeedsReassembly(const TcpSession *ssn, uint8_t direction);
+uint8_t StreamNeedsReassembly(const TcpSession *ssn, uint8_t direction);
 TmEcode StreamTcpThreadInit(ThreadVars *, void *, void **);
 TmEcode StreamTcpThreadDeinit(ThreadVars *tv, void *data);
 void StreamTcpRegisterTests (void);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4516

Describe changes:
- Fix integer warnings `-Wimplicit-int-conversion` for output, flow, and app-layer files

Part of #7006 as #7107 was

Changed from #7006 to keep using `FlowState` in function prototype and using an explicit cast afterwards to get rid of warning about implicit integer conversion