### PR TITLE
defrag: checks for timestamp overflow

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -626,6 +626,10 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
     }
 
     /* Update timeout. */
+    if (p->ts.tv_sec > INT_MAX - ((time_t)tracker->host_timeout)) {
+        SCLogWarning(SC_ERR_INVALID_ARGUMENT, "Timestamp overflow.");
+        return NULL;
+    }
     tracker->timeout.tv_sec = p->ts.tv_sec + tracker->host_timeout;
     tracker->timeout.tv_usec = p->ts.tv_usec;
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44608

Describe changes:
- checks for timestamp overflow

A few other places may need this :
 ```
> git grep "tv_sec + "
src/app-layer-expectation.c:        if (ctime > exp->ts.tv_sec + EXPECTATION_TIMEOUT) {
src/app-layer-htp-range.c:        ContainerUrlRangeUpdate(res.data->data, ts->tv_sec + ContainerUrlRangeList.timeout);
src/defrag.c:    tracker->timeout.tv_sec = p->ts.tv_sec + tracker->host_timeout;
src/detect-hostbits.c:            HostBitToggle(p->host_src,fd->idx,p->ts.tv_sec + fd->expire);
src/detect-hostbits.c:            HostBitToggle(p->host_dst,fd->idx,p->ts.tv_sec + fd->expire);
src/detect-hostbits.c:            HostBitSet(p->host_src,fd->idx,p->ts.tv_sec + fd->expire);
src/detect-hostbits.c:            HostBitSet(p->host_dst,fd->idx, p->ts.tv_sec + fd->expire);
src/detect-xbits.c:    IPPairBitToggle(pair,fd->idx,p->ts.tv_sec + fd->expire);
src/detect-xbits.c:    IPPairBitSet(pair, fd->idx, p->ts.tv_sec + fd->expire);
src/flow-util.c:    const uint32_t timeout_at = (uint32_t)f->startts.tv_sec + f->timeout_policy;
src/flow.c:            const uint32_t timeout_at = (uint32_t)f->lastts.tv_sec + f->timeout_policy;
src/flow.c:            const uint32_t timeout_at = (uint32_t)f->lastts.tv_sec + timeout_policy;
src/runmode-unix-socket.c:        HostBitSet(host, idx, current_time.tv_sec + expire);
src/source-dpdk.c:    new_tv->tv_sec = orig_tv->tv_sec + usec / 1000000;
```

Is this the right way to handle this bug before year 2262 ?
If so, I will create a ticket