### PR TITLE
5.0.x: scripts/bundle: use git instead of tar.gz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+# Specify libhtp and suricata-update requirements.
+#
+# Format:
+#
+#   name {repo} {branch|tag}
+libhtp https://github.com/OISF/libhtp 0.5.x
+suricata-update https://github.com/OISF/suricata-update 1.1.3

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -1,0 +1,48 @@
+#! /usr/bin/env bash
+#
+# This script will bundle libhtp and/or suricata-update for you.
+#
+# To use, run from the top Suricata source directory:
+#
+#    ./scripts/bundle.sh
+
+what="$1"
+
+while IFS= read -r requirement; do
+    set -- $requirement
+
+    # If a requirement was specified on the command line, skip all other
+    # requirements.
+    if [ "${what}" != "" ]; then
+        if [ "${what}" != "$1" ]; then
+            continue
+        fi
+    fi
+    case "$1" in
+        suricata-update)
+            repo=${SU_REPO:-$2}
+            branch=${SU_BRANCH:-$3}
+            echo "===> Bundling ${repo} -b ${branch}"
+            rm -rf suricata-update.tmp
+            git clone "${repo}" -b "${branch}" suricata-update.tmp
+            cp -a suricata-update.tmp/* suricata-update/
+            rm -rf suricata-update.tmp
+            ;;
+        libhtp)
+            repo=${LIBHTP_REPO:-$2}
+            branch=${LIBHTP_BRANCH:-$3}
+            echo "===> Bundling ${repo} -b ${branch}"
+            rm -rf libhtp
+            git clone "${repo}" -b "${branch}" libhtp
+            ;;
+        \#)
+            # Ignore comment.
+            ;;
+        "")
+            # Ignore blank line.
+            ;;
+        *)
+            echo "error: unknown requirement: $1"
+            ;;
+    esac
+done < ./requirements.txt


### PR DESCRIPTION
To better fit with our current CI processes, use git to clone the
suricata-update and libhtp dependencies.  The requirements.txt file has
been modified to take a repo URL and a `-b` command line option for tag
or branch.

For the 5.0.x branch we will use the libhtp 0.5.x branch and the
suricata-update 1.1.3 tag.

Also allows for repo and branch names to be overrided with environment
variables:
- SU_REPO
- SU_BRANCH
- LIBHTP_REPO
- LIBHTP_BRANCH
