### PR TITLE
6.0.x: app-layer: better warning message when enabling by default

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1962,7 +1962,7 @@ int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto,
         if (node == NULL) {
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
             SCLogWarning(SC_ERR_CONF_YAML_ERROR,
-                    "Config for protocol %s not found, so enabling by default."
+                    "App-Layer protocol %s enable status not set, so enabling by default."
                     " This behavior will change in Suricata 7, so please update"
                     " your config. See ticket #4744 for more details.",
                     alproto);


### PR DESCRIPTION
The warning message suggests that the configuration section doesn't
exist if when it does, but the "enabled" flag is not set. Clarify the
warning message that the enable status is not set.
