### PR TITLE
Smtp mime base64/v19

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1365,7 +1365,7 @@ static AppLayerResult SMTPParse(uint8_t direction, Flow *f, SMTPState *state,
     /* toserver */
     if (direction == 0) {
         while (res.status == 0) {
-            BUG_ON(state->discard_till_lf);
+            DEBUG_VALIDATE_BUG_ON(state->discard_till_lf);
             if (!state->discard_till_lf) {
                 if ((state->current_line_delimiter_len > 0) &&
                         (SMTPProcessRequest(state, f, pstate) == -1))
@@ -1385,7 +1385,7 @@ static AppLayerResult SMTPParse(uint8_t direction, Flow *f, SMTPState *state,
         /* toclient */
     } else {
         while (res.status == 0) {
-            BUG_ON(state->discard_till_lf);
+            DEBUG_VALIDATE_BUG_ON(state->discard_till_lf);
             if (!state->discard_till_lf) {
                 if ((state->current_line_delimiter_len > 0) &&
                         (SMTPProcessReply(state, f, pstate, thread_data) == -1))

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1124,11 +1124,6 @@ static int SMTPProcessRequest(SMTPState *state, Flow *f, AppLayerParserState *ps
     SCEnter();
     SMTPTransaction *tx = state->curr_tx;
 
-    /* Line with just LF */
-    if (line->len == 0 && input->consumed == 1 && line->delim_len == 0) {
-        return 0; // to continue processing further
-    }
-
     if (state->curr_tx == NULL || (state->curr_tx->done && !NoNewTx(state, line))) {
         tx = SMTPTransactionCreate();
         if (tx == NULL)

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -125,6 +125,14 @@ typedef struct SMTPInput_ {
     int32_t consumed;
 } SMTPInput;
 
+typedef struct SMTPLine_ {
+    /** current line extracted by the parser from the call to SMTPGetline() */
+    const uint8_t *buf;
+    /** length of the line in current_line.  Doesn't include the delimiter */
+    int32_t len;
+    uint8_t delim_len;
+} SMTPLine;
+
 SCEnumCharMap smtp_decoder_event_table[] = {
     { "INVALID_REPLY", SMTP_DECODER_EVENT_INVALID_REPLY },
     { "UNABLE_TO_MATCH_REPLY_WITH_REQUEST", SMTP_DECODER_EVENT_UNABLE_TO_MATCH_REPLY_WITH_REQUEST },
@@ -629,7 +637,7 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
  * \retval -1 Either when we don't have any new lines to supply anymore or
  *            on failure.
  */
-static AppLayerResult SMTPGetLine(SMTPState *state, SMTPInput *input)
+static AppLayerResult SMTPGetLine(SMTPState *state, SMTPInput *input, SMTPLine *line)
 {
     SCEnter();
 
@@ -641,31 +649,31 @@ static AppLayerResult SMTPGetLine(SMTPState *state, SMTPInput *input)
 
     if (lf_idx == NULL) {
         if (!state->discard_till_lf && input->len >= SMTP_LINE_BUFFER_LIMIT) {
-            state->current_line = input->buf;
-            state->current_line_len = SMTP_LINE_BUFFER_LIMIT;
-            state->current_line_delimiter_len = 0;
+            line->buf = input->buf;
+            line->len = SMTP_LINE_BUFFER_LIMIT;
+            line->delim_len = 0;
             SCReturnStruct(APP_LAYER_OK);
         }
         SCReturnStruct(APP_LAYER_INCOMPLETE(input->consumed, input->len + 1));
     } else {
         uint32_t o_consumed = input->consumed;
         input->consumed = lf_idx - input->buf + 1;
-        state->current_line_len = input->consumed - o_consumed;
-        input->len -= state->current_line_len;
+        line->len = input->consumed - o_consumed;
+        input->len -= line->len;
         DEBUG_VALIDATE_BUG_ON((input->consumed + input->len) != input->orig_len);
         if (state->discard_till_lf) {
             // Whatever came in with first LF should also get discarded
             state->discard_till_lf = false;
-            state->current_line_len = 0;
+            line->len = 0;
             SCReturnStruct(APP_LAYER_OK);
         }
-        state->current_line = input->buf + o_consumed;
+        line->buf = input->buf + o_consumed;
         if (input->consumed >= 2 && input->buf[input->consumed - 2] == 0x0D) {
-            state->current_line_delimiter_len = 2;
-            state->current_line_len -= 2;
+            line->delim_len = 2;
+            line->len -= 2;
         } else {
-            state->current_line_delimiter_len = 1;
-            state->current_line_len -= 1;
+            line->delim_len = 1;
+            line->len -= 1;
         }
         SCReturnStruct(APP_LAYER_OK);
     }
@@ -715,13 +723,12 @@ static int SMTPInsertCommandIntoCommandBuffer(uint8_t command, SMTPState *state,
     return 0;
 }
 
-static int SMTPProcessCommandBDAT(SMTPState *state, Flow *f,
-                                  AppLayerParserState *pstate)
+static int SMTPProcessCommandBDAT(
+        SMTPState *state, Flow *f, AppLayerParserState *pstate, SMTPLine *line)
 {
     SCEnter();
 
-    state->bdat_chunk_idx += (state->current_line_len +
-                              state->current_line_delimiter_len);
+    state->bdat_chunk_idx += (line->len + line->delim_len);
     if (state->bdat_chunk_idx > state->bdat_chunk_len) {
         state->parser_state &= ~SMTP_PARSER_STATE_COMMAND_DATA_MODE;
         /* decoder event */
@@ -782,8 +789,8 @@ static inline void SMTPTransactionComplete(SMTPState *state)
  *  \retval 0 ok
  *  \retval -1 error
  */
-static int SMTPProcessCommandDATA(SMTPState *state, Flow *f,
-                                  AppLayerParserState *pstate)
+static int SMTPProcessCommandDATA(
+        SMTPState *state, Flow *f, AppLayerParserState *pstate, SMTPLine *line)
 {
     SCEnter();
 
@@ -792,7 +799,7 @@ static int SMTPProcessCommandDATA(SMTPState *state, Flow *f,
         return 0;
     }
 
-    if (state->current_line_len == 1 && state->current_line[0] == '.') {
+    if (line->len == 1 && line->buf[0] == '.') {
         state->parser_state &= ~SMTP_PARSER_STATE_COMMAND_DATA_MODE;
         /* kinda like a hack.  The mail sent in DATA mode, would be
          * acknowledged with a reply.  We insert a dummy command to
@@ -819,8 +826,7 @@ static int SMTPProcessCommandDATA(SMTPState *state, Flow *f,
     } else if (smtp_config.raw_extraction) {
         // message not over, store the line. This is a substitution of
         // ProcessDataChunk
-        FileAppendData(state->files_ts, state->current_line,
-                state->current_line_len+state->current_line_delimiter_len);
+        FileAppendData(state->files_ts, line->buf, line->len + line->delim_len);
     }
 
     /* If DATA, then parse out a MIME message */
@@ -828,9 +834,8 @@ static int SMTPProcessCommandDATA(SMTPState *state, Flow *f,
             (state->parser_state & SMTP_PARSER_STATE_COMMAND_DATA_MODE)) {
 
         if (smtp_config.decode_mime && state->curr_tx->mime_state != NULL) {
-            int ret = MimeDecParseLine((const uint8_t *) state->current_line,
-                    state->current_line_len, state->current_line_delimiter_len,
-                    state->curr_tx->mime_state);
+            int ret = MimeDecParseLine(
+                    line->buf, line->len, line->delim_len, state->curr_tx->mime_state);
             if (ret != MIME_DEC_OK) {
                 if (ret != MIME_DEC_ERR_STATE) {
                     /* Generate decoder events */
@@ -860,32 +865,31 @@ static inline bool IsReplyToCommand(const SMTPState *state, const uint8_t cmd)
             state->cmds[state->cmds_idx] == cmd);
 }
 
-static int SMTPProcessReply(
-        SMTPState *state, Flow *f, AppLayerParserState *pstate, SMTPThreadCtx *td, SMTPInput *input)
+static int SMTPProcessReply(SMTPState *state, Flow *f, AppLayerParserState *pstate,
+        SMTPThreadCtx *td, SMTPInput *input, SMTPLine *line)
 {
     SCEnter();
 
     /* Line with just LF */
-    if (state->current_line_len == 0 && input->consumed == 1 &&
-            state->current_line_delimiter_len == 1) {
+    if (line->len == 0 && input->consumed == 1 && line->delim_len == 1) {
         return 0; // to continue processing further
     }
 
     /* the reply code has to contain at least 3 bytes, to hold the 3 digit
      * reply code */
-    if (state->current_line_len < 3) {
+    if (line->len < 3) {
         /* decoder event */
         SMTPSetEvent(state, SMTP_DECODER_EVENT_INVALID_REPLY);
         return -1;
     }
 
-    if (state->current_line_len >= 4) {
+    if (line->len >= 4) {
         if (state->parser_state & SMTP_PARSER_STATE_PARSING_MULTILINE_REPLY) {
-            if (state->current_line[3] != '-') {
+            if (line->buf[3] != '-') {
                 state->parser_state &= ~SMTP_PARSER_STATE_PARSING_MULTILINE_REPLY;
             }
         } else {
-            if (state->current_line[3] == '-') {
+            if (line->buf[3] == '-') {
                 state->parser_state |= SMTP_PARSER_STATE_PARSING_MULTILINE_REPLY;
             }
         }
@@ -898,14 +902,12 @@ static int SMTPProcessReply(
     /* I don't like this pmq reset here.  We'll devise a method later, that
      * should make the use of the mpm very efficient */
     PmqReset(td->pmq);
-    int mpm_cnt = mpm_table[SMTP_MPM].Search(smtp_mpm_ctx, td->smtp_mpm_thread_ctx,
-                                             td->pmq, state->current_line,
-                                             3);
+    int mpm_cnt = mpm_table[SMTP_MPM].Search(
+            smtp_mpm_ctx, td->smtp_mpm_thread_ctx, td->pmq, line->buf, 3);
     if (mpm_cnt == 0) {
         /* set decoder event - reply code invalid */
         SMTPSetEvent(state, SMTP_DECODER_EVENT_INVALID_REPLY);
-        SCLogDebug("invalid reply code %02x %02x %02x",
-                state->current_line[0], state->current_line[1], state->current_line[2]);
+        SCLogDebug("invalid reply code %02x %02x %02x", line->buf[0], line->buf[1], line->buf[2]);
         SCReturnInt(-1);
     }
     enum SMTPCode reply_code = smtp_reply_map[td->pmq->rule_id_array[0]].enum_value;
@@ -971,8 +973,8 @@ static int SMTPProcessReply(
         state->cmds_idx++;
     } else if (state->parser_state & SMTP_PARSER_STATE_FIRST_REPLY_SEEN) {
         /* we check if the server is indicating pipelining support */
-        if (reply_code == SMTP_REPLY_250 && state->current_line_len == 14 &&
-            SCMemcmpLowercase("pipelining", state->current_line+4, 10) == 0) {
+        if (reply_code == SMTP_REPLY_250 && line->len == 14 &&
+                SCMemcmpLowercase("pipelining", line->buf + 4, 10) == 0) {
             state->parser_state |= SMTP_PARSER_STATE_PIPELINING_SERVER;
         }
     }
@@ -986,13 +988,13 @@ static int SMTPProcessReply(
     return 0;
 }
 
-static int SMTPParseCommandBDAT(SMTPState *state)
+static int SMTPParseCommandBDAT(SMTPState *state, SMTPLine *line)
 {
     SCEnter();
 
     int i = 4;
-    while (i < state->current_line_len) {
-        if (state->current_line[i] != ' ') {
+    while (i < line->len) {
+        if (line->buf[i] != ' ') {
             break;
         }
         i++;
@@ -1001,7 +1003,7 @@ static int SMTPParseCommandBDAT(SMTPState *state)
         /* decoder event */
         return -1;
     }
-    if (i == state->current_line_len) {
+    if (i == line->len) {
         /* decoder event */
         return -1;
     }
@@ -1009,13 +1011,13 @@ static int SMTPParseCommandBDAT(SMTPState *state)
     // copy in temporary null-terminated buffer to call strtoul
     char strbuf[24];
     int len = 23;
-    if (state->current_line_len - i < len) {
-        len = state->current_line_len - i;
+    if (line->len - i < len) {
+        len = line->len - i;
     }
-    memcpy(strbuf, (const char *)state->current_line + i, len);
+    memcpy(strbuf, line->buf + i, len);
     strbuf[len] = '\0';
     state->bdat_chunk_len = strtoul((const char *)strbuf, (char **)&endptr, 10);
-    if ((uint8_t *)endptr == state->current_line + i) {
+    if ((uint8_t *)endptr == line->buf + i) {
         /* decoder event */
         return -1;
     }
@@ -1023,13 +1025,13 @@ static int SMTPParseCommandBDAT(SMTPState *state)
     return 0;
 }
 
-static int SMTPParseCommandWithParam(SMTPState *state, uint8_t prefix_len, uint8_t **target, uint16_t *target_len)
+static int SMTPParseCommandWithParam(SMTPState *state, SMTPLine *line, uint8_t prefix_len,
+        uint8_t **target, uint16_t *target_len)
 {
     int i = prefix_len + 1;
-    int spc_i = 0;
 
-    while (i < state->current_line_len) {
-        if (state->current_line[i] != ' ') {
+    while (i < line->len) {
+        if (line->buf[i] != ' ') {
             break;
         }
         i++;
@@ -1037,9 +1039,9 @@ static int SMTPParseCommandWithParam(SMTPState *state, uint8_t prefix_len, uint8
 
     /* rfc1870: with the size extension the mail from can be followed by an option.
        We use the space separator to detect it. */
-    spc_i = i;
-    while (spc_i < state->current_line_len) {
-        if (state->current_line[spc_i] == ' ') {
+    int spc_i = i;
+    while (spc_i < line->len) {
+        if (line->buf[spc_i] == ' ') {
             break;
         }
         spc_i++;
@@ -1048,7 +1050,7 @@ static int SMTPParseCommandWithParam(SMTPState *state, uint8_t prefix_len, uint8
     *target = SCMalloc(spc_i - i + 1);
     if (*target == NULL)
         return -1;
-    memcpy(*target, state->current_line + i, spc_i - i);
+    memcpy(*target, line->buf + i, spc_i - i);
     (*target)[spc_i - i] = '\0';
     if (spc_i - i > UINT16_MAX) {
         *target_len = UINT16_MAX;
@@ -1060,32 +1062,31 @@ static int SMTPParseCommandWithParam(SMTPState *state, uint8_t prefix_len, uint8
     return 0;
 }
 
-static int SMTPParseCommandHELO(SMTPState *state)
+static int SMTPParseCommandHELO(SMTPState *state, SMTPLine *line)
 {
     if (state->helo) {
         SMTPSetEvent(state, SMTP_DECODER_EVENT_DUPLICATE_FIELDS);
         return 0;
     }
-    return SMTPParseCommandWithParam(state, 4, &state->helo, &state->helo_len);
+    return SMTPParseCommandWithParam(state, line, 4, &state->helo, &state->helo_len);
 }
 
-static int SMTPParseCommandMAILFROM(SMTPState *state)
+static int SMTPParseCommandMAILFROM(SMTPState *state, SMTPLine *line)
 {
     if (state->curr_tx->mail_from) {
         SMTPSetEvent(state, SMTP_DECODER_EVENT_DUPLICATE_FIELDS);
         return 0;
     }
-    return SMTPParseCommandWithParam(state, 9,
-                                     &state->curr_tx->mail_from,
-                                     &state->curr_tx->mail_from_len);
+    return SMTPParseCommandWithParam(
+            state, line, 9, &state->curr_tx->mail_from, &state->curr_tx->mail_from_len);
 }
 
-static int SMTPParseCommandRCPTTO(SMTPState *state)
+static int SMTPParseCommandRCPTTO(SMTPState *state, SMTPLine *line)
 {
     uint8_t *rcptto;
     uint16_t rcptto_len;
 
-    if (SMTPParseCommandWithParam(state, 7, &rcptto, &rcptto_len) == 0) {
+    if (SMTPParseCommandWithParam(state, line, 7, &rcptto, &rcptto_len) == 0) {
         SMTPString *rcptto_str = SMTPStringAlloc();
         if (rcptto_str) {
             rcptto_str->str = rcptto;
@@ -1102,14 +1103,12 @@ static int SMTPParseCommandRCPTTO(SMTPState *state)
 }
 
 /* consider 'rset' and 'quit' to be part of the existing state */
-static int NoNewTx(SMTPState *state)
+static int NoNewTx(SMTPState *state, SMTPLine *line)
 {
     if (!(state->parser_state & SMTP_PARSER_STATE_COMMAND_DATA_MODE)) {
-        if (state->current_line_len >= 4 &&
-            SCMemcmpLowercase("rset", state->current_line, 4) == 0) {
+        if (line->len >= 4 && SCMemcmpLowercase("rset", line->buf, 4) == 0) {
             return 1;
-        } else if (state->current_line_len >= 4 &&
-            SCMemcmpLowercase("quit", state->current_line, 4) == 0) {
+        } else if (line->len >= 4 && SCMemcmpLowercase("quit", line->buf, 4) == 0) {
             return 1;
         }
     }
@@ -1120,18 +1119,17 @@ static int NoNewTx(SMTPState *state)
 #define rawmsgname "rawmsg"
 
 static int SMTPProcessRequest(
-        SMTPState *state, Flow *f, AppLayerParserState *pstate, SMTPInput *input)
+        SMTPState *state, Flow *f, AppLayerParserState *pstate, SMTPInput *input, SMTPLine *line)
 {
     SCEnter();
     SMTPTransaction *tx = state->curr_tx;
 
     /* Line with just LF */
-    if (state->current_line_len == 0 && input->consumed == 1 &&
-            state->current_line_delimiter_len == 0) {
+    if (line->len == 0 && input->consumed == 1 && line->delim_len == 0) {
         return 0; // to continue processing further
     }
 
-    if (state->curr_tx == NULL || (state->curr_tx->done && !NoNewTx(state))) {
+    if (state->curr_tx == NULL || (state->curr_tx->done && !NoNewTx(state, line))) {
         tx = SMTPTransactionCreate();
         if (tx == NULL)
             return -1;
@@ -1145,9 +1143,7 @@ static int SMTPProcessRequest(
                 smtp_config.content_inspect_min_size);
     }
 
-    state->toserver_data_count += (
-        state->current_line_len +
-        state->current_line_delimiter_len);
+    state->toserver_data_count += (line->len + line->delim_len);
 
     if (!(state->parser_state & SMTP_PARSER_STATE_FIRST_REPLY_SEEN)) {
         SMTPSetEvent(state, SMTP_DECODER_EVENT_NO_SERVER_WELCOME_MESSAGE);
@@ -1158,11 +1154,9 @@ static int SMTPProcessRequest(
     if (!(state->parser_state & SMTP_PARSER_STATE_COMMAND_DATA_MODE)) {
         int r = 0;
 
-        if (state->current_line_len >= 8 &&
-            SCMemcmpLowercase("starttls", state->current_line, 8) == 0) {
+        if (line->len >= 8 && SCMemcmpLowercase("starttls", line->buf, 8) == 0) {
             state->current_command = SMTP_COMMAND_STARTTLS;
-        } else if (state->current_line_len >= 4 &&
-                   SCMemcmpLowercase("data", state->current_line, 4) == 0) {
+        } else if (line->len >= 4 && SCMemcmpLowercase("data", line->buf, 4) == 0) {
             state->current_command = SMTP_COMMAND_DATA;
             if (smtp_config.raw_extraction) {
                 if (state->files_ts == NULL)
@@ -1220,38 +1214,33 @@ static int SMTPProcessRequest(
             if (state->parser_state & SMTP_PARSER_STATE_PIPELINING_SERVER) {
                 state->parser_state |= SMTP_PARSER_STATE_COMMAND_DATA_MODE;
             }
-        } else if (state->current_line_len >= 4 &&
-                   SCMemcmpLowercase("bdat", state->current_line, 4) == 0) {
-            r = SMTPParseCommandBDAT(state);
+        } else if (line->len >= 4 && SCMemcmpLowercase("bdat", line->buf, 4) == 0) {
+            r = SMTPParseCommandBDAT(state, line);
             if (r == -1) {
                 SCReturnInt(-1);
             }
             state->current_command = SMTP_COMMAND_BDAT;
             state->parser_state |= SMTP_PARSER_STATE_COMMAND_DATA_MODE;
-        } else if (state->current_line_len >= 4 &&
-                   ((SCMemcmpLowercase("helo", state->current_line, 4) == 0) ||
-                    SCMemcmpLowercase("ehlo", state->current_line, 4) == 0))  {
-            r = SMTPParseCommandHELO(state);
+        } else if (line->len >= 4 && ((SCMemcmpLowercase("helo", line->buf, 4) == 0) ||
+                                             SCMemcmpLowercase("ehlo", line->buf, 4) == 0)) {
+            r = SMTPParseCommandHELO(state, line);
             if (r == -1) {
                 SCReturnInt(-1);
             }
             state->current_command = SMTP_COMMAND_OTHER_CMD;
-        } else if (state->current_line_len >= 9 &&
-                   SCMemcmpLowercase("mail from", state->current_line, 9) == 0) {
-            r = SMTPParseCommandMAILFROM(state);
+        } else if (line->len >= 9 && SCMemcmpLowercase("mail from", line->buf, 9) == 0) {
+            r = SMTPParseCommandMAILFROM(state, line);
             if (r == -1) {
                 SCReturnInt(-1);
             }
             state->current_command = SMTP_COMMAND_OTHER_CMD;
-        } else if (state->current_line_len >= 7 &&
-                   SCMemcmpLowercase("rcpt to", state->current_line, 7) == 0) {
-            r = SMTPParseCommandRCPTTO(state);
+        } else if (line->len >= 7 && SCMemcmpLowercase("rcpt to", line->buf, 7) == 0) {
+            r = SMTPParseCommandRCPTTO(state, line);
             if (r == -1) {
                 SCReturnInt(-1);
             }
             state->current_command = SMTP_COMMAND_OTHER_CMD;
-        } else if (state->current_line_len >= 4 &&
-                   SCMemcmpLowercase("rset", state->current_line, 4) == 0) {
+        } else if (line->len >= 4 && SCMemcmpLowercase("rset", line->buf, 4) == 0) {
             // Resets chunk index in case of connection reuse
             state->bdat_chunk_idx = 0;
             state->current_command = SMTP_COMMAND_RSET;
@@ -1274,10 +1263,10 @@ static int SMTPProcessRequest(
             return SMTPProcessCommandSTARTTLS(state, f, pstate);
 
         case SMTP_COMMAND_DATA:
-            return SMTPProcessCommandDATA(state, f, pstate);
+            return SMTPProcessCommandDATA(state, f, pstate, line);
 
         case SMTP_COMMAND_BDAT:
-            return SMTPProcessCommandBDAT(state, f, pstate);
+            return SMTPProcessCommandBDAT(state, f, pstate, line);
 
         default:
             /* we have nothing to do with any other command at this instant.
@@ -1287,7 +1276,7 @@ static int SMTPProcessRequest(
 }
 
 static int SMTPPreProcessCommands(
-        SMTPState *state, Flow *f, AppLayerParserState *pstate, SMTPInput *input)
+        SMTPState *state, Flow *f, AppLayerParserState *pstate, SMTPInput *input, SMTPLine *line)
 {
     DEBUG_VALIDATE_BUG_ON((state->parser_state & SMTP_PARSER_STATE_COMMAND_DATA_MODE) == 0);
 
@@ -1297,14 +1286,14 @@ static int SMTPPreProcessCommands(
         if (input->buf[i] == 0x0d) {
             if (i < input_len - 1 && input->buf[i + 1] == 0x0a) {
                 i++;
-                state->current_line_delimiter_len++;
+                line->delim_len++;
             }
             /* Line is just ending in CR */
-            state->current_line_delimiter_len++;
+            line->delim_len++;
             line_complete = true;
         } else if (input->buf[i] == 0x0a) {
             /* Line is just ending in LF */
-            state->current_line_delimiter_len++;
+            line->delim_len++;
             line_complete = true;
         }
         /* Either line is complete or fragmented */
@@ -1320,16 +1309,18 @@ static int SMTPPreProcessCommands(
             }
             int32_t total_consumed = i + 1;
             int32_t current_line_consumed = total_consumed - input->consumed;
-            state->current_line = input->buf + input->consumed;
-            state->current_line_len = current_line_consumed - state->current_line_delimiter_len;
+            line->buf = input->buf + input->consumed;
+            line->len = current_line_consumed - line->delim_len;
             input->consumed = total_consumed;
             input->len -= current_line_consumed;
             DEBUG_VALIDATE_BUG_ON(input->consumed + input->len != input->orig_len);
-            if (SMTPProcessRequest(state, f, pstate, input) == -1) {
+            if (SMTPProcessRequest(state, f, pstate, input, line) == -1) {
                 return -1;
             }
             line_complete = false;
-            state->current_line_delimiter_len = 0;
+            line->buf = NULL;
+            line->len = 0;
+            line->delim_len = 0;
 
             /* bail if `SMTPProcessRequest` ended the data mode */
             if ((state->parser_state & SMTP_PARSER_STATE_COMMAND_DATA_MODE) == 0)
@@ -1343,6 +1334,7 @@ static AppLayerResult SMTPParse(uint8_t direction, Flow *f, SMTPState *state,
         AppLayerParserState *pstate, StreamSlice stream_slice, SMTPThreadCtx *thread_data)
 {
     SCEnter();
+    SMTPLine line = { NULL, 0, 0 };
 
     const uint8_t *input_buf = StreamSliceGetData(&stream_slice);
     uint32_t input_len = StreamSliceGetDataLen(&stream_slice);
@@ -1358,36 +1350,33 @@ static AppLayerResult SMTPParse(uint8_t direction, Flow *f, SMTPState *state,
 
     SMTPInput input = { .buf = input_buf, .len = input_len, .orig_len = input_len, .consumed = 0 };
 
-    state->current_line_delimiter_len = 0;
-
     if (direction == 0) {
         if (((state->current_command == SMTP_COMMAND_DATA) ||
                     (state->current_command == SMTP_COMMAND_BDAT)) &&
                 (state->parser_state & SMTP_PARSER_STATE_COMMAND_DATA_MODE)) {
-            int ret = SMTPPreProcessCommands(state, f, pstate, &input);
+            int ret = SMTPPreProcessCommands(state, f, pstate, &input, &line);
             if (ret == 0 && input.consumed == input.orig_len) {
                 SCReturnStruct(APP_LAYER_OK);
             }
         }
     }
-    AppLayerResult res = SMTPGetLine(state, &input);
+    AppLayerResult res = SMTPGetLine(state, &input, &line);
 
     /* toserver */
     if (direction == 0) {
         while (res.status == 0) {
             DEBUG_VALIDATE_BUG_ON(state->discard_till_lf);
             if (!state->discard_till_lf) {
-                if ((state->current_line_delimiter_len > 0) &&
-                        (SMTPProcessRequest(state, f, pstate, &input) == -1))
+                if ((line.delim_len > 0) &&
+                        (SMTPProcessRequest(state, f, pstate, &input, &line) == -1))
                     SCReturnStruct(APP_LAYER_ERROR);
-                if (state->current_line_delimiter_len == 0 &&
-                        state->current_line_len == SMTP_LINE_BUFFER_LIMIT) {
+                if (line.delim_len == 0 && line.len == SMTP_LINE_BUFFER_LIMIT) {
                     state->discard_till_lf = true;
                     input.consumed = input.len + 1; // For the newly found LF
                     SMTPSetEvent(state, SMTP_DECODER_EVENT_TRUNCATED_LINE);
                     break;
                 }
-                res = SMTPGetLine(state, &input);
+                res = SMTPGetLine(state, &input, &line);
             }
         }
         if (res.status == 1)
@@ -1397,17 +1386,16 @@ static AppLayerResult SMTPParse(uint8_t direction, Flow *f, SMTPState *state,
         while (res.status == 0) {
             DEBUG_VALIDATE_BUG_ON(state->discard_till_lf);
             if (!state->discard_till_lf) {
-                if ((state->current_line_delimiter_len > 0) &&
-                        (SMTPProcessReply(state, f, pstate, thread_data, &input) == -1))
+                if ((line.delim_len > 0) &&
+                        (SMTPProcessReply(state, f, pstate, thread_data, &input, &line) == -1))
                     SCReturnStruct(APP_LAYER_ERROR);
-                if (state->current_line_delimiter_len == 0 &&
-                        state->current_line_len == SMTP_LINE_BUFFER_LIMIT) {
+                if (line.delim_len == 0 && line.len == SMTP_LINE_BUFFER_LIMIT) {
                     state->discard_till_lf = true;
                     input.consumed = input.len + 1; // For the newly found LF
                     SMTPSetEvent(state, SMTP_DECODER_EVENT_TRUNCATED_LINE);
                     break;
                 }
-                res = SMTPGetLine(state, &input);
+                res = SMTPGetLine(state, &input, &line);
             }
         }
         if (res.status == 1)

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1278,10 +1278,11 @@ static int SMTPProcessRequest(SMTPState *state, Flow *f,
 
 static int SMTPPreProcessCommands(SMTPState *state, Flow *f, AppLayerParserState *pstate)
 {
+    DEBUG_VALIDATE_BUG_ON((state->parser_state & SMTP_PARSER_STATE_COMMAND_DATA_MODE) == 0);
+
     bool line_complete = false;
     int32_t input_len = state->input_len;
-    for (int32_t i = 0;
-            i < input_len && (state->parser_state & SMTP_PARSER_STATE_COMMAND_DATA_MODE); i++) {
+    for (int32_t i = 0; i < input_len; i++) {
         if (state->input[i] == 0x0d) {
             if (i < input_len - 1 && state->input[i + 1] == 0x0a) {
                 i++;
@@ -1312,12 +1313,16 @@ static int SMTPPreProcessCommands(SMTPState *state, Flow *f, AppLayerParserState
             state->current_line_len = current_line_consumed - state->current_line_delimiter_len;
             state->consumed = total_consumed;
             state->input_len -= current_line_consumed;
-            BUG_ON(state->consumed + state->input_len != state->orig_input_len);
+            DEBUG_VALIDATE_BUG_ON(state->consumed + state->input_len != state->orig_input_len);
             if (SMTPProcessRequest(state, f, pstate) == -1) {
                 return -1;
             }
             line_complete = false;
             state->current_line_delimiter_len = 0;
+
+            /* bail if `SMTPProcessRequest` ended the data mode */
+            if ((state->parser_state & SMTP_PARSER_STATE_COMMAND_DATA_MODE) == 0)
+                break;
         }
     }
     return 0;

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -40,6 +40,7 @@
 
 #include "util-mpm.h"
 #include "util-debug.h"
+#include "util-print.h"
 #include "util-byte.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
@@ -561,7 +562,6 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
         } else {
             /* Append data chunk to file */
             SCLogDebug("Appending file...%u bytes", len);
-
             /* 0 is ok, -2 is not stored, -1 is error */
             ret = FileAppendData(files, (uint8_t *) chunk, len);
             if (ret == -2) {
@@ -1116,7 +1116,8 @@ static int SMTPProcessRequest(SMTPState *state, Flow *f,
     SMTPTransaction *tx = state->curr_tx;
 
     /* Line with just LF */
-    if (state->current_line_len == 0 && state->consumed == 1) {
+    if (state->current_line_len == 0 && state->consumed == 1 &&
+            state->current_line_delimiter_len == 0) {
         return 0; // to continue processing further
     }
 
@@ -1277,43 +1278,47 @@ static int SMTPProcessRequest(SMTPState *state, Flow *f,
 
 static int SMTPPreProcessCommands(SMTPState *state, Flow *f, AppLayerParserState *pstate)
 {
-    // By this time we should have had the command line parsed
-    uint8_t *lf_idx = memchr(state->input + state->consumed, 0x0a, state->input_len);
-    const uint32_t orig_input_len = state->input_len;
-    // Both DATA and BDAT set SMTP_PARSER_STATE_COMMAND_DATA_MODE, so this while
-    // loop should be valid for both
-    while (state->input_len > 0 && (state->parser_state & SMTP_PARSER_STATE_COMMAND_DATA_MODE)) {
-        uint8_t delim_len = 0;
-        uint32_t consumed_line = 0;
-        if (lf_idx == NULL) {
+    bool line_complete = false;
+    int32_t input_len = state->input_len;
+    for (int32_t i = 0;
+            i < input_len && (state->parser_state & SMTP_PARSER_STATE_COMMAND_DATA_MODE); i++) {
+        if (state->input[i] == 0x0d) {
+            if (i < input_len - 1 && state->input[i + 1] == 0x0a) {
+                i++;
+                state->current_line_delimiter_len++;
+            }
+            /* Line is just ending in CR */
+            state->current_line_delimiter_len++;
+            line_complete = true;
+        } else if (state->input[i] == 0x0a) {
+            /* Line is just ending in LF */
+            state->current_line_delimiter_len++;
+            line_complete = true;
+        }
+        /* Either line is complete or fragmented */
+        if (line_complete || (i == input_len - 1)) {
+            DEBUG_VALIDATE_BUG_ON(state->consumed + state->input_len != state->orig_input_len);
+            DEBUG_VALIDATE_BUG_ON(state->input_len == 0 && input_len != 0);
+            /* state->input_len reflects data from start of the line in progress. */
             if ((state->input_len == 1 && state->input[state->consumed] == '-') ||
                     (state->input_len > 1 && state->input[state->consumed] == '-' &&
                             state->input[state->consumed + 1] == '-')) {
-                SCLogDebug("possible boundary, yield to getline");
+                SCLogDebug("Possible boundary, yield to GetLine");
                 return 1;
             }
+            int32_t total_consumed = i + 1;
+            int32_t current_line_consumed = total_consumed - state->consumed;
             state->current_line = state->input + state->consumed;
-            state->consumed = state->input_len;
-            consumed_line = state->input_len;
-        } else {
-            state->current_line = state->input + state->consumed;
-            ptrdiff_t idx = lf_idx - state->input;
-            state->consumed = idx + 1;
-            consumed_line = lf_idx - state->current_line + 1;
-            if (orig_input_len >= idx && idx > 0 && state->input[idx - 1] == 0x0d) {
-                delim_len = 2;
-            } else if (orig_input_len == 1 ||
-                       (orig_input_len >= idx && idx > 0 && state->input[idx - 1] != 0x0d)) {
-                delim_len = 1;
+            state->current_line_len = current_line_consumed - state->current_line_delimiter_len;
+            state->consumed = total_consumed;
+            state->input_len -= current_line_consumed;
+            BUG_ON(state->consumed + state->input_len != state->orig_input_len);
+            if (SMTPProcessRequest(state, f, pstate) == -1) {
+                return -1;
             }
+            line_complete = false;
+            state->current_line_delimiter_len = 0;
         }
-        state->current_line_delimiter_len = delim_len;
-        state->current_line_len = consumed_line - delim_len;
-        state->input_len -= (state->current_line_len + delim_len);
-        if (SMTPProcessRequest(state, f, pstate) == -1) {
-            return -1;
-        }
-        lf_idx = memchr(state->input + state->consumed, 0x0a, state->input_len);
     }
     return 0;
 }
@@ -1338,13 +1343,14 @@ static AppLayerResult SMTPParse(uint8_t direction, Flow *f, SMTPState *state,
     state->orig_input_len = input_len;
     state->input_len = input_len;
     state->consumed = 0;
+    state->current_line_delimiter_len = 0;
     state->direction = direction;
     if (direction == 0) {
         if (((state->current_command == SMTP_COMMAND_DATA) ||
                     (state->current_command == SMTP_COMMAND_BDAT)) &&
                 (state->parser_state & SMTP_PARSER_STATE_COMMAND_DATA_MODE)) {
             int ret = SMTPPreProcessCommands(state, f, pstate);
-            if (ret == 0 && state->consumed == state->input_len) {
+            if (ret == 0 && state->consumed == state->orig_input_len) {
                 SCReturnStruct(APP_LAYER_OK);
             }
         }
@@ -1356,7 +1362,8 @@ static AppLayerResult SMTPParse(uint8_t direction, Flow *f, SMTPState *state,
         while (res.status == 0) {
             BUG_ON(state->discard_till_lf);
             if (!state->discard_till_lf) {
-                if ((state->current_line_len > 0) && (SMTPProcessRequest(state, f, pstate) == -1))
+                if ((state->current_line_delimiter_len > 0) &&
+                        (SMTPProcessRequest(state, f, pstate) == -1))
                     SCReturnStruct(APP_LAYER_ERROR);
                 if (state->current_line_delimiter_len == 0 &&
                         state->current_line_len == SMTP_LINE_BUFFER_LIMIT) {
@@ -1375,7 +1382,7 @@ static AppLayerResult SMTPParse(uint8_t direction, Flow *f, SMTPState *state,
         while (res.status == 0) {
             BUG_ON(state->discard_till_lf);
             if (!state->discard_till_lf) {
-                if ((state->current_line_len > 0) &&
+                if ((state->current_line_delimiter_len > 0) &&
                         (SMTPProcessReply(state, f, pstate, thread_data) == -1))
                     SCReturnStruct(APP_LAYER_ERROR);
                 if (state->current_line_delimiter_len == 0 &&

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -724,7 +724,7 @@ static int SMTPInsertCommandIntoCommandBuffer(uint8_t command, SMTPState *state,
 }
 
 static int SMTPProcessCommandBDAT(
-        SMTPState *state, Flow *f, AppLayerParserState *pstate, SMTPLine *line)
+        SMTPState *state, Flow *f, AppLayerParserState *pstate, const SMTPLine *line)
 {
     SCEnter();
 
@@ -790,7 +790,7 @@ static inline void SMTPTransactionComplete(SMTPState *state)
  *  \retval -1 error
  */
 static int SMTPProcessCommandDATA(
-        SMTPState *state, Flow *f, AppLayerParserState *pstate, SMTPLine *line)
+        SMTPState *state, Flow *f, AppLayerParserState *pstate, const SMTPLine *line)
 {
     SCEnter();
 
@@ -866,7 +866,7 @@ static inline bool IsReplyToCommand(const SMTPState *state, const uint8_t cmd)
 }
 
 static int SMTPProcessReply(SMTPState *state, Flow *f, AppLayerParserState *pstate,
-        SMTPThreadCtx *td, SMTPInput *input, SMTPLine *line)
+        SMTPThreadCtx *td, SMTPInput *input, const SMTPLine *line)
 {
     SCEnter();
 
@@ -988,7 +988,7 @@ static int SMTPProcessReply(SMTPState *state, Flow *f, AppLayerParserState *psta
     return 0;
 }
 
-static int SMTPParseCommandBDAT(SMTPState *state, SMTPLine *line)
+static int SMTPParseCommandBDAT(SMTPState *state, const SMTPLine *line)
 {
     SCEnter();
 
@@ -1025,7 +1025,7 @@ static int SMTPParseCommandBDAT(SMTPState *state, SMTPLine *line)
     return 0;
 }
 
-static int SMTPParseCommandWithParam(SMTPState *state, SMTPLine *line, uint8_t prefix_len,
+static int SMTPParseCommandWithParam(SMTPState *state, const SMTPLine *line, uint8_t prefix_len,
         uint8_t **target, uint16_t *target_len)
 {
     int i = prefix_len + 1;
@@ -1062,7 +1062,7 @@ static int SMTPParseCommandWithParam(SMTPState *state, SMTPLine *line, uint8_t p
     return 0;
 }
 
-static int SMTPParseCommandHELO(SMTPState *state, SMTPLine *line)
+static int SMTPParseCommandHELO(SMTPState *state, const SMTPLine *line)
 {
     if (state->helo) {
         SMTPSetEvent(state, SMTP_DECODER_EVENT_DUPLICATE_FIELDS);
@@ -1071,7 +1071,7 @@ static int SMTPParseCommandHELO(SMTPState *state, SMTPLine *line)
     return SMTPParseCommandWithParam(state, line, 4, &state->helo, &state->helo_len);
 }
 
-static int SMTPParseCommandMAILFROM(SMTPState *state, SMTPLine *line)
+static int SMTPParseCommandMAILFROM(SMTPState *state, const SMTPLine *line)
 {
     if (state->curr_tx->mail_from) {
         SMTPSetEvent(state, SMTP_DECODER_EVENT_DUPLICATE_FIELDS);
@@ -1081,7 +1081,7 @@ static int SMTPParseCommandMAILFROM(SMTPState *state, SMTPLine *line)
             state, line, 9, &state->curr_tx->mail_from, &state->curr_tx->mail_from_len);
 }
 
-static int SMTPParseCommandRCPTTO(SMTPState *state, SMTPLine *line)
+static int SMTPParseCommandRCPTTO(SMTPState *state, const SMTPLine *line)
 {
     uint8_t *rcptto;
     uint16_t rcptto_len;
@@ -1103,7 +1103,7 @@ static int SMTPParseCommandRCPTTO(SMTPState *state, SMTPLine *line)
 }
 
 /* consider 'rset' and 'quit' to be part of the existing state */
-static int NoNewTx(SMTPState *state, SMTPLine *line)
+static int NoNewTx(SMTPState *state, const SMTPLine *line)
 {
     if (!(state->parser_state & SMTP_PARSER_STATE_COMMAND_DATA_MODE)) {
         if (line->len >= 4 && SCMemcmpLowercase("rset", line->buf, 4) == 0) {
@@ -1118,8 +1118,8 @@ static int NoNewTx(SMTPState *state, SMTPLine *line)
 /* XXX have a better name */
 #define rawmsgname "rawmsg"
 
-static int SMTPProcessRequest(
-        SMTPState *state, Flow *f, AppLayerParserState *pstate, SMTPInput *input, SMTPLine *line)
+static int SMTPProcessRequest(SMTPState *state, Flow *f, AppLayerParserState *pstate,
+        SMTPInput *input, const SMTPLine *line)
 {
     SCEnter();
     SMTPTransaction *tx = state->curr_tx;

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -110,12 +110,6 @@ typedef struct SMTPState_ {
     uint64_t toserver_data_count;
     uint64_t toserver_last_data_stamp;
 
-    /* --parser details-- */
-    /** current line extracted by the parser from the call to SMTPGetline() */
-    const uint8_t *current_line;
-    /** length of the line in current_line.  Doesn't include the delimiter */
-    int32_t current_line_len;
-    uint8_t current_line_delimiter_len;
     /* If rest of the bytes should be discarded in case of long line w/o LF */
     bool discard_till_lf;
 

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -110,22 +110,12 @@ typedef struct SMTPState_ {
     uint64_t toserver_data_count;
     uint64_t toserver_last_data_stamp;
 
-    /* current input that is being parsed */
-    const uint8_t *input;
-    int32_t input_len;
-    uint8_t direction;
-
-    /* original length of an input */
-    int32_t orig_input_len;
-
     /* --parser details-- */
     /** current line extracted by the parser from the call to SMTPGetline() */
     const uint8_t *current_line;
     /** length of the line in current_line.  Doesn't include the delimiter */
     int32_t current_line_len;
     uint8_t current_line_delimiter_len;
-    /* Consumed bytes till current line */
-    int32_t consumed;
     /* If rest of the bytes should be discarded in case of long line w/o LF */
     bool discard_till_lf;
 

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -323,7 +323,8 @@ static int DatasetLoadString(Dataset *set)
 
             // coverity[alloc_strlen : FALSE]
             uint8_t decoded[strlen(line)];
-            uint32_t len = DecodeBase64(decoded, (const uint8_t *)line, strlen(line), 1);
+            uint32_t len =
+                    DecodeBase64(decoded, (const uint8_t *)line, strlen(line), BASE64_MODE_STRICT);
             if (len == 0)
                 FatalError(SC_ERR_FATAL, "bad base64 encoding %s/%s",
                         set->name, set->load);
@@ -340,7 +341,8 @@ static int DatasetLoadString(Dataset *set)
 
             // coverity[alloc_strlen : FALSE]
             uint8_t decoded[strlen(line)];
-            uint32_t len = DecodeBase64(decoded, (const uint8_t *)line, strlen(line), 1);
+            uint32_t len =
+                    DecodeBase64(decoded, (const uint8_t *)line, strlen(line), BASE64_MODE_STRICT);
             if (len == 0)
                 FatalError(SC_ERR_FATAL, "bad base64 encoding %s/%s",
                         set->name, set->load);
@@ -1142,7 +1144,8 @@ int DatasetAddSerialized(Dataset *set, const char *string)
         case DATASET_TYPE_STRING: {
             // coverity[alloc_strlen : FALSE]
             uint8_t decoded[strlen(string)];
-            uint32_t len = DecodeBase64(decoded, (const uint8_t *)string, strlen(string), 1);
+            uint32_t len = DecodeBase64(
+                    decoded, (const uint8_t *)string, strlen(string), BASE64_MODE_STRICT);
             if (len == 0) {
                 return -2;
             }
@@ -1224,7 +1227,8 @@ int DatasetRemoveSerialized(Dataset *set, const char *string)
         case DATASET_TYPE_STRING: {
             // coverity[alloc_strlen : FALSE]
             uint8_t decoded[strlen(string)];
-            uint32_t len = DecodeBase64(decoded, (const uint8_t *)string, strlen(string), 1);
+            uint32_t len = DecodeBase64(
+                    decoded, (const uint8_t *)string, strlen(string), BASE64_MODE_STRICT);
             if (len == 0) {
                 return -2;
             }

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -323,13 +323,14 @@ static int DatasetLoadString(Dataset *set)
 
             // coverity[alloc_strlen : FALSE]
             uint8_t decoded[strlen(line)];
-            uint32_t len =
-                    DecodeBase64(decoded, (const uint8_t *)line, strlen(line), BASE64_MODE_STRICT);
-            if (len == 0)
+            uint32_t consumed = 0, num_decoded = 0;
+            Base64Ecode code = DecodeBase64(decoded, strlen(line), (const uint8_t *)line,
+                    strlen(line), &consumed, &num_decoded, BASE64_MODE_STRICT);
+            if (code == BASE64_ECODE_ERR)
                 FatalError(SC_ERR_FATAL, "bad base64 encoding %s/%s",
                         set->name, set->load);
 
-            if (DatasetAdd(set, (const uint8_t *)decoded, len) < 0)
+            if (DatasetAdd(set, (const uint8_t *)decoded, num_decoded) < 0)
                 FatalError(SC_ERR_FATAL, "dataset data add failed %s/%s",
                         set->name, set->load);
             cnt++;
@@ -341,9 +342,10 @@ static int DatasetLoadString(Dataset *set)
 
             // coverity[alloc_strlen : FALSE]
             uint8_t decoded[strlen(line)];
-            uint32_t len =
-                    DecodeBase64(decoded, (const uint8_t *)line, strlen(line), BASE64_MODE_STRICT);
-            if (len == 0)
+            uint32_t consumed = 0, num_decoded = 0;
+            Base64Ecode code = DecodeBase64(decoded, strlen(line), (const uint8_t *)line,
+                    strlen(line), &consumed, &num_decoded, BASE64_MODE_STRICT);
+            if (code == BASE64_ECODE_ERR)
                 FatalError(SC_ERR_FATAL, "bad base64 encoding %s/%s",
                         set->name, set->load);
 
@@ -355,7 +357,7 @@ static int DatasetLoadString(Dataset *set)
                 FatalError(SC_ERR_FATAL, "die: bad rep");
             SCLogDebug("rep %u", rep.value);
 
-            if (DatasetAddwRep(set, (const uint8_t *)decoded, len, &rep) < 0)
+            if (DatasetAddwRep(set, (const uint8_t *)decoded, num_decoded, &rep) < 0)
                 FatalError(SC_ERR_FATAL, "dataset data add failed %s/%s",
                         set->name, set->load);
             cnt++;
@@ -1144,13 +1146,14 @@ int DatasetAddSerialized(Dataset *set, const char *string)
         case DATASET_TYPE_STRING: {
             // coverity[alloc_strlen : FALSE]
             uint8_t decoded[strlen(string)];
-            uint32_t len = DecodeBase64(
-                    decoded, (const uint8_t *)string, strlen(string), BASE64_MODE_STRICT);
-            if (len == 0) {
+            uint32_t consumed = 0, num_decoded = 0;
+            Base64Ecode code = DecodeBase64(decoded, strlen(string), (const uint8_t *)string,
+                    strlen(string), &consumed, &num_decoded, BASE64_MODE_STRICT);
+            if (code == BASE64_ECODE_ERR) {
                 return -2;
             }
 
-            return DatasetAddString(set, decoded, len);
+            return DatasetAddString(set, decoded, num_decoded);
         }
         case DATASET_TYPE_MD5: {
             if (strlen(string) != 32)
@@ -1227,13 +1230,14 @@ int DatasetRemoveSerialized(Dataset *set, const char *string)
         case DATASET_TYPE_STRING: {
             // coverity[alloc_strlen : FALSE]
             uint8_t decoded[strlen(string)];
-            uint32_t len = DecodeBase64(
-                    decoded, (const uint8_t *)string, strlen(string), BASE64_MODE_STRICT);
-            if (len == 0) {
+            uint32_t consumed = 0, num_decoded = 0;
+            Base64Ecode code = DecodeBase64(decoded, strlen(string), (const uint8_t *)string,
+                    strlen(string), &consumed, &num_decoded, BASE64_MODE_STRICT);
+            if (code == BASE64_ECODE_ERR) {
                 return -2;
             }
 
-            return DatasetRemoveString(set, decoded, len);
+            return DatasetRemoveString(set, decoded, num_decoded);
         }
         case DATASET_TYPE_MD5: {
             if (strlen(string) != 32)

--- a/src/detect-base64-decode.c
+++ b/src/detect-base64-decode.c
@@ -87,8 +87,10 @@ int DetectBase64DecodeDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s
     PrintRawDataFp(stdout, payload, decode_len);
 #endif
 
-    det_ctx->base64_decoded_len =
-            DecodeBase64(det_ctx->base64_decoded, payload, decode_len, BASE64_MODE_RELAX);
+    uint32_t consumed = 0, num_decoded = 0;
+    DecodeBase64(det_ctx->base64_decoded, det_ctx->base64_decoded_len_max, payload, decode_len,
+            &consumed, &num_decoded, BASE64_MODE_RELAX);
+    det_ctx->base64_decoded_len = num_decoded;
     SCLogDebug("Decoded %d bytes from base64 data.",
         det_ctx->base64_decoded_len);
 #if 0

--- a/src/detect-base64-decode.c
+++ b/src/detect-base64-decode.c
@@ -87,8 +87,8 @@ int DetectBase64DecodeDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s
     PrintRawDataFp(stdout, payload, decode_len);
 #endif
 
-    det_ctx->base64_decoded_len = DecodeBase64(det_ctx->base64_decoded,
-        payload, decode_len, 0);
+    det_ctx->base64_decoded_len =
+            DecodeBase64(det_ctx->base64_decoded, payload, decode_len, BASE64_MODE_RELAX);
     SCLogDebug("Decoded %d bytes from base64 data.",
         det_ctx->base64_decoded_len);
 #if 0

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -172,6 +172,7 @@ static void RegisterUnittests(void)
     ThreadMacrosRegisterTests();
     UtilSpmSearchRegistertests();
     UtilActionRegisterTests();
+    Base64RegisterTests();
     SCClassConfRegisterTests();
     SCThresholdConfRegisterTests();
     SCRConfRegisterTests();

--- a/src/util-base64.c
+++ b/src/util-base64.c
@@ -100,8 +100,9 @@ Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, 
     bool valid = true;
     Base64Ecode ecode = BASE64_ECODE_OK;
     *decoded_bytes = 0;
+
     /* Traverse through each alpha-numeric letter in the source array */
-    for (uint32_t i = 0; i < len && src[i] != 0; i++) {
+    for (uint32_t i = 0; i < len; i++) {
         /* Get decimal representation */
         val = GetBase64Value(src[i]);
         if (val < 0) {

--- a/src/util-base64.c
+++ b/src/util-base64.c
@@ -81,35 +81,45 @@ static inline void DecodeBase64Block(uint8_t ascii[ASCII_BLOCK], uint8_t b64[B64
  * \brief Decodes a base64-encoded string buffer into an ascii-encoded byte buffer
  *
  * \param dest The destination byte buffer
+ * \param dest_size The destination byte buffer size
  * \param src The source string
  * \param len The length of the source string
- * \param strict If set file on invalid byte, otherwise return what has been
- *    decoded.
+ * \param consumed_bytes The bytes that were actually processed/consumed
+ * \param decoded_bytes The bytes that were decoded
+ * \param mode The mode in which decoding should happen
  *
- * \return Number of bytes decoded, or 0 if no data is decoded or it fails
+ * \return Error code indicating success or failures with parsing
  */
-uint32_t DecodeBase64(uint8_t *dest, const uint8_t *src, uint32_t len, Base64Mode mode)
+Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, uint32_t len,
+        uint32_t *consumed_bytes, uint32_t *decoded_bytes, Base64Mode mode)
 {
     int val;
-    uint32_t padding = 0, numDecoded = 0, bbidx = 0, valid = 1, i;
+    uint32_t padding = 0, bbidx = 0, sp = 0, leading_sp = 0;
     uint8_t *dptr = dest;
     uint8_t b64[B64_BLOCK] = { 0,0,0,0 };
-
+    bool valid = true;
+    Base64Ecode ecode = BASE64_ECODE_OK;
+    *decoded_bytes = 0;
     /* Traverse through each alpha-numeric letter in the source array */
-    for(i = 0; i < len && src[i] != 0; i++) {
-
+    for (uint32_t i = 0; i < len && src[i] != 0; i++) {
         /* Get decimal representation */
         val = GetBase64Value(src[i]);
         if (val < 0) {
-            if (mode == BASE64_MODE_RFC2045 && src[i] == ' ') {
+            if ((mode == BASE64_MODE_RFC2045) && (src[i] == ' ')) {
+                if (bbidx == 0) {
+                    /* Special case where last block of data has a leading space */
+                    leading_sp++;
+                }
+                sp++;
                 continue;
             }
             /* Invalid character found, so decoding fails */
             if (src[i] != '=') {
-                valid = 0;
+                valid = false;
                 if (mode != BASE64_MODE_RELAX) {
-                    numDecoded = 0;
+                    *decoded_bytes = 0;
                 }
+                ecode = BASE64_ECODE_ERR;
                 break;
             }
             padding++;
@@ -123,55 +133,156 @@ uint32_t DecodeBase64(uint8_t *dest, const uint8_t *src, uint32_t len, Base64Mod
         if (bbidx == B64_BLOCK) {
 
             /* For every 4 bytes, add 3 bytes but deduct the '=' padded blocks */
-            numDecoded += ASCII_BLOCK - (padding < B64_BLOCK ?
-                    padding : ASCII_BLOCK);
+            uint32_t numDecoded_blk = ASCII_BLOCK - (padding < B64_BLOCK ? padding : ASCII_BLOCK);
+            if (dest_size < *decoded_bytes + numDecoded_blk) {
+                SCLogDebug("Destination buffer full");
+                ecode = BASE64_ECODE_BUF;
+                break;
+            }
 
             /* Decode base-64 block into ascii block and move pointer */
             DecodeBase64Block(dptr, b64);
             dptr += ASCII_BLOCK;
-
+            *decoded_bytes += numDecoded_blk;
             /* Reset base-64 block and index */
             bbidx = 0;
             padding = 0;
+            *consumed_bytes += B64_BLOCK + sp;
+            sp = 0;
+            leading_sp = 0;
+            memset(&b64, 0, sizeof(b64));
         }
     }
-
     /* Finish remaining b64 bytes by padding */
-    if (valid && bbidx > 0) {
-
+    if (valid && bbidx > 0 && (mode != BASE64_MODE_RFC2045)) {
         /* Decode remaining */
-        numDecoded += ASCII_BLOCK - (B64_BLOCK - bbidx);
+        *decoded_bytes += ASCII_BLOCK - (B64_BLOCK - bbidx);
         DecodeBase64Block(dptr, b64);
     }
 
-    if (numDecoded == 0) {
+    if (*decoded_bytes == 0) {
         SCLogDebug("base64 decoding failed");
     }
 
-    return numDecoded;
+    *consumed_bytes += leading_sp;
+    return ecode;
 }
 
 #ifdef UNITTESTS
-
-static int DecodeString(void)
+static int B64DecodeCompleteString(void)
 {
     /*
-     * SGV sbG8= : Hello
+     * SGVsbG8gV29ybGR6 : Hello Worldz
+     * */
+    const char *src = "SGVsbG8gV29ybGR6";
+    const char *fin_str = "Hello Worldz";
+    uint32_t consumed_bytes = 0, num_decoded = 0;
+    uint8_t dst[strlen(fin_str)];
+    Base64Ecode code = DecodeBase64(dst, strlen(fin_str), (const uint8_t *)src, strlen(src),
+            &consumed_bytes, &num_decoded, BASE64_MODE_RFC2045);
+    FAIL_IF(code != BASE64_ECODE_OK);
+    FAIL_IF(memcmp(dst, fin_str, strlen(fin_str)) != 0);
+    FAIL_IF(num_decoded != 12);
+    FAIL_IF(consumed_bytes != strlen(src));
+    PASS;
+}
+
+static int B64DecodeInCompleteString(void)
+{
+    /*
+     * SGVsbG8gV29ybGR6 : Hello Worldz
+     * */
+    const char *src = "SGVsbG8gV29ybGR";
+    const char *fin_str = "Hello Wor"; // bc it'll error out on last 3 bytes
+    uint32_t consumed_bytes = 0, num_decoded = 0;
+    uint8_t dst[strlen(fin_str)];
+    Base64Ecode code = DecodeBase64(dst, strlen(fin_str), (const uint8_t *)src, strlen(src),
+            &consumed_bytes, &num_decoded, BASE64_MODE_RFC2045);
+    FAIL_IF(code != BASE64_ECODE_OK);
+    FAIL_IF(memcmp(dst, fin_str, strlen(fin_str)) != 0);
+    FAIL_IF(num_decoded != 9);
+    FAIL_IF(consumed_bytes == strlen(src));
+    PASS;
+}
+
+static int B64DecodeCompleteStringWSp(void)
+{
+    /*
      * SGVsbG8gV29ybGQ= : Hello World
      * */
 
     const char *src = "SGVs bG8 gV29y bGQ=";
-    uint8_t *dst = SCMalloc(sizeof(src) * 30);
-    int res = DecodeBase64(dst, (const uint8_t *)src, 30, 1);
-    printf("%d\n", res);
-    printf("dst str = \"%s\"", (const char *)dst);
-    FAIL_IF(res <= 0);
-    SCFree(dst);
+    const char *fin_str = "Hello World";
+    uint8_t dst[strlen(fin_str) + 1]; // 1 for the padding byte
+    uint32_t consumed_bytes = 0, num_decoded = 0;
+    Base64Ecode code = DecodeBase64(dst, strlen(fin_str), (const uint8_t *)src, strlen(src),
+            &consumed_bytes, &num_decoded, BASE64_MODE_RFC2045);
+    FAIL_IF(code != BASE64_ECODE_OK);
+    FAIL_IF(memcmp(dst, fin_str, strlen(fin_str)) != 0);
+    FAIL_IF(num_decoded != 11);
+    FAIL_IF(consumed_bytes != strlen(src));
+    PASS;
+}
+
+static int B64DecodeInCompleteStringWSp(void)
+{
+    /*
+     * SGVsbG8gV29ybGQ= : Hello World
+     * Special handling for this case (sp in remainder) done in ProcessBase64Remainder
+     * */
+
+    const char *src = "SGVs bG8 gV29y bGQ";
+    const char *fin_str = "Hello Wor";
+    uint32_t consumed_bytes = 0, num_decoded = 0;
+    uint8_t dst[strlen(fin_str)];
+    Base64Ecode code = DecodeBase64(dst, strlen(fin_str), (const uint8_t *)src, strlen(src),
+            &consumed_bytes, &num_decoded, BASE64_MODE_RFC2045);
+    FAIL_IF(code != BASE64_ECODE_OK);
+    FAIL_IF(memcmp(dst, fin_str, strlen(fin_str)) != 0);
+    FAIL_IF(num_decoded != 9); // bc we don't put padding in RFC2045 mode
+    FAIL_IF(consumed_bytes != strlen(src) - 3);
+    PASS;
+}
+
+static int B64DecodeStringBiggerThanBuffer(void)
+{
+    /*
+     * SGVsbG8gV29ybGQ= : Hello World
+     * */
+
+    const char *src = "SGVs bG8 gV29y bGQ=";
+    const char *fin_str = "Hello Wor";
+    uint32_t consumed_bytes = 0, num_decoded = 0;
+    uint8_t dst[strlen(fin_str)];
+    Base64Ecode code = DecodeBase64(dst, strlen(fin_str), (const uint8_t *)src, strlen(src),
+            &consumed_bytes, &num_decoded, BASE64_MODE_RFC2045);
+    FAIL_IF(code != BASE64_ECODE_BUF);
+    FAIL_IF(memcmp(dst, fin_str, strlen(fin_str)) != 0);
+    FAIL_IF(num_decoded != 9); // dest buf is 10, so 9 got consumed
+    FAIL_IF(consumed_bytes != 15);
+    PASS;
+}
+
+static int B64DecodeStringEndingSpaces(void)
+{
+    const char *src = "0YPhA d H";
+    uint32_t consumed_bytes = 0, num_decoded = 0;
+    uint8_t dst[10];
+    Base64Ecode code = DecodeBase64(dst, sizeof(dst), (const uint8_t *)src, strlen(src),
+            &consumed_bytes, &num_decoded, BASE64_MODE_RFC2045);
+    FAIL_IF(code != BASE64_ECODE_OK);
+    FAIL_IF(num_decoded != 3);
+    FAIL_IF(consumed_bytes != 4);
     PASS;
 }
 
 void Base64RegisterTests(void)
 {
-    UtRegisterTest("DecodeString", DecodeString);
+    UtRegisterTest("B64DecodeCompleteStringWSp", B64DecodeCompleteStringWSp);
+    UtRegisterTest("B64DecodeInCompleteStringWSp", B64DecodeInCompleteStringWSp);
+    UtRegisterTest("B64DecodeCompleteString", B64DecodeCompleteString);
+    UtRegisterTest("B64DecodeInCompleteString", B64DecodeInCompleteString);
+    UtRegisterTest("B64DecodeStringBiggerThanBuffer", B64DecodeStringBiggerThanBuffer);
+    UtRegisterTest("B64DecodeStringEndingSpaces", B64DecodeStringEndingSpaces);
 }
 #endif

--- a/src/util-base64.h
+++ b/src/util-base64.h
@@ -48,8 +48,17 @@
 #define ASCII_BLOCK         3
 #define B64_BLOCK           4
 
-/* Function prototypes */
-uint32_t DecodeBase64(uint8_t *dest, const uint8_t *src, uint32_t len,
-    int strict);
+typedef enum {
+    BASE64_MODE_RELAX,
+    BASE64_MODE_RFC2045, /* SPs are allowed during transfer but must be skipped by Decoder */
+    BASE64_MODE_STRICT,
+} Base64Mode;
 
+/* Function prototypes */
+uint32_t DecodeBase64(uint8_t *dest, const uint8_t *src, uint32_t len, Base64Mode mode);
+
+#endif
+
+#ifdef UNITTESTS
+void Base64RegisterTests(void);
 #endif

--- a/src/util-base64.h
+++ b/src/util-base64.h
@@ -54,6 +54,12 @@ typedef enum {
     BASE64_MODE_STRICT,
 } Base64Mode;
 
+typedef enum {
+    BASE64_ECODE_ERR = -1,
+    BASE64_ECODE_OK = 0,
+    BASE64_ECODE_BUF,
+} Base64Ecode;
+
 /* Function prototypes */
 uint32_t DecodeBase64(uint8_t *dest, const uint8_t *src, uint32_t len, Base64Mode mode);
 

--- a/src/util-base64.h
+++ b/src/util-base64.h
@@ -61,7 +61,8 @@ typedef enum {
 } Base64Ecode;
 
 /* Function prototypes */
-uint32_t DecodeBase64(uint8_t *dest, const uint8_t *src, uint32_t len, Base64Mode mode);
+Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, uint32_t len,
+        uint32_t *consumed_bytes, uint32_t *decoded_bytes, Base64Mode mode);
 
 #endif
 

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -1250,8 +1250,8 @@ static uint8_t ProcessBase64Remainder(
 
     /* Only decode if divisible by 4 */
     if (state->bvr_len == B64_BLOCK || force) {
-        remdec = DecodeBase64(state->data_chunk + state->data_chunk_len,
-                              state->bvremain, state->bvr_len, 1);
+        remdec = DecodeBase64(state->data_chunk + state->data_chunk_len, state->bvremain,
+                state->bvr_len, BASE64_MODE_RFC2045);
         if (remdec > 0) {
 
             /* Track decoded length */
@@ -1352,8 +1352,8 @@ static int ProcessBase64BodyLine(const uint8_t *buf, uint32_t len,
 
             SCLogDebug("Decoding: %u", len - rem1 - rem2);
 
-            numDecoded = DecodeBase64(state->data_chunk + state->data_chunk_len,
-                    buf + offset, tobuf, 1);
+            numDecoded = DecodeBase64(state->data_chunk + state->data_chunk_len, buf + offset,
+                    tobuf, BASE64_MODE_RFC2045);
             if (numDecoded > 0) {
 
                 /* Track decoded length */
@@ -3190,7 +3190,7 @@ static int MimeBase64DecodeTest01(void)
     if (dst == NULL)
         return 0;
 
-    ret = DecodeBase64(dst, (const uint8_t *)base64msg, strlen(base64msg), 1);
+    ret = DecodeBase64(dst, (const uint8_t *)base64msg, strlen(base64msg), BASE64_MODE_RFC2045);
 
     if (memcmp(dst, msg, strlen(msg)) == 0) {
         ret = 1;

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -1218,58 +1218,57 @@ static int ProcessDecodedDataChunk(const uint8_t *chunk, uint32_t len,
  * \param state The current parser state
  * \param force Flag indicating whether decoding should always occur
  *
- * \return Number of bytes pulled from the current buffer
+ * \return Number of bytes consumed from `buf`
  */
 static uint8_t ProcessBase64Remainder(
-        const uint8_t *buf, uint8_t len, MimeDecParseState *state, int force)
+        const uint8_t *buf, const uint32_t len, MimeDecParseState *state, int force)
 {
-    uint32_t ret;
-    uint8_t remainder = 0;
-    uint32_t remdec = 0;
-    uint32_t consumed_bytes = 0;
+    uint8_t buf_consumed = 0; /* consumed bytes from 'buf' */
     uint32_t cnt = 0;
+    uint8_t block[B64_BLOCK];
 
-    /* Fill in block with first few bytes of current line */
-    remainder = B64_BLOCK - state->bvr_len;
-    remainder = remainder < len ? remainder : len;
-    if (buf) {
-        uint8_t tmp[B64_BLOCK];
-        uint32_t rem = 0;
-        for (int i = 0; i < state->bvr_len; i++) {
-            /* Special case of SP in remainder */
-            if (state->bvremain[i] != ' ') {
-                tmp[cnt++] = state->bvremain[i];
-            } else {
-                rem++;
-            }
-        }
-        if (cnt != 4) {
-            /* Special case where the buf where we take extra bytes from contains SP */
-            for (int i = 0; i < len && cnt < 4; i++) {
-                if (buf[i] != ' ') {
-                    tmp[cnt++] = buf[i];
-                } else {
-                    rem++;
-                }
-            }
-        }
-        memcpy(state->bvremain, tmp, cnt);
-        state->bvr_len += remainder;
-        remainder += rem;
+    /* should be impossible, but lets be defensive */
+    DEBUG_VALIDATE_BUG_ON(state->bvr_len > B64_BLOCK);
+    if (state->bvr_len > B64_BLOCK) {
+        state->bvr_len = 0;
+        return 0;
     }
+
+    /* Strip spaces in remainder */
+    for (uint8_t i = 0; i < state->bvr_len; i++) {
+        if (state->bvremain[i] != ' ') {
+            block[cnt++] = state->bvremain[i];
+        }
+    }
+
+    /* if we don't have 4 bytes see if we can fill it from `buf` */
+    if (buf && len > 0 && cnt != B64_BLOCK) {
+        for (uint32_t i = 0; i < len && cnt < B64_BLOCK; i++) {
+            if (buf[i] != ' ') {
+                block[cnt++] = buf[i];
+            }
+            buf_consumed++;
+        }
+        if (cnt != 0) {
+            memcpy(state->bvremain, block, cnt);
+        }
+        state->bvr_len = cnt;
+    }
+
     /* If data chunk buffer will be full, then clear it now */
     if (DATA_CHUNK_SIZE - state->data_chunk_len < ASCII_BLOCK) {
 
         /* Invoke pre-processor and callback */
-        ret = ProcessDecodedDataChunk(state->data_chunk, state->data_chunk_len,
-                state);
+        uint32_t ret = ProcessDecodedDataChunk(state->data_chunk, state->data_chunk_len, state);
         if (ret != MIME_DEC_OK) {
             SCLogDebug("Error: ProcessDecodedDataChunk() function failed");
         }
     }
 
     if (state->bvr_len == B64_BLOCK || force) {
-        uint32_t avail_space = DATA_CHUNK_SIZE - state->data_chunk_len;
+        uint32_t consumed_bytes = 0;
+        uint32_t remdec = 0;
+        const uint32_t avail_space = DATA_CHUNK_SIZE - state->data_chunk_len;
         Base64Ecode code = DecodeBase64(state->data_chunk + state->data_chunk_len, avail_space,
                 state->bvremain, state->bvr_len, &consumed_bytes, &remdec, BASE64_MODE_RFC2045);
         if (remdec > 0 && (code == BASE64_ECODE_OK || code == BASE64_ECODE_BUF)) {
@@ -1283,8 +1282,8 @@ static uint8_t ProcessBase64Remainder(
             if (DATA_CHUNK_SIZE - state->data_chunk_len < ASCII_BLOCK) {
 
                 /* Invoke pre-processor and callback */
-                ret = ProcessDecodedDataChunk(state->data_chunk,
-                        state->data_chunk_len, state);
+                uint32_t ret =
+                        ProcessDecodedDataChunk(state->data_chunk, state->data_chunk_len, state);
                 if (ret != MIME_DEC_OK) {
                     SCLogDebug("Error: ProcessDecodedDataChunk() function "
                             "failed");
@@ -1302,7 +1301,8 @@ static uint8_t ProcessBase64Remainder(
         state->bvr_len = 0;
     }
 
-    return remainder;
+    DEBUG_VALIDATE_BUG_ON(buf_consumed > len);
+    return buf_consumed;
 }
 
 /**
@@ -1319,9 +1319,9 @@ static int ProcessBase64BodyLine(const uint8_t *buf, uint32_t len,
         MimeDecParseState *state)
 {
     int ret = MIME_DEC_OK;
-    uint8_t rem1 = 0;
-    uint32_t numDecoded, remaining, offset;
-    /* Track long line */
+    uint32_t numDecoded, remaining = len, offset = 0;
+
+    /* Track long line TODO should we count space padding too? */
     if (len > MAX_ENC_LINE_LEN) {
         state->stack->top->data->anomaly_flags |= ANOM_LONG_ENC_LINE;
         state->msg->anomaly_flags |= ANOM_LONG_ENC_LINE;
@@ -1332,30 +1332,34 @@ static int ProcessBase64BodyLine(const uint8_t *buf, uint32_t len,
     if (state->bvr_len + len < B64_BLOCK) {
         memcpy(state->bvremain + state->bvr_len, buf, len);
         state->bvr_len += len;
-        len = 0;
+        return MIME_DEC_OK;
     }
 
     /* First process remaining from previous line */
     if (state->bvr_len > 0) {
-        /* Process remainder and return number of bytes pulled from current buffer */
-        rem1 = ProcessBase64Remainder(buf, (uint8_t)len, state, 0);
-        int32_t remainder_b64 = len - rem1;
-        if (remainder_b64 < B64_BLOCK) {
-            memcpy(state->bvremain, buf + rem1, remainder_b64);
-            state->bvr_len += remainder_b64;
-            return ret;
+        uint32_t consumed = ProcessBase64Remainder(buf, len, state, 0);
+        DEBUG_VALIDATE_BUG_ON(consumed > len);
+        if (consumed > len)
+            return MIME_DEC_ERR_PARSE;
+
+        uint32_t left = len - consumed;
+        if (left < B64_BLOCK) {
+            memcpy(state->bvremain, buf + consumed, left);
+            state->bvr_len = left;
+            return MIME_DEC_OK;
         }
+        remaining -= consumed;
+        offset = consumed;
     }
 
-    remaining = len - rem1;
-    offset = rem1;
     while (remaining > 0 && remaining >= B64_BLOCK) {
         uint32_t consumed_bytes = 0;
         uint32_t avail_space = DATA_CHUNK_SIZE - state->data_chunk_len;
         Base64Ecode code = DecodeBase64(state->data_chunk + state->data_chunk_len, avail_space,
                 buf + offset, remaining, &consumed_bytes, &numDecoded, BASE64_MODE_RFC2045);
-
         DEBUG_VALIDATE_BUG_ON(consumed_bytes > remaining);
+        if (consumed_bytes > remaining)
+            return MIME_DEC_ERR_PARSE;
 
         uint32_t leftover_bytes = remaining - consumed_bytes;
         if (numDecoded > 0 && (code == BASE64_ECODE_OK || code == BASE64_ECODE_BUF)) {
@@ -1382,29 +1386,35 @@ static int ProcessBase64BodyLine(const uint8_t *buf, uint32_t len,
             state->stack->top->data->anomaly_flags |= ANOM_INVALID_BASE64;
             state->msg->anomaly_flags |= ANOM_INVALID_BASE64;
             SCLogDebug("Error: DecodeBase64() function failed");
-            ret = MIME_DEC_ERR_DATA;
-            break;
+            return MIME_DEC_ERR_DATA;
         }
-        if (leftover_bytes < B64_BLOCK) {
+
+        /* corner case: multiples spaces in the last data, leading it to exceed the block
+         * size. We strip of spaces this while storing it in bvremain */
+        if (consumed_bytes == 0 && leftover_bytes > B64_BLOCK) {
+            DEBUG_VALIDATE_BUG_ON(state->bvr_len != 0);
+            for (uint32_t i = 0; i < leftover_bytes; i++) {
+                if (buf[offset] != ' ') {
+                    DEBUG_VALIDATE_BUG_ON(state->bvr_len >= B64_BLOCK);
+                    if (state->bvr_len >= B64_BLOCK)
+                        return MIME_DEC_ERR_DATA;
+                    state->bvremain[state->bvr_len++] = buf[offset];
+                }
+                offset++;
+            }
+            return MIME_DEC_OK;
+
+        } else if (leftover_bytes > 0 && leftover_bytes <= B64_BLOCK) {
+            /* If remaining is 4 by this time, we encountered spaces during processing */
+            DEBUG_VALIDATE_BUG_ON(state->bvr_len != 0);
             memcpy(state->bvremain, buf + offset + consumed_bytes, leftover_bytes);
             state->bvr_len = leftover_bytes;
             return MIME_DEC_OK;
         }
+
         /* Update counts */
-        remaining -= consumed_bytes;
+        remaining = leftover_bytes;
         offset += consumed_bytes;
-        /* If remaining is 4 by this time, it's likely due to error/spaces during processing */
-        if (remaining == 4) {
-            memcpy(state->bvremain, buf + offset, remaining);
-            state->bvr_len = remaining;
-            break;
-        }
-        if ((remaining > 0 && remaining < B64_BLOCK) ||
-                (remaining > 0 && (remaining < B64_BLOCK) && consumed_bytes < remaining)) {
-            memcpy(state->bvremain, buf + offset, remaining);
-            state->bvr_len = remaining;
-            break;
-        }
     }
     return ret;
 }


### PR DESCRIPTION
Replaces #7482 and #7486 fixing a `base64_decode` issue and cleaning up the git history a bit.