### PR TITLE
detect/alert: directly increment alerts.discarded - v1

### DIFF
--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -268,7 +268,7 @@ void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet
         /* we must grow the alert queue */
         if (pos == AlertQueueExpand(det_ctx)) {
             /* this means we failed to expand the queue */
-            det_ctx->p->alerts.discarded++;
+            p->alerts.discarded++;
             return;
         }
     }


### PR DESCRIPTION
In the unlikely case of an AlertQueueExpand failure, we were incrementing
the discarded alerts stats in AlertQueueAppend via the Packet member in the
DetectEngineThreadCtx, which may not be initialized yet.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5353

Describe changes:
- remove indirect incrementation of alerts.discarded