### PR TITLE
detect: makes config keyword really require a flow

### DIFF
--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -561,6 +561,11 @@ static int SignatureCreateMask(Signature *s)
             case DETECT_ENGINE_EVENT:
                 s->mask |= SIG_MASK_REQUIRE_ENGINE_EVENT;
                 break;
+        }
+    }
+
+    for (sm = s->init_data->smlists[DETECT_SM_LIST_POSTMATCH]; sm != NULL; sm = sm->next) {
+        switch (sm->type) {
             case DETECT_CONFIG: {
                 DetectConfigData *fd = (DetectConfigData *)sm->ctx;
                 if (fd->scope == CONFIG_SCOPE_FLOW) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4972

Describe changes:
- detect: only apply ConfigApplyTx when relevant (like with a flow)

Completes #7080 with checking the case for `DETECT_CONFIG` with `DETECT_SM_LIST_POSTMATCH`