### PR TITLE
6.0.x-backports: log/diag: Support diagnostic stacktraces on SIGSEGV/SIGABRT, prop original signal 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1791,13 +1791,17 @@
     ;;
     esac
 
-    AC_CHECK_LIB(unwind,unw_backtrace,,LIBUNW="no")
-    if test "$LIBUNW" = "no"; then
-        echo
-        echo "   libunwind library and development headers not found"
-        echo "   stacktrace on unexpected termination due to signal not possible"
-        echo
-    fi;
+    AC_ARG_ENABLE(unwind,
+            AS_HELP_STRING([--enable-unwind], [Enable unwind support]),[enable_unwind=$enableval],[enable_unwind=no])
+    AS_IF([test "x$enable_unwind" = "xyes"], [
+        AC_CHECK_LIB(unwind,unw_backtrace,,LIBUNW="no")
+        if test "$LIBUNW" = "no"; then
+            echo
+            echo "   libunwind library and development headers not found"
+            echo "   stacktrace on unexpected termination due to signal not possible"
+            echo
+        fi;
+        ])
 
     AC_ARG_ENABLE(ebpf,
 	        AS_HELP_STRING([--enable-ebpf],[Enable eBPF support]),

--- a/configure.ac
+++ b/configure.ac
@@ -1791,6 +1791,13 @@
     ;;
     esac
 
+    AC_CHECK_LIB(unwind,unw_backtrace,,LIBUNW="no")
+    if test "$LIBUNW" = "no"; then
+        echo
+        echo "   libunwind library and development headers not found"
+        echo "   stacktrace on unexpected termination due to signal not possible"
+        echo
+    fi;
 
     AC_ARG_ENABLE(ebpf,
 	        AS_HELP_STRING([--enable-ebpf],[Enable eBPF support]),

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2246,6 +2246,21 @@ inspected for possible presence of Teredo.
 Advanced Options
 ----------------
 
+stacktrace
+~~~~~~~~~~
+Display diagnostic stacktraces when a signal unexpectedly terminates Suricata, e.g., such as
+SIGSEGV or SIGABRT. Requires the ``libunwind`` library to be available. The default value is
+to display the diagnostic message if a signal unexpectedly terminates Suricata -- e.g.,
+``SIGABRT`` or ``SIGSEGV`` occurs while Suricata is running.
+
+::
+
+    logging:
+        # Requires libunwind to be available when Suricata is configured and built.
+        # If a signal unexpectedly terminates Suricata, displays a brief diagnostic
+        # message with the offending stacktrace if enabled.
+        #stacktrace-on-signal: on
+
 luajit
 ~~~~~~
 

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -379,6 +379,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE(SC_ERR_RULE_INVALID_UTF8);
         CASE_CODE(SC_WARN_CHOWN);
         CASE_CODE(SC_ERR_HASH_ADD);
+        CASE_CODE(SC_ERR_SIGNAL);
 
         CASE_CODE (SC_ERR_MAX);
     }

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -369,6 +369,7 @@ typedef enum {
     SC_ERR_RULE_INVALID_UTF8,
     SC_WARN_CHOWN,
     SC_ERR_HASH_ADD,
+    SC_ERR_SIGNAL,
 
     SC_ERR_MAX
 } SCError;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -551,6 +551,11 @@ logging:
   # This value is overridden by the SC_LOG_OP_FILTER env var.
   default-output-filter:
 
+  # Requires libunwind to be available when Suricata is configured and built.
+  # If a signal unexpectedly terminates Suricata, displays a brief diagnostic
+  # message with the offending stacktrace if enabled.
+  #stacktrace-on-signal: on
+
   # Define your logging outputs.  If none are defined, or they are all
   # disabled you will get the default: console output.
   outputs:


### PR DESCRIPTION
Continuation of #7042

Batch backport of stack trace logging on signal issues:
- [4973](https://redmine.openinfosecfoundation.org/issues/4973)
- [5097](https://redmine.openinfosecfoundation.org/issues/5097)

Updates
- Rebase

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
