### PR TITLE
Fix doc typos

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -264,7 +264,7 @@ different YAML file.
   ...
 
 If the same section, say outputs is later redefined after the include
-statement it will overwrite the included file. Therefor any include
+statement it will overwrite the included file. Therefore any include
 statement at the end of the document will overwrite the already
 configured sections.
 

--- a/doc/userguide/rules/datasets.rst
+++ b/doc/userguide/rules/datasets.rst
@@ -4,7 +4,7 @@ Datasets
 Using the ``dataset`` and ``datarep`` keyword it is possible to match on
 large amounts of data against any sticky buffer.
 
-For example, to match against a DNs black list called ``dns-bl``::
+For example, to match against a DNS black list called ``dns-bl``::
 
     dns.query; dataset:isset,dns-bl;
 

--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -4,7 +4,7 @@ HTTP Keywords
 
 Using the HTTP specific sticky buffers provides a way to efficiently
 inspect specific fields of the HTTP protocol. After specifying a
-sticky buffer in a rule it should be followed by one or more doc:`payload-keywords`.
+sticky buffer in a rule it should be followed by one or more :doc:`payload-keywords`.
 
 Many of the sticky buffers have legacy variants in the older "content modifier"
 notation. See :ref:`rules-modifiers` for more information. As a

--- a/doc/userguide/rules/ssh-keywords.rst
+++ b/doc/userguide/rules/ssh-keywords.rst
@@ -113,7 +113,7 @@ Example::
 
   alert ssh any any -> any any (msg:"match hassh-string"; \
       ssh.hassh.string; content:"none,zlib@openssh.com,zlib"; \
-      sid:1000030;
+      sid:1000030;)
 
 ``ssh.hassh.string`` is a 'sticky buffer'.
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -93,7 +93,7 @@ outputs:
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
       # Enable for multi-threaded eve.json output; output files are amended with
-      # with an identifier, e.g., eve.9.json
+      # an identifier, e.g., eve.9.json
       #threaded: false
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1362,7 +1362,7 @@ flow-timeouts:
 #                               # of checksum. You can control the handling of checksum
 #                               # on a per-interface basis via the 'checksum-checks'
 #                               # option
-#   prealloc-sessions: 2k       # 2k sessions prealloc'd per stream thread
+#   prealloc-sessions: 2048     # 2k sessions prealloc'd per stream thread
 #   midstream: false            # don't allow midstream session pickups
 #   async-oneside: false        # don't enable async stream handling
 #   inline: no                  # stream inline mode


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
  Not applicable, since these are just minor typo fixes.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: Not applicable, since these are just minor typo and link fixes.

Describe changes:
- Fix broken link in documentation
- Fix typos in documentation
- Fix duplicate word in suricata.yaml.in
- Fix default value of prealloc-session in suricata.yaml.in

Commits not squashed to highlight each change.

If you need a ticket for this PR, please tell me.

Thanks for merging :)
