### PR TITLE
userguide: document packet alert queue - v1

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -145,6 +145,21 @@ is: pass, drop, reject, alert.
 This means a pass rule is considered before a drop rule, a drop rule
 before a reject rule and so on.
 
+Packet alert queue settings
+---------------------------
+
+It is possible to configure the size of the alerts queue that is used to append alerts triggered by each packet.
+
+This will influence how many alerts would be perceived to have matched against a given packet.
+The default value is 15. If an invalid setting or no value is provided, the engine will fall
+back to the default.
+
+::
+
+    #Define maximum number of possible alerts that can be triggered for the same
+    # packet. Default is 15
+    packet-alert-max: 15
+
 Splitting configuration in multiple files
 -----------------------------------------
 

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -160,6 +160,30 @@ back to the default.
     # packet. Default is 15
     packet-alert-max: 15
 
+Impact on engine behavior
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Internally, the Suricata engine represents each packet with a data structure that has its own alert queue. The max size
+of the queue is defined by ``packet-alert-max``. The same rule can be triggered by the same packet multiple times. As
+long as there is still space in the alert queue, those are appended. Note that ``noalert`` rules currently are also appended to the packet alert queue.
+
+Rules are queued by priority, higher priority rules may replace lower priority ones that may have been triggered earlier, if Suricata reaches ``packet-alert-max`` for a given packet (a.k.a. packet alert queue overflow).
+
+Packet alert queue overflow
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once the alert queue reaches its max size, we potentially are at packet alert queue overflow and new alerts are only appended in case their rules have a higher priority id (this is the internal id attributed by the engine, not the signature id).
+
+This may happen in two different situations:
+
+- a higher priority rule is triggered after a lower priority one: the lower priority rule is replaced in the queue;
+- a lower priority rule is triggered: the rule is just discarded.
+
+.. note ::
+
+    This behavior does not mean that triggered ``drop`` rules would have their action ignored, in IPS mode.
+
+
 Splitting configuration in multiple files
 -----------------------------------------
 

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -183,6 +183,23 @@ This may happen in two different situations:
 
     This behavior does not mean that triggered ``drop`` rules would have their action ignored, in IPS mode.
 
+Discarded Alerts Stats
+~~~~~~~~~~~~~~~~~~~~~~
+
+Both scenarios previously described will be logged as *detect.alert_queue_overflow* in the stats logs (stats.log and eve-log -- event type stats).
+
+::
+
+    Date: 4/6/2022 -- 17:18:08 (uptime: 0d, 00h 00m 00s)
+    ------------------------------------------------------------------------------------
+    Counter                                       | TM Name                   | Value
+    ------------------------------------------------------------------------------------
+    detect.alert                                  | Total                     | 3
+    detect.alert_queue_overflow                   | Total                     | 4
+
+In this example from a stats.log, we read that 7 alerts were generated: 3 were kept in the packet queue while 4
+were discarded due to packets having reached max size for the alert queue.
+
 
 Splitting configuration in multiple files
 -----------------------------------------


### PR DESCRIPTION
This work goes with 
- packet alert max and packet alert queue patches (https://github.com/OISF/suricata/pull/7211)
- stats log about discarded alerts (https://github.com/OISF/suricata/pull/7209)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
- https://redmine.openinfosecfoundation.org/issues/5179
- https://redmine.openinfosecfoundation.org/issues/5178
- https://redmine.openinfosecfoundation.org/issues/4207

Describe changes:
- Add a section about packet alert max config
- Add subsection about packet alert queue behavior (especially when an overflow happens)
- Add subsection about discarded alerts in case of packet alert queue overflow

