### PR TITLE
Add commandline option to simulate alert queue expand failure- v1

### DIFF
--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -221,7 +221,10 @@ void AlertQueueFree(DetectEngineThreadCtx *det_ctx)
 static uint16_t AlertQueueExpand(DetectEngineThreadCtx *det_ctx)
 {
     uint16_t new_cap = det_ctx->alert_queue_capacity * 2;
-    void *tmp_queue = SCRealloc(det_ctx->alert_queue, (size_t)(sizeof(PacketAlert) * new_cap));
+    void *tmp_queue = NULL;
+    if (!is_alert_queue_fail_mode) {
+        tmp_queue = SCRealloc(det_ctx->alert_queue, (size_t)(sizeof(PacketAlert) * new_cap));
+    }
     if (unlikely(tmp_queue == NULL)) {
         /* queue capacity didn't change */
         return det_ctx->alert_queue_capacity;

--- a/src/detect-engine-alert.h
+++ b/src/detect-engine-alert.h
@@ -37,4 +37,6 @@ int PacketAlertCheck(Packet *, uint32_t);
 void PacketAlertTagInit(void);
 PacketAlert *PacketAlertGetTag(void);
 
+extern bool is_alert_queue_fail_mode;
+
 #endif /* __DETECT_ENGINE_ALERT_H__ */

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -2234,7 +2234,7 @@ static void PatternFreeFunc(void *ptr)
 }
 
 /**
- * \brief Figured out the FP and their respective content ids for all the
+ * \brief Figure out the FP and their respective content ids for all the
  *        sigs in the engine.
  *
  * \param de_ctx Detection engine context.

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -70,7 +70,7 @@ void MpmStoreReportStats(const DetectEngineCtx *de_ctx);
 MpmStore *MpmStorePrepareBuffer(DetectEngineCtx *de_ctx, SigGroupHead *sgh, enum MpmBuiltinBuffers buf);
 
 /**
- * \brief Figured out the FP and their respective content ids for all the
+ * \brief Figure out the FP and their respective content ids for all the
  *        sigs in the engine.
  *
  * \param de_ctx Detection engine context.

--- a/src/detect-engine-sigorder.c
+++ b/src/detect-engine-sigorder.c
@@ -776,7 +776,7 @@ void SCSigOrderSignatures(DetectEngineCtx *de_ctx)
 
 /**
  * \brief Lets you register the Signature ordering functions.  The order in
- *        which the functions are registered, show the priority.  The first
+ *        which the functions are registered shows the priority.  The first
  *        function registered provides more priority than the function
  *        registered after it.  To add a new registration function, register
  *        it by listing it in the correct position in the below sequence,

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -895,6 +895,7 @@ static void PrintBuildInfo(void)
 int coverage_unittests;
 int g_ut_modules;
 int g_ut_covered;
+bool is_alert_queue_fail_mode;
 
 void RegisterAllModules(void)
 {
@@ -1281,6 +1282,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
     int conf_test = 0;
     int engine_analysis = 0;
     int ret = TM_ECODE_OK;
+    is_alert_queue_fail_mode = false;
 
 #ifdef UNITTESTS
     coverage_unittests = 0;
@@ -1352,6 +1354,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #ifdef HAVE_NFLOG
         {"nflog", optional_argument, 0, 0},
 #endif
+        {"disable-alert-queue-expand", 0, 0, 0},
         {NULL, 0, NULL, 0}
     };
     // clang-format on
@@ -1720,6 +1723,9 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 if (suri->strict_rule_parsing_string == NULL) {
                     FatalError(SC_ERR_MEM_ALLOC, "failed to duplicate 'strict' string");
                 }
+            } else if (strcmp((long_opts[option_index]).name, "disable-alert-queue-expand") == 0) {
+                is_alert_queue_fail_mode = true;
+                SCLogInfo("Running Suricata with alert queue expansion disabled");
             }
             break;
         case 'c':


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5319

Describe changes:
- add the command-line option `--disable-alert-queue-expand` that, when passed as an argument, will skip reallocating the alert queue, once it reaches packet alert max. This allows for one to test Suri behavior if reallocating fails.

This must merged _after_ https://github.com/OISF/suricata/pull/7396 as it exposes bug [5353](https://redmine.openinfosecfoundation.org/issues/5353)

suricata-verify-pr: 825
https://github.com/OISF/suricata-verify/pull/825