### PR TITLE
app-layer: use vecdeque instead of vector - v2

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2021 Open Information Security Foundation
+/* Copyright (C) 2017-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -535,14 +535,17 @@ pub trait Transaction {
 }
 
 pub trait State<Tx: Transaction> {
-    fn get_transactions(&self) -> &[Tx];
+    /// Return the number of transactions in the state's transaction collection.
+    fn get_transaction_count(&self) -> usize;
+
+    /// Return a transaction by its index in the container.
+    fn get_transaction_by_index(&self, index: usize) -> Option<&Tx>;
 
     fn get_transaction_iterator(&self, min_tx_id: u64, state: &mut u64) -> AppLayerGetTxIterTuple {
         let mut index = *state as usize;
-        let transactions = self.get_transactions();
-        let len = transactions.len();
+        let len = self.get_transaction_count();
         while index < len {
-            let tx = &transactions[index];
+            let tx = self.get_transaction_by_index(index).unwrap();
             if tx.id() < min_tx_id + 1 {
                 index += 1;
                 continue;

--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -60,8 +60,12 @@ pub struct TemplateState {
 }
 
 impl State<TemplateTransaction> for TemplateState {
-    fn get_transactions(&self) -> &[TemplateTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&TemplateTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2020 Open Information Security Foundation
+/* Copyright (C) 2018-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -16,6 +16,7 @@
  */
 
 use std;
+use std::collections::VecDeque;
 use crate::core::{ALPROTO_UNKNOWN, AppProto, Flow, IPPROTO_TCP};
 use crate::applayer::{self, *};
 use std::ffi::CString;
@@ -54,7 +55,7 @@ impl Transaction for TemplateTransaction {
 
 pub struct TemplateState {
     tx_id: u64,
-    transactions: Vec<TemplateTransaction>,
+    transactions: VecDeque<TemplateTransaction>,
     request_gap: bool,
     response_gap: bool,
 }
@@ -73,7 +74,7 @@ impl TemplateState {
     pub fn new() -> Self {
         Self {
             tx_id: 0,
-            transactions: Vec::new(),
+            transactions: VecDeque::new(),
             request_gap: false,
             response_gap: false,
         }
@@ -150,7 +151,7 @@ impl TemplateState {
                     SCLogNotice!("Request: {}", request);
                     let mut tx = self.new_tx();
                     tx.request = Some(request);
-                    self.transactions.push(tx);
+                    self.transactions.push_back(tx);
                 },
                 Err(nom::Err::Incomplete(_)) => {
                     // Not enough data. This parser doesn't give us a good indication

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -109,8 +109,12 @@ pub struct DHCPState {
 }
 
 impl State<DHCPTransaction> for DHCPState {
-    fn get_transactions(&self) -> &[DHCPTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&DHCPTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -321,8 +321,12 @@ pub struct DNSState {
 }
 
 impl State<DNSTransaction> for DNSState {
-    fn get_transactions(&self) -> &[DNSTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&DNSTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -311,7 +311,7 @@ pub struct DNSState {
     pub tx_id: u64,
 
     // Transactions.
-    pub transactions: Vec<DNSTransaction>,
+    pub transactions: VecDeque<DNSTransaction>,
 
     pub events: u16,
 
@@ -401,7 +401,7 @@ impl DNSState {
 
                 let mut tx = self.new_tx();
                 tx.request = Some(request);
-                self.transactions.push(tx);
+                self.transactions.push_back(tx);
 
                 if z_flag {
                     SCLogDebug!("Z-flag set on DNS response");
@@ -445,7 +445,7 @@ impl DNSState {
                     }
                 }
                 tx.response = Some(response);
-                self.transactions.push(tx);
+                self.transactions.push_back(tx);
 
                 if z_flag {
                     SCLogDebug!("Z-flag set on DNS response");

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -403,8 +403,12 @@ pub struct HTTP2State {
 }
 
 impl State<HTTP2Transaction> for HTTP2State {
-    fn get_transactions(&self) -> &[HTTP2Transaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&HTTP2Transaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -27,6 +27,7 @@ use crate::filecontainer::*;
 use crate::filetracker::*;
 use nom7::Err;
 use std;
+use std::collections::VecDeque;
 use std::ffi::CString;
 use std::fmt;
 use std::io;
@@ -397,7 +398,7 @@ pub struct HTTP2State {
     response_frame_size: u32,
     dynamic_headers_ts: HTTP2DynTable,
     dynamic_headers_tc: HTTP2DynTable,
-    transactions: Vec<HTTP2Transaction>,
+    transactions: VecDeque<HTTP2Transaction>,
     progress: HTTP2ConnectionState,
     pub files: Files,
 }
@@ -423,7 +424,7 @@ impl HTTP2State {
             // a variable number of dynamic headers
             dynamic_headers_ts: HTTP2DynTable::new(),
             dynamic_headers_tc: HTTP2DynTable::new(),
-            transactions: Vec::new(),
+            transactions: VecDeque::new(),
             progress: HTTP2ConnectionState::Http2StateInit,
             files: Files::default(),
         }
@@ -538,8 +539,8 @@ impl HTTP2State {
         self.tx_id += 1;
         tx.tx_id = self.tx_id;
         tx.state = HTTP2TransactionState::HTTP2StateGlobal;
-        self.transactions.push(tx);
-        return self.transactions.last_mut().unwrap();
+        self.transactions.push_back(tx);
+        return self.transactions.back_mut().unwrap();
     }
 
     pub fn find_or_create_tx(
@@ -591,8 +592,8 @@ impl HTTP2State {
                     }
                 }
             }
-            self.transactions.push(tx);
-            return self.transactions.last_mut().unwrap();
+            self.transactions.push_back(tx);
+            return self.transactions.back_mut().unwrap();
         }
     }
 

--- a/rust/src/ike/ike.rs
+++ b/rust/src/ike/ike.rs
@@ -144,8 +144,12 @@ pub struct IKEState {
 }
 
 impl State<IKETransaction> for IKEState {
-    fn get_transactions(&self) -> &[IKETransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&IKETransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -52,8 +52,12 @@ pub struct KRB5State {
 }
 
 impl State<KRB5Transaction> for KRB5State {
-    fn get_transactions(&self) -> &[KRB5Transaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&KRB5Transaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/modbus/modbus.rs
+++ b/rust/src/modbus/modbus.rs
@@ -96,8 +96,12 @@ pub struct ModbusState {
 }
 
 impl State<ModbusTransaction> for ModbusState {
-    fn get_transactions(&self) -> &[ModbusTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&ModbusTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -106,8 +106,12 @@ pub struct MQTTState {
 }
 
 impl State<MQTTTransaction> for MQTTState {
-    fn get_transactions(&self) -> &[MQTTTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&MQTTTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -325,8 +325,12 @@ pub struct NFSState {
 }
 
 impl State<NFSTransaction> for NFSState {
-    fn get_transactions(&self) -> &[NFSTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&NFSTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -74,8 +74,12 @@ impl NTPState {
 }
 
 impl State<NTPTransaction> for NTPState {
-    fn get_transactions(&self) -> &[NTPTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&NTPTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -125,8 +125,12 @@ pub struct PgsqlState {
 }
 
 impl State<PgsqlTransaction> for PgsqlState {
-    fn get_transactions(&self) -> &[PgsqlTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&PgsqlTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -631,9 +631,9 @@ mod tests {
         let tx0 = state.new_tx(item0);
         let tx1 = state.new_tx(item1);
         let tx2 = state.new_tx(item2);
-        state.transactions.push(tx0);
-        state.transactions.push(tx1);
-        state.transactions.push(tx2);
+        state.transactions.push_back(tx0);
+        state.transactions.push_back(tx1);
+        state.transactions.push_back(tx2);
         assert_eq!(Some(&state.transactions[1]), state.get_tx(2));
     }
 

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Open Information Security Foundation
+/* Copyright (C) 2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -24,6 +24,7 @@ use crate::core::{AppProto, Flow, ALPROTO_UNKNOWN, IPPROTO_TCP};
 use crate::rdp::parser::*;
 use nom;
 use std;
+use std::collections::VecDeque;
 use tls_parser::{parse_tls_plaintext, TlsMessage, TlsMessageHandshake, TlsRecordType};
 
 static mut ALPROTO_RDP: AppProto = ALPROTO_UNKNOWN;
@@ -107,7 +108,7 @@ pub extern "C" fn rs_rdp_tx_get_progress(
 #[derive(Debug, PartialEq)]
 pub struct RdpState {
     next_id: u64,
-    transactions: Vec<RdpTransaction>,
+    transactions: VecDeque<RdpTransaction>,
     tls_parsing: bool,
     bypass_parsing: bool,
 }
@@ -126,7 +127,7 @@ impl RdpState {
     fn new() -> Self {
         Self {
             next_id: 0,
-            transactions: Vec::new(),
+            transactions: VecDeque::new(),
             tls_parsing: false,
             bypass_parsing: false,
         }
@@ -208,7 +209,7 @@ impl RdpState {
                             T123TpktChild::X224ConnectionRequest(x224) => {
                                 let tx =
                                     self.new_tx(RdpTransactionItem::X224ConnectionRequest(x224));
-                                self.transactions.push(tx);
+                                self.transactions.push_back(tx);
                             }
 
                             // X.223 data packet, evaluate what it encapsulates
@@ -217,7 +218,7 @@ impl RdpState {
                                     X223DataChild::McsConnectRequest(mcs) => {
                                         let tx =
                                             self.new_tx(RdpTransactionItem::McsConnectRequest(mcs));
-                                        self.transactions.push(tx);
+                                        self.transactions.push_back(tx);
                                     }
                                     // unknown message in X.223, skip
                                     _ => (),
@@ -287,7 +288,7 @@ impl RdpState {
                                     }
                                     let tx =
                                         self.new_tx(RdpTransactionItem::TlsCertificateChain(chain));
-                                    self.transactions.push(tx);
+                                    self.transactions.push_back(tx);
                                     self.bypass_parsing = true;
                                 }
                                 _ => {}
@@ -320,7 +321,7 @@ impl RdpState {
                             T123TpktChild::X224ConnectionConfirm(x224) => {
                                 let tx =
                                     self.new_tx(RdpTransactionItem::X224ConnectionConfirm(x224));
-                                self.transactions.push(tx);
+                                self.transactions.push_back(tx);
                             }
 
                             // X.223 data packet, evaluate what it encapsulates
@@ -329,7 +330,7 @@ impl RdpState {
                                     X223DataChild::McsConnectResponse(mcs) => {
                                         let tx = self
                                             .new_tx(RdpTransactionItem::McsConnectResponse(mcs));
-                                        self.transactions.push(tx);
+                                        self.transactions.push_back(tx);
                                         self.bypass_parsing = true;
                                         return AppLayerResult::ok();
                                     }
@@ -606,8 +607,8 @@ mod tests {
         let tx0 = state.new_tx(item0);
         let tx1 = state.new_tx(item1);
         assert_eq!(2, state.next_id);
-        state.transactions.push(tx0);
-        state.transactions.push(tx1);
+        state.transactions.push_back(tx0);
+        state.transactions.push_back(tx1);
         assert_eq!(2, state.transactions.len());
         assert_eq!(1, state.transactions[0].id);
         assert_eq!(2, state.transactions[1].id);
@@ -651,9 +652,9 @@ mod tests {
         let tx0 = state.new_tx(item0);
         let tx1 = state.new_tx(item1);
         let tx2 = state.new_tx(item2);
-        state.transactions.push(tx0);
-        state.transactions.push(tx1);
-        state.transactions.push(tx2);
+        state.transactions.push_back(tx0);
+        state.transactions.push_back(tx1);
+        state.transactions.push_back(tx2);
         state.free_tx(1);
         assert_eq!(3, state.next_id);
         assert_eq!(2, state.transactions.len());

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -113,8 +113,12 @@ pub struct RdpState {
 }
 
 impl State<RdpTransaction> for RdpState {
-    fn get_transactions(&self) -> &[RdpTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&RdpTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/rfb/rfb.rs
+++ b/rust/src/rfb/rfb.rs
@@ -84,9 +84,14 @@ pub struct RFBState {
 }
 
 impl State<RFBTransaction> for RFBState {
-    fn get_transactions(&self) -> &[RFBTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
     }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&RFBTransaction> {
+        self.transactions.get(index)
+    }
+
 }
 
 impl RFBState {

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -51,8 +51,12 @@ pub struct SIPState {
 }
 
 impl State<SIPTransaction> for SIPState {
-    fn get_transactions(&self) -> &[SIPTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&SIPTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -795,8 +795,12 @@ pub struct SMBState<> {
 }
 
 impl State<SMBTransaction> for SMBState {
-    fn get_transactions(&self) -> &[SMBTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&SMBTransaction> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -108,8 +108,12 @@ impl<'a> Default for SNMPPduInfo<'a> {
 }
 
 impl<'a> State<SNMPTransaction<'a>> for SNMPState<'a> {
-    fn get_transactions(&self) -> &[SNMPTransaction<'a>] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&SNMPTransaction<'a>> {
+        self.transactions.get(index)
     }
 }
 

--- a/rust/src/telnet/telnet.rs
+++ b/rust/src/telnet/telnet.rs
@@ -82,8 +82,12 @@ pub struct TelnetState {
 }
 
 impl State<TelnetTransaction> for TelnetState {
-    fn get_transactions(&self) -> &[TelnetTransaction] {
-        &self.transactions
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&TelnetTransaction> {
+        self.transactions.get(index)
     }
 }
 


### PR DESCRIPTION
Use a VecDeque instead of a vec for a handful of Rust parsers to address
performance issues when removing transactions from the beginning of the
collection.

Tickets:
- https://redmine.openinfosecfoundation.org/issues/5278 (more generic trait)
- https://redmine.openinfosecfoundation.org/issues/5277 (dns)
- https://redmine.openinfosecfoundation.org/issues/5294 (mqtt)
- https://redmine.openinfosecfoundation.org/issues/5295 (rdp)
- https://redmine.openinfosecfoundation.org/issues/5296 (http2)
- https://redmine.openinfosecfoundation.org/issues/5297 (pgsql)
- https://redmine.openinfosecfoundation.org/issues/5298 (template)

Previous PR: https://github.com/OISF/suricata/pull/7313

Changes from last PR:
- Update for all protocols mentioned in ticket
  https://redmine.openinfosecfoundation.org/issues/5271.
