### PR TITLE
stacktrace-on-signal: Use kill(getpid(), sig_num)

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -342,7 +342,7 @@ static void SignalHandlerUnexpected(int sig_num, siginfo_t *info, void *context)
 
 terminate:
     // Propagate signal to watchers, if any
-    kill(0, sig_num);
+    kill(getpid(), sig_num);
 }
 #undef UNW_LOCAL_ONLY
 #endif /* HAVE_LIBUNWIND */


### PR DESCRIPTION


Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [Issue 5331](https://redmine.openinfosecfoundation.org/issues/5331)

Describe changes:

kill(0, ...) re-raises the signal to every processes in the process
group which may impact unrelated processes.

Concretely, in our CI pipeline, a segfaulting Suricata process killed
the test driver.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
