### PR TITLE
fuzz: store transaction in a VecDeque

### DIFF
--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -150,7 +150,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
                 return 0;
             }
             memcpy(isolatedBuffer, albuffer, alnext - albuffer);
-            (void) AppLayerParserParse(NULL, alp_tctx, f, f->alproto, flags, isolatedBuffer, alnext - albuffer);
+            size_t datalen = alnext - albuffer;
+            if (datalen > 0xFFFF) {
+                datalen = 0xFFFF;
+            }
+            (void) AppLayerParserParse(NULL, alp_tctx, f, f->alproto, flags, isolatedBuffer, datalen);
             free(isolatedBuffer);
             if (FlowChangeProto(f)) {
                 // exits if a protocol change is requested


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44307

Describe changes:
- fuzz: only parses 65536 bytes a time

Replaces #7217 

Is this right @jasonish ?