### PR TITLE
Fix memory leaks in bypass functions v1

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -452,11 +452,17 @@ void PacketBypassCallback(Packet *p)
                 (state == FLOW_STATE_CAPTURE_BYPASSED)) {
             return;
         }
-        FlowBypassInfo *fc = SCCalloc(sizeof(FlowBypassInfo), 1);
-        if (fc) {
-            FlowSetStorageById(p->flow, GetFlowBypassInfoID(), fc);
-        } else {
-            return;
+
+        FlowBypassInfo *fc;
+
+        fc = FlowGetStorageById(p->flow, GetFlowBypassInfoID());
+        if (fc == NULL) {
+            fc = SCCalloc(sizeof(FlowBypassInfo), 1);
+            if (fc) {
+                FlowSetStorageById(p->flow, GetFlowBypassInfoID(), fc);
+            } else {
+                return;
+            }
         }
     }
     if (p->BypassPacketsFlow && p->BypassPacketsFlow(p)) {

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2130,6 +2130,12 @@ static int AFPSetFlowStorage(Packet *p, int map_fd, void *key0, void* key1,
 {
     FlowBypassInfo *fc = FlowGetStorageById(p->flow, GetFlowBypassInfoID());
     if (fc) {
+        if (fc->bypass_data != NULL) {
+            // bypass already activated
+            SCFree(key0);
+            SCFree(key1);
+            return 1;
+        }
         EBPFBypassData *eb = SCCalloc(1, sizeof(EBPFBypassData));
         if (eb == NULL) {
             EBPFDeleteKey(map_fd, key0);


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5368) ticket:

Describe changes:
- fixes a general memory leak in the bypass function (reassigns FlowBypassInfo without checking if it is not pointing to one already)
- fixes AF-PACKET specific memory leak in the bypass function (reassigns EBPFBypassData without checking if it is not pointing to one already)