### PR TITLE
Draft: Bug 4842/v5

### DIFF
--- a/rust/src/filetracker.rs
+++ b/rust/src/filetracker.rs
@@ -34,7 +34,7 @@ use std::collections::hash_map::Entry::{Occupied, Vacant};
 use crate::filecontainer::*;
 
 #[derive(Debug)]
-pub struct FileChunk {
+struct FileChunk {
     contains_gap: bool,
     chunk: Vec<u8>,
 }

--- a/rust/src/filetracker.rs
+++ b/rust/src/filetracker.rs
@@ -66,6 +66,8 @@ pub struct FileTransferTracker {
 
     chunks: HashMap<u64, FileChunk>,
     cur_ooo_chunk_offset: u64,
+
+    in_flight: u64,
 }
 
 impl FileTransferTracker {
@@ -224,6 +226,9 @@ impl FileTransferTracker {
                     self.cur_ooo += d.len() as u64;
                     c.contains_gap |= is_gap;
                     c.chunk.extend(d);
+
+                    self.in_flight += d.len() as u64;
+                    SCLogDebug!("{:p} in_flight {}", self, self.in_flight);
                 }
 
                 consumed += self.chunk_left as usize;
@@ -247,6 +252,8 @@ impl FileTransferTracker {
                             let _offset = self.tracked;
                             match self.chunks.remove(&self.tracked) {
                                 Some(c) => {
+                                    self.in_flight -= c.chunk.len() as u64;
+
                                     let res = files.file_append(&self.track_id, &c.chunk, c.contains_gap);
                                     match res {
                                         0   => { },
@@ -307,6 +314,7 @@ impl FileTransferTracker {
                     c.chunk.extend(data);
                     c.contains_gap |= is_gap;
                     self.cur_ooo += data.len() as u64;
+                    self.in_flight += data.len() as u64;
                 }
 
                 self.chunk_left -= data.len() as u32;
@@ -318,5 +326,12 @@ impl FileTransferTracker {
 
     pub fn get_queued_size(&self) -> u64 {
         self.cur_ooo
+    }
+
+    pub fn get_inflight_size(&self) -> u64 {
+        self.in_flight
+    }
+    pub fn get_inflight_cnt(&self) -> usize {
+        self.chunks.len()
     }
 }

--- a/rust/src/smb/events.rs
+++ b/rust/src/smb/events.rs
@@ -31,6 +31,12 @@ pub enum SMBEvent {
     RequestToClient,
     /// A response was seen in the to server direction,
     ResponseToServer,
+    /// READ request asking for more than `max_read_size`
+    ReadRequestTooLarge,
+    /// READ response bigger than `max_read_size`
+    ReadResponseTooLarge,
+    /// WRITE request for more than `max_write_size`
+    WriteRequestTooLarge,
 }
 
 impl SMBTransaction {

--- a/rust/src/smb/events.rs
+++ b/rust/src/smb/events.rs
@@ -35,8 +35,12 @@ pub enum SMBEvent {
     ReadRequestTooLarge,
     /// READ response bigger than `max_read_size`
     ReadResponseTooLarge,
+    ReadResponseQueueSizeExceeded,
+    ReadResponseQueueCntExceeded,
     /// WRITE request for more than `max_write_size`
     WriteRequestTooLarge,
+    WriteQueueSizeExceeded,
+    WriteQueueCntExceeded,
 }
 
 impl SMBTransaction {

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -47,12 +47,12 @@ impl SMBTransactionFile {
 /// little wrapper around the FileTransferTracker::new_chunk method
 pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContainer,
         flags: u16, name: &Vec<u8>, data: &[u8],
-        chunk_offset: u64, chunk_size: u32, fill_bytes: u8, is_last: bool, xid: &u32)
+        chunk_offset: u64, chunk_size: u32, is_last: bool, xid: &u32)
 {
     match unsafe {SURICATA_SMB_FILE_CONFIG} {
         Some(sfcm) => {
             ft.new_chunk(sfcm, files, flags, name, data, chunk_offset,
-                    chunk_size, fill_bytes, is_last, xid); }
+                    chunk_size, 0, is_last, xid); }
         None => panic!("no SURICATA_SMB_FILE_CONFIG"),
     }
 }

--- a/rust/src/smb/log.rs
+++ b/rust/src/smb/log.rs
@@ -249,6 +249,13 @@ fn smb_common_header(jsb: &mut JsonBuilder, state: &SMBState, tx: &SMBTransactio
             }
 
             jsb.set_string("server_guid", &guid_to_string(&x.server_guid))?;
+
+            if state.max_read_size > 0 {
+                jsb.set_uint("max_read_size", state.max_read_size.into())?;
+            }
+            if state.max_write_size > 0 {
+                jsb.set_uint("max_write_size", state.max_write_size.into())?;
+            }
         },
         Some(SMBTransactionTypeData::TREECONNECT(ref x)) => {
             jsb.set_uint("tree_id", x.tree_id as u64)?;

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -74,7 +74,11 @@ pub const MIN_REC_SIZE: u16 = 32 + 4; // SMB hdr + nbss hdr
 pub const SMB_CONFIG_DEFAULT_STREAM_DEPTH: u32 = 0;
 
 pub static mut SMB_CFG_MAX_READ_SIZE: u32 = 0;
+pub static mut SMB_CFG_MAX_READ_QUEUE_SIZE: u32 = 0;
+pub static mut SMB_CFG_MAX_READ_QUEUE_CNT: u32 = 0;
 pub static mut SMB_CFG_MAX_WRITE_SIZE: u32 = 0;
+pub static mut SMB_CFG_MAX_WRITE_QUEUE_SIZE: u32 = 0;
+pub static mut SMB_CFG_MAX_WRITE_QUEUE_CNT: u32 = 0;
 
 static mut ALPROTO_SMB: AppProto = ALPROTO_UNKNOWN;
 
@@ -2425,6 +2429,34 @@ pub unsafe extern "C" fn rs_smb_register_parser() {
             match get_memval(val) {
                 Ok(retval) => { SMB_CFG_MAX_WRITE_SIZE = retval as u32; }
                 Err(_) => { SCLogError!("Invalid max-write-size value"); }
+            }
+        }
+        let retval = conf_get("app-layer.protocols.smb.max-write-queue-size");
+        if let Some(val) = retval {
+            match get_memval(val) {
+                Ok(retval) => { SMB_CFG_MAX_WRITE_QUEUE_SIZE = retval as u32; }
+                Err(_) => { SCLogError!("Invalid max-write-queue-size value"); }
+            }
+        }
+        let retval = conf_get("app-layer.protocols.smb.max-write-queue-cnt");
+        if let Some(val) = retval {
+            match get_memval(val) {
+                Ok(retval) => { SMB_CFG_MAX_WRITE_QUEUE_CNT = retval as u32; }
+                Err(_) => { SCLogError!("Invalid max-write-queue-cnt value"); }
+            }
+        }
+        let retval = conf_get("app-layer.protocols.smb.max-read-queue-size");
+        if let Some(val) = retval {
+            match get_memval(val) {
+                Ok(retval) => { SMB_CFG_MAX_READ_QUEUE_SIZE = retval as u32; }
+                Err(_) => { SCLogError!("Invalid max-read-queue-size value"); }
+            }
+        }
+        let retval = conf_get("app-layer.protocols.smb.max-read-queue-cnt");
+        if let Some(val) = retval {
+            match get_memval(val) {
+                Ok(retval) => { SMB_CFG_MAX_READ_QUEUE_CNT = retval as u32; }
+                Err(_) => { SCLogError!("Invalid max-read-queue-cnt value"); }
             }
         }
     } else {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -73,6 +73,9 @@ pub enum SMBFrameType {
 pub const MIN_REC_SIZE: u16 = 32 + 4; // SMB hdr + nbss hdr
 pub const SMB_CONFIG_DEFAULT_STREAM_DEPTH: u32 = 0;
 
+pub static mut SMB_CFG_MAX_READ_SIZE: u32 = 0;
+pub static mut SMB_CFG_MAX_WRITE_SIZE: u32 = 0;
+
 static mut ALPROTO_SMB: AppProto = ALPROTO_UNKNOWN;
 
 pub static mut SURICATA_SMB_FILE_CONFIG: Option<&'static SuricataFileContext> = None;
@@ -2407,8 +2410,22 @@ pub unsafe extern "C" fn rs_smb_register_parser() {
             match get_memval(val) {
                 Ok(retval) => { stream_depth = retval as u32; }
                 Err(_) => { SCLogError!("Invalid depth value"); }
-           }
+            }
             AppLayerParserSetStreamDepth(IPPROTO_TCP as u8, ALPROTO_SMB, stream_depth);
+        }
+        let retval = conf_get("app-layer.protocols.smb.max-read-size");
+        if let Some(val) = retval {
+            match get_memval(val) {
+                Ok(retval) => { SMB_CFG_MAX_READ_SIZE = retval as u32; }
+                Err(_) => { SCLogError!("Invalid max-read-size value"); }
+            }
+        }
+        let retval = conf_get("app-layer.protocols.smb.max-write-size");
+        if let Some(val) = retval {
+            match get_memval(val) {
+                Ok(retval) => { SMB_CFG_MAX_WRITE_SIZE = retval as u32; }
+                Err(_) => { SCLogError!("Invalid max-write-size value"); }
+            }
         }
     } else {
         SCLogDebug!("Protocol detector and parser disabled for SMB.");

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -724,6 +724,7 @@ pub fn u32_as_bytes(i: u32) -> [u8;4] {
     return [o1, o2, o3, o4]
 }
 
+#[derive(Default, Debug)]
 pub struct SMBState<> {
     /// map ssn/tree/msgid to vec (guid/name/share)
     pub ssn2vec_map: HashMap<SMBCommonHdr, Vec<u8>>,
@@ -777,6 +778,9 @@ pub struct SMBState<> {
     /// them while inspecting DCERPC REQUEST txs
     pub dcerpc_ifaces: Option<Vec<DCERPCIface>>,
 
+    pub max_read_size: u32,
+    pub max_write_size: u32,
+
     /// Timestamp in seconds of last update. This is packet time,
     /// potentially coming from pcaps.
     ts: u64,
@@ -818,6 +822,7 @@ impl SMBState {
             dialect_vec: None,
             dcerpc_ifaces: None,
             ts: 0,
+            ..Default::default()
         }
     }
 

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -969,7 +969,7 @@ pub fn smb1_write_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>, an
                         }
                         filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                                 &file_name, rd.data, rd.offset,
-                                rd.len, 0, false, &file_id);
+                                rd.len, false, &file_id);
                         SCLogDebug!("FID {:?} found at tx {}", file_fid, tx.id);
                     }
                     true
@@ -997,7 +997,7 @@ pub fn smb1_write_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>, an
                         }
                         filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                                 &file_name, rd.data, rd.offset,
-                                rd.len, 0, false, &file_id);
+                                rd.len, false, &file_id);
                         tdf.share_name = share_name;
                     }
                     tx.vercmd.set_smb1_cmd(SMB1_COMMAND_WRITE_ANDX);
@@ -1063,7 +1063,7 @@ pub fn smb1_read_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>, an
                                 }
                                 filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                                         &file_name, rd.data, offset,
-                                        rd.len, 0, false, &file_id);
+                                        rd.len, false, &file_id);
                             }
                             true
                         },
@@ -1079,7 +1079,7 @@ pub fn smb1_read_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>, an
                             }
                             filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                                     &file_name, rd.data, offset,
-                                    rd.len, 0, false, &file_id);
+                                    rd.len, false, &file_id);
                             tdf.share_name = share_name;
                         }
                         tx.vercmd.set_smb1_cmd(SMB1_COMMAND_READ_ANDX);

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -154,7 +154,7 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         }
                         filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                                 &tdf.file_name, rd.data, offset,
-                                rd.len, 0, false, &file_id);
+                                rd.len, false, &file_id);
                     }
                     true
                 },
@@ -214,7 +214,7 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         }
                         filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                                 &file_name, rd.data, offset,
-                                rd.len, 0, false, &file_id);
+                                rd.len, false, &file_id);
                         tdf.share_name = share_name;
                     }
                     tx.vercmd.set_smb2_cmd(SMB2_COMMAND_READ);
@@ -265,7 +265,7 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         }
                         filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                                 &file_name, wr.data, wr.wr_offset,
-                                wr.wr_len, 0, false, &file_id);
+                                wr.wr_len, false, &file_id);
                     }
                     true
                 },
@@ -321,7 +321,7 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         }
                         filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                                 &file_name, wr.data, wr.wr_offset,
-                                wr.wr_len, 0, false, &file_id);
+                                wr.wr_len, false, &file_id);
                     }
                     tx.vercmd.set_smb2_cmd(SMB2_COMMAND_WRITE);
                     tx.hdr = SMBCommonHdr::new(SMBHDR_TYPE_HEADER,

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -114,6 +114,9 @@ fn smb2_read_response_record_generic<'b>(state: &mut SMBState, r: &Smb2Record<'b
 
 pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
 {
+    let max_queue_size = unsafe { SMB_CFG_MAX_READ_QUEUE_SIZE };
+    let max_queue_cnt = unsafe { SMB_CFG_MAX_READ_QUEUE_CNT };
+
     smb2_read_response_record_generic(state, r);
 
     match parse_smb2_response_read(r.data) {
@@ -160,9 +163,17 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         if offset < tdf.file_tracker.tracked {
                             set_event_fileoverlap = true;
                         }
-                        filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                                &tdf.file_name, rd.data, offset,
-                                rd.len, false, &file_id);
+                        if max_queue_size != 0 && tdf.file_tracker.get_inflight_size() + rd.len as u64 > max_queue_size.into() {
+                            state.set_event(SMBEvent::ReadResponseQueueSizeExceeded);
+                            state.set_skip(Direction::ToClient, rd.len, rd.data.len() as u32);
+                        } else if max_queue_cnt != 0 && tdf.file_tracker.get_inflight_cnt() >= max_queue_cnt as usize {
+                            state.set_event(SMBEvent::ReadResponseQueueCntExceeded);
+                            state.set_skip(Direction::ToClient, rd.len, rd.data.len() as u32);
+                        } else {
+                            filetracker_newchunk(&mut tdf.file_tracker, files, flags,
+                                    &tdf.file_name, rd.data, offset,
+                                    rd.len, false, &file_id);
+                        }
                     }
                     true
                 },
@@ -211,23 +222,33 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     state.set_skip(Direction::ToClient, rd.len, rd.data.len() as u32);
                 } else {
                     let file_name = match state.guid2name_map.get(&file_guid) {
-                        Some(n) => { n.to_vec() },
-                        None => { b"<unknown>".to_vec() },
+                        Some(n) => { n.to_vec() }
+                        None => { b"<unknown>".to_vec() }
                     };
                     let (tx, files, flags) = state.new_file_tx(&file_guid, &file_name, Direction::ToClient);
+
+                    tx.vercmd.set_smb2_cmd(SMB2_COMMAND_READ);
+                    tx.hdr = SMBCommonHdr::new(SMBHDR_TYPE_HEADER,
+                            r.session_id, r.tree_id, 0); // TODO move into new_file_tx
+
                     if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
+                        tdf.share_name = share_name;
                         let file_id : u32 = tx.id as u32;
                         if offset < tdf.file_tracker.tracked {
                             set_event_fileoverlap = true;
                         }
-                        filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                                &file_name, rd.data, offset,
-                                rd.len, false, &file_id);
-                        tdf.share_name = share_name;
+                        if max_queue_size != 0 && tdf.file_tracker.get_inflight_size() + rd.len as u64 > max_queue_size.into() {
+                            state.set_event(SMBEvent::ReadResponseQueueSizeExceeded);
+                            state.set_skip(Direction::ToClient, rd.len, rd.data.len() as u32);
+                        } else if max_queue_cnt != 0 && tdf.file_tracker.get_inflight_cnt() >= max_queue_cnt as usize {
+                            state.set_event(SMBEvent::ReadResponseQueueCntExceeded);
+                            state.set_skip(Direction::ToClient, rd.len, rd.data.len() as u32);
+                        } else {
+                            filetracker_newchunk(&mut tdf.file_tracker, files, flags,
+                                    &file_name, rd.data, offset,
+                                    rd.len, false, &file_id);
+                        }
                     }
-                    tx.vercmd.set_smb2_cmd(SMB2_COMMAND_READ);
-                    tx.hdr = SMBCommonHdr::new(SMBHDR_TYPE_HEADER,
-                            r.session_id, r.tree_id, 0); // TODO move into new_file_tx
                 }
             }
 
@@ -245,6 +266,9 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
 
 pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
 {
+    let max_queue_size = unsafe { SMB_CFG_MAX_WRITE_QUEUE_SIZE };
+    let max_queue_cnt = unsafe { SMB_CFG_MAX_WRITE_QUEUE_CNT };
+
     SCLogDebug!("SMBv2/WRITE: request record");
     if smb2_create_new_tx(r.command) {
         let tx_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_GENERICTX);
@@ -278,9 +302,17 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         if wr.wr_offset < tdf.file_tracker.tracked {
                             set_event_fileoverlap = true;
                         }
-                        filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                                &file_name, wr.data, wr.wr_offset,
-                                wr.wr_len, false, &file_id);
+                        if max_queue_size != 0 && tdf.file_tracker.get_inflight_size() + wr.wr_len as u64 > max_queue_size.into() {
+                            state.set_event(SMBEvent::WriteQueueSizeExceeded);
+                            state.set_skip(Direction::ToServer, wr.wr_len, wr.data.len() as u32);
+                        } else if max_queue_cnt != 0 && tdf.file_tracker.get_inflight_cnt() >= max_queue_cnt as usize {
+                            state.set_event(SMBEvent::WriteQueueCntExceeded);
+                            state.set_skip(Direction::ToServer, wr.wr_len, wr.data.len() as u32);
+                        } else {
+                            filetracker_newchunk(&mut tdf.file_tracker, files, flags,
+                                    &file_name, wr.data, wr.wr_offset,
+                                    wr.wr_len, false, &file_id);
+                        }
                     }
                     true
                 },
@@ -329,18 +361,27 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     state.set_skip(Direction::ToServer, wr.wr_len, wr.data.len() as u32);
                 } else {
                     let (tx, files, flags) = state.new_file_tx(&file_guid, &file_name, Direction::ToServer);
+                    tx.vercmd.set_smb2_cmd(SMB2_COMMAND_WRITE);
+                    tx.hdr = SMBCommonHdr::new(SMBHDR_TYPE_HEADER,
+                            r.session_id, r.tree_id, 0); // TODO move into new_file_tx
                     if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
                         let file_id : u32 = tx.id as u32;
                         if wr.wr_offset < tdf.file_tracker.tracked {
                             set_event_fileoverlap = true;
                         }
-                        filetracker_newchunk(&mut tdf.file_tracker, files, flags,
-                                &file_name, wr.data, wr.wr_offset,
-                                wr.wr_len, false, &file_id);
+
+                        if max_queue_size != 0 && tdf.file_tracker.get_inflight_size() + wr.wr_len as u64 > max_queue_size.into() {
+                            state.set_event(SMBEvent::WriteQueueSizeExceeded);
+                            state.set_skip(Direction::ToServer, wr.wr_len, wr.data.len() as u32);
+                        } else if max_queue_cnt != 0 && tdf.file_tracker.get_inflight_cnt() >= max_queue_cnt as usize {
+                            state.set_event(SMBEvent::WriteQueueCntExceeded);
+                            state.set_skip(Direction::ToServer, wr.wr_len, wr.data.len() as u32);
+                        } else {
+                            filetracker_newchunk(&mut tdf.file_tracker, files, flags,
+                                    &file_name, wr.data, wr.wr_offset,
+                                    wr.wr_len, false, &file_id);
+                        }
                     }
-                    tx.vercmd.set_smb2_cmd(SMB2_COMMAND_WRITE);
-                    tx.hdr = SMBCommonHdr::new(SMBHDR_TYPE_HEADER,
-                            r.session_id, r.tree_id, 0); // TODO move into new_file_tx
                 }
             }
 

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -128,7 +128,9 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                 return;
             }
 
-            if state.max_read_size > 0 && rd.len > state.max_read_size {
+            if (state.max_read_size != 0 && rd.len > state.max_read_size) ||
+               (unsafe { SMB_CFG_MAX_READ_SIZE != 0 && SMB_CFG_MAX_READ_SIZE < rd.len })
+            {
                 state.set_event(SMBEvent::ReadResponseTooLarge);
                 state.set_skip(Direction::ToClient, rd.len, rd.data.len() as u32);
                 return;
@@ -251,7 +253,8 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
     }
     match parse_smb2_request_write(r.data) {
         Ok((_, wr)) => {
-            if state.max_read_size != 0 && wr.wr_len > state.max_write_size {
+            if (state.max_write_size != 0 && wr.wr_len > state.max_write_size) ||
+               (unsafe { SMB_CFG_MAX_WRITE_SIZE != 0 && SMB_CFG_MAX_WRITE_SIZE < wr.wr_len }) {
                 state.set_event(SMBEvent::WriteRequestTooLarge);
                 state.set_skip(Direction::ToServer, wr.wr_len, wr.data.len() as u32);
                 return;
@@ -492,7 +495,8 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
         SMB2_COMMAND_READ => {
             match parse_smb2_request_read(r.data) {
                 Ok((_, rd)) => {
-                    if state.max_read_size != 0 && rd.rd_len > state.max_read_size {
+                    if (state.max_read_size != 0 && rd.rd_len > state.max_read_size) ||
+                        (unsafe { SMB_CFG_MAX_READ_SIZE != 0 && SMB_CFG_MAX_READ_SIZE < rd.rd_len }) {
                         events.push(SMBEvent::ReadRequestTooLarge);
                     } else {
                         SCLogDebug!("SMBv2 READ: GUID {:?} requesting {} bytes at offset {}",

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -157,6 +157,9 @@ pub fn parse_smb2_request_negotiate_protocol(i: &[u8]) -> IResult<&[u8], Smb2Neg
 pub struct Smb2NegotiateProtocolResponseRecord<'a> {
     pub dialect: u16,
     pub server_guid: &'a[u8],
+    pub max_trans_size: u32,
+    pub max_read_size: u32,
+    pub max_write_size: u32,
 }
 
 pub fn parse_smb2_response_negotiate_protocol(i: &[u8]) -> IResult<&[u8], Smb2NegotiateProtocolResponseRecord> {
@@ -165,9 +168,16 @@ pub fn parse_smb2_response_negotiate_protocol(i: &[u8]) -> IResult<&[u8], Smb2Ne
     let (i, dialect) = le_u16(i)?;
     let (i, _ctx_cnt) = le_u16(i)?;
     let (i, server_guid) = take(16_usize)(i)?;
+    let (i, _capabilities) = le_u32(i)?;
+    let (i, max_trans_size) = le_u32(i)?;
+    let (i, max_read_size) = le_u32(i)?;
+    let (i, max_write_size) = le_u32(i)?;
     let record = Smb2NegotiateProtocolResponseRecord {
         dialect,
-        server_guid
+        server_guid,
+        max_trans_size,
+        max_read_size,
+        max_write_size
     };
     Ok((i, record))
 }
@@ -178,6 +188,9 @@ pub fn parse_smb2_response_negotiate_protocol_error(i: &[u8]) -> IResult<&[u8], 
     let record = Smb2NegotiateProtocolResponseRecord {
         dialect: 0,
         server_guid: &[],
+        max_trans_size: 0,
+        max_read_size: 0,
+        max_write_size: 0
     };
     Ok((i, record))
 }


### PR DESCRIPTION
Add various checks and options to the SMB parser to check and limit max read/write record sizes, as well as options to limit max out of order sizes.

https://redmine.openinfosecfoundation.org/issues/4842