### PR TITLE
decode: fix integer warnings

### DIFF
--- a/src/decode-geneve.c
+++ b/src/decode-geneve.c
@@ -51,11 +51,11 @@
 #define GENEVE_RESERVED_FLAGS(hdr_ptr) (hdr_ptr->flags & 0x3F)
 
 #define GENEVE_MIN_HEADER_LEN            sizeof(GeneveHeader)
-#define GENEVE_TOTAL_OPT_LEN(hdr_ptr)    ((hdr_ptr->ver_plus_len & 0x3F) << 2)
+#define GENEVE_TOTAL_OPT_LEN(hdr_ptr)    ((uint8_t)((hdr_ptr->ver_plus_len & 0x3F) << 2))
 #define GENEVE_TOTAL_HEADER_LEN(hdr_ptr) (GENEVE_MIN_HEADER_LEN + GENEVE_TOTAL_OPT_LEN(hdr_ptr))
 
 #define GENEVE_MIN_SINGLE_OPT_LEN         sizeof(GeneveOption)
-#define GENEVE_SINGLE_OPT_LEN(option_ptr) ((option_ptr->flags_plus_len & 0x1F) << 2)
+#define GENEVE_SINGLE_OPT_LEN(option_ptr) ((uint8_t)((option_ptr->flags_plus_len & 0x1F) << 2))
 #define GENEVE_SINGLE_OPT_TOTAL_LEN(option_ptr)                                                    \
     (GENEVE_MIN_SINGLE_OPT_LEN + GENEVE_SINGLE_OPT_LEN(option_ptr))
 

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -41,6 +41,7 @@
 #include "flow.h"
 #include "util-debug.h"
 #include "util-print.h"
+#include "util-validate.h"
 
 #include "pkt-var.h"
 #include "util-profiling.h"
@@ -201,7 +202,8 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     p->proto = IPPROTO_ICMPV6;
     p->icmp_s.type = p->icmpv6h->type;
     p->icmp_s.code = p->icmpv6h->code;
-    p->payload_len = len - ICMPV6_HEADER_LEN;
+    DEBUG_VALIDATE_BUG_ON(len - ICMPV6_HEADER_LEN > UINT16_MAX);
+    p->payload_len = (uint16_t)(len - ICMPV6_HEADER_LEN);
     p->payload = (uint8_t *)pkt + ICMPV6_HEADER_LEN;
 
     int ctype = ICMPv6GetCounterpart(p->icmp_s.type);
@@ -222,8 +224,8 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                 if (unlikely(len > ICMPV6_HEADER_LEN + USHRT_MAX)) {
                     return TM_ECODE_FAILED;
                 }
-                DecodePartialIPV6(p, (uint8_t*) (pkt + ICMPV6_HEADER_LEN),
-                                  len - ICMPV6_HEADER_LEN );
+                DecodePartialIPV6(p, (uint8_t *)(pkt + ICMPV6_HEADER_LEN),
+                        (uint16_t)(len - ICMPV6_HEADER_LEN));
                 full_hdr = 1;
             }
 
@@ -238,8 +240,8 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                     return TM_ECODE_FAILED;
                 }
                 p->icmpv6vars.mtu = ICMPV6_GET_MTU(p);
-                DecodePartialIPV6(p, (uint8_t*) (pkt + ICMPV6_HEADER_LEN),
-                                  len - ICMPV6_HEADER_LEN );
+                DecodePartialIPV6(p, (uint8_t *)(pkt + ICMPV6_HEADER_LEN),
+                        (uint16_t)(len - ICMPV6_HEADER_LEN));
                 full_hdr = 1;
             }
 
@@ -253,8 +255,8 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                 if (unlikely(len > ICMPV6_HEADER_LEN + USHRT_MAX)) {
                     return TM_ECODE_FAILED;
                 }
-                DecodePartialIPV6(p, (uint8_t*) (pkt + ICMPV6_HEADER_LEN),
-                                  len - ICMPV6_HEADER_LEN );
+                DecodePartialIPV6(p, (uint8_t *)(pkt + ICMPV6_HEADER_LEN),
+                        (uint16_t)(len - ICMPV6_HEADER_LEN));
                 full_hdr = 1;
             }
 
@@ -269,8 +271,8 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                     return TM_ECODE_FAILED;
                 }
                 p->icmpv6vars.error_ptr= ICMPV6_GET_ERROR_PTR(p);
-                DecodePartialIPV6(p, (uint8_t*) (pkt + ICMPV6_HEADER_LEN),
-                                  len - ICMPV6_HEADER_LEN );
+                DecodePartialIPV6(p, (uint8_t *)(pkt + ICMPV6_HEADER_LEN),
+                        (uint16_t)(len - ICMPV6_HEADER_LEN));
                 full_hdr = 1;
             }
 

--- a/src/decode-ipv4.h
+++ b/src/decode-ipv4.h
@@ -120,8 +120,7 @@ typedef struct IPV4Hdr_
  */
 #define IPV4_GET_VER(p) \
     IPV4_GET_RAW_VER((p)->ip4h)
-#define IPV4_GET_HLEN(p) \
-    (IPV4_GET_RAW_HLEN((p)->ip4h) << 2)
+#define IPV4_GET_HLEN(p) ((uint8_t)(IPV4_GET_RAW_HLEN((p)->ip4h) << 2))
 #define IPV4_GET_IPTOS(p) \
     IPV4_GET_RAW_IPTOS((p)->ip4h)
 #define IPV4_GET_IPLEN(p) \

--- a/src/decode-mpls.c
+++ b/src/decode-mpls.c
@@ -53,7 +53,7 @@ int DecodeMPLS(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 
     uint32_t shim;
     int label;
-    int event = 0;
+    uint8_t event = 0;
 
     StatsIncr(tv, dtv->counter_mpls);
 
@@ -75,7 +75,7 @@ int DecodeMPLS(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         if (len > USHRT_MAX) {
             return TM_ECODE_FAILED;
         }
-        return DecodeIPV4(tv, dtv, p, pkt, len);
+        return DecodeIPV4(tv, dtv, p, pkt, (uint16_t)len);
     }
     else if (label == MPLS_LABEL_ROUTER_ALERT) {
         /* Not valid at the bottom of the stack. */
@@ -85,7 +85,7 @@ int DecodeMPLS(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         if (len > USHRT_MAX) {
             return TM_ECODE_FAILED;
         }
-        return DecodeIPV6(tv, dtv, p, pkt, len);
+        return DecodeIPV6(tv, dtv, p, pkt, (uint16_t)len);
     }
     else if (label == MPLS_LABEL_NULL) {
         /* Shouldn't appear on the wire. */
@@ -112,13 +112,13 @@ int DecodeMPLS(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         if (len > USHRT_MAX) {
             return TM_ECODE_FAILED;
         }
-        DecodeIPV4(tv, dtv, p, pkt, len);
+        DecodeIPV4(tv, dtv, p, pkt, (uint16_t)len);
         break;
     case MPLS_PROTO_IPV6:
         if (len > USHRT_MAX) {
             return TM_ECODE_FAILED;
         }
-        DecodeIPV6(tv, dtv, p, pkt, len);
+        DecodeIPV6(tv, dtv, p, pkt, (uint16_t)len);
         break;
     case MPLS_PROTO_ETHERNET_PW:
         DecodeEthernet(tv, dtv, p, pkt + MPLS_PW_LEN, len - MPLS_PW_LEN);

--- a/src/decode-nsh.c
+++ b/src/decode-nsh.c
@@ -106,9 +106,15 @@ int DecodeNSH(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *p
     /* Try to decode the payload */
     switch (next_protocol) {
         case NSH_NEXT_PROTO_IPV4:
-            return DecodeIPV4(tv, dtv, p, pkt + length, len - length);
+            if (len - length > USHRT_MAX) {
+                return TM_ECODE_FAILED;
+            }
+            return DecodeIPV4(tv, dtv, p, pkt + length, (uint16_t)(len - length));
         case NSH_NEXT_PROTO_IPV6:
-            return DecodeIPV6(tv, dtv, p, pkt + length, len - length);
+            if (len - length > USHRT_MAX) {
+                return TM_ECODE_FAILED;
+            }
+            return DecodeIPV6(tv, dtv, p, pkt + length, (uint16_t)(len - length));
         case NSH_NEXT_PROTO_ETHERNET:
             return DecodeEthernet(tv, dtv, p, pkt + length, len - length);
         case NSH_NEXT_PROTO_MPLS:

--- a/src/decode-null.c
+++ b/src/decode-null.c
@@ -76,7 +76,11 @@ int DecodeNull(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     switch(type) {
         case AF_INET:
             SCLogDebug("IPV4 Packet");
-            DecodeIPV4(tv, dtv, p, GET_PKT_DATA(p)+HDR_SIZE, GET_PKT_LEN(p)-HDR_SIZE);
+            if (GET_PKT_LEN(p) - HDR_SIZE > USHRT_MAX) {
+                return TM_ECODE_FAILED;
+            }
+            DecodeIPV4(
+                    tv, dtv, p, GET_PKT_DATA(p) + HDR_SIZE, (uint16_t)(GET_PKT_LEN(p) - HDR_SIZE));
             break;
         case AF_INET6_BSD:
         case AF_INET6_FREEBSD:
@@ -85,7 +89,11 @@ int DecodeNull(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         case AF_INET6_SOLARIS:
         case AF_INET6_WINSOCK:
             SCLogDebug("IPV6 Packet");
-            DecodeIPV6(tv, dtv, p, GET_PKT_DATA(p)+HDR_SIZE, GET_PKT_LEN(p)-HDR_SIZE);
+            if (GET_PKT_LEN(p) - HDR_SIZE > USHRT_MAX) {
+                return TM_ECODE_FAILED;
+            }
+            DecodeIPV6(
+                    tv, dtv, p, GET_PKT_DATA(p) + HDR_SIZE, (uint16_t)(GET_PKT_LEN(p) - HDR_SIZE));
             break;
         default:
             SCLogDebug("Unknown Null packet type version %" PRIu32 "", type);

--- a/src/decode-ppp.c
+++ b/src/decode-ppp.c
@@ -75,7 +75,8 @@ int DecodePPP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             }
 
             if (likely(IPV4_GET_RAW_VER((IPV4Hdr *)(pkt + PPP_HEADER_LEN)) == 4)) {
-                return DecodeIPV4(tv, dtv, p, pkt + PPP_HEADER_LEN, len - PPP_HEADER_LEN);
+                return DecodeIPV4(
+                        tv, dtv, p, pkt + PPP_HEADER_LEN, (uint16_t)(len - PPP_HEADER_LEN));
             } else
                 return TM_ECODE_FAILED;
             break;
@@ -90,7 +91,7 @@ int DecodePPP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                 return TM_ECODE_FAILED;
             }
 
-            return DecodeIPV4(tv, dtv, p, pkt + PPP_HEADER_LEN, len - PPP_HEADER_LEN);
+            return DecodeIPV4(tv, dtv, p, pkt + PPP_HEADER_LEN, (uint16_t)(len - PPP_HEADER_LEN));
 
             /* PPP IPv6 was not tested */
         case PPP_IPV6:
@@ -103,7 +104,7 @@ int DecodePPP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                 return TM_ECODE_FAILED;
             }
 
-            return DecodeIPV6(tv, dtv, p, pkt + PPP_HEADER_LEN, len - PPP_HEADER_LEN);
+            return DecodeIPV6(tv, dtv, p, pkt + PPP_HEADER_LEN, (uint16_t)(len - PPP_HEADER_LEN));
 
         case PPP_VJ_COMP:
         case PPP_IPX:

--- a/src/decode-pppoe.c
+++ b/src/decode-pppoe.c
@@ -212,7 +212,7 @@ int DecodePPPOESession(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                 }
 
                 if (IPV4_GET_RAW_VER((IPV4Hdr *)(pkt + pppoesh_len)) == 4) {
-                    DecodeIPV4(tv, dtv, p, pkt + pppoesh_len, len - pppoesh_len);
+                    DecodeIPV4(tv, dtv, p, pkt + pppoesh_len, (uint16_t)(len - pppoesh_len));
                 }
                 break;
 
@@ -224,7 +224,7 @@ int DecodePPPOESession(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                 if (unlikely(len - pppoesh_len > USHRT_MAX)) {
                     return TM_ECODE_FAILED;
                 }
-                DecodeIPV4(tv, dtv, p, pkt + pppoesh_len, len - pppoesh_len);
+                DecodeIPV4(tv, dtv, p, pkt + pppoesh_len, (uint16_t)(len - pppoesh_len));
                 break;
 
             /* PPP IPv6 was not tested */
@@ -237,7 +237,7 @@ int DecodePPPOESession(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                     return TM_ECODE_FAILED;
                 }
 
-                DecodeIPV6(tv, dtv, p, pkt + pppoesh_len, len - pppoesh_len);
+                DecodeIPV6(tv, dtv, p, pkt + pppoesh_len, (uint16_t)(len - pppoesh_len));
                 break;
 
             default:

--- a/src/decode-raw.c
+++ b/src/decode-raw.c
@@ -64,13 +64,13 @@ int DecodeRaw(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             return TM_ECODE_FAILED;
         }
         SCLogDebug("IPV4 Packet");
-        DecodeIPV4(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p));
+        DecodeIPV4(tv, dtv, p, GET_PKT_DATA(p), (uint16_t)(GET_PKT_LEN(p)));
     } else if (IP_GET_RAW_VER(pkt) == 6) {
         if (unlikely(GET_PKT_LEN(p) > USHRT_MAX)) {
             return TM_ECODE_FAILED;
         }
         SCLogDebug("IPV6 Packet");
-        DecodeIPV6(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p));
+        DecodeIPV6(tv, dtv, p, GET_PKT_DATA(p), (uint16_t)(GET_PKT_LEN(p)));
     } else {
         SCLogDebug("Unknown ip version %d", IP_GET_RAW_VER(pkt));
         ENGINE_SET_EVENT(p,IPRAW_INVALID_IPV);

--- a/src/decode-template.c
+++ b/src/decode-template.c
@@ -94,8 +94,11 @@ int DecodeTEMPLATE(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         }
          */
 
+        if (unlikely(len - hdr_len > USHRT_MAX)) {
+            return TM_ECODE_FAILED;
+        }
         /* invoke the next decoder on the remainder of the data */
-        return DecodeUDP(tv, dtv, p, (uint8_t *)pkt + hdr_len, len - hdr_len);
+        return DecodeUDP(tv, dtv, p, (uint8_t *)pkt + hdr_len, (uint16_t)(len - hdr_len));
     } else {
         //ENGINE_SET_EVENT(p,TEMPLATE_UNSUPPORTED_PROTOCOL);
         return TM_ECODE_FAILED;

--- a/src/decode-vlan.c
+++ b/src/decode-vlan.c
@@ -62,7 +62,7 @@ int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 {
     DEBUG_VALIDATE_BUG_ON(pkt == NULL);
 
-    uint32_t proto;
+    uint16_t proto;
 
     if (p->vlan_idx == 0)
         StatsIncr(tv, dtv->counter_vlan);

--- a/src/decode.c
+++ b/src/decode.c
@@ -85,10 +85,12 @@ static int DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const 
         case DECODE_TUNNEL_PPP:
             return DecodePPP(tv, dtv, p, pkt, len);
         case DECODE_TUNNEL_IPV4:
-            return DecodeIPV4(tv, dtv, p, pkt, len);
+            DEBUG_VALIDATE_BUG_ON(len > UINT16_MAX);
+            return DecodeIPV4(tv, dtv, p, pkt, (uint16_t)len);
         case DECODE_TUNNEL_IPV6:
         case DECODE_TUNNEL_IPV6_TEREDO:
-            return DecodeIPV6(tv, dtv, p, pkt, len);
+            DEBUG_VALIDATE_BUG_ON(len > UINT16_MAX);
+            return DecodeIPV6(tv, dtv, p, pkt, (uint16_t)len);
         case DECODE_TUNNEL_VLAN:
             return DecodeVLAN(tv, dtv, p, pkt, len);
         case DECODE_TUNNEL_ETHERNET:
@@ -778,7 +780,7 @@ void DecodeGlobalConfig(void)
         if (value < 0 || value > UINT8_MAX) {
             SCLogWarning(SC_ERR_INVALID_VALUE, "Invalid value for decoder.max-layers");
         } else {
-            decoder_max_layers = value;
+            decoder_max_layers = (uint8_t)value;
         }
     }
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4516

Describe changes:
- Fix integer warnings `-Wimplicit-int-conversion` for decode files

Part of #7006 as #7239 was

Then remains defrag and detect files to fix