### PR TITLE
smtp: bring input out of state to avoid complexity

### DIFF
--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -65,6 +65,11 @@ typedef struct SMTPString_ {
     TAILQ_ENTRY(SMTPString_) next;
 } SMTPString;
 
+typedef struct SMTPInput_ {
+    const uint8_t *data;
+    int32_t len;
+} SMTPInput;
+
 typedef struct SMTPTransaction_ {
     /** id of this tx, starting at 0 */
     uint64_t tx_id;
@@ -108,9 +113,6 @@ typedef struct SMTPState_ {
     uint64_t toserver_data_count;
     uint64_t toserver_last_data_stamp;
 
-    /* current input that is being parsed */
-    const uint8_t *input;
-    int32_t input_len;
     uint8_t direction;
 
     /* --parser details-- */


### PR DESCRIPTION
Create a structure to store input and input length for SMTP which only
consists of primary data types only. This removes the need to store
input in SMTPState and opens path to pass around input and input_len
freely without having to pass the entire SMTPState whenever input is needed.

The struct was created to save the state of input as it is to be used
by SMTPGetLine function in a loop with the updated values each time.

Remove input and input_len from SMTPState and update the tests where
the input_len was checked after parsing.

The pointer approach is shown in https://github.com/OISF/suricata/pull/7141 but it can be difficult to pass things around in Rust that way as there have to be certain updates made to input/input_len.
The idea is to originally have this SMTPInput struct on the Rust side, alloc it there, do stuff there and pass back the value to C if needed.