### PR TITLE
smb: use default stream-depth 0 by default

### DIFF
--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -2449,8 +2449,8 @@ pub unsafe extern "C" fn rs_smb_register_parser() {
                 Ok(retval) => { stream_depth = retval as u32; }
                 Err(_) => { SCLogError!("Invalid depth value"); }
             }
-            AppLayerParserSetStreamDepth(IPPROTO_TCP as u8, ALPROTO_SMB, stream_depth);
         }
+        AppLayerParserSetStreamDepth(IPPROTO_TCP as u8, ALPROTO_SMB, stream_depth);
         let retval = conf_get("app-layer.protocols.smb.max-read-size");
         if let Some(val) = retval {
             match get_memval(val) {

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -32,8 +32,6 @@
 static StreamingBufferConfig sbcfg = STREAMING_BUFFER_CONFIG_INITIALIZER;
 static SuricataFileContext sfc = { &sbcfg };
 
-#define SMB_CONFIG_DEFAULT_STREAM_DEPTH 0
-
 #ifdef UNITTESTS
 static void SMBParserRegisterTests(void);
 #endif


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5390

Describe changes:
- smb: use again default stream-depth 0 by default

Modifies https://github.com/OISF/suricata/pull/7497 with ticket in commit description

See also https://github.com/OISF/suricata/pull/7498 for the S-V test