### PR TITLE
Sphinx syntax correction

### DIFF
--- a/doc/userguide/performance/tuning-considerations.rst
+++ b/doc/userguide/performance/tuning-considerations.rst
@@ -102,6 +102,7 @@ The memory used for those is set up and dedicated at start and is calculated
 as follows: 
 
 ::
+
  af-packet.threads X af-packet.ring-size X (default-packet-size + ~750 bytes)
 
 where ``af-packet.threads``, ``af-packet.ring-size``, ``default-packet-size`` 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
Per the contributing guide, no ticket needed.

Describe changes:
- Small Sphinx syntax change in the docs

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
