### PR TITLE
rust: fix doc comments that trigger rust warnings - v1

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -277,7 +277,7 @@ pub fn sc_app_layer_decoder_events_free_events(
 /// Opaque flow type (defined in C)
 pub enum Flow {}
 
-/// Extern functions operating on Flow.
+// Extern functions operating on Flow.
 extern {
     pub fn FlowGetLastTimeAsParts(flow: &Flow, secs: *mut u64, usecs: *mut u64);
     pub fn FlowGetFlags(flow: &Flow) -> u32;

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -1072,7 +1072,7 @@ pub unsafe extern "C" fn rs_http2_probing_parser_tc(
     return ALPROTO_UNKNOWN;
 }
 
-/// Extern functions operating on HTTP2.
+// Extern functions operating on HTTP2.
 extern "C" {
     pub fn HTTP2MimicHttp1Request(
         orig_state: *mut std::os::raw::c_void, new_state: *mut std::os::raw::c_void,


### PR DESCRIPTION
The Fedora 35 (debug, clang, asan, wshadow, rust-strict) CI check was failing because Rust generates warnings that are treated as errors for documentation blocks before `extern` blocks.

This fixes those errors.