### PR TITLE
rules: use primary default-rule-path if set on command line

### DIFF
--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -68,16 +68,22 @@ char *DetectLoadCompleteSigPath(const DetectEngineCtx *de_ctx, const char *sig_f
         return NULL;
     }
 
-    if (strlen(de_ctx->config_prefix) > 0) {
+    /* If we have a configuration prefix, only use it if the primary configuration node
+     * is not marked as final, as that means it was provided on the command line with
+     * a --set. */
+    ConfNode *default_rule_path = ConfGetNode("default-rule-path");
+    if ((!default_rule_path || !default_rule_path->final) && strlen(de_ctx->config_prefix) > 0) {
         snprintf(varname, sizeof(varname), "%s.default-rule-path",
                 de_ctx->config_prefix);
-    } else {
-        snprintf(varname, sizeof(varname), "default-rule-path");
+        default_rule_path = ConfGetNode(varname);
+    }
+    if (default_rule_path) {
+        defaultpath = default_rule_path->val;
     }
 
     /* Path not specified */
     if (PathIsRelative(sig_file)) {
-        if (ConfGet(varname, &defaultpath) == 1) {
+        if (defaultpath) {
             SCLogDebug("Default path: %s", defaultpath);
             size_t path_len = sizeof(char) * (strlen(defaultpath) +
                           strlen(sig_file) + 2);


### PR DESCRIPTION
When reloading rules, respect `--set default-rule-path=...` from the
command line if set.

Previously the rule reload would always take the default-rule-path from
the configuration file, even if overrided on the command line.

This is a rather narrow fix for the broader issue discussed in issue 1911, but
I think thats better suited for a much larger fix, which I've started to
discuss in https://redmine.openinfosecfoundation.org/issues/4782.

Issue: https://redmine.openinfosecfoundation.org/issues/1911
