### PR TITLE
rust: RustParser same fields as AppLayerParser

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -247,7 +247,7 @@ pub struct RustParser {
     pub default_port:       *const c_char,
 
     /// IP Protocol (core::IPPROTO_UDP, core::IPPROTO_TCP, etc.)
-    pub ipproto:            c_int,
+    pub ipproto:            u8,
 
     /// Probing function, for packets going to server
     pub probe_ts:           Option<ProbeFn>,

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -82,8 +82,8 @@ pub type AppProto = u16;
 pub const ALPROTO_UNKNOWN : AppProto = 0;
 pub static mut ALPROTO_FAILED : AppProto = 0; // updated during init
 
-pub const IPPROTO_TCP : i32 = 6;
-pub const IPPROTO_UDP : i32 = 17;
+pub const IPPROTO_TCP : u8 = 6;
+pub const IPPROTO_UDP : u8 = 17;
 
 macro_rules!BIT_U8 {
     ($x:expr) => (1 << $x);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None, should I create one QA big endian ?

Describe changes:
- rust: RustParser same fields as AppLayerParser

cc @satta following #7350 

Now make check segfaults at `AddressTestCutIPv402` and `AddressTestParse03` was first to fail