### PR TITLE
suricata/init: Remove stack-on-signal code

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2290,22 +2290,6 @@ static int InitSignalHandler(SCInstance *suri)
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     UtilSignalHandlerSetup(SIGINT, SignalHandlerSigint);
     UtilSignalHandlerSetup(SIGTERM, SignalHandlerSigterm);
-#if HAVE_LIBUNWIND
-    int enabled;
-    if (ConfGetBool("logging.stacktrace-on-signal", &enabled) == 0) {
-        enabled = 1;
-    }
-
-    if (enabled) {
-        SCLogInfo("Preparing unexpected signal handling");
-        struct sigaction stacktrace_action;
-        memset(&stacktrace_action, 0, sizeof(stacktrace_action));
-        stacktrace_action.sa_sigaction = SignalHandlerUnexpected;
-        stacktrace_action.sa_flags = SA_SIGINFO;
-        sigaction(SIGSEGV, &stacktrace_action, NULL);
-        sigaction(SIGABRT, &stacktrace_action, NULL);
-    }
-#endif /* HAVE_LIBUNWIND */
 #endif
 #ifndef OS_WIN32
     UtilSignalHandlerSetup(SIGHUP, SignalHandlerSigHup);


### PR DESCRIPTION
Issue: 5229

This commit removes functionality never intended for the 5.0.x
maintenance branch: stack-on-signal logging

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5289](https://redmine.openinfosecfoundation.org/issues/5289)

Describe changes:
- Remove unnecessary functionality that setup stack-on-signal logging.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
