### PR TITLE
util: remove malloc from streaming buffer config

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1391,7 +1391,6 @@ void RegisterFTPParsers(void)
                 ALPROTO_FTPDATA, FTPDATA_STATE_FINISHED, FTPDATA_STATE_FINISHED);
 
         sbcfg.buf_size = 4096;
-        sbcfg.Malloc = FTPMalloc;
         sbcfg.Calloc = FTPCalloc;
         sbcfg.Realloc = FTPRealloc;
         sbcfg.Free = FTPFree;

--- a/src/app-layer-htp-body.c
+++ b/src/app-layer-htp-body.c
@@ -63,7 +63,7 @@
 
 #include "util-memcmp.h"
 
-static StreamingBufferConfig default_cfg = { 0, 3072, HTPMalloc, HTPCalloc, HTPRealloc, HTPFree };
+static StreamingBufferConfig default_cfg = { 0, 3072, HTPCalloc, HTPRealloc, HTPFree };
 
 /**
  * \brief Append a chunk of body to the HtpBody struct

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2538,7 +2538,6 @@ static void HTPConfigSetDefaultsPhase2(const char *name, HTPCfgRec *cfg_prec)
     cfg_prec->request.sbcfg.buf_size = cfg_prec->request.inspect_window ?
                                        cfg_prec->request.inspect_window : 256;
     cfg_prec->request.sbcfg.buf_slide = 0;
-    cfg_prec->request.sbcfg.Malloc = HTPMalloc;
     cfg_prec->request.sbcfg.Calloc = HTPCalloc;
     cfg_prec->request.sbcfg.Realloc = HTPRealloc;
     cfg_prec->request.sbcfg.Free = HTPFree;
@@ -2546,7 +2545,6 @@ static void HTPConfigSetDefaultsPhase2(const char *name, HTPCfgRec *cfg_prec)
     cfg_prec->response.sbcfg.buf_size = cfg_prec->response.inspect_window ?
                                         cfg_prec->response.inspect_window : 256;
     cfg_prec->response.sbcfg.buf_slide = 0;
-    cfg_prec->response.sbcfg.Malloc = HTPMalloc;
     cfg_prec->response.sbcfg.Calloc = HTPCalloc;
     cfg_prec->response.sbcfg.Realloc = HTPRealloc;
     cfg_prec->response.sbcfg.Free = HTPFree;

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -194,20 +194,6 @@ uint64_t StreamTcpReassembleGetMemcap()
 /* memory functions for the streaming buffer API */
 
 /*
-    void *(*Malloc)(size_t size);
-*/
-static void *ReassembleMalloc(size_t size)
-{
-    if (StreamTcpReassembleCheckMemcap(size) == 0)
-        return NULL;
-    void *ptr = SCMalloc(size);
-    if (ptr == NULL)
-        return NULL;
-    StreamTcpReassembleIncrMemuse(size);
-    return ptr;
-}
-
-/*
     void *(*Calloc)(size_t n, size_t size);
 */
 static void *ReassembleCalloc(size_t n, size_t size)
@@ -484,7 +470,6 @@ static int StreamTcpReassemblyConfig(bool quiet)
     }
 
     stream_config.sbcnf.buf_size = 2048;
-    stream_config.sbcnf.Malloc = ReassembleMalloc;
     stream_config.sbcnf.Calloc = ReassembleCalloc;
     stream_config.sbcnf.Realloc = StreamTcpReassembleRealloc;
     stream_config.sbcnf.Free = ReassembleFree;

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -31,8 +31,6 @@
 
 /* memory handling wrappers. If config doesn't define it's own set of
  * functions, use the defaults */
-#define MALLOC(cfg, s) \
-    (cfg)->Malloc ? (cfg)->Malloc((s)) : SCMalloc((s))
 #define CALLOC(cfg, n, s) \
     (cfg)->Calloc ? (cfg)->Calloc((n), (s)) : SCCalloc((n), (s))
 #define REALLOC(cfg, ptr, orig_s, s) \
@@ -909,7 +907,7 @@ static void DumpSegment(StreamingBuffer *sb, StreamingBufferSegment *seg)
 
 static int StreamingBufferTest02(void)
 {
-    StreamingBufferConfig cfg = { 8, 24, NULL, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 24, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -965,7 +963,7 @@ static int StreamingBufferTest02(void)
 
 static int StreamingBufferTest03(void)
 {
-    StreamingBufferConfig cfg = { 8, 24, NULL, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 24, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1020,7 +1018,7 @@ static int StreamingBufferTest03(void)
 
 static int StreamingBufferTest04(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1111,7 +1109,7 @@ static int StreamingBufferTest04(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest06(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1169,7 +1167,7 @@ static int StreamingBufferTest06(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest07(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1227,7 +1225,7 @@ static int StreamingBufferTest07(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest08(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1285,7 +1283,7 @@ static int StreamingBufferTest08(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest09(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1343,7 +1341,7 @@ static int StreamingBufferTest09(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest10(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -64,7 +64,6 @@
 typedef struct StreamingBufferConfig_ {
     uint32_t buf_slide;
     uint32_t buf_size;
-    void *(*Malloc)(size_t size);
     void *(*Calloc)(size_t n, size_t size);
     void *(*Realloc)(void *ptr, size_t orig_size, size_t size);
     void (*Free)(void *ptr, size_t size);
@@ -72,7 +71,7 @@ typedef struct StreamingBufferConfig_ {
 
 #define STREAMING_BUFFER_CONFIG_INITIALIZER                                                        \
     {                                                                                              \
-        0, 0, NULL, NULL, NULL, NULL,                                                              \
+        0, 0, NULL, NULL, NULL,                                                                    \
     }
 
 /**


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None, is there a general dead code removal ticket ?

Describe changes:
- util: remove malloc from streaming buffer config as it is unused

Modifies #7420 with rebase to get CI green without failing Fedora