### PR TITLE
Coverity fixes v2

### DIFF
--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -42,6 +42,7 @@
 #include "util-unittest.h"
 
 #include "util-debug.h"
+#include "util-validate.h"
 #include "util-buffer.h"
 
 #include "output.h"
@@ -175,7 +176,8 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
     if (PKT_IS_IPV4(p)) {
         PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), dstip, sizeof(dstip));
-    } else if (PKT_IS_IPV6(p)) {
+    } else {
+        DEBUG_VALIDATE_BUG_ON(!(PKT_IS_IPV6(p)));
         PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), dstip, sizeof(dstip));
     }

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -152,9 +152,6 @@ static int DetectXbitMatchIPPair(Packet *p, const DetectXbitsData *xd)
             return DetectIPPairbitMatchUnset(p,xd);
         case DETECT_XBITS_CMD_TOGGLE:
             return DetectIPPairbitMatchToggle(p,xd);
-        default:
-            SCLogError(SC_ERR_UNKNOWN_VALUE, "unknown cmd %" PRIu32 "", xd->cmd);
-            return 0;
     }
     return 0;
 }
@@ -304,7 +301,6 @@ static int DetectXbitParse(DetectEngineCtx *de_ctx,
         case DETECT_XBITS_CMD_SET:
         case DETECT_XBITS_CMD_UNSET:
         case DETECT_XBITS_CMD_TOGGLE:
-        default:
             if (strlen(fb_name) == 0)
                 return -1;
             break;

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -813,6 +813,9 @@ Flow *FlowGetFlowFromHash(ThreadVars *tv, FlowLookupStruct *fls,
                 if (f->use_cnt == 0) {
                     if (prev_f == NULL) /* if we have no prev it means new_f is now our prev */
                         prev_f = new_f;
+                    // f got unlocked by TcpReuseReplace and will be unlocked again by
+                    // MoveToWorkQueue
+                    FromHashLockCMP(f);
                     MoveToWorkQueue(tv, fls, fb, f, prev_f); /* evict old flow */
                 }
                 if (new_f == NULL) {

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -338,7 +338,7 @@ void PacketPoolDestroy(void)
     PktPool *my_pool = GetThreadPacketPool();
 
 #ifdef DEBUG_VALIDATION
-    BUG_ON(my_pool->destroyed);
+    BUG_ON(my_pool && my_pool->destroyed);
 #endif /* DEBUG_VALIDATION */
 
     if (my_pool && my_pool->pending_pool != NULL) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None, not sure it deserves one

Describe changes: patches to make coverity happy
- Prevents a double unlock (by locking again) 
- Makes static code analyzer about a memory leak in xbits parsing (removing dead code for default switch cases) 
- Asserts all cases are covered in debuglog (`PKT_IS_IPV6` or `PKT_IS_IPV4`)
- fix possible null dereference in debug validation in `PacketPoolDestroy`

After this and #7131 (which I think is a real bug this one), there will be no more outstanding issues reported by coverity 

Replaces #7132 with review taken into account + new bug found by coverity meanwhile