### PR TITLE
Packet alerts/v9

### DIFF
--- a/src/decode-chdlc.c
+++ b/src/decode-chdlc.c
@@ -78,14 +78,13 @@ static int DecodeCHDLCTest01 (void)
         0x00,0x00,0x70,0x02,0x40,0x00,0x11,0x47,0x00,0x00,
         0x02,0x04,0x05,0xb4,0x01,0x01,0x04,0x02 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeCHDLC(&tv, &dtv, p, raw, sizeof(raw));
 

--- a/src/decode-ethernet.c
+++ b/src/decode-ethernet.c
@@ -90,7 +90,7 @@ static int DecodeEthernetTest01 (void)
         0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd,
         0xab, 0xcd };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -98,7 +98,6 @@ static int DecodeEthernetTest01 (void)
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeEthernet(&tv, &dtv, p, raw_eth, sizeof(raw_eth));
 
@@ -116,14 +115,13 @@ static int DecodeEthernetTestDceTooSmall(void)
         0x94, 0x56, 0x00, 0x01, 0x89, 0x03,
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeEthernet(&tv, &dtv, p, raw_eth, sizeof(raw_eth));
 
@@ -152,14 +150,13 @@ static int DecodeEthernetTestDceNextTooSmall(void)
         0x94, 0x56, 0x00, 0x01,
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeEthernet(&tv, &dtv, p, raw_eth, sizeof(raw_eth));
 

--- a/src/decode-icmpv4.c
+++ b/src/decode-icmpv4.c
@@ -379,7 +379,7 @@ static int DecodeICMPV4test01(void)
         0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
         0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
         0xab };
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -389,7 +389,6 @@ static int DecodeICMPV4test01(void)
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
 
@@ -431,7 +430,7 @@ static int DecodeICMPV4test02(void)
         0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
         0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27,
         0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f };
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -441,7 +440,6 @@ static int DecodeICMPV4test02(void)
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
 
     FlowInitConfig(FLOW_QUIET);
@@ -480,7 +478,7 @@ static int DecodeICMPV4test03(void)
         0x01, 0x11, 0xde, 0xfd, 0xc0, 0xa8, 0x01, 0x0d,
         0xd1, 0x55, 0xe3, 0x93, 0x8b, 0x12, 0x82, 0xaa,
         0x00, 0x28, 0x7c, 0xdd };
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -490,7 +488,6 @@ static int DecodeICMPV4test03(void)
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
 
     FlowInitConfig(FLOW_QUIET);
@@ -560,7 +557,7 @@ static int DecodeICMPV4test04(void)
         0x3e, 0x36, 0x38, 0x7c, 0x00, 0x00, 0x00, 0x00,
         0xa0, 0x02, 0x16, 0xd0, 0x72, 0x04, 0x00, 0x00,
         0x02, 0x04, 0x05, 0x8a, 0x04, 0x02, 0x08, 0x0a };
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -570,7 +567,6 @@ static int DecodeICMPV4test04(void)
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
 
     FlowInitConfig(FLOW_QUIET);
@@ -630,7 +626,7 @@ static int DecodeICMPV4test05(void)
 	0xd6, 0xbd, 0xc0, 0xa8, 0x02, 0x05, 0x3d, 0x23, 0xa1,
 	0x23, 0x04, 0x18, 0x00, 0x50, 0xd2, 0x08, 0xc2, 0x48,
          };
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -640,7 +636,6 @@ static int DecodeICMPV4test05(void)
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
 
     FlowInitConfig(FLOW_QUIET);
@@ -737,7 +732,7 @@ static int ICMPV4InvalidType07(void)
         0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x38};
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
     return 0;
     ThreadVars tv;
@@ -747,7 +742,6 @@ static int ICMPV4InvalidType07(void)
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
 
     FlowInitConfig(FLOW_QUIET);
@@ -781,7 +775,7 @@ static int DecodeICMPV4test08(void)
     uint8_t raw_icmpv4[] = {
         0x08, 0x00, 0x78, 0x47, 0xfc, 0x55, 0x00, 0x00
     };
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -791,7 +785,6 @@ static int DecodeICMPV4test08(void)
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
 
     FlowInitConfig(FLOW_QUIET);

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -608,7 +608,7 @@ static int ICMPV6ParamProbTest01(void)
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
         0x80, 0x00, 0x08, 0xb5, 0x99, 0xc3, 0xde, 0x40 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
@@ -619,7 +619,6 @@ static int ICMPV6ParamProbTest01(void)
     ipv6dst = (uint32_t*) &raw_ipv6[24];
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -664,7 +663,7 @@ static int ICMPV6PktTooBigTest01(void)
         0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
@@ -675,7 +674,6 @@ static int ICMPV6PktTooBigTest01(void)
     ipv6dst = (uint32_t*) &raw_ipv6[24];
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -723,7 +721,7 @@ static int ICMPV6TimeExceedTest01(void)
         0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
@@ -734,7 +732,6 @@ static int ICMPV6TimeExceedTest01(void)
     ipv6dst = (uint32_t*) &raw_ipv6[24];
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -782,7 +779,7 @@ static int ICMPV6DestUnreachTest01(void)
         0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
@@ -793,7 +790,6 @@ static int ICMPV6DestUnreachTest01(void)
     ipv6dst = (uint32_t*) &raw_ipv6[24];
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -833,14 +829,13 @@ static int ICMPV6EchoReqTest01(void)
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
         0x80, 0x00, 0xe5, 0xa5, 0x25, 0xf0, 0x75, 0x23 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -879,14 +874,13 @@ static int ICMPV6EchoRepTest01(void)
         0x00, 0x00, 0x00, 0x00, 0x01, 0x81, 0x00,
         0xe5, 0xa5, 0x25, 0xf0, 0x75, 0x23 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -932,14 +926,13 @@ static int ICMPV6ParamProbTest02(void)
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
         0x80, 0x00, 0x08, 0xb5, 0x99, 0xc3, 0xde, 0x40 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -975,14 +968,13 @@ static int ICMPV6PktTooBigTest02(void)
         0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1014,14 +1006,13 @@ static int ICMPV6TimeExceedTest02(void)
 
     /* The icmpv6 header is broken in the checksum (so we dont have a complete header) */
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1055,14 +1046,13 @@ static int ICMPV6DestUnreachTest02(void)
         0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1092,14 +1082,13 @@ static int ICMPV6EchoReqTest02(void)
         0x00, 0x00, 0x00, 0x00, 0x01, 0x80, 0x01,
         0xe5, 0xa5, 0x25, 0xf0, 0x75, 0x23 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1129,14 +1118,13 @@ static int ICMPV6EchoRepTest02(void)
         0x00, 0x00, 0x00, 0x00, 0x01, 0x81, 0x01,
         0xe5, 0xa5, 0x25, 0xf0, 0x75, 0x23 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1169,14 +1157,13 @@ static int ICMPV6PayloadTest01(void)
         0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1203,14 +1190,13 @@ static int ICMPV6RouterSolicitTestKnownCode(void)
         0x85, 0x00, 0xbe, 0xb0, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1236,14 +1222,13 @@ static int ICMPV6RouterSolicitTestUnknownCode(void)
         0x85, 0x01, 0xbe, 0xaf, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1269,14 +1254,13 @@ static int ICMPV6RouterAdvertTestKnownCode(void)
         0x86, 0x00, 0xbd, 0xb0, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1302,14 +1286,13 @@ static int ICMPV6RouterAdvertTestUnknownCode(void)
         0x86, 0x01, 0xbd, 0xaf, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1335,14 +1318,13 @@ static int ICMPV6NeighbourSolicitTestKnownCode(void)
         0x87, 0x00, 0xbc, 0xb0, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1368,14 +1350,13 @@ static int ICMPV6NeighbourSolicitTestUnknownCode(void)
         0x87, 0x01, 0xbc, 0xaf, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1401,14 +1382,13 @@ static int ICMPV6NeighbourAdvertTestKnownCode(void)
         0x88, 0x00, 0xbb, 0xb0, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1434,14 +1414,13 @@ static int ICMPV6NeighbourAdvertTestUnknownCode(void)
         0x88, 0x01, 0xbb, 0xaf, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1467,14 +1446,13 @@ static int ICMPV6RedirectTestKnownCode(void)
         0x89, 0x00, 0xba, 0xb0, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1500,14 +1478,13 @@ static int ICMPV6RedirectTestUnknownCode(void)
         0x89, 0x01, 0xba, 0xaf, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1550,14 +1527,13 @@ static int ICMPV6CalculateValidChecksumWithFCS(void)
     };
     uint16_t csum = *(((uint16_t *)(raw_ipv6 + 64)));
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -1630,14 +1630,13 @@ static int DecodeEthernetTestIPv4Opt(void)
 
     DefragInit();
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeEthernet(&tv, &dtv, p, raw_eth, sizeof(raw_eth));
 

--- a/src/decode-mpls.c
+++ b/src/decode-mpls.c
@@ -146,7 +146,7 @@ static int DecodeMPLSTestHeaderTooSmall(void)
         0x00, 0x00, 0x11
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL)) {
         return 0;
     }
@@ -155,7 +155,6 @@ static int DecodeMPLSTestHeaderTooSmall(void)
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeMPLS(&tv, &dtv, p, pkt, sizeof(pkt));
 
@@ -234,7 +233,7 @@ static int DecodeMPLSTestBadLabelRouterAlert(void)
         0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL)) {
         return 0;
     }
@@ -243,7 +242,6 @@ static int DecodeMPLSTestBadLabelRouterAlert(void)
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeMPLS(&tv, &dtv, p, pkt, sizeof(pkt));
 
@@ -274,7 +272,7 @@ static int DecodeMPLSTestBadLabelImplicitNull(void)
         0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL)) {
         return 0;
     }
@@ -283,7 +281,6 @@ static int DecodeMPLSTestBadLabelImplicitNull(void)
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeMPLS(&tv, &dtv, p, pkt, sizeof(pkt));
 
@@ -314,7 +311,7 @@ static int DecodeMPLSTestBadLabelReserved(void)
         0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL)) {
         return 0;
     }
@@ -323,7 +320,6 @@ static int DecodeMPLSTestBadLabelReserved(void)
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeMPLS(&tv, &dtv, p, pkt, sizeof(pkt));
 
@@ -358,7 +354,7 @@ static int DecodeMPLSTestUnknownPayloadType(void)
         0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL)) {
         return 0;
     }
@@ -367,7 +363,6 @@ static int DecodeMPLSTestUnknownPayloadType(void)
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeMPLS(&tv, &dtv, p, pkt, sizeof(pkt));
 

--- a/src/decode-nsh.c
+++ b/src/decode-nsh.c
@@ -136,11 +136,10 @@ static int DecodeNSHTestHeaderTooSmall(void)
     DecodeThreadVars dtv;
     Packet *p;
 
-    p = SCMalloc(SIZE_OF_PACKET);
+    p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     /* A packet that is too small to have a complete NSH header */
     DecodeNSH(&tv, &dtv, p, valid_nsh_packet, 7);
@@ -156,11 +155,10 @@ static int DecodeNSHTestUnsupportedVersion(void)
     DecodeThreadVars dtv;
     Packet *p;
 
-    p = SCMalloc(SIZE_OF_PACKET);
+    p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     /* Non-zero version field */
     valid_nsh_packet[0] = 0xFF;
@@ -178,11 +176,10 @@ static int DecodeNSHTestPacketTooSmall(void)
     DecodeThreadVars dtv;
     Packet *p;
 
-    p = SCMalloc(SIZE_OF_PACKET);
+    p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     /* A packet that has no payload */
     DecodeNSH(&tv, &dtv, p, valid_nsh_packet, 8);
@@ -198,11 +195,10 @@ static int DecodeNSHTestReservedType(void)
     DecodeThreadVars dtv;
     Packet *p;
 
-    p = SCMalloc(SIZE_OF_PACKET);
+    p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     /* Reserved type */
     valid_nsh_packet[2] = 0x00;
@@ -220,11 +216,10 @@ static int DecodeNSHTestInvalidType(void)
     DecodeThreadVars dtv;
     Packet *p;
 
-    p = SCMalloc(SIZE_OF_PACKET);
+    p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     /* Type length mismatch */
     valid_nsh_packet[2] = 0x01;
@@ -241,11 +236,10 @@ static int DecodeNSHTestUnsupportedType(void)
     DecodeThreadVars dtv;
     Packet *p;
 
-    p = SCMalloc(SIZE_OF_PACKET);
+    p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     /* Unsupported type */
     valid_nsh_packet[2] = 0x03;
@@ -263,11 +257,10 @@ static int DecodeNSHTestUnknownPayload(void)
     DecodeThreadVars dtv;
     Packet *p;
 
-    p = SCMalloc(SIZE_OF_PACKET);
+    p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     /* Unknown type */
     valid_nsh_packet[3] = 0x99;

--- a/src/decode.c
+++ b/src/decode.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2019 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -74,6 +74,26 @@ extern bool stats_decoder_events;
 extern const char *stats_decoder_events_prefix;
 extern bool stats_stream_events;
 uint8_t decoder_max_layers = PKT_DEFAULT_MAX_DECODED_LAYERS;
+uint16_t packet_alert_max = PACKET_ALERT_MAX;
+
+/**
+ * \brief Initialize PacketAlerts with dynamic alerts array size
+ *
+ */
+PacketAlert *CreatePacketAlert(void)
+{
+    PacketAlert *pa_array = SCCalloc(packet_alert_max, sizeof(PacketAlert));
+    BUG_ON(pa_array == NULL);
+
+    return pa_array;
+}
+
+void FreePacketAlert(PacketAlert *pa)
+{
+    if (pa != NULL) {
+        SCFree(pa);
+    }
+}
 
 static int DecodeTunnel(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t,
         enum DecodeTunnelProto) WARN_UNUSED;
@@ -781,6 +801,21 @@ void DecodeGlobalConfig(void)
             decoder_max_layers = value;
         }
     }
+    GetPacketMaxAlertConfig();
+}
+
+void GetPacketMaxAlertConfig(void)
+{
+    intmax_t max = 0;
+    if (ConfGetInt("packet-alert-max", &max) == 1) {
+        if (max <= 0 || max > UINT8_MAX) {
+            SCLogWarning(SC_ERR_INVALID_VALUE,
+                    "Invalid value for packet-alert-max, default value set instead");
+        } else {
+            packet_alert_max = max;
+        }
+    }
+    SCLogDebug("detect->packet_alert_max set to %d", packet_alert_max);
 }
 
 /**

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -1043,7 +1043,7 @@ static int DetectContentLongPatternMatchTest(uint8_t *raw_eth_pkt, uint16_t pkts
 {
     int result = 0;
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     DecodeThreadVars dtv;
@@ -1051,7 +1051,6 @@ static int DetectContentLongPatternMatchTest(uint8_t *raw_eth_pkt, uint16_t pkts
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&th_v, 0, sizeof(th_v));
 

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -702,7 +702,7 @@ static int DetectDsizeIcmpv6Test01(void)
         0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
 
     IPV6Hdr ip6h;
@@ -712,7 +712,6 @@ static int DetectDsizeIcmpv6Test01(void)
     DetectEngineThreadCtx *det_ctx = NULL;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
     memset(&th_v, 0, sizeof(ThreadVars));

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -126,12 +126,11 @@ static int PacketAlertHandle(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det
     SCReturnInt(1);
 }
 
-
 /**
  * \brief Check if a certain sid alerted, this is used in the test functions
  *
  * \param p   Packet on which we want to check if the signature alerted or not
- * \param sid Signature id of the signature that thas to be checked for a match
+ * \param sid Signature id of the signature that has to be checked for a match
  *
  * \retval match A value > 0 on a match; 0 on no match
  */

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -154,27 +154,22 @@ int PacketAlertCheck(Packet *p, uint32_t sid)
  * \brief Remove alert from the p->alerts.alerts array at pos
  * \param p Pointer to the Packet
  * \param pos Position in the array
- * \retval 0 if the number of alerts is less than pos
- *         1 if all goes well
  */
-int PacketAlertRemove(Packet *p, uint16_t pos)
+static void PacketAlertRemove(Packet *p, uint16_t pos)
 {
-    uint16_t i = 0;
-    int match = 0;
-
-    if (pos > p->alerts.cnt) {
+    if (pos >= p->alerts.cnt) {
         SCLogDebug("removing %u failed, pos > cnt %u", pos, p->alerts.cnt);
-        return 0;
+        return;
     }
 
-    for (i = pos; i <= p->alerts.cnt - 1; i++) {
-        memcpy(&p->alerts.alerts[i], &p->alerts.alerts[i + 1], sizeof(PacketAlert));
+    const uint16_t after = (p->alerts.cnt - 1) - pos;
+    if (after) {
+        const uint16_t after_start = pos + 1;
+        memmove(p->alerts.alerts + pos, p->alerts.alerts + after_start,
+                (sizeof(PacketAlert) * after));
     }
 
-    // Update it, since we removed 1
     p->alerts.cnt--;
-
-    return match;
 }
 
 /** \brief append a signature match to a packet

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -190,7 +190,7 @@ int PacketAlertAppend(DetectEngineThreadCtx *det_ctx, const Signature *s,
 {
     int i = 0;
 
-    if (p->alerts.cnt == PACKET_ALERT_MAX)
+    if (p->alerts.cnt == packet_alert_max)
         return 0;
 
     SCLogDebug("sid %"PRIu32"", s->id);

--- a/src/detect-engine-alert.h
+++ b/src/detect-engine-alert.h
@@ -32,7 +32,6 @@ void PacketAlertFinalize(DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
 int PacketAlertAppend(DetectEngineThreadCtx *, const Signature *,
         Packet *, uint64_t tx_id, uint8_t);
 int PacketAlertCheck(Packet *, uint32_t);
-int PacketAlertRemove(Packet *, uint16_t);
 void PacketAlertTagInit(void);
 PacketAlert *PacketAlertGetTag(void);
 

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -336,13 +336,12 @@ static int EngineEventTestParse05 (void)
  */
 static int EngineEventTestParse06 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
 
     ThreadVars tv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     ENGINE_SET_EVENT(p,PPP_PKT_TOO_SMALL);
 

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -944,7 +944,7 @@ static int FlowBitsTestSig06(void)
                     "Host: one.example.org\r\n"
                     "\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     Signature *s = NULL;
     ThreadVars th_v;
@@ -955,7 +955,6 @@ static int FlowBitsTestSig06(void)
     int result = 0;
     uint32_t idx = 0;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&th_v, 0, sizeof(th_v));
     memset(&f, 0, sizeof(Flow));
     memset(&flowvar, 0, sizeof(GenericVar));
@@ -1018,7 +1017,7 @@ static int FlowBitsTestSig07(void)
                     "Host: one.example.org\r\n"
                     "\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     Signature *s = NULL;
     ThreadVars th_v;
@@ -1029,7 +1028,6 @@ static int FlowBitsTestSig07(void)
     int result = 0;
     uint32_t idx = 0;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&th_v, 0, sizeof(th_v));
     memset(&f, 0, sizeof(Flow));
     memset(&flowvar, 0, sizeof(GenericVar));
@@ -1094,7 +1092,7 @@ static int FlowBitsTestSig08(void)
                     "Host: one.example.org\r\n"
                     "\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Signature *s = NULL;
@@ -1106,7 +1104,6 @@ static int FlowBitsTestSig08(void)
     int result = 0;
     uint32_t idx = 0;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&th_v, 0, sizeof(th_v));
     memset(&f, 0, sizeof(Flow));
     memset(&flowvar, 0, sizeof(GenericVar));

--- a/src/detect-fragbits.c
+++ b/src/detect-fragbits.c
@@ -467,7 +467,7 @@ static int FragBitsTestParse03 (void)
         0x0b ,0xc0 ,0x9f ,0x00 ,0x01 ,0x00 ,0x01 ,0x00,
         0x00 ,0x0e ,0x10 ,0x00 ,0x04 ,0x81 ,0x6f ,0x0b,
         0x51};
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF(unlikely(p == NULL));
     ThreadVars tv;
     DecodeThreadVars dtv;
@@ -477,7 +477,6 @@ static int FragBitsTestParse03 (void)
     SigMatch *sm = NULL;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     dtv.app_tctx = AppLayerGetCtxThread(&tv);
@@ -554,7 +553,7 @@ static int FragBitsTestParse04 (void)
         0x0b ,0xc0 ,0x9f ,0x00 ,0x01 ,0x00 ,0x01 ,0x00,
         0x00 ,0x0e ,0x10 ,0x00 ,0x04 ,0x81 ,0x6f ,0x0b,
         0x51};
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF(unlikely(p == NULL));
     ThreadVars tv;
     DecodeThreadVars dtv;
@@ -564,7 +563,6 @@ static int FragBitsTestParse04 (void)
     SigMatch *sm = NULL;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     dtv.app_tctx = AppLayerGetCtxThread(&tv);

--- a/src/detect-fragoffset.c
+++ b/src/detect-fragoffset.c
@@ -381,7 +381,7 @@ static int DetectFragOffsetParseTest03 (void)
  */
 static int DetectFragOffsetMatchTest01 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
 
     FAIL_IF_NULL(p);
     Signature *s = NULL;
@@ -390,7 +390,6 @@ static int DetectFragOffsetMatchTest01 (void)
     DetectEngineThreadCtx *det_ctx = NULL;
     IPV4Hdr ip4h;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&th_v, 0, sizeof(ThreadVars));

--- a/src/detect-ftpbounce.c
+++ b/src/detect-ftpbounce.c
@@ -432,7 +432,7 @@ static int DetectFtpbounceTestALMatch03(void)
 
     TcpSession ssn;
     Flow f;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Signature *s = NULL;
@@ -441,7 +441,6 @@ static int DetectFtpbounceTestALMatch03(void)
     AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&f, 0, sizeof(f));
     memset(&ssn, 0, sizeof(ssn));
 

--- a/src/detect-hostbits.c
+++ b/src/detect-hostbits.c
@@ -563,7 +563,6 @@ static int HostBitsTestSig01(void)
     DetectEngineCtx *de_ctx = NULL;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
     p->payload = buf;
@@ -655,7 +654,7 @@ static int HostBitsTestSig03(void)
                     "Host: one.example.org\r\n"
                     "\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Signature *s = NULL;
@@ -665,7 +664,6 @@ static int HostBitsTestSig03(void)
     int idx = 0;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
     p->payload = buf;

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -248,13 +248,12 @@ static int IpOptsTestParse02 (void)
  */
 static int IpOptsTestParse03 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     ThreadVars tv;
     IPV4Hdr ip4h;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ip4h, 0, sizeof(IPV4Hdr));
 
     p->ip4h = &ip4h;
@@ -283,13 +282,12 @@ static int IpOptsTestParse03 (void)
  */
 static int IpOptsTestParse04 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     ThreadVars tv;
     IPV4Hdr ip4h;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ip4h, 0, sizeof(IPV4Hdr));
 
     p->ip4h = &ip4h;

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -1915,10 +1915,9 @@ static int DetectIPProtoTestSig2(void)
         0x4a, 0xea, 0x7a, 0x8e,
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeThreadVars dtv;
     ThreadVars th_v;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -3718,7 +3718,7 @@ static int SigTestBidirec04 (void)
         0x6b,0x65,0x65,0x70,0x2d,0x61,0x6c,0x69,
         0x76,0x65,0x0d,0x0a,0x0d,0x0a }; /* end rawpkt1_ether */
 
-    p = SCMalloc(SIZE_OF_PACKET);
+    p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     DecodeThreadVars dtv;
@@ -3726,7 +3726,6 @@ static int SigTestBidirec04 (void)
     DetectEngineThreadCtx *det_ctx;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
 
     FlowInitConfig(FLOW_QUIET);
     DecodeEthernet(&th_v, &dtv, p, rawpkt1_ether, sizeof(rawpkt1_ether));

--- a/src/detect-tcp-flags.c
+++ b/src/detect-tcp-flags.c
@@ -656,7 +656,7 @@ static int FlagsTestParse02 (void)
  */
 static int FlagsTestParse03 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -667,7 +667,6 @@ static int FlagsTestParse03 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -711,7 +710,7 @@ error:
  */
 static int FlagsTestParse04 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -722,7 +721,6 @@ static int FlagsTestParse04 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -767,7 +765,7 @@ error:
  */
 static int FlagsTestParse05 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -778,7 +776,6 @@ static int FlagsTestParse05 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -823,7 +820,7 @@ error:
  */
 static int FlagsTestParse06 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -834,7 +831,6 @@ static int FlagsTestParse06 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -878,7 +874,7 @@ error:
  */
 static int FlagsTestParse07 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -889,7 +885,6 @@ static int FlagsTestParse07 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -934,7 +929,7 @@ error:
  */
 static int FlagsTestParse08 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -945,7 +940,6 @@ static int FlagsTestParse08 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -989,7 +983,7 @@ error:
  */
 static int FlagsTestParse09 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -1000,7 +994,6 @@ static int FlagsTestParse09 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -1044,7 +1037,7 @@ error:
  */
 static int FlagsTestParse10 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -1055,7 +1048,6 @@ static int FlagsTestParse10 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -1099,7 +1091,7 @@ error:
  */
 static int FlagsTestParse11 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -1110,7 +1102,6 @@ static int FlagsTestParse11 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -1155,7 +1146,7 @@ error:
  */
 static int FlagsTestParse12 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -1166,7 +1157,6 @@ static int FlagsTestParse12 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -1242,7 +1232,7 @@ static int FlagsTestParse14(void)
 
 static int FlagsTestParse15(void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -1253,7 +1243,6 @@ static int FlagsTestParse15(void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -1295,7 +1284,7 @@ error:
 
 static int FlagsTestParse16(void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -1306,7 +1295,6 @@ static int FlagsTestParse16(void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -1351,7 +1339,7 @@ error:
  */
 static int FlagsTestParse17(void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -1362,7 +1350,6 @@ static int FlagsTestParse17(void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -466,7 +466,7 @@ static int XBitsTestSig01(void)
                     "Host: one.example.org\r\n"
                     "\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     Signature *s = NULL;
     ThreadVars th_v;
@@ -474,7 +474,6 @@ static int XBitsTestSig01(void)
     DetectEngineCtx *de_ctx = NULL;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
     p->payload = buf;

--- a/src/tests/detect.c
+++ b/src/tests/detect.c
@@ -938,7 +938,7 @@ static int SigTest15 (void)
     uint8_t *buf = (uint8_t *)
                     "CONNECT 213.92.8.7:31204 HTTP/1.1";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars th_v;
@@ -946,7 +946,6 @@ static int SigTest15 (void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
     p->payload = buf;
@@ -1097,7 +1096,7 @@ static int SigTest18 (void)
     uint8_t *buf = (uint8_t *)
                     "220 (vsFTPd 2.0.5)\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars th_v;
@@ -1105,7 +1104,6 @@ static int SigTest18 (void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
     p->payload = buf;
@@ -1150,7 +1148,7 @@ static int SigTest19 (void)
     uint8_t *buf = (uint8_t *)
                     "220 (vsFTPd 2.0.5)\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars th_v;
@@ -1158,7 +1156,6 @@ static int SigTest19 (void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     p->src.family = AF_INET;
     p->src.addr_data32[0] = UTHSetIPv4Address("192.168.0.1");
     p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");
@@ -1211,7 +1208,7 @@ static int SigTest20 (void)
     uint8_t *buf = (uint8_t *)
                     "220 (vsFTPd 2.0.5)\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars th_v;
@@ -1219,7 +1216,6 @@ static int SigTest20 (void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     p->src.family = AF_INET;
     p->src.addr_data32[0] = UTHSetIPv4Address("192.168.0.1");
     p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");
@@ -1508,10 +1504,10 @@ static int SigTest24IPV4Keyword(void)
         0x40, 0x01, 0xb7, 0x52, 0xc0, 0xa8, 0x01, 0x03,
         0xc0, 0xa8, 0x01, 0x06};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -1525,8 +1521,6 @@ static int SigTest24IPV4Keyword(void)
     uint16_t buflen = strlen((char *)buf);
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
     PACKET_RESET_CHECKSUMS(p1);
     PACKET_RESET_CHECKSUMS(p2);
 
@@ -1612,10 +1606,10 @@ static int SigTest25NegativeIPV4Keyword(void)
         0x40, 0x01, 0xb7, 0x52, 0xc0, 0xa8, 0x01, 0x03,
         0xc0, 0xa8, 0x01, 0x06};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -1629,8 +1623,6 @@ static int SigTest25NegativeIPV4Keyword(void)
     uint16_t buflen = strlen((char *)buf);
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
     PACKET_RESET_CHECKSUMS(p1);
     PACKET_RESET_CHECKSUMS(p2);
 
@@ -1722,11 +1714,11 @@ static int SigTest26TCPV4Keyword(void)
         0x04, 0x02, 0x08, 0x0a, 0x6e, 0x18, 0x78, 0x73,
         0x01, 0x71, 0x74, 0xde, 0x01, 0x03, 0x03, 0x03};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
 
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -1736,8 +1728,6 @@ static int SigTest26TCPV4Keyword(void)
     DetectEngineThreadCtx *det_ctx = NULL;
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PacketCopyData(p1, raw_ipv4, sizeof(raw_ipv4));
     PacketCopyDataOffset(p1, GET_PKT_LEN(p1), valid_raw_tcp, sizeof(valid_raw_tcp));
@@ -1821,11 +1811,11 @@ static int SigTest26TCPV4AndNegativeIPV4Keyword(void)
         0x04, 0x02, 0x08, 0x0a, 0x6e, 0x18, 0x78, 0x73,
         0x01, 0x71, 0x74, 0xde, 0x01, 0x03, 0x03, 0x03};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
 
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -1836,8 +1826,6 @@ static int SigTest26TCPV4AndNegativeIPV4Keyword(void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PacketCopyData(p1, raw_ipv4, sizeof(raw_ipv4));
     PacketCopyDataOffset(p1, GET_PKT_LEN(p1), valid_raw_tcp, sizeof(valid_raw_tcp));
@@ -1947,11 +1935,11 @@ static int SigTest26TCPV4AndIPV4Keyword(void)
         0x19, 0x69, 0x81, 0x7e, 0xFF, 0xAA, 0x00, 0x00,
         0x04, 0x02, 0x00, 0x00};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
 
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -1962,8 +1950,6 @@ static int SigTest26TCPV4AndIPV4Keyword(void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PacketCopyData(p1, raw_ipv4, sizeof(raw_ipv4));
     PacketCopyDataOffset(p1, GET_PKT_LEN(p1), valid_raw_tcp, sizeof(valid_raw_tcp));
@@ -2062,11 +2048,10 @@ static int SigTest27NegativeTCPV4Keyword(void)
         0x04, 0x02, 0x08, 0x0a, 0x6e, 0x18, 0x78, 0x73,
         0x01, 0x71, 0x74, 0xde, 0x01, 0x03, 0x03, 0x03};
 
-
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -2076,8 +2061,6 @@ static int SigTest27NegativeTCPV4Keyword(void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PacketCopyData(p1, raw_ipv4, sizeof(raw_ipv4));
     PacketCopyDataOffset(p1, GET_PKT_LEN(p1), valid_raw_tcp, sizeof(valid_raw_tcp));
@@ -2189,10 +2172,10 @@ static int SigTest28TCPV6Keyword(void)
         0x01, 0x01, 0x08, 0x0a, 0x00, 0x08, 0xca, 0x5a,
         0x00, 0x01, 0x69, 0x28};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -2202,8 +2185,6 @@ static int SigTest28TCPV6Keyword(void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
@@ -2317,10 +2298,10 @@ static int SigTest29NegativeTCPV6Keyword(void)
         0x01, 0x01, 0x08, 0x0a, 0x00, 0x08, 0xca, 0x5a,
         0x00, 0x01, 0x69, 0x28};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -2330,8 +2311,6 @@ static int SigTest29NegativeTCPV6Keyword(void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
@@ -2440,9 +2419,9 @@ static int SigTest30UDPV4Keyword(void)
         0x61, 0x64, 0x01, 0x6c, 0x06, 0x67, 0x6f, 0x6f,
         0x67, 0x6c, 0x65, 0xc0, 0x27};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     FAIL_IF_NULL(p1);
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     FAIL_IF_NULL(p2);
 
     ThreadVars th_v;
@@ -2452,8 +2431,6 @@ static int SigTest30UDPV4Keyword(void)
                     "\r\n\r\nyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ip4h = (IPV4Hdr *)raw_ipv4;
@@ -2544,10 +2521,10 @@ static int SigTest31NegativeUDPV4Keyword(void)
         0x61, 0x64, 0x01, 0x6c, 0x06, 0x67, 0x6f, 0x6f,
         0x67, 0x6c, 0x65, 0xc0, 0x27};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -2560,8 +2537,6 @@ static int SigTest31NegativeUDPV4Keyword(void)
                     "\r\n\r\nyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ip4h = (IPV4Hdr *)raw_ipv4;
@@ -2661,9 +2636,9 @@ static int SigTest32UDPV6Keyword(void)
         0x00, 0x00, 0xf9, 0xc8, 0xe7, 0x36, 0x57, 0xb0,
         0x09, 0x01};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     FAIL_IF_NULL(p1);
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     FAIL_IF_NULL(p2);
 
     ThreadVars th_v;
@@ -2673,8 +2648,6 @@ static int SigTest32UDPV6Keyword(void)
                     "\r\n\r\n";
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
@@ -2758,10 +2731,10 @@ static int SigTest33NegativeUDPV6Keyword(void)
         0x00, 0x00, 0xf9, 0xc8, 0xe7, 0x36, 0x57, 0xb0,
         0x09, 0x01};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -2774,8 +2747,6 @@ static int SigTest33NegativeUDPV6Keyword(void)
                     "\r\n\r\n";
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
@@ -2875,10 +2846,10 @@ static int SigTest34ICMPV4Keyword(void)
         0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33,
         0x34, 0x35, 0x36, 0x38};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -2892,8 +2863,6 @@ static int SigTest34ICMPV4Keyword(void)
     uint16_t buflen = strlen((char *)buf);
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ip4h = (IPV4Hdr *)(valid_raw_ipv4);
@@ -2995,10 +2964,10 @@ static int SigTest35NegativeICMPV4Keyword(void)
         0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33,
         0x34, 0x35, 0x36, 0x38};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -3012,8 +2981,6 @@ static int SigTest35NegativeICMPV4Keyword(void)
     uint16_t buflen = strlen((char *)buf);
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ip4h = (IPV4Hdr *)(valid_raw_ipv4);
@@ -3090,7 +3057,7 @@ end:
 
 static int SigTest38(void)
 {
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
     ThreadVars th_v;
@@ -3131,7 +3098,6 @@ static int SigTest38(void)
     uint16_t buflen = sizeof(buf);
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
 
     /* Copy raw data into packet */
     if (PacketCopyData(p1, raw_eth, ethlen) == -1) {
@@ -3221,7 +3187,7 @@ end:
 
 static int SigTest39(void)
 {
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
     ThreadVars th_v;
@@ -3262,7 +3228,6 @@ static int SigTest39(void)
     uint16_t buflen = sizeof(buf);
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
 
     /* Copy raw data into packet */
     if (PacketCopyData(p1, raw_eth, ethlen) == -1) {
@@ -3397,7 +3362,7 @@ static int SigTest36ContentAndIsdataatKeywords01 (void)
 	,0x65,0x72,0x65,0x3c,0x2f,0x41,0x3e,0x2e,0x0d,0x0a,0x3c,0x2f,0x42,0x4f,0x44,0x59
 	,0x3e,0x3c,0x2f,0x48,0x54,0x4d,0x4c,0x3e,0x0d,0x0a };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     DecodeThreadVars dtv;
@@ -3405,7 +3370,6 @@ static int SigTest36ContentAndIsdataatKeywords01 (void)
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&th_v, 0, sizeof(th_v));
 
@@ -3516,7 +3480,7 @@ static int SigTest37ContentAndIsdataatKeywords02 (void)
 	,0x65,0x72,0x65,0x3c,0x2f,0x41,0x3e,0x2e,0x0d,0x0a,0x3c,0x2f,0x42,0x4f,0x44,0x59
 	,0x3e,0x3c,0x2f,0x48,0x54,0x4d,0x4c,0x3e,0x0d,0x0a };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     DecodeThreadVars dtv;
@@ -3524,7 +3488,6 @@ static int SigTest37ContentAndIsdataatKeywords02 (void)
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&th_v, 0, sizeof(th_v));
 
@@ -3607,7 +3570,7 @@ static int SigTest40NoPacketInspection01(void)
     uint8_t *buf = (uint8_t *)
                     "220 (vsFTPd 2.0.5)\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     TCPHdr tcphdr;
     if (unlikely(p == NULL))
     return 0;
@@ -3618,7 +3581,6 @@ static int SigTest40NoPacketInspection01(void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&pq, 0, sizeof(pq));
     memset(&f, 0, sizeof(f));
     memset(&tcphdr, 0, sizeof(tcphdr));
@@ -3686,9 +3648,8 @@ static int SigTest40NoPayloadInspection02(void)
     ThreadVars th_v;
     memset(&th_v, 0, sizeof(th_v));
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
-    memset(p, 0, SIZE_OF_PACKET);
 
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
@@ -3729,7 +3690,7 @@ static int SigTestMemory01 (void)
                     "Host: two.example.org\r\n"
                     "\r\n\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars th_v;
@@ -3737,7 +3698,6 @@ static int SigTestMemory01 (void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
     p->payload = buf;
@@ -4271,10 +4231,9 @@ static int SigTestWithin01 (void)
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
     /* packet 1 */
-    p1 = SCMalloc(SIZE_OF_PACKET);
+    p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    memset(p1, 0, SIZE_OF_PACKET);
     DecodeEthernet(&th_v, &dtv, p1, rawpkt1, sizeof(rawpkt1));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
     if (!(PacketAlertCheck(p1, 556))) {
@@ -4283,10 +4242,9 @@ static int SigTestWithin01 (void)
     }
 
     /* packet 2 */
-    p2 = SCMalloc(SIZE_OF_PACKET);
+    p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL))
         return 0;
-    memset(p2, 0, SIZE_OF_PACKET);
     DecodeEthernet(&th_v, &dtv, p2, rawpkt2, sizeof(rawpkt2));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
     if (!(PacketAlertCheck(p2, 556))) {
@@ -4295,10 +4253,9 @@ static int SigTestWithin01 (void)
     }
 
     /* packet 3 */
-    p3 = SCMalloc(SIZE_OF_PACKET);
+    p3 = PacketGetFromAlloc();
     if (unlikely(p3 == NULL))
         return 0;
-    memset(p3, 0, SIZE_OF_PACKET);
     DecodeEthernet(&th_v, &dtv, p3, rawpkt3, sizeof(rawpkt3));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p3);
     if (!(PacketAlertCheck(p3, 556))) {
@@ -4307,10 +4264,9 @@ static int SigTestWithin01 (void)
     }
 
     /* packet 4 */
-    p4 = SCMalloc(SIZE_OF_PACKET);
+    p4 = PacketGetFromAlloc();
     if (unlikely(p4 == NULL))
         return 0;
-    memset(p4, 0, SIZE_OF_PACKET);
     DecodeEthernet(&th_v, &dtv, p4, rawpkt4, sizeof(rawpkt4));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p4);
     if (!(PacketAlertCheck(p4, 556))) {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1180,6 +1180,10 @@ legacy:
 #   - reject
 #   - alert
 
+# Define maximum number of possible alerts that can be triggered for the same
+# packet. Default is 15
+packet-alert-max: 15
+
 # IP Reputation
 #reputation-categories-file: @e_sysconfdir@iprep/categories.txt
 #default-reputation-path: @e_sysconfdir@iprep


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/7000

Describe changes:
- address feedback from previous PRs
- Split @victorjulien commit for optimizing alert queue processing split in two, and elaborated commit messages a bit more
- instead of discarding new alerts once we reach packet_alert_max, check signature priority and keep the highest and newest
- remove duplicate checks when possible, remove needless assigns.

I think this covers @catenacyber concerns expressed in https://github.com/OISF/suricata/pull/6896#discussion_r796064516  

Redmine tickets:
https://redmine.openinfosecfoundation.org/issues/4207
and
https://redmine.openinfosecfoundation.org/issues/5178

suricata-verify-pr: 782
https://github.com/OISF/suricata-verify/pull/782