### PR TITLE
detect: config checks alstate before getting tx

### DIFF
--- a/src/detect-config.c
+++ b/src/detect-config.c
@@ -89,6 +89,9 @@ void DetectConfigRegister(void)
 static void ConfigApplyTx(Flow *f,
         const uint64_t tx_id, const DetectConfigData *config)
 {
+    if (f->alstate == NULL) {
+        return;
+    }
     void *tx = AppLayerParserGetTx(f->proto, f->alproto, f->alstate, tx_id);
     if (tx) {
         AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, f->alproto, tx);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4972

Describe changes:
- detect: only apply ConfigApplyTx when relevant (like with a flow)

Completes #7191 which fixed https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=43733 but not the variant https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44906