### PR TITLE
stmp: missing node name for default scheme 'http'

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -315,6 +315,7 @@ static void SMTPConfigure(void) {
             if (unlikely(seq_node->name == NULL)) {
                 FatalError(SC_ERR_FATAL, "SCStrdup failure.");
             }
+            scheme->name = SCStrdup("0");
             scheme->val = SCStrdup("http");
             if (unlikely(scheme->val == NULL)) {
                 FatalError(SC_ERR_FATAL, "SCStrdup failure.");


### PR DESCRIPTION
After suricata started, call ConfDump will crash, below is the debug info:
This path fixed it

multi-detect = (null)
multi-detect.enabled = false
vars = (null)
vars.address-groups = (null)
vars.address-groups.HOME_NET = [192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]
vars.address-groups.EXTERNAL_NET = !$HOME_NET
vars.address-groups.HTTP_SERVERS = $HOME_NET
vars.address-groups.SMTP_SERVERS = $HOME_NET
vars.address-groups.SQL_SERVERS = $HOME_NET
vars.address-groups.DNS_SERVERS = $HOME_NET
vars.address-groups.TELNET_SERVERS = $HOME_NET
vars.address-groups.AIM_SERVERS = $EXTERNAL_NET
vars.address-groups.DC_SERVERS = $HOME_NET
vars.address-groups.DNP3_SERVER = $HOME_NET
vars.address-groups.DNP3_CLIENT = $HOME_NET
vars.address-groups.MODBUS_CLIENT = $HOME_NET
vars.address-groups.MODBUS_SERVER = $HOME_NET
vars.address-groups.ENIP_CLIENT = $HOME_NET
vars.address-groups.ENIP_SERVER = $HOME_NET
vars.port-groups = (null)
vars.port-groups.HTTP_PORTS = 80
vars.port-groups.SHELLCODE_PORTS = !80
vars.port-groups.ORACLE_PORTS = 1521
vars.port-groups.SSH_PORTS = 22
vars.port-groups.DNP3_PORTS = 20000
vars.port-groups.MODBUS_PORTS = 502
vars.port-groups.FILE_DATA_PORTS = [$HTTP_PORTS,110,143]
vars.port-groups.FTP_PORTS = 21
vars.port-groups.GENEVE_PORTS = 6081
vars.port-groups.VXLAN_PORTS = 4789
vars.port-groups.TEREDO_PORTS = 3544
default-log-dir = /root/code/net-base/dist/script/test/../../var/log/suricata/
stats = (null)
stats.enabled = yes
stats.interval = 8
plugins = (null)
outputs = (null)
outputs.0 = fast
outputs.0.fast = (null)
outputs.0.fast.enabled = yes
outputs.0.fast.filename = fast.log
outputs.0.fast.append = yes
outputs.1 = eve-log
outputs.1.eve-log = (null)
outputs.1.eve-log.enabled = yes
outputs.1.eve-log.filetype = regular
outputs.1.eve-log.filename = eve.json
outputs.1.eve-log.pcap-file = false
outputs.1.eve-log.community-id = false
outputs.1.eve-log.community-id-seed = 0
outputs.1.eve-log.xff = (null)
outputs.1.eve-log.xff.enabled = no
outputs.1.eve-log.xff.mode = extra-data
outputs.1.eve-log.xff.deployment = reverse
outputs.1.eve-log.xff.header = X-Forwarded-For
outputs.1.eve-log.types = (null)
outputs.1.eve-log.types.0 = alert
outputs.1.eve-log.types.0.alert = (null)
outputs.1.eve-log.types.0.alert.tagged-packets = yes
outputs.1.eve-log.types.1 = frame
outputs.1.eve-log.types.1.frame = (null)
outputs.1.eve-log.types.1.frame.enabled = no
outputs.1.eve-log.types.2 = anomaly
outputs.1.eve-log.types.2.anomaly = (null)
outputs.1.eve-log.types.2.anomaly.enabled = yes
outputs.1.eve-log.types.2.anomaly.types = (null)
outputs.1.eve-log.types.3 = http
outputs.1.eve-log.types.3.http = (null)
outputs.1.eve-log.types.3.http.extended = yes
outputs.1.eve-log.types.4 = dns
outputs.1.eve-log.types.4.dns = (null)
outputs.1.eve-log.types.5 = tls
outputs.1.eve-log.types.5.tls = (null)
outputs.1.eve-log.types.5.tls.extended = yes
outputs.1.eve-log.types.6 = files
outputs.1.eve-log.types.6.files = (null)
outputs.1.eve-log.types.6.files.force-magic = no
outputs.1.eve-log.types.7 = smtp
outputs.1.eve-log.types.7.smtp = (null)
outputs.1.eve-log.types.8 = ftp
outputs.1.eve-log.types.9 = rdp
outputs.1.eve-log.types.10 = nfs
outputs.1.eve-log.types.11 = smb
outputs.1.eve-log.types.12 = tftp
outputs.1.eve-log.types.13 = ike
outputs.1.eve-log.types.14 = dcerpc
outputs.1.eve-log.types.15 = krb5
outputs.1.eve-log.types.16 = snmp
outputs.1.eve-log.types.17 = rfb
outputs.1.eve-log.types.18 = sip
outputs.1.eve-log.types.19 = quic
outputs.1.eve-log.types.20 = dhcp
outputs.1.eve-log.types.20.dhcp = (null)
outputs.1.eve-log.types.20.dhcp.enabled = yes
outputs.1.eve-log.types.20.dhcp.extended = no
outputs.1.eve-log.types.21 = ssh
outputs.1.eve-log.types.22 = mqtt
outputs.1.eve-log.types.22.mqtt = (null)
outputs.1.eve-log.types.23 = http2
outputs.1.eve-log.types.24 = pgsql
outputs.1.eve-log.types.24.pgsql = (null)
outputs.1.eve-log.types.24.pgsql.enabled = no
outputs.1.eve-log.types.25 = stats
outputs.1.eve-log.types.25.stats = (null)
outputs.1.eve-log.types.25.stats.totals = yes
outputs.1.eve-log.types.25.stats.threads = no
outputs.1.eve-log.types.25.stats.deltas = no
outputs.1.eve-log.types.26 = flow
outputs.2 = http-log
outputs.2.http-log = (null)
outputs.2.http-log.enabled = no
outputs.2.http-log.filename = http.log
outputs.2.http-log.append = yes
outputs.3 = tls-log
outputs.3.tls-log = (null)
outputs.3.tls-log.enabled = no
outputs.3.tls-log.filename = tls.log
outputs.3.tls-log.append = yes
outputs.4 = tls-store
outputs.4.tls-store = (null)
outputs.4.tls-store.enabled = yes
outputs.5 = pcap-log
outputs.5.pcap-log = (null)
outputs.5.pcap-log.enabled = no
outputs.5.pcap-log.filename = log.pcap
outputs.5.pcap-log.limit = 1000mb
outputs.5.pcap-log.max-files = 2000
outputs.5.pcap-log.compression = none
outputs.5.pcap-log.mode = normal
outputs.5.pcap-log.use-stream-depth = no
outputs.5.pcap-log.honor-pass-rules = no
outputs.6 = alert-debug
outputs.6.alert-debug = (null)
outputs.6.alert-debug.enabled = no
outputs.6.alert-debug.filename = alert-debug.log
outputs.6.alert-debug.append = yes
outputs.7 = stats
outputs.7.stats = (null)
outputs.7.stats.enabled = yes
outputs.7.stats.filename = stats.log
outputs.7.stats.append = yes
outputs.7.stats.totals = yes
outputs.7.stats.threads = no
outputs.8 = syslog
outputs.8.syslog = (null)
outputs.8.syslog.enabled = no
outputs.8.syslog.facility = local5
outputs.9 = file-store
outputs.9.file-store = (null)
outputs.9.file-store.version = 2
outputs.9.file-store.enabled = yes
outputs.9.file-store.force-filestore = yes
outputs.9.file-store.xff = (null)
outputs.9.file-store.xff.enabled = no
outputs.9.file-store.xff.mode = extra-data
outputs.9.file-store.xff.deployment = reverse
outputs.9.file-store.xff.header = X-Forwarded-For
outputs.10 = tcp-data
outputs.10.tcp-data = (null)
outputs.10.tcp-data.enabled = no
outputs.10.tcp-data.type = file
outputs.10.tcp-data.filename = tcp-data.log
outputs.11 = http-body-data
outputs.11.http-body-data = (null)
outputs.11.http-body-data.enabled = no
outputs.11.http-body-data.type = file
outputs.11.http-body-data.filename = http-data.log
outputs.12 = lua
outputs.12.lua = (null)
outputs.12.lua.enabled = no
outputs.12.lua.scripts = (null)
logging = (null)
logging.default-log-level = info
logging.default-log-format = (%f:%l) (%n) -- 
logging.default-output-filter = (null)
logging.outputs = (null)
logging.outputs.0 = console
logging.outputs.0.console = (null)
logging.outputs.0.console.enabled = yes
logging.outputs.1 = file
logging.outputs.1.file = (null)
logging.outputs.1.file.enabled = no
logging.outputs.1.file.level = info
logging.outputs.1.file.filename = suricata.log
logging.outputs.2 = syslog
logging.outputs.2.syslog = (null)
logging.outputs.2.syslog.enabled = no
logging.outputs.2.syslog.facility = local5
logging.outputs.2.syslog.format = [%i] <%d> -- 
app-layer = (null)
app-layer.protocols = (null)
app-layer.protocols.telnet = (null)
app-layer.protocols.telnet.enabled = yes
app-layer.protocols.rfb = (null)
app-layer.protocols.rfb.enabled = yes
app-layer.protocols.rfb.detection-ports = (null)
app-layer.protocols.rfb.detection-ports.dp = 5900, 5901, 5902, 5903, 5904, 5905, 5906, 5907, 5908, 5909
app-layer.protocols.mqtt = (null)
app-layer.protocols.mqtt.enabled = yes
app-layer.protocols.krb5 = (null)
app-layer.protocols.krb5.enabled = yes
app-layer.protocols.snmp = (null)
app-layer.protocols.snmp.enabled = yes
app-layer.protocols.ike = (null)
app-layer.protocols.ike.enabled = yes
app-layer.protocols.tls = (null)
app-layer.protocols.tls.enabled = yes
app-layer.protocols.tls.detection-ports = (null)
app-layer.protocols.tls.detection-ports.dp = 443
app-layer.protocols.pgsql = (null)
app-layer.protocols.pgsql.enabled = no
app-layer.protocols.pgsql.stream-depth = 0
app-layer.protocols.dcerpc = (null)
app-layer.protocols.dcerpc.enabled = yes
app-layer.protocols.ftp = (null)
app-layer.protocols.ftp.enabled = yes
app-layer.protocols.rdp = (null)
app-layer.protocols.ssh = (null)
app-layer.protocols.ssh.enabled = yes
app-layer.protocols.http2 = (null)
app-layer.protocols.http2.enabled = yes
app-layer.protocols.smtp = (null)
app-layer.protocols.smtp.enabled = yes
app-layer.protocols.smtp.raw-extraction = no
app-layer.protocols.smtp.mime = (null)
app-layer.protocols.smtp.mime.decode-mime = yes
app-layer.protocols.smtp.mime.decode-base64 = yes
app-layer.protocols.smtp.mime.decode-quoted-printable = yes
app-layer.protocols.smtp.mime.header-value-depth = 2000
app-layer.protocols.smtp.mime.extract-urls = yes
app-layer.protocols.smtp.mime.body-md5 = no
app-layer.protocols.smtp.mime.extract-urls-schemes = (null)

Program received signal SIGSEGV, Segmentation fault.
__strlen_sse2_pminub () at ../sysdeps/x86_64/multiarch/strlen-sse2-pminub.S:38
38              movdqu  (%rdi), %xmm1
Missing separate debuginfos, use: debuginfo-install jansson-2.10-1.el7.x86_64 libgcc-4.8.5-44.el7.x86_64 libstdc++-4.8.5-44.el7.x86_64 libuuid-2.23.2-65.el7_9.1.x86_64 mbedtls-2.7.17-1.el7.x86_64 pkcs11-helper-1.11-3.el7.x86_64
(gdb) bt
#0  __strlen_sse2_pminub () at ../sysdeps/x86_64/multiarch/strlen-sse2-pminub.S:38
#1  0x00007ffff744011f in __interceptor_strdup (s=0x0) at ../../../../libsanitizer/asan/asan_interceptors.cc:441
#2  0x00007fff63dc28e4 in SCStrdupFunc (s=0x0) at util-mem.c:70
#3  0x00007fff63a078d1 in ConfNodeDump (node=0x606000092720, prefix=0x0) at conf.c:758
#4  0x00007fff63a0799d in ConfNodeDump (node=0x60600000c380, prefix=0x0) at conf.c:770
#5  0x00007fff63a0799d in ConfNodeDump (node=0x60600000c260, prefix=0x0) at conf.c:770
#6  0x00007fff63a0799d in ConfNodeDump (node=0x60600000b600, prefix=0x0) at conf.c:770
#7  0x00007fff63a0799d in ConfNodeDump (node=0x60600000b5a0, prefix=0x0) at conf.c:770
#8  0x00007fff63a0799d in ConfNodeDump (node=0x606000006c80, prefix=0x0) at conf.c:770
#9  0x00007fff63a07a09 in ConfDump () at conf.c:781
#10 0x00007fff65baee78 in suricata_t1_fn (vm=0x7fff6fbff680, input=0x7ffa9dd66e60, cmd=0x7fff7107ac90) at /root/code/net-base/suricata/cli.c:293
#11 0x00007ffff470f98b in vlib_cli_dispatch_sub_commands (vm=0x7fff6fbff680, cm=0x4851a0 <vlib_global_main+32>, input=0x7ffa9dd66e60, parent_command_index=103) at /root/code/net-base/.vpp-22.02/src/vlib/cli.c:631
#12 0x00007ffff470f3e9 in vlib_cli_dispatch_sub_commands (vm=0x7fff6fbff680, cm=0x4851a0 <vlib_global_main+32>, input=0x7ffa9dd66e60, parent_command_index=0) at /root/code/net-base/.vpp-22.02/src/vlib/cli.c:588
#13 0x00007ffff47104e2 in vlib_cli_input (vm=0x7fff6fbff680, input=0x7ffa9dd66e60, function=0x7ffff47e4bb0 <unix_vlib_cli_output>, function_arg=0) at /root/code/net-base/.vpp-22.02/src/vlib/cli.c:734
#14 0x00007ffff47f6cfa in unix_cli_process_input (cm=0x7ffff490be80 <unix_cli_main>, cli_file_index=0) at /root/code/net-base/.vpp-22.02/src/vlib/unix/cli.c:2613
#15 0x00007ffff47f8f5c in unix_cli_process (vm=0x7fff6fbff680, rt=0x7fff74767e00, f=0x0) at /root/code/net-base/.vpp-22.02/src/vlib/unix/cli.c:2742
#16 0x00007ffff476e713 in vlib_process_bootstrap (_a=140734827701120) at /root/code/net-base/.vpp-22.02/src/vlib/main.c:1235
#17 0x00007ffff3f43790 in clib_calljmp () at /root/code/net-base/.vpp-22.02/src/vppinfra/longjmp.S:123
#18 0x00007fff6169a330 in ?? ()
#19 0x00007ffff476e9c9 in vlib_process_startup (vm=0x0, p=0x7fff794f46b0, f=0x50) at /root/code/net-base/.vpp-22.02/src/vlib/main.c:1260
#20 0x00007fff794f4680 in ?? ()
#21 0x0000000000000010 in ?? ()
#22 0x00007fff794f4670 in ?? ()
#23 0x00007fff6169a440 in ?? ()
#24 0x53cac605ed211700 in ?? ()
#25 0x00007fff6fbff3b8 in ?? ()
#26 0x00007fff6169a760 in ?? ()
#27 0x00000fffec2d34ec in ?? ()
#28 0x00007fff6169a7a0 in ?? ()
#29 0x00007fff6169a760 in ?? ()
#30 0x00007fff6169ae40 in ?? ()
#31 0x00007fff6169a480 in ?? ()
#32 0x00007ffff3fea81d in memset_s_inline (s=0x7fff74795eb0, smax=8, c=0, n=1) at /root/code/net-base/.vpp-22.02/src/vppinfra/string.h:202
#33 0x00007ffff487ff60 in ?? () from /root/code/net-base/install/debug/vpp/lib/libvlib.so.22.02.0
#34 0x00007ffff47741a7 in vl_api_get_elog_trace_api_messages () at /root/code/net-base/.vpp-22.02/src/vlib/main.c:1861
#35 0x00007fff70a2ded0 in ?? ()
#36 0x0000000000000000 in ?? ()
(gdb) fr 3
#3  0x00007fff63a078d1 in ConfNodeDump (node=0x606000092720, prefix=0x0) at conf.c:758
758             name[level] = SCStrdup(child->name);
(gdb) p *node
$1 = {
  name = 0x603000090970 "extract-urls-schemes", 
  val = 0x0, 
  is_seq = 1, 
  final = 0, 
  parent = 0x0, 
  head = {
    tqh_first = 0x606000092780, 
    tqh_last = 0x6060000927b0
  }, 
  next = {
    tqe_next = 0x0, 
    tqe_prev = 0x60600000c5f0
  }
}
(gdb) p *child
$2 = {
  name = 0x0, 
  val = 0x602000110d70 "http", 
  is_seq = 0, 
  final = 0, 
  parent = 0x0, 
  head = {
    tqh_first = 0x0, 
    tqh_last = 0x6060000927a0
  }, 
  next = {
    tqe_next = 0x0, 
    tqe_prev = 0x606000092740
  }
}