### PR TITLE
detect/alert: don't lose 'drop' alert - v1

### DIFF
--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -220,6 +220,11 @@ void AlertQueueFree(DetectEngineThreadCtx *det_ctx)
  */
 static uint16_t AlertQueueExpand(DetectEngineThreadCtx *det_ctx)
 {
+#ifdef DEBUG
+    if (unlikely(is_alert_queue_fail_mode)) {
+        return det_ctx->alert_queue_capacity;
+    }
+#endif
     uint16_t new_cap = det_ctx->alert_queue_capacity * 2;
     void *tmp_queue = SCRealloc(det_ctx->alert_queue, (size_t)(sizeof(PacketAlert) * new_cap));
     if (unlikely(tmp_queue == NULL)) {

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -220,6 +220,7 @@ void AlertQueueInit(DetectEngineThreadCtx *det_ctx)
                 (uint64_t)(packet_alert_max * sizeof(PacketAlert)));
     }
     det_ctx->alert_queue_capacity = packet_alert_max;
+    det_ctx->is_expand_failure = false;
     SCLogDebug("alert queue initialized to %u elements (%" PRIu64 " bytes)", packet_alert_max,
             (uint64_t)(packet_alert_max * sizeof(PacketAlert)));
 }
@@ -237,12 +238,15 @@ static uint16_t AlertQueueExpand(DetectEngineThreadCtx *det_ctx)
 {
 #ifdef DEBUG
     if (unlikely(is_alert_queue_fail_mode)) {
+        det_ctx->is_expand_failure = true;
         return det_ctx->alert_queue_capacity;
     }
 #endif
     uint16_t new_cap = det_ctx->alert_queue_capacity * 2;
     void *tmp_queue = SCRealloc(det_ctx->alert_queue, (size_t)(sizeof(PacketAlert) * new_cap));
     if (unlikely(tmp_queue == NULL)) {
+        /* save this info, so we know to double check for DROP action in packet */
+        det_ctx->is_expand_failure = true;
         /* queue capacity didn't change */
         return det_ctx->alert_queue_capacity;
     }
@@ -386,12 +390,13 @@ void PacketAlertQueueFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *de
 {
     SCEnter();
 
-    /* sort the alert queue before thresholding and appending to Packet */
-    qsort(det_ctx->alert_queue, det_ctx->alert_queue_size, sizeof(PacketAlert),
-            AlertQueueSortHelper);
-
     int i = 0;
     uint16_t max_pos = det_ctx->alert_queue_size;
+    PacketAlert tmp_queue[max_pos];
+
+    uint16_t tmp_size = 0;
+    bool is_action_pass = false;
+    uint32_t pass_sid_num = 0;
 
     while (i < max_pos) {
         const Signature *s = de_ctx->sig_array[det_ctx->alert_queue[i].num];
@@ -403,20 +408,57 @@ void PacketAlertQueueFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *de
             p->alerts.suppressed++;
             SCLogDebug("Suppressing sid %" PRIu32 " alert from alerts' queue", s->id);
         } else if (res == 1) {
-            if (p->alerts.cnt < packet_alert_max) {
-                p->alerts.alerts[p->alerts.cnt] = det_ctx->alert_queue[i];
-                SCLogDebug("Appending sid %" PRIu32 " alert to Packet::alerts at pos %u", s->id, i);
-                if (PacketTestAction(p, ACTION_PASS)) {
-                    /* Ok, reset the alert cnt to end in the previous of pass
-                     * so we ignore the rest with less prio */
-                    break;
-                }
-                p->alerts.cnt++;
-            } else {
-                p->alerts.discarded++;
+            tmp_queue[tmp_size] = det_ctx->alert_queue[i];
+            tmp_size++;
+            SCLogDebug("Appending sid %" PRIu32 " alert to Packet::alerts at pos %u", s->id, i);
+            if (PacketTestAction(p, ACTION_PASS) && !is_action_pass) {
+                /* Ok, reset the alert cnt to end in the previous of pass
+                 * so we ignore the rest with less prio */
+                pass_sid_num = s->num;
+                is_action_pass = true;
             }
         }
         i++;
+    }
+
+    if (packet_alert_max > tmp_size) {
+        p->alerts.cnt = tmp_size;
+    } else {
+        p->alerts.cnt = packet_alert_max;
+        // we also have discarded alerts in case of queue expansion failure, let's
+        // not miss that count
+        p->alerts.discarded += (tmp_size - packet_alert_max);
+    }
+    qsort(tmp_queue, tmp_size, sizeof(PacketAlert), AlertQueueSortHelper);
+
+    if (det_ctx->is_expand_failure) {
+        if (p->alerts.drop.action & ACTION_DROP) {
+            PacketAlertFinalize(de_ctx, det_ctx, p, &p->alerts.drop, p->alerts.drop.s);
+        }
+    }
+
+    if (is_action_pass) {
+        // this means we got a 'PASS' action for this Packet, pass_sid_num
+        // has the related signature's internal id
+        uint16_t j;
+        for (j = 0; j < p->alerts.cnt; j++) {
+            if (tmp_queue[j].num < pass_sid_num) {
+                // we add it to the final queue
+                p->alerts.alerts[j] = tmp_queue[j];
+            } else {
+                break;
+            }
+        }
+        if (p->alerts.drop.action != 0) {
+            if (p->alerts.drop.s->num > pass_sid_num) {
+                // if this should be a pass, then ignore drop action
+                p->alerts.drop.action = 0;
+                PACKET_PASS(p);
+            }
+        }
+        p->alerts.cnt = j;
+    } else {
+        memcpy(p->alerts.alerts, tmp_queue, p->alerts.cnt * sizeof(PacketAlert));
     }
 
     /* At this point, we should have all the new alerts. Now check the tag
@@ -431,7 +473,6 @@ void PacketAlertQueueFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *de
             p->flags |= PKT_FIRST_ALERTS;
         }
     }
-
 }
 
 

--- a/src/detect-engine-alert.h
+++ b/src/detect-engine-alert.h
@@ -37,4 +37,6 @@ int PacketAlertCheck(Packet *, uint32_t);
 void PacketAlertTagInit(void);
 PacketAlert *PacketAlertGetTag(void);
 
+extern bool is_alert_queue_fail_mode;
+
 #endif /* __DETECT_ENGINE_ALERT_H__ */

--- a/src/detect-engine-alert.h
+++ b/src/detect-engine-alert.h
@@ -32,7 +32,7 @@ void AlertQueueInit(DetectEngineThreadCtx *det_ctx);
 void AlertQueueFree(DetectEngineThreadCtx *det_ctx);
 void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p, uint64_t tx_id,
         uint8_t alert_flags);
-void PacketAlertFinalize(DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
+void PacketAlertQueueFinalize(DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
 int PacketAlertCheck(Packet *, uint32_t);
 void PacketAlertTagInit(void);
 PacketAlert *PacketAlertGetTag(void);

--- a/src/detect.c
+++ b/src/detect.c
@@ -930,11 +930,11 @@ static inline void DetectRunPostRules(
     }
 
     /* so now let's iterate the alerts and remove the ones after a pass rule
-     * matched (if any). This is done inside PacketAlertFinalize() */
+     * matched (if any). This is done inside PacketAlertQueueFinalize() */
     /* PR: installed "tag" keywords are handled after the threshold inspection */
 
     PACKET_PROFILING_DETECT_START(p, PROF_DETECT_ALERT);
-    PacketAlertFinalize(de_ctx, det_ctx, p);
+    PacketAlertQueueFinalize(de_ctx, det_ctx, p);
     if (p->alerts.cnt > 0) {
         StatsAddUI64(tv, det_ctx->counter_alerts, (uint64_t)p->alerts.cnt);
     }

--- a/src/detect.h
+++ b/src/detect.h
@@ -1119,6 +1119,7 @@ typedef struct DetectEngineThreadCtx_ {
     uint16_t alert_queue_size;
     uint16_t alert_queue_capacity;
     PacketAlert *alert_queue;
+    bool is_expand_failure;
 
     SC_ATOMIC_DECLARE(int, so_far_used_by_detect);
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -894,6 +894,7 @@ static void PrintBuildInfo(void)
 int coverage_unittests;
 int g_ut_modules;
 int g_ut_covered;
+bool is_alert_queue_fail_mode;
 
 void RegisterAllModules(void)
 {
@@ -1280,6 +1281,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
     int conf_test = 0;
     int engine_analysis = 0;
     int ret = TM_ECODE_OK;
+    is_alert_queue_fail_mode = false;
 
 #ifdef UNITTESTS
     coverage_unittests = 0;
@@ -1351,6 +1353,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #ifdef HAVE_NFLOG
         {"nflog", optional_argument, 0, 0},
 #endif
+        {"disable-alert-queue-expand", 0, 0, 0},
         {NULL, 0, NULL, 0}
     };
     // clang-format on
@@ -1719,6 +1722,9 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 if (suri->strict_rule_parsing_string == NULL) {
                     FatalError(SC_ERR_MEM_ALLOC, "failed to duplicate 'strict' string");
                 }
+            } else if (strcmp((long_opts[option_index]).name, "disable-alert-queue-expand") == 0) {
+                is_alert_queue_fail_mode = true;
+                SCLogInfo("Running Suricata with alert queue expansion disabled");
             }
             break;
         case 'c':


### PR DESCRIPTION
This is a first attempt at ensuring we don't lose a drop alert, even if the corresponding alert was discarded due to alert queue expansion failure (or just discarded in general). 

Leaving as draft both because I'm not certain this solution isn't too messy/ugly, and because I've included work from 5319, just to make sure that the corresponding sv test would work, and therefore test that behavior.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5180

Describe changes:
- First process all alerts in the queue, then sort them and copy the ones that should stay to Packet::alerts
- split 'PacketAlertFinalize()' into two functions. The loop that process all 'PacketAlert's is now in 'PacketAlertQueueFinalize()' while each individual 'PacketAlert' is process within 'PacketAlertFinalize()'
- add a flag to indicate if there was a realloc failure
- check for 'PASS' and 'DROP' actions explicitly after processing alerts' queue
- always use a function to set 'Packet::alerts::drop'

suricata-verify-pr: 841
https://github.com/OISF/suricata-verify/pull/841