### PR TITLE
dns: remove unused events field from state

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -323,8 +323,6 @@ pub struct DNSState {
     // Transactions.
     pub transactions: VecDeque<DNSTransaction>,
 
-    pub events: u16,
-
     config: Option<ConfigTracker>,
 
     gap: bool,
@@ -395,7 +393,6 @@ impl DNSState {
 
         let tx = &mut self.transactions[len - 1];
         tx.tx_data.set_event(event as u8);
-        self.events += 1;
     }
 
     fn parse_request(&mut self, input: &[u8]) -> bool {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47827

Describe changes:
- remove unused events field from state

cc @jasonish 

This was not found by rust compiler because field was public and could have been used by some external user of the crate, right ?