### PR TITLE
Coverity fixes v1

### DIFF
--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -178,6 +178,9 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
     } else if (PKT_IS_IPV6(p)) {
         PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), dstip, sizeof(dstip));
+    } else {
+        snprintf(srcip, sizeof(srcip), "unknown-ip-version");
+        snprintf(dstip, sizeof(dstip), "unknown-ip-version");
     }
 
     MemBufferWriteString(aft->buffer, "SRC IP:            %s\n"

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -365,6 +365,10 @@ int DetectXbitSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
             /* modifiers, only run when entire sig has matched */
             SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
             break;
+        default:
+            SigMatchFree(de_ctx, sm);
+            SCLogWarning(SC_ERR_UNKNOWN_VALUE, "Unknown command for xbits");
+            return -1;
     }
 
     return 0;

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -813,7 +813,8 @@ Flow *FlowGetFlowFromHash(ThreadVars *tv, FlowLookupStruct *fls,
                 if (f->use_cnt == 0) {
                     if (prev_f == NULL) /* if we have no prev it means new_f is now our prev */
                         prev_f = new_f;
-                    // f got unlocked by TcpReuseReplace and will be unlocked again by MoveToWorkQueue
+                    // f got unlocked by TcpReuseReplace and will be unlocked again by
+                    // MoveToWorkQueue
                     FromHashLockCMP(f);
                     MoveToWorkQueue(tv, fls, fb, f, prev_f); /* evict old flow */
                 }

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -813,6 +813,8 @@ Flow *FlowGetFlowFromHash(ThreadVars *tv, FlowLookupStruct *fls,
                 if (f->use_cnt == 0) {
                     if (prev_f == NULL) /* if we have no prev it means new_f is now our prev */
                         prev_f = new_f;
+                    // f got unlocked by TcpReuseReplace and will be unlocked again by MoveToWorkQueue
+                    FromHashLockCMP(f);
                     MoveToWorkQueue(tv, fls, fb, f, prev_f); /* evict old flow */
                 }
                 if (new_f == NULL) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None, not sure it deserves one

Describe changes: patches to make coverity happy
- Prevents a double unlock (by locking again) 
- Prevents a memory leak in xbits parsing (there is no leak currently, but the code pattern may induce it later) 
- Prevents a use of uninitialized memory in debuglog (I think that this code can only be reached if `PKT_IS_IPV6` or `PKT_IS_IPV4` but this makes it robust against future changes)

After this and #7131 (which I think is a real bug this one), there will be no more outstanding issues reported by coverity 