### PR TITLE
ftp: remove temporary fields from state

### DIFF
--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -160,9 +160,6 @@ typedef struct FTPTransaction_  {
 
 /** FTP State for app layer parser */
 typedef struct FtpState_ {
-    const uint8_t *input;
-    int32_t input_len;
-    uint8_t direction;
     bool active;
 
     FTPTransaction *curr_tx;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
Should I create one ?

Describe changes:
- ftp: remove temporary fields from state, so we consume less memory.

Replaces #7446 with comment taken into account.
Let's see if QA still fails for ips_afp_drop_chk