### PR TITLE
5.0.x smb fixes/v3

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1538,10 +1538,8 @@ the app-layer event ``http.compression_bomb`` is set
 (this event can also set from other conditions).
 This can happen on slow configurations (hardware, ASAN, etc...)
 
-Configure SMB (Rust)
-~~~~~~~~~~~~~~~~~~~~
-
-.. note:: for full SMB support compile Suricata with Rust support
+Configure SMB
+~~~~~~~~~~~~~
 
 The SMB parser will parse version 1, 2 and 3 of the SMB protocol over TCP.
 
@@ -1560,6 +1558,60 @@ independent. The ``probing parsers`` will only run on the ``detection-ports``.
 
 SMB is commonly used to transfer the DCERPC protocol. This traffic is also handled by
 this parser.
+
+Resource limits
+---------------
+
+Several options are available for limiting record sizes and data chunk tracking.
+
+::
+
+    smb:
+      enabled: yes
+      max-read-size: 8mb
+      max-write-size: 1mb
+
+      max-read-queue-size: 16mb
+      max-read-queue-cnt: 16
+
+      max-write-queue-size: 16mb
+      max-write-queue-cnt: 16
+
+The `max-read-size` option can be set to control the max size of accepted
+READ records. Events will be raised if a READ request asks for too much data
+and/or if READ responses are too big. A value of 0 disables the checks.
+
+The `max-write-size` option can be set to control the max size of accepted
+WRITE request records. Events will be raised if a WRITE request sends too much
+data. A value of 0 disables the checks.
+
+Additionally if the `max-read-size` or `max-write-size` values in the
+"negotiate protocol response" exceeds this limit an event will also be raised.
+
+
+For file tracking, extraction and file data inspection the parser queues up
+out of order data chunks for both READs and WRITEs. To avoid using too much
+memory the parser allows for limiting both the size in bytes and the number
+of queued chunks.
+
+::
+
+    smb:
+      enabled: yes
+
+      max-read-queue-size: 16mb
+      max-read-queue-cnt: 16
+
+      max-write-queue-size: 16mb
+      max-write-queue-cnt: 16
+
+`max-read-queue-size` controls how many bytes can be used per SMB flow for
+out of order READs. `max-read-queue-cnt` controls how many READ chunks can be
+queued per SMB flow. Processing of these chunks will be blocked when any of
+the limits are exceeded, and an event will be raised.
+
+`max-write-queue-size` and `max-write-queue-cnt` are as the READ variants,
+but then for WRITEs.
 
 Engine Logging
 --------------

--- a/rules/smb-events.rules
+++ b/rules/smb-events.rules
@@ -16,3 +16,27 @@ alert smb any any -> any any (msg:"SURICATA SMB malformed NTLMSSP record"; flow:
 alert smb any any -> any any (msg:"SURICATA SMB malformed request dialects"; flow:to_server; app-layer-event:smb.negotiate_malformed_dialects; classtype:protocol-command-decode; sid:2225005; rev:1;)
 
 alert smb any any -> any any (msg:"SURICATA SMB file overlap"; app-layer-event:smb.file_overlap; classtype:protocol-command-decode; sid:2225006; rev:1;)
+
+# checks negotiated max-read-size and 'app-layer.protocols.smb.max-read-size`
+alert smb any any -> any any (msg:"SURICATA SMB max requested READ size exceeded"; flow:to_server; app-layer-event:smb.read_request_too_large; classtype:protocol-command-decode; sid:2225009; rev:1;)
+# checks negotiated max-read-size and 'app-layer.protocols.smb.max-read-size`
+alert smb any any -> any any (msg:"SURICATA SMB max response READ size exceeded"; flow:to_client; app-layer-event:smb.read_response_too_large; classtype:protocol-command-decode; sid:2225010; rev:1;)
+# checks negotiated max-write-size and 'app-layer.protocols.smb.max-write-size`
+alert smb any any -> any any (msg:"SURICATA SMB max WRITE size exceeded"; flow:to_server; app-layer-event:smb.write_request_too_large; classtype:protocol-command-decode; sid:2225011; rev:1;)
+
+# checks 'app-layer.protocols.smb.max-read-size` against NEGOTIATE PROTOCOL response
+alert smb any any -> any any (msg:"SURICATA SMB supported READ size exceeded"; flow:to_client; app-layer-event:smb.negotiate_max_read_size_too_large; classtype:protocol-command-decode; sid:2225012; rev:1;)
+# checks 'app-layer.protocols.smb.max-write-size` against NEGOTIATE PROTOCOL response
+alert smb any any -> any any (msg:"SURICATA SMB supported WRITE size exceeded"; flow:to_server; app-layer-event:smb.negotiate_max_write_size_too_large; classtype:protocol-command-decode; sid:2225013; rev:1;)
+
+# checks 'app-layer.protocols.smb.max-write-queue-size` against out of order chunks
+alert smb any any -> any any (msg:"SURICATA SMB max WRITE queue size exceeded"; flow:to_server; app-layer-event:smb.write_queue_size_too_large; classtype:protocol-command-decode; sid:2225014; rev:1;)
+# checks 'app-layer.protocols.smb.max-write-queue-cnt` against out of order chunks
+alert smb any any -> any any (msg:"SURICATA SMB max WRITE queue cnt exceeded"; flow:to_server; app-layer-event:smb.write_queue_cnt_too_large; classtype:protocol-command-decode; sid:2225015; rev:1;)
+
+# checks 'app-layer.protocols.smb.max-read-queue-size` against out of order chunks
+alert smb any any -> any any (msg:"SURICATA SMB max READ queue size exceeded"; flow:to_client; app-layer-event:smb.read_queue_size_too_large; classtype:protocol-command-decode; sid:2225016; rev:1;)
+# checks 'app-layer.protocols.smb.max-read-queue-cnt` against out of order chunks
+alert smb any any -> any any (msg:"SURICATA SMB max READ queue cnt exceeded"; flow:to_client; app-layer-event:smb.read_queue_cnt_too_large; classtype:protocol-command-decode; sid:2225017; rev:1;)
+
+# next sid 2225018

--- a/rust/src/filetracker.rs
+++ b/rust/src/filetracker.rs
@@ -34,7 +34,7 @@ use std::collections::hash_map::Entry::{Occupied, Vacant};
 use crate::filecontainer::*;
 
 #[derive(Debug)]
-pub struct FileChunk {
+struct FileChunk {
     contains_gap: bool,
     chunk: Vec<u8>,
 }

--- a/rust/src/smb/events.rs
+++ b/rust/src/smb/events.rs
@@ -28,16 +28,20 @@ pub enum SMBEvent {
     DuplicateNegotiate = 5,
     NegotiateMalformedDialects = 6,
     FileOverlap = 7,
+    /// Negotiated max sizes exceed our limit
+    NegotiateMaxReadSizeTooLarge = 8,
+    NegotiateMaxWriteSizeTooLarge = 9,
+
     /// READ request asking for more than `max_read_size`
-    ReadRequestTooLarge = 8,
+    ReadRequestTooLarge = 10,
     /// READ response bigger than `max_read_size`
-    ReadResponseTooLarge = 9,
-    ReadResponseQueueSizeExceeded = 10,
-    ReadResponseQueueCntExceeded = 11,
+    ReadResponseTooLarge = 11,
+    ReadResponseQueueSizeExceeded = 12,
+    ReadResponseQueueCntExceeded = 13,
     /// WRITE request for more than `max_write_size`
-    WriteRequestTooLarge = 12,
-    WriteQueueSizeExceeded = 13,
-    WriteQueueCntExceeded = 14,
+    WriteRequestTooLarge = 14,
+    WriteQueueSizeExceeded = 15,
+    WriteQueueCntExceeded = 16,
 }
 
 impl SMBEvent {
@@ -51,13 +55,15 @@ impl SMBEvent {
             5 => Some(SMBEvent::DuplicateNegotiate),
             6 => Some(SMBEvent::NegotiateMalformedDialects),
             7 => Some(SMBEvent::FileOverlap),
-            8 => Some(SMBEvent::ReadRequestTooLarge),
-            9 => Some(SMBEvent::ReadResponseTooLarge),
-            10 => Some(SMBEvent::ReadResponseQueueSizeExceeded),
-            11 => Some(SMBEvent::ReadResponseQueueCntExceeded),
-            12 => Some(SMBEvent::WriteRequestTooLarge),
-            13 => Some(SMBEvent::WriteQueueSizeExceeded),
-            14 => Some(SMBEvent::WriteQueueCntExceeded),
+            8 => Some(SMBEvent::NegotiateMaxReadSizeTooLarge),
+            9 => Some(SMBEvent::NegotiateMaxWriteSizeTooLarge),
+            10 => Some(SMBEvent::ReadRequestTooLarge),
+            11 => Some(SMBEvent::ReadResponseTooLarge),
+            12 => Some(SMBEvent::ReadResponseQueueSizeExceeded),
+            13 => Some(SMBEvent::ReadResponseQueueCntExceeded),
+            14 => Some(SMBEvent::WriteRequestTooLarge),
+            15 => Some(SMBEvent::WriteQueueSizeExceeded),
+            16 => Some(SMBEvent::WriteQueueCntExceeded),
             _ => None,
         }
     }
@@ -74,6 +80,8 @@ pub fn smb_str_to_event(instr: &str) -> i32 {
         "duplicate_negotiate"               => SMBEvent::DuplicateNegotiate as i32,
         "negotiate_malformed_dialects"      => SMBEvent::NegotiateMalformedDialects as i32,
         "file_overlap"                      => SMBEvent::FileOverlap as i32,
+        "negotiate_max_read_size_too_large"  => SMBEvent::NegotiateMaxReadSizeTooLarge as i32,
+        "negotiate_max_write_size_too_large" => SMBEvent::NegotiateMaxWriteSizeTooLarge as i32,
         "read_request_too_large"            => SMBEvent::ReadRequestTooLarge as i32,
         "read_response_too_large"           => SMBEvent::ReadResponseTooLarge as i32,
         "read_queue_size_too_large"         => SMBEvent::ReadResponseQueueSizeExceeded as i32,

--- a/rust/src/smb/events.rs
+++ b/rust/src/smb/events.rs
@@ -28,6 +28,12 @@ pub enum SMBEvent {
     DuplicateNegotiate = 5,
     NegotiateMalformedDialects = 6,
     FileOverlap = 7,
+    /// READ request asking for more than `max_read_size`
+    ReadRequestTooLarge = 8,
+    /// READ response bigger than `max_read_size`
+    ReadResponseTooLarge = 9,
+    /// WRITE request for more than `max_write_size`
+    WriteRequestTooLarge = 10,
 }
 
 impl SMBEvent {
@@ -41,6 +47,9 @@ impl SMBEvent {
             5 => Some(SMBEvent::DuplicateNegotiate),
             6 => Some(SMBEvent::NegotiateMalformedDialects),
             7 => Some(SMBEvent::FileOverlap),
+            8 => Some(SMBEvent::ReadRequestTooLarge),
+            9 => Some(SMBEvent::ReadResponseTooLarge),
+            10 => Some(SMBEvent::WriteRequestTooLarge),
             _ => None,
         }
     }
@@ -57,6 +66,9 @@ pub fn smb_str_to_event(instr: &str) -> i32 {
         "duplicate_negotiate"           => SMBEvent::DuplicateNegotiate as i32,
         "negotiate_malformed_dialects"  => SMBEvent::NegotiateMalformedDialects as i32,
         "file_overlap"                  => SMBEvent::FileOverlap as i32,
+        "read_request_too_large"        => SMBEvent::ReadRequestTooLarge as i32,
+        "read_response_too_large"       => SMBEvent::ReadResponseTooLarge as i32,
+        "write_request_too_large"       => SMBEvent::WriteRequestTooLarge as i32,
         _ => -1,
     }
 }

--- a/rust/src/smb/events.rs
+++ b/rust/src/smb/events.rs
@@ -32,8 +32,12 @@ pub enum SMBEvent {
     ReadRequestTooLarge = 8,
     /// READ response bigger than `max_read_size`
     ReadResponseTooLarge = 9,
+    ReadResponseQueueSizeExceeded = 10,
+    ReadResponseQueueCntExceeded = 11,
     /// WRITE request for more than `max_write_size`
-    WriteRequestTooLarge = 10,
+    WriteRequestTooLarge = 12,
+    WriteQueueSizeExceeded = 13,
+    WriteQueueCntExceeded = 14,
 }
 
 impl SMBEvent {
@@ -49,7 +53,11 @@ impl SMBEvent {
             7 => Some(SMBEvent::FileOverlap),
             8 => Some(SMBEvent::ReadRequestTooLarge),
             9 => Some(SMBEvent::ReadResponseTooLarge),
-            10 => Some(SMBEvent::WriteRequestTooLarge),
+            10 => Some(SMBEvent::ReadResponseQueueSizeExceeded),
+            11 => Some(SMBEvent::ReadResponseQueueCntExceeded),
+            12 => Some(SMBEvent::WriteRequestTooLarge),
+            13 => Some(SMBEvent::WriteQueueSizeExceeded),
+            14 => Some(SMBEvent::WriteQueueCntExceeded),
             _ => None,
         }
     }
@@ -58,17 +66,21 @@ impl SMBEvent {
 pub fn smb_str_to_event(instr: &str) -> i32 {
     SCLogDebug!("checking {}", instr);
     match instr {
-        "internal_error"                => SMBEvent::InternalError as i32,
-        "malformed_data"                => SMBEvent::MalformedData as i32,
-        "record_overflow"               => SMBEvent::RecordOverflow as i32,
-        "malformed_ntlmssp_request"     => SMBEvent::MalformedNtlmsspRequest as i32,
-        "malformed_ntlmssp_response"    => SMBEvent::MalformedNtlmsspResponse as i32,
-        "duplicate_negotiate"           => SMBEvent::DuplicateNegotiate as i32,
-        "negotiate_malformed_dialects"  => SMBEvent::NegotiateMalformedDialects as i32,
-        "file_overlap"                  => SMBEvent::FileOverlap as i32,
-        "read_request_too_large"        => SMBEvent::ReadRequestTooLarge as i32,
-        "read_response_too_large"       => SMBEvent::ReadResponseTooLarge as i32,
-        "write_request_too_large"       => SMBEvent::WriteRequestTooLarge as i32,
+        "internal_error"                    => SMBEvent::InternalError as i32,
+        "malformed_data"                    => SMBEvent::MalformedData as i32,
+        "record_overflow"                   => SMBEvent::RecordOverflow as i32,
+        "malformed_ntlmssp_request"         => SMBEvent::MalformedNtlmsspRequest as i32,
+        "malformed_ntlmssp_response"        => SMBEvent::MalformedNtlmsspResponse as i32,
+        "duplicate_negotiate"               => SMBEvent::DuplicateNegotiate as i32,
+        "negotiate_malformed_dialects"      => SMBEvent::NegotiateMalformedDialects as i32,
+        "file_overlap"                      => SMBEvent::FileOverlap as i32,
+        "read_request_too_large"            => SMBEvent::ReadRequestTooLarge as i32,
+        "read_response_too_large"           => SMBEvent::ReadResponseTooLarge as i32,
+        "read_queue_size_too_large"         => SMBEvent::ReadResponseQueueSizeExceeded as i32,
+        "read_queue_cnt_too_large"          => SMBEvent::ReadResponseQueueCntExceeded as i32,
+        "write_request_too_large"           => SMBEvent::WriteRequestTooLarge as i32,
+        "write_queue_size_too_large"        => SMBEvent::WriteQueueSizeExceeded as i32,
+        "write_queue_cnt_too_large"         => SMBEvent::WriteQueueCntExceeded as i32,
         _ => -1,
     }
 }

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -83,13 +83,13 @@ impl SMBFiles {
 /// little wrapper around the FileTransferTracker::new_chunk method
 pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContainer,
         flags: u16, name: &Vec<u8>, data: &[u8],
-        chunk_offset: u64, chunk_size: u32, fill_bytes: u8, is_last: bool, xid: &u32)
+        chunk_offset: u64, chunk_size: u32, is_last: bool, xid: &u32)
 {
     match unsafe {SURICATA_SMB_FILE_CONFIG} {
         Some(sfcm) => {
             ft.new_chunk(sfcm, files, flags, &name, data, chunk_offset,
-                    chunk_size, fill_bytes, is_last, xid); }
-        None => panic!("BUG"),
+                    chunk_size, 0, is_last, xid); }
+        None => panic!("no SURICATA_SMB_FILE_CONFIG"),
     }
 }
 

--- a/rust/src/smb/log.rs
+++ b/rust/src/smb/log.rs
@@ -248,6 +248,13 @@ fn smb_common_header(state: &SMBState, tx: &SMBTransaction) -> Json
             }
 
             js.set_string("server_guid", &guid_to_string(&x.server_guid));
+
+            if state.max_read_size > 0 {
+                js.set_integer("max_read_size", state.max_read_size as u64);
+            }
+            if state.max_write_size > 0 {
+                js.set_integer("max_write_size", state.max_write_size as u64);
+            }
         },
         Some(SMBTransactionTypeData::TREECONNECT(ref x)) => {
             js.set_integer("tree_id", x.tree_id as u64);

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -52,7 +52,11 @@ use crate::smb::files::*;
 use crate::smb::smb2_ioctl::*;
 
 pub static mut SMB_CFG_MAX_READ_SIZE: u32 = 0;
+pub static mut SMB_CFG_MAX_READ_QUEUE_SIZE: u32 = 0;
+pub static mut SMB_CFG_MAX_READ_QUEUE_CNT: u32 = 0;
 pub static mut SMB_CFG_MAX_WRITE_SIZE: u32 = 0;
+pub static mut SMB_CFG_MAX_WRITE_QUEUE_SIZE: u32 = 0;
+pub static mut SMB_CFG_MAX_WRITE_QUEUE_CNT: u32 = 0;
 
 pub static mut SURICATA_SMB_FILE_CONFIG: Option<&'static SuricataFileContext> = None;
 
@@ -2206,7 +2210,11 @@ pub extern "C" fn rs_smb_state_get_event_info_by_id(event_id: std::os::raw::c_in
             SMBEvent::FileOverlap => { "file_overlap\0" },
             SMBEvent::ReadRequestTooLarge => { "read_request_too_large\0" },
             SMBEvent::ReadResponseTooLarge => { "read_response_too_large\0" },
+            SMBEvent::ReadResponseQueueSizeExceeded => { "read_queue_size_too_large\0" },
+            SMBEvent::ReadResponseQueueCntExceeded => { "read_queue_cnt_too_large\0" },
             SMBEvent::WriteRequestTooLarge => { "write_request_too_large\0" },
+            SMBEvent::WriteQueueSizeExceeded => { "write_queue_size_too_large\0" },
+            SMBEvent::WriteQueueCntExceeded => { "write_queue_cnt_too_large\0" },
         };
         unsafe{
             *event_name = estr.as_ptr() as *const std::os::raw::c_char;
@@ -2245,8 +2253,13 @@ pub extern "C" fn rs_smb_state_get_event_info(event_name: *const std::os::raw::c
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_smb_set_conf_val(max_read_size: u32, max_write_size: u32)
+pub unsafe extern "C" fn rs_smb_set_conf_val(max_read_size: u32, max_write_size: u32,
+    max_write_queue_size: u32, max_write_queue_cnt: u32, max_read_queue_size: u32, max_read_queue_cnt: u32)
 {
     SMB_CFG_MAX_READ_SIZE = max_read_size;
     SMB_CFG_MAX_WRITE_SIZE = max_write_size;
+    SMB_CFG_MAX_WRITE_QUEUE_SIZE = max_write_queue_size;
+    SMB_CFG_MAX_WRITE_QUEUE_CNT = max_write_queue_cnt;
+    SMB_CFG_MAX_READ_QUEUE_SIZE = max_read_queue_size;
+    SMB_CFG_MAX_READ_QUEUE_CNT = max_read_queue_cnt;
 }

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -803,6 +803,9 @@ pub struct SMBState<> {
     /// them while inspecting DCERPC REQUEST txs
     pub dcerpc_ifaces: Option<Vec<DCERPCIface>>,
 
+    pub max_read_size: u32,
+    pub max_write_size: u32,
+
     /// Timestamp in seconds of last update. This is packet time,
     /// potentially coming from pcaps.
     ts: u64,
@@ -840,6 +843,8 @@ impl SMBState {
             dialect_vec: None,
             dcerpc_ifaces: None,
             ts: 0,
+            max_read_size: 0,
+            max_write_size: 0,
         }
     }
 
@@ -2196,6 +2201,9 @@ pub extern "C" fn rs_smb_state_get_event_info_by_id(event_id: std::os::raw::c_in
             SMBEvent::DuplicateNegotiate => { "duplicate_negotiate\0" },
             SMBEvent::NegotiateMalformedDialects => { "netogiate_malformed_dialects\0" },
             SMBEvent::FileOverlap => { "file_overlap\0" },
+            SMBEvent::ReadRequestTooLarge => { "read_request_too_large\0" },
+            SMBEvent::ReadResponseTooLarge => { "read_response_too_large\0" },
+            SMBEvent::WriteRequestTooLarge => { "write_request_too_large\0" },
         };
         unsafe{
             *event_name = estr.as_ptr() as *const std::os::raw::c_char;

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -51,6 +51,9 @@ use crate::smb::events::*;
 use crate::smb::files::*;
 use crate::smb::smb2_ioctl::*;
 
+pub static mut SMB_CFG_MAX_READ_SIZE: u32 = 0;
+pub static mut SMB_CFG_MAX_WRITE_SIZE: u32 = 0;
+
 pub static mut SURICATA_SMB_FILE_CONFIG: Option<&'static SuricataFileContext> = None;
 
 #[no_mangle]
@@ -2239,4 +2242,11 @@ pub extern "C" fn rs_smb_state_get_event_info(event_name: *const std::os::raw::c
         return -1;
     }
     0
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_smb_set_conf_val(max_read_size: u32, max_write_size: u32)
+{
+    SMB_CFG_MAX_READ_SIZE = max_read_size;
+    SMB_CFG_MAX_WRITE_SIZE = max_write_size;
 }

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -2208,6 +2208,8 @@ pub extern "C" fn rs_smb_state_get_event_info_by_id(event_id: std::os::raw::c_in
             SMBEvent::DuplicateNegotiate => { "duplicate_negotiate\0" },
             SMBEvent::NegotiateMalformedDialects => { "netogiate_malformed_dialects\0" },
             SMBEvent::FileOverlap => { "file_overlap\0" },
+            SMBEvent::NegotiateMaxReadSizeTooLarge => { "negotiate_max_read_size_too_large\0" },
+            SMBEvent::NegotiateMaxWriteSizeTooLarge => { "negotiate_max_write_size_too_large\0" },
             SMBEvent::ReadRequestTooLarge => { "read_request_too_large\0" },
             SMBEvent::ReadResponseTooLarge => { "read_response_too_large\0" },
             SMBEvent::ReadResponseQueueSizeExceeded => { "read_queue_size_too_large\0" },

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -916,7 +916,7 @@ pub fn smb1_write_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
                         }
                         filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                                 &file_name, rd.data, rd.offset,
-                                rd.len, 0, false, &file_id);
+                                rd.len, false, &file_id);
                         SCLogDebug!("FID {:?} found at tx {}", file_fid, tx.id);
                     }
                     true
@@ -944,7 +944,7 @@ pub fn smb1_write_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
                         }
                         filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                                 &file_name, rd.data, rd.offset,
-                                rd.len, 0, false, &file_id);
+                                rd.len, false, &file_id);
                         tdf.share_name = share_name;
                     }
                     tx.vercmd.set_smb1_cmd(SMB1_COMMAND_WRITE_ANDX);
@@ -1010,7 +1010,7 @@ pub fn smb1_read_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
                                 }
                                 filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                                         &file_name, rd.data, offset,
-                                        rd.len, 0, false, &file_id);
+                                        rd.len, false, &file_id);
                             }
                             true
                         },
@@ -1026,7 +1026,7 @@ pub fn smb1_read_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
                             }
                             filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                                     &file_name, rd.data, offset,
-                                    rd.len, 0, false, &file_id);
+                                    rd.len, false, &file_id);
                             tdf.share_name = share_name;
                         }
                         tx.vercmd.set_smb1_cmd(SMB1_COMMAND_READ_ANDX);

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -154,7 +154,7 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         }
                         filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                                 &tdf.file_name, rd.data, offset,
-                                rd.len, 0, false, &file_id);
+                                rd.len, false, &file_id);
                     }
                     true
                 },
@@ -216,7 +216,7 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         }
                         filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                                 &file_name, rd.data, offset,
-                                rd.len, 0, false, &file_id);
+                                rd.len, false, &file_id);
                         tdf.share_name = share_name;
                     }
                     tx.vercmd.set_smb2_cmd(SMB2_COMMAND_READ);
@@ -267,7 +267,7 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         }
                         filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                                 &file_name, wr.data, wr.wr_offset,
-                                wr.wr_len, 0, false, &file_id);
+                                wr.wr_len, false, &file_id);
                     }
                     true
                 },
@@ -325,7 +325,7 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         }
                         filetracker_newchunk(&mut tdf.file_tracker, files, flags,
                                 &file_name, wr.data, wr.wr_offset,
-                                wr.wr_len, 0, false, &file_id);
+                                wr.wr_len, false, &file_id);
                     }
                     tx.vercmd.set_smb2_cmd(SMB2_COMMAND_WRITE);
                     tx.hdr = SMBCommonHdr::new(SMBHDR_TYPE_HEADER,

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -837,6 +837,15 @@ pub fn smb2_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                 Ok((_, rd)) => {
                     SCLogDebug!("SERVER dialect => {}", &smb2_dialect_string(rd.dialect));
 
+                    let smb_cfg_max_read_size = unsafe { SMB_CFG_MAX_READ_SIZE };
+                    if smb_cfg_max_read_size != 0 && rd.max_read_size > smb_cfg_max_read_size {
+                        state.set_event(SMBEvent::NegotiateMaxReadSizeTooLarge);
+                    }
+                    let smb_cfg_max_write_size = unsafe { SMB_CFG_MAX_WRITE_SIZE };
+                    if smb_cfg_max_write_size != 0 && rd.max_write_size > smb_cfg_max_write_size {
+                        state.set_event(SMBEvent::NegotiateMaxWriteSizeTooLarge);
+                    }
+
                     state.dialect = rd.dialect;
                     state.max_read_size = rd.max_read_size;
                     state.max_write_size = rd.max_write_size;

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -128,6 +128,12 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                 return;
             }
 
+            if state.max_read_size > 0 && rd.len > state.max_read_size {
+                state.set_event(SMBEvent::ReadResponseTooLarge);
+                state.set_skip(STREAM_TOCLIENT, rd.len, rd.data.len() as u32);
+                return;
+            }
+
             SCLogDebug!("SMBv2: read response => {:?}", rd);
 
             // get the request info. If we don't have it, there is nothing
@@ -247,6 +253,12 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
     }
     match parse_smb2_request_write(r.data) {
         Ok((_, wr)) => {
+            if state.max_read_size != 0 && wr.wr_len > state.max_write_size {
+                state.set_event(SMBEvent::WriteRequestTooLarge);
+                state.set_skip(STREAM_TOSERVER, wr.wr_len, wr.data.len() as u32);
+                return;
+            }
+
             /* update key-guid map */
             let guid_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_GUID);
             state.ssn2vec_map.insert(guid_key, wr.guid.to_vec());
@@ -459,13 +471,17 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
         SMB2_COMMAND_READ => {
             match parse_smb2_request_read(r.data) {
                 Ok((_, rd)) => {
-                    SCLogDebug!("SMBv2 READ: GUID {:?} requesting {} bytes at offset {}",
-                            rd.guid, rd.rd_len, rd.rd_offset);
+                    if state.max_read_size != 0 && rd.rd_len > state.max_read_size {
+                        events.push(SMBEvent::ReadRequestTooLarge);
+                    } else {
+                        SCLogDebug!("SMBv2 READ: GUID {:?} requesting {} bytes at offset {}",
+                                rd.guid, rd.rd_len, rd.rd_offset);
 
-                    // store read guid,offset in map
-                    let guid_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_OFFSET);
-                    let guidoff = SMBFileGUIDOffset::new(rd.guid.to_vec(), rd.rd_offset);
-                    state.ssn2vecoffset_map.insert(guid_key, guidoff);
+                        // store read guid,offset in map
+                        let guid_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_OFFSET);
+                        let guidoff = SMBFileGUIDOffset::new(rd.guid.to_vec(), rd.rd_offset);
+                        state.ssn2vecoffset_map.insert(guid_key, guidoff);
+                    }
                 },
                 _ => {
                     events.push(SMBEvent::MalformedData);
@@ -746,6 +762,9 @@ pub fn smb2_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     SCLogDebug!("SERVER dialect => {}", &smb2_dialect_string(rd.dialect));
 
                     state.dialect = rd.dialect;
+                    state.max_read_size = rd.max_read_size;
+                    state.max_write_size = rd.max_write_size;
+
                     let found2 = match state.get_negotiate_tx(2) {
                         Some(tx) => {
                             if let Some(SMBTransactionTypeData::NEGOTIATE(ref mut tdn)) = tx.type_data {

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -134,6 +134,9 @@ named!(pub parse_smb2_request_negotiate_protocol<Smb2NegotiateProtocolRequestRec
 pub struct Smb2NegotiateProtocolResponseRecord<'a> {
     pub dialect: u16,
     pub server_guid: &'a[u8],
+    pub max_trans_size: u32,
+    pub max_read_size: u32,
+    pub max_write_size: u32,
 }
 
 named!(pub parse_smb2_response_negotiate_protocol<Smb2NegotiateProtocolResponseRecord>,
@@ -143,9 +146,16 @@ named!(pub parse_smb2_response_negotiate_protocol<Smb2NegotiateProtocolResponseR
         >>  dialect: le_u16
         >>  _ctx_cnt: le_u16
         >>  server_guid: take!(16)
+        >>  _capabilities: le_u32
+        >>  max_trans_size: le_u32
+        >>  max_read_size: le_u32
+        >>  max_write_size: le_u32
         >>  (Smb2NegotiateProtocolResponseRecord {
                 dialect,
-                server_guid
+                server_guid,
+                max_trans_size,
+                max_read_size,
+                max_write_size
             })
 ));
 
@@ -156,9 +166,11 @@ named!(pub parse_smb2_response_negotiate_protocol_error<Smb2NegotiateProtocolRes
         >>  (Smb2NegotiateProtocolResponseRecord {
                 dialect: 0,
                 server_guid: &[],
+                max_trans_size: 0,
+                max_read_size: 0,
+                max_write_size: 0
             })
 ));
-
 
 #[derive(Debug,PartialEq)]
 pub struct Smb2SessionSetupRequestRecord<'a> {

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -263,6 +263,10 @@ void RegisterSMBParsers(void)
     const char *proto_name = "smb";
     uint32_t max_read_size = 0;
     uint32_t max_write_size = 0;
+    uint32_t max_write_queue_size = 0;
+    uint32_t max_write_queue_cnt = 0;
+    uint32_t max_read_queue_size = 0;
+    uint32_t max_read_queue_cnt = 0;
     /** SMB */
     if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name)) {
         AppLayerProtoDetectRegisterProtocol(ALPROTO_SMB, proto_name);
@@ -367,7 +371,53 @@ void RegisterSMBParsers(void)
         }
         SCLogConfig("SMB max-write-size: %u", max_write_size);
 
-        rs_smb_set_conf_val(max_read_size, max_write_size);
+        ConfNode *wqs = ConfGetNode("app-layer.protocols.smb.max-write-queue-size");
+        if (wqs != NULL) {
+            uint32_t value;
+            if (ParseSizeStringU32(wqs->val, &value) < 0) {
+                SCLogError(
+                        SC_ERR_SMB_CONFIG, "invalid value for max-write-queue-size %s", wqs->val);
+            } else {
+                max_write_queue_size = value;
+            }
+        }
+        SCLogConfig("SMB max-write-queue-size: %u", max_write_queue_size);
+
+        ConfNode *wqc = ConfGetNode("app-layer.protocols.smb.max-write-queue-cnt");
+        if (wqc != NULL) {
+            uint32_t value;
+            if (ParseSizeStringU32(wqc->val, &value) < 0) {
+                SCLogError(SC_ERR_SMB_CONFIG, "invalid value for max-write-queue-cnt %s", wqc->val);
+            } else {
+                max_write_queue_cnt = value;
+            }
+        }
+        SCLogConfig("SMB max-write-queue-cnt: %u", max_write_queue_cnt);
+
+        ConfNode *rqs = ConfGetNode("app-layer.protocols.smb.max-read-queue-size");
+        if (rqs != NULL) {
+            uint32_t value;
+            if (ParseSizeStringU32(rqs->val, &value) < 0) {
+                SCLogError(SC_ERR_SMB_CONFIG, "invalid value for max-read-queue-size %s", rqs->val);
+            } else {
+                max_read_queue_size = value;
+            }
+        }
+        SCLogConfig("SMB max-read-queue-size: %u", max_read_queue_size);
+
+        ConfNode *rqc = ConfGetNode("app-layer.protocols.smb.max-read-queue-cnt");
+        if (rqc != NULL) {
+            uint32_t value;
+            if (ParseSizeStringU32(rqc->val, &value) < 0) {
+                SCLogError(SC_ERR_SMB_CONFIG, "invalid value for max-read-queue-cnt %s", rqc->val);
+            } else {
+                max_read_queue_cnt = value;
+            }
+        }
+        SCLogConfig("SMB max-read-queue-cnt: %u", max_read_queue_cnt);
+
+        rs_smb_set_conf_val(max_read_size, max_write_size, max_write_queue_size,
+                max_write_queue_cnt, max_read_queue_size, max_read_queue_cnt);
     } else {
         SCLogConfig("Parsed disabled for %s protocol. Protocol detection"
                   "still on.", proto_name);


### PR DESCRIPTION
https://github.com/OISF/suricata/pull/7277 with fixes for Rust 1.33.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5137

Previous PR: https://github.com/OISF/suricata/pull/7275

Changes since v1:
- Rename events to match rule keywords