### PR TITLE
smb: check on param parsing

### DIFF
--- a/rust/src/smb/ntlmssp_records.rs
+++ b/rust/src/smb/ntlmssp_records.rs
@@ -101,9 +101,9 @@ pub fn parse_ntlm_auth_record(i: &[u8]) -> IResult<&[u8], NTLMSSPAuthRecord> {
 
     // subtrack 12 as idenfier (8) and type (4) are cut before we are called
     // subtract 60 for the len/offset/maxlen fields above
-    let (i, _) = cond(nego_flags.1==1, |b| take(domain_blob_offset - (12 + 60))(b))(i)?;
+    let (i, _) = cond(nego_flags.1==1 && domain_blob_offset > 72, |b| take(domain_blob_offset - (12 + 60))(b))(i)?;
     // or 52 if we have no version
-    let (i, _) = cond(nego_flags.1==0, |b| take(domain_blob_offset - (12 + 52))(b))(i)?;
+    let (i, _) = cond(nego_flags.1==0 && domain_blob_offset > 64, |b| take(domain_blob_offset - (12 + 52))(b))(i)?;
 
     let (i, domain_blob) = take(domain_blob_len)(i)?;
     let (i, user_blob) = take(user_blob_len)(i)?;

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -20,7 +20,7 @@ use crate::smb::error::SmbError;
 use crate::smb::smb::*;
 use crate::smb::smb_records::*;
 use nom7::bytes::streaming::{tag, take};
-use nom7::combinator::{complete, cond, peek, rest};
+use nom7::combinator::{complete, cond, peek, rest, verify};
 use nom7::multi::many1;
 use nom7::number::streaming::{le_u8, le_u16, le_u32, le_u64};
 use nom7::IResult;
@@ -702,7 +702,7 @@ pub fn parse_smb_trans2_request_record(i: &[u8]) -> IResult<&[u8], SmbRequestTra
     let (i, _timeout) = le_u32(i)?;
     let (i, _reserved2) = take(2_usize)(i)?;
     let (i, param_cnt) = le_u16(i)?;
-    let (i, param_offset) = le_u16(i)?;
+    let (i, param_offset) = verify(le_u16, |&v| v <= (u16::MAX - param_cnt))(i)?;
     let (i, data_cnt) = le_u16(i)?;
     let (i, data_offset) = le_u16(i)?;
     let (i, _setup_cnt) = le_u8(i)?;

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -376,10 +376,14 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                                 None => {
                                     // try to find latest created file in case of chained commands
                                     let mut guid_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_FILENAME);
-                                    guid_key.msg_id = guid_key.msg_id - 1;
-                                    match state.ssn2vec_map.get(&guid_key) {
-                                        Some(n) => { n.to_vec() },
-                                        None => { b"<unknown>".to_vec()},
+                                    if guid_key.msg_id == 0 {
+                                        b"<unknown>".to_vec()
+                                    } else {
+                                        guid_key.msg_id = guid_key.msg_id - 1;
+                                        match state.ssn2vec_map.get(&guid_key) {
+                                            Some(n) => { n.to_vec() },
+                                            None => { b"<unknown>".to_vec()},
+                                        }
                                     }
                                 },
                             };


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44227
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44262

Describe changes:
- smb: check on param parsing so as not to overflow `u16` for the padding
- smb: underflow check for ntlmssp `domain_blob_offset`
