### PR TITLE
detect/flowbits: use strtok_r for parsing 

### DIFF
--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -45,9 +45,6 @@
 #include "util-unittest.h"
 #include "util-debug.h"
 
-#define PARSE_REGEX         "^([a-z]+)(?:,\\s*(.*))?"
-static DetectParseRegex parse_regex;
-
 #define MAX_TOKENS 100
 
 int DetectFlowbitMatch (DetectEngineThreadCtx *, Packet *,
@@ -72,8 +69,6 @@ void DetectFlowbitsRegister (void)
 #endif
     /* this is compatible to ip-only signatures */
     sigmatch_table[DETECT_FLOWBITS].flags |= SIGMATCH_IPONLY_COMPAT;
-
-    DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
 }
 
 static int FlowbitOrAddData(DetectEngineCtx *de_ctx, DetectFlowbitsData *cd, char *arrptr)

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -1423,6 +1423,35 @@ static int FlowBitsTestSig11(void)
 }
 
 /**
+ * \test FlowBitsTestSig12 is a test to check random arguments to
+ *  flowbits keyword are rejected
+ *  See https://redmine.openinfosecfoundation.org/issues/5154
+ *  \retval 1 on succces
+ *  \retval 0 on failure
+ */
+
+static int FlowBitsTestSig12(void)
+{
+    Signature *s = NULL;
+    DetectEngineCtx *de_ctx = NULL;
+
+    de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    de_ctx->flags |= DE_QUIET;
+
+    s = de_ctx->sig_list =
+            SigInit(de_ctx, "alert http any any -> any any (msg:\"flowbits with noalert option\"; "
+                            "flow:established,to_server; http.method; content:\"POST\"; "
+                            "flowbits:set,ET.whatever,asdfasdf; sid:7;)");
+    FAIL_IF_NOT_NULL(s);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+/**
  * \brief this function registers unit tests for FlowBits
  */
 void FlowBitsRegisterTests(void)
@@ -1439,5 +1468,6 @@ void FlowBitsRegisterTests(void)
     UtRegisterTest("FlowBitsTestSig09", FlowBitsTestSig09);
     UtRegisterTest("FlowBitsTestSig10", FlowBitsTestSig10);
     UtRegisterTest("FlowBitsTestSig11", FlowBitsTestSig11);
+    UtRegisterTest("FlowBitsTestSig12", FlowBitsTestSig12);
 }
 #endif /* UNITTESTS */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5154

Previous PR: https://github.com/OISF/suricata/pull/7196

Changes since v1:
- Special handling for flowbits OR op with spaces
- Test for bug 5154
- Removal of dead pcre regex code