### PR TITLE
configure.ac: handle undefined LEVEL1_DCACHE_LINESIZE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2159,7 +2159,7 @@ fi
     AC_PATH_PROG(HAVE_GETCONF_CMD, getconf, "no")
     if test "$HAVE_GETCONF_CMD" != "no"; then
         CLS=$(getconf LEVEL1_DCACHE_LINESIZE)
-        if [test "$CLS" != "" && test "$CLS" != "0"]; then
+        if [test "$CLS" != "undefined" && test "$CLS" != "" && test "$CLS" != "0"]; then
             AC_DEFINE_UNQUOTED([CLS],[${CLS}],[L1 cache line size])
         else
             AC_DEFINE([CLS],[64],[L1 cache line size])


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/

Describe changes:
- On some platforms (riscv64, s390x) this value is `undefined` as returned from `getconf`. We also need to handle this to avoid using the string `undefined` blindly in further #defines, which would otherwise cause compile errors.
