### PR TITLE
eve/stats: Fix ASAN-detected overflow

### DIFF
--- a/src/output-json-common.c
+++ b/src/output-json-common.c
@@ -53,7 +53,7 @@ OutputJsonThreadCtx *CreateEveThreadCtx(ThreadVars *t, OutputJsonCtx *ctx)
         goto error;
     }
 
-    thread->file_ctx = LogFileEnsureExists(ctx->file_ctx, t->id);
+    thread->file_ctx = LogFileEnsureExists(ctx->file_ctx);
     if (!thread->file_ctx) {
         goto error;
     }
@@ -119,7 +119,7 @@ TmEcode JsonLogThreadInit(ThreadVars *t, const void *initdata, void **data)
     }
 
     thread->ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->ctx->file_ctx, t->id);
+    thread->file_ctx = LogFileEnsureExists(thread->ctx->file_ctx);
     if (!thread->file_ctx) {
         goto error_exit;
     }

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -395,7 +395,7 @@ static OutputInitResult OutputStatsLogInitSub(ConfNode *conf, OutputCtx *parent_
         return result;
     }
 
-    OutputStatsCtx *stats_ctx = SCMalloc(sizeof(OutputStatsCtx));
+    OutputStatsCtx *stats_ctx = SCCalloc(1, sizeof(OutputStatsCtx));
     if (unlikely(stats_ctx == NULL))
         return result;
 

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -344,7 +344,7 @@ static TmEcode JsonStatsLogThreadInit(ThreadVars *t, const void *initdata, void 
     /* Use the Output Context (file pointer and mutex) */
     aft->statslog_ctx = ((OutputCtx *)initdata)->data;
 
-    aft->file_ctx = LogFileEnsureExists(aft->statslog_ctx->file_ctx, t->id);
+    aft->file_ctx = LogFileEnsureExists(aft->statslog_ctx->file_ctx);
     if (!aft->file_ctx) {
         goto error_exit;
     }

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -440,7 +440,14 @@ static OutputInitResult OutputStatsLogInitSub(ConfNode *conf, OutputCtx *parent_
         return result;
     }
 
-    stats_ctx->file_ctx = ajt->file_ctx;
+    SCLogDebug("Preparing file context for stats submodule logger");
+    /* Share output slot with thread 1 */
+    stats_ctx->file_ctx = LogFileEnsureExists(ajt->file_ctx);
+    if (!stats_ctx->file_ctx) {
+        SCFree(stats_ctx);
+        SCFree(output_ctx);
+        return result;
+    }
 
     output_ctx->data = stats_ctx;
     output_ctx->DeInit = OutputStatsLogDeinitSub;

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -26,6 +26,7 @@
 
 #include "conf.h"            /* ConfNode   */
 #include "util-buffer.h"
+#include "util-hash.h"
 
 #ifdef HAVE_LIBHIREDIS
 #include "util-log-redis.h"
@@ -46,11 +47,18 @@ typedef struct SyslogSetup_ {
     int alert_syslog_level;
 } SyslogSetup;
 
+typedef struct ThreadSlotHashEntry_ {
+    uint64_t thread_id;
+    int slot; /* table slot */
+} ThreadSlotHashEntry;
+
 struct LogFileCtx_;
 typedef struct LogThreadedFileCtx_ {
-    int slot_count;
     SCMutex mutex;
-    struct LogFileCtx_ **lf_slots;
+    int slot_count;                /* Allocated slot count */
+    struct LogFileCtx_ **lf_slots; /* Slots */
+    int last_slot;                 /* Last slot allocated */
+    HashTable *ht;
     char *append;
 } LogThreadedFileCtx;
 

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -97,7 +97,7 @@ typedef struct LogFileCtx_ {
     /** When threaded, track of the parent and thread id */
     bool threaded;
     struct LogFileCtx_ *parent;
-    int id;
+    int slot;
 
     /** the type of file */
     enum LogFileType type;
@@ -174,7 +174,7 @@ LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);
 int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer);
 
-LogFileCtx *LogFileEnsureExists(LogFileCtx *lf_ctx, int thread_id);
+LogFileCtx *LogFileEnsureExists(LogFileCtx *lf_ctx);
 int SCConfLogOpenGeneric(ConfNode *conf, LogFileCtx *, const char *, int);
 int SCConfLogReopen(LogFileCtx *);
 bool SCLogOpenThreadedFile(


### PR DESCRIPTION
Continuation of #7222 

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5198](https://redmine.openinfosecfoundation.org/issues/5198)

The buffer overflow occurred due to the stats output not being set up with a valid context useful for threaded output. The stats output is created by the main thread - before the stats thread or any other Suricata thread is created.

The hash table was introduced to provide unique mappings for the thread to thread-slot relationship to guarantee that any thread using `LogFileEnsureExists` uses the proper slot.

Describe changes:
- Hashtable for thread/file slot mappings
- Ensure slot exists for stats thread

Updates
- Rebase

suricata-verify-pr: 927
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
