### PR TITLE
6.0.x - 5018 - mqtt - backport - v1/

### DIFF
--- a/rules/mqtt-events.rules
+++ b/rules/mqtt-events.rules
@@ -13,3 +13,4 @@ alert mqtt any any -> any any (msg:"SURICATA MQTT message seen before CONNECT/CO
 alert mqtt any any -> any any (msg:"SURICATA MQTT invalid QOS level"; app-layer-event:mqtt.invalid_qos_level; classtype:protocol-command-decode; sid:2229006; rev:1;)
 alert mqtt any any -> any any (msg:"SURICATA MQTT missing message ID"; app-layer-event:mqtt.missing_msg_id; classtype:protocol-command-decode; sid:2229007; rev:1;)
 alert mqtt any any -> any any (msg:"SURICATA MQTT unassigned message type (0 or >15)"; app-layer-event:mqtt.unassigned_msg_type; classtype:protocol-command-decode; sid:2229008; rev:1;)
+alert mqtt any any -> any any (msg:"SURICATA MQTT malformed traffic"; app-layer-event:mqtt.malformed_traffic; classtype:protocol-command-decode; sid:2229010; rev:1;)


### PR DESCRIPTION
Minimal backport of https://redmine.openinfosecfoundation.org/issues/5018 to 6.0.x.  Passes S-V test from https://github.com/OISF/suricata-verify/pull/737.

@satta @catenacyber Is there more to this that should be considered for 6.0.x?

Ticket: https://redmine.openinfosecfoundation.org/issues/5059