### PR TITLE
detect: introduce "like" ip-only signature type - v1

### DIFF
--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -309,7 +309,8 @@ static inline void FlowApplySignatureActions(
      * - match is in stream */
     if (s->action & (ACTION_DROP | ACTION_PASS)) {
         if ((pa->flags & (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_STREAM_MATCH)) ||
-                (s->flags & (SIG_FLAG_IPONLY | SIG_FLAG_PDONLY | SIG_FLAG_APPLAYER))) {
+                (s->flags & (SIG_FLAG_IPONLY | SIG_FLAG_LIKE_IPONLY | SIG_FLAG_PDONLY |
+                                    SIG_FLAG_APPLAYER))) {
             pa->flags |= PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW;
             SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x (set "
                        "PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW)",

--- a/src/detect.h
+++ b/src/detect.h
@@ -217,6 +217,9 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_DSIZE                  BIT_U32(5)  /**< signature has a dsize setting */
 #define SIG_FLAG_APPLAYER               BIT_U32(6)  /**< signature applies to app layer instead of packets */
 #define SIG_FLAG_IPONLY                 BIT_U32(7)  /**< ip only signature */
+#define SIG_FLAG_LIKE_IPONLY                                                                       \
+    BIT_U32(8) /**< signature that is almost ip only, but contains negation prevening some iponly  \
+                  optimizations */
 
 // vacancy
 


### PR DESCRIPTION
Rules that look like they should be IP-only but contain a negated rule
address are now marked with an LIKE_IPONLY flag. This is so they are
treated like IPONLY rules with respect to flow action, but don't
interfere with other IPONLY processing like using the radix tree.

Ticket: https://redmine.openinfosecfoundation.org/issues/5361

suricata-verify-pr: 824
