### PR TITLE
http: move xff logging to alert object

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -46,6 +46,7 @@ Logging changes
 - IKEv2 Eve logging changed, the event_type has become ``ike``. The fields ``errors`` and ``notify`` have moved to
   ``ike.ikev2.errors`` and ``ike.ikev2.notify``.
 - FTP DATA metadata for alerts are now logged in ``ftp_data`` instead of root.
+- Alert ``xff`` field is now logged as ``alert.xff`` for alerts instead of at the root.
 
 Other changes
 ~~~~~~~~~~~~~

--- a/src/output-json-alert.h
+++ b/src/output-json-alert.h
@@ -29,7 +29,7 @@
 
 void JsonAlertLogRegister(void);
 void AlertJsonHeader(void *ctx, const Packet *p, const PacketAlert *pa, JsonBuilder *js,
-                     uint16_t flags, JsonAddrInfo *addr);
+        uint16_t flags, JsonAddrInfo *addr, char *xff_buffer);
 
 #endif /* __OUTPUT_JSON_ALERT_H__ */
 

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -155,7 +155,7 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
             if ((pa->action & (ACTION_REJECT|ACTION_REJECT_DST|ACTION_REJECT_BOTH)) ||
                ((pa->action & ACTION_DROP) && EngineModeIsIPS()))
             {
-                AlertJsonHeader(NULL, p, pa, js, 0, &addr);
+                AlertJsonHeader(NULL, p, pa, js, 0, &addr, NULL);
                 logged = 1;
                 break;
             }
@@ -163,7 +163,7 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
         if (logged == 0) {
             if (p->alerts.drop.action != 0) {
                 const PacketAlert *pa = &p->alerts.drop;
-                AlertJsonHeader(NULL, p, pa, js, 0, &addr);
+                AlertJsonHeader(NULL, p, pa, js, 0, &addr, NULL);
             }
         }
     }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4860
but also https://redmine.openinfosecfoundation.org/issues/1369

Describe changes:
- http : move logged field xff from root to `alert.xff`

suricata-verify-pr: 796
https://github.com/OISF/suricata-verify/pull/796

Replaces #7051 with moving into alert instead of taking care of http stuff