### PR TITLE
detect: do not try iponly match if sig needs flow

### DIFF
--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -1107,6 +1107,8 @@ void IPOnlyMatchPacket(ThreadVars *tv,
                     } else if ((s->flags & (SIG_FLAG_DP_ANY|SIG_FLAG_SP_ANY)) != (SIG_FLAG_DP_ANY|SIG_FLAG_SP_ANY)) {
                         SCLogDebug("port-less protocol and sig needs ports");
                         continue;
+                    } else if ((s->mask & SIG_MASK_REQUIRE_FLOW) != 0) {
+                        continue;
                     }
 
                     if (!IPOnlyMatchCompatSMs(tv, det_ctx, s, p)) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4972

Describe changes:
- detect: only apply ConfigApplyTx when relevant (like with a flow)

Completes #7126

But How come we are executing `IPOnlyMatchPacket` with a signature that has `s->mask & SIG_MASK_REQUIRE_FLOW` ?
Because it is a postmatch keyword ?