### PR TITLE
util: remove malloc from streaming buffer config

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1391,7 +1391,6 @@ void RegisterFTPParsers(void)
                 ALPROTO_FTPDATA, FTPDATA_STATE_FINISHED, FTPDATA_STATE_FINISHED);
 
         sbcfg.buf_size = 4096;
-        sbcfg.Malloc = FTPMalloc;
         sbcfg.Calloc = FTPCalloc;
         sbcfg.Realloc = FTPRealloc;
         sbcfg.Free = FTPFree;

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2538,7 +2538,6 @@ static void HTPConfigSetDefaultsPhase2(const char *name, HTPCfgRec *cfg_prec)
     cfg_prec->request.sbcfg.buf_size = cfg_prec->request.inspect_window ?
                                        cfg_prec->request.inspect_window : 256;
     cfg_prec->request.sbcfg.buf_slide = 0;
-    cfg_prec->request.sbcfg.Malloc = HTPMalloc;
     cfg_prec->request.sbcfg.Calloc = HTPCalloc;
     cfg_prec->request.sbcfg.Realloc = HTPRealloc;
     cfg_prec->request.sbcfg.Free = HTPFree;
@@ -2546,7 +2545,6 @@ static void HTPConfigSetDefaultsPhase2(const char *name, HTPCfgRec *cfg_prec)
     cfg_prec->response.sbcfg.buf_size = cfg_prec->response.inspect_window ?
                                         cfg_prec->response.inspect_window : 256;
     cfg_prec->response.sbcfg.buf_slide = 0;
-    cfg_prec->response.sbcfg.Malloc = HTPMalloc;
     cfg_prec->response.sbcfg.Calloc = HTPCalloc;
     cfg_prec->response.sbcfg.Realloc = HTPRealloc;
     cfg_prec->response.sbcfg.Free = HTPFree;

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -410,7 +410,6 @@ static int StreamTcpReassemblyConfig(bool quiet)
     }
 
     stream_config.sbcnf.buf_size = 2048;
-    stream_config.sbcnf.Malloc = ReassembleMalloc;
     stream_config.sbcnf.Calloc = ReassembleCalloc;
     stream_config.sbcnf.Realloc = ReassembleRealloc;
     stream_config.sbcnf.Free = ReassembleFree;

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -31,8 +31,6 @@
 
 /* memory handling wrappers. If config doesn't define it's own set of
  * functions, use the defaults */
-#define MALLOC(cfg, s) \
-    (cfg)->Malloc ? (cfg)->Malloc((s)) : SCMalloc((s))
 #define CALLOC(cfg, n, s) \
     (cfg)->Calloc ? (cfg)->Calloc((n), (s)) : SCCalloc((n), (s))
 #define REALLOC(cfg, ptr, orig_s, s) \

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -64,7 +64,6 @@
 typedef struct StreamingBufferConfig_ {
     uint32_t buf_slide;
     uint32_t buf_size;
-    void *(*Malloc)(size_t size);
     void *(*Calloc)(size_t n, size_t size);
     void *(*Realloc)(void *ptr, size_t orig_size, size_t size);
     void (*Free)(void *ptr, size_t size);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None, is there a general dead code removal ticket ?

Describe changes:
- util: remove malloc from streaming buffer config as it is unused
