### PR TITLE
rust: make suricata context const

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -219,7 +219,7 @@ extern {
 
 pub static mut SC: Option<&'static SuricataContext> = None;
 
-pub fn init_ffi(context: &'static mut SuricataContext)
+pub fn init_ffi(context: &'static SuricataContext)
 {
     unsafe {
         SC = Some(context);
@@ -228,7 +228,7 @@ pub fn init_ffi(context: &'static mut SuricataContext)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_init(context: &'static mut SuricataContext)
+pub extern "C" fn rs_init(context: &'static SuricataContext)
 {
     init_ffi(context);
 }

--- a/src/app-layer-htp-file.h
+++ b/src/app-layer-htp-file.h
@@ -25,6 +25,8 @@
 #ifndef __APP_LAYER_HTP_FILE_H__
 #define __APP_LAYER_HTP_FILE_H__
 
+#include "app-layer-htp.h"
+
 int HTPFileOpen(HtpState *, HtpTxUserData *, const uint8_t *, uint16_t, const uint8_t *, uint32_t,
         uint64_t, uint8_t);
 int HTPParseContentRange(bstr *rawvalue, HTTPContentRange *range);

--- a/src/app-layer-register.h
+++ b/src/app-layer-register.h
@@ -24,6 +24,8 @@
 #ifndef __APP_LAYER_REGISTER_H__
 #define __APP_LAYER_REGISTER_H__
 
+#include "app-layer-detect-proto.h"
+
 typedef struct AppLayerParser {
     const char *name;
     const char *default_port;

--- a/src/rust-context.c
+++ b/src/rust-context.c
@@ -17,10 +17,33 @@
 
 #include "suricata-common.h"
 #include "rust-context.h"
+#include "app-layer-parser.h"
+#include "app-layer-register.h"
+#include "app-layer-htp-range.h"
+#include "app-layer-htp-file.h"
 
-SuricataContext suricata_context;
+const SuricataContext suricata_context = {
+    SCLogMessage,
+    DetectEngineStateFree,
+    AppLayerDecoderEventsSetEventRaw,
+    AppLayerDecoderEventsFreeEvents,
+    AppLayerParserTriggerRawStreamReassembly,
 
-SuricataContext *SCGetContext(void)
+    HttpRangeFreeBlock,
+    HTPFileCloseHandleRange,
+
+    FileOpenFileWithId,
+    FileCloseFileById,
+    FileAppendDataById,
+    FileAppendGAPById,
+    FileContainerRecycle,
+    FilePrune,
+    FileContainerSetTx,
+
+    AppLayerRegisterParser,
+};
+
+const SuricataContext *SCGetContext(void)
 {
     return &suricata_context;
 }

--- a/src/rust-context.h
+++ b/src/rust-context.h
@@ -60,7 +60,7 @@ typedef struct SuricataContext_ {
 
 } SuricataContext;
 
-extern SuricataContext suricata_context;
+extern const SuricataContext suricata_context;
 
 typedef struct SuricataFileContext_ {
 
@@ -68,6 +68,6 @@ typedef struct SuricataFileContext_ {
 
 } SuricataFileContext;
 
-SuricataContext *SCGetContext(void);
+const SuricataContext *SCGetContext(void);
 
 #endif /* !__RUST_CONTEXT_H__ */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2788,26 +2788,6 @@ static void SuricataMainLoop(SCInstance *suri)
  */
 
 int InitGlobal(void) {
-    suricata_context.SCLogMessage = SCLogMessage;
-    suricata_context.DetectEngineStateFree = DetectEngineStateFree;
-    suricata_context.AppLayerDecoderEventsSetEventRaw = AppLayerDecoderEventsSetEventRaw;
-    suricata_context.AppLayerDecoderEventsFreeEvents = AppLayerDecoderEventsFreeEvents;
-    suricata_context.AppLayerParserTriggerRawStreamReassembly =
-            AppLayerParserTriggerRawStreamReassembly;
-
-    suricata_context.HttpRangeFreeBlock = HttpRangeFreeBlock;
-    suricata_context.HTPFileCloseHandleRange = HTPFileCloseHandleRange;
-
-    suricata_context.FileOpenFileWithId = FileOpenFileWithId;
-    suricata_context.FileCloseFileById = FileCloseFileById;
-    suricata_context.FileAppendDataById = FileAppendDataById;
-    suricata_context.FileAppendGAPById = FileAppendGAPById;
-    suricata_context.FileContainerRecycle = FileContainerRecycle;
-    suricata_context.FilePrune = FilePrune;
-    suricata_context.FileSetTx = FileContainerSetTx;
-
-    suricata_context.AppLayerRegisterParser = AppLayerRegisterParser;
-
     rs_init(&suricata_context);
 
     SC_ATOMIC_INIT(engine_stage);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None, should there be one to add more `const` everywhere ?

Describe changes:
- rust: make suricata context const, ie read only

#7447 without the force-push fixing the compilation warning