### PR TITLE
pgsql: fix possible integer overflow - v1

### DIFF
--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -187,6 +187,15 @@ fn log_response(res: &PgsqlBEMessage, jb: &mut JsonBuilder) -> Result<(), JsonEr
         }) => {
             jb.set_string_from_bytes(res.to_str(), payload)?;
         }
+        PgsqlBEMessage::UnknownMessageType(RegularPacket {
+            identifier: _,
+            length,
+            payload,
+        }) => {
+            // jb.set_string_from_bytes("identifier", identifier.to_vec())?;
+            jb.set_uint("length", (*length).into())?;
+            jb.set_string_from_bytes("payload", payload)?;
+        }
         PgsqlBEMessage::AuthenticationOk(_)
         | PgsqlBEMessage::AuthenticationKerb5(_)
         | PgsqlBEMessage::AuthenticationCleartextPassword(_)

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -521,7 +521,7 @@ fn probe_tc(input: &[u8]) -> bool {
 pub unsafe extern "C" fn rs_pgsql_probing_parser_ts(
     _flow: *const Flow, _direction: u8, input: *const u8, input_len: u32, _rdir: *mut u8,
 ) -> AppProto {
-    if input_len >= 1 && input != std::ptr::null_mut() {
+    if input_len >= 1 && !input.is_null() {
         let slice: &[u8];
         slice = build_slice!(input, input_len as usize);
         if probe_ts(slice) {
@@ -536,7 +536,7 @@ pub unsafe extern "C" fn rs_pgsql_probing_parser_ts(
 pub unsafe extern "C" fn rs_pgsql_probing_parser_tc(
     _flow: *const Flow, _direction: u8, input: *const u8, input_len: u32, _rdir: *mut u8,
 ) -> AppProto {
-    if input_len >= 1 && input != std::ptr::null_mut() {
+    if input_len >= 1 && !input.is_null() {
         let slice: &[u8];
         slice = build_slice!(input, input_len as usize);
 

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -551,7 +551,7 @@ pub unsafe extern "C" fn rs_pgsql_probing_parser_tc(
             Err(Err::Incomplete(_)) => {
                 return ALPROTO_UNKNOWN;
             }
-            Err(_) => {
+            Err(_e) => {
                 return ALPROTO_FAILED;
             }
         }

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -522,8 +522,8 @@ pub unsafe extern "C" fn rs_pgsql_probing_parser_ts(
     _flow: *const Flow, _direction: u8, input: *const u8, input_len: u32, _rdir: *mut u8,
 ) -> AppProto {
     if input_len >= 1 && !input.is_null() {
-        let slice: &[u8];
-        slice = build_slice!(input, input_len as usize);
+        
+        let slice: &[u8] = build_slice!(input, input_len as usize);
         if probe_ts(slice) {
             return ALPROTO_PGSQL;
         }
@@ -537,8 +537,8 @@ pub unsafe extern "C" fn rs_pgsql_probing_parser_tc(
     _flow: *const Flow, _direction: u8, input: *const u8, input_len: u32, _rdir: *mut u8,
 ) -> AppProto {
     if input_len >= 1 && !input.is_null() {
-        let slice: &[u8];
-        slice = build_slice!(input, input_len as usize);
+        
+        let slice: &[u8] = build_slice!(input, input_len as usize);
 
         if parser::parse_ssl_response(slice).is_ok() {
             return ALPROTO_PGSQL;
@@ -597,8 +597,8 @@ pub unsafe extern "C" fn rs_pgsql_parse_request(
         }
     }
 
-    let state_safe: &mut PgsqlState;
-    state_safe = cast_pointer!(state, PgsqlState);
+    
+    let state_safe: &mut PgsqlState = cast_pointer!(state, PgsqlState);
 
     if stream_slice.is_gap() {
         state_safe.on_request_gap(stream_slice.gap_size());
@@ -618,8 +618,8 @@ pub unsafe extern "C" fn rs_pgsql_parse_response(
     } else {
         false
     };
-    let state_safe: &mut PgsqlState;
-    state_safe = cast_pointer!(state, PgsqlState);
+    
+    let state_safe: &mut PgsqlState = cast_pointer!(state, PgsqlState);
 
     if stream_slice.is_gap() {
         state_safe.on_response_gap(stream_slice.gap_size());


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: 
https://redmine.openinfosecfoundation.org/issues/5016

Describe changes:
- fix possible integer overflow bug found by fuzzers
- add new `UnknownMessageType`, which helped in the solution for the bug, but can also be useful for logging messages the parser doesn't recognize yet
- apply clippy --fix changes
- fix clippy warning about is_null usage

I ran the `fuzz_applayerparserparse_pgsql` (`sanitizer=address`) locally for a while, and it didn't run into anything.