### PR TITLE
make CIDRFromMask() work on big endian platforms

### DIFF
--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -202,6 +202,7 @@ static void RegisterUnittests(void)
     SourceWinDivertRegisterTests();
 #endif
     SCProtoNameRegisterTests();
+    UtilCIDRTests();
 }
 #endif
 

--- a/src/util-cidr.c
+++ b/src/util-cidr.c
@@ -25,6 +25,7 @@
 
 #include "suricata-common.h"
 #include "util-cidr.h"
+#include "util-unittest.h"
 
 /** \brief turn 32 bit mask into CIDR
  *  \retval cidr cidr value or -1 if the netmask can't be expressed as cidr
@@ -93,4 +94,62 @@ void CIDRGetIPv6(int cidr, struct in6_addr *in6)
         if (--cidr > 0)
             in6->s6_addr[i] = in6->s6_addr[i] >> 1;
     }
+}
+
+#ifdef UNITTESTS
+
+static int CIDRFromMaskTest01(void)
+{
+    struct in_addr in;
+    int v = inet_pton(AF_INET, "255.255.255.0", &in);
+
+    FAIL_IF(v <= 0);
+    FAIL_IF_NOT(24 == CIDRFromMask(in.s_addr));
+
+    PASS;
+}
+
+static int CIDRFromMaskTest02(void)
+{
+    struct in_addr in;
+    int v = inet_pton(AF_INET, "255.255.0.42", &in);
+
+    FAIL_IF(v <= 0);
+    FAIL_IF_NOT(-1 == CIDRFromMask(in.s_addr));
+
+    PASS;
+}
+
+static int CIDRFromMaskTest03(void)
+{
+    struct in_addr in;
+    int v = inet_pton(AF_INET, "0.0.0.0", &in);
+
+    FAIL_IF(v <= 0);
+    FAIL_IF_NOT(0 == CIDRFromMask(in.s_addr));
+
+    PASS;
+}
+
+static int CIDRFromMaskTest04(void)
+{
+    struct in_addr in;
+    int v = inet_pton(AF_INET, "255.255.255.255", &in);
+
+    FAIL_IF(v <= 0);
+    FAIL_IF_NOT(32 == CIDRFromMask(in.s_addr));
+
+    PASS;
+}
+
+#endif /* UNITTESTS */
+
+void UtilCIDRTests(void)
+{
+#ifdef UNITTESTS
+    UtRegisterTest("CIDRFromMaskTest01", CIDRFromMaskTest01);
+    UtRegisterTest("CIDRFromMaskTest02", CIDRFromMaskTest02);
+    UtRegisterTest("CIDRFromMaskTest03", CIDRFromMaskTest03);
+    UtRegisterTest("CIDRFromMaskTest04", CIDRFromMaskTest04);
+#endif /* UNITTESTS */
 }

--- a/src/util-cidr.c
+++ b/src/util-cidr.c
@@ -31,25 +31,24 @@
  */
 int CIDRFromMask(uint32_t netmask)
 {
+    netmask = ntohl(netmask);
     if (netmask == 0) {
         return 0;
     }
-    int lead_1 = 0;
-    bool seen_0 = false;
-    for (int i = 0; i < 32; i++) {
-        if (!seen_0) {
-            if ((netmask & BIT_U32(i)) != 0) {
-                lead_1++;
-            } else {
-                seen_0 = true;
-            }
+    int p = 0;
+    bool seen_1 = false;
+    while (netmask > 0) {
+        if (netmask & 1) {
+            seen_1 = true;
+            p++;
         } else {
-            if ((netmask & BIT_U32(i)) != 0) {
+            if (seen_1) {
                 return -1;
             }
         }
+        netmask >>= 1;
     }
-    return lead_1;
+    return p;
 }
 
 uint32_t CIDRGet(int cidr)

--- a/src/util-cidr.h
+++ b/src/util-cidr.h
@@ -28,5 +28,7 @@ int CIDRFromMask(uint32_t netmask);
 uint32_t CIDRGet(int);
 void CIDRGetIPv6(int cidr, struct in6_addr *in6);
 
+void UtilCIDRTests(void);
+
 #endif /* __UTIL_NETMASK_H__ */
 


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5309

Describe changes:
-  Make `CIDRFromMask()` work on big endian archs like s390x. This is required to ensure that 6.0.5 and later pass all unit tests, which are gating for migration of this version from unstable to testing.
