### PR TITLE
detect: not an iponly signature if it needs app-layer

### DIFF
--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -195,6 +195,10 @@ int SignatureIsIPOnly(DetectEngineCtx *de_ctx, const Signature *s)
     if (s->init_data->smlists[DETECT_SM_LIST_PMATCH] != NULL)
         return 0;
 
+    // may happen for 'config' keyword, postmatch
+    if (s->flags & SIG_FLAG_APPLAYER)
+        return 0;
+
     /* if flow dir is set we can't process it in ip-only */
     if (!(((s->flags & (SIG_FLAG_TOSERVER|SIG_FLAG_TOCLIENT)) == 0) ||
             (s->flags & (SIG_FLAG_TOSERVER|SIG_FLAG_TOCLIENT)) ==


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4972

Describe changes:
- detect: only apply ConfigApplyTx when relevant (like with a flow)

Completes #7126

Replaces #7180 with better fix suggested by victor