### PR TITLE
detect-content: error on single char hex pairs - v3

### DIFF
--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -111,6 +111,12 @@ int DetectContentDataParse(const char *keyword, const char *contentstr,
             if (str[i] == '|') {
                 bin_count++;
                 if (bin) {
+                    if (binpos > 0) {
+                        SCLogError(SC_ERR_INVALID_SIGNATURE,
+                                "Incomplete hex code in content - %s. Invalidating signature.",
+                                contentstr);
+                        goto error;
+                    }
                     bin = 0;
                 } else {
                     bin = 1;
@@ -3050,6 +3056,25 @@ static int DetectLongContentTest3(void)
     return !DetectLongContentTestCommon(sig, 1);
 }
 
+static int DetectBadBinContent(void)
+{
+    DetectEngineCtx *de_ctx = NULL;
+    de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    de_ctx->flags |= DE_QUIET;
+    FAIL_IF_NOT_NULL(DetectEngineAppendSig(
+            de_ctx, "alert tcp any any -> any any (msg:\"test\"; content:\"|a|\"; sid:1;)"));
+    FAIL_IF_NOT_NULL(DetectEngineAppendSig(
+            de_ctx, "alert tcp any any -> any any (msg:\"test\"; content:\"|aa b|\"; sid:1;)"));
+    FAIL_IF_NOT_NULL(DetectEngineAppendSig(
+            de_ctx, "alert tcp any any -> any any (msg:\"test\"; content:\"|aa bz|\"; sid:1;)"));
+    /* https://redmine.openinfosecfoundation.org/issues/5201 */
+    FAIL_IF_NOT_NULL(DetectEngineAppendSig(
+            de_ctx, "alert tcp any any -> any any (msg:\"test\"; content:\"|22 2 22|\"; sid:1;)"));
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
 /**
  * \brief this function registers unit tests for DetectContent
  */
@@ -3168,5 +3193,7 @@ static void DetectContentRegisterTests(void)
     UtRegisterTest("DetectLongContentTest1", DetectLongContentTest1);
     UtRegisterTest("DetectLongContentTest2", DetectLongContentTest2);
     UtRegisterTest("DetectLongContentTest3", DetectLongContentTest3);
+
+    UtRegisterTest("DetectBadBinContent", DetectBadBinContent);
 }
 #endif /* UNITTESTS */


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/7160

Changes from last PR:
- use DetectEngineAppendSig
- test |22 2 22| from ticket

Fix parsing of content like "|aa b cc|" which was parsed as "|aa bc|"
without error or warning. This will now fail out, requiring all hex
values to be 2 chars.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/5201

suricata-verify-pr: 792
