### PR TITLE
eve/stats: Fix ASAN-detected overflow

### DIFF
--- a/src/output-json-common.c
+++ b/src/output-json-common.c
@@ -53,7 +53,7 @@ OutputJsonThreadCtx *CreateEveThreadCtx(ThreadVars *t, OutputJsonCtx *ctx)
         goto error;
     }
 
-    thread->file_ctx = LogFileEnsureExists(ctx->file_ctx, t->id);
+    thread->file_ctx = LogFileEnsureExists(ctx->file_ctx);
     if (!thread->file_ctx) {
         goto error;
     }
@@ -119,7 +119,7 @@ TmEcode JsonLogThreadInit(ThreadVars *t, const void *initdata, void **data)
     }
 
     thread->ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->ctx->file_ctx, t->id);
+    thread->file_ctx = LogFileEnsureExists(thread->ctx->file_ctx);
     if (!thread->file_ctx) {
         goto error_exit;
     }

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -395,7 +395,7 @@ static OutputInitResult OutputStatsLogInitSub(ConfNode *conf, OutputCtx *parent_
         return result;
     }
 
-    OutputStatsCtx *stats_ctx = SCMalloc(sizeof(OutputStatsCtx));
+    OutputStatsCtx *stats_ctx = SCCalloc(1, sizeof(OutputStatsCtx));
     if (unlikely(stats_ctx == NULL))
         return result;
 

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -344,7 +344,7 @@ static TmEcode JsonStatsLogThreadInit(ThreadVars *t, const void *initdata, void 
     /* Use the Output Context (file pointer and mutex) */
     aft->statslog_ctx = ((OutputCtx *)initdata)->data;
 
-    aft->file_ctx = LogFileEnsureExists(aft->statslog_ctx->file_ctx, t->id);
+    aft->file_ctx = LogFileEnsureExists(aft->statslog_ctx->file_ctx);
     if (!aft->file_ctx) {
         goto error_exit;
     }

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -440,7 +440,14 @@ static OutputInitResult OutputStatsLogInitSub(ConfNode *conf, OutputCtx *parent_
         return result;
     }
 
-    stats_ctx->file_ctx = ajt->file_ctx;
+    SCLogDebug("Preparing file context for stats submodule logger");
+    /* Share output slot with thread 1 */
+    stats_ctx->file_ctx = LogFileEnsureExists(ajt->file_ctx);
+    if (!stats_ctx->file_ctx) {
+        SCFree(stats_ctx);
+        SCFree(output_ctx);
+        return result;
+    }
 
     output_ctx->data = stats_ctx;
     output_ctx->DeInit = OutputStatsLogDeinitSub;

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -1,5 +1,5 @@
 /* vi: set et ts=4: */
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -322,6 +322,33 @@ static void SCLogFileClose(LogFileCtx *log_ctx)
     SCMutexUnlock(&log_ctx->fp_mutex);
 }
 
+static char ThreadSlotHashCompareFunc(
+        void *data1, uint16_t datalen1, void *data2, uint16_t datalen2)
+{
+    ThreadSlotHashEntry *p1 = (ThreadSlotHashEntry *)data1;
+    ThreadSlotHashEntry *p2 = (ThreadSlotHashEntry *)data2;
+
+    if (p1 == NULL || p2 == NULL)
+        return 0;
+
+    return p1->thread_id == p2->thread_id;
+}
+static uint32_t ThreadSlotHashFunc(HashTable *ht, void *data, uint16_t datalen)
+{
+    const ThreadSlotHashEntry *ent = (ThreadSlotHashEntry *)data;
+
+    return ent->thread_id % ht->array_size;
+}
+
+static void ThreadSlotHashFreeFunc(void *data)
+{
+    ThreadSlotHashEntry *thread_ent = (ThreadSlotHashEntry *)data;
+
+    if (thread_ent) {
+        SCFree(thread_ent);
+    }
+}
+
 bool SCLogOpenThreadedFile(
         const char *log_path, const char *append, LogFileCtx *parent_ctx, int slot_count)
 {
@@ -329,6 +356,12 @@ bool SCLogOpenThreadedFile(
         if (!parent_ctx->threads) {
             SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate threads container");
             return false;
+        }
+
+        parent_ctx->threads->ht = HashTableInit(
+                255, ThreadSlotHashFunc, ThreadSlotHashCompareFunc, ThreadSlotHashFreeFunc);
+        if (!parent_ctx->threads->ht) {
+            FatalError(SC_ERR_HASH_TABLE_INIT, "Unable to initialize thread/slot table");
         }
 
         parent_ctx->threads->append = SCStrdup(append == NULL ? DEFAULT_LOG_MODE_APPEND : append);
@@ -361,6 +394,9 @@ error_exit:
         }
         if (parent_ctx->threads->append) {
             SCFree(parent_ctx->threads->append);
+        }
+        if (parent_ctx->threads->ht) {
+            HashTableFree(parent_ctx->threads->ht);
         }
         SCFree(parent_ctx->threads);
         parent_ctx->threads = NULL;
@@ -842,6 +878,9 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
         SCFree(lf_ctx->threads->lf_slots);
         if (lf_ctx->threads->append)
             SCFree(lf_ctx->threads->append);
+        if (lf_ctx->threads->ht) {
+            HashTableFree(lf_ctx->threads->ht);
+        }
         SCFree(lf_ctx->threads);
     } else {
         if (lf_ctx->type != LOGFILE_TYPE_PLUGIN) {

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -371,6 +371,7 @@ bool SCLogOpenThreadedFile(
         }
 
         parent_ctx->threads->slot_count = slot_count;
+        parent_ctx->threads->last_slot = 0;
         parent_ctx->threads->lf_slots = SCCalloc(slot_count, sizeof(LogFileCtx *));
         if (!parent_ctx->threads->lf_slots) {
             SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate thread slots");
@@ -684,61 +685,103 @@ LogFileCtx *LogFileNewCtx(void)
     return lf_ctx;
 }
 
+/** \brief LogFileThread2Slot() Return a file slot
+ * \retval int file slot for caller
+ *
+ * This function returns the file slot for the calling thread.
+ * Each thread -- identified by its operating system thread-id -- has its
+ * own slot that includes a file pointer.
+ */
+static int LogFileThread2Slot(LogThreadedFileCtx *parent)
+{
+    ThreadSlotHashEntry thread_hash_entry;
+
+    /* Check hash table for thread id*/
+    thread_hash_entry.thread_id = SCGetThreadIdLong();
+    ThreadSlotHashEntry *ent =
+            HashTableLookup(parent->ht, &thread_hash_entry, sizeof(thread_hash_entry));
+
+    if (ent) {
+        return ent->slot;
+    }
+
+    ent = SCCalloc(1, sizeof(*ent));
+    if (!ent) {
+        FatalError(SC_ERR_HASH_ADD, "Unable to allocate thread/slot entry");
+    }
+    ent->thread_id = thread_hash_entry.thread_id;
+    ent->slot = ++parent->last_slot;
+    SCLogDebug("Trying to add thread %ld to slot %d", ent->thread_id, ent->slot);
+    if (0 != HashTableAdd(parent->ht, ent, 0)) {
+        FatalError(SC_ERR_HASH_ADD, "Unable to add thread/slot mapping");
+    }
+    return ent->slot;
+}
+
 /** \brief LogFileEnsureExists() Ensure a log file context for the thread exists
  * \param parent_ctx
- * \param thread_id
  * \retval LogFileCtx * pointer if successful; NULL otherwise
  */
-LogFileCtx *LogFileEnsureExists(LogFileCtx *parent_ctx, int thread_id)
+LogFileCtx *LogFileEnsureExists(LogFileCtx *parent_ctx)
 {
     /* threaded output disabled */
     if (!parent_ctx->threaded)
         return parent_ctx;
 
-    SCLogDebug("Adding reference %d to file ctx %p", thread_id, parent_ctx);
     SCMutexLock(&parent_ctx->threads->mutex);
-    /* are there enough context slots already */
-    if (thread_id < parent_ctx->threads->slot_count) {
-        /* has it been opened yet? */
-        if (!parent_ctx->threads->lf_slots[thread_id]) {
-            SCLogDebug("Opening new file for %d reference to file ctx %p", thread_id, parent_ctx);
-            LogFileNewThreadedCtx(parent_ctx, parent_ctx->filename, parent_ctx->threads->append, thread_id);
+    /* Find this thread's slot */
+    int slot = LogFileThread2Slot(parent_ctx->threads);
+    SCLogDebug("Adding reference for thread %ld [slot %d] to file %s [ctx %p]", SCGetThreadIdLong(),
+            slot, parent_ctx->filename, parent_ctx);
+
+    /* Add slots if necessary */
+    if (slot >= parent_ctx->threads->slot_count) {
+        /* ensure there's a slot for the caller */
+        int new_size = MAX(parent_ctx->threads->slot_count << 1, slot + 1);
+        SCLogDebug("Increasing slot count; current %d, trying %d", parent_ctx->threads->slot_count,
+                new_size);
+        LogFileCtx **new_array =
+                SCRealloc(parent_ctx->threads->lf_slots, new_size * sizeof(LogFileCtx *));
+        if (new_array == NULL) {
+            /* Try one more time */
+            SCLogDebug("Unable to increase file context array size to %d; trying %d", new_size,
+                    slot + 1);
+            new_size = slot + 1;
+            new_array = SCRealloc(parent_ctx->threads->lf_slots, new_size * sizeof(LogFileCtx *));
         }
-        SCMutexUnlock(&parent_ctx->threads->mutex);
-        SCLogDebug("Existing file for %d reference to file ctx %p", thread_id, parent_ctx);
-        return parent_ctx->threads->lf_slots[thread_id];
+
+        if (new_array == NULL) {
+            SCMutexUnlock(&parent_ctx->threads->mutex);
+            SCLogError(
+                    SC_ERR_MEM_ALLOC, "Unable to increase file context array size to %d", new_size);
+            return NULL;
+        }
+
+        parent_ctx->threads->lf_slots = new_array;
+        /* initialize newly added slots */
+        for (int i = parent_ctx->threads->slot_count; i < new_size; i++) {
+            parent_ctx->threads->lf_slots[i] = NULL;
+        }
+        parent_ctx->threads->slot_count = new_size;
     }
 
-    /* ensure there's a slot for the caller */
-    int new_size = MAX(parent_ctx->threads->slot_count << 1, thread_id + 1);
-    SCLogDebug("Increasing slot count; current %d, trying %d",
-            parent_ctx->threads->slot_count, new_size);
-    LogFileCtx **new_array = SCRealloc(parent_ctx->threads->lf_slots, new_size * sizeof(LogFileCtx *));
-    if (new_array == NULL) {
-        /* Try one more time */
-        SCLogDebug("Unable to increase file context array size to %d; trying %d",
-                new_size, thread_id + 1);
-        new_size = thread_id + 1;
-        new_array = SCRealloc(parent_ctx->threads->lf_slots, new_size * sizeof(LogFileCtx *));
+    /* has it been opened yet? */
+    if (!parent_ctx->threads->lf_slots[slot]) {
+        SCLogDebug("Opening new file for thread/slot %d to file %s [ctx %p]", slot,
+                parent_ctx->filename, parent_ctx);
+        if (!LogFileNewThreadedCtx(
+                    parent_ctx, parent_ctx->filename, parent_ctx->threads->append, slot))
+            BUG_ON(parent_ctx->threads->lf_slots[slot] != NULL);
     }
-
-    if (new_array == NULL) {
-        SCMutexUnlock(&parent_ctx->threads->mutex);
-        SCLogError(SC_ERR_MEM_ALLOC, "Unable to increase file context array size to %d", new_size);
-        return NULL;
-    }
-
-    parent_ctx->threads->lf_slots = new_array;
-    /* initialize newly added slots */
-    for (int i = parent_ctx->threads->slot_count; i < new_size; i++) {
-        parent_ctx->threads->lf_slots[i] = NULL;
-    }
-    parent_ctx->threads->slot_count = new_size;
-    LogFileNewThreadedCtx(parent_ctx, parent_ctx->filename, parent_ctx->threads->append, thread_id);
-
     SCMutexUnlock(&parent_ctx->threads->mutex);
 
-    return parent_ctx->threads->lf_slots[thread_id];
+    if (sc_log_global_log_level >= SC_LOG_DEBUG) {
+        if (parent_ctx->threads->lf_slots[slot])
+            SCLogDebug("Existing file for thread/slot %d reference to file %s [ctx %p]", slot,
+                    parent_ctx->filename, parent_ctx);
+    }
+
+    return parent_ctx->threads->lf_slots[slot];
 }
 
 /** \brief LogFileThreadedName() Create file name for threaded EVE storage
@@ -789,13 +832,14 @@ static bool LogFileThreadedName(
  * \param parent_ctx
  * \param log_path
  * \param append
- * \param thread_id
+ * \param slot
  */
-static bool LogFileNewThreadedCtx(LogFileCtx *parent_ctx, const char *log_path, const char *append, int thread_id)
+static bool LogFileNewThreadedCtx(
+        LogFileCtx *parent_ctx, const char *log_path, const char *append, int slot)
 {
     LogFileCtx *thread = SCCalloc(1, sizeof(LogFileCtx));
     if (!thread) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate thread file context slot %d", thread_id);
+        SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate thread file context slot %d", slot);
         return false;
     }
 
@@ -813,8 +857,7 @@ static bool LogFileNewThreadedCtx(LogFileCtx *parent_ctx, const char *log_path, 
         }
         thread->filename = SCStrdup(fname);
         if (!thread->filename) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Unable to duplicate filename for context slot %d",
-                    thread_id);
+            SCLogError(SC_ERR_MEM_ALLOC, "Unable to duplicate filename for context slot %d", slot);
             goto error;
         }
         thread->is_regular = true;
@@ -823,13 +866,13 @@ static bool LogFileNewThreadedCtx(LogFileCtx *parent_ctx, const char *log_path, 
         OutputRegisterFileRotationFlag(&thread->rotation_flag);
     } else if (parent_ctx->type == LOGFILE_TYPE_PLUGIN) {
         thread->plugin.plugin->ThreadInit(
-                thread->plugin.init_data, thread_id, &thread->plugin.thread_data);
+                thread->plugin.init_data, slot, &thread->plugin.thread_data);
     }
     thread->threaded = false;
     thread->parent = parent_ctx;
-    thread->id = thread_id;
+    thread->slot = slot;
 
-    parent_ctx->threads->lf_slots[thread_id] = thread;
+    parent_ctx->threads->lf_slots[slot] = thread;
     return true;
 
 error:
@@ -842,7 +885,7 @@ error:
     if (thread) {
         SCFree(thread);
     }
-    parent_ctx->threads->lf_slots[thread_id] = NULL;
+    parent_ctx->threads->lf_slots[slot] = NULL;
     return false;
 }
 
@@ -889,7 +932,7 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
             }
             if (lf_ctx->parent) {
                 SCMutexLock(&lf_ctx->parent->threads->mutex);
-                lf_ctx->parent->threads->lf_slots[lf_ctx->id] = NULL;
+                lf_ctx->parent->threads->lf_slots[lf_ctx->slot] = NULL;
                 SCMutexUnlock(&lf_ctx->parent->threads->mutex);
             }
         }

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -26,6 +26,7 @@
 
 #include "conf.h"            /* ConfNode   */
 #include "util-buffer.h"
+#include "util-hash.h"
 
 #ifdef HAVE_LIBHIREDIS
 #include "util-log-redis.h"
@@ -46,11 +47,18 @@ typedef struct SyslogSetup_ {
     int alert_syslog_level;
 } SyslogSetup;
 
+typedef struct ThreadSlotHashEntry_ {
+    uint64_t thread_id;
+    int slot; /* table slot */
+} ThreadSlotHashEntry;
+
 struct LogFileCtx_;
 typedef struct LogThreadedFileCtx_ {
-    int slot_count;
     SCMutex mutex;
-    struct LogFileCtx_ **lf_slots;
+    int slot_count;                /* Allocated slot count */
+    struct LogFileCtx_ **lf_slots; /* Slots */
+    int last_slot;                 /* Last slot allocated */
+    HashTable *ht;
     char *append;
 } LogThreadedFileCtx;
 

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -97,7 +97,7 @@ typedef struct LogFileCtx_ {
     /** When threaded, track of the parent and thread id */
     bool threaded;
     struct LogFileCtx_ *parent;
-    int id;
+    int slot;
 
     /** the type of file */
     enum LogFileType type;
@@ -174,7 +174,7 @@ LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);
 int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer);
 
-LogFileCtx *LogFileEnsureExists(LogFileCtx *lf_ctx, int thread_id);
+LogFileCtx *LogFileEnsureExists(LogFileCtx *lf_ctx);
 int SCConfLogOpenGeneric(ConfNode *conf, LogFileCtx *, const char *, int);
 int SCConfLogReopen(LogFileCtx *);
 bool SCLogOpenThreadedFile(


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5198](https://redmine.openinfosecfoundation.org/issues/5198)

The buffer overflow occurred due to the stats output not being set up with a valid context useful for threaded output. The stats output is created by the main thread - before the stats thread or any other Suricata thread is created.

The hash table was introduced to provide unique mappings for the thread to thread-slot relationship to guarantee that any thread using `LogFileEnsureExists` uses the proper slot.

Describe changes:
- Hashtable for thread/file slot mappings
- Ensure slot exists for stats thread

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
