### PR TITLE
output: fix integer warnings

### DIFF
--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -204,7 +204,7 @@ void JsonDNP3LogResponse(JsonBuilder *js, DNP3Transaction *dnp3tx)
     jb_close(js);
 
     jb_open_object(js, "iin");
-    JsonDNP3LogIin(js, dnp3tx->response_iin.iin1 << 8 | dnp3tx->response_iin.iin2);
+    JsonDNP3LogIin(js, (uint16_t)(dnp3tx->response_iin.iin1 << 8 | dnp3tx->response_iin.iin2));
     jb_close(js);
 }
 

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -202,7 +202,7 @@ JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff, const bool
  *  \brief Write meta data on a single line json record
  */
 static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const File *ff,
-        uint32_t dir, OutputJsonCtx *eve_ctx)
+        uint8_t dir, OutputJsonCtx *eve_ctx)
 {
     HttpXFFCfg *xff_cfg = aft->filelog_ctx->xff_cfg != NULL ?
         aft->filelog_ctx->xff_cfg : aft->filelog_ctx->parent_xff_cfg;;

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -76,8 +76,13 @@ static void EveFTPLogCommand(Flow *f, FTPTransaction *tx, JsonBuilder *jb)
         TAILQ_FOREACH(response, &tx->response_list, next) {
             /* handle multiple lines within the response, \r\n delimited */
             uint8_t *where = response->str;
-            uint16_t length = response->len ? response->len -1 : 0;
+            uint16_t length = 0;
             uint16_t pos;
+            if (response->len > 0 && response->len <= UINT16_MAX) {
+                length = (uint16_t)response->len - 1;
+            } else if (response->len > UINT16_MAX) {
+                length = UINT16_MAX;
+            }
             while ((pos = JsonGetNextLineFromBuffer((const char *)where, length)) != UINT16_MAX) {
                 uint16_t offset = 0;
                 /* Try to find a completion code for this line */

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -64,7 +64,7 @@ typedef enum OutputEngineInfo_ {
 
 typedef struct OutputStatsCtx_ {
     LogFileCtx *file_ctx;
-    uint32_t flags; /** Store mode */
+    uint8_t flags; /** Store mode */
 } OutputStatsCtx;
 
 typedef struct JsonStatsLogThread_ {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4516
https://redmine.openinfosecfoundation.org/issues/5244

Describe changes:
- Fix integer warnings `-Wimplicit-int-conversion` for output files

Part of #7006 as #7107 was

Modifies #7120 to only have the output changes for now