### PR TITLE
docs: remove obsolete warning

### DIFF
--- a/doc/userguide/performance/packet-capture.rst
+++ b/doc/userguide/performance/packet-capture.rst
@@ -8,10 +8,7 @@ To get the best performance, Suricata will need to run in 'workers' mode. This e
 
 The AF_PACKET and PF_RING capture methods both have options to select the 'cluster-type'. These default to 'cluster_flow' which instructs the capture method to hash by flow (5 tuple). This hash is symmetric. Netmap does not have a cluster_flow mode built-in. It can be added separately by using the "'lb' tool":https://github.com/luigirizzo/netmap/tree/master/apps/lb
 
-> **WARNING** Recent AF_PACKET changes have "broken":https://redmine.openinfosecfoundation.org/issues/1777 this symmetry. Work is under way to "address this":https://redmine.openinfosecfoundation.org/issues/1777#note-7, but for now stay on kernel <=4.2 or update to 4.4.16+, 4.6.5+ or 4.7+.
-
 On multi-queue NICs, which is almost any modern NIC, RSS settings need to be considered.
-
 
 RSS
 ---


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Contributing guidelines says a ticket is not necessary for minor and/or simple changes.
Describe changes:
Documentation dating to 2016(!) had a warning related to a bug in AF_PACKET, which has since been fixed (and the mentioned ticket closed).