### PR TITLE
app-layer: more generic state trait; dns: use vecdeque - v1

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2021 Open Information Security Foundation
+/* Copyright (C) 2017-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -535,14 +535,17 @@ pub trait Transaction {
 }
 
 pub trait State<Tx: Transaction> {
-    fn get_transactions(&self) -> &[Tx];
+    /// Return the number of transactions in the state's transaction collection.
+    fn get_transaction_count(&self) -> usize;
+
+    /// Return a transaction by its index in the container.
+    fn get_transaction_by_index(&self, index: usize) -> Option<&Tx>;
 
     fn get_transaction_iterator(&self, min_tx_id: u64, state: &mut u64) -> AppLayerGetTxIterTuple {
         let mut index = *state as usize;
-        let transactions = self.get_transactions();
-        let len = transactions.len();
+        let len = self.get_transaction_count();
         while index < len {
-            let tx = &transactions[index];
+            let tx = self.get_transaction_by_index(index).unwrap();
             if tx.id() < min_tx_id + 1 {
                 index += 1;
                 continue;

--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -60,8 +60,12 @@ pub struct TemplateState {
 }
 
 impl State<TemplateTransaction> for TemplateState {
-    fn get_transactions(&self) -> &[TemplateTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&TemplateTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -109,8 +109,12 @@ pub struct DHCPState {
 }
 
 impl State<DHCPTransaction> for DHCPState {
-    fn get_transactions(&self) -> &[DHCPTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&DHCPTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -321,8 +321,12 @@ pub struct DNSState {
 }
 
 impl State<DNSTransaction> for DNSState {
-    fn get_transactions(&self) -> &[DNSTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&DNSTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -311,7 +311,7 @@ pub struct DNSState {
     pub tx_id: u64,
 
     // Transactions.
-    pub transactions: Vec<DNSTransaction>,
+    pub transactions: VecDeque<DNSTransaction>,
 
     pub events: u16,
 
@@ -401,7 +401,7 @@ impl DNSState {
 
                 let mut tx = self.new_tx();
                 tx.request = Some(request);
-                self.transactions.push(tx);
+                self.transactions.push_back(tx);
 
                 if z_flag {
                     SCLogDebug!("Z-flag set on DNS response");
@@ -445,7 +445,7 @@ impl DNSState {
                     }
                 }
                 tx.response = Some(response);
-                self.transactions.push(tx);
+                self.transactions.push_back(tx);
 
                 if z_flag {
                     SCLogDebug!("Z-flag set on DNS response");

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -403,8 +403,12 @@ pub struct HTTP2State {
 }
 
 impl State<HTTP2Transaction> for HTTP2State {
-    fn get_transactions(&self) -> &[HTTP2Transaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&HTTP2Transaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/ike/ike.rs
+++ b/rust/src/ike/ike.rs
@@ -144,8 +144,12 @@ pub struct IKEState {
 }
 
 impl State<IKETransaction> for IKEState {
-    fn get_transactions(&self) -> &[IKETransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&IKETransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -52,8 +52,12 @@ pub struct KRB5State {
 }
 
 impl State<KRB5Transaction> for KRB5State {
-    fn get_transactions(&self) -> &[KRB5Transaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&KRB5Transaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/modbus/modbus.rs
+++ b/rust/src/modbus/modbus.rs
@@ -96,8 +96,12 @@ pub struct ModbusState {
 }
 
 impl State<ModbusTransaction> for ModbusState {
-    fn get_transactions(&self) -> &[ModbusTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&ModbusTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -106,8 +106,12 @@ pub struct MQTTState {
 }
 
 impl State<MQTTTransaction> for MQTTState {
-    fn get_transactions(&self) -> &[MQTTTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&MQTTTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -325,8 +325,12 @@ pub struct NFSState {
 }
 
 impl State<NFSTransaction> for NFSState {
-    fn get_transactions(&self) -> &[NFSTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&NFSTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -74,8 +74,12 @@ impl NTPState {
 }
 
 impl State<NTPTransaction> for NTPState {
-    fn get_transactions(&self) -> &[NTPTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&NTPTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -125,8 +125,12 @@ pub struct PgsqlState {
 }
 
 impl State<PgsqlTransaction> for PgsqlState {
-    fn get_transactions(&self) -> &[PgsqlTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&PgsqlTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -113,8 +113,12 @@ pub struct RdpState {
 }
 
 impl State<RdpTransaction> for RdpState {
-    fn get_transactions(&self) -> &[RdpTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&RdpTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/rfb/rfb.rs
+++ b/rust/src/rfb/rfb.rs
@@ -84,9 +84,14 @@ pub struct RFBState {
 }
 
 impl State<RFBTransaction> for RFBState {
-    fn get_transactions(&self) -> &[RFBTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
     }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&RFBTransaction> {
+        self.transactions.get(index)
+    }
+
 }
 
 impl RFBState {

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -51,8 +51,12 @@ pub struct SIPState {
 }
 
 impl State<SIPTransaction> for SIPState {
-    fn get_transactions(&self) -> &[SIPTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&SIPTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -795,8 +795,12 @@ pub struct SMBState<> {
 }
 
 impl State<SMBTransaction> for SMBState {
-    fn get_transactions(&self) -> &[SMBTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&SMBTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -108,8 +108,12 @@ impl<'a> Default for SNMPPduInfo<'a> {
 }
 
 impl<'a> State<SNMPTransaction<'a>> for SNMPState<'a> {
-    fn get_transactions(&self) -> &[SNMPTransaction<'a>] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&SNMPTransaction<'a>> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/telnet/telnet.rs
+++ b/rust/src/telnet/telnet.rs
@@ -82,8 +82,12 @@ pub struct TelnetState {
 }
 
 impl State<TelnetTransaction> for TelnetState {
-    fn get_transactions(&self) -> &[TelnetTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&TelnetTransaction> {
+        self.transactions.get(index)
     }
 }
 


### PR DESCRIPTION
First, update the state trait to be more generic and update all parsers. This
allows for a VecDeque to be used as the transaction collection.

Second, update DNS to use a VecDeque.

Ticket: https://redmine.openinfosecfoundation.org/issues/5278
Ticket: https://redmine.openinfosecfoundation.org/issues/5277
