### PR TITLE
Warnint util 4516 v9.1

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1845,7 +1845,7 @@ int AppLayerProtoDetectSetup(void)
     memset(&alpd_ctx, 0, sizeof(alpd_ctx));
 
     uint16_t spm_matcher = SinglePatternMatchDefaultMatcher();
-    uint16_t mpm_matcher = PatternMatchDefaultMatcher();
+    uint8_t mpm_matcher = PatternMatchDefaultMatcher();
 
     alpd_ctx.spm_global_thread_ctx = SpmInitGlobalThreadCtx(spm_matcher);
     if (alpd_ctx.spm_global_thread_ctx == NULL) {

--- a/src/app-layer-frames.c
+++ b/src/app-layer-frames.c
@@ -70,7 +70,7 @@ Frame *FrameGetByIndex(Frames *frames, const uint32_t idx)
         FrameDebug("get_by_idx(s)", frames, frame);
         return frame;
     } else {
-        const uint16_t o = idx - FRAMES_STATIC_CNT;
+        const uint32_t o = idx - FRAMES_STATIC_CNT;
         Frame *frame = &frames->dframes[o];
         FrameDebug("get_by_idx(d)", frames, frame);
         return frame;

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1256,7 +1256,7 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
     void *alstate = NULL;
     uint64_t p_tx_cnt = 0;
     uint32_t consumed = input_len;
-    const int direction = (flags & STREAM_TOSERVER) ? 0 : 1;
+    const uint8_t direction = (flags & STREAM_TOSERVER) ? 0 : 1;
 
     /* we don't have the parser registered for this protocol */
     if (p->StateAlloc == NULL)

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -345,7 +345,7 @@ static int TCPProtoDetect(ThreadVars *tv,
 {
     AppProto *alproto;
     AppProto *alproto_otherdir;
-    int direction = (flags & STREAM_TOSERVER) ? 0 : 1;
+    uint8_t direction = (flags & STREAM_TOSERVER) ? 0 : 1;
 
     if (flags & STREAM_TOSERVER) {
         alproto = &f->alproto_ts;
@@ -651,7 +651,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         goto end;
     }
 
-    const int direction = (flags & STREAM_TOSERVER) ? 0 : 1;
+    const uint8_t direction = (flags & STREAM_TOSERVER) ? 0 : 1;
 
     if (flags & STREAM_TOSERVER) {
         alproto = f->alproto_ts;

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -853,10 +853,10 @@ int SignatureHasStreamContent(const Signature *s)
  *
  *  \retval mpm algo value
  */
-uint16_t PatternMatchDefaultMatcher(void)
+uint8_t PatternMatchDefaultMatcher(void)
 {
     const char *mpm_algo;
-    uint16_t mpm_algo_val = mpm_default_matcher;
+    uint8_t mpm_algo_val = mpm_default_matcher;
 
     /* Get the mpm algo defined in config file by the user */
     if ((ConfGet("mpm-algo", &mpm_algo)) == 1) {

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -43,7 +43,7 @@ int DetectMpmPrepareBuiltinMpms(DetectEngineCtx *de_ctx);
 
 uint32_t PatternStrength(uint8_t *, uint16_t);
 
-uint16_t PatternMatchDefaultMatcher(void);
+uint8_t PatternMatchDefaultMatcher(void);
 uint32_t DnsQueryPatternSearch(DetectEngineThreadCtx *det_ctx, uint8_t *buffer, uint32_t buffer_len, uint8_t flags);
 
 void PatternMatchPrepare(MpmCtx *, uint16_t);

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -300,8 +300,8 @@ int FlowForceReassemblyNeedReassembly(Flow *f)
     }
 
     TcpSession *ssn = (TcpSession *)f->protoctx;
-    int client = StreamNeedsReassembly(ssn, STREAM_TOSERVER);
-    int server = StreamNeedsReassembly(ssn, STREAM_TOCLIENT);
+    uint8_t client = StreamNeedsReassembly(ssn, STREAM_TOSERVER);
+    uint8_t server = StreamNeedsReassembly(ssn, STREAM_TOCLIENT);
 
     /* if state is not fully closed we assume that we haven't fully
      * inspected the app layer state yet */

--- a/src/flow.c
+++ b/src/flow.c
@@ -1159,7 +1159,8 @@ void FlowUpdateState(Flow *f, const enum FlowState s)
 {
     if (s != f->flow_state) {
         /* set the state */
-        f->flow_state = s;
+        // Explicit cast from the enum type to the compact version
+        f->flow_state = (FlowStateType)s;
 
         /* update timeout policy and value */
         const uint32_t timeout_policy = FlowGetTimeoutPolicy(f);

--- a/src/host.c
+++ b/src/host.c
@@ -34,6 +34,7 @@
 #include "util-random.h"
 #include "util-misc.h"
 #include "util-byte.h"
+#include "util-validate.h"
 
 #include "host-queue.h"
 
@@ -174,8 +175,10 @@ void HostClearMemory(Host *h)
 void HostInitConfig(bool quiet)
 {
     SCLogDebug("initializing host engine...");
-    if (HostStorageSize() > 0)
-        g_host_size = sizeof(Host) + HostStorageSize();
+    if (HostStorageSize() > 0) {
+        DEBUG_VALIDATE_BUG_ON(sizeof(Host) + HostStorageSize() > UINT16_MAX);
+        g_host_size = (uint16_t)(sizeof(Host) + HostStorageSize());
+    }
 
     memset(&host_config,  0, sizeof(host_config));
     //SC_ATOMIC_INIT(flow_flags);

--- a/src/ippair.c
+++ b/src/ippair.c
@@ -33,6 +33,7 @@
 #include "util-random.h"
 #include "util-misc.h"
 #include "util-byte.h"
+#include "util-validate.h"
 
 #include "ippair-queue.h"
 
@@ -168,8 +169,10 @@ void IPPairClearMemory(IPPair *h)
 void IPPairInitConfig(bool quiet)
 {
     SCLogDebug("initializing ippair engine...");
-    if (IPPairStorageSize() > 0)
-        g_ippair_size = sizeof(IPPair) + IPPairStorageSize();
+    if (IPPairStorageSize() > 0) {
+        DEBUG_VALIDATE_BUG_ON(sizeof(IPPair) + IPPairStorageSize() > UINT16_MAX);
+        g_ippair_size = (uint16_t)(sizeof(IPPair) + IPPairStorageSize());
+    }
 
     memset(&ippair_config,  0, sizeof(ippair_config));
     //SC_ATOMIC_INIT(flow_flags);

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -800,7 +800,7 @@ static int StreamTcpReassembleRawCheckLimit(const TcpSession *ssn,
 /**
  *  \brief see what if any work the TCP session still needs
  */
-int StreamNeedsReassembly(const TcpSession *ssn, uint8_t direction)
+uint8_t StreamNeedsReassembly(const TcpSession *ssn, uint8_t direction)
 {
     const TcpStream *stream = NULL;
 #ifdef DEBUG

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -175,7 +175,7 @@ enum {
 };
 
 TmEcode StreamTcp (ThreadVars *, Packet *, void *, PacketQueueNoLock *);
-int StreamNeedsReassembly(const TcpSession *ssn, uint8_t direction);
+uint8_t StreamNeedsReassembly(const TcpSession *ssn, uint8_t direction);
 TmEcode StreamTcpThreadInit(ThreadVars *, void *, void **);
 TmEcode StreamTcpThreadDeinit(ThreadVars *tv, void *data);
 void StreamTcpRegisterTests (void);

--- a/src/util-byte.c
+++ b/src/util-byte.c
@@ -182,7 +182,7 @@ int ByteExtractUint16(uint16_t *res, int e, uint16_t len, const uint8_t *bytes)
     return ret;
 }
 
-int ByteExtractString(uint64_t *res, int base, uint16_t len, const char *str, bool strict)
+int ByteExtractString(uint64_t *res, int base, size_t len, const char *str, bool strict)
 {
     const char *ptr = str;
     char *endptr = NULL;
@@ -231,12 +231,12 @@ int ByteExtractString(uint64_t *res, int base, uint16_t len, const char *str, bo
     return (endptr - ptr);
 }
 
-int ByteExtractStringUint64(uint64_t *res, int base, uint16_t len, const char *str)
+int ByteExtractStringUint64(uint64_t *res, int base, size_t len, const char *str)
 {
     return ByteExtractString(res, base, len, str, false);
 }
 
-int ByteExtractStringUint32(uint32_t *res, int base, uint16_t len, const char *str)
+int ByteExtractStringUint32(uint32_t *res, int base, size_t len, const char *str)
 {
     uint64_t i64;
 
@@ -259,7 +259,7 @@ int ByteExtractStringUint32(uint32_t *res, int base, uint16_t len, const char *s
     return ret;
 }
 
-int ByteExtractStringUint16(uint16_t *res, int base, uint16_t len, const char *str)
+int ByteExtractStringUint16(uint16_t *res, int base, size_t len, const char *str)
 {
     uint64_t i64;
 
@@ -282,7 +282,7 @@ int ByteExtractStringUint16(uint16_t *res, int base, uint16_t len, const char *s
     return ret;
 }
 
-int ByteExtractStringUint8(uint8_t *res, int base, uint16_t len, const char *str)
+int ByteExtractStringUint8(uint8_t *res, int base, size_t len, const char *str)
 {
     uint64_t i64;
 
@@ -305,12 +305,12 @@ int ByteExtractStringUint8(uint8_t *res, int base, uint16_t len, const char *str
     return ret;
 }
 
-int StringParseUint64(uint64_t *res, int base, uint16_t len, const char *str)
+int StringParseUint64(uint64_t *res, int base, size_t len, const char *str)
 {
     return ByteExtractString(res, base, len, str, true);
 }
 
-int StringParseUint32(uint32_t *res, int base, uint16_t len, const char *str)
+int StringParseUint32(uint32_t *res, int base, size_t len, const char *str)
 {
     uint64_t i64;
 
@@ -333,7 +333,7 @@ int StringParseUint32(uint32_t *res, int base, uint16_t len, const char *str)
     return ret;
 }
 
-int StringParseUint16(uint16_t *res, int base, uint16_t len, const char *str)
+int StringParseUint16(uint16_t *res, int base, size_t len, const char *str)
 {
     uint64_t i64;
 
@@ -356,7 +356,7 @@ int StringParseUint16(uint16_t *res, int base, uint16_t len, const char *str)
     return ret;
 }
 
-int StringParseUint8(uint8_t *res, int base, uint16_t len, const char *str)
+int StringParseUint8(uint8_t *res, int base, size_t len, const char *str)
 {
     uint64_t i64;
 
@@ -379,8 +379,8 @@ int StringParseUint8(uint8_t *res, int base, uint16_t len, const char *str)
     return ret;
 }
 
-int StringParseU64RangeCheck(uint64_t *res, int base, uint16_t len, const char *str,
-                             uint64_t min, uint64_t max)
+int StringParseU64RangeCheck(
+        uint64_t *res, int base, size_t len, const char *str, uint64_t min, uint64_t max)
 {
     uint64_t u64;
 
@@ -398,8 +398,8 @@ int StringParseU64RangeCheck(uint64_t *res, int base, uint16_t len, const char *
     return ret;
 }
 
-int StringParseU32RangeCheck(uint32_t *res, int base, uint16_t len, const char *str,
-                             uint32_t min, uint32_t max)
+int StringParseU32RangeCheck(
+        uint32_t *res, int base, size_t len, const char *str, uint32_t min, uint32_t max)
 {
     uint64_t u64;
 
@@ -426,8 +426,8 @@ int StringParseU32RangeCheck(uint32_t *res, int base, uint16_t len, const char *
     return ret;
 }
 
-int StringParseU16RangeCheck(uint16_t *res, int base, uint16_t len, const char *str,
-                             uint16_t min, uint16_t max)
+int StringParseU16RangeCheck(
+        uint16_t *res, int base, size_t len, const char *str, uint16_t min, uint16_t max)
 {
     uint64_t u64;
 
@@ -454,8 +454,8 @@ int StringParseU16RangeCheck(uint16_t *res, int base, uint16_t len, const char *
     return ret;
 }
 
-int StringParseU8RangeCheck(uint8_t *res, int base, uint16_t len, const char *str,
-                            uint8_t min, uint8_t max)
+int StringParseU8RangeCheck(
+        uint8_t *res, int base, size_t len, const char *str, uint8_t min, uint8_t max)
 {
     uint64_t u64;
 
@@ -482,7 +482,7 @@ int StringParseU8RangeCheck(uint8_t *res, int base, uint16_t len, const char *st
     return ret;
 }
 
-int ByteExtractStringSigned(int64_t *res, int base, uint16_t len, const char *str, bool strict)
+int ByteExtractStringSigned(int64_t *res, int base, size_t len, const char *str, bool strict)
 {
     const char *ptr = str;
     char *endptr;
@@ -528,12 +528,12 @@ int ByteExtractStringSigned(int64_t *res, int base, uint16_t len, const char *st
     return (endptr - ptr);
 }
 
-int ByteExtractStringInt64(int64_t *res, int base, uint16_t len, const char *str)
+int ByteExtractStringInt64(int64_t *res, int base, size_t len, const char *str)
 {
     return ByteExtractStringSigned(res, base, len, str, false);
 }
 
-int ByteExtractStringInt32(int32_t *res, int base, uint16_t len, const char *str)
+int ByteExtractStringInt32(int32_t *res, int base, size_t len, const char *str)
 {
     int64_t i64;
     int ret;
@@ -557,7 +557,7 @@ int ByteExtractStringInt32(int32_t *res, int base, uint16_t len, const char *str
     return ret;
 }
 
-int ByteExtractStringInt16(int16_t *res, int base, uint16_t len, const char *str)
+int ByteExtractStringInt16(int16_t *res, int base, size_t len, const char *str)
 {
     int64_t i64;
     int ret;
@@ -581,7 +581,7 @@ int ByteExtractStringInt16(int16_t *res, int base, uint16_t len, const char *str
     return ret;
 }
 
-int ByteExtractStringInt8(int8_t *res, int base, uint16_t len, const char *str)
+int ByteExtractStringInt8(int8_t *res, int base, size_t len, const char *str)
 {
     int64_t i64;
     int ret;
@@ -605,12 +605,12 @@ int ByteExtractStringInt8(int8_t *res, int base, uint16_t len, const char *str)
     return ret;
 }
 
-int StringParseInt64(int64_t *res, int base, uint16_t len, const char *str)
+int StringParseInt64(int64_t *res, int base, size_t len, const char *str)
 {
     return ByteExtractStringSigned(res, base, len, str, true);
 }
 
-int StringParseInt32(int32_t *res, int base, uint16_t len, const char *str)
+int StringParseInt32(int32_t *res, int base, size_t len, const char *str)
 {
     int64_t i64;
     int ret;
@@ -634,7 +634,7 @@ int StringParseInt32(int32_t *res, int base, uint16_t len, const char *str)
     return ret;
 }
 
-int StringParseInt16(int16_t *res, int base, uint16_t len, const char *str)
+int StringParseInt16(int16_t *res, int base, size_t len, const char *str)
 {
     int64_t i64;
     int ret;
@@ -658,7 +658,7 @@ int StringParseInt16(int16_t *res, int base, uint16_t len, const char *str)
     return ret;
 }
 
-int StringParseInt8(int8_t *res, int base, uint16_t len, const char *str)
+int StringParseInt8(int8_t *res, int base, size_t len, const char *str)
 {
     int64_t i64;
     int ret;
@@ -682,8 +682,8 @@ int StringParseInt8(int8_t *res, int base, uint16_t len, const char *str)
     return ret;
 }
 
-int StringParseI64RangeCheck(int64_t *res, int base, uint16_t len, const char *str,
-                             int64_t min, int64_t max)
+int StringParseI64RangeCheck(
+        int64_t *res, int base, size_t len, const char *str, int64_t min, int64_t max)
 {
     int64_t i64;
     int ret;
@@ -701,8 +701,8 @@ int StringParseI64RangeCheck(int64_t *res, int base, uint16_t len, const char *s
     return ret;
 }
 
-int StringParseI32RangeCheck(int32_t *res, int base, uint16_t len, const char *str,
-                             int32_t min, int32_t max)
+int StringParseI32RangeCheck(
+        int32_t *res, int base, size_t len, const char *str, int32_t min, int32_t max)
 {
     int64_t i64;
     int ret;
@@ -730,8 +730,8 @@ int StringParseI32RangeCheck(int32_t *res, int base, uint16_t len, const char *s
     return ret;
 }
 
-int StringParseI16RangeCheck(int16_t *res, int base, uint16_t len, const char *str,
-                             int16_t min, int16_t max)
+int StringParseI16RangeCheck(
+        int16_t *res, int base, size_t len, const char *str, int16_t min, int16_t max)
 {
     int64_t i64;
     int ret;
@@ -759,8 +759,8 @@ int StringParseI16RangeCheck(int16_t *res, int base, uint16_t len, const char *s
     return ret;
 }
 
-int StringParseI8RangeCheck(int8_t *res, int base, uint16_t len, const char *str,
-                            int8_t min, int8_t max)
+int StringParseI8RangeCheck(
+        int8_t *res, int base, size_t len, const char *str, int8_t min, int8_t max)
 {
     int64_t i64;
     int ret;

--- a/src/util-byte.h
+++ b/src/util-byte.h
@@ -134,7 +134,7 @@ int ByteExtractUint16(uint16_t *res, int e, uint16_t len, const uint8_t *bytes);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractString(uint64_t *res, int base, uint16_t len, const char *str, bool strict);
+int ByteExtractString(uint64_t *res, int base, size_t len, const char *str, bool strict);
 
 /**
  * Extract unsigned integer value from a string as uint64_t.
@@ -147,7 +147,7 @@ int ByteExtractString(uint64_t *res, int base, uint16_t len, const char *str, bo
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringUint64(uint64_t *res, int base, uint16_t len, const char *str);
+int ByteExtractStringUint64(uint64_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract unsigned integer value from a string as uint32_t.
@@ -160,7 +160,7 @@ int ByteExtractStringUint64(uint64_t *res, int base, uint16_t len, const char *s
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringUint32(uint32_t *res, int base, uint16_t len, const char *str);
+int ByteExtractStringUint32(uint32_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract unsigned integer value from a string as uint16_t.
@@ -173,7 +173,7 @@ int ByteExtractStringUint32(uint32_t *res, int base, uint16_t len, const char *s
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringUint16(uint16_t *res, int base, uint16_t len, const char *str);
+int ByteExtractStringUint16(uint16_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract unsigned integer value from a string as uint8_t.
@@ -186,7 +186,7 @@ int ByteExtractStringUint16(uint16_t *res, int base, uint16_t len, const char *s
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringUint8(uint8_t *res, int base, uint16_t len, const char *str);
+int ByteExtractStringUint8(uint8_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract signed integer value from a string.
@@ -200,7 +200,7 @@ int ByteExtractStringUint8(uint8_t *res, int base, uint16_t len, const char *str
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringSigned(int64_t *res, int base, uint16_t len, const char *str, bool strict);
+int ByteExtractStringSigned(int64_t *res, int base, size_t len, const char *str, bool strict);
 
 /**
  * Extract signed integer value from a string as uint64_t.
@@ -213,7 +213,7 @@ int ByteExtractStringSigned(int64_t *res, int base, uint16_t len, const char *st
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringInt64(int64_t *res, int base, uint16_t len, const char *str);
+int ByteExtractStringInt64(int64_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract signed integer value from a string as uint32_t.
@@ -226,7 +226,7 @@ int ByteExtractStringInt64(int64_t *res, int base, uint16_t len, const char *str
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringInt32(int32_t *res, int base, uint16_t len, const char *str);
+int ByteExtractStringInt32(int32_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract signed integer value from a string as uint16_t.
@@ -239,7 +239,7 @@ int ByteExtractStringInt32(int32_t *res, int base, uint16_t len, const char *str
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringInt16(int16_t *res, int base, uint16_t len, const char *str);
+int ByteExtractStringInt16(int16_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract signed integer value from a string as uint8_t.
@@ -252,7 +252,7 @@ int ByteExtractStringInt16(int16_t *res, int base, uint16_t len, const char *str
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringInt8(int8_t *res, int base, uint16_t len, const char *str);
+int ByteExtractStringInt8(int8_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract unsigned integer value from a string as uint64_t strictly.
@@ -265,7 +265,7 @@ int ByteExtractStringInt8(int8_t *res, int base, uint16_t len, const char *str);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int StringParseUint64(uint64_t *res, int base, uint16_t len, const char *str);
+int StringParseUint64(uint64_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract unsigned integer value from a string as uint32_t strictly.
@@ -278,7 +278,7 @@ int StringParseUint64(uint64_t *res, int base, uint16_t len, const char *str);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int StringParseUint32(uint32_t *res, int base, uint16_t len, const char *str);
+int StringParseUint32(uint32_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract unsigned integer value from a string as uint16_t strictly.
@@ -291,7 +291,7 @@ int StringParseUint32(uint32_t *res, int base, uint16_t len, const char *str);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int StringParseUint16(uint16_t *res, int base, uint16_t len, const char *str);
+int StringParseUint16(uint16_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract unsigned integer value from a string as uint8_t strictly.
@@ -304,7 +304,7 @@ int StringParseUint16(uint16_t *res, int base, uint16_t len, const char *str);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int StringParseUint8(uint8_t *res, int base, uint16_t len, const char *str);
+int StringParseUint8(uint8_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract signed integer value from a string as int64_t strictly.
@@ -317,7 +317,7 @@ int StringParseUint8(uint8_t *res, int base, uint16_t len, const char *str);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int StringParseInt64(int64_t *res, int base, uint16_t len, const char *str);
+int StringParseInt64(int64_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract signed integer value from a string as int32_t strictly.
@@ -330,7 +330,7 @@ int StringParseInt64(int64_t *res, int base, uint16_t len, const char *str);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int StringParseInt32(int32_t *res, int base, uint16_t len, const char *str);
+int StringParseInt32(int32_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract signed integer value from a string as int16_t strictly.
@@ -343,7 +343,7 @@ int StringParseInt32(int32_t *res, int base, uint16_t len, const char *str);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int StringParseInt16(int16_t *res, int base, uint16_t len, const char *str);
+int StringParseInt16(int16_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract signed integer value from a string as int8_t strictly.
@@ -356,7 +356,7 @@ int StringParseInt16(int16_t *res, int base, uint16_t len, const char *str);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int StringParseInt8(int8_t *res, int base, uint16_t len, const char *str);
+int StringParseInt8(int8_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract unsigned integer value from a string as uint64_t strictly within the range.
@@ -369,7 +369,8 @@ int StringParseInt8(int8_t *res, int base, uint16_t len, const char *str);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int WARN_UNUSED StringParseU64RangeCheck(uint64_t *res, int base, uint16_t len, const char *str, uint64_t min, uint64_t max);
+int WARN_UNUSED StringParseU64RangeCheck(
+        uint64_t *res, int base, size_t len, const char *str, uint64_t min, uint64_t max);
 
 /**
  * Extract unsigned integer value from a string as uint32_t strictly within the range.
@@ -382,7 +383,8 @@ int WARN_UNUSED StringParseU64RangeCheck(uint64_t *res, int base, uint16_t len, 
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int WARN_UNUSED StringParseU32RangeCheck(uint32_t *res, int base, uint16_t len, const char *str, uint32_t min, uint32_t max);
+int WARN_UNUSED StringParseU32RangeCheck(
+        uint32_t *res, int base, size_t len, const char *str, uint32_t min, uint32_t max);
 
 /**
  * Extract unsigned integer value from a string as uint16_t strictly within the range.
@@ -395,7 +397,8 @@ int WARN_UNUSED StringParseU32RangeCheck(uint32_t *res, int base, uint16_t len, 
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int WARN_UNUSED StringParseU16RangeCheck(uint16_t *res, int base, uint16_t len, const char *str, uint16_t min, uint16_t max);
+int WARN_UNUSED StringParseU16RangeCheck(
+        uint16_t *res, int base, size_t len, const char *str, uint16_t min, uint16_t max);
 
 /**
  * Extract unsigned integer value from a string as uint8_t strictly within the range.
@@ -408,7 +411,8 @@ int WARN_UNUSED StringParseU16RangeCheck(uint16_t *res, int base, uint16_t len, 
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int WARN_UNUSED StringParseU8RangeCheck(uint8_t *res, int base, uint16_t len, const char *str, uint8_t min, uint8_t max);
+int WARN_UNUSED StringParseU8RangeCheck(
+        uint8_t *res, int base, size_t len, const char *str, uint8_t min, uint8_t max);
 
 /**
  * Extract signed integer value from a string as int64_t strictly within the range.
@@ -421,7 +425,8 @@ int WARN_UNUSED StringParseU8RangeCheck(uint8_t *res, int base, uint16_t len, co
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int WARN_UNUSED StringParseI64RangeCheck(int64_t *res, int base, uint16_t len, const char *str, int64_t min, int64_t max);
+int WARN_UNUSED StringParseI64RangeCheck(
+        int64_t *res, int base, size_t len, const char *str, int64_t min, int64_t max);
 
 /**
  * Extract signed integer value from a string as int32_t strictly within the range.
@@ -434,7 +439,8 @@ int WARN_UNUSED StringParseI64RangeCheck(int64_t *res, int base, uint16_t len, c
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int WARN_UNUSED StringParseI32RangeCheck(int32_t *res, int base, uint16_t len, const char *str, int32_t min, int32_t max);
+int WARN_UNUSED StringParseI32RangeCheck(
+        int32_t *res, int base, size_t len, const char *str, int32_t min, int32_t max);
 
 /**
  * Extract signed integer value from a string as int16_t strictly within the range.
@@ -447,7 +453,8 @@ int WARN_UNUSED StringParseI32RangeCheck(int32_t *res, int base, uint16_t len, c
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int WARN_UNUSED StringParseI16RangeCheck(int16_t *res, int base, uint16_t len, const char *str, int16_t min, int16_t max);
+int WARN_UNUSED StringParseI16RangeCheck(
+        int16_t *res, int base, size_t len, const char *str, int16_t min, int16_t max);
 
 /**
  * Extract signed integer value from a string as int8_t strictly within the range.
@@ -460,7 +467,8 @@ int WARN_UNUSED StringParseI16RangeCheck(int16_t *res, int base, uint16_t len, c
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int WARN_UNUSED StringParseI8RangeCheck(int8_t *res, int base, uint16_t len, const char *str, int8_t min, int8_t max);
+int WARN_UNUSED StringParseI8RangeCheck(
+        int8_t *res, int base, size_t len, const char *str, int8_t min, int8_t max);
 
 #ifdef UNITTESTS
 void ByteRegisterTests(void);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4516

Describe changes:
- Fix integer warnings `-Wimplicit-int-conversion` for all files except ones beginning by d

Part of #7006 as #7107 was

Changed from #7120 : using `size_t` len for byte utils