### PR TITLE
dns: store transaction in a VecDeque

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -311,7 +311,7 @@ pub struct DNSState {
     pub tx_id: u64,
 
     // Transactions.
-    pub transactions: Vec<DNSTransaction>,
+    pub transactions: VecDeque<DNSTransaction>,
 
     pub events: u16,
 
@@ -322,7 +322,8 @@ pub struct DNSState {
 
 impl State<DNSTransaction> for DNSState {
     fn get_transactions(&self) -> &[DNSTransaction] {
-        &self.transactions
+        let (r, _) = self.transactions.as_slices();
+        return r;
     }
 }
 
@@ -397,7 +398,7 @@ impl DNSState {
 
                 let mut tx = self.new_tx();
                 tx.request = Some(request);
-                self.transactions.push(tx);
+                self.transactions.push_back(tx);
 
                 if z_flag {
                     SCLogDebug!("Z-flag set on DNS response");
@@ -441,7 +442,7 @@ impl DNSState {
                     }
                 }
                 tx.response = Some(response);
-                self.transactions.push(tx);
+                self.transactions.push_back(tx);
 
                 if z_flag {
                     SCLogDebug!("Z-flag set on DNS response");


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44307

Describe changes:
- dns: store transaction in a VecDeque

@jasonish what do you think ?
Could you test the perf of this ?