### PR TITLE
output/stats: Use thread-aware log initializer

### DIFF
--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -395,7 +395,7 @@ static OutputInitResult OutputStatsLogInitSub(ConfNode *conf, OutputCtx *parent_
         return result;
     }
 
-    OutputStatsCtx *stats_ctx = SCMalloc(sizeof(OutputStatsCtx));
+    OutputStatsCtx *stats_ctx = SCCalloc(1, sizeof(OutputStatsCtx));
     if (unlikely(stats_ctx == NULL))
         return result;
 
@@ -440,7 +440,12 @@ static OutputInitResult OutputStatsLogInitSub(ConfNode *conf, OutputCtx *parent_
         return result;
     }
 
-    stats_ctx->file_ctx = ajt->file_ctx;
+    stats_ctx->file_ctx = LogFileEnsureExists(ajt->file_ctx, 1);
+    if (!stats_ctx->file_ctx) {
+        SCFree(stats_ctx);
+        SCFree(output_ctx);
+        return result;
+    }
 
     output_ctx->data = stats_ctx;
     output_ctx->DeInit = OutputStatsLogDeinitSub;


### PR DESCRIPTION
Issue: 5198

This commit corrects the log instance initializer within the stats
sub-logger to use the thread-aware LogFileEnsureExists function.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5198](https://redmine.openinfosecfoundation.org/issues/5198)

Describe changes:
- Use thread aware initializer (`LogFileEnsureExists`) for stats submodule


#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
