### PR TITLE
flow: compute stat counters again

### DIFF
--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -358,6 +358,24 @@ static void FlowManagerHashRowTimeout(FlowManagerTimeoutThread *td,
         f->flow_end_flags |= FLOW_END_FLAG_TIMEOUT;
 
         counters->flows_timeout++;
+        switch (f->flow_state) {
+            case FLOW_STATE_NEW:
+            default:
+                counters->new ++;
+                break;
+            case FLOW_STATE_ESTABLISHED:
+                counters->est++;
+                break;
+            case FLOW_STATE_CLOSED:
+                counters->clo++;
+                break;
+            case FLOW_STATE_LOCAL_BYPASSED:
+#ifdef CAPTURE_OFFLOAD
+            case FLOW_STATE_CAPTURE_BYPASSED:
+#endif
+                counters->byp++;
+                break;
+        }
 
         RemoveFromHash(f, prev_f);
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5317

Describe changes:
- flow: compute stat counters again as broken by commit b3599507f4eb891841417575587d690ea13fe6c0

Variables like `FlowTimeoutCounters.clo` was always 0 and never changed.
It is sad that no compiler/static analysis tool caught this...

There is no S-V tests about flow timeouts (because of reading pcaps, flow manager thread does not get the time to do its job)... Are there some in QA ?