### PR TITLE
detect: introduce "like" ip-only signature type - v2

### DIFF
--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -309,7 +309,8 @@ static inline void FlowApplySignatureActions(
      * - match is in stream */
     if (s->action & (ACTION_DROP | ACTION_PASS)) {
         if ((pa->flags & (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_STREAM_MATCH)) ||
-                (s->flags & (SIG_FLAG_IPONLY | SIG_FLAG_PDONLY | SIG_FLAG_APPLAYER))) {
+                (s->flags & (SIG_FLAG_IPONLY | SIG_FLAG_LIKE_IPONLY | SIG_FLAG_PDONLY |
+                                    SIG_FLAG_APPLAYER))) {
             pa->flags |= PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW;
             SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x (set "
                        "PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW)",

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -185,6 +185,7 @@ int SignatureIsFilesizeInspecting(const Signature *s)
  *  \param de_ctx detection engine ctx
  *  \param s the signature
  *  \retval 1 sig is ip only
+ *  \retval 2 sig is like ip only
  *  \retval 0 sig is not ip only
  */
 int SignatureIsIPOnly(DetectEngineCtx *de_ctx, const Signature *s)
@@ -219,13 +220,6 @@ int SignatureIsIPOnly(DetectEngineCtx *de_ctx, const Signature *s)
     /* TMATCH list can be ignored, it contains TAGs and
      * tags are compatible to IP-only. */
 
-    /* if any of the addresses uses negation, we don't support
-     * it in ip-only */
-    if (s->init_data->src_contains_negation)
-        return 0;
-    if (s->init_data->dst_contains_negation)
-        return 0;
-
     SigMatch *sm = s->init_data->smlists[DETECT_SM_LIST_MATCH];
     for (; sm != NULL; sm = sm->next) {
         if (!(sigmatch_table[sm->type].flags & SIGMATCH_IPONLY_COMPAT))
@@ -249,6 +243,10 @@ int SignatureIsIPOnly(DetectEngineCtx *de_ctx, const Signature *s)
         }
     }
 
+    if (s->init_data->src_contains_negation || s->init_data->dst_contains_negation) {
+        /* Rule is IP only, but contains negated addresses. */
+        return 2;
+    }
     if (!(de_ctx->flags & DE_QUIET)) {
         SCLogDebug("IP-ONLY (%" PRIu32 "): source %s, dest %s", s->id,
                    s->flags & SIG_FLAG_SRC_ANY ? "ANY" : "SET",
@@ -1326,14 +1324,19 @@ static DetectPort *RulesGroupByPorts(DetectEngineCtx *de_ctx, int ipproto, uint3
 
 void SignatureSetType(DetectEngineCtx *de_ctx, Signature *s)
 {
+    int iponly = 0;
+
     /* see if the sig is dp only */
     if (SignatureIsPDOnly(de_ctx, s) == 1) {
         s->flags |= SIG_FLAG_PDONLY;
 
     /* see if the sig is ip only */
-    } else if (SignatureIsIPOnly(de_ctx, s) == 1) {
-        s->flags |= SIG_FLAG_IPONLY;
-
+    } else if ((iponly = SignatureIsIPOnly(de_ctx, s)) > 0) {
+        if (iponly == 1) {
+            s->flags |= SIG_FLAG_IPONLY;
+        } else if (iponly == 2) {
+            s->flags |= SIG_FLAG_LIKE_IPONLY;
+        }
     } else if (SignatureIsDEOnly(de_ctx, s) == 1) {
         s->init_data->init_flags |= SIG_FLAG_INIT_DEONLY;
     }

--- a/src/detect.h
+++ b/src/detect.h
@@ -217,6 +217,9 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_DSIZE                  BIT_U32(5)  /**< signature has a dsize setting */
 #define SIG_FLAG_APPLAYER               BIT_U32(6)  /**< signature applies to app layer instead of packets */
 #define SIG_FLAG_IPONLY                 BIT_U32(7)  /**< ip only signature */
+#define SIG_FLAG_LIKE_IPONLY                                                                       \
+    BIT_U32(8) /**< signature that is almost ip only, but contains negation prevening some iponly  \
+                  optimizations */
 
 // vacancy
 


### PR DESCRIPTION
Rules that look like they should be IP-only but contain a negated rule
address are now marked with an LIKE_IPONLY flag. This is so they are
treated like IPONLY rules with respect to flow action, but don't
interfere with other IPONLY processing like using the radix tree.

Ticket: https://redmine.openinfosecfoundation.org/issues/5361

Previous PR:
- https://github.com/OISF/suricata/pull/7402

Changes from last PR:
- Rebase
- Attempt to make cocci happy, but still unsuccessful.

suricata-verify-pr: 824
