### PR TITLE
signal/log: Fixup stack-on-signal commits

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2050,7 +2050,7 @@ static int InitSignalHandler(SCInstance *suri)
 #if HAVE_LIBUNWIND
     int enabled;
     if (ConfGetBool("logging.stacktrace-on-signal", &enabled) == 0) {
-        enabled = 1;
+        enabled = 0;
     }
 
     if (enabled) {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2005,27 +2005,6 @@ static int MayDaemonize(SCInstance *suri)
 /* Initialize the user and group Suricata is to run as. */
 static int InitRunAs(SCInstance *suri)
 {
-    /* registering signals we use */
-#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    UtilSignalHandlerSetup(SIGINT, SignalHandlerSigint);
-    UtilSignalHandlerSetup(SIGTERM, SignalHandlerSigterm);
-#if HAVE_LIBUNWIND
-    int enabled;
-    if (ConfGetBool("logging.stacktrace-on-signal", &enabled) == 0) {
-        enabled = 0;
-    }
-
-    if (enabled) {
-        SCLogInfo("Preparing unexpected signal handling");
-        struct sigaction stacktrace_action;
-        memset(&stacktrace_action, 0, sizeof(stacktrace_action));
-        stacktrace_action.sa_sigaction = SignalHandlerUnexpected;
-        stacktrace_action.sa_flags = SA_SIGINFO;
-        sigaction(SIGSEGV, &stacktrace_action, NULL);
-        sigaction(SIGABRT, &stacktrace_action, NULL);
-    }
-#endif /* HAVE_LIBUNWIND */
-#endif
 #ifndef OS_WIN32
     /* Try to get user/group to run suricata as if
        command line as not decide of that */


### PR DESCRIPTION
This PR changes the default setting of `stack-on-signal` to disabled. To use the feature, add `logging.stacktrace-on-signal=1` to your Suricata configuration.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5228](https://redmine.openinfosecfoundation.org/issues/5288)

Describe changes:
- Remove redundant stack handler initialization from `InitRunAs`
- Change default value to `off` or `disabled`.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
