### PR TITLE
Alert queue optimizations backports to 6.0.x - v1

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -145,6 +145,21 @@ is: pass, drop, reject, alert.
 This means a pass rule is considered before a drop rule, a drop rule
 before a reject rule and so on.
 
+Packet alert queue settings
+---------------------------
+
+It is possible to configure the size of the alerts queue that is used to append alerts triggered by each packet.
+
+This will influence how many alerts would be perceived to have matched against a given packet.
+The default value is 15. If an invalid setting or no value is provided, the engine will fall
+back to the default.
+
+::
+
+    #Define maximum number of possible alerts that can be triggered for the same
+    # packet. Default is 15
+    packet-alert-max: 15
+
 Splitting configuration in multiple files
 -----------------------------------------
 

--- a/src/decode-chdlc.c
+++ b/src/decode-chdlc.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/decode-chdlc.c
+++ b/src/decode-chdlc.c
@@ -77,15 +77,13 @@ static int DecodeCHDLCTest01 (void)
         0x00,0x00,0x70,0x02,0x40,0x00,0x11,0x47,0x00,0x00,
         0x02,0x04,0x05,0xb4,0x01,0x01,0x04,0x02 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
-    if (unlikely(p == NULL))
-        return 0;
+    Packet *p = PacketGetFromAlloc();
+    FAIL_IF_NULL(p);
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeCHDLC(&tv, &dtv, p, raw, sizeof(raw));
 

--- a/src/decode-ethernet.c
+++ b/src/decode-ethernet.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/decode-ethernet.c
+++ b/src/decode-ethernet.c
@@ -89,7 +89,7 @@ static int DecodeEthernetTest01 (void)
         0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd,
         0xab, 0xcd };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -97,7 +97,6 @@ static int DecodeEthernetTest01 (void)
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeEthernet(&tv, &dtv, p, raw_eth, sizeof(raw_eth));
 
@@ -115,14 +114,13 @@ static int DecodeEthernetTestDceTooSmall(void)
         0x94, 0x56, 0x00, 0x01, 0x89, 0x03,
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeEthernet(&tv, &dtv, p, raw_eth, sizeof(raw_eth));
 
@@ -151,14 +149,13 @@ static int DecodeEthernetTestDceNextTooSmall(void)
         0x94, 0x56, 0x00, 0x01,
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeEthernet(&tv, &dtv, p, raw_eth, sizeof(raw_eth));
 

--- a/src/decode-icmpv4.c
+++ b/src/decode-icmpv4.c
@@ -379,7 +379,7 @@ static int DecodeICMPV4test01(void)
         0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
         0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
         0xab };
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -389,7 +389,6 @@ static int DecodeICMPV4test01(void)
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
 
@@ -431,7 +430,7 @@ static int DecodeICMPV4test02(void)
         0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
         0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27,
         0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f };
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -441,7 +440,6 @@ static int DecodeICMPV4test02(void)
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
 
     FlowInitConfig(FLOW_QUIET);
@@ -480,7 +478,7 @@ static int DecodeICMPV4test03(void)
         0x01, 0x11, 0xde, 0xfd, 0xc0, 0xa8, 0x01, 0x0d,
         0xd1, 0x55, 0xe3, 0x93, 0x8b, 0x12, 0x82, 0xaa,
         0x00, 0x28, 0x7c, 0xdd };
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -490,7 +488,6 @@ static int DecodeICMPV4test03(void)
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
 
     FlowInitConfig(FLOW_QUIET);
@@ -560,7 +557,7 @@ static int DecodeICMPV4test04(void)
         0x3e, 0x36, 0x38, 0x7c, 0x00, 0x00, 0x00, 0x00,
         0xa0, 0x02, 0x16, 0xd0, 0x72, 0x04, 0x00, 0x00,
         0x02, 0x04, 0x05, 0x8a, 0x04, 0x02, 0x08, 0x0a };
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -570,7 +567,6 @@ static int DecodeICMPV4test04(void)
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
 
     FlowInitConfig(FLOW_QUIET);
@@ -630,7 +626,7 @@ static int DecodeICMPV4test05(void)
 	0xd6, 0xbd, 0xc0, 0xa8, 0x02, 0x05, 0x3d, 0x23, 0xa1,
 	0x23, 0x04, 0x18, 0x00, 0x50, 0xd2, 0x08, 0xc2, 0x48,
          };
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -640,7 +636,6 @@ static int DecodeICMPV4test05(void)
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
 
     FlowInitConfig(FLOW_QUIET);
@@ -737,7 +732,7 @@ static int ICMPV4InvalidType07(void)
         0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x38};
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
     return 0;
     ThreadVars tv;
@@ -747,7 +742,6 @@ static int ICMPV4InvalidType07(void)
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
 
     FlowInitConfig(FLOW_QUIET);
@@ -781,7 +775,7 @@ static int DecodeICMPV4test08(void)
     uint8_t raw_icmpv4[] = {
         0x08, 0x00, 0x78, 0x47, 0xfc, 0x55, 0x00, 0x00
     };
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -791,7 +785,6 @@ static int DecodeICMPV4test08(void)
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
 
     FlowInitConfig(FLOW_QUIET);

--- a/src/decode-icmpv4.c
+++ b/src/decode-icmpv4.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -608,7 +608,7 @@ static int ICMPV6ParamProbTest01(void)
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
         0x80, 0x00, 0x08, 0xb5, 0x99, 0xc3, 0xde, 0x40 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
@@ -619,7 +619,6 @@ static int ICMPV6ParamProbTest01(void)
     ipv6dst = (uint32_t*) &raw_ipv6[24];
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -664,7 +663,7 @@ static int ICMPV6PktTooBigTest01(void)
         0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
@@ -675,7 +674,6 @@ static int ICMPV6PktTooBigTest01(void)
     ipv6dst = (uint32_t*) &raw_ipv6[24];
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -723,7 +721,7 @@ static int ICMPV6TimeExceedTest01(void)
         0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
@@ -734,7 +732,6 @@ static int ICMPV6TimeExceedTest01(void)
     ipv6dst = (uint32_t*) &raw_ipv6[24];
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -782,7 +779,7 @@ static int ICMPV6DestUnreachTest01(void)
         0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
@@ -793,7 +790,6 @@ static int ICMPV6DestUnreachTest01(void)
     ipv6dst = (uint32_t*) &raw_ipv6[24];
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -833,14 +829,13 @@ static int ICMPV6EchoReqTest01(void)
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
         0x80, 0x00, 0xe5, 0xa5, 0x25, 0xf0, 0x75, 0x23 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -879,14 +874,13 @@ static int ICMPV6EchoRepTest01(void)
         0x00, 0x00, 0x00, 0x00, 0x01, 0x81, 0x00,
         0xe5, 0xa5, 0x25, 0xf0, 0x75, 0x23 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -932,14 +926,13 @@ static int ICMPV6ParamProbTest02(void)
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
         0x80, 0x00, 0x08, 0xb5, 0x99, 0xc3, 0xde, 0x40 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -975,14 +968,13 @@ static int ICMPV6PktTooBigTest02(void)
         0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1014,14 +1006,13 @@ static int ICMPV6TimeExceedTest02(void)
 
     /* The icmpv6 header is broken in the checksum (so we dont have a complete header) */
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1055,14 +1046,13 @@ static int ICMPV6DestUnreachTest02(void)
         0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1092,14 +1082,13 @@ static int ICMPV6EchoReqTest02(void)
         0x00, 0x00, 0x00, 0x00, 0x01, 0x80, 0x01,
         0xe5, 0xa5, 0x25, 0xf0, 0x75, 0x23 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1129,14 +1118,13 @@ static int ICMPV6EchoRepTest02(void)
         0x00, 0x00, 0x00, 0x00, 0x01, 0x81, 0x01,
         0xe5, 0xa5, 0x25, 0xf0, 0x75, 0x23 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1169,14 +1157,13 @@ static int ICMPV6PayloadTest01(void)
         0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1203,14 +1190,13 @@ static int ICMPV6RouterSolicitTestKnownCode(void)
         0x85, 0x00, 0xbe, 0xb0, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1236,14 +1222,13 @@ static int ICMPV6RouterSolicitTestUnknownCode(void)
         0x85, 0x01, 0xbe, 0xaf, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1269,14 +1254,13 @@ static int ICMPV6RouterAdvertTestKnownCode(void)
         0x86, 0x00, 0xbd, 0xb0, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1302,14 +1286,13 @@ static int ICMPV6RouterAdvertTestUnknownCode(void)
         0x86, 0x01, 0xbd, 0xaf, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1335,14 +1318,13 @@ static int ICMPV6NeighbourSolicitTestKnownCode(void)
         0x87, 0x00, 0xbc, 0xb0, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1368,14 +1350,13 @@ static int ICMPV6NeighbourSolicitTestUnknownCode(void)
         0x87, 0x01, 0xbc, 0xaf, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1401,14 +1382,13 @@ static int ICMPV6NeighbourAdvertTestKnownCode(void)
         0x88, 0x00, 0xbb, 0xb0, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1434,14 +1414,13 @@ static int ICMPV6NeighbourAdvertTestUnknownCode(void)
         0x88, 0x01, 0xbb, 0xaf, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1467,14 +1446,13 @@ static int ICMPV6RedirectTestKnownCode(void)
         0x89, 0x00, 0xba, 0xb0, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1500,14 +1478,13 @@ static int ICMPV6RedirectTestUnknownCode(void)
         0x89, 0x01, 0xba, 0xaf, 0x00, 0x00, 0x00, 0x00
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 
@@ -1550,14 +1527,13 @@ static int ICMPV6CalculateValidChecksumWithFCS(void)
     };
     uint16_t csum = *(((uint16_t *)(raw_ipv6 + 64)));
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     IPV6Hdr ip6h;
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
 

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -1625,14 +1625,13 @@ static int DecodeEthernetTestIPv4Opt(void)
 
     DefragInit();
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     ThreadVars tv;
     DecodeThreadVars dtv;
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeEthernet(&tv, &dtv, p, raw_eth, sizeof(raw_eth));
 

--- a/src/decode-mpls.c
+++ b/src/decode-mpls.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Open Information Security Foundation
+/* Copyright (C) 2014-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/decode-mpls.c
+++ b/src/decode-mpls.c
@@ -142,7 +142,7 @@ static int DecodeMPLSTestHeaderTooSmall(void)
         0x00, 0x00, 0x11
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL)) {
         return 0;
     }
@@ -151,7 +151,6 @@ static int DecodeMPLSTestHeaderTooSmall(void)
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeMPLS(&tv, &dtv, p, pkt, sizeof(pkt));
 
@@ -230,7 +229,7 @@ static int DecodeMPLSTestBadLabelRouterAlert(void)
         0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL)) {
         return 0;
     }
@@ -239,7 +238,6 @@ static int DecodeMPLSTestBadLabelRouterAlert(void)
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeMPLS(&tv, &dtv, p, pkt, sizeof(pkt));
 
@@ -270,7 +268,7 @@ static int DecodeMPLSTestBadLabelImplicitNull(void)
         0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL)) {
         return 0;
     }
@@ -279,7 +277,6 @@ static int DecodeMPLSTestBadLabelImplicitNull(void)
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeMPLS(&tv, &dtv, p, pkt, sizeof(pkt));
 
@@ -310,7 +307,7 @@ static int DecodeMPLSTestBadLabelReserved(void)
         0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL)) {
         return 0;
     }
@@ -319,7 +316,6 @@ static int DecodeMPLSTestBadLabelReserved(void)
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeMPLS(&tv, &dtv, p, pkt, sizeof(pkt));
 
@@ -354,7 +350,7 @@ static int DecodeMPLSTestUnknownPayloadType(void)
         0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd, 0xab, 0xcd
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL)) {
         return 0;
     }
@@ -363,7 +359,6 @@ static int DecodeMPLSTestUnknownPayloadType(void)
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&tv,  0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeMPLS(&tv, &dtv, p, pkt, sizeof(pkt));
 

--- a/src/decode.c
+++ b/src/decode.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2019 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -73,6 +73,26 @@ extern bool stats_decoder_events;
 extern const char *stats_decoder_events_prefix;
 extern bool stats_stream_events;
 uint8_t decoder_max_layers = PKT_DEFAULT_MAX_DECODED_LAYERS;
+uint16_t packet_alert_max = PACKET_ALERT_MAX;
+
+/**
+ * \brief Initialize PacketAlerts with dynamic alerts array size
+ *
+ */
+PacketAlert *PacketAlertCreate(void)
+{
+    PacketAlert *pa_array = SCCalloc(packet_alert_max, sizeof(PacketAlert));
+    BUG_ON(pa_array == NULL);
+
+    return pa_array;
+}
+
+void PacketAlertFree(PacketAlert *pa)
+{
+    if (pa != NULL) {
+        SCFree(pa);
+    }
+}
 
 static int DecodeTunnel(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t,
         enum DecodeTunnelProto) WARN_UNUSED;
@@ -776,6 +796,21 @@ void DecodeGlobalConfig(void)
             decoder_max_layers = value;
         }
     }
+    PacketAlertGetMaxConfig();
+}
+
+void PacketAlertGetMaxConfig(void)
+{
+    intmax_t max = 0;
+    if (ConfGetInt("packet-alert-max", &max) == 1) {
+        if (max <= 0 || max > UINT8_MAX) {
+            SCLogWarning(SC_ERR_INVALID_VALUE,
+                    "Invalid value for packet-alert-max, default value set instead");
+        } else {
+            packet_alert_max = max;
+        }
+    }
+    SCLogDebug("detect->packet_alert_max set to %d", packet_alert_max);
 }
 
 /**

--- a/src/decode.h
+++ b/src/decode.h
@@ -298,6 +298,7 @@ extern uint16_t packet_alert_max;
 typedef struct PacketAlerts_ {
     uint16_t cnt;
     uint16_t discarded;
+    uint16_t suppressed;
     PacketAlert *alerts;
     /* single pa used when we're dropping,
      * so we can log it out in the drop log. */
@@ -824,6 +825,7 @@ void CaptureStatsSetup(ThreadVars *tv, CaptureStats *s);
         (p)->pktlen = 0;                                                                           \
         (p)->alerts.cnt = 0;                                                                       \
         (p)->alerts.discarded = 0;                                                                 \
+        (p)->alerts.suppressed = 0;                                                                \
         (p)->alerts.drop.action = 0;                                                               \
         (p)->pcap_cnt = 0;                                                                         \
         (p)->tunnel_rtv_cnt = 0;                                                                   \

--- a/src/decode.h
+++ b/src/decode.h
@@ -275,10 +275,10 @@ typedef uint16_t Port;
  * found in this packet */
 typedef struct PacketAlert_ {
     SigIntId num; /* Internal num, used for sorting */
-    uint8_t action; /* Internal num, used for sorting */
+    uint8_t action; /* Internal num, used for thresholding */
     uint8_t flags;
     const struct Signature_ *s;
-    uint64_t tx_id;
+    uint64_t tx_id; /* Used for sorting */
 } PacketAlert;
 
 /* flag to indicate the rule action (drop/pass) needs to be applied to the flow */

--- a/src/decode.h
+++ b/src/decode.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -292,15 +292,20 @@ typedef struct PacketAlert_ {
 /** action was changed by rate_filter */
 #define PACKET_ALERT_RATE_FILTER_MODIFIED   0x10
 
+extern uint16_t packet_alert_max;
 #define PACKET_ALERT_MAX 15
 
 typedef struct PacketAlerts_ {
     uint16_t cnt;
-    PacketAlert alerts[PACKET_ALERT_MAX];
+    PacketAlert *alerts;
     /* single pa used when we're dropping,
      * so we can log it out in the drop log. */
     PacketAlert drop;
 } PacketAlerts;
+
+PacketAlert *PacketAlertCreate(void);
+
+void PacketAlertFree(PacketAlert *pa);
 
 /** number of decoder events we support per packet. Power of 2 minus 1
  *  for memory layout */
@@ -746,11 +751,13 @@ void CaptureStatsSetup(ThreadVars *tv, CaptureStats *s);
 /**
  *  \brief Initialize a packet structure for use.
  */
-#define PACKET_INITIALIZE(p) {         \
-    SCMutexInit(&(p)->tunnel_mutex, NULL); \
-    PACKET_RESET_CHECKSUMS((p)); \
-    (p)->livedev = NULL; \
-}
+#define PACKET_INITIALIZE(p)                                                                       \
+    {                                                                                              \
+        SCMutexInit(&(p)->tunnel_mutex, NULL);                                                     \
+        (p)->alerts.alerts = PacketAlertCreate();                                                  \
+        PACKET_RESET_CHECKSUMS((p));                                                               \
+        (p)->livedev = NULL;                                                                       \
+    }
 
 #define PACKET_RELEASE_REFS(p) do {              \
         FlowDeReference(&((p)->flow));          \
@@ -844,6 +851,7 @@ void CaptureStatsSetup(ThreadVars *tv, CaptureStats *s);
         if ((p)->pktvar != NULL) {                                                                 \
             PktVarFree((p)->pktvar);                                                               \
         }                                                                                          \
+        PacketAlertFree((p)->alerts.alerts);                                                       \
         PACKET_FREE_EXTDATA((p));                                                                  \
         SCMutexDestroy(&(p)->tunnel_mutex);                                                        \
         AppLayerDecoderEventsFreeEvents(&(p)->app_layer_events);                                   \
@@ -982,6 +990,7 @@ void AddressDebugPrint(Address *);
 typedef int (*DecoderFunc)(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
          const uint8_t *pkt, uint32_t len);
 void DecodeGlobalConfig(void);
+void PacketAlertGetMaxConfig(void);
 void DecodeUnregisterCounters(void);
 
 /** \brief Set the No payload inspection Flag for the packet.

--- a/src/decode.h
+++ b/src/decode.h
@@ -297,6 +297,7 @@ extern uint16_t packet_alert_max;
 
 typedef struct PacketAlerts_ {
     uint16_t cnt;
+    uint16_t discarded;
     PacketAlert *alerts;
     /* single pa used when we're dropping,
      * so we can log it out in the drop log. */
@@ -768,72 +769,74 @@ void CaptureStatsSetup(ThreadVars *tv, CaptureStats *s);
 /**
  *  \brief Recycle a packet structure for reuse.
  */
-#define PACKET_REINIT(p) do {             \
-        CLEAR_ADDR(&(p)->src);                  \
-        CLEAR_ADDR(&(p)->dst);                  \
-        (p)->sp = 0;                            \
-        (p)->dp = 0;                            \
-        (p)->proto = 0;                         \
-        (p)->recursion_level = 0;               \
-        PACKET_FREE_EXTDATA((p));               \
-        (p)->flags = (p)->flags & PKT_ALLOC;    \
-        (p)->flowflags = 0;                     \
-        (p)->pkt_src = 0;                       \
-        (p)->vlan_id[0] = 0;                    \
-        (p)->vlan_id[1] = 0;                    \
-        (p)->vlan_idx = 0;                      \
-        (p)->ts.tv_sec = 0;                     \
-        (p)->ts.tv_usec = 0;                    \
-        (p)->datalink = 0;                      \
-        (p)->action = 0;                        \
-        if ((p)->pktvar != NULL) {              \
-            PktVarFree((p)->pktvar);            \
-            (p)->pktvar = NULL;                 \
-        }                                       \
-        (p)->ethh = NULL;                       \
-        if ((p)->ip4h != NULL) {                \
-            CLEAR_IPV4_PACKET((p));             \
-        }                                       \
-        if ((p)->ip6h != NULL) {                \
-            CLEAR_IPV6_PACKET((p));             \
-        }                                       \
-        if ((p)->tcph != NULL) {                \
-            CLEAR_TCP_PACKET((p));              \
-        }                                       \
-        if ((p)->udph != NULL) {                \
-            CLEAR_UDP_PACKET((p));              \
-        }                                       \
-        if ((p)->sctph != NULL) {               \
-            CLEAR_SCTP_PACKET((p));             \
-        }                                       \
-        if ((p)->icmpv4h != NULL) {             \
-            CLEAR_ICMPV4_PACKET((p));           \
-        }                                       \
-        if ((p)->icmpv6h != NULL) {             \
-            CLEAR_ICMPV6_PACKET((p));           \
-        }                                       \
-        (p)->ppph = NULL;                       \
-        (p)->pppoesh = NULL;                    \
-        (p)->pppoedh = NULL;                    \
-        (p)->greh = NULL;                       \
-        (p)->payload = NULL;                    \
-        (p)->payload_len = 0;                   \
-        (p)->BypassPacketsFlow = NULL;          \
-        (p)->pktlen = 0;                        \
-        (p)->alerts.cnt = 0;                    \
-        (p)->alerts.drop.action = 0;            \
-        (p)->pcap_cnt = 0;                      \
-        (p)->tunnel_rtv_cnt = 0;                \
-        (p)->tunnel_tpr_cnt = 0;                \
-        (p)->events.cnt = 0;                    \
-        AppLayerDecoderEventsResetEvents((p)->app_layer_events); \
-        (p)->next = NULL;                       \
-        (p)->prev = NULL;                       \
-        (p)->root = NULL;                       \
-        (p)->livedev = NULL;                    \
-        PACKET_RESET_CHECKSUMS((p));            \
-        PACKET_PROFILING_RESET((p));            \
-        p->tenant_id = 0;                       \
+#define PACKET_REINIT(p)                                                                           \
+    do {                                                                                           \
+        CLEAR_ADDR(&(p)->src);                                                                     \
+        CLEAR_ADDR(&(p)->dst);                                                                     \
+        (p)->sp = 0;                                                                               \
+        (p)->dp = 0;                                                                               \
+        (p)->proto = 0;                                                                            \
+        (p)->recursion_level = 0;                                                                  \
+        PACKET_FREE_EXTDATA((p));                                                                  \
+        (p)->flags = (p)->flags & PKT_ALLOC;                                                       \
+        (p)->flowflags = 0;                                                                        \
+        (p)->pkt_src = 0;                                                                          \
+        (p)->vlan_id[0] = 0;                                                                       \
+        (p)->vlan_id[1] = 0;                                                                       \
+        (p)->vlan_idx = 0;                                                                         \
+        (p)->ts.tv_sec = 0;                                                                        \
+        (p)->ts.tv_usec = 0;                                                                       \
+        (p)->datalink = 0;                                                                         \
+        (p)->action = 0;                                                                           \
+        if ((p)->pktvar != NULL) {                                                                 \
+            PktVarFree((p)->pktvar);                                                               \
+            (p)->pktvar = NULL;                                                                    \
+        }                                                                                          \
+        (p)->ethh = NULL;                                                                          \
+        if ((p)->ip4h != NULL) {                                                                   \
+            CLEAR_IPV4_PACKET((p));                                                                \
+        }                                                                                          \
+        if ((p)->ip6h != NULL) {                                                                   \
+            CLEAR_IPV6_PACKET((p));                                                                \
+        }                                                                                          \
+        if ((p)->tcph != NULL) {                                                                   \
+            CLEAR_TCP_PACKET((p));                                                                 \
+        }                                                                                          \
+        if ((p)->udph != NULL) {                                                                   \
+            CLEAR_UDP_PACKET((p));                                                                 \
+        }                                                                                          \
+        if ((p)->sctph != NULL) {                                                                  \
+            CLEAR_SCTP_PACKET((p));                                                                \
+        }                                                                                          \
+        if ((p)->icmpv4h != NULL) {                                                                \
+            CLEAR_ICMPV4_PACKET((p));                                                              \
+        }                                                                                          \
+        if ((p)->icmpv6h != NULL) {                                                                \
+            CLEAR_ICMPV6_PACKET((p));                                                              \
+        }                                                                                          \
+        (p)->ppph = NULL;                                                                          \
+        (p)->pppoesh = NULL;                                                                       \
+        (p)->pppoedh = NULL;                                                                       \
+        (p)->greh = NULL;                                                                          \
+        (p)->payload = NULL;                                                                       \
+        (p)->payload_len = 0;                                                                      \
+        (p)->BypassPacketsFlow = NULL;                                                             \
+        (p)->pktlen = 0;                                                                           \
+        (p)->alerts.cnt = 0;                                                                       \
+        (p)->alerts.discarded = 0;                                                                 \
+        (p)->alerts.drop.action = 0;                                                               \
+        (p)->pcap_cnt = 0;                                                                         \
+        (p)->tunnel_rtv_cnt = 0;                                                                   \
+        (p)->tunnel_tpr_cnt = 0;                                                                   \
+        (p)->events.cnt = 0;                                                                       \
+        AppLayerDecoderEventsResetEvents((p)->app_layer_events);                                   \
+        (p)->next = NULL;                                                                          \
+        (p)->prev = NULL;                                                                          \
+        (p)->root = NULL;                                                                          \
+        (p)->livedev = NULL;                                                                       \
+        PACKET_RESET_CHECKSUMS((p));                                                               \
+        PACKET_PROFILING_RESET((p));                                                               \
+        p->tenant_id = 0;                                                                          \
         p->nb_decoded_layers = 0;                                                                  \
     } while (0)
 

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2019 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -1005,7 +1005,7 @@ static int DetectContentLongPatternMatchTest(uint8_t *raw_eth_pkt, uint16_t pkts
 {
     int result = 0;
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     DecodeThreadVars dtv;
@@ -1013,7 +1013,6 @@ static int DetectContentLongPatternMatchTest(uint8_t *raw_eth_pkt, uint16_t pkts
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&th_v, 0, sizeof(th_v));
 

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -887,7 +887,7 @@ static int DetectDsizeIcmpv6Test01 (void)
         0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     IPV6Hdr ip6h;
@@ -898,7 +898,6 @@ static int DetectDsizeIcmpv6Test01 (void)
     DetectEngineThreadCtx *det_ctx = NULL;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip6h, 0, sizeof(IPV6Hdr));
     memset(&th_v, 0, sizeof(ThreadVars));

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -266,6 +266,7 @@ void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet
         /* we must grow the alert queue */
         if (pos == AlertQueueExpand(det_ctx)) {
             /* this means we failed to expand the queue */
+            det_ctx->p->alerts.discarded++;
             return;
         }
     }
@@ -367,6 +368,7 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
         /* Thresholding removes this alert */
         if (res == 0 || res == 2 || (s->flags & SIG_FLAG_NOALERT)) {
             /* we will not copy this to the AlertQueue */
+            p->alerts.discarded++;
         } else if (p->alerts.cnt < packet_alert_max) {
             p->alerts.alerts[p->alerts.cnt] = det_ctx->alert_queue[i];
             SCLogDebug("Appending sid %" PRIu32 " alert to Packet::alerts at pos %u", s->id, i);
@@ -377,6 +379,8 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
                 break;
             }
             p->alerts.cnt++;
+        } else {
+            p->alerts.discarded++;
         }
         i++;
     }

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -368,7 +368,7 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
         /* Thresholding removes this alert */
         if (res == 0 || res == 2 || (s->flags & SIG_FLAG_NOALERT)) {
             /* we will not copy this to the AlertQueue */
-            p->alerts.discarded++;
+            p->alerts.suppressed++;
         } else if (p->alerts.cnt < packet_alert_max) {
             p->alerts.alerts[p->alerts.cnt] = det_ctx->alert_queue[i];
             SCLogDebug("Appending sid %" PRIu32 " alert to Packet::alerts at pos %u", s->id, i);

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -126,7 +126,6 @@ static int PacketAlertHandle(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det
     SCReturnInt(1);
 }
 
-
 /**
  * \brief Check if a certain sid alerted, this is used in the test functions
  *
@@ -149,81 +148,6 @@ int PacketAlertCheck(Packet *p, uint32_t sid)
     }
 
     return match;
-}
-
-/**
- * \brief Remove alert from the p->alerts.alerts array at pos
- * \param p Pointer to the Packet
- * \param pos Position in the array
- * \retval 0 if the number of alerts is less than pos
- *         1 if all goes well
- */
-int PacketAlertRemove(Packet *p, uint16_t pos)
-{
-    uint16_t i = 0;
-    int match = 0;
-
-    if (pos > p->alerts.cnt) {
-        SCLogDebug("removing %u failed, pos > cnt %u", pos, p->alerts.cnt);
-        return 0;
-    }
-
-    for (i = pos; i <= p->alerts.cnt - 1; i++) {
-        memcpy(&p->alerts.alerts[i], &p->alerts.alerts[i + 1], sizeof(PacketAlert));
-    }
-
-    // Update it, since we removed 1
-    p->alerts.cnt--;
-
-    return match;
-}
-
-/** \brief append a signature match to a packet
- *
- *  \param det_ctx thread detection engine ctx
- *  \param s the signature that matched
- *  \param p packet
- *  \param flags alert flags
- */
-int PacketAlertAppend(DetectEngineThreadCtx *det_ctx, const Signature *s,
-        Packet *p, uint64_t tx_id, uint8_t flags)
-{
-    int i = 0;
-
-    if (p->alerts.cnt == PACKET_ALERT_MAX)
-        return 0;
-
-    SCLogDebug("sid %"PRIu32"", s->id);
-
-    /* It should be usually the last, so check it before iterating */
-    if (p->alerts.cnt == 0 || (p->alerts.cnt > 0 &&
-                               p->alerts.alerts[p->alerts.cnt - 1].num < s->num)) {
-        /* We just add it */
-        p->alerts.alerts[p->alerts.cnt].num = s->num;
-        p->alerts.alerts[p->alerts.cnt].action = s->action;
-        p->alerts.alerts[p->alerts.cnt].flags = flags;
-        p->alerts.alerts[p->alerts.cnt].s = s;
-        p->alerts.alerts[p->alerts.cnt].tx_id = tx_id;
-    } else {
-        /* We need to make room for this s->num
-         (a bit ugly with memcpy but we are planning changes here)*/
-        for (i = p->alerts.cnt - 1; i >= 0 && p->alerts.alerts[i].num > s->num; i--) {
-            memcpy(&p->alerts.alerts[i + 1], &p->alerts.alerts[i], sizeof(PacketAlert));
-        }
-
-        i++; /* The right place to store the alert */
-
-        p->alerts.alerts[i].num = s->num;
-        p->alerts.alerts[i].action = s->action;
-        p->alerts.alerts[i].flags = flags;
-        p->alerts.alerts[i].s = s;
-        p->alerts.alerts[i].tx_id = tx_id;
-    }
-
-    /* Update the count */
-    p->alerts.cnt++;
-
-    return 0;
 }
 
 static inline void RuleActionToFlow(const uint8_t action, Flow *f)

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -293,6 +293,28 @@ static int AlertQueueSortHelper(const void *a, const void *b)
         return pa0->num > pa1->num ? 1 : -1;
 }
 
+/** \internal
+ * \brief Check if Signature action should be applied to flow and apply
+ *
+ */
+static inline void FlowApplySignatureActions(
+        Packet *p, PacketAlert *pa, const Signature *s, uint8_t alert_flags)
+{
+    /* For DROP and PASS sigs we need to apply the action to the flow if
+     * - sig is IP or PD only
+     * - match is in applayer
+     * - match is in stream */
+    if (s->action & (ACTION_DROP | ACTION_PASS)) {
+        if ((pa->flags & (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_STREAM_MATCH)) ||
+                (s->flags & (SIG_FLAG_IPONLY | SIG_FLAG_PDONLY | SIG_FLAG_APPLAYER))) {
+            pa->flags |= PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW;
+            SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x (set "
+                       "PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW)",
+                    p->pcap_cnt, s->id, s->action, pa->flags);
+        }
+    }
+}
+
 /**
  * \brief Check the threshold of the sigs that match, set actions, break on pass action
  *        This function iterate the packet alerts array, removing those that didn't match
@@ -334,20 +356,9 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
                 }
             }
 
-            /* For DROP and PASS sigs we need to apply the action to the flow if
-             * - sig is IP or PD only
-             * - match is in applayer
-             * - match is in stream */
-            if (s->action & (ACTION_DROP | ACTION_PASS)) {
-                if ((det_ctx->alert_queue[i].flags &
-                            (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_STREAM_MATCH)) ||
-                        (s->flags & (SIG_FLAG_IPONLY | SIG_FLAG_PDONLY | SIG_FLAG_APPLAYER))) {
-                    det_ctx->alert_queue[i].flags |= PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW;
-                    SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x (set "
-                               "PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW)",
-                            p->pcap_cnt, s->id, s->action, det_ctx->alert_queue[i].flags);
-                }
-            }
+            /* set actions on the flow */
+            FlowApplySignatureActions(
+                    p, &det_ctx->alert_queue[i], s, det_ctx->alert_queue[i].flags);
 
             /* set actions on packet */
             PacketApplySignatureActions(p, s, det_ctx->alert_queue[i].flags);

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -130,7 +130,7 @@ static int PacketAlertHandle(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det
  * \brief Check if a certain sid alerted, this is used in the test functions
  *
  * \param p   Packet on which we want to check if the signature alerted or not
- * \param sid Signature id of the signature that thas to be checked for a match
+ * \param sid Signature id of the signature that has to be checked for a match
  *
  * \retval match A value > 0 on a match; 0 on no match
  */

--- a/src/detect-engine-alert.h
+++ b/src/detect-engine-alert.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2011 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-engine-alert.h
+++ b/src/detect-engine-alert.h
@@ -28,6 +28,10 @@
 #include "decode.h"
 #include "detect.h"
 
+void AlertQueueInit(DetectEngineThreadCtx *det_ctx);
+void AlertQueueFree(DetectEngineThreadCtx *det_ctx);
+void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p, uint64_t tx_id,
+        uint8_t alert_flags);
 void PacketAlertFinalize(DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
 int PacketAlertAppend(DetectEngineThreadCtx *, const Signature *,
         Packet *, uint64_t tx_id, uint8_t);

--- a/src/detect-engine-alert.h
+++ b/src/detect-engine-alert.h
@@ -33,10 +33,7 @@ void AlertQueueFree(DetectEngineThreadCtx *det_ctx);
 void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p, uint64_t tx_id,
         uint8_t alert_flags);
 void PacketAlertFinalize(DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
-int PacketAlertAppend(DetectEngineThreadCtx *, const Signature *,
-        Packet *, uint64_t tx_id, uint8_t);
 int PacketAlertCheck(Packet *, uint32_t);
-int PacketAlertRemove(Packet *, uint16_t);
 void PacketAlertTagInit(void);
 PacketAlert *PacketAlertGetTag(void);
 

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -341,7 +341,7 @@ static int EngineEventTestParse05 (void)
  */
 static int EngineEventTestParse06 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -351,7 +351,6 @@ static int EngineEventTestParse06 (void)
 
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
 
     ENGINE_SET_EVENT(p,PPP_PKT_TOO_SMALL);
 

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -1142,7 +1142,7 @@ void IPOnlyMatchPacket(ThreadVars *tv,
 }
 
 /**
- * \brief Build the radix trees from the lists of parsed adresses in CIDR format
+ * \brief Build the radix trees from the lists of parsed addresses in CIDR format
  *        the result should be 4 radix trees: src/dst ipv4 and src/dst ipv6
  *        holding SigNumArrays, each of them with a hierarchical relation
  *        of subnets and hosts
@@ -1562,7 +1562,7 @@ void IPOnlyPrepare(DetectEngineCtx *de_ctx)
 
 /**
  * \brief Add a signature to the lists of Addresses in CIDR format (sorted)
- *        this step is necesary to build the radix tree with a hierarchical
+ *        this step is necessary to build the radix tree with a hierarchical
  *        relation between nodes
  * \param de_ctx Pointer to the current detection engine context
  * \param de_ctx Pointer to the current ip only detection engine contest
@@ -1619,7 +1619,7 @@ static int IPOnlyTestSig01(void)
 }
 
 /**
- * \test check that we dont set a Signature as IPOnly because it has no rule
+ * \test check that we don't set a Signature as IPOnly because it has no rule
  *       option appending a SigMatch but a port is fixed
  */
 
@@ -1639,7 +1639,7 @@ static int IPOnlyTestSig02 (void)
 }
 
 /**
- * \test check that we set dont set a Signature as IPOnly
+ * \test check that we set don't set a Signature as IPOnly
  *  because it has rule options appending a SigMatch like content, and pcre
  */
 

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -1133,7 +1133,7 @@ void IPOnlyMatchPacket(ThreadVars *tv,
                             }
                         }
                     }
-                    PacketAlertAppend(det_ctx, s, p, 0, 0);
+                    AlertQueueAppend(det_ctx, s, p, 0, 0);
                 }
             }
         }

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2875,6 +2875,7 @@ TmEcode DetectEngineThreadCtxInit(ThreadVars *tv, void *initdata, void **data)
 
     /** alert counter setup */
     det_ctx->counter_alerts = StatsRegisterCounter("detect.alert", tv);
+    det_ctx->counter_alerts_overflow = StatsRegisterCounter("detect.alert_queue_overflow", tv);
 #ifdef PROFILING
     det_ctx->counter_mpm_list = StatsRegisterAvgCounter("detect.mpm_list", tv);
     det_ctx->counter_nonmpm_list = StatsRegisterAvgCounter("detect.nonmpm_list", tv);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2768,6 +2768,9 @@ static TmEcode ThreadCtxDoInit (DetectEngineCtx *de_ctx, DetectEngineThreadCtx *
         RuleMatchCandidateTxArrayInit(det_ctx, de_ctx->sig_array_len);
     }
 
+    /* Alert processing queue */
+    AlertQueueInit(det_ctx);
+
     /* byte_extract storage */
     det_ctx->byte_values = SCMalloc(sizeof(*det_ctx->byte_values) *
                                   (de_ctx->byte_extract_max_local_id + 1));
@@ -2998,6 +3001,8 @@ static void DetectEngineThreadCtxFree(DetectEngineThreadCtx *det_ctx)
         SCFree(det_ctx->match_array);
 
     RuleMatchCandidateTxArrayFree(det_ctx);
+
+    AlertQueueFree(det_ctx);
 
     if (det_ctx->byte_values != NULL)
         SCFree(det_ctx->byte_values);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2876,6 +2876,7 @@ TmEcode DetectEngineThreadCtxInit(ThreadVars *tv, void *initdata, void **data)
     /** alert counter setup */
     det_ctx->counter_alerts = StatsRegisterCounter("detect.alert", tv);
     det_ctx->counter_alerts_overflow = StatsRegisterCounter("detect.alert_queue_overflow", tv);
+    det_ctx->counter_alerts_suppressed = StatsRegisterCounter("detect.alerts_suppressed", tv);
 #ifdef PROFILING
     det_ctx->counter_mpm_list = StatsRegisterAvgCounter("detect.mpm_list", tv);
     det_ctx->counter_nonmpm_list = StatsRegisterAvgCounter("detect.nonmpm_list", tv);

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -944,7 +944,7 @@ static int FlowBitsTestSig06(void)
                     "Host: one.example.org\r\n"
                     "\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     Signature *s = NULL;
     ThreadVars th_v;
@@ -955,7 +955,6 @@ static int FlowBitsTestSig06(void)
     int result = 0;
     uint32_t idx = 0;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&th_v, 0, sizeof(th_v));
     memset(&f, 0, sizeof(Flow));
     memset(&flowvar, 0, sizeof(GenericVar));
@@ -1018,7 +1017,7 @@ static int FlowBitsTestSig07(void)
                     "Host: one.example.org\r\n"
                     "\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     Signature *s = NULL;
     ThreadVars th_v;
@@ -1029,7 +1028,6 @@ static int FlowBitsTestSig07(void)
     int result = 0;
     uint32_t idx = 0;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&th_v, 0, sizeof(th_v));
     memset(&f, 0, sizeof(Flow));
     memset(&flowvar, 0, sizeof(GenericVar));
@@ -1094,7 +1092,7 @@ static int FlowBitsTestSig08(void)
                     "Host: one.example.org\r\n"
                     "\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Signature *s = NULL;
@@ -1106,7 +1104,6 @@ static int FlowBitsTestSig08(void)
     int result = 0;
     uint32_t idx = 0;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&th_v, 0, sizeof(th_v));
     memset(&f, 0, sizeof(Flow));
     memset(&flowvar, 0, sizeof(GenericVar));
@@ -1171,7 +1168,7 @@ static int FlowBitsTestSig09(void)
                     "Host: one.example.org\r\n"
                     "\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     Signature *s = NULL;
     ThreadVars th_v;
@@ -1179,7 +1176,6 @@ static int FlowBitsTestSig09(void)
     DetectEngineCtx *de_ctx = NULL;
     Flow f;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&th_v, 0, sizeof(th_v));
     memset(&f, 0, sizeof(Flow));
 
@@ -1238,7 +1234,7 @@ static int FlowBitsTestSig10(void)
                     "Host: one.example.org\r\n"
                     "\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     Signature *s = NULL;
     ThreadVars th_v;
@@ -1246,7 +1242,6 @@ static int FlowBitsTestSig10(void)
     DetectEngineCtx *de_ctx = NULL;
     Flow f;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&th_v, 0, sizeof(th_v));
     memset(&f, 0, sizeof(Flow));
 
@@ -1308,7 +1303,7 @@ static int FlowBitsTestSig11(void)
                     "Host: one.example.org\r\n"
                     "\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     Signature *s = NULL;
     ThreadVars th_v;
@@ -1316,7 +1311,6 @@ static int FlowBitsTestSig11(void)
     DetectEngineCtx *de_ctx = NULL;
     Flow f;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&th_v, 0, sizeof(th_v));
     memset(&f, 0, sizeof(Flow));
 

--- a/src/detect-fragbits.c
+++ b/src/detect-fragbits.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-fragbits.c
+++ b/src/detect-fragbits.c
@@ -467,7 +467,7 @@ static int FragBitsTestParse03 (void)
         0x0b ,0xc0 ,0x9f ,0x00 ,0x01 ,0x00 ,0x01 ,0x00,
         0x00 ,0x0e ,0x10 ,0x00 ,0x04 ,0x81 ,0x6f ,0x0b,
         0x51};
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF(unlikely(p == NULL));
     ThreadVars tv;
     DecodeThreadVars dtv;
@@ -477,7 +477,6 @@ static int FragBitsTestParse03 (void)
     SigMatch *sm = NULL;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     dtv.app_tctx = AppLayerGetCtxThread(&tv);
@@ -554,7 +553,7 @@ static int FragBitsTestParse04 (void)
         0x0b ,0xc0 ,0x9f ,0x00 ,0x01 ,0x00 ,0x01 ,0x00,
         0x00 ,0x0e ,0x10 ,0x00 ,0x04 ,0x81 ,0x6f ,0x0b,
         0x51};
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF(unlikely(p == NULL));
     ThreadVars tv;
     DecodeThreadVars dtv;
@@ -564,7 +563,6 @@ static int FragBitsTestParse04 (void)
     SigMatch *sm = NULL;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     dtv.app_tctx = AppLayerGetCtxThread(&tv);

--- a/src/detect-fragoffset.c
+++ b/src/detect-fragoffset.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-fragoffset.c
+++ b/src/detect-fragoffset.c
@@ -379,7 +379,7 @@ static int DetectFragOffsetParseTest03 (void)
 static int DetectFragOffsetMatchTest01 (void)
 {
     int result = 0;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Signature *s = NULL;
@@ -388,7 +388,6 @@ static int DetectFragOffsetMatchTest01 (void)
     DetectEngineThreadCtx *det_ctx = NULL;
     IPV4Hdr ip4h;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ip4h, 0, sizeof(IPV4Hdr));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&th_v, 0, sizeof(ThreadVars));

--- a/src/detect-ftpbounce.c
+++ b/src/detect-ftpbounce.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-ftpbounce.c
+++ b/src/detect-ftpbounce.c
@@ -437,7 +437,7 @@ static int DetectFtpbounceTestALMatch03(void)
 
     TcpSession ssn;
     Flow f;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Signature *s = NULL;
@@ -446,7 +446,6 @@ static int DetectFtpbounceTestALMatch03(void)
     AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&f, 0, sizeof(f));
     memset(&ssn, 0, sizeof(ssn));
 

--- a/src/detect-hostbits.c
+++ b/src/detect-hostbits.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-hostbits.c
+++ b/src/detect-hostbits.c
@@ -563,7 +563,6 @@ static int HostBitsTestSig01(void)
     DetectEngineCtx *de_ctx = NULL;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
     p->payload = buf;
@@ -656,7 +655,7 @@ static int HostBitsTestSig03(void)
                     "Host: one.example.org\r\n"
                     "\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Signature *s = NULL;
@@ -745,7 +744,6 @@ static int HostBitsTestSig04(void)
     int idx = 0;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
     p->payload = buf;
@@ -1070,7 +1068,6 @@ static int HostBitsTestSig07(void)
     Flow f;
     int result = 0;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&th_v, 0, sizeof(th_v));
     memset(&f, 0, sizeof(Flow));
 
@@ -1145,7 +1142,6 @@ static int HostBitsTestSig08(void)
     DetectEngineCtx *de_ctx = NULL;
     Flow f;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&th_v, 0, sizeof(th_v));
     memset(&f, 0, sizeof(Flow));
 

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -260,7 +260,7 @@ static int IpOptsTestParse02 (void)
  */
 static int IpOptsTestParse03 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -270,7 +270,6 @@ static int IpOptsTestParse03 (void)
     IPV4Hdr ip4h;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ip4h, 0, sizeof(IPV4Hdr));
 
     p->ip4h = &ip4h;
@@ -310,7 +309,7 @@ error:
  */
 static int IpOptsTestParse04 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -320,7 +319,6 @@ static int IpOptsTestParse04 (void)
     IPV4Hdr ip4h;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ip4h, 0, sizeof(IPV4Hdr));
 
     p->ip4h = &ip4h;

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -1915,10 +1915,9 @@ static int DetectIPProtoTestSig2(void)
         0x4a, 0xea, 0x7a, 0x8e,
     };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
-    memset(p, 0, SIZE_OF_PACKET);
 
     DecodeThreadVars dtv;
     ThreadVars th_v;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -3624,7 +3624,7 @@ static int SigTestBidirec04 (void)
         0x6b,0x65,0x65,0x70,0x2d,0x61,0x6c,0x69,
         0x76,0x65,0x0d,0x0a,0x0d,0x0a }; /* end rawpkt1_ether */
 
-    p = SCMalloc(SIZE_OF_PACKET);
+    p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     DecodeThreadVars dtv;
@@ -3632,7 +3632,6 @@ static int SigTestBidirec04 (void)
     DetectEngineThreadCtx *det_ctx;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
 
     FlowInitConfig(FLOW_QUIET);
     DecodeEthernet(&th_v, &dtv, p, rawpkt1_ether, sizeof(rawpkt1_ether));

--- a/src/detect-tcp-flags.c
+++ b/src/detect-tcp-flags.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-tcp-flags.c
+++ b/src/detect-tcp-flags.c
@@ -653,7 +653,7 @@ static int FlagsTestParse02 (void)
  */
 static int FlagsTestParse03 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -664,7 +664,6 @@ static int FlagsTestParse03 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -708,7 +707,7 @@ error:
  */
 static int FlagsTestParse04 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -719,7 +718,6 @@ static int FlagsTestParse04 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -764,7 +762,7 @@ error:
  */
 static int FlagsTestParse05 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -775,7 +773,6 @@ static int FlagsTestParse05 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -820,7 +817,7 @@ error:
  */
 static int FlagsTestParse06 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -831,7 +828,6 @@ static int FlagsTestParse06 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -875,7 +871,7 @@ error:
  */
 static int FlagsTestParse07 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -886,7 +882,6 @@ static int FlagsTestParse07 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -931,7 +926,7 @@ error:
  */
 static int FlagsTestParse08 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -942,7 +937,6 @@ static int FlagsTestParse08 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -986,7 +980,7 @@ error:
  */
 static int FlagsTestParse09 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -997,7 +991,6 @@ static int FlagsTestParse09 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -1041,7 +1034,7 @@ error:
  */
 static int FlagsTestParse10 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -1052,7 +1045,6 @@ static int FlagsTestParse10 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -1096,7 +1088,7 @@ error:
  */
 static int FlagsTestParse11 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -1107,7 +1099,6 @@ static int FlagsTestParse11 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -1152,7 +1143,7 @@ error:
  */
 static int FlagsTestParse12 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -1163,7 +1154,6 @@ static int FlagsTestParse12 (void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -1239,7 +1229,7 @@ static int FlagsTestParse14(void)
 
 static int FlagsTestParse15(void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -1250,7 +1240,6 @@ static int FlagsTestParse15(void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -1292,7 +1281,7 @@ error:
 
 static int FlagsTestParse16(void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -1303,7 +1292,6 @@ static int FlagsTestParse16(void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
@@ -1348,7 +1336,7 @@ error:
  */
 static int FlagsTestParse17(void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars tv;
@@ -1359,7 +1347,6 @@ static int FlagsTestParse17(void)
     TCPHdr tcph;
 
     memset(&tv, 0, sizeof(ThreadVars));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -448,7 +448,7 @@ static int XBitsTestSig01(void)
                     "Host: one.example.org\r\n"
                     "\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
     Signature *s = NULL;
     ThreadVars th_v;
@@ -456,7 +456,6 @@ static int XBitsTestSig01(void)
     DetectEngineCtx *de_ctx = NULL;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
     p->payload = buf;

--- a/src/detect.c
+++ b/src/detect.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2017 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect.c
+++ b/src/detect.c
@@ -797,7 +797,7 @@ static inline void DetectRulePacketRules(
 #endif
         DetectRunPostMatch(tv, det_ctx, p, s);
 
-        PacketAlertAppend(det_ctx, s, p, 0, alert_flags);
+        AlertQueueAppend(det_ctx, s, p, 0, alert_flags);
 next:
         DetectVarProcessList(det_ctx, pflow, p);
         DetectReplaceFree(det_ctx);
@@ -1483,7 +1483,7 @@ static void DetectRunTx(ThreadVars *tv,
 
                 const uint8_t alert_flags = (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_TX);
                 SCLogDebug("%p/%"PRIu64" sig %u (%u) matched", tx.tx_ptr, tx.tx_id, s->id, s->num);
-                PacketAlertAppend(det_ctx, s, p, tx.tx_id, alert_flags);
+                AlertQueueAppend(det_ctx, s, p, tx.tx_id, alert_flags);
             }
             DetectVarProcessList(det_ctx, p->flow, p);
             RULE_PROFILING_END(det_ctx, s, r, p);

--- a/src/detect.c
+++ b/src/detect.c
@@ -821,6 +821,7 @@ static DetectRunScratchpad DetectRunSetup(
 
 #ifdef UNITTESTS
     p->alerts.cnt = 0;
+    p->alerts.discarded = 0;
 #endif
     det_ctx->ticker++;
     det_ctx->filestore_cnt = 0;
@@ -929,6 +930,9 @@ static inline void DetectRunPostRules(
     PacketAlertFinalize(de_ctx, det_ctx, p);
     if (p->alerts.cnt > 0) {
         StatsAddUI64(tv, det_ctx->counter_alerts, (uint64_t)p->alerts.cnt);
+    }
+    if (p->alerts.discarded > 0) {
+        StatsAddUI64(tv, det_ctx->counter_alerts_overflow, (uint64_t)p->alerts.discarded);
     }
     PACKET_PROFILING_DETECT_END(p, PROF_DETECT_ALERT);
 }

--- a/src/detect.c
+++ b/src/detect.c
@@ -822,6 +822,7 @@ static DetectRunScratchpad DetectRunSetup(
 #ifdef UNITTESTS
     p->alerts.cnt = 0;
     p->alerts.discarded = 0;
+    p->alerts.suppressed = 0;
 #endif
     det_ctx->ticker++;
     det_ctx->filestore_cnt = 0;
@@ -933,6 +934,9 @@ static inline void DetectRunPostRules(
     }
     if (p->alerts.discarded > 0) {
         StatsAddUI64(tv, det_ctx->counter_alerts_overflow, (uint64_t)p->alerts.discarded);
+    }
+    if (p->alerts.suppressed > 0) {
+        StatsAddUI64(tv, det_ctx->counter_alerts_suppressed, (uint64_t)p->alerts.suppressed);
     }
     PACKET_PROFILING_DETECT_END(p, PROF_DETECT_ALERT);
 }

--- a/src/detect.c
+++ b/src/detect.c
@@ -828,6 +828,9 @@ static DetectRunScratchpad DetectRunSetup(
     det_ctx->raw_stream_progress = 0;
     det_ctx->match_array_cnt = 0;
 
+    det_ctx->alert_queue_size = 0;
+    p->alerts.drop.action = 0;
+
 #ifdef DEBUG
     if (p->flags & PKT_STREAM_ADD) {
         det_ctx->pkt_stream_add_cnt++;

--- a/src/detect.h
+++ b/src/detect.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect.h
+++ b/src/detect.h
@@ -1088,6 +1088,10 @@ typedef struct DetectEngineThreadCtx_ {
     uint64_t tx_id;
     Packet *p;
 
+    uint16_t alert_queue_size;
+    uint16_t alert_queue_capacity;
+    PacketAlert *alert_queue;
+
     SC_ATOMIC_DECLARE(int, so_far_used_by_detect);
 
     /* holds the current recursion depth on content inspection */
@@ -1502,6 +1506,11 @@ void *DetectThreadCtxGetKeywordThreadCtx(DetectEngineThreadCtx *, int);
 
 void RuleMatchCandidateTxArrayInit(DetectEngineThreadCtx *det_ctx, uint32_t size);
 void RuleMatchCandidateTxArrayFree(DetectEngineThreadCtx *det_ctx);
+
+void AlertQueueInit(DetectEngineThreadCtx *det_ctx);
+void AlertQueueFree(DetectEngineThreadCtx *det_ctx);
+void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p, uint64_t tx_id,
+        uint8_t alert_flags);
 
 int DetectFlowbitsAnalyze(DetectEngineCtx *de_ctx);
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1053,6 +1053,8 @@ typedef struct DetectEngineThreadCtx_ {
 
     /** id for alert counter */
     uint16_t counter_alerts;
+    /** id for discarded alerts counter**/
+    uint16_t counter_alerts_overflow;
 #ifdef PROFILING
     uint16_t counter_mpm_list;
     uint16_t counter_nonmpm_list;

--- a/src/detect.h
+++ b/src/detect.h
@@ -1053,8 +1053,10 @@ typedef struct DetectEngineThreadCtx_ {
 
     /** id for alert counter */
     uint16_t counter_alerts;
-    /** id for discarded alerts counter**/
+    /** id for discarded alerts counter */
     uint16_t counter_alerts_overflow;
+    /** id for suppressed alerts counter */
+    uint16_t counter_alerts_suppressed;
 #ifdef PROFILING
     uint16_t counter_mpm_list;
     uint16_t counter_nonmpm_list;

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2020 Open Information Security Foundation
+/* Copyright (C) 2018-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2016 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6379,11 +6379,10 @@ const char *StreamTcpSsnStateAsString(const TcpSession *ssn)
 static int StreamTcpTest01 (void)
 {
     StreamTcpThread stt;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
-    memset(p, 0, SIZE_OF_PACKET);
     memset (&f, 0, sizeof(Flow));
     FLOW_INITIALIZE(&f);
     p->flow = &f;
@@ -6427,7 +6426,7 @@ end:
 
 static int StreamTcpTest02 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF(unlikely(p == NULL));
     Flow f;
     ThreadVars tv;
@@ -6436,7 +6435,6 @@ static int StreamTcpTest02 (void)
     TCPHdr tcph;
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(pq));
-    memset(p, 0, SIZE_OF_PACKET);
     memset (&f, 0, sizeof(Flow));
     memset(&tv, 0, sizeof (ThreadVars));
     memset(&stt, 0, sizeof (StreamTcpThread));
@@ -6513,14 +6511,13 @@ static int StreamTcpTest02 (void)
 
 static int StreamTcpTest03 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
     ThreadVars tv;
     StreamTcpThread stt;
     TCPHdr tcph;
-    memset(p, 0, SIZE_OF_PACKET);
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(pq));
     memset (&f, 0, sizeof(Flow));
@@ -6589,14 +6586,13 @@ end:
 
 static int StreamTcpTest04 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
     ThreadVars tv;
     StreamTcpThread stt;
     TCPHdr tcph;
-    memset(p, 0, SIZE_OF_PACKET);
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(pq));
     memset (&f, 0, sizeof(Flow));
@@ -6658,7 +6654,7 @@ end:
 
 static int StreamTcpTest05 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
@@ -6666,7 +6662,6 @@ static int StreamTcpTest05 (void)
     StreamTcpThread stt;
     TCPHdr tcph;
     uint8_t payload[4];
-    memset(p, 0, SIZE_OF_PACKET);
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
     memset (&f, 0, sizeof(Flow));
@@ -6758,7 +6753,7 @@ end:
 
 static int StreamTcpTest06 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
@@ -6766,7 +6761,6 @@ static int StreamTcpTest06 (void)
     ThreadVars tv;
     StreamTcpThread stt;
     TCPHdr tcph;
-    memset(p, 0, SIZE_OF_PACKET);
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
     memset (&f, 0, sizeof(Flow));
@@ -6821,7 +6815,7 @@ end:
 
 static int StreamTcpTest07 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF(unlikely(p == NULL));
     Flow f;
     ThreadVars tv;
@@ -6830,7 +6824,6 @@ static int StreamTcpTest07 (void)
     uint8_t payload[1] = {0x42};
     PacketQueueNoLock pq;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&pq,0,sizeof(PacketQueueNoLock));
     memset (&f, 0, sizeof(Flow));
     memset(&tv, 0, sizeof (ThreadVars));
@@ -6883,7 +6876,7 @@ static int StreamTcpTest07 (void)
 
 static int StreamTcpTest08 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF(unlikely(p == NULL));
     Flow f;
     ThreadVars tv;
@@ -6891,7 +6884,6 @@ static int StreamTcpTest08 (void)
     TCPHdr tcph;
     uint8_t payload[1] = {0x42};
 
-    memset(p, 0, SIZE_OF_PACKET);
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
     memset (&f, 0, sizeof(Flow));
@@ -6946,7 +6938,7 @@ static int StreamTcpTest08 (void)
 
 static int StreamTcpTest09 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF(unlikely(p == NULL));
     Flow f;
     ThreadVars tv;
@@ -6954,7 +6946,6 @@ static int StreamTcpTest09 (void)
     TCPHdr tcph;
     uint8_t payload[1] = {0x42};
 
-    memset(p, 0, SIZE_OF_PACKET);
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
     memset (&f, 0, sizeof(Flow));
@@ -7017,14 +7008,13 @@ static int StreamTcpTest09 (void)
 
 static int StreamTcpTest10 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF(unlikely(p == NULL));
     Flow f;
     ThreadVars tv;
     StreamTcpThread stt;
     TCPHdr tcph;
     uint8_t payload[4];
-    memset(p, 0, SIZE_OF_PACKET);
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
     memset (&f, 0, sizeof(Flow));
@@ -7096,14 +7086,13 @@ static int StreamTcpTest10 (void)
 
 static int StreamTcpTest11 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF(unlikely(p == NULL));
     Flow f;
     ThreadVars tv;
     StreamTcpThread stt;
     TCPHdr tcph;
     uint8_t payload[4];
-    memset(p, 0, SIZE_OF_PACKET);
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
     memset (&f, 0, sizeof(Flow));
@@ -7176,7 +7165,7 @@ static int StreamTcpTest11 (void)
 
 static int StreamTcpTest12 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
@@ -7184,7 +7173,6 @@ static int StreamTcpTest12 (void)
     StreamTcpThread stt;
     TCPHdr tcph;
     uint8_t payload[4];
-    memset(p, 0, SIZE_OF_PACKET);
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
     memset (&f, 0, sizeof(Flow));
@@ -7272,7 +7260,7 @@ end:
 
 static int StreamTcpTest13 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
@@ -7280,7 +7268,6 @@ static int StreamTcpTest13 (void)
     StreamTcpThread stt;
     TCPHdr tcph;
     uint8_t payload[4];
-    memset(p, 0, SIZE_OF_PACKET);
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
     memset (&f, 0, sizeof(Flow));
@@ -7472,7 +7459,7 @@ static const char *StreamTcpParseOSPolicy (char *conf_var_name)
 
 static int StreamTcpTest14 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
@@ -7487,7 +7474,6 @@ static int StreamTcpTest14 (void)
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset (&f, 0, sizeof(Flow));
     memset(&tv, 0, sizeof (ThreadVars));
     memset(&stt, 0, sizeof (StreamTcpThread));
@@ -7642,14 +7628,13 @@ end:
 static int StreamTcp4WHSTest01 (void)
 {
     int ret = 0;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
     ThreadVars tv;
     StreamTcpThread stt;
     TCPHdr tcph;
-    memset(p, 0, SIZE_OF_PACKET);
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
     memset (&f, 0, sizeof(Flow));
@@ -7724,14 +7709,13 @@ end:
 static int StreamTcp4WHSTest02 (void)
 {
     int ret = 0;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
     ThreadVars tv;
     StreamTcpThread stt;
     TCPHdr tcph;
-    memset(p, 0, SIZE_OF_PACKET);
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
     memset (&f, 0, sizeof(Flow));
@@ -7795,13 +7779,12 @@ end:
 static int StreamTcp4WHSTest03 (void)
 {
     int ret = 0;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF(unlikely(p == NULL));
     Flow f;
     ThreadVars tv;
     StreamTcpThread stt;
     TCPHdr tcph;
-    memset(p, 0, SIZE_OF_PACKET);
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
     memset (&f, 0, sizeof(Flow));
@@ -7874,7 +7857,7 @@ end:
 
 static int StreamTcpTest15 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
@@ -7889,7 +7872,6 @@ static int StreamTcpTest15 (void)
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset (&f, 0, sizeof(Flow));
     memset(&tv, 0, sizeof (ThreadVars));
     memset(&stt, 0, sizeof (StreamTcpThread));
@@ -8041,7 +8023,7 @@ end:
 
 static int StreamTcpTest16 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
@@ -8056,7 +8038,6 @@ static int StreamTcpTest16 (void)
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset (&f, 0, sizeof(Flow));
     memset(&tv, 0, sizeof (ThreadVars));
     memset(&stt, 0, sizeof (StreamTcpThread));
@@ -8211,7 +8192,7 @@ end:
 
 static int StreamTcpTest17 (void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
@@ -8226,7 +8207,6 @@ static int StreamTcpTest17 (void)
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset (&f, 0, sizeof(Flow));
     memset(&tv, 0, sizeof (ThreadVars));
     memset(&stt, 0, sizeof (StreamTcpThread));
@@ -8380,7 +8360,7 @@ static int StreamTcpTest18 (void)
     char os_policy_name[10] = "windows";
     const char *ip_addr;
     TcpStream stream;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     IPV4Hdr ipv4h;
@@ -8388,7 +8368,6 @@ static int StreamTcpTest18 (void)
 
     memset(&addr, 0, sizeof(addr));
     memset(&stream, 0, sizeof(stream));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(ipv4h));
 
     StreamTcpUTInit(&stt.ra_ctx);
@@ -8429,7 +8408,7 @@ static int StreamTcpTest19 (void)
     char os_policy_name[10] = "windows";
     const char *ip_addr;
     TcpStream stream;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     IPV4Hdr ipv4h;
@@ -8437,7 +8416,6 @@ static int StreamTcpTest19 (void)
 
     memset(&addr, 0, sizeof(addr));
     memset(&stream, 0, sizeof(stream));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(ipv4h));
 
     StreamTcpUTInit(&stt.ra_ctx);
@@ -8481,7 +8459,7 @@ static int StreamTcpTest20 (void)
     char os_policy_name[10] = "linux";
     const char *ip_addr;
     TcpStream stream;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     IPV4Hdr ipv4h;
@@ -8489,7 +8467,6 @@ static int StreamTcpTest20 (void)
 
     memset(&addr, 0, sizeof(addr));
     memset(&stream, 0, sizeof(stream));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(ipv4h));
 
     StreamTcpUTInit(&stt.ra_ctx);
@@ -8533,7 +8510,7 @@ static int StreamTcpTest21 (void)
     char os_policy_name[10] = "linux";
     const char *ip_addr;
     TcpStream stream;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     IPV4Hdr ipv4h;
@@ -8541,7 +8518,6 @@ static int StreamTcpTest21 (void)
 
     memset(&addr, 0, sizeof(addr));
     memset(&stream, 0, sizeof(stream));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(ipv4h));
 
     StreamTcpUTInit(&stt.ra_ctx);
@@ -8585,7 +8561,7 @@ static int StreamTcpTest22 (void)
     char os_policy_name[10] = "windows";
     const char *ip_addr;
     TcpStream stream;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     IPV4Hdr ipv4h;
@@ -8593,7 +8569,6 @@ static int StreamTcpTest22 (void)
 
     memset(&addr, 0, sizeof(addr));
     memset(&stream, 0, sizeof(stream));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&ipv4h, 0, sizeof(ipv4h));
 
     StreamTcpUTInit(&stt.ra_ctx);
@@ -8640,11 +8615,10 @@ static int StreamTcpTest23(void)
     ThreadVars tv;
     PacketQueueNoLock pq;
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF(p == NULL);
 
     memset(&pq,0,sizeof(PacketQueueNoLock));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&f, 0, sizeof (Flow));
     memset(&tcph, 0, sizeof (TCPHdr));
     memset(&tv, 0, sizeof (ThreadVars));
@@ -8700,7 +8674,7 @@ static int StreamTcpTest24(void)
 {
     StreamTcpThread stt;
     TcpSession ssn;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF (p == NULL);
     Flow f;
     TCPHdr tcph;
@@ -8713,7 +8687,6 @@ static int StreamTcpTest24(void)
     StreamTcpUTInit(&stt.ra_ctx);
     StreamTcpUTSetupSession(&ssn);
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&f, 0, sizeof (Flow));
     memset(&tcph, 0, sizeof (TCPHdr));
     FLOW_INITIALIZE(&f);
@@ -8768,7 +8741,7 @@ static int StreamTcpTest24(void)
  */
 static int StreamTcpTest25(void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
@@ -8780,7 +8753,6 @@ static int StreamTcpTest25(void)
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset (&f, 0, sizeof(Flow));
     memset(&tv, 0, sizeof (ThreadVars));
     memset(&stt, 0, sizeof (StreamTcpThread));
@@ -8861,7 +8833,7 @@ end:
  */
 static int StreamTcpTest26(void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
@@ -8873,7 +8845,6 @@ static int StreamTcpTest26(void)
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset (&f, 0, sizeof(Flow));
     memset(&tv, 0, sizeof (ThreadVars));
     memset(&stt, 0, sizeof (StreamTcpThread));
@@ -8955,7 +8926,7 @@ end:
  */
 static int StreamTcpTest27(void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
@@ -8967,7 +8938,6 @@ static int StreamTcpTest27(void)
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset (&f, 0, sizeof(Flow));
     memset(&tv, 0, sizeof (ThreadVars));
     memset(&stt, 0, sizeof (StreamTcpThread));
@@ -9926,7 +9896,7 @@ end:
  */
 static int StreamTcpTest37(void)
 {
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     Flow f;
@@ -9938,7 +9908,6 @@ static int StreamTcpTest37(void)
     PacketQueueNoLock pq;
     memset(&pq,0,sizeof(PacketQueueNoLock));
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset (&f, 0, sizeof(Flow));
     memset(&tv, 0, sizeof (ThreadVars));
     memset(&stt, 0, sizeof (StreamTcpThread));
@@ -10059,10 +10028,9 @@ static int StreamTcpTest38 (void)
     memset(&tcph, 0, sizeof (TCPHdr));
     memset(&pq,0,sizeof(PacketQueueNoLock));
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
-    memset(p, 0, SIZE_OF_PACKET);
 
     FLOW_INITIALIZE(&f);
     p->flow = &f;
@@ -10214,10 +10182,9 @@ static int StreamTcpTest39 (void)
     memset(&tcph, 0, sizeof (TCPHdr));
     memset(&pq,0,sizeof(PacketQueueNoLock));
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
-    memset(p, 0, SIZE_OF_PACKET);
 
     FLOW_INITIALIZE(&f);
     p->flow = &f;
@@ -10336,12 +10303,11 @@ static int StreamTcpTest42 (void)
     StreamTcpThread stt;
     TCPHdr tcph;
     PacketQueueNoLock pq;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     TcpSession *ssn;
 
     if (unlikely(p == NULL))
         return 0;
-    memset(p, 0, SIZE_OF_PACKET);
 
     memset(&pq,0,sizeof(PacketQueueNoLock));
     memset (&f, 0, sizeof(Flow));
@@ -10428,12 +10394,11 @@ static int StreamTcpTest43 (void)
     StreamTcpThread stt;
     TCPHdr tcph;
     PacketQueueNoLock pq;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     TcpSession *ssn;
 
     if (unlikely(p == NULL))
         return 0;
-    memset(p, 0, SIZE_OF_PACKET);
 
     memset(&pq,0,sizeof(PacketQueueNoLock));
     memset (&f, 0, sizeof(Flow));
@@ -10520,12 +10485,11 @@ static int StreamTcpTest44 (void)
     StreamTcpThread stt;
     TCPHdr tcph;
     PacketQueueNoLock pq;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     TcpSession *ssn;
 
     if (unlikely(p == NULL))
         return 0;
-    memset(p, 0, SIZE_OF_PACKET);
 
     memset(&pq,0,sizeof(PacketQueueNoLock));
     memset (&f, 0, sizeof(Flow));
@@ -10607,12 +10571,11 @@ static int StreamTcpTest45 (void)
     StreamTcpThread stt;
     TCPHdr tcph;
     PacketQueueNoLock pq;
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     TcpSession *ssn;
 
     if (unlikely(p == NULL))
         return 0;
-    memset(p, 0, SIZE_OF_PACKET);
 
     memset(&pq,0,sizeof(PacketQueueNoLock));
     memset (&f, 0, sizeof(Flow));

--- a/src/tests/detect.c
+++ b/src/tests/detect.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2017 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/tests/detect.c
+++ b/src/tests/detect.c
@@ -943,7 +943,7 @@ static int SigTest15 (void)
     uint8_t *buf = (uint8_t *)
                     "CONNECT 213.92.8.7:31204 HTTP/1.1";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars th_v;
@@ -951,7 +951,6 @@ static int SigTest15 (void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
     p->payload = buf;
@@ -1102,7 +1101,7 @@ static int SigTest18 (void)
     uint8_t *buf = (uint8_t *)
                     "220 (vsFTPd 2.0.5)\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars th_v;
@@ -1110,7 +1109,6 @@ static int SigTest18 (void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
     p->payload = buf;
@@ -1155,7 +1153,7 @@ static int SigTest19 (void)
     uint8_t *buf = (uint8_t *)
                     "220 (vsFTPd 2.0.5)\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars th_v;
@@ -1163,7 +1161,6 @@ static int SigTest19 (void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     p->src.family = AF_INET;
     p->src.addr_data32[0] = UTHSetIPv4Address("192.168.0.1");
     p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");
@@ -1216,7 +1213,7 @@ static int SigTest20 (void)
     uint8_t *buf = (uint8_t *)
                     "220 (vsFTPd 2.0.5)\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars th_v;
@@ -1224,7 +1221,6 @@ static int SigTest20 (void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     p->src.family = AF_INET;
     p->src.addr_data32[0] = UTHSetIPv4Address("192.168.0.1");
     p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");
@@ -1513,10 +1509,10 @@ static int SigTest24IPV4Keyword(void)
         0x40, 0x01, 0xb7, 0x52, 0xc0, 0xa8, 0x01, 0x03,
         0xc0, 0xa8, 0x01, 0x06};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -1530,8 +1526,6 @@ static int SigTest24IPV4Keyword(void)
     uint16_t buflen = strlen((char *)buf);
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
     PACKET_RESET_CHECKSUMS(p1);
     PACKET_RESET_CHECKSUMS(p2);
 
@@ -1617,10 +1611,10 @@ static int SigTest25NegativeIPV4Keyword(void)
         0x40, 0x01, 0xb7, 0x52, 0xc0, 0xa8, 0x01, 0x03,
         0xc0, 0xa8, 0x01, 0x06};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -1634,8 +1628,6 @@ static int SigTest25NegativeIPV4Keyword(void)
     uint16_t buflen = strlen((char *)buf);
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
     PACKET_RESET_CHECKSUMS(p1);
     PACKET_RESET_CHECKSUMS(p2);
 
@@ -1727,11 +1719,11 @@ static int SigTest26TCPV4Keyword(void)
         0x04, 0x02, 0x08, 0x0a, 0x6e, 0x18, 0x78, 0x73,
         0x01, 0x71, 0x74, 0xde, 0x01, 0x03, 0x03, 0x03};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
 
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -1741,8 +1733,6 @@ static int SigTest26TCPV4Keyword(void)
     DetectEngineThreadCtx *det_ctx = NULL;
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PacketCopyData(p1, raw_ipv4, sizeof(raw_ipv4));
     PacketCopyDataOffset(p1, GET_PKT_LEN(p1), valid_raw_tcp, sizeof(valid_raw_tcp));
@@ -1826,11 +1816,11 @@ static int SigTest26TCPV4AndNegativeIPV4Keyword(void)
         0x04, 0x02, 0x08, 0x0a, 0x6e, 0x18, 0x78, 0x73,
         0x01, 0x71, 0x74, 0xde, 0x01, 0x03, 0x03, 0x03};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
 
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -1841,8 +1831,6 @@ static int SigTest26TCPV4AndNegativeIPV4Keyword(void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PacketCopyData(p1, raw_ipv4, sizeof(raw_ipv4));
     PacketCopyDataOffset(p1, GET_PKT_LEN(p1), valid_raw_tcp, sizeof(valid_raw_tcp));
@@ -1952,11 +1940,11 @@ static int SigTest26TCPV4AndIPV4Keyword(void)
         0x19, 0x69, 0x81, 0x7e, 0xFF, 0xAA, 0x00, 0x00,
         0x04, 0x02, 0x00, 0x00};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
 
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -1967,8 +1955,6 @@ static int SigTest26TCPV4AndIPV4Keyword(void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PacketCopyData(p1, raw_ipv4, sizeof(raw_ipv4));
     PacketCopyDataOffset(p1, GET_PKT_LEN(p1), valid_raw_tcp, sizeof(valid_raw_tcp));
@@ -2067,11 +2053,10 @@ static int SigTest27NegativeTCPV4Keyword(void)
         0x04, 0x02, 0x08, 0x0a, 0x6e, 0x18, 0x78, 0x73,
         0x01, 0x71, 0x74, 0xde, 0x01, 0x03, 0x03, 0x03};
 
-
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -2081,8 +2066,6 @@ static int SigTest27NegativeTCPV4Keyword(void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PacketCopyData(p1, raw_ipv4, sizeof(raw_ipv4));
     PacketCopyDataOffset(p1, GET_PKT_LEN(p1), valid_raw_tcp, sizeof(valid_raw_tcp));
@@ -2194,10 +2177,10 @@ static int SigTest28TCPV6Keyword(void)
         0x01, 0x01, 0x08, 0x0a, 0x00, 0x08, 0xca, 0x5a,
         0x00, 0x01, 0x69, 0x28};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -2207,8 +2190,6 @@ static int SigTest28TCPV6Keyword(void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
@@ -2322,10 +2303,10 @@ static int SigTest29NegativeTCPV6Keyword(void)
         0x01, 0x01, 0x08, 0x0a, 0x00, 0x08, 0xca, 0x5a,
         0x00, 0x01, 0x69, 0x28};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -2335,8 +2316,6 @@ static int SigTest29NegativeTCPV6Keyword(void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
@@ -2445,9 +2424,9 @@ static int SigTest30UDPV4Keyword(void)
         0x61, 0x64, 0x01, 0x6c, 0x06, 0x67, 0x6f, 0x6f,
         0x67, 0x6c, 0x65, 0xc0, 0x27};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     FAIL_IF_NULL(p1);
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     FAIL_IF_NULL(p2);
 
     ThreadVars th_v;
@@ -2457,8 +2436,6 @@ static int SigTest30UDPV4Keyword(void)
                     "\r\n\r\nyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ip4h = (IPV4Hdr *)raw_ipv4;
@@ -2549,10 +2526,10 @@ static int SigTest31NegativeUDPV4Keyword(void)
         0x61, 0x64, 0x01, 0x6c, 0x06, 0x67, 0x6f, 0x6f,
         0x67, 0x6c, 0x65, 0xc0, 0x27};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -2565,8 +2542,6 @@ static int SigTest31NegativeUDPV4Keyword(void)
                     "\r\n\r\nyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ip4h = (IPV4Hdr *)raw_ipv4;
@@ -2666,9 +2641,9 @@ static int SigTest32UDPV6Keyword(void)
         0x00, 0x00, 0xf9, 0xc8, 0xe7, 0x36, 0x57, 0xb0,
         0x09, 0x01};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     FAIL_IF_NULL(p1);
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     FAIL_IF_NULL(p2);
 
     ThreadVars th_v;
@@ -2678,8 +2653,6 @@ static int SigTest32UDPV6Keyword(void)
                     "\r\n\r\n";
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
@@ -2763,10 +2736,10 @@ static int SigTest33NegativeUDPV6Keyword(void)
         0x00, 0x00, 0xf9, 0xc8, 0xe7, 0x36, 0x57, 0xb0,
         0x09, 0x01};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -2779,8 +2752,6 @@ static int SigTest33NegativeUDPV6Keyword(void)
                     "\r\n\r\n";
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
@@ -2880,10 +2851,10 @@ static int SigTest34ICMPV4Keyword(void)
         0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33,
         0x34, 0x35, 0x36, 0x38};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -2897,8 +2868,6 @@ static int SigTest34ICMPV4Keyword(void)
     uint16_t buflen = strlen((char *)buf);
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ip4h = (IPV4Hdr *)(valid_raw_ipv4);
@@ -3000,10 +2969,10 @@ static int SigTest35NegativeICMPV4Keyword(void)
         0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33,
         0x34, 0x35, 0x36, 0x38};
 
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    Packet *p2 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL)) {
         SCFree(p1);
         return 0;
@@ -3017,8 +2986,6 @@ static int SigTest35NegativeICMPV4Keyword(void)
     uint16_t buflen = strlen((char *)buf);
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
-    memset(p2, 0, SIZE_OF_PACKET);
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ip4h = (IPV4Hdr *)(valid_raw_ipv4);
@@ -3095,7 +3062,7 @@ end:
 
 static int SigTest38(void)
 {
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
     ThreadVars th_v;
@@ -3136,7 +3103,6 @@ static int SigTest38(void)
     uint16_t buflen = sizeof(buf);
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
 
     /* Copy raw data into packet */
     if (PacketCopyData(p1, raw_eth, ethlen) == -1) {
@@ -3226,7 +3192,7 @@ end:
 
 static int SigTest39(void)
 {
-    Packet *p1 = SCMalloc(SIZE_OF_PACKET);
+    Packet *p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
     ThreadVars th_v;
@@ -3267,7 +3233,6 @@ static int SigTest39(void)
     uint16_t buflen = sizeof(buf);
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    memset(p1, 0, SIZE_OF_PACKET);
 
     /* Copy raw data into packet */
     if (PacketCopyData(p1, raw_eth, ethlen) == -1) {
@@ -3402,7 +3367,7 @@ static int SigTest36ContentAndIsdataatKeywords01 (void)
 	,0x65,0x72,0x65,0x3c,0x2f,0x41,0x3e,0x2e,0x0d,0x0a,0x3c,0x2f,0x42,0x4f,0x44,0x59
 	,0x3e,0x3c,0x2f,0x48,0x54,0x4d,0x4c,0x3e,0x0d,0x0a };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     DecodeThreadVars dtv;
@@ -3410,7 +3375,6 @@ static int SigTest36ContentAndIsdataatKeywords01 (void)
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&th_v, 0, sizeof(th_v));
 
@@ -3521,7 +3485,7 @@ static int SigTest37ContentAndIsdataatKeywords02 (void)
 	,0x65,0x72,0x65,0x3c,0x2f,0x41,0x3e,0x2e,0x0d,0x0a,0x3c,0x2f,0x42,0x4f,0x44,0x59
 	,0x3e,0x3c,0x2f,0x48,0x54,0x4d,0x4c,0x3e,0x0d,0x0a };
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     DecodeThreadVars dtv;
@@ -3529,7 +3493,6 @@ static int SigTest37ContentAndIsdataatKeywords02 (void)
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;
 
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&th_v, 0, sizeof(th_v));
 
@@ -3612,7 +3575,7 @@ static int SigTest40NoPacketInspection01(void)
     uint8_t *buf = (uint8_t *)
                     "220 (vsFTPd 2.0.5)\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     TCPHdr tcphdr;
     if (unlikely(p == NULL))
     return 0;
@@ -3623,7 +3586,6 @@ static int SigTest40NoPacketInspection01(void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     memset(&pq, 0, sizeof(pq));
     memset(&f, 0, sizeof(f));
     memset(&tcphdr, 0, sizeof(tcphdr));
@@ -3691,9 +3653,8 @@ static int SigTest40NoPayloadInspection02(void)
     ThreadVars th_v;
     memset(&th_v, 0, sizeof(th_v));
 
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
-    memset(p, 0, SIZE_OF_PACKET);
 
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
@@ -3734,7 +3695,7 @@ static int SigTestMemory01 (void)
                     "Host: two.example.org\r\n"
                     "\r\n\r\n";
     uint16_t buflen = strlen((char *)buf);
-    Packet *p = SCMalloc(SIZE_OF_PACKET);
+    Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
     ThreadVars th_v;
@@ -3742,7 +3703,6 @@ static int SigTestMemory01 (void)
     int result = 0;
 
     memset(&th_v, 0, sizeof(th_v));
-    memset(p, 0, SIZE_OF_PACKET);
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
     p->payload = buf;
@@ -4276,10 +4236,9 @@ static int SigTestWithin01 (void)
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
     /* packet 1 */
-    p1 = SCMalloc(SIZE_OF_PACKET);
+    p1 = PacketGetFromAlloc();
     if (unlikely(p1 == NULL))
         return 0;
-    memset(p1, 0, SIZE_OF_PACKET);
     DecodeEthernet(&th_v, &dtv, p1, rawpkt1, sizeof(rawpkt1));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
     if (!(PacketAlertCheck(p1, 556))) {
@@ -4288,10 +4247,9 @@ static int SigTestWithin01 (void)
     }
 
     /* packet 2 */
-    p2 = SCMalloc(SIZE_OF_PACKET);
+    p2 = PacketGetFromAlloc();
     if (unlikely(p2 == NULL))
         return 0;
-    memset(p2, 0, SIZE_OF_PACKET);
     DecodeEthernet(&th_v, &dtv, p2, rawpkt2, sizeof(rawpkt2));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
     if (!(PacketAlertCheck(p2, 556))) {
@@ -4300,10 +4258,9 @@ static int SigTestWithin01 (void)
     }
 
     /* packet 3 */
-    p3 = SCMalloc(SIZE_OF_PACKET);
+    p3 = PacketGetFromAlloc();
     if (unlikely(p3 == NULL))
         return 0;
-    memset(p3, 0, SIZE_OF_PACKET);
     DecodeEthernet(&th_v, &dtv, p3, rawpkt3, sizeof(rawpkt3));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p3);
     if (!(PacketAlertCheck(p3, 556))) {
@@ -4312,10 +4269,9 @@ static int SigTestWithin01 (void)
     }
 
     /* packet 4 */
-    p4 = SCMalloc(SIZE_OF_PACKET);
+    p4 = PacketGetFromAlloc();
     if (unlikely(p4 == NULL))
         return 0;
-    memset(p4, 0, SIZE_OF_PACKET);
     DecodeEthernet(&th_v, &dtv, p4, rawpkt4, sizeof(rawpkt4));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p4);
     if (!(PacketAlertCheck(p4, 556))) {

--- a/src/util-action.c
+++ b/src/util-action.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/util-action.c
+++ b/src/util-action.c
@@ -814,8 +814,8 @@ static int UtilActionTest13(void)
                               {0, 0, 1},
                               {0, 0, 1},
                               {0, 0, 1} };
-     /* All the patckets should match the 3 sigs. As drop has more
-      * priority than pass, it should alert on each packet */
+    /* All the packets should match the 3 sigs. As drop has more
+     * priority than pass, it should alert on each packet */
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -889,9 +889,9 @@ static int UtilActionTest14(void)
                               {1, 0, 1},
                               {1, 0, 1},
                               {1, 0, 1} };
-     /* All the patckets should match the 3 sigs. As drop
-      * and alert have more priority than pass, both should
-      * alert on each packet */
+    /* All the packets should match the 3 sigs. As drop
+     * and alert have more priority than pass, both should
+     * alert on each packet */
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -958,9 +958,9 @@ static int UtilActionTest15(void)
                               {0, 0, 0},
                               {0, 0, 0},
                               {0, 0, 0} };
-     /* All the patckets should match the 3 sigs. As drop
-      * and alert have more priority than pass, both should
-      * alert on each packet */
+    /* All the packets should match the 3 sigs. As drop
+     * and alert have more priority than pass, both should
+     * alert on each packet */
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -1022,9 +1022,9 @@ static int UtilActionTest16(void)
                               {0, 0, 0},
                               {0, 0, 0},
                               {0, 0, 0} };
-     /* All the patckets should match the 3 sigs. As drop
-      * and alert have more priority than pass, both should
-      * alert on each packet */
+    /* All the packets should match the 3 sigs. As drop
+     * and alert have more priority than pass, both should
+     * alert on each packet */
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -1086,9 +1086,9 @@ static int UtilActionTest17(void)
                               {0, 0, 0},
                               {0, 0, 0},
                               {0, 0, 0} };
-     /* All the patckets should match the 3 sigs. As drop
-      * and alert have more priority than pass, both should
-      * alert on each packet */
+    /* All the packets should match the 3 sigs. As drop
+     * and alert have more priority than pass, both should
+     * alert on each packet */
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -1155,9 +1155,9 @@ static int UtilActionTest18(void)
                               {0, 0, 1},
                               {0, 0, 1},
                               {0, 0, 1} };
-     /* All the patckets should match the 3 sigs. As drop
-      * and alert have more priority than pass, both should
-      * alert on each packet */
+    /* All the packets should match the 3 sigs. As drop
+     * and alert have more priority than pass, both should
+     * alert on each packet */
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -1230,9 +1230,9 @@ static int UtilActionTest19(void)
                               {1, 0, 0},
                               {1, 0, 0},
                               {1, 0, 0} };
-     /* All the patckets should match the 3 sigs. As drop
-      * and alert have more priority than pass, both should
-      * alert on each packet */
+    /* All the packets should match the 3 sigs. As drop
+     * and alert have more priority than pass, both should
+     * alert on each packet */
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -1305,9 +1305,9 @@ static int UtilActionTest20(void)
                               {0, 1, 0},
                               {0, 1, 0},
                               {0, 1, 0} };
-     /* All the patckets should match the 3 sigs. As drop
-      * and alert have more priority than pass, both should
-      * alert on each packet */
+    /* All the packets should match the 3 sigs. As drop
+     * and alert have more priority than pass, both should
+     * alert on each packet */
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -1374,9 +1374,9 @@ static int UtilActionTest21(void)
                               {1, 0, 1},
                               {1, 0, 1},
                               {1, 0, 1} };
-     /* All the patckets should match the 3 sigs. As drop
-      * and alert have more priority than pass, both should
-      * alert on each packet */
+    /* All the packets should match the 3 sigs. As drop
+     * and alert have more priority than pass, both should
+     * alert on each packet */
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -1449,9 +1449,9 @@ static int UtilActionTest22(void)
                               {1, 1, 0},
                               {1, 1, 0},
                               {1, 1, 0} };
-     /* All the patckets should match the 3 sigs. As drop
-      * and alert have more priority than pass, both should
-      * alert on each packet */
+    /* All the packets should match the 3 sigs. As drop
+     * and alert have more priority than pass, both should
+     * alert on each packet */
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -1524,9 +1524,9 @@ static int UtilActionTest23(void)
                               {0, 1, 1},
                               {0, 1, 1},
                               {0, 1, 1} };
-     /* All the patckets should match the 3 sigs. As drop
-      * and alert have more priority than pass, both should
-      * alert on each packet */
+    /* All the packets should match the 3 sigs. As drop
+     * and alert have more priority than pass, both should
+     * alert on each packet */
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1098,6 +1098,10 @@ legacy:
 #   - reject
 #   - alert
 
+# Define maximum number of possible alerts that can be triggered for the same
+# packet. Default is 15
+#packet-alert-max: 15
+
 # IP Reputation
 #reputation-categories-file: @e_sysconfdir@iprep/categories.txt
 #default-reputation-path: @e_sysconfdir@iprep


### PR DESCRIPTION
Alert queue optimizations backports to 6.0.x

Tickets:
- https://redmine.openinfosecfoundation.org/issues/5127
- https://redmine.openinfosecfoundation.org/issues/5323
- https://redmine.openinfosecfoundation.org/issues/5125

Describe changes:
- besides the directly related commits, also brought the commit for using PacketGetFromAlloc, to prevent unittests from breaking
- also updated copyright years for the files edited in the unittests commit
