### PR TITLE
source: pcap timestamp microsecond consistency

### DIFF
--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -70,7 +70,7 @@ void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
 
     PKT_SET_SRC(p, PKT_SRC_WIRE);
     p->ts.tv_sec = h->ts.tv_sec;
-    p->ts.tv_usec = h->ts.tv_usec;
+    p->ts.tv_usec = h->ts.tv_usec % 1000000;
     SCLogDebug("p->ts.tv_sec %"PRIuMAX"", (uintmax_t)p->ts.tv_sec);
     p->datalink = ptv->datalink;
     p->pcap_cnt = ++pcap_g.cnt;

--- a/src/tests/fuzz/fuzz_predefpcap_aware.c
+++ b/src/tests/fuzz/fuzz_predefpcap_aware.c
@@ -113,7 +113,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     r = FPC_next(&pkts, &header, &pkt);
     p = PacketGetFromAlloc();
     p->ts.tv_sec = header.ts.tv_sec;
-    p->ts.tv_usec = header.ts.tv_usec;
+    p->ts.tv_usec = header.ts.tv_usec % 1000000;
     p->datalink = pkts.datalink;
     while (r > 0) {
         if (PacketCopyData(p, pkt, header.caplen) == 0) {
@@ -137,7 +137,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         r = FPC_next(&pkts, &header, &pkt);
         PACKET_RECYCLE(p);
         p->ts.tv_sec = header.ts.tv_sec;
-        p->ts.tv_usec = header.ts.tv_usec;
+        p->ts.tv_usec = header.ts.tv_usec % 1000000;
         p->datalink = pkts.datalink;
         pcap_cnt++;
         p->pcap_cnt = pcap_cnt;

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -154,7 +154,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     r = pcap_next_ex(pkts, &header, &pkt);
     p = PacketGetFromAlloc();
     p->ts.tv_sec = header->ts.tv_sec;
-    p->ts.tv_usec = header->ts.tv_usec;
+    p->ts.tv_usec = header->ts.tv_usec % 1000000;
     p->datalink = pcap_datalink(pkts);
     while (r > 0) {
         if (PacketCopyData(p, pkt, header->caplen) == 0) {
@@ -178,7 +178,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         r = pcap_next_ex(pkts, &header, &pkt);
         PACKET_RECYCLE(p);
         p->ts.tv_sec = header->ts.tv_sec;
-        p->ts.tv_usec = header->ts.tv_usec;
+        p->ts.tv_usec = header->ts.tv_usec % 1000000;
         p->datalink = pcap_datalink(pkts);
         pcap_cnt++;
         p->pcap_cnt = pcap_cnt;

--- a/src/tests/fuzz/fuzz_sigpcap_aware.c
+++ b/src/tests/fuzz/fuzz_sigpcap_aware.c
@@ -152,7 +152,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     r = FPC_next(&pkts, &header, &pkt);
     p = PacketGetFromAlloc();
     p->ts.tv_sec = header.ts.tv_sec;
-    p->ts.tv_usec = header.ts.tv_usec;
+    p->ts.tv_usec = header.ts.tv_usec % 1000000;
     p->datalink = pkts.datalink;
     while (r > 0) {
         if (PacketCopyData(p, pkt, header.caplen) == 0) {
@@ -176,7 +176,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         r = FPC_next(&pkts, &header, &pkt);
         PACKET_RECYCLE(p);
         p->ts.tv_sec = header.ts.tv_sec;
-        p->ts.tv_usec = header.ts.tv_usec;
+        p->ts.tv_usec = header.ts.tv_usec % 1000000;
         p->datalink = pkts.datalink;
         pcap_cnt++;
         p->pcap_cnt = pcap_cnt;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
none but https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44177

Describe changes:
- Make the pcaps timestamps be consistent : their microseconds number shall be less than 1 000 000
