### PR TITLE
security: prevents process creation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -245,6 +245,7 @@
     AC_CHECK_FUNCS([gethostname inet_ntoa uname])
     AC_CHECK_FUNCS([gettimeofday clock_gettime utime strptime tzset localtime_r])
     AC_CHECK_FUNCS([socket setenv select putenv dup2 endgrent endpwent atexit munmap])
+    AC_CHECK_FUNCS([setrlimit])
 
     AC_CHECK_FUNCS([fwrite_unlocked])
 

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -37,6 +37,10 @@ Major changes
 ~~~~~~~~~~~~~
 - Upgrade of PCRE1 to PCRE2. See :ref:`pcre-update-v1-to-v2` for more details.
 
+Security changes
+~~~~~~~~~~~~~~~~
+- Process creation by Suricata is now disabled by default, this can be configured with `security.limit-noproc` (for LUA scripts for instance)
+
 Removals
 ~~~~~~~~
 - The libprelude output plugin has been removed.

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -30,6 +30,10 @@
 #if HAVE_SIGNAL_H
 #include <signal.h>
 #endif
+#ifndef OS_WIN32
+// setrlimit
+#include <sys/resource.h>
+#endif
 
 #include "suricata.h"
 #include "decode.h"
@@ -2089,6 +2093,17 @@ static int InitRunAs(SCInstance *suri)
         }
 
         sc_set_caps = TRUE;
+    }
+    int limit_nproc = 0;
+    if (ConfGetBool("security.limit-noproc", &limit_nproc) == 0) {
+        /* Ignore vlan_ids when comparing flows. */
+        limit_nproc = 0;
+    }
+    if (limit_nproc) {
+        struct rlimit r = { 0, 0 };
+        if (setrlimit(RLIMIT_NPROC, &r) != 0) {
+            SCLogWarning(SC_ERR_SYSCONF, "setrlimit failed to prevent process creation.");
+        }
     }
 #endif
     return TM_ECODE_OK;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1966,6 +1966,11 @@ napatech:
     #
     hashmode: hash5tuplesorted
 
+security:
+  # if true, prevents process creation from Suricata by calling
+  # setrlimit(RLIMIT_NPROC, 0)
+  limit-noproc: yes
+
 ##
 ## Configure Suricata to load Suricata-Update managed rules.
 ##


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5373

Describe changes:
- optionally calls `setrlimit(RLIMIT_NPROC, 0)` to prevent process creation by Suricata process

Modifies #7448 by excluding windows which does not have setrlimit