### PR TITLE
Dcerpc txiter 5271 v1

### DIFF
--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -15,7 +15,7 @@
  * 02110-1301, USA.
  */
 
-use crate::applayer::*;
+use crate::applayer::{self, *};
 use crate::core::{self, *};
 use crate::dcerpc::parser;
 use nom7::error::{Error, ErrorKind};
@@ -186,6 +186,12 @@ pub struct DCERPCTransaction {
     pub tx_data: AppLayerTxData,
 }
 
+impl Transaction for DCERPCTransaction {
+    fn id(&self) -> u64 {
+        self.id
+    }
+}
+
 impl DCERPCTransaction {
     pub fn new() -> Self {
         return Self {
@@ -314,6 +320,16 @@ pub struct DCERPCState {
     pub ts_ssn_trunc: bool, /// true if Truncated in this direction
     pub tc_ssn_trunc: bool,
     pub flow: Option<*const core::Flow>,
+}
+
+impl State<DCERPCTransaction> for DCERPCState {
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&DCERPCTransaction> {
+        self.transactions.get(index)
+    }
 }
 
 impl DCERPCState {
@@ -1349,7 +1365,7 @@ pub unsafe extern "C" fn rs_dcerpc_register_parser() {
         localstorage_new: None,
         localstorage_free: None,
         get_files: None,
-        get_tx_iterator: None,
+        get_tx_iterator: Some(applayer::state_get_tx_iterator::<DCERPCState, DCERPCTransaction>),
         get_tx_data: rs_dcerpc_get_tx_data,
         apply_tx_config: None,
         flags: APP_LAYER_PARSER_OPT_ACCEPT_GAPS,


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5321

Describe changes:
- Use VecDeque tx iterator for dcerpc